### PR TITLE
feat(dev): add global orchestrator state, event log, and token tracking

### DIFF
--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -105,3 +105,54 @@ by org/repo.
 - Falls back to `~/wt/<repo>` if `GITHUB_SOURCE_ROOT` not set
 - No hardcoded paths in scripts or documentation
 - Clean organization by org and repo
+
+---
+
+## ADR-006: Global Orchestrator State
+
+**Decision**: Maintain a single `~/catalyst/state.json` file as a global registry of all active
+orchestrators, with an append-only event log at `~/catalyst/events/YYYY-MM.jsonl` and completed
+orchestrator snapshots archived to `~/catalyst/history/`.
+
+**Rationale**:
+
+- Multiple orchestrators can run concurrently across different projects
+- Per-orchestrator local state (`state.json` in each worktree) serves crash recovery but provides no
+  cross-orchestrator visibility
+- Users and agents need a single place to answer "what is Catalyst doing right now?"
+- The file must be queryable via `jq` and consumable by dashboards (terminal, web)
+- A heartbeat pattern detects orchestrators that died without clean shutdown
+
+**Design**:
+
+```
+~/catalyst/
+├── state.json              # Global registry (active orchestrators only)
+├── events/                 # Append-only event stream, rotated monthly
+│   ├── 2026-03.jsonl
+│   └── 2026-04.jsonl
+├── history/                # Archived orchestrator snapshots
+│   └── <id>--<timestamp>.json
+└── wt/                     # Worktrees (existing, unchanged)
+```
+
+- **Global state** is a denormalized summary optimized for queries — not a replacement for local
+  state. Per-orchestrator `state.json` in worktrees continues to serve crash recovery.
+- **Writes** go through `catalyst-state.sh` which uses `mkdir`-based locking (portable, no `flock`
+  dependency) for atomic read-modify-write.
+- **Events** are appended without locking (POSIX atomic append for small writes). Monthly rotation
+  keeps files small. All event files are JSONL, so `cat *.jsonl | jq` queries across them.
+- **History** holds full orchestrator snapshots at completion/failure/abandonment. Keyed by
+  `<id>--<startedAt>` for uniqueness across reruns.
+- **Heartbeat**: Orchestrators write `lastHeartbeat` during each monitoring poll (every 2-3 min).
+  `catalyst-state.sh gc` detects entries with heartbeats older than 10 minutes and archives them as
+  `abandoned`.
+
+**Consequences**:
+
+- Orchestrators must register at startup and heartbeat during monitoring
+- Workers update both their signal file (local) and the global state (via `catalyst-state.sh`)
+- Agents can answer status questions by reading `~/catalyst/state.json` directly
+- Dashboards (terminal, web) have a stable JSON contract to build against
+- The schemas at `plugins/dev/templates/global-state.json` and `global-event.json` define the
+  contract for forward compatibility

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,32 @@ Structure:
 
 Management: Automatically updated by workflow skills. Tracked per-worktree (not committed to git).
 
