### PR TITLE
feat(dev): tiered attention signals + reason glyphs (CTL-170)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.css
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.css
@@ -362,3 +362,44 @@ a.mockup-topbar__mark:focus-visible {
   font-size: var(--font-size-label);
   text-align: center;
 }
+
+/*
+ * CTL-170 — reason glyphs for attention chips.
+ *
+ * `.chip-glyph` attaches a monospace reason symbol after the chip label via
+ * ::after. Color is inherited from the host chip, so the chip's status
+ * modifier carries severity and `.chip-glyph--*` carries the reason.
+ *
+ * Usage:
+ *   <span class="chip chip--failing chip-glyph chip-glyph--ci-fail">CI</span>
+ *   <span class="chip chip--running chip-glyph chip-glyph--stale">Running</span>
+ *
+ * Reasons:
+ *   --review     "!"  — review reply needed / PR conflict
+ *   --ci-fail    "✗"  — CI failing
+ *   --stale      "~"  — heartbeat stale > 5m
+ *   --blocked    "⚑"  — merge blocked (branch protection, dependency)
+ */
+.chip-glyph::after {
+  content: "";
+  margin-left: var(--spacing-1);
+  font-family: var(--font-family-mono);
+  font-size: inherit;
+  line-height: 1;
+}
+
+.chip-glyph--review::after {
+  content: "!";
+}
+
+.chip-glyph--ci-fail::after {
+  content: "✗";
+}
+
+.chip-glyph--stale::after {
+  content: "~";
+}
+
+.chip-glyph--blocked::after {
+  content: "⚑";
+}

--- a/plugins/dev/scripts/orch-monitor/public/mockups/home.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/home.html
@@ -73,20 +73,25 @@
        * Attention bar
        * ============================================================ */
 
+      /*
+       * CTL-170 — attention bar scoped to Tier 0 (blocked) severity. Uses
+       * --color-danger so operators distinguish blocked from merely
+       * degraded runs. `.home-attention__breakdown` carries reason counts.
+       */
       .home-attention {
         display: flex;
         align-items: center;
         gap: var(--spacing-4);
         padding: var(--spacing-3) var(--spacing-4);
-        background: color-mix(in srgb, var(--color-accent) 10%, var(--color-surface-1));
-        border: 1px solid color-mix(in srgb, var(--color-accent) 40%, transparent);
+        background: color-mix(in srgb, var(--color-danger) 10%, var(--color-surface-1));
+        border: 1px solid color-mix(in srgb, var(--color-danger) 40%, transparent);
         border-radius: var(--radius-md);
       }
 
       [data-system="precision-instrument"] .home-attention {
         background: var(--color-surface-2);
         border-color: var(--color-border-default);
-        border-left: 2px solid var(--color-accent);
+        border-left: 2px solid var(--color-danger);
         border-radius: 0;
       }
 
@@ -97,8 +102,8 @@
         width: var(--spacing-6);
         height: var(--spacing-6);
         border-radius: var(--radius-full);
-        background: color-mix(in srgb, var(--color-accent) 22%, transparent);
-        color: var(--color-accent);
+        background: color-mix(in srgb, var(--color-danger) 22%, transparent);
+        color: var(--color-danger);
         font-family: var(--font-family-mono);
         font-size: var(--font-size-data);
         font-weight: var(--font-weight-semibold);
