### PR TITLE
feat: improve skill scores for catalyst

### DIFF
--- a/plugins/analytics/skills/segment-analysis/SKILL.md
+++ b/plugins/analytics/skills/segment-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: segment-analysis
-description: Analyze user segments and cohorts for targeted insights
+description: "Analyze user segments, cohorts, and customer groups using PostHog data. Creates retention tables, compares segment behavior, and generates group breakdowns. Use when the user asks about customer segmentation, cohort retention, user group comparison, churn analysis, or funnel analysis by segment."
 disable-model-invocation: true
 allowed-tools: Task, TodoWrite
 version: 1.0.0
@@ -22,28 +22,13 @@ Examples:
   /segment-analysis "cohort: signed up in Q4 2024"
 ```
 
-## What This Analyzes
+## Workflow
 
-### User Segments
-
-- By plan type (free, pro, enterprise)
-- By geography (country, region)
-- By acquisition source (organic, paid, referral)
-- By behavior (power users, casual users, at-risk)
-
-### Cohort Analysis
-
-- By signup date (monthly, weekly cohorts)
-- By first feature used
-- By activation milestone reached
-- By engagement level
-
-### Comparison Analysis
-
-- Segment A vs Segment B
-- Before/after feature launch
-- Treatment vs control (A/B tests)
-- Time period comparisons
+1. **Define segments** — Identify segment criteria using PostHog properties (plan type, behavior, signup date, or any custom event property)
+2. **Query PostHog** — Retrieve segment data via PostHog MCP tools or HogQL queries
+3. **Compute metrics** — Calculate retention, conversion, engagement, and LTV per segment
+4. **Compare segments** — Generate side-by-side comparisons with statistical significance
+5. **Present findings** — Deliver segment profiles, key differences, and actionable recommendations
 
 ## Example Analyses
 
@@ -87,16 +72,6 @@ Analysis typically includes:
 - **Behavior patterns** unique to segment
 - **Recommendations** for targeting or improvement
 
-## Segmentation Criteria
-
-You can segment by:
-
-- **Demographics**: Country, language, device type
-- **Behavior**: Feature usage, session frequency, engagement score
-- **Business**: Plan type, payment history, LTV
-- **Temporal**: Signup date, last active, tenure
-- **Custom**: Any event or property in PostHog
-
 ## Advanced Analysis
 
 ### Multi-dimensional Segmentation
@@ -116,14 +91,6 @@ You can segment by:
 ```bash
 /segment-analysis "30-day retention by initial feature used"
 ```
-
-## Tips for Better Analysis
-
-1. **Be specific** - Define your segment clearly
-2. **Ask for comparisons** - "vs" between segments reveals insights
-3. **Look for patterns** - What makes segments different?
-4. **Consider time** - Trends over time matter
-5. **Combine criteria** - Multi-dimensional segments can be revealing
 
 ## Context Cost
 

--- a/plugins/debugging/skills/debug-production-error/SKILL.md
+++ b/plugins/debugging/skills/debug-production-error/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug-production-error
-description: Debug production errors using Sentry error tracking and analysis
+description: "Debug production errors using Sentry MCP tools. Searches issues, analyzes stack traces, identifies root causes, and suggests fixes. Use when the user mentions a Sentry error, production exception, stack trace, error monitoring, crash report, or unhandled exception."
 disable-model-invocation: true
 allowed-tools: Task, TodoWrite
 version: 1.0.0
@@ -34,50 +34,13 @@ Examples:
 
 Uses Sentry MCP tools to:
 
-1. Search for relevant errors
-2. Retrieve stack traces and context
-3. Analyze error patterns and frequency
-4. Identify affected users and environments
-5. Suggest root causes and fixes
+1. **Search** — Find matching issues via `sentry_search_issues` filtered by query, status, or date range
+2. **Retrieve** — Pull stack traces, breadcrumbs, and user context via `sentry_get_issue_details`
+3. **Analyze** — Examine error patterns, frequency, and affected releases
+4. **Diagnose** — Use Seer AI root cause analysis when available; fall back to manual stack trace analysis
+5. **Recommend** — Suggest specific code fixes with file paths and line numbers
 
-## Available Sentry Capabilities
-
-When this plugin is enabled, you have access to ~19 Sentry tools:
-
-**Error Search & Analysis**:
-
-- Search issues by query
-- Filter by status, assignment, date
-- View error trends and patterns
-- Identify new vs recurring errors
-
-**Stack Trace Analysis**:
-
-- Full stack traces with source context
-- Source map resolution
-- Frame-by-frame analysis
-- Variable inspection
-
-**Context & Metadata**:
-
-- User context (who was affected)
-- Environment details
-- Release/deployment information
-- Breadcrumb trail (user actions leading to error)
-
-**Issue Management**:
-
-- Update issue status
-- Assign to team members
-- Link to tickets/PRs
-- Add comments and notes
-
-**Root Cause Analysis** (Seer AI):
-
-- AI-powered root cause identification
-- Code-level explanations
-- Specific fix recommendations
-- Related error patterns
+**Checkpoints:** If no issues match the query, broaden search terms or check the project/environment filter. If Seer analysis is unavailable, proceed with manual analysis.
 
 ## Example Debugging Sessions
 
@@ -104,37 +67,6 @@ When this plugin is enabled, you have access to ~19 Sentry tools:
 ```bash
 /debug-production-error "Show unresolved errors affecting more than 100 users"
 ```
-
-## Output Format
-
-Analysis typically includes:
-
-**Error Overview**:
-
-- Error message and type
-- Frequency and trend
-- First seen / last seen
-- Number of users affected
-
-**Stack Trace**:
-
-- Full call stack
-- Source code context
-- File paths and line numbers
-- Variable values (if available)
-
-**User Context**:
-
-- User ID and properties
-- Browser/device information
-- URL and user actions (breadcrumbs)
-
-**Root Cause** (when Seer analysis available):
-
-- Likely cause explanation
-- Relevant code snippets
-- Specific fix recommendations
-- Related issues
 
 ## Advanced Queries
 

--- a/plugins/dev/skills/code-first-draft/SKILL.md
+++ b/plugins/dev/skills/code-first-draft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-first-draft
-description: "Initial feature implementation from a PRD or feature description. **ALWAYS use when** the user wants to build a new feature, implement a PRD, create a first draft of code, or says things like 'build this feature', 'implement this PRD', 'code this up', 'create the initial implementation'. Also use when there's no existing codebase and user needs a standalone reference prototype."
+description: "Scaffolds initial feature implementation from a PRD or feature description using TDD (Red-Green-Refactor). Generates project structure, boilerplate code, tests, and wires up dependencies. **ALWAYS use when** the user wants to build a new feature, implement a PRD, create a first draft of code, or says things like 'build this feature', 'implement this PRD', 'code this up', 'create the initial implementation'. Not for incremental changes or bug fixes. Also use when there's no existing codebase and user needs a standalone reference prototype."
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Task
 version: 1.0.0

--- a/plugins/meta/skills/validate-frontmatter/SKILL.md
+++ b/plugins/meta/skills/validate-frontmatter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate-frontmatter
-description: Validate and fix frontmatter consistency across all workflows
+description: "Validate and fix YAML frontmatter consistency across all agent and skill definitions. Checks required fields, validates field types, ensures naming conventions, and auto-fixes common issues. Use when the user asks to check, validate, lint, or fix frontmatter, YAML metadata, or markdown headers in workflow files."
 disable-model-invocation: true
 allowed-tools: Read, Edit, Glob, Grep
 version: 1.0.0
@@ -537,48 +537,6 @@ Next steps:
 4. Reference when creating new workflows
 
 ```
