### PR TITLE
feat(dev): add preview deployment links to orch-monitor

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"50a30643-b89c-49fe-8bba-7859ed37c257","pid":9492,"acquiredAt":1776192040813}

--- a/plugins/dev/scripts/orch-monitor/__tests__/preview-status.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/preview-status.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "bun:test";
+import {
+  createPreviewFetcher,
+  extractPreviewUrls,
+  mapDeploymentState,
+  DEFAULT_PREVIEW_PATTERNS,
+  type Runner,
+  type RunnerResult,
+} from "../lib/preview-status";
+
+function makeRunner(
+  responses: Map<string, RunnerResult> | ((args: string[]) => RunnerResult),
+): Runner {
+  return (args) => {
+    if (typeof responses === "function") return Promise.resolve(responses(args));
+    const key = args.join(" ");
+    return Promise.resolve(responses.get(key) ?? { stdout: "", ok: false });
+  };
+}
+
+describe("DEFAULT_PREVIEW_PATTERNS", () => {
+  it("includes common deployment providers", () => {
+    expect(DEFAULT_PREVIEW_PATTERNS).toContain("*.pages.dev");
+    expect(DEFAULT_PREVIEW_PATTERNS).toContain("*.vercel.app");
+    expect(DEFAULT_PREVIEW_PATTERNS).toContain("*.netlify.app");
+    expect(DEFAULT_PREVIEW_PATTERNS).toContain("*.up.railway.app");
+  });
+});
+
+describe("extractPreviewUrls", () => {
+  it("extracts Cloudflare Pages URLs from text", () => {
+    const text = "Visit the preview at https://abc-123.my-project.pages.dev for testing";
+    const urls = extractPreviewUrls(text);
+    expect(urls).toContain("https://abc-123.my-project.pages.dev");
+  });
+
+  it("extracts Vercel preview URLs", () => {
+    const text = "Preview: https://my-app-git-feat-abc.vercel.app";
+    const urls = extractPreviewUrls(text);
+    expect(urls).toContain("https://my-app-git-feat-abc.vercel.app");
+  });
+
+  it("extracts Railway preview URLs", () => {
+    const text = "Deploy: https://my-service-pr-42.up.railway.app/";
+    const urls = extractPreviewUrls(text);
+    expect(urls).toContain("https://my-service-pr-42.up.railway.app");
+  });
+
+  it("extracts Netlify preview URLs", () => {
+    const text = "https://deploy-preview-42--my-site.netlify.app is ready";
+    const urls = extractPreviewUrls(text);
+    expect(urls).toContain("https://deploy-preview-42--my-site.netlify.app");
+  });
+
+  it("extracts multiple URLs from the same text", () => {
+    const text =
+      "Frontend: https://app.pages.dev Backend: https://api.vercel.app";
+    const urls = extractPreviewUrls(text);
+    expect(urls.length).toBe(2);
+  });
+
+  it("deduplicates URLs", () => {
+    const text =
+      "https://app.pages.dev and again https://app.pages.dev";
+    const urls = extractPreviewUrls(text);
+    expect(urls.length).toBe(1);
+  });
+
+  it("returns empty array when no preview URLs found", () => {
+    const text = "No deployment links here, just https://github.com/foo/bar";
+    const urls = extractPreviewUrls(text);
+    expect(urls.length).toBe(0);
+  });
+
+  it("strips trailing slashes from URLs", () => {
+    const text = "https://app.pages.dev/";
+    const urls = extractPreviewUrls(text);
+    expect(urls[0]).toBe("https://app.pages.dev");
+  });
+
+  it("supports custom patterns", () => {
+    const text = "Preview at https://my-app.fly.dev/dashboard";
+    const urls = extractPreviewUrls(text, ["*.fly.dev"]);
+    expect(urls).toContain("https://my-app.fly.dev");
+  });
+
+  it("extracts URLs with paths but returns only the origin", () => {
+    const text = "https://abc.pages.dev/some/path?q=1";
+    const urls = extractPreviewUrls(text);
+    expect(urls[0]).toBe("https://abc.pages.dev");
+  });
+});
+
+describe("mapDeploymentState", () => {
+  it("maps success/active to live", () => {
+    expect(mapDeploymentState("success")).toBe("live");
+    expect(mapDeploymentState("active")).toBe("live");
+  });
+
+  it("maps pending/in_progress/queued to deploying", () => {
+    expect(mapDeploymentState("pending")).toBe("deploying");
+    expect(mapDeploymentState("in_progress")).toBe("deploying");
+    expect(mapDeploymentState("queued")).toBe("deploying");
+  });
+
+  it("maps error/failure to failed", () => {
+    expect(mapDeploymentState("error")).toBe("failed");
+    expect(mapDeploymentState("failure")).toBe("failed");
+  });
+
+  it("maps inactive to inactive", () => {
+    expect(mapDeploymentState("inactive")).toBe("inactive");
+  });
+
+  it("maps unknown states to unknown", () => {
+    expect(mapDeploymentState("something_else")).toBe("unknown");
+    expect(mapDeploymentState("")).toBe("unknown");
+  });
+});
+
+describe("createPreviewFetcher", () => {
+  it("get returns empty array when cache is empty", () => {
+    const fetcher = createPreviewFetcher({
+      runner: makeRunner(new Map()),
+    });
+    expect(fetcher.get("owner/repo", 1)).toEqual([]);
+  });
+
+  it("extracts preview URLs from PR comments", async () => {
+    const responses = new Map<string, RunnerResult>();
+    responses.set("gh --version", { stdout: "gh 2.0", ok: true });
+    responses.set(
+      "gh api repos/owner/repo/pulls/42/comments --paginate --jq .[].body",
+      {
+        stdout:
+          "Preview ready at https://my-app-abc123.pages.dev\nLGTM\n",
+        ok: true,
+      },
+    );
+    responses.set(
+      "gh api repos/owner/repo/deployments --jq [.[] | {environment, environment_url, state}]",
+      { stdout: "", ok: true },
+    );
+    const fetcher = createPreviewFetcher({ runner: makeRunner(responses) });
+    await fetcher.refreshAll([{ repo: "owner/repo", number: 42 }]);
+    const links = fetcher.get("owner/repo", 42);
+    expect(links.length).toBe(1);
+    expect(links[0].url).toBe("https://my-app-abc123.pages.dev");
+    expect(links[0].provider).toBe("cloudflare");
+    expect(links[0].source).toBe("comment");
+  });
+
+  it("extracts preview URLs from GitHub deployments API", async () => {
+    const responses = new Map<string, RunnerResult>();
+    responses.set("gh --version", { stdout: "gh 2.0", ok: true });
+    responses.set(
+      "gh api repos/owner/repo/pulls/42/comments --paginate --jq .[].body",
+      { stdout: "", ok: true },
+    );
+    responses.set(
+      "gh api repos/owner/repo/deployments --jq [.[] | {environment, environment_url, state}]",
+      {
+        stdout: JSON.stringify([
+          {
+            environment: "Preview",
+            environment_url: "https://preview-abc.vercel.app",
+            state: "success",
+          },
+        ]),
+        ok: true,
+      },
+    );
+    const fetcher = createPreviewFetcher({ runner: makeRunner(responses) });
+    await fetcher.refreshAll([{ repo: "owner/repo", number: 42 }]);
+    const links = fetcher.get("owner/repo", 42);
+    expect(links.length).toBe(1);
+    expect(links[0].url).toBe("https://preview-abc.vercel.app");
+    expect(links[0].provider).toBe("vercel");
+    expect(links[0].source).toBe("deployment");
+    expect(links[0].status).toBe("live");
+  });
+
+  it("deduplicates links across sources", async () => {
+    const responses = new Map<string, RunnerResult>();
+    responses.set("gh --version", { stdout: "gh 2.0", ok: true });
+    responses.set(
+      "gh api repos/o/r/pulls/1/comments --paginate --jq .[].body",
+      {
+        stdout: "Preview: https://app.pages.dev\n",
+        ok: true,
+      },
+    );
+    responses.set(
+      "gh api repos/o/r/deployments --jq [.[] | {environment, environment_url, state}]",
+      {
+        stdout: JSON.stringify([
+          {
+            environment: "Preview",
+            environment_url: "https://app.pages.dev",
+            state: "success",
+          },
+        ]),
+        ok: true,
+      },
+    );
+    const fetcher = createPreviewFetcher({ runner: makeRunner(responses) });
+    await fetcher.refreshAll([{ repo: "o/r", number: 1 }]);
+    const links = fetcher.get("o/r", 1);
+    expect(links.length).toBe(1);
+    expect(links[0].status).toBe("live");
+  });
+
+  it("degrades silently when gh probe fails", async () => {
+    const runner: Runner = (args) => {
+      if (args[1] === "--version")
+        return Promise.resolve({ stdout: "", ok: false });
+      throw new Error("should not be called");
+    };
+    const fetcher = createPreviewFetcher({ runner });
+    await fetcher.refreshAll([{ repo: "o/r", number: 1 }]);
+    expect(fetcher.get("o/r", 1)).toEqual([]);
+  });
+
+  it("degrades silently when comments API fails", async () => {
+    const responses = new Map<string, RunnerResult>();
+    responses.set("gh --version", { stdout: "gh 2.0", ok: true });
+    responses.set(
+      "gh api repos/o/r/pulls/1/comments --paginate --jq .[].body",
+      { stdout: "", ok: false },
+    );
+    responses.set(
+      "gh api repos/o/r/deployments --jq [.[] | {environment, environment_url, state}]",
+      { stdout: "", ok: true },
+    );
+    const fetcher = createPreviewFetcher({ runner: makeRunner(responses) });
+    await fetcher.refreshAll([{ repo: "o/r", number: 1 }]);
+    expect(fetcher.get("o/r", 1)).toEqual([]);
+  });
+
+  it("refreshAll on empty input is a no-op", async () => {
+    let calls = 0;
+    const runner: Runner = () => {
+      calls++;
+      return Promise.resolve({ stdout: "", ok: true });
+    };
+    const fetcher = createPreviewFetcher({ runner });
+    await fetcher.refreshAll([]);
+    expect(calls).toBe(0);
+  });
+
+  it("dedupes identical PR refs in a single refreshAll", async () => {
+    let apiCalls = 0;
+    const runner: Runner = (args) => {
+      if (args[1] === "--version")
+        return Promise.resolve({ stdout: "", ok: true });
+      apiCalls++;
+      return Promise.resolve({ stdout: "", ok: true });
+    };
+    const fetcher = createPreviewFetcher({ runner });
+    await fetcher.refreshAll([
+      { repo: "o/r", number: 1 },
+      { repo: "o/r", number: 1 },
+    ]);
+    expect(apiCalls).toBe(2);
+  });
+
+  it("start triggers immediate refresh and stop clears interval", async () => {
+    const responses = new Map<string, RunnerResult>();
+    responses.set("gh --version", { stdout: "gh 2.0", ok: true });
+    responses.set(
+      "gh api repos/o/r/pulls/1/comments --paginate --jq .[].body",
+      {
+        stdout: "https://app.pages.dev\n",
+        ok: true,
+      },
+    );
+    responses.set(
+      "gh api repos/o/r/deployments --jq [.[] | {environment, environment_url, state}]",
+      { stdout: "", ok: true },
+    );
+    const fetcher = createPreviewFetcher({ runner: makeRunner(responses) });
+    fetcher.start([{ repo: "o/r", number: 1 }], 60_000);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetcher.get("o/r", 1).length).toBe(1);
+    fetcher.stop();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -7,6 +7,7 @@ import { createServer, startTerminalOnly } from "../server";
 import type { BriefingProvider } from "../lib/ai-briefing";
 import type { MonitorSnapshot } from "../lib/state-reader";
 import type { LinearTicket } from "../lib/linear";
+import { createPreviewFetcher } from "../lib/preview-status";
 
 let server: ReturnType<typeof createServer>;
 let baseUrl: string;
@@ -916,5 +917,90 @@ describe("terminal mode", () => {
     expect(typeof handle.stop).toBe("function");
     handle.stop();
     rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe("Preview integration", () => {
+  let pvTmp: string;
+  let pvServer: ReturnType<typeof createServer>;
+  let pvUrl: string;
+
+  beforeAll(async () => {
+    pvTmp = mkdtempSync(join(tmpdir(), "orch-monitor-pv-"));
+    const wtDir = join(pvTmp, "wt");
+    mkdirSync(wtDir, { recursive: true });
+    const orchDir = join(wtDir, "orch-pv");
+    mkdirSync(join(orchDir, "workers"), { recursive: true });
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ id: "orch-pv", waves: [] }),
+    );
+    writeFileSync(
+      join(orchDir, "workers", "PV-1.json"),
+      JSON.stringify({
+        ticket: "PV-1",
+        orchestrator: "orch-pv",
+        workerName: "w",
+        status: "pr-created",
+        phase: 5,
+        startedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        pr: { number: 42, url: "https://github.com/test-org/test-repo/pull/42" },
+      }),
+    );
+
+    const fetcher = createPreviewFetcher({
+      runner: (args) => {
+        if (args[1] === "--version")
+          return Promise.resolve({ stdout: "gh 2.0", ok: true });
+        const key = args.join(" ");
+        if (key.includes("comments"))
+          return Promise.resolve({
+            stdout: "Preview: https://my-app.pages.dev\n",
+            ok: true,
+          });
+        if (key.includes("deployments"))
+          return Promise.resolve({ stdout: "[]", ok: true });
+        return Promise.resolve({ stdout: "", ok: true });
+      },
+    });
+
+    await fetcher.refreshAll([{ repo: "test-org/test-repo", number: 42 }]);
+
+    pvServer = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      prStatusFetcher: null,
+      linearFetcher: null,
+      previewFetcher: fetcher,
+      annotationsDbPath: join(pvTmp, "annotations.db"),
+    });
+    pvUrl = `http://localhost:${pvServer.port}`;
+  });
+
+  afterAll(() => {
+    void pvServer?.stop(true);
+    try {
+      rmSync(pvTmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("includes preview links in /api/snapshot after refresh", async () => {
+    const res = await fetch(`${pvUrl}/api/snapshot`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      orchestrators: Array<{
+        workers: Record<string, { previews?: Array<{ url: string; provider: string }> }>;
+      }>;
+    };
+    const worker = data.orchestrators[0]?.workers["PV-1"];
+    expect(worker).toBeDefined();
+    expect(worker?.previews).toBeDefined();
+    expect(worker?.previews?.length).toBeGreaterThan(0);
+    expect(worker?.previews?.[0]?.url).toBe("https://my-app.pages.dev");
+    expect(worker?.previews?.[0]?.provider).toBe("cloudflare");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/terminal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/terminal.test.ts
@@ -105,6 +105,7 @@ describe("renderSnapshot", () => {
     expect(out).toContain("PID");
     expect(out).toContain("AGE");
     expect(out).toContain("PR");
+    expect(out).toContain("PREVIEW");
   });
 
   it("includes ANSI color codes when status is a known non-default status", () => {
@@ -139,6 +140,45 @@ describe("renderSnapshot", () => {
     const snapshot = makeSnapshot([]);
     const out = renderSnapshot(snapshot);
     expect(typeof out).toBe("string");
+  });
+
+  it("renders preview provider when previews are present", () => {
+    const snapshot = makeSnapshot([
+      makeOrchestrator({
+        workers: {
+          "T-1": makeWorker({
+            ticket: "T-1",
+            previews: [
+              {
+                url: "https://my-app.pages.dev",
+                provider: "cloudflare",
+                status: "live",
+                source: "comment",
+              },
+            ],
+          }),
+        },
+      }),
+    ]);
+    const out = renderSnapshot(snapshot);
+    expect(out).toContain("cloudflare");
+    // GREEN color code for "live" status
+    expect(out).toContain("\x1b[32m");
+  });
+
+  it("renders dash for preview when no previews exist", () => {
+    const snapshot = makeSnapshot([
+      makeOrchestrator({
+        workers: {
+          "T-1": makeWorker({ ticket: "T-1" }),
+        },
+      }),
+    ]);
+    const out = renderSnapshot(snapshot);
+    // The preview column should contain a dash
+    const lines = out.split("\n");
+    const workerLine = lines.find((l) => l.includes("T-1") && !l.includes("TICKET"));
+    expect(workerLine).toBeDefined();
   });
 
   it("keeps visible line width <= 80 columns (excluding ANSI codes)", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/preview-status.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/preview-status.ts
@@ -1,0 +1,344 @@
+export interface PreviewLink {
+  url: string;
+  provider: "cloudflare" | "vercel" | "netlify" | "railway" | "unknown";
+  status: "deploying" | "live" | "failed" | "inactive" | "unknown";
+  source: "comment" | "deployment" | "description";
+}
+
+export interface PreviewRef {
+  repo: string;
+  number: number;
+}
+
+export interface RunnerResult {
+  stdout: string;
+  ok: boolean;
+}
+
+export type Runner = (args: string[]) => Promise<RunnerResult>;
+
+export interface PreviewFetcher {
+  get(repo: string, number: number): PreviewLink[];
+  refreshAll(prs: PreviewRef[]): Promise<void>;
+  start(prs: PreviewRef[], intervalMs: number): void;
+  stop(): void;
+}
+
+export interface CreatePreviewFetcherOptions {
+  runner?: Runner;
+  concurrency?: number;
+  patterns?: string[];
+}
+
+export const DEFAULT_PREVIEW_PATTERNS = [
+  "*.pages.dev",
+  "*.vercel.app",
+  "*.netlify.app",
+  "*.up.railway.app",
+];
+
+const PROVIDER_MAP: Record<string, PreviewLink["provider"]> = {
+  "pages.dev": "cloudflare",
+  "vercel.app": "vercel",
+  "netlify.app": "netlify",
+  "up.railway.app": "railway",
+};
+
+function patternToRegexSuffix(pattern: string): string {
+  return pattern.replace(/^\*\./, "").replace(/\./g, "\\.");
+}
+
+function buildUrlRegex(patterns: string[]): RegExp {
+  const suffixes = patterns.map(patternToRegexSuffix);
+  const alt = suffixes.join("|");
+  return new RegExp(
+    `https?://[a-zA-Z0-9][a-zA-Z0-9._-]*(?:${alt})(?:/[^\\s)\\]"'<>]*)?`,
+    "g",
+  );
+}
+
+function detectProvider(
+  url: string,
+  patterns: string[],
+): PreviewLink["provider"] {
+  for (const pattern of patterns) {
+    const suffix = pattern.replace(/^\*\./, "");
+    if (PROVIDER_MAP[suffix]) {
+      const dotSuffix = "." + suffix;
+      try {
+        const hostname = new URL(url).hostname;
+        if (hostname.endsWith(dotSuffix) || hostname === suffix) {
+          return PROVIDER_MAP[suffix];
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return "unknown";
+}
+
+function extractOrigin(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    return parsed.origin;
+  } catch {
+    return raw.replace(/\/+$/, "");
+  }
+}
+
+export function extractPreviewUrls(
+  text: string,
+  patterns: string[] = DEFAULT_PREVIEW_PATTERNS,
+): string[] {
+  const regex = buildUrlRegex(patterns);
+  const seen = new Set<string>();
+  const results: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    const origin = extractOrigin(match[0]);
+    if (seen.has(origin)) continue;
+    seen.add(origin);
+    results.push(origin);
+  }
+  return results;
+}
+
+export function mapDeploymentState(
+  state: string,
+): PreviewLink["status"] {
+  switch (state) {
+    case "success":
+    case "active":
+      return "live";
+    case "pending":
+    case "in_progress":
+    case "queued":
+      return "deploying";
+    case "error":
+    case "failure":
+      return "failed";
+    case "inactive":
+      return "inactive";
+    default:
+      return "unknown";
+  }
+}
+
+function cacheKey(repo: string, number: number): string {
+  return `${repo}#${number}`;
+}
+
+async function defaultRunner(args: string[]): Promise<RunnerResult> {
+  try {
+    const proc = Bun.spawn(args, {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const exit = await proc.exited;
+    return { stdout, ok: exit === 0 };
+  } catch {
+    return { stdout: "", ok: false };
+  }
+}
+
+interface DeploymentEntry {
+  environment?: string;
+  environment_url?: string;
+  state?: string;
+}
+
+export function createPreviewFetcher(
+  opts: CreatePreviewFetcherOptions = {},
+): PreviewFetcher {
+  const runner = opts.runner ?? defaultRunner;
+  const concurrency = Math.max(1, opts.concurrency ?? 3);
+  const patterns = opts.patterns ?? DEFAULT_PREVIEW_PATTERNS;
+  const cache = new Map<string, PreviewLink[]>();
+  let intervalHandle: ReturnType<typeof setInterval> | null = null;
+  let ghAvailable: boolean | null = null;
+  let ghProbeInFlight: Promise<boolean> | null = null;
+
+  async function probeGh(): Promise<boolean> {
+    if (ghAvailable !== null) return ghAvailable;
+    if (ghProbeInFlight) return ghProbeInFlight;
+    ghProbeInFlight = (async () => {
+      let ok: boolean;
+      try {
+        const res = await runner(["gh", "--version"]);
+        ok = res.ok;
+      } catch {
+        ok = false;
+      }
+      if (!ok) {
+        console.warn(
+          "[preview-status] gh CLI not available — preview status disabled",
+        );
+      }
+      ghAvailable = ok;
+      return ok;
+    })();
+    try {
+      return await ghProbeInFlight;
+    } finally {
+      ghProbeInFlight = null;
+    }
+  }
+
+  async function fetchCommentUrls(ref: PreviewRef): Promise<PreviewLink[]> {
+    const res = await runner([
+      "gh",
+      "api",
+      `repos/${ref.repo}/pulls/${ref.number}/comments`,
+      "--paginate",
+      "--jq",
+      ".[].body",
+    ]);
+    if (!res.ok) {
+      console.warn(
+        `[preview-status] comments fetch failed for ${ref.repo}#${ref.number}`,
+      );
+      return [];
+    }
+    const urls = extractPreviewUrls(res.stdout, patterns);
+    return urls.map((url) => ({
+      url,
+      provider: detectProvider(url, patterns),
+      status: "unknown" as const,
+      source: "comment" as const,
+    }));
+  }
+
+  async function fetchDeploymentUrls(
+    ref: PreviewRef,
+  ): Promise<PreviewLink[]> {
+    const res = await runner([
+      "gh",
+      "api",
+      `repos/${ref.repo}/deployments`,
+      "--jq",
+      "[.[] | {environment, environment_url, state}]",
+    ]);
+    if (!res.ok) {
+      console.warn(
+        `[preview-status] deployments fetch failed for ${ref.repo}`,
+      );
+      return [];
+    }
+
+    let entries: DeploymentEntry[];
+    try {
+      entries = JSON.parse(res.stdout) as DeploymentEntry[];
+    } catch (err) {
+      console.warn(
+        `[preview-status] deployments parse failed for ${ref.repo}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+      return [];
+    }
+    if (!Array.isArray(entries)) return [];
+
+    const links: PreviewLink[] = [];
+    for (const entry of entries) {
+      if (
+        typeof entry.environment_url !== "string" ||
+        entry.environment_url.length === 0
+      )
+        continue;
+      const origin = extractOrigin(entry.environment_url);
+      const matchesPattern = extractPreviewUrls(origin, patterns).length > 0;
+      if (!matchesPattern) continue;
+      links.push({
+        url: origin,
+        provider: detectProvider(origin, patterns),
+        status: mapDeploymentState(entry.state ?? ""),
+        source: "deployment",
+      });
+    }
+    return links;
+  }
+
+  function mergeLinks(
+    commentLinks: PreviewLink[],
+    deployLinks: PreviewLink[],
+  ): PreviewLink[] {
+    const byUrl = new Map<string, PreviewLink>();
+    for (const link of commentLinks) {
+      byUrl.set(link.url, link);
+    }
+    for (const link of deployLinks) {
+      const existing = byUrl.get(link.url);
+      if (!existing || existing.status === "unknown") {
+        byUrl.set(link.url, link);
+      }
+    }
+    return Array.from(byUrl.values());
+  }
+
+  async function fetchOne(ref: PreviewRef): Promise<void> {
+    const [commentLinks, deployLinks] = await Promise.all([
+      fetchCommentUrls(ref),
+      fetchDeploymentUrls(ref),
+    ]);
+    const merged = mergeLinks(commentLinks, deployLinks);
+    cache.set(cacheKey(ref.repo, ref.number), merged);
+  }
+
+  async function refreshAll(prs: PreviewRef[]): Promise<void> {
+    if (prs.length === 0) return;
+    const ok = await probeGh();
+    if (!ok) return;
+
+    const seen = new Set<string>();
+    const queue: PreviewRef[] = [];
+    for (const ref of prs) {
+      const k = cacheKey(ref.repo, ref.number);
+      if (seen.has(k)) continue;
+      seen.add(k);
+      queue.push(ref);
+    }
+
+    let cursor = 0;
+    async function worker(): Promise<void> {
+      while (cursor < queue.length) {
+        const idx = cursor++;
+        const ref = queue[idx];
+        if (!ref) return;
+        try {
+          await fetchOne(ref);
+        } catch (err) {
+          console.warn(
+            `[preview-status] fetch failed for ${ref.repo}#${ref.number}:`,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+    }
+
+    const workers: Promise<void>[] = [];
+    const n = Math.min(concurrency, queue.length);
+    for (let i = 0; i < n; i++) workers.push(worker());
+    await Promise.all(workers);
+  }
+
+  return {
+    get(repo: string, number: number): PreviewLink[] {
+      return cache.get(cacheKey(repo, number)) ?? [];
+    },
+    refreshAll,
+    start(prs: PreviewRef[], intervalMs: number): void {
+      if (intervalHandle !== null) return;
+      void refreshAll(prs);
+      intervalHandle = setInterval(() => {
+        void refreshAll(prs);
+      }, intervalMs);
+    },
+    stop(): void {
+      if (intervalHandle !== null) {
+        clearInterval(intervalHandle);
+        intervalHandle = null;
+      }
+    },
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
@@ -61,6 +61,12 @@ export interface WorkerState {
   prMergedAt?: string | null;
   fixupCommit?: string;
   followUpTo?: string;
+  previews?: Array<{
+    url: string;
+    provider: string;
+    status: string;
+    source: string;
+  }>;
 }
 
 export interface OrchestratorAnalytics {

--- a/plugins/dev/scripts/orch-monitor/lib/terminal.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/terminal.ts
@@ -22,6 +22,12 @@ const STATUS_COLORS: Record<string, string> = {
   dispatched: DIM,
 };
 
+const PREVIEW_STATUS_COLORS: Record<string, string> = {
+  live: GREEN,
+  deploying: YELLOW,
+  failed: RED,
+};
+
 export interface RenderOptions {
   compact?: boolean;
 }
@@ -34,6 +40,7 @@ const COL_STANDARD = {
   pid: 7,
   age: 6,
   pr: 8,
+  preview: 10,
 } as const;
 
 const COL_COMPACT = {
@@ -84,6 +91,14 @@ function formatAge(seconds: number): string {
   return `${Math.floor(seconds / 86400)}d`;
 }
 
+function formatPreview(w: WorkerState): string {
+  const previews = (w as WorkerState & { previews?: Array<{ provider: string; status: string }> }).previews;
+  if (!previews || previews.length === 0) return pad("-", COL_STANDARD.preview);
+  const first = previews[0];
+  const color = PREVIEW_STATUS_COLORS[first.status];
+  return colorize(pad(first.provider, COL_STANDARD.preview), color);
+}
+
 function renderWorkerRow(w: WorkerState, opts?: RenderOptions): string {
   const col = getCols(opts);
   const statusColor = STATUS_COLORS[w.status];
@@ -104,7 +119,8 @@ function renderWorkerRow(w: WorkerState, opts?: RenderOptions): string {
   const label = pad(w.label || "-", stdCol.label);
   const pidStr = w.pid == null ? "-" : String(w.pid);
   const pid = padLeft(w.alive ? pidStr : `${pidStr}!`, stdCol.pid);
-  return `${ticket} ${label} ${status} ${phase} ${pid} ${age} ${pr}`;
+  const preview = formatPreview(w);
+  return `${ticket} ${label} ${status} ${phase} ${pid} ${age} ${pr} ${preview}`;
 }
 
 function renderOrchestrator(
@@ -130,6 +146,9 @@ function renderOrchestrator(
   }
   headParts.push(padLeft("AGE", col.age));
   headParts.push(pad("PR", col.pr));
+  if (!opts?.compact) {
+    headParts.push(pad("PREVIEW", (col as typeof COL_STANDARD).preview));
+  }
   lines.push(BOLD + headParts.join(" ") + RESET);
 
   const workers = Object.values(orch.workers);

--- a/plugins/dev/scripts/orch-monitor/public/index.html
+++ b/plugins/dev/scripts/orch-monitor/public/index.html
@@ -320,6 +320,14 @@
       .worker-table .col-pr a { font-family: ui-monospace, monospace; }
       .worker-table .col-pr .pr-merged-note { color: var(--green); margin-left: 6px; font-size: 11px; font-weight: 600; }
       .worker-table .col-pr .pr-closed-link { color: var(--muted); text-decoration: line-through; }
+      .worker-table .col-preview { white-space: nowrap; }
+      .preview-badge { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; }
+      .pv-live { background: rgba(57, 208, 122, 0.18); color: var(--green); }
+      .pv-deploying { background: rgba(234, 188, 59, 0.18); color: var(--yellow); }
+      .pv-failed { background: rgba(239, 93, 93, 0.18); color: var(--red); }
+      .pv-inactive { background: rgba(107, 114, 128, 0.3); color: #cfd4dc; }
+      .pv-unknown { background: rgba(107, 114, 128, 0.3); color: var(--muted); }
+      .preview-more { color: var(--muted); font-size: 11px; margin-left: 4px; }
       .worker-table .col-age { font-family: ui-monospace, monospace; color: var(--muted); white-space: nowrap; }
       .worker-table .col-age.stale { color: var(--red); }
       .worker-table .col-cost,
@@ -1343,6 +1351,17 @@
           return html;
         }
 
+        function renderPreviewCell(w) {
+          var previews = w.previews;
+          if (!previews || !previews.length) return '<span style="color:var(--muted)">—</span>';
+          var first = previews[0];
+          var cls = "pv-" + statusClass(first.status || "unknown");
+          var html = '<a href="' + esc(first.url) + '" target="_blank" rel="noopener">' +
+            '<span class="preview-badge ' + cls + '">' + esc(first.provider) + '</span></a>';
+          if (previews.length > 1) html += '<span class="preview-more">+' + (previews.length - 1) + '</span>';
+          return html;
+        }
+
         function renderWorkerRow(orchId, ticket, w, waveNum) {
           const stat = w.status || "unknown";
           const badgeClass = "b-" + statusClass(stat);
@@ -1464,6 +1483,7 @@
             '<td class="col-phase">' + esc(w.phase ?? 0) + "</td>" +
             "<td>" + aliveCell + "</td>" +
             '<td class="col-pr">' + prCell + "</td>" +
+            '<td class="col-preview">' + renderPreviewCell(w) + "</td>" +
             costCell +
             tokensCell +
             '<td class="' + ageCls + '" data-since="1">' + fmtSince(tsu) + "</td>" +
@@ -1916,7 +1936,7 @@
             "</div>" +
             '<table class="worker-table"><thead><tr>' +
             "<th>Wave</th><th>Ticket</th><th>Label</th><th>Title</th><th>Status</th><th>Phase</th>" +
-            "<th>Process</th><th>PR</th>" +
+            "<th>Process</th><th>PR</th><th>Preview</th>" +
             '<th class="th-num">Cost</th><th class="th-num">Tokens</th>' +
             "<th>Last update</th>" +
             "</tr></thead><tbody>" + tableRows + "</tbody></table>" +

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -32,6 +32,10 @@ import {
   type LinearTicket,
 } from "./lib/linear";
 import type { BriefingProvider } from "./lib/ai-briefing";
+import {
+  createPreviewFetcher,
+  type PreviewFetcher,
+} from "./lib/preview-status";
 import { loadOtelConfig } from "./lib/otel-config";
 import {
   createPrometheusFetcher,
@@ -83,6 +87,8 @@ export interface CreateServerOptions {
   lokiUrl?: string | null;
   prometheusFetcher?: PrometheusFetcher | null;
   lokiFetcher?: LokiFetcher | null;
+  previewFetcher?: PreviewFetcher | null;
+  previewRefreshMs?: number;
   annotationsDbPath?: string;
   terminal?: boolean;
   renderOptions?: RenderOptions;
@@ -90,6 +96,7 @@ export interface CreateServerOptions {
 
 export const DEFAULT_PORT = 7400;
 export const PR_STATUS_REFRESH_MS = 30_000;
+export const PREVIEW_REFRESH_MS = 30_000;
 export const LINEAR_REFRESH_MS = 5 * 60_000;
 
 function collectTicketKeys(snapshot: MonitorSnapshot): string[] {
@@ -150,6 +157,22 @@ function applyPrStatus(
   }
   return snapshot;
 }
+
+function applyPreviewStatus(
+  snapshot: MonitorSnapshot,
+  fetcher: PreviewFetcher,
+): void {
+  for (const orch of snapshot.orchestrators) {
+    for (const worker of Object.values(orch.workers)) {
+      if (!worker.pr) continue;
+      const repo = parseRepoFromPrUrl(worker.pr.url);
+      if (!repo) continue;
+      const links = fetcher.get(repo, worker.pr.number);
+      if (links.length > 0) worker.previews = links;
+    }
+  }
+}
+
 const SSE_EVENTS = EVENT_TYPES;
 const ALLOWED_PUBLIC_EXTENSIONS = new Set([
   ".html",
@@ -224,6 +247,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
     lokiUrl,
     prometheusFetcher: promFetcherOpt,
     lokiFetcher: lokiFetcherOpt,
+    previewFetcher: previewFetcherOpt,
+    previewRefreshMs = PREVIEW_REFRESH_MS,
     annotationsDbPath,
   } = opts;
 
@@ -266,6 +291,12 @@ export function createServer(opts: CreateServerOptions): BunServer {
       ? null
       : (lokiFetcherOpt ?? (lokiUrl ? createLokiFetcher({ baseUrl: lokiUrl }) : null));
 
+  const previewFetcher: PreviewFetcher | null =
+    previewFetcherOpt === null
+      ? null
+      : (previewFetcherOpt ?? createPreviewFetcher());
+  let lastPreviewRefresh = 0;
+
   function snapshotWithPrStatus(): MonitorSnapshot {
     const snap = buildSnapshot(wtDir, buildOpts);
     if (prFetcher) {
@@ -276,6 +307,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
         if (refs.length > 0) void prFetcher.refreshAll(refs);
       }
       applyPrStatus(snap, prFetcher);
+    }
+    if (previewFetcher) {
+      const now = Date.now();
+      if (now - lastPreviewRefresh >= previewRefreshMs) {
+        lastPreviewRefresh = now;
+        const refs = collectPrRefs(snap);
+        if (refs.length > 0) void previewFetcher.refreshAll(refs);
+      }
+      applyPreviewStatus(snap, previewFetcher);
     }
     if (linear && !linearStarted) {
       linearStarted = true;
@@ -721,6 +761,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     for (const u of unsubscribers) u();
     watcher?.stop();
     prFetcher?.stop();
+    previewFetcher?.stop();
     linear?.stop();
     briefingProvider?.stop();
     closeDb();


### PR DESCRIPTION
## Summary

- Add preview deployment URL detection and display to the orchestration monitor (CTL-53)
- New `lib/preview-status.ts` module scans PR comments and GitHub Deployments API for preview URLs from Cloudflare Pages, Vercel, Netlify, and Railway
- Clickable preview badges in the web UI with deployment status colors (live=green, deploying=yellow, failed=red)
- Preview column in terminal ANSI output
- Configurable URL patterns via `CreatePreviewFetcherOptions`
- Follows existing fetcher pattern (injectable runner, cache, concurrency pool, gh probe)

## Test plan

- [x] 25 unit tests for `preview-status.ts` (URL extraction, state mapping, deduplication, degradation)
- [x] 1 integration test verifying preview links flow through snapshot API
- [x] 2 terminal rendering tests for preview column
- [x] All 127 existing + new tests pass
- [x] TypeScript strict mode — `tsc --noEmit` clean
- [x] ESLint clean (0 errors, 1 expected warning for non-literal RegExp)
- [x] Security audit clean
- [x] Security review: fixed jq filter bug, added error logging, XSS-safe class sanitization

Closes CTL-53