### PR TITLE
fix(dev): trim bloated research_codebase and create_plan commands

### DIFF
--- a/plugins/dev/commands/create_plan.md
+++ b/plugins/dev/commands/create_plan.md
@@ -8,37 +8,21 @@ version: 1.0.0
 
 # Implementation Plan
 
-## Configuration Note
-
-This command uses ticket references like `PROJ-123`. Replace `PROJ` with your Linear team's ticket
-prefix:
-
-- Read from `.claude/config.json` if available
-- Otherwise use a generic format like `TICKET-XXX`
-- Examples: `ENG-123`, `FEAT-456`, `BUG-789`
-
 You are tasked with creating detailed implementation plans through an interactive, iterative
 process. You should be skeptical, thorough, and work collaboratively with the user to produce
 high-quality technical specifications.
 
+Replace `PROJ` in ticket references with your Linear team's prefix from `.claude/config.json`.
+
 ## Prerequisites
 
-Before executing, verify all required tools and systems:
-
 ```bash
-# 1. Validate thoughts system (REQUIRED)
-if [[ -f "scripts/validate-thoughts-setup.sh" ]]; then
-  ./scripts/validate-thoughts-setup.sh || exit 1
-else
-  # Inline validation if script not found
-  if [[ ! -d "thoughts/shared" ]]; then
-    echo "❌ ERROR: Thoughts system not configured"
-    echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-    exit 1
-  fi
+if [[ ! -d "thoughts/shared" ]]; then
+  echo "ERROR: Thoughts system not configured"
+  echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
+  exit 1
 fi
 
-# 2. Validate plugin scripts
 if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
   "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
 fi
@@ -46,235 +30,110 @@ fi
 
 ## Initial Response
 
-**STEP 1: Check for recent research (OPTIONAL)**
-
-IMMEDIATELY run this bash script to find recent research that might be relevant:
+**STEP 1: Check for recent research**
 
 ```bash
-# Find recent research that might inform this plan
 if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
   RECENT_RESEARCH=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research)
   if [[ -n "$RECENT_RESEARCH" ]]; then
-    echo "💡 Found recent research: $RECENT_RESEARCH"
-    echo ""
+    echo "Found recent research: $RECENT_RESEARCH"
   fi
 fi
 ```
 
 **STEP 2: Gather initial input**
 
-After checking for research, follow this logic:
-
 1. **If user provided parameters** (file path or ticket reference):
-   - Immediately read any provided files FULLY
-   - If RECENT_RESEARCH was found, ask: "Should I reference the recent research document in this plan?"
+   - Read any provided files FULLY
+   - If RECENT_RESEARCH was found, mention it and ask if it should inform the plan
    - Begin the research process
 
 2. **If no parameters provided**:
-   - Show any RECENT_RESEARCH that was found
-   - Respond with:
-
-```
-I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
-
-Please provide:
-1. The task/ticket description (or reference to a ticket file)
-2. Any relevant context, constraints, or specific requirements
-3. Links to related research or previous implementations
-```
-
-If RECENT_RESEARCH exists, add:
-```
-💡 I found recent research: $RECENT_RESEARCH
-   Would you like me to use this as context for the plan?
-```
-
-Continue with:
-```
-I'll analyze this information and work with you to create a comprehensive plan.
-
-Tip: You can also invoke this command with a ticket file directly: `/create_plan thoughts/shared/tickets/PROJ-123.md`
-For deeper analysis, try: `/create_plan think deeply about thoughts/shared/tickets/PROJ-123.md`
-```
-
-Then wait for the user's input.
+   - Show any RECENT_RESEARCH found
+   - Ask for: task/ticket description, context/constraints, related research
+   - Wait for user's input
 
 ## Process Steps
 
 ### Step 1: Context Gathering & Initial Analysis
 
 1. **Read all mentioned files immediately and FULLY**:
-   - Ticket files (e.g., `thoughts/shared/tickets/PROJ-123.md`)
-   - Research documents
-   - Related implementation plans
-   - Any JSON/data files mentioned
-   - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
-   - **CRITICAL**: DO NOT spawn sub-tasks before reading these files yourself in the main context
-   - **NEVER** read files partially - if a file is mentioned, read it completely
+   - Ticket files, research documents, related plans, JSON/data files
+   - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters
+   - **CRITICAL**: Read these files yourself before spawning sub-tasks
 
-2. **Spawn initial research tasks to gather context**: Before asking the user any questions, use
-   specialized agents to research in parallel:
-   - Use the **codebase-locator** agent to find all files related to the ticket/task
-   - Use the **codebase-analyzer** agent to understand how the current implementation works
-   - If relevant, use the **thoughts-locator** agent to find any existing thoughts documents about
-     this feature
-   - If a Linear ticket is mentioned, use the **linear-ticket-reader** agent to get full details
+2. **Spawn initial research tasks in parallel**:
+   - **codebase-locator** — find all files related to the ticket/task
+   - **codebase-analyzer** — understand how the current implementation works
+   - **thoughts-locator** — find existing thoughts documents about this feature (if relevant)
 
-   These agents will:
-   - Find relevant source files, configs, and tests
-   - Identify the specific directories to focus on (e.g., they'll focus on the relevant project directory)
-   - Trace data flow and key functions
-   - Return detailed explanations with file:line references
-
-3. **Read all files identified by research tasks**:
-   - After research tasks complete, read ALL files they identified as relevant
-   - Read them FULLY into the main context
-   - This ensures you have complete understanding before proceeding
+3. **Read all files identified by research tasks** FULLY into the main context
 
 4. **Analyze and verify understanding**:
-   - Cross-reference the ticket requirements with actual code
-   - Identify any discrepancies or misunderstandings
-   - Note assumptions that need verification
-   - Determine true scope based on codebase reality
+   - Cross-reference ticket requirements with actual code
+   - Identify discrepancies, assumptions, and true scope
 
 5. **Present informed understanding and focused questions**:
-
-   ```
-   Based on the ticket and my research of the codebase, I understand we need to [accurate summary].
-
-   I've found that:
-   - [Current implementation detail with file:line reference]
-   - [Relevant pattern or constraint discovered]
-   - [Potential complexity or edge case identified]
-
-   Questions that my research couldn't answer:
-   - [Specific technical question that requires human judgment]
-   - [Business logic clarification]
-   - [Design preference that affects implementation]
-   ```
-
-   Only ask questions that you genuinely cannot answer through code investigation.
+   - Show what you found with file:line references
+   - Only ask questions you genuinely cannot answer through code investigation
 
 ### Step 2: Research & Discovery
 
 After getting initial clarifications:
 
 1. **If the user corrects any misunderstanding**:
-   - DO NOT just accept the correction
-   - Spawn new research tasks to verify the correct information
-   - Read the specific files/directories they mention
+   - Spawn new research tasks to verify — don't just accept corrections
    - Only proceed once you've verified the facts yourself
 
-2. **Create a research todo list** using TodoWrite to track exploration tasks
+2. **Create a research todo list** using TodoWrite
 
 3. **Spawn parallel sub-tasks for comprehensive research**:
-   - Create multiple Task agents to research different aspects concurrently
-   - Use the right agent for each type of research:
 
    **For local codebase:**
-   - **codebase-locator** - To find more specific files (e.g., "find all files that handle [specific
-     component]")
-   - **codebase-analyzer** - To understand implementation details (e.g., "analyze how [system]
-     works")
-   - **codebase-pattern-finder** - To find similar features we can model after
+   - **codebase-locator** — find specific files
+   - **codebase-analyzer** — understand implementation details
+   - **codebase-pattern-finder** — find similar features to model after
 
    **For external research:**
-   - **external-research** - To research framework patterns and best practices from popular repos
-   - Ask: "How does [framework] recommend implementing [feature]?"
-   - Ask: "What's the standard approach for [pattern] in [library]?"
-   - Examples: React patterns, Express middleware, Next.js routing, Prisma schemas
+   - **external-research** — framework patterns and best practices from popular repos
 
    **For historical context:**
-   - **thoughts-locator** - To find any research, plans, or decisions about this area
-   - **thoughts-analyzer** - To extract key insights from the most relevant documents
-
-   **For related tickets:**
-   - **linear-searcher** - To find similar issues or past implementations
-
-   Each agent knows how to:
-   - Find the right files and code patterns
-   - Identify conventions and patterns to follow
-   - Look for integration points and dependencies
-   - Return specific file:line references
-   - Find tests and examples
+   - **thoughts-locator** / **thoughts-analyzer** — find past research, plans, decisions
 
 4. **Wait for ALL sub-tasks to complete** before proceeding
 
-5. **Present findings and design options**:
-
-   ```
-   Based on my research, here's what I found:
-
-   **Current State:**
-   - [Key discovery about existing code]
-   - [Pattern or convention to follow]
-
-   **Design Options:**
-   1. [Option A] - [pros/cons]
-   2. [Option B] - [pros/cons]
-
-   **Open Questions:**
-   - [Technical uncertainty]
-   - [Design decision needed]
-
-   Which approach aligns best with your vision?
-   ```
+5. **Present findings and design options** with pros/cons for each approach
 
 ### Step 3: Plan Structure Development
 
 Once aligned on approach:
 
-1. **Create initial plan outline**:
-
-   ```
-   Here's my proposed plan structure:
-
-   ## Overview
-   [1-2 sentence summary]
-
-   ## Implementation Phases:
-   1. [Phase name] - [what it accomplishes]
-   2. [Phase name] - [what it accomplishes]
-   3. [Phase name] - [what it accomplishes]
-
-   Does this phasing make sense? Should I adjust the order or granularity?
-   ```
-
+1. **Create initial plan outline** showing phases and what each accomplishes
 2. **Get feedback on structure** before writing details
 
 ### Step 4: Detailed Plan Writing
 
 After structure approval:
 
-1. **Gather metadata for the plan document**:
-
-   Before writing the plan, collect git and temporal metadata:
+1. **Gather metadata**:
 
    ```bash
