### PR TITLE
fix(dev): add fully-qualified plugin prefixes to skill references

### DIFF
--- a/.claude/rules/skill-references.md
+++ b/.claude/rules/skill-references.md
@@ -1,0 +1,15 @@
+# Skill Reference Naming
+
+Plugin skills always require the fully-qualified `plugin-name:skill-name` form for invocation.
+
+When outputting skill invocation instructions to the user (in templates, error messages, "next steps" suggestions), always use the full prefix:
+
+- catalyst-dev skills: `/catalyst-dev:skill-name`
+- catalyst-pm skills: `/catalyst-pm:skill-name`
+- catalyst-meta skills: `/catalyst-meta:skill-name`
+- catalyst-debugging skills: `/catalyst-debugging:skill-name`
+- catalyst-analytics skills: `/catalyst-analytics:skill-name`
+
+In explanatory prose describing workflow relationships (e.g., "Called by /implement-plan as part of quality gates"), bare names are acceptable for readability since nobody types those.
+
+Agent `subagent_type` references always use the full `plugin-name:agent-name` format.

--- a/plugins/analytics/skills/analyze-user-behavior/SKILL.md
+++ b/plugins/analytics/skills/analyze-user-behavior/SKILL.md
@@ -117,4 +117,4 @@ The command will:
 
 ---
 
-**See also**: `/product-metrics`, `/segment-analysis`
+**See also**: `/catalyst-analytics:product-metrics`, `/catalyst-analytics:segment-analysis`

--- a/plugins/analytics/skills/product-metrics/SKILL.md
+++ b/plugins/analytics/skills/product-metrics/SKILL.md
@@ -115,4 +115,4 @@ This plugin consumes ~40k tokens. Disable after viewing metrics:
 
 ---
 
-**See also**: `/analyze-user-behavior`, `/segment-analysis`
+**See also**: `/catalyst-analytics:analyze-user-behavior`, `/catalyst-analytics:segment-analysis`

--- a/plugins/analytics/skills/segment-analysis/SKILL.md
+++ b/plugins/analytics/skills/segment-analysis/SKILL.md
@@ -135,4 +135,4 @@ Plugin uses ~40k tokens. Disable when analysis is complete:
 
 ---
 
-**See also**: `/analyze-user-behavior`, `/product-metrics`
+**See also**: `/catalyst-analytics:analyze-user-behavior`, `/catalyst-analytics:product-metrics`

--- a/plugins/debugging/skills/debug-production-error/SKILL.md
+++ b/plugins/debugging/skills/debug-production-error/SKILL.md
@@ -184,7 +184,7 @@ After identifying root cause:
 After finding the bug:
 
 ```bash
-/create-plan "Fix the TypeError in checkout.ts based on Sentry analysis"
+/catalyst-dev:create-plan "Fix the TypeError in checkout.ts based on Sentry analysis"
 ```
 
 ## Context Cost
@@ -197,4 +197,4 @@ After finding the bug:
 
 ---
 
-**See also**: `/error-impact-analysis`, `/trace-analysis`
+**See also**: `/catalyst-debugging:error-impact-analysis`, `/catalyst-debugging:trace-analysis`

--- a/plugins/debugging/skills/error-impact-analysis/SKILL.md
+++ b/plugins/debugging/skills/error-impact-analysis/SKILL.md
@@ -172,4 +172,4 @@ Plugin uses ~20k tokens. Disable after analysis:
 
 ---
 
-**See also**: `/debug-production-error`, `/trace-analysis`
+**See also**: `/catalyst-debugging:debug-production-error`, `/catalyst-debugging:trace-analysis`

--- a/plugins/debugging/skills/trace-analysis/SKILL.md
+++ b/plugins/debugging/skills/trace-analysis/SKILL.md
@@ -145,7 +145,7 @@ Transaction: POST /api/checkout (2.4s)
 After identifying bottleneck:
 
 ```bash
-/create-plan "Optimize the slow payment gateway call identified in trace analysis"
+/catalyst-dev:create-plan "Optimize the slow payment gateway call identified in trace analysis"
 ```
 
 ## Performance Optimization Workflow
@@ -171,7 +171,7 @@ After identifying bottleneck:
 ### 4. Implement Fix
 
 ```bash
-/create-plan "Add database index for user lookups based on trace analysis"
+/catalyst-dev:create-plan "Add database index for user lookups based on trace analysis"
 ```
 
 ### 5. Verify Improvement
@@ -198,4 +198,4 @@ Plugin uses ~20k tokens. Disable after analysis:
 
 ---
 
-**See also**: `/debug-production-error`, `/error-impact-analysis`
+**See also**: `/catalyst-debugging:debug-production-error`, `/catalyst-debugging:error-impact-analysis`

--- a/plugins/dev/skills/code-first-draft/SKILL.md
+++ b/plugins/dev/skills/code-first-draft/SKILL.md
@@ -215,7 +215,7 @@ Save to `thoughts/shared/prototypes/[feature]-first-draft.md`:
 
 - Run tests
 - Manual QA
