### PR TITLE
feat(dev): config-driven webhook watch list (CTL-216)

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Shell tests for setup-webhooks.sh --add-repo (CTL-216).
+#
+# Verifies that --add-repo merges into .catalyst/config.json (Layer 1) under
+# catalyst.monitor.github.watchRepos, with dedup and format validation.
+# When invoked in --add-repo-only mode (no other intent), the script must NOT
+# touch the smee channel, secret, or call out to the network — we stub `curl`
+# and `openssl` to fail loudly so the test fails if the script accidentally
+# enters normal setup mode.
+#
+# Run: bash plugins/dev/scripts/__tests__/setup-webhooks.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SETUP="${REPO_ROOT}/plugins/dev/scripts/setup-webhooks.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Per-test fake $HOME + project tree. Build a stub-bin dir that hard-fails
+# `curl` and `openssl` so any --add-repo-only invocation that accidentally
+# falls through to channel/secret provisioning is caught.
+make_test_env() {
+  local name="$1"
+  local dir="${SCRATCH}/${name}"
+  mkdir -p "${dir}/home/.config/catalyst"
+  mkdir -p "${dir}/project/.catalyst"
+  mkdir -p "${dir}/stubbin"
+  cat > "${dir}/stubbin/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "FAIL: curl invoked during --add-repo-only mode" >&2
+exit 87
+EOF
+  cat > "${dir}/stubbin/openssl" <<'EOF'
+#!/usr/bin/env bash
+# `openssl` is needed only for fresh secret generation. Hard-fail to catch
+# accidental fall-through from --add-repo-only into normal setup.
+echo "FAIL: openssl invoked during --add-repo-only mode" >&2
+exit 87
+EOF
+  chmod +x "${dir}/stubbin/curl" "${dir}/stubbin/openssl"
+  echo "$dir"
+}
+
+# Run setup-webhooks.sh with a fake $HOME, fake project cwd, stubbed
+# curl/openssl on PATH. Real `jq` from the host PATH is preserved.
+run_setup() {
+  local env_dir="$1"; shift
+  ( cd "${env_dir}/project" && \
+    HOME="${env_dir}/home" \
+    XDG_CONFIG_HOME="${env_dir}/home/.config" \
+    PATH="${env_dir}/stubbin:${PATH}" \
+    bash "$SETUP" "$@" )
+}
+
+# Read .catalyst.monitor.github.watchRepos from a project config as JSON array.
+read_watch_repos() {
+  local path="$1"
+  jq -c '.catalyst.monitor.github.watchRepos // []' "$path"
+}
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+expect_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "expected: $expected" >&2
+    echo "actual:   $actual" >&2
+    return 1
+  fi
+}
+
+# ─── Test 1 — single --add-repo bootstraps watchRepos array ──────────────────
+test_single_add() {
+  local env; env=$(make_test_env t1)
+  run_setup "$env" --add-repo coalesce-labs/catalyst >/dev/null 2>&1
+  local got; got=$(read_watch_repos "${env}/project/.catalyst/config.json")
+  expect_eq "single add" '["coalesce-labs/catalyst"]' "$got"
+}
+
+# ─── Test 2 — multiple --add-repo flags in one invocation ──────────────────
+test_multiple_adds() {
+  local env; env=$(make_test_env t2)
+  run_setup "$env" \
+    --add-repo coalesce-labs/catalyst \
+    --add-repo coalesce-labs/adva >/dev/null 2>&1
+  local got; got=$(read_watch_repos "${env}/project/.catalyst/config.json")
+  expect_eq "multiple adds" \
+    '["coalesce-labs/catalyst","coalesce-labs/adva"]' "$got"
+}
+
+# ─── Test 3 — repeated invocations dedupe (idempotent) ─────────────────────
+test_idempotent() {
+  local env; env=$(make_test_env t3)
+  run_setup "$env" --add-repo coalesce-labs/catalyst >/dev/null 2>&1
+  run_setup "$env" --add-repo coalesce-labs/catalyst >/dev/null 2>&1
+  run_setup "$env" --add-repo coalesce-labs/catalyst >/dev/null 2>&1
+  local got; got=$(read_watch_repos "${env}/project/.catalyst/config.json")
+  expect_eq "idempotent" '["coalesce-labs/catalyst"]' "$got"
+}
+
+# ─── Test 4 — invalid format rejected with non-zero exit ────────────────────
+test_invalid_format() {
+  local env; env=$(make_test_env t4)
+  if run_setup "$env" --add-repo "not-a-slash" > "${SCRATCH}/t4.out" 2>&1; then
+    echo "expected non-zero exit, got zero" >&2
+    cat "${SCRATCH}/t4.out" >&2
+    return 1
+  fi
+  # Ensure config wasn't touched on validation failure.
+  if [[ -f "${env}/project/.catalyst/config.json" ]]; then
+    local got; got=$(read_watch_repos "${env}/project/.catalyst/config.json")
+    expect_eq "no config write on invalid input" '[]' "$got"
+  fi
+}
+
+# ─── Test 5 — empty owner or repo rejected ─────────────────────────────────
+test_empty_parts_rejected() {
+  local env; env=$(make_test_env t5)
+  if run_setup "$env" --add-repo "/missing-owner" > /dev/null 2>&1; then
+    echo "expected non-zero for /missing-owner" >&2
+    return 1
+  fi
+  if run_setup "$env" --add-repo "missing-repo/" > /dev/null 2>&1; then
+    echo "expected non-zero for missing-repo/" >&2
+    return 1
+  fi
+  if run_setup "$env" --add-repo "a/b/c" > /dev/null 2>&1; then
+    echo "expected non-zero for a/b/c (extra slash)" >&2
+    return 1
+  fi
+}
+
+# ─── Test 6 — preserves an existing webhookSecretEnv field ─────────────────
+test_preserves_other_fields() {
+  local env; env=$(make_test_env t6)
+  cat > "${env}/project/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "monitor": {
+      "github": {
+        "webhookSecretEnv": "MY_SECRET"
+      }
+    }
+  }
+}
+EOF
+  run_setup "$env" --add-repo a/b >/dev/null 2>&1
+  local secret_env
+  secret_env=$(jq -r '.catalyst.monitor.github.webhookSecretEnv' \
+    "${env}/project/.catalyst/config.json")
+  expect_eq "webhookSecretEnv preserved" "MY_SECRET" "$secret_env"
+  local got; got=$(read_watch_repos "${env}/project/.catalyst/config.json")
+  expect_eq "watchRepos added" '["a/b"]' "$got"
+}
+
+# ─── Test 7 — --add-repo only mode never invokes curl/openssl ──────────────
+# The stubbin/curl and stubbin/openssl exit 87. If the script falls through
+# to channel/secret setup, the run_setup invocation will return 87 and
+# write a FAIL message to the output file. We assert the run succeeded AND
+# the FAIL marker is absent.
+test_no_network_in_add_only_mode() {
+  local env; env=$(make_test_env t7)
+  if ! run_setup "$env" --add-repo a/b > "${SCRATCH}/t7.out" 2>&1; then
+    echo "expected --add-repo only mode to succeed" >&2
+    cat "${SCRATCH}/t7.out" >&2
+    return 1
+  fi
+  if grep -q "FAIL: curl\|FAIL: openssl" "${SCRATCH}/t7.out"; then
+    echo "--add-repo only mode unexpectedly hit curl/openssl" >&2
+    cat "${SCRATCH}/t7.out" >&2
+    return 1
+  fi
+}
+
+# ─── Test 8 — preserves order of insertion across runs ─────────────────────
+test_insertion_order() {
+  local env; env=$(make_test_env t8)
+  run_setup "$env" --add-repo a/first >/dev/null 2>&1
+  run_setup "$env" --add-repo b/second >/dev/null 2>&1
+  run_setup "$env" --add-repo c/third >/dev/null 2>&1
+  local got; got=$(read_watch_repos "${env}/project/.catalyst/config.json")
+  expect_eq "insertion order" '["a/first","b/second","c/third"]' "$got"
+}
+
+# ─── Run all ──────────────────────────────────────────────────────────────
+echo "Running setup-webhooks --add-repo tests…"
+run "single add bootstraps watchRepos" test_single_add
+run "multiple adds in one invocation" test_multiple_adds
+run "repeated adds are idempotent (dedup)" test_idempotent
+run "invalid format rejected" test_invalid_format
+run "empty owner/repo parts rejected" test_empty_parts_rejected
+run "preserves existing webhookSecretEnv" test_preserves_other_fields
+run "no network in --add-repo only mode" test_no_network_in_add_only_mode
+run "preserves insertion order across runs" test_insertion_order
+
+echo
+echo "Passed: $PASSES, Failed: $FAILURES"
+exit "$FAILURES"

