### PR TITLE
fix(dev): harden prerequisites, wire up SQLite init, fix OTel config

### DIFF
--- a/plugins/dev/scripts/check-prerequisites.sh
+++ b/plugins/dev/scripts/check-prerequisites.sh
@@ -10,10 +10,27 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+# ─── Platform check ─────────────────────────────────────────────────────────
+# Catalyst is developed and tested on macOS only. Other platforms may work
+# but are unsupported.
+
+echo "🔍 Checking Catalyst dev plugin prerequisites..."
+echo ""
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+	echo -e "${YELLOW}⚠️  Catalyst is built for macOS. Detected: $(uname -s)${NC}"
+	echo -e "   Some features (Homebrew installs, open(1), direnv profiles) assume macOS."
+	echo -e "   Proceed with caution — things may not work as expected."
+	echo ""
+fi
+
+# ─── Tool lists ──────────────────────────────────────────────────────────────
+
 # Required tools (command:name:install-instruction)
 REQUIRED_TOOLS=(
 	"humanlayer:HumanLayer CLI:pip install humanlayer"
 	"jq:JSON processor:brew install jq"
+	"sqlite3:SQLite CLI (session store):Included with macOS — install via your package manager if missing"
 	"gh:GitHub CLI:brew install gh"
 	"linearis:Linear CLI:npm install -g linearis"
 	"agent-browser:Browser automation:npm install -g agent-browser && agent-browser install"
@@ -22,6 +39,7 @@ REQUIRED_TOOLS=(
 # Optional tools - used by specific agents only (command:name:install-instruction)
 OPTIONAL_TOOLS=(
 	"sentry-cli:Sentry CLI (for sentry-research agent):curl -sL https://sentry.io/get-cli/ | sh"
+	"bun:Bun runtime (for orch-monitor dashboard):curl -fsSL https://bun.sh/install | bash"
 )
 
 # Optional MCP servers (name:purpose:install-command)
@@ -29,9 +47,6 @@ OPTIONAL_MCPS=(
 	"exa:Web search:/plugin marketplace add exa-labs/exa-mcp-server"
 	"posthog:Analytics:/plugin marketplace add posthog-mcp"
 )
-
-echo "🔍 Checking Catalyst dev plugin prerequisites..."
-echo ""
 
 missing=()
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/pid-file.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/pid-file.test.ts
@@ -53,6 +53,7 @@ describe("PID file support", () => {
       wtDir,
       startWatcher: false,
       pidFile: pidPath,
+      annotationsDbPath: join(tmpDir, "annotations.db"),
     });
 
     expect(existsSync(pidPath)).toBe(true);
@@ -62,7 +63,7 @@ describe("PID file support", () => {
 
   it("does not write PID file when pidFile option is omitted", () => {
     const pidPath = join(tmpDir, "should-not-exist.pid");
-    server = createServer({ port: 0, wtDir, startWatcher: false });
+    server = createServer({ port: 0, wtDir, startWatcher: false, annotationsDbPath: join(tmpDir, "annotations.db") });
 
     expect(existsSync(pidPath)).toBe(false);
   });
@@ -74,6 +75,7 @@ describe("PID file support", () => {
       wtDir,
       startWatcher: false,
       pidFile: pidPath,
+      annotationsDbPath: join(tmpDir, "annotations.db"),
     });
 
     expect(existsSync(pidPath)).toBe(true);
@@ -89,6 +91,7 @@ describe("PID file support", () => {
       wtDir,
       startWatcher: false,
       pidFile: pidPath,
+      annotationsDbPath: join(tmpDir, "annotations.db"),
     });
 
     const content = readFileSync(pidPath, "utf-8");

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -952,6 +952,7 @@ describe("terminal mode", () => {
       terminal: true,
       prStatusFetcher: null,
       linearFetcher: null,
+      annotationsDbPath: join(tmp, "annotations.db"),
     });
     expect(srv).toBeDefined();
     expect(srv.port).toBeGreaterThan(0);

--- a/plugins/dev/scripts/orch-monitor/__tests__/ui-features.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ui-features.test.ts
@@ -51,7 +51,7 @@ beforeAll(async () => {
     );
   }
 
-  server = createServer({ port: 0, wtDir, startWatcher: false });
+  server = createServer({ port: 0, wtDir, startWatcher: false, annotationsDbPath: join(tmpDir, "annotations.db") });
   baseUrl = `http://localhost:${server.port}`;
 
   const res = await fetch(`${baseUrl}/`);

--- a/plugins/dev/scripts/orch-monitor/lib/otel-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-config.ts
@@ -15,13 +15,13 @@ function stripTrailingSlashes(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
-export function loadOtelConfig(catalystDir: string): OtelConfig {
+export function loadOtelConfig(configDir: string): OtelConfig {
   let fileEnabled = false;
   let filePrometheus: string | null = null;
   let fileLoki: string | null = null;
 
   try {
-    const raw = readFileSync(join(catalystDir, "config.json"), "utf8");
+    const raw = readFileSync(join(configDir, "config.json"), "utf8");
     const parsed: unknown = JSON.parse(raw);
     if (isRecord(parsed) && isRecord(parsed.otel)) {
       const otel = parsed.otel;

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -832,7 +832,9 @@ if (import.meta.main) {
   const compact = process.argv.includes("--compact");
   const renderOpts: RenderOptions = { compact };
 
-  const otelCfg = loadOtelConfig(`${process.env.HOME}/.catalyst`);
+  const otelCfg = loadOtelConfig(
+    process.env.CATALYST_CONFIG_DIR ?? `${process.env.HOME}/.config/catalyst`,
+  );
 
   if (terminalOnly) {
     const handle = startTerminalOnly(WT_DIR, renderOpts);

--- a/plugins/dev/scripts/setup-orchestrator.sh
+++ b/plugins/dev/scripts/setup-orchestrator.sh
@@ -109,10 +109,13 @@ fi
 
 log "${YELLOW}Project: ${PROJECT_KEY} (prefix: ${TICKET_PREFIX:-none})${NC}"
 
-# ─── Step 3: Initialize global state ─────────────────────────────────────────
+# ─── Step 3: Initialize global state and session database ────────────────────
 
 log "Initializing global state..."
 "${SCRIPT_DIR}/catalyst-state.sh" init >/dev/null 2>&1
+
+log "Initializing session database..."
+"${SCRIPT_DIR}/catalyst-db.sh" init 2>&1 | while read -r line; do log "  $line"; done
 
 # ─── Step 4: Auto-generate worktree name ──────────────────────────────────────
 

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -397,6 +397,21 @@ check_prerequisites() {
 	local missing_critical=false
 	local missing_optional=false
 
+	# Platform check — Catalyst is developed and tested on macOS only
+	if [[ "$(uname -s)" != "Darwin" ]]; then
+		echo ""
+		print_warning "Catalyst is built for macOS. Detected platform: $(uname -s)"
+		echo "  Some features (Homebrew installs, open(1), direnv profiles) assume macOS."
+		echo "  You can continue, but some things may not work as expected."
+		echo ""
+		if ! ask_yes_no "Continue on unsupported platform?" "n"; then
+			echo "Setup cancelled."
+			exit 0
+		fi
+	else
+		print_success "Platform: macOS ($(sw_vers -productVersion 2>/dev/null || echo 'unknown version'))"
+	fi
+
 	# Critical: git (used throughout for repo detection, worktrees, thoughts)
 	if ! check_command_exists "git"; then
 		print_error "git not found (required)"
@@ -412,6 +427,15 @@ check_prerequisites() {
 		offer_install_jq || missing_critical=true
 	else
 		print_success "jq installed"
+	fi
+
+	# Critical: sqlite3 (for session store)
+	if ! check_command_exists "sqlite3"; then
+		print_error "sqlite3 not found (required for session store)"
+		echo "  sqlite3 ships with macOS. If missing, install via your package manager."
+		missing_critical=true
+	else
+		print_success "sqlite3 installed"
 	fi
 
 	# Critical: humanlayer (for thoughts system)
@@ -456,12 +480,21 @@ check_prerequisites() {
 		fi
 	fi
 
-	# Check agent-browser (optional - browser automation)
-	if command -v agent-browser &>/dev/null; then
+	# Optional: agent-browser (browser automation)
+	if check_command_exists "agent-browser"; then
 		print_success "agent-browser installed"
 	else
-		print_warning "agent-browser not found (optional - browser automation)"
+		print_warning "agent-browser not found (optional — browser automation)"
 		echo "  Install: npm install -g agent-browser && agent-browser install"
+		missing_optional=true
+	fi
+
+	# Optional: bun (for orch-monitor dashboard)
+	if check_command_exists "bun"; then
+		print_success "bun installed"
+	else
+		print_warning "bun not found (optional — required for orch-monitor dashboard)"
+		echo "  Install: curl -fsSL https://bun.sh/install | bash"
 		missing_optional=true
 	fi
 
@@ -2012,6 +2045,44 @@ offer_github_backup() {
 }
 
 #
+# Session database initialization
+#
+
+init_session_database() {
+	print_header "Initializing Session Database"
+
+	local catalyst_dir="${CATALYST_DIR:-$HOME/catalyst}"
+	local db_file="${catalyst_dir}/catalyst.db"
+
+	mkdir -p "$catalyst_dir"
+
+	if ! check_command_exists "sqlite3"; then
+		print_warning "sqlite3 not found — skipping session database initialization"
+		return 0
+	fi
+
+	# Use catalyst-db.sh if available (plugin is installed), otherwise apply schema directly
+	local db_script=""
+	if [ -f "${PROJECT_DIR}/plugins/dev/scripts/catalyst-db.sh" ]; then
+		db_script="${PROJECT_DIR}/plugins/dev/scripts/catalyst-db.sh"
+	elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-db.sh" ]; then
+		db_script="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-db.sh"
+	fi
+
+	if [ -n "$db_script" ]; then
+		CATALYST_DIR="$catalyst_dir" "$db_script" init
+		print_success "Session database initialized: $db_file"
+	else
+		# Minimal init: create the db with WAL mode if it doesn't exist
+		sqlite3 "$db_file" "PRAGMA journal_mode = WAL;" >/dev/null 2>&1
+		print_success "Session database created: $db_file"
+		print_warning "Install the catalyst-dev plugin to apply full schema migrations"
+	fi
+
+	echo ""
+}
+
+#
 # Main execution
 #
 
@@ -2044,6 +2115,7 @@ main() {
 	setup_humanlayer_config
 	setup_catalyst_secrets
 	update_config_with_linear_states
+	init_session_database
 	init_humanlayer_thoughts
 	sync_thoughts
 

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -24,6 +24,7 @@ The setup script checks for and installs additional dependencies automatically:
 | Linearis CLI | Optional | Shows npm install command |
 | agent-browser | Optional | Shows npm install command |
 | Bun | Optional | For orch-monitor dashboard |
+| direnv | Recommended | Per-project env vars, API key isolation |
 
 ## Run the Setup Script
 

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -9,6 +9,7 @@ Get Catalyst installed and working in your project in under 5 minutes.
 
 ## Prerequisites
 
+- **macOS** — Catalyst is built and tested on macOS only. Other platforms are unsupported.
 - **Claude Code** — [Install Claude Code](https://docs.anthropic.com/en/docs/claude-code) before running setup
 - **Git** — required for repository detection and thoughts system
 
@@ -17,10 +18,12 @@ The setup script checks for and installs additional dependencies automatically:
 | Dependency | Required? | Auto-installed? |
 |-----------|-----------|-----------------|
 | jq | Yes | Yes (via Homebrew or apt-get) |
+| sqlite3 | Yes | Included with macOS |
 | HumanLayer CLI | Yes | Yes (via pip) |
 | GitHub CLI (gh) | Optional | Opens install page |
 | Linearis CLI | Optional | Shows npm install command |
 | agent-browser | Optional | Shows npm install command |
+| Bun | Optional | For orch-monitor dashboard |
 
 ## Run the Setup Script
 
@@ -32,10 +35,11 @@ chmod +x setup-catalyst.sh
 
 The script will:
 
-- Check and install prerequisites (HumanLayer, jq)
+- Verify platform (macOS) and check/install prerequisites (HumanLayer, jq, sqlite3)
 - Set up a thoughts repository (one per org)
 - Create project configuration
 - Configure worktree directories
+- Initialize the SQLite session database (`~/catalyst/catalyst.db`)
 - Prompt for API tokens (Linear, Sentry, etc.)
 - Link your project to shared thoughts
 

--- a/website/src/content/docs/getting-started/multi-project.md
+++ b/website/src/content/docs/getting-started/multi-project.md
@@ -112,6 +112,24 @@ cd ~/clients/acme/thoughts
 gh repo create ryan/acme-thoughts --private --source=. --push
 ```
 
+## Environment Isolation with direnv
+
+HumanLayer profiles isolate _thoughts and context_. For API key and credential isolation, pair them
+with [direnv](https://direnv.net/) profiles:
+
+```bash
+# ~/.config/direnv/profiles/personal.env  — your global defaults
+# ~/.config/direnv/profiles/acme.env      — client-specific API keys
+
+# ~/code-repos/github/acme/project/.envrc
+use_profile personal
+use_profile acme
+use_otel_context "acme"
+```
+
+This gives you per-project API keys, OTel telemetry labels, and secrets scoping — automatically,
+just by `cd`-ing into a directory. See [direnv Setup](/reference/configuration/#direnv-setup-recommended) for the full setup guide.
+
 ## Best Practices
 
 Use descriptive profile names (`acme`, `coalesce-labs`, `google-consulting`) rather than vague ones (`client1`, `work`, `temp`).

--- a/website/src/content/docs/getting-started/the-stack.md
+++ b/website/src/content/docs/getting-started/the-stack.md
@@ -43,6 +43,7 @@ This is **not** a one-click installer. It's not a polished, end-to-end package t
 
 | Tool | Role |
 |------|------|
+| [direnv](https://direnv.net) | Per-project environment variables, API key isolation, OTel context |
 | [Conductor](https://conductor.build) | Parallel agent orchestration UI |
 | [Warp](https://www.warp.dev) | Terminal |
 | [Bun](https://bun.sh) | Runtime for scripts and tooling |

--- a/website/src/content/docs/observability/events.md
+++ b/website/src/content/docs/observability/events.md
@@ -34,7 +34,7 @@ Using a status transition as the example:
 ```
 Worker writes ───> Signal file          (local snapshot, atomic via tmp+mv)
             │
-            └───> catalyst-state.sh worker   ───> Global state  (atomic via jq+flock)
+            └───> catalyst-state.sh worker   ───> Global state  (atomic via jq+mkdir lock)
                                              └──> Event         (appended to events.jsonl)
 
 orch-monitor ──> fs.watch on signal files   ───> Recomputes snapshot

--- a/website/src/content/docs/observability/setup.md
+++ b/website/src/content/docs/observability/setup.md
@@ -75,7 +75,25 @@ docker compose logs -f otel-collector
 
 You should see batches of telemetry arriving within ~10 seconds of the first tool use. If not, see [Troubleshooting](#troubleshooting) below.
 
-### 4. Import the Grafana dashboard
+### 4. Configure the orchestration monitor (optional)
+
+If you use the orch-monitor dashboard (`bun run plugins/dev/scripts/orch-monitor/server.ts`), configure it to proxy OTel queries by creating `~/.config/catalyst/config.json`:
+
+```json
+{
+  "otel": {
+    "enabled": true,
+    "prometheus": "http://localhost:9090",
+    "loki": "http://localhost:3100"
+  }
+}
+```
+
+This enables the `/api/otel/query` and `/api/otel/logs` endpoints on the monitor server, allowing the dashboard to display metrics and logs alongside signal file data.
+
+Alternatively, set environment variables: `OTEL_ENABLED=true`, `PROMETHEUS_URL`, `LOKI_URL`.
+
+### 5. Import the Grafana dashboard
 
 The claude-code-otel repo ships with a pre-built Grafana dashboard at `dashboards/claude-code.json`. Import it via Grafana → Dashboards → New → Import → Upload JSON file.
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -473,6 +473,93 @@ attributes:
 workspace root). When using worktrees, `create-worktree.sh` generates a `.envrc` and runs
 `direnv allow` automatically.
 
+## direnv Setup (Recommended)
+
+[direnv](https://direnv.net/) is recommended when working across multiple repositories. It
+automatically loads per-directory environment variables, keeping API keys isolated between projects
+and populating OTel resource attributes for observability.
+
+### Installation
+
+```bash
+brew install direnv
+```
+
+Add the shell hook to your profile (`~/.zshrc` or `~/.bashrc`):
+
+```bash
+eval "$(direnv hook zsh)"   # or bash
+```
+
+### Library Functions
+
+Catalyst ships two direnv library functions. Install them to `~/.config/direnv/lib/` so they're
+available in all `.envrc` files:
+
+**`use_profile`** — loads environment variables from a named profile file:
+
+```bash
+# ~/.config/direnv/lib/profiles.sh
+# Loads vars from ~/.config/direnv/profiles/{name}.env
+# Later profiles override earlier ones.
+```
+
+**`use_otel_context`** — sets `OTEL_RESOURCE_ATTRIBUTES` for telemetry correlation:
+
+```bash
+# ~/.config/direnv/lib/otel.sh
+# Sets project, hostname, git.branch, linear.key, catalyst.orchestration
+```
+
+### Profile Files
+
+Create profile files at `~/.config/direnv/profiles/` to separate credentials by project:
+
+```
+~/.config/direnv/profiles/
+├── personal.env     # Global defaults (Cloudflare, AWS, PostHog)
+├── adva.env         # Client-specific keys (Supabase, Postmark, geocoding APIs)
+├── slides.env       # Project-specific keys (ElevenLabs, Gemini TTS)
+└── accounting.env   # Project-specific keys (Wave, Monarch)
+```
+
+Each file is a simple `KEY=value` format — no `export` prefix needed (direnv handles that).
+
+### Per-Project `.envrc` Files
+
+Each project root gets an `.envrc` file that layers profiles and sets OTel context:
+
+```bash
+# ~/code-repos/github/acme/project/.envrc
+use_profile personal          # Base credentials
+use_profile acme              # Client-specific overrides
+use_otel_context "acme"       # OTel resource attributes
+```
+
+Sub-directories (e.g., Conductor workspaces or worktrees) inherit from the parent:
+
+```bash
+# ~/conductor/workspaces/acme/workspace-1/.envrc
+source_up                     # Inherit from parent .envrc
+use_otel_context "acme"       # OTel context for this workspace
+```
+
+The `source_up` directive walks up the directory tree until it finds a parent `.envrc`, chaining
+configurations. This means worktrees and Conductor workspaces automatically get the parent project's
+API keys without duplicating them.
+
+### Why This Matters for Multi-Repo Work
+
+Without direnv, API keys end up in shell profiles (`.zshrc`) where they're global — every project
+sees every key. With direnv profiles:
+
+- **Credentials are scoped** — `cd` into a project and only its keys are loaded
+- **OTel attributes are automatic** — every Claude Code session gets the right `project` and
+  `linear.key` labels without manual configuration
+- **Worktrees inherit** — `source_up` means new worktrees get the right environment immediately
+- **No secret leakage** — `.envrc` files are committed (they reference profiles, not secrets);
+  profile `.env` files are local-only
+
 ## Thoughts System
 
 The thoughts system provides git-backed persistent context across sessions. The setup script handles

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -246,6 +246,36 @@ Never committed. One file per project, linked by `projectKey`.
 
 Only configure the integrations you use. The setup script prompts for each one.
 
+### Monitor OTel Config (`~/.config/catalyst/config.json`)
+
+The orchestration monitor reads OpenTelemetry backend endpoints from a global config file at
+`~/.config/catalyst/config.json`. This file is separate from the per-project secrets files.
+
+```json
+{
+  "otel": {
+    "enabled": true,
+    "prometheus": "http://localhost:9090",
+    "loki": "http://localhost:3100"
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `otel.enabled` | boolean | `false` | Enable OTel proxy endpoints on orch-monitor |
+| `otel.prometheus` | string | `null` | Prometheus query URL (for `/api/otel/query`) |
+| `otel.loki` | string | `null` | Loki query URL (for `/api/otel/logs`) |
+
+Environment variable overrides: `OTEL_ENABLED`, `PROMETHEUS_URL`, `LOKI_URL`. Env vars take
+precedence over the file when both are set.
+
+If you're running the [claude-code-otel](https://github.com/coalesce-labs/claude-code-otel) Docker
+Compose stack locally, the defaults above match the standard ports. For hosted backends (Grafana
+Cloud, Datadog, etc.), point these URLs at your hosted Prometheus/Loki-compatible endpoints.
+
+See [Setting up the OTel stack](/observability/setup/) for the full installation guide.
+
 ### AI Briefing
 
 The monitor dashboard supports AI-powered status summaries. Configuration spans both layers:

--- a/website/src/content/docs/reference/orchestration/workers.md
+++ b/website/src/content/docs/reference/orchestration/workers.md
@@ -89,7 +89,7 @@ The worker writes statuses up through `pr-created`. The orchestrator writes `mer
 
 ## The global state
 
-In parallel with the signal file, workers also write to `~/catalyst/state.json` via `catalyst-state.sh worker`. This is the fleet-wide aggregate that the dashboard reads — it unifies workers across multiple orchestrators. Writes are atomic (jq + flock).
+In parallel with the signal file, workers also write to `~/catalyst/state.json` via `catalyst-state.sh worker`. This is the fleet-wide aggregate that the dashboard reads — it unifies workers across multiple orchestrators. Writes are atomic (jq + mkdir-based locking).
 
 Schema:
 


### PR DESCRIPTION
## Summary

- **macOS platform check** — both `check-prerequisites.sh` and `setup-catalyst.sh` now warn (and offer to abort) on non-macOS platforms
- **sqlite3 + bun in prerequisites** — `sqlite3` is now a required check (ships with macOS), `bun` is optional (needed for orch-monitor)
- **SQLite database initialization wired up** — `setup-orchestrator.sh` now calls `catalyst-db.sh init` alongside `catalyst-state.sh init`, so orchestrator bootstraps get schema migrations + WAL mode automatically. `setup-catalyst.sh` also initializes the session database during first-time setup.
- **OTel config path fixed** — the monitor server was reading from `~/.catalyst/config.json` (which doesn't exist); now reads from `~/.config/catalyst/config.json` (where per-project secrets already live), overridable via `CATALYST_CONFIG_DIR` env var
- **Docs updated** — documented OTel monitor config schema in `reference/configuration.md` and `observability/setup.md`; fixed docs that incorrectly described locking as `flock` (actual impl uses portable `mkdir`-based locking); updated prerequisites table

## Test plan

- [ ] Run `bash -n` on all modified shell scripts (done — all pass)
- [ ] Run `check-prerequisites.sh` and verify sqlite3 + platform checks appear
- [ ] Run `setup-orchestrator.sh` and verify `catalyst-db.sh init` runs
- [ ] Verify `orch-monitor` reads OTel config from `~/.config/catalyst/config.json`
- [ ] Review website docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)