### PR TITLE
feat(dev): SQLite reader and unified data source for orch-monitor (CTL-40)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createServer } from "../server";
@@ -186,4 +187,126 @@ describe("SSE integration (file change -> SSE push)", () => {
     expect(received).toContain("event: worker-update");
     expect(received).toContain("SSE-1");
   }, 10000);
+});
+
+describe("SQLite session endpoints", () => {
+  let sessTmp: string;
+  let sessServer: ReturnType<typeof createServer>;
+  let sessBaseUrl: string;
+  let dbPath: string;
+
+  beforeAll(() => {
+    sessTmp = mkdtempSync(join(tmpdir(), "orch-monitor-sess-"));
+    const wtDir = join(sessTmp, "wt");
+    mkdirSync(wtDir, { recursive: true });
+    dbPath = join(sessTmp, "catalyst.db");
+
+    const schemaSql = readFileSync(
+      join(__dirname, "..", "..", "db-migrations", "001_initial_schema.sql"),
+      "utf8",
+    );
+    const db = new Database(dbPath, { create: true });
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec(schemaSql);
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO sessions (session_id, workflow_id, ticket_key, status, phase, started_at, updated_at)
+       VALUES (?, NULL, ?, ?, ?, ?, ?)`,
+      ["solo-1", "CTL-40", "researching", 1, now, now],
+    );
+    db.run(
+      `INSERT INTO sessions (session_id, workflow_id, ticket_key, status, phase, started_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ["orch-1", "orch-abc", "CTL-50", "in_progress", 2, now, now],
+    );
+    db.close();
+
+    sessServer = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      dbPath,
+    });
+    sessBaseUrl = `http://localhost:${sessServer.port}`;
+  });
+
+  afterAll(() => {
+    void sessServer?.stop(true);
+    try {
+      rmSync(sessTmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("returns all sessions by default", async () => {
+    const res = await fetch(`${sessBaseUrl}/api/sessions`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      available: boolean;
+      sessions: { sessionId: string }[];
+    };
+    expect(data.available).toBe(true);
+    expect(data.sessions).toHaveLength(2);
+  });
+
+  it("filters to solo sessions when ?solo=true", async () => {
+    const res = await fetch(`${sessBaseUrl}/api/sessions?solo=true`);
+    const data = (await res.json()) as {
+      sessions: { sessionId: string; workflowId: string | null }[];
+    };
+    expect(data.sessions).toHaveLength(1);
+    expect(data.sessions[0].sessionId).toBe("solo-1");
+    expect(data.sessions[0].workflowId).toBeNull();
+  });
+
+  it("filters by ticket", async () => {
+    const res = await fetch(`${sessBaseUrl}/api/sessions?ticket=CTL-50`);
+    const data = (await res.json()) as { sessions: { sessionId: string }[] };
+    expect(data.sessions).toHaveLength(1);
+    expect(data.sessions[0].sessionId).toBe("orch-1");
+  });
+
+  it("includes sessions in /api/snapshot", async () => {
+    const res = await fetch(`${sessBaseUrl}/api/snapshot`);
+    const data = (await res.json()) as {
+      sessionStoreAvailable: boolean;
+      sessions: { sessionId: string }[];
+    };
+    expect(data.sessionStoreAvailable).toBe(true);
+    expect(data.sessions.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("SQLite session endpoints (no dbPath)", () => {
+  let sessTmp: string;
+  let noDbServer: ReturnType<typeof createServer>;
+  let url: string;
+
+  beforeAll(() => {
+    sessTmp = mkdtempSync(join(tmpdir(), "orch-monitor-nodb-"));
+    const wtDir = join(sessTmp, "wt");
+    mkdirSync(wtDir, { recursive: true });
+    noDbServer = createServer({ port: 0, wtDir, startWatcher: false });
+    url = `http://localhost:${noDbServer.port}`;
+  });
+
+  afterAll(() => {
+    void noDbServer?.stop(true);
+    try {
+      rmSync(sessTmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("returns available:false when dbPath not configured", async () => {
+    const res = await fetch(`${url}/api/sessions`);
+    const data = (await res.json()) as {
+      available: boolean;
+      sessions: unknown[];
+    };
+    expect(data.available).toBe(false);
+    expect(data.sessions).toEqual([]);
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/session-store.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/session-store.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  readSessionStore,
+  sessionStoreAvailable,
+} from "../lib/session-store";
+
+let tmpRoot: string;
+let dbPath: string;
+
+function loadSchemaSql(): string {
+  const schemaPath = join(
+    __dirname,
+    "..",
+    "..",
+    "db-migrations",
+    "001_initial_schema.sql",
+  );
+  return readFileSync(schemaPath, "utf8");
+}
+
+function seedDb(path: string, fn: (db: Database) => void): void {
+  const db = new Database(path, { create: true });
+  db.exec("PRAGMA foreign_keys = ON;");
+  db.exec(loadSchemaSql());
+  fn(db);
+  db.close();
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "session-store-test-"));
+  dbPath = join(tmpRoot, "catalyst.db");
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("sessionStoreAvailable", () => {
+  it("returns false when db file does not exist", () => {
+    expect(sessionStoreAvailable(dbPath)).toBe(false);
+  });
+
+  it("returns true when db file exists with sessions table", () => {
+    seedDb(dbPath, () => {});
+    expect(sessionStoreAvailable(dbPath)).toBe(true);
+  });
+
+  it("returns false when file exists but is not a valid sqlite db", () => {
+    writeFileSync(dbPath, "not a sqlite file");
+    expect(sessionStoreAvailable(dbPath)).toBe(false);
+  });
+});
+
+describe("readSessionStore", () => {
+  it("returns an empty sessions array when db file is missing", () => {
+    const snap = readSessionStore(dbPath);
+    expect(snap.sessions).toEqual([]);
+    expect(snap.available).toBe(false);
+  });
+
+  it("reads session rows mapped to SessionState", () => {
+    const now = new Date().toISOString();
+    seedDb(dbPath, (db) => {
+      db.run(
+        `INSERT INTO sessions (session_id, workflow_id, ticket_key, label, skill_name, status, phase, pid, started_at, updated_at)
+         VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ["sess-1", "CTL-40", "research", "oneshot", "researching", 1, 99999, now, now],
+      );
+    });
+
+    const snap = readSessionStore(dbPath);
+    expect(snap.available).toBe(true);
+    expect(snap.sessions).toHaveLength(1);
+    const s = snap.sessions[0];
+    expect(s.sessionId).toBe("sess-1");
+    expect(s.ticket).toBe("CTL-40");
+    expect(s.status).toBe("researching");
+    expect(s.phase).toBe(1);
+    expect(s.workflowId).toBeNull();
+    expect(s.pid).toBe(99999);
+    expect(typeof s.alive).toBe("boolean");
+    expect(s.startedAt).toBe(now);
+    expect(s.updatedAt).toBe(now);
+    expect(typeof s.timeSinceUpdate).toBe("number");
+  });
+
+  it("joins session_metrics as cost", () => {
+    const now = new Date().toISOString();
+    seedDb(dbPath, (db) => {
+      db.run(
+        `INSERT INTO sessions (session_id, status, phase, started_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+        ["sess-1", "done", 6, now, now],
+      );
+      db.run(
+        `INSERT INTO session_metrics (session_id, cost_usd, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, duration_ms, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        ["sess-1", 1.23, 1000, 500, 200, 100, 5000, now],
+      );
+    });
+
+    const snap = readSessionStore(dbPath);
+    expect(snap.sessions[0].cost).toMatchObject({
+      costUSD: 1.23,
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadTokens: 200,
+    });
+  });
+
+  it("joins session_prs as pr", () => {
+    const now = new Date().toISOString();
+    seedDb(dbPath, (db) => {
+      db.run(
+        `INSERT INTO sessions (session_id, status, phase, started_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+        ["sess-1", "pr-created", 5, now, now],
+      );
+      db.run(
+        `INSERT INTO session_prs (session_id, pr_number, pr_url, ci_status, opened_at, merged_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        ["sess-1", 123, "https://github.com/o/r/pull/123", "passing", now, null, now],
+      );
+    });
+
+    const snap = readSessionStore(dbPath);
+    const pr = snap.sessions[0].pr!;
+    expect(pr.number).toBe(123);
+    expect(pr.url).toBe("https://github.com/o/r/pull/123");
+    expect(pr.ciStatus).toBe("passing");
+    expect(pr.openedAt).toBe(now);
+    expect(pr.mergedAt).toBeNull();
+  });
+
+  it("filters by workflowId=null to return solo sessions only", () => {
+    const now = new Date().toISOString();
+    seedDb(dbPath, (db) => {
+      db.run(
+        `INSERT INTO sessions (session_id, workflow_id, status, phase, started_at, updated_at)
+         VALUES (?, NULL, ?, ?, ?, ?)`,
+        ["solo-1", "in_progress", 1, now, now],
+      );
+      db.run(
+        `INSERT INTO sessions (session_id, workflow_id, status, phase, started_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        ["orch-1", "orch-abc", "in_progress", 1, now, now],
+      );
+    });
+
+    const all = readSessionStore(dbPath);
+    expect(all.sessions).toHaveLength(2);
+
+    const solo = readSessionStore(dbPath, { soloOnly: true });
+    expect(solo.sessions).toHaveLength(1);
+    expect(solo.sessions[0].sessionId).toBe("solo-1");
+  });
+
+  it("supports status + limit filters", () => {
+    const now = new Date().toISOString();
+    seedDb(dbPath, (db) => {
+      for (let i = 0; i < 5; i++) {
+        db.run(
+          `INSERT INTO sessions (session_id, status, phase, started_at, updated_at)
+           VALUES (?, ?, ?, ?, ?)`,
+          [`s-${i}`, i < 3 ? "done" : "in_progress", i, now, now],
+        );
+      }
+    });
+
+    const done = readSessionStore(dbPath, { status: "done" });
+    expect(done.sessions).toHaveLength(3);
+
+    const limited = readSessionStore(dbPath, { limit: 2 });
+    expect(limited.sessions).toHaveLength(2);
+  });
+
+  it("returns sessions ordered by started_at DESC (newest first)", () => {
+    seedDb(dbPath, (db) => {
+      db.run(
+        `INSERT INTO sessions (session_id, status, phase, started_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+        ["old", "done", 6, "2026-04-10T00:00:00Z", "2026-04-10T00:00:00Z"],
+      );
+      db.run(
+        `INSERT INTO sessions (session_id, status, phase, started_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+        ["new", "done", 6, "2026-04-14T00:00:00Z", "2026-04-14T00:00:00Z"],
+      );
+    });
+
+    const snap = readSessionStore(dbPath);
+    expect(snap.sessions.map((s) => s.sessionId)).toEqual(["new", "old"]);
+  });
+
+  it("is robust when db is malformed (not a sqlite file)", () => {
+    writeFileSync(dbPath, "garbage");
+    const snap = readSessionStore(dbPath);
+    expect(snap.sessions).toEqual([]);
+    expect(snap.available).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/state-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/state-reader.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -361,6 +362,35 @@ describe("buildSnapshot", () => {
     const snap = buildSnapshot(join(tmpRoot, "nope"));
     expect(snap.orchestrators).toEqual([]);
     expect(typeof snap.timestamp).toBe("string");
+  });
+
+  it("includes empty sessions array and sessionStoreAvailable=false when no dbPath given", () => {
+    const snap = buildSnapshot(tmpRoot);
+    expect(snap.sessions).toEqual([]);
+    expect(snap.sessionStoreAvailable).toBe(false);
+  });
+
+  it("includes sessions from SQLite store when dbPath is provided", () => {
+    const dbPath = join(tmpRoot, "catalyst.db");
+    const schemaSql = readFileSync(
+      join(__dirname, "..", "..", "db-migrations", "001_initial_schema.sql"),
+      "utf8",
+    );
+    const db = new Database(dbPath, { create: true });
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec(schemaSql);
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO sessions (session_id, workflow_id, ticket_key, status, phase, started_at, updated_at)
+       VALUES (?, NULL, ?, ?, ?, ?, ?)`,
+      ["solo-1", "CTL-40", "researching", 1, now, now],
+    );
+    db.close();
+
+    const snap = buildSnapshot(tmpRoot, { dbPath });
+    expect(snap.sessionStoreAvailable).toBe(true);
+    expect(snap.sessions).toHaveLength(1);
+    expect(snap.sessions[0].sessionId).toBe("solo-1");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/terminal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/terminal.test.ts
@@ -46,6 +46,8 @@ function makeSnapshot(orchestrators: OrchestratorState[]): MonitorSnapshot {
   return {
     timestamp: new Date().toISOString(),
     orchestrators,
+    sessions: [],
+    sessionStoreAvailable: false,
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/watcher.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/watcher.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
   diffWorkers,
+  diffSessions,
   diffLiveness,
   isRelevant,
   startWatching,
 } from "../lib/watcher";
 import { subscribe } from "../lib/event-bus";
-import type { MonitorSnapshot, WorkerState } from "../lib/state-reader";
+import type { MonitorSnapshot, SessionState, WorkerState } from "../lib/state-reader";
 
 function makeWorker(overrides: Partial<WorkerState> = {}): WorkerState {
   return {
@@ -29,7 +31,10 @@ function makeWorker(overrides: Partial<WorkerState> = {}): WorkerState {
   };
 }
 
-function makeSnapshot(workers: Record<string, WorkerState>): MonitorSnapshot {
+function makeSnapshot(
+  workers: Record<string, WorkerState>,
+  sessions: SessionState[] = [],
+): MonitorSnapshot {
   return {
     timestamp: "2026-04-13T18:00:00Z",
     orchestrators: [
@@ -46,6 +51,29 @@ function makeSnapshot(workers: Record<string, WorkerState>): MonitorSnapshot {
         attention: [],
       },
     ],
+    sessions,
+    sessionStoreAvailable: sessions.length > 0,
+  };
+}
+
+function makeSession(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: "sess-1",
+    workflowId: null,
+    ticket: "CTL-40",
+    label: "oneshot",
+    skillName: "oneshot",
+    status: "researching",
+    phase: 1,
+    pid: null,
+    alive: false,
+    startedAt: "2026-04-14T19:00:00Z",
+    updatedAt: "2026-04-14T19:00:00Z",
+    completedAt: null,
+    timeSinceUpdate: 0,
+    cost: null,
+    pr: null,
+    ...overrides,
   };
 }
 
@@ -113,6 +141,51 @@ describe("diffWorkers", () => {
   it("returns empty array when nothing changed", () => {
     const snap = makeSnapshot({ "T-1": makeWorker() });
     expect(diffWorkers(snap, snap)).toEqual([]);
+  });
+});
+
+describe("diffSessions", () => {
+  it("emits when a new session appears", () => {
+    const prev = makeSnapshot({}, []);
+    const next = makeSnapshot({}, [makeSession({ sessionId: "new-1" })]);
+    expect(diffSessions(prev, next).map((c) => c.session.sessionId)).toEqual([
+      "new-1",
+    ]);
+  });
+
+  it("emits when status / phase / updatedAt / pid changes", () => {
+    const base = makeSession({ sessionId: "s-1" });
+    const prev = makeSnapshot({}, [base]);
+
+    expect(
+      diffSessions(
+        prev,
+        makeSnapshot({}, [{ ...base, status: "done" }]),
+      ),
+    ).toHaveLength(1);
+    expect(
+      diffSessions(
+        prev,
+        makeSnapshot({}, [{ ...base, phase: 5 }]),
+      ),
+    ).toHaveLength(1);
+    expect(
+      diffSessions(
+        prev,
+        makeSnapshot({}, [{ ...base, updatedAt: "2026-04-14T20:00:00Z" }]),
+      ),
+    ).toHaveLength(1);
+    expect(
+      diffSessions(
+        prev,
+        makeSnapshot({}, [{ ...base, pid: 9999 }]),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("does not emit when nothing changed", () => {
+    const snap = makeSnapshot({}, [makeSession()]);
+    expect(diffSessions(snap, snap)).toEqual([]);
   });
 });
 
@@ -198,5 +271,45 @@ describe("startWatching integration", () => {
     const handle = startWatching(tmp);
     handle.stop();
     expect(() => handle.stop()).not.toThrow();
+  });
+
+  it("polls SQLite and emits session-update events when dbPath is given", async () => {
+    const dbPath = join(tmp, "catalyst.db");
+    const schemaSql = readFileSync(
+      join(__dirname, "..", "..", "db-migrations", "001_initial_schema.sql"),
+      "utf8",
+    );
+    const db = new Database(dbPath, { create: true });
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec(schemaSql);
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO sessions (session_id, status, phase, started_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      ["sess-1", "researching", 1, now, now],
+    );
+    db.close();
+
+    const updates: unknown[] = [];
+    const unsub = subscribe("session-update", (d) => updates.push(d));
+    const handle = startWatching(tmp, {
+      dbPath,
+      sqlitePollIntervalMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Mutate the DB: status change should trigger a session-update
+    const db2 = new Database(dbPath);
+    db2.run(
+      `UPDATE sessions SET status = ?, updated_at = ? WHERE session_id = ?`,
+      ["done", new Date().toISOString(), "sess-1"],
+    );
+    db2.close();
+
+    await new Promise((r) => setTimeout(r, 200));
+    unsub();
+    handle.stop();
+
+    expect(updates.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/session-store.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/session-store.ts
@@ -1,0 +1,240 @@
+import { Database } from "bun:sqlite";
+import { existsSync } from "fs";
+import { checkProcessAlive } from "./liveness";
+import type { WorkerCost } from "./state-reader";
+
+export interface SessionPr {
+  number: number;
+  url: string | null;
+  ciStatus: string | null;
+  openedAt: string | null;
+  mergedAt: string | null;
+}
+
+export interface SessionState {
+  sessionId: string;
+  workflowId: string | null;
+  ticket: string | null;
+  label: string | null;
+  skillName: string | null;
+  status: string;
+  phase: number;
+  pid: number | null;
+  alive: boolean;
+  startedAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+  timeSinceUpdate: number;
+  cost: WorkerCost | null;
+  pr: SessionPr | null;
+}
+
+export interface SessionStoreSnapshot {
+  available: boolean;
+  sessions: SessionState[];
+}
+
+export interface SessionQuery {
+  soloOnly?: boolean;
+  workflowId?: string;
+  ticket?: string;
+  status?: string;
+  limit?: number;
+}
+
+function openReadonly(dbPath: string): Database | null {
+  try {
+    const db = new Database(dbPath, { readonly: true });
+    return db;
+  } catch (err) {
+    console.error(`[session-store] open failed for ${dbPath}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Returns true if dbPath exists and contains a `sessions` table we can query.
+ * This is a cheap probe — callers use it to short-circuit when the SQLite
+ * store isn't yet provisioned on this machine.
+ */
+export function sessionStoreAvailable(dbPath: string): boolean {
+  if (!existsSync(dbPath)) return false;
+  const db = openReadonly(dbPath);
+  if (!db) return false;
+  try {
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'",
+      )
+      .get();
+    return !!row;
+  } catch (err) {
+    console.error(`[session-store] availability check failed:`, err);
+    return false;
+  } finally {
+    db.close();
+  }
+}
+
+interface SessionRow {
+  session_id: string;
+  workflow_id: string | null;
+  ticket_key: string | null;
+  label: string | null;
+  skill_name: string | null;
+  status: string;
+  phase: number;
+  pid: number | null;
+  started_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  cost_usd: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_tokens: number | null;
+  pr_number: number | null;
+  pr_url: string | null;
+  ci_status: string | null;
+  opened_at: string | null;
+  merged_at: string | null;
+}
+
+function rowToState(row: SessionRow): SessionState {
+  const timeSinceUpdate = (() => {
+    const parsed = Date.parse(row.updated_at);
+    if (Number.isNaN(parsed)) return 0;
+    return Math.max(0, (Date.now() - parsed) / 1000);
+  })();
+
+  const cost: WorkerCost | null =
+    row.cost_usd === null
+      ? null
+      : {
+          costUSD: row.cost_usd ?? 0,
+          inputTokens: row.input_tokens ?? 0,
+          outputTokens: row.output_tokens ?? 0,
+          cacheReadTokens: row.cache_read_tokens ?? 0,
+        };
+
+  const pr: SessionPr | null =
+    row.pr_number === null
+      ? null
+      : {
+          number: row.pr_number,
+          url: row.pr_url,
+          ciStatus: row.ci_status,
+          openedAt: row.opened_at,
+          mergedAt: row.merged_at,
+        };
+
+  return {
+    sessionId: row.session_id,
+    workflowId: row.workflow_id,
+    ticket: row.ticket_key,
+    label: row.label,
+    skillName: row.skill_name,
+    status: row.status,
+    phase: row.phase,
+    pid: row.pid,
+    alive: checkProcessAlive(row.pid),
+    startedAt: row.started_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+    timeSinceUpdate,
+    cost,
+    pr,
+  };
+}
+
+/**
+ * Read all (or filtered) sessions from the SQLite store, left-joined with
+ * metrics and the most-recent PR per session. Returns a snapshot object
+ * with an `available` flag so callers can distinguish "store not yet
+ * provisioned" from "store queried and empty".
+ */
+export function readSessionStore(
+  dbPath: string,
+  query: SessionQuery = {},
+): SessionStoreSnapshot {
+  if (!existsSync(dbPath)) {
+    return { available: false, sessions: [] };
+  }
+
+  const db = openReadonly(dbPath);
+  if (!db) return { available: false, sessions: [] };
+
+  try {
+    // Build WHERE clause with parameter bindings so user input never
+    // interpolates into SQL.
+    const clauses: string[] = [];
+    const params: (string | number | null)[] = [];
+    if (query.soloOnly) clauses.push("s.workflow_id IS NULL");
+    if (query.workflowId) {
+      clauses.push("s.workflow_id = ?");
+      params.push(query.workflowId);
+    }
+    if (query.ticket) {
+      clauses.push("s.ticket_key = ?");
+      params.push(query.ticket);
+    }
+    if (query.status) {
+      clauses.push("s.status = ?");
+      params.push(query.status);
+    }
+    const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+    const limit =
+      typeof query.limit === "number" && Number.isFinite(query.limit)
+        ? `LIMIT ${Math.max(0, Math.floor(query.limit))}`
+        : "";
+
+    // Join latest PR per session (by opened_at DESC, then pr_number DESC as tiebreak).
+    // SQLite's min/max with companion columns pattern is awkward; we use a
+    // correlated subquery. Still cheap for realistic session counts.
+    const sql = `
+      SELECT
+        s.session_id,
+        s.workflow_id,
+        s.ticket_key,
+        s.label,
+        s.skill_name,
+        s.status,
+        s.phase,
+        s.pid,
+        s.started_at,
+        s.updated_at,
+        s.completed_at,
+        m.cost_usd,
+        m.input_tokens,
+        m.output_tokens,
+        m.cache_read_tokens,
+        p.pr_number,
+        p.pr_url,
+        p.ci_status,
+        p.opened_at,
+        p.merged_at
+      FROM sessions s
+      LEFT JOIN session_metrics m ON m.session_id = s.session_id
+      LEFT JOIN (
+        SELECT session_id, pr_number, pr_url, ci_status, opened_at, merged_at
+        FROM session_prs
+        WHERE (session_id, pr_number) IN (
+          SELECT session_id, MAX(pr_number) FROM session_prs GROUP BY session_id
+        )
+      ) p ON p.session_id = s.session_id
+      ${where}
+      ORDER BY s.started_at DESC
+      ${limit}
+    `;
+
+    const rows = db.prepare(sql).all(...params) as SessionRow[];
+    return {
+      available: true,
+      sessions: rows.map(rowToState),
+    };
+  } catch (err) {
+    console.error(`[session-store] query failed on ${dbPath}:`, err);
+    return { available: false, sessions: [] };
+  } finally {
+    db.close();
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
@@ -3,6 +3,14 @@ import { join, basename, resolve as resolvePath } from "path";
 import { execSync } from "child_process";
 import { checkProcessAlive } from "./liveness";
 import { parseOutputJson, analyticsPath, type WorkerAnalytics } from "./output-parser";
+import {
+  readSessionStore,
+  sessionStoreAvailable,
+  type SessionState,
+  type SessionQuery,
+} from "./session-store";
+
+export type { SessionState, SessionQuery } from "./session-store";
 
 export interface DefinitionOfDone {
   testsWrittenFirst?: boolean;
@@ -88,6 +96,13 @@ export interface OrchestratorState {
 export interface MonitorSnapshot {
   timestamp: string;
   orchestrators: OrchestratorState[];
+  sessions: SessionState[];
+  sessionStoreAvailable: boolean;
+}
+
+export interface BuildSnapshotOptions {
+  dbPath?: string | null;
+  sessionQuery?: SessionQuery;
 }
 
 function isRecord(x: unknown): x is Record<string, unknown> {
@@ -416,7 +431,10 @@ export function buildAnalyticsSnapshot(baseDir: string): AnalyticsSnapshot {
   };
 }
 
-export function buildSnapshot(baseDir: string): MonitorSnapshot {
+export function buildSnapshot(
+  baseDir: string,
+  options: BuildSnapshotOptions = {},
+): MonitorSnapshot {
   const dirs = scanOrchestrators(baseDir);
   const orchestrators: OrchestratorState[] = [];
   for (const d of dirs) {
@@ -426,9 +444,22 @@ export function buildSnapshot(baseDir: string): MonitorSnapshot {
       console.error(`[state-reader] readOrchestratorState failed for ${d}:`, err);
     }
   }
+
+  let sessions: SessionState[] = [];
+  let storeAvailable = false;
+  const dbPath = options.dbPath ?? null;
+  if (dbPath) {
+    storeAvailable = sessionStoreAvailable(dbPath);
+    if (storeAvailable) {
+      sessions = readSessionStore(dbPath, options.sessionQuery ?? {}).sessions;
+    }
+  }
+
   return {
     timestamp: new Date().toISOString(),
     orchestrators,
+    sessions,
+    sessionStoreAvailable: storeAvailable,
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/watcher.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/watcher.ts
@@ -3,6 +3,8 @@ import {
   buildSnapshot,
   type MonitorSnapshot,
   type WorkerState,
+  type SessionState,
+  type BuildSnapshotOptions,
 } from "./state-reader";
 import { emit } from "./event-bus";
 
@@ -15,6 +17,10 @@ export interface WorkerChange {
   worker: WorkerState;
 }
 
+export interface SessionChange {
+  session: SessionState;
+}
+
 function flattenWorkers(snap: MonitorSnapshot): Map<string, WorkerChange> {
   const out = new Map<string, WorkerChange>();
   for (const orch of snap.orchestrators) {
@@ -22,6 +28,12 @@ function flattenWorkers(snap: MonitorSnapshot): Map<string, WorkerChange> {
       out.set(`${orch.id}:${key}`, { orchId: orch.id, worker: w });
     }
   }
+  return out;
+}
+
+function flattenSessions(snap: MonitorSnapshot): Map<string, SessionState> {
+  const out = new Map<string, SessionState>();
+  for (const s of snap.sessions) out.set(s.sessionId, s);
   return out;
 }
 
@@ -42,6 +54,28 @@ export function diffWorkers(
       before.worker.pid !== v.worker.pid
     ) {
       changed.push(v);
+    }
+  }
+  return changed;
+}
+
+export function diffSessions(
+  prev: MonitorSnapshot,
+  next: MonitorSnapshot,
+): SessionChange[] {
+  const prevMap = flattenSessions(prev);
+  const nextMap = flattenSessions(next);
+  const changed: SessionChange[] = [];
+  for (const [id, s] of nextMap) {
+    const before = prevMap.get(id);
+    if (
+      !before ||
+      before.status !== s.status ||
+      before.phase !== s.phase ||
+      before.updatedAt !== s.updatedAt ||
+      before.pid !== s.pid
+    ) {
+      changed.push({ session: s });
     }
   }
   return changed;
@@ -78,9 +112,19 @@ export function isRelevant(filename: string): boolean {
 export const DEBOUNCE_MS = 200;
 export const LIVENESS_INTERVAL_MS = 5000;
 export const SNAPSHOT_INTERVAL_MS = 30000;
+export const SQLITE_POLL_INTERVAL_MS = 2000;
 
-export function startWatching(baseDir: string): WatcherHandle {
-  let lastSnapshot: MonitorSnapshot = buildSnapshot(baseDir);
+export interface StartWatchingOptions {
+  dbPath?: string | null;
+  sqlitePollIntervalMs?: number;
+}
+
+export function startWatching(
+  baseDir: string,
+  options: StartWatchingOptions = {},
+): WatcherHandle {
+  const buildOpts: BuildSnapshotOptions = { dbPath: options.dbPath ?? null };
+  let lastSnapshot: MonitorSnapshot = buildSnapshot(baseDir, buildOpts);
   emit("snapshot", lastSnapshot);
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -91,7 +135,7 @@ export function startWatching(baseDir: string): WatcherHandle {
       if (!filename || !isRelevant(String(filename))) return;
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
-        const next = buildSnapshot(baseDir);
+        const next = buildSnapshot(baseDir, buildOpts);
         for (const change of diffWorkers(lastSnapshot, next)) {
           emit("worker-update", change);
         }
@@ -109,7 +153,7 @@ export function startWatching(baseDir: string): WatcherHandle {
   }
 
   const livenessInterval = setInterval(() => {
-    const next = buildSnapshot(baseDir);
+    const next = buildSnapshot(baseDir, buildOpts);
     for (const flip of diffLiveness(lastSnapshot, next)) {
       emit("liveness-change", flip);
     }
@@ -117,9 +161,23 @@ export function startWatching(baseDir: string): WatcherHandle {
   }, LIVENESS_INTERVAL_MS);
 
   const snapshotInterval = setInterval(() => {
-    lastSnapshot = buildSnapshot(baseDir);
+    lastSnapshot = buildSnapshot(baseDir, buildOpts);
     emit("snapshot", lastSnapshot);
   }, SNAPSHOT_INTERVAL_MS);
+
+  // SQLite doesn't support fs.watch semantics reliably (WAL writes bypass the
+  // main file mtime), so poll at a configurable interval when a dbPath is set.
+  let sqliteInterval: ReturnType<typeof setInterval> | null = null;
+  if (options.dbPath) {
+    const pollMs = options.sqlitePollIntervalMs ?? SQLITE_POLL_INTERVAL_MS;
+    sqliteInterval = setInterval(() => {
+      const next = buildSnapshot(baseDir, buildOpts);
+      for (const change of diffSessions(lastSnapshot, next)) {
+        emit("session-update", change);
+      }
+      lastSnapshot = next;
+    }, pollMs);
+  }
 
   let stopped = false;
   return {
@@ -129,6 +187,7 @@ export function startWatching(baseDir: string): WatcherHandle {
       if (debounceTimer) clearTimeout(debounceTimer);
       clearInterval(livenessInterval);
       clearInterval(snapshotInterval);
+      if (sqliteInterval) clearInterval(sqliteInterval);
       try {
         watcher?.close();
       } catch (err) {

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -5,7 +5,10 @@ import {
   buildSnapshot,
   buildAnalyticsSnapshot,
   type MonitorSnapshot,
+  type BuildSnapshotOptions,
+  type SessionState,
 } from "./lib/state-reader";
+import { readSessionStore } from "./lib/session-store";
 import { startWatching, type WatcherHandle } from "./lib/watcher";
 import {
   createPrStatusFetcher,
@@ -31,6 +34,10 @@ export interface CreateServerOptions {
   prStatusRefreshMs?: number;
   linearFetcher?: LinearFetcher | null;
   linearRefreshMs?: number;
+  /** Path to the SQLite session store. Pass `null` to disable. */
+  dbPath?: string | null;
+  /** SQLite poll interval for the watcher (ms). */
+  sqlitePollIntervalMs?: number;
 }
 
 export const DEFAULT_PORT = 7400;
@@ -95,7 +102,12 @@ function applyPrStatus(
   }
   return snapshot;
 }
-const SSE_EVENTS = ["snapshot", "worker-update", "liveness-change"] as const;
+const SSE_EVENTS = [
+  "snapshot",
+  "worker-update",
+  "liveness-change",
+  "session-update",
+] as const;
 const ALLOWED_PUBLIC_EXTENSIONS = new Set([
   ".html",
   ".css",
@@ -161,7 +173,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
     prStatusRefreshMs = PR_STATUS_REFRESH_MS,
     linearFetcher,
     linearRefreshMs = LINEAR_REFRESH_MS,
+    dbPath = null,
+    sqlitePollIntervalMs,
   } = opts;
+
+  const buildOpts: BuildSnapshotOptions = { dbPath };
 
   const prFetcher: PrStatusFetcher | null =
     prStatusFetcher === null
@@ -176,7 +192,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
   let linearStarted = false;
 
   function snapshotWithPrStatus(): MonitorSnapshot {
-    const snap = buildSnapshot(wtDir);
+    const snap = buildSnapshot(wtDir, buildOpts);
     if (prFetcher) {
       const now = Date.now();
       if (now - lastPrRefresh >= prStatusRefreshMs) {
@@ -188,7 +204,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
     }
     if (linear && !linearStarted) {
       linearStarted = true;
-      linear.start(() => collectTicketKeys(buildSnapshot(wtDir)), linearRefreshMs);
+      linear.start(
+        () => collectTicketKeys(buildSnapshot(wtDir, buildOpts)),
+        linearRefreshMs,
+      );
     }
     return snap;
   }
@@ -260,6 +279,24 @@ export function createServer(opts: CreateServerOptions): BunServer {
           return Response.json(buildAnalyticsSnapshot(wtDir));
         }
 
+        if (url.pathname === "/api/sessions") {
+          if (!dbPath) {
+            return Response.json({ available: false, sessions: [] });
+          }
+          const params = url.searchParams;
+          const limitRaw = params.get("limit");
+          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+          const result = readSessionStore(dbPath, {
+            soloOnly: params.get("solo") === "true",
+            workflowId: params.get("workflow") ?? undefined,
+            ticket: params.get("ticket") ?? undefined,
+            status: params.get("status") ?? undefined,
+            limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+          });
+          const sessions: SessionState[] = result.sessions;
+          return Response.json({ available: result.available, sessions });
+        }
+
         if (url.pathname === "/api/linear") {
           const tickets: Record<string, LinearTicket> = {};
           if (linear) {
@@ -304,7 +341,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
   });
 
   if (startWatcher) {
-    watcher = startWatching(wtDir);
+    watcher = startWatching(wtDir, { dbPath, sqlitePollIntervalMs });
   }
 
   const originalStop = server.stop.bind(server);
@@ -326,8 +363,10 @@ if (import.meta.main) {
   const WT_DIR = `${CATALYST_DIR}/wt`;
   const parsedPort = parseInt(process.env.MONITOR_PORT ?? "", 10);
   const PORT = Number.isFinite(parsedPort) && parsedPort > 0 ? parsedPort : DEFAULT_PORT;
+  const DB_PATH =
+    process.env.CATALYST_DB_FILE ?? `${CATALYST_DIR}/catalyst.db`;
 
-  const srv = createServer({ port: PORT, wtDir: WT_DIR });
+  const srv = createServer({ port: PORT, wtDir: WT_DIR, dbPath: DB_PATH });
   const displayHost =
     srv.hostname === "0.0.0.0" ? "localhost" : String(srv.hostname);
   console.info(`Monitor running at http://${displayHost}:${srv.port}`);


### PR DESCRIPTION
## Summary

Adds SQLite session reader to orch-monitor alongside the existing filesystem reader. Solo Claude Code sessions recorded by the session store (CTL-36) now surface in `/api/snapshot`, `/api/sessions`, and SSE streams next to orchestrated workers — unifying the two data sources behind one monitor UI.

- `lib/session-store.ts`: `readSessionStore(dbPath, query)` with `solo`, `workflow`, `ticket`, `status`, `limit` filters. Joins `session_metrics` and latest `session_prs`. Readonly, graceful on missing/malformed DB.
- `buildSnapshot()` accepts `{ dbPath }` and adds `sessions[]` + `sessionStoreAvailable` to `MonitorSnapshot`.
- `watcher.ts` polls SQLite at 2s (configurable) and emits `session-update` events via `diffSessions`. Filesystem debounce unchanged (200ms).
- `server.ts` wires `dbPath` through, adds `session-update` to SSE events, exposes `/api/sessions`, defaults `CATALYST_DB_FILE` to `${CATALYST_DIR}/catalyst.db`.

## Test plan

- [x] 11 new `session-store.test.ts` cases (availability probe, filters, joins, ordering, error robustness)
- [x] `state-reader.test.ts`: backward-compat (no dbPath → empty sessions) + SQLite session read
- [x] `watcher.test.ts`: `diffSessions` + SQLite polling emits `session-update`
- [x] `server.test.ts`: `/api/sessions` with solo/ticket filters, `/api/snapshot` includes sessions, `available:false` without dbPath
- [x] `bun run check` clean (typecheck + lint + 127 tests)

Closes CTL-40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)