### PR TITLE
feat(dev): standalone setup-orchestrator.sh for external automation

### DIFF
--- a/plugins/dev/scripts/setup-orchestrator.sh
+++ b/plugins/dev/scripts/setup-orchestrator.sh
@@ -76,21 +76,11 @@ log() {
   fi
 }
 
-# ─── Step 1: Validate — must be main repo root, not a worktree ───────────────
+# ─── Step 1: Validate — must be in a git repo ────────────────────────────────
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [[ -z "$REPO_ROOT" ]]; then
   echo "ERROR: Not in a git repository" >&2
-  exit 1
-fi
-
-COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
-GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
-
-if [[ "$COMMON_DIR" != "$GIT_DIR" ]]; then
-  MAIN_REPO=$(git -C "$(git rev-parse --git-common-dir)" rev-parse --show-toplevel 2>/dev/null || true)
-  echo "ERROR: You are inside a git worktree, not the main repo." >&2
-  echo "Run this from: ${MAIN_REPO:-the main repo root}" >&2
   exit 1
 fi
 

--- a/plugins/dev/scripts/setup-orchestrator.sh
+++ b/plugins/dev/scripts/setup-orchestrator.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# setup-orchestrator.sh — Standalone orchestrator worktree bootstrap
+#
+# Creates an orch-YYYY-MM-DD[-N] worktree from the main repo, initializes global
+# state, and outputs a machine-readable WORKTREE_PATH for automation. Wraps
+# create-worktree.sh with orchestrator-specific naming and state init.
+#
+# Usage:
+#   setup-orchestrator.sh [--tickets "ID1 ID2"] [--cycle current] [--project "Name"]
+#                         [--quiet] [--launch]
+#
+# Flags:
+#   --tickets "ID1 ID2"   Ticket IDs to pass through to orchestrate command
+#   --cycle current       Use cycle mode (passed through to orchestrate)
+#   --project "Name"      Use project mode (passed through to orchestrate)
+#   --quiet               Suppress all output except WORKTREE_PATH=... line
+#   --launch              Exec claude with /catalyst-dev:orchestrate in the new worktree
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors (suppressed in quiet mode)
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# ─── Parse flags ─────────────────────────────────────────────────────────────
+
+TICKETS=""
+CYCLE=""
+PROJECT=""
+QUIET=false
+LAUNCH=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --tickets)  TICKETS="$2"; shift 2 ;;
+    --cycle)    CYCLE="$2"; shift 2 ;;
+    --project)  PROJECT="$2"; shift 2 ;;
+    --quiet)    QUIET=true; shift ;;
+    --launch)   LAUNCH=true; shift ;;
+    -h|--help)
+      echo "Usage: setup-orchestrator.sh [--tickets \"ID1 ID2\"] [--cycle current] [--project \"Name\"]"
+      echo "                             [--quiet] [--launch]"
+      echo ""
+      echo "Flags:"
+      echo "  --tickets \"ID1 ID2\"   Ticket IDs for orchestration"
+      echo "  --cycle current       Use cycle mode"
+      echo "  --project \"Name\"      Use project mode"
+      echo "  --quiet               Output only WORKTREE_PATH=... (for automation)"
+      echo "  --launch              Create worktree and exec claude with orchestrate command"
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}Unknown flag: $1${NC}" >&2
+      echo "Run with --help for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# At least one input mode required
+if [[ -z "$TICKETS" && -z "$CYCLE" && -z "$PROJECT" ]]; then
+  echo -e "${RED}Error: Must provide --tickets, --cycle, or --project${NC}" >&2
+  echo "Usage: setup-orchestrator.sh --tickets \"ID1 ID2\"" >&2
+  echo "       setup-orchestrator.sh --cycle current" >&2
+  echo "       setup-orchestrator.sh --project \"Project Name\"" >&2
+  exit 1
+fi
+
+log() {
+  if [[ "$QUIET" != true ]]; then
+    echo -e "$@"
+  fi
+}
+
+# ─── Step 1: Validate — must be main repo root, not a worktree ───────────────
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "ERROR: Not in a git repository" >&2
+  exit 1
+fi
+
+COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+
+if [[ "$COMMON_DIR" != "$GIT_DIR" ]]; then
+  MAIN_REPO=$(git -C "$(git rev-parse --git-common-dir)" rev-parse --show-toplevel 2>/dev/null || true)
+  echo "ERROR: You are inside a git worktree, not the main repo." >&2
+  echo "Run this from: ${MAIN_REPO:-the main repo root}" >&2
+  exit 1
+fi
+
+# ─── Step 2: Read config ─────────────────────────────────────────────────────
+
+CONFIG_FILE=""
+for CFG in "${REPO_ROOT}/.catalyst/config.json" "${REPO_ROOT}/.claude/config.json"; do
+  if [[ -f "$CFG" ]]; then
+    CONFIG_FILE="$CFG"
+    break
+  fi
+done
+
+if [[ -z "$CONFIG_FILE" ]]; then
+  echo "ERROR: No .catalyst/config.json found." >&2
+  exit 1
+fi
+
+PROJECT_KEY=$(jq -r '.catalyst.projectKey // empty' "$CONFIG_FILE")
+TICKET_PREFIX=$(jq -r '.catalyst.project.ticketPrefix // empty' "$CONFIG_FILE")
+
+if [[ -z "$PROJECT_KEY" ]]; then
+  echo "ERROR: catalyst.projectKey not set in $CONFIG_FILE" >&2
+  exit 1
+fi
+
+log "${YELLOW}Project: ${PROJECT_KEY} (prefix: ${TICKET_PREFIX:-none})${NC}"
+
+# ─── Step 3: Initialize global state ─────────────────────────────────────────
+
+log "Initializing global state..."
+"${SCRIPT_DIR}/catalyst-state.sh" init >/dev/null 2>&1
+
+# ─── Step 4: Auto-generate worktree name ──────────────────────────────────────
+
+TODAY=$(date +%Y-%m-%d)
+ORCH_NAME="orch-${TODAY}"
+
+WT_DIR_CONFIG=$(jq -r '.catalyst.orchestration.worktreeDir // empty' "$CONFIG_FILE" 2>/dev/null)
+if [[ -n "$WT_DIR_CONFIG" ]]; then
+  WORKTREES_BASE="${WT_DIR_CONFIG/#\~/$HOME}"
+else
+  WORKTREES_BASE="$HOME/catalyst/wt/${PROJECT_KEY}"
+fi
+
+if [[ -d "${WORKTREES_BASE}/${ORCH_NAME}" ]]; then
+  N=2
+  while [[ -d "${WORKTREES_BASE}/${ORCH_NAME}-${N}" ]]; do
+    N=$((N + 1))
+  done
+  ORCH_NAME="${ORCH_NAME}-${N}"
+fi
+
+log "Worktree name: ${ORCH_NAME}"
+
+# ─── Step 5: Create the worktree ──────────────────────────────────────────────
+
+log ""
+if [[ "$QUIET" == true ]]; then
+  "${SCRIPT_DIR}/create-worktree.sh" "$ORCH_NAME" main --orchestration "$ORCH_NAME" >/dev/null 2>&1
+else
+  "${SCRIPT_DIR}/create-worktree.sh" "$ORCH_NAME" main --orchestration "$ORCH_NAME"
+fi
+
+WORKTREE_PATH="${WORKTREES_BASE}/${ORCH_NAME}"
+
+# ─── Step 6: Build ticket args string for commands ────────────────────────────
+
+TICKET_ARGS=""
+if [[ -n "$TICKETS" ]]; then
+  TICKET_ARGS="$TICKETS"
+elif [[ -n "$CYCLE" ]]; then
+  TICKET_ARGS="--cycle $CYCLE"
+elif [[ -n "$PROJECT" ]]; then
+  TICKET_ARGS="--project \"$PROJECT\""
+fi
+
+# ─── Step 7: Output ──────────────────────────────────────────────────────────
+
+DISPLAY_PATH="${WORKTREE_PATH/#$HOME/~}"
+MONITOR_SCRIPT="${SCRIPT_DIR}/orch-monitor/server.ts"
+DISPLAY_MONITOR="${MONITOR_SCRIPT/#$HOME/~}"
+
+if [[ "$QUIET" != true && "$LAUNCH" != true ]]; then
+  echo ""
+  echo "════════════════════════════════════════════════════════════════"
+  echo " Orchestrator ready: ${DISPLAY_PATH}"
+  echo ""
+  echo " Dry run (preview wave plan):"
+  echo "   cd ${DISPLAY_PATH} && claude \"/catalyst-dev:orchestrate ${TICKET_ARGS} --dry-run\""
+  echo ""
+  echo " Full run (dispatch workers):"
+  echo "   cd ${DISPLAY_PATH} && claude \"/catalyst-dev:orchestrate ${TICKET_ARGS}\""
+  echo ""
+  echo " Monitor (optional — real-time web + terminal dashboard):"
+  echo "   bun run ${DISPLAY_MONITOR}"
+  echo "════════════════════════════════════════════════════════════════"
+fi
+
+# Machine-readable output (always last line)
+echo "WORKTREE_PATH=${WORKTREE_PATH}"
+
+# ─── Optional: launch claude in the new worktree ──────────────────────────────
+
+if [[ "$LAUNCH" == true ]]; then
+  log ""
+  log "${GREEN}Launching claude in ${DISPLAY_PATH}...${NC}"
+  cd "$WORKTREE_PATH"
+  exec claude "/catalyst-dev:orchestrate ${TICKET_ARGS}"
+fi

