### PR TITLE
fix(dev): DRY linearis CLI commands, fix setup false positive

### DIFF
--- a/plugins/dev/agents/linear-research.md
+++ b/plugins/dev/agents/linear-research.md
@@ -38,56 +38,13 @@ Linearis CLI tool.
 **CLI Syntax**: The `linearis` skill provides full CLI syntax reference. It is auto-loaded when
 needed.
 
-## Key Commands
+## CLI Syntax
 
-### Ticket Operations
+For exact command syntax, run `linearis <domain> usage` (e.g., `linearis issues usage`,
+`linearis cycles usage`). The `/catalyst-dev:linearis` skill is the authoritative reference — **do
+not guess or improvise commands**.
 
-```bash
-# List tickets (note: issues list only supports --limit, not --team or --status)
-linearis issues list --limit 100
-
-# Filter by team and status using jq
-linearis issues list --limit 100 | jq '.[] | select(.team.key == "TEAM" and .state.name == "In Progress")'
-
-# Read specific ticket
-linearis issues read TICKET-123
-
-# Search tickets by title
-linearis issues list --limit 100 | jq '.[] | select(.title | contains("search term"))'
-```
-
-### Cycle Operations
-
-```bash
-# List cycles for team
-linearis cycles list --team TEAM [--active] [--limit 5]
-
-# Read cycle details
-linearis cycles read "Sprint 2025-10" --team TEAM
-
-# Get active cycle
-linearis cycles list --team TEAM --active
-```
-
-### Project Operations
-
-```bash
-# List projects
-linearis projects list
-
-# Get project details (parse JSON output)
-linearis projects list | jq '.[] | select(.name == "Project Name")'
-```
-
-### Configuration Discovery
-
-```bash
-# Get full command list
-linearis usage
-
-# List labels
-linearis labels list --team TEAM
-```
+All linearis output is JSON — use jq for filtering and transformation.
 
 ## Output Format
 

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -47,8 +47,10 @@ fi
 
 # 2. Check thoughts is synced (has .git or is managed)
 if [[ -d "thoughts" ]] && [[ ! -d "thoughts/.git" ]] && [[ ! -L "thoughts" ]]; then
-	# thoughts exists but isn't git-backed or a symlink
-	warnings+=("thoughts/ exists but doesn't appear to be git-backed — run: humanlayer thoughts sync")
+	# Only warn if humanlayer CLI isn't available to manage thoughts
+	if ! command -v humanlayer &>/dev/null; then
+		warnings+=("thoughts/ exists but doesn't appear to be managed — install humanlayer CLI or run: humanlayer thoughts sync")
+	fi
 fi
 
 # 3. Check CLAUDE.md has Catalyst snippet

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -47,9 +47,13 @@ fi
 
 # 2. Check thoughts is synced (has .git or is managed)
 if [[ -d "thoughts" ]] && [[ ! -d "thoughts/.git" ]] && [[ ! -L "thoughts" ]]; then
-	# Only warn if humanlayer CLI isn't available to manage thoughts
-	if ! command -v humanlayer &>/dev/null; then
-		warnings+=("thoughts/ exists but doesn't appear to be managed — install humanlayer CLI or run: humanlayer thoughts sync")
+	if command -v humanlayer &>/dev/null; then
+		hl_status=$(humanlayer thoughts status 2>&1 || true)
+		if ! echo "$hl_status" | grep -q "Repository:"; then
+			warnings+=("thoughts/ exists but humanlayer is not configured — run: humanlayer thoughts init")
+		fi
+	else
+		warnings+=("thoughts/ exists but is not git-backed and humanlayer is not installed")
 	fi
 fi
 

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -44,14 +44,11 @@ CONFIG_FILE=".catalyst/config.json"
 TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // "PROJ"' "$CONFIG_FILE")
 
 # Read team UUID — required for issues create and issues search (keys don't work)
-# Fallback chain: config → lookup from existing issue → error
+# Use `linearis teams usage` to discover UUIDs — see /catalyst-dev:linearis
 TEAM_UUID=$(jq -r '.catalyst.linear.teamUuid // empty' "$CONFIG_FILE")
 if [ -z "$TEAM_UUID" ]; then
-  TEAM_UUID=$(linearis issues list --limit 1 | jq -r --arg key "$TEAM_KEY" '.[0].team | select(.key == $key) | .id // empty')
-fi
-if [ -z "$TEAM_UUID" ]; then
   echo "WARNING: Could not resolve team UUID for $TEAM_KEY. issues create/search may target wrong team."
