### PR TITLE
feat(dev): smart merge blocker diagnosis and review thread resolution

### DIFF
--- a/plugins/dev/references/merge-blocker-diagnosis.md
+++ b/plugins/dev/references/merge-blocker-diagnosis.md
@@ -1,0 +1,369 @@
+# Merge Blocker Diagnosis Workflow
+
+Shared workflow for diagnosing and resolving all merge blockers on a pull request. Referenced by
+`/merge-pr` (Step 6) and `/oneshot` (Phase 5, Step 3).
+
+## Safety Rules
+
+**NEVER bypass branch protection.** These rules are non-negotiable:
+
+- **NEVER** use `--admin` flag on `gh pr merge`
+- **NEVER** use `--force` or any flag that bypasses branch protection rules
+- **NEVER** disable or modify branch protection rules programmatically
+- **NEVER** suggest the user disable branch protection to unblock a merge
+
+The goal is to satisfy branch protection requirements, not circumvent them. If a blocker cannot be
+resolved autonomously, tell the user **exactly** what is needed and what they need to do — not just
+"branch protection is blocking the merge."
+
+## Step 1: Query Full Merge State
+
+Get everything in a single GraphQL call to avoid multiple round-trips:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+MERGE_STATE=$(gh api graphql -f query='
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      mergeStateStatus
+      mergeable
+      reviewDecision
+      isDraft
+      baseRefName
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                nodes {
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                    detailsUrl
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                    targetUrl
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body author { login } path line }
+          }
+        }
+      }
+      reviews(last: 20) {
+        nodes {
+          state
+          author { login }
+          body
+        }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER")
+```
+
+## Step 2: Identify Blockers
+
+Parse the response and build a list of every reason the PR cannot merge:
+
+| `mergeStateStatus` | Meaning                                       | Blocker Type                   |
+| ------------------- | --------------------------------------------- | ------------------------------ |
+| `CLEAN`             | Ready to merge                                | None                           |
+| `BEHIND`            | Branch needs update                           | `branch-behind`                |
+| `DIRTY`             | Merge conflicts                               | `conflicts`                    |
+| `BLOCKED`           | Branch protection rule(s) not satisfied        | Decompose further (see below) |
+| `DRAFT`             | PR is a draft                                 | `draft`                        |
+| `UNSTABLE`          | Required checks not yet complete or failing   | `ci-failing`                   |
+| `HAS_HOOKS`         | Merge hooks pending                           | `hooks-pending`                |
+| `UNKNOWN`           | State not yet computed                        | Wait and re-query              |
+
+When `mergeStateStatus` is `BLOCKED`, decompose into specific blockers by checking each field:
+
+```
+blockers = []
+
+if reviewDecision == "REVIEW_REQUIRED":
+  blockers += "review-required"
+if reviewDecision == "CHANGES_REQUESTED":
+  blockers += "changes-requested"
+if any reviewThread has isResolved == false:
+  blockers += "unresolved-threads"
+if statusCheckRollup.state != "SUCCESS":
+  blockers += "ci-failing"
+if isDraft:
+  blockers += "draft"
+```
+
+If `BLOCKED` and no specific blockers identified from the above fields, query branch protection
+rules directly to surface what's missing:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $name: String!, $branch: String!) {
+  repository(owner: $owner, name: $name) {
+    branchProtectionRules(first: 10) {
+      nodes {
+        pattern
+        requiresApprovingReviews
+        requiredApprovingReviewCount
+        requiresStatusChecks
+        requiredStatusCheckContexts
+        requiresConversationResolution
+        requiresLinearHistory
+        requiresStrictStatusChecks
+        isAdminEnforced
+      }
+    }
+  }
+}' -f owner="$OWNER" -f name="$NAME" -f branch="$base_branch"
+```
+
+Use this to explain exactly which rule is unsatisfied.
+
+## Step 3: Resolve Each Blocker
+
+Loop through the blockers list. For each one, attempt autonomous resolution. **Never bypass — always
+resolve legitimately.**
+
+```
+MAX_RESOLVE_ATTEMPTS=3
+attempt=0
+
+while blockers is not empty AND attempt < MAX_RESOLVE_ATTEMPTS:
+  for each blocker:
+    attempt_resolution(blocker)
+  re-query merge state (step 1)
+  rebuild blockers list (step 2)
+  attempt += 1
+```
+
+### Resolution Strategies
+
+---
+
+#### `branch-behind` — Branch needs to be updated with base branch changes.
+
+*Can fix:* Yes, always attempt.
+
+```bash
+git fetch origin $base_branch
+git rebase origin/$base_branch
+if [ $? -eq 0 ]; then
+  git push --force-with-lease
+else
+  git rebase --abort
+  # Report specific conflicting files to user
+fi
+```
+
+---
+
+#### `conflicts` — Merge conflicts exist.
+
+*Can fix:* Attempt rebase. If conflicts are in generated files (lockfiles, etc.), try auto-resolve.
+Otherwise, report specific files.
+
+```
+I can regenerate lockfiles automatically. For source conflicts, you'll need to:
+  1. Resolve conflicts in the listed files
+  2. git add <resolved-files>
+  3. git rebase --continue
+  4. git push --force-with-lease
+  5. Run /merge-pr again
+```
+
+---
+
+#### `draft` — PR is still in draft mode.
+
+*Can fix:* Yes.
+
+```bash
+gh pr ready $pr_number
+```
+
+---
+
+#### `ci-failing` — One or more required status checks are failing or pending.
+
+*Can fix:* Depends on the failure. Analyze each failing check.
+
+For **pending** checks: wait and re-poll (up to 10 minutes).
+
+```bash
+gh pr checks $pr_number --watch --fail-fast
+```
+
+For **failed** checks: read the failure details and attempt a fix.
+
+```bash
+# Get the failed check's log
+gh run view $run_id --log-failed
+```
+
+Analyze the failure. If it's a linting, type-check, or test error that can be fixed in code:
+
+1. Read the error output
+2. Fix the code
+3. Commit and push
+4. Re-poll checks
+
+If it's an infrastructure failure (timeout, flaky test, service unavailable):
+
+```
+CI check "$check_name" failed — appears to be infrastructure-related, not a code issue.
+
+Failure: $failure_summary
+Log: $details_url
+
+Options:
+  [1] Re-run the failed check: gh run rerun $run_id --failed
+  [2] I'll investigate and re-run /merge-pr when ready
+```
+
+Do NOT suggest force-merging past a failing required check.
+
+---
+
+#### `unresolved-threads` — Unresolved review conversation threads.
+
+*Can fix:* Yes — run `/review-comments` which addresses comments and resolves threads.
+
+```bash
+/review-comments $pr_number
+# review-comments fixes code, posts replies, AND resolves threads via GraphQL
+# (see review-thread-resolution.md for the resolution workflow)
+```
+
+After `/review-comments`, re-query to confirm threads are resolved. If some remain unresolved
+(couldn't be addressed automatically), report them specifically:
+
+```
+$N unresolved thread(s) could not be resolved automatically:
+
+  1. @reviewer on src/api/auth.ts:42:
+     "This changes the public API contract — needs migration guide"
+     -> Requires your decision: write a migration guide or reply explaining why it's not needed
+
+  2. @reviewer on src/db/schema.ts:15:
+     "This migration is irreversible — are we sure?"
+     -> Requires your confirmation to proceed
+```
+
+---
+
+#### `changes-requested` — A reviewer requested changes.
+
+*Can fix:* Partially. Check if the changes have already been addressed.
+
+1. Check if commits were pushed after the review that requested changes
+2. If yes, the reviewer may just need to re-review — tell the user:
+
+```
+@reviewer requested changes on $(date of review).
+$N commit(s) have been pushed since that review.
+
+The changes may already address the feedback. Options:
+  [1] I'll request a re-review from @reviewer
+  [2] I'll check with @reviewer — don't re-request yet
+```
+
+If user says yes to option 1:
+
+```bash
+gh pr edit $pr_number --add-reviewer "$reviewer_login"
+```
+
+3. If no commits since the review, tell the user what was requested:
+
+```
+@reviewer requested changes:
+   "$review_body_summary"
+
+Address the feedback first, then re-run /merge-pr.
+Or run /review-comments to see all outstanding feedback.
+```
+
+---
+
+#### `review-required` — Branch protection requires approving reviews that haven't been given yet.
+
+*Can fix:* No — this requires a human reviewer.
+
+Query the specific requirement:
+
+```
+Branch protection requires $required_count approving review(s).
+Current: $current_approvals approval(s).
+
+Reviewers who can approve:
+  - @reviewer1 (already reviewed — requested changes)
+  - @reviewer2 (not yet reviewed)
+  - Request review: gh pr edit $pr_number --add-reviewer "username"
+```
+
+Do NOT suggest any workaround. This is a human gate.
+
+---
+
+#### `hooks-pending` — Pre-merge hooks are running.
+
+*Can fix:* Wait. Re-query after 30 seconds.
+
+---
+
+#### `unknown-blocker` — `BLOCKED` but none of the above matched.
+
+*Can fix:* No — but provide maximum diagnostic detail.
+
+```
+Branch protection is blocking the merge, but I couldn't identify the specific blocker.
+
+Branch protection rules for "$base_branch":
+  - Requires $N approving review(s): $status
+  - Requires status checks: $check_list
+  - Requires conversation resolution: $status
+  - Requires linear history: $status
+  - Requires strict status checks (branch up-to-date): $status
+  - Admin enforced: $status
+
+Current PR state:
+  mergeStateStatus: $state
+  reviewDecision: $decision
+  CI: $ci_state
+  Unresolved threads: $thread_count
+
+Check the branch protection settings at:
+  https://github.com/$OWNER/$NAME/settings/branches
+```
+
+## Step 4: Report Final State
+
+After the resolution loop, if blockers remain:
+
+```
+Resolved:
+  [list what was fixed and how]
+
+Still blocking:
+  [list each remaining blocker with specific actionable guidance]
+```
+
+If all blockers resolved, the PR is ready to merge.

--- a/plugins/dev/references/review-thread-resolution.md
+++ b/plugins/dev/references/review-thread-resolution.md
@@ -1,0 +1,72 @@
+# Review Thread Resolution Workflow
+
+Shared workflow for resolving GitHub review threads after addressing comments. Referenced by
+`/review-comments` (Step 5) and the `unresolved-threads` blocker strategy in
+`merge-blocker-diagnosis.md`.
+
+## Step 1: Fetch Unresolved Review Threads
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+gh api graphql -f query='
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body author { login } path line }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER"
+```
+
+## Step 2: Resolve Each Addressed Thread
+
+For each unresolved thread that was either fixed or replied to:
+
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}' -f threadId="$THREAD_NODE_ID"
+```
+
+## Resolution Rules
+
+| Outcome | Action |
+|---------|--------|
+| **Code change implemented** | Resolve the thread |
+| **Reply posted** (disagreement or clarification) | Resolve the thread (reply is visible in the resolved thread; reviewer can re-open if they disagree) |
+| **Approval / praise** | Already not blocking — skip |
+| **Could not address** | Do NOT resolve — leave for human review |
+
+## Step 3: Verify
+
+```bash
+UNRESOLVED=$(gh api graphql -f query='
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes { isResolved }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+
+if [ "$UNRESOLVED" -gt 0 ]; then
+  echo "$UNRESOLVED unresolved thread(s) remain — manual review needed"
+fi
+```

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -15,18 +15,10 @@ Safely merges a PR after comprehensive verification, with Linear integration and
 
 ## Branch Protection — Safety Rules
 
-**NEVER bypass branch protection.** These rules are non-negotiable:
-
-- **NEVER** use `--admin` flag on `gh pr merge`
-- **NEVER** use `--force` or any flag that bypasses branch protection rules
-- **NEVER** disable or modify branch protection rules programmatically
-- **NEVER** suggest the user disable branch protection to unblock a merge
-- If `gh pr merge` fails due to branch protection, **diagnose the specific blockers and fix them
-  legitimately** — do not work around the protection
-
-The goal is to satisfy branch protection requirements, not circumvent them. If a blocker cannot be
-resolved autonomously, tell the user **exactly** what is needed and what they need to do — not just
-"branch protection is blocking the merge."
+Read and follow the safety rules in
+`"${CLAUDE_PLUGIN_ROOT}/references/merge-blocker-diagnosis.md"` — specifically the "Safety Rules"
+section. Summary: **NEVER** use `--admin`, `--force`, or any flag that bypasses branch protection.
+Always resolve blockers legitimately or escalate with specifics.
 
 ## Configuration
 
@@ -193,383 +185,32 @@ Exit with error (unless `--skip-tests` flag provided).
 
 ### 6. Diagnose and resolve merge blockers
 
-Instead of checking individual requirements in sequence, query GitHub for the **complete merge
-readiness state** and resolve all blockers in a loop. This prevents the common failure mode of
-`gh pr merge` returning a generic "branch protection" error with no actionable detail.
-
-**Step 6a: Query full merge state**
-
-```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-OWNER=$(echo "$REPO" | cut -d'/' -f1)
-NAME=$(echo "$REPO" | cut -d'/' -f2)
-
-# Single GraphQL query to get everything at once
-MERGE_STATE=$(gh api graphql -f query='
-query($owner: String!, $name: String!, $pr: Int!) {
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $pr) {
-      mergeStateStatus
-      mergeable
-      reviewDecision
-      isDraft
-      baseRefName
-      commits(last: 1) {
-        nodes {
-          commit {
-            statusCheckRollup {
-              state
-              contexts(first: 100) {
-                nodes {
-                  ... on CheckRun {
-                    name
-                    conclusion
-                    status
-                    detailsUrl
-                  }
-                  ... on StatusContext {
-                    context
-                    state
-                    targetUrl
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      reviewThreads(first: 100) {
-        nodes {
-          id
-          isResolved
-          comments(first: 1) {
-            nodes { body author { login } path line }
-          }
-        }
-      }
-      reviews(last: 20) {
-        nodes {
-          state
-          author { login }
-          body
-        }
-      }
-    }
-  }
-}' -f owner="$OWNER" -f name="$NAME" -F pr="$pr_number")
-```
-
-**Step 6b: Identify blockers**
-
-Parse the response and build a list of every reason the PR cannot merge:
-
-| `mergeStateStatus` | Meaning | Blocker Type |
-|---|---|---|
-| `CLEAN` | Ready to merge | None |
-| `BEHIND` | Branch needs update | `branch-behind` |
-| `DIRTY` | Merge conflicts | `conflicts` |
-| `BLOCKED` | Branch protection rule(s) not satisfied | Decompose further (see below) |
-| `DRAFT` | PR is a draft | `draft` |
-| `UNSTABLE` | Required checks not yet complete or failing | `ci-failing` |
-| `HAS_HOOKS` | Merge hooks pending | `hooks-pending` |
-| `UNKNOWN` | State not yet computed | Wait and re-query |
-
-When `mergeStateStatus` is `BLOCKED`, decompose into specific blockers by checking each field:
-
-```
-blockers = []
-
-if reviewDecision == "REVIEW_REQUIRED":
-  blockers += "review-required"
-if reviewDecision == "CHANGES_REQUESTED":
-  blockers += "changes-requested"
-if any reviewThread has isResolved == false:
-  blockers += "unresolved-threads"
-if statusCheckRollup.state != "SUCCESS":
-  blockers += "ci-failing"
-if isDraft:
-  blockers += "draft"
-```
-
-If `BLOCKED` and no specific blockers identified from the above fields, query branch protection
-rules directly to surface what's missing:
-
-```bash
-gh api graphql -f query='
-query($owner: String!, $name: String!, $branch: String!) {
-  repository(owner: $owner, name: $name) {
-    branchProtectionRules(first: 10) {
-      nodes {
-        pattern
-        requiresApprovingReviews
-        requiredApprovingReviewCount
-        requiresStatusChecks
-        requiredStatusCheckContexts
-        requiresConversationResolution
-        requiresLinearHistory
-        requiresStrictStatusChecks
-        isAdminEnforced
-      }
-    }
-  }
-}' -f owner="$OWNER" -f name="$NAME" -f branch="$base_branch"
-```
-
-Use this to explain exactly which rule is unsatisfied.
-
-**Step 6c: Resolve each blocker**
-
-Loop through the blockers list. For each one, attempt autonomous resolution. **Never bypass — always
-resolve legitimately.**
-
-```
-MAX_RESOLVE_ATTEMPTS=3
-attempt=0
-
-while blockers is not empty AND attempt < MAX_RESOLVE_ATTEMPTS:
-  for each blocker:
-    attempt_resolution(blocker)
-  re-query merge state (step 6a)
-  rebuild blockers list (step 6b)
-  attempt += 1
-```
-
-**Blocker resolution strategies:**
-
----
-
-**`branch-behind`** — Branch needs to be updated with base branch changes.
-
-*Can fix:* Yes, always attempt.
-
-```bash
-git fetch origin $base_branch
-git rebase origin/$base_branch
-if [ $? -eq 0 ]; then
-  git push --force-with-lease
-else
-  git rebase --abort
-  # Report specific conflicting files to user
-fi
-```
-
----
-
-**`conflicts`** — Merge conflicts exist.
-
-*Can fix:* Attempt rebase. If conflicts are in generated files (lockfiles, etc.), try auto-resolve.
-Otherwise, report specific files.
-
-```
-❌ Merge conflicts in $N file(s):
-  - src/components/Header.tsx (manual resolution needed)
-  - package-lock.json (can be regenerated)
-
-I can regenerate lockfiles automatically. For source conflicts, you'll need to:
-  1. Resolve conflicts in the listed files
-  2. git add <resolved-files>
-  3. git rebase --continue
-  4. git push --force-with-lease
-  5. Run /merge-pr again
-```
-
----
-
-**`draft`** — PR is still in draft mode.
-
-*Can fix:* Yes.
-
-```bash
-gh pr ready $pr_number
-```
-
----
-
-**`ci-failing`** — One or more required status checks are failing or pending.
-
-*Can fix:* Depends on the failure. Analyze each failing check.
-
-For **pending** checks: wait and re-poll (up to 10 minutes).
-
-```bash
-gh pr checks $pr_number --watch --fail-fast
-```
-
-For **failed** checks: read the failure details and attempt a fix.
-
-```bash
-# Get the failed check's log
-gh run view $run_id --log-failed
-```
-
-Analyze the failure. If it's a linting, type-check, or test error that can be fixed in code:
-1. Read the error output
-2. Fix the code
-3. Commit and push
-4. Re-poll checks
-
-If it's an infrastructure failure (timeout, flaky test, service unavailable):
-
-```
-⚠️  CI check "$check_name" failed — appears to be infrastructure-related, not a code issue.
-
-Failure: $failure_summary
-Log: $details_url
-
-Options:
-  [1] Re-run the failed check: gh run rerun $run_id --failed
-  [2] I'll investigate and re-run /merge-pr when ready
-```
-
-Do NOT suggest force-merging past a failing required check.
-
----
-
-**`unresolved-threads`** — Unresolved review conversation threads.
-
-*Can fix:* Yes — run `/review-comments` which addresses comments and resolves threads.
-
-```bash
-/review-comments $pr_number
-# review-comments now fixes code, posts replies, AND resolves threads via GraphQL
-```
-
-After `/review-comments`, re-query to confirm threads are resolved. If some remain unresolved
-(couldn't be addressed automatically), report them specifically:
-
-```
-⚠️  $N unresolved thread(s) could not be resolved automatically:
-
-  1. @reviewer on src/api/auth.ts:42:
-     "This changes the public API contract — needs migration guide"
-     → Requires your decision: write a migration guide or reply explaining why it's not needed
-
-  2. @reviewer on src/db/schema.ts:15:
-     "This migration is irreversible — are we sure?"
-     → Requires your confirmation to proceed
-```
-
----
-
-**`changes-requested`** — A reviewer requested changes.
-
-*Can fix:* Partially. Check if the changes have already been addressed.
-
-1. Check if commits were pushed after the review that requested changes
-2. If yes, the reviewer may just need to re-review — tell the user:
-
-```
-⚠️  @reviewer requested changes on $(date of review).
-    $N commit(s) have been pushed since that review.
-
-The changes may already address the feedback. Options:
-  [1] I'll request a re-review from @reviewer
-  [2] I'll check with @reviewer — don't re-request yet
-```
-
-If user says yes to option 1:
-
-```bash
-gh pr edit $pr_number --add-reviewer "$reviewer_login"
-```
-
-3. If no commits since the review, tell the user what was requested:
-
-```
-❌ @reviewer requested changes:
-   "$review_body_summary"
-
-Address the feedback first, then re-run /merge-pr.
-Or run /review-comments to see all outstanding feedback.
-```
-
----
-
-**`review-required`** — Branch protection requires approving reviews that haven't been given yet.
-
-*Can fix:* No — this requires a human reviewer.
-
-Query the specific requirement:
-
-```
-❌ Branch protection requires $required_count approving review(s).
-   Current: $current_approvals approval(s).
-
-Reviewers who can approve:
-  - @reviewer1 (already reviewed — requested changes)
-  - @reviewer2 (not yet reviewed)
-  - Request review: gh pr edit $pr_number --add-reviewer "username"
-```
-
-Do NOT suggest any workaround. This is a human gate.
-
----
-
-**`hooks-pending`** — Pre-merge hooks are running.
-
-*Can fix:* Wait.
-
-```
-Merge hooks are running. Waiting...
-```
-
-Re-query after 30 seconds.
-
----
-
-**`unknown-blocker`** — `BLOCKED` but none of the above matched.
-
-*Can fix:* No — but provide maximum diagnostic detail.
-
-```
-❌ Branch protection is blocking the merge, but I couldn't identify the specific blocker.
-
-Branch protection rules for "$base_branch":
-  - Requires $N approving review(s): $status
-  - Requires status checks: $check_list
-  - Requires conversation resolution: $status
-  - Requires linear history: $status
-  - Requires strict status checks (branch up-to-date): $status
-  - Admin enforced: $status
-
-Current PR state:
-  mergeStateStatus: $state
-  reviewDecision: $decision
-  CI: $ci_state
-  Unresolved threads: $thread_count
-
-Check the branch protection settings at:
-  https://github.com/$OWNER/$NAME/settings/branches
-```
-
----
-
-**Step 6d: Final state after resolution attempts**
-
-After the resolution loop, if blockers remain:
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-⚠️  Cannot merge — $N blocker(s) remain
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Resolved:
-  ✅ CI checks — fixed lint errors, pushed commit abc1234
-  ✅ Unresolved threads — 3 comments addressed and resolved
-  ✅ Branch behind — rebased on main
-
-Still blocking:
-  ❌ Review required — needs 1 more approval
-     → Request: gh pr edit $pr_number --add-reviewer "username"
-
-  ❌ Changes requested by @reviewer2
-     → 2 commits pushed since review; re-request review or address feedback
-
-Run /merge-pr again after resolving these.
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```
-
-If all blockers resolved, continue to next step.
+Read and follow the full workflow in
+`"${CLAUDE_PLUGIN_ROOT}/references/merge-blocker-diagnosis.md"`.
+
+This step queries GitHub's `mergeStateStatus` via GraphQL, identifies every specific blocker, and
+attempts to fix each one in a loop (max 3 attempts). The reference doc contains:
+
+- The GraphQL query (merge state + CI checks + review threads + reviews in one call)
+- Blocker type table (`CLEAN`, `BEHIND`, `DIRTY`, `BLOCKED`, `DRAFT`, `UNSTABLE`, `HAS_HOOKS`,
+  `UNKNOWN`)
+- How to decompose `BLOCKED` into specific causes
+- Resolution strategy for each blocker type:
+
+| Blocker | Auto-resolution |
+|---------|----------------|
+| `branch-behind` | Rebase and push |
+| `conflicts` | Attempt rebase; report specific files if can't resolve |
+| `draft` | `gh pr ready` |
+| `ci-failing` | Analyze failure logs, fix code, push, re-poll |
+| `unresolved-threads` | Run `/review-comments` (see `review-thread-resolution.md`) |
+| `changes-requested` | Check if addressed; suggest re-request review |
+| `review-required` | Cannot fix — report how many approvals needed and who to request |
+| `hooks-pending` | Wait and re-query |
+| `unknown-blocker` | Query branch protection rules, report every requirement with status |
+
+After the resolution loop, report what was resolved and what still blocks with specific actionable
+guidance. If all blockers resolved, continue to next step.
 
 ### 7. Extract ticket reference
 

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -206,7 +206,55 @@ Continue merge anyway? [y/N]:
 
 If user says no: exit. If user says yes: continue (user override).
 
-### 7. Check approval status
+### 7. Check for unresolved review threads
+
+Branch protection requires all review conversations to be resolved before merging. Check for
+unresolved threads:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+UNRESOLVED=$(gh api graphql -f query='
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body author { login } }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f name="$NAME" -F pr="$pr_number" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+```
+
+**If unresolved threads exist:**
+
+```
+❌ $UNRESOLVED unresolved review thread(s) on PR #$pr_number
+
+Unresolved comments:
+  - @reviewer on file.ts:42: "This should use..."
+  - @reviewer on file.ts:89: "Missing error..."
+
+Address these first:
+  /review-comments $pr_number
+
+Or resolve them manually on GitHub before merging.
+```
+
+Exit with error. Do NOT prompt for override — branch protection will reject the merge anyway.
+
+**If no unresolved threads:** continue.
+
+### 8. Check approval status
 
 ```bash
 review_decision=$(gh pr view $pr_number --json reviewDecision -q .reviewDecision)
@@ -233,7 +281,7 @@ If user says no: exit. If user says yes: continue (user override).
 
 **Skip these prompts if** `requireApproval: false` in config.
 
-### 8. Extract ticket reference
+### 9. Extract ticket reference
 
 ```bash
 branch=$(gh pr view $pr_number --json headRefName -q .headRefName)
@@ -250,7 +298,7 @@ if [[ -z "$ticket" ]] && [[ "$title" =~ ($TEAM_KEY-[0-9]+) ]]; then
 fi
 ```
 
-### 9. Show merge summary
+### 10. Show merge summary
 
 ```
 About to merge:
@@ -261,10 +309,11 @@ About to merge:
  Commits: $commit_count
  Files:   $file_count changed
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Reviews: $review_status
- CI:      $ci_status
- Tests:   ✅ Passed locally
- Ticket:  $ticket (will move to Done)
+ Reviews:  $review_status
+ Threads:  ✅ All resolved
+ CI:       $ci_status
+ Tests:    ✅ Passed locally
+ Ticket:   $ticket (will move to Done)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Merge strategy: Squash and merge
@@ -272,7 +321,7 @@ Merge strategy: Squash and merge
 Proceed? [Y/n]:
 ```
 
-### 10. Execute squash merge
+### 11. Execute squash merge
 
 ```bash
 gh pr merge $pr_number --squash --delete-branch
@@ -289,7 +338,7 @@ gh pr merge $pr_number --squash --delete-branch
 merge_sha=$(git rev-parse HEAD)
 ```
 
-### 11. Update Linear ticket
+### 12. Update Linear ticket
 
 If ticket found and not using `--no-update`:
 
@@ -311,7 +360,7 @@ else
 fi
 ```
 
-### 12. Delete local branch and update base
+### 13. Delete local branch and update base
 
 ```bash
 # Switch to base branch
@@ -329,7 +378,7 @@ echo "✅ Deleted local branch: $head_branch"
 
 **Always delete local branch** - no prompt (remote already deleted).
 
-### 12a. Update primary worktree
+### 13a. Update primary worktree
 
 If running in a git worktree, the primary checkout of main may be stale. Update it:
 
@@ -347,7 +396,7 @@ else
 fi
 ```
 
-### 13. Extract post-merge tasks
+### 14. Extract post-merge tasks
 
 **Read PR description:**
 
@@ -386,7 +435,7 @@ EOF
 humanlayer thoughts sync
 ```
 
-### 14. Detect Deployments and Report Success
+### 15. Detect Deployments and Report Success
 
 After branch cleanup, check if the merge triggered any deployment workflows:
 

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -13,6 +13,21 @@ version: 1.0.0
 
 Safely merges a PR after comprehensive verification, with Linear integration and automated cleanup.
 
+## Branch Protection — Safety Rules
+
+**NEVER bypass branch protection.** These rules are non-negotiable:
+
+- **NEVER** use `--admin` flag on `gh pr merge`
+- **NEVER** use `--force` or any flag that bypasses branch protection rules
+- **NEVER** disable or modify branch protection rules programmatically
+- **NEVER** suggest the user disable branch protection to unblock a merge
+- If `gh pr merge` fails due to branch protection, **diagnose the specific blockers and fix them
+  legitimately** — do not work around the protection
+
+The goal is to satisfy branch protection requirements, not circumvent them. If a blocker cannot be
+resolved autonomously, tell the user **exactly** what is needed and what they need to do — not just
+"branch protection is blocking the merge."
+
 ## Configuration
 
 Read team configuration from `.catalyst/config.json`:
@@ -176,112 +191,387 @@ Or skip tests (not recommended):
 
 Exit with error (unless `--skip-tests` flag provided).
 
-### 6. Check CI/CD status
+### 6. Diagnose and resolve merge blockers
 
-```bash
-gh pr checks $pr_number
-```
+Instead of checking individual requirements in sequence, query GitHub for the **complete merge
+readiness state** and resolve all blockers in a loop. This prevents the common failure mode of
+`gh pr merge` returning a generic "branch protection" error with no actionable detail.
 
-**Parse output for failures:**
-
-- If all checks pass: continue
-- If required checks fail: prompt user
-- If optional checks fail: warn but allow
-
-**If required checks failing:**
-
-```
-⚠️  Some required CI checks are failing
-
-Failed checks:
-  - build (required)
-  - lint (required)
-
-Passed checks:
-  - test ✅
-  - security ✅
-
-Continue merge anyway? [y/N]:
-```
-
-If user says no: exit. If user says yes: continue (user override).
-
-### 7. Check for unresolved review threads
-
-Branch protection requires all review conversations to be resolved before merging. Check for
-unresolved threads:
+**Step 6a: Query full merge state**
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 OWNER=$(echo "$REPO" | cut -d'/' -f1)
 NAME=$(echo "$REPO" | cut -d'/' -f2)
 
-UNRESOLVED=$(gh api graphql -f query='
+# Single GraphQL query to get everything at once
+MERGE_STATE=$(gh api graphql -f query='
 query($owner: String!, $name: String!, $pr: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $pr) {
+      mergeStateStatus
+      mergeable
+      reviewDecision
+      isDraft
+      baseRefName
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                nodes {
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                    detailsUrl
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                    targetUrl
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
       reviewThreads(first: 100) {
         nodes {
           id
           isResolved
           comments(first: 1) {
-            nodes { body author { login } }
+            nodes { body author { login } path line }
           }
+        }
+      }
+      reviews(last: 20) {
+        nodes {
+          state
+          author { login }
+          body
         }
       }
     }
   }
-}' -f owner="$OWNER" -f name="$NAME" -F pr="$pr_number" \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+}' -f owner="$OWNER" -f name="$NAME" -F pr="$pr_number")
 ```
 
-**If unresolved threads exist:**
+**Step 6b: Identify blockers**
+
+Parse the response and build a list of every reason the PR cannot merge:
+
+| `mergeStateStatus` | Meaning | Blocker Type |
+|---|---|---|
+| `CLEAN` | Ready to merge | None |
+| `BEHIND` | Branch needs update | `branch-behind` |
+| `DIRTY` | Merge conflicts | `conflicts` |
+| `BLOCKED` | Branch protection rule(s) not satisfied | Decompose further (see below) |
+| `DRAFT` | PR is a draft | `draft` |
+| `UNSTABLE` | Required checks not yet complete or failing | `ci-failing` |
+| `HAS_HOOKS` | Merge hooks pending | `hooks-pending` |
+| `UNKNOWN` | State not yet computed | Wait and re-query |
+
+When `mergeStateStatus` is `BLOCKED`, decompose into specific blockers by checking each field:
 
 ```
-❌ $UNRESOLVED unresolved review thread(s) on PR #$pr_number
+blockers = []
 
-Unresolved comments:
-  - @reviewer on file.ts:42: "This should use..."
-  - @reviewer on file.ts:89: "Missing error..."
-
-Address these first:
-  /review-comments $pr_number
-
-Or resolve them manually on GitHub before merging.
+if reviewDecision == "REVIEW_REQUIRED":
+  blockers += "review-required"
+if reviewDecision == "CHANGES_REQUESTED":
+  blockers += "changes-requested"
+if any reviewThread has isResolved == false:
+  blockers += "unresolved-threads"
+if statusCheckRollup.state != "SUCCESS":
+  blockers += "ci-failing"
+if isDraft:
+  blockers += "draft"
 ```
 
-Exit with error. Do NOT prompt for override — branch protection will reject the merge anyway.
-
-**If no unresolved threads:** continue.
-
-### 8. Check approval status
+If `BLOCKED` and no specific blockers identified from the above fields, query branch protection
+rules directly to surface what's missing:
 
 ```bash
-review_decision=$(gh pr view $pr_number --json reviewDecision -q .reviewDecision)
+gh api graphql -f query='
+query($owner: String!, $name: String!, $branch: String!) {
+  repository(owner: $owner, name: $name) {
+    branchProtectionRules(first: 10) {
+      nodes {
+        pattern
+        requiresApprovingReviews
+        requiredApprovingReviewCount
+        requiresStatusChecks
+        requiredStatusCheckContexts
+        requiresConversationResolution
+        requiresLinearHistory
+        requiresStrictStatusChecks
+        isAdminEnforced
+      }
+    }
+  }
+}' -f owner="$OWNER" -f name="$NAME" -f branch="$base_branch"
 ```
 
-**Review decisions:**
+Use this to explain exactly which rule is unsatisfied.
 
-- `APPROVED` - proceed
-- `CHANGES_REQUESTED` - prompt user
-- `REVIEW_REQUIRED` - prompt user
-- `null` / empty - no reviews, prompt user
+**Step 6c: Resolve each blocker**
 
-**If not approved:**
+Loop through the blockers list. For each one, attempt autonomous resolution. **Never bypass — always
+resolve legitimately.**
 
 ```
-⚠️  PR has not been approved
+MAX_RESOLVE_ATTEMPTS=3
+attempt=0
 
-Review status: $review_decision
-
-Continue merge anyway? [y/N]:
+while blockers is not empty AND attempt < MAX_RESOLVE_ATTEMPTS:
+  for each blocker:
+    attempt_resolution(blocker)
+  re-query merge state (step 6a)
+  rebuild blockers list (step 6b)
+  attempt += 1
 ```
 
-If user says no: exit. If user says yes: continue (user override).
+**Blocker resolution strategies:**
 
-**Skip these prompts if** `requireApproval: false` in config.
+---
 
-### 9. Extract ticket reference
+**`branch-behind`** — Branch needs to be updated with base branch changes.
+
+*Can fix:* Yes, always attempt.
+
+```bash
+git fetch origin $base_branch
+git rebase origin/$base_branch
+if [ $? -eq 0 ]; then
+  git push --force-with-lease
+else
+  git rebase --abort
+  # Report specific conflicting files to user
+fi
+```
+
+---
+
+**`conflicts`** — Merge conflicts exist.
+
+*Can fix:* Attempt rebase. If conflicts are in generated files (lockfiles, etc.), try auto-resolve.
+Otherwise, report specific files.
+
+```
+❌ Merge conflicts in $N file(s):
+  - src/components/Header.tsx (manual resolution needed)
+  - package-lock.json (can be regenerated)
+
+I can regenerate lockfiles automatically. For source conflicts, you'll need to:
+  1. Resolve conflicts in the listed files
+  2. git add <resolved-files>
+  3. git rebase --continue
+  4. git push --force-with-lease
+  5. Run /merge-pr again
+```
+
+---
+
+**`draft`** — PR is still in draft mode.
+
+*Can fix:* Yes.
+
+```bash
+gh pr ready $pr_number
+```
+
+---
+
+**`ci-failing`** — One or more required status checks are failing or pending.
+
+*Can fix:* Depends on the failure. Analyze each failing check.
+
+For **pending** checks: wait and re-poll (up to 10 minutes).
+
+```bash
+gh pr checks $pr_number --watch --fail-fast
+```
+
+For **failed** checks: read the failure details and attempt a fix.
+
+```bash
+# Get the failed check's log
+gh run view $run_id --log-failed
+```
+
+Analyze the failure. If it's a linting, type-check, or test error that can be fixed in code:
+1. Read the error output
+2. Fix the code
+3. Commit and push
+4. Re-poll checks
+
+If it's an infrastructure failure (timeout, flaky test, service unavailable):
+
+```
+⚠️  CI check "$check_name" failed — appears to be infrastructure-related, not a code issue.
+
+Failure: $failure_summary
+Log: $details_url
+
+Options:
+  [1] Re-run the failed check: gh run rerun $run_id --failed
+  [2] I'll investigate and re-run /merge-pr when ready
+```
+
+Do NOT suggest force-merging past a failing required check.
+
+---
+
+**`unresolved-threads`** — Unresolved review conversation threads.
+
+*Can fix:* Yes — run `/review-comments` which addresses comments and resolves threads.
+
+```bash
+/review-comments $pr_number
+# review-comments now fixes code, posts replies, AND resolves threads via GraphQL
+```
+
+After `/review-comments`, re-query to confirm threads are resolved. If some remain unresolved
+(couldn't be addressed automatically), report them specifically:
+
+```
+⚠️  $N unresolved thread(s) could not be resolved automatically:
+
+  1. @reviewer on src/api/auth.ts:42:
+     "This changes the public API contract — needs migration guide"
+     → Requires your decision: write a migration guide or reply explaining why it's not needed
+
+  2. @reviewer on src/db/schema.ts:15:
+     "This migration is irreversible — are we sure?"
+     → Requires your confirmation to proceed
+```
+
+---
+
+**`changes-requested`** — A reviewer requested changes.
+
+*Can fix:* Partially. Check if the changes have already been addressed.
+
+1. Check if commits were pushed after the review that requested changes
+2. If yes, the reviewer may just need to re-review — tell the user:
+
+```
+⚠️  @reviewer requested changes on $(date of review).
+    $N commit(s) have been pushed since that review.
+
+The changes may already address the feedback. Options:
+  [1] I'll request a re-review from @reviewer
+  [2] I'll check with @reviewer — don't re-request yet
+```
+
+If user says yes to option 1:
+
+```bash
+gh pr edit $pr_number --add-reviewer "$reviewer_login"
+```
+
+3. If no commits since the review, tell the user what was requested:
+
+```
+❌ @reviewer requested changes:
+   "$review_body_summary"
+
+Address the feedback first, then re-run /merge-pr.
+Or run /review-comments to see all outstanding feedback.
+```
+
+---
+
+**`review-required`** — Branch protection requires approving reviews that haven't been given yet.
+
+*Can fix:* No — this requires a human reviewer.
+
+Query the specific requirement:
+
+```
+❌ Branch protection requires $required_count approving review(s).
+   Current: $current_approvals approval(s).
+
+Reviewers who can approve:
+  - @reviewer1 (already reviewed — requested changes)
+  - @reviewer2 (not yet reviewed)
+  - Request review: gh pr edit $pr_number --add-reviewer "username"
+```
+
+Do NOT suggest any workaround. This is a human gate.
+
+---
+
+**`hooks-pending`** — Pre-merge hooks are running.
+
+*Can fix:* Wait.
+
+```
+Merge hooks are running. Waiting...
+```
+
+Re-query after 30 seconds.
+
+---
+
+**`unknown-blocker`** — `BLOCKED` but none of the above matched.
+
+*Can fix:* No — but provide maximum diagnostic detail.
+
+```
+❌ Branch protection is blocking the merge, but I couldn't identify the specific blocker.
+
+Branch protection rules for "$base_branch":
+  - Requires $N approving review(s): $status
+  - Requires status checks: $check_list
+  - Requires conversation resolution: $status
+  - Requires linear history: $status
+  - Requires strict status checks (branch up-to-date): $status
+  - Admin enforced: $status
+
+Current PR state:
+  mergeStateStatus: $state
+  reviewDecision: $decision
+  CI: $ci_state
+  Unresolved threads: $thread_count
+
+Check the branch protection settings at:
+  https://github.com/$OWNER/$NAME/settings/branches
+```
+
+---
+
+**Step 6d: Final state after resolution attempts**
+
+After the resolution loop, if blockers remain:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⚠️  Cannot merge — $N blocker(s) remain
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Resolved:
+  ✅ CI checks — fixed lint errors, pushed commit abc1234
+  ✅ Unresolved threads — 3 comments addressed and resolved
+  ✅ Branch behind — rebased on main
+
+Still blocking:
+  ❌ Review required — needs 1 more approval
+     → Request: gh pr edit $pr_number --add-reviewer "username"
+
+  ❌ Changes requested by @reviewer2
+     → 2 commits pushed since review; re-request review or address feedback
+
+Run /merge-pr again after resolving these.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If all blockers resolved, continue to next step.
+
+### 7. Extract ticket reference
 
 ```bash
 branch=$(gh pr view $pr_number --json headRefName -q .headRefName)
@@ -298,19 +588,19 @@ if [[ -z "$ticket" ]] && [[ "$title" =~ ($TEAM_KEY-[0-9]+) ]]; then
 fi
 ```
 
-### 10. Show merge summary
+### 8. Show merge summary
 
 ```
 About to merge:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- PR:      #$pr_number - $title
- From:    $head_branch
- To:      $base_branch
- Commits: $commit_count
- Files:   $file_count changed
+ PR:       #$pr_number - $title
+ From:     $head_branch
+ To:       $base_branch
+ Commits:  $commit_count
+ Files:    $file_count changed
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Merge:    $mergeStateStatus (CLEAN)
  Reviews:  $review_status
- Threads:  ✅ All resolved
  CI:       $ci_status
  Tests:    ✅ Passed locally
  Ticket:   $ticket (will move to Done)
@@ -321,7 +611,7 @@ Merge strategy: Squash and merge
 Proceed? [Y/n]:
 ```
 
-### 11. Execute squash merge
+### 9. Execute squash merge
 
 ```bash
 gh pr merge $pr_number --squash --delete-branch
@@ -338,7 +628,7 @@ gh pr merge $pr_number --squash --delete-branch
 merge_sha=$(git rev-parse HEAD)
 ```
 
-### 12. Update Linear ticket
+### 10. Update Linear ticket
 
 If ticket found and not using `--no-update`:
 
@@ -360,7 +650,7 @@ else
 fi
 ```
 
-### 13. Delete local branch and update base
+### 11. Delete local branch and update base
 
 ```bash
 # Switch to base branch
@@ -378,7 +668,7 @@ echo "✅ Deleted local branch: $head_branch"
 
 **Always delete local branch** - no prompt (remote already deleted).
 
-### 13a. Update primary worktree
+### 11a. Update primary worktree
 
 If running in a git worktree, the primary checkout of main may be stale. Update it:
 
@@ -396,7 +686,7 @@ else
 fi
 ```
 
-### 14. Extract post-merge tasks
+### 12. Extract post-merge tasks
 
 **Read PR description:**
 
@@ -435,7 +725,7 @@ EOF
 humanlayer thoughts sync
 ```
 
-### 15. Detect Deployments and Report Success
+### 13. Detect Deployments and Report Success
 
 After branch cleanup, check if the merge triggered any deployment workflows:
 
@@ -514,6 +804,8 @@ Post-merge tasks: $task_count saved to thoughts/
 ## Error Handling
 
 For all errors, provide clear messages with the specific error, what went wrong, and how to fix it.
+**Never give up with a generic message** — always diagnose the specific cause and provide actionable
+next steps.
 
 **Fail fast (stop execution):**
 
@@ -522,10 +814,26 @@ For all errors, provide clear messages with the specific error, what went wrong,
 - Test failures → show failed tests, suggest fix or `--skip-tests`
 - PR not open/mergeable → show current state
 
-**Prompt for override:**
+**Diagnose and attempt to fix (step 6 blocker loop):**
 
-- CI checks failing → show failures, ask `Continue anyway? [y/N]`
-- Missing approvals → show review status, ask `Continue anyway? [y/N]`
+- CI checks failing → analyze failure, attempt code fix, re-push, re-poll
+- Unresolved threads → run `/review-comments`, resolve threads
+- Branch behind → rebase and push
+- Draft PR → mark as ready
+- Changes requested → check if addressed, suggest re-request review
+- Infrastructure failures → suggest re-run, provide log URL
+
+**Escalate with specifics (never generic):**
+
+- Review required → tell user exactly how many approvals needed and who to request
+- Unresolvable conflicts → list specific files and what conflicts exist
+- Unknown blockers → query branch protection rules and list every requirement with its status
+
+**Never suggest:**
+
+- Force merge, admin override, or disabling branch protection
+- Skipping required checks or reviews
+- Any workaround that bypasses the protection rather than satisfying it
 
 **Warn but continue (graceful degradation):**
 
@@ -576,6 +884,13 @@ keys.
 
 ## Safety Features
 
+**Never bypass branch protection:**
+
+- No `--admin`, `--force`, or any flag that circumvents protection rules
+- No disabling or modifying branch protection rules
+- No suggesting the user disable protections
+- Always satisfy requirements legitimately or escalate with specifics
+
 **Fail fast on:**
 
 - Merge conflicts (can't auto-resolve)
@@ -583,11 +898,18 @@ keys.
 - Rebase conflicts
 - PR not in mergeable state
 
-**Prompt for confirmation on:**
+**Diagnose and fix automatically:**
 
-- Missing required approvals
-- Failing CI checks
-- Any exceptional circumstance
+- CI failures → analyze errors, fix code, push, re-poll
+- Unresolved review threads → run `/review-comments`, resolve via GraphQL
+- Branch behind → rebase and push
+- Draft PR → mark as ready with `gh pr ready`
+
+**Escalate with actionable specifics:**
+
+- Review required → who to request, how many needed
+- Changes requested → what was asked, whether commits address it
+- Unknown blockers → full branch protection rule breakdown
 
 **Always automated:**
 
@@ -605,12 +927,12 @@ keys.
 
 ## Remember:
 
+- **Never bypass branch protection** — diagnose and resolve blockers legitimately
 - **Always squash merge** — clean history
 - **Always delete branches** — no orphan branches
 - **Always run tests** — unless explicitly skipped
 - **Auto-rebase** — keep up-to-date with base
-- **Fail fast** — stop on conflicts or test failures
+- **Diagnose, don't give up** — identify specific blockers and fix or explain them
 - **Update Linear** — move ticket to Done automatically (if Linearis available)
-- **Only prompt for exceptions** — approvals missing, CI failing
 - **Graceful degradation** — work without Linearis if needed
 - For Linearis CLI syntax, see the `linearis` skill reference

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -341,84 +341,21 @@ fi
 **Step 3: Resolve All Merge Blockers**
 
 After the automated reviewer wait, proactively resolve any merge blockers before attempting merge.
-This mirrors the blocker diagnosis loop in `/merge-pr` but runs earlier — while the PR is still
-fresh and before the user is waiting on a merge.
+This runs the same workflow as `/merge-pr` Step 6 but earlier — while the PR is still fresh.
 
-Query the full merge state via GraphQL (same query as `/merge-pr` step 6a):
+Read and follow `"${CLAUDE_PLUGIN_ROOT}/references/merge-blocker-diagnosis.md"`. This queries
+`mergeStateStatus` via GraphQL, identifies every specific blocker, and attempts to fix each one in
+a loop (max 3 rounds). Key blocker resolutions:
 
-```bash
-# Query mergeStateStatus, reviewDecision, CI checks, review threads in one call
-MERGE_STATE=$(gh api graphql -f query='
-query($owner: String!, $name: String!, $pr: Int!) {
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $pr) {
-      mergeStateStatus
-      mergeable
-      reviewDecision
-      isDraft
-      commits(last: 1) {
-        nodes {
-          commit {
-            statusCheckRollup {
-              state
-              contexts(first: 100) {
-                nodes {
-                  ... on CheckRun { name conclusion status detailsUrl }
-                  ... on StatusContext { context state targetUrl }
-                }
-              }
-            }
-          }
-        }
-      }
-      reviewThreads(first: 100) {
-        nodes {
-          id
-          isResolved
-          comments(first: 1) {
-            nodes { body author { login } path line }
-          }
-        }
-      }
-    }
-  }
-}' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER")
-```
+- `ci-failing` → analyze failure logs, fix code, push, re-poll
+- `unresolved-threads` → run `/review-comments` (see `review-thread-resolution.md`)
+- `branch-behind` → rebase and push
+- `draft` → `gh pr ready`
+- `changes-requested` → check if addressed; suggest re-request review
+- `review-required` → cannot fix — report how many approvals needed
 
-Identify blockers and resolve each one in a loop (max 3 rounds):
-
-| Blocker | Auto-resolution |
-|---------|----------------|
-| `ci-failing` | Analyze failure logs, fix code, push, re-poll |
-| `unresolved-threads` | Run `/review-comments` (fixes, replies, and resolves threads) |
-| `branch-behind` | Rebase and push |
-| `draft` | `gh pr ready` |
-| `changes-requested` | Check if addressed; suggest re-request review |
-| `review-required` | Cannot fix — report how many approvals needed and who to request |
-
-**After each round:** re-query merge state, rebuild blocker list, continue if blockers remain.
-
-**If blockers remain after 3 rounds:**
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-⚠️  Cannot auto-resolve $N blocker(s)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Resolved:
-  ✅ CI — fixed lint errors (commit abc1234)
-  ✅ Threads — 3 comments addressed and resolved
-
-Still blocking:
-  ❌ Review required — needs 1 approval
-     → gh pr edit $PR_NUMBER --add-reviewer "username"
-
-Options:
-  [1] Wait for resolution and auto-merge
-  [2] Create handoff and stop
-```
-
-**Never** use `--admin`, force merge, or bypass branch protection. See `/merge-pr` safety rules.
+If blockers remain after 3 rounds, present what was resolved and what still blocks with options
+to wait or create a handoff.
 
 **Step 4: Present options**
 
@@ -456,10 +393,9 @@ Otherwise, user merges manually later with `/merge-pr`.
 
 **What happens:**
 
-- Runs `/merge-pr` which runs the full blocker diagnosis loop (step 6) — checks mergeStateStatus,
-  resolves any remaining blockers (CI, threads, branch behind, etc.), and only merges when all
-  branch protection requirements are satisfied
-- **Never** uses `--admin`, force merge, or bypasses branch protection
+- Runs `/merge-pr` which runs the blocker diagnosis loop (see `merge-blocker-diagnosis.md`) —
+  resolves any remaining blockers and only merges when all branch protection requirements are
+  satisfied
 - If blockers cannot be resolved, reports exactly what's needed and stops
 - Moves Linear ticket to `stateMap.done` (default: "Done")
 

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -338,121 +338,106 @@ if [ "$COMMENT_COUNT" -eq 0 ] && [ "$REVIEW_COUNT" -eq 0 ]; then
 fi
 ```
 
-**Step 3: Address and Resolve Review Comments**
+**Step 3: Resolve All Merge Blockers**
 
-Check for unresolved review threads and address them. This step loops until all threads are resolved
-or no new comments arrive after a fix push.
+After the automated reviewer wait, proactively resolve any merge blockers before attempting merge.
+This mirrors the blocker diagnosis loop in `/merge-pr` but runs earlier — while the PR is still
+fresh and before the user is waiting on a merge.
+
+Query the full merge state via GraphQL (same query as `/merge-pr` step 6a):
 
 ```bash
-MAX_COMMENT_ROUNDS=3
-ROUND=0
-
-while [ $ROUND -lt $MAX_COMMENT_ROUNDS ]; do
-  # Check for unresolved threads
-  UNRESOLVED=$(gh api graphql -f query='
-  query($owner: String!, $name: String!, $pr: Int!) {
-    repository(owner: $owner, name: $name) {
-      pullRequest(number: $pr) {
-        reviewThreads(first: 100) {
-          nodes { id isResolved comments(first: 1) { nodes { body author { login } } } }
+# Query mergeStateStatus, reviewDecision, CI checks, review threads in one call
+MERGE_STATE=$(gh api graphql -f query='
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      mergeStateStatus
+      mergeable
+      reviewDecision
+      isDraft
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                nodes {
+                  ... on CheckRun { name conclusion status detailsUrl }
+                  ... on StatusContext { context state targetUrl }
+                }
+              }
+            }
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body author { login } path line }
+          }
         }
       }
     }
-  }' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER" \
-    --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
-
-  if [ "$UNRESOLVED" -eq 0 ]; then
-    echo "All review threads resolved"
-    break
-  fi
-
-  echo "$UNRESOLVED unresolved thread(s) — running /review-comments"
-
-  # /review-comments now handles: fetch, categorize, fix/reply, commit, push, AND resolve threads
-  /review-comments $PR_NUMBER
-
-  ROUND=$((ROUND + 1))
-
-  # Brief pause for any new automated comments triggered by the fix push
-  if [ $ROUND -lt $MAX_COMMENT_ROUNDS ]; then
-    sleep 60
-  fi
-done
-
-if [ "$UNRESOLVED" -gt 0 ]; then
-  echo "⚠️  $UNRESOLVED unresolved thread(s) remain after $MAX_COMMENT_ROUNDS rounds"
-  echo "Manual review may be needed before merge"
-fi
+  }
+}' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER")
 ```
 
-**Step 4: CI Polling with Auto-Fix**
+Identify blockers and resolve each one in a loop (max 3 rounds):
 
-After comments are addressed (fixes may have been pushed), poll CI checks:
+| Blocker | Auto-resolution |
+|---------|----------------|
+| `ci-failing` | Analyze failure logs, fix code, push, re-poll |
+| `unresolved-threads` | Run `/review-comments` (fixes, replies, and resolves threads) |
+| `branch-behind` | Rebase and push |
+| `draft` | `gh pr ready` |
+| `changes-requested` | Check if addressed; suggest re-request review |
+| `review-required` | Cannot fix — report how many approvals needed and who to request |
 
-```bash
-# Poll CI — max 3 fix attempts
-ATTEMPT=0
-MAX_ATTEMPTS=3
+**After each round:** re-query merge state, rebuild blocker list, continue if blockers remain.
 
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-  gh pr checks $PR_NUMBER --watch --fail-fast
-
-  if [ $? -eq 0 ]; then
-    break  # CI passed
-  fi
-
-  ATTEMPT=$((ATTEMPT + 1))
-  if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
-    # Analyze CI failures
-    # Attempt automated fix
-    # Commit and push fix
-    # Re-poll
-  fi
-done
-```
-
-If CI fails after all attempts, present the user with options:
+**If blockers remain after 3 rounds:**
 
 ```
-CI failed after {ATTEMPT} fix attempts:
-  ❌ {check name}: {failure reason}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⚠️  Cannot auto-resolve $N blocker(s)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Resolved:
+  ✅ CI — fixed lint errors (commit abc1234)
+  ✅ Threads — 3 comments addressed and resolved
+
+Still blocking:
+  ❌ Review required — needs 1 approval
+     → gh pr edit $PR_NUMBER --add-reviewer "username"
 
 Options:
-  [1] Fix manually and re-poll
-  [2] Continue to merge anyway (if branch protections allow)
-  [3] Create handoff and stop
+  [1] Wait for resolution and auto-merge
+  [2] Create handoff and stop
 ```
 
-**Step 5: Final Comment Check**
+**Never** use `--admin`, force merge, or bypass branch protection. See `/merge-pr` safety rules.
 
-After CI passes, do one final check for any new comments that arrived during CI fixes:
-
-```bash
-FINAL_UNRESOLVED=$(gh api graphql -f query='...' \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
-
-if [ "$FINAL_UNRESOLVED" -gt 0 ]; then
-  echo "$FINAL_UNRESOLVED new unresolved thread(s) — running /review-comments"
-  /review-comments $PR_NUMBER
-fi
-```
-
-**Step 6: Present options**
+**Step 4: Present options**
 
 ```
 PR ready: https://github.com/org/repo/pull/{number}
 
-CI:       ✅ passed
-Threads:  ✅ all resolved ({N} addressed)
-Reviews:  {N} comments addressed / no comments
+Merge state: $mergeStateStatus
+  ✅ CI passed
+  ✅ Threads resolved ({N} addressed)
+  ✅ Reviews addressed
+  ❌ Review required — 1 approval needed (if applicable)
 
 Options:
-  [1] Wait for approval and auto-merge (runs Phase 6 automatically)
+  [1] Wait for remaining blockers to clear, then auto-merge (runs Phase 6)
   [2] Exit — merge later with /merge-pr
 ```
 
-**If `--auto-merge` flag was set:** Skips the prompt, waits for CI, and proceeds to Phase 6
-automatically.
+**If `--auto-merge` flag was set:** Skips the prompt and proceeds to Phase 6 automatically. Phase 6
+(`/merge-pr`) will run its own blocker diagnosis loop and resolve anything remaining.
 
 **Linear**: `/create-pr` moves ticket to `stateMap.inReview` (default: "In Review").
 
@@ -471,8 +456,11 @@ Otherwise, user merges manually later with `/merge-pr`.
 
 **What happens:**
 
-- Runs `/merge-pr` which internally handles: CI verification, rebase if needed, squash merge, branch
-  cleanup
+- Runs `/merge-pr` which runs the full blocker diagnosis loop (step 6) — checks mergeStateStatus,
+  resolves any remaining blockers (CI, threads, branch behind, etc.), and only merges when all
+  branch protection requirements are satisfied
+- **Never** uses `--admin`, force merge, or bypasses branch protection
+- If blockers cannot be resolved, reports exactly what's needed and stops
 - Moves Linear ticket to `stateMap.done` (default: "Done")
 
 ## Team Mode (Optional)

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -303,9 +303,91 @@ EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --j
 - **If no PR exists**:
   - Run `/create-pr` (handles commit, push, PR creation, description, Linear linking)
 
-**Step 2: CI Polling with Auto-Fix**
+**Step 2: Wait for Automated Reviewers**
 
-After PR is created/updated, poll CI checks with auto-fix capability:
+Automated review agents (Codex, Direnv, etc.) typically post comments within 3-5 minutes of PR
+creation. Wait for them before processing comments, so we can address everything in one pass.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+# Wait 3 minutes, then start checking for comments
+sleep 180
+
+# Poll for up to 2 more minutes (5 min total) — check every 30s
+WAITED=180
+MAX_WAIT=300
+while [ $WAITED -lt $MAX_WAIT ]; do
+  COMMENT_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --jq 'length')
+  REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --jq '[.[] | select(.state != "APPROVED" and .state != "DISMISSED")] | length')
+
+  if [ "$COMMENT_COUNT" -gt 0 ] || [ "$REVIEW_COUNT" -gt 0 ]; then
+    echo "Found review comments — proceeding to address them"
+    break
+  fi
+
+  sleep 30
+  WAITED=$((WAITED + 30))
+done
+
+if [ "$COMMENT_COUNT" -eq 0 ] && [ "$REVIEW_COUNT" -eq 0 ]; then
+  echo "No automated review comments after ${MAX_WAIT}s — proceeding"
+fi
+```
+
+**Step 3: Address and Resolve Review Comments**
+
+Check for unresolved review threads and address them. This step loops until all threads are resolved
+or no new comments arrive after a fix push.
+
+```bash
+MAX_COMMENT_ROUNDS=3
+ROUND=0
+
+while [ $ROUND -lt $MAX_COMMENT_ROUNDS ]; do
+  # Check for unresolved threads
+  UNRESOLVED=$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $pr: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes { id isResolved comments(first: 1) { nodes { body author { login } } } }
+        }
+      }
+    }
+  }' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER" \
+    --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+
+  if [ "$UNRESOLVED" -eq 0 ]; then
+    echo "All review threads resolved"
+    break
+  fi
+
+  echo "$UNRESOLVED unresolved thread(s) — running /review-comments"
+
+  # /review-comments now handles: fetch, categorize, fix/reply, commit, push, AND resolve threads
+  /review-comments $PR_NUMBER
+
+  ROUND=$((ROUND + 1))
+
+  # Brief pause for any new automated comments triggered by the fix push
+  if [ $ROUND -lt $MAX_COMMENT_ROUNDS ]; then
+    sleep 60
+  fi
+done
+
+if [ "$UNRESOLVED" -gt 0 ]; then
+  echo "⚠️  $UNRESOLVED unresolved thread(s) remain after $MAX_COMMENT_ROUNDS rounds"
+  echo "Manual review may be needed before merge"
+fi
+```
+
+**Step 4: CI Polling with Auto-Fix**
+
+After comments are addressed (fixes may have been pushed), poll CI checks:
 
 ```bash
 # Poll CI — max 3 fix attempts
