### PR TITLE
fix(dev): DRY linearis across all skills, fix direnv timing and @me bug

### DIFF
--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -180,14 +180,14 @@ if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
 fi
 
 # Generate .envrc for OTEL context (source_up inherits parent profiles)
+# Note: direnv allow runs AFTER setup hooks to avoid re-blocking if hooks modify .envrc
 OTEL_PROJECT="${PROJECT_KEY:-$REPO_NAME}"
 if command -v direnv >/dev/null 2>&1 && [ ! -f "${WORKTREE_PATH}/.envrc" ]; then
 	cat > "${WORKTREE_PATH}/.envrc" <<EOF
 source_up
 use_otel_context "${OTEL_PROJECT}"
 EOF
-	direnv allow "${WORKTREE_PATH}" 2>/dev/null || true
-	echo "📡 OTEL context configured (.envrc created + allowed)"
+	echo "📡 OTEL context configured (.envrc created)"
 fi
 
 # Change to worktree directory
@@ -315,6 +315,12 @@ fi
 if [ -n "$HOOKS_JSON" ] && [ "$HOOKS_JSON" != "[]" ]; then
 	echo -e "${YELLOW}🔧 Running orchestration hooks...${NC}"
 	run_hook_array "$HOOKS_JSON" "orchestration"
+fi
+
+# Allow direnv AFTER all setup hooks have run (hooks like setup-env.sh may modify .envrc)
+if command -v direnv >/dev/null 2>&1 && [ -f "${WORKTREE_PATH}/.envrc" ]; then
+	direnv allow "${WORKTREE_PATH}/.envrc" 2>/dev/null || true
+	echo "📡 direnv allowed"
 fi
 
 # Return to original directory

--- a/plugins/dev/skills/ci-describe-pr/SKILL.md
+++ b/plugins/dev/skills/ci-describe-pr/SKILL.md
@@ -89,14 +89,8 @@ gh pr edit $PR_NUMBER --body-file "thoughts/shared/prs/${PR_NUMBER}_description.
 
 ### 7. Update Linear (if ticket found)
 
-```bash
-if [[ -n "$ticket" ]] && command -v linearis &>/dev/null; then
-  IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .catalyst/config.json 2>/dev/null || echo "In Review")
-  if [[ "$IN_REVIEW_STATE" != "null" ]]; then
-    linearis issues update "$ticket" --status "$IN_REVIEW_STATE" --assignee "@me"
-  fi
-fi
-```
+If Linearis CLI is available, update the ticket status to `stateMap.inReview` from config.
+Use `linearis issues usage` for exact update syntax. Skip silently if CLI not available.
 
 ### 8. Report
 

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -69,15 +69,8 @@ Auto-discovery has already run in Prerequisites above. Check its output and foll
 2. **Extract ticket and update Linear state**:
 
    If a ticket is detected (from the research document's `source_ticket` frontmatter, from the
-   command argument, or from context), move it to the planning state:
-
-   ```bash
-   PLANNING_STATE=$(jq -r '.catalyst.linear.stateMap.planning // "In Progress"' .catalyst/config.json 2>/dev/null || echo "In Progress")
-   if [[ "$PLANNING_STATE" != "null" ]]; then
-       linearis issues update "$ticketId" --status "$PLANNING_STATE"
-   fi
-   ```
-
+   command argument, or from context), update ticket status to `stateMap.planning` from config
+   using Linearis CLI (run `linearis issues usage` for syntax).
    If Linearis CLI is not available, skip silently and continue planning.
 
 3. **Spawn initial research tasks in parallel**:
@@ -380,12 +373,8 @@ compatibility → migration strategy
 If a ticket is detected (from research document's `source_ticket` frontmatter, command argument, or
 context):
 
