### PR TITLE
feat(dev): add document lineage and reliable workflow context tracking

### DIFF
--- a/plugins/dev/commands/create_handoff.md
+++ b/plugins/dev/commands/create_handoff.md
@@ -68,7 +68,10 @@ tags: [implementation, strategy, relevant-component-names]
 status: complete
 last_updated: [Current date in YYYY-MM-DD format]
 last_updated_by: [Researcher name]
-type: implementation_strategy
+type: handoff
+source_ticket: [TICKET-ID or null]
+source_plan: [path to implementation plan, or null]
+source_research: [path to research doc, or null]
 ---
 
 # Handoff: {TICKET or General} - {very concise description}
@@ -121,15 +124,21 @@ Ask the user to review and approve the document. if they request any changes, yo
 and ask for approval again. Once the user approves the documents, you should run
 `humanlayer thoughts sync` to save the document.
 
-### Track in Workflow Context
+### Track in Workflow Context (REQUIRED)
 
-After saving the handoff document, add it to workflow context:
+After saving the handoff document, you MUST track it. Substitute the actual file path and ticket:
 
 ```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add handoffs "$HANDOFF_FILE" "${TICKET_ID:-null}"
-fi
+"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add handoffs "thoughts/shared/handoffs/PROJ-XXX/YYYY-MM-DD_HH-MM-SS_description.md" "TICKET-ID"
 ```
+
+Verify it was tracked:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent handoffs
+```
+
+This MUST print the handoff path. If not, re-run the add command.
 
 Once this is completed, you should respond to the user with the template between
 <template_response></template_response> XML tags. do NOT include the tags in your response.

--- a/plugins/dev/commands/create_handoff.md
+++ b/plugins/dev/commands/create_handoff.md
@@ -10,24 +10,10 @@ version: 1.0.0
 
 ## Prerequisites
 
-Before executing, verify all required tools and systems:
-
 ```bash
-# 1. Validate thoughts system (REQUIRED)
-if [[ -f "scripts/validate-thoughts-setup.sh" ]]; then
-  ./scripts/validate-thoughts-setup.sh || exit 1
-else
-  # Inline validation if script not found
-  if [[ ! -d "thoughts/shared" ]]; then
-    echo "❌ ERROR: Thoughts system not configured"
-    echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-    exit 1
-  fi
-fi
-
-# 2. Validate plugin scripts
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/create_plan.md
+++ b/plugins/dev/commands/create_plan.md
@@ -17,14 +17,9 @@ Replace `PROJ` in ticket references with your Linear team's prefix from `.claude
 ## Prerequisites
 
 ```bash
-if [[ ! -d "thoughts/shared" ]]; then
-  echo "ERROR: Thoughts system not configured"
-  echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-  exit 1
-fi
-
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/create_plan.md
+++ b/plugins/dev/commands/create_plan.md
@@ -143,6 +143,8 @@ status: ready_for_implementation
 last_updated: {CURRENT_DATE}
 last_updated_by: claude
 type: implementation_plan
+source_ticket: { TICKET-ID or null }
+source_research: { path to research doc used, or null }
 ---
 
 # [Feature/Task Name] Implementation Plan
@@ -230,18 +232,31 @@ type: implementation_plan
 - Similar implementation: `[file:line]`
 ````
 
-### Step 5: Sync and Review
+### Step 5: Sync, Track, and Review
 
-1. **Sync**: Run `humanlayer thoughts sync`
+**5a. Sync thoughts:**
 
-2. **Track in Workflow Context**:
-   ```bash
-   if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-     "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add plans "$PLAN_FILE" "${TICKET_ID}"
-   fi
-   ```
+```bash
+humanlayer thoughts sync
+```
 
-3. **Present plan** and ask for review:
+**5b. Track in workflow context (REQUIRED):**
+
+Substitute the actual file path and ticket ID:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add plans "thoughts/shared/plans/YYYY-MM-DD-PROJ-XXX-description.md" "TICKET-ID"
+```
+
+**5c. Verify tracking:**
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans
+```
+
+This MUST print the plan path. If not, re-run 5b.
+
+**5d. Present plan** and ask for review:
    - Show plan location
    - Ask: Are phases properly scoped? Success criteria specific enough? Missing edge cases?
    - If context >60%, recommend clearing before implementation phase

--- a/plugins/dev/commands/create_pr.md
+++ b/plugins/dev/commands/create_pr.md
@@ -13,11 +13,10 @@ ticket.
 
 ## Prerequisites
 
-Before executing, verify required tools are installed:
-
 ```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/create_pr.md
