### PR TITLE
feat(dev): detect API stream idle timeout in orchestrate-revive (CTL-62)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
@@ -222,6 +222,151 @@ REVIVED=$(echo "$OUT" | jq -r '.revived')
 [ "$REVIVED" = "1" ] && pass "summary.revived = 1" || fail "summary.revived" "got: $REVIVED"
 scratch_teardown
 
+# ─── CTL-62: API stream idle timeout detection ───────────────────────────────
+
+# write_stream_api_error TICKET SESSION_ID ERROR_UUID [MESSAGE]
+# Appends an init event, one assistant turn, and a final `result` event with
+# is_error=true + an api_error_status that mentions a stream idle timeout.
+write_stream_api_error() {
+  local ticket="$1" sid="$2" err_uuid="$3"
+  local msg="${4:-API Error: Stream idle timeout - partial response received}"
+  local stream="${ORCH_DIR}/workers/output/${ticket}-stream.jsonl"
+  mkdir -p "$(dirname "$stream")"
+  {
+    printf '{"type":"system","subtype":"init","session_id":"%s"}\n' "$sid"
+    printf '{"type":"assistant","session_id":"%s","uuid":"turn-1"}\n' "$sid"
+    printf '{"type":"result","subtype":"error","is_error":true,"api_error_status":"%s","session_id":"%s","uuid":"%s"}\n' \
+      "$msg" "$sid" "$err_uuid"
+  } > "$stream"
+}
+
+echo "test: API stream idle timeout on live PID triggers revive"
+scratch_setup
+ALIVE_PID=$$
+make_signal "IDLE-1" "$ALIVE_PID" "implementing" 3
+write_stream_api_error "IDLE-1" "sess-idle-1" "err-uuid-1"
+run_revive > "${SCRATCH}/out" 2>&1
+REVIVE_COUNT=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/IDLE-1.json")
+REASON=$(jq -r '.lastReviveReason // ""' "${ORCH_DIR}/workers/IDLE-1.json")
+RECORDED_UUID=$(jq -r '.lastApiErrorUuid // ""' "${ORCH_DIR}/workers/IDLE-1.json")
+[ "$REVIVE_COUNT" = "1" ] && pass "api-idle: revived despite live PID + fresh heartbeat" \
+  || fail "api-idle: revived despite live PID + fresh heartbeat" "rc: $REVIVE_COUNT"
+[ "$REASON" = "api-stream-idle-timeout" ] && pass "api-idle: lastReviveReason recorded" \
+  || fail "api-idle: lastReviveReason recorded" "got: $REASON"
+[ "$RECORDED_UUID" = "err-uuid-1" ] && pass "api-idle: lastApiErrorUuid recorded" \
+  || fail "api-idle: lastApiErrorUuid recorded" "got: $RECORDED_UUID"
+grep -q "worker-revived" "$STATE_LOG" && pass "api-idle: revive event emitted" \
+  || fail "api-idle: revive event emitted" "log: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test: same API error uuid is NOT re-revived on a second pass"
+scratch_setup
+ALIVE_PID=$$
+make_signal "IDLE-2" "$ALIVE_PID" "implementing" 3
+write_stream_api_error "IDLE-2" "sess-idle-2" "err-uuid-2"
+# Simulate post-first-revive state directly: live PID + fresh heartbeat +
+# lastApiErrorUuid already recorded for this error event. Running revive now
+# must NOT trigger another revive, because the error has already been handled.
+jq --arg uuid "err-uuid-2" \
+   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+   '.lastApiErrorUuid = $uuid
+    | .reviveCount = 1
+    | .lastReviveReason = "api-stream-idle-timeout"
+    | .lastHeartbeat = $ts
+    | .updatedAt = $ts' \
+  "${ORCH_DIR}/workers/IDLE-2.json" > "${ORCH_DIR}/workers/IDLE-2.json.tmp" \
+  && mv "${ORCH_DIR}/workers/IDLE-2.json.tmp" "${ORCH_DIR}/workers/IDLE-2.json"
+run_revive > "${SCRATCH}/out" 2>&1
+SECOND_RC=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/IDLE-2.json")
+[ "$SECOND_RC" = "1" ] && pass "api-idle-dedup: same uuid not re-revived" \
+  || fail "api-idle-dedup: same uuid not re-revived" "rc: $SECOND_RC"
+[ ! -s "$CLAUDE_LOG" ] && pass "api-idle-dedup: claude not invoked" \
+  || fail "api-idle-dedup: claude not invoked" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test: new API error uuid after dedup state DOES trigger revive"
+scratch_setup
+ALIVE_PID=$$
+make_signal "IDLE-3" "$ALIVE_PID" "implementing" 3
+# Signal already saw err-uuid-old, but the stream now shows a NEW error event.
+write_stream_api_error "IDLE-3" "sess-idle-3" "err-uuid-new"
+jq --arg uuid "err-uuid-old" \
+   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+   '.lastApiErrorUuid = $uuid
+    | .reviveCount = 1
+    | .lastHeartbeat = $ts
+    | .updatedAt = $ts' \
+  "${ORCH_DIR}/workers/IDLE-3.json" > "${ORCH_DIR}/workers/IDLE-3.json.tmp" \
+  && mv "${ORCH_DIR}/workers/IDLE-3.json.tmp" "${ORCH_DIR}/workers/IDLE-3.json"
+run_revive > "${SCRATCH}/out" 2>&1
+RC=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/IDLE-3.json")
+RECORDED_UUID=$(jq -r '.lastApiErrorUuid // ""' "${ORCH_DIR}/workers/IDLE-3.json")
+[ "$RC" = "2" ] && pass "api-idle-new-uuid: fresh error re-triggers revive" \
+  || fail "api-idle-new-uuid: fresh error re-triggers revive" "rc: $RC"
+[ "$RECORDED_UUID" = "err-uuid-new" ] && pass "api-idle-new-uuid: lastApiErrorUuid updated" \
+  || fail "api-idle-new-uuid: lastApiErrorUuid updated" "got: $RECORDED_UUID"
+scratch_teardown
+
+echo "test: lastReviveReason = pid-dead for dead-PID revives"
+scratch_setup
+make_signal "REASON-DEAD" "$DEAD_PID" "implementing" 3
+write_stream_init "REASON-DEAD" "sess-reason-dead"
+run_revive > "${SCRATCH}/out" 2>&1
+REASON=$(jq -r '.lastReviveReason // ""' "${ORCH_DIR}/workers/REASON-DEAD.json")
+[ "$REASON" = "pid-dead" ] && pass "reason: pid-dead recorded" \
+  || fail "reason: pid-dead recorded" "got: $REASON"
+scratch_teardown
+
+echo "test: lastReviveReason = heartbeat-stale for stale-heartbeat revives"
+scratch_setup
+ALIVE_PID=$$
+make_signal "REASON-STALE" "$ALIVE_PID" "implementing" 3
+write_stream_init "REASON-STALE" "sess-reason-stale"
+OLD_TS=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+jq --arg ts "$OLD_TS" '.updatedAt = $ts | .lastHeartbeat = $ts' \
+  "${ORCH_DIR}/workers/REASON-STALE.json" > "${ORCH_DIR}/workers/REASON-STALE.json.tmp" \
+  && mv "${ORCH_DIR}/workers/REASON-STALE.json.tmp" "${ORCH_DIR}/workers/REASON-STALE.json"
+run_revive --stale-heartbeat-seconds 900 > "${SCRATCH}/out" 2>&1
+REASON=$(jq -r '.lastReviveReason // ""' "${ORCH_DIR}/workers/REASON-STALE.json")
+[ "$REASON" = "heartbeat-stale" ] && pass "reason: heartbeat-stale recorded" \
+  || fail "reason: heartbeat-stale recorded" "got: $REASON"
+scratch_teardown
+
+echo "test: dry-run with API error detection does not mutate signal"
+scratch_setup
+ALIVE_PID=$$
+make_signal "IDLE-DRY" "$ALIVE_PID" "implementing" 3
+write_stream_api_error "IDLE-DRY" "sess-idle-dry" "err-uuid-dry"
+run_revive --dry-run > "${SCRATCH}/out" 2>&1
+RC=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/IDLE-DRY.json")
+UUID_RECORDED=$(jq -r '.lastApiErrorUuid // ""' "${ORCH_DIR}/workers/IDLE-DRY.json")
+[ "$RC" = "0" ] && pass "api-idle-dry: reviveCount unchanged" \
+  || fail "api-idle-dry: reviveCount unchanged" "rc: $RC"
+[ "$UUID_RECORDED" = "" ] && pass "api-idle-dry: lastApiErrorUuid not written" \
+  || fail "api-idle-dry: lastApiErrorUuid not written" "got: $UUID_RECORDED"
+[ ! -s "$CLAUDE_LOG" ] && pass "api-idle-dry: claude not invoked" \
+  || fail "api-idle-dry: claude not invoked"
+scratch_teardown
+
+echo "test: non-API is_error=true (e.g. tool error) does NOT trigger revive"
+scratch_setup
+ALIVE_PID=$$
+make_signal "TOOL-ERR" "$ALIVE_PID" "implementing" 3
+# Write a result event that is_error=true but has NO api_error_status and no
+# stream-idle-timeout marker — e.g. a test failure that ended the run cleanly.
+stream="${ORCH_DIR}/workers/output/TOOL-ERR-stream.jsonl"
+mkdir -p "$(dirname "$stream")"
+{
+  printf '{"type":"system","subtype":"init","session_id":"sess-tool-err"}\n'
+  printf '{"type":"result","subtype":"error","is_error":true,"api_error_status":null,"result":"Tests failed","session_id":"sess-tool-err","uuid":"tool-err-uuid"}\n'
+} > "$stream"
+run_revive > "${SCRATCH}/out" 2>&1
+RC=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/TOOL-ERR.json")
+[ "$RC" = "0" ] && pass "tool-error: non-API is_error does not revive" \
+  || fail "tool-error: non-API is_error does not revive" "rc: $RC"
+scratch_teardown
+
 # ─── Results ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -120,6 +120,51 @@ resolve_session_id() {
   return 1
 }
 
