### PR TITLE
Fix workflow file auto-discovery reliability

### DIFF
--- a/plugins/dev/WORKFLOW_CONTEXT.md
+++ b/plugins/dev/WORKFLOW_CONTEXT.md
@@ -140,6 +140,7 @@ Claude reads the research and creates plan
 | `/implement-plan` | Recent plan | Finds last plan, asks to proceed |
 | `/create-plan` | Recent research | **Suggests** research as context |
 | `/iterate-plan` | Recent plan | Auto-discovers recent plans to iterate on |
+| `/validate-plan` | Recent plan | Finds last plan, asks to validate |
 | `/oneshot` | Tickets, research, plans | Auto-discovers tickets and chains research, plan, and implement |
 
 ### 🚧 Fallback if Not Found

--- a/plugins/dev/scripts/workflow-context.sh
+++ b/plugins/dev/scripts/workflow-context.sh
@@ -55,12 +55,21 @@ add_document() {
 	mv "${CONTEXT_FILE}.tmp" "$CONTEXT_FILE"
 }
 
-# Get most recent document of type
+# Get most recent document of type (with filesystem fallback)
 # Usage: get_recent <type>
 get_recent() {
 	local doc_type="$1"
 	init_context
-	jq -r --arg type "$doc_type" '.workflow[$type][0].path // empty' "$CONTEXT_FILE"
+	local result
+	result=$(jq -r --arg type "$doc_type" '.workflow[$type][0].path // empty' "$CONTEXT_FILE")
+	# Filesystem fallback if workflow context has no entries for this type
+	if [[ -z "$result" && -d "${PROJECT_ROOT}/thoughts/shared/${doc_type}" ]]; then
+		result=$(find "${PROJECT_ROOT}/thoughts/shared/${doc_type}" -name '*.md' -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1)
+		if [[ -n "$result" ]]; then
+			result="${result#"${PROJECT_ROOT}/"}"
+		fi
+	fi
+	echo "$result"
 }
 
 # Get most recent document (any type)

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -21,30 +21,35 @@ Replace `PROJ` in ticket references with your Linear team's prefix from `.claude
 if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
   "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
+
+# Auto-discover most recent research (workflow context + filesystem fallback)
+RECENT_RESEARCH=""
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
+  RECENT_RESEARCH=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research)
+fi
+if [[ -n "$RECENT_RESEARCH" ]]; then
+  echo "📋 Auto-discovered recent research: $RECENT_RESEARCH"
+else
+  echo "⚠️ No recent research found in workflow context or filesystem"
+fi
 ```
 
 ## Initial Response
 
-**STEP 1: Check for recent research**
-
-```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-  RECENT_RESEARCH=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research)
-  if [[ -n "$RECENT_RESEARCH" ]]; then
-    echo "Found recent research: $RECENT_RESEARCH"
-  fi
-fi
-```
-
-**STEP 2: Gather initial input**
+Auto-discovery has already run in Prerequisites above. Check its output and follow this priority:
 
 1. **If user provided parameters** (file path or ticket reference):
+   - Use the provided path (user override)
    - Read any provided files FULLY
-   - If RECENT_RESEARCH was found, mention it and ask if it should inform the plan
+   - If Prerequisites also discovered research (📋), mention it and ask if it should inform the plan
    - Begin the research process
 
-2. **If no parameters provided**:
-   - Show any RECENT_RESEARCH found
+2. **If no parameters provided AND Prerequisites discovered research (📋)**:
+   - Show the discovered research path
+   - Ask if it should be used as context for the plan
+   - Wait for user's confirmation
+
+3. **If no parameters AND no research found (⚠️)**:
    - Ask for: task/ticket description, context/constraints, related research
    - Wait for user's input
 

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -18,40 +18,32 @@ plans contain phases with specific changes and success criteria.
 if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
   "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
+
+# Auto-discover most recent plan (workflow context + filesystem fallback)
+RECENT_PLAN=""
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
+  RECENT_PLAN=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans)
+fi
+if [[ -n "$RECENT_PLAN" ]]; then
+  echo "📋 Auto-discovered recent plan: $RECENT_PLAN"
+else
+  echo "⚠️ No recent plan found in workflow context or filesystem"
+fi
 ```
 
 ## Initial Response
 
-**STEP 1: Auto-discover recent plan (REQUIRED)**
+Auto-discovery has already run in Prerequisites above. Check its output and follow this priority:
 
