### PR TITLE
fix(dev): upgrade linearis CLI and fix skill command syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,14 @@ This workspace has no build process - it's markdown files and bash scripts.
 - `chore(meta): update docs` — no version bump
 - Valid scopes: `dev`, `pm`, `meta`, `analytics`, `debugging`
 
+**How release-please routes version bumps (monorepo):**
+- Routing is by **file paths changed**, NOT by commit message scope. A commit touching files in
+  both `plugins/dev/` and `plugins/pm/` bumps both plugins regardless of scope.
+- The `(scope)` in `fix(dev):` controls **changelog grouping**, not which plugin gets bumped.
+- Squash merges work correctly — GitHub API provides the file list to release-please.
+- Use the scope that best describes the primary intent (e.g., `fix(dev):` for a dev-led change
+  that also touches pm files). Both plugins still get their version bumps.
+
 ## Version Control
 
 This workspace tracks: agent definitions, skills, documentation, scripts, configuration templates.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -52,6 +52,15 @@ Tags follow `<component>-v<version>` format:
 3. The release PR updates CHANGELOG.md and version files
 4. Merging the release PR creates a git tag and GitHub Release
 
+## How Commit Routing Works
+
+Release-please routes commits to plugins by **file paths changed**, not by commit message scope:
+
+- A commit touching `plugins/dev/` and `plugins/pm/` bumps **both** plugins, regardless of scope
+- The `(scope)` in `fix(dev):` controls **changelog section headers**, not routing
+- Squash merges work correctly — GitHub API provides the full file list
+- Use the scope matching the primary plugin; cross-plugin changes still bump all affected plugins
+
 ## Important
 
 - Never manually edit `version.txt`, `marketplace.json` versions, or the manifest

--- a/plugins/dev/skills/ci-describe-pr/SKILL.md
+++ b/plugins/dev/skills/ci-describe-pr/SKILL.md
@@ -90,7 +90,7 @@ gh pr edit $PR_NUMBER --body-file "thoughts/shared/prs/${PR_NUMBER}_description.
 if [[ -n "$ticket" ]] && command -v linearis &>/dev/null; then
   IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .claude/config.json 2>/dev/null || echo "In Review")
   if [[ "$IN_REVIEW_STATE" != "null" ]]; then
-    linearis issues update "$ticket" --state "$IN_REVIEW_STATE" --assignee "@me"
+    linearis issues update "$ticket" --status "$IN_REVIEW_STATE" --assignee "@me"
   fi
 fi
 ```

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -65,7 +65,7 @@ fi
    ```bash
    PLANNING_STATE=$(jq -r '.catalyst.linear.stateMap.planning // "In Progress"' .claude/config.json 2>/dev/null || echo "In Progress")
    if [[ "$PLANNING_STATE" != "null" ]]; then
-       linearis issues update "$ticketId" --state "$PLANNING_STATE"
+       linearis issues update "$ticketId" --status "$PLANNING_STATE"
    fi
    ```
 
@@ -328,7 +328,7 @@ If a ticket is detected (from research document's `source_ticket` frontmatter, c
   ```bash
   PLANNING_STATE=$(jq -r '.catalyst.linear.stateMap.planning // "In Progress"' .claude/config.json 2>/dev/null || echo "In Progress")
   if [[ "$PLANNING_STATE" != "null" ]]; then
-      linearis issues update "$ticketId" --state "$PLANNING_STATE"
+      linearis issues update "$ticketId" --status "$PLANNING_STATE"
   fi
   ```
 - **After plan saved**: `linearis comments create "$ticketId" --body "Plan created: $planPath"`

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -210,7 +210,7 @@ else
     # Update ticket state from stateMap config
     IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .claude/config.json 2>/dev/null || echo "In Review")
     if [[ "$IN_REVIEW_STATE" != "null" ]]; then
-        linearis issues update "$ticket" --state "$IN_REVIEW_STATE" --assignee "@me"
+        linearis issues update "$ticket" --status "$IN_REVIEW_STATE" --assignee "@me"
     fi
 
     # Add comment with PR link

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -363,7 +363,7 @@ else
     # Move to configured "In Review" state and assign to self
     IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .claude/config.json 2>/dev/null || echo "In Review")
     if [[ "$IN_REVIEW_STATE" != "null" ]]; then
-        linearis issues update "$ticket" --state "$IN_REVIEW_STATE" --assignee "@me"
+        linearis issues update "$ticket" --status "$IN_REVIEW_STATE" --assignee "@me"
     fi
 
     # Add comment about update with PR link

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -67,7 +67,7 @@ Once you have a plan path:
   ```bash
   IN_PROGRESS_STATE=$(jq -r '.catalyst.linear.stateMap.inProgress // "In Progress"' .claude/config.json 2>/dev/null || echo "In Progress")
   if [[ "$IN_PROGRESS_STATE" != "null" ]]; then
