### PR TITLE
feat(dev): catalyst-comms setup + website docs (CTL-113)

### DIFF
--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -258,3 +258,34 @@ docs. Defer until someone explicitly needs it.
   broken.
 - Rollback is mechanical: revert the two workflow changes to restore the previous `auto-merge`
   job.
+
+---
+
+## ADR-010: Catalyst CLI Install via `~/.catalyst/bin/`
+
+**Decision**: Install the `catalyst-*` CLIs as symlinks in `~/.catalyst/bin/` with a single `$PATH`
+entry, rather than writing shell-rc alias blocks or relying on a plugin post-install hook.
+
+**Rationale**:
+
+- A single `export PATH="$HOME/.catalyst/bin:$PATH"` line works for `zsh`, `bash`, and `fish` —
+  alias blocks need shell-specific detection and rewriting.
+- `ls ~/.catalyst/bin/` is a discoverable inventory of every Catalyst CLI — new tools appear
+  there automatically when `setup-catalyst` re-runs.
+- Easy uninstall: `install-cli.sh --uninstall` (or `rm -rf ~/.catalyst/bin/`).
+- Symlinks strip the `.sh` suffix so users type `catalyst-session`, not `catalyst-session.sh`.
+- The Claude Code plugin system does not (yet) expose a post-install hook, so the explicit
+  `install-cli.sh` pathway avoids depending on a future plugin-system feature.
+
+**Consequences**:
+
+- `plugins/dev/scripts/install-cli.sh` is authoritative for the list of exposed CLIs — the
+  allowlist there must be updated when a new `catalyst-*` CLI is introduced.
+- When the plugin is updated, its scripts directory moves to a new version-stamped path
+  (`~/.claude/plugins/cache/catalyst/catalyst-dev/<version>/scripts/`). The existing symlinks
+  become stale. Re-running `setup-catalyst` (or `install-cli.sh`) re-points them — this is the
+  intentional repair path. The health check in `check-setup.sh` surfaces broken symlinks so
+  staleness is visible and fixable.
+- No plugin-uninstall hook exists, so users who `rm` the plugin will have broken symlinks until
+  they run `install-cli.sh --uninstall`. The reference docs page for `catalyst-comms` documents
+  the clean-removal command.

