### PR TITLE
feat: migrate to HumanLayer profiles and update PM agents to Opus

### DIFF
--- a/.claude/config.json
+++ b/.claude/config.json
@@ -6,8 +6,7 @@
       "defaultTicketPrefix": "PROJ"
     },
     "thoughts": {
-      "user": null,
-      "configName": null
+      "user": null
     }
   }
 }

--- a/.claude/config.template.json
+++ b/.claude/config.template.json
@@ -27,7 +27,6 @@
     "projectId": "[NEEDS_SETUP]"
   },
   "thoughts": {
-    "user": null,
-    "configName": null
+    "user": null
   }
 }

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -254,9 +254,15 @@ The setup script automatically:
 If you skipped thoughts setup or want to initialize additional projects:
 
 ```bash
-# Initialize thoughts in current project
+# Initialize with default profile
 cd /path/to/your-project
-humanlayer thoughts init --directory <repo-name>
+humanlayer thoughts init
+
+# Or with a specific profile
+humanlayer thoughts init --profile coalesce-labs
+
+# Create a new profile first (if needed)
+humanlayer thoughts profile create my-profile --repo ~/thoughts/repos/my-profile
 ```
 
 **Directory structure:**

--- a/docs/THOUGHTS_SETUP.md
+++ b/docs/THOUGHTS_SETUP.md
@@ -5,13 +5,19 @@ The thoughts system is the backbone of Catalyst workflows, providing persistent,
 ## Quick Setup
 
 ```bash
-# 1. Initialize for your project
-./scripts/humanlayer/init-project.sh . acme-corp
+# Default profile
+humanlayer thoughts init
 
-# 2. Verify structure created
+# Specific profile
+humanlayer thoughts init --profile coalesce-labs
+
+# Or use the helper script
+./scripts/humanlayer/init-project.sh . project-name coalesce-labs
+
+# Verify structure created
 ls -la thoughts/shared/
 
-# 3. Sync with HumanLayer
+# Sync with HumanLayer
 humanlayer thoughts sync
 ```
 
@@ -74,8 +80,8 @@ humanlayer thoughts status
 # Sync with verbose output for debugging
 humanlayer thoughts sync --verbose
 
-# Verify config name is set
-cat .claude/config.json | jq '.thoughts.configName'
+# List available profiles
+humanlayer thoughts profile list
 ```
 
 ## Best Practices
@@ -107,22 +113,21 @@ thoughts/shared/
 
 ### Per-Project Thoughts
 
-If you work on multiple projects, each can have its own thoughts repository:
+If you work on multiple projects, each can have its own thoughts repository using HumanLayer profiles:
 
-```json
-// .claude/config.json
-{
-  "projectKey": "acme",
-  "thoughts": {
-    "configName": "acme"  // Points to HumanLayer config named "acme"
-  }
-}
-```
-
-Then configure HumanLayer:
 ```bash
-humanlayer config add --name acme --repo ~/thoughts/repos/acme
+# List available profiles
+humanlayer thoughts profile list
+
+# Create a new profile
+humanlayer thoughts profile create acme --repo ~/clients/acme/thoughts
+
+# Initialize a project with a profile
+cd /path/to/acme-project
+humanlayer thoughts init --profile acme
 ```
+
+HumanLayer automatically maps working directories to profiles via `repoMappings`.
 
 ### Sharing Across Worktrees
 
@@ -185,14 +190,19 @@ HumanLayer provides:
 - **Git-backed storage**: Thoughts are versioned
 - **Multi-machine sync**: Work from anywhere
 - **Team collaboration**: Share context with team
+- **Profile-based config**: Automatic thoughts repo detection via repoMappings
 
 Setup:
 ```bash
 # Install HumanLayer CLI
 npm install -g humanlayer
 
-# Configure for your project
-humanlayer config add --name my-project --repo ~/thoughts/repos/my-project
+# Initialize with default profile
+humanlayer thoughts init
+
+# Or create and use a specific profile
+humanlayer thoughts profile create my-project --repo ~/thoughts/repos/my-project
+humanlayer thoughts init --profile my-project
 
 # Sync thoughts
 humanlayer thoughts sync

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -113,8 +113,19 @@ fi
 # Initialize thoughts (REQUIRED for Catalyst workflows)
 if command -v humanlayer >/dev/null 2>&1; then
 	echo "🧠 Initializing HumanLayer thoughts system..."
