### PR TITLE
feat(dev): auto-dispatch fixup workers on BLOCKED PRs (CTL-64)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-auto-fixup.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-auto-fixup.test.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-auto-fixup (CTL-64).
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-auto-fixup.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+AUTO_FIXUP="${REPO_ROOT}/plugins/dev/scripts/orchestrate-auto-fixup"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/orchestrate/SKILL.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+scratch_setup() {
+  SCRATCH="$(mktemp -d)"
+  ORCH_DIR="${SCRATCH}/orch"
+  mkdir -p "${ORCH_DIR}/workers" "${SCRATCH}/bin"
+
+  # Stub state script — logs every invocation so tests can assert.
+  cat > "${SCRATCH}/bin/catalyst-state.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$STATE_LOG"
+EOF
+  chmod +x "${SCRATCH}/bin/catalyst-state.sh"
+  export STATE_LOG="${SCRATCH}/state.log"
+  : > "$STATE_LOG"
+  export CATALYST_STATE_SCRIPT="${SCRATCH}/bin/catalyst-state.sh"
+
+  # Stub orchestrate-fixup — records every dispatch invocation.
+  cat > "${SCRATCH}/bin/orchestrate-fixup" <<'EOF'
+#!/usr/bin/env bash
+echo "FIXUP_CALLED $*" >> "$FIXUP_LOG"
+EOF
+  chmod +x "${SCRATCH}/bin/orchestrate-fixup"
+  export FIXUP_LOG="${SCRATCH}/fixup.log"
+  : > "$FIXUP_LOG"
+  export CATALYST_AUTO_FIXUP_DISPATCH_BIN="${SCRATCH}/bin/orchestrate-fixup"
+
+  # Stub gh — reads from a per-test fixture table.
+  cat > "${SCRATCH}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+# Route by command shape — the two calls we make are:
+#   gh -R <repo> pr view <n> --json state,mergeStateStatus,reviewDecision,statusCheckRollup
+#   gh api graphql -f query=... -F owner=... -F repo=... -F pr=...
+args="$*"
+if [[ "$args" == *"pr view"* ]]; then
+  cat "$GH_PR_VIEW_FIXTURE"
+elif [[ "$args" == *"api graphql"* ]]; then
+  cat "$GH_THREADS_FIXTURE"
+else
+  echo "stub gh: unexpected invocation: $args" >&2
+  exit 99
+fi
+EOF
+  chmod +x "${SCRATCH}/bin/gh"
+  export CATALYST_AUTO_FIXUP_GH_BIN="${SCRATCH}/bin/gh"
+
+  # Default fixtures — overridden per-test via set_fixtures.
+  export GH_PR_VIEW_FIXTURE="${SCRATCH}/pr-view.json"
+  export GH_THREADS_FIXTURE="${SCRATCH}/threads.json"
+  echo '{"state":"OPEN","mergeStateStatus":"CLEAN","reviewDecision":null,"statusCheckRollup":[]}' > "$GH_PR_VIEW_FIXTURE"
+  echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' > "$GH_THREADS_FIXTURE"
+}
+
+scratch_teardown() {
+  rm -rf "$SCRATCH"
+  unset STATE_LOG FIXUP_LOG CATALYST_STATE_SCRIPT CATALYST_AUTO_FIXUP_DISPATCH_BIN CATALYST_AUTO_FIXUP_GH_BIN GH_PR_VIEW_FIXTURE GH_THREADS_FIXTURE SCRATCH ORCH_DIR
+}
+
+# Build a PR-view fixture with given merge state, review decision, and check conclusions.
+set_pr_view() {
+  local state="$1" merge_state="$2" review_dec="$3" checks_json="$4"
+  if [ "$review_dec" = "null" ]; then
+    jq -n --arg s "$state" --arg m "$merge_state" --argjson checks "$checks_json" \
+      '{state:$s, mergeStateStatus:$m, reviewDecision:null, statusCheckRollup:$checks}' \
+      > "$GH_PR_VIEW_FIXTURE"
+  else
+    jq -n --arg s "$state" --arg m "$merge_state" --arg r "$review_dec" --argjson checks "$checks_json" \
+      '{state:$s, mergeStateStatus:$m, reviewDecision:$r, statusCheckRollup:$checks}' \
+      > "$GH_PR_VIEW_FIXTURE"
+  fi
+}
+
+# Build a threads fixture with given unresolved thread nodes. Input is a JSON array
+# of {path, line, author, body} objects.
+set_threads() {
+  local threads_json="$1"
+  jq -n --argjson t "$threads_json" \
+    '{data:{repository:{pullRequest:{reviewThreads:{nodes:[$t[] | {isResolved:false, isOutdated:false, path:.path, line:.line, comments:{nodes:[{author:{login:.author}, body:.body}]}}]}}}}}' \
+    > "$GH_THREADS_FIXTURE"
+}
+
+# Seed a worker signal at ORCH_DIR/workers/<ticket>.json
+make_signal() {
+  # Args: TICKET STATUS PR_NUMBER PR_URL [BLOCKED_SINCE] [FIXUP_ATTEMPTS]
+  local ticket="$1" status="$2" pr_num="$3" pr_url="$4"
+  local blocked_since="${5:-}" attempts="${6:-0}"
+  local now="2026-04-16T12:00:00Z"
+
+  if [ -z "$pr_num" ]; then
+    jq -n --arg t "$ticket" --arg s "$status" --arg ts "$now" \
+      '{ticket:$t, status:$s, phase:5, startedAt:$ts, updatedAt:$ts, pr:null}' \
+      > "${ORCH_DIR}/workers/${ticket}.json"
+    return
+  fi
+
+  local base
+  base=$(jq -n --arg t "$ticket" --arg s "$status" --arg ts "$now" \
+    --argjson n "$pr_num" --arg u "$pr_url" \
+    '{ticket:$t, status:$s, phase:5, startedAt:$ts, updatedAt:$ts,
+      pr:{number:$n, url:$u, ciStatus:"pending"}}')
+
+  if [ -n "$blocked_since" ]; then
+    base=$(echo "$base" | jq --arg bs "$blocked_since" '.blockedSince = $bs')
+  fi
+  if [ -n "$attempts" ] && [ "$attempts" != "0" ]; then
+    base=$(echo "$base" | jq --argjson a "$attempts" '.fixupAttempts = $a')
+  fi
+  echo "$base" > "${ORCH_DIR}/workers/${ticket}.json"
+}
+
+# ---
+
+echo "orchestrate-auto-fixup tests"
+echo
+
+echo "test: missing --orch-dir fails"
+set +e
+"$AUTO_FIXUP" --orch-id demo 2>/dev/null; RC=$?
+set -e
+[ "$RC" != "0" ] && pass "errors without --orch-dir" || fail "errors without --orch-dir" "rc=$RC"
+
+echo "test: missing --orch-id fails"
+set +e
+"$AUTO_FIXUP" --orch-dir /tmp 2>/dev/null; RC=$?
+set -e
+[ "$RC" != "0" ] && pass "errors without --orch-id" || fail "errors without --orch-id" "rc=$RC"
+
+echo "test: empty workers dir is a clean no-op"
+scratch_setup
+OUT=$("$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo 2>/dev/null)
+CHECKED=$(echo "$OUT" | jq -r '.checked' 2>/dev/null || echo "?")
+[ "$CHECKED" = "0" ] && pass "summary.checked=0 when no signals" || fail "summary.checked=0 when no signals" "got: $CHECKED; out: $OUT"
+[ ! -s "$FIXUP_LOG" ] && pass "no fixup dispatch when empty" || fail "no fixup dispatch when empty" "log: $(cat "$FIXUP_LOG")"
+scratch_teardown
+
+echo "test: worker without PR is skipped"
+scratch_setup
+make_signal "T-1" "implementing" "" ""
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo > "${SCRATCH}/out" 2>&1
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch for PR-less worker" || fail "no dispatch for PR-less worker"
+BLOCKED_SINCE=$(jq -r '.blockedSince // empty' "${ORCH_DIR}/workers/T-1.json")
+[ -z "$BLOCKED_SINCE" ] && pass "no blockedSince written for PR-less worker" || fail "no blockedSince written for PR-less worker" "got: $BLOCKED_SINCE"
+scratch_teardown
+
+echo "test: terminal worker is skipped"
+scratch_setup
+make_signal "T-2" "done" "42" "https://github.com/o/r/pull/42"
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo > "${SCRATCH}/out" 2>&1
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch for terminal worker" || fail "no dispatch for terminal worker"
+scratch_teardown
+
+echo "test: MERGED PR is skipped (state != OPEN)"
+scratch_setup
+make_signal "T-3" "pr-created" "42" "https://github.com/o/r/pull/42"
+set_pr_view "MERGED" "UNKNOWN" "null" "[]"
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo > "${SCRATCH}/out" 2>&1
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch when PR merged" || fail "no dispatch when PR merged"
+scratch_teardown
+
+echo "test: non-BLOCKED OPEN PR clears blockedSince and skips"
+scratch_setup
+make_signal "T-4" "pr-created" "42" "https://github.com/o/r/pull/42" "2026-04-16T11:00:00Z"
+set_pr_view "OPEN" "CLEAN" "null" "[]"
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo > "${SCRATCH}/out" 2>&1
+BLOCKED_SINCE=$(jq -r '.blockedSince // empty' "${ORCH_DIR}/workers/T-4.json")
+[ -z "$BLOCKED_SINCE" ] && pass "blockedSince cleared when PR is no longer blocked" || fail "blockedSince cleared when PR is no longer blocked" "got: $BLOCKED_SINCE"
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch on CLEAN" || fail "no dispatch on CLEAN"
+scratch_teardown
+
+echo "test: first observation of BLOCKED sets blockedSince, does not dispatch"
+scratch_setup
+make_signal "T-5" "pr-created" "42" "https://github.com/o/r/pull/42"
+set_pr_view "OPEN" "BLOCKED" "CHANGES_REQUESTED" "[]"
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo > "${SCRATCH}/out" 2>&1
+BLOCKED_SINCE=$(jq -r '.blockedSince // empty' "${ORCH_DIR}/workers/T-5.json")
+[ -n "$BLOCKED_SINCE" ] && pass "blockedSince recorded on first BLOCKED observation" || fail "blockedSince recorded on first BLOCKED observation"
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch on first observation" || fail "no dispatch on first observation"
+scratch_teardown
+
+echo "test: BLOCKED within stable-minutes window does not dispatch"
+scratch_setup
+# blockedSince 5 minutes ago, stable-minutes=10 → not yet actionable.
+recent=$(date -u -v-5M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "5 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-6" "pr-created" "42" "https://github.com/o/r/pull/42" "$recent"
+set_pr_view "OPEN" "BLOCKED" "CHANGES_REQUESTED" "[]"
+set_threads '[{"path":"a.ts","line":1,"author":"codex-bot","body":"fix x"}]'
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 > "${SCRATCH}/out" 2>&1
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch within stable window" || fail "no dispatch within stable window"
+scratch_teardown
+
+echo "test: stable BLOCKED with failing required check → checks-failing attention, no dispatch"
+scratch_setup
+old=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-7" "pr-created" "42" "https://github.com/o/r/pull/42" "$old"
+set_pr_view "OPEN" "BLOCKED" "APPROVED" '[{"conclusion":"FAILURE","status":"COMPLETED","name":"ci"}]'
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 > "${SCRATCH}/out" 2>&1
+grep -q "attention demo checks-failing T-7" "$STATE_LOG" \
+  && pass "raised checks-failing attention" || fail "raised checks-failing attention" "log: $(cat "$STATE_LOG")"
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch when checks are failing" || fail "no dispatch when checks are failing"
+scratch_teardown
+
+echo "test: stable BLOCKED + CI running (IN_PROGRESS) defers (no dispatch, no attention)"
+scratch_setup
+old=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-8" "pr-created" "42" "https://github.com/o/r/pull/42" "$old"
+set_pr_view "OPEN" "BLOCKED" "CHANGES_REQUESTED" '[{"conclusion":null,"status":"IN_PROGRESS","name":"ci"}]'
+set_threads '[{"path":"a.ts","line":1,"author":"codex-bot","body":"fix x"}]'
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 > "${SCRATCH}/out" 2>&1
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch while CI still running" || fail "no dispatch while CI still running"
+[ ! -s "$STATE_LOG" ] && pass "no attention raised while CI still running" || fail "no attention raised while CI still running" "log: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test: stable BLOCKED + CI passing + unresolved threads → dispatches fixup, bumps attempts"
+scratch_setup
+old=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-9" "pr-created" "42" "https://github.com/o/r/pull/42" "$old"
+set_pr_view "OPEN" "BLOCKED" "CHANGES_REQUESTED" '[{"conclusion":"SUCCESS","status":"COMPLETED","name":"ci"}]'
+set_threads '[{"path":"src/foo.ts","line":42,"author":"codex-bot","body":"Missing null check on session"},{"path":"src/bar.ts","line":7,"author":"codex-bot","body":"Timing attack in compare"}]'
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 > "${SCRATCH}/out" 2>&1
+grep -q "FIXUP_CALLED" "$FIXUP_LOG" && pass "dispatched orchestrate-fixup" || fail "dispatched orchestrate-fixup" "log: $(cat "$FIXUP_LOG")"
+grep -q -- "--dispatch" "$FIXUP_LOG" && pass "called with --dispatch flag" || fail "called with --dispatch flag" "log: $(cat "$FIXUP_LOG")"
+grep -q -- "--pr 42" "$FIXUP_LOG" && pass "called with correct --pr" || fail "called with correct --pr" "log: $(cat "$FIXUP_LOG")"
+grep -q "T-9" "$FIXUP_LOG" && pass "called with ticket id" || fail "called with ticket id" "log: $(cat "$FIXUP_LOG")"
+ATTEMPTS=$(jq -r '.fixupAttempts' "${ORCH_DIR}/workers/T-9.json")
+[ "$ATTEMPTS" = "1" ] && pass "fixupAttempts bumped to 1" || fail "fixupAttempts bumped to 1" "got: $ATTEMPTS"
+LAST=$(jq -r '.lastFixupDispatchedAt // empty' "${ORCH_DIR}/workers/T-9.json")
+[ -n "$LAST" ] && pass "lastFixupDispatchedAt recorded" || fail "lastFixupDispatchedAt recorded"
+scratch_teardown
+
+echo "test: stable BLOCKED + CI passing + REVIEW_REQUIRED + no threads → review-required attention, no dispatch"
+scratch_setup
+old=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-10" "pr-created" "42" "https://github.com/o/r/pull/42" "$old"
+set_pr_view "OPEN" "BLOCKED" "REVIEW_REQUIRED" '[{"conclusion":"SUCCESS","status":"COMPLETED","name":"ci"}]'
+set_threads '[]'
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 > "${SCRATCH}/out" 2>&1
+grep -q "attention demo review-required T-10" "$STATE_LOG" \
+  && pass "raised review-required attention" || fail "raised review-required attention" "log: $(cat "$STATE_LOG")"
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch when review-required only" || fail "no dispatch when review-required only" "log: $(cat "$FIXUP_LOG")"
+scratch_teardown
+
+echo "test: fixupAttempts at budget → escalates, does not dispatch"
+scratch_setup
+old=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-11" "pr-created" "42" "https://github.com/o/r/pull/42" "$old" "2"
+set_pr_view "OPEN" "BLOCKED" "CHANGES_REQUESTED" '[{"conclusion":"SUCCESS","status":"COMPLETED","name":"ci"}]'
+set_threads '[{"path":"a.ts","line":1,"author":"codex-bot","body":"still broken"}]'
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 --max-fixups 2 > "${SCRATCH}/out" 2>&1
+grep -q "attention demo fixup-budget-exhausted T-11" "$STATE_LOG" \
+  && pass "raised fixup-budget-exhausted attention" || fail "raised fixup-budget-exhausted attention" "log: $(cat "$STATE_LOG")"
+[ ! -s "$FIXUP_LOG" ] && pass "no dispatch after budget exhausted" || fail "no dispatch after budget exhausted" "log: $(cat "$FIXUP_LOG")"
+scratch_teardown
+
+echo "test: --dry-run does not mutate signals or dispatch"
+scratch_setup
+old=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-12" "pr-created" "42" "https://github.com/o/r/pull/42" "$old"
+set_pr_view "OPEN" "BLOCKED" "CHANGES_REQUESTED" '[{"conclusion":"SUCCESS","status":"COMPLETED","name":"ci"}]'
+set_threads '[{"path":"a.ts","line":1,"author":"codex-bot","body":"fix x"}]'
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 --dry-run > "${SCRATCH}/out" 2>&1
+ATTEMPTS=$(jq -r '.fixupAttempts // 0' "${ORCH_DIR}/workers/T-12.json")
+[ "$ATTEMPTS" = "0" ] && pass "dry-run does not bump fixupAttempts" || fail "dry-run does not bump fixupAttempts" "got: $ATTEMPTS"
+[ ! -s "$FIXUP_LOG" ] && pass "dry-run does not invoke orchestrate-fixup" || fail "dry-run does not invoke orchestrate-fixup"
+[ ! -s "$STATE_LOG" ] && pass "dry-run does not call state script" || fail "dry-run does not call state script"
+scratch_teardown
+
+echo "test: non-worker JSON files are ignored gracefully"
+scratch_setup
+old=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-13" "pr-created" "42" "https://github.com/o/r/pull/42" "$old"
+echo '{"notASignal": true}' > "${ORCH_DIR}/workers/junk.json"
+set_pr_view "OPEN" "BLOCKED" "CHANGES_REQUESTED" '[{"conclusion":"SUCCESS","status":"COMPLETED","name":"ci"}]'
+set_threads '[{"path":"a.ts","line":1,"author":"codex-bot","body":"fix x"}]'
+set +e
+"$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 > "${SCRATCH}/out" 2>&1
+RC=$?
+set -e
+[ "$RC" = "0" ] && pass "non-signal JSON does not crash" || fail "non-signal JSON does not crash" "rc=$RC; out: $(cat "${SCRATCH}/out")"
+grep -q "FIXUP_CALLED" "$FIXUP_LOG" && pass "dispatches for real worker despite junk file" || fail "dispatches for real worker despite junk file"
+scratch_teardown
+
+echo "test: summary JSON on stdout"
+scratch_setup
+old=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "30 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+make_signal "T-14" "pr-created" "42" "https://github.com/o/r/pull/42" "$old"
+set_pr_view "OPEN" "BLOCKED" "CHANGES_REQUESTED" '[{"conclusion":"SUCCESS","status":"COMPLETED","name":"ci"}]'
+set_threads '[{"path":"a.ts","line":1,"author":"codex-bot","body":"fix x"}]'
+OUT=$("$AUTO_FIXUP" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 10 2>/dev/null)
+CHECKED=$(echo "$OUT" | jq -r '.checked' 2>/dev/null || echo "?")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched' 2>/dev/null || echo "?")
+[ "$CHECKED" = "1" ] && pass "summary.checked=1" || fail "summary.checked=1" "got: $CHECKED; out: $OUT"
+[ "$DISPATCHED" = "1" ] && pass "summary.dispatched=1" || fail "summary.dispatched=1" "got: $DISPATCHED; out: $OUT"
+scratch_teardown
+
+echo
+echo "test: SKILL.md documents the new script (prevents doc drift)"
+grep -q "orchestrate-auto-fixup" "$SKILL_MD" \
+  && pass "SKILL.md references orchestrate-auto-fixup" || fail "SKILL.md references orchestrate-auto-fixup"
+grep -q "blockedSince" "$SKILL_MD" \
+  && pass "SKILL.md documents blockedSince field" || fail "SKILL.md documents blockedSince field"
+grep -q "fixupAttempts" "$SKILL_MD" \
+  && pass "SKILL.md documents fixupAttempts field" || fail "SKILL.md documents fixupAttempts field"
+
+echo
+echo "Results: $PASSES passed, $FAILURES failed"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/orchestrate-auto-fixup
+++ b/plugins/dev/scripts/orchestrate-auto-fixup
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# orchestrate-auto-fixup - Auto-dispatch fix-up workers for PRs stuck in BLOCKED (CTL-64).
+#
+# Runs as part of the orchestrator's Phase 4 monitoring cycle. For each non-terminal
+# worker signal whose PR has been sitting in state=OPEN, mergeStateStatus=BLOCKED for
+# at least --stable-minutes, classify the reason and take action:
+#
+#   - checks-failing     → raise `checks-failing` attention (the worker's own poll
+#                          loop or a revive handles CI failures; escalating here
+#                          surfaces long-running ones)
+#   - threads-unresolved → auto-dispatch `orchestrate-fixup` with an issues list
+#                          composed from the unresolved review thread comments
+#                          (up to --max-fixups iterations per worker)
+#   - review-required    → raise `review-required` attention (only a human can
+#                          approve)
+#   - blocked-unknown    → raise `blocked-unknown` attention (state does not
+#                          match any classifier — surface for human triage)
+#
+# Usage:
+#   orchestrate-auto-fixup --orch-dir <path> --orch-id <id>
+#                          [--stable-minutes <n>]    # default 10
+#                          [--max-fixups <n>]        # default 2
+#                          [--dry-run]
+#
+# Outputs a single-line JSON summary on stdout:
+#   {"checked":N,"dispatched":M,"escalated":K,"skipped":S}
+#
+# Environment overrides:
+#   CATALYST_STATE_SCRIPT              path to catalyst-state.sh (default: sibling)
+#   CATALYST_AUTO_FIXUP_GH_BIN         gh binary (default: `gh` on PATH)
+#   CATALYST_AUTO_FIXUP_DISPATCH_BIN   orchestrate-fixup path (default: sibling)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
+GH_BIN="${CATALYST_AUTO_FIXUP_GH_BIN:-gh}"
+DISPATCH_BIN="${CATALYST_AUTO_FIXUP_DISPATCH_BIN:-${SCRIPT_DIR}/orchestrate-fixup}"
+
+ORCH_DIR=""
+ORCH_ID=""
+STABLE_MINUTES=10
+MAX_FIXUPS=2
+DRY_RUN=0
+
+usage() {
+  sed -n '2,33p' "$0"
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir)       ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)        ORCH_ID="$2"; shift 2 ;;
+    --stable-minutes) STABLE_MINUTES="$2"; shift 2 ;;
+    --max-fixups)     MAX_FIXUPS="$2"; shift 2 ;;
+    --dry-run)        DRY_RUN=1; shift ;;
+    -h|--help)        usage 0 ;;
+    *)                echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
+[ -z "$ORCH_ID" ]  && { echo "ERROR: --orch-id required"  >&2; exit 2; }
+[ ! -d "$ORCH_DIR/workers" ] && { echo "ERROR: no workers dir at $ORCH_DIR/workers" >&2; exit 2; }
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# Seconds since the given ISO timestamp, or 999999 if missing/unparseable.
+seconds_since() {
+  local ts="$1"
+  [ -z "$ts" ] && { echo 999999; return; }
+  local then
+  then=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null \
+        || date -u -d "$ts" +%s 2>/dev/null \
+        || echo "")
+  [ -z "$then" ] && { echo 999999; return; }
+  local now; now=$(date -u +%s)
+  echo $(( now - then ))
+}
+
+# Emit a state-script call (attention, event, etc.). Silent on missing script
+# or dry-run.
+emit_state() {
+  [ "$DRY_RUN" -eq 1 ] && return 0
+  [ -x "$STATE_SCRIPT" ] || return 0
+  "$STATE_SCRIPT" "$@" >/dev/null 2>&1 || true
+}
+
+# Parse owner/repo from a github PR URL.
+parse_repo() {
+  local url="$1"
+  echo "$url" | sed -nE 's|https?://github\.com/([^/]+)/([^/]+)/pull/.*|\1/\2|p'
+}
+
+# Write a jq-style expression into the given signal file atomically.
+# Usage: update_signal <signal_file> <jq_expr> [jq_args...]
+update_signal() {
+  local signal="$1"; shift
+  local expr="$1"; shift
+  jq "$@" "$expr" "$signal" > "${signal}.tmp" && mv "${signal}.tmp" "$signal"
+}
+
+# Classify the current PR-view JSON into one of:
+#   ci-running | checks-failing | threads-unresolved | review-required | blocked-unknown
+# stdout is the classifier. Reads $PR_VIEW (file path) and $UNRESOLVED_THREAD_COUNT.
+classify_blocked() {
+  local pr_view_json="$1" unresolved_count="$2"
+
+  # Check for any in-progress required checks first — we should wait.
+  local running_count
+  running_count=$(jq -r '[.statusCheckRollup[]? | select(.status=="IN_PROGRESS" or .status=="QUEUED" or .status=="PENDING" or .status=="WAITING")] | length' "$pr_view_json" 2>/dev/null || echo 0)
+  if [ "${running_count:-0}" -gt 0 ]; then
+    echo "ci-running"
+    return
+  fi
+
+  # Any failing required check?
+  local failing_count
+  failing_count=$(jq -r '[.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="CANCELLED" or .conclusion=="ACTION_REQUIRED" or .conclusion=="STARTUP_FAILURE")] | length' "$pr_view_json" 2>/dev/null || echo 0)
+  if [ "${failing_count:-0}" -gt 0 ]; then
+    echo "checks-failing"
+    return
+  fi
+
+  if [ "${unresolved_count:-0}" -gt 0 ]; then
+    echo "threads-unresolved"
+    return
+  fi
+
+  local review_dec
+  review_dec=$(jq -r '.reviewDecision // empty' "$pr_view_json" 2>/dev/null || echo "")
+  if [ "$review_dec" = "REVIEW_REQUIRED" ]; then
+    echo "review-required"
+    return
+  fi
+
+  echo "blocked-unknown"
+}
+
+# Compose the --issues string for orchestrate-fixup from unresolved thread JSON.
+# Reads thread file, emits one line per thread in `path:line: [author]: body`
+# format. Bodies truncated at 200 chars; newlines collapsed to spaces.
+compose_issues() {
+  local threads_file="$1"
+  jq -r '
+    .data.repository.pullRequest.reviewThreads.nodes[]
+    | select(.isResolved == false and .isOutdated == false)
+    | . as $t
+    | ($t.comments.nodes[0] // {author:{login:"reviewer"}, body:"(no body)"}) as $c
+    | ($c.body // "")
+    | gsub("\r?\n"; " ")
+    | .[0:200] as $body
+    | ($t.path // "?") + ":" + (($t.line // 0) | tostring)
+      + ": [" + ($c.author.login // "reviewer") + "]: " + $body
+  ' "$threads_file" 2>/dev/null
+}
+
+# Count unresolved, non-outdated review threads.
+count_unresolved_threads() {
+  local threads_file="$1"
+  jq -r '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false and .isOutdated == false)] | length' "$threads_file" 2>/dev/null || echo 0
+}
+
+fetch_pr_view() {
+  local repo="$1" pr_num="$2" out="$3"
+  "$GH_BIN" -R "$repo" pr view "$pr_num" \
+    --json state,mergeStateStatus,reviewDecision,statusCheckRollup \
+    > "$out" 2>/dev/null
+}
+
+fetch_threads() {
+  local repo="$1" pr_num="$2" out="$3"
+  local owner name
+  owner="${repo%%/*}"; name="${repo##*/}"
+  # The GraphQL query asks for enough thread metadata to compose issue lines.
+  local query='query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviewThreads(first: 100) { nodes { isResolved isOutdated path line comments(first: 3) { nodes { author { login } body } } } } } } }'
+  "$GH_BIN" api graphql \
+    -f query="$query" \
+    -F owner="$owner" \
+    -F repo="$name" \
+    -F pr="$pr_num" \
+    > "$out" 2>/dev/null
+}
+
+# ─── Main loop ────────────────────────────────────────────────────────────────
+
+CHECKED=0
+DISPATCHED=0
+ESCALATED=0
+SKIPPED=0
+
+TERMINAL=" done failed stalled "
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+shopt -s nullglob
+for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
+  TICKET=$(jq -r '.ticket // empty' "$SIGNAL" 2>/dev/null || echo "")
+  [ -z "$TICKET" ] && continue
+
+  STATUS=$(jq -r '.status // empty' "$SIGNAL" 2>/dev/null || echo "")
+  if [[ "$TERMINAL" == *" $STATUS "* ]]; then
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  PR_NUMBER=$(jq -r '.pr.number // empty' "$SIGNAL" 2>/dev/null || echo "")
+  PR_URL=$(jq -r '.pr.url // empty' "$SIGNAL" 2>/dev/null || echo "")
+  if [ -z "$PR_NUMBER" ] || [ -z "$PR_URL" ]; then
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  REPO=$(parse_repo "$PR_URL")
+  if [ -z "$REPO" ]; then
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  CHECKED=$((CHECKED+1))
+
+  PR_VIEW="${TMP_DIR}/pr-${TICKET}.json"
+  fetch_pr_view "$REPO" "$PR_NUMBER" "$PR_VIEW" || { SKIPPED=$((SKIPPED+1)); continue; }
+
+  if [ ! -s "$PR_VIEW" ]; then
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  STATE=$(jq -r '.state // "UNKNOWN"' "$PR_VIEW")
+  MERGE_STATE=$(jq -r '.mergeStateStatus // "UNKNOWN"' "$PR_VIEW")
+
+  # Not OPEN — the orchestrator's PR-view safety net handles MERGED/CLOSED,
+  # and we should clear any stale blockedSince so future BLOCKED episodes
+  # start their clock fresh.
+  if [ "$STATE" != "OPEN" ]; then
+    if [ "$DRY_RUN" -ne 1 ]; then
+      update_signal "$SIGNAL" '.blockedSince = null'
+    fi
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  # Not BLOCKED — clear the clock, move on.
+  if [ "$MERGE_STATE" != "BLOCKED" ]; then
+    if [ "$DRY_RUN" -ne 1 ]; then
+      update_signal "$SIGNAL" '.blockedSince = null'
+    fi
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  # BLOCKED: record first-observation timestamp if missing, then wait one cycle.
+  BLOCKED_SINCE=$(jq -r '.blockedSince // empty' "$SIGNAL")
+  if [ -z "$BLOCKED_SINCE" ]; then
+    if [ "$DRY_RUN" -ne 1 ]; then
+      TS=$(now_iso)
+      update_signal "$SIGNAL" '.blockedSince = $ts' --arg ts "$TS"
+    fi
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  # Still within the stability window — defer.
+  AGE=$(seconds_since "$BLOCKED_SINCE")
+  STABLE_SECONDS=$(( STABLE_MINUTES * 60 ))
+  if [ "$AGE" -lt "$STABLE_SECONDS" ]; then
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  # Classify. Threads fetch only matters if checks are clean.
+  THREADS_FILE="${TMP_DIR}/threads-${TICKET}.json"
+  UNRESOLVED=0
+  if fetch_threads "$REPO" "$PR_NUMBER" "$THREADS_FILE"; then
+    UNRESOLVED=$(count_unresolved_threads "$THREADS_FILE")
+  fi
+
+  CLASSIFICATION=$(classify_blocked "$PR_VIEW" "$UNRESOLVED")
+
+  case "$CLASSIFICATION" in
+    ci-running)
+      # Transient — don't act; next tick will re-check.
+      SKIPPED=$((SKIPPED+1))
+      continue
+      ;;
+
+    checks-failing)
+      MSG="PR #${PR_NUMBER} is BLOCKED with failing required checks (${AGE}s stable)"
+      if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[dry-run] ${TICKET}: would escalate (checks-failing)" >&2
+      else
+        emit_state attention "$ORCH_ID" "checks-failing" "$TICKET" "$MSG"
+      fi
+      ESCALATED=$((ESCALATED+1))
+      ;;
+
+    review-required)
+      MSG="PR #${PR_NUMBER} is BLOCKED awaiting human review (${AGE}s stable)"
+      if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[dry-run] ${TICKET}: would escalate (review-required)" >&2
+      else
+        emit_state attention "$ORCH_ID" "review-required" "$TICKET" "$MSG"
+      fi
+      ESCALATED=$((ESCALATED+1))
+      ;;
+
+    threads-unresolved)
+      FIXUP_ATTEMPTS=$(jq -r '.fixupAttempts // 0' "$SIGNAL")
+      if [ "$FIXUP_ATTEMPTS" -ge "$MAX_FIXUPS" ]; then
+        MSG="Auto-fixup budget exhausted (${FIXUP_ATTEMPTS}/${MAX_FIXUPS}) on PR #${PR_NUMBER}"
+        if [ "$DRY_RUN" -eq 1 ]; then
+          echo "[dry-run] ${TICKET}: would escalate (budget exhausted)" >&2
+        else
+          emit_state attention "$ORCH_ID" "fixup-budget-exhausted" "$TICKET" "$MSG"
+        fi
+        ESCALATED=$((ESCALATED+1))
+        continue
+      fi
+
+      ISSUES=$(compose_issues "$THREADS_FILE")
+      if [ -z "$ISSUES" ]; then
+        ISSUES="Resolve all unresolved review threads on PR #${PR_NUMBER}"
+      fi
+
+      if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[dry-run] ${TICKET}: would dispatch fixup with $UNRESOLVED threads" >&2
+        DISPATCHED=$((DISPATCHED+1))
+        continue
+      fi
+
+      if ! "$DISPATCH_BIN" "$TICKET" \
+            --issues "$ISSUES" \
+            --pr "$PR_NUMBER" \
+            --orch "$ORCH_ID" \
+            --orch-dir "$ORCH_DIR" \
+            --dispatch >/dev/null 2>&1; then
+        MSG="Failed to dispatch auto-fixup for PR #${PR_NUMBER}"
+        emit_state attention "$ORCH_ID" "fixup-dispatch-failed" "$TICKET" "$MSG"
+        ESCALATED=$((ESCALATED+1))
+        continue
+      fi
+
+      TS=$(now_iso)
+      NEW_ATTEMPTS=$((FIXUP_ATTEMPTS+1))
+      update_signal "$SIGNAL" \
+        '.fixupAttempts = $a | .lastFixupDispatchedAt = $ts | .updatedAt = $ts' \
+        --argjson a "$NEW_ATTEMPTS" --arg ts "$TS"
+
+      emit_state event "$(jq -nc \
+        --arg ts "$TS" --arg orch "$ORCH_ID" --arg w "$TICKET" \
+        --argjson pr "$PR_NUMBER" --argjson a "$NEW_ATTEMPTS" \
+        '{ts:$ts, orchestrator:$orch, worker:$w,
+          event:"worker-auto-fixup-dispatched",
+          detail:{pr:$pr, attempt:$a}}')"
+
+      DISPATCHED=$((DISPATCHED+1))
+      ;;
+
+    blocked-unknown)
+      MSG="PR #${PR_NUMBER} is BLOCKED with no identifiable cause (${AGE}s stable)"
+      if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[dry-run] ${TICKET}: would escalate (blocked-unknown)" >&2
+      else
+        emit_state attention "$ORCH_ID" "blocked-unknown" "$TICKET" "$MSG"
+      fi
+      ESCALATED=$((ESCALATED+1))
+      ;;
+  esac
+done
+
+jq -nc \
+  --argjson c "$CHECKED" \
+  --argjson d "$DISPATCHED" \
+  --argjson e "$ESCALATED" \
+  --argjson s "$SKIPPED" \
+  '{checked:$c, dispatched:$d, escalated:$e, skipped:$s}'

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -822,6 +822,11 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
         BEHIND)
           # Often auto-resolves when auto-merge rebases; log only
           ;;
