### PR TITLE
feat(dev): canonical orchestrate-dispatch-next reading all waveN queues (CTL-116)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-dispatch-next (CTL-116).
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/orchestrate-dispatch-next"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+scratch_setup() {
+  SCRATCH="$(mktemp -d)"
+  ORCH_DIR="${SCRATCH}/orch"
+  WORKTREE_ROOT="${SCRATCH}/wt"
+  mkdir -p "${ORCH_DIR}/workers/output" "${SCRATCH}/bin" "${WORKTREE_ROOT}"
+
+  # Fake catalyst-state.sh — logs argv so tests can assert.
+  cat > "${SCRATCH}/bin/catalyst-state.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$STATE_LOG"
+EOF
+  chmod +x "${SCRATCH}/bin/catalyst-state.sh"
+  export STATE_LOG="${SCRATCH}/state.log"
+  : > "$STATE_LOG"
+  export CATALYST_STATE_SCRIPT="${SCRATCH}/bin/catalyst-state.sh"
+
+  # Fake claude binary — logs argv + env then sleeps so kill-0 sees a live PID.
+  cat > "${SCRATCH}/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+{
+  echo "---"
+  echo "pid=$$"
+  echo "cwd=$(pwd)"
+  echo "ORCH_DIR=${CATALYST_ORCHESTRATOR_DIR:-}"
+  echo "ORCH_ID=${CATALYST_ORCHESTRATOR_ID:-}"
+  echo "COMMS=${CATALYST_COMMS_CHANNEL:-}"
+  echo "SESSION=${CATALYST_SESSION_ID:-}"
+  echo "args: $*"
+} >> "$CLAUDE_LOG"
+sleep 30 &
+disown $! 2>/dev/null || true
+EOF
+  chmod +x "${SCRATCH}/bin/claude"
+  export CLAUDE_LOG="${SCRATCH}/claude.log"
+  : > "$CLAUDE_LOG"
+  export CATALYST_DISPATCH_CLAUDE_BIN="${SCRATCH}/bin/claude"
+
+  # Disable the post-dispatch healthcheck in tests (would try to re-read signals
+  # and might interfere with assertions). The script honors an empty env var.
+  export CATALYST_DISPATCH_HEALTHCHECK=""
+}
+
+scratch_teardown() {
+  pkill -f "sleep 30" 2>/dev/null || true
+  rm -rf "$SCRATCH"
+  unset STATE_LOG CLAUDE_LOG CATALYST_STATE_SCRIPT CATALYST_DISPATCH_CLAUDE_BIN
+  unset CATALYST_DISPATCH_HEALTHCHECK SCRATCH ORCH_DIR WORKTREE_ROOT
+}
+
+# write_state ORCH_ID MAX_PARALLEL JQ_QUEUE
+# Writes a minimal state.json into ORCH_DIR with the given orchestrator name,
+# maxParallel, and a .queue object supplied as a JSON literal.
+write_state() {
+  local orch="$1" mp="$2" queue="$3"
+  cat > "${ORCH_DIR}/state.json" <<EOF
+{
+  "orchestrator": "${orch}",
+  "startedAt": "$(now_iso)",
+  "baseBranch": "main",
+  "worktreeBase": "${WORKTREE_ROOT}",
+  "maxParallel": ${mp},
+  "totalWaves": 3,
+  "currentWave": 1,
+  "queue": ${queue},
+  "workers": {}
+}
+EOF
+}
+
+# make_worktree ORCH_ID TICKET — create an empty directory so the dispatcher's
+# worktree existence check passes.
+make_worktree() {
+  mkdir -p "${WORKTREE_ROOT}/${1}-${2}"
+}
+
+# make_running_signal TICKET STATUS — seed a pre-existing signal so the
+# running-count logic observes it.
+make_running_signal() {
+  local t="$1" s="$2"
+  jq -n --arg t "$t" --arg s "$s" --arg ts "$(now_iso)" \
+    '{ticket: $t, orchestrator: "demo", workerName: ("demo-" + $t),
+      label: ("oneshot " + $t), status: $s, phase: 3,
+      startedAt: $ts, updatedAt: $ts}' \
+    > "${ORCH_DIR}/workers/${t}.json"
+}
+
+run_dispatch() {
+  "$DISPATCH" --orch-dir "$ORCH_DIR" "$@"
+}
+
+# ─── Test cases ───────────────────────────────────────────────────────────────
+
+echo "test 1: empty queue reports queueEmpty and exits 0"
+scratch_setup
+write_state "demo" 4 '{"wave1Pending": [], "wave2Pending": []}'
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0" || fail "exit 0" "got rc=$RC stderr=$(cat "${SCRATCH}/err")"
+echo "$OUT" | jq -e '.queueEmpty == true' >/dev/null && pass "queueEmpty=true" || fail "queueEmpty=true" "got: $OUT"
+echo "$OUT" | jq -e '.dispatched == []' >/dev/null && pass "dispatched empty" || fail "dispatched empty" "got: $OUT"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude not invoked" || fail "claude not invoked"
+scratch_teardown
+
+echo "test 2: single wave — dispatches all up to maxParallel"
+scratch_setup
+write_state "demo" 4 '{"wave1Pending": ["T-1", "T-2"]}'
+make_worktree "demo" "T-1"
+make_worktree "demo" "T-2"
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "T-1,T-2" ] && pass "dispatched T-1,T-2 in order" || fail "dispatched in order" "got: $DISPATCHED"
+[ -f "${ORCH_DIR}/workers/T-1.json" ] && pass "signal T-1 created" || fail "signal T-1 created"
+[ -f "${ORCH_DIR}/workers/T-2.json" ] && pass "signal T-2 created" || fail "signal T-2 created"
+grep -q "oneshot" "$CLAUDE_LOG" && pass "claude invoked" || fail "claude invoked"
+# Verify queue was drained
+REMAINING=$(jq -r '.queue.wave1Pending | length' "${ORCH_DIR}/state.json")
+[ "$REMAINING" = "0" ] && pass "wave1Pending drained" || fail "wave1Pending drained" "remaining: $REMAINING"
+# Verify signal carries expected fields
+S1_STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/T-1.json")
+S1_PHASE=$(jq -r '.phase' "${ORCH_DIR}/workers/T-1.json")
+S1_LABEL=$(jq -r '.label' "${ORCH_DIR}/workers/T-1.json")
+S1_WT=$(jq -r '.worktreePath' "${ORCH_DIR}/workers/T-1.json")
+[ "$S1_STATUS" = "dispatched" ] && pass "T-1.status=dispatched" || fail "T-1.status=dispatched" "got: $S1_STATUS"
+[ "$S1_PHASE" = "0" ] && pass "T-1.phase=0" || fail "T-1.phase=0" "got: $S1_PHASE"
+[ "$S1_LABEL" = "oneshot T-1" ] && pass "T-1.label" || fail "T-1.label" "got: $S1_LABEL"
+[ "$S1_WT" = "${WORKTREE_ROOT}/demo-T-1" ] && pass "T-1.worktreePath" || fail "T-1.worktreePath" "got: $S1_WT"
+# Verify catalyst-state was called for dispatch
+grep -q "worker demo T-1" "$STATE_LOG" && pass "state worker T-1 emitted" || fail "state worker T-1 emitted"
+grep -q "event" "$STATE_LOG" && pass "state event emitted" || fail "state event emitted"
+scratch_teardown
+
+echo "test 3: three waves drain in numeric order (1 → 2 → 3)"
+scratch_setup
+write_state "demo" 4 '{"wave1Pending": ["A"], "wave2Pending": ["B"], "wave3Pending": ["C", "D"]}'
+for T in A B C D; do make_worktree "demo" "$T"; done
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "A,B,C,D" ] && pass "drains waves in order" || fail "drains waves in order" "got: $DISPATCHED"
+for T in A B C D; do
+  [ -f "${ORCH_DIR}/workers/${T}.json" ] && pass "$T signal created" || fail "$T signal created"
+done
+scratch_teardown
+
+echo "test 4: dynamic waveN enumeration — wave5, wave10 also drain"
+scratch_setup
+write_state "demo" 4 '{"wave1Pending": [], "wave5Pending": ["X-5"], "wave10Pending": ["X-10"]}'
+make_worktree "demo" "X-5"
+make_worktree "demo" "X-10"
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+# Wave 5 before wave 10 (numeric sort, not lexicographic)
+[ "$DISPATCHED" = "X-5,X-10" ] && pass "wave5 before wave10 (numeric order)" || fail "wave5 before wave10" "got: $DISPATCHED"
+[ -f "${ORCH_DIR}/workers/X-5.json" ] && pass "X-5 dispatched" || fail "X-5 dispatched"
+[ -f "${ORCH_DIR}/workers/X-10.json" ] && pass "X-10 dispatched" || fail "X-10 dispatched"
+scratch_teardown
+
+echo "test 5: respects maxParallel across waves"
+scratch_setup
+write_state "demo" 2 '{"wave1Pending": ["A", "B"], "wave2Pending": ["C"], "wave3Pending": ["D"]}'
+for T in A B C D; do make_worktree "demo" "$T"; done
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "A,B" ] && pass "only 2 dispatched" || fail "only 2 dispatched" "got: $DISPATCHED"
+REMAINING_1=$(jq -r '.queue.wave1Pending | length' "${ORCH_DIR}/state.json")
+REMAINING_2=$(jq -r '.queue.wave2Pending | length' "${ORCH_DIR}/state.json")
+REMAINING_3=$(jq -r '.queue.wave3Pending | length' "${ORCH_DIR}/state.json")
+[ "$REMAINING_1" = "0" ] && pass "wave1 drained" || fail "wave1 drained" "$REMAINING_1"
+[ "$REMAINING_2" = "1" ] && pass "wave2 untouched" || fail "wave2 untouched" "$REMAINING_2"
+[ "$REMAINING_3" = "1" ] && pass "wave3 untouched" || fail "wave3 untouched" "$REMAINING_3"
+scratch_teardown
+
+echo "test 6: respects already-running workers"
+scratch_setup
+write_state "demo" 3 '{"wave1Pending": ["A", "B"]}'
+make_running_signal "RUN-1" "implementing"
+make_running_signal "RUN-2" "pr-created"
+make_worktree "demo" "A"
+make_worktree "demo" "B"
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+RUNNING=$(echo "$OUT" | jq -r '.running')
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$RUNNING" = "2" ] && pass "running=2 counted" || fail "running=2 counted" "got: $RUNNING"
+[ "$DISPATCHED" = "A" ] && pass "only 1 new dispatched (maxParallel=3)" || fail "only 1 new dispatched" "got: $DISPATCHED"
+scratch_teardown
+
+echo "test 7: terminal workers don't count toward running"
+scratch_setup
+write_state "demo" 2 '{"wave1Pending": ["A", "B"]}'
+make_running_signal "DONE-1" "done"
+make_running_signal "FAIL-1" "failed"
+make_running_signal "STALL-1" "stalled"
+make_worktree "demo" "A"
+make_worktree "demo" "B"
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "A,B" ] && pass "both dispatched — terminals ignored" || fail "both dispatched" "got: $DISPATCHED"
+scratch_teardown
+
+echo "test 8: skips tickets whose worktree is missing"
+scratch_setup
+write_state "demo" 4 '{"wave1Pending": ["A", "MISSING", "B"]}'
+make_worktree "demo" "A"
+make_worktree "demo" "B"
+# MISSING deliberately has no worktree
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "A,B" ] && pass "A and B dispatched, MISSING skipped" || fail "A and B dispatched, MISSING skipped" "got: $DISPATCHED"
+grep -qi "MISSING" "${SCRATCH}/err" && pass "stderr mentions missing worktree" || fail "stderr mentions missing" "stderr: $(cat "${SCRATCH}/err")"
+# MISSING stays in wave1Pending
+jq -e '.queue.wave1Pending | contains(["MISSING"])' "${ORCH_DIR}/state.json" >/dev/null \
+  && pass "MISSING left in queue" || fail "MISSING left in queue"
+scratch_teardown
+
+echo "test 9: idempotent — skips tickets that already have a signal"
+scratch_setup
+write_state "demo" 4 '{"wave1Pending": ["PRE-1", "NEW-1"]}'
+make_running_signal "PRE-1" "researching"
+make_worktree "demo" "PRE-1"
+make_worktree "demo" "NEW-1"
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "NEW-1" ] && pass "only NEW-1 dispatched" || fail "only NEW-1 dispatched" "got: $DISPATCHED"
+# PRE-1 signal's status is preserved
+PRE_STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PRE-1.json")
+[ "$PRE_STATUS" = "researching" ] && pass "PRE-1 signal untouched" || fail "PRE-1 signal untouched" "got: $PRE_STATUS"
+scratch_teardown
+
+echo "test 10: --dry-run makes no state changes"
+scratch_setup
+write_state "demo" 4 '{"wave1Pending": ["T-1"]}'
+make_worktree "demo" "T-1"
+OUT=$(run_dispatch --dry-run 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "T-1" ] && pass "dispatched list reports T-1" || fail "dispatched list reports T-1" "got: $DISPATCHED"
+[ ! -f "${ORCH_DIR}/workers/T-1.json" ] && pass "no signal file created" || fail "no signal file created"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude not invoked" || fail "claude not invoked"
+REMAINING=$(jq -r '.queue.wave1Pending | length' "${ORCH_DIR}/state.json")
+[ "$REMAINING" = "1" ] && pass "queue untouched" || fail "queue untouched" "remaining: $REMAINING"
+scratch_teardown
+
+echo "test 11: no slots available → exits 0 with slots=0, no dispatches"
+scratch_setup
+write_state "demo" 2 '{"wave1Pending": ["A"]}'
+make_running_signal "R1" "implementing"
+make_running_signal "R2" "validating"
+make_worktree "demo" "A"
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 when full" || fail "exit 0 when full"
+echo "$OUT" | jq -e '.slotsAfter == 0 and .dispatched == []' >/dev/null \
+  && pass "slotsAfter=0 dispatched=[]" || fail "slotsAfter=0 dispatched=[]" "got: $OUT"
+[ ! -f "${ORCH_DIR}/workers/A.json" ] && pass "A not dispatched" || fail "A not dispatched"
+scratch_teardown
+
+echo "test 12: ticket removed only from the wave it came from (not from others)"
+scratch_setup
+# Put a ticket "DUP" only in wave3Pending; verify wave1/wave2 untouched.
+write_state "demo" 4 '{"wave1Pending": ["W1"], "wave2Pending": ["W2"], "wave3Pending": ["DUP"]}'
+make_worktree "demo" "W1"
+make_worktree "demo" "W2"
+make_worktree "demo" "DUP"
+run_dispatch 2>"${SCRATCH}/err" >/dev/null
+W1_LEN=$(jq -r '.queue.wave1Pending | length' "${ORCH_DIR}/state.json")
+W2_LEN=$(jq -r '.queue.wave2Pending | length' "${ORCH_DIR}/state.json")
+W3_LEN=$(jq -r '.queue.wave3Pending | length' "${ORCH_DIR}/state.json")
+[ "$W1_LEN" = "0" ] && pass "wave1 drained to 0" || fail "wave1 drained" "$W1_LEN"
+[ "$W2_LEN" = "0" ] && pass "wave2 drained to 0" || fail "wave2 drained" "$W2_LEN"
+[ "$W3_LEN" = "0" ] && pass "wave3 drained to 0" || fail "wave3 drained" "$W3_LEN"
+scratch_teardown
+
+echo "test 13: env/args forwarded to claude"
+scratch_setup
+write_state "demo" 4 '{"wave1Pending": ["T-1"]}'
+make_worktree "demo" "T-1"
+run_dispatch --session-id "sess-abc" --worker-command "/catalyst-dev:oneshot" \
+  --worker-args "--auto-merge --extra" 2>"${SCRATCH}/err" >/dev/null
+grep -q "ORCH_ID=demo" "$CLAUDE_LOG" && pass "ORCH_ID forwarded" || fail "ORCH_ID forwarded" "log: $(cat "$CLAUDE_LOG")"
+grep -q "ORCH_DIR=${ORCH_DIR}" "$CLAUDE_LOG" && pass "ORCH_DIR forwarded" || fail "ORCH_DIR forwarded"
+grep -q "SESSION=sess-abc" "$CLAUDE_LOG" && pass "SESSION_ID forwarded" || fail "SESSION_ID forwarded"
+grep -q "COMMS=orch-demo" "$CLAUDE_LOG" && pass "COMMS channel forwarded (default orch-<id>)" || fail "COMMS channel forwarded"
+grep -q -- "T-1 --auto-merge --extra" "$CLAUDE_LOG" && pass "worker args forwarded" || fail "worker args forwarded" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test 14: --orch-id override takes precedence over state.json"
+scratch_setup
+write_state "stateorch" 4 '{"wave1Pending": ["T-1"]}'
+mkdir -p "${WORKTREE_ROOT}/cliorch-T-1"
+run_dispatch --orch-id "cliorch" 2>"${SCRATCH}/err" >/dev/null
+[ -f "${ORCH_DIR}/workers/T-1.json" ] && pass "signal created with override" || fail "signal created with override"
+SIGNAL_ORCH=$(jq -r '.orchestrator' "${ORCH_DIR}/workers/T-1.json")
+[ "$SIGNAL_ORCH" = "cliorch" ] && pass "signal.orchestrator=cliorch" || fail "signal.orchestrator=cliorch" "got: $SIGNAL_ORCH"
+SIGNAL_WT=$(jq -r '.worktreePath' "${ORCH_DIR}/workers/T-1.json")
+[ "$SIGNAL_WT" = "${WORKTREE_ROOT}/cliorch-T-1" ] && pass "worktreePath uses cli orch-id" || fail "worktreePath uses cli orch-id" "got: $SIGNAL_WT"
+scratch_teardown
+
+echo "test 15: missing --orch-dir fails with non-zero exit"
+OUT=$("$DISPATCH" 2>&1)
+RC=$?
+[ "$RC" != "0" ] && pass "exits non-zero without --orch-dir" || fail "exits non-zero" "got rc=$RC"
+
+echo "test 15b: --help prints the full usage block (concurrency note present)"
+OUT=$("$DISPATCH" --help 2>&1)
+echo "$OUT" | grep -q "Concurrency:" && pass "help shows concurrency note" || fail "help shows concurrency note" "got: $OUT"
+echo "$OUT" | grep -q "CATALYST_DISPATCH_HEALTHCHECK" && pass "help shows env overrides" || fail "help shows env overrides"
+
+echo "test 16: missing state.json fails"
+scratch_setup
+# No state.json
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" 2>&1)
+RC=$?
+[ "$RC" != "0" ] && pass "exits non-zero when state.json missing" || fail "exits non-zero when state.json missing"
+scratch_teardown
+
+echo "test 17: no .queue key → treated as empty queue"
+scratch_setup
+cat > "${ORCH_DIR}/state.json" <<EOF
+{"orchestrator": "demo", "worktreeBase": "${WORKTREE_ROOT}", "maxParallel": 2}
+EOF
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+echo "$OUT" | jq -e '.queueEmpty == true' >/dev/null \
+  && pass "queueEmpty when .queue missing" || fail "queueEmpty when .queue missing" "got: $OUT"
+scratch_teardown
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# orchestrate-dispatch-next - Canonical wave-queue dispatcher (CTL-116).
+#
+# Drains `.queue.waveNPending` in numeric wave order from an orchestrator's
+# state.json, dispatching up to (maxParallel - currentlyRunning) fresh `/oneshot`
+# workers. Replaces the hand-rolled per-run `dispatch-next.sh` that previously
+# hardcoded wave1/wave2/wave3 keys.
+#
+# Usage:
+#   orchestrate-dispatch-next --orch-dir <path>
+#                             [--orch-id <id>]
+#                             [--worktree-base <path>]
+#                             [--max-parallel <n>]
+#                             [--session-id <id>]
+#                             [--worker-command <cmd>]    # default "/catalyst-dev:oneshot"
+#                             [--worker-args <str>]       # default "--auto-merge"
+#                             [--comms-channel <name>]    # default "orch-<orch-id>"
+#                             [--dry-run]
+#                             [--skip-healthcheck]
+#
+# Defaults read from state.json (`.orchestrator`, `.worktreeBase`, `.maxParallel`)
+# when the CLI flag is not provided. Session ID falls back to
+# $CATALYST_SESSION_ID or $ORCH_DIR/.session-id.
+#
+# Outputs a single JSON line on stdout:
+#   {"running":R,"slotsAfter":S,"dispatched":["T-1",...][,"queueEmpty":true]}
+#
+# Environment overrides (for tests):
+#   CATALYST_STATE_SCRIPT         path to catalyst-state.sh (default: sibling)
+#   CATALYST_DISPATCH_CLAUDE_BIN  claude binary (default: `claude` on PATH)
+#   CATALYST_DISPATCH_HEALTHCHECK path to orchestrate-healthcheck; empty string
+#                                 disables the post-dispatch check entirely.
+#
+# Concurrency: assumes a single-writer orchestrator. Two concurrent invocations
+# can observe the same pre-dispatch `RUNNING` count and over-subscribe past
+# `maxParallel`; callers that poll should serialize dispatcher calls.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
+CLAUDE_BIN="${CATALYST_DISPATCH_CLAUDE_BIN:-claude}"
+# When the env var is defined (even if empty), honor it. Empty → no healthcheck.
+if [ -n "${CATALYST_DISPATCH_HEALTHCHECK+x}" ]; then
+  HEALTHCHECK_BIN="$CATALYST_DISPATCH_HEALTHCHECK"
+else
+  HEALTHCHECK_BIN="${SCRIPT_DIR}/orchestrate-healthcheck"
+fi
+
+ORCH_DIR=""
+ORCH_ID=""
+WORKTREE_BASE=""
+MAX_PARALLEL=""
+SESSION_ID=""
+WORKER_COMMAND="/catalyst-dev:oneshot"
+WORKER_ARGS="--auto-merge"
+COMMS_CHANNEL=""
+DRY_RUN=0
+SKIP_HEALTHCHECK=0
+
+usage() {
+  sed -n '2,36p' "$0"
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir)        ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)         ORCH_ID="$2"; shift 2 ;;
+    --worktree-base)   WORKTREE_BASE="$2"; shift 2 ;;
+    --max-parallel)    MAX_PARALLEL="$2"; shift 2 ;;
+    --session-id)      SESSION_ID="$2"; shift 2 ;;
+    --worker-command)  WORKER_COMMAND="$2"; shift 2 ;;
+    --worker-args)     WORKER_ARGS="$2"; shift 2 ;;
+    --comms-channel)   COMMS_CHANNEL="$2"; shift 2 ;;
+    --dry-run)         DRY_RUN=1; shift ;;
+    --skip-healthcheck) SKIP_HEALTHCHECK=1; shift ;;
+    -h|--help)         usage 0 ;;
+    *)                 echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
+[ ! -d "$ORCH_DIR/workers" ] && { echo "ERROR: no workers dir at $ORCH_DIR/workers" >&2; exit 2; }
+STATE_JSON="${ORCH_DIR}/state.json"
+[ ! -f "$STATE_JSON" ] && { echo "ERROR: state.json missing at $STATE_JSON" >&2; exit 2; }
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# Resolve defaults from state.json when not supplied on the CLI.
+[ -z "$ORCH_ID" ]       && ORCH_ID=$(jq -r '.orchestrator // ""' "$STATE_JSON")
+[ -z "$WORKTREE_BASE" ] && WORKTREE_BASE=$(jq -r '.worktreeBase // ""' "$STATE_JSON")
+[ -z "$MAX_PARALLEL" ]  && MAX_PARALLEL=$(jq -r '.maxParallel // 1' "$STATE_JSON")
+[ -z "$ORCH_ID" ]       && { echo "ERROR: orchestrator id not set (in state.json or --orch-id)" >&2; exit 2; }
+[ -z "$WORKTREE_BASE" ] && { echo "ERROR: worktreeBase not set (in state.json or --worktree-base)" >&2; exit 2; }
+
+[ -z "$COMMS_CHANNEL" ] && COMMS_CHANNEL="orch-${ORCH_ID}"
+
+# Session id: CLI > env > .session-id stash > empty (which becomes "")
+if [ -z "$SESSION_ID" ]; then
+  SESSION_ID="${CATALYST_SESSION_ID:-}"
+  if [ -z "$SESSION_ID" ] && [ -f "$ORCH_DIR/.session-id" ]; then
+    SESSION_ID=$(cat "$ORCH_DIR/.session-id" 2>/dev/null || echo "")
+  fi
+fi
+
+# ─── Count non-terminal workers ───────────────────────────────────────────────
+RUNNING=0
+for SIGNAL in "$ORCH_DIR/workers/"*.json; do
+  [ -f "$SIGNAL" ] || continue
+  S=$(jq -r '.status // ""' "$SIGNAL" 2>/dev/null)
+  case "$S" in
+    done|failed|stalled|"") ;;
+    *) RUNNING=$((RUNNING+1));;
+  esac
+done
+
+SLOTS=$((MAX_PARALLEL - RUNNING))
+if [ "$SLOTS" -le 0 ]; then
+  printf '{"running":%d,"slotsAfter":0,"dispatched":[]}\n' "$RUNNING"
+  exit 0
+fi
+
+# ─── Enumerate pending queue across every waveN, in numeric order ─────────────
+PENDING=$(jq -r '
+  (.queue // {})
+  | to_entries
+  | map(select(.key | test("^wave[0-9]+Pending$")))
+  | map({n: (.key | capture("^wave(?<x>[0-9]+)Pending$") | .x | tonumber),
+         tickets: .value})
+  | sort_by(.n)
+  | map(.tickets[])
+  | .[]
+' "$STATE_JSON" 2>/dev/null)
+
+if [ -z "$PENDING" ]; then
+  printf '{"running":%d,"slotsAfter":%d,"dispatched":[],"queueEmpty":true}\n' \
+    "$RUNNING" "$SLOTS"
+  exit 0
+fi
+
+# ─── Dispatch loop ────────────────────────────────────────────────────────────
+DISPATCHED=()
+while IFS= read -r T; do
+  [ -z "$T" ] && continue
+  [ "$SLOTS" -le 0 ] && break
+
+  WORKER_DIR="${WORKTREE_BASE}/${ORCH_ID}-${T}"
+  SIGNAL_FILE="${ORCH_DIR}/workers/${T}.json"
+
+  if [ -f "$SIGNAL_FILE" ]; then
+    # Already has a signal (idempotent — previously dispatched)
+    continue
+  fi
+
+  if [ ! -d "$WORKER_DIR" ]; then
+    echo "skip $T: worktree missing ($WORKER_DIR)" >&2
+    continue
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    DISPATCHED+=("$T")
+    SLOTS=$((SLOTS-1))
+    continue
+  fi
+
+  # Write signal file with the shared dispatched/phase0 template.
+  NOW=$(now_iso)
+  jq -n \
+    --arg ticket "$T" \
+    --arg orch "$ORCH_ID" \
+    --arg name "${ORCH_ID}-${T}" \
+    --arg label "oneshot ${T}" \
+    --arg ts "$NOW" \
+    --arg wt "$WORKER_DIR" \
+    '{
+      ticket: $ticket,
+      orchestrator: $orch,
+      workerName: $name,
+      label: $label,
+      status: "dispatched",
+      phase: 0,
+      startedAt: $ts,
+      updatedAt: $ts,
+      lastHeartbeat: $ts,
+      worktreePath: $wt,
+      pr: null,
+      linearState: null,
+      definitionOfDone: {
+        testsWrittenFirst: false,
+        unitTests: {exists: false, count: 0},
+        apiTests: {exists: false, count: 0},
+        functionalTests: {exists: false, count: 0},
+        typeCheck: {passed: false},
+        securityReview: {passed: false},
+        codeReview: {passed: false},
+        rewardHackingScan: {passed: false}
+      }
+    }' > "$SIGNAL_FILE"
+
+  STREAM="${ORCH_DIR}/workers/output/${T}-stream.jsonl"
+  STDERR="${ORCH_DIR}/workers/output/${T}-stderr.log"
+  mkdir -p "${ORCH_DIR}/workers/output"
+
+  (
+    cd "$WORKER_DIR" || exit 1
+    CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
+    CATALYST_ORCHESTRATOR_ID="$ORCH_ID" \
+    CATALYST_COMMS_CHANNEL="$COMMS_CHANNEL" \
+    CATALYST_SESSION_ID="$SESSION_ID" \
+    exec nohup "$CLAUDE_BIN" \
+      -n "${ORCH_ID}-${T}" \
+      --output-format stream-json \
+      --verbose \
+      --dangerously-skip-permissions \
+      -p "${WORKER_COMMAND} ${T} ${WORKER_ARGS}"
+  ) > "$STREAM" 2> "$STDERR" &
+  PID=$!
+
+  NOW2=$(now_iso)
+  jq --argjson pid "$PID" --arg ts "$NOW2" \
+    '.pid = $pid | .lastHeartbeat = $ts' \
+    "$SIGNAL_FILE" > "${SIGNAL_FILE}.tmp" && mv "${SIGNAL_FILE}.tmp" "$SIGNAL_FILE"
+
+  # Mirror into global state (best-effort — logged via fake script in tests).
+  "$STATE_SCRIPT" worker "$ORCH_ID" "$T" '.status = "dispatched" | .phase = 0' >/dev/null 2>&1 || true
+  "$STATE_SCRIPT" update "$ORCH_ID" '.progress.inProgressTickets += 1' >/dev/null 2>&1 || true
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg ts "$(now_iso)" --arg orch "$ORCH_ID" --arg w "$T" \
+    '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-dispatched", detail: null}')" \
+    >/dev/null 2>&1 || true
+
+  # Remove ticket from whichever waveNPending list it came from.
+  jq --arg t "$T" '
+    .queue |= (
+      (. // {}) | with_entries(
+        if (.key | test("^wave[0-9]+Pending$"))
+        then .value |= (. - [$t])
+        else . end
+      )
+    )' "$STATE_JSON" > "${STATE_JSON}.tmp" && mv "${STATE_JSON}.tmp" "$STATE_JSON"
+
+  DISPATCHED+=("$T")
+  SLOTS=$((SLOTS-1))
+done <<< "$PENDING"
+
+# ─── Dry-run also drains the queue conceptually, but in memory only ───────────
+if [ "$DRY_RUN" -eq 1 ] && [ "${#DISPATCHED[@]}" -gt 0 ]; then
+  : # queue was NOT mutated; intentional for dry-run
+fi
+
+# ─── Post-dispatch healthcheck (skip in dry-run or if disabled) ───────────────
+if [ "$DRY_RUN" -eq 0 ] && [ "$SKIP_HEALTHCHECK" -eq 0 ] \
+   && [ "${#DISPATCHED[@]}" -gt 0 ] \
+   && [ -n "$HEALTHCHECK_BIN" ] && [ -x "$HEALTHCHECK_BIN" ]; then
+  "$HEALTHCHECK_BIN" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+# ─── Emit final JSON summary ──────────────────────────────────────────────────
+if [ "${#DISPATCHED[@]}" -eq 0 ]; then
+  DISPATCHED_JSON='[]'
+else
+  DISPATCHED_JSON=$(printf '%s\n' "${DISPATCHED[@]}" | jq -R . | jq -sc .)
+fi
+printf '{"running":%d,"slotsAfter":%d,"dispatched":%s}\n' \
+  "$RUNNING" "$SLOTS" "$DISPATCHED_JSON"

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -454,6 +454,29 @@ fi
 
 For each provisioned worker worktree, dispatch a `/oneshot` session.
 