+## Global Orchestrator State
+
+Cross-orchestrator visibility lives at `~/catalyst/state.json` — a single JSON file that all
+orchestrators and workers write to via `catalyst-state.sh` (lock-protected).
+
+```
+~/catalyst/
+├── state.json              # Active orchestrators (denormalized summary)
+├── events/                 # Append-only JSONL event stream, rotated monthly
+│   └── YYYY-MM.jsonl
+├── history/                # Archived orchestrator snapshots
+│   └── <id>--<timestamp>.json
+└── wt/                     # Worktrees (existing)
+```
+
+- **state.json**: Registry of active orchestrators with progress, worker status, and attention
+  items. Queryable with `jq`. Schema: `plugins/dev/templates/global-state.json`.
+- **events/**: Every phase transition, PR creation, verification result, and attention item is
+  logged as a JSONL entry. Schema: `plugins/dev/templates/global-event.json`.
+- **history/**: Full orchestrator snapshots archived on completion, failure, or stale detection.
+- **Heartbeat**: Orchestrators write `lastHeartbeat` every 2-3 min. Stale entries (>10 min) are
+  garbage-collected as `abandoned`.
+
+This is a denormalized summary layer — per-orchestrator local state in worktrees remains the
+source of truth for crash recovery. See ADR-006 for the full design decision.
+
 ## Three-Layer Memory Architecture
 
 Catalyst uses a three-layer memory architecture to manage context across multiple projects:

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+# catalyst-state.sh — Manage global orchestrator state at ~/catalyst/state.json
+#
+# Provides flock-protected read-modify-write for concurrent orchestrators and workers.
+# Also manages the append-only event log at ~/catalyst/events/YYYY-MM.jsonl
+# and history archival at ~/catalyst/history/.
+#
+# Usage:
+#   catalyst-state.sh init                                    Initialize state file if missing
+#   catalyst-state.sh register <orch-id> <json>               Register a new orchestrator
+#   catalyst-state.sh update <orch-id> <jq-filter>            Update orchestrator fields
+#   catalyst-state.sh worker <orch-id> <ticket-id> <jq-filter> Update a worker entry
+#   catalyst-state.sh heartbeat <orch-id>                     Update lastHeartbeat timestamp
+#   catalyst-state.sh attention <orch-id> <type> <ticket> <msg> Add attention item
+#   catalyst-state.sh resolve-attention <orch-id> <ticket>    Remove attention for a ticket
+#   catalyst-state.sh event <json>                            Append event to the log
+#   catalyst-state.sh archive <orch-id>                       Move orchestrator to history
+#   catalyst-state.sh gc [--stale-after <minutes>] [--events-older-than <months>]  Garbage collect
+#   catalyst-state.sh status [--project <key>]                Print summary of active orchestrators
+#   catalyst-state.sh query <jq-filter>                       Run a jq query against state.json
+#   catalyst-state.sh events [--last <n>] [--ticket <id>] [--type <event-type>]  Query events
+
+set -euo pipefail
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+STATE_FILE="${CATALYST_STATE_FILE:-$CATALYST_DIR/state.json}"
+LOCK_FILE="${STATE_FILE}.lock"
+EVENTS_DIR="${CATALYST_DIR}/events"
+HISTORY_DIR="${CATALYST_DIR}/history"
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+now_iso() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+ensure_dirs() {
+  mkdir -p "$CATALYST_DIR" "$EVENTS_DIR" "$HISTORY_DIR"
+}
+
+ensure_state_file() {
+  ensure_dirs
+  if [[ ! -f "$STATE_FILE" ]]; then
+    cat > "$STATE_FILE" <<'INIT'
+{
+  "version": "1.0.0",
+  "lastUpdated": "",
+  "orchestrators": {}
+}
+INIT
+    jq --arg now "$(now_iso)" '.lastUpdated = $now' "$STATE_FILE" > "${STATE_FILE}.tmp" \
+      && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  fi
+}
+
+# Portable lock acquire/release using mkdir (atomic on all POSIX systems).
+# Falls back to flock on Linux where available.
+lock_acquire() {
+  local max_wait=10
+  local waited=0
+  while ! mkdir "$LOCK_FILE" 2>/dev/null; do
+    if [[ $waited -ge $max_wait ]]; then
+      echo "error: failed to acquire state lock after ${max_wait}s" >&2
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  trap 'rmdir "$LOCK_FILE" 2>/dev/null' EXIT
+}
+
+lock_release() {
+  rmdir "$LOCK_FILE" 2>/dev/null || true
+  trap - EXIT
+}
+
+# Lock-protected read-modify-write on state.json
+# $1: jq filter (receives $now as a bound variable)
+state_write() {
+  local jq_filter="$1"
+  shift
+  ensure_state_file
+  lock_acquire
+  jq --arg now "$(now_iso)" "$@" \
+     "${jq_filter} | .lastUpdated = \$now" \
+     "$STATE_FILE" > "${STATE_FILE}.tmp" \
+  && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  lock_release
+}
+
+# Append a single JSON line to the current month's event log.
+# No locking needed — POSIX atomic append for small writes.
+event_append() {
+  local event_json="$1"
+  ensure_dirs
+  local month_file="${EVENTS_DIR}/$(date -u +%Y-%m).jsonl"
+  echo "$event_json" >> "$month_file"
+}
+
+# ─── Commands ─────────────────────────────────────────────────────────────────
+
+cmd_init() {
+  ensure_state_file
+  echo "Initialized $STATE_FILE"
+}
+
+cmd_register() {
+  local orch_id="$1"
+  local orch_json="$2"
+
+  # Merge the provided JSON into the orchestrators map
+  state_write \
+    '.orchestrators[$id] = ($orch | fromjson) | .orchestrators[$id].updatedAt = $now | .orchestrators[$id].lastHeartbeat = $now' \
+    --arg id "$orch_id" \
+    --arg orch "$orch_json"
+
+  # Emit event
+  local tickets
+  tickets=$(echo "$orch_json" | jq -c '[.workers // {} | keys[]]')
+  event_append "$(jq -nc \
+    --arg ts "$(now_iso)" \
+    --arg orch "$orch_id" \
+    --argjson tickets "$tickets" \
+    '{ts: $ts, orchestrator: $orch, worker: null, event: "orchestrator-started", detail: {tickets: $tickets}}')"
+}
+
+cmd_update() {
+  local orch_id="$1"
+  local jq_filter="$2"
+
+  state_write \
+    ".orchestrators[\$id] |= (${jq_filter} | .updatedAt = \$now)" \
+    --arg id "$orch_id"
+}
+
+cmd_worker() {
+  local orch_id="$1"
+  local ticket_id="$2"
+  local jq_filter="$3"
+
+  state_write \
+    ".orchestrators[\$oid].workers[\$tid] |= (${jq_filter} | .updatedAt = \$now) | .orchestrators[\$oid].updatedAt = \$now" \
+    --arg oid "$orch_id" \
+    --arg tid "$ticket_id"
+}
+
+cmd_heartbeat() {
+  local orch_id="$1"
+
+  state_write \
+    '.orchestrators[$id].lastHeartbeat = $now | .orchestrators[$id].updatedAt = $now' \
+    --arg id "$orch_id"
+}
+
+cmd_attention() {
+  local orch_id="$1"
+  local attn_type="$2"
+  local ticket_id="$3"
+  local message="$4"
+
+  # Add attention item to the orchestrator and mark the worker
+  state_write \
+    '.orchestrators[$oid].attention = ([{type: $atype, ticketId: $tid, message: $msg, since: $now}] + .orchestrators[$oid].attention)
+     | .orchestrators[$oid].workers[$tid].needsAttention = true
+     | .orchestrators[$oid].workers[$tid].attentionReason = $msg
+     | .orchestrators[$oid].updatedAt = $now' \
+    --arg oid "$orch_id" \
+    --arg atype "$attn_type" \
+    --arg tid "$ticket_id" \
+    --arg msg "$message"
+
+  # Emit event
+  event_append "$(jq -nc \
+    --arg ts "$(now_iso)" \
+    --arg orch "$orch_id" \
+    --arg worker "$ticket_id" \
+    --arg atype "$attn_type" \
+    --arg msg "$message" \
+    '{ts: $ts, orchestrator: $orch, worker: $worker, event: "attention-raised", detail: {attentionType: $atype, reason: $msg}}')"
+}
+
+cmd_resolve_attention() {
+  local orch_id="$1"
+  local ticket_id="$2"
+
+  state_write \
+    '.orchestrators[$oid].attention = [.orchestrators[$oid].attention[] | select(.ticketId != $tid)]
+     | .orchestrators[$oid].workers[$tid].needsAttention = false
+     | .orchestrators[$oid].workers[$tid].attentionReason = null
+     | .orchestrators[$oid].updatedAt = $now' \
+    --arg oid "$orch_id" \
+    --arg tid "$ticket_id"
+
+  # Emit event
+  event_append "$(jq -nc \
+    --arg ts "$(now_iso)" \
+    --arg orch "$orch_id" \
+    --arg worker "$ticket_id" \
+    '{ts: $ts, orchestrator: $orch, worker: $worker, event: "attention-resolved", detail: null}')"
+}
+
+cmd_event() {
+  local event_json="$1"
+  event_append "$event_json"
+}
+
+cmd_archive() {
+  local orch_id="$1"
+
+  ensure_dirs
+  lock_acquire
+
+  # Extract the orchestrator entry
+  local started_at
+  started_at=$(jq -r ".orchestrators[\"$orch_id\"].startedAt // empty" "$STATE_FILE")
+  if [[ -z "$started_at" ]]; then
+    lock_release
+    echo "error: orchestrator '$orch_id' not found in state" >&2
+    return 1
+  fi
+
+  # Sanitize timestamp for filename (replace colons)
+  local ts_safe="${started_at//:/-}"
+
+  # Write to history
+  jq ".orchestrators[\"$orch_id\"]" "$STATE_FILE" > "${HISTORY_DIR}/${orch_id}--${ts_safe}.json"
+
+  # Remove from active state
+  jq --arg now "$(now_iso)" --arg id "$orch_id" \
+     'del(.orchestrators[$id]) | .lastUpdated = $now' \
+     "$STATE_FILE" > "${STATE_FILE}.tmp" \
+  && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+
+  lock_release
+
+  # Emit event
+  event_append "$(jq -nc \
+    --arg ts "$(now_iso)" \
+    --arg orch "$orch_id" \
+    '{ts: $ts, orchestrator: $orch, worker: null, event: "archive", detail: null}')"
+
+  echo "Archived $orch_id to ${HISTORY_DIR}/"
+}
+
+cmd_gc() {
+  local stale_minutes=10
+  local events_months=6
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --stale-after) stale_minutes="$2"; shift 2 ;;
+      --events-older-than) events_months="${2%m}"; shift 2 ;;  # strip trailing 'm' if present
+      *) echo "Unknown gc flag: $1" >&2; return 1 ;;
+    esac
+  done
+
+  ensure_state_file
+
+  # Find and archive stale orchestrators (heartbeat older than threshold)
+  local cutoff_ts
+  cutoff_ts=$(date -u -v-${stale_minutes}M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "${stale_minutes} minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+
+  local stale_ids
+  stale_ids=$(jq -r --arg cutoff "$cutoff_ts" \
+    '.orchestrators | to_entries[]
+     | select(.value.status == "active" and .value.lastHeartbeat < $cutoff)
+     | .key' "$STATE_FILE")
+
+  for id in $stale_ids; do
+    echo "Marking stale orchestrator: $id"
+    cmd_update "$id" '.status = "abandoned"'
+
+    event_append "$(jq -nc \
+      --arg ts "$(now_iso)" \
+      --arg orch "$id" \
+      '{ts: $ts, orchestrator: $orch, worker: null, event: "orchestrator-failed", detail: {reason: "heartbeat expired — presumed dead"}}')"
+
+    cmd_archive "$id"
+  done
+
+  # Prune old event files
+  local cutoff_month
+  cutoff_month=$(date -u -v-${events_months}m +%Y-%m 2>/dev/null \
+    || date -u -d "${events_months} months ago" +%Y-%m)
+
+  for f in "$EVENTS_DIR"/*.jsonl; do
+    [[ ! -f "$f" ]] && continue
+    local basename
+    basename=$(basename "$f" .jsonl)
+    if [[ "$basename" < "$cutoff_month" ]]; then
+      echo "Removing old event log: $f"
+      rm "$f"
+    fi
+  done
+}
+
+cmd_status() {
+  local project_filter=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --project) project_filter="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  ensure_state_file
+
+  if [[ -n "$project_filter" ]]; then
+    jq --arg proj "$project_filter" '
+      .orchestrators | to_entries
+      | map(select(.value.projectKey == $proj))
+      | from_entries
+      | to_entries[]
+      | {
+          id: .key,
+          status: .value.status,
+          progress: "\(.value.progress.completedTickets)/\(.value.progress.totalTickets) done",
+          wave: "\(.value.progress.currentWave)/\(.value.progress.totalWaves)",
+          attention: (.value.attention | length),
+          lastHeartbeat: .value.lastHeartbeat
+        }
+    ' "$STATE_FILE"
+  else
+    jq '
+      .orchestrators | to_entries[]
+      | {
+          id: .key,
+          project: .value.projectKey,
+          status: .value.status,
+          progress: "\(.value.progress.completedTickets)/\(.value.progress.totalTickets) done",
+          wave: "\(.value.progress.currentWave)/\(.value.progress.totalWaves)",
+          attention: (.value.attention | length),
+          lastHeartbeat: .value.lastHeartbeat
+        }
+    ' "$STATE_FILE"
+  fi
+}
+
+cmd_query() {
+  local jq_filter="$1"
+  ensure_state_file
+  jq "$jq_filter" "$STATE_FILE"
+}
+
+cmd_events() {
+  local last_n=""
+  local ticket_filter=""
+  local type_filter=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --last) last_n="$2"; shift 2 ;;
+      --ticket) ticket_filter="$2"; shift 2 ;;
+      --type) type_filter="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  ensure_dirs
+
+  # Concatenate all event files in chronological order
+  local all_events
+  all_events=$(cat "$EVENTS_DIR"/*.jsonl 2>/dev/null || true)
+
+  if [[ -z "$all_events" ]]; then
+    echo "No events found."
+    return 0
+  fi
+
+  # Build jq filter
+  local filter="."
+  if [[ -n "$ticket_filter" ]]; then
+    filter="${filter} | select(.worker == \"$ticket_filter\" or (.detail.tickets // [] | index(\"$ticket_filter\")))"
+  fi
+  if [[ -n "$type_filter" ]]; then
+    filter="${filter} | select(.event == \"$type_filter\")"
+  fi
+
+  if [[ -n "$last_n" ]]; then
+    echo "$all_events" | jq -s "[.[] | ${filter}] | .[-${last_n}:][]"
+  else
+    echo "$all_events" | jq "$filter"
+  fi
+}
+
+# ─── Dispatch ─────────────────────────────────────────────────────────────────
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+  init)               cmd_init ;;
+  register)           cmd_register "$@" ;;
+  update)             cmd_update "$@" ;;
+  worker)             cmd_worker "$@" ;;
+  heartbeat)          cmd_heartbeat "$@" ;;
+  attention)          cmd_attention "$@" ;;
+  resolve-attention)  cmd_resolve_attention "$@" ;;
+  event)              cmd_event "$@" ;;
+  archive)            cmd_archive "$@" ;;
+  gc)                 cmd_gc "$@" ;;
+  status)             cmd_status "$@" ;;
+  query)              cmd_query "$@" ;;
+  events)             cmd_events "$@" ;;
+  help|--help|-h)
+    echo "Usage: catalyst-state.sh <command> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  init                                    Initialize ~/catalyst/state.json"
+    echo "  register <orch-id> <json>               Register a new orchestrator"
+    echo "  update <orch-id> <jq-filter>            Update orchestrator fields"
+    echo "  worker <orch-id> <ticket> <jq-filter>   Update a worker entry"
+    echo "  heartbeat <orch-id>                     Update heartbeat timestamp"
+    echo "  attention <orch-id> <type> <ticket> <msg>  Flag item for human attention"
+    echo "  resolve-attention <orch-id> <ticket>    Clear attention for a ticket"
+    echo "  event <json>                            Append event to the log"
+    echo "  archive <orch-id>                       Move orchestrator to history"
+    echo "  gc [--stale-after <min>] [--events-older-than <months>]  Clean up"
+    echo "  status [--project <key>]                Print active orchestrator summary"
+    echo "  query <jq-filter>                       Run jq query against state.json"
+    echo "  events [--last <n>] [--ticket <id>] [--type <event-type>]  Query events"
+    ;;
+  *)
+    echo "Unknown command: $cmd" >&2
+    echo "Run 'catalyst-state.sh help' for usage." >&2
+    exit 1
+    ;;
+esac

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -75,7 +75,10 @@ signal file** so the orchestrator can track progress and run adversarial verific
 # 1. CATALYST_ORCHESTRATOR_DIR env var (set by orchestrator in dispatch)
 ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
 
-# 2. Sibling directory with workers/ subdirectory (convention-based)
+# 2. CATALYST_ORCHESTRATOR_ID env var (set by orchestrator in dispatch)
+ORCH_ID="${CATALYST_ORCHESTRATOR_ID:-}"
+
+# 3. Sibling directory with workers/ subdirectory (convention-based)
 if [ -z "$ORCH_DIR" ]; then
   PARENT=$(dirname "$(pwd)")
   for DIR in "$PARENT"/*/workers; do
