### PR TITLE
feat(dev): worker comms posting discipline — budgets, escalation, severity (CTL-165)

### DIFF
--- a/plugins/dev/skills/catalyst-comms/SKILL.md
+++ b/plugins/dev/skills/catalyst-comms/SKILL.md
@@ -83,6 +83,94 @@ MSG_ID=$(catalyst-comms send pr-114 "ack, holding" \
   --as frontend-worker --type ack --re msg-abc123)
 ```
 
+## Posting Discipline
+
+The message-type table above defines what each type *means*. This section defines *when*
+a worker should choose each type. Workers that emit `attention` as a heartbeat make the
+orchestrator's NEEDS ATTENTION banner useless and foreclose any real-time interrupt
+pattern (e.g., the Claude Code Monitor tool). Follow these rules.
+
+### 1. Message-Type Semantics (when to choose which)
+
+- **`info`** — the default. Cheap, append-only, never interrupts anyone. Use for phase
+  transitions, PR-opened, "still working", and any FYI a human auditor or the orchestrator
+  *might* read but is not required to act on.
+- **`attention`** — reserved for orchestrator action. The orchestrator promotes every
+  `attention` to a state-level NEEDS ATTENTION item. If you would not interrupt a human
+  for it, do not post it. Default to `info` and ask: "is the orchestrator blocked from
+  making forward progress unless it sees this *now*?" If no, it is `info`.
+- **`done`** — sent only via the `done` subcommand at terminal success. One per worker
+  per session. Never use `send --type done` manually; let the subcommand do it so quorum
+  is auto-checked.
+- **`proposal` / `question` / `answer` / `ack`** — peer-to-peer coordination only. Use
+  when you need a sibling worker to confirm before you proceed (e.g., overlapping file
+  scope). The recipient is expected to reply within minutes; if no reply, treat as `ack`
+  and proceed.
+
+### 2. Volume Budgets
+
+Per worker per session:
+
+| Type        | Budget                                                          |
+|-------------|-----------------------------------------------------------------|
+| `info`      | At phase boundaries + PR-opened only. ~5–7 in the normal path.  |
+| `attention` | **0–2 per worker.** More than 2 means you are using it as info. |
+| `done`      | Exactly 1, on terminal success.                                 |
+| `proposal` / `question` / `answer` / `ack` | As needed for active coordination. |
+
+`info` posts in the middle of a phase ("running tests…", "still here…") are noise. Phase
+transitions are the heartbeat — skip per-step status updates.
+
+`attention` above 2 is a signal that either (a) the worker is mis-categorising routine
+events, or (b) something is genuinely wrong and the worker should stop and write a
+clear final `attention` instead of spamming partial status.
+
+### 3. Mandatory Escalation (when you MUST post `attention`)
+
+These are not discretionary. The worker MUST post exactly one `attention` message —
+clear, single-shot, with a body the orchestrator can act on — when any of these occur:
+
+- **Scope conflict** — your dispatch brief tells you to touch files another worker also
+  owns, or your work has a hard dependency on a sibling worker's output that has not
+  arrived. Body: name the conflicting file/sibling.
+- **Missing access** — required CLI / credential / API not available, and you cannot
+  proceed without it. Body: name the missing thing.
+- **Ambiguous spec** — the ticket / dispatch brief contradicts itself or omits a fact
+  you must have to make a correct choice. Body: state the ambiguity and the two
+  candidate interpretations.
+- **Repeated test/CI failures** — same failure mode 3+ times after distinct fix
+  attempts. Body: failure signature + what you tried.
+- **Stalled merge** — you wrote `status="stalled"` for any reason (merge conflict you
+  cannot resolve, required reviewer you cannot satisfy, branch protection rule you
+  cannot meet). Body: which blocker, which PR.
+
+Do NOT wait for human input before escalating. Post the `attention`, then either
+continue working on what you *can* still do, or exit if the blocker is total.
+
+### 4. Severity Framing (blocking vs nonblocking)
+
+Catalyst uses a binary severity system mapped onto the existing types:
+
+- **blocking** → `attention` (orchestrator must act before forward progress is possible)
+- **nonblocking** → `info` (informational; orchestrator may act eventually)
+
+When in doubt, prefix the body to make severity unambiguous to a human reading the
+channel:
+
+```bash
+# blocking — pairs with --type attention
+catalyst-comms send "$CH" "[blocking] missing GH_TOKEN, cannot create PR" \
+  --as worker-3 --type attention
+
+# nonblocking — pairs with --type info
+catalyst-comms send "$CH" "[nonblocking] codex flagged 1 minor style issue, fixing inline" \
+  --as worker-3 --type info
+```
+
+Workers MAY adopt P1/P2/P3 in the body (`[P1]`, `[P2]`, `[P3]`) for finer grain — but
+only the binary distinction is enforced by the orchestrator. P1/P2/P3 is a body
+convention, not a schema change.
+
 ## Polling and Waiting
 
 ```bash

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -281,6 +281,21 @@ fi
 
 **When worker reaches terminal state** (done or failed):
 