-- For complex features: Consider `/create-plan` + `/implement-plan` for structured iteration
+- For complex features: Consider `/catalyst-dev:create-plan` + `/catalyst-dev:implement-plan` for structured iteration
 ```
 
 ---
@@ -330,14 +330,14 @@ Check for additional accessibility requirements in project documentation (e.g., 
 
 **Before:**
 
-- `/create-plan` - Create a detailed implementation plan first (for complex features)
-- `/research-codebase` - Research existing patterns before building
+- `/catalyst-dev:create-plan` - Create a detailed implementation plan first (for complex features)
+- `/catalyst-dev:research-codebase` - Research existing patterns before building
 
 **After:**
 
-- `/commit` - Commit the implementation
-- `/create-pr` - Create a pull request for review
-- `/validate-plan` - Verify implementation matches requirements
+- `/catalyst-dev:commit` - Commit the implementation
+- `/catalyst-dev:create-pr` - Create a pull request for review
+- `/catalyst-dev:validate-plan` - Verify implementation matches requirements
 
 ---
 

--- a/plugins/dev/skills/create-handoff/SKILL.md
+++ b/plugins/dev/skills/create-handoff/SKILL.md
@@ -156,7 +156,7 @@ Once this is completed, you should respond to the user with the template between
 with the following command:
 
 ```bash
-/resume-handoff path/to/handoff.md
+/catalyst-dev:resume-handoff path/to/handoff.md
 ```
 
 </template_response>
@@ -168,7 +168,7 @@ your actual response to the user)
 with the following command:
 
 ```bash
-/resume-handoff thoughts/shared/handoffs/PROJ-123/2025-01-08_13-44-55_PROJ-123_create-context-compaction.md
+/catalyst-dev:resume-handoff thoughts/shared/handoffs/PROJ-123/2025-01-08_13-44-55_PROJ-123_create-context-compaction.md
 ```
 
 </example_response>

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -334,7 +334,7 @@ This MUST print the plan path. If not, re-run 5b.
    ## Ready to Implement
 
    Start a new session and run:
-   /implement-plan [--team] thoughts/shared/plans/{PLAN_FILENAME}
+   /catalyst-dev:implement-plan [--team] thoughts/shared/plans/{PLAN_FILENAME}
 
    Tip: Start a fresh session — implementation needs context for source files and progress tracking.
    ```

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -89,7 +89,7 @@ If behind:
 - Auto-rebase: `git rebase origin/$base`
 - If conflicts:
   - Show conflicting files
-  - Error: "Rebase conflicts detected. Resolve conflicts and run /create-pr again."
+  - Error: "Rebase conflicts detected. Resolve conflicts and run /catalyst-dev:create-pr again."
   - Exit
 
 ### 5. Check for existing PR
@@ -283,7 +283,7 @@ Conflicting files:
 Resolve conflicts and run:
   git add <resolved-files>
   git rebase --continue
-  /create-pr
+  /catalyst-dev:create-pr
 ```
 
 **GitHub CLI not configured:**
@@ -350,7 +350,7 @@ Extracting ticket: ENG-123
 Generated title: "ENG-123: Implement pr lifecycle"
 Creating PR...
 ✅ PR #2 created
-Calling /describe-pr to generate description...
+Calling /catalyst-dev:describe-pr to generate description...
 Updating Linear ticket ENG-123 → In Review
 ✅ Complete!
 ```

--- a/plugins/dev/skills/create-worktree/SKILL.md
+++ b/plugins/dev/skills/create-worktree/SKILL.md
@@ -67,7 +67,7 @@ When this command is invoked:
    wants to launch Claude in the worktree:
    ```bash
    humanlayer launch --model opus -w <worktree_path> \
-     "/implement_plan <plan_path> and when done: create commit, create PR, update Linear ticket"
+     "/catalyst-dev:implement-plan <plan_path> and when done: create commit, create PR, update Linear ticket"
    ```
 
 ## Worktree Location Convention

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -412,28 +412,28 @@ When these commands are run, check if there's a related Linear ticket and update
 
 ```bash
 # 1. Research and document
-/research-codebase "authentication patterns"
+/catalyst-dev:research-codebase "authentication patterns"
 # Saves to thoughts/shared/research/auth-patterns.md
 
 # 2. Create ticket from research
-/linear create thoughts/shared/research/auth-patterns.md
+/catalyst-dev:linear create thoughts/shared/research/auth-patterns.md
 # Creates ticket in Backlog
 
 # 3. Create plan
-/create-plan
+/catalyst-dev:create-plan
 # Reads research, creates plan
 # Ticket moves to stateMap.planning (default: "In Progress")
 
 # 4. Implement
-/implement-plan thoughts/shared/plans/2025-01-08-auth-feature.md
+/catalyst-dev:implement-plan thoughts/shared/plans/2025-01-08-auth-feature.md
 # Ticket moves to stateMap.inProgress (default: "In Progress")
 
 # 5. Create PR
-/create-pr
+/catalyst-dev:create-pr
 # Ticket moves to stateMap.inReview (default: "In Review")
 
 # 6. Merge PR
-/merge-pr
+/catalyst-dev:merge-pr
 # Ticket moves to stateMap.done (default: "Done")
 ```
 

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -146,7 +146,7 @@ Resolve manually:
   2. git add <resolved-files>
   3. git rebase --continue
   4. git push --force-with-lease
