### PR TITLE
feat(dev): SQLite session store for agent activity (CTL-36)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,12 +56,20 @@ orchestrators and workers write to via `catalyst-state.sh` (lock-protected).
 ```
 ~/catalyst/
 ├── state.json              # Active orchestrators (denormalized summary)
+├── catalyst.db             # Durable session store (SQLite, WAL mode)
 ├── events/                 # Append-only JSONL event stream, rotated monthly
 │   └── YYYY-MM.jsonl
 ├── history/                # Archived orchestrator snapshots
 │   └── <id>--<timestamp>.json
 └── wt/                     # Worktrees (existing)
 ```
+
+- **catalyst.db**: SQLite-backed session store — durable source of truth for agent activity
+  (solo and orchestrated). Managed by `catalyst-db.sh`. Tables: `sessions`, `session_events`,
+  `session_metrics`, `session_tools`, `session_prs`, `schema_migrations`. Writers run in WAL
+  mode so monitor-style readers can operate concurrently. `catalyst-state.sh` continues to
+  write JSON/JSONL during the migration period for backward compatibility. Schema lives at
+  `plugins/dev/scripts/db-migrations/`.
 
 - **state.json**: Registry of active orchestrators with progress, worker status, and attention
   items. Queryable with `jq`. Schema: `plugins/dev/templates/global-state.json`.

