### PR TITLE
chore(meta): enable model invocation on 55 skills

### DIFF
--- a/plugins/analytics/skills/analyze-user-behavior/SKILL.md
+++ b/plugins/analytics/skills/analyze-user-behavior/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-user-behavior
 description: Analyze user behavior patterns and cohorts using PostHog
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/analytics/skills/product-metrics/SKILL.md
+++ b/plugins/analytics/skills/product-metrics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: product-metrics
 description: View key product metrics, KPIs, and conversion rates from PostHog
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/analytics/skills/segment-analysis/SKILL.md
+++ b/plugins/analytics/skills/segment-analysis/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: segment-analysis
 description: Analyze user segments and cohorts for targeted insights
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/debugging/skills/debug-production-error/SKILL.md
+++ b/plugins/debugging/skills/debug-production-error/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: debug-production-error
 description: Debug production errors using Sentry error tracking and analysis
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/debugging/skills/error-impact-analysis/SKILL.md
+++ b/plugins/debugging/skills/error-impact-analysis/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: error-impact-analysis
 description: Analyze the impact and scope of production errors
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/debugging/skills/trace-analysis/SKILL.md
+++ b/plugins/debugging/skills/trace-analysis/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: trace-analysis
 description: Analyze distributed traces and performance issues with Sentry
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/dev/skills/add-changelog-media/SKILL.md
+++ b/plugins/dev/skills/add-changelog-media/SKILL.md
@@ -4,7 +4,7 @@ description:
   "Add screenshots, screencasts (GIFs), or other media to changelog entries. Supports both local
   files and externally-hosted assets on R2/CDN. Inserts markdown image references into CHANGELOG.md
   files so they render on the website."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Edit, Glob, Grep
 ---
 

--- a/plugins/dev/skills/code-first-draft/SKILL.md
+++ b/plugins/dev/skills/code-first-draft/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-first-draft
 description: "Initial feature implementation from a PRD or feature description. **ALWAYS use when** the user wants to build a new feature, implement a PRD, create a first draft of code, or says things like 'build this feature', 'implement this PRD', 'code this up', 'create the initial implementation'. Also use when there's no existing codebase and user needs a standalone reference prototype."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Task
 version: 1.0.0
 ---

--- a/plugins/dev/skills/commit/SKILL.md
+++ b/plugins/dev/skills/commit/SKILL.md
@@ -5,7 +5,7 @@ description:
   when the user indicates they want to save their work, commit changes, or says 'commit this', 'save
   my changes', 'let's commit'. Auto-detects commit type, scope, and ticket reference from branch
   name."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read
 version: 2.0.0
 ---

--- a/plugins/dev/skills/compound/SKILL.md
+++ b/plugins/dev/skills/compound/SKILL.md
@@ -6,7 +6,7 @@ description:
   actuals for a shipped Linear ticket. Writes a structured entry (linear.key, pr_number, merged_at,
   estimate_at_start, estimate_actual, cost_usd, wall_time_hours, what_worked, what_surprised_me)
   to `thoughts/shared/pm/metrics/YYYY-WW-compound-log.md` — one file per ISO week, appends."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash(gh *), Bash(linearis *), Bash(jq *), Bash(git *), Bash(./plugins/dev/scripts/compound-log.sh *), Bash(plugins/dev/scripts/compound-log.sh *), Read, Write
 version: 1.0.0
 ---

--- a/plugins/dev/skills/create-handoff/SKILL.md
+++ b/plugins/dev/skills/create-handoff/SKILL.md
@@ -4,7 +4,7 @@ description:
   "Create handoff document for passing work to another session. **ALWAYS use when** the user says
   'create a handoff', 'hand this off', 'save progress for later', 'I need to stop here', or when
   context usage is high (>60%) during implementation and work needs to continue in a fresh session."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Write, Bash, Read
 version: 1.0.0
 ---
@@ -127,29 +127,9 @@ that don't fall into the above categories}
 
 ---
 
-### 3. Approve and Sync
+### 3. Sync and Complete
 
