### PR TITLE
feat(dev): mockup chrome — clickable home, breadcrumb, ⌘K palette (CTL-166)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/mockup-chrome.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/mockup-chrome.test.ts
@@ -124,6 +124,15 @@ describe("chrome.js file structure — static markers", () => {
     expect(text).toContain("GNAV");
     expect(text).toContain("keydown");
   });
+
+  it("contains CTL-166 nav-shell symbols", async () => {
+    const text = await Bun.file(chromePath).text();
+    expect(text).toContain("mockup-palette");
+    expect(text).toContain("mockup-topbar__crumb");
+    expect(text).toContain("mockup-topbar__chip");
+    expect(text).toContain("mockup-breadcrumb");
+    expect(text).toContain("metaKey");
+  });
 });
 
 describe("chrome.css file — cheatsheet styles exist", () => {
@@ -138,6 +147,160 @@ describe("chrome.css file — cheatsheet styles exist", () => {
     );
     const text = await Bun.file(cssPath).text();
     expect(text).toContain(".mockup-cheatsheet");
+  });
+
+  it("defines CTL-166 nav-shell styles", async () => {
+    const cssPath = join(
+      import.meta.dir,
+      "..",
+      "public",
+      "mockups",
+      "_shared",
+      "chrome.css",
+    );
+    const text = await Bun.file(cssPath).text();
+    expect(text).toContain(".mockup-palette");
+    expect(text).toContain(".mockup-topbar__crumb");
+    expect(text).toContain(".mockup-topbar__chip");
+  });
+});
+
+describe("chrome.js pure helpers — parseBreadcrumb", () => {
+  it("returns empty array for missing/blank input", () => {
+    expect(chrome.parseBreadcrumb("")).toEqual([]);
+    expect(chrome.parseBreadcrumb("   ")).toEqual([]);
+    expect(chrome.parseBreadcrumb(null)).toEqual([]);
+    expect(chrome.parseBreadcrumb(undefined)).toEqual([]);
+  });
+
+  it("returns single segment", () => {
+    expect(chrome.parseBreadcrumb("Home")).toEqual(["Home"]);
+  });
+
+  it("splits on slash with surrounding spaces", () => {
+    expect(chrome.parseBreadcrumb("Monitor / ctl-ux-apr20")).toEqual([
+      "Monitor",
+      "ctl-ux-apr20",
+    ]);
+  });
+
+  it("handles many segments", () => {
+    expect(
+      chrome.parseBreadcrumb("Monitor / orch-2026-04-22-3 / wave 2 / CTL-138"),
+    ).toEqual(["Monitor", "orch-2026-04-22-3", "wave 2", "CTL-138"]);
+  });
+
+  it("trims extra whitespace and drops empty segments", () => {
+    expect(chrome.parseBreadcrumb("  A  /  B  / / C  ")).toEqual(["A", "B", "C"]);
+  });
+});
+
+describe("chrome.js pure helpers — isMacPlatform", () => {
+  it("detects platform=MacIntel", () => {
+    expect(chrome.isMacPlatform({ platform: "MacIntel" })).toBe(true);
+  });
+
+  it("detects platform containing Mac in any case", () => {
+    expect(chrome.isMacPlatform({ platform: "macOS" })).toBe(true);
+  });
+
+  it("returns false for Windows", () => {
+    expect(chrome.isMacPlatform({ platform: "Win32" })).toBe(false);
+  });
+
+  it("returns false for Linux", () => {
+    expect(chrome.isMacPlatform({ platform: "Linux x86_64" })).toBe(false);
+  });
+
+  it("falls back to userAgent when platform is missing", () => {
+    expect(
+      chrome.isMacPlatform({ userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5)" }),
+    ).toBe(true);
+    expect(
+      chrome.isMacPlatform({ userAgent: "Mozilla/5.0 (X11; Linux x86_64)" }),
+    ).toBe(false);
+  });
+
+  it("returns false for empty navigator object", () => {
+    expect(chrome.isMacPlatform({})).toBe(false);
+    expect(chrome.isMacPlatform(null)).toBe(false);
+    expect(chrome.isMacPlatform(undefined)).toBe(false);
+  });
+});
+
+describe("chrome.js pure helpers — paletteActions", () => {
+  it("returns 12 actions (8 nav + 3 appearance + 1 help)", () => {
+    const actions = chrome.paletteActions(chrome.GNAV);
+    expect(actions.length).toBe(12);
+  });
+
+  it("covers every GNAV key with a nav action", () => {
+    const actions = chrome.paletteActions(chrome.GNAV);
+    const navPaths = actions.filter((a) => a.type === "nav").map((a) => a.payload.path);
+    expect(navPaths.sort()).toEqual(Object.values(chrome.GNAV).sort());
+  });
+
+  it("includes all three groups", () => {
+    const actions = chrome.paletteActions(chrome.GNAV);
+    const groups = new Set(actions.map((a) => a.group));
+    expect(groups.has("Navigate")).toBe(true);
+    expect(groups.has("Appearance")).toBe(true);
+    expect(groups.has("Help")).toBe(true);
+  });
+
+  it("labels Orchestrator nav action", () => {
+    const actions = chrome.paletteActions(chrome.GNAV);
+    const orch = actions.find((a) => a.type === "nav" && a.payload.path === "orch.html");
+    expect(orch).toBeDefined();
+    expect(orch?.label).toBe("Orchestrator");
+  });
+
+  it("includes appearance actions for theme/system/palette", () => {
+    const actions = chrome.paletteActions(chrome.GNAV);
+    const appearanceLabels = actions
+      .filter((a) => a.type === "appearance")
+      .map((a) => a.label)
+      .sort();
+    expect(appearanceLabels).toEqual(
+      ["Cycle palette", "Cycle system", "Toggle theme"].sort(),
+    );
+  });
+
+  it("includes a help action for the cheatsheet", () => {
+    const actions = chrome.paletteActions(chrome.GNAV);
+    const help = actions.find((a) => a.type === "help");
+    expect(help).toBeDefined();
+    expect(help?.label.toLowerCase()).toContain("cheat");
+  });
+});
+
+describe("chrome.js pure helpers — filterPaletteActions", () => {
+  const actions: chrome.PaletteAction[] = [
+    { id: "n-h", group: "Navigate", label: "Home", type: "nav", payload: {} },
+    { id: "n-d", group: "Navigate", label: "Orchestrator", type: "nav", payload: {} },
+    { id: "n-w", group: "Navigate", label: "Worker", type: "nav", payload: {} },
+    { id: "a-t", group: "Appearance", label: "Toggle theme", type: "appearance", payload: {} },
+    { id: "h-c", group: "Help", label: "Open cheatsheet", type: "help", payload: {} },
+  ];
+
+  it("returns all actions for empty / whitespace query", () => {
+    expect(chrome.filterPaletteActions(actions, "").length).toBe(actions.length);
+    expect(chrome.filterPaletteActions(actions, "   ").length).toBe(actions.length);
+  });
+
+  it("does case-insensitive substring match on label", () => {
+    expect(chrome.filterPaletteActions(actions, "orch").map((a) => a.id)).toEqual(["n-d"]);
+    expect(chrome.filterPaletteActions(actions, "ORCH").map((a) => a.id)).toEqual(["n-d"]);
+  });
+
+  it("returns empty array when nothing matches", () => {
+    expect(chrome.filterPaletteActions(actions, "zzzz")).toEqual([]);
+  });
+
+  it("matches across groups", () => {
+    expect(chrome.filterPaletteActions(actions, "o").map((a) => a.id).sort()).toEqual(
+      ["a-t", "h-c", "n-d", "n-h", "n-w"].sort(),
+    );
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/README.md
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/README.md
@@ -139,11 +139,32 @@ a cheat-sheet overlay. Bindings never fire while focus is on `input`, `textarea`
 | `p`         | Cycle palette (reserved — no-op until palettes.css) |
 | `/`         | Focus first `input[data-search]` or `input[type=search]` |
 | `?`         | Open the cheat-sheet overlay                        |
+| `⌘K` / `Ctrl K` | Open the command palette                        |
 | `Esc`       | Close any open overlay / popover                    |
 
 Press `?` in-page to see the live cheat sheet. The `g` prefix resets after any key or a 1.5s timeout.
 Pages that don't exist yet (every `g`-nav target besides `h` and `r`) will 404 — add the page and
 the binding just works.
+
+## Topbar nav shell (CTL-166)
+
+Every page ships a static `<header class="mockup-topbar">` with a `catalyst` mark and a
+single eyebrow. `chrome.js` upgrades the topbar on load:
+
+1. The mark becomes an `<a href="./index.html">` so a single click goes back to the gallery.
+2. A breadcrumb is injected in the middle, sourced from the page's
+   `<meta name="mockup-breadcrumb" content="Monitor / orch-2026-04-22 / briefing">`. Segments
+   are split on ` / `. The original eyebrow is removed once the breadcrumb renders to avoid
+   showing the same label twice. If the meta tag is absent or empty, the eyebrow stays put
+   as a fallback.
+3. A `⌘K` (or `Ctrl K` on non-mac) chip is appended on the right. Clicking the chip — or
+   pressing the binding — opens a filterable command palette modal with three sections:
+   **Navigate** (every entry from `GNAV`), **Appearance** (toggle theme, cycle system,
+   cycle palette), and **Help** (open cheat sheet). Type to filter by substring; `↑/↓`
+   to move; `Enter` to execute; `Esc` to close.
+
+The page-body breadcrumbs in `worker.html`, `briefing.html`, and `agent-graph.html` are part
+of the page heading, not the chrome — they stay in place.
 
 ## Voice for mockup copy
 

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.css
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.css
@@ -275,3 +275,231 @@
 .mockup-cheatsheet__label {
   color: var(--color-text-md);
 }
+
+/*
+ * CTL-166 — topbar nav shell.
+ *
+ * The static markup ships as `<header class="mockup-topbar"><span class="mockup-topbar__mark">
+ * catalyst</span><span class="eyebrow">…</span></header>`. chrome.js upgrades it on load —
+ * the mark becomes an anchor, a breadcrumb is injected in the middle, and a ⌘K chip is
+ * appended on the right. These rules style the upgraded shape; base.css still owns the
+ * outer flex container.
+ */
+
+.mockup-topbar {
+  gap: var(--spacing-4);
+}
+
+a.mockup-topbar__mark {
+  text-decoration: none;
+  color: var(--color-text-hi);
+  border-radius: var(--radius-sm);
+  transition: color var(--motion-duration-state) var(--motion-easing-standard);
+}
+
+a.mockup-topbar__mark:hover,
+a.mockup-topbar__mark:focus-visible {
+  color: var(--color-accent);
+  outline: none;
+}
+
+.mockup-topbar__crumb {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-label);
+  line-height: var(--line-height-label);
+  letter-spacing: var(--letter-spacing-label);
+  text-transform: uppercase;
+  color: var(--color-text-md);
+  overflow: hidden;
+}
+
+.mockup-topbar__crumb-segment {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mockup-topbar__crumb-segment:last-child {
+  color: var(--color-text-hi);
+}
+
+.mockup-topbar__crumb-sep {
+  color: var(--color-text-lo);
+  flex-shrink: 0;
+}
+
+.mockup-topbar__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-full);
+  color: var(--color-text-md);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-label);
+  line-height: var(--line-height-label);
+  letter-spacing: var(--letter-spacing-label);
+  cursor: pointer;
+  transition:
+    border-color var(--motion-duration-state) var(--motion-easing-standard),
+    color var(--motion-duration-state) var(--motion-easing-standard);
+}
+
+.mockup-topbar__chip:hover,
+.mockup-topbar__chip:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-text-hi);
+  outline: none;
+}
+
+.mockup-topbar__chip-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  padding: 0 var(--spacing-1);
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-hi);
+}
+
+/*
+ * CTL-166 — command palette overlay. Mirrors the cheatsheet modal pattern with
+ * an input + filtered list. Built lazily by chrome.js the first time the user
+ * opens it.
+ */
+
+.mockup-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.mockup-palette[hidden] {
+  display: none;
+}
+
+.mockup-palette__backdrop {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--color-bg) 70%, transparent);
+  backdrop-filter: blur(2px);
+}
+
+.mockup-palette__modal {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  width: min(560px, 90vw);
+  max-height: 70vh;
+  padding: var(--spacing-4);
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-body);
+  color: var(--color-text-hi);
+}
+
+.mockup-palette__input {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-hi);
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.mockup-palette__input:focus-visible {
+  outline: none;
+  border-color: var(--color-border-strong);
+}
+
+.mockup-palette__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+}
+
+.mockup-palette__group-label {
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-label);
+  color: var(--color-text-md);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-label);
+  padding: var(--spacing-2) var(--spacing-2) 0 var(--spacing-2);
+}
+
+.mockup-palette__row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text-md);
+  transition:
+    background-color var(--motion-duration-state) var(--motion-easing-standard),
+    color var(--motion-duration-state) var(--motion-easing-standard);
+}
+
+.mockup-palette__row:hover,
+.mockup-palette__row--active {
+  background: var(--color-surface-2);
+  color: var(--color-text-hi);
+}
+
+.mockup-palette__row-label {
+  font-family: var(--font-family-body);
+}
+
+.mockup-palette__row-keys {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+.mockup-palette__row-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 0 var(--spacing-1);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-label);
+  line-height: var(--line-height-label);
+  color: var(--color-text-md);
+}
+
+.mockup-palette__empty {
+  padding: var(--spacing-3);
+  color: var(--color-text-lo);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-label);
+  text-align: center;
+}

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.d.ts
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.d.ts
@@ -7,9 +7,30 @@
 export const SYSTEMS: readonly ["operator-console", "precision-instrument"];
 export const THEMES: readonly ["dark", "light"];
 export const GNAV: Readonly<Record<string, string>>;