+++ b/plugins/dev/commands/create_pr.md
@@ -179,14 +179,12 @@ gh pr create --title "$title" --body "$body" --base "$base"
 
 Capture PR number and URL from output.
 
-### Track in Workflow Context
+### Track in Workflow Context (REQUIRED)
 
-After creating the PR, add it to workflow context:
+After creating the PR, track it — substitute the actual PR URL and ticket:
 
 ```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add prs "$PR_URL" "${TICKET_ID:-null}"
-fi
+"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add prs "https://github.com/org/repo/pull/NUMBER" "TICKET-ID"
 ```
 
 ### 10. Auto-call /catalyst-dev:describe_pr

--- a/plugins/dev/commands/describe_pr.md
+++ b/plugins/dev/commands/describe_pr.md
@@ -13,24 +13,10 @@ Linear tickets.
 
 ## Prerequisites
 
-Before executing, verify all required tools and systems:
-
 ```bash
-# 1. Validate thoughts system (REQUIRED)
-if [[ -f "scripts/validate-thoughts-setup.sh" ]]; then
-  ./scripts/validate-thoughts-setup.sh || exit 1
-else
-  # Inline validation if script not found
-  if [[ ! -d "thoughts/shared" ]]; then
-    echo "❌ ERROR: Thoughts system not configured"
-    echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-    exit 1
-  fi
-fi
-
-# 2. Validate plugin scripts
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/implement_plan.md
+++ b/plugins/dev/commands/implement_plan.md
@@ -13,11 +13,10 @@ plans contain phases with specific changes and success criteria.
 
 ## Prerequisites
 
-Before executing, verify required tools are installed:
-
 ```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/iterate_plan.md
+++ b/plugins/dev/commands/iterate_plan.md
@@ -14,23 +14,10 @@ research-backed modifications, not just text edits.
 
 ## Prerequisites
 
-Before executing, verify all required tools and systems:
-
 ```bash
-# 1. Validate thoughts system (REQUIRED)
-if [[ -f "scripts/validate-thoughts-setup.sh" ]]; then
-  ./scripts/validate-thoughts-setup.sh || exit 1
-else
-  if [[ ! -d "thoughts/shared" ]]; then
-    echo "❌ ERROR: Thoughts system not configured"
-    echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-    exit 1
-  fi
-fi
-
-# 2. Validate plugin scripts
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/commands/iterate_plan.md
+++ b/plugins/dev/commands/iterate_plan.md
@@ -108,12 +108,11 @@ If the changes require new technical understanding:
 
 1. Save the updated plan (overwrite the existing file)
 2. Sync thoughts: `humanlayer thoughts sync`
-3. Update workflow context:
+3. Track in workflow context (REQUIRED) — substitute actual path and ticket:
    ```bash
-   if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-     "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add plans "$PLAN_FILE" "${TICKET_ID}"
-   fi
+   "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add plans "thoughts/shared/plans/YYYY-MM-DD-description.md" "TICKET-ID"
    ```
+4. Verify: `"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans` must print the path
 
 ### Step 6: Present Summary
 

--- a/plugins/dev/commands/oneshot.md
+++ b/plugins/dev/commands/oneshot.md
@@ -62,12 +62,11 @@ This phase runs in the current session to allow user interaction during research
    - **external-research**: Research frameworks/libraries (if relevant)
 4. **Synthesize findings**: Create research document at `thoughts/shared/research/YYYY-MM-DD-{ticket}-{description}.md`
 5. **Sync**: `humanlayer thoughts sync`
-6. **Update workflow context**:
+6. **Track in workflow context (REQUIRED)** — substitute actual path and ticket:
    ```bash
-   if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-     "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "$DOC_PATH" "${TICKET_ID:-null}"
-   fi
+   "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "thoughts/shared/research/YYYY-MM-DD-description.md" "TICKET-ID"
    ```
+7. **Verify**: `"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research` must print the path
 
 ### Phase 2: Plan (New Session via `humanlayer launch`)
 

--- a/plugins/dev/commands/research_codebase.md
+++ b/plugins/dev/commands/research_codebase.md
@@ -14,20 +14,18 @@ by spawning parallel sub-agents and synthesizing their findings.
 **You are a documentarian, not a critic.** Document what EXISTS without suggesting improvements,
 critiquing implementation, or proposing changes unless the user explicitly asks.
 
