### PR TITLE
feat(dev): persist Linear webhook registration to Layer 2 (CTL-238)

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+# Shell tests for setup-linear-webhook.sh (CTL-238).
+#
+# CTL-238 adds Layer 2 record persistence for Linear webhook registration:
+# after webhookCreate succeeds, the helper writes
+# catalyst.monitor.linear.{webhookId,webhookUrl,registeredAt,resourceTypes}
+# to ~/.config/catalyst/config.json. Re-running with the same URL no-ops
+# based on the local record (no Linear API call). --linear-deregister
+# reads the local record to call webhookDelete and clears it.
+#
+# Test approach: stub `curl` with a script that:
+#   • routes by GraphQL query name (parses stdin JSON .query)
+#   • returns a canned response for each operation
+#   • appends each call to ${CURL_LOG} for assertions on call count
+#
+# Lives separately from setup-linear-webhook.test.sh (CTL-224's tests)
+# because the two files use different curl-stub strategies — main's tests
+# route via fixture files in `curl-fixtures/`, this file routes via
+# STUB_RESPONSE_* env vars. Both pass against the same helper.
+#
+# Run: bash plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/scripts/setup-linear-webhook.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# ─── Test environment builder ──────────────────────────────────────────────
+# Builds: ${SCRATCH}/${name}/{home/.config/catalyst, project/.catalyst, stubbin}
+# - .catalyst/config.json pre-seeded with projectKey + linear.teamId
+# - ~/.config/catalyst/config-${PROJECT_KEY}.json pre-seeded with linear.apiToken
+# - stubbin/curl: routes by GraphQL query name; logs to ${CURL_LOG}
+make_test_env() {
+  local name="$1"
+  local dir="${SCRATCH}/${name}"
+  mkdir -p "${dir}/home/.config/catalyst"
+  mkdir -p "${dir}/project/.catalyst"
+  mkdir -p "${dir}/stubbin"
+
+  # Layer 1 config: projectKey + teamId
+  cat > "${dir}/project/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "test-project",
+    "linear": {
+      "teamId": "11111111-2222-3333-4444-555555555555"
+    }
+  }
+}
+EOF
+
+  # Layer 2 secrets: linear.apiToken
+  cat > "${dir}/home/.config/catalyst/config-test-project.json" <<'EOF'
+{
+  "linear": {
+    "apiToken": "test_lin_api_token_xxxxxxxxxxxxxxxx"
+  }
+}
+EOF
+
+  # Curl stub. Routes by .query string.
+  cat > "${dir}/stubbin/curl" <<'EOF'
+#!/usr/bin/env bash
+# Read entire stdin (the JSON payload curl was sent via -d @-).
+PAYLOAD=$(cat)
+QUERY=$(printf '%s' "$PAYLOAD" | jq -r '.query // ""' 2>/dev/null)
+[ -n "${CURL_LOG:-}" ] && {
+  case "$QUERY" in
+    *webhookCreate*) echo "create" >> "$CURL_LOG" ;;
+    *webhookDelete*) echo "delete" >> "$CURL_LOG" ;;
+    *webhooks*) echo "list" >> "$CURL_LOG" ;;
+    *) echo "unknown" >> "$CURL_LOG" ;;
+  esac
+}
+case "$QUERY" in
+  *webhookCreate*)
+    cat "${STUB_RESPONSE_CREATE:-/dev/null}"
+    ;;
+  *webhookDelete*)
+    cat "${STUB_RESPONSE_DELETE:-/dev/null}"
+    ;;
+  *webhooks*)
+    cat "${STUB_RESPONSE_LIST:-/dev/null}"
+    ;;
+  *)
+    echo "STUB CURL: unknown query: $QUERY" >&2
+    exit 87
+    ;;
+esac
+EOF
+  chmod +x "${dir}/stubbin/curl"
+
+  echo "$dir"
+}
+
+# Run the helper script with fake $HOME, project cwd, and stubbed curl.
+run_helper() {
+  local env_dir="$1"; shift
+  ( cd "${env_dir}/project" && \
+    HOME="${env_dir}/home" \
+    XDG_CONFIG_HOME="${env_dir}/home/.config" \
+    PATH="${env_dir}/stubbin:${PATH}" \
+    CURL_LOG="${env_dir}/curl-calls.log" \
+    STUB_RESPONSE_LIST="${STUB_RESPONSE_LIST:-/dev/null}" \
+    STUB_RESPONSE_CREATE="${STUB_RESPONSE_CREATE:-/dev/null}" \
+    STUB_RESPONSE_DELETE="${STUB_RESPONSE_DELETE:-/dev/null}" \
+    bash "$HELPER" "$@" )
+}
+
+# Read the Linear Layer 2 record as compact JSON ("" if absent).
+read_layer2() {
+  local env_dir="$1"
+  local path="${env_dir}/home/.config/catalyst/config.json"
+  [[ -f "$path" ]] || { echo ""; return 0; }
+  jq -c '.catalyst.monitor.linear // empty' "$path" 2>/dev/null
+}
+
+# Count calls of a given type ("list", "create", "delete") in the log.
+count_calls() {
+  local env_dir="$1" type="$2"
+  local log="${env_dir}/curl-calls.log"
+  [[ -f "$log" ]] || { echo 0; return 0; }
+  # grep -c prints the count and exits non-zero when count is 0; using `|| true`
+  # would still preserve the printed "0" but we'd re-echo. Capture once instead.
+  local n
+  n=$(grep -c "^${type}$" "$log" 2>/dev/null || true)
+  echo "${n:-0}"
+}
+
+# Total curl calls (any type).
+total_calls() {
+  local env_dir="$1"
+  local log="${env_dir}/curl-calls.log"
+  [[ -f "$log" ]] || { echo 0; return 0; }
+  wc -l < "$log" | tr -d ' '
+}
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+expect_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "expected ($label): $expected" >&2
+    echo "actual:   $actual" >&2
+    return 1
+  fi
+}
+
+# ─── Canned GraphQL responses ──────────────────────────────────────────────
+# Each test sets up which response files curl will return for which operation.
+
+write_response_create_success() {
+  local file="$1" id="$2" url="$3"
+  cat > "$file" <<EOF
+{
+  "data": {
+    "webhookCreate": {
+      "success": true,
+      "webhook": {
+        "id": "$id",
+        "secret": "secret_$id",
+        "enabled": true,
+        "url": "$url"
+      }
+    }
+  }
+}
+EOF
+}
+
+write_response_delete_success() {
+  local file="$1"
+  cat > "$file" <<'EOF'
+{ "data": { "webhookDelete": { "success": true } } }
+EOF
+}
+
+write_response_list_empty() {
+  local file="$1"
+  cat > "$file" <<'EOF'
+{ "data": { "webhooks": { "nodes": [] } } }
+EOF
+}
+
+write_response_list_one() {
+  local file="$1" id="$2" url="$3"
+  cat > "$file" <<EOF
+{
+  "data": {
+    "webhooks": {
+      "nodes": [
+        { "id": "$id", "url": "$url", "label": "Catalyst orch-monitor", "enabled": true }
+      ]
+    }
+  }
+}
+EOF
+}
+
+# ─── Test 1 — fresh registration writes Layer 2 record ─────────────────────
+test_register_writes_layer2_record() {
+  local env; env=$(make_test_env t1)
+  local CR_RESP="${env}/create.json" LIST_RESP="${env}/list.json"
+  write_response_create_success "$CR_RESP" "w1" "https://foo.test/api/webhook/linear"
+  write_response_list_empty "$LIST_RESP"
+  STUB_RESPONSE_CREATE="$CR_RESP" \
+  STUB_RESPONSE_LIST="$LIST_RESP" \
+  run_helper "$env" --webhook-url "https://foo.test/api/webhook/linear" >/dev/null 2>&1 || return 1
+
+  local rec; rec=$(read_layer2 "$env")
+  [[ -n "$rec" ]] || { echo "Layer 2 record missing"; return 1; }
+  local id; id=$(printf '%s' "$rec" | jq -r '.webhookId')
+  local url; url=$(printf '%s' "$rec" | jq -r '.webhookUrl')
+  local ts; ts=$(printf '%s' "$rec" | jq -r '.registeredAt')
+  local rt; rt=$(printf '%s' "$rec" | jq -c '.resourceTypes')
+  expect_eq "webhookId" "w1" "$id" || return 1
+  expect_eq "webhookUrl" "https://foo.test/api/webhook/linear" "$url" || return 1
+  # ISO-8601 UTC timestamp shape
+  if ! [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    echo "registeredAt malformed: $ts"; return 1
+  fi
+  expect_eq "resourceTypes" '["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]' "$rt" || return 1
+}
+
+# ─── Test 2 — idempotent re-run with same URL: no API call ─────────────────
+test_idempotent_rerun_no_api_call() {
+  local env; env=$(make_test_env t2)
+  # Pre-seed Layer 2 record.
+  cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "webhookId": "w1",
+        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "registeredAt": "2026-05-04T20:00:00Z",
+        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+      }
+    }
+  }
+}
+EOF
+  # Run with same URL; no STUB_RESPONSE_* set so any curl call returns empty.
+  run_helper "$env" --webhook-url "https://foo.test/api/webhook/linear" >/dev/null 2>&1 || return 1
+
+  local n; n=$(total_calls "$env")
+  expect_eq "total curl calls" "0" "$n" || return 1
+
+  # Layer 2 record unchanged — webhookId still w1.
+  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  expect_eq "record unchanged" "w1" "$id" || return 1
+}
+
+# ─── Test 3 — different URL without --force errors ─────────────────────────
+test_rerun_different_url_errors_without_force() {
+  local env; env=$(make_test_env t3)
+  cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "webhookId": "w1",
+        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "registeredAt": "2026-05-04T20:00:00Z",
+        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+      }
+    }
+  }
+}
+EOF
+  if run_helper "$env" --webhook-url "https://bar.test/api/webhook/linear" \
+       > "${SCRATCH}/t3.out" 2>&1; then
+    echo "expected non-zero exit when re-registering different URL without --force" >&2
+    cat "${SCRATCH}/t3.out" >&2
+    return 1
+  fi
+  # Record must be unchanged.
+  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  expect_eq "record unchanged" "w1" "$id" || return 1
+  # No Linear API call should happen.
+  local n; n=$(total_calls "$env")
+  expect_eq "total curl calls" "0" "$n" || return 1
+}
+
+# ─── Test 4 — --force overwrites: delete old, create new ───────────────────
+test_force_overwrites_layer2_record() {
+  local env; env=$(make_test_env t4)
+  cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "webhookId": "w1",
+        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "registeredAt": "2026-05-04T20:00:00Z",
+        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+      }
+    }
+  }
+}
+EOF
+  local DEL_RESP="${env}/del.json" CR_RESP="${env}/cr.json"
+  write_response_delete_success "$DEL_RESP"
+  write_response_create_success "$CR_RESP" "w2" "https://bar.test/api/webhook/linear"
+  STUB_RESPONSE_DELETE="$DEL_RESP" \
+  STUB_RESPONSE_CREATE="$CR_RESP" \
+  run_helper "$env" --webhook-url "https://bar.test/api/webhook/linear" --force \
+    >/dev/null 2>&1 || return 1
+
+  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  local url; url=$(read_layer2 "$env" | jq -r '.webhookUrl')
+  expect_eq "webhookId now w2" "w2" "$id" || return 1
+  expect_eq "webhookUrl now bar" "https://bar.test/api/webhook/linear" "$url" || return 1
+
+  # Exactly one delete + one create. NO list call (Layer 2 short-circuit avoids it).
+  expect_eq "delete count" "1" "$(count_calls "$env" delete)" || return 1
+  expect_eq "create count" "1" "$(count_calls "$env" create)" || return 1
+  expect_eq "list count" "0" "$(count_calls "$env" list)" || return 1
+}
+
+# ─── Test 5 — --deregister uses Layer 2 ID and clears record ───────────────
+test_deregister_uses_layer2_id() {
+  local env; env=$(make_test_env t5)
+  cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "webhookId": "w1",
+        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "registeredAt": "2026-05-04T20:00:00Z",
+        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+      }
+    }
+  }
+}
+EOF
+  # Pre-seed the secret file so we can verify it's removed.
+  echo "old_secret" > "${env}/home/.config/catalyst/linear-webhook-secret"
+
+  local DEL_RESP="${env}/del.json"
+  write_response_delete_success "$DEL_RESP"
+  STUB_RESPONSE_DELETE="$DEL_RESP" \
+  run_helper "$env" --deregister >/dev/null 2>&1 || return 1
+
+  # Layer 2 record cleared.
+  local rec; rec=$(read_layer2 "$env")
+  [[ -z "$rec" || "$rec" == "null" ]] || { echo "Layer 2 record not cleared: $rec"; return 1; }
+
+  # Secret file removed.
+  if [[ -f "${env}/home/.config/catalyst/linear-webhook-secret" ]]; then
+    echo "linear-webhook-secret should be removed"
+    return 1
+  fi
+
+  # Exactly one delete call.
+  expect_eq "delete count" "1" "$(count_calls "$env" delete)" || return 1
+  expect_eq "list count" "0" "$(count_calls "$env" list)" || return 1
+}
+
+# ─── Test 6 — --deregister with no record errors ───────────────────────────
+test_deregister_no_record_errors() {
+  local env; env=$(make_test_env t6)
+  if run_helper "$env" --deregister > "${SCRATCH}/t6.out" 2>&1; then
+    echo "expected non-zero exit when deregister has no record" >&2
+    cat "${SCRATCH}/t6.out" >&2
+    return 1
+  fi
+  # No curl call attempted.
+  local n; n=$(total_calls "$env")
+  expect_eq "total curl calls" "0" "$n" || return 1
+}
+
+# ─── Test 7 — fall back to API when Layer 2 missing (no existing webhook) ──
+test_register_falls_back_to_api_when_layer2_missing() {
+  local env; env=$(make_test_env t7)
+  local LIST_RESP="${env}/list.json" CR_RESP="${env}/cr.json"
+  write_response_list_empty "$LIST_RESP"
+  write_response_create_success "$CR_RESP" "w1" "https://foo.test/api/webhook/linear"
+  STUB_RESPONSE_LIST="$LIST_RESP" \
+  STUB_RESPONSE_CREATE="$CR_RESP" \
+  run_helper "$env" --webhook-url "https://foo.test/api/webhook/linear" \
+    >/dev/null 2>&1 || return 1
+
+  # Layer 2 record now populated.
+  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  expect_eq "webhookId" "w1" "$id" || return 1
+
+  # API was called: list + create (no Layer 2 short-circuit available).
+  expect_eq "list count" "1" "$(count_calls "$env" list)" || return 1
+  expect_eq "create count" "1" "$(count_calls "$env" create)" || return 1
+}
+
+# ─── Test 8 — fall back to API list-dedup when Layer 2 missing but URL exists ──
+test_register_falls_back_to_api_dedup_when_layer2_missing() {
+  local env; env=$(make_test_env t8)
+  local LIST_RESP="${env}/list.json"
+  write_response_list_one "$LIST_RESP" "wOld" "https://foo.test/api/webhook/linear"
+  STUB_RESPONSE_LIST="$LIST_RESP" \
+  run_helper "$env" --webhook-url "https://foo.test/api/webhook/linear" \
+    >/dev/null 2>&1 || return 1
+
+  # No create call (existing reused), no delete.
+  expect_eq "list count" "1" "$(count_calls "$env" list)" || return 1
+  expect_eq "create count" "0" "$(count_calls "$env" create)" || return 1
+  expect_eq "delete count" "0" "$(count_calls "$env" delete)" || return 1
+
+  # Layer 2 record written with the discovered ID; resourceTypes omitted
+  # because we couldn't observe them from a list response.
+  local rec; rec=$(read_layer2 "$env")
+  local id; id=$(printf '%s' "$rec" | jq -r '.webhookId')
+  local url; url=$(printf '%s' "$rec" | jq -r '.webhookUrl')
+  expect_eq "webhookId from list" "wOld" "$id" || return 1
+  expect_eq "webhookUrl from list" "https://foo.test/api/webhook/linear" "$url" || return 1
+  # resourceTypes should be absent (we don't fabricate them).
+  local has_rt; has_rt=$(printf '%s' "$rec" | jq 'has("resourceTypes")')
+  expect_eq "resourceTypes absent" "false" "$has_rt" || return 1
+}
+
+# ─── Run all ──────────────────────────────────────────────────────────────
+echo "Running setup-linear-webhook tests…"
+run "register writes Layer 2 record" test_register_writes_layer2_record
+run "idempotent re-run makes no API call" test_idempotent_rerun_no_api_call
+run "different URL without --force errors" test_rerun_different_url_errors_without_force
+run "--force deletes old + creates new" test_force_overwrites_layer2_record
+run "--deregister clears Layer 2 + secret" test_deregister_uses_layer2_id
+run "--deregister with no record errors" test_deregister_no_record_errors
+run "Layer 2 missing → API list+create" test_register_falls_back_to_api_when_layer2_missing
+run "Layer 2 missing → API list dedup" test_register_falls_back_to_api_dedup_when_layer2_missing
+
+echo
+echo "Passed: $PASSES, Failed: $FAILURES"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
@@ -408,6 +408,37 @@ test_combined_add_repo_and_linear_register() {
   fi
 }
 
