### PR TITLE
feat(dev): worker-status-change emitter — severity tiers, coalesce, PR enrichment (CTL-229)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-events.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-events.test.sh
@@ -77,12 +77,12 @@ run "wait-for times out with exit 1" expect_exit 1 "$EVENTS" wait-for --timeout 
 reset_events
 (
   sleep 1
-  write_event '{"ts":"2026-05-03T00:00:00Z","event":"worker-status-change","worker":"X","detail":null}'
+  write_event '{"ts":"2026-05-03T00:00:00Z","event":"worker-status-terminal","worker":"X","detail":null}'
 ) &
 EMITTER_PID=$!
 
 START=$(date +%s)
-OUT=$("$EVENTS" wait-for --timeout 5 --filter '.event == "worker-status-change"')
+OUT=$("$EVENTS" wait-for --timeout 5 --filter '.event == "worker-status-terminal"')
 RC=$?
 END=$(date +%s)
 ELAPSED=$((END - START))
@@ -91,7 +91,7 @@ wait "$EMITTER_PID" 2>/dev/null || true
 
 run "wait-for exits 0 when match arrives" bash -c "[ '$RC' = '0' ]"
 run "wait-for prints the matching line" bash -c "
-  echo '$OUT' | grep -q 'worker-status-change'
+  echo '$OUT' | grep -q 'worker-status-terminal'
 "
 run "wait-for completes in <5s when event arrives early" bash -c "[ '$ELAPSED' -lt 5 ]"
 

