### PR TITLE
fix(dev): add thoughts preflight assertions for orchestrated worktrees (CTL-195)

### DIFF
--- a/plugins/dev/agents/thoughts-analyzer.md
+++ b/plugins/dev/agents/thoughts-analyzer.md
@@ -32,6 +32,27 @@ out noise.
    - Distinguish decisions from explorations
    - Identify what was actually implemented vs proposed
 
+## Preflight Check (MANDATORY — run before ANY analysis)
+
+Before reading any documents, run `ls thoughts/shared/` to verify the thoughts directory exists.
+
+- **If `thoughts/shared/` does not exist**: STOP immediately. Do NOT attempt any analysis. Report:
+  ```
+  ⚠️ thoughts/shared/ not found
+  Working directory: <output of pwd or the cwd you observe>
+  Checked path: thoughts/shared/
+
+  The thoughts directory is not initialized in this working directory.
+  This may indicate a worktree setup issue — thoughts init or sync may not have run.
+  ```
+  Return this as your complete response.
+
+- **If the specific document path you were asked to analyze does not exist**: Report clearly that the
+  file was not found, include the exact path checked and your working directory. Do not silently
+  return empty analysis.
+
+- **If `thoughts/shared/` exists**: Proceed normally to analysis below.
+
 ## Analysis Strategy
 
 ### Step 1: Read with Purpose

--- a/plugins/dev/agents/thoughts-locator.md
+++ b/plugins/dev/agents/thoughts-locator.md
@@ -35,6 +35,28 @@ thought documents and categorize them, NOT to analyze their contents in depth.
    - Note document dates if visible in filename
    - Correct searchable/ paths to actual paths
 
+## Preflight Check (MANDATORY — run before ANY search)
+
+Before doing anything else, run `ls thoughts/shared/` to verify the thoughts directory exists.
+
+- **If `thoughts/shared/` does not exist**: STOP immediately. Do NOT attempt any searches. Report:
+  ```
+  ⚠️ thoughts/shared/ not found
+  Working directory: <output of pwd or the cwd you observe>
+  Checked path: thoughts/shared/
+
+  The thoughts directory is not initialized in this working directory.
+  This may indicate a worktree setup issue — thoughts init or sync may not have run.
+  ```
+  Return this as your complete response. Do not guess, do not return empty results, do not say
+  "no relevant documents found" — the directory itself is missing, which is a setup problem.
+
+- **If `thoughts/shared/` exists but is completely empty** (no subdirectories, no files): Report a
+  warning that thoughts appears uninitialized, include the working directory, then proceed with
+  searching other locations (searchable/, global/, user dirs).
+
+- **If `thoughts/shared/` exists and has content**: Proceed normally to the search strategy below.
+
 ## Search Strategy
 
 First, think deeply about the search approach - consider which directories to prioritize based on

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -322,6 +322,17 @@ else
 			echo -e "${GREEN}  ✅ Thoughts initialized${NC}"
 			echo "  Running: humanlayer thoughts sync"
 			humanlayer thoughts sync >/dev/null 2>&1 || echo -e "${YELLOW}  ⚠️  Sync warning: run 'humanlayer thoughts sync' manually${NC}"
+			# Verify thoughts/shared/ exists after init+sync
+			if [ ! -d "thoughts/shared" ]; then
+				echo -e "${RED}❌ Error: thoughts/shared/ does not exist after init+sync${NC}"
+				echo "  Working directory: $(pwd)"
+				echo "  Expected path: $(pwd)/thoughts/shared/"
+				echo "  This indicates a thoughts initialization failure."
+				exit 1
+			fi
+			if [ -z "$(ls -A thoughts/shared/ 2>/dev/null)" ]; then
+				echo -e "${YELLOW}  ⚠️  thoughts/shared/ exists but is empty — sync may not have pulled content yet${NC}"
+			fi
 		else
 			echo -e "${YELLOW}  ⚠️  Could not initialize thoughts${NC}"
 		fi

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -43,6 +43,11 @@ if ! command -v claude &>/dev/null; then
   echo "ERROR: Claude CLI required for worker dispatch"
   exit 1
 fi
+
+# 5. Project setup (REQUIRED — thoughts, config, workflow context)
+if [[ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" ]]; then
+  "${CLAUDE_PLUGIN_ROOT}/scripts/check-project-setup.sh" || exit 1
+fi
 ```
 
 ## Invocation


### PR DESCRIPTION
## Summary

- **thoughts-locator & thoughts-analyzer agents**: Added mandatory preflight check that verifies `thoughts/shared/` exists before searching/analyzing. Reports working directory and exact path on failure instead of silently returning empty results.
- **create-worktree.sh**: Added post-sync verification gate — fails worktree creation if `thoughts/shared/` doesn't exist after `humanlayer thoughts init + sync`, warns if the directory is empty.
- **orchestrate skill**: Added `check-project-setup.sh` to prerequisites so broken thoughts config is caught before any workers are dispatched.

Closes CTL-195

## Test plan

- [ ] Create a worktree in a project with thoughts configured — verify `thoughts/shared/` check passes silently
- [ ] Manually remove `thoughts/shared/` from a worktree and run `thoughts-locator` — verify it reports the missing directory with cwd instead of returning empty
- [ ] Run `create-worktree.sh` with a broken humanlayer config — verify it exits 1 with a clear error about `thoughts/shared/`
- [ ] Run `/catalyst-dev:orchestrate --dry-run` — verify `check-project-setup.sh` runs in prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)