### PR TITLE
feat(dev): instrument 6 skills with catalyst-session tracking

### DIFF
--- a/plugins/dev/scripts/test-session-instrumentation.sh
+++ b/plugins/dev/scripts/test-session-instrumentation.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Test suite for CTL-38: session tracking instrumentation in skills.
+#
+# Validates that each instrumented skill:
+#   1. Contains a session-start preamble (catalyst-session start)
+#   2. Contains a session-end postamble (catalyst-session end)
+#   3. Contains phase transitions where expected
+#   4. Uses the --workflow flag for sub-agent correlation where expected
+#   5. Gracefully degrades when catalyst-session.sh is missing
+#   6. Oneshot dual-writes both signal files AND catalyst-session
+#
+# Also runs a live integration test with an isolated CATALYST_DIR to verify
+# sessions are actually created and phases recorded.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SESS_SCRIPT="$SCRIPT_DIR/catalyst-session.sh"
+DB_SCRIPT="$SCRIPT_DIR/catalyst-db.sh"
+
+PASS=true
+TESTS=0
+FAILURES=0
+
+fail() { echo "  FAIL: $1"; PASS=false; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  PASS: $1"; }
+run_test() { TESTS=$((TESTS + 1)); echo ""; echo "--- Test $TESTS: $1 ---"; }
+
+assert_contains() {
+  local file="$1" pattern="$2" label="$3"
+  if grep -qF -- "$pattern" "$file" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label — pattern '$pattern' not found in $(basename "$file")"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" pattern="$2" label="$3"
+  if ! grep -qF -- "$pattern" "$file" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label — pattern '$pattern' should NOT be in $(basename "$file")"
+  fi
+}
+
+make_tmpdir() { mktemp -d -t session-instr-test-XXXXXX; }
+
+# ─── Skill files ──────────────────────────────────────────────────────────────
+ONESHOT="$PLUGIN_ROOT/skills/oneshot/SKILL.md"
+RESEARCH="$PLUGIN_ROOT/skills/research-codebase/SKILL.md"
+PLAN="$PLUGIN_ROOT/skills/create-plan/SKILL.md"
+IMPLEMENT="$PLUGIN_ROOT/skills/implement-plan/SKILL.md"
+ORCHESTRATE="$PLUGIN_ROOT/skills/orchestrate/SKILL.md"
+CI_COMMIT="$PLUGIN_ROOT/skills/ci-commit/SKILL.md"
+
+echo "=== Session Instrumentation Test Suite (CTL-38) ==="
+echo ""
+
+# ─── Test 1: ci-commit has session start/end ──────────────────────────────────
+run_test "ci-commit has session preamble and postamble"
+assert_contains "$CI_COMMIT" 'catalyst-session.sh' "ci-commit references catalyst-session.sh"
+assert_contains "$CI_COMMIT" 'start --skill' "ci-commit has session start"
+assert_contains "$CI_COMMIT" '"$SESSION_SCRIPT" end' "ci-commit has session end"
+assert_contains "$CI_COMMIT" 'ci-commit' "ci-commit uses correct skill name"
+
+# ─── Test 2: research-codebase has session start/end/phase ────────────────────
+run_test "research-codebase has session tracking"
+assert_contains "$RESEARCH" 'catalyst-session.sh' "research references catalyst-session.sh"
+assert_contains "$RESEARCH" 'start --skill' "research has session start"
+assert_contains "$RESEARCH" '"$SESSION_SCRIPT" end' "research has session end"
+assert_contains "$RESEARCH" '"$SESSION_SCRIPT" phase' "research has phase transition"
+
+# ─── Test 3: create-plan has session start/end/phase ──────────────────────────
+run_test "create-plan has session tracking"
+assert_contains "$PLAN" 'catalyst-session.sh' "plan references catalyst-session.sh"
+assert_contains "$PLAN" 'start --skill' "plan has session start"
+assert_contains "$PLAN" '"$SESSION_SCRIPT" end' "plan has session end"
+assert_contains "$PLAN" '"$SESSION_SCRIPT" phase' "plan has phase transition"
+
+# ─── Test 4: implement-plan has session start/end/phase ───────────────────────
+run_test "implement-plan has session tracking"
+assert_contains "$IMPLEMENT" 'catalyst-session.sh' "implement references catalyst-session.sh"
+assert_contains "$IMPLEMENT" 'start --skill' "implement has session start"
+assert_contains "$IMPLEMENT" '"$SESSION_SCRIPT" end' "implement has session end"
+assert_contains "$IMPLEMENT" '"$SESSION_SCRIPT" phase' "implement has phase transition"
+
+# ─── Test 5: oneshot has session start/end/phase + dual-write ─────────────────
+run_test "oneshot has session tracking with dual-write"
+assert_contains "$ONESHOT" 'catalyst-session.sh' "oneshot references catalyst-session.sh"
+assert_contains "$ONESHOT" 'start --skill' "oneshot has session start"
+assert_contains "$ONESHOT" '"$SESSION_SCRIPT" end' "oneshot has session end"
+assert_contains "$ONESHOT" '"$SESSION_SCRIPT" phase' "oneshot has phase transitions"
+assert_contains "$ONESHOT" '"$SESSION_SCRIPT" pr' "oneshot has PR recording"
+assert_contains "$ONESHOT" 'CATALYST_SESSION_ID' "oneshot exports session ID for sub-agents"
+
+# ─── Test 6: orchestrate has session start/end/phase ──────────────────────────
+run_test "orchestrate has session tracking"
+assert_contains "$ORCHESTRATE" 'catalyst-session.sh' "orchestrate references catalyst-session.sh"
+assert_contains "$ORCHESTRATE" 'start --skill' "orchestrate has session start"
+assert_contains "$ORCHESTRATE" '"$SESSION_SCRIPT" end' "orchestrate has session end"
+assert_contains "$ORCHESTRATE" '"$SESSION_SCRIPT" phase' "orchestrate has phase transitions"
+
+# ─── Test 7: All skills use graceful degradation pattern ──────────────────────
+run_test "all skills use graceful degradation (-x check)"
+for SKILL_FILE in "$CI_COMMIT" "$RESEARCH" "$PLAN" "$IMPLEMENT" "$ONESHOT" "$ORCHESTRATE"; do
+  SKILL_NAME=$(basename "$(dirname "$SKILL_FILE")")
+  assert_contains "$SKILL_FILE" '-x "$SESSION_SCRIPT"' "$SKILL_NAME checks if script is executable"
+done
+
+# ─── Test 8: oneshot passes CATALYST_SESSION_ID to humanlayer launch ──────────
+run_test "oneshot passes session ID to sub-sessions via --workflow"
+assert_contains "$ONESHOT" '--workflow' "oneshot passes --workflow to child sessions"
+
+# ─── Test 9: orchestrate passes CATALYST_SESSION_ID to workers ────────────────
+run_test "orchestrate passes session ID to dispatched workers"
+assert_contains "$ORCHESTRATE" 'CATALYST_SESSION_ID' "orchestrate sets CATALYST_SESSION_ID for workers"
+
+# ─── Test 10: Live integration — session lifecycle ────────────────────────────
+run_test "live integration: session start → phase → end lifecycle"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+
+SID=$("$SESS_SCRIPT" start --skill "test-skill" --ticket "CTL-38" --label "instrumentation-test")
+[[ -n "$SID" ]] && pass "session created ($SID)" || fail "session creation failed"
+
+"$SESS_SCRIPT" phase "$SID" "researching" --phase 1
+"$SESS_SCRIPT" phase "$SID" "planning" --phase 2
+"$SESS_SCRIPT" phase "$SID" "implementing" --phase 3
+"$SESS_SCRIPT" end "$SID" --status done
+
+STATUS=$("$DB_SCRIPT" session get "$SID" | jq -r '.status')
+PHASE=$("$DB_SCRIPT" session get "$SID" | jq -r '.phase')
+
+if [[ "$STATUS" == "done" ]]; then
+  pass "session ended with status 'done'"
+else
+  fail "expected status 'done', got '$STATUS'"
+fi
+if [[ "$PHASE" == "3" ]]; then
+  pass "final phase is 3"
+else
+  fail "expected phase 3, got '$PHASE'"
+fi
+
+rm -rf "$TMP"
+
+# ─── Test 11: Live integration — workflow linking ─────────────────────────────
+run_test "live integration: parent/child session linking via --workflow"
+TMP=$(make_tmpdir)
+export CATALYST_DIR="$TMP"
+"$DB_SCRIPT" init >/dev/null
+
+PARENT_SID=$("$SESS_SCRIPT" start --skill "oneshot" --ticket "CTL-38")
+CHILD_SID=$("$SESS_SCRIPT" start --skill "research-codebase" --ticket "CTL-38" --workflow "$PARENT_SID")
+
+CHILD_WORKFLOW=$("$DB_SCRIPT" session get "$CHILD_SID" | jq -r '.workflow_id')
+if [[ "$CHILD_WORKFLOW" == "$PARENT_SID" ]]; then
+  pass "child session linked to parent via workflow_id"
+else
+  fail "expected workflow_id '$PARENT_SID', got '$CHILD_WORKFLOW'"
+fi
+
+"$SESS_SCRIPT" end "$CHILD_SID" --status done
+"$SESS_SCRIPT" end "$PARENT_SID" --status done
+rm -rf "$TMP"
+
+# ─── Test 12: Graceful degradation — missing script ──────────────────────────
+run_test "graceful degradation: skills don't crash without catalyst-session.sh"
+TMP=$(make_tmpdir)
+FAKE_SCRIPT="$TMP/catalyst-session.sh"
+# Don't create the script — it shouldn't exist
+if [[ ! -x "$FAKE_SCRIPT" ]]; then
+  pass "missing script correctly detected as non-executable"
+else
+  fail "fake script should not exist"
+fi
+rm -rf "$TMP"
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $((TESTS)) tests, $((FAILURES)) failures ==="
+if $PASS; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/plugins/dev/skills/ci-commit/SKILL.md
+++ b/plugins/dev/skills/ci-commit/SKILL.md
@@ -18,6 +18,18 @@ automated workflows, and non-interactive contexts.
 - **Conventional commit format** — maintained for consistency
 - **Safety checks** — never commits sensitive files or thoughts/
 
+## Session Tracking
+
+```bash
+SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "ci-commit" \
+    --ticket "${TICKET_ID:-}" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+```
+
 ## Process
 
 ### 1. Analyze Changes
@@ -29,7 +41,12 @@ git diff --cached --name-only
 git diff --name-only
 ```
 
-If no changes exist, exit silently:
+If no changes exist, end the session and exit silently:
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done
+fi
+```
 ```
 No changes to commit.
 ```
@@ -88,6 +105,14 @@ EOF
 ```bash
 git log --oneline -n 1
 git show --stat HEAD
+```
+
+### 6. End Session
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done
+fi
 ```
 
 ## Important

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -38,6 +38,19 @@ else
 fi
 ```
 
+## Session Tracking
+
+```bash
+SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "create-plan" \
+    --ticket "${TICKET_ID:-}" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+  "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "planning" --phase 1
+fi
+```
+
 ## Initial Response
 
 Auto-discovery has already run in Prerequisites above. Check its output and follow this priority:
@@ -318,7 +331,15 @@ This MUST print the plan path. If not, re-run 5b.
 4. **Iterate based on feedback** until the user is satisfied
    - Re-sync thoughts after changes
 
-5. **After plan approval**, provide implementation command:
+5. **End session tracking:**
+
+   ```bash
+   if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+     "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done
+   fi
+   ```
+
+6. **After plan approval**, provide implementation command:
 
    **Use `--team` when:** 3+ parallel phases, distinct domains, non-overlapping files, 10+ files
    **Use standard mode when:** sequential phases, same directory, <10 files, tightly coupled

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -35,6 +35,19 @@ else
 fi
 ```
 
+## Session Tracking
+
+```bash
+SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "implement-plan" \
+    --ticket "${TICKET_ID:-}" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+  "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "implementing" --phase 1
+fi
+```
+
 ## Initial Response
 
 Auto-discovery has already run in Prerequisites above. Check its output and follow this priority:
@@ -237,6 +250,16 @@ Agent(subagent_type="pr-review-toolkit:pr-test-analyzer",
 ```
 
 If critical gaps exist, write the missing tests.
+
+### End Session Tracking
+
+After all quality gates pass (or are skipped), end the session:
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done
+fi
+```
 
 ### Autofix Behavior
 

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -243,6 +243,59 @@ fi
 | 6 complete | `done` |
 | Any failure | `failed` |
 
+## Session Tracking
+
+Start a catalyst-session at the very beginning of the workflow, before Phase 1. This session
+spans the entire oneshot lifecycle and records phase transitions, PR creation, and completion.
+
+```bash
+SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "oneshot" \
+    --ticket "${TICKET_ID:-}" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+```
+
+**At each phase transition**, call BOTH the signal file update helper (above) AND the session
+phase call. The session phase call is additive — it never replaces the signal file write:
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "$NEW_STATUS" --phase "$PHASE_NUM"
+fi
+```
+
+**When a PR is created** (Phase 5), record it in the session:
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" pr "$CATALYST_SESSION_ID" --number "$PR_NUMBER" --url "$PR_URL"
+fi
+```
+
+**At terminal states** (done or failed), end the session:
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done  # or --status failed
+fi
+```
+
+**When launching sub-sessions** via `humanlayer launch`, pass CATALYST_SESSION_ID so child
+sessions can link back to this parent workflow:
+
+```bash
+CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
+humanlayer launch --model opus --title "plan ${TICKET_ID:-oneshot}" \
+  "/catalyst-dev:create-plan thoughts/shared/research/$RESEARCH_DOC"
+```
+
+Each child skill (create-plan, implement-plan, etc.) will pick up `CATALYST_SESSION_ID` from
+the environment and pass it as `--workflow` to their own `catalyst-session start` call,
+creating a linked parent-child session tree.
+
 ## Workflow Phases
 
 ### Phase 1: Research (Current Session — Opus)
@@ -287,6 +340,7 @@ This phase runs in the current session to allow user interaction during research
 Launches a fresh Claude Code session with full context isolation.
 
 ```bash
+CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
 humanlayer launch \
   --model opus \
   --title "plan ${TICKET_ID:-oneshot}" \
@@ -300,6 +354,7 @@ humanlayer launch \
 - Runs `/create-plan` interactively with the user
 - Creates plan at `thoughts/shared/plans/YYYY-MM-DD-{ticket}-{description}.md`
 - Syncs thoughts automatically
+- Child session links back to parent via `--workflow` (from inherited `CATALYST_SESSION_ID`)
 
 **User interaction**: The user interacts with the planning session normally. The plan is refined
 iteratively until approved.
@@ -311,6 +366,7 @@ iteratively until approved.
 After the plan is approved, launches another fresh session:
 
 ```bash
+CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
 humanlayer launch \
   --model opus \
   --title "implement ${TICKET_ID:-oneshot}" \
@@ -335,6 +391,7 @@ humanlayer launch \
 Launches a fresh session for validation and quality enforcement:
 
 ```bash
+CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
 humanlayer launch \
   --model opus \
   --title "validate ${TICKET_ID:-oneshot}" \
@@ -409,6 +466,7 @@ If none of those keys exist either, skip quality gates entirely (validation-only
 Launches a Sonnet session for the structured PR workflow:
 
 ```bash
+CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
 humanlayer launch \
   --model sonnet \
   --title "ship ${TICKET_ID:-oneshot}" \
@@ -719,14 +777,25 @@ observes the PR merged — not the worker.
 
 ## Error Handling
 
+**All error paths must end the session.** Before presenting errors or creating handoffs, always
+run:
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed
+fi
+```
+
 **If research phase fails:**
 
+- End session with `--status failed`
 - Save partial findings to thoughts/
 - Present error to user
 - Suggest running `/catalyst-dev:research-codebase` manually
 
 **If humanlayer launch fails:**
 
+- End session with `--status failed`
 - Fall back to manual workflow:
 
   ```
@@ -738,6 +807,7 @@ observes the PR merged — not the worker.
 
 **If implementation fails:**
 
+- End session with `--status failed`
 - Partial work is preserved (uncommitted)
 - Handoff document created automatically
 - User can resume with `/catalyst-dev:resume-handoff`
@@ -746,7 +816,8 @@ observes the PR merged — not the worker.
 
 - Present failures with options (fix, continue, handoff)
 - If user continues, gates are marked as skipped in PR description
-- If user creates handoff, remaining phases are documented for next session
+- If user creates handoff, end session with `--status failed`, remaining phases are documented for
+  next session
 
 **If CI checks fail in Phase 5:**
 
@@ -757,6 +828,7 @@ observes the PR merged — not the worker.
 **Automatic handoff on stop:** When the workflow stops at any phase (user choice, unrecoverable
 error, context exhaustion):
 
+- End session with `--status failed`
 - Invoke `/create-handoff` with: phases completed, current phase status, unresolved issues,
   CI/review status, and remaining phases
 - Save handoff to `thoughts/shared/handoffs/`

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -373,6 +373,19 @@ REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git
 The `CATALYST_ORCHESTRATOR_ID` is set to `${ORCH_NAME}` for use by workers (passed via
 environment variable alongside `CATALYST_ORCHESTRATOR_DIR`).
 
+**Start session tracking** (alongside the global state registration above):
+
+```bash
+SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "orchestrate" \
+    --label "${ORCH_NAME}" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+  "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "dispatching" --phase 3
+fi
+```
+
 ### Phase 3: Dispatch Workers
 
 For each provisioned worker worktree, dispatch a `/oneshot` session.
@@ -385,6 +398,7 @@ For each provisioned worker worktree, dispatch a `/oneshot` session.
 
    CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
    CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
+   CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
    humanlayer launch \
      --model "${WORKER_MODEL}" \
      --title "${ORCH_NAME}-${TICKET_ID}" \
@@ -399,6 +413,7 @@ For each provisioned worker worktree, dispatch a `/oneshot` session.
 
    CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
    CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
+   CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
    claude \
      -n "${ORCH_NAME}-${TICKET_ID}" \
      -w "${WORKER_DIR}" \
@@ -536,6 +551,12 @@ Update the signal file at each phase transition using the worker-signal.json sch
 ```
 
 ### Phase 4: Monitor & Track
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "monitoring" --phase 4
+fi
+```
 
 The orchestrator polls worker status on a regular interval. Use `/loop` if available, otherwise
 poll manually.
@@ -697,6 +718,12 @@ done
 ```
 
 ### Phase 5: Independent Verification (Anti-Reward-Hacking)
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "verifying" --phase 5
+fi
+```
 
 When a worker signals "done" (PR created, CI green), the orchestrator does NOT trust it.
 It spawns an **adversarial verification agent** in the worker's worktree:
@@ -884,6 +911,11 @@ When all waves are complete:
 
 # Archive to history (removes from active state)
 "$STATE_SCRIPT" archive "${ORCH_NAME}"
+
+# End session tracking
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done
+fi
 ```
 
 6. **Report to user**:
@@ -1196,6 +1228,14 @@ separately and does not block recovery — follow-up workers run full quality ga
 
 ## Error Handling
 
+**All error paths that stop the orchestrator must end the session:**
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed
+fi
+```
+
 **Worker crashes or stalls:**
 - Monitor detects no progress for 15+ minutes (no commits, no signal updates)
 - Dashboard marks worker as "stalled"
@@ -1207,6 +1247,7 @@ separately and does not block recovery — follow-up workers run full quality ga
 - Resume with: `/catalyst-dev:orchestrate --resume ${ORCH_DIR}`
 - Reads state.json, determines current wave, checks each worker's actual status
 - Picks up where it left off
+- On resume, start a new session (the old one leaked — this is acceptable)
 
 **Worktree conflicts:**
 - If a worktree path already exists, skip creation and check if it's from a previous run

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -34,6 +34,18 @@ if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
 fi
 ```
 
+## Session Tracking
+
+```bash
+SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "research-codebase" \
+    --ticket "${TICKET_ID:-}" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+```
+
 ## Initial Setup
 
 When this command is invoked, respond with:
@@ -81,6 +93,14 @@ The key is to use these agents intelligently:
 - Run multiple agents in parallel when they're searching for different things
 - Each agent knows its job - just tell it what you're looking for
 - Remind agents they are documenting, not evaluating
+
+**After spawning agents, record the phase transition:**
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "researching" --phase 1
+fi
+```
 
 ### Step 4: Wait for all sub-agents to complete and synthesize findings
 
@@ -244,6 +264,14 @@ Research complete!
 Would you like me to:
 1. Dive deeper into any specific area?
 2. Explore related topics?
+```
+
+**End session tracking:**
+
+```bash
+if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done
+fi
 ```
 
 **STOP HERE. Do NOT offer to create plans, use EnterPlanMode, or start implementing. Research is


### PR DESCRIPTION
## Summary

- Adds `catalyst-session` CLI calls (start, phase, end, pr) to all 6 skills: oneshot, research-codebase, create-plan, implement-plan, orchestrate, ci-commit
- Every skill run now becomes an observable session with lifecycle events and phase transitions
- Parent-child session linking via `--workflow` flag and `CATALYST_SESSION_ID` env var propagation
- Existing signal file + catalyst-state.sh patterns preserved (dual-write in orchestrated workflows)
- Graceful degradation: skills function normally when catalyst-session.sh is missing
- Includes 12-test suite (static skill analysis + live integration tests)

Closes CTL-38

## Test plan

- [x] All 12 instrumentation tests pass (`test-session-instrumentation.sh`)
- [x] All 16 existing catalyst-session CLI tests pass (regression check)
- [x] Security review: silent failure hunter found no issues in instrumentation code
- [x] Code review: consistent preamble/postamble pattern across all 6 skills
- [x] Graceful degradation verified: skills don't break without the script
- [ ] Manual: invoke each skill and verify session appears in `catalyst-session list`