### PR TITLE
fix(dev): claude-only worker dispatch with cd subshell (CTL-58, CTL-35)

### DIFF
--- a/plugins/dev/scripts/orchestrate-followup
+++ b/plugins/dev/scripts/orchestrate-followup
@@ -35,53 +35,99 @@ CREATE_WORKTREE="${SCRIPT_DIR}/create-worktree.sh"
 PARENT_TICKET=""
 FINDINGS=""
 TITLE=""
-ORCH_NAME="${CATALYST_ORCHESTRATOR_ID:-}"
-ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
+ORCH_NAME="${CATALYST_ORCHESTRATOR_ID-}"
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR-}"
 BASE_BRANCH="main"
 TEAM_KEY=""
 FORCED_TICKET=""
 DRY_RUN=0
 
 usage() {
-  sed -n '2,27p' "$0"
-  exit "${1:-1}"
+	sed -n '2,27p' "$0"
+	exit "${1:-1}"
 }
 
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --findings)    FINDINGS="$2"; shift 2 ;;
-    --title)       TITLE="$2"; shift 2 ;;
-    --orch)        ORCH_NAME="$2"; shift 2 ;;
-    --orch-dir)    ORCH_DIR="$2"; shift 2 ;;
-    --base-branch) BASE_BRANCH="$2"; shift 2 ;;
-    --team-key)    TEAM_KEY="$2"; shift 2 ;;
-    --ticket)      FORCED_TICKET="$2"; shift 2 ;;
-    --dry-run)     DRY_RUN=1; shift ;;
-    -h|--help)     usage 0 ;;
-    -*)            echo "unknown flag: $1" >&2; usage ;;
-    *)
-      if [ -z "$PARENT_TICKET" ]; then PARENT_TICKET="$1"; shift
-      else echo "unexpected arg: $1" >&2; usage; fi
-      ;;
-  esac
+	case "$1" in
+	--findings)
+		FINDINGS="$2"
+		shift 2
+		;;
+	--title)
+		TITLE="$2"
+		shift 2
+		;;
+	--orch)
+		ORCH_NAME="$2"
+		shift 2
+		;;
+	--orch-dir)
+		ORCH_DIR="$2"
+		shift 2
+		;;
+	--base-branch)
+		BASE_BRANCH="$2"
+		shift 2
+		;;
+	--team-key)
+		TEAM_KEY="$2"
+		shift 2
+		;;
+	--ticket)
+		FORCED_TICKET="$2"
+		shift 2
+		;;
+	--dry-run)
+		DRY_RUN=1
+		shift
+		;;
+	-h | --help) usage 0 ;;
+	-*)
+		echo "unknown flag: $1" >&2
+		usage
+		;;
+	*)
+		if [ -z "$PARENT_TICKET" ]; then
+			PARENT_TICKET="$1"
+			shift
+		else
+			echo "unexpected arg: $1" >&2
+			usage
+		fi
+		;;
+	esac
 done
 
-[ -z "$PARENT_TICKET" ] && { echo "ERROR: PARENT_TICKET required" >&2; usage; }
-[ -z "$FINDINGS" ]      && { echo "ERROR: --findings required" >&2; usage; }
-[ -z "$ORCH_NAME" ]     && { echo "ERROR: --orch (or \$CATALYST_ORCHESTRATOR_ID) required" >&2; exit 1; }
-[ -z "$ORCH_DIR" ]      && { echo "ERROR: --orch-dir (or \$CATALYST_ORCHESTRATOR_DIR) required" >&2; exit 1; }
+[ -z "$PARENT_TICKET" ] && {
+	echo "ERROR: PARENT_TICKET required" >&2
+	usage
+}
+[ -z "$FINDINGS" ] && {
+	echo "ERROR: --findings required" >&2
+	usage
+}
+# shellcheck disable=SC2016 # printing literal env-var names to guide the user
+[ -z "$ORCH_NAME" ] && {
+	echo 'ERROR: --orch (or $CATALYST_ORCHESTRATOR_ID) required' >&2
+	exit 1
+}
+# shellcheck disable=SC2016 # printing literal env-var names to guide the user
+[ -z "$ORCH_DIR" ] && {
+	echo 'ERROR: --orch-dir (or $CATALYST_ORCHESTRATOR_DIR) required' >&2
+	exit 1
+}
 
 if [ -z "$TITLE" ]; then
-  TITLE="Follow-up: ${PARENT_TICKET} post-merge findings"
+	TITLE="Follow-up: ${PARENT_TICKET} post-merge findings"
 fi
 
 if [ -z "$TEAM_KEY" ]; then
-  for CFG in ".catalyst/config.json" ".claude/config.json"; do
-    if [ -f "$CFG" ]; then
-      TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CFG" 2>/dev/null || true)
-      [ -n "$TEAM_KEY" ] && break
-    fi
-  done
+	for CFG in ".catalyst/config.json" ".claude/config.json"; do
+		if [ -f "$CFG" ]; then
+			TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CFG" 2>/dev/null || true)
+			[ -n "$TEAM_KEY" ] && break
+		fi
+	done
 fi
 
 DESCRIPTION="Follow-up to ${PARENT_TICKET}. Findings surfaced after merge:
