### PR TITLE
fix(linearis): correct --team flag docs and add UUID resolution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "catalyst-dev",
       "source": "./plugins/dev",
       "description": "Core development workflow: research → plan → implement → validate → ship. Includes 10 research agents, workflow commands, Linear integration, handoff system. Always enabled. ~3.5k context (lightweight MCPs: DeepWiki, Context7).",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"
@@ -34,7 +34,7 @@
       "name": "catalyst-pm",
       "source": "./plugins/pm",
       "description": "Linear-focused project management: cycle tracking, milestone planning, backlog grooming, daily standups, GitHub-Linear sync. Enable when managing Linear projects. ~5k context when enabled.",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-dev",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Complete development workflow: research → plan → implement → validate → ship. Includes research agents, planning tools, handoff system, Linear integration, and PM commands.",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/dev/agents/linear-research.md
+++ b/plugins/dev/agents/linear-research.md
@@ -119,7 +119,7 @@ Present findings as structured data:
 
 ## Important Guidelines
 
-- **Always specify --team**: Required for most commands
+- **Team flag varies by command**: `cycles`, `projects`, `labels` support `--team TEAM-KEY`. `issues list` does NOT support `--team` (use `--limit` + jq filtering). `issues create --team` requires a UUID, not a key/name
 - **JSON output**: Linearis returns JSON, parse with jq for filtering
 - **Ticket format**: Use TEAM-NUMBER format (e.g., ENG-123)
 - **Error handling**: If ticket not found, suggest checking team key

--- a/plugins/dev/agents/linear-research.md
+++ b/plugins/dev/agents/linear-research.md
@@ -72,10 +72,10 @@ linearis cycles list --team TEAM --active
 
 ```bash
 # List projects
-linearis projects list --team TEAM
+linearis projects list
 
 # Get project details (parse JSON output)
-linearis projects list --team TEAM | jq '.[] | select(.name == "Project Name")'
+linearis projects list | jq '.[] | select(.name == "Project Name")'
 ```
 
 ### Configuration Discovery

--- a/plugins/dev/commands/cycle_review.md
+++ b/plugins/dev/commands/cycle_review.md
@@ -46,8 +46,8 @@ CYCLE=$(linearis cycles list --team ENG --active | jq -r '.[0].name')
 echo "Active cycle: $CYCLE"
 
 # 2. Get all tickets in cycle
-linearis issues list --team ENG | \
-  jq --arg cycle "$CYCLE" '.[] | select(.cycle.name == $cycle)'
+linearis issues list --limit 100 | \
+  jq --arg cycle "$CYCLE" '.[] | select(.team.key == "ENG" and .cycle.name == $cycle)'
 
 # 3. Count by status (use cycles read to get issues)
 CYCLE_DATA=$(linearis cycles read "$CYCLE" --team ENG)

--- a/plugins/dev/commands/linear.md
+++ b/plugins/dev/commands/linear.md
@@ -206,8 +206,9 @@ When referencing thoughts documents, always provide GitHub links:
    # Create issue with linearis
    # WARNING: --team only accepts UUIDs, not team keys/names (upstream bug: czottmann/linearis#56)
    # Team keys/names silently fall back to the workspace default team.
-   # To target a specific team, look up the UUID first:
-   #   TEAM_UUID=$(linearis teams list | jq -r '.[] | select(.key == "TEAM") | .id')
+   # Get the team UUID from config or from any existing issue:
+   #   TEAM_UUID=$(jq -r '.catalyst.linear.teamUuid // empty' .claude/config.json)
+   #   # Or: TEAM_UUID=$(linearis issues list --limit 1 | jq -r '.[0].team.id')
    linearis issues create \
      --team "$TEAM_UUID" \
      --title "[refined title]" \

