### PR TITLE
fix(dev): disown watcher subshell before exec

### DIFF
--- a/plugins/dev/scripts/catalyst-claude.sh
+++ b/plugins/dev/scripts/catalyst-claude.sh
@@ -133,6 +133,7 @@ SESSION_ID_FILE="${WORKTREE_PATH}/.catalyst/.session-id"
   rm -f "$SESSION_ID_FILE" 2>/dev/null || true
   "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done 2>/dev/null || true
 ) &
+disown
 
 # ─── Replace process with claude ─────────────────────────────────────────────
 # After exec, this PID becomes claude. Warp sees "claude" in the process table.


### PR DESCRIPTION
## Summary
- Adds `disown` after the background watcher subshell `() &` in `catalyst-claude.sh` to fully detach it from bash's job table before `exec claude` replaces the process
- Defensive fix: prevents any edge case where bash might send SIGHUP to the watcher, and documents the intent that the watcher should outlive the shell

## Context
Follows up on feedback from #168. The watcher already works correctly because `exec` destroys the job table and the subshell has `trap '' INT TERM`, but `disown` is zero-cost insurance.

## Test plan
- [ ] Run `catalyst-claude` wrapper, verify session heartbeat and cleanup still work
- [ ] Verify watcher process survives after claude exits and performs cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)