### PR TITLE
feat(dev): add single-session detail view to orch-monitor

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -161,6 +161,22 @@ describe("SSE server", () => {
     expect(res.status).toBe(404);
     await res.text();
   });
+
+  it("should 400 for path traversal in ticket", async () => {
+    const res = await fetch(
+      `${baseUrl}/api/session/orch-test/${encodeURIComponent("../../etc/passwd")}`,
+    );
+    expect(res.status).toBe(400);
+    await res.text();
+  });
+
+  it("should 400 for path traversal in orchId", async () => {
+    const res = await fetch(
+      `${baseUrl}/api/session/${encodeURIComponent("../secret")}/TEST-1`,
+    );
+    expect(res.status).toBe(400);
+    await res.text();
+  });
 });
 
 describe("SSE filtering", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -137,6 +137,30 @@ describe("SSE server", () => {
     expect([403, 404]).toContain(res.status);
     await res.text();
   });
+
+  it("should return session detail at /api/session/:orchId/:ticket", async () => {
+    const res = await fetch(`${baseUrl}/api/session/orch-test/TEST-1`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      orchId: string;
+      worker: { ticket: string; status: string };
+    };
+    expect(data.orchId).toBe("orch-test");
+    expect(data.worker.ticket).toBe("TEST-1");
+    expect(data.worker.status).toBe("in_progress");
+  });
+
+  it("should 404 for nonexistent session", async () => {
+    const res = await fetch(`${baseUrl}/api/session/orch-test/NONEXISTENT`);
+    expect(res.status).toBe(404);
+    await res.text();
+  });
+
+  it("should 404 for nonexistent orchestrator", async () => {
+    const res = await fetch(`${baseUrl}/api/session/orch-fake/TEST-1`);
+    expect(res.status).toBe(404);
+    await res.text();
+  });
 });
 
 describe("SSE filtering", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/state-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/state-reader.test.ts
@@ -8,6 +8,7 @@ import {
   readOrchestratorState,
   buildSnapshot,
   buildAnalyticsSnapshot,
+  buildSessionDetail,
 } from "../lib/state-reader";
 
 let tmpRoot: string;
@@ -713,5 +714,109 @@ describe("buildAnalyticsSnapshot", () => {
     expect(analytics?.ticket).toBe("A-1");
     expect(analytics?.costUSD).toBe(0.5);
     expect(analytics?.durationMs).toBe(1000);
+  });
+});
+
+describe("buildSessionDetail", () => {
+  function writeOutputJson(orchDir: string, ticket: string, data: unknown): void {
+    const logsDir = join(orchDir, "workers", "logs");
+    mkdirSync(logsDir, { recursive: true });
+    writeFileSync(join(logsDir, `${ticket}.output.json`), JSON.stringify(data));
+  }
+
+  it("returns session detail for a valid orchestrator + ticket", () => {
+    const now = new Date().toISOString();
+    const orchDir = setupOrch(tmpRoot, "orch-alpha", {
+      state: {
+        id: "orch-alpha",
+        startedAt: "2026-04-13T18:00:00Z",
+        currentWave: 1,
+        totalWaves: 2,
+        waves: [
+          { wave: 1, status: "in_progress", tickets: ["T-1"] },
+          { wave: 2, status: "pending", tickets: ["T-2"] },
+        ],
+      },
+      workers: {
+        "T-1": {
+          ticket: "T-1",
+          orchestrator: "orch-alpha",
+          workerName: "orch-alpha-T-1",
+          status: "implementing",
+          phase: 3,
+          startedAt: now,
+          updatedAt: now,
+          pid: process.pid,
+          phaseTimestamps: {
+            researching: "2026-04-13T18:01:00Z",
+            implementing: "2026-04-13T18:05:00Z",
+          },
+          cost: { costUSD: 0.75, inputTokens: 500, outputTokens: 200, cacheReadTokens: 100 },
+        },
+      },
+    });
+    writeOutputJson(orchDir, "T-1", [
+      {
+        type: "result",
+        duration_ms: 60000,
+        duration_api_ms: 30000,
+        num_turns: 10,
+        total_cost_usd: 0.80,
+        modelUsage: { "claude-opus-4-6": {} },
+        usage: { input_tokens: 600, output_tokens: 250, cache_read_input_tokens: 150 },
+      },
+    ]);
+
+    const detail = buildSessionDetail(tmpRoot, "orch-alpha", "T-1");
+    expect(detail).not.toBeNull();
+    expect(detail!.orchId).toBe("orch-alpha");
+    expect(detail!.worker.ticket).toBe("T-1");
+    expect(detail!.worker.status).toBe("implementing");
+    expect(detail!.worker.phase).toBe(3);
+    expect(detail!.worker.wave).toBe(1);
+    expect(detail!.worker.alive).toBe(true);
+    expect(detail!.analytics).not.toBeNull();
+    expect(detail!.analytics!.costUSD).toBe(0.80);
+    expect(detail!.analytics!.toolUsage).toBeDefined();
+    expect(detail!.orchStartedAt).toBe("2026-04-13T18:00:00Z");
+  });
+
+  it("returns null for a nonexistent orchestrator", () => {
+    setupOrch(tmpRoot, "orch-alpha", {
+      workers: { "T-1": { ticket: "T-1", status: "done", phase: 6, startedAt: "", updatedAt: "" } },
+    });
+
+    const detail = buildSessionDetail(tmpRoot, "orch-nonexistent", "T-1");
+    expect(detail).toBeNull();
+  });
+
+  it("returns null for a nonexistent ticket within a valid orchestrator", () => {
+    setupOrch(tmpRoot, "orch-alpha", {
+      workers: { "T-1": { ticket: "T-1", status: "done", phase: 6, startedAt: "", updatedAt: "" } },
+    });
+
+    const detail = buildSessionDetail(tmpRoot, "orch-alpha", "NONEXISTENT");
+    expect(detail).toBeNull();
+  });
+
+  it("returns analytics as null when output.json is missing", () => {
+    const now = new Date().toISOString();
+    setupOrch(tmpRoot, "orch-alpha", {
+      workers: {
+        "T-1": {
+          ticket: "T-1",
+          orchestrator: "orch-alpha",
+          workerName: "orch-alpha-T-1",
+          status: "in_progress",
+          phase: 1,
+          startedAt: now,
+          updatedAt: now,
+        },
+      },
+    });
+
+    const detail = buildSessionDetail(tmpRoot, "orch-alpha", "T-1");
+    expect(detail).not.toBeNull();
+    expect(detail!.analytics).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
@@ -73,6 +73,13 @@ export interface AnalyticsSnapshot {
   orchestrators: OrchestratorAnalytics[];
 }
 
+export interface SessionDetail {
+  orchId: string;
+  orchStartedAt: string;
+  worker: WorkerState;
+  analytics: WorkerAnalytics | null;
+}
+
 export interface Wave {
   wave: number;
   status: string;
@@ -467,6 +474,30 @@ export function buildSnapshot(
     orchestrators,
     sessions,
     sessionStoreAvailable: storeAvailable,
+  };
+}
+
+export function buildSessionDetail(
+  baseDir: string,
+  orchId: string,
+  ticket: string,
+): SessionDetail | null {
+  const dirs = scanOrchestrators(baseDir);
+  const orchDir = dirs.find((d) => basename(d) === orchId);
+  if (!orchDir) return null;
+
+  const orch = readOrchestratorState(orchDir);
+  const worker = orch.workers[ticket];
+  if (!worker) return null;
+
+  const analytics = parseOutputJson(analyticsPath(orchDir, ticket));
+  if (analytics) analytics.ticket = ticket;
+
+  return {
+    orchId: orch.id,
+    orchStartedAt: orch.startedAt,
+    worker,
+    analytics,
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/public/index.html
+++ b/plugins/dev/scripts/orch-monitor/public/index.html
@@ -855,6 +855,203 @@
         .briefing-drawer { padding: 14px; }
         .md { font-size: 13px; }
       }
+
+      /* --- Session detail view --- */
+      .session-back {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        color: var(--accent);
+        font-size: 13px;
+        cursor: pointer;
+        padding: 4px 0;
+        margin-bottom: 8px;
+      }
+      .session-back:hover { text-decoration: underline; }
+      .session-header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+        padding: 14px;
+        border-bottom: 1px solid var(--border);
+      }
+      .session-header .sh-ticket {
+        font-size: 18px;
+        font-weight: 700;
+        font-family: ui-monospace, monospace;
+      }
+      .session-header .sh-ticket a { color: var(--accent); }
+      .session-header .sh-title {
+        flex: 1 1 auto;
+        font-size: 14px;
+        color: var(--fg);
+        min-width: 200px;
+      }
+      .session-header .sh-elapsed {
+        font-family: ui-monospace, monospace;
+        font-size: 13px;
+        color: var(--muted);
+      }
+      .session-sections {
+        display: flex;
+        flex-direction: column;
+      }
+      .session-section {
+        border-top: 1px solid var(--border);
+        padding: 14px;
+      }
+      .session-section h3 {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin: 0 0 10px;
+      }
+      .phase-timeline {
+        display: flex;
+        gap: 0;
+        height: 28px;
+        border-radius: 4px;
+        overflow: hidden;
+        margin-bottom: 8px;
+      }
+      .phase-timeline .pt-seg {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 24px;
+        font-size: 10px;
+        color: rgba(255,255,255,0.85);
+        font-weight: 600;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        padding: 0 6px;
+      }
+      .phase-timeline .pt-seg.current::after {
+        content: "";
+        position: absolute;
+        right: 0; top: 0; bottom: 0; width: 3px;
+        background: rgba(255,255,255,0.35);
+        animation: gantt-pulse 1.4s ease-in-out infinite;
+      }
+      .phase-details {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 16px;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .phase-details .pd-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+      }
+      .phase-details .pd-swatch {
+        width: 8px;
+        height: 8px;
+        border-radius: 2px;
+        display: inline-block;
+      }
+      .phase-details .pd-dur {
+        font-family: ui-monospace, monospace;
+        color: var(--fg);
+      }
+      .session-cost-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 12px;
+      }
+      .sc-item {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .sc-item .sc-value {
+        font-size: 20px;
+        font-weight: 700;
+        font-family: ui-monospace, monospace;
+        font-variant-numeric: tabular-nums;
+        color: var(--fg);
+      }
+      .sc-item .sc-label {
+        font-size: 11px;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+      }
+      .tool-bars {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .tool-bar-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 12px;
+      }
+      .tool-bar-row .tb-name {
+        width: 120px;
+        flex-shrink: 0;
+        text-align: right;
+        font-family: ui-monospace, monospace;
+        color: var(--fg);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .tool-bar-row .tb-bar {
+        flex: 1;
+        height: 14px;
+        background: var(--panel-2);
+        border-radius: 2px;
+        overflow: hidden;
+      }
+      .tool-bar-row .tb-fill {
+        height: 100%;
+        background: var(--accent);
+        border-radius: 2px;
+      }
+      .tool-bar-row .tb-count {
+        width: 40px;
+        font-family: ui-monospace, monospace;
+        color: var(--muted);
+        font-size: 11px;
+      }
+      .session-pr-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px 24px;
+        align-items: baseline;
+      }
+      .session-pr-grid .sp-number {
+        font-size: 18px;
+        font-weight: 700;
+        font-family: ui-monospace, monospace;
+      }
+      .session-pr-grid .sp-number a { color: var(--accent); }
+      .session-health-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 8px;
+      }
+      .sh-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+      }
+      .sh-item .sh-label { color: var(--muted); }
+      .sh-item .sh-val { font-family: ui-monospace, monospace; color: var(--fg); }
+      .session-events {
+        max-height: 400px;
+        overflow-y: auto;
+      }
+      .worker-table tbody tr { cursor: pointer; }
     </style>
     <script src="/public/vendor/marked.umd.js"></script>
     <script src="/public/vendor/purify.min.js"></script>
@@ -872,24 +1069,32 @@
       <span id="last-update" class="conn"></span>
     </header>
     <main>
-      <div id="attention" class="attention-panel"></div>
-      <div id="orchestrators"></div>
-      <div class="card">
-        <div class="card-head"><h2>Events</h2></div>
-        <div id="events" class="events">
-          <div class="empty">No events yet.</div>
+      <div id="dashboard-view">
+        <div id="attention" class="attention-panel"></div>
+        <div id="orchestrators"></div>
+        <div class="card">
+          <div class="card-head"><h2>Events</h2></div>
+          <div id="events" class="events">
+            <div class="empty">No events yet.</div>
+          </div>
         </div>
       </div>
+      <div id="session-view" style="display:none"></div>
     </main>
     <script>
       (function () {
         const $orch = document.getElementById("orchestrators");
         const $attention = document.getElementById("attention");
         const $events = document.getElementById("events");
+        const $dashboardView = document.getElementById("dashboard-view");
+        const $sessionView = document.getElementById("session-view");
         const STALE_THRESHOLD_SECONDS = 900;
         const $dot = document.getElementById("conn-dot");
         const $connText = document.getElementById("conn-text");
         const $lastUpdate = document.getElementById("last-update");
+
+        let currentRoute = { view: "dashboard", orchId: null, ticket: null };
+        let sessionDetail = null;
 
         let snapshot = { timestamp: null, orchestrators: [] };
         const eventLog = [];
@@ -1659,6 +1864,14 @@
         }
 
         function render() {
+          if (snapshot.timestamp) {
+            $lastUpdate.textContent =
+              "snapshot " + new Date(snapshot.timestamp).toLocaleTimeString();
+          }
+          if (currentRoute.view === "session") {
+            refreshSessionFromSnapshot();
+            return;
+          }
           const list = snapshot.orchestrators || [];
           if (!list.length) {
             $orch.innerHTML =
@@ -1667,10 +1880,21 @@
             $orch.innerHTML = list.map(renderOrch).join("");
           }
           renderAttention();
-          if (snapshot.timestamp) {
-            $lastUpdate.textContent =
-              "snapshot " + new Date(snapshot.timestamp).toLocaleTimeString();
-          }
+        }
+
+        function refreshSessionFromSnapshot() {
+          if (!sessionDetail || currentRoute.view !== "session") return;
+          var orchId = currentRoute.orchId;
+          var ticket = currentRoute.ticket;
+          var orch = (snapshot.orchestrators || []).find(function (o) { return o.id === orchId; });
+          if (!orch) return;
+          var w = orch.workers && orch.workers[ticket];
+          if (!w) return;
+          sessionDetail.worker = w;
+          var orchAn = analyticsByOrch.get(orchId) || {};
+          var wa = orchAn[ticket] || null;
+          if (wa) sessionDetail.analytics = wa;
+          $sessionView.innerHTML = buildSessionView(sessionDetail);
         }
 
         function patchWorker(payload) {
@@ -1705,9 +1929,9 @@
           }
         });
 
-        function addEvent(kind, html) {
+        function addEvent(kind, html, ticket) {
           const when = new Date().toLocaleTimeString();
-          eventLog.unshift({ when, kind, html });
+          eventLog.unshift({ when, kind, html, ticket: ticket || null });
           if (eventLog.length > MAX_EVENTS) eventLog.length = MAX_EVENTS;
           renderEvents();
         }
@@ -1744,17 +1968,20 @@
               addEvent("new",
                 tkt(tktStr) + " discovered · status <span class=\"to\">" +
                 esc(next.status || "?") + "</span> · phase " +
-                esc(next.phase ?? 0));
+                esc(next.phase ?? 0),
+                tktStr);
             }
             return;
           }
           if (prev.status !== next.status) {
             addEvent("status",
-              tkt(tktStr) + " status " + trans(prev.status || "?", next.status || "?"));
+              tkt(tktStr) + " status " + trans(prev.status || "?", next.status || "?"),
+              tktStr);
           }
           if ((prev.phase ?? 0) !== (next.phase ?? 0)) {
             addEvent("phase",
-              tkt(tktStr) + " phase " + trans(prev.phase ?? 0, next.phase ?? 0));
+              tkt(tktStr) + " phase " + trans(prev.phase ?? 0, next.phase ?? 0),
+              tktStr);
           }
           const prevPr = prev.pr && prev.pr.number;
           const nextPr = next.pr && next.pr.number;
