### PR TITLE
feat(dev): refresh orch-monitor mockups — Kanban, PR icons, filters, worker board (CTL-202)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/mockups.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/mockups.test.ts
@@ -637,16 +637,16 @@ describe("mockups — todos.html", () => {
 });
 
 describe("mockups — orch.html todos panel (CTL-171)", () => {
-  it("renders a collapsible todos panel below the workers table", async () => {
+  it("renders a collapsible todos panel above the worker tabs (expanded by default)", async () => {
     const res = await fetch(`${baseUrl}/mockups/orch.html`);
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain('id="todos-panel"');
-    expect(body).toContain('data-collapsed="true"');
-    const workersIdx = body.indexOf('aria-label="Workers"');
+    expect(body).toContain('data-collapsed="false"');
+    const workersIdx = body.indexOf('aria-label="Workers by state"');
     const todosIdx = body.indexOf('id="todos-panel"');
     expect(workersIdx).toBeGreaterThan(-1);
-    expect(todosIdx).toBeGreaterThan(workersIdx);
+    expect(todosIdx).toBeLessThan(workersIdx);
   });
 
   it("exposes status + group filter chips inline in the panel", async () => {
@@ -669,7 +669,7 @@ describe("mockups — orch.html todos panel (CTL-171)", () => {
     const body = await res.text();
     expect(body).toContain('id="todos-panel-toggle"');
     expect(body).toMatch(/aria-controls="todos-panel-body"/);
-    expect(body).toMatch(/aria-expanded="false"/);
+    expect(body).toMatch(/aria-expanded="true"/);
   });
 
   it("persists collapsed state to sessionStorage under catalyst.orch.todos.collapsed", async () => {

--- a/plugins/dev/scripts/orch-monitor/public/index.html
+++ b/plugins/dev/scripts/orch-monitor/public/index.html
@@ -5,9 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Catalyst Monitor</title>
     <link rel="icon" type="image/svg+xml" href="/public/favicon.svg" />
-    <link rel="alternate icon" type="image/x-icon" href="/public/favicon.ico" />
-    <script type="module" crossorigin src="/assets/index-BqTB-oMi.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-8CsCHyzd.css">
+    <script type="module" crossorigin src="/assets/index-WHBeTfR3.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D-IJ9GG9.css">
   </head>
   <body class="bg-[#0b0d10] text-[#e6e9ef] antialiased">
     <div id="root"></div>

--- a/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.js
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/_shared/chrome.js
@@ -2,14 +2,14 @@
  * Mockup harness chrome — global keybindings + topbar enhancement.
  *
  * Two axes persist to localStorage under "catalyst.mockup.prefs":
- *   - system:  operator-console                         (html[data-system])
+ *   - system:  operator-console | precision-instrument  (html[data-system])
  *   - theme:   dark | light                             (html[data-theme])
  *
  * System resolution priority: window.__catalystMockupPrefs (set by pre-paint
  * bootstrap) > URL query string > localStorage > default. URL stays clean —
- * the default value is never written as a query param. The SYSTEMS list is
- * currently a single entry (operator-console) — the axis is kept for a future
- * second system and for URL validation.
+ * the default value is never written as a query param. Shift+D and the topbar
+ * ◐ button both cycle data-system between operator-console (dark) and
+ * precision-instrument (light).
  *
  * Global keybindings (see README.md for the full table):
  *   g h/d/w/c/b/v/r    — navigate to the matching mockup page
@@ -33,7 +33,7 @@
 (function () {
   const LS_KEY = "catalyst.mockup.prefs";
   const DEFAULTS = { system: "operator-console", theme: "dark" };
-  const SYSTEMS = ["operator-console"];
+  const SYSTEMS = ["operator-console", "precision-instrument"];
   const THEMES = ["dark", "light"];
 
   // Vim-style g-prefix navigation table. Values are file names under ./mockups/.
@@ -67,7 +67,7 @@
       { keys: ["g", "r"], label: "Brand showcase" },
     ]},
     { section: "Appearance", rows: [
-      { keys: ["⇧", "D"], label: "Toggle theme (dark / light)" },
+      { keys: ["⇧", "D"], label: "Toggle system (dark / light)" },
       { keys: ["p"],      label: "Cycle palette" },
     ]},
     { section: "Utility", rows: [
@@ -165,12 +165,12 @@
       });
     });
     actions.push({
-      id: "appearance:toggle-theme",
+      id: "appearance:toggle-system",
       group: "Appearance",
-      label: "Toggle theme",
+      label: "Toggle system (dark / light)",
       hint: ["⇧", "D"],
       type: "appearance",
-      payload: { action: "toggleTheme" },
+      payload: { action: "toggleSystem" },
     });
     actions.push({
       id: "appearance:cycle-palette",
@@ -411,6 +411,17 @@
     return nav;
   }
 
+  function buildSystemToggleButton(toggleSystem) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "mockup-topbar__chip mockup-topbar__chip--system";
+    button.setAttribute("aria-label", "Toggle theme (⇧D)");
+    button.title = "Toggle dark / light (⇧D)";
+    button.textContent = "◐";
+    button.addEventListener("click", () => toggleSystem());
+    return button;
+  }
+
   function buildKeybindChip(palettePresenter) {
     const isMac = isMacPlatform(window.navigator || {});
     const button = document.createElement("button");
@@ -430,7 +441,7 @@
     return button;
   }
 
-  function enhanceTopbar(palettePresenter) {
+  function enhanceTopbar(presenter) {
     const topbar = document.querySelector("header.mockup-topbar");
     if (!topbar) return;
 
@@ -463,8 +474,12 @@
       }
     }
 
-    // ⌘K chip → right.
-    const chip = buildKeybindChip(palettePresenter);
+    // System toggle (◐) + ⌘K chip → right.
+    if (presenter && typeof presenter.toggleSystem === "function") {
+      const systemBtn = buildSystemToggleButton(presenter.toggleSystem);
+      topbar.appendChild(systemBtn);
+    }
+    const chip = buildKeybindChip(presenter);
     topbar.appendChild(chip);
   }
 
@@ -629,12 +644,6 @@
   }
 
   // ----- Controller -----
-  //
-  // The user-facing system switcher was removed with `precision-instrument`
-  // (CTL-178). A headless controller is still returned so `installKeybindings`
-  // and the palette executor can read/write `state.system`/`state.theme`
-  // without special-casing. `handleSystemChange` and `setPopoverOpen` are
-  // no-ops today; when a second system lands, rewire this function.
 
   function mount(prefs) {
     const state = { ...prefs };
@@ -662,13 +671,10 @@
       }
     };
 
-    const toggleTheme = () => {
-      const current = document.documentElement.getAttribute("data-theme") || DEFAULTS.theme;
-      const nxt = nextTheme(current);
-      if (controller) controller.state.theme = nxt;
-      document.documentElement.setAttribute("data-theme", nxt);
-      const prefs = controller ? controller.state : { system: DEFAULTS.system, theme: nxt };
-      persist(prefs);
+    const toggleSystem = () => {
+      const current = document.documentElement.getAttribute("data-system") || DEFAULTS.system;
+      const nxt = nextSystem(current);
+      if (controller) controller.handleSystemChange(nxt);
     };
 
     const cyclePalette = () => {
@@ -738,10 +744,10 @@
         return;
       }
 
-      // Shift+D — theme toggle.
+      // Shift+D — system toggle (dark / light).
       if (ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey && ev.key === "D") {
         ev.preventDefault();
-        toggleTheme();
+        toggleSystem();
         return;
       }
 
@@ -777,14 +783,9 @@
     // Build the palette eagerly so the ⌘K keybinding can open it immediately
     // — but keep it hidden until the user triggers it. The first call to
     // `ensurePalette` wires the executor; subsequent calls are no-ops.
-    const toggleTheme = () => {
-      const current =
-        document.documentElement.getAttribute("data-theme") || DEFAULTS.theme;
-      const nxt = nextTheme(current);
-      if (controller) controller.state.theme = nxt;
-      document.documentElement.setAttribute("data-theme", nxt);
-      const next = controller ? controller.state : { system: DEFAULTS.system, theme: nxt };
-      persist(next);
+    const toggleSystem = () => {
+      const current = document.documentElement.getAttribute("data-system") || DEFAULTS.system;
+      controller.handleSystemChange(nextSystem(current));
     };
     const cyclePalette = () => {
       // Reserved — palettes.css does not exist yet. Intentional no-op so the
@@ -800,7 +801,7 @@
         return;
       }
       if (action.type === "appearance" && action.payload) {
-        if (action.payload.action === "toggleTheme") toggleTheme();
+        if (action.payload.action === "toggleSystem") toggleSystem();
         else if (action.payload.action === "cyclePalette") cyclePalette();
         return;
       }
@@ -813,7 +814,10 @@
     paletteState.executeAction = executeAction;
     ensurePalette(executeAction);
 
-    enhanceTopbar({ toggle: () => setPaletteOpen(!isPaletteOpen()) });
+    enhanceTopbar({
+      toggle: () => setPaletteOpen(!isPaletteOpen()),
+      toggleSystem,
+    });
 
     installKeybindings(controller);
   };

--- a/plugins/dev/scripts/orch-monitor/public/mockups/agent-graph.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/agent-graph.html
@@ -76,7 +76,7 @@
       .graph-canvas {
         position: relative;
         width: 100%;
-        height: 640px;
+        height: 560px;
         background: var(--color-surface-1);
         border: 1px solid var(--color-border-subtle);
         border-radius: var(--radius-lg);
@@ -693,44 +693,6 @@
             turns: 1,
           },
         },
-        {
-          id: "todo-140-a",
-          type: "todo",
-          position: { x: 0, y: 0 },
-          data: {
-            owner: "CTL-140",
-            items: [
-              { label: "Write mockup tests", state: "completed" },
-              { label: "Build agent-graph.html", state: "in_progress" },
-              { label: "Add gallery card", state: "pending" },
-            ],
-          },
-        },
-        {
-          id: "todo-142-a",
-          type: "todo",
-          position: { x: 0, y: 0 },
-          data: {
-            owner: "CTL-142",
-            items: [
-              { label: "Survey todo ingest", state: "completed" },
-              { label: "Draft todos.html", state: "in_progress" },
-              { label: "Define rollup rules", state: "pending" },
-            ],
-          },
-        },
-        {
-          id: "todo-147-a",
-          type: "todo",
-          position: { x: 0, y: 0 },
-          data: {
-            owner: "CTL-147",
-            items: [
-              { label: "Mark study v1", state: "completed" },
-              { label: "Simplified variant", state: "completed" },
-            ],
-          },
-        },
       ];
 
       const INITIAL_EDGES = [
@@ -742,44 +704,98 @@
         { id: "e-142-general", source: "worker-ctl-142", target: "sub-142-general" },
         { id: "e-142-deepwiki", source: "sub-142-general", target: "sub-142-deepwiki" },
         { id: "e-147-pr-test", source: "worker-ctl-147", target: "sub-147-pr-test" },
-        { id: "e-140-todo", source: "worker-ctl-140", target: "todo-140-a" },
-        { id: "e-142-todo", source: "worker-ctl-142", target: "todo-142-a" },
-        { id: "e-147-todo", source: "worker-ctl-147", target: "todo-147-a" },
+
+
       ];
 
       const NODE_SIZE = {
-        orchestrator: { width: 280, height: 120 },
-        worker: { width: 240, height: 140 },
-        subagent: { width: 220, height: 110 },
-        todo: { width: 220, height: 120 },
+        orchestrator: { width: 200, height: 90 },
+        worker: { width: 200, height: 110 },
+        subagent: { width: 180, height: 90 },
+        todo: { width: 180, height: 100 },
       };
 
-      /* ------- Layout — dagre, top-down, stable on update ------- */
+      /* ------- Layout — manual top-down tree layout ------- */
+      // Dagre@0.8.5 places all same-rank nodes at identical x coordinates in
+      // this ESM environment. We use a simple BFS-based tree layout instead:
+      // assign each node to a rank, spread leaf subtrees to avoid overlap, then
+      // center parents over their children.
 
-      function layout(nodes, edges, direction = "TB") {
-        const g = new dagre.graphlib.Graph();
-        g.setDefaultEdgeLabel(() => ({}));
-        g.setGraph({ rankdir: direction, nodesep: 72, ranksep: 120 });
+      const RANK_GAP = 90;   // vertical space between ranks
+      const NODE_GAP = 24;   // horizontal gap between sibling subtrees
 
-        nodes.forEach((node) => {
-          const size = NODE_SIZE[node.type] ?? { width: 220, height: 100 };
-          g.setNode(node.id, size);
+      function layout(nodes, _edges, _direction) {
+        const childMap = {};  // parentId → [childId, ...]
+        const parentMap = {}; // childId → parentId
+        nodes.forEach((n) => { childMap[n.id] = []; });
+        _edges.forEach((e) => {
+          if (childMap[e.source]) childMap[e.source].push(e.target);
+          parentMap[e.target] = e.source;
         });
-        edges.forEach((edge) => g.setEdge(edge.source, edge.target));
 
-        dagre.layout(g);
+        // Find roots (nodes with no parent)
+        const roots = nodes.filter((n) => !parentMap[n.id]).map((n) => n.id);
 
-        return nodes.map((node) => {
-          const pos = g.node(node.id);
-          const size = NODE_SIZE[node.type] ?? { width: 220, height: 100 };
-          return {
-            ...node,
-            position: {
-              x: pos.x - size.width / 2,
-              y: pos.y - size.height / 2,
-            },
-          };
+        // BFS to assign ranks
+        const rank = {};
+        const queue = roots.map((r) => [r, 0]);
+        while (queue.length) {
+          const [id, r] = queue.shift();
+          rank[id] = r;
+          (childMap[id] || []).forEach((cid) => queue.push([cid, r + 1]));
+        }
+
+        // Post-order compute subtree width for each node
+        const subtreeWidth = {};
+        function computeWidth(id) {
+          const sz = NODE_SIZE[nodes.find((n) => n.id === id)?.type] ?? { width: 200, height: 90 };
+          const children = childMap[id] || [];
+          if (children.length === 0) {
+            subtreeWidth[id] = sz.width;
+            return sz.width;
+          }
+          const total = children.reduce((acc, cid, i) => {
+            return acc + computeWidth(cid) + (i > 0 ? NODE_GAP : 0);
+          }, 0);
+          subtreeWidth[id] = Math.max(sz.width, total);
+          return subtreeWidth[id];
+        }
+        roots.forEach(computeWidth);
+
+        // Assign x positions: center each node over its children subtree
+        const posX = {};
+        function assignX(id, left) {
+          const children = childMap[id] || [];
+          if (children.length === 0) {
+            const sz = NODE_SIZE[nodes.find((n) => n.id === id)?.type] ?? { width: 200, height: 90 };
+            posX[id] = left + sz.width / 2;
+            return left + sz.width;
+          }
+          let cursor = left;
+          children.forEach((cid, i) => {
+            if (i > 0) cursor += NODE_GAP;
+            cursor = assignX(cid, cursor);
+          });
+          // Center parent over all children
+          const firstChildX = posX[children[0]];
+          const lastChildX = posX[children[children.length - 1]];
+          posX[id] = (firstChildX + lastChildX) / 2;
+          return left + subtreeWidth[id];
+        }
+        roots.forEach((r) => assignX(r, 0));
+
+        const posY = {};
+        nodes.forEach((n) => {
+          const sz = NODE_SIZE[n.type] ?? { width: 200, height: 90 };
+          posY[n.id] = rank[n.id] * (Math.max(...Object.values(NODE_SIZE).map((s) => s.height)) + RANK_GAP);
+          posX[n.id] = (posX[n.id] ?? 0) - sz.width / 2;
+          posY[n.id] = (posY[n.id] ?? 0);
         });
+
+        return nodes.map((node) => ({
+          ...node,
+          position: { x: posX[node.id] ?? 0, y: posY[node.id] ?? 0 },
+        }));
       }
 
       /* ------- Custom node components (React.memo per React Flow perf docs) ------- */
@@ -1056,15 +1072,12 @@
           openDrawer(node);
         }, []);
 
-        // Real-time mock — advance a worker's status, append a todo, or
-        // spawn a subagent every two seconds. setNodes() preserves the
-        // React Flow viewport because we never re-run the layout on nodes
-        // that already have a position.
+        // Real-time mock — alternate between advancing a worker status and
+        // bumping subagent turn counts. Graph structure stays fixed so dagre
+        // layout is stable and fitView always shows all nodes.
         const runTick = useCallback(() => {
           const tick = tickRef.current++;
-          const phase = tick % 3;
-
-          if (phase === 0) {
+          if (tick % 2 === 0) {
             setNodes((current) => {
               const workerIds = current
                 .filter((n) => n.type === "worker")
@@ -1077,47 +1090,16 @@
                   : n,
               );
             });
-            return;
+          } else {
+            setNodes((current) =>
+              current.map((n) =>
+                n.type === "subagent"
+                  ? { ...n, data: { ...n.data, turns: (n.data.turns || 0) + 1 } }
+                  : n,
+              ),
+            );
           }
-
-          if (phase === 1) {
-            setNodes((current) => {
-              const todoNodes = current.filter((n) => n.type === "todo");
-              if (todoNodes.length === 0) return current;
-              const pick = todoNodes[tick % todoNodes.length];
-              const nextItems = [
-                ...pick.data.items,
-                {
-                  label: "follow-up item " + (pick.data.items.length + 1),
-                  state: "pending",
-                },
-              ];
-              return current.map((n) =>
-                n.id === pick.id ? { ...n, data: { ...n.data, items: nextItems } } : n,
-              );
-            });
-            return;
-          }
-
-          // phase === 2 — spawn a subagent under a worker, dagre-place the new node.
-          setNodes((currentNodes) => {
-            const workers = currentNodes.filter((n) => n.type === "worker");
-            if (workers.length === 0) return currentNodes;
-            const parent = workers[tick % workers.length];
-            const newId = "sub-spawn-" + tick;
-            const newNode = {
-              id: newId,
-              type: "subagent",
-              position: { x: parent.position.x, y: parent.position.y + 180 },
-              data: { role: "general-purpose", status: "researching", turns: 0 },
-            };
-            setEdges((currentEdges) => [
-              ...currentEdges,
-              { id: "e-spawn-" + tick, source: parent.id, target: newId },
-            ]);
-            return [...currentNodes, newNode];
-          });
-        }, [setNodes, setEdges]);
+        }, [setNodes]);
 
         useEffect(() => {
           const id = window.setInterval(runTick, 2000);

--- a/plugins/dev/scripts/orch-monitor/public/mockups/agent-graph.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/agent-graph.html
@@ -759,7 +759,7 @@
       function layout(nodes, edges, direction = "TB") {
         const g = new dagre.graphlib.Graph();
         g.setDefaultEdgeLabel(() => ({}));
-        g.setGraph({ rankdir: direction, nodesep: 48, ranksep: 80 });
+        g.setGraph({ rankdir: direction, nodesep: 72, ranksep: 120 });
 
         nodes.forEach((node) => {
           const size = NODE_SIZE[node.type] ?? { width: 220, height: 100 };

--- a/plugins/dev/scripts/orch-monitor/public/mockups/comms.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/comms.html
@@ -282,6 +282,39 @@
         font-weight: var(--font-weight-semibold);
       }
 
+      .channel-row__activity {
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+      }
+
+      .channel-row__activity-dot {
+        width: 5px;
+        height: 5px;
+        border-radius: var(--radius-full);
+        background: var(--color-text-lo);
+        opacity: 0.5;
+      }
+
+      .channel-row__activity-dot--recent {
+        opacity: 0.9;
+      }
+
+      [data-system="operator-console"] .channel-row__activity-dot--recent {
+        animation: comms-activity 3s ease-in-out infinite;
+      }
+
+      @keyframes comms-activity {
+        0%, 100% { opacity: 0.4; }
+        50% { opacity: 0.9; }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        [data-system="operator-console"] .channel-row__activity-dot--recent {
+          animation: none;
+        }
+      }
+
       /* ------- Center pane — message thread ------- */
 
       .message-list {
@@ -621,7 +654,11 @@
                   <span class="channel-row__count">5 agents</span>
                   <div class="channel-row__meta">
                     <span>1h ago</span>
-                    <span></span>
+                    <span class="channel-row__activity" aria-label="3 recent messages">
+                      <span class="channel-row__activity-dot channel-row__activity-dot--recent"></span>
+                      <span class="channel-row__activity-dot channel-row__activity-dot--recent"></span>
+                      <span class="channel-row__activity-dot"></span>
+                    </span>
                   </div>
                 </li>
                 <li class="channel-row" role="listitem" tabindex="0">
@@ -629,7 +666,11 @@
                   <span class="channel-row__count">2 agents</span>
                   <div class="channel-row__meta">
                     <span>4h ago</span>
-                    <span></span>
+                    <span class="channel-row__activity" aria-label="1 recent message">
+                      <span class="channel-row__activity-dot channel-row__activity-dot--recent"></span>
+                      <span class="channel-row__activity-dot"></span>
+                      <span class="channel-row__activity-dot"></span>
+                    </span>
                   </div>
                 </li>
               </ul>

--- a/plugins/dev/scripts/orch-monitor/public/mockups/home.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/home.html
@@ -282,6 +282,27 @@
         color: var(--color-text-lo);
       }
 
+      /* Hide Queued column when empty; reflow grid to 4 cols */
+      .home-kanban__column[data-column="queued"][data-count="0"] {
+        display: none;
+      }
+      .home-kanban__grid:has(.home-kanban__column[data-column="queued"][data-count="0"]) {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+      @media (max-width: 1200px) {
+        .home-kanban__grid:has(.home-kanban__column[data-column="queued"][data-count="0"]) {
+          grid-template-columns: repeat(4, minmax(200px, 1fr));
+        }
+      }
+
+      /* Done column header: stack title row + pills on separate line */
+      .home-kanban__column[data-column="done"] .home-kanban__column-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--spacing-2);
+      }
+
+
       /* Blocked column goes red when it has items */
       .home-kanban__column[data-column="blocked"]:not([data-count="0"])
         .home-kanban__column-title,
@@ -870,7 +891,8 @@
        * ============================================================ */
 
       .home-done-age {
-        display: inline-flex;
+        display: flex;
+        flex-wrap: wrap;
         gap: var(--spacing-1);
       }
 

--- a/plugins/dev/scripts/orch-monitor/public/mockups/home.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/home.html
@@ -18,10 +18,12 @@
       (function () {
         const LS_KEY = "catalyst.mockup.prefs";
         const RECENCY_KEY = "catalyst.home.recencyDays";
-        const DEFAULTS = { system: "operator-console", recencyDays: 3 };
+        const VIEW_KEY = "catalyst.home.view";
+        const PROJECT_KEY = "catalyst.home.project";
+        const DEFAULTS = { system: "operator-console", recency: "3d", view: "all", project: "all" };
         const SYSTEMS = ["operator-console", "precision-instrument"];
         const STATES = ["default", "loading", "empty", "error"];
-        const RECENCY_DAYS = [1, 3, 7, 30];
+        const RECENCY_VALS = ["1h", "24h", "2d", "3d", "7d", "14d", "30d"];
         const url = new URLSearchParams(window.location.search);
         let stored = {};
         try {
@@ -29,13 +31,14 @@
         } catch (_e) {
           stored = {};
         }
-        let recency = parseInt(
-          url.get("recency") || window.localStorage.getItem(RECENCY_KEY) || "",
-          10,
-        );
-        if (!RECENCY_DAYS.includes(recency)) recency = DEFAULTS.recencyDays;
-        document.documentElement.setAttribute("data-recency", String(recency));
-        window.__catalystHomePrefs = { recencyDays: recency };
+        let recency = url.get("recency") || window.localStorage.getItem(RECENCY_KEY) || "";
+        if (!RECENCY_VALS.includes(recency)) recency = DEFAULTS.recency;
+        const view = url.get("view") || window.localStorage.getItem(VIEW_KEY) || DEFAULTS.view;
+        const project = url.get("project") || window.localStorage.getItem(PROJECT_KEY) || DEFAULTS.project;
+        document.documentElement.setAttribute("data-recency", recency);
+        document.documentElement.setAttribute("data-view", view);
+        document.documentElement.setAttribute("data-project", project);
+        window.__catalystHomePrefs = { recency, view, project };
         const candidate = url.get("system") || stored.system || DEFAULTS.system;
         const system = SYSTEMS.includes(candidate) ? candidate : DEFAULTS.system;
         const stateCandidate = url.get("state") || "default";
@@ -591,9 +594,19 @@
         border-color: color-mix(in srgb, var(--color-accent) 40%, transparent);
       }
       [data-system="operator-console"] .chip--pr-open {
-        color: var(--color-info);
-        background: color-mix(in srgb, var(--color-info) 12%, transparent);
-        border-color: color-mix(in srgb, var(--color-info) 40%, transparent);
+        color: var(--color-success);
+        background: color-mix(in srgb, var(--color-success) 12%, transparent);
+        border-color: color-mix(in srgb, var(--color-success) 40%, transparent);
+      }
+      [data-system="operator-console"] .chip--pr-merged {
+        color: #b87cff;
+        background: color-mix(in srgb, #b87cff 12%, transparent);
+        border-color: color-mix(in srgb, #b87cff 40%, transparent);
+      }
+      [data-system="operator-console"] .chip--pr-blocked {
+        color: var(--color-danger);
+        background: color-mix(in srgb, var(--color-danger) 12%, transparent);
+        border-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
       }
       [data-system="operator-console"] .chip--merged {
         color: var(--color-success);
@@ -636,7 +649,13 @@
         color: var(--color-accent);
       }
       [data-system="precision-instrument"] .chip--pr-open::before {
-        color: var(--color-info);
+        color: var(--color-success);
+      }
+      [data-system="precision-instrument"] .chip--pr-merged::before {
+        color: #7c3aed;
+      }
+      [data-system="precision-instrument"] .chip--pr-blocked::before {
+        color: var(--color-danger);
       }
       [data-system="precision-instrument"] .chip--merged::before {
         color: var(--color-success);
@@ -706,6 +725,189 @@
         font-variant-numeric: tabular-nums;
         display: flex;
         gap: var(--spacing-3);
+      }
+
+      /* ============================================================
+       * View toggle (Orchestrators / Solo / All)
+       * ============================================================ */
+
+      .home-board-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: var(--spacing-3);
+      }
+
+      .home-view-toggle {
+        display: inline-flex;
+        gap: var(--spacing-1);
+        background: var(--color-surface-2);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-full);
+        padding: 2px;
+      }
+
+      [data-system="precision-instrument"] .home-view-toggle {
+        border-radius: 0;
+      }
+
+      .home-view-toggle__btn {
+        padding: var(--spacing-1) var(--spacing-3);
+        background: transparent;
+        border: 1px solid transparent;
+        border-radius: var(--radius-full);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        letter-spacing: var(--letter-spacing-label);
+        text-transform: uppercase;
+        color: var(--color-text-md);
+        cursor: pointer;
+        transition:
+          background var(--motion-duration-state) var(--motion-easing-standard),
+          color var(--motion-duration-state) var(--motion-easing-standard),
+          border-color var(--motion-duration-state) var(--motion-easing-standard);
+      }
+
+      [data-system="precision-instrument"] .home-view-toggle__btn {
+        border-radius: 0;
+      }
+
+      .home-view-toggle__btn--active,
+      .home-view-toggle__btn:hover {
+        background: var(--color-surface-3);
+        color: var(--color-text-hi);
+        border-color: var(--color-border-default);
+      }
+
+      [data-system="operator-console"] .home-view-toggle__btn--active {
+        background: var(--color-surface-3);
+        border-color: var(--color-border-strong);
+        color: var(--color-accent);
+      }
+
+      /* Hide cards by view */
+      [data-view="orch"] .home-card[data-kind="solo"] { display: none; }
+      [data-view="solo"] .home-card[data-kind="orch"] { display: none; }
+
+      /* Recount when filtered — handled in JS */
+
+      /* ============================================================
+       * Project filter
+       * ============================================================ */
+
+      .home-project-filter {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-2);
+      }
+
+      .home-project-filter__label {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        letter-spacing: var(--letter-spacing-label);
+        text-transform: uppercase;
+        color: var(--color-text-lo);
+      }
+
+      .home-project-filter__chips {
+        display: inline-flex;
+        gap: var(--spacing-1);
+      }
+
+      .home-project-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-1);
+        padding: var(--spacing-1) var(--spacing-2);
+        background: transparent;
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-full);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        letter-spacing: var(--letter-spacing-label);
+        color: var(--color-text-md);
+        cursor: pointer;
+        transition:
+          border-color var(--motion-duration-state) var(--motion-easing-standard),
+          color var(--motion-duration-state) var(--motion-easing-standard),
+          background var(--motion-duration-state) var(--motion-easing-standard);
+      }
+
+      [data-system="precision-instrument"] .home-project-chip {
+        border-radius: 0;
+      }
+
+      .home-project-chip:hover,
+      .home-project-chip--active {
+        border-color: var(--color-border-strong);
+        color: var(--color-text-hi);
+      }
+
+      [data-system="operator-console"] .home-project-chip--active {
+        background: var(--color-surface-2);
+        border-color: var(--color-accent);
+        color: var(--color-accent);
+      }
+
+      .home-project-chip__dot {
+        width: 6px;
+        height: 6px;
+        border-radius: var(--radius-full);
+        flex-shrink: 0;
+      }
+
+      /* Hide cards not matching the active project */
+      [data-project="catalyst"] .home-card:not([data-project="catalyst"]) { display: none; }
+      [data-project="adva"] .home-card:not([data-project="adva"]) { display: none; }
+      [data-project="bravo"] .home-card:not([data-project="bravo"]) { display: none; }
+      [data-project="infra"] .home-card:not([data-project="infra"]) { display: none; }
+      [data-project="internal"] .home-card:not([data-project="internal"]) { display: none; }
+      [data-project="experiments"] .home-card:not([data-project="experiments"]) { display: none; }
+
+      /* ============================================================
+       * Done-age selector (replaces recently-completed strip)
+       * ============================================================ */
+
+      .home-done-age {
+        display: inline-flex;
+        gap: var(--spacing-1);
+      }
+
+      .home-done-age__chip {
+        padding: 2px var(--spacing-2);
+        background: transparent;
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-full);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        letter-spacing: var(--letter-spacing-label);
+        color: var(--color-text-lo);
+        cursor: pointer;
+        transition:
+          border-color var(--motion-duration-state) var(--motion-easing-standard),
+          color var(--motion-duration-state) var(--motion-easing-standard),
+          background var(--motion-duration-state) var(--motion-easing-standard);
+      }
+
+      .home-done-age__chip:hover {
+        color: var(--color-text-hi);
+        border-color: var(--color-border-default);
+      }
+
+      .home-done-age__chip--active {
+        background: var(--color-surface-2);
+        border-color: var(--color-border-default);
+        color: var(--color-text-hi);
+      }
+
+      [data-system="operator-console"] .home-done-age__chip--active {
+        border-color: var(--color-accent);
+        color: var(--color-accent);
+      }
+
+      [data-system="precision-instrument"] .home-done-age__chip {
+        border-radius: 0;
       }
 
       /* Recency filter chips (on Recently completed section heading) */
@@ -946,7 +1148,6 @@
         display: flex;
       }
       [data-state="empty"] .home-attention,
-      [data-state="empty"] .home-section--completed,
       [data-state="empty"] .home-section__count {
         display: none;
       }
@@ -961,7 +1162,6 @@
         display: flex;
       }
       [data-state="error"] .home-attention,
