### PR TITLE
feat(linear): add configurable stateMap for portable state transitions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "catalyst-dev",
       "source": "./plugins/dev",
       "description": "Core development workflow: research → plan → implement → validate → ship. Includes 10 research agents, workflow commands, Linear integration, handoff system. Always enabled. ~3.5k context (lightweight MCPs: DeepWiki, Context7).",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -35,7 +35,7 @@
       "name": "catalyst-pm",
       "source": "./plugins/pm",
       "description": "Linear-focused project management: cycle tracking, milestone planning, backlog grooming, daily standups, GitHub-Linear sync. Enable when managing Linear projects. ~5k context when enabled.",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -58,7 +58,7 @@
       "name": "catalyst-analytics",
       "source": "./plugins/analytics",
       "description": "Product analytics with PostHog MCP integration. Enable when analyzing user behavior, conversion funnels, and product metrics. ~40k context when enabled.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -80,7 +80,7 @@
       "name": "catalyst-debugging",
       "source": "./plugins/debugging",
       "description": "Production error monitoring with Sentry MCP integration. Enable when debugging errors, analyzing stack traces, and investigating incidents. ~20k context when enabled.",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -102,7 +102,7 @@
       "name": "catalyst-meta",
       "source": "./plugins/meta",
       "description": "Workflow discovery and creation: learn from community patterns and extend Catalyst. Optional plugin for advanced users.",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"

--- a/.claude/config.json
+++ b/.claude/config.json
@@ -5,6 +5,19 @@
       "ticketPrefix": "PROJ",
       "defaultTicketPrefix": "PROJ"
     },
+    "linear": {
+      "teamKey": "PROJ",
+      "stateMap": {
+        "backlog": "Backlog",
+        "todo": "Todo",
+        "research": "In Progress",
+        "planning": "In Progress",
+        "inProgress": "In Progress",
+        "inReview": "In Review",
+        "done": "Done",
+        "canceled": "Canceled"
+      }
+    },
     "thoughts": {
       "user": null
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,19 @@ Catalyst uses a **two-layer config system** to keep secrets out of git:
     "ticketPrefix": "ACME",
     "name": "Acme Corp Project"
   },
+  "linear": {
+    "teamKey": "ACME",
+    "stateMap": {
+      "backlog": "Backlog",
+      "todo": "Todo",
+      "research": "In Progress",
+      "planning": "In Progress",
+      "inProgress": "In Progress",
+      "inReview": "In Review",
+      "done": "Done",
+      "canceled": "Canceled"
+    }
+  },
   "thoughts": {
     "user": null
   }
@@ -687,8 +700,9 @@ All agents and commands specify their tier explicitly in frontmatter — no more
 ### Linear Integration
 
 - `/linear` command for ticket management
-- Auto-configures on first use
-- Saves config to `.claude/config.json`
+- State transitions are configurable via `linear.stateMap` in `.claude/config.json`
+- Defaults match standard Linear states (Backlog, Todo, In Progress, In Review, Done, Canceled)
+- Set any `stateMap` key to `null` to skip that transition
 - See `docs/LINEAR_WORKFLOW_AUTOMATION.md`
 
 ### PM Plugin (catalyst-pm)

--- a/artifacts/CLAUDE.md.workspace
+++ b/artifacts/CLAUDE.md.workspace
@@ -52,13 +52,15 @@ This workspace **automatically manages Linear tickets** throughout your workflow
 
 ### Automatic Status Updates
 
-| Command | Ticket Status | Assignment |
-|---------|---------------|------------|
-| `/workflow:research_codebase TICKET-123` | → "Research" | Assigns to you |
-| `/workflow:create_plan TICKET-123` | → "Planning" | (already assigned) |
-| `/workflow:implement_plan` | → "In Progress" | (already assigned) |
-| `/linear:create_pr` | → "In Review" | (already assigned) |
-| `/linear:merge_pr` | → "Done" | (already assigned) |
+| Command | stateMap Key | Default State | Assignment |
+|---------|-------------|---------------|------------|
+| `/workflow:research_codebase TICKET-123` | `research` | "In Progress" | Assigns to you |
+| `/workflow:create_plan TICKET-123` | `planning` | "In Progress" | (already assigned) |
+| `/workflow:implement_plan` | `inProgress` | "In Progress" | (already assigned) |
+| `/linear:create_pr` | `inReview` | "In Review" | (already assigned) |
+| `/linear:merge_pr` | `done` | "Done" | (already assigned) |
+
+State names are configurable via `linear.stateMap` in `.claude/config.json`.
 
 ### Automatic Document Linking
 

--- a/docs/LINEAR_WORKFLOW_AUTOMATION.md
+++ b/docs/LINEAR_WORKFLOW_AUTOMATION.md
@@ -11,13 +11,16 @@ based on your workflow commands.
 
 When you run workflow commands, the Linear command automatically updates ticket status:
 
-| Command                            | Ticket Status Update               |
-| ---------------------------------- | ---------------------------------- |
-| `/catalyst-dev:research_codebase` (with ticket) | → **Research**                     |
-| `/catalyst-dev:create_plan` (with ticket)       | → **Planning**                     |
-| `/catalyst-dev:implement_plan` (with ticket)    | → **In Progress**                  |
-| `/catalyst-dev:describe_pr` (with ticket)       | → **In Review**                    |
-| PR merged                          | → **Done** (manual or via webhook) |
+| Command                            | stateMap Key | Default State |
+| ---------------------------------- | ------------ | ------------- |
+| `/catalyst-dev:research_codebase` (with ticket) | `research` | **In Progress** |
+| `/catalyst-dev:create_plan` (with ticket)       | `planning` | **In Progress** |
+| `/catalyst-dev:implement_plan` (with ticket)    | `inProgress` | **In Progress** |
+| `/catalyst-dev:describe_pr` (with ticket)       | `inReview` | **In Review** |
+| `/catalyst-dev:merge_pr`                        | `done` | **Done** |
+
+State names are configurable via `linear.stateMap` in `.claude/config.json`. Defaults match
+standard Linear workspace states.
 
 ### How It Detects Tickets
 