@@ -1762,19 +1989,23 @@
             const url = (next.pr && next.pr.url) || "#";
             addEvent("pr",
               tkt(tktStr) + ' PR opened · <a href="' + esc(url) +
-              '" target="_blank" rel="noopener">#' + esc(nextPr) + "</a>");
+              '" target="_blank" rel="noopener">#' + esc(nextPr) + "</a>",
+              tktStr);
           }
           if (prev.alive !== next.alive) {
             addEvent("live",
               tkt(tktStr) + " process " + trans(
                 prev.alive ? "alive" : "dead",
-                next.alive ? "alive" : "dead"));
+                next.alive ? "alive" : "dead"),
+              tktStr);
           }
           if (!prev.pid && next.pid) {
-            addEvent("live", tkt(tktStr) + " PID acquired · " + esc(next.pid));
+            addEvent("live", tkt(tktStr) + " PID acquired · " + esc(next.pid),
+              tktStr);
           }
           if (prev.pid && !next.pid) {
-            addEvent("live", tkt(tktStr) + " PID cleared (was " + esc(prev.pid) + ")");
+            addEvent("live", tkt(tktStr) + " PID cleared (was " + esc(prev.pid) + ")",
+              tktStr);
           }
         }
 
@@ -1899,6 +2130,319 @@
             $connText.textContent = "connecting...";
           }
         }