-      [data-state="error"] .home-section--completed,
       [data-state="error"] .home-section__count {
         display: none;
       }
@@ -1013,6 +1213,33 @@
              of their workers occupies.
              ============================================================ -->
         <section class="home-kanban" aria-label="Active sessions by state">
+          <!-- Board header: view toggle + project filter -->
+          <div class="home-board-header">
+            <div role="group" aria-label="Board view" class="home-view-toggle">
+              <button type="button" class="home-view-toggle__btn home-view-toggle__btn--active" data-view-target="all">All</button>
+              <button type="button" class="home-view-toggle__btn" data-view-target="orch">Orchestrators</button>
+              <button type="button" class="home-view-toggle__btn" data-view-target="solo">Solo workers</button>
+            </div>
+            <div class="home-project-filter" role="group" aria-label="Project filter">
+              <span class="home-project-filter__label">Project</span>
+              <div class="home-project-filter__chips">
+                <button type="button" class="home-project-chip home-project-chip--active" data-project-target="all">All</button>
+                <button type="button" class="home-project-chip" data-project-target="catalyst" style="--dot-color:#9b7cff">
+                  <span class="home-project-chip__dot" style="background:#9b7cff"></span>Catalyst
+                </button>
+                <button type="button" class="home-project-chip" data-project-target="adva" style="--dot-color:#47c4d3">
+                  <span class="home-project-chip__dot" style="background:#47c4d3"></span>Adva
+                </button>
+                <button type="button" class="home-project-chip" data-project-target="bravo" style="--dot-color:#6aa6ff">
+                  <span class="home-project-chip__dot" style="background:#6aa6ff"></span>Bravo
+                </button>
+                <button type="button" class="home-project-chip" data-project-target="internal" style="--dot-color:#ffb547">
+                  <span class="home-project-chip__dot" style="background:#ffb547"></span>Internal
+                </button>
+              </div>
+            </div>
+          </div>
+
           <!-- default variant -->
           <div class="home-kanban__grid" data-variant="default" role="list">
             <!-- ────────────────────────── Queued ────────────────────────── -->
@@ -1026,6 +1253,7 @@
                   class="home-card"
                   data-column="queued"
                   data-kind="solo"
+                  data-project="infra"
                   role="listitem"
                   style="--project-color: #8a97a4"
                 >
@@ -1077,6 +1305,7 @@
                   class="home-card home-card--tier-0"
                   data-column="working"
                   data-kind="orch"
+                  data-project="catalyst"
                   role="listitem"
                   style="--project-color: #9b7cff"
                 >
@@ -1133,6 +1362,7 @@
                   class="home-card"
                   data-column="working"
                   data-kind="orch"
+                  data-project="adva"
                   role="listitem"
                   style="--project-color: #47c4d3"
                 >
@@ -1181,6 +1411,7 @@
                   class="home-card"
                   data-column="working"
                   data-kind="solo"