-  echo "Add teamUuid to .catalyst/config.json to fix: linearis issues list --limit 20 | jq '[.[].team | {key, id}] | unique_by(.key)'"
+  echo "Add teamUuid to .catalyst/config.json — see /catalyst-dev:linearis for lookup commands"
 fi
 
 # Read thoughts repo URL
@@ -71,11 +68,7 @@ THOUGHTS_URL=$(jq -r '.catalyst.linear.thoughtsRepoUrl // "https://github.com/or
 }
 ```
 
-To find your team UUID:
-
-```bash
-linearis issues list --limit 20 | jq '[.[].team | {key, id, name}] | unique_by(.key)'
-```
+To find your team UUID, see `/catalyst-dev:linearis` for team discovery commands.
 
 ## Initial Response
 
@@ -219,31 +212,14 @@ When referencing thoughts documents, always provide GitHub links:
 
 6. **Create the Linear ticket using Linearis CLI:**
 
-   ```bash
-   # Create issue with linearis
-   # WARNING: --team only accepts UUIDs, not team keys/names (upstream bug: czottmann/linearis#56)
-   # Team keys/names silently fall back to the workspace default team.
-   # Get the team UUID from config or from any existing issue:
-   #   TEAM_UUID=$(jq -r '.catalyst.linear.teamUuid // empty' .catalyst/config.json)
-   #   # Or: TEAM_UUID=$(linearis issues list --limit 1 | jq -r '.[0].team.id')
-   linearis issues create "[refined title]" \
-     --team "$TEAM_UUID" \
-     --description "[final description in markdown]" \
-     --priority [1-4] \
-     --status "$(jq -r '.catalyst.linear.stateMap.backlog // "Backlog"' .catalyst/config.json 2>/dev/null || echo "Backlog")"
+   Use `linearis issues usage` for create syntax, or see `/catalyst-dev:linearis`.
 
-   # Capture the created issue ID from output
-   ISSUE_ID=$(linearis issues create "[refined title]" --team "$TEAM_UUID" -d "Description" | jq -r '.id')
-   ```
+   **Important**: `--team` only accepts UUIDs, not team keys/names (upstream bug:
+   czottmann/linearis#56). Team keys silently fall back to the workspace default. Use the
+   `$TEAM_UUID` from config above.
 
-   **Note**: Linearis creates issues in the team's default backlog state. To set specific status or
-   assignee, create first then update:
-
-   ```bash
-   # Assign to a user (requires user UUID, not email or @me)
-   # Look up your user ID: linearis issues list --limit 5 | jq '[.[].assignee | select(.) | {name, id}] | unique_by(.id)'
-   linearis issues update "$ISSUE_ID" --assignee "<user-uuid>"
-   ```
+   Linearis creates issues in the team's default backlog state. To set specific status or assignee,
+   create first then update. Capture the created issue ID from the JSON output with jq.
 
 7. **Post-creation actions:**
    - Show the created ticket URL
@@ -265,7 +241,7 @@ When user wants to add a comment to a ticket:
 
 1. **Determine which ticket:**
    - Use context from the current conversation to identify the relevant ticket
-   - If uncertain, use `linearis issues read TEAM-123` to show ticket details and confirm
+   - If uncertain, read the ticket to show details and confirm (see `linearis issues usage`)
 
 2. **Format comments for clarity:**
    - Keep concise (~10 lines) unless more detail needed
@@ -291,21 +267,13 @@ When user wants to add a comment to a ticket:
    - `thoughts/shared/rate_limit_analysis.md` ([GitHub](link))
    ```
 
-5. **Add comment with Linearis:**
-
-   ```bash
-   linearis comments create TEAM-123 --body "Your comment text here"
-   ```
+5. **Add comment with Linearis** (see `linearis comments usage` for syntax)
 
 ### 3. Moving Tickets Through Workflow
 
 When moving tickets to a new status:
 
-1. **Get current status:**
-
-   ```bash
-   linearis issues read TEAM-123 | jq -r '.state.name'
-   ```
+1. **Get current status** by reading the ticket (see `linearis issues usage`)
 
 2. **Suggest next status based on workflow:**
 
@@ -328,16 +296,9 @@ When moving tickets to a new status:
    - `/create-pr` with ticket → Move to `stateMap.inReview`
    - `/merge-pr` with ticket → Move to `stateMap.done`
 
