### PR TITLE
fix(dev): initialize workflow context and OTEL ticket early

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+source_up
+use_otel_context "catalyst"

--- a/plugins/dev/WORKFLOW_CONTEXT.md
+++ b/plugins/dev/WORKFLOW_CONTEXT.md
@@ -227,6 +227,10 @@ workflow-context.sh recent <type>
 workflow-context.sh ticket PROJ-123
 # → Returns: all docs with ticket PROJ-123
 
+# Set current ticket without adding a document
+workflow-context.sh set-ticket PROJ-123
+# → Sets currentTicket and lastUpdated; creates file if needed
+
 # Initialize context file
 workflow-context.sh init
 ```

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -127,6 +127,41 @@ if [ -d ".catalyst" ]; then
 	cp -r .catalyst "$WORKTREE_PATH/"
 fi
 
+# Initialize workflow context with ticket from worktree name (before setup runs)
+# This ensures .catalyst/.workflow-context.json exists with currentTicket set
+# so that direnv's use_otel_context can read it when someone enters the directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
+	# Remove stale workflow-context.json if copied from main repo
+	rm -f "${WORKTREE_PATH}/.catalyst/.workflow-context.json"
+	mkdir -p "${WORKTREE_PATH}/.catalyst"
+
+	# Extract ticket from worktree name (e.g., ENG-123, orch-1-ADV-42)
+	WT_TICKET=""
+	if [[ "$WORKTREE_NAME" =~ ([A-Za-z]+-[0-9]+) ]]; then
+		WT_TICKET=$(echo "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')
+	fi
+
+	(cd "$WORKTREE_PATH" && bash "${SCRIPT_DIR}/workflow-context.sh" init)
+	if [ -n "$WT_TICKET" ]; then
+		(cd "$WORKTREE_PATH" && bash "${SCRIPT_DIR}/workflow-context.sh" set-ticket "$WT_TICKET")
+		echo "📋 Workflow context initialized with ticket: ${WT_TICKET}"
+	else
+		echo "📋 Workflow context initialized (no ticket in worktree name)"
+	fi
+fi
+
+# Generate .envrc for OTEL context (source_up inherits parent profiles)
+OTEL_PROJECT="${PROJECT_KEY:-$REPO_NAME}"
+if command -v direnv >/dev/null 2>&1 && [ ! -f "${WORKTREE_PATH}/.envrc" ]; then
+	cat > "${WORKTREE_PATH}/.envrc" <<EOF
+source_up
+use_otel_context "${OTEL_PROJECT}"
+EOF
+	direnv allow "${WORKTREE_PATH}" 2>/dev/null || true
+	echo "📡 OTEL context configured (.envrc created + allowed)"
+fi
+
 # Change to worktree directory
 cd "$WORKTREE_PATH"
 

--- a/plugins/dev/scripts/test-workflow-context.sh
+++ b/plugins/dev/scripts/test-workflow-context.sh
@@ -9,6 +9,7 @@
 # - Project root resolution from subdirectories
 # - most-recent cross-type query
 # - Null ticket preservation
+# - set-ticket (ticket-only, no document)
 # - Dual-write (hook + skill) behavior
 # - Array ordering invariant (newest-first)
 # - sync-plan-to-thoughts.sh (title, slug, ticket, frontmatter, workflow-context update)
@@ -764,11 +765,40 @@ else
 	fail "resolve-ticket returned '$RESULT', expected 'XYZ-500'"
 fi
 
-# ── Test 30: backward compat — reads from .claude/ if .catalyst/ missing ─
+# ── Test 30: set-ticket sets currentTicket without adding a document ────
+
+run_test "workflow-context.sh set-ticket sets currentTicket without adding a document"
+
+TEST_DIR="$TMPDIR/test30"
+setup_project "$TEST_DIR"
+
+(cd "$TEST_DIR" && bash plugins/dev/scripts/workflow-context.sh set-ticket "PROJ-42")
+
+TICKET=$(cd "$TEST_DIR" && jq -r '.currentTicket' .catalyst/.workflow-context.json)
+UPDATED=$(cd "$TEST_DIR" && jq -r '.lastUpdated' .catalyst/.workflow-context.json)
+RESEARCH_COUNT=$(cd "$TEST_DIR" && jq '.workflow.research | length' .catalyst/.workflow-context.json)
+
+if [[ $TICKET == "PROJ-42" ]]; then
+	pass "currentTicket set to PROJ-42"
+else
+	fail "currentTicket is '$TICKET', expected 'PROJ-42'"
+fi
+if [[ -n $UPDATED && $UPDATED != "" ]]; then
+	pass "lastUpdated is set"
+else
+	fail "lastUpdated should be set after set-ticket"
+fi
+if [[ $RESEARCH_COUNT -eq 0 ]]; then
+	pass "No documents added (workflow arrays empty)"
+else
+	fail "research array has $RESEARCH_COUNT items, expected 0"
+fi
+
+# ── Test 31: backward compat — reads from .claude/ if .catalyst/ missing ─
 
 run_test "workflow-context.sh reads from .claude/ when .catalyst/ doesn't exist"
 
-TEST_DIR="$TMPDIR/test30"
+TEST_DIR="$TMPDIR/test31"
 mkdir -p "$TEST_DIR"
 (
 	cd "$TEST_DIR"

--- a/plugins/dev/scripts/workflow-context.sh
+++ b/plugins/dev/scripts/workflow-context.sh
@@ -87,6 +87,18 @@ get_most_recent() {
 	jq -r '.mostRecentDocument.path // empty' "$CONTEXT_FILE"
 }
 
+# Set current ticket without adding a document
+# Usage: set_ticket <ticket>
+set_ticket() {
+	local ticket="$1"
+	init_context
+	local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	jq --arg ticket "$ticket" --arg ts "$timestamp" \
+		'.currentTicket = $ticket | .lastUpdated = $ts' \
+		"$CONTEXT_FILE" >"${CONTEXT_FILE}.tmp"
+	mv "${CONTEXT_FILE}.tmp" "$CONTEXT_FILE"
+}
+
 # Get documents for ticket
 # Usage: get_by_ticket <ticket>
 get_by_ticket() {
@@ -113,11 +125,14 @@ recent)
 most-recent)
 	get_most_recent
 	;;
+set-ticket)
+	set_ticket "$2"
+	;;
 ticket)
 	get_by_ticket "$2"
 	;;
 *)
-	echo "Usage: $0 {init|add|recent|most-recent|ticket}"
+	echo "Usage: $0 {init|add|recent|most-recent|set-ticket|ticket}"
 	exit 1
 	;;
 esac

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -19,6 +19,11 @@ Code session with full capabilities.
 ## Prerequisites
 
 ```bash
