### PR TITLE
feat(dev): static mockup harness + gallery (CTL-125)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/README.md
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/README.md
@@ -1,0 +1,132 @@
+# Mockup harness
+
+Static HTML mockups served directly by the orch-monitor Bun server (no Vite, no auth, no build step
+per mockup). One `.html` file per screen. Shared harness files live in `_shared/`.
+
+## What lives here
+
+| File         | Role                                                                          |
+| ------------ | ----------------------------------------------------------------------------- |
+| `tokens.css` | Auto-generated from `@catalyst/tokens`. Both system blocks. **Do not edit.**  |
+| `fonts.css`  | Google Fonts `@import` for both systems' families + fallbacks.                |
+| `base.css`   | Reset + baseline typography + harness utilities (`.mockup-shell`, `.card`, …) |
+| `chrome.css` | Floating switcher pill + popover styling.                                     |
+| `chrome.js`  | Switcher runtime: reads prefs, writes `html[data-system]`, persists.          |
+| `README.md`  | This file.                                                                    |
+
+No `palettes.css`. The harness has one axis — `data-system` — and `tokens.css` already ships both
+system blocks via `[data-system="..."]` selectors. An overlay file would be dead weight.
+
+## Adding a new mockup
+
+1. Create `<name>.html` in `plugins/dev/scripts/orch-monitor/public/mockups/`.
+2. Use the exact load order below in `<head>`.
+3. Copy the inline pre-paint bootstrap IIFE verbatim — it MUST run before first paint or the page
+   flashes the default system before switching.
+4. Put `<script src="./_shared/chrome.js"></script>` at the bottom of `<body>` (no `defer`).
+5. Add a `<a class="card mockup-card">` to the gallery `index.html` linking to the new file.
+
+## Load order inside each `.html`
+
+```html
+<link rel="stylesheet" href="./_shared/tokens.css" />
+<link rel="stylesheet" href="./_shared/fonts.css" />
+<link rel="stylesheet" href="./_shared/base.css" />
+<link rel="stylesheet" href="./_shared/chrome.css" />
+<script>
+  /* pre-paint bootstrap — see below */
+</script>
+<style>
+  /* optional page-specific rules */
+</style>
+```
+
+Body:
+
+```html
+<main class="mockup-shell">
+  <div class="mockup-container">…</div>
+</main>
+<script src="./_shared/chrome.js"></script>
+```
+
+## Pre-paint bootstrap (copy verbatim)
+
+The inline script sits after all `<link>` tags, before `</head>`. It runs synchronously during HTML
+parsing, so `data-system` is set before the browser paints anything.
+
+```html
+<script>
+  (function () {
+    const LS_KEY = "catalyst.mockup.prefs";
+    const DEFAULTS = { system: "operator-console" };
+    const SYSTEMS = ["operator-console", "precision-instrument"];
+    const url = new URLSearchParams(window.location.search);
+    let stored = {};
+    try {
+      stored = JSON.parse(window.localStorage.getItem(LS_KEY) || "{}");
+    } catch (_e) {
+      stored = {};
+    }
+    const candidate = url.get("system") || stored.system || DEFAULTS.system;
+    const system = SYSTEMS.includes(candidate) ? candidate : DEFAULTS.system;
+    document.documentElement.setAttribute("data-system", system);
+    window.__catalystMockupPrefs = { system };
+  })();
+</script>
+```
+
+`chrome.js` picks up `window.__catalystMockupPrefs` to avoid re-parsing the URL and localStorage on
+mount.
+
+## The `data-system` axis
+
+| Value                  | Description                                       |
+| ---------------------- | ------------------------------------------------- |
+| `operator-console`     | Default. Dark canvas, amber accent, grotesk type. |
+| `precision-instrument` | Ivory canvas, ink-blue accent, serif display.     |
+
+`operator-console` is the default because `tokens.css` scopes its block to `:root` in addition to
+`[data-system="operator-console"]`.
+
+### Persistence + clean URL
+
+Priority when resolving the system value:
+
+1. `window.__catalystMockupPrefs` (set by bootstrap above)
+2. `?system=…` URL query param
+3. `localStorage["catalyst.mockup.prefs"].system`
+4. Default (`operator-console`)
+
+When writing back to the URL, the switcher only emits `?system=…` for **non-default** values. A
+default system stays clean (`/mockups/`, not `/mockups/?system=operator-console`). `localStorage` is
+always written.
+
+## Regenerating `tokens.css`
+
+The file in this directory is auto-copied by the tokens package build:
+
+```sh
+cd packages/tokens && bun run build
+```
+
+The build writes `dist/theme.css` and copies it to
+`plugins/dev/scripts/orch-monitor/public/mockups/_shared/tokens.css`. Do not hand-edit the output —
+edit `packages/tokens/tokens/*.json` and rebuild.
+
+## Voice for mockup copy
+
+Per the UX direction docs
+(`thoughts/shared/product/ux-refresh/design-direction-A-operator-console.md` and
+`-B-precision-instrument.md`):
+
+- No emoji.
+- No exclamation marks.
+- Operator voice: declarative, terse, past-tense when possible. Units spelled out. UPPERCASE for
+  state tags (`SHIPPED`, `HOLD`); sentence case for prose.
+
+## Why these files live under `public/`
+
+The orch-monitor backend is a Bun server. `public/` is its static asset root. Files under
+`public/mockups/` are served via a small `/mockups/*` route that mirrors the existing `/public/*`
+block (same `resolveSafeStaticPath` + extension allowlist). No Vite, no auth, no SPA routing.

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/base.css
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/base.css
@@ -1,0 +1,158 @@
+/*
+ * Reset + baseline typography + harness utility classes.
+ * All values read from tokens.css CSS custom properties.
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  background: var(--color-bg);
+  color: var(--color-text-hi);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-body);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  color-scheme: dark;
+}
+
+html[data-system="precision-instrument"] {
+  color-scheme: light;
+}
+
+body {
+  min-height: 100vh;
+}
+
+h1,
+h2,
+h3 {
+  font-family: var(--font-family-display);
+  color: var(--color-text-hi);
+  margin: 0;
+  font-weight: var(--font-weight-medium);
+}
+
+h1 {
+  font-size: var(--font-size-display);
+  line-height: var(--line-height-display);
+  letter-spacing: var(--letter-spacing-display);
+}
+
+h2 {
+  font-size: var(--font-size-title);
+  line-height: var(--line-height-title);
+  letter-spacing: var(--letter-spacing-title);
+}
+
+h3 {
+  font-size: var(--font-size-heading);
+  line-height: var(--line-height-heading);
+}
+
+p {
+  margin: 0;
+  color: var(--color-text-md);
+}
+
+code {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-data);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--spacing-1);
+  color: var(--color-text-hi);
+}
+
+a {
+  color: var(--color-text-hi);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--color-accent);
+}
+
+/* ---------- Harness utility classes ---------- */
+
+.mockup-shell {
+  min-height: 100vh;
+  padding: var(--spacing-8) var(--spacing-6);
+}
+
+.mockup-container {
+  max-width: 1440px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+}
+
+.mockup-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: var(--spacing-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.mockup-topbar__mark {
+  font-family: var(--font-family-display);
+  font-size: var(--font-size-title);
+  letter-spacing: var(--letter-spacing-title);
+  color: var(--color-text-hi);
+}
+
+.eyebrow {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-label);
+  line-height: var(--line-height-label);
+  letter-spacing: var(--letter-spacing-label);
+  text-transform: uppercase;
+  color: var(--color-text-md);
+}
+
+.gallery-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  max-width: 680px;
+}
+
+.card {
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-5);
+  transition: border-color var(--motion-duration-state) var(--motion-easing-standard);
+}
+
+.card:hover {
+  border-color: var(--color-border-strong);
+}
+
+.card-grid {
+  display: grid;
+  gap: var(--spacing-4);
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+.footer {
+  padding: var(--spacing-6) 0;
+  border-top: 1px solid var(--color-border-subtle);
+  color: var(--color-text-lo);
+  font-size: var(--font-size-label);
+  line-height: var(--line-height-label);
+}

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.css
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.css
@@ -1,0 +1,140 @@
+/*
+ * Floating switcher toolbar — top-right pill + expand-on-click popover.
+ * Styles read from tokens.css; switches appearance with the active system.
+ */
+
+.mockup-chrome {
+  position: fixed;
+  top: var(--spacing-4);
+  right: var(--spacing-4);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--spacing-2);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-label);
+  line-height: var(--line-height-label);
+}
+
+.mockup-chrome__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-full);
+  color: var(--color-text-hi);
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  cursor: pointer;
+  transition:
+    border-color var(--motion-duration-state) var(--motion-easing-standard),
+    background-color var(--motion-duration-state) var(--motion-easing-standard);
+}
+
+.mockup-chrome__pill:hover,
+.mockup-chrome__pill:focus-visible {
+  border-color: var(--color-border-strong);
+  outline: none;
+}
+
+.mockup-chrome__pill[aria-expanded="true"] {
+  background: var(--color-surface-3);
+  border-color: var(--color-border-strong);
+}
+
+.mockup-chrome__pill-label {
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-label);
+  color: var(--color-text-md);
+  font-family: var(--font-family-mono);
+}
+
+.mockup-chrome__pill-value {
+  font-family: var(--font-family-display);
+  color: var(--color-text-hi);
+}
+
+.mockup-chrome__pill-caret {
+  width: 8px;
+  height: 8px;
+  border-right: 1px solid var(--color-text-md);
+  border-bottom: 1px solid var(--color-text-md);
+  transform: rotate(45deg);
+  margin-left: var(--spacing-1);
+  transition: transform var(--motion-duration-state) var(--motion-easing-standard);
+}
+
+.mockup-chrome__pill[aria-expanded="true"] .mockup-chrome__pill-caret {
+  transform: rotate(-135deg);
+}
+
+.mockup-chrome__popover {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  min-width: 240px;
+  padding: var(--spacing-4);
+  background: var(--color-surface-3);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+}
+
+.mockup-chrome__popover[hidden] {
+  display: none;
+}
+
+.mockup-chrome__group-label {
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-label);
+  color: var(--color-text-md);
+  font-family: var(--font-family-mono);
+}
+
+.mockup-chrome__options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.mockup-chrome__option {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text-md);
+  transition:
+    background-color var(--motion-duration-state) var(--motion-easing-standard),
+    color var(--motion-duration-state) var(--motion-easing-standard);
+}
+
+.mockup-chrome__option:hover {
+  background: var(--color-surface-2);
+  color: var(--color-text-hi);
+}
+
+.mockup-chrome__option input[type="radio"] {
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  margin: 0;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-full);
+  background: transparent;
+  flex-shrink: 0;
+  transition: border-color var(--motion-duration-state) var(--motion-easing-standard);
+}
+
+.mockup-chrome__option input[type="radio"]:checked {
+  border-color: var(--color-accent);
+  background: radial-gradient(circle, var(--color-accent) 0 3px, transparent 3px 100%);
+}
+
+.mockup-chrome__option--checked {
+  color: var(--color-text-hi);
+}

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.js
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.js
@@ -1,0 +1,181 @@
+/*
+ * Mockup harness chrome — floating switcher that toggles html[data-system].
+ *
+ * Preference priority: window.__catalystMockupPrefs (set by pre-paint bootstrap)
+ *   > URL query string > localStorage > default.
+ *
+ * URL "clean" rule: the default value is never written as a query param —
+ * only non-default values appear in the URL.
+ *
+ * Idempotent: mount() early-returns if a .mockup-chrome element already exists.
+ */
+(function () {
+  const LS_KEY = "catalyst.mockup.prefs";
+  const DEFAULTS = { system: "operator-console" };
+  const SYSTEMS = ["operator-console", "precision-instrument"];
+  const SYSTEM_LABELS = {
+    "operator-console": "Operator Console",
+    "precision-instrument": "Precision Instrument",
+  };
+
+  function readPrefs() {
+    if (window.__catalystMockupPrefs) {
+      return { ...window.__catalystMockupPrefs };
+    }
+    const url = new URLSearchParams(window.location.search);
+    let stored = {};
+    try {
+      stored = JSON.parse(window.localStorage.getItem(LS_KEY) || "{}");
+    } catch (_e) {
+      stored = {};
+    }
+    const candidate = url.get("system") || stored.system || DEFAULTS.system;
+    const system = SYSTEMS.includes(candidate) ? candidate : DEFAULTS.system;
+    return { system };
+  }
+
+  function apply(prefs) {
+    document.documentElement.setAttribute("data-system", prefs.system);
+  }
+
+  function persist(prefs) {
+    try {
+      window.localStorage.setItem(LS_KEY, JSON.stringify(prefs));
+    } catch (_e) {
+      /* localStorage unavailable — URL still round-trips */
+    }
+    const url = new URL(window.location.href);
+    if (prefs.system !== DEFAULTS.system) {
+      url.searchParams.set("system", prefs.system);
+    } else {
+      url.searchParams.delete("system");
+    }
+    window.history.replaceState({}, "", url.toString());
+  }
+
+  function buildPopover(prefs, onChange) {
+    const popover = document.createElement("div");
+    popover.className = "mockup-chrome__popover";
+    popover.hidden = true;
+    popover.setAttribute("role", "group");
+    popover.setAttribute("aria-label", "Visual system");
+
+    const label = document.createElement("span");
+    label.className = "eyebrow mockup-chrome__group-label";
+    label.textContent = "System";
+    popover.appendChild(label);
+
+    const options = document.createElement("div");
+    options.className = "mockup-chrome__options";
+    SYSTEMS.forEach((value) => {
+      const option = document.createElement("label");
+      option.className = "mockup-chrome__option";
+      if (value === prefs.system) {
+        option.classList.add("mockup-chrome__option--checked");
+      }
+
+      const radio = document.createElement("input");
+      radio.type = "radio";
+      radio.name = "system";
+      radio.value = value;
+      radio.checked = value === prefs.system;
+      radio.setAttribute("data-control", "system");
+      radio.addEventListener("change", () => onChange(value));
+
+      const text = document.createElement("span");
+      text.textContent = SYSTEM_LABELS[value];
+
+      option.appendChild(radio);
+      option.appendChild(text);
+      options.appendChild(option);
+    });
+    popover.appendChild(options);
+
+    return popover;
+  }
+
+  function buildPill(prefs) {
+    const pill = document.createElement("button");
+    pill.type = "button";
+    pill.className = "mockup-chrome__pill";
+    pill.setAttribute("aria-haspopup", "true");
+    pill.setAttribute("aria-expanded", "false");
+    pill.setAttribute("aria-label", "Open system switcher");
+
+    const label = document.createElement("span");
+    label.className = "mockup-chrome__pill-label";
+    label.textContent = "System";
+
+    const value = document.createElement("span");
+    value.className = "mockup-chrome__pill-value";
+    value.textContent = SYSTEM_LABELS[prefs.system];
+
+    const caret = document.createElement("span");
+    caret.className = "mockup-chrome__pill-caret";
+    caret.setAttribute("aria-hidden", "true");
+
+    pill.appendChild(label);
+    pill.appendChild(value);
+    pill.appendChild(caret);
+    return pill;
+  }
+
+  function mount(prefs) {
+    if (document.querySelector(".mockup-chrome")) return;
+
+    const state = { ...prefs };
+    const root = document.createElement("div");
+    root.className = "mockup-chrome";
+
+    const pill = buildPill(state);
+    const valueEl = pill.querySelector(".mockup-chrome__pill-value");
+
+    const handleChange = (system) => {
+      if (!SYSTEMS.includes(system)) return;
+      state.system = system;
+      apply(state);
+      persist(state);
+      valueEl.textContent = SYSTEM_LABELS[system];
+      root
+        .querySelectorAll(".mockup-chrome__option")
+        .forEach((el) => el.classList.remove("mockup-chrome__option--checked"));
+      const checkedInput = root.querySelector(`.mockup-chrome__option input[value="${system}"]`);
+      if (checkedInput && checkedInput.parentElement) {
+        checkedInput.parentElement.classList.add("mockup-chrome__option--checked");
+      }
+    };
+
+    const popover = buildPopover(state, handleChange);
+
+    const setOpen = (open) => {
+      popover.hidden = !open;
+      pill.setAttribute("aria-expanded", open ? "true" : "false");
+    };
+
+    pill.addEventListener("click", () => {
+      setOpen(popover.hidden);
+    });
+
+    document.addEventListener("click", (ev) => {
+      if (!root.contains(ev.target)) setOpen(false);
+    });
+
+    document.addEventListener("keydown", (ev) => {
+      if (ev.key === "Escape") setOpen(false);
+    });
+
+    root.appendChild(pill);
+    root.appendChild(popover);
+    document.body.appendChild(root);
+  }
+
+  const prefs = readPrefs();
+  apply(prefs);
+  persist(prefs);
+
+  if (document.readyState !== "loading") {
+    mount(prefs);
+  } else {
+    document.addEventListener("DOMContentLoaded", () => mount(prefs));
+  }
+})();

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/fonts.css
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/fonts.css
@@ -1,0 +1,13 @@
+/*
+ * Shared font imports for both systems.
+ *
+ * System A (Operator Console) — Space Grotesk + IBM Plex Sans + JetBrains Mono.
+ *   All Google Fonts, open source.
+ *
+ * System B (Precision Instrument) — GT Super Display + Söhne + Söhne Mono are
+ *   the licensed targets. Licensed faces are deferred; we load the fallbacks
+ *   that tokens.css references in the font-family chain: Source Serif Pro,
+ *   Inter, and JetBrains Mono (shared with A).
+ */
+
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+Pro:wght@400;600&family=Inter:wght@400;500;600&display=swap");