-	if humanlayer thoughts init --directory "$REPO_BASE_NAME" >/dev/null 2>&1; then
-		echo -e "${GREEN}✅ Thoughts initialized for ${REPO_BASE_NAME}${NC}"
+
+	# Detect current profile from parent directory
+	CURRENT_PROFILE=$(humanlayer thoughts status 2>/dev/null | grep -i "Profile:" | head -1 | awk '{print $2}')
+
+	# Build init command with profile if detected
+	INIT_CMD="humanlayer thoughts init --directory $REPO_NAME"
+	if [ -n "$CURRENT_PROFILE" ]; then
+		INIT_CMD="$INIT_CMD --profile $CURRENT_PROFILE"
+		echo "📋 Using profile from parent: $CURRENT_PROFILE"
+	fi
+
+	if eval "$INIT_CMD" >/dev/null 2>&1; then
+		echo -e "${GREEN}✅ Thoughts initialized for ${REPO_NAME}${NC}"
 		echo "🔄 Syncing with shared thoughts repository..."
 		if humanlayer thoughts sync >/dev/null 2>&1; then
 			echo -e "${GREEN}✅ Thoughts synced! Worktree has access to:${NC}"
@@ -125,12 +136,12 @@ if command -v humanlayer >/dev/null 2>&1; then
 			echo -e "${YELLOW}⚠️  Sync warning: Run 'humanlayer thoughts sync' manually in worktree${NC}"
 		fi
 	else
-		echo -e "${YELLOW}⚠️  Could not initialize thoughts. Run 'humanlayer thoughts init --directory ${REPO_BASE_NAME}' manually.${NC}"
+		echo -e "${YELLOW}⚠️  Could not initialize thoughts. Run 'humanlayer thoughts init --directory ${REPO_NAME}' manually.${NC}"
 	fi
 else
 	echo -e "${RED}❌ HumanLayer CLI not found! Catalyst workflows require HumanLayer.${NC}"
 	echo "   Install: pip install humanlayer"
-	echo "   Then run: humanlayer thoughts init --directory ${REPO_BASE_NAME}"
+	echo "   Then run: humanlayer thoughts init --directory ${REPO_NAME}"
 	echo "             humanlayer thoughts sync"
 fi
 

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -29,8 +29,7 @@
       "projectId": "[NEEDS_SETUP]"
     },
     "thoughts": {
-      "user": null,
-      "configName": null
+      "user": null
     }
   }
 }

--- a/plugins/pm/agents/backlog-analyzer.md
+++ b/plugins/pm/agents/backlog-analyzer.md
@@ -2,7 +2,7 @@
 name: backlog-analyzer
 description: Analyzes Linear backlog to identify orphaned issues, incorrect project assignments, missing estimates, stale issues, and potential duplicates. Provides actionable recommendations with confidence scores.
 tools: Read, Write, Grep
-model: sonnet
+model: inherit
 color: violet
 version: 1.0.0
 ---

--- a/plugins/pm/agents/cycle-analyzer.md
+++ b/plugins/pm/agents/cycle-analyzer.md
@@ -2,7 +2,7 @@
 name: cycle-analyzer
 description: Analyzes cycle health by calculating health scores, identifying risk factors, assessing team capacity, and generating specific recommendations. Returns structured insights for health reports.
 tools: Read, Write
-model: sonnet
+model: inherit
 color: emerald
 version: 1.0.0
 ---

--- a/plugins/pm/agents/github-linear-analyzer.md
+++ b/plugins/pm/agents/github-linear-analyzer.md
@@ -2,7 +2,7 @@
 name: github-linear-analyzer
 description: Analyzes the relationship between GitHub pull requests and Linear issues. Identifies sync gaps, orphaned PRs, orphaned issues, and correlation opportunities.
 tools: Read, Write, Grep
-model: sonnet
+model: inherit
 color: blue
 version: 1.0.0
 ---

--- a/plugins/pm/agents/health-scorer.md
+++ b/plugins/pm/agents/health-scorer.md
@@ -11,7 +11,7 @@ description: |
 
   This agent provides analysis and recommendations.
 tools: Read
