### PR TITLE
feat(dev): add session & orchestrator annotations

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/annotations.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/annotations.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  openDb,
+  closeDb,
+  getAnnotation,
+  getAllAnnotations,
+  setDisplayName,
+  addFlag,
+  removeFlag,
+  addNote,
+  removeNote,
+  addTag,
+  removeTag,
+  deleteAnnotation,
+} from "../lib/annotations";
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "annotations-test-"));
+  dbPath = join(tmpDir, "annotations.db");
+  openDb(dbPath);
+});
+
+afterEach(() => {
+  closeDb();
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("annotations database", () => {
+  it("returns null for non-existent session", () => {
+    const result = getAnnotation("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("returns empty record when no annotations exist", () => {
+    const result = getAllAnnotations();
+    expect(result).toEqual({});
+  });
+
+  describe("display name", () => {
+    it("sets and retrieves a display name", () => {
+      setDisplayName("CTL-1", "auth refactor batch");
+      const ann = getAnnotation("CTL-1");
+      expect(ann).not.toBeNull();
+      expect(ann!.displayName).toBe("auth refactor batch");
+    });
+
+    it("updates an existing display name", () => {
+      setDisplayName("CTL-1", "original");
+      setDisplayName("CTL-1", "updated");
+      const ann = getAnnotation("CTL-1");
+      expect(ann!.displayName).toBe("updated");
+    });
+
+    it("clears display name when set to null", () => {
+      setDisplayName("CTL-1", "name");
+      setDisplayName("CTL-1", null);
+      const ann = getAnnotation("CTL-1");
+      expect(ann!.displayName).toBeNull();
+    });
+  });
+
+  describe("flags", () => {
+    it("adds a flag", () => {
+      addFlag("CTL-2", "starred");
+      const ann = getAnnotation("CTL-2");
+      expect(ann!.flags).toEqual(["starred"]);
+    });
+
+    it("does not duplicate flags", () => {
+      addFlag("CTL-2", "starred");
+      addFlag("CTL-2", "starred");
+      const ann = getAnnotation("CTL-2");
+      expect(ann!.flags).toEqual(["starred"]);
+    });
+
+    it("supports multiple flags", () => {
+      addFlag("CTL-2", "starred");
+      addFlag("CTL-2", "flagged");
+      const ann = getAnnotation("CTL-2");
+      expect(ann!.flags).toContain("starred");
+      expect(ann!.flags).toContain("flagged");
+      expect(ann!.flags.length).toBe(2);
+    });
+
+    it("removes a flag", () => {
+      addFlag("CTL-2", "starred");
+      addFlag("CTL-2", "flagged");
+      removeFlag("CTL-2", "starred");
+      const ann = getAnnotation("CTL-2");
+      expect(ann!.flags).toEqual(["flagged"]);
+    });
+
+    it("removing non-existent flag is a no-op", () => {
+      addFlag("CTL-2", "starred");
+      removeFlag("CTL-2", "archived");
+      const ann = getAnnotation("CTL-2");
+      expect(ann!.flags).toEqual(["starred"]);
+    });
+  });
+
+  describe("notes", () => {
+    it("adds a note with timestamp", () => {
+      addNote("CTL-3", "flaky test, re-ran manually");
+      const ann = getAnnotation("CTL-3");
+      expect(ann!.notes.length).toBe(1);
+      expect(ann!.notes[0].text).toBe("flaky test, re-ran manually");
+      expect(ann!.notes[0].createdAt).toBeTruthy();
+    });
+
+    it("adds multiple notes in order", () => {
+      addNote("CTL-3", "first note");
+      addNote("CTL-3", "second note");
+      const ann = getAnnotation("CTL-3");
+      expect(ann!.notes.length).toBe(2);
+      expect(ann!.notes[0].text).toBe("first note");
+      expect(ann!.notes[1].text).toBe("second note");
+    });
+
+    it("removes a note by index", () => {
+      addNote("CTL-3", "keep");
+      addNote("CTL-3", "remove");
+      addNote("CTL-3", "also keep");
+      removeNote("CTL-3", 1);
+      const ann = getAnnotation("CTL-3");
+      expect(ann!.notes.length).toBe(2);
+      expect(ann!.notes[0].text).toBe("keep");
+      expect(ann!.notes[1].text).toBe("also keep");
+    });
+
+    it("removing out-of-range index is a no-op", () => {
+      addNote("CTL-3", "only note");
+      removeNote("CTL-3", 5);
+      const ann = getAnnotation("CTL-3");
+      expect(ann!.notes.length).toBe(1);
+    });
+  });
+
+  describe("tags", () => {
+    it("adds a tag", () => {
+      addTag("CTL-4", "refactor");
+      const ann = getAnnotation("CTL-4");
+      expect(ann!.tags).toEqual(["refactor"]);
+    });
+
+    it("does not duplicate tags", () => {
+      addTag("CTL-4", "refactor");
+      addTag("CTL-4", "refactor");
+      const ann = getAnnotation("CTL-4");
+      expect(ann!.tags).toEqual(["refactor"]);
+    });
+
+    it("supports multiple tags", () => {
+      addTag("CTL-4", "refactor");
+      addTag("CTL-4", "high-cost");
+      const ann = getAnnotation("CTL-4");
+      expect(ann!.tags).toContain("refactor");
+      expect(ann!.tags).toContain("high-cost");
+    });
+
+    it("removes a tag", () => {
+      addTag("CTL-4", "refactor");
+      addTag("CTL-4", "bugfix");
+      removeTag("CTL-4", "refactor");
+      const ann = getAnnotation("CTL-4");
+      expect(ann!.tags).toEqual(["bugfix"]);
+    });
+  });
+
+  describe("deleteAnnotation", () => {
+    it("deletes all annotation data for a session", () => {
+      setDisplayName("CTL-5", "test");
+      addFlag("CTL-5", "starred");
+      addNote("CTL-5", "some note");
+      addTag("CTL-5", "spike");
+      deleteAnnotation("CTL-5");
+      expect(getAnnotation("CTL-5")).toBeNull();
+    });
+
+    it("deleting non-existent session is a no-op", () => {
+      deleteAnnotation("nonexistent");
+      expect(getAllAnnotations()).toEqual({});
+    });
+  });
+
+  describe("getAllAnnotations", () => {
+    it("returns all annotated sessions", () => {
+      setDisplayName("CTL-A", "Alpha");
+      addTag("CTL-B", "beta");
+      const all = getAllAnnotations();
+      expect(Object.keys(all)).toHaveLength(2);
+      expect(all["CTL-A"].displayName).toBe("Alpha");
+      expect(all["CTL-B"].tags).toEqual(["beta"]);
+    });
+  });
+
+  describe("updatedAt", () => {
+    it("is set on creation", () => {
+      setDisplayName("CTL-6", "test");
+      const ann = getAnnotation("CTL-6");
+      expect(ann!.updatedAt).toBeTruthy();
+      const ts = Date.parse(ann!.updatedAt);
+      expect(Number.isNaN(ts)).toBe(false);
+    });
+
+    it("is updated on modification", () => {
+      setDisplayName("CTL-6", "first");
+      const first = getAnnotation("CTL-6")!.updatedAt;
+      setDisplayName("CTL-6", "second");
+      const second = getAnnotation("CTL-6")!.updatedAt;
+      expect(Date.parse(second)).toBeGreaterThanOrEqual(Date.parse(first));
+    });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/catalyst-session.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/catalyst-session.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { openDb, closeDb, getAnnotation } from "../lib/annotations";
+
+let tmpDir: string;
+let dbPath: string;
+
+function run(...args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const script = join(import.meta.dir, "..", "catalyst-session.ts");
+  const result = Bun.spawnSync(["bun", script, ...args], {
+    env: { ...process.env, CATALYST_DIR: tmpDir },
+    cwd: import.meta.dir,
+  });
+  return {
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+    exitCode: result.exitCode,
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "catalyst-session-test-"));
+  dbPath = join(tmpDir, "annotations.db");
+  openDb(dbPath);
+});
+
+afterEach(() => {
+  closeDb();
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("catalyst-session CLI", () => {
+  it("prints usage when called with no args", () => {
+    const { stderr, exitCode } = run();
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Usage:");
+  });
+
+  it("prints usage for unknown commands", () => {
+    const { stderr, exitCode } = run("unknown-cmd");
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Usage:");
+  });
+
+  describe("annotate", () => {
+    it("sets a display name", () => {
+      const { exitCode } = run("annotate", "CTL-1", "--name", "my worker");
+      expect(exitCode).toBe(0);
+      closeDb();
+      openDb(dbPath);
+      const ann = getAnnotation("CTL-1");
+      expect(ann!.displayName).toBe("my worker");
+    });
+
+    it("adds a flag", () => {
+      const { exitCode } = run("annotate", "CTL-2", "--flag", "starred");
+      expect(exitCode).toBe(0);
+      closeDb();
+      openDb(dbPath);
+      const ann = getAnnotation("CTL-2");
+      expect(ann!.flags).toContain("starred");
+    });
+
+    it("removes a flag with --unflag", () => {
+      run("annotate", "CTL-2", "--flag", "starred");
+      run("annotate", "CTL-2", "--unflag", "starred");
+      closeDb();
+      openDb(dbPath);
+      const ann = getAnnotation("CTL-2");
+      expect(ann!.flags).not.toContain("starred");
+    });
+
+    it("adds a note", () => {
+      const { exitCode } = run("annotate", "CTL-3", "--note", "flaky test");
+      expect(exitCode).toBe(0);
+      closeDb();
+      openDb(dbPath);
+      const ann = getAnnotation("CTL-3");
+      expect(ann!.notes.length).toBe(1);
+      expect(ann!.notes[0].text).toBe("flaky test");
+    });
+
+    it("adds tags", () => {
+      const { exitCode } = run(
+        "annotate", "CTL-4", "--tag", "refactor", "--tag", "high-cost",
+      );
+      expect(exitCode).toBe(0);
+      closeDb();
+      openDb(dbPath);
+      const ann = getAnnotation("CTL-4");
+      expect(ann!.tags).toContain("refactor");
+      expect(ann!.tags).toContain("high-cost");
+    });
+
+    it("removes a tag with --untag", () => {
+      run("annotate", "CTL-4", "--tag", "refactor");
+      run("annotate", "CTL-4", "--untag", "refactor");
+      closeDb();
+      openDb(dbPath);
+      const ann = getAnnotation("CTL-4");
+      expect(ann!.tags).not.toContain("refactor");
+    });
+
+    it("clears all annotations with --clear", () => {
+      run("annotate", "CTL-5", "--name", "test", "--flag", "starred");
+      run("annotate", "CTL-5", "--clear");
+      closeDb();
+      openDb(dbPath);
+      const ann = getAnnotation("CTL-5");
+      expect(ann).toBeNull();
+    });
+
+    it("requires a session-id argument", () => {
+      const { stderr, exitCode } = run("annotate");
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("session-id");
+    });
+
+    it("requires at least one annotation option", () => {
+      const { stderr, exitCode } = run("annotate", "CTL-6");
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("option");
+    });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -45,7 +45,8 @@ beforeAll(() => {
     }),
   );
 
-  server = createServer({ port: 0, wtDir, startWatcher: false });
+  const annotationsDbPath = join(tmpDir, "annotations.db");
+  server = createServer({ port: 0, wtDir, startWatcher: false, annotationsDbPath });
   baseUrl = `http://localhost:${server.port}`;
 });
 
@@ -222,6 +223,90 @@ describe("SSE filtering", () => {
   });
 });
 
+describe("Annotation API", () => {
+  it("GET /api/annotations returns empty initially", async () => {
+    const res = await fetch(`${baseUrl}/api/annotations`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { annotations: Record<string, unknown> };
+    expect(data.annotations).toBeDefined();
+  });
+
+  it("PUT /api/annotations/:id sets display name", async () => {
+    const res = await fetch(`${baseUrl}/api/annotations/TEST-1`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ displayName: "my worker" }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { annotation: { displayName: string } };
+    expect(data.annotation.displayName).toBe("my worker");
+  });
+
+  it("PUT /api/annotations/:id adds flags", async () => {
+    const res = await fetch(`${baseUrl}/api/annotations/TEST-1`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ addFlags: ["starred"] }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { annotation: { flags: string[] } };
+    expect(data.annotation.flags).toContain("starred");
+  });
+
+  it("PUT /api/annotations/:id adds tags", async () => {
+    const res = await fetch(`${baseUrl}/api/annotations/TEST-1`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ addTags: ["refactor"] }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { annotation: { tags: string[] } };
+    expect(data.annotation.tags).toContain("refactor");
+  });
+
+  it("PUT /api/annotations/:id adds notes", async () => {
+    const res = await fetch(`${baseUrl}/api/annotations/TEST-1`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ addNote: "flaky test" }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { annotation: { notes: Array<{ text: string }> } };
+    expect(data.annotation.notes.some((n) => n.text === "flaky test")).toBe(true);
+  });
+
+  it("DELETE /api/annotations/:id removes annotation", async () => {
+    await fetch(`${baseUrl}/api/annotations/TEST-DEL`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ displayName: "to delete" }),
+    });
+    const del = await fetch(`${baseUrl}/api/annotations/TEST-DEL`, {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(200);
+    const res = await fetch(`${baseUrl}/api/annotations`);
+    const data = (await res.json()) as { annotations: Record<string, unknown> };
+    expect(data.annotations["TEST-DEL"]).toBeUndefined();
+  });
+
+  it("PUT /api/annotations/:id rejects invalid flag values", async () => {
+    const res = await fetch(`${baseUrl}/api/annotations/TEST-1`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ addFlags: ["invalid-flag"] }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /api/annotations returns previously set annotations", async () => {
+    const res = await fetch(`${baseUrl}/api/annotations`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { annotations: Record<string, { displayName: string }> };
+    expect(data.annotations["TEST-1"]?.displayName).toBe("my worker");
+  });
+});
+
 describe("OTel API endpoints", () => {
   it("returns disabled status when OTel is not configured", async () => {
     const res = await fetch(`${baseUrl}/api/otel/status`);
@@ -338,6 +423,7 @@ describe("OTel API with mock clients", () => {
       linearFetcher: null,
       prometheusFetcher: mockProm,
       lokiFetcher: mockLoki,
+      annotationsDbPath: join(otelTmp, "annotations.db"),
     });
     otelUrl = `http://localhost:${otelServer.port}`;
   });
@@ -409,7 +495,7 @@ describe("SSE integration (file change -> SSE push)", () => {
       join(orchDir, "state.json"),
       JSON.stringify({ id: "orch-sse", waves: [] }),
     );
-    sseServer = createServer({ port: 0, wtDir, startWatcher: true });
+    sseServer = createServer({ port: 0, wtDir, startWatcher: true, annotationsDbPath: join(sseTmp, "annotations.db") });
   });
 
   afterAll(() => {
@@ -500,6 +586,7 @@ describe("SQLite session endpoints", () => {
       wtDir,
       startWatcher: false,
       dbPath,
+      annotationsDbPath: join(sessTmp, "annotations.db"),
     });
     sessBaseUrl = `http://localhost:${sessServer.port}`;
   });
@@ -604,6 +691,7 @@ describe("History API endpoints", () => {
       wtDir,
       startWatcher: false,
       dbPath: histDbPath,
+      annotationsDbPath: join(histTmp, "annotations.db"),
     });
     histBaseUrl = `http://localhost:${histServer.port}`;
   });
@@ -699,7 +787,7 @@ describe("SQLite session endpoints (no dbPath)", () => {
     sessTmp = mkdtempSync(join(tmpdir(), "orch-monitor-nodb-"));
     const wtDir = join(sessTmp, "wt");
     mkdirSync(wtDir, { recursive: true });
-    noDbServer = createServer({ port: 0, wtDir, startWatcher: false });
+    noDbServer = createServer({ port: 0, wtDir, startWatcher: false, annotationsDbPath: join(sessTmp, "annotations.db") });
     url = `http://localhost:${noDbServer.port}`;
   });
 
@@ -763,6 +851,7 @@ describe("AI briefing endpoint", () => {
         prStatusFetcher: null,
         linearFetcher: null,
         briefingProvider: mockProvider,
+        annotationsDbPath: join(bTmp!, "annotations.db"),
       });
 
       const bUrl = `http://localhost:${bServer.port}`;

--- a/plugins/dev/scripts/orch-monitor/catalyst-session.ts
+++ b/plugins/dev/scripts/orch-monitor/catalyst-session.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env bun
+import {
+  openDb,
+  closeDb,
+  setDisplayName,
+  addFlag,
+  removeFlag,
+  addNote,
+  addTag,
+  removeTag,
+  deleteAnnotation,
+  getAnnotation,
+  getAllAnnotations,
+} from "./lib/annotations";
+
+const VALID_FLAGS = new Set(["starred", "flagged", "archived"]);
+
+const CATALYST_DIR =
+  process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+
+function usage(): never {
+  console.error(
+    `Usage: catalyst-session <command> [options]
+
+Commands:
+  annotate <session-id>  Add/modify annotations for a session
+  list                   List all annotated sessions
+
+annotate options:
+  --name <text>          Set display name
+  --flag <flag>          Add flag (starred, flagged, archived)
+  --unflag <flag>        Remove flag
+  --note <text>          Add a note
+  --tag <tag>            Add tag (repeatable)
+  --untag <tag>          Remove tag
+  --clear                Remove all annotations for this session`,
+  );
+  process.exit(1);
+}
+
+function parseAnnotateArgs(args: string[]): {
+  sessionId: string;
+  name?: string | null;
+  flags: string[];
+  unflags: string[];
+  notes: string[];
+  tags: string[];
+  untags: string[];
+  clear: boolean;
+} {
+  if (args.length === 0) {
+    console.error("Error: annotate requires a session-id argument");
+    process.exit(1);
+  }
+
+  const sessionId = args[0];
+  const flags: string[] = [];
+  const unflags: string[] = [];
+  const notes: string[] = [];
+  const tags: string[] = [];
+  const untags: string[] = [];
+  let name: string | null | undefined;
+  let clear = false;
+
+  function requireValue(opt: string, i: number): string {
+    const val = args[i];
+    if (val === undefined) {
+      console.error(`Error: ${opt} requires a value`);
+      process.exit(1);
+    }
+    return val;
+  }
+
+  let i = 1;
+  while (i < args.length) {
+    const arg = args[i];
+    switch (arg) {
+      case "--name":
+        name = args[++i] ?? null;
+        break;
+      case "--flag": {
+        const val = requireValue("--flag", ++i);
+        if (!VALID_FLAGS.has(val)) {
+          console.error(
+            `Error: invalid flag "${val}". Valid: starred, flagged, archived`,
+          );
+          process.exit(1);
+        }
+        flags.push(val);
+        break;
+      }
+      case "--unflag":
+        unflags.push(requireValue("--unflag", ++i));
+        break;
+      case "--note":
+        notes.push(requireValue("--note", ++i));
+        break;
+      case "--tag":
+        tags.push(requireValue("--tag", ++i));
+        break;
+      case "--untag":
+        untags.push(requireValue("--untag", ++i));
+        break;
+      case "--clear":
+        clear = true;
+        break;
+      default:
+        console.error(`Unknown option: ${arg}`);
+        process.exit(1);
+    }
+    i++;
+  }
+
+  const hasAction =
+    name !== undefined ||
+    flags.length > 0 ||
+    unflags.length > 0 ||
+    notes.length > 0 ||
+    tags.length > 0 ||
+    untags.length > 0 ||
+    clear;
+
+  if (!hasAction) {
+    console.error("Error: annotate requires at least one option");
+    process.exit(1);
+  }
+
+  return { sessionId, name, flags, unflags, notes, tags, untags, clear };
+}
+
+function cmdAnnotate(args: string[]): void {
+  const parsed = parseAnnotateArgs(args);
+  const dbPath = `${CATALYST_DIR}/annotations.db`;
+  openDb(dbPath);
+
+  try {
+    if (parsed.clear) {
+      deleteAnnotation(parsed.sessionId);
+      console.info(`Cleared annotations for ${parsed.sessionId}`);
+      return;
+    }
+
+    if (parsed.name !== undefined) {
+      setDisplayName(parsed.sessionId, parsed.name);
+    }
+    for (const f of parsed.flags) addFlag(parsed.sessionId, f);
+    for (const f of parsed.unflags) removeFlag(parsed.sessionId, f);
+    for (const n of parsed.notes) addNote(parsed.sessionId, n);
+    for (const t of parsed.tags) addTag(parsed.sessionId, t);
+    for (const t of parsed.untags) removeTag(parsed.sessionId, t);
+
+    const ann = getAnnotation(parsed.sessionId);
+    if (ann) {
+      console.info(JSON.stringify(ann, null, 2));
+    }
+  } finally {
+    closeDb();
+  }
+}
+
+function cmdList(): void {
+  const dbPath = `${CATALYST_DIR}/annotations.db`;
+  openDb(dbPath);
+  try {
+    const all = getAllAnnotations();
+    console.info(JSON.stringify(all, null, 2));
+  } finally {
+    closeDb();
+  }
+}
+
+const [command, ...rest] = process.argv.slice(2);
+
+switch (command) {
+  case "annotate":
+    cmdAnnotate(rest);
+    break;
+  case "list":
+    cmdList();
+    break;
+  default:
+    usage();
+}

--- a/plugins/dev/scripts/orch-monitor/lib/annotations.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/annotations.ts
@@ -1,0 +1,197 @@
+import { Database } from "bun:sqlite";
+
+export interface NoteEntry {
+  text: string;
+  createdAt: string;
+}
+
+export interface SessionAnnotation {
+  sessionId: string;
+  displayName: string | null;
+  flags: string[];
+  notes: NoteEntry[];
+  tags: string[];
+  updatedAt: string;
+}
+
+let db: Database | null = null;
+
+const DEFAULT_DB_DIR =
+  process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+
+export function openDb(
+  dbPath: string = `${DEFAULT_DB_DIR}/annotations.db`,
+): Database {
+  if (db) return db;
+  db = new Database(dbPath, { create: true });
+  db.run("PRAGMA journal_mode=WAL");
+  db.run(`
+    CREATE TABLE IF NOT EXISTS session_annotations (
+      session_id TEXT PRIMARY KEY,
+      display_name TEXT,
+      flags TEXT NOT NULL DEFAULT '[]',
+      notes TEXT NOT NULL DEFAULT '[]',
+      tags TEXT NOT NULL DEFAULT '[]',
+      updated_at TEXT NOT NULL
+    )
+  `);
+  return db;
+}
+
+export function closeDb(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+function ensureDb(): Database {
+  if (!db) throw new Error("Database not opened — call openDb() first");
+  return db;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function parseJsonArray<T>(raw: string | null | undefined): T[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch (err) {
+    console.warn("[annotations] corrupt JSON in DB column:", raw, err);
+    return [];
+  }
+}
+
+interface RawRow {
+  session_id: string;
+  display_name: string | null;
+  flags: string;
+  notes: string;
+  tags: string;
+  updated_at: string;
+}
+
+function rowToAnnotation(row: RawRow): SessionAnnotation {
+  return {
+    sessionId: row.session_id,
+    displayName: row.display_name,
+    flags: parseJsonArray<string>(row.flags),
+    notes: parseJsonArray<NoteEntry>(row.notes),
+    tags: parseJsonArray<string>(row.tags),
+    updatedAt: row.updated_at,
+  };
+}
+
+export function getAnnotation(sessionId: string): SessionAnnotation | null {
+  const d = ensureDb();
+  const row = d
+    .query("SELECT * FROM session_annotations WHERE session_id = ?")
+    .get(sessionId) as RawRow | null;
+  return row ? rowToAnnotation(row) : null;
+}
+
+export function getAllAnnotations(): Record<string, SessionAnnotation> {
+  const d = ensureDb();
+  const rows = d
+    .query("SELECT * FROM session_annotations")
+    .all() as RawRow[];
+  const result: Record<string, SessionAnnotation> = {};
+  for (const row of rows) {
+    result[row.session_id] = rowToAnnotation(row);
+  }
+  return result;
+}
+
+function ensureRow(sessionId: string): void {
+  const d = ensureDb();
+  d.run(
+    `INSERT OR IGNORE INTO session_annotations (session_id, updated_at) VALUES (?, ?)`,
+    [sessionId, now()],
+  );
+}
+
+export function setDisplayName(
+  sessionId: string,
+  name: string | null,
+): void {
+  ensureRow(sessionId);
+  ensureDb().run(
+    `UPDATE session_annotations SET display_name = ?, updated_at = ? WHERE session_id = ?`,
+    [name, now(), sessionId],
+  );
+}
+
+export function addFlag(sessionId: string, flag: string): void {
+  ensureRow(sessionId);
+  const ann = getAnnotation(sessionId);
+  if (!ann || ann.flags.includes(flag)) return;
+  const updated = [...ann.flags, flag];
+  ensureDb().run(
+    `UPDATE session_annotations SET flags = ?, updated_at = ? WHERE session_id = ?`,
+    [JSON.stringify(updated), now(), sessionId],
+  );
+}
+
+export function removeFlag(sessionId: string, flag: string): void {
+  const ann = getAnnotation(sessionId);
+  if (!ann) return;
+  const updated = ann.flags.filter((f) => f !== flag);
+  if (updated.length === ann.flags.length) return;
+  ensureDb().run(
+    `UPDATE session_annotations SET flags = ?, updated_at = ? WHERE session_id = ?`,
+    [JSON.stringify(updated), now(), sessionId],
+  );
+}
+
+export function addNote(sessionId: string, text: string): void {
+  ensureRow(sessionId);
+  const ann = getAnnotation(sessionId);
+  if (!ann) return;
+  const updated = [...ann.notes, { text, createdAt: now() }];
+  ensureDb().run(
+    `UPDATE session_annotations SET notes = ?, updated_at = ? WHERE session_id = ?`,
+    [JSON.stringify(updated), now(), sessionId],
+  );
+}
+
+export function removeNote(sessionId: string, index: number): void {
+  const ann = getAnnotation(sessionId);
+  if (!ann || index < 0 || index >= ann.notes.length) return;
+  const updated = ann.notes.filter((_, i) => i !== index);
+  ensureDb().run(
+    `UPDATE session_annotations SET notes = ?, updated_at = ? WHERE session_id = ?`,
+    [JSON.stringify(updated), now(), sessionId],
+  );
+}
+
+export function addTag(sessionId: string, tag: string): void {
+  ensureRow(sessionId);
+  const ann = getAnnotation(sessionId);
+  if (!ann || ann.tags.includes(tag)) return;
+  const updated = [...ann.tags, tag];
+  ensureDb().run(
+    `UPDATE session_annotations SET tags = ?, updated_at = ? WHERE session_id = ?`,
+    [JSON.stringify(updated), now(), sessionId],
+  );
+}
+
+export function removeTag(sessionId: string, tag: string): void {
+  const ann = getAnnotation(sessionId);
+  if (!ann) return;
+  const updated = ann.tags.filter((t) => t !== tag);
+  if (updated.length === ann.tags.length) return;
+  ensureDb().run(
+    `UPDATE session_annotations SET tags = ?, updated_at = ? WHERE session_id = ?`,
+    [JSON.stringify(updated), now(), sessionId],
+  );
+}
+
+export function deleteAnnotation(sessionId: string): void {
+  ensureDb().run(
+    `DELETE FROM session_annotations WHERE session_id = ?`,
+    [sessionId],
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/public/index.html
+++ b/plugins/dev/scripts/orch-monitor/public/index.html
@@ -410,6 +410,63 @@
       .b-stalled, .b-blocked {
         background: rgba(234, 188, 59, 0.18); color: var(--yellow);
       }
+      /* --- Annotation UI --- */
+      .ann-star, .ann-flag { cursor: pointer; font-size: 14px; opacity: 0.3; transition: opacity 120ms; }
+      .ann-star:hover, .ann-flag:hover { opacity: 0.7; }
+      .ann-star.active { opacity: 1; color: #eabc3b; }
+      .ann-flag.active { opacity: 1; color: #ef5d5d; }
+      .ann-archived { opacity: 0.5; font-size: 10px; color: var(--muted); text-transform: uppercase; margin-left: 4px; }
+      .ann-tags { display: inline-flex; flex-wrap: wrap; gap: 3px; margin-left: 6px; vertical-align: middle; }
+      .ann-tag {
+        display: inline-block; font-size: 10px; padding: 1px 6px;
+        border-radius: 3px; background: rgba(78, 161, 255, 0.12); color: var(--accent);
+        font-family: ui-monospace, monospace; line-height: 1.4; cursor: default;
+      }
+      .ann-tag .ann-tag-x { cursor: pointer; margin-left: 4px; opacity: 0.5; }
+      .ann-tag .ann-tag-x:hover { opacity: 1; }
+      .ann-name-edit {
+        background: transparent; border: 1px solid var(--accent); border-radius: 3px;
+        color: var(--fg); font: inherit; padding: 1px 4px; width: 180px;
+      }
+      .card-head h2 .ann-display-name { cursor: pointer; }
+      .card-head h2 .ann-display-name:hover { text-decoration: underline; text-decoration-style: dashed; }
+      .ann-notes-btn { cursor: pointer; font-size: 12px; color: var(--muted); margin-left: 6px; }
+      .ann-notes-btn:hover { color: var(--accent); }
+      .ann-notes-drawer {
+        border-top: 1px solid var(--border); background: #0f1216;
+        padding: 10px 14px; display: none; font-size: 12px;
+      }
+      .ann-notes-drawer.open { display: block; }
+      .ann-notes-drawer .ann-note {
+        padding: 4px 0; border-bottom: 1px solid var(--border); color: var(--fg);
+      }
+      .ann-notes-drawer .ann-note:last-child { border-bottom: none; }
+      .ann-notes-drawer .ann-note-time { color: var(--muted); font-size: 10px; margin-left: 8px; }
+      .ann-notes-drawer .ann-note-add {
+        margin-top: 6px; display: flex; gap: 4px;
+      }
+      .ann-notes-drawer .ann-note-input {
+        flex: 1; background: var(--panel-2); border: 1px solid var(--border);
+        border-radius: 3px; color: var(--fg); font: inherit; padding: 3px 6px;
+      }
+      .ann-notes-drawer .ann-note-submit {
+        background: var(--accent); color: #fff; border: none; border-radius: 3px;
+        padding: 3px 10px; cursor: pointer; font-size: 12px;
+      }
+      .ann-add-tag-input {
+        background: transparent; border: 1px dashed var(--border); border-radius: 3px;
+        color: var(--accent); font: inherit; font-size: 10px; padding: 1px 4px; width: 60px;
+      }
+      .ann-add-tag-input::placeholder { color: var(--muted); }
+      .worker-table tbody tr.row-archived { opacity: 0.4; }
+      .ann-filter-tags { display: inline-flex; gap: 4px; margin-left: 12px; }
+      .ann-filter-tag {
+        font-size: 10px; padding: 2px 6px; border-radius: 3px;
+        background: rgba(78, 161, 255, 0.12); color: var(--accent);
+        cursor: pointer; font-family: ui-monospace, monospace;
+      }
+      .ann-filter-tag.active { background: var(--accent); color: #fff; }
+      .ann-filter-tag:hover { opacity: 0.8; }
       .b-unknown { background: var(--panel-2); color: var(--muted); }
       .alive { color: var(--green); font-weight: 600; }
       .dead { color: var(--red); font-weight: 600; }
@@ -1164,6 +1221,8 @@
         // Per-wave status "orchId:waveN" -> status
         const prevWaveStatus = new Map();
         let snapshotPrimed = false;
+        const annotationsMap = new Map();
+        let activeTagFilter = null;
 
         function esc(s) {
           return String(s == null ? "" : s)
@@ -1228,6 +1287,60 @@
 
         function statusClass(s) {
           return (s || "").replace(/[^a-z0-9_]/gi, "_");
+        }
+
+        function annFor(id) {
+          return annotationsMap.get(id) || null;
+        }
+
+        function renderOrchName(orchId) {
+          const ann = annFor(orchId);
+          const display = (ann && ann.displayName) || orchId;
+          const nameHtml =
+            '<span class="ann-display-name" data-ann-rename="' +
+            esc(orchId) + '" title="Click to rename">' +
+            esc(display) + "</span>";
+          const suffix = (ann && ann.displayName)
+            ? ' <span style="color:var(--muted);font-size:11px">(' + esc(orchId) + ")</span>"
+            : "";
+          return nameHtml + suffix;
+        }
+
+        function renderAnnotationControls(id) {
+          const ann = annFor(id);
+          const flags = (ann && ann.flags) || [];
+          const tags = (ann && ann.tags) || [];
+          const notes = (ann && ann.notes) || [];
+
+          const starCls = flags.includes("starred") ? " active" : "";
+          const flagCls = flags.includes("flagged") ? " active" : "";
+          const archived = flags.includes("archived");
+
+          let html =
+            '<span class="ann-star' + starCls + '" data-ann-flag="starred" data-ann-id="' +
+            esc(id) + '" title="Star">&#9733;</span>' +
+            '<span class="ann-flag' + flagCls + '" data-ann-flag="flagged" data-ann-id="' +
+            esc(id) + '" title="Flag">&#9873;</span>';
+          if (archived) {
+            html += '<span class="ann-archived">archived</span>';
+          }
+          if (notes.length > 0) {
+            html += '<span class="ann-notes-btn" data-ann-notes="' +
+              esc(id) + '" title="' + notes.length + ' note(s)">' +
+              notes.length + ' note' + (notes.length === 1 ? '' : 's') + '</span>';
+          }
+          if (tags.length > 0) {
+            html += '<span class="ann-tags">';
+            for (const t of tags) {
+              html +=
+                '<span class="ann-tag" data-ann-id="' + esc(id) +
+                '">' + esc(t) +
+                '<span class="ann-tag-x" data-ann-untag="' + esc(t) +
+                '" data-ann-id="' + esc(id) + '">x</span></span>';
+            }
+            html += '</span>';
+          }
+          return html;
         }
 
         function renderWorkerRow(orchId, ticket, w, waveNum) {
@@ -1329,12 +1442,22 @@
             ? '<td class="col-tokens">' + esc(fmtTokens(totalTokens)) + "</td>"
             : '<td class="col-tokens muted">—</td>';
 
+          const workerAnn = annFor(ticket);
+          const workerFlags = (workerAnn && workerAnn.flags) || [];
+          if (workerFlags.includes("archived")) rowStateCls += " row-archived";
+          if (activeTagFilter) {
+            const wTags = (workerAnn && workerAnn.tags) || [];
+            if (!wTags.includes(activeTagFilter)) return "";
+          }
+
+          const annCtrl = renderAnnotationControls(ticket);
+
           return (
             '<tr class="worker-row' + rowStateCls + '" data-orch="' + esc(orchId) +
             '" data-ticket="' + esc(ticket) +
             '" data-updated-at="' + esc(w.updatedAt || "") + '">' +
             '<td class="col-wave">' + (waveNum != null ? esc(waveNum) : "—") + "</td>" +
-            '<td class="col-ticket">' + ticketLink + "</td>" +
+            '<td class="col-ticket">' + ticketLink + " " + annCtrl + "</td>" +
             '<td class="col-label">' + (w.label ? '<span class="ct-label">' + esc(w.label) + '</span>' : '<span style="color:var(--muted)">—</span>') + "</td>" +
             '<td class="col-title">' + titleHtml + "</td>" +
             '<td><span class="badge ' + esc(badgeClass) + '">' + esc(stat) + "</span></td>" +
@@ -1773,7 +1896,7 @@
           return (
             '<div class="card" data-orch="' + esc(o.id) + '">' +
             '<div class="card-head">' +
-            "<h2>" + esc(o.id) + "</h2>" +
+            "<h2>" + renderOrchName(o.id) + "</h2>" +
             '<span class="meta">wave ' + esc(wavesInfo) + " · " +
             done + "/" + entries.length + " merged</span>" +
             '<span class="wave-bar"><span style="width:' + pct + '%"></span></span>' +
@@ -2578,6 +2701,42 @@
           }
         }
 
+        async function refreshAnnotations() {
+          try {
+            const resp = await fetch("/api/annotations");
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const anns = (data && data.annotations) || {};
+            annotationsMap.clear();
+            for (const key of Object.keys(anns)) {
+              annotationsMap.set(key, anns[key]);
+            }
+            render();
+          } catch (err) {
+            console.error("annotations refresh failed", err);
+          }
+        }
+
+        async function updateAnnotation(sessionId, body) {
+          try {
+            const resp = await fetch("/api/annotations/" + encodeURIComponent(sessionId), {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            });
+            if (!resp.ok) return null;
+            const data = await resp.json();
+            if (data && data.annotation) {
+              annotationsMap.set(sessionId, data.annotation);
+              render();
+            }
+            return data;
+          } catch (err) {
+            console.error("annotation update failed", err);
+            return null;
+          }
+        }
+
         async function refreshLinear() {
           try {
             const resp = await fetch("/api/linear");
@@ -2596,6 +2755,104 @@
 
         $orch.addEventListener("click", (e) => {
           if (e.target.closest("a")) return;
+
+          const flagEl = e.target.closest("[data-ann-flag]");
+          if (flagEl) {
+            const flag = flagEl.getAttribute("data-ann-flag");
+            const id = flagEl.getAttribute("data-ann-id");
+            if (!id || !flag) return;
+            const ann = annFor(id);
+            const flags = (ann && ann.flags) || [];
+            if (flags.includes(flag)) {
+              updateAnnotation(id, { removeFlags: [flag] });
+            } else {
+              updateAnnotation(id, { addFlags: [flag] });
+            }
+            return;
+          }
+
+          const untagEl = e.target.closest("[data-ann-untag]");
+          if (untagEl) {
+            const tag = untagEl.getAttribute("data-ann-untag");
+            const id = untagEl.getAttribute("data-ann-id");
+            if (id && tag) updateAnnotation(id, { removeTags: [tag] });
+            return;
+          }
+
+          const renameEl = e.target.closest("[data-ann-rename]");
+          if (renameEl) {
+            const id = renameEl.getAttribute("data-ann-rename");
+            if (!id) return;
+            const ann = annFor(id);
+            const current = (ann && ann.displayName) || "";
+            const input = document.createElement("input");
+            input.className = "ann-name-edit";
+            input.value = current;
+            input.placeholder = id;
+            renameEl.replaceWith(input);
+            input.focus();
+            input.select();
+            let saved = false;
+            const save = () => {
+              if (saved) return;
+              saved = true;
+              const val = input.value.trim();
+              updateAnnotation(id, { displayName: val || null });
+            };
+            input.addEventListener("blur", save);
+            input.addEventListener("keydown", (ev) => {
+              if (ev.key === "Enter") { ev.preventDefault(); input.blur(); }
+              if (ev.key === "Escape") { input.value = current; input.blur(); }
+            });
+            return;
+          }
+
+          const notesBtn = e.target.closest("[data-ann-notes]");
+          if (notesBtn) {
+            const id = notesBtn.getAttribute("data-ann-notes");
+            if (!id) return;
+            const row = notesBtn.closest("tr");
+            if (!row) return;
+            let drawer = row.nextElementSibling;
+            if (drawer && drawer.classList.contains("ann-notes-row")) {
+              drawer.remove();
+              return;
+            }
+            const ann = annFor(id);
+            const notes = (ann && ann.notes) || [];
+            const notesTr = document.createElement("tr");
+            notesTr.className = "ann-notes-row";
+            const td = document.createElement("td");
+            td.colSpan = 10;
+            td.className = "ann-notes-drawer open";
+            let notesHtml = notes.map((n, i) =>
+              '<div class="ann-note">' + esc(n.text) +
+              '<span class="ann-note-time">' +
+              new Date(n.createdAt).toLocaleString() + "</span></div>"
+            ).join("");
+            notesHtml += '<div class="ann-note-add">' +
+              '<input class="ann-note-input" placeholder="Add a note..." data-ann-id="' + esc(id) + '">' +
+              '<button class="ann-note-submit" data-ann-id="' + esc(id) + '">Add</button></div>';
+            td.innerHTML = notesHtml;
+            notesTr.appendChild(td);
+            row.after(notesTr);
+
+            const addBtn = td.querySelector(".ann-note-submit");
+            const noteInput = td.querySelector(".ann-note-input");
+            const submitNote = () => {
+              const text = noteInput.value.trim();
+              if (!text) return;
+              updateAnnotation(id, { addNote: text }).then((result) => {
+                if (result) notesTr.remove();
+              });
+            };
+            addBtn.addEventListener("click", submitNote);
+            noteInput.addEventListener("keydown", (ev) => {
+              if (ev.key === "Enter") submitNote();
+            });
+            return;
+          }
+
           const toggle = e.target.closest("[data-gantt-toggle]");
           if (toggle) {
             const orchId = toggle.getAttribute("data-gantt-toggle");
@@ -2743,6 +3000,8 @@
         setConnected("pending");
         connect();
         setInterval(updateTimers, 1000);
+        refreshAnnotations();
+        setInterval(refreshAnnotations, 15000);
         refreshAnalytics();
         setInterval(refreshAnalytics, 10000);
         refreshLinear();

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -47,6 +47,20 @@ import {
   apiErrors,
   costValidation,
 } from "./lib/otel-queries";
+import {
+  openDb,
+  closeDb,
+  getAllAnnotations,
+  getAnnotation,
+  setDisplayName,
+  addFlag,
+  removeFlag,
+  addNote,
+  removeNote,
+  addTag,
+  removeTag,
+  deleteAnnotation,
+} from "./lib/annotations";
 
 type BunServer = ReturnType<typeof Bun.serve>;
 
@@ -68,6 +82,7 @@ export interface CreateServerOptions {
   lokiUrl?: string | null;
   prometheusFetcher?: PrometheusFetcher | null;
   lokiFetcher?: LokiFetcher | null;
+  annotationsDbPath?: string;
 }
 
 export const DEFAULT_PORT = 7400;
@@ -206,9 +221,22 @@ export function createServer(opts: CreateServerOptions): BunServer {
     lokiUrl,
     prometheusFetcher: promFetcherOpt,
     lokiFetcher: lokiFetcherOpt,
+    annotationsDbPath,
   } = opts;
 
   const buildOpts: BuildSnapshotOptions = { dbPath };
+
+  const CATALYST_DIR =
+    process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+  const annDbPath = annotationsDbPath ?? `${CATALYST_DIR}/annotations.db`;
+  try {
+    openDb(annDbPath);
+  } catch (err) {
+    throw new Error(
+      `Failed to open annotations database at ${annDbPath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 
   const prFetcher: PrStatusFetcher | null =
     prStatusFetcher === null
@@ -542,6 +570,94 @@ export function createServer(opts: CreateServerOptions): BunServer {
           return Response.json({ data: result });
         }
 
+        if (url.pathname === "/api/annotations") {
+          return Response.json({ annotations: getAllAnnotations() });
+        }
+
+        const annMatch = url.pathname.match(
+          /^\/api\/annotations\/([A-Za-z0-9._-]+)$/,
+        );
+        if (annMatch && annMatch[1]) {
+          const sessionId = decodeURIComponent(annMatch[1]);
+
+          if (req.method === "DELETE") {
+            deleteAnnotation(sessionId);
+            return Response.json({ ok: true });
+          }
+
+          if (req.method === "PUT") {
+            let body: Record<string, unknown>;
+            try {
+              body = (await req.json()) as Record<string, unknown>;
+            } catch {
+              return Response.json(
+                { error: "Invalid JSON body" },
+                { status: 400 },
+              );
+            }
+
+            const VALID_FLAGS = new Set([
+              "starred",
+              "flagged",
+              "archived",
+            ]);
+
+            if (Array.isArray(body.addFlags)) {
+              for (const f of body.addFlags) {
+                if (typeof f !== "string" || !VALID_FLAGS.has(f)) {
+                  return Response.json(
+                    {
+                      error: `Invalid flag: ${String(f)}. Valid: starred, flagged, archived`,
+                    },
+                    { status: 400 },
+                  );
+                }
+              }
+            }
+
+            if (typeof body.displayName === "string") {
+              setDisplayName(sessionId, body.displayName);
+            } else if (body.displayName === null) {
+              setDisplayName(sessionId, null);
+            }
+
+            if (Array.isArray(body.addFlags)) {
+              for (const f of body.addFlags) {
+                if (typeof f === "string") addFlag(sessionId, f);
+              }
+            }
+            if (Array.isArray(body.removeFlags)) {
+              for (const f of body.removeFlags) {
+                if (typeof f === "string") removeFlag(sessionId, f);
+              }
+            }
+            if (typeof body.addNote === "string") {
+              addNote(sessionId, body.addNote);
+            }
+            if (
+              typeof body.removeNoteIndex === "number" &&
+              Number.isInteger(body.removeNoteIndex)
+            ) {
+              removeNote(sessionId, body.removeNoteIndex);
+            }
+            if (Array.isArray(body.addTags)) {
+              for (const t of body.addTags) {
+                if (typeof t === "string") addTag(sessionId, t);
+              }
+            }
+            if (Array.isArray(body.removeTags)) {
+              for (const t of body.removeTags) {
+                if (typeof t === "string") removeTag(sessionId, t);
+              }
+            }
+
+            const annotation = getAnnotation(sessionId);
+            return Response.json({ annotation });
+          }
+
+          return new Response("Method Not Allowed", { status: 405 });
+        }
+
         if (
           url.pathname === "/" ||
           url.pathname === "/index.html" ||
@@ -600,6 +716,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     prFetcher?.stop();
     linear?.stop();
     briefingProvider?.stop();
+    closeDb();
     sseClients.clear();
     if (pidFile) {
       try {


### PR DESCRIPTION
## Summary

- Add SQLite-backed annotation capabilities to orch-monitor sessions and orchestrators
- New `lib/annotations.ts` module using `bun:sqlite` for display names, flags, notes, and tags
- New `catalyst-session` CLI tool with `annotate` and `list` commands
- REST API endpoints (GET/PUT/DELETE `/api/annotations/:id`) with input validation
- Monitor UI: inline rename (click-to-edit), star/flag toggles, tag pills with remove, expandable notes drawer
- 42 new tests across 3 test files (unit, API, CLI integration)

## Test plan

- [x] Unit tests for all CRUD operations in annotations module (23 tests)
- [x] API endpoint tests for GET/PUT/DELETE annotations (8 tests)
- [x] CLI integration tests via Bun.spawnSync (11 tests)
- [x] TypeScript strict type checking passes
- [x] ESLint passes with zero errors
- [x] All 141 tests pass across 12 test files
- [x] Security review: parameterized SQL, XSS escaping, input validation
- [x] Code review: fixed silent failures, double-save bug, undefined injection

Closes CTL-47