### PR TITLE
fix(dev): init-or-repair auto-fixes thoughts profile drift (CTL-91)

### DIFF
--- a/plugins/dev/scripts/catalyst-thoughts.sh
+++ b/plugins/dev/scripts/catalyst-thoughts.sh
@@ -48,8 +48,43 @@ _mkdir_subdirs() {
 }
 
 cmd_init_or_repair() {
-	# Case A: thoughts/shared is a valid symlink → ensure subdirs exist inside it, done.
+	# Case A: thoughts/shared is a valid symlink → check for profile/directory drift
+	# between .catalyst/config.json and humanlayer's mapping. If found, repair by
+	# `humanlayer thoughts uninit --force` followed by re-`init` with the config's
+	# profile/directory. Safe because thoughts content lives in the canonical
+	# thoughts repo, not in the symlink target. Otherwise, just ensure subdirs.
 	if [[ -L "thoughts/shared" && -d "thoughts/shared" ]]; then
+		if command -v humanlayer &>/dev/null && _read_thoughts_config && [[ -n "${CAT_DIR:-}" ]]; then
+			local mapping hl_profile hl_repo needs_fix=0
+			mapping="$(_humanlayer_mapping 2>/dev/null || true)"
+			if [[ -n "$mapping" ]]; then
+				hl_profile="$(printf '%s' "$mapping" | cut -f1)"
+				hl_repo="$(printf '%s' "$mapping" | cut -f2)"
+				if [[ -n "${CAT_PROFILE:-}" && -n "$hl_profile" && "$CAT_PROFILE" != "$hl_profile" ]]; then
+					needs_fix=1
+				fi
+				if [[ -n "$hl_repo" && "$CAT_DIR" != "$hl_repo" ]]; then
+					needs_fix=1
+				fi
+			fi
+			if [[ $needs_fix -eq 1 ]]; then
+				echo "  Drift detected between .catalyst/config.json and humanlayer mapping — repairing."
+				echo "  Running: humanlayer thoughts uninit --force"
+				if ! humanlayer thoughts uninit --force; then
+					echo "ERROR: humanlayer thoughts uninit failed" >&2
+					return 1
+				fi
+				local init_args=(thoughts init --directory "$CAT_DIR")
+				[[ -n "${CAT_PROFILE:-}" ]] && init_args+=(--profile "$CAT_PROFILE")
+				echo "  Running: humanlayer ${init_args[*]}"
+				if ! humanlayer "${init_args[@]}"; then
+					echo "ERROR: humanlayer thoughts init failed" >&2
+					return 1
+				fi
+				_mkdir_subdirs "thoughts/shared"
+				return 0
+			fi
+		fi
 		_mkdir_subdirs "thoughts/shared"
 		return 0
 	fi

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -450,7 +450,8 @@ if [[ -d "thoughts" ]]; then
                 hl_repo=$(echo "$hl_map" | jq -r '.repo // empty' 2>/dev/null)
                 if [[ -n "$cat_profile" && -n "$hl_profile" && "$cat_profile" != "$hl_profile" ]]; then
                     fail "Profile drift: .catalyst/config.json='$cat_profile', humanlayer='$hl_profile' for this repo"
-                    info "Fix: humanlayer thoughts init --force --profile $cat_profile --directory ${cat_dir:-<directory>}"
+                    info "Fix: bash plugins/dev/scripts/catalyst-thoughts.sh init-or-repair"
+                    info "  (or manually: humanlayer thoughts uninit --force && humanlayer thoughts init --profile $cat_profile --directory ${cat_dir:-<directory>})"
                 fi
                 if [[ -n "$cat_dir" && -n "$hl_repo" && "$cat_dir" != "$hl_repo" ]]; then
                     fail "Directory drift: .catalyst/config.json='$cat_dir', humanlayer='$hl_repo' for this repo"

--- a/plugins/dev/scripts/test-thoughts-repair.sh
+++ b/plugins/dev/scripts/test-thoughts-repair.sh
@@ -72,6 +72,11 @@ if [[ "\$1" == "thoughts" && "\$2" == "init" ]]; then
     ln -sfn "$fake_repo/repos/\$DIR/ryan"  thoughts/ryan
     exit 0
 fi
+if [[ "\$1" == "thoughts" && "\$2" == "uninit" ]]; then
+    # Simulate humanlayer removing the symlinks it owns.
+    rm -f thoughts/shared thoughts/global thoughts/ryan 2>/dev/null || true
+    exit 0
+fi
 if [[ "\$1" == "thoughts" && "\$2" == "status" ]]; then
     echo "✓ Initialized"
     exit 0
@@ -425,6 +430,91 @@ mkdir -p "$TEST_DIR"
 	else
 		fail "check exited non-zero on healthy project. stderr:"
 		cat /tmp/ctl-90-test5d-stderr | sed 's/^/    /'
+	fi
+)
+
+# ── Test 6: init-or-repair auto-fixes profile drift ──────────────────────
+
+run_test "init-or-repair auto-fixes profile drift (uninit + init)"
+
+TEST_DIR="$TMPDIR/test6"
+FAKE_REPO="$TMPDIR/test6-thoughts"
+mkdir -p "$TEST_DIR"
+(
+	cd "$TEST_DIR"
+	write_catalyst_config ".catalyst/config.json" "profile-A" "dir-A"
+	SHIM_LOG="$TEST_DIR/humanlayer.log"
+	# humanlayer claims the repo is mapped under profile-B (drift)
+	HL_JSON=$(humanlayer_config_json "$TEST_DIR" "dir-A" "profile-B")
+	make_humanlayer_shim "$TEST_DIR/bin" "$SHIM_LOG" "$FAKE_REPO" "$HL_JSON"
+	export PATH="$TEST_DIR/bin:$PATH"
+
+	# Pre-create a valid symlink so we're past the symlink-clobbered case.
+	mkdir -p "$FAKE_REPO/repos/dir-A/shared"
+	mkdir -p thoughts
+	ln -sfn "$FAKE_REPO/repos/dir-A/shared" thoughts/shared
+
+	if bash "$SUT" init-or-repair >/tmp/ctl-91-test6-stdout 2>&1; then
+		pass "init-or-repair exited 0"
+	else
+		fail "init-or-repair exit non-zero on drift. output:"
+		cat /tmp/ctl-91-test6-stdout | sed 's/^/    /'
+	fi
+
+	if grep -q "thoughts uninit --force" "$SHIM_LOG"; then
+		pass "humanlayer uninit --force was invoked"
+	else
+		fail "humanlayer uninit was not invoked. log:"
+		cat "$SHIM_LOG" | sed 's/^/    /'
+	fi
+
+	if grep -q "thoughts init --directory dir-A --profile profile-A" "$SHIM_LOG"; then
+		pass "humanlayer init invoked with config profile"
+	else
+		fail "humanlayer init was not invoked with expected args. log:"
+		cat "$SHIM_LOG" | sed 's/^/    /'
+	fi
+
+	if [[ -L "thoughts/shared" ]]; then
+		pass "thoughts/shared is a symlink after drift repair"
+	else
+		fail "thoughts/shared is not a symlink after drift repair"
+	fi
+)
+
+# ── Test 7: init-or-repair auto-fixes directory drift ────────────────────
+
+run_test "init-or-repair auto-fixes directory drift"
+
+TEST_DIR="$TMPDIR/test7"
+FAKE_REPO="$TMPDIR/test7-thoughts"
+mkdir -p "$TEST_DIR"
+(
+	cd "$TEST_DIR"
+	write_catalyst_config ".catalyst/config.json" "profile-A" "dir-A"
+	SHIM_LOG="$TEST_DIR/humanlayer.log"
+	# Same profile, wrong directory in humanlayer mapping
+	HL_JSON=$(humanlayer_config_json "$TEST_DIR" "dir-OTHER" "profile-A")
+	make_humanlayer_shim "$TEST_DIR/bin" "$SHIM_LOG" "$FAKE_REPO" "$HL_JSON"
+	export PATH="$TEST_DIR/bin:$PATH"
+
+	mkdir -p "$FAKE_REPO/repos/dir-A/shared"
+	mkdir -p thoughts
+	ln -sfn "$FAKE_REPO/repos/dir-A/shared" thoughts/shared
+
+	if bash "$SUT" init-or-repair >/tmp/ctl-91-test7-stdout 2>&1; then
+		pass "init-or-repair exited 0"
+	else
+		fail "init-or-repair exit non-zero on directory drift. output:"
+		cat /tmp/ctl-91-test7-stdout | sed 's/^/    /'
+	fi
+
+	if grep -q "thoughts uninit --force" "$SHIM_LOG" && \
+	   grep -q "thoughts init --directory dir-A --profile profile-A" "$SHIM_LOG"; then
+		pass "humanlayer uninit + init invoked for directory drift"
+	else
+		fail "humanlayer uninit + init not invoked for directory drift. log:"
+		cat "$SHIM_LOG" | sed 's/^/    /'
 	fi
 )
 