@@ -45,18 +48,38 @@ The commands look for tickets in:
 
 ## The Workflow
 
-### Recommended Workflow Statuses
+### Default Workflow (Standard Linear States)
 
-Simplified 6-status workflow (Option C):
+Catalyst works out of the box with standard Linear states. No custom states required:
 
 ```
 1. Backlog → New ideas and requests
-2. Research → Investigation, triage, spec definition ← /catalyst-dev:research_codebase
-3. Planning → Implementation plans ← /catalyst-dev:create_plan
-4. In Progress → Active development ← /catalyst-dev:implement_plan
-5. In Review → Code review ← /catalyst-dev:describe_pr
-6. Done → Complete
+2. Todo → Acknowledged, unstarted
+3. In Progress → Research, planning, or development ← /research_codebase, /create_plan, /implement_plan
+4. In Review → Code review ← /create_pr, /describe_pr
+5. Done → Complete ← /merge_pr
+6. Canceled → Closed without completing
 ```
+
+### Custom Workflow (Optional)
+
+Teams that want finer-grained tracking can configure `stateMap` to use custom states:
+
+```json
+{
+  "linear": {
+    "stateMap": {
+      "research": "Research in Progress",
+      "planning": "Plan in Progress",
+      "inProgress": "In Dev",
+      "inReview": "In Review",
+      "done": "Done"
+    }
+  }
+}
+```
+
+Run `scripts/linear/setup-linear-workflow` to create the full 12-state custom workflow.
 
 ### Why This Workflow Works
 
@@ -73,31 +96,29 @@ Simplified 6-status workflow (Option C):
 
 ## Setting Up Linear Statuses
 
-### Quick Setup (Recommended)
+### Default Setup (No Configuration Needed)
 
-Use the `/linear_setup_workflow` command:
+Standard Linear workspaces already have the states Catalyst needs:
+
+- **Backlog** (Backlog category)
+- **Todo** (Unstarted category)
+- **In Progress** (Started category)
+- **In Review** (Started category) — commonly added
+- **Done** (Completed category)
+- **Canceled** (Canceled category)
+
+If your workspace has these states, Catalyst works immediately with no configuration.
+
+### Advanced Setup (Optional)
+
+For teams that want fine-grained status tracking, run the setup script:
 
 ```bash
-/catalyst-dev:linear_setup_workflow
+scripts/linear/setup-linear-workflow
 ```
 
-This creates 6 statuses optimized for the workflow commands:
-
-1. **Backlog** (Backlog category) - Gray
-2. **Research** (Unstarted category) - Yellow
-3. **Planning** (Started category) - Yellow
-4. **In Progress** (Started category) - Blue
-5. **In Review** (Started category) - Blue
-6. **Done** (Completed category) - Blue
-
-### Manual Setup
-
-If you prefer to create statuses manually in Linear:
-
-1. Go to Team Settings → Workflow States
-2. Create these 6 statuses in order
-3. Assign to the correct category (Backlog/Unstarted/Started/Completed)
-4. Use the color scheme above for visual clarity
+This creates a 12-state custom workflow. After running it, update your `stateMap` in
+`.claude/config.json` to use the custom state names (the script outputs the config to copy).
 
 ## Complete Workflow Example
 
@@ -117,7 +138,7 @@ Here's how tickets flow through the simplified workflow:
 > "How does authentication currently work?"
 
 # Automatically:
-# - Moves ticket to "Research"
+# - Moves ticket to stateMap.research (default: "In Progress")
 # - Adds comment: "Starting research: How does authentication currently work?"
 # - Saves research document
 # - Attaches research to ticket
@@ -132,10 +153,9 @@ Here's how tickets flow through the simplified workflow:
 # User provides task details
 
 # Automatically:
-# - Moves ticket to "Planning"
+# - Moves ticket to stateMap.planning (default: "In Progress")
 # - Creates plan document
 # - Attaches plan to ticket
-# - Stays in "Planning" for team review
 ```
 
 ### 4. Team Review
@@ -153,7 +173,7 @@ Here's how tickets flow through the simplified workflow:
 /catalyst-dev:implement_plan thoughts/shared/plans/2025-10-04-PROJ-123-oauth.md
 
 # Automatically:
-# - Moves ticket to "In Progress"
+# - Moves ticket to stateMap.inProgress (default: "In Progress")
 # - Implements each phase
 # - Updates plan checkboxes
 ```
@@ -164,7 +184,7 @@ Here's how tickets flow through the simplified workflow:
 /catalyst-dev:describe_pr
 
 # Automatically:
-# - Moves ticket to "In Review"
+# - Moves ticket to stateMap.inReview (default: "In Review")
 # - Attaches PR to ticket
 # - Adds comment with PR link
 ```
@@ -180,21 +200,20 @@ Here's how tickets flow through the simplified workflow:
 ## Workflow Progression Summary
 
 ```
-Backlog
+Backlog (stateMap.backlog)
   ↓ (create ticket)
