### PR TITLE
fix(dev): worker worktrees get correct currentTicket + orchestration field

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,7 @@ Structure:
 {
   "lastUpdated": "2025-10-26T10:30:00Z",
   "currentTicket": "PROJ-123",
+  "orchestration": null,
   "mostRecentDocument": {
     "type": "plans",
     "path": "thoughts/shared/plans/2025-10-26-PROJ-123-feature.md",

--- a/plugins/dev/WORKFLOW_CONTEXT.md
+++ b/plugins/dev/WORKFLOW_CONTEXT.md
@@ -171,6 +171,7 @@ All commands gracefully fall back to asking for input:
 {
   "lastUpdated": "ISO timestamp",
   "currentTicket": "PROJ-123",
+  "orchestration": "orch-api-redesign-2026-04-13",
   "mostRecentDocument": {
     "type": "plans|research|handoffs|prs",
     "path": "thoughts/shared/.../file.md",
@@ -230,6 +231,10 @@ workflow-context.sh ticket PROJ-123
 # Set current ticket without adding a document
 workflow-context.sh set-ticket PROJ-123
 # → Sets currentTicket and lastUpdated; creates file if needed
+
+# Set orchestration run name
+workflow-context.sh set-orchestration orch-api-redesign-2026-04-13
+# → Sets orchestration and lastUpdated; creates file if needed
 
 # Initialize context file
 workflow-context.sh init

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # create-worktree.sh - Create a git worktree for isolated development
-# Usage: ./create-worktree.sh [worktree_name] [base_branch] [--worktree-dir <path>] [--hooks-json <json>]
+# Usage: ./create-worktree.sh [worktree_name] [base_branch] [--worktree-dir <path>] [--hooks-json <json>] [--orchestration <name>]
 #
 # Options:
-#   --worktree-dir <path>   Override worktree base directory (used by orchestrator)
-#   --hooks-json <json>     JSON array of setup hook commands to run after creation
+#   --worktree-dir <path>       Override worktree base directory (used by orchestrator)
+#   --hooks-json <json>         JSON array of setup hook commands to run after creation
+#   --orchestration <name>      Set orchestration run name in workflow context
 
 set -e
 
@@ -18,11 +19,13 @@ NC='\033[0m'
 POSITIONAL=()
 OVERRIDE_WORKTREE_DIR=""
 HOOKS_JSON=""
+ORCHESTRATION_NAME=""
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
 		--worktree-dir) OVERRIDE_WORKTREE_DIR="$2"; shift 2 ;;
 		--hooks-json) HOOKS_JSON="$2"; shift 2 ;;
+		--orchestration) ORCHESTRATION_NAME="$2"; shift 2 ;;
 		*) POSITIONAL+=("$1"); shift ;;
 	esac
 done
@@ -164,9 +167,11 @@ if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
 	rm -f "${WORKTREE_PATH}/.catalyst/.workflow-context.json"
 	mkdir -p "${WORKTREE_PATH}/.catalyst"
 
-	# Extract ticket from worktree name (e.g., ENG-123, orch-1-ADV-42)
+	# Extract ticket from worktree name, anchored to end to avoid false matches
+	# on date fragments in orchestrator prefixes (e.g., "import-2026" in
+	# "orch-data-import-2026-04-13-ADV-220" — we want ADV-220, not IMPORT-2026)
 	WT_TICKET=""