+# Detect an API stream-idle-timeout failure in the tail of the worker's stream
+# JSONL (CTL-62). Returns the uuid of the most recent matching `result` event,
+# or empty string if none is found.
+#
+# Match criteria (both required):
+#   1. .type == "result" AND .is_error == true
+#   2. Either .api_error_status is a non-null/non-empty value that mentions a
+#      stream idle timeout / partial response, OR the result text contains one
+#      of those markers.
+#
+# This is intentionally conservative — legitimate tool errors / test failures
+# (is_error=true with no api_error_status and no idle-timeout marker) do NOT
+# trigger a revive.
+detect_api_error_in_stream() {
+  local ticket="$1"
+
+  local stream=""
+  for candidate in \
+    "${ORCH_DIR}/workers/output/${ticket}-stream.jsonl" \
+    "${ORCH_DIR}/workers/${ticket}-stream.jsonl"; do
+    if [ -f "$candidate" ]; then
+      stream="$candidate"
+      break
+    fi
+  done
+  [ -z "$stream" ] && return 1
+
+  # Scan the last 50 lines for a matching API-error result event.
+  # The jq filter returns the uuid of the most recent matching event, or nothing.
+  local uuid
+  uuid=$(tail -n 50 "$stream" 2>/dev/null \
+    | jq -r 'select(.type == "result" and .is_error == true)
+             | select(
+                 (.api_error_status // "" | tostring
+                   | test("Stream idle timeout|partial response received"; "i"))
+                 or
+                 ((.result // "" | tostring)
+                   | test("Stream idle timeout|partial response received"; "i"))
+               )
+             | .uuid // empty' 2>/dev/null \
+    | tail -n 1)
+  [ -n "$uuid" ] && { echo "$uuid"; return 0; }
+  return 1
+}
+
 # Emit a fresh-start event via the state script (no-op when state script is
 # missing or when this is a dry run).
 emit_state() {
@@ -206,6 +251,7 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
   WORKER_NAME=$(jq -r '.workerName // empty' "$SIGNAL")
   LAST_HEARTBEAT=$(jq -r '.lastHeartbeat // .updatedAt // empty' "$SIGNAL")
   REVIVE_COUNT=$(jq -r '.reviveCount // 0' "$SIGNAL")
+  LAST_API_ERROR_UUID=$(jq -r '.lastApiErrorUuid // ""' "$SIGNAL")
 
   # Skip workers that have already reached a terminal state.
   if [[ "$TERMINAL_STATUSES" == *" $STATUS "* ]]; then
@@ -215,9 +261,10 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
 
   CHECKED=$((CHECKED+1))
 
-  # Liveness decision: dead PID OR (alive PID with heartbeat older than
-  # stale-heartbeat-seconds — a zombie-sleep situation documented in the
-  # CTL-63 ticket).
+  # Liveness decision (CTL-63 + CTL-62):
+  #   - dead PID (kill -0 fails)
+  #   - alive PID with heartbeat older than stale-heartbeat-seconds (zombie-sleep)
+  #   - stream JSONL shows a fresh API stream idle timeout we haven't handled yet
   local_dead=0
   if [ -z "$PID" ] || ! kill -0 "$PID" 2>/dev/null; then
     local_dead=1
@@ -228,9 +275,21 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
     local_stale=1
   fi
 
-  if [ "$local_dead" -eq 0 ] && [ "$local_stale" -eq 0 ]; then
+  API_ERROR_UUID=$(detect_api_error_in_stream "$TICKET" || echo "")
+  local_api_error=0
+  if [ -n "$API_ERROR_UUID" ] && [ "$API_ERROR_UUID" != "$LAST_API_ERROR_UUID" ]; then
+    local_api_error=1
+  fi
+
+  if [ "$local_dead" -eq 0 ] && [ "$local_stale" -eq 0 ] && [ "$local_api_error" -eq 0 ]; then
     continue
   fi
+
+  # Priority for lastReviveReason (most informative wins):
+  #   api-stream-idle-timeout > pid-dead > heartbeat-stale
+  REVIVE_REASON="heartbeat-stale"
+  [ "$local_dead" -eq 1 ] && REVIVE_REASON="pid-dead"
+  [ "$local_api_error" -eq 1 ] && REVIVE_REASON="api-stream-idle-timeout"
 
   TS=$(now_iso)
 
@@ -304,23 +363,26 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
 
   REVIVED=$((REVIVED+1))
   NEW_REVIVE_COUNT=$((REVIVE_COUNT+1))
-  jq --arg ts "$TS" --arg sid "$SESSION_ID" \
+  jq --arg ts "$TS" --arg sid "$SESSION_ID" --arg reason "$REVIVE_REASON" \
+     --arg err_uuid "$API_ERROR_UUID" \
      --argjson pid "$NEW_PID" --argjson rc "$NEW_REVIVE_COUNT" \
      '.pid = $pid
       | .reviveCount = $rc
       | .lastReviveAt = $ts
+      | .lastReviveReason = $reason
       | .revivedFromSessionId = $sid
       | .lastHeartbeat = $ts
-      | .updatedAt = $ts' \
+      | .updatedAt = $ts
+      | (if $err_uuid == "" then . else .lastApiErrorUuid = $err_uuid end)' \
      "$SIGNAL" > "${SIGNAL}.tmp" && mv "${SIGNAL}.tmp" "$SIGNAL"
 
   emit_state event "$(jq -nc --arg ts "$TS" --arg orch "$ORCH_ID" \
-    --arg w "$TICKET" --arg sid "$SESSION_ID" \
+    --arg w "$TICKET" --arg sid "$SESSION_ID" --arg reason "$REVIVE_REASON" \
     --argjson pid "$NEW_PID" --argjson rc "$NEW_REVIVE_COUNT" \
     '{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-revived",
-      detail:{pid:$pid, sessionId:$sid, reviveCount:$rc}}')"
+      detail:{pid:$pid, sessionId:$sid, reviveCount:$rc, reason:$reason}}')"
 