-- **At planning start** (Step 1):
-  ```bash
-  PLANNING_STATE=$(jq -r '.catalyst.linear.stateMap.planning // "In Progress"' .catalyst/config.json 2>/dev/null || echo "In Progress")
-  if [[ "$PLANNING_STATE" != "null" ]]; then
-      linearis issues update "$ticketId" --status "$PLANNING_STATE"
-  fi
-  ```
-- **After plan saved**: `linearis comments create "$ticketId" --body "Plan created: $planPath"`
+- **At planning start** (Step 1): Update ticket status to `stateMap.planning` from config
+  using Linearis CLI (run `linearis issues usage` for syntax).
+- **After plan saved**: Add a comment with the plan path using Linearis CLI
+  (run `linearis comments usage` for syntax).
 - If Linearis CLI not available, skip silently and continue planning

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -217,21 +217,11 @@ Immediately call `/describe-pr` with the PR number to:
 If ticket was extracted from branch:
 
 ```bash
-# Verify linearis is available
-if ! command -v linearis &> /dev/null; then
-    echo "⚠️  Linearis CLI not found - skipping Linear ticket update"
-    echo "Install: npm install -g linearis"
-else
-    # Update ticket state from stateMap config
-    IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .catalyst/config.json 2>/dev/null || echo "In Review")
-    if [[ "$IN_REVIEW_STATE" != "null" ]]; then
-        linearis issues update "$ticket" --status "$IN_REVIEW_STATE" --assignee "@me"
-    fi
-
-    # Add comment with PR link
-    linearis comments create "$ticket" \
-        --body "PR created and ready for review!\n\n**PR**: $prUrl\n\nDescription has been auto-generated with verification checks."
-fi
+# If Linearis CLI is available:
+# 1. Update ticket status to stateMap.inReview from config
+# 2. Add a comment with the PR link
+# Use `linearis issues usage` and `linearis comments usage` for exact syntax.
+# Skip silently if CLI not available.
 ```
 
 ### 12. Post-PR Monitoring & Resolution Loop

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -228,28 +228,17 @@ If ticket found:
 - Related to [any other linked issues]
 ```
 
-Get Linear ticket details:
-
-```bash
-# Use Linearis CLI to get ticket details
-linearis issues read "$ticket"
-
-# Extract title and description with jq
-ticket_title=$(linearis issues read "$ticket" | jq -r '.title')
-ticket_description=$(linearis issues read "$ticket" | jq -r '.description')
-```
-
-Use ticket title and description for context.
+Get Linear ticket details using the Linearis CLI (run `linearis issues usage` for read syntax).
+Extract title and description with jq. Use ticket title and description for context.
 
 ### 9. Generate updated title
 
 **Title generation rules:**
 
 ```bash
-# If ticket exists and linearis available
+# If ticket exists and linearis available, read ticket title (see `linearis issues usage`)
 if [[ "$ticket" ]] && command -v linearis &>/dev/null; then
     ticket_title=$(linearis issues read "$ticket" | jq -r '.title')
-    # Format: TICKET: Descriptive title (max 72 chars)
     title="$ticket: ${ticket_title:0:60}"
 elif [[ "$ticket" ]]; then
     # Fallback: generate title from branch name + commits
@@ -362,20 +351,11 @@ gh pr edit $pr_number --body-file "thoughts/shared/prs/${pr_number}_description.
 If ticket found:
 
 ```bash
-# Verify linearis is available
-if ! command -v linearis &> /dev/null; then
-    echo "⚠️  Linearis CLI not found - skipping Linear ticket update"
-else
-    # Move to configured "In Review" state and assign to self
-    IN_REVIEW_STATE=$(jq -r '.catalyst.linear.stateMap.inReview // "In Review"' .catalyst/config.json 2>/dev/null || echo "In Review")
-    if [[ "$IN_REVIEW_STATE" != "null" ]]; then
-        linearis issues update "$ticket" --status "$IN_REVIEW_STATE" --assignee "@me"
-    fi
-
-    # Add comment about update with PR link
-    linearis comments create "$ticket" \
-        --body "PR description updated!\n\n**Changes**: ${updateSummary}\n**Verification**: ${checksPassedCount}/${totalChecks} automated checks passed\n\nView PR: ${prUrl}"
-fi
+# If Linearis CLI is available:
+# 1. Update ticket status to stateMap.inReview from config
+# 2. Add a comment with the PR link and verification summary
+# Use `linearis issues usage` and `linearis comments usage` for exact syntax.
+# Skip silently if CLI not available.
 ```
 
 ### 14. Report results

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -61,13 +61,8 @@ Once you have a plan path:
 - Read the plan completely (no limit/offset)
 - Check for any existing checkmarks (- [x]) to see what's done
 - Read the original ticket and all files mentioned in the plan