+export const GNAV_LABELS: Readonly<Record<string, string>>;
 
 export function isTypingTarget(el: unknown): boolean;
 export function shouldIgnoreKey(ev: { key?: string; target?: unknown } | null | undefined): boolean;
 export function nextSystem(current: string): string;
 export function nextTheme(current: string): string;
 export function resolveGNav(key: string): string | undefined;
+
+export function parseBreadcrumb(value: string | null | undefined): string[];
+
+export function isMacPlatform(
+  nav: { platform?: string; userAgent?: string } | null | undefined,
+): boolean;
+
+export type PaletteActionType = "nav" | "appearance" | "help";
+export interface PaletteAction {
+  id: string;
+  group: "Navigate" | "Appearance" | "Help";
+  label: string;
+  hint?: readonly string[];
+  type: PaletteActionType;
+  // `payload.path` for nav actions; `payload.action` for appearance/help.
+  payload: { path?: string; action?: string };
+}
+
+export function paletteActions(gnav: Readonly<Record<string, string>>): PaletteAction[];
+export function filterPaletteActions(actions: PaletteAction[], query: string): PaletteAction[];

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.js
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.js
@@ -16,7 +16,14 @@
  *   p                  — cycle palette (no-op until palettes.css ships)
  *   /                  — focus search input if present
  *   ?                  — open keybinding cheat sheet overlay
