### PR TITLE
feat(dev): add CI quality gates for orch-monitor

### DIFF
--- a/.github/workflows/orch-monitor-quality.yml
+++ b/.github/workflows/orch-monitor-quality.yml
@@ -1,0 +1,32 @@
+name: Orch Monitor Quality Gates
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "plugins/dev/scripts/orch-monitor/**"
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/dev/scripts/orch-monitor
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Test
+        run: bun test


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`orch-monitor-quality.yml`) that runs typecheck, lint, and tests on PRs touching `plugins/dev/scripts/orch-monitor/**`
- Uses `bun install --frozen-lockfile` for reproducible CI builds
- All 3 gates verified passing locally (99 tests, clean typecheck, clean lint)

## Test plan
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally  
- [x] `bun test` passes locally (99 tests, 245 assertions)
- [ ] Workflow triggers on this PR (touches orch-monitor path via prior commits)
- [ ] All 3 jobs pass in CI

Closes CTL-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)