--- a/plugins/dev/scripts/setup-orchestrator.sh
+++ b/plugins/dev/scripts/setup-orchestrator.sh
@@ -150,7 +150,7 @@ log "Worktree name: ${ORCH_NAME}"
 
 log ""
 if [[ "$QUIET" == true ]]; then
-  "${SCRIPT_DIR}/create-worktree.sh" "$ORCH_NAME" main --orchestration "$ORCH_NAME" >/dev/null 2>&1
+  "${SCRIPT_DIR}/create-worktree.sh" "$ORCH_NAME" main --orchestration "$ORCH_NAME" >/dev/null
 else
   "${SCRIPT_DIR}/create-worktree.sh" "$ORCH_NAME" main --orchestration "$ORCH_NAME"
 fi
@@ -190,8 +190,10 @@ if [[ "$QUIET" != true && "$LAUNCH" != true ]]; then
   echo "════════════════════════════════════════════════════════════════"
 fi
 
-# Machine-readable output (always last line)
-echo "WORKTREE_PATH=${WORKTREE_PATH}"
+# Machine-readable output (skip in --launch mode — claude would see it flash by)
+if [[ "$LAUNCH" != true ]]; then
+  echo "WORKTREE_PATH=${WORKTREE_PATH}"
+fi
 
 # ─── Optional: launch claude in the new worktree ──────────────────────────────
 

