### PR TITLE
feat(dev,pm): wiki-links and PM thoughts path restructuring

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,19 +6,27 @@ Catalyst uses **Release Please** for automated per-plugin releases.
 
 1. **Merge PRs to main** with conventional commit titles (`feat(dev):`, `fix(pm):`, etc.)
 2. **Release Please opens release PRs** — one per affected plugin, accumulating changes
-3. **Merge a release PR** to create: git tag, GitHub Release, updated CHANGELOG.md, bumped versions in `version.txt` and `marketplace.json`
+3. **Merge a release PR** to create: git tag, GitHub Release, updated CHANGELOG.md, bumped versions
 
 ## Version Source of Truth
 
 | File | Purpose | Updated By |
 |---|---|---|
 | `plugins/<x>/version.txt` | Release Please primary version | Release Please |
-| `.claude-plugin/marketplace.json` | Marketplace registry (authoritative for Claude Code) | Release Please (extra-files) |
+| `plugins/<x>/.claude-plugin/plugin.json` | Plugin version (authoritative for Claude Code auto-updates) | Release Please (extra-files) |
+| `.claude-plugin/marketplace.json` | Marketplace plugin registry (lists plugins, no versions) | Manual |
 | `plugins/<x>/CHANGELOG.md` | Per-plugin changelog | Release Please |
 
-Per [Claude Code docs](https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels),
-relative-path plugins should set version in `marketplace.json` only, not in `plugin.json`.
-The `plugin.json` files contain plugin metadata (name, description, author, etc.) but no version.
+### How Claude Code auto-updates work
+
+1. At session start, Claude Code `git fetch`es the marketplace repo
+2. Compares the stored commit SHA (in `installed_plugins.json`) against remote HEAD
+3. If SHAs differ, reads `plugin.json` at the new commit and compares the `version` string
+4. If the version changed → updates the plugin cache. Same version → skips (even if code changed)
+
+The `version` field in `plugin.json` is the gate. Release Please bumps it via the `extra-files`
+jsonpath config (`$.version`). The `marketplace.json` lists available plugins and their source
+paths but does not carry per-plugin version fields.
 
 ## Commit Conventions
 
@@ -63,5 +71,5 @@ Release-please routes commits to plugins by **file paths changed**, not by commi
 
 ## Important
 
-- Never manually edit `version.txt`, `marketplace.json` versions, or the manifest
+- Never manually edit `version.txt`, `plugin.json` versions, or the manifest
 - Release Please manages all versions via conventional commits

--- a/plugins/dev/skills/create-handoff/SKILL.md
+++ b/plugins/dev/skills/create-handoff/SKILL.md
@@ -70,8 +70,8 @@ last_updated: [Current date in YYYY-MM-DD format]
 last_updated_by: [Researcher name]
 type: handoff
 source_ticket: [TICKET-ID or null]
-source_plan: [path to implementation plan, or null]
-source_research: [path to research doc, or null]
+source_plan: "[[plan-filename]]"  # or null
+source_research: "[[research-filename]]"  # or null
 ---
 
 # Handoff: {TICKET or General} - {very concise description}
@@ -80,13 +80,13 @@ source_research: [path to research doc, or null]
 
 {description of the task(s) that you were working on, along with the status of each (completed, work
 in progress, planned/discussed). If you are working on an implementation plan, make sure to call out
-which phase you are on. Make sure to reference the plan document and/or research document(s) you are
-working from that were provided to you at the beginning of the session, if applicable.}
+which phase you are on. Reference the plan and/or research documents using wiki-links
+(e.g., [[plan-filename]], [[research-filename]]), if applicable.}
 
 ## Critical References
 
 {List any critical specification documents, architectural decisions, or design docs that must be
-followed. Include only 2-3 most important file paths. Leave blank if none.}
+followed using wiki-links (e.g., [[doc-filename]]). Include only 2-3 most important references. Leave blank if none.}
 
 ## Recent changes
 

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -158,7 +158,7 @@ last_updated: {CURRENT_DATE}
 last_updated_by: claude
 type: implementation_plan
 source_ticket: { TICKET-ID or null }
-source_research: { path to research doc used, or null }
+source_research: "[[research-doc-filename]]"  # or null
 ---
 
 # [Feature/Task Name] Implementation Plan
@@ -241,8 +241,8 @@ source_research: { path to research doc used, or null }
 
 ## References
 
-- Original ticket: `thoughts/shared/tickets/PROJ-XXX.md`
-- Related research: `thoughts/shared/research/[relevant].md`
+- Original ticket: [[PROJ-XXX]]
+- Related research: [[YYYY-MM-DD-relevant-research]]
 - Similar implementation: `[file:line]`
 ````
 

--- a/plugins/dev/skills/iterate-plan/SKILL.md
+++ b/plugins/dev/skills/iterate-plan/SKILL.md
@@ -101,7 +101,7 @@ If the changes require new technical understanding:
 **Changes**:
 - [Phase X]: [What changed and why]
 - [Phase Y]: [Added/removed/modified]
-**Research conducted**: [Brief summary of any new research]
+**Research conducted**: [[research-doc-filename]] — [Brief summary, if any]
 ```
 
 ### Step 5: Save and Sync

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -395,6 +395,7 @@ State transitions throughout the lifecycle:
 - **thoughts/ is the handoff mechanism** — all documents persist between sessions
 - **`humanlayer launch` is required** — no fallback for context isolation
 - **NEVER add Claude attribution** to any generated artifacts
+- **Use wiki-links** for cross-references between thoughts documents (e.g., `[[filename]]`), not full paths
 - **Phase 3 does NOT commit** — all git operations are deferred to Phase 5
 - **Phase 6 is opt-in** — requires `--auto-merge` or explicit user choice
 

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -172,6 +172,12 @@ system in this area. Focus on WHAT EXISTS, not what should exist.}
 ## Open Questions
 
 {Areas that would benefit from further investigation}
+
+## Related Documents
+
+{List related thoughts documents using wiki-links, e.g.:}
+- [[YYYY-MM-DD-source-ticket|Source Ticket]]
+- [[YYYY-MM-DD-related-research|Related Research]]
 ```
 
 ### Step 7: Add GitHub permalinks (if applicable)

--- a/plugins/pm/README.md
+++ b/plugins/pm/README.md
@@ -66,7 +66,7 @@ Generate comprehensive cycle health report with recommendations.
 - Generates progress metrics, risk factors, capacity analysis
 - Provides specific, prioritized recommendations
 
-**Output**: Health report saved to `thoughts/shared/reports/cycles/`
+**Output**: Health report saved to `thoughts/shared/pm/reports/`
 
 **Example**:
 ```
@@ -98,7 +98,7 @@ Quick daily standup report (scannable in <30 seconds).
 - Identifies team members needing work assignments
 - Flags quick blockers and stalled issues
 
-**Output**: Daily report saved to `thoughts/shared/reports/daily/`
+**Output**: Daily report saved to `thoughts/shared/pm/reports/`
 
 **Example**:
 ```
@@ -127,7 +127,7 @@ Analyze backlog health and generate cleanup recommendations.
 - Identifies orphaned, misplaced, stale, and duplicate issues
 - Generates batch update commands
 
-**Output**: Grooming report saved to `thoughts/shared/reports/backlog/`
+**Output**: Grooming report saved to `thoughts/shared/pm/reports/`
 
 **Options**:
 1. Review detailed report
@@ -151,7 +151,7 @@ Correlate GitHub PRs with Linear issues and identify gaps.
 - Identifies orphaned PRs, orphaned issues, merge candidates
 - Generates auto-close commands
 
