### PR TITLE
fix(meta): use fine-grained PAT for release-please auto-merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,20 +14,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Auto-merge release PR
         if: ${{ steps.release.outputs.pr }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} --squash --auto --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Replaces GitHub App token approach with a fine-grained PAT (`RELEASE_TOKEN` secret)
- GitHub App required org-level installation that wasn't working; PAT is simpler and already scoped
- The PAT identity triggers follow-up workflows when the release PR auto-merges, so release-please creates the actual GitHub release

Supersedes #145 approach (GitHub App token).

## Test plan
- [ ] Merge this PR → release-please creates a release PR
- [ ] Release PR auto-merges → second release-please run creates the GitHub release + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)