### PR TITLE
chore(meta): add stack page, scope messaging, and update guidance to website docs

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -136,7 +136,6 @@
       "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.37.6.tgz",
       "integrity": "sha512-wQrKwH431q+8FsLBnNQeG+R36TMtEGxTQ2AuiVpcx9APcazvL3n7wVW8mMmYyxX0POjTnxlcWPkdMGR3Yj1L+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/markdown-remark": "^6.3.1",
         "@astrojs/mdx": "^4.2.3",
@@ -2211,7 +2210,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2372,7 +2370,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.0.tgz",
       "integrity": "sha512-CHiohwJIS4L0G6/IzE1Fx3dgWqXBCXus/od0eGUfxrZJD2um2pE7ehclMmgL/fXqbU7NfE1Ze2pq34h2QaA6iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -3062,7 +3059,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -3361,7 +3357,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3771,7 +3766,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5542,7 +5536,6 @@
       "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.3.tgz",
       "integrity": "sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.1",
@@ -6664,7 +6657,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7167,7 +7159,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8741,7 +8732,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -2,7 +2,7 @@
 title: Getting Started
 description: Get up and running with Catalyst in 5 minutes.
 sidebar:
-  order: 1
+  order: 2
 ---
 
 Get Catalyst installed and working in your project in under 5 minutes.
