### PR TITLE
fix(meta): add --repo flag to release-please auto-merge step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} --squash --auto
+          gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} --squash --auto --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
- The auto-merge step in release-please.yml failed with `fatal: not a git repository` because `gh pr merge` was called without a checkout and without `--repo`
- Adds `--repo ${{ github.repository }}` to fix it

## Test plan
- [ ] Merge this PR, then re-run the release-please workflow — auto-merge step should succeed