@@ -92,37 +138,40 @@ This ticket was created by \`orchestrate-followup\`. The parent PR is merged; th
 change off \`${BASE_BRANCH}\`. See \`templates/followup-prompt.md\` for the worker contract."
 
 if [ "$DRY_RUN" -eq 1 ]; then
-  echo "[dry-run] parent: $PARENT_TICKET"
-  echo "[dry-run] title:  $TITLE"
-  echo "[dry-run] team:   ${TEAM_KEY:-UNKNOWN}"
-  echo "[dry-run] base:   $BASE_BRANCH"
-  echo "[dry-run] orch:   $ORCH_NAME"
-  echo "[dry-run] ticket: ${FORCED_TICKET:-<will create via linearis>}"
-  echo "[dry-run] description:"
-  echo "$DESCRIPTION" | sed 's/^/    /'
-  exit 0
+	echo "[dry-run] parent: $PARENT_TICKET"
+	echo "[dry-run] title:  $TITLE"
+	echo "[dry-run] team:   ${TEAM_KEY:-UNKNOWN}"
+	echo "[dry-run] base:   $BASE_BRANCH"
+	echo "[dry-run] orch:   $ORCH_NAME"
+	echo "[dry-run] ticket: ${FORCED_TICKET:-<will create via linearis>}"
+	echo "[dry-run] description:"
+	echo "$DESCRIPTION" | sed 's/^/    /'
+	exit 0
 fi
 
 # Step 1: Create (or accept) the follow-up ticket.
 if [ -n "$FORCED_TICKET" ]; then
-  NEW_TICKET="$FORCED_TICKET"
+	NEW_TICKET="$FORCED_TICKET"
 else
-  if ! command -v linearis >/dev/null 2>&1; then
-    echo "ERROR: linearis CLI required to create follow-up ticket (or pass --ticket <id>)" >&2
-    exit 1
-  fi
-  [ -z "$TEAM_KEY" ] && { echo "ERROR: --team-key required (or configure catalyst.linear.teamKey)" >&2; exit 1; }
+	if ! command -v linearis >/dev/null 2>&1; then
+		echo "ERROR: linearis CLI required to create follow-up ticket (or pass --ticket <id>)" >&2
+		exit 1
+	fi
+	[ -z "$TEAM_KEY" ] && {
+		echo "ERROR: --team-key required (or configure catalyst.linear.teamKey)" >&2
+		exit 1
+	}
 
-  CREATE_JSON=$(linearis issues create "$TITLE" \
-    --team "$TEAM_KEY" \
-    --description "$DESCRIPTION" \
-    --output json 2>/dev/null || true)
-  NEW_TICKET=$(echo "$CREATE_JSON" | jq -r '.identifier // empty' 2>/dev/null || true)
-  if [ -z "$NEW_TICKET" ]; then
-    echo "ERROR: failed to create Linear ticket — check linearis output" >&2
-    echo "$CREATE_JSON" >&2
-    exit 1
-  fi
+	CREATE_JSON=$(linearis issues create "$TITLE" \
+		--team "$TEAM_KEY" \
+		--description "$DESCRIPTION" \
+		--output json 2>/dev/null || true)
+	NEW_TICKET=$(echo "$CREATE_JSON" | jq -r '.identifier // empty' 2>/dev/null || true)
+	if [ -z "$NEW_TICKET" ]; then
+		echo "ERROR: failed to create Linear ticket — check linearis output" >&2
+		echo "$CREATE_JSON" >&2
+		exit 1
+	fi
 fi
 
 echo "Follow-up ticket: $NEW_TICKET (parent: $PARENT_TICKET)"
@@ -130,8 +179,8 @@ echo "Follow-up ticket: $NEW_TICKET (parent: $PARENT_TICKET)"
 # Step 2: Provision the worker worktree.
 WORKER_NAME="${ORCH_NAME}-${NEW_TICKET}"
 if [ ! -x "$CREATE_WORKTREE" ]; then
-  echo "ERROR: create-worktree.sh missing or not executable: $CREATE_WORKTREE" >&2
-  exit 1
+	echo "ERROR: create-worktree.sh missing or not executable: $CREATE_WORKTREE" >&2
+	exit 1
 fi
 "$CREATE_WORKTREE" "$WORKER_NAME" "$BASE_BRANCH" --orchestration "$ORCH_NAME"
 
@@ -142,7 +191,7 @@ WORKER_DIR="$(dirname "$ORCH_DIR")/${WORKER_NAME}"
 SIGNAL_FILE="${ORCH_DIR}/workers/${NEW_TICKET}.json"
 mkdir -p "${ORCH_DIR}/workers"
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-cat > "$SIGNAL_FILE" <<EOF
+cat >"$SIGNAL_FILE" <<EOF
 {
   "ticket": "${NEW_TICKET}",
   "orchestrator": "${ORCH_NAME}",
@@ -173,28 +222,28 @@ PROMPT_FILE="${ORCH_DIR}/workers/${NEW_TICKET}-prompt.md"
 PARENT_PR_URL=""
 PARENT_PR_NUMBER=""
 if command -v gh >/dev/null 2>&1; then
-  REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
-  PARENT_BRANCH="${ORCH_NAME}-${PARENT_TICKET}"
-  PARENT_PR_NUMBER=$(gh -R "$REPO" pr list --state merged --head "$PARENT_BRANCH" \
-    --json number --jq '.[0].number' 2>/dev/null || echo "")
-  if [ -n "$PARENT_PR_NUMBER" ]; then
-    PARENT_PR_URL=$(gh -R "$REPO" pr view "$PARENT_PR_NUMBER" --json url --jq '.url' 2>/dev/null || echo "")
-  fi
+	REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
+	PARENT_BRANCH="${ORCH_NAME}-${PARENT_TICKET}"
+	PARENT_PR_NUMBER=$(gh -R "$REPO" pr list --state merged --head "$PARENT_BRANCH" \
+		--json number --jq '.[0].number' 2>/dev/null || echo "")
+	if [ -n "$PARENT_PR_NUMBER" ]; then
+		PARENT_PR_URL=$(gh -R "$REPO" pr view "$PARENT_PR_NUMBER" --json url --jq '.url' 2>/dev/null || echo "")
+	fi
 fi
 PARENT_PR_NUMBER="${PARENT_PR_NUMBER:-UNKNOWN}"
 PARENT_PR_URL="${PARENT_PR_URL:-UNKNOWN}"
 
 awk -v tid="$NEW_TICKET" \
-    -v parent="$PARENT_TICKET" \
-    -v orch="$ORCH_NAME" \
-    -v wd="$WORKER_DIR" \
-    -v bn="$WORKER_NAME" \
-    -v bb="$BASE_BRANCH" \
-    -v sf="$SIGNAL_FILE" \
-    -v findings="$FINDINGS" \
-    -v ppurl="$PARENT_PR_URL" \
-    -v ppnum="$PARENT_PR_NUMBER" \
-'{
+	-v parent="$PARENT_TICKET" \
+	-v orch="$ORCH_NAME" \
+	-v wd="$WORKER_DIR" \
+	-v bn="$WORKER_NAME" \
+	-v bb="$BASE_BRANCH" \
+	-v sf="$SIGNAL_FILE" \
+	-v findings="$FINDINGS" \
+	-v ppurl="$PARENT_PR_URL" \
+	-v ppnum="$PARENT_PR_NUMBER" \
+	'{
   gsub(/\$\{TICKET_ID\}/, tid);
   gsub(/\$\{PARENT_TICKET\}/, parent);
   gsub(/\$\{ORCH_NAME\}/, orch);
@@ -206,8 +255,8 @@ awk -v tid="$NEW_TICKET" \
   gsub(/\$\{PARENT_PR_URL\}/, ppurl);
   gsub(/\$\{PARENT_PR_NUMBER\}/, ppnum);
   print;
-}' "$TEMPLATE_PROMPT" > "$PROMPT_FILE"
+}' "$TEMPLATE_PROMPT" >"$PROMPT_FILE"
 echo "Wrote prompt: $PROMPT_FILE"
 echo ""
 echo "Dispatch the follow-up worker with:"
-echo "  claude -n \"${WORKER_NAME}\" -w \"${WORKER_DIR}\" --output-format stream-json --verbose -p \"\$(cat ${PROMPT_FILE})\" > \"${ORCH_DIR}/workers/${NEW_TICKET}-stream.jsonl\" 2>/dev/null &"
+echo "  ( cd \"${WORKER_DIR}\" && exec nohup claude -n \"${WORKER_NAME}\" --output-format stream-json --verbose --dangerously-skip-permissions -p \"\$(cat ${PROMPT_FILE})\" ) > \"${ORCH_DIR}/workers/${NEW_TICKET}-stream.jsonl\" 2> \"${ORCH_DIR}/workers/${NEW_TICKET}-stderr.log\" &"

--- a/plugins/dev/skills/create-worktree/SKILL.md
+++ b/plugins/dev/skills/create-worktree/SKILL.md
@@ -44,10 +44,11 @@ When this command is invoked:
 
 4. **Project setup** (handled by script based on config):
 
-   If `catalyst.worktree.setup` is defined in config, those commands run in order.
-   Otherwise, the script auto-detects: dependency install (`bun/npm`) + thoughts init.
+   If `catalyst.worktree.setup` is defined in config, those commands run in order. Otherwise, the
+   script auto-detects: dependency install (`bun/npm`) + thoughts init.
 
    Example config for full control:
+
    ```json
    {
      "catalyst": {
@@ -64,12 +65,17 @@ When this command is invoked:
    ```
 
 5. **Optional: Launch implementation session**: If a plan file path was provided, ask if the user
-   wants to launch Claude in the worktree:
+   wants to launch Claude in the worktree. Note: `claude -w` takes a _name_ and creates a new
+   worktree — so `cd` into the already-created worktree instead, capture stderr to a real file for
+   post-mortem debugging, and use `--dangerously-skip-permissions` since there's no TTY.
    ```bash
-   claude -w <worktree_path> \
-     -p "/catalyst-dev:implement-plan <plan_path> and when done: create commit, create PR, update Linear ticket" \
-     --output-format stream-json --verbose \
-     > "<worktree_path>/worker-stream.jsonl" 2>/dev/null &
+   (
+     cd "<worktree_path>" || exit 1
+     exec nohup claude \
+       --output-format stream-json --verbose \
+       --dangerously-skip-permissions \
+       -p "/catalyst-dev:implement-plan <plan_path> and when done: create commit, create PR, update Linear ticket"
+   ) > "<worktree_path>/worker-stream.jsonl" 2> "<worktree_path>/worker-stderr.log" &
    ```
 
 ## Worktree Location Convention

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: orchestrate
-description: Coordinate multiple tickets in parallel across worktrees with wave-based execution, worker dispatch, and adversarial verification
+description:
+  Coordinate multiple tickets in parallel across worktrees with wave-based execution, worker
+  dispatch, and adversarial verification
 disable-model-invocation: true
 allowed-tools: Read, Write, Bash, Task, Grep, Glob, Agent
 version: 1.0.0
@@ -10,8 +12,8 @@ version: 1.0.0
 
 Coordinate multiple Linear tickets in parallel across git worktrees. The orchestrator creates
 worktrees, dispatches `/oneshot` workers, tracks progress via a dashboard, and enforces quality
-gates through adversarial verification. **The orchestrator NEVER writes application code** — it
-only coordinates, monitors, and verifies.
+gates through adversarial verification. **The orchestrator NEVER writes application code** — it only
+coordinates, monitors, and verifies.
 
 ## Prerequisites
 
@@ -54,18 +56,18 @@ fi
 
 ## Flags
 
-| Flag | Description |
-|------|-------------|
-| `--name <name>` | Name this orchestrator instance (default: auto-generated from tickets) |
-| `--project <name>` | Pull tickets from a Linear project |
-| `--cycle current` | Pull tickets from the current Linear cycle |
-| `--file <path>` | Read ticket IDs from a file (one per line) |
-| `--auto-merge` | Workers auto-merge PRs when CI + verification pass |
-| `--max-parallel <n>` | Override config `maxParallel` (default: 3) |
-| `--base-branch <branch>` | Base branch for worktrees (default: main) |
-| `--interactive` | Include PM intake phase before orchestration |
-| `--prd <path>` | Run PRD review panel + ticket creation before orchestration |
-| `--dry-run` | Show wave plan without executing |
+| Flag                     | Description                                                            |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `--name <name>`          | Name this orchestrator instance (default: auto-generated from tickets) |
+| `--project <name>`       | Pull tickets from a Linear project                                     |
+| `--cycle current`        | Pull tickets from the current Linear cycle                             |
+| `--file <path>`          | Read ticket IDs from a file (one per line)                             |
+| `--auto-merge`           | Workers auto-merge PRs when CI + verification pass                     |
+| `--max-parallel <n>`     | Override config `maxParallel` (default: 3)                             |
+| `--base-branch <branch>` | Base branch for worktrees (default: main)                              |
+| `--interactive`          | Include PM intake phase before orchestration                           |
+| `--prd <path>`           | Run PRD review panel + ticket creation before orchestration            |
+| `--dry-run`              | Show wave plan without executing                                       |
 
 ## Configuration
 
@@ -124,8 +126,8 @@ It NEVER:
 
 ### Phase 1: Intake & Dependency Analysis
 
-1. **Resolve tickets**: Based on invocation mode, use the Linearis CLI to fetch ticket data.
-   **For exact CLI syntax, run `linearis issues usage` or `linearis cycles usage`** — do not guess.
+1. **Resolve tickets**: Based on invocation mode, use the Linearis CLI to fetch ticket data. **For
+   exact CLI syntax, run `linearis issues usage` or `linearis cycles usage`** — do not guess.
    - Explicit IDs: read each ticket's full details
    - `--project`: list issues filtered by project name
    - `--cycle current`: list the active cycle, then list its issues
@@ -171,6 +173,7 @@ Proceed? [Y/n]
 ### Phase 2: Provision Worktrees
 
 Determine worktree base directory (in priority order):
+
 1. `catalyst.orchestration.worktreeDir` from config
 2. `${GITHUB_SOURCE_ROOT}/<org>/<repo>-worktrees/` (from env var + git remote)
 3. `~/wt/<repo>/` (fallback)
@@ -193,9 +196,9 @@ WORKER_COMMAND=$(jq -r '.catalyst.orchestration.workerCommand // "/catalyst-dev:
 WORKER_MODEL=$(jq -r '.catalyst.orchestration.workerModel // "opus"' "$CONFIG_FILE" 2>/dev/null)
 ```
 
-**Create ALL worktrees using `create-worktree.sh`** — both orchestrator and workers go
-through the same script so they all get `.claude/`, `.catalyst/`, dependency install,
-thoughts init, and custom hooks:
+**Create ALL worktrees using `create-worktree.sh`** — both orchestrator and workers go through the
+same script so they all get `.claude/`, `.catalyst/`, dependency install, thoughts init, and custom
+hooks:
 
 ```bash
 # The create-worktree.sh script lives relative to this plugin
@@ -226,15 +229,14 @@ for TICKET_ID in "${WAVE_TICKETS[@]}"; do
 done
 ```
 
-**Where worktrees actually land** — the `create-worktree.sh` script resolves the base
-directory in this priority order:
+**Where worktrees actually land** — the `create-worktree.sh` script resolves the base directory in
+this priority order:
 
 1. `--worktree-dir <path>` flag (from `catalyst.orchestration.worktreeDir` config)
 2. `~/catalyst/wt/<projectKey>/` (default — reads `catalyst.projectKey` from config)
 3. `~/catalyst/wt/<repo>/` (fallback if no config)
 
-So for a project with `projectKey: "acme"` and no `worktreeDir` override, all worktrees
-land in:
+So for a project with `projectKey: "acme"` and no `worktreeDir` override, all worktrees land in:
 
 ```
 ~/catalyst/wt/acme/
@@ -260,9 +262,7 @@ With `worktreeDir: "~/catalyst/api"` explicitly configured:
 ```json
 {
   "permissions": {
-    "additionalDirectories": [
-      "/Users/you/catalyst"
-    ]
+    "additionalDirectories": ["/Users/you/catalyst"]
   }
 }
 ```
@@ -273,10 +273,12 @@ With `worktreeDir: "~/catalyst/api"` explicitly configured:
 2. Copies `.claude/` directory (Claude Code native config, plugins, rules)
 3. Copies `.catalyst/` directory (Catalyst workflow config, if it exists)
 4. **Runs `catalyst.worktree.setup` commands from config** — dependency install, thoughts init,
-   permission grants, or any project-specific setup (like Conductor's `conductor.json` lifecycle hooks)
-5. If no `catalyst.worktree.setup` configured, falls back to auto-detected setup: `make setup`
-   or `bun/npm install`, then `humanlayer thoughts init` + `sync`
-6. Runs additional orchestration hooks from `--hooks-json` (from `catalyst.orchestration.hooks.setup`)
+   permission grants, or any project-specific setup (like Conductor's `conductor.json` lifecycle
+   hooks)
+5. If no `catalyst.worktree.setup` configured, falls back to auto-detected setup: `make setup` or
+   `bun/npm install`, then `humanlayer thoughts init` + `sync`
+6. Runs additional orchestration hooks from `--hooks-json` (from
+   `catalyst.orchestration.hooks.setup`)
 
 **Available variables in setup commands:** `${WORKTREE_PATH}`, `${BRANCH_NAME}`, `${TICKET_ID}`,
 `${REPO_NAME}`, `${DIRECTORY}`, `${PROFILE}`
@@ -300,10 +302,19 @@ ${ORCH_DIR}/
 ├── DASHBOARD.md                    # human-readable status (from template)
 ├── state.json                      # machine-readable orchestration state
 └── workers/                        # worker signal files written here
-    ├── ${TICKET_1}.json
+    ├── ${TICKET_1}.json            # worker signal (schema: worker-signal.json)
+    ├── ${TICKET_1}-stream.jsonl    # streaming JSON events from claude CLI
+    ├── ${TICKET_1}-stderr.log      # worker stderr (silent exits diagnosable)
     ├── ${TICKET_2}.json
+    ├── ${TICKET_2}-stream.jsonl
+    ├── ${TICKET_2}-stderr.log
     └── ...
 ```
+
+**Debugging silent worker exits:** If `${TICKET_ID}-stream.jsonl` is 0 bytes AND
+`${TICKET_ID}-stderr.log` is 0 bytes, the worker exited before emitting its first event — check
+`git -C ${WORKER_DIR} log --oneline -5` and the worktree's `.claude/` directory for setup issues. A
+non-empty stderr log will identify permission, path, or environment errors.
 
 Initialize `state.json`:
 
@@ -371,8 +382,8 @@ REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git
   }')"
 ```
 
-The `CATALYST_ORCHESTRATOR_ID` is set to `${ORCH_NAME}` for use by workers (passed via
-environment variable alongside `CATALYST_ORCHESTRATOR_DIR`).
+The `CATALYST_ORCHESTRATOR_ID` is set to `${ORCH_NAME}` for use by workers (passed via environment
+variable alongside `CATALYST_ORCHESTRATOR_DIR`).
 
 **Start session tracking** (alongside the global state registration above):
 
@@ -396,18 +407,30 @@ For each provisioned worker worktree, dispatch a `/oneshot` session.
 ```bash
 WORKER_DIR="${WORKTREES_BASE}/${ORCH_NAME}-${TICKET_ID}"
 WORKER_STREAM="${ORCH_DIR}/workers/${TICKET_ID}-stream.jsonl"
+WORKER_STDERR="${ORCH_DIR}/workers/${TICKET_ID}-stderr.log"
 SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET_ID}.json"
 
-CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
-CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
-CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
-claude \
-  -n "${ORCH_NAME}-${TICKET_ID}" \
-  -w "${WORKER_DIR}" \
-  --output-format stream-json \
-  --verbose \
-  -p "${WORKER_COMMAND} ${TICKET_ID} --auto-merge" \
-  > "$WORKER_STREAM" 2>/dev/null &
+# `claude -w` takes a *name* and creates a new worktree — it does NOT accept a
+# path to an existing worktree. The worker worktree was already provisioned in
+# Phase 2, so `cd` into it inside a backgrounded subshell and `exec` claude so
+# its PID is reachable from the outer shell as `$!`.
+# `--dangerously-skip-permissions` is required because headless workers have no
+# TTY to answer permission prompts; the worktree is pre-trusted via Catalyst's
+# setup hooks. `nohup` keeps the worker alive after the orchestrator shell
+# exits. Stderr goes to a real file (not /dev/null) so a silent worker exit
+# stays debuggable.
+(
+  cd "${WORKER_DIR}" || exit 1
+  CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
+  CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
+  CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
+  exec nohup claude \
+    -n "${ORCH_NAME}-${TICKET_ID}" \
+    --output-format stream-json \
+    --verbose \
+    --dangerously-skip-permissions \
+    -p "${WORKER_COMMAND} ${TICKET_ID} --auto-merge"
+) > "$WORKER_STREAM" 2> "$WORKER_STDERR" &
 
 WORKER_PID=$!
 
