### PR TITLE
feat(dev): OSS-safe feedback routing — linear→github fallback + consent (CTL-183)

### DIFF
--- a/plugins/dev/scripts/feedback-consent.sh
+++ b/plugins/dev/scripts/feedback-consent.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# feedback-consent - Manage the user's opt-in for automatic ticket filing by
+# catalyst skills. Reads and writes the `catalyst.feedback` block of
+# `.catalyst/config.json`. The consent model is deliberately asymmetric: "yes"
+# persists, "no" never persists — skills re-prompt on the next run. CTL-183.
+#
+# Usage:
+#   feedback-consent.sh check [--config <path>]
+#     → prints "granted" if catalyst.feedback.autoFile is true, else "unset"
+#
+#   feedback-consent.sh grant [--config <path>]
+#     → writes catalyst.feedback.autoFile = true (creates the block if needed)
+#     → prints "granted"
+#
+#   feedback-consent.sh status [--config <path>] [--json]
+#     → prints the full feedback block (human-readable by default, JSON with --json)
+#
+# Exit codes:
+#   0  success
+#   1  usage error or missing jq
+
+set -uo pipefail
+
+CONFIG=""
+JSON_OUT=0
+SUBCOMMAND=""
+
+usage() {
+  sed -n '2,21p' "$0" >&2
+  exit "${1:-1}"
+}
+
+[ $# -lt 1 ] && usage
+SUBCOMMAND="$1"; shift
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config) CONFIG="$2"; shift 2 ;;
+    --json)   JSON_OUT=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+resolve_config() {
+  if [ -n "$CONFIG" ]; then
+    echo "$CONFIG"; return 0
+  fi
+  local dir
+  dir="$(pwd)"
+  while [ "$dir" != "/" ]; do
+    if [ -f "${dir}/.catalyst/config.json" ]; then
+      echo "${dir}/.catalyst/config.json"; return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  # No config found; default to .catalyst/config.json relative to CWD so
+  # `grant` can create it.
+  echo "$(pwd)/.catalyst/config.json"
+}
+
+CONFIG_PATH="$(resolve_config)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for feedback-consent operations" >&2
+  exit 1
+fi
+
+read_auto_file() {
+  if [ ! -f "$CONFIG_PATH" ]; then
+    echo ""
+    return 0
+  fi
+  jq -r '.catalyst.feedback.autoFile // empty' "$CONFIG_PATH" 2>/dev/null
+}
+
+case "$SUBCOMMAND" in
+  check)
+    VAL="$(read_auto_file)"
+    if [ "$VAL" = "true" ]; then
+      echo "granted"
+    else
+      echo "unset"
+    fi
+    ;;
+
+  grant)
+    mkdir -p "$(dirname "$CONFIG_PATH")"
+    if [ ! -f "$CONFIG_PATH" ]; then
+      echo '{}' > "$CONFIG_PATH"
+    fi
+    TMP="${CONFIG_PATH}.tmp.$$"
+    if jq '.catalyst = (.catalyst // {})
+           | .catalyst.feedback = (.catalyst.feedback // {})
+           | .catalyst.feedback.autoFile = true
+           | .catalyst.feedback.githubRepo = (.catalyst.feedback.githubRepo // "coalesce-labs/catalyst")
+           | .catalyst.feedback.labels = (.catalyst.feedback.labels // ["auto-submitted"])' \
+         "$CONFIG_PATH" > "$TMP"; then
+      mv "$TMP" "$CONFIG_PATH"
+      echo "granted"
+    else
+      rm -f "$TMP"
+      echo "ERROR: failed to update config" >&2
+      exit 1
+    fi
+    ;;
+
+  status)
+    if [ ! -f "$CONFIG_PATH" ]; then
+      if [ "$JSON_OUT" -eq 1 ]; then
+        echo '{}'
+      else
+        echo "config not found: $CONFIG_PATH"
+        echo "autoFile: unset"
+      fi
+      exit 0
+    fi
+    BLOCK=$(jq -c '.catalyst.feedback // {}' "$CONFIG_PATH" 2>/dev/null)
+    if [ "$JSON_OUT" -eq 1 ]; then
+      echo "$BLOCK"
+    else
+      echo "config: $CONFIG_PATH"
+      AUTO=$(echo "$BLOCK" | jq -r '.autoFile // "unset"')
+      REPO=$(echo "$BLOCK" | jq -r '.githubRepo // "coalesce-labs/catalyst (default)"')
+      LABELS=$(echo "$BLOCK" | jq -r '.labels // ["auto-submitted"] | join(",")')
+      echo "autoFile:   $AUTO"
+      echo "githubRepo: $REPO"
+      echo "labels:     $LABELS"
+    fi
+    ;;
+
+  *)
+    echo "unknown subcommand: $SUBCOMMAND" >&2
+    usage
+    ;;
+esac

--- a/plugins/dev/scripts/file-feedback.sh
+++ b/plugins/dev/scripts/file-feedback.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# file-feedback - Route an auto-filed improvement ticket to Linear first, fall
+# back to GitHub on failure. Reads `.catalyst/config.json` for the consent
+# flag, github repo, and label list. Applies `auto-submitted` + the caller's
+# skill name as labels on both destinations. CTL-183.
+#
+# Usage:
+#   file-feedback.sh --title <T> --body <B> --skill <S>
+#                    [--labels <csv>] [--config <path>]
+#                    [--ensure-consent] [--json] [--dry-run]
+#
+#   --title <T>         Ticket title (required)
+#   --body <B>          Ticket body / description (required)
+#   --skill <S>         Invoking skill name, added as a label (required)
+#   --labels <csv>      Extra labels, comma-separated
+#   --config <path>     Path to .catalyst/config.json (default: auto-discover)
+#   --ensure-consent    Exit 3 with consent-required instead of 2 skipped when
+#                       autoFile is unset. Caller is expected to prompt and
+#                       call feedback-consent.sh grant, then retry.
+#   --json              Always emit JSON (default: JSON for non-TTY, human-
+#                       readable otherwise)
+#   --dry-run           Compose the payload + destination, don't call any CLI
+#
+# Exit codes:
+#   0  filed successfully
+#   1  hard failure (no destinations available, or both CLI calls errored)
+#   2  skipped — consent not granted (no --ensure-consent)
+#   3  consent-required — only when --ensure-consent is set
+#  64  usage error
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONSENT_SCRIPT="${SCRIPT_DIR}/feedback-consent.sh"
+
+TITLE=""
+BODY=""
+SKILL=""
+EXTRA_LABELS=""
+CONFIG=""
+ENSURE_CONSENT=0
+JSON_OUT=""
+DRY_RUN=0
+
+usage() {
+  sed -n '2,29p' "$0" >&2
+  exit "${1:-64}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)           TITLE="$2"; shift 2 ;;
+    --body)            BODY="$2"; shift 2 ;;
+    --skill)           SKILL="$2"; shift 2 ;;
+    --labels)          EXTRA_LABELS="$2"; shift 2 ;;
+    --config)          CONFIG="$2"; shift 2 ;;
+    --ensure-consent)  ENSURE_CONSENT=1; shift ;;
+    --json)            JSON_OUT=1; shift ;;
+    --dry-run)         DRY_RUN=1; shift ;;
+    -h|--help)         usage 0 ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -z "$TITLE" ] && { echo "ERROR: --title required" >&2; exit 64; }
+[ -z "$BODY" ]  && { echo "ERROR: --body required" >&2; exit 64; }
+[ -z "$SKILL" ] && { echo "ERROR: --skill required" >&2; exit 64; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for file-feedback" >&2
+  exit 1
+fi
+
+# Default JSON output to on for non-TTY, off for TTY.
+if [ -z "$JSON_OUT" ]; then
+  if [ -t 1 ]; then JSON_OUT=0; else JSON_OUT=1; fi
+fi
+
+# ─── Resolve config ────────────────────────────────────────────────────────
+resolve_config() {
+  if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]; then
+    echo "$CONFIG"; return 0
+  fi
+  local dir
+  dir="$(pwd)"
+  while [ "$dir" != "/" ]; do
+    if [ -f "${dir}/.catalyst/config.json" ]; then
+      echo "${dir}/.catalyst/config.json"; return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo ""
+}
+
+CONFIG_PATH="$(resolve_config)"
+
+# ─── Read config values ────────────────────────────────────────────────────
+AUTO_FILE=""
+GITHUB_REPO=""
+CONFIG_LABELS=""
+TEAM_KEY=""
+
+if [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ]; then
+  AUTO_FILE=$(jq -r '.catalyst.feedback.autoFile // empty' "$CONFIG_PATH" 2>/dev/null)
+  GITHUB_REPO=$(jq -r '.catalyst.feedback.githubRepo // empty' "$CONFIG_PATH" 2>/dev/null)
+  CONFIG_LABELS=$(jq -r '.catalyst.feedback.labels // ["auto-submitted"] | join(",")' \
+    "$CONFIG_PATH" 2>/dev/null)
+  TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CONFIG_PATH" 2>/dev/null)
+fi
+
+# Defaults when config is silent.
+[ -z "$GITHUB_REPO" ]   && GITHUB_REPO="coalesce-labs/catalyst"
+[ -z "$CONFIG_LABELS" ] && CONFIG_LABELS="auto-submitted"
+
+# ─── Emit helper ───────────────────────────────────────────────────────────
+emit() {
+  local status="$1" destination="$2" identifier="$3" number="$4" url="$5" err="$6"
+  local labels_json
+  labels_json=$(printf '%s' "$LABELS_CSV" | jq -Rc 'split(",")' 2>/dev/null || echo "[]")
+
+  if [ "$JSON_OUT" -eq 1 ]; then
+    jq -nc \
+      --arg status "$status" \
+      --arg destination "$destination" \
+      --arg identifier "$identifier" \
+      --arg number "$number" \
+      --arg url "$url" \
+      --arg err "$err" \
+      --argjson labels "$labels_json" \
+      '{
+        status: $status,
+        destination: (if $destination == "" then null else $destination end),
+        identifier: (if $identifier == "" then null else $identifier end),
+        number: (if $number == "" then null else ($number | tonumber?) end),
+        url: (if $url == "" then null else $url end),
+        labels: $labels,
+        error: (if $err == "" then null else $err end)
+      }'
+  else
+    printf '%s' "$status"
+    [ -n "$destination" ] && printf ' → %s' "$destination"
+    [ -n "$identifier" ]  && printf ' (%s)' "$identifier"
+    [ -n "$number" ]      && printf ' (#%s)' "$number"
+    [ -n "$url" ]         && printf ' %s' "$url"
+    [ -n "$err" ]         && printf ' — %s' "$err"
+    printf '\n'
+  fi
+}
+
+# ─── Compose label set ─────────────────────────────────────────────────────
+# Merge config labels + --labels arg + skill name, deduplicated, CSV.
+join_labels() {
+  local parts=""
+  [ -n "$CONFIG_LABELS" ] && parts="${parts}${CONFIG_LABELS},"
+  [ -n "$EXTRA_LABELS" ]  && parts="${parts}${EXTRA_LABELS},"
+  [ -n "$SKILL" ]         && parts="${parts}${SKILL}"
+  # Deduplicate while preserving order. awk handles CSV splits cleanly.
+  printf '%s' "$parts" | awk -v RS=',' '!seen[$0]++ && NF' | paste -sd, -
+}
+
+LABELS_CSV="$(join_labels)"
+
+# ─── Consent gate ──────────────────────────────────────────────────────────
+if [ "$AUTO_FILE" != "true" ]; then
+  if [ "$ENSURE_CONSENT" -eq 1 ]; then
+    emit "consent-required" "" "" "" "" ""
+    exit 3
+  fi
+  emit "skipped-no-consent" "" "" "" "" ""
+  exit 2
+fi
+
+# ─── Dry run ───────────────────────────────────────────────────────────────
+if [ "$DRY_RUN" -eq 1 ]; then
+  # Pick the best guess destination for dry-run output.
+  if command -v linearis >/dev/null 2>&1; then
+    emit "dry-run" "linear" "" "" "" "would file to team=${TEAM_KEY:-?}"
+  elif command -v gh >/dev/null 2>&1; then
+    emit "dry-run" "github" "" "" "" "would file to repo=${GITHUB_REPO}"
+  else
+    emit "dry-run" "" "" "" "" "no CLI available"
+  fi
+  exit 0
+fi
+
+# ─── Try Linear first ──────────────────────────────────────────────────────
+try_linearis() {
+  if ! command -v linearis >/dev/null 2>&1; then
+    return 1
+  fi
+  if [ -z "$TEAM_KEY" ]; then
+    return 1
+  fi
+
+  local create_json identifier linear_url
+  create_json=$(linearis issues create "$TITLE" \
+    --team "$TEAM_KEY" \
+    --description "$BODY" \
+    --output json 2>/dev/null || echo "")
+  identifier=$(echo "$create_json" | jq -r '.identifier // empty' 2>/dev/null)
+  linear_url=$(echo "$create_json" | jq -r '.url // empty' 2>/dev/null)
+
+  if [ -z "$identifier" ]; then
+    return 1
+  fi
+
+  # Apply labels via a follow-up update. Label failures are non-fatal.
+  if [ -n "$LABELS_CSV" ]; then
+    linearis issues update "$identifier" \
+      --labels "$LABELS_CSV" --label-mode add >/dev/null 2>&1 || true
+  fi
+
+  # Fetch URL if the create response didn't include one.
+  if [ -z "$linear_url" ]; then
+    linear_url=$(linearis issues read "$identifier" --output json 2>/dev/null \
+      | jq -r '.url // empty' 2>/dev/null || echo "")
+  fi
+
+  emit "filed" "linear" "$identifier" "" "$linear_url" ""
+  return 0
+}
+
+if try_linearis; then
+  exit 0
+fi
+
+# ─── Fall back to GitHub ───────────────────────────────────────────────────
+try_gh() {
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+
+  # Build the --label args as separate flags so commas in label names never
+  # collide with gh's CSV parsing.
+  local -a label_args=()
+  local IFS=','
+  for L in $LABELS_CSV; do
+    [ -n "$L" ] && label_args+=(--label "$L")
+  done
+  unset IFS
+
+  local gh_out gh_err issue_url issue_number
+  gh_err=$(mktemp)
+  gh_out=$(gh issue create \
+    --repo "$GITHUB_REPO" \
+    --title "$TITLE" \
+    --body "$BODY" \
+    "${label_args[@]}" 2>"$gh_err")
+  local rc=$?
+
+  if [ $rc -ne 0 ]; then
+    local err_msg
+    err_msg=$(tr '\n' ' ' < "$gh_err" | head -c 200)
+    rm -f "$gh_err"
+    emit "failed" "" "" "" "" "gh issue create failed: ${err_msg}"
+    return 2
+  fi
+  rm -f "$gh_err"
+
+  # gh issue create emits the issue URL on its last line.
+  issue_url=$(printf '%s' "$gh_out" | tail -n1 | tr -d '[:space:]')
+  issue_number=$(printf '%s' "$issue_url" | sed -n 's:.*/issues/\([0-9][0-9]*\).*:\1:p')
+
+  emit "filed" "github" "" "$issue_number" "$issue_url" ""
+  return 0
+}
+
+GH_RESULT=0
+try_gh || GH_RESULT=$?
+
+if [ $GH_RESULT -eq 0 ]; then
+  exit 0
+elif [ $GH_RESULT -eq 2 ]; then
+  # emit was already called with the error message
+  exit 1
+fi
+
+# Neither CLI worked.
+emit "failed-no-destinations" "" "" "" "" "neither linearis nor gh could file this ticket"
+exit 1