@@ -85,6 +85,43 @@ Catalyst is a 5-plugin system. Install what you need:
 # Workflow discovery (advanced users)
 /plugin install catalyst-meta
 ```
+
+## Keeping Plugins Up to Date
+
+Catalyst plugins are updated frequently. There are two ways to stay current.
+
+### Automatic Updates
+
+Claude Code checks for plugin updates at session start. If a new version has been released, it pulls the update automatically. You just need to restart Claude Code (exit and reopen, or start a new session) to load the new version.
+
+To confirm auto-updates are working, your plugins should show as installed from the marketplace:
+
+```bash
+/plugins
+```
+
+### Manual Updates
+
+If you want to pull the latest right now — for example, a release just dropped — you can force an update:
+
+```bash
+# Fetch latest from the marketplace
+/plugins update
+
+# Restart Claude Code to load the new version
+```
+
+### Checking Versions
+
+```bash
+# See installed plugins and current versions
+/plugins
+```
+
+Compare against the latest releases:
+
+- [Documentation — Changelogs](https://catalyst.coalescelabs.ai/changelog/catalyst-dev/) — per-plugin changelogs on the docs site
+- [GitHub Releases](https://github.com/coalesce-labs/catalyst/releases) — release notes with full commit history
 
 ## Next Steps
 

--- a/website/src/content/docs/getting-started/introduction.mdx
+++ b/website/src/content/docs/getting-started/introduction.mdx
@@ -22,6 +22,23 @@ And the prompt loop breaks down fast:
 
 Catalyst solves this by giving Claude Code structure.
 
+## Who This Is For
+
+- **Tinkerers and experimenters.** You're comfortable spinning up Docker Compose stacks, installing unfamiliar CLIs, and trying new platforms. You might fork this repo.
+- **Solo developers or small teams** using Claude Code as their primary AI coding tool.
+- **Teams already on GitHub + Linear** (or willing to adopt them).
+- **macOS users** comfortable with CLI-driven workflows.
+- People who want **structured AI workflows**, not just chat-and-generate.
+
+## Who This Is Not For
+
+- Teams looking for IDE-integrated AI (Copilot, Cursor). Catalyst runs in the terminal.
+- Developers who want a polished, one-click installer. This is a working toolkit, not a packaged product.
+- Windows or Linux-primary developers. There's no cross-platform support planned.
+- Organizations that need Jira, Azure DevOps, or GitLab integration.
+
+See [The Stack](/getting-started/the-stack/) for the full list of tools and what "opinionated" means in practice.
+
 ## Background
 
 Catalyst is developed by [Ryan Rozich](https://ryanrozich.bio/). The methodology behind it — inverting time allocation to roughly 80% research and planning, 20% execution — is described in detail in [Beyond Prompt and Pray: A Field Guide to Structured AI Engineering](https://slides.rozich.net/ai/structured-ai-development-guide). That guide captures the daily workflow that the **catalyst-dev** plugin implements: defining tasks clearly before agents engage, fanning out sub-agents for parallel research, compacting findings into focused documents, planning interactively with human approval gates, and executing against an agreed spec with continuous validation.

--- a/website/src/content/docs/getting-started/multi-project.md
+++ b/website/src/content/docs/getting-started/multi-project.md
@@ -2,7 +2,7 @@
 title: Multi-Project Setup
 description: Managing separate thoughts repositories for different clients and projects.
 sidebar:
-  order: 2
+  order: 3
 ---
 
 Catalyst supports completely isolated contexts for different clients and projects using HumanLayer profiles.

--- a/website/src/content/docs/getting-started/the-stack.md
+++ b/website/src/content/docs/getting-started/the-stack.md
@@ -1,0 +1,87 @@
+---
+title: The Stack
+description: The specific development environment Catalyst is built around — and what that means for you.
+sidebar:
+  order: 1
+---
+
+Catalyst is built around a specific development environment. It's not trying to be universal — it's trying to be excellent for one workflow. This page tells you exactly what that workflow looks like, so you can decide whether to jump in.
+
+## Who This Is For
+
+Catalyst is for developers who like to tinker. You're comfortable spinning up a Docker Compose stack, installing CLIs you haven't used before, and experimenting with new platforms. You might fork this repo and reshape it for your own workflow.
+
+This is **not** a one-click installer. It's not a polished, end-to-end package that's been battle-tested by tens of thousands of users. It's a working toolkit that one developer uses daily, released so others can benefit from the patterns and adapt them.
+
+## The Development Environment
+
+### Core (Required)
+
+| Tool | Role |
+|------|------|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | The AI engine everything plugs into |
+| [GitHub](https://github.com) | PRs, issues, CI/CD |
+| [Git](https://git-scm.com) | Worktrees, branching, thoughts system |
+| macOS | Primary supported platform |
+
+### Task Management
+
+| Tool | Role |
+|------|------|
+| [Linear](https://linear.app) | Task management, cycle tracking |
+| [Linearis CLI](https://www.npmjs.com/package/linearis) | Linear integration for Claude Code |
+
+### Observability
+
+| Tool | Role |
+|------|------|
+| [OpenTelemetry](https://opentelemetry.io) | Structured telemetry from agent runs |
+| [Grafana](https://grafana.com) | Dashboards, alerting, log exploration |
+| SQLite | Local session store and cost tracking |
+
+### Development Environment
+
+| Tool | Role |
+|------|------|
+| [Conductor](https://conductor.build) | Parallel agent orchestration UI |
+| [Warp](https://www.warp.dev) | Terminal |
+| [Bun](https://bun.sh) | Runtime for scripts and tooling |
+
+### AI Agents (Beyond Claude Code)
+
+| Tool | Role |
+|------|------|
+| [Devin](https://devin.ai) | Autonomous coding agent |
+| [Codex](https://openai.com/index/codex/) | OpenAI's coding agent |
+
+Catalyst skills can orchestrate handoffs between these agents and Claude Code.
+
+## What This Means for You
+
+If your stack looks like this, Catalyst works out of the box. Install the plugins, run the setup script, and you're in a working workflow within minutes.
+
+If you're on Windows, use Jira instead of Linear, or prefer a different AI coding tool — Catalyst may still be useful for ideas and patterns, but you'll be adapting rather than installing. There's no active effort to add support for alternative task managers, IDEs, operating systems, or AI providers. This is a working toolkit, not a framework.
+
+You're welcome to fork the repo and adapt it for your own stack. That's part of why it's open source.
+
+## A Note on Security
+
+Installing these plugins means installing code that runs on your computer — or has the potential to run on your computer.
+
+**Don't trust me or anybody else.** You should review anything you install into Claude Code. At minimum, use [GitHub's code scanning](https://docs.github.com/en/code-security/code-scanning) (Copilot or CodeQL) to run a security check on this or any other plugin before installing it.
+
+Catalyst bakes security checks and security reviews into its own CI/CD pipeline. But of course, that's exactly what someone would tell you if they were trying to put something nasty on your machine. Run your own scans. Read the code. Trust your own review, not someone else's assurances.
+
+## Start at Level 2
+
+Catalyst describes three levels of AI-assisted development (detailed in [Beyond Prompt and Pray](https://slides.rozich.net/ai/structured-ai-development-guide)):
+
+- **Level 1** — Prompt and generate. Basic AI code completion.
+- **Level 2** — Structured workflows. Research, plan, implement, validate — one ticket at a time.
+- **Level 3** — Orchestrated parallelism. Multiple agents working across multiple tickets simultaneously.
+
+**Start at Level 2.** Spend real time there. Work ticket by ticket through the research-plan-implement cycle. Get a feel for what's happening under the hood. Understand how context flows between phases, how handoffs work, how the AI reasons about your codebase.
+
+Ship with rigor and confidence at Level 2 before you think about Level 3. If you jump straight to orchestrating parallel work streams, you'll burn through tokens fast and get frustrated when things go sideways — because you won't have the mental model to debug what went wrong.
+
+Level 3 is powerful, but it assumes you already know how each individual workflow phase behaves. Master the single-ticket workflow first.

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,14 +1,18 @@
 ---
 title: Catalyst
-description: A structured workspace for building real software with AI — skills, agents, and workflows for Claude Code.
+description: Opinionated AI development workflows for Claude Code — skills, agents, and orchestration built around a specific stack.
 template: splash
 hero:
-  tagline: A structured workspace for building real software with AI. Skills, agents, and workflows that plug into Claude Code.
+  tagline: Opinionated AI development workflows for Claude Code. Built around a specific stack, shared so others can benefit.
   actions:
     - text: Get Started
       link: /getting-started/introduction/
       icon: right-arrow
       variant: primary
+    - text: See the Stack
+      link: /getting-started/the-stack/
+      icon: setting
+      variant: secondary
     - text: View on GitHub
       link: https://github.com/coalesce-labs/catalyst
       icon: external
@@ -34,8 +38,9 @@ AI can write code. But real software development involves research, planning, co
     Interactive planning, validation gates, and context handoffs keep
     developers in control of what gets built and shipped.
   </Card>
-  <Card title="Install What You Need" icon="puzzle">
-    Five independent plugins — development workflows, project management,
-    analytics, debugging, and meta-tooling. Use what fits.
+  <Card title="Built for One Stack" icon="setting">
+    Optimized for macOS + Claude Code + Linear + GitHub. Not trying to be
+    everything — just excellent for this workflow.
+    [See what's in the stack →](/getting-started/the-stack/)
   </Card>
 </CardGrid>

--- a/website/src/content/docs/plugins/index.md
+++ b/website/src/content/docs/plugins/index.md
@@ -71,10 +71,27 @@ The dev plugin includes three Claude Code hooks that run automatically:
 
 ## Updating
 
+Claude Code auto-updates plugins at session start — if a new version is available, it pulls it automatically. Restart Claude Code to load the update.
+
+To force an immediate update (e.g., a release just dropped):
+
 ```bash