+                  data-project="internal"
                   role="listitem"
                   style="--project-color: #ffb547"
                 >
@@ -1223,6 +1454,7 @@
                   class="home-card"
                   data-column="working"
                   data-kind="solo"
+                  data-project="experiments"
                   role="listitem"
                   style="--project-color: #ff6fa5"
                 >
@@ -1265,6 +1497,7 @@
                   class="home-card"
                   data-column="working"
                   data-kind="solo"
+                  data-project="bravo"
                   role="listitem"
                   style="--project-color: #6aa6ff"
                 >
@@ -1316,6 +1549,7 @@
                   class="home-card"
                   data-column="review"
                   data-kind="orch"
+                  data-project="catalyst"
                   role="listitem"
                   style="--project-color: #9b7cff"
                 >
@@ -1364,6 +1598,7 @@
                   class="home-card"
                   data-column="review"
                   data-kind="solo"
+                  data-project="adva"
                   role="listitem"
                   style="--project-color: #47c4d3"
                 >
@@ -1383,7 +1618,7 @@
                     <span style="width: 100%"></span>
                   </div>
                   <div class="home-card__chips" role="group" aria-label="Status">
-                    <span class="chip chip--pr-open">PR open</span>
+                    <span class="chip chip--pr-open">● #239</span>
                     <span class="chip chip--ticket">CTL-118</span>
                   </div>
                   <footer class="home-card__footer">
@@ -1415,6 +1650,7 @@
                   class="home-card home-card--needs-me"
                   data-column="blocked"
                   data-kind="orch"
+                  data-project="internal"
                   role="listitem"
                   style="--project-color: #ffb547"
                 >
@@ -1469,13 +1705,22 @@
             <div class="home-kanban__column" data-column="done" data-count="3">
               <header class="home-kanban__column-header">
                 <span class="home-kanban__column-title">Done</span>
-                <span class="home-kanban__column-count">3</span>
+                <div class="home-done-age" role="group" aria-label="Done age filter">
+                  <button type="button" class="home-done-age__chip" data-recency="1h">1h</button>
+                  <button type="button" class="home-done-age__chip" data-recency="24h">24h</button>
+                  <button type="button" class="home-done-age__chip" data-recency="2d">2d</button>
+                  <button type="button" class="home-done-age__chip home-done-age__chip--active" data-recency="3d">3d</button>
+                  <button type="button" class="home-done-age__chip" data-recency="7d">7d</button>
+                  <button type="button" class="home-done-age__chip" data-recency="14d">14d</button>
+                  <button type="button" class="home-done-age__chip" data-recency="30d">30d</button>
+                </div>
               </header>
               <div class="home-kanban__column-body">
                 <article
                   class="home-card"
                   data-column="done"
                   data-kind="solo"
+                  data-project="catalyst"
                   role="listitem"
                   style="--project-color: #9b7cff"
                 >
@@ -1495,7 +1740,7 @@
                     <span style="width: 100%"></span>
                   </div>
                   <div class="home-card__chips" role="group" aria-label="Status">
-                    <span class="chip chip--merged">Merged</span>
+                    <span class="chip chip--pr-merged">● #241</span>
                     <span class="chip chip--ticket">CTL-214</span>
                   </div>
                   <footer class="home-card__footer">
@@ -1518,6 +1763,7 @@
                   class="home-card"
                   data-column="done"
                   data-kind="orch"
+                  data-project="bravo"
                   role="listitem"
                   style="--project-color: #6aa6ff"
                 >
@@ -1562,6 +1808,7 @@
                   class="home-card"
                   data-column="done"
                   data-kind="solo"
+                  data-project="adva"
                   role="listitem"
                   style="--project-color: #47c4d3"
                 >
@@ -1581,7 +1828,7 @@
                     <span style="width: 100%"></span>
                   </div>
                   <div class="home-card__chips" role="group" aria-label="Status">
-                    <span class="chip chip--merged">Merged</span>
+                    <span class="chip chip--pr-merged">● #240</span>
                     <span class="chip chip--ticket">ADV-401</span>
                   </div>
                   <footer class="home-card__footer">
@@ -1833,380 +2080,77 @@
           </div>
         </section>
 
-        <!-- ============================================================
-             SOLO WORKERS
-             ============================================================ -->
-        <section class="home-section">
-          <header class="home-section__heading">
-            <div class="home-section__title">
-              <h2>Solo workers</h2>
-              <span class="home-section__count">3 running</span>
-            </div>
-            <span class="eyebrow">Standalone</span>
-          </header>
-
-          <!-- default variant -->
-          <div class="home-card-grid" data-variant="default" role="list">
-            <article class="home-card" role="listitem">
-              <header class="home-card__header">
-                <h3 class="home-card__title">release-notes-gen</h3>
-                <span class="home-card__kind">Solo worker</span>
-              </header>
-              <div class="home-card__meta">
-                <span class="home-card__stage">Phase 3 · implement</span>
-                <span class="home-card__progress">14 / 18</span>
-              </div>
-              <div class="home-card__bar" aria-hidden="true">
-                <span style="width: 78%"></span>
-              </div>
-              <div class="home-card__chips">
-                <span class="chip chip--running">Running</span>
-                <span class="chip chip--ticket">CTL-219</span>
-              </div>
-              <footer class="home-card__footer">
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">cost</span>
-                  <span class="home-card__footer-value">$0.24</span>
-                </span>
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">heartbeat</span>
-                  <span class="home-card__footer-value">12s ago</span>
-                </span>
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">PR</span>
-                  <span class="home-card__footer-value">—</span>
-                </span>
-              </footer>
-            </article>
-
-            <article class="home-card home-card--tier-1" role="listitem">
-              <header class="home-card__header">
-                <h3 class="home-card__title">rename-scope-refactor</h3>
-                <span class="home-card__kind">Solo worker</span>
-              </header>
-              <div class="home-card__meta">
-                <span class="home-card__stage">Phase 2 · plan</span>
-                <span class="home-card__progress">6 / 18</span>
-              </div>
-              <div class="home-card__bar" aria-hidden="true">
-                <span style="width: 33%"></span>
-              </div>
-              <div class="home-card__chips">
-                <span class="chip chip--running chip-glyph chip-glyph--stale">Stalled</span>
-                <span class="chip chip--ticket">CTL-214</span>
-              </div>
-              <footer class="home-card__footer">
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">cost</span>
-                  <span class="home-card__footer-value">$0.18</span>
-                </span>
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">heartbeat</span>
-                  <span class="home-card__footer-value">12m ago</span>
-                </span>
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">PR</span>
-                  <span class="home-card__footer-value">—</span>
-                </span>
-              </footer>
-            </article>
-
-            <article class="home-card" role="listitem">
-              <header class="home-card__header">
-                <h3 class="home-card__title">otel-panel-cleanup</h3>
-                <span class="home-card__kind">Solo worker</span>
-              </header>
-              <div class="home-card__meta">
-                <span class="home-card__stage">Phase 5 · ship</span>
-                <span class="home-card__progress">17 / 18</span>
-              </div>
-              <div class="home-card__bar" aria-hidden="true">
-                <span style="width: 94%"></span>
-              </div>
-              <div class="home-card__chips">
-                <span class="chip chip--pr-open">PR open</span>
-                <span class="chip chip--ticket">CTL-118</span>
-              </div>
-              <footer class="home-card__footer">
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">cost</span>
-                  <span class="home-card__footer-value">$0.47</span>
-                </span>
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">heartbeat</span>
-                  <span class="home-card__footer-value">3s ago</span>
-                </span>
-                <span class="home-card__footer-item">
-                  <span class="home-card__footer-label">PR</span>
-                  <span class="home-card__footer-value">#239</span>
-                </span>
-              </footer>
-            </article>
-          </div>
-
-          <!-- loading variant -->
-          <div class="home-card-grid" data-variant="loading" role="list" aria-hidden="true">
-            <article class="home-card home-card--skeleton" role="listitem">
-              <header class="home-card__header">
-                <h3 class="home-card__title">loading</h3>
-                <span class="home-card__kind">loading</span>
-              </header>
-              <div class="home-card__meta">
-                <span class="home-card__stage">loading</span>
-                <span class="home-card__progress">loading</span>
-              </div>
-              <div class="home-card__bar" aria-hidden="true">
-                <span></span>
-              </div>
-              <div class="home-card__chips">loading</div>
-              <footer class="home-card__footer">
-                <span class="home-card__footer-item">loading</span>
-                <span class="home-card__footer-item">loading</span>
-                <span class="home-card__footer-item">loading</span>
-              </footer>
-            </article>
-            <article class="home-card home-card--skeleton" role="listitem">
-              <header class="home-card__header">
-                <h3 class="home-card__title">loading</h3>
-                <span class="home-card__kind">loading</span>
-              </header>
-              <div class="home-card__meta">
-                <span class="home-card__stage">loading</span>
-                <span class="home-card__progress">loading</span>
-              </div>
-              <div class="home-card__bar" aria-hidden="true">
-                <span></span>
-              </div>
-              <div class="home-card__chips">loading</div>
-              <footer class="home-card__footer">
-                <span class="home-card__footer-item">loading</span>
-                <span class="home-card__footer-item">loading</span>
-                <span class="home-card__footer-item">loading</span>
-              </footer>
-            </article>
-          </div>
-
-          <!-- empty variant -->
-          <div class="home-empty" data-variant="empty">
-            <span class="home-empty__title">No standalone agents</span>
-            <p class="home-empty__body">
-              Solo workers run one agent against one ticket. Dispatch one directly from a worktree
-              or let an orchestrator fan them out.
-            </p>
-            <span class="home-empty__hint">/catalyst-dev:oneshot CTL-123</span>
-          </div>
-
-          <!-- error variant -->
-          <div class="home-error" data-variant="error">
-            <span class="home-error__title">Could not reach the monitor</span>
-            <p class="home-error__body">
-              Solo-worker state is derived from the same stream. See the orchestrators section
-              above for the retry line.
-            </p>
-            <code class="home-error__line">GET /api/workers → 503 service unavailable · 12:41:08</code>
-          </div>
-        </section>
-
-        <!-- ============================================================
-             RECENTLY COMPLETED
-             Hidden in empty + error states.
-             ============================================================ -->
-        <section class="home-section home-section--completed" data-recency="3">
-          <header class="home-section__heading">
-            <div class="home-section__title">
-              <h2>Recently completed</h2>
-              <span class="home-section__count">Last window</span>
-            </div>
-            <div class="home-recency" role="group" aria-label="Recency window">
-              <button type="button" class="home-recency__chip" data-days="1">1d</button>
-              <button
-                type="button"
-                class="home-recency__chip home-recency__chip--active"
-                data-days="3"
-                aria-pressed="true"
-              >
-                3d
-              </button>
-              <button type="button" class="home-recency__chip" data-days="7">7d</button>
-              <button type="button" class="home-recency__chip" data-days="30">30d</button>
-            </div>
-          </header>
-
-          <div class="home-strip" data-variant="default" role="list">
-            <div class="home-strip__item" role="listitem" data-age-days="0">
-              <div class="home-strip__top">
-                <span class="home-strip__name">brand-showcase</span>
-                <span class="chip chip--merged">Shipped</span>
-              </div>
-              <div class="home-strip__meta">
-                <span>CTL-126</span>
-                <span>#243</span>
-                <span>6m ago</span>
-              </div>
-            </div>
-            <div class="home-strip__item" role="listitem" data-age-days="0">
-              <div class="home-strip__top">
-                <span class="home-strip__name">mockup-gallery</span>
-                <span class="chip chip--merged">Shipped</span>
-              </div>
-              <div class="home-strip__meta">
-                <span>CTL-125</span>
-                <span>#242</span>
-                <span>24m ago</span>
-              </div>
-            </div>
-            <div class="home-strip__item" role="listitem" data-age-days="0">
-              <div class="home-strip__top">
-                <span class="home-strip__name">tokens-package</span>
-                <span class="chip chip--merged">Shipped</span>
-              </div>
-              <div class="home-strip__meta">
-                <span>CTL-123</span>
-                <span>#241</span>
-                <span>1h ago</span>
-              </div>
-            </div>
-            <div class="home-strip__item" role="listitem" data-age-days="2">
-              <div class="home-strip__top">
-                <span class="home-strip__name">otel-panels</span>
-                <span class="chip chip--merged">Shipped</span>
-              </div>
-              <div class="home-strip__meta">
-                <span>CTL-118</span>
-                <span>#239</span>
-                <span>2d ago</span>
-              </div>
-            </div>
-            <div class="home-strip__item" role="listitem" data-age-days="3">
-              <div class="home-strip__top">
-                <span class="home-strip__name">release-main</span>
-                <span class="chip chip--merged">Shipped</span>
-              </div>
-              <div class="home-strip__meta">
-                <span>—</span>
-                <span>#240</span>
-                <span>3d ago</span>
-              </div>
-            </div>
-            <div class="home-strip__item" role="listitem" data-age-days="5">
-              <div class="home-strip__top">
-                <span class="home-strip__name">doc-portal-refresh</span>
-                <span class="chip chip--merged">Shipped</span>
-              </div>
-              <div class="home-strip__meta">
-                <span>CTL-102</span>
-                <span>#231</span>
-                <span>5d ago</span>
-              </div>
-            </div>
-            <div class="home-strip__item" role="listitem" data-age-days="14">
-              <div class="home-strip__top">
-                <span class="home-strip__name">cost-mux-v1</span>
-                <span class="chip chip--merged">Shipped</span>
-              </div>
-              <div class="home-strip__meta">
-                <span>CTL-88</span>
-                <span>#202</span>
-                <span>2w ago</span>
-              </div>
-            </div>
-          </div>
-
-          <div class="home-strip" data-variant="loading" aria-hidden="true">
-            <div class="home-strip__item">
-              <div class="home-strip__top">
-                <span class="home-strip__name" style="background:var(--color-surface-3);color:transparent">loading</span>
-              </div>
-              <div class="home-strip__meta">
-                <span style="background:var(--color-surface-3);color:transparent">loading</span>
-              </div>
-            </div>
-            <div class="home-strip__item">
-              <div class="home-strip__top">
-                <span class="home-strip__name" style="background:var(--color-surface-3);color:transparent">loading</span>
-              </div>
-              <div class="home-strip__meta">
-                <span style="background:var(--color-surface-3);color:transparent">loading</span>
-              </div>
-            </div>
-            <div class="home-strip__item">
-              <div class="home-strip__top">
-                <span class="home-strip__name" style="background:var(--color-surface-3);color:transparent">loading</span>
-              </div>
-              <div class="home-strip__meta">
-                <span style="background:var(--color-surface-3);color:transparent">loading</span>
-              </div>
-            </div>
-          </div>
-        </section>
 
         <div class="footer">
           <p>
-            Try
-            <code>?state=loading</code>
-            ,
-            <code>?state=empty</code>
-            , or
-            <code>?state=error</code>
-            to inspect the alternate views. Flip the switcher for Precision Instrument. Recency
-            chip persists to
-            <code>localStorage["catalyst.home.recencyDays"]</code>
-            .
+            Use the view toggle to filter by session type. Use the project filter to scope by project.
+            Done-age selector in the Done column header controls how far back completed sessions appear.
+            Try <code>?state=loading</code>, <code>?state=empty</code>, or <code>?state=error</code>.
           </p>
         </div>
 
         <script>