--- a/plugins/dev/scripts/test-file-feedback.sh
+++ b/plugins/dev/scripts/test-file-feedback.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Test suite for feedback-consent.sh + file-feedback.sh
+#
+# Uses PATH-stubbed `linearis` and `gh` to exercise routing logic without
+# touching real APIs. CTL-183.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONSENT_SCRIPT="$SCRIPT_DIR/feedback-consent.sh"
+FILE_SCRIPT="$SCRIPT_DIR/file-feedback.sh"
+
+PASS=true
+TESTS=0
+FAILURES=0
+
+fail() { echo "  FAIL: $1"; PASS=false; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  PASS: $1"; }
+run_test() { TESTS=$((TESTS + 1)); echo ""; echo "--- Test $TESTS: $1 ---"; }
+
+# Make a scratch dir with a minimal .catalyst/config.json.
+setup_config() {
+  local dir="$1"
+  local contents="$2"
+  [ -z "$contents" ] && contents='{}'
+  mkdir -p "$dir/.catalyst"
+  printf '%s' "$contents" > "$dir/.catalyst/config.json"
+}
+
+# Write a PATH stub with given contents. $1=name, $2=script body.
+make_stub() {
+  local dir="$1" name="$2" body="$3"
+  cat > "$dir/$name" <<EOF
+#!/usr/bin/env bash
+$body
+EOF
+  chmod +x "$dir/$name"
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Consent helper tests
+# ───────────────────────────────────────────────────────────────────────────
+
+run_test "consent check on fresh config returns unset"
+TMPD=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{}}'
+OUT=$("$CONSENT_SCRIPT" check --config "$TMPD/.catalyst/config.json")
+[ "$OUT" = "unset" ] && pass "got unset" || fail "expected unset, got: $OUT"
+rm -rf "$TMPD"
+
+run_test "consent grant writes autoFile=true + defaults"
+TMPD=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{}}'
+"$CONSENT_SCRIPT" grant --config "$TMPD/.catalyst/config.json" >/dev/null
+AUTO=$(jq -r '.catalyst.feedback.autoFile' "$TMPD/.catalyst/config.json")
+REPO=$(jq -r '.catalyst.feedback.githubRepo' "$TMPD/.catalyst/config.json")
+LABELS=$(jq -r '.catalyst.feedback.labels | join(",")' "$TMPD/.catalyst/config.json")
+[ "$AUTO" = "true" ] && pass "autoFile=true" || fail "autoFile=$AUTO"
+[ "$REPO" = "coalesce-labs/catalyst" ] && pass "githubRepo default" || fail "repo=$REPO"
+[ "$LABELS" = "auto-submitted" ] && pass "labels default" || fail "labels=$LABELS"
+rm -rf "$TMPD"
+
+run_test "consent grant is idempotent (does not overwrite existing values)"
+TMPD=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{"feedback":{"autoFile":false,"githubRepo":"foo/bar","labels":["custom"]}}}'
+"$CONSENT_SCRIPT" grant --config "$TMPD/.catalyst/config.json" >/dev/null
+AUTO=$(jq -r '.catalyst.feedback.autoFile' "$TMPD/.catalyst/config.json")
+REPO=$(jq -r '.catalyst.feedback.githubRepo' "$TMPD/.catalyst/config.json")
+LABELS=$(jq -r '.catalyst.feedback.labels | join(",")' "$TMPD/.catalyst/config.json")
+[ "$AUTO" = "true" ] && pass "autoFile flipped to true" || fail "autoFile=$AUTO"
+[ "$REPO" = "foo/bar" ] && pass "existing repo preserved" || fail "repo=$REPO"
+[ "$LABELS" = "custom" ] && pass "existing labels preserved" || fail "labels=$LABELS"
+rm -rf "$TMPD"
+
+run_test "consent check returns granted after grant"
+TMPD=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{"feedback":{"autoFile":true}}}'
+OUT=$("$CONSENT_SCRIPT" check --config "$TMPD/.catalyst/config.json")
+[ "$OUT" = "granted" ] && pass "got granted" || fail "expected granted, got: $OUT"
+rm -rf "$TMPD"
+
+# ───────────────────────────────────────────────────────────────────────────
+# File-feedback routing tests
+# ───────────────────────────────────────────────────────────────────────────
+
+run_test "skipped-no-consent when autoFile unset, exit 2"
+TMPD=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{}}'
+OUT=$("$FILE_SCRIPT" --title T --body B --skill oneshot \
+  --config "$TMPD/.catalyst/config.json" --json)
+RC=$?
+STATUS=$(echo "$OUT" | jq -r .status)
+[ $RC -eq 2 ] && pass "exit 2" || fail "exit=$RC"
+[ "$STATUS" = "skipped-no-consent" ] && pass "status=skipped-no-consent" || fail "status=$STATUS"
+rm -rf "$TMPD"
+
+run_test "consent-required with --ensure-consent, exit 3"
+TMPD=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{}}'
+OUT=$("$FILE_SCRIPT" --title T --body B --skill oneshot \
+  --config "$TMPD/.catalyst/config.json" --ensure-consent --json)
+RC=$?
+STATUS=$(echo "$OUT" | jq -r .status)
+[ $RC -eq 3 ] && pass "exit 3" || fail "exit=$RC"
+[ "$STATUS" = "consent-required" ] && pass "status=consent-required" || fail "status=$STATUS"
+rm -rf "$TMPD"
+
+run_test "linearis stub returns identifier → filed to linear"
+TMPD=$(mktemp -d); STUB=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{"feedback":{"autoFile":true},"linear":{"teamKey":"TEST"}}}'
+make_stub "$STUB" "linearis" '
+if [ "$1" = "issues" ] && [ "$2" = "create" ]; then
+  echo "{\"identifier\":\"TEST-42\",\"url\":\"https://linear.app/test/issue/TEST-42\"}"
+elif [ "$1" = "issues" ] && [ "$2" = "update" ]; then
+  echo "{\"ok\":true}"
+else
+  echo "{}"
+fi
+'
+PATH="$STUB:$PATH" OUT=$("$FILE_SCRIPT" --title T --body B --skill oneshot \
+  --config "$TMPD/.catalyst/config.json" --json)
+RC=$?
+STATUS=$(echo "$OUT" | jq -r .status)
+DEST=$(echo "$OUT" | jq -r .destination)
+IDENT=$(echo "$OUT" | jq -r .identifier)
+URL=$(echo "$OUT" | jq -r .url)
+LABELS=$(echo "$OUT" | jq -r '.labels | join(",")')
+[ $RC -eq 0 ] && pass "exit 0" || fail "exit=$RC"
+[ "$STATUS" = "filed" ] && pass "status=filed" || fail "status=$STATUS"
+[ "$DEST" = "linear" ] && pass "destination=linear" || fail "dest=$DEST"
+[ "$IDENT" = "TEST-42" ] && pass "identifier=TEST-42" || fail "ident=$IDENT"
+[ "$URL" = "https://linear.app/test/issue/TEST-42" ] && pass "url set" || fail "url=$URL"
+[ "$LABELS" = "auto-submitted,oneshot" ] && pass "labels=auto-submitted,oneshot" || fail "labels=$LABELS"
+rm -rf "$TMPD" "$STUB"
+
+run_test "linearis returns empty → falls through to github"
+TMPD=$(mktemp -d); STUB=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{"feedback":{"autoFile":true,"githubRepo":"my/repo"},"linear":{"teamKey":"TEST"}}}'
+make_stub "$STUB" "linearis" 'echo ""'
+make_stub "$STUB" "gh" '
+# Capture args for verification.
+echo "https://github.com/my/repo/issues/7"
+'
+PATH="$STUB:$PATH" OUT=$("$FILE_SCRIPT" --title T --body B --skill oneshot \
+  --config "$TMPD/.catalyst/config.json" --json)
+RC=$?
+STATUS=$(echo "$OUT" | jq -r .status)
+DEST=$(echo "$OUT" | jq -r .destination)
+NUM=$(echo "$OUT" | jq -r .number)
+URL=$(echo "$OUT" | jq -r .url)
+[ $RC -eq 0 ] && pass "exit 0" || fail "exit=$RC"
+[ "$STATUS" = "filed" ] && pass "status=filed" || fail "status=$STATUS"
+[ "$DEST" = "github" ] && pass "destination=github" || fail "dest=$DEST"
+[ "$NUM" = "7" ] && pass "number=7" || fail "num=$NUM"
+[ "$URL" = "https://github.com/my/repo/issues/7" ] && pass "url set" || fail "url=$URL"
+rm -rf "$TMPD" "$STUB"
+
+run_test "no linearis, gh present → files to github"
+TMPD=$(mktemp -d); STUB=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{"feedback":{"autoFile":true,"githubRepo":"coalesce-labs/catalyst"}}}'
+# Only gh stub — no linearis. Build a minimal PATH that still has jq + core utilities.
+make_stub "$STUB" "gh" 'echo "https://github.com/coalesce-labs/catalyst/issues/99"'
+REAL_PATH=$(dirname "$(command -v jq)"):$(dirname "$(command -v bash)"):$(dirname "$(command -v awk)"):$(dirname "$(command -v sed)")
+OUT=$(PATH="$STUB:$REAL_PATH:/usr/bin:/bin" "$FILE_SCRIPT" --title T --body B --skill oneshot \
+  --config "$TMPD/.catalyst/config.json" --json)
+RC=$?
+STATUS=$(echo "$OUT" | jq -r .status)
+DEST=$(echo "$OUT" | jq -r .destination)
+[ $RC -eq 0 ] && pass "exit 0" || fail "exit=$RC"
+[ "$STATUS" = "filed" ] && pass "status=filed" || fail "status=$STATUS"
+[ "$DEST" = "github" ] && pass "destination=github" || fail "dest=$DEST"
+rm -rf "$TMPD" "$STUB"
+
+run_test "neither CLI → failed-no-destinations, exit 1"
+TMPD=$(mktemp -d); STUB=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{"feedback":{"autoFile":true}}}'
+# Put deliberately-broken stubs that make `command -v` succeed but invocation
+# fails — except we want command -v to FAIL, so we don't create them at all.
+# Instead, shadow real tools with blockers by placing non-exec files named
+# linearis/gh ahead of PATH so `command -v` doesn't find them.
+# Easiest: build PATH with only the real dirs needed for jq/coreutils, and
+# skip the stubdir.
+JQ_DIR=$(dirname "$(command -v jq)")
+OUT=$(PATH="$JQ_DIR:/usr/bin:/bin" "$FILE_SCRIPT" --title T --body B --skill oneshot \
+  --config "$TMPD/.catalyst/config.json" --json)
+RC=$?
+STATUS=$(echo "$OUT" | jq -r .status)
+[ $RC -eq 1 ] && pass "exit 1" || fail "exit=$RC"
+[ "$STATUS" = "failed-no-destinations" ] && pass "status=failed-no-destinations" || fail "status=$STATUS"
+rm -rf "$TMPD" "$STUB"
+
+run_test "custom --labels merged + deduplicated with config labels + skill name"
+TMPD=$(mktemp -d); STUB=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{"feedback":{"autoFile":true,"labels":["auto-submitted","critical"]},"linear":{"teamKey":"TEST"}}}'
+make_stub "$STUB" "linearis" 'echo "{\"identifier\":\"TEST-1\",\"url\":\"https://linear.app/x/issue/TEST-1\"}"'
+PATH="$STUB:$PATH" OUT=$("$FILE_SCRIPT" --title T --body B --skill oneshot \
+  --labels "auto-submitted,extra-label" \
+  --config "$TMPD/.catalyst/config.json" --json)
+LABELS=$(echo "$OUT" | jq -r '.labels | join(",")')
+# Expected order: config labels → --labels → skill name, deduped in-place
+[ "$LABELS" = "auto-submitted,critical,extra-label,oneshot" ] && pass "labels deduped: $LABELS" || fail "labels=$LABELS"
+rm -rf "$TMPD" "$STUB"
+
+run_test "dry-run reports linear destination when linearis present"
+TMPD=$(mktemp -d); STUB=$(mktemp -d)
+setup_config "$TMPD" '{"catalyst":{"feedback":{"autoFile":true},"linear":{"teamKey":"TEST"}}}'
+make_stub "$STUB" "linearis" 'echo "{}"'
+PATH="$STUB:$PATH" OUT=$("$FILE_SCRIPT" --title T --body B --skill oneshot \
+  --config "$TMPD/.catalyst/config.json" --dry-run --json)
+STATUS=$(echo "$OUT" | jq -r .status)
+DEST=$(echo "$OUT" | jq -r .destination)
+[ "$STATUS" = "dry-run" ] && pass "status=dry-run" || fail "status=$STATUS"
+[ "$DEST" = "linear" ] && pass "dest=linear" || fail "dest=$DEST"
+rm -rf "$TMPD" "$STUB"
+
+# ───────────────────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================"
+echo "Tests: $TESTS, Failures: $FAILURES"
+if [ "$PASS" = "true" ]; then
+  echo "All tests passed."
+  exit 0
+else
+  echo "Some tests failed."
+  exit 1
+fi

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -253,6 +253,31 @@ Agent(subagent_type="pr-review-toolkit:pr-test-analyzer",
 
 If critical gaps exist, write the missing tests.
 
+### File Improvement Findings (Optional)
+
+If the implementation surfaced any improvement findings worth filing as follow-up tickets
+(per [[CTL-176]] — inert until that ticket lands), route each through the feedback helper.
+`implement-plan` usually runs under another orchestrator or under `/oneshot`, so prefer the
+calling skill's filing step when one exists; the block below is a safety net for direct
+invocations:
+
+```bash
+FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
+CONSENT="${CLAUDE_PLUGIN_ROOT}/scripts/feedback-consent.sh"
+
+if [ -x "$FEEDBACK" ] && [ -x "$CONSENT" ] && [ -n "${FINDINGS[*]:-}" ]; then
+  if [ "$("$CONSENT" check)" != "granted" ] && [ -z "${CATALYST_AUTONOMOUS:-}" ] && [ -t 0 ]; then
+    read -r -p "File ${#FINDINGS[@]} improvement tickets now? [Y/n] " yn
+    case "$yn" in [Nn]*) : ;; *) "$CONSENT" grant >/dev/null ;; esac
+  fi
+  if [ "$("$CONSENT" check)" = "granted" ]; then
+    for F in "${FINDINGS[@]}"; do
+      "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill implement-plan --json || true
+    done
+  fi
+fi
+```
+
 ### End Session Tracking
 
 After all quality gates pass (or are skipped), end the session:

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -658,6 +658,31 @@ missing `linearis` CLI (CTL-69):
 The orchestrator's safety-net poll loop calls the same helper when it independently confirms a
 PR has merged, so both paths stay in sync.
 
+**Step 5: File improvement findings (CTL-183 routing, optional)**
+
+If the worker captured any improvement findings during the run (per [[CTL-176]] — inert until
+that ticket lands), route each through the feedback helper. Runs as a no-op if no findings were
+collected. In orchestrator-dispatched workers, stdin is not a TTY and `CATALYST_AUTONOMOUS=1`
+is expected to be set — the helper silently skips filing when consent is not already granted,
+never prompts. Standalone oneshot runs prompt interactively once and persist "yes":
+
+```bash
+FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
+CONSENT="${CLAUDE_PLUGIN_ROOT}/scripts/feedback-consent.sh"
+
+if [ -x "$FEEDBACK" ] && [ -x "$CONSENT" ] && [ -n "${FINDINGS[*]:-}" ]; then
+  if [ "$("$CONSENT" check)" != "granted" ] && [ -z "${CATALYST_AUTONOMOUS:-}" ] && [ -t 0 ]; then
+    read -r -p "File ${#FINDINGS[@]} improvement tickets at end of run? [Y/n] " yn
+    case "$yn" in [Nn]*) : ;; *) "$CONSENT" grant >/dev/null ;; esac
+  fi
+  if [ "$("$CONSENT" check)" = "granted" ]; then
+    for F in "${FINDINGS[@]}"; do
+      "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill oneshot --json || true
+    done
+  fi
+fi
+```
+
 **If `--no-merge` was set**, skip Steps 2–3 entirely and report PR status instead:
 
 ```

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -1245,13 +1245,38 @@ When all waves are complete:
 3. **Verify Linear states**: Check all tickets are in `stateMap.done`. If any are stuck, update them
    using the Linearis CLI (run `linearis issues usage` for update syntax).
 
-4. **Clean up all worktrees** (including orchestrator worktree, unless user wants to keep it).
+4. **File improvement findings (CTL-183 routing, optional):** If the orchestrator collected any
+   improvement findings during the run (per [[CTL-176]] — inert until that ticket lands), route
+   each finding through the feedback helper so it lands in Linear (or GitHub, if Linear is
+   unavailable). Runs as a no-op when there are no findings.
+
+   ```bash
+   FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
+   CONSENT="${CLAUDE_PLUGIN_ROOT}/scripts/feedback-consent.sh"
+
+   # Autonomous mode (orchestrator runs without a TTY): file only when consent
+   # is already granted — never prompt. Interactive maintainer invocations
+   # prompt once, then persist on yes.
+   if [ -x "$FEEDBACK" ] && [ -x "$CONSENT" ] && [ -n "${FINDINGS[*]:-}" ]; then
+     if [ "$("$CONSENT" check)" != "granted" ] && [ -z "${CATALYST_AUTONOMOUS:-}" ] && [ -t 0 ]; then
+       read -r -p "File ${#FINDINGS[@]} improvement tickets at end of run? [Y/n] " yn
+       case "$yn" in [Nn]*) : ;; *) "$CONSENT" grant >/dev/null ;; esac
+     fi
+     if [ "$("$CONSENT" check)" = "granted" ]; then
+       for F in "${FINDINGS[@]}"; do
+         "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill orchestrate --json || true
+       done
+     fi
+   fi
+   ```
+
+5. **Clean up all worktrees** (including orchestrator worktree, unless user wants to keep it).
    Use `/catalyst-dev:teardown ${ORCH_NAME}` for a safe, archive-gated deletion. Teardown
    refuses to run unless step 2's sweep succeeded (use `--force` to override).
 
-5. **Sync thoughts**: `humanlayer thoughts sync` to persist any shared documents.
+6. **Sync thoughts**: `humanlayer thoughts sync` to persist any shared documents.
 
-6. **Complete and archive global state**:
+7. **Complete and archive global state**:
 
 ```bash
 # CTL-111: post orchestrator done to shared comms channel. Workers have already