-  echo "REVIVED: ${TICKET} (sid=${SESSION_ID}, pid=${NEW_PID}, count=${NEW_REVIVE_COUNT})" >&2
+  echo "REVIVED: ${TICKET} (sid=${SESSION_ID}, pid=${NEW_PID}, count=${NEW_REVIVE_COUNT}, reason=${REVIVE_REASON})" >&2
 done
 
 jq -nc \

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -880,11 +880,12 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
 done
 ```
 
-**Auto-revive dead/wedged workers (CTL-63):**
+**Auto-revive dead/wedged workers (CTL-63, CTL-62):**
 
-After the stalled-worker scan, attempt to resume any dead or heartbeat-stale
-worker from its original `session_id`. Resumed sessions preserve tool-call
-history, plan context, and PR state at ~10× lower cost than a fresh redispatch.
+After the stalled-worker scan, attempt to resume any dead, heartbeat-stale,
+or API-stream-idle-timeout'd worker from its original `session_id`. Resumed
+sessions preserve tool-call history, plan context, and PR state at ~10×
+lower cost than a fresh redispatch.
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-revive" \
@@ -892,12 +893,26 @@ history, plan context, and PR state at ~10× lower cost than a fresh redispatch.
   --orch-id "$ORCH_NAME"
 ```
 