+**Preferred entrypoint — `orchestrate-dispatch-next` (CTL-116):**
+
+The canonical dispatcher drains `state.json`'s `.queue.waveNPending` for every `N`
+(dynamically, so wave 1/2/3/…/N all work without code changes), respects
+`maxParallel - currentlyRunning`, writes dispatched/phase-0 signal files, launches
+workers via `nohup`, updates global state, removes dispatched tickets from whichever
+`waveNPending` list they lived in, and runs the post-dispatch healthcheck:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-dispatch-next" \
+  --orch-dir "${ORCH_DIR}" \
+  --orch-id "${ORCH_NAME}"
+# Emits a one-line JSON summary: {"running":R,"slotsAfter":S,"dispatched":[...][,"queueEmpty":true]}
+# Reads `orchestrator`, `worktreeBase`, `maxParallel` from state.json by default.
+# Pass --session-id / --worker-command / --worker-args / --comms-channel to override.
+# Pass --dry-run to preview without writing state or launching claude.
+```
+
+Call this once when the current wave is ready to dispatch, and again whenever a
+worker slot frees up. It supersedes the hand-rolled `dispatch-next.sh` pattern from
+pre-CTL-116 orchestration runs (which hardcoded `wave1Pending + wave2Pending + wave3Pending`).
+The inline block below is preserved as reference for the underlying machinery.
+
 **Dispatch mechanism — `claude` CLI with streaming JSON:**
 
 ```bash


