### PR TITLE
fix(dev): combined release PRs + auto-merge

### DIFF
--- a/.claude/rules/plugin-editing.md
+++ b/.claude/rules/plugin-editing.md
@@ -28,3 +28,5 @@ paths: ["plugins/**"]
 - Version lives in plugin.json only (each plugin's `.claude-plugin/plugin.json`)
 - marketplace.json is a discovery manifest only — it must NOT have version fields
 - release-please updates both version.txt and plugin.json via extra-files
+- All plugins share a single combined release PR (avoids manifest conflicts)
+- Release PRs auto-merge via `--squash --auto` in the workflow

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -17,3 +18,10 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} --squash --auto

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "bootstrap-sha": "e494235",
   "packages": {
     "plugins/dev": {


### PR DESCRIPTION
## Summary

- **Combined release PRs**: Switch from `separate-pull-requests: true` to `false`. Separate PRs all touch `.release-please-manifest.json`, causing serial conflicts that require manual intervention after each merge. A combined PR updates all changed plugins atomically.
- **Auto-merge**: Release PRs now auto-merge (`--squash --auto`) so you don't have to manually merge them or risk forgetting.
- **Manual trigger**: Added `workflow_dispatch` so release-please can be re-triggered without a push to main.
- **Closed stuck PRs**: #33, #34, #36 were conflicting and unmergeable. They'll be superseded by a single combined PR after this merges.

## Context

After merging PR #32 (which fixed the release-please pipeline), release-please correctly created 5 release PRs. We merged #37 (catalyst-dev 5.1.0) and #35 (catalyst-debugging 1.3.0), but the remaining 3 had manifest conflicts. This change prevents that from happening again.

## Test plan
- [x] `validate-release-config.sh` passes (all 8 checks)
- [ ] After merge: release-please creates a single combined PR for pm, analytics, meta
- [ ] After merge: combined PR auto-merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)