### PR TITLE
fix(meta): switch PostHog to localStorage+cookie persistence

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -86,7 +86,7 @@ export default defineConfig({
                   posthog.init('${PUBLIC_POSTHOG_KEY}', {
                     api_host: 'https://us.i.posthog.com',
                     person_profiles: 'identified_only',
-                    persistence: 'localStorage',
+                    persistence: 'localStorage+cookie',
                   });
                 `,
               },


### PR DESCRIPTION
## Summary
- Switches PostHog `persistence` from `localStorage` to `localStorage+cookie`
- Enables cross-subdomain tracking and more resilient visitor identification
- Note: may require a cookie consent banner for GDPR/ePrivacy compliance

## Test plan
- [ ] Verify PostHog sets a first-party cookie on the docs site
- [ ] Confirm returning visitors are tracked correctly in PostHog dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)