+# 0. Check project setup (thoughts, config, workflow context init)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
+fi
+
 # 1. Validate thoughts system (REQUIRED)
 if [[ ! -d "thoughts/shared" ]]; then
   echo "❌ ERROR: Thoughts system not configured"
@@ -186,30 +191,36 @@ fi
 This phase runs in the current session to allow user interaction during research.
 
 1. **Parse input**: Determine if ticket ID or freeform query
-2. **If ticket**: Read ticket details via Linearis CLI, move to `stateMap.research` (default: "In
+2. **Register ticket in workflow context (REQUIRED if ticket-based)** — immediately after parsing:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" set-ticket "TICKET-ID"
+   ```
+   This ensures `.catalyst/.workflow-context.json` exists and `currentTicket` is set before any
+   other work begins. Downstream skills and hooks depend on this file existing.
+3. **If ticket**: Read ticket details via Linearis CLI, move to `stateMap.research` (default: "In
    Progress")
-3. **If freeform (and NOT `--no-ticket`)**: After research completes, offer to create a Linear
+4. **If freeform (and NOT `--no-ticket`)**: After research completes, offer to create a Linear
    ticket from the findings:
    ```
    Research complete. Would you like to create a Linear ticket from these findings?
    [y/N]
    ```
    If yes, create a ticket via `linearis issue create` using the research summary as description,
-   then track the ticket ID for subsequent phases.
-4. **Conduct research**: Spawn parallel sub-agents (same as `/research-codebase`):
+   then register the ticket ID: `workflow-context.sh set-ticket "NEW-TICKET-ID"`
+5. **Conduct research**: Spawn parallel sub-agents (same as `/research-codebase`):
    - **codebase-locator**: Find relevant files
    - **codebase-analyzer**: Understand current implementation
    - **codebase-pattern-finder**: Find similar patterns
    - **thoughts-locator**: Find existing context (if relevant)
    - **external-research**: Research frameworks/libraries (if relevant)
-5. **Synthesize findings**: Create research document at
+6. **Synthesize findings**: Create research document at
    `thoughts/shared/research/YYYY-MM-DD-{ticket}-{description}.md`
-6. **Sync**: `humanlayer thoughts sync`
-7. **Track in workflow context (REQUIRED)** — substitute actual path and ticket:
+7. **Sync**: `humanlayer thoughts sync`
+8. **Track in workflow context (REQUIRED)** — substitute actual path and ticket:
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "thoughts/shared/research/YYYY-MM-DD-description.md" "TICKET-ID"
    ```
-8. **Verify**: `"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research` must print the
+9. **Verify**: `"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research` must print the
    path
 
 ### Phase 2: Plan (New Session via `humanlayer launch` — Opus)

--- a/plugins/pm/scripts/workflow-context.sh
+++ b/plugins/pm/scripts/workflow-context.sh
@@ -76,6 +76,18 @@ get_most_recent() {
 	jq -r '.mostRecentDocument.path // empty' "$CONTEXT_FILE"
 }
 
+# Set current ticket without adding a document
+# Usage: set_ticket <ticket>
+set_ticket() {
+	local ticket="$1"
+	init_context
+	local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	jq --arg ticket "$ticket" --arg ts "$timestamp" \
+		'.currentTicket = $ticket | .lastUpdated = $ts' \
+		"$CONTEXT_FILE" >"${CONTEXT_FILE}.tmp"
+	mv "${CONTEXT_FILE}.tmp" "$CONTEXT_FILE"
+}
+
 # Get documents for ticket
 # Usage: get_by_ticket <ticket>
 get_by_ticket() {
@@ -96,6 +108,9 @@ init)
 add)
 	add_document "$2" "$3" "${4:-null}"
 	;;