--- a/plugins/dev/commands/linear.md
+++ b/plugins/dev/commands/linear.md
@@ -204,8 +204,12 @@ When referencing thoughts documents, always provide GitHub links:
 
    ```bash
    # Create issue with linearis
+   # WARNING: --team only accepts UUIDs, not team keys/names (upstream bug: czottmann/linearis#56)
+   # Team keys/names silently fall back to the workspace default team.
+   # To target a specific team, look up the UUID first:
+   #   TEAM_UUID=$(linearis teams list | jq -r '.[] | select(.key == "TEAM") | .id')
    linearis issues create \
-     --team "$TEAM_KEY" \
+     --team "$TEAM_UUID" \
      --title "[refined title]" \
      --description "[final description in markdown]" \
      --priority [1-4] \
@@ -422,7 +426,7 @@ linearis comments create PROJ-123 --body "Completed phase 1, moving to phase 2"
 linearis issues update PROJ-123 --state "In Progress"
 
 # Search for related tickets
-linearis issues list --team PROJ | jq '.[] | select(.title | contains("authentication"))'
+linearis issues list --limit 100 | jq '.[] | select(.team.key == "PROJ" and (.title | contains("authentication")))'
 ```
 
 ---

--- a/plugins/dev/commands/linear.md
+++ b/plugins/dev/commands/linear.md
@@ -39,8 +39,16 @@ CONFIG_FILE=".claude/config.json"
 # Read team key (e.g., "ENG", "PROJ")
 TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // "PROJ"' "$CONFIG_FILE")
 
-# Read default team name (optional)
-DEFAULT_TEAM=$(jq -r '.catalyst.linear.defaultTeam // null' "$CONFIG_FILE")
+# Read team UUID — required for issues create and issues search (keys don't work)
+# Fallback chain: config → lookup from existing issue → error
+TEAM_UUID=$(jq -r '.catalyst.linear.teamUuid // empty' "$CONFIG_FILE")
+if [ -z "$TEAM_UUID" ]; then
+  TEAM_UUID=$(linearis issues list --limit 1 | jq -r --arg key "$TEAM_KEY" '.[0].team | select(.key == $key) | .id // empty')
+fi
+if [ -z "$TEAM_UUID" ]; then
+  echo "WARNING: Could not resolve team UUID for $TEAM_KEY. issues create/search may target wrong team."
+  echo "Add teamUuid to .claude/config.json to fix: linearis issues list --limit 20 | jq '[.[].team | {key, id}] | unique_by(.key)'"
+fi
 
 # Read thoughts repo URL
 THOUGHTS_URL=$(jq -r '.catalyst.linear.thoughtsRepoUrl // "https://github.com/org/thoughts/blob/main"' "$CONFIG_FILE")
