### PR TITLE
fix(meta): switch PostHog to localStorage persistence

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -86,7 +86,7 @@ export default defineConfig({
                   posthog.init('${PUBLIC_POSTHOG_KEY}', {
                     api_host: 'https://us.i.posthog.com',
                     person_profiles: 'identified_only',
-                    persistence: 'memory',
+                    persistence: 'localStorage',
                   });
                 `,
               },


### PR DESCRIPTION
## Summary
- Switches PostHog `persistence` from `'memory'` to `'localStorage'`
- `memory` resets the distinct ID on every page load, so every pageview looks like a new unique visitor
- `localStorage` persists the visitor ID across page loads **without cookies** — no cookie banner needed, but proper unique visitor and session tracking

## Test plan
- [ ] Verify PostHog events fire on the deployed site
- [ ] Check PostHog dashboard shows returning visitors (not all unique)
- [ ] Confirm no cookie banner is needed (localStorage only, no cookies set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)