### PR TITLE
fix(dev): replace warp_precmd with OSC 7 to prevent block split (CTL-201)

### DIFF
--- a/plugins/dev/scripts/launch-orchestrator-tab.sh
+++ b/plugins/dev/scripts/launch-orchestrator-tab.sh
@@ -107,8 +107,10 @@ if [[ "$SHELL_EVAL" == true ]]; then
   printf 'eval "$(direnv export zsh 2>/dev/null || true)"\n'
   printf 'export CATALYST_WARP_NAME=%q\n' "$SESSION_NAME"
   printf 'export CATALYST_WARP_REMOTE=%q\n' "$SESSION_NAME"
-  # Force Warp to update CWD tracking before launching Claude.
-  printf '{ type warp_precmd &>/dev/null && warp_precmd; } 2>/dev/null || true\n'
+  # Update Warp's CWD display via OSC 7 (standard terminal CWD notification).
+  # Do NOT call warp_precmd — it emits DCS block-delimiter sequences that cause
+  # Warp to split the eval into two blocks, dropping a new shell below Claude.
+  printf 'printf '"'"'\\e]7;file://%%s%%s\\a'"'"' "$(hostname)" "$PWD"\n'
   # No exec — these run inside the caller's shell via eval. See worktree launcher.
   printf '%q %q\n' "$CLAUDE_LAUNCHER" "$CLAUDE_INVOCATION"
   exit 0

--- a/plugins/dev/scripts/launch-worktree-tab.sh
+++ b/plugins/dev/scripts/launch-worktree-tab.sh
@@ -102,10 +102,10 @@ if [[ "$SHELL_EVAL" == true ]]; then
   printf 'eval "$(direnv export zsh 2>/dev/null || true)"\n'
   printf 'export CATALYST_WARP_NAME=%q\n' "$SESSION_NAME"
   printf 'export CATALYST_WARP_REMOTE=%q\n' "$SESSION_NAME"
-  # Force Warp to update CWD tracking before launching Claude.
-  # warp_precmd emits the DCS payload Warp uses to track $PWD; without this,
-  # Claude launches before any prompt renders and Warp never learns about the cd.
-  printf '{ type warp_precmd &>/dev/null && warp_precmd; } 2>/dev/null || true\n'
+  # Update Warp's CWD display via OSC 7 (standard terminal CWD notification).
+  # Do NOT call warp_precmd here — it emits DCS block-delimiter sequences that
+  # cause Warp to split the eval into two blocks, dropping a new shell below Claude.
+  printf 'printf '"'"'\\e]7;file://%%s%%s\\a'"'"' "$(hostname)" "$PWD"\n'
   # No exec here — these commands run inside the caller's shell via eval, so
   # exec would replace the tab's login shell. When Claude exits, the shell
   # would be gone and Warp would respawn a bare shell with no context.


### PR DESCRIPTION
## Summary

- Replaces `warp_precmd` call with standard OSC 7 CWD notification in both `launch-worktree-tab.sh` and `launch-orchestrator-tab.sh`
- `warp_precmd` emits DCS block-delimiter escape sequences that cause Warp to split the eval'd command chain into two blocks, dropping a new shell block below Claude
- OSC 7 (`\e]7;file://host/path\a`) updates Warp's CWD display without triggering block boundaries
- Root cause of CTL-201 persisting after PR #307 — removing `exec` was necessary but insufficient; the block split was the real symptom

## Test plan

- [ ] Open any `--shell-eval` Warp tab (e.g., "Adva: Worktree", "Catalyst: Worktree")
- [ ] Verify Claude opens without a second shell block appearing below
- [ ] Verify Warp sidebar shows the correct worktree CWD (not the repo root)
- [ ] Verify Claude exits cleanly and the shell prompt returns in the same block

🤖 Generated with [Claude Code](https://claude.com/claude-code)