### PR TITLE
chore: bump plugin versions and add CI version enforcement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "catalyst-dev",
       "source": "./plugins/dev",
       "description": "Core development workflow: research → plan → implement → validate → ship. Includes 10 research agents, workflow commands, Linear integration, handoff system. Always enabled. ~3.5k context (lightweight MCPs: DeepWiki, Context7).",
-      "version": "3.0.1",
+      "version": "4.0.0",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -35,7 +35,7 @@
       "name": "catalyst-pm",
       "source": "./plugins/pm",
       "description": "Linear-focused project management: cycle tracking, milestone planning, backlog grooming, daily standups, GitHub-Linear sync. Enable when managing Linear projects. ~5k context when enabled.",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -58,7 +58,7 @@
       "name": "catalyst-analytics",
       "source": "./plugins/analytics",
       "description": "Product analytics with PostHog MCP integration. Enable when analyzing user behavior, conversion funnels, and product metrics. ~40k context when enabled.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -80,7 +80,7 @@
       "name": "catalyst-debugging",
       "source": "./plugins/debugging",
       "description": "Production error monitoring with Sentry MCP integration. Enable when debugging errors, analyzing stack traces, and investigating incidents. ~20k context when enabled.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -102,7 +102,7 @@
       "name": "catalyst-meta",
       "source": "./plugins/meta",
       "description": "Workflow discovery and creation: learn from community patterns and extend Catalyst. Optional plugin for advanced users.",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"

--- a/.github/workflows/check-plugin-versions.yml
+++ b/.github/workflows/check-plugin-versions.yml
@@ -1,0 +1,23 @@
+name: Check Plugin Versions
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'plugins/**'
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check plugin version bumps
+        env:
+          STRICT_VERSION_CHECK: "true"
+          BASE_REF: "origin/${{ github.base_ref }}"
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          bash scripts/check-plugin-version.sh

--- a/plugins/analytics/.claude-plugin/plugin.json
+++ b/plugins/analytics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-analytics",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Product analytics with PostHog MCP integration. Enable when analyzing user behavior, conversion metrics, and product usage. ~40k context tokens when enabled.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/debugging/.claude-plugin/plugin.json
+++ b/plugins/debugging/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-debugging",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Production error monitoring with Sentry MCP integration. Enable when debugging errors, analyzing stack traces, and investigating incidents. ~20k context tokens when enabled.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-dev",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Complete development workflow: research → plan → implement → validate → ship. Includes research agents, planning tools, handoff system, Linear integration, and PM commands.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/meta/.claude-plugin/plugin.json
+++ b/plugins/meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-meta",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Workflow discovery and creation tools: learn from community patterns and extend Catalyst with new workflows.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-pm",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Linear-focused project management plugin with cycle management, milestone tracking, backlog grooming, and team analytics",
   "author": {
     "name": "Coalesce Labs",

--- a/scripts/check-plugin-version.sh
+++ b/scripts/check-plugin-version.sh
@@ -4,11 +4,15 @@
 
 set -e
 
-# Get list of changed files in this commit
-CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || echo "")
-
-if [[ -z "$CHANGED_FILES" ]]; then
-  # No staged changes, check working directory instead
+# Get list of changed files
+if [[ -n "${BASE_REF:-}" ]]; then
+  # CI mode: compare against PR base branch
+  CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD 2>/dev/null || echo "")
+elif [[ -n "$(git diff --cached --name-only 2>/dev/null)" ]]; then
+  # Pre-commit mode: staged files
+  CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || echo "")
+else
+  # Working directory mode
   CHANGED_FILES=$(git diff --name-only 2>/dev/null || echo "")
 fi
 


### PR DESCRIPTION
## Summary

- **Bump all plugin versions** to trigger marketplace re-installs — users have been stuck on 3.0.1 across 20+ commits and 5 PRs, missing oneshot, iterate_plan, ci_commit, ci_describe_pr, and model tier improvements
- **Add CI enforcement** via GitHub Actions workflow that fails PRs touching `plugins/**` without a version bump
- **Enhance check-plugin-version.sh** with `BASE_REF` env var support for three-dot diff in CI

### Version Changes

| Plugin | Old | New | Reason |
|--------|-----|-----|--------|
| catalyst-dev | 3.0.1 | 4.0.0 | Breaking: removed debug.md + 4 new commands + massive rewrites |
| catalyst-pm | 3.0.1 | 3.1.0 | New: registered commands/agents in plugin.json |
| catalyst-meta | 2.0.1 | 2.0.2 | Patch: model tier updates only |
| catalyst-analytics | 1.0.1 | 1.0.2 | Patch: model tier updates only |
| catalyst-debugging | 1.0.2 | 1.0.3 | Patch: model tier updates only |

## Test plan

- [ ] After merge, verify `~/.claude/plugins/marketplaces/catalyst/.claude-plugin/marketplace.json` shows new versions
- [ ] Run `/plugin update catalyst-dev` — should show version change from 3.0.1 to 4.0.0
- [ ] Verify cached plugin has oneshot: `ls ~/.claude/plugins/cache/catalyst/catalyst-dev/4.0.0/commands/oneshot.md`
- [ ] Test CI: create a test branch, modify a file in `plugins/dev/commands/`, push without version bump — should fail the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)