### PR TITLE
fix(dev): upgrade setup prereq checks for event-driven pipeline (CTL-253)

### DIFF
--- a/plugins/dev/scripts/__tests__/check-project-setup.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup.test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Tests for check-project-setup.sh — focuses on the CTL-253 webhook-pipeline checks
+# (smee binary, smeeChannel in cross-project Layer 2, Linear webhookId in per-project Layer 2).
+# Run: bash plugins/dev/scripts/__tests__/check-project-setup.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/plugins/dev/scripts/check-project-setup.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Build an isolated project dir with a minimal valid .catalyst/config.json and an
+# isolated $XDG_CONFIG_HOME for cross-project + per-project Layer 2 fixtures.
+#   $1 — project dir to create
+#   $2 — projectKey
+make_project() {
+  local dir="$1" key="$2"
+  mkdir -p "$dir/.catalyst"
+  cat > "$dir/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "$key",
+    "project": { "ticketPrefix": "CTL" },
+    "linear": {
+      "teamKey": "CTL",
+      "stateMap": { "research": "Research" }
+    }
+  }
+}
+EOF
+  # thoughts/shared subdirs so the early thoughts checks don't dominate output
+  mkdir -p "$dir/thoughts/shared/research" "$dir/thoughts/shared/plans" \
+    "$dir/thoughts/shared/handoffs" "$dir/thoughts/shared/prs" "$dir/thoughts/shared/reports"
+}
+
+# Run the script in a fully isolated env: PATH stripped so `humanlayer` and `smee`
+# are guaranteed-absent regardless of host setup; XDG_CONFIG_HOME pointed at the
+# scratch dir so home Layer 2 files come from the fixture.
+run_script() {
+  local cwd="$1"
+  ( cd "$cwd" \
+    && env -i HOME="$HOME" PATH="/usr/bin:/bin" \
+       XDG_CONFIG_HOME="$SCRATCH/xdg" \
+       bash "$SCRIPT" \
+  )
+}
+
+assert_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    expected substring: $pattern"
+    echo "    actual output:"
+    sed 's/^/      /' <<<"$output"
+  fi
+}
+
+assert_not_grep() {
+  local label="$1" output="$2" pattern="$3"
+  if grep -qF -- "$pattern" <<<"$output"; then
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    unexpected substring: $pattern"
+    echo "    actual output:"
+    sed 's/^/      /' <<<"$output"
+  else
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  fi
+}
+
+# ─── Test: smee binary missing → warn ───────────────────────────────────────
+test_smee_missing() {
+  echo "test: smee binary missing → warn (PATH stripped of npm bin)"
+  local proj="$SCRATCH/proj-smee" key="proj-smee"
+  make_project "$proj" "$key"
+  mkdir -p "$SCRATCH/xdg/catalyst"
+  # Configured smeeChannel + webhookId so only the smee binary check fires
+  cat > "$SCRATCH/xdg/catalyst/config.json" <<EOF
+{ "catalyst": { "monitor": { "github": { "smeeChannel": "https://smee.io/abc" } } } }
+EOF
+  cat > "$SCRATCH/xdg/catalyst/config-${key}.json" <<EOF
+{ "catalyst": { "monitor": { "linear": { "webhookId": "wh_test_123" } } } }
+EOF
+
+  local out
+  out=$(run_script "$proj" 2>&1)
+  assert_grep "smee binary warn fires" "$out" "smee binary not on PATH"
+  assert_grep "install hint suggests smee-client" "$out" "npm install -g smee-client"
+  assert_not_grep "smeeChannel warn does NOT fire" "$out" "Missing catalyst.monitor.github.smeeChannel"
+  assert_not_grep "Linear webhook warn does NOT fire" "$out" "Missing catalyst.monitor.linear.webhookId"
+}
+
+# ─── Test: smeeChannel missing → warn (independent of daemon — the script
+# never queries the daemon, so this implicitly proves AC #3) ────────────────
+test_smee_channel_missing() {
+  echo "test: smeeChannel missing → warn"
+  local proj="$SCRATCH/proj-channel" key="proj-channel"
+  make_project "$proj" "$key"
+  mkdir -p "$SCRATCH/xdg/catalyst"
+  # Empty home config — no smeeChannel
+  echo '{}' > "$SCRATCH/xdg/catalyst/config.json"
+  cat > "$SCRATCH/xdg/catalyst/config-${key}.json" <<EOF
+{ "catalyst": { "monitor": { "linear": { "webhookId": "wh_test_123" } } } }
+EOF
+
+  local out
+  out=$(run_script "$proj" 2>&1)
+  assert_grep "smeeChannel missing warn fires" "$out" "Missing catalyst.monitor.github.smeeChannel"
+  assert_grep "fix command points at setup-webhooks.sh" "$out" "setup-webhooks.sh"
+}
+
+# ─── Test: home config file missing entirely → warn ─────────────────────────
+test_home_config_missing() {
+  echo "test: home config file missing entirely → warn"
+  local proj="$SCRATCH/proj-nohome" key="proj-nohome"
+  make_project "$proj" "$key"
+  # No $SCRATCH/xdg/catalyst/ at all
+  rm -rf "$SCRATCH/xdg"
+
+  local out
+  out=$(run_script "$proj" 2>&1)
+  assert_grep "missing-home-config warn fires" "$out" "Cross-project Layer 2 config missing"
+}
+
+# ─── Test: Linear webhookId missing → warn ──────────────────────────────────
+test_linear_webhook_missing() {
+  echo "test: Linear webhookId missing in per-project Layer 2 → warn"
+  local proj="$SCRATCH/proj-linear" key="proj-linear"
+  make_project "$proj" "$key"
+  mkdir -p "$SCRATCH/xdg/catalyst"
+  cat > "$SCRATCH/xdg/catalyst/config.json" <<EOF
+{ "catalyst": { "monitor": { "github": { "smeeChannel": "https://smee.io/abc" } } } }
+EOF
+  # Per-project secrets file exists but has no webhookId
+  echo '{}' > "$SCRATCH/xdg/catalyst/config-${key}.json"
+
+  local out
+  out=$(run_script "$proj" 2>&1)
+  assert_grep "Linear webhook warn fires" "$out" "Missing catalyst.monitor.linear.webhookId"
+  assert_grep "Linear fix hint mentions --linear-register" "$out" "setup-webhooks.sh --linear-register"
+}
+
+# ─── Test: all configured → no webhook warnings ─────────────────────────────
+test_all_configured() {
+  echo "test: all webhook config present → no webhook warnings"
+  local proj="$SCRATCH/proj-allgood" key="proj-allgood"
+  make_project "$proj" "$key"
+  mkdir -p "$SCRATCH/xdg/catalyst"
+  cat > "$SCRATCH/xdg/catalyst/config.json" <<EOF
+{ "catalyst": { "monitor": { "github": { "smeeChannel": "https://smee.io/abc" } } } }
+EOF
+  cat > "$SCRATCH/xdg/catalyst/config-${key}.json" <<EOF
+{ "catalyst": { "monitor": { "linear": { "webhookId": "wh_test_456" } } } }
+EOF
+
+  local out
+  out=$(run_script "$proj" 2>&1)
+  assert_not_grep "no smeeChannel warn" "$out" "Missing catalyst.monitor.github.smeeChannel"
+  assert_not_grep "no missing-home-config warn" "$out" "Cross-project Layer 2 config missing"
+  assert_not_grep "no Linear webhook warn" "$out" "Missing catalyst.monitor.linear.webhookId"
+}
+
+# ─── Run ────────────────────────────────────────────────────────────────────
+test_smee_missing
+test_smee_channel_missing
+test_home_config_missing
+test_linear_webhook_missing
+test_all_configured
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -13,6 +13,10 @@ NC='\033[0m'
 errors=()
 warnings=()
 
