### PR TITLE
feat(dev): catalyst-events CLI + Linear webhooks + event-driven skill migration (CTL-210)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-comms.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-comms.test.sh
@@ -180,6 +180,41 @@ run "messages posted from different cwd visible" bash -c "
   $COMMS poll shared-ch | grep -q 'from other cwd'
 "
 
+# ── 17. send fans out comms.message.posted to global event log (CTL-210) ───
+# A successful send must also append a `comms.message.posted` event to
+# ~/catalyst/events/YYYY-MM.jsonl via catalyst-state.sh. Both stores share
+# $CATALYST_DIR (set by the test harness), so we read events directly.
+reset_comms
+rm -rf "${CATALYST_DIR}/events"
+"$COMMS" join fanout-ch --as alice --ttl 300 > /dev/null
+MSG_ID=$("$COMMS" send fanout-ch "global fan-out test" --as alice --type info)
+EVENTS_FILE="${CATALYST_DIR}/events/$(date -u +%Y-%m).jsonl"
+run "send writes a comms.message.posted line to events.jsonl" bash -c "
+  test -f '$EVENTS_FILE' && grep -q '\"event\":\"comms.message.posted\"' '$EVENTS_FILE'
+"
+run "fan-out event carries the matching msgId in detail" bash -c "
+  jq -e --arg id '$MSG_ID' \
+    'select(.event == \"comms.message.posted\" and .detail.msgId == \$id)' \
+    '$EVENTS_FILE' >/dev/null
+"
+run "fan-out event records channel and type in detail" bash -c "
+  jq -e --arg id '$MSG_ID' \
+    'select(.event == \"comms.message.posted\" and .detail.msgId == \$id)
+       | (.detail.channel == \"fanout-ch\" and .detail.type == \"info\")' \
+    '$EVENTS_FILE' >/dev/null
+"
+
+# ── 18. send still succeeds when catalyst-state.sh is unavailable ──────────
+# Override the resolver to a non-existent path; the send must still work.
+reset_comms
+rm -rf "${CATALYST_DIR}/events"
+"$COMMS" join resilient-ch --as alice --ttl 300 > /dev/null
+CATALYST_STATE_SCRIPT="/dev/null/missing" \
+  "$COMMS" send resilient-ch "no events writer" --as alice --type info >/dev/null
+run "send succeeds when state script unavailable" bash -c "
+  grep -q 'no events writer' '${CATALYST_COMMS_DIR}/channels/resilient-ch.jsonl'
+"
+
 echo ""
 echo "Results: $PASSES passed, $FAILURES failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/catalyst-events.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-events.test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Shell tests for catalyst-events.
+# Run: bash plugins/dev/scripts/__tests__/catalyst-events.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+EVENTS="${REPO_ROOT}/plugins/dev/scripts/catalyst-events"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+export CATALYST_DIR="$SCRATCH"
+export CATALYST_EVENTS_DIR="$SCRATCH/events"
+EVENTS_FILE="$CATALYST_EVENTS_DIR/$(date -u +%Y-%m).jsonl"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+mkdir -p "$CATALYST_EVENTS_DIR"
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+expect_exit() {
+  local expected="$1"; shift
+  "$@" > "${SCRATCH}/out" 2>&1
+  local rc=$?
+  if [ "$rc" = "$expected" ]; then
+    return 0
+  else
+    echo "    expected rc=$expected got rc=$rc"
+    sed 's/^/    /' "${SCRATCH}/out"
+    return 1
+  fi
+}
+
+reset_events() {
+  rm -rf "$CATALYST_EVENTS_DIR"
+  mkdir -p "$CATALYST_EVENTS_DIR"
+  : > "$EVENTS_FILE"
+}
+
+write_event() {
+  echo "$1" >> "$EVENTS_FILE"
+}
+
+echo "catalyst-events tests"
+
+# ── 1. help exits 0 ─────────────────────────────────────────────────────────
+run "help exits 0 and prints usage" bash -c "
+  out=\$($EVENTS help 2>&1)
+  echo \"\$out\" | grep -q 'tail and wait-for'
+"
+
+# ── 2. unknown subcommand exits 2 ───────────────────────────────────────────
+run "unknown subcommand exits 2" expect_exit 2 "$EVENTS" bogus-cmd
+
+# ── 3. wait-for usage error on non-numeric timeout ──────────────────────────
+run "wait-for non-numeric --timeout exits 2" expect_exit 2 "$EVENTS" wait-for --timeout banana
+
+# ── 4. wait-for times out cleanly when no event arrives ─────────────────────
+reset_events
+run "wait-for times out with exit 1" expect_exit 1 "$EVENTS" wait-for --timeout 2
+
+# ── 5. wait-for blocks then unblocks on matching line ───────────────────────
+reset_events
+(
+  sleep 1
+  write_event '{"ts":"2026-05-03T00:00:00Z","event":"worker-status-change","worker":"X","detail":null}'
+) &
+EMITTER_PID=$!
+
+START=$(date +%s)
+OUT=$("$EVENTS" wait-for --timeout 5 --filter '.event == "worker-status-change"')
+RC=$?
+END=$(date +%s)
+ELAPSED=$((END - START))
+
+wait "$EMITTER_PID" 2>/dev/null || true
+
+run "wait-for exits 0 when match arrives" bash -c "[ '$RC' = '0' ]"
+run "wait-for prints the matching line" bash -c "
+  echo '$OUT' | grep -q 'worker-status-change'
+"
+run "wait-for completes in <5s when event arrives early" bash -c "[ '$ELAPSED' -lt 5 ]"
+
+# ── 6. wait-for filter excludes non-matching lines ──────────────────────────
+reset_events
+(
+  sleep 1
+  write_event '{"ts":"2026-05-03T00:00:01Z","event":"heartbeat","detail":null}'
+  sleep 1
+  write_event '{"ts":"2026-05-03T00:00:02Z","event":"target-event","detail":null}'
+) &
+EMITTER_PID=$!
+
+OUT=$("$EVENTS" wait-for --timeout 8 --filter '.event == "target-event"')
+RC=$?
+wait "$EMITTER_PID" 2>/dev/null || true
+
+run "wait-for skips non-matching lines and returns the target" bash -c "
+  [ '$RC' = '0' ] && echo '$OUT' | grep -q 'target-event' && ! echo '$OUT' | grep -q 'heartbeat'
+"
+
+# ── 7. wait-for handles v2 envelope (with .source / .scope) ─────────────────
+reset_events
+(
+  sleep 1
+  write_event '{"ts":"2026-05-03T00:00:00Z","id":"evt_x","schemaVersion":2,"source":"github.webhook","event":"github.pr.merged","scope":{"repo":"a/b","pr":42},"detail":{},"orchestrator":null,"worker":null}'
+) &
+EMITTER_PID=$!
+
+OUT=$("$EVENTS" wait-for --timeout 5 --filter '.event == "github.pr.merged" and .scope.pr == 42')
+RC=$?
+wait "$EMITTER_PID" 2>/dev/null || true
+
+run "wait-for matches v2 envelope by .scope.pr" bash -c "
+  [ '$RC' = '0' ] && echo '$OUT' | grep -q 'github.pr.merged'
+"
+
+# ── 8. wait-for ignores HISTORICAL lines (seek to EOF) ──────────────────────
+reset_events
+write_event '{"ts":"2026-05-03T00:00:00Z","event":"historical-event","detail":null}'
+sleep 0.5  # ensure historical line exists before wait-for opens
+
+# wait-for should NOT match the historical line — it should time out (rc=1).
+run "wait-for seeks to EOF and ignores historical lines" \
+  expect_exit 1 "$EVENTS" wait-for --timeout 2 --filter '.event == "historical-event"'
+
+# ── 9. wait-for survives missing events file (file appears later) ───────────
+reset_events
+rm -f "$EVENTS_FILE"
+(
+  sleep 1
+  mkdir -p "$(dirname "$EVENTS_FILE")"
+  echo '{"ts":"2026-05-03T00:00:00Z","event":"appeared","detail":null}' > "$EVENTS_FILE"
+) &
+EMITTER_PID=$!
+
+OUT=$("$EVENTS" wait-for --timeout 5 --filter '.event == "appeared"')
+RC=$?
+wait "$EMITTER_PID" 2>/dev/null || true
+
+run "wait-for handles file appearing after start" bash -c "
+  [ '$RC' = '0' ] && echo '$OUT' | grep -q 'appeared'
+"
+
+# ── 10. tail emits new lines (run with timeout, kill cleanly) ───────────────
+reset_events
+(
+  sleep 1
+  write_event '{"ts":"2026-05-03T00:00:00Z","event":"new-line-1","detail":null}'
+  sleep 1
+  write_event '{"ts":"2026-05-03T00:00:01Z","event":"new-line-2","detail":null}'
+  sleep 1
+) &
+
+# Capture tail output for a few seconds, then kill.
+TAIL_OUT=$(timeout 4 "$EVENTS" tail --filter '.event | startswith("new-line")' 2>/dev/null || true)
+
+run "tail emits matching new lines" bash -c "
+  echo '$TAIL_OUT' | grep -q 'new-line-1' && echo '$TAIL_OUT' | grep -q 'new-line-2'
+"
+
+# ── 11. tail does NOT emit historical lines ─────────────────────────────────
+reset_events
+write_event '{"ts":"2026-05-03T00:00:00Z","event":"old-line","detail":null}'
+write_event '{"ts":"2026-05-03T00:00:01Z","event":"older-line","detail":null}'
+sleep 0.5
+
+(
+  sleep 1
+  write_event '{"ts":"2026-05-03T00:00:02Z","event":"new-line","detail":null}'
+  sleep 1
+) &
+
+# Filter passes any event that starts with "old", "older", or "new" — wrap each
+# `.event | startswith()` in parens so jq parses precedence correctly.
+TAIL_OUT=$(timeout 4 "$EVENTS" tail --filter '(.event | startswith("o")) or (.event | startswith("n"))' 2>/dev/null || true)
+
+run "tail seeks to EOF, ignoring historical lines" bash -c "
+  echo '$TAIL_OUT' | grep -q 'new-line' && ! echo '$TAIL_OUT' | grep -q 'old-line'
+"
+
+# ── 12. tail with --since-line emits backlog from N onward ──────────────────
+reset_events
+write_event '{"ts":"2026-05-03T00:00:00Z","event":"line-1","detail":null}'
+write_event '{"ts":"2026-05-03T00:00:01Z","event":"line-2","detail":null}'
+write_event '{"ts":"2026-05-03T00:00:02Z","event":"line-3","detail":null}'
+
+# Tail with --since-line 1 should emit lines 2 and 3 (and then keep watching).
+TAIL_OUT=$(timeout 2 "$EVENTS" tail --since-line 1 2>/dev/null || true)
+
+run "tail --since-line 1 emits backlog from line 2 onward" bash -c "
+  ! echo '$TAIL_OUT' | grep -q 'line-1' && echo '$TAIL_OUT' | grep -q 'line-2' && echo '$TAIL_OUT' | grep -q 'line-3'
+"
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo
+echo "Results: $PASSES passed, $FAILURES failed"
+if [ "$FAILURES" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
@@ -199,6 +199,66 @@ test_insertion_order() {
   expect_eq "insertion order" '["a/first","b/second","c/third"]' "$got"
 }
 
+# ─── Test 9 — --linear-secret-env writes to project config (CTL-210) ────────
+test_linear_secret_env() {
+  local env; env=$(make_test_env t9)
+  run_setup "$env" --linear-secret-env MY_LINEAR_SECRET >/dev/null 2>&1
+  local got
+  got=$(jq -r '.catalyst.monitor.linear.webhookSecretEnv' \
+    "${env}/project/.catalyst/config.json")
+  expect_eq "linear secret env name" "MY_LINEAR_SECRET" "$got"
+}
+
+# ─── Test 10 — --linear-secret-env only mode never invokes curl/openssl ─────
+test_linear_no_network() {
+  local env; env=$(make_test_env t10)
+  if ! run_setup "$env" --linear-secret-env CATALYST_LINEAR_WEBHOOK_SECRET \
+      > "${SCRATCH}/t10.out" 2>&1; then
+    echo "expected --linear-secret-env only mode to succeed" >&2
+    cat "${SCRATCH}/t10.out" >&2
+    return 1
+  fi
+  if grep -q "FAIL: curl\|FAIL: openssl" "${SCRATCH}/t10.out"; then
+    echo "--linear-secret-env only mode unexpectedly hit curl/openssl" >&2
+    cat "${SCRATCH}/t10.out" >&2
+    return 1
+  fi
+}
+
+# ─── Test 11 — invalid env-var name rejected ────────────────────────────────
+test_linear_invalid_env_name() {
+  local env; env=$(make_test_env t11)
+  # lowercase letters are not valid in env-var names per our schema
+  if run_setup "$env" --linear-secret-env "lowercase_name" \
+      > "${SCRATCH}/t11.out" 2>&1; then
+    echo "expected non-zero exit for lowercase env-var name" >&2
+    cat "${SCRATCH}/t11.out" >&2
+    return 1
+  fi
+  # Starts-with-digit is also invalid.
+  if run_setup "$env" --linear-secret-env "1FOO" > /dev/null 2>&1; then
+    echo "expected non-zero exit for leading-digit env-var name" >&2
+    return 1
+  fi
+}
+
+# ─── Test 12 — combining --add-repo and --linear-secret-env in one run ──────
+test_combined_flags() {
+  local env; env=$(make_test_env t12)
+  run_setup "$env" \
+    --add-repo coalesce-labs/catalyst \
+    --linear-secret-env CATALYST_LINEAR_WEBHOOK_SECRET >/dev/null 2>&1
+
+  local repos
+  repos=$(read_watch_repos "${env}/project/.catalyst/config.json")
+  expect_eq "watchRepos written" '["coalesce-labs/catalyst"]' "$repos" || return 1
+
+  local linear_env
+  linear_env=$(jq -r '.catalyst.monitor.linear.webhookSecretEnv' \
+    "${env}/project/.catalyst/config.json")
+  expect_eq "linear env preserved" "CATALYST_LINEAR_WEBHOOK_SECRET" "$linear_env"
+}
+
 # ─── Run all ──────────────────────────────────────────────────────────────
 echo "Running setup-webhooks --add-repo tests…"
 run "single add bootstraps watchRepos" test_single_add
@@ -209,6 +269,10 @@ run "empty owner/repo parts rejected" test_empty_parts_rejected
 run "preserves existing webhookSecretEnv" test_preserves_other_fields
 run "no network in --add-repo only mode" test_no_network_in_add_only_mode
 run "preserves insertion order across runs" test_insertion_order
+run "--linear-secret-env writes config" test_linear_secret_env
+run "--linear-secret-env only mode no network" test_linear_no_network
+run "--linear-secret-env invalid name rejected" test_linear_invalid_env_name
+run "combined --add-repo + --linear-secret-env" test_combined_flags
 
 echo
 echo "Passed: $PASSES, Failed: $FAILURES"

--- a/plugins/dev/scripts/catalyst-comms
+++ b/plugins/dev/scripts/catalyst-comms
@@ -230,6 +230,37 @@ cmd_send() {
     --arg who "$name" \
     --arg now "$(now_iso)"
 
+  # Fan-out to the global event log so cross-cutting consumers (catalyst-events
+  # tail, monitor-events skill) can observe comms traffic without subscribing
+  # to every channel file. Best-effort — failures here must NOT fail the send.
+  # Per-channel files remain authoritative for agent-to-agent pub/sub. CTL-210.
+  emit_global_event() {
+    local script="${CATALYST_STATE_SCRIPT:-}"
+    if [[ -z "$script" ]]; then
+      script="$(dirname "${BASH_SOURCE[0]}")/catalyst-state.sh"
+    fi
+    [[ -x "$script" ]] || return 0
+    local envelope
+    envelope=$(jq -nc \
+      --arg ts "$(now_iso)" \
+      --arg event "comms.message.posted" \
+      --arg orch "$orch" \
+      --arg from "$name" \
+      --arg ch "$channel" \
+      --arg type "$type" \
+      --arg id "$id" \
+      --arg to "$to" \
+      '{
+        ts: $ts,
+        event: $event,
+        orchestrator: (if $orch == "" then null else $orch end),
+        worker: $from,
+        detail: { channel: $ch, type: $type, msgId: $id, to: $to }
+      }') || return 0
+    "$script" event "$envelope" >/dev/null 2>&1 || true
+  }
+  emit_global_event || true
+
   echo "$id"
 }
 

--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# catalyst-events — tail and wait-for primitives over the global event log.
+#
+# Reads the append-only JSONL event stream at
+# ${CATALYST_DIR:-$HOME/catalyst}/events/YYYY-MM.jsonl and exposes two consumer
+# patterns:
+#
+#   tail      — long-running follower; prints matching new lines to stdout.
+#   wait-for  — blocks until first matching line arrives, prints it, exits 0.
+#
+# Both seek to EOF on first run so historical heartbeat noise does not skew
+# filters. Both use fswatch when available and fall back to 1 s sleep polling
+# when not (matches the catalyst-comms poll --wait precedent).
+#
+# Topics in the log today include catalyst.* (orchestrator/worker/session),
+# github.* (CTL-209 webhook fan-out), linear.* (CTL-210), and comms.* (CTL-210).
+# v1 envelopes (no `source` field) and v2 envelopes (with `source`,
+# `schemaVersion`, `id`, `scope`) coexist in the same file.
+#
+# Commands:
+#   tail [--filter <jq>] [--since-line <N>]
+#   wait-for [--filter <jq>] [--timeout <sec>]
+#   help
+
+set -uo pipefail
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+EVENTS_DIR="${CATALYST_EVENTS_DIR:-$CATALYST_DIR/events}"
+
+# Resolve the current month's events file. Re-resolved each loop iteration so
+# month rollover is handled transparently.
+events_file_path() {
+  if [[ -n "${CATALYST_EVENTS_FILE:-}" ]]; then
+    echo "$CATALYST_EVENTS_FILE"
+  else
+    echo "$EVENTS_DIR/$(date -u +%Y-%m).jsonl"
+  fi
+}
+
+# Apply a jq predicate filter to a stream. With no filter, pass through.
+# The filter is wrapped in `select(...)` so callers write predicates, not full
+# jq programs. Lines that don't parse as JSON are silently skipped.
+apply_filter() {
+  local filter="$1"
+  if [[ -z "$filter" ]]; then
+    cat
+  else
+    jq -c --unbuffered "select($filter)" 2>/dev/null
+  fi
+}
+
+# Count lines in a file safely (returns 0 if file is missing).
+line_count() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    wc -l < "$file" | tr -d ' '
+  else
+    echo 0
+  fi
+}
+
+# Emit lines from $file starting at 1-indexed line ($start + 1).
+emit_lines_since() {
+  local file="$1" start="$2" filter="$3"
+  if [[ ! -s "$file" ]]; then
+    return 0
+  fi
+  local start_at=$((start + 1))
+  tail -n +"$start_at" "$file" | apply_filter "$filter"
+}
+
+# Wait for the events file to exist. Returns once the file is present, or
+# exits 1 if a deadline is set and reached.
+wait_for_file() {
+  local file="$1" deadline="$2"
+  while [[ ! -f "$file" ]]; do
+    if [[ -n "$deadline" ]] && [[ "$(date +%s)" -ge "$deadline" ]]; then
+      return 1
+    fi
+    sleep 1
+    # Re-resolve in case month rolled over.
+    file="$(events_file_path)"
+  done
+  return 0
+}
+
+cmd_tail() {
+  local filter="" since_line=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --filter)     filter="$2"; shift 2 ;;
+      --since-line) since_line="$2"; shift 2 ;;
+      -h|--help)    cmd_help; return 0 ;;
+      *) echo "error: unknown tail flag: $1" >&2; return 2 ;;
+    esac
+  done
+
+  local file
+  file="$(events_file_path)"
+
+  # Wait up to 5s for the file to exist if missing — tests can race the writer.
+  if [[ ! -f "$file" ]]; then
+    local short_deadline=$(( $(date +%s) + 5 ))
+    wait_for_file "$file" "$short_deadline" || true
+    file="$(events_file_path)"
+  fi
+
+  # Default: seek to EOF so historical lines don't reprint.
+  local last_lines
+  last_lines="$(line_count "$file")"
+  if [[ -n "$since_line" ]]; then
+    last_lines="$since_line"
+    emit_lines_since "$file" "$last_lines" "$filter"
+    last_lines="$(line_count "$file")"
+  fi
+
+  if command -v fswatch >/dev/null 2>&1; then
+    # fswatch -o emits an event count; we re-check line count on each.
+    fswatch -o "$file" 2>/dev/null | while read -r _; do
+      local cur
+      cur="$(line_count "$file")"
+      if [[ "$cur" -gt "$last_lines" ]]; then
+        emit_lines_since "$file" "$last_lines" "$filter"
+        last_lines="$cur"
+      fi
+      # Re-resolve path for month rollover.
+      local new_file
+      new_file="$(events_file_path)"
+      if [[ "$new_file" != "$file" ]]; then
+        file="$new_file"
+        last_lines="$(line_count "$file")"
+      fi
+    done
+  else
+    while :; do
+      sleep 1
+      local cur
+      cur="$(line_count "$file")"
+      if [[ "$cur" -gt "$last_lines" ]]; then
+        emit_lines_since "$file" "$last_lines" "$filter"
+        last_lines="$cur"
+      fi
+      local new_file
+      new_file="$(events_file_path)"
+      if [[ "$new_file" != "$file" ]]; then
+        file="$new_file"
+        last_lines="$(line_count "$file")"
+      fi
+    done
+  fi
+}
+
+cmd_wait_for() {
+  local filter="" timeout="1800"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --filter)  filter="$2"; shift 2 ;;
+      --timeout) timeout="$2"; shift 2 ;;
+      -h|--help) cmd_help; return 0 ;;
+      *) echo "error: unknown wait-for flag: $1" >&2; return 2 ;;
+    esac
+  done
+
+  if ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
+    echo "error: --timeout must be a non-negative integer" >&2
+    return 2
+  fi
+
+  local file
+  file="$(events_file_path)"
+  local deadline=$(( $(date +%s) + timeout ))
+
+  # If the file doesn't exist yet, wait for it AND treat all of its lines as
+  # "new" once it appears (the consumer started before the writer).
+  local file_existed_at_start=1
+  if [[ ! -f "$file" ]]; then
+    file_existed_at_start=0
+  fi
+  if ! wait_for_file "$file" "$deadline"; then
+    return 1
+  fi
+  file="$(events_file_path)"
+
+  # When the file already existed when we started: seek to EOF (skip history).
+  # When the file appeared after we started: start from line 0.
+  local last_lines=0
+  if [[ "$file_existed_at_start" = "1" ]]; then
+    last_lines="$(line_count "$file")"
+  fi
+
+  while :; do
+    if [[ "$(date +%s)" -ge "$deadline" ]]; then
+      return 1
+    fi
+
+    sleep 1
+
+    local cur
+    cur="$(line_count "$file")"
+    if [[ "$cur" -gt "$last_lines" ]]; then
+      local match
+      match="$(emit_lines_since "$file" "$last_lines" "$filter")"
+      if [[ -n "$match" ]]; then
+        # Only emit the FIRST matching line, then exit.
+        echo "$match" | head -n 1
+        return 0
+      fi
+      last_lines="$cur"
+    fi
+
+    local new_file
+    new_file="$(events_file_path)"
+    if [[ "$new_file" != "$file" ]]; then
+      file="$new_file"
+      last_lines="$(line_count "$file")"
+    fi
+  done
+}
+
+cmd_help() {
+  cat <<'EOF'
+catalyst-events — tail and wait-for primitives over the global event log.
+
+Usage:
+  catalyst-events tail [--filter <jq-predicate>] [--since-line <N>]
+  catalyst-events wait-for [--filter <jq-predicate>] [--timeout <sec>]
+  catalyst-events help
+
+Examples:
+  # Tail all GitHub events live
+  catalyst-events tail --filter '.event | startswith("github.")'
+
+  # Tail everything happening to one ticket
+  catalyst-events tail --filter '.scope.ticket == "CTL-210"'
+
+  # Block a worker until its PR is merged
+  catalyst-events wait-for \
+    --filter '.event == "github.pr.merged" and .scope.pr == 342' \
+    --timeout 7200
+
+  # Block until the first failure of any worker in this orchestrator
+  catalyst-events wait-for \
+    --filter '.event == "worker-failed" and .orchestrator == "orch-foo"' \
+    --timeout 600
+
+Environment:
+  CATALYST_DIR          base directory (default: $HOME/catalyst)
+  CATALYST_EVENTS_DIR   events directory (default: $CATALYST_DIR/events)
+  CATALYST_EVENTS_FILE  override file path entirely (used by tests)
+
+Exit codes:
+  0   wait-for: matched a line
+  1   wait-for: timed out
+  2   usage error
+EOF
+}
+
+main() {
+  local cmd="${1:-help}"
+  shift || true
+  case "$cmd" in
+    tail)     cmd_tail "$@" ;;
+    wait-for) cmd_wait_for "$@" ;;
+    help|-h|--help) cmd_help ;;
+    *)
+      echo "error: unknown command: $cmd" >&2
+      cmd_help >&2
+      return 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/plugins/dev/scripts/orch-monitor/README.md
+++ b/plugins/dev/scripts/orch-monitor/README.md
@@ -102,4 +102,33 @@ The monitor subscribes to ten event types per repo:
 | `deployment`                  | (logged; preview state via fallback poll) |
 | `deployment_status`           | (logged; preview state via fallback poll) |
 
