### PR TITLE
fix(dev): add poll-until-merged loop and PR state verification

### DIFF
--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -378,9 +378,37 @@ fi
 echo ""
 
 # ============================================================
-# 8. WORKER SIGNAL CROSS-CHECK
+# 8. PR MERGE STATE VERIFICATION
 # ============================================================
-echo -e "${CYAN}--- 8. Worker Signal Cross-Check ---${NC}"
+echo -e "${CYAN}--- 8. PR Merge State ---${NC}"
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [ -n "$BRANCH" ]; then
+  PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+  if [ -n "$PR_NUMBER" ]; then
+    PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+    if [ "$PR_STATE" = "MERGED" ]; then
+      report_pass "PR #${PR_NUMBER} is MERGED"
+    elif [ "$PR_STATE" = "OPEN" ]; then
+      MERGE_STATUS=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")
+      report_fail "PR #${PR_NUMBER} is still OPEN (mergeStateStatus: ${MERGE_STATUS}) — worker exited before merge"
+    elif [ "$PR_STATE" = "CLOSED" ]; then
+      report_fail "PR #${PR_NUMBER} is CLOSED without merge"
+    else
+      report_warn "PR #${PR_NUMBER} state: ${PR_STATE}"
+    fi
+  else
+    report_fail "No PR found for branch ${BRANCH}"
+  fi
+else
+  report_warn "Could not determine current branch"
+fi
+echo ""
+
+# ============================================================
+# 9. WORKER SIGNAL CROSS-CHECK
+# ============================================================
+echo -e "${CYAN}--- 9. Worker Signal Cross-Check ---${NC}"
 
 if [ -n "$SIGNAL_FILE" ] && [ -f "$SIGNAL_FILE" ]; then
   # Compare worker's self-reported definitionOfDone with our findings

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -236,25 +236,46 @@ all the follow-up work manually.
 **Step 12a: Wait for CI checks and automated reviewers (3-5 minutes)**
 
 Automated review agents (Codex, security scanners, linters) typically post comments within 3-5
-minutes of PR creation. Wait for them before processing comments so you address everything in one
-pass.
+minutes of PR creation. CI checks also need time to run. Wait at least 3 minutes before checking,
+then poll every 30 seconds monitoring CI status, review comments, and PR state.
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 
-# Wait 3 minutes for initial CI + automated reviews
+# Wait 3 minutes — CI and automated reviewers need time to run
 sleep 180
 
 # Poll for up to 2 more minutes (5 min total) — check every 30s
 WAITED=180
 MAX_WAIT=300
 while [ $WAITED -lt $MAX_WAIT ]; do
+  # Check CI status
+  CI_STATUS=$(gh pr checks $pr_number --json state \
+    --jq '[.[].state] | unique | join(",")' 2>/dev/null || echo "PENDING")
+
+  # Check for review comments/threads
   COMMENT_COUNT=$(gh api "repos/${REPO}/pulls/${pr_number}/comments" --jq 'length')
   REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${pr_number}/reviews" \
     --jq '[.[] | select(.state != "APPROVED" and .state != "DISMISSED")] | length')
 
+  # Check PR state (may have auto-merged already)
+  PR_STATE=$(gh pr view $pr_number --json state --jq '.state' 2>/dev/null || echo "OPEN")
+
+  echo "Poll @${WAITED}s: state=${PR_STATE} CI=${CI_STATUS} comments=${COMMENT_COUNT} reviews=${REVIEW_COUNT}"
+
+  if [ "$PR_STATE" = "MERGED" ]; then
+    echo "PR already merged"
+    break
+  fi
+
   if [ "$COMMENT_COUNT" -gt 0 ] || [ "$REVIEW_COUNT" -gt 0 ]; then
     echo "Found review comments — proceeding to address them"
+    break
+  fi
+
+  # If all CI passed and no comments, clean exit
+  if echo "$CI_STATUS" | grep -qv "PENDING\|QUEUED"; then
+    echo "CI complete (${CI_STATUS}), no review comments — proceeding"
     break
   fi
 