@@ -123,8 +128,17 @@
       .home-attention__count {
         font-family: var(--font-family-mono);
         font-variant-numeric: tabular-nums;
-        color: var(--color-accent);
+        color: var(--color-danger);
         margin-right: var(--spacing-1);
+      }
+
+      .home-attention__breakdown {
+        margin-left: var(--spacing-2);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-data);
+        line-height: var(--line-height-data);
+        color: var(--color-text-md);
+        font-variant-numeric: tabular-nums;
       }
 
       .home-attention__meta {
@@ -149,8 +163,8 @@
       }
 
       .home-attention__action:hover {
-        border-color: var(--color-accent);
-        color: var(--color-accent);
+        border-color: var(--color-danger);
+        color: var(--color-danger);
       }
 
       /* ============================================================
@@ -490,24 +504,47 @@
         color: var(--color-text-md);
       }
 
-      /* Needs-me accent rail */
-      .home-card--needs-me {
+      /*
+       * CTL-170 — tiered attention rails.
+       *
+       * Tier 0 (blocked) : danger rail, static. Triggers: PR conflict,
+       *                    merge hold, review reply needed.
+       * Tier 1 (degraded): warning rail, pulsing. Triggers: CI failing,
+       *                    heartbeat stale > 5m, rate-limit backoff.
+       * Tier 2 (info)    : success chip in .home-card__chips, no rail.
+       *                    Triggers: auto-recovered, PR auto-merged,
+       *                    wave settled.
+       *
+       * The heartbeat pulse moves to Tier 1 — "something is alive but
+       * slow" is the right metaphor. Tier 0 is static because blocked
+       * runs aren't making progress at all.
+       */
+      .home-card--tier-0,
+      .home-card--tier-1 {
         padding-left: calc(var(--spacing-5) + 2px);
       }
 
-      .home-card--needs-me::before {
+      .home-card--tier-0::before,
+      .home-card--tier-1::before {
         content: "";
         position: absolute;
         left: 0;
         top: 0;
         bottom: 0;
         width: 2px;
-        background: var(--color-accent);
         border-radius: var(--radius-sm) 0 0 var(--radius-sm);
         opacity: 0.9;
       }
 
-      [data-system="operator-console"] .home-card--needs-me::before {
+      .home-card--tier-0::before {
+        background: var(--color-danger);
+      }
+
+      .home-card--tier-1::before {
+        background: var(--color-warning);
+      }
+
+      [data-system="operator-console"] .home-card--tier-1::before {
         animation: brand-heartbeat var(--motion-duration-heartbeat) ease-in-out infinite;
       }
 
@@ -522,7 +559,7 @@
       }
 
       @media (prefers-reduced-motion: reduce) {
-        [data-system="operator-console"] .home-card--needs-me::before {
+        [data-system="operator-console"] .home-card--tier-1::before {
           animation: none;
         }
       }
@@ -568,13 +605,7 @@
         background: color-mix(in srgb, var(--color-danger) 12%, transparent);
         border-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
       }
-      [data-system="operator-console"] .chip--needs-me {
-        color: var(--color-accent);
-        background: color-mix(in srgb, var(--color-accent) 18%, transparent);
-        border-color: var(--color-accent);
-      }
-      [data-system="operator-console"] .chip--queued,
-      [data-system="operator-console"] .chip--dispatched {
+      [data-system="operator-console"] .chip--queued {
         color: var(--color-text-md);
         background: var(--color-surface-2);
         border-color: var(--color-border-subtle);
@@ -613,11 +644,7 @@
       [data-system="precision-instrument"] .chip--failed::before {
         color: var(--color-danger);
       }
-      [data-system="precision-instrument"] .chip--needs-me::before {
-        color: var(--color-accent);
-      }
-      [data-system="precision-instrument"] .chip--queued::before,
-      [data-system="precision-instrument"] .chip--dispatched::before {
+      [data-system="precision-instrument"] .chip--queued::before {
         color: var(--color-text-lo);
       }
       [data-system="precision-instrument"] .chip--stalled::before {
@@ -968,7 +995,8 @@
           <span class="home-attention__icon" aria-hidden="true">!</span>
           <span class="home-attention__text">
             <span class="home-attention__count">2</span>
-            runs are waiting on you. Review before the next wave kicks off.
+            runs are blocked.
+            <span class="home-attention__breakdown">2 blocked · 1 CI fail</span>
           </span>
           <span class="home-attention__meta">oldest · 14m</span>
           <button type="button" class="home-attention__action">Review</button>
@@ -1046,7 +1074,7 @@
               </header>
               <div class="home-kanban__column-body">
                 <article
-                  class="home-card"
+                  class="home-card home-card--tier-0"
                   data-column="working"
                   data-kind="orch"
                   role="listitem"
@@ -1076,19 +1104,27 @@
                       <span class="chip chip--pr-open">PR open</span>
                       <span class="home-card__chip-count">2</span>
                     </span>
+                    <span class="home-card__chip-group">
+                      <span class="chip chip--merged">Auto-merged</span>
+                      <span class="home-card__chip-count">4</span>
+                    </span>
+                    <span class="home-card__chip-group">
+                      <span class="chip chip--failed chip-glyph chip-glyph--ci-fail">Failed</span>
+                      <span class="home-card__chip-count">1</span>
+                    </span>
                   </div>
                   <footer class="home-card__footer">
                     <span class="home-card__footer-item">
                       <span class="home-card__footer-label">cost</span>
-                      <span class="home-card__footer-value">$4.82</span>
+                      <span class="home-card__footer-value">$3.41</span>
                     </span>
                     <span class="home-card__footer-item">
                       <span class="home-card__footer-label">heartbeat</span>
-                      <span class="home-card__footer-value">12s</span>
+                      <span class="home-card__footer-value">18s ago</span>
                     </span>
                     <span class="home-card__footer-item">
                       <span class="home-card__footer-label">PRs</span>
-                      <span class="home-card__footer-value">2</span>
+                      <span class="home-card__footer-value">6</span>
                     </span>
                   </footer>
                 </article>
@@ -1794,6 +1830,180 @@
             </p>
             <code class="home-error__line">GET /api/sessions → 503 service unavailable · 12:41:08</code>
             <button type="button" class="home-retry">Retry</button>
+          </div>
+        </section>
+
+        <!-- ============================================================
+             SOLO WORKERS
+             ============================================================ -->
+        <section class="home-section">
+          <header class="home-section__heading">
+            <div class="home-section__title">
+              <h2>Solo workers</h2>
+              <span class="home-section__count">3 running</span>
+            </div>
+            <span class="eyebrow">Standalone</span>
+          </header>
+
+          <!-- default variant -->
+          <div class="home-card-grid" data-variant="default" role="list">
+            <article class="home-card" role="listitem">
+              <header class="home-card__header">
+                <h3 class="home-card__title">release-notes-gen</h3>
+                <span class="home-card__kind">Solo worker</span>
+              </header>
+              <div class="home-card__meta">
+                <span class="home-card__stage">Phase 3 · implement</span>
+                <span class="home-card__progress">14 / 18</span>
+              </div>
+              <div class="home-card__bar" aria-hidden="true">
+                <span style="width: 78%"></span>
+              </div>
+              <div class="home-card__chips">
+                <span class="chip chip--running">Running</span>
+                <span class="chip chip--ticket">CTL-219</span>
+              </div>
+              <footer class="home-card__footer">
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">cost</span>
+                  <span class="home-card__footer-value">$0.24</span>
+                </span>
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">heartbeat</span>
+                  <span class="home-card__footer-value">12s ago</span>
+                </span>
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">PR</span>
+                  <span class="home-card__footer-value">—</span>
+                </span>
+              </footer>
+            </article>
+
+            <article class="home-card home-card--tier-1" role="listitem">
+              <header class="home-card__header">
+                <h3 class="home-card__title">rename-scope-refactor</h3>
+                <span class="home-card__kind">Solo worker</span>
+              </header>
+              <div class="home-card__meta">
+                <span class="home-card__stage">Phase 2 · plan</span>
+                <span class="home-card__progress">6 / 18</span>
+              </div>
+              <div class="home-card__bar" aria-hidden="true">
+                <span style="width: 33%"></span>
+              </div>
+              <div class="home-card__chips">
+                <span class="chip chip--running chip-glyph chip-glyph--stale">Stalled</span>
+                <span class="chip chip--ticket">CTL-214</span>
+              </div>
+              <footer class="home-card__footer">
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">cost</span>
+                  <span class="home-card__footer-value">$0.18</span>
+                </span>
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">heartbeat</span>
+                  <span class="home-card__footer-value">12m ago</span>
+                </span>
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">PR</span>
+                  <span class="home-card__footer-value">—</span>
+                </span>
+              </footer>
+            </article>
+
+            <article class="home-card" role="listitem">
+              <header class="home-card__header">
+                <h3 class="home-card__title">otel-panel-cleanup</h3>
+                <span class="home-card__kind">Solo worker</span>
+              </header>
+              <div class="home-card__meta">
+                <span class="home-card__stage">Phase 5 · ship</span>
+                <span class="home-card__progress">17 / 18</span>
+              </div>
+              <div class="home-card__bar" aria-hidden="true">
+                <span style="width: 94%"></span>
+              </div>
+              <div class="home-card__chips">
+                <span class="chip chip--pr-open">PR open</span>
+                <span class="chip chip--ticket">CTL-118</span>
+              </div>
+              <footer class="home-card__footer">
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">cost</span>
+                  <span class="home-card__footer-value">$0.47</span>
+                </span>
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">heartbeat</span>
+                  <span class="home-card__footer-value">3s ago</span>
+                </span>
+                <span class="home-card__footer-item">
+                  <span class="home-card__footer-label">PR</span>
+                  <span class="home-card__footer-value">#239</span>
+                </span>
+              </footer>
+            </article>
+          </div>
+
+          <!-- loading variant -->
+          <div class="home-card-grid" data-variant="loading" role="list" aria-hidden="true">
+            <article class="home-card home-card--skeleton" role="listitem">
+              <header class="home-card__header">
+                <h3 class="home-card__title">loading</h3>
+                <span class="home-card__kind">loading</span>
+              </header>
+              <div class="home-card__meta">
+                <span class="home-card__stage">loading</span>
+                <span class="home-card__progress">loading</span>
+              </div>
+              <div class="home-card__bar" aria-hidden="true">
+                <span></span>
+              </div>
+              <div class="home-card__chips">loading</div>
+              <footer class="home-card__footer">
+                <span class="home-card__footer-item">loading</span>
+                <span class="home-card__footer-item">loading</span>
+                <span class="home-card__footer-item">loading</span>
+              </footer>
+            </article>
+            <article class="home-card home-card--skeleton" role="listitem">
+              <header class="home-card__header">
+                <h3 class="home-card__title">loading</h3>
+                <span class="home-card__kind">loading</span>
+              </header>
+              <div class="home-card__meta">
+                <span class="home-card__stage">loading</span>
+                <span class="home-card__progress">loading</span>
+              </div>
+              <div class="home-card__bar" aria-hidden="true">
+                <span></span>
+              </div>
+              <div class="home-card__chips">loading</div>
+              <footer class="home-card__footer">
+                <span class="home-card__footer-item">loading</span>
+                <span class="home-card__footer-item">loading</span>
+                <span class="home-card__footer-item">loading</span>
+              </footer>
+            </article>
+          </div>
+
+          <!-- empty variant -->
+          <div class="home-empty" data-variant="empty">
+            <span class="home-empty__title">No standalone agents</span>
+            <p class="home-empty__body">
+              Solo workers run one agent against one ticket. Dispatch one directly from a worktree
+              or let an orchestrator fan them out.
+            </p>
+            <span class="home-empty__hint">/catalyst-dev:oneshot CTL-123</span>
+          </div>
+
+          <!-- error variant -->
+          <div class="home-error" data-variant="error">
+            <span class="home-error__title">Could not reach the monitor</span>
+            <p class="home-error__body">
+              Solo-worker state is derived from the same stream. See the orchestrators section
+              above for the retry line.
+            </p>
+            <code class="home-error__line">GET /api/workers → 503 service unavailable · 12:41:08</code>
           </div>
         </section>
 

--- a/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
@@ -157,11 +157,6 @@
         background: color-mix(in srgb, var(--color-danger) 12%, transparent);
         border-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
       }
-      [data-system="operator-console"] .chip--needs-me {
-        color: var(--color-accent);
-        background: color-mix(in srgb, var(--color-accent) 18%, transparent);
-        border-color: var(--color-accent);
-      }
       [data-system="operator-console"] .chip--queued,
       [data-system="operator-console"] .chip--ticket {
         color: var(--color-text-md);
@@ -181,8 +176,7 @@
         line-height: 1;
       }
       [data-system="precision-instrument"] .chip--running::before,
-      [data-system="precision-instrument"] .chip--merging::before,
-      [data-system="precision-instrument"] .chip--needs-me::before {
+      [data-system="precision-instrument"] .chip--merging::before {
         color: var(--color-accent);
       }
       [data-system="precision-instrument"] .chip--pr-open::before,
@@ -1463,7 +1457,7 @@
                       <span class="wave-card__chip-ticket">CTL-145</span>
                     </span>
                     <span class="wave-card__chip" role="listitem">
-                      <span class="chip chip--needs-me">Needs me</span>
+                      <span class="chip chip--failed chip-glyph chip-glyph--review">Review</span>
                       <span class="wave-card__chip-ticket">CTL-139</span>
                     </span>
                   </div>
@@ -1647,7 +1641,7 @@
 
                 <div class="worker-table__row" role="row">
                   <span class="worker-table__cell--ticket" role="cell">CTL-139</span>
-                  <span role="cell"><span class="chip chip--needs-me">Needs me</span></span>
+                  <span role="cell"><span class="chip chip--failing chip-glyph chip-glyph--ci-fail">CI fail</span></span>
                   <span role="cell">validate</span>
                   <span class="worker-table__cell--pr" role="cell"><a href="#">#243</a></span>
                   <span role="cell">96</span>

--- a/plugins/dev/scripts/orch-monitor/public/mockups/worker.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/worker.html
@@ -658,6 +658,7 @@
           <div class="worker-head__title">
             <span class="worker-head__ticket chip chip--ticket">CTL-138</span>
             <span class="chip chip--merging">Merging</span>
+            <span class="chip chip--failed chip-glyph chip-glyph--review">Review reply</span>
             <h1 class="worker-head__name">worker.html mockup</h1>
             <a class="worker-head__pr-link" href="#">PR #247 ↗</a>
           </div>


### PR DESCRIPTION
## Summary

Replace the yellow `home-card--needs-me` accent-tint system with a 3-tier
severity model on the mockup surfaces, plus 4 reason glyphs on worker chips
across home / orch / worker pages.

- Tier 0 blocked — 2px danger rail, **static** (PR conflict, merge hold, review reply)
- Tier 1 degraded — 2px warning rail, **pulsing** (CI failing, heartbeat stale, rate-limit backoff) — heartbeat pulse moves here
- Tier 2 informational — green success chip in card chips, no rail (auto-merged, auto-recovered, wave settled)

Shared `.chip-glyph` modifier added to `_shared/chrome.css` with 4 variants — `!` review, `✗` ci-fail, `~` stale, `⚑` blocked. Inline doc comment covers usage.

Home attention bar rescoped to Tier 0, tinted with `--color-danger`, and gains a `.home-attention__breakdown` reason-count span.

All `chip--needs-me` and `home-card--needs-me` rules + markup removed from `home.html`, `orch.html`, `chrome.css`.

Closes CTL-170. Depends on CTL-166 (merged).

## Acceptance criteria

- [x] Tier 0 cards show danger rail (static), Tier 1 show warning rail (pulsing)
- [x] Four reason glyphs render on worker chips across home, orch, worker pages
- [x] Home attention bar shows count breakdown by reason type ("2 blocked · 1 CI fail")
- [x] `.chip-glyph` documented in chrome.css with usage comment
- [x] Yellow tint system fully removed from home.html and chrome.css

## Test plan

- [x] Grep assertions: zero `needs-me` in home.html / chrome.css; `chip-glyph` used in chrome.css + home + orch + worker
- [x] CSS brace balance verified in all edited files
- [ ] Visual review: open home.html in browser — confirm Tier 0 is static red, Tier 1 is pulsing amber, attention bar is red with breakdown, glyphs render correctly

## Files

- `plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.css` (+41) — new `.chip-glyph` + variants
- `plugins/dev/scripts/orch-monitor/public/mockups/home.html` (+90/-39) — tier rails, attention bar, chip markup
- `plugins/dev/scripts/orch-monitor/public/mockups/orch.html` (+6/-6) — chip--needs-me → glyph chips
- `plugins/dev/scripts/orch-monitor/public/mockups/worker.html` (+1) — chip-glyph demo