### PR TITLE
feat(dev): enforce post-PR monitoring and merge completion

### DIFF
--- a/plugins/dev/references/merge-blocker-diagnosis.md
+++ b/plugins/dev/references/merge-blocker-diagnosis.md
@@ -16,6 +16,31 @@ The goal is to satisfy branch protection requirements, not circumvent them. If a
 resolved autonomously, tell the user **exactly** what is needed and what they need to do — not just
 "branch protection is blocking the merge."
 
+## Common Misdiagnosis — READ THIS FIRST
+
+The most common agent error is **confusing unresolved review threads with "needs approving
+reviewer"** and then stopping, telling the user they need to approve the PR.
+
+**Unresolved threads** (from Codex, security scanners, linters, or human reviewers) are comments
+that create review threads on specific lines of code. These block merge when branch protection
+requires conversation resolution. **The agent CAN and MUST resolve these** by:
+
+1. Reading the comment and understanding the feedback
+2. Implementing the requested code change (or drafting a reply if it's a question)
+3. Pushing the fix
+4. Resolving the thread via GraphQL `resolveReviewThread` mutation
+
+**Review required** means no approving reviews exist and branch protection requires at least one.
+This is a genuine human gate — the agent cannot approve its own PR.
+
+**How to tell the difference:**
+- Check `reviewThreads` — if any have `isResolved: false`, that's `unresolved-threads` (fixable)
+- Check `reviewDecision` — if it's `REVIEW_REQUIRED`, that's a human gate (not fixable)
+- These can coexist! Fix the threads first, then report the review requirement
+
+**NEVER stop and tell the user "an approving reviewer is required" when the actual blocker is an
+unresolved code comment.** Diagnose carefully using the steps below.
+
 ## Step 1: Query Full Merge State
 
 Get everything in a single GraphQL call to avoid multiple round-trips:

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -234,30 +234,114 @@ else
 fi
 ```
 
-### 12. Suggest CI Monitoring
+### 12. Post-PR Monitoring & Resolution Loop
 
-After PR creation is complete, suggest the user monitor CI checks:
+**CRITICAL: Creating the PR is NOT the end of this skill.** You MUST monitor CI checks, wait for
+automated reviewer comments, address them, and only report success when the PR is in a clean,
+mergeable state — or genuinely blocked on a human gate (like approval from a specific person).
+
+Do NOT just say "PR created" or "PR created with auto-merge" and stop. That leaves the user to do
+all the follow-up work manually.
+
+**Step 12a: Wait for CI checks and automated reviewers (3-5 minutes)**
+
+Automated review agents (Codex, security scanners, linters) typically post comments within 3-5
+minutes of PR creation. Wait for them before processing comments so you address everything in one
+pass.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+
+# Wait 3 minutes for initial CI + automated reviews
+sleep 180
+
+# Poll for up to 2 more minutes (5 min total) — check every 30s
+WAITED=180
+MAX_WAIT=300
+while [ $WAITED -lt $MAX_WAIT ]; do
+  COMMENT_COUNT=$(gh api "repos/${REPO}/pulls/${pr_number}/comments" --jq 'length')
+  REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${pr_number}/reviews" \
+    --jq '[.[] | select(.state != "APPROVED" and .state != "DISMISSED")] | length')
+
+  if [ "$COMMENT_COUNT" -gt 0 ] || [ "$REVIEW_COUNT" -gt 0 ]; then
+    echo "Found review comments — proceeding to address them"
+    break
+  fi
+
+  sleep 30
+  WAITED=$((WAITED + 30))
+done
+```
+
+**Step 12b: Address all review comments**
+
+If any comments or reviews exist, run `/review-comments $pr_number` to:
+
+- Fetch and categorize all comments (inline, review threads, issue comments)
+- Implement requested code changes
+- Resolve review threads via GraphQL
+- Push a single addressing commit
+
+**Step 12c: Diagnose and resolve merge blockers**
+
+Read and follow `"${CLAUDE_PLUGIN_ROOT}/references/merge-blocker-diagnosis.md"`. Run the full
+blocker diagnosis and resolution loop (max 3 rounds):
+
+- `ci-failing` → analyze failure logs, fix code, push, re-poll
+- `unresolved-threads` → run `/review-comments` (addresses + resolves threads)
+- `branch-behind` → rebase and push
+- `draft` → `gh pr ready`
+- `changes-requested` → check if addressed; attempt to fix
+
+**CRITICAL MISDIAGNOSIS WARNING**: Do NOT confuse "unresolved review threads" with "needs approving
+reviewer." Code comments from automated reviewers (Codex, security scanners) create **threads** that
+YOU can resolve by addressing the feedback and resolving the thread via GraphQL. These are NOT a
+human approval gate. Only `review-required` (no approving reviews at all) is a genuine human gate.
+Read the merge-blocker-diagnosis reference carefully.
+
+**Step 12d: Re-poll until clean or genuinely human-blocked**
+
+After each fix cycle, re-query the merge state. Continue looping until:
+
+- `mergeStateStatus` is `CLEAN` → PR is ready to merge, report success
+- Only remaining blocker is `review-required` (needs human approval) → report what's needed
+- Max attempts (3) exhausted → report exactly what's still blocking with actionable guidance
+
+### 13. Report final state
+
+Report based on the **actual merge state** after monitoring — not just "PR created."
+
+**If CLEAN (ready to merge):**
 
 ```
-echo ""
-echo "Tip: Monitor CI checks with:"
-echo "  /loop 2m gh pr checks $pr_number --watch"
-echo ""
-echo "This will check every 2 minutes and report when checks pass or fail."
+✅ PR #{number} ready to merge
+
+PR: #{number} - {title}
+URL: {url}
+Base: {base_branch}
+Ticket: {ticket} (moved to "In Review")
+
+Status:
+  ✅ CI checks passed
+  ✅ Review comments addressed ({N} resolved)
+  ✅ No merge blockers
+
+Merge with: /catalyst-dev:merge-pr
 ```
 
-### 13. Report success
+**If blockers remain (report exactly what's needed):**
 
 ```
-✅ Pull request created successfully!
+PR #{number} created — {N} blocker(s) remain
 
-**PR**: #{number} - {title}
-**URL**: {url}
-**Base**: {base_branch}
-**Ticket**: {ticket} (moved to "In Review")
+PR: #{number} - {title}
+URL: {url}
 
-Description has been generated and verification checks have been run.
-Review the PR on GitHub!
+Resolved:
+  ✅ {what was fixed}
+
+Still blocking:
+  ❌ {specific blocker and exactly what's needed to resolve it}
 ```
 
 ## Error Handling
@@ -375,6 +459,9 @@ Calling /describe-pr...
 
 ## Remember:
 
+- **NEVER stop at "PR created"** — monitor CI, address review comments, resolve blockers
+- **"PR created with auto-merge" is NOT done** — you must verify it actually merges cleanly
+- **Automated reviewer comments are YOUR job** — address Codex/scanner feedback, don't wait for human
 - **Minimize prompts** — only ask when PR already exists
 - **Auto-rebase** — keep branch up-to-date with base
 - **Auto-link Linear** — extract ticket from branch, update status with Linearis CLI

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -64,7 +64,7 @@ Uses the provided text as the research query directly.
 | Flag                   | Description                                            |
 | ---------------------- | ------------------------------------------------------ |
 | `--team`               | Use agent teams for parallel implementation in Phase 3 |
-| `--auto-merge`         | Phase 5 waits for CI and auto-invokes Phase 6          |
+| `--no-merge`           | Stop after PR creation — do NOT auto-merge             |
 | `--no-ticket`          | Skip Linear ticket creation in freeform mode           |
 | `--skip-validation`    | Skip Phase 4 entirely                                  |
 | `--skip-quality-gates` | Run `/validate-plan` but skip quality gate loop        |
@@ -180,6 +180,7 @@ fi
 | 4 start | `validating` |
 | 5 start | `shipping` |
 | 5 PR created | `pr-created` |
+| 5 monitoring | `monitoring` |
 | 6 start | `merging` |
 | 6 complete | `done` |
 | Any failure | `failed` |
@@ -426,7 +427,12 @@ a loop (max 3 rounds). Key blocker resolutions:
 If blockers remain after 3 rounds, present what was resolved and what still blocks with options
 to wait or create a handoff.
 
-**Step 4: Present options**
+**Step 4: Proceed to merge (default) or report status**
+
+By default, oneshot completes the full lifecycle — it does NOT stop at PR creation. After resolving
+all blockers, it proceeds directly to Phase 6 (merge).
+
+If `--no-merge` was set, report the PR status and exit:
 
 ```
 PR ready: https://github.com/org/repo/pull/{number}
@@ -437,24 +443,20 @@ Merge state: $mergeStateStatus
   ✅ Reviews addressed
   ❌ Review required — 1 approval needed (if applicable)
 
-Options:
-  [1] Wait for remaining blockers to clear, then auto-merge (runs Phase 6)
-  [2] Exit — merge later with /catalyst-dev:merge-pr
+Merge later with: /catalyst-dev:merge-pr
 ```
 
-**If `--auto-merge` flag was set:** Skips the prompt and proceeds to Phase 6 automatically. Phase 6
-(`/merge-pr`) will run its own blocker diagnosis loop and resolve anything remaining.
+**Default behavior (no `--no-merge` flag):** Proceeds to Phase 6 automatically. Phase 6
+(`/merge-pr`) will run its own blocker diagnosis loop and resolve anything remaining. If all
+blockers are resolved, it merges. If a genuine human gate remains (e.g., required approval),
+it reports what's needed and stops.
 
 **Linear**: `/create-pr` moves ticket to `stateMap.inReview` (default: "In Review").
 
-### Phase 6: Merge (Same Session as Phase 5 or Manual — Sonnet)
+### Phase 6: Merge (Same Session as Phase 5 — Sonnet)
 
-Only runs automatically if:
-
-- User selected option [1] in Phase 5, OR
-- `--auto-merge` flag was passed
-
-Otherwise, user merges manually later with `/catalyst-dev:merge-pr`.
+Runs automatically by default. Only skipped if `--no-merge` flag was passed, in which case the user
+merges manually later with `/catalyst-dev:merge-pr`.
 
 ```
 /catalyst-dev:merge-pr
@@ -522,12 +524,13 @@ Phase 4: Validate + Quality Gates (NEW session — Opus)
 
 Phase 5: Ship (NEW session — Sonnet)
   - Starts with 0% context used
-  - Lightweight: commit, PR, CI polling
+  - Lightweight: commit, PR, CI polling, comment resolution
   - Sonnet is sufficient for structured workflow
 
-Phase 6: Merge (same session as Phase 5 or manual — Sonnet)
+Phase 6: Merge (same session as Phase 5 — Sonnet)
   - Reuses Phase 5 context (minimal usage)
   - Procedural: verify, merge, cleanup
+  - Runs by default (skip with --no-merge)
 ```
 
 ## Configuration
@@ -672,7 +675,12 @@ error, context exhaustion):
 - **Use wiki-links** for cross-references between thoughts documents (e.g., `[[filename]]`), not
   full paths
 - **Phase 3 does NOT commit** — all git operations are deferred to Phase 5
-- **Phase 6 is opt-in** — requires `--auto-merge` or explicit user choice
+- **Phase 6 (merge) runs by default** — use `--no-merge` to opt out
+- **NEVER stop at "PR created"** — monitor CI, address automated review comments, resolve blockers,
+  and merge. "PR created with auto-merge" is NOT a terminal state — verify it actually merges
+- **Automated reviewer comments are the agent's job** — Codex, security scanners, and linters post
+  code comments that create unresolved threads. These are NOT "needs approving reviewer" — they are
+  fixable blockers. Address the feedback, resolve the threads, and continue
 
 **IMPORTANT: Document Storage Rules**
 

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -449,7 +449,7 @@ For each provisioned worker worktree, dispatch a `/oneshot` session.
   '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-dispatched", detail: null}')"
 ```
 
-**Worker dispatch prompt includes mandatory testing requirements:**
+**Worker dispatch prompt includes mandatory testing AND lifecycle requirements:**
 
 ```
 MANDATORY: Before marking this ticket as complete:
