### PR TITLE
fix(dev): add monitor.* to config templates + verify GitHub webhook registration (CTL-254)

### DIFF
--- a/.claude/config.example.json
+++ b/.claude/config.example.json
@@ -60,6 +60,16 @@
       },
       "verifyBeforeMerge": true,
       "allowSelfReportedCompletion": false
+    },
+    "monitor": {
+      "$comment": "smeeChannel lives in Layer 2 (~/.config/catalyst/config.json) — written by setup-webhooks.sh, never committed.",
+      "github": {
+        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET",
+        "watchRepos": ["acme-corp/api"]
+      },
+      "linear": {
+        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET"
+      }
     }
   }
 }

--- a/.claude/config.template.json
+++ b/.claude/config.template.json
@@ -50,6 +50,16 @@
       },
       "verifyBeforeMerge": true,
       "allowSelfReportedCompletion": false
+    },
+    "monitor": {
+      "$comment": "smeeChannel lives in Layer 2 (~/.config/catalyst/config.json) — written by setup-webhooks.sh, never committed.",
+      "github": {
+        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET",
+        "watchRepos": []
+      },
+      "linear": {
+        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET"
+      }
     }
   }
 }

--- a/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
@@ -24,12 +24,17 @@ trap 'rm -rf "$SCRATCH"' EXIT
 # Per-test fake $HOME + project tree. Build a stub-bin dir that hard-fails
 # `curl` and `openssl` so any --add-repo-only invocation that accidentally
 # falls through to channel/secret provisioning is caught.
+#
+# Also stubs `gh`. The stub reads scripted responses from $GH_STUB_DIR for
+# tests that exercise webhook verification (CTL-254). When $GH_STUB_DIR is
+# unset the stub hard-fails (loud signal that gh was called outside intent).
 make_test_env() {
   local name="$1"
   local dir="${SCRATCH}/${name}"
   mkdir -p "${dir}/home/.config/catalyst"
   mkdir -p "${dir}/project/.catalyst"
   mkdir -p "${dir}/stubbin"
+  mkdir -p "${dir}/gh_stub"
   cat > "${dir}/stubbin/curl" <<'EOF'
 #!/usr/bin/env bash
 echo "FAIL: curl invoked during --add-repo-only mode" >&2
@@ -42,7 +47,33 @@ EOF
 echo "FAIL: openssl invoked during --add-repo-only mode" >&2
 exit 87
 EOF
-  chmod +x "${dir}/stubbin/curl" "${dir}/stubbin/openssl"
+  cat > "${dir}/stubbin/gh" <<'EOF'
+#!/usr/bin/env bash
+# Scriptable gh stub for setup-webhooks tests.
+#   GH_STUB_DIR/list-response.json — body returned for `gh api repos/X/hooks` (GET)
+#   GH_STUB_DIR/post-response.json — body returned for `gh api -X POST repos/X/hooks`
+#   GH_STUB_DIR/list-exit         — exit code for GET (default 0)
+#   GH_STUB_DIR/post-exit         — exit code for POST (default 0)
+#   GH_STUB_DIR/calls.log         — append-only call log
+if [[ -z "${GH_STUB_DIR:-}" ]]; then
+  echo "FAIL: gh invoked but GH_STUB_DIR is unset (test setup error)" >&2
+  exit 88
+fi
+echo "$*" >> "${GH_STUB_DIR}/calls.log"
+# `gh api -X POST repos/X/hooks ...`
+if [[ "$1" == "api" && "$2" == "-X" && "$3" == "POST" && "$4" == repos/*/hooks ]]; then
+  cat "${GH_STUB_DIR}/post-response.json" 2>/dev/null || echo '{"id":1}'
+  exit "$(cat "${GH_STUB_DIR}/post-exit" 2>/dev/null || echo 0)"
+fi
+# `gh api repos/X/hooks` (GET)
+if [[ "$1" == "api" && "$2" == repos/*/hooks ]]; then
+  cat "${GH_STUB_DIR}/list-response.json" 2>/dev/null || echo "[]"
+  exit "$(cat "${GH_STUB_DIR}/list-exit" 2>/dev/null || echo 0)"
+fi
+echo "stub: unhandled gh call: $*" >&2
+exit 1
+EOF
+  chmod +x "${dir}/stubbin/curl" "${dir}/stubbin/openssl" "${dir}/stubbin/gh"
   echo "$dir"
 }
 
