### PR TITLE
feat(dev): auto-file improvement findings at skill run end (CTL-176)

### DIFF
--- a/plugins/dev/scripts/add-finding.sh
+++ b/plugins/dev/scripts/add-finding.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# add-finding - Record an improvement finding to a per-run JSONL queue that the
+# end-of-run hook (CTL-183) drains via file-feedback.sh. Called by orchestrate,
+# oneshot, implement-plan, and worker dispatch templates the moment a finding is
+# observed — context compaction loses observations that are postponed. CTL-176.
+#
+# Usage:
+#   add-finding.sh --title <T> --body <B>
+#                  [--skill <S>]      # default: $CATALYST_SKILL or "unknown"
+#                  [--severity <L>]   # low | med | high (default low)
+#                  [--tags <csv>]     # comma-separated, informational only
+#                  [--file <path>]    # override log path resolution
+#                  [--dry-run]        # print path + JSON, don't write
+#
+# Path resolution (first match wins):
+#   1. --file <path>
+#   2. $CATALYST_FINDINGS_FILE
+#   3. .catalyst/findings/${CATALYST_SESSION_ID}.jsonl
+#   4. .catalyst/findings/current.jsonl
+#
+# Output:
+#   stdout: the appended JSON line
+#   stderr: the resolved log path (visibility)
+#
+# Exit codes:
+#   0   success (line appended, or --dry-run printed)
+#   1   filesystem / jq error during append
+#   64  usage error (missing --title or --body)
+
+set -uo pipefail
+
+TITLE=""
+BODY=""
+SKILL="${CATALYST_SKILL:-unknown}"
+SEVERITY="low"
+TAGS=""
+FILE_OVERRIDE=""
+DRY_RUN=0
+
+usage() {
+  sed -n '2,28p' "$0" >&2
+  exit "${1:-64}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)    TITLE="$2"; shift 2 ;;
+    --body)     BODY="$2"; shift 2 ;;
+    --skill)    SKILL="$2"; shift 2 ;;
+    --severity) SEVERITY="$2"; shift 2 ;;
+    --tags)     TAGS="$2"; shift 2 ;;
+    --file)     FILE_OVERRIDE="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    -h|--help)  usage 0 ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -z "$TITLE" ] && { echo "ERROR: --title is required" >&2; usage; }
+[ -z "$BODY" ]  && { echo "ERROR: --body is required" >&2; usage; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for add-finding" >&2
+  exit 1
+fi
+
+resolve_path() {
+  if [ -n "$FILE_OVERRIDE" ]; then
+    echo "$FILE_OVERRIDE"; return
+  fi
+  if [ -n "${CATALYST_FINDINGS_FILE:-}" ]; then
+    echo "$CATALYST_FINDINGS_FILE"; return
+  fi
+  if [ -n "${CATALYST_SESSION_ID:-}" ]; then
+    echo ".catalyst/findings/${CATALYST_SESSION_ID}.jsonl"; return
+  fi
+  echo ".catalyst/findings/current.jsonl"
+}
+
+LOG_PATH="$(resolve_path)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Build the JSON line. jq handles escaping of newlines, quotes, and unicode.
+TAGS_JSON="[]"
+if [ -n "$TAGS" ]; then
+  TAGS_JSON=$(echo "$TAGS" | jq -R 'split(",") | map(select(length > 0))')
+fi
+
+if ! LINE=$(jq -nc \
+    --arg ts "$TS" \
+    --arg skill "$SKILL" \
+    --arg title "$TITLE" \
+    --arg body "$BODY" \
+    --arg severity "$SEVERITY" \
+    --argjson tags "$TAGS_JSON" \
+    '{ts: $ts, skill: $skill, title: $title, body: $body, severity: $severity, tags: $tags}'); then
+  echo "ERROR: failed to build JSON line" >&2
+  exit 1
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "$LOG_PATH" >&2
+  echo "$LINE"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$LOG_PATH")" || { echo "ERROR: cannot create $(dirname "$LOG_PATH")" >&2; exit 1; }
+
+# Append; bash `>>` is atomic for lines below PIPE_BUF (~4 KB) on POSIX.
+if ! printf '%s\n' "$LINE" >> "$LOG_PATH"; then
+  echo "ERROR: failed to append to $LOG_PATH" >&2
+  exit 1
+fi
+
+echo "$LOG_PATH" >&2
+echo "$LINE"

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -208,6 +208,7 @@ while IFS= read -r T; do
     CATALYST_ORCHESTRATOR_ID="$ORCH_ID" \
     CATALYST_COMMS_CHANNEL="$COMMS_CHANNEL" \
     CATALYST_SESSION_ID="$SESSION_ID" \
+    CATALYST_FINDINGS_FILE="${ORCH_DIR}/findings.jsonl" \
     exec nohup "$CLAUDE_BIN" \
       -n "${ORCH_ID}-${T}" \
       --output-format stream-json \

--- a/plugins/dev/scripts/test-add-finding.sh
+++ b/plugins/dev/scripts/test-add-finding.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Test suite for add-finding.sh. CTL-176.
+#
+# No network, no PATH stubs needed — the script only touches the filesystem and jq.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ADD_SCRIPT="$SCRIPT_DIR/add-finding.sh"
+
+PASS=true
+TESTS=0
+FAILURES=0
+
+fail() { echo "  FAIL: $1"; PASS=false; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  PASS: $1"; }
+run_test() { TESTS=$((TESTS + 1)); echo ""; echo "--- Test $TESTS: $1 ---"; }
+
+# ───────────────────────────────────────────────────────────────────────────
+
+run_test "fresh run creates parent dir and writes valid JSON line"
+TMPD=$(mktemp -d)
+unset CATALYST_FINDINGS_FILE CATALYST_SESSION_ID
+(cd "$TMPD" && "$ADD_SCRIPT" --title "First" --body "Body one" --skill oneshot) >/dev/null
+LOG="$TMPD/.catalyst/findings/current.jsonl"
+[ -f "$LOG" ] && pass "file created" || fail "file missing: $LOG"
+LINES=$(wc -l < "$LOG" | tr -d ' ')
+[ "$LINES" = "1" ] && pass "one line" || fail "lines=$LINES"
+jq -e '.title == "First" and .body == "Body one" and .skill == "oneshot"' "$LOG" >/dev/null \
+  && pass "JSON fields correct" || fail "JSON mismatch: $(cat "$LOG")"
+rm -rf "$TMPD"
+
+run_test "second call appends (not overwrites)"
+TMPD=$(mktemp -d)
+unset CATALYST_FINDINGS_FILE CATALYST_SESSION_ID
+(cd "$TMPD" && "$ADD_SCRIPT" --title "One" --body "B1") >/dev/null
+(cd "$TMPD" && "$ADD_SCRIPT" --title "Two" --body "B2") >/dev/null
+LINES=$(wc -l < "$TMPD/.catalyst/findings/current.jsonl" | tr -d ' ')
+[ "$LINES" = "2" ] && pass "appended to 2 lines" || fail "lines=$LINES"
+T1=$(jq -r 'select(.title == "One") | .title' "$TMPD/.catalyst/findings/current.jsonl")
+T2=$(jq -r 'select(.title == "Two") | .title' "$TMPD/.catalyst/findings/current.jsonl")
+[ "$T1" = "One" ] && [ "$T2" = "Two" ] && pass "both entries present" || fail "t1=$T1 t2=$T2"
+rm -rf "$TMPD"
+
+run_test "multi-line body with quotes round-trips via jq"
+TMPD=$(mktemp -d)
+unset CATALYST_FINDINGS_FILE CATALYST_SESSION_ID
+BODY=$'Line 1\nLine 2 with "quotes" and \'apostrophes\'\nLine 3'
+(cd "$TMPD" && "$ADD_SCRIPT" --title "Complex" --body "$BODY") >/dev/null
+ROUND=$(jq -r '.body' "$TMPD/.catalyst/findings/current.jsonl")
+[ "$ROUND" = "$BODY" ] && pass "body preserved" || fail "body mangled"
+rm -rf "$TMPD"
+
+run_test "CATALYST_FINDINGS_FILE env override resolves first"
+TMPD=$(mktemp -d)
+OVERRIDE="$TMPD/custom/path.jsonl"
+env -u CATALYST_SESSION_ID CATALYST_FINDINGS_FILE="$OVERRIDE" \
+  bash -c "cd '$TMPD' && '$ADD_SCRIPT' --title X --body Y" >/dev/null
+[ -f "$OVERRIDE" ] && pass "wrote to override path" || fail "override not honored; override=$OVERRIDE"
+[ ! -f "$TMPD/.catalyst/findings/ignored.jsonl" ] && pass "session path not used" || fail "session path also written"
+rm -rf "$TMPD"
+
+run_test "CATALYST_SESSION_ID fallback resolves when no override"
+TMPD=$(mktemp -d)
+env -u CATALYST_FINDINGS_FILE CATALYST_SESSION_ID="sess-test-42" \
+  bash -c "cd '$TMPD' && '$ADD_SCRIPT' --title X --body Y" >/dev/null
+LOG="$TMPD/.catalyst/findings/sess-test-42.jsonl"
+[ -f "$LOG" ] && pass "session path used" || fail "expected $LOG"
+rm -rf "$TMPD"
+
+run_test "neither env var set → current.jsonl"
+TMPD=$(mktemp -d)
+env -u CATALYST_FINDINGS_FILE -u CATALYST_SESSION_ID \
+  bash -c "cd '$TMPD' && '$ADD_SCRIPT' --title X --body Y" >/dev/null
+[ -f "$TMPD/.catalyst/findings/current.jsonl" ] && pass "current.jsonl used" || fail "fallback missed"
+rm -rf "$TMPD"
+
+run_test "--file override wins over env vars"
+TMPD=$(mktemp -d)
+OVERRIDE="$TMPD/explicit.jsonl"
+env CATALYST_FINDINGS_FILE="$TMPD/env.jsonl" CATALYST_SESSION_ID="sess-x" \
+  bash -c "cd '$TMPD' && '$ADD_SCRIPT' --title X --body Y --file '$OVERRIDE'" >/dev/null
+[ -f "$OVERRIDE" ] && pass "flag path used" || fail "flag ignored"
+[ ! -f "$TMPD/env.jsonl" ] && pass "env ignored" || fail "env path also written"
+rm -rf "$TMPD"
+
+run_test "missing --title exits 64"
+TMPD=$(mktemp -d)
+unset CATALYST_FINDINGS_FILE CATALYST_SESSION_ID
+(cd "$TMPD" && "$ADD_SCRIPT" --body "Y" 2>/dev/null); RC=$?
+[ $RC -eq 64 ] && pass "exit 64" || fail "exit=$RC"
+rm -rf "$TMPD"
+
+run_test "missing --body exits 64"
+TMPD=$(mktemp -d)
+unset CATALYST_FINDINGS_FILE CATALYST_SESSION_ID
+(cd "$TMPD" && "$ADD_SCRIPT" --title "X" 2>/dev/null); RC=$?
+[ $RC -eq 64 ] && pass "exit 64" || fail "exit=$RC"
+rm -rf "$TMPD"
+
+run_test "--dry-run prints JSON and does not write"
+TMPD=$(mktemp -d)
+unset CATALYST_FINDINGS_FILE CATALYST_SESSION_ID
+OUT=$(cd "$TMPD" && "$ADD_SCRIPT" --title "Dry" --body "Z" --dry-run 2>/dev/null)
+STATUS=$(echo "$OUT" | jq -r '.title')
+[ "$STATUS" = "Dry" ] && pass "JSON printed to stdout" || fail "got: $OUT"
+[ ! -f "$TMPD/.catalyst/findings/current.jsonl" ] && pass "no file written" || fail "file created"
+rm -rf "$TMPD"
+
+run_test "--severity high lands in JSON"
+TMPD=$(mktemp -d)
+unset CATALYST_FINDINGS_FILE CATALYST_SESSION_ID
+(cd "$TMPD" && "$ADD_SCRIPT" --title "X" --body "Y" --severity high) >/dev/null
+SEV=$(jq -r '.severity' "$TMPD/.catalyst/findings/current.jsonl")
+[ "$SEV" = "high" ] && pass "severity=high" || fail "sev=$SEV"
+rm -rf "$TMPD"
+
+run_test "--tags a,b,c parses to 3-element array"
+TMPD=$(mktemp -d)
+unset CATALYST_FINDINGS_FILE CATALYST_SESSION_ID
+(cd "$TMPD" && "$ADD_SCRIPT" --title "X" --body "Y" --tags "ci,flaky,test") >/dev/null
+LEN=$(jq -r '.tags | length' "$TMPD/.catalyst/findings/current.jsonl")
+[ "$LEN" = "3" ] && pass "3 tags" || fail "len=$LEN"
+FIRST=$(jq -r '.tags[0]' "$TMPD/.catalyst/findings/current.jsonl")
+[ "$FIRST" = "ci" ] && pass "first tag correct" || fail "first=$FIRST"
+rm -rf "$TMPD"
+
+run_test "second run with same session id keeps appending"
+TMPD=$(mktemp -d)
+env -u CATALYST_FINDINGS_FILE CATALYST_SESSION_ID="sess-append-test" \
+  bash -c "cd '$TMPD' && '$ADD_SCRIPT' --title A --body A" >/dev/null
+env -u CATALYST_FINDINGS_FILE CATALYST_SESSION_ID="sess-append-test" \
+  bash -c "cd '$TMPD' && '$ADD_SCRIPT' --title B --body B" >/dev/null
+LINES=$(wc -l < "$TMPD/.catalyst/findings/sess-append-test.jsonl" | tr -d ' ')
+[ "$LINES" = "2" ] && pass "2 lines across invocations" || fail "lines=$LINES"
+rm -rf "$TMPD"
+
+# ───────────────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================"
+echo "Tests: $TESTS, Failures: $FAILURES"
+if [ "$PASS" = "true" ]; then
+  echo "All tests passed."
+  exit 0
+else
+  echo "Some tests failed."
+  exit 1
+fi

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -253,27 +253,50 @@ Agent(subagent_type="pr-review-toolkit:pr-test-analyzer",
 
 If critical gaps exist, write the missing tests.
 
-### File Improvement Findings (Optional)
+### File Improvement Findings
 
-If the implementation surfaced any improvement findings worth filing as follow-up tickets
-(per [[CTL-176]] — inert until that ticket lands), route each through the feedback helper.
-`implement-plan` usually runs under another orchestrator or under `/oneshot`, so prefer the
-calling skill's filing step when one exists; the block below is a safety net for direct
-invocations:
+**Recording findings during implementation.** When a phase surfaces friction worth fixing —
+a bug noticed in adjacent code, a step that shouldn't need manual intervention, a gap in
+tooling — record it the moment it's observed:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/add-finding.sh" \
+  --title "Short imperative title" \
+  --body "Reproduction + expected + observed + any links" \
+  --skill implement-plan
+```
+
+Findings go to a shared queue (under orchestrate/oneshot, that skill's queue; direct
+invocations get a per-session queue). The block below files the queue at end-of-run. It's a
+safety net: when `implement-plan` runs under `/orchestrate` or `/oneshot`, the parent's
+filing step drains the same queue first and this block finds an empty file:
 
 ```bash
 FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
 CONSENT="${CLAUDE_PLUGIN_ROOT}/scripts/feedback-consent.sh"
+FINDINGS_FILE="${CATALYST_FINDINGS_FILE:-.catalyst/findings/${CATALYST_SESSION_ID:-current}.jsonl}"
 
-if [ -x "$FEEDBACK" ] && [ -x "$CONSENT" ] && [ -n "${FINDINGS[*]:-}" ]; then
+if [ -x "$FEEDBACK" ] && [ -f "$FINDINGS_FILE" ] && [ -s "$FINDINGS_FILE" ]; then
+  COUNT=$(wc -l < "$FINDINGS_FILE" | tr -d ' ')
   if [ "$("$CONSENT" check)" != "granted" ] && [ -z "${CATALYST_AUTONOMOUS:-}" ] && [ -t 0 ]; then
-    read -r -p "File ${#FINDINGS[@]} improvement tickets now? [Y/n] " yn
+    read -r -p "File $COUNT improvement tickets now? [Y/n] " yn
     case "$yn" in [Nn]*) : ;; *) "$CONSENT" grant >/dev/null ;; esac
   fi
   if [ "$("$CONSENT" check)" = "granted" ]; then
-    for F in "${FINDINGS[@]}"; do
-      "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill implement-plan --json || true
-    done
+    FILED=0
+    while IFS= read -r line; do
+      TITLE=$(jq -r '.title' <<<"$line")
+      BODY=$(jq -r '.body' <<<"$line")
+      SKILL=$(jq -r '.skill // "implement-plan"' <<<"$line")
+      RESULT=$("$FEEDBACK" --title "$TITLE" --body "$BODY" --skill "$SKILL" --json 2>/dev/null || true)
+      STATUS=$(jq -r '.status // "failed"' <<<"$RESULT")
+      if [ "$STATUS" = "filed" ]; then
+        ID=$(jq -r '.identifier // .url // ""' <<<"$RESULT")
+        echo "  filed: $ID  ($TITLE)"
+        FILED=$((FILED + 1))
+      fi
+    done < "$FINDINGS_FILE"
+    [ "$FILED" -eq "$COUNT" ] && rm -f "$FINDINGS_FILE"
   fi
 fi
 ```

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -658,27 +658,61 @@ missing `linearis` CLI (CTL-69):
 The orchestrator's safety-net poll loop calls the same helper when it independently confirms a
 PR has merged, so both paths stay in sync.
 
-**Step 5: File improvement findings (CTL-183 routing, optional)**
+**Step 5: File improvement findings (CTL-176 / CTL-183 routing)**
 
-If the worker captured any improvement findings during the run (per [[CTL-176]] — inert until
-that ticket lands), route each through the feedback helper. Runs as a no-op if no findings were
-collected. In orchestrator-dispatched workers, stdin is not a TTY and `CATALYST_AUTONOMOUS=1`
-is expected to be set — the helper silently skips filing when consent is not already granted,
-never prompts. Standalone oneshot runs prompt interactively once and persist "yes":
+Drain the findings queue and file one ticket per entry. Orchestrator-dispatched oneshot runs
+share the orchestrator's queue (`$CATALYST_FINDINGS_FILE=$ORCH_DIR/findings.jsonl`) and the
+orchestrator's Phase 7 files everything — this step is still safe to run and will find an
+empty queue in that case. Standalone oneshot runs (no orchestrator) use a session-scoped
+queue path derived from `$CATALYST_SESSION_ID`, falling back to `.catalyst/findings/current.jsonl`.
+
+**Recording findings during the run.** The moment you notice friction worth fixing (workflow
+gaps, bugs spotted in adjacent code, recurring manual steps), record it on the queue:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/add-finding.sh" \
+  --title "Short imperative title" \
+  --body "Reproduction + expected + observed + any links" \
+  --skill oneshot --severity low
+```
+
+Record inline, not as a post-run retrospective — context compaction loses observations that
+wait. Don't prompt the user; don't batch. Step 5 below files the whole queue in one pass.
+
+**What counts:** friction the maintainer would want fixed, bugs in adjacent catalyst code
+spotted incidentally, gaps in tooling, manual steps that should be automated.
+**What doesn't:** this ticket's own follow-up TODOs (PR body), user preferences that should
+be durable memory, routine debugging. In orchestrator-dispatched workers, stdin is not a TTY
+and `CATALYST_AUTONOMOUS=1` is expected to be set — the helper silently skips filing when
+consent is not already granted, never prompts. Standalone oneshot runs prompt interactively
+once and persist "yes":
 
 ```bash
 FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
 CONSENT="${CLAUDE_PLUGIN_ROOT}/scripts/feedback-consent.sh"
+FINDINGS_FILE="${CATALYST_FINDINGS_FILE:-.catalyst/findings/${CATALYST_SESSION_ID:-current}.jsonl}"
 
-if [ -x "$FEEDBACK" ] && [ -x "$CONSENT" ] && [ -n "${FINDINGS[*]:-}" ]; then
+if [ -x "$FEEDBACK" ] && [ -f "$FINDINGS_FILE" ] && [ -s "$FINDINGS_FILE" ]; then
+  COUNT=$(wc -l < "$FINDINGS_FILE" | tr -d ' ')
   if [ "$("$CONSENT" check)" != "granted" ] && [ -z "${CATALYST_AUTONOMOUS:-}" ] && [ -t 0 ]; then
-    read -r -p "File ${#FINDINGS[@]} improvement tickets at end of run? [Y/n] " yn
+    read -r -p "File $COUNT improvement tickets at end of run? [Y/n] " yn
     case "$yn" in [Nn]*) : ;; *) "$CONSENT" grant >/dev/null ;; esac
   fi
   if [ "$("$CONSENT" check)" = "granted" ]; then
-    for F in "${FINDINGS[@]}"; do
-      "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill oneshot --json || true
-    done
+    FILED=0
+    while IFS= read -r line; do
+      TITLE=$(jq -r '.title' <<<"$line")
+      BODY=$(jq -r '.body' <<<"$line")
+      SKILL=$(jq -r '.skill // "oneshot"' <<<"$line")
+      RESULT=$("$FEEDBACK" --title "$TITLE" --body "$BODY" --skill "$SKILL" --json 2>/dev/null || true)
+      STATUS=$(jq -r '.status // "failed"' <<<"$RESULT")
+      if [ "$STATUS" = "filed" ]; then
+        ID=$(jq -r '.identifier // .url // ""' <<<"$RESULT")
+        echo "  filed: $ID  ($TITLE)"
+        FILED=$((FILED + 1))
+      fi
+    done < "$FINDINGS_FILE"
+    [ "$FILED" -eq "$COUNT" ] && rm -f "$FINDINGS_FILE"
   fi
 fi
 ```

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -1245,27 +1245,61 @@ When all waves are complete:
 3. **Verify Linear states**: Check all tickets are in `stateMap.done`. If any are stuck, update them
    using the Linearis CLI (run `linearis issues usage` for update syntax).
 
-4. **File improvement findings (CTL-183 routing, optional):** If the orchestrator collected any
-   improvement findings during the run (per [[CTL-176]] — inert until that ticket lands), route
-   each finding through the feedback helper so it lands in Linear (or GitHub, if Linear is
-   unavailable). Runs as a no-op when there are no findings.
+4. **File improvement findings (CTL-176 / CTL-183 routing):** Drain the shared findings queue
+   and file one ticket per entry. The orchestrator and every dispatched worker share one queue
+   (dispatch sets `CATALYST_FINDINGS_FILE=$ORCH_DIR/findings.jsonl`), so this one pass covers
+   everything surfaced across the whole run. Runs as a no-op when the queue is empty.
+
+   **Recording findings during the run.** The moment you or a worker notices friction worth
+   fixing (workflow gaps, bugs spotted in adjacent code, recurring manual steps, gaps in
+   tooling), record it on the shared queue:
+
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/add-finding.sh" \
+     --title "Short imperative title" \
+     --body "Reproduction + expected + observed + any links" \
+     --skill orchestrate --severity low
+   ```
+
+   Record inline, the moment it's observed — context compaction loses it otherwise. Don't
+   prompt the user mid-run; don't wait for the end; don't batch. Step 4 below files the whole
+   queue in one pass.
+
+   **What counts:** friction the maintainer would want fixed, bugs in adjacent catalyst code
+   spotted incidentally, gaps in tooling, manual steps that should be automated.
+   **What doesn't:** this run's own ticket TODOs (those go in the PR body), user preferences
+   that should be durable memory, routine debugging.
 
    ```bash
    FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
    CONSENT="${CLAUDE_PLUGIN_ROOT}/scripts/feedback-consent.sh"
+   FINDINGS_FILE="${CATALYST_FINDINGS_FILE:-${ORCH_DIR}/findings.jsonl}"
 
-   # Autonomous mode (orchestrator runs without a TTY): file only when consent
-   # is already granted — never prompt. Interactive maintainer invocations
-   # prompt once, then persist on yes.
-   if [ -x "$FEEDBACK" ] && [ -x "$CONSENT" ] && [ -n "${FINDINGS[*]:-}" ]; then
+   if [ -x "$FEEDBACK" ] && [ -f "$FINDINGS_FILE" ] && [ -s "$FINDINGS_FILE" ]; then
+     COUNT=$(wc -l < "$FINDINGS_FILE" | tr -d ' ')
+     # Autonomous mode (orchestrator runs without a TTY): file only when consent
+     # is already granted — never prompt. Interactive maintainer invocations
+     # prompt once, then persist on yes.
      if [ "$("$CONSENT" check)" != "granted" ] && [ -z "${CATALYST_AUTONOMOUS:-}" ] && [ -t 0 ]; then
-       read -r -p "File ${#FINDINGS[@]} improvement tickets at end of run? [Y/n] " yn
+       read -r -p "File $COUNT improvement tickets at end of run? [Y/n] " yn
        case "$yn" in [Nn]*) : ;; *) "$CONSENT" grant >/dev/null ;; esac
      fi
      if [ "$("$CONSENT" check)" = "granted" ]; then
