### PR TITLE
chore(meta): polish mobile homepage and expand stack/monitor docs

### DIFF
--- a/website/src/components/LatestRelease.astro
+++ b/website/src/components/LatestRelease.astro
@@ -74,4 +74,15 @@ const formattedDate = rawDate
     color: var(--sl-color-accent-high);
     font-weight: 500;
   }
+
+  @media (max-width: 640px) {
+    .latest-release {
+      display: flex;
+      width: fit-content;
+      margin-inline: auto;
+      margin-bottom: 1rem;
+      padding: 0.375rem 0.875rem;
+      font-size: var(--sl-text-xs);
+    }
+  }
 </style>

--- a/website/src/components/MonitorShowcase.astro
+++ b/website/src/components/MonitorShowcase.astro
@@ -56,11 +56,17 @@ const { src, poster, caption } = Astro.props;
 
   @media (max-width: 640px) {
     .monitor-showcase {
-      margin: 1.5rem auto 1rem;
+      margin: 1.25rem -0.75rem 1rem;
+      padding: 0;
     }
 
     .monitor-frame {
       border-radius: 10px;
+    }
+
+    figcaption {
+      margin-top: 1rem;
+      padding: 0 1rem;
     }
   }
 </style>

--- a/website/src/content/docs/getting-started/the-stack.md
+++ b/website/src/content/docs/getting-started/the-stack.md
@@ -44,8 +44,7 @@ This is **not** a one-click installer. It's not a polished, end-to-end package t
 | Tool | Role |
 |------|------|
 | [direnv](https://direnv.net) | Per-project environment variables, API key isolation, OTel context |
-| [Conductor](https://conductor.build) | Parallel agent orchestration UI |
-| [Warp](https://www.warp.dev) | Terminal |
+| [Warp](https://www.warp.dev) | Terminal — automation for orchestrating worktrees and kicking off code agents (optional, not required) |
 | [Bun](https://bun.sh) | Runtime for scripts and tooling |
 
 ### AI Agents (Beyond Claude Code)
@@ -56,6 +55,22 @@ This is **not** a one-click installer. It's not a polished, end-to-end package t
 | [Codex](https://openai.com/index/codex/) | OpenAI's coding agent |
 
 Catalyst skills can orchestrate handoffs between these agents and Claude Code.
+
+## How I Actually Work
+
+Catalyst grew out of friction I hit using other orchestration tools. A short tour of what I've tried and where I've landed:
+
+- **Code Layer (HumanLayer)** — A daily driver for a while. HumanLayer popularized the research-plan-implement loop and combined context engineering with opinionated multi-agent workflow management. The team has since pivoted to a new product called Riptide, and Code Layer hasn't seen meaningful updates in a while. I'm still on the waitlist for Riptide.
+- **[Conductor.build](https://conductor.build)** — My daily driver before Catalyst-native orchestration, and I still reach for it for single-threaded work. Responsive team, clean tabbed UI for multiple agents, solid Linear integration — Catalyst runs fine inside Conductor. Its constraint: it's built around single-branch, single-worktree sessions. Great for Level 2, but it doesn't have first-class support for forked agents (worktrees that spawn other worktrees), which is what Catalyst's `/orchestrate` skill and Claude's teams/swarm features need. That gap is what pushed me to build wave-based orchestration here, plus the [Catalyst Monitor](/observability/monitor/) web dashboard.
+- **[Warp](https://www.warp.dev)** — My current terminal. I've been experimenting with its vertical tabs and automated tab templates for spinning up agent worktrees. Still dialing it in, but it's become my daily driver.
+
+**What's open on my screen while I'm shipping:**
+
+- Warp
+- [Catalyst Monitor](/observability/monitor/) (web UI) — live view of orchestration waves and worker status
+- Linear — tickets and cycle state
+- Grafana — Claude OpenTelemetry dashboard for token and cost monitoring
+- GitHub (or [GitKraken](https://www.gitkraken.com)) — to watch PRs open, CI run, and merges land
 
 ## What This Means for You
 
@@ -73,6 +88,10 @@ Installing these plugins means installing code that runs on your computer — or
 
 Catalyst bakes security checks and security reviews into its own CI/CD pipeline. But of course, that's exactly what someone would tell you if they were trying to put something nasty on your machine. Run your own scans. Read the code. Trust your own review, not someone else's assurances.
 
+## A Note on Harnesses
+
+Harnesses like Catalyst exist because we still need to steer raw models toward the specific engineering behaviors — research, planning, validation, handoffs — that give us confidence shipping real software. I'm drawing from the best pieces I've found across other systems plus my own, and I'll keep improving this until something genuinely better shows up. Eventually the models may be powerful enough that most of this scaffolding isn't needed and they figure it out from first principles — until then, the harness is the thing.
+
 ## Start at Level 2
 
 Catalyst describes three levels of AI-assisted development (detailed in [Beyond Prompt and Pray](https://slides.rozich.net/ai/structured-ai-development-guide)):
@@ -80,6 +99,10 @@ Catalyst describes three levels of AI-assisted development (detailed in [Beyond 
 - **Level 1** — Prompt and generate. Basic AI code completion.
 - **Level 2** — Structured workflows. Research, plan, implement, validate — one ticket at a time.
 - **Level 3** — Orchestrated parallelism. Multiple agents working across multiple tickets simultaneously.
+
+![Catalyst Monitor showing a Level 3 orchestration run: multiple waves of parallel workers with completion percentage, active worker count, total cost, and wall clock time](https://assets.coalescelabs.ai/images/screenshots/orchestrator-2026-04-17%20at%2008.05.20%402x.png)
+
+*Level 3 in practice — the [Catalyst Monitor](/observability/monitor/) tracking nine waves of parallel agents on a single orchestration run.*
 
 **Start at Level 2.** Spend real time there. Work ticket by ticket through the research-plan-implement cycle. Get a feel for what's happening under the hood. Understand how context flows between phases, how handoffs work, how the AI reasons about your codebase.
 

--- a/website/src/content/docs/observability/monitor.md
+++ b/website/src/content/docs/observability/monitor.md
@@ -7,6 +7,10 @@ sidebar:
 
 `orch-monitor` is a Bun-based HTTP server that aggregates worker signal files, polls GitHub for PR state, and serves a live dashboard with server-sent event streams. One process powers both the web UI and the terminal UI.
 
+![Orchestrator overview showing active waves, completion percentage, total cost, wall clock, and the worker list](https://assets.coalescelabs.ai/images/screenshots/orchestrator-2026-04-17%20at%2008.05.20%402x.png)
+
+*Orchestrator overview — waves, workers, cost, and wall-clock time at a glance.*
+
 ## Running the server
 
 The simplest way to start the monitor:
@@ -68,9 +72,25 @@ One row per worker showing:
 - **Duration** since startedAt
 - **Last heartbeat** (red if > 15 min)
 
+![Workers tab showing a tabular list of workers per orchestrator with ticket, status, phase, PR number, cost, tokens, and last-update columns](https://assets.coalescelabs.ai/images/screenshots/workers-09.09.12.png)
+
+*Workers tab — one row per worker with ticket, phase, PR, cost, and activity.*
+
 ### Row 3 — Event stream
 
 Real-time event log from `~/catalyst/events.jsonl` and filesystem watches, rendered as a timeline. Filters: event type, worker ticket, orchestrator, date range.
+
+![Timeline tab showing a Gantt-style view with colored phase bars per worker across research, plan, implement, validate, ship, and merged states](https://assets.coalescelabs.ai/images/screenshots/timeline-2026-04-17%20at%2009.08.04.png)
+
+*Timeline tab — phase Gantt bars per worker (research → plan → implement → validate → ship → merged).*
+
+### Worker detail
+
+Click any worker row to open a detail drawer with the phase timeline, PR metadata, and the live activity feed for that ticket.
+
+![Worker detail drawer open on the right showing phase timeline, PR info, and a streaming activity feed for a single worker](https://assets.coalescelabs.ai/images/screenshots/worker-detail-9.06.34%402x.png)
+
+*Worker detail — drill into a single ticket for its phase timeline, PR state, and activity feed.*
 
 ## API endpoints
 

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -15,6 +15,29 @@
   border-radius: 4px;
 }
 
+/* ─── Mobile homepage polish ──────────────────────────────────────────────
+ * Tighten hero vertical rhythm and shrink the oversized logo on small
+ * screens so the monitor video appears closer to the first fold.
+ */
+@media (max-width: 640px) {
+  .hero img {
+    width: 112px !important;
+    height: 112px !important;
+  }
+
+  .hero .hero-html {
+    justify-content: center;
+  }
+
+  .hero .stack {
+    gap: 1rem;
+  }
+
+  .hero .actions {
+    gap: 0.5rem;
+  }
+}
+
 /* ─── Changelog Styling (Conductor-inspired) ────────────────────────────────
  *
  * DOM structure per version entry (from starlight-changelogs):


### PR DESCRIPTION
## Summary

Two threads of polish across the marketing site:

**1. Mobile homepage layout** — the homepage wasted horizontal space on phones and the hero logo + changelog pill were left-shifted instead of centered on iPhone 12 and similar viewports.

**2. Docs content** — remove Conductor from the stack (Warp is the current terminal orchestrator of choice), add framing on why harnesses exist, document my actual daily workflow, and embed Catalyst Monitor screenshots in the stack doc and the monitor reference page.

## What changed

### Mobile layout (`<640px` only — desktop untouched)

- `MonitorShowcase.astro` — monitor video breaks out of prose padding (324px → 380px at 390px viewport); caption re-padded so it stays inside the text column
- `custom.css` — hero logo scales down to 112px on mobile; `.hero .hero-html` gets `justify-content: center` so the logo sits centered when the hero collapses to a single column
- `LatestRelease.astro` — changelog pill switches to `display: flex; width: fit-content; margin-inline: auto` on mobile so it centers instead of left-aligning in `.sl-markdown-content`

### `getting-started/the-stack.md`

- Drop Conductor row from the Development Environment table
- Update Warp row to describe its worktree/agent automation as optional
- New **A Note on Harnesses** section — 3-sentence take on why harnesses exist and when models may eventually outgrow them
- New **How I Actually Work** section — short tour of Code Layer (HumanLayer), Conductor.build, and Warp, plus the five-app daily workflow (Warp + Monitor + Linear + Grafana + GitHub/GitKraken)
- Level 3 orchestrator screenshot under the Level 1/2/3 bullet list

### `observability/monitor.md`

Four screenshots added with captions:

- Orchestrator overview (hero, after intro paragraph)
- Workers list (in Row 2 — Worker grid)
- Timeline Gantt (in Row 3 — Event stream)
- Worker detail (new subsection between Row 3 and API endpoints)

Screenshots served from `assets.coalescelabs.ai` (R2 + Cloudflare CDN). I tried the `/cdn-cgi/image/...` and query-string transform URLs against the domain and both returned the raw file — image transformations don't appear to be active at the URL layer. Using raw URLs for now; can swap in transformed variants later if the zone gets the Transform Images toggle flipped.

## Test plan

- [x] Audited homepage at 390px and 320px widths (dark + light theme) via agent-browser
- [x] Verified centering with pixel math: `logoCenterOff: 0`, `pillCenterOff: 0` at 390px
- [x] Verified video width grew from 324 → 380 at 390px viewport
- [x] Reloaded stack doc and monitor doc in-browser; all screenshots load and captions render
- [ ] Astro build passes in CI