@@ -85,25 +88,80 @@ if [ -z "$ORCH_DIR" ]; then
     fi
   done
 fi
+
+# Resolve global state script path
+STATE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-state.sh"
 ```
 
 If `ORCH_DIR` is detected, the worker:
 
 1. **Reads its signal file** from `${ORCH_DIR}/workers/${TICKET_ID}.json` (created by orchestrator)
-2. **Updates status at each phase transition** — writes `status`, `phase`, and `updatedAt`
-3. **Fills `definitionOfDone`** at Phase 4 (validation) and Phase 5 (ship) with actual results
-4. **Reads wave briefing** if referenced in `${ORCH_DIR}/wave-*-briefing.md` before starting
+2. **Updates status at each phase transition** — writes `status`, `phase`, and `updatedAt` to both
+   the local signal file AND the global state at `~/catalyst/state.json`
+3. **Emits events** to the global event log at each phase transition
+4. **Fills `definitionOfDone`** at Phase 4 (validation) and Phase 5 (ship) with actual results
+5. **Reads wave briefing** if referenced in `${ORCH_DIR}/wave-*-briefing.md` before starting
 
-**Signal file update helper** (run at each phase boundary):
+**Signal file + global state update helper** (run at each phase boundary):
 
 ```bash
 SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET_ID}.json"
 if [ -f "$SIGNAL_FILE" ]; then
+  OLD_STATUS=$(jq -r '.status' "$SIGNAL_FILE")
+
+  # Update local signal file
   jq --arg status "$NEW_STATUS" \
      --arg phase "$PHASE_NUM" \
      --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
      '.status = $status | .phase = ($phase | tonumber) | .updatedAt = $updated' \
      "$SIGNAL_FILE" > "${SIGNAL_FILE}.tmp" && mv "${SIGNAL_FILE}.tmp" "$SIGNAL_FILE"