@@ -449,8 +470,9 @@ Calling /describe-pr...
 
 ## Remember:
 
-- **NEVER stop at "PR created"** — monitor CI, address review comments, resolve blockers
-- **"PR created with auto-merge" is NOT done** — you must verify it actually merges cleanly
+- **NEVER stop at "PR created"** — poll every 30s (after 3-min minimum wait) checking CI, reviews,
+  and PR state. Address any comments, fix CI failures, confirm clean merge state
+- **"PR created with auto-merge" is NOT done** — poll until state=MERGED or genuinely human-blocked
 - **Automated reviewer comments are YOUR job** — address Codex/scanner feedback, don't wait for human
 - **Minimize prompts** — only ask when PR already exists
 - **Auto-rebase** — keep branch up-to-date with base

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -411,66 +411,90 @@ EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --j
 - **If no PR exists**:
   - Run `/create-pr` (handles commit, push, PR creation, description, Linear linking)
 
-**Step 2: Wait for Automated Reviewers**
+**Step 2: Monitor Through Merge**
 
-Automated review agents (Codex, Direnv, etc.) typically post comments within 3-5 minutes of PR
-creation. Wait for them before processing comments, so we can address everything in one pass.
+After creating/updating the PR, enter a monitoring loop. Do NOT exit until the PR is **actually
+merged** or genuinely blocked on human approval. "PR created with auto-merge" is NOT done.
+
+**Minimum 3-minute wait:** CI checks and automated reviewers (Codex, security scanners) need time
+to run. Always wait at least 3 minutes from PR creation before even checking status. Then poll
+every 30 seconds.
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-OWNER=$(echo "$REPO" | cut -d'/' -f1)
-NAME=$(echo "$REPO" | cut -d'/' -f2)
+MIN_WAIT=180  # 3 minutes — CI and reviewers need time
 
-# Wait 3 minutes, then start checking for comments
-sleep 180
+# Initial wait — do not skip this
+sleep $MIN_WAIT
 
-# Poll for up to 2 more minutes (5 min total) — check every 30s
-WAITED=180
-MAX_WAIT=300
+# Poll until merged or human-blocked (max 15 min total)
+MAX_WAIT=900
+WAITED=$MIN_WAIT
 while [ $WAITED -lt $MAX_WAIT ]; do
+  # 1. Check PR merge state — the primary exit condition
+  PR_STATE=$(gh pr view $PR_NUMBER --json state --jq '.state')
+  if [ "$PR_STATE" = "MERGED" ]; then
+    echo "✅ PR #${PR_NUMBER} merged"
+    break
+  fi
+  if [ "$PR_STATE" = "CLOSED" ]; then
+    echo "PR #${PR_NUMBER} was closed unexpectedly"
+    break
+  fi
+
+  # 2. Check CI status
+  CI_STATUS=$(gh pr checks $PR_NUMBER --json state \
+    --jq '[.[].state] | unique | join(",")' 2>/dev/null || echo "PENDING")
+
+  # 3. Check for review comments/threads
   COMMENT_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --jq 'length')
   REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
     --jq '[.[] | select(.state != "APPROVED" and .state != "DISMISSED")] | length')
 
+  echo "Poll @${WAITED}s: state=${PR_STATE} CI=${CI_STATUS} comments=${COMMENT_COUNT} reviews=${REVIEW_COUNT}"
+
+  # 4. Address review comments if any arrived
   if [ "$COMMENT_COUNT" -gt 0 ] || [ "$REVIEW_COUNT" -gt 0 ]; then
-    echo "Found review comments — proceeding to address them"
-    break
+    # Run /review-comments, resolve threads via GraphQL, push fixes
+    # Then continue polling — auto-merge will proceed once threads resolved
+  fi
+
+  # 5. If CI failed, investigate and fix
+  if echo "$CI_STATUS" | grep -q "FAILURE"; then
+    # Analyze failure logs, fix code, push — then continue polling
   fi
 
   sleep 30
   WAITED=$((WAITED + 30))
 done