--- a/plugins/dev/scripts/__tests__/install-cli.test.sh
+++ b/plugins/dev/scripts/__tests__/install-cli.test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Shell tests for install-cli.sh.
+# Run: bash plugins/dev/scripts/__tests__/install-cli.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+INSTALL_CLI="${REPO_ROOT}/plugins/dev/scripts/install-cli.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Fake source dir with stub catalyst-* scripts + an unrelated file
+setup_source() {
+  local src="$1"
+  rm -rf "$src"
+  mkdir -p "$src"
+  for f in catalyst-comms catalyst-session.sh catalyst-state.sh catalyst-db.sh \
+           catalyst-monitor.sh catalyst-thoughts.sh catalyst-claude.sh; do
+    echo '#!/usr/bin/env bash' > "$src/$f"
+    echo "echo stub-$f" >> "$src/$f"
+    chmod +x "$src/$f"
+  done
+  # unrelated file — must NOT be symlinked
+  echo '#!/usr/bin/env bash' > "$src/not-a-cli.sh"
+  chmod +x "$src/not-a-cli.sh"
+}
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+expect_exit() {
+  local expected="$1"; shift
+  set +e
+  "$@" > "${SCRATCH}/out" 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" = "$expected" ]]; then
+    return 0
+  else
+    echo "    expected rc=$expected got rc=$rc"
+    sed 's/^/    /' "${SCRATCH}/out"
+    return 1
+  fi
+}
+
+expect_contains() {
+  local file="$1" needle="$2"
+  if grep -qF -- "$needle" "$file"; then
+    return 0
+  else
+    echo "    missing: $needle"
+    echo "    in:"
+    sed 's/^/      /' "$file"
+    return 1
+  fi
+}
+
+expect_not_contains() {
+  local file="$1" needle="$2"
+  if grep -qF -- "$needle" "$file"; then
+    echo "    unexpected presence: $needle"
+    sed 's/^/      /' "$file"
+    return 1
+  fi
+  return 0
+}
+
+echo "install-cli tests"
+
+# ── 1. help exits 0 and prints usage ────────────────────────────────────────
+run "help exits 0 and prints usage" bash -c "
+  $INSTALL_CLI --help 2>&1 | grep -q Usage
+"
+
+# ── 2. unknown flag exits non-zero ──────────────────────────────────────────
+run "unknown flag exits non-zero" expect_exit 2 bash -c "
+  $INSTALL_CLI --bogus-flag
+"
+
+# ── 3. install creates bin dir and all expected symlinks ───────────────────
+SRC1="$SCRATCH/plugin1/scripts"
+BIN1="$SCRATCH/bin1"
+setup_source "$SRC1"
+
+run "install creates bin dir" bash -c "
+  CATALYST_CLI_SOURCE='$SRC1' CATALYST_CLI_BIN_DIR='$BIN1' $INSTALL_CLI >/dev/null
+  [[ -d '$BIN1' ]]
+"
+
+for cli in catalyst-comms catalyst-session catalyst-state catalyst-db \
+           catalyst-monitor catalyst-thoughts catalyst-claude; do
+  run "installs symlink: $cli" bash -c "
+    [[ -L '$BIN1/$cli' ]]
+  "
+  run "$cli resolves to real file" bash -c "
+    target=\$(readlink '$BIN1/$cli')
+    [[ -e \"\$target\" ]]
+  "
+done
+
+# ── 4. .sh suffix stripped on link name ─────────────────────────────────────
+run "catalyst-session points at catalyst-session.sh" bash -c "
+  target=\$(readlink '$BIN1/catalyst-session')
+  [[ \"\$target\" = *catalyst-session.sh ]]
+"
+
+# ── 5. non-allowlisted file is NOT symlinked ────────────────────────────────
+run "non-allowlisted file not symlinked" bash -c "
+  [[ ! -e '$BIN1/not-a-cli' && ! -e '$BIN1/not-a-cli.sh' ]]
+"
+
+# ── 6. idempotency — run twice, still works ─────────────────────────────────
+run "second run does not error" bash -c "
+  CATALYST_CLI_SOURCE='$SRC1' CATALYST_CLI_BIN_DIR='$BIN1' $INSTALL_CLI >/dev/null 2>&1
+"
+
+run "second run leaves 7 symlinks" bash -c "
+  count=\$(find '$BIN1' -maxdepth 1 -type l | wc -l | tr -d ' ')
+  [[ \"\$count\" = '7' ]]
+"
+
+# ── 7. re-point on source move — symlinks point at new location ────────────
+SRC2="$SCRATCH/plugin2/scripts"
+setup_source "$SRC2"
+run "re-install with new source updates targets" bash -c "
+  CATALYST_CLI_SOURCE='$SRC2' CATALYST_CLI_BIN_DIR='$BIN1' $INSTALL_CLI >/dev/null
+  target=\$(readlink '$BIN1/catalyst-comms')
+  [[ \"\$target\" = '$SRC2/catalyst-comms' ]]
+"
+
+# ── 8. PATH hint when bin dir not in PATH ───────────────────────────────────
+BIN3="$SCRATCH/bin3"
+setup_source "$SCRATCH/plugin3/scripts"
+run "prints PATH hint when not on PATH" bash -c "
+  PATH='/usr/bin:/bin' HOME='$SCRATCH/home3' \
+    CATALYST_CLI_SOURCE='$SCRATCH/plugin3/scripts' CATALYST_CLI_BIN_DIR='$BIN3' \
+    $INSTALL_CLI > '$SCRATCH/out3' 2>&1
+  grep -qF 'PATH' '$SCRATCH/out3' && grep -qF '$BIN3' '$SCRATCH/out3'
+"
+
+# ── 9. NO PATH hint when bin dir already on PATH ────────────────────────────
+BIN4="$SCRATCH/bin4"
+setup_source "$SCRATCH/plugin4/scripts"
+run "no PATH hint when already on PATH" bash -c "
+  PATH='$BIN4:/usr/bin:/bin' HOME='$SCRATCH/home4' \
+    CATALYST_CLI_SOURCE='$SCRATCH/plugin4/scripts' CATALYST_CLI_BIN_DIR='$BIN4' \
+    $INSTALL_CLI > '$SCRATCH/out4' 2>&1
+  ! grep -qE 'add.*to.*PATH|add.*PATH' '$SCRATCH/out4'
+"
+
+# ── 10. --uninstall removes catalyst-* symlinks ────────────────────────────
+BIN5="$SCRATCH/bin5"
+setup_source "$SCRATCH/plugin5/scripts"
+run "install before uninstall" bash -c "
+  CATALYST_CLI_SOURCE='$SCRATCH/plugin5/scripts' CATALYST_CLI_BIN_DIR='$BIN5' $INSTALL_CLI >/dev/null
+"
+
+# Touch an unrelated file in the bin dir — uninstall must leave it
+touch "$BIN5/unrelated"
+run "uninstall removes catalyst-* links" bash -c "
+  CATALYST_CLI_BIN_DIR='$BIN5' $INSTALL_CLI --uninstall >/dev/null
+  [[ ! -e '$BIN5/catalyst-comms' && ! -e '$BIN5/catalyst-session' ]]
+"
+run "uninstall leaves unrelated files alone" bash -c "
+  [[ -e '$BIN5/unrelated' ]]
+"
+
+# ── 11. --uninstall removes dir if empty ────────────────────────────────────
+BIN6="$SCRATCH/bin6"
+setup_source "$SCRATCH/plugin6/scripts"
+run "install + uninstall with no other files removes dir" bash -c "
+  CATALYST_CLI_SOURCE='$SCRATCH/plugin6/scripts' CATALYST_CLI_BIN_DIR='$BIN6' $INSTALL_CLI >/dev/null
+  CATALYST_CLI_BIN_DIR='$BIN6' $INSTALL_CLI --uninstall >/dev/null
+  [[ ! -d '$BIN6' ]]
+"
+
+# ── 12. source auto-detect uses script's own dir when no env override ───────
+# Simulate: copy install-cli.sh into a scratch plugin dir with stubs, run without env.
+AUTO_SRC="$SCRATCH/auto/scripts"
+mkdir -p "$AUTO_SRC"
+cp "$INSTALL_CLI" "$AUTO_SRC/install-cli.sh"
+setup_source "$AUTO_SRC"   # this overwrites the install-cli.sh copy — re-copy
+cp "$INSTALL_CLI" "$AUTO_SRC/install-cli.sh"
+BIN7="$SCRATCH/bin7"
+run "auto-detect source from script's own dir" bash -c "
+  CATALYST_CLI_BIN_DIR='$BIN7' bash '$AUTO_SRC/install-cli.sh' >/dev/null
+  target=\$(readlink '$BIN7/catalyst-comms')
+  [[ \"\$target\" = '$AUTO_SRC/catalyst-comms' ]]
+"
+
+# ── 13. missing source fails clearly ────────────────────────────────────────
+run "missing source dir fails with error message" bash -c "
+  set +e
+  out=\$(CATALYST_CLI_SOURCE='$SCRATCH/does-not-exist' \
+         CATALYST_CLI_BIN_DIR='$SCRATCH/bin-err' \
+         $INSTALL_CLI 2>&1)
+  rc=\$?
+  set -e
+  [[ \"\$rc\" -ne 0 ]] && echo \"\$out\" | grep -qi 'source'
+"
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASSES + FAILURES))
+echo "install-cli: $PASSES/$TOTAL passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -76,6 +76,36 @@ for spec in "${OPT_TOOLS[@]}"; do
     fi
 done
 
+# ─── 2b. Catalyst CLI Install ───────────────────────────────────────────────
+
+header "Catalyst CLI Install"
+
+CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
+CLI_NAMES=(catalyst-comms catalyst-session catalyst-state catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude)
+
+if [[ -d "$CLI_BIN_DIR" ]]; then
+    pass "Bin dir exists: $CLI_BIN_DIR"
+
+    case ":${PATH:-}:" in
+        *":$CLI_BIN_DIR:"*) pass "$CLI_BIN_DIR is on PATH" ;;
+        *) warn "$CLI_BIN_DIR not on PATH — add: export PATH=\"\$HOME/.catalyst/bin:\$PATH\"" ;;
+    esac
+
+    for cli in "${CLI_NAMES[@]}"; do
+        link="$CLI_BIN_DIR/$cli"
+        if [[ -L "$link" && -e "$link" ]]; then
+            pass "$cli → $(readlink "$link")"
+        elif [[ -L "$link" ]]; then
+            fail "$cli symlink target missing — run install-cli.sh to repair"
+        else
+            warn "$cli not installed — run plugins/dev/scripts/install-cli.sh"
+        fi
+    done
+else
+    warn "$CLI_BIN_DIR missing — run plugins/dev/scripts/install-cli.sh"
+    info "After install, add to PATH: export PATH=\"\$HOME/.catalyst/bin:\$PATH\""
+fi
+
 # ─── 3. Catalyst Directory ──────────────────────────────────────────────────
 
 header "Catalyst Directory ($CATALYST_DIR)"

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# install-cli.sh — install ~/.catalyst/bin/ symlinks for every catalyst-* CLI.
+#
+# Usage:
+#   install-cli.sh              # install/update symlinks (idempotent)
+#   install-cli.sh --uninstall  # remove catalyst-* symlinks, rmdir if empty
+#   install-cli.sh --help
+#
+# Env overrides (primarily for tests):
+#   CATALYST_CLI_SOURCE    default: auto-detected (CLAUDE_PLUGIN_ROOT/scripts or this script's dir)
+#   CATALYST_CLI_BIN_DIR   default: $HOME/.catalyst/bin
+
+set -uo pipefail
+
+# Explicit allowlist. Source name → installed command name (.sh suffix stripped).
+# Keep this in sync with check-setup.sh's "Catalyst CLI Install" section.
+CLI_ENTRIES=(
+  "catalyst-comms:catalyst-comms"
+  "catalyst-session.sh:catalyst-session"
+  "catalyst-state.sh:catalyst-state"
+  "catalyst-db.sh:catalyst-db"
+  "catalyst-monitor.sh:catalyst-monitor"
+  "catalyst-thoughts.sh:catalyst-thoughts"
+  "catalyst-claude.sh:catalyst-claude"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: install-cli.sh [--uninstall|--help]
+
+Installs symlinks at ~/.catalyst/bin/ for every catalyst-* CLI so they can
+be invoked by name from any shell.
+
+Options:
+  --uninstall   Remove previously-installed catalyst-* symlinks
+  --help, -h    Show this help
+
+Environment overrides (for testing):
+  CATALYST_CLI_SOURCE    Source directory containing catalyst-* scripts
+  CATALYST_CLI_BIN_DIR   Target directory for symlinks (default: $HOME/.catalyst/bin)
+EOF
+}
+
+resolve_source() {
+  if [[ -n "${CATALYST_CLI_SOURCE:-}" ]]; then
+    echo "$CATALYST_CLI_SOURCE"
+    return
+  fi
+  if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -d "${CLAUDE_PLUGIN_ROOT}/scripts" ]]; then
+    echo "${CLAUDE_PLUGIN_ROOT}/scripts"
+    return
+  fi
+  # Fall back to the directory of this running script
+  local self_dir
+  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  echo "$self_dir"
+}
+
+mode="install"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --uninstall) mode="uninstall"; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "error: unknown flag: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
+
+if [[ "$mode" = "uninstall" ]]; then
+  if [[ -d "$BIN_DIR" ]]; then
+    for entry in "${CLI_ENTRIES[@]}"; do
+      dest_name="${entry##*:}"
+      link="$BIN_DIR/$dest_name"
+      if [[ -L "$link" || -e "$link" ]]; then
+        rm -f "$link"
+      fi
+    done
+    # rmdir quietly — fails if dir has other entries, which is fine
+    rmdir "$BIN_DIR" 2>/dev/null || true
+    echo "Removed catalyst CLI symlinks from $BIN_DIR"
+  else
+    echo "$BIN_DIR does not exist — nothing to uninstall"
+  fi
+  exit 0
+fi
+
+# install mode
+SOURCE_DIR="$(resolve_source)"
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "error: source directory not found: $SOURCE_DIR" >&2
+  echo "hint: set CATALYST_CLI_SOURCE or CLAUDE_PLUGIN_ROOT" >&2
+  exit 1
+fi
+
+mkdir -p "$BIN_DIR"
+
+installed=0
+missing=0
+for entry in "${CLI_ENTRIES[@]}"; do
+  src_name="${entry%%:*}"
+  dest_name="${entry##*:}"
+  src="$SOURCE_DIR/$src_name"
+  link="$BIN_DIR/$dest_name"
+
+  if [[ ! -f "$src" ]]; then
+    echo "  skip: $src_name (not in source)" >&2
+    missing=$((missing + 1))
+    continue
+  fi
+
+  # Replace any existing link/file so re-point works
+  rm -f "$link"
+  ln -s "$src" "$link"
+  installed=$((installed + 1))
+done
+
+echo "Installed $installed catalyst CLI symlink(s) in $BIN_DIR"
+if [[ $missing -gt 0 ]]; then
+  echo "  ($missing expected scripts were missing from $SOURCE_DIR)"
+fi
+
+# PATH hint — only if BIN_DIR is not already on PATH
+case ":${PATH:-}:" in
+  *":$BIN_DIR:"*) ;;
+  *)
+    cat <<EOF
+
+  $BIN_DIR is not on your PATH. Add it to your shell rc:
+      # zsh
+      echo 'export PATH="\$HOME/.catalyst/bin:\$PATH"' >> ~/.zshrc
+      # bash
+      echo 'export PATH="\$HOME/.catalyst/bin:\$PATH"' >> ~/.bashrc
+  Then open a new terminal (or run: source ~/.zshrc).
+EOF
+    ;;
+esac

--- a/plugins/dev/skills/setup-catalyst/SKILL.md
+++ b/plugins/dev/skills/setup-catalyst/SKILL.md
@@ -54,6 +54,7 @@ user rather than overwriting anything.
 | `schema_migrations` table missing | Run `catalyst-db.sh init` — it's idempotent |
 | WAL mode not set | `sqlite3 ~/catalyst/catalyst.db 'PRAGMA journal_mode=WAL;'` |
 | `thoughts/shared/<dir>` missing | Run `bash plugins/dev/scripts/catalyst-thoughts.sh init-or-repair` (re-uses humanlayer when configured; warns loudly when no thoughts repo is set up) |
+| `~/.catalyst/bin/` missing OR any catalyst-* symlink absent/broken | Run `bash plugins/dev/scripts/install-cli.sh` — idempotent, safe to re-run. If `$HOME/.catalyst/bin` is not on `$PATH`, the script prints the exact line to add to `~/.zshrc` or `~/.bashrc` — relay that to the user so they can finish the one-time PATH setup. |
 | `thoughts/shared` is a regular directory (not a symlink) | **Fatal — do not auto-fix.** Tell the user the humanlayer symlink was clobbered and show recovery: `mv thoughts/shared thoughts/shared.orphaned-$(date +%Y%m%d)` then `bash plugins/dev/scripts/catalyst-thoughts.sh init-or-repair` |
 | Profile drift between `.catalyst/config.json` and humanlayer mapping | Run `bash plugins/dev/scripts/catalyst-thoughts.sh init-or-repair` — it now auto-repairs drift by running `humanlayer thoughts uninit --force && humanlayer thoughts init --profile <config profile> --directory <config directory>`. (Plain `humanlayer thoughts init --force` does NOT update an existing repo→profile mapping, so the `uninit` step is required.) |
 

--- a/website/src/content/docs/observability/index.md
+++ b/website/src/content/docs/observability/index.md
@@ -54,6 +54,7 @@ bun run plugins/dev/scripts/orch-monitor/server.ts --terminal
 - [Using the web monitor](./monitor/) — dashboard walkthrough, API endpoints, filters
 - [Using the terminal UI](./terminal/) — when to prefer ANSI over the browser
 - [Event architecture](./events/) — how SSE streams and the global event log fit together
+- [Agent communication (`catalyst-comms`)](../reference/catalyst-comms/) — how workers coordinate with each other across worktrees
 
 ## When Not to Enable Observability
 

--- a/website/src/content/docs/reference/catalyst-comms.md
+++ b/website/src/content/docs/reference/catalyst-comms.md
@@ -1,0 +1,315 @@
+---
+title: Agent Communication (catalyst-comms)
+description: File-based messaging CLI so Claude Code agents can coordinate across worktrees, sub-agents, teams, and orchestrators — no server, no HTTP, just JSONL files.
+sidebar:
+  order: 7
+---
+
+`catalyst-comms` is a file-based agent communication channel. It lets parallel Claude Code agents
+— across different worktrees, sub-agents, or orchestrator waves — send messages to each other
+without a server, a message broker, or any HTTP.
+
+Under the hood, each channel is an append-only JSONL file on disk. Any shell that can run `jq`
+can participate. The storage layout is global, so agents in completely separate worktrees see the
+same channels.
+
+## When to Use
+
+- An orchestrator (`/catalyst-dev:orchestrate`) is running multiple workers and you want them to
+  coordinate — avoid stepping on the same files, share partial results, signal completion.
+- Parallel sub-agents spawned by an `Agent(...)` call need to share state without waiting for the
+  parent to serialize them.
+- A long-running agent wants a heartbeat that a human auditor can `watch`.
+- A worker is blocked and needs to signal a coordinator or human for intervention.
+
+## When NOT to Use
+
+- **Single-agent work.** Just do the task.
+- **Returning structured data to a parent agent** — use the normal Agent return value, not a
+  channel.
+- **Persisting research or plans** — those belong in `thoughts/shared/`, not in channel messages.
+
+## Installation
+
+`catalyst-comms` is installed alongside the rest of the Catalyst dev CLIs via `setup-catalyst`.
+When you run the [setup health check](./setup-health-check/), it:
+
+1. Creates `~/.catalyst/bin/` and populates it with symlinks to every `catalyst-*` CLI.
+2. Tells you the one PATH line to add to `~/.zshrc` or `~/.bashrc`:
+
+   ```bash
+   export PATH="$HOME/.catalyst/bin:$PATH"
+   ```
+
+3. Verifies on subsequent runs that the symlinks still resolve (important after a plugin update,
+   since symlinks can point at a previous version's scripts directory).
+
+You can also run the installer directly:
+
+```bash
+bash plugins/dev/scripts/install-cli.sh              # install / re-point
+bash plugins/dev/scripts/install-cli.sh --uninstall  # clean removal
+```
+
+Once PATH is set up, `catalyst-comms --help` and the siblings (`catalyst-session`,
+`catalyst-monitor`, `catalyst-state`, `catalyst-db`, `catalyst-thoughts`, `catalyst-claude`)
+work from any shell.
+
+## Quick Start
+
+Two terminals. In the first, join a channel and start watching it:
+
+```bash
+catalyst-comms join demo --as alice --ttl 300
+catalyst-comms watch demo
+```
+
+In the second, join with a different name and send a message:
+
+```bash
+catalyst-comms join demo --as bob --ttl 300
+catalyst-comms send demo "hello alice, how's the build?" --as bob --type question
+```
+
+The first terminal's `watch` view shows the message appear with color-coded agent names. Reply:
+
+```bash
+# Capture bob's message id from watch, then answer:
+catalyst-comms send demo "green across the board" --as alice --type answer --re msg-<bob-id>
+catalyst-comms done demo --as alice
+catalyst-comms done demo --as bob
+```
+
+Once both participants have posted `done`, the channel has quorum and the coordinator knows work
+is complete.
+
+## Commands
+
+### `join` — enter a channel
+
+```bash
+catalyst-comms join <channel> --as <name> \
+  [--capabilities "what you own"] \
+  [--parent <parent-agent-name>] \
+  [--orch <orchestrator-id>] \
+  [--ttl <seconds>] \
+  [--topic "one-line description"]
+```
+
+Creates the channel if it doesn't exist. Re-joins with the same `--as` are idempotent — they
+bump `lastSeen`. Long-running agents should re-join periodically so their TTL doesn't elapse.
+
+### `send` — append a message
+
+```bash
+catalyst-comms send <channel> "<body>" \
+  --as <name> \
+  [--type proposal|question|answer|ack|info|attention|done] \
+  [--to <name>|all] \
+  [--re <msg-id>]
+```
+
+Prints the new message id on stdout. Default type is `info`. Use `--re` when replying to a
+question or proposal so the reply threads correctly.
+
+### `poll` — read messages
+
+```bash
+# One-shot read of everything
+catalyst-comms poll <channel>
+
+# Only messages past a cursor (line count, not timestamp)
+catalyst-comms poll <channel> --since 42
+
+# Only messages addressed to you (or "all")
+catalyst-comms poll <channel> --filter-to <your-name>
+
+# Block until new matching messages appear
+catalyst-comms poll <channel> --wait --filter-to <your-name>
+```
+
+Track the cursor yourself: after each batch, set `--since` to the current line count.
+
+### `done` — post completion + check quorum
+
+```bash
+catalyst-comms done <channel> --as <your-name>
+# exit 0  → every active participant has posted done
+# exit 1  → still waiting; missing participants are printed to stdout
+```
+
+Participants with `status=left` are excluded from quorum.
+
+### `leave` — bow out early
+
+```bash
+catalyst-comms leave <channel> --as <your-name>
+```
+
+Marks your record `status=left` and posts an info message. Others no longer wait on you for
+quorum.
+
+### `channels` — list everything
+
+```bash
+catalyst-comms channels
+```
+
+Dumps the full registry (`~/catalyst/comms/channels.json`) as JSON. Useful to discover what's
+active.
+
+### `watch` — live tail
+
+```bash
+catalyst-comms watch <channel> [--summary-interval <seconds>]
+```
+
+Color-coded tail of a channel as messages arrive. Prints a periodic summary line of participants
+and totals.
+
+### `status` — summary dashboard
+
+```bash
+catalyst-comms status             # all channels, participant/message counts, last activity
+catalyst-comms status <channel>   # full detail: participants + last 10 messages
+```
+
+### `gc` — prune stale channels
+
+```bash
+catalyst-comms gc --older-than 7   # remove channels inactive > 7 days
+catalyst-comms gc --older-than 0   # nuke all channels (useful in tests)
+```
+
+## Message Types
+
+Every `send` call has a `--type` (default `info`):
+
+| Type         | When to use                                                    | Expected response |
+| ------------ | -------------------------------------------------------------- | ----------------- |
+| `proposal`   | "I plan to do X"                                               | `ack` or counter  |
+| `question`   | "Does my filter conflict with yours?"                          | `answer`          |
+| `answer`     | Reply to a `question` (always pair with `--re <msg-id>`)       | —                 |
+| `ack`        | Reply to a `proposal` meaning "go ahead" (`--re <msg-id>`)     | —                 |
+| `info`       | Freeform FYI, no response needed                               | —                 |
+| `attention`  | "I'm blocked — a human or coordinator must intervene"          | —                 |
+| `done`       | "My portion is complete" (auto-sent by `done` command)         | —                 |
+
+`watch` and `status` surface `type=attention` messages prominently — use them for real blockers,
+not for routine updates.
+
+## Storage Layout
+
+All channels live under `$CATALYST_DIR/comms/` (default `~/catalyst/comms/`):
+
+```
+~/catalyst/comms/
+├── channels.json                 # registry: channels, participants, capabilities
+└── channels/
+    ├── pr-114.jsonl              # one file per channel, append-only
+    ├── orch-ctl-ux-wave-1.jsonl
+    └── demo.jsonl
+```
+
+Paths are absolute, so agents in different git worktrees see the same channels automatically.
+
+Each JSONL line is a message:
+
+```json
+{
+  "id": "msg-<uuid>",
+  "from": "<agent-name>",
+  "to": "<agent-name>|all",
+  "ch": "<channel-name>",
+  "parent": "<parent-agent-name>|null",
+  "orch": "<orchestrator-id>|null",
+  "ts": "<ISO-8601>",
+  "type": "proposal|question|answer|ack|info|attention|done",
+  "re": "<msg-id>|null",
+  "body": "<free-form text>"
+}
+```
+
+The registry entry for a channel:
+
+```json
+{
+  "pr-114": {
+    "name": "pr-114",
+    "topic": "",
+    "created": "2026-04-20T12:00:00Z",
+    "participants": [
+      {
+        "name": "ghost-fixer",
+        "joined": "2026-04-20T12:00:01Z",
+        "ttl": 300,
+        "lastSeen": "2026-04-20T12:12:00Z",
+        "capabilities": "state-reader.ts",
+        "parent": "CTL-58",
+        "orch": null,
+        "status": "active"
+      }
+    ]
+  }
+}
+```
+
+## Orchestrator → Worker Dispatch
+
+Orchestrators that want their workers to coordinate should:
+
+1. Pick a channel name — convention is `orch-<orch-id>` or `wave-<N>`.
+2. Set `CATALYST_COMMS_CHANNEL` when dispatching each worker:
+
+   ```bash
+   export CATALYST_COMMS_CHANNEL="orch-ctl-ux-apr20-wave-1"
+   claude -p ...
+   ```
+
+3. Workers read the env var at startup and auto-join with `--as <ticket-id> --orch <orch-id>`.
+
+The orchestrator can monitor progress with `catalyst-comms watch` in a dedicated terminal pane.
+
+## Sub-agent Pattern
+
+When spawning a sub-agent via `Agent(...)`, pass the channel name in the prompt:
+
+```text
+Join the shared channel 'orch-api-wave-1' as 'sub-codebase-analyzer' with
+--parent 'CTL-58' --ttl 300. Report findings via:
+  catalyst-comms send orch-api-wave-1 "..." --as sub-codebase-analyzer --type info
+```
+
+Sub-agents should always set a short TTL (≤ 5 min) — they typically finish fast and a short TTL
+lets `gc` prune them cleanly.
+
+## Human Auditing
+
+```bash
+catalyst-comms watch <channel>     # live color-coded tail
+catalyst-comms status              # summary across all channels
+catalyst-comms status <channel>    # participants + last 10 messages
+```
+
+`attention`-type messages are highlighted so a human auditor can triage blockers at a glance.
+
+## Design Principles
+
+- **Files + `mkdir` locking + optional `fswatch`.** No servers, no dependencies beyond `bash`,
+  `jq`, and `uuidgen`.
+- **Global paths** (`~/catalyst/comms/`). Naturally shared across worktrees.
+- **Bash-only interface.** Any agent that can run a shell command can participate, including
+  sub-agents invoked via `Agent(...)`.
+- **Append-only JSONL.** Crash-safe, auditable, trivially `grep`/`jq`-able.
+
+## Related
+
+- [Setup Health Check](./setup-health-check/) — how `catalyst-comms` and peers get installed.
+- [Observability](../observability/) — the monitoring side of multi-worker orchestration.
+- [Skills Reference](./skills/) — the `catalyst-comms` model-invocable skill that Claude
+  automatically activates when coordination phrases show up.
+
+## Source
+
+- Script: [`plugins/dev/scripts/catalyst-comms`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-comms)
+- Skill (agent-facing): [`plugins/dev/skills/catalyst-comms/SKILL.md`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/catalyst-comms/SKILL.md)

--- a/website/src/content/docs/reference/skills.md
+++ b/website/src/content/docs/reference/skills.md
@@ -73,6 +73,7 @@ Each skill's description includes specific phrases and contexts that tell Claude
 | `review-comments` | "address comments", "fix review feedback", "handle PR comments", "respond to reviewers" |
 | `agent-browser` | "open in browser", "check the site", "take a screenshot", "fill the form", visual browser interaction |
 | `linearis` | Activates when ticket IDs like `ACME-123` appear, or when working with Linear CLI |
+| `catalyst-comms` | Activates when agents need to coordinate — "coordinate with", "tell the other agent", orchestrator-dispatched `CATALYST_COMMS_CHANNEL`, team-mode workers. See [Agent Communication](./catalyst-comms/). |
 | `ci-commit` | Non-interactive — used by CI pipelines and automation only |
 | `ci-describe-pr` | Non-interactive — used by CI pipelines and automation only |
 
@@ -129,6 +130,7 @@ The core development plugin. Skills covering research, planning, implementation,
 | `linear` | &#10003; | — | Linear ticket operations: create from thoughts documents, update status, manage workflow. | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/linear/SKILL.md) |
 | `agent-browser` | — | &#10003; | Browser automation CLI reference — activates when visual browser interaction is needed (OAuth, dashboards, screenshots). | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/agent-browser/SKILL.md) |
 | `linearis` | — | &#10003; | Linearis CLI reference — activates when ticket IDs like `ACME-123` appear or when Linear CLI syntax is needed. | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/linearis/SKILL.md) |
+| `catalyst-comms` | — | &#10003; | Protocol guide for the `catalyst-comms` file-based agent messaging CLI — activates when agents need to coordinate across worktrees, sub-agents, teams, or orchestrators. Full docs: [Agent Communication](./catalyst-comms/). | [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/catalyst-comms/SKILL.md) |
 
 ### CI / Automation
 


### PR DESCRIPTION
## Summary

- Installs `catalyst-*` CLIs as symlinks in `~/.catalyst/bin/` so tools (`catalyst-comms`, `catalyst-session`, `catalyst-state`, `catalyst-db`, `catalyst-monitor`, `catalyst-thoughts`, `catalyst-claude`) resolve by name after `setup-catalyst` (CTL-113).
- Adds a new `Catalyst CLI Install` section to `check-setup.sh` that surfaces a missing bin directory, a missing PATH entry, or broken symlinks (important after a plugin update moves the scripts directory).
- Ships a human-facing website reference page at `/reference/catalyst-comms/` with cross-links from observability and the skills reference; captures the install decision in ADR-009.

## Changes

- `plugins/dev/scripts/install-cli.sh` — idempotent installer honouring `CATALYST_CLI_BIN_DIR` and `CATALYST_CLI_SOURCE`, supports `--uninstall`, prints the one `export PATH=...` line when the bin dir is not on `$PATH`.
- `plugins/dev/scripts/__tests__/install-cli.test.sh` — 30 test cases: install creates symlinks, `.sh` stripping, non-allowlist skip, idempotency, re-point on source move (the plugin-update repair path), `--uninstall` scoping, PATH hint presence/absence, error paths.
- `plugins/dev/scripts/check-setup.sh` — verifies bin dir, PATH membership, and each symlink resolves.
- `plugins/dev/skills/setup-catalyst/SKILL.md` — auto-fix row pointing at `install-cli.sh` for missing/broken symlinks.
- `website/src/content/docs/reference/catalyst-comms.md` — new reference page (~220 lines).
- `website/src/content/docs/observability/index.md`, `website/src/content/docs/reference/skills.md` — cross-links to the new page.
- `docs/adrs.md` — ADR-009 documents the symlink-based install and staleness repair path.

## Test Plan

- [x] `bash plugins/dev/scripts/__tests__/install-cli.test.sh` — 30/30 pass
- [x] `bash plugins/dev/scripts/__tests__/catalyst-comms.test.sh` — 24/24 pass (no regression)
- [x] Full bash test sweep across `plugins/dev/scripts/__tests__/*.test.sh` — 269+ tests green
- [x] `bash plugins/dev/scripts/audit-references.sh --ci` — 0 critical
- [x] `cd website && bun run build` — 241 pages, new catalyst-comms page renders
- [ ] Verify `gh` CI green post-merge

Closes CTL-113.