--- a/plugins/dev/scripts/orch-monitor/public/mockups/index.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/index.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en" data-system="operator-console">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Catalyst Mockups</title>
+    <link rel="stylesheet" href="./_shared/tokens.css" />
+    <link rel="stylesheet" href="./_shared/fonts.css" />
+    <link rel="stylesheet" href="./_shared/base.css" />
+    <link rel="stylesheet" href="./_shared/chrome.css" />
+    <script>
+      // Pre-paint bootstrap — sets html[data-system] before first paint to
+      // prevent flicker. Mirrors chrome.js's resolution priority (URL query
+      // > localStorage > default). chrome.js reads __catalystMockupPrefs to
+      // avoid re-parsing.
+      (function () {
+        const LS_KEY = "catalyst.mockup.prefs";
+        const DEFAULTS = { system: "operator-console" };
+        const SYSTEMS = ["operator-console", "precision-instrument"];
+        const url = new URLSearchParams(window.location.search);
+        let stored = {};
+        try {
+          stored = JSON.parse(window.localStorage.getItem(LS_KEY) || "{}");
+        } catch (_e) {
+          stored = {};
+        }
+        const candidate = url.get("system") || stored.system || DEFAULTS.system;
+        const system = SYSTEMS.includes(candidate) ? candidate : DEFAULTS.system;
+        document.documentElement.setAttribute("data-system", system);
+        window.__catalystMockupPrefs = { system };
+      })();
+    </script>
+    <style>
+      .gallery-header h1 {
+        margin-top: var(--spacing-2);
+      }
+
+      .mockup-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-3);
+      }
+
+      .mockup-card__thumb {
+        aspect-ratio: 16 / 10;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--color-surface-2);
+        border: 1px dashed var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        color: var(--color-text-lo);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-data);
+      }
+
+      .mockup-card--placeholder .mockup-card__thumb {
+        border-style: dashed;
+      }
+
+      .mockup-card__meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        color: var(--color-text-lo);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        letter-spacing: var(--letter-spacing-label);
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="mockup-shell">
+      <div class="mockup-container">
+        <header class="mockup-topbar">
+          <span class="mockup-topbar__mark">catalyst</span>
+          <span class="eyebrow">Mockups</span>
+        </header>
+
+        <section class="gallery-header">
+          <span class="eyebrow">Visual direction preview</span>
+          <h1>Mockup harness</h1>
+          <p>
+            Side-by-side rendering of the Operator Console and Precision Instrument systems. Flip
+            the switcher (top right) to compare. Selection persists to localStorage and the URL.
+          </p>
+        </section>
+
+        <div class="card-grid" role="list">
+          <div class="card mockup-card mockup-card--placeholder" role="listitem">
+            <div class="mockup-card__thumb" aria-hidden="true">—</div>
+            <h3 class="mockup-card__title">No screens yet</h3>
+            <p class="mockup-card__desc">
+              Add a
+              <code>.html</code>
+              file in this directory, then add a card here that links to it. See
+              <code>_shared/README.md</code>
+              for load order and the pre-paint bootstrap script.
+            </p>
+            <div class="mockup-card__meta">
+              <span>Placeholder</span>
+              <span>empty</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="footer">
+          <p>
+            Reload to verify persistence. Try
+            <code>?system=precision-instrument</code>
+            in the URL to hard-set a system. Default stays clean.
+          </p>
+        </div>
+      </div>
+    </main>
+    <script src="./_shared/chrome.js"></script>
+  </body>
+</html>

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1135,6 +1135,31 @@ export function createServer(opts: CreateServerOptions): BunServer {
         }
 
 