+# Cross-project Layer 2 home config (smeeChannel + per-project secrets files live here)
+CATALYST_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/catalyst"
+HOME_CONFIG_PATH="$CATALYST_CONFIG/config.json"
+
 # 0. Resolve config path (.catalyst/ preferred, .claude/ deprecated fallback)
 CONFIG_PATH=""
 if [[ -f ".catalyst/config.json" ]]; then
@@ -82,6 +86,23 @@ if [[ -d "thoughts" ]] && [[ ! -d "thoughts/.git" ]] && [[ ! -L "thoughts" ]]; t
 	fi
 fi
 
+# 2b. Webhook pipeline (smee binary + smeeChannel — checked independently of daemon state)
+if ! command -v smee &>/dev/null; then
+	warnings+=("smee binary not on PATH — webhook tunnel cannot start")
+	warnings+=("  Install: npm install -g smee-client")
+fi
+
+if [[ -f "$HOME_CONFIG_PATH" ]]; then
+	SMEE_CHANNEL=$(jq -r '.catalyst.monitor.github.smeeChannel // empty' "$HOME_CONFIG_PATH" 2>/dev/null)
+	if [[ -z $SMEE_CHANNEL ]]; then
+		warnings+=("Missing catalyst.monitor.github.smeeChannel in $HOME_CONFIG_PATH — webhook tunnel won't start")
+		warnings+=("  Run: bash plugins/dev/scripts/setup-webhooks.sh")
+	fi
+else
+	warnings+=("Cross-project Layer 2 config missing: $HOME_CONFIG_PATH — webhook tunnel not configured")
+	warnings+=("  Run: bash plugins/dev/scripts/setup-webhooks.sh")
+fi
+
 # 3. Check CLAUDE.md has Catalyst snippet
 if [[ -f "CLAUDE.md" ]]; then
 	if ! grep -q "Catalyst Development Workflow" CLAUDE.md 2>/dev/null; then
