### PR TITLE
fix(dev): add YAML frontmatter to /create_plan command template

### DIFF
--- a/plugins/dev/commands/create_plan.md
+++ b/plugins/dev/commands/create_plan.md
@@ -247,7 +247,22 @@ Once aligned on approach:
 
 After structure approval:
 
-1. **Write the plan** to `thoughts/shared/plans/YYYY-MM-DD-PROJ-XXXX-description.md`
+1. **Gather metadata for the plan document**:
+
+   Before writing the plan, collect git and temporal metadata:
+
+   ```bash
+   # Get current date/time in ISO 8601 format with timezone
+   CURRENT_ISO_DATETIME=$(date -Iseconds)  # e.g., 2025-01-11T14:30:00-06:00
+   CURRENT_DATE=$(date +%Y-%m-%d)          # e.g., 2025-01-11
+
+   # Get git information
+   GIT_COMMIT_SHORT=$(git rev-parse --short HEAD)
+   GIT_BRANCH=$(git branch --show-current)
+   REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+   ```
+
+2. **Write the plan** to `thoughts/shared/plans/YYYY-MM-DD-PROJ-XXXX-description.md`
    - Format: `YYYY-MM-DD-PROJ-XXXX-description.md` where:
      - YYYY-MM-DD is today's date
      - PROJ-XXXX is the ticket number (omit if no ticket)
@@ -255,9 +270,24 @@ After structure approval:
    - Examples:
      - With ticket: `2025-01-08-PROJ-123-parent-child-tracking.md`
      - Without ticket: `2025-01-08-improve-error-handling.md`
-2. **Use this template structure**:
+
+3. **Use this template structure** (note: frontmatter comes BEFORE the heading):
 
 ````markdown
+---
+date: {CURRENT_ISO_DATETIME}
+researcher: claude
+git_commit: {GIT_COMMIT_SHORT}
+branch: {GIT_BRANCH}
+repository: {REPO_NAME}
+topic: "{PLAN_TITLE}"
+tags: [plan, implementation, {RELEVANT_COMPONENT_TAGS}]
+status: ready_for_implementation
+last_updated: {CURRENT_DATE}
+last_updated_by: claude
+type: implementation_plan
+---
+
 # [Feature/Task Name] Implementation Plan
 
 ## Overview


### PR DESCRIPTION
## Summary

- Add YAML frontmatter template to `/create_plan` command output
- Include metadata gathering step (git commit, branch, repo, ISO datetime)
- Ensure consistency with `/create_handoff` and `/research_codebase` patterns

## Context

We audited the frontmatter consistency across `thoughts/shared/` in bravo-1 and found **291 out of 908 documents were missing YAML frontmatter**. While we have a backfill script for existing documents, this PR prevents the issue going forward by ensuring `/create_plan` includes proper frontmatter.

Frontmatter is critical because HumanLayer's thoughts sync system uses it to index documents for AI-assisted search across worktrees.

## Changes

The plan template now includes:
```yaml
---
date: {CURRENT_ISO_DATETIME}
researcher: claude
git_commit: {GIT_COMMIT_SHORT}
branch: {GIT_BRANCH}
repository: {REPO_NAME}
topic: "{PLAN_TITLE}"
tags: [plan, implementation, {RELEVANT_COMPONENT_TAGS}]
status: ready_for_implementation
last_updated: {CURRENT_DATE}
last_updated_by: claude
type: implementation_plan
---
```

## Test plan

- [x] Verify all 11 required fields are present in template
- [x] Confirm frontmatter appears BEFORE the `# Title` heading
- [x] Check field types match schema (ISO 8601 dates, arrays, etc.)
- [ ] Manual: Run `/create_plan` and verify output includes frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)