-      linearis issues update "$ticketId" --state "$IN_PROGRESS_STATE"
+      linearis issues update "$ticketId" --status "$IN_PROGRESS_STATE"
   fi
   ```
   If Linearis CLI is not available, skip silently and continue implementation.
@@ -243,7 +243,7 @@ If a ticket is detected (from plan document's `source_ticket` frontmatter or fro
   ```bash
   IN_PROGRESS_STATE=$(jq -r '.catalyst.linear.stateMap.inProgress // "In Progress"' .claude/config.json 2>/dev/null || echo "In Progress")
   if [[ "$IN_PROGRESS_STATE" != "null" ]]; then
-      linearis issues update "$ticketId" --state "$IN_PROGRESS_STATE"
+      linearis issues update "$ticketId" --status "$IN_PROGRESS_STATE"
   fi
   ```
 - If Linearis CLI not available, skip silently and continue implementation

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -223,23 +223,23 @@ When referencing thoughts documents, always provide GitHub links:
    # Get the team UUID from config or from any existing issue:
    #   TEAM_UUID=$(jq -r '.catalyst.linear.teamUuid // empty' .claude/config.json)
    #   # Or: TEAM_UUID=$(linearis issues list --limit 1 | jq -r '.[0].team.id')
-   linearis issues create \
+   linearis issues create "[refined title]" \
      --team "$TEAM_UUID" \
-     --title "[refined title]" \
      --description "[final description in markdown]" \
      --priority [1-4] \
      --status "$(jq -r '.catalyst.linear.stateMap.backlog // "Backlog"' .claude/config.json 2>/dev/null || echo "Backlog")"
 
    # Capture the created issue ID from output
-   ISSUE_ID=$(linearis issues create ... | jq -r '.id')
+   ISSUE_ID=$(linearis issues create "[refined title]" --team "$TEAM_UUID" -d "Description" | jq -r '.id')
    ```
 
    **Note**: Linearis creates issues in the team's default backlog state. To set specific status or
    assignee, create first then update:
 
    ```bash
-   # Assign to self
-   linearis issues update "$ISSUE_ID" --assignee "@me"
+   # Assign to a user (requires user UUID, not email or @me)
+   # Look up your user ID: linearis issues list --limit 5 | jq '[.[].assignee | select(.) | {name, id}] | unique_by(.id)'
+   linearis issues update "$ISSUE_ID" --assignee "<user-uuid>"
    ```
 
 7. **Post-creation actions:**
@@ -328,7 +328,7 @@ When moving tickets to a new status:
 4. **Manual status updates:**
 
    ```bash
-   linearis issues update TEAM-123 --state "In Progress"
+   linearis issues update TEAM-123 --status "In Progress"
    ```
 
 5. **Add comment explaining the transition:**
@@ -348,7 +348,14 @@ When user wants to find tickets:
 2. **Execute search:**
 
    ```bash
-   # List all issues (linearis issues list only supports --limit, not --team)
+   # Text search — use `issues search` for server-side query matching
+   # WARNING: --team requires a UUID, not a team key (upstream bug: czottmann/linearis#56)
+   linearis issues search "search term" --team "$TEAM_UUID"
+   linearis issues search "search term" --status "In Progress,In Review"
+   linearis issues search "search term" --limit 20
+
+   # List + jq — use for filtering by fields that search doesn't support
+   # (linearis issues list only supports --limit, not --team)
    linearis issues list --limit 100
 
    # Filter by team using jq
@@ -359,10 +366,6 @@ When user wants to find tickets:
 
    # Filter by assignee using jq
    linearis issues list --limit 100 | jq '.[] | select(.assignee.email == "user@example.com")'
-
-   # Search by text (filter JSON output with jq)
-   linearis issues list --limit 100 | \
-     jq '.[] | select(.title | contains("search term"))'
    ```
 
 3. **Present results:**
@@ -438,7 +441,7 @@ When these commands are run, check if there's a related Linear ticket and update
 linearis comments create PROJ-123 --body "Completed phase 1, moving to phase 2"
 
 # Move ticket forward (state name from stateMap config)
