### PR TITLE
feat(dev): add /orchestrate skill for parallel development

### DIFF
--- a/.claude/config.example.json
+++ b/.claude/config.example.json
@@ -24,6 +24,42 @@
     },
     "thoughts": {
       "user": null
+    },
+    "worktree": {
+      "setup": [
+        "humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}",
+        "humanlayer thoughts sync",
+        "bun install",
+        "~/.claude/scripts/trust-workspace.sh \"$(pwd)\""
+      ]
+    },
+    "orchestration": {
+      "worktreeDir": "~/catalyst/api",
+      "maxParallel": 4,
+      "hooks": {
+        "setup": [
+          "humanlayer thoughts init --directory ${DIRECTORY}",
+          "humanlayer thoughts sync",
+          "bun install"
+        ],
+        "teardown": [
+          "git worktree remove ${WORKTREE_PATH}",
+          "git branch -D ${BRANCH_NAME}"
+        ]
+      },
+      "workerCommand": "/oneshot",
+      "workerModel": "opus",
+      "thoughts": {
+        "profile": "my-profile",
+        "directory": "api"
+      },
+      "testRequirements": {
+        "backend": ["unit", "bruno"],
+        "frontend": ["unit", "functional"],
+        "fullstack": ["unit", "bruno", "functional"]
+      },
+      "verifyBeforeMerge": true,
+      "allowSelfReportedCompletion": false
     }
   }
 }

--- a/.claude/config.template.json
+++ b/.claude/config.template.json
@@ -26,6 +26,30 @@
     },
     "thoughts": {
       "user": null
+    },
+    "worktree": {
+      "setup": []
+    },
+    "orchestration": {
+      "worktreeDir": null,
+      "maxParallel": 3,
+      "hooks": {
+        "setup": [],
+        "teardown": []
+      },
+      "workerCommand": "/oneshot",
+      "workerModel": "opus",
+      "thoughts": {
+        "profile": null,
+        "directory": null
+      },
+      "testRequirements": {
+        "backend": ["unit"],
+        "frontend": ["unit"],
+        "fullstack": ["unit"]
+      },
+      "verifyBeforeMerge": true,
+      "allowSelfReportedCompletion": false
     }
   }
 }

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # create-worktree.sh - Create a git worktree for isolated development
-# Usage: ./create-worktree.sh [worktree_name] [base_branch]
+# Usage: ./create-worktree.sh [worktree_name] [base_branch] [--worktree-dir <path>] [--hooks-json <json>]
+#
+# Options:
+#   --worktree-dir <path>   Override worktree base directory (used by orchestrator)
+#   --hooks-json <json>     JSON array of setup hook commands to run after creation
 
 set -e
 