-  5. Run /merge-pr again
+  5. Run /catalyst-dev:merge-pr again
 ```
 
 Exit with error.
@@ -178,7 +178,7 @@ Fix failing tests before merge:
   $test_cmd
 
 Or skip tests (not recommended):
-  /merge-pr $pr_number --skip-tests
+  /catalyst-dev:merge-pr $pr_number --skip-tests
 ```
 
 Exit with error (unless `--skip-tests` flag provided).
@@ -421,25 +421,25 @@ Post-merge tasks: $task_count saved to thoughts/
 **`--skip-tests`** - Skip local test execution
 
 ```bash
-/merge-pr 123 --skip-tests
+/catalyst-dev:merge-pr 123 --skip-tests
 ```
 
 **`--no-update`** - Don't update Linear ticket
 
 ```bash
-/merge-pr 123 --no-update
+/catalyst-dev:merge-pr 123 --no-update
 ```
 
 **`--keep-branch`** - Don't delete local branch
 
 ```bash
-/merge-pr 123 --keep-branch
+/catalyst-dev:merge-pr 123 --keep-branch
 ```
 
 **Combined:**
 
 ```bash
-/merge-pr 123 --skip-tests --no-update
+/catalyst-dev:merge-pr 123 --skip-tests --no-update
 ```
 
 ## Error Handling
@@ -451,7 +451,7 @@ next steps.
 **Fail fast (stop execution):**
 
 - Rebase conflicts → show conflicting files, instructions to resolve manually, then re-run
-  `/merge-pr`
+  `/catalyst-dev:merge-pr`
 - Test failures → show failed tests, suggest fix or `--skip-tests`
 - PR not open/mergeable → show current state
 
@@ -517,10 +517,10 @@ keys.
 ## Examples
 
 ```bash
-/merge-pr 123              # Merge PR for current branch
-/merge-pr 123 --skip-tests # Skip local test execution
-/merge-pr 123 --no-update  # Don't update Linear ticket
-/merge-pr 123 --keep-branch # Don't delete local branch
+/catalyst-dev:merge-pr 123              # Merge PR for current branch
+/catalyst-dev:merge-pr 123 --skip-tests # Skip local test execution
+/catalyst-dev:merge-pr 123 --no-update  # Don't update Linear ticket
+/catalyst-dev:merge-pr 123 --keep-branch # Don't delete local branch
 ```
 
 ## Safety Features

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -41,7 +41,7 @@ Supports two input modes:
 **Ticket-based:**
 
 ```
-/oneshot PROJ-123
+/catalyst-dev:oneshot PROJ-123
 ```
 
 Reads ticket from Linear, uses title/description as research query.
@@ -49,7 +49,7 @@ Reads ticket from Linear, uses title/description as research query.
 **Freeform:**
 
 ```
-/oneshot "How does authentication work and can we add OAuth?"
+/catalyst-dev:oneshot "How does authentication work and can we add OAuth?"
 ```
 
 Uses the provided text as the research query directly.
@@ -162,7 +162,7 @@ Launches a fresh Claude Code session with full context isolation.
 humanlayer launch \
   --model opus \
   --title "plan ${TICKET_ID:-oneshot}" \
-  "/create-plan thoughts/shared/research/$RESEARCH_DOC"
+  "/catalyst-dev:create-plan thoughts/shared/research/$RESEARCH_DOC"
 ```
 
 **What happens in the launched session:**
@@ -186,7 +186,7 @@ After the plan is approved, launches another fresh session:
 humanlayer launch \
   --model opus \
   --title "implement ${TICKET_ID:-oneshot}" \
-  "/implement-plan thoughts/shared/plans/$PLAN_DOC"
+  "/catalyst-dev:implement-plan thoughts/shared/plans/$PLAN_DOC"
 ```
 
 **What happens in the launched session:**
@@ -210,7 +210,7 @@ Launches a fresh session for validation and quality enforcement:
 humanlayer launch \
   --model opus \
   --title "validate ${TICKET_ID:-oneshot}" \
-  "Run /validate-plan then run quality gates. Plan: thoughts/shared/plans/$PLAN_DOC"
+  "Run /catalyst-dev:validate-plan then run quality gates. Plan: thoughts/shared/plans/$PLAN_DOC"
 ```
 
 **Step 1: Validate plan implementation**
@@ -370,7 +370,7 @@ Merge state: $mergeStateStatus
 
 Options:
   [1] Wait for remaining blockers to clear, then auto-merge (runs Phase 6)
-  [2] Exit — merge later with /merge-pr
+  [2] Exit — merge later with /catalyst-dev:merge-pr
 ```
 
 **If `--auto-merge` flag was set:** Skips the prompt and proceeds to Phase 6 automatically. Phase 6
@@ -385,10 +385,10 @@ Only runs automatically if:
 - User selected option [1] in Phase 5, OR
 - `--auto-merge` flag was passed
 