-model: sonnet
+model: inherit
 ---
 
 # Health Score Analyzer

--- a/plugins/pm/agents/milestone-analyzer.md
+++ b/plugins/pm/agents/milestone-analyzer.md
@@ -2,7 +2,7 @@
 name: milestone-analyzer
 description: Analyzes project milestone health by calculating progress toward target date, identifying blocked/at-risk issues, and generating specific recommendations. Similar to cycle-analyzer but for milestones.
 tools: Read, Write
-model: sonnet
+model: inherit
 color: amber
 version: 1.0.0
 ---

--- a/scripts/humanlayer/add-client-config
+++ b/scripts/humanlayer/add-client-config
@@ -1,243 +1,40 @@
 #!/bin/bash
-# add-client-config - Add a new client-specific thoughts configuration
-# Usage: add-client-config <client-name> <thoughts-repo-path>
-# Example: add-client-config acme ~/clients/acme/thoughts
+# add-client-config - Add a new client-specific thoughts profile
+# Usage: add-client-config <client-name> [thoughts-repo-path]
 
 set -e
-
-# Colors
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-RED='\033[0;31m'
-NC='\033[0m'
-
-CONFIG_DIR="$HOME/.config/humanlayer"
-
-# Function to show usage
-show_usage() {
-	echo "Usage: add-client-config <client-name> [thoughts-repo-path]"
-	echo ""
-	echo "Examples:"
-	echo "  add-client-config acme                    # Interactive - will prompt for path"
-	echo "  add-client-config acme ~/clients/acme/thoughts"
-	echo "  add-client-config acme ~/code-repos/github/acme/bravo_code/thoughts"
-	echo ""
-	echo "This creates a new HumanLayer configuration for a client project."
-	echo "You can then switch to it with: hl-switch <client-name>"
-}
-
-# Check arguments
-if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
-	show_usage
-	exit 0
-fi
 
 CLIENT_NAME="$1"
 THOUGHTS_REPO="${2-}"
 