-Ask the user to review and approve the document. if they request any changes, you should make them
-and ask for approval again. Once the user approves the documents, you should run
-`humanlayer thoughts sync` to save the document.
-
-### Track in Workflow Context (REQUIRED)
-
-After saving the handoff document, you MUST track it. Substitute the actual file path and ticket:
-
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add handoffs "thoughts/shared/handoffs/PROJ-XXX/YYYY-MM-DD_HH-MM-SS_description.md" "TICKET-ID"
-```
-
-Verify it was tracked:
-
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent handoffs
-```
-
-This MUST print the handoff path. If not, re-run the add command.
-
-Once this is completed, you should respond to the user with the template between
+Run `humanlayer thoughts sync` to save the document. Then respond to the user with the template between
 <template_response></template_response> XML tags. do NOT include the tags in your response.
 
 <template_response> Handoff created and synced! You can resume from this handoff in a new session

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -5,7 +5,7 @@ description:
   says 'plan this', 'create a plan', 'let's plan the implementation', 'design the approach', or
   wants a structured TDD implementation plan before writing code. Works best after
   /research-codebase."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools:
   Read, Write, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
   mcp__deepwiki__read_wiki_structure
@@ -311,23 +311,7 @@ Each phase writes tests BEFORE implementation code. This ensures:
 humanlayer thoughts sync
 ```
 
-**5b. Track in workflow context (REQUIRED):**
-
-Substitute the actual file path and ticket ID:
-
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add plans "thoughts/shared/plans/YYYY-MM-DD-PROJ-XXX-description.md" "TICKET-ID"
-```
-
-**5c. Verify tracking:**
-
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans
-```
-
-This MUST print the plan path. If not, re-run 5b.
-
-**5d. Present plan** and ask for review:
+**5b. Present plan** and ask for review:
 
 - Show plan location
 - Ask: Are phases properly scoped? Success criteria specific enough? Missing edge cases?

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -5,7 +5,7 @@ description:
   a PR', 'open a pull request', 'ship this', 'ready for review', or wants to push changes and create
   a GitHub PR. Handles commit, rebase, push, PR creation, description generation, and Linear ticket
   update."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash(linearis *), Bash(git *), Bash(gh *), Read, Task
 version: 1.0.0
 ---

--- a/plugins/dev/skills/create-worktree/SKILL.md
+++ b/plugins/dev/skills/create-worktree/SKILL.md
@@ -4,7 +4,7 @@ description:
   "Create a git worktree for parallel work and optionally launch implementation session. **ALWAYS
   use when** the user says 'create a worktree', 'work in parallel', 'start a worktree for', or needs
   to work on multiple features simultaneously without switching branches."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read
 version: 1.0.0
 ---

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -4,7 +4,7 @@ description:
   "Generate or update PR description with incremental changes. **ALWAYS use when** the user says
   'describe the PR', 'update PR description', 'generate PR description', or after pushing new
   commits to an existing PR. Supports incremental updates that preserve manual edits."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Write
 version: 2.0.0
 ---

--- a/plugins/dev/skills/fix-typescript/SKILL.md
+++ b/plugins/dev/skills/fix-typescript/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fix-typescript
 description: "Fix TypeScript errors with strict anti-reward-hacking rules. **ALWAYS use when** the user says 'fix type errors', 'fix typescript', 'type-check is failing', or when TypeScript compilation errors need to be resolved. Ensures runtime type safety — fixes root causes instead of silencing errors with casts."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Edit, Bash, Grep
 version: 1.0.0
 ---

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -5,7 +5,7 @@ description:
   'implement the plan', 'start implementing', 'build from the plan', or wants to execute a
   previously created implementation plan using TDD (Red-Green-Refactor). Supports team mode for
   parallel implementation."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools:
   Read, Write, Edit, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
   mcp__deepwiki__read_wiki_structure

--- a/plugins/dev/skills/iterate-plan/SKILL.md
+++ b/plugins/dev/skills/iterate-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: iterate-plan
 description: "Update existing implementation plans based on feedback or changed requirements. **ALWAYS use when** the user says 'update the plan', 'change the plan', 'the requirements changed', 'revise the approach', or wants to modify an existing plan in thoughts/shared/plans/ after review feedback or discovered issues."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Write, Task, Bash, Grep, Glob
 version: 1.0.0
 ---
@@ -108,11 +108,6 @@ If the changes require new technical understanding:
 
 1. Save the updated plan (overwrite the existing file)
 2. Sync thoughts: `humanlayer thoughts sync`
-3. Track in workflow context (REQUIRED) — substitute actual path and ticket:
-   ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add plans "thoughts/shared/plans/YYYY-MM-DD-description.md" "TICKET-ID"
-   ```
-4. Verify: `"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent plans` must print the path
 
 ### Step 6: Present Summary
 

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -4,7 +4,7 @@ description:
   "Manage Linear tickets with workflow automation. **ALWAYS use when** the user says 'create a
   ticket', 'update the ticket', 'move ticket to', 'search Linear', or wants to create tickets from
   thoughts documents, update ticket status, or manage the Linear workflow. Uses Linearis CLI."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash(linearis *), Read, Write, Edit, Grep
 version: 1.0.0
 ---

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -4,7 +4,7 @@ description:
   "Safely merge PR with verification and Linear integration. **ALWAYS use when** the user says
   'merge the PR', 'merge this', 'ship it', or wants to merge an approved pull request. Runs tests,
   checks CI, verifies approvals, squash merges, cleans up branches, and moves Linear ticket to Done."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash(linearis *), Bash(git *), Bash(gh *), Read
 version: 1.0.0
 ---

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -5,7 +5,7 @@ description:
   command. **ALWAYS use when** the user says 'oneshot', 'do everything end to end', 'full workflow',
   or wants to go from ticket/idea to merged PR autonomously. All phases run sequentially in the
   current session, using agent teams for parallelism when needed."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools:
   Read, Write, Bash, Task, Grep, Glob, mcp__deepwiki__ask_question,
   mcp__deepwiki__read_wiki_structure

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -3,7 +3,7 @@ name: orchestrate
 description:
   Coordinate multiple tickets in parallel across worktrees with wave-based execution, worker
   dispatch, and adversarial verification
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Write, Bash, Task, Grep, Glob, Agent
 version: 1.0.0
 ---

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -5,7 +5,7 @@ description:
   asks to 'research', 'investigate', 'explore the codebase', 'how does X work', 'find out about', or
   needs deep analysis of how existing code is structured. Produces a research document in
   thoughts/shared/research/ with file:line references."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools:
   Read, Write, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
   mcp__deepwiki__read_wiki_structure
