### PR TITLE
feat(dev): PM kickoff prompt + worktree symlink fix

### DIFF
--- a/plugins/dev/prompts/pm-kickoff.md
+++ b/plugins/dev/prompts/pm-kickoff.md
@@ -1,0 +1,50 @@
+You're the Product Manager for this project.
+
+Your job: plan, prioritize, and define work — and surface well-shaped feature ideas
+that move the product forward. Think in outcomes, users, and trade-offs, not output.
+
+## What you have
+
+The `catalyst-pm` plugin is installed. Use its skills freely — browse them as
+`/catalyst-pm:<skill>`:
+
+- **Planning & prioritization**: `daily-plan`, `weekly-plan`, `weekly-review`,
+  `prioritize` (LNO framework), `groom-backlog`
+- **Definition**: `prd-draft`, `decision-doc`, `napkin-sketch`, `impact-sizing`,
+  `feature-metrics`, `ralph-wiggum` (devil's advocate review)
+- **Research & discovery**: `user-interview`, `user-research-synthesis`,
+  `interview-guide`, `competitor-analysis`, `journey-map`, `strategy-sprint`
+- **Cycle / milestone health**: `analyze-cycle`, `analyze-milestone`,
+  `status-update`, `launch-checklist`
+- **Post-launch**: `feature-results`, `activation-analysis`, `retention-analysis`
+
+Linear is the source of truth for tickets, cycles, and milestones — reach it via
+the `linearis` CLI. Don't hardcode invocations; reference `/catalyst-dev:linearis`
+for the syntax.
+
+## How to start
+
+Skip generic "what would you like to work on?" prompts. Orient first, then recommend.
+
+1. Pull the active Linear cycle state (via `linearis`) — what's in progress,
+   blocked, unestimated
+2. Check the last ~5 commits on main and any open PRs to get the current direction
+3. Glance at `thoughts/` for recent decision docs, plans, or research
+
+Then give me a crisp read: the state of play, the decisions that feel due, and a
+recommendation for what to focus on right now. Offer to drive with a specific
+skill or dig into a specific area.
+
+If the cycle is empty or quiet, pivot to discovery: propose features from gaps
+you see in the codebase, suggest `competitor-analysis`, or kick off a
+`strategy-sprint`.
+
+## Principles
+
+- **Outcomes over output** — a thing that ships but doesn't move the metric isn't done
+- **Smallest useful shape** — first version is the minimum that tests the hypothesis
+- **Make trade-offs visible** — when there's a cost, name it
+- **Open loops are expensive** — decisions need owners and deadlines
+- **Documentarian, not critic** — document what exists; only suggest changes when asked
+
+Start by getting state, then recommend a move.

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -131,13 +131,13 @@ fi
 # Copy .claude directory if it exists (Claude Code native config)
 if [ -d ".claude" ]; then
 	echo "📋 Copying .claude directory..."
-	cp -r .claude "$WORKTREE_PATH/"
+	cp -R .claude "$WORKTREE_PATH/"
 fi
 
 # Copy .catalyst directory if it exists (Catalyst workflow config)
 if [ -d ".catalyst" ]; then
 	echo "📋 Copying .catalyst directory..."
-	cp -r .catalyst "$WORKTREE_PATH/"
+	cp -R .catalyst "$WORKTREE_PATH/"
 fi
 
 # Pre-trust worktree in Claude Code so no trust dialog appears on first launch

--- a/plugins/dev/scripts/launch-worktree-tab.sh
+++ b/plugins/dev/scripts/launch-worktree-tab.sh
@@ -6,16 +6,21 @@
 # permanent "pm" worktree and on-demand ticket worktrees.
 #
 # Usage:
-#   launch-worktree-tab.sh [--project NAME] <worktree-name> [base-branch] [description]
+#   launch-worktree-tab.sh [--project NAME] [--prompt-file PATH] <worktree-name> [base-branch] [description]
 #
 # Examples:
 #   launch-worktree-tab.sh --project catalyst pm main
+#   launch-worktree-tab.sh --project catalyst --prompt-file /path/to/pm-kickoff.md pm main
 #   launch-worktree-tab.sh --project catalyst CTL-64 main fix-auth
 #   launch-worktree-tab.sh ADV-230 main                  # --project omitted
 #
 # Session naming convention (for Claude's --name + remote-control prefix):
 #   <project>_<worktree>[_<description>]
 # e.g., catalyst_pm, catalyst_CTL-64, catalyst_CTL-64_fix-auth
+#
+# --prompt-file: Path to a file whose contents are passed to claude as the
+# initial positional prompt (interactive mode). Missing file is a non-fatal
+# warning; the tab still opens normally.
 #
 # Must be invoked from the repo root (Warp tab sets `directory`). Expects
 # create-worktree.sh and catalyst-claude.sh in a sibling directory.
@@ -27,9 +32,11 @@ CREATE="${SCRIPT_DIR}/create-worktree.sh"
 CLAUDE_LAUNCHER="${SCRIPT_DIR}/catalyst-claude.sh"
 
 PROJECT=""
+PROMPT_FILE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project) PROJECT="$2"; shift 2 ;;
+    --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
     --) shift; break ;;
     --*) echo "Unknown flag: $1" >&2; exit 2 ;;
     *) break ;;
