### PR TITLE
fix(dev): bundle warp helper scripts in plugin

### DIFF
--- a/plugins/dev/scripts/open-project-tab.sh
+++ b/plugins/dev/scripts/open-project-tab.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# open-project-tab.sh — Standard init for a "project 📦" Warp tab.
+#
+# Runs the shared 5-step startup used by every ~/.warp/tab_configs/*.toml that
+# opens a project's main checkout (no worktree, no claude launch).
+#
+# Steps:
+#   1. direnv allow + export
+#   2. humanlayer thoughts init + sync (if humanlayer installed)
+#   3. optional project-specific setup (first arg — e.g. "bun install && scripts/setup-env.sh")
+#   4. trust-workspace.sh so Claude Code skips the trust dialog
+#   5. git fetch + git status
+#
+# Usage (from a tab_configs commands array):
+#   "<catalyst-root>/plugins/dev/scripts/open-project-tab.sh"
+#   "<catalyst-root>/plugins/dev/scripts/open-project-tab.sh 'bun install && scripts/setup-env.sh'"
+#
+# Assumes cwd is the project root (Warp tab sets `directory`). No `set -e`: if any
+# step soft-fails, we still want the tab to drop the user into a usable shell.
+
+SETUP_CMD="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 1. direnv
+if command -v direnv >/dev/null 2>&1; then
+  direnv allow . && eval "$(direnv export zsh)"
+fi
+
+# 2. humanlayer thoughts — mirrors the pattern used across all project tabs.
+#    $HUMANLAYER_PROFILE / $HUMANLAYER_DIRECTORY come from the shell env.
+if command -v humanlayer >/dev/null 2>&1; then
+  yes | humanlayer thoughts init --profile "$HUMANLAYER_PROFILE" --directory "$HUMANLAYER_DIRECTORY" 2>/dev/null
+  humanlayer thoughts sync
+fi
+
+# 3. Project-specific setup
+if [[ -n "$SETUP_CMD" ]]; then
+  eval "$SETUP_CMD"
+fi
+
+# 4. Trust workspace for Claude Code
+if [[ -x "$SCRIPT_DIR/trust-workspace.sh" ]]; then
+  "$SCRIPT_DIR/trust-workspace.sh" "$(pwd)"
+fi
+
+# 5. Git state
+git fetch && git status

--- a/plugins/dev/scripts/trust-workspace.sh
+++ b/plugins/dev/scripts/trust-workspace.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# trust-workspace.sh — Pre-trust a directory in Claude Code's ~/.claude.json
+# Usage: trust-workspace.sh [path]
+#   path: Directory to trust (defaults to current directory)
+
+set -euo pipefail
+
+CLAUDE_CONFIG="$HOME/.claude.json"
+WORKSPACE_PATH="${1:-$(pwd)}"
+
+# Resolve to absolute path
+WORKSPACE_PATH="$(cd "$WORKSPACE_PATH" 2>/dev/null && pwd)" || {
+  echo "Error: Directory '$1' does not exist" >&2
+  exit 1
+}
+
+if [ ! -f "$CLAUDE_CONFIG" ]; then
+  echo "Error: $CLAUDE_CONFIG not found" >&2
+  exit 1
+fi
+
+LOCKFILE="$CLAUDE_CONFIG.lock"
+exec 200>"$LOCKFILE"
+flock -w 5 200 2>/dev/null || {
+  echo "Warning: Could not acquire lock, proceeding anyway" >&2
+}
+
+TMPFILE="$(mktemp "$CLAUDE_CONFIG.XXXXXX")"
+trap 'rm -f "$TMPFILE" "$LOCKFILE"' EXIT
+
+if jq -e --arg path "$WORKSPACE_PATH" '.projects[$path]' "$CLAUDE_CONFIG" > /dev/null 2>&1; then
+  # Project entry exists — just flip the trust flag
+  jq --arg path "$WORKSPACE_PATH" \
+    '.projects[$path].hasTrustDialogAccepted = true' \
+    "$CLAUDE_CONFIG" > "$TMPFILE"
+else
+  # Project entry doesn't exist — create with sensible defaults
+  jq --arg path "$WORKSPACE_PATH" \
+    '.projects[$path] = {
+      "allowedTools": [],
+      "mcpContextUris": [],
+      "mcpServers": {},
+      "enabledMcpjsonServers": [],
+      "disabledMcpjsonServers": [],
+      "hasTrustDialogAccepted": true,
+      "projectOnboardingSeenCount": 0,
+      "hasClaudeMdExternalIncludesApproved": false,
+      "hasClaudeMdExternalIncludesWarningShown": false,
+      "hasCompletedProjectOnboarding": false
+    }' \
+    "$CLAUDE_CONFIG" > "$TMPFILE"
+fi
+
+mv "$TMPFILE" "$CLAUDE_CONFIG"
+echo "Trusted: $WORKSPACE_PATH"