-	if [[ "$WORKTREE_NAME" =~ ([A-Za-z]+-[0-9]+) ]]; then
+	if [[ "$WORKTREE_NAME" =~ ([A-Za-z]+-[0-9]+)$ ]]; then
 		WT_TICKET=$(echo "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')
 	fi
 
@@ -176,6 +181,11 @@ if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
 		echo "📋 Workflow context initialized with ticket: ${WT_TICKET}"
 	else
 		echo "📋 Workflow context initialized (no ticket in worktree name)"
+	fi
+
+	if [ -n "$ORCHESTRATION_NAME" ]; then
+		(cd "$WORKTREE_PATH" && bash "${SCRIPT_DIR}/workflow-context.sh" set-orchestration "$ORCHESTRATION_NAME")
+		echo "📋 Orchestration context set: ${ORCHESTRATION_NAME}"
 	fi
 fi
 

--- a/plugins/dev/scripts/test-workflow-context.sh
+++ b/plugins/dev/scripts/test-workflow-context.sh
@@ -833,6 +833,72 @@ else
 	fail "recent returned '$RESULT', expected 'thoughts/shared/research/old.md'"
 fi
 
+# ── Test 32: set-orchestration sets orchestration field ───────────────────
+
+run_test "workflow-context.sh set-orchestration sets orchestration field"
+
+TEST_DIR="$TMPDIR/test32"
+setup_project "$TEST_DIR"
+
+(cd "$TEST_DIR" && bash plugins/dev/scripts/workflow-context.sh set-orchestration "orch-data-import-2026-04-13")
+
+ORCH=$(cd "$TEST_DIR" && jq -r '.orchestration' .catalyst/.workflow-context.json)
+UPDATED=$(cd "$TEST_DIR" && jq -r '.lastUpdated' .catalyst/.workflow-context.json)
+
+if [[ $ORCH == "orch-data-import-2026-04-13" ]]; then
+	pass "orchestration set correctly"
+else
+	fail "orchestration is '$ORCH', expected 'orch-data-import-2026-04-13'"
+fi
+if [[ -n $UPDATED && $UPDATED != "" ]]; then
+	pass "lastUpdated is set"
+else
+	fail "lastUpdated should be set after set-orchestration"
+fi
+
+# ── Test 33: init includes orchestration field ───────────────────────────
+
+run_test "workflow-context.sh init creates context with orchestration field"
+
+TEST_DIR="$TMPDIR/test33"
+setup_project "$TEST_DIR"
+
+(cd "$TEST_DIR" && bash plugins/dev/scripts/workflow-context.sh init)
+
+ORCH=$(cd "$TEST_DIR" && jq -r '.orchestration' .catalyst/.workflow-context.json)
+if [[ $ORCH == "null" ]]; then
+	pass "orchestration defaults to null"
+else
+	fail "orchestration is '$ORCH', expected 'null'"
+fi
+
+# ── Test 34: set-orchestration preserves currentTicket ───────────────────
+
+run_test "set-orchestration does not overwrite currentTicket"
+
+TEST_DIR="$TMPDIR/test34"
+setup_project "$TEST_DIR"
+
+(
+	cd "$TEST_DIR"
+	bash plugins/dev/scripts/workflow-context.sh set-ticket "ADV-220"
+	bash plugins/dev/scripts/workflow-context.sh set-orchestration "orch-data-import-2026-04-13"
+)
+
+TICKET=$(cd "$TEST_DIR" && jq -r '.currentTicket' .catalyst/.workflow-context.json)
+ORCH=$(cd "$TEST_DIR" && jq -r '.orchestration' .catalyst/.workflow-context.json)
+
+if [[ $TICKET == "ADV-220" ]]; then
+	pass "currentTicket preserved as ADV-220"
+else
+	fail "currentTicket is '$TICKET', expected 'ADV-220'"
+fi
+if [[ $ORCH == "orch-data-import-2026-04-13" ]]; then
+	pass "orchestration set correctly alongside ticket"
+else
+	fail "orchestration is '$ORCH', expected 'orch-data-import-2026-04-13'"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/workflow-context.sh
+++ b/plugins/dev/scripts/workflow-context.sh
@@ -27,6 +27,7 @@ init_context() {
 {
   "lastUpdated": "",
   "currentTicket": null,
+  "orchestration": null,
   "mostRecentDocument": null,
   "workflow": {
     "research": [],
@@ -99,6 +100,18 @@ set_ticket() {
 	mv "${CONTEXT_FILE}.tmp" "$CONTEXT_FILE"
 }
 
+# Set orchestration run name
+# Usage: set_orchestration <name>
+set_orchestration() {
+	local name="$1"
+	init_context
+	local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	jq --arg name "$name" --arg ts "$timestamp" \
+		'.orchestration = $name | .lastUpdated = $ts' \
+		"$CONTEXT_FILE" >"${CONTEXT_FILE}.tmp"
+	mv "${CONTEXT_FILE}.tmp" "$CONTEXT_FILE"
+}
+
 # Get documents for ticket
 # Usage: get_by_ticket <ticket>
 get_by_ticket() {
@@ -128,11 +141,14 @@ most-recent)
 set-ticket)
 	set_ticket "$2"
 	;;
+set-orchestration)
+	set_orchestration "$2"
+	;;
 ticket)
 	get_by_ticket "$2"
 	;;
 *)
