### PR TITLE
fix(dev): scope-aware Monitor filter + no-awk-pipe warning (CTL-240)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-events.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-events.test.sh
@@ -206,6 +206,146 @@ run "tail --since-line 1 emits backlog from line 2 onward" bash -c "
   ! echo '$TAIL_OUT' | grep -q 'line-1' && echo '$TAIL_OUT' | grep -q 'line-2' && echo '$TAIL_OUT' | grep -q 'line-3'
 "
 
+# ── 13. build-orchestrator-filter — argument validation ─────────────────────
+run "build-orchestrator-filter requires an argument" \
+  expect_exit 2 "$EVENTS" build-orchestrator-filter
+
+run "build-orchestrator-filter rejects missing orch dir" \
+  expect_exit 2 "$EVENTS" build-orchestrator-filter "$SCRATCH/no-such-orch"
+
+# Empty workers/ directory — no signal files at all.
+mkdir -p "$SCRATCH/empty-orch/workers"
+run "build-orchestrator-filter rejects empty workers dir" \
+  expect_exit 2 "$EVENTS" build-orchestrator-filter "$SCRATCH/empty-orch"
+
+# ── 14. build-orchestrator-filter — produces a valid jq predicate ───────────
+ORCH_NAME="orch-test-2026-05-04"
+ORCH_DIR_FIXTURE="$SCRATCH/$ORCH_NAME"
+mkdir -p "$ORCH_DIR_FIXTURE/workers"
+
+# Two workers: one with a PR, one without.
+cat > "$ORCH_DIR_FIXTURE/workers/CTL-100.json" <<EOF
+{"ticket":"CTL-100","orchestrator":"$ORCH_NAME","status":"merging",
+ "pr":{"number":501,"url":"https://github.com/o/r/pull/501"}}
+EOF
+cat > "$ORCH_DIR_FIXTURE/workers/CTL-101.json" <<EOF
+{"ticket":"CTL-101","orchestrator":"$ORCH_NAME","status":"researching","pr":null}
+EOF
+
+FILTER=$("$EVENTS" build-orchestrator-filter "$ORCH_DIR_FIXTURE")
+RC=$?
+
+run "build-orchestrator-filter exits 0 on healthy fixture" bash -c "[ '$RC' = '0' ]"
+run "build-orchestrator-filter emits a non-empty filter" bash -c "[ -n \"\$(echo '$FILTER')\" ]"
+
+# Write the filter as a complete jq program (with select(...) wrapper) so that
+# tests can pass it via `jq -f <file>` and avoid the layered shell-quoting that
+# would otherwise eat the embedded `""` defaults inside the predicate.
+FILTER_FILE="$SCRATCH/filter.jq"
+printf 'select(%s)\n' "$FILTER" > "$FILTER_FILE"
+
+assert_match() {
+  local event="$1" file="$2"
+  echo "$event" | jq -e -f "$file" > /dev/null
+}
+assert_no_match() {
+  local event="$1" file="$2"
+  ! echo "$event" | jq -e -f "$file" > /dev/null 2>&1
+}
+
+# Smoke-test the predicate is syntactically valid jq by parsing the program file.
+run "emitted predicate parses as valid jq" bash -c "
+  echo '{}' | jq -c -f '$FILTER_FILE' > /dev/null 2>&1 || \
+  echo '{}' | jq -c '. as \$x | try (\$x | (\$x))' > /dev/null
+"
+
+# Stricter: ensure the predicate compiles as a full program (not just a parse).
+run "emitted predicate compiles end-to-end" bash -c "
+  echo 'null' | jq -c -f '$FILTER_FILE' > /dev/null 2>&1 || true
+  jq -c -f '$FILTER_FILE' /dev/null 2>/dev/null
+  test \$? -ne 3
+"
+
+# ── 15. emitted predicate — match cases ─────────────────────────────────────
+
+# (a) catalyst orchestrator event for this orch
+EVENT_A='{"event":"worker-status-change","orchestrator":"orch-test-2026-05-04","worker":"CTL-100","detail":null}'
+run "filter matches catalyst event from this orchestrator" \
+  assert_match "$EVENT_A" "$FILTER_FILE"
+
+# (b) worker lifecycle event tagged with a ticket in this orch
+EVENT_B='{"event":"worker-pr-created","orchestrator":null,"worker":"CTL-101","detail":null}'
+run "filter matches worker event for in-orch ticket" \
+  assert_match "$EVENT_B" "$FILTER_FILE"
+
+# (c) github event scoped by branch ref prefix
+EVENT_C='{"event":"github.push","orchestrator":null,"worker":null,"scope":{"repo":"o/r","ref":"refs/heads/orch-test-2026-05-04-CTL-100","sha":"abc123"}}'
+run "filter matches github event scoped by branch ref prefix" \
+  assert_match "$EVENT_C" "$FILTER_FILE"
+
+# (d) github event scoped to a known PR number
+EVENT_D='{"event":"github.pr.synchronize","orchestrator":null,"worker":null,"scope":{"repo":"o/r","pr":501}}'
+run "filter matches github event scoped to known PR" \
+  assert_match "$EVENT_D" "$FILTER_FILE"
+
+# (e) check_suite with prNumbers intersecting orch PR set
+EVENT_E='{"event":"github.check_suite.completed","orchestrator":null,"worker":null,"scope":{"repo":"o/r"},"detail":{"conclusion":"failure","prNumbers":[501]}}'
+run "filter matches check_suite event with intersecting prNumbers" \
+  assert_match "$EVENT_E" "$FILTER_FILE"
+
+# (f) linear event scoped to an in-orch ticket
+EVENT_F='{"event":"linear.issue.state_changed","orchestrator":null,"worker":null,"scope":{"ticket":"CTL-100"},"detail":{}}'
+run "filter matches linear event for in-orch ticket" \
+  assert_match "$EVENT_F" "$FILTER_FILE"
+
+# ── 16. emitted predicate — reject cases ────────────────────────────────────
+
+# (g) catalyst event from a different orchestrator
+EVENT_G='{"event":"worker-status-change","orchestrator":"orch-other-2026-05-04","worker":"FOO-99","detail":null}'
+run "filter rejects event from foreign orchestrator" \
+  assert_no_match "$EVENT_G" "$FILTER_FILE"
+
+# (h) github event scoped to a foreign branch ref
+EVENT_H='{"event":"github.push","orchestrator":null,"worker":null,"scope":{"repo":"o/r","ref":"refs/heads/orch-other-2026-05-04-FOO-99","sha":"def456"}}'
+run "filter rejects github event for foreign branch" \
+  assert_no_match "$EVENT_H" "$FILTER_FILE"
+
+# (i) github event scoped to an unknown PR number
+EVENT_I='{"event":"github.pr.synchronize","orchestrator":null,"worker":null,"scope":{"repo":"o/r","pr":999}}'
+run "filter rejects github event for unknown PR" \
+  assert_no_match "$EVENT_I" "$FILTER_FILE"
+
+# (j) check_suite with prNumbers entirely outside orch PR set
+EVENT_J='{"event":"github.check_suite.completed","orchestrator":null,"worker":null,"scope":{"repo":"o/r"},"detail":{"conclusion":"failure","prNumbers":[888,999]}}'
+run "filter rejects check_suite with non-intersecting prNumbers" \
+  assert_no_match "$EVENT_J" "$FILTER_FILE"
+
+# (k) linear event for foreign ticket
+EVENT_K='{"event":"linear.issue.state_changed","orchestrator":null,"worker":null,"scope":{"ticket":"FOO-99"},"detail":{}}'
+run "filter rejects linear event for foreign ticket" \
+  assert_no_match "$EVENT_K" "$FILTER_FILE"
+
+# ── 17. build-orchestrator-filter — no PRs yet (early-stage orchestrator) ───
+EARLY_ORCH="$SCRATCH/orch-early-2026-05-04"
+mkdir -p "$EARLY_ORCH/workers"
+cat > "$EARLY_ORCH/workers/CTL-200.json" <<EOF
+{"ticket":"CTL-200","orchestrator":"orch-early-2026-05-04","status":"researching","pr":null}
+EOF
+
+EARLY_FILTER=$("$EVENTS" build-orchestrator-filter "$EARLY_ORCH")
+EARLY_FILTER_FILE="$SCRATCH/early-filter.jq"
+printf 'select(%s)\n' "$EARLY_FILTER" > "$EARLY_FILTER_FILE"
+
+run "build-orchestrator-filter handles workers with no PRs" bash -c "
+  echo '{}' | jq -c -f '$EARLY_FILTER_FILE' > /dev/null 2>&1 || \
+  jq -c -f '$EARLY_FILTER_FILE' /dev/null 2>/dev/null; test \$? -ne 3
+"
+
+# Branch-ref scoping still works without any PRs
+EVENT_PRELESS='{"event":"github.push","orchestrator":null,"worker":null,"scope":{"repo":"o/r","ref":"refs/heads/orch-early-2026-05-04-CTL-200","sha":"a1b2"}}'
+run "filter matches branch-ref event when orch has no PRs" \
+  assert_match "$EVENT_PRELESS" "$EARLY_FILTER_FILE"
+
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo
 echo "Results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -20,6 +20,7 @@
 # Commands:
 #   tail [--filter <jq>] [--since-line <N>]
 #   wait-for [--filter <jq>] [--timeout <sec>]