-
-## Advanced Usage
-
-### Validate Specific Workflow
-
-```
-
-/catalyst-meta:validate-frontmatter agents/codebase-analyzer.md
-
-```
-
-Validates just one file.
-
-### Auto-Fix Everything
-
-```
-
-/catalyst-meta:validate-frontmatter --fix
-
-```
-
-Automatically fixes all issues without prompting.
-
-### Generate Report Only
-
-```
-
-/catalyst-meta:validate-frontmatter --report-only > frontmatter-report.md
-
-```
-
-Saves report to file for review.
-
-### Validate by Category
-
-```
-
-/catalyst-meta:validate-frontmatter --category research
-
-```
-
-Only validates workflows in "research" category.
 
 ## Validation Categories
 

--- a/plugins/pm/skills/prd-draft/SKILL.md
+++ b/plugins/pm/skills/prd-draft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-draft
-description: Create a modern, AI-era PRD for features and initiatives. Guides through clarifying questions, generates draft, and offers multi-agent review.
+description: "Create a PRD (product requirements document) for features and initiatives. Guides through clarifying questions, generates a structured draft with hypothesis, strategic fit, non-goals, success metrics, and rollout plan, then offers multi-agent review. Use when the user asks to create a PRD, product spec, feature spec, requirements doc, or product brief."
 disable-model-invocation: false
 user-invocable: true
 ---
@@ -748,112 +748,7 @@ Before presenting the PRD draft to the PM, verify:
 
 ---
 