@@ -132,6 +153,18 @@ if [[ -n $CONFIG_PATH ]]; then
 		STATE_IDS=$(jq -r '.catalyst.linear.stateIds // empty' "$CONFIG_PATH" 2>/dev/null)
 		if [[ -z $STATE_IDS || $STATE_IDS == "null" ]]; then
 			warnings+=("Missing catalyst.linear.stateIds — run: plugins/dev/scripts/resolve-linear-ids.sh")
+		fi
+	fi
+
+	# Check Linear webhook registration (CTL-253) — gates whether Linear events reach the event log
+	if [[ -n $PROJECT_KEY ]]; then
+		SECRETS_FILE="$CATALYST_CONFIG/config-${PROJECT_KEY}.json"
+		if [[ -f $SECRETS_FILE ]]; then
+			LINEAR_WEBHOOK_ID=$(jq -r '.catalyst.monitor.linear.webhookId // empty' "$SECRETS_FILE" 2>/dev/null)
+			if [[ -z $LINEAR_WEBHOOK_ID ]]; then
+				warnings+=("Missing catalyst.monitor.linear.webhookId in $SECRETS_FILE — Linear events won't reach the event log")
+				warnings+=("  Register: bash plugins/dev/scripts/setup-webhooks.sh --linear-register")
+			fi
 		fi
 	fi
 

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -65,6 +65,7 @@ OPT_TOOLS=(
     "sentry-cli:Sentry CLI"
     "bun:Bun runtime"
     "direnv:direnv"
+    "smee:smee-client (webhook tunnel)"
 )
 
 for spec in "${OPT_TOOLS[@]}"; do
@@ -255,6 +256,34 @@ else
     warn "Can't check secrets — no projectKey found"
 fi
 
+# ─── 6b. Webhook Pipeline ──────────────────────────────────────────────────
+
+header "Webhook Pipeline"
+
+HOME_CONFIG_PATH="$CATALYST_CONFIG/config.json"
+if [[ -f "$HOME_CONFIG_PATH" ]]; then
+    smee_channel=$(jq -r '.catalyst.monitor.github.smeeChannel // empty' "$HOME_CONFIG_PATH" 2>/dev/null)
+    if [[ -n "$smee_channel" ]]; then
+        pass "smeeChannel configured ($smee_channel)"
+    else
+        warn "Missing catalyst.monitor.github.smeeChannel in $HOME_CONFIG_PATH — webhook tunnel won't start"
+        info "Run: bash plugins/dev/scripts/setup-webhooks.sh"
+    fi
+else
+    warn "Cross-project Layer 2 config missing: $HOME_CONFIG_PATH — webhook tunnel not configured"
+    info "Run: bash plugins/dev/scripts/setup-webhooks.sh"
+fi
+
+if [[ -n "${PROJECT_KEY:-}" && -f "${SECRETS_FILE:-}" ]]; then
+    linear_webhook_id=$(jq -r '.catalyst.monitor.linear.webhookId // empty' "$SECRETS_FILE" 2>/dev/null)
+    if [[ -n "$linear_webhook_id" ]]; then
+        pass "Linear webhook registered (id: ${linear_webhook_id:0:8}…)"
+    else
+        warn "Linear webhook not registered — Linear events won't reach the event log"
+        info "Register: bash plugins/dev/scripts/setup-webhooks.sh --linear-register"
+    fi
+fi
+
 # ─── 7. OTel Observability Stack (optional) ────────────────────────────────
 
 header "Observability Stack (optional)"