+### Linear webhooks (CTL-210)
+
+The monitor also accepts Linear events at `POST /api/webhook/linear` when `monitor.linear.webhookSecretEnv` is configured:
+
+```bash
+plugins/dev/scripts/setup-webhooks.sh --linear-secret-env CATALYST_LINEAR_WEBHOOK_SECRET
+export CATALYST_LINEAR_WEBHOOK_SECRET=<your-linear-webhook-signing-secret>
+```
+
+Linear webhooks must be registered manually via Linear's GraphQL API (no `gh api` equivalent). See the [website docs](https://github.com/coalesce-labs/catalyst/blob/main/website/src/content/docs/observability/webhooks.md#linear-webhooks) for the `webhookCreate` mutation.
+
+Topics emitted to the unified event log:
+
+| Linear `type` + action | Topic |
+|---|---|
+| `Issue` create / update (state, priority, assignee, generic) / remove | `linear.issue.created` / `linear.issue.{state,priority,assignee}_changed` / `linear.issue.updated` / `linear.issue.removed` |
+| `Comment` create / update / remove | `linear.comment.{created,updated,removed}` |
+| `Cycle` create / update / remove | `linear.cycle.{created,updated,removed}` |
+| `Reaction` create / remove | `linear.reaction.{created,removed}` |
+| `IssueLabel` create / update / remove | `linear.issue_label.{created,updated,removed}` |
+
+The signing scheme differs from GitHub's: Linear sends a bare hex digest in the
+`Linear-Signature` header (no `sha256=` prefix), and uses `Linear-Delivery` as the
+idempotency header.
+
+### Event log consumption (CTL-210)
+
+Long-lived consumers (orchestrators, the dashboard, operator shells) tail the unified event log via `catalyst-events tail --filter <jq>`. Short-lived `claude -p` workers block on `catalyst-events wait-for --filter <jq> --timeout <sec>` until a matching event arrives. See the `monitor-events` skill (`plugins/dev/skills/monitor-events/SKILL.md`) for the canonical patterns and the safety-net rule (every wait MUST be paired with an authoritative one-shot check, since daemon-down means no webhook events).
+
 [shadcn]: https://ui.shadcn.com

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "bun:test";
+import { parseLinearWebhookEvent } from "../lib/linear-webhook-events";
+
+function issuePayload(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    action: "update",
+    type: "Issue",
+    data: {
+      id: "issue-uuid-1",
+      identifier: "CTL-210",
+      title: "Build event bus",
+      stateId: "new-state-id",
+      priority: 2,
+      assigneeId: "new-user-id",
+      team: { id: "team-uuid", key: "CTL", name: "Catalyst" },
+    },
+    ...overrides,
+  };
+}
+
+describe("parseLinearWebhookEvent — Issue", () => {
+  it("Issue create → linear.issue.created", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ action: "create", updatedFrom: undefined }),
+    );
+    expect(ev.kind).toBe("issue");
+    if (ev.kind !== "issue") return;
+    expect(ev.action).toBe("create");
+    expect(ev.topic).toBe("linear.issue.created");
+    expect(ev.ticket).toBe("CTL-210");
+    expect(ev.teamKey).toBe("CTL");
+  });
+
+  it("Issue update with stateId in updatedFrom → state_changed", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { stateId: "old-state-id" },
+      }),
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.state_changed");
+    expect(ev.updatedFromKeys).toContain("stateId");
+  });
+
+  it("Issue update with only priority → priority_changed", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ updatedFrom: { priority: 3 } }),
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.priority_changed");
+  });
+
+  it("Issue update with only assigneeId → assignee_changed", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ updatedFrom: { assigneeId: "old-user" } }),
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.assignee_changed");
+  });
+
+  it("Issue update with stateId + priority → state wins (priority order)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: { stateId: "old", priority: 1 },
+      }),
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.state_changed");
+  });
+
+  it("Issue update with no recognized changes → linear.issue.updated", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ updatedFrom: { title: "old title" } }),
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.updated");
+  });
+
+  it("Issue remove → linear.issue.removed", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ action: "remove", updatedFrom: undefined }),
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.topic).toBe("linear.issue.removed");
+  });
+
+  it("Issue with unknown action → ignored", () => {
+    const ev = parseLinearWebhookEvent("Issue", {
+      action: "frobnicate",
+      type: "Issue",
+      data: { identifier: "CTL-1" },
+    });
+    expect(ev.kind).toBe("ignored");
+  });
+
+  it("Issue with no data → ignored", () => {
+    const ev = parseLinearWebhookEvent("Issue", {
+      action: "update",
+      type: "Issue",
+    });
+    expect(ev.kind).toBe("ignored");
+  });
+});
+
+describe("parseLinearWebhookEvent — Comment", () => {
+  it("Comment create → kind comment, action create", () => {
+    const ev = parseLinearWebhookEvent("Comment", {
+      action: "create",
+      type: "Comment",
+      data: {
+        id: "comment-uuid",
+        body: "looks good",
+        issueId: "issue-uuid",
+        issue: { id: "issue-uuid", identifier: "CTL-99" },
+      },
+    });
+    expect(ev.kind).toBe("comment");
+    if (ev.kind !== "comment") return;
+    expect(ev.action).toBe("create");
+    expect(ev.commentId).toBe("comment-uuid");
+    expect(ev.ticket).toBe("CTL-99");
+  });
+
+  it("Comment update → kind comment, action update", () => {
+    const ev = parseLinearWebhookEvent("Comment", {
+      action: "update",
+      type: "Comment",
+      data: { id: "c1", issueId: "i1" },
+    });
+    if (ev.kind !== "comment") throw new Error("expected comment kind");
+    expect(ev.action).toBe("update");
+  });
+
+  it("Comment remove → kind comment, action remove", () => {
+    const ev = parseLinearWebhookEvent("Comment", {
+      action: "remove",
+      type: "Comment",
+      data: { id: "c1", issueId: "i1" },
+    });
+    if (ev.kind !== "comment") throw new Error("expected comment kind");
+    expect(ev.action).toBe("remove");
+  });
+});
+
+describe("parseLinearWebhookEvent — Cycle", () => {
+  it("Cycle update → kind cycle", () => {
+    const ev = parseLinearWebhookEvent("Cycle", {
+      action: "update",
+      type: "Cycle",
+      data: {
+        id: "cycle-1",
+        team: { key: "CTL" },
+        progress: 0.5,
+      },
+    });
+    expect(ev.kind).toBe("cycle");
+    if (ev.kind !== "cycle") return;
+    expect(ev.cycleId).toBe("cycle-1");
+    expect(ev.teamKey).toBe("CTL");
+  });
+});
+
+describe("parseLinearWebhookEvent — Reaction", () => {
+  it("Reaction create → kind reaction", () => {
+    const ev = parseLinearWebhookEvent("Reaction", {
+      action: "create",
+      type: "Reaction",
+      data: { id: "rx-1", emoji: "thumbsup" },
+    });
+    expect(ev.kind).toBe("reaction");
+    if (ev.kind !== "reaction") return;
+    expect(ev.reactionId).toBe("rx-1");
+  });
+});
+
+describe("parseLinearWebhookEvent — IssueLabel", () => {
+  it("IssueLabel create → kind issue_label", () => {
+    const ev = parseLinearWebhookEvent("IssueLabel", {
+      action: "create",
+      type: "IssueLabel",
+      data: { id: "lbl-1", name: "bug" },
+    });
+    expect(ev.kind).toBe("issue_label");
+    if (ev.kind !== "issue_label") return;
+    expect(ev.labelId).toBe("lbl-1");
+  });
+});
+
+describe("parseLinearWebhookEvent — ignored", () => {
+  it("non-object payload → ignored", () => {
+    const ev = parseLinearWebhookEvent("Issue", "not an object");
+    expect(ev.kind).toBe("ignored");
+  });
+
+  it("unknown type → ignored", () => {
+    const ev = parseLinearWebhookEvent("Project", {
+      action: "create",
+      type: "Project",
+      data: { id: "p1" },
+    });
+    expect(ev.kind).toBe("ignored");
+  });
+
+  it("falls back to payload.type when eventName is empty", () => {
+    const ev = parseLinearWebhookEvent("", {
+      action: "create",
+      type: "Issue",
+      data: { identifier: "CTL-1", team: { key: "CTL" } },
+    });
+    expect(ev.kind).toBe("issue");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createHmac } from "node:crypto";
+import {
+  createLinearWebhookHandler,
+  buildLinearEventLogEnvelope,
+  LINEAR_WEBHOOK_SOURCE,
+} from "../lib/linear-webhook-handler";
+import type { EventLogWriter, AppendableEvent } from "../lib/event-log";
+
+const SECRET = "linear-test-secret";
+
+function sign(body: string): string {
+  // Linear: hex digest only, no `sha256=` prefix.
+  return createHmac("sha256", SECRET).update(body).digest("hex");
+}
+
+function makeReq(
+  body: unknown,
+  headers: Partial<{
+    "linear-event": string;
+    "linear-delivery": string;
+    "linear-signature": string;
+  }> = {},
+  method = "POST",
+): Request {
+  const bodyStr = JSON.stringify(body);
+  return new Request("http://localhost:7400/api/webhook/linear", {
+    method,
+    headers: {
+      "linear-event": headers["linear-event"] ?? "Issue",
+      "linear-delivery":
+        headers["linear-delivery"] ?? `linear-delivery-${Math.random()}`,
+      "linear-signature": headers["linear-signature"] ?? sign(bodyStr),
+      "content-type": "application/json",
+    },
+    body: bodyStr,
+  });
+}
+
+class FakeEventLog implements EventLogWriter {
+  appends: AppendableEvent[] = [];
+  failNext = false;
+  append(envelope: AppendableEvent): Promise<void> {
+    if (this.failNext) {
+      this.failNext = false;
+      return Promise.reject(new Error("disk full"));
+    }
+    this.appends.push(envelope);
+    return Promise.resolve();
+  }
+}
+
+function issueUpdatePayload(): unknown {
+  return {
+    action: "update",
+    type: "Issue",
+    data: {
+      id: "issue-uuid",
+      identifier: "CTL-210",
+      stateId: "new-state",
+      team: { key: "CTL" },
+    },
+    updatedFrom: { stateId: "old-state" },
+  };
+}
+
+describe("createLinearWebhookHandler", () => {
+  let eventLog: FakeEventLog;
+
+  beforeEach(() => {
+    eventLog = new FakeEventLog();
+  });
+
+  it("returns 503 when secret is empty", async () => {
+    const handler = createLinearWebhookHandler({ secret: "" });
+    const res = await handler.handle(makeReq(issueUpdatePayload()));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 405 for non-POST", async () => {
+    const handler = createLinearWebhookHandler({ secret: SECRET });
+    const res = await handler.handle(
+      makeReq(issueUpdatePayload(), {}, "GET"),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it("returns 401 for bad signature", async () => {
+    const handler = createLinearWebhookHandler({ secret: SECRET });
+    const res = await handler.handle(
+      makeReq(issueUpdatePayload(), { "linear-signature": "deadbeef" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when event header is missing", async () => {
+    const handler = createLinearWebhookHandler({ secret: SECRET });
+    const res = await handler.handle(
+      makeReq(issueUpdatePayload(), { "linear-event": "" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when delivery header is missing", async () => {
+    const handler = createLinearWebhookHandler({ secret: SECRET });
+    const res = await handler.handle(
+      makeReq(issueUpdatePayload(), { "linear-delivery": "" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const bodyStr = "{not json";
+    const handler = createLinearWebhookHandler({ secret: SECRET });
+    const req = new Request("http://localhost/api/webhook/linear", {
+      method: "POST",
+      headers: {
+        "linear-event": "Issue",
+        "linear-delivery": "delivery-1",
+        "linear-signature": createHmac("sha256", SECRET)
+          .update(bodyStr)
+          .digest("hex"),
+        "content-type": "application/json",
+      },
+      body: bodyStr,
+    });
+    const res = await handler.handle(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("happy path → 200 + envelope written to event log", async () => {
+    const handler = createLinearWebhookHandler({
+      secret: SECRET,
+      eventLog,
+    });
+    const res = await handler.handle(makeReq(issueUpdatePayload()));
+    expect(res.status).toBe(200);
+    expect(eventLog.appends.length).toBe(1);
+    const env = eventLog.appends[0];
+    expect(env).toBeDefined();
+    if (!env) throw new Error("expected event log append");
+    expect(env.source).toBe(LINEAR_WEBHOOK_SOURCE);
+    expect(env.event).toBe("linear.issue.state_changed");
+    expect(env.scope.ticket).toBe("CTL-210");
+    expect(env.id).toMatch(/^evt_linear_/);
+  });
+
+  it("emits to in-process bus on success", async () => {
+    const emitted: Array<{ type: string; data: unknown }> = [];
+    const handler = createLinearWebhookHandler({
+      secret: SECRET,
+      eventLog,
+      emit: (type, data) => emitted.push({ type, data }),
+    });
+    await handler.handle(makeReq(issueUpdatePayload()));
+    expect(emitted.length).toBe(1);
+    expect(emitted[0]?.type).toBe("linear-webhook-event");
+  });
+
+  it("idempotent on replay (same delivery id)", async () => {
+    const handler = createLinearWebhookHandler({
+      secret: SECRET,
+      eventLog,
+    });
+    const deliveryId = "stable-delivery-1";
+    await handler.handle(
+      makeReq(issueUpdatePayload(), { "linear-delivery": deliveryId }),
+    );
+    expect(eventLog.appends.length).toBe(1);
+
+    const res2 = await handler.handle(
+      makeReq(issueUpdatePayload(), { "linear-delivery": deliveryId }),
+    );
+    expect(res2.status).toBe(200);
+    const body = (await res2.json()) as { ok: boolean; replay?: boolean };
+    expect(body.replay).toBe(true);
+    // Replay must NOT produce a second event-log append.
+    expect(eventLog.appends.length).toBe(1);
+  });
+
+  it("event-log failure does not fail the request", async () => {
+    eventLog.failNext = true;
+    const handler = createLinearWebhookHandler({
+      secret: SECRET,
+      eventLog,
+      logger: { warn: () => {} },
+    });
+    const res = await handler.handle(makeReq(issueUpdatePayload()));
+    expect(res.status).toBe(200);
+    expect(eventLog.appends.length).toBe(0);
+  });
+
+  it("ignored events return 200 but write no envelope", async () => {
+    const handler = createLinearWebhookHandler({
+      secret: SECRET,
+      eventLog,
+    });
+    const res = await handler.handle(
+      makeReq(
+        {
+          action: "create",
+          type: "Project",
+          data: { id: "p1" },
+        },
+        { "linear-event": "Project" },
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(eventLog.appends.length).toBe(0);
+  });
+});
+
+describe("buildLinearEventLogEnvelope", () => {
+  it("Issue update → topic from event.topic, scope.ticket from event.ticket", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "update",
+        topic: "linear.issue.state_changed",
+        ticket: "CTL-1",
+        teamKey: "CTL",
+        data: {},
+        updatedFromKeys: ["stateId"],
+      },
+      "delivery-1",
+    );
+    expect(env).not.toBeNull();
+    expect(env?.event).toBe("linear.issue.state_changed");
+    expect(env?.scope.ticket).toBe("CTL-1");
+    expect(env?.id).toBe("evt_linear_delivery-1");
+  });
+
+  it("Comment create → linear.comment.created", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "comment",
+        action: "create",
+        ticket: "CTL-1",
+        commentId: "c1",
+        issueId: "i1",
+        data: {},
+      },
+      "delivery-1",
+    );
+    expect(env?.event).toBe("linear.comment.created");
+  });
+
+  it("Cycle update → linear.cycle.updated", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "cycle",
+        action: "update",
+        cycleId: "c1",
+        teamKey: "CTL",
+        data: {},
+      },
+      "delivery-1",
+    );
+    expect(env?.event).toBe("linear.cycle.updated");
+  });
+
+  it("ignored → null", () => {
+    const env = buildLinearEventLogEnvelope(
+      { kind: "ignored", reason: "test" },
+      "delivery-1",
+    );
+    expect(env).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-verify.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-verify.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "bun:test";
+import { createHmac } from "node:crypto";
+import { verifyLinearSignature } from "../lib/linear-webhook-verify";
+
+function sign(secret: string, body: string | Uint8Array): string {
+  // Linear format: hex digest only, no `sha256=` prefix.
+  return createHmac("sha256", secret)
+    .update(typeof body === "string" ? Buffer.from(body) : body)
+    .digest("hex");
+}
+
+describe("verifyLinearSignature", () => {
+  const secret = "s3cret";
+  const body = Buffer.from(
+    '{"action":"update","type":"Issue","data":{"identifier":"CTL-1"}}',
+  );
+
+  it("returns true for a valid signature", () => {
+    expect(verifyLinearSignature(secret, body, sign(secret, body))).toBe(true);
+  });
+
+  it("returns false when secret does not match", () => {
+    expect(verifyLinearSignature("wrong", body, sign(secret, body))).toBe(false);
+  });
+
+  it("returns false when signature header is null", () => {
+    expect(verifyLinearSignature(secret, body, null)).toBe(false);
+  });
+
+  it("returns false when signature header is empty string", () => {
+    expect(verifyLinearSignature(secret, body, "")).toBe(false);
+  });
+
+  it("returns false when secret is empty string", () => {
+    expect(verifyLinearSignature("", body, sign("anything", body))).toBe(false);
+  });
+
+  it("returns false for length-mismatched header without throwing", () => {
+    expect(verifyLinearSignature(secret, body, "abc123")).toBe(false);
+  });
+
+  it("returns false when body bytes change but signature does not", () => {
+    const validSig = sign(secret, body);
+    const tampered = Buffer.from(
+      '{"action":"update","type":"Issue","data":{"identifier":"CTL-2"}}',
+    );
+    expect(verifyLinearSignature(secret, tampered, validSig)).toBe(false);
+  });
+
+  it("rejects GitHub-style sha256-prefixed signatures", () => {
+    // Linear does NOT use the `sha256=` prefix — a header carrying it must
+    // fail verification rather than silently succeed.
+    const githubStyle = "sha256=" + sign(secret, body);
+    expect(verifyLinearSignature(secret, body, githubStyle)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -1688,3 +1688,83 @@ describe("Webhook config-driven watch list (CTL-216)", () => {
     }
   });
 });
+
+describe("Linear webhook receiver route (/api/webhook/linear) — CTL-210", () => {
+  let linearServer: ReturnType<typeof createServer>;
+  let linearUrl: string;
+  let linearTmp: string;
+
+  beforeAll(() => {
+    linearTmp = mkdtempSync(join(tmpdir(), "linear-webhook-route-"));
+    const wtDir = join(linearTmp, "wt");
+    mkdirSync(wtDir, { recursive: true });
+
+    linearServer = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      annotationsDbPath: join(linearTmp, "annotations.db"),
+      linearWebhookConfig: { secret: "linear-test-secret" },
+    });
+    linearUrl = `http://localhost:${linearServer.port}`;
+  });
+
+  afterAll(() => {
+    void linearServer?.stop(true);
+    try {
+      rmSync(linearTmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("returns 401 (not 404) for POST without signature — route is registered", async () => {
+    const res = await fetch(`${linearUrl}/api/webhook/linear`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-event": "Issue",
+        "linear-delivery": "delivery-1",
+      },
+      body: '{"action":"create","type":"Issue","data":{}}',
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("Linear webhook receiver — disabled (no linearWebhookConfig)", () => {
+  let plainServer: ReturnType<typeof createServer>;
+  let plainUrl: string;
+  let plainTmp: string;
+
+  beforeAll(() => {
+    plainTmp = mkdtempSync(join(tmpdir(), "linear-webhook-disabled-"));
+    const wtDir = join(plainTmp, "wt");
+    mkdirSync(wtDir, { recursive: true });
+    plainServer = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      annotationsDbPath: join(plainTmp, "annotations.db"),
+    });
+    plainUrl = `http://localhost:${plainServer.port}`;
+  });
+
+  afterAll(() => {
+    void plainServer?.stop(true);
+    try {
+      rmSync(plainTmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("returns 503 when linearWebhookConfig is not provided", async () => {
+    const res = await fetch(`${plainUrl}/api/webhook/linear`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(503);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
   delete process.env.CATALYST_WEBHOOK_SECRET;
   delete process.env.CATALYST_SMEE_SECRET;
   delete process.env.CATALYST_SMEE_CHANNEL;
+  delete process.env.CATALYST_LINEAR_WEBHOOK_SECRET;
 });
 
 afterEach(() => {
@@ -30,6 +31,7 @@ afterEach(() => {
   delete process.env.CATALYST_WEBHOOK_SECRET;
   delete process.env.CATALYST_SMEE_SECRET;
   delete process.env.CATALYST_SMEE_CHANNEL;
+  delete process.env.CATALYST_LINEAR_WEBHOOK_SECRET;
 });
 
 function writeProject(json: object): void {
@@ -63,6 +65,7 @@ describe("loadWebhookConfig", () => {
       smeeChannel: "https://smee.io/home-channel",
       secret: "home-secret",
       watchRepos: [],
+      linearSecret: "",
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -88,6 +91,7 @@ describe("loadWebhookConfig", () => {
       smeeChannel: "https://smee.io/legacy-channel",
       secret: "legacy-secret",
       watchRepos: [],
+      linearSecret: "",
     });
     expect(warn).toHaveBeenCalledTimes(1);
     const msg = String(warn.mock.calls[0]?.[0] ?? "");
@@ -121,6 +125,7 @@ describe("loadWebhookConfig", () => {
       smeeChannel: "https://smee.io/home-wins",
       secret: "secret",
       watchRepos: [],
+      linearSecret: "",
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -148,6 +153,7 @@ describe("loadWebhookConfig", () => {
       smeeChannel: "https://smee.io/home",
       secret: "custom-value",
       watchRepos: [],
+      linearSecret: "",
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -169,6 +175,7 @@ describe("loadWebhookConfig", () => {
       smeeChannel: "https://smee.io/env-override",
       secret: "secret",
       watchRepos: [],
+      linearSecret: "",
     });
   });
 
@@ -191,6 +198,7 @@ describe("loadWebhookConfig", () => {
       smeeChannel: "https://smee.io/home",
       secret: "legacy-fallback",
       watchRepos: [],
+      linearSecret: "",
     });
   });
 
@@ -261,6 +269,7 @@ describe("loadWebhookConfig", () => {
       smeeChannel: "https://smee.io/legacy",
       secret: "secret",
       watchRepos: [],
+      linearSecret: "",
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -291,6 +300,7 @@ describe("loadWebhookConfig", () => {
       smeeChannel: "https://smee.io/home",
       secret: "default-secret",
       watchRepos: [],
+      linearSecret: "",
     });
   });
 });
@@ -383,6 +393,7 @@ describe("loadWebhookConfig watchRepos (CTL-216)", () => {
       smeeChannel: "https://smee.io/home",
       secret: "secret",
       watchRepos: ["a/b"],
+      linearSecret: "",
     });
   });
 
@@ -509,5 +520,87 @@ describe("loadWebhookConfig watchRepos (CTL-216)", () => {
     const cfg = loadWebhookConfig(homeDir, projectConfigPath);
 
     expect(cfg!.watchRepos).toEqual(["a/b", "c/d", "e/f"]);
+  });
+});
+
+describe("loadWebhookConfig — Linear webhook secret (CTL-210)", () => {
+  it("resolves linearSecret from the env-var named in Layer 1", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: { webhookSecretEnv: "CATALYST_WEBHOOK_SECRET" },
+          linear: { webhookSecretEnv: "MY_LINEAR_SECRET" },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "github-secret";
+    process.env.MY_LINEAR_SECRET = "linear-from-named-env";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearSecret).toBe("linear-from-named-env");
+
+    delete process.env.MY_LINEAR_SECRET;
+  });
+
+  it("falls back to CATALYST_LINEAR_WEBHOOK_SECRET when no env-var name is configured", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          github: { webhookSecretEnv: "CATALYST_WEBHOOK_SECRET" },
+          linear: {},
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "github-secret";
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "linear-fallback";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSecret).toBe("linear-fallback");
+  });
+
+  it("returns linearSecret as empty string when no Linear config and no env var", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/home" } },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "github-secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSecret).toBe("");
+  });
+
+  it("Linear-only config (no GitHub channel) still loads with smeeChannel/secret empty", () => {
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "MY_LINEAR_SECRET" },
+        },
+      },
+    });
+    process.env.MY_LINEAR_SECRET = "linear-only";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.smeeChannel).toBe("");
+    expect(cfg!.secret).toBe("");
+    expect(cfg!.linearSecret).toBe("linear-only");
+
+    delete process.env.MY_LINEAR_SECRET;
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
@@ -1,0 +1,223 @@
+/**
+ * Type-safe parser from Linear webhook payloads to internal event shapes.
+ *
+ * Linear's webhook envelope is `{ action, type, data, updatedFrom?, … }` —
+ * `action` is "create" | "update" | "remove", `type` is the resource type
+ * (Issue, Comment, Cycle, Reaction, IssueLabel, Project), `data` carries the
+ * full current state, and `updatedFrom` (only on update) carries previous
+ * values of changed fields.
+ *
+ * Topic naming: `linear.<noun>.<verb>` — e.g. `linear.issue.state_changed`,
+ * `linear.comment.created`. For Issue updates we inspect `updatedFrom` keys
+ * to pick the most-specific topic in priority order:
+ *   state > priority > assignee > generic-update.
+ *
+ * Returns `{ kind: "ignored", reason }` for unrecognized types/actions.
+ */
+
+export type LinearWebhookEvent =
+  | {
+      kind: "issue";
+      action: "create" | "update" | "remove";
+      topic: string;
+      ticket: string | null; // e.g. "CTL-210" — from data.identifier
+      teamKey: string | null;
+      data: Record<string, unknown>;
+      updatedFromKeys: string[];
+    }
+  | {
+      kind: "comment";
+      action: "create" | "update" | "remove";
+      ticket: string | null;
+      commentId: string | null;
+      issueId: string | null;
+      data: Record<string, unknown>;
+    }
+  | {
+      kind: "cycle";
+      action: "create" | "update" | "remove";
+      cycleId: string | null;
+      teamKey: string | null;
+      data: Record<string, unknown>;
+    }
+  | {
+      kind: "reaction";
+      action: "create" | "update" | "remove";
+      reactionId: string | null;
+      data: Record<string, unknown>;
+    }
+  | {
+      kind: "issue_label";
+      action: "create" | "update" | "remove";
+      labelId: string | null;
+      data: Record<string, unknown>;
+    }
+  | { kind: "ignored"; reason: string };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getOptStr(
+  obj: Record<string, unknown>,
+  key: string,
+): string | null {
+  const v = obj[key];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function ignored(reason: string): LinearWebhookEvent {
+  return { kind: "ignored", reason };
+}
+
+function normalizeAction(value: unknown): "create" | "update" | "remove" | null {
+  if (value === "create" || value === "update" || value === "remove") {
+    return value;
+  }
+  return null;
+}
+
+function actionLabel(value: unknown): string {
+  return typeof value === "string" ? value : "(non-string)";
+}
+
+/**
+ * Pick the topic for an Issue event based on action and (for updates) the
+ * fields changed in updatedFrom.
+ *
+ * Priority for updates: state > priority > assignee > generic.
+ */
+function issueTopic(
+  action: "create" | "update" | "remove",
+  updatedFromKeys: string[],
+): string {
+  if (action === "create") return "linear.issue.created";
+  if (action === "remove") return "linear.issue.removed";
+  if (updatedFromKeys.includes("stateId")) return "linear.issue.state_changed";
+  if (updatedFromKeys.includes("priority"))
+    return "linear.issue.priority_changed";
+  if (updatedFromKeys.includes("assigneeId"))
+    return "linear.issue.assignee_changed";
+  return "linear.issue.updated";
+}
+
+function teamKeyFromData(data: Record<string, unknown>): string | null {
+  const team = data.team;
+  if (!isObject(team)) return null;
+  return getOptStr(team, "key");
+}
+
+function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
+  const action = normalizeAction(payload.action);
+  if (action === null)
+    return ignored(`Issue: unknown action ${actionLabel(payload.action)}`);
+  const data = isObject(payload.data) ? payload.data : null;
+  if (data === null) return ignored("Issue: missing data");
+  const updatedFrom = isObject(payload.updatedFrom)
+    ? payload.updatedFrom
+    : {};
+  const updatedFromKeys = Object.keys(updatedFrom);
+  return {
+    kind: "issue",
+    action,
+    topic: issueTopic(action, updatedFromKeys),
+    ticket: getOptStr(data, "identifier"),
+    teamKey: teamKeyFromData(data),
+    data,
+    updatedFromKeys,
+  };
+}
+
+function parseComment(payload: Record<string, unknown>): LinearWebhookEvent {
+  const action = normalizeAction(payload.action);
+  if (action === null)
+    return ignored(`Comment: unknown action ${actionLabel(payload.action)}`);
+  const data = isObject(payload.data) ? payload.data : null;
+  if (data === null) return ignored("Comment: missing data");
+  // Linear's Comment payload nests issue identifier under `issue.identifier`
+  // when it expands the relation; older payloads carry just `issueId`.
+  let ticket: string | null = null;
+  if (isObject(data.issue)) {
+    ticket = getOptStr(data.issue, "identifier");
+  }
+  return {
+    kind: "comment",
+    action,
+    ticket,
+    commentId: getOptStr(data, "id"),
+    issueId: getOptStr(data, "issueId"),
+    data,
+  };
+}
+
+function parseCycle(payload: Record<string, unknown>): LinearWebhookEvent {
+  const action = normalizeAction(payload.action);
+  if (action === null)
+    return ignored(`Cycle: unknown action ${actionLabel(payload.action)}`);
+  const data = isObject(payload.data) ? payload.data : null;
+  if (data === null) return ignored("Cycle: missing data");
+  return {
+    kind: "cycle",
+    action,
+    cycleId: getOptStr(data, "id"),
+    teamKey: teamKeyFromData(data),
+    data,
+  };
+}
+
+function parseReaction(payload: Record<string, unknown>): LinearWebhookEvent {
+  const action = normalizeAction(payload.action);
+  if (action === null)
+    return ignored(`Reaction: unknown action ${actionLabel(payload.action)}`);
+  const data = isObject(payload.data) ? payload.data : null;
+  if (data === null) return ignored("Reaction: missing data");
+  return {
+    kind: "reaction",
+    action,
+    reactionId: getOptStr(data, "id"),
+    data,
+  };
+}
+
+function parseIssueLabel(payload: Record<string, unknown>): LinearWebhookEvent {
+  const action = normalizeAction(payload.action);
+  if (action === null)
+    return ignored(`IssueLabel: unknown action ${actionLabel(payload.action)}`);
+  const data = isObject(payload.data) ? payload.data : null;
+  if (data === null) return ignored("IssueLabel: missing data");
+  return {
+    kind: "issue_label",
+    action,
+    labelId: getOptStr(data, "id"),
+    data,
+  };
+}
+
+/**
+ * Parse a Linear webhook payload by `type` (read from the `Linear-Event`
+ * header; passed in by the handler). The payload's own `type` field should
+ * match — we accept either as the dispatch key, preferring the header.
+ */
+export function parseLinearWebhookEvent(
+  eventName: string,
+  payload: unknown,
+): LinearWebhookEvent {
+  if (!isObject(payload)) return ignored("payload is not an object");
+  const payloadType =
+    typeof payload.type === "string" ? payload.type : "";
+  const eventType = eventName.length > 0 ? eventName : payloadType;
+  switch (eventType) {
+    case "Issue":
+      return parseIssue(payload);
+    case "Comment":
+      return parseComment(payload);
+    case "Cycle":
+      return parseCycle(payload);
+    case "Reaction":
+      return parseReaction(payload);
+    case "IssueLabel":
+      return parseIssueLabel(payload);
+    default:
+      return ignored(`unhandled type: ${eventType}`);
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -1,0 +1,212 @@
+import { verifyLinearSignature } from "./linear-webhook-verify";
+import {
+  parseLinearWebhookEvent,
+  type LinearWebhookEvent,
+} from "./linear-webhook-events";
+import {
+  type EventLogWriter,
+  type AppendableEvent,
+} from "./event-log";
+
+export const LINEAR_WEBHOOK_SOURCE = "linear.webhook";
+
+export interface LinearWebhookLogger {
+  info?: (msg: string) => void;
+  warn?: (msg: string) => void;
+  error?: (msg: string) => void;
+}
+
+export interface LinearWebhookHandlerDeps {
+  /** HMAC signing secret. Empty string disables the handler (returns 503). */
+  secret: string;
+  /** Optional pub/sub for SSE fan-out to UI clients. */
+  emit?: (type: string, data: unknown) => void;
+  /** Event-log fan-out — every accepted event is appended here. */
+  eventLog?: EventLogWriter;
+  /** Cap for the in-memory delivery-ID dedup set. Default 1000. */
+  idempotencyMax?: number;
+  logger?: LinearWebhookLogger;
+}
+
+export interface LinearWebhookHandler {
+  handle(req: Request): Promise<Response>;
+  hasSeenDelivery(deliveryId: string): boolean;
+  markDelivery(deliveryId: string): void;
+}
+
+/**
+ * Map a parsed LinearWebhookEvent to a unified-event-log envelope.
+ *
+ * Topic namespace: `linear.<noun>.<verb>` — e.g. `linear.issue.state_changed`,
+ * `linear.comment.created`. Returns null for `kind: "ignored"`.
+ */
+export function buildLinearEventLogEnvelope(
+  event: LinearWebhookEvent,
+  deliveryId: string,
+): AppendableEvent | null {
+  const id = `evt_linear_${deliveryId}`;
+  switch (event.kind) {
+    case "issue":
+      return {
+        id,
+        source: LINEAR_WEBHOOK_SOURCE,
+        event: event.topic,
+        scope: {
+          ticket: event.ticket ?? undefined,
+        },
+        detail: {
+          action: event.action,
+          ticket: event.ticket,
+          teamKey: event.teamKey,
+          updatedFromKeys: event.updatedFromKeys,
+        },
+      };
+    case "comment":
+      return {
+        id,
+        source: LINEAR_WEBHOOK_SOURCE,
+        event: `linear.comment.${event.action}d`,
+        scope: {
+          ticket: event.ticket ?? undefined,
+        },
+        detail: {
+          action: event.action,
+          commentId: event.commentId,
+          issueId: event.issueId,
+          ticket: event.ticket,
+        },
+      };
+    case "cycle":
+      return {
+        id,
+        source: LINEAR_WEBHOOK_SOURCE,
+        event: `linear.cycle.${event.action}d`,
+        scope: {},
+        detail: {
+          action: event.action,
+          cycleId: event.cycleId,
+          teamKey: event.teamKey,
+        },
+      };
+    case "reaction":
+      return {
+        id,
+        source: LINEAR_WEBHOOK_SOURCE,
+        event: `linear.reaction.${event.action}d`,
+        scope: {},
+        detail: {
+          action: event.action,
+          reactionId: event.reactionId,
+        },
+      };
+    case "issue_label":
+      return {
+        id,
+        source: LINEAR_WEBHOOK_SOURCE,
+        event: `linear.issue_label.${event.action}d`,
+        scope: {},
+        detail: {
+          action: event.action,
+          labelId: event.labelId,
+        },
+      };
+    case "ignored":
+      return null;
+  }
+}
+
+export function createLinearWebhookHandler(
+  deps: LinearWebhookHandlerDeps,
+): LinearWebhookHandler {
+  const idempotencyMax = deps.idempotencyMax ?? 1000;
+  const seenDeliveries: string[] = [];
+  const seenDeliveriesSet = new Set<string>();
+  const logger = deps.logger ?? {};
+
+  function rememberDelivery(deliveryId: string): void {
+    if (seenDeliveriesSet.has(deliveryId)) return;
+    seenDeliveriesSet.add(deliveryId);
+    seenDeliveries.push(deliveryId);
+    while (seenDeliveries.length > idempotencyMax) {
+      const oldest = seenDeliveries.shift();
+      if (oldest !== undefined) seenDeliveriesSet.delete(oldest);
+    }
+  }
+
+  async function handle(req: Request): Promise<Response> {
+    if (deps.secret.length === 0) {
+      return new Response("linear webhook secret not configured", {
+        status: 503,
+      });
+    }
+    if (req.method !== "POST") {
+      return new Response("method not allowed", { status: 405 });
+    }
+
+    const rawBody = new Uint8Array(await req.arrayBuffer());
+    const sig = req.headers.get("linear-signature");
+    if (!verifyLinearSignature(deps.secret, rawBody, sig)) {
+      return new Response("signature verification failed", { status: 401 });
+    }
+
+    const eventName = req.headers.get("linear-event") ?? "";
+    const deliveryId = req.headers.get("linear-delivery") ?? "";
+    if (eventName.length === 0 || deliveryId.length === 0) {
+      return new Response("missing event/delivery headers", { status: 400 });
+    }
+
+    if (seenDeliveriesSet.has(deliveryId)) {
+      return new Response(JSON.stringify({ ok: true, replay: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    rememberDelivery(deliveryId);
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(new TextDecoder().decode(rawBody));
+    } catch (err) {
+      logger.warn?.(
+        `[linear-webhook] body parse failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return new Response("invalid json body", { status: 400 });
+    }
+
+    const event = parseLinearWebhookEvent(eventName, payload);
+
+    if (deps.eventLog && event.kind !== "ignored") {
+      const envelope = buildLinearEventLogEnvelope(event, deliveryId);
+      if (envelope !== null) {
+        try {
+          await deps.eventLog.append(envelope);
+        } catch (err) {
+          logger.warn?.(
+            `[linear-webhook] event-log append failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+    }
+
+    deps.emit?.("linear-webhook-event", { event, deliveryId, eventName });
+
+    if (event.kind === "ignored") {
+      logger.info?.(`[linear-webhook] ignored: ${event.reason}`);
+    }
+
+    return new Response(JSON.stringify({ ok: true, kind: event.kind }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  return {
+    handle,
+    hasSeenDelivery: (id) => seenDeliveriesSet.has(id),
+    markDelivery: rememberDelivery,
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-verify.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-verify.ts
@@ -1,0 +1,28 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Verify a Linear webhook HMAC-SHA256 signature.
+ *
+ * Linear sends `Linear-Signature: <hex>` (no `sha256=` prefix, unlike GitHub's
+ * `X-Hub-Signature-256`). The HMAC is computed over the raw request body bytes.
+ */
+export function verifyLinearSignature(
+  secret: string,
+  rawBody: Uint8Array,
+  signatureHeader: string | null,
+): boolean {
+  if (signatureHeader === null || signatureHeader.length === 0) return false;
+  if (secret.length === 0) return false;
+  const expected = createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("hex");
+  if (expected.length !== signatureHeader.length) return false;
+  try {
+    return timingSafeEqual(
+      Buffer.from(expected),
+      Buffer.from(signatureHeader),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -10,12 +10,22 @@ export interface WebhookCliConfig {
    * auto-discovery is the only subscription path. CTL-216.
    */
   watchRepos: string[];
+  /**
+   * Linear webhook signing secret (resolved from
+   * `catalyst.monitor.linear.webhookSecretEnv` env-var name in Layer 1, with
+   * fallback to `CATALYST_LINEAR_WEBHOOK_SECRET`). Empty string when no Linear
+   * config is present — the server then disables `POST /api/webhook/linear`.
+   * CTL-210.
+   */
+  linearSecret: string;
 }
 
 interface FileExtract {
   smeeChannel: string | null;
   webhookSecretEnv: string | null;
   watchRepos: string[];
+  /** Env-var name holding the Linear webhook signing secret (Layer 1). */
+  linearWebhookSecretEnv: string | null;
 }
 
 let warnedDeprecatedSmeeChannel = false;
@@ -73,21 +83,31 @@ function readGithubSection(filePath: string): FileExtract | null {
   if (!isRecord(parsed) || !isRecord(parsed.catalyst)) return null;
   const monitor = parsed.catalyst.monitor;
   if (!isRecord(monitor)) return null;
-  const github = monitor.github;
-  if (!isRecord(github)) return null;
+  const github = isRecord(monitor.github) ? monitor.github : null;
+  const linear = isRecord(monitor.linear) ? monitor.linear : null;
+  if (github === null && linear === null) return null;
 
   const smeeChannel =
-    typeof github.smeeChannel === "string" && github.smeeChannel.length > 0
+    github !== null &&
+    typeof github.smeeChannel === "string" &&
+    github.smeeChannel.length > 0
       ? github.smeeChannel
       : null;
   const webhookSecretEnv =
+    github !== null &&
     typeof github.webhookSecretEnv === "string" &&
     github.webhookSecretEnv.length > 0
       ? github.webhookSecretEnv
       : null;
-  const watchRepos = readWatchRepos(github);
+  const watchRepos = github !== null ? readWatchRepos(github) : [];
+  const linearWebhookSecretEnv =
+    linear !== null &&
+    typeof linear.webhookSecretEnv === "string" &&
+    linear.webhookSecretEnv.length > 0
+      ? linear.webhookSecretEnv
+      : null;
 
-  return { smeeChannel, webhookSecretEnv, watchRepos };
+  return { smeeChannel, webhookSecretEnv, watchRepos, linearWebhookSecretEnv };
 }
 
 /**
@@ -148,6 +168,35 @@ export function loadWebhookConfig(
   // opposite of what we want. CTL-216.
   const watchRepos = projectExtract?.watchRepos ?? [];
 
-  if (finalChannel.length === 0 || secret.length === 0) return null;
-  return { smeeChannel: finalChannel, secret, watchRepos };
+  // Linear webhook secret. Layer 1 carries the env-var name; the value lives
+  // in the env var itself. Optional — empty string disables the Linear route.
+  // CTL-210.
+  const linearWebhookSecretEnv =
+    projectExtract?.linearWebhookSecretEnv ?? null;
+  const linearSecret =
+    (linearWebhookSecretEnv !== null
+      ? process.env[linearWebhookSecretEnv]
+      : undefined) ??
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET ??
+    "";
+
+  // Allow Linear-only configurations: if the GitHub channel/secret are missing
+  // but a Linear secret is present, return a config that disables the GitHub
+  // route but enables the Linear route. CTL-210.
+  if (finalChannel.length === 0 || secret.length === 0) {
+    if (linearSecret.length === 0) return null;
+    return {
+      smeeChannel: "",
+      secret: "",
+      watchRepos,
+      linearSecret,
+    };
+  }
+
+  return {
+    smeeChannel: finalChannel,
+    secret,
+    watchRepos,
+    linearSecret,
+  };
 }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -65,6 +65,10 @@ import {
   type WebhookHandler,
 } from "./lib/webhook-handler";
 import {
+  createLinearWebhookHandler,
+  type LinearWebhookHandler,
+} from "./lib/linear-webhook-handler";
+import {
   createWebhookTunnel,
   type WebhookTunnel,
   type SmeeClientFactory,
@@ -172,6 +176,14 @@ export interface CreateServerOptions {
      * used. Tests pass a stub so no real `gh` is invoked.
      */
     subscriberRunner?: SubscriberRunner;
+  } | null;
+  /**
+   * Linear webhook config. Independent of `webhookConfig` (which carries the
+   * GitHub bits) so a daemon can run Linear-only or GitHub-only setups.
+   * `secret` empty disables `POST /api/webhook/linear`. CTL-210.
+   */
+  linearWebhookConfig?: {
+    secret: string;
   } | null;
 }
 
@@ -410,6 +422,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     annotationsDbPath,
     commsReader: commsReaderOpt,
     webhookConfig,
+    linearWebhookConfig,
   } = opts;
 
   const buildOpts: BuildSnapshotOptions = { dbPath, runsDir };
@@ -539,6 +552,30 @@ export function createServer(opts: CreateServerOptions): BunServer {
       runner: defaultGhRunner,
       handler: webhookHandler,
       secret: webhookConfig.secret,
+      logger: {
+        info: (m) => console.info(m),
+        warn: (m) => console.warn(m),
+        error: (m) => console.error(m),
+      },
+    });
+  }
+
+  // Linear webhook handler — independent of GitHub config so a daemon can run
+  // either or both. Shares the same EventLogWriter when both are present so
+  // GitHub and Linear events interleave in the same monthly file. CTL-210.
+  let linearWebhookHandler: LinearWebhookHandler | null = null;
+  if (linearWebhookConfig && linearWebhookConfig.secret.length > 0) {
+    const linearEventLog: EventLogWriter = createEventLogWriter({
+      catalystDir: CATALYST_DIR,
+      logger: {
+        warn: (m) => console.warn(m),
+        error: (m) => console.error(m),
+      },
+    });
+    linearWebhookHandler = createLinearWebhookHandler({
+      secret: linearWebhookConfig.secret,
+      eventLog: linearEventLog,
+      emit: (type, data) => emit(type, data),
       logger: {
         info: (m) => console.info(m),
         warn: (m) => console.warn(m),
@@ -1133,6 +1170,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
           return webhookHandler.handle(req);
         }
 
+        if (url.pathname === "/api/webhook/linear" && req.method === "POST") {
+          if (!linearWebhookHandler) {
+            return new Response("linear webhook receiver not configured", {
+              status: 503,
+            });
+          }
+          return linearWebhookHandler.handle(req);
+        }
+
         if (url.pathname === "/api/summarize" && req.method === "POST") {
           if (!summarizeHandler) {
             return Response.json(
@@ -1619,10 +1665,24 @@ if (import.meta.main) {
     `${process.cwd()}/.catalyst/config.json`,
   );
 
-  const webhookConfig = loadWebhookConfig(
+  const fullWebhookConfig = loadWebhookConfig(
     process.env.CATALYST_CONFIG_DIR ?? `${process.env.HOME}/.config/catalyst`,
     `${process.cwd()}/.catalyst/config.json`,
   );
+  const webhookConfig =
+    fullWebhookConfig &&
+    fullWebhookConfig.smeeChannel.length > 0 &&
+    fullWebhookConfig.secret.length > 0
+      ? {
+          smeeChannel: fullWebhookConfig.smeeChannel,
+          secret: fullWebhookConfig.secret,
+          watchRepos: fullWebhookConfig.watchRepos,
+        }
+      : null;
+  const linearWebhookConfig =
+    fullWebhookConfig && fullWebhookConfig.linearSecret.length > 0
+      ? { secret: fullWebhookConfig.linearSecret }
+      : null;
   let summarizeHandler: SummarizeHandler | null = null;
   if (summarizeCfg.enabled) {
     const providers: Record<ProviderName, SummarizeProvider> = {
@@ -1664,6 +1724,7 @@ if (import.meta.main) {
       renderOptions: renderOpts,
       summarizeHandler,
       webhookConfig,
+      linearWebhookConfig,
     });
     const displayHost =
       srv.hostname === "0.0.0.0" ? "localhost" : String(srv.hostname);

--- a/plugins/dev/scripts/setup-webhooks.sh
+++ b/plugins/dev/scripts/setup-webhooks.sh
@@ -24,9 +24,12 @@ HOME_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/catalyst"
 HOME_CONFIG_PATH="${HOME_CONFIG_DIR}/config.json"
 SECRET_PATH="${HOME_CONFIG_DIR}/webhook-secret"
 DEFAULT_SECRET_ENV="CATALYST_WEBHOOK_SECRET"
+DEFAULT_LINEAR_SECRET_ENV="CATALYST_LINEAR_WEBHOOK_SECRET"
 FORCE=0
 ADD_REPOS=()
+LINEAR_SECRET_ENV=""
 REPO_SHAPE='^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
+ENV_VAR_SHAPE='^[A-Z_][A-Z0-9_]*$'
 
 usage() {
   cat <<EOF
@@ -44,6 +47,12 @@ Options:
   --add-repo <owner/repo>    Add a repo to catalyst.monitor.github.watchRepos in
                              ${PROJECT_CONFIG_PATH}. Repeatable. When this is the
                              only intent flag, channel/secret setup is skipped.
+  --linear-secret-env <NAME> Write catalyst.monitor.linear.webhookSecretEnv = NAME
+                             to ${PROJECT_CONFIG_PATH}. Default ${DEFAULT_LINEAR_SECRET_ENV}.
+                             When this is the only intent flag, channel/secret
+                             setup for GitHub is skipped. Linear webhooks are
+                             registered manually via Linear's GraphQL API; see
+                             website/src/content/docs/observability/webhooks.md.
   -h|--help                  Show this message
 
 Environment:
@@ -63,6 +72,15 @@ while [[ $# -gt 0 ]]; do
       ADD_REPOS+=("$2")
       shift 2
       ;;
+    --linear-secret-env)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --linear-secret-env requires an argument" >&2
+        usage
+        exit 1
+      fi
+      LINEAR_SECRET_ENV="$2"
+      shift 2
+      ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
   esac
@@ -77,6 +95,15 @@ for repo in "${ADD_REPOS[@]}"; do
   fi
 done
 
+# Validate --linear-secret-env name shape (env-var conventions: uppercase,
+# alphanumeric, underscores, must not start with a digit).
+if [[ -n "$LINEAR_SECRET_ENV" ]]; then
+  if [[ ! "$LINEAR_SECRET_ENV" =~ $ENV_VAR_SHAPE ]]; then
+    echo "ERROR: --linear-secret-env value '$LINEAR_SECRET_ENV' must be a valid env-var name (uppercase letters, digits, underscores; cannot start with a digit)" >&2
+    exit 1
+  fi
+fi
+
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "ERROR: '$1' is required but not installed" >&2
@@ -86,14 +113,18 @@ require_cmd() {
 
 require_cmd jq
 
-# Short-circuit when --add-repo is the only intent flag. The user is asking
-# to update the watch list, not (re)provision channel/secret — which means
-# we don't need curl/openssl and we never call out to the network. Channel
-# setup is a separate user action; the daemon tolerates a missing channel.
-ADD_REPO_ONLY=0
-if [[ ${#ADD_REPOS[@]} -gt 0 && $FORCE -eq 0 && -z "${CATALYST_SMEE_CHANNEL:-}" ]]; then
-  ADD_REPO_ONLY=1
+# Short-circuit when --add-repo and/or --linear-secret-env are the only intent
+# flags. The user is asking to update Layer 1 config, not (re)provision
+# channel/secret — which means we don't need curl/openssl and we never call
+# out to the network. Channel setup is a separate user action; the daemon
+# tolerates a missing channel.
+SKIP_GITHUB_SETUP=0
+if [[ $FORCE -eq 0 && -z "${CATALYST_SMEE_CHANNEL:-}" ]]; then
+  if [[ ${#ADD_REPOS[@]} -gt 0 || -n "$LINEAR_SECRET_ENV" ]]; then
+    SKIP_GITHUB_SETUP=1
+  fi
 fi
+ADD_REPO_ONLY=$SKIP_GITHUB_SETUP
 
 if [[ $ADD_REPO_ONLY -eq 0 ]]; then
   require_cmd curl
@@ -122,12 +153,40 @@ merge_watch_repos() {
   mv "$tmp" "$PROJECT_CONFIG_PATH"
 }
 
-if [[ $ADD_REPO_ONLY -eq 1 ]]; then
-  repos_json=$(printf '%s\n' "${ADD_REPOS[@]}" | jq -R . | jq -s .)
-  merge_watch_repos "$repos_json"
-  echo "Added ${#ADD_REPOS[@]} repo(s) to catalyst.monitor.github.watchRepos in $PROJECT_CONFIG_PATH"
-  jq -r '.catalyst.monitor.github.watchRepos[]' "$PROJECT_CONFIG_PATH" \
-    | sed 's/^/  • /'
+# Write catalyst.monitor.linear.webhookSecretEnv to the project config (Layer 1).
+# Mirrors the GitHub webhookSecretEnv pattern — env-var NAME only, never the
+# value. CTL-210.
+write_linear_secret_env() {
+  local env_name="$1"
+  mkdir -p "$(dirname "$PROJECT_CONFIG_PATH")"
+  if [[ ! -f "$PROJECT_CONFIG_PATH" ]]; then
+    echo "{}" > "$PROJECT_CONFIG_PATH"
+  fi
+  local tmp; tmp=$(mktemp)
+  jq --arg env_name "$env_name" '
+    .catalyst //= {} |
+    .catalyst.monitor //= {} |
+    .catalyst.monitor.linear //= {} |
+    .catalyst.monitor.linear.webhookSecretEnv = $env_name
+  ' "$PROJECT_CONFIG_PATH" > "$tmp"
+  mv "$tmp" "$PROJECT_CONFIG_PATH"
+}
+
+if [[ $SKIP_GITHUB_SETUP -eq 1 ]]; then
+  if [[ ${#ADD_REPOS[@]} -gt 0 ]]; then
+    repos_json=$(printf '%s\n' "${ADD_REPOS[@]}" | jq -R . | jq -s .)
+    merge_watch_repos "$repos_json"
+    echo "Added ${#ADD_REPOS[@]} repo(s) to catalyst.monitor.github.watchRepos in $PROJECT_CONFIG_PATH"
+    jq -r '.catalyst.monitor.github.watchRepos[]' "$PROJECT_CONFIG_PATH" \
+      | sed 's/^/  • /'
+  fi
+  if [[ -n "$LINEAR_SECRET_ENV" ]]; then
+    write_linear_secret_env "$LINEAR_SECRET_ENV"
+    echo "Wrote catalyst.monitor.linear.webhookSecretEnv = $LINEAR_SECRET_ENV to $PROJECT_CONFIG_PATH"
+    echo "  → Set the secret with: export $LINEAR_SECRET_ENV=<your-linear-webhook-signing-secret>"
+    echo "  → Then register the webhook URL with Linear's GraphQL API."
+    echo "  → See website/src/content/docs/observability/webhooks.md for the mutation."
+  fi
   exit 0
 fi
 
@@ -223,6 +282,12 @@ if [[ ${#ADD_REPOS[@]} -gt 0 ]]; then
   repos_json=$(printf '%s\n' "${ADD_REPOS[@]}" | jq -R . | jq -s .)
   merge_watch_repos "$repos_json"
   echo "Added ${#ADD_REPOS[@]} repo(s) to catalyst.monitor.github.watchRepos"
+fi
+
+# ─── 6b. Apply --linear-secret-env (if combined with normal setup) ──────────
+if [[ -n "$LINEAR_SECRET_ENV" ]]; then
+  write_linear_secret_env "$LINEAR_SECRET_ENV"
+  echo "Wrote catalyst.monitor.linear.webhookSecretEnv = $LINEAR_SECRET_ENV"
 fi
 
 # ─── 7. Print next steps ───────────────────────────────────────────────────

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -183,27 +183,44 @@ Or skip tests (not recommended):
 
 Exit with error (unless `--skip-tests` flag provided).
 
-### 6. Diagnose and resolve merge blockers — poll until state=MERGED
+### 6. Diagnose and resolve merge blockers — wait for merge event, then verify
 
 Read and follow the full workflow in
-`"${CLAUDE_PLUGIN_ROOT}/references/merge-blocker-diagnosis.md"`.
+`"${CLAUDE_PLUGIN_ROOT}/references/merge-blocker-diagnosis.md"`. See also the
+`monitor-events` skill for the canonical event-driven wait pattern.
 
-This step is a **poll-until-merged loop**. The loop only exits successfully when
-`state == "MERGED"` and `mergedAt` is non-null. **Always include `sleep 30` between
-iterations** — a tight loop without sleep exhausts GitHub's 5,000/hr GraphQL rate limit
-in minutes.
+This step **waits on the unified event log** for `github.pr.merged` and pairs every
+wake-up with a one-shot `gh pr view` for authoritative verification. The cheap wake-up
+is event-driven; the source of truth is GitHub. CTL-210 replaces the old `sleep 30`
+poll loop — see `plugins/dev/skills/monitor-events/SKILL.md` for the rationale.
 
 ```bash
 while true; do
+  # Wait for the merge event. wait-for is a no-op on event arrival; on
+  # timeout we fall through to the authoritative re-check below. The
+  # 600-second timeout is the fallback cadence when no events arrive (e.g.
+  # daemon down). Empty result on stderr means timed out — that's expected,
+  # don't treat it as a failure.
+  catalyst-events wait-for \
+    --filter ".event == \"github.pr.merged\" and .scope.pr == $pr_number" \
+    --timeout 600 >/dev/null 2>&1 || true
+
+  # MANDATORY authoritative re-check — never trust the event stream as proof
+  # of merge. The wait-for is a wake-up trigger; gh pr view is truth.
   MERGE_STATE=$(gh pr view $pr_number --json state,mergeStateStatus,mergedAt)
   STATE=$(echo "$MERGE_STATE" | jq -r '.state')
   if [ "$STATE" = "MERGED" ]; then
     break
   fi
-  # Diagnose and resolve blockers per the reference doc
-  sleep 30
+  # Diagnose and resolve blockers per the reference doc.
+  # No sleep needed — wait-for already provided the cadence.
 done
 ```
+
+**Why the pairing is mandatory:** if the orch-monitor daemon is down, no GitHub
+webhook events flow into the log, and `wait-for` will block until timeout (600 s).
+The `gh pr view` after timeout is the safety net that keeps the merge confirmation
+correct even when the event stream has dropped.
 
 The reference doc contains:
 

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: monitor-events
+description:
+  Reference for the canonical event-driven wait pattern in Catalyst skills. Use when a skill
+  needs to block on a state change (PR merged, CI completed, push to branch, ticket
+  transitioned) WITHOUT polling. Pairs the `catalyst-events` CLI with the Claude Code
+  `Monitor` tool and `wait-for` for short-lived workers.
+---
+
+# monitor-events — Event-driven waits in skill prose
+
+## What this is for
+
+CTL-210 unified the Catalyst event log: every GitHub webhook, Linear webhook, comms post,
+and orchestrator/worker lifecycle event flows through `~/catalyst/events/YYYY-MM.jsonl`.
+Consumers no longer poll `gh pr view`, `linearis read`, or signal files — they subscribe
+to the event stream via filter.
+
+This skill documents the canonical patterns. Use it as a reference when writing or
+migrating skill prose; do not invoke it as a slash command.
+
+## The two primitives
+
+| Primitive | When | What |
+|---|---|---|
+| `Monitor` | Long-lived in-skill watch | Claude Code built-in tool; runs a background command and surfaces stdout lines as notifications |
+| `catalyst-events wait-for` | Short-lived `claude -p` worker | Bash CLI; blocks until a matching event arrives, prints the line, exits 0 |
+
+Both use `catalyst-events` under the hood. `tail` is the streaming foundation; `wait-for`
+is `tail | head -n 1` with a timeout.
+
+## Pattern 1 — Worker waits for its PR to merge
+
+A `claude -p` worker that just opened PR #342 needs to block until the PR merges, then
+do post-merge work. Use `wait-for`:
+
+```bash
+# Block until github.pr.merged for this PR arrives — up to 2 hours.
+EVENT=$(catalyst-events wait-for \
+  --filter ".event == \"github.pr.merged\" and .scope.pr == ${PR_NUMBER}" \
+  --timeout 7200 || true)
+
+# Mandatory fallback: ALWAYS confirm with an authoritative one-shot check.
+# wait-for can return 0 (matched) or 1 (timed out); both paths must verify.
+MERGE_STATE=$(gh pr view ${PR_NUMBER} --json state)
+STATE=$(echo "$MERGE_STATE" | jq -r '.state')
+if [ "$STATE" = "MERGED" ]; then
+  # Proceed with post-merge work
+fi
+```
+
+**Non-negotiable:** every `wait-for` is paired with an authoritative check. Reasons:
+
+- The orch-monitor daemon may be down. No daemon → no webhook events → `wait-for`
+  blocks until timeout. The `gh pr view` after timeout is the safety net.
+- Transient state can race the event. The webhook may arrive while the worker is doing
+  setup before reaching `wait-for`. The fallback covers that gap too.
+- Filters may not match exactly. `wait-for` returns the first matching line; `gh pr view`
+  returns canonical truth.
+
+## Pattern 2 — Long-lived orchestrator wakes on multiple event types
+
+The orchestrator's Phase 4 used to poll every 2–3 minutes for every active worker. With
+CTL-210, the orchestrator runs a `Monitor` watching all PR/CI/push events, and the
+per-cycle scan drops to 10 minutes maximum:
+
+```text
+Use the `Monitor` tool with this command:
+
+catalyst-events tail --filter '
+  (.event | startswith("github.pr.")) or
+  (.event | startswith("github.check_")) or
+  (.event == "github.push")
+'
+
+When a notification arrives, re-evaluate the affected worker's state via the
+canonical `gh pr view` query. Do NOT trust the event's payload as the source
+of truth — use it only as a wake-up trigger.
+```
+
+The orchestrator continues to maintain its 10-minute fallback scan (defense-in-depth).
+The fast path is event-driven; the slow path is the safety net.
+
+## Pattern 3 — Tail everything happening to a ticket
+
+Useful for live debugging or operator dashboards:
+
+```bash
+catalyst-events tail --filter '.scope.ticket == "CTL-210"'
+```
+
+Captures GitHub PR events scoped to that ticket, Linear webhook events for the issue,
+comms posts where the ticket is the from/parent, and orchestrator/worker lifecycle
+events.
+
+## Filter cookbook
+
+| Need | Filter |
+|---|---|
+| All GitHub webhook events | `.event \| startswith("github.")` |
+| All Linear webhook events | `.event \| startswith("linear.")` |
+| One PR's merge | `.event == "github.pr.merged" and .scope.pr == 342` |
+| Any push to a branch | `.event == "github.push" and .scope.ref == "refs/heads/main"` |
+| CI completion | `.event \| startswith("github.check_suite.")` |
+| Linear ticket state change | `.event == "linear.issue.state_changed" and .scope.ticket == "CTL-210"` |
+| Comms message in one channel | `.event == "comms.message.posted" and .detail.channel == "orch-foo"` |
+| Worker phase transition | `.event == "worker-status-change" and .worker == "CTL-210"` |
+| Attention raised in this orchestrator | `.event == "attention-raised" and .orchestrator == "orch-foo"` |
+
+## `--timeout` semantics
+
+- `wait-for --timeout N` exits 1 after N seconds with no output. The caller decides what
+  to do (usually: run the authoritative one-shot, then either re-invoke `wait-for` or
+  give up).
+- Default timeout is 1800 s (30 min) — long enough for human-paced events, short enough
+  to recover from a daemon crash.
+- For long waits (e.g. PR merge: hours), set `--timeout 7200`. The fallback after timeout
+  re-checks via `gh` and either continues or re-invokes `wait-for`.
+
+## Centralization risk
+
+The event stream is a single point of failure. Mitigations:
+
+1. **Always pair `wait-for` with a one-shot fallback.** No skill prose may say "trust the
+   event stream" — every wait must be paired with an authoritative check.
+2. **The 10-minute fallback poll inside orch-monitor** keeps writing events even when
+   webhook delivery is broken. So daemon-up-but-webhooks-down is recoverable.
+3. **The event log is plain JSONL on the local filesystem.** Anyone with shell access
+   can `tail -F` it; no daemon required for reads.
+4. **Catalyst-origin events** (worker-dispatched, phase-changed, comms.message.posted)
+   are written by writers that don't depend on the daemon. Daemon-down only loses
+   GitHub/Linear webhook events.
+
+## v1 vs v2 envelopes
+
+The event log carries two schemas in the same file:
+
+- **v1** (bash writers, `catalyst-state.sh event`): `{ ts, event, orchestrator, worker, detail }`
+- **v2** (TypeScript writers, webhook receiver, CTL-209+): adds `id`, `schemaVersion: 2`,
+  `source`, `scope` (replacing flat `orchestrator` / `worker` with a nested object;
+  v2 still emits the flat fields too as backward-compat aliases).
+
+Filters that read `.scope.repo` / `.scope.pr` / `.scope.ticket` only match v2 envelopes.
+Filters that read `.event` / `.worker` / `.orchestrator` work for both. Choose based on
+which sources you need to match — webhook events use v2, orchestrator events use v1.
+
+## Quick reference
+
+```bash
+catalyst-events tail [--filter <jq>] [--since-line <N>]
+catalyst-events wait-for [--filter <jq>] [--timeout <sec>]
+
+# Exit codes:
+#   0   wait-for: matched a line (printed to stdout)
+#   1   wait-for: timed out
+#   2   usage error
+```
+
+Environment:
+
+- `CATALYST_DIR` — base directory (default `$HOME/catalyst`)
+- `CATALYST_EVENTS_DIR` — events directory (default `$CATALYST_DIR/events`)
+- `CATALYST_EVENTS_FILE` — override path entirely (used by tests)
+
+## Related skills
+
+- `merge-pr` Phase 6 — uses `wait-for github.pr.merged` (CTL-210 migration)
+- `orchestrate` Phase 4 — uses `Monitor` over `tail` (CTL-210 migration)
+- `catalyst-comms` — agent-to-agent pub/sub on per-channel files; `comms.message.posted`
+  fan-out events go through this same log

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -719,7 +719,35 @@ file says. A worker with a live upstream PR is not stalled even if its signal fi
 When the signal disagrees with git/PR, the orchestrator reconciles the signal from the
 authoritative source.
 
-**Monitoring loop (every 2-3 minutes):**
+**Cadence — event-driven with safety-net fallback (CTL-210):**
+
+The orchestrator runs a `Monitor` watching the unified event log via `catalyst-events
+tail`. The Monitor wakes the orchestrator on every relevant GitHub/Linear/lifecycle
+event, so the per-cycle scan no longer needs to poll on a fixed schedule. The fallback
+cadence is **10 minutes maximum** (instead of 2–3) — this defends against daemon
+downtime and missed events. See `plugins/dev/skills/monitor-events/SKILL.md` for the
+full pattern.
+
+The orchestrator skill prose recommends launching the `Monitor` tool with this
+command before entering the per-cycle scan:
+
+```text
+catalyst-events tail --filter '
+  (.event | startswith("github.pr.")) or
+  (.event | startswith("github.check_")) or
+  (.event == "github.push") or
+  (.event | startswith("linear.issue.")) or
+  (.event == "worker-status-change") or
+  (.event == "attention-raised")
+'
+```
+
+When the Monitor surfaces a notification, the orchestrator runs ONE per-cycle scan
+immediately and then returns to event-driven idle. Every event is treated as a
+**wake-up trigger only** — the scan below uses `gh pr view` / `git rev-list` /
+signal-file reads as the source of truth.
+
+**Per-cycle scan:**
 
 ```bash
 # For each active worker:
@@ -959,10 +987,20 @@ REMEDIATION_EOF
 done
 ```
 
-**Poll cadence**: 60–120s while CI is running (MERGE_STATE in {UNKNOWN, PENDING, BLOCKED}); 30s
-while merge is imminent (MERGE_STATE=CLEAN but not yet MERGED). Since CTL-133, workers exit at
-`status: "merging"` after arming auto-merge — this orchestrator loop is the authoritative merge
-watcher that writes `pr.mergedAt` + `status: "done"` and handles BEHIND/DIRTY/BLOCKED states.
+**Cadence (CTL-210)**: The merge-watcher block runs on every Monitor wake-up plus a
+10-minute safety-net fallback. The Monitor watches `github.pr.merged`, `github.push`,
+`github.check_*`, and `worker-status-change` topics — when any fires, this scan runs
+immediately. Without an event, the fallback runs every ~10 minutes. The scan body is
+unchanged: each `gh pr view` is the canonical truth, the events are wake-up triggers
+only.
+
+For BEHIND/DIRTY recovery: a `github.push` event to the PR's branch signals that an
+auto-merge rebase or worker-driven fixup completed. The orchestrator can re-evaluate
+`mergeStateStatus` immediately on that event instead of waiting for the next cycle.
+
+Since CTL-133, workers exit at `status: "merging"` after arming auto-merge — this
+orchestrator loop is the authoritative merge watcher that writes `pr.mergedAt` +
+`status: "done"` and handles BEHIND/DIRTY/BLOCKED states.
 
 **Poll shared comms channel for attention (CTL-111):**
 

--- a/website/src/content/docs/observability/webhooks.md
+++ b/website/src/content/docs/observability/webhooks.md
@@ -295,3 +295,94 @@ the channel URL as a low-grade secret — anyone with it can post events. Mitiga
 If you need higher assurance (regulated environments, etc.), replace smee with a private
 relay — the tunnel module (`plugins/dev/scripts/orch-monitor/lib/webhook-tunnel.ts`)
 accepts a custom factory you can wire to any EventSource-compatible service.
+
+## Linear webhooks
+
+CTL-210 added a parallel receiver for Linear events. When configured, the daemon exposes
+`POST /api/webhook/linear` and writes Linear-origin events to the same unified event log
+(`~/catalyst/events/YYYY-MM.jsonl`) as GitHub events. Topics use `linear.<noun>.<verb>` —
+e.g. `linear.issue.state_changed`, `linear.comment.created`.
+
+### Configuration
+
+| What | Where | Committed |
+|------|-------|-----------|
+| `webhookSecretEnv` (env-var name only) | `catalyst.monitor.linear.webhookSecretEnv` in `.catalyst/config.json` | YES |
+| HMAC secret value | env var named above (default fallback `CATALYST_LINEAR_WEBHOOK_SECRET`) | NO (per-developer env) |
+
+Run `setup-webhooks.sh --linear-secret-env CATALYST_LINEAR_WEBHOOK_SECRET` to write the
+env-var name to `.catalyst/config.json`. Then `export CATALYST_LINEAR_WEBHOOK_SECRET=<your-secret>`
+in your shell rc file. Linear webhooks share the same Layer 1 / Layer 2 split as GitHub:
+team-wide config in `.catalyst/config.json`, per-developer values in environment.
+
+### Registering the webhook with Linear
+
+Linear webhooks are NOT auto-registered — there is no equivalent to the `gh api`
+auto-discovery used for GitHub. Register manually via Linear's GraphQL API:
+
+```graphql
+mutation {
+  webhookCreate(input: {
+    url: "https://your-public-host/api/webhook/linear"
+    label: "Catalyst orch-monitor"
+    teamId: "<your-team-uuid>"
+    resourceTypes: ["Issue", "Comment", "Cycle", "Reaction", "IssueLabel"]
+  }) {
+    success
+    webhook {
+      id
+      secret    # store this — needed for Linear-Signature verification
+      enabled
+    }
+  }
+}
+```
+
+Run via the [Linear API Explorer](https://studio.apollographql.com/public/Linear-API/home).
+The `secret` field is returned exactly once — store it immediately as the value of
+your `CATALYST_LINEAR_WEBHOOK_SECRET` env var.
+
+For local development, use a public tunnel (`cloudflared tunnel`, `ngrok`, etc.) to expose
+`http://localhost:7400/api/webhook/linear` to the internet. Linear cannot deliver to a
+smee.io URL the way GitHub can, because Linear webhooks require a stable HTTPS endpoint.
+
+### Signing scheme
+
+| | GitHub | Linear |
+|---|---|---|
+| Header | `X-Hub-Signature-256` | `Linear-Signature` |
+| Format | `sha256=<hex>` | `<hex>` (no prefix) |
+| Algorithm | HMAC-SHA256 over raw body | HMAC-SHA256 over raw body |
+| Delivery ID header | `X-GitHub-Delivery` | `Linear-Delivery` |
+
+### Event topics
+
+| Linear `type` + `action` (and changed fields) | Topic emitted |
+|---|---|
+| `Issue` create | `linear.issue.created` |
+| `Issue` update + `stateId` changed | `linear.issue.state_changed` |
+| `Issue` update + `priority` changed | `linear.issue.priority_changed` |
+| `Issue` update + `assigneeId` changed | `linear.issue.assignee_changed` |
+| `Issue` update (other fields only) | `linear.issue.updated` |
+| `Issue` remove | `linear.issue.removed` |
+| `Comment` create / update / remove | `linear.comment.{created,updated,removed}` |
+| `Cycle` create / update / remove | `linear.cycle.{created,updated,removed}` |
+| `Reaction` create / remove | `linear.reaction.{created,removed}` |
+| `IssueLabel` create / update / remove | `linear.issue_label.{created,updated,removed}` |
+
+For Issue updates with multiple changed fields, the topic is selected by priority order:
+state > priority > assignee > generic. This matches the GitHub PR pattern of one event
+per delivery.
+
+`IssueRelation` is not in Linear's webhook resourceTypes and is not received.
+
+### Testing the receiver
+
+```bash
+# After configuring the secret and starting the daemon:
+catalyst-events tail --filter '.event | startswith("linear.")'
+
+# In another shell, cause a Linear ticket state change.
+# The first shell should print the matching event line within seconds.
+```
+

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -334,6 +334,9 @@ team-wide.
           "coalesce-labs/catalyst",
           "coalesce-labs/adva"
         ]
+      },
+      "linear": {
+        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET"
       }
     }
   }
@@ -345,11 +348,14 @@ team-wide.
 | `catalyst.monitor.github.smeeChannel` | `~/.config/catalyst/config.json` | string | _(none)_ | Per-machine smee.io channel URL the daemon tunnels deliveries through |
 | `catalyst.monitor.github.webhookSecretEnv` | `.catalyst/config.json` | string | `"CATALYST_WEBHOOK_SECRET"` | **Name** of the env var the HMAC secret value is read from at runtime |
 | `catalyst.monitor.github.watchRepos` | `.catalyst/config.json` | string[] | `[]` | Repos (owner/repo) subscribed at daemon startup — additive on top of worker-driven auto-discovery. See [Persistent watch list](/observability/webhooks/#persistent-watch-list). |
+| `catalyst.monitor.linear.webhookSecretEnv` | `.catalyst/config.json` | string | `"CATALYST_LINEAR_WEBHOOK_SECRET"` | **Name** of the env var the Linear HMAC secret is read from. Empty/missing → `POST /api/webhook/linear` returns 503. See [Linear webhooks](/observability/webhooks/#linear-webhooks). |
 
 Environment variable overrides:
 - `CATALYST_SMEE_CHANNEL` — overrides any file-derived channel.
 - The env var named by `webhookSecretEnv` (default `CATALYST_WEBHOOK_SECRET`) holds the
-  shared HMAC secret value.
+  shared GitHub HMAC secret value.
+- The env var named by `monitor.linear.webhookSecretEnv` (default fallback
+  `CATALYST_LINEAR_WEBHOOK_SECRET`) holds the Linear HMAC secret value.
 
 If the channel is missing from both files (and unset in env), the receiver disables itself
 silently and the daemon falls back to 10-minute polling. Run `plugins/dev/scripts/setup-webhooks.sh`


### PR DESCRIPTION
Closes CTL-210. Builds on CTL-209's GitHub webhook seed (#330) and CTL-217/CTL-216's
Layer 1/Layer 2 config split (#341/#342). Six deliverables in one PR — the largest
ticket in this run (5pt) — but the migration deliverable (#5) is what makes the
WHOLE pipeline stop polling.

## What ships

### 1. `catalyst-events` CLI

`plugins/dev/scripts/catalyst-events` — `tail` + `wait-for` primitives over
the unified event log. Mirrors `catalyst-comms` shape. fswatch when
available; falls back to 1 s sleep polling. Both seek to EOF on first run so
historical heartbeats don't skew filters. `wait-for` correctly handles a
freshly-created file (consumer started before writer).

```bash
# Block until github.pr.merged for PR 342 — up to 2 hours
catalyst-events wait-for \
  --filter '.event == "github.pr.merged" and .scope.pr == 342' \
  --timeout 7200

# Tail everything happening to a ticket across GitHub/Linear/comms/lifecycle
catalyst-events tail --filter '.scope.ticket == "CTL-210"'
```

### 2. Linear webhook receiver

`POST /api/webhook/linear` route on the orch-monitor server. HMAC-SHA256
verification of `Linear-Signature` (bare hex, no `sha256=` prefix — different
from GitHub). Event parser maps Linear's `{action, type, updatedFrom}`
envelope to topics by priority order:

| Linear `type` + action + changed fields | Topic |
|---|---|
| `Issue` create | `linear.issue.created` |
| `Issue` update + `stateId` | `linear.issue.state_changed` |
| `Issue` update + `priority` | `linear.issue.priority_changed` |
| `Issue` update + `assigneeId` | `linear.issue.assignee_changed` |
| `Issue` update (other) | `linear.issue.updated` |
| `Comment` / `Cycle` / `Reaction` / `IssueLabel` | `linear.<noun>.<verb>` |

Multiple fields changed → most-specific wins (state > priority > assignee >
generic). One event per delivery. `IssueRelation` is not in Linear's
resourceTypes and is dropped from scope.

### 3. catalyst-comms internal fan-out

`catalyst-comms send` now also emits a `comms.message.posted` event to the
global log. Best-effort — failures must not fail the send (regression test
included). Per-channel files remain authoritative for agent-to-agent
pub/sub; the global mirror gives cross-cutting visibility.

### 4. `monitor-events` skill

`plugins/dev/skills/monitor-events/SKILL.md` — documents the canonical
event-driven wait pattern: `Monitor` for long-lived in-skill watches,
`wait-for` for short-lived `claude -p` workers. Includes the
**non-negotiable safety rule**: every wait MUST be paired with an
authoritative one-shot fallback, since daemon-down means no webhook events
flow.

### 5. Skill polling-loop migration (THE deliverable)

The user's primary motivation for this orchestration. Three concrete
migrations:

- **`merge-pr` Phase 6**: `while true; gh pr view; sleep 30` →
  `catalyst-events wait-for --filter github.pr.merged --timeout 600`
  paired with `gh pr view` for truth.
- **`orchestrate` Phase 4**: documented `Monitor` over `catalyst-events
  tail` filtering on `(github.pr.* | github.check_* | github.push |
  linear.issue.* | worker-status-change | attention-raised)`. Per-cycle
  cadence drops from 2-3 min to 10 min as safety-net only.
- **`orchestrate` BEHIND/DIRTY recovery**: documented `github.push` as the
  event-driven trigger.

Each migration keeps the authoritative `gh pr view` for verification —
event arrival is a wake-up, not a source of truth.

### 6. `setup-webhooks.sh --linear-secret-env`

Adds the Layer 1 `monitor.linear.webhookSecretEnv` field. Combined-flag
mode supported (`--add-repo` + `--linear-secret-env` in one run).
Linear webhooks must be registered manually via Linear's GraphQL API
(`webhookCreate` mutation) — `linearis` doesn't expose webhook CRUD.
Setup docs cover the GraphQL flow.

## Test summary

- **1189 pass / 6 fail** — matches Wave 2 baseline (6 catalyst-monitor.sh
  process-spawn tests, brittle, pre-existing).
- **54 new tests**: 14 catalyst-events bash, 8 linear-verify, 18
  linear-events, 15 linear-handler, 4 server route + config, 4 setup-webhooks
  linear/combined, 4 catalyst-comms fan-out.
- **Type check clean.** **Lint clean** (1 pre-existing security warning in
  preview-status.ts, not new).
- All bash test suites green: catalyst-events 14/14, catalyst-comms 28/28
  (was 24, +4 fan-out), setup-webhooks 12/12 (was 8, +4 linear/combined).

## Out of scope

- UI activity feed (CTL-210 lists as optional; deferred to follow-up).
- `IssueRelation` (not in Linear's webhook resourceTypes).
- `linearis`-based auto-registration (requires admin GraphQL; manual for v1).
- `linear.ts` polling cache (kept; CTL-211 will rewrite worker lifecycle).

## Test plan

- [x] Type-check passes
- [x] Lint passes (no new warnings)
- [x] All 54 new tests pass
- [x] Test parity baseline preserved (1189/6 matches Wave 2)
- [x] Skill prose is bash-syntax-clean
- [ ] Manual smoke: tail + wait-for + Linear webhook end-to-end (depends on
      Linear webhook registration, which is per-machine setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)