### PR TITLE
fix(dev): force Warp CWD update before exec in --shell-eval mode (CTL-199)

### DIFF
--- a/plugins/dev/scripts/launch-orchestrator-tab.sh
+++ b/plugins/dev/scripts/launch-orchestrator-tab.sh
@@ -107,6 +107,10 @@ if [[ "$SHELL_EVAL" == true ]]; then
   printf 'eval "$(direnv export zsh 2>/dev/null || true)"\n'
   printf 'export CATALYST_WARP_NAME=%q\n' "$SESSION_NAME"
   printf 'export CATALYST_WARP_REMOTE=%q\n' "$SESSION_NAME"
+  # Force Warp to update CWD tracking before exec replaces the shell.
+  # warp_precmd emits the DCS payload Warp uses to track $PWD; without this,
+  # exec fires before any prompt renders and Warp never learns about the cd.
+  printf '{ type warp_precmd &>/dev/null && warp_precmd; } 2>/dev/null || true\n'
   printf 'exec %q %q\n' "$CLAUDE_LAUNCHER" "$CLAUDE_INVOCATION"
   exit 0
 fi

--- a/plugins/dev/scripts/launch-worktree-tab.sh
+++ b/plugins/dev/scripts/launch-worktree-tab.sh
@@ -102,6 +102,10 @@ if [[ "$SHELL_EVAL" == true ]]; then
   printf 'eval "$(direnv export zsh 2>/dev/null || true)"\n'
   printf 'export CATALYST_WARP_NAME=%q\n' "$SESSION_NAME"
   printf 'export CATALYST_WARP_REMOTE=%q\n' "$SESSION_NAME"
+  # Force Warp to update CWD tracking before exec replaces the shell.
+  # warp_precmd emits the DCS payload Warp uses to track $PWD; without this,
+  # exec fires before any prompt renders and Warp never learns about the cd.
+  printf '{ type warp_precmd &>/dev/null && warp_precmd; } 2>/dev/null || true\n'
   if [[ -n "$INITIAL_PROMPT" ]]; then
     printf 'exec %q %q\n' "$CLAUDE_LAUNCHER" "$INITIAL_PROMPT"
   else


### PR DESCRIPTION
## Summary

- Fixes Warp's file explorer and path indicator showing the main checkout instead of the worktree directory after `--shell-eval` cd
- Adds explicit `warp_precmd` call between `cd` and `exec` in both `launch-worktree-tab.sh` and `launch-orchestrator-tab.sh`
- The call is a safe no-op in non-Warp shells (`type` check + `|| true`)

## Root Cause

Warp tracks CWD via a `warp_precmd` hook that emits a proprietary DCS JSON payload at prompt time. The `--shell-eval` output runs `cd <worktree>` followed immediately by `exec catalyst-claude.sh`, which replaces the shell before any prompt renders. Since `warp_precmd` never fires, Warp's UI stays at the TOML `directory` value.

## Test plan

- [ ] Open a worktree Warp tab (e.g., "New Worktree One-Shot") with a ticket ID
- [ ] Verify Warp's path bar and file explorer show the worktree path, not the main checkout
- [ ] Verify Claude Code starts in the correct worktree directory
- [ ] Open an orchestrator Warp tab and verify the same CWD behavior
- [ ] Verify non-Warp terminals still work (the `warp_precmd` guard makes it a no-op)

Closes CTL-199