### PR DESCRIPTION
## Summary

- Ship a canonical `plugins/dev/scripts/orchestrate-dispatch-next` that drains `state.json`'s `.queue.waveNPending` for **every** `N` (dynamically enumerated via jq regex) — replacing the per-run hand-rolled `dispatch-next.sh` that hardcoded wave 1/2/3.
- 58 shell tests (`plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh`) cover empty queues, single/multi-wave drain, dynamic wave5/wave10 enumeration, `maxParallel` respect, running-worker accounting, missing worktrees, idempotency, dry-run, per-wave drain scope, env forwarding, override precedence, error modes, and help-output surface.
- `plugins/dev/skills/orchestrate/SKILL.md` Phase 3 now recommends the script as the preferred entrypoint; the inline dispatch block is kept as reference for the underlying machinery.
- No change to `state.json` shape — existing per-run `dispatch-next.sh` scripts continue to work unchanged.

## Ticket

Closes [CTL-116](https://linear.app/coalesce-labs/issue/CTL-116) — _Dispatch script should read all waveN pending queues_.

Surfaced during the 2026-04-20 `ctl-ux-apr20` orchestration run, where advancing to Wave 3 required a mid-run monkey-patch of that run's `dispatch-next.sh` to extend the jq read to `wave3Pending`. This change folds the pattern back upstream as a first-class, tested script.

## Acceptance

- [x] Canonical dispatcher script exists, tested against fixtures with waves 1/2/3/N (test 4 exercises wave5 + wave10)
- [x] Orchestrate skill references this script in Phase 3/4 docs (new "Preferred entrypoint" block at line ~457)
- [x] Existing custom `dispatch-next.sh` in active runs continues to work (no breaking change to `.queue.waveNPending` shape; verified by test 12)

## Key design notes

- **Dynamic wave enumeration**: single jq pipeline `select(.key | test("^wave[0-9]+Pending$"))` + `capture(...)` numeric sort + `map(.tickets[])` drains every wave in order without code-level wave limits.
- **Sibling conventions**: flags (`--orch-dir`, `--orch-id`, `--dry-run`), `CATALYST_STATE_SCRIPT` env override for tests, usage-via-`sed`, one-line JSON summary on stdout — all modeled on `orchestrate-revive` / `orchestrate-healthcheck`.
- **Defaults from state.json**: `orchestrator`, `worktreeBase`, `maxParallel` read from `state.json` when the CLI flag is omitted. CLI flags still take precedence so tests can inject whatever they need.
- **Concurrency note** added to the header: single-writer assumption, same as the existing hand-rolled pattern. Callers that poll should serialize dispatcher calls.

## Test plan

- [x] 58 new tests pass (`bash plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh`)
- [x] All 16 existing sibling shell test suites still pass — no regressions
- [x] Manual dry-run against the live `orch-ctl-115-116` state.json returns `{"running":2,"slotsAfter":1,"dispatched":[],"queueEmpty":true}` — script gracefully handles the missing-`.queue` case
- [x] `--help` prints the full usage block including the Concurrency note