### PR TITLE
feat(dev): backfill AI-enhanced notes and use LOCAL_ANTHROPIC_API_KEY

### DIFF
--- a/plugins/dev/CHANGELOG.md
+++ b/plugins/dev/CHANGELOG.md
@@ -1,38 +1,66 @@
 # Changelog
 
-## [6.36.0](https://github.com/coalesce-labs/catalyst/compare/catalyst-dev-v6.35.0...catalyst-dev-v6.36.0) (2026-04-16)
+## [6.36.0](https://github.com/coalesce-labs/catalyst/compare/catalyst-dev-v6.35.0...catalyst-dev-v6.36.0)
+
+Apr 16, 2026
+
+<!-- ai-enhanced -->
+
+### AI-Enhanced Changelogs and Homepage Badge
+
+All 51 catalyst-dev changelog entries now have Sonnet-generated titles and 2-4 sentence summaries. The website homepage gains a version badge that reads the latest release from CHANGELOG.md at build time. Changelog page styling follows a Conductor-inspired layout with small muted version numbers, bold release titles, and comfortable reading line-height. CI release note generation upgraded from Haiku to Sonnet, and a new `add-changelog-media` skill supports R2/CDN hosting for screenshots and GIF screencasts.
 
 
-### Features
+
+### PRs
 
 * **dev:** AI-enhanced changelogs with titles, homepage badge, and Conductor-style styling ([#170](https://github.com/coalesce-labs/catalyst/issues/170)) ([ebdaf99](https://github.com/coalesce-labs/catalyst/commit/ebdaf99061b9c4f4801abe77290e9c41712f096d))
 
-## [6.35.0](https://github.com/coalesce-labs/catalyst/compare/catalyst-dev-v6.34.2...catalyst-dev-v6.35.0) (2026-04-16)
+## [6.35.0](https://github.com/coalesce-labs/catalyst/compare/catalyst-dev-v6.34.2...catalyst-dev-v6.35.0)
 
-# Catalyst-Dev v6.35.0 Release
+Apr 16, 2026
 
-This release includes maintenance updates and preparation for the next development cycle. The changes ensure the codebase remains stable and ready for future feature development.
+<!-- ai-enhanced -->
 
-<details><summary>Detailed changes</summary>
+### Activity Feed and Task List Integration
+
+The orchestration monitor activity feed now shows tool names, text previews, and rate limit info instead of generic "new turn" labels. A new task list integration reads from `~/.claude/tasks/{sessionId}/` to display per-worker task progress with badges in the worker table and a collapsible task section in the detail drawer.
 
 
 
-### Features
+### PRs
 
 * **dev:** fix activity feed labels and add task list integration ([#165](https://github.com/coalesce-labs/catalyst/issues/165)) ([96e098e](https://github.com/coalesce-labs/catalyst/commit/96e098e3138045868ebdb5e45da2e1ff509ddfba))
 
-</details>
-## [6.34.2](https://github.com/coalesce-labs/catalyst/compare/catalyst-dev-v6.34.1...catalyst-dev-v6.34.2) (2026-04-16)
+## [6.34.2](https://github.com/coalesce-labs/catalyst/compare/catalyst-dev-v6.34.1...catalyst-dev-v6.34.2)
+
+Apr 16, 2026
+
+<!-- ai-enhanced -->
+
+### Watcher Subshell Detach
+
+Adds `disown` after the background watcher subshell in `catalyst-claude.sh` to fully detach it from bash's job table before `exec` replaces the process. This is a defensive fix that prevents any edge case where bash might send SIGHUP to the watcher on exit.
 
 
-### Bug Fixes
+
+### PRs
 
 * **dev:** disown watcher subshell before exec ([#171](https://github.com/coalesce-labs/catalyst/issues/171)) ([5a902b3](https://github.com/coalesce-labs/catalyst/commit/5a902b35d4aefe74d1d237cff00119e41683fc2b))
 
-## [6.34.1](https://github.com/coalesce-labs/catalyst/compare/catalyst-dev-v6.34.0...catalyst-dev-v6.34.1) (2026-04-16)
+## [6.34.1](https://github.com/coalesce-labs/catalyst/compare/catalyst-dev-v6.34.0...catalyst-dev-v6.34.1)
+
+Apr 16, 2026
+
+<!-- ai-enhanced -->
+
+### Warp Terminal Integration
+
+Replaces child-process `claude "$@"` with `exec claude "$@"` in the session wrapper so the process image becomes `claude` directly, restoring Warp's rich sidebar metadata (repo, branch, change count) and notification integration. Heartbeat and cleanup logic moves to a background watcher that polls the wrapper PID.
 
 
-### Bug Fixes
+
+### PRs
 
 * **dev:** exec claude in wrapper for Warp terminal integration ([#168](https://github.com/coalesce-labs/catalyst/issues/168)) ([59e7509](https://github.com/coalesce-labs/catalyst/commit/59e750958cd963aa42972f83a7aba1efcaf0de82))
 

--- a/scripts/backfill-release-notes.sh
+++ b/scripts/backfill-release-notes.sh
@@ -3,21 +3,25 @@
 # entries with AI-generated summaries.
 #
 # Usage:
-#   ANTHROPIC_API_KEY=sk-... bash scripts/backfill-release-notes.sh [plugin]
+#   LOCAL_ANTHROPIC_API_KEY=sk-... bash scripts/backfill-release-notes.sh [plugin]
 #
 # If plugin is omitted, processes all plugins. Otherwise just the named one.
 # Writes enhanced CHANGELOGs in-place with AI summaries inserted after each
 # version heading, preserving the original conventional changelog entries
 # (with PR links) below the summary.
+#
+# Uses LOCAL_ANTHROPIC_API_KEY to avoid conflicts with Claude Code's own
+# ANTHROPIC_API_KEY. Falls back to ANTHROPIC_API_KEY for CI environments.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO="${GITHUB_REPOSITORY:-coalesce-labs/catalyst}"
 PROMPT_TEMPLATE="$SCRIPT_DIR/templates/backfill-release-notes-prompt.md"
+API_KEY="${LOCAL_ANTHROPIC_API_KEY:-${ANTHROPIC_API_KEY:-}}"
 
-if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-  echo "Error: ANTHROPIC_API_KEY not set"
+if [[ -z "$API_KEY" ]]; then
+  echo "Error: LOCAL_ANTHROPIC_API_KEY (or ANTHROPIC_API_KEY) not set"
   exit 1
 fi
 
@@ -47,7 +51,7 @@ call_claude() {
 
   local response
   response=$(curl -sS --max-time 60 \
-    -H "x-api-key: $ANTHROPIC_API_KEY" \
+    -H "x-api-key: $API_KEY" \
     -H "anthropic-version: 2023-06-01" \
     -H "content-type: application/json" \
     -d "$request_body" \

--- a/scripts/enhance-release-notes.sh
+++ b/scripts/enhance-release-notes.sh
@@ -11,8 +11,12 @@ REPO="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq '.nameWithOw
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROMPT_TEMPLATE="$SCRIPT_DIR/templates/release-notes-prompt.md"
 
-if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-  echo "::warning::ANTHROPIC_API_KEY not set — skipping release notes enhancement"
+# Prefer LOCAL_ANTHROPIC_API_KEY to avoid conflicts with Claude Code's own key.
+# Falls back to ANTHROPIC_API_KEY for CI environments.
+API_KEY="${LOCAL_ANTHROPIC_API_KEY:-${ANTHROPIC_API_KEY:-}}"
+
+if [[ -z "$API_KEY" ]]; then
+  echo "::warning::LOCAL_ANTHROPIC_API_KEY (or ANTHROPIC_API_KEY) not set — skipping release notes enhancement"
   exit 0
 fi
 
@@ -196,7 +200,7 @@ if [[ -n "$head_branch" ]]; then
       }')
 
     plugin_response=$(curl -sS --max-time 30 \
-      -H "x-api-key: $ANTHROPIC_API_KEY" \
+      -H "x-api-key: $API_KEY" \
       -H "anthropic-version: 2023-06-01" \
       -H "content-type: application/json" \
       -d "$plugin_request" \


### PR DESCRIPTION
## Summary
- Backfills AI-enhanced changelog summaries for 6.34.1, 6.34.2, and 6.35.0 (the 3 releases since PR #170's original backfill)
- Updates `backfill-release-notes.sh` and `enhance-release-notes.sh` to prefer `LOCAL_ANTHROPIC_API_KEY` over `ANTHROPIC_API_KEY` to avoid conflicts with Claude Code's own key, with fallback for CI

## Test plan
- [x] All 54 changelog entries now have `<!-- ai-enhanced -->` markers
- [x] Scripts fall back to `ANTHROPIC_API_KEY` when `LOCAL_ANTHROPIC_API_KEY` is unset (CI compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)