### PR TITLE
fix(dev): move smee channel URL to per-machine Layer 2 config (CTL-217)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -32,6 +32,11 @@
       "profile": "coalesce-labs",
       "directory": "catalyst-workspace",
       "user": null
+    },
+    "monitor": {
+      "github": {
+        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET"
+      }
     }
   }
 }

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  loadWebhookConfig,
+  _resetWebhookDeprecationWarning,
+} from "../lib/webhook-config";
+
+let tmpDir: string;
+let homeDir: string;
+let projectDir: string;
+let projectConfigPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "webhook-config-test-"));
+  homeDir = join(tmpDir, "home-config");
+  projectDir = join(tmpDir, "project");
+  projectConfigPath = join(projectDir, "config.json");
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(projectDir, { recursive: true });
+  _resetWebhookDeprecationWarning();
+  delete process.env.CATALYST_WEBHOOK_SECRET;
+  delete process.env.CATALYST_SMEE_SECRET;
+  delete process.env.CATALYST_SMEE_CHANNEL;
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.CATALYST_WEBHOOK_SECRET;
+  delete process.env.CATALYST_SMEE_SECRET;
+  delete process.env.CATALYST_SMEE_CHANNEL;
+});
+
+function writeProject(json: object): void {
+  writeFileSync(projectConfigPath, JSON.stringify(json));
+}
+
+function writeHome(json: object): void {
+  writeFileSync(join(homeDir, "config.json"), JSON.stringify(json));
+}
+
+describe("loadWebhookConfig", () => {
+  it("returns null when neither layer has config and env is unset", () => {
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+    expect(cfg).toBeNull();
+  });
+
+  it("loads channel from home-dir Layer 2 with secret env from default name (no warning)", () => {
+    writeHome({
+      catalyst: {
+        monitor: {
+          github: { smeeChannel: "https://smee.io/home-channel" },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "home-secret";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/home-channel",
+      secret: "home-secret",
+    });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("loads channel from Layer 1 only and emits a single deprecation warning", () => {
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            smeeChannel: "https://smee.io/legacy-channel",
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "legacy-secret";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/legacy-channel",
+      secret: "legacy-secret",
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = String(warn.mock.calls[0]?.[0] ?? "");
+    expect(msg).toContain("smeeChannel");
+    expect(msg).toContain(".catalyst/config.json");
+    warn.mockRestore();
+  });
+
+  it("home-dir Layer 2 wins when both layers have smeeChannel; deprecation warning still fires for Layer 1", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home-wins" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            smeeChannel: "https://smee.io/legacy-loses",
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/home-wins",
+      secret: "secret",
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("merges Layer 1 webhookSecretEnv name with home-dir smeeChannel", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: { webhookSecretEnv: "MY_CUSTOM_SECRET_ENV" },
+        },
+      },
+    });
+    process.env.MY_CUSTOM_SECRET_ENV = "custom-value";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/home",
+      secret: "custom-value",
+    });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+    delete process.env.MY_CUSTOM_SECRET_ENV;
+  });
+
+  it("CATALYST_SMEE_CHANNEL env overrides both layers", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    process.env.CATALYST_SMEE_CHANNEL = "https://smee.io/env-override";
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/env-override",
+      secret: "secret",
+    });
+  });
+
+  it("falls back to CATALYST_SMEE_SECRET when the named env var is unset", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: { github: { webhookSecretEnv: "CATALYST_WEBHOOK_SECRET" } },
+      },
+    });
+    process.env.CATALYST_SMEE_SECRET = "legacy-fallback";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/home",
+      secret: "legacy-fallback",
+    });
+  });
+
+  it("returns null when channel is set but secret is empty", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    // No env var set
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+    expect(cfg).toBeNull();
+  });
+
+  it("returns null when secret is set but no channel anywhere", () => {
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+    expect(cfg).toBeNull();
+  });
+
+  it("emits the deprecation warning at most once per process across multiple loads", () => {
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            smeeChannel: "https://smee.io/legacy",
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    loadWebhookConfig(homeDir, projectConfigPath);
+    loadWebhookConfig(homeDir, projectConfigPath);
+    loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("returns null when project config is malformed JSON", () => {
+    writeFileSync(projectConfigPath, "not json{{{");
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+    expect(cfg).toBeNull();
+  });
+
+  it("ignores home-dir file with malformed JSON and falls back to Layer 1", () => {
+    writeFileSync(join(homeDir, "config.json"), "garbage{");
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            smeeChannel: "https://smee.io/legacy",
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/legacy",
+      secret: "secret",
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("returns null when configs exist but lack the catalyst.monitor.github shape", () => {
+    writeHome({ unrelated: "value" });
+    writeProject({ catalyst: { other: "thing" } });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+    expect(cfg).toBeNull();
+  });
+
+  it("uses default secret env name CATALYST_WEBHOOK_SECRET when webhookSecretEnv is absent", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    // Project config has no webhookSecretEnv at all
+    writeProject({});
+    process.env.CATALYST_WEBHOOK_SECRET = "default-secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/home",
+      secret: "default-secret",
+    });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export interface WebhookCliConfig {
+  smeeChannel: string;
+  secret: string;
+}
+
+interface FileExtract {
+  smeeChannel: string | null;
+  webhookSecretEnv: string | null;
+}
+
+let warnedDeprecatedSmeeChannel = false;
+
+// Exposed for tests only.
+export function _resetWebhookDeprecationWarning(): void {
+  warnedDeprecatedSmeeChannel = false;
+}
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function readGithubSection(filePath: string): FileExtract | null {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.catalyst)) return null;
+  const monitor = parsed.catalyst.monitor;
+  if (!isRecord(monitor)) return null;
+  const github = monitor.github;
+  if (!isRecord(github)) return null;
+
+  const smeeChannel =
+    typeof github.smeeChannel === "string" && github.smeeChannel.length > 0
+      ? github.smeeChannel
+      : null;
+  const webhookSecretEnv =
+    typeof github.webhookSecretEnv === "string" &&
+    github.webhookSecretEnv.length > 0
+      ? github.webhookSecretEnv
+      : null;
+
+  return { smeeChannel, webhookSecretEnv };
+}
+
+/**
+ * Loads webhook delivery config from the two files where pieces of it live:
+ *
+ * - `<homeConfigDir>/config.json` (cross-project, per-machine, NOT committed) —
+ *   holds `catalyst.monitor.github.smeeChannel`. The smee URL is per-laptop
+ *   because one orch-monitor daemon tunnels webhooks for every project on the
+ *   machine.
+ * - `<projectConfigPath>` (per-repo, committed, team-wide) — holds
+ *   `catalyst.monitor.github.webhookSecretEnv` (the env-var **name** the secret
+ *   is read from, not the value).
+ *
+ * If `smeeChannel` is found in `<projectConfigPath>` (the deprecated location),
+ * the value is still honored but a one-shot deprecation warning is emitted.
+ *
+ * Env-var overrides:
+ *   - `CATALYST_SMEE_CHANNEL` overrides any file-derived channel.
+ *   - The secret is read from `process.env[webhookSecretEnv]`, with a legacy
+ *     fallback to `process.env.CATALYST_SMEE_SECRET`.
+ *
+ * Returns `null` if either the channel or secret cannot be resolved.
+ */
+export function loadWebhookConfig(
+  homeConfigDir: string,
+  projectConfigPath: string,
+): WebhookCliConfig | null {
+  const projectExtract = readGithubSection(projectConfigPath);
+  const homeExtract = readGithubSection(join(homeConfigDir, "config.json"));
+
+  const homeChannel = homeExtract?.smeeChannel ?? null;
+  const projectChannel = projectExtract?.smeeChannel ?? null;
+  const webhookSecretEnv =
+    projectExtract?.webhookSecretEnv ?? "CATALYST_WEBHOOK_SECRET";
+
+  if (projectChannel !== null && !warnedDeprecatedSmeeChannel) {
+    warnedDeprecatedSmeeChannel = true;
+    console.warn(
+      "[webhook-config] Deprecated: catalyst.monitor.github.smeeChannel found in " +
+        ".catalyst/config.json. The smee URL is per-machine — move it to " +
+        "~/.config/catalyst/config.json. Run `setup-webhooks.sh --force` to " +
+        "migrate. Layer 1 reads will be removed in a future release.",
+    );
+  }
+
+  const fileChannel = homeChannel ?? projectChannel;
+  const channelOverride = process.env.CATALYST_SMEE_CHANNEL;
+  const finalChannel =
+    channelOverride && channelOverride.length > 0
+      ? channelOverride
+      : (fileChannel ?? "");
+
+  const secret =
+    process.env[webhookSecretEnv] ?? process.env.CATALYST_SMEE_SECRET ?? "";
+
+  if (finalChannel.length === 0 || secret.length === 0) return null;
+  return { smeeChannel: finalChannel, secret };
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -84,6 +84,7 @@ import {
   type EventLogWriter,
 } from "./lib/event-log";
 import { loadOtelConfig } from "./lib/otel-config";
+import { loadWebhookConfig } from "./lib/webhook-config";
 import { detectProjectKey } from "./lib/project-key";
 import {
   createPrometheusFetcher,
@@ -185,11 +186,6 @@ const PR_STATUS_REFRESH_MS = 10 * 60_000;
 const PREVIEW_REFRESH_MS = 10 * 60_000;
 export const LINEAR_REFRESH_MS = 5 * 60_000;
 
-interface WebhookCliConfig {
-  smeeChannel: string;
-  secret: string;
-}
-
 const defaultGhRunner: SubscriberRunner = async (args) => {
   try {
     const proc = Bun.spawn(args, {
@@ -203,44 +199,6 @@ const defaultGhRunner: SubscriberRunner = async (args) => {
     return { stdout: "", ok: false };
   }
 };
-
-export function loadWebhookConfig(
-  configPath: string,
-): WebhookCliConfig | null {
-  let raw: string;
-  try {
-    raw = readFileSync(configPath, "utf-8");
-  } catch {
-    return null;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return null;
-  }
-  if (typeof parsed !== "object" || parsed === null) return null;
-  const root = parsed as Record<string, unknown>;
-  const cat = root.catalyst;
-  if (typeof cat !== "object" || cat === null) return null;
-  const monitor = (cat as Record<string, unknown>).monitor;
-  if (typeof monitor !== "object" || monitor === null) return null;
-  const github = (monitor as Record<string, unknown>).github;
-  if (typeof github !== "object" || github === null) return null;
-  const ghCfg = github as Record<string, unknown>;
-  const smeeChannel =
-    typeof ghCfg.smeeChannel === "string" ? ghCfg.smeeChannel : "";
-  const secretEnv =
-    typeof ghCfg.webhookSecretEnv === "string"
-      ? ghCfg.webhookSecretEnv
-      : "CATALYST_WEBHOOK_SECRET";
-  const secret =
-    process.env[secretEnv] ?? process.env.CATALYST_SMEE_SECRET ?? "";
-  const channelOverride = process.env.CATALYST_SMEE_CHANNEL;
-  const finalChannel = channelOverride ?? smeeChannel;
-  if (finalChannel.length === 0 || secret.length === 0) return null;
-  return { smeeChannel: finalChannel, secret };
-}
 
 function collectTicketKeys(snapshot: MonitorSnapshot): string[] {
   const keys = new Set<string>();
@@ -1641,6 +1599,7 @@ if (import.meta.main) {
   );
 
   const webhookConfig = loadWebhookConfig(
+    process.env.CATALYST_CONFIG_DIR ?? `${process.env.HOME}/.config/catalyst`,
     `${process.cwd()}/.catalyst/config.json`,
   );
   let summarizeHandler: SummarizeHandler | null = null;

--- a/plugins/dev/scripts/setup-webhooks.sh
+++ b/plugins/dev/scripts/setup-webhooks.sh
@@ -4,18 +4,22 @@
 # What this script does:
 #   1. Creates a fresh smee.io channel (or reuses one supplied via $CATALYST_SMEE_CHANNEL)
 #   2. Generates a 32-byte HMAC secret
-#   3. Writes catalyst.monitor.github.{smeeChannel,webhookSecretEnv} into
-#      .catalyst/config.json (creates the file if absent; merges with jq if present)
-#   4. Persists the secret to ~/.config/catalyst/webhook-secret with mode 600
-#   5. Prints the export instruction the user needs to source
+#   3. Writes catalyst.monitor.github.smeeChannel to ~/.config/catalyst/config.json
+#      (cross-project, per-machine — one smee tunnel serves every project on this laptop)
+#   4. Writes catalyst.monitor.github.webhookSecretEnv to .catalyst/config.json
+#      (team-wide repo config — env-var NAME only, never the value)
+#   5. Persists the secret to ~/.config/catalyst/webhook-secret with mode 600
+#   6. Migrates a deprecated smeeChannel out of .catalyst/config.json if present
 #
 # Re-running is safe: the script never overwrites an existing channel
 # unless --force is passed.
 
 set -euo pipefail
 
-CONFIG_PATH=".catalyst/config.json"
-SECRET_PATH="${HOME}/.config/catalyst/webhook-secret"
+PROJECT_CONFIG_PATH=".catalyst/config.json"
+HOME_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/catalyst"
+HOME_CONFIG_PATH="${HOME_CONFIG_DIR}/config.json"
+SECRET_PATH="${HOME_CONFIG_DIR}/webhook-secret"
 DEFAULT_SECRET_ENV="CATALYST_WEBHOOK_SECRET"
 FORCE=0
 
@@ -26,7 +30,8 @@ Usage: $(basename "$0") [--force]
 Sets up webhook delivery for orch-monitor:
   • Creates a smee.io channel
   • Generates an HMAC secret
-  • Writes config to ${CONFIG_PATH}
+  • Writes channel URL to ${HOME_CONFIG_PATH} (cross-project, per-machine)
+  • Writes env-var name to ${PROJECT_CONFIG_PATH} (team-wide repo config)
   • Persists the secret to ${SECRET_PATH} (mode 600)
 
 Options:
@@ -57,18 +62,26 @@ require_cmd jq
 require_cmd curl
 require_cmd openssl
 
+read_smee_channel_from() {
+  local path="$1"
+  [[ -f "$path" ]] || return 0
+  jq -r '.catalyst.monitor.github.smeeChannel // ""' "$path" 2>/dev/null || true
+}
+
 # ─── 1. Determine smee channel ─────────────────────────────────────────────
-existing_channel=""
-if [[ -f "$CONFIG_PATH" ]]; then
-  existing_channel=$(jq -r '.catalyst.monitor.github.smeeChannel // ""' "$CONFIG_PATH" 2>/dev/null || true)
-fi
+existing_home_channel=$(read_smee_channel_from "$HOME_CONFIG_PATH")
+existing_project_channel=$(read_smee_channel_from "$PROJECT_CONFIG_PATH")
 
 if [[ -n "${CATALYST_SMEE_CHANNEL:-}" ]]; then
   channel="$CATALYST_SMEE_CHANNEL"
   echo "Using channel from CATALYST_SMEE_CHANNEL: $channel"
-elif [[ -n "$existing_channel" && $FORCE -eq 0 ]]; then
-  channel="$existing_channel"
-  echo "Reusing existing channel: $channel (use --force to regenerate)"
+elif [[ -n "$existing_home_channel" && $FORCE -eq 0 ]]; then
+  channel="$existing_home_channel"
+  echo "Reusing existing channel from $HOME_CONFIG_PATH: $channel (use --force to regenerate)"
+elif [[ -n "$existing_project_channel" && $FORCE -eq 0 ]]; then
+  # Migrate deprecated location.
+  channel="$existing_project_channel"
+  echo "Found deprecated smeeChannel in $PROJECT_CONFIG_PATH — migrating to $HOME_CONFIG_PATH"
 else
   echo "Creating new smee.io channel..."
   # smee.io/new responds with HTTP 307 to GET (not POST). Follow the redirect
@@ -82,7 +95,7 @@ else
 fi
 
 # ─── 2. Generate or reuse secret ───────────────────────────────────────────
-mkdir -p "$(dirname "$SECRET_PATH")"
+mkdir -p "$HOME_CONFIG_DIR"
 if [[ -f "$SECRET_PATH" && $FORCE -eq 0 ]]; then
   echo "Reusing existing secret at $SECRET_PATH (use --force to regenerate)"
 else
@@ -92,27 +105,51 @@ else
   echo "Wrote new HMAC secret to $SECRET_PATH (mode 600)"
 fi
 
-# ─── 3. Merge config into .catalyst/config.json ────────────────────────────
-mkdir -p "$(dirname "$CONFIG_PATH")"
-if [[ ! -f "$CONFIG_PATH" ]]; then
-  echo "{}" > "$CONFIG_PATH"
+# ─── 3. Write smeeChannel to cross-project home-dir config ────────────────
+if [[ ! -f "$HOME_CONFIG_PATH" ]]; then
+  echo "{}" > "$HOME_CONFIG_PATH"
 fi
-
 tmp=$(mktemp)
-jq \
-  --arg channel "$channel" \
-  --arg secret_env "$DEFAULT_SECRET_ENV" \
+jq --arg channel "$channel" \
   '
     .catalyst //= {}
     | .catalyst.monitor //= {}
     | .catalyst.monitor.github //= {}
     | .catalyst.monitor.github.smeeChannel = $channel
-    | .catalyst.monitor.github.webhookSecretEnv = $secret_env
-  ' "$CONFIG_PATH" > "$tmp"
-mv "$tmp" "$CONFIG_PATH"
-echo "Updated $CONFIG_PATH"
+  ' "$HOME_CONFIG_PATH" > "$tmp"
+mv "$tmp" "$HOME_CONFIG_PATH"
+echo "Updated $HOME_CONFIG_PATH"
 
-# ─── 4. Print next steps ───────────────────────────────────────────────────
+# ─── 4. Write webhookSecretEnv to per-repo project config ─────────────────
+mkdir -p "$(dirname "$PROJECT_CONFIG_PATH")"
+if [[ ! -f "$PROJECT_CONFIG_PATH" ]]; then
+  echo "{}" > "$PROJECT_CONFIG_PATH"
+fi
+tmp=$(mktemp)
+jq --arg secret_env "$DEFAULT_SECRET_ENV" \
+  '
+    .catalyst //= {}
+    | .catalyst.monitor //= {}
+    | .catalyst.monitor.github //= {}
+    | .catalyst.monitor.github.webhookSecretEnv = $secret_env
+  ' "$PROJECT_CONFIG_PATH" > "$tmp"
+mv "$tmp" "$PROJECT_CONFIG_PATH"
+echo "Updated $PROJECT_CONFIG_PATH"
+
+# ─── 5. Migrate: drop deprecated smeeChannel from project config ───────────
+if [[ -n "$existing_project_channel" ]]; then
+  tmp=$(mktemp)
+  jq '
+    del(.catalyst.monitor.github.smeeChannel)
+    | if (.catalyst.monitor.github // {}) == {} then del(.catalyst.monitor.github) else . end
+    | if (.catalyst.monitor // {}) == {} then del(.catalyst.monitor) else . end
+    | if (.catalyst // {}) == {} then del(.catalyst) else . end
+  ' "$PROJECT_CONFIG_PATH" > "$tmp"
+  mv "$tmp" "$PROJECT_CONFIG_PATH"
+  echo "→ Removed deprecated smeeChannel from $PROJECT_CONFIG_PATH (commit this change)"
+fi
+
+# ─── 6. Print next steps ───────────────────────────────────────────────────
 cat <<EOF
 
 Setup complete.

--- a/website/src/content/docs/observability/webhooks.md
+++ b/website/src/content/docs/observability/webhooks.md
@@ -35,18 +35,26 @@ The only third-party in the path is smee itself. It does not log payload bodies 
 forwards them in-flight), but you should not assume privacy on a free public relay — secrets
 inside webhook payloads (like environment URLs) traverse smee.
 
-## Setup is per-installation, not per-repo
+## Setup is per-machine, not per-project
 
-You configure smee **once per machine** that runs orch-monitor. Repository subscriptions
-are then created automatically on demand — the daemon registers a webhook on each
-`(owner, repo)` it observes via worker signal files, deduping with any existing webhook
-that already targets the same channel URL.
+You configure smee **once per machine** that runs orch-monitor. The daemon is
+one-process-per-laptop, watching `~/catalyst/wt/` across **every project** (catalyst, adva,
+slides, etc.) — so there is exactly one smee tunnel per machine, fanning events in for every
+repo it watches. Repository subscriptions are then created automatically on demand: the
+daemon registers a webhook on each `(owner, repo)` it observes via worker signal files,
+deduping with any existing webhook that already targets the same channel URL.
 
-| What | Where | When |
-|------|-------|------|
-| smee channel URL | `.catalyst/config.json` (project) or `CATALYST_SMEE_CHANNEL` env (machine) | Once at setup |
-| HMAC secret | env var named by `webhookSecretEnv` (default `CATALYST_WEBHOOK_SECRET`) | Once at setup |
-| Repo webhook subscription | GitHub repo settings (auto-created via `gh api`) | Lazily, on first observation of the repo |
+The channel URL therefore belongs in the **cross-project, per-machine** config file
+(`~/.config/catalyst/config.json`), the same place the OTel endpoints live for the same
+reason. The env-var **name** (`webhookSecretEnv`) is team-wide and lives in
+`.catalyst/config.json`.
+
+| What | Where | Committed | When |
+|------|-------|-----------|------|
+| smee channel URL | `~/.config/catalyst/config.json` (cross-project, per-machine) or `CATALYST_SMEE_CHANNEL` env | NO | Once at setup |
+| `webhookSecretEnv` (env-var name only) | `.catalyst/config.json` (per-repo, team-wide) | YES | Once at setup |
+| HMAC secret value | env var named by `webhookSecretEnv` (default `CATALYST_WEBHOOK_SECRET`) | NO (per-developer env) | Once at setup |
+| Repo webhook subscription | GitHub repo settings (auto-created via `gh api`) | n/a | Lazily, on first observation of the repo |
 
 **You do not need to add the smee channel to each repo manually.** The daemon does this for
 you the first time a worker for that repo runs and is observed by the monitor.
@@ -61,12 +69,16 @@ plugins/dev/scripts/setup-webhooks.sh
 
 It:
 
-1. Calls `curl -X POST https://smee.io/new` to create a fresh channel (or reuses
-   `CATALYST_SMEE_CHANNEL` if already set)
+1. Calls `curl -L https://smee.io/new` to create a fresh channel (or reuses an existing one
+   from `~/.config/catalyst/config.json`, or `CATALYST_SMEE_CHANNEL` if already set)
 2. Generates a 32-byte HMAC secret with `openssl rand -hex 32`
 3. Writes the secret to `~/.config/catalyst/webhook-secret` (mode 600)
-4. Merges `catalyst.monitor.github.{smeeChannel, webhookSecretEnv}` into
-   `.catalyst/config.json`
+4. Writes `catalyst.monitor.github.smeeChannel` to `~/.config/catalyst/config.json`
+   (cross-project, per-machine — never committed)
+5. Writes `catalyst.monitor.github.webhookSecretEnv` to `.catalyst/config.json` (committed,
+   team-wide — env-var **name** only)
+6. Migrates a deprecated `smeeChannel` out of `.catalyst/config.json` if it finds one there
+   (one-line console note; commit the resulting diff)
 
 Then export the secret in your shell:
 
@@ -79,14 +91,32 @@ the webhook tunnel comes up automatically.
 
 ## Configuration shape
 
-`.catalyst/config.json`:
+The webhook config is split across two files because the channel URL is per-machine while
+the env-var name is team-wide. This mirrors the [OTel config layout](/reference/configuration/#monitor-otel-config),
+where Prometheus and Loki URLs also live in `~/.config/catalyst/config.json` for the same
+per-machine reason.
+
+`~/.config/catalyst/config.json` (cross-project, per-machine — never committed):
 
 ```json
 {
   "catalyst": {
     "monitor": {
       "github": {
-        "smeeChannel": "https://smee.io/<channel-id>",
+        "smeeChannel": "https://smee.io/<channel-id>"
+      }
+    }
+  }
+}
+```
+
+`.catalyst/config.json` (per-repo, committed, team-wide):
+
+```json
+{
+  "catalyst": {
+    "monitor": {
+      "github": {
         "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET"
       }
     }
@@ -100,9 +130,18 @@ Override the channel without editing config (useful for ephemeral debugging):
 CATALYST_SMEE_CHANNEL=https://smee.io/another-channel bun run server.ts
 ```
 
-If the secret env var is unset or `smeeChannel` is missing, the receiver disables itself
-silently and the daemon falls back to 10-minute polling. Nothing breaks; you just lose the
-sub-5-second update latency.
+If the secret env var is unset or `smeeChannel` is missing from both files, the receiver
+disables itself silently and the daemon falls back to 10-minute polling. Nothing breaks; you
+just lose the sub-5-second update latency.
+
+### Migration from earlier versions
+
+Earlier `setup-webhooks.sh` runs wrote `smeeChannel` to `.catalyst/config.json` (Layer 1,
+committed). That was wrong — the value is per-machine, not per-team. The daemon still reads
+that location for one release cycle and emits a one-shot deprecation warning when it does.
+To migrate, re-run `setup-webhooks.sh`: it picks up the deprecated value, moves it to
+`~/.config/catalyst/config.json`, and removes it from the committed file. Commit the
+resulting Layer 1 diff.
 
 ## Subscribed events
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -300,6 +300,62 @@ Cloud, Datadog, etc.), point these URLs at your hosted Prometheus/Loki-compatibl
 
 See [Setting up the OTel stack](/observability/setup/) for the full installation guide.
 
+### Monitor Webhook Config
+
+The orch-monitor daemon receives GitHub events through a smee.io tunnel — see
+[GitHub webhooks for orch-monitor](/observability/webhooks/) for the why and the full setup
+flow. The webhook config is split across two files because the channel URL is per-machine
+(one daemon, one tunnel, every project on the laptop) while the env-var **name** is
+team-wide.
+
+`~/.config/catalyst/config.json` — cross-project, per-machine, **not committed**:
+
+```json
+{
+  "catalyst": {
+    "monitor": {
+      "github": {
+        "smeeChannel": "https://smee.io/<channel-id>"
+      }
+    }
+  }
+}
+```
+
+`.catalyst/config.json` — per-repo, **committed**, team-wide:
+
+```json
+{
+  "catalyst": {
+    "monitor": {
+      "github": {
+        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET"
+      }
+    }
+  }
+}
+```
+
+| Field | Where | Type | Default | Description |
+|-------|-------|------|---------|-------------|
+| `catalyst.monitor.github.smeeChannel` | `~/.config/catalyst/config.json` | string | _(none)_ | Per-machine smee.io channel URL the daemon tunnels deliveries through |
+| `catalyst.monitor.github.webhookSecretEnv` | `.catalyst/config.json` | string | `"CATALYST_WEBHOOK_SECRET"` | **Name** of the env var the HMAC secret value is read from at runtime |
+
+Environment variable overrides:
+- `CATALYST_SMEE_CHANNEL` — overrides any file-derived channel.
+- The env var named by `webhookSecretEnv` (default `CATALYST_WEBHOOK_SECRET`) holds the
+  shared HMAC secret value.
+
+If the channel is missing from both files (and unset in env), the receiver disables itself
+silently and the daemon falls back to 10-minute polling. Run `plugins/dev/scripts/setup-webhooks.sh`
+to provision both files and the secret.
+
+**Deprecated location**: `catalyst.monitor.github.smeeChannel` was originally written to
+`.catalyst/config.json` (Layer 1). The monitor still reads that location for one release
+cycle and emits a one-shot deprecation warning on startup if it finds a value there.
+Re-running `setup-webhooks.sh` migrates the value to the right home and clears it from the
+committed config.
+
 ### AI Briefing
 
 The monitor dashboard supports AI-powered status summaries. Configuration spans both layers:


### PR DESCRIPTION
Fixes [CTL-217](https://linear.app/rozich/issue/CTL-217).

## Why

The orch-monitor daemon is **one-process-per-machine** and tunnels webhook
deliveries for every project the laptop watches through one smee channel —
catalyst, adva, slides, etc. So the smee URL is per-machine, not per-team
and not per-project. It does not belong in the committed `.catalyst/config.json`.

Confirmed during [CTL-209](https://linear.app/rozich/issue/CTL-209) Tier 3
testing: the daemon registered webhooks on `coalesce-labs/catalyst`,
`rightsite-cloud/Adva`, and `ryanrozich/slides` simultaneously, all pointing
at the same smee URL.

## What

| File | Scope | Committed | Holds |
|---|---|---|---|
| `~/.config/catalyst/config.json` | cross-project, per-machine | NO | `catalyst.monitor.github.smeeChannel` |
| `.catalyst/config.json` | per-repo, team-wide | YES | `catalyst.monitor.github.webhookSecretEnv` (env-var **name** only) |

This mirrors the OTel endpoint layout for the same reason — Prometheus/Loki
URLs are also per-machine and live in `~/.config/catalyst/config.json`.

## Changes

- **`plugins/dev/scripts/orch-monitor/lib/webhook-config.ts`** (new) —
  `loadWebhookConfig(homeConfigDir, projectConfigPath)` reads both files,
  merges with home-dir winning, emits a single console.warn the first time
  it sees `smeeChannel` in Layer 1. Mirrors `lib/otel-config.ts` shape
  (including the `_resetWebhookDeprecationWarning()` test helper).
- **`plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts`** —
  14 unit tests covering: missing config, Layer 1 only (deprecation warning),
  Layer 2 only (no warning), both layers (home wins; warning still fires for
  the Layer 1 wart), env-var overrides, secret fallback chain, single-warning
  latch across multiple loads, malformed JSON tolerance.
- **`plugins/dev/scripts/orch-monitor/server.ts`** — drops the inline
  `loadWebhookConfig`/`WebhookCliConfig`, imports the new lib, threads the
  cross-project config dir (uses the same `CATALYST_CONFIG_DIR` env var
  precedent that `loadOtelConfig` already honors).
- **`plugins/dev/scripts/setup-webhooks.sh`** — writes `smeeChannel` to
  `~/.config/catalyst/config.json` and `webhookSecretEnv` to
  `.catalyst/config.json`. If it finds a deprecated `smeeChannel` in
  Layer 1, it migrates the value to the home-dir file and removes it from
  Layer 1 (with a one-line console note).
- **`website/src/content/docs/observability/webhooks.md`** — rewrites the
  "Setup is per-machine" section, shows two JSON snippets in the
  Configuration shape section, adds a "Migration from earlier versions"
  callout.
- **`website/src/content/docs/reference/configuration.md`** — new
  "Monitor Webhook Config" section, placed adjacent to the OTel section
  that establishes the precedent.
- **`.catalyst/config.json`** — adds `webhookSecretEnv: CATALYST_WEBHOOK_SECRET`
  (the value `setup-webhooks.sh` would write — a no-op since that's the
  default name, but documents the expected schema).

## Test plan

- [x] `bun test __tests__/webhook-config.test.ts` — 14 pass / 0 fail
- [x] Full orch-monitor suite at parity with baseline (1121 pass / 7 fail
      pre-existing — 6 brittle catalyst-monitor.sh process-spawn tests +
      1 session-store)
- [x] Type-check: only pre-existing errors in `ui/src/lib/briefings.ts`
      (unrelated `marked`/`dompurify` imports); no new CTL-217 errors
- [x] Lint: only pre-existing warning in `lib/preview-status.ts`; no new
- [x] Smoke: setup-webhooks.sh against scratch `$HOME` —
  - Migration: deprecated Layer 1 `smeeChannel` correctly moves to home-dir
  - Idempotent re-run: reuses existing channel + secret
  - Fresh deploy: writes to both files correctly with no Layer 1 wart

## Acceptance criteria

- [x] `loadWebhookConfig` reads both files, merges, with home-dir taking precedence
- [x] `setup-webhooks.sh` writes URL → `~/.config/catalyst/config.json`, env-var name → `.catalyst/config.json`
- [x] Tests cover Layer 1 only, home-dir Layer 2 only, both layers, conflicting URLs (home wins)
- [x] Existing `.catalyst/config.json` `smeeChannel` reads with deprecation warning for one release
- [x] `webhooks.md` documents the per-machine model and file layout
- [x] `configuration.md` schema reference updated to reflect three-tier layout