### PR TITLE
feat(dev): add project setup validation and strengthen command guardrails

### DIFF
--- a/plugins/dev/commands/create_handoff.md
+++ b/plugins/dev/commands/create_handoff.md
@@ -10,24 +10,10 @@ version: 1.0.0
 
 ## Prerequisites
 
-Before executing, verify all required tools and systems:
-
 ```bash
-# 1. Validate thoughts system (REQUIRED)
-if [[ -f "scripts/validate-thoughts-setup.sh" ]]; then
-  ./scripts/validate-thoughts-setup.sh || exit 1
-else
-  # Inline validation if script not found
-  if [[ ! -d "thoughts/shared" ]]; then
-    echo "❌ ERROR: Thoughts system not configured"
-    echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-    exit 1
-  fi
-fi
-
-# 2. Validate plugin scripts
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/create_plan.md
+++ b/plugins/dev/commands/create_plan.md
@@ -17,14 +17,9 @@ Replace `PROJ` in ticket references with your Linear team's prefix from `.claude
 ## Prerequisites
 
 ```bash
-if [[ ! -d "thoughts/shared" ]]; then
-  echo "ERROR: Thoughts system not configured"
-  echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-  exit 1
-fi
-
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/create_pr.md
+++ b/plugins/dev/commands/create_pr.md
@@ -13,11 +13,10 @@ ticket.
 
 ## Prerequisites
 
-Before executing, verify required tools are installed:
-
 ```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/describe_pr.md
+++ b/plugins/dev/commands/describe_pr.md
@@ -13,24 +13,10 @@ Linear tickets.
 
 ## Prerequisites
 
-Before executing, verify all required tools and systems:
-
 ```bash
-# 1. Validate thoughts system (REQUIRED)
-if [[ -f "scripts/validate-thoughts-setup.sh" ]]; then
-  ./scripts/validate-thoughts-setup.sh || exit 1
-else
-  # Inline validation if script not found
-  if [[ ! -d "thoughts/shared" ]]; then
-    echo "❌ ERROR: Thoughts system not configured"
-    echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-    exit 1
-  fi
-fi
-
-# 2. Validate plugin scripts
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/implement_plan.md
+++ b/plugins/dev/commands/implement_plan.md
@@ -13,11 +13,10 @@ plans contain phases with specific changes and success criteria.
 
 ## Prerequisites
 
-Before executing, verify required tools are installed:
-
 ```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/iterate_plan.md
+++ b/plugins/dev/commands/iterate_plan.md
@@ -14,23 +14,10 @@ research-backed modifications, not just text edits.
 
 ## Prerequisites
 
-Before executing, verify all required tools and systems:
-
 ```bash
-# 1. Validate thoughts system (REQUIRED)
-if [[ -f "scripts/validate-thoughts-setup.sh" ]]; then
-  ./scripts/validate-thoughts-setup.sh || exit 1
-else
-  if [[ ! -d "thoughts/shared" ]]; then
-    echo "❌ ERROR: Thoughts system not configured"
-    echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-    exit 1
-  fi
-fi
-
-# 2. Validate plugin scripts
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/research_codebase.md
+++ b/plugins/dev/commands/research_codebase.md
@@ -14,20 +14,18 @@ by spawning parallel sub-agents and synthesizing their findings.
 **You are a documentarian, not a critic.** Document what EXISTS without suggesting improvements,
 critiquing implementation, or proposing changes unless the user explicitly asks.
 
-**CRITICAL: Your ONLY output is a research document. Do NOT enter plan mode, create implementation
-plans, or start implementing. Your job ends when the research document is saved.**
+**CRITICAL REQUIREMENTS — read these before doing anything else:**
+1. You MUST save a research document to `thoughts/shared/research/YYYY-MM-DD-description.md`
+2. Do NOT save to memory, personal notes, or any other location
+3. Do NOT use the EnterPlanMode tool, create plans, or start implementing
+4. Your job ends when the research document is written and synced to thoughts/
 
 ## Prerequisites
 
 ```bash
-if [[ ! -d "thoughts/shared" ]]; then
-  echo "ERROR: Thoughts system not configured"
-  echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-  exit 1
-fi
-
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 
@@ -206,7 +204,7 @@ Would you like me to:
 2. Explore related topics?
 ```
 
-**STOP HERE. Do NOT offer to create plans or start implementing. Research is complete.**
+**STOP HERE. Do NOT offer to create plans, use EnterPlanMode, or start implementing. Research is complete.**
 
 ### Step 9: Handle follow-up questions
 
@@ -219,7 +217,7 @@ If the user has follow-up questions:
 
 ## Important Notes
 
-- **NEVER enter plan mode or create implementation plans** - that's `/create_plan`'s job
+- **NEVER use EnterPlanMode or create implementation plans** — that's `/create_plan`'s job
 - ALWAYS use parallel Task agents - spawn all at once, then wait for all to complete
 - Always perform fresh codebase research - never rely solely on existing docs
 - Focus on concrete file paths and line numbers

--- a/plugins/dev/commands/resume_handoff.md
+++ b/plugins/dev/commands/resume_handoff.md
@@ -10,11 +10,10 @@ version: 1.0.0
 
 ## Prerequisites
 
-Before executing, verify required tools are installed:
-
 ```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Catalyst Project Setup Check