-The script checks every non-terminal worker signal, revives from
-`workers/output/<ticket>-stream.jsonl` (with legacy / transcript fallbacks),
-enforces a per-ticket budget (default 2), and transitions workers whose
-budget is exhausted or whose session_id cannot be found to
-`status=stalled` with an attention item so you can decide between manual
-intervention and a fresh redispatch.
+The script checks every non-terminal worker signal and revives when any of:
+
+1. **PID dead** — `kill -0 <pid>` fails (CTL-63)
+2. **Heartbeat stale** — `lastHeartbeat` older than 15 minutes (catches
+   zombie-sleep PIDs whose process is alive but idle) (CTL-63)
+3. **API stream idle timeout** — the tail of
+   `workers/output/<ticket>-stream.jsonl` contains a `type=result`,
+   `is_error=true` event whose `api_error_status` or `result` mentions
+   `Stream idle timeout` or `partial response received`, and whose `uuid`
+   differs from the signal's `lastApiErrorUuid` (CTL-62)
+
+Each successful revive records `lastReviveReason`
+(`pid-dead` / `heartbeat-stale` / `api-stream-idle-timeout`) in the signal
+file and emits a `worker-revived` event with the same reason in its detail.
+The per-ticket revive budget (default 2) applies across all reasons
+combined. Workers whose budget is exhausted or whose session_id cannot be
+found transition to `status=stalled` with an attention item so you can
+decide between manual intervention and a fresh redispatch. Session resume
+uses `workers/output/<ticket>-stream.jsonl` (with legacy / transcript
+fallbacks) to find the original `session_id`.
 
 ### Phase 5: Independent Verification (Anti-Reward-Hacking)
 

