### PR TITLE
feat(dev): add catalyst-monitor CLI for zero-config monitoring

### DIFF
--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# catalyst-monitor.sh — On-demand monitor server management.
+#
+# Commands:
+#   start [--port N]     Start monitor server in background (idempotent)
+#   stop                 Stop monitor server
+#   status [--json]      Check if monitor is running
+#   open                 Start monitor if needed, open browser to dashboard
+#   url                  Print the monitor URL
+
+set -uo pipefail
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+DEFAULT_PORT=7400
+PORT="${MONITOR_PORT:-$DEFAULT_PORT}"
+if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
+  echo "error: MONITOR_PORT must be a numeric port, got: $PORT" >&2
+  exit 1
+fi
+PID_FILE="${MONITOR_PID_FILE:-$CATALYST_DIR/monitor.pid}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_SCRIPT="${MONITOR_SERVER_SCRIPT:-$SCRIPT_DIR/orch-monitor/server.ts}"
+
+is_alive() {
+  local pid="$1"
+  kill -0 "$pid" 2>/dev/null
+}
+
+read_pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    local pid
+    pid="$(cat "$PID_FILE" 2>/dev/null)"
+    if [[ "$pid" =~ ^[0-9]+$ ]] && is_alive "$pid"; then
+      echo "$pid"
+      return 0
+    fi
+    rm -f "$PID_FILE" 2>/dev/null
+  fi
+  return 1
+}
+
+cmd_start() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --port) PORT="$2"; shift 2 ;;
+      *) echo "error: unknown flag for start: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local existing_pid
+  if existing_pid=$(read_pid); then
+    echo "Monitor already running (pid $existing_pid)"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$PID_FILE")" 2>/dev/null || true
+  mkdir -p "$CATALYST_DIR/wt" 2>/dev/null || true
+
+  MONITOR_PORT="$PORT" nohup bun run "$SERVER_SCRIPT" --pid-file "$PID_FILE" \
+    > "$CATALYST_DIR/monitor.log" 2>&1 &
+  local server_pid=$!
+  disown "$server_pid" 2>/dev/null || true
+
+  local waited=0
+  while [[ $waited -lt 20 ]]; do
+    if [[ -f "$PID_FILE" ]]; then
+      echo "Monitor started (pid $(cat "$PID_FILE")) at http://localhost:$PORT"
+      return 0
+    fi
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+
+  if is_alive "$server_pid"; then
+    echo "$server_pid" > "$PID_FILE"
+    echo "Monitor started (pid $server_pid) at http://localhost:$PORT"
+    return 0
+  fi
+
+  echo "error: failed to start monitor server" >&2
+  return 1
+}
+
+cmd_stop() {
+  local pid
+  if ! pid=$(read_pid); then
+    echo "Monitor not running"
+    return 0
+  fi
+
+  kill "$pid" 2>/dev/null || true
+
+  local waited=0
+  while [[ $waited -lt 30 ]] && is_alive "$pid"; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+
+  if is_alive "$pid"; then
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+
+  rm -f "$PID_FILE" 2>/dev/null || true
+  echo "Monitor stopped"
+}
+
+cmd_status() {
+  local json=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) json=1; shift ;;
+      *) echo "error: unknown flag for status: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local pid
+  if pid=$(read_pid); then
+    if [[ $json -eq 1 ]]; then
+      printf '{"running":true,"pid":%d,"port":%d,"url":"http://localhost:%d"}\n' \
+        "$pid" "$PORT" "$PORT"
+    else
+      echo "Monitor running (pid $pid) at http://localhost:$PORT"
+    fi
+    return 0
+  else
+    if [[ $json -eq 1 ]]; then
+      printf '{"running":false,"pid":null,"port":%d,"url":"http://localhost:%d"}\n' \
+        "$PORT" "$PORT"
+    else
+      echo "Monitor stopped"
+    fi
+    return 1
+  fi
+}
+
+cmd_open() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --port) PORT="$2"; shift 2 ;;
+      *) echo "error: unknown flag for open: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local pid
+  if ! pid=$(read_pid); then
+    cmd_start --port "$PORT"
+  fi
+
+  local url="http://localhost:$PORT"
+  if command -v open &>/dev/null; then
+    open "$url"
+  elif command -v xdg-open &>/dev/null; then
+    xdg-open "$url"
+  else
+    echo "Open $url in your browser"
+  fi
+}
+
+cmd_url() {
+  echo "http://localhost:$PORT"
+}
+
+usage() {
+  echo "Usage: catalyst-monitor.sh <command> [options]"
+  echo ""
+  echo "Commands:"
+  echo "  start [--port N]   Start monitor server in background"
+  echo "  stop               Stop monitor server"
+  echo "  status [--json]    Check if monitor is running"
+  echo "  open               Start if needed, open browser to dashboard"
+  echo "  url                Print the monitor URL"
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+  start)     cmd_start "$@" ;;
+  stop)      cmd_stop ;;
+  status)    cmd_status "$@" ;;
+  open)      cmd_open "$@" ;;
+  url)       cmd_url ;;
+  help|--help|-h) usage ;;
+  *) echo "error: unknown command: $cmd" >&2; exit 1 ;;
+esac