@@ -459,9 +459,17 @@ MANDATORY: Before marking this ticket as complete:
 4. Security review — must pass /security-review or equivalent
 5. Code review — must pass code-reviewer agent
 6. All quality gates in config must pass
+7. PR MUST be monitored through merge — do NOT stop at "PR created"
+   - Wait for CI checks to pass
+   - Address ALL automated review comments (Codex, security scanners)
+   - Resolve all merge blocker threads via GraphQL
+   - Only report done when PR is actually MERGED or blocked on human approval
 
 Your work will be independently verified by the orchestrator. Do NOT mark as done
-until all test types exist. Write your status to the worker signal file at:
+until all test types exist AND the PR is merged. "PR created with auto-merge" is
+NOT done — you must verify it actually merges cleanly.
+
+Write your status to the worker signal file at:
   ${ORCH_DIR}/workers/${TICKET_ID}.json
 
 Update the signal file at each phase transition using the worker-signal.json schema.


### PR DESCRIPTION
## Summary

- **create-pr**: Replaced the passive "tip: monitor CI" step with a mandatory post-PR monitoring and resolution loop — agents now wait for CI, address automated review comments (Codex, scanners), resolve merge blockers, and only report success when the PR is clean or genuinely human-blocked
- **oneshot**: Made auto-merge the default behavior (was opt-in via `--auto-merge`), added `--no-merge` for opt-out, removed interactive option prompt in Phase 5
- **merge-blocker-diagnosis**: Added "Common Misdiagnosis" section at the top — agents were confusing unresolved code comments (fixable) with "needs approving reviewer" (human gate) and stopping prematurely
- **orchestrate**: Added PR lifecycle requirements to worker dispatch prompt — workers must verify merge completion, not just create PR

## Test plan

- [ ] Run `/catalyst-dev:oneshot` on a test ticket and verify it proceeds through merge by default
- [ ] Verify `/catalyst-dev:create-pr` monitors CI and addresses automated review comments before reporting success
- [ ] Confirm that when Codex posts a code comment, the agent addresses it instead of reporting "needs approving reviewer"
- [ ] Verify `--no-merge` flag stops after PR creation without attempting merge