### PR TITLE
fix(meta): use GitHub App token for release-please auto-merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,14 +14,20 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Auto-merge release PR
         if: ${{ steps.release.outputs.pr }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} --squash --auto --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Swaps `GITHUB_TOKEN` for a GitHub App installation token in the release-please workflow
- Auto-merges via `GITHUB_TOKEN` don't trigger follow-up workflows, so release-please never created the actual GitHub release after the release PR merged (had to manually dispatch)
- Using `actions/create-github-app-token@v1` with the `ryanrozich-claude` GitHub App so the merge event triggers the second release-please run

## Test plan
- [ ] Merge this PR and verify the release-please workflow creates a release PR
- [ ] When the release PR auto-merges, verify a second release-please run triggers and creates the GitHub release + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)