### PR TITLE
feat(dev): pre-assign Supabase migration numbers per wave (CTL-29)

### DIFF
--- a/plugins/dev/scripts/__tests__/pre-assign-migrations.test.sh
+++ b/plugins/dev/scripts/__tests__/pre-assign-migrations.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Shell tests for pre-assign-migrations.sh.
+# Run: bash plugins/dev/scripts/__tests__/pre-assign-migrations.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+PREASSIGN="${REPO_ROOT}/plugins/dev/scripts/pre-assign-migrations.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+expect_contains() {
+  local file="$1" needle="$2"
+  grep -qF -- "$needle" "$file" || { echo "    missing: $needle"; return 1; }
+}
+
+expect_not_contains() {
+  local file="$1" needle="$2"
+  ! grep -qF -- "$needle" "$file" || { echo "    unexpected: $needle"; return 1; }
+}
+
+expect_empty() {
+  local file="$1"
+  [ ! -s "$file" ] || { echo "    expected empty output; got:"; sed 's/^/    /' "$file"; return 1; }
+}
+
+expect_exit() {
+  local expected="$1"; shift
+  set +e
+  "$@" > "${SCRATCH}/out" 2>&1
+  local rc=$?
+  set -e
+  [ "$rc" = "$expected" ] || { echo "    expected rc=$expected got rc=$rc"; sed 's/^/    /' "${SCRATCH}/out"; return 1; }
+}
+
+echo "pre-assign-migrations tests"
+
+# Test 1: missing --tickets-json errors
+run "errors when --tickets-json omitted" \
+  expect_exit 1 "$PREASSIGN"
+
+# Test 2: no migrations dir → silent exit 0 (repo-agnostic)
+NOMIG_DIR="${SCRATCH}/no-migrations"
+mkdir -p "$NOMIG_DIR"
+"$PREASSIGN" --migrations-dir "${NOMIG_DIR}/supabase/migrations" \
+  --tickets-json '[{"id":"CTL-1","title":"add migration","description":"","labels":[]}]' \
+  > "${SCRATCH}/t2.out" 2>&1
+run "silent when migrations dir missing" expect_empty "${SCRATCH}/t2.out"
+
+# Test 3: no migration-likely tickets → silent output
+MIG_DIR="${SCRATCH}/supabase/migrations"
+mkdir -p "$MIG_DIR"
+touch "${MIG_DIR}/001_init.sql"
+touch "${MIG_DIR}/002_users.sql"
+"$PREASSIGN" --migrations-dir "$MIG_DIR" \
+  --tickets-json '[{"id":"CTL-1","title":"fix button styles","description":"small UI fix","labels":["frontend"]}]' \
+  > "${SCRATCH}/t3.out" 2>&1
+run "silent when no migration-likely tickets" expect_empty "${SCRATCH}/t3.out"
+
+# Test 4: single migration-likely ticket gets next number (003)
+"$PREASSIGN" --migrations-dir "$MIG_DIR" \
+  --tickets-json '[{"id":"CTL-10","title":"add users table","description":"CREATE TABLE users","labels":[]}]' \
+  > "${SCRATCH}/t4.out" 2>&1
+run "outputs Migration Number Assignments header" expect_contains "${SCRATCH}/t4.out" "## Migration Number Assignments"
+run "assigns next number (003) to single ticket" expect_contains "${SCRATCH}/t4.out" '**CTL-10**: `003_'
+
+# Test 5: multiple migration tickets get sequential numbers
+"$PREASSIGN" --migrations-dir "$MIG_DIR" \
+  --tickets-json '[
+    {"id":"CTL-10","title":"add users table","description":"CREATE TABLE users","labels":[]},
+    {"id":"CTL-11","title":"add orders","description":"schema change","labels":["database"]}
+  ]' \
+  > "${SCRATCH}/t5.out" 2>&1
+run "CTL-10 gets 003" expect_contains "${SCRATCH}/t5.out" '**CTL-10**: `003_'
+run "CTL-11 gets 004" expect_contains "${SCRATCH}/t5.out" '**CTL-11**: `004_'
+
+# Test 6: label-based detection
+"$PREASSIGN" --migrations-dir "$MIG_DIR" \
+  --tickets-json '[{"id":"CTL-20","title":"infra work","description":"no keywords here","labels":["migration"]}]' \
+  > "${SCRATCH}/t6.out" 2>&1
+run 'detects via migration label' expect_contains "${SCRATCH}/t6.out" '**CTL-20**: `003_'
+
+# Test 7: only migration-likely tickets are assigned; others skipped
+"$PREASSIGN" --migrations-dir "$MIG_DIR" \
+  --tickets-json '[
+    {"id":"CTL-30","title":"frontend button","description":"UI","labels":["frontend"]},
+    {"id":"CTL-31","title":"add comments table","description":"ALTER TABLE comments","labels":[]}
+  ]' \
+  > "${SCRATCH}/t7.out" 2>&1
+run "mixed wave: UI ticket not listed" expect_not_contains "${SCRATCH}/t7.out" "CTL-30"
+run "mixed wave: migration ticket listed" expect_contains "${SCRATCH}/t7.out" '**CTL-31**: `003_'
+
+# Test 8: scans largest NNN correctly when files are out of order / padded
+MIG_DIR_B="${SCRATCH}/scan/supabase/migrations"
+mkdir -p "$MIG_DIR_B"
+touch "${MIG_DIR_B}/001_a.sql" "${MIG_DIR_B}/007_g.sql" "${MIG_DIR_B}/003_c.sql"
+"$PREASSIGN" --migrations-dir "$MIG_DIR_B" \
+  --tickets-json '[{"id":"CTL-40","title":"add reports","description":"CREATE TABLE reports","labels":[]}]' \
+  > "${SCRATCH}/t8.out" 2>&1
+run "picks max NNN across files (008 after 007)" expect_contains "${SCRATCH}/t8.out" '**CTL-40**: `008_'
+
+# Test 9: empty migrations dir → starts at 001
+MIG_DIR_C="${SCRATCH}/empty/supabase/migrations"
+mkdir -p "$MIG_DIR_C"
+"$PREASSIGN" --migrations-dir "$MIG_DIR_C" \
+  --tickets-json '[{"id":"CTL-50","title":"initial schema","description":"CREATE TABLE foo","labels":[]}]' \
+  > "${SCRATCH}/t9.out" 2>&1
+run "empty migrations dir starts at 001" expect_contains "${SCRATCH}/t9.out" '**CTL-50**: `001_'
+
+# Test 10: migration-likely keywords are case-insensitive
+"$PREASSIGN" --migrations-dir "$MIG_DIR" \
+  --tickets-json '[{"id":"CTL-60","title":"Schema Update","description":"alter table foo add column","labels":[]}]' \
+  > "${SCRATCH}/t10.out" 2>&1
+run "case-insensitive keyword match" expect_contains "${SCRATCH}/t10.out" '**CTL-60**: `003_'
+
+# Test 11: non-matching .sql filenames are ignored
+MIG_DIR_D="${SCRATCH}/weird/supabase/migrations"
+mkdir -p "$MIG_DIR_D"
+touch "${MIG_DIR_D}/001_a.sql" "${MIG_DIR_D}/README.md" "${MIG_DIR_D}/backup.sql" "${MIG_DIR_D}/002_b.sql"
+"$PREASSIGN" --migrations-dir "$MIG_DIR_D" \
+  --tickets-json '[{"id":"CTL-70","title":"add table","description":"CREATE TABLE x","labels":[]}]' \
+  > "${SCRATCH}/t11.out" 2>&1
+run "ignores non-NNN_*.sql files (picks 003 after 002)" expect_contains "${SCRATCH}/t11.out" '**CTL-70**: `003_'
+
+echo ""
+echo "pre-assign-migrations: ${PASSES} passed, ${FAILURES} failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/pre-assign-migrations.sh
+++ b/plugins/dev/scripts/pre-assign-migrations.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# pre-assign-migrations.sh - Pre-assign Supabase migration numbers to tickets in an upcoming wave
+#                            so parallel workers don't collide on the same NNN_ filename.
+#
+# Usage:
+#   pre-assign-migrations.sh --tickets "CTL-1 CTL-2" [--migrations-dir <dir>]
+#   pre-assign-migrations.sh --tickets-json '<json>' [--migrations-dir <dir>]
+#
+# Flags:
+#   --tickets <ids>          Space-separated ticket IDs. Uses `linearis issues read` to fetch
+#                            title/description/labels per ticket.
+#   --tickets-json <json>    Array of {id,title,description,labels[]} objects. Bypasses linearis
+#                            (used by tests and when ticket metadata is already in hand).
+#   --migrations-dir <dir>   Migrations directory to scan. Default: supabase/migrations in cwd.
+#
+# Output:
+#   - If the migrations directory does not exist: exit 0 silently (repo-agnostic).
+#   - If no tickets in the wave are migration-likely: exit 0 silently.
+#   - Otherwise: a Markdown "## Migration Number Assignments" section on stdout, suitable for
+#     appending to a wave briefing. Each migration-likely ticket gets the next sequential
+#     NNN number starting from max(existing NNN_*.sql prefixes) + 1.
+#
+# Detection heuristic for migration-likely tickets (any of the following):
+#   * Labels include (case-insensitive) one of: database, migration, schema
+#   * Title or description contains (case-insensitive) one of:
+#     `supabase/migrations`, `migration`, `schema`, `ALTER TABLE`, `CREATE TABLE`
+#
+# This matches the heuristic documented in orchestrate SKILL.md.
+
+set -euo pipefail
+
+TICKETS=""
+TICKETS_JSON=""
+MIG_DIR="supabase/migrations"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tickets)           TICKETS="$2"; shift 2 ;;
+    --tickets-json)      TICKETS_JSON="$2"; shift 2 ;;
+    --migrations-dir)    MIG_DIR="$2"; shift 2 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "error: unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$TICKETS" ] && [ -z "$TICKETS_JSON" ]; then
+  echo "error: --tickets or --tickets-json required" >&2
+  exit 1
+fi
+
+# Gate 1: migrations dir must exist on disk (worker/orchestrator runs this in a worktree
+# that already has the base branch checked out, so the filesystem is authoritative).
+if [ ! -d "$MIG_DIR" ]; then
+  exit 0
+fi
+
+# Build ticket JSON if not supplied.
+if [ -z "$TICKETS_JSON" ]; then
+  if ! command -v linearis >/dev/null 2>&1; then
+    echo "error: --tickets requires linearis CLI; pass --tickets-json instead" >&2
+    exit 1
+  fi
+  TICKETS_JSON="["
+  FIRST=1
+  for T in $TICKETS; do
+    RAW=$(linearis issues read "$T" 2>/dev/null || echo '{}')
+    OBJ=$(echo "$RAW" | jq -c --arg id "$T" '{
+      id: $id,
+      title: (.title // ""),
+      description: (.description // ""),
+      labels: [(.labels.nodes // [])[].name]
+    }')
+    if [ "$FIRST" = "1" ]; then TICKETS_JSON="${TICKETS_JSON}${OBJ}"; FIRST=0
+    else                        TICKETS_JSON="${TICKETS_JSON},${OBJ}"
+    fi
+  done
+  TICKETS_JSON="${TICKETS_JSON}]"
+fi
+
+# Detect migration-likely tickets (IDs in input order).
+MIG_TICKETS=$(echo "$TICKETS_JSON" | jq -r '
+  [ .[]
+    | select(
+        ((.labels // []) | map(ascii_downcase) | any(. == "database" or . == "migration" or . == "schema"))
+        or ((.title + " " + .description) | ascii_downcase |
+            test("supabase/migrations|\\bmigration\\b|\\bschema\\b|alter table|create table"))
+      )
+    | .id
+  ] | .[]
+')
+
+if [ -z "$MIG_TICKETS" ]; then
+  exit 0
+fi
+
+# Scan the migrations directory for the highest existing NNN_ prefix.
+HIGHEST=0
+for F in "$MIG_DIR"/[0-9][0-9][0-9]_*.sql; do
+  [ -e "$F" ] || continue
+  NAME=$(basename "$F")
+  N=${NAME:0:3}
+  N=$((10#$N))  # force base-10 (avoids octal parsing of 007, 008, etc.)
+  if [ "$N" -gt "$HIGHEST" ]; then HIGHEST="$N"; fi
+done
+
+# Emit the briefing section.
+printf '## Migration Number Assignments\n\n'
+printf 'The following tickets in this wave are likely to add a Supabase migration.\n'
+printf 'Use the assigned number as the filename prefix to prevent collisions:\n\n'
+
+NEXT=$((HIGHEST + 1))
+while IFS= read -r TID; do
+  [ -n "$TID" ] || continue
+  PADDED=$(printf '%03d' "$NEXT")
+  printf -- '- **%s**: `%s_<description>.sql`\n' "$TID" "$PADDED"
+  NEXT=$((NEXT + 1))
+done <<< "$MIG_TICKETS"
+
+printf '\n'
+printf '_These are reservations — if your ticket does not actually add a migration, ignore._\n'

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -915,8 +915,47 @@ to `${ORCH_DIR}/wave-${N}-briefing.md` summarizing what prior waves learned.
 3. Read any research documents workers saved to `thoughts/shared/`
 4. Synthesize into: patterns established, new dependencies added, test helpers created,
    gotchas discovered
+5. **Pre-assign Supabase migration numbers** for the upcoming wave (see Migration Number
+   Assignments below)
 
 Use the wave briefing template from `plugins/dev/templates/orchestrate-wave-briefing.md`.
+
+### Migration Number Assignments (CTL-29)
+
+When two tickets in the same wave both add a Supabase migration, they can race on the same
+`NNN_` filename prefix — whichever PR merges first wins, the other must rebase post-PR. The
+orchestrator pre-assigns numbers in the briefing to prevent this.
+
+**Generation step** (run before rendering the template):
+
+```bash
+# Scan migrations dir and assign numbers to migration-likely tickets in the NEXT wave.
+# Prints a Markdown "## Migration Number Assignments" section, or nothing if the
+# project has no supabase/migrations/ directory or no ticket in the wave is migration-
+# likely. Safe to append unconditionally to the briefing.
+MIG_SECTION=$("${CLAUDE_PLUGIN_ROOT}/scripts/pre-assign-migrations.sh" \
+  --migrations-dir "${ORCH_DIR}/supabase/migrations" \
+  --tickets "${NEXT_WAVE_TICKETS[*]}") || MIG_SECTION=""
+```
+
+The script replaces the `${MIGRATION_ASSIGNMENTS}` placeholder in the briefing template.
+
+**Detection heuristic** (matches `pre-assign-migrations.sh`):
+
+- Label match (case-insensitive): `database`, `migration`, `schema`
+- Keyword match in title or description (case-insensitive): `supabase/migrations`,
+  `migration`, `schema`, `ALTER TABLE`, `CREATE TABLE`
+
+**Behavior:**
+
+- If `supabase/migrations/` does not exist in the orchestrator worktree, the script emits
+  nothing (repo-agnostic — projects without Supabase are unaffected).
+- If no ticket in the wave is migration-likely, it emits nothing.
+- Otherwise it scans for the highest existing `NNN_` prefix and assigns `NNN+1`, `NNN+2`, ...
+  to each migration-likely ticket in input order.
+
+**Tests:** `plugins/dev/scripts/__tests__/pre-assign-migrations.test.sh` covers the detection
+heuristic, the scanning logic, repo-agnostic fallback, and sequential assignment.
 
 **Thoughts persistence:** Every briefing is copied to `thoughts/shared/handoffs/${ORCH_NAME}/`
 with timestamped filenames (`YYYY-MM-DD_HH-MM-SS_wave-N-briefing.md`). This ensures briefings

--- a/plugins/dev/templates/orchestrate-wave-briefing.md
+++ b/plugins/dev/templates/orchestrate-wave-briefing.md
@@ -33,6 +33,8 @@
 
 - **${TICKET_ID}**: ${TITLE} (depends on ${DEPENDENCY})
 
+${MIGRATION_ASSIGNMENTS}
+
 ## Important
 
 - Build ON TOP of Wave ${PREV_WAVE}'s patterns — don't reinvent what already exists


### PR DESCRIPTION
## Summary

Prevents parallel workers in the same wave from colliding on the same Supabase migration `NNN_` filename prefix. The orchestrator now scans `supabase/migrations/` at wave-briefing time and reserves sequential numbers for migration-likely tickets, emitting a **Migration Number Assignments** section into the briefing.

Fixes the problem observed in `orch-data-import-2026-04-13` Round 2 where ADV-218 and ADV-219 both chose `005_*.sql` and one had to rebase post-PR.

## Changes

- **`plugins/dev/scripts/pre-assign-migrations.sh`** — new helper. Scans migrations dir, detects migration-likely tickets via labels + keyword heuristic, emits a ready-to-paste Markdown section. Repo-agnostic: silent exit if `supabase/migrations/` doesn't exist.
- **`plugins/dev/scripts/__tests__/pre-assign-migrations.test.sh`** — 14 shell tests (heuristic, scanning, fallbacks).
- **`plugins/dev/skills/orchestrate/SKILL.md`** — new "Migration Number Assignments (CTL-29)" subsection under Wave Briefing, wires the helper into the briefing-generation flow.
- **`plugins/dev/templates/orchestrate-wave-briefing.md`** — adds `${MIGRATION_ASSIGNMENTS}` placeholder.

## Detection heuristic (case-insensitive)

- Labels: `database`, `migration`, `schema`
- Keywords in title/description: `supabase/migrations`, `migration`, `schema`, `ALTER TABLE`, `CREATE TABLE`

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/pre-assign-migrations.test.sh` — 14/14 pass
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-fixup.test.sh` — 16/16 pass (regression)
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-followup.test.sh` — 10/10 pass (regression)
- [x] `bun test` in `plugins/dev/scripts/orch-monitor` — 105/105 pass (regression; no TS changes made)
- [x] Manual end-to-end: script output rendered correctly with mock tickets (mixed migration + UI)

## Built on

- Wave 1 (CTL-31): orchestrator-owned poll-until-MERGED
- Wave 2 (CTL-30): fix-up + follow-up recovery patterns