### PR TITLE
feat(dev): drive Linear ticket state transitions on PR merge (CTL-69)

### DIFF
--- a/plugins/dev/scripts/__tests__/linear-transition.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-transition.test.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# Shell tests for linear-transition (CTL-69).
+#
+# The orchestrator and workers both need a single source of truth for
+# transitioning Linear ticket state when a PR merges, a ticket is canceled
+# for zero-scope, etc. This helper reads `.catalyst/config.json` stateMap,
+# is idempotent, and handles edge cases (subsumed/zero-diff → canceled).
+#
+# Run: bash plugins/dev/scripts/__tests__/linear-transition.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+TRANSITION="${REPO_ROOT}/plugins/dev/scripts/linear-transition.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+expect_contains() {
+  local file="$1" needle="$2"
+  grep -qF "$needle" "$file"
+}
+
+# Build a config.json with a given stateMap. Writes under $1 (directory).
+build_config() {
+  local dir="$1"
+  mkdir -p "${dir}/.catalyst"
+  cat > "${dir}/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "test",
+    "linear": {
+      "teamKey": "TST",
+      "stateMap": {
+        "backlog": "Backlog",
+        "todo": "Todo",
+        "research": "In Progress",
+        "planning": "In Progress",
+        "inProgress": "In Progress",
+        "inReview": "In Review",
+        "done": "Done",
+        "canceled": "Canceled",
+        "duplicate": "Duplicate"
+      }
+    }
+  }
+}
+EOF
+}
+
+# Install a fake `linearis` on PATH that records calls and returns a canned
+# issue state. Controlled by env vars:
+#   FAKE_LINEARIS_STATE      - state to report for `issues read`
+#   FAKE_LINEARIS_LOG        - path where commands get appended
+#   FAKE_LINEARIS_UPDATE_EXIT - exit code for `issues update` (default 0)
+install_fake_linearis() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "${bin_dir}/linearis" <<'EOF'
+#!/usr/bin/env bash
+# Record the full invocation for test assertions.
+echo "linearis $*" >> "${FAKE_LINEARIS_LOG:-/dev/null}"
+
+if [ "$1" = "issues" ] && [ "$2" = "read" ]; then
+  STATE="${FAKE_LINEARIS_STATE:-In Review}"
+  cat <<JSON
+{"identifier":"${3:-TST-1}","title":"Fake","state":{"name":"${STATE}"}}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "issues" ] && [ "$2" = "update" ]; then
+  exit "${FAKE_LINEARIS_UPDATE_EXIT:-0}"
+fi
+
+exit 0
+EOF
+  chmod +x "${bin_dir}/linearis"
+}
+
+[ -x "$TRANSITION" ] || { echo "SKIP: $TRANSITION not present yet (expected during TDD)"; }
+
+echo "linear-transition tests"
+
+# ─── Test 1: reads target state from config stateMap.done ──────────────────
+WORK1="${SCRATCH}/t1"
+BIN1="${SCRATCH}/t1/bin"
+LOG1="${SCRATCH}/t1/log"
+build_config "$WORK1"
+install_fake_linearis "$BIN1"
+touch "$LOG1"
+
+run "done transition uses stateMap.done from config" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG1' PATH='$BIN1:$PATH' \
+    '$TRANSITION' --ticket TST-1 --transition done --config '$WORK1/.catalyst/config.json'"
+
+run "recorded update call with correct ticket and status" \
+  expect_contains "$LOG1" "linearis issues update TST-1 --status Done"
+
+# ─── Test 2: canceled transition uses stateMap.canceled ────────────────────
+WORK2="${SCRATCH}/t2"
+BIN2="${SCRATCH}/t2/bin"
+LOG2="${SCRATCH}/t2/log"
+build_config "$WORK2"
+install_fake_linearis "$BIN2"
+touch "$LOG2"
+
+run "canceled transition uses stateMap.canceled from config" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG2' PATH='$BIN2:$PATH' \
+    '$TRANSITION' --ticket TST-2 --transition canceled --config '$WORK2/.catalyst/config.json'"
+
+run "canceled update call recorded with correct status" \
+  expect_contains "$LOG2" "linearis issues update TST-2 --status Canceled"
+
+# ─── Test 3: --state overrides config (explicit state name) ────────────────
+WORK3="${SCRATCH}/t3"
+BIN3="${SCRATCH}/t3/bin"
+LOG3="${SCRATCH}/t3/log"
+build_config "$WORK3"
+install_fake_linearis "$BIN3"
+touch "$LOG3"
+
+run "explicit --state overrides config stateMap" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG3' PATH='$BIN3:$PATH' \
+    '$TRANSITION' --ticket TST-3 --state 'Shipped' --config '$WORK3/.catalyst/config.json'"
+
+run "explicit state passed to linearis" \
+  expect_contains "$LOG3" "linearis issues update TST-3 --status Shipped"
+
+# ─── Test 4: idempotent — no-op when already in target state ───────────────
+WORK4="${SCRATCH}/t4"
+BIN4="${SCRATCH}/t4/bin"
+LOG4="${SCRATCH}/t4/log"
+build_config "$WORK4"
+install_fake_linearis "$BIN4"
+touch "$LOG4"
+
+run "idempotent: skips update when state matches" \
+  bash -c "FAKE_LINEARIS_STATE='Done' FAKE_LINEARIS_LOG='$LOG4' PATH='$BIN4:$PATH' \
+    '$TRANSITION' --ticket TST-4 --transition done --config '$WORK4/.catalyst/config.json'"
+
+run "idempotent: no update call recorded when already Done" \
+  bash -c "! grep -q 'issues update' '$LOG4'"
+
+run "idempotent: read call IS recorded (check was performed)" \
+  expect_contains "$LOG4" "linearis issues read TST-4"
+
+# ─── Test 5: --force bypasses idempotency check ────────────────────────────
+WORK5="${SCRATCH}/t5"
+BIN5="${SCRATCH}/t5/bin"
+LOG5="${SCRATCH}/t5/log"
+build_config "$WORK5"
+install_fake_linearis "$BIN5"
+touch "$LOG5"
+
+run "--force bypasses idempotency check" \
+  bash -c "FAKE_LINEARIS_STATE='Done' FAKE_LINEARIS_LOG='$LOG5' PATH='$BIN5:$PATH' \
+    '$TRANSITION' --ticket TST-5 --transition done --force --config '$WORK5/.catalyst/config.json'"
+
+run "--force: update call IS recorded even when state matches" \
+  expect_contains "$LOG5" "linearis issues update TST-5 --status Done"
+
+# ─── Test 6: defaults — when --config omitted, falls back to sensible name ─
+# Skip this test when no CWD config is available. The script should find
+# .catalyst/config.json in CWD or walk up.
+WORK6="${SCRATCH}/t6"
+BIN6="${SCRATCH}/t6/bin"
+LOG6="${SCRATCH}/t6/log"
+build_config "$WORK6"
+install_fake_linearis "$BIN6"
+touch "$LOG6"
+
+run "auto-discovers config from CWD" \
+  bash -c "cd '$WORK6' && FAKE_LINEARIS_LOG='$LOG6' PATH='$BIN6:$PATH' \
+    '$TRANSITION' --ticket TST-6 --transition done"
+
+run "auto-discover: recorded correct status for ticket" \
+  expect_contains "$LOG6" "linearis issues update TST-6 --status Done"
+
+# ─── Test 7: sensible defaults when state missing from config ──────────────
+WORK7="${SCRATCH}/t7"
+BIN7="${SCRATCH}/t7/bin"
+LOG7="${SCRATCH}/t7/log"
+mkdir -p "${WORK7}/.catalyst"
+cat > "${WORK7}/.catalyst/config.json" <<'EOF'
+{"catalyst":{"linear":{}}}
+EOF
+install_fake_linearis "$BIN7"
+touch "$LOG7"
+
+run "falls back to default 'Done' when stateMap.done missing" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG7' PATH='$BIN7:$PATH' \
+    '$TRANSITION' --ticket TST-7 --transition done --config '$WORK7/.catalyst/config.json'"
+
+run "default Done used when config has no stateMap" \
+  expect_contains "$LOG7" "linearis issues update TST-7 --status Done"
+
+# ─── Test 8: missing linearis CLI → exits 0 with warning (skip silently) ──
+WORK8="${SCRATCH}/t8"
+BIN8="${SCRATCH}/t8/bin-empty"
+build_config "$WORK8"
+mkdir -p "$BIN8"
+
+# Replace PATH with only the empty directory PLUS /usr/bin & /bin so basic
+# utilities (jq, bash, grep) remain available but `linearis` is missing.
+run "missing linearis: exits 0 (graceful skip)" \
+  bash -c "PATH='$BIN8:/usr/bin:/bin' '$TRANSITION' --ticket TST-8 --transition done --config '$WORK8/.catalyst/config.json'"
+
+# ─── Test 9: dry-run reports but doesn't invoke update ─────────────────────
+WORK9="${SCRATCH}/t9"
+BIN9="${SCRATCH}/t9/bin"
+LOG9="${SCRATCH}/t9/log"
+build_config "$WORK9"
+install_fake_linearis "$BIN9"
+touch "$LOG9"
+
+run "--dry-run exits 0" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG9' PATH='$BIN9:$PATH' \
+    '$TRANSITION' --ticket TST-9 --transition done --dry-run --config '$WORK9/.catalyst/config.json'"
+
+run "--dry-run: no update call was made" \
+  bash -c "! grep -q 'issues update' '$LOG9'"
+
+# ─── Test 10: JSON output on success ───────────────────────────────────────
+WORK10="${SCRATCH}/t10"
+BIN10="${SCRATCH}/t10/bin"
+LOG10="${SCRATCH}/t10/log"
+OUT10="${SCRATCH}/t10/stdout"
+build_config "$WORK10"
+install_fake_linearis "$BIN10"
+touch "$LOG10"
+
+FAKE_LINEARIS_LOG="$LOG10" PATH="$BIN10:$PATH" \
+  "$TRANSITION" --ticket TST-10 --transition done --json \
+    --config "$WORK10/.catalyst/config.json" > "$OUT10" 2>&1 || true
+
+run "--json output contains ticket" \
+  bash -c "jq -e '.ticket == \"TST-10\"' '$OUT10'"
+run "--json output contains target state" \
+  bash -c "jq -e '.targetState == \"Done\"' '$OUT10'"
+run "--json output contains action" \
+  bash -c "jq -e '.action == \"transitioned\" or .action == \"skipped\" or .action == \"dry-run\"' '$OUT10'"
+
+# ─── Test 11: missing --ticket fails with clear error ──────────────────────
+run "missing --ticket fails non-zero" \
+  bash -c "! '$TRANSITION' --transition done 2>/dev/null"
+
+# ─── Test 12: both --transition and --state given → --state wins ──────────
+WORK12="${SCRATCH}/t12"
+BIN12="${SCRATCH}/t12/bin"
+LOG12="${SCRATCH}/t12/log"
+build_config "$WORK12"
+install_fake_linearis "$BIN12"
+touch "$LOG12"
+
+run "--state takes precedence over --transition" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG12' PATH='$BIN12:$PATH' \
+    '$TRANSITION' --ticket TST-12 --transition done --state 'Manual Override' --config '$WORK12/.catalyst/config.json'"
+
+run "manual override state was used" \
+  expect_contains "$LOG12" "linearis issues update TST-12 --status Manual Override"
+
+# ─── Test 13: transitions with spaces in state name are quoted correctly ──
+WORK13="${SCRATCH}/t13"
+BIN13="${SCRATCH}/t13/bin"
+LOG13="${SCRATCH}/t13/log"
+build_config "$WORK13"
+install_fake_linearis "$BIN13"
+touch "$LOG13"
+
+run "state names with spaces passed through correctly" \
+  bash -c "FAKE_LINEARIS_STATE='Backlog' FAKE_LINEARIS_LOG='$LOG13' PATH='$BIN13:$PATH' \
+    '$TRANSITION' --ticket TST-13 --transition inReview --config '$WORK13/.catalyst/config.json'"
+
+run "multi-word state name preserved" \
+  expect_contains "$LOG13" "linearis issues update TST-13 --status In Review"
+
+# ─── Test 14: orchestrate SKILL.md references the helper (no drift) ───────
+ORCH_SKILL="${REPO_ROOT}/plugins/dev/skills/orchestrate/SKILL.md"
+run "orchestrate SKILL.md references linear-transition.sh" \
+  bash -c "grep -q 'linear-transition.sh' '$ORCH_SKILL'"
+run "orchestrate SKILL.md documents --state-on-merge flag" \
+  bash -c "grep -q 'state-on-merge' '$ORCH_SKILL'"
+
+# ─── Test 15: oneshot SKILL.md references the helper ──────────────────────
+ONESHOT_SKILL="${REPO_ROOT}/plugins/dev/skills/oneshot/SKILL.md"
+run "oneshot SKILL.md references linear-transition.sh" \
+  bash -c "grep -q 'linear-transition.sh' '$ONESHOT_SKILL'"
+
+# ─── Test 16: merge-pr SKILL.md uses the helper ───────────────────────────
+MERGE_SKILL="${REPO_ROOT}/plugins/dev/skills/merge-pr/SKILL.md"
+run "merge-pr SKILL.md uses linear-transition.sh" \
+  bash -c "grep -q 'linear-transition.sh' '$MERGE_SKILL'"
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/orchestrate-bulk-close.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-bulk-close.test.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-bulk-close (CTL-69).
+#
+# The bulk-close helper retroactively transitions Linear tickets for all
+# workers in an orchestration run. It inspects each worker signal + (when
+# possible) the PR's merge state and diff size to decide between:
+#   - `done`     → PR merged with non-empty diff
+#   - `canceled` → PR merged with zero diff (subsumed), OR no PR/no commits
+#   - skip       → worker still in progress, or explicit exclusion
+#
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-bulk-close.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+BULK_CLOSE="${REPO_ROOT}/plugins/dev/scripts/orchestrate-bulk-close"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+expect_contains() {
+  local file="$1" needle="$2"
+  grep -qF "$needle" "$file"
+}
+
+# ─── Shared fixture builders ───────────────────────────────────────────────
+
+build_config() {
+  local dir="$1"
+  mkdir -p "${dir}/.catalyst"
+  cat > "${dir}/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "linear": {
+      "teamKey": "TST",
+      "stateMap": {
+        "done": "Done",
+        "canceled": "Canceled",
+        "inReview": "In Review"
+      }
+    }
+  }
+}
+EOF
+}
+
+build_orch_dir() {
+  local dir="$1"
+  mkdir -p "${dir}/workers"
+}
+
+write_signal() {
+  local orch_dir="$1" ticket="$2" status="$3" pr_json="$4"
+  cat > "${orch_dir}/workers/${ticket}.json" <<EOF
+{
+  "ticket": "${ticket}",
+  "orchestrator": "test-orch",
+  "workerName": "test-orch-${ticket}",
+  "status": "${status}",
+  "phase": 5,
+  "startedAt": "2026-04-16T18:00:00Z",
+  "updatedAt": "2026-04-16T18:30:00Z",
+  "pr": ${pr_json}
+}
+EOF
+}
+
+# Install a fake gh (PR state + diff) and linearis (record + state reporting).
+install_fakes() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat > "${bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+# Minimal gh fake. Supports:
+#   gh pr view <N> --json state,mergedAt,additions,deletions
+# Controlled by env vars per PR number:
+#   FAKE_PR_<N>_STATE       (MERGED|OPEN|CLOSED)
+#   FAKE_PR_<N>_MERGED_AT   (ISO string or empty)
+#   FAKE_PR_<N>_ADDITIONS   (int, default 0)
+#   FAKE_PR_<N>_DELETIONS   (int, default 0)
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  PR_NUM="$3"
+  varname_state="FAKE_PR_${PR_NUM}_STATE"
+  varname_merged="FAKE_PR_${PR_NUM}_MERGED_AT"
+  varname_add="FAKE_PR_${PR_NUM}_ADDITIONS"
+  varname_del="FAKE_PR_${PR_NUM}_DELETIONS"
+  STATE="${!varname_state:-OPEN}"
+  MERGED="${!varname_merged:-}"
+  ADD="${!varname_add:-0}"
+  DEL="${!varname_del:-0}"
+  printf '{"state":"%s","mergedAt":"%s","additions":%s,"deletions":%s}\n' \
+    "$STATE" "$MERGED" "$ADD" "$DEL"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${bin_dir}/gh"
+
+  cat > "${bin_dir}/linearis" <<'EOF'
+#!/usr/bin/env bash
+echo "linearis $*" >> "${FAKE_LINEARIS_LOG:-/dev/null}"
+if [ "$1" = "issues" ] && [ "$2" = "read" ]; then
+  # Return a deterministic "In Review" state so the idempotency check
+  # always falls through to an update call.
+  echo '{"identifier":"'"${3}"'","title":"Fake","state":{"name":"In Review"}}'
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${bin_dir}/linearis"
+}
+
+[ -x "$BULK_CLOSE" ] || echo "NOTE: $BULK_CLOSE not present yet (TDD mode)"
+
+echo "orchestrate-bulk-close tests"
+
+# ─── Test 1: merged PR with diff → done ────────────────────────────────────
+T1="${SCRATCH}/t1"
+BIN1="${SCRATCH}/t1/bin"
+LOG1="${SCRATCH}/t1/log"
+build_config "$T1"
+build_orch_dir "$T1/orch"
+install_fakes "$BIN1"
+touch "$LOG1"
+
+write_signal "$T1/orch" "TST-1" "done" \
+  '{"number":101,"url":"https://github.com/o/r/pull/101","mergedAt":"2026-04-16T19:00:00Z"}'
+
+run "merged PR with diff: transitions to Done" \
+  bash -c "FAKE_PR_101_STATE=MERGED FAKE_PR_101_MERGED_AT=2026-04-16T19:00:00Z \
+    FAKE_PR_101_ADDITIONS=50 FAKE_PR_101_DELETIONS=10 \
+    FAKE_LINEARIS_LOG='$LOG1' PATH='$BIN1:/usr/bin:/bin' \
+    '$BULK_CLOSE' --orch-dir '$T1/orch' --config '$T1/.catalyst/config.json'"
+
+run "done transition recorded for TST-1" \
+  expect_contains "$LOG1" "linearis issues update TST-1 --status Done"
+
+# ─── Test 2: merged PR with ZERO diff → canceled (subsumed) ────────────────
+T2="${SCRATCH}/t2"
+BIN2="${SCRATCH}/t2/bin"
+LOG2="${SCRATCH}/t2/log"
+build_config "$T2"
+build_orch_dir "$T2/orch"
+install_fakes "$BIN2"
+touch "$LOG2"
+
+write_signal "$T2/orch" "TST-2" "done" \
+  '{"number":102,"url":"https://github.com/o/r/pull/102","mergedAt":"2026-04-16T19:00:00Z"}'
+
+run "zero-diff PR: transitions to Canceled (subsumed)" \
+  bash -c "FAKE_PR_102_STATE=MERGED FAKE_PR_102_MERGED_AT=2026-04-16T19:00:00Z \
+    FAKE_PR_102_ADDITIONS=0 FAKE_PR_102_DELETIONS=0 \
+    FAKE_LINEARIS_LOG='$LOG2' PATH='$BIN2:/usr/bin:/bin' \
+    '$BULK_CLOSE' --orch-dir '$T2/orch' --config '$T2/.catalyst/config.json'"
+
+run "canceled transition recorded for zero-diff TST-2" \
+  expect_contains "$LOG2" "linearis issues update TST-2 --status Canceled"
+
+# ─── Test 3: no PR, worker done → canceled (zero-scope) ────────────────────
+T3="${SCRATCH}/t3"
+BIN3="${SCRATCH}/t3/bin"
+LOG3="${SCRATCH}/t3/log"
+build_config "$T3"
+build_orch_dir "$T3/orch"
+install_fakes "$BIN3"
+touch "$LOG3"
+
+write_signal "$T3/orch" "TST-3" "done" "null"
+
+run "no-PR worker at done: transitions to Canceled (zero-scope)" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG3' PATH='$BIN3:/usr/bin:/bin' \
+    '$BULK_CLOSE' --orch-dir '$T3/orch' --config '$T3/.catalyst/config.json'"
+
+run "canceled transition recorded for no-PR TST-3" \
+  expect_contains "$LOG3" "linearis issues update TST-3 --status Canceled"
+
+# ─── Test 4: worker still in progress → skip (no transition) ───────────────
+T4="${SCRATCH}/t4"
+BIN4="${SCRATCH}/t4/bin"
+LOG4="${SCRATCH}/t4/log"
+build_config "$T4"
+build_orch_dir "$T4/orch"
+install_fakes "$BIN4"
+touch "$LOG4"
+
+write_signal "$T4/orch" "TST-4" "implementing" "null"
+
+run "in-progress worker: no transition called" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG4' PATH='$BIN4:/usr/bin:/bin' \
+    '$BULK_CLOSE' --orch-dir '$T4/orch' --config '$T4/.catalyst/config.json'"
+
+run "in-progress worker: no update call was made" \
+  bash -c "! grep -q 'issues update' '$LOG4'"
+
+# ─── Test 5: dry-run exits 0 and invokes no updates ────────────────────────
+T5="${SCRATCH}/t5"
+BIN5="${SCRATCH}/t5/bin"
+LOG5="${SCRATCH}/t5/log"
+build_config "$T5"
+build_orch_dir "$T5/orch"
+install_fakes "$BIN5"
+touch "$LOG5"
+
+write_signal "$T5/orch" "TST-5" "done" \
+  '{"number":105,"url":"https://github.com/o/r/pull/105","mergedAt":"2026-04-16T19:00:00Z"}'
+
+run "--dry-run exits 0" \
+  bash -c "FAKE_PR_105_STATE=MERGED FAKE_PR_105_ADDITIONS=100 \
+    FAKE_LINEARIS_LOG='$LOG5' PATH='$BIN5:/usr/bin:/bin' \
+    '$BULK_CLOSE' --orch-dir '$T5/orch' --config '$T5/.catalyst/config.json' --dry-run"
+
+run "--dry-run makes no update calls" \
+  bash -c "! grep -q 'issues update' '$LOG5'"
+
+# ─── Test 6: handles multiple workers in one run ───────────────────────────
+T6="${SCRATCH}/t6"
+BIN6="${SCRATCH}/t6/bin"
+LOG6="${SCRATCH}/t6/log"
+build_config "$T6"
+build_orch_dir "$T6/orch"
+install_fakes "$BIN6"
+touch "$LOG6"
+
+write_signal "$T6/orch" "TST-6a" "done" \
+  '{"number":106,"url":"https://github.com/o/r/pull/106","mergedAt":"2026-04-16T19:00:00Z"}'
+write_signal "$T6/orch" "TST-6b" "done" \
+  '{"number":107,"url":"https://github.com/o/r/pull/107","mergedAt":"2026-04-16T19:00:00Z"}'
+write_signal "$T6/orch" "TST-6c" "implementing" "null"
+
+run "processes multiple workers in one run" \
+  bash -c "FAKE_PR_106_STATE=MERGED FAKE_PR_106_ADDITIONS=42 \
+    FAKE_PR_107_STATE=MERGED FAKE_PR_107_ADDITIONS=0 FAKE_PR_107_DELETIONS=0 \
+    FAKE_LINEARIS_LOG='$LOG6' PATH='$BIN6:/usr/bin:/bin' \
+    '$BULK_CLOSE' --orch-dir '$T6/orch' --config '$T6/.catalyst/config.json'"
+
+run "6a (merged with diff) got Done" \
+  expect_contains "$LOG6" "linearis issues update TST-6a --status Done"
+run "6b (zero-diff) got Canceled" \
+  expect_contains "$LOG6" "linearis issues update TST-6b --status Canceled"
+run "6c (in-progress) got no transition" \
+  bash -c "! grep -q 'update TST-6c' '$LOG6'"
+
+# ─── Test 7: ignores non-worker JSON files in workers/ ─────────────────────
+T7="${SCRATCH}/t7"
+BIN7="${SCRATCH}/t7/bin"
+LOG7="${SCRATCH}/t7/log"
+build_config "$T7"
+build_orch_dir "$T7/orch"
+install_fakes "$BIN7"
+touch "$LOG7"
+
+# Valid worker signal
+write_signal "$T7/orch" "TST-7" "done" \
+  '{"number":108,"url":"https://github.com/o/r/pull/108"}'
+# Non-worker file (e.g., dispatch-fixup helpers)
+echo '{"not_a_worker":true}' > "$T7/orch/workers/fixup-meta.json"
+
+run "skips JSON files without .ticket field" \
+  bash -c "FAKE_PR_108_STATE=MERGED FAKE_PR_108_ADDITIONS=10 \
+    FAKE_LINEARIS_LOG='$LOG7' PATH='$BIN7:/usr/bin:/bin' \
+    '$BULK_CLOSE' --orch-dir '$T7/orch' --config '$T7/.catalyst/config.json'"
+
+# ─── Test 8: --state-on-merge override ─────────────────────────────────────
+T8="${SCRATCH}/t8"
+BIN8="${SCRATCH}/t8/bin"
+LOG8="${SCRATCH}/t8/log"
+build_config "$T8"
+build_orch_dir "$T8/orch"
+install_fakes "$BIN8"
+touch "$LOG8"
+
+write_signal "$T8/orch" "TST-8" "done" \
+  '{"number":118,"url":"https://github.com/o/r/pull/118"}'
+
+run "--state-on-merge overrides default 'done' transition" \
+  bash -c "FAKE_PR_118_STATE=MERGED FAKE_PR_118_ADDITIONS=5 \
+    FAKE_LINEARIS_LOG='$LOG8' PATH='$BIN8:/usr/bin:/bin' \
+    '$BULK_CLOSE' --orch-dir '$T8/orch' --config '$T8/.catalyst/config.json' \
+    --state-on-merge 'Shipped to Prod'"
+
+run "override state used in linearis call" \
+  expect_contains "$LOG8" "linearis issues update TST-8 --status Shipped to Prod"
+
+# ─── Test 9: missing --orch-dir exits non-zero with error ──────────────────
+run "missing --orch-dir fails" \
+  bash -c "! '$BULK_CLOSE' 2>/dev/null"
+
+# ─── Test 10: JSON summary output on stdout ────────────────────────────────
+T10="${SCRATCH}/t10"
+BIN10="${SCRATCH}/t10/bin"
+LOG10="${SCRATCH}/t10/log"
+OUT10="${SCRATCH}/t10/stdout"
+build_config "$T10"
+build_orch_dir "$T10/orch"
+install_fakes "$BIN10"
+touch "$LOG10"
+
+write_signal "$T10/orch" "TST-10" "done" \
+  '{"number":110,"url":"https://github.com/o/r/pull/110"}'
+
+FAKE_PR_110_STATE=MERGED FAKE_PR_110_ADDITIONS=25 \
+  FAKE_LINEARIS_LOG="$LOG10" PATH="$BIN10:/usr/bin:/bin" \
+  "$BULK_CLOSE" --orch-dir "$T10/orch" --config "$T10/.catalyst/config.json" \
+  --json > "$OUT10" 2>/dev/null || true
+
+run "--json summary parses as JSON" \
+  bash -c "jq -e '.' '$OUT10' >/dev/null"
+run "--json summary has transitioned count" \
+  bash -c "jq -e '.transitioned' '$OUT10' >/dev/null"
+run "--json summary has canceled count" \
+  bash -c "jq -e '.canceled' '$OUT10' >/dev/null"
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/linear-transition.sh
+++ b/plugins/dev/scripts/linear-transition.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# linear-transition - Single source of truth for transitioning Linear ticket
+# state. Reads stateMap from `.catalyst/config.json`, is idempotent, and emits
+# JSON when requested. Used by the orchestrator's PR-merge safety net, by
+# workers at end of `/oneshot`, and by the bulk-close helper. CTL-69.
+#
+# Usage:
+#   linear-transition.sh --ticket <ID> --transition <name> [--state <literal>]
+#                        [--config <path>] [--force] [--dry-run] [--json]
+#
+#   --ticket <ID>        Linear ticket identifier (required)
+#   --transition <name>  State map key to look up (one of: backlog, todo,
+#                        research, planning, inProgress, inReview, done,
+#                        canceled, duplicate). Required unless --state given.
+#   --state <literal>    Literal state name (takes precedence over --transition)
+#   --config <path>      Path to .catalyst/config.json. Default: auto-discover
+#                        by walking up from CWD.
+#   --force              Skip idempotency check (always call update even if
+#                        ticket is already in target state)
+#   --dry-run            Print what would happen without calling linearis
+#   --json               Emit a JSON result to stdout (default: human-readable)
+#
+# Exit codes:
+#   0  success (transitioned, idempotent skip, dry-run, or linearis missing)
+#   1  usage error (missing required args)
+#   2  linearis update call failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ─── Default state fallbacks (when config doesn't specify them) ────────────
+# These match the defaults documented in oneshot/orchestrate skills.
+default_state_for() {
+  case "$1" in
+    backlog)     echo "Backlog" ;;
+    todo)        echo "Todo" ;;
+    research)    echo "In Progress" ;;
+    planning)    echo "In Progress" ;;
+    inProgress)  echo "In Progress" ;;
+    inReview)    echo "In Review" ;;
+    done)        echo "Done" ;;
+    canceled)    echo "Canceled" ;;
+    duplicate)   echo "Duplicate" ;;
+    *)           echo "" ;;
+  esac
+}
+
+TICKET=""
+TRANSITION=""
+STATE=""
+CONFIG=""
+FORCE=0
+DRY_RUN=0
+JSON_OUT=0
+
+usage() {
+  sed -n '2,24p' "$0" >&2
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ticket)      TICKET="$2"; shift 2 ;;
+    --transition)  TRANSITION="$2"; shift 2 ;;
+    --state)       STATE="$2"; shift 2 ;;
+    --config)      CONFIG="$2"; shift 2 ;;
+    --force)       FORCE=1; shift ;;
+    --dry-run)     DRY_RUN=1; shift ;;
+    --json)        JSON_OUT=1; shift ;;
+    -h|--help)     usage 0 ;;
+    *)             echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -z "$TICKET" ] && { echo "ERROR: --ticket required" >&2; exit 1; }
+if [ -z "$TRANSITION" ] && [ -z "$STATE" ]; then
+  echo "ERROR: --transition or --state required" >&2; exit 1
+fi
+
+# ─── Resolve config path ───────────────────────────────────────────────────
+resolve_config() {
+  if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]; then
+    echo "$CONFIG"; return 0
+  fi
+  local dir
+  dir="$(pwd)"
+  while [ "$dir" != "/" ]; do
+    if [ -f "${dir}/.catalyst/config.json" ]; then
+      echo "${dir}/.catalyst/config.json"; return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo ""
+}
+
+CONFIG_PATH="$(resolve_config)"
+
+# ─── Resolve target state ──────────────────────────────────────────────────
+# Precedence: explicit --state > config stateMap[transition] > default.
+TARGET_STATE=""
+if [ -n "$STATE" ]; then
+  TARGET_STATE="$STATE"
+elif [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ] && command -v jq >/dev/null 2>&1; then
+  TARGET_STATE=$(jq -r --arg k "$TRANSITION" \
+    '.catalyst.linear.stateMap[$k] // empty' "$CONFIG_PATH" 2>/dev/null)
+fi
+if [ -z "$TARGET_STATE" ]; then
+  TARGET_STATE="$(default_state_for "$TRANSITION")"
+fi
+if [ -z "$TARGET_STATE" ]; then
+  echo "ERROR: could not resolve target state (transition='${TRANSITION}')" >&2
+  exit 1
+fi
+
+# ─── Emit a JSON or human-readable result ──────────────────────────────────
+emit() {
+  local action="$1" current="$2" message="$3"
+  if [ "$JSON_OUT" -eq 1 ]; then
+    jq -nc \
+      --arg ticket "$TICKET" \
+      --arg targetState "$TARGET_STATE" \
+      --arg currentState "$current" \
+      --arg transition "$TRANSITION" \
+      --arg action "$action" \
+      --arg message "$message" \
+      '{ticket:$ticket, targetState:$targetState, currentState:$currentState,
+        transition:$transition, action:$action, message:$message}'
+  else
+    printf '%s — %s (target=%s)' "$TICKET" "$action" "$TARGET_STATE"
+    [ -n "$current" ] && printf ' (current=%s)' "$current"
+    [ -n "$message" ] && printf ': %s' "$message"
+    printf '\n'
+  fi
+}
+
+# ─── Check linearis availability ───────────────────────────────────────────
+if ! command -v linearis >/dev/null 2>&1; then
+  emit "skipped-no-linearis" "" "linearis CLI not installed; cannot transition ticket"
+  exit 0
+fi
+
+# ─── Idempotency check (read current state first) ──────────────────────────
+CURRENT_STATE=""
+if [ "$FORCE" -ne 1 ] && command -v jq >/dev/null 2>&1; then
+  READ_JSON=$(linearis issues read "$TICKET" 2>/dev/null || echo "")
+  if [ -n "$READ_JSON" ]; then
+    CURRENT_STATE=$(echo "$READ_JSON" | jq -r '.state.name // empty' 2>/dev/null || echo "")
+  fi
+  if [ -n "$CURRENT_STATE" ] && [ "$CURRENT_STATE" = "$TARGET_STATE" ]; then
+    emit "skipped" "$CURRENT_STATE" "already in target state"
+    exit 0
+  fi
+fi
+
+# ─── Dry-run short-circuit ─────────────────────────────────────────────────
+if [ "$DRY_RUN" -eq 1 ]; then
+  emit "dry-run" "$CURRENT_STATE" "would transition to ${TARGET_STATE}"
+  exit 0
+fi
+
+# ─── Perform the transition ────────────────────────────────────────────────
+# Note: `linearis issues update --status "<name>"` expects the state name
+# exactly as it appears in Linear. Multi-word names like "In Review" are
+# passed as a single argument — the shell quotes handle spaces.
+if linearis issues update "$TICKET" --status "$TARGET_STATE" >/dev/null 2>&1; then
+  emit "transitioned" "$CURRENT_STATE" ""
+  exit 0
+else
+  emit "update-failed" "$CURRENT_STATE" "linearis update call returned non-zero"
+  exit 2
+fi