@@ -439,6 +470,197 @@ test_linear_deregister_only_skips_github_setup() {
   fi
 }
 
+# ─── Tests 19-25 — GitHub webhook verification + --register-github-hooks (CTL-254)
+#
+# `run_setup_full` exercises the normal-setup path while keeping the test
+# isolated from the network: $CATALYST_SMEE_CHANNEL is set so curl is never
+# called, and the secret file is pre-seeded so openssl is never called.
+# `gh` is the only allowed external command, scripted via $GH_STUB_DIR.
+run_setup_full() {
+  local env_dir="$1"; shift
+  ( cd "${env_dir}/project" && \
+    HOME="${env_dir}/home" \
+    XDG_CONFIG_HOME="${env_dir}/home/.config" \
+    PATH="${env_dir}/stubbin:${PATH}" \
+    GH_STUB_DIR="${env_dir}/gh_stub" \
+    CATALYST_SMEE_CHANNEL="https://smee.io/test-channel" \
+    bash "$SETUP" "$@" )
+}
+
+# Pre-seed a secret file so the script's openssl-rand path is skipped.
+seed_secret() {
+  local env="$1"
+  echo "deadbeef" > "${env}/home/.config/catalyst/webhook-secret"
+  chmod 600 "${env}/home/.config/catalyst/webhook-secret"
+}
+
+# Pre-populate watchRepos so the verifier has something to iterate.
+seed_watch_repos() {
+  local env="$1"; shift
+  local repos_json; repos_json=$(printf '%s\n' "$@" | jq -R . | jq -s .)
+  cat > "${env}/project/.catalyst/config.json" <<EOF
+{ "catalyst": { "monitor": { "github": { "watchRepos": ${repos_json} } } } }
+EOF
+}
+
+# ─── Test 19 — verifier reports already-registered hook ────────────────────
+test_verifier_reports_existing() {
+  local env; env=$(make_test_env t19)
+  seed_secret "$env"
+  seed_watch_repos "$env" "acme/api"
+  cat > "${env}/gh_stub/list-response.json" <<'EOF'
+[{"id":42,"config":{"url":"https://smee.io/test-channel","content_type":"json"}}]
+EOF
+  if ! run_setup_full "$env" > "${SCRATCH}/t19.out" 2>&1; then
+    echo "expected setup to succeed" >&2
+    cat "${SCRATCH}/t19.out" >&2
+    return 1
+  fi
+  if ! grep -q "already registered" "${SCRATCH}/t19.out"; then
+    echo "expected output to mention 'already registered'" >&2
+    cat "${SCRATCH}/t19.out" >&2
+    return 1
+  fi
+  if grep -q "^api -X POST" "${env}/gh_stub/calls.log"; then
+    echo "expected no POST to be issued when hook already exists" >&2
+    cat "${env}/gh_stub/calls.log" >&2
+    return 1
+  fi
+}
+
+# ─── Test 20 — verifier warns when hook missing and flag absent ────────────
+test_verifier_warns_missing_without_flag() {
+  local env; env=$(make_test_env t20)
+  seed_secret "$env"
+  seed_watch_repos "$env" "acme/api"
+  echo "[]" > "${env}/gh_stub/list-response.json"
+  if ! run_setup_full "$env" > "${SCRATCH}/t20.out" 2>&1; then
+    echo "expected setup to succeed (a missing hook is a warning, not an error)" >&2
+    cat "${SCRATCH}/t20.out" >&2
+    return 1
+  fi
+  if ! grep -q "no webhook registered" "${SCRATCH}/t20.out"; then
+    echo "expected output to mention 'no webhook registered'" >&2
+    cat "${SCRATCH}/t20.out" >&2
+    return 1
+  fi
+  if grep -q "^api -X POST" "${env}/gh_stub/calls.log"; then
+    echo "expected no POST without --register-github-hooks" >&2
+    cat "${env}/gh_stub/calls.log" >&2
+    return 1
+  fi
+}
+
+# ─── Test 21 — --register-github-hooks creates the missing hook ────────────
+test_registers_when_flag_set() {
+  local env; env=$(make_test_env t21)
+  seed_secret "$env"
+  seed_watch_repos "$env" "acme/api"
+  echo "[]" > "${env}/gh_stub/list-response.json"
+  echo '{"id":99}' > "${env}/gh_stub/post-response.json"
+  if ! run_setup_full "$env" --register-github-hooks > "${SCRATCH}/t21.out" 2>&1; then
+    echo "expected setup to succeed" >&2
+    cat "${SCRATCH}/t21.out" >&2
+    return 1
+  fi
+  if ! grep -q "webhook registered" "${SCRATCH}/t21.out"; then
+    echo "expected output to mention 'webhook registered'" >&2
+    cat "${SCRATCH}/t21.out" >&2
+    return 1
+  fi
+  if ! grep -q "^api -X POST repos/acme/api/hooks" "${env}/gh_stub/calls.log"; then
+    echo "expected POST to repos/acme/api/hooks" >&2
+    cat "${env}/gh_stub/calls.log" >&2
+    return 1
+  fi
+  if ! grep -q "config\[url\]=https://smee.io/test-channel" "${env}/gh_stub/calls.log"; then
+    echo "expected POST to include config[url]=<smee channel>" >&2
+    cat "${env}/gh_stub/calls.log" >&2
+    return 1
+  fi
+  if ! grep -q "events\[\]=pull_request" "${env}/gh_stub/calls.log"; then
+    echo "expected POST to include events[]=pull_request" >&2
+    cat "${env}/gh_stub/calls.log" >&2
+    return 1
+  fi
+}
+
+# ─── Test 22 — --register-github-hooks is idempotent (no POST if hook exists)
+test_register_idempotent() {
+  local env; env=$(make_test_env t22)
+  seed_secret "$env"
+  seed_watch_repos "$env" "acme/api"
+  cat > "${env}/gh_stub/list-response.json" <<'EOF'
+[{"id":42,"config":{"url":"https://smee.io/test-channel"}}]
+EOF
+  if ! run_setup_full "$env" --register-github-hooks > "${SCRATCH}/t22.out" 2>&1; then
+    echo "expected setup to succeed" >&2
+    cat "${SCRATCH}/t22.out" >&2
+    return 1
+  fi
+  if grep -q "^api -X POST" "${env}/gh_stub/calls.log"; then
+    echo "expected no POST when hook already registered (idempotent)" >&2
+    cat "${env}/gh_stub/calls.log" >&2
+    return 1
+  fi
+}
+
+# ─── Test 23 — --add-repo only mode does NOT call gh ───────────────────────
+# In this mode the script must not touch the network at all (CTL-216 contract).
+# Our gh stub fails loudly when invoked without GH_STUB_DIR set; we point PATH
+# at the stubbin (so `gh` resolves to it) but leave GH_STUB_DIR unset.
+test_add_repo_only_no_gh_calls() {
+  local env; env=$(make_test_env t23)
+  if ! run_setup "$env" --add-repo a/b > "${SCRATCH}/t23.out" 2>&1; then
+    echo "expected --add-repo only mode to succeed without invoking gh" >&2
+    cat "${SCRATCH}/t23.out" >&2
+    return 1
+  fi
+  if grep -q "FAIL: gh invoked" "${SCRATCH}/t23.out"; then
+    echo "--add-repo only mode unexpectedly invoked gh" >&2
+    cat "${SCRATCH}/t23.out" >&2
+    return 1
+  fi
+}
+
+# ─── Tests 24-25 — config templates carry the canonical monitor block (CTL-254)
+test_example_template_has_monitor_block() {
+  local file="${REPO_ROOT}/.claude/config.example.json"
+  local secret_env watch_repos linear_env comment
+  secret_env=$(jq -r '.catalyst.monitor.github.webhookSecretEnv' "$file")
+  watch_repos=$(jq -c '.catalyst.monitor.github.watchRepos' "$file")
+  linear_env=$(jq -r '.catalyst.monitor.linear.webhookSecretEnv' "$file")
+  comment=$(jq -r '.catalyst.monitor."$comment" // ""' "$file")
+  expect_eq "example.json github.webhookSecretEnv" "CATALYST_WEBHOOK_SECRET" "$secret_env" || return 1
+  expect_eq "example.json linear.webhookSecretEnv" "CATALYST_LINEAR_WEBHOOK_SECRET" "$linear_env" || return 1
+  if [[ "$watch_repos" == "null" ]]; then
+    echo "example.json watchRepos must be present" >&2
+    return 1
+  fi
+  if [[ -z "$comment" ]] || ! echo "$comment" | grep -q "Layer 2"; then
+    echo "example.json must have a \$comment mentioning Layer 2 for smeeChannel" >&2
+    echo "got: $comment" >&2
+    return 1
+  fi
+}
+
+test_template_has_monitor_block() {
+  local file="${REPO_ROOT}/.claude/config.template.json"
+  local secret_env watch_repos linear_env comment
+  secret_env=$(jq -r '.catalyst.monitor.github.webhookSecretEnv' "$file")
+  watch_repos=$(jq -c '.catalyst.monitor.github.watchRepos' "$file")
+  linear_env=$(jq -r '.catalyst.monitor.linear.webhookSecretEnv' "$file")
+  comment=$(jq -r '.catalyst.monitor."$comment" // ""' "$file")
+  expect_eq "template.json github.webhookSecretEnv" "CATALYST_WEBHOOK_SECRET" "$secret_env" || return 1
+  expect_eq "template.json linear.webhookSecretEnv" "CATALYST_LINEAR_WEBHOOK_SECRET" "$linear_env" || return 1
+  expect_eq "template.json watchRepos shape" "[]" "$watch_repos" || return 1
+  if [[ -z "$comment" ]] || ! echo "$comment" | grep -q "Layer 2"; then
+    echo "template.json must have a \$comment mentioning Layer 2 for smeeChannel" >&2
+    echo "got: $comment" >&2
+    return 1
+  fi
+}
+
 # ─── Run all ──────────────────────────────────────────────────────────────
 echo "Running setup-webhooks --add-repo tests…"
 run "single add bootstraps watchRepos" test_single_add