@@ -419,18 +442,18 @@ if [ -f "$SIGNAL_FILE" ]; then
 fi
 ```
 
-**Streaming JSON output** (`--output-format stream-json --verbose`) emits NDJSON to stdout,
-one event per line, in real-time as the worker runs. The monitor can tail the stream file to
-show live worker activity. Key event types:
+**Streaming JSON output** (`--output-format stream-json --verbose`) emits NDJSON to stdout, one
+event per line, in real-time as the worker runs. The monitor can tail the stream file to show live
+worker activity. Key event types:
 
-| Event | What it signals |
-|-------|----------------|
-| `{"type":"system","subtype":"init"}` | Worker session started; contains `session_id` |
+| Event                                                                                                             | What it signals                                                 |
+| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `{"type":"system","subtype":"init"}`                                                                              | Worker session started; contains `session_id`                   |
 | `{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"..."}}}` | Worker is now invoking a specific tool (Bash, Read, Edit, etc.) |
-| `{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta"}}}` | Worker is generating reasoning/response text |
-| `{"type":"assistant"}` | Complete assistant turn with all content blocks |
-| `{"type":"system","subtype":"api_retry"}` | Worker hit rate limit / error; shows attempt and delay |
-| `{"type":"result"}` | Worker finished; contains final answer and usage stats |
+| `{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta"}}}`                    | Worker is generating reasoning/response text                    |
+| `{"type":"assistant"}`                                                                                            | Complete assistant turn with all content blocks                 |
+| `{"type":"system","subtype":"api_retry"}`                                                                         | Worker hit rate limit / error; shows attempt and delay          |
+| `{"type":"result"}`                                                                                               | Worker finished; contains final answer and usage stats          |
 
 When the worker process exits, parse usage from the final `result` event:
 
@@ -558,8 +581,8 @@ if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
 fi
 ```
 
-The orchestrator polls worker status on a regular interval. Use `/loop` if available, otherwise
-poll manually.
+The orchestrator polls worker status on a regular interval. Use `/loop` if available, otherwise poll
+manually.
 
 **Monitoring loop (every 2-3 minutes):**
 
@@ -590,6 +613,7 @@ done
 ```
 
 **Update `DASHBOARD.md`** after each poll using the dashboard template. Include:
+
 - Wave progress (current wave, tickets per wave)
 - Per-worker status table (ticket, status, PR, test coverage columns)
 - Event log (timestamped significant events)
@@ -619,8 +643,8 @@ done
 
 Workers exit at `pr-created` with auto-merge armed. The orchestrator — which survives subprocess
 exits and stays alive across the entire run — owns the long poll that confirms the merge actually
-happens. On each monitoring cycle, for every worker in `pr-created`/`merging` status whose PR is
-not yet known-merged, ping GitHub directly:
+happens. On each monitoring cycle, for every worker in `pr-created`/`merging` status whose PR is not
+yet known-merged, ping GitHub directly:
 
 ```bash
 for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
@@ -725,8 +749,8 @@ if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
 fi
 ```
 
-When a worker signals "done" (PR created, CI green), the orchestrator does NOT trust it.
-It spawns an **adversarial verification agent** in the worker's worktree:
+When a worker signals "done" (PR created, CI green), the orchestrator does NOT trust it. It spawns
+an **adversarial verification agent** in the worker's worktree:
 
 ```bash
 # Run adversarial verification
@@ -740,10 +764,10 @@ It spawns an **adversarial verification agent** in the worker's worktree:
 
 The verification script checks:
 
-1. **Unit tests**: For each new/modified source file, verify a corresponding test file exists.
-   Run the test suite, verify tests pass.
-2. **API tests**: If API routes were added/modified, verify test coverage exists (Bruno
-   collections, integration tests, etc.).
+1. **Unit tests**: For each new/modified source file, verify a corresponding test file exists. Run
+   the test suite, verify tests pass.
+2. **API tests**: If API routes were added/modified, verify test coverage exists (Bruno collections,
+   integration tests, etc.).
 3. **Functional tests**: If UI was changed, verify functional/E2E test coverage exists.
 4. **Type safety**: Run typecheck command, verify no errors.
 5. **Security**: Check for OWASP top 10 patterns in new code.
@@ -809,15 +833,16 @@ Update your worker signal file when fixed. The orchestrator will re-verify.
 
 When ALL tickets in the current wave pass verification:
 
-1. **Confirm merges**: If `--auto-merge`, the Phase 4 orchestrator-owned poll loop already
-   observed `state=MERGED` for each worker and recorded `pr.mergedAt`. Before advancing the
-   wave, double-check every worker in this wave has `status="done"` with a non-null
-   `pr.mergedAt` in its signal file. If any still show `pr-created` or `merging`, run one more
-   Phase 4 poll cycle before proceeding. If `--auto-merge` is off, flag these PRs for human
-   review on the dashboard instead of advancing.
+1. **Confirm merges**: If `--auto-merge`, the Phase 4 orchestrator-owned poll loop already observed
+   `state=MERGED` for each worker and recorded `pr.mergedAt`. Before advancing the wave,
+   double-check every worker in this wave has `status="done"` with a non-null `pr.mergedAt` in its
+   signal file. If any still show `pr-created` or `merging`, run one more Phase 4 poll cycle before
+   proceeding. If `--auto-merge` is off, flag these PRs for human review on the dashboard instead of
+   advancing.
 
-2. **Write wave briefing** for the next wave (see Wave Briefing section below).
-   Then persist a copy to the thoughts repository so it survives worktree cleanup:
+2. **Write wave briefing** for the next wave (see Wave Briefing section below). Then persist a copy
+   to the thoughts repository so it survives worktree cleanup:
+
    ```bash
    HANDOFF_DIR="thoughts/shared/handoffs/${ORCH_NAME}"
    mkdir -p "${HANDOFF_DIR}"
@@ -827,6 +852,7 @@ When ALL tickets in the current wave pass verification:
    ```
 
 3. **Clean up completed worktrees**: Run teardown hooks from config, then remove.
+
    ```bash
    WORKER_DIR="${WORKTREES_BASE}/${ORCH_NAME}-${TICKET_ID}"
    BRANCH_NAME="${ORCH_NAME}-${TICKET_ID}"
@@ -851,6 +877,7 @@ When ALL tickets in the current wave pass verification:
    `create-worktree.sh` invocation from Phase 2.
 
 5. **Dispatch next wave workers**: Include wave briefing in dispatch prompt:
+
    ```
    IMPORTANT: Read the Wave ${PREV} briefing before starting:
      ${ORCH_DIR}/wave-${PREV}-briefing.md
@@ -885,6 +912,7 @@ When all waves are complete:
    - Any verification failures that required remediation
 
    Then persist summary and any remaining briefings to thoughts:
+
    ```bash
    HANDOFF_DIR="thoughts/shared/handoffs/${ORCH_NAME}"
    mkdir -p "${HANDOFF_DIR}"
@@ -893,8 +921,8 @@ When all waves are complete:
       "${HANDOFF_DIR}/${TIMESTAMP}_${ORCH_NAME}-summary.md"
    ```
 
-2. **Verify Linear states**: Check all tickets are in `stateMap.done`. If any are stuck,
-   update them using the Linearis CLI (run `linearis issues usage` for update syntax).
+2. **Verify Linear states**: Check all tickets are in `stateMap.done`. If any are stuck, update them
+   using the Linearis CLI (run `linearis issues usage` for update syntax).
 
 3. **Clean up all worktrees** (including orchestrator worktree, unless user wants to keep it).
 
@@ -919,6 +947,7 @@ fi
 ```
 
 6. **Report to user**:
+
    ```
    Orchestration Complete — "api-redesign"
 
@@ -937,26 +966,26 @@ fi
 
 ## Wave Briefing Documents
 
-Before dispatching each wave after Wave 1, the orchestrator writes a **briefing document**
-to `${ORCH_DIR}/wave-${N}-briefing.md` summarizing what prior waves learned.
+Before dispatching each wave after Wave 1, the orchestrator writes a **briefing document** to
+`${ORCH_DIR}/wave-${N}-briefing.md` summarizing what prior waves learned.
 
 **How the briefing is created:**
 
 1. Read each completed worker's PR description
 2. Read git diff summaries from each merged PR (`git diff --stat`)
 3. Read any research documents workers saved to `thoughts/shared/`
-4. Synthesize into: patterns established, new dependencies added, test helpers created,
-   gotchas discovered
-5. **Pre-assign Supabase migration numbers** for the upcoming wave (see Migration Number
-   Assignments below)
+4. Synthesize into: patterns established, new dependencies added, test helpers created, gotchas
+   discovered
+5. **Pre-assign Supabase migration numbers** for the upcoming wave (see Migration Number Assignments
+   below)
 
 Use the wave briefing template from `plugins/dev/templates/orchestrate-wave-briefing.md`.
 
 ### Migration Number Assignments (CTL-29)
 
-When two tickets in the same wave both add a Supabase migration, they can race on the same
-`NNN_` filename prefix — whichever PR merges first wins, the other must rebase post-PR. The
-orchestrator pre-assigns numbers in the briefing to prevent this.
+When two tickets in the same wave both add a Supabase migration, they can race on the same `NNN_`
+filename prefix — whichever PR merges first wins, the other must rebase post-PR. The orchestrator
+pre-assigns numbers in the briefing to prevent this.
 
 **Generation step** (run before rendering the template):
 
@@ -975,27 +1004,28 @@ The script replaces the `${MIGRATION_ASSIGNMENTS}` placeholder in the briefing t
 **Detection heuristic** (matches `pre-assign-migrations.sh`):
 
 - Label match (case-insensitive): `database`, `migration`, `schema`
-- Keyword match in title or description (case-insensitive): `supabase/migrations`,
-  `migration`, `schema`, `ALTER TABLE`, `CREATE TABLE`
+- Keyword match in title or description (case-insensitive): `supabase/migrations`, `migration`,
+  `schema`, `ALTER TABLE`, `CREATE TABLE`
 
 **Behavior:**
 
-- If `supabase/migrations/` does not exist in the orchestrator worktree, the script emits
-  nothing (repo-agnostic — projects without Supabase are unaffected).
+- If `supabase/migrations/` does not exist in the orchestrator worktree, the script emits nothing
+  (repo-agnostic — projects without Supabase are unaffected).
 - If no ticket in the wave is migration-likely, it emits nothing.
-- Otherwise it scans for the highest existing `NNN_` prefix and assigns `NNN+1`, `NNN+2`, ...
-  to each migration-likely ticket in input order.
+- Otherwise it scans for the highest existing `NNN_` prefix and assigns `NNN+1`, `NNN+2`, ... to
+  each migration-likely ticket in input order.
 
 **Tests:** `plugins/dev/scripts/__tests__/pre-assign-migrations.test.sh` covers the detection
 heuristic, the scanning logic, repo-agnostic fallback, and sequential assignment.
 
-**Thoughts persistence:** Every briefing is copied to `thoughts/shared/handoffs/${ORCH_NAME}/`
-with timestamped filenames (`YYYY-MM-DD_HH-MM-SS_wave-N-briefing.md`). This ensures briefings
-survive worktree cleanup and are available via thoughts sync across workspaces.
-The final `SUMMARY.md` is also persisted there at completion.
+**Thoughts persistence:** Every briefing is copied to `thoughts/shared/handoffs/${ORCH_NAME}/` with
+timestamped filenames (`YYYY-MM-DD_HH-MM-SS_wave-N-briefing.md`). This ensures briefings survive
+worktree cleanup and are available via thoughts sync across workspaces. The final `SUMMARY.md` is
+also persisted there at completion.
 
-**Why this matters:** This is a unique advantage over other frameworks. GSD executors are
-stateless. Gas Town Polecats don't share findings. Wave briefings mean:
+**Why this matters:** This is a unique advantage over other frameworks. GSD executors are stateless.
+Gas Town Polecats don't share findings. Wave briefings mean:
+
 - Wave 2+ workers know which patterns to follow
 - Wave 2+ workers know which test helpers exist
 - Wave 2+ workers know about gotchas discovered by earlier waves
@@ -1005,29 +1035,30 @@ stateless. Gas Town Polecats don't share findings. Wave briefings mean:
 
 ### Layer 1 — Dispatch Prompt (Prevention)
 
-Every worker dispatch includes mandatory testing requirements in the prompt itself.
-Not a suggestion — a hard requirement. The prompt explicitly states that work will be
-independently verified and workers should not claim done without tests.
+Every worker dispatch includes mandatory testing requirements in the prompt itself. Not a suggestion
+— a hard requirement. The prompt explicitly states that work will be independently verified and
+workers should not claim done without tests.
 
 ### Layer 2 — Quality Gates (Automated)
 
-The existing quality gate system (`/validate-type-safety`, `/security-review`,
-`code-reviewer`, `pr-test-analyzer`) plus config-based gates run inside each worker's
-`/oneshot` pipeline. These are the worker's own self-checks.
+The existing quality gate system (`/validate-type-safety`, `/security-review`, `code-reviewer`,
+`pr-test-analyzer`) plus config-based gates run inside each worker's `/oneshot` pipeline. These are
+the worker's own self-checks.
 
 ### Layer 3 — Independent Verification (Adversarial)
 
-The orchestrator's own verification script audits the worker's output AFTER the worker
-claims done. This is the anti-reward-hacking layer — the worker can't game its own quality
-gates because the orchestrator runs a separate, adversarial check. The verification agent
-has no incentive to pass — it's scored on catching gaps, not shipping fast.
+The orchestrator's own verification script audits the worker's output AFTER the worker claims done.
+This is the anti-reward-hacking layer — the worker can't game its own quality gates because the
+orchestrator runs a separate, adversarial check. The verification agent has no incentive to pass —
+it's scored on catching gaps, not shipping fast.
 
 ## Dashboard
 
-The orchestrator maintains a live dashboard at `${ORCH_DIR}/DASHBOARD.md`. Updated after
-each monitoring poll. Uses the template from `plugins/dev/templates/orchestrate-dashboard.md`.
+The orchestrator maintains a live dashboard at `${ORCH_DIR}/DASHBOARD.md`. Updated after each
+monitoring poll. Uses the template from `plugins/dev/templates/orchestrate-dashboard.md`.
 
 The dashboard includes:
+
 - Orchestrator metadata (name, start time, project, base branch)
 - Current wave progress
 - Per-worker status table with test coverage columns
@@ -1038,29 +1069,33 @@ The dashboard includes:
 
 The orchestrator manages Linear state transitions as a safety net:
 
-| Event | Linear Action |
-|-------|--------------|
-| Worker dispatched | Move ticket to `stateMap.inProgress` |
-| Worker creates PR | Verify ticket is `stateMap.inReview` — fix if not |
-| Worker passes verification | No change (already in review) |
-| PR merged | Verify ticket is `stateMap.done` — fix if not |
-| Worker fails/stalls | Add comment with status, keep `inProgress` |
+| Event                      | Linear Action                                     |
+| -------------------------- | ------------------------------------------------- |
+| Worker dispatched          | Move ticket to `stateMap.inProgress`              |
+| Worker creates PR          | Verify ticket is `stateMap.inReview` — fix if not |
+| Worker passes verification | No change (already in review)                     |
+| PR merged                  | Verify ticket is `stateMap.done` — fix if not     |
+| Worker fails/stalls        | Add comment with status, keep `inProgress`        |
 
-The orchestrator also adds comments to tickets for visibility using the Linearis CLI
-(run `linearis comments usage` for syntax).
+The orchestrator also adds comments to tickets for visibility using the Linearis CLI (run
+`linearis comments usage` for syntax).
 
 ## Named Orchestrators & Remote Control
 
-Start the orchestrator with remote control for access from claude.ai/code:
+Start the orchestrator with remote control for access from claude.ai/code. The orchestrator worktree
+was already created in Phase 2, so `cd` into it — do not pass `-w` (that would ask claude to create
+a _new_ worktree using the path as a name):
+
 ```bash
-claude --remote-control "${ORCH_NAME}" -w "${ORCH_DIR}"
+( cd "${ORCH_DIR}" && claude --remote-control "${ORCH_NAME}" )
 ```
 
-Workers should NOT use remote control — they're autonomous. The human monitors workers
-through the orchestrator's dashboard.
+Workers should NOT use remote control — they're autonomous. The human monitors workers through the
+orchestrator's dashboard.
 
-**Multiple orchestrators** can run concurrently. Worktree names are prefixed with the
-orchestrator name to avoid collisions:
+**Multiple orchestrators** can run concurrently. Worktree names are prefixed with the orchestrator
+name to avoid collisions:
+
 ```
 ${WORKTREE_BASE}/
 ├── auth-orch/                    # orchestrator 1
@@ -1073,12 +1108,12 @@ ${WORKTREE_BASE}/
 
 ## Worker Communication
 
-Workers write status updates to `${ORCH_DIR}/workers/${TICKET_ID}.json`. The `/oneshot`
-skill detects orchestrator presence by checking for a sibling `orchestrator/` directory or
-the `CATALYST_ORCHESTRATOR_DIR` environment variable.
+Workers write status updates to `${ORCH_DIR}/workers/${TICKET_ID}.json`. The `/oneshot` skill
+detects orchestrator presence by checking for a sibling `orchestrator/` directory or the
+`CATALYST_ORCHESTRATOR_DIR` environment variable.
 
-**Worker signal file schema:** See `plugins/dev/templates/worker-signal.json` for the full
-JSON schema including the `definitionOfDone` block.
+**Worker signal file schema:** See `plugins/dev/templates/worker-signal.json` for the full JSON
+schema including the `definitionOfDone` block.
 
 **How workers detect orchestrator mode:**
 
@@ -1116,19 +1151,19 @@ Did the PR already merge?
 ```
 
 Ask `gh pr view $PR_NUMBER --json state` before choosing. `OPEN` → fix-up. `MERGED`/`CLOSED` →
-follow-up. If the PR is `MERGED` you physically cannot push to that branch anymore; a fix-up
-attempt will fail silently or push to an orphan branch.
+follow-up. If the PR is `MERGED` you physically cannot push to that branch anymore; a fix-up attempt
+will fail silently or push to an orphan branch.
 
 ### Pattern A: Fix-up Worker (PR still open)
 
-Used on ADV-219 / PR #130 and ADV-220 / PR #132 during `orch-data-import-2026-04-13`. The
-original worker exited at `pr-created`. Codex or a security scanner posted inline threads after.
-Auto-merge is blocked on unresolved threads.
+Used on ADV-219 / PR #130 and ADV-220 / PR #132 during `orch-data-import-2026-04-13`. The original
+worker exited at `pr-created`. Codex or a security scanner posted inline threads after. Auto-merge
+is blocked on unresolved threads.
 
 **When to use:**
+
 - `pr.state = OPEN`
-- Blockers are specific and file:line-scoped (inline review comments, CI test failures, lint
-  errors)
+- Blockers are specific and file:line-scoped (inline review comments, CI test failures, lint errors)
 - The remediation is a small targeted patch, not a re-design
 
 **How the orchestrator dispatches:**
@@ -1143,12 +1178,15 @@ test/auth.test.ts: add regression test for the null-token path" \
 ```
 
 What this does:
+
 1. Renders `templates/fixup-prompt.md` → `${ORCH_DIR}/workers/fixup-${TICKET}-prompt.md`
-2. Renders `templates/dispatch-fixup.sh.template` → `${ORCH_DIR}/workers/dispatch-fixup-${TICKET}.sh`
+2. Renders `templates/dispatch-fixup.sh.template` →
+   `${ORCH_DIR}/workers/dispatch-fixup-${TICKET}.sh`
 3. With `--dispatch`, runs the dispatch script in the background (via `claude -p` with streaming
    JSON output)
 
 The fix-up worker:
+
 - Pulls latest on the existing PR branch (does NOT create a new branch)
 - Resolves ONLY the listed blockers
 - Pushes ONE commit with message `fix(...): resolve review feedback on #${PR}`
@@ -1156,9 +1194,9 @@ The fix-up worker:
 - Writes its commit SHA to the worker signal file as `fixupCommit`
 - Does one ~3-minute settle-window pass and exits
 
-The orchestrator's Phase 4 poll loop then observes the re-triggered CI and eventual `MERGED`
-state, exactly as with a fresh worker. No additional orchestrator logic is needed — `fixupCommit`
-is metadata for the dashboard, not a signal the orchestrator acts on.
+The orchestrator's Phase 4 poll loop then observes the re-triggered CI and eventual `MERGED` state,
+exactly as with a fresh worker. No additional orchestrator logic is needed — `fixupCommit` is
+metadata for the dashboard, not a signal the orchestrator acts on.
 
 **Typical cost:** ~$2 (much cheaper than a fresh worker because scope is narrow).
 
@@ -1169,6 +1207,7 @@ cleanly; a post-merge security review or prod observation surfaced issues later.
 physically impossible — the merged branch is gone.
 
 **When to use:**
+
 - `pr.state = MERGED`
 - New findings that would have blocked merge if they had arrived 10 minutes earlier
 - Traceability to the parent is important (audit, incident response)
@@ -1182,49 +1221,50 @@ post-merge: missing rate-limit on POST /api/auth/token (src/api/auth.ts:18)"
 ```
 
 What this does:
+
 1. Files a new Linear ticket via `linearis issues create`, with description that references the
    parent and enumerates the findings. Title defaults to
    `Follow-up: <PARENT_TICKET> post-merge findings`; override with `--title`.
 2. Provisions a fresh worktree off `main` via `create-worktree.sh`, named
    `${ORCH_NAME}-${NEW_TICKET}`.
-3. Seeds the new worker's signal file with `followUpTo: "${PARENT_TICKET}"` — the orchestrator
-   and dashboard both use this field to render the ancestry.
+3. Seeds the new worker's signal file with `followUpTo: "${PARENT_TICKET}"` — the orchestrator and
+   dashboard both use this field to render the ancestry.
 4. Renders `templates/followup-prompt.md` → `${ORCH_DIR}/workers/${NEW_TICKET}-prompt.md`, which
    points the worker at the findings, the parent PR, and the TDD contract.
 5. Prints the `claude -p` command to actually start the worker — it does NOT auto-dispatch
    (follow-up tickets are heavier and warrant human confirmation).
 
 The follow-up worker runs the full `/oneshot` pipeline (research → plan → implement → validate →
-ship), same as any other worker. Its PR description must reference the parent PR number; the
-prompt enforces this.
+ship), same as any other worker. Its PR description must reference the parent PR number; the prompt
+enforces this.
 
 **Typical cost:** ~$4 (full pipeline, but scoped to the findings).
 
-**Skip Linear ticket creation** with `--ticket <id>` if you filed the ticket manually or Linear
-is unavailable. The rest of the flow proceeds with the given ticket ID.
+**Skip Linear ticket creation** with `--ticket <id>` if you filed the ticket manually or Linear is
+unavailable. The rest of the flow proceeds with the given ticket ID.
 
 ### Signal file metadata
 
-| Field          | Written by                     | Pattern |
-| -------------- | ------------------------------ | ------- |
-| `fixupCommit`  | fix-up worker (after push)     | A       |
-| `followUpTo`   | orchestrator (at provisioning) | B       |
+| Field         | Written by                     | Pattern |
+| ------------- | ------------------------------ | ------- |
+| `fixupCommit` | fix-up worker (after push)     | A       |
+| `followUpTo`  | orchestrator (at provisioning) | B       |
 
 These fields are additive — they do not conflict with `pr.prOpenedAt`, `pr.autoMergeArmedAt`, or
 `pr.mergedAt` (which remain worker-owned / orchestrator-owned per the normal split).
 
 ### Dashboard columns
 
-`DASHBOARD.md` has two additional columns: `Fix-up Commit` (short SHA, empty for normal workers)
-and `Follow-up To` (parent ticket ID, empty for normal workers and fix-up workers). See
+`DASHBOARD.md` has two additional columns: `Fix-up Commit` (short SHA, empty for normal workers) and
+`Follow-up To` (parent ticket ID, empty for normal workers and fix-up workers). See
 `templates/orchestrate-dashboard.md`.
 
 ### Known limitation
 
-`orchestrate-verify.sh` currently only matches open PRs via `gh pr list --head`; already-merged
-PRs (the exact target of Pattern B) slip past its checks as false-negatives. This is tracked
-separately and does not block recovery — follow-up workers run full quality gates from their
-`/oneshot` pipeline, which is the real verification.
+`orchestrate-verify.sh` currently only matches open PRs via `gh pr list --head`; already-merged PRs
+(the exact target of Pattern B) slip past its checks as false-negatives. This is tracked separately
+and does not block recovery — follow-up workers run full quality gates from their `/oneshot`
+pipeline, which is the real verification.
 
 ## Error Handling
 
@@ -1237,12 +1277,14 @@ fi
 ```
 
 **Worker crashes or stalls:**
+
 - Monitor detects no progress for 15+ minutes (no commits, no signal updates)
 - Dashboard marks worker as "stalled"
 - Orchestrator does NOT auto-restart — flags for human decision
 - Options presented: restart worker, skip ticket, investigate manually
 
 **Orchestrator crash recovery:**
+
 - All state is in `${ORCH_DIR}/state.json` + worker signal files
 - Resume with: `/catalyst-dev:orchestrate --resume ${ORCH_DIR}`
 - Reads state.json, determines current wave, checks each worker's actual status
@@ -1250,6 +1292,7 @@ fi
 - On resume, start a new session (the old one leaked — this is acceptable)
 
 **Worktree conflicts:**
+
 - If a worktree path already exists, skip creation and check if it's from a previous run
 - If it has a valid worker signal file, treat as a resumed worker
 
@@ -1260,7 +1303,8 @@ fi
 - Wave advancement requires ALL tickets in the wave to pass verification
 - The `--auto-merge` flag applies to workers, not the orchestrator
 - Dashboard and state files are ephemeral — they don't survive worktree removal
-- Wave briefings and summaries are persisted to `thoughts/shared/handoffs/${ORCH_NAME}/` for archival
+- Wave briefings and summaries are persisted to `thoughts/shared/handoffs/${ORCH_NAME}/` for
+  archival
 - Wave briefings are the key differentiator — knowledge compounds across waves
 - The 3-layer testing enforcement prevents the observed failure mode of agents skipping tests
 - CTL-26 dependency: Uses `.catalyst/` paths. Falls back to `.claude/` if `.catalyst/` doesn't exist

--- a/plugins/dev/templates/dispatch-fixup.sh.template
+++ b/plugins/dev/templates/dispatch-fixup.sh.template
@@ -30,13 +30,21 @@ fi
 
 PROMPT_BODY="$(cat "${PROMPT_FILE}")"
 
-CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
-CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
-claude \
-  -n "fixup-${TICKET_ID}" \
-  -w "${WORKER_DIR}" \
-  --output-format stream-json \
-  --verbose \
-  -p "${PROMPT_BODY}" \
-  > "${STREAM_FILE}" 2> "${LOG_FILE}" &
+# `claude -w` takes a *name* and creates a new worktree — do NOT pass the path
+# to the already-provisioned worker worktree there. Run the dispatch inside a
+# backgrounded subshell that `cd`s then `exec`s claude, so `$!` in this shell
+# resolves to the worker's PID. `--dangerously-skip-permissions` is required
+# for headless workers (no TTY to accept permission prompts). `nohup` keeps
+# the worker alive after this dispatching shell exits.
+(
+  cd "${WORKER_DIR}" || exit 1
+  CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
+  CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
+  exec nohup claude \
+    -n "fixup-${TICKET_ID}" \
+    --output-format stream-json \
+    --verbose \
+    --dangerously-skip-permissions \
+    -p "${PROMPT_BODY}"
+) > "${STREAM_FILE}" 2> "${LOG_FILE}" &
 echo "Dispatched fix-up worker via claude CLI (pid $!)"

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -1,71 +1,83 @@
 ---
 title: Orchestration
-description: Coordinate multiple tickets in parallel — wave-based execution, worker dispatch, adversarial verification, and cross-wave knowledge sharing.
+description:
+  Coordinate multiple tickets in parallel — wave-based execution, worker dispatch, adversarial
+  verification, and cross-wave knowledge sharing.
 sidebar:
   order: 5
 ---
 
-Orchestration is Catalyst's system for coordinating **multiple tickets in parallel** across git worktrees. An AI coordinator dispatches workers, tracks progress via a dashboard, and enforces quality through adversarial verification.
+Orchestration is Catalyst's system for coordinating **multiple tickets in parallel** across git
+worktrees. An AI coordinator dispatches workers, tracks progress via a dashboard, and enforces
+quality through adversarial verification.
 
-:::note[Focused subarticles]
-This page is the orchestration overview. For deeper dives see:
-- [Workers and signal files](./orchestration/workers/) — lifecycle, signal-file schema, state machine
-- [Verification and reward-hacking defense](./orchestration/verification/) — how the orchestrator adversarially checks worker output
-- [Observability overview](/observability/) — monitoring orchestrations in real time
-:::
+:::note[Focused subarticles] This page is the orchestration overview. For deeper dives see:
+
+- [Workers and signal files](./orchestration/workers/) — lifecycle, signal-file schema, state
+  machine
+- [Verification and reward-hacking defense](./orchestration/verification/) — how the orchestrator
+  adversarially checks worker output
+- [Observability overview](/observability/) — monitoring orchestrations in real time :::
 
 ## Orchestration Levels
 
 Catalyst workflows operate at two levels:
 
-| Level | What | How |
-|-------|------|-----|
-| **Level 2** | Single-ticket pipeline | `/catalyst-dev:oneshot` chains research, plan, implement, validate, ship, merge with context isolation |
+| Level       | What                      | How                                                                                                                              |
+| ----------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Level 2** | Single-ticket pipeline    | `/catalyst-dev:oneshot` chains research, plan, implement, validate, ship, merge with context isolation                           |
 | **Level 3** | Multi-ticket coordination | `/catalyst-dev:orchestrate` dispatches Level 2 workers across worktrees with wave-based parallelism and independent verification |
 
-Level 3 builds on Level 2 — each worker runs the full `/catalyst-dev:oneshot` pipeline autonomously. The orchestrator adds coordination, knowledge sharing, and anti-reward-hacking verification on top.
+Level 3 builds on Level 2 — each worker runs the full `/catalyst-dev:oneshot` pipeline autonomously.
+The orchestrator adds coordination, knowledge sharing, and anti-reward-hacking verification on top.
 
 ## Prerequisites
 
 ### Required Tools
 
-| Tool | Purpose | Install |
-|------|---------|---------|
-| **Git** | Worktree creation, branch management | Pre-installed on macOS |
-| **Linearis CLI** | Read tickets from Linear, update states | `npm install -g linearis` |
-| **GitHub CLI** | PR creation, CI monitoring | `brew install gh` |
-| **jq** | Config parsing, signal file updates | `brew install jq` |
-| **HumanLayer CLI** | Worker dispatch with context isolation, thoughts system | `pip install humanlayer` |
+| Tool               | Purpose                                                                 | Install                    |
+| ------------------ | ----------------------------------------------------------------------- | -------------------------- |
+| **Git**            | Worktree creation, branch management                                    | Pre-installed on macOS     |
+| **Linearis CLI**   | Read tickets from Linear, update states                                 | `npm install -g linearis`  |
+| **GitHub CLI**     | PR creation, CI monitoring                                              | `brew install gh`          |
+| **jq**             | Config parsing, signal file updates                                     | `brew install jq`          |
+| **Claude CLI**     | Worker dispatch (the only dispatch path)                                | Installed with Claude Code |
+| **HumanLayer CLI** | Thoughts persistence: shared research, plans, handoffs across worktrees | `pip install humanlayer`   |
 
-If HumanLayer is not installed, the orchestrator falls back to launching workers with the `claude` CLI directly. The thoughts system (shared research, plans, handoffs across worktrees) requires HumanLayer.
+The orchestrator always dispatches workers via the `claude` CLI (streaming JSON output). HumanLayer
+is used only for the thoughts system — it is not a dispatch mechanism. Projects that don't use the
+thoughts system can skip it entirely; dispatch still works.
 
 ### Claude Code Settings
 
-Add `~/catalyst` to Claude Code's trusted directories so all worktrees across all projects are accessible without per-worktree approval:
+Add `~/catalyst` to Claude Code's trusted directories so all worktrees across all projects are
+accessible without per-worktree approval:
 
 ```json
 // ~/.claude/settings.json
 {
   "permissions": {
-    "additionalDirectories": [
-      "/Users/you/catalyst"
-    ]
+    "additionalDirectories": ["/Users/you/catalyst"]
   }
 }
 ```
 
-This is a one-time setup. All orchestrator and worker worktrees for every project land under `~/catalyst/wt/<projectKey>/`.
+This is a one-time setup. All orchestrator and worker worktrees for every project land under
+`~/catalyst/wt/<projectKey>/`.
 
 Catalyst also pre-trusts newly created worktrees automatically, so the `additionalDirectories`
 setting is best treated as a convenience and backup layer rather than a hard requirement.
 
 ### Project Configuration
 
-The orchestrator reads from your project's Catalyst config (`.catalyst/config.json` or `.claude/config.json`). Two config blocks are relevant:
+The orchestrator reads from your project's Catalyst config (`.catalyst/config.json` or
+`.claude/config.json`). Two config blocks are relevant:
 
 #### 1. Worktree Setup Commands (`catalyst.worktree.setup`)
 
