### PR TITLE
docs: document autonomous GitHub repo settings and always-on PR checks

### DIFF
--- a/.github/workflows/audit-references.yml
+++ b/.github/workflows/audit-references.yml
@@ -3,8 +3,6 @@ name: Audit References
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'plugins/**'
 
 jobs:
   audit-references:

--- a/.github/workflows/check-plugin-versions.yml
+++ b/.github/workflows/check-plugin-versions.yml
@@ -3,9 +3,6 @@ name: Check Plugin Versions
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'plugins/**'
-      - '.claude-plugin/marketplace.json'
 
 jobs:
   check-versions:
@@ -22,4 +19,3 @@ jobs:
         run: |
           git fetch origin ${{ github.base_ref }}
           bash scripts/check-plugin-version.sh
-

--- a/.github/workflows/validate-release-config.yml
+++ b/.github/workflows/validate-release-config.yml
@@ -3,10 +3,6 @@ name: Validate Release Config
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'release-please-config.json'
-      - '.release-please-manifest.json'
-      - '.github/workflows/release-please.yml'
 
 jobs:
   validate:

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -257,8 +257,7 @@ Define the commands that run when creating a new worktree via `/create-worktree`
       "setup": [
         "humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}",
         "humanlayer thoughts sync",
-        "bun install",
-        "~/.claude/scripts/trust-workspace.sh \"$(pwd)\""
+        "bun install"
       ]
     }
   }
@@ -277,6 +276,9 @@ Commands run in order, inside the new worktree directory. Each command supports 
 | `${PROFILE}` | Thoughts profile (from `catalyst.thoughts.profile` or auto-detected) |
 
 If `catalyst.worktree.setup` is **not configured**, the script falls back to auto-detected setup: `make setup` or `bun/npm install`, then `humanlayer thoughts init` + `sync`. Once you define `setup`, only your commands run — the auto-detection is skipped entirely.
+
+Catalyst now pre-trusts newly created worktrees in Claude Code automatically, so you do **not**
+need to add a separate `trust-workspace.sh` command to your setup array.
 
 ## Orchestration Config
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -82,6 +82,131 @@ Set any key to `null` to skip that automatic transition.
 API token, the script fetches your team's actual workflow states and populates `stateMap` with the
 correct names. Manual customization is only needed for non-standard state names.
 
+### Plain-Language State Flow
+
+In most teams, the intended meaning is:
+
+- `research` — Catalyst is still understanding the problem and the current code
+- `planning` — the implementation approach is being written and reviewed
+- `inProgress` — code changes are actively being made
+- `inReview` — a PR exists and is being worked through review and CI
+- `done` — the PR has merged
+
+This is useful because the PR stage is not just "waiting on somebody else." In Catalyst's model,
+`inReview` still includes active follow-up work such as fixing CI, addressing automated review
+feedback, updating the PR description, and re-checking merge readiness.
+
+## GitHub Merge Rules Are Separate
+
+Catalyst can open PRs, watch checks, address review comments, and try to merge safely. But GitHub
+decides what is actually required before `main` can be merged into.
+
+Those merge requirements live in **GitHub branch protection or repository rulesets**, not in
+`.catalyst/config.json`.
+
+If you want GitHub to block merges until review is complete, configure that in GitHub:
+
+- require pull requests for `main`
+- require status checks before merge
+- require one or more approving reviews
+- require conversation resolution if review threads must be closed
+- optionally enable auto-merge once those requirements pass
+
+Catalyst should behave as if these gates matter, but only GitHub can enforce them.
+
+## Recommended GitHub Repo Settings
+
+For most teams using Catalyst, the best default is **autonomous mode**: let Catalyst work the PR to
+completion, but make GitHub enforce the quality gates around checks and unresolved review comments.
+
+### Repository Settings
+
+- Enable pull requests.
+- Enable squash merge.
+- Enable auto-merge.
+- Enable automatic deletion of head branches after merge.
+- Set the default branch to `main`.
+
+### `main` Ruleset
+
+Target `refs/heads/main` with an active branch ruleset that:
+
+- blocks direct deletion
+- blocks non-fast-forward pushes
+- requires pull requests for changes into `main`
+- requires review conversations to be resolved before merge
+- requires status checks to pass before merge
+
+For **autonomous mode**, set:
+
+- required approving reviews: `0`
+- required review thread resolution: `true`
+- required status checks: `true`
+
+This gives you a fully automated merge path where Catalyst can:
+
+- open the PR
+- wait for checks and bot comments
+- fix actionable feedback
+- resolve review threads
+- merge once the PR is genuinely clean
+
+without waiting for a human approval click.
+
+For this repo shape, the recommended required check currently enabled in GitHub is:
+
+- `Cloudflare Pages`
+
+Once your repository runs the following checks on **every** PR to `main`, you should add them as
+required checks too:
+
+- `audit-references`
+- `check-versions`
+- `validate`
+
+`Cloudflare Pages` covers preview deploy readiness. The other three checks are repository-owned
+guardrails:
+
+- `audit-references` catches broken plugin references
+- `check-versions` verifies plugin changes are releasable through Release Please
+- `validate` checks release configuration consistency
+
+If your repository has additional always-on checks, add them too. The important rule is: only mark a
+check as required if it runs on every PR to `main`.
+
+### Optional Human-In-The-Loop Mode
+
+If you want a human signoff before merge, keep everything above and additionally set:
+
+- required approving reviews: `1` or more
+
+That changes the operating model from autonomous shipping to human-approved shipping. Catalyst still
+does the same review-follow-up work, but GitHub will not allow the merge until a human reviewer
+approves it.
+
+### Review Expectations
+
+The recommended operating model is:
+
+- automated reviewers can leave comments and request fixes
+- Catalyst should address actionable review feedback and resolve threads
+- GitHub should block merge until required conversations and checks are complete
+- human approval should be optional and controlled by the repository owner, not assumed by Catalyst
+
+### Why This Split Matters
+
+Catalyst can do the work of:
+
+- opening the PR
+- waiting for checks
+- reading bot and human review comments
+- fixing code
+- updating the PR
+- attempting the merge once the PR is clean
+
+But the repository settings are what make those expectations enforceable for every contributor, not
+just when Catalyst happens to be driving.
+
 ## Secrets Config (`~/.config/catalyst/config-{projectKey}.json`)
 
 Never committed. One file per project, linked by `projectKey`.

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -49,6 +49,9 @@ Add `~/catalyst` to Claude Code's trusted directories so all worktrees across al
 
 This is a one-time setup. All orchestrator and worker worktrees for every project land under `~/catalyst/wt/<projectKey>/`.
 