-Research
-  ↓ (/research_codebase)
-Planning
-  ↓ (/create_plan)
-Planning (stays for team review)
-  ↓ (team approves or /catalyst-dev:implement_plan)
-In Progress
-  ↓ (/implement_plan)
-In Review
-  ↓ (/describe_pr)
-Done
-  ↓ (PR merged)
+Todo (stateMap.todo)
+  ↓ (acknowledged)
+In Progress (stateMap.research / stateMap.planning / stateMap.inProgress)
+  ↓ (/research_codebase → /create_plan → /implement_plan)
+In Review (stateMap.inReview)
+  ↓ (/create_pr or /describe_pr)
+Done (stateMap.done)
+  ↓ (/merge_pr)
 ```
+
+With standard Linear states, research/planning/implementation all map to "In Progress".
+Teams with custom states can differentiate these phases via `stateMap`.
 
 ---
 
@@ -263,14 +282,14 @@ cp ~/ryan-claude-workspace/commands/linear/linear.md .claude/commands/linear/
 2. Command asks: "Is this for a Linear ticket?"
 3. If yes:
    a. Get ticket ID (from user or auto-detect)
-   b. Update ticket status → "Planning"
+   b. Update ticket status → stateMap.planning (default: "In Progress")
    c. Add comment: "Creating implementation plan"
 4. Create plan document
 5. Save to thoughts/shared/plans/
 6. When complete:
    a. Attach plan to Linear ticket via links
    b. Add comment with plan summary
-   c. Ticket stays in "Planning" for team review
+   c. Ticket stays for team review
 ```
 
 ### During `/catalyst-dev:implement_plan`
@@ -280,7 +299,7 @@ cp ~/ryan-claude-workspace/commands/linear/linear.md .claude/commands/linear/
 2. Read plan document
 3. Check plan frontmatter for ticket ID
 4. If ticket found:
-   a. Update ticket status → "In Progress"
+   a. Update ticket status → stateMap.inProgress (default: "In Progress")
    b. Add comment: "Started implementation from plan: [link]"
 5. Implement the plan
 6. Update checkboxes in plan as phases complete
@@ -296,7 +315,7 @@ cp ~/ryan-claude-workspace/commands/linear/linear.md .claude/commands/linear/
    - Commit messages
    - Plan document linked in description
 4. If ticket found:
-   a. Update ticket status → "In Review"
+   a. Update ticket status → stateMap.inReview (default: "In Review")
    b. Add comment with PR link
    c. Attach PR to ticket via links
 ```
@@ -487,7 +506,7 @@ Update command to use exact names.
 
 ### 🎯 Recommended Approach
 
-1. **Start simple**: Use HumanLayer's proven statuses
+1. **Start simple**: Use standard Linear states (works out of the box)
 2. **Configure per-project**: Each project gets own settings
 3. **Let automation work**: Trust the workflow commands to update tickets
 4. **Review in 1 month**: Adjust statuses based on what you learn

--- a/docs/PR_LIFECYCLE.md
+++ b/docs/PR_LIFECYCLE.md
@@ -399,10 +399,14 @@ git checkout -b PROJ-42-add-validation
 ### Workflow State Progression
 
 ```
-Backlog → Research → Planning → In Progress → In Review → Done
-          ↑          ↑          ↑             ↑            ↑
-     /research  /create-plan  /implement  /catalyst-dev:create_pr  /catalyst-dev:merge_pr
+Backlog → Todo → In Progress → In Review → Done
+                  ↑              ↑           ↑
+         /research_codebase  /create_pr  /merge_pr
+         /create_plan
+         /implement_plan
 ```
+
+State names are configurable via `linear.stateMap` in `.claude/config.json`.
 
 ### Auto-Assignment
 
@@ -450,11 +454,18 @@ View linked PRs in Linear:
     "ticketPrefix": "PROJ"
   },
   "linear": {
-    "teamId": "your-team-id",
-    "projectId": "your-project-id",
+    "teamKey": "PROJ",
     "thoughtsRepoUrl": "https://github.com/org/thoughts/blob/main",
-    "inReviewStatusName": "In Review",
-    "doneStatusName": "Done"
+    "stateMap": {
+      "backlog": "Backlog",
+      "todo": "Todo",
+      "research": "In Progress",
+      "planning": "In Progress",
+      "inProgress": "In Progress",
+      "inReview": "In Review",
+      "done": "Done",
+      "canceled": "Canceled"
+    }
   },
   "commit": {
     "useConventional": true,

--- a/plugins/analytics/.claude-plugin/plugin.json
+++ b/plugins/analytics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-analytics",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Product analytics with PostHog MCP integration. Enable when analyzing user behavior, conversion metrics, and product usage. ~40k context tokens when enabled.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/debugging/.claude-plugin/plugin.json
+++ b/plugins/debugging/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-debugging",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Production error monitoring with Sentry MCP integration. Enable when debugging errors, analyzing stack traces, and investigating incidents. ~20k context tokens when enabled.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-dev",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Complete development workflow: research → plan → implement → validate → ship. Includes research agents, planning tools, handoff system, Linear integration, and PM commands.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/dev/agents/.linearis-syntax-reference.md
+++ b/plugins/dev/agents/.linearis-syntax-reference.md
@@ -32,8 +32,9 @@ linearis issues list --limit 100 | jq '.[] | select(.title | contains("auth"))'
 ### Update a ticket
 ```bash
 # Update state (use --state NOT --status!)
+# State names should come from stateMap in .claude/config.json
 linearis issues update TEAM-123 --state "In Progress"
-linearis issues update TEAM-123 --state "Research"
+linearis issues update TEAM-123 --state "In Review"
 
 # Update title
 linearis issues update TEAM-123 --title "New title"
@@ -167,8 +168,8 @@ linearis labels list --team TEAM
 TICKET_DATA=$(linearis issues read TEAM-123)
 echo "$TICKET_DATA" | jq .
 
-# 2. Update state to Research
-linearis issues update TEAM-123 --state "Research"
+# 2. Update state (name from stateMap config)
+linearis issues update TEAM-123 --state "In Progress"
 
 # 3. Add starting comment
 linearis comments create TEAM-123 --body "Starting research on authentication flow"
@@ -213,8 +214,8 @@ linearis cycles --help
 
 ## Common Mistakes to Avoid
 
-❌ `linearis issues update TEAM-123 --status "Research"`
-✅ `linearis issues update TEAM-123 --state "Research"`
+❌ `linearis issues update TEAM-123 --status "In Progress"`
+✅ `linearis issues update TEAM-123 --state "In Progress"`
 
 ❌ `linearis issues comment TEAM-123 "Comment text"`
 ✅ `linearis comments create TEAM-123 --body "Comment text"`

