### PR TITLE
fix(pm): remove explicit agents array that also broke auto-discovery

### DIFF
--- a/plugins/meta/scripts/audit-references.sh
+++ b/plugins/meta/scripts/audit-references.sh
@@ -109,12 +109,15 @@ audit_manifest() {
 		return
 	fi
 
-	# Check for explicit "skills" array — this breaks Claude Code auto-discovery
-	if jq -e '.skills' "$manifest" &>/dev/null; then
-		local line
-		line=$(grep -nF '"skills"' "$manifest" 2>/dev/null | head -1 | cut -d: -f1)
-		echo "${manifest}|${line:-0}|skills|Explicit skills array breaks autocomplete — remove it and let Claude Code auto-discover skills/**/SKILL.md" >> "$CRITICAL_FILE"
-	fi
+	# Check for explicit "skills" or "agents" arrays — these break Claude Code auto-discovery
+	local array_type
+	for array_type in skills agents; do
+		if jq -e ".${array_type}" "$manifest" &>/dev/null; then
+			local line
+			line=$(grep -nF "\"${array_type}\"" "$manifest" 2>/dev/null | head -1 | cut -d: -f1)
+			echo "${manifest}|${line:-0}|${array_type}|Explicit ${array_type} array breaks auto-discovery — remove it and let Claude Code discover ${array_type} automatically" >> "$CRITICAL_FILE"
+		fi
+	done
 
 	# Helper: extract file paths from a JSON array that may contain strings or objects with .file
 	local extract_files='if type == "string" then . elif type == "object" then .file // empty else empty end'

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -21,12 +21,5 @@
     "skills",
     "posthog"
   ],
-  "license": "MIT",
-  "agents": [
-    "./agents/linear-research.md",
-    "./agents/cycle-analyzer.md",
-    "./agents/milestone-analyzer.md",
-    "./agents/backlog-analyzer.md",
-    "./agents/github-linear-analyzer.md"
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Removes the explicit `"agents"` array from PM's `plugin.json` — PM was the **only** plugin with any explicit arrays; all working plugins (dev, meta, analytics, debugging) rely entirely on auto-discovery
- Extends the `audit-references.sh` CI check to catch both `"skills"` and `"agents"` arrays in plugin.json files

## Context
Follow-up to #54 which removed the `"skills"` array but left the `"agents"` array. Skills still weren't appearing in autocomplete, suggesting that having **any** explicit array in plugin.json switches Claude Code out of auto-discovery mode for the entire plugin.

## Test plan
- [ ] Run `/reload-plugins` and verify PM skills appear in `/` autocomplete
- [ ] Run `bash plugins/meta/scripts/audit-references.sh` — no CRITICAL issues
- [ ] Verify PM agents still work (e.g., `catalyst-pm:cycle-analyzer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)