### PR TITLE
feat(dev): port revive-worker session-resume into orchestrator Phase 4 (CTL-63)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-revive (CTL-63).
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+REVIVE="${REPO_ROOT}/plugins/dev/scripts/orchestrate-revive"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+# A PID that is guaranteed to be dead.
+DEAD_PID=99999999
+while kill -0 "$DEAD_PID" 2>/dev/null; do DEAD_PID=$((DEAD_PID+1)); done
+
+scratch_setup() {
+  SCRATCH="$(mktemp -d)"
+  ORCH_DIR="${SCRATCH}/orch"
+  WORKTREE_ROOT="${SCRATCH}/wt"
+  mkdir -p "${ORCH_DIR}/workers/output" "${SCRATCH}/bin" "${WORKTREE_ROOT}"
+
+  # Fake state script: appends argv to state.log so tests can assert.
+  cat > "${SCRATCH}/bin/catalyst-state.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$STATE_LOG"
+EOF
+  chmod +x "${SCRATCH}/bin/catalyst-state.sh"
+  export STATE_LOG="${SCRATCH}/state.log"
+  : > "$STATE_LOG"
+  export CATALYST_STATE_SCRIPT="${SCRATCH}/bin/catalyst-state.sh"
+
+  # Fake claude binary: records argv + env into claude.log and exits 0 quickly,
+  # leaving a PID that's alive just long enough to be sampled.
+  cat > "${SCRATCH}/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+{
+  echo "pid=$$"
+  echo "cwd=$(pwd)"
+  echo "ORCH_DIR=${CATALYST_ORCHESTRATOR_DIR:-}"
+  echo "ORCH_ID=${CATALYST_ORCHESTRATOR_ID:-}"
+  echo "args: $*"
+} >> "$CLAUDE_LOG"
+# Long-running placeholder so kill-0 succeeds for the test window.
+sleep 30 &
+disown $! 2>/dev/null || true
+EOF
+  chmod +x "${SCRATCH}/bin/claude"
+  export CLAUDE_LOG="${SCRATCH}/claude.log"
+  : > "$CLAUDE_LOG"
+  export CATALYST_REVIVE_CLAUDE_BIN="${SCRATCH}/bin/claude"
+}
+
+scratch_teardown() {
+  # Reap any sleepers the fake claude left behind.
+  pkill -f "sleep 30" 2>/dev/null || true
+  rm -rf "$SCRATCH"
+  unset STATE_LOG CLAUDE_LOG CATALYST_STATE_SCRIPT CATALYST_REVIVE_CLAUDE_BIN
+  unset SCRATCH ORCH_DIR WORKTREE_ROOT
+}
+
+# make_signal TICKET PID STATUS PHASE [EXTRA_JQ]
+make_signal() {
+  local ticket="$1" pid="$2" status="$3" phase="$4" extra="${5:-.}"
+  local worktree="${WORKTREE_ROOT}/${ticket}"
+  mkdir -p "$worktree"
+  local updated
+  updated=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  jq -n \
+    --arg t "$ticket" --arg s "$status" --arg u "$updated" \
+    --arg wt "$worktree" --arg wn "test-${ticket}" \
+    --argjson p "$phase" --argjson pid "$pid" \
+    '{ticket:$t, orchestrator:"test", workerName:$wn, status:$s, phase:$p,
+      pid:$pid, worktreePath:$wt, startedAt:$u, updatedAt:$u,
+      lastHeartbeat:$u}' \
+    | jq "$extra" \
+    > "${ORCH_DIR}/workers/${ticket}.json"
+}
+
+# write_stream_init TICKET SESSION_ID
+write_stream_init() {
+  local ticket="$1" sid="$2"
+  cat > "${ORCH_DIR}/workers/output/${ticket}-stream.jsonl" <<EOF
+{"type":"system","subtype":"init","session_id":"${sid}"}
+EOF
+}
+
+run_revive() {
+  "$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "demo" "$@"
+}
+
+# ─── Test cases ───────────────────────────────────────────────────────────────
+
+echo "test: alive worker with fresh heartbeat is left untouched"
+scratch_setup
+ALIVE_PID=$$
+make_signal "T-1" "$ALIVE_PID" "implementing" 3
+write_stream_init "T-1" "sess-alive"
+run_revive > "${SCRATCH}/out" 2>&1
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/T-1.json")
+REVIVE_COUNT=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/T-1.json")
+[ "$STATUS" = "implementing" ] && pass "status unchanged" || fail "status unchanged" "got: $STATUS"
+[ "$REVIVE_COUNT" = "0" ] && pass "reviveCount unchanged" || fail "reviveCount unchanged" "got: $REVIVE_COUNT"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude not invoked" || fail "claude not invoked" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test: dead worker is revived via stream session_id"
+scratch_setup
+make_signal "T-2" "$DEAD_PID" "pr-created" 5
+write_stream_init "T-2" "sess-resume-abc"
+run_revive > "${SCRATCH}/out" 2>&1
+REVIVE_COUNT=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/T-2.json")
+NEW_PID=$(jq -r '.pid' "${ORCH_DIR}/workers/T-2.json")
+REVIVED_SID=$(jq -r '.revivedFromSessionId // ""' "${ORCH_DIR}/workers/T-2.json")
+[ "$REVIVE_COUNT" = "1" ] && pass "reviveCount bumped" || fail "reviveCount bumped" "got: $REVIVE_COUNT"
+[ "$NEW_PID" != "$DEAD_PID" ] && pass "pid replaced" || fail "pid replaced" "got: $NEW_PID"
+[ "$REVIVED_SID" = "sess-resume-abc" ] && pass "revived session tracked" || fail "revived session tracked" "got: $REVIVED_SID"
+grep -q -- "--resume sess-resume-abc" "$CLAUDE_LOG" && pass "claude launched with --resume" || fail "claude launched with --resume" "log: $(cat "$CLAUDE_LOG")"
+grep -q "ORCH_DIR=${ORCH_DIR}" "$CLAUDE_LOG" && pass "CATALYST_ORCHESTRATOR_DIR forwarded" || fail "CATALYST_ORCHESTRATOR_DIR forwarded" "log: $(cat "$CLAUDE_LOG")"
+grep -q "ORCH_ID=demo" "$CLAUDE_LOG" && pass "CATALYST_ORCHESTRATOR_ID forwarded" || fail "CATALYST_ORCHESTRATOR_ID forwarded" "log: $(cat "$CLAUDE_LOG")"
+grep -q "worker-revived" "$STATE_LOG" && pass "revive event emitted" || fail "revive event emitted" "log: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test: worker in terminal state is skipped"
+scratch_setup
+for TS in done failed stalled merged; do
+  make_signal "TERM-${TS}" "$DEAD_PID" "$TS" 5
+  write_stream_init "TERM-${TS}" "sess-${TS}"
+done
+run_revive > "${SCRATCH}/out" 2>&1
+for TS in done failed stalled merged; do
+  GOT=$(jq -r '.status' "${ORCH_DIR}/workers/TERM-${TS}.json")
+  RC=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/TERM-${TS}.json")
+  [ "$GOT" = "$TS" ] && pass "${TS}: status unchanged" || fail "${TS}: status unchanged" "got: $GOT"
+  [ "$RC" = "0" ] && pass "${TS}: no revive" || fail "${TS}: no revive" "rc: $RC"
+done
+[ ! -s "$CLAUDE_LOG" ] && pass "terminal: claude not invoked" || fail "terminal: claude not invoked"
+scratch_teardown
+
+echo "test: revive budget exhausted → stalled + attention"
+scratch_setup
+make_signal "T-3" "$DEAD_PID" "merging" 5 '.reviveCount = 2'
+write_stream_init "T-3" "sess-exhausted"
+run_revive --max-revives 2 > "${SCRATCH}/out" 2>&1
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/T-3.json")
+REASON=$(jq -r '.attentionReason // ""' "${ORCH_DIR}/workers/T-3.json")
+[ "$STATUS" = "stalled" ] && pass "status → stalled when budget exhausted" || fail "status → stalled" "got: $STATUS"
+[ "$REASON" = "revive-budget-exhausted" ] && pass "attentionReason set" || fail "attentionReason set" "got: $REASON"
+grep -q "attention demo revive-budget-exhausted T-3" "$STATE_LOG" && pass "attention raised" || fail "attention raised" "log: $(cat "$STATE_LOG")"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude not invoked after budget exhausted" || fail "claude not invoked after budget exhausted"
+scratch_teardown
+
+echo "test: stale heartbeat on live PID triggers revive"
+scratch_setup
+ALIVE_PID=$$
+make_signal "T-4" "$ALIVE_PID" "implementing" 3
+write_stream_init "T-4" "sess-stale"
+# Rewrite lastHeartbeat & updatedAt to 30 minutes ago.
+OLD_TS=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+jq --arg ts "$OLD_TS" '.updatedAt = $ts | .lastHeartbeat = $ts' \
+  "${ORCH_DIR}/workers/T-4.json" > "${ORCH_DIR}/workers/T-4.json.tmp" \
+  && mv "${ORCH_DIR}/workers/T-4.json.tmp" "${ORCH_DIR}/workers/T-4.json"
+run_revive --stale-heartbeat-seconds 900 > "${SCRATCH}/out" 2>&1
+REVIVE_COUNT=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/T-4.json")
+[ "$REVIVE_COUNT" = "1" ] && pass "stale heartbeat triggers revive" || fail "stale heartbeat triggers revive" "got: $REVIVE_COUNT"
+grep -q -- "--resume sess-stale" "$CLAUDE_LOG" && pass "claude launched for stale heartbeat" || fail "claude launched for stale heartbeat"
+scratch_teardown
+
+echo "test: dry-run makes no state changes"
+scratch_setup
+make_signal "T-5" "$DEAD_PID" "implementing" 3
+write_stream_init "T-5" "sess-dry"
+run_revive --dry-run > "${SCRATCH}/out" 2>&1
+REVIVE_COUNT=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/T-5.json")
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/T-5.json")
+[ "$REVIVE_COUNT" = "0" ] && pass "dry-run: reviveCount unchanged" || fail "dry-run: reviveCount unchanged" "got: $REVIVE_COUNT"
+[ "$STATUS" = "implementing" ] && pass "dry-run: status unchanged" || fail "dry-run: status unchanged" "got: $STATUS"
+[ ! -s "$CLAUDE_LOG" ] && pass "dry-run: claude not invoked" || fail "dry-run: claude not invoked"
+[ ! -s "$STATE_LOG" ] && pass "dry-run: state script not invoked" || fail "dry-run: state script not invoked"
+scratch_teardown
+
+echo "test: missing session_id → stalled with attention"
+scratch_setup
+make_signal "T-6" "$DEAD_PID" "implementing" 3
+# No stream file written — no session_id anywhere.
+run_revive > "${SCRATCH}/out" 2>&1
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/T-6.json")
+REASON=$(jq -r '.attentionReason // ""' "${ORCH_DIR}/workers/T-6.json")
+[ "$STATUS" = "stalled" ] && pass "no session_id → stalled" || fail "no session_id → stalled" "got: $STATUS"
+[ "$REASON" = "no-session-id" ] && pass "attentionReason = no-session-id" || fail "attentionReason = no-session-id" "got: $REASON"
+grep -q "attention demo no-session-id T-6" "$STATE_LOG" && pass "no-session-id attention raised" || fail "no-session-id attention raised"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude not invoked when session_id missing" || fail "claude not invoked when session_id missing"
+scratch_teardown
+
+echo "test: legacy output.json session_id fallback"
+scratch_setup
+make_signal "T-7" "$DEAD_PID" "merging" 5
+# No stream file — only legacy output.json format.
+echo '{"session_id":"sess-legacy-xyz"}' > "${ORCH_DIR}/workers/T-7-output.json"
+run_revive > "${SCRATCH}/out" 2>&1
+REVIVED_SID=$(jq -r '.revivedFromSessionId // ""' "${ORCH_DIR}/workers/T-7.json")
+[ "$REVIVED_SID" = "sess-legacy-xyz" ] && pass "legacy output.json session_id used" || fail "legacy output.json session_id used" "got: $REVIVED_SID"
+grep -q -- "--resume sess-legacy-xyz" "$CLAUDE_LOG" && pass "claude launched with legacy session_id" || fail "claude launched with legacy session_id"
+scratch_teardown
+
+echo "test: summary JSON has expected shape"
+scratch_setup
+ALIVE_PID=$$
+make_signal "S-alive" "$ALIVE_PID" "implementing" 3
+make_signal "S-dead" "$DEAD_PID" "implementing" 3
+write_stream_init "S-alive" "sess-s-alive"
+write_stream_init "S-dead" "sess-s-dead"
+OUT=$(run_revive)
+CHECKED=$(echo "$OUT" | jq -r '.checked')
+REVIVED=$(echo "$OUT" | jq -r '.revived')
+[ "$CHECKED" = "2" ] && pass "summary.checked = 2" || fail "summary.checked" "got: $CHECKED"
+[ "$REVIVED" = "1" ] && pass "summary.revived = 1" || fail "summary.revived" "got: $REVIVED"
+scratch_teardown
+
+# ─── Results ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Passes: $PASSES  Failures: $FAILURES"
+[ $FAILURES -eq 0 ] && exit 0 || exit 1

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# orchestrate-revive - Revive dead/stalled workers via claude session-resume (CTL-63).
+#
+# Ports the agent-obs/revive-worker.sh pattern into the orchestrator. For each
+# worker signal under ORCH_DIR/workers/*.json, checks PID liveness and
+# heartbeat staleness; when a non-terminal worker is dead or wedged, resolves
+# its original session_id and relaunches `claude -p --resume <sid>` so the
+# revived process picks up the full prior context (tool calls, plan, PR state)
+# at a fraction of the cost of a fresh redispatch.
+#
+# Usage:
+#   orchestrate-revive --orch-dir <path> --orch-id <id>
+#                      [--max-revives <n>]               # default 2
+#                      [--stale-heartbeat-seconds <n>]   # default 900 (15 min)
+#                      [--worker-command <cmd>]          # default /catalyst-dev:oneshot
+#                      [--model <name>]                  # default opus
+#                      [--dry-run]
+#
+# Outputs a JSON summary on stdout:
+#   {"checked":N,"revived":M,"stalled":K,"skipped":S}
+#
+# Environment:
+#   CATALYST_STATE_SCRIPT       path to catalyst-state.sh (default: sibling of this script)
+#   CATALYST_REVIVE_CLAUDE_BIN  claude binary to invoke (default: `claude` on PATH) — tests override
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
+CLAUDE_BIN="${CATALYST_REVIVE_CLAUDE_BIN:-claude}"
+
+ORCH_DIR=""
+ORCH_ID=""
+MAX_REVIVES=2
+STALE_HEARTBEAT_SECONDS=900
+WORKER_COMMAND="/catalyst-dev:oneshot"
+MODEL="opus"
+DRY_RUN=0
+
+usage() {
+  sed -n '2,32p' "$0"
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir)                 ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)                  ORCH_ID="$2"; shift 2 ;;
+    --max-revives)              MAX_REVIVES="$2"; shift 2 ;;
+    --stale-heartbeat-seconds)  STALE_HEARTBEAT_SECONDS="$2"; shift 2 ;;
+    --worker-command)           WORKER_COMMAND="$2"; shift 2 ;;
+    --model)                    MODEL="$2"; shift 2 ;;
+    --dry-run)                  DRY_RUN=1; shift ;;
+    -h|--help)                  usage 0 ;;
+    *)                          echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
+[ -z "$ORCH_ID" ]  && { echo "ERROR: --orch-id required"  >&2; exit 2; }
+[ ! -d "$ORCH_DIR/workers" ] && { echo "ERROR: no workers dir at $ORCH_DIR/workers" >&2; exit 2; }
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# Return number of seconds since the given ISO timestamp, or a very large value
+# if the timestamp is empty/unparseable (so callers treat it as stale).
+seconds_since() {
+  local ts="$1"
+  [ -z "$ts" ] && { echo 999999; return; }
+  local then
+  # macOS `date -j -f` vs GNU `date -d` — fall back if neither accepts.
+  then=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null \
+        || date -u -d "$ts" +%s 2>/dev/null \
+        || echo "")
+  [ -z "$then" ] && { echo 999999; return; }
+  local now
+  now=$(date -u +%s)
+  echo $(( now - then ))
+}
+
+# Resolve the session_id for a ticket from (in priority order):
+#   1. workers/output/<ticket>-stream.jsonl first system/init event
+#   2. workers/<ticket>-stream.jsonl first system/init event (legacy path)
+#   3. workers/<ticket>-output.json .session_id (agent-obs legacy format)
+#   4. Basename of newest ~/.claude/projects/*<worker-name>*/*.jsonl
+resolve_session_id() {
+  local ticket="$1" worker_name="$2"
+  local sid=""
+
+  for stream in \
+    "${ORCH_DIR}/workers/output/${ticket}-stream.jsonl" \
+    "${ORCH_DIR}/workers/${ticket}-stream.jsonl"; do
+    if [ -f "$stream" ]; then
+      sid=$(grep -m1 '"subtype":"init"' "$stream" 2>/dev/null \
+        | jq -r '.session_id // empty' 2>/dev/null || echo "")
+      [ -n "$sid" ] && { echo "$sid"; return 0; }
+    fi
+  done
+
+  local legacy="${ORCH_DIR}/workers/${ticket}-output.json"
+  if [ -f "$legacy" ]; then
+    sid=$(jq -r '.session_id // empty' "$legacy" 2>/dev/null || echo "")
+    [ -n "$sid" ] && { echo "$sid"; return 0; }
+  fi
+
+  # Last resort: scan the local Claude Code project dirs for a transcript whose
+  # directory name matches the worker-name. Basename of the newest jsonl is the
+  # session_id.
+  if [ -n "$worker_name" ] && [ -d "$HOME/.claude/projects" ]; then
+    local newest
+    newest=$(find "$HOME/.claude/projects" -type d -name "*${worker_name}*" -maxdepth 2 \
+      -exec find {} -maxdepth 1 -name "*.jsonl" -type f \; 2>/dev/null \
+      | xargs ls -t 2>/dev/null | head -1)
+    if [ -n "$newest" ]; then
+      sid=$(basename "$newest" .jsonl)
+      [ -n "$sid" ] && { echo "$sid"; return 0; }
+    fi
+  fi
+
+  return 1
+}
+
+# Emit a fresh-start event via the state script (no-op when state script is
+# missing or when this is a dry run).
+emit_state() {
+  [ "$DRY_RUN" -eq 1 ] && return 0
+  [ -x "$STATE_SCRIPT" ] || return 0
+  "$STATE_SCRIPT" "$@" >/dev/null 2>&1 || true
+}
+
+# Compose the revive prompt based on the worker's self-reported phase so the
+# resumed session knows which loop to re-enter. Kept short — the session
+# already carries full prior context.
+build_prompt() {
+  local status="$1"
+  case "$status" in
+    pr-created|merging)
+      echo "Your session was revived by the orchestrator. Resume your merge-completion loop: poll \`gh pr view <PR> --json state,mergeStateStatus,mergedAt\` every 30-60s. Handle BEHIND (call \`gh api -X PUT repos/.../update-branch\`), UNSTABLE/BLOCKED (investigate CI + Codex threads, fix and push), DIRTY (rebase). Update your signal file lastHeartbeat every iteration. You are not done until state=MERGED with a real mergedAt — write pr.mergedAt + status=done to your signal before exiting."
+      ;;
+    shipping)
+      echo "Your session was revived by the orchestrator. Resume Phase 5: if no PR yet, create it; then arm auto-merge and enter the poll-until-MERGED loop. You are not done until gh pr view returns state=MERGED with a real mergedAt."
+      ;;
+    validating)
+      echo "Your session was revived by the orchestrator. Resume Phase 4 (validation + quality gates) where you left off, then proceed to Phase 5 (ship) and poll until MERGED."
+      ;;
+    implementing|planning|researching|dispatched)
+      echo "Your session was revived by the orchestrator. Resume your current phase where you left off and continue through validation, ship, and merge. You are not done until gh pr view returns state=MERGED with a real mergedAt."
+      ;;
+    *)
+      echo "Your session was revived by the orchestrator. Continue your oneshot workflow where you left off — research → plan → implement → validate → ship → merge. You are not done until gh pr view returns state=MERGED with a real mergedAt."
+      ;;
+  esac
+}
+
+# Spawn a revived claude session for a worker. Emits the new PID on stdout, or
+# empty string on failure.
+spawn_revive() {
+  local ticket="$1" worktree="$2" session_id="$3" prompt="$4"
+
+  if [ ! -d "$worktree" ]; then
+    echo "ERROR: worktree missing for ${ticket}: ${worktree}" >&2
+    return 1
+  fi
+
+  local stream_file="${ORCH_DIR}/workers/output/${ticket}-stream.jsonl"
+  local stderr_file="${ORCH_DIR}/workers/output/${ticket}-stderr.log"
+  mkdir -p "$(dirname "$stream_file")"
+
+  (
+    cd "$worktree" || exit 1
+    CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
+    CATALYST_ORCHESTRATOR_ID="$ORCH_ID" \
+    exec nohup "$CLAUDE_BIN" \
+      --model "$MODEL" \
+      --output-format stream-json \
+      --verbose \
+      --dangerously-skip-permissions \
+      --resume "$session_id" \
+      -p "$prompt"
+  ) >> "$stream_file" 2>> "$stderr_file" < /dev/null &
+
+  local pid=$!
+  disown "$pid" 2>/dev/null || true
+  echo "$pid"
+}
+
+# ─── Main loop ────────────────────────────────────────────────────────────────
+
+CHECKED=0
+REVIVED=0
+STALLED=0
+SKIPPED=0
+
+TERMINAL_STATUSES=" done merged failed stalled signal_corrupt "
+
+shopt -s nullglob
+for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
+  # Skip non-worker JSON files (orchestrator artifacts etc.) — real signals
+  # always have a .ticket field.
+  TICKET=$(jq -r '.ticket // empty' "$SIGNAL" 2>/dev/null || echo "")
+  [ -z "$TICKET" ] && continue
+
+  STATUS=$(jq -r '.status // empty' "$SIGNAL")
+  PID=$(jq -r '.pid // empty' "$SIGNAL")
+  WORKTREE=$(jq -r '.worktreePath // empty' "$SIGNAL")
+  WORKER_NAME=$(jq -r '.workerName // empty' "$SIGNAL")
+  LAST_HEARTBEAT=$(jq -r '.lastHeartbeat // .updatedAt // empty' "$SIGNAL")
+  REVIVE_COUNT=$(jq -r '.reviveCount // 0' "$SIGNAL")
+
+  # Skip workers that have already reached a terminal state.
+  if [[ "$TERMINAL_STATUSES" == *" $STATUS "* ]]; then
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  CHECKED=$((CHECKED+1))
+
+  # Liveness decision: dead PID OR (alive PID with heartbeat older than
+  # stale-heartbeat-seconds — a zombie-sleep situation documented in the
+  # CTL-63 ticket).
+  local_dead=0
+  if [ -z "$PID" ] || ! kill -0 "$PID" 2>/dev/null; then
+    local_dead=1
+  fi
+  STALE_AGE=$(seconds_since "$LAST_HEARTBEAT")
+  local_stale=0
+  if [ "$STALE_AGE" -ge "$STALE_HEARTBEAT_SECONDS" ]; then
+    local_stale=1
+  fi
+
+  if [ "$local_dead" -eq 0 ] && [ "$local_stale" -eq 0 ]; then
+    continue
+  fi
+
+  TS=$(now_iso)
+
+  # Budget check: if we have already used MAX_REVIVES, escalate to stalled.
+  if [ "$REVIVE_COUNT" -ge "$MAX_REVIVES" ]; then
+    STALLED=$((STALLED+1))
+    MSG="Revive budget exhausted after ${REVIVE_COUNT} attempts"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "[dry-run] ${TICKET}: ${MSG}" >&2
+      continue
+    fi
+    jq --arg ts "$TS" --arg msg "$MSG" \
+       '.status = "stalled"
+        | .attentionReason = "revive-budget-exhausted"
+        | .attentionMessage = $msg
+        | .updatedAt = $ts
+        | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \
+       "$SIGNAL" > "${SIGNAL}.tmp" && mv "${SIGNAL}.tmp" "$SIGNAL"
+    emit_state attention "$ORCH_ID" "revive-budget-exhausted" "$TICKET" "$MSG"
+    emit_state event "$(jq -nc --arg ts "$TS" --arg orch "$ORCH_ID" \
+      --arg w "$TICKET" --argjson rc "$REVIVE_COUNT" \
+      '{ts:$ts, orchestrator:$orch, worker:$w,
+        event:"worker-revive-budget-exhausted", detail:{reviveCount:$rc}}')"
+    echo "BUDGET-EXHAUSTED: ${TICKET} (reviveCount=${REVIVE_COUNT})" >&2
+    continue
+  fi
+
+  # Resolve session_id; without one we cannot resume.
+  SESSION_ID=$(resolve_session_id "$TICKET" "$WORKER_NAME" || echo "")
+  if [ -z "$SESSION_ID" ]; then
+    STALLED=$((STALLED+1))
+    MSG="No session_id available for revive"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "[dry-run] ${TICKET}: ${MSG}" >&2
+      continue
+    fi
+    jq --arg ts "$TS" --arg msg "$MSG" \
+       '.status = "stalled"
+        | .attentionReason = "no-session-id"
+        | .attentionMessage = $msg
+        | .updatedAt = $ts
+        | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \
+       "$SIGNAL" > "${SIGNAL}.tmp" && mv "${SIGNAL}.tmp" "$SIGNAL"
+    emit_state attention "$ORCH_ID" "no-session-id" "$TICKET" "$MSG"
+    echo "NO-SESSION-ID: ${TICKET}" >&2
+    continue
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] ${TICKET}: would revive via session ${SESSION_ID}" >&2
+    REVIVED=$((REVIVED+1))
+    continue
+  fi
+
+  # Actually revive.
+  PROMPT=$(build_prompt "$STATUS")
+  NEW_PID=$(spawn_revive "$TICKET" "$WORKTREE" "$SESSION_ID" "$PROMPT" || echo "")
+  if [ -z "$NEW_PID" ]; then
+    STALLED=$((STALLED+1))
+    MSG="Failed to spawn claude for revive"
+    jq --arg ts "$TS" --arg msg "$MSG" \
+       '.status = "stalled"
+        | .attentionReason = "revive-spawn-failed"
+        | .attentionMessage = $msg
+        | .updatedAt = $ts
+        | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \
+       "$SIGNAL" > "${SIGNAL}.tmp" && mv "${SIGNAL}.tmp" "$SIGNAL"
+    emit_state attention "$ORCH_ID" "revive-spawn-failed" "$TICKET" "$MSG"
+    continue
+  fi
+
+  REVIVED=$((REVIVED+1))
+  NEW_REVIVE_COUNT=$((REVIVE_COUNT+1))
+  jq --arg ts "$TS" --arg sid "$SESSION_ID" \
+     --argjson pid "$NEW_PID" --argjson rc "$NEW_REVIVE_COUNT" \
+     '.pid = $pid
+      | .reviveCount = $rc
+      | .lastReviveAt = $ts
+      | .revivedFromSessionId = $sid
+      | .lastHeartbeat = $ts
+      | .updatedAt = $ts' \
+     "$SIGNAL" > "${SIGNAL}.tmp" && mv "${SIGNAL}.tmp" "$SIGNAL"
+
+  emit_state event "$(jq -nc --arg ts "$TS" --arg orch "$ORCH_ID" \
+    --arg w "$TICKET" --arg sid "$SESSION_ID" \
+    --argjson pid "$NEW_PID" --argjson rc "$NEW_REVIVE_COUNT" \
+    '{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-revived",
+      detail:{pid:$pid, sessionId:$sid, reviveCount:$rc}}')"
+
+  echo "REVIVED: ${TICKET} (sid=${SESSION_ID}, pid=${NEW_PID}, count=${NEW_REVIVE_COUNT})" >&2
+done
+
+jq -nc \
+  --argjson c "$CHECKED" \
+  --argjson r "$REVIVED" \
+  --argjson s "$STALLED" \
+  --argjson k "$SKIPPED" \
+  '{checked:$c, revived:$r, stalled:$s, skipped:$k}'

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -804,6 +804,25 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
 done
 ```
 
+**Auto-revive dead/wedged workers (CTL-63):**
+
+After the stalled-worker scan, attempt to resume any dead or heartbeat-stale
+worker from its original `session_id`. Resumed sessions preserve tool-call
+history, plan context, and PR state at ~10× lower cost than a fresh redispatch.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-revive" \
+  --orch-dir "$ORCH_DIR" \
+  --orch-id "$ORCH_NAME"
+```
+
+The script checks every non-terminal worker signal, revives from
+`workers/output/<ticket>-stream.jsonl` (with legacy / transcript fallbacks),
+enforces a per-ticket budget (default 2), and transitions workers whose
+budget is exhausted or whose session_id cannot be found to
+`status=stalled` with an attention item so you can decide between manual
+intervention and a fresh redispatch.
+
 ### Phase 5: Independent Verification (Anti-Reward-Hacking)
 
 ```bash


### PR DESCRIPTION
## Summary

Ports the proven `agent-obs/revive-worker.sh` session-resume pattern into orchestrator Phase 4 as `plugins/dev/scripts/orchestrate-revive`. When a worker dies mid-merge-loop or wedges with a stale heartbeat, the orchestrator can now resume it via `claude -p --resume <session_id>` instead of dispatching fresh — ~10× cheaper, preserves full prior context (tool calls, plan, PR state).

Validated pattern: during the 2026-04-14 agent-obs run, 9 workers died post-PR-creation or mid-rebase and were revived this way, saving ~$30.

Closes CTL-63. Part of epic CTL-61.

## What it does

Per Phase 4 monitoring tick, for every non-terminal worker signal:
- Checks PID liveness (`kill -0`) **and** heartbeat staleness — PID alone is insufficient (zombies in sleep state).
- Resolves `session_id` from `workers/output/<ticket>-stream.jsonl` (primary), with fallbacks to the legacy stream path, agent-obs-style `workers/<ticket>-output.json`, and `~/.claude/projects/*<worker-name>*/*.jsonl`.
- Spawns `claude --resume <sid> -p <prompt>` with `CATALYST_ORCHESTRATOR_DIR`/`ID` forwarded; writes new PID + `reviveCount` + `revivedFromSessionId` + fresh heartbeat into the signal file.
- Enforces a per-ticket revive budget (default 2). When exhausted or when no `session_id` can be found, transitions to `status=stalled` with an attention item so the orchestrator escalates rather than spinning.

Phase-aware resume prompts keep the revived session in its original loop (merge-polling vs. implementation vs. validation).

## Test plan

- [x] 37 shell tests (`plugins/dev/scripts/__tests__/orchestrate-revive.test.sh`) — all pass
  - alive worker with fresh heartbeat: untouched
  - dead worker: revived via stream session_id
  - terminal states (done/merged/failed/stalled): skipped
  - budget exhausted: transitions to stalled + attention
  - stale heartbeat with live PID: triggers revive
  - `--dry-run`: no state changes
  - missing session_id: stalled + `no-session-id` attention
  - legacy `output.json` fallback
  - summary JSON shape
- [x] `bun run typecheck`: clean
- [x] `bun run lint`: only pre-existing warning in `preview-status.ts`
- [x] All other shell test suites pass (healthcheck, fixup, followup, etc.)

Pre-existing `catalyst-monitor.test.ts` failures (6) also fail on `main` — unrelated environment/port issues.