--- a/plugins/dev/scripts/orch-monitor/README.md
+++ b/plugins/dev/scripts/orch-monitor/README.md
@@ -56,7 +56,8 @@ export CATALYST_WEBHOOK_SECRET="$(cat ~/.config/catalyst/webhook-secret)"
     "monitor": {
       "github": {
         "smeeChannel": "https://smee.io/<channel-id>",
-        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET"
+        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET",
+        "watchRepos": []
       }
     }
   }
@@ -65,13 +66,24 @@ export CATALYST_WEBHOOK_SECRET="$(cat ~/.config/catalyst/webhook-secret)"
 
 Override the channel without editing the config: `CATALYST_SMEE_CHANNEL=https://smee.io/...`.
 
+### Persistent watch list
+
+Add `watchRepos` to subscribe to repos at daemon startup regardless of whether a worker has been observed for them — useful when running orch-monitor as a continuous background activity feed for your core repos. Use the helper to add entries:
+
+```bash
+plugins/dev/scripts/setup-webhooks.sh --add-repo coalesce-labs/catalyst
+```
+
+Empty/missing → auto-discovery only. See the website docs for the full setup flow: [GitHub webhooks for orch-monitor — Persistent watch list](https://github.com/coalesce-labs/catalyst/blob/main/website/src/content/docs/observability/webhooks.md#persistent-watch-list).
+
 ### What the monitor does on startup
 
 1. Reads `monitor.github` config — if absent or the secret is missing, the receiver is disabled and the daemon falls back to 10-min polling
 2. Starts the smee tunnel toward `http://localhost:{port}/api/webhook`
-3. For each observed `(owner, repo)` (via worker signal files), creates or reuses a webhook subscription on that repo
-4. On startup, replays the last hour of deliveries from `gh api repos/{repo}/hooks/{id}/deliveries` so events missed during downtime are reconciled
-5. Every accepted webhook event is also fanned out to `~/catalyst/events/YYYY-MM.jsonl` for downstream consumers (UI activity feed, future `catalyst-events` CLI)
+3. Subscribes to each repo in `watchRepos` (Layer 1) before replay runs, so configured repos get the 1-hour replay too
+4. For each `(owner, repo)` observed in worker signal files, creates or reuses a webhook subscription — deduped against step 3
+5. On startup, replays the last hour of deliveries from `gh api repos/{repo}/hooks/{id}/deliveries` so events missed during downtime are reconciled
+6. Every accepted webhook event is also fanned out to `~/catalyst/events/YYYY-MM.jsonl` for downstream consumers (UI activity feed, future `catalyst-events` CLI)
 
 ### Subscribed events
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -1422,3 +1422,269 @@ describe("Webhook receiver — disabled (no webhookConfig)", () => {
     expect(res.status).toBe(503);
   });
 });