-       for F in "${FINDINGS[@]}"; do
-         "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill orchestrate --json || true
-       done
+       FILED=0
+       while IFS= read -r line; do
+         TITLE=$(jq -r '.title' <<<"$line")
+         BODY=$(jq -r '.body' <<<"$line")
+         SKILL=$(jq -r '.skill // "orchestrate"' <<<"$line")
+         RESULT=$("$FEEDBACK" --title "$TITLE" --body "$BODY" --skill "$SKILL" --json 2>/dev/null || true)
+         STATUS=$(jq -r '.status // "failed"' <<<"$RESULT")
+         if [ "$STATUS" = "filed" ]; then
+           ID=$(jq -r '.identifier // .url // ""' <<<"$RESULT")
+           echo "  filed: $ID  ($TITLE)"
+           FILED=$((FILED + 1))
+         fi
+       done < "$FINDINGS_FILE"
+       # Preserve queue on partial failure; delete on full success.
+       [ "$FILED" -eq "$COUNT" ] && rm -f "$FINDINGS_FILE"
      fi
    fi
    ```

--- a/plugins/dev/templates/fixup-prompt.md
+++ b/plugins/dev/templates/fixup-prompt.md
@@ -60,16 +60,31 @@ ${ISSUES}
     signal file (sourced from `gh pr view --json mergedAt`), transition the Linear ticket to
     Done, then exit successfully.
 
-11. **File improvement findings (optional, CTL-183 routing)** — if you captured improvement
-    findings during this fix-up (per CTL-176, inert until that ticket lands), invoke the feedback
-    helper once per finding. Fix-up workers always run autonomously (no TTY, no prompt), so the
-    helper silently skips when consent is not already granted:
+11. **File improvement findings (CTL-176 / CTL-183 routing)** — when you notice friction
+    worth fixing during this fix-up (workflow gaps, bugs in adjacent code, tooling gaps),
+    record it on the shared findings queue:
+    ```bash
+    "${CLAUDE_PLUGIN_ROOT}/scripts/add-finding.sh" \
+      --title "Short imperative title" --body "Details" --skill worker-fixup
+    ```
+    Do NOT drain the queue yourself when running under an orchestrator — the orchestrator's
+    Phase 7 owns the single drain pass over the shared queue (`$ORCH_DIR/findings.jsonl`).
+    Only file at end-of-run when invoked standalone (no `CATALYST_ORCHESTRATOR_ID`). Fix-up
+    workers always run autonomously (no TTY, no prompt), so the helper silently skips when
+    consent is not already granted:
     ```bash
     FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