--- a/plugins/dev/scripts/catalyst-db.sh
+++ b/plugins/dev/scripts/catalyst-db.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+# catalyst-db.sh — SQLite-backed session store for Catalyst agent activity.
+#
+# Durable source of truth for agent runs (solo and orchestrated). During the
+# migration period, catalyst-state.sh continues to dual-write JSON/JSONL for
+# backward compatibility.
+#
+# Storage:
+#   $CATALYST_DIR/catalyst.db   (default CATALYST_DIR=$HOME/catalyst)
+#
+# SQL migrations live in ./db-migrations/NNN_*.sql and are applied in order
+# by the `init` / `migrate` commands. Applied versions are tracked in the
+# schema_migrations table.
+#
+# Usage (run with --help for full syntax):
+#   catalyst-db.sh init
+#   catalyst-db.sh migrate
+#   catalyst-db.sh session create <id> [--ticket K] [--workflow W] [--label L] [--skill S] [--pid P]
+#   catalyst-db.sh session update <id> key=value [...]
+#   catalyst-db.sh session get <id>
+#   catalyst-db.sh session list [--ticket K] [--status S] [--workflow W] [--limit N]
+#   catalyst-db.sh event append <session-id> <event-type> <payload-json>
+#   catalyst-db.sh events list [--session ID] [--type T] [--last N]
+#   catalyst-db.sh metrics update <session-id> key=value [...]
+#   catalyst-db.sh metrics get <session-id>
+#   catalyst-db.sh tool record <session-id> <tool-name> [--duration MS]
+#   catalyst-db.sh pr upsert <session-id> <pr-number> [--url U] [--ci S] [--opened TS] [--merged TS]
+#   catalyst-db.sh pr get <session-id> <pr-number>
+#   catalyst-db.sh exec <sql>
+
+set -euo pipefail
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+DB_FILE="${CATALYST_DB_FILE:-$CATALYST_DIR/catalyst.db}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_DIR="${CATALYST_MIGRATIONS_DIR:-$SCRIPT_DIR/db-migrations}"
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+ensure_dir() { mkdir -p "$(dirname "$DB_FILE")"; }
+
+# Fields recognized by whitelists to prevent SQL injection via key=value input.
+SESSION_FIELDS=(workflow_id ticket_key label skill_name status phase pid started_at updated_at completed_at)
+METRIC_FIELDS=(cost_usd input_tokens output_tokens cache_read_tokens cache_creation_tokens duration_ms)
+
+# ─── SQL helpers ────────────────────────────────────────────────────────────
+
+# Escape a literal for SQL: wrap in single quotes, doubling any embedded '.
+sql_quote() {
+  local s="${1:-}"
+  printf "'%s'" "${s//\'/\'\'}"
+}
+
+# Return 'NULL' for empty string, otherwise a quoted literal.
+sql_value_or_null() {
+  if [[ -z "${1:-}" ]]; then printf 'NULL'; else sql_quote "$1"; fi
+}
+
+# Assert that a name is in a whitelist. $1 = name, $2+ = allowed names.
+assert_field() {
+  local name="$1"; shift
+  local f
+  for f in "$@"; do [[ "$f" == "$name" ]] && return 0; done
+  echo "error: unknown field '$name'" >&2
+  return 1
+}
+
+# foreign_keys is a per-connection pragma, so enable it on every invocation.
+db_exec() { sqlite3 "$DB_FILE" -cmd "PRAGMA foreign_keys = ON;" "$@"; }
+
+db_exec_json() { sqlite3 -json "$DB_FILE" -cmd "PRAGMA foreign_keys = ON;" "$@"; }
+
+# ─── Migrations ─────────────────────────────────────────────────────────────
+
+apply_migrations() {
+  ensure_dir
+
+  # Configure durable, concurrency-friendly settings. `journal_mode = WAL`
+  # persists across connections once set.
+  db_exec "PRAGMA journal_mode = WAL;" >/dev/null
+  db_exec "PRAGMA foreign_keys = ON;" >/dev/null
+
+  db_exec "CREATE TABLE IF NOT EXISTS schema_migrations (
+             version    TEXT PRIMARY KEY,
+             applied_at TEXT NOT NULL
+           );"
+
+  if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+    echo "error: migrations directory not found: $MIGRATIONS_DIR" >&2
+    return 1
+  fi
+
+  local file version applied
+  shopt -s nullglob
+  for file in "$MIGRATIONS_DIR"/*.sql; do
+    version="$(basename "$file" .sql)"
+    applied=$(db_exec "SELECT 1 FROM schema_migrations WHERE version=$(sql_quote "$version");")
+    if [[ -n "$applied" ]]; then continue; fi
+
+    # Apply migration + record version atomically.
+    {
+      echo "PRAGMA foreign_keys = ON;"
+      echo "BEGIN;"
+      cat "$file"
+      printf "INSERT INTO schema_migrations(version, applied_at) VALUES (%s, %s);\n" \
+        "$(sql_quote "$version")" "$(sql_quote "$(now_iso)")"
+      echo "COMMIT;"
+    } | sqlite3 "$DB_FILE"
+    echo "Applied migration: $version"
+  done
+  shopt -u nullglob
+}
+
+# ─── Session commands ──────────────────────────────────────────────────────
+
+session_create() {
+  local id="${1:?session id required}"; shift || true
+  local ticket="" workflow="" label="" skill="" pid="" status="dispatched"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --ticket)   ticket="$2"; shift 2 ;;
+      --workflow) workflow="$2"; shift 2 ;;
+      --label)    label="$2"; shift 2 ;;
+      --skill)    skill="$2"; shift 2 ;;
+      --pid)      pid="$2"; shift 2 ;;
+      --status)   status="$2"; shift 2 ;;
+      *) echo "unknown flag for session create: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local ts; ts="$(now_iso)"
+  local pid_sql="NULL"
+  [[ -n "$pid" ]] && pid_sql="$pid"
+
+  db_exec "INSERT INTO sessions
+             (session_id, workflow_id, ticket_key, label, skill_name, status, phase, pid, started_at, updated_at)
+           VALUES
+             ($(sql_quote "$id"),
+              $(sql_value_or_null "$workflow"),
+              $(sql_value_or_null "$ticket"),
+              $(sql_value_or_null "$label"),
+              $(sql_value_or_null "$skill"),
+              $(sql_quote "$status"),
+              0,
+              $pid_sql,
+              $(sql_quote "$ts"),
+              $(sql_quote "$ts"));"
+}
+
+# Build a SET clause from key=value args, validating against a field whitelist.
+# Writes SQL fragment to stdout; numeric fields are emitted unquoted when
+# the value looks numeric, otherwise quoted.
+build_set_clause() {
+  local whitelist_name="$1"; shift
+  local -n whitelist="$whitelist_name"
+  local first=1
+  while [[ $# -gt 0 ]]; do
+    local kv="$1"; shift
+    local key="${kv%%=*}"
+    local val="${kv#*=}"
+    assert_field "$key" "${whitelist[@]}" || return 1
+    if [[ $first -eq 0 ]]; then printf ', '; fi
+    first=0
+    if [[ "$val" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+      printf '%s = %s' "$key" "$val"
+    else
+      printf '%s = %s' "$key" "$(sql_quote "$val")"
+    fi
+  done
+}
+
+session_update() {
+  local id="${1:?session id required}"; shift
+  [[ $# -eq 0 ]] && { echo "error: no fields to update" >&2; return 1; }
+
+  local set_clause
+  set_clause="$(build_set_clause SESSION_FIELDS "$@")"
+
+  local ts; ts="$(now_iso)"
+  db_exec "UPDATE sessions
+           SET $set_clause, updated_at = $(sql_quote "$ts")
+           WHERE session_id = $(sql_quote "$id");"
+}
+
+session_get() {
+  local id="${1:?session id required}"
+  local out
+  out=$(db_exec_json "SELECT * FROM sessions WHERE session_id = $(sql_quote "$id");")
+  [[ -z "$out" ]] && { echo 'null'; return 0; }
+  echo "$out" | jq '.[0]'
+}
+
+session_list() {
+  local where="" limit="" ticket="" status="" workflow=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --ticket)   ticket="$2"; shift 2 ;;
+      --status)   status="$2"; shift 2 ;;
+      --workflow) workflow="$2"; shift 2 ;;
+      --limit)    limit="$2"; shift 2 ;;
+      *) echo "unknown flag for session list: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local conds=()
+  [[ -n "$ticket" ]]   && conds+=("ticket_key = $(sql_quote "$ticket")")
+  [[ -n "$status" ]]   && conds+=("status = $(sql_quote "$status")")
+  [[ -n "$workflow" ]] && conds+=("workflow_id = $(sql_quote "$workflow")")
+
+  if [[ ${#conds[@]} -gt 0 ]]; then
+    where="WHERE $(IFS=' AND '; printf '%s' "${conds[*]}")"
+    # bash IFS trick is fragile for multi-char separators — build manually
+    where="WHERE ${conds[0]}"
+    local i
+    for ((i=1; i<${#conds[@]}; i++)); do where+=" AND ${conds[$i]}"; done
+  fi
+
+  local lim=""
+  [[ -n "$limit" ]] && lim="LIMIT $limit"
+
+  local out
+  out=$(db_exec_json "SELECT * FROM sessions $where ORDER BY started_at DESC $lim;")
+  [[ -z "$out" ]] && { echo '[]'; return 0; }
+  echo "$out"
+}
+
+# ─── Event commands ─────────────────────────────────────────────────────────
+
+event_append() {
+  local id="${1:?session id required}"
+  local type="${2:?event type required}"
+  local payload="${3:-}"
+
+  # Validate JSON if provided; reject malformed input so queries stay clean.
+  if [[ -n "$payload" ]]; then
+    if ! echo "$payload" | jq empty 2>/dev/null; then
+      echo "error: payload is not valid JSON" >&2
+      return 1
+    fi
+  fi
+
+  local ts; ts="$(now_iso)"
+  db_exec "INSERT INTO session_events (session_id, event_type, payload, ts)
+           VALUES ($(sql_quote "$id"),
+                   $(sql_quote "$type"),
+                   $(sql_value_or_null "$payload"),
+                   $(sql_quote "$ts"));"
+}
+
+events_list() {
+  local session="" type="" last=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session) session="$2"; shift 2 ;;
+      --type)    type="$2"; shift 2 ;;
+      --last)    last="$2"; shift 2 ;;
+      *) echo "unknown flag for events list: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local conds=()
+  [[ -n "$session" ]] && conds+=("session_id = $(sql_quote "$session")")
+  [[ -n "$type" ]]    && conds+=("event_type = $(sql_quote "$type")")
+
+  local where=""
+  if [[ ${#conds[@]} -gt 0 ]]; then
+    where="WHERE ${conds[0]}"
+    local i
+    for ((i=1; i<${#conds[@]}; i++)); do where+=" AND ${conds[$i]}"; done
+  fi
+
+  # For --last N, order DESC then reverse so callers get chronological order.
+  local out
+  if [[ -n "$last" ]]; then
+    out=$(db_exec_json "SELECT * FROM session_events $where ORDER BY event_id DESC LIMIT $last;")
+    [[ -z "$out" ]] && { echo '[]'; return 0; }
+    echo "$out" | jq 'reverse'
+  else
+    out=$(db_exec_json "SELECT * FROM session_events $where ORDER BY event_id ASC;")
+    [[ -z "$out" ]] && { echo '[]'; return 0; }
+    echo "$out"
+  fi
+}
+
+# ─── Metrics commands ───────────────────────────────────────────────────────
+
+metrics_update() {
+  local id="${1:?session id required}"; shift
+  [[ $# -eq 0 ]] && { echo "error: no metric fields to update" >&2; return 1; }
+
+  # Validate each key against the whitelist before writing.
+  local kv key
+  for kv in "$@"; do
+    key="${kv%%=*}"
+    assert_field "$key" "${METRIC_FIELDS[@]}"
+  done
+
+  local ts; ts="$(now_iso)"
+
+  # Ensure a row exists, then update. INSERT OR IGNORE is safe & idempotent.
+  db_exec "INSERT OR IGNORE INTO session_metrics (session_id, updated_at)
+           VALUES ($(sql_quote "$id"), $(sql_quote "$ts"));"
+
+  local set_clause
+  set_clause="$(build_set_clause METRIC_FIELDS "$@")"
+  db_exec "UPDATE session_metrics
+           SET $set_clause, updated_at = $(sql_quote "$ts")
+           WHERE session_id = $(sql_quote "$id");"
+}
+
+metrics_get() {
+  local id="${1:?session id required}"
+  local out
+  out=$(db_exec_json "SELECT * FROM session_metrics WHERE session_id = $(sql_quote "$id");")
+  [[ -z "$out" ]] && { echo 'null'; return 0; }
+  echo "$out" | jq '.[0]'
+}
+
+# ─── Tool usage ─────────────────────────────────────────────────────────────
+
+tool_record() {
+  local id="${1:?session id required}"
+  local name="${2:?tool name required}"
+  shift 2 || true
+  local duration=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --duration) duration="$2"; shift 2 ;;
+      *) echo "unknown flag for tool record: $1" >&2; return 1 ;;
+    esac
+  done
+  [[ "$duration" =~ ^[0-9]+$ ]] || { echo "error: --duration must be a non-negative integer" >&2; return 1; }
+
+  local ts; ts="$(now_iso)"
+  db_exec "INSERT INTO session_tools (session_id, tool_name, call_count, total_duration_ms, updated_at)
+           VALUES ($(sql_quote "$id"), $(sql_quote "$name"), 1, $duration, $(sql_quote "$ts"))
+           ON CONFLICT(session_id, tool_name) DO UPDATE SET
+             call_count = call_count + 1,
+             total_duration_ms = total_duration_ms + $duration,
+             updated_at = $(sql_quote "$ts");"
+}
+
+# ─── PR commands ────────────────────────────────────────────────────────────
+
+pr_upsert() {
+  local id="${1:?session id required}"
+  local num="${2:?pr number required}"
+  shift 2 || true
+  [[ "$num" =~ ^[0-9]+$ ]] || { echo "error: pr-number must be an integer" >&2; return 1; }
+
+  local url="" ci="" opened="" merged=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --url)    url="$2"; shift 2 ;;
+      --ci)     ci="$2"; shift 2 ;;
+      --opened) opened="$2"; shift 2 ;;
+      --merged) merged="$2"; shift 2 ;;
+      *) echo "unknown flag for pr upsert: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local ts; ts="$(now_iso)"
+
+  # Build SET fragments only for flags the caller actually supplied, so that
+  # subsequent upserts don't accidentally clobber previously-set columns
+  # (e.g. keeping pr_url when only --ci is updated).
+  local sets=()
+  [[ -n "$url" ]]    && sets+=("pr_url = $(sql_quote "$url")")
+  [[ -n "$ci" ]]     && sets+=("ci_status = $(sql_quote "$ci")")
+  [[ -n "$opened" ]] && sets+=("opened_at = $(sql_quote "$opened")")
+  [[ -n "$merged" ]] && sets+=("merged_at = $(sql_quote "$merged")")
+  sets+=("updated_at = $(sql_quote "$ts")")
+
+  local set_clause="${sets[0]}"
+  local i
+  for ((i=1; i<${#sets[@]}; i++)); do set_clause+=", ${sets[$i]}"; done
+
+  db_exec "INSERT INTO session_prs (session_id, pr_number, pr_url, ci_status, opened_at, merged_at, updated_at)
+           VALUES ($(sql_quote "$id"), $num,
+                   $(sql_value_or_null "$url"),
+                   $(sql_value_or_null "$ci"),
+                   $(sql_value_or_null "$opened"),
+                   $(sql_value_or_null "$merged"),
+                   $(sql_quote "$ts"))
+           ON CONFLICT(session_id, pr_number) DO UPDATE SET $set_clause;"
+}
+
+pr_get() {
+  local id="${1:?session id required}"
+  local num="${2:?pr number required}"
+  local out
+  out=$(db_exec_json "SELECT * FROM session_prs WHERE session_id = $(sql_quote "$id") AND pr_number = $num;")
+  [[ -z "$out" ]] && { echo 'null'; return 0; }
+  echo "$out" | jq '.[0]'
+}
+
+# ─── Dispatch ───────────────────────────────────────────────────────────────
+
+usage() {
+  sed -n '/^# Usage/,/^set -/p' "${BASH_SOURCE[0]}" | sed 's/^# //; s/^#$//' | head -n -1
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+  init|migrate) apply_migrations ;;
+  session)
+    sub="${1:?session subcommand required}"; shift
+    case "$sub" in
+      create) session_create "$@" ;;
+      update) session_update "$@" ;;
+      get)    session_get "$@" ;;
+      list)   session_list "$@" ;;
+      *) echo "unknown session subcommand: $sub" >&2; exit 1 ;;
+    esac
+    ;;
+  event)
+    sub="${1:?event subcommand required}"; shift
+    case "$sub" in
+      append) event_append "$@" ;;
+      *) echo "unknown event subcommand: $sub" >&2; exit 1 ;;
+    esac
+    ;;
+  events)
+    sub="${1:?events subcommand required}"; shift
+    case "$sub" in
+      list) events_list "$@" ;;
+      *) echo "unknown events subcommand: $sub" >&2; exit 1 ;;
+    esac
+    ;;
+  metrics)
+    sub="${1:?metrics subcommand required}"; shift
+    case "$sub" in
+      update) metrics_update "$@" ;;
+      get)    metrics_get "$@" ;;
+      *) echo "unknown metrics subcommand: $sub" >&2; exit 1 ;;
+    esac
+    ;;
+  tool)
+    sub="${1:?tool subcommand required}"; shift
+    case "$sub" in
+      record) tool_record "$@" ;;
+      *) echo "unknown tool subcommand: $sub" >&2; exit 1 ;;
+    esac
+    ;;
+  pr)
+    sub="${1:?pr subcommand required}"; shift
+    case "$sub" in
+      upsert) pr_upsert "$@" ;;
+      get)    pr_get "$@" ;;
+      *) echo "unknown pr subcommand: $sub" >&2; exit 1 ;;
+    esac
+    ;;
+  exec)
+    [[ $# -ge 1 ]] || { echo "error: exec requires a SQL string" >&2; exit 1; }
+    db_exec "$1"
+    ;;
+  help|--help|-h) usage ;;
+  *) echo "unknown command: $cmd" >&2; echo "run '$0 help' for usage" >&2; exit 1 ;;
+esac

--- a/plugins/dev/scripts/db-migrations/001_initial_schema.sql
+++ b/plugins/dev/scripts/db-migrations/001_initial_schema.sql
@@ -1,0 +1,71 @@
+-- 001_initial_schema.sql
+-- Durable session store for Catalyst agent activity (solo and orchestrated).
+--
+-- See CTL-36. This schema replaces the per-worker JSON signal files and
+-- ~/catalyst/events/*.jsonl as the source of truth over time. Dual-write
+-- from catalyst-state.sh continues during the migration period.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id    TEXT PRIMARY KEY,
+  workflow_id   TEXT,
+  ticket_key    TEXT,
+  label         TEXT,
+  skill_name    TEXT,
+  status        TEXT NOT NULL DEFAULT 'dispatched',
+  phase         INTEGER NOT NULL DEFAULT 0,
+  pid           INTEGER,
+  started_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL,
+  completed_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_workflow ON sessions(workflow_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_ticket   ON sessions(ticket_key);
+CREATE INDEX IF NOT EXISTS idx_sessions_status   ON sessions(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_started  ON sessions(started_at);
+
+CREATE TABLE IF NOT EXISTS session_events (
+  event_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id  TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+  event_type  TEXT NOT NULL,
+  payload     TEXT,
+  ts          TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_session ON session_events(session_id, ts);
+CREATE INDEX IF NOT EXISTS idx_events_type    ON session_events(event_type, ts);
+
+CREATE TABLE IF NOT EXISTS session_metrics (
+  session_id            TEXT PRIMARY KEY REFERENCES sessions(session_id) ON DELETE CASCADE,
+  cost_usd              REAL NOT NULL DEFAULT 0,
+  input_tokens          INTEGER NOT NULL DEFAULT 0,
+  output_tokens         INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+  cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+  duration_ms           INTEGER NOT NULL DEFAULT 0,
+  updated_at            TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_tools (
+  session_id        TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+  tool_name         TEXT NOT NULL,
+  call_count        INTEGER NOT NULL DEFAULT 0,
+  total_duration_ms INTEGER NOT NULL DEFAULT 0,
+  updated_at        TEXT NOT NULL,
+  PRIMARY KEY (session_id, tool_name)
+);
+
+CREATE TABLE IF NOT EXISTS session_prs (
+  session_id  TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+  pr_number   INTEGER NOT NULL,
+  pr_url      TEXT,
+  ci_status   TEXT,
+  opened_at   TEXT,
+  merged_at   TEXT,
+  updated_at  TEXT NOT NULL,
+  PRIMARY KEY (session_id, pr_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prs_number ON session_prs(pr_number);

--- a/plugins/dev/scripts/test-catalyst-db.sh
+++ b/plugins/dev/scripts/test-catalyst-db.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Test suite for catalyst-db.sh
+#
+# Validates:
+# - init creates the DB, schema_migrations table, and enables WAL mode
+# - Migrations are applied once and tracked by version (idempotent)
+# - Sessions CRUD (create, update, get, list)
+# - Event append and query
+# - Metrics upsert
+# - Tool usage increments
+# - PR upsert (create + update)
+# - Concurrent readers while a writer holds the DB (WAL)
+# - Foreign-key cascade on session delete
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DB_SCRIPT="$SCRIPT_DIR/catalyst-db.sh"
+
+PASS=true
+TESTS=0
+FAILURES=0
+
+fail() { echo "  FAIL: $1"; PASS=false; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  PASS: $1"; }
+run_test() { TESTS=$((TESTS + 1)); echo ""; echo "--- Test $TESTS: $1 ---"; }
+
+# Isolated per-test DB dir
+make_tmpdir() {
+  mktemp -d -t catalyst-db-test-XXXXXX
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label ($actual)"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+# Guard against accidentally running without the implementation in place
+if [[ ! -x "$DB_SCRIPT" ]]; then
+  echo "FATAL: catalyst-db.sh not found or not executable at $DB_SCRIPT" >&2
+  exit 1
+fi
+
+# ─── Test 1: init creates DB, applies migrations, enables WAL ───────────────
+run_test "init creates DB and enables WAL mode"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+DB_PATH="$TMP/catalyst.db"
+
+"$DB_SCRIPT" init >/dev/null
+
+[[ -f "$DB_PATH" ]] && pass "DB file exists" || fail "DB file missing at $DB_PATH"
+
+JOURNAL=$(sqlite3 "$DB_PATH" "PRAGMA journal_mode;")
+assert_eq "wal" "$JOURNAL" "journal_mode is WAL"
+
+# foreign_keys is a per-connection pragma. Verify the script enables it on
+# its own connections (rather than a bare `sqlite3` reopen which defaults to 0).
+FK=$(  "$DB_SCRIPT" exec "PRAGMA foreign_keys;")
+assert_eq "1" "$FK" "foreign_keys enabled on script connection"
+
+APPLIED=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM schema_migrations;")
+[[ "$APPLIED" -ge 1 ]] && pass "at least one migration applied ($APPLIED)" || fail "no migrations applied"
+
+# Verify all expected tables exist
+for tbl in sessions session_events session_metrics session_tools session_prs schema_migrations; do
+  FOUND=$(sqlite3 "$DB_PATH" "SELECT name FROM sqlite_master WHERE type='table' AND name='$tbl';")
+  assert_eq "$tbl" "$FOUND" "table $tbl exists"
+done
+
+rm -rf "$TMP"
+
+# ─── Test 2: migrate is idempotent ──────────────────────────────────────────
+run_test "migrate is idempotent"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+DB_PATH="$TMP/catalyst.db"
+
+"$DB_SCRIPT" init >/dev/null
+FIRST=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM schema_migrations;")
+"$DB_SCRIPT" migrate >/dev/null
+SECOND=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM schema_migrations;")
+assert_eq "$FIRST" "$SECOND" "migrate a second time does not re-apply"
+
+rm -rf "$TMP"
+
+# ─── Test 3: session create / get / update / list ───────────────────────────
+run_test "session CRUD"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+
+"$DB_SCRIPT" session create sess-1 \
+  --ticket CTL-36 --workflow orch-1 --label "test session" --skill oneshot --pid 12345 \
+  >/dev/null
+
+GOT=$(  "$DB_SCRIPT" session get sess-1)
+TID=$(echo "$GOT" | jq -r '.ticket_key')
+assert_eq "CTL-36" "$TID" "get returns ticket_key"
+WID=$(echo "$GOT" | jq -r '.workflow_id')
+assert_eq "orch-1" "$WID" "get returns workflow_id"
+STATUS=$(echo "$GOT" | jq -r '.status')
+assert_eq "dispatched" "$STATUS" "default status is dispatched"
+
+"$DB_SCRIPT" session update sess-1 status=implementing phase=3 >/dev/null
+GOT=$(  "$DB_SCRIPT" session get sess-1)
+assert_eq "implementing" "$(echo "$GOT" | jq -r '.status')" "update changed status"
+assert_eq "3" "$(echo "$GOT" | jq -r '.phase')" "update changed phase"
+
+# updated_at should be newer than started_at after update
+STARTED=$(echo "$GOT" | jq -r '.started_at')
+UPDATED=$(echo "$GOT" | jq -r '.updated_at')
+if [[ "$UPDATED" > "$STARTED" || "$UPDATED" == "$STARTED" ]]; then
+  pass "updated_at >= started_at"
+else
+  fail "updated_at ($UPDATED) is earlier than started_at ($STARTED)"
+fi
+
+# list
+"$DB_SCRIPT" session create sess-2 --ticket CTL-99 >/dev/null
+LIST=$(  "$DB_SCRIPT" session list)
+COUNT=$(echo "$LIST" | jq 'length')
+assert_eq "2" "$COUNT" "list returns both sessions"
+
+# Filter by ticket
+FILTERED=$(  "$DB_SCRIPT" session list --ticket CTL-36)
+FCOUNT=$(echo "$FILTERED" | jq 'length')
+assert_eq "1" "$FCOUNT" "list --ticket filters correctly"
+
+# Filter by status
+FILTERED=$(  "$DB_SCRIPT" session list --status implementing)
+FCOUNT=$(echo "$FILTERED" | jq 'length')
+assert_eq "1" "$FCOUNT" "list --status filters correctly"
+
+rm -rf "$TMP"
+
+# ─── Test 4: events append + query ──────────────────────────────────────────
+run_test "events append and query"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+"$DB_SCRIPT" session create sess-1 --ticket CTL-36 >/dev/null
+
+"$DB_SCRIPT" event append sess-1 phase-started '{"phase":3,"name":"implementing"}' >/dev/null
+"$DB_SCRIPT" event append sess-1 phase-completed '{"phase":3}' >/dev/null
+"$DB_SCRIPT" event append sess-1 pr-opened '{"pr":42}' >/dev/null
+
+ALL=$(  "$DB_SCRIPT" events list --session sess-1)
+COUNT=$(echo "$ALL" | jq 'length')
+assert_eq "3" "$COUNT" "three events appended"
+
+# Query by type
+BY_TYPE=$(  "$DB_SCRIPT" events list --type pr-opened)
+COUNT=$(echo "$BY_TYPE" | jq 'length')
+assert_eq "1" "$COUNT" "filter by event type"
+PR=$(echo "$BY_TYPE" | jq -r '.[0].payload | fromjson | .pr')
+assert_eq "42" "$PR" "payload round-trips as JSON"
+
+# --last limits results
+LAST=$(  "$DB_SCRIPT" events list --session sess-1 --last 1)
+LC=$(echo "$LAST" | jq 'length')
+assert_eq "1" "$LC" "--last limits count"
+TYPE=$(echo "$LAST" | jq -r '.[0].event_type')
+assert_eq "pr-opened" "$TYPE" "--last returns most recent"
+
+rm -rf "$TMP"
+
+# ─── Test 5: metrics upsert ─────────────────────────────────────────────────
+run_test "metrics upsert"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+"$DB_SCRIPT" session create sess-1 --ticket CTL-36 >/dev/null
+
+"$DB_SCRIPT" metrics update sess-1 cost_usd=1.23 input_tokens=1000 output_tokens=500 >/dev/null
+M=$(  "$DB_SCRIPT" metrics get sess-1)
+# cost_usd is REAL (IEEE-754) — compare numerically, not as string.
+DIFF=$(echo "$M" | jq '(.cost_usd - 1.23) | if . < 0 then -. else . end')
+if jq -n --argjson d "$DIFF" '$d < 0.0001' | grep -q true; then
+  pass "cost_usd stored (~1.23)"
+else
+  fail "cost_usd not within tolerance of 1.23: $(echo "$M" | jq -r '.cost_usd')"
+fi
+assert_eq "1000" "$(echo "$M" | jq -r '.input_tokens')" "input_tokens stored"
+
+# Second update should replace, not duplicate
+"$DB_SCRIPT" metrics update sess-1 cost_usd=2.50 output_tokens=800 >/dev/null
+M=$(  "$DB_SCRIPT" metrics get sess-1)
+DIFF=$(echo "$M" | jq '(.cost_usd - 2.5) | if . < 0 then -. else . end')
+if jq -n --argjson d "$DIFF" '$d < 0.0001' | grep -q true; then
+  pass "cost_usd replaced on second upsert (~2.5)"
+else
+  fail "cost_usd did not replace: $(echo "$M" | jq -r '.cost_usd')"
+fi
+assert_eq "800" "$(echo "$M" | jq -r '.output_tokens')" "output_tokens replaced"
+# input_tokens preserved from first write
+assert_eq "1000" "$(echo "$M" | jq -r '.input_tokens')" "input_tokens preserved when not re-specified"
+
+# Exactly one row per session
+ROWS=$(sqlite3 "$TMP/catalyst.db" "SELECT COUNT(*) FROM session_metrics WHERE session_id='sess-1';")
+assert_eq "1" "$ROWS" "metrics has exactly one row per session"
+
+rm -rf "$TMP"
+
+# ─── Test 6: tool record increments ─────────────────────────────────────────
+run_test "tool record increments counter"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+"$DB_SCRIPT" session create sess-1 --ticket CTL-36 >/dev/null
+
+"$DB_SCRIPT" tool record sess-1 Bash --duration 150 >/dev/null
+"$DB_SCRIPT" tool record sess-1 Bash --duration 200 >/dev/null
+"$DB_SCRIPT" tool record sess-1 Bash --duration 50 >/dev/null
+"$DB_SCRIPT" tool record sess-1 Edit --duration 30 >/dev/null
+
+COUNT_BASH=$(sqlite3 "$TMP/catalyst.db" "SELECT call_count FROM session_tools WHERE session_id='sess-1' AND tool_name='Bash';")
+assert_eq "3" "$COUNT_BASH" "Bash call_count = 3"
+
+DUR_BASH=$(sqlite3 "$TMP/catalyst.db" "SELECT total_duration_ms FROM session_tools WHERE session_id='sess-1' AND tool_name='Bash';")
+assert_eq "400" "$DUR_BASH" "Bash total_duration_ms = 400"
+
+COUNT_EDIT=$(sqlite3 "$TMP/catalyst.db" "SELECT call_count FROM session_tools WHERE session_id='sess-1' AND tool_name='Edit';")
+assert_eq "1" "$COUNT_EDIT" "Edit call_count = 1"
+
+rm -rf "$TMP"
+
+# ─── Test 7: PR upsert ──────────────────────────────────────────────────────
+run_test "PR upsert (create and update)"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+"$DB_SCRIPT" session create sess-1 --ticket CTL-36 >/dev/null
+
+"$DB_SCRIPT" pr upsert sess-1 42 --url "https://github.com/x/y/pull/42" \
+  --ci pending --opened "2026-04-14T12:00:00Z" >/dev/null
+
+PR=$(  "$DB_SCRIPT" pr get sess-1 42)
+assert_eq "pending" "$(echo "$PR" | jq -r '.ci_status')" "PR ci_status pending"
+assert_eq "42" "$(echo "$PR" | jq -r '.pr_number')" "PR number stored"
+
+"$DB_SCRIPT" pr upsert sess-1 42 --ci merged --merged "2026-04-14T13:00:00Z" >/dev/null
+PR=$(  "$DB_SCRIPT" pr get sess-1 42)
+assert_eq "merged" "$(echo "$PR" | jq -r '.ci_status')" "PR ci_status updated to merged"
+assert_eq "2026-04-14T13:00:00Z" "$(echo "$PR" | jq -r '.merged_at')" "merged_at set"
+# URL preserved from first write
+assert_eq "https://github.com/x/y/pull/42" "$(echo "$PR" | jq -r '.pr_url')" "pr_url preserved"
+
+rm -rf "$TMP"
+
+# ─── Test 8: WAL mode allows concurrent readers while writer is active ─────
+run_test "WAL allows concurrent readers during write"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+"$DB_SCRIPT" session create sess-wal --ticket CTL-36 >/dev/null
+
+# Start a long-ish writer in the background that holds a write transaction
+(
+  sqlite3 "$TMP/catalyst.db" <<SQL
+BEGIN IMMEDIATE;
+UPDATE sessions SET phase = 1 WHERE session_id = 'sess-wal';
+SELECT 1;
+-- hold for a moment before committing
+SELECT sqlite_version();
+COMMIT;
+SQL
+) &
+WRITER_PID=$!
+
+# Reader should succeed immediately (WAL) even while writer is working
+sleep 0.1
+READ_RESULT=$(sqlite3 "$TMP/catalyst.db" "SELECT session_id FROM sessions WHERE session_id='sess-wal';")
+assert_eq "sess-wal" "$READ_RESULT" "reader sees row while writer is active"
+
+wait $WRITER_PID
+rm -rf "$TMP"
+
+# ─── Test 9: cascade delete ─────────────────────────────────────────────────
+run_test "deleting a session cascades to events, metrics, tools, prs"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+"$DB_SCRIPT" session create sess-del --ticket CTL-36 >/dev/null
+"$DB_SCRIPT" event append sess-del test '{}' >/dev/null
+"$DB_SCRIPT" metrics update sess-del cost_usd=1 >/dev/null
+"$DB_SCRIPT" tool record sess-del Bash >/dev/null
+"$DB_SCRIPT" pr upsert sess-del 1 --url x --ci pending >/dev/null
+
+sqlite3 "$TMP/catalyst.db" "PRAGMA foreign_keys = ON; DELETE FROM sessions WHERE session_id='sess-del';"
+
+for tbl in session_events session_metrics session_tools session_prs; do
+  N=$(sqlite3 "$TMP/catalyst.db" "SELECT COUNT(*) FROM $tbl WHERE session_id='sess-del';")
+  assert_eq "0" "$N" "$tbl cleaned up on cascade"
+done
+
+rm -rf "$TMP"
+
+# ─── Test 10: exec runs arbitrary SQL ───────────────────────────────────────
+run_test "exec runs arbitrary SQL against the DB"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+OUT=$(  "$DB_SCRIPT" exec "SELECT COUNT(*) FROM sessions;")
+assert_eq "0" "$OUT" "empty session count via exec"
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+echo ""
+echo "────────────────────────────────────────"
+echo "Ran $TESTS tests, $FAILURES failures"
+if [[ "$PASS" == "true" ]]; then
+  echo "✅ All tests passed"
+  exit 0
+else
+  echo "❌ Failures detected"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Durable SQLite-backed session store for agent activity — solo and orchestrated.
Becomes the long-term source of truth over today's fragile per-worker JSON
signal files and JSONL event logs. Dual-write from `catalyst-state.sh` continues
during the migration period.

Closes CTL-36. Unblocks CTL-37, CTL-39, CTL-40, CTL-44, CTL-47.

## What landed

- **Schema** (`plugins/dev/scripts/db-migrations/001_initial_schema.sql`):
  `sessions`, `session_events`, `session_metrics`, `session_tools`, `session_prs`,
  plus `schema_migrations` for versioned migrations.
- **CLI** (`plugins/dev/scripts/catalyst-db.sh`): `init` / `migrate` / `session`
  CRUD / `event append` / `events list` / `metrics update|get` / `tool record` /
  `pr upsert|get` / raw `exec`.
- **Concurrency**: WAL mode enabled; `PRAGMA foreign_keys = ON` on every connection
  so cascade deletes are enforced.
- **Safety**: all values routed through `sql_quote` (doubling `'`), whitelist of
  updatable fields per table, typed input validation (PR number, duration, event
  payload JSON). Injection attempt (`"CTL-36'; DROP TABLE sessions; --"`) stores
  literally; `sessions` table survives.
- **Docs**: `docs/architecture.md` Global Orchestrator State section updated to
  reference `catalyst.db` and its role.

## Test plan

- [x] `bash plugins/dev/scripts/test-catalyst-db.sh` — 10 tests, 0 failures
  - init creates DB, WAL journal_mode, foreign_keys per-connection, all tables
  - migrate idempotent (second apply is a no-op)
  - session create / get / update / list + filters (ticket, status)
  - events append + query by session / type / --last limit, payload JSON round-trip
  - metrics upsert: row-per-session invariant, partial update preserves other fields
  - tool record increments call_count and total_duration_ms
  - PR upsert: create then partial update preserves pr_url
  - WAL: reader succeeds while writer holds a transaction
  - cascade delete across events / metrics / tools / prs
  - raw exec passes SQL through

## Acceptance criteria (from CTL-36)

- [x] Schema defined and documented
- [x] Migration tooling creates/upgrades the DB
- [x] Basic CRUD operations via a shell-callable interface
- [x] WAL mode enabled, concurrent read/write tested
- [x] Existing `catalyst-state.sh` still works (dual-write period — unchanged)