@@ -259,31 +259,7 @@ system in this area. Focus on WHAT EXISTS, not what should exist.}
 humanlayer thoughts sync
 ```
 
-**8b. Track in workflow context (REQUIRED):**
-
-You MUST run this command, substituting the actual file path you wrote and the ticket ID (or
-"null"):
-
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "thoughts/shared/research/YYYY-MM-DD-description.md" "TICKET-ID"
-```
-
-For example, if you wrote `thoughts/shared/research/2026-02-16-ADV-33-api-layer-research.md` for
-ticket ADV-33:
-
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" add research "thoughts/shared/research/2026-02-16-ADV-33-api-layer-research.md" "ADV-33"
-```
-
-**8c. Verify tracking succeeded:**
-
-```bash
-"${CLAUDE_PLUGIN_ROOT}/scripts/workflow-context.sh" recent research
-```
-
-This MUST print the path you just saved. If it doesn't, re-run step 8b.
-
-**8d. Linear comment** (if ticket detected): Add a comment noting research is complete and
+**8b. Linear comment** (if ticket detected): Add a comment noting research is complete and
 linking the document path. Use Linearis CLI (run `linearis comments usage` for syntax).
 
 **8e. Present summary to user:**

--- a/plugins/dev/skills/resume-handoff/SKILL.md
+++ b/plugins/dev/skills/resume-handoff/SKILL.md
@@ -4,7 +4,7 @@ description:
   "Resume work from a handoff document. **ALWAYS use when** the user says 'resume handoff', 'pick up
   where we left off', 'continue from handoff', or provides a handoff document path. Verifies current
   codebase state against handoff, validates changes, and creates an action plan."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Bash, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/dev/skills/review-comments/SKILL.md
+++ b/plugins/dev/skills/review-comments/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-comments
 description: "Systematically pull, categorize, and address all PR review comments — code change requests, questions, and suggestions. This skill fetches comments via gh api, groups them by file, implements fixes, handles disagreements diplomatically, and pushes a single commit. You should not try to handle PR review feedback manually — this skill ensures nothing gets missed. **ALWAYS consult this skill when** the user says 'address comments', 'fix review feedback', 'handle PR comments', 'respond to reviewers', 'address review', 'review feedback', or mentions that a PR has unresolved comments or review threads. Also used by /oneshot Phase 5 to process reviewer feedback before merging."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 version: 1.0.0
 argument-hint: "[PR-number]"

--- a/plugins/dev/skills/scan-reward-hacking/SKILL.md
+++ b/plugins/dev/skills/scan-reward-hacking/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scan-reward-hacking
 description: "Scan TypeScript code for reward hacking patterns — shortcuts that make linters pass without actually fixing type safety. This skill has a comprehensive checklist of 8 forbidden patterns with severity tuning (libraries vs apps) that you cannot reliably check on your own. **ALWAYS consult this skill when** the user says 'scan for hacks', 'check for type cheats', 'reward hacking', 'verify no shortcuts', wants to check for `as any`, `as unknown as`, `@ts-ignore`, non-null assertions (`value!`), `forEach(async`, or void tricks after fixing TypeScript errors. Also use after /fix-typescript completes, or when verifying TypeScript changes before marking work done. Accepts optional file/directory arguments to scope the scan."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Grep, Glob
 argument-hint: "[files-or-directories]"
 version: 1.1.0

--- a/plugins/dev/skills/teardown/SKILL.md
+++ b/plugins/dev/skills/teardown/SKILL.md
@@ -5,7 +5,7 @@ description:
   archiving artifacts to ~/catalyst/archives/{orchId}. **ALWAYS use when** the user says
   'teardown', 'delete orchestrator', 'cleanup orchestrator', or 'remove worktree' for a finished
   orchestrator. Refuses to delete unless the archive sweep succeeded; use --force to bypass."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Bash, Glob
 ---
 

--- a/plugins/dev/skills/validate-plan/SKILL.md
+++ b/plugins/dev/skills/validate-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate-plan
 description: "Validate that implementation plans were correctly executed. **ALWAYS use when** the user says 'validate the plan', 'check if the plan was implemented correctly', 'verify the implementation', or after completing /implement-plan to confirm all phases were properly executed and success criteria met."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Grep, Glob, Bash, Task
 version: 1.0.0
 ---

--- a/plugins/dev/skills/validate-type-safety/SKILL.md
+++ b/plugins/dev/skills/validate-type-safety/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate-type-safety
 description: "Run the full 5-step TypeScript validation gate: type check, reward hacking scan, test inclusion, tests, and lint. This skill provides a structured multi-step pipeline that you cannot replicate on your own — it detects the project's package manager and linter automatically, checks tsconfig strictness, and invokes /scan-reward-hacking internally. **ALWAYS consult this skill when** the user mentions 'validate types', 'check type safety', 'type validation', 'type safety gate', wants to verify TypeScript changes before a PR, after completing a plan phase, or says anything about running type checks + tests + lint together. Even if you think you can run tsc yourself, use this skill — it catches issues you'd miss (tsconfig strictness, test exclusions, reward hacking patterns)."
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Grep, Glob
 version: 1.0.0
 ---

--- a/plugins/meta/skills/audit-references/SKILL.md
+++ b/plugins/meta/skills/audit-references/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit-references
 description: Audit plugin health and find broken references in manifests, commands, agents, and skills
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Task, Glob, Grep, Edit
 version: 1.0.0
 ---

--- a/plugins/meta/skills/create-workflow/SKILL.md
+++ b/plugins/meta/skills/create-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-workflow
 description: Create new agents or commands using discovered patterns and templates
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Write, Edit, Grep, Glob
 version: 1.0.0
 ---

--- a/plugins/meta/skills/discover-workflows/SKILL.md
+++ b/plugins/meta/skills/discover-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: discover-workflows
 description: Research and catalog workflows from external Claude Code repositories
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: mcp__deepwiki__ask_question, mcp__deepwiki__read_wiki_structure, Read, Write
 version: 1.0.0
 ---

--- a/plugins/meta/skills/import-workflow/SKILL.md
+++ b/plugins/meta/skills/import-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: import-workflow
 description: Import and adapt a workflow from external repositories
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Write, Edit, mcp__deepwiki__ask_question
 version: 1.0.0
 ---

--- a/plugins/meta/skills/reorganize/SKILL.md
+++ b/plugins/meta/skills/reorganize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reorganize
 description: Analyze and reorganize a directory structure with safe reference updates
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Glob, Grep, Bash, Task, Write
 version: 1.0.0
 ---

--- a/plugins/meta/skills/validate-frontmatter/SKILL.md
+++ b/plugins/meta/skills/validate-frontmatter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate-frontmatter
 description: Validate and fix frontmatter consistency across all workflows
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Edit, Glob, Grep
 version: 1.0.0
 ---
@@ -77,7 +77,7 @@ Return: Validation report for all agents
 Use codebase-analyzer agent:
 "Validate frontmatter in all files matching skills/*/SKILL.md. For each file, check:
 1. Required fields present (name, description)
-2. User-invoked skills have disable-model-invocation: true
+2. User-invoked skills have disable-model-invocation: false
 3. CI/background skills have user-invocable: false
 4. Uses allowed-tools (not tools) for tool restrictions
 5. Does NOT include model or category in frontmatter

--- a/plugins/pm/skills/analyze-cycle/SKILL.md
+++ b/plugins/pm/skills/analyze-cycle/SKILL.md
@@ -3,7 +3,7 @@ name: analyze-cycle
 description:
   Analyze cycle health and generate comprehensive report with actionable insights, risk analysis,
   capacity assessment, and specific recommendations
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, Read, Write, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/pm/skills/analyze-milestone/SKILL.md
+++ b/plugins/pm/skills/analyze-milestone/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-milestone
 description: Analyze project milestone health with actionable insights, target date assessment, risk analysis, and specific recommendations
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, Read, Write, TodoWrite
 version: 1.0.0
 ---

--- a/plugins/pm/skills/connect-mcps/SKILL.md
+++ b/plugins/pm/skills/connect-mcps/SKILL.md
@@ -2,7 +2,7 @@
 name: connect-mcps
 description: Connect MCPs for real-time tool integration
 version: 1.0
-disable-model-invocation: true
+disable-model-invocation: false
 modifies-workspace: true
 ---
 

--- a/plugins/pm/skills/context-daily/SKILL.md
+++ b/plugins/pm/skills/context-daily/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: context-daily
 description: Generate daily context engineering adoption dashboard
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Read, Write, Task, TodoWrite, Bash
 version: 1.0.0
 ---

--- a/plugins/pm/skills/create-tickets/SKILL.md
+++ b/plugins/pm/skills/create-tickets/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-tickets
 description: Create tickets via Linear MCP or generate formatted ticket text
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Create Tickets Skill

--- a/plugins/pm/skills/generate-ai-prototype/SKILL.md
+++ b/plugins/pm/skills/generate-ai-prototype/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: generate-ai-prototype
 description: Generate v0.dev, Lovable, or Bolt.new prompts for AI-powered prototyping
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Generate AI Prototype Skill

--- a/plugins/pm/skills/groom-backlog/SKILL.md
+++ b/plugins/pm/skills/groom-backlog/SKILL.md
@@ -2,7 +2,7 @@
 name: groom-backlog
 description:
   Groom Linear backlog to identify orphaned issues, incorrect project assignments, and health issues
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, Read, Write
 version: 1.0.0
 ---

--- a/plugins/pm/skills/interview-feedback/SKILL.md
+++ b/plugins/pm/skills/interview-feedback/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: interview-feedback
 description: Post-PM-interview debrief and continuous improvement for job search
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 **Note:** This skill is for PM career interviews (job interviews). For debriefing after conducting user research interviews, use `/user-research-synthesis` instead.

--- a/plugins/pm/skills/interview-prep/SKILL.md
+++ b/plugins/pm/skills/interview-prep/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: interview-prep
 description: Pre-interview preparation for PM job interviews (Product Sense, Execution, Behavioral)
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 **Note:** This skill is for PM career interviews (job interviews). For preparing to conduct user research interviews, see `/interview-guide`.

--- a/plugins/pm/skills/journey-map/SKILL.md
+++ b/plugins/pm/skills/journey-map/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: journey-map
 description: Create user journey maps and customer journey maps (dual mode)
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Journey Map Skill

--- a/plugins/pm/skills/launch-checklist/SKILL.md
+++ b/plugins/pm/skills/launch-checklist/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: launch-checklist
 description: Comprehensive product launch planning
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 ## Quick Start

--- a/plugins/pm/skills/meeting-agenda/SKILL.md
+++ b/plugins/pm/skills/meeting-agenda/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meeting-agenda
 description: Create structured meeting agendas for effective collaboration
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 ## Quick Start

--- a/plugins/pm/skills/meeting-feedback/SKILL.md
+++ b/plugins/pm/skills/meeting-feedback/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meeting-feedback
 description: Post-meeting effectiveness feedback and continuous improvement
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 ## Quick Start

--- a/plugins/pm/skills/napkin-sketch/SKILL.md
+++ b/plugins/pm/skills/napkin-sketch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: napkin-sketch
 description: ASCII wireframes + browser capture for design matching
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Napkin Sketch Skill

--- a/plugins/pm/skills/prd-review-panel/SKILL.md
+++ b/plugins/pm/skills/prd-review-panel/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prd-review-panel
 description: Multi-agent PRD review (7 perspectives)
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 ## Purpose

--- a/plugins/pm/skills/report-daily/SKILL.md
+++ b/plugins/pm/skills/report-daily/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report-daily
 description: Generate daily status report showing yesterday's deliveries, current work, and team members needing assignments
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, Read, Write
 version: 1.0.0
 ---

--- a/plugins/pm/skills/sync-prs/SKILL.md
+++ b/plugins/pm/skills/sync-prs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sync-prs
 description: Sync GitHub PRs with Linear issues and identify correlation gaps
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Task, Read, Write
 version: 1.0.0
 ---

--- a/plugins/pm/skills/weekly-plan/SKILL.md
+++ b/plugins/pm/skills/weekly-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: weekly-plan
 description: Set next week's priorities
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 ## Purpose

--- a/plugins/pm/skills/weekly-review/SKILL.md
+++ b/plugins/pm/skills/weekly-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: weekly-review
 description: Review week's progress, meetings, learnings
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 ## Quick Start

--- a/plugins/pm/skills/write-prod-strategy/SKILL.md
+++ b/plugins/pm/skills/write-prod-strategy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write-prod-strategy
 description: Product strategy docs using 7-component framework
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Write Product Strategy Skill


### PR DESCRIPTION
## Summary

- Flips `disable-model-invocation` from `true` to `false` on 55 skills across all 5 plugins (dev, pm, meta, analytics, debugging)
- Keeps 3 setup skills disabled (`setup-catalyst`, `setup-warp`, `setup-orchestrate`) since they're destructive if re-run
- Enables the model to invoke skills programmatically when the user instructs it to chain commands in sequence

## Test plan

- [ ] Verify model can invoke a previously-blocked skill (e.g., `/catalyst-dev:create-plan`) when instructed
- [ ] Verify the 3 setup skills remain non-model-callable

🤖 Generated with [Claude Code](https://claude.com/claude-code)