-Otherwise, user merges manually later with `/merge-pr`.
+Otherwise, user merges manually later with `/catalyst-dev:merge-pr`.
 
 ```
-/merge-pr
+/catalyst-dev:merge-pr
 ```
 
 **What happens:**
@@ -404,7 +404,7 @@ Otherwise, user merges manually later with `/merge-pr`.
 For complex implementations spanning multiple files/layers:
 
 ```
-/oneshot --team PROJ-123
+/catalyst-dev:oneshot --team PROJ-123
 ```
 
 In team mode, Phase 3 uses agent teams for parallel implementation:
@@ -554,7 +554,7 @@ State transitions throughout the lifecycle:
 
 - Save partial findings to thoughts/
 - Present error to user
-- Suggest running `/research-codebase` manually
+- Suggest running `/catalyst-dev:research-codebase` manually
 
 **If humanlayer launch fails:**
 
@@ -564,14 +564,14 @@ State transitions throughout the lifecycle:
   Could not launch new session automatically.
 
   Please start a new session and run:
-    /create-plan thoughts/shared/research/$RESEARCH_DOC
+    /catalyst-dev:create-plan thoughts/shared/research/$RESEARCH_DOC
   ```
 
 **If implementation fails:**
 
 - Partial work is preserved (uncommitted)
 - Handoff document created automatically
-- User can resume with `/resume-handoff`
+- User can resume with `/catalyst-dev:resume-handoff`
 
 **If quality gates fail after max retries:**
 
@@ -591,7 +591,7 @@ error, context exhaustion):
 - Invoke `/create-handoff` with: phases completed, current phase status, unresolved issues,
   CI/review status, and remaining phases
 - Save handoff to `thoughts/shared/handoffs/`
-- User can resume with `/resume-handoff`
+- User can resume with `/catalyst-dev:resume-handoff`
 
 ## Important
 

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -44,10 +44,10 @@ fi
 ## Invocation
 
 ```
-/orchestrate PROJ-101 PROJ-102 PROJ-103             # explicit tickets
-/orchestrate --project "Q2 API Redesign"              # pull from Linear project
-/orchestrate --cycle current                           # pull from current cycle
-/orchestrate --file tickets.txt                        # read ticket IDs from file
+/catalyst-dev:orchestrate PROJ-101 PROJ-102 PROJ-103             # explicit tickets
+/catalyst-dev:orchestrate --project "Q2 API Redesign"              # pull from Linear project
+/catalyst-dev:orchestrate --cycle current                           # pull from current cycle
+/catalyst-dev:orchestrate --file tickets.txt                        # read ticket IDs from file
 ```
 
 ## Flags
@@ -80,7 +80,7 @@ doesn't exist). Falls back to sensible defaults if no orchestration block exists
         "setup": [],
         "teardown": []
       },
-      "workerCommand": "/oneshot",
+      "workerCommand": "/catalyst-dev:oneshot",
       "workerModel": "opus",
       "thoughts": {
         "profile": null,
@@ -186,7 +186,7 @@ WORKTREE_DIR=$(jq -r '.catalyst.orchestration.worktreeDir // empty' "$CONFIG_FIL
 MAX_PARALLEL=$(jq -r '.catalyst.orchestration.maxParallel // 3' "$CONFIG_FILE" 2>/dev/null)
 SETUP_HOOKS=$(jq -c '.catalyst.orchestration.hooks.setup // []' "$CONFIG_FILE" 2>/dev/null)
 TEARDOWN_HOOKS=$(jq -c '.catalyst.orchestration.hooks.teardown // []' "$CONFIG_FILE" 2>/dev/null)
-WORKER_COMMAND=$(jq -r '.catalyst.orchestration.workerCommand // "/oneshot"' "$CONFIG_FILE" 2>/dev/null)
+WORKER_COMMAND=$(jq -r '.catalyst.orchestration.workerCommand // "/catalyst-dev:oneshot"' "$CONFIG_FILE" 2>/dev/null)
 WORKER_MODEL=$(jq -r '.catalyst.orchestration.workerModel // "opus"' "$CONFIG_FILE" 2>/dev/null)
 ```
 
@@ -711,7 +711,7 @@ fi
 
 **Orchestrator crash recovery:**
 - All state is in `${ORCH_DIR}/state.json` + worker signal files
-- Resume with: `/orchestrate --resume ${ORCH_DIR}`
+- Resume with: `/catalyst-dev:orchestrate --resume ${ORCH_DIR}`
 - Reads state.json, determines current wave, checks each worker's actual status
 - Picks up where it left off
 

--- a/plugins/dev/skills/resume-handoff/SKILL.md
+++ b/plugins/dev/skills/resume-handoff/SKILL.md
@@ -266,7 +266,7 @@ Once you have a handoff path:
 ## Example Interaction Flow
 
 ```
-User: /resume-handoff specification/feature/handoffs/handoff-0.md
+User: /catalyst-dev:resume-handoff specification/feature/handoffs/handoff-0.md
 Assistant: Let me read and analyze that handoff document...
 
 [Reads handoff completely]

--- a/plugins/dev/skills/validate-plan/SKILL.md
+++ b/plugins/dev/skills/validate-plan/SKILL.md
@@ -143,7 +143,7 @@ Current usage: {X}% ({Y}K/{Z}K tokens)
 1. Review this validation report
 2. Address any failures
 3. Close this session (clear context)
-4. Start fresh for: `/commit` and `/describe-pr`
+4. Start fresh for: `/catalyst-dev:commit` and `/catalyst-dev:describe-pr`
 
 {If <60%}:
 ✅ Context healthy. Ready for PR creation.

--- a/plugins/meta/skills/create-workflow/SKILL.md
+++ b/plugins/meta/skills/create-workflow/SKILL.md
@@ -448,7 +448,7 @@ Creation recorded in: thoughts/shared/workflows/created.md
 ### Create from Catalog Entry
 
 ```