-
-if [ "$COMMENT_COUNT" -eq 0 ] && [ "$REVIEW_COUNT" -eq 0 ]; then
-  echo "No automated review comments after ${MAX_WAIT}s — proceeding"
-fi
 ```
 
-**Step 3: Resolve All Merge Blockers**
+On each poll cycle, handle what you find:
 
-After the automated reviewer wait, proactively resolve any merge blockers before attempting merge.
-This runs the same workflow as `/merge-pr` Step 6 but earlier — while the PR is still fresh.
+- **PR state = MERGED** → exit loop, proceed to post-merge cleanup
+- **Review comments/threads exist** → address them: run `/review-comments ${PR_NUMBER}`, resolve
+  threads via GraphQL, push fixes. Then continue polling — auto-merge will retry once threads
+  are resolved and `required_conversation_resolution` is satisfied
+- **CI failing** → analyze failure logs, fix code, push, continue polling
+- **CI pending** → normal, continue polling
+- **Genuinely blocked on human approval** (`review-required` with no other fixable blockers) →
+  report what's needed and stop
 
-Read and follow `"${CLAUDE_PLUGIN_ROOT}/references/merge-blocker-diagnosis.md"`. This queries
-`mergeStateStatus` via GraphQL, identifies every specific blocker, and attempts to fix each one in
-a loop (max 3 rounds). Key blocker resolutions:
+The agent does NOT need to decide whether to merge. Auto-merge handles that. The agent's job is to
+**keep the path clear** (address reviews, fix CI) and **confirm it actually happened**.
 
-- `ci-failing` → analyze failure logs, fix code, push, re-poll
-- `unresolved-threads` → run `/review-comments` (see `review-thread-resolution.md`)
-- `branch-behind` → rebase and push
-- `draft` → `gh pr ready`
-- `changes-requested` → check if addressed; suggest re-request review
-- `review-required` → cannot fix — report how many approvals needed
+If the PR has not merged after 15 minutes of polling, run the full merge blocker diagnosis
+(`merge-blocker-diagnosis.md`) to identify exactly what's stuck and report to the user.
 
-If blockers remain after 3 rounds, present what was resolved and what still blocks with options
-to wait or create a handoff.
+**Step 3: Post-Merge Cleanup (only after PR state = MERGED)**
 
-**Step 4: Proceed to merge (default) or report status**
+Only execute this step after confirming `PR_STATE = "MERGED"` in the poll loop above.
 
-By default, oneshot completes the full lifecycle — it does NOT stop at PR creation. After resolving
-all blockers, it proceeds directly to Phase 6 (merge).
+- Move Linear ticket to `stateMap.done` (default: "Done") via Linearis CLI
+- Delete local branch: `git branch -D "$BRANCH" 2>/dev/null || true`
+- Update primary worktree: `git -C "$PRIMARY_WORKTREE" pull --rebase 2>/dev/null || true`
 
-If `--no-merge` was set, report the PR status and exit:
+**If `--no-merge` was set**, skip the poll loop and report PR status instead:
 
 ```
 PR ready: https://github.com/org/repo/pull/{number}
@@ -484,17 +508,14 @@ Merge state: $mergeStateStatus
 Merge later with: /catalyst-dev:merge-pr
 ```
 
-**Default behavior (no `--no-merge` flag):** Proceeds to Phase 6 automatically. Phase 6
-(`/merge-pr`) will run its own blocker diagnosis loop and resolve anything remaining. If all
-blockers are resolved, it merges. If a genuine human gate remains (e.g., required approval),
-it reports what's needed and stops.
-
 **Linear**: `/create-pr` moves ticket to `stateMap.inReview` (default: "In Review").
 
-### Phase 6: Merge (Same Session as Phase 5 — Sonnet)
+### Phase 6: Merge (Only When Auto-Merge is NOT Armed)
 
-Runs automatically by default. Only skipped if `--no-merge` flag was passed, in which case the user
-merges manually later with `/catalyst-dev:merge-pr`.
+If auto-merge is armed, Phase 5 Step 2's poll loop already confirms merge — skip Phase 6.
+
+If auto-merge is NOT armed (manual merge flow), run merge-pr after the poll loop confirms
+a clean merge state:
 
 ```
 /catalyst-dev:merge-pr