+
+        // --- Hash router ---
+        function parseRoute() {
+          const hash = location.hash || "#/";
+          const sessionMatch = hash.match(/^#\/session\/([^/]+)\/([^/]+)$/);
+          if (sessionMatch) {
+            try {
+              return { view: "session", orchId: decodeURIComponent(sessionMatch[1]), ticket: decodeURIComponent(sessionMatch[2]) };
+            } catch (err) {
+              console.error("malformed hash, falling back to dashboard:", err);
+              return { view: "dashboard", orchId: null, ticket: null };
+            }
+          }
+          return { view: "dashboard", orchId: null, ticket: null };
+        }
+
+        function navigateTo(hash) {
+          location.hash = hash;
+        }
+
+        async function fetchSessionDetail(orchId, ticket) {
+          try {
+            const resp = await fetch("/api/session/" + encodeURIComponent(orchId) + "/" + encodeURIComponent(ticket));
+            if (resp.status === 404) return { error: "not_found" };
+            if (!resp.ok) return { error: "server_error", status: resp.status };
+            return { data: await resp.json() };
+          } catch (err) {
+            console.error("session detail fetch failed", err);
+            return { error: "network" };
+          }
+        }
+
+        function renderPhaseTimeline(w) {
+          const phaseTs = w.phaseTimestamps || {};
+          const stops = [];
+          for (var p of PHASE_ORDER) {
+            var ts = phaseTs[p];
+            if (!ts) continue;
+            var t = Date.parse(ts);
+            if (!Number.isFinite(t)) continue;
+            stops.push({ phase: p, t: t });
+          }
+          stops.sort(function (a, b) { return a.t - b.t; });
+          if (!stops.length) {
+            return '<div class="empty">No phase data available.</div>';
+          }
+          var now = Date.now();
+          var startMs = stops[0].t;
+          var isLive = !w.completedAt && w.status !== "done" && w.status !== "merged" && w.status !== "failed";
+          var endMs = w.completedAt ? Date.parse(w.completedAt) : (isLive ? now : Date.parse(w.updatedAt || "") || now);
+          var totalSpan = Math.max(endMs - startMs, 1);
+
+          var segsHtml = "";
+          var detailsHtml = "";
+          for (var i = 0; i < stops.length; i++) {
+            var from = stops[i].t;
+            var to = i + 1 < stops.length ? stops[i + 1].t : endMs;
+            var pct = ((to - from) / totalSpan) * 100;
+            var color = phaseColor(stops[i].phase);
+            var isCurrent = isLive && i === stops.length - 1;
+            segsHtml +=
+              '<div class="pt-seg' + (isCurrent ? " current" : "") +
+              '" style="width:' + pct.toFixed(1) + "%;background:" + color +
+              ';" title="' + esc(stops[i].phase) + " " + fmtDuration(to - from) + '">' +
+              (pct > 8 ? esc(stops[i].phase) : "") + "</div>";
+            detailsHtml +=
+              '<span class="pd-item"><span class="pd-swatch" style="background:' + color +
+              '"></span>' + esc(stops[i].phase) +
+              ' <span class="pd-dur">' + esc(fmtDuration(to - from)) + "</span></span>";
+          }
+          return (
+            '<div class="phase-timeline">' + segsHtml + "</div>" +
+            '<div class="phase-details">' + detailsHtml + "</div>"
+          );
+        }
+
+        function renderSessionCost(w, analytics) {
+          var liveCost = w.cost && Number.isFinite(Number(w.cost.costUSD)) ? Number(w.cost.costUSD) : 0;
+          var aCost = analytics && Number.isFinite(Number(analytics.costUSD)) ? Number(analytics.costUSD) : 0;
+          var costVal = Math.max(liveCost, aCost);
+
+          var inputTokens = 0, outputTokens = 0, cacheTokens = 0;
+          if (analytics) {
+            inputTokens = analytics.inputTokens || 0;
+            outputTokens = analytics.outputTokens || 0;
+            cacheTokens = analytics.cacheReadTokens || 0;
+          } else if (w.cost) {
+            inputTokens = w.cost.inputTokens || 0;
+            outputTokens = w.cost.outputTokens || 0;
+            cacheTokens = w.cost.cacheReadTokens || 0;
+          }
+          var totalTokens = inputTokens + outputTokens + cacheTokens;
+          var cacheRate = totalTokens > 0 ? ((cacheTokens / totalTokens) * 100).toFixed(1) : "0.0";
+
+          return (
+            '<div class="session-cost-grid">' +
+            '<div class="sc-item"><span class="sc-value">' +
+            (costVal > 0 ? "$" + costVal.toFixed(2) : "\u2014") +
+            '</span><span class="sc-label">Cost</span></div>' +
+            '<div class="sc-item"><span class="sc-value">' +
+            esc(fmtTokens(inputTokens)) +
+            '</span><span class="sc-label">Input tokens</span></div>' +
+            '<div class="sc-item"><span class="sc-value">' +
+            esc(fmtTokens(outputTokens)) +
+            '</span><span class="sc-label">Output tokens</span></div>' +
+            '<div class="sc-item"><span class="sc-value">' +
+            esc(fmtTokens(cacheTokens)) +
+            '</span><span class="sc-label">Cache read</span></div>' +
+            '<div class="sc-item"><span class="sc-value">' +
+            esc(cacheRate) + "%" +
+            '</span><span class="sc-label">Cache hit rate</span></div>' +
+            (analytics && analytics.numTurns
+              ? '<div class="sc-item"><span class="sc-value">' + esc(analytics.numTurns) +
+                '</span><span class="sc-label">Turns</span></div>'
+              : "") +
+            "</div>"
+          );
+        }
+
+        function renderToolUsage(analytics) {
+          if (!analytics || !analytics.toolUsage) {
+            return '<div class="empty">No tool data available.</div>';
+          }
+          var entries = Object.entries(analytics.toolUsage).sort(function (a, b) { return b[1] - a[1]; });
+          if (!entries.length) return '<div class="empty">No tools used.</div>';
+          var maxCount = entries[0][1];
+          return '<div class="tool-bars">' + entries.slice(0, 20).map(function (e) {
+            var pct = (e[1] / maxCount) * 100;
+            return (
+              '<div class="tool-bar-row">' +
+              '<span class="tb-name" title="' + esc(e[0]) + '">' + esc(e[0]) + "</span>" +
+              '<div class="tb-bar"><div class="tb-fill" style="width:' + pct.toFixed(1) + '%"></div></div>' +
+              '<span class="tb-count">' + esc(e[1]) + "</span>" +
+              "</div>"
+            );
+          }).join("") + "</div>";
+        }
+
+        function renderSessionPr(w) {
+          if (!w.pr) return '<div class="empty">No PR created yet.</div>';
+          var url = esc(w.pr.url);
+          var num = esc(w.pr.number);
+          var stateStr = w.prState || w.pr.state || w.pr.ciStatus || "unknown";
+          var badgeClass = "b-" + statusClass(stateStr);
+          var mergedAt = w.prMergedAt || w.pr.mergedAt;
+          return (
+            '<div class="session-pr-grid">' +
+            '<span class="sp-number"><a href="' + url + '" target="_blank" rel="noopener">#' + num + "</a></span>" +
+            '<span class="badge ' + esc(badgeClass) + '">' + esc(stateStr) + "</span>" +
+            (mergedAt ? '<span style="color:var(--green);font-size:12px">merged ' + esc(new Date(mergedAt).toLocaleString()) + "</span>" : "") +
+            "</div>"
+          );
+        }
+
+        function renderSessionHealth(w) {
+          var aliveDot = w.pid
+            ? '<span class="alive-dot ' + (w.alive ? "alive" : "dead") + '"></span>' + (w.alive ? "alive" : "dead")
+            : "\u2014";
+          var hb = w.lastHeartbeat
+            ? new Date(w.lastHeartbeat).toLocaleTimeString()
+            : "\u2014";
+          var dod = w.definitionOfDone || {};
+          var gatesHtml = "";
+          var gateKeys = ["testsWrittenFirst", "typeCheck", "securityReview", "codeReview", "rewardHackingScan"];
+          for (var g of gateKeys) {
+            var val = dod[g];
+            if (val === undefined) continue;
+            var passed = val === true || (typeof val === "object" && val && val.passed === true);
+            gatesHtml += renderGate(g.replace(/([A-Z])/g, " $1").trim(), passed);
+          }
+          var unitTests = dod.unitTests;
+          if (unitTests) {
+            gatesHtml += renderGate("unit tests (" + (unitTests.count || 0) + ")", unitTests.exists);
+          }
+          var apiTests = dod.apiTests;
+          if (apiTests) {
+            gatesHtml += renderGate("api tests (" + (apiTests.count || 0) + ")", apiTests.exists);
+          }
+          return (
+            '<div class="session-health-grid">' +
+            '<div class="sh-item"><span class="sh-label">PID</span> <span class="sh-val">' + (w.pid ? esc(w.pid) : "\u2014") + "</span></div>" +
+            '<div class="sh-item"><span class="sh-label">Status</span> ' + aliveDot + "</div>" +
+            '<div class="sh-item"><span class="sh-label">Heartbeat</span> <span class="sh-val">' + esc(hb) + "</span></div>" +
+            '<div class="sh-item"><span class="sh-label">Phase</span> <span class="sh-val">' + esc(w.phase ?? 0) + "</span></div>" +
+            "</div>" +
+            (gatesHtml ? '<div class="gates" style="margin-top:10px">' + gatesHtml + "</div>" : "")
+          );
+        }
+
+        function renderSessionEvents(orchId, ticket) {
+          var filtered = eventLog.filter(function (e) {
+            return e.ticket === ticket;
+          });
+          if (!filtered.length) return '<div class="empty">No events for this session.</div>';
+          return '<div class="session-events">' + filtered.map(function (e) {
+            return (
+              '<div class="ev ' + esc(e.kind) + '">' +
+              '<span class="t">' + esc(e.when) + "</span>" +
+              '<span class="k">' + esc(e.kind) + "</span>" +
+              '<span class="msg">' + e.html + "</span>" +
+              "</div>"
+            );
+          }).join("") + "</div>";
+        }
+
+        function buildSessionView(detail) {
+          var w = detail.worker;
+          var analytics = detail.analytics;
+          var lt = linearFor(w.ticket);
+          var ticketUrl = (lt && lt.url) || "https://linear.app/issue/" + encodeURIComponent(w.ticket);
+          var stat = w.status || "unknown";
+          var badgeClass = "b-" + statusClass(stat);
+
+          var isLive = !w.completedAt && w.status !== "done" && w.status !== "merged" && w.status !== "failed";
+          var elapsed = "";
+          if (w.startedAt) {
+            var startMs = Date.parse(w.startedAt);
+            var endMs = w.completedAt ? Date.parse(w.completedAt) : (isLive ? Date.now() : Date.parse(w.updatedAt || "") || Date.now());
+            elapsed = fmtDuration(endMs - startMs);
+          }
+
+          var titleHtml = (lt && lt.title) ? esc(lt.title) : "";
+
+          return (
+            '<div class="session-back" id="session-back">\u2190 Back to dashboard</div>' +
+            '<div class="card">' +
+            '<div class="session-header">' +
+            '<span class="sh-ticket"><a href="' + esc(ticketUrl) + '" target="_blank" rel="noopener">' + esc(w.ticket) + "</a></span>" +
+            '<span class="badge ' + esc(badgeClass) + '">' + esc(stat) + "</span>" +
+            (elapsed ? '<span class="sh-elapsed">' + esc(elapsed) + (isLive ? " (live)" : "") + "</span>" : "") +
+            (w.wave != null ? '<span style="color:var(--muted);font-size:12px">Wave ' + esc(w.wave) + "</span>" : "") +
+            "</div>" +
+            (titleHtml ? '<div style="padding:10px 14px;border-bottom:1px solid var(--border);font-size:14px">' + titleHtml + "</div>" : "") +
+            '<div class="session-sections">' +
+
+            '<div class="session-section"><h3>Phase Timeline</h3>' +
+            renderPhaseTimeline(w) +
+            "</div>" +
+
+            '<div class="session-section"><h3>Cost &amp; Tokens</h3>' +
+            renderSessionCost(w, analytics) +
+            "</div>" +
+
+            '<div class="session-section"><h3>Tool Usage</h3>' +
+            renderToolUsage(analytics) +
+            "</div>" +
+
+            '<div class="session-section"><h3>Event Log</h3>' +
+            renderSessionEvents(detail.orchId, w.ticket) +
+            "</div>" +
+
+            '<div class="session-section"><h3>PR Status</h3>' +
+            renderSessionPr(w) +
+            "</div>" +
+
+            '<div class="session-section"><h3>Process Health</h3>' +
+            renderSessionHealth(w) +
+            "</div>" +
+
+            "</div>" +
+            "</div>"
+          );
+        }
+
+        async function showSessionView(orchId, ticket) {
+          $dashboardView.style.display = "none";
+          $sessionView.style.display = "block";
+          $sessionView.innerHTML = '<div class="empty">Loading session...</div>';
+
+          var result = await fetchSessionDetail(orchId, ticket);
+          if (result.error) {
+            var msg = result.error === "not_found"
+              ? "Session not found: " + esc(orchId) + "/" + esc(ticket)
+              : result.error === "network"
+                ? "Network error \u2014 check your connection and try again"
+                : "Server error (HTTP " + esc(result.status) + ") \u2014 try again later";
+            $sessionView.innerHTML =
+              '<div class="session-back" id="session-back">\u2190 Back to dashboard</div>' +
+              '<div class="card"><div class="empty">' + msg + "</div></div>";
+            return;
+          }
+          sessionDetail = result.data;
+          $sessionView.innerHTML = buildSessionView(result.data);
+        }
+
+        function showDashboardView() {
+          $dashboardView.style.display = "block";
+          $sessionView.style.display = "none";
+          $sessionView.innerHTML = "";
+          sessionDetail = null;
+          render();
+        }
+
+        function handleRoute() {
+          var route = parseRoute();
+          currentRoute = route;
+          if (route.view === "session" && route.orchId && route.ticket) {
+            showSessionView(route.orchId, route.ticket);
+          } else {
+            showDashboardView();
+          }
+        }
+
+        window.addEventListener("hashchange", handleRoute);
+
+        document.addEventListener("click", function (e) {
+          var back = e.target.closest("#session-back");
+          if (back) {
+            e.preventDefault();
+            navigateTo("#/");
+            return;
+          }
+        });
 
         let backoff = 500;
         const BACKOFF_MAX = 15000;
@@ -2033,6 +2577,7 @@
         }
 
         $orch.addEventListener("click", (e) => {
+          if (e.target.closest("a")) return;
           const toggle = e.target.closest("[data-gantt-toggle]");
           if (toggle) {
             const orchId = toggle.getAttribute("data-gantt-toggle");
@@ -2060,6 +2605,15 @@
             }
             return;
           }
+          const row = e.target.closest("tr.worker-row");
+          if (row) {
+            const orchId = row.getAttribute("data-orch");
+            const ticket = row.getAttribute("data-ticket");
+            if (orchId && ticket) {
+              navigateTo("#/session/" + encodeURIComponent(orchId) + "/" + encodeURIComponent(ticket));
+              return;
+            }
+          }
           const wcard = e.target.closest(".wcard");
           if (!wcard) return;
           const orchId = wcard.getAttribute("data-orch");
@@ -2074,6 +2628,7 @@
         setInterval(refreshAnalytics, 10000);
         refreshLinear();
         setInterval(refreshLinear, 60000);
+        handleRoute();
       })();
     </script>
   </body>