-/create-workflow from catalog wshobson/commands/code-review
+/catalyst-meta:create-workflow from catalog wshobson/commands/code-review
 ```
 
 Creates a new workflow based on a specific catalog entry.
@@ -456,7 +456,7 @@ Creates a new workflow based on a specific catalog entry.
 ### Create with Custom Template
 
 ```
-/create-workflow agent data-analyzer --template minimal
+/catalyst-meta:create-workflow agent data-analyzer --template minimal
 ```
 
 Uses predefined templates:
@@ -468,7 +468,7 @@ Uses predefined templates:
 ### Quick Create
 
 ```
-/create-workflow command quick-commit "Create conventional commits"
+/catalyst-meta:create-workflow command quick-commit "Create conventional commits"
 ```
 
 Skips interactive steps, uses defaults.
@@ -582,10 +582,10 @@ Standard categories found in workspace:
 
 ## Integration with Other Commands
 
-- **Discover**: `/discover-workflows` → find examples to model after
-- **Import**: `/import-workflow` → import external workflow as starting point
-- **Create**: `/create-workflow` (this command) → create new workflow
-- **Validate**: `/validate-frontmatter` → ensure consistency
+- **Discover**: `/catalyst-meta:discover-workflows` → find examples to model after
+- **Import**: `/catalyst-meta:import-workflow` → import external workflow as starting point
+- **Create**: `/catalyst-meta:create-workflow` (this command) → create new workflow
+- **Validate**: `/catalyst-meta:validate-frontmatter` → ensure consistency
 
 ## Error Handling
 

--- a/plugins/meta/skills/discover-workflows/SKILL.md
+++ b/plugins/meta/skills/discover-workflows/SKILL.md
@@ -305,8 +305,8 @@ Discovered {N} workflows ({X} commands, {Y} agents)
 ## Next Steps
 
 1. **Review the analysis**: `thoughts/shared/workflows/{repo}/analysis.md`
-2. **Import a workflow**: `/import-workflow {repo} {workflow-name}`
-3. **Discover another repo**: `/discover-workflows`
+2. **Import a workflow**: `/catalyst-meta:import-workflow {repo} {workflow-name}`
+3. **Discover another repo**: `/catalyst-meta:discover-workflows`
 
 Catalog updated at: `thoughts/shared/workflows/catalog.md`
 ```
@@ -316,7 +316,7 @@ Catalog updated at: `thoughts/shared/workflows/catalog.md`
 ### Discover All Repos (Maximum Parallelism)
 
 ```
-/discover-workflows all
+/catalyst-meta:discover-workflows all
 ```
 
 This will:
@@ -336,7 +336,7 @@ This will:
 ### Discover Custom Repo
 
 ```
-/discover-workflows org/repo
+/catalyst-meta:discover-workflows org/repo
 ```
 
 Works with any public GitHub repo with Claude Code workflows.
@@ -344,7 +344,7 @@ Works with any public GitHub repo with Claude Code workflows.
 ### Focus on Specific Type
 
 ```
-/discover-workflows wshobson/agents --focus agents
+/catalyst-meta:discover-workflows wshobson/agents --focus agents
 ```
 
 Only analyzes agents, skips commands.
@@ -354,13 +354,13 @@ Only analyzes agents, skips commands.
 - **Read-only**: This command only researches, doesn't import
 - **Catalog persistence**: Saved in thoughts/ for future reference
 - **Reusable**: Run anytime to update catalog
-- **Combinable**: Use with `/import-workflow` to actually import
+- **Combinable**: Use with `/catalyst-meta:import-workflow` to actually import
 
 ## Integration with Other Commands
 
-- **Discover** → `/discover-workflows` (this command)
-- **Import** → `/import-workflow` (imports discovered workflows)
-- **Create** → `/create-workflow` (creates new using discovered patterns)
-- **Validate** → `/validate-frontmatter` (ensures consistency)
+- **Discover** → `/catalyst-meta:discover-workflows` (this command)
+- **Import** → `/catalyst-meta:import-workflow` (imports discovered workflows)
+- **Create** → `/catalyst-meta:create-workflow` (creates new using discovered patterns)
+- **Validate** → `/catalyst-meta:validate-frontmatter` (ensures consistency)
 
 This command is the first step in workflow discovery and reuse!

--- a/plugins/meta/skills/import-workflow/SKILL.md
+++ b/plugins/meta/skills/import-workflow/SKILL.md
@@ -27,7 +27,7 @@ Please provide:
 1. Repository name (e.g., wshobson/commands)
 2. Workflow name (e.g., code-review)
 
