### PR TITLE
chore(meta): documentation audit fixes — stale refs, missing tools, prefix consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ This workspace has no build process - it's markdown files and bash scripts.
 - **Single source of truth** — Don't duplicate information across files:
   - CLI syntax lives in skills (e.g., `linearis` skill) — reference it, don't copy
   - Workflow logic lives in skills — each skill owns its own state transitions
-  - Config schema lives in `website/reference/configuration.md`
+  - Config schema lives in `website/src/content/docs/reference/configuration.md`
 - **Spawn parallel agents** — Maximize efficiency
 - **Agents are documentarians** — Never suggest improvements unless asked
 - **Preserve context** — Save to thoughts/, not just memory
@@ -88,7 +88,7 @@ Two-layer config system:
 
 **Required**: Claude Code, Git, Bash
 
-**Optional**: HumanLayer CLI (`humanlayer`), Linearis CLI (`linearis`), GitHub CLI (`gh`)
+**Optional**: HumanLayer CLI (`humanlayer`, being removed — see CTL-58), Linearis CLI (`linearis`), GitHub CLI (`gh`), `catalyst-session` CLI (`plugins/dev/scripts/catalyst-session.sh`), `sqlite3`
 
 ## Plugin Development
 

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -128,6 +128,7 @@ orchestrator snapshots archived to `~/catalyst/history/`.
 ```
 ~/catalyst/
 ├── state.json              # Global registry (active orchestrators only)
+├── catalyst.db             # SQLite session store (WAL mode)
 ├── events/                 # Append-only event stream, rotated monthly
 │   ├── 2026-03.jsonl
 │   └── 2026-04.jsonl
@@ -156,3 +157,37 @@ orchestrator snapshots archived to `~/catalyst/history/`.
 - Dashboards (terminal, web) have a stable JSON contract to build against
 - The schemas at `plugins/dev/templates/global-state.json` and `global-event.json` define the
   contract for forward compatibility
+
+---
+
+## ADR-008: SQLite Session Store
+
+**Decision**: Replace JSONL event streams with a SQLite database (`~/catalyst/catalyst.db`) as the
+durable source of truth for agent session data, managed by `catalyst-db.sh` and `catalyst-session.sh`.
+
+**Rationale**:
+
+- JSONL event files grow unbounded and require full scans for queries
+- Cross-session analytics (cost rollups, tool histograms, duration trends) are expensive over flat files
+- SQLite provides ACID transactions, indexed queries, and WAL-mode concurrent readers — all with zero
+  server dependencies
+- A CLI wrapper (`catalyst-session.sh`) gives skills a sub-50ms write interface without importing
+  library code
+
+**Schema** (`plugins/dev/scripts/db-migrations/001_initial_schema.sql`):
+
+- `sessions` — One row per agent run (skill, ticket, workflow, status, timestamps)
+- `session_events` — Phase transitions, PR opens, heartbeats (typed, append-only)
+- `session_metrics` — Cost and token counters (upserted per session)
+- `session_tools` — Tool usage histograms (tool name → call count, total duration)
+- `session_prs` — PRs created during a session (number, URL, CI status)
+- `schema_migrations` — Applied migration versions
+
+**Consequences**:
+
+- Skills call `catalyst-session.sh start|phase|metric|tool|pr|end` instead of writing JSON directly
+- `catalyst-db.sh` handles schema init, migration, and low-level CRUD
+- Dual-write to `~/catalyst/events/YYYY-MM.jsonl` continues during the migration period for backward
+  compatibility with tools that still consume the JSONL stream
+- `orch-monitor` reads the SQLite store directly (WAL mode allows concurrent readers)
+- `sqlite3` is now listed as an optional dependency

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,11 +65,13 @@ orchestrators and workers write to via `catalyst-state.sh` (lock-protected).
 ```
 
 - **catalyst.db**: SQLite-backed session store — durable source of truth for agent activity
-  (solo and orchestrated). Managed by `catalyst-db.sh`. Tables: `sessions`, `session_events`,
-  `session_metrics`, `session_tools`, `session_prs`, `schema_migrations`. Writers run in WAL
-  mode so monitor-style readers can operate concurrently. `catalyst-state.sh` continues to
-  write JSON/JSONL during the migration period for backward compatibility. Schema lives at
-  `plugins/dev/scripts/db-migrations/`.
+  (solo and orchestrated). Managed by `catalyst-db.sh` (low-level CRUD, migrations) and
+  `catalyst-session.sh` (high-level lifecycle CLI used by instrumented skills). Tables:
+  `sessions`, `session_events`, `session_metrics`, `session_tools`, `session_prs`,
+  `schema_migrations`. Writers run in WAL mode so monitor-style readers (including
+  `orch-monitor`) can operate concurrently. `catalyst-state.sh` continues to write JSON/JSONL
+  during the migration period for backward compatibility. Schema lives at
+  `plugins/dev/scripts/db-migrations/`. See ADR-008.
 
 - **state.json**: Registry of active orchestrators with progress, worker status, and attention
   items. Queryable with `jq`. Schema: `plugins/dev/templates/global-state.json`.