-**This is the most important configuration to get right.** It defines the commands that run in every new worktree — both standalone worktrees from `/create-worktree` and orchestrator/worker worktrees from `/orchestrate`.
+**This is the most important configuration to get right.** It defines the commands that run in every
+new worktree — both standalone worktrees from `/create-worktree` and orchestrator/worker worktrees
+from `/orchestrate`.
 
 ```json
 {
@@ -83,20 +95,25 @@ The orchestrator reads from your project's Catalyst config (`.catalyst/config.js
 
 **What to include in your setup array:**
 
-| Step | Command | Why |
-|------|---------|-----|
-| Thoughts init | `humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}` | Workers need access to shared research, plans, and handoffs. Without this, workers can't read wave briefings or save their findings for other waves. |
-| Thoughts sync | `humanlayer thoughts sync` | Pulls down existing shared documents so the worker starts with full context. |
-| Dependency install | `bun install` or `npm install` or `make setup` | Workers need project dependencies to run tests, typecheck, and build. |
-| Environment setup | `cp .env.example .env.local` | Workers may need environment variables for local dev. |
-| Database setup | `./scripts/setup-test-db.sh` | If tests require a local database. |
+| Step               | Command                                                                  | Why                                                                                                                                                  |
+| ------------------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Thoughts init      | `humanlayer thoughts init --directory ${DIRECTORY} --profile ${PROFILE}` | Workers need access to shared research, plans, and handoffs. Without this, workers can't read wave briefings or save their findings for other waves. |
+| Thoughts sync      | `humanlayer thoughts sync`                                               | Pulls down existing shared documents so the worker starts with full context.                                                                         |
+| Dependency install | `bun install` or `npm install` or `make setup`                           | Workers need project dependencies to run tests, typecheck, and build.                                                                                |
+| Environment setup  | `cp .env.example .env.local`                                             | Workers may need environment variables for local dev.                                                                                                |
+| Database setup     | `./scripts/setup-test-db.sh`                                             | If tests require a local database.                                                                                                                   |
 
 You do not need a separate "permission grant" step anymore. `create-worktree.sh` now marks the new
 worktree as trusted in Claude Code automatically.
 
-**If `catalyst.worktree.setup` is NOT configured:** The script falls back to auto-detected setup — it will auto-detect `make setup`/`bun install`/`npm install` for dependencies, and run `humanlayer thoughts init` + `sync` if HumanLayer is installed. This fallback is convenient for simple projects but gives you no control over the order, additional steps, or error handling.
+**If `catalyst.worktree.setup` is NOT configured:** The script falls back to auto-detected setup —
+it will auto-detect `make setup`/`bun install`/`npm install` for dependencies, and run
+`humanlayer thoughts init` + `sync` if HumanLayer is installed. This fallback is convenient for
+simple projects but gives you no control over the order, additional steps, or error handling.
 
