### PR TITLE
Update merge-pr skill and improve website reference docs

### DIFF
--- a/.claude/rules/website-docs.md
+++ b/.claude/rules/website-docs.md
@@ -12,7 +12,7 @@ paths: ["website/**"]
 
 ## Terminology
 - Always use "skills" — never "commands" when referring to Catalyst functionality
-- User-invocable skills: triggered by user with `/plugin:skill_name`
+- User-invocable skills: triggered by user with `/skill-name` (plugin shown in description for disambiguation)
 - Model-invocable skills: activated automatically by Claude when relevant context detected
 - CI skills: non-interactive variants for automation pipelines
 

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -325,6 +325,24 @@ echo "✅ Deleted local branch: $head_branch"
 
 **Always delete local branch** - no prompt (remote already deleted).
 
+### 12a. Update primary worktree
+
+If running in a git worktree, the primary checkout of main may be stale. Update it:
+
+```bash
+# Find the primary worktree checked out on the base branch
+PRIMARY_WORKTREE=$(git worktree list | grep "\[$base_branch\]" | awk '{print $1}')
+CURRENT_DIR=$(pwd)
+
+if [[ -n "$PRIMARY_WORKTREE" && "$PRIMARY_WORKTREE" != "$CURRENT_DIR" ]]; then
+    echo "Updating primary worktree at $PRIMARY_WORKTREE..."
+    git -C "$PRIMARY_WORKTREE" pull origin "$base_branch"
+    echo "✅ Primary worktree updated"
+else
+    echo "No separate primary worktree to update"
+fi
+```
+
 ### 13. Extract post-merge tasks
 
 **Read PR description:**
@@ -652,6 +670,8 @@ Linear ticket → Done (if Linearis available)
 Branches deleted
     ↓
 Base branch updated locally
+    ↓
+Primary worktree updated (if separate)
     ↓
 Post-merge tasks extracted
     ↓

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,7 +2,9 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import sitemap from "@astrojs/sitemap";
 import starlightLlmsTxt from "starlight-llms-txt";
