### PR TITLE
fix(dev): tighten setup-orchestrate to zero-interaction

### DIFF
--- a/plugins/dev/skills/setup-orchestrate/SKILL.md
+++ b/plugins/dev/skills/setup-orchestrate/SKILL.md
@@ -6,132 +6,126 @@ description:
   copy-paste command to launch the orchestrator in a new terminal."
 disable-model-invocation: true
 allowed-tools: Bash, Read
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Setup Orchestrate
 
-Create an orchestrator worktree and provide the user with a single command to launch the
-orchestration run. This skill handles all the bootstrapping so the user never touches shell scripts
-directly.
+Create an orchestrator worktree and output a single copy-paste command to launch the orchestration
+run. No questions — parse the input, create the worktree, print the command.
+
+## Input Format
+
+```
+/catalyst-dev:setup-orchestrate <ticket-ids...>
+/catalyst-dev:setup-orchestrate --cycle current
+/catalyst-dev:setup-orchestrate --project "Project Name"
+```
+
+The input MUST be one of:
+- **Ticket IDs**: space-separated (e.g., `ADV-214 ADV-215 ADV-208`)
+- **Cycle flag**: `--cycle current`
+- **Project flag**: `--project "Project Name"`
+
+If no input is provided, stop and tell the user:
+```
+Usage: /catalyst-dev:setup-orchestrate <ticket-ids...>
+       /catalyst-dev:setup-orchestrate --cycle current
+       /catalyst-dev:setup-orchestrate --project "Project Name"
+```
+
+**Do NOT** analyze tickets, suggest sequencing, research ticket details, or do any work beyond
+creating the worktree. Wave planning and dependency analysis is the orchestrate skill's job.
 
 ## Process
 
-### Step 1: Validate Environment
+Execute all steps without asking questions. No confirmations, no menus, no options.
 
-Confirm you are in the **main repo root** (not an existing worktree):
+### Step 1: Validate — Must Be Main Repo
+
+You MUST be in the main repo root, not a worktree. Check and **hard stop** if wrong:
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-if [ -z "$REPO_ROOT" ]; then
-  echo "ERROR: Not in a git repository"
-  exit 1
-fi
-
-# Warn if inside a worktree (not the main working tree)
 COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+
+if [ -z "$REPO_ROOT" ]; then
+  echo "ERROR: Not in a git repository"; exit 1
+fi
+
 if [ "$COMMON_DIR" != "$GIT_DIR" ]; then
-  echo "WARNING: You are inside a git worktree, not the main repo."
-  echo "Run this from the main repo root instead."
+  MAIN_REPO=$(git -C "$(git rev-parse --git-common-dir)" rev-parse --show-toplevel 2>/dev/null)
+  echo "ERROR: You are inside a git worktree, not the main repo."
+  echo "Run this from: ${MAIN_REPO:-the main repo root}"
+  exit 1
 fi
 ```
 
-### Step 2: Read Config
+If the check fails, print the error and **stop**. Do not offer to continue from the worktree.
 
-Read the project config to get `projectKey` and orchestration settings:
+### Step 2: Read Config
 
 ```bash
 CONFIG_FILE=""
 for CFG in "${REPO_ROOT}/.catalyst/config.json" "${REPO_ROOT}/.claude/config.json"; do
-  if [ -f "$CFG" ]; then
-    CONFIG_FILE="$CFG"
-    break
-  fi
+  if [ -f "$CFG" ]; then CONFIG_FILE="$CFG"; break; fi
 done
 
 if [ -z "$CONFIG_FILE" ]; then
-  echo "ERROR: No .catalyst/config.json or .claude/config.json found."
-  echo "Create one from the template: /catalyst-dev:linearis"
+  echo "ERROR: No .catalyst/config.json found. See /catalyst-dev:linearis for setup."
   exit 1
 fi
 
 PROJECT_KEY=$(jq -r '.catalyst.projectKey // empty' "$CONFIG_FILE")
 TICKET_PREFIX=$(jq -r '.catalyst.project.ticketPrefix // empty' "$CONFIG_FILE")
-PROJECT_NAME=$(jq -r '.catalyst.project.name // empty' "$CONFIG_FILE")
 ```
 
-### Step 3: Determine Orchestrator Name
-
-Ask the user what to name this orchestration run. Suggest a sensible default based on the date:
-
-- Default suggestion: `orch-YYYY-MM-DD` (e.g., `orch-2026-04-13`)
-- User can provide a custom name (e.g., `auth-sprint`, `api-redesign`)
-
-The name is used for the orchestrator worktree directory and branch name.
-
-### Step 4: Initialize Global State
-
-Ensure `~/catalyst/state.json` exists:
+### Step 3: Initialize Global State
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-state.sh" init
 ```
 