--- a/plugins/dev/agents/linear-research.md
+++ b/plugins/dev/agents/linear-research.md
@@ -46,8 +46,9 @@ Linearis CLI tool.
 linearis issues read TEAM-123
 
 # Update ticket state (use --state NOT --status!)
-linearis issues update TEAM-123 --state "Research"
+# State names should come from stateMap in .claude/config.json
 linearis issues update TEAM-123 --state "In Progress"
+linearis issues update TEAM-123 --state "In Review"
 
 # Add comment (use 'comments create' NOT 'issues comment'!)
 linearis comments create TEAM-123 --body "Starting research"
@@ -67,8 +68,8 @@ linearis projects list --team TEAM
 
 ### Common Mistakes to Avoid
 
-❌ `linearis issues update TICKET-123 --status "Research"` (Wrong flag)
-✅ `linearis issues update TICKET-123 --state "Research"`
+❌ `linearis issues update TICKET-123 --status "In Progress"` (Wrong flag)
+✅ `linearis issues update TICKET-123 --state "In Progress"`
 
 ❌ `linearis issues comment TICKET-123 "text"` (Wrong subcommand)
 ✅ `linearis comments create TICKET-123 --body "text"`

--- a/plugins/dev/commands/ci_describe_pr.md
+++ b/plugins/dev/commands/ci_describe_pr.md
@@ -88,7 +88,10 @@ gh pr edit $PR_NUMBER --body-file "thoughts/shared/prs/${PR_NUMBER}_description.
 
 ```bash
 if [[ -n "$ticket" ]] && command -v linearis &>/dev/null; then
-  linearis issues update "$ticket" --state "In Review" --assignee "@me"
+  IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .claude/config.json 2>/dev/null || echo "In Review")
+  if [[ "$IN_REVIEW_STATE" != "null" ]]; then
+    linearis issues update "$ticket" --state "$IN_REVIEW_STATE" --assignee "@me"
+  fi
 fi
 ```
 

--- a/plugins/dev/commands/create_pr.md
+++ b/plugins/dev/commands/create_pr.md
@@ -207,8 +207,11 @@ if ! command -v linearis &> /dev/null; then
     echo "⚠️  Linearis CLI not found - skipping Linear ticket update"
     echo "Install: npm install -g linearis"
 else
-    # Update ticket state to "In Review"
-    linearis issues update "$ticket" --state "In Review" --assignee "@me"
+    # Update ticket state from stateMap config
+    IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .claude/config.json 2>/dev/null || echo "In Review")
+    if [[ "$IN_REVIEW_STATE" != "null" ]]; then
+        linearis issues update "$ticket" --state "$IN_REVIEW_STATE" --assignee "@me"
+    fi
 
     # Add comment with PR link
     linearis comments create "$ticket" \
@@ -300,11 +303,15 @@ Uses `.claude/config.json`:
     },
     "linear": {
       "teamKey": "PROJ",
-      "inReviewStatusName": "In Review"
+      "stateMap": {
+        "inReview": "In Review"
+      }
     }
   }
 }
 ```
+
+State names are read from `stateMap` with sensible defaults. See `.claude/config.json` for all keys.
 
 ## Examples
 

--- a/plugins/dev/commands/describe_pr.md
+++ b/plugins/dev/commands/describe_pr.md
@@ -360,8 +360,11 @@ If ticket found:
 if ! command -v linearis &> /dev/null; then
     echo "⚠️  Linearis CLI not found - skipping Linear ticket update"
 else
-    # If not already in "In Review", move it and assign to self
-    linearis issues update "$ticket" --state "In Review" --assignee "@me"
+    # Move to configured "In Review" state and assign to self
+    IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .claude/config.json 2>/dev/null || echo "In Review")
+    if [[ "$IN_REVIEW_STATE" != "null" ]]; then
+        linearis issues update "$ticket" --state "$IN_REVIEW_STATE" --assignee "@me"
+    fi
 
     # Add comment about update with PR link
     linearis comments create "$ticket" \
@@ -523,8 +526,10 @@ Uses `.claude/config.json`:
       "ticketPrefix": "PROJ"
     },
     "linear": {
-      "teamId": "team-id",
-      "inReviewStatusName": "In Review"
+      "teamKey": "PROJ",
+      "stateMap": {
+        "inReview": "In Review"
+      }
     },
     "pr": {
       "testCommand": "make test",
@@ -534,6 +539,8 @@ Uses `.claude/config.json`:
   }
 }
 ```
+
+State names are read from `stateMap` with sensible defaults. See `.claude/config.json` for all keys.
 
 ## Remember:
 

--- a/plugins/dev/commands/linear.md
+++ b/plugins/dev/commands/linear.md
@@ -83,21 +83,26 @@ This workflow ensures alignment through planning before implementation:
 
 ### Workflow Statuses
 
-1. **Backlog** → New ideas and feature requests
-2. **Triage** → Initial review and prioritization
-3. **Spec Needed** → Needs problem statement and solution outline
-4. **Research Needed** → Requires investigation
-5. **Research in Progress** → Active research underway
-6. **Ready for Plan** → Research complete, needs implementation plan
-7. **Plan in Progress** → Writing implementation plan
-8. **Plan in Review** → Plan under discussion
-9. **Ready for Dev** → Plan approved, ready to implement
-10. **In Dev** → Active development
-11. **In Review** → PR submitted
-12. **Done** → Completed
+Catalyst maps workflow phases to your Linear workspace states via `stateMap` in
+`.claude/config.json`. Default mapping (matches standard Linear states):
 