-    if [ -x "$FEEDBACK" ] && [ -n "${FINDINGS[*]:-}" ]; then
-      for F in "${FINDINGS[@]}"; do
-        "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill worker-fixup --json || true
-      done
+    FINDINGS_FILE="${CATALYST_FINDINGS_FILE:-.catalyst/findings/${CATALYST_SESSION_ID:-current}.jsonl}"
+    # Under orchestrator → orchestrator drains. Standalone → drain here.
+    if [ -z "${CATALYST_ORCHESTRATOR_ID:-}${CATALYST_ORCHESTRATOR_DIR:-}" ] \
+        && [ -x "$FEEDBACK" ] && [ -f "$FINDINGS_FILE" ] && [ -s "$FINDINGS_FILE" ]; then
+      while IFS= read -r line; do
+        TITLE=$(jq -r '.title' <<<"$line")
+        BODY=$(jq -r '.body' <<<"$line")
+        SKILL=$(jq -r '.skill // "worker-fixup"' <<<"$line")
+        "$FEEDBACK" --title "$TITLE" --body "$BODY" --skill "$SKILL" --json || true
+      done < "$FINDINGS_FILE"
+      rm -f "$FINDINGS_FILE"
     fi
     ```
 

--- a/plugins/dev/templates/followup-prompt.md
+++ b/plugins/dev/templates/followup-prompt.md
@@ -59,16 +59,29 @@ known parent to reference.
    resolve BEHIND/CI/review blockers, and only exit when `state=MERGED` and you have written
    `pr.mergedAt` + `status: "done"` to your signal file.
 
-10. **File new improvement findings (optional, CTL-183 routing)** — if this follow-up surfaces
-    its own new findings worth tracking (per CTL-176, inert until that ticket lands), invoke the
-    feedback helper once per finding. Follow-up workers always run autonomously (no TTY), so
-    the helper silently skips when consent is not already granted:
+10. **File new improvement findings (CTL-176 / CTL-183 routing)** — if this follow-up
+    surfaces new friction worth tracking (beyond the parent findings that triggered it),
+    record it on the shared findings queue:
+    ```bash
+    "${CLAUDE_PLUGIN_ROOT}/scripts/add-finding.sh" \
+      --title "Short imperative title" --body "Details" --skill worker-followup
+    ```
+    Do NOT drain the queue yourself when running under an orchestrator — the orchestrator's
+    Phase 7 owns the single drain pass over the shared queue. Only file at end-of-run when
+    invoked standalone (no `CATALYST_ORCHESTRATOR_ID`). Follow-up workers always run
+    autonomously (no TTY), so the helper silently skips when consent is not already granted:
     ```bash
     FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