+ *   ⌘K / Ctrl K        — open command palette (CTL-166)
  *   Escape             — close any overlay / popover
+ *
+ * Topbar enhancement (CTL-166): once the page loads, chrome.js upgrades the
+ * static `<header class="mockup-topbar">` by (a) turning the catalyst mark
+ * into an `<a href="./index.html">`, (b) injecting a breadcrumb sourced from
+ * `<meta name="mockup-breadcrumb">`, and (c) appending a ⌘K chip on the right
+ * that opens a filterable palette modal.
  *
  * The module is browser-first. A CommonJS export guard at the bottom exposes
  * pure helpers for Bun unit tests — DOM side effects are wrapped in a
@@ -103,6 +110,110 @@
     return Object.prototype.hasOwnProperty.call(GNAV, key) ? GNAV[key] : undefined;
   }
 
+  // CTL-166 — breadcrumb segments come from a per-page meta tag whose value
+  // looks like "Monitor / orch-2026-04-22-3 / wave 2". Split on " / ", trim
+  // each segment, and drop empties so an extra separator doesn't render a
+  // ghost crumb.
+  function parseBreadcrumb(value) {
+    if (typeof value !== "string") return [];
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return [];
+    return trimmed
+      .split("/")
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0);
+  }
+
+  // CTL-166 — used to pick the right modifier glyph (⌘ vs Ctrl). Tests stub
+  // this with a plain `{ platform, userAgent }` object so no real navigator
+  // is required. Falls back to userAgent when platform is missing because
+  // userAgentData / platform are spotty across browsers.
+  function isMacPlatform(nav) {
+    if (!nav || typeof nav !== "object") return false;
+    const platform = typeof nav.platform === "string" ? nav.platform : "";
+    if (platform.toLowerCase().indexOf("mac") !== -1) return true;
+    const ua = typeof nav.userAgent === "string" ? nav.userAgent : "";
+    return ua.toLowerCase().indexOf("mac") !== -1;
+  }
+
+  // CTL-166 — labels rendered in the palette and breadcrumb fallback. Keep in
+  // sync with the cheatsheet's GNAV row labels.
+  const GNAV_LABELS = {
+    "index.html": "Home",
+    "orch.html": "Orchestrator",
+    "worker.html": "Worker",
+    "comms.html": "Comms",
+    "briefing.html": "Briefing",
+    "agent-graph.html": "Agent graph",
+    "todos.html": "Todos",
+    "brand.html": "Brand showcase",
+  };
+
+  // CTL-166 — derive the static palette action list. `gnav` is injected so the
+  // tests can pass the live GNAV table without reaching into module state.
+  // Each action carries the keybinding hint that the cheatsheet already shows
+  // so users learn the shortcut while filtering.
+  function paletteActions(gnav) {
+    const actions = [];
+    Object.keys(gnav).forEach((key) => {
+      const path = gnav[key];
+      const label = GNAV_LABELS[path] || path;
+      actions.push({
+        id: "nav:" + path,
+        group: "Navigate",
+        label,
+        hint: ["g", key],
+        type: "nav",
+        payload: { path },
+      });
+    });
+    actions.push({
+      id: "appearance:toggle-theme",
+      group: "Appearance",
+      label: "Toggle theme",
+      hint: ["⇧", "D"],
+      type: "appearance",
+      payload: { action: "toggleTheme" },
+    });
+    actions.push({
+      id: "appearance:cycle-system",
+      group: "Appearance",
+      label: "Cycle system",
+      hint: ["."],
+      type: "appearance",
+      payload: { action: "cycleSystem" },
+    });
+    actions.push({
+      id: "appearance:cycle-palette",
+      group: "Appearance",
+      label: "Cycle palette",
+      hint: ["p"],
+      type: "appearance",
+      payload: { action: "cyclePalette" },
+    });
+    actions.push({
+      id: "help:cheatsheet",
+      group: "Help",
+      label: "Open cheatsheet",
+      hint: ["?"],
+      type: "help",
+      payload: { action: "openCheatsheet" },
+    });
+    return actions;
+  }
+
+  // CTL-166 — case-insensitive substring filter on `label`. No fuzzy matcher
+  // by design; ticket says substring is good enough for v1.
+  function filterPaletteActions(actions, query) {
+    if (!Array.isArray(actions)) return [];
+    const q = typeof query === "string" ? query.trim().toLowerCase() : "";
+    if (q.length === 0) return actions.slice();
+    return actions.filter((action) => {
+      const label = action && typeof action.label === "string" ? action.label : "";
+      return label.toLowerCase().indexOf(q) !== -1;
+    });
+  }
+
   // ----- CommonJS export guard (used by Bun unit tests; skipped in browser) -----
 
   if (typeof module !== "undefined" && module.exports) {
@@ -110,11 +221,16 @@
       SYSTEMS,
       THEMES,
       GNAV,
+      GNAV_LABELS,
       isTypingTarget,
       shouldIgnoreKey,
       nextSystem,
       nextTheme,
       resolveGNav,
+      parseBreadcrumb,
+      isMacPlatform,
+      paletteActions,
+      filterPaletteActions,
     };
   }
 