-**CRITICAL: Your ONLY output is a research document. Do NOT enter plan mode, create implementation
-plans, or start implementing. Your job ends when the research document is saved.**
+**CRITICAL REQUIREMENTS — read these before doing anything else:**
+1. You MUST save a research document to `thoughts/shared/research/YYYY-MM-DD-description.md`
+2. Do NOT save to memory, personal notes, or any other location
+3. Do NOT use the EnterPlanMode tool, create plans, or start implementing
+4. Your job ends when the research document is written and synced to thoughts/
 
 ## Prerequisites
 
 ```bash
-if [[ ! -d "thoughts/shared" ]]; then
-  echo "ERROR: Thoughts system not configured"
-  echo "Run: ./scripts/humanlayer/init-project.sh . {project-name}"
-  exit 1
-fi
-
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 
@@ -206,7 +204,7 @@ Would you like me to:
 2. Explore related topics?
 ```
 
-**STOP HERE. Do NOT offer to create plans or start implementing. Research is complete.**
+**STOP HERE. Do NOT offer to create plans, use EnterPlanMode, or start implementing. Research is complete.**
 
 ### Step 9: Handle follow-up questions
 
@@ -219,7 +217,7 @@ If the user has follow-up questions:
 
 ## Important Notes
 
-- **NEVER enter plan mode or create implementation plans** - that's `/create_plan`'s job
+- **NEVER use EnterPlanMode or create implementation plans** — that's `/create_plan`'s job
 - ALWAYS use parallel Task agents - spawn all at once, then wait for all to complete
 - Always perform fresh codebase research - never rely solely on existing docs
 - Focus on concrete file paths and line numbers

--- a/plugins/dev/commands/research_codebase.md
+++ b/plugins/dev/commands/research_codebase.md
@@ -119,6 +119,8 @@ tags: [research, codebase, { component-names }]
 status: complete
 last_updated: YYYY-MM-DD
 last_updated_by: { your-name }
+type: research
+source_ticket: { TICKET-ID or null }
 ---
 
 # Research: {User's Research Question}
@@ -180,20 +182,48 @@ system in this area. Focus on WHAT EXISTS, not what should exist.}
 
 ### Step 8: Sync, track, and present findings
 
-1. Run `humanlayer thoughts sync` to sync the thoughts directory
-2. Track in workflow context:
-   ```bash
-   if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-     "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "$DOC_PATH" "${TICKET_ID:-null}"
-   fi
-   ```
-3. If a Linear ticket was detected, add completion comment via Linearis CLI
-4. Present a concise summary to the user:
+**MANDATORY — do all three sub-steps before presenting results to the user.**
+
+**8a. Sync thoughts:**
+
+```bash
+humanlayer thoughts sync
+```
+
+**8b. Track in workflow context (REQUIRED):**
+
+You MUST run this command, substituting the actual file path you wrote and the ticket ID (or "null"):
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "thoughts/shared/research/YYYY-MM-DD-description.md" "TICKET-ID"
+```
+
+For example, if you wrote `thoughts/shared/research/2026-02-16-ADV-33-api-layer-research.md` for ticket ADV-33:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "thoughts/shared/research/2026-02-16-ADV-33-api-layer-research.md" "ADV-33"
+```
+
+**8c. Verify tracking succeeded:**
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research
+```
+
+This MUST print the path you just saved. If it doesn't, re-run step 8b.
+
+**8d. Linear comment** (if ticket detected):
+
+```bash
+linearis comments create "TICKET-ID" --body "Research complete: thoughts/shared/research/YYYY-MM-DD-description.md"
+```
+
+**8e. Present summary to user:**
 
 ```
 Research complete!
 
-**Research document**: {file-path}
+**Research document**: {exact file path you wrote}
 
 **Summary**: {2-3 sentence summary}
 

--- a/plugins/dev/commands/resume_handoff.md
+++ b/plugins/dev/commands/resume_handoff.md
@@ -10,11 +10,10 @@ version: 1.0.0
 
 ## Prerequisites
 