-import starlightChangelogs from "starlight-changelogs";
+import starlightChangelogs, {
+  makeChangelogsSidebarLinks,
+} from "starlight-changelogs";
 import mermaid from "astro-mermaid";
 
 export default defineConfig({
@@ -37,6 +39,61 @@ export default defineConfig({
         {
           label: "Plugins",
           autogenerate: { directory: "plugins" },
+        },
+        {
+          label: "Changelogs",
+          items: [
+            {
+              label: "catalyst-dev",
+              items: makeChangelogsSidebarLinks([
+                {
+                  type: "all",
+                  base: "changelog/catalyst-dev",
+                  label: "All Versions",
+                },
+              ]),
+            },
+            {
+              label: "catalyst-pm",
+              items: makeChangelogsSidebarLinks([
+                {
+                  type: "all",
+                  base: "changelog/catalyst-pm",
+                  label: "All Versions",
+                },
+              ]),
+            },
+            {
+              label: "catalyst-meta",
+              items: makeChangelogsSidebarLinks([
+                {
+                  type: "all",
+                  base: "changelog/catalyst-meta",
+                  label: "All Versions",
+                },
+              ]),
+            },
+            {
+              label: "catalyst-analytics",
+              items: makeChangelogsSidebarLinks([
+                {
+                  type: "all",
+                  base: "changelog/catalyst-analytics",
+                  label: "All Versions",
+                },
+              ]),
+            },
+            {
+              label: "catalyst-debugging",
+              items: makeChangelogsSidebarLinks([
+                {
+                  type: "all",
+                  base: "changelog/catalyst-debugging",
+                  label: "All Versions",
+                },
+              ]),
+            },
+          ],
         },
       ],
       head: [

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import sitemap from "@astrojs/sitemap";
@@ -6,6 +7,20 @@ import starlightChangelogs, {
   makeChangelogsSidebarLinks,
 } from "starlight-changelogs";
 import mermaid from "astro-mermaid";
+
+function getLatestVersion(changelogPath) {
+  const content = readFileSync(new URL(changelogPath, import.meta.url), "utf8");
+  const match = content.match(/^## \[(\d+\.\d+\.\d+)]/m);
+  return match ? match[1] : null;
+}
+
+const plugins = [
+  { name: "catalyst-dev", changelog: "../plugins/dev/CHANGELOG.md" },
+  { name: "catalyst-pm", changelog: "../plugins/pm/CHANGELOG.md" },
+  { name: "catalyst-meta", changelog: "../plugins/meta/CHANGELOG.md" },
+  { name: "catalyst-analytics", changelog: "../plugins/analytics/CHANGELOG.md" },
+  { name: "catalyst-debugging", changelog: "../plugins/debugging/CHANGELOG.md" },
+];
 
 export default defineConfig({
   site: "https://catalyst.coalescelabs.ai",
@@ -42,33 +57,16 @@ export default defineConfig({
         },
         {
           label: "Changelogs",
-          items: makeChangelogsSidebarLinks([
-            {
-              type: "all",
-              base: "changelog/catalyst-dev",
-              label: "catalyst-dev",
-            },
-            {
-              type: "all",
-              base: "changelog/catalyst-pm",
-              label: "catalyst-pm",
-            },
-            {
-              type: "all",
-              base: "changelog/catalyst-meta",
-              label: "catalyst-meta",
-            },
-            {
-              type: "all",
-              base: "changelog/catalyst-analytics",
-              label: "catalyst-analytics",
-            },
-            {
-              type: "all",
-              base: "changelog/catalyst-debugging",
-              label: "catalyst-debugging",
-            },
-          ]),
+          items: makeChangelogsSidebarLinks(
+            plugins.map(({ name, changelog }) => {
+              const version = getLatestVersion(changelog);
+              return {
+                type: "all",
+                base: `changelog/${name}`,
+                label: version ? `${name} v${version}` : name,
+              };
+            }),
+          ),
         },
       ],
       head: [

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -42,58 +42,33 @@ export default defineConfig({
         },
         {
           label: "Changelogs",
-          items: [
+          items: makeChangelogsSidebarLinks([
             {
+              type: "all",
+              base: "changelog/catalyst-dev",
               label: "catalyst-dev",
-              items: makeChangelogsSidebarLinks([
-                {
-                  type: "all",
-                  base: "changelog/catalyst-dev",
-                  label: "All Versions",
-                },
-              ]),
             },
             {
+              type: "all",
+              base: "changelog/catalyst-pm",
               label: "catalyst-pm",
-              items: makeChangelogsSidebarLinks([
-                {
-                  type: "all",
-                  base: "changelog/catalyst-pm",
-                  label: "All Versions",
-                },
-              ]),
             },
             {
+              type: "all",
+              base: "changelog/catalyst-meta",
               label: "catalyst-meta",
-              items: makeChangelogsSidebarLinks([
-                {
-                  type: "all",
-                  base: "changelog/catalyst-meta",
-                  label: "All Versions",
-                },
-              ]),
             },
             {
+              type: "all",
+              base: "changelog/catalyst-analytics",
               label: "catalyst-analytics",
-              items: makeChangelogsSidebarLinks([
-                {
-                  type: "all",
-                  base: "changelog/catalyst-analytics",
-                  label: "All Versions",
-                },
-              ]),
             },
             {
+              type: "all",
+              base: "changelog/catalyst-debugging",
               label: "catalyst-debugging",
-              items: makeChangelogsSidebarLinks([
-                {
-                  type: "all",
-                  base: "changelog/catalyst-debugging",
-                  label: "All Versions",
-                },
-              ]),
             },
-          ],
+          ]),
         },
       ],
       head: [

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -63,7 +63,7 @@ cat plugins/dev/templates/CLAUDE_SNIPPET.md >> .claude/CLAUDE.md
 Start a Claude Code session and run:
 
 ```
-/catalyst-dev:research_codebase
+/research-codebase
 ```
 
 Follow the prompts to research your codebase. Catalyst will spawn parallel agents, document what exists, and save findings to `thoughts/shared/research/`.

--- a/website/src/content/docs/getting-started/introduction.mdx
+++ b/website/src/content/docs/getting-started/introduction.mdx
@@ -28,7 +28,7 @@ Catalyst is a plugin system for Claude Code. It chains together four types of bu
 
 <CardGrid>
   <Card title="Skills" icon="rocket">
-    The core unit of Catalyst functionality. Some skills are **user-invocable** — structured workflows you trigger with a slash command (`/catalyst-dev:commit`). Others are **model-invocable** — reference knowledge that Claude activates automatically when it detects relevant context, like seeing a ticket ID. Skills orchestrate multi-step processes, spawn agents, and save artifacts.
+    The core unit of Catalyst functionality. Some skills are **user-invocable** — structured workflows you trigger with a slash command (`/commit`). Others are **model-invocable** — reference knowledge that Claude activates automatically when it detects relevant context, like seeing a ticket ID. Skills orchestrate multi-step processes, spawn agents, and save artifacts.
   </Card>
   <Card title="Agents" icon="magnifier">
     Specialized roles that skills delegate to. A locator agent finds files. An analyzer agent reads implementation details. A pattern-finder agent discovers reusable code. Skills spawn these in parallel to gather information fast — and each agent gets its own context window, so it can focus deeply on one thing.
@@ -49,10 +49,10 @@ The central pattern in Catalyst is the **RPI workflow** — research, plan, impl
 
 ```mermaid
 graph LR
-    R["/research_codebase"] --> P["/create_plan"]
-    P --> I["/implement_plan"]
-    I --> V["/validate_plan"]
-    V --> S["/create_pr"]
+    R["/research-codebase"] --> P["/create-plan"]
+    P --> I["/implement-plan"]
+    I --> V["/validate-plan"]
+    V --> S["/create-pr"]
 
     style R fill:#2563eb,color:#fff,stroke:none
     style P fill:#7c3aed,color:#fff,stroke:none
@@ -61,19 +61,19 @@ graph LR
     style S fill:#dc2626,color:#fff,stroke:none
 ```
 
-**Research** — `/research_codebase` spawns parallel agents (locator, analyzer, pattern-finder) that fan out across the codebase and report back. External tools like DeepWiki and Context7 pull in library docs and open-source patterns. The output is a research document saved to persistent storage.
+**Research** — `/research-codebase` spawns parallel agents (locator, analyzer, pattern-finder) that fan out across the codebase and report back. External tools like DeepWiki and Context7 pull in library docs and open-source patterns. The output is a research document saved to persistent storage.
 
-**Plan** — `/create_plan` reads the research, then works with you interactively to build an implementation plan. Phases, success criteria, file-level specifics. The plan is a contract — both you and the AI agree on what gets built before any code is written.
+**Plan** — `/create-plan` reads the research, then works with you interactively to build an implementation plan. Phases, success criteria, file-level specifics. The plan is a contract — both you and the AI agree on what gets built before any code is written.
 
-**Implement** — `/implement_plan` reads the full plan and executes it phase by phase. Each phase has automated verification. Checkboxes update as work completes. Subagents handle individual tasks — not just for parallelism, but so each agent gets a focused job and can use its full context window on that one thing.
+**Implement** — `/implement-plan` reads the full plan and executes it phase by phase. Each phase has automated verification. Checkboxes update as work completes. Subagents handle individual tasks — not just for parallelism, but so each agent gets a focused job and can use its full context window on that one thing.
 
-**Validate** — `/validate_plan` verifies the implementation against the plan's success criteria. Tests pass. Behavior matches. Deviations are documented.
+**Validate** — `/validate-plan` verifies the implementation against the plan's success criteria. Tests pass. Behavior matches. Deviations are documented.
 
-**Ship** — `/create_pr` generates a PR description from the work, links to the Linear ticket, and pushes. `/merge_pr` handles the merge with verification.
+**Ship** — `/create-pr` generates a PR description from the work, links to the Linear ticket, and pushes. `/merge-pr` handles the merge with verification.
 
 ### Clean Handoffs Between Phases
 
-Each phase clears context and starts fresh — that's by design. Long-running sessions are where AI loses the thread. Instead, Catalyst uses **handoff checkpoints** (`/create_handoff` and `/resume_handoff`) to compress what the AI knows into a persistent document before moving on. The next phase picks up exactly where the last one left off, with clean context and no drift.
+Each phase clears context and starts fresh — that's by design. Long-running sessions are where AI loses the thread. Instead, Catalyst uses **handoff checkpoints** (`/create-handoff` and `/resume-handoff`) to compress what the AI knows into a persistent document before moving on. The next phase picks up exactly where the last one left off, with clean context and no drift.
 
 This happens automatically between workflow phases, but you can also create handoffs manually — mid-implementation when context is getting long, at the end of a session, or when passing work to a teammate. Every handoff is a snapshot: what was done, what's left, and what decisions were made.
 
@@ -83,19 +83,19 @@ The workflow runs on a few key pieces of infrastructure:
 
 - **Thoughts system** — Think of it like a shared S3 bucket for everything the AI has done: research, plans, handoffs, PR descriptions. It's git-backed, shared across worktrees and sessions, and it's how any agent — in any session — can come back and understand what happened before.
 - **Worktrees** — Catalyst is designed around git worktrees so you can have multiple features in flight at once. Each worktree gets its own workspace, its own branch, and its own local state — but they all share the same thoughts repo.
-- **Workflow context** — Local state that tracks what you've done in this worktree. It's what lets `/create_plan` automatically find your latest research and `/implement_plan` find your latest plan — no file paths to remember.
+- **Workflow context** — Local state that tracks what you've done in this worktree. It's what lets `/create-plan` automatically find your latest research and `/implement-plan` find your latest plan — no file paths to remember.
 - **Subagents** — Commands spawn specialized agents, each with a focused job and a full context window dedicated to it. A locator agent searches the whole codebase for relevant files. An analyzer agent reads those files deeply. They work in parallel, but the real benefit is focus — each agent reasons about one thing well instead of juggling everything at once.
 - **Third-party integrations** — Linear for tickets, GitHub for PRs, DeepWiki and Context7 for external documentation, Sentry for error investigation.
 
 ## What This Looks Like in Practice
 
-You start a session. You run `/research_codebase` and describe what you need to understand. Three agents fan out across the codebase, find relevant files, analyze patterns, and report back. A research document lands in your thoughts repo. Context is clean.
+You start a session. You run `/research-codebase` and describe what you need to understand. Three agents fan out across the codebase, find relevant files, analyze patterns, and report back. A research document lands in your thoughts repo. Context is clean.
 
-You run `/create_plan`. Catalyst picks up the research automatically, and you work together to design the implementation. Phases, files, success criteria. When you're satisfied, the plan saves. If the session is getting long, `/create_handoff` compresses everything into a checkpoint — you can resume later or hand it to a fresh session.
+You run `/create-plan`. Catalyst picks up the research automatically, and you work together to design the implementation. Phases, files, success criteria. When you're satisfied, the plan saves. If the session is getting long, `/create-handoff` compresses everything into a checkpoint — you can resume later or hand it to a fresh session.
 
-You run `/implement_plan`. Catalyst reads the full plan and starts building — phase by phase, with verification at each step. When it's done, you run `/validate_plan` to confirm everything matches the spec.
+You run `/implement-plan`. Catalyst reads the full plan and starts building — phase by phase, with verification at each step. When it's done, you run `/validate-plan` to confirm everything matches the spec.
 
-You run `/create_pr`. A PR with a structured description, linked to your Linear ticket, ready for review.
+You run `/create-pr`. A PR with a structured description, linked to your Linear ticket, ready for review.
 
 Research to shipped PR. Each step is structured, each handoff is clean, and humans approve at every gate.
 

--- a/website/src/content/docs/getting-started/multi-project.md
+++ b/website/src/content/docs/getting-started/multi-project.md
@@ -86,7 +86,7 @@ thoughts/
 ```bash
 cd ~/code-repos/my-project
 humanlayer thoughts init --profile coalesce-labs
-/catalyst-dev:create_plan  # Works as normal
+/create-plan  # Works as normal
 ```
 
 ### Starting Work on a Client Project
@@ -94,7 +94,7 @@ humanlayer thoughts init --profile coalesce-labs
 ```bash
 cd ~/code-repos/github/acme/project
 humanlayer thoughts init --profile acme
-/catalyst-dev:create_plan  # Uses client-specific context
+/create-plan  # Uses client-specific context
 ```
 
 ## Backup Strategy

--- a/website/src/content/docs/plugins/index.md
+++ b/website/src/content/docs/plugins/index.md
@@ -50,7 +50,7 @@ Most sessions start with just `catalyst-dev` (~3.5K tokens) and enable heavier p
 Each plugin contains:
 
 - **agents/** — Specialized research agents
-- **skills/** — Workflow skills (invoked via `/plugin:skill_name`)
+- **skills/** — Workflow skills (invoked via `/skill-name`)
 - **scripts/** — Runtime utilities
 - **hooks/** — Automatic triggers (e.g., workflow context tracking)
 - **plugin.json** — Manifest with metadata and dependencies

--- a/website/src/content/docs/reference/agents.md
+++ b/website/src/content/docs/reference/agents.md
@@ -1,6 +1,6 @@
 ---
 title: Agents
-description: Complete reference for research agents, patterns, team configuration, and creating custom agents.
+description: Complete reference for research agents, patterns, team configuration, and invoking agents.
 sidebar:
   order: 1
 ---
@@ -11,51 +11,99 @@ Agents are specialized roles that skills delegate to. Each agent has a focused j
 
 ### Research Agents
 
-| Agent | Purpose | Tools | Model |
-|-------|---------|-------|-------|
-| `codebase-locator` | Find files, directories, and components | Grep, Glob, Bash(ls) | Haiku |
-| `codebase-analyzer` | Understand implementation details and patterns | Read, Grep, Glob | Sonnet |
-| `codebase-pattern-finder` | Find reusable patterns and code examples | Read, Grep, Glob | Sonnet |
-| `thoughts-locator` | Search thoughts repository for relevant documents | Grep, Glob, Bash(ls) | Haiku |
-| `thoughts-analyzer` | Analyze documentation and decisions | Read, Grep, Glob | Sonnet |
-| `external-research` | Research external repos and libraries | DeepWiki, Context7, Exa | Sonnet |
+| Agent | Purpose | Tools | Model | Source |
+|-------|---------|-------|-------|--------|
+| `codebase-locator` | Find files, directories, and components | Grep, Glob, Bash(ls) | Haiku | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/codebase-locator.md) |
+| `codebase-analyzer` | Understand implementation details and patterns | Read, Grep, Glob | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/codebase-analyzer.md) |
+| `codebase-pattern-finder` | Find reusable patterns and code examples | Read, Grep, Glob | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/codebase-pattern-finder.md) |
+| `thoughts-locator` | Search thoughts repository for relevant documents | Grep, Glob, Bash(ls) | Haiku | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/thoughts-locator.md) |
+| `thoughts-analyzer` | Analyze documentation and decisions | Read, Grep, Glob | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/thoughts-analyzer.md) |
+| `external-research` | Research external repos and libraries | DeepWiki, Context7, Exa | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/external-research.md) |
 
 ### Infrastructure Agents
 
-| Agent | Purpose | Tools | Model |
-|-------|---------|-------|-------|
-| `linear-research` | Gather Linear data via CLI | Bash(linearis) | Haiku |
-| `github-research` | Research GitHub PRs and issues | Bash(gh) | Haiku |
-| `sentry-research` | Research Sentry errors | Bash(sentry-cli) | Haiku |
+| Agent | Purpose | Tools | Model | Source |
+|-------|---------|-------|-------|--------|
+| `linear-research` | Gather Linear data via CLI | Bash(linearis) | Haiku | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/linear-research.md) |
+| `github-research` | Research GitHub PRs and issues | Bash(gh) | Haiku | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/github-research.md) |
+| `sentry-research` | Research Sentry errors | Bash(sentry-cli) | Haiku | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/agents/sentry-research.md) |
 
 ## catalyst-pm Agents
 
 ### Research Agents
 
-| Agent | Purpose | Model |
-|-------|---------|-------|
-| `linear-research` | Gather cycle, issue, and milestone data | Haiku |
+| Agent | Purpose | Model | Source |
+|-------|---------|-------|--------|
+| `linear-research` | Gather cycle, issue, and milestone data | Haiku | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/pm/agents/linear-research.md) |
 
 ### Analyzer Agents
 
-| Agent | Purpose | Model |
-|-------|---------|-------|
-| `cycle-analyzer` | Transform cycle data into health insights | Sonnet |
-| `milestone-analyzer` | Analyze milestone progress toward target dates | Sonnet |
-| `backlog-analyzer` | Analyze backlog health and organization | Sonnet |
-| `github-linear-analyzer` | Correlate GitHub PRs with Linear issues | Sonnet |
-| `context-analyzer` | Track context engineering adoption | Sonnet |
+| Agent | Purpose | Model | Source |
+|-------|---------|-------|--------|
+| `cycle-analyzer` | Transform cycle data into health insights | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/pm/agents/cycle-analyzer.md) |
+| `milestone-analyzer` | Analyze milestone progress toward target dates | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/pm/agents/milestone-analyzer.md) |
+| `backlog-analyzer` | Analyze backlog health and organization | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/pm/agents/backlog-analyzer.md) |
+| `github-linear-analyzer` | Correlate GitHub PRs with Linear issues | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/pm/agents/github-linear-analyzer.md) |
+| `context-analyzer` | Track context engineering adoption | Sonnet | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/pm/agents/context-analyzer.md) |
 
 ## When to Use Which Agent
 
-| Agent | Question it Answers |
-|-------|-------------------|
-| `codebase-locator` | Where is X? |
-| `codebase-analyzer` | How does X work? |
-| `codebase-pattern-finder` | Show me examples of X |
-| `thoughts-locator` | What do we know about X? |
-| `thoughts-analyzer` | What were the decisions about X? |
-| `external-research` | What do libraries/docs say about X? |
+Most of the time, **you don't invoke agents directly**. Skills like `/research-codebase` and `/create-plan` spawn the right agents automatically based on what you ask. When you run `/research-codebase`, Catalyst decides which combination of locators, analyzers, and pattern finders to launch in parallel — you just describe what you want to understand.
+
+That said, you can invoke any agent directly when you have a quick, focused question and don't need a full research workflow:
+
+| Agent | Question it Answers | Example |
+|-------|-------------------|---------|
+| `codebase-locator` | Where is X? | "Find all payment-related files" |
+| `codebase-analyzer` | How does X work? | "Trace the authentication flow" |
+| `codebase-pattern-finder` | Show me examples of X | "Show me how we handle API errors" |
+| `thoughts-locator` | What do we know about X? | "Find research on caching strategy" |
+| `thoughts-analyzer` | What were the decisions about X? | "What did we decide about the DB schema?" |
+| `external-research` | What do libraries/docs say about X? | "How does React Server Components work?" |
+
+## Invoking Agents
+
+Use the `@` prefix with the plugin name and agent name:
+
+```
+@catalyst-dev:codebase-locator find all payment-related files
+@catalyst-dev:codebase-analyzer trace the authentication flow in src/auth/
+@catalyst-pm:linear-research get current cycle issues
+```
+
+Claude Code has auto-complete for this — type `@catalyst` and it will suggest available agents.
+
+### When to Invoke Directly vs Use a Skill
+
+**Use a skill** (`/research-codebase`) when you want a comprehensive, multi-agent research workflow that saves artifacts for later phases. Skills coordinate multiple agents, manage context, and persist results.
+
+**Invoke an agent directly** (`@catalyst-dev:codebase-locator`) when you have a quick, one-off question that doesn't need the full workflow. This is faster and uses less context.
+
+```
+# Full research workflow — spawns multiple agents, saves to thoughts/
+/research-codebase how does the payment system handle refunds?
+
+# Quick direct question — just the locator agent
+@catalyst-dev:codebase-locator find refund handler files
+```
+
+### Parallel vs Sequential
+
+**Use parallel** when researching independent aspects:
+
+```
+@catalyst-dev:codebase-locator find payment files
+@catalyst-dev:thoughts-locator search payment research
+@catalyst-dev:codebase-pattern-finder show payment patterns
+```
+
+**Use sequential** when each step depends on the previous:
+
+```
+@catalyst-dev:codebase-locator find auth files
+# Wait for results
+@catalyst-dev:codebase-analyzer analyze src/auth/handler.js
+```
 
 ## Agent Patterns
 
@@ -84,36 +132,6 @@ Agents follow five core patterns:
 | 1 | **Opus** | Planning, complex analysis, implementation orchestration |
 | 2 | **Sonnet** | Code analysis, PR workflows, structured research |
 | 3 | **Haiku** | Fast lookups, data collection, file finding |
-
-## Invoking Agents
-
-Agents are invoked via the `@` prefix:
-
-```
-@catalyst-dev:codebase-locator find payment files
-@catalyst-dev:codebase-analyzer trace authentication flow
-@catalyst-dev:external-research query React Server Components patterns
-```
-
-Skills spawn agents automatically — you rarely need to invoke them directly.
-
-### Parallel vs Sequential
-
-**Use parallel** when researching independent aspects:
-
-```
-@catalyst-dev:codebase-locator find payment files
-@catalyst-dev:thoughts-locator search payment research
-@catalyst-dev:codebase-pattern-finder show payment patterns
-```
-
-**Use sequential** when each step depends on the previous:
-
-```
-@catalyst-dev:codebase-locator find auth files
-# Wait for results
-@catalyst-dev:codebase-analyzer analyze src/auth/handler.js
-```
 
 ## Agent Teams
 
@@ -144,8 +162,8 @@ Lead (Opus) — Coordinates implementation
 Each teammate is a full Claude Code session that can spawn its own subagents — two-level parallelism that subagents alone cannot achieve.
 
 ```
-/catalyst-dev:implement_plan --team
-/catalyst-dev:oneshot --team PROJ-123
+/implement-plan --team
+/oneshot --team PROJ-123
 ```
 
 ### Requirements
@@ -153,93 +171,3 @@ Each teammate is a full Claude Code session that can spawn its own subagents —
 ```bash
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 ```
-
-## Creating Custom Agents and Skills
-
-### Agent Template
-
-Agents are markdown files in `plugins/<plugin>/agents/` with YAML frontmatter:
-
-```yaml
----
-name: my-agent
-description: |
-  What this agent does.
-
-  Use this agent when:
-  - Scenario 1
-  - Scenario 2
-tools: Read, Grep
----
-
-# My Agent
-
-You are a specialized agent for [purpose].
-
-## Process
-
-1. Step one
-2. Step two
-
-## Output
-
-Return findings in this format:
-- `path/to/file:line` — Description
-
-## What NOT to Do
-
-- Don't [boundary 1]
-- Don't [boundary 2]
-```
-
-#### Agent Frontmatter Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | kebab-case, must match filename (without `.md`) |
-| `description` | Yes | Multi-line with use cases |
-| `tools` | Yes | Comma-separated list of allowed Claude Code tools |
-| `source` | No | URL if imported from external source |
-
-### Skill Template
-
-Skills are markdown files at `plugins/<plugin>/skills/<skill-name>/SKILL.md`:
-
-```yaml
----
-name: my-skill
-description: One-line summary of what this skill does
-disable-model-invocation: true
-allowed-tools: Read, Write
-version: 1.0.0
----
-
-# Skill Name
-
-You are tasked with [purpose].
-
-## Process
-
-1. Step one
-2. Step two
-```
-
-#### Skill Frontmatter Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | kebab-case, must match directory name |
-| `description` | Yes | One-line summary |
-| `disable-model-invocation` | Conditional | Set `true` for user-invoked-only skills |
-| `user-invocable` | Conditional | Set `false` for CI/background skills |
-| `allowed-tools` | No | Comma-separated list of allowed Claude Code tools |
-| `version` | No | Semantic version |
-
-Do **not** include `model`, `category`, or `tools` (use `allowed-tools` instead).
-
-### Testing
-
-1. Edit files in the appropriate `plugins/<plugin>/` directory
-2. Restart Claude Code to reload
-3. Invoke with `@catalyst-dev:{agent-name}` or `/catalyst-dev:{skill-name}`
-4. Validate with `/catalyst-meta:validate_frontmatter`

--- a/website/src/content/docs/reference/skills.md
+++ b/website/src/content/docs/reference/skills.md
@@ -1,5 +1,5 @@
 ---
-title: Skills Reference
+title: Skills
 description: Complete reference for all skills across Catalyst plugins — user-invocable and model-invocable.
 sidebar:
   order: 0
@@ -11,7 +11,7 @@ Skills are reusable capabilities delivered as markdown files that teach Claude C
 
 There are two types of skills, distinguished by **who activates them**:
 
-**User-invocable skills** are structured workflows you trigger with a slash command (`/catalyst-dev:commit`). They orchestrate multi-step processes — spawning agents, reading context, interacting with you, and saving artifacts.
+**User-invocable skills** are structured workflows you trigger with a slash command. They orchestrate multi-step processes — spawning agents, reading context, interacting with you, and saving artifacts.
 
 **Model-invocable skills** are reference knowledge that Claude activates automatically when it detects relevant context. For example, when Claude sees a ticket ID like `ACME-123`, the `linearis` skill activates and teaches Claude how to use the Linearis CLI — without you having to explain it. These skills shape Claude's behavior the way a README or style guide would, but they load on demand instead of consuming context all the time.
 
@@ -21,7 +21,19 @@ A third category, **CI skills**, are non-interactive variants designed for autom
 
 For more on how Claude Code skills work under the hood, see [Anthropic's skills documentation](https://docs.anthropic.com/en/docs/claude-code/skills).
 
-**Legend**: User column: checkmark = invoke with `/plugin:skill` | Model column: checkmark = Claude activates automatically | `CI` = non-interactive, for automation pipelines
+## Invoking Skills
+
+Type `/` followed by the skill name:
+
+```
+/research-codebase
+/commit
+/create-plan
+```
+
+Claude Code has excellent auto-complete — start typing `/res` and it will suggest `/research-codebase`. You don't need to include the plugin name; Claude Code resolves skills across all installed plugins automatically.
+
+**Legend**: User column: checkmark = invoke with `/skill-name` | Model column: checkmark = Claude activates automatically | `CI` = non-interactive, for automation pipelines
 
 ## catalyst-dev
 

--- a/website/src/content/docs/reference/workflows.md
+++ b/website/src/content/docs/reference/workflows.md
@@ -15,32 +15,32 @@ sequenceDiagram
     participant CC as Claude Code
     participant T as Thoughts System
 
-    Dev->>CC: /catalyst-dev:research_codebase
+    Dev->>CC: /research-codebase
     CC->>CC: Spawn agents (locator, analyzer, pattern-finder)
     CC->>T: Save research document
     Note over Dev,CC: Clear context
 
-    Dev->>CC: /catalyst-dev:create_plan
+    Dev->>CC: /create-plan
     CC->>T: Read recent research
     CC->>Dev: Interactive planning
     CC->>T: Save implementation plan
     Note over Dev,CC: Clear context
 
-    Dev->>CC: /catalyst-dev:implement_plan
+    Dev->>CC: /implement-plan
     CC->>T: Read plan
     CC->>CC: Implement phase by phase
     Note over Dev,CC: Clear context
 
-    Dev->>CC: /catalyst-dev:validate_plan
+    Dev->>CC: /validate-plan
     CC->>CC: Run tests, verify criteria
-    Dev->>CC: /catalyst-dev:create_pr
+    Dev->>CC: /create-pr
     CC->>T: Save PR description
 ```
 
 ### 1. Research
 
 ```
-/catalyst-dev:research_codebase
+/research-codebase
 ```
 
 Describe what you want to understand. Catalyst spawns parallel research agents (locator, analyzer, pattern-finder), documents what exists in the codebase, and saves findings to `thoughts/shared/research/`.
@@ -50,19 +50,19 @@ Clear context after research completes. The research document persists — the n
 ### 2. Plan
 
 ```
-/catalyst-dev:create_plan
+/create-plan
 ```
 
 Catalyst auto-discovers your most recent research, reads it, and interactively builds a plan with you — including automated AND manual success criteria. Saved to `thoughts/shared/plans/`.
 
-If revisions are needed: `/catalyst-dev:iterate_plan`.
+If revisions are needed: `/iterate-plan`.
 
 Clear context after the plan is approved.
 
 ### 3. Implement
 
 ```
-/catalyst-dev:implement_plan
+/implement-plan
 ```
 
 Catalyst auto-finds your most recent plan, reads it fully, and implements each phase sequentially with automated verification after each phase. Checkboxes update as work completes.
@@ -70,7 +70,7 @@ Catalyst auto-finds your most recent plan, reads it fully, and implements each p
 ### 4. Validate
 
 ```
-/catalyst-dev:validate_plan
+/validate-plan
 ```
 
 Verifies all success criteria, runs automated test suites, documents deviations, and provides a manual testing checklist.
@@ -78,7 +78,7 @@ Verifies all success criteria, runs automated test suites, documents deviations,
 ### 5. Ship
 
 ```
-/catalyst-dev:create_pr
+/create-pr
 ```
 
 Creates a pull request with a description generated from your research and plan, linked to the relevant ticket.
@@ -90,13 +90,13 @@ Creates a pull request with a description generated from your research and plan,
 The standard flow for a well-scoped ticket:
 
 ```bash
-/catalyst-dev:research_codebase          # Research
+/research-codebase          # Research
 # Clear context
-/catalyst-dev:create_plan                # Plan
+/create-plan                # Plan
 # Clear context
-/catalyst-dev:implement_plan             # Implement
+/implement-plan             # Implement
 # Clear context
-/catalyst-dev:commit && /catalyst-dev:create_pr  # Ship
+/commit && /create-pr  # Ship
 ```
 
 ### Multi-Day Feature
@@ -105,21 +105,21 @@ For larger work that spans sessions:
 
 ```bash
 # Day 1
-/catalyst-dev:research_codebase
-/catalyst-dev:create_handoff
+/research-codebase
+/create-handoff
 # Day 2
-/catalyst-dev:resume_handoff
-/catalyst-dev:create_plan
-/catalyst-dev:create_handoff
+/resume-handoff
+/create-plan
+/create-handoff
 # Day 3
-/catalyst-dev:resume_handoff
-/catalyst-dev:implement_plan             # Phases 1-2
-/catalyst-dev:create_handoff
+/resume-handoff
+/implement-plan             # Phases 1-2
+/create-handoff
 # Day 4
-/catalyst-dev:resume_handoff
-/catalyst-dev:implement_plan             # Phases 3-4
-/catalyst-dev:validate_plan
-/catalyst-dev:commit && /catalyst-dev:create_pr
+/resume-handoff
+/implement-plan             # Phases 3-4
+/validate-plan
+/commit && /create-pr
 ```
 
 ### One-Shot
@@ -127,7 +127,7 @@ For larger work that spans sessions:
 For straightforward tasks, chain the entire workflow:
 
 ```
-/catalyst-dev:oneshot PROJ-123
+/oneshot PROJ-123
 ```
 
 Runs research, planning, and implementation in a single invocation with context isolation between phases.
@@ -139,13 +139,13 @@ Each phase ends with "clear context" — that's intentional. Long sessions are w
 If you need to pause mid-workflow (end of day, context getting long, waiting on something), create a handoff:
 
 ```
-/catalyst-dev:create_handoff
+/create-handoff
 ```
 
 This compresses the current session into a persistent document: what was done, what's left, decisions made, and file references. Resume later with:
 
 ```
-/catalyst-dev:resume_handoff
+/resume-handoff
 ```
 
 Handoffs are cheap (under a minute) and you should use them liberally.
@@ -154,9 +154,9 @@ Handoffs are cheap (under a minute) and you should use them liberally.
 
 You don't need to specify file paths between skills. Catalyst tracks your workflow automatically:
 
-- `research_codebase` saves research → `create_plan` auto-references it
-- `create_plan` saves plan → `implement_plan` auto-finds it
-- `create_handoff` saves handoff → `resume_handoff` auto-finds it
+- `research-codebase` saves research → `create-plan` auto-references it
+- `create-plan` saves plan → `implement-plan` auto-finds it
+- `create-handoff` saves handoff → `resume-handoff` auto-finds it
 
 ## Parallel Development with Worktrees
 
@@ -171,7 +171,7 @@ Git worktrees let you work on multiple features simultaneously, each in its own 
 ### Creating a Worktree
 
 ```
-/catalyst-dev:create_worktree PROJ-123 feature-name
+/create-worktree PROJ-123 feature-name
 ```
 
 This creates a git worktree at `~/wt/{project}/{PROJ-123-feature-name}/` with a new branch, `.claude/` copied over, dependencies installed, and `thoughts/` shared via symlink.
@@ -183,15 +183,15 @@ Run separate Claude Code sessions in different worktrees:
 ```bash
 # Terminal 1 — Feature A
 cd ~/wt/api/PROJ-123-feature-a && claude
-/catalyst-dev:implement_plan
+/implement-plan
 
 # Terminal 2 — Feature B
 cd ~/wt/api/PROJ-456-feature-b && claude
-/catalyst-dev:implement_plan
+/implement-plan
 
 # Terminal 3 — Research (main repo)
 cd ~/projects/api && claude
-/catalyst-dev:research_codebase
+/research-codebase
 ```
 
 All worktrees share the same thoughts directory via symlink. Plans created in one worktree are visible in all others.


### PR DESCRIPTION
## Summary

- **merge-pr skill**: Add primary worktree update step after merge so the main repo stays current without manual `git pull`
- **Website docs**: Remove outdated `/plugin:skill` invocation syntax across all reference pages, update to current `/skill-name` format with auto-complete guidance
- **Agents reference**: Add Source column with GitHub links to all agent tables, rewrite "When to Use Which Agent" and "Invoking Agents" sections to explain automatic vs direct invocation, remove developer-only "Creating Custom Agents and Skills" section
- **Skills reference**: Add "Invoking Skills" section, simplify title

## Changes

| File | Change |
|------|--------|
| `plugins/dev/skills/merge-pr/SKILL.md` | Add worktree update step after merge |
| `website/.../reference/agents.md` | Source links, invocation guidance, remove dev templates |
| `website/.../reference/skills.md` | Add invocation section, drop "Reference" from title |
| `website/.../reference/workflows.md` | Remove plugin prefixes from skill invocations |
| `website/.../getting-started/*` | Remove plugin prefixes from examples |
| `website/.../plugins/index.md` | Remove plugin prefix from skill invocation |
| `.claude/rules/website-docs.md` | Update terminology to match new conventions |

## Test plan

- [ ] Verify website builds without errors
- [ ] Check all Source links in agents reference resolve to valid GitHub URLs
- [ ] Confirm skill invocation examples use `/skill-name` format (no plugin prefix)