### PR TITLE
feat(dev): New Worktree One-Shot Warp variant

### DIFF
--- a/plugins/dev/scripts/launch-worktree-tab.sh
+++ b/plugins/dev/scripts/launch-worktree-tab.sh
@@ -6,11 +6,12 @@
 # permanent "pm" worktree and on-demand ticket worktrees.
 #
 # Usage:
-#   launch-worktree-tab.sh [--project NAME] [--prompt-file PATH] <worktree-name> [base-branch] [description]
+#   launch-worktree-tab.sh [--project NAME] [--prompt-file PATH | --prompt STRING] <worktree-name> [base-branch] [description]
 #
 # Examples:
 #   launch-worktree-tab.sh --project catalyst pm main
 #   launch-worktree-tab.sh --project catalyst --prompt-file /path/to/pm-kickoff.md pm main
+#   launch-worktree-tab.sh --project catalyst --prompt '/catalyst-dev:oneshot CTL-123' CTL-123 main
 #   launch-worktree-tab.sh --project catalyst CTL-64 main fix-auth
 #   launch-worktree-tab.sh ADV-230 main                  # --project omitted
 #
@@ -21,6 +22,10 @@
 # --prompt-file: Path to a file whose contents are passed to claude as the
 # initial positional prompt (interactive mode). Missing file is a non-fatal
 # warning; the tab still opens normally.
+#
+# --prompt: Literal string passed to claude as the initial prompt. Use this
+# when the prompt is built from Warp params (e.g., /catalyst-dev:oneshot
+# {{ticket}}). If both --prompt and --prompt-file are given, --prompt wins.
 #
 # Must be invoked from the repo root (Warp tab sets `directory`). Expects
 # create-worktree.sh and catalyst-claude.sh in a sibling directory.
@@ -33,10 +38,12 @@ CLAUDE_LAUNCHER="${SCRIPT_DIR}/catalyst-claude.sh"
 
 PROJECT=""
 PROMPT_FILE=""
+PROMPT_STRING=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project) PROJECT="$2"; shift 2 ;;
     --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
+    --prompt) PROMPT_STRING="$2"; shift 2 ;;
     --) shift; break ;;
     --*) echo "Unknown flag: $1" >&2; exit 2 ;;
     *) break ;;
@@ -84,6 +91,10 @@ fi
 # Forward session name to claude via catalyst-claude.sh (reads CATALYST_WARP_*)
 export CATALYST_WARP_NAME="$SESSION_NAME"
 export CATALYST_WARP_REMOTE="$SESSION_NAME"
+
+if [[ -n "$PROMPT_STRING" ]]; then
+  exec "$CLAUDE_LAUNCHER" "$PROMPT_STRING"
+fi
 
 if [[ -n "$PROMPT_FILE" ]]; then
   if [[ -f "$PROMPT_FILE" ]]; then

--- a/plugins/dev/skills/setup-warp/SKILL.md
+++ b/plugins/dev/skills/setup-warp/SKILL.md
@@ -137,6 +137,8 @@ possible, or sequential questions):
   - Main (always recommended)
   - PM worktree (only for Catalyst-managed projects)
   - New worktree (prompts for branch + optional description)
+  - New worktree one-shot (prompts for ticket, creates worktree, launches Claude
+    with `/catalyst-dev:oneshot {{ticket}}` already queued)
   - Existing worktree (branch picker)
   - Orchestrator (for projects using `/catalyst-dev:orchestrate`)
 - **Setup command** — optional init for the main tab (e.g., `bun install && scripts/setup-env.sh`).