-**Output**: Correlation report saved to `thoughts/shared/reports/pr-sync/`
+**Output**: Correlation report saved to `thoughts/shared/pm/reports/`
 
 **Example**:
 ```

--- a/plugins/pm/skills/activation-analysis/SKILL.md
+++ b/plugins/pm/skills/activation-analysis/SKILL.md
@@ -22,7 +22,7 @@ Then provide:
 I'll diagnose your activation funnel using Setup -> Aha -> Habit,
 identify the biggest bottleneck, and recommend specific fixes.
 
-**Output:** Saved to `thoughts/shared/analyses/activation-analysis-[date].md`
+**Output:** Saved to `thoughts/shared/pm/analyses/activation-analysis-[date].md`
 **Time:** ~15 min with data, ~25 min if defining stages from scratch
 
 **When to use:** When diagnosing activation problems, improving onboarding, or measuring early product engagement
@@ -36,11 +36,11 @@ When this skill is invoked, immediately check:
 
 | Source            | Files/Folders                                  | Search Terms                                                           | What to Extract                                                         |
 | ----------------- | ---------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| Metrics/Analytics | `pm/context-library/metrics/*.md`              | "onboarding", "setup", "activation", D7, D30, "time to value", TTV     | Current activation rates by stage, onboarding metrics, D7/D30 retention |
-| User Research     | `pm/context-library/research/*.md`             | "onboarding", "setup", "first time", "confused", "stuck", "struggle"   | User feedback on onboarding, confusion points, success moments          |
-| Meeting Notes     | `pm/context-library/meetings/*.md`             | "activation", "onboarding", "new users", "drop-off", "support tickets" | CS/support feedback on where users get stuck, win/loss reasons          |
-| PRDs              | `pm/context-library/prds/*.md`                 | "onboarding", "activation", "tutorial", "first-time user"              | Past onboarding improvements, features to drive activation              |
-| Business Info     | `pm/context-library/business-info-template.md` | target user, customer segment, use case, primary value                 | Who you're activating, what value matters to them                       |
+| Metrics/Analytics | `thoughts/shared/pm/metrics/*.md`              | "onboarding", "setup", "activation", D7, D30, "time to value", TTV     | Current activation rates by stage, onboarding metrics, D7/D30 retention |
+| User Research     | `thoughts/shared/pm/*.md`                      | "onboarding", "setup", "first time", "confused", "stuck", "struggle"   | User feedback on onboarding, confusion points, success moments          |
+| Meeting Notes     | `thoughts/shared/product/meeting-notes/*.md`   | "activation", "onboarding", "new users", "drop-off", "support tickets" | CS/support feedback on where users get stuck, win/loss reasons          |
+| PRDs              | `thoughts/shared/pm/prds/*.md`                 | "onboarding", "activation", "tutorial", "first-time user"              | Past onboarding improvements, features to drive activation              |
+| Business Info     | `thoughts/shared/pm/context/business-info-template.md` | target user, customer segment, use case, primary value                 | Who you're activating, what value matters to them                       |
 
 **Context Priority:**
 
@@ -62,11 +62,11 @@ Before measuring the Setup → Aha → Habit stages, let me check what data alre
 
 **Checking:**
 
-- `pm/context-library/business-info-template.md` for your product and target users
-- `pm/context-library/metrics/` for existing activation metrics and onboarding data
-- `pm/context-library/research/` for user research on onboarding struggles
-- `pm/context-library/meetings/` for CS/support feedback on where users get stuck
-- `pm/context-library/prds/` for past onboarding improvements
+- `thoughts/shared/pm/context/business-info-template.md` for your product and target users
+- `thoughts/shared/pm/metrics/` for existing activation metrics and onboarding data
+- `thoughts/shared/pm/` for user research on onboarding struggles
+- `thoughts/shared/product/meeting-notes/` for CS/support feedback on where users get stuck
+- `thoughts/shared/pm/prds/` for past onboarding improvements
 
 **[If analytics MCP connected]:** "Let me also query [PostHog/PostHog] for your current activation funnel, setup completion rates, and D7/D30 retention by cohort."
 
@@ -259,7 +259,7 @@ The Setup → Aha → Habit framework breaks activation into three measurable st
 Use this prompt pattern:
 
 ```
-Use /activation-analysis and reference pm/context-library/business-info-template.md
+Use /activation-analysis and reference [[business-info-template]]
 
 Help me define the Setup → Aha → Habit stages for my product.
 
@@ -335,7 +335,7 @@ Overall Activation = Setup Rate × Aha Rate × Habit Rate
 2. **For Setup improvements:**
    - Reduce required fields
    - Add progress indicators
-   - Provide pm/templates/examples
+   - Provide templates/examples
    - Allow "skip" for non-essential items
    - Use social proof ("Join 10,000 teams...")
 
@@ -522,18 +522,17 @@ Use this with your team:
 
 **Research & Findings:**
 
-- Save to: `thoughts/shared/analyses/activation-analysis-[date].md`
-- When finalized, move to: `pm/context-library/research/activation-[product].md`
+- Save to: `thoughts/shared/pm/analyses/activation-analysis-[date].md`
 
 **Onboarding Improvements:**
 
-- Create PRD in `pm/context-library/prds/` for each onboarding change
+- Create PRD in `thoughts/shared/pm/prds/` for each onboarding change
 - Link this activation analysis as context
 - Track changes in the PRD's success metrics section
 
 **Activation Metrics:**
 
-- Update `pm/context-library/metrics/` with your Setup, Aha, Habit definitions and rates
+- Update `thoughts/shared/pm/metrics/` with your Setup, Aha, Habit definitions and rates
 - Track weekly changes as baseline for comparison
 
 ### Cross-Skill Integration

--- a/plugins/pm/skills/analyze-cycle/SKILL.md
+++ b/plugins/pm/skills/analyze-cycle/SKILL.md
@@ -214,13 +214,13 @@ Format the agent's analysis into a user-facing health report:
 ### Step 5: Save Report
 
 **IMPORTANT: Document Storage Rules**
-- ALWAYS write to `thoughts/shared/` (appropriate subdirectory)
+- ALWAYS write to `thoughts/shared/pm/reports/`
 - NEVER write to `thoughts/searchable/` — this is a read-only search index
 
-Write report to `thoughts/shared/reports/cycles/YYYY-MM-DD-cycle-N-status.md`
+Write report to `thoughts/shared/pm/reports/YYYY-MM-DD-cycle-N-status.md`
 
 ```bash
-REPORT_DIR="thoughts/shared/reports/cycles"
+REPORT_DIR="thoughts/shared/pm/reports"
 mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/$(date +%Y-%m-%d)-cycle-${cycle_number}-status.md"
@@ -266,7 +266,7 @@ Status:
   ✅ Done: 18  |  🔄 In Progress: 12  |  📋 Todo: 10
   🚨 Blocked: 2  |  ⚠️  At Risk: 3 (>5 days)
 
-Full health report: thoughts/shared/reports/cycles/2025-01-27-cycle-4-health.md
+Full health report: thoughts/shared/pm/reports/2025-01-27-cycle-4-health.md
 ```
 
 ## Success Criteria

--- a/plugins/pm/skills/analyze-milestone/SKILL.md
+++ b/plugins/pm/skills/analyze-milestone/SKILL.md
@@ -144,11 +144,11 @@ Format the analyzer output into final report:
 ### Step 5: Save Report
 
 **IMPORTANT: Document Storage Rules**
-- ALWAYS write to `thoughts/shared/` (appropriate subdirectory)
+- ALWAYS write to `thoughts/shared/pm/reports/`
 - NEVER write to `thoughts/searchable/` — this is a read-only search index
 
 ```bash
-REPORT_DIR="thoughts/shared/reports/milestones"
+REPORT_DIR="thoughts/shared/pm/reports"
 mkdir -p "$REPORT_DIR"
 
 # Sanitize milestone name for filename
@@ -180,7 +180,7 @@ Priority Actions:
   2. [Action 2]
   3. [Action 3]
 
-Full report: thoughts/shared/reports/milestones/YYYY-MM-DD-milestone.md
+Full report: thoughts/shared/pm/reports/YYYY-MM-DD-milestone.md
 ```
 
 ## Success Criteria

--- a/plugins/pm/skills/competitor-analysis/SKILL.md
+++ b/plugins/pm/skills/competitor-analysis/SKILL.md
@@ -19,7 +19,7 @@ Two modes: **Deep Analysis** (comprehensive one-time research) + **Ongoing Monit
 
 **Example:** "Analyze Competitor X -- we're losing enterprise deals to them"
 
-**Output:** `thoughts/shared/research-synthesis/competitor-analysis-[name]-[date].md`
+**Output:** `thoughts/shared/pm/analyses/competitor-analysis-[name]-[date].md`
 
 **Time:** Deep Analysis: 2-4 hours | Monitoring: 30 min/month
 
@@ -30,12 +30,12 @@ When this skill is invoked, immediately check:
 
 | Source            | Files/Folders                                  | Search Terms                                                             | What to Extract                                   |
 | ----------------- | ---------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------- |
-| User Research     | `pm/context-library/research/*.md`             | competitor name, "switched to", "chose", "vs [competitor]", "competitor" | Customer quotes, pain points, feature comparisons |
-| Existing Analysis | `pm/context-library/research/competitive-*.md` | competitor name                                                          | Past findings, dates, trends, avoid duplication   |
-| Meeting Notes     | `pm/context-library/meetings/*.md`             | competitor name, "lost deal", "churn", sales, CS                         | Sales losses, CS feedback, win/loss patterns      |
-| PRDs              | `pm/context-library/prds/*.md`                 | competitor name, "competitive", "positioning"                            | Feature decisions, positioning rationale          |
-| Strategy          | `pm/context-library/strategy/*.md`             | competitor name, "positioning", "differentiation"                        | Strategic context, counter-positioning            |
-| Metrics           | `pm/context-library/metrics/*.md`              | "churn", "retention", competitor name                                    | Churn to competitors, competitive benchmarks      |
+| User Research     | `thoughts/shared/pm/*.md`                      | competitor name, "switched to", "chose", "vs [competitor]", "competitor" | Customer quotes, pain points, feature comparisons |
+| Existing Analysis | `thoughts/shared/pm/analyses/competitive-*.md` | competitor name                                                          | Past findings, dates, trends, avoid duplication   |
+| Meeting Notes     | `thoughts/shared/product/meeting-notes/*.md`   | competitor name, "lost deal", "churn", sales, CS                         | Sales losses, CS feedback, win/loss patterns      |
+| PRDs              | `thoughts/shared/pm/prds/*.md`                 | competitor name, "competitive", "positioning"                            | Feature decisions, positioning rationale          |
+| Strategy          | `thoughts/shared/pm/frameworks/*.md`           | competitor name, "positioning", "differentiation"                        | Strategic context, counter-positioning            |
+| Metrics           | `thoughts/shared/pm/metrics/*.md`              | "churn", "retention", competitor name                                    | Churn to competitors, competitive benchmarks      |
 
 **Context Priority:**
 
@@ -57,12 +57,12 @@ Before diving into research, let me check what competitive intelligence already 
 
 **Checking:**
 
-- `pm/context-library/research/` for user interviews mentioning competitors
-- `pm/context-library/research/competitive-*.md` for past competitive analysis
-- `pm/context-library/meetings/` for sales/CS notes with competitive intel
-- `pm/context-library/prds/` for competitive positioning decisions
-- `pm/context-library/strategy/` for strategic context
-- `pm/context-library/metrics/` for churn data
+- `thoughts/shared/pm/` for user interviews mentioning competitors
+- `thoughts/shared/pm/analyses/competitive-*.md` for past competitive analysis
+- `thoughts/shared/product/meeting-notes/` for sales/CS notes with competitive intel
+- `thoughts/shared/pm/prds/` for competitive positioning decisions
+- `thoughts/shared/pm/frameworks/` for strategic context
+- `thoughts/shared/pm/metrics/` for churn data
 
 **[If analytics MCP connected]:** "Let me also query [PostHog/PostHog] for churn patterns and competitor-related data."
 
@@ -137,7 +137,7 @@ Based on your objective and existing context:
 
 **Time:** 2-4 hours (depending on number of competitors)
 
-**Output:** Comprehensive report saved to `thoughts/shared/research-synthesis/competitor-analysis-[date].md`
+**Output:** Comprehensive report saved to `thoughts/shared/pm/analyses/competitor-analysis-[date].md`
 
 ### Ongoing Monitoring Mode
 
@@ -157,7 +157,7 @@ Based on your objective and existing context:
 
 **Time:** 30 minutes/month
 
-**Output:** Updates saved to `thoughts/shared/research-synthesis/competitive-intel-[month].md`
+**Output:** Updates saved to `thoughts/shared/pm/analyses/competitive-intel-[month].md`
 
 ---
 
@@ -432,7 +432,7 @@ Instead of complex Make.com automation, I'll help you set up:
 - [ ] [Action 2 with owner]
 ```
 
-Save to: `thoughts/shared/research-synthesis/competitive-intel-[month].md`
+Save to: `thoughts/shared/pm/analyses/competitive-intel-[month].md`
 
 ### Optional: Google Alerts Setup
 
@@ -451,12 +451,11 @@ I can help you set up:
 
 **Deep Analysis:**
 
-- Active work: `thoughts/shared/research-synthesis/competitor-analysis-[name]-[date].md`
-- When finalized: Move to `pm/context-library/research/` for future reference
+- Save to: `thoughts/shared/pm/analyses/competitor-analysis-[name]-[date].md`
 
 **Ongoing Monitoring:**
 
-- Save directly to: `thoughts/shared/research-synthesis/competitive-intel-[month].md`
+- Save to: `thoughts/shared/pm/analyses/competitive-intel-[month].md`
 
 ### Link to Other Work
 

--- a/plugins/pm/skills/connect-mcps/SKILL.md
+++ b/plugins/pm/skills/connect-mcps/SKILL.md
@@ -22,7 +22,7 @@ Tell me which tool to connect (e.g., "connect to PostHog") and I will guide you 
 
 **Example:** `/connect-mcps connect to linear`
 
-**Output:** MCP connected, skills updated, integration log saved to `thoughts/shared/mcp-integration-logs/`
+**Output:** MCP connected, skills updated, integration log saved to `thoughts/shared/pm/reports/`
 
 **Time:** 5-20 minutes per tool depending on setup method
 
@@ -226,7 +226,7 @@ posthog.query_insights({
 - Query on-demand without switching tools
 - Segment and filter programmatically
 
-**Fallback:** If PostHog not connected, you can upload exported CSV data to `pm/context-library/metrics/` and I'll analyze that instead.
+**Fallback:** If PostHog not connected, you can upload exported CSV data to `thoughts/shared/pm/metrics/` and I'll analyze that instead.
 
 ````
 
@@ -253,7 +253,7 @@ This enables me to automatically understand queries like:
 ### Step 9: Generate Integration Summary
 
 After successful integration, I:
-- Save a detailed log to `thoughts/shared/mcp-integration-logs/[timestamp]-[tool-name].md`
+- Save a detailed log to `thoughts/shared/pm/reports/[timestamp]-[tool-name].md`
 - Display a summary showing:
   - Tools discovered
   - Skills updated
@@ -375,7 +375,7 @@ search, browse, web, internet, competitor, market research
 - [Benefit 1 - e.g., Real-time data access]
 - [Benefit 2 - e.g., No manual exports needed]
 
-**Fallback:** [What happens when MCP not available - e.g., "Upload CSV data to pm/context-library/metrics/ for manual analysis"]
+**Fallback:** [What happens when MCP not available - e.g., "Upload CSV data to thoughts/shared/pm/metrics/ for manual analysis"]
 
 ````
 
@@ -404,13 +404,13 @@ This ensures MCP integration info appears early but doesn't interrupt the skill'
 **Analytics Queries** → Analytics MCPs (PostHog)
 
 - Pattern: "give me metrics on X", "show funnel for Y", "retention for Z"
-- Fallback: Check pm/context-library/metrics/
+- Fallback: Check thoughts/shared/pm/metrics/
 
 **Task Queries** → PM MCPs (Linear)
 
 - Pattern: "show my tasks", "create ticket for X", "status of epic Y"
 - Multi-MCP: Ask user which tool to use
-- Fallback: Check pm/context-library/meetings/ for action items
+- Fallback: Check thoughts/shared/product/meeting-notes/ for action items
 ```
 
 ## Example Integrations
@@ -481,7 +481,7 @@ Examples:
 
 I'll automatically query PostHog and return the data with insights.
 
-Full log: thoughts/shared/mcp-integration-logs/2026-01-30-posthog.md
+Full log: thoughts/shared/pm/reports/2026-01-30-posthog.md
 
 ```
 
@@ -547,7 +547,7 @@ Examples:
 
 I'll automatically query Linear and perform operations.
 
-Full log: thoughts/shared/mcp-integration-logs/2026-01-30-linear.md
+Full log: thoughts/shared/pm/reports/2026-01-30-linear.md
 
 ```
 
@@ -598,7 +598,7 @@ You can now:
 - Manage tasks → I'll use Linear
 - Access docs → I'll search Notion
 
-Full logs saved to: thoughts/shared/mcp-integration-logs/2026-01-30-batch/
+Full logs saved to: thoughts/shared/pm/reports/2026-01-30-batch/
 
 ```
 
@@ -792,7 +792,7 @@ I'll continue with other skills and log this issue.
 
 14 out of 15 skills updated successfully.
 
-Check: thoughts/shared/mcp-integration-logs/[timestamp]-errors.md
+Check: thoughts/shared/pm/reports/[timestamp]-errors.md
 
 ```
 
@@ -830,9 +830,9 @@ Me: [maps to both skill groups]
 
 5. **Keep credentials handy** - Have your API keys and workspace IDs ready before running `/connect-mcps connect to [tool]` to speed up setup.
 
-6. **Check the integration log** - Each connection creates a log in `thoughts/shared/mcp-integration-logs/` with full details about what was updated.
+6. **Check the integration log** - Each connection creates a log in `thoughts/shared/pm/reports/` with full details about what was updated.
 
-7. **MCPs are optional** - If an MCP isn't connected, skills will gracefully fall back to manual workflows (e.g., "Upload CSV to pm/context-library/metrics/").
+7. **MCPs are optional** - If an MCP isn't connected, skills will gracefully fall back to manual workflows (e.g., "Upload CSV to thoughts/shared/pm/metrics/").
 
 8. **Re-run `/connect-mcps connect` to update** - If credentials change or expire, just run the connect command again to reconfigure.
 
@@ -860,7 +860,7 @@ Me: [maps to both skill groups]
 
 ❌ **Don't forget to check prerequisites** - Some MCPs require specific permissions or scopes on the API key. Check the tool's documentation.
 
-❌ **Don't skip the fallback** - Even with MCPs connected, keep some exported data in `pm/context-library/` as backup for offline work.
+❌ **Don't skip the fallback** - Even with MCPs connected, keep some exported data in `thoughts/shared/pm/` as backup for offline work.
 
 ## Troubleshooting
 
@@ -871,7 +871,7 @@ Me: [maps to both skill groups]
 - GitHub for community MCP implementations
 - The Anthropic MCP directory
 
-If no MCP exists, you can still use the tool manually and store outputs in `pm/context-library/`.
+If no MCP exists, you can still use the tool manually and store outputs in `thoughts/shared/pm/`.
 
 ### "Connection test failed"
 
@@ -885,7 +885,7 @@ If no MCP exists, you can still use the tool manually and store outputs in `pm/c
 ### "Skills weren't updated"
 
 **Solution:**
-1. Check the integration log in `thoughts/shared/mcp-integration-logs/`
+1. Check the integration log in `thoughts/shared/pm/reports/`
 2. Look for error messages indicating which skills failed
 3. Verify skill files aren't read-only or locked
 4. Re-run `/connect-mcps connect to [tool]` to retry updates
@@ -1209,7 +1209,7 @@ The `catalyst-analytics` plugin provides analytics-focused workflows that levera
 - **Community Discord:** MCP Community server
 
 **For PM-specific help:**
-- Check `thoughts/shared/mcp-integration-logs/` for detailed error messages
+- Check `thoughts/shared/pm/reports/` for detailed error messages
 - Ask in chat: "Why did my PostHog connection fail?"
 - Reference pm/CLAUDE.md → MCP Integrations section for routing logic
 
@@ -1258,7 +1258,7 @@ Before confirming an MCP connection is complete, verify:
 - [ ] **Relevant skills updated** -- All skills that benefit from this MCP have integration sections added
 - [ ] **pm/CLAUDE.md registry updated** -- MCP appears in the registry table with purpose, category, used-in skills, and key tools
 - [ ] **Routing logic updated** -- Natural language query patterns are mapped to this MCP in pm/CLAUDE.md
-- [ ] **Integration log saved** -- Detailed log written to `thoughts/shared/mcp-integration-logs/[timestamp]-[tool].md`
+- [ ] **Integration log saved** -- Detailed log written to `thoughts/shared/pm/reports/[timestamp]-[tool].md`
 - [ ] **Fallback documented** -- Skills note what to do when this MCP is unavailable
 - [ ] **No duplicate entries** -- MCP is not listed twice in registry or skill files
 - [ ] **PM knows how to use it** -- Example natural language queries provided so the PM can start using the MCP immediately

--- a/plugins/pm/skills/context-daily/SKILL.md
+++ b/plugins/pm/skills/context-daily/SKILL.md
@@ -205,7 +205,7 @@ You will receive two data sets:
 [Paste thoughts-metrics agent output here]
 
 Generate a comprehensive context engineering dashboard following the template at:
-plugins/pm/templates/reports/CONTEXT_ENGINEERING_DAILY.md
+thoughts/shared/pm/templates/reports/CONTEXT_ENGINEERING_DAILY.md
 
 CRITICAL REQUIREMENTS:
 1. Identify developers with code activity but NO thoughts activity (not using context engineering)

--- a/plugins/pm/skills/create-tickets/SKILL.md
+++ b/plugins/pm/skills/create-tickets/SKILL.md
@@ -16,9 +16,9 @@ Generate engineering tickets from PRDs, feature specs, or task lists. Supports d
 4. If Linear MCP is connected, I create tickets directly; otherwise, I generate copy-paste text
 5. I provide a dependency summary and sprint assignment suggestion
 
-**Example:** "Create tickets from thoughts/shared/prds/checkout-redesign.md targeting a March 15 launch"
+**Example:** "Create tickets from thoughts/shared/pm/prds/checkout-redesign.md targeting a March 15 launch"
 
-**Output:** Tickets created in Linear, or saved to `thoughts/shared/analyses/[feature]-tickets.md`
+**Output:** Tickets created in Linear, or saved to `thoughts/shared/pm/analyses/[feature]-tickets.md`
 
 **Time:** 15-30 minutes depending on PRD complexity
 
@@ -406,7 +406,7 @@ When the PM uses `/create-tickets`, I automatically:
 
 ### 1. Extract Source Material Understanding
 
-**Source:** PRDs in `pm/context-library/prds/`, or uploaded documents
+**Source:** PRDs in `thoughts/shared/pm/prds/`, or uploaded documents
 
 - **What I look for:** Acceptance criteria, technical requirements, design context
 - **How I use it:** Generate detailed tickets with full context
@@ -422,7 +422,7 @@ When the PM uses `/create-tickets`, I automatically:
 
 ### 3. Check Dependencies Across Roadmap
 
-**Source:** `pm/context-library/prds/`, related PRDs
+**Source:** `thoughts/shared/pm/prds/`, related PRDs
 
 - **What I look for:** What else is being built that might block this
 - **How I use it:** Surface dependency tickets

--- a/plugins/pm/skills/daily-plan/SKILL.md
+++ b/plugins/pm/skills/daily-plan/SKILL.md
@@ -23,7 +23,7 @@ user-invocable: true
 
 ## Same-Day Plan Detection
 
-Before generating a new plan, check `thoughts/shared/` for an existing plan from today.
+Before generating a new plan, check `thoughts/shared/pm/reports/` for an existing plan from today.
 
 **If a same-day plan exists:**
 
@@ -60,12 +60,12 @@ Inspired by personal operating system patterns but tailored specifically for Pro
 
 **Check these files first:**
 
-1. `pm/context-library/strategy/` - Quarter priorities, OKRs, North Star
-2. `thoughts/shared/weekly-plans/` - This week's priorities (if `/weekly-plan` was run)
-3. `thoughts/shared/prds/` - Active PRDs and their stages
-4. `pm/context-library/stakeholder-*.md` - Stakeholder profiles and communication styles
-5. `thoughts/shared/meeting-notes/` - Recent meeting context
-6. `pm/context-library/launches/` - Recently launched features (past 2 weeks)
+1. `thoughts/shared/pm/frameworks/` - Quarter priorities, OKRs, North Star
+2. `thoughts/shared/pm/reports/` - This week's priorities (if `/weekly-plan` was run)
+3. `thoughts/shared/pm/prds/` - Active PRDs and their stages
+4. `thoughts/shared/pm/context/stakeholder-*.md` - Stakeholder profiles and communication styles
+5. `thoughts/shared/product/meeting-notes/` - Recent meeting context
+6. `thoughts/shared/pm/launches/` - Recently launched features (past 2 weeks)
 
 **Integration Options (Multiple Paths):**
 
@@ -127,7 +127,7 @@ If no integrations available, I'll:
    - Calculate day of week, week number
 
 2. **Check for yesterday's plan (carry-over):**
-   - Read `thoughts/shared/daily-plans/` for yesterday's plan file
+   - Read `thoughts/shared/pm/reports/` for yesterday's plan file
    - If found: Identify which items were likely completed vs. deferred based on:
      - Items with checkboxes still unchecked
      - P0 tasks that had no time blocked
@@ -136,7 +136,7 @@ If no integrations available, I'll:
    - If no previous plan exists, skip this step.
 
 3. **Check for weekly plan:**
-   - Read `thoughts/shared/weekly-plans/YYYY-WXX-weekly-plan.md` for current week
+   - Read `thoughts/shared/pm/reports/YYYY-WXX-weekly-plan.md` for current week
    - If exists: Extract this week's Top 3 priorities
    - If missing: Note that week isn't planned (suggest `/weekly-plan`)
 
@@ -164,8 +164,8 @@ Extract:
 
 For each meeting:
 
-- Look up attendees in `pm/context-library/stakeholder-*.md`
-- Scan `thoughts/shared/meeting-notes/` for recent interactions with each person
+- Look up attendees in `thoughts/shared/pm/context/stakeholder-*.md`
+- Scan `thoughts/shared/product/meeting-notes/` for recent interactions with each person
 - Note: What was discussed last time, open action items
 
 Flag issues:
@@ -207,7 +207,7 @@ If Gmail MCP not available:
 
 **C. Active PRDs & Initiatives:**
 
-Scan `thoughts/shared/prds/` and `pm/context-library/prds/`:
+Scan `thoughts/shared/pm/prds/`:
 
 - Check file modification dates (recently updated = active)
 - Read frontmatter or first section to determine stage:
@@ -224,7 +224,7 @@ For each active PRD:
 - What the next milestone is
 - Who's blocking progress (if stalled)
 
-Cross-reference with `pm/context-library/strategy/`:
+Cross-reference with `thoughts/shared/pm/frameworks/`:
 
 - How does each PRD map to quarter priorities?
 - Which strategic pillar does it support?
@@ -245,7 +245,7 @@ Filter by priority/labels:
 
 If MCP not available:
 
-- Scan `thoughts/shared/meeting-notes/` for unchecked action items
+- Scan `thoughts/shared/product/meeting-notes/` for unchecked action items
 - Look for task lists in recent notes
 
 Categorize:
@@ -258,7 +258,7 @@ Categorize:
 
 **E. Metrics to Monitor (Analytics MCP or files):**
 
-Check `pm/context-library/launches/` for features launched in past 2 weeks.
+Check `thoughts/shared/pm/launches/` for features launched in past 2 weeks.
 
 For each recent launch:
 If Analytics MCP available:
@@ -271,7 +271,7 @@ Metrics: Adoption, engagement, conversion (based on PRD success criteria)
 
 If MCP not available:
 
-- Check if metrics file exists in `pm/context-library/metrics/`
+- Check if metrics file exists in `thoughts/shared/pm/metrics/`
 - Or note: "Manual check needed for [feature] metrics"
 
 Flag:
@@ -287,11 +287,11 @@ Flag:
 For each person you're meeting today:
 
 1. **Profile lookup:**
-   - Read `pm/context-library/stakeholder-*.md` if exists
+   - Read `thoughts/shared/pm/context/stakeholder-*.md` if exists
    - Extract: Role, communication style, priorities, pet peeves
 
 2. **Recent interaction history:**
-   - Scan `thoughts/shared/meeting-notes/` for past meetings with this person
+   - Scan `thoughts/shared/product/meeting-notes/` for past meetings with this person
    - Extract: Last meeting date, topics discussed, commitments made
 
 3. **Open loops:**
@@ -352,7 +352,7 @@ If light meeting day (< 2 hours):
 
 ### Step 4: Generate Daily Plan
 
-Create file: `thoughts/shared/daily-plans/YYYY-MM-DD-daily-plan.md`
+Create file: `thoughts/shared/pm/reports/YYYY-MM-DD-daily-plan.md`
 
 **Template:**
 
@@ -525,7 +525,7 @@ _Why these three:_
 
 Include this section when ANY of these are true:
 
-- PM's role is VP, Director, or Head of [function] (check `pm/context-library/personal-context-pm-background.md` or `pm/context-library/business-info-template.md`)
+- PM's role is VP, Director, or Head of [function] (check `thoughts/shared/pm/context/personal-context-pm-background.md` or `thoughts/shared/pm/context/business-info-template.md`)
 - PM has direct reports or manages PM leads (check stakeholder profiles for reports)
 - PM explicitly asks for delegation suggestions
 
@@ -581,7 +581,7 @@ Before presenting the daily plan, verify:
 - [ ] **Stakeholder profiles used:** If profiles exist, attendee context references them (not generic)
 - [ ] **Strategic alignment present:** At least one task or meeting connects to weekly/quarterly goals
 - [ ] **Delegation section:** Included with stated reason (e.g., "you manage 3 reports") OR excluded because PM is IC / no reports found
-- [ ] **File saved:** Plan saved to `thoughts/shared/daily-plans/YYYY-MM-DD-daily-plan.md`
+- [ ] **File saved:** Plan saved to `thoughts/shared/pm/reports/YYYY-MM-DD-daily-plan.md`
 
 ---
 
@@ -610,7 +610,7 @@ When user runs `/daily-plan tomorrow`:
    - Check what got done (if daily plan exists for today)
    - Identify what's carrying over
 3. **Generate tomorrow's draft plan**
-4. **Save as:** `thoughts/shared/daily-plans/YYYY-MM-DD-draft.md`
+4. **Save as:** `thoughts/shared/pm/reports/YYYY-MM-DD-draft.md`
 5. **Prompt:** "Tomorrow's plan is ready. Want to adjust priorities before end of day?"
 
 ---
@@ -860,8 +860,8 @@ Total time: 2 minutes
 **I'll then:**
 
 - Look up Sarah, John, VP Eng in stakeholder profiles (if exists)
-- Check PRD X in `thoughts/shared/prds/`
-- Find Feature Z in `pm/context-library/launches/`
+- Check PRD X in `thoughts/shared/pm/prds/`
+- Find Feature Z in `thoughts/shared/pm/launches/`
 - Generate full daily plan with all context
 
 **Trade-off:**
@@ -921,7 +921,7 @@ Total time: 2 minutes
 
 **If Linear MCP not connected:**
 
-- Scan `thoughts/shared/meeting-notes/` for unchecked action items
+- Scan `thoughts/shared/product/meeting-notes/` for unchecked action items
 - Ask: "What tasks are on your plate today?"
 
 **If Analytics MCP not connected:**
@@ -932,7 +932,7 @@ Total time: 2 minutes
 **If Stakeholder profiles don't exist:**
 
 - Generate basic meeting list without context
-- Suggest: "Want richer meeting context? Fill out stakeholder profiles in `pm/context-library/`"
+- Suggest: "Want richer meeting context? Fill out stakeholder profiles in `thoughts/shared/pm/context/`"
 
 ---
 

--- a/plugins/pm/skills/decision-doc/SKILL.md
+++ b/plugins/pm/skills/decision-doc/SKILL.md
@@ -919,7 +919,7 @@ When the PM uses `/decision-doc`, I automatically:
 
 ### 1. Check Strategic Alignment
 
-**Source:** `pm/context-library/strategy/`, `pm/context-library/prds/`
+**Source:** `thoughts/shared/pm/frameworks/`, `thoughts/shared/pm/prds/`
 
 - **What I look for:** Current roadmap, strategic pillars, OKRs, company direction
 - **How I use it:** Ensure recommendation aligns with broader strategy
@@ -927,7 +927,7 @@ When the PM uses `/decision-doc`, I automatically:
 
 ### 2. Identify Affected Stakeholders
 
-**Source:** `pm/context-library/stakeholder-template.md` + profiles
+**Source:** `thoughts/shared/pm/context/stakeholder-template.md` + profiles
 
 - **What I look for:** Who has input on this decision, who needs to approve, who will be affected
 - **How I use it:** Build stakeholder consultation section automatically
@@ -935,7 +935,7 @@ When the PM uses `/decision-doc`, I automatically:
 
 ### 3. Research Past Related Decisions
 
-**Source:** `pm/context-library/decisions/`
+**Source:** `thoughts/shared/product/decisions/`
 
 - **What I look for:** Similar decisions made before, how they were analyzed, what succeeded/failed
 - **How I use it:** Reference precedent, avoid contradictory decisions, build on learnings
@@ -943,7 +943,7 @@ When the PM uses `/decision-doc`, I automatically:
 
 ### 4. Pull Success Metrics Framework
 
-**Source:** `pm/context-library/metrics/`, this chat thread
+**Source:** `thoughts/shared/pm/metrics/`, this chat thread
 
 - **What I look for:** How you typically measure success, what metrics you care about
 - **How I use it:** Suggest relevant metrics for this decision
@@ -951,7 +951,7 @@ When the PM uses `/decision-doc`, I automatically:
 
 ### 5. Extract Competitive Context
 
-**Source:** `pm/context-library/research/competitive-*.md`, web search if needed
+**Source:** `thoughts/shared/pm/competitive-*.md`, web search if needed
 
 - **What I look for:** Competitor moves, market trends, positioning implications
 - **How I use it:** Include competitive rationale in decision reasoning
@@ -972,11 +972,11 @@ When the PM uses `/decision-doc`, I automatically:
 
 Before presenting output to the PM, verify:
 
-- [ ] **File saved to correct location:** Output saved to `thoughts/shared/decisions/decision-[topic]-[date].md`
-- [ ] **Context routing table was checked:** Reviewed `pm/context-library/decisions/` for past decisions, `pm/context-library/strategy/` for alignment, and `pm/context-library/stakeholder-template.md` for stakeholder context
+- [ ] **File saved to correct location:** Output saved to `thoughts/shared/product/decisions/decision-[topic]-[date].md`
+- [ ] **Context routing table was checked:** Reviewed `thoughts/shared/product/decisions/` for past decisions, `thoughts/shared/pm/frameworks/` for alignment, and `thoughts/shared/pm/context/stakeholder-template.md` for stakeholder context
 - [ ] **Decision framed as clear question:** The decision is stated as a specific, answerable question with 2-4 distinct options (not open-ended or vague)
 - [ ] **Each alternative has pros, cons, and trade-offs:** Every option includes at least 2 pros, 2 cons, and explicit trade-offs with the other options
 - [ ] **Recommendation includes explicit rationale:** The recommendation states which option is chosen and provides numbered reasons why, with data or logic supporting each
 - [ ] **Stakeholders who need to sign off are named:** Specific people (not roles) are listed as approvers, contributors, and informed parties
 - [ ] **Reversibility assessment included:** The document explicitly states whether this is a one-way door or two-way door decision, with reasoning
-- [ ] **Conflicts with existing strategy or past decisions flagged:** Any tension with decisions in `pm/context-library/decisions/` or goals in `pm/context-library/strategy/` is called out with explanation of how the conflict is resolved
+- [ ] **Conflicts with existing strategy or past decisions flagged:** Any tension with decisions in `thoughts/shared/product/decisions/` or goals in `thoughts/shared/pm/frameworks/` is called out with explanation of how the conflict is resolved

--- a/plugins/pm/skills/define-north-star/SKILL.md
+++ b/plugins/pm/skills/define-north-star/SKILL.md
@@ -14,10 +14,10 @@ user-invocable: true
 ## Quick Start
 
 1. Tell me: "Help me define our North Star metric" (or "Validate our current North Star")
-2. I will check `pm/context-library/business-info-template.md` and `pm/context-library/strategy/` for your business model, growth stage, and existing metrics
+2. I will check [[business-info-template]] and `thoughts/shared/pm/frameworks/` for your business model, growth stage, and existing metrics
 3. I will ask about your core value, retention drivers, and business model to narrow candidates
 4. We work through: Core Value identification, Metric formula (Frequency x Core Action x Breadth), Validation tests, Input metrics, and Guardrails
-5. Output goes to `thoughts/shared/analyses/north-star-[quarter].md`
+5. Output goes to `thoughts/shared/pm/metrics/north-star-[quarter].md`
 
 **Key decision:** Not every product needs a single North Star. Marketplaces, multi-product companies, and complex B2B may need a constellation of 2-4 metrics instead. I will help you decide which approach fits.
 
@@ -28,11 +28,11 @@ When this skill is invoked, immediately check:
 
 | Source          | Files/Folders                                  | Search Terms                             | What to Extract                       |
 | --------------- | ---------------------------------------------- | ---------------------------------------- | ------------------------------------- |
-| Strategy Docs   | `pm/context-library/strategy/*.md`             | objective, business goal, success metric | Current metric direction, if any      |
-| Business Model  | `pm/context-library/business-info-template.md` | revenue model, growth focus, metrics     | What drives the business              |
-| Metrics History | `pm/context-library/metrics/*.md`              | baseline, trends, retention data         | Current metric baselines and movement |
-| Meetings        | `pm/context-library/meetings/*.md`             | "North Star", "KPI", "success metric"    | Stakeholder expectations              |
-| PRDs            | `pm/context-library/prds/*.md`                 | success metric, target                   | Feature-level success indicators      |
+| Strategy Docs   | `thoughts/shared/pm/frameworks/*.md`           | objective, business goal, success metric | Current metric direction, if any      |
+| Business Model  | `thoughts/shared/pm/context/business-info-template.md` | revenue model, growth focus, metrics     | What drives the business              |
+| Metrics History | `thoughts/shared/pm/metrics/*.md`              | baseline, trends, retention data         | Current metric baselines and movement |
+| Meetings        | `thoughts/shared/product/meeting-notes/*.md`   | "North Star", "KPI", "success metric"    | Stakeholder expectations              |
+| PRDs            | `thoughts/shared/pm/prds/*.md`                 | success metric, target                   | Feature-level success indicators      |
 
 **Context Priority:**
 
@@ -56,10 +56,10 @@ Before defining your North Star, let me understand where you are...
 
 **Checking:**
 
-- `pm/context-library/business-info-template.md` for your business model
-- `pm/context-library/strategy/` for strategic direction
-- `pm/context-library/metrics/` for baseline metrics and trends
-- `pm/context-library/meetings/` for stakeholder priorities
+- `thoughts/shared/pm/context/business-info-template.md` for your business model
+- `thoughts/shared/pm/frameworks/` for strategic direction
+- `thoughts/shared/pm/metrics/` for baseline metrics and trends
+- `thoughts/shared/product/meeting-notes/` for stakeholder priorities
 
 **Based on what I find, I'll show you:**
 
@@ -229,7 +229,7 @@ Answer these questions:
 Use this prompt:
 
 ```
-Use /define-north-star and reference pm/context-library/business-info-template.md
+Use /define-north-star and reference [[business-info-template]]
 
 Help me identify our core value:
 - Product: [describe your product]
@@ -630,8 +630,7 @@ Without guardrails, teams will find ways to game the North Star that hurt the bu
 
 **North Star definition:**
 
-- Active work: `thoughts/shared/analyses/north-star-[quarter].md` (your working definition)
-- When finalized: Move to `pm/context-library/metrics/north-star-[year].md` for reference
+- Save to: `thoughts/shared/pm/metrics/north-star-[quarter].md` (your working definition)
 - Share widely: This becomes the basis for all team metrics
 
 ### Link to Other Work
@@ -654,8 +653,8 @@ After defining North Star:
 
 **Pulls from:**
 
-- `pm/context-library/business-info-template.md` - Business model informs what matters
-- `pm/context-library/metrics/` - Historical data validates metric choices
+- [[business-info-template]] - Business model informs what matters
+- `thoughts/shared/pm/metrics/` - Historical data validates metric choices
 - `/retention-analysis` - Understand what drives long-term success
 - `/activation-analysis` - Early indicators of North Star movement
 

--- a/plugins/pm/skills/expansion-strategy/SKILL.md
+++ b/plugins/pm/skills/expansion-strategy/SKILL.md
@@ -22,7 +22,7 @@ Then provide:
 I'll decompose your NRR, identify the biggest expansion gap, assess
 pricing sensitivity, design in-product triggers, and build a playbook.
 
-**Output:** Saved to `thoughts/shared/analyses/expansion-strategy-[date].md`
+**Output:** Saved to `thoughts/shared/pm/analyses/expansion-strategy-[date].md`
 **Time:** ~15 min for focused lever, ~30 min for full strategy
 
 **When to use:** When optimizing monetization, planning pricing tiers, or building expansion features
@@ -36,11 +36,11 @@ When this skill is invoked, immediately check:
 
 | Source            | Files/Folders                                  | Search Terms                                                      | What to Extract                                                       |
 | ----------------- | ---------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Business Info     | `pm/context-library/business-info-template.md` | pricing, tiers, plans, ACV, revenue model, monetization           | Current pricing, tiers, customer segments, revenue targets            |
-| Metrics/Analytics | `pm/context-library/metrics/*.md`              | NRR, "net revenue retention", expansion rate, upsell, churn, MRR  | Existing expansion metrics, NRR benchmarks, churn by segment          |
-| PRDs              | `pm/context-library/prds/*.md`                 | pricing, tier, feature gate, monetization                         | Feature decisions tied to monetization, pricing rationale             |
-| Strategy          | `pm/context-library/strategy/*.md`             | "growth", "expansion", "pricing", "positioning"                   | Strategic approach, customer segmentation, market positioning         |
-| Meeting Notes     | `pm/context-library/meetings/*.md`             | pricing, customer expansion, upsell, enterprise, segment, revenue | Sales conversations, customer upgrade opportunities, pricing feedback |
+| Business Info     | `thoughts/shared/pm/context/business-info-template.md` | pricing, tiers, plans, ACV, revenue model, monetization           | Current pricing, tiers, customer segments, revenue targets            |
+| Metrics/Analytics | `thoughts/shared/pm/metrics/*.md`              | NRR, "net revenue retention", expansion rate, upsell, churn, MRR  | Existing expansion metrics, NRR benchmarks, churn by segment          |
+| PRDs              | `thoughts/shared/pm/prds/*.md`                 | pricing, tier, feature gate, monetization                         | Feature decisions tied to monetization, pricing rationale             |
+| Strategy          | `thoughts/shared/pm/frameworks/*.md`           | "growth", "expansion", "pricing", "positioning"                   | Strategic approach, customer segmentation, market positioning         |
+| Meeting Notes     | `thoughts/shared/product/meeting-notes/*.md`   | pricing, customer expansion, upsell, enterprise, segment, revenue | Sales conversations, customer upgrade opportunities, pricing feedback |
 
 **Context Priority:**
 
@@ -62,11 +62,11 @@ Before diving into expansion tactics, let me check what you already know about y
 
 **Checking:**
 
-- `pm/context-library/business-info-template.md` for current pricing and segments
-- `pm/context-library/metrics/` for existing expansion metrics and NRR
-- `pm/context-library/prds/` for monetization-related decisions
-- `pm/context-library/strategy/` for revenue growth strategy
-- `pm/context-library/meetings/` for sales conversations about expansion
+- `thoughts/shared/pm/context/business-info-template.md` for current pricing and segments
+- `thoughts/shared/pm/metrics/` for existing expansion metrics and NRR
+- `thoughts/shared/pm/prds/` for monetization-related decisions
+- `thoughts/shared/pm/frameworks/` for revenue growth strategy
+- `thoughts/shared/product/meeting-notes/` for sales conversations about expansion
 
 **[If analytics MCP connected]:** "Let me also query [PostHog/PostHog] for current expansion rates, NRR, and customer segment growth patterns."
 
@@ -245,7 +245,7 @@ Upgraded (10%) - completed expansion
 **Use this prompt:**
 
 ```
-Use /expansion-strategy and reference pm/context-library/business-info-template.md
+Use /expansion-strategy and reference [[business-info-template]]
 
 Help me identify expansion opportunities:
 - Product: [describe your product]
@@ -629,12 +629,11 @@ Median days from signup to first upgrade
 
 **Strategy Documents:**
 
-- Save to: `thoughts/shared/analyses/expansion-strategy-[quarter].md`
-- When finalized: Move to `pm/context-library/strategy/expansion-strategy-[quarter].md` for reference
+- Save to: `thoughts/shared/pm/analyses/expansion-strategy-[quarter].md`
 
 **Pricing Changes & Experiments:**
 
-- Create PRD in `pm/context-library/prds/` for any tier changes or feature gating
+- Create PRD in `thoughts/shared/pm/prds/` for any tier changes or feature gating
 - Link to this expansion strategy as context
 
 **Sales Playbooks:**
@@ -750,7 +749,7 @@ When analyzing expansion opportunities, map your pricing against competitors:
 2. What features do competitors gate at each tier? (If a key feature is free at Competitor A but gated at your Business tier, that's churn risk)
 3. Is there a tier gap? (Price point where no option exists -- e.g., between $25 and $65/user, there's a $40 gap where users might feel stuck)
 
-Pull competitor pricing from `pm/context-library/research/competitive-*.md` or `pm/context-library/business-info-template.md` competitor sections.
+Pull competitor pricing from [[competitive-analysis]] documents or [[business-info-template]] competitor sections.
 
 ---
 

--- a/plugins/pm/skills/experiment-decision/SKILL.md
+++ b/plugins/pm/skills/experiment-decision/SKILL.md
@@ -23,7 +23,7 @@ I'll walk you through the decision tree: reversibility, hypothesis
 strength, detectable impact, and risk level. You'll get a clear
 recommendation: A/B test, ship + monitor, or just ship.
 
-**Output:** Decision documented inline or saved to `thoughts/shared/decisions/`
+**Output:** Decision documented inline or saved to `thoughts/shared/product/decisions/`
 **Time:** ~5 min for clear-cut cases, ~15 min for nuanced decisions
 
 **When to use:** Before building any feature, when stakeholders demand "data-driven" decisions, or when unsure if testing is worth the effort
@@ -386,7 +386,7 @@ When the PM uses `/experiment-decision`, I automatically:
 
 ### 1. Check Historical Reversibility Precedent
 
-**Source:** `pm/context-library/decisions/`, past decisions
+**Source:** `thoughts/shared/product/decisions/`, past decisions
 
 - **What I look for:** Similar decisions, how reversibility was judged
 - **How I use it:** Ensure consistent reversibility assessment
@@ -394,7 +394,7 @@ When the PM uses `/experiment-decision`, I automatically:
 
 ### 2. Extract Success Metrics Framework
 
-**Source:** `pm/context-library/metrics/`, active PRDs
+**Source:** `thoughts/shared/pm/metrics/`, active PRDs
 
 - **What I look for:** What metrics you typically measure, variance patterns
 - **How I use it:** Calculate minimum detectable effect (MDE) more accurately
@@ -410,7 +410,7 @@ When the PM uses `/experiment-decision`, I automatically:
 
 ### 4. Check Stakeholder Consensus on Risk
 
-**Source:** `pm/context-library/stakeholder-template.md`, recent discussions
+**Source:** `thoughts/shared/pm/context/stakeholder-template.md`, recent discussions
 
 - **What I look for:** Stakeholder risk tolerance, veto power
 - **How I use it:** Surface if high-risk decision needs executive approval

--- a/plugins/pm/skills/experiment-metrics/SKILL.md
+++ b/plugins/pm/skills/experiment-metrics/SKILL.md
@@ -385,7 +385,7 @@ Before you launch an experiment, verify:
 When the PM uses `/experiment-metrics`, I automatically:
 
 ### 1. Pull Metrics from PRDs & Strategy
-**Source:** `pm/context-library/prds/`, success metrics defined there
+**Source:** `thoughts/shared/pm/prds/`, success metrics defined there
 - **What I look for:** Feature's pre-defined success metrics, targets
 - **How I use it:** Pre-populate primary and secondary metrics for STEDII evaluation
 - **Example:** "Your PRD says success = conversion >60%, let's test if that's STEDII-compliant"
@@ -397,13 +397,13 @@ When the PM uses `/experiment-metrics`, I automatically:
 - **Example:** "Metric X has 12% variance historically, so needs N=5000 sample size"
 
 ### 3. Check for Metric Conflicts with Guardrails
-**Source:** `pm/context-library/metrics/`, company guardrails
+**Source:** `thoughts/shared/pm/metrics/`, company guardrails
 - **What I look for:** Metrics that must not decline, company KPIs
 - **How I use it:** Ensure secondary metrics include guardrails
 - **Example:** "NPS is a company guardrail, must include in secondary metrics"
 
 ### 4. Reference Past Experiments for Benchmarks
-**Source:** `pm/context-library/metrics/`, A/B test results
+**Source:** `thoughts/shared/pm/metrics/`, A/B test results
 - **What I look for:** What worked in past experiments, surprising metric learnings
 - **How I use it:** Suggest metrics that detected real impacts before
 - **Example:** "In past experiments, page load time was poorly Sensitive, don't use it"
@@ -420,7 +420,7 @@ When the PM uses `/experiment-metrics`, I automatically:
 
 Before presenting output to the PM, verify:
 
-- [ ] **Context was checked:** Reviewed `pm/context-library/metrics/` for existing experiments and baselines, and `pm/context-library/prds/` for pre-defined success metrics
+- [ ] **Context was checked:** Reviewed `thoughts/shared/pm/metrics/` for existing experiments and baselines, and `thoughts/shared/pm/prds/` for pre-defined success metrics
 - [ ] **Each metric evaluated against all 6 STEDII dimensions:** Every candidate metric has a score (0-3) for Sensitive, Timely, Efficient, Debuggable, Interpretable, and Isolated, with reasoning for each score
 - [ ] **Sample size requirements calculated:** The output includes a minimum sample size estimate for the primary metric based on expected effect size and variance
 - [ ] **Metric sensitivity analysis included:** The output states whether the expected change is detectable given current traffic, variance, and experiment duration

--- a/plugins/pm/skills/feature-metrics/SKILL.md
+++ b/plugins/pm/skills/feature-metrics/SKILL.md
@@ -16,11 +16,11 @@ When this skill is invoked, immediately check:
 
 | Source          | Files/Folders                                  | Search Terms                          | What to Extract                            |
 | --------------- | ---------------------------------------------- | ------------------------------------- | ------------------------------------------ |
-| Current PRD     | `pm/context-library/prds/*.md`                 | feature name from chat                | Hypothesis, problem statement, user impact |
-| Business Info   | `pm/context-library/business-info-template.md` | business model, growth stage, metrics | Product strategy, current North Star       |
-| Metrics Context | `pm/context-library/metrics/*.md`              | baseline numbers, historical data     | Current metric baselines, ranges           |
-| Strategy        | `pm/context-library/strategy/*.md`             | feature related to strategic pillar   | Strategic fit and expected outcomes        |
-| Meetings        | `pm/context-library/meetings/*.md`             | feature name, "success metrics"       | Stakeholder expectations, past decisions   |
+| Current PRD     | `thoughts/shared/pm/prds/*.md`                 | feature name from chat                | Hypothesis, problem statement, user impact |
+| Business Info   | `thoughts/shared/pm/context/business-info-template.md` | business model, growth stage, metrics | Product strategy, current North Star       |
+| Metrics Context | `thoughts/shared/pm/metrics/*.md`              | baseline numbers, historical data     | Current metric baselines, ranges           |
+| Strategy        | `thoughts/shared/pm/frameworks/*.md`           | feature related to strategic pillar   | Strategic fit and expected outcomes        |
+| Meetings        | `thoughts/shared/product/meeting-notes/*.md`   | feature name, "success metrics"       | Stakeholder expectations, past decisions   |
 
 **Context Priority:**
 
@@ -54,11 +54,11 @@ Before we define metrics, let me check what context already exists...
 
 **Checking:**
 
-- `pm/context-library/prds/` for any existing PRD for this feature
-- `pm/context-library/business-info-template.md` for your product model
-- `pm/context-library/metrics/` for historical baseline data
-- `pm/context-library/strategy/` for strategic context
-- `pm/context-library/meetings/` for stakeholder expectations
+- `thoughts/shared/pm/prds/` for any existing PRD for this feature
+- `thoughts/shared/pm/context/business-info-template.md` for your product model
+- `thoughts/shared/pm/metrics/` for historical baseline data
+- `thoughts/shared/pm/frameworks/` for strategic context
+- `thoughts/shared/product/meeting-notes/` for stakeholder expectations
 
 **[If feature PRD exists]:** "I found your [Feature Name] PRD from [date]. It mentions [hypothesis/goal]. Let me use that as context."
 
@@ -255,7 +255,7 @@ If any of these occur, immediately rollback:
 
 - Active work: Add to PRD in `Strategic Fit` section
 - When finalized: Reference in `/experiment-decision` for A/B testing approach
-- Archive: Store final metrics in `pm/context-library/metrics/[feature-name]-baseline.md` for historical reference
+- Archive: Store final metrics in `thoughts/shared/pm/metrics/[feature-name]-baseline.md` for historical reference
 
 ### Link to Other Work
 
@@ -279,7 +279,7 @@ After defining metrics:
 
 - `/define-north-star` - Ensure primary metric ladders up to North Star
 - `/impact-sizing` - Usage estimates inform what metrics can detect changes
-- `pm/context-library/business-info-template.md` - Company metrics and baselines
+- [[business-info-template]] - Company metrics and baselines
 
 ---
 
@@ -298,11 +298,11 @@ After defining metrics:
 
 Before presenting output to the PM, verify:
 
-- [ ] **File saved to correct location:** Output saved to `thoughts/shared/analyses/feature-metrics-[feature-name]-[date].md`
-- [ ] **Context routing table was checked:** Reviewed `pm/context-library/prds/` for feature context, `pm/context-library/business-info-template.md` for North Star metric, and `pm/context-library/metrics/` for existing dashboards and baselines
+- [ ] **File saved to correct location:** Output saved to `thoughts/shared/pm/metrics/feature-metrics-[feature-name]-[date].md`
+- [ ] **Context routing table was checked:** Reviewed `thoughts/shared/pm/prds/` for feature context, `thoughts/shared/pm/context/business-info-template.md` for North Star metric, and `thoughts/shared/pm/metrics/` for existing dashboards and baselines
 - [ ] **Metrics pass STEDII framework:** Each proposed metric is evaluated against all 6 STEDII dimensions (Sensitive, Timely, Easy to understand, Directional, Implementable, Independent) with pass/fail reasoning
 - [ ] **Primary metric has baseline and target:** The primary metric includes a current baseline number and a specific target value with timeline (not "improve" or "increase")
 - [ ] **Guardrail metrics defined:** At least 1 guardrail metric is specified with an acceptable range and explanation of what it protects against
-- [ ] **Metrics ladder to North Star:** The output explicitly shows how the primary metric connects upward to the company's North Star metric from `pm/context-library/business-info-template.md`
+- [ ] **Metrics ladder to North Star:** The output explicitly shows how the primary metric connects upward to the company's North Star metric from [[business-info-template]]
 - [ ] **Data source identified for each metric:** Every metric names where the data comes from (e.g., "PostHog event: task_created" or "database query on users table")
 - [ ] **Metric sensitivity estimated:** The output addresses whether the expected feature impact is large enough for the metric to detect, given current variance and traffic

--- a/plugins/pm/skills/feature-results/SKILL.md
+++ b/plugins/pm/skills/feature-results/SKILL.md
@@ -25,7 +25,7 @@ I'll generate a results doc with: executive summary, results vs targets,
 root cause analysis (if missed), segment breakdown, estimate calibration,
 stakeholder communication guidance, and concrete next steps.
 
-**Output:** Saved to `thoughts/shared/analyses/feature-results-[name]-[date].md`
+**Output:** Saved to `thoughts/shared/pm/analyses/feature-results-[name]-[date].md`
 **Time:** ~10 min with data ready, ~20 min if we need to dig
 
 ---
@@ -36,7 +36,7 @@ Before generating a results analysis, verify the feature has actually shipped.
 
 **Check for launch signals:**
 
-- Does the PRD in `pm/context-library/prds/` or `thoughts/shared/prds/` show status "Shipped" or "Launched"?
+- Does the PRD in `thoughts/shared/pm/prds/` show status "Shipped" or "Launched"?
 - Does the PM mention actual results data (not projections)?
 
 **If the feature hasn't launched yet:**
@@ -386,7 +386,7 @@ When the PM uses `/feature-results`, I automatically:
 
 ### 1. Pull Original PRD & Hypothesis
 
-**Source:** `pm/context-library/prds/`, conversation history
+**Source:** `thoughts/shared/pm/prds/`, conversation history
 
 - **What I look for:** Original hypothesis, target metrics, success criteria
 - **How I use it:** Compare actual results against original targets
@@ -402,14 +402,14 @@ When the PM uses `/feature-results`, I automatically:
 
 ### 3. Check Related Experiments
 
-**Source:** `pm/context-library/metrics/`, past feature results
+**Source:** `thoughts/shared/pm/metrics/`, past feature results
 
 - **What I look for:** Similar features' results, patterns in what works
 - **How I use it:** Add context like "This compares to our pricing redesign which saw 12% improvement"
 
 ### 4. Extract Guardrail Metrics
 
-**Source:** `pm/context-library/metrics/`, PRD success metrics section
+**Source:** `thoughts/shared/pm/metrics/`, PRD success metrics section
 
 - **What I look for:** Metrics that must not decline (retention, NPS, etc.)
 - **How I use it:** Pre-populate guardrail metrics table with relevant metrics

--- a/plugins/pm/skills/generate-ai-prototype/SKILL.md
+++ b/plugins/pm/skills/generate-ai-prototype/SKILL.md
@@ -18,7 +18,7 @@ Create optimized prompts for AI prototyping tools (v0.dev, Lovable, Bolt.new) to
 
 **Example:** "Generate a prototype prompt for the onboarding wizard from PRD-2024-05"
 
-**Output:** Saved to `thoughts/shared/prototypes/[feature]-prototype-prompt.md`
+**Output:** Saved to `thoughts/shared/product/prototypes/[feature]-prototype-prompt.md`
 
 **Time:** 10-15 minutes to generate prompt, 1-2 minutes to build prototype
 

--- a/plugins/pm/skills/groom-backlog/SKILL.md
+++ b/plugins/pm/skills/groom-backlog/SKILL.md
@@ -187,7 +187,7 @@ echo "✅ Backlog grooming updates applied"
 
 ```bash
 # Save update script
-UPDATE_SCRIPT="thoughts/shared/reports/backlog/$(date +%Y-%m-%d)-grooming-updates.sh"
+UPDATE_SCRIPT="thoughts/shared/pm/reports/$(date +%Y-%m-%d)-grooming-updates.sh"
 mkdir -p "$(dirname "$UPDATE_SCRIPT")"
 # [script contents saved here]
 chmod +x "$UPDATE_SCRIPT"
@@ -196,11 +196,11 @@ chmod +x "$UPDATE_SCRIPT"
 ### Step 6: Save Report
 
 **IMPORTANT: Document Storage Rules**
-- ALWAYS write to `thoughts/shared/` (appropriate subdirectory)
+- ALWAYS write to `thoughts/shared/pm/reports/`
 - NEVER write to `thoughts/searchable/` — this is a read-only search index
 
 ```bash
-REPORT_DIR="thoughts/shared/reports/backlog"
+REPORT_DIR="thoughts/shared/pm/reports"
 mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/$(date +%Y-%m-%d)-backlog-grooming.md"

--- a/plugins/pm/skills/impact-sizing/SKILL.md
+++ b/plugins/pm/skills/impact-sizing/SKILL.md
@@ -16,11 +16,11 @@ When this skill is invoked, immediately check:
 
 | Source          | Files/Folders                                  | Search Terms                          | What to Extract                         |
 | --------------- | ---------------------------------------------- | ------------------------------------- | --------------------------------------- |
-| Current PRD     | `pm/context-library/prds/*.md`                 | feature name from chat                | User impact, problem severity           |
-| User Research   | `pm/context-library/research/*.md`             | feature problem, user quotes          | Addressable users, pain severity        |
-| Business Model  | `pm/context-library/business-info-template.md` | pricing, revenue model, TAM           | Revenue impact drivers                  |
-| Historical Data | `pm/context-library/metrics/*.md`              | similar features, baseline conversion | Reference adoption rates                |
-| Strategy        | `pm/context-library/strategy/*.md`             | feature strategic fit                 | Resource availability, priority context |
+| Current PRD     | `thoughts/shared/pm/prds/*.md`                 | feature name from chat                | User impact, problem severity           |
+| User Research   | `thoughts/shared/pm/*.md`                      | feature problem, user quotes          | Addressable users, pain severity        |
+| Business Model  | `thoughts/shared/pm/context/business-info-template.md` | pricing, revenue model, TAM           | Revenue impact drivers                  |
+| Historical Data | `thoughts/shared/pm/metrics/*.md`              | similar features, baseline conversion | Reference adoption rates                |
+| Strategy        | `thoughts/shared/pm/frameworks/*.md`           | feature strategic fit                 | Resource availability, priority context |
 
 **Context Priority:**
 
@@ -44,10 +44,10 @@ Before we estimate impact, let me check what context exists...
 
 **Checking:**
 
-- `pm/context-library/prds/` for the feature definition
-- `pm/context-library/research/` for user research on this problem
-- `pm/context-library/business-info-template.md` for business model context
-- `pm/context-library/metrics/` for comparable feature data
+- `thoughts/shared/pm/prds/` for the feature definition
+- `thoughts/shared/pm/` for user research on this problem
+- `thoughts/shared/pm/context/business-info-template.md` for business model context
+- `thoughts/shared/pm/metrics/` for comparable feature data
 
 **Based on what I find, I'll show you:**
 
@@ -249,9 +249,8 @@ Feature: [Name]
 
 **Impact sizing analysis:**
 
-- Active work: `thoughts/shared/analyses/impact-sizing-[feature-name]-[date].md`
+- Save to: `thoughts/shared/pm/analyses/impact-sizing-[feature-name]-[date].md`
 - When finalized: Reference in PRD in `Strategic Fit` section
-- Archive: Move to `pm/context-library/prds/` as historical reference when feature ships
 
 ### Link to Other Work
 
@@ -273,10 +272,10 @@ After sizing impact:
 
 **Pulls from:**
 
-- `pm/context-library/research/` - User pain and adoption patterns
+- `thoughts/shared/pm/` - User pain and adoption patterns
 - `/user-research-synthesis` - Qualitative insights about addressable users
-- `pm/context-library/business-info-template.md` - Business model and growth drivers
-- `pm/context-library/metrics/` - Historical data on similar features
+- [[business-info-template]] - Business model and growth drivers
+- `thoughts/shared/pm/metrics/` - Historical data on similar features
 
 ---
 
@@ -294,11 +293,11 @@ After sizing impact:
 
 Before presenting output to the PM, verify:
 
-- [ ] **File saved to correct location:** Output saved to `thoughts/shared/analyses/impact-sizing-[feature-name]-[date].md`
-- [ ] **Context routing table was checked:** Reviewed `pm/context-library/business-info-template.md`, `pm/context-library/strategy/`, and `pm/context-library/metrics/` for relevant context
+- [ ] **File saved to correct location:** Output saved to `thoughts/shared/pm/analyses/impact-sizing-[feature-name]-[date].md`
+- [ ] **Context routing table was checked:** Reviewed `thoughts/shared/pm/context/business-info-template.md`, `thoughts/shared/pm/frameworks/`, and `thoughts/shared/pm/metrics/` for relevant context
 - [ ] **Driver tree has specific numbers:** Every node in the driver tree contains actual estimates (not placeholders like "[X]" or "[number]")
 - [ ] **Confidence levels assigned:** Each assumption in the confidence assessment table has a High/Med/Low rating with justification
 - [ ] **Revenue/user impact calculated with clear methodology:** Impact estimates show the math (e.g., "10,000 eligible users x 30% adoption x $5 ARPU = $15,000/month"), not just final numbers
 - [ ] **De-risking actions identified:** Every Low-confidence assumption has a specific, actionable de-risking step (not generic "do more research")
-- [ ] **Impact tied to strategic goal:** The recommendation section explicitly references a strategic goal or OKR from `pm/context-library/strategy/`
+- [ ] **Impact tied to strategic goal:** The recommendation section explicitly references a strategic goal or OKR from `thoughts/shared/pm/frameworks/`
 - [ ] **Sensitivity analysis included:** Output shows best-case, worst-case, and expected-case scenarios with the key variable that drives the range

--- a/plugins/pm/skills/interview-feedback/SKILL.md
+++ b/plugins/pm/skills/interview-feedback/SKILL.md
@@ -30,7 +30,7 @@ I'll help you:
 
 For user research interview debriefs, use /user-research-synthesis instead.
 
-Output: thoughts/shared/interview-feedback/[date]-[company]-debrief.md
+Output: thoughts/shared/pm/interviews/[date]-[company]-debrief.md
 ```
 
 ## When to Use This Skill
@@ -274,14 +274,14 @@ This comparison accelerates learning by making the gap between intention and exe
 
 ### Step 6: Pattern Recognition (Multi-Interview)
 
-**Before generating feedback, check `thoughts/shared/interview-feedback/` for previous debrief files.**
+**Before generating feedback, check `thoughts/shared/pm/interviews/` for previous debrief files.**
 
 If previous debriefs are found, show a trend analysis:
 
 ```
 ## Cross-Interview Pattern Analysis
 
-**Previous debriefs found:** [N] files in thoughts/shared/interview-feedback/
+**Previous debriefs found:** [N] files in thoughts/shared/pm/interviews/
 
 ### Trend Report (across last [N] interviews)
 
@@ -625,7 +625,7 @@ After every interview debrief:
 
 **During job search:**
 
-- Track all feedback in `thoughts/shared/interview-feedback/`
+- Track all feedback in `thoughts/shared/pm/interviews/`
 - Monthly review: Look for patterns
 - Adjust prep based on recurring weaknesses
 
@@ -649,10 +649,10 @@ Before delivering the debrief, verify:
 | **Scores are honest**            | Scores reflect actual performance, not what the PM wants to hear                                          | [ ]   |
 | **Specific examples**            | Each strength and weakness cites a specific moment from the interview, not generalities                   | [ ]   |
 | **Improvement drills provided**  | At least 1 targeted drill for the lowest-scoring dimension                                                | [ ]   |
-| **Pattern check done**           | Checked `thoughts/shared/interview-feedback/` for prior debriefs and showed trends if found               | [ ]   |
+| **Pattern check done**           | Checked `thoughts/shared/pm/interviews/` for prior debriefs and showed trends if found               | [ ]   |
 | **Action items concrete**        | Next steps are specific and time-bound, not vague ("practice more")                                       | [ ]   |
 | **Follow-up tasks included**     | Thank-you email reminder, LinkedIn connection, next round prep noted                                      | [ ]   |
-| **Output file saved**            | Debrief saved to `thoughts/shared/interview-feedback/[date]-[company]-debrief.md`                         | [ ]   |
+| **Output file saved**            | Debrief saved to `thoughts/shared/pm/interviews/[date]-[company]-debrief.md`                         | [ ]   |
 
 **If any check fails, address it before delivering the output.**
 

--- a/plugins/pm/skills/interview-guide/SKILL.md
+++ b/plugins/pm/skills/interview-guide/SKILL.md
@@ -24,7 +24,7 @@ Tell me:
 I'll check your existing research first, then generate a guide that
 focuses on gaps -- not re-asking what you already know.
 
-Output: thoughts/shared/interview-guides-[topic]-[date].md
+Output: thoughts/shared/pm/interviews/interview-guide-[topic]-[date].md
 ```
 
 ---
@@ -36,11 +36,11 @@ When this skill is invoked, immediately check:
 
 | Source            | Files/Folders                                                      | Search Terms                                | What to Extract                          |
 | ----------------- | ------------------------------------------------------------------ | ------------------------------------------- | ---------------------------------------- |
-| Research Plan     | `pm/context-library/research/*.md`                                 | hypothesis, problem statement, target users | Current understanding of problem         |
-| User Personas     | `pm/context-library/research/personas*.md` or stakeholder template | target segment, role, company size          | Who to interview and their context       |
-| PRDs              | `pm/context-library/prds/*.md`                                     | problem statement, user pain                | Problem framing for interview hypothesis |
-| Strategy          | `pm/context-library/strategy/*.md`                                 | user segment, JTBD canvas                   | Jobs framework and strategic fit         |
-| Previous Research | `pm/context-library/research/interviews*.md`                       | similar problem area, past themes           | Avoid revalidating, build on insights    |
+| Research Plan     | `thoughts/shared/pm/research/*.md`                                 | hypothesis, problem statement, target users | Current understanding of problem         |
+| User Personas     | `thoughts/shared/pm/research/personas*.md` or stakeholder template | target segment, role, company size          | Who to interview and their context       |
+| PRDs              | `thoughts/shared/pm/prds/*.md`                                     | problem statement, user pain                | Problem framing for interview hypothesis |
+| Strategy          | `thoughts/shared/pm/frameworks/*.md`                               | user segment, JTBD canvas                   | Jobs framework and strategic fit         |
+| Previous Research | `thoughts/shared/pm/interviews/*.md`                               | similar problem area, past themes           | Avoid revalidating, build on insights    |
 
 **Context Priority:**
 
@@ -65,9 +65,9 @@ Before creating the guide, let me understand what you're trying to learn...
 
 **Checking:**
 
-- `pm/context-library/prds/` for the feature or problem you're researching
-- `pm/context-library/research/` for previous findings on this area
-- `pm/context-library/strategy/` for strategic context
+- `thoughts/shared/pm/prds/` for the feature or problem you're researching
+- `thoughts/shared/pm/research/` for previous findings on this area
+- `thoughts/shared/pm/frameworks/` for strategic context
 - Stakeholder profiles for interview target information
 
 **Based on what I find, I'll show you:**
@@ -104,7 +104,7 @@ Before creating the guide, let me understand what you're trying to learn...
 
 ## Step 0.5: Integrate Past Research
 
-**Before creating the guide, check `pm/context-library/research/` for existing interview syntheses and findings.**
+**Before creating the guide, check `thoughts/shared/pm/research/` for existing interview syntheses and findings.**
 
 Search for:
 
@@ -117,7 +117,7 @@ Search for:
 ```
 ## Research Foundation for This Interview Guide
 
-**Based on [N] previous interviews/syntheses found in pm/context-library/research/:**
+**Based on [N] previous interviews/syntheses found in thoughts/shared/pm/research/:**
 
 ### Well-Validated Themes (don't over-index here)
 These themes have strong evidence from prior research. Include 1-2 confirmation
@@ -142,7 +142,7 @@ Add open-ended discovery questions to surface new insights.
 
 > "Based on [N] previous interviews, we already know [validated themes summary]. This guide focuses on deepening [weak evidence areas] and exploring [new areas]. Avoid spending excessive time re-validating established findings."
 
-If no previous research is found, note: "No existing research found in pm/context-library/research/. This is a discovery interview -- all questions are exploratory."
+If no previous research is found, note: "No existing research found in thoughts/shared/pm/research/. This is a discovery interview -- all questions are exploratory."
 
 ---
 
@@ -342,8 +342,7 @@ Wrap up, ask for referrals
 
 **Interview guides:**
 
-- Active work: `thoughts/shared/interview-guides-[topic]-[date].md`
-- When finalized: Archive to `pm/context-library/research/interview-guides/` for team reference
+- Active work: `thoughts/shared/pm/interviews/interview-guide-[topic]-[date].md`
 - Use directly: Share with interviewing team before sessions
 
 ### Link to Other Work
@@ -365,8 +364,8 @@ After creating the guide:
 
 **Pulls from:**
 
-- `pm/context-library/research/` - Previous research on this topic
-- `pm/context-library/strategy/` - Strategic context about this user problem
+- `thoughts/shared/pm/research/` - Previous research on this topic
+- `thoughts/shared/pm/frameworks/` - Strategic context about this user problem
 - Stakeholder profiles - Information about target user segment
 
 ---
@@ -377,7 +376,7 @@ Before delivering the interview guide, verify:
 
 | Check                                 | Criteria                                                                                                  | Pass? |
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------- | ----- |
-| **Past research checked**             | Searched `pm/context-library/research/` and categorized findings into validated/needs-evidence/unexplored | [ ]   |
+| **Past research checked**             | Searched `thoughts/shared/pm/research/` and categorized findings into validated/needs-evidence/unexplored | [ ]   |
 | **Guide reflects prior knowledge**    | Questions focus on gaps, not re-validating what's already known                                           | [ ]   |
 | **Research foundation note included** | Top of guide states what's known and where this guide focuses                                             | [ ]   |
 | **No leading questions**              | Every question is open-ended, not suggesting a desired answer                                             | [ ]   |
@@ -385,7 +384,7 @@ Before delivering the interview guide, verify:
 | **Time-boxed sections**               | Each section has a suggested time allocation that totals 45-60 min                                        | [ ]   |
 | **Follow-up prompts included**        | At least 2-3 follow-up probes per core question                                                           | [ ]   |
 | **Closing includes referrals**        | Guide asks "Who else should I talk to?"                                                                   | [ ]   |
-| **Output file saved**                 | Guide saved to `thoughts/shared/interview-guides-[topic]-[date].md`                                       | [ ]   |
+| **Output file saved**                 | Guide saved to `thoughts/shared/pm/interviews/interview-guide-[topic]-[date].md`                           | [ ]   |
 
 **If any check fails, address it before delivering the output.**
 

--- a/plugins/pm/skills/journey-map/SKILL.md
+++ b/plugins/pm/skills/journey-map/SKILL.md
@@ -524,7 +524,7 @@ When the PM uses `/journey-map`, I automatically:
 
 ### 1. Pull User Research for Personas & Pain Points
 
-**Source:** `pm/context-library/research/`, user research MCPs (research repository, UserTesting)
+**Source:** `thoughts/shared/pm/research/`, user research MCPs (research repository, UserTesting)
 
 - **What I look for:** User personas, quotes, pain points, behavior patterns
 - **How I use it:** Pre-populate persona sections with real research data
@@ -532,7 +532,7 @@ When the PM uses `/journey-map`, I automatically:
 
 ### 2. Extract Relevant Metrics & Analytics
 
-**Source:** PostHog, PostHog, Posthog (if connected), `pm/context-library/metrics/`
+**Source:** PostHog, PostHog, Posthog (if connected), `thoughts/shared/pm/metrics/`
 
 - **What I look for:** Conversion rates, drop-off points, time-in-flow metrics
 - **How I use it:** Quantify pain points with actual data
@@ -540,7 +540,7 @@ When the PM uses `/journey-map`, I automatically:
 
 ### 3. Align With Strategy & OKRs
 
-**Source:** `pm/context-library/strategy/`, PRDs
+**Source:** `thoughts/shared/pm/frameworks/`, PRDs
 
 - **What I look for:** Current strategic focus, activation goals, retention goals
 - **How I use it:** Suggest which journey phases matter most for strategy
@@ -548,7 +548,7 @@ When the PM uses `/journey-map`, I automatically:
 
 ### 4. Cross-Reference Customer Lifecycle
 
-**Source:** Sales/CS data, past customer journey maps in `pm/context-library/`
+**Source:** Sales/CS data, past customer journey maps in `thoughts/shared/pm/`
 
 - **What I look for:** Typical customer progression, expansion patterns
 - **How I use it:** Build customer journey map that aligns with business model
@@ -556,7 +556,7 @@ When the PM uses `/journey-map`, I automatically:
 
 ### 5. Identify Cross-Functional Stakeholders
 
-**Source:** `pm/context-library/stakeholder-template.md`
+**Source:** `thoughts/shared/pm/context/stakeholder-template.md`
 
 - **What I look for:** Who owns different journey phases (sales, product, CS, success)
 - **How I use it:** Suggest who to involve in journey mapping workshop
@@ -577,9 +577,9 @@ When the PM uses `/journey-map`, I automatically:
 
 Before presenting output to the PM, verify:
 
-- [ ] **File saved to correct location:** Output saved to `thoughts/shared/journey-maps/[journey-name]-[date].md`
-- [ ] **Context routing table was checked:** Reviewed `pm/context-library/research/` for user research, interview transcripts, and persona data before building the map
+- [ ] **File saved to correct location:** Output saved to `thoughts/shared/pm/journey-maps/[journey-name]-[date].md`
+- [ ] **Context routing table was checked:** Reviewed `thoughts/shared/pm/research/` for user research, interview transcripts, and persona data before building the map
 - [ ] **Every stage has all four elements:** Each journey phase includes actions, thoughts, emotions, and pain points (no empty or missing sections)
-- [ ] **User quotes from research included:** Where available, real user quotes from `pm/context-library/research/` are embedded in relevant journey stages (not fabricated quotes)
+- [ ] **User quotes from research included:** Where available, real user quotes from `thoughts/shared/pm/research/` are embedded in relevant journey stages (not fabricated quotes)
 - [ ] **Opportunities linked to specific product improvements:** Each opportunity names a concrete product change (e.g., "add progress bar to onboarding step 3"), not generic advice like "improve the experience"
 - [ ] **Emotional journey shows highs and lows:** The emotional arc across stages is not flat; it includes at least one high point and one low point with explanations for the shifts

--- a/plugins/pm/skills/launch-checklist/SKILL.md
+++ b/plugins/pm/skills/launch-checklist/SKILL.md
@@ -14,7 +14,7 @@ disable-model-invocation: true
 
 **Example:** "Create a launch checklist for the checkout redesign, targeting March 15"
 
-**Output:** Saved to `thoughts/shared/launches/[feature-name]-launch-checklist.md`
+**Output:** Saved to `thoughts/shared/pm/launches/[feature-name]-launch-checklist.md`
 
 **Time:** 15-20 minutes to generate, then ongoing tracking
 
@@ -34,11 +34,11 @@ Generate comprehensive launch checklist ensuring nothing falls through the crack
 
 **Check these files first:**
 
-1. `thoughts/shared/prds/` or `pm/context-library/prds/` - PRD for feature details
-2. `pm/context-library/launches/` - Past launch checklists (learn from history)
-3. `pm/context-library/strategy/` - GTM approach, stakeholders
-4. `pm/context-library/stakeholder-*.md` - Who needs to be involved
-5. `pm/templates/launch-checklist-template.md` - Base template (if exists)
+1. `thoughts/shared/pm/prds/` - PRD for feature details
+2. `thoughts/shared/pm/launches/` - Past launch checklists (learn from history)
+3. `thoughts/shared/pm/frameworks/` - GTM approach, stakeholders
+4. `thoughts/shared/pm/context/stakeholder-template.md` - Who needs to be involved
+5. `thoughts/shared/pm/templates/launch-checklist-template.md` - Base template (if exists)
 
 ---
 
@@ -64,7 +64,7 @@ Generate comprehensive launch checklist ensuring nothing falls through the crack
 
 ### Step 2: Generate Checklist
 
-Create file: `thoughts/shared/launches/[feature-name]-launch-checklist.md`
+Create file: `thoughts/shared/pm/launches/[feature-name]-launch-checklist.md`
 
 **Template Structure:**
 

--- a/plugins/pm/skills/meeting-agenda/SKILL.md
+++ b/plugins/pm/skills/meeting-agenda/SKILL.md
@@ -61,7 +61,7 @@ Week 3: Planning session (45 min)
 Week 4: Retro + learnings (30 min)
 ```
 
-For recurring meetings, check `pm/context-library/meetings/` and `thoughts/shared/meeting-notes/` for previous agendas and notes. Reference what was discussed last time, carry over open items, and avoid repeating the same format every week.
+For recurring meetings, check `thoughts/shared/product/meeting-notes/` for previous agendas and notes. Reference what was discussed last time, carry over open items, and avoid repeating the same format every week.
 
 **One-off meetings** need a clear single outcome and should default to 25 minutes. If you cannot define the single outcome, push back on scheduling it.
 
@@ -817,7 +817,7 @@ When the PM uses `/meeting-agenda`, I automatically:
 
 ### 1. Check Recent Meeting Context
 
-**Source:** `pm/context-library/meetings/`, recent decisions and action items
+**Source:** `thoughts/shared/product/meeting-notes/`, recent decisions and action items
 
 - **What I look for:** Related meetings, earlier discussions, open questions
 - **How I use it:** Reference previous context in pre-read section
@@ -825,7 +825,7 @@ When the PM uses `/meeting-agenda`, I automatically:
 
 ### 2. Pull Stakeholder Communication Preferences
 
-**Source:** `pm/context-library/stakeholder-template.md`
+**Source:** `thoughts/shared/pm/context/stakeholder-template.md`
 
 - **What I look for:** How each stakeholder prefers communication, decision style
 - **How I use it:** Format agenda and pre-read to match their preferences
@@ -833,7 +833,7 @@ When the PM uses `/meeting-agenda`, I automatically:
 
 ### 3. Reference Relevant PRDs & Strategy
 
-**Source:** `pm/context-library/prds/`, `pm/context-library/strategy/`
+**Source:** `thoughts/shared/pm/prds/`, `thoughts/shared/pm/frameworks/`
 
 - **What I look for:** Strategic context that informs meeting purpose
 - **How I use it:** Add strategic rationale to meeting purpose statement

--- a/plugins/pm/skills/meeting-cleanup/SKILL.md
+++ b/plugins/pm/skills/meeting-cleanup/SKILL.md
@@ -30,12 +30,12 @@ When this skill is invoked, immediately check:
 
 | Source               | Files/Folders                                                        | Search Terms                      | What to Extract                                      |
 | -------------------- | -------------------------------------------------------------------- | --------------------------------- | ---------------------------------------------------- |
-| Business Info        | `pm/context-library/business-info-template.md`                       | company, product, team            | Company context for interpreting discussions         |
-| Stakeholder Profiles | `pm/context-library/stakeholder-template.md`                         | attendees' names                  | Communication preferences, roles, decision authority |
-| Active PRDs          | `pm/context-library/prds/*.md`                                       | features discussed                | Link action items to active PRDs                     |
-| Previous Meetings    | `pm/context-library/meetings/*.md`, `thoughts/shared/meeting-notes/` | same meeting name, same attendees | Carry-over items, open questions from last time      |
-| Strategy             | `pm/context-library/strategy/*.md`                                   | strategic pillars, OKRs           | Align decisions to strategic context                 |
-| Decisions            | `pm/context-library/decisions/*.md`                                  | related decisions                 | Check for conflicts with past decisions              |
+| Business Info        | `thoughts/shared/pm/context/business-info-template.md`               | company, product, team            | Company context for interpreting discussions         |
+| Stakeholder Profiles | `thoughts/shared/pm/context/stakeholder-template.md`                 | attendees' names                  | Communication preferences, roles, decision authority |
+| Active PRDs          | `thoughts/shared/pm/prds/*.md`                                       | features discussed                | Link action items to active PRDs                     |
+| Previous Meetings    | `thoughts/shared/product/meeting-notes/`                             | same meeting name, same attendees | Carry-over items, open questions from last time      |
+| Strategy             | `thoughts/shared/pm/frameworks/*.md`                                 | strategic pillars, OKRs           | Align decisions to strategic context                 |
+| Decisions            | `thoughts/shared/product/decisions/*.md`                             | related decisions                 | Check for conflicts with past decisions              |
 
 **Context Priority:**
 
@@ -91,7 +91,7 @@ For each meeting processed, verify:
 2. **All action items have deadlines** -- if an action item lacks a date, assign a reasonable default and flag it: "No deadline stated -- defaulting to [date], confirm?"
 3. **No duplicate action items across meetings** -- if the same action appears in multiple meetings, consolidate into one entry and note which meetings referenced it
 4. **Conflicting decisions across meetings are flagged** -- if Meeting 1 decided "launch in March" and Meeting 3 discussed "push to April," flag the conflict explicitly
-5. **Strategic alignment is noted for each decision** -- tie decisions to strategic pillars from `pm/context-library/strategy/` when relevant
+5. **Strategic alignment is noted for each decision** -- tie decisions to strategic pillars from `thoughts/shared/pm/frameworks/` when relevant
 
 ### Step 3: Update Systems (5 min)
 
@@ -309,6 +309,6 @@ Before delivering the meeting cleanup, verify:
 - [ ] **Consolidated action list is complete** -- a single master list appears at the end with all items across all meetings
 - [ ] **Cross-meeting conflicts checked and flagged** -- timelines, scope, owners, and priorities are compared across meetings for contradictions
 - [ ] **Parking lot captured** -- unresolved questions and ideas that surfaced but were not actionable are noted
-- [ ] **File saved correctly** -- output saved to `thoughts/shared/meeting-notes/cleanup-[date].md`
+- [ ] **File saved correctly** -- output saved to `thoughts/shared/product/meeting-notes/cleanup-[date].md`
 
 If any check fails, revise before delivering.

--- a/plugins/pm/skills/meeting-feedback/SKILL.md
+++ b/plugins/pm/skills/meeting-feedback/SKILL.md
@@ -538,7 +538,7 @@ After any meeting, ask yourself:
 
 ## Trend Tracking
 
-After scoring, check `thoughts/shared/meeting-notes/` and previous feedback files for the same recurring meeting. If previous feedback exists, show a trend:
+After scoring, check `thoughts/shared/product/meeting-notes/` and previous feedback files for the same recurring meeting. If previous feedback exists, show a trend:
 
 ```
 ## Meeting Effectiveness Trend: [Meeting Name]
@@ -561,7 +561,7 @@ assigning a facilitator or using round-robin format.
 
 If no previous feedback exists, note: "This is the first feedback for this meeting. Future ratings will show trends."
 
-Save feedback files with consistent naming: `thoughts/shared/meeting-notes/feedback-[meeting-name]-[date].md` to enable trend tracking.
+Save feedback files with consistent naming: `thoughts/shared/product/meeting-notes/feedback-[meeting-name]-[date].md` to enable trend tracking.
 
 ---
 
@@ -644,7 +644,7 @@ When the PM uses `/meeting-feedback`, I automatically:
 
 ### 2. Reference Related Decisions
 
-**Source:** `pm/context-library/decisions/` if this meeting made a decision
+**Source:** `thoughts/shared/product/decisions/` if this meeting made a decision
 
 - **What I look for:** Decision that came out of the meeting
 - **How I use it:** Note whether decision was crisp and clear
@@ -660,7 +660,7 @@ When the PM uses `/meeting-feedback`, I automatically:
 
 ### 4. Pull Attendee Context
 
-**Source:** `pm/context-library/stakeholder-template.md`
+**Source:** `thoughts/shared/pm/context/stakeholder-template.md`
 
 - **What I look for:** Attendees' roles, personality styles
 - **How I use it:** Calibrate feedback (e.g., "Person X dominates, needs facilitation")

--- a/plugins/pm/skills/meeting-notes/SKILL.md
+++ b/plugins/pm/skills/meeting-notes/SKILL.md
@@ -18,7 +18,7 @@ user-invocable: true
 
 **Accepted inputs:** Zoom/Otter/Grain transcripts, bullet-point notes, voice memo dictation, Slack threads, email chains, or just "tell me what happened."
 
-**What you get:** Structured notes with decisions, action items (with owners and dates), key insights, open questions, and next steps. Saved to `thoughts/shared/meeting-notes/[date]-[topic].md`.
+**What you get:** Structured notes with decisions, action items (with owners and dates), key insights, open questions, and next steps. Saved to `thoughts/shared/product/meeting-notes/[date]-[topic].md`.
 
 **Time:** 2-5 minutes per meeting.
 
@@ -52,10 +52,10 @@ When this skill is invoked, immediately check:
 
 | Source               | Files/Folders                      | Search Terms                     | What to Extract                            |
 | -------------------- | ---------------------------------- | -------------------------------- | ------------------------------------------ |
-| Related PRDs         | `pm/context-library/prds/*.md`     | feature from meeting             | PRD context, decisions already made        |
-| Stakeholder Profiles | Stakeholder templates              | attendees from meeting           | Communication style, preferences, concerns |
-| Strategy             | `pm/context-library/strategy/*.md` | feature or decision from meeting | Strategic alignment context                |
-| Previous Meetings    | `pm/context-library/meetings/*.md` | topic from this meeting          | Historical context, related decisions      |
+| Related PRDs         | `thoughts/shared/pm/prds/*.md`              | feature from meeting             | PRD context, decisions already made        |
+| Stakeholder Profiles | Stakeholder templates                       | attendees from meeting           | Communication style, preferences, concerns |
+| Strategy             | `thoughts/shared/pm/frameworks/*.md`        | feature or decision from meeting | Strategic alignment context                |
+| Previous Meetings    | `thoughts/shared/product/meeting-notes/*.md` | topic from this meeting          | Historical context, related decisions      |
 | Action Items         | Previous meeting notes             | same owners, same topics         | Recurring blockers or items                |
 
 **Context Priority:**
@@ -80,10 +80,10 @@ Before processing, let me check if there's relevant context...
 
 **Checking:**
 
-- `pm/context-library/meetings/` for any previous meetings on this topic
+- `thoughts/shared/product/meeting-notes/` for any previous meetings on this topic
 - Stakeholder profiles for communication style of attendees
-- `pm/context-library/prds/` for related feature context
-- `pm/context-library/strategy/` for strategic alignment
+- `thoughts/shared/pm/prds/` for related feature context
+- `thoughts/shared/pm/frameworks/` for strategic alignment
 
 **Based on what I find, I'll show you:**
 
@@ -193,7 +193,7 @@ I'll create a structured summary with:
 - Next steps
 
 Output format: [Standard / Detailed / Minimal]
-(I'll use your preferred writing style from pm/context-library/writing-style-*.md)
+(I'll use your preferred writing style from thoughts/shared/pm/context/writing-style-*.md)
 
 Processing now...
 ```
@@ -369,7 +369,7 @@ I'll automatically adjust the format based on meeting type:
 
 ### By Writing Style
 
-I'll match your preferred style from `pm/context-library/writing-style-*.md`:
+I'll match your preferred style from `thoughts/shared/pm/context/writing-style-*.md`:
 
 **Internal Audience:**
 
@@ -423,7 +423,7 @@ I'll create:
 
 If you don't specify who owns an action item, I'll:
 
-- Look at stakeholder info in `pm/context-library/stakeholder-template.md` (or any profiles you add)
+- Look at stakeholder info in `thoughts/shared/pm/context/stakeholder-template.md` (or any profiles you add)
 - Check who has context on similar work
 - Suggest the right owner with reasoning
 - Flag items that need clarification
@@ -440,8 +440,8 @@ Example:
 
 I'll automatically:
 
-- Link to related PRDs in `pm/context-library/prds/`
-- Reference relevant strategy docs in `pm/context-library/`
+- Link to related PRDs in `thoughts/shared/pm/prds/`
+- Reference relevant strategy docs in `thoughts/shared/pm/frameworks/`
 - Connect to similar past meetings or decisions
 - Pull in stakeholder preferences
 
@@ -463,9 +463,9 @@ Also see: [Voice Task PRD] which used similar rollout approach successfully.
 
 Compare all time estimates and deadlines mentioned in the meeting against known dates from:
 
-- PRDs in `pm/context-library/prds/*.md` and `thoughts/shared/prds/*.md` (launch dates, milestone dates)
-- Previous meeting notes in `pm/context-library/meetings/*.md` (prior commitments, deadlines)
-- Strategy docs in `pm/context-library/strategy/*.md` (quarter end dates, OKR deadlines)
+- PRDs in `thoughts/shared/pm/prds/*.md` (launch dates, milestone dates)
+- Previous meeting notes in `thoughts/shared/product/meeting-notes/*.md` (prior commitments, deadlines)
+- Strategy docs in `thoughts/shared/pm/frameworks/*.md` (quarter end dates, OKR deadlines)
 - Calendar context if available (upcoming reviews, stakeholder meetings)
 
 If any estimates conflict with known deadlines, flag explicitly in the output:
@@ -724,7 +724,7 @@ After I create the notes, review and edit:
 
 Save processed meeting notes to:
 
-- `thoughts/shared/meeting-notes/[date]-[topic].md`
+- `thoughts/shared/product/meeting-notes/[date]-[topic].md`
 
 Over time, I'll spot patterns:
 
@@ -1028,8 +1028,7 @@ _→ Add to lessons-learned: VPs appreciate when PMs anticipate their questions_
 
 **Meeting notes:**
 
-- Quick capture: `thoughts/shared/meeting-notes/[date]-[topic].md` (raw processing)
-- When finalized: Archive to `pm/context-library/meetings/[date]-[topic].md` for historical reference
+- Save to: `thoughts/shared/product/meeting-notes/[date]-[topic].md`
 - Use as templates: Your meeting notes become template for team
 
 ### Link to Other Work
@@ -1053,10 +1052,10 @@ After processing meeting notes:
 
 **Pulls from:**
 
-- `pm/context-library/prds/` - Feature context for meeting
+- `thoughts/shared/pm/prds/` - Feature context for meeting
 - Stakeholder profiles - Communication preferences and concerns
-- `pm/context-library/strategy/` - Strategic alignment context
-- `pm/context-library/meetings/` - Previous decisions and context
+- `thoughts/shared/pm/frameworks/` - Strategic alignment context
+- `thoughts/shared/product/meeting-notes/` - Previous decisions and context
 
 ---
 
@@ -1074,7 +1073,7 @@ Before presenting the meeting notes, verify:
 - [ ] **Context cross-reference done:** At least one check against PRDs, strategy, or previous meetings was performed
 - [ ] **Key quotes are verbatim:** Customer quotes use exact wording from transcript, not paraphrased
 - [ ] **Sensitive content flagged:** If confidential topics detected, recommendation to mark as internal-only is included
-- [ ] **File saved correctly:** `thoughts/shared/meeting-notes/[YYYY-MM-DD]-[topic-kebab-case].md`
+- [ ] **File saved correctly:** `thoughts/shared/product/meeting-notes/[YYYY-MM-DD]-[topic-kebab-case].md`
 - [ ] **Next steps are actionable:** Someone reading "Next Steps" knows exactly what to do without re-reading the full notes
 
 ---

--- a/plugins/pm/skills/metrics-framework/SKILL.md
+++ b/plugins/pm/skills/metrics-framework/SKILL.md
@@ -14,11 +14,11 @@ user-invocable: true
 ## Quick Start
 
 1. Tell me: "Help me build a metrics framework for [product/feature]"
-2. I will check `pm/context-library/strategy/` for your North Star and `pm/context-library/metrics/` for baseline data
+2. I will check `thoughts/shared/pm/frameworks/` for your North Star and `thoughts/shared/pm/metrics/` for baseline data
 3. I will ask about your North Star (lagging metric), product stage, and decision speed needs
 4. We build a metric hierarchy: Lagging (quarterly) -> Leading (weekly) -> Input (daily)
 5. For each key metric, we define alert thresholds (green/yellow/red) and a dashboard layout
-6. Output goes to `thoughts/shared/metrics-framework-[date].md`
+6. Output goes to `thoughts/shared/pm/metrics/metrics-framework-[date].md`
 
 **Key principle:** Leading metrics should PREDICT lagging metrics. If they do not, you are tracking the wrong thing. We always validate the correlation before committing to a leading indicator.
 
@@ -29,11 +29,11 @@ When this skill is invoked, immediately check:
 
 | Source           | Files/Folders                                  | Search Terms                         | What to Extract                        |
 | ---------------- | ---------------------------------------------- | ------------------------------------ | -------------------------------------- |
-| Strategy Context | `pm/context-library/strategy/*.md`             | North Star, objective, business goal | Company-wide lagging metric target     |
-| Business Model   | `pm/context-library/business-info-template.md` | metrics, KPIs, growth model          | Current revenue/retention/growth focus |
-| Metrics History  | `pm/context-library/metrics/*.md`              | baseline, trends, benchmarks         | Historical leading/lagging metric data |
-| PRDs             | `pm/context-library/prds/*.md`                 | success metrics, measurement         | Feature-level metric definitions       |
-| Meetings         | `pm/context-library/meetings/*.md`             | "metrics", "dashboard", "KPI"        | Stakeholder metric priorities          |
+| Strategy Context | `thoughts/shared/pm/frameworks/*.md`             | North Star, objective, business goal | Company-wide lagging metric target     |
+| Business Model   | `thoughts/shared/pm/context/business-info-template.md` | metrics, KPIs, growth model          | Current revenue/retention/growth focus |
+| Metrics History  | `thoughts/shared/pm/metrics/*.md`              | baseline, trends, benchmarks         | Historical leading/lagging metric data |
+| PRDs             | `thoughts/shared/pm/prds/*.md`                 | success metrics, measurement         | Feature-level metric definitions       |
+| Meetings         | `thoughts/shared/product/meeting-notes/*.md`   | "metrics", "dashboard", "KPI"        | Stakeholder metric priorities          |
 
 **Context Priority:**
 
@@ -57,10 +57,10 @@ Before designing your metrics framework, let me understand what you're optimizin
 
 **Checking:**
 
-- `pm/context-library/business-info-template.md` for business model and goals
-- `pm/context-library/strategy/*.md` for strategic priorities
-- `pm/context-library/metrics/` for existing metric baselines
-- `pm/context-library/prds/` for current feature success metrics
+- `thoughts/shared/pm/context/business-info-template.md` for business model and goals
+- `thoughts/shared/pm/frameworks/*.md` for strategic priorities
+- `thoughts/shared/pm/metrics/` for existing metric baselines
+- `thoughts/shared/pm/prds/` for current feature success metrics
 
 **Based on what I find, I'll show you:**
 
@@ -219,7 +219,7 @@ Examples:
 Use this prompt pattern:
 
 ```
-Use /metrics-framework and reference pm/context-library/business-info-template.md
+Use /metrics-framework and reference thoughts/shared/pm/context/business-info-template.md
 
 Our North Star / main outcome metric is: [your lagging metric]
 
@@ -717,8 +717,7 @@ For products with multiple value streams (e.g., separate features for creation, 
 
 **Metric framework documentation:**
 
-- Active work: `thoughts/shared/metrics-framework-[date].md` (living document for your team)
-- When finalized: Move to `pm/context-library/metrics/metric-hierarchy-[quarter].md` for historical reference
+- Active work: `thoughts/shared/pm/metrics/metrics-framework-[date].md` (living document for your team)
 - Dashboard spec: Share with analytics team for instrumentation
 
 ### Link to Other Work
@@ -742,7 +741,7 @@ After building your framework:
 **Pulls from:**
 
 - `/write-prod-strategy` - Strategy determines what you're optimizing for
-- `pm/context-library/metrics/` - Historical data validates correlations
+- `thoughts/shared/pm/metrics/` - Historical data validates correlations
 - `/define-north-star` - What is your ultimate success metric?
 
 ---

--- a/plugins/pm/skills/napkin-sketch/SKILL.md
+++ b/plugins/pm/skills/napkin-sketch/SKILL.md
@@ -18,7 +18,7 @@ Create quick wireframes as ASCII art OR capture existing UI from browser to matc
 
 **Example:** "Sketch a settings page with tabs for Profile, Security, and Billing"
 
-**Output:** Wireframe delivered inline, also saved to `thoughts/shared/prototypes/[feature]-napkin-sketch.md`
+**Output:** Wireframe delivered inline, also saved to `thoughts/shared/product/prototypes/[feature]-napkin-sketch.md`
 
 **Time:** 5-10 minutes per screen
 
@@ -592,12 +592,12 @@ Before creating any wireframe, check these sources:
 
 | Source               | Files                                                       | What to Extract                                                              |
 | -------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Active PRD           | `pm/context-library/prds/*.md`, `thoughts/shared/prds/*.md` | UI requirements, user flows, feature scope, non-goals (what NOT to design)   |
-| User Research        | `pm/context-library/research/*.md`                          | Pain points to solve, user quotes about current UX frustrations              |
-| Stakeholder Profiles | `pm/context-library/stakeholder-template.md`                | Designer preferences (e.g., Lisa wants accessibility-first), exec priorities |
+| Active PRD           | `thoughts/shared/pm/prds/*.md`                              | UI requirements, user flows, feature scope, non-goals (what NOT to design)   |
+| User Research        | `thoughts/shared/pm/*.md`                                   | Pain points to solve, user quotes about current UX frustrations              |
+| Stakeholder Profiles | `thoughts/shared/pm/context/stakeholder-template.md`        | Designer preferences (e.g., Lisa wants accessibility-first), exec priorities |
 | Design System        | Any design docs or style references in workspace            | Colors, component patterns, layout conventions to follow                     |
-| Past Prototypes      | `thoughts/shared/prototypes/*.md`                           | Existing wireframes for consistency, decisions already made                  |
-| Business Context     | `pm/context-library/business-info-template.md`              | Product type, user personas, platform (web/mobile/both)                      |
+| Past Prototypes      | `thoughts/shared/product/prototypes/*.md`                   | Existing wireframes for consistency, decisions already made                  |
+| Business Context     | `thoughts/shared/pm/context/business-info-template.md`      | Product type, user personas, platform (web/mobile/both)                      |
 
 **Priority:** PRD requirements first (the wireframe must match the spec), then user research (ground the design in real pain points), then past prototypes (maintain consistency).
 

--- a/plugins/pm/skills/prd-draft/SKILL.md
+++ b/plugins/pm/skills/prd-draft/SKILL.md
@@ -16,7 +16,7 @@ user-invocable: true
 /prd-draft --ai                           → Include AI behavior specification sections
 ```
 
-**What you get:** A 1-2 page modern PRD with hypothesis, strategic fit, non-goals, success metrics, rollout plan, and optional behavior examples. Saved to `thoughts/shared/prds/[feature-name-kebab-case]-[stage].md`. Based on `pm/templates/prd-template.md`.
+**What you get:** A 1-2 page modern PRD with hypothesis, strategic fit, non-goals, success metrics, rollout plan, and optional behavior examples. Saved to `thoughts/shared/pm/prds/[feature-name-kebab-case]-[stage].md`. Based on `thoughts/shared/pm/templates/prd-template.md`.
 
 **Time:** 10-20 minutes for first draft. Then iterate.
 
@@ -35,12 +35,12 @@ When this skill is invoked, immediately check:
 
 | Source              | Files/Folders                                  | Search Terms                      | What to Extract                              |
 | ------------------- | ---------------------------------------------- | --------------------------------- | -------------------------------------------- |
-| Strategy Docs       | `pm/context-library/strategy/*.md`             | feature name from chat            | Strategic pillar alignment                   |
-| Related PRDs        | `pm/context-library/prds/*.md`                 | feature dependencies              | Related features and cross-functional impact |
-| User Research       | `pm/context-library/research/*.md`             | problem related to feature        | User pain points, quotes, validation         |
-| Business Model      | `pm/context-library/business-info-template.md` | pricing, revenue, metrics         | Revenue impact, North Star alignment         |
-| Competitor Analysis | `pm/context-library/research/competitive-*.md` | feature name                      | Competitive positioning if relevant          |
-| Stakeholder Context | Stakeholder profiles                           | key stakeholders for this feature | Who to involve, communication style          |
+| Strategy Docs       | `thoughts/shared/pm/frameworks/*.md`                  | feature name from chat            | Strategic pillar alignment                   |
+| Related PRDs        | `thoughts/shared/pm/prds/*.md`                        | feature dependencies              | Related features and cross-functional impact |
+| User Research       | `thoughts/shared/pm/*.md`                             | problem related to feature        | User pain points, quotes, validation         |
+| Business Model      | `thoughts/shared/pm/context/business-info-template.md` | pricing, revenue, metrics         | Revenue impact, North Star alignment         |
+| Competitor Analysis | `thoughts/shared/pm/competitive-*.md`                 | feature name                      | Competitive positioning if relevant          |
+| Stakeholder Context | Stakeholder profiles                                   | key stakeholders for this feature | Who to involve, communication style          |
 
 **Context Priority:**
 
@@ -64,10 +64,10 @@ Before we draft, let me check what context exists...
 
 **Checking:**
 
-- `pm/context-library/prds/` for any related feature PRDs
-- `pm/context-library/strategy/` for strategic alignment
-- `pm/context-library/research/` for user validation
-- `pm/context-library/business-info-template.md` for business context
+- `thoughts/shared/pm/prds/` for any related feature PRDs
+- `thoughts/shared/pm/frameworks/` for strategic alignment
+- `thoughts/shared/pm/` for user validation
+- `thoughts/shared/pm/context/business-info-template.md` for business context
 - Stakeholder profiles for who needs to be involved
 
 ### Context Health Check
@@ -161,7 +161,7 @@ Before I draft anything, I need to understand the initiative. Don't worry about 
 5. Is this an A/B test or full launch?
 6. What are the non-goals? (What are we explicitly NOT doing?)
 7. What are the success metrics? (How will we know this worked?)
-8. Who are the key stakeholders? (@ mention them if you have profiles in `pm/context-library/stakeholder-template.md` or similar)
+8. Who are the key stakeholders? (@ mention them if you have profiles in `thoughts/shared/pm/context/stakeholder-template.md` or similar)
 
 **AI-specific (if applicable):**
 9. What are example prompts or user inputs?
@@ -203,16 +203,16 @@ Great, I have enough to draft a first version. This will be:
 - Focused on the key sections for this stage
 - At the [STAGE] stage of evolution
 - Using your [AUDIENCE] writing style
-- Based on pm/templates/prd-template.md
+- Based on thoughts/shared/pm/templates/prd-template.md
 
-I'll create it now and save it to `thoughts/shared/prds/[feature-name-kebab-case]-[stage].md`.
+I'll create it now and save it to `thoughts/shared/pm/prds/[feature-name-kebab-case]-[stage].md`.
 
 After you review, we can iterate or get multi-perspective feedback.
 ```
 
 ### PRD Structure
 
-**Reference the full template at `pm/templates/prd-template.md`.** Include only sections relevant to the current stage. Use this structure:
+**Reference the full template at `thoughts/shared/pm/templates/prd-template.md`.** Include only sections relevant to the current stage. Use this structure:
 
 ```markdown
 # [Feature Name]
@@ -334,7 +334,7 @@ If [scenario], we will [specific action].
 
 ## AI Behavior Contract (AI features only)
 
-> Include for AI/ML features. Delete for non-AI features. See `pm/templates/prd-template.md` Section 3 for the full contract format.
+> Include for AI/ML features. Delete for non-AI features. See `thoughts/shared/pm/templates/prd-template.md` Section 3 for the full contract format.
 
 | Dimension            | Specification                                     |
 | -------------------- | ------------------------------------------------- |
@@ -401,7 +401,7 @@ If [scenario], we will [specific action].
 
 **Tone:**
 
-- Use the appropriate writing style from `pm/context-library/writing-style-*.md`
+- Use the appropriate writing style from `thoughts/shared/pm/context/writing-style-*.md`
 - Write like the PM would write (human, not AI-generated)
 - Be direct and crisp
 
@@ -509,7 +509,7 @@ Create a [component type] for [product context].
 After generating the draft, offer:
 
 ```
-First draft created! Saved to `thoughts/shared/prds/[feature-name]-[stage].md`.
+First draft created! Saved to `thoughts/shared/pm/prds/[feature-name]-[stage].md`.
 
 Want me to review this from multiple perspectives?
 - Engineer (technical feasibility, implementation concerns)
@@ -529,7 +529,7 @@ When the PM requests review:
 
    ```
    I'll review this from [Engineer / Designer / Executive] perspective.
-   Reading from `pm/sub-agents/[agent-name].md`...
+   Reading from `thoughts/shared/pm/sub-agents/[agent-name].md`...
    ```
 
 2. **For each agent, provide:**
@@ -692,8 +692,7 @@ Great work! Your PRD is ready for review.
 
 **PRD documents:**
 
-- Active work: `thoughts/shared/prds/[feature-name]-[stage].md`
-- When finalized: Move to `pm/context-library/prds/[feature-name].md` for historical reference
+- Active work: `thoughts/shared/pm/prds/[feature-name]-[stage].md`
 - Evolve through stages: Team Kickoff → Planning Review → XFN Kickoff → Solution Review → Launch → Impact
 
 ### Link to Other Work
@@ -719,7 +718,7 @@ After creating PRD:
 - `/user-research-synthesis` - User quotes and insights populate Hypothesis
 - `/impact-sizing` - Usage estimates and revenue impact go into Strategic Fit
 - `/interview-guide` - User research that validated the problem
-- `pm/context-library/strategy/` - Strategic pillar and alignment context
+- `thoughts/shared/pm/frameworks/` - Strategic pillar and alignment context
 - `/define-north-star` - Ensure feature's success metrics ladder to North Star
 
 ---
@@ -731,16 +730,16 @@ After creating PRD:
 Before presenting the PRD draft to the PM, verify:
 
 - [ ] **Filename follows convention:** `[feature-name-kebab-case]-[stage].md` (e.g., `voice-task-capture-team-kickoff.md`)
-- [ ] **Saved to correct location:** `thoughts/shared/prds/` (NOT `pm/context-library/prds/`)
+- [ ] **Saved to correct location:** `thoughts/shared/pm/prds/`
 - [ ] **Word count matches stage:** Check against the Stage-Specific Length Guidance table
 - [ ] **Hypothesis is testable:** Contains a clear "If we... then... because..." statement
-- [ ] **Strategic fit references actual strategy:** Cites specific goals from `pm/context-library/strategy/`, not generic strategy language
+- [ ] **Strategic fit references actual strategy:** Cites specific goals from `thoughts/shared/pm/frameworks/`, not generic strategy language
 - [ ] **Non-goals are specific:** Each non-goal explains WHY it's excluded, not just what it is
 - [ ] **Success metrics have baselines and targets:** Not just "increase X" but "X from [current] to [target] by [date]"
 - [ ] **Kill criteria are realistic:** Would the team actually pull the plug at this threshold?
 - [ ] **Behavior Examples vs Solution Overview:** AI features have the behavior table; non-AI features have the solution overview
 - [ ] **Sounds human:** Read it aloud -- does it sound like the PM wrote it, or like an AI generated it?
-- [ ] **User quotes included:** If user research exists in `pm/context-library/research/`, at least one real quote is referenced
+- [ ] **User quotes included:** If user research exists in `thoughts/shared/pm/`, at least one real quote is referenced
 - [ ] **Open questions have owners:** Every open question has a @stakeholder assigned
 
 ---

--- a/plugins/pm/skills/prd-review-panel/SKILL.md
+++ b/plugins/pm/skills/prd-review-panel/SKILL.md
@@ -22,11 +22,10 @@ Catches gaps, challenges assumptions, and surfaces conflicts before stakeholder 
 
 **Check these files first:**
 
-1. `thoughts/shared/prds/` - Active PRDs to review
-2. `pm/context-library/prds/` - Reference PRDs and past reviews
-3. `pm/sub-agents/` - The 7 reviewer personas
-4. `pm/context-library/strategy/` - Strategic context for executive review
-5. `pm/context-library/research/` - User research for UXR validation
+1. `thoughts/shared/pm/prds/` - Active PRDs to review
+2. `thoughts/shared/pm/sub-agents/` - The 7 reviewer personas
+3. `thoughts/shared/pm/frameworks/` - Strategic context for executive review
+4. `thoughts/shared/pm/` - User research for UXR validation
 
 **Sub-agents available:**
 
@@ -45,12 +44,12 @@ Catches gaps, challenges assumptions, and surfaces conflicts before stakeholder 
 ### Step 1: PRD Selection
 
 1. **If user specified PRD name:**
-   - Look for it in `thoughts/shared/prds/` and `pm/context-library/prds/`
+   - Look for it in `thoughts/shared/pm/prds/`
    - If found: Proceed
    - If not found: List available PRDs, ask user to choose
 
 2. **If no PRD specified:**
-   - Scan `thoughts/shared/prds/` for recent PRDs (modified in last 30 days)
+   - Scan `thoughts/shared/pm/prds/` for recent PRDs (modified in last 30 days)
    - List them with:
      - File name
      - Title (from content)
@@ -194,7 +193,7 @@ PRD Content:
 [Full PRD text]
 
 Strategic Context:
-[Include content from pm/context-library/strategy/ if available]
+[Include content from thoughts/shared/pm/frameworks/ if available]
 
 Review framework:
 1. Strategic Alignment
@@ -285,7 +284,7 @@ PRD Content:
 [Full PRD text]
 
 User Research Context:
-[Include recent research from pm/context-library/research/ if relevant]
+[Include recent research from thoughts/shared/pm/ if relevant]
 
 Review framework:
 1. Research Validation
@@ -459,7 +458,7 @@ Once all 7 agents complete (wait for all Task outputs):
 
 ### Step 5: Generate Review Synthesis
 
-Create file: `thoughts/shared/prds/[prd-name]-review-synthesis.md`
+Create file: `thoughts/shared/pm/reviews/[prd-name]-review-synthesis.md`
 
 **Template:**
 

--- a/plugins/pm/skills/prioritize/SKILL.md
+++ b/plugins/pm/skills/prioritize/SKILL.md
@@ -439,7 +439,7 @@ Ask yourself weekly:
 
 **Rules:**
 - **Leverage tasks:** Generally do these yourself. They are your highest-value contribution.
-- **Neutral tasks:** For each, ask: "Could someone on my team do this at B- quality?" If yes, delegate. Reference names from stakeholder profiles in `pm/context-library/stakeholder-template.md`.
+- **Neutral tasks:** For each, ask: "Could someone on my team do this at B- quality?" If yes, delegate. Reference names from stakeholder profiles in `thoughts/shared/pm/context/stakeholder-template.md`.
 - **Overhead tasks:** Always delegate, automate, or eliminate. If you cannot delegate, timebox aggressively (set a hard stop).
 
 ---
@@ -469,7 +469,7 @@ After classifying tasks, check total estimated hours against available time:
 When the PM uses `/prioritize`, I automatically:
 
 ### 1. Analyze Your Task List Against Strategy
-**Source:** `pm/context-library/strategy/`, OKRs, quarterly goals
+**Source:** `thoughts/shared/pm/frameworks/`, OKRs, quarterly goals
 - **What I look for:** Strategic priorities vs. your task list
 - **How I use it:** Classify tasks against declared strategy
 - **Example:** "Strategy says focus on retention, but you're 60% on new feature work → recalibrate"
@@ -517,4 +517,4 @@ Before delivering the prioritization output, verify:
 - [ ] **Capacity check done:** Total Leverage hours are compared against available deep work time. If over capacity, specific recommendations are provided.
 - [ ] **Actionable recommendations:** At least 2-3 specific overhead tasks are flagged for elimination or delegation, with a suggested alternative (who to delegate to, or why it can be skipped).
 - [ ] **Calendar blocking suggested:** Specific time blocks are recommended for Leverage work (e.g., "Block Monday 9-12 for PRD writing").
-- [ ] **Strategy alignment checked:** Leverage tasks are validated against current strategic priorities from `pm/context-library/strategy/`. If a Leverage task does not connect to strategy, flag it.
+- [ ] **Strategy alignment checked:** Leverage tasks are validated against current strategic priorities from `thoughts/shared/pm/frameworks/`. If a Leverage task does not connect to strategy, flag it.

--- a/plugins/pm/skills/prototype-feedback/SKILL.md
+++ b/plugins/pm/skills/prototype-feedback/SKILL.md
@@ -17,9 +17,9 @@ Rapidly iterate on prototypes using AI-powered building and automated feedback c
 4. I deliver prioritized recommendations: must-fix, should-fix, and nice-to-have
 5. You iterate on the prototype and we repeat until validated
 
-**Example:** "Review my checkout prototype: [link]. PRD is in thoughts/shared/prds/checkout-redesign.md"
+**Example:** "Review my checkout prototype: [link]. PRD is in thoughts/shared/pm/prds/checkout-redesign.md"
 
-**Output:** Saved to `thoughts/shared/prototypes/[feature]-feedback-round-[N].md`
+**Output:** Saved to `thoughts/shared/product/prototypes/[feature]-feedback-round-[N].md`
 
 **Time:** 30 minutes per feedback round
 
@@ -29,11 +29,11 @@ Rapidly iterate on prototypes using AI-powered building and automated feedback c
 
 | Source               | Files/Folders                                       | What to Extract                                    |
 | -------------------- | --------------------------------------------------- | -------------------------------------------------- |
-| PRD                  | `thoughts/shared/prds/`, `pm/context-library/prds/` | Requirements, acceptance criteria, success metrics |
-| Design System        | `pm/context-library/technical/`, design docs        | Colors, typography, component patterns to match    |
-| Stakeholder Profiles | `pm/context-library/stakeholder-*.md`               | Who reviews this, their priorities and concerns    |
-| User Research        | `pm/context-library/research/`                      | User pain points, quotes, behavior patterns        |
-| Past Prototypes      | `thoughts/shared/prototypes/`                       | Previous feedback rounds, resolved issues          |
+| PRD                  | `thoughts/shared/pm/prds/`                          | Requirements, acceptance criteria, success metrics |
+| Design System        | design docs                                         | Colors, typography, component patterns to match    |
+| Stakeholder Profiles | `thoughts/shared/pm/context/stakeholder-template.md` | Who reviews this, their priorities and concerns    |
+| User Research        | `thoughts/shared/pm/`                               | User pain points, quotes, behavior patterns        |
+| Past Prototypes      | `thoughts/shared/product/prototypes/`               | Previous feedback rounds, resolved issues          |
 
 ## Overview
 

--- a/plugins/pm/skills/prototype/SKILL.md
+++ b/plugins/pm/skills/prototype/SKILL.md
@@ -45,13 +45,13 @@ When this skill is invoked, immediately check:
 
 | Source               | Files/Folders                                               | Search Terms       | What to Extract                                         |
 | -------------------- | ----------------------------------------------------------- | ------------------ | ------------------------------------------------------- |
-| Active PRDs          | `thoughts/shared/prds/*.md`, `pm/context-library/prds/*.md` | feature name       | Requirements, user flows, success metrics, edge cases   |
-| Previous Prototypes  | `thoughts/shared/prototypes/*.md`                           | feature name       | Previous versions, iteration history, feedback received |
-| User Research        | `pm/context-library/research/*.md`                          | user pain, problem | User quotes, pain points, workflows to design for       |
-| Napkin Sketches      | `thoughts/shared/prototypes/*-napkin*.md`                   | feature name       | ASCII wireframes to convert to prototype                |
+| Active PRDs          | `thoughts/shared/pm/prds/*.md`                              | feature name       | Requirements, user flows, success metrics, edge cases   |
+| Previous Prototypes  | `thoughts/shared/product/prototypes/*.md`                   | feature name       | Previous versions, iteration history, feedback received |
+| User Research        | `thoughts/shared/pm/*.md`                                   | user pain, problem | User quotes, pain points, workflows to design for       |
+| Napkin Sketches      | `thoughts/shared/product/prototypes/*-napkin*.md`           | feature name       | ASCII wireframes to convert to prototype                |
 | Stakeholder Profiles | Stakeholder templates                                       | design reviewers   | Who will review this and what they care about           |
-| Business Info        | `pm/context-library/business-info-template.md`              | brand, product     | Brand guidelines, product context, existing UI patterns |
-| Competitor Analysis  | `pm/context-library/research/competitive-*.md`              | feature name       | Competitor implementations for reference                |
+| Business Info        | `thoughts/shared/pm/context/business-info-template.md`      | brand, product     | Brand guidelines, product context, existing UI patterns |
+| Competitor Analysis  | `thoughts/shared/pm/competitive-*.md`                       | feature name       | Competitor implementations for reference                |
 
 **Context Priority:**
 
@@ -98,8 +98,8 @@ Let's build a prototype. First, let me check what we're working with...
 
 **Silently check:**
 
-1. Read most recent PRDs in `thoughts/shared/prds/` and `pm/context-library/prds/`
-2. Check `thoughts/shared/prototypes/` for previous versions
+1. Read most recent PRDs in `thoughts/shared/pm/prds/`
+2. Check `thoughts/shared/product/prototypes/` for previous versions
 3. Read any napkin sketches from `/napkin-sketch`
 4. Check user research for UX-relevant insights
 
@@ -251,7 +251,7 @@ Create a [component/page type] for [product context].
 ---
 ```
 
-Save to: `thoughts/shared/prototypes/[feature-name]-v0-prompt.md`
+Save to: `thoughts/shared/product/prototypes/[feature-name]-v0-prompt.md`
 
 ---
 
@@ -329,7 +329,7 @@ Build a [app type] for [product context].
 ---
 ```
 
-Save to: `thoughts/shared/prototypes/[feature-name]-lovable-prompt.md`
+Save to: `thoughts/shared/product/prototypes/[feature-name]-lovable-prompt.md`
 
 ---
 
@@ -370,7 +370,7 @@ Build a [app type] using [React/Next.js/vanilla].
 ---
 ```
 
-Save to: `thoughts/shared/prototypes/[feature-name]-bolt-prompt.md`
+Save to: `thoughts/shared/product/prototypes/[feature-name]-bolt-prompt.md`
 
 ---
 
@@ -396,7 +396,7 @@ Build the prototype directly in the conversation.
 - Footer/secondary actions
 ```
 
-Save the code to: `thoughts/shared/prototypes/[feature-name]-artifacts-v[N].md`
+Save the code to: `thoughts/shared/product/prototypes/[feature-name]-artifacts-v[N].md`
 
 ---
 
@@ -428,7 +428,7 @@ This checklist goes at the end of the prototype output, before the "Next steps" 
 After generating the prototype, offer next steps:
 
 ```
-Prototype ready! Saved to thoughts/shared/prototypes/[filename].
+Prototype ready! Saved to thoughts/shared/product/prototypes/[filename].
 
 **Next steps:**
 1. **Test it:** [Instructions specific to type -- paste into v0, open in Lovable, etc.]
@@ -449,7 +449,7 @@ Prototype ready! Saved to thoughts/shared/prototypes/[filename].
 
 When the PM comes back with feedback:
 
-1. **Read previous prototype:** Check `thoughts/shared/prototypes/[feature]-*` for history
+1. **Read previous prototype:** Check `thoughts/shared/product/prototypes/[feature]-*` for history
 2. **Understand feedback:** What worked? What didn't? What changed?
 3. **Generate updated version:** Increment version number
 4. **Track changes:** Note what changed between versions

--- a/plugins/pm/skills/ralph-wiggum/SKILL.md
+++ b/plugins/pm/skills/ralph-wiggum/SKILL.md
@@ -10,9 +10,9 @@ user-invocable: true
 **What to provide:** A PRD, strategy doc, decision doc, or any product document you want challenged.
 
 ```
-/ralph-wiggum                          → Review the most recent PRD in thoughts/shared/prds/
+/ralph-wiggum                          → Review the most recent PRD in thoughts/shared/pm/prds/
 /ralph-wiggum [paste document]         → Review pasted content
-/ralph-wiggum thoughts/shared/prds/my-prd.md   → Review a specific file
+/ralph-wiggum thoughts/shared/pm/prds/my-prd.md   → Review a specific file
 ```
 
 **What you get:** A skeptic's review that finds logical gaps, questionable assumptions, and missing data -- delivered with personality and humor. Think sharp product critique meets Ralph Wiggum one-liners.
@@ -36,13 +36,13 @@ When this skill is invoked, immediately check:
 
 | Source              | Files/Folders                                               | Search Terms                   | What to Extract                                                            |
 | ------------------- | ----------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------- |
-| Strategy Docs       | `pm/context-library/strategy/*.md`                          | claims in the document         | Does the document contradict stated strategy?                              |
-| Related PRDs        | `pm/context-library/prds/*.md`, `thoughts/shared/prds/*.md` | feature name, related features | Conflicting scope, duplicated work, missed dependencies                    |
-| User Research       | `pm/context-library/research/*.md`                          | problem claims, user quotes    | Are claims actually supported by research? Are quotes cherry-picked?       |
-| Business Info       | `pm/context-library/business-info-template.md`              | metrics, revenue, North Star   | Do success metrics ladder to the North Star? Are impact numbers realistic? |
-| Decisions           | `pm/context-library/decisions/*.md`                         | feature name, trade-offs       | Has this been tried before? Are we repeating past mistakes?                |
-| Competitor Analysis | `pm/context-library/research/competitive-*.md`              | feature name                   | Is competitor positioning accurate or outdated?                            |
-| Previous Meetings   | `pm/context-library/meetings/*.md`                          | feature name, stakeholders     | Were concerns raised that got swept under the rug?                         |
+| Strategy Docs       | `thoughts/shared/pm/frameworks/*.md`                                    | claims in the document         | Does the document contradict stated strategy?                              |
+| Related PRDs        | `thoughts/shared/pm/prds/*.md`                                          | feature name, related features | Conflicting scope, duplicated work, missed dependencies                    |
+| User Research       | `thoughts/shared/pm/research/*.md`                                      | problem claims, user quotes    | Are claims actually supported by research? Are quotes cherry-picked?       |
+| Business Info       | `thoughts/shared/pm/context/business-info-template.md`                  | metrics, revenue, North Star   | Do success metrics ladder to the North Star? Are impact numbers realistic? |
+| Decisions           | `thoughts/shared/product/decisions/*.md`                                | feature name, trade-offs       | Has this been tried before? Are we repeating past mistakes?                |
+| Competitor Analysis | `thoughts/shared/pm/research/competitive-*.md`                          | feature name                   | Is competitor positioning accurate or outdated?                            |
+| Previous Meetings   | `thoughts/shared/product/meeting-notes/*.md`                            | feature name, stakeholders     | Were concerns raised that got swept under the rug?                         |
 
 **Context Priority:**
 
@@ -102,10 +102,10 @@ When the PM types `/ralph-wiggum`, determine what to review:
 
 1. **If they pasted content:** Use that directly
 2. **If they specified a file path:** Read that file
-3. **If they said nothing:** Check `thoughts/shared/prds/` for the most recently modified file, then ask:
+3. **If they said nothing:** Check `thoughts/shared/pm/prds/` for the most recently modified file, then ask:
 
    ```
-   I found [filename] in thoughts/shared/prds/ (last modified [date]). Want me to roast -- er, review -- this one?
+   I found [filename] in thoughts/shared/pm/prds/ (last modified [date]). Want me to roast -- er, review -- this one?
 
    Or paste/point me to something else.
    ```
@@ -114,10 +114,10 @@ When the PM types `/ralph-wiggum`, determine what to review:
 
 Before reviewing, silently check:
 
-1. **Strategy alignment:** Read `pm/context-library/strategy/*.md`. Does the document's "why now" actually match current strategy?
-2. **Research backing:** Read `pm/context-library/research/*.md`. Are the user pain points real or assumed?
-3. **Past decisions:** Read `pm/context-library/decisions/*.md`. Have we been here before?
-4. **Related PRDs:** Read `pm/context-library/prds/*.md` and `thoughts/shared/prds/*.md`. Any conflicts or dependencies?
+1. **Strategy alignment:** Read `thoughts/shared/pm/frameworks/*.md`. Does the document's "why now" actually match current strategy?
+2. **Research backing:** Read `thoughts/shared/pm/research/*.md`. Are the user pain points real or assumed?
+3. **Past decisions:** Read `thoughts/shared/product/decisions/*.md`. Have we been here before?
+4. **Related PRDs:** Read `thoughts/shared/pm/prds/*.md`. Any conflicts or dependencies?
 5. **Stakeholder concerns:** Read stakeholder profiles. Who will object to this and why?
 
 Note any contradictions, unsupported claims, or gaps for the review.
@@ -186,7 +186,7 @@ Use the output template below. Be specific -- vague feedback is useless. Quote t
 
 ## Output Template
 
-Save to: `thoughts/shared/reviews/[document-name]-ralph-review.md`
+Save to: `thoughts/shared/pm/reviews/[document-name]-ralph-review.md`
 
 ```markdown
 # Ralph Wiggum Review: [Document Title]
@@ -339,7 +339,7 @@ Use these consistently:
 **Ralph is the Skeptic sub-agent from pm/CLAUDE.md:**
 
 - When `/prd-draft` Step 3 offers multi-agent review and the PM picks "Skeptic," invoke Ralph's approach.
-- Ralph complements `pm/sub-agents/engineer-reviewer.md`, `pm/sub-agents/designer-reviewer.md`, and `pm/sub-agents/executive-reviewer.md`.
+- Ralph complements `thoughts/shared/pm/sub-agents/engineer-reviewer.md`, `thoughts/shared/pm/sub-agents/designer-reviewer.md`, and `thoughts/shared/pm/sub-agents/executive-reviewer.md`.
 
 ---
 

--- a/plugins/pm/skills/report-daily/SKILL.md
+++ b/plugins/pm/skills/report-daily/SKILL.md
@@ -171,11 +171,11 @@ Combine research results to identify:
 ### Step 5: Save Report
 
 **IMPORTANT: Document Storage Rules**
-- ALWAYS write to `thoughts/shared/` (appropriate subdirectory)
+- ALWAYS write to `thoughts/shared/pm/reports/`
 - NEVER write to `thoughts/searchable/` — this is a read-only search index
 
 ```bash
-REPORT_DIR="thoughts/shared/reports/daily"
+REPORT_DIR="thoughts/shared/pm/reports"
 mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/$(date +%Y-%m-%d)-team-daily.md"
@@ -210,7 +210,7 @@ Quick Actions:
   • Assign backlog work to Dave and Emily
   • Check TEAM-465 status with Charlie
 
-Full report: thoughts/shared/reports/daily/2025-01-27-team-daily.md
+Full report: thoughts/shared/pm/reports/2025-01-27-team-daily.md
 ```
 
 ## Success Criteria

--- a/plugins/pm/skills/retention-analysis/SKILL.md
+++ b/plugins/pm/skills/retention-analysis/SKILL.md
@@ -22,7 +22,7 @@ Then provide:
 I'll analyze your retention curve shape, identify the biggest drop-off,
 compare retained vs churned user behavior, and recommend interventions.
 
-**Output:** Saved to `thoughts/shared/analyses/retention-analysis-[date].md`
+**Output:** Saved to `thoughts/shared/pm/analyses/retention-analysis-[date].md`
 **Time:** ~15 min with data, ~25 min with cohort deep-dive
 
 **When to use:** When diagnosing churn problems, measuring product-market fit, or optimizing for stickiness
@@ -36,11 +36,11 @@ When this skill is invoked, immediately check:
 
 | Source            | Files/Folders                                  | Search Terms                                                               | What to Extract                                              |
 | ----------------- | ---------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Metrics/Analytics | `pm/context-library/metrics/*.md`              | D7, D30, retention, churn, cohort, "monthly active", DAU, WAU              | Current retention curves, cohort performance, churn rates    |
-| User Research     | `pm/context-library/research/*.md`             | churn, "stopped using", "didn't come back", "why I left", "why I switched" | Churn interview quotes, reasons users stop using product     |
-| Meeting Notes     | `pm/context-library/meetings/*.md`             | churn, "cancelled", "downgrade", lost deal, customer feedback              | CS feedback on churn, customer complaints, drop-off patterns |
-| PRDs              | `pm/context-library/prds/*.md`                 | retention, sticky, habit, engagement, notification, reminder               | Features built to improve retention                          |
-| Business Info     | `pm/context-library/business-info-template.md` | target user, use case, frequency, engagement, core activity                | How often users should use product, what drives stickiness   |
+| Metrics/Analytics | `thoughts/shared/pm/metrics/*.md`              | D7, D30, retention, churn, cohort, "monthly active", DAU, WAU              | Current retention curves, cohort performance, churn rates    |
+| User Research     | `thoughts/shared/pm/*.md`                      | churn, "stopped using", "didn't come back", "why I left", "why I switched" | Churn interview quotes, reasons users stop using product     |
+| Meeting Notes     | `thoughts/shared/product/meeting-notes/*.md`   | churn, "cancelled", "downgrade", lost deal, customer feedback              | CS feedback on churn, customer complaints, drop-off patterns |
+| PRDs              | `thoughts/shared/pm/prds/*.md`                 | retention, sticky, habit, engagement, notification, reminder               | Features built to improve retention                          |
+| Business Info     | `thoughts/shared/pm/context/business-info-template.md` | target user, use case, frequency, engagement, core activity                | How often users should use product, what drives stickiness   |
 
 **Context Priority:**
 
@@ -62,11 +62,11 @@ Before diving into retention analysis, let me check what data already exists abo
 
 **Checking:**
 
-- `pm/context-library/business-info-template.md` for expected product usage patterns
-- `pm/context-library/metrics/` for existing retention metrics and cohort data
-- `pm/context-library/research/` for churn interviews and user feedback
-- `pm/context-library/meetings/` for CS/support feedback on why users churn
-- `pm/context-library/prds/` for features built to improve retention
+- `thoughts/shared/pm/context/business-info-template.md` for expected product usage patterns
+- `thoughts/shared/pm/metrics/` for existing retention metrics and cohort data
+- `thoughts/shared/pm/` for churn interviews and user feedback
+- `thoughts/shared/product/meeting-notes/` for CS/support feedback on why users churn
+- `thoughts/shared/pm/prds/` for features built to improve retention
 
 **[If analytics MCP connected]:** "Let me also query [PostHog/PostHog] for your current retention curves, churn rates by cohort, and behavioral differences between retained vs churned users."
 
@@ -307,7 +307,7 @@ Referrals: 70% D30 retention
 **Run retention analysis:**
 
 ```
-Use /retention-analysis and reference pm/context-library/business-info-template.md
+Use /retention-analysis and reference [[business-info-template]]
 
 Help me analyze our retention:
 - D1 retention: ___%
@@ -579,18 +579,17 @@ Use this with your data:
 
 **Research & Findings:**
 
-- Save to: `thoughts/shared/analyses/retention-analysis-[date].md`
-- When finalized, move to: `pm/context-library/research/retention-[product].md`
+- Save to: `thoughts/shared/pm/analyses/retention-analysis-[date].md`
 
 **Retention Metrics & Dashboards:**
 
-- Update `pm/context-library/metrics/` with your retention dashboard
+- Update `thoughts/shared/pm/metrics/` with your retention dashboard
 - Include retention curves, cohort analysis, and trend notes
 - Link retention findings to broader business metrics
 
 **Retention Features & Improvements:**
 
-- Create PRD in `pm/context-library/prds/` for each retention initiative
+- Create PRD in `thoughts/shared/pm/prds/` for each retention initiative
 - Link this retention analysis as context
 - Track impact in PRD success metrics
 

--- a/plugins/pm/skills/slack-message/SKILL.md
+++ b/plugins/pm/skills/slack-message/SKILL.md
@@ -424,7 +424,7 @@ Based on your situation, I'll automatically:
 
 ### Stakeholder-Specific Customization
 
-I'll check `pm/context-library/stakeholder-template.md` (and any profiles you add) and adapt:
+I'll check `thoughts/shared/pm/context/stakeholder-template.md` (and any profiles you add) and adapt:
 
 **For detail-oriented stakeholders:**
 - Include more context and data
@@ -537,25 +537,25 @@ Slack lets you edit. Use it. Fix typos, clarify wording, add missing context.
 When the PM uses `/slack-message`, I automatically:
 
 ### 1. Pull Stakeholder Context
-**Source:** `pm/context-library/stakeholder-template.md` + any stakeholder profiles
+**Source:** `thoughts/shared/pm/context/stakeholder-template.md` + any stakeholder profiles
 - **What I look for:** Communication preferences, decision-making style, priorities, relationship history
 - **How I use it:** Adapt tone, detail level, and framing to the specific recipient
 - **Example:** If messaging a detail-oriented CFO, I'll include numbers and source links. If messaging a busy CEO, I'll use BLUF format.
 
 ### 2. Reference Writing Style
-**Source:** `pm/context-library/writing-style-*.md`
+**Source:** `thoughts/shared/pm/context/writing-style-*.md`
 - **What I look for:** Your preferred communication voice (formal/casual/direct/collaborative)
 - **How I use it:** Match your authentic voice, not corporate-speak
 - **Example:** If your style is "conversational but professional," I won't use buzzwords like "leverage" or "synergize"
 
 ### 3. Check Recent Decisions & Context
-**Source:** `pm/context-library/decisions/`, recent conversation history
+**Source:** `thoughts/shared/product/decisions/`, recent conversation history
 - **What I look for:** Decisions that affect the message, strategic context, previous disagreements
 - **How I use it:** Reference decisions without re-explaining context, acknowledge past objections
 - **Example:** If you previously decided to prioritize retention over growth, I won't frame a new request around growth
 
 ### 4. Pull Meeting Notes for Specificity
-**Source:** `pm/context-library/meetings/` + this chat thread
+**Source:** `thoughts/shared/product/meeting-notes/` + this chat thread
 - **What I look for:** Specific meeting outcomes, action items, decisions, quotes
 - **How I use it:** Reference the actual meeting (date, attendees) rather than generic "our conversation"
 - **Example:** "From our Jan 28 roadmap review with Sarah..." instead of "We discussed this meeting"
@@ -583,4 +583,4 @@ Before presenting output to the PM, verify:
 - [ ] **Message has clear ask or action item:** The message contains a specific request, decision needed, or next step (not just information with no call to action)
 - [ ] **No corporate jargon or banned words:** The message does not contain "delve," "leverage," "utilize," "unlock," "harness," "synergize," or other banned words from the writing style guide
 - [ ] **Length appropriate for Slack:** The main message is 5 sentences or fewer; any additional detail is suggested as a thread reply or linked document
-- [ ] **Stakeholder communication style referenced:** If the recipient has a profile in `pm/context-library/stakeholder-template.md`, their communication preferences (detail level, format, priorities) are reflected in the message
+- [ ] **Stakeholder communication style referenced:** If the recipient has a profile in `thoughts/shared/pm/context/stakeholder-template.md`, their communication preferences (detail level, format, priorities) are reflected in the message

--- a/plugins/pm/skills/status-update/SKILL.md
+++ b/plugins/pm/skills/status-update/SKILL.md
@@ -32,11 +32,11 @@ When this skill is invoked, immediately check:
 
 | Source               | Files/Folders                      | Search Terms                      | What to Extract                   |
 | -------------------- | ---------------------------------- | --------------------------------- | --------------------------------- |
-| Recent PRDs          | `pm/context-library/prds/*.md`     | feature being updated             | Feature status and changes        |
-| Meeting Notes        | `pm/context-library/meetings/*.md` | this week's meetings              | Decisions, action items, blockers |
-| Action Items         | `pm/context-library/meetings/`     | completed / in progress / blocked | Track completion of commitments   |
-| Strategy             | `pm/context-library/strategy/*.md` | strategic pillars                 | Tie accomplishments to strategy   |
-| Metrics              | `pm/context-library/metrics/*.md`  | baseline, trends                  | Metric movement and progress      |
+| Recent PRDs          | `thoughts/shared/pm/prds/*.md`              | feature being updated             | Feature status and changes        |
+| Meeting Notes        | `thoughts/shared/product/meeting-notes/*.md` | this week's meetings              | Decisions, action items, blockers |
+| Action Items         | `thoughts/shared/product/meeting-notes/`     | completed / in progress / blocked | Track completion of commitments   |
+| Strategy             | `thoughts/shared/pm/frameworks/*.md`         | strategic pillars                 | Tie accomplishments to strategy   |
+| Metrics              | `thoughts/shared/pm/metrics/*.md`            | baseline, trends                  | Metric movement and progress      |
 | Stakeholder Profiles | Stakeholder templates              | your audience                     | Communication style for audience  |
 
 **Context Priority:**
@@ -61,10 +61,10 @@ Before drafting, let me gather what happened...
 
 **Checking:**
 
-- `pm/context-library/meetings/` for recent meetings this week/period
-- `pm/context-library/prds/` for features you're working on
-- `pm/context-library/metrics/` for recent metric changes
-- `pm/context-library/strategy/` for strategic context
+- `thoughts/shared/product/meeting-notes/` for recent meetings this week/period
+- `thoughts/shared/pm/prds/` for features you're working on
+- `thoughts/shared/pm/metrics/` for recent metric changes
+- `thoughts/shared/pm/frameworks/` for strategic context
 - Stakeholder profiles for communication style of audience
 
 **Based on what I find, I'll show you:**
@@ -864,8 +864,7 @@ Given the extra time, we could:
 
 **Status updates:**
 
-- Weekly/recurring: Save to `thoughts/shared/status-updates/[date]-[audience].md`
-- Archive: Move finalized updates to `pm/context-library/meetings/status-updates/` for historical record
+- Weekly/recurring: Save to `thoughts/shared/pm/reports/[date]-[audience].md`
 - Share: Send directly or paste into Slack/email
 
 ### Link to Other Work
@@ -893,7 +892,7 @@ After creating status update:
 - `/prd-draft` - Feature status and progress on PRDs
 - `/feature-results` - Shipped feature performance
 - `/metrics-framework` - Current metric values and movement
-- `pm/context-library/strategy/` - Strategic context and goals
+- `thoughts/shared/pm/frameworks/` - Strategic context and goals
 
 ---
 

--- a/plugins/pm/skills/strategy-sprint/SKILL.md
+++ b/plugins/pm/skills/strategy-sprint/SKILL.md
@@ -14,10 +14,10 @@ user-invocable: true
 ## Quick Start
 
 1. Tell me: "I need a [1-day / 1-week / 1-month] strategy for [topic]"
-2. I will check `pm/context-library/strategy/` and `pm/context-library/business-info-template.md` for existing context
+2. I will check `thoughts/shared/pm/frameworks/` and `thoughts/shared/pm/context/business-info-template.md` for existing context
 3. I will ask 3-5 clarifying questions about scope, stakeholders, and constraints
 4. We build progressively -- even a 1-month sprint starts with the 1-day foundation first
-5. Output goes to `thoughts/shared/strategy-[topic]-[date].md`
+5. Output goes to `thoughts/shared/product/strategy/strategy-[topic]-[date].md`
 
 **Which tier should you pick?**
 
@@ -114,12 +114,12 @@ Strategy doesn't always need to be a month-long exercise. Depending on your time
 1. **Jobs-to-Be-Done Analysis**
    - What job is the customer hiring our product to do?
    - What progress are they trying to make?
-   - Reference: `@pm/context-library/strategy/jtbd-canvas.md`
+   - Reference: [[jtbd-canvas]]
 
 2. **Competitive Positioning**
    - How do we differentiate?
    - What's our unfair advantage?
-   - Reference: `@pm/context-library/strategy/7-powers-framework.md`
+   - Reference: [[7-powers-framework]]
 
 3. **User Research Validation**
    - 5-10 customer interviews
@@ -183,7 +183,7 @@ Strategy doesn't always need to be a month-long exercise. Depending on your time
 3. **7 Powers Analysis**
    - Which power(s) does this unlock?
    - Network effects, brand, scale, switching costs?
-   - Reference: `@pm/context-library/strategy/7-powers-framework.md`
+   - Reference: [[7-powers-framework]]
 
 4. **Financial Model**
    - Revenue projections
@@ -250,7 +250,7 @@ Ask yourself:
 ### Step 2: Use This Prompt Pattern
 
 ```
-Use /strategy-sprint and reference pm/context-library/business-info-template.md
+Use /strategy-sprint and reference thoughts/shared/pm/context/business-info-template.md
 
 I need to create a [1-day / 1-week / 1-month] strategy for: [describe the opportunity/problem]
 
@@ -291,7 +291,7 @@ Help me work through the appropriate framework step by step.
 - Schedule stakeholder reviews in weeks 2-3, not week 4
 - Build in time to incorporate feedback
 - Create a FAQ doc as you go (capture all questions you get)
-- Use sub-agents for multiple perspectives: `@pm/sub-agents/engineer-reviewer.md`, `@pm/sub-agents/executive-reviewer.md`
+- Use sub-agents for multiple perspectives: [[engineer-reviewer]], [[executive-reviewer]]
 
 **Universal tip:**
 
@@ -358,8 +358,8 @@ Help me work through the appropriate framework step by step.
 - `/prd-draft` - Turn strategy into PRDs
 - `/competitor-analysis` - Research competitors
 - `/user-research-synthesis` - Process customer insights
-- `pm/context-library/strategy/jtbd-canvas.md` - Understand customer jobs
-- `pm/context-library/strategy/7-powers-framework.md` - Identify unfair advantages
+- [[jtbd-canvas]] - Understand customer jobs
+- [[7-powers-framework]] - Identify unfair advantages
 
 ---
 

--- a/plugins/pm/skills/sync-prs/SKILL.md
+++ b/plugins/pm/skills/sync-prs/SKILL.md
@@ -172,11 +172,11 @@ linearis comments create TEAM-457 --body "PR #124 merged: https://github.com/use
 ### Step 4: Save Report
 
 **IMPORTANT: Document Storage Rules**
-- ALWAYS write to `thoughts/shared/` (appropriate subdirectory)
+- ALWAYS write to `thoughts/shared/pm/reports/`
 - NEVER write to `thoughts/searchable/` — this is a read-only search index
 
 ```bash
-REPORT_DIR="thoughts/shared/reports/pr-sync"
+REPORT_DIR="thoughts/shared/pm/reports"
 mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/$(date +%Y-%m-%d)-pr-sync.md"
@@ -212,7 +212,7 @@ Actions available:
   2. Create Linear issues for orphaned PRs
   3. View full report
 
-Full report: thoughts/shared/reports/pr-sync/2025-01-27-pr-sync.md
+Full report: thoughts/shared/pm/reports/2025-01-27-pr-sync.md
 ```
 
 ## Success Criteria

--- a/plugins/pm/skills/user-interview/SKILL.md
+++ b/plugins/pm/skills/user-interview/SKILL.md
@@ -24,7 +24,7 @@ Tell me:
 I'll cross-reference with your existing research, extract pain points,
 feature requests, JTBD insights, and generate a shareable report.
 
-Output: thoughts/shared/research-synthesis/[date]-interview-insights.md
+Output: thoughts/shared/pm/interviews/[date]-interview-insights.md
 ```
 
 ---
@@ -56,11 +56,11 @@ When this skill is invoked, immediately check:
 
 | Source                                       | What to Check                                   | Priority |
 | -------------------------------------------- | ----------------------------------------------- | -------- |
-| pm/context-library/research/                 | Previous interview syntheses, existing themes   | High     |
-| pm/context-library/prds/                     | Active PRDs that this interview relates to      | High     |
-| pm/context-library/stakeholder-template.md   | If interviewee is a known stakeholder/customer  | Medium   |
-| pm/context-library/business-info-template.md | Company context, product positioning            | Medium   |
-| pm/context-library/launches/                 | Recent launches the interviewee might reference | Low      |
+| thoughts/shared/pm/research/                          | Previous interview syntheses, existing themes   | High     |
+| thoughts/shared/pm/prds/                              | Active PRDs that this interview relates to      | High     |
+| thoughts/shared/pm/context/stakeholder-template.md    | If interviewee is a known stakeholder/customer  | Medium   |
+| thoughts/shared/pm/context/business-info-template.md  | Company context, product positioning            | Medium   |
+| thoughts/shared/pm/launches/                          | Recent launches the interviewee might reference | Low      |
 
 **Context Priority:**
 
@@ -91,10 +91,10 @@ When this skill is invoked, immediately check:
 
 **Before processing new interviews, check existing context:**
 
-1. Search `pm/context-library/research/` for previous interview syntheses and findings
+1. Search `thoughts/shared/pm/research/` for previous interview syntheses and findings
 2. Identify validated themes from prior research
 3. Note which PRDs or strategic initiatives these interviews relate to
-4. Check `pm/context-library/business-info-template.md` for product positioning context
+4. Check `thoughts/shared/pm/context/business-info-template.md` for product positioning context
 
 **For each theme that emerges in the new interviews:**
 
@@ -106,9 +106,9 @@ When this skill is invoked, immediately check:
 
 ```
 ## Existing Research Context
-- Found [N] previous interview syntheses in pm/context-library/research/
+- Found [N] previous interview syntheses in thoughts/shared/pm/research/
 - Validated themes from prior research: [list]
-- Active PRDs this research relates to: [list]
+- Active PRDs from thoughts/shared/pm/prds/ this research relates to: [list]
 - New themes to watch for: [will identify during analysis]
 ```
 
@@ -192,7 +192,7 @@ Ask Claude:
 - Top 3 feature requests
 - Recommended next steps
 Format as a report I can share with my team.
-Save to thoughts/shared/research-synthesis/[date]-interview-insights.md"
+Save to thoughts/shared/pm/interviews/[date]-interview-insights.md"
 ```
 
 ---
@@ -423,7 +423,7 @@ research repository is purpose-built for research synthesis:
 
 **Build a repository:**
 
-- All past interviews in `pm/context-library/research/`
+- All past interviews in `thoughts/shared/pm/research/`
 - Searchable by theme/topic
 - Updated quote bank
 - Trend tracking over time
@@ -487,7 +487,7 @@ research repository is purpose-built for research synthesis:
 
 **Using Claude Code:**
 
-- Keep all transcripts in `pm/context-library/research/interviews/`
+- Keep all transcripts in `thoughts/shared/pm/interviews/`
 - Query anytime: "Search all interviews for mentions of [topic]"
 - Get instant insights from entire history
 
@@ -537,16 +537,16 @@ Before delivering the final research synthesis, verify:
 
 | Check                            | Criteria                                                                          | Pass? |
 | -------------------------------- | --------------------------------------------------------------------------------- | ----- |
-| **Existing research referenced** | Cross-referenced with `pm/context-library/research/` findings                     | [ ]   |
+| **Existing research referenced** | Cross-referenced with `thoughts/shared/pm/research/` findings                     | [ ]   |
 | **Themes labeled correctly**     | Each theme marked as VALIDATED, CHALLENGED, or NEW vs. prior research             | [ ]   |
 | **Quotes are real**              | Every quote is directly from a transcript (not paraphrased or invented)           | [ ]   |
 | **Pain points quantified**       | Each pain point shows how many users mentioned it + severity                      | [ ]   |
 | **Actionable recommendations**   | At least 3 specific next steps with owners and timelines                          | [ ]   |
-| **PRD linkage**                  | Insights connected to relevant active PRDs in `pm/context-library/prds/`          | [ ]   |
+| **PRD linkage**                  | Insights connected to relevant active PRDs in `thoughts/shared/pm/prds/`          | [ ]   |
 | **Segments identified**          | At least 2 distinct user archetypes with unique needs called out                  | [ ]   |
 | **Surprises captured**           | At least 1 unexpected finding or challenged assumption noted                      | [ ]   |
 | **Scope boundary stated**        | User knows when to use this skill vs /user-research-synthesis                     | [ ]   |
-| **Output file saved**            | Report saved to `thoughts/shared/research-synthesis/[date]-interview-insights.md` | [ ]   |
+| **Output file saved**            | Report saved to `thoughts/shared/pm/interviews/[date]-interview-insights.md` | [ ]   |
 
 **If any check fails, address it before delivering the output.**
 

--- a/plugins/pm/skills/user-research-synthesis/SKILL.md
+++ b/plugins/pm/skills/user-research-synthesis/SKILL.md
@@ -16,11 +16,11 @@ When this skill is invoked, immediately check:
 
 | Source             | Files/Folders                                   | Search Terms                   | What to Extract                        |
 | ------------------ | ----------------------------------------------- | ------------------------------ | -------------------------------------- |
-| Existing Research  | `pm/context-library/research/*.md`              | topic from chat, user segments | Previous findings to avoid duplication |
-| Related PRDs       | `pm/context-library/prds/*.md`                  | problem related to interviews  | Problem framing and hypothesis         |
-| Strategy Context   | `pm/context-library/strategy/*.md`              | user segment, strategic fit    | How findings ladder to strategy        |
-| Previous Synthesis | `thoughts/shared/research-synthesis/`           | topic name                     | Past research to build on              |
-| Interview Guides   | `pm/context-library/research/interview-guides/` | topic                          | What questions were asked              |
+| Existing Research  | `thoughts/shared/pm/research/*.md`              | topic from chat, user segments | Previous findings to avoid duplication |
+| Related PRDs       | `thoughts/shared/pm/prds/*.md`                  | problem related to interviews  | Problem framing and hypothesis         |
+| Strategy Context   | `thoughts/shared/pm/frameworks/*.md`            | user segment, strategic fit    | How findings ladder to strategy        |
+| Previous Synthesis | `thoughts/shared/pm/interviews/`                | topic name                     | Past research to build on              |
+| Interview Guides   | `thoughts/shared/pm/interviews/`                | topic                          | What questions were asked              |
 
 **Context Priority:**
 
@@ -44,8 +44,8 @@ Before we synthesize, let me understand what you've learned...
 
 **Checking:**
 
-- `pm/context-library/research/` for previous findings on this topic
-- `pm/context-library/prds/` for the problem statement
+- `thoughts/shared/pm/research/` for previous findings on this topic
+- `thoughts/shared/pm/prds/` for the problem statement
 - Interview guides used: what were you trying to validate?
 - Previous synthesis on related topics
 
@@ -588,8 +588,7 @@ I'll remind you:
 
 **Research synthesis:**
 
-- Active work: `thoughts/shared/research-synthesis/[topic]-[date].md`
-- When finalized: Archive to `pm/context-library/research/[topic]-synthesis.md` for future reference
+- Active work: `thoughts/shared/pm/interviews/[topic]-[date].md`
 - Executive summary: Can be shared directly with stakeholders
 
 ### Link to Other Work
@@ -612,10 +611,10 @@ After synthesis:
 
 **Pulls from:**
 
-- `pm/context-library/research/` - What questions were asked?
-- `pm/context-library/prds/` - What was the original problem hypothesis?
+- `thoughts/shared/pm/research/` - What questions were asked?
+- `thoughts/shared/pm/prds/` - What was the original problem hypothesis?
 - `/interview-guide` - Questions asked in the interview
-- `pm/context-library/meetings/` - Past conversations about this problem
+- `thoughts/shared/product/meeting-notes/` - Past conversations about this problem
 
 ---
 
@@ -685,8 +684,7 @@ When synthesis is complete, I'll create:
 
 All files will be saved to:
 
-- `thoughts/shared/research-synthesis/[topic]-[date].md`
-- `pm/context-library/personal-context-pm-background.md` (updated)
+- `thoughts/shared/pm/interviews/[topic]-[date].md`
 
 ---
 
@@ -712,8 +710,8 @@ Remember: User research isn't about validation. It's about discovery. The goal i
 
 Before presenting output to the PM, verify:
 
-- [ ] **File saved to correct location:** Output saved to `thoughts/shared/research-synthesis/[topic]-[date].md`
-- [ ] **Context routing table was checked:** Reviewed `pm/context-library/research/` for past findings, `pm/context-library/prds/` for related problem statements, and `pm/context-library/strategy/` for strategic fit
+- [ ] **File saved to correct location:** Output saved to `thoughts/shared/pm/interviews/[topic]-[date].md`
+- [ ] **Context routing table was checked:** Reviewed `thoughts/shared/pm/research/` for past findings, `thoughts/shared/pm/prds/` for related problem statements, and `thoughts/shared/pm/frameworks/` for strategic fit
 - [ ] **Themes backed by 2+ sources:** Every theme in the synthesis is supported by observations from at least 2 different interview participants (not a single anecdote)
 - [ ] **Direct user quotes included:** Each key finding includes at least one verbatim user quote with attribution (participant name or identifier)
 - [ ] **Insight severity/frequency rated:** Every theme has a frequency count (e.g., "6 out of 8 users") and a severity rating (High/Medium/Low)

--- a/plugins/pm/skills/weekly-plan/SKILL.md
+++ b/plugins/pm/skills/weekly-plan/SKILL.md
@@ -19,11 +19,11 @@ Plan your week forward with clear priorities tied to quarterly goals. Sets the f
 
 **Check these files first:**
 
-1. `pm/context-library/strategy/` - Quarter OKRs, North Star, strategic pillars
-2. `thoughts/shared/weekly-reviews/` - Last week's review (if exists)
-3. `thoughts/shared/prds/` - Active PRDs and their stages
-4. `pm/context-library/launches/` - Upcoming launches
-5. `thoughts/shared/weekly-plans/` - Previous weekly plans (for pattern analysis)
+1. `thoughts/shared/pm/frameworks/` - Quarter OKRs, North Star, strategic pillars
+2. `thoughts/shared/pm/reports/` - Last week's review (if exists)
+3. `thoughts/shared/pm/prds/` - Active PRDs and their stages
+4. `thoughts/shared/pm/launches/` - Upcoming launches
+5. `thoughts/shared/pm/reports/` - Previous weekly plans (for pattern analysis)
 
 **MCP Queries (if available):**
 
@@ -45,14 +45,14 @@ Plan your week forward with clear priorities tied to quarterly goals. Sets the f
    - If user specified "next": Next week
 
 2. **Check if week already planned:**
-   - Look for `thoughts/shared/weekly-plans/YYYY-WXX-weekly-plan.md`
+   - Look for `thoughts/shared/pm/reports/YYYY-WXX-weekly-plan.md`
    - If exists: Ask "Week already planned. Update it or create new version?"
 
 ---
 
 ### Step 2: Review Last Week (If Available)
 
-Check for `thoughts/shared/weekly-reviews/[last-week]-weekly-review.md`:
+Check for `thoughts/shared/pm/reports/[last-week]-weekly-review.md`:
 
 If exists, extract:
 
@@ -72,7 +72,7 @@ If doesn't exist:
 
 **A. Quarter Goals & North Star:**
 
-Read `pm/context-library/strategy/`:
+Read `thoughts/shared/pm/frameworks/`:
 
 - Current quarter OKRs
 - North Star metric and target
@@ -88,7 +88,7 @@ Extract:
 
 **B. Active PRD Pipeline:**
 
-Scan `thoughts/shared/prds/` and `pm/context-library/prds/`:
+Scan `thoughts/shared/pm/prds/`:
 
 For each active PRD:
 
@@ -112,7 +112,7 @@ Identify: Which PRDs need to advance this week?
 
 **C. Upcoming Launches:**
 
-Check `pm/context-library/launches/`:
+Check `thoughts/shared/pm/launches/`:
 
 - Features launching this week
 - Pre-launch checklists due
@@ -204,7 +204,7 @@ This helps with:
 
 ### Step 6: Generate Weekly Plan
 
-Create file: `thoughts/shared/weekly-plans/YYYY-WXX-weekly-plan.md`
+Create file: `thoughts/shared/pm/reports/YYYY-WXX-weekly-plan.md`
 
 **Template:**
 
@@ -447,7 +447,7 @@ _Next: Run `/daily-plan` each morning to execute against this plan_
 **If strategy docs don't exist:**
 
 - Ask: "What are your top quarterly goals?"
-- Suggest: "Fill out `pm/context-library/strategy/OKRs.md` for better alignment"
+- Suggest: "Fill out `thoughts/shared/pm/frameworks/OKRs.md` for better alignment"
 
 ---
 
@@ -521,8 +521,8 @@ _Next: Run `/daily-plan` each morning to execute against this plan_
 
 Before presenting output to the PM, verify:
 
-- [ ] **Context was checked:** Reviewed `pm/context-library/strategy/` for quarter OKRs, `thoughts/shared/prds/` for active PRDs, and `pm/context-library/meetings/` for upcoming commitments
+- [ ] **Context was checked:** Reviewed `thoughts/shared/pm/frameworks/` for quarter OKRs, `thoughts/shared/pm/prds/` for active PRDs, and `thoughts/shared/product/meeting-notes/` for upcoming commitments
 - [ ] **Priorities aligned with strategic goals:** Each of the top 3 priorities explicitly references which quarter goal, OKR, or strategic pillar it advances
 - [ ] **LNO classification applied:** Key tasks are tagged as Leverage, Neutral, or Overhead to ensure the week is weighted toward high-leverage work
 - [ ] **Dependencies and blockers identified:** Each priority lists what it depends on (people, decisions, deliverables) and any known blockers with mitigation plans
-- [ ] **Carry-over items from last week addressed:** If `thoughts/shared/weekly-reviews/` or `thoughts/shared/weekly-plans/` contain incomplete items from last week, they are explicitly acknowledged as carried over, deferred, or dropped with reasoning
+- [ ] **Carry-over items from last week addressed:** If `thoughts/shared/pm/reports/` contains incomplete items from last week, they are explicitly acknowledged as carried over, deferred, or dropped with reasoning

--- a/plugins/pm/skills/weekly-review/SKILL.md
+++ b/plugins/pm/skills/weekly-review/SKILL.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 1. Run `/weekly-review` on Friday afternoon (best time) or Monday morning
 2. I will scan your workspace: weekly plans, daily plans, PRDs, meeting notes, decisions, and launches from the past 7 days
 3. I will generate a focused review comparing plan vs. actual, surfacing key wins, blockers, and learnings
-4. Output goes to `thoughts/shared/weekly-reviews/YYYY-WXX-weekly-review.md`
+4. Output goes to `thoughts/shared/pm/reports/YYYY-WXX-weekly-review.md`
 5. After the review, I will suggest running `/weekly-plan` to plan next week
 
 **Default output is focused (~150 lines max).** Say "full review" if you want the expanded version with stakeholder pulse, task-level execution metrics, and pattern analysis.
@@ -29,14 +29,14 @@ End-of-week synthesis reviewing what you accomplished, what you learned, and wha
 
 **Check these files first:**
 
-1. `thoughts/shared/weekly-plans/` - This week's plan (what you intended)
-2. `thoughts/shared/daily-plans/` - Daily plans from this week (what actually happened)
-3. `thoughts/shared/prds/` - PRDs modified this week
-4. `thoughts/shared/meeting-notes/` - Meeting notes from past 7 days
-5. `pm/context-library/launches/` - Launches that happened this week
-6. `pm/context-library/decisions/` - Decisions made this week
-7. `thoughts/shared/research-synthesis/` - Research conducted
-8. `pm/context-library/strategy/` - Quarter goals (to track progress)
+1. `thoughts/shared/pm/reports/` - This week's plan (what you intended)
+2. `thoughts/shared/pm/reports/` - Daily plans from this week (what actually happened)
+3. `thoughts/shared/pm/prds/` - PRDs modified this week
+4. `thoughts/shared/product/meeting-notes/` - Meeting notes from past 7 days
+5. `thoughts/shared/pm/launches/` - Launches that happened this week
+6. `thoughts/shared/product/decisions/` - Decisions made this week
+7. `thoughts/shared/pm/analyses/` - Research conducted
+8. `thoughts/shared/pm/frameworks/` - Quarter goals (to track progress)
 
 **MCP Queries (if available):**
 
@@ -59,7 +59,7 @@ End-of-week synthesis reviewing what you accomplished, what you learned, and wha
    - If user specified: Use that week
 
 2. **Check if review already exists:**
-   - Look for `thoughts/shared/weekly-reviews/YYYY-WXX-weekly-review.md`
+   - Look for `thoughts/shared/pm/reports/YYYY-WXX-weekly-review.md`
    - If exists: Ask "Update existing review or create new version?"
 
 ---
@@ -68,7 +68,7 @@ End-of-week synthesis reviewing what you accomplished, what you learned, and wha
 
 **A. Weekly Plan (What Was Intended):**
 
-Read `thoughts/shared/weekly-plans/YYYY-WXX-weekly-plan.md`:
+Read `thoughts/shared/pm/reports/YYYY-WXX-weekly-plan.md`:
 
 Extract:
 
@@ -86,13 +86,13 @@ If no weekly plan exists:
 
 **B. PRD Progress:**
 
-Scan `thoughts/shared/prds/` and `pm/context-library/prds/`:
+Scan `thoughts/shared/pm/prds/`:
 
 Method 1 - File modification dates:
 
 ```bash
 # Files modified in the past 7 days
-find thoughts/shared/prds/ pm/context-library/prds/ -name "*.md" -mtime -7
+find thoughts/shared/pm/prds/ -name "*.md" -mtime -7
 ```
 
 For each PRD touched this week:
@@ -119,7 +119,7 @@ git log --since="7 days ago" --name-only --pretty=format: | grep -E "prds/.*\.md
 
 **C. Feature Launches:**
 
-Check `pm/context-library/launches/`:
+Check `thoughts/shared/pm/launches/`:
 
 - Launches completed this week
 - Launch checklists finished
@@ -144,14 +144,14 @@ Categorize:
 
 **D. Meetings & Decisions:**
 
-Scan `thoughts/shared/meeting-notes/` from past 7 days:
+Scan `thoughts/shared/product/meeting-notes/` from past 7 days:
 
 For each meeting:
 
 - Extract date, attendees, topic
 - Look for: Decisions made, action items created, blockers identified
 
-Check `pm/context-library/decisions/`:
+Check `thoughts/shared/product/decisions/`:
 
 - Decision docs created this week
 - Link to related meetings
@@ -198,12 +198,12 @@ Initiative: [PRD Name]
 
 **F. User Research & Insights:**
 
-Check `pm/context-library/research/`:
+Check `thoughts/shared/pm/`:
 
 - New interview notes this week
 - Competitive analysis updates
 
-Check `thoughts/shared/research-synthesis/`:
+Check `thoughts/shared/pm/analyses/`:
 
 - Synthesis reports created
 - Themes identified
@@ -258,7 +258,7 @@ For each PRD:
 
 **Strategic Alignment:**
 
-Read `pm/context-library/strategy/` for quarter goals.
+Read `thoughts/shared/pm/frameworks/` for quarter goals.
 
 For each goal:
 
@@ -291,7 +291,7 @@ Look for:
 
 ### Step 4: Generate Weekly Review
 
-Create file: `thoughts/shared/weekly-reviews/YYYY-WXX-weekly-review.md`
+Create file: `thoughts/shared/pm/reports/YYYY-WXX-weekly-review.md`
 
 **Output Length Guidance:**
 
@@ -684,7 +684,7 @@ After generating review, prompt user with contextual suggestions:
 > - [Learning 1]
 > - [Learning 2]
 >
-> I'll surface these in future planning. Want me to add to `pm/context-library/personal-context/lessons-learned.md`?"
+> I'll surface these in future planning. Want me to add to `thoughts/shared/pm/context/lessons-learned.md`?"
 
 **If metrics concerning:**
 

--- a/plugins/pm/skills/write-prod-strategy/SKILL.md
+++ b/plugins/pm/skills/write-prod-strategy/SKILL.md
@@ -11,10 +11,10 @@ Create comprehensive product strategy using a 7-component framework. Connects vi
 ## Quick Start
 
 1. Tell me: "I need a product strategy for [product/initiative]"
-2. I will check `pm/context-library/strategy/`, `pm/context-library/business-info-template.md`, and `pm/context-library/research/` for existing context
+2. I will check `thoughts/shared/pm/frameworks/`, `thoughts/shared/pm/context/business-info-template.md`, and `thoughts/shared/pm/research/` for existing context
 3. I will ask about scope (company vs product), horizon (6mo/1yr/3yr), audience, and whether we are building on or replacing existing strategy
 4. We work through the 7 components: Objective, Users, Superpowers, Vision, Pillars, Impact, Roadmap
-5. Output goes to `thoughts/shared/analyses/strategy-[product]-[date].md`
+5. Output goes to `thoughts/shared/pm/analyses/strategy-[product]-[date].md`
 
 **Output length:** A complete 7-component strategy doc should be 2,000-3,000 words with an executive summary of 200-300 words. If you want a shorter version, ask for a "1-page strategy brief" and I will generate only: Objective, Target Users, Strategic Pillars, and Key Metrics.
 
@@ -25,12 +25,12 @@ When this skill is invoked, immediately check:
 
 | Source               | Files/Folders                                  | Search Terms                              | What to Extract                          |
 | -------------------- | ---------------------------------------------- | ----------------------------------------- | ---------------------------------------- |
-| Existing Strategy    | `pm/context-library/strategy/*.md`             | company strategy, vision, roadmap         | Current strategy to build on or update   |
-| Business Model       | `pm/context-library/business-info-template.md` | TAM, revenue model, metrics               | Objective anchor and North Star          |
-| User Research        | `pm/context-library/research/*.md`             | user segments, JTBD, pain points          | Users section and strategic fit          |
-| Competitive Analysis | `pm/context-library/research/competitive-*.md` | competitor positioning                    | Superpowers and differentiation          |
-| Historical PRDs      | `pm/context-library/prds/*.md`                 | strategic features, decisions             | Precedent for feature strategy alignment |
-| Meetings             | `pm/context-library/meetings/*.md`             | strategy discussion, OKRs, board feedback | Stakeholder input and constraints        |
+| Existing Strategy    | `thoughts/shared/pm/frameworks/*.md`                   | company strategy, vision, roadmap         | Current strategy to build on or update   |
+| Business Model       | `thoughts/shared/pm/context/business-info-template.md` | TAM, revenue model, metrics               | Objective anchor and North Star          |
+| User Research        | `thoughts/shared/pm/research/*.md`                     | user segments, JTBD, pain points          | Users section and strategic fit          |
+| Competitive Analysis | `thoughts/shared/pm/research/competitive-*.md`         | competitor positioning                    | Superpowers and differentiation          |
+| Historical PRDs      | `thoughts/shared/pm/prds/*.md`                         | strategic features, decisions             | Precedent for feature strategy alignment |
+| Meetings             | `thoughts/shared/product/meeting-notes/*.md`           | strategy discussion, OKRs, board feedback | Stakeholder input and constraints        |
 
 **Context Priority:**
 
@@ -54,10 +54,10 @@ Before writing strategy, let me understand where you are...
 
 **Checking:**
 
-- `pm/context-library/strategy/` for existing strategy docs
-- `pm/context-library/business-info-template.md` for business model
-- `pm/context-library/research/` for user and competitive insights
-- `pm/context-library/meetings/` for stakeholder input and OKRs
+- `thoughts/shared/pm/frameworks/` for existing strategy docs
+- `thoughts/shared/pm/context/business-info-template.md` for business model
+- `thoughts/shared/pm/research/` for user and competitive insights
+- `thoughts/shared/product/meeting-notes/` for stakeholder input and OKRs
 
 **Based on what I find, I'll show you:**
 
@@ -707,8 +707,7 @@ What we're NOT doing (and why):
 
 **Strategy documents:**
 
-- Active work: `thoughts/shared/analyses/strategy-[product]-[date].md` (living document)
-- When finalized: Move to `pm/context-library/strategy/[product]-strategy-[year].md` for reference
+- Active work: `thoughts/shared/pm/analyses/strategy-[product]-[date].md` (living document)
 - Executive version: Can be adapted for board/investor presentations
 
 ### Link to Other Work

--- a/plugins/pm/sub-agents/designer-reviewer.md
+++ b/plugins/pm/sub-agents/designer-reviewer.md
@@ -400,7 +400,7 @@ Long-press to select on mobile?
 ## How to Use This Sub-Agent
 
 ```bash
-claude "Read pm/sub-agents/designer-reviewer.md
+claude "Read thoughts/shared/pm/sub-agents/designer-reviewer.md
 
 Review this PRD from a design perspective:
 [paste PRD]

--- a/plugins/pm/sub-agents/engineer-reviewer.md
+++ b/plugins/pm/sub-agents/engineer-reviewer.md
@@ -538,7 +538,7 @@ Use Firebase Cloud Messaging + Firestore instead of building custom:
 
 ```bash
 cd ~/pm-operating-system
-claude "Read pm/sub-agents/engineer-reviewer.md
+claude "Read thoughts/shared/pm/sub-agents/engineer-reviewer.md
 
 Then review this PRD from an engineering perspective:
 [paste PRD or reference file]

--- a/plugins/pm/templates/context-library-scaffold/README.md
+++ b/plugins/pm/templates/context-library-scaffold/README.md
@@ -1,24 +1,28 @@
 # Context Library Setup
 
 The context library is a project-specific directory structure that powers PM skills.
-Skills reference `pm/context-library/` paths to load business context, strategy docs,
+Skills reference `thoughts/shared/pm/` paths to load business context, strategy docs,
 research, and more.
 
 ## Quick Setup
 
-Create this structure in your project root:
+Create this structure in your thoughts repository:
 
 ```
-pm/context-library/
-├── business-info.md          # Company/product overview, North Star metric
-├── stakeholders.md           # Key stakeholders and their concerns
-├── writing-style.md          # Internal communication style guide
-├── strategy/                 # OKRs, quarterly goals, strategic pillars
-├── research/                 # User research, competitive analysis
-├── decisions/                # Decision documents and ADRs
-├── prds/                     # Product Requirements Documents
-├── launches/                 # Launch plans and checklists
-└── meetings/                 # Meeting notes and action items
+thoughts/shared/pm/
+├── context/
+│   ├── business-info.md          # Company/product overview, North Star metric
+│   ├── stakeholders.md           # Key stakeholders and their concerns
+│   └── writing-style.md          # Internal communication style guide
+├── frameworks/                   # OKRs, quarterly goals, strategic pillars
+├── prds/                         # Product Requirements Documents
+├── launches/                     # Launch plans and checklists
+├── metrics/                      # Metric baselines and dashboards
+└── example-prds/                 # Example PRDs for reference
+thoughts/shared/product/
+├── meeting-notes/                # Meeting notes and action items
+├── decisions/                    # Decision documents and ADRs
+└── strategy/                     # Product strategy documents
 ```
 
 ## Templates
@@ -29,8 +33,8 @@ Use the template files in this directory as starting points:
 
 ## How Skills Use Context
 
-Skills automatically check `pm/context-library/` for relevant context:
-- `/weekly-plan` reads strategy/ for OKR alignment
-- `/prd-draft` reads business-info and strategy for product context
-- `/ralph-wiggum` reads strategy, research, and decisions to challenge assumptions
+Skills automatically check `thoughts/shared/pm/context/` for relevant context:
+- `/weekly-plan` reads frameworks/ for OKR alignment
+- `/prd-draft` reads business-info and frameworks for product context
+- `/ralph-wiggum` reads frameworks, research, and decisions to challenge assumptions
 - `/status-update` reads stakeholders for audience-aware updates


### PR DESCRIPTION
## Summary
- **catalyst-dev**: Convert plain path references to `[[filename]]` Obsidian wiki-links in 5 skill templates. Only document-to-document cross-references are converted; filesystem instructions, CLI arguments, and code `file:line` references remain as paths.
- **catalyst-pm**: Restructure all PM skill output/input paths from scattered `thoughts/shared/*` and `pm/context-library/*` to organized `thoughts/shared/pm/*` and `thoughts/shared/product/*` directories. Removes finalization/promotion patterns to `pm/context-library/` (49 files changed).

### PM Path Migration Summary
| Old Path | New Path |
|----------|----------|
| `pm/context-library/*` | `thoughts/shared/pm/{context,frameworks,metrics,prds,...}` |
| `thoughts/shared/analyses/` | `thoughts/shared/pm/analyses/` |
| `thoughts/shared/prds/` | `thoughts/shared/pm/prds/` |
| `thoughts/shared/decisions/` | `thoughts/shared/product/decisions/` |
| `thoughts/shared/meeting-notes/` | `thoughts/shared/product/meeting-notes/` |
| `thoughts/shared/prototypes/` | `thoughts/shared/product/prototypes/` |
| `thoughts/shared/reports/{cycles,milestones,backlog,daily,pr-sync}/` | `thoughts/shared/pm/reports/` |
| `thoughts/shared/{daily,weekly}-plans/` | `thoughts/shared/pm/reports/` |
| `thoughts/shared/weekly-reviews/` | `thoughts/shared/pm/reports/` |
| `thoughts/shared/research-synthesis/` | `thoughts/shared/pm/analyses/` |
| `thoughts/shared/interview-feedback/` | `thoughts/shared/pm/interviews/` |

## Expected Version Bumps
- **catalyst-dev**: 5.1.1 → 5.2.0 (feat)
- **catalyst-pm**: 5.1.0 → 5.2.0 (feat)

## Test plan
- [ ] Verify no old `pm/context-library/` paths remain: `grep -r "pm/context-library" plugins/pm/` returns 0
- [ ] Verify no old scattered `thoughts/shared/` paths remain (analyses, prds, decisions, etc.)
- [ ] Restart Claude Code and invoke a PM skill — verify output paths point to `thoughts/shared/pm/`
- [ ] Invoke `/create-plan` — verify wiki-links in frontmatter

Closes CTL-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)