@@ -341,31 +423,28 @@ Options:
   [3] Create handoff and stop
 ```
 
-**Step 3: PR Comment Monitoring**
+**Step 5: Final Comment Check**
 
-After CI passes (or user chooses to proceed), check for review comments:
+After CI passes, do one final check for any new comments that arrived during CI fixes:
 
 ```bash
-# Fetch PR comments and reviews
-gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[].body'
-gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.state != "APPROVED") | .body'
+FINAL_UNRESOLVED=$(gh api graphql -f query='...' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+
+if [ "$FINAL_UNRESOLVED" -gt 0 ]; then
+  echo "$FINAL_UNRESOLVED new unresolved thread(s) — running /review-comments"
+  /review-comments $PR_NUMBER
+fi
 ```
 
-If comments exist that need addressing:
-
-1. Invoke `/review-comments` to analyze and address each comment
-2. Push fixes
-3. Re-poll CI if fixes were pushed
-
-If no actionable comments, proceed to merge prompt.
-
-**Step 4: Present options**
+**Step 6: Present options**
 
 ```
 PR ready: https://github.com/org/repo/pull/{number}
 
-CI: ✅ passed
-Reviews: {N} comments addressed / no comments
+CI:       ✅ passed
+Threads:  ✅ all resolved ({N} addressed)
+Reviews:  {N} comments addressed / no comments
 
 Options:
   [1] Wait for approval and auto-merge (runs Phase 6 automatically)

--- a/plugins/dev/skills/review-comments/SKILL.md
+++ b/plugins/dev/skills/review-comments/SKILL.md
@@ -100,61 +100,19 @@ git push
 After pushing fixes (or posting replies for disagreements), resolve each addressed thread on GitHub
 so it no longer blocks merge under branch protection rules that require resolved conversations.
 
-**Get unresolved review threads:**
+Read and follow `"${CLAUDE_PLUGIN_ROOT}/references/review-thread-resolution.md"` for the full
+workflow. Summary:
 
-```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-OWNER=$(echo "$REPO" | cut -d'/' -f1)
-NAME=$(echo "$REPO" | cut -d'/' -f2)
+1. Fetch unresolved review threads via GraphQL
+2. For each thread addressed in steps above, resolve it via `resolveReviewThread` mutation
+3. Verify remaining unresolved count
 
-gh api graphql -f query='
-query($owner: String!, $name: String!, $pr: Int!) {
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $pr) {
-      reviewThreads(first: 100) {
-        nodes {
-          id
-          isResolved
-          comments(first: 1) {
-            nodes { body author { login } }
-          }
-        }
-      }
-    }
-  }
-}' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER"
-```
-
-**Resolve each thread that was addressed:**
-
-For each unresolved thread that was either fixed or replied to in the steps above:
-
-```bash
-gh api graphql -f query='
-mutation($threadId: ID!) {
-  resolveReviewThread(input: {threadId: $threadId}) {
-    thread { isResolved }
-  }
-}' -f threadId="$THREAD_NODE_ID"
-```
-
-**Rules for resolving:**
+**Resolution rules:**
 
 - **Code change implemented** → resolve the thread
-- **Reply posted (disagreement or clarification)** → resolve the thread (the reply is visible in the
-  resolved thread; the reviewer can re-open if they disagree)
+- **Reply posted** (disagreement or clarification) → resolve the thread
 - **Approval / praise** → already not blocking, skip
 - **Could not address** → do NOT resolve; leave for human review
-
-**Verify all threads resolved:**
-
-```bash
-# Re-fetch to confirm
-UNRESOLVED=$(gh api graphql -f query='...' | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
-if [ "$UNRESOLVED" -gt 0 ]; then
-  echo "⚠️  $UNRESOLVED unresolved thread(s) remain — manual review needed"
-fi
-```
 
 ## Output Format
 

--- a/plugins/dev/skills/review-comments/SKILL.md
+++ b/plugins/dev/skills/review-comments/SKILL.md
@@ -95,6 +95,67 @@ git commit -m "address review comments from PR #${PR_NUMBER}"
 git push
 ```
 
+## Step 5: Resolve Comment Threads
+
+After pushing fixes (or posting replies for disagreements), resolve each addressed thread on GitHub
+so it no longer blocks merge under branch protection rules that require resolved conversations.
+
+**Get unresolved review threads:**
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+gh api graphql -f query='
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body author { login } }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER"
+```
+
+**Resolve each thread that was addressed:**
+
+For each unresolved thread that was either fixed or replied to in the steps above:
+
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}' -f threadId="$THREAD_NODE_ID"
+```
+
+**Rules for resolving:**
+
+- **Code change implemented** → resolve the thread
+- **Reply posted (disagreement or clarification)** → resolve the thread (the reply is visible in the
+  resolved thread; the reviewer can re-open if they disagree)
+- **Approval / praise** → already not blocking, skip
+- **Could not address** → do NOT resolve; leave for human review
+
+**Verify all threads resolved:**
+
+```bash
+# Re-fetch to confirm
+UNRESOLVED=$(gh api graphql -f query='...' | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+if [ "$UNRESOLVED" -gt 0 ]; then
+  echo "⚠️  $UNRESOLVED unresolved thread(s) remain — manual review needed"
+fi
+```
+
 ## Output Format
 
 ```markdown


### PR DESCRIPTION
## Summary

Replaces the merge-pr skill's individual check steps with a unified "diagnose and resolve" loop that queries GitHub's full merge state, identifies every specific blocker, and fixes what it can — without ever bypassing branch protection.

**merge-pr** (major rewrite of verification flow):
- New safety rules section: never `--admin`, never force merge, never bypass branch protection
- New Step 6 queries `mergeStateStatus` + `reviewDecision` + `statusCheckRollup` + `reviewThreads` in a single GraphQL call
- Decomposes `BLOCKED` into specific causes (`ci-failing`, `unresolved-threads`, `changes-requested`, `review-required`, `branch-behind`, `draft`, etc.)
- Resolves each blocker in a loop: fix CI failures, run `/review-comments`, rebase, mark ready, etc.
- When a blocker can't be auto-fixed, reports exactly what's needed (who to request review from, which files conflict) — never "branch protection is blocking"
- Falls back to querying branch protection rules directly for unknown blockers

**review-comments** (new Step 5):
- Resolves GitHub review threads via GraphQL `resolveReviewThread` after addressing each comment
- Rules: fix → resolve, reply → resolve, can't address → leave open for human review

**oneshot Phase 5** (restructured):
- Step 2: Waits 3-5 min for automated reviewers (Codex, Direnv, etc.) after PR creation
- Step 3: Mirrors merge-pr's blocker diagnosis loop, proactively resolving CI/threads/branch-behind
- Step 4: Presents options with full merge state breakdown
- Phase 6: Clarifies it runs the full blocker loop and never bypasses protection

## Context

Branch protection now requires resolved conversations before merge. Automated review agents (Codex, etc.) post comments within 3-5 minutes. Without this, `--auto-merge` workflows failed with generic "branch protection" errors and no actionable guidance.

## Test plan

- [ ] Create a PR with automated reviewer comments → verify `/review-comments` resolves threads
- [ ] Attempt `/merge-pr` on a PR with unresolved threads → verify it runs `/review-comments` and resolves them
- [ ] Attempt `/merge-pr` on a PR that needs approval → verify it reports who to request, not generic error
- [ ] Attempt `/merge-pr` with failing CI → verify it analyzes the failure and attempts a fix
- [ ] Run `/oneshot --auto-merge` end-to-end → verify it waits for reviewers, resolves blockers, merges cleanly
- [ ] Verify no `--admin` or `--force` flags appear anywhere in the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)