@@ -1277,7 +1302,7 @@ if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
 fi
 ```
 
-7. **Report to user**:
+8. **Report to user**:
 
    ```
    Orchestration Complete — "api-redesign"

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -26,6 +26,11 @@
     },
     "thoughts": {
       "user": null
+    },
+    "feedback": {
+      "autoFile": false,
+      "githubRepo": "coalesce-labs/catalyst",
+      "labels": ["auto-submitted"]
     }
   }
 }

--- a/plugins/dev/templates/fixup-prompt.md
+++ b/plugins/dev/templates/fixup-prompt.md
@@ -60,6 +60,19 @@ ${ISSUES}
     signal file (sourced from `gh pr view --json mergedAt`), transition the Linear ticket to
     Done, then exit successfully.
 
+11. **File improvement findings (optional, CTL-183 routing)** — if you captured improvement
+    findings during this fix-up (per CTL-176, inert until that ticket lands), invoke the feedback
+    helper once per finding. Fix-up workers always run autonomously (no TTY, no prompt), so the
+    helper silently skips when consent is not already granted:
+    ```bash
+    FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
+    if [ -x "$FEEDBACK" ] && [ -n "${FINDINGS[*]:-}" ]; then
+      for F in "${FINDINGS[@]}"; do
+        "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill worker-fixup --json || true
+      done
+    fi
+    ```
+
 ## What NOT to do
 
 - Do NOT file a new Linear ticket — this is recovery on the same ticket.