--- a/plugins/dev/skills/setup-orchestrate/SKILL.md
+++ b/plugins/dev/skills/setup-orchestrate/SKILL.md
@@ -6,7 +6,7 @@ description:
   copy-paste command to launch the orchestrator in a new terminal."
 disable-model-invocation: true
 allowed-tools: Bash, Read
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Setup Orchestrate
@@ -41,87 +41,35 @@ creating the worktree. Wave planning and dependency analysis is the orchestrate 
 
 Execute all steps without asking questions. No confirmations, no menus, no options.
 
-### Step 1: Validate — Must Be Main Repo
+### Step 1: Parse Input
 
-You MUST be in the main repo root, not a worktree. Check and **hard stop** if wrong:
+Determine which mode the user invoked:
+- If the input contains `--cycle`, extract the value (e.g., `current`)
+- If the input contains `--project`, extract the quoted value (e.g., `"Project Name"`)
+- Otherwise, treat all tokens as space-separated ticket IDs
 
-```bash
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
-GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+### Step 2: Call setup-orchestrator.sh
 
-if [ -z "$REPO_ROOT" ]; then
-  echo "ERROR: Not in a git repository"; exit 1
-fi
-
-if [ "$COMMON_DIR" != "$GIT_DIR" ]; then
-  MAIN_REPO=$(git -C "$(git rev-parse --git-common-dir)" rev-parse --show-toplevel 2>/dev/null)
-  echo "ERROR: You are inside a git worktree, not the main repo."
-  echo "Run this from: ${MAIN_REPO:-the main repo root}"
-  exit 1
-fi
-```
-
-If the check fails, print the error and **stop**. Do not offer to continue from the worktree.
-
-### Step 2: Read Config
+Build the flag string from the parsed input and call the standalone script:
 
 ```bash
-CONFIG_FILE=""
-for CFG in "${REPO_ROOT}/.catalyst/config.json" "${REPO_ROOT}/.claude/config.json"; do
-  if [ -f "$CFG" ]; then CONFIG_FILE="$CFG"; break; fi
-done
+# For ticket IDs:
+"${CLAUDE_PLUGIN_ROOT}/scripts/setup-orchestrator.sh" --tickets "<ticket-ids>"
 
-if [ -z "$CONFIG_FILE" ]; then
-  echo "ERROR: No .catalyst/config.json found. See /catalyst-dev:linearis for setup."
-  exit 1
-fi
+# For cycle mode:
+"${CLAUDE_PLUGIN_ROOT}/scripts/setup-orchestrator.sh" --cycle current
 
-PROJECT_KEY=$(jq -r '.catalyst.projectKey // empty' "$CONFIG_FILE")
-TICKET_PREFIX=$(jq -r '.catalyst.project.ticketPrefix // empty' "$CONFIG_FILE")
+# For project mode:
+"${CLAUDE_PLUGIN_ROOT}/scripts/setup-orchestrator.sh" --project "<project-name>"
 ```
 