--- a/plugins/dev/scripts/orchestrate-bulk-close
+++ b/plugins/dev/scripts/orchestrate-bulk-close
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# orchestrate-bulk-close - Retroactively transition Linear ticket state for
+# every worker in an orchestration run. Inspects each signal file and the PR
+# (if any) to pick the right state map entry:
+#
+#   merged PR with non-empty diff     → stateMap.done
+#   merged PR with zero diff          → stateMap.canceled  (subsumed)
+#   no PR, worker status=done         → stateMap.canceled  (zero-scope)
+#   merged PR, signal status=done     → stateMap.done      (fallback when gh fails)
+#   worker still in progress          → skip
+#
+# Useful when (a) a run predates this feature or (b) the orchestrator's poll
+# loop missed some workers. CTL-69.
+#
+# Usage:
+#   orchestrate-bulk-close --orch-dir <path> [--config <path>]
+#                          [--state-on-merge <name>] [--state-on-canceled <name>]
+#                          [--dry-run] [--json]
+#
+#   --orch-dir <path>          Orchestrator directory (contains workers/*.json).
+#                              Required.
+#   --config <path>            Path to .catalyst/config.json.
+#                              Default: auto-discover from CWD.
+#   --state-on-merge <name>    Literal Linear state name to use for merged-with-diff
+#                              PRs (overrides stateMap.done).
+#   --state-on-canceled <name> Literal Linear state name for subsumed/zero-scope
+#                              tickets (overrides stateMap.canceled).
+#   --dry-run                  Print what would happen without updating Linear.
+#   --json                     Emit a JSON summary to stdout.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRANSITION="${SCRIPT_DIR}/linear-transition.sh"
+
+ORCH_DIR=""
+CONFIG=""
+STATE_ON_MERGE=""
+STATE_ON_CANCELED=""
+DRY_RUN=0
+JSON_OUT=0
+
+usage() {
+  sed -n '2,29p' "$0" >&2
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir)           ORCH_DIR="$2"; shift 2 ;;
+    --config)             CONFIG="$2"; shift 2 ;;
+    --state-on-merge)     STATE_ON_MERGE="$2"; shift 2 ;;
+    --state-on-canceled)  STATE_ON_CANCELED="$2"; shift 2 ;;
+    --dry-run)            DRY_RUN=1; shift ;;
+    --json)               JSON_OUT=1; shift ;;
+    -h|--help)            usage 0 ;;
+    *)                    echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 1; }
+[ ! -d "$ORCH_DIR/workers" ] && { echo "ERROR: no workers dir under $ORCH_DIR" >&2; exit 1; }
+
+[ -x "$TRANSITION" ] || { echo "ERROR: linear-transition.sh missing at $TRANSITION" >&2; exit 1; }
+
+# ─── Call the transition helper with consistent flags ─────────────────────
+# Prints one log line per ticket for human readability and updates the
+# per-action counters via a name-reference.
+transition_ticket() {
+  local ticket="$1" action="$2"   # action: merge|canceled
+  local args=(--ticket "$ticket")
+
+  case "$action" in
+    merge)
+      if [ -n "$STATE_ON_MERGE" ]; then
+        args+=(--state "$STATE_ON_MERGE")
+      else
+        args+=(--transition done)
+      fi
+      ;;
+    canceled)
+      if [ -n "$STATE_ON_CANCELED" ]; then
+        args+=(--state "$STATE_ON_CANCELED")
+      else
+        args+=(--transition canceled)
+      fi
+      ;;
+  esac
+  [ -n "$CONFIG" ] && args+=(--config "$CONFIG")
+  [ "$DRY_RUN" -eq 1 ] && args+=(--dry-run)
+
+  if "$TRANSITION" "${args[@]}" >&2; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# ─── Fetch PR state+diff size from gh; tolerant of missing gh/net errors ──
+fetch_pr_info() {
+  local pr_number="$1"
+  if ! command -v gh >/dev/null 2>&1; then
+    echo '{"state":"UNKNOWN","additions":0,"deletions":0}'; return
+  fi
+  local out
+  out=$(gh pr view "$pr_number" --json state,mergedAt,additions,deletions 2>/dev/null || echo "")
+  if [ -z "$out" ]; then
+    echo '{"state":"UNKNOWN","additions":0,"deletions":0}'; return
+  fi
+  echo "$out"
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────
+TOTAL=0
+TRANSITIONED=0
+CANCELED=0
+SKIPPED=0
+FAILED=0
+
+shopt -s nullglob
+for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
+  TICKET=$(jq -r '.ticket // empty' "$SIGNAL" 2>/dev/null || echo "")
+  [ -z "$TICKET" ] && continue
+
+  TOTAL=$((TOTAL+1))
+  STATUS=$(jq -r '.status // empty' "$SIGNAL")
+  PR_NUMBER=$(jq -r '.pr.number // empty' "$SIGNAL")
+
+  # If the worker is still in flight (not in a terminal state AND no PR)
+  # just skip — bulk-close is for reconciling completed/abandoned runs.
+  case "$STATUS" in
+    done|failed|stalled|merged) ;;  # proceed below
+    *)
+      if [ -z "$PR_NUMBER" ]; then
+        SKIPPED=$((SKIPPED+1))
+        echo "SKIP: ${TICKET} status=${STATUS} (in-flight, no PR)" >&2
+        continue
+      fi
+      ;;
+  esac
+
+  # Decide action based on PR state + diff.
+  ACTION="skip"
+  if [ -n "$PR_NUMBER" ]; then
+    PR_INFO=$(fetch_pr_info "$PR_NUMBER")
+    PR_STATE=$(echo "$PR_INFO" | jq -r '.state // "UNKNOWN"')
+    ADDS=$(echo "$PR_INFO" | jq -r '.additions // 0')
+    DELS=$(echo "$PR_INFO" | jq -r '.deletions // 0')
+    DIFF_LINES=$((ADDS + DELS))
+
+    case "$PR_STATE" in
+      MERGED)
+        if [ "$DIFF_LINES" -eq 0 ]; then
+          ACTION="canceled"
+        else
+          ACTION="merge"
+        fi
+        ;;
+      UNKNOWN)
+        # Fall back to signal — if the signal says done, treat as merge.
+        if [ "$STATUS" = "done" ] || [ "$STATUS" = "merged" ]; then
+          ACTION="merge"
+        else
+          ACTION="skip"
+        fi
+        ;;
+      OPEN|CLOSED|*)
+        # Open/closed PRs stay as-is. Let the human decide.
+        ACTION="skip"
+        ;;
+    esac
+  else
+    # No PR. If the worker reached "done" without a PR, it's a subsumed or
+    # zero-scope ticket — cancel it.
+    if [ "$STATUS" = "done" ]; then
+      ACTION="canceled"
+    else
+      ACTION="skip"
+    fi
+  fi
+
+  case "$ACTION" in
+    merge)
+      if transition_ticket "$TICKET" "merge"; then
+        TRANSITIONED=$((TRANSITIONED+1))
+      else
+        FAILED=$((FAILED+1))
+      fi
+      ;;
+    canceled)
+      if transition_ticket "$TICKET" "canceled"; then
+        CANCELED=$((CANCELED+1))
+      else
+        FAILED=$((FAILED+1))
+      fi
+      ;;
+    skip)
+      SKIPPED=$((SKIPPED+1))
+      echo "SKIP: ${TICKET} status=${STATUS} pr=${PR_NUMBER:-<none>}" >&2
+      ;;
+  esac
+done
+
+if [ "$JSON_OUT" -eq 1 ]; then
+  jq -nc \
+    --argjson total "$TOTAL" \
+    --argjson transitioned "$TRANSITIONED" \
+    --argjson canceled "$CANCELED" \
+    --argjson skipped "$SKIPPED" \
+    --argjson failed "$FAILED" \
+    --arg dry_run "$([ "$DRY_RUN" -eq 1 ] && echo true || echo false)" \
+    '{total:$total, transitioned:$transitioned, canceled:$canceled,
+      skipped:$skipped, failed:$failed, dryRun:($dry_run == "true")}'
+else
+  echo ""
+  echo "bulk-close summary: total=${TOTAL} transitioned=${TRANSITIONED} canceled=${CANCELED} skipped=${SKIPPED} failed=${FAILED}$([ "$DRY_RUN" -eq 1 ] && echo ' (dry-run)')"
+fi
+
+[ "$FAILED" -eq 0 ]

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -294,12 +294,14 @@ merge_sha=$(git rev-parse HEAD)
 If ticket found and not using `--no-update`:
 
 ```bash
-# Verify linearis is available
-# If Linearis CLI is available:
-# 1. Update ticket status to stateMap.done from config
-# 2. Add a comment with PR number, merge commit, and base branch
-# Use `linearis issues usage` and `linearis comments usage` for exact syntax.
-# Skip silently if CLI not available.
+# Use the shared transition helper (CTL-69). It reads stateMap from
+# `.catalyst/config.json`, is idempotent, and silently skips when the
+# linearis CLI is not installed.
+"${CLAUDE_PLUGIN_ROOT}/scripts/linear-transition.sh" \
+  --ticket "$ticket_id" --transition done --config .catalyst/config.json
+
+# Then add a comment with PR number, merge commit, and base branch.
+# Use `linearis comments usage` for exact syntax. Skip silently if CLI missing.
 ```
 
 ### 11. Delete local branch and update base

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -551,6 +551,17 @@ cannot be satisfied).
 Linear ticket to `stateMap.done`, save post-merge tasks. The orchestrator's Phase 4 loop is now a
 safety net that can re-dispatch a fix-up worker if the primary worker gets stuck.
 
