### PR TITLE
fix(meta): update Linear team key to CTL

### DIFF
--- a/.claude/config.json
+++ b/.claude/config.json
@@ -2,10 +2,10 @@
   "catalyst": {
     "projectKey": "catalyst-workspace",
     "project": {
-      "ticketPrefix": "PROJ"
+      "ticketPrefix": "CTL"
     },
     "linear": {
-      "teamKey": "PROJ",
+      "teamKey": "CTL",
       "stateMap": {
         "backlog": "Backlog",
         "todo": "Todo",


### PR DESCRIPTION
## Summary
- Updated `.claude/config.json` to use the actual Catalyst Linear team key (`CTL`) and ticket prefix instead of the placeholder `PROJ` values

## Test plan
- [x] Config values match the actual Linear team configuration
- [x] No functional changes — config-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)