@@ -714,8 +735,8 @@ error, context exhaustion):
   full paths
 - **Phase 3 does NOT commit** — all git operations are deferred to Phase 5
 - **Phase 6 (merge) runs by default** — use `--no-merge` to opt out
-- **NEVER stop at "PR created"** — monitor CI, address automated review comments, resolve blockers,
-  and merge. "PR created with auto-merge" is NOT a terminal state — verify it actually merges
+- **NEVER stop at "PR created"** — poll every 30s (after 3-min minimum wait) checking CI, reviews,
+  and merge state. "PR created with auto-merge" is NOT done — poll until state=MERGED
 - **Automated reviewer comments are the agent's job** — Codex, security scanners, and linters post
   code comments that create unresolved threads. These are NOT "needs approving reviewer" — they are
   fixable blockers. Address the feedback, resolve the threads, and continue

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -473,15 +473,21 @@ MANDATORY: Before marking this ticket as complete:
 4. Security review — must pass /security-review or equivalent
 5. Code review — must pass code-reviewer agent
 6. All quality gates in config must pass
-7. PR MUST be monitored through merge — do NOT stop at "PR created"
-   - Wait for CI checks to pass
-   - Address ALL automated review comments (Codex, security scanners)
-   - Resolve all merge blocker threads via GraphQL
-   - Only report done when PR is actually MERGED or blocked on human approval
+7. PR MUST be monitored through ACTUAL MERGE — do NOT stop at "PR created"
+   After creating the PR with auto-merge, you MUST:
+   a. Wait at least 3 minutes — CI checks and automated reviewers need time
+   b. Poll every 30s: check PR state, CI status, and review comments
+   c. If review comments arrive — address them, resolve threads, push fixes
+   d. If CI fails — analyze, fix, push
+   e. Continue polling until gh pr view shows state=MERGED
+   f. Only stop if genuinely blocked on human approval (review-required)
+   "PR created with auto-merge" is NOT done. You are polling to CONFIRM
+   the merge happened, not to decide whether to merge. Auto-merge handles
+   that — your job is to keep the path clear and verify completion.
 
 Your work will be independently verified by the orchestrator. Do NOT mark as done
-until all test types exist AND the PR is merged. "PR created with auto-merge" is
-NOT done — you must verify it actually merges cleanly.
+until all test types exist AND the PR state is MERGED (confirmed via gh pr view).
+The orchestrator will independently check PR merge state during verification.
 
 Write your status to the worker signal file at:
   ${ORCH_DIR}/workers/${TICKET_ID}.json


### PR DESCRIPTION
## Summary

- Replaces the comment-only 3-5 min wait in oneshot Phase 5 with a unified "Monitor Through Merge" poll loop — 3-min minimum wait, then 30s polling cycles checking PR state, CI status, and review comments until `state=MERGED`
- Updates orchestrate dispatch prompt with concrete polling steps (a-f) so workers know exactly what to do instead of vague "monitor through merge"
- Adds new section 8 ("PR Merge State") to `orchestrate-verify.sh` — independently checks `gh pr view --json state` so even if the worker ignores polling instructions, verification catches the gap
- Updates create-pr poll loop to also check CI status and PR state alongside review comments

## Context

Workers dispatched via `claude -p` were exiting after creating a PR with auto-merge armed, saying "Waiting for CI to finish" as aspirational text rather than actually waiting. The existing instructions told workers not to stop at "PR created" but lacked concrete polling commands. The verification script checked code quality (tests, types, security) but never checked whether the PR actually merged.

## Test plan

- [ ] Deploy an orchestrated worker with `--auto-merge` and verify it polls until merge
- [ ] Verify `orchestrate-verify.sh` fails when PR is still OPEN
- [ ] Verify the 3-minute minimum wait is respected before first poll
- [ ] Verify review comments are addressed during poll cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)