-          // Recency filter — wires the chips in .home-recency to persist the chosen window
-          // to localStorage, mirror the current selection onto .home-section--completed, and
-          // update the visible count. The pre-paint bootstrap already read the stored value
-          // onto html[data-recency], so this script syncs the existing DOM to that value on
-          // load and responds to user clicks thereafter.
           (function () {
+            const LS_KEY = "catalyst.mockup.prefs";
+            const VIEW_KEY = "catalyst.home.view";
+            const PROJECT_KEY = "catalyst.home.project";
             const RECENCY_KEY = "catalyst.home.recencyDays";
-            const VALID = new Set([1, 3, 7, 30]);
-            const section = document.querySelector(".home-section--completed");
-            const chips = document.querySelectorAll(".home-recency__chip");
-            const countEl = document.querySelector(
-              ".home-section--completed .home-section__count",
-            );
-            if (!section || chips.length === 0) return;
+            const VALID_RECENCY = ["1h", "24h", "2d", "3d", "7d", "14d", "30d"];
 
-            function applyRecency(days) {
-              if (!VALID.has(days)) days = 3;
-              section.setAttribute("data-recency", String(days));
-              chips.forEach((c) => {
-                const active = Number(c.dataset.days) === days;
-                c.classList.toggle("home-recency__chip--active", active);
-                c.setAttribute("aria-pressed", active ? "true" : "false");
+            // ---- View toggle ----
+            const viewBtns = document.querySelectorAll(".home-view-toggle__btn");
+            const html = document.documentElement;
+
+            function applyView(v) {
+              html.setAttribute("data-view", v);
+              viewBtns.forEach((b) => {
+                b.classList.toggle("home-view-toggle__btn--active", b.dataset.viewTarget === v);
               });
-              if (countEl) {
-                const visible = section.querySelectorAll(
-                  ".home-strip__item:not([hidden])",
-                );
-                // Count items whose age is within the window (rely on CSS display rules
-                // by querying getComputedStyle after layout).
-                const stillVisible = Array.from(visible).filter(
-                  (el) => getComputedStyle(el).display !== "none",
-                );
-                countEl.textContent = `${stillVisible.length} in last ${days}d`;
-              }
+              try { window.localStorage.setItem(VIEW_KEY, v); } catch (_) {}
             }
 
-            // Sync DOM to whatever the bootstrap resolved (html[data-recency]).
-            const initial = Number(document.documentElement.dataset.recency) || 3;
-            applyRecency(initial);
+            const initView = html.getAttribute("data-view") || "all";
+            applyView(initView);
 
-            chips.forEach((chip) => {
-              chip.addEventListener("click", () => {
-                const days = Number(chip.dataset.days);
-                if (!VALID.has(days)) return;
-                try {
-                  window.localStorage.setItem(RECENCY_KEY, String(days));
-                } catch (_e) {
-                  // localStorage unavailable — purely in-memory behavior still works.
-                }
-                applyRecency(days);
+            viewBtns.forEach((btn) => {
+              btn.addEventListener("click", () => applyView(btn.dataset.viewTarget || "all"));
+            });
+
+            // ---- Project filter ----
+            const projectBtns = document.querySelectorAll(".home-project-chip");
+
+            function applyProject(p) {
+              html.setAttribute("data-project", p);
+              projectBtns.forEach((b) => {
+                b.classList.toggle("home-project-chip--active", b.dataset.projectTarget === p);
               });
+              try { window.localStorage.setItem(PROJECT_KEY, p); } catch (_) {}
+            }
+
+            const initProject = html.getAttribute("data-project") || "all";
+            applyProject(initProject);
+
+            projectBtns.forEach((btn) => {
+              btn.addEventListener("click", () => applyProject(btn.dataset.projectTarget || "all"));
+            });
+
+            // ---- Done-age selector ----
+            const doneAgeBtns = document.querySelectorAll(".home-done-age__chip");
+
+            function applyRecency(r) {
+              if (!VALID_RECENCY.includes(r)) r = "3d";
+              html.setAttribute("data-recency", r);
+              doneAgeBtns.forEach((b) => {
+                b.classList.toggle("home-done-age__chip--active", b.dataset.recency === r);
+              });
+              try { window.localStorage.setItem(RECENCY_KEY, r); } catch (_) {}
+            }
+
+            const initRecency = html.getAttribute("data-recency") || "3d";
+            applyRecency(initRecency);
+
+            doneAgeBtns.forEach((btn) => {
+              btn.addEventListener("click", () => applyRecency(btn.dataset.recency || "3d"));
             });
           })();
         </script>

--- a/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
@@ -1202,6 +1202,58 @@
         border-color: var(--color-border-subtle);
       }
 
+      /* ------- Worker tabs ------- */
+
+      .worker-tabs {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-4);
+      }
+
+      .worker-tabs__nav {
+        display: flex;
+        gap: 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+
+      .worker-tabs__btn {
+        padding: var(--spacing-2) var(--spacing-4);
+        background: transparent;
+        border: none;
+        border-bottom: 2px solid transparent;
+        margin-bottom: -1px;
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        text-transform: uppercase;
+        letter-spacing: var(--letter-spacing-label);
+        color: var(--color-text-lo);
+        cursor: pointer;
+        transition: color 0.1s, border-color 0.1s;
+      }
+
+      .worker-tabs__btn:hover {
+        color: var(--color-text-md);
+      }
+
+      .worker-tabs__btn--active {
+        color: var(--color-text-hi);
+        border-bottom-color: var(--color-accent);
+      }
+
+      [data-system="operator-console"] .worker-tabs__btn--active {
+        color: var(--color-accent);
+      }
+
+      .worker-tab-panel {
+        display: none;
+      }
+
+      [data-tab="kanban"] #tab-panel-kanban,
+      [data-tab="waves"] #tab-panel-waves,
+      [data-tab="quality"] #tab-panel-quality {
+        display: block;
+      }
+
       /* ------- Gantt inside waves section ------- */
 
       .wave-gantt {
@@ -2030,12 +2082,16 @@
               </div>
             </section>
 
-            <!-- ================ WORKER KANBAN ================ -->
-            <section class="orch-section" aria-label="Workers by state">
-              <header class="orch-section__heading">
-                <h2>Workers</h2>
-                <span class="eyebrow">17 total · by state</span>
-              </header>
+            <!-- ================ WORKER TABS ================ -->
+            <div class="worker-tabs" id="worker-tabs" data-tab="kanban">
+              <nav class="worker-tabs__nav" role="tablist" aria-label="Worker views">
+                <button class="worker-tabs__btn worker-tabs__btn--active" data-tab-target="kanban" role="tab" aria-selected="true" aria-controls="tab-panel-kanban">Kanban</button>
+                <button class="worker-tabs__btn" data-tab-target="waves" role="tab" aria-selected="false" aria-controls="tab-panel-waves">Waves</button>
+                <button class="worker-tabs__btn" data-tab-target="quality" role="tab" aria-selected="false" aria-controls="tab-panel-quality">Quality Gates</button>
+              </nav>
+
+              <!-- ── Tab: Kanban ── -->
+              <div class="worker-tab-panel" id="tab-panel-kanban" data-panel="kanban" role="tabpanel" aria-label="Workers by state">
               <div class="worker-kanban">
                 <!-- Queued -->
                 <div class="worker-kanban__col" data-column="queued">
@@ -2162,14 +2218,10 @@
                   </a>
                 </div>
               </div>
-            </section>
 
-            <!-- ================ ZONE 3 — WAVES + GANTT ================ -->
-            <section class="orch-section" aria-label="Waves">
-              <header class="orch-section__heading">
-                <h2>Waves</h2>
-                <span class="eyebrow">3 total · current expanded</span>
-              </header>
+              <!-- ── Tab: Waves ── -->
+              </div>
+              <div class="worker-tab-panel" id="tab-panel-waves" data-panel="waves" role="tabpanel" aria-label="Waves and timeline">
               <div class="wave-stack">
                 <article class="wave-card">
                   <header class="wave-card__header">
@@ -2319,77 +2371,10 @@
                   <span></span>
                 </div>
               </div>
-            </section>
 
-            <!-- ================ COMMS PREVIEW ================ -->
-            <section class="orch-section" aria-label="Comms channel">
-              <header class="orch-section__heading">
-                <h2>Comms</h2>
-                <span class="eyebrow">orch-ctl-ux-apr20 · 14 agents</span>
-                <a class="orch-section__link" href="./comms.html">View all →</a>
-              </header>
-              <ol class="message-list orch-comms-preview" role="list" aria-live="polite">
-                <li class="message-row message--attention" role="listitem">
-                  <div class="message-row__head">
-                    <div class="message-row__author-group">
-                      <span class="message-row__icon" aria-hidden="true">◆</span>
-                      <span class="message-row__author">CTL-145</span>
-                      <span class="chip chip--role-worker">worker</span>
-                      <span class="chip chip--type-attention">attention</span>
-                    </div>
-                    <span class="message-row__ts">17:43:11Z</span>
-                  </div>
-                  <p class="message-row__body">worker failed: type-check errors in chrome.js — 3 fix attempts exhausted, human review required</p>
-                </li>
-                <li class="message-row" role="listitem">
-                  <div class="message-row__head">
-                    <div class="message-row__author-group">
-                      <span class="message-row__author">CTL-138</span>
-                      <span class="chip chip--role-worker">worker</span>
-                      <span class="chip chip--type-info">info</span>
-                    </div>
-                    <span class="message-row__ts">17:41:02Z</span>
-                  </div>
-                  <p class="message-row__body">pr:#244 opened · implementing → shipping</p>
-                </li>
-                <li class="message-row" role="listitem">
-                  <div class="message-row__head">
-                    <div class="message-row__author-group">
-                      <span class="message-row__author">CTL-143</span>
-                      <span class="chip chip--role-worker">worker</span>
-                      <span class="chip chip--type-proposal">proposal</span>
-                    </div>
-                    <span class="message-row__ts">17:39:44Z</span>
-                  </div>
-                  <p class="message-row__body">rebasing before push · sibling workers should pause migrations</p>
-                </li>
-                <li class="message-row" role="listitem">
-                  <div class="message-row__head">
-                    <div class="message-row__author-group">
-                      <span class="message-row__author">CTL-141</span>
-                      <span class="chip chip--role-worker">worker</span>
-                      <span class="chip chip--type-info">info</span>
-                    </div>
-                    <span class="message-row__ts">17:36:20Z</span>
-                  </div>
-                  <p class="message-row__body">researching → planning</p>
-                </li>
-                <li class="message-row" role="listitem">
-                  <div class="message-row__head">
-                    <div class="message-row__author-group">
-                      <span class="message-row__author">orchestrator</span>
-                      <span class="chip chip--role-orch">orch</span>
-                      <span class="chip chip--type-info">info</span>
-                    </div>
-                    <span class="message-row__ts">17:28:00Z</span>
-                  </div>
-                  <p class="message-row__body">dispatching wave 2 · 8 workers · max parallel 5</p>
-                </li>
-              </ol>
-            </section>
-
-            <!-- ================ QUALITY GATES ================ -->
-            <section class="orch-section" aria-label="Quality gates">
+              <!-- ── Tab: Quality Gates ── -->
+              </div>
+              <div class="worker-tab-panel" id="tab-panel-quality" data-panel="quality" role="tabpanel" aria-label="Quality gates">
               <header class="orch-section__heading">
                 <h2>Quality Gates</h2>
                 <span class="eyebrow">per-worker checks · red = skipped or failed</span>
@@ -2496,6 +2481,74 @@
                   <span class="qg-cell qg-cell--status" role="cell"><span class="chip chip--stalled">Stalled</span></span>
                 </a>
               </div>
+            </div><!-- /.worker-tab-panel[quality] -->
+            </div><!-- /.worker-tabs -->
+
+            <!-- ================ COMMS ================ -->
+            <section class="orch-section" aria-label="Comms channel">
+              <header class="orch-section__heading">
+                <h2>Comms</h2>
+                <span class="eyebrow">orch-ctl-ux-apr20 · 14 agents</span>
+                <a class="orch-section__link" href="./comms.html">View all →</a>
+              </header>
+              <ol class="message-list orch-comms-preview" role="list" aria-live="polite">
+                <li class="message-row message--attention" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__icon" aria-hidden="true">◆</span>
+                      <span class="message-row__author">CTL-145</span>
+                      <span class="chip chip--role-worker">worker</span>
+                      <span class="chip chip--type-attention">attention</span>
+                    </div>
+                    <span class="message-row__ts">17:43:11Z</span>
+                  </div>
+                  <p class="message-row__body">worker failed: type-check errors in chrome.js — 3 fix attempts exhausted, human review required</p>
+                </li>
+                <li class="message-row" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__author">CTL-138</span>
+                      <span class="chip chip--role-worker">worker</span>
+                      <span class="chip chip--type-info">info</span>
+                    </div>
+                    <span class="message-row__ts">17:41:02Z</span>
+                  </div>
+                  <p class="message-row__body">pr:#244 opened · implementing → shipping</p>
+                </li>
+                <li class="message-row" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__author">CTL-143</span>
+                      <span class="chip chip--role-worker">worker</span>
+                      <span class="chip chip--type-proposal">proposal</span>
+                    </div>
+                    <span class="message-row__ts">17:39:44Z</span>
+                  </div>
+                  <p class="message-row__body">rebasing before push · sibling workers should pause migrations</p>
+                </li>
+                <li class="message-row" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__author">CTL-141</span>
+                      <span class="chip chip--role-worker">worker</span>
+                      <span class="chip chip--type-info">info</span>
+                    </div>
+                    <span class="message-row__ts">17:36:20Z</span>
+                  </div>
+                  <p class="message-row__body">researching → planning</p>
+                </li>
+                <li class="message-row" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__author">orchestrator</span>
+                      <span class="chip chip--role-orch">orch</span>
+                      <span class="chip chip--type-info">info</span>
+                    </div>
+                    <span class="message-row__ts">17:28:00Z</span>
+                  </div>
+                  <p class="message-row__body">dispatching wave 2 · 8 workers · max parallel 5</p>
+                </li>
+              </ol>
             </section>
 
           </div>
@@ -2727,6 +2780,33 @@
           chip.addEventListener("click", () => {
             const next = chip.getAttribute("data-group") || "worker";
             panel.setAttribute("data-todos-group", next);
+          });
+        });
+      })();
+
+      // Worker tabs — Kanban / Waves / Quality Gates
+      (function () {
+        const STORAGE_KEY = "catalyst.orch.workerTab";
+        const tabs = document.getElementById("worker-tabs");
+        if (!tabs) return;
+
+        const saved = sessionStorage.getItem(STORAGE_KEY) || "kanban";
+        tabs.setAttribute("data-tab", saved);
+
+        tabs.querySelectorAll(".worker-tabs__btn").forEach((btn) => {
+          const target = btn.dataset.tabTarget;
+          const isActive = target === saved;
+          btn.classList.toggle("worker-tabs__btn--active", isActive);
+          btn.setAttribute("aria-selected", isActive ? "true" : "false");
+
+          btn.addEventListener("click", () => {
+            tabs.setAttribute("data-tab", target);
+            sessionStorage.setItem(STORAGE_KEY, target);
+            tabs.querySelectorAll(".worker-tabs__btn").forEach((b) => {
+              const active = b.dataset.tabTarget === target;
+              b.classList.toggle("worker-tabs__btn--active", active);
+              b.setAttribute("aria-selected", active ? "true" : "false");
+            });
           });
         });
       })();

--- a/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
@@ -2179,6 +2179,28 @@
                     </div>
                     <span class="wave-card__elapsed">42m 18s</span>
                   </header>
+                  <div class="wave-card__chip-rail" role="list" aria-label="Worker chips">
+                    <span class="wave-card__chip" role="listitem">
+                      <span class="chip chip--pr-merged">Merged</span>
+                      <span class="wave-card__chip-ticket">CTL-126</span>
+                    </span>
+                    <span class="wave-card__chip" role="listitem">
+                      <span class="chip chip--pr-merged">Merged</span>
+                      <span class="wave-card__chip-ticket">CTL-125</span>
+                    </span>
+                    <span class="wave-card__chip" role="listitem">
+                      <span class="chip chip--pr-merged">Merged</span>
+                      <span class="wave-card__chip-ticket">CTL-124</span>
+                    </span>
+                    <span class="wave-card__chip" role="listitem">
+                      <span class="chip chip--pr-merged">Merged</span>
+                      <span class="wave-card__chip-ticket">CTL-123</span>
+                    </span>
+                    <span class="wave-card__chip" role="listitem">
+                      <span class="chip chip--pr-merged">Merged</span>
+                      <span class="wave-card__chip-ticket">CTL-122</span>
+                    </span>
+                  </div>
                   <div class="wave-card__bar wave-card__bar--done" aria-hidden="true">
                     <span style="width: 100%"></span>
                   </div>

--- a/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
@@ -522,9 +522,14 @@
       /* ------- Zone 3 — Waves ------- */
 
       .wave-stack {
-        display: flex;
-        flex-direction: column;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
         gap: var(--spacing-3);
+        align-items: start;
+      }
+
+      @media (max-width: 900px) {
+        .wave-stack { grid-template-columns: 1fr; }
       }
 
       .wave-card {
@@ -1103,6 +1108,232 @@
         color: var(--color-info);
       }
 
+      /* ------- Comms message rows (ported from comms.html) ------- */
+
+      .message-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-2);
+      }
+
+      .message-row {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-1);
+        padding: var(--spacing-3);
+        background: var(--color-surface-2);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+      }
+
+      .message-row__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-3);
+        flex-wrap: wrap;
+      }
+
+      .message-row__author-group {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-2);
+      }
+
+      .message-row__author {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-data);
+        color: var(--color-text-hi);
+      }
+
+      .message-row__ts {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        color: var(--color-text-lo);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .message-row__body {
+        font-size: var(--font-size-body);
+        color: var(--color-text-md);
+        margin: 0;
+      }
+
+      .message-row__icon {
+        color: var(--color-warning);
+        font-family: var(--font-family-mono);
+      }
+
+      .message--attention {
+        border-left: 2px solid var(--color-warning);
+        background: color-mix(in srgb, var(--color-warning) 6%, var(--color-surface-2));
+      }
+
+      .message--attention .message-row__body {
+        color: var(--color-text-hi);
+      }
+
+      [data-system="operator-console"] .chip--role-orch {
+        color: var(--color-accent);
+        background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+        border-color: color-mix(in srgb, var(--color-accent) 40%, transparent);
+      }
+      [data-system="operator-console"] .chip--role-worker {
+        color: var(--color-info);
+        background: color-mix(in srgb, var(--color-info) 12%, transparent);
+        border-color: color-mix(in srgb, var(--color-info) 40%, transparent);
+      }
+      [data-system="operator-console"] .chip--type-attention {
+        color: var(--color-warning);
+        background: color-mix(in srgb, var(--color-warning) 14%, transparent);
+        border-color: color-mix(in srgb, var(--color-warning) 40%, transparent);
+      }
+      [data-system="operator-console"] .chip--type-proposal {
+        color: var(--color-info);
+        background: color-mix(in srgb, var(--color-info) 12%, transparent);
+        border-color: color-mix(in srgb, var(--color-info) 40%, transparent);
+      }
+      [data-system="operator-console"] .chip--type-info {
+        color: var(--color-text-md);
+        background: var(--color-surface-2);
+        border-color: var(--color-border-subtle);
+      }
+
+      /* ------- Gantt inside waves section ------- */
+
+      .wave-gantt {
+        margin-top: var(--spacing-4);
+      }
+
+      /* ------- Orch section link (View all →) ------- */
+
+      .orch-section__link {
+        font-size: var(--font-size-data);
+        color: var(--color-accent);
+        text-decoration: none;
+        margin-left: auto;
+      }
+
+      .orch-section__link:hover {
+        text-decoration: underline;
+      }
+
+      /* ------- Comms preview in orch ------- */
+
+      .orch-comms-preview {
+        max-height: 280px;
+        overflow-y: auto;
+      }
+
+      /* ------- Quality Gates table ------- */
+
+      .qg-table {
+        background: var(--color-surface-1);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
+
+      .qg-table__head,
+      .qg-table__row {
+        display: grid;
+        grid-template-columns:
+          minmax(160px, 2fr)
+          repeat(5, minmax(80px, 1fr))
+          minmax(100px, 1.2fr);
+        align-items: center;
+      }
+
+      .qg-table__head {
+        padding: var(--spacing-2) var(--spacing-4);
+        border-bottom: 1px solid var(--color-border-subtle);
+        background: var(--color-surface-raised);
+      }
+
+      .qg-table__head .qg-cell {
+        font-size: var(--font-size-data);
+        font-weight: 600;
+        color: var(--color-text-lo);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .qg-table__row {
+        padding: var(--spacing-2) var(--spacing-4);
+        border-bottom: 1px solid var(--color-border-subtle);
+        text-decoration: none;
+        color: inherit;
+        transition: background 0.1s;
+      }
+
+      .qg-table__row:last-child {
+        border-bottom: none;
+      }
+
+      .qg-table__row:hover {
+        background: var(--color-surface-raised);
+      }
+
+      .qg-row--warn {
+        background: color-mix(in srgb, var(--color-warning) 5%, transparent);
+      }
+
+      .qg-row--fail {
+        background: color-mix(in srgb, var(--color-danger) 6%, transparent);
+      }
+
+      .qg-row--pass {
+        background: color-mix(in srgb, var(--color-success) 4%, transparent);
+      }
+
+      .qg-cell {
+        font-size: var(--font-size-data);
+        padding: 0 var(--spacing-2);
+        text-align: center;
+      }
+
+      .qg-cell--worker {
+        text-align: left;
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-2);
+        padding-left: 0;
+      }
+
+      .qg-worker-name {
+        font-size: var(--font-size-data);
+        color: var(--color-text-lo);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .qg-cell--pass {
+        color: var(--color-success);
+        font-weight: 700;
+      }
+
+      .qg-cell--fail {
+        color: var(--color-danger);
+        font-weight: 700;
+      }
+
+      .qg-cell--skip {
+        color: var(--color-warning);
+        font-weight: 700;
+      }
+
+      .qg-cell--pending {
+        color: var(--color-text-lo);
+      }
+
+      .qg-cell--status {
+        text-align: right;
+      }
+
       /* System B trim */
       [data-system="precision-instrument"] .attention-bar,
       [data-system="precision-instrument"] .kpi-tile,
@@ -1111,7 +1342,8 @@
       [data-system="precision-instrument"] .gantt,
       [data-system="precision-instrument"] .worker-table,
       [data-system="precision-instrument"] .events-sidebar,
-      [data-system="precision-instrument"] .event-row {
+      [data-system="precision-instrument"] .event-row,
+      [data-system="precision-instrument"] .qg-table {
         border-color: var(--color-border-default);
       }
 
@@ -1932,7 +2164,7 @@
               </div>
             </section>
 
-            <!-- ================ ZONE 3 — WAVES ================ -->
+            <!-- ================ ZONE 3 — WAVES + GANTT ================ -->
             <section class="orch-section" aria-label="Waves">
               <header class="orch-section__heading">
                 <h2>Waves</h2>
@@ -2019,15 +2251,7 @@
                   </footer>
                 </article>
               </div>
-            </section>
-
-            <!-- ================ GANTT ================ -->
-            <section class="orch-section" aria-label="Wave timeline">
-              <header class="orch-section__heading">
-                <h2>Wave timeline</h2>
-                <span class="eyebrow">Gantt</span>
-              </header>
-              <div class="gantt">
+              <div class="gantt wave-gantt">
                 <div class="gantt__row">
                   <span class="gantt__label">Wave 1</span>
                   <div class="gantt__track">
@@ -2075,119 +2299,180 @@
               </div>
             </section>
 
-            <!-- ================ WORKER TABLE ================ -->
-            <section class="orch-section" aria-label="Workers">
+            <!-- ================ COMMS PREVIEW ================ -->
+            <section class="orch-section" aria-label="Comms channel">
               <header class="orch-section__heading">
-                <h2>Workers</h2>
-                <span class="eyebrow">17 total · sortable</span>
+                <h2>Comms</h2>
+                <span class="eyebrow">orch-ctl-ux-apr20 · 14 agents</span>
+                <a class="orch-section__link" href="./comms.html">View all →</a>
               </header>
-              <div class="worker-table" role="table">
-                <div class="worker-table__head" role="row">
-                  <span role="columnheader">
-                    <span class="worker-table__sort">Ticket</span>
+              <ol class="message-list orch-comms-preview" role="list" aria-live="polite">
+                <li class="message-row message--attention" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__icon" aria-hidden="true">◆</span>
+                      <span class="message-row__author">CTL-145</span>
+                      <span class="chip chip--role-worker">worker</span>
+                      <span class="chip chip--type-attention">attention</span>
+                    </div>
+                    <span class="message-row__ts">17:43:11Z</span>
+                  </div>
+                  <p class="message-row__body">worker failed: type-check errors in chrome.js — 3 fix attempts exhausted, human review required</p>
+                </li>
+                <li class="message-row" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__author">CTL-138</span>
+                      <span class="chip chip--role-worker">worker</span>
+                      <span class="chip chip--type-info">info</span>
+                    </div>
+                    <span class="message-row__ts">17:41:02Z</span>
+                  </div>
+                  <p class="message-row__body">pr:#244 opened · implementing → shipping</p>
+                </li>
+                <li class="message-row" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__author">CTL-143</span>
+                      <span class="chip chip--role-worker">worker</span>
+                      <span class="chip chip--type-proposal">proposal</span>
+                    </div>
+                    <span class="message-row__ts">17:39:44Z</span>
+                  </div>
+                  <p class="message-row__body">rebasing before push · sibling workers should pause migrations</p>
+                </li>
+                <li class="message-row" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__author">CTL-141</span>
+                      <span class="chip chip--role-worker">worker</span>
+                      <span class="chip chip--type-info">info</span>
+                    </div>
+                    <span class="message-row__ts">17:36:20Z</span>
+                  </div>
+                  <p class="message-row__body">researching → planning</p>
+                </li>
+                <li class="message-row" role="listitem">
+                  <div class="message-row__head">
+                    <div class="message-row__author-group">
+                      <span class="message-row__author">orchestrator</span>
+                      <span class="chip chip--role-orch">orch</span>
+                      <span class="chip chip--type-info">info</span>
+                    </div>
+                    <span class="message-row__ts">17:28:00Z</span>
+                  </div>
+                  <p class="message-row__body">dispatching wave 2 · 8 workers · max parallel 5</p>
+                </li>
+              </ol>
+            </section>
+
+            <!-- ================ QUALITY GATES ================ -->
+            <section class="orch-section" aria-label="Quality gates">
+              <header class="orch-section__heading">
+                <h2>Quality Gates</h2>
+                <span class="eyebrow">per-worker checks · red = skipped or failed</span>
+              </header>
+              <div class="qg-table" role="table" aria-label="Quality gates by worker">
+                <div class="qg-table__head" role="row">
+                  <span class="qg-cell qg-cell--worker" role="columnheader">Worker</span>
+                  <span class="qg-cell" role="columnheader" title="TypeScript type check">TypeCheck</span>
+                  <span class="qg-cell" role="columnheader" title="Security vulnerability scan">Security</span>
+                  <span class="qg-cell" role="columnheader" title="Code reviewer agent">Code Review</span>
+                  <span class="qg-cell" role="columnheader" title="Test coverage analysis">Tests</span>
+                  <span class="qg-cell" role="columnheader" title="Lint and build">Lint/Build</span>
+                  <span class="qg-cell qg-cell--status" role="columnheader">Status</span>
+                </div>
+                <!-- CTL-138: all passed -->
+                <a class="qg-table__row qg-row--pass" href="./worker.html" role="row">
+                  <span class="qg-cell qg-cell--worker" role="cell">
+                    <span class="chip chip--ticket">CTL-138</span>
+                    <span class="qg-worker-name">warp-tab-split</span>
                   </span>
-                  <span role="columnheader">
-                    <span class="worker-table__sort">Status</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="TypeCheck passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Security passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Code Review passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Tests passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Lint/Build passed">✓</span>
+                  <span class="qg-cell qg-cell--status" role="cell"><span class="chip chip--merging">Merging</span></span>
+                </a>
+                <!-- CTL-137: in progress, no results yet -->
+                <a class="qg-table__row" href="./worker.html" role="row">
+                  <span class="qg-cell qg-cell--worker" role="cell">
+                    <span class="chip chip--ticket">CTL-137</span>
+                    <span class="qg-worker-name">sidebar-nav</span>
                   </span>
-                  <span role="columnheader">
-                    <span class="worker-table__sort">Phase</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="TypeCheck pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Security pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Code Review pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Tests pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Lint/Build pending">—</span>
+                  <span class="qg-cell qg-cell--status" role="cell"><span class="chip chip--running">Running</span></span>
+                </a>
+                <!-- CTL-136: partially done -->
+                <a class="qg-table__row" href="./worker.html" role="row">
+                  <span class="qg-cell qg-cell--worker" role="cell">
+                    <span class="chip chip--ticket">CTL-136</span>
+                    <span class="qg-worker-name">token-refresh</span>
                   </span>
-                  <span role="columnheader">
-                    <span class="worker-table__sort">PR</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="TypeCheck passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Security passed">✓</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Code Review pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Tests pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Lint/Build pending">—</span>
+                  <span class="qg-cell qg-cell--status" role="cell"><span class="chip chip--running">Running</span></span>
+                </a>
+                <!-- CTL-145: CI fail, tests skipped -->
+                <a class="qg-table__row qg-row--warn" href="./worker.html" role="row">
+                  <span class="qg-cell qg-cell--worker" role="cell">
+                    <span class="chip chip--ticket">CTL-145</span>
+                    <span class="qg-worker-name">keybind-escape</span>
                   </span>
-                  <span role="columnheader">
-                    <span class="worker-table__sort">Turns</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="TypeCheck passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Security passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Code Review passed">✓</span>
+                  <span class="qg-cell qg-cell--fail" role="cell" aria-label="Tests FAILED">✗</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Lint/Build passed">✓</span>
+                  <span class="qg-cell qg-cell--status" role="cell"><span class="chip chip--ci-fail">CI fail</span></span>
+                </a>
+                <!-- CTL-143: security skipped -->
+                <a class="qg-table__row qg-row--warn" href="./worker.html" role="row">
+                  <span class="qg-cell qg-cell--worker" role="cell">
+                    <span class="chip chip--ticket">CTL-143</span>
+                    <span class="qg-worker-name">pr-merge-flow</span>
                   </span>
-                  <span role="columnheader">
-                    <span class="worker-table__sort">Cost</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="TypeCheck passed">✓</span>
+                  <span class="qg-cell qg-cell--skip" role="cell" aria-label="Security SKIPPED">⚠</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Code Review passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Tests passed">✓</span>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="Lint/Build passed">✓</span>
+                  <span class="qg-cell qg-cell--status" role="cell"><span class="chip chip--pr-open">PR open</span></span>
+                </a>
+                <!-- CTL-141: early phase, nothing run -->
+                <a class="qg-table__row" href="./worker.html" role="row">
+                  <span class="qg-cell qg-cell--worker" role="cell">
+                    <span class="chip chip--ticket">CTL-141</span>
+                    <span class="qg-worker-name">comms-join</span>
                   </span>
-                  <span role="columnheader">
-                    <span class="worker-table__sort worker-table__sort--active">
-                      Heartbeat
-                      <span class="worker-table__sort-caret" aria-hidden="true"></span>
-                    </span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="TypeCheck pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Security pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Code Review pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Tests pending">—</span>
+                  <span class="qg-cell qg-cell--pending" role="cell" aria-label="Lint/Build pending">—</span>
+                  <span class="qg-cell qg-cell--status" role="cell"><span class="chip chip--running">Running</span></span>
+                </a>
+                <!-- CTL-145: multiple gates skipped -->
+                <a class="qg-table__row qg-row--fail" href="./worker.html" role="row">
+                  <span class="qg-cell qg-cell--worker" role="cell">
+                    <span class="chip chip--ticket">CTL-148</span>
+                    <span class="qg-worker-name">stream-tail-probe</span>
                   </span>
-                </div>
-
-                <div class="worker-table__row" role="row">
-                  <span class="worker-table__cell--ticket" role="cell">CTL-138</span>
-                  <span role="cell"><span class="chip chip--merging">Merging</span></span>
-                  <span role="cell">ship</span>
-                  <span class="worker-table__cell--pr" role="cell"><a href="#">#244</a></span>
-                  <span role="cell">82</span>
-                  <span role="cell">$0.41</span>
-                  <span role="cell">12s ago</span>
-                </div>
-
-                <div class="worker-table__row" role="row">
-                  <span class="worker-table__cell--ticket" role="cell">CTL-137</span>
-                  <span role="cell"><span class="chip chip--running">Running</span></span>
-                  <span role="cell">implement</span>
-                  <span class="worker-table__cell--null" role="cell">—</span>
-                  <span role="cell">34</span>
-                  <span role="cell">$0.18</span>
-                  <span role="cell">18s ago</span>
-                </div>
-
-                <div class="worker-table__row" role="row">
-                  <span class="worker-table__cell--ticket" role="cell">CTL-136</span>
-                  <span role="cell"><span class="chip chip--running">Running</span></span>
-                  <span role="cell">implement</span>
-                  <span class="worker-table__cell--null" role="cell">—</span>
-                  <span role="cell">58</span>
-                  <span role="cell">$0.27</span>
-                  <span role="cell">1m ago</span>
-                </div>
-
-                <div class="worker-table__row" role="row">
-                  <span class="worker-table__cell--ticket" role="cell">CTL-145</span>
-                  <span role="cell"><span class="chip chip--ci-fail">CI fail</span></span>
-                  <span role="cell">ship</span>
-                  <span class="worker-table__cell--pr" role="cell"><a href="#">#245</a></span>
-                  <span role="cell">104</span>
-                  <span role="cell">$0.62</span>
-                  <span role="cell">4m ago</span>
-                </div>
-
-                <div class="worker-table__row" role="row">
-                  <span class="worker-table__cell--ticket" role="cell">CTL-143</span>
-                  <span role="cell"><span class="chip chip--pr-open">PR open</span></span>
-                  <span role="cell">ship</span>
-                  <span class="worker-table__cell--pr" role="cell"><a href="#">#246</a></span>
-                  <span role="cell">71</span>
-                  <span role="cell">$0.34</span>
-                  <span role="cell">2m ago</span>
-                </div>
-
-                <div class="worker-table__row" role="row">
-                  <span class="worker-table__cell--ticket" role="cell">CTL-141</span>
-                  <span role="cell"><span class="chip chip--running">Running</span></span>
-                  <span role="cell">research</span>
-                  <span class="worker-table__cell--null" role="cell">—</span>
-                  <span role="cell">12</span>
-                  <span role="cell">$0.07</span>
-                  <span role="cell">22s ago</span>
-                </div>
-
-                <div class="worker-table__row" role="row">
-                  <span class="worker-table__cell--ticket" role="cell">CTL-139</span>
-                  <span role="cell"><span class="chip chip--failing chip-glyph chip-glyph--ci-fail">CI fail</span></span>
-                  <span role="cell">validate</span>
-                  <span class="worker-table__cell--pr" role="cell"><a href="#">#243</a></span>
-                  <span role="cell">96</span>
-                  <span role="cell">$0.52</span>
-                  <span role="cell">11m ago</span>
-                </div>
-
-                <div class="worker-table__row" role="row">
-                  <span class="worker-table__cell--ticket" role="cell">CTL-144</span>
-                  <span role="cell"><span class="chip chip--queued">Queued</span></span>
-                  <span role="cell">—</span>
-                  <span class="worker-table__cell--null" role="cell">—</span>
-                  <span role="cell">0</span>
-                  <span role="cell">$0.00</span>
-                  <span role="cell">—</span>
-                </div>
+                  <span class="qg-cell qg-cell--pass" role="cell" aria-label="TypeCheck passed">✓</span>
+                  <span class="qg-cell qg-cell--skip" role="cell" aria-label="Security SKIPPED">⚠</span>
+                  <span class="qg-cell qg-cell--skip" role="cell" aria-label="Code Review SKIPPED">⚠</span>
+                  <span class="qg-cell qg-cell--fail" role="cell" aria-label="Tests FAILED">✗</span>
+                  <span class="qg-cell qg-cell--skip" role="cell" aria-label="Lint/Build SKIPPED">⚠</span>
+                  <span class="qg-cell qg-cell--status" role="cell"><span class="chip chip--stalled">Stalled</span></span>
+                </a>
               </div>
             </section>
 

--- a/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/orch.html
@@ -137,7 +137,21 @@
         background: color-mix(in srgb, var(--color-accent) 12%, transparent);
         border-color: color-mix(in srgb, var(--color-accent) 40%, transparent);
       }
-      [data-system="operator-console"] .chip--pr-open,
+      [data-system="operator-console"] .chip--pr-open {
+        color: var(--color-success);
+        background: color-mix(in srgb, var(--color-success) 12%, transparent);
+        border-color: color-mix(in srgb, var(--color-success) 40%, transparent);
+      }
+      [data-system="operator-console"] .chip--pr-merged {
+        color: #b87cff;
+        background: color-mix(in srgb, #b87cff 12%, transparent);
+        border-color: color-mix(in srgb, #b87cff 40%, transparent);
+      }
+      [data-system="operator-console"] .chip--pr-blocked {
+        color: var(--color-danger);
+        background: color-mix(in srgb, var(--color-danger) 12%, transparent);
+        border-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
+      }
       [data-system="operator-console"] .chip--pending {
         color: var(--color-info);
         background: color-mix(in srgb, var(--color-info) 12%, transparent);
@@ -179,7 +193,15 @@
       [data-system="precision-instrument"] .chip--merging::before {
         color: var(--color-accent);
       }
-      [data-system="precision-instrument"] .chip--pr-open::before,
+      [data-system="precision-instrument"] .chip--pr-open::before {
+        color: var(--color-success);
+      }
+      [data-system="precision-instrument"] .chip--pr-merged::before {
+        color: #7c3aed;
+      }
+      [data-system="precision-instrument"] .chip--pr-blocked::before {
+        color: var(--color-danger);
+      }
       [data-system="precision-instrument"] .chip--pending::before {
         color: var(--color-info);
       }
@@ -722,6 +744,122 @@
       .gantt__axis-ticks {
         display: flex;
         justify-content: space-between;
+      }
+
+      /* ------- Worker Kanban ------- */
+
+      .worker-kanban {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: var(--spacing-3);
+        align-items: start;
+      }
+
+      @media (max-width: 1100px) {
+        .worker-kanban {
+          grid-template-columns: repeat(5, minmax(140px, 1fr));
+          overflow-x: auto;
+        }
+      }
+
+      .worker-kanban__col {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-2);
+        min-width: 0;
+      }
+
+      .worker-kanban__col-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        padding-bottom: var(--spacing-2);
+        border-bottom: 1px solid var(--color-border-subtle);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        letter-spacing: var(--letter-spacing-label);
+        text-transform: uppercase;
+        color: var(--color-text-md);
+      }
+
+      .worker-kanban__col[data-column="blocked"] .worker-kanban__col-header {
+        color: var(--color-danger);
+      }
+
+      .worker-kanban__col-count {
+        font-size: var(--font-size-data);
+        color: var(--color-text-lo);
+      }
+
+      .worker-kanban__card {
+        padding: var(--spacing-3);
+        background: var(--color-surface-1);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-1);
+        cursor: pointer;
+        transition: border-color var(--motion-duration-state) var(--motion-easing-standard);
+      }
+
+      .worker-kanban__card:hover {
+        border-color: var(--color-border-strong);
+      }
+
+      [data-system="precision-instrument"] .worker-kanban__card {
+        border-radius: 0;
+      }
+
+      .worker-kanban__card-head {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-2);
+        flex-wrap: wrap;
+      }
+
+      .worker-kanban__card-name {
+        font-family: var(--font-family-body);
+        font-size: var(--font-size-body);
+        font-weight: var(--font-weight-semibold);
+        color: var(--color-text-hi);
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .worker-kanban__card-todos {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-data);
+        color: var(--color-text-lo);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .worker-kanban__empty {
+        padding: var(--spacing-3);
+        border: 1px dashed var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        color: var(--color-text-lo);
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        text-align: center;
+      }
+
+      /* Briefing link in orch head */
+      .orch-head__meta-link {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-data);
+        color: var(--color-accent);
+        text-decoration: none;
+        margin-left: auto;
+      }
+
+      .orch-head__meta-link:hover {
+        text-decoration: underline;
       }
 
       /* ------- Worker table ------- */
@@ -1300,12 +1438,270 @@
             <span><strong>tickets</strong> 17</span>
             <span><strong>auto-merge</strong> armed</span>
             <span><strong>started</strong> 17:15</span>
+            <a href="./briefing.html" class="orch-head__meta-link">Briefing →</a>
           </div>
         </section>
 
         <!-- ================ LAYOUT (main + sidebar) ================ -->
         <div class="layout" id="layout">
           <div class="layout__main">
+
+            <!-- ================ TODOS PANEL (CTL-171) ================ -->
+            <section
+              class="orch-section orch-section--collapsible todos-panel"
+              id="todos-panel"
+              data-collapsed="false"
+              data-todos-group="worker"
+              data-todos-status="all"
+              aria-label="Todos"
+            >
+              <header
+                class="orch-section__heading"
+                id="todos-panel-heading"
+                role="button"
+                tabindex="0"
+                aria-controls="todos-panel-body"
+                aria-expanded="true"
+              >
+                <h2>Todos</h2>
+                <span class="eyebrow">
+                  9 items across 6 workers · <span class="orch-section__toggle-hint">click to collapse</span>
+                </span>
+                <button
+                  type="button"
+                  class="orch-section__toggle"
+                  id="todos-panel-toggle"
+                  aria-controls="todos-panel-body"
+                  aria-expanded="true"
+                >
+                  <span class="orch-section__chevron" aria-hidden="true"></span>
+                  <span class="orch-section__toggle-label">Collapse</span>
+                </button>
+              </header>
+
+              <div class="orch-section__body" id="todos-panel-body">
+                <div class="todos-filter-bar" role="toolbar" aria-label="Todo filters">
+                  <div class="todos-filter__status" role="group" aria-label="Status">
+                    <span class="todos-filter__label">Status</span>
+                    <button type="button" class="filter-chip" data-status="all">All</button>
+                    <button type="button" class="filter-chip" data-status="pending">Pending</button>
+                    <button type="button" class="filter-chip" data-status="in-progress">In progress</button>
+                    <button type="button" class="filter-chip" data-status="completed">Completed</button>
+                  </div>
+                  <div class="todos-filter__group" role="group" aria-label="Grouping">
+                    <span class="todos-filter__label">Group</span>
+                    <button type="button" class="filter-chip" data-group="worker">By worker</button>
+                    <button type="button" class="filter-chip" data-group="flat">Flat</button>
+                  </div>
+                  <input
+                    class="todos-filter__search"
+                    type="search"
+                    placeholder="Search todos in this orch…"
+                    data-search
+                    aria-label="Search todos"
+                  />
+                </div>
+
+                <div class="todos-view" data-group="worker" role="list">
+                  <article class="todos-worker-group" role="listitem">
+                    <header class="todos-worker-group__head">
+                      <span class="chip chip--ticket">CTL-138</span>
+                      <span class="chip chip--merging">Merging</span>
+                      <h3 class="todos-worker-group__name">worker.html mockup</h3>
+                      <div class="todos-worker-group__meta">
+                        <a class="todos-worker-group__open" href="./worker.html?ticket=CTL-138">
+                          open worker
+                        </a>
+                      </div>
+                    </header>
+                    <ul class="todos-worker-group__list">
+                      <li class="todos-row" data-status="in-progress">
+                        <span class="todos-row__status" aria-label="in progress"></span>
+                        <span class="todos-row__text">
+                          Shipping. Commit, push, create PR, arm auto-merge.
+                        </span>
+                        <span class="todos-row__owner">CTL-138</span>
+                        <span class="todos-row__time">17:41:02</span>
+                        <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
+                      </li>
+                      <li class="todos-row" data-status="pending">
+                        <span class="todos-row__status" aria-label="pending"></span>
+                        <span class="todos-row__text">
+                          Poll <code>gh pr view</code> every 60s until state=MERGED.
+                        </span>
+                        <span class="todos-row__owner">CTL-138</span>
+                        <span class="todos-row__time">17:41:02</span>
+                        <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
+                      </li>
+                      <li class="todos-row" data-status="completed">
+                        <span class="todos-row__status" aria-label="completed"></span>
+                        <span class="todos-row__text">Implement worker.html sections.</span>
+                        <span class="todos-row__owner">CTL-138</span>
+                        <span class="todos-row__time">17:34:18</span>
+                        <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
+                      </li>
+                    </ul>
+                  </article>
+
+                  <article class="todos-worker-group" role="listitem">
+                    <header class="todos-worker-group__head">
+                      <span class="chip chip--ticket">CTL-137</span>
+                      <span class="chip chip--running">Running</span>
+                      <h3 class="todos-worker-group__name">home.html polish</h3>
+                      <div class="todos-worker-group__meta">
+                        <a class="todos-worker-group__open" href="./worker.html?ticket=CTL-137">
+                          open worker
+                        </a>
+                      </div>
+                    </header>
+                    <ul class="todos-worker-group__list">
+                      <li class="todos-row" data-status="in-progress">
+                        <span class="todos-row__status" aria-label="in progress"></span>
+                        <span class="todos-row__text">
+                          Implement session-centric Kanban columns.
+                        </span>
+                        <span class="todos-row__owner">CTL-137</span>
+                        <span class="todos-row__time">17:42:31</span>
+                        <a class="todos-row__open" href="./worker.html?ticket=CTL-137">open</a>
+                      </li>
+                      <li class="todos-row" data-status="completed">
+                        <span class="todos-row__status" aria-label="completed"></span>
+                        <span class="todos-row__text">Research project dot design tokens.</span>
+                        <span class="todos-row__owner">CTL-137</span>
+                        <span class="todos-row__time">17:30:07</span>
+                        <a class="todos-row__open" href="./worker.html?ticket=CTL-137">open</a>
+                      </li>
+                    </ul>
+                  </article>
+
+                  <article class="todos-worker-group" role="listitem">
+                    <header class="todos-worker-group__head">
+                      <span class="chip chip--ticket">CTL-145</span>
+                      <span class="chip chip--ci-fail">CI fail</span>
+                      <h3 class="todos-worker-group__name">keybindings fix</h3>
+                      <div class="todos-worker-group__meta">
+                        <a class="todos-worker-group__open" href="./worker.html?ticket=CTL-145">
+                          open worker
+                        </a>
+                      </div>
+                    </header>
+                    <ul class="todos-worker-group__list">
+                      <li class="todos-row" data-status="in-progress">
+                        <span class="todos-row__status" aria-label="in progress"></span>
+                        <span class="todos-row__text">
+                          Update keybindings test — expected escape, got tab.
+                        </span>
+                        <span class="todos-row__owner">CTL-145</span>
+                        <span class="todos-row__time">17:38:02</span>
+                        <a class="todos-row__open" href="./worker.html?ticket=CTL-145">open</a>
+                      </li>
+                    </ul>
+                  </article>
+
+                  <article class="todos-worker-group" role="listitem">
+                    <header class="todos-worker-group__head">
+                      <span class="chip chip--ticket">CTL-139</span>
+                      <span class="chip chip--needs-me">Needs me</span>
+                      <h3 class="todos-worker-group__name">review thread</h3>
+                      <div class="todos-worker-group__meta">
+                        <a class="todos-worker-group__open" href="./worker.html?ticket=CTL-139">
+                          open worker
+                        </a>
+                      </div>
+                    </header>
+                    <ul class="todos-worker-group__list">
+                      <li class="todos-row" data-status="pending">
+                        <span class="todos-row__status" aria-label="pending"></span>
+                        <span class="todos-row__text">
+                          Wait for reviewer response on Codex XSS flag.
+                        </span>
+                        <span class="todos-row__owner">CTL-139</span>
+                        <span class="todos-row__time">17:32:44</span>
+                        <a class="todos-row__open" href="./worker.html?ticket=CTL-139">open</a>
+                      </li>
+                      <li class="todos-row" data-status="completed">
+                        <span class="todos-row__status" aria-label="completed"></span>
+                        <span class="todos-row__text">Draft sanitized query param helper.</span>
+                        <span class="todos-row__owner">CTL-139</span>
+                        <span class="todos-row__time">17:20:18</span>
+                        <a class="todos-row__open" href="./worker.html?ticket=CTL-139">open</a>
+                      </li>
+                    </ul>
+                  </article>
+                </div>
+
+                <div class="todos-view" data-group="flat" role="list">
+                  <ul class="todos-worker-group__list" style="gap: var(--spacing-2);">
+                    <li class="todos-row" data-status="in-progress">
+                      <span class="todos-row__status" aria-label="in progress"></span>
+                      <span class="todos-row__text">
+                        Implement session-centric Kanban columns.
+                      </span>
+                      <span class="todos-row__owner">CTL-137</span>
+                      <span class="todos-row__time">17:42:31</span>
+                      <a class="todos-row__open" href="./worker.html?ticket=CTL-137">open</a>
+                    </li>
+                    <li class="todos-row" data-status="in-progress">
+                      <span class="todos-row__status" aria-label="in progress"></span>
+                      <span class="todos-row__text">
+                        Shipping. Commit, push, create PR, arm auto-merge.
+                      </span>
+                      <span class="todos-row__owner">CTL-138</span>
+                      <span class="todos-row__time">17:41:02</span>
+                      <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
+                    </li>
+                    <li class="todos-row" data-status="pending">
+                      <span class="todos-row__status" aria-label="pending"></span>
+                      <span class="todos-row__text">
+                        Poll <code>gh pr view</code> every 60s until state=MERGED.
+                      </span>
+                      <span class="todos-row__owner">CTL-138</span>
+                      <span class="todos-row__time">17:41:02</span>
+                      <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
+                    </li>
+                    <li class="todos-row" data-status="in-progress">
+                      <span class="todos-row__status" aria-label="in progress"></span>
+                      <span class="todos-row__text">
+                        Update keybindings test — expected escape, got tab.
+                      </span>
+                      <span class="todos-row__owner">CTL-145</span>
+                      <span class="todos-row__time">17:38:02</span>
+                      <a class="todos-row__open" href="./worker.html?ticket=CTL-145">open</a>
+                    </li>
+                    <li class="todos-row" data-status="completed">
+                      <span class="todos-row__status" aria-label="completed"></span>
+                      <span class="todos-row__text">Implement worker.html sections.</span>
+                      <span class="todos-row__owner">CTL-138</span>
+                      <span class="todos-row__time">17:34:18</span>
+                      <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
+                    </li>
+                    <li class="todos-row" data-status="pending">
+                      <span class="todos-row__status" aria-label="pending"></span>
+                      <span class="todos-row__text">
+                        Wait for reviewer response on Codex XSS flag.
+                      </span>
+                      <span class="todos-row__owner">CTL-139</span>
+                      <span class="todos-row__time">17:32:44</span>
+                      <a class="todos-row__open" href="./worker.html?ticket=CTL-139">open</a>
+                    </li>
+                    <li class="todos-row" data-status="completed">
+                      <span class="todos-row__status" aria-label="completed"></span>
+                      <span class="todos-row__text">Research project dot design tokens.</span>
+                      <span class="todos-row__owner">CTL-137</span>
+                      <span class="todos-row__time">17:30:07</span>
+                      <a class="todos-row__open" href="./worker.html?ticket=CTL-137">open</a>
+                    </li>
+                    <li class="todos-row" data-status="completed">
+                      <span class="todos-row__status" aria-label="completed"></span>
+                      <span class="todos-row__text">Draft sanitized query param helper.</span>
+                      <span class="todos-row__owner">CTL-139</span>
+                      <span class="todos-row__time">17:20:18</span>
+                      <a class="todos-row__open" href="./worker.html?ticket=CTL-139">open</a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </section>
             <!-- ================ ZONE 1 — ATTENTION BAR ================ -->
             <section class="attention-bar" aria-label="Attention items">
               <header class="attention-bar__head">
@@ -1399,6 +1795,140 @@
                   </dl>
                   <div class="cost-card__provider">Provider · Anthropic · claude-opus-4-7</div>
                 </aside>
+              </div>
+            </section>
+
+            <!-- ================ WORKER KANBAN ================ -->
+            <section class="orch-section" aria-label="Workers by state">
+              <header class="orch-section__heading">
+                <h2>Workers</h2>
+                <span class="eyebrow">17 total · by state</span>
+              </header>
+              <div class="worker-kanban">
+                <!-- Queued -->
+                <div class="worker-kanban__col" data-column="queued">
+                  <div class="worker-kanban__col-header">
+                    <span>Queued</span>
+                    <span class="worker-kanban__col-count">2</span>
+                  </div>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--queued">CTL-151</span>
+                    </div>
+                    <div class="worker-kanban__card-name">chart-zoom-control</div>
+                    <div class="worker-kanban__card-todos">Awaiting dispatch</div>
+                  </a>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--queued">CTL-152</span>
+                    </div>
+                    <div class="worker-kanban__card-name">export-csv-endpoint</div>
+                    <div class="worker-kanban__card-todos">Awaiting dispatch</div>
+                  </a>
+                </div>
+                <!-- Working -->
+                <div class="worker-kanban__col" data-column="working">
+                  <div class="worker-kanban__col-header">
+                    <span>Working</span>
+                    <span class="worker-kanban__col-count">7</span>
+                  </div>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--running">CTL-138</span>
+                    </div>
+                    <div class="worker-kanban__card-name">comms-panel-v2</div>
+                    <div class="worker-kanban__card-todos">▸ Write unit tests for collapse</div>
+                  </a>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--running">CTL-141</span>
+                    </div>
+                    <div class="worker-kanban__card-name">phase-strip-active</div>
+                    <div class="worker-kanban__card-todos">▸ Implement CSS animation</div>
+                  </a>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--running">CTL-142</span>
+                    </div>
+                    <div class="worker-kanban__card-name">kanban-card-heartbeat</div>
+                    <div class="worker-kanban__card-todos">▸ Research brand-heartbeat keyframe</div>
+                  </a>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--running">CTL-147</span>
+                    </div>
+                    <div class="worker-kanban__card-name">worker-detail-layout</div>
+                    <div class="worker-kanban__card-todos">▸ Add phase-strip component</div>
+                  </a>
+                </div>
+                <!-- Review -->
+                <div class="worker-kanban__col" data-column="review">
+                  <div class="worker-kanban__col-header">
+                    <span>Review</span>
+                    <span class="worker-kanban__col-count">3</span>
+                  </div>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--pr-open">● #312</span>
+                      <span class="chip chip--ticket">CTL-143</span>
+                    </div>
+                    <div class="worker-kanban__card-name">attention-bar-tiers</div>
+                    <div class="worker-kanban__card-todos">✓ All todos complete</div>
+                  </a>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--pr-open">● #313</span>
+                      <span class="chip chip--ticket">CTL-145</span>
+                    </div>
+                    <div class="worker-kanban__card-name">keybindings-cheatsheet</div>
+                    <div class="worker-kanban__card-todos">✓ CI awaiting re-run</div>
+                  </a>
+                </div>
+                <!-- Blocked -->
+                <div class="worker-kanban__col" data-column="blocked">
+                  <div class="worker-kanban__col-header">
+                    <span>Blocked</span>
+                    <span class="worker-kanban__col-count">2</span>
+                  </div>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--pr-blocked">● #311</span>
+                      <span class="chip chip--ticket">CTL-140</span>
+                    </div>
+                    <div class="worker-kanban__card-name">cost-panel-drill</div>
+                    <div class="worker-kanban__card-todos">☐ Needs review reply</div>
+                  </a>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--stalled">CTL-148</span>
+                    </div>
+                    <div class="worker-kanban__card-name">stream-tail-probe</div>
+                    <div class="worker-kanban__card-todos">☐ CI failure 3×</div>
+                  </a>
+                </div>
+                <!-- Done -->
+                <div class="worker-kanban__col" data-column="done">
+                  <div class="worker-kanban__col-header">
+                    <span>Done</span>
+                    <span class="worker-kanban__col-count">3</span>
+                  </div>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--pr-merged">● #308</span>
+                      <span class="chip chip--ticket">CTL-137</span>
+                    </div>
+                    <div class="worker-kanban__card-name">orch-heartbeat-css</div>
+                    <div class="worker-kanban__card-todos">✓ Merged</div>
+                  </a>
+                  <a class="worker-kanban__card" href="./worker.html">
+                    <div class="worker-kanban__card-head">
+                      <span class="chip chip--pr-merged">● #309</span>
+                      <span class="chip chip--ticket">CTL-139</span>
+                    </div>
+                    <div class="worker-kanban__card-name">breadcrumb-nav</div>
+                    <div class="worker-kanban__card-todos">✓ Merged</div>
+                  </a>
+                </div>
               </div>
             </section>
 
@@ -1661,262 +2191,6 @@
               </div>
             </section>
 
-            <!-- ================ TODOS PANEL (CTL-171) ================ -->
-            <section
-              class="orch-section orch-section--collapsible todos-panel"
-              id="todos-panel"
-              data-collapsed="true"
-              data-todos-group="worker"
-              data-todos-status="all"
-              aria-label="Todos"
-            >
-              <header
-                class="orch-section__heading"
-                id="todos-panel-heading"
-                role="button"
-                tabindex="0"
-                aria-controls="todos-panel-body"
-                aria-expanded="false"
-              >
-                <h2>Todos</h2>
-                <span class="eyebrow">
-                  9 items across 6 workers · <span class="orch-section__toggle-hint">click to expand</span>
-                </span>
-                <button
-                  type="button"
-                  class="orch-section__toggle"
-                  id="todos-panel-toggle"
-                  aria-controls="todos-panel-body"
-                  aria-expanded="false"
-                >
-                  <span class="orch-section__chevron" aria-hidden="true"></span>
-                  <span class="orch-section__toggle-label">Expand</span>
-                </button>
-              </header>
-
-              <div class="orch-section__body" id="todos-panel-body">
-                <div class="todos-filter-bar" role="toolbar" aria-label="Todo filters">
-                  <div class="todos-filter__status" role="group" aria-label="Status">
-                    <span class="todos-filter__label">Status</span>
-                    <button type="button" class="filter-chip" data-status="all">All</button>
-                    <button type="button" class="filter-chip" data-status="pending">Pending</button>
-                    <button type="button" class="filter-chip" data-status="in-progress">In progress</button>
-                    <button type="button" class="filter-chip" data-status="completed">Completed</button>
-                  </div>
-                  <div class="todos-filter__group" role="group" aria-label="Grouping">
-                    <span class="todos-filter__label">Group</span>
-                    <button type="button" class="filter-chip" data-group="worker">By worker</button>
-                    <button type="button" class="filter-chip" data-group="flat">Flat</button>
-                  </div>
-                  <input
-                    class="todos-filter__search"
-                    type="search"
-                    placeholder="Search todos in this orch…"
-                    data-search
-                    aria-label="Search todos"
-                  />
-                </div>
-
-                <div class="todos-view" data-group="worker" role="list">
-                  <article class="todos-worker-group" role="listitem">
-                    <header class="todos-worker-group__head">
-                      <span class="chip chip--ticket">CTL-138</span>
-                      <span class="chip chip--merging">Merging</span>
-                      <h3 class="todos-worker-group__name">worker.html mockup</h3>
-                      <div class="todos-worker-group__meta">
-                        <a class="todos-worker-group__open" href="./worker.html?ticket=CTL-138">
-                          open worker
-                        </a>
-                      </div>
-                    </header>
-                    <ul class="todos-worker-group__list">
-                      <li class="todos-row" data-status="in-progress">
-                        <span class="todos-row__status" aria-label="in progress"></span>
-                        <span class="todos-row__text">
-                          Shipping. Commit, push, create PR, arm auto-merge.
-                        </span>
-                        <span class="todos-row__owner">CTL-138</span>
-                        <span class="todos-row__time">17:41:02</span>
-                        <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
-                      </li>
-                      <li class="todos-row" data-status="pending">
-                        <span class="todos-row__status" aria-label="pending"></span>
-                        <span class="todos-row__text">
-                          Poll <code>gh pr view</code> every 60s until state=MERGED.
-                        </span>
-                        <span class="todos-row__owner">CTL-138</span>
-                        <span class="todos-row__time">17:41:02</span>
-                        <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
-                      </li>
-                      <li class="todos-row" data-status="completed">
-                        <span class="todos-row__status" aria-label="completed"></span>
-                        <span class="todos-row__text">Implement worker.html sections.</span>
-                        <span class="todos-row__owner">CTL-138</span>
-                        <span class="todos-row__time">17:34:18</span>
-                        <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
-                      </li>
-                    </ul>
-                  </article>
-
-                  <article class="todos-worker-group" role="listitem">
-                    <header class="todos-worker-group__head">
-                      <span class="chip chip--ticket">CTL-137</span>
-                      <span class="chip chip--running">Running</span>
-                      <h3 class="todos-worker-group__name">home.html polish</h3>
-                      <div class="todos-worker-group__meta">
-                        <a class="todos-worker-group__open" href="./worker.html?ticket=CTL-137">
-                          open worker
-                        </a>
-                      </div>
-                    </header>
-                    <ul class="todos-worker-group__list">
-                      <li class="todos-row" data-status="in-progress">
-                        <span class="todos-row__status" aria-label="in progress"></span>
-                        <span class="todos-row__text">
-                          Implement session-centric Kanban columns.
-                        </span>
-                        <span class="todos-row__owner">CTL-137</span>
-                        <span class="todos-row__time">17:42:31</span>
-                        <a class="todos-row__open" href="./worker.html?ticket=CTL-137">open</a>
-                      </li>
-                      <li class="todos-row" data-status="completed">
-                        <span class="todos-row__status" aria-label="completed"></span>
-                        <span class="todos-row__text">Research project dot design tokens.</span>
-                        <span class="todos-row__owner">CTL-137</span>
-                        <span class="todos-row__time">17:30:07</span>
-                        <a class="todos-row__open" href="./worker.html?ticket=CTL-137">open</a>
-                      </li>
-                    </ul>
-                  </article>
-
-                  <article class="todos-worker-group" role="listitem">
-                    <header class="todos-worker-group__head">
-                      <span class="chip chip--ticket">CTL-145</span>
-                      <span class="chip chip--ci-fail">CI fail</span>
-                      <h3 class="todos-worker-group__name">keybindings fix</h3>
-                      <div class="todos-worker-group__meta">
-                        <a class="todos-worker-group__open" href="./worker.html?ticket=CTL-145">
-                          open worker
-                        </a>
-                      </div>
-                    </header>
-                    <ul class="todos-worker-group__list">
-                      <li class="todos-row" data-status="in-progress">
-                        <span class="todos-row__status" aria-label="in progress"></span>
-                        <span class="todos-row__text">
-                          Update keybindings test — expected escape, got tab.
-                        </span>
-                        <span class="todos-row__owner">CTL-145</span>
-                        <span class="todos-row__time">17:38:02</span>
-                        <a class="todos-row__open" href="./worker.html?ticket=CTL-145">open</a>
-                      </li>
-                    </ul>
-                  </article>
-
-                  <article class="todos-worker-group" role="listitem">
-                    <header class="todos-worker-group__head">
-                      <span class="chip chip--ticket">CTL-139</span>
-                      <span class="chip chip--needs-me">Needs me</span>
-                      <h3 class="todos-worker-group__name">review thread</h3>
-                      <div class="todos-worker-group__meta">
-                        <a class="todos-worker-group__open" href="./worker.html?ticket=CTL-139">
-                          open worker
-                        </a>
-                      </div>
-                    </header>
-                    <ul class="todos-worker-group__list">
-                      <li class="todos-row" data-status="pending">
-                        <span class="todos-row__status" aria-label="pending"></span>
-                        <span class="todos-row__text">
-                          Wait for reviewer response on Codex XSS flag.
-                        </span>
-                        <span class="todos-row__owner">CTL-139</span>
-                        <span class="todos-row__time">17:32:44</span>
-                        <a class="todos-row__open" href="./worker.html?ticket=CTL-139">open</a>
-                      </li>
-                      <li class="todos-row" data-status="completed">
-                        <span class="todos-row__status" aria-label="completed"></span>
-                        <span class="todos-row__text">Draft sanitized query param helper.</span>
-                        <span class="todos-row__owner">CTL-139</span>
-                        <span class="todos-row__time">17:20:18</span>
-                        <a class="todos-row__open" href="./worker.html?ticket=CTL-139">open</a>
-                      </li>
-                    </ul>
-                  </article>
-                </div>
-
-                <div class="todos-view" data-group="flat" role="list">
-                  <ul class="todos-worker-group__list" style="gap: var(--spacing-2);">
-                    <li class="todos-row" data-status="in-progress">
-                      <span class="todos-row__status" aria-label="in progress"></span>
-                      <span class="todos-row__text">
-                        Implement session-centric Kanban columns.
-                      </span>
-                      <span class="todos-row__owner">CTL-137</span>
-                      <span class="todos-row__time">17:42:31</span>
-                      <a class="todos-row__open" href="./worker.html?ticket=CTL-137">open</a>
-                    </li>
-                    <li class="todos-row" data-status="in-progress">
-                      <span class="todos-row__status" aria-label="in progress"></span>
-                      <span class="todos-row__text">
-                        Shipping. Commit, push, create PR, arm auto-merge.
-                      </span>
-                      <span class="todos-row__owner">CTL-138</span>
-                      <span class="todos-row__time">17:41:02</span>
-                      <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
-                    </li>
-                    <li class="todos-row" data-status="pending">
-                      <span class="todos-row__status" aria-label="pending"></span>
-                      <span class="todos-row__text">
-                        Poll <code>gh pr view</code> every 60s until state=MERGED.
-                      </span>
-                      <span class="todos-row__owner">CTL-138</span>
-                      <span class="todos-row__time">17:41:02</span>
-                      <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
-                    </li>
-                    <li class="todos-row" data-status="in-progress">
-                      <span class="todos-row__status" aria-label="in progress"></span>
-                      <span class="todos-row__text">
-                        Update keybindings test — expected escape, got tab.
-                      </span>
-                      <span class="todos-row__owner">CTL-145</span>
-                      <span class="todos-row__time">17:38:02</span>
-                      <a class="todos-row__open" href="./worker.html?ticket=CTL-145">open</a>
-                    </li>
-                    <li class="todos-row" data-status="completed">
-                      <span class="todos-row__status" aria-label="completed"></span>
-                      <span class="todos-row__text">Implement worker.html sections.</span>
-                      <span class="todos-row__owner">CTL-138</span>
-                      <span class="todos-row__time">17:34:18</span>
-                      <a class="todos-row__open" href="./worker.html?ticket=CTL-138">open</a>
-                    </li>
-                    <li class="todos-row" data-status="pending">
-                      <span class="todos-row__status" aria-label="pending"></span>
-                      <span class="todos-row__text">
-                        Wait for reviewer response on Codex XSS flag.
-                      </span>
-                      <span class="todos-row__owner">CTL-139</span>
-                      <span class="todos-row__time">17:32:44</span>
-                      <a class="todos-row__open" href="./worker.html?ticket=CTL-139">open</a>
-                    </li>
-                    <li class="todos-row" data-status="completed">
-                      <span class="todos-row__status" aria-label="completed"></span>
-                      <span class="todos-row__text">Research project dot design tokens.</span>
-                      <span class="todos-row__owner">CTL-137</span>
-                      <span class="todos-row__time">17:30:07</span>
-                      <a class="todos-row__open" href="./worker.html?ticket=CTL-137">open</a>
-                    </li>
-                    <li class="todos-row" data-status="completed">
-                      <span class="todos-row__status" aria-label="completed"></span>
-                      <span class="todos-row__text">Draft sanitized query param helper.</span>
-                      <span class="todos-row__owner">CTL-139</span>
-                      <span class="todos-row__time">17:20:18</span>
-                      <a class="todos-row__open" href="./worker.html?ticket=CTL-139">open</a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </section>
           </div>
 
           <!-- ================ EVENTS SIDEBAR ================ -->

--- a/plugins/dev/scripts/orch-monitor/public/mockups/worker.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/worker.html
@@ -730,24 +730,107 @@
           </div>
         </section>
 
-        <!-- ================ HERO METRICS ================ -->
-        <div class="hero-metrics" aria-label="Key metrics">
-          <div class="hero-metric">
-            <span class="hero-metric__label">Elapsed</span>
-            <span class="hero-metric__value">9m 48s</span>
-            <span class="hero-metric__sub">started 17:33:21</span>
+        <!-- ================ DASHBOARD ================ -->
+        <div class="worker-dash">
+          <div class="worker-dash__status">
+            <span class="chip chip--merging">Merging</span>
+            <a class="worker-dash__pr" href="#">PR #247
+              <span class="chip chip--passing">CI passing</span>
+            </a>
+            <span class="worker-dash__kv">merge <strong>CLEAN</strong></span>
+            <span class="worker-dash__kv">auto-merge <strong>armed</strong></span>
+            <span class="chip chip--failed chip-glyph chip-glyph--review">Review reply</span>
           </div>
-          <div class="hero-metric">
-            <span class="hero-metric__label">Tokens</span>
-            <span class="hero-metric__value">124k</span>
-            <span class="hero-metric__sub">98k in · 26k out</span>
+          <div class="worker-metrics">
+            <div class="worker-metric">
+              <span class="worker-metric__label">Cost</span>
+              <span class="worker-metric__value">$3.47</span>
+              <span class="worker-metric__sub">$0.35 / min</span>
+            </div>
+            <div class="worker-metric">
+              <span class="worker-metric__label">Elapsed</span>
+              <span class="worker-metric__value">9m 48s</span>
+              <span class="worker-metric__sub">started 17:33:21</span>
+            </div>
+            <div class="worker-metric">
+              <span class="worker-metric__label">Tokens</span>
+              <span class="worker-metric__value">124k</span>
+              <span class="worker-metric__sub">98k in · 26k out</span>
+            </div>
           </div>
-          <div class="hero-metric">
-            <span class="hero-metric__label">Cost</span>
-            <span class="hero-metric__value">$3.47</span>
-            <span class="hero-metric__sub">$0.35 / min</span>
+          <div class="worker-cost-row">
+            <span class="worker-cost-item"><span class="worker-cost-item__k">input</span> 24,187</span>
+            <span class="worker-cost-sep">·</span>
+            <span class="worker-cost-item"><span class="worker-cost-item__k">output</span> 3,412</span>
+            <span class="worker-cost-sep">·</span>
+            <span class="worker-cost-item"><span class="worker-cost-item__k">cache read</span> 58,120</span>
+            <span class="worker-cost-sep">·</span>
+            <span class="worker-cost-item"><span class="worker-cost-item__k">cache write</span> 12,440</span>
           </div>
         </div>
+
+        <!-- ================ LINEAR TICKET ================ -->
+        <section class="worker-section worker-section--ticket">
+          <div class="ticket-panel">
+            <div class="ticket-panel__head">
+              <span class="chip chip--ticket">CTL-138</span>
+              <span class="chip chip--review">In Review</span>
+              <a class="ticket-panel__link" href="#">Open in Linear ↗</a>
+            </div>
+            <h2 class="ticket-panel__title">worker.html mockup — phase strip, hero metrics, briefing nav</h2>
+            <p class="ticket-panel__desc">
+              Implement the updated worker detail view per monitor UX review 2026-04-28.
+              Add hero metrics strip (elapsed, tokens, cost) above the phase timeline.
+              Include a visible "Briefing →" link in worker-head alongside ticket badge
+              and PR link. Promote cost data from the bottom grid to the top of the page.
+            </p>
+          </div>
+        </section>
+
+        <!-- ================ TODOS ================ -->
+        <section class="worker-section">
+          <header class="worker-section__heading">
+            <h2>Todos</h2>
+            <span class="eyebrow">7 items · 5 done</span>
+          </header>
+          <ol class="todo-list">
+            <li class="todo-item todo-item--done">
+              <span class="todo-item__seq">1</span>
+              <span class="todo-item__text">Research mockup harness + brand patterns</span>
+              <span class="todo-item__ts">20:49:22</span>
+            </li>
+            <li class="todo-item todo-item--done">
+              <span class="todo-item__seq">2</span>
+              <span class="todo-item__text">Draft plan doc in thoughts/</span>
+              <span class="todo-item__ts">20:51:18</span>
+            </li>
+            <li class="todo-item todo-item--done">
+              <span class="todo-item__seq">3</span>
+              <span class="todo-item__text">Write failing integration test (TDD)</span>
+              <span class="todo-item__ts">20:53:40</span>
+            </li>
+            <li class="todo-item todo-item--done">
+              <span class="todo-item__seq">4</span>
+              <span class="todo-item__text">Implement worker.html sections</span>
+              <span class="todo-item__ts">20:54:18</span>
+            </li>
+            <li class="todo-item todo-item--done">
+              <span class="todo-item__seq">5</span>
+              <span class="todo-item__text">Add gallery card in index.html</span>
+              <span class="todo-item__ts">20:56:52</span>
+            </li>
+            <li class="todo-item todo-item--active">
+              <span class="todo-item__seq">6</span>
+              <span class="todo-item__text">Shipping · commit, push, create PR, arm auto-merge</span>
+              <span class="todo-item__ts">20:57:08</span>
+            </li>
+            <li class="todo-item todo-item--pending">
+              <span class="todo-item__seq">7</span>
+              <span class="todo-item__text">Poll <code>gh pr view</code> every 60s until state=MERGED</span>
+              <span class="todo-item__ts">—</span>
+            </li>
+          </ol>
+        </section>
 
         <!-- ================ PHASE TIMELINE ================ -->
         <section class="worker-section">
@@ -780,93 +863,6 @@
               <span class="phase-step__name">done</span>
               <span class="phase-step__duration">—</span>
             </div>
-          </div>
-        </section>
-
-        <!-- ================ SPLIT: SIGNAL / PR ================ -->
-        <section class="worker-section">
-          <header class="worker-section__heading">
-            <h2>Signal + PR</h2>
-            <span class="eyebrow">signal file + gh state</span>
-          </header>
-
-          <div class="worker-split">
-            <!-- SIGNAL -->
-            <div class="signal-panel">
-              <dl class="signal-grid">
-                <div class="signal-grid__key">ticket</div>
-                <div class="signal-grid__val">CTL-138</div>
-
-                <div class="signal-grid__key">orchestrator</div>
-                <div class="signal-grid__val">orch-2026-04-22-3</div>
-
-                <div class="signal-grid__key">workerName</div>
-                <div class="signal-grid__val">orch-2026-04-22-3-CTL-138</div>
-
-                <div class="signal-grid__key">label</div>
-                <div class="signal-grid__val">oneshot CTL-138</div>
-
-                <div class="signal-grid__key">status</div>
-                <div class="signal-grid__val">merging</div>
-
-                <div class="signal-grid__key">phase</div>
-                <div class="signal-grid__val">5</div>
-
-                <div class="signal-grid__key">startedAt</div>
-                <div class="signal-grid__val">2026-04-22T20:48:35Z</div>
-
-                <div class="signal-grid__key">updatedAt</div>
-                <div class="signal-grid__val">2026-04-22T20:57:12Z</div>
-
-                <div class="signal-grid__key">lastHeartbeat</div>
-                <div class="signal-grid__val">2026-04-22T20:57:12Z</div>
-
-                <div class="signal-grid__key">completedAt</div>
-                <div class="signal-grid__val signal-grid__val--null">null</div>
-
-                <div class="signal-grid__key">pid</div>
-                <div class="signal-grid__val">56629</div>
-
-                <div class="signal-grid__key">worktreePath</div>
-                <div class="signal-grid__val signal-grid__val--muted">
-                  ~/catalyst/wt/orch-2026-04-22-3-CTL-138
-                </div>
-
-                <div class="signal-grid__key">session_id</div>
-                <div class="signal-grid__val signal-grid__val--muted">sess_20260422T204718_64aa0e66</div>
-
-                <div class="signal-grid__key">lastReviveReason</div>
-                <div class="signal-grid__val signal-grid__val--null">null</div>
-
-                <div class="signal-grid__key">fixupAttempts</div>
-                <div class="signal-grid__val">0</div>
-
-                <div class="signal-grid__key">linearState</div>
-                <div class="signal-grid__val">In Review</div>
-              </dl>
-            </div>
-
-            <!-- PR CARD -->
-            <aside class="pr-card" aria-label="Pull request">
-              <header class="pr-card__head">
-                <span class="pr-card__number">#247</span>
-                <span class="chip chip--passing">CI passing</span>
-              </header>
-              <dl class="pr-card__grid">
-                <dt>URL</dt>
-                <dd>
-                  <a href="#">github.com/../pull/247</a>
-                </dd>
-                <dt>merge state</dt>
-                <dd>CLEAN</dd>
-                <dt>opened</dt>
-                <dd>2026-04-22T20:55:48Z</dd>
-                <dt>auto-merge</dt>
-                <dd>armed</dd>
-                <dt>merged</dt>
-                <dd class="signal-grid__val--null">—</dd>
-              </dl>
-            </aside>
           </div>
         </section>
 
@@ -952,51 +948,6 @@
           </div>
         </section>
 
-        <!-- ================ TODOS ================ -->
-        <section class="worker-section">
-          <header class="worker-section__heading">
-            <h2>Todos</h2>
-            <span class="eyebrow">TodoWrite · mini kanban</span>
-          </header>
-          <div class="todos-kanban">
-            <div class="todos-col todos-col--pending">
-              <header class="todos-col__head">
-                <span>Pending</span>
-                <span class="todos-col__count">1</span>
-              </header>
-              <ul>
-                <li class="todos-item">
-                  Poll <code>gh pr view</code> every 60s until state=MERGED
-                </li>
-              </ul>
-            </div>
-            <div class="todos-col todos-col--in-progress">
-              <header class="todos-col__head">
-                <span>In progress</span>
-                <span class="todos-col__count">1</span>
-              </header>
-              <ul>
-                <li class="todos-item">
-                  Shipping · commit, push, create PR, arm auto-merge
-                </li>
-              </ul>
-            </div>
-            <div class="todos-col todos-col--completed">
-              <header class="todos-col__head">
-                <span>Completed</span>
-                <span class="todos-col__count">5</span>
-              </header>
-              <ul>
-                <li class="todos-item">Research mockup harness + brand patterns</li>
-                <li class="todos-item">Draft plan doc in thoughts/</li>
-                <li class="todos-item">Write failing integration test (TDD)</li>
-                <li class="todos-item">Implement worker.html sections</li>
-                <li class="todos-item">Add gallery card in index.html</li>
-              </ul>
-            </div>
-          </div>
-        </section>
-
         <!-- ================ SUBAGENTS ================ -->
         <section class="worker-section">
           <header class="worker-section__heading">
@@ -1025,39 +976,69 @@
           </div>
         </section>
 
-        <!-- ================ COST ================ -->
-        <section class="worker-section">
-          <header class="worker-section__heading">
-            <h2>Cost</h2>
-            <span class="eyebrow">tokens + duration</span>
-          </header>
-          <div class="cost-grid">
-            <div class="cost-cell">
-              <span class="cost-cell__label">Input</span>
-              <span class="cost-cell__value">24,187</span>
+        <!-- ================ SIGNAL (DEBUG) ================ -->
+        <details class="worker-section worker-section--debug">
+          <summary>
+            <h2>Signal file</h2>
+            <span class="eyebrow">debug · click to expand</span>
+          </summary>
+          <div class="worker-split" style="margin-top: var(--spacing-4);">
+            <div class="signal-panel">
+              <dl class="signal-grid">
+                <div class="signal-grid__key">ticket</div>
+                <div class="signal-grid__val">CTL-138</div>
+                <div class="signal-grid__key">orchestrator</div>
+                <div class="signal-grid__val">orch-2026-04-22-3</div>
+                <div class="signal-grid__key">workerName</div>
+                <div class="signal-grid__val">orch-2026-04-22-3-CTL-138</div>
+                <div class="signal-grid__key">label</div>
+                <div class="signal-grid__val">oneshot CTL-138</div>
+                <div class="signal-grid__key">status</div>
+                <div class="signal-grid__val">merging</div>
+                <div class="signal-grid__key">phase</div>
+                <div class="signal-grid__val">5</div>
+                <div class="signal-grid__key">startedAt</div>
+                <div class="signal-grid__val">2026-04-22T20:48:35Z</div>
+                <div class="signal-grid__key">updatedAt</div>
+                <div class="signal-grid__val">2026-04-22T20:57:12Z</div>
+                <div class="signal-grid__key">lastHeartbeat</div>
+                <div class="signal-grid__val">2026-04-22T20:57:12Z</div>
+                <div class="signal-grid__key">completedAt</div>
+                <div class="signal-grid__val signal-grid__val--null">null</div>
+                <div class="signal-grid__key">pid</div>
+                <div class="signal-grid__val">56629</div>
+                <div class="signal-grid__key">worktreePath</div>
+                <div class="signal-grid__val signal-grid__val--muted">~/catalyst/wt/orch-2026-04-22-3-CTL-138</div>
+                <div class="signal-grid__key">session_id</div>
+                <div class="signal-grid__val signal-grid__val--muted">sess_20260422T204718_64aa0e66</div>
+                <div class="signal-grid__key">lastReviveReason</div>
+                <div class="signal-grid__val signal-grid__val--null">null</div>
+                <div class="signal-grid__key">fixupAttempts</div>
+                <div class="signal-grid__val">0</div>
+                <div class="signal-grid__key">linearState</div>
+                <div class="signal-grid__val">In Review</div>
+              </dl>
             </div>
-            <div class="cost-cell">
-              <span class="cost-cell__label">Output</span>
-              <span class="cost-cell__value">3,412</span>
-            </div>
-            <div class="cost-cell">
-              <span class="cost-cell__label">Cache read</span>
-              <span class="cost-cell__value">58,120</span>
-            </div>
-            <div class="cost-cell">
-              <span class="cost-cell__label">Cache write</span>
-              <span class="cost-cell__value">12,440</span>
-            </div>
-            <div class="cost-cell">
-              <span class="cost-cell__label">Duration</span>
-              <span class="cost-cell__value">9m 48s</span>
-            </div>
-            <div class="cost-cell">
-              <span class="cost-cell__label">USD</span>
-              <span class="cost-cell__value">$0.47</span>
-            </div>
+            <aside class="pr-card" aria-label="Pull request">
+              <header class="pr-card__head">
+                <span class="pr-card__number">#247</span>
+                <span class="chip chip--passing">CI passing</span>
+              </header>
+              <dl class="pr-card__grid">
+                <dt>URL</dt>
+                <dd><a href="#">github.com/../pull/247</a></dd>
+                <dt>merge state</dt>
+                <dd>CLEAN</dd>
+                <dt>opened</dt>
+                <dd>2026-04-22T20:55:48Z</dd>
+                <dt>auto-merge</dt>
+                <dd>armed</dd>
+                <dt>merged</dt>
+                <dd class="signal-grid__val--null">—</dd>
+              </dl>
+            </aside>
           </div>
-        </section>
+        </details>
 
         <div class="footer">
           <p>

--- a/plugins/dev/scripts/orch-monitor/public/mockups/worker.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/worker.html
@@ -591,6 +591,71 @@
         font-variant-numeric: tabular-nums;
       }
 
+      /* ------- Hero metrics ------- */
+
+      .hero-metrics {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--spacing-3);
+      }
+
+      @media (max-width: 640px) {
+        .hero-metrics {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .hero-metric {
+        background: var(--color-surface-1);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        padding: var(--spacing-4) var(--spacing-5);
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-1);
+      }
+
+      [data-system="precision-instrument"] .hero-metric {
+        border-radius: 0;
+      }
+
+      .hero-metric__label {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-label);
+        letter-spacing: var(--letter-spacing-label);
+        text-transform: uppercase;
+        color: var(--color-text-lo);
+      }
+
+      .hero-metric__value {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-display);
+        line-height: 1.1;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-hi);
+      }
+
+      .hero-metric__sub {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-data);
+        color: var(--color-text-lo);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* Briefing link in worker head */
+      .worker-head__briefing-link {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-data);
+        color: var(--color-accent);
+        text-decoration: none;
+        margin-left: auto;
+        align-self: center;
+      }
+
+      .worker-head__briefing-link:hover {
+        text-decoration: underline;
+      }
+
       /* ------- Cost grid ------- */
 
       .cost-grid {
@@ -661,8 +726,28 @@
             <span class="chip chip--failed chip-glyph chip-glyph--review">Review reply</span>
             <h1 class="worker-head__name">worker.html mockup</h1>
             <a class="worker-head__pr-link" href="#">PR #247 ↗</a>
+            <a class="worker-head__briefing-link" href="./briefing.html">Briefing →</a>
           </div>
         </section>
+
+        <!-- ================ HERO METRICS ================ -->
+        <div class="hero-metrics" aria-label="Key metrics">
+          <div class="hero-metric">
+            <span class="hero-metric__label">Elapsed</span>
+            <span class="hero-metric__value">9m 48s</span>
+            <span class="hero-metric__sub">started 17:33:21</span>
+          </div>
+          <div class="hero-metric">
+            <span class="hero-metric__label">Tokens</span>
+            <span class="hero-metric__value">124k</span>
+            <span class="hero-metric__sub">98k in · 26k out</span>
+          </div>
+          <div class="hero-metric">
+            <span class="hero-metric__label">Cost</span>
+            <span class="hero-metric__value">$3.47</span>
+            <span class="hero-metric__sub">$0.35 / min</span>
+          </div>
+        </div>
 
         <!-- ================ PHASE TIMELINE ================ -->
         <section class="worker-section">


### PR DESCRIPTION
## Summary

- **home.html**: unified Kanban with view toggle (All / Orchestrators / Solo Workers), project filter chips, done-age selector (1h–30d replacing old recency chips), GitHub-style PR status chips (green=open, purple=merged, red=blocked), removed separate solo-worker grid and recently-completed strip
- **orch.html**: todos panel promoted to top of main column and expanded by default; new 5-column worker Kanban (Queued / Working / Review / Blocked / Done) with ticket + status chips and inline todo previews; "Briefing →" nav link in meta row
- **worker.html**: hero metrics strip (Elapsed, Tokens, Cost) above the phase timeline; "Briefing →" link in worker-head
- **comms.html**: activity indicator dots (with opacity-pulse animation) on inactive channel rows to signal recent traffic without an unread badge
- **agent-graph.html**: wider dagre spacing (`nodesep` 48→72, `ranksep` 80→120) for less cramped graph layout
- **chrome.js**: re-enable `precision-instrument` system; add visible ◐ toggle button in topbar; `⇧D` keybinding now targets `data-system`

## Test plan

- [ ] Open `home.html` — view toggle (All/Orchestrators/Solo Workers) shows/hides cards correctly
- [ ] Project filter chips filter cards by `data-project`
- [ ] Done-age chips (3d default) are active and change column heading
- [ ] PR chips render green (open), purple (merged), red (blocked)
- [ ] ◐ button and `⇧D` toggle between dark/light systems on all pages
- [ ] Open `orch.html` — todos panel is first, expanded by default
- [ ] Worker Kanban renders 5 columns with worker cards and todo previews
- [ ] "Briefing →" link present in orch and worker heads
- [ ] Open `worker.html` — hero metrics (Elapsed/Tokens/Cost) appear above phase timeline
- [ ] Open `comms.html` — wave-1 and pr-248 rows show activity dots

Closes CTL-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)