--- a/plugins/dev/scripts/__tests__/emit-worker-status-change.test.sh
+++ b/plugins/dev/scripts/__tests__/emit-worker-status-change.test.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# Tests for emit-worker-status-change.sh (CTL-229).
+#
+# Covers severity classification (terminal vs info), coalesce-window batching
+# of routine info events, immediate-emit semantics for terminal events with
+# pending-queue flush, and PR enrichment for PR-bearing terminal transitions.
+#
+# Run: bash plugins/dev/scripts/__tests__/emit-worker-status-change.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+EMITTER="${REPO_ROOT}/plugins/dev/scripts/emit-worker-status-change.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Isolate catalyst dirs so tests don't touch the user's real state.
+export CATALYST_DIR="${SCRATCH}/catalyst"
+EVENTS_DIR="${CATALYST_DIR}/events"
+# catalyst-state.sh writes to ${CATALYST_DIR}/events/YYYY-MM.jsonl; resolve once
+# so tests can read the same path.
+EVENTS_FILE="${EVENTS_DIR}/$(date -u +%Y-%m).jsonl"
+mkdir -p "$EVENTS_DIR"
+: > "$EVENTS_FILE"
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+reset_state() {
+  rm -rf "$EVENTS_DIR" "${CATALYST_DIR}/coalesce"
+  mkdir -p "$EVENTS_DIR"
+  : > "$EVENTS_FILE"
+}
+
+build_signal() {
+  # build a signal file with optional pr block
+  local out="$1" ticket="$2" pr_number="${3:-}" pr_url="${4:-}"
+  if [ -n "$pr_number" ]; then
+    cat > "$out" <<EOF
+{
+  "ticket": "${ticket}",
+  "status": "merging",
+  "pr": {
+    "number": ${pr_number},
+    "url": "${pr_url}"
+  }
+}
+EOF
+  else
+    cat > "$out" <<EOF
+{
+  "ticket": "${ticket}",
+  "status": "implementing",
+  "pr": null
+}
+EOF
+  fi
+}
+
+count_events() {
+  wc -l < "$EVENTS_FILE" | tr -d ' '
+}
+
+last_event() {
+  tail -n 1 "$EVENTS_FILE"
+}
+
+echo "emit-worker-status-change tests"
+
+# ── 1. classify subcommand ─────────────────────────────────────────────────
+run "classify pr-created -> terminal" bash -c "
+  out=\$('$EMITTER' classify pr-created)
+  [ \"\$out\" = 'terminal' ]
+"
+run "classify merging -> terminal" bash -c "
+  out=\$('$EMITTER' classify merging)
+  [ \"\$out\" = 'terminal' ]
+"
+run "classify done -> terminal" bash -c "
+  out=\$('$EMITTER' classify done)
+  [ \"\$out\" = 'terminal' ]
+"
+run "classify failed -> terminal" bash -c "
+  out=\$('$EMITTER' classify failed)
+  [ \"\$out\" = 'terminal' ]
+"
+run "classify stalled -> terminal" bash -c "
+  out=\$('$EMITTER' classify stalled)
+  [ \"\$out\" = 'terminal' ]
+"
+run "classify deploy-failed -> terminal" bash -c "
+  out=\$('$EMITTER' classify deploy-failed)
+  [ \"\$out\" = 'terminal' ]
+"
+run "classify researching -> info" bash -c "
+  out=\$('$EMITTER' classify researching)
+  [ \"\$out\" = 'info' ]
+"
+run "classify planning -> info" bash -c "
+  out=\$('$EMITTER' classify planning)
+  [ \"\$out\" = 'info' ]
+"
+run "classify implementing -> info" bash -c "
+  out=\$('$EMITTER' classify implementing)
+  [ \"\$out\" = 'info' ]
+"
+run "classify validating -> info" bash -c "
+  out=\$('$EMITTER' classify validating)
+  [ \"\$out\" = 'info' ]
+"
+run "classify shipping -> info" bash -c "
+  out=\$('$EMITTER' classify shipping)
+  [ \"\$out\" = 'info' ]
+"
+
+# ── 2. Single info emit does NOT write to event log ────────────────────────
+reset_state
+"$EMITTER" emit --orch orch-a --ticket CTL-100 --from researching --to planning > /dev/null
+run "single info emit writes 0 events" bash -c "[ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '0' ]"
+run "single info emit writes coalesce queue" bash -c "
+  test -f '$CATALYST_DIR/coalesce/orch-a.json' && \
+    jq -e '.changes | length == 1' '$CATALYST_DIR/coalesce/orch-a.json' >/dev/null
+"
+
+# ── 3. 5 info emits in window, then flush -> 1 coalesced event ─────────────
+reset_state
+for i in 1 2 3 4 5; do
+  "$EMITTER" emit --orch orch-b --ticket "CTL-${i}00" --from researching --to planning --coalesce-window 60 > /dev/null
+done
+"$EMITTER" flush --orch orch-b > /dev/null
+run "5 info emits + flush = 1 event in log" bash -c "[ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '1' ]"
+run "coalesced event has 5 changes" bash -c "
+  jq -e '.detail.changes | length == 5' '$EVENTS_FILE' >/dev/null
+"
+run "coalesced event has topic worker-phase-advanced" bash -c "
+  jq -e '.event == \"worker-phase-advanced\"' '$EVENTS_FILE' >/dev/null
+"
+run "coalesced event has worker:null" bash -c "
+  jq -e '.worker == null' '$EVENTS_FILE' >/dev/null
+"
+run "coalesced event has orchestrator field" bash -c "
+  jq -e '.orchestrator == \"orch-b\"' '$EVENTS_FILE' >/dev/null
+"
+run "coalesced changes carry per-worker ids" bash -c "
+  jq -e '[.detail.changes[].worker] == [\"CTL-100\",\"CTL-200\",\"CTL-300\",\"CTL-400\",\"CTL-500\"]' '$EVENTS_FILE' >/dev/null
+"
+
+# ── 4. Stale queue auto-flushed on next emit ───────────────────────────────
+reset_state
+"$EMITTER" emit --orch orch-c --ticket CTL-100 --from researching --to planning --coalesce-window 1 > /dev/null
+sleep 2
+"$EMITTER" emit --orch orch-c --ticket CTL-200 --from researching --to planning --coalesce-window 1 > /dev/null
+run "stale queue flushed on next emit -> 1 event" bash -c "[ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '1' ]"
+run "auto-flushed event has only 1 (stale) change" bash -c "
+  jq -e '.detail.changes | length == 1' '$EVENTS_FILE' >/dev/null
+"
+run "auto-flushed change is the FIRST one" bash -c "
+  jq -e '.detail.changes[0].worker == \"CTL-100\"' '$EVENTS_FILE' >/dev/null
+"
+
+# ── 5. Terminal during coalesce window flushes pending + emits terminal ────
+reset_state
+"$EMITTER" emit --orch orch-d --ticket CTL-100 --from researching --to planning --coalesce-window 60 > /dev/null
+"$EMITTER" emit --orch orch-d --ticket CTL-200 --from planning --to implementing --coalesce-window 60 > /dev/null
+"$EMITTER" emit --orch orch-d --ticket CTL-300 --from implementing --to merging --coalesce-window 60 > /dev/null
+run "terminal during window -> 2 events (coalesced + terminal)" bash -c "
+  [ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '2' ]
+"
+run "first event is coalesced phase-advanced with 2 changes" bash -c "
+  head -n 1 '$EVENTS_FILE' | jq -e '.event == \"worker-phase-advanced\" and (.detail.changes | length == 2)' >/dev/null
+"
+run "second event is worker-status-terminal" bash -c "
+  tail -n 1 '$EVENTS_FILE' | jq -e '.event == \"worker-status-terminal\"' >/dev/null
+"
+run "terminal event identifies worker CTL-300" bash -c "
+  tail -n 1 '$EVENTS_FILE' | jq -e '.worker == \"CTL-300\"' >/dev/null
+"
+run "terminal event has detail.from and detail.to" bash -c "
+  tail -n 1 '$EVENTS_FILE' | jq -e '.detail.from == \"implementing\" and .detail.to == \"merging\"' >/dev/null
+"
+
+# ── 6. PR-bearing terminal with signal file -> .detail.pr populated ────────
+reset_state
+SIGNAL="${SCRATCH}/signal-pr.json"
+build_signal "$SIGNAL" CTL-400 4242 "https://github.com/test/test/pull/4242"
+"$EMITTER" emit --orch orch-e --ticket CTL-400 --from shipping --to pr-created --signal-file "$SIGNAL" > /dev/null
+run "pr-created with signal -> 1 event" bash -c "[ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '1' ]"
+run "pr-created event has .detail.pr.number" bash -c "
+  jq -e '.detail.pr.number == 4242' '$EVENTS_FILE' >/dev/null
+"
+run "pr-created event has .detail.pr.url" bash -c "
+  jq -e '.detail.pr.url == \"https://github.com/test/test/pull/4242\"' '$EVENTS_FILE' >/dev/null
+"
+
+# ── 7. PR-bearing terminal WITHOUT signal file -> .detail.pr omitted, no error
+reset_state
+"$EMITTER" emit --orch orch-f --ticket CTL-500 --from shipping --to merging > "${SCRATCH}/out" 2>&1
+RC=$?
+run "merging without signal returns 0" bash -c "[ '$RC' = '0' ]"
+run "merging without signal -> .detail.pr absent" bash -c "
+  jq -e '.detail | (.pr // null) == null' '$EVENTS_FILE' >/dev/null
+"
+
+# ── 8. Non-PR terminal (failed/stalled) -> .detail.pr omitted ──────────────
+reset_state
+SIGNAL="${SCRATCH}/signal-pr.json"
+build_signal "$SIGNAL" CTL-600 5050 "https://github.com/test/test/pull/5050"
+"$EMITTER" emit --orch orch-g --ticket CTL-600 --from implementing --to failed --signal-file "$SIGNAL" > /dev/null
+run "failed -> 1 event" bash -c "[ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '1' ]"
+run "failed -> .detail.pr absent (even with signal carrying pr)" bash -c "
+  jq -e '.detail | (.pr // null) == null' '$EVENTS_FILE' >/dev/null
+"
+
+reset_state
+"$EMITTER" emit --orch orch-h --ticket CTL-700 --from validating --to stalled --signal-file "$SIGNAL" > /dev/null
+run "stalled -> .detail.pr absent" bash -c "
+  jq -e '.detail | (.pr // null) == null' '$EVENTS_FILE' >/dev/null
+"
+
+# ── 9. Explicit flush with empty queue is no-op ────────────────────────────
+reset_state
+"$EMITTER" flush --orch orch-i > /dev/null
+run "flush of empty/missing queue writes 0 events" bash -c "
+  [ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '0' ]
+"
+
+# ── 10. Explicit flush with non-empty queue emits + clears queue ───────────
+reset_state
+"$EMITTER" emit --orch orch-j --ticket CTL-800 --from researching --to planning > /dev/null
+"$EMITTER" emit --orch orch-j --ticket CTL-900 --from planning --to implementing > /dev/null
+"$EMITTER" flush --orch orch-j > /dev/null
+run "flush -> 1 event" bash -c "[ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '1' ]"
+run "flush -> 2 changes in coalesced event" bash -c "
+  jq -e '.detail.changes | length == 2' '$EVENTS_FILE' >/dev/null
+"
+"$EMITTER" flush --orch orch-j > /dev/null
+run "second flush is no-op (queue cleared)" bash -c "[ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '1' ]"
+
+# ── 11. coalesced event respects --coalesce-window flag (recorded in detail)
+reset_state
+"$EMITTER" emit --orch orch-k --ticket CTL-1000 --from researching --to planning --coalesce-window 120 > /dev/null
+"$EMITTER" flush --orch orch-k > /dev/null
+run "coalesced event records windowSec from --coalesce-window" bash -c "
+  jq -e '.detail.windowSec == 120' '$EVENTS_FILE' >/dev/null
+"
+
+# ── 12. Different orchestrators have independent queues ────────────────────
+reset_state
+"$EMITTER" emit --orch orch-l --ticket CTL-1100 --from researching --to planning > /dev/null
+"$EMITTER" emit --orch orch-m --ticket CTL-1200 --from researching --to planning > /dev/null
+"$EMITTER" flush --orch orch-l > /dev/null
+run "flushing orch-l does not flush orch-m" bash -c "
+  [ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '1' ] && \
+    test -f '$CATALYST_DIR/coalesce/orch-m.json'
+"
+"$EMITTER" flush --orch orch-m > /dev/null
+run "flushing orch-m emits second independent event" bash -c "
+  [ \"\$(wc -l < '$EVENTS_FILE' | tr -d ' ')\" = '2' ]
+"
+
+# ── 13. PR-bearing 'done' terminal pulls pr from signal ────────────────────
+reset_state
+SIGNAL="${SCRATCH}/signal-done.json"
+build_signal "$SIGNAL" CTL-1300 6060 "https://github.com/test/test/pull/6060"
+"$EMITTER" emit --orch orch-n --ticket CTL-1300 --from merging --to done --signal-file "$SIGNAL" > /dev/null
+run "done with signal -> .detail.pr populated" bash -c "
+  jq -e '.detail.pr.number == 6060 and .detail.pr.url == \"https://github.com/test/test/pull/6060\"' '$EVENTS_FILE' >/dev/null
+"
+
+# ── 14. CATALYST_COALESCE_WINDOW_SEC env var honored ───────────────────────
+reset_state
+CATALYST_COALESCE_WINDOW_SEC=99 "$EMITTER" emit --orch orch-o --ticket CTL-1400 --from researching --to planning > /dev/null
+"$EMITTER" flush --orch orch-o > /dev/null
+run "env var CATALYST_COALESCE_WINDOW_SEC respected" bash -c "
+  jq -e '.detail.windowSec == 99' '$EVENTS_FILE' >/dev/null
+"
+
+# ── 15. emit returns nonzero on missing required args ──────────────────────
+"$EMITTER" emit --orch orch-x --ticket CTL-X --from a > "${SCRATCH}/out" 2>&1
+RC=$?
+run "emit without --to returns nonzero" bash -c "[ '$RC' != '0' ]"
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/emit-worker-status-change.sh
+++ b/plugins/dev/scripts/emit-worker-status-change.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# emit-worker-status-change.sh — central producer for worker phase / terminal events (CTL-229).
+#
+# Replaces the inline `jq -nc … event: "worker-status-change"` block in
+# oneshot/SKILL.md's phase_transition helper. Adds three things on top of the
+# old single-event-per-transition shape:
+#
+#   1. Severity tier (topic split):
+#        worker-phase-advanced  — info-tier, coalescable, routine in-flight phases
+#        worker-status-terminal — actionable, emitted immediately, with PR enrichment
+#
+#   2. Coalesce window (info-tier only): routine events arriving within
+#      windowSec for the same orchestrator merge into a single emitted event
+#      with .detail.changes: [{ts, worker, from, to}, …]. Default 30 s.
+#
+#   3. PR enrichment: when --to is in the PR-bearing terminal set
+#      (pr-created, merging, merged, done, deploy-failed), the emitter reads
+#      .pr.{number,url} from --signal-file and adds .detail.pr to the event.
+#
+# Subcommands:
+#
+#   emit-worker-status-change.sh emit \
+#     --orch <id> --ticket <id> --from <s> --to <s> \
+#     [--signal-file <path>] [--coalesce-window <sec>]
+#
+#   emit-worker-status-change.sh flush --orch <id>
+#       Flush any pending coalesce queue for the given orchestrator. No-op if
+#       the queue is empty. Used by orchestrator periodic sweeps and
+#       end-of-orchestration cleanup so the last event in a sequence does not
+#       linger past windowSec.
+#
+#   emit-worker-status-change.sh classify <to-status>
+#       Print "terminal" or "info" for the given destination status. Helper
+#       for tests and skill prose.
+#
+# Stragglers (the last event in a sequence) flush via the next emit OR an
+# explicit flush call. We do NOT spawn a background flusher — the
+# orchestrator's existing 10-min idle scan in orchestrate/SKILL.md Phase 4 is
+# the documented contract for periodic flushing.
+#
+# All events are appended via catalyst-state.sh event <json>, the same path
+# that previously emitted worker-status-change.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks (CTL-239 pattern) so installs that symlink the script work.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  TARGET="$(readlink "$SOURCE")"
+  case "$TARGET" in
+    /*) SOURCE="$TARGET" ;;
+    *)  SOURCE="$(cd "$(dirname "$SOURCE")" && pwd)/$TARGET" ;;
+  esac
+done
+SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+STATE_SCRIPT="${SCRIPT_DIR}/catalyst-state.sh"
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+COALESCE_DIR="${CATALYST_DIR}/coalesce"
+
+# Default coalesce window. CLI --coalesce-window flag overrides; env var
+# CATALYST_COALESCE_WINDOW_SEC overrides the built-in default but is itself
+# overridden by the flag.
+DEFAULT_WINDOW_SEC="${CATALYST_COALESCE_WINDOW_SEC:-30}"
+
+# Terminal destination set — these states fire immediately and may carry
+# PR enrichment. Anything else is info-tier and goes through the coalesce
+# queue.
+is_terminal() {
+  case "$1" in
+    pr-created|merging|merged|done|failed|stalled|deploy-failed|deploying)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+# PR-bearing subset of terminal states — for these the emitter looks up
+# .pr.{number,url} on the worker signal file and adds .detail.pr to the
+# event. Other terminals (failed, stalled, deploying) never carry .detail.pr.
+is_pr_bearing() {
+  case "$1" in
+    pr-created|merging|merged|done|deploy-failed) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+now_iso() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# Convert ISO 8601 UTC timestamp to epoch seconds. Portable across macOS
+# (BSD date) and Linux (GNU date) by stripping the trailing Z and using a
+# format string both accept.
+iso_to_epoch() {
+  local iso="$1"
+  # Strip trailing Z
+  local naive="${iso%Z}"
+  if date -j -u -f "%Y-%m-%dT%H:%M:%S" "$naive" +%s 2>/dev/null; then
+    return
+  fi
+  # GNU date fallback
+  date -u -d "${naive}Z" +%s
+}
+
+ensure_coalesce_dir() {
+  mkdir -p "$COALESCE_DIR"
+}
+
+# mkdir-based atomic lock (same pattern as catalyst-state.sh). Spins for up
+# to ~10 s waiting for the lock holder to release.
+lock_acquire() {
+  local lock_dir="$1"
+  local i=0
+  until mkdir "$lock_dir" 2>/dev/null; do
+    i=$((i + 1))
+    if [ "$i" -gt 100 ]; then
+      echo "emit-worker-status-change: timed out waiting for lock $lock_dir" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+}
+
+lock_release() {
+  rmdir "$1" 2>/dev/null || true
+}
+
+# Append a JSON event to the event log via catalyst-state.sh. We pipe the
+# JSON in to avoid bash quoting fragility.
+append_event() {
+  local event_json="$1"
+  if [ -x "$STATE_SCRIPT" ]; then
+    "$STATE_SCRIPT" event "$event_json"
+  else
+    # Fallback: write directly to the events file. Same path catalyst-state.sh
+    # uses (CATALYST_EVENTS_DIR / YYYY-MM.jsonl, or CATALYST_EVENTS_FILE if
+    # explicitly set, used by tests).
+    local events_file
+    if [ -n "${CATALYST_EVENTS_FILE:-}" ]; then
+      events_file="$CATALYST_EVENTS_FILE"
+    else
+      events_file="${CATALYST_EVENTS_DIR:-$CATALYST_DIR/events}/$(date -u +%Y-%m).jsonl"
+      mkdir -p "$(dirname "$events_file")"
+    fi
+    printf '%s\n' "$event_json" >> "$events_file"
+  fi
+}
+
+# Flush the queue for an orchestrator if non-empty. Caller must hold the lock.
+# Emits a worker-phase-advanced event with the accumulated changes and clears
+# the queue file.
+flush_queue_locked() {
+  local orch="$1"
+  local queue_file="${COALESCE_DIR}/${orch}.json"
+  [ -f "$queue_file" ] || return 0
+
+  local change_count
+  change_count=$(jq '.changes | length' "$queue_file" 2>/dev/null || echo 0)
+  if [ "$change_count" = "0" ] || [ -z "$change_count" ]; then
+    rm -f "$queue_file"
+    return 0
+  fi
+
+  local event_json
+  event_json=$(jq -nc \
+    --slurpfile q "$queue_file" \
+    --arg ts "$(now_iso)" \
+    '{
+      ts: $ts,
+      orchestrator: $q[0].orchestrator,
+      worker: null,
+      event: "worker-phase-advanced",
+      detail: {
+        windowSec: $q[0].windowSec,
+        changes: $q[0].changes
+      }
+    }')
+  append_event "$event_json"
+  rm -f "$queue_file"
+}
+
+# ─── Subcommands ──────────────────────────────────────────────────────────
+
+cmd_classify() {
+  local to="${1:-}"
+  if [ -z "$to" ]; then
+    echo "usage: emit-worker-status-change.sh classify <to-status>" >&2
+    return 2
+  fi
+  if is_terminal "$to"; then
+    echo "terminal"
+  else
+    echo "info"
+  fi
+}
+
+cmd_flush() {
+  local orch=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --orch) orch="$2"; shift 2 ;;
+      *) echo "flush: unknown arg: $1" >&2; return 2 ;;
+    esac
+  done
+  if [ -z "$orch" ]; then
+    echo "flush: --orch is required" >&2
+    return 2
+  fi
+  ensure_coalesce_dir
+  local lock_dir="${COALESCE_DIR}/${orch}.lock"
+  lock_acquire "$lock_dir" || return 1
+  flush_queue_locked "$orch"
+  lock_release "$lock_dir"
+}
+
+cmd_emit() {
+  local orch="" ticket="" from="" to="" signal_file=""
+  local window_sec="$DEFAULT_WINDOW_SEC"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --orch)             orch="$2";        shift 2 ;;
+      --ticket)           ticket="$2";      shift 2 ;;
+      --from)             from="$2";        shift 2 ;;
+      --to)               to="$2";          shift 2 ;;
+      --signal-file)      signal_file="$2"; shift 2 ;;
+      --coalesce-window)  window_sec="$2";  shift 2 ;;
+      *) echo "emit: unknown arg: $1" >&2; return 2 ;;
+    esac
+  done
+
+  if [ -z "$orch" ] || [ -z "$ticket" ] || [ -z "$from" ] || [ -z "$to" ]; then
+    echo "emit: --orch, --ticket, --from, --to are required" >&2
+    return 2
+  fi
+
+  ensure_coalesce_dir
+  local lock_dir="${COALESCE_DIR}/${orch}.lock"
+  lock_acquire "$lock_dir" || return 1
+
+  local queue_file="${COALESCE_DIR}/${orch}.json"
+  local now ts
+  now=$(date -u +%s)
+  ts=$(now_iso)
+
+  # Step 1: if existing queue is stale, flush it before doing anything else.
+  if [ -f "$queue_file" ]; then
+    local q_start q_window q_start_epoch
+    q_start=$(jq -r '.windowStartTs // empty' "$queue_file" 2>/dev/null || echo "")
+    q_window=$(jq -r '.windowSec // 30' "$queue_file" 2>/dev/null || echo 30)
+    if [ -n "$q_start" ]; then
+      q_start_epoch=$(iso_to_epoch "$q_start" 2>/dev/null || echo 0)
+      if [ -n "$q_start_epoch" ] && [ "$q_start_epoch" != "0" ]; then
+        if [ "$((q_start_epoch + q_window))" -lt "$now" ]; then
+          flush_queue_locked "$orch"
+        fi
+      fi
+    fi
+  fi
+
+  if is_terminal "$to"; then
+    # Flush any pending (non-stale) info-tier queue first so the order in the
+    # log is "all preceding routine progress, then this terminal event".
+    flush_queue_locked "$orch"
+
+    # Build the terminal event payload.
+    local detail_json="{\"from\": \"$from\", \"to\": \"$to\"}"
+    if is_pr_bearing "$to" && [ -n "$signal_file" ] && [ -f "$signal_file" ]; then
+      local pr_number pr_url
+      pr_number=$(jq -r '.pr.number // empty' "$signal_file" 2>/dev/null || echo "")
+      pr_url=$(jq -r '.pr.url // empty' "$signal_file" 2>/dev/null || echo "")
+      if [ -n "$pr_number" ] && [ -n "$pr_url" ]; then
+        detail_json=$(jq -nc \
+          --arg from "$from" \
+          --arg to "$to" \
+          --argjson n "$pr_number" \
+          --arg url "$pr_url" \
+          '{from: $from, to: $to, pr: {number: $n, url: $url}}')
+      fi
+    fi
+
+    local event_json
+    event_json=$(jq -nc \
+      --arg ts "$ts" \
+      --arg orch "$orch" \
+      --arg ticket "$ticket" \
+      --argjson detail "$detail_json" \
+      '{
+        ts: $ts,
+        orchestrator: $orch,
+        worker: $ticket,
+        event: "worker-status-terminal",
+        detail: $detail
+      }')
+    append_event "$event_json"
+  else
+    # Info-tier: append change to coalesce queue. Start a new window if queue
+    # is empty/missing.
+    if [ ! -f "$queue_file" ]; then
+      jq -nc \
+        --arg orch "$orch" \
+        --arg ts "$ts" \
+        --argjson w "$window_sec" \
+        --arg worker "$ticket" \
+        --arg from "$from" \
+        --arg to "$to" \
+        '{
+          schemaVersion: 1,
+          orchestrator: $orch,
+          windowStartTs: $ts,
+          windowSec: $w,
+          changes: [{ts: $ts, worker: $worker, from: $from, to: $to}]
+        }' > "$queue_file"
+    else
+      # Append to existing queue. Preserve windowStartTs and windowSec.
+      jq --arg ts "$ts" \
+         --arg worker "$ticket" \
+         --arg from "$from" \
+         --arg to "$to" \
+         '.changes += [{ts: $ts, worker: $worker, from: $from, to: $to}]' \
+         "$queue_file" > "${queue_file}.tmp" && mv "${queue_file}.tmp" "$queue_file"
+    fi
+  fi
+
+  lock_release "$lock_dir"
+}
+
+# ─── Dispatch ─────────────────────────────────────────────────────────────
+
+main() {
+  local cmd="${1:-}"
+  if [ -z "$cmd" ]; then
+    cat >&2 <<EOF
+usage: emit-worker-status-change.sh <subcommand> [...]
+
+subcommands:
+  emit      --orch <id> --ticket <id> --from <s> --to <s>
+            [--signal-file <path>] [--coalesce-window <sec>]
+  flush     --orch <id>
+  classify  <to-status>
+EOF
+    return 2
+  fi
+  shift
+  case "$cmd" in
+    emit)     cmd_emit "$@" ;;
+    flush)    cmd_flush "$@" ;;
+    classify) cmd_classify "$@" ;;
+    -h|--help|help)
+      cat <<EOF
+emit-worker-status-change.sh — emit worker-phase-advanced / worker-status-terminal events.
+
+  emit      Emit (or buffer) a phase transition.
+  flush     Flush a pending coalesce queue.
+  classify  Print "terminal" or "info" for a destination status.
+
+Env:
+  CATALYST_DIR                       base catalyst dir (default: \$HOME/catalyst)
+  CATALYST_COALESCE_WINDOW_SEC       default coalesce window in seconds (default: 30)
+  CATALYST_EVENTS_FILE               override events file path (used by tests)
+EOF
+      return 0 ;;
+    *)
+      echo "unknown subcommand: $cmd" >&2
+      return 2 ;;
+  esac
+}
+
+main "$@"

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -97,7 +97,8 @@ catalyst-events tail --filter '
   (.event | startswith("github.deployment")) or
   (.event == "github.push") or
   (.event | startswith("linear.issue.")) or
-  (.event == "worker-status-change") or
+  (.event == "worker-phase-advanced") or
+  (.event == "worker-status-terminal") or
   (.event == "worker-pr-created") or
   (.event == "worker-done") or
   (.event == "worker-failed") or
@@ -228,6 +229,56 @@ equivalent: `wait-for` instead of `Monitor`, `case` on the matched event
 instead of the canonical PR state. They share the same safety rule: treat
 events as wake-up triggers; treat `gh pr view` (or its equivalent) as truth.
 
+## Worker phase events — severity tiers and coalescing (CTL-229)
+
+The worker emitter splits phase transitions into two topics so subscribers can
+filter by severity instead of inspecting `.detail` fields:
+
+| Topic | Tier | When | Coalesces? | Carries `detail.pr`? |
+|---|---|---|---|---|
+| `worker-phase-advanced` | info | routine in-flight phases (researching, planning, implementing, validating, shipping) | yes — batched per orchestrator within `windowSec` (default 30 s) | no |
+| `worker-status-terminal` | act  | actionable transitions (pr-created, merging, merged, done, failed, stalled, deploy-failed, deploying) | no — emitted immediately and flushes any pending coalesce queue | yes when `to ∈ {pr-created, merging, merged, done, deploy-failed}` |
+
+Coalesced `worker-phase-advanced` events have `worker: null` at the envelope level;
+the per-change `worker` lives inside `.detail.changes[]`:
+
+```json
+{
+  "ts": "2026-05-04T22:00:00Z",
+  "orchestrator": "orch-foo",
+  "worker": null,
+  "event": "worker-phase-advanced",
+  "detail": {
+    "windowSec": 30,
+    "changes": [
+      { "ts": "2026-05-04T21:59:32Z", "worker": "CTL-229", "from": "researching", "to": "planning" },
+      { "ts": "2026-05-04T21:59:36Z", "worker": "CTL-232", "from": "planning",    "to": "implementing" }
+    ]
+  }
+}
+```
+
+Stragglers (the last event in a sequence) flush via the next `emit` OR via an
+explicit `emit-worker-status-change.sh flush --orch <id>` invocation. The
+orchestrator's 10-min idle scan is the documented contract for periodic
+flushing — a worker exiting between phases does not need to flush its own
+queue.
+
+Subscriber recipes:
+
+```bash
+# Subscribe to actionable transitions only (no routine progress noise)
+catalyst-events tail --filter '.event == "worker-status-terminal"'
+
+# Subscribe to routine progress (already coalesced into batches)
+catalyst-events tail --filter '.event == "worker-phase-advanced"'
+
+# A worker just opened a PR — wait until it tells you the PR number
+catalyst-events wait-for --timeout 600 \
+  --filter '.event == "worker-status-terminal" and .detail.to == "pr-created" and .worker == "CTL-229"' \
+  | jq -r '.detail.pr.number'
+```
+
 ## Pattern 4 — Tail everything happening to a ticket
 
 Useful for live debugging or operator dashboards:
@@ -305,7 +356,9 @@ unavailable, insufficient, or contradicts what you expect.
 | Comment from a human on a PR | `.event == "github.issue_comment.created" and (.detail.author.type // "User") != "Bot"` |
 | Linear ticket state change | `.event == "linear.issue.state_changed" and .scope.ticket == "CTL-210"` |
 | Comms message in one channel | `.event == "comms.message.posted" and .detail.channel == "orch-foo"` |
-| Worker phase transition | `.event == "worker-status-change" and .worker == "CTL-210"` |
+| Routine worker phase transitions (info-tier, coalesced batches; CTL-229) | `.event == "worker-phase-advanced"` |
+| Worker terminal transitions (PR-created, merging, done, fail; CTL-229) | `.event == "worker-status-terminal"` |
+| One worker's terminal events with PR number | `.event == "worker-status-terminal" and .worker == "CTL-210" and (.detail.pr.number // null)` |
 | Worker reached terminal state | `.event == "worker-done" or .event == "worker-failed"` |
 | PR review activity | `(.event \| startswith("github.pr_review")) or (.event == "github.issue_comment.created")` |
 | Deploy outcome | `.event \| startswith("github.deployment")` |

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -222,14 +222,20 @@ if [ -f "$SIGNAL_FILE" ]; then
     "$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET_ID" \
       ".status = \"$NEW_STATUS\" | .phase = $PHASE_NUM"
 
-    # Emit status change event
-    "$STATE_SCRIPT" event "$(jq -nc \
-      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-      --arg orch "$ORCH_ID" \
-      --arg w "$TICKET_ID" \
-      --arg from "$OLD_STATUS" \
-      --arg to "$NEW_STATUS" \
-      '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-status-change", detail: {from: $from, to: $to}}')"
+    # Emit phase-advance / terminal event via the central producer (CTL-229).
+    # Routine info-tier transitions (researching → planning → …) coalesce
+    # within the configured window; terminal transitions (pr-created, merging,
+    # done, failed, stalled, deploy-failed) flush any pending queue and emit
+    # immediately, with PR enrichment when --to is PR-bearing.
+    EMITTER="${CLAUDE_PLUGIN_ROOT:-/Users/ryan/.claude/plugins/cache/catalyst/catalyst-dev/8.1.0}/scripts/emit-worker-status-change.sh"
+    if [ -x "$EMITTER" ]; then
+      "$EMITTER" emit \
+        --orch "$ORCH_ID" \
+        --ticket "$TICKET_ID" \
+        --from "$OLD_STATUS" \
+        --to "$NEW_STATUS" \
+        --signal-file "$SIGNAL_FILE" >/dev/null 2>&1 || true
+    fi
   fi
 
   # CTL-111: announce phase transition to shared comms channel. Runs 5× in the

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -718,7 +718,8 @@ catalyst-events tail --filter '
   (.event | startswith("github.deployment")) or
   (.event == "github.push") or
   (.event | startswith("linear.issue.")) or
-  (.event == "worker-status-change") or
+  (.event == "worker-phase-advanced") or
+  (.event == "worker-status-terminal") or
   (.event == "worker-pr-created") or
   (.event == "worker-done") or
   (.event == "worker-failed") or
@@ -734,7 +735,8 @@ are wake-up triggers, never sources of truth.
 
 | Event | Reaction |
 |---|---|
-| `worker-status-change`, `worker-done`, `worker-failed` | Re-render `DASHBOARD.md`; if terminal, run `orchestrate-dispatch-next` to fill freed slots |
+| `worker-phase-advanced` | Routine in-flight progress; re-render `DASHBOARD.md`. Coalesced — `.detail.changes` carries the batch (CTL-229) |
+| `worker-status-terminal`, `worker-done`, `worker-failed` | Terminal transition; re-render `DASHBOARD.md` and run `orchestrate-dispatch-next` to fill freed slots. PR-bearing transitions carry `.detail.pr.{number,url}` (CTL-229) |
 | `worker-pr-created` | Reconcile the PR number into signal/state; re-render `DASHBOARD.md` |
 | `attention-raised`, `attention-resolved` | Re-render the `DASHBOARD.md` NEEDS ATTENTION banner |
 | `github.pr.merged`, `github.pr.closed` | Run the merge-confirmation scan for that PR |

--- a/plugins/dev/templates/global-event.json
+++ b/plugins/dev/templates/global-event.json
@@ -29,7 +29,8 @@
         "wave-started",
         "wave-completed",
         "worker-dispatched",
-        "worker-status-change",
+        "worker-phase-advanced",
+        "worker-status-terminal",
         "worker-pr-created",
         "worker-done",
         "worker-failed",
@@ -51,11 +52,29 @@
       "properties": {
         "from": {
           "type": "string",
-          "description": "Previous status (for status-change events)"
+          "description": "Previous status (for worker-status-terminal events)"
         },
         "to": {
           "type": "string",
-          "description": "New status (for status-change events)"
+          "description": "New status (for worker-status-terminal events)"
+        },
+        "windowSec": {
+          "type": "integer",
+          "description": "Coalesce window in seconds (for worker-phase-advanced events)"
+        },
+        "changes": {
+          "type": "array",
+          "description": "Coalesced batch of routine phase transitions (for worker-phase-advanced events)",
+          "items": {
+            "type": "object",
+            "required": ["ts", "worker", "from", "to"],
+            "properties": {
+              "ts": { "type": "string", "format": "date-time" },
+              "worker": { "type": "string" },
+              "from": { "type": "string" },
+              "to": { "type": "string" }
+            }
+          }
         },
         "wave": {
           "type": "integer",
@@ -67,8 +86,18 @@
           "description": "Tickets involved (for wave-started, orchestrator-started)"
         },
         "pr": {
-          "type": "integer",
-          "description": "PR number (for pr-created events)"
+          "oneOf": [
+            { "type": "integer", "description": "PR number (for worker-pr-created events)" },
+            {
+              "type": "object",
+              "description": "PR enrichment block (for PR-bearing worker-status-terminal events)",
+              "required": ["number", "url"],
+              "properties": {
+                "number": { "type": "integer" },
+                "url": { "type": "string" }
+              }
+            }
+          ]
         },
         "url": {
           "type": "string",

--- a/website/src/content/docs/observability/recording.md
+++ b/website/src/content/docs/observability/recording.md
@@ -95,7 +95,7 @@ Event types:
 
 - `orchestrator-started`, `orchestrator-completed`, `orchestrator-stalled`
 - `wave-started`, `wave-completed`
-- `worker-status-change`, `worker-pr-created`, `worker-done`, `worker-failed`
+- `worker-phase-advanced`, `worker-status-terminal`, `worker-pr-created`, `worker-done`, `worker-failed`
 - `verification-started`, `verification-passed`, `verification-failed`
 - `attention-raised`, `attention-resolved`
 

--- a/website/src/content/docs/observability/terminal.md
+++ b/website/src/content/docs/observability/terminal.md
@@ -37,9 +37,9 @@ Quit with `q` or `Ctrl-C`.
 │ CTL-48  researching !                      1m 15s │  ← dead PID
 └────────────────────────────────────────────────────┘
 Events (most recent first):
-  19:15:32  CTL-44  worker-pr-created     pr#120
-  19:14:01  CTL-46  worker-status-change  validating
-  19:13:44  CTL-48  worker-failed         crashed — PID gone
+  19:15:32  CTL-44  worker-pr-created       pr#120
+  19:14:01  CTL-46  worker-phase-advanced   validating
+  19:13:44  CTL-48  worker-failed           crashed — PID gone
 ```
 
 Color coding matches the web UI: blue for in-progress phases, green for done, red for failed/dead, amber for validating/shipping.


### PR DESCRIPTION
## Summary

Implements [CTL-229](https://linear.app/coalesce-labs/issue/CTL-229) — three ergonomic gaps in the `worker-status-change` emitter that surfaced during multi-worker orchestration dogfood:

- **Severity tier (topic split):** transitions now split into `worker-phase-advanced` (info, routine in-flight phases) and `worker-status-terminal` (act, terminal/PR-bearing). Subscribers filter by topic instead of inspecting `.detail` fields.
- **Coalesce window:** info-tier events for the same orchestrator merge within `windowSec` (default 30 s, configurable). One coalesced event with `.detail.changes: [{ts, worker, from, to}, …]` replaces N events with 1 change each. Terminal events emit immediately and flush any pending queue.
- **PR enrichment:** `worker-status-terminal` events with `to ∈ {pr-created, merging, merged, done, deploy-failed}` carry `.detail.pr.{number, url}` read from the worker signal file. Consumers no longer have to `jq` the signal file to recover the PR.

## Implementation

### New: `plugins/dev/scripts/emit-worker-status-change.sh`

Central producer with three subcommands:

```
emit       --orch <id> --ticket <id> --from <s> --to <s>
           [--signal-file <path>] [--coalesce-window <sec>]
flush      --orch <id>
classify   <to-status>
```

Coalesce queue lives at `${CATALYST_DIR}/coalesce/<orch-id>.json` with mkdir-based atomic locking (same pattern as `catalyst-state.sh`). Stragglers flush via the next emit OR an explicit `flush` invocation; the orchestrator's 10-min idle scan is the documented periodic-flush contract.

### Producer migration

`plugins/dev/skills/oneshot/SKILL.md` — `phase_transition` helper now delegates to the new script instead of inlining a `jq -nc … event: "worker-status-change"` block.

### Consumer migration (clean cutover)

- `plugins/dev/skills/orchestrate/SKILL.md` — Phase 4 Monitor filter subscribes to both new topics; wake-up classification table updated.
- `plugins/dev/skills/monitor-events/SKILL.md` — canonical filter, filter cookbook, plus a new "Worker phase events — severity tiers and coalescing" section documenting the contract.
- `plugins/dev/templates/global-event.json` — replaced `worker-status-change` enum entry with the two new topics; added schema for `windowSec`, `changes[]`, and the `pr` `oneOf` (integer for `worker-pr-created`, object for terminal).
- `plugins/dev/scripts/__tests__/catalyst-events.test.sh` — fixture event names migrated.
- Website docs (`observability/recording.md`, `observability/terminal.md`) updated.

## Test plan

- [x] Shell tests: `bash plugins/dev/scripts/__tests__/emit-worker-status-change.test.sh` — **45 pass / 0 fail**
- [x] No regressions: `bash plugins/dev/scripts/__tests__/catalyst-events.test.sh` — 14 pass; `catalyst-state.test.sh` — 17 pass; `orchestrate-roll-usage.test.sh` — 49 pass
- [x] JSON schema validates
- [x] orch-monitor TS typecheck clean (no producer changes touch TS code)
- [x] `audit-references.sh --ci` rc=0

Test coverage maps directly to the ticket's acceptance criteria:

| Acceptance | Test |
|---|---|
| 5 routine transitions in 30 s → 1 coalesced event | `5 info emits + flush = 1 event in log`, `coalesced event has 5 changes` |
| Terminal during coalesce window → emits immediately | `terminal during window -> 2 events (coalesced + terminal)`, `second event is worker-status-terminal` |
| PR-implying transition has `.detail.pr.number` | `pr-created event has .detail.pr.number`, `done with signal -> .detail.pr populated` |
| Non-PR transition omits `.detail.pr` | `failed -> .detail.pr absent (even with signal carrying pr)`, `stalled -> .detail.pr absent` |

## Notes

- This is a clean cutover for an internal event contract — both producer and consumer skills live in this repo and co-evolve. External agents (if any) that subscribed to `worker-status-change` directly need to update their filter to either of the two new topics.
- We deliberately do NOT spawn a background flusher process — the orchestrator's existing 10-min idle scan is the documented periodic-flush contract. Bash `&`/`disown` is fragile in tests and unnecessary given that orchestrators have continuous activity.