+The worker transitions its Linear ticket via the shared helper — idempotent and tolerant of a
+missing `linearis` CLI (CTL-69):
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/linear-transition.sh" \
+  --ticket "$TICKET_ID" --transition done --config .catalyst/config.json
+```
+
+The orchestrator's safety-net poll loop calls the same helper when it independently confirms a
+PR has merged, so both paths stay in sync.
+
 **If `--no-merge` was set**, skip Steps 2–3 entirely and report PR status instead:
 
 ```

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -68,6 +68,7 @@ fi
 | `--interactive`          | Include PM intake phase before orchestration                           |
 | `--prd <path>`           | Run PRD review panel + ticket creation before orchestration            |
 | `--dry-run`              | Show wave plan without executing                                       |
+| `--state-on-merge <name>` | Linear state to set on PR merge. Default: `stateMap.done` (typically "Done") |
 
 ## Configuration
 
@@ -786,10 +787,20 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
         --arg w "${TICKET}" --argjson pr "$PR_NUMBER" --arg mt "$PR_MERGED_AT" \
         '{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-pr-merged", detail:{pr:$pr, mergedAt:$mt}}')"
 
-      # Transition Linear ticket (safety net — workers now do this themselves;
-      # this is idempotent in case the worker exited before transitioning)
-      LINEAR_DONE=$(jq -r '.catalyst.linear.stateMap.done // "Done"' "$CONFIG_FILE")
-      linearis issues update "${TICKET}" --status "${LINEAR_DONE}" 2>/dev/null || true
+      # Transition Linear ticket via the shared helper (CTL-69). The helper
+      # reads stateMap from `.catalyst/config.json`, is idempotent, and
+      # respects --state-on-merge when the operator wants a non-default
+      # state (e.g., "Shipped"). Workers now drive this themselves on merge;
+      # this call is a safety net for cases where the worker exited early.
+      STATE_ON_MERGE_FLAG=""
+      if [ -n "${STATE_ON_MERGE:-}" ]; then
+        STATE_ON_MERGE_FLAG="--state ${STATE_ON_MERGE}"
+      fi
+      "${CLAUDE_PLUGIN_ROOT}/scripts/linear-transition.sh" \
+        --ticket "${TICKET}" \
+        --transition done \
+        --config "$CONFIG_FILE" \
+        ${STATE_ON_MERGE_FLAG} >/dev/null 2>&1 || true
       ;;
 
     CLOSED)