-**Note**: These statuses must be configured in your Linear workspace settings. The Linearis CLI will
-read and use whatever states exist in your workspace.
+| Workflow Phase | Default State | Config Key |
+|---------------|---------------|------------|
+| New tickets | Backlog | `stateMap.backlog` |
+| Acknowledged | Todo | `stateMap.todo` |
+| Research started | In Progress | `stateMap.research` |
+| Planning started | In Progress | `stateMap.planning` |
+| Implementation | In Progress | `stateMap.inProgress` |
+| PR created | In Review | `stateMap.inReview` |
+| Completed | Done | `stateMap.done` |
+| Canceled | Canceled | `stateMap.canceled` |
+
+**Customization**: Override any key to match your workspace. Set to `null` to skip
+that transition.
+
+**Note**: These states must exist in your Linear workspace. The defaults match what
+Linear provides out of the box (plus "In Review" which is commonly added to the
+Started category).
 
 ### Key Principle
 
@@ -105,13 +110,13 @@ read and use whatever states exist in your workspace.
 
 ### Workflow Commands Integration
 
-These commands automatically update ticket status:
+These commands automatically update ticket status using `stateMap` config:
 
-- `/catalyst-dev:create_plan` → Moves ticket to "Plan in Progress"
-- Plan completed → Moves to "Plan in Review"
-- `/catalyst-dev:implement_plan` → Moves to "In Dev"
-- `/catalyst-dev:create_pr` → Moves to "In Review"
-- `/catalyst-dev:merge_pr` → Moves to "Done"
+- `/catalyst-dev:research_codebase` → Moves ticket to `stateMap.research` (default: "In Progress")
+- `/catalyst-dev:create_plan` → Moves ticket to `stateMap.planning` (default: "In Progress")
+- `/catalyst-dev:implement_plan` → Moves to `stateMap.inProgress` (default: "In Progress")
+- `/catalyst-dev:create_pr` → Moves to `stateMap.inReview` (default: "In Review")
+- `/catalyst-dev:merge_pr` → Moves to `stateMap.done` (default: "Done")
 
 ---
 
@@ -204,7 +209,7 @@ When referencing thoughts documents, always provide GitHub links:
      --title "[refined title]" \
      --description "[final description in markdown]" \
      --priority [1-4] \
-     --status "Backlog"
+     --status "$(jq -r '.catalyst.linear.stateMap.backlog // "Backlog"' .claude/config.json 2>/dev/null || echo "Backlog")"
 
    # Capture the created issue ID from output
    ISSUE_ID=$(linearis issues create ... | jq -r '.id')
@@ -282,26 +287,24 @@ When moving tickets to a new status:
 
 2. **Suggest next status based on workflow:**
 
+   State names come from `stateMap` in `.claude/config.json`:
+
    ```
-   Backlog → Triage (for initial review)
-   Triage → Spec Needed (needs more detail) OR Research Needed (needs investigation)
-   Spec Needed → Research Needed (once problem outlined)
-   Research Needed → Research in Progress (starting research)
-   Research in Progress → Ready for Plan (research complete)
-   Ready for Plan → Plan in Progress (starting plan with /catalyst-dev:create_plan)
-   Plan in Progress → Plan in Review (plan complete)
-   Plan in Review → Ready for Dev (plan approved)
-   Ready for Dev → In Dev (starting work with /catalyst-dev:implement_plan)
-   In Dev → In Review (PR created)
+   Backlog → Todo (acknowledged)
+   Todo → In Progress (research/planning/implementation started)
+   In Progress → In Review (PR created)
    In Review → Done (PR merged)
    ```
 
-3. **Automatic status updates:** When certain commands are run, automatically update ticket status:
-   - `/catalyst-dev:create_plan` with ticket → Move to "Plan in Progress"
-   - Plan synced and linked → Move to "Plan in Review"
-   - `/catalyst-dev:implement_plan` with ticket → Move to "In Dev"
-   - `/catalyst-dev:create_pr` with ticket → Move to "In Review"
-   - `/catalyst-dev:merge_pr` with ticket → Move to "Done"
+   Teams with custom states can configure finer-grained transitions via `stateMap`.
+
+3. **Automatic status updates:** When certain commands are run, automatically update ticket status
+   (state names read from `stateMap` config):
+   - `/catalyst-dev:research_codebase` with ticket → Move to `stateMap.research`
+   - `/catalyst-dev:create_plan` with ticket → Move to `stateMap.planning`
+   - `/catalyst-dev:implement_plan` with ticket → Move to `stateMap.inProgress`
+   - `/catalyst-dev:create_pr` with ticket → Move to `stateMap.inReview`
+   - `/catalyst-dev:merge_pr` with ticket → Move to `stateMap.done`
 
 4. **Manual status updates:**
 
@@ -358,23 +361,22 @@ When these commands are run, check if there's a related Linear ticket and update
 
 **During `/catalyst-dev:create_plan`:**
 
-1. If ticket mentioned, move to "Plan in Progress"
+1. If ticket mentioned, move to `stateMap.planning` (default: "In Progress")
 2. When plan complete, add comment with plan link
-3. Move to "Plan in Review"
 
 **During `/catalyst-dev:implement_plan`:**
 
-1. If ticket in plan metadata, move to "In Dev"
+1. If ticket in plan metadata, move to `stateMap.inProgress` (default: "In Progress")
 2. Add comment: "Started implementation from plan: [link]"
 
 **During `/catalyst-dev:create_pr`:**
 
-1. If ticket mentioned in PR or plan, move to "In Review"
+1. If ticket mentioned in PR or plan, move to `stateMap.inReview` (default: "In Review")
 2. Add comment with PR link
 
 **During `/catalyst-dev:merge_pr`:**
 
-1. Move ticket to "Done"
+1. Move ticket to `stateMap.done` (default: "Done")
 2. Add comment with merge details
 
 ---
@@ -395,19 +397,19 @@ When these commands are run, check if there's a related Linear ticket and update
 # 3. Create plan
 /catalyst-dev:create_plan
 # Reads research, creates plan