-   # Get current date/time in ISO 8601 format with timezone
-   CURRENT_ISO_DATETIME=$(date -Iseconds)  # e.g., 2025-01-11T14:30:00-06:00
-   CURRENT_DATE=$(date +%Y-%m-%d)          # e.g., 2025-01-11
-
-   # Get git information
+   CURRENT_ISO_DATETIME=$(date -Iseconds)
+   CURRENT_DATE=$(date +%Y-%m-%d)
    GIT_COMMIT_SHORT=$(git rev-parse --short HEAD)
    GIT_BRANCH=$(git branch --show-current)
    REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
    ```
 
    **IMPORTANT: Document Storage Rules**
-   - ALWAYS write to `thoughts/shared/plans/` for plan documents
-   - NEVER write to `thoughts/searchable/` — this is a read-only search index
+   - ALWAYS write to `thoughts/shared/plans/`
+   - NEVER write to `thoughts/searchable/` (read-only search index)
 
 2. **Write the plan** to `thoughts/shared/plans/YYYY-MM-DD-PROJ-XXXX-description.md`
-   - Format: `YYYY-MM-DD-PROJ-XXXX-description.md` where:
-     - YYYY-MM-DD is today's date
-     - PROJ-XXXX is the ticket number (omit if no ticket)
-     - description is a brief kebab-case description
-   - Examples:
-     - With ticket: `2025-01-08-PROJ-123-parent-child-tracking.md`
-     - Without ticket: `2025-01-08-improve-error-handling.md`
+   - With ticket: `2025-01-08-PROJ-123-parent-child-tracking.md`
+   - Without ticket: `2025-01-08-improve-error-handling.md`
 
-3. **Use this template structure** (note: frontmatter comes BEFORE the heading):
+3. **Use this template structure** (frontmatter comes BEFORE the heading):
 
 ````markdown
 ---
@@ -303,7 +162,7 @@ type: implementation_plan
 
 ## Desired End State
 
-[A Specification of the desired end state after this plan is complete, and how to verify it]
+[Specification of the desired end state and how to verify it]
 
 ### Key Discoveries:
 
@@ -329,7 +188,8 @@ type: implementation_plan
 
 #### 1. [Component/File Group]
 
-**File**: `path/to/file.ext` **Changes**: [Summary of changes]
+**File**: `path/to/file.ext`
+**Changes**: [Summary of changes]
 
 ```[language]
 // Specific code to add/modify
@@ -339,51 +199,34 @@ type: implementation_plan
 
 #### Automated Verification:
 
-- [ ] Migration applies cleanly: `make migrate`
-- [ ] Unit tests pass: `make test-component`
-- [ ] Type checking passes: `npm run typecheck`
+- [ ] Unit tests pass: `make test`
+- [ ] Type checking passes: `make check`
 - [ ] Linting passes: `make lint`