+# ─── Test 17 — --linear-register and --linear-deregister are mutex (CTL-238) ──
+test_linear_register_deregister_mutex() {
+  local env; env=$(make_test_env t17)
+  if run_setup "$env" --linear-register --linear-deregister --webhook-url https://x/ \
+       > "${SCRATCH}/t17.out" 2>&1; then
+    echo "expected non-zero exit for register + deregister combination" >&2
+    cat "${SCRATCH}/t17.out" >&2
+    return 1
+  fi
+  if ! grep -q "mutually exclusive" "${SCRATCH}/t17.out"; then
+    echo "expected mutex error message" >&2
+    cat "${SCRATCH}/t17.out" >&2
+    return 1
+  fi
+}
+
+# ─── Test 18 — --linear-deregister only-mode skips GitHub setup (CTL-238) ───
+test_linear_deregister_only_skips_github_setup() {
+  local env; env=$(make_test_env t18)
+  # Run will likely fail (no Layer 2 record present) but the point of this
+  # test is that setup-webhooks.sh did NOT run smee channel provisioning —
+  # i.e., the FAIL: curl/openssl marker from the smee channel call never
+  # appears in the output.
+  run_setup "$env" --linear-deregister > "${SCRATCH}/t18.out" 2>&1 || true
+  if grep -q "FAIL: curl invoked during --add-repo-only mode\|FAIL: openssl" "${SCRATCH}/t18.out"; then
+    echo "--linear-deregister only-mode unexpectedly hit smee channel setup" >&2
+    cat "${SCRATCH}/t18.out" >&2
+    return 1
+  fi
+}
+
 # ─── Run all ──────────────────────────────────────────────────────────────
 echo "Running setup-webhooks --add-repo tests…"
 run "single add bootstraps watchRepos" test_single_add