-    if [ -x "$FEEDBACK" ] && [ -n "${NEW_FINDINGS[*]:-}" ]; then
-      for F in "${NEW_FINDINGS[@]}"; do
-        "$FEEDBACK" --title "${F%%$'\n'*}" --body "$F" --skill worker-followup --json || true
-      done
+    FINDINGS_FILE="${CATALYST_FINDINGS_FILE:-.catalyst/findings/${CATALYST_SESSION_ID:-current}.jsonl}"
+    if [ -z "${CATALYST_ORCHESTRATOR_ID:-}${CATALYST_ORCHESTRATOR_DIR:-}" ] \
+        && [ -x "$FEEDBACK" ] && [ -f "$FINDINGS_FILE" ] && [ -s "$FINDINGS_FILE" ]; then
+      while IFS= read -r line; do
+        TITLE=$(jq -r '.title' <<<"$line")
+        BODY=$(jq -r '.body' <<<"$line")
+        SKILL=$(jq -r '.skill // "worker-followup"' <<<"$line")
+        "$FEEDBACK" --title "$TITLE" --body "$BODY" --skill "$SKILL" --json || true
+      done < "$FINDINGS_FILE"
+      rm -f "$FINDINGS_FILE"
     fi
     ```
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -461,8 +461,9 @@ Optional. Add this block to enable `/orchestrate` — see [Orchestration](/refer
 ## Feedback Config
 
 Optional. Controls where catalyst skills auto-file improvement tickets at run end and on whose
-permission. Primarily relevant once [CTL-176](https://github.com/coalesce-labs/catalyst/issues)
-(skill-driven auto-filing) lands; CTL-183 ships the routing layer it will consume.
+permission. CTL-183 ships the routing layer, CTL-176 ships the findings-collection layer that
+populates it: skills call `plugins/dev/scripts/add-finding.sh` to record observations during a
+run, and the end-of-run hook drains the queue via `file-feedback.sh`.
 
 ```json
 {
@@ -504,6 +505,30 @@ subcommands for scripted use.
 
 See [Integrations › Linear ⇄ GitHub Sync](/reference/integrations/#linear--github-sync) for the
 maintainer-side setup that mirrors `auto-submitted`-labeled GitHub issues back into Linear.
+
+### Findings queue
+
+Skills record improvement findings the moment they are observed by calling
+`plugins/dev/scripts/add-finding.sh` with `--title` and `--body`. Each call appends one JSON
+line to a per-run queue; the end-of-run hook reads the queue and files one ticket per line
+via `file-feedback.sh` (respecting consent and routing above).
+
+Queue path resolution (first match wins):
+
+1. `$CATALYST_FINDINGS_FILE` — orchestrator dispatch sets this to
+   `<orch-dir>/findings.jsonl` so the orchestrator and all workers share one queue per run.
+2. `.catalyst/findings/${CATALYST_SESSION_ID}.jsonl` — standalone oneshot / implement-plan
+   runs, scoped to the catalyst session id.
+3. `.catalyst/findings/current.jsonl` — final fallback when neither var is set.
+
+Each line has the shape:
+
+```json
+{"ts":"2026-04-24T20:30:00Z","skill":"oneshot","title":"…","body":"…","severity":"low","tags":[]}
+```
+
+The hook deletes the queue file after a successful full drain. On partial failure (some
+entries filed, some not), the queue is preserved so the next run can retry.
 
 ## Archive Config
 


### PR DESCRIPTION
## Summary

Wires findings collection into orchestrate/oneshot/implement-plan/worker runs so CTL-183's
end-of-run hook has something to file. Skills no longer depend on the user remembering to
prompt *file as Linear tickets* — findings recorded inline during a run get filed at Phase 7
/ Phase 5 automatically.

- **`plugins/dev/scripts/add-finding.sh`** — record one finding to a per-run JSONL queue.
  `--title --body` required; `--skill --severity --tags --file --dry-run` optional. Path
  resolution: `--file` → env `$CATALYST_FINDINGS_FILE` → `.catalyst/findings/<session-id>.jsonl`
  → `.catalyst/findings/current.jsonl`. Atomic append, jq-escaped JSON.
- **Dispatch env** — `orchestrate-dispatch-next` exports
  `CATALYST_FINDINGS_FILE=$ORCH_DIR/findings.jsonl` so the orchestrator and every dispatched
  worker share one queue per run.
- **Hook rewrites** — orchestrate Phase 7, oneshot Phase 5, implement-plan end-of-run now
  read the queue (not an in-memory bash array) and file one ticket per line via
  `file-feedback.sh`, deleting the queue on full success. Prints `filed: <id>  (<title>)`
  per entry so the human gets a summary.
- **Worker templates** — `fixup-prompt.md` / `followup-prompt.md` record findings but skip
  draining when running under an orchestrator (the orchestrator's Phase 7 owns the single
  drain of the shared queue); standalone workers drain their own per-session queue.
- **Prose** — each skill gets a *Recording improvement findings* section covering what
  counts, what doesn't, and inline recording at the moment of observation.
- **Docs** — `configuration.md` gains a *Findings queue* subsection documenting the env/path
  convention and the line shape.

Companion ticket **CTL-183** shipped the routing (Linear → GitHub fallback) and consent
layers; this change adds the findings-collection layer that populates them.

Research: [`thoughts/shared/research/2026-04-24-CTL-176-auto-file-improvement-findings.md`](thoughts/shared/research/2026-04-24-CTL-176-auto-file-improvement-findings.md)
Plan: [`thoughts/shared/plans/2026-04-24-CTL-176-auto-file-improvement-findings.md`](thoughts/shared/plans/2026-04-24-CTL-176-auto-file-improvement-findings.md)

Linear: CTL-176

## Test plan

- [x] `plugins/dev/scripts/test-add-finding.sh` — 13 cases pass (create, append, multi-line
  bodies, env override, session-id fallback, missing args, dry-run, severity/tags)
- [x] `plugins/dev/scripts/test-file-feedback.sh` — 12 cases pass, unaffected by this change
- [x] End-to-end: seeded `.catalyst/config.json` with consent granted + team key, recorded
  3 findings, ran the orchestrate Phase 7 hook body with a stubbed `linearis`, saw 3
  `filed: TEST-100` lines and the queue deleted on success
- [x] `bash -n` clean on every touched script