+
+  # Update global state (if orchestrator ID is known)
+  if [ -n "$ORCH_ID" ] && [ -f "$STATE_SCRIPT" ]; then
+    "$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET_ID" \
+      ".status = \"$NEW_STATUS\" | .phase = $PHASE_NUM"
+
+    # Emit status change event
+    "$STATE_SCRIPT" event "$(jq -nc \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg orch "$ORCH_ID" \
+      --arg w "$TICKET_ID" \
+      --arg from "$OLD_STATUS" \
+      --arg to "$NEW_STATUS" \
+      '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-status-change", detail: {from: $from, to: $to}}')"
+  fi
+fi
+```
+
+**When worker creates a PR**, also update global state with PR details:
+
+```bash
+if [ -n "$ORCH_ID" ] && [ -f "$STATE_SCRIPT" ]; then
+  "$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET_ID" \
+    ".pr = {number: ${PR_NUMBER}, url: \"${PR_URL}\", ciStatus: \"pending\"}"
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg orch "$ORCH_ID" --arg w "$TICKET_ID" \
+    --argjson pr "$PR_NUMBER" --arg url "$PR_URL" \
+    '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-pr-created", detail: {pr: $pr, url: $url}}')"
+fi
+```
+
+**When worker reaches terminal state** (done or failed):
+
+```bash
+if [ -n "$ORCH_ID" ] && [ -f "$STATE_SCRIPT" ]; then
+  if [ "$NEW_STATUS" = "done" ]; then
+    "$STATE_SCRIPT" event "$(jq -nc --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg orch "$ORCH_ID" --arg w "$TICKET_ID" \
+      '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-done", detail: null}')"
+  elif [ "$NEW_STATUS" = "failed" ]; then
+    "$STATE_SCRIPT" event "$(jq -nc --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg orch "$ORCH_ID" --arg w "$TICKET_ID" --arg reason "$ERROR_MSG" \
+      '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-failed", detail: {reason: $reason}}')"
+    "$STATE_SCRIPT" attention "$ORCH_ID" "waiting-for-user" "$TICKET_ID" \
+      "Worker failed: ${ERROR_MSG}"
+  fi
 fi
 ```
 

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -327,6 +327,46 @@ Initialize `state.json`:
 }
 ```
 
+**Register with global state** (immediately after local state initialization):
+
+```bash
+STATE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-state.sh"
+
+# Build the registration JSON with all workers from all waves
+WORKERS_JSON="{}"
+for TICKET_ID in "${ALL_TICKETS[@]}"; do
+  TITLE=$(linearis issues get "$TICKET_ID" --json title --quiet | jq -r '.title')
+  WORKERS_JSON=$(echo "$WORKERS_JSON" | jq \
+    --arg tid "$TICKET_ID" --arg title "$TITLE" \
+    '. + {($tid): {ticketId: $tid, title: $title, status: "dispatched", phase: 0, branch: null, pr: null, updatedAt: "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", needsAttention: false, attentionReason: null}}')
+done
+
+# Detect repository from git remote
+REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
+
+"$STATE_SCRIPT" register "${ORCH_NAME}" "$(jq -nc \
+  --arg id "${ORCH_NAME}" \
+  --arg pk "$(jq -r '.catalyst.projectKey // "unknown"' "$CONFIG_FILE")" \
+  --arg repo "$REPO" \
+  --arg bb "${BASE_BRANCH}" \
+  --arg wtd "${ORCH_DIR}" \
+  --arg sf "${ORCH_DIR}/state.json" \
+  --argjson total "${#ALL_TICKETS[@]}" \
+  --argjson waves "$TOTAL_WAVES" \
+  --argjson workers "$WORKERS_JSON" \
+  '{
+    id: $id, projectKey: $pk, repository: $repo, baseBranch: $bb,
+    status: "active", startedAt: (now | strftime("%Y-%m-%dT%H:%M:%SZ")),
+    worktreeDir: $wtd, stateFile: $sf,
+    progress: {totalTickets: $total, completedTickets: 0, failedTickets: 0, inProgressTickets: 0, currentWave: 1, totalWaves: $waves},
+    usage: {inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, costUSD: 0, numTurns: 0, durationMs: 0, durationApiMs: 0, model: null},
+    workers: $workers, attention: []
+  }')"
+```
+
+The `CATALYST_ORCHESTRATOR_ID` is set to `${ORCH_NAME}` for use by workers (passed via
+environment variable alongside `CATALYST_ORCHESTRATOR_DIR`).
+
 ### Phase 3: Dispatch Workers
 
 For each provisioned worker worktree, dispatch a `/oneshot` session.
@@ -338,6 +378,7 @@ For each provisioned worker worktree, dispatch a `/oneshot` session.
    WORKER_DIR="${WORKTREES_BASE}/${ORCH_NAME}-${TICKET_ID}"
 
    CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
+   CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
    humanlayer launch \
      --model "${WORKER_MODEL}" \
      --title "${ORCH_NAME}-${TICKET_ID}" \
@@ -345,14 +386,68 @@ For each provisioned worker worktree, dispatch a `/oneshot` session.
      "${WORKER_COMMAND} ${TICKET_ID} --auto-merge"
    ```
 
-2. **Direct `claude` CLI** (fallback):
+2. **Direct `claude` CLI** (fallback — includes usage capture):
    ```bash
+   WORKER_OUTPUT="${ORCH_DIR}/workers/${TICKET_ID}-output.json"
+
    CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
+   CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
    claude \
      -n "${ORCH_NAME}-${TICKET_ID}" \
      -w "${WORKER_DIR}" \