-# Part 2: Full PRD Workflow
-
-For comprehensive end-to-end PRD creation, follow this 7-step process.
-
-## Step-by-Step Workflow
-
-### Workflow Step 1: Gather Context (10 min)
-
-Before touching AI, collect:
-
-**Research & Data:**
-
-- User research findings (interviews, surveys)
-- Analytics data (usage patterns, metrics)
-- Support tickets (common issues, requests)
-- Competitive analysis
-
-**Strategic Context:**
-
-- How this ladders to OKRs
-- Business case (revenue/user impact)
-- Strategic importance (why now?)
-
-**Technical Context:**
-
-- Existing architecture constraints
-- Integration requirements
-- Known dependencies
-
-### Workflow Step 2: Generate First Draft (5 min)
-
-Use the conversational workflow in Step 1-3 above to generate your first draft.
-
-### Workflow Step 3: Enhance Each Section (30-60 min)
-
-**Problem Statement:**
-
-- [ ] Add specific customer quotes
-- [ ] Include quantitative data
-- [ ] Connect to company strategy
-
-**Solution:**
-
-- [ ] Explain WHY this solution
-- [ ] Detail alternatives considered
-- [ ] Call out tradeoffs made
-
-**Success Metrics:**
-
-- [ ] Define leading AND lagging indicators
-- [ ] Set specific targets
-- [ ] Define success criteria
-
-### Workflow Step 4: Multi-Perspective Review (15 min)
-
-Use the multi-agent review in Step 3 above to get feedback from:
-
-- Engineering (feasibility)
-- Design (UX)
-- Executive (strategy)
-- Customer voice (user needs)
-
-### Workflow Step 5: Human Review
-
-**Must review with:**
-
-- Engineering lead
-- Design lead
-- Your manager
-
-**Should review with:**
-
-- Key stakeholders
-- PM peers
-
-### Workflow Step 6: Refine & Ship (30 min)
-
-**Final checklist:**
-
-- [ ] Can someone unfamiliar understand it?
-- [ ] All sections complete
-- [ ] Dependencies identified
-- [ ] Success criteria clear
-- [ ] Next steps defined
-
-### Workflow Step 7: Announce
-
-```
-Hi team,
-
-I've published the PRD for [Feature Name]: [link]
-
-TL;DR: [One sentence]
-Why now: [Strategic rationale]
-Timeline: [When we plan to start/ship]
-
-Action needed:
-- Engineering: Review technical approach by [date]
-- Design: Review UX approach by [date]
-
-Questions? Drop them in [Slack channel].
-```
-
----
-
-# Part 3: AI Feature PRDs
+# AI Feature PRDs
 
 **When to use:** When building any AI-powered feature, LLM integration, or ML product.
 
@@ -948,19 +843,6 @@ Create a table with three categories:
 - Correction rate (% of edited outputs)
 - Abandonment rate
 - Escalation rate
-
-## 10 Principles for AI Products
-
-1. **Focus on user value** - Users care about outcomes, not technology
-2. **Anticipate mistakes** - Show confidence, allow corrections
-3. **Start simple** - One use case, nail it, expand
-4. **Make AI transparent** - What it can/can't do, when uncertain
-5. **Build for iteration** - Feedback loops from Day 1
-6. **Design for diverse users** - Beginners and experts
-7. **Control context** - System instructions, user history, RAG
-8. **Optimize for latency** - Streaming, perceived performance
-9. **Safety is non-negotiable** - Input/output filtering, rate limiting
-10. **Measure what matters** - Satisfaction, completion, corrections
 
 ## AI PRD Template Addition
 


### PR DESCRIPTION
Hey @ryanrozich 👋

Token-efficient Claude Code workspace with parallel agents, persistent memory, and a Research→Plan→Implement→Validate pipeline - 98 commits in, with release-please, .claude-plugin/, and a docs site. The engineering discipline here (markdownlint, prettier, trunk) shows this isn't just another skills repo, it's a proper developer tool. Wanted to suggest a few improvements to the SKILL.md.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| segment-analysis | 27% | 72% | +45% |
| prd-draft | 42% | 83% | +41% |
| debug-production-error | 48% | 78% | +30% |
| validate-frontmatter | 41% | 68% | +27% |
| code-first-draft | 70% | 74% | +4% |

<details>
<summary>What changed</summary>

**All 5 skills - description improvements:**
- Added explicit "Use when..." clauses with natural trigger terms for reliable skill selection
- Added specific concrete actions to descriptions (e.g., "Creates retention tables, compares segment behavior" instead of "Analyze user segments")
- Wrapped descriptions in quoted strings for consistent frontmatter formatting

**segment-analysis (+45%):**
- Replaced generic taxonomy of segment types with a concrete 5-step PostHog workflow (define → query → compute → compare → present)
- Removed "Tips for Better Analysis" and "Segmentation Criteria" sections (knowledge Claude already has)

**debug-production-error (+30%):**
- Replaced ~40 lines of "Available Sentry Capabilities" listing with concrete MCP tool call references (`sentry_search_issues`, `sentry_get_issue_details`)
- Added validation checkpoints to the workflow (what to do when search returns no results, when Seer is unavailable)
- Removed "Output Format" section (Claude knows what stack traces contain)

**validate-frontmatter (+27%):**
- Removed "Advanced Usage" section showing CLI flags that don't exist as actual flags

**prd-draft (+41%):**
- Removed "Part 2: Full PRD Workflow" (~100 lines) that duplicated the conversational workflow already in Part 1
- Removed "10 Principles for AI Products" conceptual padding

**code-first-draft (+4%):**
- Added specificity to description (scaffolding, TDD methodology) and explicit boundary ("Not for incremental changes or bug fixes")

</details>

I kept this PR focused on the 5 skills with the biggest improvements to keep the diff reviewable. Happy to follow up with the rest in a separate PR if you'd like.

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@yogesh-tessl](https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