-# Ticket moves to "Plan in Progress" → "Plan in Review"
+# Ticket moves to stateMap.planning (default: "In Progress")
 
 # 4. Implement
 /catalyst-dev:implement_plan thoughts/shared/plans/2025-01-08-auth-feature.md
-# Ticket moves to "In Dev"
+# Ticket moves to stateMap.inProgress (default: "In Progress")
 
 # 5. Create PR
 /catalyst-dev:create_pr
-# Ticket moves to "In Review"
+# Ticket moves to stateMap.inReview (default: "In Review")
 
 # 6. Merge PR
 /catalyst-dev:merge_pr
-# Ticket moves to "Done"
+# Ticket moves to stateMap.done (default: "Done")
 ```
 
 ### Workflow 2: Quick Ticket Updates
@@ -416,8 +418,8 @@ When these commands are run, check if there's a related Linear ticket and update
 # Add progress comment
 linearis comments create PROJ-123 --body "Completed phase 1, moving to phase 2"
 
-# Move ticket forward
-linearis issues update PROJ-123 --state "In Dev"
+# Move ticket forward (state name from stateMap config)
+linearis issues update PROJ-123 --state "In Progress"
 
 # Search for related tickets
 linearis issues list --team PROJ | jq '.[] | select(.title | contains("authentication"))'
@@ -440,7 +442,7 @@ linearis issues list --limit 100 | jq '.[] | select(.state.name == "In Progress"
 linearis issues read TICKET-123
 
 # Create issue
-linearis issues create "Title" --description "Description" --state "Todo"
+linearis issues create "Title" --description "Description" --state "Backlog"
 
 # Update issue state
 linearis issues update TICKET-123 --state "In Progress"
@@ -480,9 +482,9 @@ linearis issues list --team TEAM | jq '.[] | select(.title | contains("bug"))'
 
 ## Notes
 
-- **Configuration**: Use `.claude/config.json` for team settings
-- **Status mapping**: Use status names that exist in your Linear workspace
-- **Automation**: Workflow commands auto-update tickets when ticket IDs are referenced
+- **Configuration**: Use `.claude/config.json` for team settings and `stateMap` for state names
+- **Status mapping**: Configure `linear.stateMap` to match your Linear workspace states
+- **Automation**: Workflow commands auto-update tickets using state names from `stateMap`
 - **CLI required**: Linearis CLI must be installed and configured with LINEAR_API_TOKEN
 
 This command integrates seamlessly with the create_plan → implement_plan → validate_plan workflow

--- a/plugins/dev/commands/merge_pr.md
+++ b/plugins/dev/commands/merge_pr.md
@@ -295,8 +295,11 @@ if ! command -v linearis &> /dev/null; then
     echo "⚠️  Linearis CLI not found - skipping Linear ticket update"
     echo "Install: npm install -g linearis"
 else
-    # Move to "Done"
-    linearis issues update "$ticket" --state "Done"
+    # Move to configured "Done" state
+    DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .claude/config.json 2>/dev/null || echo "Done")
+    if [[ "$DONE_STATE" != "null" ]]; then
+        linearis issues update "$ticket" --state "$DONE_STATE"
+    fi
 
     # Add merge comment
     linearis comments create "$ticket" \
@@ -482,8 +485,8 @@ Install Linearis:
 Configure:
   export LINEAR_API_TOKEN=your_token
 
-Then update ticket manually:
-  linearis issues update $ticket --state "Done"
+Then update ticket manually (use state name from your stateMap config):
+  linearis issues update $ticket --state "Done"  # or your configured done state
 ```
 
 **Linear API error:**
@@ -520,7 +523,9 @@ Uses `.claude/config.json`:
     },
     "linear": {
       "teamKey": "PROJ",
-      "doneStatusName": "Done"
+      "stateMap": {
+        "done": "Done"
+      }
     },
     "pr": {
       "defaultMergeStrategy": "squash",
@@ -534,6 +539,8 @@ Uses `.claude/config.json`:
   }
 }
 ```
+
+State names are read from `stateMap` with sensible defaults. See `.claude/config.json` for all keys.
 
 ## Examples
 

--- a/plugins/dev/commands/oneshot.md
+++ b/plugins/dev/commands/oneshot.md
@@ -53,7 +53,7 @@ Uses the provided text as the research query directly.
 This phase runs in the current session to allow user interaction during research.
 
 1. **Parse input**: Determine if ticket ID or freeform query
-2. **If ticket**: Read ticket details via Linearis CLI, move to "Research in Progress"
+2. **If ticket**: Read ticket details via Linearis CLI, move to `stateMap.research` (default: "In Progress")
 3. **Conduct research**: Spawn parallel sub-agents (same as `/research-codebase`):
    - **codebase-locator**: Find relevant files
    - **codebase-analyzer**: Understand current implementation
@@ -158,14 +158,14 @@ Phase 3: Implement (NEW session via humanlayer launch)
 
 If a ticket ID is provided:
 
-| Phase | Linear Status | Action |
-|-------|--------------|--------|
-| Research starts | "Research in Progress" | Comment: "Starting research" |
-| Research complete | — | Comment with research doc link |
-| Plan starts | "Plan in Progress" | Comment: "Starting planning" |
-| Plan approved | "Ready for Dev" | Comment with plan doc link |
-| Implementation starts | "In Dev" | Comment: "Starting implementation" |
-| PR created | "In Review" | Comment with PR link |
+| Phase | State (from stateMap) | Config Key | Default |
+|-------|----------------------|------------|---------|
+| Research starts | stateMap.research | `research` | "In Progress" |
+| Research complete | — | — | Comment with research doc link |
+| Plan starts | stateMap.planning | `planning` | "In Progress" |
+| Plan approved | stateMap.inProgress | `inProgress` | "In Progress" |
+| Implementation starts | stateMap.inProgress | `inProgress` | "In Progress" |
+| PR created | stateMap.inReview | `inReview` | "In Review" |
 
 ## Error Handling
 

--- a/plugins/dev/commands/research_codebase.md
+++ b/plugins/dev/commands/research_codebase.md
@@ -53,7 +53,7 @@ Then wait for the user's research query.
 - Break down the user's query into composable research areas
 - Think deeply about underlying patterns, connections, and architectural implications
 - Create a research plan using TodoWrite to track all subtasks
-- If a Linear ticket is provided, update it to "Research" status via Linearis CLI
+- If a Linear ticket is provided, update it to the configured research state via Linearis CLI (from `stateMap.research`)
 
 ### Step 3: Spawn parallel sub-agent tasks for comprehensive research
 
@@ -260,6 +260,12 @@ If the user has follow-up questions:
 
 If a ticket is detected (provided as argument, mentioned in query, or from context):
 
-- **At research start**: `linearis issues update "$ticketId" --state "Research"`
+- **At research start**:
+  ```bash
+  RESEARCH_STATE=$(jq -r '.catalyst.linear.stateMap.research // "In Progress"' .claude/config.json 2>/dev/null || echo "In Progress")
+  if [[ "$RESEARCH_STATE" != "null" ]]; then
+      linearis issues update "$ticketId" --state "$RESEARCH_STATE"
+  fi
+  ```
 - **After document saved**: `linearis comments create "$ticketId" --body "Research complete: $link"`
 - If Linearis CLI not available, skip silently and continue research

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -55,8 +55,9 @@ linearis issues search "auth" --team ENG         # ✅ Correct
 ### Update a Ticket
 ```bash
 # Update state - use --state NOT --status!