-Or, if you've already run /discover-workflows:
+Or, if you've already run /catalyst-meta:discover-workflows:
 - Check the catalog: thoughts/shared/workflows/catalog.md
 - Pick from discovered workflows
 ```
@@ -285,13 +285,13 @@ Import recorded in: thoughts/shared/workflows/imports.md
 ### Import with Custom Adaptations
 
 ```
-/import-workflow wshobson/commands code-review --adapt "Use our custom linting rules"
+/catalyst-meta:import-workflow wshobson/commands code-review --adapt "Use our custom linting rules"
 ```
 
 ### Import Multiple Workflows
 
 ```
-/import-workflow wshobson/commands code-review refactor test-gen
+/catalyst-meta:import-workflow wshobson/commands code-review refactor test-gen
 ```
 
 Imports all 3 in sequence (with parallel validation for each).
@@ -299,7 +299,7 @@ Imports all 3 in sequence (with parallel validation for each).
 ### Dry Run Mode
 
 ```
-/import-workflow wshobson/commands code-review --dry-run
+/catalyst-meta:import-workflow wshobson/commands code-review --dry-run
 ```
 
 Shows what would be imported without actually saving files.
@@ -314,16 +314,16 @@ Shows what would be imported without actually saving files.
 
 ## Integration with Other Commands
 
-- **Discover first**: `/discover-workflows` → catalog workflows
-- **Then import**: `/import-workflow` (this command)
-- **Validate**: `/validate-frontmatter` ensures consistency
-- **Create custom**: `/create-workflow` for new workflows
+- **Discover first**: `/catalyst-meta:discover-workflows` → catalog workflows
+- **Then import**: `/catalyst-meta:import-workflow` (this command)
+- **Validate**: `/catalyst-meta:validate-frontmatter` ensures consistency
+- **Create custom**: `/catalyst-meta:create-workflow` for new workflows
 
 ## Error Handling
 
 ### Workflow Not Found
 
-- Suggest running `/discover-workflows {repo}` first
+- Suggest running `/catalyst-meta:discover-workflows {repo}` first
 - Check catalog for available workflows
 
 ### Incompatible Tools

--- a/plugins/meta/skills/validate-frontmatter/SKILL.md
+++ b/plugins/meta/skills/validate-frontmatter/SKILL.md
@@ -279,7 +279,7 @@ If user chose auto-fix:
 
    - {workflow-name}.md: {issue description}
 
-   Re-run validation to verify: `/validate-frontmatter`
+   Re-run validation to verify: `/catalyst-meta:validate-frontmatter`
    ```
 
 ### Step 6: Generate Standard Document (if requested)
@@ -514,9 +514,9 @@ When adding new categories or patterns:
 
 ## See Also
 
-- `/validate-frontmatter` - Validate workflows against this standard
-- `/create-workflow` - Create new workflows with correct frontmatter
-- `/import-workflow` - Import external workflows and adapt frontmatter
+- `/catalyst-meta:validate-frontmatter` - Validate workflows against this standard
+- `/catalyst-meta:create-workflow` - Create new workflows with correct frontmatter
+- `/catalyst-meta:import-workflow` - Import external workflows and adapt frontmatter
 
 ```
 
@@ -533,7 +533,7 @@ Next steps:
 
 1. Review the standard
 2. Share with team
-3. Use `/validate-frontmatter` to check compliance
+3. Use `/catalyst-meta:validate-frontmatter` to check compliance
 4. Reference when creating new workflows
 
 ```
@@ -544,7 +544,7 @@ Next steps:
 
 ```
 
-/validate-frontmatter agents/codebase-analyzer.md
+/catalyst-meta:validate-frontmatter agents/codebase-analyzer.md
 
 ```
 
@@ -554,7 +554,7 @@ Validates just one file.
 
 ```
 
-/validate-frontmatter --fix
+/catalyst-meta:validate-frontmatter --fix
 
 ```
 
@@ -564,7 +564,7 @@ Automatically fixes all issues without prompting.
 
 ```
 
-/validate-frontmatter --report-only > frontmatter-report.md
+/catalyst-meta:validate-frontmatter --report-only > frontmatter-report.md
 
 ```
 
@@ -574,7 +574,7 @@ Saves report to file for review.
 
 ```
 
-/validate-frontmatter --category research
+/catalyst-meta:validate-frontmatter --category research
 
 ```
 
@@ -632,10 +632,10 @@ Only validates workflows in "research" category.
 
 ## Integration with Other Commands
 
-- **Discover**: `/discover-workflows` → uses this for validation
-- **Import**: `/import-workflow` → validates imported workflows
-- **Create**: `/create-workflow` → ensures new workflows are valid
-- **Validate**: `/validate-frontmatter` (this command) → checks everything
+- **Discover**: `/catalyst-meta:discover-workflows` → uses this for validation
+- **Import**: `/catalyst-meta:import-workflow` → validates imported workflows
+- **Create**: `/catalyst-meta:create-workflow` → ensures new workflows are valid
+- **Validate**: `/catalyst-meta:validate-frontmatter` (this command) → checks everything
 
 ## Error Handling
 