@@ -77,5 +84,14 @@ fi
 # Forward session name to claude via catalyst-claude.sh (reads CATALYST_WARP_*)
 export CATALYST_WARP_NAME="$SESSION_NAME"
 export CATALYST_WARP_REMOTE="$SESSION_NAME"
+
+if [[ -n "$PROMPT_FILE" ]]; then
+  if [[ -f "$PROMPT_FILE" ]]; then
+    INITIAL_PROMPT="$(<"$PROMPT_FILE")"
+    exec "$CLAUDE_LAUNCHER" "$INITIAL_PROMPT"
+  else
+    echo "⚠️  --prompt-file not found: $PROMPT_FILE — launching without initial prompt" >&2
+  fi
+fi
 
 exec "$CLAUDE_LAUNCHER"


### PR DESCRIPTION
## Summary

Two changes bundled into one PR:

### `fix(dev)`: preserve symlinks when copying `.claude`/`.catalyst` into a new worktree

BSD `cp -r` on macOS dereferences symlinks, which produced noisy "Not a directory" errors every time a new worktree was created (triggered because `.claude/plugins/{dev,meta,pm}` are tracked symlinks → `../../plugins/*`). Switched `create-worktree.sh` to `cp -R`, which preserves symlinks. Was non-fatal before (git already checked out the symlinks correctly) but confusing in tab output.

### `feat(dev)`: PM kickoff prompt + `--prompt-file` flag for `launch-worktree-tab.sh`

Adds `plugins/dev/prompts/pm-kickoff.md` — a reusable starter prompt that puts Claude in a PM mindset (plan, prioritize, define work, generate feature ideas) and points at the relevant `catalyst-pm` skills and the `linearis` CLI.

Extends `launch-worktree-tab.sh` with `--prompt-file PATH`. When supplied, the file's contents are passed to `claude` as the initial positional prompt so the session opens already primed. Missing-file case is a non-fatal warning — the tab still opens.

Intended wire-up in Warp PM tabs:

```
launch-worktree-tab.sh --project <slug> --prompt-file /abs/path/to/pm-kickoff.md pm main
```

## Test plan

- [x] Reproduced `cp -r` → "Not a directory" error and confirmed `cp -R` on macOS preserves symlinks cleanly
- [x] Verified `claude [prompt]` positional-arg usage against `claude --help` — interactive mode accepts a seed prompt
- [ ] Fire the Catalyst PM Warp tab after merge + local config update → Claude should open with the PM kickoff prompt pre-filled
- [ ] Confirm `--prompt-file` gracefully warns (not exits) when path is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)