@@ -168,14 +170,15 @@ rm -f ~/.warp/tab_configs/*.toml
 ### 4.2 — Write each TOML
 
 Compute prefix counter starting at 01. For each project in the Phase 3 order, emit each enabled
-variant in this order: Main, PM, New Worktree, Worktree, Orchestrator.
+variant in this order: Main, PM, New Worktree, New Worktree One-Shot, Worktree, Orchestrator.
 
 **Naming conventions**:
-- Emoji per variant: Main `📦`, PM `📋`, New Worktree `🆕`, Worktree `🔀`, Orchestrator `🚀`
-- Color per variant: Main/New/Worktree/Orchestrator → project color. PM → always `blue` (cross-project
-  convention for PM/backlog work).
+- Emoji per variant: Main `📦`, PM `📋`, New Worktree `🆕`, New Worktree One-Shot `🎯`,
+  Worktree `🔀`, Orchestrator `🚀`
+- Color per variant: Main/New/One-Shot/Worktree/Orchestrator → project color. PM → always `blue`
+  (cross-project convention for PM/backlog work).
 - Session name per variant: `<slug>` (main), `<slug>_pm`, `<slug>_<branch>[_<desc>]`,
-  `<slug>_<worktree>`, `<slug>_<tickets>`.
+  `<slug>_<ticket>` (one-shot), `<slug>_<worktree>`, `<slug>_<tickets>`.
 
 ### 4.3 — Templates
 
@@ -241,6 +244,34 @@ description = "Optional short description. Leave blank for none."
 
 `{TICKET_EXAMPLE}` — use a sensible example like `CTL-72` for catalyst, `ADV-230` for Adva, or
 `NEW-1` as fallback.
+
+#### New worktree one-shot tab (prompts for ticket, fires `/catalyst-dev:oneshot`)
+
+Creates the worktree AND launches Claude with the oneshot invocation pre-filled. Intended for
+the walk-away workflow: user types a ticket, hits enter, Claude runs the full research →
+plan → implement → ship pipeline autonomously.
+
+The `--prompt` flag passes a literal string that Warp has already substituted (`{{ticket}}`).
+The worktree name equals the ticket, so `create-worktree.sh` makes a branch matching the
+ticket ID.
+
+```toml
+name = "{DISPLAY} 🎯 New Worktree One-Shot"
+title = "{DISPLAY}: oneshot {{ticket}}"
+color = "{COLOR}"
+
+[[panes]]
+id = "main"
+type = "terminal"
+directory = "{PROJECT_PATH}"
+commands = [
+  "{CATALYST_ROOT}/plugins/dev/scripts/launch-worktree-tab.sh --project {SLUG} --prompt '/catalyst-dev:oneshot {{ticket}}' '{{ticket}}' main",
+]
+
+[params.ticket]
+type = "text"
+description = "Ticket ID (e.g. {TICKET_EXAMPLE}). Worktree/branch = this value; Claude auto-runs /catalyst-dev:oneshot with it."
+```
 
 #### Existing worktree picker tab
 


### PR DESCRIPTION
## Summary

Adds a new Warp tab variant — **New Worktree One-Shot** — that creates a ticket worktree *and* launches Claude with `/catalyst-dev:oneshot {{ticket}}` pre-queued. Walk-away workflow: type ticket, hit enter, the full research → plan → implement → ship pipeline runs autonomously.

## Changes

- `launch-worktree-tab.sh`: new `--prompt STRING` flag that passes a literal prompt string to Claude (complements the existing `--prompt-file PATH`). Used by Warp so `{{ticket}}` can be substituted into the oneshot invocation.
- `setup-warp` skill: documents the new variant — added to Phase 2 variant list, included in Phase 4 ordering (`Main, PM, New, New One-Shot, Worktree, Orch`), emoji (`🎯`), session-name convention (`<slug>_<ticket>`), and a TOML template.

## Test plan

- [x] `bash -n launch-worktree-tab.sh` — syntax clean
- [ ] Open Warp's "Catalyst 🎯 New Worktree One-Shot" tab, enter `CTL-123`, confirm worktree is created at `~/catalyst/wt/catalyst/CTL-123` and Claude launches with `/catalyst-dev:oneshot CTL-123` as the first message
- [ ] Confirm existing "New Worktree" (interactive) tab still works
- [ ] Confirm PM tab (which uses `--prompt-file`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)