+        BLOCKED)
+          # Out-of-band: orchestrate-auto-fixup runs after this loop and handles
+          # BLOCKED (unresolved review threads, failing checks, review-required)
+          # once the state has been stable for ≥10 minutes (CTL-64).
+          ;;
       esac
       ;;
   esac
@@ -924,6 +929,44 @@ found transition to `status=stalled` with an attention item so you can
 decide between manual intervention and a fresh redispatch. Session resume
 uses `workers/output/<ticket>-stream.jsonl` (with legacy / transcript
 fallbacks) to find the original `session_id`.
+
+**Auto-dispatch fix-up workers for BLOCKED PRs (CTL-64):**
+
+After revive, a second pass detects PRs stuck in `state=OPEN,
+mergeStateStatus=BLOCKED` and either auto-dispatches `orchestrate-fixup`
+or escalates to an attention item depending on the cause.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-auto-fixup" \
+  --orch-dir "$ORCH_DIR" \
+  --orch-id "$ORCH_NAME"
+```
+
+The script records `blockedSince` on the worker signal the first time it
+observes BLOCKED, then — once the state has been stable for
+`--stable-minutes` (default 10) — classifies the cause via `gh pr view`
+and an `api graphql` query for unresolved review threads:
+
+| Classification       | Trigger                                               | Action                                                                   |
+| -------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------ |
+| `ci-running`         | any check `status ∈ {IN_PROGRESS, QUEUED, PENDING}`   | defer — try again next tick                                              |
+| `checks-failing`     | any check `conclusion ∈ {FAILURE, TIMED_OUT, …}`      | raise `checks-failing` attention (worker's own loop / revive handles it) |
+| `threads-unresolved` | checks pass AND unresolved review threads exist       | dispatch `orchestrate-fixup` with `--issues` composed from thread bodies |
+| `review-required`    | checks pass AND `reviewDecision = REVIEW_REQUIRED`    | raise `review-required` attention (human must approve)                   |
+| `blocked-unknown`    | none of the above (rare — shape not yet classified)   | raise `blocked-unknown` attention                                        |
+
+Each auto-dispatch bumps `fixupAttempts` on the signal. When
+`fixupAttempts ≥ --max-fixups` (default 2), the script raises
+`fixup-budget-exhausted` attention instead of dispatching again, so a
+human can decide between manual intervention and abandonment.
+
+Signal-file fields the script reads/writes:
+
+| Field                    | Written by                | Purpose                                                    |
+| ------------------------ | ------------------------- | ---------------------------------------------------------- |
+| `blockedSince`           | orchestrate-auto-fixup    | First observation of BLOCKED; cleared when PR leaves BLOCKED |
+| `fixupAttempts`          | orchestrate-auto-fixup    | Auto-dispatch counter (max = `--max-fixups`)               |
+| `lastFixupDispatchedAt`  | orchestrate-auto-fixup    | Timestamp of the most recent dispatch (for the dashboard)  |
 
 ### Phase 5: Independent Verification (Anti-Reward-Hacking)
 

--- a/plugins/dev/templates/worker-signal.json
+++ b/plugins/dev/templates/worker-signal.json
@@ -207,6 +207,21 @@
     "lastApiErrorUuid": {
       "type": ["string", "null"],
       "description": "UUID of the last API-error stream event (Stream idle timeout / partial response received) that `orchestrate-revive` has already handled (CTL-62). Used to dedup against the same error re-appearing in the appended stream JSONL after a successful revive. Null if no API-error revive has occurred."
+    },
+    "blockedSince": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the first observation that this worker's PR entered mergeStateStatus=BLOCKED. Written by orchestrate-auto-fixup (CTL-64); cleared when the PR leaves BLOCKED. Used to enforce a stability window before auto-dispatching a fix-up worker."
+    },
+    "fixupAttempts": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Count of auto-fixup dispatches triggered by orchestrate-auto-fixup (CTL-64). Bumped on each successful dispatch; escalates to a `fixup-budget-exhausted` attention when it reaches --max-fixups (default 2)."
+    },
+    "lastFixupDispatchedAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the most recent auto-fixup dispatch by orchestrate-auto-fixup (CTL-64). For dashboard/telemetry only."
     }
   }
 }


### PR DESCRIPTION
## Summary

Phase 4 poll loop previously only raised attention for DIRTY/BEHIND merge states. For the more common OPEN/BLOCKED case (unresolved review threads or REVIEW_REQUIRED), it did nothing and PRs sat stuck with zombie workers until human intervention.

Adds `plugins/dev/scripts/orchestrate-auto-fixup` which the orchestrator invokes alongside `orchestrate-revive`. It walks non-terminal worker signals, queries `gh pr view` for merge state and `gh api graphql` for review threads, classifies the BLOCKED reason (checks-failing vs threads-unresolved vs review-required), and either auto-dispatches a fix-up worker via `orchestrate-fixup --dispatch` or raises an attention item.

Stability is enforced via a configurable `blockedSince` window (default 10 min) so transient BLOCKED states don't trigger dispatches, and a `fixupAttempts` counter caps auto-dispatches at 2 before escalating to `fixup-budget-exhausted`.

## New signal fields (all nullable, additive)

- `blockedSince` — first observation the PR entered BLOCKED; cleared on exit
- `fixupAttempts` — count of auto-dispatches so far
- `lastFixupDispatchedAt` — telemetry for dashboard / monitor

## Tests

37 shell tests in `__tests__/orchestrate-auto-fixup.test.sh` using stub gh + stub orchestrate-fixup (Wave 3 convention). All pass. No regressions in existing shell test suites.

Closes CTL-64.