### PR TITLE
fix(dev): render DASHBOARD.md every Phase 4 cycle (CTL-230)

### DIFF
--- a/plugins/dev/scripts/__tests__/update-dashboard.test.sh
+++ b/plugins/dev/scripts/__tests__/update-dashboard.test.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Shell tests for update-dashboard.sh (CTL-230).
+#
+# Verifies the renderer that the orchestrator monitor pass invokes once per
+# cycle to write ${ORCH_DIR}/DASHBOARD.md from per-orch state.json + worker
+# signal files + the events log.
+#
+# Run: bash plugins/dev/scripts/__tests__/update-dashboard.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/scripts/update-dashboard.sh"
+STATE_SCRIPT="${REPO_ROOT}/plugins/dev/scripts/catalyst-state.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Isolate state — tests must not touch the user's real ~/catalyst.
+export CATALYST_DIR="${SCRATCH}/catalyst"
+export CATALYST_STATE_FILE="${CATALYST_DIR}/state.json"
+mkdir -p "$CATALYST_DIR" "$CATALYST_DIR/events"
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+# Asserts that the rendered file (or string) contains a substring.
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if grep -qF "$needle" <<<"$haystack"; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name (missing: $needle)"
+    echo "    haystack head:"
+    head -20 <<<"$haystack" | sed 's/^/      /'
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if grep -qF "$needle" <<<"$haystack"; then
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name (unexpectedly contains: $needle)"
+  else
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  fi
+}
+
+# Provision an orch dir with state.json (per-orch metadata) and a stub global
+# state.json entry for the same orch (for projectKey lookup).
+setup_orch() {
+  local orch_id="$1"
+  local total_tickets="${2:-0}"
+  local total_waves="${3:-1}"
+  local current_wave="${4:-1}"
+  local started_at="${5:-2026-05-04T20:00:00Z}"
+  local base_branch="${6:-main}"
+  local project_key="${7:-test-proj}"
+  local orch_dir="${SCRATCH}/runs/${orch_id}"
+  mkdir -p "${orch_dir}/workers/output"
+
+  # Per-orch state.json — orchestrator metadata + waves array
+  cat > "${orch_dir}/state.json" <<EOF
+{
+  "orchestrator": "${orch_id}",
+  "startedAt": "${started_at}",
+  "baseBranch": "${base_branch}",
+  "totalTickets": ${total_tickets},
+  "totalWaves": ${total_waves},
+  "currentWave": ${current_wave},
+  "worktreeBase": "${SCRATCH}/wt",
+  "maxParallel": 3,
+  "queue": {},
+  "waves": []
+}
+EOF
+
+  # Reset global state for projectKey lookup.
+  rm -f "$CATALYST_STATE_FILE"
+  "$STATE_SCRIPT" init >/dev/null
+  "$STATE_SCRIPT" register "$orch_id" "$(jq -nc \
+    --arg pk "$project_key" --arg sa "$started_at" --arg bb "$base_branch" \
+    '{id: "TEST", projectKey: $pk, repository: "test/repo",
+      baseBranch: $bb, status: "active", startedAt: $sa,
+      progress: {totalTickets: 0, completedTickets: 0, failedTickets: 0, inProgressTickets: 0, currentWave: 1, totalWaves: 1},
+      usage: {inputTokens: 0, outputTokens: 0, costUSD: 0},
+      workers: {}, attention: []}')" >/dev/null
+
+  echo "$orch_dir"
+}
+
+# Write a `waves` array onto an existing per-orch state.json.
+set_waves_json() {
+  local orch_dir="$1" waves_json="$2"
+  jq --argjson w "$waves_json" '.waves = $w' "${orch_dir}/state.json" \
+    > "${orch_dir}/state.json.tmp" && mv "${orch_dir}/state.json.tmp" "${orch_dir}/state.json"
+}
+
+# Build a worker signal file with sensible defaults; override JSON via $extra.
+build_signal() {
+  local out="$1" ticket="$2" wave="$3" status="$4" phase="$5" extra="${6:-{\}}"
+  jq -n \
+    --arg t "$ticket" --arg w "$wave" --arg s "$status" --arg p "$phase" \
+    --argjson extra "$extra" \
+    '{ticket: $t, orchestrator: "orch-test", wave: ($w|tonumber),
+      workerName: ("orch-test-" + $t), label: ("oneshot " + $t),
+      status: $s, phase: ($p|tonumber),
+      startedAt: "2026-05-04T20:05:00Z",
+      updatedAt: "2026-05-04T20:30:00Z",
+      lastHeartbeat: "2026-05-04T20:30:00Z",
+      worktreePath: ("/tmp/" + $t),
+      pr: null, linearState: null,
+      definitionOfDone: {
+        testsWrittenFirst: false,
+        unitTests: {exists: false, count: 0},
+        apiTests: {exists: false, count: 0},
+        functionalTests: {exists: false, count: 0},
+        typeCheck: {passed: false},
+        securityReview: {passed: false},
+        codeReview: {passed: false},
+        rewardHackingScan: {passed: false}
+      },
+      pid: null} * $extra' > "$out"
+}
+
+# Append events to the scratch events log.
+append_events() {
+  local events_file="${CATALYST_DIR}/events/$(date -u +%Y-%m).jsonl"
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "$line" >> "$events_file"
+  done
+}
+
+# ───────────────────────────────────────────────────────────────────────────────
+echo "update-dashboard tests"
+echo ""
+
+# ─── 1: helper exists and is executable ────────────────────────────────────────
+run "helper script exists" bash -c "[ -f '$HELPER' ]"
+run "helper script is executable" bash -c "[ -x '$HELPER' ]"
+run "helper rejects missing --orch" bash -c "! '$HELPER' 2>/dev/null"
+
+# ─── 2: header_renders ─────────────────────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-h" 5 2 1 "2026-05-04T20:00:00Z" "main" "catalyst")
+OUT=$("$HELPER" --orch "orch-h" --orch-dir "$ORCH_DIR" --stdout)
+assert_contains "header has orchestrator name" "$OUT" "**Orchestrator:** orch-h"
+assert_contains "header has started timestamp" "$OUT" "**Started:** 2026-05-04T20:00:00Z"
+assert_contains "header has base branch" "$OUT" "**Base branch:** main"
+assert_contains "header has totals line" "$OUT" "5 tickets | 2 waves | Max parallel: 3"
+assert_contains "header has project name" "$OUT" "**Project:** catalyst"
+assert_contains "current wave heading present" "$OUT" "## Current Wave: 1 of 2"
+assert_not_contains "no literal placeholders in output" "$OUT" '${'
+
+# ─── 3: current_wave_table_renders_workers ─────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-cw" 2 1 1)
+build_signal "${ORCH_DIR}/workers/T-1.json" "T-1" "1" "researching" "1"
+build_signal "${ORCH_DIR}/workers/T-2.json" "T-2" "1" "merging" "5" \
+  '{"pr": {"number": 42, "url": "https://github.com/o/r/pull/42", "ciStatus": "passing", "prOpenedAt": "2026-05-04T20:10:00Z", "autoMergeArmedAt": "2026-05-04T20:11:00Z", "mergedAt": null}}'
+
+OUT=$("$HELPER" --orch "orch-cw" --orch-dir "$ORCH_DIR" --stdout)
+assert_contains "current wave row T-1 status researching" "$OUT" "T-1"
+assert_contains "current wave row T-2 status merging" "$OUT" "T-2"
+assert_contains "current wave row T-2 PR cell #42" "$OUT" "[#42]"
+assert_contains "current wave row T-2 PR cell url" "$OUT" "https://github.com/o/r/pull/42"
+assert_contains "current wave row T-2 prOpenedAt" "$OUT" "2026-05-04T20:10:00Z"
+assert_contains "current wave row T-2 autoMergeArmedAt" "$OUT" "2026-05-04T20:11:00Z"
+assert_contains "current wave row T-1 status text" "$OUT" "researching"
+assert_contains "current wave row T-2 status text" "$OUT" "merging"
+
+# ─── 4: definition_of_done_columns ─────────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-dod" 1 1 1)
+build_signal "${ORCH_DIR}/workers/D-1.json" "D-1" "1" "validating" "4" \
+  '{"definitionOfDone": {"unitTests": {"exists": true, "count": 3}, "apiTests": {"exists": false, "count": 0}, "functionalTests": {"exists": false, "count": 0}, "typeCheck": {"passed": true}, "securityReview": {"passed": true}, "codeReview": {"passed": false}, "rewardHackingScan": {"passed": true}}}'
+
+OUT=$("$HELPER" --orch "orch-dod" --orch-dir "$ORCH_DIR" --stdout)
+# Find the table row for D-1 and verify the cells encode the DoD shape.
+ROW=$(grep '^| D-1 ' <<<"$OUT" || true)
+[ -n "$ROW" ] && PASSES=$((PASSES+1)) && echo "  PASS: D-1 has a row" || { FAILURES=$((FAILURES+1)); echo "  FAIL: D-1 has a row (no row found)"; }
+assert_contains "DoD row contains unit count 3" "$ROW" "3"
+# securityReview passed → ✓; codeReview failed → ✗
+assert_contains "DoD row contains a tick mark for security" "$ROW" "✓"
+assert_contains "DoD row contains a cross for failed review" "$ROW" "✗"
+
+# ─── 5: completed_waves_section ────────────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-cmp" 4 2 2)
+set_waves_json "$ORCH_DIR" '[
+  {"wave": 1, "status": "completed", "tickets": ["A-1", "A-2"], "completedAt": "2026-05-04T20:30:00Z"},
+  {"wave": 2, "status": "active", "tickets": ["B-1", "B-2"]}
+]'
+build_signal "${ORCH_DIR}/workers/A-1.json" "A-1" "1" "done" "5" \
+  '{"pr": {"number": 100, "url": "https://github.com/o/r/pull/100", "mergedAt": "2026-05-04T20:25:00Z", "ciStatus": "merged"}, "completedAt": "2026-05-04T20:25:00Z"}'
+build_signal "${ORCH_DIR}/workers/A-2.json" "A-2" "1" "done" "5" \
+  '{"pr": {"number": 101, "url": "https://github.com/o/r/pull/101", "mergedAt": "2026-05-04T20:28:00Z", "ciStatus": "merged"}, "completedAt": "2026-05-04T20:28:00Z"}'
+build_signal "${ORCH_DIR}/workers/B-1.json" "B-1" "2" "implementing" "3"
+build_signal "${ORCH_DIR}/workers/B-2.json" "B-2" "2" "researching" "1"
+
+OUT=$("$HELPER" --orch "orch-cmp" --orch-dir "$ORCH_DIR" --stdout)
+assert_contains "completed waves heading" "$OUT" "## Completed Waves"
+assert_contains "wave 1 heading" "$OUT" "### Wave 1"
+assert_contains "completed wave row A-1 PR" "$OUT" "[#100]"
+assert_contains "completed wave row A-2 PR" "$OUT" "[#101]"
+assert_contains "current wave heading is wave 2" "$OUT" "## Current Wave: 2 of 2"
+assert_contains "current wave shows B-1" "$OUT" "B-1"
+assert_contains "current wave shows B-2" "$OUT" "B-2"
+# Completed-wave tickets must NOT appear in the current-wave table — that's the point.
+# Look for A-1 between "## Current Wave" and the next "## " heading; should be absent.
+CURRENT_BLOCK=$(awk '/^## Current Wave/{flag=1;next} /^## /{flag=0} flag' <<<"$OUT" || true)
+assert_not_contains "current wave block does not contain completed worker A-1" "$CURRENT_BLOCK" "| A-1 "
+
+# ─── 6: upcoming_waves_section ─────────────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-up" 4 3 1)
+set_waves_json "$ORCH_DIR" '[
+  {"wave": 1, "status": "active", "tickets": ["W1-1"]},
+  {"wave": 2, "status": "pending", "tickets": ["W2-1", "W2-2"], "dependsOn": [1]},
+  {"wave": 3, "status": "pending", "tickets": ["W3-1"], "dependsOn": [2]}
+]'
+build_signal "${ORCH_DIR}/workers/W1-1.json" "W1-1" "1" "implementing" "3"
+
+OUT=$("$HELPER" --orch "orch-up" --orch-dir "$ORCH_DIR" --stdout)
+assert_contains "upcoming waves heading" "$OUT" "## Upcoming Waves"
+assert_contains "wave 2 heading" "$OUT" "### Wave 2"
+assert_contains "wave 2 depends-on note" "$OUT" "blocked on Wave 1"
+assert_contains "wave 2 ticket W2-1" "$OUT" "W2-1"
+assert_contains "wave 2 ticket W2-2" "$OUT" "W2-2"
+assert_contains "wave 3 heading" "$OUT" "### Wave 3"
+assert_contains "wave 3 depends-on note" "$OUT" "blocked on Wave 2"
+assert_contains "wave 3 ticket W3-1" "$OUT" "W3-1"
+
+# ─── 7: event_log_section (filters by orchestrator) ────────────────────────────
+ORCH_DIR=$(setup_orch "orch-ev" 1 1 1)
+build_signal "${ORCH_DIR}/workers/E-1.json" "E-1" "1" "researching" "1"
+append_events <<EOF
+{"ts":"2026-05-04T20:00:00Z","orchestrator":"orch-ev","worker":null,"event":"orchestrator-started","detail":{"tickets":["E-1"]}}
+{"ts":"2026-05-04T20:05:00Z","orchestrator":"orch-ev","worker":"E-1","event":"worker-dispatched","detail":{"pid":1234}}
+{"ts":"2026-05-04T20:10:00Z","orchestrator":"OTHER-ORCH","worker":"X-1","event":"worker-dispatched","detail":null}
+{"ts":"2026-05-04T20:15:00Z","orchestrator":"orch-ev","worker":"E-1","event":"worker-status-change","detail":{"from":"researching","to":"planning"}}
+EOF
+
+OUT=$("$HELPER" --orch "orch-ev" --orch-dir "$ORCH_DIR" --stdout)
+assert_contains "event log heading" "$OUT" "## Event Log"
+assert_contains "event log includes own orch event" "$OUT" "orchestrator-started"
+assert_contains "event log includes worker-dispatched" "$OUT" "worker-dispatched"
+assert_contains "event log includes status-change" "$OUT" "worker-status-change"
+assert_not_contains "event log excludes other orch" "$OUT" "OTHER-ORCH"
+assert_not_contains "event log excludes other orch worker" "$OUT" "X-1"
+
+# ─── 8: idempotent ─────────────────────────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-idem" 2 1 1)
+build_signal "${ORCH_DIR}/workers/I-1.json" "I-1" "1" "implementing" "3"
+build_signal "${ORCH_DIR}/workers/I-2.json" "I-2" "1" "validating" "4"
+"$HELPER" --orch "orch-idem" --orch-dir "$ORCH_DIR" >/dev/null
+FIRST=$(cat "${ORCH_DIR}/DASHBOARD.md")
+"$HELPER" --orch "orch-idem" --orch-dir "$ORCH_DIR" >/dev/null
+SECOND=$(cat "${ORCH_DIR}/DASHBOARD.md")
+if [ "$FIRST" = "$SECOND" ]; then
+  PASSES=$((PASSES+1)); echo "  PASS: idempotent — two consecutive renders are byte-identical"
+else
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: idempotent — output changed across re-runs"
+  diff <(echo "$FIRST") <(echo "$SECOND") | head -20 | sed 's/^/      /'
+fi
+
+# ─── 9: handles_missing_pr ─────────────────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-nopr" 1 1 1)
+build_signal "${ORCH_DIR}/workers/N-1.json" "N-1" "1" "researching" "1"
+run "renders cleanly with pr=null" \
+  "$HELPER" --orch "orch-nopr" --orch-dir "$ORCH_DIR" --stdout
+
+# ─── 10: handles_missing_workers_dir ───────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-empty" 0 1 1)
+rm -rf "${ORCH_DIR}/workers"   # simulate Phase 2 init: state.json exists, no workers yet
+run "renders with no workers/ dir" \
+  "$HELPER" --orch "orch-empty" --orch-dir "$ORCH_DIR" --stdout
+
+# ─── 11: deterministic_worker_order ────────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-ord" 4 1 1)
+# Create signal files in non-alphabetical order
+build_signal "${ORCH_DIR}/workers/CTL-99.json"  "CTL-99"  "1" "researching" "1"
+build_signal "${ORCH_DIR}/workers/CTL-1.json"   "CTL-1"   "1" "researching" "1"
+build_signal "${ORCH_DIR}/workers/CTL-50.json"  "CTL-50"  "1" "researching" "1"
+build_signal "${ORCH_DIR}/workers/CTL-12.json"  "CTL-12"  "1" "researching" "1"
+
+OUT=$("$HELPER" --orch "orch-ord" --orch-dir "$ORCH_DIR" --stdout)
+# Extract ticket-row order from current-wave table
+ORDER=$(awk '/^## Current Wave/{flag=1;next} /^## /{flag=0} flag && /^\| CTL-/' <<<"$OUT" \
+  | sed -E 's/^\| ([^ ]+) .*/\1/' | tr '\n' ' ')
+EXPECTED="CTL-1 CTL-12 CTL-50 CTL-99 "
+if [ "$ORDER" = "$EXPECTED" ]; then
+  PASSES=$((PASSES+1)); echo "  PASS: workers sorted alphabetically (got: $ORDER)"
+else
+  FAILURES=$((FAILURES+1)); echo "  FAIL: worker order — expected '$EXPECTED' got '$ORDER'"
+fi
+
+# ─── 12: writes file atomically ────────────────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-atom" 1 1 1)
+build_signal "${ORCH_DIR}/workers/AT-1.json" "AT-1" "1" "implementing" "3"
+"$HELPER" --orch "orch-atom" --orch-dir "$ORCH_DIR" >/dev/null
+run "DASHBOARD.md exists after run" bash -c "[ -f '${ORCH_DIR}/DASHBOARD.md' ]"
+run "DASHBOARD.md is non-empty" bash -c "[ -s '${ORCH_DIR}/DASHBOARD.md' ]"
+run "no template placeholders left in file" \
+  bash -c "! grep -qF '\${ORCH_NAME}' '${ORCH_DIR}/DASHBOARD.md'"
+
+# ─── Report ────────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================"
+echo "PASSED: ${PASSES}"
+echo "FAILED: ${FAILURES}"
+echo "============================================"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/update-dashboard.sh
+++ b/plugins/dev/scripts/update-dashboard.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# update-dashboard.sh — Render ${ORCH_DIR}/DASHBOARD.md from orchestrator state.
+#
+# Reads ${ORCH_DIR}/state.json + ${ORCH_DIR}/workers/*.json signal files +
+# ${CATALYST_DIR}/events/*.jsonl, writes ${ORCH_DIR}/DASHBOARD.md atomically.
+# Idempotent: rerunning with no state change produces a byte-identical file.
+#
+# Usage:
+#   update-dashboard.sh --orch <id> [--orch-dir <dir>] [--stdout]
+#
+# No-op (exits 0) when:
+#   - state.json missing
+#
+# Exits non-zero on:
+#   - missing required args
+
+set -euo pipefail
+
+# Resolve symlinks for SCRIPT_DIR (CTL-239 pattern).
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+GLOBAL_STATE="${CATALYST_STATE_FILE:-$CATALYST_DIR/state.json}"
+EVENTS_DIR="${CATALYST_DIR}/events"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: update-dashboard.sh --orch <id> [--orch-dir <dir>] [--stdout]
+
+required:
+  --orch <id>         orchestrator id
+
+optional:
+  --orch-dir <dir>    override default ~/catalyst/runs/<orch>/
+  --stdout            write to stdout instead of DASHBOARD.md
+EOF
+  exit 2
+}
+
+ORCH_ID="" ORCH_DIR="" STDOUT_MODE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --orch)     ORCH_ID="${2:-}"; shift 2 ;;
+    --orch-dir) ORCH_DIR="${2:-}"; shift 2 ;;
+    --stdout)   STDOUT_MODE=1; shift ;;
+    -h|--help)  usage ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$ORCH_ID" ] || usage
+[ -n "$ORCH_DIR" ] || ORCH_DIR="${CATALYST_DIR}/runs/${ORCH_ID}"
+
+STATE_FILE="${ORCH_DIR}/state.json"
+WORKERS_DIR="${ORCH_DIR}/workers"
+DASHBOARD_FILE="${ORCH_DIR}/DASHBOARD.md"
+
+# No-op when state.json absent — orchestrator hasn't initialised yet.
+if [ ! -f "$STATE_FILE" ]; then
+  echo "warn: state.json not found at $STATE_FILE" >&2
+  exit 0
+fi
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+dod_count_cell() {
+  # Args: signal_file key
+  local signal="$1" key="$2"
+  local exists count
+  exists=$(jq -r ".definitionOfDone.${key}.exists // false" "$signal")
+  count=$(jq -r ".definitionOfDone.${key}.count // 0" "$signal")
+  if [ "$exists" = "true" ]; then
+    printf '✓ %s' "$count"
+  else
+    printf '—'
+  fi
+}
+
+dod_passed_cell() {
+  # Args: signal_file key
+  # Don't use jq's `//` here — it treats both null and false as nullish, so an
+  # explicit `passed: false` would collapse to the default branch. Read the raw
+  # value (jq -r prints "true"/"false"/"null") and match on the string.
+  local signal="$1" key="$2"
+  local passed
+  passed=$(jq -r ".definitionOfDone.${key}.passed" "$signal")
+  case "$passed" in
+    true)  printf '✓' ;;
+    false) printf '✗' ;;
+    *)     printf '—' ;;
+  esac
+}
+
+pr_link_cell() {
+  # Args: signal_file
+  local signal="$1" num url
+  num=$(jq -r '.pr.number // empty' "$signal")
+  url=$(jq -r '.pr.url // empty' "$signal")
+  if [ -n "$num" ] && [ -n "$url" ]; then
+    printf '[#%s](%s)' "$num" "$url"
+  fi
+}
+
+pr_field() {
+  # Args: signal_file field
+  jq -r --arg f "$2" '.pr[$f] // ""' "$1"
+}
+
+worker_row() {
+  # Args: signal_file
+  local sig="$1" ticket title status pr_link pr_opened auto_armed merged
+  ticket=$(jq -r '.ticket' "$sig")
+  title=$(jq -r '.label // .ticket' "$sig")
+  status=$(jq -r '.status' "$sig")
+  pr_link=$(pr_link_cell "$sig")
+  pr_opened=$(pr_field "$sig" prOpenedAt)
+  auto_armed=$(pr_field "$sig" autoMergeArmedAt)
+  merged=$(pr_field "$sig" mergedAt)
+  local unit api func sec review verified fixup followup
+  unit=$(dod_count_cell "$sig" unitTests)
+  api=$(dod_count_cell "$sig" apiTests)
+  func=$(dod_count_cell "$sig" functionalTests)
+  sec=$(dod_passed_cell "$sig" securityReview)
+  review=$(dod_passed_cell "$sig" codeReview)
+  verified=$(dod_passed_cell "$sig" rewardHackingScan)
+  fixup=$(jq -r '.fixupCommit // ""' "$sig")
+  followup=$(jq -r '.followUpTo // ""' "$sig")
+  printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+    "$ticket" "$title" "$status" "$pr_link" \
+    "$pr_opened" "$auto_armed" "$merged" \
+    "$unit" "$api" "$func" "$sec" "$review" "$verified" \
+    "$fixup" "$followup"
+}
+
+# Read orch-level metadata
+ORCH_NAME=$(jq -r '.orchestrator // ""' "$STATE_FILE")
+STARTED_AT=$(jq -r '.startedAt // ""' "$STATE_FILE")
+BASE_BRANCH=$(jq -r '.baseBranch // ""' "$STATE_FILE")
+TOTAL_TICKETS=$(jq -r '.totalTickets // 0' "$STATE_FILE")
+TOTAL_WAVES=$(jq -r '.totalWaves // 0' "$STATE_FILE")
+CURRENT_WAVE=$(jq -r '.currentWave // 1' "$STATE_FILE")
+MAX_PARALLEL=$(jq -r '.maxParallel // 0' "$STATE_FILE")
+
+# projectKey lives in the global state; falls back to "unknown" if absent.
+PROJECT_NAME="unknown"
+if [ -f "$GLOBAL_STATE" ]; then
+  PROJECT_NAME=$(jq -r --arg id "$ORCH_NAME" '.orchestrators[$id].projectKey // "unknown"' "$GLOBAL_STATE" 2>/dev/null || echo "unknown")
+fi
+
+shopt -s nullglob
+
+# Render to a string so we can write atomically.
+render() {
+  cat <<EOF
+# Orchestration Dashboard
+
+**Orchestrator:** ${ORCH_NAME}
+**Started:** ${STARTED_AT}
+**Project:** ${PROJECT_NAME}
+**Base branch:** ${BASE_BRANCH}
+**Total:** ${TOTAL_TICKETS} tickets | ${TOTAL_WAVES} waves | Max parallel: ${MAX_PARALLEL}
+
+## Current Wave: ${CURRENT_WAVE} of ${TOTAL_WAVES}
+
+| Ticket | Title | Status | PR | PR Opened | Auto-Merge Armed | Merged | Unit Tests | API Tests | Functional | Security | Code Review | Verified | Fix-up Commit | Follow-up To |
+|--------|-------|--------|-----|-----------|------------------|--------|-----------|-----------|------------|----------|-------------|----------|---------------|--------------|
+EOF
+
+  if [ -d "$WORKERS_DIR" ]; then
+    for sig in "$WORKERS_DIR"/*.json; do
+      [ -f "$sig" ] || continue
+      local sig_wave
+      sig_wave=$(jq -r '.wave // 0' "$sig")
+      [ "$sig_wave" = "$CURRENT_WAVE" ] || continue
+      worker_row "$sig"
+    done
+  fi
+
+  # ─── Upcoming Waves ─────────────────────────────────────────────────────────
+  local upcoming_count
+  upcoming_count=$(jq --arg cw "$CURRENT_WAVE" \
+    '[.waves[]? | select(.wave > ($cw|tonumber))] | length' "$STATE_FILE")
+  if [ "$upcoming_count" -gt 0 ]; then
+    printf '\n## Upcoming Waves\n'
+    # Iterate upcoming waves in ascending wave order.
+    while IFS= read -r wave_json; do
+      [ -z "$wave_json" ] && continue
+      local w_num w_deps tickets_count
+      w_num=$(jq -r '.wave' <<<"$wave_json")
+      w_deps=$(jq -rc '.dependsOn // []' <<<"$wave_json")
+      tickets_count=$(jq -r '(.tickets // []) | length' <<<"$wave_json")
+      local depends_on_label="—"
+      if [ "$(jq -r 'length' <<<"$w_deps")" -gt 0 ]; then
+        # Print the highest dependency as "Wave N" so the heading reads cleanly.
+        local dep_max
+        dep_max=$(jq -r 'max' <<<"$w_deps")
+        depends_on_label="Wave ${dep_max}"
+      fi
+      if [ "$depends_on_label" = "—" ]; then
+        printf '\n### Wave %s\n' "$w_num"
+      else
+        printf '\n### Wave %s (blocked on %s)\n' "$w_num" "$depends_on_label"
+      fi
+      printf '\n| Ticket | Depends On |\n'
+      printf '|--------|------------|\n'
+      if [ "$tickets_count" -gt 0 ]; then
+        # Stable: state.json wave-array order is the queue order.
+        jq -r --arg dep "$depends_on_label" \
+          '(.tickets // [])[] | "| \(.) | \($dep) |"' <<<"$wave_json"
+      fi
+    done < <(jq -c --arg cw "$CURRENT_WAVE" \
+      '.waves[]? | select(.wave > ($cw|tonumber))' "$STATE_FILE" \
+      | jq -sc 'sort_by(.wave) | .[]')
+  fi
+
+  # ─── Completed Waves ────────────────────────────────────────────────────────
+  local completed_count
+  completed_count=$(jq '[.waves[]? | select(.status == "completed")] | length' "$STATE_FILE")
+  if [ "$completed_count" -gt 0 ]; then
+    printf '\n## Completed Waves\n'
+    while IFS= read -r wave_json; do
+      [ -z "$wave_json" ] && continue
+      local w_num
+      w_num=$(jq -r '.wave' <<<"$wave_json")
+      printf '\n### Wave %s\n' "$w_num"
+      printf '\n| Ticket | PR | Merged |\n'
+      printf '|--------|-----|--------|\n'
+      # Iterate this wave's tickets in array order; pull each signal file
+      # to render the PR link + merge timestamp.
+      while IFS= read -r tkt; do
+        [ -z "$tkt" ] && continue
+        local sig="${WORKERS_DIR}/${tkt}.json"
+        local pr_link="" merged=""
+        if [ -f "$sig" ]; then
+          pr_link=$(pr_link_cell "$sig")
+          merged=$(pr_field "$sig" mergedAt)
+        fi
+        printf '| %s | %s | %s |\n' "$tkt" "$pr_link" "$merged"
+      done < <(jq -r '(.tickets // [])[]' <<<"$wave_json")
+    done < <(jq -c '.waves[]? | select(.status == "completed")' "$STATE_FILE" \
+      | jq -sc 'sort_by(.wave) | .[]')
+  fi
+
+  # ─── Event Log ──────────────────────────────────────────────────────────────
+  printf '\n## Event Log\n\n'
+  if [ -d "$EVENTS_DIR" ]; then
+    # Combine all monthly events files (sorted), filter to this orchestrator,
+    # take last 30 by chronological order. Stable input → stable output.
+    local events_glob=( "$EVENTS_DIR"/*.jsonl )
+    if [ ${#events_glob[@]} -gt 0 ]; then
+      # Read raw and use `fromjson?` so partial/concurrent-write lines in the
+      # shared events log don't abort rendering for everyone.
+      cat "${events_glob[@]}" 2>/dev/null \
+        | jq -Rrc --arg orch "$ORCH_NAME" \
+            'fromjson?
+             | select(.orchestrator == $orch)
+             | "- \(.ts) — \(.event)" + (if .worker then " (\(.worker))" else "" end)' \
+        | tail -30
+    fi
+  fi
+}
+
+# Atomic write — render to a temp file in the same directory then mv.
+if [ "$STDOUT_MODE" = "1" ]; then
+  render
+else
+  mkdir -p "$ORCH_DIR"
+  TMP=$(mktemp "${ORCH_DIR}/.DASHBOARD.md.XXXXXX")
+  trap 'rm -f "$TMP"' EXIT
+  render > "$TMP"
+  mv "$TMP" "$DASHBOARD_FILE"
+  trap - EXIT
+fi

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -323,17 +323,21 @@ With `worktreeDir: "~/catalyst/api"` explicitly configured:
 mkdir -p "${ORCH_DIR}/workers/output"
 ```
 
-Initialize `DASHBOARD.md` from the template:
+Render the initial `DASHBOARD.md` (CTL-230) — the renderer reads `state.json` +
+`workers/*.json` signals + the events log every cycle, so calling it now produces a real
+header + empty worker table + waves outline rather than a template skeleton:
 
 ```bash
-cp "${CLAUDE_PLUGIN_ROOT}/templates/orchestrate-dashboard.md" "${ORCH_DIR}/DASHBOARD.md"
+"${CLAUDE_PLUGIN_ROOT}/scripts/update-dashboard.sh" \
+  --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" \
+  >/dev/null 2>>"${ORCH_DIR}/.update-dashboard.log" || true
 ```
 
 Create the orchestrator's status directory:
 
 ```
 ${ORCH_DIR}/                                    # ~/catalyst/runs/${ORCH_NAME}/
-├── DASHBOARD.md                                # human-readable status (from template)
+├── DASHBOARD.md                                # human-readable status (re-rendered each Phase 4 cycle)
 ├── state.json                                  # machine-readable orchestration state
 ├── wave-1-briefing.md                          # per-wave briefings
 ├── SUMMARY.md                                  # final run summary (post-Phase 5)
@@ -822,6 +826,13 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
     --orch "${ORCH_NAME}" --ticket "${TICKET}" --orch-dir "${ORCH_DIR}" -v \
     >/dev/null 2>>"${ORCH_DIR}/.roll-usage.log" || true
 done
+
+# Re-render DASHBOARD.md so the file artifact reflects current state (CTL-230).
+# Idempotent — same inputs produce a byte-identical file. The orch-monitor daemon
+# file-watches DASHBOARD.md and forwards changes to UI clients via SSE.
+"${CLAUDE_PLUGIN_ROOT}/scripts/update-dashboard.sh" \
+  --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" \
+  >/dev/null 2>>"${ORCH_DIR}/.update-dashboard.log" || true
 ```
 
 **Authoritative merge confirmation (CTL-31, refined by CTL-80, CTL-133, CTL-243):**
@@ -1487,14 +1498,21 @@ When all waves are complete:
    - Timeline (start to finish, per-wave durations)
    - Any verification failures that required remediation
 
-   Then persist summary and any remaining briefings to thoughts:
+   Then render the dashboard one final time so the persisted handoff copy reflects the
+   run's terminal state (CTL-230), and persist both alongside any remaining briefings:
 
    ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/update-dashboard.sh" \
+     --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" \
+     >/dev/null 2>>"${ORCH_DIR}/.update-dashboard.log" || true
+
    HANDOFF_DIR="thoughts/shared/handoffs/${ORCH_NAME}"
    mkdir -p "${HANDOFF_DIR}"
    TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
    cp "${ORCH_DIR}/SUMMARY.md" \
       "${HANDOFF_DIR}/${TIMESTAMP}_${ORCH_NAME}-summary.md"
+   cp "${ORCH_DIR}/DASHBOARD.md" \
+      "${HANDOFF_DIR}/${TIMESTAMP}_${ORCH_NAME}-dashboard.md"
    ```
 
 2. **Archive orchestrator artifacts** (CTL-110).
@@ -2030,8 +2048,8 @@ fi
 - Wave advancement requires ALL tickets in the wave to pass verification
 - The `--auto-merge` flag applies to workers, not the orchestrator
 - Dashboard and state files are ephemeral — they don't survive worktree removal
-- Wave briefings and summaries are persisted to `thoughts/shared/handoffs/${ORCH_NAME}/` for
-  archival
+- Wave briefings, summaries, and the final dashboard are persisted to
+  `thoughts/shared/handoffs/${ORCH_NAME}/` for archival (CTL-230)
 - Wave briefings are the key differentiator — knowledge compounds across waves
 - The 3-layer testing enforcement prevents the observed failure mode of agents skipping tests
 - CTL-26 dependency: Uses `.catalyst/` paths. Falls back to `.claude/` if `.catalyst/` doesn't exist


### PR DESCRIPTION
Closes CTL-230.

## Problem

`plugins/dev/skills/orchestrate/SKILL.md` copied `templates/orchestrate-dashboard.md` to `${ORCH_DIR}/DASHBOARD.md` once at Phase 2 init and never touched it again. The file stayed a template skeleton with literal `${VAR}` placeholders for the entire run — misleading anyone reading the file artifact (handoff copies, manual `cat`, audit) instead of the orch-monitor TS UI.

This was visible on this very orchestrator run before the fix:

```
$ head -3 ~/catalyst/runs/orch-ctl-228-2026-05-04/DASHBOARD.md
# Orchestration Dashboard
**Orchestrator:** ${ORCH_NAME}
**Started:** ${STARTED_AT}
```

## What changed

- **`plugins/dev/scripts/update-dashboard.sh`** (new) — renders the dashboard from `${ORCH_DIR}/state.json` + `workers/*.json` signal files + `${CATALYST_DIR}/events/*.jsonl`. Atomic write via `mktemp` + `mv`. Idempotent (same inputs → byte-identical output, no `now()` calls). Reads worker signals directly per Wave 1 pattern #3. Parses events with `fromjson?` so a partially-written line in the shared events log doesn't abort the render.
- **Phase 2 init** in `orchestrate/SKILL.md` — replaced `cp template DASHBOARD.md` with a single renderer invocation so the initial dashboard reflects real metadata even before any worker runs.
- **Phase 4 monitor poll** in `orchestrate/SKILL.md` — re-renders after the worker-status sync + roll-usage loops each cycle, mirroring the `orchestrate-roll-usage.sh` invocation pattern (CTL-229 / CTL-233).
- **Phase 7 close-out** in `orchestrate/SKILL.md` — renders one final time, then copies `DASHBOARD.md` to `thoughts/shared/handoffs/${ORCH_NAME}/` alongside `SUMMARY.md` so the persisted snapshot is accurate (acceptance criterion #5).
- **`plugins/dev/scripts/__tests__/update-dashboard.test.sh`** (new) — 51 cases following the `orchestrate-roll-usage.test.sh` fixture pattern: header, current-wave table, DoD column encoding, completed-wave + upcoming-wave sections, event-log filtering by orchestrator, idempotency, missing PR / missing workers dir, deterministic worker order.

## Acceptance

- [x] `update-dashboard.sh` implemented
- [x] Phase 4 monitoring loop calls the renderer each cycle (after the worker-status sync block)
- [x] Phase 7 close-out renders one final time before SUMMARY.md persistence
- [x] Renderer is idempotent (verified live + in tests)
- [x] Persisted handoff copies are accurate (Phase 7 also copies DASHBOARD.md to handoffs)
- [x] Tests: 51 cases covering header / table / sections / filtering / idempotency / edge cases

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/update-dashboard.test.sh` — 51 passing
- [x] Live render against this orch dir (`orch-ctl-228-2026-05-04`) — produces real ticket IDs (CTL-228…CTL-245), real PR links, no `${` placeholders, byte-identical on re-run
- [x] `bash -n` syntax check on script and test
- [x] Verified pre-existing `orchestrate-comms-integration` failure (CTL-236, separate ticket) is unaffected