--- a/plugins/dev/README.md
+++ b/plugins/dev/README.md
@@ -97,7 +97,7 @@ curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-c
 ## Requirements
 
 - **Required**: Git, Bash
-- **Recommended**: HumanLayer CLI (`pip install humanlayer`) for the thoughts system and context-isolated worker launches
+- **Optional**: HumanLayer CLI (`pip install humanlayer`) for the thoughts system and context-isolated worker launches (being removed — see CTL-58)
 - **Optional**: Linearis CLI (`npm install -g linearis`) for Linear integration
 - **Optional**: GitHub CLI (`brew install gh`) for PR workflows
 
@@ -105,13 +105,19 @@ curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-c
 
 Runtime utilities under `scripts/`:
 
-- `catalyst-state.sh` — Writes to `~/catalyst/state.json` and `~/catalyst/events.jsonl`
+- `catalyst-db.sh` — SQLite session store CRUD and schema migrations (see ADR-008)
+- `catalyst-monitor.sh` — On-demand orch-monitor server management (`start`, `stop`, `status`, `open`, `url`)
+- `catalyst-session.sh` — Lifecycle CLI for agent sessions (`start`, `phase`, `metric`, `tool`, `pr`, `end`, `heartbeat`, `list`, `read`, `history`). Writes to SQLite via `catalyst-db.sh` and dual-writes JSONL events for backward compatibility
+- `catalyst-state.sh` — Writes to `~/catalyst/state.json` and `~/catalyst/events/YYYY-MM.jsonl`
 - `check-prerequisites.sh` — Validate tool availability
 - `check-project-setup.sh` — Validate workspace has thoughts system, config, etc.
 - `create-worktree.sh` — Worktree creation with setup hooks
 - `frontmatter-utils.sh` — Parse and update markdown frontmatter