-- [ ] Integration tests pass: `make test-integration`
 
 #### Manual Verification:
 
-- [ ] Feature works as expected when tested via UI
-- [ ] Performance is acceptable under load
-- [ ] Edge case handling verified manually
+- [ ] Feature works as expected when tested
 - [ ] No regressions in related features
 
 ---
 
 ## Phase 2: [Descriptive Name]
 
-[Similar structure with both automated and manual success criteria...]
+[Similar structure...]
 
 ---
 
 ## Testing Strategy
 
-### Unit Tests:
-
-- [What to test]
-- [Key edge cases]
-
-### Integration Tests:
-
-- [End-to-end scenarios]
-
-### Manual Testing Steps:
-
-1. [Specific step to verify feature]
-2. [Another verification step]
-3. [Edge case to test manually]
+[Unit tests, integration tests, manual testing steps]
 
 ## Performance Considerations
 
-[Any performance implications or optimizations needed]
+[Any performance implications]
 
 ## Migration Notes
 
-[If applicable, how to handle existing data/systems]
+[If applicable]
 
 ## References
 
@@ -394,267 +237,61 @@ type: implementation_plan
 
 ### Step 5: Sync and Review
 
-1. **Sync the thoughts directory**:
-   - Run `humanlayer thoughts sync` to sync the newly created plan
-   - This ensures the plan is properly indexed and available
+1. **Sync**: Run `humanlayer thoughts sync`
 
 2. **Track in Workflow Context**:
-
-   After saving the plan document, add it to workflow context:
-
    ```bash
    if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
      "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add plans "$PLAN_FILE" "${TICKET_ID}"
    fi
    ```
 
-3. **Check context usage and present plan**:
+3. **Present plan** and ask for review:
+   - Show plan location
+   - Ask: Are phases properly scoped? Success criteria specific enough? Missing edge cases?
+   - If context >60%, recommend clearing before implementation phase
 
-   **Monitor your context** and present:
+4. **Iterate based on feedback** until the user is satisfied
+   - Re-sync thoughts after changes
+
+5. **After plan approval**, provide implementation command:
+
+   **Use `--team` when:** 3+ parallel phases, distinct domains, non-overlapping files, 10+ files
+   **Use standard mode when:** sequential phases, same directory, <10 files, tightly coupled
 
    ```
-   ✅ Implementation plan created!
-
-   **Plan location**: `thoughts/shared/plans/YYYY-MM-DD-PROJ-XXXX-description.md`
-
-   ## 📊 Context Status
-
-   Current usage: {X}% ({Y}K/{Z}K tokens)
-
-   {If >60%}:
-   ⚠️ **Context Alert**: We're at {X}% context usage.
-
-   **Recommendation**: Clear context before implementation phase.
-
-   **Why?** The implementation phase will:
-   - Load the complete plan file
-   - Read multiple source files
-   - Track progress with TodoWrite
-   - Benefit from fresh context for optimal performance
-
-   **What to do**:
-   1. ✅ Review the plan (read the file above)
-   2. ✅ Close this session (clear context)
-   3. ✅ Start fresh session in worktree
-   4. ✅ Run `/implement-plan {plan-path}`
-
-   This is normal! Context is meant to be cleared between phases.
-
-   {If <60%}:
-   ✅ Context healthy ({X}%).
-
-   ---
-
-   Please review the plan and let me know:
-   - Are the phases properly scoped?
-   - Are the success criteria specific enough?
-   - Any technical details that need adjustment?
-   - Missing edge cases or considerations?
-   ```
-
-4. **Iterate based on feedback** - be ready to:
-   - Add missing phases
-   - Adjust technical approach
-   - Clarify success criteria (both automated and manual)
-   - Add/remove scope items
-   - After making changes, run `humanlayer thoughts sync` again
-   - **Monitor context** - if >70% during iterations, warn user to review file offline
-
-5. **Continue refining** until the user is satisfied
-
-6. **Final context check and implementation recommendation** after approval:
-   - If context >50%, remind user to clear before implementation
-
-   **Analyze the plan to determine the best implementation approach and provide a copy-paste ready command.**
-
-   **Use `--team` when ALL of these are true:**
-   1. Plan has 3+ phases that can be executed in parallel (not sequential dependencies)
-   2. Changes span distinct domains (e.g., frontend + backend + tests + config)
-   3. Each domain's file changes don't overlap (no two teammates editing the same file)
-   4. The total scope is substantial (10+ files across 3+ directories)
-
-   **Use standard mode (no `--team`) when ANY of these are true:**
-   1. Changes are sequential (each phase depends on the previous)
-   2. Most changes are in the same directory or closely related files
-   3. Total scope is small (fewer than 10 files)
-   4. Changes are tightly coupled (e.g., API + client contract changes)
-
-   **Always output this block after plan approval:**
-
-   ````
    ## Ready to Implement
 
-   {IF team mode recommended:}
-   This plan spans {N} independent domains ({list domains}) with {M}+ files.
-   **Recommended: agent team mode** for parallel implementation.
-
    Start a new session and run:
-   ```
-   /catalyst-dev:implement_plan --team thoughts/shared/plans/{PLAN_FILENAME}
-   ```
+   /catalyst-dev:implement_plan [--team] thoughts/shared/plans/{PLAN_FILENAME}
 
-   {IF standard mode recommended:}
-   This plan has sequential phases with tightly coupled changes.
-   **Recommended: standard mode** for focused implementation.
-
-   Start a new session and run:
+   Tip: Start a fresh session — implementation needs context for source files and progress tracking.
    ```
-   /catalyst-dev:implement_plan thoughts/shared/plans/{PLAN_FILENAME}
-   ```
-
-   {ALWAYS include:}
-   Tip: Start a fresh session before implementing. The implementation phase
-   needs context for reading source files and tracking progress.
-   ````
 
 ## Important Guidelines
 