+# State names should come from stateMap in .claude/config.json
 linearis issues update TEAM-123 --state "In Progress"
-linearis issues update TEAM-123 --state "Research"
+linearis issues update TEAM-123 --state "In Review"
 linearis issues update TEAM-123 --state "Done"
 
 # Other updates
@@ -189,7 +190,9 @@ linearis issues list --team BRAVO --limit 100 | jq '.[] | select(.project.name =
 
 ### Mark ticket as done with PR link
 ```bash
-linearis issues update TEAM-123 --state "Done"
+# State name from stateMap.done config (default: "Done")
+DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .claude/config.json 2>/dev/null || echo "Done")
+linearis issues update TEAM-123 --state "$DONE_STATE"
 linearis comments create TEAM-123 --body "Merged: PR #456 https://github.com/org/repo/pull/456"
 ```
 

--- a/plugins/meta/.claude-plugin/plugin.json
+++ b/plugins/meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-meta",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Workflow discovery and creation tools: learn from community patterns and extend Catalyst with new workflows.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-pm",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Linear-focused project management plugin with cycle management, milestone tracking, backlog grooming, and team analytics",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/pm/agents/github-linear-analyzer.md
+++ b/plugins/pm/agents/github-linear-analyzer.md
@@ -151,15 +151,18 @@ linearis issues create \
 | TEAM-456 | #123 | 2025-01-25 | Close issue |
 | TEAM-457 | #124 | 2025-01-26 | Close issue |
 
-**Auto-close commands**:
+**Auto-close commands** (state name from `stateMap.done` config):
 ```bash
+# Read configured done state
+DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .claude/config.json 2>/dev/null || echo "Done")
+
 # Update state
-linearis issues update TEAM-456 --state "Done"
+linearis issues update TEAM-456 --state "$DONE_STATE"
 # Add comment
 linearis comments create TEAM-456 --body "PR #123 merged: https://github.com/user/repo/pull/123"
 
 # Update state
-linearis issues update TEAM-457 --state "Done"
+linearis issues update TEAM-457 --state "$DONE_STATE"
 # Add comment
 linearis comments create TEAM-457 --body "PR #124 merged: https://github.com/user/repo/pull/124"
 ```

--- a/plugins/pm/agents/linear-research.md
+++ b/plugins/pm/agents/linear-research.md
@@ -31,7 +31,8 @@ Gather data from Linear using the Linearis CLI. This is a **data collection spec
 linearis issues read TEAM-123
 
 # Update ticket state (use --state NOT --status!)
-linearis issues update TEAM-123 --state "Research"
+# State names should come from stateMap in .claude/config.json
+linearis issues update TEAM-123 --state "In Progress"
 
 # Add comment (use 'comments create' NOT 'issues comment'!)
 linearis comments create TEAM-123 --body "Starting research"
@@ -48,8 +49,8 @@ linearis cycles read "Sprint 2025-11" --team BRAVO
 
 ### Common Mistakes to Avoid
 
-❌ `linearis issues update TICKET --status "Research"` (Wrong flag)
-✅ `linearis issues update TICKET --state "Research"`
+❌ `linearis issues update TICKET --status "In Progress"` (Wrong flag)
+✅ `linearis issues update TICKET --state "In Progress"`
 
 ❌ `linearis issues comment TICKET "text"` (Wrong subcommand)
 ✅ `linearis comments create TICKET --body "text"`

--- a/plugins/pm/commands/groom_backlog.md
+++ b/plugins/pm/commands/groom_backlog.md
@@ -175,8 +175,9 @@ linearis issues update TEAM-456 --project "Auth & Security"
 # Move TEAM-123 to Frontend project
 linearis issues update TEAM-123 --project "Frontend"
 
-# Close stale issue TEAM-789
-linearis issues update TEAM-789 --state "Canceled"
+# Close stale issue TEAM-789 (state from stateMap.canceled config)
+CANCELED_STATE=$(jq -r '.catalyst.linear.stateMap.canceled // "Canceled"' .claude/config.json 2>/dev/null || echo "Canceled")
+linearis issues update TEAM-789 --state "$CANCELED_STATE"
 linearis comments create TEAM-789 --body "Closing stale issue (>30 days inactive)"
 
 # [... more commands ...]

