### PR TITLE
feat(dev): /compound closing ritual writes compound-log entry at PR merge (CTL-159)

### DIFF
--- a/plugins/dev/scripts/__tests__/compound-log.test.sh
+++ b/plugins/dev/scripts/__tests__/compound-log.test.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# Shell tests for compound-log helper (CTL-159).
+#
+# The /compound skill is a closing ritual at PR merge that writes a
+# compound-log entry to thoughts/shared/pm/metrics/YYYY-WW-compound-log.md.
+# This helper does the mechanical work: ISO-week routing, fail-loud field
+# validation, dedup, and append.
+#
+# Run: bash plugins/dev/scripts/__tests__/compound-log.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+COMPOUND="${REPO_ROOT}/plugins/dev/scripts/compound-log.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $1"
+  [ -n "${2:-}" ] && echo "    detail: $2"
+  if [ -f "${SCRATCH}/out" ]; then
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+# Minimal fake gh and linearis stand-ins, used by several tests.
+install_fakes() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat > "${bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+# Fake `gh`. Reads FAKE_GH_JSON for JSON responses.
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  if [ -n "${FAKE_GH_PR_JSON:-}" ]; then
+    echo "$FAKE_GH_PR_JSON"
+    exit 0
+  fi
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "${bin_dir}/gh"
+
+  cat > "${bin_dir}/linearis" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "issues" ] && [ "$2" = "read" ]; then
+  if [ -n "${FAKE_LINEARIS_JSON:-}" ]; then
+    echo "$FAKE_LINEARIS_JSON"
+    exit 0
+  fi
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "${bin_dir}/linearis"
+}
+
+# Set up an isolated scratch project: thoughts root + fake-bin PATH prefix +
+# fresh state.json-free env. Echoes the scratch project dir.
+new_scratch_project() {
+  local name="$1"
+  local dir="${SCRATCH}/${name}"
+  mkdir -p "${dir}/thoughts/shared/pm/metrics"
+  mkdir -p "${dir}/.catalyst"
+  install_fakes "${dir}/bin"
+  echo "$dir"
+}
+
+# ─── Sanity: helper exists ──────────────────────────────────────────────────
+if [ ! -x "$COMPOUND" ]; then
+  echo "ERROR: ${COMPOUND} not present or not executable"
+  echo "       (expected during TDD — write the helper next to satisfy tests)"
+  FAILURES=1
+  echo ""
+  echo "summary: 0 passed, 1 failed"
+  exit 1
+fi
+
+echo "compound-log tests"
+echo "---"
+
+# ─── ISO week derivation ────────────────────────────────────────────────────
+
+test_iso_week_basic() {
+  # 2026-04-24 is in ISO week 17
+  out=$("$COMPOUND" iso-week "2026-04-24T12:00:00Z" 2>&1)
+  if [ "$out" = "2026-W17" ]; then
+    pass "iso-week: 2026-04-24 → 2026-W17"
+  else
+    fail "iso-week: expected 2026-W17, got $out"
+  fi
+}
+
+test_iso_week_year_boundary() {
+  # Friday 2027-01-01 is still in ISO week 53 of 2026
+  out=$("$COMPOUND" iso-week "2027-01-01T00:00:00Z" 2>&1)
+  if [ "$out" = "2026-W53" ] || [ "$out" = "2027-W01" ]; then
+    pass "iso-week: year boundary handled (got $out)"
+  else
+    fail "iso-week: year boundary wrong, got $out"
+  fi
+}
+
+test_iso_week_rejects_non_iso() {
+  "$COMPOUND" iso-week "not-a-date" > "${SCRATCH}/out" 2>&1
+  rc=$?
+  if [ $rc -ne 0 ]; then
+    pass "iso-week: rejects non-ISO input"
+  else
+    fail "iso-week: should have failed on non-ISO input"
+  fi
+}
+
+# ─── write: happy path ─────────────────────────────────────────────────────
+
+test_write_creates_file_with_header() {
+  proj=$(new_scratch_project write_creates)
+  export FAKE_GH_PR_JSON='{"number":273,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T18:32:10Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-159","estimate":3}'
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-159 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 \
+    --cost-usd 2.47 \
+    --what-worked "tests first" \
+    --what-surprised-me "prometheus not needed" \
+    > "${SCRATCH}/out" 2>&1
+  rc=$?
+
+  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  if [ $rc -eq 0 ] && [ -f "$outfile" ] && \
+     grep -q "^# Compound Log" "$outfile" && \
+     grep -q "^### CTL-159 — #273" "$outfile" && \
+     grep -q "cost_usd: 2.47" "$outfile"; then
+    pass "write: creates file with header and entry"
+  else
+    fail "write: header/entry missing (rc=$rc, file=$outfile)" "$(cat "$outfile" 2>/dev/null)"
+  fi
+
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+test_write_appends_to_existing_file() {
+  proj=$(new_scratch_project write_appends)
+  export FAKE_GH_PR_JSON='{"number":100,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-100","estimate":2}'
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-100 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 3 --cost-usd 1.00 \
+    --what-worked "a" --what-surprised-me "b" > "${SCRATCH}/out" 2>&1
+
+  export FAKE_GH_PR_JSON='{"number":101,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T14:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-101","estimate":3}'
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-101 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --cost-usd 2.00 \
+    --what-worked "c" --what-surprised-me "d" > "${SCRATCH}/out" 2>&1
+
+  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  count=$(grep -c "^### CTL-" "$outfile" 2>/dev/null || echo 0)
+  if [ "$count" = "2" ]; then
+    pass "write: appends second entry to existing file"
+  else
+    fail "write: expected 2 entries, found $count"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+# ─── write: dedup / --force ─────────────────────────────────────────────────
+
+test_write_rejects_duplicate() {
+  proj=$(new_scratch_project write_dup)
+  export FAKE_GH_PR_JSON='{"number":200,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-200","estimate":3}'
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-200 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --cost-usd 1.00 \
+    --what-worked "a" --what-surprised-me "b" > "${SCRATCH}/out" 2>&1
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-200 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 8 --cost-usd 2.00 \
+    --what-worked "a2" --what-surprised-me "b2" > "${SCRATCH}/out" 2>&1
+  rc=$?
+
+  if [ $rc -ne 0 ] && grep -q "already exists" "${SCRATCH}/out"; then
+    pass "write: rejects duplicate (ticket, pr)"
+  else
+    fail "write: duplicate should have been rejected (rc=$rc)"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+test_write_force_replaces_duplicate() {
+  proj=$(new_scratch_project write_force)
+  export FAKE_GH_PR_JSON='{"number":300,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-300","estimate":3}'
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-300 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --cost-usd 1.00 \
+    --what-worked "v1" --what-surprised-me "x" > "${SCRATCH}/out" 2>&1
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-300 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 8 --cost-usd 9.99 \
+    --what-worked "v2" --what-surprised-me "x" \
+    --force > "${SCRATCH}/out" 2>&1
+  rc=$?
+
+  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  count=$(grep -c "^### CTL-300" "$outfile" 2>/dev/null || echo 0)
+  if [ $rc -eq 0 ] && [ "$count" = "1" ] && grep -q "cost_usd: 9.99" "$outfile"; then
+    pass "write: --force replaces existing entry"
+  else
+    fail "write: --force did not replace (rc=$rc, count=$count)"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+# ─── write: fail-loud on missing required fields ───────────────────────────
+
+test_fail_loud_missing_estimate_actual() {
+  proj=$(new_scratch_project fail_est)
+  export FAKE_GH_PR_JSON='{"number":400,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-400","estimate":3}'
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-400 \
+    --thoughts-dir "${proj}/thoughts" \
+    --cost-usd 1.00 --what-worked "a" --what-surprised-me "b" \
+    > "${SCRATCH}/out" 2>&1
+  rc=$?
+
+  if [ $rc -ne 0 ] && grep -q "estimate-actual" "${SCRATCH}/out"; then
+    pass "fail-loud: missing --estimate-actual"
+  else
+    fail "fail-loud: expected error about estimate-actual (rc=$rc)"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+test_fail_loud_missing_what_worked() {
+  proj=$(new_scratch_project fail_what)
+  export FAKE_GH_PR_JSON='{"number":401,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-401","estimate":3}'
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-401 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --cost-usd 1.00 --what-surprised-me "b" \
+    > "${SCRATCH}/out" 2>&1
+  rc=$?
+
+  if [ $rc -ne 0 ] && grep -q "what-worked" "${SCRATCH}/out"; then
+    pass "fail-loud: missing --what-worked"
+  else
+    fail "fail-loud: expected error about what-worked (rc=$rc)"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+test_fail_loud_missing_cost_entirely() {
+  proj=$(new_scratch_project fail_cost)
+  # PR and Linear available, but no --cost-usd and no session data
+  export FAKE_GH_PR_JSON='{"number":500,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-500","estimate":3}'
+  # isolate HOME so catalyst-state can't find real aggregates
+  export HOME="${proj}/fakehome"
+  mkdir -p "$HOME"
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-500 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --what-worked "a" --what-surprised-me "b" \
+    > "${SCRATCH}/out" 2>&1
+  rc=$?
+
+  if [ $rc -ne 0 ] && grep -qi "cost" "${SCRATCH}/out"; then
+    pass "fail-loud: missing cost with no fallback source"
+  else
+    fail "fail-loud: expected cost-related error (rc=$rc)"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON HOME
+}
+
+# ─── dry-run ────────────────────────────────────────────────────────────────
+
+test_dry_run_does_not_write() {
+  proj=$(new_scratch_project dry)
+  export FAKE_GH_PR_JSON='{"number":600,"createdAt":"2026-04-23T12:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-600","estimate":3}'
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-600 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --cost-usd 1.00 \
+    --what-worked "a" --what-surprised-me "b" \
+    --dry-run > "${SCRATCH}/out" 2>&1
+  rc=$?
+
+  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  if [ $rc -eq 0 ] && [ ! -f "$outfile" ] && grep -q "CTL-600" "${SCRATCH}/out"; then
+    pass "dry-run: prints entry, writes nothing"
+  else
+    fail "dry-run: unexpected state (rc=$rc, file exists: $([ -f "$outfile" ] && echo yes || echo no))"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+# ─── ISO-week routing uses mergedAt, not today's date ──────────────────────
+
+test_week_routing_uses_merged_at() {
+  proj=$(new_scratch_project week_route)
+  # Merged in week 18 (2026-04-27 Mon) even though today may be week 17
+  export FAKE_GH_PR_JSON='{"number":700,"createdAt":"2026-04-25T12:00:00Z","mergedAt":"2026-04-27T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-700","estimate":3}'
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-700 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --cost-usd 1.00 \
+    --what-worked "a" --what-surprised-me "b" > "${SCRATCH}/out" 2>&1
+
+  outfile="${proj}/thoughts/shared/pm/metrics/2026-W18-compound-log.md"
+  if [ -f "$outfile" ]; then
+    pass "week routing: uses mergedAt (2026-W18 file created)"
+  else
+    fail "week routing: expected 2026-W18 file, got $(ls "${proj}/thoughts/shared/pm/metrics/" 2>&1)"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+# ─── wall-time computation from PR timestamps ──────────────────────────────
+
+test_wall_time_computed_from_pr() {
+  proj=$(new_scratch_project wtime)
+  # createdAt → mergedAt = 3 hours exactly
+  export FAKE_GH_PR_JSON='{"number":800,"createdAt":"2026-04-24T09:00:00Z","mergedAt":"2026-04-24T12:00:00Z","state":"MERGED"}'
+  export FAKE_LINEARIS_JSON='{"identifier":"CTL-800","estimate":3}'
+
+  PATH="${proj}/bin:$PATH" "$COMPOUND" write CTL-800 \
+    --thoughts-dir "${proj}/thoughts" \
+    --estimate-actual 5 --cost-usd 1.00 \
+    --what-worked "a" --what-surprised-me "b" > "${SCRATCH}/out" 2>&1
+
+  outfile="${proj}/thoughts/shared/pm/metrics/2026-W17-compound-log.md"
+  if grep -q "wall_time_hours: 3" "$outfile" 2>/dev/null; then
+    pass "wall-time: computed from PR createdAt→mergedAt"
+  else
+    fail "wall-time: expected 3.0 hours" "$(cat "$outfile" 2>/dev/null)"
+  fi
+  unset FAKE_GH_PR_JSON FAKE_LINEARIS_JSON
+}
+
+# ─── Run all test_* functions ───────────────────────────────────────────────
+
+for t in $(declare -F | awk '/^declare -f test_/{print $3}'); do
+  $t
+done
+
+echo "---"
+echo "summary: ${PASSES} passed, ${FAILURES} failed"
+exit $([ "$FAILURES" -eq 0 ] && echo 0 || echo 1)

--- a/plugins/dev/scripts/compound-log.sh
+++ b/plugins/dev/scripts/compound-log.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# compound-log.sh — write a compound-log entry at PR merge.
+#
+# Closing ritual for the AI-native estimation feedback loop (CTL-159). At PR
+# merge, this helper writes a structured entry to:
+#
+#   <thoughts-dir>/shared/pm/metrics/<YYYY-WW>-compound-log.md
+#
+# One file per ISO week, one entry per merged PR. Fields follow the
+# CTL-159 schema: linear.key, pr_number, merged_at, estimate_at_start,
+# estimate_actual, cost_usd, wall_time_hours, what_worked, what_surprised_me.
+#
+# Commands:
+#   iso-week <iso-timestamp>
+#       Print YYYY-WW for the given UTC timestamp. Exits non-zero on bad input.
+#
+#   write <ticket-id> [options]
+#       Append an entry for <ticket-id>. Options:
+#         --pr <number>               PR number (default: gh pr view on branch)
+#         --merged-at <iso>           override (default: gh pr view mergedAt)
+#         --created-at <iso>          override (default: gh pr view createdAt)
+#         --estimate-start <int>      override (default: linearis read .estimate)
+#         --estimate-actual <int>     REQUIRED
+#         --cost-usd <float>          override (default: catalyst-state aggregate)
+#         --wall-time-hours <float>   override (default: computed from PR ts)
+#         --what-worked <text>        REQUIRED
+#         --what-surprised-me <text>  REQUIRED
+#         --thoughts-dir <path>       override thoughts root (default: ./thoughts)
+#         --force                     replace existing (ticket, pr) entry
+#         --dry-run                   print entry, write nothing
+#
+# Exit codes: 0 on success, 1 on any validation/IO failure (fails loud).
+
+set -uo pipefail
+
+# ─── utilities ──────────────────────────────────────────────────────────────
+
+err() { echo "error: $*" >&2; }
+
+fatal() {
+  err "$*"
+  exit 1
+}
+
+# Parse an ISO-8601 UTC timestamp to epoch seconds. Returns epoch on stdout,
+# non-zero on failure. Tries BSD date first (macOS), then GNU date (Linux).
+iso_to_epoch() {
+  local ts="$1"
+  local epoch
+  epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" "+%s" 2>/dev/null) \
+    || epoch=$(date -u -d "$ts" "+%s" 2>/dev/null) \
+    || return 1
+  printf "%s" "$epoch"
+}
+
+# Emit YYYY-WW (ISO-8601 week) for a UTC timestamp.
+iso_week_of() {
+  local ts="$1"
+  local out
+  out=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" "+%G-W%V" 2>/dev/null) \
+    || out=$(date -u -d "$ts" "+%G-W%V" 2>/dev/null) \
+    || return 1
+  printf "%s" "$out"
+}
+
+# Numeric check — accepts ints and decimals (positive only).
+is_numeric() {
+  [[ "$1" =~ ^[0-9]+(\.[0-9]+)?$ ]]
+}
+
+# ─── PR + Linear probes ─────────────────────────────────────────────────────
+
+# Echo key=value lines from `gh pr view --json number,createdAt,mergedAt,state`.
+# Returns non-zero if gh is unavailable or PR lookup fails.
+probe_pr() {
+  local pr_arg="$1" json
+  if [ -n "$pr_arg" ]; then
+    json=$(gh pr view "$pr_arg" --json number,createdAt,mergedAt,state 2>/dev/null) || return 1
+  else
+    json=$(gh pr view --json number,createdAt,mergedAt,state 2>/dev/null) || return 1
+  fi
+  [ -z "$json" ] && return 1
+  printf "%s" "$json"
+}
+
+probe_linear_estimate() {
+  local ticket="$1" json
+  json=$(linearis issues read "$ticket" 2>/dev/null) || return 1
+  [ -z "$json" ] && return 1
+  echo "$json" | jq -r '.estimate // empty'
+}
+
+# Probe local cost data. Tries (in order):
+#   1. catalyst-state.sh worker aggregate for current orchestrator
+#   2. catalyst-session.sh history --ticket
+# Prints numeric cost on stdout, exits non-zero if no data found.
+probe_cost_local() {
+  local ticket="$1"
+  local script_dir="$2"
+  local state_script="${script_dir}/catalyst-state.sh"
+  local session_script="${script_dir}/catalyst-session.sh"
+
+  # State aggregate (orchestrator mode)
+  if [ -n "${CATALYST_ORCHESTRATOR_ID:-}" ] && [ -x "$state_script" ]; then
+    local agg
+    agg=$("$state_script" worker-usage "${CATALYST_ORCHESTRATOR_ID}" "$ticket" 2>/dev/null \
+      | jq -r '.cost_usd // empty' 2>/dev/null)
+    if [ -n "$agg" ] && is_numeric "$agg"; then
+      printf "%s" "$agg"
+      return 0
+    fi
+  fi
+
+  # Session history fallback
+  if [ -x "$session_script" ]; then
+    local hist
+    hist=$("$session_script" history --ticket "$ticket" --limit 1 2>/dev/null \
+      | jq -r '.[0].cost_usd // empty' 2>/dev/null)
+    if [ -n "$hist" ] && is_numeric "$hist"; then
+      printf "%s" "$hist"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# ─── entry rendering + file writing ─────────────────────────────────────────
+
+# Args: all resolved fields in positional order.
+render_entry() {
+  local linear_key="$1" pr="$2" merged_at="$3" est_start="$4" est_actual="$5"
+  local cost="$6" wall_hours="$7" what_worked="$8" what_surprised="$9"
+
+  # YAML-escape: replace " with \" in free-text fields; wrap in double quotes.
+  local ww="${what_worked//\"/\\\"}"
+  local ws="${what_surprised//\"/\\\"}"
+
+  cat <<EOF
+### ${linear_key} — #${pr} — ${merged_at}
+
+\`\`\`yaml
+linear_key: ${linear_key}
+pr_number: ${pr}
+merged_at: ${merged_at}
+estimate_at_start: ${est_start}
+estimate_actual: ${est_actual}
+cost_usd: ${cost}
+wall_time_hours: ${wall_hours}
+what_worked: "${ww}"
+what_surprised_me: "${ws}"
+\`\`\`
+
+EOF
+}
+
+# Ensure the weekly file exists with its header.
+ensure_week_file() {
+  local file="$1" week="$2"
+  if [ ! -f "$file" ]; then
+    mkdir -p "$(dirname "$file")"
+    cat > "$file" <<EOF
+# Compound Log — ${week}
+
+One entry per merged PR. Fields follow the CTL-159 schema.
+
+EOF
+  fi
+}
+
+# Remove an existing entry (### TICKET — #PR … through the next ### or EOF).
+# Writes the result back to the file in-place.
+remove_entry() {
+  local file="$1" ticket="$2" pr="$3"
+  local tmp="${file}.tmp.$$"
+  awk -v marker="### ${ticket} — #${pr}" '
+    BEGIN { in_block = 0 }
+    /^### / {
+      if (index($0, marker) == 1) { in_block = 1; next }
+      else { in_block = 0 }
+    }
+    { if (!in_block) print }
+  ' "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+# ─── subcommand: iso-week ───────────────────────────────────────────────────
+
+cmd_iso_week() {
+  local ts="${1:-}"
+  [ -z "$ts" ] && fatal "iso-week: missing timestamp argument"
+  local out
+  out=$(iso_week_of "$ts") || fatal "iso-week: invalid ISO-8601 timestamp: $ts"
+  printf "%s\n" "$out"
+}
+
+# ─── subcommand: write ──────────────────────────────────────────────────────
+
+cmd_write() {
+  local ticket="${1:-}"
+  shift || true
+  [ -z "$ticket" ] && fatal "write: missing ticket-id argument"
+
+  local pr=""
+  local merged_at=""
+  local created_at=""
+  local est_start=""
+  local est_actual=""
+  local cost_usd=""
+  local wall_hours=""
+  local what_worked=""
+  local what_surprised=""
+  local thoughts_dir="./thoughts"
+  local force=0
+  local dry_run=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --pr)                pr="$2"; shift 2 ;;
+      --merged-at)         merged_at="$2"; shift 2 ;;
+      --created-at)        created_at="$2"; shift 2 ;;
+      --estimate-start)    est_start="$2"; shift 2 ;;
+      --estimate-actual)   est_actual="$2"; shift 2 ;;
+      --cost-usd)          cost_usd="$2"; shift 2 ;;
+      --wall-time-hours)   wall_hours="$2"; shift 2 ;;
+      --what-worked)       what_worked="$2"; shift 2 ;;
+      --what-surprised-me) what_surprised="$2"; shift 2 ;;
+      --thoughts-dir)      thoughts_dir="$2"; shift 2 ;;
+      --force)             force=1; shift ;;
+      --dry-run)           dry_run=1; shift ;;
+      *) fatal "write: unknown flag: $1" ;;
+    esac
+  done
+
+  # 1. Required user-supplied fields (fail loud before any external calls).
+  [ -z "$est_actual" ] && fatal "write: required: --estimate-actual"
+  is_numeric "$est_actual" || fatal "write: --estimate-actual must be numeric, got: $est_actual"
+  [ -z "$what_worked" ] && fatal "write: required: --what-worked"
+  [ -z "$what_surprised" ] && fatal "write: required: --what-surprised-me"
+
+  # 2. Resolve PR details via `gh` unless fully overridden.
+  local pr_json=""
+  if [ -z "$pr" ] || [ -z "$merged_at" ] || [ -z "$created_at" ]; then
+    pr_json=$(probe_pr "$pr") \
+      || fatal "write: could not resolve PR via gh (pass --pr/--merged-at/--created-at to override)"
+  fi
+
+  if [ -z "$pr" ]; then
+    pr=$(echo "$pr_json" | jq -r '.number // empty')
+    [ -z "$pr" ] && fatal "write: gh returned no PR number"
+  fi
+
+  if [ -z "$merged_at" ]; then
+    merged_at=$(echo "$pr_json" | jq -r '.mergedAt // empty')
+    [ -z "$merged_at" ] || [ "$merged_at" = "null" ] && fatal "write: PR #${pr} has no mergedAt (not yet merged?)"
+  fi
+
+  if [ -z "$created_at" ]; then
+    created_at=$(echo "$pr_json" | jq -r '.createdAt // empty')
+  fi
+
+  # 3. Resolve Linear estimate_at_start via linearis unless overridden.
+  if [ -z "$est_start" ]; then
+    est_start=$(probe_linear_estimate "$ticket") \
+      || fatal "write: could not resolve estimate via linearis (pass --estimate-start to override)"
+    [ -z "$est_start" ] && fatal "write: ticket $ticket has no estimate set in Linear"
+  fi
+  is_numeric "$est_start" || fatal "write: estimate_at_start not numeric: $est_start"
+
+  # 4. Resolve cost_usd from local aggregates unless overridden.
+  if [ -z "$cost_usd" ]; then
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cost_usd=$(probe_cost_local "$ticket" "$script_dir") \
+      || fatal "write: no cost data for $ticket in catalyst-state or session history (pass --cost-usd to override)"
+  fi
+  is_numeric "$cost_usd" || fatal "write: cost_usd not numeric: $cost_usd"
+
+  # 5. Compute wall_time_hours unless overridden.
+  if [ -z "$wall_hours" ]; then
+    [ -z "$created_at" ] && fatal "write: cannot compute wall_time_hours without createdAt (pass --wall-time-hours)"
+    local t0 t1 delta
+    t0=$(iso_to_epoch "$created_at") || fatal "write: invalid createdAt: $created_at"
+    t1=$(iso_to_epoch "$merged_at")  || fatal "write: invalid mergedAt: $merged_at"
+    delta=$(( t1 - t0 ))
+    # One decimal place; awk handles division portably.
+    wall_hours=$(awk -v d="$delta" 'BEGIN{ printf "%.1f", d/3600 }')
+  fi
+  is_numeric "$wall_hours" || fatal "write: wall_time_hours not numeric: $wall_hours"
+
+  # 6. Prometheus overlay is gated but not yet implemented. Advertise clearly.
+  if [ -n "${CATALYST_PROMETHEUS_URL:-}" ]; then
+    echo "note: CATALYST_PROMETHEUS_URL is set; Prometheus overlay not yet implemented — using local aggregates" >&2
+  fi
+
+  # 7. Compute target week file from mergedAt (NOT today).
+  local week outfile
+  week=$(iso_week_of "$merged_at") || fatal "write: could not derive ISO week from mergedAt: $merged_at"
+  outfile="${thoughts_dir}/shared/pm/metrics/${week}-compound-log.md"
+
+  # 8. Dry-run: print entry only.
+  local entry
+  entry=$(render_entry "$ticket" "$pr" "$merged_at" "$est_start" "$est_actual" \
+                       "$cost_usd" "$wall_hours" "$what_worked" "$what_surprised")
+
+  if [ "$dry_run" -eq 1 ]; then
+    echo "dry-run: would write to ${outfile}"
+    echo ""
+    printf "%s" "$entry"
+    return 0
+  fi
+
+  # 9. Dedup check.
+  ensure_week_file "$outfile" "$week"
+  if grep -q "^### ${ticket} — #${pr} " "$outfile" 2>/dev/null \
+     || grep -q "^### ${ticket} — #${pr}$" "$outfile" 2>/dev/null; then
+    if [ "$force" -eq 0 ]; then
+      fatal "write: entry for ${ticket} #${pr} already exists in ${outfile}; pass --force to replace"
+    fi
+    remove_entry "$outfile" "$ticket" "$pr"
+  fi
+
+  # 10. Append. Trailing newline re-added — $(heredoc) strips them, and we
+  # need a blank line between entries so `### ` headings stay on their own line.
+  printf "%s\n\n" "$entry" >> "$outfile"
+  echo "wrote: ${outfile}"
+  echo "entry: ${ticket} — #${pr} — ${merged_at}"
+}
+
+# ─── main ───────────────────────────────────────────────────────────────────
+
+usage() {
+  sed -n '2,35p' "$0" | sed 's|^# \{0,1\}||'
+}
+
+case "${1:-}" in
+  iso-week)  shift; cmd_iso_week "$@" ;;
+  write)     shift; cmd_write "$@" ;;
+  -h|--help|help|"") usage ;;
+  *) fatal "unknown subcommand: ${1}" ;;
+esac

--- a/plugins/dev/skills/compound/SKILL.md
+++ b/plugins/dev/skills/compound/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: compound
+description:
+  "Closing ritual for the AI-native estimation feedback loop. **ALWAYS use when** the user says
+  'compound', 'close the loop', 'record learnings', 'compound-log', or wants to log post-merge
+  actuals for a shipped Linear ticket. Writes a structured entry (linear.key, pr_number, merged_at,
+  estimate_at_start, estimate_actual, cost_usd, wall_time_hours, what_worked, what_surprised_me)
+  to `thoughts/shared/pm/metrics/YYYY-WW-compound-log.md` — one file per ISO week, appends."
+disable-model-invocation: true
+allowed-tools: Bash(gh *), Bash(linearis *), Bash(jq *), Bash(git *), Bash(./plugins/dev/scripts/compound-log.sh *), Bash(plugins/dev/scripts/compound-log.sh *), Read, Write
+version: 1.0.0
+---
+
+# Compound — Closing Ritual at PR Merge
+
+Write a compound-log entry for a just-shipped ticket. This is the Phase 1 exit gate for AI-native estimation: without this closer, `claude-code-otel` cost/wall-time signals never feed future estimates and the calibration loop stays open.
+
+The skill delegates all mechanical work to `plugins/dev/scripts/compound-log.sh`. Your job is to collect the three human-authored inputs (estimate_actual, what_worked, what_surprised_me) and invoke the helper.
+
+## Invocation
+
+```
+/compound <TICKET-ID>
+```
+
+**Inputs:**
+- `<TICKET-ID>` — required. Linear ticket key (e.g. `CTL-159`). If omitted, detect from the current branch name (`gh pr view --json headRefName` → parse ticket prefix).
+
+## Output
+
+Appends an entry to `thoughts/shared/pm/metrics/YYYY-WW-compound-log.md`, creating the weekly file with a header if it doesn't exist. Weeks are ISO-8601 and derived from the PR's `mergedAt` (not today's date).
+
+## Process
+
+### 1. Resolve the ticket
+
+If the user passed a ticket ID, use it. Otherwise:
+
+```bash
+BRANCH=$(git branch --show-current)
+# Extract ticket prefix from .catalyst/config.json
+TICKET_PREFIX=$(jq -r '.catalyst.project.ticketPrefix // "PROJ"' .catalyst/config.json)
+TICKET_ID=$(echo "$BRANCH" | grep -oE "${TICKET_PREFIX}-[0-9]+" | head -1)
+```
+
+If no ticket can be resolved, ask the user explicitly. Do not guess.
+
+### 2. Verify the PR is merged
+
+The helper will fail loud if `mergedAt` is missing, but give the user a clearer error up front:
+
+```bash
+PR_JSON=$(gh pr view --json number,state,mergedAt 2>/dev/null)
+STATE=$(echo "$PR_JSON" | jq -r '.state')
+if [ "$STATE" != "MERGED" ]; then
+  echo "error: PR on current branch is not merged (state=$STATE). Run /compound after the PR merges."
+  exit 1
+fi
+```
+
+### 3. Collect the three human-authored inputs
+
+Prompt the user interactively (one at a time). Keep the prompts short and concrete; the estimate re-scoring is the calibration signal, so do not skip it.
+
+- **estimate_actual** — re-score the ticket on the same T-shirt scale used at ticket creation (XS=1, S=2, M=3, L=5, XL=8). Ask: "After shipping, what T-shirt would you set this ticket to? (XS/S/M/L/XL or integer 1/2/3/5/8)"
+- **what_worked** — ask: "What worked? (one or two sentences)"
+- **what_surprised_me** — ask: "What surprised you? (one or two sentences — this is the highest-signal calibration input)"
+
+If the user answers with a T-shirt letter, convert to the integer before passing to the helper.
+
+### 4. Invoke the helper
+
+```bash
+plugins/dev/scripts/compound-log.sh write "$TICKET_ID" \
+  --estimate-actual "$EST_ACTUAL_INT" \
+  --what-worked "$WHAT_WORKED" \
+  --what-surprised-me "$WHAT_SURPRISED"
+```
+
+The helper resolves the rest:
+- `pr_number`, `merged_at`, `created_at` via `gh pr view`
+- `estimate_at_start` via `linearis issues read <ticket> | jq .estimate`
+- `cost_usd` from `catalyst-state.sh` worker aggregate (orchestrator mode) or `catalyst-session.sh history --ticket` (local fallback)
+- `wall_time_hours` computed from PR `createdAt` → `mergedAt`
+
+### 5. Report back
+
+On success, the helper prints the target file and a one-line summary. Show that to the user.
+
+On failure, surface the helper's error verbatim. The helper fails loud with actionable messages — don't paraphrase them. Common causes and fixes:
+
+| Error fragment | Meaning | Fix |
+|---|---|---|
+| `required: --estimate-actual` | You did not collect the re-score | Re-prompt the user |
+| `PR #N has no mergedAt` | PR isn't merged yet | Run after merge |
+| `could not resolve estimate via linearis` | Linear unreachable or ticket has no estimate | Pass `--estimate-start <int>` |
+| `no cost data for <ticket> in catalyst-state or session history` | No cost telemetry captured for this ticket | Pass `--cost-usd <float>` explicitly |
+| `already exists in ...; pass --force to replace` | Skill was run twice for same (ticket, pr) | Either skip, or re-run with `--force` |
+
+## Flags the helper accepts (for power users or auto-trigger from other skills)
+
+```
+plugins/dev/scripts/compound-log.sh write <ticket> [options]
+
+  --pr <number>               PR number (default: gh pr view on current branch)
+  --merged-at <iso-ts>        override (default: gh pr view mergedAt)
+  --created-at <iso-ts>       override (default: gh pr view createdAt)
+  --estimate-start <int>      override (default: linearis .estimate)
+  --estimate-actual <int>     REQUIRED — post-merge re-score on same scale
+  --cost-usd <float>          override (default: catalyst-state/session aggregate)
+  --wall-time-hours <float>   override (default: computed from PR timestamps)
+  --what-worked <text>        REQUIRED
+  --what-surprised-me <text>  REQUIRED
+  --thoughts-dir <path>       override thoughts root (default: ./thoughts)
+  --force                     replace existing (ticket, pr) entry
+  --dry-run                   print entry; write nothing
+```
+
+## Schema of a written entry
+
+Each entry is a level-3 heading with a fenced YAML block (parseable by the forthcoming `/pm:weekly-cycle-review` aggregator):
+
+```markdown
+### CTL-159 — #273 — 2026-04-24T18:32:10Z
+
+```yaml
+linear_key: CTL-159
+pr_number: 273
+merged_at: 2026-04-24T18:32:10Z
+estimate_at_start: 3     # team scale: 3 → M
+estimate_actual: 5       # team scale: 5 → L
+cost_usd: 2.47
+wall_time_hours: 3.2
+what_worked: "Tests-first TDD kept the helper script testable."
+what_surprised_me: "Prometheus integration wasn't plumbed; local state.json sufficed."
+```
+```
+
+## Data source notes
+
+- **Primary cost source** is local: the `catalyst-state.sh` worker-usage aggregate (when orchestrated) or `catalyst-session.sh history` (standalone). This is deliberate — `claude-code-otel` + Prometheus is referenced in the original spec but not yet wired up in this repo.
+- **Prometheus overlay** is gated by `CATALYST_PROMETHEUS_URL`. When set, the helper logs a note to stderr; the HTTP client itself is a follow-up ticket.
+- **Linear estimate** is read as an integer from `linearis issues read`. The team's estimation config (T-shirt, Fibonacci, linear) is applied client-side when re-scoring in step 3.
+
+## Testing
+
+```bash
+bash plugins/dev/scripts/__tests__/compound-log.test.sh
+```
+
+Covers ISO-week derivation, happy-path writes, append-idempotence, dedup + `--force`, fail-loud paths for each required field, wall-time computation, and mergedAt-based week routing.
+
+## Related
+
+- Spec: `thoughts/shared/research/2026-04-24-CTL-159-compound-closing-ritual.md`
+- Plan: `thoughts/shared/plans/2026-04-24-CTL-159-compound-closing-ritual.md`
+- Unblocks: CTL-189 (auto-invoke from `merge-pr` / `oneshot` Phase 5)
+- Consumer (future): `/pm:weekly-cycle-review` reads all `YYYY-WW-compound-log.md` files and joins to Linear cycle data for the retrospective


### PR DESCRIPTION
## Summary

New Catalyst skill `/compound` runs at PR merge and writes a structured entry to `thoughts/shared/pm/metrics/YYYY-WW-compound-log.md` — one file per ISO week, appended. This is the Phase 1 exit gate for AI-native estimation: without a closing ritual that extracts cost / wall-time / T-shirt reassessment per shipped ticket, the calibration loop stays open.

Linear: [CTL-159](https://linear.app/coalesce-labs/issue/CTL-159) — unblocks CTL-189.

## What ships

- `plugins/dev/skills/compound/SKILL.md` — user-invokable skill (`/compound <TICKET-ID>`)
- `plugins/dev/scripts/compound-log.sh` — stateless helper (`iso-week`, `write` subcommands, fail-loud validation)
- `plugins/dev/scripts/__tests__/compound-log.test.sh` — 13 bash tests, written first

## Schema per entry

```yaml
linear_key: CTL-159
pr_number: 273
merged_at: 2026-04-24T18:32:10Z
estimate_at_start: 3     # Linear integer, team scale → T-shirt M
estimate_actual: 5       # re-scored post-merge → T-shirt L
cost_usd: 2.47
wall_time_hours: 3.2
what_worked: "…"
what_surprised_me: "…"
```

ISO-week routing uses the PR's `mergedAt`, not today's date, so PRs merged at week boundaries still land in the correct file. Dedup is per `(linear_key, pr_number)`; `--force` replaces.

## Data sources

| Field | Source | Fallback |
|---|---|---|
| `pr_number`, `merged_at`, `created_at` | `gh pr view` | `--pr` / `--merged-at` / `--created-at` |
| `estimate_at_start` | `linearis issues read <id>.estimate` | `--estimate-start` |
| `cost_usd` | `catalyst-state.sh` worker aggregate → `catalyst-session.sh history` | `--cost-usd` |
| `wall_time_hours` | `(mergedAt − createdAt) / 3600` | `--wall-time-hours` |
| `estimate_actual`, `what_worked`, `what_surprised_me` | **user-supplied, required** | n/a — fail loud |

Prometheus overlay (`CATALYST_PROMETHEUS_URL`) is gated but not yet implemented — the spec referenced `claude_code.cost.usage` but that integration isn't wired up in this repo. Local catalyst-state/session aggregates are the authoritative cost source today; the HTTP client is a follow-up.

## Fail-loud behavior

The helper validates **all nine required fields** before any write. On any missing or malformed field it exits 1 with an actionable message. No partial entries are ever written. Idempotence is enforced by grep on `^### <ticket> — #<pr>` — re-running the skill for the same `(ticket, pr)` fails unless `--force` is passed.

## Tests

13 bash tests (all passing):
- ISO-week derivation (happy path, year boundary, non-ISO rejection)
- write creates file with header + entry
- write appends second entry to existing week file
- duplicate rejected; `--force` replaces
- fail-loud for missing `--estimate-actual`, `--what-worked`, cost data
- `--dry-run` prints entry, writes nothing
- week routing uses `mergedAt` (not today's date)
- wall-time computed from PR timestamps

```
bash plugins/dev/scripts/__tests__/compound-log.test.sh
→ 13 passed, 0 failed
```

## Test plan

- [x] Unit tests pass (13/13)
- [x] Bash syntax check clean (`bash -n` on both scripts)
- [x] No test-mode escape hatches in implementation
- [x] Manual smoke: `compound-log.sh iso-week 2026-04-24T12:00:00Z` → `2026-W17`
- [ ] CI green
- [ ] First real-world invocation against a merged PR (post-merge follow-up in CTL-189)

## Docs

- Research: `thoughts/shared/research/2026-04-24-CTL-159-compound-closing-ritual.md`
- Plan: `thoughts/shared/plans/2026-04-24-CTL-159-compound-closing-ritual.md`