--- a/plugins/dev/templates/worker-signal.json
+++ b/plugins/dev/templates/worker-signal.json
@@ -198,6 +198,15 @@
     "followUpTo": {
       "type": ["string", "null"],
       "description": "Parent ticket ID if this worker is a follow-up ticket filed after the parent's PR was already merged (Pattern B recovery). Written by the orchestrator when initializing the follow-up worker's signal. Null for normal workers and for fix-up workers (use `fixupCommit` instead)."
+    },
+    "lastReviveReason": {
+      "type": ["string", "null"],
+      "enum": [null, "pid-dead", "heartbeat-stale", "api-stream-idle-timeout"],
+      "description": "Reason the orchestrator last revived this worker (CTL-62, CTL-63). Written by `orchestrate-revive` on a successful revive. Null if never revived."
+    },
+    "lastApiErrorUuid": {
+      "type": ["string", "null"],
+      "description": "UUID of the last API-error stream event (Stream idle timeout / partial response received) that `orchestrate-revive` has already handled (CTL-62). Used to dedup against the same error re-appearing in the appended stream JSONL after a successful revive. Null if no API-error revive has occurred."
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds proactive detection of `API Error: Stream idle timeout - partial response received` in the worker stream JSONL
- When detected, `orchestrate-revive` reanimates the worker immediately instead of waiting up to 15 minutes for heartbeat staleness (the pre-CTL-62 fallback path from CTL-63)
- New signal fields `lastReviveReason` and `lastApiErrorUuid` (dedup guard) so dashboards can slice failure modes and the revive loop doesn't re-trigger on the same error event

Closes CTL-62 (sibling of CTL-63 / PR #191).

## Design

`detect_api_error_in_stream` tails the last 50 lines of `workers/output/<ticket>-stream.jsonl` (with the legacy `workers/<ticket>-stream.jsonl` fallback) and looks for `type=result`, `is_error=true` events whose `api_error_status` or `result` text matches `Stream idle timeout|partial response received` (case-insensitive).

The detector returns the event's `uuid`. The main loop compares against the signal's `lastApiErrorUuid`; if the uuid differs, the worker is revived. On successful revive we persist the new uuid into the signal, preventing the same error line re-triggering a revive while it sits at the tail of the appended stream JSONL after session-resume.

Matching is intentionally conservative: plain tool failures / test failures (`is_error=true` with no idle-timeout marker and no `api_error_status`) do **not** trigger a revive.

`lastReviveReason` priority: `api-stream-idle-timeout > pid-dead > heartbeat-stale`. It's written to the signal on every successful revive and also carried in the `worker-revived` state event detail.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/orchestrate-revive.test.sh` — 51 pass / 0 fail (37 existing + 14 new)
- [x] `bash plugins/dev/scripts/__tests__/signal-cost-write.test.sh` — 17/0
- [x] All other shell suites in `plugins/dev/scripts/__tests__/` pass
- [x] `jq . plugins/dev/templates/worker-signal.json` valid
- [x] Six pre-existing `catalyst-monitor.test.ts` failures on main are unrelated (local server port binding, confirmed via `git stash` run on main)

## Files

- `plugins/dev/scripts/orchestrate-revive` — detector + new signal fields
- `plugins/dev/scripts/__tests__/orchestrate-revive.test.sh` — 6 new test cases
- `plugins/dev/skills/orchestrate/SKILL.md` — documents the new detection path
- `plugins/dev/templates/worker-signal.json` — schema entries for `lastReviveReason` and `lastApiErrorUuid`