+**Mandatory `attention` on block** (per [[catalyst-comms]] § Posting Discipline §3): in
+addition to the failure path below, the worker MUST also `comms_post attention "<reason>"`
+when it hits any of the following mid-flight, even if it is not yet writing
+`status: "failed"`:
+
+- scope conflict with a sibling worker
+- missing required access (CLI / credential / API)
+- ambiguous spec the worker cannot resolve unilaterally
+- same test/CI failure 3+ times after distinct fix attempts
+- writing `status: "stalled"` from the Phase 5 poll loop
+
+Use a single `attention` per blocker (do not retry). Continue with whatever work is still
+possible, or exit if the blocker is total. The orchestrator's poll loop will promote the
+message to a state-level NEEDS ATTENTION item.
+
 ```bash
 if [ -n "$ORCH_ID" ] && [ -f "$STATE_SCRIPT" ]; then
   if [ "$NEW_STATUS" = "done" ]; then
@@ -878,6 +893,13 @@ error, context exhaustion):
 - **Orchestrator poll loop is now a safety net, not the primary merge confirmation** — if the
   worker reliably writes `pr.mergedAt`, the orchestrator's poll loop is reconciliation only.
   The orchestrator may still re-dispatch a fix-up worker if the primary worker exits stalled
+- **Worker comms discipline** — when posting to the shared comms channel, follow the rules
+  in [[catalyst-comms]] § Posting Discipline: `info` is the default heartbeat (phase
+  transitions only, ~5–7 per session), `attention` is reserved for orchestrator action
+  (0–2 per session, MANDATORY on the escalation triggers listed there — scope conflict,
+  missing access, ambiguous spec, 3+ repeated CI failures, `status="stalled"`), `done`
+  fires once at terminal success via the `done` subcommand. The existing `comms_post`
+  helper in this skill already routes correctly — these rules govern *when* you call it.
 
 **IMPORTANT: Document Storage Rules**
 

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -641,6 +641,15 @@ poll loop is a safety net for stalled workers — if you exit successfully with
 pr.mergedAt set, the orchestrator simply reconciles. If you exit at "stalled" or
 "failed", the orchestrator can dispatch a fix-up worker.
 
+COMMS DISCIPLINE: when posting to the shared comms channel, follow the rules in the
+catalyst-comms skill (plugins/dev/skills/catalyst-comms/SKILL.md § Posting Discipline):
+  - info = phase transitions + PR-opened only (default heartbeat, ~5-7 per session)
+  - attention = orchestrator action required (0-2 per session, MANDATORY on: scope
+    conflict, missing access, ambiguous spec, 3+ repeated CI failures, status=stalled)
+  - done = exactly 1, only via the `done` subcommand at terminal success
+  - never use attention as a heartbeat — it triggers the orchestrator's NEEDS ATTENTION
+    banner
+
 Write your status to the worker signal file at:
   ${ORCH_DIR}/workers/${TICKET_ID}.json
 


### PR DESCRIPTION
## Summary

Adds explicit prompt-level rules for **when** workers should post to the catalyst-comms channel. Closes CTL-165.

Previously, workers could emit `attention` as a heartbeat — making the orchestrator's NEEDS ATTENTION banner useless and foreclosing any real-time interrupt pattern (e.g., the Claude Code Monitor tool). Workers now have explicit message-type semantics, per-session volume budgets, mandatory escalation triggers, and a binary severity framing.

## Changes

| File | Change |
|---|---|
| `plugins/dev/skills/catalyst-comms/SKILL.md` | **+88 lines.** New `## Posting Discipline` section between the Message Types table and Polling. Four subsections: (1) Message-Type Semantics — when to choose info vs attention vs done vs proposal/question/answer/ack; (2) Volume Budgets — per-session caps (info ~5–7, attention 0–2, done 1); (3) Mandatory Escalation — five triggers where the worker MUST post `attention` (scope conflict, missing access, ambiguous spec, repeated CI failures, status=stalled); (4) Severity Framing — binary blocking/nonblocking with optional `[P1]/[P2]/[P3]` body convention. |
| `plugins/dev/skills/oneshot/SKILL.md` | **+22 lines.** Adds a "Worker comms discipline" bullet to the Important list pointing at `[[catalyst-comms]] § Posting Discipline`, plus a "Mandatory `attention` on block" prose block immediately above the existing failure `attention` callsite — so the worker also escalates on mid-flight blockers, not just terminal failure. |
| `plugins/dev/skills/orchestrate/SKILL.md` | **+9 lines.** Adds a `COMMS DISCIPLINE:` block inside the literal worker dispatch prompt (lines 644–651) so workers reading only the dispatch brief don't drift from the rules. |