-### Step 3: Initialize Global State
+The script handles everything: validation, config reading, state init, worktree creation.
 
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-state.sh" init
-```
+### Step 3: Format Output
 
-Idempotent — safe to run every time.
-
-### Step 4: Create Orchestrator Worktree
-
-Auto-generate the name from today's date: `orch-YYYY-MM-DD`. If that already exists, append
-`-2`, `-3`, etc.
-
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/create-worktree.sh" "<orch-name>" main
-```
-
-Do not ask for a custom name. The auto-generated name is always used.
-
-### Step 5: Build and Print Launch Command
-
-Construct the ticket arguments from the user's input exactly as provided (ticket IDs, --cycle, or
---project). Always append `--dry-run` to the first suggested command.
-
-Print this block:
-
-```
-════════════════════════════════════════════════════════════════
- Orchestrator ready: ~/catalyst/wt/<projectKey>/<orch-name>
-
- Dry run (preview wave plan):
-   cd ~/catalyst/wt/<projectKey>/<orch-name> && claude "/catalyst-dev:orchestrate <ticket-args> --dry-run"
-
- Full run (dispatch workers):
-   cd ~/catalyst/wt/<projectKey>/<orch-name> && claude "/catalyst-dev:orchestrate <ticket-args>"
-
- Monitor (optional — real-time web + terminal dashboard):
-   bun run ${CLAUDE_PLUGIN_ROOT}/scripts/orch-monitor/server.ts
-   Open http://<tailscale-ip>:7400 on any device
-════════════════════════════════════════════════════════════════
-```
+The script prints a formatted output block with the worktree path and launch commands.
+Display the script's output directly — it already includes the ═══ banner with dry-run
+and full-run commands, plus the machine-readable `WORKTREE_PATH=...` line.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Adds `plugins/dev/scripts/setup-orchestrator.sh` — a standalone bash script that bootstraps orchestrator worktrees without requiring a Claude Code session
- Refactors `/catalyst-dev:setup-orchestrate` skill to be a thin wrapper that calls the new script
- Script resolves paths via `BASH_SOURCE`, not `CLAUDE_PLUGIN_ROOT`, so it works from Warp tab configs, cron, and other external automation

### Flags supported
- `--tickets "ADV-214 ADV-215"` — pass-through ticket IDs
- `--cycle current` / `--project "Name"` — alternative input modes
- `--quiet` — suppress all output except `WORKTREE_PATH=...` (for automation)
- `--launch` — exec `claude "/catalyst-dev:orchestrate ..."` in the new worktree (one-shot tab config usage)

### What the script does
1. Validates it's running from a main repo root (not a worktree)
2. Reads `projectKey` and `ticketPrefix` from `.catalyst/config.json`
3. Runs `catalyst-state.sh init` (idempotent)
4. Auto-generates `orch-YYYY-MM-DD[-N]` name
5. Calls `create-worktree.sh` with the generated name
6. Outputs machine-readable `WORKTREE_PATH=...` on the last line

No changes to `create-worktree.sh` — all project-specific setup continues to be driven by `.catalyst/config.json`.

## Test plan
- [ ] Run `setup-orchestrator.sh --tickets "ADV-230 ADV-231"` from Adva main repo — creates orch worktree, prints commands
- [ ] Run `setup-orchestrator.sh --quiet --tickets "ADV-230"` — outputs only `WORKTREE_PATH=...`
- [ ] Run from a worktree — fails with clear error
- [ ] Run without args — shows usage
- [ ] `/catalyst-dev:setup-orchestrate ADV-230` skill still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)