+set-ticket)
+	set_ticket "$2"
+	;;
 recent)
 	get_recent "$2"
 	;;
@@ -106,7 +121,7 @@ ticket)
 	get_by_ticket "$2"
 	;;
 *)
-	echo "Usage: $0 {init|add|recent|most-recent|ticket}"
+	echo "Usage: $0 {init|add|recent|most-recent|set-ticket|ticket}"
 	exit 1
 	;;
 esac

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -195,7 +195,7 @@ Optional. Add this block to enable `/orchestrate` — see [Orchestration](/refer
 
 ## Workflow Context (`.catalyst/.workflow-context.json`)
 
-Auto-managed by Claude Code hooks. Not committed to git.
+Auto-managed by Claude Code hooks and skills. Not committed to git.
 
 ```json
 {
@@ -219,6 +219,54 @@ Auto-managed by Claude Code hooks. Not committed to git.
 This file is what enables skill chaining — when you save research, `create-plan` finds it
 automatically. When you save a plan, `implement-plan` finds it. You never need to specify file paths
 between workflow phases.
+
+### Script API
+
+The `workflow-context.sh` script manages this file programmatically:
+
+```bash
+workflow-context.sh init                    # Create file if missing
+workflow-context.sh set-ticket PROJ-123     # Set currentTicket (no document needed)
+workflow-context.sh add research "path" "PROJ-123"  # Add document + set ticket
+workflow-context.sh recent research         # Get most recent document of type
+workflow-context.sh most-recent             # Get most recent document (any type)
+workflow-context.sh ticket PROJ-123         # Get all documents for a ticket
+```
+
+### Initialization
+
+The workflow context file is created automatically at several points:
+
+- **Skill prerequisites** — all workflow skills call `check-project-setup.sh` which runs `workflow-context.sh init`
+- **Worktree creation** — `create-worktree.sh` initializes the file and sets `currentTicket` from the worktree name (e.g., worktree `ENG-123` sets ticket to `ENG-123`)
+- **Ticket-based skills** — `/oneshot PROJ-123` calls `set-ticket` immediately after parsing the ticket, before any research begins
+
+### OpenTelemetry Integration
+
+The workflow context file is also read by [direnv](https://direnv.net/) to populate
+`OTEL_RESOURCE_ATTRIBUTES` with the current ticket. This enables per-ticket telemetry correlation
+in Claude Code's native OpenTelemetry support.
+
+**Setup**: Add a `.envrc` to your repo root:
+
+```bash
+source_up
+use_otel_context "your-project-name"
+```
+
+The `use_otel_context` function (from `~/.config/direnv/lib/otel.sh`) sets these OTEL resource
+attributes:
+
+| Attribute | Source |
+|-----------|--------|
+| `project` | Argument to `use_otel_context` |
+| `hostname` | Machine short name |
+| `git.branch` | Current git branch |
+| `linear.key` | Ticket from branch name, fallback to `currentTicket` in workflow context |
+
+`source_up` inherits environment from parent `.envrc` files (e.g., profile-based secrets at the
+workspace root). When using worktrees, `create-worktree.sh` generates a `.envrc` and runs
+`direnv allow` automatically.
 
 ## Thoughts System
 

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -281,10 +281,15 @@ For every worktree (orchestrator and workers), the `create-worktree.sh` script r
 1. git worktree add -b <name> <path> <base-branch>
 2. Copy .claude/ directory (plugins, rules, prompts)
 3. Copy .catalyst/ directory (project config)
-4. Run catalyst.worktree.setup commands (your config)
+4. Initialize workflow context with ticket from worktree name
+   (e.g., worktree "ENG-123" → currentTicket: "ENG-123")
+5. Generate .envrc (source_up + use_otel_context) and run direnv allow
+6. Run catalyst.worktree.setup commands (your config)
    — OR auto-detect: dependency install + humanlayer thoughts init (fallback)
-5. Run catalyst.orchestration.hooks.setup (orchestration-only, if present)
+7. Run catalyst.orchestration.hooks.setup (orchestration-only, if present)
 ```
+
+Steps 4–5 ensure that `.catalyst/.workflow-context.json` exists with the ticket set and that OTEL resource attributes include the ticket — before any skills run.
 
 The orchestrator then creates its status directory (`workers/`, `DASHBOARD.md`, `state.json`) and initializes worker signal files.
 

--- a/website/src/content/docs/reference/workflows.md
+++ b/website/src/content/docs/reference/workflows.md
@@ -174,7 +174,7 @@ Git worktrees let you work on multiple features simultaneously, each in its own 
 /create-worktree PROJ-123 feature-name
 ```
 
-This creates a git worktree at `~/catalyst/wt/{projectKey}/{PROJ-123-feature-name}/` with a new branch, `.claude/` and `.catalyst/` copied over, dependencies installed, and `thoughts/` shared via symlink.
+This creates a git worktree at `~/catalyst/wt/{projectKey}/{PROJ-123-feature-name}/` with a new branch, `.claude/` and `.catalyst/` copied over, workflow context initialized with the ticket, `.envrc` generated for OTEL telemetry, dependencies installed, and `thoughts/` shared via symlink.
 
 ### Parallel Sessions
 


### PR DESCRIPTION
## Summary

- `.catalyst/.workflow-context.json` was never being created in worktrees because `/oneshot` skipped `check-project-setup.sh` (the only workflow skill that did), and there was no way to set `currentTicket` without adding a document
- direnv's `use_otel_context` falls back to reading `currentTicket` from workflow context, but the file never existed — so OTEL spans had no `linear.key`
- New worktrees now get workflow context initialized with the ticket + a generated `.envrc` before any setup runs

### Changes

| File | What |
|------|------|
| `workflow-context.sh` (dev + pm) | New `set-ticket` command — sets `currentTicket` without requiring a document |
| `oneshot/SKILL.md` | Added `check-project-setup.sh` prereq + immediate `set-ticket` after parsing ticket input |
| `create-worktree.sh` | Initialize workflow context with ticket from worktree name; generate `.envrc` + `direnv allow` |
| `.envrc` | Checked into repo root (`source_up` + `use_otel_context "catalyst"`) |
| `test-workflow-context.sh` | Test 30: `set-ticket` sets ticket without adding documents |
| `WORKFLOW_CONTEXT.md` | Documented `set-ticket` in script API |
| Website docs | Configuration (script API, initialization, OTEL integration), orchestration (worktree steps), workflows (worktree description) |

## Test plan

- [x] All 31 workflow-context tests pass (including new `set-ticket` test)
- [ ] Create a worktree with ticket name, verify `.catalyst/.workflow-context.json` has `currentTicket` set
- [ ] Verify `.envrc` is generated in new worktree with correct project name
- [ ] Run `/oneshot PROJ-123` and verify workflow context file exists after prereq step

🤖 Generated with [Claude Code](https://claude.com/claude-code)