-     -p "${WORKER_COMMAND} ${TICKET_ID} --auto-merge" &
+     --output-format json \
+     -p "${WORKER_COMMAND} ${TICKET_ID} --auto-merge" \
+     > "$WORKER_OUTPUT" 2>/dev/null &
    ```
+
+   When the worker process exits, parse usage from its output:
+
+   ```bash
+   # After worker PID exits, extract usage and write to global state
+   if [ -f "$WORKER_OUTPUT" ]; then
+     USAGE=$(jq -c '{
+       inputTokens: .usage.input_tokens,
+       outputTokens: .usage.output_tokens,
+       cacheReadTokens: .usage.cache_read_input_tokens,
+       cacheCreationTokens: .usage.cache_creation_input_tokens,
+       costUSD: .total_cost_usd,
+       numTurns: .num_turns,
+       durationMs: .duration_ms,
+       durationApiMs: .duration_api_ms,
+       model: (.modelUsage | keys[0] // null)
+     }' "$WORKER_OUTPUT" 2>/dev/null || echo 'null')
+
+     if [ "$USAGE" != "null" ]; then
+       "$STATE_SCRIPT" worker "${ORCH_NAME}" "${TICKET_ID}" ".usage = ${USAGE}"
+
+       # Aggregate into orchestrator-level usage
+       "$STATE_SCRIPT" update "${ORCH_NAME}" "
+         .usage.inputTokens += $(echo "$USAGE" | jq '.inputTokens')
+         | .usage.outputTokens += $(echo "$USAGE" | jq '.outputTokens')
+         | .usage.cacheReadTokens += $(echo "$USAGE" | jq '.cacheReadTokens')
+         | .usage.cacheCreationTokens += $(echo "$USAGE" | jq '.cacheCreationTokens')
+         | .usage.costUSD += $(echo "$USAGE" | jq '.costUSD')
+         | .usage.numTurns += $(echo "$USAGE" | jq '.numTurns')
+         | .usage.durationMs += $(echo "$USAGE" | jq '.durationMs')
+         | .usage.durationApiMs += $(echo "$USAGE" | jq '.durationApiMs')"
+     fi
+   fi
+   ```
+
+   **Note**: Usage capture requires the `claude` CLI fallback path with `--output-format json`.
+   Workers launched via `humanlayer launch` do not currently expose session usage data — their
+   `usage` fields remain null until humanlayer adds this capability.
+
+**Emit dispatch event and update global state** after each worker dispatch:
+
+```bash
+"$STATE_SCRIPT" worker "${ORCH_NAME}" "${TICKET_ID}" '.status = "dispatched" | .phase = 0'
+"$STATE_SCRIPT" update "${ORCH_NAME}" '.progress.inProgressTickets += 1'
+"$STATE_SCRIPT" event "$(jq -nc \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg orch "${ORCH_NAME}" --arg w "${TICKET_ID}" \
+  '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-dispatched", detail: null}')"
+```
 
 **Worker dispatch prompt includes mandatory testing requirements:**
 
@@ -439,6 +534,42 @@ done
 
 **Update `state.json`** with machine-readable state for crash recovery.
 
+**Update global state and heartbeat** after each monitoring poll:
+
+```bash
+# Heartbeat — proves the orchestrator is alive
+"$STATE_SCRIPT" heartbeat "${ORCH_NAME}"
+
+# Sync each worker's status from signal file to global state
+for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
+  TICKET=$(jq -r '.ticket' "$WORKER_SIGNAL")
+  W_STATUS=$(jq -r '.status' "$WORKER_SIGNAL")
+  W_PHASE=$(jq -r '.phase' "$WORKER_SIGNAL")
+  W_BRANCH=$(git -C "${WORKTREE_BASE}/${ORCH_NAME}-${TICKET}" branch --show-current 2>/dev/null || echo "")
+  W_PR=$(jq -c '.pr // null' "$WORKER_SIGNAL")
+
+  "$STATE_SCRIPT" worker "${ORCH_NAME}" "${TICKET}" \
+    ".status = \"${W_STATUS}\" | .phase = ${W_PHASE} | .branch = \"${W_BRANCH}\" | .pr = ${W_PR}"
+done
+
+# Detect stalled workers and raise attention
+for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
+  TICKET=$(jq -r '.ticket' "$WORKER_SIGNAL")
+  W_STATUS=$(jq -r '.status' "$WORKER_SIGNAL")
+  UPDATED=$(jq -r '.updatedAt' "$WORKER_SIGNAL")
+
+  # If no update in 15+ minutes and not in a terminal state, flag as stalled
+  if [[ "$W_STATUS" != "done" && "$W_STATUS" != "failed" && "$W_STATUS" != "stalled" ]]; then
+    STALE_CUTOFF=$(date -u -v-15M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+      || date -u -d "15 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+    if [[ "$UPDATED" < "$STALE_CUTOFF" ]]; then
+      "$STATE_SCRIPT" attention "${ORCH_NAME}" "stalled" "${TICKET}" \
+        "No progress for 15+ minutes (last update: ${UPDATED})"
+    fi
+  fi
+done
+```
+
 ### Phase 5: Independent Verification (Anti-Reward-Hacking)
 
 When a worker signals "done" (PR created, CI green), the orchestrator does NOT trust it.
@@ -465,6 +596,26 @@ The verification script checks:
 5. **Security**: Check for OWASP top 10 patterns in new code.
 6. **Reward hacking scan**: Run `/scan-reward-hacking` on changed files — check for `as any`,
    `@ts-ignore`, void patterns, suppressed errors.
+
+**Emit verification events:**
+
+```bash
+# Before running verification
+"$STATE_SCRIPT" event "$(jq -nc --arg ts "$(now_iso)" --arg orch "${ORCH_NAME}" --arg w "${TICKET_ID}" \
+  '{ts: $ts, orchestrator: $orch, worker: $w, event: "verification-started", detail: null}')"
+
+# After verification
+if [[ $VERIFY_EXIT -eq 0 ]]; then
+  "$STATE_SCRIPT" event "$(jq -nc --arg ts "$(now_iso)" --arg orch "${ORCH_NAME}" --arg w "${TICKET_ID}" \
+    '{ts: $ts, orchestrator: $orch, worker: $w, event: "verification-passed", detail: null}')"
+  "$STATE_SCRIPT" resolve-attention "${ORCH_NAME}" "${TICKET_ID}"
+else
+  "$STATE_SCRIPT" event "$(jq -nc --arg ts "$(now_iso)" --arg orch "${ORCH_NAME}" --arg w "${TICKET_ID}" \
+    '{ts: $ts, orchestrator: $orch, worker: $w, event: "verification-failed", detail: null}')"
+  "$STATE_SCRIPT" attention "${ORCH_NAME}" "verification-failed" "${TICKET_ID}" \
+    "Independent verification found gaps — remediation required"
+fi
+```
 
 **Verification outcomes:**
 
@@ -543,7 +694,19 @@ When ALL tickets in the current wave pass verification:
    discovered by the previous wave. Build ON TOP of these — do not reinvent.
    ```
 
-6. **Update dashboard and state**: Advance `currentWave`, update wave statuses.
+6. **Update dashboard, local state, and global state**: Advance `currentWave`, update wave statuses.
+
+```bash
+# Update global state for wave advancement
+"$STATE_SCRIPT" update "${ORCH_NAME}" \
+  ".progress.currentWave = ${NEXT_WAVE} | .progress.completedTickets += ${COMPLETED_COUNT}"
+"$STATE_SCRIPT" event "$(jq -nc \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg orch "${ORCH_NAME}" \
+  --argjson wave $NEXT_WAVE \
+  --argjson tickets "$(printf '%s\n' "${NEXT_WAVE_TICKETS[@]}" | jq -R . | jq -sc .)" \
+  '{ts: $ts, orchestrator: $orch, worker: null, event: "wave-started", detail: {wave: $wave, tickets: $tickets}}')"
+```
 
 ### Phase 7: Completion
 
@@ -566,7 +729,20 @@ When all waves are complete:
 
 4. **Sync thoughts**: `humanlayer thoughts sync` to persist any shared documents.
 
-5. **Report to user**:
+5. **Complete and archive global state**:
+
+```bash
+# Mark completed in global state
+"$STATE_SCRIPT" update "${ORCH_NAME}" \
+  '.status = "completed" | .completedAt = $now | .progress.completedTickets = .progress.totalTickets | .progress.inProgressTickets = 0'
+"$STATE_SCRIPT" event "$(jq -nc --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg orch "${ORCH_NAME}" \
+  '{ts: $ts, orchestrator: $orch, worker: null, event: "orchestrator-completed", detail: null}')"
+
+# Archive to history (removes from active state)
+"$STATE_SCRIPT" archive "${ORCH_NAME}"
+```
+
+6. **Report to user**:
    ```
    Orchestration Complete — "api-redesign"
 
@@ -580,6 +756,7 @@ When all waves are complete:
      - PROJ-105: as any cast (fixed on retry)
 
    Summary: ${ORCH_DIR}/SUMMARY.md
+   History: ~/catalyst/history/${ORCH_NAME}--<timestamp>.json
    ```
 
 ## Wave Briefing Documents

--- a/plugins/dev/templates/global-event.json
+++ b/plugins/dev/templates/global-event.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$comment": "Event log entry schema — appended to ~/catalyst/events/YYYY-MM.jsonl by catalyst-state.sh.",
+  "type": "object",
+  "required": ["ts", "orchestrator", "event"],
+  "properties": {
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp of the event"
+    },
+    "orchestrator": {
+      "type": "string",
+      "description": "Orchestrator ID that produced this event"
+    },
+    "worker": {
+      "type": ["string", "null"],
+      "description": "Ticket ID of the worker involved (null for orchestrator-level events)"
+    },
+    "event": {
+      "type": "string",
+      "enum": [
+        "orchestrator-started",
+        "orchestrator-completed",
+        "orchestrator-failed",
+        "orchestrator-paused",
+        "orchestrator-resumed",
+        "orchestrator-heartbeat",
+        "wave-started",
+        "wave-completed",
+        "worker-dispatched",
+        "worker-status-change",
+        "worker-pr-created",
+        "worker-done",
+        "worker-failed",
+        "worker-stalled",
+        "verification-started",
+        "verification-passed",
+        "verification-failed",
+        "remediation-started",
+        "attention-raised",
+        "attention-resolved",
+        "worker-usage-captured",
+        "archive"
+      ],
+      "description": "Event type"
+    },
+    "detail": {
+      "type": ["object", "null"],
+      "description": "Event-specific payload (varies by event type)",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Previous status (for status-change events)"
+        },
+        "to": {
+          "type": "string",
+          "description": "New status (for status-change events)"
+        },
+        "wave": {
+          "type": "integer",
+          "description": "Wave number (for wave events)"
+        },
+        "tickets": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Tickets involved (for wave-started, orchestrator-started)"
+        },
+        "pr": {
+          "type": "integer",
+          "description": "PR number (for pr-created events)"
+        },
+        "url": {
+          "type": "string",
+          "description": "URL (for pr-created events)"
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason (for failed, stalled, attention events)"
+        },
+        "attentionType": {
+          "type": "string",
+          "description": "Attention category (for attention-raised events)"
+        }
+      }
+    }
+  }
+}