@@ -366,7 +395,7 @@ if [[ -n "$LAUNCHER" ]] && command -v jq &>/dev/null; then
         if [[ "$MONITOR_RUNNING" == "true" ]]; then
             pass "Monitor running on :$MONITOR_PORT (v$MONITOR_RV)"
         else
-            info "Monitor not running on :$MONITOR_PORT"
+            warn "Monitor not running on :$MONITOR_PORT — catalyst-events wait-for falls back to 600s polling timeout"
             info "Start with: bash $LAUNCHER start"
         fi
         if [[ "$MONITOR_STALE" == "true" ]]; then
@@ -375,13 +404,13 @@ if [[ -n "$LAUNCHER" ]] && command -v jq &>/dev/null; then
     elif (echo >/dev/tcp/localhost/"$MONITOR_PORT") 2>/dev/null; then
         pass "Monitor running on :$MONITOR_PORT"
     else
-        info "Monitor not running on :$MONITOR_PORT"
+        warn "Monitor not running on :$MONITOR_PORT — catalyst-events wait-for falls back to 600s polling timeout"
         info "Start with: bash $LAUNCHER start"
     fi
 elif (echo >/dev/tcp/localhost/"$MONITOR_PORT") 2>/dev/null; then
     pass "Monitor running on :$MONITOR_PORT"
 else
-    info "Monitor not running on :$MONITOR_PORT"
+    warn "Monitor not running on :$MONITOR_PORT — catalyst-events wait-for falls back to 600s polling timeout"
     if [[ -n "$LAUNCHER" ]]; then
         info "Start with: bash $LAUNCHER start"
     else


### PR DESCRIPTION
## Summary

Closes [CTL-253](https://linear.app/coalesce-labs/issue/CTL-253).

The setup and prerequisite check scripts predate the event-driven webhook
pipeline. On fresh installs, missing components silently degrade
`catalyst-events wait-for` (used by `orchestrate`, `oneshot`, `merge-pr`) to a
600s polling timeout with no visible cause. This PR upgrades the four checks
called out in the ticket so fresh installs see the cause clearly.

### Gaps fixed

1. **`smee` binary missing (HIGH).** Added to `check-setup.sh` OPT_TOOLS and
   to `check-project-setup.sh` as a `warn`. Without `smee` on PATH the
   webhook tunnel cannot start.
2. **Monitor not running classified as `info` (HIGH).** Reclassified to
   `warn` with the degradation message: "catalyst-events wait-for falls back
   to 600s polling timeout".
3. **smeeChannel check skipped when daemon down (MEDIUM).** Added a check in
   `check-project-setup.sh` that reads `~/.config/catalyst/config.json`
   directly. The check runs unconditionally — daemon state is never queried.
   This same check is mirrored in `check-setup.sh` so the global health
   check shows the configured smee channel.
4. **Linear webhook never verified (HIGH).** Both files now read
   `~/.config/catalyst/config-${projectKey}.json` and warn if
   `catalyst.monitor.linear.webhookId` is absent, pointing at
   `setup-webhooks.sh --linear-register` as the fix command. (The
   registration command itself is out of scope — this PR adds the
   diagnostic that will surface it.)

All new checks are non-fatal — fresh installs are informed, not blocked.

### Test plan

- [x] `bash -n` passes on both scripts
- [x] New `plugins/dev/scripts/__tests__/check-project-setup.test.sh` runs
      12 assertions across 5 scenarios (smee missing, smeeChannel missing,
      home config missing, Linear webhookId missing, all-configured) — all
      green
- [x] Live verification of every AC item:
  - smee absent → `warn` (`smee binary not on PATH`)
  - monitor down (`MONITOR_PORT=99999`) → `warn` (`Monitor not running …
    catalyst-events wait-for falls back to 600s polling timeout`)
  - smeeChannel absent (cross-project Layer 2) → `warn` regardless of
    daemon state
  - `webhookId` absent (per-project Layer 2) → `warn` with
    `setup-webhooks.sh --linear-register` hint

### Out of scope

- Implementing `setup-webhooks.sh --linear-register` itself (separate
  ticket — this PR only adds the diagnostic that motivates it).
- Tunnel runtime probes against `/api/status/...` — the orch-monitor
  doesn't currently expose such an endpoint, and configuration-level checks
  are sufficient for the AC.