--- a/plugins/dev/skills/setup-catalyst/SKILL.md
+++ b/plugins/dev/skills/setup-catalyst/SKILL.md
@@ -55,7 +55,7 @@ user rather than overwriting anything.
 | WAL mode not set | `sqlite3 ~/catalyst/catalyst.db 'PRAGMA journal_mode=WAL;'` |
 | `thoughts/shared/<dir>` missing | Run `bash plugins/dev/scripts/catalyst-thoughts.sh init-or-repair` (re-uses humanlayer when configured; warns loudly when no thoughts repo is set up) |
 | `thoughts/shared` is a regular directory (not a symlink) | **Fatal — do not auto-fix.** Tell the user the humanlayer symlink was clobbered and show recovery: `mv thoughts/shared thoughts/shared.orphaned-$(date +%Y%m%d)` then `bash plugins/dev/scripts/catalyst-thoughts.sh init-or-repair` |
-| Profile drift between `.catalyst/config.json` and humanlayer mapping | Show the user: `humanlayer thoughts init --force --profile <profile from .catalyst/config.json> --directory <directory from .catalyst/config.json>` |
+| Profile drift between `.catalyst/config.json` and humanlayer mapping | Run `bash plugins/dev/scripts/catalyst-thoughts.sh init-or-repair` — it now auto-repairs drift by running `humanlayer thoughts uninit --force && humanlayer thoughts init --profile <config profile> --directory <config directory>`. (Plain `humanlayer thoughts init --force` does NOT update an existing repo→profile mapping, so the `uninit` step is required.) |
 
 For issues needing user input, explain what's needed and how to provide it:
 