-Before executing, verify required tools are installed:
-
 ```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" ]]; then
-  "${CLAUDE_PLUGIN_ROOT}/scripts/check-prerequisites.sh" || exit 1
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
 ```
 

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Catalyst Project Setup Check
+# Validates that the current project is properly configured for Catalyst workflows.
+# Run by workflow commands as a prerequisite check.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+errors=()
+warnings=()
+
+# 1. Check thoughts system is initialized
+if [[ -d "thoughts/shared" ]]; then
+  # Check subdirectories exist
+  for dir in research plans handoffs prs; do
+    if [[ ! -d "thoughts/shared/$dir" ]]; then
+      warnings+=("thoughts/shared/$dir/ directory missing — run: mkdir -p thoughts/shared/$dir")
+    fi
+  done
+else
+  errors+=("Thoughts system not configured — run: humanlayer thoughts init")
+fi
+
+# 2. Check thoughts is synced (has .git or is managed)
+if [[ -d "thoughts" ]] && [[ ! -d "thoughts/.git" ]] && [[ ! -L "thoughts" ]]; then
+  # thoughts exists but isn't git-backed or a symlink
+  warnings+=("thoughts/ exists but doesn't appear to be git-backed — run: humanlayer thoughts sync")
+fi
+
+# 3. Check CLAUDE.md has Catalyst snippet
+if [[ -f "CLAUDE.md" ]]; then
+  if ! grep -q "Catalyst Development Workflow" CLAUDE.md 2>/dev/null; then
+    warnings+=("CLAUDE.md is missing the Catalyst workflow snippet")
+    warnings+=("  Add the snippet from: plugins/dev/templates/CLAUDE_SNIPPET.md")
+    warnings+=("  Or run: cat plugins/dev/templates/CLAUDE_SNIPPET.md >> CLAUDE.md")
+  fi
+else
+  warnings+=("No CLAUDE.md found — agents will lack project-level workflow context")
+  warnings+=("  Create one and add the Catalyst snippet from: plugins/dev/templates/CLAUDE_SNIPPET.md")
+fi
+
+# 4. Check .claude/config.json exists
+if [[ ! -f ".claude/config.json" ]]; then
+  warnings+=(".claude/config.json not found — ticket prefix will default to PROJ")
+fi
+
+# Report errors (fatal)
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo -e "${RED}ERROR: Project setup incomplete${NC}"
+  for err in "${errors[@]}"; do
+    echo -e "  ${RED}•${NC} $err"
+  done
+  echo ""
+  exit 1
+fi
+
+# Report warnings (non-fatal but important)
+if [[ ${#warnings[@]} -gt 0 ]]; then
+  echo -e "${YELLOW}WARN: Project setup has issues${NC}"
+  for warn in "${warnings[@]}"; do
+    echo -e "  ${YELLOW}•${NC} $warn"
+  done
+  echo ""
+fi
+
+# Success
+if [[ ${#warnings[@]} -eq 0 ]]; then
+  echo -e "${GREEN}Project setup OK${NC}"
+fi


### PR DESCRIPTION
## Summary

- **Document lineage via `source_*` frontmatter fields** — every document now carries its ancestry:
  - Research docs: `source_ticket`
  - Plans: `source_ticket`, `source_research` (path to research doc used)
  - Handoffs: `source_ticket`, `source_plan`, `source_research`
- **Reliable workflow-context tracking** — fixes issue where 4 of 5 worktrees had empty `research: []` despite research docs being created
- **Verification steps** — all tracking now includes a "verify it worked" check

## Problem

The `workflow-context.sh add` calls were wrapped in conditional guards with placeholder variables (`$DOC_PATH`, `$TICKET_ID`), buried at the end of multi-step processes. Agents treated them as optional cleanup and frequently skipped them. This broke the command chaining that makes `/create_plan` auto-find recent research.

## Solution

### Tracking reliability (6 commands)

| Before | After |
|--------|-------|
| `if [[ -f "...workflow-context.sh" ]]; then ... fi` | Direct call, no guard |
| Placeholder vars: `"$DOC_PATH"` | Concrete example: `"thoughts/shared/research/2026-02-16-ADV-33-description.md"` |
| No verification | `recent research` must print path, re-run if not |
| Unmarked optional step | Heading says **(REQUIRED)** |

### Document lineage (3 templates)

Enables tracing the full chain: `ticket → research → plan → handoff → PR`

Each document's YAML frontmatter now includes:
```yaml
source_ticket: ADV-33
source_research: thoughts/shared/research/2026-02-16-ADV-33-api-layer-research.md
source_plan: thoughts/shared/plans/2026-02-16-ADV-33-api-layer-plan.md
```

This is git-backed (in thoughts repo), searchable, and doesn't depend on the ephemeral workflow-context.json.

## Commands updated

- `research_codebase.md` — lineage fields + restructured Step 8
- `create_plan.md` — lineage fields + restructured Step 5
- `create_handoff.md` — lineage fields + tightened tracking
- `iterate_plan.md` — tightened tracking
- `oneshot.md` — tightened tracking
- `create_pr.md` — tightened tracking

## Test plan

- [ ] Run `/research_codebase` — verify `.workflow-context.json` has non-empty `research` array
- [ ] Run `/create_plan` after research — verify plan frontmatter has `source_research` pointing to research doc
- [ ] Check `workflow-context.sh recent research` returns path after research completes
- [ ] Grep `source_research:` in thoughts repo to trace plan→research lineage