-- `orch-monitor/` — Web + terminal dashboard (Bun server, see [Observability](https://catalyst.coalescelabs.ai/observability/))
+- `orch-monitor/` — React SPA + Bun server dashboard (default port 7400, configurable via `MONITOR_PORT`). Reads `~/catalyst/catalyst.db` (SQLite, WAL mode) and watches `~/catalyst/wt/`. Start with `cd plugins/dev/scripts/orch-monitor && bun run server.ts`, or use `catalyst-monitor.sh open`
+- `orchestrate-fixup` — Fix issues found during orchestration verification
+- `orchestrate-followup` — Handle follow-up tasks after orchestration completes
 - `orchestrate-verify.sh` — Adversarial verification checks (test existence, reward-hacking patterns)
+- `pre-assign-migrations.sh` — Pre-assign database migration numbers to avoid conflicts
 - `resolve-ticket.sh` — Extract ticket IDs from various contexts
 - `workflow-context.sh` — Read/write `.catalyst/.workflow-context.json`
 

--- a/plugins/pm/README.md
+++ b/plugins/pm/README.md
@@ -54,7 +54,7 @@ exactly what action to take after reading any report.
 
 ### Cycle Management
 
-- `/analyze-cycle` - Analyze cycle health with actionable insights
+- `/catalyst-pm:analyze-cycle` - Analyze cycle health with actionable insights
   - Health assessment (🟢/🟡/🔴)
   - Risk identification (blockers, at-risk issues)
   - Team capacity analysis
@@ -62,13 +62,13 @@ exactly what action to take after reading any report.
 
 ### Milestone Management
 
-- `/analyze-milestone` - Analyze milestone health toward target date
+- `/catalyst-pm:analyze-milestone` - Analyze milestone health toward target date
   - Target date feasibility assessment
   - Progress tracking (actual vs expected)
   - Risk identification (behind schedule, blockers)
   - Specific recommendations (adjust timeline, reduce scope)
 
-### `/analyze-cycle`
+### `/catalyst-pm:analyze-cycle`
 
 Generate comprehensive cycle health report with recommendations.
 
@@ -98,13 +98,13 @@ Priority Actions:
 
 ### Daily Operations
 
-- `/report-daily` - Quick daily standup report
+- `/catalyst-pm:report-daily` - Quick daily standup report
   - Yesterday's deliveries
   - Current work in progress
   - Team members needing assignments
   - Quick blockers/risks
 
-### `/report-daily`
+### `/catalyst-pm:report-daily`
 
 Quick daily standup report (scannable in <30 seconds).
 
@@ -130,14 +130,14 @@ Quick daily standup report (scannable in <30 seconds).
 
 ### Backlog Health
 
-- `/groom-backlog` - Analyze backlog health
+- `/catalyst-pm:groom-backlog` - Analyze backlog health
   - Orphaned issues (no project)
   - Misplaced issues (wrong project)
   - Stale issues (>30 days inactive)
   - Potential duplicates
   - Missing estimates
 
-### `/groom-backlog`
+### `/catalyst-pm:groom-backlog`
 
 Analyze backlog health and generate cleanup recommendations.
 
@@ -159,13 +159,13 @@ Analyze backlog health and generate cleanup recommendations.
 
 ### GitHub-Linear Sync
 
-- `/sync-prs` - Correlate GitHub PRs with Linear issues
+- `/catalyst-pm:sync-prs` - Correlate GitHub PRs with Linear issues
   - Orphaned PRs (no Linear issue)
   - Orphaned issues (no PR)
   - Ready to close (PR merged, issue open)
   - Stale PRs (>14 days)
 
-### `/sync-prs`
+### `/catalyst-pm:sync-prs`
 
 Correlate GitHub PRs with Linear issues and identify gaps.
 
@@ -192,13 +192,13 @@ Health Score: 75/100
 
 ### Context Engineering
 
-- `/context-daily` - Generate daily context engineering adoption dashboard
+- `/catalyst-pm:context-daily` - Generate daily context engineering adoption dashboard
   - Cross-repo analysis (code vs thoughts activity)
   - Identify developers NOT using context engineering
   - Individual adoption scores
   - 28-day trend analysis
 
-### `/context-daily`
+### `/catalyst-pm:context-daily`
 
 Track context engineering adoption by cross-referencing code and thoughts repository activity.
 
@@ -371,7 +371,10 @@ PM commands read from two config sources:
 }
 ```
 
-**Setup**: Run `./scripts/setup-catalyst-config.sh` to configure your project
+**Setup**: Create both files manually, or use the `setup-catalyst.sh` script from the project root:
+```bash
+curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh | bash
+```
 
 ## Installation
 
@@ -415,7 +418,7 @@ cd /path/to/your/project
 **Morning Standup**:
 
 ```bash
-/context-daily
+/catalyst-pm:context-daily
 ```
 
 - See what shipped yesterday
@@ -428,7 +431,7 @@ cd /path/to/your/project
 **Start of Week**:
 
 ```bash
-/analyze-cycle
+/catalyst-pm:analyze-cycle
 ```
 
 - Assess cycle health
@@ -439,7 +442,7 @@ cd /path/to/your/project
 **Mid-Week**:
 
 ```bash
-/sync-prs
+/catalyst-pm:sync-prs
 ```
 
 - Check GitHub-Linear correlation
@@ -449,7 +452,7 @@ cd /path/to/your/project
 **End of Week**:
 
 ```bash
-/groom-backlog
+/catalyst-pm:groom-backlog
 ```
 
 - Clean up orphaned issues


### PR DESCRIPTION
## Summary

Closes CTL-70. Full documentation audit fixing stale references, adding missing tool documentation, and enforcing skill prefix consistency across CLAUDE.md, architecture.md, ADRs, and plugin READMEs.

### Stale references fixed
- **CLAUDE.md**: Config path `website/reference/configuration.md` → actual path at `website/src/content/docs/reference/configuration.md`
- **CLAUDE.md**: HumanLayer marked "Optional (being removed — see CTL-58)", added `catalyst-session` and `sqlite3` as optional deps
- **dev README**: HumanLayer changed from "Recommended" → "Optional (being removed)" to align with CLAUDE.md
- **dev README**: Events path fixed from `events.jsonl` → `events/YYYY-MM.jsonl`
- **PM README**: Removed stale `./scripts/setup-catalyst-config.sh` reference (file doesn't exist), replaced with working setup command

### Missing documentation added
- **ADR-008**: New ADR for SQLite session store decision (catalyst-db.sh, catalyst-session.sh, schema, migration strategy)
- **ADR-006**: Design tree updated with `catalyst.db`
- **architecture.md**: Expanded catalyst.db section to reference both `catalyst-db.sh` and `catalyst-session.sh`, plus ADR-008
- **dev README Scripts**: Added 6 missing scripts: `catalyst-db.sh`, `catalyst-monitor.sh`, `catalyst-session.sh`, `orchestrate-fixup`, `orchestrate-followup`, `pre-assign-migrations.sh`
- **dev README**: Orch-monitor entry expanded with local setup instructions (port, env var, start command, SQLite reader)

### Prefix consistency
- **PM README**: All 12 bare skill references (`/analyze-cycle`, `/report-daily`, etc.) updated to use full `catalyst-pm:` prefix per `.claude/rules/skill-references.md`

## Test plan

- [ ] Verify `website/src/content/docs/reference/configuration.md` exists at the referenced path
- [ ] Confirm all script files referenced in dev README exist in `plugins/dev/scripts/`
- [ ] Grep PM README for any remaining bare `/skill-name` references (should be zero)
- [ ] Verify no remaining references to `setup-catalyst-config.sh` anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)