--- a/plugins/pm/skills/connect-mcps/SKILL.md
+++ b/plugins/pm/skills/connect-mcps/SKILL.md
@@ -20,7 +20,7 @@ Tell me which tool to connect (e.g., "connect to PostHog") and I will guide you 
 4. I test the connection and discover available tools
 5. I update your PM OS skills and pm/CLAUDE.md routing automatically
 
-**Example:** `/connect-mcps connect to linear`
+**Example:** `/catalyst-pm:connect-mcps connect to linear`
 
 **Output:** MCP connected, skills updated, integration log saved to `thoughts/shared/pm/reports/`
 
@@ -37,15 +37,15 @@ Tell me which tool to connect (e.g., "connect to PostHog") and I will guide you 
 ### Individual Connection (Recommended)
 
 ```
-/connect-mcps connect to posthog
-/connect-mcps connect to linear
-/connect-mcps connect to notion
+/catalyst-pm:connect-mcps connect to posthog
+/catalyst-pm:connect-mcps connect to linear
+/catalyst-pm:connect-mcps connect to notion
 ```
 
 ### Batch Connection (Advanced)
 
 ```
-/connect-mcps batch
+/catalyst-pm:connect-mcps batch
 ```
 
 Then provide multiple tool names when prompted.
@@ -73,7 +73,7 @@ When you run `/connect-mcps connect to [tool name]`, I will:
 
 ### Step 1: Parse Tool Name
 
-When you run `/connect-mcps connect to posthog`:
+When you run `/catalyst-pm:connect-mcps connect to posthog`:
 
 - Extract tool name: "posthog"
 - Normalize and validate the name
@@ -419,7 +419,7 @@ This ensures MCP integration info appears early but doesn't interrupt the skill'
 
 ```
 
-User: /connect-mcps connect to posthog
+User: /catalyst-pm:connect-mcps connect to posthog
 
 Me:
 Let me help you connect PostHog to your PM OS workspace.
@@ -489,7 +489,7 @@ Full log: thoughts/shared/pm/reports/2026-01-30-posthog.md
 
 ```
 
-User: /connect-mcps connect to linear
+User: /catalyst-pm:connect-mcps connect to linear
 
 Me:
 Let me help you connect Linear to your PM OS workspace.
@@ -555,7 +555,7 @@ Full log: thoughts/shared/pm/reports/2026-01-30-linear.md
 
 ```
 
-User: /connect-mcps batch
+User: /catalyst-pm:connect-mcps batch
 
 Me:
 Let's connect multiple MCPs at once.
@@ -765,7 +765,7 @@ Want to try again? Enter your API key:
 **3. MCP Already Connected**
 ```
 
-User: /connect-mcps connect to posthog
+User: /catalyst-pm:connect-mcps connect to posthog
 
 Me: PostHog is already connected!
 
@@ -824,7 +824,7 @@ Me: [maps to both skill groups]
 
 2. **Use natural language after setup** - Don't think about which MCP to call. Just ask your question naturally and I'll figure out the routing.
 
-3. **Batch connect if you can** - If you're setting up multiple tools, use `/connect-mcps batch` to go through them all at once.
+3. **Batch connect if you can** - If you're setting up multiple tools, use `/catalyst-pm:connect-mcps batch` to go through them all at once.
 
 4. **Test with simple queries first** - After connecting, try a simple query like "show me X" to verify the connection works before complex queries.
 
@@ -844,7 +844,7 @@ Me: [maps to both skill groups]
 
 ❌ **Don't paste credentials in chat without the prompt** - Wait for me to explicitly ask for your API key. Don't volunteer it unprompted.
 
-❌ **Don't skip the tool name** - Use `/connect-mcps connect to posthog`, not just `/connect-mcps posthog` or `/connect-mcps connect posthog`.
+❌ **Don't skip the tool name** - Use `/catalyst-pm:connect-mcps connect to posthog`, not just `/connect-mcps posthog` or `/connect-mcps connect posthog`.
 
 ❌ **Don't connect before installing** - Install the MCP server locally first (via NPM, Docker, etc.), then run `/connect-mcps connect to [tool]`.
 
@@ -852,7 +852,7 @@ Me: [maps to both skill groups]
 
 ❌ **Don't manually edit pm/CLAUDE.md** - Let me update the registry automatically. Manual edits can break the routing logic.
 
-❌ **Don't connect duplicate MCPs** - If you already have PostHog connected, don't run `/connect-mcps connect to posthog` again unless you're reconfiguring.
+❌ **Don't connect duplicate MCPs** - If you already have PostHog connected, don't run `/catalyst-pm:connect-mcps connect to posthog` again unless you're reconfiguring.
 
 ❌ **Don't ignore errors** - If connection fails, read the error message. It usually tells you exactly what's wrong (expired key, wrong format, etc.).
 
@@ -927,7 +927,7 @@ Connect these first. They provide immediate ROI for product managers.
 - "Which features correlate with power user behavior?"
 - "Pull session recordings for users who churned last week"
 