+
+describe("Webhook config-driven watch list (CTL-216)", () => {
+  // The subscriber issues a `gh api repos/{repo}/hooks` GET-list call before
+  // doing anything else (see webhook-subscriber.ts). We use the recorded calls
+  // as the signal that ensureSubscribed was invoked for a repo.
+  type Call = string[];
+
+  // Default responder returns a single existing hook that matches the test
+  // smee channel, so listExistingHook resolves to that hook id and the cache
+  // is populated WITHOUT a POST. This is the "happy path" used by tests A and
+  // B; bad-token / failure cases override the responder.
+  function defaultResponder(channel: string) {
+    return (args: string[]): { stdout: string; ok: boolean } => {
+      if (args.includes("-X")) {
+        // POST createHook — only reached when listExistingHook returns null,
+        // which our default responder avoids. Stub a created-hook response.
+        return { stdout: '{"id":777}', ok: true };
+      }
+      return {
+        stdout: JSON.stringify([{ id: 12345, config: { url: channel } }]),
+        ok: true,
+      };
+    };
+  }
+
+  function makeRunner(
+    responder?: (args: string[]) => { stdout: string; ok: boolean },
+    channel = "https://smee.io/test",
+  ): {
+    runner: (args: string[]) => Promise<{ stdout: string; ok: boolean }>;
+    calls: Call[];
+  } {
+    const calls: Call[] = [];
+    const respond = responder ?? defaultResponder(channel);
+    const runner = (args: string[]) => {
+      calls.push([...args]);
+      return Promise.resolve(respond(args));
+    };
+    return { runner, calls };
+  }
+
+  // Fake smee-client constructor — never opens a real network connection.
+  const fakeFactory = () => ({
+    start: () => Promise.resolve({}),
+    stop: () => Promise.resolve(),
+  });
+
+  // Subscriber subscriptions are kicked off in a `then(...)` chain after
+  // `webhookTunnel.start()`. Allow microtasks/macrotasks to drain so the
+  // recorded calls reflect the startup hook firing.
+  async function waitForSubscribeCalls(
+    calls: Call[],
+    expected: number,
+    deadlineMs = 1000,
+  ): Promise<void> {
+    const start = Date.now();
+    while (calls.length < expected && Date.now() - start < deadlineMs) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  }
+
+  function reposCalledFromGetHooks(calls: Call[]): string[] {
+    const out: string[] = [];
+    for (const args of calls) {
+      // GET-list step is `gh api repos/<owner>/<repo>/hooks` with no `-X POST`.
+      if (args[0] !== "gh" || args[1] !== "api") continue;
+      if (args.includes("-X")) continue;
+      const path = args[2] ?? "";
+      const m = path.match(/^repos\/([^/]+\/[^/]+)\/hooks$/);
+      if (m && m[1]) out.push(m[1]);
+    }
+    return out;
+  }
+
+  it("subscribes to configured watchRepos at startup with no workers present", async () => {
+    const channel = "https://smee.io/test-a";
+    const { runner, calls } = makeRunner(undefined, channel);
+    const tmp = mkdtempSync(join(tmpdir(), "webhook-watchrepos-a-"));
+    try {
+      const wtDir = join(tmp, "wt");
+      mkdirSync(wtDir, { recursive: true });
+      const srv = createServer({
+        port: 0,
+        wtDir,
+        startWatcher: false,
+        annotationsDbPath: join(tmp, "annotations.db"),
+        webhookConfig: {
+          smeeChannel: channel,
+          secret: "secret",
+          tunnelFactory: fakeFactory,
+          watchRepos: ["coalesce-labs/catalyst", "coalesce-labs/adva"],
+          subscriberRunner: runner,
+        },
+      });
+      try {
+        await waitForSubscribeCalls(calls, 2);
+        const repos = reposCalledFromGetHooks(calls);
+        expect(repos).toContain("coalesce-labs/catalyst");
+        expect(repos).toContain("coalesce-labs/adva");
+      } finally {
+        void srv.stop(true);
+      }
+    } finally {
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it("dedupes when a configured repo is also auto-discovered via worker signal", async () => {
+    const channel = "https://smee.io/test-b";
+    const { runner, calls } = makeRunner(undefined, channel);
+    const tmp = mkdtempSync(join(tmpdir(), "webhook-watchrepos-b-"));
+    try {
+      const wtDir = join(tmp, "wt");
+      const orchDir = join(wtDir, "orch-dedup");
+      mkdirSync(join(orchDir, "workers"), { recursive: true });
+      writeFileSync(
+        join(orchDir, "state.json"),
+        JSON.stringify({
+          id: "orch-dedup",
+          startedAt: new Date().toISOString(),
+          currentWave: 1,
+          totalWaves: 1,
+          waves: [{ wave: 1, status: "in_progress", tickets: ["X-1"] }],
+        }),
+      );
+      writeFileSync(
+        join(orchDir, "workers", "X-1.json"),
+        JSON.stringify({
+          ticket: "X-1",
+          orchestrator: "orch-dedup",
+          workerName: "orch-dedup-X-1",
+          status: "in_progress",
+          phase: 1,
+          startedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          pid: process.pid,
+          pr: {
+            number: 99,
+            url: "https://github.com/coalesce-labs/catalyst/pull/99",
+            ciStatus: "pending",
+            prOpenedAt: new Date().toISOString(),
+            autoMergeArmedAt: null,
+            mergedAt: null,
+          },
+        }),
+      );
+
+      const srv = createServer({
+        port: 0,
+        wtDir,
+        startWatcher: false,
+        annotationsDbPath: join(tmp, "annotations.db"),
+        webhookConfig: {
+          smeeChannel: channel,
+          secret: "secret",
+          tunnelFactory: fakeFactory,
+          watchRepos: ["coalesce-labs/catalyst"],
+          subscriberRunner: runner,
+        },
+      });
+      try {
+        await waitForSubscribeCalls(calls, 1);
+        // Force snapshot to run the auto-discovery path too.
+        const res = await fetch(`http://localhost:${srv.port}/api/snapshot`);
+        expect(res.ok).toBe(true);
+        await res.json();
+        // Give the snapshot's `void ensureSubscribed` a tick to attempt running.
+        await new Promise((r) => setTimeout(r, 20));
+        const repos = reposCalledFromGetHooks(calls);
+        const catalystCalls = repos.filter(
+          (r) => r === "coalesce-labs/catalyst",
+        );
+        // Subscriber's in-memory cache dedupes — only one subscription attempt
+        // even though both startup hook and snapshot would have fired.
+        expect(catalystCalls.length).toBe(1);
+      } finally {
+        void srv.stop(true);
+      }
+    } finally {
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it("does not subscribe to anything when watchRepos is empty/missing", async () => {
+    const { runner, calls } = makeRunner();
+    const tmp = mkdtempSync(join(tmpdir(), "webhook-watchrepos-c-"));
+    try {
+      const wtDir = join(tmp, "wt");
+      mkdirSync(wtDir, { recursive: true });
+      const srv = createServer({
+        port: 0,
+        wtDir,
+        startWatcher: false,
+        annotationsDbPath: join(tmp, "annotations.db"),
+        webhookConfig: {
+          smeeChannel: "https://smee.io/test-c",
+          secret: "secret",
+          tunnelFactory: fakeFactory,
+          // watchRepos omitted entirely.
+          subscriberRunner: runner,
+        },
+      });
+      try {
+        // Wait long enough that any rogue subscription attempt would have
+        // started. Don't loop on calls.length — we're asserting it stays 0.
+        await new Promise((r) => setTimeout(r, 50));
+        expect(reposCalledFromGetHooks(calls)).toEqual([]);
+      } finally {
+        void srv.stop(true);
+      }
+    } finally {
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it("keeps the daemon running when a configured repo's hook list call fails", async () => {
+    // Simulate the gh CLI returning ok:false for the GET hooks call. The
+    // subscriber's tolerance contract is: log a warning and continue. The
+    // server must NOT throw / crash.
+    const { runner, calls } = makeRunner(() => ({ stdout: "", ok: false }));
+    const tmp = mkdtempSync(join(tmpdir(), "webhook-watchrepos-d-"));
+    try {
+      const wtDir = join(tmp, "wt");
+      mkdirSync(wtDir, { recursive: true });
+      const srv = createServer({
+        port: 0,
+        wtDir,
+        startWatcher: false,
+        annotationsDbPath: join(tmp, "annotations.db"),
+        webhookConfig: {
+          smeeChannel: "https://smee.io/test-d",
+          secret: "secret",
+          tunnelFactory: fakeFactory,
+          watchRepos: ["unknown-org/no-access"],
+          subscriberRunner: runner,
+        },
+      });
+      try {
+        await waitForSubscribeCalls(calls, 1);
+        // Server is still serving requests after the failed subscription.
+        const res = await fetch(`http://localhost:${srv.port}/api/snapshot`);
+        expect(res.ok).toBe(true);
+      } finally {
+        void srv.stop(true);
+      }
+    } finally {
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -62,6 +62,7 @@ describe("loadWebhookConfig", () => {
     expect(cfg).toEqual({
       smeeChannel: "https://smee.io/home-channel",
       secret: "home-secret",
+      watchRepos: [],
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -86,6 +87,7 @@ describe("loadWebhookConfig", () => {
     expect(cfg).toEqual({
       smeeChannel: "https://smee.io/legacy-channel",
       secret: "legacy-secret",
+      watchRepos: [],
     });
     expect(warn).toHaveBeenCalledTimes(1);
     const msg = String(warn.mock.calls[0]?.[0] ?? "");
@@ -118,6 +120,7 @@ describe("loadWebhookConfig", () => {
     expect(cfg).toEqual({
       smeeChannel: "https://smee.io/home-wins",
       secret: "secret",
+      watchRepos: [],
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -144,6 +147,7 @@ describe("loadWebhookConfig", () => {
     expect(cfg).toEqual({
       smeeChannel: "https://smee.io/home",
       secret: "custom-value",
+      watchRepos: [],
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -164,6 +168,7 @@ describe("loadWebhookConfig", () => {
     expect(cfg).toEqual({
       smeeChannel: "https://smee.io/env-override",
       secret: "secret",
+      watchRepos: [],
     });
   });
 
@@ -185,6 +190,7 @@ describe("loadWebhookConfig", () => {
     expect(cfg).toEqual({
       smeeChannel: "https://smee.io/home",
       secret: "legacy-fallback",
+      watchRepos: [],
     });
   });
 
@@ -254,6 +260,7 @@ describe("loadWebhookConfig", () => {
     expect(cfg).toEqual({
       smeeChannel: "https://smee.io/legacy",
       secret: "secret",
+      watchRepos: [],
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -283,6 +290,224 @@ describe("loadWebhookConfig", () => {
     expect(cfg).toEqual({
       smeeChannel: "https://smee.io/home",
       secret: "default-secret",
+      watchRepos: [],
     });
+  });
+});
+
+describe("loadWebhookConfig watchRepos (CTL-216)", () => {
+  it("returns an empty watchRepos array when the field is absent", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.watchRepos).toEqual([]);
+  });
+
+  it("reads watchRepos from Layer 1 (project config)", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+            watchRepos: ["coalesce-labs/catalyst", "coalesce-labs/adva"],
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.watchRepos).toEqual([
+      "coalesce-labs/catalyst",
+      "coalesce-labs/adva",
+    ]);
+  });
+
+  it("ignores watchRepos in Layer 2 (home-dir config) — Layer 1 only", () => {
+    // watchRepos is a team-default field; per CTL-217's split, only Layer 1
+    // contributes. A user putting watchRepos in their home-dir config should
+    // be a no-op rather than an override.
+    writeHome({
+      catalyst: {
+        monitor: {
+          github: {
+            smeeChannel: "https://smee.io/home",
+            watchRepos: ["should/be-ignored"],
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.watchRepos).toEqual([]);
+  });
+
+  it("merges Layer 1 watchRepos with Layer 2 smeeChannel", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+            watchRepos: ["a/b"],
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).toEqual({
+      smeeChannel: "https://smee.io/home",
+      secret: "secret",
+      watchRepos: ["a/b"],
+    });
+  });
+
+  it("filters out non-string entries", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+            // Mixed types — only valid owner/repo strings should survive.
+            watchRepos: ["good/repo", 42, null, { not: "string" }, ["nested"]],
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.watchRepos).toEqual(["good/repo"]);
+    warn.mockRestore();
+  });
+
+  it("filters out empty and whitespace-only strings", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+            watchRepos: ["a/b", "", "   ", "c/d"],
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.watchRepos).toEqual(["a/b", "c/d"]);
+    warn.mockRestore();
+  });
+
+  it("filters entries that don't match owner/repo shape", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+            watchRepos: ["a/b", "no-slash", "/leading", "trailing/", "a/b/c"],
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    // Only "a/b" matches the owner/repo shape (single slash, non-empty parts,
+    // no path components). Entries like "a/b/c" are not GitHub repos.
+    expect(cfg!.watchRepos).toEqual(["a/b"]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns empty array when watchRepos is not an array", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+            watchRepos: "not-an-array",
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.watchRepos).toEqual([]);
+  });
+
+  it("dedupes duplicate entries while preserving first-occurrence order", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: {
+            webhookSecretEnv: "CATALYST_WEBHOOK_SECRET",
+            watchRepos: ["a/b", "c/d", "a/b", "e/f", "c/d"],
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.watchRepos).toEqual(["a/b", "c/d", "e/f"]);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -4,11 +4,18 @@ import { join } from "path";
 export interface WebhookCliConfig {
   smeeChannel: string;
   secret: string;
+  /**
+   * Repos to subscribe to at startup, regardless of whether a worker has been
+   * observed for them. Layer 1 only (team-wide). Empty array means
+   * auto-discovery is the only subscription path. CTL-216.
+   */
+  watchRepos: string[];
 }
 
 interface FileExtract {
   smeeChannel: string | null;
   webhookSecretEnv: string | null;
+  watchRepos: string[];
 }
 
 let warnedDeprecatedSmeeChannel = false;
@@ -16,6 +23,34 @@ let warnedDeprecatedSmeeChannel = false;
 // Exposed for tests only.
 export function _resetWebhookDeprecationWarning(): void {
   warnedDeprecatedSmeeChannel = false;
+}
+
+// Loose owner/repo shape: alphanumerics, dots, dashes, underscores, exactly one
+// slash, non-empty parts. GitHub allows more characters in usernames but this
+// covers every realistic case and rejects obvious typos like missing slashes
+// or extra path components.
+const REPO_SHAPE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+function readWatchRepos(github: Record<string, unknown>): string[] {
+  const raw = github.watchRepos;
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) continue;
+    if (!REPO_SHAPE.test(trimmed)) {
+      console.warn(
+        `[webhook-config] Ignoring watchRepos entry "${trimmed}" — expected "owner/repo".`,
+      );
+      continue;
+    }
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
 }
 
 function isRecord(x: unknown): x is Record<string, unknown> {
@@ -50,8 +85,9 @@ function readGithubSection(filePath: string): FileExtract | null {
     github.webhookSecretEnv.length > 0
       ? github.webhookSecretEnv
       : null;
+  const watchRepos = readWatchRepos(github);
 
-  return { smeeChannel, webhookSecretEnv };
+  return { smeeChannel, webhookSecretEnv, watchRepos };
 }
 
 /**
@@ -107,6 +143,11 @@ export function loadWebhookConfig(
   const secret =
     process.env[webhookSecretEnv] ?? process.env.CATALYST_SMEE_SECRET ?? "";
 
+  // watchRepos is Layer 1 only — a team-default field. Reading from Layer 2
+  // would let one developer's machine override the team list, which is the
+  // opposite of what we want. CTL-216.
+  const watchRepos = projectExtract?.watchRepos ?? [];
+
   if (finalChannel.length === 0 || secret.length === 0) return null;
-  return { smeeChannel: finalChannel, secret };
+  return { smeeChannel: finalChannel, secret, watchRepos };
 }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -161,6 +161,17 @@ export interface CreateServerOptions {
     target?: string;
     /** Override for tests so the real smee-client isn't invoked. */
     tunnelFactory?: SmeeClientFactory;
+    /**
+     * Repos to subscribe to at daemon startup, in addition to the workers
+     * observed in signal files. Empty/missing → auto-discovery only. CTL-216.
+     */
+    watchRepos?: string[];
+    /**
+     * Test override for the gh subprocess runner used by the subscriber. When
+     * omitted, the production `defaultGhRunner` (Bun.spawn → real `gh`) is
+     * used. Tests pass a stub so no real `gh` is invoked.
+     */
+    subscriberRunner?: SubscriberRunner;
   } | null;
 }
 
@@ -517,7 +528,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
       smeeChannel: webhookConfig.smeeChannel,
       secret: webhookConfig.secret,
       events: [...DEFAULT_WEBHOOK_EVENTS],
-      runner: defaultGhRunner,
+      runner: webhookConfig.subscriberRunner ?? defaultGhRunner,
       logger: {
         info: (m) => console.info(m),
         warn: (m) => console.warn(m),
@@ -1477,10 +1488,20 @@ export function createServer(opts: CreateServerOptions): BunServer {
     if (webhookReplay && webhookSubscriber) {
       const replay = webhookReplay;
       const subscriber = webhookSubscriber;
+      // CTL-216: subscribe to configured watchRepos before replay so they're
+      // present in subscriber.listSubscribed() when replay runs. Errors per
+      // repo are tolerated by ensureSubscribed (logged + continue).
+      const watchRepos = webhookConfig.watchRepos ?? [];
+      const watchSubscriptions =
+        watchRepos.length > 0
+          ? Promise.allSettled(
+              watchRepos.map((repo) => subscriber.ensureSubscribed(repo)),
+            )
+          : Promise.resolve();
       // 1-hour replay window — wide enough to cover most outages, narrow enough
       // to keep startup latency under a few seconds.
       const since = new Date(Date.now() - 60 * 60_000);
-      void Promise.resolve()
+      void watchSubscriptions
         .then(() => replay.replaySince(subscriber.listSubscribed(), since))
         .then((count) => {
           if (count > 0) {

--- a/plugins/dev/scripts/setup-webhooks.sh
+++ b/plugins/dev/scripts/setup-webhooks.sh
@@ -10,6 +10,9 @@
 #      (team-wide repo config — env-var NAME only, never the value)
 #   5. Persists the secret to ~/.config/catalyst/webhook-secret with mode 600
 #   6. Migrates a deprecated smeeChannel out of .catalyst/config.json if present
+#   7. Optionally adds repos to catalyst.monitor.github.watchRepos (Layer 1) via
+#      one or more --add-repo <owner/repo> flags. When ONLY --add-repo flags are
+#      passed, the script skips steps 1–6 entirely (no smee channel mutation).
 #
 # Re-running is safe: the script never overwrites an existing channel
 # unless --force is passed.
@@ -22,10 +25,12 @@ HOME_CONFIG_PATH="${HOME_CONFIG_DIR}/config.json"
 SECRET_PATH="${HOME_CONFIG_DIR}/webhook-secret"
 DEFAULT_SECRET_ENV="CATALYST_WEBHOOK_SECRET"
 FORCE=0
+ADD_REPOS=()
+REPO_SHAPE='^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--force]
+Usage: $(basename "$0") [--force] [--add-repo owner/repo ...]
 
 Sets up webhook delivery for orch-monitor:
   • Creates a smee.io channel
@@ -35,8 +40,11 @@ Sets up webhook delivery for orch-monitor:
   • Persists the secret to ${SECRET_PATH} (mode 600)
 
 Options:
-  --force    Overwrite existing channel/secret if already configured
-  -h|--help  Show this message
+  --force                    Overwrite existing channel/secret if already configured
+  --add-repo <owner/repo>    Add a repo to catalyst.monitor.github.watchRepos in
+                             ${PROJECT_CONFIG_PATH}. Repeatable. When this is the
+                             only intent flag, channel/secret setup is skipped.
+  -h|--help                  Show this message
 
 Environment:
   CATALYST_SMEE_CHANNEL  Reuse this smee URL instead of generating one
@@ -46,9 +54,27 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --force) FORCE=1; shift ;;
+    --add-repo)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --add-repo requires an argument" >&2
+        usage
+        exit 1
+      fi
+      ADD_REPOS+=("$2")
+      shift 2
+      ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
   esac
+done
+
+# Validate --add-repo arguments before doing any work so a typo doesn't leave
+# the config in a half-modified state.
+for repo in "${ADD_REPOS[@]}"; do
+  if [[ ! "$repo" =~ $REPO_SHAPE ]]; then
+    echo "ERROR: --add-repo value '$repo' must match owner/repo (e.g. coalesce-labs/catalyst)" >&2
+    exit 1
+  fi
 done
 
 require_cmd() {
@@ -59,8 +85,51 @@ require_cmd() {
 }
 
 require_cmd jq
-require_cmd curl
-require_cmd openssl
+
+# Short-circuit when --add-repo is the only intent flag. The user is asking
+# to update the watch list, not (re)provision channel/secret — which means
+# we don't need curl/openssl and we never call out to the network. Channel
+# setup is a separate user action; the daemon tolerates a missing channel.
+ADD_REPO_ONLY=0
+if [[ ${#ADD_REPOS[@]} -gt 0 && $FORCE -eq 0 && -z "${CATALYST_SMEE_CHANNEL:-}" ]]; then
+  ADD_REPO_ONLY=1
+fi
+
+if [[ $ADD_REPO_ONLY -eq 0 ]]; then
+  require_cmd curl
+  require_cmd openssl
+fi
+
+# Merge an array of new repos into .catalyst.monitor.github.watchRepos in the
+# project config, deduping while preserving insertion order. Creates parent
+# objects as needed.
+merge_watch_repos() {
+  local repos_json="$1"
+  mkdir -p "$(dirname "$PROJECT_CONFIG_PATH")"
+  if [[ ! -f "$PROJECT_CONFIG_PATH" ]]; then
+    echo "{}" > "$PROJECT_CONFIG_PATH"
+  fi
+  local tmp; tmp=$(mktemp)
+  jq --argjson new "$repos_json" '
+    def dedup_preserve_order:
+      reduce .[] as $x ([]; if any(.[]; . == $x) then . else . + [$x] end);
+    .catalyst //= {} |
+    .catalyst.monitor //= {} |
+    .catalyst.monitor.github //= {} |
+    .catalyst.monitor.github.watchRepos =
+      (((.catalyst.monitor.github.watchRepos // []) + $new) | dedup_preserve_order)
+  ' "$PROJECT_CONFIG_PATH" > "$tmp"
+  mv "$tmp" "$PROJECT_CONFIG_PATH"
+}
+
+if [[ $ADD_REPO_ONLY -eq 1 ]]; then
+  repos_json=$(printf '%s\n' "${ADD_REPOS[@]}" | jq -R . | jq -s .)
+  merge_watch_repos "$repos_json"
+  echo "Added ${#ADD_REPOS[@]} repo(s) to catalyst.monitor.github.watchRepos in $PROJECT_CONFIG_PATH"
+  jq -r '.catalyst.monitor.github.watchRepos[]' "$PROJECT_CONFIG_PATH" \
+    | sed 's/^/  • /'
+  exit 0
+fi
 
 read_smee_channel_from() {
   local path="$1"
@@ -149,7 +218,14 @@ if [[ -n "$existing_project_channel" ]]; then
   echo "→ Removed deprecated smeeChannel from $PROJECT_CONFIG_PATH (commit this change)"
 fi
 
-# ─── 6. Print next steps ───────────────────────────────────────────────────
+# ─── 6. Apply --add-repo entries (if combined with normal setup) ────────────
+if [[ ${#ADD_REPOS[@]} -gt 0 ]]; then
+  repos_json=$(printf '%s\n' "${ADD_REPOS[@]}" | jq -R . | jq -s .)
+  merge_watch_repos "$repos_json"
+  echo "Added ${#ADD_REPOS[@]} repo(s) to catalyst.monitor.github.watchRepos"
+fi
+
+# ─── 7. Print next steps ───────────────────────────────────────────────────
 cat <<EOF
 
 Setup complete.

--- a/website/src/content/docs/observability/webhooks.md
+++ b/website/src/content/docs/observability/webhooks.md
@@ -54,10 +54,78 @@ reason. The env-var **name** (`webhookSecretEnv`) is team-wide and lives in
 | smee channel URL | `~/.config/catalyst/config.json` (cross-project, per-machine) or `CATALYST_SMEE_CHANNEL` env | NO | Once at setup |
 | `webhookSecretEnv` (env-var name only) | `.catalyst/config.json` (per-repo, team-wide) | YES | Once at setup |
 | HMAC secret value | env var named by `webhookSecretEnv` (default `CATALYST_WEBHOOK_SECRET`) | NO (per-developer env) | Once at setup |
-| Repo webhook subscription | GitHub repo settings (auto-created via `gh api`) | n/a | Lazily, on first observation of the repo |
+| `watchRepos` (persistent watch list) | `.catalyst/config.json` (per-repo, team-wide) | YES | Optional; once per added repo |
+| Repo webhook subscription | GitHub repo settings (auto-created via `gh api`) | n/a | At startup for `watchRepos` entries; lazily for repos observed via worker signals |
 
 **You do not need to add the smee channel to each repo manually.** The daemon does this for
-you the first time a worker for that repo runs and is observed by the monitor.
+you the first time a worker for that repo runs and is observed by the monitor — or eagerly at
+startup if you list the repo in `watchRepos` (see [Persistent watch list](#persistent-watch-list)
+below).
+
+## Persistent watch list
+
+The default subscription model is **worker-driven**: the daemon registers a webhook on a
+`(owner, repo)` only after it observes a worker signal file referencing that repo. That works
+well for repos you actively orchestrate against, but it leaves a gap for the "always-on
+activity feed" use case — running orch-monitor as a background daemon (auto-start at login)
+and wanting a continuous event stream for your core repos even when no worker is currently
+active for them.
+
+For that, configure `catalyst.monitor.github.watchRepos` in `.catalyst/config.json` (Layer 1,
+team-wide). On daemon startup, after the smee tunnel is up and **before** the 1-hour replay
+window runs, the daemon iterates this list and ensures each repo is subscribed.
+
+`.catalyst/config.json`:
+
+```json
+{
+  "catalyst": {
+    "monitor": {
+      "github": {
+        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET",
+        "watchRepos": [
+          "coalesce-labs/catalyst",
+          "coalesce-labs/adva"
+        ]
+      }
+    }
+  }
+}
+```
+
+To add a repo without hand-editing the JSON, use the helper script:
+
+```bash
+plugins/dev/scripts/setup-webhooks.sh --add-repo coalesce-labs/catalyst
+```
+
+The flag is repeatable (`--add-repo a/b --add-repo c/d`) and idempotent (re-running with the
+same repo doesn't duplicate). When `--add-repo` is the only intent flag, the script skips
+channel/secret setup and just merges the repos into Layer 1 — safe to commit the resulting
+diff.
+
+### Auto-discovery still works alongside it
+
+`watchRepos` is **additive**, not a replacement. Any repo observed in a worker signal file
+still gets subscribed lazily, deduping against the in-memory cache so configured repos that
+later show up in worker signals don't double-subscribe. You can use either path, both, or
+neither — the daemon doesn't care which mechanism added a `(owner, repo)` to its subscription
+set.
+
+### When the gh CLI can't admin a configured repo
+
+If a repo in `watchRepos` is inaccessible to the `gh` CLI's stored token (no admin
+permission, repo doesn't exist, or the token is missing the `admin:repo_hook` scope), hook
+creation fails. The daemon logs a warning and continues — same tolerance as the
+auto-discovery path:
+
+```
+[webhook-subscriber] failed to list hooks for unknown-org/no-access; skipping
+[webhook-subscriber] failed to create hook for unknown-org/no-access; falling back to polling
+```
+
+The 10-minute polling fallback then handles that repo. Fix the token (or remove the repo from
+`watchRepos`) to silence the warning.
 
 ## One-time setup
 
@@ -117,12 +185,16 @@ per-machine reason.
   "catalyst": {
     "monitor": {
       "github": {
-        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET"
+        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET",
+        "watchRepos": []
       }
     }
   }
 }
 ```
+
+`watchRepos` is optional; see [Persistent watch list](#persistent-watch-list) for what it
+does and when to use it. Empty/missing → auto-discovery only.
 
 Override the channel without editing config (useful for ephemeral debugging):
 
@@ -167,14 +239,17 @@ preview-link updates.
    the receiver and continues with polling-only.
 2. The smee tunnel opens, forwarding `https://smee.io/<channel>` →
    `http://localhost:7400/api/webhook`.
-3. For each `(owner, repo)` observed in worker signal files, the daemon calls
+3. For each repo listed in `watchRepos`, the daemon calls
    `gh api repos/{repo}/hooks` and creates a webhook (or reuses an existing one whose
-   `config.url` matches the smee channel — case-insensitive match).
-4. **Replay**: for each subscribed repo, the last hour of webhook deliveries are pulled via
+   `config.url` matches the smee channel — case-insensitive match). This step runs
+   **before** the replay window so configured repos get the 1-hour replay too.
+4. For each `(owner, repo)` observed in worker signal files, the daemon does the same
+   thing — auto-discovery. The subscriber's in-memory cache dedupes against step 3.
+5. **Replay**: for each subscribed repo, the last hour of webhook deliveries are pulled via
    `gh api repos/{repo}/hooks/{id}/deliveries`, signed synthetically (we own the secret),
    and dispatched through the same handler used for live events. The handler dedupes by
    `X-GitHub-Delivery` so deliveries that raced replay don't double-process.
-5. Every accepted webhook event is also appended to
+6. Every accepted webhook event is also appended to
    `~/catalyst/events/YYYY-MM.jsonl` with a topic like `github.pr.merged` —
    see [Event architecture](../events/).
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -329,7 +329,11 @@ team-wide.
   "catalyst": {
     "monitor": {
       "github": {
-        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET"
+        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET",
+        "watchRepos": [
+          "coalesce-labs/catalyst",
+          "coalesce-labs/adva"
+        ]
       }
     }
   }
@@ -340,6 +344,7 @@ team-wide.
 |-------|-------|------|---------|-------------|
 | `catalyst.monitor.github.smeeChannel` | `~/.config/catalyst/config.json` | string | _(none)_ | Per-machine smee.io channel URL the daemon tunnels deliveries through |
 | `catalyst.monitor.github.webhookSecretEnv` | `.catalyst/config.json` | string | `"CATALYST_WEBHOOK_SECRET"` | **Name** of the env var the HMAC secret value is read from at runtime |
+| `catalyst.monitor.github.watchRepos` | `.catalyst/config.json` | string[] | `[]` | Repos (owner/repo) subscribed at daemon startup — additive on top of worker-driven auto-discovery. See [Persistent watch list](/observability/webhooks/#persistent-watch-list). |
 
 Environment variable overrides:
 - `CATALYST_SMEE_CHANNEL` — overrides any file-derived channel.


### PR DESCRIPTION
## What & why

Adds `catalyst.monitor.github.watchRepos` (Layer 1, team-wide) so orch-monitor subscribes to a configured set of repos at startup, in addition to the existing worker-driven auto-discovery. Unblocks the "continuous activity feed" use case — daemon running in the background, you want events for your core repos (catalyst, adva, …) even when no worker is currently active for them.

Both subscription paths share `WebhookSubscriber.ensureSubscribed()`, so configured + auto-discovered repos dedupe through the in-memory cache. Configured subscriptions are awaited via `Promise.allSettled` BEFORE the 1-hour replay window starts so they get the replay too.

Builds on CTL-217 (Wave 1, #341) — extends `loadWebhookConfig` (the single config entry point established by Wave 1) and adds the startup hook in `server.ts` between `webhookTunnel.start()` and the replay window.

## Config shape

```json
// .catalyst/config.json — committed, team-wide
{
  "catalyst": {
    "monitor": {
      "github": {
        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET",
        "watchRepos": ["coalesce-labs/catalyst", "coalesce-labs/adva"]
      }
    }
  }
}
```

## CLI

`setup-webhooks.sh` learns a repeatable `--add-repo <owner/repo>` flag:

```bash
plugins/dev/scripts/setup-webhooks.sh --add-repo coalesce-labs/catalyst
```

- Merges into Layer 1 with insertion-order-preserving dedup
- When `--add-repo` is the only intent flag (no `--force`, no `CATALYST_SMEE_CHANNEL` env), the script skips channel/secret provisioning entirely — safe to run repeatedly without touching the smee tunnel
- Validates `owner/repo` shape; bad input exits non-zero before any config write

## Acceptance (CTL-216)

- [x] `WebhookConfig` accepts `watchRepos: string[]` — extended `WebhookCliConfig` and `FileExtract` in `webhook-config.ts`; Layer 1 only (Layer 2 entries are ignored)
- [x] On startup, AFTER `webhookTunnel.start()`, configured repos are subscribed BEFORE replay — `await Promise.allSettled(...)` chain in `server.ts`
- [x] If a configured repo isn't accessible, failure is logged, daemon continues — covered by existing `ensureSubscribed` tolerance + new test
- [x] Tests: configured repo subscribed at startup with no workers / configured + auto dedupes / missing watchRepos no-op / inaccessible repo tolerated
- [x] `setup-webhooks.sh --add-repo <owner/repo>` works — repeatable, idempotent, validating
- [x] Docs: webhooks.md, configuration.md, orch-monitor README updated

## Test plan

- [x] 9 new unit tests in `webhook-config.test.ts` (parsing, Layer 1 only, dedup, validation, malformed shapes)
- [x] 4 new server-level integration tests in `server.test.ts` (startup hook, dedup with auto-discovery, no-op on empty, fault tolerance)
- [x] 8 new shell tests in `__tests__/setup-webhooks.test.sh` (single/multi-add, idempotent, format rejection, no-network in --add-repo-only mode, insertion-order preservation)
- [x] `bun test`: **1134 pass / 7 fail** (+13 from Wave 1 baseline of 1121/7; 7 fails are pre-existing brittle catalyst-monitor.sh + session-store)
- [x] `bun run typecheck`: clean for orch-monitor; pre-existing `ui/` errors unrelated
- [x] `bun run lint`: clean (1 pre-existing warning in `preview-status.ts`)
- [x] `bash plugins/dev/scripts/__tests__/setup-webhooks.test.sh`: 8/8 pass

## Out of scope

- Linear webhook subscription (CTL-210)
- "Unsubscribe / prune unused webhooks" path
- A `--remove-repo` flag for `setup-webhooks.sh`

Closes CTL-216.