-1. **Be Skeptical**:
-   - Question vague requirements
-   - Identify potential issues early
-   - Ask "why" and "what about"
-   - Don't assume - verify with code
-
-2. **Be Interactive**:
-   - Don't write the full plan in one shot
-   - Get buy-in at each major step
-   - Allow course corrections
-   - Work collaboratively
-
-3. **Be Thorough**:
-   - Read all context files COMPLETELY before planning
-   - Research actual code patterns using parallel sub-tasks
-   - Include specific file paths and line numbers
-   - Write measurable success criteria with clear automated vs manual distinction
-   - automated steps should use `make` whenever possible - for example
-     `make check` instead of running individual lint/test commands
-
-4. **Be Practical**:
-   - Focus on incremental, testable changes
-   - Consider migration and rollback
-   - Think about edge cases
-   - Include "what we're NOT doing"
-
-5. **Track Progress**:
-   - Use TodoWrite to track planning tasks
-   - Update todos as you complete research
-   - Mark planning tasks complete when done
-
-6. **No Open Questions in Final Plan**:
-   - If you encounter open questions during planning, STOP
-   - Research or ask for clarification immediately
-   - Do NOT write the plan with unresolved questions
-   - The implementation plan must be complete and actionable
-   - Every decision must be made before finalizing the plan
+1. **Be Skeptical**: Question vague requirements. Don't assume — verify with code.
+2. **Be Interactive**: Don't write the full plan in one shot. Get buy-in at each step.
+3. **Be Thorough**: Read all context files COMPLETELY. Include file:line references.
+   Use `make check` over individual lint/test commands when available.
+4. **Be Practical**: Focus on incremental, testable changes. Include "what we're NOT doing".
+5. **No Open Questions in Final Plan**: Research or ask for clarification immediately.
+   The plan must be complete and actionable — every decision made before finalizing.
 
 ## Success Criteria Guidelines
 
-**Always separate success criteria into two categories:**
+**Always separate into two categories:**
 
-1. **Automated Verification** (can be run by execution agents):
-   - Commands that can be run: `make test`, `npm run lint`, etc.
-   - Specific files that should exist
-   - Code compilation/type checking
-   - Automated test suites
-
-2. **Manual Verification** (requires human testing):
-   - UI/UX functionality
-   - Performance under real conditions
-   - Edge cases that are hard to automate
-   - User acceptance criteria
-
-**Format example:**
-
-```markdown
-### Success Criteria:
-
-#### Automated Verification:
-
-- [ ] Database migration runs successfully: `make migrate`
-- [ ] All unit tests pass: `go test ./...`
-- [ ] No linting errors: `golangci-lint run`
-- [ ] API endpoint returns 200: `curl localhost:8080/api/new-endpoint`
-
-#### Manual Verification:
-
-- [ ] New feature appears correctly in the UI
-- [ ] Performance is acceptable with 1000+ items
-- [ ] Error messages are user-friendly
-- [ ] Feature works correctly on mobile devices
-```
+1. **Automated Verification** (run by agents): `make test`, `make lint`, type checking, etc.
+2. **Manual Verification** (requires human): UI/UX, performance, edge cases, acceptance criteria
 
 ## Common Patterns
 
 ### For Database Changes:
-
-- Start with schema/migration
-- Add store methods
-- Update business logic
-- Expose via API
-- Update clients
+Schema/migration → store methods → business logic → API → clients
 
 ### For New Features:
-
-- Research existing patterns first
-- Start with data model
-- Build backend logic
-- Add API endpoints
-- Implement UI last
+Research patterns → data model → backend logic → API endpoints → UI
 
 ### For Refactoring:
-
-- Document current behavior
-- Plan incremental changes
-- Maintain backwards compatibility
-- Include migration strategy
-
-## Sub-task Spawning Best Practices
-
-When spawning research sub-tasks:
-
-1. **Spawn multiple tasks in parallel** for efficiency
-2. **Each task should be focused** on a specific area
-3. **Provide detailed instructions** including:
-   - Exactly what to search for
-   - Which directories to focus on
-   - What information to extract
-   - Expected output format
-4. **Be EXTREMELY specific about directories**:
-   - Use exact directory names from the codebase, not generic terms
-   - If the project has specific directory conventions, follow them precisely
-   - Include the full path context in your prompts
-5. **Specify read-only tools** to use
-6. **Request specific file:line references** in responses
-7. **Wait for all tasks to complete** before synthesizing
-8. **Verify sub-task results**:
-   - If a sub-task returns unexpected results, spawn follow-up tasks
-   - Cross-check findings against the actual codebase
-   - Don't accept results that seem incorrect
-
-Example of spawning multiple tasks:
-
-```python
-# Spawn these tasks concurrently:
-tasks = [
-    Task("Research database schema", db_research_prompt),
-    Task("Find API patterns", api_research_prompt),
-    Task("Investigate UI components", ui_research_prompt),
-    Task("Check test patterns", test_research_prompt)
-]
-```
-
-## Example Interaction Flow
-
-```
-User: /implementation_plan
-Assistant: I'll help you create a detailed implementation plan...
-
-User: We need to add parent-child tracking for Claude sub-tasks. See thoughts/shared/tickets/PROJ-456.md
-Assistant: Let me read that ticket file completely first...
-
-[Reads file fully]
-
-Based on the ticket, I understand we need to [specific task from ticket]. Before I start planning, I have some questions...
-
-[Interactive process continues...]
-```
+Document behavior → incremental changes → backwards compatibility → migration strategy

--- a/plugins/dev/commands/research_codebase.md
+++ b/plugins/dev/commands/research_codebase.md
@@ -11,34 +11,21 @@ version: 1.0.0
 You are tasked with conducting comprehensive research across the codebase to answer user questions
 by spawning parallel sub-agents and synthesizing their findings.
 
-## CRITICAL: YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY
+**You are a documentarian, not a critic.** Document what EXISTS without suggesting improvements,
+critiquing implementation, or proposing changes unless the user explicitly asks.
 
-- DO NOT suggest improvements or changes unless the user explicitly asks for them
-- DO NOT perform root cause analysis unless the user explicitly asks for them
-- DO NOT propose future enhancements unless the user explicitly asks for them
-- DO NOT critique the implementation or identify problems
-- DO NOT recommend refactoring, optimization, or architectural changes
-- ONLY describe what exists, where it exists, how it works, and how components interact
-- You are creating a technical map/documentation of the existing system
+**CRITICAL: Your ONLY output is a research document. Do NOT enter plan mode, create implementation
+plans, or start implementing. Your job ends when the research document is saved.**
 
 ## Prerequisites
 