--- a/plugins/pm/commands/sync_prs.md
+++ b/plugins/pm/commands/sync_prs.md
@@ -146,15 +146,18 @@ linearis issues create \
 | TEAM-456 | #123 | 2025-01-25 | Close issue |
 | TEAM-457 | #124 | 2025-01-26 | Close issue |
 
-**Auto-close commands**:
+**Auto-close commands** (state name from `stateMap.done` config):
 ```bash
+# Read configured done state
+DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .claude/config.json 2>/dev/null || echo "Done")
+
 # Update state
-linearis issues update TEAM-456 --state "Done"
+linearis issues update TEAM-456 --state "$DONE_STATE"
 # Add comment
 linearis comments create TEAM-456 --body "PR #123 merged: https://github.com/user/repo/pull/123"
 
 # Update state
-linearis issues update TEAM-457 --state "Done"
+linearis issues update TEAM-457 --state "$DONE_STATE"
 # Add comment
 linearis comments create TEAM-457 --body "PR #124 merged: https://github.com/user/repo/pull/124"
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -138,11 +138,14 @@ pip install humanlayer  # or: pipx install humanlayer
 **What it does**:
 
 - Creates GraphQL mutation file at `/tmp/linear-workflow-setup.graphql`
-- Defines workflow statuses:
-  - Backlog → Triage → Research → Planning → In Progress → In Review → Done
-- Provides setup instructions
+- Creates an optional 12-state custom workflow (Backlog → Triage → Research → Planning → In Dev → In Review → Done, etc.)
+- Outputs the `stateMap` configuration to add to `.claude/config.json`
 
-**When to use**: Initial Linear integration setup (optional, can manage statuses manually)
+**Note**: This is **optional**. Catalyst works out-of-the-box with standard Linear states
+(Backlog, Todo, In Progress, In Review, Done, Canceled). Only run this if you want finer-grained
+status tracking. State names are configurable via `linear.stateMap` in `.claude/config.json`.
+
+**When to use**: Optional setup for teams wanting a detailed 12-state workflow
 
 ---
 

--- a/scripts/linear/setup-linear-workflow
+++ b/scripts/linear/setup-linear-workflow
@@ -1,5 +1,14 @@
 #!/bin/bash
-# setup-linear-workflow - Automatically create workflow statuses in Linear
+# setup-linear-workflow - Create OPTIONAL custom workflow statuses in Linear
+#
+# NOTE: This script is OPTIONAL. Catalyst works out-of-the-box with standard
+# Linear states (Backlog, Todo, In Progress, In Review, Done, Canceled).
+# Only run this if you want the full 12-state custom workflow for fine-grained
+# status tracking.
+#
+# After running, update your .claude/config.json with the stateMap output
+# shown at the end of the script.
+#
 # Usage: ./setup-linear-workflow [team_key]
 
 set -e
@@ -11,7 +20,10 @@ BLUE='\033[0;34m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-echo -e "${BLUE}🔄 Linear Workflow Setup${NC}"
+echo -e "${BLUE}🔄 Linear Custom Workflow Setup (OPTIONAL)${NC}"
+echo ""
+echo -e "${YELLOW}Note: Catalyst works out-of-the-box with standard Linear states.${NC}"
+echo "This script creates an advanced 12-state workflow for fine-grained tracking."
 echo ""
 
 # Check for Linear CLI or API key
@@ -374,4 +386,22 @@ echo ""
 echo -e "${GREEN}✅ Workflow setup guide complete!${NC}"
 echo ""
 echo "Recommended: Use Option 1 (Claude with Linear MCP) for easiest setup"
+echo ""
+echo -e "${YELLOW}════════════════════════════════════════════════════════${NC}"
+echo -e "${YELLOW}After creating the custom states, add this to your${NC}"
+echo -e "${YELLOW}.claude/config.json to use them with Catalyst:${NC}"
+echo -e "${YELLOW}════════════════════════════════════════════════════════${NC}"
+echo ""
+echo '  "linear": {'
+echo '    "stateMap": {'
+echo '      "backlog": "Backlog",'
+echo '      "todo": "Triage",'
+echo '      "research": "Research in Progress",'
+echo '      "planning": "Plan in Progress",'
+echo '      "inProgress": "In Dev",'
+echo '      "inReview": "In Review",'
+echo '      "done": "Done",'
+echo '      "canceled": "Canceled"'
+echo '    }'
+echo '  }'
 echo ""


### PR DESCRIPTION
## Summary

- Add `linear.stateMap` config to map workflow phases to Linear state names with defaults matching standard Linear states
- Replace hardcoded state names across 21 files with config-driven lookups using jq fallbacks
- Unify two competing state schemes (12-state and 6-state) into one configurable system
- Support `null` values to skip specific transitions

## Problem

Catalyst's Linear commands hardcoded state names like "Research in Progress", "Plan in Progress", and "In Dev" that don't exist in standard Linear workspaces. A new user would see silent failures when commands tried to transition to nonexistent states. Two competing schemes existed across the codebase with conflicting state names.

## Solution

A `stateMap` in `.claude/config.json` maps 8 workflow events (backlog, todo, research, planning, inProgress, inReview, done, canceled) to actual Linear state names. Defaults match what Linear provides out of the box. Users with custom states can override specific mappings. Setting any key to `null` skips that transition.

## Test plan

- [ ] Clone fresh, run `/create-pr` — should transition to "In Review" (not fail on missing state)
- [ ] Set `stateMap.inReview` to `"Code Review"` — `/create-pr` should use that name
- [ ] Set `stateMap.research` to `null` — `/research-codebase` should skip the Linear transition
- [ ] Verify `jq . .claude/config.json` parses cleanly
- [ ] Grep for bare `--state "` in command files — only appears in doc examples, not automated transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)