@@ -1237,6 +1248,50 @@ The orchestrator manages Linear state transitions as a safety net:
 
 The orchestrator also adds comments to tickets for visibility using the Linearis CLI (run
 `linearis comments usage` for syntax).
+
+### Single source of truth: `linear-transition.sh`
+
+All Linear state transitions (by the orchestrator's safety net AND by workers at end of
+`/oneshot`) go through `plugins/dev/scripts/linear-transition.sh`. It reads `stateMap` from
+`.catalyst/config.json`, is idempotent (no-op when the ticket is already in the target state),
+and exits 0 when the `linearis` CLI is not installed (graceful skip).
+
+```bash
+# Transition via transition-key (reads stateMap.done from config):
+"${CLAUDE_PLUGIN_ROOT}/scripts/linear-transition.sh" \
+  --ticket PROJ-123 --transition done --config .catalyst/config.json
+
+# Override with an explicit state name (e.g., --state-on-merge "Shipped"):
+"${CLAUDE_PLUGIN_ROOT}/scripts/linear-transition.sh" \
+  --ticket PROJ-123 --state "Shipped" --config .catalyst/config.json
+```
+
+The `--state-on-merge` flag on orchestrate is passed through to this helper whenever it is set.
+
+### Retroactive bulk-close: `orchestrate-bulk-close`
+
+For runs that predated the state-transition wiring (or where the orchestrator's poll loop exited
+before reconciling tickets), run the bulk-close helper. It walks `workers/*.json`, inspects each
+PR via `gh`, and transitions tickets via `linear-transition.sh`:
+
+- Merged PR with non-empty diff → `stateMap.done`
+- Merged PR with zero diff (subsumed) → `stateMap.canceled`
+- No PR, signal `status=done` (zero-scope) → `stateMap.canceled`
+- Worker still in progress → skip (bulk-close is for reconciliation only)
+
+```bash
+# Preview what the helper would do (no changes):
+plugins/dev/scripts/orchestrate-bulk-close --orch-dir ~/catalyst/runs/<orch-name> --dry-run
+
+# Actually transition tickets:
+plugins/dev/scripts/orchestrate-bulk-close --orch-dir ~/catalyst/runs/<orch-name>
+
+# JSON summary for scripting:
+plugins/dev/scripts/orchestrate-bulk-close --orch-dir ~/catalyst/runs/<orch-name> --json
+```
+
+Flags mirror orchestrate: `--state-on-merge <name>` and `--state-on-canceled <name>` override the
+respective defaults.
 
 ## Named Orchestrators & Remote Control
 