-**Once you define `catalyst.worktree.setup`, only your commands run.** The auto-detection is skipped entirely. This means you must include dependency install and thoughts init in your array if you need them — they are not added automatically.
+**Once you define `catalyst.worktree.setup`, only your commands run.** The auto-detection is skipped
+entirely. This means you must include dependency install and thoughts init in your array if you need
+them — they are not added automatically.
 
 #### 2. Orchestration Config (`catalyst.orchestration`)
 
@@ -128,11 +145,16 @@ Optional. Controls orchestrator-specific behavior. All fields have sensible defa
 
 **The difference between `worktree.setup` and `orchestration.hooks.setup`:**
 
-- `catalyst.worktree.setup` — runs for **every** worktree (standalone, orchestrator, and workers). This is your base project setup.
-- `catalyst.orchestration.hooks.setup` — runs **only** for orchestrator-managed worktrees, **after** the base setup. Use this for orchestration-specific steps that don't apply to standalone worktrees.
-- `catalyst.orchestration.hooks.teardown` — runs when the orchestrator cleans up completed worktrees after wave advancement.
+- `catalyst.worktree.setup` — runs for **every** worktree (standalone, orchestrator, and workers).
+  This is your base project setup.
+- `catalyst.orchestration.hooks.setup` — runs **only** for orchestrator-managed worktrees, **after**
+  the base setup. Use this for orchestration-specific steps that don't apply to standalone
+  worktrees.
+- `catalyst.orchestration.hooks.teardown` — runs when the orchestrator cleans up completed worktrees
+  after wave advancement.
 
-Most projects only need `catalyst.worktree.setup`. The orchestration hooks are for edge cases like registering workers with an external monitoring system.
+Most projects only need `catalyst.worktree.setup`. The orchestration hooks are for edge cases like
+registering workers with an external monitoring system.
 
 ### Full Config Example
 
@@ -189,8 +211,10 @@ Before running `/orchestrate` for the first time:
 
 - [ ] **Linearis CLI installed** and authenticated (`linearis auth login`)
 - [ ] **GitHub CLI installed** and authenticated (`gh auth login`)
-- [ ] **HumanLayer CLI installed** and thoughts initialized in the main repo (`humanlayer thoughts init`)
-- [ ] **`catalyst.worktree.setup` configured** with your project's setup commands (thoughts init, dependency install, environment setup, etc.)
+- [ ] **HumanLayer CLI installed** and thoughts initialized in the main repo
+      (`humanlayer thoughts init`)
+- [ ] **`catalyst.worktree.setup` configured** with your project's setup commands (thoughts init,
+      dependency install, environment setup, etc.)
 - [ ] **`catalyst.linear.stateMap` configured** so ticket state transitions work
 - [ ] **`catalyst.thoughts` configured** with your profile and directory names
 
@@ -216,6 +240,7 @@ If you prefer to start manually from an existing orchestrator worktree, use:
 ```
 
 The orchestrator:
+
 1. Reads each ticket from Linear
 2. Builds a dependency graph and groups tickets into waves
 3. Presents the wave plan for approval
@@ -237,14 +262,14 @@ The orchestrator:
 
 ### Flags
 
-| Flag | Description |
-|------|-------------|
-| `--name <name>` | Name this orchestrator (default: auto-generated) |
-| `--auto-merge` | Workers auto-merge when CI + verification pass |
-| `--max-parallel <n>` | Override max concurrent workers (default: 3) |
-| `--base-branch <branch>` | Base branch for worktrees (default: main) |
-| `--dry-run` | Show wave plan without executing |
-| `--interactive` | Include PM intake phase before orchestration |
+| Flag                     | Description                                      |
+| ------------------------ | ------------------------------------------------ |
+| `--name <name>`          | Name this orchestrator (default: auto-generated) |
+| `--auto-merge`           | Workers auto-merge when CI + verification pass   |
+| `--max-parallel <n>`     | Override max concurrent workers (default: 3)     |
+| `--base-branch <branch>` | Base branch for worktrees (default: main)        |
+| `--dry-run`              | Show wave plan without executing                 |
+| `--interactive`          | Include PM intake phase before orchestration     |
 
 ## Wave-Based Parallelism
 
@@ -311,31 +336,42 @@ For every worktree (orchestrator and workers), the `create-worktree.sh` script r
 7. Run catalyst.orchestration.hooks.setup (orchestration-only, if present)
 ```
 
-Steps 4–5 ensure that `.catalyst/.workflow-context.json` exists with the ticket set and that OTEL resource attributes include the ticket — before any skills run.
+Steps 4–5 ensure that `.catalyst/.workflow-context.json` exists with the ticket set and that OTEL
+resource attributes include the ticket — before any skills run.
 
-The orchestrator then creates its status directory (`workers/`, `DASHBOARD.md`, `state.json`) and initializes worker signal files.
+The orchestrator then creates its status directory (`workers/`, `DASHBOARD.md`, `state.json`) and
+initializes worker signal files.
 
 ## Worker Dispatch
 
-Workers are launched via `claude -p` with `--output-format stream-json --verbose`, producing real-time NDJSON that the monitor can tail to show live worker activity. Each runs `/oneshot <ticket> --auto-merge` autonomously.
+Workers are launched via `claude -p` with `--output-format stream-json --verbose`, producing
+real-time NDJSON that the monitor can tail to show live worker activity. Each runs
+`/oneshot <ticket> --auto-merge` autonomously.
 
-The dispatch prompt includes **mandatory testing requirements** — not suggestions. Workers are told their output will be independently verified. The `CATALYST_ORCHESTRATOR_DIR` environment variable is set so workers know where to write their signal files.
+The dispatch prompt includes **mandatory testing requirements** — not suggestions. Workers are told
+their output will be independently verified. The `CATALYST_ORCHESTRATOR_DIR` environment variable is
+set so workers know where to write their signal files.
 
 ## Testing Enforcement (3 Layers)
 
-The orchestrator addresses a specific failure mode: **agents ship PRs with minimal tests and self-report "done."** Three layers prevent this:
+The orchestrator addresses a specific failure mode: **agents ship PRs with minimal tests and
+self-report "done."** Three layers prevent this:
 
 ### Layer 1 — Dispatch Prompt (Prevention)
 
-Every worker's dispatch prompt includes hard requirements for TDD, unit tests, API tests, security review, and code review. The prompt explicitly states that work will be independently verified.
+Every worker's dispatch prompt includes hard requirements for TDD, unit tests, API tests, security
+review, and code review. The prompt explicitly states that work will be independently verified.
 
 ### Layer 2 — Quality Gates (Automated)
 
-Inside each worker's `/oneshot` pipeline, the existing quality gate system runs: `/validate-type-safety`, `/security-review`, `code-reviewer` agent, `pr-test-analyzer` agent, plus any project-specific gates from config.
+Inside each worker's `/oneshot` pipeline, the existing quality gate system runs:
+`/validate-type-safety`, `/security-review`, `code-reviewer` agent, `pr-test-analyzer` agent, plus
+any project-specific gates from config.
 
 ### Layer 3 — Independent Verification (Adversarial)
 
-After a worker claims "done", the orchestrator runs `orchestrate-verify.sh` **independently** in the worker's worktree. This script:
+After a worker claims "done", the orchestrator runs `orchestrate-verify.sh` **independently** in the
+worker's worktree. This script:
 
 - Checks that every changed source file has a corresponding test file
 - Verifies API test coverage for new/modified routes
@@ -344,11 +380,13 @@ After a worker claims "done", the orchestrator runs `orchestrate-verify.sh` **in
 - Scans for reward-hacking patterns (`as any`, `@ts-ignore`, empty catch blocks)
 - Cross-checks the worker's self-reported `definitionOfDone` against actual findings
 
-If verification **fails**, the worker gets explicit remediation instructions and must fix the gaps before advancing. The orchestrator re-verifies after fixes.
+If verification **fails**, the worker gets explicit remediation instructions and must fix the gaps
+before advancing. The orchestrator re-verifies after fixes.
 
 ## Wave Briefing Documents
 
-Before dispatching each wave after Wave 1, the orchestrator writes a **briefing document** summarizing what prior waves learned:
+Before dispatching each wave after Wave 1, the orchestrator writes a **briefing document**
+summarizing what prior waves learned:
 
 - Patterns and conventions established (e.g., "Auth uses `withAuth()` decorator")
 - New dependencies added
@@ -363,27 +401,29 @@ Wave 2+ workers read the briefing before starting. This means:
 - Workers avoid known gotchas instead of hitting them again
 - **Knowledge compounds across waves** instead of being lost
 
-This requires the thoughts system to be initialized in each worktree (via `catalyst.worktree.setup`). Without it, workers can't access shared documents.
+This requires the thoughts system to be initialized in each worktree (via
+`catalyst.worktree.setup`). Without it, workers can't access shared documents.
 
 ## Dashboard
 
