### PR TITLE
fix(dev): drop exec from --shell-eval to preserve tab shell (CTL-201)

### DIFF
--- a/plugins/dev/scripts/launch-orchestrator-tab.sh
+++ b/plugins/dev/scripts/launch-orchestrator-tab.sh
@@ -107,11 +107,10 @@ if [[ "$SHELL_EVAL" == true ]]; then
   printf 'eval "$(direnv export zsh 2>/dev/null || true)"\n'
   printf 'export CATALYST_WARP_NAME=%q\n' "$SESSION_NAME"
   printf 'export CATALYST_WARP_REMOTE=%q\n' "$SESSION_NAME"
-  # Force Warp to update CWD tracking before exec replaces the shell.
-  # warp_precmd emits the DCS payload Warp uses to track $PWD; without this,
-  # exec fires before any prompt renders and Warp never learns about the cd.
+  # Force Warp to update CWD tracking before launching Claude.
   printf '{ type warp_precmd &>/dev/null && warp_precmd; } 2>/dev/null || true\n'
-  printf 'exec %q %q\n' "$CLAUDE_LAUNCHER" "$CLAUDE_INVOCATION"
+  # No exec — these run inside the caller's shell via eval. See worktree launcher.
+  printf '%q %q\n' "$CLAUDE_LAUNCHER" "$CLAUDE_INVOCATION"
   exit 0
 fi
 

--- a/plugins/dev/scripts/launch-worktree-tab.sh
+++ b/plugins/dev/scripts/launch-worktree-tab.sh
@@ -2,7 +2,7 @@
 # launch-worktree-tab.sh — Tab-config launcher for long-lived catalyst worktrees
 #
 # Called as a one-liner from Warp tab configs. Creates the worktree if it doesn't
-# exist (reusing it if it does), then execs claude inside it. Used for both the
+# exist (reusing it if it does), then launches claude inside it. Used for both the
 # permanent "pm" worktree and on-demand ticket worktrees.
 #
 # Usage:
@@ -102,14 +102,18 @@ if [[ "$SHELL_EVAL" == true ]]; then
   printf 'eval "$(direnv export zsh 2>/dev/null || true)"\n'
   printf 'export CATALYST_WARP_NAME=%q\n' "$SESSION_NAME"
   printf 'export CATALYST_WARP_REMOTE=%q\n' "$SESSION_NAME"
-  # Force Warp to update CWD tracking before exec replaces the shell.
+  # Force Warp to update CWD tracking before launching Claude.
   # warp_precmd emits the DCS payload Warp uses to track $PWD; without this,
-  # exec fires before any prompt renders and Warp never learns about the cd.
+  # Claude launches before any prompt renders and Warp never learns about the cd.
   printf '{ type warp_precmd &>/dev/null && warp_precmd; } 2>/dev/null || true\n'
+  # No exec here — these commands run inside the caller's shell via eval, so
+  # exec would replace the tab's login shell. When Claude exits, the shell
+  # would be gone and Warp would respawn a bare shell with no context.
+  # Running without exec keeps the shell alive after Claude exits.
   if [[ -n "$INITIAL_PROMPT" ]]; then
-    printf 'exec %q %q\n' "$CLAUDE_LAUNCHER" "$INITIAL_PROMPT"
+    printf '%q %q\n' "$CLAUDE_LAUNCHER" "$INITIAL_PROMPT"
   else
-    printf 'exec %q\n' "$CLAUDE_LAUNCHER"
+    printf '%q\n' "$CLAUDE_LAUNCHER"
   fi
   exit 0
 fi


### PR DESCRIPTION
## Summary

- Removes `exec` from `--shell-eval` output in both `launch-worktree-tab.sh` and `launch-orchestrator-tab.sh`
- Fixes regression from #298 where Claude sessions launched via Warp tab configs would kill the tab's login shell on exit, dropping the user to a bare respawned shell

**Root cause:** `--shell-eval` emits commands that get `eval`'d in the tab's shell. `exec` replaced that shell with Claude, so when Claude exited there was no shell to return to.

**Fix:** Run Claude as a child process (no `exec`) in shell-eval mode. The shell survives and the user stays at the worktree path when Claude exits. Direct mode (non-eval) still uses `exec` since it runs in a subprocess.

## Test plan

- [ ] Open a Warp oneshot tab → run oneshot → when Claude exits, verify you return to zsh at the worktree path (not a bare respawned shell)
- [ ] Open a Warp PM tab → `/exit` Claude → verify shell survives
- [ ] Open a Warp orchestrator tab → verify Claude launches correctly
- [ ] Verify Warp CWD tracking still shows the worktree path (not the repo root)
- [ ] Verify direct mode (without --shell-eval) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)