### PR TITLE
fix(pm): restore agents array removed in error

### DIFF
--- a/plugins/meta/scripts/audit-references.sh
+++ b/plugins/meta/scripts/audit-references.sh
@@ -109,15 +109,12 @@ audit_manifest() {
 		return
 	fi
 
-	# Check for explicit "skills" or "agents" arrays — these break Claude Code auto-discovery
-	local array_type
-	for array_type in skills agents; do
-		if jq -e ".${array_type}" "$manifest" &>/dev/null; then
-			local line
-			line=$(grep -nF "\"${array_type}\"" "$manifest" 2>/dev/null | head -1 | cut -d: -f1)
-			echo "${manifest}|${line:-0}|${array_type}|Explicit ${array_type} array breaks auto-discovery — remove it and let Claude Code discover ${array_type} automatically" >> "$CRITICAL_FILE"
-		fi
-	done
+	# Check for explicit "skills" array — this prevents Claude Code skill auto-discovery
+	if jq -e '.skills' "$manifest" &>/dev/null; then
+		local line
+		line=$(grep -nF '"skills"' "$manifest" 2>/dev/null | head -1 | cut -d: -f1)
+		echo "${manifest}|${line:-0}|skills|Explicit skills array prevents auto-discovery — remove it and let Claude Code discover skills/**/SKILL.md automatically" >> "$CRITICAL_FILE"
+	fi
 
 	# Helper: extract file paths from a JSON array that may contain strings or objects with .file
 	local extract_files='if type == "string" then . elif type == "object" then .file // empty else empty end'

--- a/plugins/pm/.claude-plugin/plugin.json
+++ b/plugins/pm/.claude-plugin/plugin.json
@@ -21,5 +21,12 @@
     "skills",
     "posthog"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "agents": [
+    "./agents/linear-research.md",
+    "./agents/cycle-analyzer.md",
+    "./agents/milestone-analyzer.md",
+    "./agents/backlog-analyzer.md",
+    "./agents/github-linear-analyzer.md"
+  ]
 }


### PR DESCRIPTION
## Summary
- Restores the `"agents"` array to PM's `plugin.json` that was incorrectly removed in #56
- Narrows the `audit-references.sh` CI check to only flag explicit `"skills"` arrays (not `"agents"`)

## Context
The agents array removal in #56 was based on the wrong hypothesis that explicit arrays broke auto-discovery. The actual root cause of PM skills not appearing in autocomplete was `"catalyst-pm@catalyst": false` in `~/.claude/settings.json` — the plugin was disabled at the user level despite appearing enabled in the plugin UI.

## Test plan
- [ ] Run `bash plugins/meta/scripts/audit-references.sh` — no CRITICAL issues
- [ ] Verify PM agents still work after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)