### PR DESCRIPTION
## Summary

Closes CTL-69. During the agent-obs run, workers merged 18 PRs but no Linear ticket states were updated — all stayed in "In Review". This PR centralizes Linear state transitions behind a single, testable helper and wires it through the orchestrator's safety net, `/oneshot`, and `/merge-pr`.

- **`plugins/dev/scripts/linear-transition.sh`** — Single source of truth. Reads `stateMap` from `.catalyst/config.json`, is idempotent (no-op when already in target state), gracefully exits 0 when `linearis` is missing. Supports `--transition <key>` (stateMap lookup), `--state <literal>` (override), `--force` (bypass idempotency), `--dry-run`, `--json`.
- **`plugins/dev/scripts/orchestrate-bulk-close`** — Retroactive reconciliation. Walks `workers/*.json` and inspects each PR via `gh` to decide:
  - Merged PR with non-empty diff → `stateMap.done`
  - Merged PR with zero diff (subsumed) → `stateMap.canceled`
  - No PR, signal `status=done` (zero-scope) → `stateMap.canceled`
  - In-flight worker → skip
- **`--state-on-merge <name>` flag** on `orchestrate` skill is plumbed through to the helper so operators can set a non-default state (e.g., "Shipped").
- Orchestrate/oneshot/merge-pr SKILL.md docs updated to use the helper script instead of inline `linearis issues update` calls.

## Test plan

- [x] 30 shell tests in `plugins/dev/scripts/__tests__/linear-transition.test.sh` cover: stateMap lookup, explicit-state override, idempotent skip, `--force`, auto-discover config, default-state fallback, missing-CLI graceful exit, `--dry-run`, JSON output, SKILL.md drift-guards (prevents doc/helper divergence)
- [x] 21 shell tests in `plugins/dev/scripts/__tests__/orchestrate-bulk-close.test.sh` cover: merged-with-diff → done, zero-diff → canceled, no-PR → canceled, in-flight skip, multi-worker runs, non-worker JSON skipped, `--state-on-merge` override, JSON summary
- [x] `bun test` in `orch-monitor` — 484 pass / 6 pre-existing catalyst-monitor.sh flakes (unrelated)
- [x] `bun run typecheck` passes
- [x] `bun run lint` clean (one pre-existing security warning in `preview-status.ts`)
- [x] All existing shell tests still pass (catalyst-state, orchestrate-fixup, orchestrate-followup, orchestrate-revive, signal-cost-write, etc.)