--- a/plugins/dev/scripts/orch-monitor/public/index.html
+++ b/plugins/dev/scripts/orch-monitor/public/index.html
@@ -2154,7 +2154,10 @@
           try {
             const resp = await fetch("/api/session/" + encodeURIComponent(orchId) + "/" + encodeURIComponent(ticket));
             if (resp.status === 404) return { error: "not_found" };
-            if (!resp.ok) return { error: "server_error", status: resp.status };
+            if (!resp.ok) {
+              await resp.text().catch(function () {});
+              return { error: "server_error", status: resp.status };
+            }
             return { data: await resp.json() };
           } catch (err) {
             console.error("session detail fetch failed", err);

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -4,6 +4,7 @@ import { subscribe } from "./lib/event-bus";
 import {
   buildSnapshot,
   buildAnalyticsSnapshot,
+  buildSessionDetail,
   type MonitorSnapshot,
   type BuildSnapshotOptions,
   type SessionState,
@@ -369,6 +370,44 @@ export function createServer(opts: CreateServerOptions): BunServer {
             return new Response("Session(s) not found", { status: 404 });
           }
           return Response.json(result);
+        }
+
+        const sessionMatch = url.pathname.match(
+          /^\/api\/session\/([^/]+)\/([^/]+)$/,
+        );
+        if (sessionMatch) {
+          let orchId: string;
+          let ticket: string;
+          try {
+            orchId = decodeURIComponent(sessionMatch[1]);
+            ticket = decodeURIComponent(sessionMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            orchId.includes("..") ||
+            orchId.includes("\0") ||
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const detail = buildSessionDetail(wtDir, orchId, ticket);
+          if (!detail) {
+            return new Response("Not Found", { status: 404 });
+          }
+          if (prFetcher && detail.worker.pr) {
+            const repo = parseRepoFromPrUrl(detail.worker.pr.url);
+            if (repo) {
+              const status = prFetcher.get(repo, detail.worker.pr.number);
+              if (status) {
+                detail.worker.prState = status.state;
+                detail.worker.prMergedAt = status.mergedAt;
+              }
+            }
+          }
+          return Response.json(detail);
         }
 
         if (url.pathname === "/api/linear") {


### PR DESCRIPTION
## Summary

- Adds `/session/:orchId/:ticket` detail view to the orch-monitor dashboard with phase timeline, live cost/token display, tool usage bars, event log, PR status, and process health sections
- Backend `buildSessionDetail()` function and `/api/session/:orchId/:ticket` API endpoint with path traversal validation
- Hash-based routing (`#/session/orchId/ticket`) with click-through from worker table rows and back navigation
- Live updates via SSE — session detail refreshes when snapshot pushes arrive

Closes CTL-41

## Test plan

- [x] 108 tests pass (7 new: 4 for `buildSessionDetail`, 3 for endpoint including path traversal)
- [x] Security review: path traversal validation, decodeURIComponent safety, response body consumption
- [x] Code review: consistent with existing patterns, proper escaping, correct event delegation