### PR TITLE
fix(dev): Warp tab shows worktree CWD via --shell-eval mode

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -8,6 +8,7 @@
       "teamKey": "CTL",
       "stateMap": {
         "backlog": "Backlog",
+        "todo": "Backlog",
         "research": "In Progress",
         "planning": "In Progress",
         "inProgress": "In Progress",

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"50a30643-b89c-49fe-8bba-7859ed37c257","pid":9492,"acquiredAt":1776192040813}
+{"sessionId":"966d6785-620b-44b3-b060-aea1d1ff8732","pid":84354,"procStart":"Sat Apr 25 03:35:01 2026","acquiredAt":1777089037648}

--- a/plugins/dev/scripts/launch-orchestrator-tab.sh
+++ b/plugins/dev/scripts/launch-orchestrator-tab.sh
@@ -31,9 +31,11 @@ SETUP="${SCRIPT_DIR}/setup-orchestrator.sh"
 CLAUDE_LAUNCHER="${SCRIPT_DIR}/catalyst-claude.sh"
 
 PROJECT=""
+SHELL_EVAL=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project) PROJECT="$2"; shift 2 ;;
+    --shell-eval) SHELL_EVAL=true; shift ;;
     --) shift; break ;;
     *) break ;;
   esac
@@ -100,15 +102,23 @@ if [[ -z "${WORKTREE_PATH:-}" ]]; then
   exit 1
 fi
 
+if [[ "$SHELL_EVAL" == true ]]; then
+  printf 'cd %q\n' "$WORKTREE_PATH"
+  printf 'eval "$(direnv export zsh 2>/dev/null || true)"\n'
+  printf 'export CATALYST_WARP_NAME=%q\n' "$SESSION_NAME"
+  printf 'export CATALYST_WARP_REMOTE=%q\n' "$SESSION_NAME"
+  printf 'exec %q %q\n' "$CLAUDE_LAUNCHER" "$CLAUDE_INVOCATION"
+  exit 0
+fi
+
+# Direct mode: cd + exec (used when not invoked via eval)
 cd "$WORKTREE_PATH"
 
-# Re-activate direnv inside the worktree (per-worktree .envrc)
 if command -v direnv >/dev/null 2>&1; then
   direnv allow . >/dev/null 2>&1 || true
   eval "$(direnv export zsh 2>/dev/null || true)"
 fi
 
-# Forward session name to claude via catalyst-claude.sh (reads CATALYST_WARP_*)
 export CATALYST_WARP_NAME="$SESSION_NAME"
 export CATALYST_WARP_REMOTE="$SESSION_NAME"
 

--- a/plugins/dev/scripts/launch-worktree-tab.sh
+++ b/plugins/dev/scripts/launch-worktree-tab.sh
@@ -39,11 +39,13 @@ CLAUDE_LAUNCHER="${SCRIPT_DIR}/catalyst-claude.sh"
 PROJECT=""
 PROMPT_FILE=""
 PROMPT_STRING=""
+SHELL_EVAL=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project) PROJECT="$2"; shift 2 ;;
     --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
     --prompt) PROMPT_STRING="$2"; shift 2 ;;
+    --shell-eval) SHELL_EVAL=true; shift ;;
     --) shift; break ;;
     --*) echo "Unknown flag: $1" >&2; exit 2 ;;
     *) break ;;
@@ -81,6 +83,34 @@ if [[ -z "${WORKTREE_PATH:-}" ]]; then
   exit 1
 fi
 
+# Resolve the initial prompt (used by both modes)
+INITIAL_PROMPT=""
+if [[ -n "$PROMPT_STRING" ]]; then
+  INITIAL_PROMPT="$PROMPT_STRING"
+elif [[ -n "$PROMPT_FILE" ]]; then
+  if [[ -f "$PROMPT_FILE" ]]; then
+    INITIAL_PROMPT="$(<"$PROMPT_FILE")"
+  else
+    echo "⚠️  --prompt-file not found: $PROMPT_FILE — launching without initial prompt" >&2
+  fi
+fi
+
+if [[ "$SHELL_EVAL" == true ]]; then
+  # Emit shell commands for the caller to eval. The cd happens in the calling
+  # shell so Warp's directory tracking picks it up.
+  printf 'cd %q\n' "$WORKTREE_PATH"
+  printf 'eval "$(direnv export zsh 2>/dev/null || true)"\n'
+  printf 'export CATALYST_WARP_NAME=%q\n' "$SESSION_NAME"
+  printf 'export CATALYST_WARP_REMOTE=%q\n' "$SESSION_NAME"
+  if [[ -n "$INITIAL_PROMPT" ]]; then
+    printf 'exec %q %q\n' "$CLAUDE_LAUNCHER" "$INITIAL_PROMPT"
+  else
+    printf 'exec %q\n' "$CLAUDE_LAUNCHER"
+  fi
+  exit 0
+fi
+
+# Direct mode: cd + exec (used when not invoked via eval)
 cd "$WORKTREE_PATH"
 
 if command -v direnv >/dev/null 2>&1; then
@@ -88,21 +118,11 @@ if command -v direnv >/dev/null 2>&1; then
   eval "$(direnv export zsh 2>/dev/null || true)"
 fi
 
-# Forward session name to claude via catalyst-claude.sh (reads CATALYST_WARP_*)
 export CATALYST_WARP_NAME="$SESSION_NAME"
 export CATALYST_WARP_REMOTE="$SESSION_NAME"
 
-if [[ -n "$PROMPT_STRING" ]]; then
-  exec "$CLAUDE_LAUNCHER" "$PROMPT_STRING"
-fi
-
-if [[ -n "$PROMPT_FILE" ]]; then
-  if [[ -f "$PROMPT_FILE" ]]; then
-    INITIAL_PROMPT="$(<"$PROMPT_FILE")"
-    exec "$CLAUDE_LAUNCHER" "$INITIAL_PROMPT"
-  else
-    echo "⚠️  --prompt-file not found: $PROMPT_FILE — launching without initial prompt" >&2
-  fi
+if [[ -n "$INITIAL_PROMPT" ]]; then
+  exec "$CLAUDE_LAUNCHER" "$INITIAL_PROMPT"
 fi
 
 exec "$CLAUDE_LAUNCHER"


### PR DESCRIPTION
## Summary

- Adds `--shell-eval` flag to `launch-worktree-tab.sh` and `launch-orchestrator-tab.sh`
- When used, scripts emit shell commands to stdout instead of cd+exec directly
- Warp tab configs use `eval "$(...--shell-eval...)"` so the `cd` happens in the shell where Warp's directory tracking picks it up

**Root cause:** Warp tracks CWD via shell integration (OSC 7 from the shell itself). The `cd` inside a subprocess was invisible — Warp always showed the initial `directory` from the TOML, not the actual worktree path.

## Test plan

- [ ] Open a Catalyst PM tab — Warp path indicator should show the worktree path, not the main checkout
- [ ] Open a new worktree tab — same behavior
- [ ] Verify direct mode (without --shell-eval) still works for backward compat
- [ ] Verify orchestrator tabs cd to the orch worktree

> ⚠️ Tab configs in `~/.warp/tab_configs/` already reference `--shell-eval`. They'll fail until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)