+Catalyst also pre-trusts newly created worktrees automatically, so the `additionalDirectories`
+setting is best treated as a convenience and backup layer rather than a hard requirement.
+
 ### Project Configuration
 
 The orchestrator reads from your project's Catalyst config (`.catalyst/config.json` or `.claude/config.json`). Two config blocks are relevant:
@@ -64,8 +67,7 @@ The orchestrator reads from your project's Catalyst config (`.catalyst/config.js
       "setup": [
         "humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}",
         "humanlayer thoughts sync",
-        "bun install",
-        "~/.claude/scripts/trust-workspace.sh \"$(pwd)\""
+        "bun install"
       ]
     }
   }
@@ -79,9 +81,11 @@ The orchestrator reads from your project's Catalyst config (`.catalyst/config.js
 | Thoughts init | `humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}` | Workers need access to shared research, plans, and handoffs. Without this, workers can't read wave briefings or save their findings for other waves. |
 | Thoughts sync | `humanlayer thoughts sync` | Pulls down existing shared documents so the worker starts with full context. |
 | Dependency install | `bun install` or `npm install` or `make setup` | Workers need project dependencies to run tests, typecheck, and build. |
-| Permission grant | `~/.claude/scripts/trust-workspace.sh "$(pwd)"` | Adds the worktree to Claude Code's allowed directories. Not needed if `~/catalyst` is already in `additionalDirectories`. |
 | Environment setup | `cp .env.example .env.local` | Workers may need environment variables for local dev. |
 | Database setup | `./scripts/setup-test-db.sh` | If tests require a local database. |
+
+You do not need a separate "permission grant" step anymore. `create-worktree.sh` now marks the new
+worktree as trusted in Claude Code automatically.
 
 **If `catalyst.worktree.setup` is NOT configured:** The script falls back to auto-detected setup — it will auto-detect `make setup`/`bun install`/`npm install` for dependencies, and run `humanlayer thoughts init` + `sync` if HumanLayer is installed. This fallback is convenient for simple projects but gives you no control over the order, additional steps, or error handling.
 