@@ -10,19 +14,33 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-# Get worktree name from parameter or generate one
-if [ -z "$1" ]; then
+# Parse flags (collect positional args separately)
+POSITIONAL=()
+OVERRIDE_WORKTREE_DIR=""
+HOOKS_JSON=""
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--worktree-dir) OVERRIDE_WORKTREE_DIR="$2"; shift 2 ;;
+		--hooks-json) HOOKS_JSON="$2"; shift 2 ;;
+		*) POSITIONAL+=("$1"); shift ;;
+	esac
+done
+
+# Get worktree name from positional args
+if [ ${#POSITIONAL[@]} -eq 0 ]; then
 	echo -e "${RED}Error: Worktree name is required${NC}"
-	echo "Usage: ./create-worktree.sh <worktree_name> [base_branch]"
+	echo "Usage: ./create-worktree.sh <worktree_name> [base_branch] [--worktree-dir <path>] [--hooks-json <json>]"
 	echo ""
 	echo "Examples:"
 	echo "  ./create-worktree.sh ENG-123"
 	echo "  ./create-worktree.sh feature-auth main"
+	echo "  ./create-worktree.sh orch-1-ENG-123 main --worktree-dir ~/catalyst/my-app"
 	exit 1
 fi
 
-WORKTREE_NAME="$1"
-BASE_BRANCH="${2:-$(git branch --show-current)}"
+WORKTREE_NAME="${POSITIONAL[0]}"
+BASE_BRANCH="${POSITIONAL[1]:-$(git branch --show-current)}"
 
 # Get repository information
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -38,20 +56,35 @@ else
 	GITHUB_REPO="$REPO_NAME"
 fi
 
-# Determine worktree base path using convention
-# Convention: <GITHUB_SOURCE_ROOT>/<org>/<repo>-worktrees/<worktree-name>
-# Main checkout: <GITHUB_SOURCE_ROOT>/<org>/<repo>
-# Worktrees: <GITHUB_SOURCE_ROOT>/<org>/<repo>-worktrees/<feature>
-if [ -n "$GITHUB_SOURCE_ROOT" ]; then
-	# Use GITHUB_SOURCE_ROOT convention
-	if [ -n "$GITHUB_ORG" ]; then
-		WORKTREES_BASE="${GITHUB_SOURCE_ROOT}/${GITHUB_ORG}/${GITHUB_REPO}-worktrees"
-	else
-		WORKTREES_BASE="${GITHUB_SOURCE_ROOT}/${GITHUB_REPO}-worktrees"
+# Resolve Catalyst config file (.catalyst/ first, then .claude/)
+CONFIG_FILE=""
+for CFG in "${REPO_ROOT}/.catalyst/config.json" "${REPO_ROOT}/.claude/config.json"; do
+	if [ -f "$CFG" ]; then
+		CONFIG_FILE="$CFG"
+		break
 	fi
+done
+
+PROJECT_KEY=""
+WT_DIR_CONFIG=""
+if [ -n "$CONFIG_FILE" ]; then
+	PROJECT_KEY=$(jq -r '.catalyst.projectKey // empty' "$CONFIG_FILE" 2>/dev/null)
+	WT_DIR_CONFIG=$(jq -r '.catalyst.orchestration.worktreeDir // empty' "$CONFIG_FILE" 2>/dev/null)
+fi
+
+# Determine worktree base path (priority order):
+# 1. --worktree-dir flag (explicit override, used by orchestrator)
+# 2. catalyst.orchestration.worktreeDir from config
+# 3. ~/catalyst/wt/<projectKey>/ (default — read projectKey from config)
+# 4. ~/catalyst/wt/<repo>/ (fallback if no config)
+if [ -n "$OVERRIDE_WORKTREE_DIR" ]; then
+	WORKTREES_BASE="${OVERRIDE_WORKTREE_DIR/#\~/$HOME}"
+elif [ -n "$WT_DIR_CONFIG" ]; then
+	WORKTREES_BASE="${WT_DIR_CONFIG/#\~/$HOME}"
+elif [ -n "$PROJECT_KEY" ]; then
+	WORKTREES_BASE="$HOME/catalyst/wt/${PROJECT_KEY}"
 else
-	# Default fallback: ~/wt/<repo>
-	WORKTREES_BASE="$HOME/wt/${REPO_NAME}"
+	WORKTREES_BASE="$HOME/catalyst/wt/${REPO_NAME}"
 fi
 
 WORKTREE_PATH="${WORKTREES_BASE}/${WORKTREE_NAME}"
@@ -82,67 +115,143 @@ else
 	git worktree add -b "$WORKTREE_NAME" "$WORKTREE_PATH" "$BASE_BRANCH"
 fi
 
-# Copy .claude directory if it exists
+# Copy .claude directory if it exists (Claude Code native config)
 if [ -d ".claude" ]; then
 	echo "📋 Copying .claude directory..."
 	cp -r .claude "$WORKTREE_PATH/"
 fi
 
+# Copy .catalyst directory if it exists (Catalyst workflow config)
+if [ -d ".catalyst" ]; then
+	echo "📋 Copying .catalyst directory..."
+	cp -r .catalyst "$WORKTREE_PATH/"
+fi
+
 # Change to worktree directory
 cd "$WORKTREE_PATH"
 
-# Run setup if Makefile exists
-if [ -f "Makefile" ] && grep -q "^setup:" Makefile; then
-	echo "🔧 Running setup..."
-	if ! make setup; then
-		echo -e "${RED}❌ Setup failed. Cleaning up worktree...${NC}"
-		cd - >/dev/null
-		git worktree remove --force "$WORKTREE_PATH"
-		git branch -D "$WORKTREE_NAME" 2>/dev/null || true
-		exit 1
-	fi
-elif [ -f "package.json" ]; then
-	echo "🔧 Installing dependencies..."
-	if command -v bun >/dev/null 2>&1; then
-		bun install
-	else
-		npm install
+# ============================================================
+# WORKTREE SETUP
+#
+# Setup commands are read from catalyst.worktree.setup in config.
+# If configured, ONLY those commands run (full control to the project).
+# If not configured, falls back to auto-detected setup for backwards compat.
+#
+# Available variables in setup commands:
+#   ${WORKTREE_PATH}  — absolute path to the new worktree
+#   ${BRANCH_NAME}    — git branch name
+#   ${TICKET_ID}      — same as branch name (useful for orchestrator-prefixed names)
+#   ${REPO_NAME}      — repository name
+#   ${DIRECTORY}       — thoughts directory name (defaults to repo name)
+#   ${PROFILE}         — thoughts profile (auto-detected or from config)
+# ============================================================
+
+# Read thoughts config for variable substitution
+THOUGHTS_PROFILE=""
+THOUGHTS_DIRECTORY="$REPO_NAME"
+if [ -n "$CONFIG_FILE" ]; then
+	THOUGHTS_PROFILE=$(jq -r '.catalyst.thoughts.profile // empty' "$CONFIG_FILE" 2>/dev/null)
+	THOUGHTS_DIR_CFG=$(jq -r '.catalyst.thoughts.directory // empty' "$CONFIG_FILE" 2>/dev/null)
+	if [ -n "$THOUGHTS_DIR_CFG" ]; then
+		THOUGHTS_DIRECTORY="$THOUGHTS_DIR_CFG"
 	fi
 fi
 
-# Initialize thoughts (REQUIRED for Catalyst workflows)
-if command -v humanlayer >/dev/null 2>&1; then
-	echo "🧠 Initializing HumanLayer thoughts system..."
+# Auto-detect profile from parent if not in config
+if [ -z "$THOUGHTS_PROFILE" ] && command -v humanlayer >/dev/null 2>&1; then
+	THOUGHTS_PROFILE=$(humanlayer thoughts status 2>/dev/null | grep -i "Profile:" | head -1 | awk '{print $2}')
+fi
 
-	# Detect current profile from parent directory
-	CURRENT_PROFILE=$(humanlayer thoughts status 2>/dev/null | grep -i "Profile:" | head -1 | awk '{print $2}')
+# Helper: substitute variables in a command string
+substitute_vars() {
+	local CMD="$1"
+	CMD="${CMD//\$\{WORKTREE_PATH\}/$WORKTREE_PATH}"
+	CMD="${CMD//\$\{BRANCH_NAME\}/$WORKTREE_NAME}"
+	CMD="${CMD//\$\{TICKET_ID\}/$WORKTREE_NAME}"
+	CMD="${CMD//\$\{REPO_NAME\}/$REPO_NAME}"
+	CMD="${CMD//\$\{DIRECTORY\}/$THOUGHTS_DIRECTORY}"
+	CMD="${CMD//\$\{PROFILE\}/$THOUGHTS_PROFILE}"
+	echo "$CMD"
+}
 
-	# Build init command with profile if detected
-	INIT_CMD="humanlayer thoughts init --directory $REPO_NAME"
-	if [ -n "$CURRENT_PROFILE" ]; then
-		INIT_CMD="$INIT_CMD --profile $CURRENT_PROFILE"
-		echo "📋 Using profile from parent: $CURRENT_PROFILE"
+# Helper: run an array of commands from JSON with variable substitution
+run_hook_array() {
+	local JSON_ARRAY="$1"
+	local LABEL="$2"
+	local HOOK_COUNT
+	HOOK_COUNT=$(echo "$JSON_ARRAY" | jq -r 'length' 2>/dev/null || echo 0)
+
+	for i in $(seq 0 $((HOOK_COUNT - 1))); do
+		local HOOK_CMD
+		HOOK_CMD=$(echo "$JSON_ARRAY" | jq -r ".[$i]" 2>/dev/null)
+		if [ -n "$HOOK_CMD" ] && [ "$HOOK_CMD" != "null" ]; then
+			HOOK_CMD=$(substitute_vars "$HOOK_CMD")
+			echo "  [$LABEL] Running: $HOOK_CMD"
+			if ! eval "$HOOK_CMD"; then
+				echo -e "${YELLOW}⚠️  $LABEL hook failed: $HOOK_CMD${NC}"
+			fi
+		fi
+	done
+}
+
+# Read setup commands from config
+SETUP_COMMANDS=""
+if [ -n "$CONFIG_FILE" ]; then
+	SETUP_COMMANDS=$(jq -c '.catalyst.worktree.setup // empty' "$CONFIG_FILE" 2>/dev/null)
+fi
+
+if [ -n "$SETUP_COMMANDS" ] && [ "$SETUP_COMMANDS" != "null" ] && [ "$SETUP_COMMANDS" != "[]" ]; then
+	# ── Config-driven setup ──
+	echo -e "${YELLOW}🔧 Running project setup from config...${NC}"
+	run_hook_array "$SETUP_COMMANDS" "setup"
+else
+	# ── Auto-detected setup (backwards compatibility) ──
+	echo -e "${YELLOW}🔧 Running auto-detected setup (no catalyst.worktree.setup in config)${NC}"
+
+	# 1. Install dependencies
+	if [ -f "Makefile" ] && grep -q "^setup:" Makefile; then
+		echo "  Running: make setup"
+		if ! make setup; then
+			echo -e "${RED}❌ Setup failed. Cleaning up worktree...${NC}"
+			cd - >/dev/null
+			git worktree remove --force "$WORKTREE_PATH"
+			git branch -D "$WORKTREE_NAME" 2>/dev/null || true
+			exit 1
+		fi
+	elif [ -f "package.json" ]; then
+		if command -v bun >/dev/null 2>&1; then
+			echo "  Running: bun install"
+			bun install
+		else
+			echo "  Running: npm install"
+			npm install
+		fi
 	fi
 
-	if eval "$INIT_CMD" >/dev/null 2>&1; then
-		echo -e "${GREEN}✅ Thoughts initialized for ${REPO_NAME}${NC}"
-		echo "🔄 Syncing with shared thoughts repository..."
-		if humanlayer thoughts sync >/dev/null 2>&1; then
-			echo -e "${GREEN}✅ Thoughts synced! Worktree has access to:${NC}"
-			echo "   - Shared research documents"
-			echo "   - Implementation plans"
-			echo "   - Handoff documents"
+	# 2. Initialize thoughts
+	if command -v humanlayer >/dev/null 2>&1; then
+		INIT_CMD="humanlayer thoughts init --directory $THOUGHTS_DIRECTORY"
+		if [ -n "$THOUGHTS_PROFILE" ]; then
+			INIT_CMD="$INIT_CMD --profile $THOUGHTS_PROFILE"
+		fi
+		echo "  Running: $INIT_CMD"
+		if eval "$INIT_CMD" >/dev/null 2>&1; then
+			echo -e "${GREEN}  ✅ Thoughts initialized${NC}"
+			echo "  Running: humanlayer thoughts sync"
+			humanlayer thoughts sync >/dev/null 2>&1 || echo -e "${YELLOW}  ⚠️  Sync warning: run 'humanlayer thoughts sync' manually${NC}"
 		else
-			echo -e "${YELLOW}⚠️  Sync warning: Run 'humanlayer thoughts sync' manually in worktree${NC}"
+			echo -e "${YELLOW}  ⚠️  Could not initialize thoughts${NC}"
 		fi
 	else
-		echo -e "${YELLOW}⚠️  Could not initialize thoughts. Run 'humanlayer thoughts init --directory ${REPO_NAME}' manually.${NC}"
+		echo -e "${YELLOW}  ⚠️  HumanLayer CLI not found — skipping thoughts init${NC}"
 	fi
-else
-	echo -e "${RED}❌ HumanLayer CLI not found! Catalyst workflows require HumanLayer.${NC}"
-	echo "   Install: pip install humanlayer"
-	echo "   Then run: humanlayer thoughts init --directory ${REPO_NAME}"
-	echo "             humanlayer thoughts sync"
+fi
+
+# Run additional orchestration hooks if provided via --hooks-json
+# These run AFTER the base setup (config-driven or auto-detected)
+if [ -n "$HOOKS_JSON" ] && [ "$HOOKS_JSON" != "[]" ]; then
+	echo -e "${YELLOW}🔧 Running orchestration hooks...${NC}"
+	run_hook_array "$HOOKS_JSON" "orchestration"
 fi
 
 # Return to original directory

--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -1,0 +1,443 @@
+#!/bin/bash
+# orchestrate-verify.sh - Adversarial verification of worker output
+#
+# Independent quality audit run by the orchestrator after a worker claims "done".
+# Checks for test coverage gaps, security issues, and reward-hacking patterns.
+#
+# Usage:
+#   orchestrate-verify.sh \
+#     --worktree <path> \
+#     --ticket <ID> \
+#     --base-branch <branch> \
+#     --signal-file <path> \
+#     [--test-requirements <backend|frontend|fullstack>]
+#
+# Exit codes:
+#   0 — PASS (all required coverage present)
+#   1 — FAIL (gaps found, details in output)
+#   2 — ERROR (script misconfiguration)
+
+set -euo pipefail
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Parse arguments
+WORKTREE=""
+TICKET=""
+BASE_BRANCH="main"
+SIGNAL_FILE=""
+TEST_REQUIREMENTS="backend"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --worktree) WORKTREE="$2"; shift 2 ;;
+    --ticket) TICKET="$2"; shift 2 ;;
+    --base-branch) BASE_BRANCH="$2"; shift 2 ;;
+    --signal-file) SIGNAL_FILE="$2"; shift 2 ;;
+    --test-requirements) TEST_REQUIREMENTS="$2"; shift 2 ;;
+    *) echo -e "${RED}Unknown option: $1${NC}"; exit 2 ;;
+  esac
+done
+
+if [ -z "$WORKTREE" ] || [ -z "$TICKET" ]; then
+  echo -e "${RED}ERROR: --worktree and --ticket are required${NC}"
+  exit 2
+fi
+
+if [ ! -d "$WORKTREE" ]; then
+  echo -e "${RED}ERROR: Worktree directory does not exist: $WORKTREE${NC}"
+  exit 2
+fi
+
+# Track failures
+FAILURES=()
+WARNINGS=()
+PASS_COUNT=0
+
+report_pass() {
+  echo -e "  ${GREEN}PASS${NC} $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+report_fail() {
+  echo -e "  ${RED}FAIL${NC} $1"
+  FAILURES+=("$1")
+}
+
+report_warn() {
+  echo -e "  ${YELLOW}WARN${NC} $1"
+  WARNINGS+=("$1")
+}
+
+report_skip() {
+  echo -e "  ${CYAN}SKIP${NC} $1"
+}
+
+echo -e "${CYAN}=== Adversarial Verification: ${TICKET} ===${NC}"
+echo "Worktree: $WORKTREE"
+echo "Base branch: $BASE_BRANCH"
+echo "Test requirements: $TEST_REQUIREMENTS"
+echo ""
+
+cd "$WORKTREE"
+
+# ============================================================
+# 1. CHANGED FILES ANALYSIS
+# ============================================================
+echo -e "${CYAN}--- 1. Changed Files Analysis ---${NC}"
+
+CHANGED_FILES=$(git diff --name-only "${BASE_BRANCH}..." 2>/dev/null || echo "")
+if [ -z "$CHANGED_FILES" ]; then
+  echo -e "${RED}ERROR: No changed files found vs ${BASE_BRANCH}${NC}"
+  exit 2
+fi
+
+# Categorize changed files
+SOURCE_FILES=$(echo "$CHANGED_FILES" | grep -E '\.(ts|tsx|js|jsx|py|go|rs)$' | grep -vE '(\.test\.|\.spec\.|__test__|_test\.)' || true)
+TEST_FILES=$(echo "$CHANGED_FILES" | grep -E '(\.test\.|\.spec\.|__test__|_test\.)' || true)
+CONFIG_FILES=$(echo "$CHANGED_FILES" | grep -E '(\.json|\.yaml|\.yml|\.toml|\.env)$' || true)
+ROUTE_FILES=$(echo "$CHANGED_FILES" | grep -iE '(route|controller|handler|endpoint|api)' | grep -vE '(\.test\.|\.spec\.)' || true)
+UI_FILES=$(echo "$CHANGED_FILES" | grep -iE '\.(tsx|jsx|vue|svelte)$' | grep -vE '(\.test\.|\.spec\.)' || true)
+
+SOURCE_COUNT=$(echo "$SOURCE_FILES" | grep -c . 2>/dev/null || echo 0)
+TEST_COUNT=$(echo "$TEST_FILES" | grep -c . 2>/dev/null || echo 0)
+ROUTE_COUNT=$(echo "$ROUTE_FILES" | grep -c . 2>/dev/null || echo 0)
+UI_COUNT=$(echo "$UI_FILES" | grep -c . 2>/dev/null || echo 0)
+
+echo "  Source files changed: $SOURCE_COUNT"
+echo "  Test files changed: $TEST_COUNT"
+echo "  Route/API files changed: $ROUTE_COUNT"
+echo "  UI component files changed: $UI_COUNT"
+echo ""
+
+# ============================================================
+# 2. UNIT TEST VERIFICATION
+# ============================================================
+echo -e "${CYAN}--- 2. Unit Test Coverage ---${NC}"
+
+if [ "$SOURCE_COUNT" -eq 0 ]; then
+  report_skip "No source files changed — unit tests not applicable"
+else
+  # Check if test files exist for changed source files
+  MISSING_TESTS=()
+  for SRC in $SOURCE_FILES; do
+    # Derive expected test file paths
+    DIR=$(dirname "$SRC")
+    BASENAME=$(basename "$SRC" | sed -E 's/\.(ts|tsx|js|jsx|py|go|rs)$//')
+    EXT=$(echo "$SRC" | grep -oE '\.[^.]+$')
+
+    # Common test file patterns
+    FOUND_TEST=false
+    for PATTERN in \
+      "${DIR}/${BASENAME}.test${EXT}" \
+      "${DIR}/${BASENAME}.spec${EXT}" \
+      "${DIR}/__tests__/${BASENAME}${EXT}" \
+      "${DIR}/__tests__/${BASENAME}.test${EXT}" \
+      "${DIR}/../__tests__/${BASENAME}${EXT}" \
+      "test/${DIR}/${BASENAME}${EXT}" \
+      "tests/${DIR}/${BASENAME}${EXT}"; do
+      if [ -f "$PATTERN" ] || echo "$CHANGED_FILES" | grep -qF "$PATTERN"; then
+        FOUND_TEST=true
+        break
+      fi
+    done
+
+    if [ "$FOUND_TEST" = false ]; then
+      MISSING_TESTS+=("$SRC")
+    fi
+  done
+
+  if [ ${#MISSING_TESTS[@]} -eq 0 ]; then
+    report_pass "All $SOURCE_COUNT source files have corresponding test files"
+  else
+    report_fail "Missing tests for ${#MISSING_TESTS[@]} of $SOURCE_COUNT source files:"
+    for F in "${MISSING_TESTS[@]}"; do
+      echo "    - $F"
+    done
+  fi
+
+  # Run test suite if a test command can be detected
+  if [ -f "package.json" ]; then
+    TEST_CMD=""
+    if command -v bun >/dev/null 2>&1 && grep -q '"test"' package.json; then
+      TEST_CMD="bun test"
+    elif grep -q '"test"' package.json; then
+      TEST_CMD="npm test"
+    fi
+
+    if [ -n "$TEST_CMD" ]; then
+      echo "  Running test suite: $TEST_CMD"
+      if eval "$TEST_CMD" >/dev/null 2>&1; then
+        report_pass "Test suite passes"
+      else
+        report_fail "Test suite has failures"
+      fi
+    fi
+  fi
+fi
+echo ""
+
+# ============================================================
+# 3. API TEST VERIFICATION
+# ============================================================
+echo -e "${CYAN}--- 3. API Test Coverage ---${NC}"
+
+if [ "$TEST_REQUIREMENTS" = "frontend" ]; then
+  report_skip "API tests not required for frontend-only scope"
+elif [ "$ROUTE_COUNT" -eq 0 ]; then
+  report_skip "No API route files changed — API tests not applicable"
+else
+  # Check for Bruno collections
+  BRUNO_DIR=""
+  for DIR in "bruno" "Bruno" "api-tests" "collections"; do
+    if [ -d "$DIR" ]; then
+      BRUNO_DIR="$DIR"
+      break
+    fi
+  done
+
+  if [ -n "$BRUNO_DIR" ]; then
+    # Check for new .bru files in the diff
+    NEW_BRU=$(echo "$CHANGED_FILES" | grep -E '\.bru$' || true)
+    BRU_COUNT=$(echo "$NEW_BRU" | grep -c . 2>/dev/null || echo 0)
+
+    if [ "$BRU_COUNT" -gt 0 ]; then
+      report_pass "Found $BRU_COUNT Bruno API test files for $ROUTE_COUNT route changes"
+    else
+      report_fail "API routes changed ($ROUTE_COUNT files) but no Bruno test files added/modified"
+      echo "    Route files:"
+      for F in $ROUTE_FILES; do
+        echo "      - $F"
+      done
+    fi
+  else
+    # Check for other API test patterns (supertest, axios tests, etc.)
+    API_TEST_FILES=$(echo "$TEST_FILES" | grep -iE '(api|route|endpoint|integration)' || true)
+    API_TEST_COUNT=$(echo "$API_TEST_FILES" | grep -c . 2>/dev/null || echo 0)
+
+    if [ "$API_TEST_COUNT" -gt 0 ]; then
+      report_pass "Found $API_TEST_COUNT API test files for $ROUTE_COUNT route changes"
+    else
+      report_fail "API routes changed ($ROUTE_COUNT files) but no API test files found"
+    fi
+  fi
+fi
+echo ""
+
+# ============================================================
+# 4. FUNCTIONAL/E2E TEST VERIFICATION
+# ============================================================
+echo -e "${CYAN}--- 4. Functional Test Coverage ---${NC}"
+
+if [ "$TEST_REQUIREMENTS" = "backend" ]; then
+  report_skip "Functional tests not required for backend-only scope"
+elif [ "$UI_COUNT" -eq 0 ]; then
+  report_skip "No UI component files changed — functional tests not applicable"
+else
+  # Check for E2E/functional test files
+  E2E_FILES=$(echo "$CHANGED_FILES" | grep -iE '(e2e|playwright|cypress|functional|integration)' || true)
+  E2E_COUNT=$(echo "$E2E_FILES" | grep -c . 2>/dev/null || echo 0)
+
+  if [ "$E2E_COUNT" -gt 0 ]; then
+    report_pass "Found $E2E_COUNT functional/E2E test files for $UI_COUNT UI changes"
+  else
+    # Check if E2E test infrastructure exists at all
+    if [ -d "e2e" ] || [ -d "tests/e2e" ] || [ -f "playwright.config.ts" ] || [ -f "cypress.config.ts" ]; then
+      report_fail "UI changed ($UI_COUNT files) but no functional/E2E test files added/modified"
+    else
+      report_warn "UI changed ($UI_COUNT files) — no E2E test infrastructure detected in project"
+    fi
+  fi
+fi
+echo ""
+
+# ============================================================
+# 5. TYPE SAFETY VERIFICATION
+# ============================================================
+echo -e "${CYAN}--- 5. Type Safety ---${NC}"
+
+# Detect TypeScript project
+if [ -f "tsconfig.json" ]; then
+  TYPECHECK_CMD=""
+  if command -v bun >/dev/null 2>&1; then
+    TYPECHECK_CMD="bun tsc --noEmit"
+  elif command -v npx >/dev/null 2>&1; then
+    TYPECHECK_CMD="npx tsc --noEmit"
+  fi
+
+  if [ -n "$TYPECHECK_CMD" ]; then
+    echo "  Running typecheck: $TYPECHECK_CMD"
+    if eval "$TYPECHECK_CMD" 2>/dev/null; then
+      report_pass "TypeScript compilation clean"
+    else
+      report_fail "TypeScript compilation errors"
+    fi
+  else
+    report_warn "TypeScript project but no tsc available"
+  fi
+else
+  report_skip "Not a TypeScript project"
+fi
+echo ""
+
+# ============================================================
+# 6. SECURITY SCAN
+# ============================================================
+echo -e "${CYAN}--- 6. Security Patterns ---${NC}"
+
+SECURITY_ISSUES=()
+
+# Check for common security anti-patterns in changed files
+for SRC in $SOURCE_FILES; do
+  if [ ! -f "$SRC" ]; then continue; fi
+
+  # SQL injection patterns
+  if grep -nE "(query|exec|execute)\s*\(" "$SRC" | grep -qE '\$\{|` *\+|"\s*\+' 2>/dev/null; then
+    SECURITY_ISSUES+=("Potential SQL injection in $SRC")
+  fi
+
+  # Hardcoded secrets
+  if grep -nEi '(password|secret|api_key|apikey|token)\s*[:=]\s*["\x27][^"\x27]{8,}' "$SRC" 2>/dev/null | grep -qvE '(test|mock|fake|example|placeholder|TODO)'; then
+    SECURITY_ISSUES+=("Potential hardcoded secret in $SRC")
+  fi
+
+  # eval() usage
+  if grep -nE '\beval\s*\(' "$SRC" 2>/dev/null | grep -qvE '(test|spec)'; then
+    SECURITY_ISSUES+=("eval() usage in $SRC")
+  fi
+
+  # innerHTML without sanitization
+  if grep -nE '(innerHTML|dangerouslySetInnerHTML)' "$SRC" 2>/dev/null; then
+    SECURITY_ISSUES+=("Potential XSS via innerHTML in $SRC")
+  fi
+done
+
+if [ ${#SECURITY_ISSUES[@]} -eq 0 ]; then
+  report_pass "No common security anti-patterns found"
+else
+  for ISSUE in "${SECURITY_ISSUES[@]}"; do
+    report_fail "$ISSUE"
+  done
+fi
+echo ""
+
+# ============================================================
+# 7. REWARD HACKING SCAN
+# ============================================================
+echo -e "${CYAN}--- 7. Reward Hacking Patterns ---${NC}"
+
+RH_ISSUES=()
+
+for SRC in $SOURCE_FILES; do
+  if [ ! -f "$SRC" ]; then continue; fi
+
+  # as any casts
+  AS_ANY_COUNT=$(grep -c 'as any' "$SRC" 2>/dev/null || echo 0)
+  if [ "$AS_ANY_COUNT" -gt 0 ]; then
+    RH_ISSUES+=("$AS_ANY_COUNT 'as any' cast(s) in $SRC")
+  fi
+
+  # @ts-ignore / @ts-expect-error without explanation
+  TS_IGNORE_COUNT=$(grep -cE '@ts-(ignore|expect-error)' "$SRC" 2>/dev/null || echo 0)
+  if [ "$TS_IGNORE_COUNT" -gt 0 ]; then
+    RH_ISSUES+=("$TS_IGNORE_COUNT @ts-ignore/@ts-expect-error in $SRC")
+  fi
+
+  # Empty catch blocks
+  if grep -Pzo 'catch\s*\([^)]*\)\s*\{\s*\}' "$SRC" >/dev/null 2>&1; then
+    RH_ISSUES+=("Empty catch block in $SRC")
+  fi
+
+  # console.log left in (non-test files)
+  if ! echo "$SRC" | grep -qE '(test|spec)'; then
+    LOG_COUNT=$(grep -c 'console\.log' "$SRC" 2>/dev/null || echo 0)
+    if [ "$LOG_COUNT" -gt 2 ]; then
+      RH_ISSUES+=("$LOG_COUNT console.log statements in $SRC (possible debug leftovers)")
+    fi
+  fi
+
+  # Non-null assertions (!)
+  BANG_COUNT=$(grep -cE '\w+!' "$SRC" 2>/dev/null || echo 0)
+  if [ "$BANG_COUNT" -gt 5 ]; then
+    RH_ISSUES+=("$BANG_COUNT non-null assertions in $SRC (excessive)")
+  fi
+done
+
+if [ ${#RH_ISSUES[@]} -eq 0 ]; then
+  report_pass "No reward hacking patterns found"
+else
+  for ISSUE in "${RH_ISSUES[@]}"; do
+    report_fail "$ISSUE"
+  done
+fi
+echo ""
+
+# ============================================================
+# 8. WORKER SIGNAL CROSS-CHECK
+# ============================================================
+echo -e "${CYAN}--- 8. Worker Signal Cross-Check ---${NC}"
+
+if [ -n "$SIGNAL_FILE" ] && [ -f "$SIGNAL_FILE" ]; then
+  # Compare worker's self-reported definitionOfDone with our findings
+  CLAIMED_UNIT=$(jq -r '.definitionOfDone.unitTests.exists' "$SIGNAL_FILE" 2>/dev/null || echo "unknown")
+  CLAIMED_API=$(jq -r '.definitionOfDone.apiTests.exists' "$SIGNAL_FILE" 2>/dev/null || echo "unknown")
+  CLAIMED_FUNCTIONAL=$(jq -r '.definitionOfDone.functionalTests.exists' "$SIGNAL_FILE" 2>/dev/null || echo "unknown")
+  CLAIMED_TDD=$(jq -r '.definitionOfDone.testsWrittenFirst' "$SIGNAL_FILE" 2>/dev/null || echo "unknown")
+
+  if [ "$CLAIMED_UNIT" = "true" ] && [ "$TEST_COUNT" -eq 0 ]; then
+    report_fail "Worker claims unit tests exist but no test files found in diff"
+  fi
+
+  if [ "$CLAIMED_API" = "true" ] && [ "$ROUTE_COUNT" -gt 0 ]; then
+    NEW_BRU=$(echo "$CHANGED_FILES" | grep -E '\.bru$' | grep -c . 2>/dev/null || echo 0)
+    API_TESTS=$(echo "$TEST_FILES" | grep -iE '(api|route|endpoint|integration)' | grep -c . 2>/dev/null || echo 0)
+    if [ "$NEW_BRU" -eq 0 ] && [ "$API_TESTS" -eq 0 ]; then
+      report_fail "Worker claims API tests exist but none found in diff"
+    fi
+  fi
+
+  report_pass "Worker signal cross-check complete"
+else
+  report_skip "No signal file provided — skipping cross-check"
+fi
+echo ""
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo -e "${CYAN}=== Verification Summary: ${TICKET} ===${NC}"
+echo ""
+
+TOTAL_CHECKS=$((PASS_COUNT + ${#FAILURES[@]}))
+
+if [ ${#FAILURES[@]} -eq 0 ]; then
+  echo -e "${GREEN}RESULT: PASS${NC} ($PASS_COUNT checks passed)"
+  if [ ${#WARNINGS[@]} -gt 0 ]; then
+    echo ""
+    echo "Warnings (non-blocking):"
+    for W in "${WARNINGS[@]}"; do
+      echo "  - $W"
+    done
+  fi
+  exit 0
+else
+  echo -e "${RED}RESULT: FAIL${NC} (${#FAILURES[@]} failures, $PASS_COUNT passes)"
+  echo ""
+  echo "Failures (blocking):"
+  for F in "${FAILURES[@]}"; do
+    echo "  - $F"
+  done
+  if [ ${#WARNINGS[@]} -gt 0 ]; then
+    echo ""
+    echo "Warnings (non-blocking):"
+    for W in "${WARNINGS[@]}"; do
+      echo "  - $W"
+    done
+  fi
+  exit 1
+fi

--- a/plugins/dev/skills/create-worktree/SKILL.md
+++ b/plugins/dev/skills/create-worktree/SKILL.md
@@ -38,18 +38,30 @@ When this command is invoked:
    ```
 
    The script automatically:
-   - Detects GitHub org/repo from git remote
-   - Uses `GITHUB_SOURCE_ROOT` environment variable if set
-   - Creates worktrees in a clean, organized structure
+   - Reads `catalyst.worktree.setup` from config for project-specific setup
+   - Copies `.claude/` and `.catalyst/` directories
+   - Falls back to auto-detected setup if no config (dependency install + thoughts init)
 
-4. **Initialize thoughts** (REQUIRED - handled automatically by script):
+4. **Project setup** (handled by script based on config):
 
-   The create-worktree.sh script automatically initializes thoughts and syncs with the shared
-   repository, giving the worktree access to:
-   - Shared research documents
-   - Implementation plans
-   - Handoff documents
-   - Team knowledge base
+   If `catalyst.worktree.setup` is defined in config, those commands run in order.
+   Otherwise, the script auto-detects: dependency install (`bun/npm`) + thoughts init.
+
+   Example config for full control:
+   ```json
+   {
+     "catalyst": {
+       "worktree": {
+         "setup": [
+           "humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}",
+           "humanlayer thoughts sync",
+           "bun install",
+           "~/.claude/scripts/trust-workspace.sh \"$(pwd)\""
+         ]
+       }
+     }
+   }
+   ```
 
 5. **Optional: Launch implementation session**: If a plan file path was provided, ask if the user
    wants to launch Claude in the worktree:
@@ -60,45 +72,33 @@ When this command is invoked:
 
 ## Worktree Location Convention
 
-**Recommended Setup**: Set `GITHUB_SOURCE_ROOT` environment variable for clean organization:
+Worktree base directory is resolved in this order:
 
-```bash
-# In ~/.zshrc or ~/.bashrc
-export GITHUB_SOURCE_ROOT="$HOME/code-repos/github"
-```
+1. `catalyst.orchestration.worktreeDir` from config (explicit override)
+2. `~/catalyst/wt/<projectKey>/` (default — reads `catalyst.projectKey` from config)
+3. `~/catalyst/wt/<repo>/` (fallback if no config)
 
-**Convention**:
+**Recommended**: Add `~/catalyst` to Claude Code's `additionalDirectories` in
+`~/.claude/settings.json` so all worktrees across projects are automatically trusted.
 
-- **Main repository**: `${GITHUB_SOURCE_ROOT}/<org>/<repo>`
-  - Example: `~/code-repos/github/coalesce-labs/catalyst`
-- **Worktrees**: `${GITHUB_SOURCE_ROOT}/<org>/<repo>-worktrees/<feature>`
-  - Example: `~/code-repos/github/coalesce-labs/catalyst-worktrees/PROJ-123`
-
-**Fallback behavior** (if `GITHUB_SOURCE_ROOT` not set):
-
-- Defaults to `~/wt/<repo_name>/<worktree_name>`
-
-**Why this convention?**
-
-- ✅ Main branches and worktrees are organized together by org/repo
-- ✅ Easy to find: all worktrees for a project in one place
-- ✅ Clean separation: `<repo>` vs `<repo>-worktrees`
-- ✅ Configurable per-developer via environment variable
-- ✅ No hardcoded paths in scripts or documentation
-
-**Example with GITHUB_SOURCE_ROOT**:
+**Example layout** (for project with `projectKey: "acme"`):
 
 ```
-~/code-repos/github/
-├── coalesce-labs/
-│   ├── catalyst/                    # Main branch
-│   └── catalyst-worktrees/          # All worktrees
-│       ├── PROJ-123-feature/
-│       └── PROJ-456-bugfix/
-└── acme/
-    ├── api/                          # Main branch
-    └── api-worktrees/                # All worktrees
-        └── ENG-789-oauth/
+~/catalyst/wt/acme/
+├── ACME-123-feature/
+├── ACME-456-bugfix/
+└── ENG-789-oauth/
+```
+
+**With orchestration** (multiple named orchestrators):
+
+```
+~/catalyst/wt/acme/
+├── auth-orch/                       # orchestrator
+├── auth-orch-ACME-101/              # worker
+├── auth-orch-ACME-102/              # worker
+├── dash-orch/                       # another orchestrator
+└── dash-orch-ACME-201/              # worker
 ```
 
 ## Example Interaction

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -64,6 +64,63 @@ Uses the provided text as the research query directly.
 | `--skip-validation`    | Skip Phase 4 entirely                                  |
 | `--skip-quality-gates` | Run `/validate-plan` but skip quality gate loop        |
 
+## Orchestrator Mode
+
+When running under an `/orchestrate` coordinator, oneshot writes status updates to a **worker
+signal file** so the orchestrator can track progress and run adversarial verification.
+
+**Detection (checked once at startup):**
+
+```bash
+# 1. CATALYST_ORCHESTRATOR_DIR env var (set by orchestrator in dispatch)
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
+
+# 2. Sibling directory with workers/ subdirectory (convention-based)
+if [ -z "$ORCH_DIR" ]; then
+  PARENT=$(dirname "$(pwd)")
+  for DIR in "$PARENT"/*/workers; do
+    if [ -d "$DIR" ]; then
+      ORCH_DIR=$(dirname "$DIR")
+      break
+    fi
+  done
+fi
+```
+
+If `ORCH_DIR` is detected, the worker:
+
+1. **Reads its signal file** from `${ORCH_DIR}/workers/${TICKET_ID}.json` (created by orchestrator)
+2. **Updates status at each phase transition** — writes `status`, `phase`, and `updatedAt`
+3. **Fills `definitionOfDone`** at Phase 4 (validation) and Phase 5 (ship) with actual results
+4. **Reads wave briefing** if referenced in `${ORCH_DIR}/wave-*-briefing.md` before starting
+
+**Signal file update helper** (run at each phase boundary):
+
+```bash
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET_ID}.json"
+if [ -f "$SIGNAL_FILE" ]; then
+  jq --arg status "$NEW_STATUS" \
+     --arg phase "$PHASE_NUM" \
+     --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '.status = $status | .phase = ($phase | tonumber) | .updatedAt = $updated' \
+     "$SIGNAL_FILE" > "${SIGNAL_FILE}.tmp" && mv "${SIGNAL_FILE}.tmp" "$SIGNAL_FILE"
+fi
+```
+
+**Phase-to-status mapping for signal file:**
+
+| Phase | Signal Status |
+|-------|--------------|
+| 1 start | `researching` |
+| 2 start | `planning` |
+| 3 start | `implementing` |
+| 4 start | `validating` |
+| 5 start | `shipping` |
+| 5 PR created | `pr-created` |
+| 6 start | `merging` |
+| 6 complete | `done` |
+| Any failure | `failed` |
+
 ## Workflow Phases
 
 ### Phase 1: Research (Current Session — Opus)

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -1,0 +1,731 @@
+---
+name: orchestrate
+description: Coordinate multiple tickets in parallel across worktrees with wave-based execution, worker dispatch, and adversarial verification
+disable-model-invocation: true
+allowed-tools: Read, Write, Bash, Task, Grep, Glob, Agent
+version: 1.0.0
+---
+
+# Orchestrate
+
+Coordinate multiple Linear tickets in parallel across git worktrees. The orchestrator creates
+worktrees, dispatches `/oneshot` workers, tracks progress via a dashboard, and enforces quality
+gates through adversarial verification. **The orchestrator NEVER writes application code** — it
+only coordinates, monitors, and verifies.
+
+## Prerequisites
+
+```bash
+# 1. Git (REQUIRED)
+if ! command -v git &>/dev/null; then
+  echo "ERROR: Git is required"
+  exit 1
+fi
+
+# 2. Linearis CLI (REQUIRED for ticket reading)
+if ! command -v linearis &>/dev/null; then
+  echo "ERROR: Linearis CLI required for ticket intake"
+  echo "Install: npm install -g @anthropic/linearis"
+  exit 1
+fi
+
+# 3. GitHub CLI (REQUIRED for PR monitoring)
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: GitHub CLI required for PR/CI monitoring"
+  exit 1
+fi
+
+# 4. HumanLayer CLI (REQUIRED for worker dispatch)
+if ! command -v humanlayer &>/dev/null; then
+  echo "WARNING: HumanLayer CLI not found — falling back to direct claude CLI"
+fi
+```
+
+## Invocation
+
+```
+/orchestrate PROJ-101 PROJ-102 PROJ-103             # explicit tickets
+/orchestrate --project "Q2 API Redesign"              # pull from Linear project
+/orchestrate --cycle current                           # pull from current cycle
+/orchestrate --file tickets.txt                        # read ticket IDs from file
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | Name this orchestrator instance (default: auto-generated from tickets) |
+| `--project <name>` | Pull tickets from a Linear project |
+| `--cycle current` | Pull tickets from the current Linear cycle |
+| `--file <path>` | Read ticket IDs from a file (one per line) |
+| `--auto-merge` | Workers auto-merge PRs when CI + verification pass |
+| `--max-parallel <n>` | Override config `maxParallel` (default: 3) |
+| `--base-branch <branch>` | Base branch for worktrees (default: main) |
+| `--interactive` | Include PM intake phase before orchestration |
+| `--prd <path>` | Run PRD review panel + ticket creation before orchestration |
+| `--dry-run` | Show wave plan without executing |
+
+## Configuration
+
+Reads orchestration config from `.catalyst/config.json` (or `.claude/config.json` if `.catalyst/`
+doesn't exist). Falls back to sensible defaults if no orchestration block exists.
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "worktreeDir": null,
+      "maxParallel": 3,
+      "hooks": {
+        "setup": [],
+        "teardown": []
+      },
+      "workerCommand": "/oneshot",
+      "workerModel": "opus",
+      "thoughts": {
+        "profile": null,
+        "directory": null
+      },
+      "testRequirements": {
+        "backend": ["unit"],
+        "frontend": ["unit"],
+        "fullstack": ["unit"]
+      },
+      "verifyBeforeMerge": true,
+      "allowSelfReportedCompletion": false
+    }
+  }
+}
+```
+
+See config template for full schema documentation.
+
+## Core Principle: The Orchestrator Never Writes Code
+
+The orchestrator operates ONLY from its own worktree. It:
+
+- Creates/removes worker worktrees
+- Dispatches worker sessions (via `humanlayer launch` or `claude` CLI)
+- Reads status from worker signal files and git
+- Writes dashboard and briefing documents for the human
+- Runs adversarial verification agents in worker worktrees
+- Updates Linear ticket states when workers fail to do so
+
+It NEVER:
+
+- Modifies application code
+- Writes test code
+- Changes configuration in worker worktrees
+- Commits to worker branches
+
+## Workflow
+
+### Phase 1: Intake & Dependency Analysis
+
+1. **Resolve tickets**: Based on invocation mode:
+   - Explicit IDs: validate each via `linearis issues get <ID>`
+   - `--project`: `linearis issues list --project "<name>" --status "Todo,Backlog,In Progress"`
+   - `--cycle current`: `linearis cycles list --current` then `linearis issues list --cycle <id>`
+   - `--file`: read IDs from file, validate each
+
+2. **Read ticket details**: For each ticket, extract:
+   - Title, description, estimate
+   - Dependencies (linked blocking/blocked-by issues)
+   - Labels (to detect scope: backend, frontend, fullstack)
+
+3. **Build dependency graph**: Identify which tickets in the set depend on each other.
+
+4. **Group into waves**:
+   - **Wave 1**: tickets with no dependencies on other tickets in the set
+   - **Wave 2**: tickets that depend only on Wave 1 tickets
+   - **Wave N**: tickets that depend on Wave N-1 tickets
+   - Tickets with circular dependencies → flag to user, do NOT proceed
+
+5. **Present wave plan for approval**:
+
+```
+Orchestration Plan — "api-redesign"
+Total: 6 tickets | 3 waves | Max parallel: 3
+
+Wave 1 (parallel, 3 workers):
+  PROJ-101: Auth middleware rewrite [backend, 3pt]
+  PROJ-102: Rate limiting service [backend, 2pt]
+  PROJ-103: Email templates [frontend, 1pt]
+
+Wave 2 (after Wave 1, 2 workers):
+  PROJ-104: OAuth integration [fullstack, 5pt] — depends on PROJ-101
+  PROJ-105: API usage dashboard [frontend, 3pt] — depends on PROJ-102
+
+Wave 3 (after Wave 2, 1 worker):
+  PROJ-106: Self-service API keys [fullstack, 5pt] — depends on PROJ-104, PROJ-105
+
+Estimated waves: 3 sequential rounds
+Proceed? [Y/n]
+```
+
+6. **If `--dry-run`**: Print wave plan and exit.
+
+### Phase 2: Provision Worktrees
+
+Determine worktree base directory (in priority order):
+1. `catalyst.orchestration.worktreeDir` from config
+2. `${GITHUB_SOURCE_ROOT}/<org>/<repo>-worktrees/` (from env var + git remote)
+3. `~/wt/<repo>/` (fallback)
+
+**Read config for orchestration settings:**
+
+```bash
+# Resolve config file (.catalyst/ first, then .claude/)
+CONFIG_FILE=""
+for CFG in ".catalyst/config.json" ".claude/config.json"; do
+  if [ -f "$CFG" ]; then CONFIG_FILE="$CFG"; break; fi
+done
+
+# Read orchestration config (all have defaults)
+WORKTREE_DIR=$(jq -r '.catalyst.orchestration.worktreeDir // empty' "$CONFIG_FILE" 2>/dev/null)
+MAX_PARALLEL=$(jq -r '.catalyst.orchestration.maxParallel // 3' "$CONFIG_FILE" 2>/dev/null)
+SETUP_HOOKS=$(jq -c '.catalyst.orchestration.hooks.setup // []' "$CONFIG_FILE" 2>/dev/null)
+TEARDOWN_HOOKS=$(jq -c '.catalyst.orchestration.hooks.teardown // []' "$CONFIG_FILE" 2>/dev/null)
+WORKER_COMMAND=$(jq -r '.catalyst.orchestration.workerCommand // "/oneshot"' "$CONFIG_FILE" 2>/dev/null)
+WORKER_MODEL=$(jq -r '.catalyst.orchestration.workerModel // "opus"' "$CONFIG_FILE" 2>/dev/null)
+```
+
+**Create ALL worktrees using `create-worktree.sh`** — both orchestrator and workers go
+through the same script so they all get `.claude/`, `.catalyst/`, dependency install,
+thoughts init, and custom hooks:
+
+```bash
+# The create-worktree.sh script lives relative to this plugin
+SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/create-worktree.sh"
+
+# Resolve --worktree-dir to pass through (omit flag if not configured — script uses its own defaults)
+WT_DIR_FLAG=""
+if [ -n "$WORKTREE_DIR" ]; then
+  WT_DIR_FLAG="--worktree-dir ${WORKTREE_DIR}"
+fi
+
+# Resolve --hooks-json to pass custom setup hooks from config
+HOOKS_FLAG=""
+if [ "$SETUP_HOOKS" != "[]" ] && [ -n "$SETUP_HOOKS" ]; then
+  HOOKS_FLAG="--hooks-json '${SETUP_HOOKS}'"
+fi
+
+# 1. Create orchestrator worktree (same script, same initialization)
+"$SCRIPT" "${ORCH_NAME}" "${BASE_BRANCH}" ${WT_DIR_FLAG} ${HOOKS_FLAG}
+ORCH_DIR="${WORKTREES_BASE}/${ORCH_NAME}"
+
+# 2. Create worker worktrees for current wave
+for TICKET_ID in "${WAVE_TICKETS[@]}"; do
+  "$SCRIPT" "${ORCH_NAME}-${TICKET_ID}" "${BASE_BRANCH}" ${WT_DIR_FLAG} ${HOOKS_FLAG}
+done
+```
+
+**Where worktrees actually land** — the `create-worktree.sh` script resolves the base
+directory in this priority order:
+
+1. `--worktree-dir <path>` flag (from `catalyst.orchestration.worktreeDir` config)
+2. `~/catalyst/wt/<projectKey>/` (default — reads `catalyst.projectKey` from config)
+3. `~/catalyst/wt/<repo>/` (fallback if no config)
+
+So for a project with `projectKey: "acme"` and no `worktreeDir` override, all worktrees
+land in:
+
+```
+~/catalyst/wt/acme/
+├── api-redesign/                         # orchestrator
+├── api-redesign-ACME-101/                # worker
+├── api-redesign-ACME-102/                # worker
+└── api-redesign-ACME-103/                # worker
+```
+
+With `worktreeDir: "~/catalyst/api"` explicitly configured:
+
+```
+~/catalyst/api/
+├── api-redesign/                         # orchestrator
+├── api-redesign-ACME-101/                # worker
+├── api-redesign-ACME-102/                # worker
+└── api-redesign-ACME-103/                # worker
+```
+
+**Recommended**: Add `~/catalyst` to Claude Code's `additionalDirectories` in
+`~/.claude/settings.json` so all worktrees across projects are automatically trusted:
+
+```json
+{
+  "permissions": {
+    "additionalDirectories": [
+      "/Users/you/catalyst"
+    ]
+  }
+}
+```
+
+**What `create-worktree.sh` does for EACH worktree** (orchestrator and workers alike):
+
+1. `git worktree add -b <name> <path> <base-branch>` — creates the worktree
+2. Copies `.claude/` directory (Claude Code native config, plugins, rules)
+3. Copies `.catalyst/` directory (Catalyst workflow config, if it exists)
+4. **Runs `catalyst.worktree.setup` commands from config** — dependency install, thoughts init,
+   permission grants, or any project-specific setup (like Conductor's `conductor.json` lifecycle hooks)
+5. If no `catalyst.worktree.setup` configured, falls back to auto-detected setup: `make setup`
+   or `bun/npm install`, then `humanlayer thoughts init` + `sync`
+6. Runs additional orchestration hooks from `--hooks-json` (from `catalyst.orchestration.hooks.setup`)
+
+**Available variables in setup commands:** `${WORKTREE_PATH}`, `${BRANCH_NAME}`, `${TICKET_ID}`,
+`${REPO_NAME}`, `${DIRECTORY}`, `${PROFILE}`
+
+**After worktree creation, set up the orchestrator's status directory:**
+
+```bash
+mkdir -p "${ORCH_DIR}/workers"
+```
+
+Initialize `DASHBOARD.md` from the template:
+
+```bash
+cp "${CLAUDE_PLUGIN_ROOT}/templates/orchestrate-dashboard.md" "${ORCH_DIR}/DASHBOARD.md"
+```
+
+Create the orchestrator's status directory:
+
+```
+${ORCH_DIR}/
+├── DASHBOARD.md                    # human-readable status (from template)
+├── state.json                      # machine-readable orchestration state
+└── workers/                        # worker signal files written here
+    ├── ${TICKET_1}.json
+    ├── ${TICKET_2}.json
+    └── ...
+```
+
+Initialize `state.json`:
+
+```json
+{
+  "orchestrator": "<name>",
+  "startedAt": "<ISO timestamp>",
+  "baseBranch": "main",
+  "totalTickets": 6,
+  "totalWaves": 3,
+  "currentWave": 1,
+  "worktreeBase": "<path>",
+  "waves": [
+    {
+      "wave": 1,
+      "status": "provisioning",
+      "tickets": ["PROJ-101", "PROJ-102", "PROJ-103"]
+    },
+    {
+      "wave": 2,
+      "status": "blocked",
+      "tickets": ["PROJ-104", "PROJ-105"],
+      "dependsOn": [1]
+    }
+  ],
+  "workers": {}
+}
+```
+
+### Phase 3: Dispatch Workers
+
+For each provisioned worker worktree, dispatch a `/oneshot` session.
+
+**Dispatch mechanism (priority order):**
+
+1. **`humanlayer launch`** (preferred — context isolation + named sessions):
+   ```bash
+   WORKER_DIR="${WORKTREES_BASE}/${ORCH_NAME}-${TICKET_ID}"
+
+   CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
+   humanlayer launch \
+     --model "${WORKER_MODEL}" \
+     --title "${ORCH_NAME}-${TICKET_ID}" \
+     -w "${WORKER_DIR}" \
+     "${WORKER_COMMAND} ${TICKET_ID} --auto-merge"
+   ```
+
+2. **Direct `claude` CLI** (fallback):
+   ```bash
+   CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
+   claude \
+     -n "${ORCH_NAME}-${TICKET_ID}" \
+     -w "${WORKER_DIR}" \
+     -p "${WORKER_COMMAND} ${TICKET_ID} --auto-merge" &
+   ```
+
+**Worker dispatch prompt includes mandatory testing requirements:**
+
+```
+MANDATORY: Before marking this ticket as complete:
+1. TDD — write failing tests BEFORE implementation for every feature
+2. Unit tests — required for all new functions/methods
+3. Integration/API tests — required for every new/modified API endpoint
+4. Security review — must pass /security-review or equivalent
+5. Code review — must pass code-reviewer agent
+6. All quality gates in config must pass
+
+Your work will be independently verified by the orchestrator. Do NOT mark as done
+until all test types exist. Write your status to the worker signal file at:
+  ${ORCH_DIR}/workers/${TICKET_ID}.json
+
+Update the signal file at each phase transition using the worker-signal.json schema.
+```
+
+**Initialize worker signal file** (orchestrator writes the initial state):
+
+```json
+{
+  "ticket": "PROJ-101",
+  "orchestrator": "<name>",
+  "workerName": "<orch-name>-PROJ-101",
+  "status": "dispatched",
+  "phase": 0,
+  "startedAt": "<ISO timestamp>",
+  "updatedAt": "<ISO timestamp>",
+  "worktreePath": "<path>",
+  "pr": null,
+  "linearState": null,
+  "definitionOfDone": {
+    "testsWrittenFirst": false,
+    "unitTests": { "exists": false, "count": 0 },
+    "apiTests": { "exists": false, "count": 0 },
+    "functionalTests": { "exists": false, "count": 0 },
+    "typeCheck": { "passed": false },
+    "securityReview": { "passed": false },
+    "codeReview": { "passed": false },
+    "rewardHackingScan": { "passed": false }
+  }
+}
+```
+
+### Phase 4: Monitor & Track
+
+The orchestrator polls worker status on a regular interval. Use `/loop` if available, otherwise
+poll manually.
+
+**Monitoring loop (every 2-3 minutes):**
+
+```bash
+# For each active worker:
+for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
+  TICKET=$(jq -r '.ticket' "$WORKER_SIGNAL")
+  WORKER_DIR="${WORKTREE_BASE}/${ORCH_NAME}-${TICKET}"
+
+  # 1. Read worker signal file for self-reported status
+  STATUS=$(jq -r '.status' "$WORKER_SIGNAL")
+
+  # 2. Check git state in worker worktree
+  cd "$WORKER_DIR"
+  BRANCH=$(git branch --show-current)
+  COMMIT_COUNT=$(git rev-list --count "${BASE_BRANCH}..HEAD" 2>/dev/null || echo 0)
+
+  # 3. Check for PR
+  PR_URL=$(gh pr list --head "$BRANCH" --json url --jq '.[0].url' 2>/dev/null || echo "")
+
+  # 4. If PR exists, check CI
+  if [ -n "$PR_URL" ]; then
+    CI_STATUS=$(gh pr checks "$BRANCH" --json state --jq '.[].state' 2>/dev/null | sort -u)
+  fi
+
+  # 5. Update dashboard
+done
+```
+
+**Update `DASHBOARD.md`** after each poll using the dashboard template. Include:
+- Wave progress (current wave, tickets per wave)
+- Per-worker status table (ticket, status, PR, test coverage columns)
+- Event log (timestamped significant events)
+
+**Update `state.json`** with machine-readable state for crash recovery.
+
+### Phase 5: Independent Verification (Anti-Reward-Hacking)
+
+When a worker signals "done" (PR created, CI green), the orchestrator does NOT trust it.
+It spawns an **adversarial verification agent** in the worker's worktree:
+
+```bash
+# Run adversarial verification
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-verify.sh" \
+  --worktree "${WORKER_DIR}" \
+  --ticket "${TICKET_ID}" \
+  --base-branch "${BASE_BRANCH}" \
+  --signal-file "${ORCH_DIR}/workers/${TICKET_ID}.json" \
+  --test-requirements "${TEST_REQUIREMENTS}"
+```
+
+The verification script checks:
+
+1. **Unit tests**: For each new/modified source file, verify a corresponding test file exists.
+   Run the test suite, verify tests pass.
+2. **API tests**: If API routes were added/modified, verify test coverage exists (Bruno
+   collections, integration tests, etc.).
+3. **Functional tests**: If UI was changed, verify functional/E2E test coverage exists.
+4. **Type safety**: Run typecheck command, verify no errors.
+5. **Security**: Check for OWASP top 10 patterns in new code.
+6. **Reward hacking scan**: Run `/scan-reward-hacking` on changed files — check for `as any`,
+   `@ts-ignore`, void patterns, suppressed errors.
+
+**Verification outcomes:**
+
+- **PASS**: All required coverage types present and passing. Worker advances to merge.
+- **FAIL**: Specific gaps identified. Orchestrator:
+  1. Updates dashboard with specific failures
+  2. Sends worker back with explicit remediation instructions
+  3. Does NOT allow the ticket to advance to merge
+  4. Re-verifies after worker reports fix
+
+**Send worker back (on failure):**
+
+Write remediation instructions to a file the worker can read:
+
+```
+${ORCH_DIR}/workers/${TICKET_ID}-remediation.md
+
+# Verification Failed — ${TICKET_ID}
+
+The following gaps were found by independent verification:
+
+## Missing Coverage
+- [ ] No unit tests for src/auth/middleware.ts (new file)
+- [ ] No Bruno API tests for POST /api/auth/token (new endpoint)
+
+## Quality Issues
+- [ ] `as any` cast at src/auth/types.ts:42
+
+## Required Actions
+1. Write unit tests for the middleware
+2. Add Bruno collection for the auth endpoint
+3. Remove the `as any` cast, use proper type guard
+
+Update your worker signal file when fixed. The orchestrator will re-verify.
+```
+
+### Phase 6: Wave Advancement
+
+When ALL tickets in the current wave pass verification:
+
+1. **Merge PRs**: If `--auto-merge`, run `/merge-pr` in each worker worktree. Otherwise, flag
+   PRs for human review on the dashboard.
+
+2. **Write wave briefing** for the next wave (see Wave Briefing section below).
+
+3. **Clean up completed worktrees**: Run teardown hooks from config, then remove.
+   ```bash
+   WORKER_DIR="${WORKTREES_BASE}/${ORCH_NAME}-${TICKET_ID}"
+   BRANCH_NAME="${ORCH_NAME}-${TICKET_ID}"
+
+   # Run teardown hooks from catalyst.orchestration.hooks.teardown
+   # Variable substitution: ${WORKTREE_PATH}, ${BRANCH_NAME}, ${TICKET_ID}, ${REPO_NAME}
+   for HOOK in $(echo "$TEARDOWN_HOOKS" | jq -r '.[]'); do
+     HOOK="${HOOK//\$\{WORKTREE_PATH\}/$WORKER_DIR}"
+     HOOK="${HOOK//\$\{BRANCH_NAME\}/$BRANCH_NAME}"
+     HOOK="${HOOK//\$\{TICKET_ID\}/$TICKET_ID}"
+     eval "$HOOK" || true
+   done
+
+   # If teardown hooks didn't already remove the worktree, do it now
+   if [ -d "$WORKER_DIR" ]; then
+     git worktree remove "$WORKER_DIR" 2>/dev/null || true
+     git branch -D "$BRANCH_NAME" 2>/dev/null || true
+   fi
+   ```
+
+4. **Provision next wave**: Create worktrees for Wave N+1 tickets using the same
+   `create-worktree.sh` invocation from Phase 2.
+
+5. **Dispatch next wave workers**: Include wave briefing in dispatch prompt:
+   ```
+   IMPORTANT: Read the Wave ${PREV} briefing before starting:
+     ${ORCH_DIR}/wave-${PREV}-briefing.md
+
+   This briefing contains patterns, conventions, test helpers, and gotchas
+   discovered by the previous wave. Build ON TOP of these — do not reinvent.
+   ```
+
+6. **Update dashboard and state**: Advance `currentWave`, update wave statuses.
+
+### Phase 7: Completion
+
+When all waves are complete:
+
+1. **Write final summary** to `${ORCH_DIR}/SUMMARY.md`:
+   - Total tickets completed
+   - Total PRs merged
+   - Test coverage summary across all tickets
+   - Timeline (start to finish, per-wave durations)
+   - Any verification failures that required remediation
+
+2. **Verify Linear states**: Check all tickets are in `stateMap.done`. If any are stuck,
+   update them:
+   ```bash
+   linearis issues update "${TICKET_ID}" --status "${STATE_MAP_DONE}"
+   ```
+
+3. **Clean up all worktrees** (including orchestrator worktree, unless user wants to keep it).
+
+4. **Sync thoughts**: `humanlayer thoughts sync` to persist any shared documents.
+
+5. **Report to user**:
+   ```
+   Orchestration Complete — "api-redesign"
+
+   Waves: 3/3 complete
+   Tickets: 6/6 merged
+   PRs: #87, #88, #89, #91, #92, #93
+   Duration: 2h 14m
+
+   Verification: 2 tickets required remediation
+     - PROJ-101: Missing Bruno API tests (fixed on retry)
+     - PROJ-105: as any cast (fixed on retry)
+
+   Summary: ${ORCH_DIR}/SUMMARY.md
+   ```
+
+## Wave Briefing Documents
+
+Before dispatching each wave after Wave 1, the orchestrator writes a **briefing document**
+to `${ORCH_DIR}/wave-${N}-briefing.md` summarizing what prior waves learned.
+
+**How the briefing is created:**
+
+1. Read each completed worker's PR description
+2. Read git diff summaries from each merged PR (`git diff --stat`)
+3. Read any research documents workers saved to `thoughts/shared/`
+4. Synthesize into: patterns established, new dependencies added, test helpers created,
+   gotchas discovered
+
+Use the wave briefing template from `plugins/dev/templates/orchestrate-wave-briefing.md`.
+
+**Why this matters:** This is a unique advantage over other frameworks. GSD executors are
+stateless. Gas Town Polecats don't share findings. Wave briefings mean:
+- Wave 2+ workers know which patterns to follow
+- Wave 2+ workers know which test helpers exist
+- Wave 2+ workers know about gotchas discovered by earlier waves
+- Knowledge compounds across waves
+
+## Testing Enforcement (3 Layers)
+
+### Layer 1 — Dispatch Prompt (Prevention)
+
+Every worker dispatch includes mandatory testing requirements in the prompt itself.
+Not a suggestion — a hard requirement. The prompt explicitly states that work will be
+independently verified and workers should not claim done without tests.
+
+### Layer 2 — Quality Gates (Automated)
+
+The existing quality gate system (`/validate-type-safety`, `/security-review`,
+`code-reviewer`, `pr-test-analyzer`) plus config-based gates run inside each worker's
+`/oneshot` pipeline. These are the worker's own self-checks.
+
+### Layer 3 — Independent Verification (Adversarial)
+
+The orchestrator's own verification script audits the worker's output AFTER the worker
+claims done. This is the anti-reward-hacking layer — the worker can't game its own quality
+gates because the orchestrator runs a separate, adversarial check. The verification agent
+has no incentive to pass — it's scored on catching gaps, not shipping fast.
+
+## Dashboard
+
+The orchestrator maintains a live dashboard at `${ORCH_DIR}/DASHBOARD.md`. Updated after
+each monitoring poll. Uses the template from `plugins/dev/templates/orchestrate-dashboard.md`.
+
+The dashboard includes:
+- Orchestrator metadata (name, start time, project, base branch)
+- Current wave progress
+- Per-worker status table with test coverage columns
+- Blocked waves with dependency information
+- Timestamped event log
+
+## Linear Integration
+
+The orchestrator manages Linear state transitions as a safety net:
+
+| Event | Linear Action |
+|-------|--------------|
+| Worker dispatched | Move ticket to `stateMap.inProgress` |
+| Worker creates PR | Verify ticket is `stateMap.inReview` — fix if not |
+| Worker passes verification | No change (already in review) |
+| PR merged | Verify ticket is `stateMap.done` — fix if not |
+| Worker fails/stalls | Add comment with status, keep `inProgress` |
+
+The orchestrator also adds comments to tickets for visibility:
+```bash
+linearis comments create "${TICKET_ID}" \
+  --body "Orchestrator [${ORCH_NAME}]: Worker dispatched. Phase: research."
+```
+
+## Named Orchestrators & Remote Control
+
+Start the orchestrator with remote control for access from claude.ai/code:
+```bash
+claude --remote-control "${ORCH_NAME}" -w "${ORCH_DIR}"
+```
+
+Workers should NOT use remote control — they're autonomous. The human monitors workers
+through the orchestrator's dashboard.
+
+**Multiple orchestrators** can run concurrently. Worktree names are prefixed with the
+orchestrator name to avoid collisions:
+```
+${WORKTREE_BASE}/
+├── auth-orch/                    # orchestrator 1
+├── auth-orch-PROJ-101/           # orchestrator 1's worker
+├── auth-orch-PROJ-102/           # orchestrator 1's worker
+├── dash-orch/                    # orchestrator 2
+├── dash-orch-PROJ-201/           # orchestrator 2's worker
+└── dash-orch-PROJ-202/           # orchestrator 2's worker
+```
+
+## Worker Communication
+
+Workers write status updates to `${ORCH_DIR}/workers/${TICKET_ID}.json`. The `/oneshot`
+skill detects orchestrator presence by checking for a sibling `orchestrator/` directory or
+the `CATALYST_ORCHESTRATOR_DIR` environment variable.
+
+**Worker signal file schema:** See `plugins/dev/templates/worker-signal.json` for the full
+JSON schema including the `definitionOfDone` block.
+
+**How workers detect orchestrator mode:**
+
+```bash
+# Detection order:
+# 1. CATALYST_ORCHESTRATOR_DIR env var (set by orchestrator in dispatch)
+# 2. Sibling directory matching *-orchestrator or <prefix>/ pattern
+# 3. ../*/workers/ directory exists (convention-based)
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
+if [ -z "$ORCH_DIR" ]; then
+  # Check for sibling orchestrator directory
+  PARENT=$(dirname "$(pwd)")
+  ORCH_DIR=$(find "$PARENT" -maxdepth 1 -name "*/workers" -type d 2>/dev/null | head -1 | sed 's|/workers$||')
+fi
+```
+
+## Error Handling
+
+**Worker crashes or stalls:**
+- Monitor detects no progress for 15+ minutes (no commits, no signal updates)
+- Dashboard marks worker as "stalled"
+- Orchestrator does NOT auto-restart — flags for human decision
+- Options presented: restart worker, skip ticket, investigate manually
+
+**Orchestrator crash recovery:**
+- All state is in `${ORCH_DIR}/state.json` + worker signal files
+- Resume with: `/orchestrate --resume ${ORCH_DIR}`
+- Reads state.json, determines current wave, checks each worker's actual status
+- Picks up where it left off
+
+**Worktree conflicts:**
+- If a worktree path already exists, skip creation and check if it's from a previous run
+- If it has a valid worker signal file, treat as a resumed worker
+
+## Important
+
+- The orchestrator lives in its own worktree and **never modifies code**
+- Workers are fully autonomous — they run `/oneshot` with all its phases
+- Wave advancement requires ALL tickets in the wave to pass verification
+- The `--auto-merge` flag applies to workers, not the orchestrator
+- Dashboard and state files are ephemeral — they don't survive worktree removal
+- Wave briefings are the key differentiator — knowledge compounds across waves
+- The 3-layer testing enforcement prevents the observed failure mode of agents skipping tests
+- CTL-26 dependency: Uses `.catalyst/` paths. Falls back to `.claude/` if `.catalyst/` doesn't exist

--- a/plugins/dev/templates/orchestrate-dashboard.md
+++ b/plugins/dev/templates/orchestrate-dashboard.md
@@ -1,0 +1,33 @@
+# Orchestration Dashboard
+
+**Orchestrator:** ${ORCH_NAME}
+**Started:** ${STARTED_AT}
+**Project:** ${PROJECT_NAME}
+**Base branch:** ${BASE_BRANCH}
+**Total:** ${TOTAL_TICKETS} tickets | ${TOTAL_WAVES} waves | Max parallel: ${MAX_PARALLEL}
+
+## Current Wave: ${CURRENT_WAVE} of ${TOTAL_WAVES}
+
+| Ticket | Title | Status | PR | Unit Tests | API Tests | Functional | Security | Code Review | Verified |
+|--------|-------|--------|-----|-----------|-----------|------------|----------|-------------|----------|
+| ${TICKET_ID} | ${TITLE} | ${STATUS} | ${PR_LINK} | ${UNIT} | ${API} | ${FUNC} | ${SEC} | ${REVIEW} | ${VERIFIED} |
+
+## Upcoming Waves
+
+### Wave ${NEXT_WAVE} (blocked on Wave ${CURRENT_WAVE})
+
+| Ticket | Title | Depends On |
+|--------|-------|------------|
+| ${TICKET_ID} | ${TITLE} | ${DEPENDS_ON} |
+
+## Completed Waves
+
+### Wave ${PREV_WAVE}
+
+| Ticket | PR | Duration | Remediation |
+|--------|-----|----------|-------------|
+| ${TICKET_ID} | ${PR_LINK} | ${DURATION} | ${REMEDIATION_NOTE} |
+
+## Event Log
+
+- ${TIMESTAMP} — ${EVENT_DESCRIPTION}

--- a/plugins/dev/templates/orchestrate-wave-briefing.md
+++ b/plugins/dev/templates/orchestrate-wave-briefing.md
@@ -1,0 +1,41 @@
+# Wave ${WAVE_NUMBER} Briefing — ${ORCH_NAME}
+
+**Date:** ${TIMESTAMP}
+**Project:** ${PROJECT_NAME}
+
+## Context from Wave ${PREV_WAVE}
+
+### Completed Tickets
+
+- **${TICKET_ID}**: ${TITLE}
+  - PR ${PR_LINK} merged
+  - Key finding: ${KEY_FINDING}
+  - New pattern established: ${PATTERN_DESCRIPTION}
+  - Tests: ${UNIT_COUNT} unit, ${API_COUNT} API tests
+
+### Patterns and Conventions Established
+
+- ${PATTERN_NAME}: ${PATTERN_USAGE}
+
+### New Dependencies Added
+
+- ${PACKAGE_NAME}: ${PACKAGE_PURPOSE}
+
+### Test Helpers Created
+
+- ${HELPER_NAME}: ${HELPER_DESCRIPTION} (location: ${HELPER_PATH})
+
+### Known Issues / Gotchas
+
+- ${GOTCHA_DESCRIPTION}
+
+## Your Tickets (Wave ${WAVE_NUMBER})
+
+- **${TICKET_ID}**: ${TITLE} (depends on ${DEPENDENCY})
+
+## Important
+
+- Build ON TOP of Wave ${PREV_WAVE}'s patterns — don't reinvent what already exists
+- Use the established test helpers listed above
+- Follow the naming conventions and file organization from completed PRs
+- Check `thoughts/shared/research/` for any relevant research from prior waves

--- a/plugins/dev/templates/worker-signal.json
+++ b/plugins/dev/templates/worker-signal.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$comment": "Worker signal file schema — written by /oneshot workers, read by /orchestrate coordinator",
+  "type": "object",
+  "required": ["ticket", "orchestrator", "workerName", "status", "phase", "startedAt", "updatedAt"],
+  "properties": {
+    "ticket": {
+      "type": "string",
+      "description": "Linear ticket ID (e.g., PROJ-101)"
+    },
+    "orchestrator": {
+      "type": "string",
+      "description": "Name of the orchestrator that dispatched this worker"
+    },
+    "workerName": {
+      "type": "string",
+      "description": "Full worker name (e.g., api-redesign-PROJ-101)"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "dispatched",
+        "researching",
+        "planning",
+        "implementing",
+        "validating",
+        "shipping",
+        "pr-created",
+        "merging",
+        "done",
+        "failed",
+        "stalled",
+        "remediation"
+      ],
+      "description": "Current worker status"
+    },
+    "phase": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 6,
+      "description": "Current /oneshot phase (0=dispatched, 1=research, 2=plan, 3=implement, 4=validate, 5=ship, 6=merge)"
+    },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when worker was dispatched"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of last status update"
+    },
+    "worktreePath": {
+      "type": "string",
+      "description": "Absolute path to the worker's worktree directory"
+    },
+    "pr": {
+      "type": ["object", "null"],
+      "properties": {
+        "number": { "type": "integer" },
+        "url": { "type": "string", "format": "uri" },
+        "ciStatus": {
+          "type": "string",
+          "enum": ["pending", "passing", "failing", "unknown"]
+        }
+      },
+      "description": "Pull request details (null until PR is created)"
+    },
+    "linearState": {
+      "type": ["string", "null"],
+      "description": "Current Linear ticket state as reported by the worker"
+    },
+    "definitionOfDone": {
+      "type": "object",
+      "description": "Self-reported completion status for each quality gate. The orchestrator independently verifies these claims.",
+      "properties": {
+        "testsWrittenFirst": {
+          "type": "boolean",
+          "description": "Whether tests were written before implementation (TDD)"
+        },
+        "unitTests": {
+          "type": "object",
+          "properties": {
+            "exists": { "type": "boolean" },
+            "count": { "type": "integer", "minimum": 0 }
+          },
+          "description": "Unit test coverage"
+        },
+        "apiTests": {
+          "type": "object",
+          "properties": {
+            "exists": { "type": "boolean" },
+            "count": { "type": "integer", "minimum": 0 },
+            "reason": { "type": "string" }
+          },
+          "description": "API/integration test coverage (Bruno collections, supertest, etc.)"
+        },
+        "functionalTests": {
+          "type": "object",
+          "properties": {
+            "exists": { "type": "boolean" },
+            "count": { "type": "integer", "minimum": 0 },
+            "reason": { "type": "string" }
+          },
+          "description": "Functional/E2E test coverage"
+        },
+        "typeCheck": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" }
+          },
+          "description": "TypeScript compilation status"
+        },
+        "securityReview": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" }
+          },
+          "description": "Security review status"
+        },
+        "codeReview": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" },
+            "findings": { "type": "integer", "minimum": 0 }
+          },
+          "description": "Code review agent status"
+        },
+        "rewardHackingScan": {
+          "type": "object",
+          "properties": {
+            "passed": { "type": "boolean" },
+            "violations": { "type": "integer", "minimum": 0 }
+          },
+          "description": "Reward hacking scan results"
+        }
+      }
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Error message if status is 'failed'"
+    }
+  }
+}

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -121,6 +121,78 @@ Never committed. One file per project, linked by `projectKey`.
 
 Only configure the integrations you use. The setup script prompts for each one.
 
+## Worktree Setup
+
+Define the commands that run when creating a new worktree via `/create-worktree` or `/orchestrate`. This replaces the default auto-detected setup (dependency install + thoughts init) with full project control — like `conductor.json`'s lifecycle hooks.
+
+```json
+{
+  "catalyst": {
+    "worktree": {
+      "setup": [
+        "humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}",
+        "humanlayer thoughts sync",
+        "bun install",
+        "~/.claude/scripts/trust-workspace.sh \"$(pwd)\""
+      ]
+    }
+  }
+}
+```
+
+Commands run in order, inside the new worktree directory. Each command supports variable substitution:
+
+| Variable | Value |
+|----------|-------|
+| `${WORKTREE_PATH}` | Absolute path to the new worktree |
+| `${BRANCH_NAME}` | Git branch name |
+| `${TICKET_ID}` | Same as branch name |
+| `${REPO_NAME}` | Repository name |
+| `${DIRECTORY}` | Thoughts directory (from `catalyst.thoughts.directory` or repo name) |
+| `${PROFILE}` | Thoughts profile (from `catalyst.thoughts.profile` or auto-detected) |
+
+If `catalyst.worktree.setup` is **not configured**, the script falls back to auto-detected setup: `make setup` or `bun/npm install`, then `humanlayer thoughts init` + `sync`. Once you define `setup`, only your commands run — the auto-detection is skipped entirely.
+
+## Orchestration Config
+
+Optional. Add this block to enable `/orchestrate` — see [Orchestration](/reference/orchestration/) for full documentation.
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "worktreeDir": null,
+      "maxParallel": 3,
+      "hooks": {
+        "setup": ["bun install"],
+        "teardown": []
+      },
+      "workerCommand": "/oneshot",
+      "workerModel": "opus",
+      "testRequirements": {
+        "backend": ["unit"],
+        "frontend": ["unit"],
+        "fullstack": ["unit"]
+      },
+      "verifyBeforeMerge": true,
+      "allowSelfReportedCompletion": false
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `worktreeDir` | string\|null | `~/catalyst/wt/<projectKey>` | Base directory for worktrees |
+| `maxParallel` | number | 3 | Max concurrent workers |
+| `hooks.setup` | string[] | `[]` | Run after worktree creation (supports `${WORKTREE_PATH}`, `${BRANCH_NAME}`, `${TICKET_ID}`, `${REPO_NAME}`, `${DIRECTORY}` variables) |
+| `hooks.teardown` | string[] | `[]` | Run before worktree removal |
+| `workerCommand` | string | `/oneshot` | Skill to dispatch in each worker |
+| `workerModel` | string | `opus` | Model for worker sessions |
+| `testRequirements` | object | See above | Required test types by scope (backend/frontend/fullstack) |
+| `verifyBeforeMerge` | boolean | `true` | Run adversarial verification before allowing merge |
+| `allowSelfReportedCompletion` | boolean | `false` | Trust worker's self-reported completion without verification |
+
 ## Workflow Context (`.catalyst/.workflow-context.json`)
 
 Auto-managed by Claude Code hooks. Not committed to git.

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -1,0 +1,458 @@
+---
+title: Orchestration
+description: Coordinate multiple tickets in parallel — wave-based execution, worker dispatch, adversarial verification, and cross-wave knowledge sharing.
+sidebar:
+  order: 5
+---
+
+Orchestration is Catalyst's system for coordinating **multiple tickets in parallel** across git worktrees. An AI coordinator dispatches workers, tracks progress via a dashboard, and enforces quality through adversarial verification.
+
+## Orchestration Levels
+
+Catalyst workflows operate at two levels:
+
+| Level | What | How |
+|-------|------|-----|
+| **Level 2** | Single-ticket pipeline | `/oneshot` chains research, plan, implement, validate, ship, merge with context isolation |
+| **Level 3** | Multi-ticket coordination | `/orchestrate` dispatches Level 2 workers across worktrees with wave-based parallelism and independent verification |
+
+Level 3 builds on Level 2 — each worker runs the full `/oneshot` pipeline autonomously. The orchestrator adds coordination, knowledge sharing, and anti-reward-hacking verification on top.
+
+## Prerequisites
+
+### Required Tools
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| **Git** | Worktree creation, branch management | Pre-installed on macOS |
+| **Linearis CLI** | Read tickets from Linear, update states | `npm install -g @anthropic/linearis` |
+| **GitHub CLI** | PR creation, CI monitoring | `brew install gh` |
+| **jq** | Config parsing, signal file updates | `brew install jq` |
+| **HumanLayer CLI** | Worker dispatch with context isolation, thoughts system | `pip install humanlayer` |
+
+If HumanLayer is not installed, the orchestrator falls back to launching workers with the `claude` CLI directly. The thoughts system (shared research, plans, handoffs across worktrees) requires HumanLayer.
+
+### Claude Code Settings
+
+Add `~/catalyst` to Claude Code's trusted directories so all worktrees across all projects are accessible without per-worktree approval:
+
+```json
+// ~/.claude/settings.json
+{
+  "permissions": {
+    "additionalDirectories": [
+      "/Users/you/catalyst"
+    ]
+  }
+}
+```
+
+This is a one-time setup. All orchestrator and worker worktrees for every project land under `~/catalyst/wt/<projectKey>/`.
+
+### Project Configuration
+
+The orchestrator reads from your project's Catalyst config (`.catalyst/config.json` or `.claude/config.json`). Two config blocks are relevant:
+
+#### 1. Worktree Setup Commands (`catalyst.worktree.setup`)
+
+**This is the most important configuration to get right.** It defines the commands that run in every new worktree — both standalone worktrees from `/create-worktree` and orchestrator/worker worktrees from `/orchestrate`.
+
+```json
+{
+  "catalyst": {
+    "worktree": {
+      "setup": [
+        "humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}",
+        "humanlayer thoughts sync",
+        "bun install",
+        "~/.claude/scripts/trust-workspace.sh \"$(pwd)\""
+      ]
+    }
+  }
+}
+```
+
+**What to include in your setup array:**
+
+| Step | Command | Why |
+|------|---------|-----|
+| Thoughts init | `humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}` | Workers need access to shared research, plans, and handoffs. Without this, workers can't read wave briefings or save their findings for other waves. |
+| Thoughts sync | `humanlayer thoughts sync` | Pulls down existing shared documents so the worker starts with full context. |
+| Dependency install | `bun install` or `npm install` or `make setup` | Workers need project dependencies to run tests, typecheck, and build. |
+| Permission grant | `~/.claude/scripts/trust-workspace.sh "$(pwd)"` | Adds the worktree to Claude Code's allowed directories. Not needed if `~/catalyst` is already in `additionalDirectories`. |
+| Environment setup | `cp .env.example .env.local` | Workers may need environment variables for local dev. |
+| Database setup | `./scripts/setup-test-db.sh` | If tests require a local database. |
+
+**If `catalyst.worktree.setup` is NOT configured:** The script falls back to auto-detected setup — it will auto-detect `make setup`/`bun install`/`npm install` for dependencies, and run `humanlayer thoughts init` + `sync` if HumanLayer is installed. This fallback is convenient for simple projects but gives you no control over the order, additional steps, or error handling.
+
+**Once you define `catalyst.worktree.setup`, only your commands run.** The auto-detection is skipped entirely. This means you must include dependency install and thoughts init in your array if you need them — they are not added automatically.
+
+#### 2. Orchestration Config (`catalyst.orchestration`)
+
+Optional. Controls orchestrator-specific behavior. All fields have sensible defaults:
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "worktreeDir": null,
+      "maxParallel": 3,
+      "hooks": {
+        "setup": [],
+        "teardown": []
+      },
+      "workerCommand": "/oneshot",
+      "workerModel": "opus",
+      "testRequirements": {
+        "backend": ["unit", "bruno"],
+        "frontend": ["unit", "functional"],
+        "fullstack": ["unit", "bruno", "functional"]
+      },
+      "verifyBeforeMerge": true,
+      "allowSelfReportedCompletion": false
+    }
+  }
+}
+```
+
+**The difference between `worktree.setup` and `orchestration.hooks.setup`:**
+
+- `catalyst.worktree.setup` — runs for **every** worktree (standalone, orchestrator, and workers). This is your base project setup.
+- `catalyst.orchestration.hooks.setup` — runs **only** for orchestrator-managed worktrees, **after** the base setup. Use this for orchestration-specific steps that don't apply to standalone worktrees.
+- `catalyst.orchestration.hooks.teardown` — runs when the orchestrator cleans up completed worktrees after wave advancement.
+
+Most projects only need `catalyst.worktree.setup`. The orchestration hooks are for edge cases like registering workers with an external monitoring system.
+
+### Full Config Example
+
+Here's a complete config for a project using orchestration:
+
+```json
+{
+  "catalyst": {
+    "projectKey": "acme",
+    "repository": { "org": "acme-corp", "name": "api" },
+    "project": { "ticketPrefix": "ACME", "name": "Acme Corp API" },
+    "linear": {
+      "teamKey": "ACME",
+      "stateMap": {
+        "backlog": "Backlog",
+        "todo": "Todo",
+        "research": "In Progress",
+        "planning": "In Progress",
+        "inProgress": "In Progress",
+        "inReview": "In Review",
+        "done": "Done",
+        "canceled": "Canceled"
+      }
+    },
+    "thoughts": {
+      "user": "ryan",
+      "profile": "acme",
+      "directory": "api"
+    },
+    "worktree": {
+      "setup": [
+        "humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}",
+        "humanlayer thoughts sync",
+        "bun install",
+        "~/.claude/scripts/trust-workspace.sh \"$(pwd)\""
+      ]
+    },
+    "orchestration": {
+      "maxParallel": 4,
+      "workerModel": "opus",
+      "testRequirements": {
+        "backend": ["unit", "bruno"],
+        "frontend": ["unit", "functional"],
+        "fullstack": ["unit", "bruno", "functional"]
+      },
+      "verifyBeforeMerge": true
+    }
+  }
+}
+```
+
+### Setup Checklist
+
+Before running `/orchestrate` for the first time:
+
+- [ ] **Linearis CLI installed** and authenticated (`linearis auth login`)
+- [ ] **GitHub CLI installed** and authenticated (`gh auth login`)
+- [ ] **HumanLayer CLI installed** and thoughts initialized in the main repo (`humanlayer thoughts init`)
+- [ ] **`~/catalyst` added** to `~/.claude/settings.json` `additionalDirectories`
+- [ ] **`catalyst.worktree.setup` configured** with your project's setup commands (thoughts init, dependency install, permission grant, etc.)
+- [ ] **`catalyst.linear.stateMap` configured** so ticket state transitions work
+- [ ] **`catalyst.thoughts` configured** with your profile and directory names
+
+## Quick Start
+
+Once prerequisites are met:
+
+```
+/orchestrate ACME-101 ACME-102 ACME-103
+```
+
+The orchestrator:
+1. Reads each ticket from Linear
+2. Builds a dependency graph and groups tickets into waves
+3. Presents the wave plan for approval
+4. Creates worktrees for each ticket (running your `worktree.setup` commands)
+5. Dispatches `/oneshot` workers into each worktree
+6. Monitors progress and updates a dashboard
+7. Runs adversarial verification when workers claim "done"
+8. Advances to the next wave when all tickets pass
+9. Writes wave briefings so later waves benefit from earlier discoveries
+
+## Invocation
+
+```bash
+/orchestrate ACME-101 ACME-102 ACME-103        # explicit tickets
+/orchestrate --project "Q2 API Redesign"         # from a Linear project
+/orchestrate --cycle current                      # from the current Linear cycle
+/orchestrate --file tickets.txt                   # from a file (one ID per line)
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | Name this orchestrator (default: auto-generated) |
+| `--auto-merge` | Workers auto-merge when CI + verification pass |
+| `--max-parallel <n>` | Override max concurrent workers (default: 3) |
+| `--base-branch <branch>` | Base branch for worktrees (default: main) |
+| `--dry-run` | Show wave plan without executing |
+| `--interactive` | Include PM intake phase before orchestration |
+
+## Wave-Based Parallelism
+
+Tickets are grouped into **waves** based on their dependency graph:
+
+```
+Wave 1 (parallel, 3 workers):
+  ACME-101: Auth middleware rewrite
+  ACME-102: Rate limiting service
+  ACME-103: Email templates
+
+Wave 2 (after Wave 1, 2 workers):
+  ACME-104: OAuth integration         — depends on ACME-101
+  ACME-105: API usage dashboard        — depends on ACME-102
+
+Wave 3 (after Wave 2, 1 worker):
+  ACME-106: Self-service API keys      — depends on ACME-104, ACME-105
+```
+
+- **Wave 1** tickets have no dependencies on other tickets in the set — they run in parallel
+- **Wave 2** tickets depend on Wave 1 — they start only after Wave 1 is verified and merged
+- Circular dependencies are flagged and rejected
+
+The orchestrator presents the wave plan and waits for approval before provisioning.
+
+## Directory Layout
+
+All worktrees for a project land under `~/catalyst/wt/<projectKey>/`:
+
+```
+~/catalyst/wt/acme/
+├── api-redesign/                    # orchestrator (read-only, no code changes)
+│   ├── DASHBOARD.md                 # live status board
+│   ├── state.json                   # machine-readable state for crash recovery
+│   ├── wave-1-briefing.md           # knowledge transfer to Wave 2
+│   └── workers/
+│       ├── ACME-101.json            # worker signal file
+│       ├── ACME-102.json
+│       └── ACME-103.json
+├── api-redesign-ACME-101/           # worker worktree
+├── api-redesign-ACME-102/           # worker worktree
+└── api-redesign-ACME-103/           # worker worktree
+```
+
+The base directory is resolved in this order:
+
+1. `catalyst.orchestration.worktreeDir` from config (explicit override)
+2. `~/catalyst/wt/<projectKey>/` (default — reads `catalyst.projectKey` from config)
+3. `~/catalyst/wt/<repo>/` (fallback if no config)
+
+## What Happens When a Worktree is Created
+
+For every worktree (orchestrator and workers), the `create-worktree.sh` script runs this sequence:
+
+```
+1. git worktree add -b <name> <path> <base-branch>
+2. Copy .claude/ directory (plugins, rules, prompts)
+3. Copy .catalyst/ directory (project config)
+4. Run catalyst.worktree.setup commands (your config)
+   — OR auto-detect: dependency install + humanlayer thoughts init (fallback)
+5. Run catalyst.orchestration.hooks.setup (orchestration-only, if present)
+```
+
+The orchestrator then creates its status directory (`workers/`, `DASHBOARD.md`, `state.json`) and initializes worker signal files.
+
+## Worker Dispatch
+
+Workers are launched via `humanlayer launch` (preferred for context isolation and named sessions) or `claude` CLI (fallback). Each runs `/oneshot <ticket> --auto-merge` autonomously.
+
+The dispatch prompt includes **mandatory testing requirements** — not suggestions. Workers are told their output will be independently verified. The `CATALYST_ORCHESTRATOR_DIR` environment variable is set so workers know where to write their signal files.
+
+## Testing Enforcement (3 Layers)
+
+The orchestrator addresses a specific failure mode: **agents ship PRs with minimal tests and self-report "done."** Three layers prevent this:
+
+### Layer 1 — Dispatch Prompt (Prevention)
+
+Every worker's dispatch prompt includes hard requirements for TDD, unit tests, API tests, security review, and code review. The prompt explicitly states that work will be independently verified.
+
+### Layer 2 — Quality Gates (Automated)
+
+Inside each worker's `/oneshot` pipeline, the existing quality gate system runs: `/validate-type-safety`, `/security-review`, `code-reviewer` agent, `pr-test-analyzer` agent, plus any project-specific gates from config.
+
+### Layer 3 — Independent Verification (Adversarial)
+
+After a worker claims "done", the orchestrator runs `orchestrate-verify.sh` **independently** in the worker's worktree. This script:
+
+- Checks that every changed source file has a corresponding test file
+- Verifies API test coverage for new/modified routes
+- Runs the test suite to confirm tests pass
+- Scans for security anti-patterns (SQL injection, hardcoded secrets, eval, innerHTML)
+- Scans for reward-hacking patterns (`as any`, `@ts-ignore`, empty catch blocks)
+- Cross-checks the worker's self-reported `definitionOfDone` against actual findings
+
+If verification **fails**, the worker gets explicit remediation instructions and must fix the gaps before advancing. The orchestrator re-verifies after fixes.
+
+## Wave Briefing Documents
+
+Before dispatching each wave after Wave 1, the orchestrator writes a **briefing document** summarizing what prior waves learned:
+
+- Patterns and conventions established (e.g., "Auth uses `withAuth()` decorator")
+- New dependencies added
+- Test helpers created (e.g., `createTestToken()`)
+- Gotchas discovered (e.g., "Redis requires `REDIS_URL` env var")
+- File organization conventions from merged PRs
+
+Wave 2+ workers read the briefing before starting. This means:
+
+- Workers follow established patterns instead of inventing conflicting ones
+- Workers reuse test helpers instead of writing duplicates
+- Workers avoid known gotchas instead of hitting them again
+- **Knowledge compounds across waves** instead of being lost
+
+This requires the thoughts system to be initialized in each worktree (via `catalyst.worktree.setup`). Without it, workers can't access shared documents.
+
+## Dashboard
+
+The orchestrator maintains a live dashboard at `DASHBOARD.md` in its worktree directory, updated after each monitoring poll:
+
+```markdown
+# Orchestration Dashboard
+**Orchestrator:** api-redesign
+**Started:** 2026-04-10 14:00 UTC
+**Total:** 6 tickets | 3 waves
+
+## Current Wave: 1 of 3
+
+| Ticket | Status | PR | Unit Tests | API Tests | Security | Verified |
+|--------|--------|-----|-----------|-----------|----------|----------|
+| ACME-101 | Implementing | — | — | — | — | — |
+| ACME-102 | PR Created | #87 | 18 tests | 6 requests | PASS | Pending |
+| ACME-103 | Validating | — | 12 tests | N/A | Pending | — |
+
+## Event Log
+- 14:32 — ACME-102 PR #87 created, CI running
+- 14:15 — ACME-101 research complete, starting plan
+- 14:00 — Wave 1 dispatched (3 workers)
+```
+
+## Worker Signal Files
+
+Workers report status via JSON signal files in `workers/`. The orchestrator writes the initial file; workers update it at each phase transition.
+
+```json
+{
+  "ticket": "ACME-101",
+  "status": "pr-created",
+  "phase": 5,
+  "pr": { "number": 87, "ciStatus": "passing" },
+  "definitionOfDone": {
+    "testsWrittenFirst": true,
+    "unitTests": { "exists": true, "count": 22 },
+    "apiTests": { "exists": true, "count": 8 },
+    "typeCheck": { "passed": true },
+    "securityReview": { "passed": true },
+    "codeReview": { "passed": true }
+  }
+}
+```
+
+The `definitionOfDone` is the accountability layer — workers declare yes/no for each gate, and the orchestrator's verification independently confirms. A worker claiming 22 unit tests when 0 exist gets caught.
+
+## Configuration Reference
+
+### Orchestration Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `worktreeDir` | string\|null | `~/catalyst/wt/<projectKey>` | Base directory for worktrees |
+| `maxParallel` | number | 3 | Max concurrent workers per wave |
+| `hooks.setup` | string[] | `[]` | Extra commands after base `worktree.setup` (orchestration-only) |
+| `hooks.teardown` | string[] | `[]` | Commands before worktree removal on wave advancement |
+| `workerCommand` | string | `/oneshot` | Skill to run in each worker |
+| `workerModel` | string | `opus` | Model for worker sessions |
+| `testRequirements` | object | `{"backend":["unit"]}` | Required test types by scope |
+| `verifyBeforeMerge` | boolean | `true` | Run adversarial verification before merging |
+| `allowSelfReportedCompletion` | boolean | `false` | Trust worker's `definitionOfDone` without verification |
+
+### Hook Variables
+
+All setup and teardown commands support these variables:
+
+| Variable | Source | Value |
+|----------|--------|-------|
+| `${WORKTREE_PATH}` | Computed | Absolute path to the worktree |
+| `${BRANCH_NAME}` | Computed | Git branch name |
+| `${TICKET_ID}` | Computed | Same as branch name (includes orchestrator prefix) |
+| `${REPO_NAME}` | Git | Repository name |
+| `${DIRECTORY}` | Config | `catalyst.thoughts.directory` or repo name |
+| `${PROFILE}` | Config | `catalyst.thoughts.profile` or auto-detected from HumanLayer |
+
+## Linear Integration
+
+The orchestrator manages Linear state as a safety net:
+
+| Event | Linear Action |
+|-------|--------------|
+| Worker dispatched | Move ticket to In Progress |
+| Worker creates PR | Verify ticket is In Review — fix if not |
+| PR merged | Verify ticket is Done — fix if not |
+| Worker fails/stalls | Add comment with status |
+
+Comments are added to tickets for team visibility:
+
+```
+Orchestrator [api-redesign]: Worker dispatched. Starting research phase.
+Orchestrator [api-redesign]: PR #87 created. CI running. Unit: 18, API: 6.
+```
+
+## Named Orchestrators
+
+Multiple orchestrators can run concurrently. Each gets a unique name that prefixes its worktrees:
+
+```bash
+# Two orchestrators for different projects, running simultaneously
+/orchestrate --project "Auth Rewrite" --name auth-orch
+/orchestrate --project "Dashboard V2" --name dash-orch
+
+# Worktrees are namespaced — no collisions
+~/catalyst/wt/acme/
+├── auth-orch/
+├── auth-orch-ACME-101/
+├── dash-orch/
+└── dash-orch-ACME-201/
+```
+
+## Error Handling
+
+**Worker crashes or stalls**: The orchestrator detects no progress for 15+ minutes (no commits, no signal updates). It marks the worker as "stalled" on the dashboard and flags it for human decision — it does not auto-restart.
+
+**Orchestrator crash recovery**: All state lives in `state.json` and worker signal files. Resume with `/orchestrate --resume <orch-dir>` to pick up where it left off.
+
+**Verification failure**: The worker gets specific remediation instructions. The orchestrator re-verifies after fixes. A ticket cannot advance to merge until verification passes.

--- a/website/src/content/docs/reference/workflows.md
+++ b/website/src/content/docs/reference/workflows.md
@@ -174,7 +174,7 @@ Git worktrees let you work on multiple features simultaneously, each in its own 
 /create-worktree PROJ-123 feature-name
 ```
 
-This creates a git worktree at `~/wt/{project}/{PROJ-123-feature-name}/` with a new branch, `.claude/` copied over, dependencies installed, and `thoughts/` shared via symlink.
+This creates a git worktree at `~/catalyst/wt/{projectKey}/{PROJ-123-feature-name}/` with a new branch, `.claude/` and `.catalyst/` copied over, dependencies installed, and `thoughts/` shared via symlink.
 
 ### Parallel Sessions
 
@@ -182,11 +182,11 @@ Run separate Claude Code sessions in different worktrees:
 
 ```bash
 # Terminal 1 — Feature A
-cd ~/wt/api/PROJ-123-feature-a && claude
+cd ~/catalyst/wt/acme/ACME-123-feature-a && claude
 /implement-plan
 
 # Terminal 2 — Feature B
-cd ~/wt/api/PROJ-456-feature-b && claude
+cd ~/catalyst/wt/acme/ACME-456-feature-b && claude
 /implement-plan
 
 # Terminal 3 — Research (main repo)
@@ -200,11 +200,15 @@ All worktrees share the same thoughts directory via symlink. Plans created in on
 
 ```bash
 git worktree list                                          # List all
-git worktree remove ~/wt/my-project/PROJ-123-feature       # Remove after merge
+git worktree remove ~/catalyst/wt/acme/ACME-123-feature    # Remove after merge
 git worktree prune                                         # Clean stale references
 ```
 
-The worktree location defaults to `~/wt/{repo}` but can be customized with `GITHUB_SOURCE_ROOT`.
+The worktree location defaults to `~/catalyst/wt/{projectKey}` (reads `catalyst.projectKey` from config). Override with `catalyst.orchestration.worktreeDir` in config.
+
+### AI-Coordinated Parallel Work
+
+For coordinating multiple tickets with automated dispatch and verification, see [Orchestration](/reference/orchestration/).
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

- Adds `/orchestrate` skill — a wave-based coordinator that takes Linear tickets, creates worktrees, dispatches `/oneshot` workers in parallel, and enforces quality gates via adversarial verification
- Refactors `create-worktree.sh` to support config-driven setup (`catalyst.worktree.setup`) with variable substitution, replacing hardcoded auto-detection
- Adds comprehensive orchestration documentation page at `/reference/orchestration/`

### New files
- `plugins/dev/skills/orchestrate/SKILL.md` — 7-phase orchestrator (intake → completion)
- `plugins/dev/scripts/orchestrate-verify.sh` — adversarial verification (8 checks including reward hacking scan)
- `plugins/dev/templates/` — dashboard, wave briefing, and worker signal templates
- `website/src/content/docs/reference/orchestration.md` — full docs with prerequisites, config reference, setup checklist

### Modified files
- `create-worktree.sh` — `--worktree-dir`/`--hooks-json` flags, config-driven setup, two-tier hooks
- `oneshot/SKILL.md` — orchestrator mode via `CATALYST_ORCHESTRATOR_DIR` env var + signal file writing
- `create-worktree/SKILL.md` — updated for config-driven setup and new worktree paths
- `configuration.md` — worktree setup and orchestration config sections
- `workflows.md` — updated worktree paths, cross-reference to orchestration
- Config template/example — `catalyst.worktree.setup` and `catalyst.orchestration` blocks

## Test plan
- [ ] `/create-worktree TICKET-123` still works with auto-detected setup (no config change)
- [ ] Adding `catalyst.worktree.setup` to config runs only those commands
- [ ] `/orchestrate` intake phase reads tickets from Linear
- [ ] Worker dispatch sets `CATALYST_ORCHESTRATOR_DIR` env var
- [ ] `orchestrate-verify.sh` runs all 8 verification sections
- [ ] Orchestration docs page renders correctly in Starlight
- [ ] Configuration page renders without conflict markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)