### PR TITLE
feat(dev): add AI-powered status briefing to orch-monitor

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/ai-briefing.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ai-briefing.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  createBriefingProvider,
+  buildPrompt,
+  parseBriefingResponse,
+  type AiFetcher,
+} from "../lib/ai-briefing";
+import type { AiConfig } from "../lib/ai-config";
+import type { MonitorSnapshot } from "../lib/state-reader";
+import type { LinearTicket } from "../lib/linear";
+
+function makeConfig(overrides: Partial<AiConfig> = {}): AiConfig {
+  return {
+    enabled: true,
+    gateway: "https://gateway.ai.cloudflare.com/v1/acct/gw",
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    apiKey: "sk-test",
+    ...overrides,
+  };
+}
+
+function makeSnapshot(
+  overrides: Partial<MonitorSnapshot> = {},
+): MonitorSnapshot {
+  return {
+    timestamp: "2026-04-14T12:00:00Z",
+    sessions: [],
+    sessionStoreAvailable: false,
+    orchestrators: [
+      {
+        id: "orch-test",
+        path: "/tmp/orch-test",
+        startedAt: "2026-04-14T11:00:00Z",
+        currentWave: 1,
+        totalWaves: 2,
+        waves: [
+          { wave: 1, status: "in_progress", tickets: ["CTL-10", "CTL-11"] },
+        ],
+        workers: {
+          "CTL-10": {
+            ticket: "CTL-10",
+            status: "pr-created",
+            phase: 5,
+            wave: 1,
+            pid: 1234,
+            alive: true,
+            pr: { number: 42, url: "https://github.com/org/repo/pull/42" },
+            startedAt: "2026-04-14T11:10:00Z",
+            updatedAt: "2026-04-14T11:50:00Z",
+            timeSinceUpdate: 600,
+            lastHeartbeat: "2026-04-14T11:50:00Z",
+            definitionOfDone: {},
+            label: null,
+          },
+          "CTL-11": {
+            ticket: "CTL-11",
+            status: "failed",
+            phase: 3,
+            wave: 1,
+            pid: 1235,
+            alive: false,
+            pr: null,
+            startedAt: "2026-04-14T11:15:00Z",
+            updatedAt: "2026-04-14T11:40:00Z",
+            timeSinceUpdate: 1200,
+            lastHeartbeat: "2026-04-14T11:35:00Z",
+            definitionOfDone: {},
+            label: null,
+          },
+        },
+        dashboard: null,
+        briefings: {},
+        attention: [
+          {
+            type: "waiting-for-user",
+            ticket: "CTL-11",
+            message: "Worker failed: test failures",
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeLinearTickets(): Record<string, LinearTicket> {
+  return {
+    "CTL-10": {
+      key: "CTL-10",
+      title: "Add OAuth2 support",
+      url: "https://linear.app/issue/CTL-10",
+      state: "In Review",
+      project: "Auth",
+      labels: ["feature"],
+      fetchedAt: "2026-04-14T12:00:00Z",
+    },
+    "CTL-11": {
+      key: "CTL-11",
+      title: "Fix login redirect loop",
+      url: "https://linear.app/issue/CTL-11",
+      state: "In Progress",
+      project: "Auth",
+      labels: ["bug"],
+      fetchedAt: "2026-04-14T12:00:00Z",
+    },
+  };
+}
+
+function makeSuccessResponse(): string {
+  return JSON.stringify({
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          briefing:
+            "You have 1 orchestrator running with 2 workers. CTL-10 has a PR open waiting for CI. CTL-11 failed during implementation — needs attention.",
+          suggestedLabels: {
+            "CTL-10": ["feature", "auth"],
+            "CTL-11": ["bugfix", "auth"],
+          },
+        }),
+      },
+    ],
+  });
+}
+
+describe("buildPrompt", () => {
+  it("includes worker status information", () => {
+    const prompt = buildPrompt(makeSnapshot(), makeLinearTickets());
+    expect(prompt).toContain("CTL-10");
+    expect(prompt).toContain("CTL-11");
+    expect(prompt).toContain("pr-created");
+    expect(prompt).toContain("failed");
+  });
+
+  it("includes attention items", () => {
+    const prompt = buildPrompt(makeSnapshot(), makeLinearTickets());
+    expect(prompt).toContain("Worker failed: test failures");
+  });
+
+  it("includes Linear ticket context", () => {
+    const prompt = buildPrompt(makeSnapshot(), makeLinearTickets());
+    expect(prompt).toContain("Add OAuth2 support");
+    expect(prompt).toContain("Fix login redirect loop");
+  });
+
+  it("handles empty snapshot gracefully", () => {
+    const empty: MonitorSnapshot = {
+      timestamp: "2026-04-14T12:00:00Z",
+      orchestrators: [],
+      sessions: [],
+      sessionStoreAvailable: false,
+    };
+    const prompt = buildPrompt(empty, {});
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+});
+
+describe("parseBriefingResponse", () => {
+  it("extracts briefing and labels from valid Anthropic response", () => {
+    const result = parseBriefingResponse(makeSuccessResponse());
+    expect(result).not.toBeNull();
+    expect(result!.briefing).toContain("CTL-10 has a PR open");
+    expect(result!.suggestedLabels["CTL-10"]).toEqual(["feature", "auth"]);
+    expect(result!.suggestedLabels["CTL-11"]).toEqual(["bugfix", "auth"]);
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseBriefingResponse("not json")).toBeNull();
+  });
+
+  it("returns null for missing content array", () => {
+    expect(parseBriefingResponse(JSON.stringify({}))).toBeNull();
+  });
+
+  it("returns null for empty content array", () => {
+    expect(
+      parseBriefingResponse(JSON.stringify({ content: [] })),
+    ).toBeNull();
+  });
+
+  it("handles OpenAI-format response", () => {
+    const openaiResp = JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              briefing: "All systems nominal.",
+              suggestedLabels: {},
+            }),
+          },
+        },
+      ],
+    });
+    const result = parseBriefingResponse(openaiResp);
+    expect(result).not.toBeNull();
+    expect(result!.briefing).toBe("All systems nominal.");
+  });
+});
+
+describe("createBriefingProvider", () => {
+  let lastRequest: { url: string; body: string; headers: Record<string, string> } | null;
+  let fetchResponse: string;
+  let fetchShouldFail: boolean;
+
+  function makeFetcher(): AiFetcher {
+    return (url, init) => {
+      if (fetchShouldFail) return Promise.reject(new Error("network failure"));
+      lastRequest = {
+        url,
+        body: typeof init.body === "string" ? init.body : "",
+        headers: init.headers,
+      };
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(fetchResponse) });
+    };
+  }
+
+  beforeEach(() => {
+    lastRequest = null;
+    fetchResponse = makeSuccessResponse();
+    fetchShouldFail = false;
+  });
+
+  it("returns null when config is disabled", async () => {
+    const provider = createBriefingProvider(
+      { enabled: false },
+      { fetcher: makeFetcher() },
+    );
+    const result = await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(result).toBeNull();
+    expect(lastRequest).toBeNull();
+  });
+
+  it("calls the correct Anthropic gateway URL", async () => {
+    const config = makeConfig();
+    const provider = createBriefingProvider(config, { fetcher: makeFetcher() });
+    await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest!.url).toBe(
+      "https://gateway.ai.cloudflare.com/v1/acct/gw/anthropic/v1/messages",
+    );
+  });
+
+  it("calls the correct OpenAI gateway URL", async () => {
+    const config = makeConfig({ provider: "openai", model: "gpt-4o-mini" });
+    const provider = createBriefingProvider(config, { fetcher: makeFetcher() });
+    fetchResponse = JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              briefing: "All good.",
+              suggestedLabels: {},
+            }),
+          },
+        },
+      ],
+    });
+    await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest!.url).toBe(
+      "https://gateway.ai.cloudflare.com/v1/acct/gw/openai/v1/chat/completions",
+    );
+  });
+
+  it("sends correct headers for Anthropic", async () => {
+    const provider = createBriefingProvider(makeConfig(), {
+      fetcher: makeFetcher(),
+    });
+    await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(lastRequest!.headers["x-api-key"]).toBe("sk-test");
+    expect(lastRequest!.headers["anthropic-version"]).toBe("2023-06-01");
+  });
+
+  it("returns cached result within TTL", async () => {
+    let callCount = 0;
+    const countingFetcher: AiFetcher = (_url, _init) => {
+      callCount++;
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(fetchResponse) });
+    };
+    const provider = createBriefingProvider(makeConfig(), {
+      fetcher: countingFetcher,
+      cacheTtlMs: 60_000,
+    });
+
+    const r1 = await provider.generate(makeSnapshot(), makeLinearTickets());
+    const r2 = await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(r1).not.toBeNull();
+    expect(r2).not.toBeNull();
+    expect(r1!.briefing).toBe(r2!.briefing);
+    expect(callCount).toBe(1);
+  });
+
+  it("returns null on fetch failure", async () => {
+    fetchShouldFail = true;
+    const provider = createBriefingProvider(makeConfig(), {
+      fetcher: makeFetcher(),
+    });
+    const result = await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(result).toBeNull();
+  });
+
+  it("returns null on non-ok response", async () => {
+    const failFetcher: AiFetcher = () =>
+      Promise.resolve({
+        ok: false,
+        status: 429,
+        text: () => Promise.resolve("rate limited"),
+      });
+    const provider = createBriefingProvider(makeConfig(), {
+      fetcher: failFetcher,
+    });
+    const result = await provider.generate(makeSnapshot(), makeLinearTickets());
+    expect(result).toBeNull();
+  });
+
+  it("stop clears any pending operations", () => {
+    const provider = createBriefingProvider(makeConfig(), {
+      fetcher: makeFetcher(),
+    });
+    expect(() => provider.stop()).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/ai-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ai-config.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { loadAiConfig } from "../lib/ai-config";
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "ai-config-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("loadAiConfig", () => {
+  it("returns disabled config when no files exist", () => {
+    const cfg = loadAiConfig(
+      join(tmpRoot, "missing-project.json"),
+      join(tmpRoot, "missing-secrets.json"),
+    );
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it("returns disabled config when ai.enabled is false", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ catalyst: { ai: { enabled: false } } }),
+    );
+    const cfg = loadAiConfig(projectPath, join(tmpRoot, "missing.json"));
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it("returns disabled config when ai section is missing from project config", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    writeFileSync(projectPath, JSON.stringify({ catalyst: {} }));
+    const cfg = loadAiConfig(projectPath, join(tmpRoot, "missing.json"));
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it("returns disabled config when secrets file is missing but enabled=true", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ catalyst: { ai: { enabled: true } } }),
+    );
+    const cfg = loadAiConfig(projectPath, join(tmpRoot, "missing.json"));
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it("returns full config when both files are valid", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    const secretsPath = join(tmpRoot, "secrets.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ catalyst: { ai: { enabled: true } } }),
+    );
+    writeFileSync(
+      secretsPath,
+      JSON.stringify({
+        ai: {
+          gateway: "https://gateway.ai.cloudflare.com/v1/acct/gw",
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+          apiKey: "sk-test-key",
+        },
+      }),
+    );
+
+    const cfg = loadAiConfig(projectPath, secretsPath);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.gateway).toBe("https://gateway.ai.cloudflare.com/v1/acct/gw");
+    expect(cfg.provider).toBe("anthropic");
+    expect(cfg.model).toBe("claude-haiku-4-5-20251001");
+    expect(cfg.apiKey).toBe("sk-test-key");
+  });
+
+  it("returns disabled if secrets missing required gateway field", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    const secretsPath = join(tmpRoot, "secrets.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ catalyst: { ai: { enabled: true } } }),
+    );
+    writeFileSync(
+      secretsPath,
+      JSON.stringify({
+        ai: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+      }),
+    );
+
+    const cfg = loadAiConfig(projectPath, secretsPath);
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it("returns disabled if secrets missing required apiKey field", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    const secretsPath = join(tmpRoot, "secrets.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ catalyst: { ai: { enabled: true } } }),
+    );
+    writeFileSync(
+      secretsPath,
+      JSON.stringify({
+        ai: {
+          gateway: "https://gateway.ai.cloudflare.com/v1/acct/gw",
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+        },
+      }),
+    );
+
+    const cfg = loadAiConfig(projectPath, secretsPath);
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it("uses default model when model not specified in secrets", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    const secretsPath = join(tmpRoot, "secrets.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ catalyst: { ai: { enabled: true } } }),
+    );
+    writeFileSync(
+      secretsPath,
+      JSON.stringify({
+        ai: {
+          gateway: "https://gateway.ai.cloudflare.com/v1/acct/gw",
+          provider: "anthropic",
+          apiKey: "sk-test-key",
+        },
+      }),
+    );
+
+    const cfg = loadAiConfig(projectPath, secretsPath);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("uses default provider when provider not specified in secrets", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    const secretsPath = join(tmpRoot, "secrets.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ catalyst: { ai: { enabled: true } } }),
+    );
+    writeFileSync(
+      secretsPath,
+      JSON.stringify({
+        ai: {
+          gateway: "https://gateway.ai.cloudflare.com/v1/acct/gw",
+          apiKey: "sk-test-key",
+        },
+      }),
+    );
+
+    const cfg = loadAiConfig(projectPath, secretsPath);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.provider).toBe("anthropic");
+  });
+
+  it("handles malformed JSON gracefully", () => {
+    const projectPath = join(tmpRoot, "project.json");
+    writeFileSync(projectPath, "not json{{{");
+    const cfg = loadAiConfig(projectPath, join(tmpRoot, "missing.json"));
+    expect(cfg.enabled).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -4,6 +4,9 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "fs"
 import { tmpdir } from "os";
 import { join } from "path";
 import { createServer } from "../server";
+import type { BriefingProvider } from "../lib/ai-briefing";
+import type { MonitorSnapshot } from "../lib/state-reader";
+import type { LinearTicket } from "../lib/linear";
 
 let server: ReturnType<typeof createServer>;
 let baseUrl: string;
@@ -545,5 +548,67 @@ describe("SQLite session endpoints (no dbPath)", () => {
     };
     expect(data.available).toBe(false);
     expect(data.sessions).toEqual([]);
+  });
+});
+
+describe("AI briefing endpoint", () => {
+  it("returns enabled:false when no briefing provider is configured", async () => {
+    const res = await fetch(`${baseUrl}/api/briefing`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { enabled: boolean };
+    expect(data.enabled).toBe(false);
+  });
+
+  it("returns briefing data when provider is configured", async () => {
+    let bTmp: string | null = null;
+    let bServer: ReturnType<typeof createServer> | null = null;
+    try {
+      bTmp = mkdtempSync(join(tmpdir(), "orch-monitor-briefing-"));
+      const bWtDir = join(bTmp, "wt");
+      mkdirSync(bWtDir, { recursive: true });
+      const bOrchDir = join(bWtDir, "orch-briefing");
+      mkdirSync(join(bOrchDir, "workers"), { recursive: true });
+      writeFileSync(
+        join(bOrchDir, "state.json"),
+        JSON.stringify({ id: "orch-briefing", waves: [] }),
+      );
+
+      const mockProvider: BriefingProvider = {
+        generate(_snapshot: MonitorSnapshot, _linear: Record<string, LinearTicket>) {
+          return Promise.resolve({
+            briefing: "All 1 orchestrator is idle.",
+            suggestedLabels: {},
+            generatedAt: "2026-04-14T12:00:00Z",
+          });
+        },
+        stop() {},
+      };
+
+      bServer = createServer({
+        port: 0,
+        wtDir: bWtDir,
+        startWatcher: false,
+        prStatusFetcher: null,
+        linearFetcher: null,
+        briefingProvider: mockProvider,
+      });
+
+      const bUrl = `http://localhost:${bServer.port}`;
+      const res = await fetch(`${bUrl}/api/briefing`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        enabled: boolean;
+        briefing: string;
+        suggestedLabels: Record<string, string[]>;
+      };
+      expect(data.enabled).toBe(true);
+      expect(data.briefing).toContain("idle");
+      expect(data.suggestedLabels).toBeDefined();
+    } finally {
+      if (bServer) void bServer.stop(true);
+      if (bTmp) {
+        try { rmSync(bTmp, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+    }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/ai-briefing.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/ai-briefing.ts
@@ -1,0 +1,284 @@
+import type { AiConfig } from "./ai-config";
+import type { MonitorSnapshot, WorkerState } from "./state-reader";
+import type { LinearTicket } from "./linear";
+
+export interface BriefingResult {
+  briefing: string;
+  suggestedLabels: Record<string, string[]>;
+  generatedAt: string;
+}
+
+export type AiFetcher = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
+export interface BriefingProvider {
+  generate(
+    snapshot: MonitorSnapshot,
+    linearTickets: Record<string, LinearTicket>,
+  ): Promise<BriefingResult | null>;
+  stop(): void;
+}
+
+interface CacheEntry {
+  result: BriefingResult;
+  fetchedAt: number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 5 * 60_000;
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function statusSummary(w: WorkerState): string {
+  let line = `${w.ticket}: status=${w.status}, phase=${w.phase}`;
+  if (w.pr) line += `, PR=#${w.pr.number}`;
+  if (w.cost?.costUSD) line += `, cost=$${w.cost.costUSD.toFixed(2)}`;
+  if (w.timeSinceUpdate > 0) line += `, idle=${Math.round(w.timeSinceUpdate)}s`;
+  if (!w.alive && w.pid) line += ` [process dead]`;
+  return line;
+}
+
+export function buildPrompt(
+  snapshot: MonitorSnapshot,
+  linearTickets: Record<string, LinearTicket>,
+): string {
+  const sections: string[] = [];
+
+  sections.push(
+    "You are a concise status reporter for an AI-assisted development orchestration system.",
+  );
+  sections.push(
+    "Produce a natural-language briefing (2-4 sentences) highlighting what needs attention and what is progressing fine.",
+  );
+  sections.push(
+    'Also classify each ticket into categories: "bugfix", "feature", "refactor", "infrastructure", "docs".',
+  );
+  sections.push(
+    "Respond with ONLY valid JSON in this exact format (no markdown, no explanation):",
+  );
+  sections.push(
+    '{"briefing":"...","suggestedLabels":{"TICKET-1":["category1"],"TICKET-2":["category2"]}}',
+  );
+
+  sections.push("\n## Current State");
+  sections.push(`Timestamp: ${snapshot.timestamp}`);
+  sections.push(`Orchestrators: ${snapshot.orchestrators.length}`);
+
+  for (const orch of snapshot.orchestrators) {
+    sections.push(
+      `\n### Orchestrator: ${orch.id} (wave ${orch.currentWave}/${orch.totalWaves})`,
+    );
+
+    const workers = Object.values(orch.workers);
+    if (workers.length === 0) {
+      sections.push("No workers.");
+      continue;
+    }
+
+    sections.push("Workers:");
+    for (const w of workers) {
+      sections.push(`- ${statusSummary(w)}`);
+    }
+
+    if (orch.attention.length > 0) {
+      sections.push("\nAttention items:");
+      for (const item of orch.attention) {
+        if (isRecord(item)) {
+          const iType = typeof item.type === "string" ? item.type : "unknown";
+          const iTicket = typeof item.ticket === "string" ? item.ticket : "";
+          const iMsg = typeof item.message === "string" ? item.message : "";
+          sections.push(`- [${iType}] ${iTicket} — ${iMsg}`);
+        }
+      }
+    }
+  }
+
+  const ticketKeys = Object.keys(linearTickets);
+  if (ticketKeys.length > 0) {
+    sections.push("\n## Linear Ticket Context");
+    for (const key of ticketKeys) {
+      const t = linearTickets[key];
+      if (!t) continue;
+      let line = `- ${t.key}: "${t.title}" (state: ${t.state}`;
+      if (t.project) line += `, project: ${t.project}`;
+      if (t.labels.length > 0) line += `, labels: [${t.labels.join(", ")}]`;
+      line += ")";
+      sections.push(line);
+    }
+  }
+
+  return sections.join("\n");
+}
+
+function extractTextFromAnthropicResponse(parsed: unknown): string | null {
+  if (!isRecord(parsed)) return null;
+  const content = parsed.content;
+  if (!Array.isArray(content) || content.length === 0) return null;
+  const first: unknown = content[0];
+  if (!isRecord(first)) return null;
+  return typeof first.text === "string" ? first.text : null;
+}
+
+function extractTextFromOpenAIResponse(parsed: unknown): string | null {
+  if (!isRecord(parsed)) return null;
+  const choices = parsed.choices;
+  if (!Array.isArray(choices) || choices.length === 0) return null;
+  const first: unknown = choices[0];
+  if (!isRecord(first)) return null;
+  const message = first.message;
+  if (!isRecord(message)) return null;
+  return typeof message.content === "string" ? message.content : null;
+}
+
+export function parseBriefingResponse(raw: string): BriefingResult | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+
+  const text =
+    extractTextFromAnthropicResponse(parsed) ??
+    extractTextFromOpenAIResponse(parsed);
+  if (!text) return null;
+
+  let briefingData: unknown;
+  try {
+    briefingData = JSON.parse(text) as unknown;
+  } catch {
+    return {
+      briefing: text,
+      suggestedLabels: {},
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  if (!isRecord(briefingData)) return null;
+
+  const briefing =
+    typeof briefingData.briefing === "string" ? briefingData.briefing : "";
+  if (!briefing) return null;
+
+  const labels: Record<string, string[]> = {};
+  if (isRecord(briefingData.suggestedLabels)) {
+    for (const [k, v] of Object.entries(briefingData.suggestedLabels)) {
+      if (Array.isArray(v)) {
+        labels[k] = v.filter((x): x is string => typeof x === "string");
+      }
+    }
+  }
+
+  return {
+    briefing,
+    suggestedLabels: labels,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function buildGatewayUrl(config: AiConfig): string {
+  const base = (config.gateway ?? "").replace(/\/+$/, "");
+  const provider = config.provider ?? "anthropic";
+
+  if (provider === "openai") return `${base}/openai/v1/chat/completions`;
+  return `${base}/anthropic/v1/messages`;
+}
+
+function buildRequestBody(config: AiConfig, prompt: string): string {
+  const provider = config.provider ?? "anthropic";
+  const model = config.model ?? "claude-haiku-4-5-20251001";
+
+  if (provider === "openai") {
+    return JSON.stringify({
+      model,
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: 1024,
+    });
+  }
+
+  return JSON.stringify({
+    model,
+    max_tokens: 1024,
+    messages: [{ role: "user", content: prompt }],
+  });
+}
+
+function buildHeaders(config: AiConfig): Record<string, string> {
+  const provider = config.provider ?? "anthropic";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (provider === "openai") {
+    headers["Authorization"] = `Bearer ${config.apiKey ?? ""}`;
+  } else {
+    headers["x-api-key"] = config.apiKey ?? "";
+    headers["anthropic-version"] = "2023-06-01";
+  }
+
+  return headers;
+}
+
+const defaultFetcher: AiFetcher = async (url, init) => {
+  const resp = await fetch(url, init);
+  return {
+    ok: resp.ok,
+    status: resp.status,
+    text: () => resp.text(),
+  };
+};
+
+export function createBriefingProvider(
+  config: AiConfig,
+  opts: { fetcher?: AiFetcher; cacheTtlMs?: number } = {},
+): BriefingProvider {
+  const fetcher = opts.fetcher ?? defaultFetcher;
+  const cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  let cache: CacheEntry | null = null;
+
+  return {
+    async generate(snapshot, linearTickets) {
+      if (!config.enabled) return null;
+
+      if (cache && Date.now() - cache.fetchedAt < cacheTtlMs) {
+        return cache.result;
+      }
+
+      const prompt = buildPrompt(snapshot, linearTickets);
+      const url = buildGatewayUrl(config);
+      const headers = buildHeaders(config);
+      const body = buildRequestBody(config, prompt);
+
+      let raw: string;
+      try {
+        const resp = await fetcher(url, { method: "POST", headers, body });
+        if (!resp.ok) {
+          console.warn(
+            `[ai-briefing] API returned ${String(resp.status)}`,
+          );
+          return null;
+        }
+        raw = await resp.text();
+      } catch (err) {
+        console.warn(
+          `[ai-briefing] fetch failed:`,
+          err instanceof Error ? err.message : "unknown error",
+        );
+        return null;
+      }
+
+      const result = parseBriefingResponse(raw);
+      if (result) {
+        cache = { result, fetchedAt: Date.now() };
+      }
+      return result;
+    },
+
+    stop() {
+      cache = null;
+    },
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/ai-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/ai-config.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "fs";
+
+export interface AiConfig {
+  enabled: boolean;
+  gateway?: string;
+  provider?: string;
+  model?: string;
+  apiKey?: string;
+}
+
+const DISABLED: AiConfig = { enabled: false };
+const DEFAULT_PROVIDER = "anthropic";
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function readJsonSafe(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export function loadAiConfig(
+  projectConfigPath: string,
+  secretsConfigPath: string,
+): AiConfig {
+  const project = readJsonSafe(projectConfigPath);
+  if (!isRecord(project)) return DISABLED;
+
+  const catalyst = isRecord(project.catalyst) ? project.catalyst : null;
+  if (!catalyst) return DISABLED;
+
+  const aiProject = isRecord(catalyst.ai) ? catalyst.ai : null;
+  if (!aiProject || aiProject.enabled !== true) return DISABLED;
+
+  const secrets = readJsonSafe(secretsConfigPath);
+  if (!isRecord(secrets)) return DISABLED;
+
+  const aiSecrets = isRecord(secrets.ai) ? secrets.ai : null;
+  if (!aiSecrets) return DISABLED;
+
+  const gateway =
+    typeof aiSecrets.gateway === "string" ? aiSecrets.gateway : "";
+  const apiKey = typeof aiSecrets.apiKey === "string" ? aiSecrets.apiKey : "";
+
+  if (!gateway || !apiKey) return DISABLED;
+
+  const provider =
+    typeof aiSecrets.provider === "string" && aiSecrets.provider
+      ? aiSecrets.provider
+      : DEFAULT_PROVIDER;
+  const model =
+    typeof aiSecrets.model === "string" && aiSecrets.model
+      ? aiSecrets.model
+      : DEFAULT_MODEL;
+
+  return { enabled: true, gateway, provider, model, apiKey };
+}

--- a/plugins/dev/scripts/orch-monitor/public/index.html
+++ b/plugins/dev/scripts/orch-monitor/public/index.html
@@ -1071,6 +1071,21 @@
     <main>
       <div id="dashboard-view">
         <div id="attention" class="attention-panel"></div>
+        <div id="ai-briefing" class="card" style="display:none">
+          <div class="card-head">
+            <h2>AI Briefing</h2>
+            <div style="display:flex;gap:8px;align-items:center;margin-left:auto">
+              <label style="font-size:12px;color:var(--muted);display:flex;align-items:center;gap:4px;cursor:pointer">
+                <input type="checkbox" id="briefing-auto" style="accent-color:var(--accent)"> Auto
+              </label>
+              <button id="briefing-btn" style="background:var(--accent);color:#fff;border:none;border-radius:4px;padding:4px 12px;font-size:12px;cursor:pointer">Generate</button>
+            </div>
+          </div>
+          <div id="briefing-content" style="padding:12px 14px;font-size:13px;line-height:1.5;color:var(--muted)">
+            Click "Generate" to get an AI-powered status summary.
+          </div>
+          <div id="briefing-labels" style="padding:0 14px 12px;display:flex;flex-wrap:wrap;gap:6px"></div>
+        </div>
         <div id="orchestrators"></div>
         <div class="card">
           <div class="card-head"><h2>Events</h2></div>
@@ -2624,6 +2639,107 @@
           renderBriefing(orchId, waveNum);
         });
 
+        // --- AI Briefing ---
+        const $briefingPanel = document.getElementById("ai-briefing");
+        const $briefingContent = document.getElementById("briefing-content");
+        const $briefingLabels = document.getElementById("briefing-labels");
+        const $briefingBtn = document.getElementById("briefing-btn");
+        const $briefingAuto = document.getElementById("briefing-auto");
+        let briefingAutoTimer = null;
+        const BRIEFING_AUTO_INTERVAL = 5 * 60 * 1000;
+
+        async function checkBriefingEnabled() {
+          try {
+            const resp = await fetch("/api/briefing");
+            if (!resp.ok) return;
+            const data = await resp.json();
+            if (data.enabled === false && !data.briefing) {
+              $briefingPanel.style.display = "none";
+            } else {
+              $briefingPanel.style.display = "";
+              if (data.briefing) renderBriefingAi(data);
+            }
+          } catch (err) {
+            console.error("briefing check failed", err);
+          }
+        }
+
+        async function fetchBriefing() {
+          $briefingBtn.disabled = true;
+          $briefingBtn.textContent = "Generating...";
+          $briefingContent.textContent = "Generating briefing...";
+          $briefingLabels.innerHTML = "";
+          try {
+            const resp = await fetch("/api/briefing");
+            if (!resp.ok) {
+              $briefingContent.textContent = "Failed to generate briefing.";
+              return;
+            }
+            const data = await resp.json();
+            if (data.enabled === false) {
+              $briefingPanel.style.display = "none";
+              return;
+            }
+            if (!data.briefing) {
+              $briefingContent.textContent = "AI returned no briefing. Check configuration.";
+              return;
+            }
+            renderBriefingAi(data);
+          } catch (err) {
+            console.error("briefing fetch failed", err);
+            $briefingContent.textContent = "Error generating briefing.";
+          } finally {
+            $briefingBtn.disabled = false;
+            $briefingBtn.textContent = "Generate";
+          }
+        }
+
+        function renderBriefingAi(data) {
+          var html;
+          if (window.marked && window.DOMPurify) {
+            html = window.DOMPurify.sanitize(window.marked.parse(data.briefing));
+          } else {
+            html = esc(data.briefing);
+          }
+          $briefingContent.innerHTML = html;
+          $briefingContent.querySelectorAll("a").forEach(function(a) {
+            a.setAttribute("target", "_blank");
+            a.setAttribute("rel", "noopener noreferrer");
+          });
+          $briefingContent.style.color = "var(--fg)";
+
+          $briefingLabels.innerHTML = "";
+          var labels = data.suggestedLabels || {};
+          var keys = Object.keys(labels);
+          if (keys.length > 0) {
+            for (var i = 0; i < keys.length; i++) {
+              var ticket = keys[i];
+              var tags = labels[ticket];
+              if (!tags || !tags.length) continue;
+              var chip = document.createElement("span");
+              chip.style.cssText = "display:inline-flex;align-items:center;gap:4px;background:var(--panel-2);border:1px solid var(--border);border-radius:12px;padding:2px 8px;font-size:11px;color:var(--muted)";
+              chip.innerHTML = '<strong style="color:var(--fg)">' + esc(ticket) + "</strong> " + tags.map(function(t) { return esc(t); }).join(", ");
+              $briefingLabels.appendChild(chip);
+            }
+          }
+
+          if (data.generatedAt) {
+            var ts = document.createElement("span");
+            ts.style.cssText = "font-size:10px;color:var(--gray);margin-left:auto";
+            ts.textContent = "Generated " + new Date(data.generatedAt).toLocaleTimeString();
+            $briefingLabels.appendChild(ts);
+          }
+        }
+
+        $briefingBtn.addEventListener("click", fetchBriefing);
+        $briefingAuto.addEventListener("change", function () {
+          if (briefingAutoTimer) { clearInterval(briefingAutoTimer); briefingAutoTimer = null; }
+          if ($briefingAuto.checked) {
+            fetchBriefing();
+            briefingAutoTimer = setInterval(fetchBriefing, BRIEFING_AUTO_INTERVAL);
+          }
+        });
+
         setConnected("pending");
         connect();
         setInterval(updateTimers, 1000);
@@ -2632,6 +2748,7 @@
         refreshLinear();
         setInterval(refreshLinear, 60000);
         handleRoute();
+        checkBriefingEnabled();
       })();
     </script>
   </body>

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -31,6 +31,7 @@ import {
   type LinearFetcher,
   type LinearTicket,
 } from "./lib/linear";
+import type { BriefingProvider } from "./lib/ai-briefing";
 
 type BunServer = ReturnType<typeof Bun.serve>;
 
@@ -49,6 +50,7 @@ export interface CreateServerOptions {
   dbPath?: string | null;
   /** SQLite poll interval for the watcher (ms). */
   sqlitePollIntervalMs?: number;
+  briefingProvider?: BriefingProvider | null;
 }
 
 export const DEFAULT_PORT = 7400;
@@ -182,6 +184,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     linearRefreshMs = LINEAR_REFRESH_MS,
     dbPath = null,
     sqlitePollIntervalMs,
+    briefingProvider: briefingProviderOpt,
   } = opts;
 
   const buildOpts: BuildSnapshotOptions = { dbPath };
@@ -197,6 +200,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
       ? null
       : (linearFetcher ?? createLinearFetcher());
   let linearStarted = false;
+
+  const briefingProvider: BriefingProvider | null =
+    briefingProviderOpt === null ? null : (briefingProviderOpt ?? null);
 
   function snapshotWithPrStatus(): MonitorSnapshot {
     const snap = buildSnapshot(wtDir, buildOpts);
@@ -421,6 +427,30 @@ export function createServer(opts: CreateServerOptions): BunServer {
           return Response.json({ tickets });
         }
 
+        if (url.pathname === "/api/briefing") {
+          if (!briefingProvider) {
+            return Response.json({ enabled: false });
+          }
+          const snap = snapshotWithPrStatus();
+          const tickets: Record<string, LinearTicket> = {};
+          if (linear) {
+            for (const key of collectTicketKeys(snap)) {
+              const t = linear.get(key);
+              if (t) tickets[key] = t;
+            }
+          }
+          const result = await briefingProvider.generate(snap, tickets);
+          if (!result) {
+            return Response.json({ enabled: true, briefing: null });
+          }
+          return Response.json({
+            enabled: true,
+            briefing: result.briefing,
+            suggestedLabels: result.suggestedLabels,
+            generatedAt: result.generatedAt,
+          });
+        }
+
         if (
           url.pathname === "/" ||
           url.pathname === "/index.html" ||
@@ -478,6 +508,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     watcher?.stop();
     prFetcher?.stop();
     linear?.stop();
+    briefingProvider?.stop();
     sseClients.clear();
     if (pidFile) {
       try {

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -246,6 +246,47 @@ Never committed. One file per project, linked by `projectKey`.
 
 Only configure the integrations you use. The setup script prompts for each one.
 
+### AI Briefing
+
+The monitor dashboard supports AI-powered status summaries. Configuration spans both layers:
+
+**Project config** (`.catalyst/config.json`) — opt-in toggle:
+
+```json
+{
+  "catalyst": {
+    "ai": {
+      "enabled": true
+    }
+  }
+}
+```
+
+**Secrets config** (`~/.config/catalyst/config-{projectKey}.json`) — provider credentials:
+
+```json
+{
+  "ai": {
+    "gateway": "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}",
+    "provider": "anthropic",
+    "model": "claude-haiku-4-5-20251001",
+    "apiKey": "sk-ant-..."
+  }
+}
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `ai.enabled` | Yes (project config) | `false` | Master toggle. No API calls when off. |
+| `ai.gateway` | Yes (secrets) | — | Cloudflare AI Gateway URL |
+| `ai.provider` | No | `anthropic` | AI provider: `anthropic` or `openai` |
+| `ai.model` | No | `claude-haiku-4-5-20251001` | Model ID |
+| `ai.apiKey` | Yes (secrets) | — | Provider API key |
+
+The AI briefing generates a natural-language status summary and suggests session labels based on
+Linear ticket context. It is on-demand (button click) or optionally auto-refreshing. Zero cost
+when disabled.
+
 ## Worktree Setup
 
 Define the commands that run when creating a new worktree via `/create-worktree` or `/orchestrate`. This replaces the default auto-detected setup (dependency install + thoughts init) with full project control — like `conductor.json`'s lifecycle hooks.


### PR DESCRIPTION
## Summary

- Adds opt-in AI briefing system to the orch-monitor dashboard that generates natural-language status summaries and suggested session labels via Cloudflare AI Gateway
- New `lib/ai-config.ts` (two-layer config loading) and `lib/ai-briefing.ts` (provider with injectable fetcher, caching, Anthropic/OpenAI multi-provider support)
- New `GET /api/briefing` endpoint, dashboard AI Briefing panel with generate button + auto-refresh toggle
- XSS-safe rendering with DOMPurify fallback to text escaping, `noopener noreferrer` on rendered links
- 29 new tests (27 unit + 2 integration), all 128 tests passing, typecheck + lint clean

## Test plan

- [x] All 128 tests pass (`bun test`)
- [x] TypeScript type check passes (`bun run typecheck`)
- [x] ESLint passes (`bun run lint`)
- [x] Security review: XSS protection verified (DOMPurify fallback, link safety)
- [x] Code review: all findings addressed
- [ ] CI checks pass on PR

Closes CTL-52