@@ -155,8 +159,7 @@ Here's a complete config for a project using orchestration:
       "setup": [
         "humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}",
         "humanlayer thoughts sync",
-        "bun install",
-        "~/.claude/scripts/trust-workspace.sh \"$(pwd)\""
+        "bun install"
       ]
     },
     "orchestration": {
@@ -180,14 +183,26 @@ Before running `/orchestrate` for the first time:
 - [ ] **Linearis CLI installed** and authenticated (`linearis auth login`)
 - [ ] **GitHub CLI installed** and authenticated (`gh auth login`)
 - [ ] **HumanLayer CLI installed** and thoughts initialized in the main repo (`humanlayer thoughts init`)
-- [ ] **`~/catalyst` added** to `~/.claude/settings.json` `additionalDirectories`
-- [ ] **`catalyst.worktree.setup` configured** with your project's setup commands (thoughts init, dependency install, permission grant, etc.)
+- [ ] **`catalyst.worktree.setup` configured** with your project's setup commands (thoughts init, dependency install, environment setup, etc.)
 - [ ] **`catalyst.linear.stateMap` configured** so ticket state transitions work
 - [ ] **`catalyst.thoughts` configured** with your profile and directory names
+
+Optional but still useful:
+
+- [ ] **`~/catalyst` added** to `~/.claude/settings.json` `additionalDirectories`
 
 ## Quick Start
 
 Once prerequisites are met:
+
+```
+/setup-orchestrate
+```
+
+This creates an orchestrator worktree, initializes the shared orchestration state, and prints a
+single copy-paste command to launch the orchestrator in a new terminal.
+
+If you prefer to start manually from an existing orchestrator worktree, use:
 
 ```
 /orchestrate ACME-101 ACME-102 ACME-103

--- a/website/src/content/docs/reference/skills.md
+++ b/website/src/content/docs/reference/skills.md
@@ -65,6 +65,7 @@ Each skill's description includes specific phrases and contexts that tell Claude
 | `resume-handoff` | "resume handoff", "pick up where we left off", "continue from handoff" |
 | `linear` | "create a ticket", "update the ticket", "move ticket to", "search Linear" |
 | `create-worktree` | "create a worktree", "work in parallel", parallel feature development |
+| `setup-orchestrate` | "start orchestration", "set up orchestrator", "bootstrap orchestrate", create orchestrator worktree and launch command |
 | `fix-typescript` | "fix type errors", "fix typescript", "type-check is failing", TypeScript compilation errors |
 | `scan-reward-hacking` | After `/fix-typescript`, "scan for hacks", "check for type cheats", verifying TS fixes |
 | `validate-type-safety` | "validate types", "check type safety", "run type validation", before PRs with TS changes |
@@ -117,6 +118,7 @@ The core development plugin. Skills covering research, planning, implementation,
 | `create-handoff` | &#10003; | — | Save session context, learnings, and next steps for continuation in a fresh session. | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/create-handoff/SKILL.md) |
 | `resume-handoff` | &#10003; | — | Resume work from a handoff document. Verifies codebase state and creates an action plan. | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/resume-handoff/SKILL.md) |
 | `create-worktree` | &#10003; | — | Create git worktree for parallel development without switching branches. | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/create-worktree/SKILL.md) |
+| `setup-orchestrate` | &#10003; | — | Bootstrap an orchestrator worktree and print a ready-to-run launch command for `/orchestrate`. | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/setup-orchestrate/SKILL.md) |
 
 ### Integrations & References
 

--- a/website/src/content/docs/reference/workflows.md
+++ b/website/src/content/docs/reference/workflows.md
@@ -7,6 +7,43 @@ sidebar:
 
 Catalyst's development workflow chains together: **research, plan, implement, validate, and ship**. Each phase produces a persistent artifact that feeds the next, with clean context handoffs in between.
 
+## In Plain English
+
+The intended development cycle is:
+
+1. You point Catalyst at a ticket or goal.
+2. Catalyst researches the existing code and writes down what it found.
+3. Catalyst turns that into an implementation plan with clear success criteria.
+4. Catalyst makes the changes in small steps and verifies each step as it goes.
+5. Catalyst opens a PR, waits for CI and automated reviewers, fixes actionable feedback, and keeps checking until the PR is either clean or clearly blocked on a human decision.
+6. Once the PR is clean, Catalyst can merge it and update the linked Linear ticket.
+
+The important mindset is that "opened a PR" is not the finish line. The finish line is one of:
+
+- the PR is clean and ready to merge
+- the PR has merged successfully
+- Catalyst can point to a real human-only blocker, such as "needs approval from a reviewer"
+
+## What Catalyst Should Do
+
+- Read the existing codebase before making broad changes.
+- Save research, plans, PR descriptions, and handoffs so later steps do not depend on chat memory.
+- Keep the branch up to date with `main` before asking to merge.
+- Run local verification before shipping when the project defines a test command.
+- Wait for CI checks and automated review comments after opening a PR.
+- Fix actionable review comments and re-poll the merge state instead of stopping at "PR created."
+- Update Linear states as work moves from implementation to review to done.
+- Stop and report clearly when the remaining blocker is genuinely human-owned.
+
+## What Catalyst Should Not Do
+
+- It should not merge with known failing checks.
+- It should not bypass GitHub protections with `--admin`, force pushes to protected branches, or other shortcuts.
+- It should not treat unresolved review comments as "someone else will handle this."
+- It should not tell you a PR is done just because the PR exists.
+- It should not silently change scope after planning. If the plan is wrong, it should stop and say so.
+- It should not assume GitHub is enforcing review rules that have not actually been configured in the repository.
+
 ## Development Workflow
 
 ```mermaid
@@ -83,6 +120,51 @@ Verifies all success criteria, runs automated test suites, documents deviations,
 
 Creates a pull request with a description generated from your research and plan, linked to the relevant ticket.
 
+In Catalyst's intended flow, shipping has two distinct stages:
+
+1. `/create-pr` gets the branch into review and works the PR until it is clean or clearly blocked.
+2. `/merge-pr` performs the final verification and squash merge once the PR is ready.
+
+### Shipping Loop
+
+After a PR is opened, Catalyst should continue through this loop instead of stopping immediately:
+
+1. Wait for CI checks, preview deploys, and automated reviewers to report back.
+2. Read review comments and group them by actual issue, not by comment count.
+3. Fix actionable feedback in code.
+4. Resolve review threads when the feedback has been addressed.
+5. Re-run local verification as needed.
+6. Re-check GitHub merge state.
+7. Repeat until the PR is clean or the only remaining blocker is a human gate.
+
+Typical human gates are:
+
+- an approval that a repository rule requires
+- a design or product decision
+- a merge conflict that needs a human judgment call
+
+Typical non-human blockers that Catalyst should usually handle itself are:
+
+- branch is behind `main`
+- CI is failing because of code issues
+- review comments from automated tools
+- draft PR state
+- unresolved review threads
+
+### GitHub Gates vs Catalyst Behavior
+
+Catalyst can behave as though reviews and checks matter, but GitHub only blocks merges based on the
+rules configured in the repository.
+
+That means there are two separate layers:
+
+- **Catalyst behavior**: what the skills try to do before merging
+- **GitHub enforcement**: what the repository rules or rulesets actually require
+
+If you want merges to be blocked until checks, approvals, or resolved threads are complete, that
+must be configured in GitHub. Catalyst should honor those rules, but it does not create them by
+itself.
+
 ## Workflow Patterns
 
 ### Quick Feature
@@ -131,6 +213,10 @@ For straightforward tasks, chain the entire workflow:
 ```
 
 Runs research, planning, and implementation in a single invocation with context isolation between phases.
+
+When `/oneshot` is used for shipping work, the expected behavior is still the same: do the work,
+open the PR, wait for review signals, address fixable feedback, and only stop when the PR is truly
+ready or genuinely blocked.
 
 ## Handoffs
 
@@ -237,6 +323,18 @@ Resolve all decisions during planning — no open questions in final plans.
 Follow the plan's intent, not its letter. When reality differs — a file moved, a better pattern found — adapt and document the deviation. If the core approach is invalid, stop and ask before proceeding.
 
 Verify incrementally: implement → test → fix → mark complete for each phase.
+
+### Linear Updates
+
+Catalyst can also keep Linear in sync with the workflow:
+
+- `research-codebase` can move work into the configured research state
+- `create-plan` can move work into the configured planning state
+- `implement-plan` can move work into the configured in-progress state
+- `create-pr` and `describe-pr` can move work into the configured in-review state
+- `merge-pr` can move work into the configured done state
+
+The exact state names come from `catalyst.linear.stateMap` in the project config.
 
 ### Anti-Patterns
 


### PR DESCRIPTION
## Summary
- document the development and merge loop in plain language
- document recommended GitHub repo settings with autonomous mode as the default
- make PR validation workflows run on every PR to main so they can become required checks safely

## Context
The live GitHub ruleset for `main` has already been updated to autonomous mode:
- pull requests required
- resolved review threads required
- `Cloudflare Pages` required
- no human approval required

This PR brings the repository workflows and docs in line with that operating model and explains how users can opt into a human-in-the-loop approval gate in their own repos.

## Verification
- `npm run build` in `website/`
- `bash scripts/validate-release-config.sh`