--- a/plugins/dev/templates/global-state.json
+++ b/plugins/dev/templates/global-state.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$comment": "Global orchestrator state — ~/catalyst/state.json. Written by orchestrators and workers via catalyst-state.sh.",
+  "type": "object",
+  "required": ["version", "lastUpdated", "orchestrators"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0.0",
+      "description": "Schema version for forward compatibility"
+    },
+    "lastUpdated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of last write to this file"
+    },
+    "orchestrators": {
+      "type": "object",
+      "description": "Active orchestrators keyed by orchestrator ID. Completed orchestrators are archived to ~/catalyst/history/.",
+      "additionalProperties": {
+        "$ref": "#/$defs/orchestrator"
+      }
+    }
+  },
+  "$defs": {
+    "orchestrator": {
+      "type": "object",
+      "required": ["id", "projectKey", "repository", "baseBranch", "status", "startedAt", "updatedAt", "lastHeartbeat", "worktreeDir", "stateFile", "progress", "workers", "attention"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique orchestrator name (e.g., 'q2-api-redesign')"
+        },
+        "projectKey": {
+          "type": "string",
+          "description": "Project key from .catalyst/config.json (e.g., 'bravo-1')"
+        },
+        "repository": {
+          "type": "string",
+          "description": "GitHub org/repo (e.g., 'coalesce-labs/bravo-1')"
+        },
+        "baseBranch": {
+          "type": "string",
+          "description": "Git base branch (e.g., 'main')"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["active", "paused", "completed", "failed", "abandoned"],
+          "description": "Orchestrator lifecycle status. 'abandoned' is set by GC when heartbeat expires."
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when orchestrator was created"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of last state change"
+        },
+        "completedAt": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when orchestrator finished (null while active)"
+        },
+        "lastHeartbeat": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of last monitoring poll. Stale if >10 minutes old."
+        },
+        "worktreeDir": {
+          "type": "string",
+          "description": "Absolute path to the orchestrator's worktree directory"
+        },
+        "stateFile": {
+          "type": "string",
+          "description": "Absolute path to the orchestrator's detailed local state.json"
+        },
+        "progress": {
+          "$ref": "#/$defs/progress"
+        },
+        "workers": {
+          "type": "object",
+          "description": "Worker summaries keyed by ticket ID",
+          "additionalProperties": {
+            "$ref": "#/$defs/worker"
+          }
+        },
+        "usage": {
+          "$ref": "#/$defs/usage",
+          "description": "Aggregate token/cost usage across orchestrator + all workers. Updated when worker sessions complete."
+        },
+        "attention": {
+          "type": "array",
+          "description": "Items requiring human attention, ordered newest first",
+          "items": {
+            "$ref": "#/$defs/attentionItem"
+          }
+        }
+      }
+    },
+    "progress": {
+      "type": "object",
+      "required": ["totalTickets", "completedTickets", "failedTickets", "inProgressTickets", "currentWave", "totalWaves"],
+      "properties": {
+        "totalTickets": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total tickets across all waves"
+        },
+        "completedTickets": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Tickets that passed verification and merged"
+        },
+        "failedTickets": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Tickets that failed and were not recovered"
+        },
+        "inProgressTickets": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Tickets currently being worked on"
+        },
+        "currentWave": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Current wave number (1-indexed)"
+        },
+        "totalWaves": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Total number of waves in the plan"
+        }
+      }
+    },
+    "worker": {
+      "type": "object",
+      "required": ["ticketId", "title", "status", "phase", "updatedAt", "needsAttention"],
+      "properties": {
+        "ticketId": {
+          "type": "string",
+          "description": "Linear ticket ID (e.g., 'ACME-101')"
+        },
+        "title": {
+          "type": "string",
+          "description": "Ticket title for display"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["dispatched", "researching", "planning", "implementing", "validating", "shipping", "pr-created", "merging", "done", "failed", "stalled", "remediation"],
+          "description": "Current worker status (mirrors worker-signal.json status enum)"
+        },
+        "phase": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 6,
+          "description": "Current /oneshot phase (0=dispatched through 6=merge)"
+        },
+        "branch": {
+          "type": ["string", "null"],
+          "description": "Git branch name"
+        },
+        "pr": {
+          "type": ["object", "null"],
+          "properties": {
+            "number": { "type": "integer" },
+            "url": { "type": "string", "format": "uri" },
+            "ciStatus": {
+              "type": "string",
+              "enum": ["pending", "passing", "failing", "unknown"]
+            }
+          },
+          "description": "Pull request details (null until PR is created)"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of last status update"
+        },
+        "needsAttention": {
+          "type": "boolean",
+          "description": "True if this worker requires human intervention"
+        },
+        "attentionReason": {
+          "type": ["string", "null"],
+          "description": "Why this worker needs attention (null if needsAttention is false)"
+        },
+        "usage": {
+          "oneOf": [
+            { "$ref": "#/$defs/usage" },
+            { "type": "null" }
+          ],
+          "description": "Token/cost usage for this worker session. Populated when session completes (requires --output-format json capture). Null while in-flight or if usage unavailable."
+        }
+      }
+    },
+    "attentionItem": {
+      "type": "object",
+      "required": ["type", "ticketId", "message", "since"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["needs-review", "verification-failed", "stalled", "merge-conflict", "ci-failing", "waiting-for-user", "remediation"],
+          "description": "Category of attention needed"
+        },
+        "ticketId": {
+          "type": "string",
+          "description": "Ticket that needs attention"
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable description of what needs to happen"
+        },
+        "since": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When this attention item was raised"
+        }
+      }
+    },
+    "usage": {
+      "type": "object",
+      "description": "Token usage and cost tracking. Matches the structure returned by `claude --output-format json`.",
+      "properties": {
+        "inputTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total input tokens (excluding cache)"
+        },
+        "outputTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total output tokens"
+        },
+        "cacheReadTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Tokens served from prompt cache"
+        },
+        "cacheCreationTokens": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Tokens written to prompt cache"
+        },
+        "costUSD": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Total cost in USD"
+        },
+        "numTurns": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of conversational turns"
+        },
+        "durationMs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total wall-clock time in milliseconds"
+        },
+        "durationApiMs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Time spent in API calls in milliseconds"
+        },
+        "model": {
+          "type": ["string", "null"],
+          "description": "Primary model used (e.g., 'claude-opus-4-6')"
+        }
+      }
+    }
+  }
+}

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -449,10 +449,236 @@ Multiple orchestrators can run concurrently. Each gets a unique name that prefix
 └── dash-orch-ACME-201/
 ```
 
+## Global State & Event Log
+
+When multiple orchestrators run concurrently — or you want to check on things after the fact — a single global state file at `~/catalyst/state.json` provides a unified view of all active orchestrators, their workers, and anything that needs your attention.
+
+### File Layout
+
+```
+~/catalyst/
+├── state.json              # Active orchestrators (machine-readable)
+├── events/                 # Append-only event stream, rotated monthly
+│   ├── 2026-03.jsonl
+│   └── 2026-04.jsonl
+├── history/                # Completed/archived orchestrator snapshots
+│   └── q2-api-redesign--2026-04-11T14-00-00Z.json
+└── wt/                     # Worktrees (existing)
+    └── <projectKey>/...
+```
+
+**`state.json`** contains all active orchestrators with their progress, worker status, and attention items. Orchestrators register at startup and heartbeat every 2-3 minutes. Workers update their own entries at each phase transition.
+
+**`events/`** contains append-only JSONL files, rotated monthly. Every significant transition — worker dispatched, status change, PR created, verification passed/failed, attention raised — is logged here. Query across all months with `cat ~/catalyst/events/*.jsonl | jq`.
+
+**`history/`** contains full snapshots of orchestrators after they complete, fail, or are garbage-collected due to stale heartbeats.
+
+### Global State Schema
+
+Each orchestrator entry in `state.json` contains:
+
+```json
+{
+  "id": "q2-api-redesign",
+  "projectKey": "acme",
+  "repository": "acme-corp/api",
+  "status": "active",
+  "lastHeartbeat": "2026-04-11T18:30:00Z",
+  "progress": {
+    "totalTickets": 6,
+    "completedTickets": 3,
+    "currentWave": 2,
+    "totalWaves": 3
+  },
+  "workers": {
+    "ACME-101": {
+      "title": "Add OAuth2 provider",
+      "status": "done",
+      "phase": 6,
+      "pr": { "number": 234, "url": "...", "ciStatus": "passing" },
+      "needsAttention": false
+    },
+    "ACME-105": {
+      "title": "Audit log schema",
+      "status": "stalled",
+      "phase": 3,
+      "needsAttention": true,
+      "attentionReason": "No progress for 15+ minutes"
+    }
+  },
+  "attention": [
+    {
+      "type": "stalled",
+      "ticketId": "ACME-105",
+      "message": "No progress for 15+ minutes",
+      "since": "2026-04-11T17:10:00Z"
+    }
+  ]
+}
+```
+
+The full JSON Schema is at `plugins/dev/templates/global-state.json`. The global state is a denormalized summary — each orchestrator's detailed local state remains at `<worktree>/state.json` for crash recovery.
+
+### Querying with jq
+
+The global state is designed for fast `jq` queries. Here are common patterns:
+
+```bash
+# What needs my attention right now?
+jq '[.orchestrators[].attention[]] | sort_by(.since)' ~/catalyst/state.json
+
+# All active orchestrators at a glance
+jq '.orchestrators[] | {id, status, progress: "\(.progress.completedTickets)/\(.progress.totalTickets)", wave: "\(.progress.currentWave)/\(.progress.totalWaves)"}' ~/catalyst/state.json
+
+# Workers currently in-flight
+jq '[.orchestrators[].workers[] | select(.status != "done" and .status != "failed") | {ticket: .ticketId, title, status, phase}]' ~/catalyst/state.json
+
+# PRs ready for review
+jq '[.orchestrators[].workers[] | select(.status == "pr-created") | {ticket: .ticketId, pr: .pr.url}]' ~/catalyst/state.json
+
+# Filter by project
+jq '[.orchestrators[] | select(.projectKey == "acme")]' ~/catalyst/state.json
+```
+
+### Querying Events
+
+Events are JSONL files (one JSON object per line), so `grep`, `jq`, and standard Unix tools all work:
+
+```bash
+# Last 20 events
+tail -20 ~/catalyst/events/2026-04.jsonl | jq .
+
+# All events for a specific ticket
+grep '"ACME-105"' ~/catalyst/events/*.jsonl | jq .
+
+# All attention events
+cat ~/catalyst/events/*.jsonl | jq 'select(.event == "attention-raised")'
+
+# Timeline for an orchestrator
+grep '"q2-api-redesign"' ~/catalyst/events/*.jsonl | jq -r '"\(.ts) \(.worker // "-") \(.event)"'
+
+# Event types
+cat ~/catalyst/events/*.jsonl | jq -r '.event' | sort | uniq -c | sort -rn
+```
+
+### The catalyst-state.sh CLI
+
+All state reads and writes go through `catalyst-state.sh`, which handles file locking for concurrent access:
+
+```bash
+# View active orchestrators
+catalyst-state.sh status
+
+# Filter by project
+catalyst-state.sh status --project acme
+
+# Run any jq query
+catalyst-state.sh query '.orchestrators | keys'
+
+# Query events
+catalyst-state.sh events --last 10
+catalyst-state.sh events --ticket ACME-105
+catalyst-state.sh events --type verification-failed
+
+# Garbage collect stale orchestrators and old events
+catalyst-state.sh gc --stale-after 10 --events-older-than 6m
+```
+
+Orchestrators and workers call `catalyst-state.sh` internally — you don't need to run it manually unless you're querying or debugging.
+
+### Heartbeat & Stale Detection
+
+Orchestrators write a `lastHeartbeat` timestamp during each monitoring poll (every 2-3 minutes). If an orchestrator dies without clean shutdown (process killed, machine restarts), its heartbeat goes stale.
+
+`catalyst-state.sh gc` detects stale entries (default: heartbeat older than 10 minutes), marks them as `abandoned`, and archives them to `~/catalyst/history/`. Run it manually or let the next orchestrator startup clean up automatically.
+
+### Building Interfaces
+
+The global state JSON is a stable contract designed for building rich interfaces:
+
+**Terminal dashboard** — Simplest approach with `watch`:
+```bash
+watch -n5 'jq ".orchestrators[] | {id, status, progress: \"\(.progress.completedTickets)/\(.progress.totalTickets)\", attention: (.attention | length)}" ~/catalyst/state.json'
+```
+
+**Web dashboard** — Serve `state.json` via a lightweight HTTP server and build a React/Svelte frontend that polls or watches for changes. The schema is documented in `plugins/dev/templates/global-state.json`.
+
+**Agent integration** — Any Claude Code agent can read `~/catalyst/state.json` directly to answer questions like "what's the status of the auth migration?" or "are any workers waiting for me?" without asking the orchestrator.
+
+**Event replay** — The event log in `~/catalyst/events/` gives you a full audit trail. Build timeline views, calculate cycle times, or feed events into analytics. Every event has a timestamp, orchestrator ID, optional worker/ticket ID, and event type — so you can reconstruct the full sequence of what happened in any orchestration run:
+
+```bash
+# Replay an entire orchestration run chronologically
+grep '"q2-api-redesign"' ~/catalyst/events/*.jsonl | jq -r '"\(.ts) [\(.worker // "orch")] \(.event) \(.detail // "" | tostring)"'
+
+# Calculate time from dispatch to PR for each worker
+cat ~/catalyst/events/*.jsonl | jq -s '
+  group_by(.worker) | map(select(.[0].worker != null)) | map({
+    ticket: .[0].worker,
+    dispatched: (map(select(.event == "worker-dispatched")) | .[0].ts),
+    pr_created: (map(select(.event == "worker-pr-created")) | .[0].ts)
+  }) | map(select(.dispatched and .pr_created))'
+
+# Total duration per orchestrator (start to completion)
+cat ~/catalyst/events/*.jsonl | jq -s '
+  group_by(.orchestrator) | map({
+    orchestrator: .[0].orchestrator,
+    started: (map(select(.event == "orchestrator-started")) | .[0].ts),
+    completed: (map(select(.event == "orchestrator-completed")) | .[0].ts)
+  })'
+```
+
+### Token Usage & Cost Tracking
+
+Each orchestrator and worker entry in the global state includes a `usage` block that tracks token consumption and cost:
+
+```json
+{
+  "usage": {
+    "inputTokens": 15420,
+    "outputTokens": 8730,
+    "cacheReadTokens": 42000,
+    "cacheCreationTokens": 29670,
+    "costUSD": 1.47,
+    "numTurns": 23,
+    "durationMs": 847000,
+    "durationApiMs": 312000,
+    "model": "claude-opus-4-6[1m]"
+  }
+}
+```
+
+**How it works**: Workers launched via the `claude` CLI with `--output-format json` produce a JSON output that includes full token counts, cost, and timing. After a worker process exits, the orchestrator parses this output and writes the usage data to both the worker's entry and the orchestrator's aggregate.
+
+**Query patterns**:
+
+```bash
+# Total cost across all active orchestrators
+jq '[.orchestrators[].usage.costUSD] | add' ~/catalyst/state.json
+
+# Cost per worker in an orchestration
+jq '.orchestrators["q2-api-redesign"].workers | to_entries[] | {ticket: .key, cost: .value.usage.costUSD}' ~/catalyst/state.json
+
+# Most expensive workers (from history)
+cat ~/catalyst/history/*.json | jq -s '[.[].workers | to_entries[] | {ticket: .key, cost: .value.usage.costUSD}] | sort_by(.cost) | reverse | .[:10]'
+
+# Average cost per ticket across all historical orchestrations
+cat ~/catalyst/history/*.json | jq -s '[.[].usage.costUSD / .[].progress.totalTickets] | add / length'
+```
+
+**Current limitations**:
+- Workers launched via `humanlayer launch` do not currently expose session usage — their `usage` fields remain null
+- The orchestrator itself cannot capture its own usage from within the session
+- Usage is only captured after a worker process exits, not in real-time
+
+As these tools evolve to expose usage data, the schema is ready to accept it.
+
 ## Error Handling
 
-**Worker crashes or stalls**: The orchestrator detects no progress for 15+ minutes (no commits, no signal updates). It marks the worker as "stalled" on the dashboard and flags it for human decision — it does not auto-restart.
+**Worker crashes or stalls**: The orchestrator detects no progress for 15+ minutes (no commits, no signal updates). It marks the worker as "stalled" on the dashboard, flags it in the global state's `attention` array, and emits an `attention-raised` event. It does not auto-restart — it flags for human decision.
 
-**Orchestrator crash recovery**: All state lives in `state.json` and worker signal files. Resume with `/orchestrate --resume <orch-dir>` to pick up where it left off.
+**Orchestrator crash recovery**: Local state lives in `<worktree>/state.json` + worker signal files. Resume with `/orchestrate --resume <orch-dir>` to pick up where it left off. The orchestrator re-registers itself in the global state on resume.
 
-**Verification failure**: The worker gets specific remediation instructions. The orchestrator re-verifies after fixes. A ticket cannot advance to merge until verification passes.
+**Orchestrator unclean death**: If the orchestrator process dies, its `lastHeartbeat` goes stale. `catalyst-state.sh gc` archives the entry as `abandoned`. Workers that were in-flight may still be running — check their worktrees and signal files manually, or let the next orchestrator pick them up.
+
+**Verification failure**: The worker gets specific remediation instructions. The global state gets an `attention` item with type `verification-failed`. The orchestrator re-verifies after fixes. A ticket cannot advance to merge until verification passes.


### PR DESCRIPTION
## Summary

- Adds `~/catalyst/state.json` as a single global registry of all active orchestrators — queryable with `jq`, consumable by terminal/web dashboards, and readable by any agent
- Adds append-only event log (`~/catalyst/events/YYYY-MM.jsonl`) with monthly rotation for full audit trail and event replay
- Adds history archival (`~/catalyst/history/`) for completed/failed/abandoned orchestrator snapshots
- Adds per-worker token/cost tracking captured from `claude --output-format json`
- Adds `catalyst-state.sh` helper script with portable `mkdir`-based locking for concurrent orchestrator/worker writes

## Details

**New files:**
- `plugins/dev/scripts/catalyst-state.sh` — CLI with 13 subcommands: init, register, update, worker, heartbeat, attention, resolve-attention, event, archive, gc, status, query, events
- `plugins/dev/templates/global-state.json` — JSON Schema for state.json (orchestrator, worker, progress, attention, usage defs)
- `plugins/dev/templates/global-event.json` — JSON Schema for event log entries (22 event types)

**Integration:**
- `orchestrate/SKILL.md` — registers at startup, heartbeats during monitoring, syncs worker status from signal files, emits events for dispatch/verification/wave advancement/completion, archives to history on completion, captures worker token usage from claude CLI output
- `oneshot/SKILL.md` — detects `CATALYST_ORCHESTRATOR_ID` env var, updates global state at each phase transition, emits status-change/pr-created/done/failed events, raises attention on failure

**Documentation:**
- `docs/adrs.md` — ADR-006: Global Orchestrator State
- `docs/architecture.md` — new section on global state layer
- `website/.../orchestration.md` — full user-facing docs: schema reference, jq query cookbook, event querying, catalyst-state.sh CLI reference, heartbeat/stale detection, token tracking, event replay examples, building interfaces guide

## Test plan

- [x] `catalyst-state.sh` tested end-to-end: init → register → worker update → heartbeat → attention → resolve → status → events query → archive → history → gc
- [x] JSON schemas validated with `jq empty`
- [x] Portable locking tested on macOS (mkdir-based, no flock dependency)
- [ ] Integration test with live `/orchestrate` run (requires full orchestration setup)