### PR TITLE
feat(dev): OTel config cleanup + Loki-backed UI panels (CTL-118)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/otel-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/otel-config.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { loadOtelConfig } from "../lib/otel-config";
+import { loadOtelConfig, _resetDeprecationWarning } from "../lib/otel-config";
 
 let tmpDir: string;
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "otel-config-test-"));
+  _resetDeprecationWarning();
 });
 
 afterEach(() => {
@@ -25,7 +26,28 @@ describe("loadOtelConfig", () => {
     expect(cfg.lokiUrl).toBeNull();
   });
 
-  it("reads otel config from config.json", () => {
+  it("reads otel config from config.json using new key names", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "config.json"),
+      JSON.stringify({
+        otel: {
+          enabled: true,
+          prometheusUrl: "http://localhost:9098",
+          lokiUrl: "http://localhost:3100",
+        },
+      }),
+    );
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const cfg = loadOtelConfig(tmpDir);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.prometheusUrl).toBe("http://localhost:9098");
+    expect(cfg.lokiUrl).toBe("http://localhost:3100");
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("reads otel config from config.json using deprecated key names with warning", () => {
     mkdirSync(tmpDir, { recursive: true });
     writeFileSync(
       join(tmpDir, "config.json"),
@@ -37,10 +59,110 @@ describe("loadOtelConfig", () => {
         },
       }),
     );
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
     const cfg = loadOtelConfig(tmpDir);
     expect(cfg.enabled).toBe(true);
     expect(cfg.prometheusUrl).toBe("http://localhost:9098");
     expect(cfg.lokiUrl).toBe("http://localhost:3100");
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = String(warn.mock.calls[0]?.[0] ?? "");
+    expect(msg).toContain("otel.prometheus");
+    expect(msg).toContain("otel.loki");
+    expect(msg).toContain("prometheusUrl");
+    expect(msg).toContain("lokiUrl");
+    warn.mockRestore();
+  });
+
+  it("prefers new keys over deprecated when both are present (no warning)", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "config.json"),
+      JSON.stringify({
+        otel: {
+          enabled: true,
+          prometheus: "http://old-prom:9098",
+          prometheusUrl: "http://new-prom:9098",
+          loki: "http://old-loki:3100",
+          lokiUrl: "http://new-loki:3100",
+        },
+      }),
+    );
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const cfg = loadOtelConfig(tmpDir);
+    expect(cfg.prometheusUrl).toBe("http://new-prom:9098");
+    expect(cfg.lokiUrl).toBe("http://new-loki:3100");
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("emits deprecation warning only once per process across multiple loads", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "config.json"),
+      JSON.stringify({ otel: { enabled: true, prometheus: "http://p:9098" } }),
+    );
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    loadOtelConfig(tmpDir);
+    loadOtelConfig(tmpDir);
+    loadOtelConfig(tmpDir);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("reads projectKey-scoped file first when projectKey is provided", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "config-myproj.json"),
+      JSON.stringify({
+        otel: {
+          enabled: true,
+          prometheusUrl: "http://scoped-prom:9098",
+          lokiUrl: "http://scoped-loki:3100",
+        },
+      }),
+    );
+    writeFileSync(
+      join(tmpDir, "config.json"),
+      JSON.stringify({
+        otel: {
+          enabled: true,
+          prometheusUrl: "http://global-prom:9098",
+          lokiUrl: "http://global-loki:3100",
+        },
+      }),
+    );
+    const cfg = loadOtelConfig(tmpDir, "myproj");
+    expect(cfg.prometheusUrl).toBe("http://scoped-prom:9098");
+    expect(cfg.lokiUrl).toBe("http://scoped-loki:3100");
+  });
+
+  it("falls back to global config.json when projectKey-scoped file is missing", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "config.json"),
+      JSON.stringify({
+        otel: {
+          enabled: true,
+          prometheusUrl: "http://global-prom:9098",
+          lokiUrl: "http://global-loki:3100",
+        },
+      }),
+    );
+    const cfg = loadOtelConfig(tmpDir, "nonexistent-proj");
+    expect(cfg.prometheusUrl).toBe("http://global-prom:9098");
+    expect(cfg.lokiUrl).toBe("http://global-loki:3100");
+  });
+
+  it("reads global file when projectKey is null", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "config.json"),
+      JSON.stringify({
+        otel: { enabled: true, prometheusUrl: "http://p:9098" },
+      }),
+    );
+    const cfg = loadOtelConfig(tmpDir, null);
+    expect(cfg.prometheusUrl).toBe("http://p:9098");
   });
 
   it("defaults enabled to false when otel key exists but enabled is missing", () => {
@@ -49,7 +171,7 @@ describe("loadOtelConfig", () => {
       join(tmpDir, "config.json"),
       JSON.stringify({
         otel: {
-          prometheus: "http://localhost:9098",
+          prometheusUrl: "http://localhost:9098",
         },
       }),
     );
@@ -84,8 +206,8 @@ describe("loadOtelConfig", () => {
       JSON.stringify({
         otel: {
           enabled: false,
-          prometheus: "http://file-prom:9098",
-          loki: "http://file-loki:3100",
+          prometheusUrl: "http://file-prom:9098",
+          lokiUrl: "http://file-loki:3100",
         },
       }),
     );

--- a/plugins/dev/scripts/orch-monitor/__tests__/project-key.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/project-key.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { detectProjectKey } from "../lib/project-key";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "project-key-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("detectProjectKey", () => {
+  it("returns null when .catalyst/config.json does not exist", () => {
+    expect(detectProjectKey(tmpDir)).toBeNull();
+  });
+
+  it("returns null when .catalyst/config.json is malformed", () => {
+    mkdirSync(join(tmpDir, ".catalyst"), { recursive: true });
+    writeFileSync(join(tmpDir, ".catalyst", "config.json"), "not json{{{");
+    expect(detectProjectKey(tmpDir)).toBeNull();
+  });
+
+  it("returns null when catalyst key is absent", () => {
+    mkdirSync(join(tmpDir, ".catalyst"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".catalyst", "config.json"),
+      JSON.stringify({ other: "value" }),
+    );
+    expect(detectProjectKey(tmpDir)).toBeNull();
+  });
+
+  it("returns null when projectKey is missing", () => {
+    mkdirSync(join(tmpDir, ".catalyst"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".catalyst", "config.json"),
+      JSON.stringify({ catalyst: { project: { ticketPrefix: "ABC" } } }),
+    );
+    expect(detectProjectKey(tmpDir)).toBeNull();
+  });
+
+  it("returns null when projectKey is empty string", () => {
+    mkdirSync(join(tmpDir, ".catalyst"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".catalyst", "config.json"),
+      JSON.stringify({ catalyst: { projectKey: "" } }),
+    );
+    expect(detectProjectKey(tmpDir)).toBeNull();
+  });
+
+  it("returns the projectKey when present", () => {
+    mkdirSync(join(tmpDir, ".catalyst"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".catalyst", "config.json"),
+      JSON.stringify({ catalyst: { projectKey: "my-project" } }),
+    );
+    expect(detectProjectKey(tmpDir)).toBe("my-project");
+  });
+
+  it("returns null when projectKey is not a string", () => {
+    mkdirSync(join(tmpDir, ".catalyst"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".catalyst", "config.json"),
+      JSON.stringify({ catalyst: { projectKey: 42 } }),
+    );
+    expect(detectProjectKey(tmpDir)).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/otel-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-config.ts
@@ -7,6 +7,20 @@ interface OtelConfig {
   lokiUrl: string | null;
 }
 
+interface FileRead {
+  enabled: boolean;
+  prometheusUrl: string | null;
+  lokiUrl: string | null;
+  deprecatedKeys: string[];
+}
+
+let warnedDeprecatedKeys = false;
+
+// Exposed for tests only.
+export function _resetDeprecationWarning(): void {
+  warnedDeprecatedKeys = false;
+}
+
 function isRecord(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null && !Array.isArray(x);
 }
@@ -15,23 +29,83 @@ function stripTrailingSlashes(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
-export function loadOtelConfig(configDir: string): OtelConfig {
+function readOtelFromFile(filePath: string): FileRead | null {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.otel)) return null;
+
+  const otel = parsed.otel;
+  const out: FileRead = {
+    enabled: false,
+    prometheusUrl: null,
+    lokiUrl: null,
+    deprecatedKeys: [],
+  };
+
+  if (typeof otel.enabled === "boolean") out.enabled = otel.enabled;
+
+  if (typeof otel.prometheusUrl === "string" && otel.prometheusUrl) {
+    out.prometheusUrl = otel.prometheusUrl;
+  } else if (typeof otel.prometheus === "string" && otel.prometheus) {
+    out.prometheusUrl = otel.prometheus;
+    out.deprecatedKeys.push("otel.prometheus");
+  }
+
+  if (typeof otel.lokiUrl === "string" && otel.lokiUrl) {
+    out.lokiUrl = otel.lokiUrl;
+  } else if (typeof otel.loki === "string" && otel.loki) {
+    out.lokiUrl = otel.loki;
+    out.deprecatedKeys.push("otel.loki");
+  }
+
+  return out;
+}
+
+export function loadOtelConfig(
+  configDir: string,
+  projectKey?: string | null,
+): OtelConfig {
+  const paths: string[] = [];
+  if (projectKey) paths.push(join(configDir, `config-${projectKey}.json`));
+  paths.push(join(configDir, "config.json"));
+
   let fileEnabled = false;
   let filePrometheus: string | null = null;
   let fileLoki: string | null = null;
+  const deprecatedKeys = new Set<string>();
 
-  try {
-    const raw = readFileSync(join(configDir, "config.json"), "utf8");
-    const parsed: unknown = JSON.parse(raw);
-    if (isRecord(parsed) && isRecord(parsed.otel)) {
-      const otel = parsed.otel;
-      if (typeof otel.enabled === "boolean") fileEnabled = otel.enabled;
-      if (typeof otel.prometheus === "string" && otel.prometheus)
-        filePrometheus = otel.prometheus;
-      if (typeof otel.loki === "string" && otel.loki) fileLoki = otel.loki;
-    }
-  } catch {
-    // config file missing or malformed — use defaults
+  for (const p of paths) {
+    const result = readOtelFromFile(p);
+    if (result === null) continue;
+    fileEnabled = result.enabled;
+    filePrometheus = result.prometheusUrl;
+    fileLoki = result.lokiUrl;
+    for (const k of result.deprecatedKeys) deprecatedKeys.add(k);
+    break;
+  }
+
+  if (deprecatedKeys.size > 0 && !warnedDeprecatedKeys) {
+    warnedDeprecatedKeys = true;
+    const mapping: Record<string, string> = {
+      "otel.prometheus": "otel.prometheusUrl",
+      "otel.loki": "otel.lokiUrl",
+    };
+    const hints = Array.from(deprecatedKeys)
+      .map((k) => `${k} → ${mapping[k] ?? k}`)
+      .join(", ");
+    console.warn(
+      `[otel-config] Deprecated keys in use: ${hints}. These will be removed in a future release.`,
+    );
   }
 
   const envEnabled = process.env.OTEL_ENABLED;

--- a/plugins/dev/scripts/orch-monitor/lib/project-key.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/project-key.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+export function detectProjectKey(cwd: string): string | null {
+  try {
+    const raw = readFileSync(join(cwd, ".catalyst", "config.json"), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || !isRecord(parsed.catalyst)) return null;
+    const key = parsed.catalyst.projectKey;
+    return typeof key === "string" && key ? key : null;
+  } catch {
+    return null;
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -49,6 +49,7 @@ import {
 } from "./lib/preview-status";
 import { writeMergedSignalFile } from "./lib/signal-writer";
 import { loadOtelConfig } from "./lib/otel-config";
+import { detectProjectKey } from "./lib/project-key";
 import {
   createPrometheusFetcher,
   type PrometheusFetcher,
@@ -1253,8 +1254,10 @@ if (import.meta.main) {
   const compact = process.argv.includes("--compact");
   const renderOpts: RenderOptions = { compact };
 
+  const projectKey = detectProjectKey(process.cwd());
   const otelCfg = loadOtelConfig(
     process.env.CATALYST_CONFIG_DIR ?? `${process.env.HOME}/.config/catalyst`,
+    projectKey,
   );
 
   if (terminalOnly) {

--- a/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
@@ -60,6 +60,8 @@ function Monitor() {
     analytics,
     linear,
     otelHealth,
+    otelTools,
+    otelErrors,
     staleThreshold,
   } = useMonitor();
 
@@ -289,6 +291,9 @@ function Monitor() {
                   selectedSessionId={selectedSession}
                   onSessionSelect={handleSessionSelect}
                   timeFilter={timeFilter}
+                  otelConfigured={otelHealth?.configured === true}
+                  otelTools={otelTools}
+                  otelErrors={otelErrors}
                 />
               </div>
             )}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/api-errors-panel.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/api-errors-panel.tsx
@@ -1,0 +1,117 @@
+import { AlertTriangle } from "lucide-react";
+import { Panel, PanelHeader, SectionLabel } from "./ui/panel";
+import { EmptyState } from "./ui/empty-state";
+import type { OtelLogEntry } from "@/lib/types";
+
+interface ApiErrorsPanelProps {
+  errors: OtelLogEntry[] | null;
+  configured: boolean;
+}
+
+const MAX_ROWS = 5;
+const MAX_MSG_CHARS = 120;
+
+export function ApiErrorsPanel({ errors, configured }: ApiErrorsPanelProps) {
+  if (!configured) return null;
+
+  return (
+    <Panel>
+      <PanelHeader className="flex items-center justify-between">
+        <SectionLabel>API errors · last 1h</SectionLabel>
+        <AlertTriangle className="h-3.5 w-3.5 text-muted" />
+      </PanelHeader>
+      <div>{renderBody(errors)}</div>
+    </Panel>
+  );
+}
+
+function renderBody(errors: OtelLogEntry[] | null) {
+  if (errors === null) {
+    return (
+      <div className="flex flex-col gap-1.5 p-3">
+        {Array.from({ length: MAX_ROWS }).map((_, i) => (
+          <div
+            key={i}
+            className="h-4 animate-pulse rounded bg-surface-3 opacity-60"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (errors.length === 0) {
+    return (
+      <EmptyState icon={AlertTriangle} message="No API errors in the last hour" />
+    );
+  }
+
+  // Loki streams aren't guaranteed to arrive newest-first when concatenated across streams.
+  const sorted = [...errors].sort((a, b) => tsCompare(b.timestamp, a.timestamp));
+  const recent = sorted.slice(0, MAX_ROWS);
+
+  return (
+    <div>
+      {recent.map((entry, i) => {
+        const ts = formatTimestamp(entry.timestamp);
+        const kind = entry.labels["error_type"] ?? entry.labels["level"] ?? "error";
+        const msg = truncate(extractMessage(entry.line), MAX_MSG_CHARS);
+        return (
+          <div
+            key={i}
+            className="flex items-baseline gap-2 border-b border-border-subtle px-3 py-1.5 font-mono text-[12px] last:border-b-0"
+          >
+            <span className="shrink-0 text-muted tabular-nums">{ts}</span>
+            <span className="shrink-0 rounded bg-[#5a2a2a] px-1.5 py-px text-[10px] uppercase tracking-wider text-[#f4a8a8]">
+              {kind}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-fg" title={entry.line}>
+              {msg}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatTimestamp(ts: string): string {
+  // Loki timestamps are nanoseconds as strings; fall back to raw when unparseable.
+  const ms = parseLokiTimestamp(ts);
+  if (ms === null) return ts.slice(0, 8);
+  const d = new Date(ms);
+  return d.toLocaleTimeString("en-US", { hour12: false });
+}
+
+function parseLokiTimestamp(ts: string): number | null {
+  if (!/^\d+$/.test(ts)) {
+    const d = Date.parse(ts);
+    return Number.isFinite(d) ? d : null;
+  }
+  // Nanoseconds → ms
+  const n = Number(ts);
+  if (!Number.isFinite(n)) return null;
+  return Math.floor(n / 1_000_000);
+}
+
+function tsCompare(a: string, b: string): number {
+  const am = parseLokiTimestamp(a);
+  const bm = parseLokiTimestamp(b);
+  if (am !== null && bm !== null) return am - bm;
+  return a.localeCompare(b);
+}
+
+function extractMessage(line: string): string {
+  try {
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    const body = parsed["body"] ?? parsed["message"] ?? parsed["msg"];
+    if (typeof body === "string") return body;
+  } catch {
+    // Not JSON; fall through to raw line.
+  }
+  return line;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/dashboard.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/dashboard.tsx
@@ -12,6 +12,8 @@ import { PrBadge } from "./ui/pr-badge";
 import { KpiStrip } from "./kpi-strip";
 import { AttentionBar } from "./attention-bar";
 import { EventLog } from "./event-log";
+import { ToolUsagePanel } from "./tool-usage-panel";
+import { ApiErrorsPanel } from "./api-errors-panel";
 import type {
   OrchestratorState,
   SessionTimeFilter,
@@ -20,6 +22,7 @@ import type {
   EventEntry,
   SessionState,
   SessionKind,
+  OtelLogEntry,
 } from "@/lib/types";
 import { sessionKind } from "@/lib/types";
 import {
@@ -44,6 +47,9 @@ interface DashboardProps {
   selectedSessionId?: string | null;
   onSessionSelect?: (sessionId: string) => void;
   timeFilter: SessionTimeFilter;
+  otelConfigured: boolean;
+  otelTools: Record<string, number> | null;
+  otelErrors: OtelLogEntry[] | null;
 }
 
 function OrchestratorCard({
@@ -233,6 +239,9 @@ export function Dashboard({
   selectedSessionId,
   onSessionSelect,
   timeFilter,
+  otelConfigured,
+  otelTools,
+  otelErrors,
 }: DashboardProps) {
   const { needsMe, shipping, recent } = partitionDashboard({
     orchestrators,
@@ -246,6 +255,13 @@ export function Dashboard({
       <h1 className="text-lg font-bold text-fg">Dashboard</h1>
 
       <KpiStrip orchestrators={orchestrators} getAnalytics={getAnalytics} />
+
+      {otelConfigured && (
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          <ToolUsagePanel tools={otelTools} configured={otelConfigured} />
+          <ApiErrorsPanel errors={otelErrors} configured={otelConfigured} />
+        </div>
+      )}
 
       {needsMe.length > 0 && (
         <section aria-labelledby="zone-needs-me-heading">

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/tool-usage-panel.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/tool-usage-panel.tsx
@@ -1,0 +1,69 @@
+import { Wrench } from "lucide-react";
+import { Panel, PanelHeader, SectionLabel } from "./ui/panel";
+import { EmptyState } from "./ui/empty-state";
+
+interface ToolUsagePanelProps {
+  tools: Record<string, number> | null;
+  configured: boolean;
+}
+
+const MAX_ROWS = 8;
+
+export function ToolUsagePanel({ tools, configured }: ToolUsagePanelProps) {
+  if (!configured) return null;
+
+  return (
+    <Panel>
+      <PanelHeader className="flex items-center justify-between">
+        <SectionLabel>Tool usage · last 1h</SectionLabel>
+        <Wrench className="h-3.5 w-3.5 text-muted" />
+      </PanelHeader>
+      <div className="p-3">{renderBody(tools)}</div>
+    </Panel>
+  );
+}
+
+function renderBody(tools: Record<string, number> | null) {
+  if (tools === null) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-4 animate-pulse rounded bg-surface-3 opacity-60"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const entries = Object.entries(tools).sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0) {
+    return <EmptyState icon={Wrench} message="No tool usage in the last hour" />;
+  }
+
+  const top = entries.slice(0, MAX_ROWS);
+  const maxCount = top[0]?.[1] ?? 1;
+
+  return (
+    <div className="flex flex-col gap-1.5 font-mono text-[12px]">
+      {top.map(([name, count]) => {
+        const pct = Math.max(4, Math.round((count / maxCount) * 100));
+        return (
+          <div key={name} className="flex items-center gap-2">
+            <span className="w-24 shrink-0 truncate text-fg">{name}</span>
+            <div className="relative h-3 flex-1 overflow-hidden rounded bg-surface-3">
+              <div
+                className="h-full bg-gradient-to-r from-accent to-green"
+                style={{ width: pct + "%" }}
+              />
+            </div>
+            <span className="w-10 shrink-0 text-right tabular-nums text-muted">
+              {count}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-monitor.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-monitor.ts
@@ -10,6 +10,7 @@ import type {
   OrchestratorState,
   SessionState,
   OtelHealth,
+  OtelLogEntry,
 } from "@/lib/types";
 import { derivePrVariant } from "../../../lib/pr-variant";
 
@@ -101,6 +102,10 @@ export function useMonitor() {
   const [attention, setAttention] = useState<CollectedAttention[]>([]);
   const [sessions, setSessions] = useState<SessionState[]>([]);
   const [otelHealth, setOtelHealth] = useState<OtelHealth | null>(null);
+  const [otelTools, setOtelTools] = useState<Record<string, number> | null>(
+    null,
+  );
+  const [otelErrors, setOtelErrors] = useState<OtelLogEntry[] | null>(null);
 
   const prevWorkerRef = useRef<Map<string, WorkerPrev>>(new Map());
   const seenAttentionRef = useRef<Set<string>>(new Set());
@@ -437,6 +442,41 @@ export function useMonitor() {
     return () => clearInterval(id);
   }, []);
 
+  // OTel tools + errors polling (only when OTel is configured)
+  const otelConfigured = otelHealth?.configured === true;
+  useEffect(() => {
+    if (!otelConfigured) {
+      setOtelTools(null);
+      setOtelErrors(null);
+      return;
+    }
+    async function refreshTools() {
+      try {
+        const resp = await fetch("/api/otel/tools?range=1h");
+        if (!resp.ok) return;
+        const body = (await resp.json()) as {
+          data: Record<string, number> | null;
+        };
+        setOtelTools(body.data);
+      } catch {}
+    }
+    async function refreshErrors() {
+      try {
+        const resp = await fetch("/api/otel/errors?range=1h&limit=10");
+        if (!resp.ok) return;
+        const body = (await resp.json()) as { data: OtelLogEntry[] | null };
+        setOtelErrors(body.data);
+      } catch {}
+    }
+    refreshTools();
+    refreshErrors();
+    const id = setInterval(() => {
+      refreshTools();
+      refreshErrors();
+    }, 30000);
+    return () => clearInterval(id);
+  }, [otelConfigured]);
+
   const getAnalytics = useCallback(
     (orchId: string) => analytics.get(orchId) || {},
     [analytics],
@@ -456,6 +496,8 @@ export function useMonitor() {
     linear: getLinear,
     sessions,
     otelHealth,
+    otelTools,
+    otelErrors,
     staleThreshold: STALE_THRESHOLD,
   };
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
@@ -255,6 +255,12 @@ export interface OtelHealth {
   loki: OtelEndpointHealth;
 }
 
+export interface OtelLogEntry {
+  timestamp: string;
+  line: string;
+  labels: Record<string, string>;
+}
+
 export type CommsMessageType =
   | "proposal"
   | "question"

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -246,17 +246,18 @@ Never committed. One file per project, linked by `projectKey`.
 
 Only configure the integrations you use. The setup script prompts for each one.
 
-### Monitor OTel Config (`~/.config/catalyst/config.json`)
+### Monitor OTel Config
 
-The orchestration monitor reads OpenTelemetry backend endpoints from a global config file at
-`~/.config/catalyst/config.json`. This file is separate from the per-project secrets files.
+The orchestration monitor reads OpenTelemetry backend endpoints from the per-project secrets
+file `~/.config/catalyst/config-<projectKey>.json` (layer 2). If that file is not present it
+falls back to the global `~/.config/catalyst/config.json`.
 
 ```json
 {
   "otel": {
     "enabled": true,
-    "prometheus": "http://localhost:9090",
-    "loki": "http://localhost:3100"
+    "prometheusUrl": "http://localhost:9090",
+    "lokiUrl": "http://localhost:3100"
   }
 }
 ```
@@ -264,11 +265,15 @@ The orchestration monitor reads OpenTelemetry backend endpoints from a global co
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `otel.enabled` | boolean | `false` | Enable OTel proxy endpoints on orch-monitor |
-| `otel.prometheus` | string | `null` | Prometheus query URL (for `/api/otel/query`) |
-| `otel.loki` | string | `null` | Loki query URL (for `/api/otel/logs`) |
+| `otel.prometheusUrl` | string | `null` | Prometheus query URL (for `/api/otel/query` and cost/token panels) |
+| `otel.lokiUrl` | string | `null` | Loki query URL (for `/api/otel/logs`, Tool Usage, and API Errors panels) |
 
 Environment variable overrides: `OTEL_ENABLED`, `PROMETHEUS_URL`, `LOKI_URL`. Env vars take
 precedence over the file when both are set.
+
+**Deprecated names**: the monitor still accepts `otel.prometheus` and `otel.loki` for one
+release cycle, but emits a deprecation warning on startup. Rename to `otel.prometheusUrl` and
+`otel.lokiUrl` to silence the warning.
 
 If you're running the [claude-code-otel](https://github.com/ryanrozich/claude-code-otel) Docker
 Compose stack locally, the defaults above match the standard ports. For hosted backends (Grafana


### PR DESCRIPTION
Closes CTL-118.

## Part 1 — Config cleanup

`loadOtelConfig` now:

- accepts an optional `projectKey` argument and reads from
  `~/.config/catalyst/config-<projectKey>.json` first, falling back to the
  global `~/.config/catalyst/config.json` — matching the layer-2 convention
  that every other Catalyst integration uses;
- accepts both the new key names (`otel.prometheusUrl`, `otel.lokiUrl`, matching
  the TS types) and the old names (`otel.prometheus`, `otel.loki`) for one
  release cycle, emitting a single deprecation warning per process when old
  names are found;
- detects `projectKey` via a new `detectProjectKey(cwd)` helper that reads
  `.catalyst/config.json`.

`server.ts` now calls `detectProjectKey(process.cwd())` and passes the result to
`loadOtelConfig`. Env-var overrides (`OTEL_ENABLED`, `PROMETHEUS_URL`, `LOKI_URL`)
are unchanged.

The ticket flagged `.catalyst/config.json.catalyst.otel` as dead schema — verified
the field is already absent from the committed config and the documented layer-1
schema, so no removal is needed. Decision: OTel config lives in layer-2 only.

## Part 2 — Loki-backed UI panels

`/api/otel/tools` and `/api/otel/errors` have been live on the server for a
while with no UI consumer. Wired both into the dashboard:

- **Tool Usage** — top-8 tools by invocation count over the last hour, rendered
  as a horizontal bar list next to the cost/token KPIs.
- **API Errors** — last 5 error events, sorted newest-first, rendered in an
  `EventLog`-style feed in the same row.

Both panels:

- poll at 30s (matches the existing `/api/health/otel` cadence);
- hide entirely when `otelHealth.configured === false`;
- show a skeleton → empty state → populated progression;
- go through `useMonitor()` so there's no direct fetch from the components.

## Docs

`website/src/content/docs/reference/configuration.md` — rewrote the OTel section
for the new file path, new key names, and added a deprecation callout.

## Test plan

- [x] `bun test __tests__/otel-config.test.ts __tests__/project-key.test.ts` → 21 pass
- [x] `bun run typecheck` → clean
- [x] `bun run lint` → clean (1 pre-existing security warning in `preview-status.ts`)
- [x] UI `tsc --noEmit` → only pre-existing `kpi-strip.tsx abandoned` error, not mine
- [ ] Manual: launch monitor with live OTel stack, confirm panels render with real data; confirm they hide when `otel.enabled=false`
- [ ] Manual: launch monitor with a config file using old key names, confirm deprecation warning is logged once

## Acceptance criteria

- [x] `otel.prometheusUrl` / `otel.lokiUrl` keys work; old names log a deprecation warning but still work for 1 release
- [x] Config read path honors `~/.config/catalyst/config-<projectKey>.json` first, falls back to `~/.config/catalyst/config.json`
- [x] Decision documented for `.catalyst/config.json.catalyst.otel` (not wired — already absent from schema/docs)
- [x] Tool Usage panel renders from Loki with real tool counts
- [x] API Errors feed renders from Loki with the last N error events
- [x] Both panels disappear cleanly when OTel is unconfigured
- [x] `check-setup.sh` validates the new config location (already did — reads from projectKey-scoped path)
- [x] Docs updated

Linear: [CTL-118](https://linear.app/catalyst-labs/issue/CTL-118)