-The orchestrator maintains a live dashboard at `DASHBOARD.md` in its worktree directory, updated after each monitoring poll:
+The orchestrator maintains a live dashboard at `DASHBOARD.md` in its worktree directory, updated
+after each monitoring poll:
 
 ```markdown
 # Orchestration Dashboard
-**Orchestrator:** api-redesign
-**Started:** 2026-04-10 14:00 UTC
-**Total:** 6 tickets | 3 waves
+
+**Orchestrator:** api-redesign **Started:** 2026-04-10 14:00 UTC **Total:** 6 tickets | 3 waves
 
 ## Current Wave: 1 of 3
 
-| Ticket | Status | PR | Unit Tests | API Tests | Security | Verified |
-|--------|--------|-----|-----------|-----------|----------|----------|
-| ACME-101 | Implementing | — | — | — | — | — |
-| ACME-102 | PR Created | #87 | 18 tests | 6 requests | PASS | Pending |
-| ACME-103 | Validating | — | 12 tests | N/A | Pending | — |
+| Ticket   | Status       | PR  | Unit Tests | API Tests  | Security | Verified |
+| -------- | ------------ | --- | ---------- | ---------- | -------- | -------- |
+| ACME-101 | Implementing | —   | —          | —          | —        | —        |
+| ACME-102 | PR Created   | #87 | 18 tests   | 6 requests | PASS     | Pending  |
+| ACME-103 | Validating   | —   | 12 tests   | N/A        | Pending  | —        |
 
 ## Event Log
+
 - 14:32 — ACME-102 PR #87 created, CI running
 - 14:15 — ACME-101 research complete, starting plan
 - 14:00 — Wave 1 dispatched (3 workers)
@@ -391,7 +431,8 @@ The orchestrator maintains a live dashboard at `DASHBOARD.md` in its worktree di
 
 ## Worker Signal Files
 
-Workers report status via JSON signal files in `workers/`. The orchestrator writes the initial file; workers update it at each phase transition.
+Workers report status via JSON signal files in `workers/`. The orchestrator writes the initial file;
+workers update it at each phase transition.
 
 ```json
 {
@@ -410,47 +451,49 @@ Workers report status via JSON signal files in `workers/`. The orchestrator writ
 }
 ```
 
-The `definitionOfDone` is the accountability layer — workers declare yes/no for each gate, and the orchestrator's verification independently confirms. A worker claiming 22 unit tests when 0 exist gets caught.
+The `definitionOfDone` is the accountability layer — workers declare yes/no for each gate, and the
+orchestrator's verification independently confirms. A worker claiming 22 unit tests when 0 exist
+gets caught.
 
 ## Configuration Reference
 
 ### Orchestration Fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `worktreeDir` | string\|null | `~/catalyst/wt/<projectKey>` | Base directory for worktrees |
-| `maxParallel` | number | 3 | Max concurrent workers per wave |
-| `hooks.setup` | string[] | `[]` | Extra commands after base `worktree.setup` (orchestration-only) |
-| `hooks.teardown` | string[] | `[]` | Commands before worktree removal on wave advancement |
-| `workerCommand` | string | `/oneshot` | Skill to run in each worker |
-| `workerModel` | string | `opus` | Model for worker sessions |
-| `testRequirements` | object | `{"backend":["unit"]}` | Required test types by scope |
-| `verifyBeforeMerge` | boolean | `true` | Run adversarial verification before merging |
-| `allowSelfReportedCompletion` | boolean | `false` | Trust worker's `definitionOfDone` without verification |
+| Field                         | Type         | Default                      | Description                                                     |
+| ----------------------------- | ------------ | ---------------------------- | --------------------------------------------------------------- |
+| `worktreeDir`                 | string\|null | `~/catalyst/wt/<projectKey>` | Base directory for worktrees                                    |
+| `maxParallel`                 | number       | 3                            | Max concurrent workers per wave                                 |
+| `hooks.setup`                 | string[]     | `[]`                         | Extra commands after base `worktree.setup` (orchestration-only) |
+| `hooks.teardown`              | string[]     | `[]`                         | Commands before worktree removal on wave advancement            |
+| `workerCommand`               | string       | `/oneshot`                   | Skill to run in each worker                                     |
+| `workerModel`                 | string       | `opus`                       | Model for worker sessions                                       |
+| `testRequirements`            | object       | `{"backend":["unit"]}`       | Required test types by scope                                    |
+| `verifyBeforeMerge`           | boolean      | `true`                       | Run adversarial verification before merging                     |
+| `allowSelfReportedCompletion` | boolean      | `false`                      | Trust worker's `definitionOfDone` without verification          |
 
 ### Hook Variables
 
 All setup and teardown commands support these variables:
 
-| Variable | Source | Value |
-|----------|--------|-------|
-| `${WORKTREE_PATH}` | Computed | Absolute path to the worktree |
-| `${BRANCH_NAME}` | Computed | Git branch name |
-| `${TICKET_ID}` | Computed | Same as branch name (includes orchestrator prefix) |
-| `${REPO_NAME}` | Git | Repository name |
-| `${DIRECTORY}` | Config | `catalyst.thoughts.directory` or repo name |
-| `${PROFILE}` | Config | `catalyst.thoughts.profile` or auto-detected from HumanLayer |
+| Variable           | Source   | Value                                                        |
+| ------------------ | -------- | ------------------------------------------------------------ |
+| `${WORKTREE_PATH}` | Computed | Absolute path to the worktree                                |
+| `${BRANCH_NAME}`   | Computed | Git branch name                                              |
+| `${TICKET_ID}`     | Computed | Same as branch name (includes orchestrator prefix)           |
+| `${REPO_NAME}`     | Git      | Repository name                                              |
+| `${DIRECTORY}`     | Config   | `catalyst.thoughts.directory` or repo name                   |
+| `${PROFILE}`       | Config   | `catalyst.thoughts.profile` or auto-detected from HumanLayer |
 
 ## Linear Integration
 
 The orchestrator manages Linear state as a safety net:
 
-| Event | Linear Action |
-|-------|--------------|
-| Worker dispatched | Move ticket to In Progress |
-| Worker creates PR | Verify ticket is In Review — fix if not |
-| PR merged | Verify ticket is Done — fix if not |
-| Worker fails/stalls | Add comment with status |
+| Event               | Linear Action                           |
+| ------------------- | --------------------------------------- |
+| Worker dispatched   | Move ticket to In Progress              |
+| Worker creates PR   | Verify ticket is In Review — fix if not |
+| PR merged           | Verify ticket is Done — fix if not      |
+| Worker fails/stalls | Add comment with status                 |
 
 Comments are added to tickets for team visibility:
 
@@ -478,7 +521,9 @@ Multiple orchestrators can run concurrently. Each gets a unique name that prefix
 
 ## Global State & Event Log
 
-When multiple orchestrators run concurrently — or you want to check on things after the fact — a single global state file at `~/catalyst/state.json` provides a unified view of all active orchestrators, their workers, and anything that needs your attention.
+When multiple orchestrators run concurrently — or you want to check on things after the fact — a
+single global state file at `~/catalyst/state.json` provides a unified view of all active
+orchestrators, their workers, and anything that needs your attention.
 
 ### File Layout
 
@@ -494,11 +539,16 @@ When multiple orchestrators run concurrently — or you want to check on things 
     └── <projectKey>/...
 ```
 
-**`state.json`** contains all active orchestrators with their progress, worker status, and attention items. Orchestrators register at startup and heartbeat every 2-3 minutes. Workers update their own entries at each phase transition.
+**`state.json`** contains all active orchestrators with their progress, worker status, and attention
+items. Orchestrators register at startup and heartbeat every 2-3 minutes. Workers update their own
+entries at each phase transition.
 
-**`events/`** contains append-only JSONL files, rotated monthly. Every significant transition — worker dispatched, status change, PR created, verification passed/failed, attention raised — is logged here. Query across all months with `cat ~/catalyst/events/*.jsonl | jq`.
+**`events/`** contains append-only JSONL files, rotated monthly. Every significant transition —
+worker dispatched, status change, PR created, verification passed/failed, attention raised — is
+logged here. Query across all months with `cat ~/catalyst/events/*.jsonl | jq`.
 
-**`history/`** contains full snapshots of orchestrators after they complete, fail, or are garbage-collected due to stale heartbeats.
+**`history/`** contains full snapshots of orchestrators after they complete, fail, or are
+garbage-collected due to stale heartbeats.
 
 ### Global State Schema
 
@@ -544,7 +594,9 @@ Each orchestrator entry in `state.json` contains:
 }
 ```
 
-The full JSON Schema is at `plugins/dev/templates/global-state.json`. The global state is a denormalized summary — each orchestrator's detailed local state remains at `<worktree>/state.json` for crash recovery.
+The full JSON Schema is at `plugins/dev/templates/global-state.json`. The global state is a
+denormalized summary — each orchestrator's detailed local state remains at `<worktree>/state.json`
+for crash recovery.
 
 ### Querying with jq
 
@@ -569,7 +621,8 @@ jq '[.orchestrators[] | select(.projectKey == "acme")]' ~/catalyst/state.json
 
 ### Querying Events
 
-Events are JSONL files (one JSON object per line), so `grep`, `jq`, and standard Unix tools all work:
+Events are JSONL files (one JSON object per line), so `grep`, `jq`, and standard Unix tools all
+work:
 
 ```bash
 # Last 20 events