@@ -52,10 +60,16 @@ THOUGHTS_URL=$(jq -r '.catalyst.linear.thoughtsRepoUrl // "https://github.com/or
 {
   "catalyst": {
     "linear": {
-      "teamKey": "ENG"
+      "teamKey": "ENG",
+      "teamUuid": "<team-uuid>"
     }
   }
 }
+```
+
+To find your team UUID:
+```bash
+linearis issues list --limit 20 | jq '[.[].team | {key, id, name}] | unique_by(.key)'
 ```
 
 ## Initial Response

--- a/plugins/dev/commands/roadmap_review.md
+++ b/plugins/dev/commands/roadmap_review.md
@@ -27,10 +27,10 @@ Use Linearis CLI directly:
 
 ```bash
 # List projects
-linearis projects list --team TEAM
+linearis projects list
 
 # Parse project status from JSON
-linearis projects list --team TEAM | jq '.[] | {name, status, progress}'
+linearis projects list | jq '.[] | {name, status, progress}'
 
 # List tickets for specific project
 linearis issues list --limit 100 | jq '.[] | select(.team.key == "TEAM" and .project.name == "Project Name")'
@@ -40,11 +40,11 @@ linearis issues list --limit 100 | jq '.[] | select(.team.key == "TEAM" and .pro
 
 ```bash
 # 1. List all active projects
-linearis projects list --team ENG | \
+linearis projects list | \
   jq '.[] | select(.state != "completed") | {name, lead, targetDate}'
 
 # 2. Get project details with ticket counts
-for project in $(linearis projects list --team ENG | jq -r '.[].name'); do
+for project in $(linearis projects list | jq -r '.[].name'); do
   echo "Project: $project"
 
   # Count tickets by status

--- a/plugins/dev/commands/roadmap_review.md
+++ b/plugins/dev/commands/roadmap_review.md
@@ -33,7 +33,7 @@ linearis projects list --team TEAM
 linearis projects list --team TEAM | jq '.[] | {name, status, progress}'
 
 # List tickets for specific project
-linearis issues list --team TEAM | jq '.[] | select(.project.name == "Project Name")'
+linearis issues list --limit 100 | jq '.[] | select(.team.key == "TEAM" and .project.name == "Project Name")'
 ```
 
 ### Example Workflow
@@ -48,9 +48,9 @@ for project in $(linearis projects list --team ENG | jq -r '.[].name'); do
   echo "Project: $project"
 
   # Count tickets by status
-  linearis issues list --team ENG | \
-    jq --arg proj "$project" '
-      [.[] | select(.project.name == $proj)] |
+  linearis issues list --limit 100 | \
+    jq --arg proj "$project" --arg team "ENG" '
+      [.[] | select(.team.key == $team and .project.name == $proj)] |
       group_by(.state.name) |
       map({status: .[0].state.name, count: length})
     '

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -26,12 +26,14 @@ linearis issue TEAM-123           # ❌ WRONG - missing subcommand
 ```bash
 linearis issues list                      # Basic list (25 tickets)
 linearis issues list --limit 50           # With limit
-linearis issues list --team BRAVO         # Filter by team
-linearis issues list --team BRAVO --limit 100
 ```
 
-**NOTE:** `--limit` and `--team` are the ONLY supported filters. For other filtering, use jq:
+**NOTE:** `--limit` is the ONLY supported flag for `issues list`. There is NO `--team` flag
+(upstream feature request: czottmann/linearis#20). For filtering, use jq:
 ```bash
+# Filter by team
+linearis issues list --limit 100 | jq '.[] | select(.team.key == "BRAVO")'
+
 # Filter by status - use jq, NOT --status or --filter
 linearis issues list --limit 100 | jq '.[] | select(.state.name == "In Progress")'
 
@@ -82,7 +84,11 @@ linearis issues update TEAM-123 --status "Done"   # ❌ WRONG - use --state
 ```bash
 linearis issues create "Title of ticket"
 linearis issues create "Title" --description "Description" --state "Todo" --priority 2
-linearis issues create "Title" --team BRAVO --project "Project Name"
+linearis issues create "Title" --project "Project Name"
+
+# WARNING: --team only accepts UUIDs (upstream bug: czottmann/linearis#56)
+# Team keys and names silently fall back to the workspace default team!
+linearis issues create "Title" --team "<team-uuid>" --project "Project Name"
 ```
 
 ## Comment Operations
@@ -185,7 +191,7 @@ linearis cycles read "$CYCLE" --team BRAVO | jq '.issues[] | {identifier, title,
 
 ### Get tickets by project
 ```bash
-linearis issues list --team BRAVO --limit 100 | jq '.[] | select(.project.name == "Auth System")'
+linearis issues list --limit 100 | jq '.[] | select(.team.key == "BRAVO" and .project.name == "Auth System")'
 ```
 
 ### Mark ticket as done with PR link
@@ -204,7 +210,7 @@ linearis comments create TEAM-123 --body "Merged: PR #456 https://github.com/org
 | Update state | `linearis issues update TEAM-123 --state "State"` |
 | Add comment | `linearis comments create TEAM-123 --body "text"` |
 | Search | `linearis issues search "keyword" --team TEAM` |
-| List issues | `linearis issues list --team TEAM --limit N` |
+| List issues | `linearis issues list --limit N` (filter by team with jq) |
 | Active cycle | `linearis cycles list --team TEAM --active` |
 | Cycle details | `linearis cycles read "Name" --team TEAM` |
 
@@ -214,7 +220,7 @@ linearis comments create TEAM-123 --body "Merged: PR #456 https://github.com/org
 2. **comments create**: Use `linearis comments create`, not `issues comment`
 3. **issues read**: Use `read`, not `get` or `view`
 4. **Filtering via jq**: No `--filter` or `--status` flags - pipe to jq instead
-5. **Team parameter**: Most commands need `--team TEAM-KEY`
+5. **Team parameter**: `cycles`, `projects`, `labels`, `search` support `--team TEAM-KEY`. `issues list` does NOT (use jq). `issues create --team` requires a UUID (not key/name — upstream bug: czottmann/linearis#56)
 6. **Quotes for spaces**: `--cycle "Sprint 2025-11"` not `--cycle Sprint 2025-11`
 7. **JSON output**: All commands return JSON - use jq for parsing
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -50,8 +50,11 @@ linearis issues --filter "keyword"           # ❌ WRONG - no --filter flag
 
 ### Search Tickets
 ```bash
-linearis issues search "keyword" --team BRAVO    # ✅ Correct
-linearis issues search "auth" --team ENG         # ✅ Correct
+# WARNING: --team only works with UUIDs for search too (keys return wrong team's results)
+linearis issues search "keyword" --team "<team-uuid>"
+
+# Without --team, search returns results across all teams
+linearis issues search "keyword"
 ```
 
 ### Update a Ticket
@@ -139,8 +142,9 @@ linearis cycles read "$CYCLE" --team BRAVO | jq '.issues[] | {identifier, title,
 
 ### List Projects
 ```bash
-linearis projects list --team BRAVO
-linearis projects list --team BRAVO | jq '.[] | select(.name == "Auth System")'
+# NOTE: projects list does NOT support --team. It returns all workspace projects.
+linearis projects list
+linearis projects list | jq '.[] | select(.name == "Auth System")'
 ```
 
 ## Milestone Operations
@@ -209,7 +213,7 @@ linearis comments create TEAM-123 --body "Merged: PR #456 https://github.com/org
 | Read ticket | `linearis issues read TEAM-123` |
 | Update state | `linearis issues update TEAM-123 --state "State"` |
 | Add comment | `linearis comments create TEAM-123 --body "text"` |
-| Search | `linearis issues search "keyword" --team TEAM` |
+| Search | `linearis issues search "keyword"` (--team needs UUID) |
 | List issues | `linearis issues list --limit N` (filter by team with jq) |
 | Active cycle | `linearis cycles list --team TEAM --active` |
 | Cycle details | `linearis cycles read "Name" --team TEAM` |
@@ -220,7 +224,7 @@ linearis comments create TEAM-123 --body "Merged: PR #456 https://github.com/org
 2. **comments create**: Use `linearis comments create`, not `issues comment`
 3. **issues read**: Use `read`, not `get` or `view`
 4. **Filtering via jq**: No `--filter` or `--status` flags - pipe to jq instead
-5. **Team parameter**: `cycles`, `projects`, `labels`, `search` support `--team TEAM-KEY`. `issues list` does NOT (use jq). `issues create --team` requires a UUID (not key/name — upstream bug: czottmann/linearis#56)
+5. **Team parameter**: `cycles list` and `labels list` support `--team TEAM-KEY`. `issues list` and `projects list` do NOT support `--team` (use jq). `issues create` and `issues search` accept `--team` but **require a UUID** — keys/names silently return wrong results (upstream bug: czottmann/linearis#56)
 6. **Quotes for spaces**: `--cycle "Sprint 2025-11"` not `--cycle Sprint 2025-11`
 7. **JSON output**: All commands return JSON - use jq for parsing
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -206,6 +206,24 @@ linearis issues update TEAM-123 --state "$DONE_STATE"
 linearis comments create TEAM-123 --body "Merged: PR #456 https://github.com/org/repo/pull/456"
 ```
 
+## Team UUID Resolution
+
+Many commands require a team UUID (not key/name) for the `--team` flag. Use this pattern:
+
+```bash
+# Preferred: read from config
+TEAM_UUID=$(jq -r '.catalyst.linear.teamUuid // empty' .claude/config.json)
+
+# Fallback: look up from any existing issue
+if [ -z "$TEAM_UUID" ]; then
+  TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // "PROJ"' .claude/config.json)
+  TEAM_UUID=$(linearis issues list --limit 1 | jq -r --arg key "$TEAM_KEY" '.[0].team | select(.key == $key) | .id // empty')
+fi
+
+# Discover all team UUIDs in workspace
+linearis issues list --limit 20 | jq '[.[].team | {key, id, name}] | unique_by(.key)'
+```
+
 ## Quick Reference Card
 
 | Action | Command |

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "catalyst-pm",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Comprehensive product management toolkit: PM skills, research pipelines, PRD workflows, analytics, reporting, and Linear integration",
   "author": {
     "name": "Coalesce Labs",

--- a/plugins/pm/agents/linear-research.md
+++ b/plugins/pm/agents/linear-research.md
@@ -74,7 +74,8 @@ fi
 **Processing**:
 ```bash
 TEAM_KEY="PROJ"
-issues_data=$(linearis issues list --team "$TEAM_KEY" --states "Backlog" 2>&1)
+# NOTE: issues list only supports --limit (no --team or --states flags)
+issues_data=$(linearis issues list --limit 100 2>&1 | jq --arg team "$TEAM_KEY" '[.[] | select(.team.key == $team and .state.name == "Backlog")]')
 
 # Filter for issues without cycles using jq
 backlog_no_cycle=$(echo "$issues_data" | jq '[.[] | select(.cycle == null)]')


### PR DESCRIPTION
## Summary

Fixes incorrect `--team` flag documentation in the linearis skill and related files. Discovered through live testing that the bugs are broader than the original report — adds UUID resolution pattern so agents can reliably create issues.

- **`issues list --team` doesn't exist** — removed all references, replaced with `--limit` + jq filtering
- **`issues create/search --team` requires UUIDs** — keys/names silently return wrong team (upstream: czottmann/linearis#56)
- **`projects list --team` doesn't exist** — removed all references
- **`issues search --team` with keys returns wrong team's results** — added UUID warning, updated examples
- **No `teams` command exists** — fixed broken workaround, replaced with config + issue-lookup fallback
- **Added `teamUuid` to config schema** with auto-resolution fallback chain

## Files Changed

- `plugins/dev/skills/linearis/SKILL.md` — primary CLI reference, 5 fix areas + new UUID Resolution section
- `plugins/dev/commands/linear.md` — UUID resolution in Configuration section, fixed create/search patterns
- `plugins/dev/commands/cycle_review.md` — fixed `issues list --team`
- `plugins/dev/commands/roadmap_review.md` — fixed `issues list --team` and `projects list --team`
- `plugins/dev/agents/linear-research.md` — fixed guidelines and `projects list --team`
- `plugins/pm/agents/linear-research.md` — fixed `issues list --team --states` (neither flag exists)

## UUID Resolution Pattern for Agents

Agents now use a three-level fallback to get the team UUID:

```bash
# 1. Config (fastest)
TEAM_UUID=$(jq -r '.catalyst.linear.teamUuid // empty' .claude/config.json)
# 2. Derive from existing issue
if [ -z "$TEAM_UUID" ]; then
  TEAM_UUID=$(linearis issues list --limit 1 | jq -r --arg key "$TEAM_KEY" '.[0].team | select(.key == $key) | .id // empty')
fi
# 3. Warn
if [ -z "$TEAM_UUID" ]; then
  echo "WARNING: Could not resolve team UUID"
fi
```

## Upstream Issues

- czottmann/linearis#20 — `issues list --team` (feature request, open)
- czottmann/linearis#56 — `issues create --team` silent fallback (bug, open, filed by @ryanrozich)

Refs: CTL-20