-claude plugin marketplace update catalyst
-# Restart Claude Code to load updates
+# Fetch latest from the marketplace
+/plugins update
+
+# Restart Claude Code to load the new version
 ```
+
+Check your current versions:
+
+```bash
+/plugins
+```
+
+Compare against the latest:
+
+- [Changelogs](/changelog/catalyst-dev/) — per-plugin changelogs on this site
+- [GitHub Releases](https://github.com/coalesce-labs/catalyst/releases) — release notes with full commit history
 
 ## Release Strategy
 


### PR DESCRIPTION
## Summary

- **New "The Stack" page** (`getting-started/the-stack.md`) — documents Ryan's actual toolchain (Claude Code, Conductor, Warp, Linear, GitHub, OTel, Grafana, Devin, Codex), frames requirements as features, includes security disclaimer ("don't trust me or anybody else"), and "Start at Level 2" progression guidance
- **Landing page reframed** — new hero tagline ("Opinionated AI development workflows...built around a specific stack"), "See the Stack" CTA button, replaced "Install What You Need" card with "Built for One Stack"
- **"Who This Is For" sections** on introduction page — tinkerers and experimenters, not one-click-installer seekers; explicit "Who This Is Not For" list
- **Plugin update/upgrade guidance** on both Getting Started and Plugins pages — auto-updates, manual `/plugins update`, version checking, links to changelogs and GitHub Releases
- **Sidebar reordering** — Introduction → The Stack → Installation → Multi-Project

## Test plan

- [x] `npm run build` passes clean (168 pages)
- [ ] Verify new "The Stack" page renders at `/getting-started/the-stack/`
- [ ] Verify "See the Stack" CTA on landing page links correctly
- [ ] Verify sidebar order: Introduction → The Stack → Getting Started → Multi-Project Setup
- [ ] Verify changelog and GitHub Releases links resolve

Refs: CTL-71