### PR TITLE
fix(dev): restrict setup-warp colors to Warp's 8 valid variants

### DIFF
--- a/plugins/dev/skills/setup-warp/SKILL.md
+++ b/plugins/dev/skills/setup-warp/SKILL.md
@@ -129,9 +129,10 @@ possible, or sequential questions):
 - **Short identifier (slug)** — alnum/dash only, lowercase (e.g., `catalyst`, `bob-rozich`). Default:
   lowercase display name with spaces → dashes, non-alnum stripped.
 - **Emoji** — for main tab (default: `📦`)
-- **Color** — pick from: `magenta`, `blue`, `green`, `cyan`, `yellow`, `red`, `teal`, `purple`,
-  `orange`, `pink`, `white`. Each project gets a distinct color so vertical-sidebar tabs are visually
-  separable.
+- **Color** — Warp only accepts these 8 values: `black`, `red`, `green`, `yellow`, `blue`,
+  `magenta`, `cyan`, `white`. **Do not offer any others** — Warp rejects unknown variants with a
+  TOML parse error at load. Recommend against `black` (invisible on dark themes). Each project
+  gets a distinct color so vertical-sidebar tabs are visually separable.
 - **Variants** — multi-select from:
   - Main (always recommended)
   - PM worktree (only for Catalyst-managed projects)

--- a/website/src/content/docs/reference/warp-terminal.md
+++ b/website/src/content/docs/reference/warp-terminal.md
@@ -52,7 +52,9 @@ color.
 | Personal tools | blue |
 | Client work | cyan |
 
-(These are just conventions — pick whatever you like.)
+Warp accepts 8 color variants total: `black`, `red`, `green`, `yellow`, `blue`, `magenta`,
+`cyan`, `white`. Any other value (e.g. `purple`, `orange`, `teal`, `pink`) fails to load with a
+TOML parse error. `black` is valid but invisible on dark themes.
 
 ### Session Name Convention
 


### PR DESCRIPTION
## Summary

`setup-warp` offered `purple`, `orange`, `teal`, `pink` as color choices — Warp doesn't accept any of those. Picking one caused Warp to reject the generated TOML on load with:

```
Failed to load tab config ~/.warp/tab_configs/01_catalyst.toml: TOML parse error at line 3, column 9
  color = \"purple\"
unknown variant `purple`, expected one of `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`
```

Hit this during my first real `setup-warp` run — 4 Catalyst tabs and 3 Omnicell tabs refused to load.

Fix: list the exactly-8 valid Warp variants in both the skill and the website reference. Added an explicit \"do not offer any others\" note in the skill so future edits don't regress.

## Test plan

- [x] Visual audit of SKILL.md interview prompt
- [x] Local repair: rewrote my broken TOMLs (`purple → magenta`, `pink → cyan`) and Warp now loads them
- [ ] Re-run `/catalyst-dev:setup-warp` after merge to confirm the skill only offers valid colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)