@@ -590,7 +643,8 @@ cat ~/catalyst/events/*.jsonl | jq -r '.event' | sort | uniq -c | sort -rn
 
 ### The catalyst-state.sh CLI
 
-All state reads and writes go through `catalyst-state.sh`, which handles file locking for concurrent access:
+All state reads and writes go through `catalyst-state.sh`, which handles file locking for concurrent
+access:
 
 ```bash
 # View active orchestrators
@@ -611,28 +665,42 @@ catalyst-state.sh events --type verification-failed
 catalyst-state.sh gc --stale-after 10 --events-older-than 6m
 ```
 
-Orchestrators and workers call `catalyst-state.sh` internally — you don't need to run it manually unless you're querying or debugging.
+Orchestrators and workers call `catalyst-state.sh` internally — you don't need to run it manually
+unless you're querying or debugging.
 
 ### Heartbeat & Stale Detection
 
-Orchestrators write a `lastHeartbeat` timestamp during each monitoring poll (every 2-3 minutes). If an orchestrator dies without clean shutdown (process killed, machine restarts), its heartbeat goes stale.
+Orchestrators write a `lastHeartbeat` timestamp during each monitoring poll (every 2-3 minutes). If
+an orchestrator dies without clean shutdown (process killed, machine restarts), its heartbeat goes
+stale.
 
-`catalyst-state.sh gc` detects stale entries (default: heartbeat older than 10 minutes), marks them as `abandoned`, and archives them to `~/catalyst/history/`. Run it manually or let the next orchestrator startup clean up automatically.
+`catalyst-state.sh gc` detects stale entries (default: heartbeat older than 10 minutes), marks them
+as `abandoned`, and archives them to `~/catalyst/history/`. Run it manually or let the next
+orchestrator startup clean up automatically.
 
 ### Building Interfaces
 
-The global state JSON is a stable contract designed for building interfaces. The [Orchestration Monitor](#orchestration-monitor) is the built-in implementation — a real-time web + terminal dashboard that reads signal files, polls GitHub, and pushes updates via SSE. See the dedicated section below for full details.
+The global state JSON is a stable contract designed for building interfaces. The
+[Orchestration Monitor](#orchestration-monitor) is the built-in implementation — a real-time web +
+terminal dashboard that reads signal files, polls GitHub, and pushes updates via SSE. See the
+dedicated section below for full details.
 
 For custom integrations, you can also access the data directly:
 
 **`jq` one-liners** — Quick terminal queries without running a server:
+
 ```bash
 watch -n5 'jq ".orchestrators[] | {id, status, progress: \"\(.progress.completedTickets)/\(.progress.totalTickets)\", attention: (.attention | length)}" ~/catalyst/state.json'
 ```
 
-**Agent integration** — Any Claude Code agent can read `~/catalyst/state.json` directly to answer questions like "what's the status of the auth migration?" or "are any workers waiting for me?" without asking the orchestrator.
+**Agent integration** — Any Claude Code agent can read `~/catalyst/state.json` directly to answer
+questions like "what's the status of the auth migration?" or "are any workers waiting for me?"
+without asking the orchestrator.
 
-**Event replay** — The event log in `~/catalyst/events/` gives you a full audit trail. Build timeline views, calculate cycle times, or feed events into analytics. Every event has a timestamp, orchestrator ID, optional worker/ticket ID, and event type — so you can reconstruct the full sequence of what happened in any orchestration run:
+**Event replay** — The event log in `~/catalyst/events/` gives you a full audit trail. Build
+timeline views, calculate cycle times, or feed events into analytics. Every event has a timestamp,
+orchestrator ID, optional worker/ticket ID, and event type — so you can reconstruct the full
+sequence of what happened in any orchestration run:
 
 ```bash
 # Replay an entire orchestration run chronologically
@@ -657,7 +725,8 @@ cat ~/catalyst/events/*.jsonl | jq -s '
 
 ### Token Usage & Cost Tracking
 
-Each orchestrator and worker entry in the global state includes a `usage` block that tracks token consumption and cost:
+Each orchestrator and worker entry in the global state includes a `usage` block that tracks token
+consumption and cost:
 
 ```json
 {
@@ -675,7 +744,10 @@ Each orchestrator and worker entry in the global state includes a `usage` block 
 }
 ```
 
-**How it works**: Workers launched via the `claude` CLI with `--output-format json` produce a JSON output that includes full token counts, cost, and timing. After a worker process exits, the orchestrator parses this output and writes the usage data to both the worker's entry and the orchestrator's aggregate.
+**How it works**: Workers launched via the `claude` CLI with `--output-format json` produce a JSON
+output that includes full token counts, cost, and timing. After a worker process exits, the
+orchestrator parses this output and writes the usage data to both the worker's entry and the
+orchestrator's aggregate.
 
 **Query patterns**:
 
@@ -694,16 +766,25 @@ cat ~/catalyst/history/*.json | jq -s '[.[].usage.costUSD / .[].progress.totalTi
 ```
 
 **Current limitations**:
+
 - The orchestrator itself cannot capture its own usage from within the session
-- Usage is extracted from the `result` event in the worker's stream-json output after the worker process exits
+- Usage is extracted from the `result` event in the worker's stream-json output after the worker
+  process exits
 
 As these tools evolve to expose usage data, the schema is ready to accept it.
 
 ## Orchestration Monitor
 
-The orchestration monitor is a real-time dashboard for watching your orchestration runs. It reads worker signal files, polls GitHub for PR status, and pushes updates to connected clients via Server-Sent Events — no polling from the browser.
+The orchestration monitor is a real-time dashboard for watching your orchestration runs. It reads
+worker signal files, polls GitHub for PR status, and pushes updates to connected clients via
+Server-Sent Events — no polling from the browser.
 
-The monitor runs entirely on your local machine and uses the same CLI tools as the rest of Catalyst — `gh` for GitHub PR status, filesystem watches for signal files, `kill -0` for process liveness. There's no cloud service, no account to create, no data leaving your machine. It's a lightweight Bun process that reads the files your orchestrator and workers are already writing. A hosted version with persistent history and team dashboards is a natural evolution, but the local-first approach means you get full monitoring today with zero infrastructure.
+The monitor runs entirely on your local machine and uses the same CLI tools as the rest of Catalyst
+— `gh` for GitHub PR status, filesystem watches for signal files, `kill -0` for process liveness.
+There's no cloud service, no account to create, no data leaving your machine. It's a lightweight Bun
+process that reads the files your orchestrator and workers are already writing. A hosted version
+with persistent history and team dashboards is a natural evolution, but the local-first approach
+means you get full monitoring today with zero infrastructure.
 
 ### Starting the Monitor
 
@@ -715,28 +796,37 @@ bun run plugins/dev/scripts/orch-monitor/server.ts
 
 By default it listens on `0.0.0.0:7400`. Override with environment variables:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MONITOR_PORT` | `7400` | HTTP port |
+| Variable       | Default      | Description                                 |
+| -------------- | ------------ | ------------------------------------------- |
+| `MONITOR_PORT` | `7400`       | HTTP port                                   |
 | `CATALYST_DIR` | `~/catalyst` | Base directory (reads `wt/` subdirectories) |
 
-The `/setup-orchestrate` skill prints the monitor launch command as part of its output, so you can copy-paste it alongside the orchestrator launch command.
+The `/setup-orchestrate` skill prints the monitor launch command as part of its output, so you can
+copy-paste it alongside the orchestrator launch command.
 
 ### Web Dashboard
 
-Open `http://localhost:7400` in any browser. The dashboard is a single self-contained HTML page with no external dependencies — all CSS and JS are inline.
+Open `http://localhost:7400` in any browser. The dashboard is a single self-contained HTML page with
+no external dependencies — all CSS and JS are inline.
 
 **What you see at a glance:**
 
-- **Header bar** — orchestrator name, total cost, wall-clock time, parallel efficiency ratio, wave progress, merge count
+- **Header bar** — orchestrator name, total cost, wall-clock time, parallel efficiency ratio, wave
+  progress, merge count
 - **Wave cards** — each wave shows its tickets as status badges with completion state
-- **Worker table** — per-worker rows with ticket, status, phase, process liveness, time since last update, and PR link
+- **Worker table** — per-worker rows with ticket, status, phase, process liveness, time since last
+  update, and PR link
 - **Timeline** — Gantt-style bars showing worker parallelism and phase durations
-- **Event feed** — scrolling log of the last 50 events (dispatches, status changes, PR creation, merges)
+- **Event feed** — scrolling log of the last 50 events (dispatches, status changes, PR creation,
+  merges)
 
-Status badges are color-coded: green for done/merged, blue for in-progress, red for failed, yellow for stalled, gray for dispatched/waiting.
+Status badges are color-coded: green for done/merged, blue for in-progress, red for failed, yellow
+for stalled, gray for dispatched/waiting.
 
-**Real-time updates:** The browser connects to `/events` (SSE endpoint) and receives push updates whenever a worker signal file changes, a PR status is refreshed from GitHub, or a liveness check detects a dead process. Updates appear within 1-2 seconds of the underlying file change — no manual refresh needed.
+**Real-time updates:** The browser connects to `/events` (SSE endpoint) and receives push updates
+whenever a worker signal file changes, a PR status is refreshed from GitHub, or a liveness check
+detects a dead process. Updates appear within 1-2 seconds of the underlying file change — no manual
+refresh needed.
 
 <!-- TODO: Add screenshot of the orchestration monitor dashboard -->
 <!-- Drop a screenshot at: website/public/orchestration-monitor.png -->
@@ -744,7 +834,9 @@ Status badges are color-coded: green for done/merged, blue for in-progress, red 
 
 ### Remote Access via Tailscale
 
-Because the monitor binds to `0.0.0.0`, it's accessible from any device on your Tailscale network. This means you can check on your orchestration runs from your phone or iPad while away from your desk.
+Because the monitor binds to `0.0.0.0`, it's accessible from any device on your Tailscale network.
+This means you can check on your orchestration runs from your phone or iPad while away from your
+desk.
 
 ```bash
 # Find your Tailscale IP
@@ -754,44 +846,55 @@ tailscale ip -4
 # http://<tailscale-ip>:7400
 ```
 
-The dashboard is mobile-responsive — the layout adapts to narrow screens so worker status, PR links, and the event feed are all readable on a phone. No VPN configuration or port forwarding required — Tailscale handles the secure mesh networking.
+The dashboard is mobile-responsive — the layout adapts to narrow screens so worker status, PR links,
+and the event feed are all readable on a phone. No VPN configuration or port forwarding required —
+Tailscale handles the secure mesh networking.
 
-**Typical workflow:** Start an orchestration on your workstation, walk away, and periodically check `http://<tailscale-ip>:7400` from your phone to see if any workers need attention (failed, stalled, or waiting for human input).
+**Typical workflow:** Start an orchestration on your workstation, walk away, and periodically check
+`http://<tailscale-ip>:7400` from your phone to see if any workers need attention (failed, stalled,
+or waiting for human input).
 
 ### Terminal Mode
 
-The monitor also includes an ANSI terminal renderer for headless environments or quick checks without opening a browser:
+The monitor also includes an ANSI terminal renderer for headless environments or quick checks
+without opening a browser:
 
 ```bash
 bun run plugins/dev/scripts/orch-monitor/server.ts --terminal
 ```
 
-This clears the screen and renders a compact 80-column dashboard with color-coded status, updated in real-time as signal files change. The HTTP server runs simultaneously, so you get both terminal and web access from a single process.
+This clears the screen and renders a compact 80-column dashboard with color-coded status, updated in
+real-time as signal files change. The HTTP server runs simultaneously, so you get both terminal and
+web access from a single process.
 
 ### What the Monitor Tracks
 
 The monitor watches `~/catalyst/wt/` for orchestrator directories (matching `orch-*`) and reads:
 
-| Source | Data | Refresh |
-|--------|------|---------|
-| Worker signal files (`workers/*.json`) | Status, phase, PR number, definition of done | Instant (filesystem watch) |
-| GitHub API (`gh pr view`) | PR state (open/merged/closed), merge timestamp | Every 30 seconds |
-| Process table (`kill -0 <pid>`) | Whether the worker's Claude process is still alive | Every 5 seconds |
-| Orchestrator `state.json` | Wave count, progress, attention items | Instant (filesystem watch) |
+| Source                                 | Data                                               | Refresh                    |
+| -------------------------------------- | -------------------------------------------------- | -------------------------- |
+| Worker signal files (`workers/*.json`) | Status, phase, PR number, definition of done       | Instant (filesystem watch) |
+| GitHub API (`gh pr view`)              | PR state (open/merged/closed), merge timestamp     | Every 30 seconds           |
+| Process table (`kill -0 <pid>`)        | Whether the worker's Claude process is still alive | Every 5 seconds            |
+| Orchestrator `state.json`              | Wave count, progress, attention items              | Instant (filesystem watch) |
 
-**Dead process detection:** If a worker's PID is recorded in its signal file but `kill -0` fails, the monitor marks it with a `!` indicator. This catches silently crashed workers that stopped updating their signal file — the status might say "implementing" but the process is gone.
+**Dead process detection:** If a worker's PID is recorded in its signal file but `kill -0` fails,
+the monitor marks it with a `!` indicator. This catches silently crashed workers that stopped
+updating their signal file — the status might say "implementing" but the process is gone.
 
-**PR status enrichment:** The monitor polls GitHub independently of what workers report. Even if a worker exited before updating its signal file after merge, the monitor shows the correct PR state. This is the backstop that prevents the "shows pr_open when actually merged" problem.
+**PR status enrichment:** The monitor polls GitHub independently of what workers report. Even if a
+worker exited before updating its signal file after merge, the monitor shows the correct PR state.
+This is the backstop that prevents the "shows pr_open when actually merged" problem.
 
 ### API Endpoints
 
 The monitor exposes a JSON API for programmatic access:
 
-| Endpoint | Description |
-|----------|-------------|
-| `GET /api/snapshot` | Full current state of all orchestrators, workers, and PR statuses |
-| `GET /api/analytics` | Extended analytics including phase timelines and cost data |
-| `GET /events` | SSE stream — events: `snapshot`, `worker-update`, `liveness-change` |
+| Endpoint             | Description                                                         |
+| -------------------- | ------------------------------------------------------------------- |
+| `GET /api/snapshot`  | Full current state of all orchestrators, workers, and PR statuses   |
+| `GET /api/analytics` | Extended analytics including phase timelines and cost data          |
+| `GET /events`        | SSE stream — events: `snapshot`, `worker-update`, `liveness-change` |
 
 ```bash
 # Quick status check from the command line
@@ -803,10 +906,20 @@ curl -N http://localhost:7400/events
 
 ## Error Handling
 
-**Worker crashes or stalls**: The orchestrator detects no progress for 15+ minutes (no commits, no signal updates). It marks the worker as "stalled" on the dashboard, flags it in the global state's `attention` array, and emits an `attention-raised` event. It does not auto-restart — it flags for human decision.
+**Worker crashes or stalls**: The orchestrator detects no progress for 15+ minutes (no commits, no
+signal updates). It marks the worker as "stalled" on the dashboard, flags it in the global state's
+`attention` array, and emits an `attention-raised` event. It does not auto-restart — it flags for
+human decision.
 
-**Orchestrator crash recovery**: Local state lives in `<worktree>/state.json` + worker signal files. Resume with `/orchestrate --resume <orch-dir>` to pick up where it left off. The orchestrator re-registers itself in the global state on resume.
+**Orchestrator crash recovery**: Local state lives in `<worktree>/state.json` + worker signal files.
+Resume with `/orchestrate --resume <orch-dir>` to pick up where it left off. The orchestrator
+re-registers itself in the global state on resume.
 
-**Orchestrator unclean death**: If the orchestrator process dies, its `lastHeartbeat` goes stale. `catalyst-state.sh gc` archives the entry as `abandoned`. Workers that were in-flight may still be running — check their worktrees and signal files manually, or let the next orchestrator pick them up.
+**Orchestrator unclean death**: If the orchestrator process dies, its `lastHeartbeat` goes stale.
+`catalyst-state.sh gc` archives the entry as `abandoned`. Workers that were in-flight may still be
+running — check their worktrees and signal files manually, or let the next orchestrator pick them
+up.
 
-**Verification failure**: The worker gets specific remediation instructions. The global state gets an `attention` item with type `verification-failed`. The orchestrator re-verifies after fixes. A ticket cannot advance to merge until verification passes.
+**Verification failure**: The worker gets specific remediation instructions. The global state gets
+an `attention` item with type `verification-failed`. The orchestrator re-verifies after fixes. A
+ticket cannot advance to merge until verification passes.


### PR DESCRIPTION
## Summary

- **Fix the `-w` flag misuse.** `claude -w` takes a *name* and creates a new worktree — it does NOT accept a path. Every dispatch site that passed the worker worktree path via `-w` was broken (`"Invalid worktree name"`). Replaced with a backgrounded subshell: `( cd "$WORKER_DIR" && exec nohup claude ... ) &` so `$!` in the outer shell still resolves to the worker PID.
- **Add `--dangerously-skip-permissions`** to every dispatch site. Headless workers have no TTY to answer permission prompts, so they block silently. Worktrees are pre-trusted by Catalyst's setup, so this is safe.
- **Capture worker stderr to a real file** (`$ORCH_DIR/workers/$TICKET_ID-stderr.log`) instead of `/dev/null`. Silent worker exits are now debuggable.
- **Close out CTL-58's doc debt.** The HumanLayer dispatcher was already removed from the skill source; stale docs in `website/.../orchestration.md` still described a dispatch fallback. Rewrote to say HumanLayer is used only for the thoughts system. Dispatch is always via `claude` CLI.

## Tickets

- Closes CTL-58 (remove HumanLayer dispatcher, make claude CLI the only dispatch path)
- Closes CTL-35 (fix `-w` flag bug, add `--dangerously-skip-permissions`, capture stderr)

The two were merged per the 2026-04-16 comment on CTL-35.

## Files changed

| File | What |
|------|------|
| `plugins/dev/skills/orchestrate/SKILL.md` | Phase 3 dispatch block, directory-layout snippet (adds stderr log + silent-exit debug note), Named Orchestrators example |
| `plugins/dev/templates/dispatch-fixup.sh.template` | Fix-up worker dispatch |
| `plugins/dev/scripts/orchestrate-followup` | Printed dispatch instruction for follow-up workers |
| `plugins/dev/skills/create-worktree/SKILL.md` | Optional "Launch Claude in the worktree" example |
| `website/src/content/docs/reference/orchestration.md` | Required Tools table + "HumanLayer for thoughts only" paragraph |

## Test plan

- [x] `bash -n plugins/dev/templates/dispatch-fixup.sh.template` — syntax OK
- [x] `bash -n plugins/dev/scripts/orchestrate-followup` — syntax OK
- [x] `grep -rn 'claude.*-w "\${' plugins/ website/ docs/ scripts/` — no hits
- [x] `grep -rn "humanlayer launch\|humanlayer run\|humanlayer dispatch" .` — no hits
- [x] `trunk check --ci` on all touched files — no new issues
- [ ] Next orchestrator run dispatches a worker successfully (live validation)