-Before executing, verify all required tools and systems:
-
 ```bash
-# 1. Validate thoughts system (REQUIRED)
-if [[ -f "scripts/validate-thoughts-setup.sh" ]]; then
-  ./scripts/validate-thoughts-setup.sh || exit 1
-else
-  # Inline validation if script not found
-  if [[ ! -d "thoughts/shared" ]]; then
-    echo "❌ ERROR: Thoughts system not configured"
-    echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-    exit 1
-  fi
+if [[ ! -d "thoughts/shared" ]]; then
+  echo "ERROR: Thoughts system not configured"
+  echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
+  exit 1
 fi
 
-# 2. Validate plugin scripts
 if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
   "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
 fi
@@ -49,145 +36,78 @@ fi
 When this command is invoked, respond with:
 
 ```
-I'm ready to research the codebase. Please provide your research question or area of interest, and I'll analyze it thoroughly by exploring relevant components and connections.
+I'm ready to research the codebase. Please provide your research question or area of interest,
+and I'll analyze it thoroughly by exploring relevant components and connections.
 ```
 
 Then wait for the user's research query.
 
 ## Steps to Follow After Receiving the Research Query
 
-### Step 1: Read Any Directly Mentioned Files First
+### Step 1: Read any directly mentioned files first
 
 - If the user mentions specific files (tickets, docs, JSON), read them FULLY first
 - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
 - **CRITICAL**: Read these files yourself in the main context before spawning any sub-tasks
-- This ensures you have full context before decomposing the research
 
-### Step 2: Analyze and Decompose the Research Question
+### Step 2: Analyze and decompose the research question
 
 - Break down the user's query into composable research areas
-- Take time to think deeply about the underlying patterns, connections, and architectural
-  implications the user might be seeking
-- Identify specific components, patterns, or concepts to investigate
+- Think deeply about underlying patterns, connections, and architectural implications
 - Create a research plan using TodoWrite to track all subtasks
-- Consider which directories, files, or architectural patterns are relevant
+- If a Linear ticket is provided, update it to "Research" status via Linearis CLI
 
-### Step 3: Spawn Parallel Sub-Agent Tasks for Comprehensive Research
+### Step 3: Spawn parallel sub-agent tasks for comprehensive research
 
 Create multiple Task agents to research different aspects concurrently.
 
-We have specialized agents that know how to do specific research tasks:
+**Specialized agents available:**
 
-**For codebase research:**
-
-- Use the **codebase-locator** agent to find WHERE files and components live
-- Use the **codebase-analyzer** agent to understand HOW specific code works (without critiquing it)
-- Use the **codebase-pattern-finder** agent to find examples of existing patterns (without
-  evaluating them)
-
-**IMPORTANT**: All agents are documentarians, not critics. They will describe what exists without
-suggesting improvements or identifying issues.
-
-**For thoughts directory (if using thoughts system):**
-
-- Use the **thoughts-locator** agent to discover what documents exist about the topic
-- Use the **thoughts-analyzer** agent to extract key insights from specific documents (only the most
-  relevant ones)
-
-**For external research (only if user explicitly asks):**
-
-- Use the **external-research** agent for external documentation and resources
-- IF you use external research agents, instruct them to return LINKS with their findings, and
-  INCLUDE those links in your final report
-
-**For Linear tickets (if relevant):**
-
-- Use the **linear-ticket-reader** agent to get full details of a specific ticket (if Linear MCP
-  available)
-- Use the **linear-searcher** agent to find related tickets or historical context
+- **codebase-locator** — find WHERE files and components live
+- **codebase-analyzer** — understand HOW specific code works
+- **codebase-pattern-finder** — find examples of existing patterns
+- **thoughts-locator** — discover relevant documents in thoughts/ (if configured)
+- **thoughts-analyzer** — extract key insights from specific thoughts documents
+- **external-research** — research external repos/frameworks (only if user asks)
 
 The key is to use these agents intelligently:
-
 - Start with locator agents to find what exists
-- Then use analyzer agents on the most promising findings to document how they work
+- Then use analyzer agents on the most promising findings
 - Run multiple agents in parallel when they're searching for different things
 - Each agent knows its job - just tell it what you're looking for
-- Don't write detailed prompts about HOW to search - the agents already know
-- Remind agents they are documenting, not evaluating or improving
+- Remind agents they are documenting, not evaluating
 
-**Example of spawning parallel research tasks:**
-
-```
-I'm going to spawn 3 parallel research tasks:
-
-Task 1 - Find WHERE components live:
-"Use codebase-locator to find all files related to [topic]. Focus on [specific directories if known]."
-
-Task 2 - Understand HOW it works:
-"Use codebase-analyzer to analyze [specific component] and document how it currently works. Include data flow and key integration points."
-
-Task 3 - Find existing patterns:
-"Use codebase-pattern-finder to find similar implementations of [pattern] in the codebase. Show concrete examples."
-```
-
-### Step 4: Wait for All Sub-Agents to Complete and Synthesize Findings
+### Step 4: Wait for all sub-agents to complete and synthesize findings
 
 - **IMPORTANT**: Wait for ALL sub-agent tasks to complete before proceeding
-- Compile all sub-agent results (both codebase and thoughts findings if applicable)
+- Compile all sub-agent results
 - Prioritize live codebase findings as primary source of truth
-- Use thoughts/ findings as supplementary historical context (if thoughts system is used)
+- Use thoughts/ findings as supplementary historical context
 - Connect findings across different components
-- Document specific file paths and line numbers (format: `file.ext:line`)
-- Explain how components interact with each other
-- Include temporal context where relevant (e.g., "This was added in commit abc123")
+- Include specific file paths and line numbers (format: `file.ext:line`)
 - Mark all research tasks as complete in TodoWrite
 
-### Step 5: Gather Metadata for the Research Document
+### Step 5: Gather metadata for the research document
 
-Collect metadata for the research document:
+Collect metadata using git commands:
+- Current date/time
+- Git commit hash: `git rev-parse HEAD`
+- Current branch: `git branch --show-current`
+- Repository name from working directory
 
-**If using thoughts system with metadata script:**
+**Document location:** `thoughts/shared/research/YYYY-MM-DD-{ticket}-{description}.md`
 
-- Generate metadata using git commands (see simple approach below)
-- Metadata includes: date, researcher, git commit, branch, repository
-
-**If using simple approach:**
-
-- Get current date/time
-- Get git commit hash: `git rev-parse HEAD`
-- Get current branch: `git branch --show-current`
-- Get repository name from `.git/config` or working directory
-
-**Document Storage:**
-
-All research documents are stored in the **thoughts system** for persistence:
-
-**Required location:** `thoughts/shared/research/YYYY-MM-DD-{ticket}-{description}.md`
-
-**Why thoughts/shared/**:
-- ✅ Persisted across sessions (git-backed via HumanLayer)
-- ✅ Shared across worktrees
-- ✅ Synced via `humanlayer thoughts sync`
-- ✅ Team collaboration ready
-
-**IMPORTANT: Document Storage Rules**
-- ALWAYS write to `thoughts/shared/` (e.g., `thoughts/shared/research/`, `thoughts/shared/plans/`)
-- NEVER write to `thoughts/searchable/` — this is a read-only search index
-- NEVER write to `thoughts/{username}/` unless explicitly for personal notes
-
-**Filename format:**
 - With ticket: `thoughts/shared/research/YYYY-MM-DD-PROJ-XXXX-description.md`
 - Without ticket: `thoughts/shared/research/YYYY-MM-DD-description.md`
+- Replace `PROJ` with your ticket prefix from `.claude/config.json`
 
-Replace `PROJ` with your ticket prefix from `.claude/config.json`.
+**IMPORTANT: Document Storage Rules**
+- ALWAYS write to `thoughts/shared/research/`
+- NEVER write to `thoughts/searchable/` (read-only search index)
 
-**Examples:**
-- `thoughts/shared/research/2025-01-08-PROJ-1478-parent-child-tracking.md`
-- `thoughts/shared/research/2025-01-08-authentication-flow.md` (no ticket)
+### Step 6: Generate research document
 
-### Step 6: Generate Research Document
-
-Create a structured research document with the following format:
+Create a structured research document:
 
 ```markdown
 ---
