### PR TITLE
fix(dev): replace polling loops in merge-pr and create-pr with wait-for-github (CTL-250)

### DIFF
--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -271,31 +271,31 @@ if command -v catalyst-events >/dev/null 2>&1; then
     --jq '[.[].state] | unique | join(",")' 2>/dev/null || echo "PENDING")
   echo "wake: state=${PR_STATE} CI=${CI_STATUS} event=$(echo "$EVENT_JSON" | jq -r '.event // "(timeout)"')"
 else
-  # Fallback when catalyst-events CLI is not installed — sleep + poll.
-  sleep 180
-  WAITED=180
-  MAX_WAIT=300
-  while [ $WAITED -lt $MAX_WAIT ]; do
-    CI_STATUS=$(gh pr checks "$pr_number" --json state \
-      --jq '[.[].state] | unique | join(",")' 2>/dev/null || echo "PENDING")
-    COMMENT_COUNT=$(gh api "repos/${REPO}/pulls/${pr_number}/comments" --jq 'length')
+  # Fallback when catalyst-events CLI is not installed — REST-only poll.
+  # See [[wait-for-github]] for the full two-phase pattern.
+  COUNT=0
+  MAX=24  # 2-hour limit at 5-min intervals
+  MERGED_FLAG="false"
+  while [ "$MERGED_FLAG" != "true" ] && [ $COUNT -lt $MAX ]; do
+    sleep 300
+    COUNT=$((COUNT + 1))
+    PR_DATA=$(gh api "repos/${REPO}/pulls/${pr_number}" 2>/dev/null || echo '{"merged":false}')
+    MERGED_FLAG=$(echo "$PR_DATA" | jq -r '.merged')
+    COMMENT_COUNT=$(gh api "repos/${REPO}/pulls/${pr_number}/comments" --jq 'length' 2>/dev/null || echo "0")
     REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${pr_number}/reviews" \
-      --jq '[.[] | select(.state != "APPROVED" and .state != "DISMISSED")] | length')
-    PR_STATE=$(gh pr view "$pr_number" --json state --jq '.state' 2>/dev/null || echo "OPEN")
-    echo "Poll @${WAITED}s: state=${PR_STATE} CI=${CI_STATUS} comments=${COMMENT_COUNT} reviews=${REVIEW_COUNT}"
-    [ "$PR_STATE" = "MERGED" ] && break
-    [ "$COMMENT_COUNT" -gt 0 ] || [ "$REVIEW_COUNT" -gt 0 ] && break
-    echo "$CI_STATUS" | grep -qv "PENDING\|QUEUED" && break
-    sleep 30
-    WAITED=$((WAITED + 30))
+      --jq '[.[] | select(.state != "APPROVED" and .state != "DISMISSED")] | length' 2>/dev/null || echo "0")
+    echo "REST poll @$((COUNT * 5))min: merged=${MERGED_FLAG} comments=${COMMENT_COUNT} reviews=${REVIEW_COUNT}"
+    [ "$MERGED_FLAG" = "true" ] && break
+    { [ "$COMMENT_COUNT" -gt 0 ] || [ "$REVIEW_COUNT" -gt 0 ]; } && break
   done
 fi
 ```
 
 The reactive path replaces the `sleep 180 + sleep 30` poll cadence with
 event-driven wake-ups. The `--timeout 300` floor prevents indefinite blocks
-when the orch-monitor daemon is down. The fallback path is preserved verbatim
-for installs without the `catalyst-events` CLI.
+when the orch-monitor daemon is down. The fallback path uses REST-only polling
+(`gh api` at 5-min intervals) — no `gh pr checks --json` or `gh pr view --json`
+in any loop. See `[[wait-for-github]]` for the full two-phase diagnostic pattern.
 
 **Step 12b: Address all review comments**
 

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -212,6 +212,7 @@ it falls back to `gh pr view` polling. The disjunctive filter restores
 event-driven dispatch for those cases.
 
 ```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 BASE_BRANCH=$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName')
 ITER=0
 MAX_ITER=20
@@ -237,9 +238,9 @@ while [ $ITER -lt $MAX_ITER ]; do
     ' \
     --timeout 600 || true)
 
-  # MANDATORY authoritative re-check on every wake-up.
-  MERGE_STATE=$(gh pr view "$pr_number" --json state,mergeStateStatus,mergedAt)
-  STATE=$(echo "$MERGE_STATE" | jq -r '.state')
+  # MANDATORY authoritative re-check — REST only, no GraphQL. See [[wait-for-github]].
+  PR_DATA=$(gh api "repos/${REPO}/pulls/${pr_number}" 2>/dev/null || echo '{"merged":false,"state":"open"}')
+  STATE=$(echo "$PR_DATA" | jq -r 'if .merged then "MERGED" elif .state == "closed" then "CLOSED" else "OPEN" end')
   if [ "$STATE" = "MERGED" ]; then break; fi
   if [ "$STATE" = "CLOSED" ]; then
     echo "❌ PR #$pr_number was closed without merging"
@@ -271,12 +272,13 @@ while [ $ITER -lt $MAX_ITER ]; do
 done
 ```
 
-**Why every wake-up runs `gh pr view`:** if the orch-monitor daemon is down,
-no GitHub webhook events flow into the log and `wait-for` blocks until
-timeout (600 s). The `gh pr view` after timeout is the safety net that keeps
-merge confirmation correct even when the event stream has dropped. Same rule
-applies on real event arrivals — events are wake-up triggers, never the
-source of truth.
+**Why every wake-up runs an authoritative REST check:** if the orch-monitor
+daemon is down, no GitHub webhook events flow into the log and `wait-for`
+blocks until timeout (600 s). The `gh api` REST check after timeout is the
+safety net that keeps merge confirmation correct even when the event stream
+has dropped. Same rule applies on real event arrivals — events are wake-up
+triggers, never the source of truth. See `[[wait-for-github]]` for the full
+two-phase diagnostic pattern and the full list of forbidden GraphQL patterns.
 
 The reference doc contains:
 


### PR DESCRIPTION
## Changes

Replace `gh pr view --json` and `gh pr checks --json` calls inside while loops with REST-only
equivalents and `[[wait-for-github]]` references. Eliminates GraphQL budget drain from production
workers hitting these skills.

### merge-pr step 6

- Add `REPO` variable before the reactive while loop
- Replace `gh pr view --json state,mergeStateStatus,mergedAt` (GraphQL) in loop with `gh api repos/.../pulls/...` (REST)
- Update "Why every wake-up..." prose to reference `[[wait-for-github]]` and say REST instead of `gh pr view`

### create-pr step 12a fallback

- Replace `sleep 180` + 30s poll loop using `gh pr checks --json` + `gh pr view --json` with REST-only poll at 5-min intervals using `gh api`
- Keep `gh api` REST calls for comments/reviews (these were already REST-compliant)
- Update prose to reference `[[wait-for-github]]`

## Acceptance criteria

- [x] `merge-pr/SKILL.md`: `gh pr view --json` removed from the reactive while loop
- [x] `create-pr/SKILL.md`: `gh pr checks --json` and `gh pr view --json` removed from the fallback loop
- [x] `[[wait-for-github]]` referenced in both files
- [x] No `gh pr view --json` or `gh pr checks --json` in any loop in either file

Refs: CTL-250