@@ -459,6 +681,13 @@ run "--linear-register only mode skips GitHub setup" test_linear_register_only_s
 run "combined --add-repo + --linear-register" test_combined_add_repo_and_linear_register
 run "--linear-register/-deregister mutex" test_linear_register_deregister_mutex
 run "--linear-deregister only-mode skips GitHub setup" test_linear_deregister_only_skips_github_setup
+run "verifier reports already-registered hook" test_verifier_reports_existing
+run "verifier warns missing hook (no flag)" test_verifier_warns_missing_without_flag
+run "--register-github-hooks creates missing hook" test_registers_when_flag_set
+run "--register-github-hooks is idempotent" test_register_idempotent
+run "no gh calls in --add-repo only mode" test_add_repo_only_no_gh_calls
+run "config.example.json has monitor block" test_example_template_has_monitor_block
+run "config.template.json has monitor block" test_template_has_monitor_block
 
 echo
 echo "Passed: $PASSES, Failed: $FAILURES"

--- a/plugins/dev/scripts/setup-webhooks.sh
+++ b/plugins/dev/scripts/setup-webhooks.sh
@@ -31,9 +31,27 @@ LINEAR_SECRET_ENV=""
 LINEAR_REGISTER=0
 LINEAR_DEREGISTER=0
 LINEAR_WEBHOOK_URL=""