@@ -205,8 +125,11 @@ last_updated_by: { your-name }
 
 # Research: {User's Research Question}
 
-**Date**: {date/time with timezone} **Researcher**: {your-name} **Git Commit**: {commit-hash}
-**Branch**: {branch-name} **Repository**: {repo-name}
+**Date**: {date/time with timezone}
+**Researcher**: {your-name}
+**Git Commit**: {commit-hash}
+**Branch**: {branch-name}
+**Repository**: {repo-name}
 
 ## Research Question
 
@@ -229,491 +152,86 @@ system in this area. Focus on WHAT EXISTS, not what should exist.}
 
 **Connections**: {How this component integrates with others}
 
-- Calls: `other-component.ts:45` - {description}
-- Used by: `consumer.ts:67` - {description}
-
-**Implementation details**: {Technical specifics without evaluation}
-
-### {Component/Area 2}
-
-{Same structure as above}
-
 ### {Component/Area N}
 
 {Continue for all major findings}
 
 ## Code References
 
-Quick reference of key files and their roles:
-
 - `path/to/file1.ext:123-145` - {What this code does}
 - `path/to/file2.ext:67` - {What this code does}
-- `path/to/file3.ext:200-250` - {What this code does}
 
 ## Architecture Documentation
 
-{Document the current architectural patterns, conventions, and design decisions observed in the
-code. This is descriptive, not prescriptive.}
-
-### Current Patterns
-
-- **Pattern 1**: {How it's implemented in the codebase}
-- **Pattern 2**: {How it's implemented in the codebase}
-
-### Data Flow
-
-{Document how data moves through the system in this area}
-```
-
-Component A → Component B → Component C {Describe what happens at each step}
-
-```
-
-### Key Integrations
-
-{Document how different parts of the system connect}
+{Document current architectural patterns and data flow. Descriptive, not prescriptive.}
 
 ## Historical Context (from thoughts/)
 
-{ONLY if using thoughts system}
-
-{Include insights from thoughts/ documents that provide context}
-
-- `thoughts/shared/research/previous-doc.md` - {Key decision or insight}
-- `thoughts/shared/plans/plan-123.md` - {Related implementation detail}
-
-## Related Research
-
-{Links to other research documents that touch on related topics}
-
-- `research/YYYY-MM-DD-related-topic.md` - {How it relates}
+{Include insights from thoughts/ documents that provide context, if applicable}
 
 ## Open Questions
 
-{Areas that would benefit from further investigation - NOT problems to fix, just areas where understanding could be deepened}
-
-- {Question 1}
-- {Question 2}
+{Areas that would benefit from further investigation}
 ```
 
-### Step 7: Add GitHub Permalinks (If Applicable)
+### Step 7: Add GitHub permalinks (if applicable)
 
-**If you're on the main/master branch OR if the commit is pushed:**
+- If on main/master or commit is pushed, generate GitHub permalinks:
+  `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+- If on unpushed feature branch, keep local file references
 
-Generate GitHub permalinks and replace file references:
+### Step 8: Sync, track, and present findings
+
+1. Run `humanlayer thoughts sync` to sync the thoughts directory
+2. Track in workflow context:
+   ```bash
+   if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
+     "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "$DOC_PATH" "${TICKET_ID:-null}"
+   fi
+   ```
+3. If a Linear ticket was detected, add completion comment via Linearis CLI
+4. Present a concise summary to the user:
 
 ```
-https://github.com/{owner}/{repo}/blob/{commit-hash}/{file-path}#L{line}
-```
-
-For line ranges:
-
-```
-https://github.com/{owner}/{repo}/blob/{commit-hash}/{file-path}#L{start}-L{end}
-```
-
-**If working on a feature branch that's not pushed yet:**
-
-- Keep local file references: `path/to/file.ext:line`
-- Add note: "GitHub permalinks will be added once this branch is pushed"
-
-### Step 8: Sync and Present Findings
-
-**If using thoughts system:**
-
-- Run `humanlayer thoughts sync` to sync the thoughts directory
-- This updates symlinks, creates searchable index, and commits to thoughts repo
-
-**If using simple approach:**
-
-- Just save the file to your research directory
-- Optionally commit to git
-
-**Present to user:**
-
-```markdown
-✅ Research complete!
+Research complete!
 
 **Research document**: {file-path}
 
-## Summary
+**Summary**: {2-3 sentence summary}
 
-{2-3 sentence summary of key findings}
-
-## Key Files
-
-{Top 3-5 most important file references}
-
-## What I Found
-
-{Brief overview - save details for the document}
-
----
-
-## 📊 Context Status
-
-Current usage: {X}% ({Y}K/{Z}K tokens)
-
-{If >60%}: ⚠️ **Recommendation**: Context is getting full. For best results in the planning phase, I
-recommend clearing context now.
-
-**Options**:
-
-1. ✅ Clear context now (recommended) - Close this session and start fresh for planning
-2. Create handoff to pause work
-3. Continue anyway (may impact performance)
-
-**Why clear?** Fresh context ensures optimal AI performance for the planning phase, which will load
-additional files and research.
-
-{If <60%}: ✅ Context healthy. Ready to proceed to planning phase if needed.
-
----
+**Key files**: {Top 3-5 file references}
 
 Would you like me to:
-
 1. Dive deeper into any specific area?
-2. Create an implementation plan based on this research?
-3. Explore related topics?
+2. Explore related topics?
 ```
 
-### Step 9: Handle Follow-Up Questions
+**STOP HERE. Do NOT offer to create plans or start implementing. Research is complete.**
+
+### Step 9: Handle follow-up questions
 
 If the user has follow-up questions:
-
-1. **DO NOT create a new research document** - append to the same one
-2. **Update frontmatter fields:**
-   - `last_updated`: {new date}
-   - `last_updated_by`: {your name}
-   - Add `last_updated_note`: "{Brief note about what was added}"
-
-3. **Add new section to existing document:**
-
-```markdown
----
-
-## Follow-up Research: {Follow-up Question}
-
-**Date**: {date} **Updated by**: {your-name}
-
-### Additional Findings
-
-{New research results using same structure as above}
-```
-
-4. **Spawn new sub-agents as needed** for the follow-up research
-5. **Re-sync** (if using thoughts system)
+- DO NOT create a new research document - append to the same one
+- Update frontmatter: `last_updated`, `last_updated_by`, add `last_updated_note`
+- Add new section: `## Follow-up Research: {Question}`
+- Spawn new sub-agents as needed
+- Re-sync thoughts
 
 ## Important Notes
 
-### Proactive Context Management
-
-**Monitor Your Context Throughout Research**:
-
-- Check token usage after spawning parallel agents
-- After synthesis phase, check context again
-- **If context >60%**: Warn user and recommend handoff
-
-**Example Warning**:
-
-```
-⚠️ Context Usage Alert: Currently at 65% (130K/200K tokens)
-
-Research is complete, but context is getting full. Before continuing to
-planning phase, I recommend creating a handoff to preserve this work
-and start fresh.
-
-Would you like me to:
-1. Create a handoff now (recommended)
-2. Continue and clear context manually
-3. Proceed anyway (not recommended - may impact planning quality)
-
-**Why this matters**: The planning phase will load additional context.
-Starting fresh ensures optimal AI performance.
-```
-
-**When to Warn**:
-
-- After Step 7 (document generated) if context >60%
-- After Step 9 (follow-up complete) if context >70%
-- Anytime during research if context >80%
-
-**Educate the User**:
-
-- Explain WHY clearing context matters (performance, token efficiency)
-- Explain WHEN to clear (between phases)
-- Offer to create handoff yourself if `/create-handoff` command exists
-
-### Parallel Execution
-
-- ALWAYS use parallel Task agents for efficiency
-- Don't wait for one agent to finish before spawning the next
-- Spawn all research tasks at once, then wait for all to complete
-
-### Research Philosophy
-
+- **NEVER enter plan mode or create implementation plans** - that's `/create_plan`'s job
+- ALWAYS use parallel Task agents - spawn all at once, then wait for all to complete
 - Always perform fresh codebase research - never rely solely on existing docs
-- The `thoughts/` directory (if used) provides historical context, not primary source
-- Focus on concrete file paths and line numbers - make it easy to navigate
-- Research documents should be self-contained and understandable months later
-
-### Sub-Agent Prompts
-
-- Be specific about what to search for
-- Specify directories to focus on when known
-- Make prompts focused on read-only documentation
-- Remind agents they are documentarians, not critics
-
-### Cross-Component Understanding
-
-- Document how components interact, not just what they do individually
-- Trace data flow across boundaries
-- Note integration points and dependencies
-
-### Temporal Context
-
-- Include when things were added/changed if relevant
-- Note deprecated patterns still in the codebase
-- Don't judge - just document the timeline
-
-### GitHub Links
-
-- Use permalinks for permanent references
-- Include line numbers for precision
-- Link to specific commits, not branches (branches move)
-
-### Main Agent Role
-
-- Your role is synthesis, not deep file reading
-- Let sub-agents do the detailed reading
-- You orchestrate, compile, and connect their findings
-- Focus on the big picture and cross-component connections
-
-### Documentation Style
-
-- Sub-agents document examples and usage patterns as they exist
-- Main agent synthesizes into coherent narrative
-- Both levels: documentarian, not evaluator
-- Never recommend changes or improvements unless explicitly asked
-
-### File Reading Rules
-
-- ALWAYS read mentioned files fully before spawning sub-tasks
-- Use Read tool WITHOUT limit/offset for complete files
-- This is critical for proper decomposition
-
-### Follow the Steps
-
-- These numbered steps are not suggestions - follow them exactly
-- Don't skip steps or reorder them
-- Each step builds on the previous ones
-
-### Thoughts Directory Handling
-
-**If using thoughts system:**
-
-- `thoughts/searchable/` is a read-only search index directory
-- Paths found there should be documented as their actual location in `thoughts/shared/`
-- Example: `thoughts/searchable/shared/research/topic.md` → document as `thoughts/shared/research/topic.md`
-
-**If NOT using thoughts system:**
-
-- Skip thoughts-related agents
-- Skip thoughts sync commands
-- Save research docs to `research/` directory in workspace root
-
-### Frontmatter Consistency
-
-- Always include complete frontmatter as shown in template
-- Use ISO 8601 dates with timezone
-- Keep tags consistent across research documents
-- Update `last_updated` fields when appending follow-ups
+- Focus on concrete file paths and line numbers
+- Read mentioned files FULLY (no limit/offset) before spawning sub-tasks
+- Follow the numbered steps exactly - don't skip or reorder
+- `thoughts/searchable/` paths should be documented as `thoughts/shared/` equivalents
+- If context exceeds 60% after research, recommend clearing before planning phase
 
 ## Linear Integration
 
-If a Linear ticket is associated with the research, the command can automatically update the ticket
-status.
+If a ticket is detected (provided as argument, mentioned in query, or from context):
 
-### How It Works
-
-**Ticket detection** (same as other commands):
-
-1. User provides ticket ID explicitly: `/research_codebase PROJ-123`
-2. Ticket mentioned in research query
-3. Auto-detected from current context
-
-**Status updates:**
-
-- When research starts → Move ticket to **"Research"**
-- When research document is saved → Add comment with link to research doc
-
-### Implementation Pattern
-
-**At research start** (Step 2 - after reading mentioned files):
-
-```bash
-# If ticket is detected or provided
-if [[ -n "$ticketId" ]]; then
-  # Check if Linearis CLI is available
-  if command -v linearis &> /dev/null; then
-    # Update ticket state to "Research" (use --state NOT --status!)
-    linearis issues update "$ticketId" --state "Research"
-
-    # Add comment (use 'comments create' NOT 'issues comment'!)
-    linearis comments create "$ticketId" --body "Starting research: [user's research question]"
-  else
-    echo "⚠️  Linearis CLI not found - skipping Linear ticket update"
-  fi
-fi
-```
-
-**After research document is saved** (Step 6 - after generating document):
-
-```bash
-# Attach research document to ticket
-if [[ -n "$ticketId" ]] && [[ -n "$githubPermalink" ]]; then
-  # Check if Linearis CLI is available
-  if command -v linearis &> /dev/null; then
-    # Add completion comment with research doc link
-    linearis comments create "$ticketId" \
-        --body "Research complete! See findings: $githubPermalink"
-  else
-    echo "⚠️  Linearis CLI not found - skipping Linear ticket update"
-  fi
-fi
-```
-
-### User Experience
-
-**With ticket:**
-
-```bash
-/catalyst-dev:research_codebase PROJ-123
-> "How does authentication work?"
-```
-
-**What happens:**
-
-1. Command detects ticket PROJ-123
-2. Moves ticket from Backlog → Research
-3. Adds comment: "Starting research: How does authentication work?"
-4. Conducts research with parallel agents
-5. Saves document to thoughts/shared/research/
-6. Attaches document to Linear ticket
-7. Adds comment: "Research complete! See findings: [link]"
-
-**Without ticket:**
-
-```bash
-/catalyst-dev:research_codebase
-> "How does authentication work?"
-```
-
-**What happens:**
-
-- Same research process, but no Linear updates
-- User can manually attach research to ticket later
-
-### Configuration
-
-Uses the same Linear configuration as other commands from `.claude/config.json`:
-
-- `linear.teamId`
-- `linear.thoughtsRepoUrl` (for GitHub permalinks)
-
-### Error Handling
-
-**If Linear MCP not available:**
-
-- Skip Linear integration silently
-- Continue with research as normal
-- Note in output: "Research complete (Linear not configured)"
-
-**If ticket not found:**
-
-- Show warning: "Ticket PROJ-123 not found in Linear"
-- Ask user: "Continue research without Linear integration? (Y/n)"
-
-**If status update fails:**
-
-- Log error but continue research
-- Include note in final output: "⚠️ Could not update Linear ticket status"
-
-## Integration with Other Commands
-
-This command integrates with the complete development workflow:
-
-```
-/research-codebase → research document (+ Linear: Research)
-                  ↓
-           /create-plan → implementation plan (+ Linear: Planning)
-                  ↓
-          /implement-plan → code changes (+ Linear: In Progress)
-                  ↓
-              /describe-pr → PR created (+ Linear: In Review)
-```
-
-**How it connects:**
-
-- **research_codebase → Linear**: Moves ticket to "Research" status and attaches research document
-
-- **research_codebase → create_plan**: Research findings provide foundation for planning. The
-  create_plan command can reference research documents in its "References" section.
-
-- **Research before planning**: Always research the codebase first to understand what exists before
-  planning changes.
-
-- **Shared agents**: Both research_codebase and create_plan use the same specialized agents
-  (codebase-locator, codebase-analyzer, codebase-pattern-finder).
-
-- **Documentation persistence**: Research documents serve as permanent reference for future work.
-
-## Example Workflow
-
-```bash
-# User starts research
-/research-codebase
-
-# You respond with initial prompt
-# User asks: "How does authentication work in the API?"
-
-# You execute:
-# 1. Read any mentioned files fully
-# 2. Decompose into research areas (auth middleware, token validation, session management)
-# 3. Spawn parallel agents:
-#    - codebase-locator: Find auth-related files
-#    - codebase-analyzer: Understand auth middleware implementation
-#    - codebase-pattern-finder: Find auth usage patterns
-#    - thoughts-locator: Find previous auth discussions (if using thoughts)
-# 4. Wait for all agents
-# 5. Synthesize findings
-# 6. Generate research document at research/2025-01-08-authentication-system.md
-# 7. Present summary to user
-
-# User follows up: "How does it integrate with the database?"
-# You append to same document with new findings
-```
-
-### Track in Workflow Context
-
-After saving the research document, add it to workflow context:
-
-```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "$DOC_PATH" "${TICKET_ID:-null}"
-fi
-```
-
-## Adaptation Notes
-
-This command is adapted from HumanLayer's research_codebase command. Key differences for
-portability:
-
-- **Thoughts system**: Made optional - can use simple `research/` directory
-- **Metadata script**: Made optional - can generate metadata inline
-- **Ticket prefixes**: Read from `.claude/config.json` or use PROJ- placeholder
-- **Linear integration**: Made optional - only used if Linear MCP available
-- **Web research**: Uses `external-research` agent instead of `web-search-researcher`
-
-The core workflow and philosophy remain the same: parallel sub-agents, documentarian mindset, and
-structured output.
+- **At research start**: `linearis issues update "$ticketId" --state "Research"`
+- **After document saved**: `linearis comments create "$ticketId" --body "Research complete: $link"`
+- If Linearis CLI not available, skip silently and continue research


### PR DESCRIPTION
## Summary

- **research_codebase.md**: 720→237 lines (67% reduction) — removes the "create implementation plan" option that caused agent to skip saving research document and jump directly into plan mode. Adds explicit guardrails against entering plan mode.
- **create_plan.md**: 660→297 lines (55% reduction) — removes duplicated sub-task spawning section, verbose context management templates, and example interaction flow.

Both commands are now much closer to the HumanLayer generic baselines they were derived from (179 and 442 lines respectively).

## Test plan

- [ ] Run `/catalyst-dev:research_codebase` and verify it saves a research document to `thoughts/shared/research/` without jumping to plan mode
- [ ] Run `/catalyst-dev:create_plan` and verify interactive planning flow works end-to-end
- [ ] Verify both commands still reference workflow context, thoughts sync, and Linear integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)