-linearis issues update PROJ-123 --state "In Progress"
+linearis issues update PROJ-123 --status "In Progress"
 
 # Search for related tickets
 linearis issues list --limit 100 | jq '.[] | select(.team.key == "PROJ" and (.title | contains("authentication")))'

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -59,11 +59,11 @@ linearis issues search "keyword"
 
 ### Update a Ticket
 ```bash
-# Update state - use --state NOT --status!
-# State names should come from stateMap in .claude/config.json
-linearis issues update TEAM-123 --state "In Progress"
-linearis issues update TEAM-123 --state "In Review"
-linearis issues update TEAM-123 --state "Done"
+# Update status (renamed from --state in v2025.12.2)
+# Status names should come from stateMap in .claude/config.json
+linearis issues update TEAM-123 --status "In Progress"
+linearis issues update TEAM-123 --status "In Review"
+linearis issues update TEAM-123 --status "Done"
 
 # Other updates
 linearis issues update TEAM-123 --title "New title"
@@ -80,13 +80,13 @@ linearis issues update TEAM-123 --clear-project-milestone
 
 **Common mistakes:**
 ```bash
-linearis issues update TEAM-123 --status "Done"   # ❌ WRONG - use --state
+linearis issues update TEAM-123 --state "Done"    # ❌ WRONG - use --status (--state removed in v2025.12.2)
 ```
 
 ### Create a Ticket
 ```bash
 linearis issues create "Title of ticket"
-linearis issues create "Title" --description "Description" --state "Todo" --priority 2
+linearis issues create "Title" --description "Description" --status "Todo" --priority 2
 linearis issues create "Title" --project "Project Name"
 
 # WARNING: --team only accepts UUIDs (upstream bug: czottmann/linearis#56)
@@ -181,7 +181,7 @@ linearis labels list --team BRAVO
 linearis issues read TEAM-123
 
 # 2. Update state
-linearis issues update TEAM-123 --state "In Progress"
+linearis issues update TEAM-123 --status "In Progress"
 
 # 3. Add comment
 linearis comments create TEAM-123 --body "Starting work on this"
@@ -202,7 +202,7 @@ linearis issues list --limit 100 | jq '.[] | select(.team.key == "BRAVO" and .pr
 ```bash
 # State name from stateMap.done config (default: "Done")
 DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .claude/config.json 2>/dev/null || echo "Done")
-linearis issues update TEAM-123 --state "$DONE_STATE"
+linearis issues update TEAM-123 --status "$DONE_STATE"
 linearis comments create TEAM-123 --body "Merged: PR #456 https://github.com/org/repo/pull/456"
 ```
 
@@ -229,7 +229,7 @@ linearis issues list --limit 20 | jq '[.[].team | {key, id, name}] | unique_by(.
 | Action | Command |
 |--------|---------|
 | Read ticket | `linearis issues read TEAM-123` |
-| Update state | `linearis issues update TEAM-123 --state "State"` |
+| Update status | `linearis issues update TEAM-123 --status "Status"` |
 | Add comment | `linearis comments create TEAM-123 --body "text"` |
 | Search | `linearis issues search "keyword"` (--team needs UUID) |
 | List issues | `linearis issues list --limit N` (filter by team with jq) |
@@ -238,7 +238,7 @@ linearis issues list --limit 20 | jq '[.[].team | {key, id, name}] | unique_by(.
 
 ## Important Rules
 
-1. **--state NOT --status**: Always use `--state` for issue state updates
+1. **--status NOT --state**: Always use `--status` for issue status updates (renamed in v2025.12.2)
 2. **comments create**: Use `linearis comments create`, not `issues comment`
 3. **issues read**: Use `read`, not `get` or `view`
 4. **Filtering via jq**: No `--filter` or `--status` flags - pipe to jq instead

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -298,7 +298,7 @@ else
     # Move to configured "Done" state
     DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .claude/config.json 2>/dev/null || echo "Done")
     if [[ "$DONE_STATE" != "null" ]]; then
-        linearis issues update "$ticket" --state "$DONE_STATE"
+        linearis issues update "$ticket" --status "$DONE_STATE"
     fi
 
     # Add merge comment
@@ -523,7 +523,7 @@ Configure:
   export LINEAR_API_TOKEN=your_token
 
 Then update ticket manually (use state name from your stateMap config):
-  linearis issues update $ticket --state "Done"  # or your configured done state
+  linearis issues update $ticket --status "Done"  # or your configured done state
 ```
 
 **Linear API error:**

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -264,7 +264,7 @@ If a ticket is detected (provided as argument, mentioned in query, or from conte
   ```bash
   RESEARCH_STATE=$(jq -r '.catalyst.linear.stateMap.research // "In Progress"' .claude/config.json 2>/dev/null || echo "In Progress")
   if [[ "$RESEARCH_STATE" != "null" ]]; then