-This is idempotent — safe to run if it already exists.
+Idempotent — safe to run every time.
 
-### Step 5: Create Orchestrator Worktree
+### Step 4: Create Orchestrator Worktree
 
-Run the create-worktree script for the orchestrator:
+Auto-generate the name from today's date: `orch-YYYY-MM-DD`. If that already exists, append
+`-2`, `-3`, etc.
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/create-worktree.sh" "<orchestrator-name>" main
+"${CLAUDE_PLUGIN_ROOT}/scripts/create-worktree.sh" "<orch-name>" main
 ```
 
-This automatically:
-- Creates `~/catalyst/wt/<projectKey>/<orchestrator-name>/`
-- Copies `.claude/` and `.catalyst/` directories
-- Pre-trusts the worktree in Claude Code (no trust dialog)
-- Initializes workflow context
-- Generates `.envrc` for OTEL
-- Runs project setup hooks (`bun install`, etc.)
+Do not ask for a custom name. The auto-generated name is always used.
 
-### Step 6: Determine Ticket Source
+### Step 5: Build and Print Launch Command
 
-Ask the user how they want to select tickets for orchestration. Present these options:
+Construct the ticket arguments from the user's input exactly as provided (ticket IDs, --cycle, or
+--project). Always append `--dry-run` to the first suggested command.
 
-1. **Specific tickets**: `ADV-101 ADV-102 ADV-103`
-2. **Current cycle**: `--cycle current` (pulls all in-progress tickets from the current Linear cycle)
-3. **Project**: `--project "Project Name"` (pulls tickets from a Linear project)
-4. **Dry run first**: Add `--dry-run` to see the wave plan without dispatching workers
-
-### Step 7: Output Launch Command
-
-After the worktree is created and the user has chosen their ticket source, print a single
-copy-paste command block:
+Print this block:
 
 ```
-════════════════════════════════════════════════════════
-  Orchestrator worktree ready!
+════════════════════════════════════════════════════════════════
+ Orchestrator ready: ~/catalyst/wt/<projectKey>/<orch-name>
 
-  Run this command in a new terminal:
+ Dry run (preview wave plan):
+   cd ~/catalyst/wt/<projectKey>/<orch-name> && claude "/catalyst-dev:orchestrate <ticket-args> --dry-run"
 
-  cd ~/catalyst/wt/<projectKey>/<orchestrator-name> && claude "/catalyst-dev:orchestrate <ticket-args>"
-════════════════════════════════════════════════════════
+ Full run (dispatch workers):
+   cd ~/catalyst/wt/<projectKey>/<orch-name> && claude "/catalyst-dev:orchestrate <ticket-args>"
+════════════════════════════════════════════════════════════════
 ```
 
-Replace `<ticket-args>` with the user's chosen ticket source (e.g., `ADV-101 ADV-102`,
-`--cycle current`, `--project "Adva Platform"`).
+## Rules
 
-If the user wants a dry run, append `--dry-run`:
-
-```
-cd ~/catalyst/wt/<projectKey>/<orchestrator-name> && claude "/catalyst-dev:orchestrate <ticket-args> --dry-run"
-```
-
-## Important
-
-- Do NOT run the orchestrate skill yourself — the user needs to run it from the new worktree in a
-  separate Claude session
-- The orchestrator must run from its own worktree so it can create worker worktrees as siblings
-- Always suggest `--dry-run` first so the user can review the wave plan before committing
+- **No questions.** Parse input, execute, print command. The entire skill should complete in one
+  turn with zero user interaction.
+- **No ticket analysis.** Do not fetch ticket details, suggest sequencing, or build wave plans.
+  That is Phase 1 of the orchestrate skill.
+- **No worktree option.** Always refuse if not on main repo. Do not offer alternatives.
+- **No custom names.** Always auto-generate `orch-YYYY-MM-DD[-N]`.
+- **Always show both commands** — dry run first, full run second.
+- **Do NOT run the orchestrate skill** — the user runs it from the new worktree in a new terminal.


### PR DESCRIPTION
## Summary
- Removes all questions/menus from `setup-orchestrate` — parses input, creates worktree, prints command in one turn
- Hard stops if run from a worktree (no "continue anyway?" option)
- Auto-generates orchestrator name from date (`orch-YYYY-MM-DD`)
- Leaves ticket analysis/sequencing to the orchestrate skill where it belongs

## Test plan
- [ ] Run `/catalyst-dev:setup-orchestrate ADV-214 ADV-215` from main repo — should create worktree and print command with no questions
- [ ] Run from a worktree — should hard stop with error pointing to main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)