### PR TITLE
feat(meta): add HumanLayer env vars and gitignore session-id

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,4 @@
 source_up
 use_otel_context "catalyst"
+export HUMANLAYER_PROFILE=coalesce-labs
+export HUMANLAYER_DIRECTORY=catalyst-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ research/
 .claude/config.json.backup
 .catalyst/config.json.backup
 
+# Session state (per-session, not committed)
+.catalyst/.session-id
+
 # Catalyst workflow state (per-session, not committed)
 # NOTE: .catalyst/config.json is SAFE to commit (only has projectKey, no secrets)
 # Secrets are stored in ~/.config/catalyst/config-*.json (never in repo)


### PR DESCRIPTION
## Summary
- Add `HUMANLAYER_PROFILE` and `HUMANLAYER_DIRECTORY` env vars to `.envrc` for HumanLayer integration
- Add `.catalyst/.session-id` to `.gitignore` (runtime state, same category as workflow-context files)

## Test plan
- [ ] Verify `direnv allow` picks up new env vars
- [ ] Confirm `.catalyst/.session-id` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)