-      linearis issues update "$ticketId" --state "$RESEARCH_STATE"
+      linearis issues update "$ticketId" --status "$RESEARCH_STATE"
   fi
   ```
 - **After document saved**: `linearis comments create "$ticketId" --body "Research complete: $link"`

--- a/plugins/pm/agents/github-linear-analyzer.md
+++ b/plugins/pm/agents/github-linear-analyzer.md
@@ -157,12 +157,12 @@ linearis issues create \
 DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .claude/config.json 2>/dev/null || echo "Done")
 
 # Update state
-linearis issues update TEAM-456 --state "$DONE_STATE"
+linearis issues update TEAM-456 --status "$DONE_STATE"
 # Add comment
 linearis comments create TEAM-456 --body "PR #123 merged: https://github.com/user/repo/pull/123"
 
 # Update state
-linearis issues update TEAM-457 --state "$DONE_STATE"
+linearis issues update TEAM-457 --status "$DONE_STATE"
 # Add comment
 linearis comments create TEAM-457 --body "PR #124 merged: https://github.com/user/repo/pull/124"
 ```

--- a/plugins/pm/skills/groom-backlog/SKILL.md
+++ b/plugins/pm/skills/groom-backlog/SKILL.md
@@ -177,7 +177,7 @@ linearis issues update TEAM-123 --project "Frontend"
 
 # Close stale issue TEAM-789 (state from stateMap.canceled config)
 CANCELED_STATE=$(jq -r '.catalyst.linear.stateMap.canceled // "Canceled"' .claude/config.json 2>/dev/null || echo "Canceled")
-linearis issues update TEAM-789 --state "$CANCELED_STATE"
+linearis issues update TEAM-789 --status "$CANCELED_STATE"
 linearis comments create TEAM-789 --body "Closing stale issue (>30 days inactive)"
 
 # [... more commands ...]

--- a/plugins/pm/skills/sync-prs/SKILL.md
+++ b/plugins/pm/skills/sync-prs/SKILL.md
@@ -152,12 +152,12 @@ linearis issues create \
 DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .claude/config.json 2>/dev/null || echo "Done")
 
 # Update state
-linearis issues update TEAM-456 --state "$DONE_STATE"
+linearis issues update TEAM-456 --status "$DONE_STATE"
 # Add comment
 linearis comments create TEAM-456 --body "PR #123 merged: https://github.com/user/repo/pull/123"
 
 # Update state
-linearis issues update TEAM-457 --state "$DONE_STATE"
+linearis issues update TEAM-457 --status "$DONE_STATE"
 # Add comment
 linearis comments create TEAM-457 --body "PR #124 merged: https://github.com/user/repo/pull/124"
 ```


### PR DESCRIPTION
## Summary

Completes [CTL-20](https://linear.app/catalyst/issue/CTL-20): upgrades linearis CLI from 2025.11.2 to 2025.12.3 and fixes command syntax across all skill docs.

- **`--state` → `--status`**: Renamed in linearis v2025.12.2 to match Linear UI terminology. Migrated across 12 files in catalyst-dev and catalyst-pm plugins.
- **`issues create --title`**: Title is a positional argument, not a `--title` flag. Fixed in linear skill.
- **`--assignee "@me"`**: CLI requires a user UUID, not `@me`. Replaced with UUID lookup pattern.
- **Search section**: Added `linearis issues search` for server-side queries instead of relying solely on `issues list | jq`.
- **Linearis reference skill**: Flipped rule #1 guidance — `--status` is now correct, `--state` is the common mistake.

## Files changed (12)

| Plugin | Files |
|--------|-------|
| catalyst-dev | `linear`, `linearis`, `create-plan`, `create-pr`, `describe-pr`, `ci-describe-pr`, `implement-plan`, `merge-pr`, `research-codebase` |
| catalyst-pm | `github-linear-analyzer`, `groom-backlog`, `sync-prs` |

## Test plan

- [ ] Verify `linearis issues update TEAM-123 --status "In Progress"` works on v2025.12.3
- [ ] Verify `linearis issues create "Title" --team "$UUID" -d "Desc"` works (positional title)
- [ ] Verify `linearis issues search "keyword" --status "In Progress"` works
- [ ] Spot-check cached skill files update after merge + release

🤖 Generated with [Claude Code](https://claude.com/claude-code)