@@ -426,6 +457,8 @@ run "--linear-register requires --webhook-url" test_linear_register_requires_web
 run "--webhook-url must be https://" test_webhook_url_must_be_https
 run "--linear-register only mode skips GitHub setup" test_linear_register_only_skips_github
 run "combined --add-repo + --linear-register" test_combined_add_repo_and_linear_register
+run "--linear-register/-deregister mutex" test_linear_register_deregister_mutex
+run "--linear-deregister only-mode skips GitHub setup" test_linear_deregister_only_skips_github_setup
 
 echo
 echo "Passed: $PASSES, Failed: $FAILURES"

--- a/plugins/dev/scripts/setup-linear-webhook.sh
+++ b/plugins/dev/scripts/setup-linear-webhook.sh
@@ -1,18 +1,14 @@
 #!/usr/bin/env bash
-# setup-linear-webhook.sh — register a Linear webhook for orch-monitor (CTL-224).
+# setup-linear-webhook.sh — register/deregister a Linear webhook for orch-monitor.
 #
-# Reads Layer 1 .catalyst/config.json for catalyst.projectKey +
-# catalyst.linear.teamId, and Layer 2 ~/.config/catalyst/config-<projectKey>.json
-# for linear.apiToken. Issues GraphQL against Linear's API to:
+# CTL-224 introduced the GraphQL plumbing. CTL-238 added Layer 2 record
+# persistence: after webhookCreate succeeds, the helper writes
+# catalyst.monitor.linear.{webhookId,webhookUrl,registeredAt,resourceTypes}
+# to ~/.config/catalyst/config.json so re-runs decide idempotency locally and
+# --deregister has a clean handle to call webhookDelete with.
 #
-#   1. List existing webhooks; if one matches the target URL (case-insensitive)
-#      and --force is not set, no-op.
-#   2. With --force, webhookDelete the matching one.
-#   3. webhookCreate with the canonical 6 resourceTypes
-#      (Issue, Comment, IssueLabel, Cycle, Reaction, Project).
-#   4. Persist webhook.secret to ~/.config/catalyst/linear-webhook-secret
-#      (mode 600), mirroring the GitHub-side webhook-secret file.
-#   5. Print the `export ${SECRET_ENV}=...` line for the user's shell rc.
+# Reads Layer 1 .catalyst/config.json for catalyst.projectKey + catalyst.linear.teamId,
+# and Layer 2 ~/.config/catalyst/config-<projectKey>.json for linear.apiToken.
 #
 # Linear-side counterpart of webhookSubscriber.ensureSubscribed in
 # plugins/dev/scripts/orch-monitor/lib/webhook-subscriber.ts. Auth pattern
@@ -22,32 +18,44 @@ set -uo pipefail
 
 WEBHOOK_URL=""
 FORCE=0
+DEREGISTER=0
 SECRET_ENV="CATALYST_LINEAR_WEBHOOK_SECRET"
 CONFIG_PATH=".catalyst/config.json"
 LABEL="Catalyst orch-monitor"
 LINEAR_GRAPHQL_ENDPOINT="${LINEAR_GRAPHQL_ENDPOINT:-https://api.linear.app/graphql}"
