### PR TITLE
feat(dev): wire Linear webhook delivery via smee.io end-to-end (CTL-242)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -24,6 +24,7 @@ beforeEach(() => {
   delete process.env.CATALYST_SMEE_SECRET;
   delete process.env.CATALYST_SMEE_CHANNEL;
   delete process.env.CATALYST_LINEAR_WEBHOOK_SECRET;
+  delete process.env.CATALYST_LINEAR_SMEE_CHANNEL;
 });
 
 afterEach(() => {
@@ -32,6 +33,7 @@ afterEach(() => {
   delete process.env.CATALYST_SMEE_SECRET;
   delete process.env.CATALYST_SMEE_CHANNEL;
   delete process.env.CATALYST_LINEAR_WEBHOOK_SECRET;
+  delete process.env.CATALYST_LINEAR_SMEE_CHANNEL;
 });
 
 function writeProject(json: object): void {
@@ -66,6 +68,7 @@ describe("loadWebhookConfig", () => {
       secret: "home-secret",
       watchRepos: [],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -92,6 +95,7 @@ describe("loadWebhookConfig", () => {
       secret: "legacy-secret",
       watchRepos: [],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
     expect(warn).toHaveBeenCalledTimes(1);
     const msg = String(warn.mock.calls[0]?.[0] ?? "");
@@ -126,6 +130,7 @@ describe("loadWebhookConfig", () => {
       secret: "secret",
       watchRepos: [],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -154,6 +159,7 @@ describe("loadWebhookConfig", () => {
       secret: "custom-value",
       watchRepos: [],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -176,6 +182,7 @@ describe("loadWebhookConfig", () => {
       secret: "secret",
       watchRepos: [],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
   });
 
@@ -199,6 +206,7 @@ describe("loadWebhookConfig", () => {
       secret: "legacy-fallback",
       watchRepos: [],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
   });
 
@@ -270,6 +278,7 @@ describe("loadWebhookConfig", () => {
       secret: "secret",
       watchRepos: [],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -301,6 +310,7 @@ describe("loadWebhookConfig", () => {
       secret: "default-secret",
       watchRepos: [],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
   });
 });
@@ -394,6 +404,7 @@ describe("loadWebhookConfig watchRepos (CTL-216)", () => {
       secret: "secret",
       watchRepos: ["a/b"],
       linearSecret: "",
+      linearSmeeChannel: "",
     });
   });
 
@@ -600,7 +611,83 @@ describe("loadWebhookConfig — Linear webhook secret (CTL-210)", () => {
     expect(cfg!.smeeChannel).toBe("");
     expect(cfg!.secret).toBe("");
     expect(cfg!.linearSecret).toBe("linear-only");
+    expect(cfg!.linearSmeeChannel).toBe("");
 
     delete process.env.MY_LINEAR_SECRET;
+  });
+});
+
+describe("loadWebhookConfig — linearSmeeChannel (CTL-242)", () => {
+  it("loads linearSmeeChannel from home-dir Layer 2 config", () => {
+    writeHome({
+      catalyst: {
+        monitor: {
+          github: { smeeChannel: "https://smee.io/github-chan" },
+          linear: { smeeChannel: "https://smee.io/linear123" },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearSmeeChannel).toBe("https://smee.io/linear123");
+  });
+
+  it("linearSmeeChannel is empty when neither config nor env present", () => {
+    writeHome({
+      catalyst: {
+        monitor: { github: { smeeChannel: "https://smee.io/github-chan" } },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearSmeeChannel).toBe("");
+  });
+
+  it("CATALYST_LINEAR_SMEE_CHANNEL env override beats file value", () => {
+    writeHome({
+      catalyst: {
+        monitor: {
+          github: { smeeChannel: "https://smee.io/github-chan" },
+          linear: { smeeChannel: "https://smee.io/file-value" },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+    process.env.CATALYST_LINEAR_SMEE_CHANNEL = "https://smee.io/env-override";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearSmeeChannel).toBe("https://smee.io/env-override");
+  });
+
+  it("linearSmeeChannel and smeeChannel are independent (one set, other empty)", () => {
+    writeHome({
+      catalyst: {
+        monitor: {
+          linear: { smeeChannel: "https://smee.io/linear-only" },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "CATALYST_LINEAR_WEBHOOK_SECRET" },
+        },
+      },
+    });
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "linear-secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.smeeChannel).toBe("");
+    expect(cfg!.linearSmeeChannel).toBe("https://smee.io/linear-only");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -18,6 +18,13 @@ export interface WebhookCliConfig {
    * CTL-210.
    */
   linearSecret: string;
+  /**
+   * smee.io channel URL for Linear webhook delivery (Layer 2, per-machine).
+   * Read from `catalyst.monitor.linear.smeeChannel` in `~/.config/catalyst/config.json`.
+   * Env override: `CATALYST_LINEAR_SMEE_CHANNEL`. Empty string when not configured —
+   * the server then skips creating the second tunnel. CTL-242.
+   */
+  linearSmeeChannel: string;
 }
 
 interface FileExtract {
@@ -26,6 +33,8 @@ interface FileExtract {
   watchRepos: string[];
   /** Env-var name holding the Linear webhook signing secret (Layer 1). */
   linearWebhookSecretEnv: string | null;
+  /** smee.io channel URL for Linear, from Layer 2 only (per-machine). CTL-242. */
+  linearSmeeChannel: string | null;
 }
 
 let warnedDeprecatedSmeeChannel = false;
@@ -106,8 +115,14 @@ function readGithubSection(filePath: string): FileExtract | null {
     linear.webhookSecretEnv.length > 0
       ? linear.webhookSecretEnv
       : null;
+  const linearSmeeChannel =
+    linear !== null &&
+    typeof linear.smeeChannel === "string" &&
+    linear.smeeChannel.length > 0
+      ? linear.smeeChannel
+      : null;
 
-  return { smeeChannel, webhookSecretEnv, watchRepos, linearWebhookSecretEnv };
+  return { smeeChannel, webhookSecretEnv, watchRepos, linearWebhookSecretEnv, linearSmeeChannel };
 }
 
 /**
@@ -180,16 +195,26 @@ export function loadWebhookConfig(
     process.env.CATALYST_LINEAR_WEBHOOK_SECRET ??
     "";
 
+  // Linear smee channel. Layer 2 only (per-machine) — same split as GitHub
+  // smeeChannel. Env override wins. CTL-242.
+  const fileLinearSmeeChannel = homeExtract?.linearSmeeChannel ?? null;
+  const linearSmeeChannelOverride = process.env.CATALYST_LINEAR_SMEE_CHANNEL;
+  const linearSmeeChannel =
+    linearSmeeChannelOverride && linearSmeeChannelOverride.length > 0
+      ? linearSmeeChannelOverride
+      : (fileLinearSmeeChannel ?? "");
+
   // Allow Linear-only configurations: if the GitHub channel/secret are missing
   // but a Linear secret is present, return a config that disables the GitHub
   // route but enables the Linear route. CTL-210.
   if (finalChannel.length === 0 || secret.length === 0) {
-    if (linearSecret.length === 0) return null;
+    if (linearSecret.length === 0 && linearSmeeChannel.length === 0) return null;
     return {
       smeeChannel: "",
       secret: "",
       watchRepos,
       linearSecret,
+      linearSmeeChannel,
     };
   }
 
@@ -198,5 +223,6 @@ export function loadWebhookConfig(
     secret,
     watchRepos,
     linearSecret,
+    linearSmeeChannel,
   };
 }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -187,9 +187,12 @@ export interface CreateServerOptions {
    * Linear webhook config. Independent of `webhookConfig` (which carries the
    * GitHub bits) so a daemon can run Linear-only or GitHub-only setups.
    * `secret` empty disables `POST /api/webhook/linear`. CTL-210.
+   * `smeeChannel` drives the second smee tunnel (CTL-242); empty means no tunnel.
    */
   linearWebhookConfig?: {
     secret: string;
+    /** smee.io channel URL for Linear delivery. Empty = no tunnel. CTL-242. */
+    smeeChannel?: string;
   } | null;
 }
 
@@ -566,6 +569,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
 
   let webhookHandler: WebhookHandler | null = null;
   let webhookTunnel: WebhookTunnel | null = null;
+  let linearWebhookTunnel: WebhookTunnel | null = null;
   let webhookSubscriber: WebhookSubscriber | null = null;
   let webhookReplay: WebhookReplay | null = null;
   if (webhookConfig && prFetcher) {
@@ -1710,6 +1714,24 @@ export function createServer(opts: CreateServerOptions): BunServer {
     }
   }
 
+  const linearSmeeChannel = opts.linearWebhookConfig?.smeeChannel ?? "";
+  if (linearSmeeChannel.length > 0) {
+    linearWebhookTunnel = createWebhookTunnel({
+      source: linearSmeeChannel,
+      target: `http://localhost:${server.port}/api/webhook/linear`,
+      logger: {
+        info: (m) => console.info(`[linear-tunnel] ${m}`),
+        error: (m) => console.error(`[linear-tunnel] ${m}`),
+      },
+    });
+    void linearWebhookTunnel.start().catch((err: unknown) => {
+      console.error(
+        `[server] linear webhook tunnel start failed:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+  }
+
   if (pidFile) {
     try {
       writeFileSync(pidFile, `${process.pid}\n`);
@@ -1731,6 +1753,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     linear?.stop();
     briefingProvider?.stop();
     void webhookTunnel?.stop();
+    void linearWebhookTunnel?.stop();
     closeDb();
     sseClients.clear();
     if (pidFile) {
@@ -1825,8 +1848,13 @@ if (import.meta.main) {
         }
       : null;
   const linearWebhookConfig =
-    fullWebhookConfig && fullWebhookConfig.linearSecret.length > 0
-      ? { secret: fullWebhookConfig.linearSecret }
+    fullWebhookConfig &&
+    (fullWebhookConfig.linearSecret.length > 0 ||
+      fullWebhookConfig.linearSmeeChannel.length > 0)
+      ? {
+          secret: fullWebhookConfig.linearSecret,
+          smeeChannel: fullWebhookConfig.linearSmeeChannel,
+        }
       : null;
   let summarizeHandler: SummarizeHandler | null = null;
   if (summarizeCfg.enabled) {

--- a/plugins/dev/scripts/setup-webhooks.sh
+++ b/plugins/dev/scripts/setup-webhooks.sh
@@ -66,7 +66,9 @@ Options:
                              is the only intent flag, channel/secret setup for
                              GitHub is skipped.
   --webhook-url <https-url>  Public HTTPS URL where Linear should deliver
-                             events. Required when --linear-register is used.
+                             events. When omitted with --linear-register, a
+                             new smee.io channel is auto-provisioned and the
+                             URL is written to ${HOME_CONFIG_PATH}. CTL-242.
   -h|--help                  Show this message
 
 Environment:
@@ -134,10 +136,6 @@ if [[ $LINEAR_REGISTER -eq 1 && $LINEAR_DEREGISTER -eq 1 ]]; then
   echo "ERROR: --linear-register and --linear-deregister are mutually exclusive" >&2
   exit 1
 fi
-if [[ $LINEAR_REGISTER -eq 1 && -z "$LINEAR_WEBHOOK_URL" ]]; then
-  echo "ERROR: --linear-register requires --webhook-url <https-url>" >&2
-  exit 1
-fi
 if [[ $LINEAR_DEREGISTER -eq 1 && -n "$LINEAR_WEBHOOK_URL" ]]; then
   echo "ERROR: --linear-deregister and --webhook-url are mutually exclusive" >&2
   exit 1
@@ -170,10 +168,57 @@ if [[ $FORCE -eq 0 && -z "${CATALYST_SMEE_CHANNEL:-}" ]]; then
 fi
 ADD_REPO_ONLY=$SKIP_GITHUB_SETUP
 
-if [[ $ADD_REPO_ONLY -eq 0 ]]; then
+# --linear-register without --webhook-url auto-provisions a smee channel (CTL-242)
+# and needs curl. --linear-deregister only does GraphQL + local file ops (no curl).
+LINEAR_NEEDS_SMEE=0
+if [[ $LINEAR_REGISTER -eq 1 && -z "$LINEAR_WEBHOOK_URL" ]]; then
+  LINEAR_NEEDS_SMEE=1
+fi
+
+if [[ $ADD_REPO_ONLY -eq 0 || $LINEAR_NEEDS_SMEE -eq 1 ]]; then
   require_cmd curl
+fi
+if [[ $ADD_REPO_ONLY -eq 0 ]]; then
   require_cmd openssl
 fi
+
+# Provision (or reuse) a Linear smee.io channel and write it to Layer 2.
+# Sets LINEAR_WEBHOOK_URL to the resulting URL. CTL-242.
+provision_linear_smee_channel() {
+  mkdir -p "$HOME_CONFIG_DIR"
+  if [[ ! -f "$HOME_CONFIG_PATH" ]]; then
+    echo "{}" > "$HOME_CONFIG_PATH"
+  fi
+
+  local existing_linear_channel
+  existing_linear_channel=$(jq -r '.catalyst.monitor.linear.smeeChannel // ""' "$HOME_CONFIG_PATH" 2>/dev/null || true)
+
+  if [[ -n "$existing_linear_channel" && $FORCE -eq 0 ]]; then
+    echo "Reusing existing Linear smee channel from $HOME_CONFIG_PATH: $existing_linear_channel (use --force to regenerate)"
+    LINEAR_WEBHOOK_URL="$existing_linear_channel"
+    return 0
+  fi
+
+  echo "Creating new Linear smee.io channel..."
+  local new_channel
+  new_channel=$(curl -s -L -o /dev/null -w "%{url_effective}" https://smee.io/new)
+  if [[ -z "$new_channel" || "$new_channel" != https://smee.io/* || "$new_channel" == "https://smee.io/new" ]]; then
+    echo "ERROR: failed to create Linear smee channel (got: $new_channel)" >&2
+    exit 1
+  fi
+  echo "Created Linear smee channel: $new_channel"
+
+  local tmp; tmp=$(mktemp)
+  jq --arg channel "$new_channel" '
+    .catalyst //= {}
+    | .catalyst.monitor //= {}
+    | .catalyst.monitor.linear //= {}
+    | .catalyst.monitor.linear.smeeChannel = $channel
+  ' "$HOME_CONFIG_PATH" > "$tmp"
+  mv "$tmp" "$HOME_CONFIG_PATH"
+  echo "Wrote catalyst.monitor.linear.smeeChannel to $HOME_CONFIG_PATH"
+  LINEAR_WEBHOOK_URL="$new_channel"
+}
 
 # Merge an array of new repos into .catalyst.monitor.github.watchRepos in the
 # project config, deduping while preserving insertion order. Creates parent
@@ -234,6 +279,9 @@ if [[ $SKIP_GITHUB_SETUP -eq 1 ]]; then
     fi
   fi
   if [[ $LINEAR_REGISTER -eq 1 ]]; then
+    if [[ -z "$LINEAR_WEBHOOK_URL" ]]; then
+      provision_linear_smee_channel
+    fi
     helper_secret_env="${LINEAR_SECRET_ENV:-$DEFAULT_LINEAR_SECRET_ENV}"
     helper_args=(
       --webhook-url "$LINEAR_WEBHOOK_URL"
@@ -351,6 +399,9 @@ fi
 
 # ─── 6c. --linear-register / --linear-deregister (if combined) ─────────────
 if [[ $LINEAR_REGISTER -eq 1 ]]; then
+  if [[ -z "$LINEAR_WEBHOOK_URL" ]]; then
+    provision_linear_smee_channel
+  fi
   helper_secret_env="${LINEAR_SECRET_ENV:-$DEFAULT_LINEAR_SECRET_ENV}"
   helper_args=(
     --webhook-url "$LINEAR_WEBHOOK_URL"

--- a/website/src/content/docs/observability/webhooks.md
+++ b/website/src/content/docs/observability/webhooks.md
@@ -345,6 +345,7 @@ e.g. `linear.issue.state_changed`, `linear.comment.created`.
 |------|-------|-----------|
 | `webhookSecretEnv` (env-var name only) | `catalyst.monitor.linear.webhookSecretEnv` in `.catalyst/config.json` | YES |
 | HMAC secret value | env var named above (default fallback `CATALYST_LINEAR_WEBHOOK_SECRET`) | NO (per-developer env) |
+| `smeeChannel` (Linear smee URL) | `catalyst.monitor.linear.smeeChannel` in `~/.config/catalyst/config.json` | NO (per-machine, written by `--linear-register`) |
 | Registration record (`webhookId`, `webhookUrl`, `registeredAt`, `resourceTypes`) | `catalyst.monitor.linear` in `~/.config/catalyst/config.json` | NO (per-machine, written by `--linear-register`) |
 | HMAC secret file | `~/.config/catalyst/linear-webhook-secret` (mode 600, read by `--linear-register` post-create) | NO (per-developer) |
 
@@ -383,8 +384,32 @@ GraphQL API, and `--linear-deregister` reads `webhookId` from this record to cal
 
 ### Registering the webhook with Linear
 
-The setup script auto-registers the webhook for you (CTL-224). Combine
-`--linear-register` with `--webhook-url`:
+The setup script auto-registers the webhook for you (CTL-224) and, when no
+`--webhook-url` is supplied, auto-provisions a smee.io channel for delivery
+(CTL-242). The simplest end-to-end setup is a single command:
+
+```bash
+plugins/dev/scripts/setup-webhooks.sh \
+  --linear-secret-env CATALYST_LINEAR_WEBHOOK_SECRET \
+  --linear-register
+```
+
+This creates a fresh smee.io channel, writes `catalyst.monitor.linear.smeeChannel`
+to `~/.config/catalyst/config.json`, registers the webhook against that URL
+with Linear, and writes the resulting HMAC secret to
+`~/.config/catalyst/linear-webhook-secret`. The daemon picks up the smee
+channel automatically on next start and tunnels Linear deliveries to
+`http://localhost:7400/api/webhook/linear`.
+
+To reuse an existing smee channel instead of generating a new one, set
+`CATALYST_LINEAR_SMEE_CHANNEL` before running:
+
+```bash
+CATALYST_LINEAR_SMEE_CHANNEL=https://smee.io/existing-channel \
+  plugins/dev/scripts/setup-webhooks.sh --linear-register
+```
+
+To use an existing public URL instead:
 
 ```bash
 plugins/dev/scripts/setup-webhooks.sh \
@@ -446,12 +471,11 @@ plugins/dev/scripts/setup-webhooks.sh \
 secret can only be retrieved once, so persist it immediately (the script
 does this automatically) and re-export it in any active shell.
 
-For local development you still need a public tunnel — Linear webhooks
-require a stable HTTPS endpoint, so smee.io URLs do not work. Use
-[`cloudflared tunnel`](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/),
-[`ngrok`](https://ngrok.com/), or any other reverse-proxy of your choice to
-expose `http://localhost:7400/api/webhook/linear` to the internet, then pass
-that public URL via `--webhook-url`.
+smee.io URLs work with Linear (empirically verified — Linear accepts any public HTTPS
+non-localhost URL). The limitation is offline buffering: smee.io is a pass-through relay
+and does not persist payloads, so events sent while the tunnel is offline are lost. The
+daemon's `linear.ts` polling fallback (every 5 minutes) compensates for this. For a
+durable relay see CTL-241 (Cloudflare-based store-and-forward, in progress).
 
 You can also run the helper directly without `setup-webhooks.sh` if you only
 want webhook registration (no env-var-name write):


### PR DESCRIPTION
## Changes

- Add `linearSmeeChannel` to `WebhookCliConfig`; reads from Layer 2 home-dir config + `CATALYST_LINEAR_SMEE_CHANNEL` env override
- Run second `WebhookTunnel` in `server.ts` pointed at `/api/webhook/linear` when `linearSmeeChannel` is set; stop on shutdown
- Remove `--webhook-url` requirement from `--linear-register` in `setup-webhooks.sh`; `provision_linear_smee_channel` helper auto-generates + persists smee channel to Layer 2
- Correct false claim in `webhooks.md` that smee.io URLs don't work with Linear; document one-command setup flow
- 4 new `linearSmeeChannel` tests; zero regressions

Refs: CTL-242