-4. **Manual status updates:**
+4. **Manual status updates** — use `linearis issues usage` for update syntax
 
-   ```bash
-   linearis issues update TEAM-123 --status "In Progress"
-   ```
-
-5. **Add comment explaining the transition:**
-   ```bash
-   linearis comments create TEAM-123 --body "Moving to In Progress: Starting implementation"
-   ```
+5. **Add comment explaining the transition** — use `linearis comments usage` for syntax
 
 ### 4. Searching for Tickets
 
@@ -348,28 +309,10 @@ When user wants to find tickets:
    - Status filters
    - Assignee filters
 
-2. **Execute search:**
-
-   ```bash
-   # Text search — use `issues search` for server-side query matching
-   # WARNING: --team requires a UUID, not a team key (upstream bug: czottmann/linearis#56)
-   linearis issues search "search term" --team "$TEAM_UUID"
-   linearis issues search "search term" --status "In Progress,In Review"
-   linearis issues search "search term" --limit 20
-
-   # List + jq — use for filtering by fields that search doesn't support
-   # (linearis issues list only supports --limit, not --team)
-   linearis issues list --limit 100
-
-   # Filter by team using jq
-   linearis issues list --limit 100 | jq '.[] | select(.team.key == "TEAM")'
-
-   # Filter by status using jq
-   linearis issues list --limit 100 | jq '.[] | select(.state.name == "In Progress")'
-
-   # Filter by assignee using jq
-   linearis issues list --limit 100 | jq '.[] | select(.assignee.email == "user@example.com")'
-   ```
+2. **Execute search** using `linearis issues usage` for search/list syntax:
+   - Use `issues search` for server-side query matching
+   - Use `issues list` + jq for filtering by fields that search doesn't support
+   - **Note**: `--team` requires a UUID on search (upstream bug: czottmann/linearis#56)
 
 3. **Present results:**
    - Show ticket ID, title, status, assignee
@@ -439,16 +382,9 @@ When these commands are run, check if there's a related Linear ticket and update
 
 ### Workflow 2: Quick Ticket Updates
 
-```bash
-# Add progress comment
-linearis comments create PROJ-123 --body "Completed phase 1, moving to phase 2"
-
-# Move ticket forward (state name from stateMap config)
-linearis issues update PROJ-123 --status "In Progress"
-
-# Search for related tickets
-linearis issues list --limit 100 | jq '.[] | select(.team.key == "PROJ" and (.title | contains("authentication")))'
-```
+Add a progress comment, move the ticket forward using the state name from `stateMap` config, and
+search for related tickets. Use `linearis issues usage` and `linearis comments usage` for exact
+syntax.
 
 ---
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -252,7 +252,7 @@ linearis comments create ENG-123 --body "Merged: PR #456"
 2. **comments create**: The command is `linearis comments create`, not `issues comment`
 3. **milestones NOT project-milestones**: The command was renamed in v2026.4
 4. **--status requires --team**: On `issues list` and `issues search`, `--status` only works when `--team` is also provided
-5. **--team accepts keys, names, and UUIDs**: Any form works on all commands (e.g., `--team ENG`)
+5. **--team accepts keys, names, and UUIDs on most commands** (e.g., `--team ENG`), but `issues create` and `issues search` require a UUID — keys/names silently fall back to the workspace default team (upstream bug: czottmann/linearis#56)
 6. **Quotes for spaces**: `--status "In Progress"` not `--status In Progress`
 7. **JSON output**: All commands return JSON — use jq for parsing
 8. **Use `linearis <domain> usage`**: When unsure about flags, check usage instead of guessing

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -338,7 +338,7 @@ STATE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-state.sh"
 # Use linearis CLI to read ticket titles (run `linearis issues usage` for syntax)
 WORKERS_JSON="{}"
 for TICKET_ID in "${ALL_TICKETS[@]}"; do
-  TITLE=$(linearis issues read "$TICKET_ID" | jq -r '.title')
+  TITLE=$(linearis issues read "$TICKET_ID" | jq -r '.title')  # see `linearis issues usage`
   WORKERS_JSON=$(echo "$WORKERS_JSON" | jq \
     --arg tid "$TICKET_ID" --arg title "$TITLE" \
     '. + {($tid): {ticketId: $tid, title: $title, status: "dispatched", phase: 0, branch: null, pr: null, updatedAt: "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", needsAttention: false, attentionReason: null}}')

--- a/plugins/dev/skills/resume-handoff/SKILL.md
+++ b/plugins/dev/skills/resume-handoff/SKILL.md
@@ -204,17 +204,8 @@ Once you have a handoff path:
 ## CLI Tools
 
 When you need to fetch ticket context from Linear (e.g., reading a ticket referenced in the
-handoff), use the Linearis CLI. For exact syntax, run `linearis issues usage` — **do not guess
-commands**.
-
-Quick reference for the most common operation during handoff resume:
-
-```bash
-linearis issues read PROJ-123          # Read a ticket (NOT 'get' or 'view')
-linearis comments create PROJ-123 --body "Resuming work from handoff"
-```
-
-For full CLI syntax, see `/catalyst-dev:linearis`.
+handoff), use the Linearis CLI. For exact syntax, run `linearis issues usage` or see
+`/catalyst-dev:linearis` — **do not guess commands**.
 
 ## Guidelines
 

--- a/plugins/dev/skills/resume-handoff/SKILL.md
+++ b/plugins/dev/skills/resume-handoff/SKILL.md
@@ -201,6 +201,21 @@ Once you have a handoff path:
 3. **Apply patterns and approaches documented** in the handoff
 4. **Update progress** as tasks are completed
 
+## CLI Tools
+
+When you need to fetch ticket context from Linear (e.g., reading a ticket referenced in the
+handoff), use the Linearis CLI. For exact syntax, run `linearis issues usage` — **do not guess
+commands**.
+
+Quick reference for the most common operation during handoff resume:
+
+```bash
+linearis issues read PROJ-123          # Read a ticket (NOT 'get' or 'view')
+linearis comments create PROJ-123 --body "Resuming work from handoff"
+```
+
+For full CLI syntax, see `/catalyst-dev:linearis`.
+
 ## Guidelines
 
 1. **Be Thorough in Analysis**:

--- a/plugins/pm/README.md
+++ b/plugins/pm/README.md
@@ -523,7 +523,7 @@ echo '{"catalyst": {"linear": {"teamKey": "TEAM"}}}' > .catalyst/config.json
 Verify you have an active cycle in Linear:
 
 ```bash
-linearis cycles list --team TEAM
+# Run `linearis cycles usage` for exact syntax
 ```
 
 Create a cycle in Linear UI or via API.

--- a/plugins/pm/agents/linear-metrics.md
+++ b/plugins/pm/agents/linear-metrics.md
@@ -61,155 +61,35 @@ LINEAR_TEAM=$(jq -r '.catalyst.linear.teamKey' "$SECRETS_FILE")
 
 ### Step 2: Collect Completed Issues
 
-Fetch all issues completed in the time period:
-
-```bash
-# Get completed issues with full metadata
-linearis issues search \
-  "completed:>=$START_DATE" \
-  --team "$LINEAR_TEAM" \
-  --format json | jq '[.[] | {
-    id,
-    identifier,
-    title,
-    state: .state.name,
-    assignee: .assignee.name,
-    priority,
-    estimate,
-    project: .project.name,
-    projectId: .project.id,
-    cycle: .cycle.name,
-    cycleId: .cycle.id,
-    createdAt,
-    startedAt,
-    completedAt,
-    labels: [.labels[].name],
-    parent: .parent.identifier,
-    subIssues: [.children[].identifier],
-    blockedBy: [.relations[] | select(.type == "blocks") | .relatedIssue.identifier]
-  }]'
-```
+Search for issues completed in the time period. Use `linearis issues usage` for search syntax. Extract with jq:
+`id`, `identifier`, `title`, `state.name`, `assignee.name`, `priority`, `estimate`, `project.name`,
+`cycle.name`, `createdAt`, `startedAt`, `completedAt`, `labels[].name`, `parent.identifier`,
+`children[].identifier`, blocker relations.
 
 ### Step 3: Collect Active Cycles
 
-Fetch current and recent cycles:
-
-```bash
-# Get active and completed cycles in period
-linearis cycles list \
-  --team "$LINEAR_TEAM" \
-  --format json | jq '[.[] | select(
-    .startsAt >= "'"$START_DATE"'" or .endsAt >= "'"$START_DATE"'"
-  ) | {
-    id,
-    name,
-    number,
-    startsAt,
-    endsAt,
-    completedAt,
-    progress,
-    scopedIssueCount,
-    completedIssueCount,
-    inProgressIssueCount,
-    backlogIssueCount,
-    unestimatedIssueCount
-  }]'
-```
+Fetch current and recent cycles. Use `linearis cycles usage` for list syntax. Filter by date range
+with jq. Extract: `id`, `name`, `number`, `startsAt`, `endsAt`, `progress`, issue counts by status.
 
 ### Step 4: Collect Milestone Data
 
-Fetch active milestones:
-
-```bash
-# Get milestones with progress
-linearis projects list \
-  --team "$LINEAR_TEAM" \
-  --format json | jq '[.[] | select(.targetDate != null) | {
-    id,
-    name,
-    description,
-    targetDate,
-    startDate,
-    state,
-    progress,
-    scope,
-    lead: .lead.name,
-    members: [.members[].name],
-    completedIssueCount,
-    totalIssueCount,
-    completedScopeCount,
-    totalScopeCount
-  }]'
-```
+Fetch active milestones. Use `linearis milestones usage` for list syntax. Filter for milestones with
+target dates. Extract: `id`, `name`, `targetDate`, `state`, `progress`, issue counts.
 
 ### Step 5: Collect Project Assignments
 
-Group issues by project:
-
-```bash
-# Get all projects with issue counts
-linearis projects list \
-  --team "$LINEAR_TEAM" \
-  --format json | jq '[.[] | {
-    id,
-    name,
-    description,
-    state,
-    lead: .lead.name,
-    issueCount,
-    completedIssueCount,
-    canceledIssueCount,
-    startedIssueCount,
-    backlogIssueCount,
-    startDate,
-    targetDate,
-    priority
-  }]'
-```
+List projects with issue counts. Use `linearis projects usage` for list syntax. Extract: `id`,
+`name`, `state`, `lead`, issue counts by status, `startDate`, `targetDate`, `priority`.
 
 ### Step 6: Collect Team Member Data
 
-Aggregate metrics by assignee:
-
-```bash
-# Get all team members with issue counts
-linearis team members \
-  --team "$LINEAR_TEAM" \
-  --format json | jq '[.[] | {
-    id,
-    name,
-    email,
-    active,
-    assignedIssueCount,
-    completedIssueCount
-  }]'
-```
+Aggregate metrics by assignee from collected issue data using jq. Group completed/assigned issues by
+`assignee.name`.
 
 ### Step 7: Collect Blocker Data
 
-Find all blocked issues:
-
-```bash
-# Get blocked issues with blocker details
-linearis issues search \
-  "state:in_progress OR state:todo" \
-  --team "$LINEAR_TEAM" \
-  --format json | jq '[.[] | select(
-    .relations[] | select(.type == "blocks")
-  ) | {
-    identifier,
-    title,
-    assignee: .assignee.name,
-    priority,
-    blockedBy: [.relations[] | select(.type == "blocks") | {
-      identifier: .relatedIssue.identifier,
-      title: .relatedIssue.title,
-      state: .relatedIssue.state.name,
-      assignee: .relatedIssue.assignee.name
-    }],
-    blockedSince: .updatedAt
-  }]'
-```
+Search for in-progress and todo issues, then filter for those with blocker relations using jq.
+Extract: `identifier`, `title`, `assignee`, `priority`, and the blocking issue details.
 
 ## Output Format
 

--- a/plugins/pm/agents/linear-research.md
+++ b/plugins/pm/agents/linear-research.md
@@ -42,7 +42,7 @@ Accept requests like:
 2. **Determine the appropriate linearis command**:
    - Cycle queries → `linearis cycles list/read`
    - Issue queries → `linearis issues list/search`
-   - Milestone queries → `linearis projectMilestones list/read`
+   - Milestone queries → `linearis milestones list/read`
    - Project queries → `linearis projects list`
 
 3. **Build the CLI command** with appropriate flags
@@ -102,7 +102,7 @@ echo "$backlog_no_cycle"
 PROJECT="Mobile App"
 MILESTONE="Q1 Launch"
 
-milestone_data=$(linearis projectMilestones read "$MILESTONE" \
+milestone_data=$(linearis milestones read "$MILESTONE" \
   --project "$PROJECT" \
   --issues-first 100 2>&1)
 

--- a/plugins/pm/agents/linear-research.md
+++ b/plugins/pm/agents/linear-research.md
@@ -50,71 +50,32 @@ Accept requests like:
 5. **Validate JSON structure**
 6. **Return data or error message**
 
+## CLI Syntax
+
+For exact command syntax, run `linearis <domain> usage` (e.g., `linearis issues usage`,
+`linearis cycles usage`, `linearis milestones usage`). The `/catalyst-dev:linearis` skill is the
+authoritative reference — **do not guess or improvise commands**.
+
 ## Examples
 
 ### Example 1: Get Active Cycle
 
 **Request**: "Get the active cycle for team ENG with all issues"
 
-**Processing**:
-
-```bash
-TEAM_KEY="ENG"
-cycle_data=$(linearis cycles list --team "$TEAM_KEY" --active 2>&1)
-
-# Validate JSON
-if echo "$cycle_data" | jq empty 2>/dev/null; then
-  echo "$cycle_data"
-else
-  echo "ERROR: Failed to fetch active cycle: $cycle_data"
-  exit 1
-fi
-```
-
-**Output**: Raw JSON from linearis
+**Steps**: Use `linearis cycles usage` for list/read syntax. Filter with jq. Validate JSON output.
 
 ### Example 2: Get Backlog Issues
 
 **Request**: "List all issues in Backlog status for team PROJ with no cycle"
 
-**Processing**:
-
-```bash
-TEAM_KEY="PROJ"
-# NOTE: issues list only supports --limit (no --team or --states flags)
-issues_data=$(linearis issues list --limit 100 2>&1 | jq --arg team "$TEAM_KEY" '[.[] | select(.team.key == $team and .state.name == "Backlog")]')
-
-# Filter for issues without cycles using jq
-backlog_no_cycle=$(echo "$issues_data" | jq '[.[] | select(.cycle == null)]')
-
-echo "$backlog_no_cycle"
-```
-
-**Output**: Filtered JSON array of backlog issues
+**Steps**: Use `linearis issues usage` for list syntax. Filter by team and status with jq. Further
+filter for `cycle == null`.
 
 ### Example 3: Get Milestone Details
 
 **Request**: "Get milestone 'Q1 Launch' details for project 'Mobile App' with issues"
 
-**Processing**:
-
-```bash
-PROJECT="Mobile App"
-MILESTONE="Q1 Launch"
-
-milestone_data=$(linearis milestones read "$MILESTONE" \
-  --project "$PROJECT" \
-  --issues-first 100 2>&1)
-
-if echo "$milestone_data" | jq empty 2>/dev/null; then
-  echo "$milestone_data"
-else
-  echo "ERROR: Failed to fetch milestone: $milestone_data"
-  exit 1
-fi
-```
-
-**Output**: Milestone JSON with issues array
+**Steps**: Use `linearis milestones usage` for read syntax. Validate JSON output.
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

- Remove hardcoded linearis CLI commands from 8 files (-322 lines), replacing with references to `linearis <domain> usage` and `/catalyst-dev:linearis`. The linearis skill is now the single source of truth for all CLI syntax.
- Fix `--team` UUID gotcha in linearis skill (was incorrectly documented as working on all commands — `issues create` and `issues search` require UUIDs)
- Fix `check-project-setup.sh` false positive for thoughts/ directory by using `humanlayer thoughts status` to validate configuration instead of checking for `.git` dir

## Files changed

| File | Change |
|---|---|
| `plugins/dev/skills/linear/SKILL.md` | Removed ~15 inline command blocks, replaced with usage references |
| `plugins/dev/agents/linear-research.md` | Replaced Key Commands section with skill reference |
| `plugins/pm/agents/linear-research.md` | Replaced example code blocks, fixed stale `projectMilestones` → `milestones` |
| `plugins/pm/agents/linear-metrics.md` | Replaced 6 step bash blocks with descriptions |
| `plugins/dev/skills/resume-handoff/SKILL.md` | Added CLI Tools section pointing to linearis skill |
| `plugins/dev/skills/orchestrate/SKILL.md` | Added usage reference comment to inline invocation |
| `plugins/dev/skills/linearis/SKILL.md` | Fixed `--team` UUID gotcha documentation |
| `plugins/dev/scripts/check-project-setup.sh` | Uses `humanlayer thoughts status` for real validation |
| `plugins/pm/README.md` | Replaced hardcoded troubleshooting command |

## Test plan

- [ ] Run `/catalyst-dev:resume-handoff` — verify agent uses correct linearis commands without fumbling
- [ ] Run `check-project-setup.sh` in a repo with humanlayer thoughts configured — no false positive
- [ ] Run `check-project-setup.sh` in a repo without humanlayer — appropriate warning shown
- [ ] Invoke linearis skill — verify it's still the authoritative reference with correct UUID caveat