### PR DESCRIPTION
## Summary

Follow-up polish to CTL-90 (PR #209). Two small fixes:

- **`catalyst-thoughts.sh init-or-repair`** now detects profile/directory drift between `.catalyst/config.json` and humanlayer's repo mapping, and auto-repairs it via `humanlayer thoughts uninit --force` followed by re-init with the config's profile/directory. Previously exited 0 silently on drift.
- **`check-setup.sh`** and **`setup-catalyst/SKILL.md`** now recommend the working incantation (`uninit && init`, or the self-healing `init-or-repair` script). The previous `humanlayer thoughts init --force` suggestion does NOT actually update an existing repo→profile mapping — verified on the Adva repo.

## Why `uninit` is needed

`humanlayer thoughts init --force` recreates symlinks but does not update humanlayer's stored `repoMappings[$cwd].profile`. Only `uninit` drops the stale mapping so a subsequent `init` can register the correct one. Content is safe — it lives in the canonical thoughts repo, not in the local symlink target.

## Test plan

- [x] `bash plugins/dev/scripts/test-thoughts-repair.sh` — 10/10 groups pass (was 8/8; added 2 new groups for profile drift and directory drift auto-fix)
- [x] Existing behavior unchanged: healthy-symlink noop path, regular-directory fatal path, humanlayer-absent fallback path
- [x] `bash plugins/dev/scripts/catalyst-thoughts.sh check` still exits 0 on this (non-drifted) repo
- [x] Syntax check: `bash -n` passes on all three modified scripts

Closes CTL-91