-**Setup:** Run `/connect-mcps connect to posthog`
+**Setup:** Run `/catalyst-pm:connect-mcps connect to posthog`
 
 **PostHog MCP Tools:**
 - `mcp__posthog__insight-query` - Query insights (trends, funnels, retention, paths, lifecycle)
@@ -950,7 +950,7 @@ See also: `catalyst-analytics` plugin for analytics-focused workflows
 - "List all blocked tickets and their reasons"
 - "Update ticket LIN-123 to mark it as done"
 
-**Setup:** Run `/connect-mcps connect to linear` (or your PM tool)
+**Setup:** Run `/catalyst-pm:connect-mcps connect to linear` (or your PM tool)
 
 **Tools discovered:** create_issue, update_issue, search_issues, get_project_status
 
@@ -1217,7 +1217,7 @@ The `catalyst-analytics` plugin provides analytics-focused workflows that levera
 
 ## What Happens Behind the Scenes
 
-When you run `/connect-mcps connect to posthog`:
+When you run `/catalyst-pm:connect-mcps connect to posthog`:
 
 1. **I search the web** for PostHog MCP documentation
 2. **I parse** the results to extract setup requirements
@@ -1240,7 +1240,7 @@ All of this happens automatically in seconds. You just provide credentials and I
 
 ```
 
-/connect-mcps connect to [your analytics tool]
+/catalyst-pm:connect-mcps connect to [your analytics tool]
 
 ```
 

--- a/plugins/pm/skills/context-daily/SKILL.md
+++ b/plugins/pm/skills/context-daily/SKILL.md
@@ -301,7 +301,7 @@ Show the user:
 ## Example Interaction Flow
 
 ```
-User: /context-daily
+User: /catalyst-pm:context-daily
 Assistant: [Runs prerequisites check]
 
 [Creates task list with TodoWrite]

--- a/plugins/pm/skills/daily-plan/SKILL.md
+++ b/plugins/pm/skills/daily-plan/SKILL.md
@@ -622,18 +622,18 @@ When user runs `/daily-plan tomorrow`:
 **Google Calendar MCP:**
 
 ```
-1. Run: /connect-mcps connect to google-calendar
+1. Run: /catalyst-pm:connect-mcps connect to google-calendar
 2. I'll first check for official remote MCP server
 3. If remote server available: Guide you to use `claude mcp add --transport http`
 4. If not: Walk you through OAuth setup (credentials from Google Cloud Console)
 5. Test: I'll fetch today's events to confirm it works
-6. Done! Future /daily-plan calls will auto-fetch meetings
+6. Done! Future /catalyst-pm:daily-plan calls will auto-fetch meetings
 ```
 
 **Gmail MCP:**
 
 ```
-1. Run: /connect-mcps connect to gmail
+1. Run: /catalyst-pm:connect-mcps connect to gmail
 2. Similar priority: Check remote server first, then OAuth flow
 3. Permissions needed: Read email (not send)
 4. I'll fetch unread/important emails for daily context
@@ -642,7 +642,7 @@ When user runs `/daily-plan tomorrow`:
 **Linear MCP:**
 
 ```
-1. Run: /connect-mcps connect to linear (or linear)
+1. Run: /catalyst-pm:connect-mcps connect to linear (or linear)
 2. I'll check for remote servers, then fall back to API keys
 3. You'll need: API key from Linear settings (if no remote server)
 4. I'll query your assigned tasks daily
@@ -651,7 +651,7 @@ When user runs `/daily-plan tomorrow`:
 **Analytics MCP (PostHog/PostHog):**
 
 ```
-1. Run: /connect-mcps connect to posthog (or posthog)
+1. Run: /catalyst-pm:connect-mcps connect to posthog (or posthog)
 2. I'll check remote servers first, then manual setup
 3. You'll need: API key + Project ID (if manual)
 4. I'll pull metrics for recently launched features


### PR DESCRIPTION
## Summary

- Adds fully-qualified `plugin-name:skill-name` prefixes to all user-facing skill references across 24 SKILL.md files in all 5 plugins (dev, pm, meta, debugging, analytics)
- Adds `.claude/rules/skill-references.md` rule to enforce correct prefixing in future skill authoring
- Fixes typo: `implement_plan` → `implement-plan` in create-worktree

## Context

Plugin skills in Claude Code always require the fully-qualified `plugin-name:skill-name` form for invocation (e.g., `/catalyst-dev:create-plan`, not `/create-plan`). A previous cleanup removed these prefixes when an autocomplete bug temporarily hid them, but the invocation system always required the full form. This PR restores the correct prefixes in all user-facing contexts: output templates, error messages, example invocations, humanlayer launch args, and "See also" sections.

Explanatory prose (e.g., "Called by /implement-plan as part of quality gates") retains bare names for readability since those aren't typed by users.

## Test plan

- [ ] Restart Claude Code and invoke `/catalyst-dev:create-handoff` — verify the output template shows `/catalyst-dev:resume-handoff` (not bare `/resume-handoff`)
- [ ] Check autocomplete shows prefixed skill names in the slash menu
- [ ] Verify the `.claude/rules/skill-references.md` rule loads as a system-reminder in new sessions