--- a/plugins/dev/scripts/orch-monitor/__tests__/catalyst-monitor.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/catalyst-monitor.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+const SCRIPT = resolve(
+  import.meta.dir,
+  "..",
+  "..",
+  "catalyst-monitor.sh",
+);
+const SERVER_SCRIPT = resolve(import.meta.dir, "..", "server.ts");
+
+let tmpDir: string;
+let wtDir: string;
+let pidFile: string;
+
+function run(
+  args: string[],
+  env?: Record<string, string>,
+): { stdout: string; stderr: string; exitCode: number } {
+  const result = Bun.spawnSync(["bash", SCRIPT, ...args], {
+    env: {
+      ...process.env,
+      CATALYST_DIR: tmpDir,
+      MONITOR_PID_FILE: pidFile,
+      MONITOR_SERVER_SCRIPT: SERVER_SCRIPT,
+      ...env,
+    },
+    cwd: tmpDir,
+  });
+  return {
+    stdout: result.stdout.toString().trim(),
+    stderr: result.stderr.toString().trim(),
+    exitCode: result.exitCode,
+  };
+}
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "catalyst-monitor-test-"));
+  wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  pidFile = join(tmpDir, "monitor.pid");
+
+  const orchDir = join(wtDir, "orch-test");
+  mkdirSync(join(orchDir, "workers"), { recursive: true });
+  writeFileSync(
+    join(orchDir, "state.json"),
+    JSON.stringify({ id: "orch-test", waves: [] }),
+  );
+});
+
+afterAll(() => {
+  // Clean up any lingering server processes
+  if (existsSync(pidFile)) {
+    try {
+      const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+      process.kill(pid, "SIGTERM");
+    } catch {
+      /* already dead */
+    }
+  }
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+afterEach(() => {
+  // Stop server between tests
+  if (existsSync(pidFile)) {
+    try {
+      const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+      process.kill(pid, "SIGTERM");
+    } catch {
+      /* already dead */
+    }
+    // Wait briefly for process to exit
+    Bun.sleepSync(200);
+    try {
+      rmSync(pidFile, { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("catalyst-monitor.sh", () => {
+  it("script exists and is executable", () => {
+    expect(existsSync(SCRIPT)).toBe(true);
+    const result = Bun.spawnSync(["test", "-x", SCRIPT]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("help command prints usage", () => {
+    const { stdout, exitCode } = run(["help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("start");
+    expect(stdout).toContain("stop");
+    expect(stdout).toContain("status");
+    expect(stdout).toContain("open");
+    expect(stdout).toContain("url");
+  });
+
+  it("url command prints monitor URL", () => {
+    const { stdout, exitCode } = run(["url"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/^http:\/\/localhost:\d+$/);
+  });
+
+  it("url respects MONITOR_PORT env var", () => {
+    const { stdout, exitCode } = run(["url"], { MONITOR_PORT: "9999" });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("http://localhost:9999");
+  });
+
+  it("status reports stopped when no PID file", () => {
+    const { stdout, exitCode } = run(["status"]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("stopped");
+  });
+
+  it("status --json reports stopped when no PID file", () => {
+    const { stdout, exitCode } = run(["status", "--json"]);
+    expect(exitCode).toBe(1);
+    const data = JSON.parse(stdout);
+    expect(data.running).toBe(false);
+    expect(data.pid).toBeNull();
+  });
+
+  it("start launches server and creates PID file", () => {
+    const { exitCode } = run(["start"]);
+    expect(exitCode).toBe(0);
+
+    // Give server a moment to start
+    Bun.sleepSync(500);
+    expect(existsSync(pidFile)).toBe(true);
+
+    const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    expect(pid).toBeGreaterThan(0);
+
+    // Verify the process is actually running
+    expect(() => process.kill(pid, 0)).not.toThrow();
+  });
+
+  it("start is idempotent when server already running", () => {
+    // Start first
+    run(["start"]);
+    Bun.sleepSync(500);
+    const pid1 = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+
+    // Start again — should detect existing and not start a new one
+    const { stdout, exitCode } = run(["start"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("already running");
+
+    // PID should be unchanged
+    const pid2 = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    expect(pid2).toBe(pid1);
+  });
+
+  it("stop kills the process and removes PID file", () => {
+    run(["start"]);
+    Bun.sleepSync(500);
+    const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+
+    const { exitCode } = run(["stop"]);
+    expect(exitCode).toBe(0);
+
+    Bun.sleepSync(300);
+
+    // Process should be dead
+    expect(() => process.kill(pid, 0)).toThrow();
+  });
+
+  it("stop when not running is a no-op", () => {
+    const { exitCode, stdout } = run(["stop"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("not running");
+  });
+
+  it("status reports running after start", () => {
+    run(["start"]);
+    Bun.sleepSync(500);
+
+    const { stdout, exitCode } = run(["status"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("running");
+  });
+
+  it("status --json reports running with PID and port", () => {
+    run(["start"]);
+    Bun.sleepSync(500);
+
+    const { stdout, exitCode } = run(["status", "--json"]);
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.running).toBe(true);
+    expect(data.pid).toBeGreaterThan(0);
+    expect(data.port).toBe(7400);
+    expect(data.url).toBe("http://localhost:7400");
+  });
+
+  it("handles stale PID file (dead process)", () => {
+    // Write a PID file pointing to a non-existent process
+    writeFileSync(pidFile, "999999\n");
+
+    const { exitCode } = run(["start"]);
+    expect(exitCode).toBe(0);
+
+    Bun.sleepSync(500);
+    const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    expect(pid).not.toBe(999999);
+    expect(pid).toBeGreaterThan(0);
+  });
+
+  it("unknown command prints error", () => {
+    const { exitCode, stderr } = run(["bogus"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("unknown command");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/pid-file.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/pid-file.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+let tmpDir: string;
+let wtDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "orch-monitor-pid-test-"));
+  wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  const orchDir = join(wtDir, "orch-pid");
+  mkdirSync(join(orchDir, "workers"), { recursive: true });
+  writeFileSync(
+    join(orchDir, "state.json"),
+    JSON.stringify({ id: "orch-pid", waves: [] }),
+  );
+});
+
+afterAll(() => {
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("PID file support", () => {
+  let server: ReturnType<typeof createServer> | null = null;
+
+  afterEach(() => {
+    if (server) {
+      void server.stop(true);
+      server = null;
+    }
+  });
+
+  it("writes PID file when pidFile option is provided", () => {
+    const pidPath = join(tmpDir, "test.pid");
+    server = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      pidFile: pidPath,
+    });
+
+    expect(existsSync(pidPath)).toBe(true);
+    const content = readFileSync(pidPath, "utf-8").trim();
+    expect(parseInt(content, 10)).toBe(process.pid);
+  });
+
+  it("does not write PID file when pidFile option is omitted", () => {
+    const pidPath = join(tmpDir, "should-not-exist.pid");
+    server = createServer({ port: 0, wtDir, startWatcher: false });
+
+    expect(existsSync(pidPath)).toBe(false);
+  });
+
+  it("deletes PID file on server stop", () => {
+    const pidPath = join(tmpDir, "stop-test.pid");
+    server = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      pidFile: pidPath,
+    });
+
+    expect(existsSync(pidPath)).toBe(true);
+    void server.stop(true);
+    server = null;
+    expect(existsSync(pidPath)).toBe(false);
+  });
+
+  it("PID file contains only the numeric PID", () => {
+    const pidPath = join(tmpDir, "format-test.pid");
+    server = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      pidFile: pidPath,
+    });
+
+    const content = readFileSync(pidPath, "utf-8");
+    expect(content).toMatch(/^\d+\n$/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1,5 +1,5 @@
 import { join, resolve as resolvePath, sep } from "path";
-import { realpathSync } from "fs";
+import { realpathSync, writeFileSync, unlinkSync } from "fs";
 import { subscribe } from "./lib/event-bus";
 import {
   buildSnapshot,
@@ -38,6 +38,7 @@ export interface CreateServerOptions {
   wtDir: string;
   startWatcher?: boolean;
   publicDir?: string;
+  pidFile?: string;
   prStatusFetcher?: PrStatusFetcher | null;
   prStatusRefreshMs?: number;
   linearFetcher?: LinearFetcher | null;
@@ -172,6 +173,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     wtDir,
     startWatcher = true,
     publicDir = join(import.meta.dir, "public"),
+    pidFile,
     prStatusFetcher,
     prStatusRefreshMs = PR_STATUS_REFRESH_MS,
     linearFetcher,
@@ -355,6 +357,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
     watcher = startWatching(wtDir, { dbPath, sqlitePollIntervalMs });
   }
 
+  if (pidFile) {
+    try {
+      writeFileSync(pidFile, `${process.pid}\n`);
+    } catch (err) {
+      console.error(`[server] failed to write PID file ${pidFile}:`, err);
+    }
+  }
+
   const originalStop = server.stop.bind(server);
   server.stop = ((closeActiveConnections?: boolean) => {
     for (const u of unsubscribers) u();
@@ -362,6 +372,19 @@ export function createServer(opts: CreateServerOptions): BunServer {
     prFetcher?.stop();
     linear?.stop();
     sseClients.clear();
+    if (pidFile) {
+      try {
+        unlinkSync(pidFile);
+      } catch (err: unknown) {
+        if (
+          !(err instanceof Error) ||
+          !("code" in err) ||
+          (err as NodeJS.ErrnoException).code !== "ENOENT"
+        ) {
+          console.warn(`[server] failed to remove PID file:`, err);
+        }
+      }
+    }
     return originalStop(closeActiveConnections);
   }) as typeof server.stop;
 
@@ -377,7 +400,17 @@ if (import.meta.main) {
   const DB_PATH =
     process.env.CATALYST_DB_FILE ?? `${CATALYST_DIR}/catalyst.db`;
 
-  const srv = createServer({ port: PORT, wtDir: WT_DIR, dbPath: DB_PATH });
+  const pidFileIdx = process.argv.indexOf("--pid-file");
+  let pidFilePath: string | undefined;
+  if (pidFileIdx >= 0) {
+    pidFilePath = process.argv[pidFileIdx + 1];
+    if (!pidFilePath || pidFilePath.startsWith("--")) {
+      console.error("[server] --pid-file requires a path argument");
+      process.exit(1);
+    }
+  }
+
+  const srv = createServer({ port: PORT, wtDir: WT_DIR, dbPath: DB_PATH, pidFile: pidFilePath });
   const displayHost =
     srv.hostname === "0.0.0.0" ? "localhost" : String(srv.hostname);
   console.info(`Monitor running at http://${displayHost}:${srv.port}`);


### PR DESCRIPTION
## Summary

- Add `catalyst-monitor.sh` CLI with `start`, `stop`, `status`, `open`, and `url` commands for on-demand monitor server management
- Extend `server.ts` with `pidFile` option for PID file lifecycle (write on startup, delete on shutdown)
- Add `--pid-file PATH` CLI flag to server entry point with validation

## Details

Closes CTL-45. Today, the orch-monitor must be started manually. This PR adds zero-config monitor management:

- **`catalyst-monitor.sh start`** — launches the Bun monitor server in the background with PID file at `~/.catalyst/monitor.pid`
- **`catalyst-monitor.sh stop`** — graceful shutdown (SIGTERM → SIGKILL fallback)
- **`catalyst-monitor.sh status [--json]`** — reports running/stopped with PID, port, URL
- **`catalyst-monitor.sh open`** — starts if needed, opens browser to dashboard
- **`catalyst-monitor.sh url`** — prints monitor URL for skill integration

PID file support in `server.ts` enables detection of running instances and clean lifecycle management. Stale PID files (dead processes) are automatically cleaned up on the next invocation.

## Test plan

- [x] 4 unit tests for PID file support in server.ts (write, omit, delete, format)
- [x] 14 integration tests for catalyst-monitor.sh (help, url, port override, status when stopped, status --json, start, idempotent start, stop, stop when not running, status after start, status --json after start, stale PID recovery, unknown command)
- [x] All 117 existing tests pass (zero regressions)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Security review completed (input validation, ENOENT-only catch, --pid-file arg validation)
- [x] Code review completed (addressed all actionable findings)