-	echo "Usage: $0 {init|add|recent|most-recent|set-ticket|ticket}"
+	echo "Usage: $0 {init|add|recent|most-recent|set-ticket|set-orchestration|ticket}"
 	exit 1
 	;;
 esac

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -212,13 +212,16 @@ if [ "$SETUP_HOOKS" != "[]" ] && [ -n "$SETUP_HOOKS" ]; then
   HOOKS_FLAG="--hooks-json '${SETUP_HOOKS}'"
 fi
 
+# Pass --orchestration so all worktrees record which run they belong to
+ORCH_FLAG="--orchestration ${ORCH_NAME}"
+
 # 1. Create orchestrator worktree (same script, same initialization)
-"$SCRIPT" "${ORCH_NAME}" "${BASE_BRANCH}" ${WT_DIR_FLAG} ${HOOKS_FLAG}
+"$SCRIPT" "${ORCH_NAME}" "${BASE_BRANCH}" ${WT_DIR_FLAG} ${HOOKS_FLAG} ${ORCH_FLAG}
 ORCH_DIR="${WORKTREES_BASE}/${ORCH_NAME}"
 
 # 2. Create worker worktrees for current wave
 for TICKET_ID in "${WAVE_TICKETS[@]}"; do
-  "$SCRIPT" "${ORCH_NAME}-${TICKET_ID}" "${BASE_BRANCH}" ${WT_DIR_FLAG} ${HOOKS_FLAG}
+  "$SCRIPT" "${ORCH_NAME}-${TICKET_ID}" "${BASE_BRANCH}" ${WT_DIR_FLAG} ${HOOKS_FLAG} ${ORCH_FLAG}
 done
 ```
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -328,6 +328,7 @@ Auto-managed by Claude Code hooks and skills. Not committed to git.
 {
   "lastUpdated": "2025-10-26T10:30:00Z",
   "currentTicket": "PROJ-123",
+  "orchestration": null,
   "mostRecentDocument": {
     "type": "plans",
     "path": "thoughts/shared/plans/...",
@@ -343,6 +344,11 @@ Auto-managed by Claude Code hooks and skills. Not committed to git.
 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `currentTicket` | string \| null | Active ticket ID for this worktree |
+| `orchestration` | string \| null | Orchestration run name (set by `create-worktree.sh --orchestration`). Groups orchestrator + workers for per-run telemetry via `catalyst.orchestration` OTel resource attribute. |
+
 This file is what enables skill chaining — when you save research, `create-plan` finds it
 automatically. When you save a plan, `implement-plan` finds it. You never need to specify file paths
 between workflow phases.
@@ -354,6 +360,7 @@ The `workflow-context.sh` script manages this file programmatically:
 ```bash
 workflow-context.sh init                    # Create file if missing
 workflow-context.sh set-ticket PROJ-123     # Set currentTicket (no document needed)
+workflow-context.sh set-orchestration NAME  # Set orchestration run name
 workflow-context.sh add research "path" "PROJ-123"  # Add document + set ticket
 workflow-context.sh recent research         # Get most recent document of type
 workflow-context.sh most-recent             # Get most recent document (any type)


### PR DESCRIPTION
## Summary

- **Bug fix**: Anchored ticket-extraction regex in `create-worktree.sh` to `$` (end-of-string) so worker worktrees like `orch-data-import-2026-04-13-ADV-220` get `currentTicket: "ADV-220"` instead of the false match `IMPORT-2026` from the orchestrator prefix
- **Feature**: Added `orchestration` field to `.catalyst/.workflow-context.json` and `--orchestration` flag to `create-worktree.sh`, enabling per-run OTel telemetry grouping across orchestrator + worker sessions
- Updated orchestrate skill to pass `--orchestration` when creating worktrees

## Test plan

- [x] All 34 tests pass (3 new tests for orchestration field)
- [ ] Verify regex fix: create worktree named `orch-data-import-2026-04-13-ADV-220` and confirm `currentTicket` is `ADV-220`
- [ ] Verify orchestration flag: `create-worktree.sh foo --orchestration my-orch` sets `orchestration: "my-orch"` in workflow context
- [ ] Verify no regression: simple worktree names like `ENG-123` still extract ticket correctly

Closes CTL-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)