-IMMEDIATELY run this bash script BEFORE any other response:
+1. **If user provided a plan path as parameter**: Use the provided path (user override). Skip to Step 3.
 
-```bash
-# Auto-discover most recent plan from workflow context
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-  RECENT_PLAN=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans)
-  if [[ -n "$RECENT_PLAN" ]]; then
-    echo "📋 Auto-discovered recent plan: $RECENT_PLAN"
-    echo ""
-  fi
-fi
-```
-
-**STEP 2: Determine which plan to implement**
-
-After running the auto-discovery script, follow this logic:
-
-1. **If user provided a plan path as parameter**:
-   - Use the provided path (user override)
-   - Skip to Step 3
-
-2. **If no parameter provided AND RECENT_PLAN was found**:
-   - Show user: "📋 Found recent plan: $RECENT_PLAN"
+2. **If no parameter provided AND Prerequisites output shows a discovered plan (📋)**:
+   - Show user the discovered plan path
    - Ask: "**Proceed with this plan?** [Y/n]"
-   - If yes: use RECENT_PLAN and skip to Step 3
+   - If yes: use it and skip to Step 3
    - If no: proceed to option 3
 
-3. **If no parameter AND no RECENT_PLAN found**:
+3. **If no parameter AND Prerequisites shows no plan found (⚠️)**:
    - List available plans from `thoughts/shared/plans/`
    - Show most recent 5 plans with dates and ticket numbers
    - Ask user which plan to implement

--- a/plugins/dev/skills/iterate-plan/SKILL.md
+++ b/plugins/dev/skills/iterate-plan/SKILL.md
@@ -19,26 +19,26 @@ research-backed modifications, not just text edits.
 if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
   "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
+
+# Auto-discover most recent plan (workflow context + filesystem fallback)
+RECENT_PLAN=""
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
+  RECENT_PLAN=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans)
+fi
+if [[ -n "$RECENT_PLAN" ]]; then
+  echo "📋 Auto-discovered recent plan: $RECENT_PLAN"
+else
+  echo "⚠️ No recent plan found in workflow context or filesystem"
+fi
 ```
 
 ## Initial Response
 
-**STEP 1: Check for recent plan (AUTO-DETECT)**
+Auto-discovery has already run in Prerequisites above. Check its output and follow this priority:
 
-```bash
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-  RECENT_PLAN=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans)
-  if [[ -n "$RECENT_PLAN" ]]; then
-    echo "Found recent plan: $RECENT_PLAN"
-  fi
-fi
-```
-
-**STEP 2: Gather input**
-
-1. **If user provided a plan file path**: Read it FULLY immediately
-2. **If RECENT_PLAN found and no path provided**: Ask "Should I update the recent plan?"
-3. **If neither**: Ask user to provide the plan file path
+1. **If user provided a plan file path**: Use the provided path (user override). Read it FULLY immediately.
+2. **If no path provided AND Prerequisites discovered a plan (📋)**: Show the path and ask "**Update this plan?** [Y/n]"
+3. **If no path AND no plan found (⚠️)**: Ask user to provide the plan file path
 
 Then ask: "What changes need to be made to this plan?"
 

--- a/plugins/dev/skills/resume-handoff/SKILL.md
+++ b/plugins/dev/skills/resume-handoff/SKILL.md
@@ -15,6 +15,17 @@ version: 1.0.0
 if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
   "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
 fi
+
+# Auto-discover most recent handoff (workflow context + filesystem fallback)
+RECENT_HANDOFF=""
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
+  RECENT_HANDOFF=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent handoffs)
+fi
+if [[ -n "$RECENT_HANDOFF" ]]; then
+  echo "📋 Auto-discovered recent handoff: $RECENT_HANDOFF"
+else
+  echo "⚠️ No recent handoff found in workflow context or filesystem"
+fi
 ```
 
 ## Configuration Note
@@ -32,28 +43,9 @@ to be understood and continued.
 
 ## Initial Response
 
-**STEP 1: Auto-discover recent handoff (REQUIRED)**
+Auto-discovery has already run in Prerequisites above. Check its output and follow this priority:
 