--- a/plugins/dev/skills/setup-warp/SKILL.md
+++ b/plugins/dev/skills/setup-warp/SKILL.md
@@ -194,7 +194,7 @@ type = "terminal"
 directory = "{PROJECT_PATH}"
 commands = [
   "export CATALYST_WARP_NAME={SLUG} CATALYST_WARP_REMOTE={SLUG}",
-  "~/.claude/scripts/open-project-tab.sh{SETUP_CMD_SUFFIX}",
+  "{CATALYST_ROOT}/plugins/dev/scripts/open-project-tab.sh{SETUP_CMD_SUFFIX}",
 ]
 ```
 
@@ -256,7 +256,7 @@ commands = [
   "export CATALYST_WARP_NAME={SLUG}_{{worktree}} CATALYST_WARP_REMOTE={SLUG}_{{worktree}}",
   "direnv allow . && eval \"$(direnv export zsh)\"",
   "yes | humanlayer thoughts init --profile $HUMANLAYER_PROFILE --directory $HUMANLAYER_DIRECTORY 2>/dev/null; humanlayer thoughts sync",
-  "~/.claude/scripts/trust-workspace.sh \"$(pwd)\"",
+  "{CATALYST_ROOT}/plugins/dev/scripts/trust-workspace.sh \"$(pwd)\"",
   "git status",
 ]
 

--- a/website/src/content/docs/reference/warp-terminal.md
+++ b/website/src/content/docs/reference/warp-terminal.md
@@ -122,17 +122,18 @@ type = "terminal"
 directory = "~/code-repos/github/coalesce-labs/catalyst"
 commands = [
   "export CATALYST_WARP_NAME=catalyst CATALYST_WARP_REMOTE=catalyst",
-  "~/.claude/scripts/open-project-tab.sh",
+  "~/code-repos/github/coalesce-labs/catalyst/plugins/dev/scripts/open-project-tab.sh",
 ]
 ```
 
-The helper `open-project-tab.sh` runs direnv, `humanlayer thoughts sync`, trust-workspace, and
-`git fetch && git status`. You can pass a project-specific init command as its first argument:
+The helper `open-project-tab.sh` (shipped in the catalyst plugin) runs direnv, `humanlayer
+thoughts sync`, trust-workspace, and `git fetch && git status`. You can pass a project-specific
+init command as its first argument:
 
 ```toml
 commands = [
   "export CATALYST_WARP_NAME=adva CATALYST_WARP_REMOTE=adva",
-  "~/.claude/scripts/open-project-tab.sh 'bun install && scripts/setup-env.sh'",
+  "~/code-repos/github/coalesce-labs/catalyst/plugins/dev/scripts/open-project-tab.sh 'bun install && scripts/setup-env.sh'",
 ]
 ```
 
@@ -197,7 +198,7 @@ commands = [
   "export CATALYST_WARP_NAME=catalyst_{{worktree}} CATALYST_WARP_REMOTE=catalyst_{{worktree}}",
   "direnv allow . && eval \"$(direnv export zsh)\"",
   "yes | humanlayer thoughts init --profile $HUMANLAYER_PROFILE --directory $HUMANLAYER_DIRECTORY 2>/dev/null; humanlayer thoughts sync",
-  "~/.claude/scripts/trust-workspace.sh \"$(pwd)\"",
+  "~/code-repos/github/coalesce-labs/catalyst/plugins/dev/scripts/trust-workspace.sh \"$(pwd)\"",
   "git status",
 ]
 
@@ -264,8 +265,14 @@ environment and forwards them to Claude as `--name` and
 ### `open-project-tab.sh`
 
 Shared init for Main tabs: direnv, humanlayer thoughts sync, optional project-specific setup
-command, trust-workspace, git fetch+status. Lives in `~/.claude/scripts/` (personal dotfiles
-territory, not part of the Catalyst plugin).
+command, trust-workspace, git fetch+status. Ships in `plugins/dev/scripts/` so the generated
+tab configs work on any checkout of the catalyst repo.
+
+### `trust-workspace.sh`
+
+Pre-trusts a directory in Claude Code's `~/.claude.json` so the first `claude` invocation in a
+fresh worktree skips the trust dialog. Called by `open-project-tab.sh` and by the existing-
+worktree tab template. Also ships in `plugins/dev/scripts/`.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

The `setup-warp` skill's generated tab configs referenced `~/.claude/scripts/open-project-tab.sh` and `~/.claude/scripts/trust-workspace.sh` — scripts that only exist in my personal dotfiles. Anyone else installing the plugin would have generated tab configs that point at nonexistent files.

Fix: ship both scripts inside `plugins/dev/scripts/` so they travel with the plugin.

- Added `plugins/dev/scripts/open-project-tab.sh` (direnv → humanlayer thoughts → optional setup cmd → trust-workspace → git fetch/status)
- Added `plugins/dev/scripts/trust-workspace.sh` (pre-trusts dir in `~/.claude.json`)
- `open-project-tab.sh` resolves `trust-workspace.sh` via `$(dirname "${BASH_SOURCE[0]}")` so they stay co-located regardless of install path
- Updated `plugins/dev/skills/setup-warp/SKILL.md` — TOML templates now reference `{CATALYST_ROOT}/plugins/dev/scripts/...`
- Updated `website/src/content/docs/reference/warp-terminal.md` to match and documented `trust-workspace.sh` in the helper script reference

## Test plan

- [x] `bash -n` syntax check on both scripts
- [ ] Delete local `~/.warp/tab_configs/*.toml`, run `/catalyst-dev:setup-warp`, verify generated TOMLs reference `{catalyst-root}/plugins/dev/scripts/...`
- [ ] Open a regenerated Main tab and confirm the standard init still runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)