### PR TITLE
feat(dev): add DeepWiki orientation to codebase research workflow

### DIFF
--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -6,7 +6,9 @@ description:
   wants a structured TDD implementation plan before writing code. Works best after
   /research-codebase."
 disable-model-invocation: true
-allowed-tools: Read, Write, Grep, Glob, Task, TodoWrite, Bash
+allowed-tools:
+  Read, Write, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
+  mcp__deepwiki__read_wiki_structure
 version: 1.0.0
 ---
 
@@ -86,7 +88,10 @@ Auto-discovery has already run in Prerequisites above. Check its output and foll
    using Linearis CLI (run `linearis issues usage` for syntax).
    If Linearis CLI is not available, skip silently and continue planning.
 
-3. **Spawn initial research tasks in parallel**:
+3. **Gather context using research sub-agents** — use the same agent palette and DeepWiki
+   orientation process as `/catalyst-dev:research-codebase` (that skill is the single source of
+   truth for how codebase research works). For planning, focus agents on the specific ticket/task
+   scope rather than broad exploration:
    - **codebase-locator** — find all files related to the ticket/task
    - **codebase-analyzer** — understand how the current implementation works
    - **thoughts-locator** — find existing thoughts documents about this feature (if relevant)

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -6,7 +6,9 @@ description:
   previously created implementation plan using TDD (Red-Green-Refactor). Supports team mode for
   parallel implementation."
 disable-model-invocation: true
-allowed-tools: Read, Write, Edit, Grep, Glob, Task, TodoWrite, Bash
+allowed-tools:
+  Read, Write, Edit, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
+  mcp__deepwiki__read_wiki_structure
 version: 1.0.0
 ---
 

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -6,7 +6,9 @@ description:
   or wants to go from ticket/idea to merged PR autonomously. Each phase runs in a fresh session for
   context isolation."
 disable-model-invocation: true
-allowed-tools: Read, Write, Bash, Task, Grep, Glob
+allowed-tools:
+  Read, Write, Bash, Task, Grep, Glob, mcp__deepwiki__ask_question,
+  mcp__deepwiki__read_wiki_structure
 version: 3.0.0
 ---
 
@@ -347,21 +349,10 @@ This phase runs in the current session to allow user interaction during research
    ```
    If yes, create a ticket via the Linearis CLI (run `linearis issues usage` for create syntax) using the research summary as description,
    then register the ticket ID: `workflow-context.sh set-ticket "NEW-TICKET-ID"`
-5. **Conduct research**: Spawn parallel sub-agents (same as `/research-codebase`):
-   - **codebase-locator**: Find relevant files
-   - **codebase-analyzer**: Understand current implementation
-   - **codebase-pattern-finder**: Find similar patterns
-   - **thoughts-locator**: Find existing context (if relevant)
-   - **external-research**: Research frameworks/libraries (if relevant)
-6. **Synthesize findings**: Create research document at
-   `thoughts/shared/research/YYYY-MM-DD-{ticket}-{description}.md`
-7. **Sync**: `humanlayer thoughts sync`
-8. **Track in workflow context (REQUIRED)** — substitute actual path and ticket:
-   ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "thoughts/shared/research/YYYY-MM-DD-description.md" "TICKET-ID"
-   ```
-9. **Verify**: `"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research` must print the
-   path
+5. **Conduct research** — follow the `/catalyst-dev:research-codebase` process exactly. This is the
+   single source of truth for how codebase research works (including DeepWiki orientation, sub-agent
+   spawning, synthesis, and document creation). The research document MUST be written to
+   `thoughts/shared/research/` and tracked in workflow context before proceeding to Phase 2.
 
 ### Phase 2: Plan (New Session via `humanlayer launch` — Opus)
 

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -6,7 +6,9 @@ description:
   needs deep analysis of how existing code is structured. Produces a research document in
   thoughts/shared/research/ with file:line references."
 disable-model-invocation: true
-allowed-tools: Read, Write, Grep, Glob, Task, TodoWrite, Bash
+allowed-tools:
+  Read, Write, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
+  mcp__deepwiki__read_wiki_structure
 version: 1.0.0
 ---
 
@@ -58,6 +60,40 @@ and I'll analyze it thoroughly by exploring relevant components and connections.
 Then wait for the user's research query.
 
 ## Steps to Follow After Receiving the Research Query
+
+### Step 0: Orient with DeepWiki (ALWAYS attempt this first)
+
+Before reading files or spawning sub-agents, get a high-level understanding from DeepWiki. This
+provides a compressed overview of the codebase that guides all subsequent research and saves tokens.
+
+**Prerequisite check** — only run this step if both conditions are met:
+1. The `mcp__deepwiki__ask_question` tool is available (DeepWiki MCP is installed)
+2. The repo is indexed by DeepWiki (the call returns a meaningful response, not an error)
+
+If either condition fails, skip to Step 1 — do not retry or warn the user.
+
+**Steps:**
+
+1. **Determine the repo name** from the git remote:
+   ```bash
+   gh repo view --json nameWithOwner -q .nameWithOwner
+   ```
+2. **Ask DeepWiki** about the user's research topic on this repo:
+   ```
+   mcp__deepwiki__ask_question({
+     repoName: "<owner/repo>",
+     question: "<rephrase the user's research query for DeepWiki>"
+   })
+   ```
+3. **Use the response to plan your research**: DeepWiki's answer will identify relevant components,
+   files, and architectural patterns. Use this to make your sub-agent prompts specific and targeted
+   rather than exploratory.
+
+**Guidelines:**
+- Rephrase the user's query to be specific and technical (e.g., "How does the orchestration monitor
+  track worker session state?" not "tell me about the monitor")
+- If the topic is broad, ask 1-2 focused questions rather than one vague one
+- DeepWiki results are a starting point — always verify with live code via sub-agents
 
 ### Step 1: Read any directly mentioned files first
 


### PR DESCRIPTION
## Summary
- **research-codebase** gets a new Step 0 that calls DeepWiki on the current repo before spawning sub-agents, providing a compressed codebase map that makes all subsequent research targeted instead of exploratory. Gracefully skips if DeepWiki MCP isn't installed or the repo isn't indexed.
- **oneshot** Phase 1 research now references research-codebase as the single source of truth (DRY) instead of duplicating the process inline — removed 16 lines of duplicated sub-agent/sync/tracking instructions.
- **create-plan** references research-codebase's process for its focused planning research.
- All four core skills (research-codebase, oneshot, create-plan, implement-plan) now have `mcp__deepwiki__ask_question` and `mcp__deepwiki__read_wiki_structure` in allowed-tools so they can ask DeepWiki specific questions at any point.

## Test plan
- [ ] Run `/catalyst-dev:research-codebase` on a repo indexed in DeepWiki — verify Step 0 fires and response informs sub-agent prompts
- [ ] Run `/catalyst-dev:research-codebase` on a repo NOT indexed — verify it skips gracefully
- [ ] Run `/catalyst-dev:oneshot` — verify it produces a research doc in thoughts/shared/research/
- [ ] Run `/catalyst-dev:create-plan` — verify it references research-codebase process
- [ ] Run `/catalyst-dev:implement-plan` — verify DeepWiki tool is accessible for ad-hoc questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)