-IMMEDIATELY run this bash script BEFORE any other response:
-
-```bash
-# Auto-discover most recent handoff from workflow context
-if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
-  RECENT_HANDOFF=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent handoffs)
-  if [[ -n "$RECENT_HANDOFF" ]]; then
-    echo "📋 Auto-discovered recent handoff: $RECENT_HANDOFF"
-    echo ""
-  fi
-fi
-```
-
-**STEP 2: Determine which handoff to use**
-
-After running the auto-discovery script, follow this logic:
-
-1. **If user provided a file path as parameter**:
-   - Use the provided path (user override)
-   - Skip to Step 3
+1. **If user provided a file path as parameter**: Use the provided path (user override). Skip to Step 3.
 
 2. **If user provided a ticket number (like PROJ-123)**:
    - Run `humanlayer thoughts sync` to ensure `thoughts/` is up to date
@@ -63,13 +55,13 @@ After running the auto-discovery script, follow this logic:
    - If none exist, tell user and wait for input
    - Skip to Step 3
 
-3. **If no parameters provided AND RECENT_HANDOFF was found**:
-   - Show user: "📋 Found recent handoff: $RECENT_HANDOFF"
+3. **If no parameters provided AND Prerequisites output shows a discovered handoff (📋)**:
+   - Show user the discovered path
    - Ask: "**Proceed with this handoff?** [Y/n]"
-   - If yes: use RECENT_HANDOFF and skip to Step 3
+   - If yes: use it and skip to Step 3
    - If no: proceed to option 4
 
-4. **If no parameters AND no RECENT_HANDOFF found**:
+4. **If no parameters AND Prerequisites shows no handoff found (⚠️)**:
    - List available handoffs from `thoughts/shared/handoffs/`
    - Show most recent 5 handoffs with dates
    - Ask user which one to use

--- a/plugins/dev/skills/validate-plan/SKILL.md
+++ b/plugins/dev/skills/validate-plan/SKILL.md
@@ -9,19 +9,44 @@ disable-model-invocation: true
 You are tasked with validating that an implementation plan was correctly executed, verifying all
 success criteria and identifying any deviations or issues.
 
+## Prerequisites
+
+```bash
+# Check project setup (thoughts, CLAUDE.md snippet, config)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
+fi
+
+# Auto-discover most recent plan (workflow context + filesystem fallback)
+RECENT_PLAN=""
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" ]]; then
+  RECENT_PLAN=$("${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans)
+fi
+if [[ -n "$RECENT_PLAN" ]]; then
+  echo "📋 Auto-discovered recent plan: $RECENT_PLAN"
+else
+  echo "⚠️ No recent plan found in workflow context or filesystem"
+fi
+```
+
 ## Initial Setup
 
-When invoked:
+Auto-discovery has already run in Prerequisites above. Check its output and follow this priority:
 
-1. **Determine context** - Are you in an existing conversation or starting fresh?
-   - If existing: Review what was implemented in this session
-   - If fresh: Need to discover what was done through git and codebase analysis
+1. **If user provided a plan path as parameter**: Use the provided path (user override).
 
-2. **Locate the plan**:
-   - If plan path provided, use it
-   - Otherwise, search recent commits for plan references or ask user
+2. **If no parameter AND Prerequisites discovered a plan (📋)**:
+   - Show user the discovered plan path
+   - Ask: "**Validate this plan?** [Y/n]"
+   - If yes: use it
+   - If no: proceed to option 3
 
-3. **Gather implementation evidence**:
+3. **If no parameter AND no plan found (⚠️)**:
+   - Search recent commits for plan references
+   - List available plans from `thoughts/shared/plans/`
+   - Ask user which plan to validate
+
+4. **Gather implementation evidence**:
 
    ```bash
    # Check recent commits


### PR DESCRIPTION
## Summary

- Moves auto-discovery bash blocks into the Prerequisites section (same block as `check-project-setup.sh`) across all workflow skills so they execute reliably instead of being skipped
- Adds filesystem fallback to `workflow-context.sh` `get_recent()` — if `.workflow-context.json` has no entries, falls back to finding the most recent `.md` file by modification time
- Adds auto-discovery to `validate-plan` which was missing it entirely

## Test plan

- [ ] Run `/resume-handoff` without arguments — should show auto-discovered handoff from Prerequisites output
- [ ] Run `/create-plan` without arguments — should show auto-discovered research
- [ ] Run `/implement-plan` without arguments — should show auto-discovered plan
- [ ] Run `/validate-plan` without arguments — should show auto-discovered plan (new)
- [ ] Run any workflow skill with an explicit file path — should use the override
- [ ] Delete `.workflow-context.json` and run a skill — filesystem fallback should find the most recent file