@@ -330,6 +446,266 @@
     }
   }
 
+  // ----- Topbar enhancement (CTL-166) -----
+  //
+  // The static markup ships with a `<span class="mockup-topbar__mark">` and a
+  // `<span class="eyebrow">…</span>` per page. We turn the mark into a real
+  // anchor and inject a breadcrumb sourced from `<meta name="mockup-breadcrumb">`
+  // (or `window.__catalystMockupBreadcrumb` for pages that prefer to set it via
+  // script). The original eyebrow is removed once the breadcrumb is rendered to
+  // keep the topbar from showing the same label twice.
+
+  function readBreadcrumbMeta() {
+    if (typeof document === "undefined") return "";
+    if (typeof window !== "undefined" && typeof window.__catalystMockupBreadcrumb === "string") {
+      return window.__catalystMockupBreadcrumb;
+    }
+    const meta = document.querySelector('meta[name="mockup-breadcrumb"]');
+    return meta && typeof meta.getAttribute === "function"
+      ? meta.getAttribute("content") || ""
+      : "";
+  }
+
+  function buildBreadcrumb(segments) {
+    const nav = document.createElement("nav");
+    nav.className = "mockup-topbar__crumb";
+    nav.setAttribute("aria-label", "Breadcrumb");
+    segments.forEach((segment, idx) => {
+      if (idx > 0) {
+        const sep = document.createElement("span");
+        sep.className = "mockup-topbar__crumb-sep";
+        sep.setAttribute("aria-hidden", "true");
+        sep.textContent = "/";
+        nav.appendChild(sep);
+      }
+      const span = document.createElement("span");
+      span.className = "mockup-topbar__crumb-segment";
+      span.textContent = segment;
+      if (idx === segments.length - 1) {
+        span.setAttribute("aria-current", "page");
+      }
+      nav.appendChild(span);
+    });
+    return nav;
+  }
+
+  function buildKeybindChip(palettePresenter) {
+    const isMac = isMacPlatform(window.navigator || {});
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "mockup-topbar__chip";
+    button.setAttribute("aria-label", "Open command palette");
+
+    const keys = isMac ? ["⌘", "K"] : ["Ctrl", "K"];
+    keys.forEach((k) => {
+      const kbd = document.createElement("kbd");
+      kbd.className = "mockup-topbar__chip-kbd";
+      kbd.textContent = k;
+      button.appendChild(kbd);
+    });
+
+    button.addEventListener("click", () => palettePresenter.toggle());
+    return button;
+  }
+
+  function enhanceTopbar(palettePresenter) {
+    const topbar = document.querySelector("header.mockup-topbar");
+    if (!topbar) return;
+
+    // Mark → anchor. Replace in-place so the existing CSS selector keeps matching.
+    const oldMark = topbar.querySelector(".mockup-topbar__mark");
+    if (oldMark && oldMark.tagName !== "A") {
+      const anchor = document.createElement("a");
+      anchor.className = oldMark.className;
+      anchor.href = "./index.html";
+      anchor.textContent = oldMark.textContent || "catalyst";
+      anchor.setAttribute("aria-label", "Catalyst mockups gallery");
+      oldMark.parentNode.replaceChild(anchor, oldMark);
+    }
+
+    // Breadcrumb → middle. If the meta tag is absent or empty, skip the crumb
+    // and leave the original eyebrow alone (graceful fallback for pages that
+    // forget to add the meta).
+    const segments = parseBreadcrumb(readBreadcrumbMeta());
+    if (segments.length > 0) {
+      const eyebrow = topbar.querySelector(".eyebrow");
+      const crumb = buildBreadcrumb(segments);
+      const mark = topbar.querySelector(".mockup-topbar__mark");
+      if (mark && mark.parentNode === topbar) {
+        topbar.insertBefore(crumb, mark.nextSibling);
+      } else {
+        topbar.appendChild(crumb);
+      }
+      if (eyebrow && eyebrow.parentNode === topbar) {
+        topbar.removeChild(eyebrow);
+      }
+    }
+
+    // ⌘K chip → right.
+    const chip = buildKeybindChip(palettePresenter);
+    topbar.appendChild(chip);
+  }
+
+  // ----- Command palette (CTL-166) -----
+
+  let paletteEl = null;
+  let paletteState = {
+    actions: [],
+    visible: [],
+    activeIndex: 0,
+    query: "",
+  };
+
+  function buildPalette(executeAction) {
+    const root = document.createElement("div");
+    root.className = "mockup-palette";
+    root.hidden = true;
+    root.setAttribute("role", "dialog");
+    root.setAttribute("aria-modal", "true");
+    root.setAttribute("aria-label", "Command palette");
+
+    const backdrop = document.createElement("div");
+    backdrop.className = "mockup-palette__backdrop";
+    backdrop.setAttribute("aria-hidden", "true");
+    backdrop.addEventListener("click", () => setPaletteOpen(false));
+
+    const modal = document.createElement("div");
+    modal.className = "mockup-palette__modal";
+
+    const input = document.createElement("input");
+    input.className = "mockup-palette__input";
+    input.type = "search";
+    input.placeholder = "Type to filter…";
+    input.setAttribute("aria-label", "Filter palette actions");
+    input.setAttribute("data-control", "palette-filter");
+
+    const list = document.createElement("ul");
+    list.className = "mockup-palette__list";
+    list.setAttribute("role", "listbox");
+
+    input.addEventListener("input", () => {
+      paletteState.query = input.value || "";
+      renderPaletteList(list, executeAction);
+    });
+
+    input.addEventListener("keydown", (ev) => {
+      if (ev.key === "ArrowDown") {
+        ev.preventDefault();
+        movePaletteSelection(1, list);
+      } else if (ev.key === "ArrowUp") {
+        ev.preventDefault();
+        movePaletteSelection(-1, list);
+      } else if (ev.key === "Enter") {
+        ev.preventDefault();
+        const action = paletteState.visible[paletteState.activeIndex];
+        if (action) executeAction(action);
+      }
+    });
+
+    modal.appendChild(input);
+    modal.appendChild(list);
+    root.appendChild(backdrop);
+    root.appendChild(modal);
+    return root;
+  }
+
+  function renderPaletteList(list, executeAction) {
+    while (list.firstChild) list.removeChild(list.firstChild);
+    const filtered = filterPaletteActions(paletteState.actions, paletteState.query);
+    paletteState.visible = filtered;
+    paletteState.activeIndex = 0;
+
+    if (filtered.length === 0) {
+      const empty = document.createElement("li");
+      empty.className = "mockup-palette__empty";
+      empty.textContent = "No matches";
+      list.appendChild(empty);
+      return;
+    }
+
+    const groupedNoFilter = paletteState.query.trim().length === 0;
+    let lastGroup = null;
+    filtered.forEach((action, idx) => {
+      if (groupedNoFilter && action.group !== lastGroup) {
+        const label = document.createElement("li");
+        label.className = "mockup-palette__group-label";
+        label.textContent = action.group;
+        label.setAttribute("aria-hidden", "true");
+        list.appendChild(label);
+        lastGroup = action.group;
+      }
+
+      const row = document.createElement("li");
+      row.className = "mockup-palette__row";
+      if (idx === paletteState.activeIndex) {
+        row.classList.add("mockup-palette__row--active");
+      }
+      row.setAttribute("role", "option");
+      row.setAttribute("data-action-id", action.id);
+
+      const labelEl = document.createElement("span");
+      labelEl.className = "mockup-palette__row-label";
+      labelEl.textContent = action.label;
+      row.appendChild(labelEl);
+
+      if (Array.isArray(action.hint) && action.hint.length > 0) {
+        const keys = document.createElement("span");
+        keys.className = "mockup-palette__row-keys";
+        action.hint.forEach((k) => {
+          const kbd = document.createElement("kbd");
+          kbd.className = "mockup-palette__row-kbd";
+          kbd.textContent = k;
+          keys.appendChild(kbd);
+        });
+        row.appendChild(keys);
+      }
+
+      row.addEventListener("click", () => executeAction(action));
+      list.appendChild(row);
+    });
+  }
+
+  function movePaletteSelection(delta, list) {
+    if (paletteState.visible.length === 0) return;
+    const next =
+      (paletteState.activeIndex + delta + paletteState.visible.length) %
+      paletteState.visible.length;
+    paletteState.activeIndex = next;
+    const rows = list.querySelectorAll(".mockup-palette__row");
+    rows.forEach((row, idx) => {
+      row.classList.toggle("mockup-palette__row--active", idx === next);
+    });
+    const activeRow = rows[next];
+    if (activeRow && typeof activeRow.scrollIntoView === "function") {
+      activeRow.scrollIntoView({ block: "nearest" });
+    }
+  }
+
+  function ensurePalette(executeAction) {
+    if (paletteEl && document.body.contains(paletteEl)) return paletteEl;
+    paletteEl = buildPalette(executeAction);
+    document.body.appendChild(paletteEl);
+    return paletteEl;
+  }
+
+  function isPaletteOpen() {
+    return Boolean(paletteEl && paletteEl.hidden === false);
+  }
+
+  function setPaletteOpen(open) {
+    if (!paletteEl) return;
+    paletteEl.hidden = !open;
+    if (open) {
+      const input = paletteEl.querySelector(".mockup-palette__input");
+      const list = paletteEl.querySelector(".mockup-palette__list");
+      if (input) {
+        input.value = paletteState.query || "";
+        if (typeof input.focus === "function") input.focus();
+      }
+      if (list) renderPaletteList(list, paletteState.executeAction);
+    }
+  }
+
   // ----- Mount -----
 
   function mount(prefs) {
@@ -426,6 +802,11 @@
     document.addEventListener("keydown", (ev) => {
       // Escape always fires so overlays can close even when something is focused.
       if (ev.key === "Escape") {
+        if (isPaletteOpen()) {
+          setPaletteOpen(false);
+          ev.preventDefault();
+          return;
+        }
         if (isCheatSheetOpen()) {
           setCheatSheetOpen(false);
           ev.preventDefault();
@@ -433,6 +814,21 @@
         }
         if (controller) controller.setPopoverOpen(false);
         clearGPrefix();
+        return;
+      }
+
+      // ⌘K / Ctrl K — open command palette (CTL-166). Fires even when focus is
+      // on an input so users can re-summon the palette while typing in the
+      // page's own search fields. The palette modal owns Esc to close.
+      if (
+        (ev.metaKey || ev.ctrlKey) &&
+        !ev.shiftKey &&
+        !ev.altKey &&
+        typeof ev.key === "string" &&
+        ev.key.toLowerCase() === "k"
+      ) {
+        ev.preventDefault();
+        setPaletteOpen(!isPaletteOpen());
         return;
       }
 
@@ -498,6 +894,53 @@
 
   const boot = () => {
     const controller = mount(prefs);
+
+    // Build the palette eagerly so the ⌘K keybinding can open it immediately
+    // — but keep it hidden until the user triggers it. The first call to
+    // `ensurePalette` wires the executor; subsequent calls are no-ops.
+    const cycleSystem = () => {
+      if (!controller) return;
+      controller.handleSystemChange(nextSystem(controller.state.system));
+    };
+    const toggleTheme = () => {
+      const current =
+        document.documentElement.getAttribute("data-theme") || DEFAULTS.theme;
+      const nxt = nextTheme(current);
+      if (controller) controller.state.theme = nxt;
+      document.documentElement.setAttribute("data-theme", nxt);
+      const next = controller ? controller.state : { system: DEFAULTS.system, theme: nxt };
+      persist(next);
+    };
+    const cyclePalette = () => {
+      // Reserved — palettes.css does not exist yet. Intentional no-op so the
+      // palette can still surface the action and stay in sync with the
+      // keybinding row in the cheatsheet.
+    };
+
+    const executeAction = (action) => {
+      if (!action || typeof action !== "object") return;
+      setPaletteOpen(false);
+      if (action.type === "nav" && action.payload && action.payload.path) {
+        window.location.href = "./" + action.payload.path;
+        return;
+      }
+      if (action.type === "appearance" && action.payload) {
+        if (action.payload.action === "toggleTheme") toggleTheme();
+        else if (action.payload.action === "cycleSystem") cycleSystem();
+        else if (action.payload.action === "cyclePalette") cyclePalette();
+        return;
+      }
+      if (action.type === "help" && action.payload && action.payload.action === "openCheatsheet") {
+        setCheatSheetOpen(true);
+      }
+    };
+
+    paletteState.actions = paletteActions(GNAV);
+    paletteState.executeAction = executeAction;
+    ensurePalette(executeAction);
+
+    enhanceTopbar({ toggle: () => setPaletteOpen(!isPaletteOpen()) });
+
     installKeybindings(controller);
   };
 

--- a/plugins/dev/scripts/orch-monitor/public/mockups/agent-graph.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/agent-graph.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst — Agent graph</title>
+    <meta name="mockup-breadcrumb" content="Monitor / orch-2026-04-22-3 / agent graph" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />

--- a/plugins/dev/scripts/orch-monitor/public/mockups/brand.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/brand.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst — Brand</title>
+    <meta name="mockup-breadcrumb" content="Brand showcase" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />

--- a/plugins/dev/scripts/orch-monitor/public/mockups/briefing.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/briefing.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst — Briefing</title>
+    <meta name="mockup-breadcrumb" content="Monitor / orch-2026-04-22 / briefing" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />

--- a/plugins/dev/scripts/orch-monitor/public/mockups/comms.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/comms.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst — Comms</title>
+    <meta name="mockup-breadcrumb" content="Monitor / orch-2026-04-22-3 / comms" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />

--- a/plugins/dev/scripts/orch-monitor/public/mockups/home.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/home.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst — Home</title>
+    <meta name="mockup-breadcrumb" content="Home" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />

--- a/plugins/dev/scripts/orch-monitor/public/mockups/index.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst Mockups</title>
+    <meta name="mockup-breadcrumb" content="Mockups" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />

--- a/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst — Orchestrator</title>
+    <meta name="mockup-breadcrumb" content="Monitor / ctl-ux-apr20" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />

--- a/plugins/dev/scripts/orch-monitor/public/mockups/todos.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/todos.html
@@ -10,6 +10,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst — Todos</title>
+    <meta name="mockup-breadcrumb" content="Monitor / orch-2026-04-22-3 / todos" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />

--- a/plugins/dev/scripts/orch-monitor/public/mockups/worker.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/worker.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst — Worker</title>
+    <meta name="mockup-breadcrumb" content="Monitor / orch-2026-04-22-3 / wave 2 / CTL-138" />
     <link rel="stylesheet" href="./_shared/tokens.css" />
     <link rel="stylesheet" href="./_shared/fonts.css" />
     <link rel="stylesheet" href="./_shared/base.css" />


### PR DESCRIPTION
Closes CTL-166.

## Summary

Adds three discoverable nav affordances to the existing mockup-topbar, keeping the
keyboard-first intent from CTL-145 intact:

1. The `catalyst` mark becomes an `<a href=\"./index.html\">` so a single click goes
   back to the mockup gallery.
2. A lightweight breadcrumb is injected in the middle of the topbar, sourced from a
   per-page `<meta name=\"mockup-breadcrumb\" content=\"Monitor / orch-2026-04-22 / briefing\">`.
   Segments are split on ` / `. The original per-page eyebrow is removed once the
   breadcrumb renders so the topbar doesn't show the same label twice.
3. A `⌘K` (or `Ctrl K` on non-mac) chip is appended on the right. Click — or press
   the binding — to open a filterable command palette with three sections:
   **Navigate** (every entry from `GNAV`), **Appearance** (toggle theme, cycle
   system, cycle palette), **Help** (open cheat sheet). Substring filter only;
   `↑/↓` to move; `Enter` to execute; `Esc` to close.

All existing keybindings keep working. `⌘K` is additive and gated by `metaKey || ctrlKey`.
The page-body breadcrumbs in `worker.html`, `briefing.html`, and `agent-graph.html`
are part of the page heading — they stay in place.

## Files changed

- `_shared/chrome.js` — pure helpers (`parseBreadcrumb`, `isMacPlatform`,
  `paletteActions`, `filterPaletteActions`), `enhanceTopbar`, palette modal,
  `⌘K` keybinding.
- `_shared/chrome.css` — topbar layout adjustments + breadcrumb / chip / palette
  styles. Token-driven, no new color values.
- `_shared/chrome.d.ts` — declares the new helpers.
- `_shared/README.md` — adds `⌘K` to the keybinding table + a Topbar nav shell section.
- 9 mockup pages (`home`, `index`, `orch`, `worker`, `comms`, `briefing`,
  `agent-graph`, `todos`, `brand`) — one `<meta name=\"mockup-breadcrumb\">` line each.
- `__tests__/mockup-chrome.test.ts` — extends with palette + breadcrumb + chip + topbar
  static-marker coverage. 23 new test cases; full file is 46 tests, 76 expects.

## Test plan

- [x] `bun test __tests__/mockup-chrome.test.ts` — 46 pass / 0 fail
- [x] `bun run check` — typecheck + lint + knip + audit + 1008 tests, exit 0
  (one pre-existing lint warning in `lib/preview-status.ts` is unchanged)
- [x] Visual smoke test via `agent-browser` on `orch.html` and `briefing.html`:
      mark click navigates to `/mockups/index.html`, ⌘K opens palette, typing
      \"orch\" filters to `Orchestrator`, Esc closes, Meta+K re-opens.

## Acceptance (from ticket)

1. ✅ Click `catalyst` (top-left) on any page → lands on gallery
2. ✅ Visible breadcrumb shows page location on every page
3. ✅ ⌘K chip top-right; click opens palette; typing filters; Enter on nav navigates;
      Enter on appearance fires same action as the keybinding
4. ✅ Existing `g`-prefix / `?` / `⇧D` / `p` / `.` / `/` keep working
5. ✅ `mockup-chrome.test.ts` (existing test file; ticket calls it `chrome.test.ts`) passes