### PR TITLE
feat(dev): detect worker launch failures within 30s of dispatch (CTL-87)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-healthcheck (CTL-87).
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HEALTHCHECK="${REPO_ROOT}/plugins/dev/scripts/orchestrate-healthcheck"
+
+FAILURES=0
+PASSES=0
+
+scratch_setup() {
+  SCRATCH="$(mktemp -d)"
+  ORCH_DIR="${SCRATCH}/orch"
+  mkdir -p "${ORCH_DIR}/workers" "${SCRATCH}/bin"
+
+  # Fake state script: appends argv to state.log so tests can assert.
+  cat > "${SCRATCH}/bin/catalyst-state.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$STATE_LOG"
+EOF
+  chmod +x "${SCRATCH}/bin/catalyst-state.sh"
+  export STATE_LOG="${SCRATCH}/state.log"
+  : > "$STATE_LOG"
+  export CATALYST_STATE_SCRIPT="${SCRATCH}/bin/catalyst-state.sh"
+}
+
+scratch_teardown() {
+  rm -rf "$SCRATCH"
+  unset STATE_LOG CATALYST_STATE_SCRIPT SCRATCH ORCH_DIR
+}
+
+make_signal() {
+  # Usage: make_signal TICKET PID STATUS PHASE
+  local ticket="$1" pid="$2" status="$3" phase="$4"
+  jq -n \
+    --arg t "$ticket" --arg s "$status" \
+    --argjson p "$phase" \
+    --argjson pid "$pid" \
+    '{ticket:$t, status:$s, phase:$p, pid:$pid, updatedAt:"2026-04-16T00:00:00Z"}' \
+    > "${ORCH_DIR}/workers/${ticket}.json"
+}
+
+make_signal_no_pid() {
+  local ticket="$1" status="$2" phase="$3"
+  jq -n \
+    --arg t "$ticket" --arg s "$status" --argjson p "$phase" \
+    '{ticket:$t, status:$s, phase:$p, pid:null, updatedAt:"2026-04-16T00:00:00Z"}' \
+    > "${ORCH_DIR}/workers/${ticket}.json"
+}
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+# A PID guaranteed to be dead.
+DEAD_PID=99999999
+while kill -0 "$DEAD_PID" 2>/dev/null; do DEAD_PID=$((DEAD_PID+1)); done
+
+# ---
+
+echo "test: alive worker is left untouched"
+scratch_setup
+ALIVE_PID=$$   # this test process itself
+make_signal "PROJ-1" "$ALIVE_PID" "dispatched" 0
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-1.json")
+[ "$STATUS" = "dispatched" ] && pass "status unchanged" || fail "status unchanged" "got: $STATUS"
+[ ! -s "$STATE_LOG" ] && pass "no state-script calls" || fail "no state-script calls" "log: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test: dead worker is flagged"
+scratch_setup
+make_signal "PROJ-2" "$DEAD_PID" "dispatched" 0
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-2.json")
+REASON=$(jq -r '.failureReason' "${ORCH_DIR}/workers/PROJ-2.json")
+[ "$STATUS" = "failed" ] && pass "status transitioned to failed" || fail "status transitioned to failed" "got: $STATUS"
+[ "$REASON" = "launch-failure" ] && pass "failureReason set" || fail "failureReason set" "got: $REASON"
+grep -q "attention demo launch-failure PROJ-2" "$STATE_LOG" \
+  && pass "attention raised" || fail "attention raised" "log: $(cat "$STATE_LOG")"
+grep -q "worker-launch-failed" "$STATE_LOG" \
+  && pass "launch-failed event emitted" || fail "launch-failed event emitted" "log: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test: worker past phase 0 is skipped"
+scratch_setup
+make_signal "PROJ-3" "$DEAD_PID" "implementing" 3
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-3.json")
+[ "$STATUS" = "implementing" ] && pass "advanced worker untouched" || fail "advanced worker untouched" "got: $STATUS"
+[ ! -s "$STATE_LOG" ] && pass "no state-script calls for advanced worker" || fail "no state-script calls for advanced worker"
+scratch_teardown
+
+echo "test: worker with null pid is skipped safely"
+scratch_setup
+make_signal_no_pid "PROJ-4" "dispatched" 0
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+RC=$?
+[ $RC -eq 0 ] && pass "null pid exits zero" || fail "null pid exits zero" "rc=$RC"
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-4.json")
+[ "$STATUS" = "dispatched" ] && pass "null-pid worker untouched" || fail "null-pid worker untouched" "got: $STATUS"
+scratch_teardown
+
+echo "test: mixed wave — 2 alive + 1 dead, only dead one is flagged"
+scratch_setup
+make_signal "PROJ-A" "$$" "dispatched" 0
+make_signal "PROJ-B" "$DEAD_PID" "dispatched" 0
+make_signal "PROJ-C" "$$" "dispatched" 0
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+SA=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-A.json")
+SB=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-B.json")
+SC=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-C.json")
+[ "$SA" = "dispatched" ] && [ "$SC" = "dispatched" ] && pass "alive workers untouched" \
+  || fail "alive workers untouched" "A=$SA C=$SC"
+[ "$SB" = "failed" ] && pass "dead worker flagged" || fail "dead worker flagged" "B=$SB"
+DEAD_COUNT=$(grep -c "attention demo launch-failure" "$STATE_LOG" || true)
+[ "$DEAD_COUNT" = "1" ] && pass "exactly one attention call" || fail "exactly one attention call" "count=$DEAD_COUNT"
+scratch_teardown
+
+echo "test: --dry-run detects but does not mutate"
+scratch_setup
+make_signal "PROJ-5" "$DEAD_PID" "dispatched" 0
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --dry-run > "${SCRATCH}/out" 2>&1
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-5.json")
+[ "$STATUS" = "dispatched" ] && pass "dry-run leaves signal unchanged" || fail "dry-run leaves signal unchanged" "got: $STATUS"
+[ ! -s "$STATE_LOG" ] && pass "dry-run makes no state-script calls" || fail "dry-run makes no state-script calls" "log: $(cat "$STATE_LOG")"
+grep -q "PROJ-5" "${SCRATCH}/out" && pass "dry-run reports the dead worker" || fail "dry-run reports the dead worker" "out: $(cat "${SCRATCH}/out")"
+scratch_teardown
+
+echo "test: non-worker JSON files are ignored"
+scratch_setup
+make_signal "PROJ-6" "$DEAD_PID" "dispatched" 0
+# Drop a non-signal JSON file shaped like something that could appear in workers/.
+echo '{"somethingElse": true}' > "${ORCH_DIR}/workers/not-a-signal.json"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+RC=$?
+[ $RC -eq 0 ] && pass "non-worker JSON does not crash" || fail "non-worker JSON does not crash" "rc=$RC; out: $(cat "${SCRATCH}/out")"
+# Still flags the real dead worker.
+SB=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-6.json")
+[ "$SB" = "failed" ] && pass "real dead worker still flagged despite junk file" || fail "real dead worker still flagged despite junk file" "got: $SB"
+scratch_teardown
+
+echo "test: summary JSON on stdout"
+scratch_setup
+make_signal "PROJ-7" "$$" "dispatched" 0
+make_signal "PROJ-8" "$DEAD_PID" "dispatched" 0
+OUT=$("$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 2>/dev/null)
+CHECKED=$(echo "$OUT" | jq -r '.checked' 2>/dev/null || echo "")
+DEAD=$(echo "$OUT" | jq -r '.dead' 2>/dev/null || echo "")
+[ "$CHECKED" = "2" ] && pass "summary.checked=2" || fail "summary.checked=2" "got: $CHECKED; out: $OUT"
+[ "$DEAD" = "1" ] && pass "summary.dead=1" || fail "summary.dead=1" "got: $DEAD; out: $OUT"
+scratch_teardown
+
+echo
+echo "Results: $PASSES passed, $FAILURES failed"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/orchestrate-healthcheck
+++ b/plugins/dev/scripts/orchestrate-healthcheck
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# orchestrate-healthcheck - Batch liveness check for freshly-dispatched workers (CTL-87).
+#
+# Run this once per wave, shortly after all workers are dispatched in Phase 3.
+# For each worker signal still at status="dispatched"/phase=0, verify the recorded
+# PID is alive. If it isn't, transition the signal to status="failed" with
+# failureReason="launch-failure", raise an attention item, and emit an event so
+# the orchestrator can react immediately instead of waiting 15 minutes for the
+# stalled-worker detector to fire.
+#
+# Usage:
+#   orchestrate-healthcheck --orch-dir <path> --orch-id <name>
+#                           [--grace-seconds <n>]   # default 15
+#                           [--dry-run]
+#
+# Outputs a single JSON summary on stdout:
+#   {"checked":N,"dead":M,"deadTickets":["TID-1",...]}
+#
+# Environment:
+#   CATALYST_STATE_SCRIPT   path to catalyst-state.sh (default: ../catalyst-state.sh
+#                           next to this script). Tests override this to capture calls.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
+
+ORCH_DIR=""
+ORCH_ID=""
+GRACE_SECONDS=15
+DRY_RUN=0
+
+usage() {
+  sed -n '2,22p' "$0"
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir)        ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)         ORCH_ID="$2"; shift 2 ;;
+    --grace-seconds)   GRACE_SECONDS="$2"; shift 2 ;;
+    --dry-run)         DRY_RUN=1; shift ;;
+    -h|--help)         usage 0 ;;
+    *)                 echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
+[ -z "$ORCH_ID" ]  && { echo "ERROR: --orch-id required"  >&2; exit 2; }
+[ ! -d "$ORCH_DIR/workers" ] && { echo "ERROR: no workers dir at $ORCH_DIR/workers" >&2; exit 2; }
+
+# Give freshly-dispatched processes a moment to fail before we judge them.
+if [ "$GRACE_SECONDS" -gt 0 ]; then
+  sleep "$GRACE_SECONDS"
+fi
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+CHECKED=0
+DEAD_TICKETS=()
+
+shopt -s nullglob
+for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
+  # Skip non-worker JSON files (fixup prompts, misc artifacts) — a real signal
+  # has at minimum a .ticket field.
+  TICKET=$(jq -r '.ticket // empty' "$SIGNAL" 2>/dev/null || echo "")
+  [ -z "$TICKET" ] && continue
+
+  STATUS=$(jq -r '.status // empty' "$SIGNAL")
+  PHASE=$(jq -r '.phase // 0' "$SIGNAL")
+  PID=$(jq -r '.pid // empty' "$SIGNAL")
+
+  # Only inspect workers that haven't announced themselves yet. Anything that
+  # moved off `dispatched`/phase 0 is clearly alive; anything terminal should
+  # not be relitigated.
+  [ "$STATUS" != "dispatched" ] && continue
+  [ "$PHASE" != "0" ] && continue
+  [ -z "$PID" ] && continue
+
+  CHECKED=$((CHECKED+1))
+
+  if kill -0 "$PID" 2>/dev/null; then
+    continue
+  fi
+
+  # PID is dead — this is a launch failure.
+  DEAD_TICKETS+=("$TICKET")
+  MSG="Worker PID ${PID} died within ${GRACE_SECONDS}s of dispatch"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] ${TICKET}: ${MSG}" >&2
+    continue
+  fi
+
+  TS=$(now_iso)
+  jq --arg status "failed" \
+     --arg reason "launch-failure" \
+     --arg ts "$TS" \
+     '.status = $status
+      | .failureReason = $reason
+      | .updatedAt = $ts
+      | .completedAt = $ts
+      | .phaseTimestamps = ((.phaseTimestamps // {}) | .failed = $ts)' \
+     "$SIGNAL" > "${SIGNAL}.tmp" && mv "${SIGNAL}.tmp" "$SIGNAL"
+
+  if [ -x "$STATE_SCRIPT" ]; then
+    "$STATE_SCRIPT" attention "$ORCH_ID" "launch-failure" "$TICKET" "$MSG"
+    "$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET" \
+      '.status = "failed" | .attentionReason = "'"${MSG//\"/\\\"}"'"'
+    EVT=$(jq -nc \
+      --arg ts "$TS" --arg orch "$ORCH_ID" --arg w "$TICKET" \
+      --argjson pid "$PID" --argjson grace "$GRACE_SECONDS" \
+      '{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-launch-failed",
+        detail:{pid:$pid, graceSeconds:$grace}}')
+    "$STATE_SCRIPT" event "$EVT"
+  fi
+
+  echo "LAUNCH-FAILURE: ${TICKET} (pid=${PID})" >&2
+done
+
+# Summary on stdout (machine-readable).
+DEAD_COUNT=${#DEAD_TICKETS[@]}
+if [ "$DEAD_COUNT" -eq 0 ]; then
+  DEAD_JSON="[]"
+else
+  DEAD_JSON=$(printf '%s\n' "${DEAD_TICKETS[@]}" | jq -R . | jq -s .)
+fi
+
+jq -nc \
+  --argjson c "$CHECKED" \
+  --argjson d "$DEAD_COUNT" \
+  --argjson t "$DEAD_JSON" \
+  '{checked:$c, dead:$d, deadTickets:$t}'

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -503,6 +503,34 @@ fi
   '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-dispatched", detail: null}')"
 ```
 
+**Post-dispatch health check (CTL-87):**
+
+After the wave's per-worker dispatch loop has completed, run the batch health check
+**once per wave**. It sleeps briefly (default 15s — configurable via `--grace-seconds`),
+then verifies that every worker still sitting at `status="dispatched"`/`phase=0` has a
+live PID. Any worker whose PID has already died is transitioned to `status="failed"`
+with `failureReason="launch-failure"`, an attention item of type `launch-failure` is
+raised, and a `worker-launch-failed` event is emitted. This means dead-on-arrival
+workers surface in under 30 seconds instead of after the 15-minute stalled-worker
+timeout, and the orchestrator can re-dispatch them (via `orchestrate-fixup` or a
+manual redispatch) in the same wave.
+
+```bash
+# Run ONCE, after all workers in this wave have been dispatched.
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-healthcheck" \
+  --orch-dir "${ORCH_DIR}" \
+  --orch-id "${ORCH_NAME}"
+# Prints a JSON summary on stdout: {"checked":N,"dead":M,"deadTickets":[...]}.
+# Launch failures also appear in the attention list and as `worker-launch-failed`
+# events in the global state log.
+```
+
+Healthy workers are untouched. Workers that have already advanced past `dispatched`
+(e.g. into `researching`) are skipped because reaching a later status is itself
+proof of life. This check complements the 15-minute stalled-worker detection in
+Phase 4 — healthcheck catches launch failures, the stalled-worker scan catches
+workers that die mid-run.
+
 **Worker dispatch prompt includes mandatory testing AND lifecycle requirements:**
 
 ```


### PR DESCRIPTION
## Summary

Fixes [CTL-87](https://linear.app/coalesce-labs/issue/CTL-87). When a worker process dies before writing its first signal update (bad flag, transient env error), the signal file sits at `dispatched`/`phase: 0` forever. The stalled-worker detector only fires after 15 minutes — far too slow. In orch-2026-04-15-2, 3 Adva workers died at phase 0 with dead processes and no PRs, undetected.

This PR adds a **batch** post-dispatch health check that runs once per wave and surfaces dead-on-arrival workers in under 30 seconds.

## What changed

- **New script** `plugins/dev/scripts/orchestrate-healthcheck`
  - Scans `${ORCH_DIR}/workers/*.json` for signals at `status=dispatched`/`phase=0`
  - Sleeps a grace period (default 15s; configurable via `--grace-seconds`)
  - Verifies each signal's recorded `.pid` with `kill -0`
  - For dead PIDs: signal → `status=failed` / `failureReason=launch-failure`, raises `launch-failure` attention, emits `worker-launch-failed` event
  - Supports `--dry-run` and `CATALYST_STATE_SCRIPT` env var for testability
  - Emits a JSON summary on stdout: `{"checked":N,"dead":M,"deadTickets":[...]}`

- **`plugins/dev/skills/orchestrate/SKILL.md`** — Phase 3 now invokes the health check once per wave after all workers are dispatched. The batch approach (as the ticket suggested) keeps per-worker dispatch fast.

- **`plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh`** — 20 shell tests (TDD).

## Design notes

- **Batch, not per-worker.** Per-worker `sleep 15` would serialize dispatch. Batch scan happens once after the wave.
- **Skips workers past `phase=0`.** Reaching any later phase is proof of life — we never override a worker that has advanced.
- **Complements, does not replace**, the 15-minute stalled-worker detector, which still catches mid-run deaths.
- **No auto-redispatch.** The ticket marks redispatch as optional; `orchestrate-fixup` already provides that path. Kept surgical.

## Acceptance criteria (from CTL-87)

- [x] Within 30s of dispatch, orchestrator verifies worker PID is still alive
- [x] Dead-on-arrival workers are flagged as attention items immediately
- [x] Does not slow down the dispatch loop for healthy workers (batch, not per-worker)
- [ ] ~~Auto-redispatch~~ — deferred (optional in ticket; existing fixup flow covers this)

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh` — 20/20 pass
- [x] Full test dir: 84/84 pass (nothing else broken)
- [x] Manual end-to-end smoke with a known-dead PID + a live PID — only the dead one flagged, correct `catalyst-state.sh attention/worker/event` calls, summary JSON correct
- [x] Syntax: `bash -n` clean on both script and test