+#   build-orchestrator-filter <orch-dir>
 #   help
 
 set -uo pipefail
@@ -219,6 +220,117 @@ cmd_wait_for() {
   done
 }
 
+# Build a single jq predicate that matches every event relevant to the given
+# orchestrator. Reads <orch-dir>/workers/*.json to learn ticket IDs and PR
+# numbers, then emits a multi-line predicate covering:
+#
+#   - catalyst-origin events for this orchestrator (.orchestrator == ORCH)
+#   - worker lifecycle events for any in-orch ticket (.worker matches set)
+#   - github events scoped by branch-ref prefix (refs/heads/<orch>-...)
+#   - github events scoped to a known PR number (.scope.pr or detail.prNumbers)
+#   - linear events scoped to an in-orch ticket (.scope.ticket)
+#
+# The output is intended to be passed verbatim as `--filter "$FILTER"` to
+# `tail` or `wait-for`; do NOT compose with downstream awk/sed/grep — those
+# buffer stdout and silently drop low-rate events (CTL-240).
+cmd_build_orchestrator_filter() {
+  local orch_dir=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) cmd_help; return 0 ;;
+      -*) echo "error: unknown flag: $1" >&2; return 2 ;;
+      *)
+        if [[ -z "$orch_dir" ]]; then
+          orch_dir="$1"
+        else
+          echo "error: too many positional arguments" >&2
+          return 2
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [[ -z "$orch_dir" ]]; then
+    echo "error: orchestrator directory required" >&2
+    echo "usage: catalyst-events build-orchestrator-filter <orch-dir>" >&2
+    return 2
+  fi
+  if [[ ! -d "$orch_dir/workers" ]]; then
+    echo "error: $orch_dir/workers directory not found" >&2
+    return 2
+  fi
+
+  shopt -s nullglob
+  local signal_files=("$orch_dir"/workers/*.json)
+  shopt -u nullglob
+  if [[ ${#signal_files[@]} -eq 0 ]]; then
+    echo "error: no worker signal files in $orch_dir/workers" >&2
+    return 2
+  fi
+
+  # Derive orchestrator name from the first signal file with a non-null value;
+  # fall back to the orch directory's basename if every signal is missing it.
+  local orch_name=""
+  for f in "${signal_files[@]}"; do
+    local cand
+    cand=$(jq -r '.orchestrator // empty' "$f" 2>/dev/null || true)
+    if [[ -n "$cand" && "$cand" != "null" ]]; then
+      orch_name="$cand"
+      break
+    fi
+  done
+  if [[ -z "$orch_name" ]]; then
+    orch_name="$(basename "$orch_dir")"
+  fi
+
+  # Collect ticket IDs (one per signal) and any non-null PR numbers across all
+  # signals. Tickets are required to construct the worker/ticket clauses; PRs
+  # are optional — the helper handles early-stage orchestrators where no PRs
+  # have been opened yet.
+  local tickets=() prs=()
+  for f in "${signal_files[@]}"; do
+    local t p
+    t=$(jq -r '.ticket // empty' "$f" 2>/dev/null || true)
+    p=$(jq -r '.pr.number // empty' "$f" 2>/dev/null || true)
+    if [[ -n "$t" && "$t" != "null" ]]; then
+      tickets+=("$t")
+    fi
+    if [[ -n "$p" && "$p" != "null" ]]; then
+      prs+=("$p")
+    fi
+  done
+
+  if [[ ${#tickets[@]} -eq 0 ]]; then
+    echo "error: no .ticket fields found in $orch_dir/workers/*.json" >&2
+    return 2
+  fi
+
+  # Build jq stream literals: "CTL-100","CTL-101"  and  501,502
+  local ticket_stream pr_stream=""
+  ticket_stream=$(printf '"%s",' "${tickets[@]}")
+  ticket_stream="${ticket_stream%,}"
+  if [[ ${#prs[@]} -gt 0 ]]; then
+    pr_stream=$(printf '%s,' "${prs[@]}")
+    pr_stream="${pr_stream%,}"
+  fi
+
+  # Emit a single parenthesized jq predicate. Each clause is itself
+  # parenthesized; clauses are joined by `or` so the predicate evaluates to
+  # boolean true when ANY clause matches. The PR clauses are conditional —
+  # an early-stage orchestrator with no PRs still gets a valid filter.
+  printf '(\n'
+  printf '  (.orchestrator == "%s")\n' "$orch_name"
+  printf '  or ((.worker // "") | IN(%s))\n' "$ticket_stream"
+  printf '  or ((.scope.ref // "") | startswith("refs/heads/%s-"))\n' "$orch_name"
+  if [[ -n "$pr_stream" ]]; then
+    printf '  or ((.scope.pr // -1) | IN(%s))\n' "$pr_stream"
+    printf '  or ((.detail.prNumbers // []) | any(IN(%s)))\n' "$pr_stream"
+  fi
+  printf '  or ((.scope.ticket // "") | IN(%s))\n' "$ticket_stream"
+  printf ')\n'
+}
+
 cmd_help() {
   cat <<'EOF'
 catalyst-events — tail and wait-for primitives over the global event log.
@@ -226,6 +338,7 @@ catalyst-events — tail and wait-for primitives over the global event log.
 Usage:
   catalyst-events tail [--filter <jq-predicate>] [--since-line <N>]
   catalyst-events wait-for [--filter <jq-predicate>] [--timeout <sec>]
+  catalyst-events build-orchestrator-filter <orch-dir>
   catalyst-events help
 
 Examples:
@@ -245,6 +358,12 @@ Examples:
     --filter '.event == "worker-failed" and .orchestrator == "orch-foo"' \
     --timeout 600
 
+  # Tail every relevant event for one orchestrator (scoped by ticket + PR set
+  # + branch-ref prefix). Filtering belongs inside --filter; do NOT pipe tail
+  # through awk/sed/grep — buffering will swallow events.
+  FILTER=$(catalyst-events build-orchestrator-filter "$ORCH_DIR")
+  catalyst-events tail --filter "$FILTER"
+
 Environment:
   CATALYST_DIR          base directory (default: $HOME/catalyst)
   CATALYST_EVENTS_DIR   events directory (default: $CATALYST_DIR/events)
@@ -261,9 +380,10 @@ main() {
   local cmd="${1:-help}"
   shift || true
   case "$cmd" in
-    tail)     cmd_tail "$@" ;;
-    wait-for) cmd_wait_for "$@" ;;
-    help|-h|--help) cmd_help ;;
+    tail)                       cmd_tail "$@" ;;
+    wait-for)                   cmd_wait_for "$@" ;;
+    build-orchestrator-filter)  cmd_build_orchestrator_filter "$@" ;;
+    help|-h|--help)             cmd_help ;;
     *)
       echo "error: unknown command: $cmd" >&2
       cmd_help >&2

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -85,15 +85,39 @@ fi
 
 The orchestrator's Phase 4 used to poll every 2–3 minutes for every active worker. With
 CTL-210, the orchestrator runs a `Monitor` watching all PR/CI/push/lifecycle events, and
-the reactive scan drops to a 10-minute idle fallback as the safety net (CTL-243):
+the reactive scan drops to a 10-minute idle fallback as the safety net (CTL-243).
+
+The recommended shape is **scope-aware**, generated from the orchestrator's worker
+signal directory (CTL-240):
 
 ```text
 Use the `Monitor` tool with this command:
 
+FILTER=$(catalyst-events build-orchestrator-filter "$ORCH_DIR")
+catalyst-events tail --filter "$FILTER"
+
+When a notification arrives, re-evaluate the affected worker's state via the
+canonical `gh pr view` query. Do NOT trust the event's payload as the source
+of truth — use it only as a wake-up trigger.
+```
+
+`build-orchestrator-filter` reads `${ORCH_DIR}/workers/*.json` and emits a single jq
+predicate that scopes catalyst-origin events by orchestrator name, github events by
+branch-ref prefix and PR-number set, `check_suite` / `workflow_run` events by
+`detail.prNumbers`, and linear events by ticket. Re-build it after dispatching new
+workers so the PR/ticket sets stay in sync.
+
+If you need a hand-rolled equivalent (e.g. the orchestrator name isn't yet known, or
+you only want broad event-type coverage and don't care about scoping out sibling
+orchestrators), the broad form is:
+
+```text
 catalyst-events tail --filter '
   (.event | startswith("github.pr.")) or
   (.event | startswith("github.pr_review")) or
+  (.event | startswith("github.issue_comment")) or
   (.event | startswith("github.check_")) or
+  (.event | startswith("github.workflow_run")) or
   (.event | startswith("github.deployment")) or
   (.event == "github.push") or
   (.event | startswith("linear.issue.")) or
@@ -105,13 +129,11 @@ catalyst-events tail --filter '
   (.event == "attention-raised") or
   (.event == "attention-resolved")
 '
-
-When a notification arrives, re-evaluate the affected worker's state via the
-canonical `gh pr view` query. Do NOT trust the event's payload as the source
-of truth — use it only as a wake-up trigger.
 ```
 
-The orchestrator's filter is intentionally broad — it covers every event type that
+`pr_review_comment` events are where Codex review threads land (required for CTL-64
+BLOCKED auto-fixup detection); `workflow_run.completed` is the most reliable
+CI-done signal. The filter is intentionally broad — it covers every event type that
 could require a dashboard re-render, a fix-up dispatch, or a merge-confirmation
 re-scan. See `orchestrate/SKILL.md` Phase 4 for the wake-up classification table that
 maps each event to its reaction.
@@ -239,6 +261,21 @@ treated as human-authored — the safer default.
 - **Iteration cap.** `MAX_ITER=20` prevents runaway loops on a stuck failure
   mode. Apply per-failure-type fix budgets inside each handler too (e.g. give
   up after 3 distinct fix attempts on the same CI check).
+- **Do NOT pipe `catalyst-events tail` through `awk`/`sed`/`grep` (CTL-240).**
+  BSD awk and similar line-oriented tools buffer stdout in 4 KB blocks when
+  stdout is not a TTY (the Monitor harness captures it). With the typical
+  ~1–3 events/min orchestrator cadence the buffer never fills and notifications
+  stall silently for 15+ minutes despite live PR activity. All filtering belongs
+  inside the `--filter` jq predicate. Use `catalyst-events build-orchestrator-filter
+  "$ORCH_DIR"` to generate a complete scope-aware predicate from the worker signal
+  directory instead of hand-rolling secondary pipes.
+- **`github.*` events carry `orchestrator: null` and `worker: null` (CTL-240).**
+  Real webhook events are scoped only by `.scope.repo`, `.scope.ref`, `.scope.pr`,
+  `.scope.sha`, and `.detail.prNumbers`. A scope predicate like
+  `.orchestrator == "orch-foo"` will silently drop every github event.
+  Use branch-ref prefix matching (`.scope.ref | startswith("refs/heads/orch-foo-")`)
+  and PR-number-set matching (`.scope.pr | IN(501,502)`) instead — or use
+  `build-orchestrator-filter` which handles this for you.
 
 ### Long-lived precedent
 

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -712,13 +712,50 @@ context to no purpose. See `plugins/dev/skills/monitor-events/SKILL.md` for the
 full pattern.
 
 **Launch the Monitor before entering the reactive scan.** Wrap this command with the
-`Monitor` tool — each emitted line is a wake-up:
+`Monitor` tool — each emitted line is a wake-up.
+
+The recommended filter is **scope-aware**: build it from the orchestrator's worker
+signal directory using `catalyst-events build-orchestrator-filter`, then pass the
+result verbatim as `--filter`:
+
+```text
+FILTER=$(catalyst-events build-orchestrator-filter "$ORCH_DIR")
+catalyst-events tail --filter "$FILTER"
+```
+
+The helper reads `${ORCH_DIR}/workers/*.json` and emits a single jq predicate that
+matches catalyst-origin events for this orchestrator, worker lifecycle events for
+any in-orch ticket, github events scoped by branch-ref prefix
+(`refs/heads/<orch>-...`) or PR-number set, `check_suite`/`workflow_run` events
+whose `detail.prNumbers` intersect the PR set, and linear events for any in-orch
+ticket. Re-build it after `orchestrate-dispatch-next` adds new workers so the
+PR/ticket sets stay in sync.
+
+**Filter discipline (CTL-240).** All noise filtering belongs **inside** `--filter`.
+Do NOT pipe `catalyst-events tail` through `awk`/`sed`/`grep` for additional
+filtering: BSD awk (and most other line-oriented filters) buffer stdout in 4 KB
+blocks when stdout is not a TTY (the Monitor harness captures it). With the typical
+~1–3 events/min orchestrator cadence the buffer never fills and notifications stall
+silently for 15+ minutes despite live PR activity.
+
+**GitHub event schema (CTL-240).** `github.*` webhook events carry
+`orchestrator: null` and `worker: null` on every line — they are scoped only by
+`.scope.repo`, `.scope.ref`, `.scope.pr`, `.scope.sha`, and (for `check_suite` /
+`workflow_run`) `detail.prNumbers`. Predicates that try to scope github events by
+`.orchestrator == "<orch>"` will silently drop every github event.
+`build-orchestrator-filter` handles this correctly — prefer it over hand-rolled
+filters.
+
+If you need to write a filter by hand (e.g. for one-off `wait-for` calls), the
+broad event-type recommendation is:
 
 ```text
 catalyst-events tail --filter '
   (.event | startswith("github.pr.")) or
   (.event | startswith("github.pr_review")) or
+  (.event | startswith("github.issue_comment")) or
   (.event | startswith("github.check_")) or
+  (.event | startswith("github.workflow_run")) or
   (.event | startswith("github.deployment")) or
   (.event == "github.push") or
   (.event | startswith("linear.issue.")) or
@@ -731,6 +768,13 @@ catalyst-events tail --filter '
   (.event == "attention-resolved")
 '
 ```
+
+This list extends the pre-CTL-240 recommendation with `pr_review_comment` (Codex
+review threads land here — needed for CTL-64 BLOCKED auto-fixup detection),
+`issue_comment` (general PR comments), and `workflow_run` (the most reliable
+CI-done signal). The broad form has no scope filter, so events from sibling
+orchestrators sharing the repo will also fire wake-ups; prefer
+`build-orchestrator-filter` when you have an `$ORCH_DIR` to draw on.
 
 > **Orchestrator-scoped filtering (CTL-234):** `github.*` events now carry `.scope.orchestrator`
 > (stamped at receive time by the webhook handler). You may safely add
@@ -749,8 +793,8 @@ are wake-up triggers, never sources of truth.
 | `attention-raised`, `attention-resolved` | Re-render the `DASHBOARD.md` NEEDS ATTENTION banner |
 | `github.pr.merged`, `github.pr.closed` | Run the merge-confirmation scan for that PR |
 | `github.pr.synchronize`, `github.push` | Re-evaluate `mergeStateStatus` for the affected PR; if DIRTY ≥2 min, `orchestrate-auto-rebase` may dispatch a rebase worker (BEHIND auto-resolves via auto-merge) |
-| `github.check_*` | Re-check CI; if BLOCKED ≥10 min, `orchestrate-auto-fixup` may dispatch a fix-up |
-| `github.pr_review*`, `github.issue_comment.created` | Re-evaluate `mergeStateStatus`; surface review activity on the dashboard |
+| `github.check_*`, `github.workflow_run.completed` | Re-check CI; if BLOCKED ≥10 min, `orchestrate-auto-fixup` may dispatch a fix-up. `workflow_run.completed` is the most reliable CI-done signal |
+| `github.pr_review*`, `github.pr_review_comment*`, `github.issue_comment.created` | Re-evaluate `mergeStateStatus`; surface review activity on the dashboard. Codex review threads land as `pr_review_comment.created` — required for CTL-64 BLOCKED auto-fixup detection |
 | `github.deployment*` | Record deploy outcome on the worker's signal file |
 | `linear.issue.state_changed` | Reconcile Linear state with the worker signal |
 | 10-minute idle (no event) | Run the full reactive scan as a safety net |


### PR DESCRIPTION
## Summary

Fixes two bugs that caused the orchestrator's `Monitor` over `catalyst-events tail` to silently swallow events (CTL-240):

- **Filter scope gap**: `github.*` webhook events carry `orchestrator: null` / `worker: null` — any predicate that scopes on `.orchestrator == "orch-x"` silently drops every github event. Fixed by adding `catalyst-events build-orchestrator-filter <orch-dir>` which emits a correct jq predicate scoped by branch-ref prefix and PR-number set.
- **Stdout buffering**: BSD awk buffers 4 KB when stdout isn't a TTY. At ~1–3 events/min the buffer never fills; notifications stall silently for 15+ min. Fixed by documenting that all filtering must go inside `--filter`, never in downstream pipes.

## Changes

- **`plugins/dev/scripts/catalyst-events`** — new `build-orchestrator-filter <orch-dir>` subcommand: reads `workers/*.json`, emits a single jq predicate covering orchestrator-origin events, worker lifecycle events, branch-ref-prefixed github events, PR-number-set github events, `detail.prNumbers`-intersecting check_suite/workflow_run events, and ticket-scoped linear events.
- **`orchestrate/SKILL.md` Phase 4** — replace bare filter literal with scope-aware helper invocation; add "filter discipline" callout; document github null-scope schema; extend broad fallback filter with `pr_review_comment`, `issue_comment`, `workflow_run`; update wake-up classification table.
- **`monitor-events/SKILL.md`** — sync Pattern 2 with scope-aware helper; add two Gotchas entries (awk buffering, null-scope schema); extend hand-rolled broad filter.
- **`__tests__/catalyst-events.test.sh`** — 20 new tests for `build-orchestrator-filter` (argument validation, valid jq output, match/reject matrix across all 6 scope axes). 34/34 passing.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/catalyst-events.test.sh` — 34/34 pass
- [x] Smoke: `catalyst-events build-orchestrator-filter /Users/ryan/catalyst/runs/orch-ctl-228-2026-05-04` emits valid jq accepted by `catalyst-events tail --filter "$FILTER"`
- [x] Existing 14 tail/wait-for tests unchanged
- [x] install-cli tests: 42/42 pass

Fixes CTL-240.