+REGISTER_GITHUB_HOOKS=0
 REPO_SHAPE='^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
 ENV_VAR_SHAPE='^[A-Z_][A-Z0-9_]*$'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# GitHub events the orch-monitor daemon subscribes to at startup. The bash
+# verifier mirrors this list so hooks registered here match what the daemon
+# would otherwise create on first observation. Source of truth:
+# plugins/dev/scripts/orch-monitor/lib/webhook-subscriber.ts (DEFAULT_WEBHOOK_EVENTS).
+WEBHOOK_EVENTS=(
+  pull_request
+  pull_request_review
+  pull_request_review_thread
+  pull_request_review_comment
+  check_suite
+  status
+  push
+  issue_comment
+  deployment
+  deployment_status
+)
 
 usage() {
   cat <<EOF
@@ -69,6 +87,12 @@ Options:
                              events. When omitted with --linear-register, a
                              new smee.io channel is auto-provisioned and the
                              URL is written to ${HOME_CONFIG_PATH}. CTL-242.
+  --register-github-hooks    For each repo in catalyst.monitor.github.watchRepos,
+                             POST a webhook to the GitHub API if one pointing at
+                             the smee channel does not already exist. Off by
+                             default — without this flag the script only reports
+                             registration status. Requires \`gh\` to be installed
+                             and authenticated with admin access to each repo.
   -h|--help                  Show this message
 
 Environment:
@@ -108,6 +132,7 @@ while [[ $# -gt 0 ]]; do
       LINEAR_WEBHOOK_URL="$2"
       shift 2
       ;;
+    --register-github-hooks) REGISTER_GITHUB_HOOKS=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
   esac
@@ -259,6 +284,61 @@ write_linear_secret_env() {
     .catalyst.monitor.linear.webhookSecretEnv = $env_name
   ' "$PROJECT_CONFIG_PATH" > "$tmp"
   mv "$tmp" "$PROJECT_CONFIG_PATH"
+}
+
+# Verify (and optionally register) a GitHub webhook on `repo` that delivers to
+# `channel`. Idempotent: if a hook with config.url == channel already exists,
+# the function reports it and exits without POSTing. CTL-254.
+#
+# Arguments:
+#   $1 — owner/repo
+#   $2 — smee channel URL
+#   $3 — HMAC secret (only consulted on POST; pass empty string to register
+#        without one, e.g. when called for a status-only check)
+#
+# Globals:
+#   REGISTER_GITHUB_HOOKS — 1 to POST when missing, 0 to only warn
+#   WEBHOOK_EVENTS        — array of event names to subscribe (POST path only)
+verify_github_hook() {
+  local repo="$1" channel="$2" secret="$3"
+  local hooks_json existing
+  if ! hooks_json=$(gh api "repos/${repo}/hooks" 2>&1); then
+    echo "  ⚠ ${repo}: could not list hooks (gh not authenticated, or no admin access)"
+    echo "    ${hooks_json}" | sed 's/^/      /'
+    return 0
+  fi
+  existing=$(jq -r --arg ch "$channel" \
+    '[.[] | select(.config.url == $ch)] | length' <<<"$hooks_json" 2>/dev/null || echo "0")
+  if [[ "$existing" != "0" ]]; then
+    echo "  ✓ ${repo}: webhook already registered (${channel})"
+    return 0
+  fi
+  if [[ $REGISTER_GITHUB_HOOKS -eq 0 ]]; then
+    echo "  ⚠ ${repo}: no webhook registered for ${channel}"
+    echo "    Register with: $(basename "$0") --register-github-hooks"
+    return 0
+  fi
+  # POST a new hook. Mirror the events list used by the runtime daemon.
+  local args=(api -X POST "repos/${repo}/hooks"
+    -f name=web
+    -F active=true
+    -f "config[url]=${channel}"
+    -f "config[content_type]=json")
+  if [[ -n "$secret" ]]; then
+    args+=(-f "config[secret]=${secret}")
+  fi
+  local evt
+  for evt in "${WEBHOOK_EVENTS[@]}"; do
+    args+=(-f "events[]=${evt}")
+  done
+  local err_file; err_file=$(mktemp)
+  if gh "${args[@]}" >/dev/null 2>"$err_file"; then
+    echo "  ✓ ${repo}: webhook registered (${channel})"
+  else
+    echo "  ✗ ${repo}: failed to register webhook"
+    sed 's/^/      /' "$err_file" 2>/dev/null || true
+  fi
+  rm -f "$err_file"
 }
 
 if [[ $SKIP_GITHUB_SETUP -eq 1 ]]; then
@@ -415,6 +495,31 @@ elif [[ $LINEAR_DEREGISTER -eq 1 ]]; then
     --deregister --config "$PROJECT_CONFIG_PATH"
 fi
 
+# ─── 6d. Verify GitHub webhook registration for each watched repo ───────────
+# For each repo in catalyst.monitor.github.watchRepos, call the GitHub Hooks
+# API to check whether a hook pointing at $channel already exists. Reports
+# the status; with --register-github-hooks, registers any missing hook via
+# POST. Skipped silently when watchRepos is empty.
+mapfile -t WATCH_REPOS < <(jq -r '.catalyst.monitor.github.watchRepos[]?' \
+  "$PROJECT_CONFIG_PATH" 2>/dev/null || true)
+
+if [[ ${#WATCH_REPOS[@]} -gt 0 ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "⚠ Skipping GitHub webhook verification — \`gh\` is not installed."
+    echo "  Install GitHub CLI to verify or auto-register webhooks: https://cli.github.com"
+  else
+    echo
+    echo "Verifying GitHub webhook registration for ${#WATCH_REPOS[@]} repo(s)…"
+    secret_value=""
+    if [[ -f "$SECRET_PATH" ]]; then
+      secret_value=$(cat "$SECRET_PATH")
+    fi
+    for repo in "${WATCH_REPOS[@]}"; do
+      verify_github_hook "$repo" "$channel" "$secret_value"
+    done
+  fi
+fi
+
 # ─── 7. Print next steps ───────────────────────────────────────────────────
 cat <<EOF
 
@@ -426,5 +531,8 @@ Export the secret in your shell (and add to your ~/.zshrc / ~/.bashrc):
 
 Then restart orch-monitor — it will tunnel deliveries from $channel to
 http://localhost:7400/api/webhook and auto-subscribe each repo it observes.
+
+If any repo above shows ⚠, register its webhook with:
+  $(basename "$0") --register-github-hooks
 
 EOF


### PR DESCRIPTION
## Summary

Closes two install gaps for fresh Catalyst projects:

1. **Config templates lacked `monitor.*` schema.** `.claude/config.example.json` and
   `.claude/config.template.json` now ship the canonical Layer 1 webhook config
   (`github.webhookSecretEnv`, `github.watchRepos`, `linear.webhookSecretEnv`)
   with a `$comment` noting that `smeeChannel` lives in Layer 2 and should
   never be committed.
2. **`setup-webhooks.sh` never verified GitHub webhooks were actually registered.**
   The script now lists each repo's hooks via the GitHub API and reports
   whether one pointing at the smee channel exists. With the new
   `--register-github-hooks` flag, it auto-registers any missing hook via
   `POST repos/{owner}/{repo}/hooks` — idempotent on re-run.

## Changes

| File | Change |
|---|---|
| `.claude/config.example.json` | Add `catalyst.monitor` block with example `watchRepos` |
| `.claude/config.template.json` | Add `catalyst.monitor` block with empty `watchRepos` |
| `plugins/dev/scripts/setup-webhooks.sh` | New `--register-github-hooks` flag; new `verify_github_hook` helper; new Step 6c verification loop; mirrors `DEFAULT_WEBHOOK_EVENTS` from `webhook-subscriber.ts` |
| `plugins/dev/scripts/__tests__/setup-webhooks.test.sh` | Scriptable `gh` stub + 7 new tests (verifier reports existing, warns missing, registers with flag, idempotent, no `gh` calls in `--add-repo` only mode, plus 2 template-invariant tests) |

## Acceptance criteria

- [x] `config.example.json` and `config.template.json` both contain a `monitor.*` section with `github.webhookSecretEnv`, `github.watchRepos`, and `linear.webhookSecretEnv`
- [x] Templates include a comment explaining that `smeeChannel` lives in Layer 2 and is not committed
- [x] `setup-webhooks.sh` checks GitHub API for existing webhook and prints status (registered vs not)
- [x] `setup-webhooks.sh --register-github-hooks` auto-registers the webhook via `gh api -X POST`
- [x] Re-running `setup-webhooks.sh` is still idempotent (no duplicate hooks created)

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/setup-webhooks.test.sh` — all 19 tests pass (12 existing + 7 new)
- [x] `bash -n plugins/dev/scripts/setup-webhooks.sh` — no syntax errors
- [x] `jq -e .` on both config templates — valid JSON
- [ ] Manual: run `setup-webhooks.sh` on a fresh checkout with a real repo and `--register-github-hooks`, verify hook appears in GitHub UI
- [ ] Manual: re-run with same flag, verify no duplicate is created and the "already registered" message prints

## Related

- CTL-216 — `--add-repo` flag for `watchRepos` (existing)
- CTL-217 — Layer 2 split for `smeeChannel` (existing)
- CTL-209 / CTL-210 — orch-monitor webhook ingestion + Linear webhook routing (existing)

Closes CTL-254.