-- **Extract ticket from plan frontmatter** (`source_ticket` field) and update Linear state:
-  ```bash
-  IN_PROGRESS_STATE=$(jq -r '.catalyst.linear.stateMap.inProgress // "In Progress"' .catalyst/config.json 2>/dev/null || echo "In Progress")
-  if [[ "$IN_PROGRESS_STATE" != "null" ]]; then
-      linearis issues update "$ticketId" --status "$IN_PROGRESS_STATE"
-  fi
-  ```
+- **Extract ticket from plan frontmatter** (`source_ticket` field) and update Linear state
+  to `stateMap.inProgress` from config using Linearis CLI (run `linearis issues usage` for syntax).
   If Linearis CLI is not available, skip silently and continue implementation.
 - Think deeply about how the pieces fit together
 - Create a todo list to track your progress
@@ -318,11 +313,6 @@ Lead (Opus) — Coordinates implementation
 
 If a ticket is detected (from plan document's `source_ticket` frontmatter or from context):
 
-- **At implementation start** (Step 3):
-  ```bash
-  IN_PROGRESS_STATE=$(jq -r '.catalyst.linear.stateMap.inProgress // "In Progress"' .catalyst/config.json 2>/dev/null || echo "In Progress")
-  if [[ "$IN_PROGRESS_STATE" != "null" ]]; then
-      linearis issues update "$ticketId" --status "$IN_PROGRESS_STATE"
-  fi
-  ```
+- **At implementation start** (Step 3): Update ticket status to `stateMap.inProgress` from config
+  using Linearis CLI (run `linearis issues usage` for syntax).
 - If Linearis CLI not available, skip silently and continue implementation

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -275,20 +275,11 @@ If ticket found and not using `--no-update`:
 
 ```bash
 # Verify linearis is available
-if ! command -v linearis &> /dev/null; then
-    echo "⚠️  Linearis CLI not found - skipping Linear ticket update"
-    echo "Install: npm install -g linearis"
-else
-    # Move to configured "Done" state
-    DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' .catalyst/config.json 2>/dev/null || echo "Done")
-    if [[ "$DONE_STATE" != "null" ]]; then
-        linearis issues update "$ticket" --status "$DONE_STATE"
-    fi
-
-    # Add merge comment
-    linearis comments create "$ticket" \
-        --body "✅ PR merged!\n\n**PR**: #${prNumber} - ${prTitle}\n**Merge commit**: ${mergeSha}\n**Merged into**: ${baseBranch}\n\nView PR: ${prUrl}"
-fi
+# If Linearis CLI is available:
+# 1. Update ticket status to stateMap.done from config
+# 2. Add a comment with PR number, merge commit, and base branch
+# Use `linearis issues usage` and `linearis comments usage` for exact syntax.
+# Skip silently if CLI not available.
 ```
 
 ### 11. Delete local branch and update base

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -206,7 +206,7 @@ This phase runs in the current session to allow user interaction during research
    Research complete. Would you like to create a Linear ticket from these findings?
    [y/N]
    ```
-   If yes, create a ticket via `linearis issue create` using the research summary as description,
+   If yes, create a ticket via the Linearis CLI (run `linearis issues usage` for create syntax) using the research summary as description,
    then register the ticket ID: `workflow-context.sh set-ticket "NEW-TICKET-ID"`
 5. **Conduct research**: Spawn parallel sub-agents (same as `/research-codebase`):
    - **codebase-locator**: Find relevant files

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -23,9 +23,10 @@ if ! command -v git &>/dev/null; then
 fi
 
 # 2. Linearis CLI (REQUIRED for ticket reading)
+# See /catalyst-dev:linearis for CLI syntax reference
 if ! command -v linearis &>/dev/null; then
   echo "ERROR: Linearis CLI required for ticket intake"
-  echo "Install: npm install -g @anthropic/linearis"
+  echo "Install: npm install -g linearis"
   exit 1
 fi
 
@@ -122,11 +123,12 @@ It NEVER:
 
 ### Phase 1: Intake & Dependency Analysis
 
-1. **Resolve tickets**: Based on invocation mode:
-   - Explicit IDs: validate each via `linearis issues read <ID>`
-   - `--project`: `linearis issues list --project "<name>" --status "Todo,Backlog,In Progress"`
-   - `--cycle current`: `linearis cycles list --current` then `linearis issues list --cycle <id>`
-   - `--file`: read IDs from file, validate each
+1. **Resolve tickets**: Based on invocation mode, use the Linearis CLI to fetch ticket data.
+   **For exact CLI syntax, run `linearis issues usage` or `linearis cycles usage`** — do not guess.
+   - Explicit IDs: read each ticket's full details
+   - `--project`: list issues filtered by project name
+   - `--cycle current`: list the active cycle, then list its issues
+   - `--file`: read IDs from file, then read each ticket's details
 
 2. **Read ticket details**: For each ticket, extract:
    - Title, description, estimate
@@ -333,6 +335,7 @@ Initialize `state.json`:
 STATE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-state.sh"
 
 # Build the registration JSON with all workers from all waves
+# Use linearis CLI to read ticket titles (run `linearis issues usage` for syntax)
 WORKERS_JSON="{}"
 for TICKET_ID in "${ALL_TICKETS[@]}"; do
   TITLE=$(linearis issues read "$TICKET_ID" | jq -r '.title')
@@ -728,10 +731,7 @@ When all waves are complete:
    - Any verification failures that required remediation
 
 2. **Verify Linear states**: Check all tickets are in `stateMap.done`. If any are stuck,
-   update them:
-   ```bash
-   linearis issues update "${TICKET_ID}" --status "${STATE_MAP_DONE}"
-   ```
+   update them using the Linearis CLI (run `linearis issues usage` for update syntax).
 
 3. **Clean up all worktrees** (including orchestrator worktree, unless user wants to keep it).
 
@@ -834,11 +834,8 @@ The orchestrator manages Linear state transitions as a safety net:
 | PR merged | Verify ticket is `stateMap.done` — fix if not |
 | Worker fails/stalls | Add comment with status, keep `inProgress` |
 
-The orchestrator also adds comments to tickets for visibility:
-```bash
-linearis comments create "${TICKET_ID}" \
-  --body "Orchestrator [${ORCH_NAME}]: Worker dispatched. Phase: research."
-```
+The orchestrator also adds comments to tickets for visibility using the Linearis CLI
+(run `linearis comments usage` for syntax).
 
 ## Named Orchestrators & Remote Control
 

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -123,7 +123,7 @@ It NEVER:
 ### Phase 1: Intake & Dependency Analysis
 
 1. **Resolve tickets**: Based on invocation mode:
-   - Explicit IDs: validate each via `linearis issues get <ID>`
+   - Explicit IDs: validate each via `linearis issues read <ID>`
    - `--project`: `linearis issues list --project "<name>" --status "Todo,Backlog,In Progress"`
    - `--cycle current`: `linearis cycles list --current` then `linearis issues list --cycle <id>`
    - `--file`: read IDs from file, validate each
@@ -335,7 +335,7 @@ STATE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-state.sh"
 # Build the registration JSON with all workers from all waves
 WORKERS_JSON="{}"
 for TICKET_ID in "${ALL_TICKETS[@]}"; do
-  TITLE=$(linearis issues get "$TICKET_ID" --json title --quiet | jq -r '.title')
+  TITLE=$(linearis issues read "$TICKET_ID" | jq -r '.title')
   WORKERS_JSON=$(echo "$WORKERS_JSON" | jq \
     --arg tid "$TICKET_ID" --arg title "$TITLE" \
     '. + {($tid): {ticketId: $tid, title: $title, status: "dispatched", phase: 0, branch: null, pr: null, updatedAt: "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", needsAttention: false, attentionReason: null}}')

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -227,11 +227,8 @@ ticket ADV-33:
 
 This MUST print the path you just saved. If it doesn't, re-run step 8b.
 
-**8d. Linear comment** (if ticket detected):
-
-```bash
-linearis comments create "TICKET-ID" --body "Research complete: thoughts/shared/research/YYYY-MM-DD-description.md"
-```
+**8d. Linear comment** (if ticket detected): Add a comment noting research is complete and
+linking the document path. Use Linearis CLI (run `linearis comments usage` for syntax).
 
 **8e. Present summary to user:**
 
@@ -277,12 +274,8 @@ If the user has follow-up questions:
 
 If a ticket is detected (provided as argument, mentioned in query, or from context):
 
-- **At research start**:
-  ```bash
-  RESEARCH_STATE=$(jq -r '.catalyst.linear.stateMap.research // "In Progress"' .catalyst/config.json 2>/dev/null || echo "In Progress")
-  if [[ "$RESEARCH_STATE" != "null" ]]; then
-      linearis issues update "$ticketId" --status "$RESEARCH_STATE"
-  fi
-  ```
-- **After document saved**: `linearis comments create "$ticketId" --body "Research complete: $link"`
+- **At research start**: Update ticket status to `stateMap.research` from config
+  using Linearis CLI (run `linearis issues usage` for syntax).
+- **After document saved**: Add a comment with the document link
+  (run `linearis comments usage` for syntax).
 - If Linearis CLI not available, skip silently and continue research

--- a/plugins/pm/agents/github-linear-analyzer.md
+++ b/plugins/pm/agents/github-linear-analyzer.md
@@ -144,13 +144,8 @@ Return structured markdown:
 
 **Suggested Actions**:
 
-```bash
-# Create Linear issue for PR #125
-linearis issues create \
-  --team TEAM \
-  --title "Fix bug (from PR #125)" \
-  --description "Imported from PR: https://github.com/user/repo/pull/125"
-```
+Create a Linear issue for the orphaned PR using Linearis CLI (run `linearis issues usage` for
+create syntax). Include the PR URL in the description.
 ````
 
 ## 🏷️ Orphaned Issues (No PR)
@@ -167,24 +162,9 @@ linearis issues create \
 | TEAM-456 | #123 | 2025-01-25  | Close issue |
 | TEAM-457 | #124 | 2025-01-26  | Close issue |
 
-**Auto-close commands** (state name from `stateMap.done` config):
-
-```bash
-# Read configured done state
-CONFIG_FILE=".catalyst/config.json"
-[[ ! -f "$CONFIG_FILE" ]] && CONFIG_FILE=".claude/config.json"
-DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' "$CONFIG_FILE" 2>/dev/null || echo "Done")
-
-# Update state
-linearis issues update TEAM-456 --status "$DONE_STATE"
-# Add comment
-linearis comments create TEAM-456 --body "PR #123 merged: https://github.com/user/repo/pull/123"
-
-# Update state
-linearis issues update TEAM-457 --status "$DONE_STATE"
-# Add comment
-linearis comments create TEAM-457 --body "PR #124 merged: https://github.com/user/repo/pull/124"
-```
+**Auto-close**: For each issue with a merged PR, update ticket status to `stateMap.done`
+from config and add a comment with the PR link. Use `linearis issues usage` and
+`linearis comments usage` for exact syntax.
 
 ## 🕐 Stale PRs (Open >14 Days)
 

--- a/plugins/pm/skills/groom-backlog/SKILL.md
+++ b/plugins/pm/skills/groom-backlog/SKILL.md
@@ -177,22 +177,13 @@ If user chooses option 3, generate batch update script:
 
 ```bash
 #!/usr/bin/env bash
-# Backlog grooming updates - Generated 2025-01-27
+# Backlog grooming updates - Generated from audit
+# Use `linearis issues usage` and `linearis comments usage` for exact CLI syntax.
 
-# Move TEAM-456 to Auth project
-linearis issues update TEAM-456 --project "Auth & Security"
-
-# Move TEAM-123 to Frontend project
-linearis issues update TEAM-123 --project "Frontend"
-
-# Close stale issue TEAM-789 (state from stateMap.canceled config)
-CONFIG_FILE=".catalyst/config.json"
-[[ ! -f "$CONFIG_FILE" ]] && CONFIG_FILE=".claude/config.json"
-CANCELED_STATE=$(jq -r '.catalyst.linear.stateMap.canceled // "Canceled"' "$CONFIG_FILE" 2>/dev/null || echo "Canceled")
-linearis issues update TEAM-789 --status "$CANCELED_STATE"
-linearis comments create TEAM-789 --body "Closing stale issue (>30 days inactive)"
-
-# [... more commands ...]
+# For each recommended action, use linearis to:
+# - Move tickets to projects: update with --project flag
+# - Close stale issues: update status to stateMap.canceled from config, add comment
+# - Re-prioritize: update with --priority flag
 
 echo "✅ Backlog grooming updates applied"
 ```

--- a/plugins/pm/skills/sync-prs/SKILL.md
+++ b/plugins/pm/skills/sync-prs/SKILL.md
@@ -125,15 +125,8 @@ Use Task tool with `github-linear-analyzer` agent:
 
 **Recommended Actions**:
 
-```bash
-# Create Linear issue for PR #125
-linearis issues create \
-  --team TEAM \
-  --title "Fix bug (from PR #125)" \
-  --description "Imported from PR: https://github.com/user/repo/pull/125"
-
-# Or manually link in Linear UI
-```
+Create a Linear issue for the orphaned PR using Linearis CLI (run `linearis issues usage` for
+create syntax). Include the PR URL in the description.
 ````
 
 ## 🏷️ Orphaned Issues (No PR)
@@ -150,24 +143,9 @@ linearis issues create \
 | TEAM-456 | #123 | 2025-01-25 | Close issue |
 | TEAM-457 | #124 | 2025-01-26 | Close issue |
 
-**Auto-close commands** (state name from `stateMap.done` config):
-
-```bash
-# Read configured done state
-CONFIG_FILE=".catalyst/config.json"
-[[ ! -f "$CONFIG_FILE" ]] && CONFIG_FILE=".claude/config.json"
-DONE_STATE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' "$CONFIG_FILE" 2>/dev/null || echo "Done")
-
-# Update state
-linearis issues update TEAM-456 --status "$DONE_STATE"
-# Add comment
-linearis comments create TEAM-456 --body "PR #123 merged: https://github.com/user/repo/pull/123"
-
-# Update state
-linearis issues update TEAM-457 --status "$DONE_STATE"
-# Add comment
-linearis comments create TEAM-457 --body "PR #124 merged: https://github.com/user/repo/pull/124"
-```
+**Auto-close commands**: For each issue with a merged PR, update ticket status to `stateMap.done`
+from config and add a comment with the PR link. Use `linearis issues usage` and
+`linearis comments usage` for exact syntax.
 
 ## 🕐 Stale PRs (Open >14 days)
 


### PR DESCRIPTION
## Summary
- **DRY audit**: Remove hardcoded linearis CLI commands from 12 skills/agents across dev and pm plugins. Each now describes intent and references `linearis <domain> usage` for exact syntax. Single source of truth is the linearis skill.
- **direnv fix**: Move `direnv allow` from before setup hooks to after in `create-worktree.sh`, preventing re-blocking when hooks modify `.envrc`
- **`@me` bug**: Remove `--assignee "@me"` from ci-describe-pr, create-pr, describe-pr — linearis requires a UUID, `@me` returns "User not found"
- **linearis syntax**: Fix `issues get` → `issues read`, `issue create` → `issues create`

### Files changed (13)
**Scripts**: `create-worktree.sh`
**Dev skills**: orchestrate, oneshot, ci-describe-pr, create-plan, create-pr, describe-pr, implement-plan, merge-pr, research-codebase
**PM skills**: groom-backlog, sync-prs
**PM agents**: github-linear-analyzer

## Test plan
- [ ] Create a worktree — no `direnv: error .envrc is blocked` on launch
- [ ] Run `/catalyst-dev:orchestrate --dry-run` — linearis calls succeed on first try
- [ ] Run `/catalyst-dev:create-pr` — no `@me` error on ticket update

🤖 Generated with [Claude Code](https://claude.com/claude-code)