+if [ -z "$CLIENT_NAME" ]; then
+    echo "Usage: add-client-config <client-name> [thoughts-repo-path]"
+    exit 1
+fi
+
 # Sanitize client name
 CLIENT_NAME=$(echo "$CLIENT_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 
-CONFIG_FILE="$CONFIG_DIR/config-${CLIENT_NAME}.json"
-
-# Check if config already exists
-if [ -f "$CONFIG_FILE" ]; then
-	echo -e "${RED}Error: Configuration for '$CLIENT_NAME' already exists${NC}"
-	echo "File: $CONFIG_FILE"
-	echo ""
-	echo "To update it, edit the file directly or remove it first:"
-	echo "  rm $CONFIG_FILE"
-	exit 1
-fi
-
-echo -e "${BLUE}🆕 Adding new client configuration: $CLIENT_NAME${NC}"
-echo ""
-
 # Get thoughts repo path if not provided
 if [ -z "$THOUGHTS_REPO" ]; then
-	echo "Where should this client's thoughts be stored?"
-	echo ""
-	echo "Suggestions:"
-	echo "  ~/thoughts-${CLIENT_NAME}"
-	echo "  ~/clients/${CLIENT_NAME}/thoughts"
-	echo "  ~/code-repos/github/${CLIENT_NAME}/thoughts"
-	echo ""
-	read -p "Thoughts repository path: " THOUGHTS_REPO
-
-	if [ -z "$THOUGHTS_REPO" ]; then
-		echo -e "${RED}Error: Path cannot be empty${NC}"
-		exit 1
-	fi
+    echo "Where should this client's thoughts be stored?"
+    read -p "Thoughts repository path: " THOUGHTS_REPO
 fi
 
-# Expand tilde
+# Expand tilde and make absolute
 THOUGHTS_REPO="${THOUGHTS_REPO/#\~/$HOME}"
-
-# Convert to absolute path if relative
 if [[ $THOUGHTS_REPO != /* ]]; then
-	THOUGHTS_REPO="$(cd "$(dirname "$THOUGHTS_REPO")" 2>/dev/null && pwd)/$(basename "$THOUGHTS_REPO")" || THOUGHTS_REPO="$HOME/$THOUGHTS_REPO"
+    THOUGHTS_REPO="$(pwd)/$THOUGHTS_REPO"
 fi
 
-echo ""
-echo "Configuration details:"
-echo "  Client: $CLIENT_NAME"
-echo "  Thoughts repo: $THOUGHTS_REPO"
-echo "  Config file: $CONFIG_FILE"
+# Create profile using HumanLayer CLI
+echo "Creating profile: $CLIENT_NAME"
+echo "Thoughts repo: $THOUGHTS_REPO"
 echo ""
 
-read -p "Create this configuration? (Y/n) " -n 1 -r
-echo
-
-if [[ $REPLY =~ ^[Nn]$ ]]; then
-	echo "Cancelled."
-	exit 0
-fi
-
-# Create the config file
-mkdir -p "$CONFIG_DIR"
-
-cat >"$CONFIG_FILE" <<EOF
-{
-  "thoughts": {
-    "thoughtsRepo": "$THOUGHTS_REPO",
-    "reposDir": "repos",
-    "globalDir": "global",
-    "user": "ryan",
-    "repoMappings": {}
-  }
-}
-EOF
-
-echo -e "${GREEN}✓ Created configuration: $CLIENT_NAME${NC}"
-echo ""
-
-# Ask if they want to initialize the thoughts repo
-if [ ! -d "$THOUGHTS_REPO" ]; then
-	echo "The thoughts repository doesn't exist yet."
-	echo ""
-	read -p "Create and initialize $THOUGHTS_REPO? (Y/n) " -n 1 -r
-	echo
-
-	if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-		echo ""
-		echo "Creating thoughts repository..."
-
-		mkdir -p "$THOUGHTS_REPO"
-		cd "$THOUGHTS_REPO"
-
-		# Create structure
-		mkdir -p repos global/ryan global/shared
-
-		# Create .gitignore
-		cat >.gitignore <<'GITIGNORE'
-# OS files
-.DS_Store
-Thumbs.db
-
-# Editor files
-.vscode/
-.idea/
-*.swp
-*.swo
-*~
-
-# Temporary files
-*.tmp
-*.bak
-
-# Searchable directory (generated)
-**/searchable/
-GITIGNORE
-
-		# Create README
-		cat >README.md <<README
-# ${CLIENT_NAME^} Thoughts Repository
-
-Thoughts repository for managing context across ${CLIENT_NAME} projects.
-
-## Structure
-
-\`\`\`
-thoughts/
-├── repos/              # Project-specific thoughts
-│   └── {project}/
-│       ├── ryan/      # Your personal notes
-│       └── shared/    # Team-shared notes
-└── global/            # Cross-project thoughts
-    ├── ryan/          # Your personal notes
-    └── shared/        # Team-shared notes
-\`\`\`
-
-## Usage
-
-\`\`\`bash
-# Switch to ${CLIENT_NAME} config
-hl-switch ${CLIENT_NAME}
-
-# Initialize a project
-cd /path/to/project
-humanlayer thoughts init
-\`\`\`
-README
-
-		# Initialize git
-		git init
-		git add .
-		git commit -m "Initial ${CLIENT_NAME} thoughts repository"
-
-		echo -e "${GREEN}✓ Created and initialized: $THOUGHTS_REPO${NC}"
-		echo ""
-
-		# Ask about GitHub
-		read -p "Push to GitHub? (y/N) " -n 1 -r
-		echo
-
-		if [[ $REPLY =~ ^[Yy]$ ]]; then
-			echo ""
-			echo "Enter GitHub repository (e.g., org-name/thoughts or just repo-name):"
-			read -p "GitHub repo: " GITHUB_REPO
-
-			if [ -n "$GITHUB_REPO" ]; then
-				# Check if it includes org/repo or just repo
-				if [[ $GITHUB_REPO != *"/"* ]]; then
-					# Just repo name, ask for org
-					echo ""
-					echo "GitHub organization/owner:"
-					echo "  1. Your personal account"
-					echo "  2. coalesce-labs"
-					echo "  3. Client organization"
-					echo ""
-					read -p "Enter org name: " ORG_NAME
-					GITHUB_REPO="${ORG_NAME}/${GITHUB_REPO}"
-				fi
-
-				echo ""
-				echo "Creating GitHub repository: $GITHUB_REPO"
-				gh repo create "$GITHUB_REPO" \
-					--private \
-					--source=. \
-					--description="Thoughts repository for ${CLIENT_NAME} projects" \
-					--push || echo -e "${YELLOW}Failed to create/push to GitHub${NC}"
-			fi
-		fi
-	fi
-else
-	echo -e "${GREEN}✓ Thoughts repository already exists: $THOUGHTS_REPO${NC}"
-fi
+humanlayer thoughts profile create "$CLIENT_NAME" --repo "$THOUGHTS_REPO"
 
 echo ""
-echo -e "${GREEN}✅ Configuration added successfully!${NC}"
-echo ""
-echo "To start using it:"
-echo ""
-echo "  # Switch to this configuration"
-echo "  hl-switch ${CLIENT_NAME}"
-echo ""
-echo "  # Initialize a project"
-echo "  cd /path/to/${CLIENT_NAME}-project"
-echo "  humanlayer thoughts init"
-echo ""
-echo "To switch back to personal:"
-echo "  hl-switch coalesce-labs"
-echo ""
+echo "Profile created! To use:"
+echo "  cd /path/to/project"
+echo "  humanlayer thoughts init --profile $CLIENT_NAME"

--- a/scripts/humanlayer/init-project.sh
+++ b/scripts/humanlayer/init-project.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 # init-project.sh - Initialize a project with thoughts using HumanLayer CLI
-# Usage: ./init-project.sh [project_path] [directory_name] [config_name]
+# Usage: ./init-project.sh [project_path] [directory_name] [profile]
 #
 # Arguments:
 #   project_path   - Path to project (default: current directory)
 #   directory_name - Name for thoughts directory (optional, will prompt if not provided)
-#   config_name    - HumanLayer config name (e.g., "acme", "coalesce-labs")
-#                    Will use ~/.config/humanlayer/config-{name}.json
-#                    Also stores in .claude/config.json for per-project config
+#   profile        - HumanLayer profile name (e.g., "coalesce-labs", "ryanrozich")
+#                    If not provided, will try to detect from current directory
 
 set -e
 
@@ -19,146 +18,58 @@ NC='\033[0m'
 
 PROJECT_DIR="${1:-.}"
 DIRECTORY_NAME="${2-}"
-CONFIG_NAME="${3-}"
+PROFILE="${3-}"
 
 # Resolve to absolute path
 PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
 
-echo -e "${YELLOW}🚀 Initializing project with thoughts${NC}"
+echo -e "${YELLOW}Initializing project with thoughts${NC}"
 echo "Project: $PROJECT_DIR"
-if [ -n "$CONFIG_NAME" ]; then
-	echo "Config: $CONFIG_NAME (will use ~/.config/humanlayer/config-${CONFIG_NAME}.json)"
-fi
-echo ""
 
 # Check if humanlayer CLI is installed
 if ! command -v humanlayer &>/dev/null; then
-	echo -e "${RED}❌ Error: humanlayer CLI not found${NC}"
-	echo ""
-	echo "Please install the HumanLayer CLI first:"
-	echo "  pip install humanlayer"
-	echo "  # or"
-	echo "  pipx install humanlayer"
-	echo ""
-	echo "Or run: ./scripts/humanlayer/setup-thoughts.sh"
-	exit 1
-fi
-
-# Determine which config file to use
-if [ -n "$CONFIG_NAME" ]; then
-	CONFIG_FILE="$HOME/.config/humanlayer/config-${CONFIG_NAME}.json"
-	if [ ! -f "$CONFIG_FILE" ]; then
-		echo -e "${RED}❌ Error: Config not found: $CONFIG_FILE${NC}"
-		echo ""
-		echo "Available configs:"
-		ls -1 ~/.config/humanlayer/config-*.json 2>/dev/null | sed 's/.*config-\(.*\)\.json/  - \1/' || echo "  (none found)"
-		echo ""
-		echo "Create a new config with:"
-		echo "  ./scripts/humanlayer/add-client-config $CONFIG_NAME /path/to/thoughts"
-		exit 1
-	fi
-	CONFIG_FLAG="--config-file $CONFIG_FILE"
-else
-	# Use default config
-	CONFIG_FILE="$HOME/.config/humanlayer/config.json"
-	if [ ! -f "$CONFIG_FILE" ]; then
-		echo -e "${RED}❌ Error: Thoughts not configured${NC}"
-		echo ""
-		echo "Please run the setup script first:"
-		echo "  ./scripts/humanlayer/setup-thoughts.sh"
-		exit 1
-	fi
-	CONFIG_FLAG=""
+    echo -e "${RED}Error: humanlayer CLI not found${NC}"
+    exit 1
 fi
 
 # Check if we're in a git repository
 cd "$PROJECT_DIR"
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
-	echo -e "${RED}❌ Error: Not a git repository${NC}"
-	echo "The project must be a git repository to use thoughts."
-	echo ""
-	read -p "Initialize git repository now? (Y/n) " -n 1 -r
-	echo
-	if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-		git init
-		echo -e "${GREEN}✓ Git repository initialized${NC}"
-	else
-		exit 1
-	fi
+    echo -e "${RED}Error: Not a git repository${NC}"
+    exit 1
 fi
 
-# Run humanlayer thoughts init with appropriate config
-echo ""
-echo -e "${YELLOW}Initializing thoughts for this project...${NC}"
+# If no profile provided, try to detect from current environment
+if [ -z "$PROFILE" ]; then
+    DETECTED_PROFILE=$(humanlayer thoughts status 2>/dev/null | grep -i "Profile:" | head -1 | awk '{print $2}')
+    if [ -n "$DETECTED_PROFILE" ]; then
+        PROFILE="$DETECTED_PROFILE"
+        echo "Profile: $PROFILE (auto-detected)"
+    fi
+else
+    echo "Profile: $PROFILE"
+fi
 echo ""
 
+# Build humanlayer command
+HL_CMD="humanlayer thoughts init"
+if [ -n "$PROFILE" ]; then
+    HL_CMD="$HL_CMD --profile $PROFILE"
+fi
 if [ -n "$DIRECTORY_NAME" ]; then
-	# Non-interactive mode with directory name
-	echo "Using directory name: $DIRECTORY_NAME"
-	humanlayer thoughts init $CONFIG_FLAG --directory "$DIRECTORY_NAME"
-else
-	# Interactive mode
-	humanlayer thoughts init $CONFIG_FLAG
+    HL_CMD="$HL_CMD --directory $DIRECTORY_NAME"
 fi
 
-# Store configName in .claude/config.json if provided
-if [ -n "$CONFIG_NAME" ]; then
-	CLAUDE_CONFIG="$PROJECT_DIR/.claude/config.json"
+# Run humanlayer thoughts init
+echo -e "${YELLOW}Running: $HL_CMD${NC}"
+eval $HL_CMD
 
-	# Create .claude directory if it doesn't exist
-	mkdir -p "$PROJECT_DIR/.claude"
-
-	# Create or update config.json
-	if [ -f "$CLAUDE_CONFIG" ]; then
-		# Update existing config using jq
-		if command -v jq &>/dev/null; then
-			TMP=$(mktemp)
-			jq ".thoughts.configName = \"$CONFIG_NAME\"" "$CLAUDE_CONFIG" > "$TMP"
-			mv "$TMP" "$CLAUDE_CONFIG"
-			echo -e "${GREEN}✓ Updated .claude/config.json with configName: $CONFIG_NAME${NC}"
-		else
-			echo -e "${YELLOW}⚠️  jq not found - please manually add to .claude/config.json:${NC}"
-			echo "  \"thoughts\": {"
-			echo "    \"configName\": \"$CONFIG_NAME\""
-			echo "  }"
-		fi
-	else
-		# Create new config
-		cat > "$CLAUDE_CONFIG" <<EOF
-{
-  "thoughts": {
-    "configName": "$CONFIG_NAME"
-  }
-}
-EOF
-		echo -e "${GREEN}✓ Created .claude/config.json with configName: $CONFIG_NAME${NC}"
-	fi
-fi
-
-# Check if initialization was successful
+# Verify initialization
 if [ -d "$PROJECT_DIR/thoughts" ]; then
-	echo ""
-	echo -e "${GREEN}✅ Project initialized with thoughts!${NC}"
-	echo ""
-	echo "Created structure:"
-	ls -la "$PROJECT_DIR/thoughts" | tail -n +4
-	echo ""
-	if [ -n "$CONFIG_NAME" ]; then
-		echo -e "${GREEN}✓ Per-project config set to: $CONFIG_NAME${NC}"
-		echo "  All humanlayer commands will automatically use config-${CONFIG_NAME}.json"
-		echo ""
-	fi
-	echo -e "${YELLOW}Next steps:${NC}"
-	echo "1. Create the searchable index:"
-	echo "   humanlayer thoughts sync"
-	echo ""
-	echo "2. Start documenting in thoughts/{your_name}/"
-	echo ""
-	echo "3. Use the workflow commands:"
-	echo "   /create-plan - Interactive planning with research"
-	echo "   /implement-plan - Execute a plan"
-	echo "   /validate-plan - Verify implementation"
-	echo ""
-else
-	echo -e "${YELLOW}⚠️  Thoughts initialization may have been cancelled${NC}"
+    echo ""
+    echo -e "${GREEN}Project initialized with thoughts!${NC}"
+    echo ""
+    echo "Next steps:"
+    echo "1. humanlayer thoughts sync"
+    echo "2. Start using /research-codebase, /create-plan, etc."
 fi


### PR DESCRIPTION
## Summary

This PR implements two related improvements to simplify configuration and improve analysis quality:

1. **HumanLayer Profile Migration**: Leverage HumanLayer's native profile and `repoMappings` system for automatic thoughts repository detection, eliminating the need to track `configName` in Catalyst config files.

2. **Model Updates**: Upgrade PM analysis agents from Sonnet to Opus 4.5 (via `model: inherit`) for better quality analysis. With Opus 4.5's 76% token efficiency improvement, the cost difference is minimal while quality is significantly better.

## Changes

### Model Updates (Phase 1)
- Updated 5 PM analysis agents from `model: sonnet` to `model: inherit`:
  - `backlog-analyzer.md`
  - `cycle-analyzer.md`
  - `github-linear-analyzer.md`
  - `health-scorer.md`
  - `milestone-analyzer.md`
- Added "Model Selection Guidance" section to CLAUDE.md documenting two-tier strategy:
  - **Opus 4.5** (`inherit`): All analysis, planning, implementation
  - **Haiku 4.5** (`haiku`): Data collection only (metrics, classification)

### HumanLayer Profile Migration (Phase 2)
- Removed `configName` from all config files (`.claude/config.json`, templates)
- Updated `init-project.sh` to use `--profile` flag with auto-detection
- Updated `add-client-config` to use `humanlayer thoughts profile create`
- Updated `create-worktree.sh` to inherit profile from parent directory
- Updated `context_daily.md` to detect thoughts repo via `humanlayer thoughts status`

### Documentation Updates
- **CLAUDE.md**: Updated three-layer memory system description, ADR-002
- **THOUGHTS_SETUP.md**: Profile-based initialization instructions
- **MULTI_CONFIG_GUIDE.md**: Complete rewrite for HumanLayer profiles
- **QUICKSTART.md**: Simplified config examples
- **scripts/README.md**: Updated for profile-based workflow

## How Profile Detection Works

The key insight is that HumanLayer already tracks profile-to-directory mappings via `repoMappings`:

1. `humanlayer thoughts status` shows `Profile: <name>` for current directory
2. Scripts parse this to auto-detect the active profile
3. Worktrees automatically inherit parent's profile when created
4. No manual `configName` tracking needed

```bash
# Check current profile
humanlayer thoughts status
# Output shows: Profile: coalesce-labs

# Worktree creation auto-inherits profile
/create-worktree feature-branch
# New worktree initialized with same profile
```

## Test plan

- [ ] Verify `humanlayer thoughts status` shows correct profile
- [ ] Test `create-worktree` inherits profile from parent
- [ ] Run `/catalyst-pm:analyze-cycle` to verify Opus model works
- [ ] Initialize new project with `--profile` flag
- [ ] Verify no `configName` references remain in active config files

## Migration Notes

For existing projects with `configName` in `.claude/config.json`:
- The field will simply be ignored (HumanLayer uses repoMappings instead)
- Can optionally clean up: `jq 'del(.thoughts.configName)' .claude/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)