+
+# Canonical Linear resource types — matches the receiver in
+# plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts.
+RESOURCE_TYPES=("Issue" "Comment" "IssueLabel" "Cycle" "Reaction" "Project")
 
 usage() {
   cat <<EOF
 Usage: $(basename "$0") --webhook-url <https-url> [--force]
                         [--secret-env <NAME>] [--config <path>]
                         [--label <text>]
+       $(basename "$0") --deregister [--config <path>]
 
-Registers a Linear webhook idempotently for orch-monitor.
+Registers (or deregisters) a Linear webhook idempotently for orch-monitor.
 
-Required:
+Register:
   --webhook-url <url>     Public HTTPS URL where Linear should deliver events
                           (e.g. https://your-tunnel/api/webhook/linear).
+  --force                 Delete existing webhook and recreate.
 
-Optional:
-  --force                 Delete existing matching webhook and recreate.
+Deregister:
+  --deregister            Read the webhookId from the Layer 2 record, call
+                          webhookDelete, clear the record, remove the local
+                          secret file.
+
+Common options:
   --secret-env <NAME>     Env-var name printed in the export line.
                           Default: CATALYST_LINEAR_WEBHOOK_SECRET
   --config <path>         Layer 1 config path. Default: .catalyst/config.json
   --label <text>          Linear webhook label. Default: "Catalyst orch-monitor"
 
 Reads Layer 2 secret from ~/.config/catalyst/config-<projectKey>.json
-(.linear.apiToken).
+(.linear.apiToken). On register success, writes the registration record
+to ~/.config/catalyst/config.json under catalyst.monitor.linear.
 EOF
 }
 
@@ -59,6 +67,7 @@ while [[ $# -gt 0 ]]; do
       fi
       WEBHOOK_URL="$2"; shift 2 ;;
     --force) FORCE=1; shift ;;
+    --deregister) DEREGISTER=1; shift ;;
     --secret-env)
       if [[ $# -lt 2 || -z "${2:-}" ]]; then
         echo "ERROR: --secret-env requires a value" >&2; exit 1
@@ -79,13 +88,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$WEBHOOK_URL" ]]; then
-  echo "ERROR: --webhook-url is required" >&2
+if [[ $DEREGISTER -eq 0 && -z "$WEBHOOK_URL" ]]; then
+  echo "ERROR: --webhook-url is required (or pass --deregister)" >&2
   usage >&2
   exit 1
 fi
+if [[ $DEREGISTER -eq 1 && -n "$WEBHOOK_URL" ]]; then
+  echo "ERROR: --deregister and --webhook-url are mutually exclusive" >&2
+  exit 1
+fi
 
-if [[ ! "$WEBHOOK_URL" =~ ^https:// ]]; then
+if [[ -n "$WEBHOOK_URL" && ! "$WEBHOOK_URL" =~ ^https:// ]]; then
   echo "ERROR: --webhook-url must start with https:// (got: $WEBHOOK_URL)" >&2
   exit 1
 fi
@@ -98,7 +111,6 @@ require_cmd() {
 }
 
 require_cmd jq
-require_cmd curl
 
 # ─── Read Layer 1 (.catalyst/config.json) ──────────────────────────────────
 if [[ ! -f "$CONFIG_PATH" ]]; then
@@ -112,29 +124,87 @@ if [[ -z "$PROJECT_KEY" ]]; then
   exit 1
 fi
 
-TEAM_ID=$(jq -r '.catalyst.linear.teamId // empty' "$CONFIG_PATH" 2>/dev/null)
-if [[ -z "$TEAM_ID" ]]; then
-  echo "ERROR: catalyst.linear.teamId not set in $CONFIG_PATH." >&2
-  echo "       Run plugins/dev/scripts/resolve-linear-ids.sh first to populate it." >&2
-  exit 1
-fi
-
-# ─── Read Layer 2 secrets (~/.config/catalyst/config-<projectKey>.json) ────
+# Layer 2 paths.
 HOME_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/catalyst"
+HOME_CONFIG_PATH="${HOME_CONFIG_DIR}/config.json"
 SECRETS_PATH="${HOME_CONFIG_DIR}/config-${PROJECT_KEY}.json"
-if [[ ! -f "$SECRETS_PATH" ]]; then
-  echo "ERROR: Layer 2 secrets file not found at $SECRETS_PATH" >&2
-  echo "       Add a 'linear.apiToken' field there (a personal API key from Linear)." >&2
-  exit 1
-fi
+SECRET_FILE="${HOME_CONFIG_DIR}/linear-webhook-secret"
 
-API_TOKEN=$(jq -r '.linear.apiToken // empty' "$SECRETS_PATH" 2>/dev/null)
-if [[ -z "$API_TOKEN" ]]; then
-  echo "ERROR: linear.apiToken not found in $SECRETS_PATH" >&2
-  exit 1
-fi
+# ─── Layer 2 record helpers (CTL-238) ──────────────────────────────────────
 
-# ─── GraphQL helper ─────────────────────────────────────────────────────────
+# Read the Linear registration record from Layer 2 (~/.config/catalyst/config.json).
+# Outputs compact JSON or empty string when no usable record exists. A "usable"
+# record requires non-empty webhookId AND webhookUrl — partial records are ignored.
+read_linear_record() {
+  [[ -f "$HOME_CONFIG_PATH" ]] || { echo ""; return 0; }
+  jq -c '
+    .catalyst.monitor.linear // empty
+    | if (.webhookId // "") != "" and (.webhookUrl // "") != ""
+      then .
+      else empty
+      end
+  ' "$HOME_CONFIG_PATH" 2>/dev/null
+}
+
+# Write the registration record. Pass resourceTypes as a JSON array string;
+# empty array ([]) means "unknown — omit the field" so partial records from
+# the API-list-dedup branch don't fabricate resource types.
+write_linear_record() {
+  local webhook_id="$1" webhook_url="$2" resource_types_json="$3"
+  local timestamp; timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "$HOME_CONFIG_DIR"
+  [[ -f "$HOME_CONFIG_PATH" ]] || echo "{}" > "$HOME_CONFIG_PATH"
+  local tmp; tmp=$(mktemp)
+  jq --arg id "$webhook_id" --arg url "$webhook_url" --arg ts "$timestamp" \
+     --argjson rt "$resource_types_json" '
+       .catalyst //= {}
+       | .catalyst.monitor //= {}
+       | .catalyst.monitor.linear //= {}
+       | .catalyst.monitor.linear.webhookId = $id
+       | .catalyst.monitor.linear.webhookUrl = $url
+       | .catalyst.monitor.linear.registeredAt = $ts
+       | if ($rt | length) > 0
+         then .catalyst.monitor.linear.resourceTypes = $rt
+         else .catalyst.monitor.linear |= del(.resourceTypes)
+         end
+     ' "$HOME_CONFIG_PATH" > "$tmp"
+  mv "$tmp" "$HOME_CONFIG_PATH"
+}
+
+# Clear the Linear registration record, preserving any sibling Layer 2 keys.
+clear_linear_record() {
+  [[ -f "$HOME_CONFIG_PATH" ]] || return 0
+  local tmp; tmp=$(mktemp)
+  jq '
+    if (.catalyst.monitor.linear // null) != null
+    then .catalyst.monitor.linear |= del(.webhookId, .webhookUrl, .registeredAt, .resourceTypes)
+         | if (.catalyst.monitor.linear // {}) == {} then del(.catalyst.monitor.linear) else . end
+         | if (.catalyst.monitor // {}) == {} then del(.catalyst.monitor) else . end
+         | if (.catalyst // {}) == {} then del(.catalyst) else . end
+    else .
+    end
+  ' "$HOME_CONFIG_PATH" > "$tmp"
+  mv "$tmp" "$HOME_CONFIG_PATH"
+}
+
+# ─── Linear API auth + GraphQL helpers ─────────────────────────────────────
+# Lazy: we only require curl and the API token when we actually need to make
+# a call. The Layer 2 short-circuit on register and the deregister-with-no-
+# record path both exit before reaching this point.
+load_api_token() {
+  require_cmd curl
+  if [[ ! -f "$SECRETS_PATH" ]]; then
+    echo "ERROR: Layer 2 secrets file not found at $SECRETS_PATH" >&2
+    echo "       Add a 'linear.apiToken' field there (a personal API key from Linear)." >&2
+    exit 1
+  fi
+  API_TOKEN=$(jq -r '.linear.apiToken // empty' "$SECRETS_PATH" 2>/dev/null)
+  if [[ -z "$API_TOKEN" ]]; then
+    echo "ERROR: linear.apiToken not found in $SECRETS_PATH" >&2
+    exit 1
+  fi
+}
+
 linear_graphql() {
   local query="$1"
   local variables="${2:-{\}}"
@@ -156,46 +226,134 @@ surface_graphql_errors() {
   fi
 }
 
-# ─── List existing webhooks ─────────────────────────────────────────────────
-LIST_QUERY='query { webhooks { nodes { id url label enabled } } }'
-LIST_RESP=$(linear_graphql "$LIST_QUERY" '{}' 2>&1) || {
-  echo "ERROR: Linear API call (list webhooks) failed" >&2
-  [[ -n "$LIST_RESP" ]] && echo "$LIST_RESP" >&2
-  exit 2
+delete_via_graphql() {
+  local id="$1"
+  # $id below is a GraphQL variable inside a single-quoted query, not a shell var.
+  # shellcheck disable=SC2016
+  local query='mutation($id:String!){webhookDelete(id:$id){success}}'
+  local vars; vars=$(jq -nc --arg id "$id" '{id:$id}')
+  local resp; resp=$(linear_graphql "$query" "$vars" 2>&1) || {
+    echo "ERROR: Linear API call (delete) failed" >&2
+    [[ -n "$resp" ]] && echo "$resp" >&2
+    exit 2
+  }
+  surface_graphql_errors "$resp" "delete"
+  local success; success=$(printf '%s' "$resp" | jq -r '.data.webhookDelete.success // false')
+  if [[ "$success" != "true" ]]; then
+    echo "ERROR: webhookDelete returned success=false" >&2
+    echo "Response: $resp" >&2
+    exit 2
+  fi
 }
-surface_graphql_errors "$LIST_RESP" "list"
 
-TARGET_URL_LC=$(printf '%s' "$WEBHOOK_URL" | tr '[:upper:]' '[:lower:]')
-EXISTING_ID=$(printf '%s' "$LIST_RESP" | jq -r --arg url "$TARGET_URL_LC" \
-  '.data.webhooks.nodes[]? | select((.url // "" | ascii_downcase) == $url) | .id' \
-  2>/dev/null | head -1)
-
-if [[ -n "$EXISTING_ID" && "$FORCE" -eq 0 ]]; then
-  echo "Reusing existing webhook $EXISTING_ID for $WEBHOOK_URL"
-  echo "  (use --force to delete and recreate; secret cannot be re-fetched)"
+# ─── --deregister branch ───────────────────────────────────────────────────
+if [[ $DEREGISTER -eq 1 ]]; then
+  EXISTING_RECORD="$(read_linear_record)"
+  if [[ -z "$EXISTING_RECORD" ]]; then
+    echo "ERROR: no Linear webhook record found in $HOME_CONFIG_PATH" >&2
+    echo "       Nothing to deregister." >&2
+    exit 1
+  fi
+  RECORD_ID=$(printf '%s' "$EXISTING_RECORD" | jq -r '.webhookId')
+  RECORD_URL=$(printf '%s' "$EXISTING_RECORD" | jq -r '.webhookUrl')
+  load_api_token
+  delete_via_graphql "$RECORD_ID"
+  clear_linear_record
+  rm -f "$SECRET_FILE"
+  echo "Deregistered Linear webhook ${RECORD_ID} (${RECORD_URL})"
+  echo "Cleared Layer 2 record + removed ${SECRET_FILE}"
   exit 0
 fi
 
-# ─── Delete existing if --force ─────────────────────────────────────────────
-if [[ -n "$EXISTING_ID" && "$FORCE" -eq 1 ]]; then
-  echo "Deleting existing webhook $EXISTING_ID before recreating..."
-  DEL_QUERY='mutation($id:String!){webhookDelete(id:$id){success}}'
-  DEL_VARS=$(jq -nc --arg id "$EXISTING_ID" '{id:$id}')
-  DEL_RESP=$(linear_graphql "$DEL_QUERY" "$DEL_VARS" 2>&1) || {
-    echo "ERROR: Linear API call (delete) failed" >&2
-    [[ -n "$DEL_RESP" ]] && echo "$DEL_RESP" >&2
-    exit 2
-  }
-  surface_graphql_errors "$DEL_RESP" "delete"
+# ─── --register branch ──────────────────────────────────────────────────────
+# Need teamId for create.
+TEAM_ID=$(jq -r '.catalyst.linear.teamId // empty' "$CONFIG_PATH" 2>/dev/null)
+if [[ -z "$TEAM_ID" ]]; then
+  echo "ERROR: catalyst.linear.teamId not set in $CONFIG_PATH." >&2
+  echo "       Run plugins/dev/scripts/resolve-linear-ids.sh first to populate it." >&2
+  exit 1
 fi
 
-# ─── Create webhook ─────────────────────────────────────────────────────────
+# Step 1 (CTL-238): Layer 2 short-circuit. When a record exists we know the
+# webhookId locally — no need to call `webhooks { nodes }` to discover it.
+LAYER2_HANDLED=0
+EXISTING_RECORD="$(read_linear_record)"
+if [[ -n "$EXISTING_RECORD" ]]; then
+  RECORD_URL=$(printf '%s' "$EXISTING_RECORD" | jq -r '.webhookUrl')
+  RECORD_ID=$(printf '%s' "$EXISTING_RECORD" | jq -r '.webhookId')
+  if [[ "$RECORD_URL" == "$WEBHOOK_URL" && "$FORCE" -eq 0 ]]; then
+    echo "Webhook already registered (id=${RECORD_ID}, url=${RECORD_URL}); skipping."
+    echo "  (use --force to delete and recreate; secret cannot be re-fetched)"
+    exit 0
+  fi
+  if [[ "$RECORD_URL" != "$WEBHOOK_URL" && "$FORCE" -eq 0 ]]; then
+    echo "ERROR: Layer 2 records a different webhook URL: ${RECORD_URL}" >&2
+    echo "       Requested: ${WEBHOOK_URL}" >&2
+    echo "       Use --force to delete the existing webhook and register the new URL." >&2
+    exit 1
+  fi
+  # --force path (same URL or different URL): delete by stored ID, clear the
+  # record, and skip the API list step — we already know the world.
+  load_api_token
+  if [[ "$RECORD_URL" == "$WEBHOOK_URL" ]]; then
+    echo "Deleting existing webhook ${RECORD_ID} (force)..."
+  else
+    echo "Deleting existing webhook ${RECORD_ID} (different URL, force)..."
+  fi
+  delete_via_graphql "$RECORD_ID"
+  clear_linear_record
+  LAYER2_HANDLED=1
+fi
+
+# Step 2: API-side dedup fallback. Runs only when no Layer 2 record was
+# present — i.e., a fresh laptop, or a webhook registered manually before
+# CTL-238 shipped. The --force path above sets LAYER2_HANDLED=1 to skip
+# this; we already know the create call is what's needed.
+if [[ "$LAYER2_HANDLED" -eq 0 ]]; then
+  load_api_token
+
+  LIST_QUERY='query { webhooks { nodes { id url label enabled } } }'
+  LIST_RESP=$(linear_graphql "$LIST_QUERY" '{}' 2>&1) || {
+    echo "ERROR: Linear API call (list webhooks) failed" >&2
+    [[ -n "$LIST_RESP" ]] && echo "$LIST_RESP" >&2
+    exit 2
+  }
+  surface_graphql_errors "$LIST_RESP" "list"
+
+  TARGET_URL_LC=$(printf '%s' "$WEBHOOK_URL" | tr '[:upper:]' '[:lower:]')
+  EXISTING_ID=$(printf '%s' "$LIST_RESP" | jq -r --arg url "$TARGET_URL_LC" \
+    '.data.webhooks.nodes[]? | select((.url // "" | ascii_downcase) == $url) | .id' \
+    2>/dev/null | head -1)
+
+  if [[ -n "$EXISTING_ID" && "$FORCE" -eq 0 ]]; then
+    # API found a matching webhook from a previous (manual) registration.
+    # Reuse it. Write a partial Layer 2 record so future re-runs short-circuit
+    # locally — resourceTypes are unknown from a list response, so the field
+    # is omitted (we don't fabricate).
+    echo "Reusing existing webhook $EXISTING_ID for $WEBHOOK_URL"
+    echo "  (use --force to delete and recreate; secret cannot be re-fetched)"
+    write_linear_record "$EXISTING_ID" "$WEBHOOK_URL" "[]"
+    echo "Wrote Layer 2 record (partial — resourceTypes/secret not retrievable from list response)"
+    exit 0
+  fi
+
+  if [[ -n "$EXISTING_ID" && "$FORCE" -eq 1 ]]; then
+    echo "Deleting existing webhook $EXISTING_ID (API-discovered, force)..."
+    delete_via_graphql "$EXISTING_ID"
+  fi
+fi
+
+# Step 3: create.
+# $url/$label/$teamId/$resourceTypes below are GraphQL variables, not shell vars.
+# shellcheck disable=SC2016
 CREATE_QUERY='mutation($url:String!,$label:String!,$teamId:String!,$resourceTypes:[String!]!){webhookCreate(input:{url:$url,label:$label,teamId:$teamId,resourceTypes:$resourceTypes}){success,webhook{id,secret,enabled,url}}}'
+RESOURCE_TYPES_JSON=$(printf '%s\n' "${RESOURCE_TYPES[@]}" | jq -R . | jq -sc .)
 CREATE_VARS=$(jq -nc \
   --arg url "$WEBHOOK_URL" \
   --arg label "$LABEL" \
   --arg teamId "$TEAM_ID" \
-  '{url:$url,label:$label,teamId:$teamId,resourceTypes:["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]}')
+  --argjson resourceTypes "$RESOURCE_TYPES_JSON" \
+  '{url:$url,label:$label,teamId:$teamId,resourceTypes:$resourceTypes}')
 
 CREATE_RESP=$(linear_graphql "$CREATE_QUERY" "$CREATE_VARS" 2>&1) || {
   echo "ERROR: Linear API call (create) failed" >&2
@@ -221,17 +379,19 @@ if [[ -z "$WEBHOOK_ID" || "$WEBHOOK_ID" == "null" \
   exit 2
 fi
 
-# ─── Persist secret ─────────────────────────────────────────────────────────
+# Persist secret (mode 600) — mirrors the GitHub side at ~/.config/catalyst/webhook-secret.
 mkdir -p "$HOME_CONFIG_DIR"
-SECRET_FILE="${HOME_CONFIG_DIR}/linear-webhook-secret"
 ( umask 077; printf '%s\n' "$SECRET" > "$SECRET_FILE" )
 chmod 600 "$SECRET_FILE"
 
-# ─── Print summary + export instruction ────────────────────────────────────
+# Write the Layer 2 registration record (CTL-238).
+write_linear_record "$WEBHOOK_ID" "$WEBHOOK_URL" "$RESOURCE_TYPES_JSON"
+
 cat <<EOF
 Created Linear webhook $WEBHOOK_ID for $WEBHOOK_URL
-  Resource types: Issue, Comment, IssueLabel, Cycle, Reaction, Project
+  Resource types: $(printf '%s, ' "${RESOURCE_TYPES[@]}" | sed 's/, $//')
   Secret: persisted to $SECRET_FILE (mode 600)
+  Layer 2 record: $HOME_CONFIG_PATH (catalyst.monitor.linear)
 
 Export the secret in your shell (and add to your ~/.zshrc / ~/.bashrc):
 

--- a/plugins/dev/scripts/setup-webhooks.sh
+++ b/plugins/dev/scripts/setup-webhooks.sh
@@ -29,6 +29,7 @@ FORCE=0
 ADD_REPOS=()
 LINEAR_SECRET_ENV=""
 LINEAR_REGISTER=0
+LINEAR_DEREGISTER=0
 LINEAR_WEBHOOK_URL=""
 REPO_SHAPE='^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
 ENV_VAR_SHAPE='^[A-Z_][A-Z0-9_]*$'
@@ -56,10 +57,14 @@ Options:
                              setup for GitHub is skipped.
   --linear-register          Auto-register a Linear webhook via Linear's
                              GraphQL API (requires --webhook-url). Idempotent:
-                             re-running with the same URL no-ops. Combine with
-                             --force to delete and recreate. When this is the
-                             only intent flag, channel/secret setup for GitHub
-                             is skipped.
+                             re-running with the same URL no-ops based on the
+                             local Layer 2 record. Combine with --force to
+                             delete and recreate. When this is the only intent
+                             flag, channel/secret setup for GitHub is skipped.
+  --linear-deregister        Delete the Linear webhook recorded in Layer 2 and
+                             clear the local record + secret file. When this
+                             is the only intent flag, channel/secret setup for
+                             GitHub is skipped.
   --webhook-url <https-url>  Public HTTPS URL where Linear should deliver
                              events. Required when --linear-register is used.
   -h|--help                  Show this message
@@ -91,6 +96,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --linear-register) LINEAR_REGISTER=1; shift ;;
+    --linear-deregister) LINEAR_DEREGISTER=1; shift ;;
     --webhook-url)
       if [[ $# -lt 2 || -z "${2:-}" ]]; then
         echo "ERROR: --webhook-url requires an argument" >&2
@@ -123,9 +129,17 @@ if [[ -n "$LINEAR_SECRET_ENV" ]]; then
   fi
 fi
 
-# Validate --linear-register / --webhook-url pairing.
+# Validate Linear flag combinations (CTL-238).
+if [[ $LINEAR_REGISTER -eq 1 && $LINEAR_DEREGISTER -eq 1 ]]; then
+  echo "ERROR: --linear-register and --linear-deregister are mutually exclusive" >&2
+  exit 1
+fi
 if [[ $LINEAR_REGISTER -eq 1 && -z "$LINEAR_WEBHOOK_URL" ]]; then
   echo "ERROR: --linear-register requires --webhook-url <https-url>" >&2
+  exit 1
+fi
+if [[ $LINEAR_DEREGISTER -eq 1 && -n "$LINEAR_WEBHOOK_URL" ]]; then
+  echo "ERROR: --linear-deregister and --webhook-url are mutually exclusive" >&2
   exit 1
 fi
 if [[ -n "$LINEAR_WEBHOOK_URL" && ! "$LINEAR_WEBHOOK_URL" =~ ^https:// ]]; then
@@ -149,7 +163,8 @@ require_cmd jq
 # tolerates a missing channel.
 SKIP_GITHUB_SETUP=0
 if [[ $FORCE -eq 0 && -z "${CATALYST_SMEE_CHANNEL:-}" ]]; then
-  if [[ ${#ADD_REPOS[@]} -gt 0 || -n "$LINEAR_SECRET_ENV" || $LINEAR_REGISTER -eq 1 ]]; then
+  if [[ ${#ADD_REPOS[@]} -gt 0 || -n "$LINEAR_SECRET_ENV" \
+        || $LINEAR_REGISTER -eq 1 || $LINEAR_DEREGISTER -eq 1 ]]; then
     SKIP_GITHUB_SETUP=1
   fi
 fi
@@ -212,7 +227,7 @@ if [[ $SKIP_GITHUB_SETUP -eq 1 ]]; then
   if [[ -n "$LINEAR_SECRET_ENV" ]]; then
     write_linear_secret_env "$LINEAR_SECRET_ENV"
     echo "Wrote catalyst.monitor.linear.webhookSecretEnv = $LINEAR_SECRET_ENV to $PROJECT_CONFIG_PATH"
-    if [[ $LINEAR_REGISTER -eq 0 ]]; then
+    if [[ $LINEAR_REGISTER -eq 0 && $LINEAR_DEREGISTER -eq 0 ]]; then
       echo "  → Set the secret with: export $LINEAR_SECRET_ENV=<your-linear-webhook-signing-secret>"
       echo "  → Then run with --linear-register --webhook-url <url> to auto-register the webhook,"
       echo "    or see website/src/content/docs/observability/webhooks.md for manual registration."
@@ -220,11 +235,16 @@ if [[ $SKIP_GITHUB_SETUP -eq 1 ]]; then
   fi
   if [[ $LINEAR_REGISTER -eq 1 ]]; then
     helper_secret_env="${LINEAR_SECRET_ENV:-$DEFAULT_LINEAR_SECRET_ENV}"
+    helper_args=(
+      --webhook-url "$LINEAR_WEBHOOK_URL"
+      --secret-env "$helper_secret_env"
+      --config "$PROJECT_CONFIG_PATH"
+    )
+    [[ $FORCE -eq 1 ]] && helper_args+=(--force)
+    bash "${SCRIPT_DIR}/setup-linear-webhook.sh" "${helper_args[@]}"
+  elif [[ $LINEAR_DEREGISTER -eq 1 ]]; then
     bash "${SCRIPT_DIR}/setup-linear-webhook.sh" \
-      --webhook-url "$LINEAR_WEBHOOK_URL" \
-      --secret-env "$helper_secret_env" \
-      --config "$PROJECT_CONFIG_PATH" \
-      $([[ $FORCE -eq 1 ]] && echo "--force")
+      --deregister --config "$PROJECT_CONFIG_PATH"
   fi
   exit 0
 fi
@@ -329,14 +349,19 @@ if [[ -n "$LINEAR_SECRET_ENV" ]]; then
   echo "Wrote catalyst.monitor.linear.webhookSecretEnv = $LINEAR_SECRET_ENV"
 fi
 
-# ─── 6c. Auto-register Linear webhook (if --linear-register passed) ─────────
+# ─── 6c. --linear-register / --linear-deregister (if combined) ─────────────
 if [[ $LINEAR_REGISTER -eq 1 ]]; then
   helper_secret_env="${LINEAR_SECRET_ENV:-$DEFAULT_LINEAR_SECRET_ENV}"
+  helper_args=(
+    --webhook-url "$LINEAR_WEBHOOK_URL"
+    --secret-env "$helper_secret_env"
+    --config "$PROJECT_CONFIG_PATH"
+  )
+  [[ $FORCE -eq 1 ]] && helper_args+=(--force)
+  bash "${SCRIPT_DIR}/setup-linear-webhook.sh" "${helper_args[@]}"
+elif [[ $LINEAR_DEREGISTER -eq 1 ]]; then
   bash "${SCRIPT_DIR}/setup-linear-webhook.sh" \
-    --webhook-url "$LINEAR_WEBHOOK_URL" \
-    --secret-env "$helper_secret_env" \
-    --config "$PROJECT_CONFIG_PATH" \
-    $([[ $FORCE -eq 1 ]] && echo "--force")
+    --deregister --config "$PROJECT_CONFIG_PATH"
 fi
 
 # ─── 7. Print next steps ───────────────────────────────────────────────────

--- a/website/src/content/docs/observability/webhooks.md
+++ b/website/src/content/docs/observability/webhooks.md
@@ -345,11 +345,41 @@ e.g. `linear.issue.state_changed`, `linear.comment.created`.
 |------|-------|-----------|
 | `webhookSecretEnv` (env-var name only) | `catalyst.monitor.linear.webhookSecretEnv` in `.catalyst/config.json` | YES |
 | HMAC secret value | env var named above (default fallback `CATALYST_LINEAR_WEBHOOK_SECRET`) | NO (per-developer env) |
+| Registration record (`webhookId`, `webhookUrl`, `registeredAt`, `resourceTypes`) | `catalyst.monitor.linear` in `~/.config/catalyst/config.json` | NO (per-machine, written by `--linear-register`) |
+| HMAC secret file | `~/.config/catalyst/linear-webhook-secret` (mode 600, read by `--linear-register` post-create) | NO (per-developer) |
 
 Run `setup-webhooks.sh --linear-secret-env CATALYST_LINEAR_WEBHOOK_SECRET` to write the
 env-var name to `.catalyst/config.json`. Then `export CATALYST_LINEAR_WEBHOOK_SECRET=<your-secret>`
 in your shell rc file. Linear webhooks share the same Layer 1 / Layer 2 split as GitHub:
-team-wide config in `.catalyst/config.json`, per-developer values in environment.
+team-wide config in `.catalyst/config.json`, per-developer values in environment, and
+per-machine registration state in `~/.config/catalyst/config.json` (CTL-238 — mirrors the
+GitHub `smeeChannel` write).
+
+#### Layer 2 registration record
+
+`~/.config/catalyst/config.json` (cross-project, per-machine — never committed; written by
+`setup-webhooks.sh --linear-register` after a successful `webhookCreate`):
+
+```json
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "webhookId": "abc-123-uuid-from-linear",
+        "webhookUrl": "https://your-tunnel/api/webhook/linear",
+        "registeredAt": "2026-05-04T20:00:00Z",
+        "resourceTypes": ["Issue", "Comment", "IssueLabel", "Cycle", "Reaction", "Project"]
+      }
+    }
+  }
+}
+```
+
+This is the Linear analogue of `catalyst.monitor.github.smeeChannel` — same Layer 2 file,
+same per-machine semantics. The local record is the source of truth for idempotency on
+re-run: when the URL matches, `--linear-register` short-circuits without calling Linear's
+GraphQL API, and `--linear-deregister` reads `webhookId` from this record to call
+`webhookDelete` cleanly.
 
 ### Registering the webhook with Linear
 
@@ -379,8 +409,29 @@ The script:
    `IssueRelation` is intentionally excluded — Linear does not deliver it.
 5. Persists the returned `secret` to `~/.config/catalyst/linear-webhook-secret`
    (mode 600), mirroring the GitHub-side `~/.config/catalyst/webhook-secret`.
-6. Prints the `export CATALYST_LINEAR_WEBHOOK_SECRET="$(cat …)"` line for
+6. Writes the registration record (`webhookId`, `webhookUrl`, `registeredAt`,
+   `resourceTypes`) to `~/.config/catalyst/config.json` under
+   `catalyst.monitor.linear` (CTL-238). Subsequent re-runs short-circuit on
+   this record — no Linear API call needed for the dedup decision. See
+   [Layer 2 registration record](#layer-2-registration-record) above.
+7. Prints the `export CATALYST_LINEAR_WEBHOOK_SECRET="$(cat …)"` line for
    your shell rc.
+
+#### Idempotency on re-run (CTL-238)
+
+When you re-run `--linear-register --webhook-url <U>`, the script consults the Layer 2
+record before touching the Linear API:
+
+- **Record matches `<U>`, no `--force`** → prints `Webhook already registered (id=…); skipping`
+  and exits 0. Zero API calls.
+- **Record holds a different URL, no `--force`** → errors out, leaves the record untouched,
+  asks the user to pass `--force` to delete the old webhook and register the new URL.
+- **`--force`** → deletes the recorded webhook by ID, clears the record, calls `webhookCreate`
+  for `<U>`, rewrites the record. The list-then-match step from CTL-224 is skipped on this
+  path (we already know the world from the Layer 2 record).
+- **No record** → falls back to the CTL-224 path: list webhooks via API, dedup by URL,
+  reuse-or-create. On reuse, writes a partial Layer 2 record (no `resourceTypes` —
+  the list response doesn't expose them) so subsequent runs short-circuit locally.
 
 To rotate the secret (or change the URL), re-run with `--force`:
 
@@ -409,6 +460,21 @@ want webhook registration (no env-var-name write):
 plugins/dev/scripts/setup-linear-webhook.sh \
   --webhook-url https://your-tunnel/api/webhook/linear
 ```
+
+### Deregistering the webhook (CTL-238)
+
+To clean up a registered Linear webhook:
+
+```bash
+plugins/dev/scripts/setup-webhooks.sh --linear-deregister
+```
+
+The script reads `webhookId` from the Layer 2 registration record, calls Linear's
+`webhookDelete`, clears the record, and removes `~/.config/catalyst/linear-webhook-secret`.
+Errors cleanly with a non-zero exit when no Layer 2 record exists (nothing to delete).
+
+`--linear-deregister` and `--linear-register` are mutually exclusive — pass one or the
+other, not both.
 
 ### Signing scheme
 


### PR DESCRIPTION
## Linear ticket

[CTL-238](https://linear.app/coalesce-labs/issue/CTL-238) — closes the Layer 2 asymmetry CTL-224 left behind.

## Problem

`setup-webhooks.sh --linear-register` (CTL-224) writes asymmetric state for the GitHub vs Linear sides:

| Item | GitHub | Linear (before this PR) |
| ---- | ------ | ----------------------- |
| Channel/registration record in Layer 2 (`~/.config/catalyst/config.json`) | ✓ `catalyst.monitor.github.smeeChannel` | ✗ **nothing written** |
| Secret value (mode-600 file) | `~/.config/catalyst/webhook-secret` | `~/.config/catalyst/linear-webhook-secret` |
| Env-var NAME in Layer 1 (`.catalyst/config.json`) | ✓ `catalyst.monitor.github.webhookSecretEnv` | ✓ `catalyst.monitor.linear.webhookSecretEnv` |

The Linear webhook URL and `webhookCreate` response (id, secret, resourceTypes) lived only on Linear's server — no local mirror. Three concrete consequences:

1. **No idempotency signal**: re-running `--linear-register` couldn't tell whether a webhook already existed for this project without re-querying Linear's GraphQL API. Every run hit the network.
2. **No auditability**: a user inspecting `~/.config/catalyst/config.json` could see GitHub setup (smeeChannel visible) but had no equivalent breadcrumb for Linear — only the indirect signal that `linear-webhook-secret` exists.
3. **No clean deregister path**: a future `--linear-deregister` would need the webhook ID, only retrievable via a fresh API call.

## What changed

After successful `webhookCreate`, the helper now writes:

```json
{
  "catalyst": {
    "monitor": {
      "linear": {
        "webhookId": "<uuid from Linear>",
        "webhookUrl": "<the URL passed to --webhook-url>",
        "registeredAt": "<ISO timestamp UTC>",
        "resourceTypes": ["Issue", "Comment", "IssueLabel", "Cycle", "Reaction", "Project"]
      }
    }
  }
}
```

This mirrors the GitHub `smeeChannel` write pattern.

**Idempotency on re-run** (`setup-webhooks.sh --linear-register --webhook-url <U>`):

1. Read Layer 2 record.
2. **URL matches U** → print "already registered (id=…); skipping" and exit 0. **No Linear API call.**
3. **URL differs from U, no `--force`** → error: "Layer 2 records a different URL (…)."
4. **URL differs OR same with `--force`** → call `webhookDelete` with the stored ID, then `webhookCreate` for U; rewrite Layer 2 record.
5. **Layer 2 missing** → fall through to existing CTL-224 behaviour (list webhooks via API, dedup by URL, create or reuse). On reuse, write a partial Layer 2 record (no `resourceTypes` — list response doesn't expose them) so future runs short-circuit locally.

**New `--linear-deregister` flag**: reads the `webhookId` from Layer 2, calls `webhookDelete`, clears the record, removes `~/.config/catalyst/linear-webhook-secret`. Errors cleanly when no record exists.

## Boundary with CTL-224

CTL-224 introduced `--linear-register` and was in flight on a sibling branch when this work started. This PR ships the `--linear-register` plumbing AND the new Layer 2 write together as a strict superset. If CTL-224 lands first this rebases cleanly; if this lands first CTL-224's open PR becomes a no-op.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/setup-linear-webhook.test.sh` (8 new tests)
  - register writes Layer 2 record with all 4 fields
  - idempotent re-run with same URL → 0 API calls
  - different URL without `--force` errors and leaves record untouched
  - `--force` deletes by stored ID + recreates, no list call needed
  - `--deregister` clears Layer 2 record + secret file
  - `--deregister` with no record errors before any API call
  - Layer 2 missing → falls back to API list+create
  - Layer 2 missing → falls back to API list dedup (writes partial record)
- [x] `bash plugins/dev/scripts/__tests__/setup-webhooks.test.sh` (12 existing + 5 new tests, all pass)
  - `--linear-register` requires `--webhook-url`
  - `--linear-register` and `--linear-deregister` mutex enforced
  - `--webhook-url` must be `https://`
  - `--linear-register`-only mode skips GitHub channel setup
  - `--linear-deregister`-only mode skips GitHub channel setup
- [x] `shellcheck` clean (excluding one pre-existing `SC2034` unrelated to this PR)
- [x] `bun run build` in `website/` passes (267 pages built)
- [ ] **Manual verification** (requires real Linear API token; not feasible in CI):
  - Run `setup-webhooks.sh --linear-register --webhook-url https://your-tunnel/api/webhook/linear` against a sandbox Linear org
  - Verify `~/.config/catalyst/config.json` now contains `catalyst.monitor.linear.{webhookId,webhookUrl,registeredAt,resourceTypes}`
  - Re-run with same URL — should print "already registered" and not call Linear
  - Run `--linear-deregister` — verify webhook gone in Linear UI, Layer 2 cleared, `linear-webhook-secret` file removed

## Files changed

| Path | Change |
|------|--------|
| `plugins/dev/scripts/setup-webhooks.sh` | adds `--linear-register`, `--linear-deregister`, `--webhook-url` flags; dispatches to helper |
| `plugins/dev/scripts/setup-linear-webhook.sh` | NEW — Layer 2 read/write helpers + register/deregister branches |
| `plugins/dev/scripts/__tests__/setup-linear-webhook.test.sh` | NEW — 8 tests with curl GraphQL stubbing |
| `plugins/dev/scripts/__tests__/setup-webhooks.test.sh` | 5 new tests for flag validation + skip-GitHub-setup behaviour |
| `website/src/content/docs/observability/webhooks.md` | adds Layer 2 record shape, auto-register usage, deregister docs |