### PR TITLE
feat(meta): add homepage monitor video and auto-generated OG images

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
     mermaid(),
     starlight({
       title: "Catalyst",
+      routeMiddleware: "./src/routeData.ts",
       favicon: "/favicon.svg",
       logo: {
         src: "./public/favicon.svg",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/starlight": "^0.37.0",
         "astro": "^5.7.10",
         "astro-mermaid": "^1.3.1",
+        "astro-og-canvas": "^0.11.0",
         "mermaid": "^11.12.3",
         "sharp": "^0.33.5",
         "starlight-changelogs": "^0.4.0",
@@ -2205,6 +2206,12 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2482,6 +2489,32 @@
         "@mermaid-js/layout-elk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/astro-og-canvas": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/astro-og-canvas/-/astro-og-canvas-0.11.0.tgz",
+      "integrity": "sha512-ED733XHTOrAOOucUJh+nZ1g/u0dor6Du+3rReiFhNaYpjcURKHhanEZDIoW7FDHi3T6cp0UQtY0WYhushoZnng==",
+      "license": "MIT",
+      "dependencies": {
+        "canvaskit-wasm": "^0.41.0",
+        "deterministic-object-hash": "^2.0.2",
+        "entities": "^8.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0 || ^6.0.0-alpha"
+      }
+    },
+    "node_modules/astro-og-canvas/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/astro/node_modules/@img/sharp-darwin-arm64": {
@@ -2990,6 +3023,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.41.1.tgz",
+      "integrity": "sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
       }
     },
     "node_modules/ccount": {

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "@astrojs/starlight": "^0.37.0",
     "astro": "^5.7.10",
     "astro-mermaid": "^1.3.1",
+    "astro-og-canvas": "^0.11.0",
     "mermaid": "^11.12.3",
     "sharp": "^0.33.5",
     "starlight-changelogs": "^0.4.0",

--- a/website/src/components/MonitorShowcase.astro
+++ b/website/src/components/MonitorShowcase.astro
@@ -1,0 +1,66 @@
+---
+interface Props {
+  src: string;
+  poster?: string;
+  caption?: string;
+}
+
+const { src, poster, caption } = Astro.props;
+---
+
+<figure class="monitor-showcase">
+  <div class="monitor-frame">
+    <video
+      class="monitor-video"
+      src={src}
+      poster={poster}
+      autoplay
+      loop
+      muted
+      playsinline
+      preload="metadata"
+    ></video>
+  </div>
+  {caption && <figcaption>{caption}</figcaption>}
+</figure>
+
+<style>
+  .monitor-showcase {
+    margin: 2rem auto 2rem;
+    max-width: 1400px;
+    padding: 0 1rem;
+  }
+
+  .monitor-frame {
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid var(--sl-color-gray-5);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.2),
+      0 12px 32px rgba(0, 0, 0, 0.3),
+      0 32px 80px rgba(0, 0, 0, 0.35);
+  }
+
+  .monitor-video {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  figcaption {
+    margin-top: 1.5rem;
+    text-align: center;
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-sm);
+  }
+
+  @media (max-width: 640px) {
+    .monitor-showcase {
+      margin: 1.5rem auto 1rem;
+    }
+
+    .monitor-frame {
+      border-radius: 10px;
+    }
+  }
+</style>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,9 +1,12 @@
 ---
 title: Catalyst
-description: Opinionated AI development workflows for Claude Code — skills, agents, and orchestration built around a specific stack.
+description: Orchestrate parallel Claude Code agents across real codebases. Structured workflows, research-to-ship — not prompt-and-pray.
 template: splash
 hero:
-  tagline: Opinionated AI development workflows for Claude Code. Built around a specific stack, shared so others can benefit.
+  tagline: Orchestrate parallel Claude Code agents across real codebases. Structured workflows, research-to-ship — not prompt-and-pray.
+  image:
+    alt: Catalyst
+    html: '<img src="/favicon.svg" alt="Catalyst" width="150" height="150" />'
   actions:
     - text: Get Started
       link: /getting-started/introduction/
@@ -21,8 +24,15 @@ hero:
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 import LatestRelease from "../../../src/components/LatestRelease.astro";
+import MonitorShowcase from "../../../src/components/MonitorShowcase.astro";
 
 <LatestRelease />
+
+{/* Replace `src` with your Cloudflare R2 URL once uploaded. Optional `poster` = first-frame still. */}
+<MonitorShowcase
+  src="https://assets.coalescelabs.ai/video/Catalyst-2026-04-16d.mp4"
+  caption="Catalyst Monitor — orchestrating parallel agent waves in real time."
+/>
 
 ## Why Catalyst?
 

--- a/website/src/pages/og/[...slug].ts
+++ b/website/src/pages/og/[...slug].ts
@@ -1,0 +1,44 @@
+import { getCollection } from "astro:content";
+import { OGImageRoute } from "astro-og-canvas";
+
+const entries = await getCollection("docs");
+const pages = Object.fromEntries(
+  entries.map(({ data, id }) => [id || "index", { data }]),
+);
+
+export const { getStaticPaths, GET } = await OGImageRoute({
+  pages,
+  param: "slug",
+  getImageOptions: (_id, page: (typeof pages)[string]) => ({
+    title: page.data.title,
+    description: page.data.description ?? "",
+    bgGradient: [
+      [23, 23, 33],
+      [12, 10, 24],
+    ],
+    border: {
+      color: [79, 70, 229],
+      width: 20,
+      side: "inline-start",
+    },
+    padding: 100,
+    logo: {
+      path: "./public/icon-192.png",
+      size: [140],
+    },
+    font: {
+      title: {
+        size: 80,
+        weight: "Bold",
+        color: [255, 255, 255],
+        lineHeight: 1.15,
+      },
+      description: {
+        size: 36,
+        weight: "Normal",
+        color: [199, 210, 254],
+        lineHeight: 1.45,
+      },
+    },
+  }),
+});

--- a/website/src/routeData.ts
+++ b/website/src/routeData.ts
@@ -1,0 +1,19 @@
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+
+export const onRequest = defineRouteMiddleware((context) => {
+  const { id } = context.locals.starlightRoute;
+  const slug = id || "index";
+  const ogImageUrl = new URL(
+    `/og/${slug}.png`,
+    context.site ?? context.url,
+  ).href;
+  const { head } = context.locals.starlightRoute;
+  head.push({
+    tag: "meta",
+    attrs: { property: "og:image", content: ogImageUrl },
+  });
+  head.push({
+    tag: "meta",
+    attrs: { name: "twitter:image", content: ogImageUrl },
+  });
+});


### PR DESCRIPTION
## Summary

- **Homepage hero video** — adds a looping Catalyst Monitor screen recording below the splash hero via a new `MonitorShowcase` component (rounded frame, hairline border, layered drop shadow). Video is hosted on Cloudflare at `assets.coalescelabs.ai`.
- **Logo in hero content area** — brings the flame mark into the hero via Starlight's `hero.image`, balancing with the wordmark.
- **New tagline** — replaces "opinionated AI development workflows" (defensive jargon + self-effacing coda) with a concrete pitch:
  > Orchestrate parallel Claude Code agents across real codebases. Structured workflows, research-to-ship — not prompt-and-pray.
- **Auto-generated social share images** — fixes missing `og:image` and `twitter:image` tags. Wires up `astro-og-canvas` to generate per-page 1200×630 PNGs at `/og/<slug>.png` using the plugin logo + page metadata, and a Starlight route middleware injects the meta tags on every page.

## Test plan

- [x] `npm run build` passes — 226 pages built, 29+ OG images generated under `dist/og/`
- [x] Verified `og:image` and `twitter:image` meta tags present on homepage HTML pointing to `/og/index.png`
- [x] Verified generated OG image renders correctly (logo, title, description, accent border)
- [x] Video autoplays, loops, is muted, plays inline on the homepage
- [ ] Verify social unfurl on Slack/Twitter after merge (needs production URL to be reachable)

## Release impact

No version bumps — all changes are under `website/`, outside all release-please package paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)