+        if (url.pathname === "/mockups" || url.pathname === "/mockups/") {
+          const file = Bun.file(join(publicDir, "mockups", "index.html"));
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            });
+          }
+        }
+
+        if (url.pathname.startsWith("/mockups/")) {
+          const rel = decodeURIComponent(
+            "mockups/" + url.pathname.slice("/mockups/".length),
+          );
+          const safe = resolveSafeStaticPath(publicDir, rel);
+          if (!safe) return new Response("Forbidden", { status: 403 });
+          const file = Bun.file(safe);
+          if (await file.exists()) {
+            const dot = safe.lastIndexOf(".");
+            const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
+            return new Response(file, {
+              headers: { "Content-Type": contentTypeForExt(ext) },
+            });
+          }
+        }
+
         if (url.pathname.startsWith("/public/") || url.pathname.startsWith("/assets/")) {
           const rel = decodeURIComponent(
             url.pathname.startsWith("/public/")


### PR DESCRIPTION
## Summary

Stands up `plugins/dev/scripts/orch-monitor/public/mockups/` — a static HTML mockup harness that consumes the `@catalyst/tokens` output shipped in CTL-123 (PR #241). Mirrors [Adva's `apps/web/public/mockups/` pattern](https://github.com/groundworkapp/Adva), simplified to a single `html[data-system]` axis.

## What shipped

- `_shared/fonts.css` — Google Fonts import for both systems' families + free fallbacks (System B's GT Super / Söhne are licensed and deferred per ticket; falls back to Source Serif Pro / Inter which `tokens.css` already names in its font chain).
- `_shared/base.css` — reset + harness utilities (`.mockup-shell`, `.mockup-container`, `.mockup-topbar`, `.eyebrow`, `.card`, `.card-grid`, `.footer`). All values read from `tokens.css` custom properties.
- `_shared/chrome.css` — floating top-right pill + popover, styled via tokens so it inherits the active system.
- `_shared/chrome.js` — switcher runtime. Resolves preferences with the priority `window.__catalystMockupPrefs → ?system= → localStorage → default`. Applies `html[data-system]`, persists to `localStorage`, and writes the URL back via `history.replaceState` — only emitting `?system=…` for **non-default** values so the default URL stays clean. `mount()` is idempotent (guarded by `querySelector(".mockup-chrome")`).
- `_shared/README.md` — documents load order, the pre-paint bootstrap requirement, the `data-system` axis, persistence + clean-URL rule, how to regenerate `tokens.css`, and the operator voice for mockup copy.
- `index.html` — gallery page. Inline pre-paint bootstrap `<script>` in `<head>` sets `data-system` before first paint to prevent flicker. One placeholder card pointing at `_shared/README.md`.
- `server.ts` — new `/mockups/*` route (25 lines) that mirrors the existing `/public/*` block. Reuses `resolveSafeStaticPath` and the existing extension allowlist — no new surface for path traversal.

## Deviation from the ticket's file list

`palettes.css` is intentionally skipped. The Catalyst harness has one axis (`data-system`), and `tokens.css` already ships both system blocks via `[data-system="..."]` selectors — a palette overlay file would be dead weight. Documented in `_shared/README.md`.

## Acceptance criteria

- [x] `/mockups/` renders the gallery in the orch-monitor dev server.
- [x] Placeholder card with copy explaining how to add mockups.
- [x] Floating switcher (top right) toggles `html[data-system]` between `operator-console` and `precision-instrument`; visible change on the page.
- [x] Switcher choice persists across reloads via localStorage and round-trips through `?system=` URL param.
- [x] Non-default system is reflected in URL; default stays clean.
- [x] `_shared/README.md` documents CSS load order, pre-paint bootstrap requirement, and switcher behavior.
- [x] No auth, no SPA routing, no build step per mockup.
- [x] Pre-paint bootstrap script inline in `<head>` prevents flicker.

## Test plan

**Manual (done via `agent-browser`):**

- [x] Gallery loads at `http://localhost:7411/mockups/` → `data-system=operator-console`, URL clean, localStorage seeded.
- [x] Click switcher → toggle to `precision-instrument` → URL becomes `?system=precision-instrument`, localStorage updates, `getComputedStyle(html).backgroundColor` resolves to `#fafaf7` (the ivory canvas from tokens.css line 81).
- [x] Reload → system persists as `precision-instrument`.
- [x] Switch back to default → URL param is removed (`?system=` cleared), localStorage updated.
- [x] URL param with conflicting localStorage → URL wins.
- [x] Fresh incognito simulation (localStorage cleared) → defaults to `operator-console`.
- [x] Screenshots attached showing both systems rendering the same layout with different tokens.

**Quality gates:**

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors (1 pre-existing warning in `lib/preview-status.ts`, unrelated).
- [x] `bun run knip` — clean.
- [x] `trunk check` (markdownlint, prettier, yamllint) — clean on CTL-125 files.
- [x] `bun test` — 687 pass. 6 pre-existing `catalyst-monitor.sh` failures (confirmed unrelated via `git stash`; CI on main is all-green for the same suite).

Blocked by: none (CTL-123 is merged). Blocks: CTL-126 (brand specimen page).

## Screenshots

### Operator Console (default)

System A renders dark canvas, amber accent, Space Grotesk + IBM Plex Sans.

### Precision Instrument

System B renders ivory canvas, ink-blue accent, Source Serif Pro (stand-in for GT Super) + Inter (stand-in for Söhne).

Both systems use the same layout and copy — only tokens differ.