## Design decisions

1. **Discipline lives in `catalyst-comms` as the single source of truth.** `oneshot` and `orchestrate` reference it via wiki-link / file-path so future edits have one place to change.
2. **Severity = binary blocking/nonblocking** mapped onto existing `attention`/`info` types. Optional `[blocking]`/`[nonblocking]` body prefix as a documentation convention. **No new schema fields.** P1/P2/P3 considered but rejected as heavier than the ticket asked for; allowed as an optional body convention.
3. **Pure prompt content — no behavioural code changed.** Existing `comms_post` callsites are untouched; the new rules only govern *when* the agent calls them.

## Out of scope (per ticket)

Agent cards / A2A registration · addressed / peer-to-peer messages · Monitor tool integration · ccswarm-style pre-execution scope check · message-schema changes.

## Success criteria (from ticket)

- [x] `oneshot` + `catalyst-comms/SKILL.md` have explicit "when to post to comms" sections covering message-type semantics, volume budgets, mandatory escalation, severity framing
- [x] Worker dispatch brief in `orchestrate/SKILL.md` references these rules (no silent drift)
- [x] Existing flow still passes (no schema changes; no behavioural code touched)

## Verification

```
$ git diff --stat
 plugins/dev/skills/catalyst-comms/SKILL.md | 88 +++++++++
 plugins/dev/skills/oneshot/SKILL.md        | 22 ++
 plugins/dev/skills/orchestrate/SKILL.md    |  9 +

$ grep -c "Message-Type Semantics\|Volume Budgets\|Mandatory Escalation\|Severity Framing" \
    plugins/dev/skills/catalyst-comms/SKILL.md
4

$ for f in plugins/dev/skills/{catalyst-comms,oneshot,orchestrate}/SKILL.md; do
    echo "$f: parity=$(($(grep -c '^```' $f) % 2))"
  done
plugins/dev/skills/catalyst-comms/SKILL.md: parity=0
plugins/dev/skills/oneshot/SKILL.md: parity=0
plugins/dev/skills/orchestrate/SKILL.md: parity=0
```

## Test plan

- [x] All code fences balanced in all three modified files
- [x] Both `[[catalyst-comms]]` wiki-links present in oneshot
- [x] `COMMS DISCIPLINE` block present in the orchestrate dispatch prompt
- [x] No schema changes — JSONL message format unchanged
- [x] No behavioural code changed — `git diff` shows only `.md`
- [ ] Next orchestrator run will exercise the new guidance with live workers (out of scope for this PR; verified by future CTL- tickets that share an orchestrator run)

## Refs

- Research: `thoughts/shared/research/2026-04-22-multi-agent-communication-patterns.md` (gastown rules quoted verbatim)
- Research: `thoughts/shared/research/2026-04-22-claude-code-monitor-tool-usage.md` (Monitor not currently used; comms not yet structured to be interrupt-worthy)
- Plan: `thoughts/shared/plans/2026-04-23-CTL-165-worker-comms-prompt-guidance.md`

Linear: CTL-165