+# Validates that the current project is properly configured for Catalyst workflows.
+# Run by workflow commands as a prerequisite check.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+errors=()
+warnings=()
+
+# 1. Check thoughts system is initialized
+if [[ -d "thoughts/shared" ]]; then
+  # Check subdirectories exist
+  for dir in research plans handoffs prs; do
+    if [[ ! -d "thoughts/shared/$dir" ]]; then
+      warnings+=("thoughts/shared/$dir/ directory missing — run: mkdir -p thoughts/shared/$dir")
+    fi
+  done
+else
+  errors+=("Thoughts system not configured — run: humanlayer thoughts init")
+fi
+
+# 2. Check thoughts is synced (has .git or is managed)
+if [[ -d "thoughts" ]] && [[ ! -d "thoughts/.git" ]] && [[ ! -L "thoughts" ]]; then
+  # thoughts exists but isn't git-backed or a symlink
+  warnings+=("thoughts/ exists but doesn't appear to be git-backed — run: humanlayer thoughts sync")
+fi
+
+# 3. Check CLAUDE.md has Catalyst snippet
+if [[ -f "CLAUDE.md" ]]; then
+  if ! grep -q "Catalyst Development Workflow" CLAUDE.md 2>/dev/null; then
+    warnings+=("CLAUDE.md is missing the Catalyst workflow snippet")
+    warnings+=("  Add the snippet from: plugins/dev/templates/CLAUDE_SNIPPET.md")
+    warnings+=("  Or run: cat plugins/dev/templates/CLAUDE_SNIPPET.md >> CLAUDE.md")
+  fi
+else
+  warnings+=("No CLAUDE.md found — agents will lack project-level workflow context")
+  warnings+=("  Create one and add the Catalyst snippet from: plugins/dev/templates/CLAUDE_SNIPPET.md")
+fi
+
+# 4. Check .claude/config.json exists
+if [[ ! -f ".claude/config.json" ]]; then
+  warnings+=(".claude/config.json not found — ticket prefix will default to PROJ")
+fi
+
+# Report errors (fatal)
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo -e "${RED}ERROR: Project setup incomplete${NC}"
+  for err in "${errors[@]}"; do
+    echo -e "  ${RED}•${NC} $err"
+  done
+  echo ""
+  exit 1
+fi
+
+# Report warnings (non-fatal but important)
+if [[ ${#warnings[@]} -gt 0 ]]; then
+  echo -e "${YELLOW}WARN: Project setup has issues${NC}"
+  for warn in "${warnings[@]}"; do
+    echo -e "  ${YELLOW}•${NC} $warn"
+  done
+  echo ""
+fi
+
+# Success
+if [[ ${#warnings[@]} -eq 0 ]]; then
+  echo -e "${GREEN}Project setup OK${NC}"
+fi


### PR DESCRIPTION
## Summary

- **New `check-project-setup.sh` script** that validates project prerequisites before any workflow command runs:
  - `thoughts/shared/` directory and subdirectories (research, plans, handoffs, prs)
  - `thoughts/` is git-backed or symlinked
  - `CLAUDE.md` contains the Catalyst workflow snippet (checks for "Catalyst Development Workflow" marker)
  - `.claude/config.json` exists
- **Unified prerequisites** across all 8 workflow commands — replaces fragmented `validate-thoughts-setup.sh`, `check-prerequisites.sh`, and inline fallback checks
- **Stronger research_codebase guardrails** — explicit `EnterPlanMode` prohibition, mandatory save path to `thoughts/shared/research/`, no plan creation option

## Motivation

When running `/research_codebase` in projects without the CLAUDE.md snippet installed, agents would:
1. Skip saving to `thoughts/shared/research/` and save to memory instead
2. Call Claude Code's built-in `EnterPlanMode` tool instead of stopping after research

The new prerequisites script catches missing setup early with clear warnings, and the command-level guardrails prevent agent misbehavior even without project-level reinforcement.

## Commands Updated

| Command | Old Pattern | New Pattern |
|---------|------------|-------------|
| `research_codebase` | `check-prerequisites.sh` only | `check-project-setup.sh` + stronger guardrails |
| `create_plan` | `check-prerequisites.sh` only | `check-project-setup.sh` |
| `implement_plan` | `check-prerequisites.sh` only | `check-project-setup.sh` |
| `create_handoff` | verbose inline + `validate-thoughts-setup.sh` | `check-project-setup.sh` |
| `resume_handoff` | `check-prerequisites.sh` only | `check-project-setup.sh` |
| `create_pr` | `check-prerequisites.sh` only | `check-project-setup.sh` |
| `describe_pr` | verbose inline + `validate-thoughts-setup.sh` | `check-project-setup.sh` |
| `iterate_plan` | verbose inline + `validate-thoughts-setup.sh` | `check-project-setup.sh` |

## Test plan

- [ ] Run `/research_codebase` in a project WITH the CLAUDE.md snippet — should pass prerequisites
- [ ] Run `/research_codebase` in a project WITHOUT the snippet — should show warning about missing snippet
- [ ] Run any workflow command without `thoughts/shared/` — should error with setup instructions
- [ ] Verify `check-project-setup.sh` is executable and runs cleanly