--- a/plugins/dev/templates/followup-prompt.md
+++ b/plugins/dev/templates/followup-prompt.md
@@ -59,6 +59,19 @@ known parent to reference.
    resolve BEHIND/CI/review blockers, and only exit when `state=MERGED` and you have written
    `pr.mergedAt` + `status: "done"` to your signal file.
 
+10. **File new improvement findings (optional, CTL-183 routing)** — if this follow-up surfaces
+    its own new findings worth tracking (per CTL-176, inert until that ticket lands), invoke the
+    feedback helper once per finding. Follow-up workers always run autonomously (no TTY), so
+    the helper silently skips when consent is not already granted:
+    ```bash
+    FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
+    if [ -x "$FEEDBACK" ] && [ -n "${NEW_FINDINGS[*]:-}" ]; then
+      for F in "${NEW_FINDINGS[@]}"; do
+        "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill worker-followup --json || true
+      done
+    fi
+    ```
+
 ## What NOT to do
 
 - Do NOT reopen or push to the parent's PR — it's merged, that branch is gone.

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -458,6 +458,53 @@ Optional. Add this block to enable `/orchestrate` — see [Orchestration](/refer
 | `verifyBeforeMerge` | boolean | `true` | Run adversarial verification before allowing merge |
 | `allowSelfReportedCompletion` | boolean | `false` | Trust worker's self-reported completion without verification |
 
+## Feedback Config
+
+Optional. Controls where catalyst skills auto-file improvement tickets at run end and on whose
+permission. Primarily relevant once [CTL-176](https://github.com/coalesce-labs/catalyst/issues)
+(skill-driven auto-filing) lands; CTL-183 ships the routing layer it will consume.
+
+```json
+{
+  "catalyst": {
+    "feedback": {
+      "autoFile": false,
+      "githubRepo": "coalesce-labs/catalyst",
+      "labels": ["auto-submitted"]
+    }
+  }
+}
+```
+
+| Field         | Type     | Default                      | Description                                                                                                                                           |
+| ------------- | -------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autoFile`    | boolean  | `false`                      | When `true`, skills may auto-file findings at run end without prompting. When `false` or absent, skills prompt before filing each run.                |
+| `githubRepo`  | string   | `"coalesce-labs/catalyst"`   | `<owner>/<repo>` slug used when Linear filing fails or is unavailable. Defaults to upstream; override to redirect findings to your own fork.          |
+| `labels`      | string[] | `["auto-submitted"]`         | Base labels applied to every auto-filed ticket. The invoking skill name is appended automatically (e.g., `oneshot`, `orchestrate`, `implement-plan`). |
+
+### Routing
+
+Skills attempt `linearis issues create` first, using `catalyst.linear.teamKey`. On Linear
+failure (no API key, team mismatch, CLI unavailable), they fall back to
+`gh issue create --repo <feedback.githubRepo>`. Destinations are never split — GitHub is used
+only when Linear is unavailable.
+
+### Consent
+
+The first time a skill is ready to auto-file, it prompts:
+
+> Would you like us to automatically file tickets at the end of each run? [Y/n]
+
+- **Yes** → `autoFile` is set to `true` in `.catalyst/config.json`; no prompt on subsequent runs.
+- **No** → nothing is persisted; the prompt will return on the next run.
+
+Revoke by setting `autoFile` to `false` or deleting the `feedback` block. The
+`plugins/dev/scripts/feedback-consent.sh` helper exposes `check`, `grant`, and `status`
+subcommands for scripted use.
+
+See [Integrations › Linear ⇄ GitHub Sync](/reference/integrations/#linear--github-sync) for the
+maintainer-side setup that mirrors `auto-submitted`-labeled GitHub issues back into Linear.
+
 ## Archive Config
 
 Optional. Controls where orchestrator artifacts are persisted and how long they are retained.

--- a/website/src/content/docs/reference/integrations.md
+++ b/website/src/content/docs/reference/integrations.md
@@ -53,6 +53,29 @@ Customize state names via `stateMap` in your [project config](/reference/configu
 
 Skills detect tickets automatically from plan frontmatter (`ticket: PROJ-123`), filenames, handoff documents, and worktree directory names.
 
+### Linear ⇄ GitHub Sync
+
+Catalyst's feedback routing (see [Feedback Config](/reference/configuration/#feedback-config))
+prefers Linear but falls back to a GitHub issue on a configured repository when Linear is
+unavailable. Maintainers can mirror those GitHub issues back into Linear via Linear's native
+GitHub integration, so all auto-filed tickets land in the same triage queue regardless of who
+filed them.
+
+**Setup** (one-time, Linear workspace admin):
+
+1. In Linear, open **Settings → Integrations → GitHub**.
+2. Connect the Linear workspace to the repository that receives fallback filings (default:
+   `coalesce-labs/catalyst`, or whatever `catalyst.feedback.githubRepo` is set to in your
+   project config).
+3. In the connector's issue-sync rules, filter on the `auto-submitted` label so only
+   agent-filed issues are mirrored.
+4. Map the target Linear team (e.g., `CTL`) and the default status (e.g., `Backlog`).
+
+Once configured, any GitHub issue created by a Catalyst skill surfaces in the maintainer's
+Linear workspace automatically, preserving the `auto-submitted` label plus the skill-name
+label (e.g., `oneshot`, `orchestrate`). See Linear's [GitHub integration
+docs](https://linear.app/docs/github) for the current setup UI.
+
 ## Sentry
 
 Production error monitoring via the `catalyst-debugging` plugin.


### PR DESCRIPTION
## Summary

Ships the routing + consent infrastructure that skill auto-filing (CTL-176) will consume. Skills that want to auto-file improvement tickets at run end now have a single helper that prefers Linear, falls back to GitHub, and refuses to file without explicit user consent.

- **`plugins/dev/scripts/feedback-consent.sh`** — `check` / `grant` / `status` subcommands for the new `catalyst.feedback.autoFile` flag. Consent is asymmetric: "yes" persists, "no" never persists (re-prompt each run, per design).
- **`plugins/dev/scripts/file-feedback.sh`** — routing helper. Linear first via `linearis issues create`; on failure (no CLI, no API key, team mismatch), falls back to `gh issue create` against `catalyst.feedback.githubRepo` (default `coalesce-labs/catalyst`). Labels every ticket with `auto-submitted` + the invoking skill name. `--ensure-consent` lets callers prompt on their own; `CATALYST_AUTONOMOUS=1` or non-TTY disables prompting.
- **Config schema** — new `catalyst.feedback` block (optional, documented) in `configuration.md`, plus a `### Linear ⇄ GitHub Sync` subsection in `integrations.md` describing the maintainer-side native-connector setup. Template updated with safe defaults.
- **Skill hook points** — `orchestrate` Phase 7, `oneshot` Phase 5, `implement-plan` end-of-run, plus `fixup-prompt.md` / `followup-prompt.md` worker templates all document the optional feedback-filing step. Hooks are no-ops when no findings were collected (CTL-176 generates them; inert until that ticket lands).

Research: [`thoughts/shared/research/2026-04-24-CTL-183-oss-safe-feedback-routing.md`](thoughts/shared/research/2026-04-24-CTL-183-oss-safe-feedback-routing.md)
Plan: [`thoughts/shared/plans/2026-04-24-CTL-183-oss-safe-feedback-routing.md`](thoughts/shared/plans/2026-04-24-CTL-183-oss-safe-feedback-routing.md)

Linear: CTL-183

## Test plan

- [x] `plugins/dev/scripts/test-file-feedback.sh` — 12 cases pass end-to-end with PATH-stubbed `linearis` + `gh`:
  - consent check on fresh config → `unset`
  - grant writes `autoFile: true` + defaults; preserves existing values on re-grant
  - consent check after grant → `granted`
  - `skipped-no-consent` exit 2 without `--ensure-consent`
  - `consent-required` exit 3 with `--ensure-consent`
  - linearis stub returns identifier → filed to linear + labels applied
  - linearis empty → falls through to gh
  - gh-only path (no linearis) → filed to github
  - neither CLI → `failed-no-destinations` exit 1
  - label merge + dedup across config + `--labels` + skill name
  - dry-run reports expected destination
- [x] Bash `-n` syntax checks clean on all three new scripts
- [x] `jq .` validates updated `config.template.json`
- [x] Manual `feedback-consent.sh check / grant / status` cycle works against a scratch config

## Out of scope

- The actual finding-generation logic (CTL-176). This PR ships the plumbing only; the hook-point docs say "when findings exist, invoke the helper," but do not generate findings.
- Custom Linear↔GitHub connector (use Linear's native GitHub integration).
- Migrating `orchestrate-followup:165-168`'s existing `linearis issues create` call to use the new helper — its purpose is a manual follow-up ticket, not an auto-filed improvement; migration can happen in a later pass if/when scopes align.