### PR TITLE
feat(dev): catalyst-filter daemon — Groq-powered semantic event routing (CTL-256)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -15,28 +15,12 @@
         "inReview": "In Review",
         "done": "Done",
         "canceled": "Canceled"
-      },
-      "teamId": "e7e703c4-13a8-42d4-97c1-25e342618f25",
-      "stateIds": {
-        "Planning": "b64f94a4-954d-4cb1-943f-daee603ed9f7",
-        "Research": "2d478844-8383-490f-9d8d-207363899764",
-        "In Review": "06397ace-b4ac-4a52-9754-befb13dc6e9b",
-        "Triage": "a35390a0-5ae1-474d-804d-0533e5735303",
-        "Backlog": "71a1f143-cc27-4a6c-94fb-5ba0b164020e",
-        "In Progress": "5e9c1bfb-0949-4a12-b375-c84670905c33",
-        "Done": "5d779765-6245-4f15-a2d1-a33f477b87a3",
-        "Canceled": "560f8e87-d745-420b-aa04-6ff418ae8b68"
       }
     },
     "thoughts": {
       "profile": "coalesce-labs",
       "directory": "catalyst-workspace",
       "user": null
-    },
-    "monitor": {
-      "github": {
-        "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET"
-      }
     }
   }
 }

--- a/.claude/config.example.json
+++ b/.claude/config.example.json
@@ -47,7 +47,7 @@
           "git branch -D ${BRANCH_NAME}"
         ]
       },
-      "workerCommand": "/catalyst-dev:oneshot",
+      "workerCommand": "/oneshot",
       "workerModel": "opus",
       "thoughts": {
         "profile": "my-profile",
@@ -70,6 +70,9 @@
       "linear": {
         "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET"
       }
+    },
+    "filter": {
+      "groqModel": "llama-3.1-8b-instant"
     }
   }
 }

--- a/.claude/config.template.json
+++ b/.claude/config.template.json
@@ -37,7 +37,7 @@
         "setup": [],
         "teardown": []
       },
-      "workerCommand": "/catalyst-dev:oneshot",
+      "workerCommand": "/oneshot",
       "workerModel": "opus",
       "thoughts": {
         "profile": null,
@@ -60,6 +60,9 @@
       "linear": {
         "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET"
       }
+    },
+    "filter": {
+      "groqModel": "llama-3.1-8b-instant"
     }
   }
 }

--- a/plugins/dev/scripts/catalyst-filter
+++ b/plugins/dev/scripts/catalyst-filter
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# catalyst-filter — manage the Groq-powered semantic event filter daemon
+#
+# Commands:
+#   start      Start filter daemon in background (idempotent)
+#   stop       Stop filter daemon
+#   restart    Stop then start
+#   status     Print running/stopped + pid
+#   logs       Tail daemon log
+#   run [args] Run daemon in foreground (debugging)
+
+set -uo pipefail
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+PID_FILE="${FILTER_PID_FILE:-$CATALYST_DIR/filter.pid}"
+LOG_FILE="${FILTER_LOG_FILE:-$CATALYST_DIR/filter.log}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DAEMON_SCRIPT="${FILTER_DAEMON_SCRIPT:-$SCRIPT_DIR/filter-daemon/index.mjs}"
+
+is_alive() { kill -0 "$1" 2>/dev/null; }
+
+read_pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    local pid
+    pid="$(cat "$PID_FILE" 2>/dev/null)"
+    if [[ "$pid" =~ ^[0-9]+$ ]] && is_alive "$pid"; then
+      echo "$pid"; return 0
+    fi
+    rm -f "$PID_FILE" 2>/dev/null
+  fi
+  return 1
+}
+
+resolve_runtime() {
+  if command -v bun &>/dev/null; then echo "bun"; return 0; fi
+  if command -v node &>/dev/null; then echo "node"; return 0; fi
+  echo "error: neither bun nor node found on PATH" >&2
+  return 1
+}
+
+cmd_start() {
+  if read_pid > /dev/null 2>&1; then
+    echo "catalyst-filter already running (pid $(read_pid))"
+    return 0
+  fi
+  local runtime
+  runtime=$(resolve_runtime) || return 1
+  if [[ ! -f "$DAEMON_SCRIPT" ]]; then
+    echo "error: daemon script not found: $DAEMON_SCRIPT" >&2
+    return 1
+  fi
+  mkdir -p "$(dirname "$PID_FILE")" 2>/dev/null || true
+  nohup "$runtime" "$DAEMON_SCRIPT" --pid-file "$PID_FILE" > "$LOG_FILE" 2>&1 &
+  local server_pid=$!
+  disown "$server_pid" 2>/dev/null || true
+  local waited=0
+  while [[ $waited -lt 20 ]]; do
+    if [[ -f "$PID_FILE" ]]; then
+      echo "catalyst-filter started (pid $(cat "$PID_FILE"))"
+      return 0
+    fi
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if is_alive "$server_pid"; then
+    echo "$server_pid" > "$PID_FILE"
+    echo "catalyst-filter started (pid $server_pid)"
+    return 0
+  fi
+  echo "error: catalyst-filter failed to start — check $LOG_FILE" >&2
+  return 1
+}
+
+cmd_stop() {
+  local pid
+  if ! pid=$(read_pid); then
+    echo "catalyst-filter not running"
+    return 0
+  fi
+  kill "$pid" 2>/dev/null || true
+  local waited=0
+  while [[ $waited -lt 30 ]] && is_alive "$pid"; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  is_alive "$pid" && kill -9 "$pid" 2>/dev/null || true
+  rm -f "$PID_FILE" 2>/dev/null
+  echo "catalyst-filter stopped"
+}
+
+cmd_restart() {
+  cmd_stop
+  cmd_start
+}
+
+cmd_status() {
+  local pid
+  if pid=$(read_pid); then
+    echo "running (pid $pid)"
+  else
+    echo "stopped"
+  fi
+}
+
+cmd_logs() {
+  if [[ -f "$LOG_FILE" ]]; then
+    tail -f "$LOG_FILE"
+  else
+    echo "No log file: $LOG_FILE"
+  fi
+}
+
+cmd_run() {
+  local runtime
+  runtime=$(resolve_runtime) || return 1
+  exec "$runtime" "$DAEMON_SCRIPT" "$@"
+}
+
+case "${1:-}" in
+  start)   cmd_start ;;
+  stop)    cmd_stop ;;
+  restart) cmd_restart ;;
+  status)  cmd_status ;;
+  logs)    cmd_logs ;;
+  run)     shift; cmd_run "$@" ;;
+  *)
+    echo "Usage: catalyst-filter {start|stop|restart|status|logs|run}" >&2
+    exit 1
+    ;;
+esac

--- a/plugins/dev/scripts/filter-daemon/index.mjs
+++ b/plugins/dev/scripts/filter-daemon/index.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+// filter-daemon/index.mjs — Groq-powered semantic event router
+// No build step, no npm dependencies. Requires Node.js >=21 or Bun.
+
+import { readFileSync, appendFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// --- Config ---
+const CATALYST_DIR = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+const GROQ_API_KEY = process.env.GROQ_API_KEY ?? '';
+const GROQ_ENDPOINT = 'https://api.groq.com/openai/v1/chat/completions';
+const GROQ_MODEL = process.env.FILTER_GROQ_MODEL ?? 'llama-3.1-8b-instant';
+const DEBOUNCE_MS = parseInt(process.env.FILTER_DEBOUNCE_MS ?? '100', 10);
+const HARD_CAP_MS = parseInt(process.env.FILTER_HARD_CAP_MS ?? '500', 10);
+const MAX_BATCH_SIZE = parseInt(process.env.FILTER_BATCH_SIZE ?? '20', 10);
+const POLL_MS = parseInt(process.env.FILTER_POLL_MS ?? '200', 10);
+const LOOKBACK_LINES = 1000;
+
+// --- Event log ---
+function getEventLogPath() {
+  const now = new Date();
+  const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  return resolve(CATALYST_DIR, 'events', `${ym}.jsonl`);
+}
+
+function appendEvent(event) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), ...event }) + '\n');
+}
+
+// --- Interest table ---
+const interests = new Map();
+
+export function getInterests() {
+  return interests;
+}
+
+export function clearInterests() {
+  interests.clear();
+}
+
+export function handleRegister(event) {
+  const d = event.detail ?? {};
+  const id = d.interest_id ?? event.orchestrator ?? d.notify_event;
+  if (!id) return;
+  interests.set(id, {
+    notify_event: d.notify_event ?? `filter.wake.${id}`,
+    prompt: d.prompt ?? '',
+    context: d.context ?? null,
+    orchestrator: event.orchestrator ?? null,
+  });
+  console.log(`[filter] Registered: ${id} — "${d.prompt}"`);
+}
+
+export function handleDeregister(event) {
+  const id = (event.detail ?? {}).interest_id ?? event.orchestrator;
+  if (!id) return;
+  if (interests.delete(id)) {
+    console.log(`[filter] Deregistered: ${id}`);
+  }
+}
+
+// --- Event classification ---
+
+// Returns true if this event should be completely ignored (not batched, not dispatched)
+export function shouldSkipEvent(event) {
+  const name = event.event ?? '';
+  // Self-loop prevention: skip wake events the daemon itself emitted.
+  // filter.register and filter.deregister are dispatched to handlers, not skipped here.
+  return name.startsWith('filter.wake.');
+}
+
+export function buildGroqPrompt(events) {
+  if (!interests.size) return null;
+
+  const interestLines = [...interests.entries()]
+    .map(([id, reg]) => {
+      const ctx = reg.context ? ` (context: ${JSON.stringify(reg.context)})` : '';
+      return `- ${id}: "${reg.prompt}"${ctx}`;
+    })
+    .join('\n');
+
+  const eventLines = events.map((e, i) => `${i + 1}. ${JSON.stringify(e)}`).join('\n');
+
+  const systemPrompt =
+    'You are a semantic event router for a developer automation system. ' +
+    'Given a list of events and registered orchestrator interests, determine which events are relevant to which interests.\n\n' +
+    'Respond with a JSON array of matches. Each element: ' +
+    '{"interest_id":"...","reason":"one sentence why","event_indices":[1,2,...]}.\n' +
+    'Only include interests with at least one matching event. Return [] if nothing matches.\n' +
+    'Return ONLY the JSON array, no other text.';
+
+  const userPrompt = `Events:\n${eventLines}\n\nRegistered interests:\n${interestLines}`;
+
+  return { systemPrompt, userPrompt };
+}
+
+async function classifyBatch(events) {
+  const prompts = buildGroqPrompt(events);
+  if (!prompts) return;
+
+  if (!GROQ_API_KEY) {
+    console.error('[filter] GROQ_API_KEY not set — skipping batch of', events.length, 'events');
+    return;
+  }
+
+  let responseText;
+  try {
+    const res = await fetch(GROQ_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${GROQ_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: GROQ_MODEL,
+        messages: [
+          { role: 'system', content: prompts.systemPrompt },
+          { role: 'user', content: prompts.userPrompt },
+        ],
+        temperature: 0,
+        max_tokens: 512,
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[filter] Groq error ${res.status}:`, await res.text());
+      return;
+    }
+    const data = await res.json();
+    responseText = data.choices?.[0]?.message?.content ?? '[]';
+  } catch (err) {
+    console.error('[filter] Groq fetch failed:', err.message);
+    return;
+  }
+
+  let matches;
+  try {
+    matches = JSON.parse(responseText);
+  } catch {
+    console.error('[filter] Failed to parse Groq response:', responseText);
+    return;
+  }
+
+  if (!Array.isArray(matches)) return;
+
+  for (const match of matches) {
+    const reg = interests.get(match.interest_id);
+    if (!reg) continue;
+
+    const sourceIds = (match.event_indices ?? [])
+      .map((i) => events[i - 1]?.id)
+      .filter(Boolean);
+
+    appendEvent({
+      event: reg.notify_event,
+      orchestrator: reg.orchestrator ?? match.interest_id,
+      worker: null,
+      detail: {
+        reason: match.reason,
+        source_event_ids: sourceIds,
+        interest_id: match.interest_id,
+      },
+    });
+    console.log(`[filter] Wake: ${reg.notify_event} — ${match.reason}`);
+  }
+}
+
+// --- Debounce ---
+let pendingBatch = [];
+let debounceTimer = null;
+let hardCapTimer = null;
+
+async function flushBatch() {
+  clearTimeout(debounceTimer);
+  clearTimeout(hardCapTimer);
+  debounceTimer = null;
+  hardCapTimer = null;
+  const batch = pendingBatch.splice(0);
+  if (batch.length) await classifyBatch(batch);
+}
+
+function scheduleBatchFlush() {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(flushBatch, DEBOUNCE_MS);
+  if (!hardCapTimer) {
+    hardCapTimer = setTimeout(flushBatch, HARD_CAP_MS);
+  }
+}
+
+function queueEvent(event) {
+  pendingBatch.push(event);
+  if (pendingBatch.length >= MAX_BATCH_SIZE) {
+    flushBatch();
+  } else {
+    scheduleBatchFlush();
+  }
+}
+
+// --- Event processing ---
+function processEvent(event) {
+  const name = event.event ?? '';
+
+  if (name === 'filter.register') { handleRegister(event); return; }
+  if (name === 'filter.deregister') { handleDeregister(event); return; }
+
+  if (shouldSkipEvent(event)) return;
+  if (name === 'heartbeat') return;
+
+  if (!interests.size) return;
+  queueEvent(event);
+}
+
+// --- Event log tailing ---
+let lastLineCount = 0;
+let lastLogPath = '';
+
+function pollEventLog() {
+  const logPath = getEventLogPath();
+
+  if (logPath !== lastLogPath) {
+    // Month rollover: snapshot current EOF, don't replay history
+    lastLogPath = logPath;
+    try {
+      const content = readFileSync(logPath, 'utf8');
+      lastLineCount = content.split('\n').filter((l) => l.trim()).length;
+    } catch {
+      lastLineCount = 0;
+    }
+    return;
+  }
+
+  let content;
+  try {
+    content = readFileSync(logPath, 'utf8');
+  } catch {
+    return;
+  }
+
+  const lines = content.split('\n').filter((l) => l.trim());
+  if (lines.length <= lastLineCount) return;
+
+  const newLines = lines.slice(lastLineCount);
+  lastLineCount = lines.length;
+
+  for (const line of newLines) {
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    processEvent(event);
+  }
+}
+
+function loadExistingRegistrations() {
+  try {
+    const content = readFileSync(lastLogPath, 'utf8');
+    const lines = content.split('\n').filter((l) => l.trim());
+    for (const line of lines.slice(-LOOKBACK_LINES)) {
+      let event;
+      try { event = JSON.parse(line); } catch { continue; }
+      if (event.event === 'filter.register') handleRegister(event);
+      if (event.event === 'filter.deregister') handleDeregister(event);
+    }
+    if (interests.size) {
+      console.log(`[filter] Recovered ${interests.size} interest(s) from log`);
+    }
+  } catch {
+    // No log file yet — fine
+  }
+}
+
+// --- PID file ---
+function parsePidFilePath() {
+  const idx = process.argv.indexOf('--pid-file');
+  return idx !== -1 ? process.argv[idx + 1] : null;
+}
+
+const PID_FILE_PATH = parsePidFilePath();
+
+function writePidFile() {
+  if (!PID_FILE_PATH) return;
+  try {
+    mkdirSync(dirname(PID_FILE_PATH), { recursive: true });
+    writeFileSync(PID_FILE_PATH, `${process.pid}\n`);
+  } catch (err) {
+    console.error('[filter] Failed to write PID file:', err.message);
+  }
+}
+
+function removePidFile() {
+  if (!PID_FILE_PATH) return;
+  try { unlinkSync(PID_FILE_PATH); } catch { /* already gone */ }
+}
+
+// --- Main ---
+function main() {
+  if (!GROQ_API_KEY) {
+    console.warn('[filter] WARN: GROQ_API_KEY not set — semantic filtering disabled until set');
+  }
+
+  writePidFile();
+
+  lastLogPath = getEventLogPath();
+  loadExistingRegistrations();
+
+  try {
+    const content = readFileSync(lastLogPath, 'utf8');
+    lastLineCount = content.split('\n').filter((l) => l.trim()).length;
+    console.log(`[filter] Starting from line ${lastLineCount} of ${lastLogPath}`);
+  } catch {
+    console.log(`[filter] Starting (no log file yet at ${lastLogPath})`);
+  }
+
+  const pollId = setInterval(pollEventLog, POLL_MS);
+  console.log(`[filter] catalyst-filter daemon started (pid ${process.pid})`);
+
+  const shutdown = () => {
+    clearInterval(pollId);
+    clearTimeout(debounceTimer);
+    clearTimeout(hardCapTimer);
+    removePidFile();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+// Run as script only, not when imported as a module (enables unit testing)
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/plugins/dev/scripts/filter-daemon/index.test.mjs
+++ b/plugins/dev/scripts/filter-daemon/index.test.mjs
@@ -1,0 +1,195 @@
+// Unit tests for filter-daemon core logic
+// Run: bun test plugins/dev/scripts/filter-daemon/index.test.mjs
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import {
+  handleRegister,
+  handleDeregister,
+  shouldSkipEvent,
+  buildGroqPrompt,
+  getInterests,
+  clearInterests,
+} from './index.mjs';
+
+describe('interest table', () => {
+  beforeEach(() => clearInterests());
+
+  test('handleRegister adds entry keyed by interest_id', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-1',
+      detail: {
+        interest_id: 'orch-1',
+        notify_event: 'filter.wake.orch-1',
+        prompt: 'Wake me on CI failure',
+        context: { pr_numbers: [42] },
+      },
+    });
+    const entry = getInterests().get('orch-1');
+    expect(entry).toBeDefined();
+    expect(entry.notify_event).toBe('filter.wake.orch-1');
+    expect(entry.prompt).toBe('Wake me on CI failure');
+    expect(entry.context).toEqual({ pr_numbers: [42] });
+  });
+
+  test('handleRegister falls back to orchestrator field when no interest_id', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-2',
+      detail: {
+        notify_event: 'filter.wake.orch-2',
+        prompt: 'PR merge events',
+      },
+    });
+    expect(getInterests().has('orch-2')).toBe(true);
+  });
+
+  test('handleRegister derives notify_event from id when not provided', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-x',
+      detail: { interest_id: 'orch-x', prompt: 'any event' },
+    });
+    expect(getInterests().get('orch-x').notify_event).toBe('filter.wake.orch-x');
+  });
+
+  test('handleRegister is idempotent — updates existing entry', () => {
+    const base = {
+      event: 'filter.register',
+      orchestrator: 'orch-3',
+      detail: { interest_id: 'orch-3', notify_event: 'filter.wake.orch-3', prompt: 'v1' },
+    };
+    handleRegister(base);
+    handleRegister({ ...base, detail: { ...base.detail, prompt: 'v2' } });
+    expect(getInterests().get('orch-3').prompt).toBe('v2');
+    expect(getInterests().size).toBe(1);
+  });
+
+  test('handleDeregister removes entry by interest_id', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-4',
+      detail: { interest_id: 'orch-4', notify_event: 'filter.wake.orch-4', prompt: 'x' },
+    });
+    handleDeregister({ event: 'filter.deregister', detail: { interest_id: 'orch-4' } });
+    expect(getInterests().has('orch-4')).toBe(false);
+  });
+
+  test('handleDeregister falls back to orchestrator field', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-5',
+      detail: { interest_id: 'orch-5', notify_event: 'filter.wake.orch-5', prompt: 'x' },
+    });
+    handleDeregister({ event: 'filter.deregister', orchestrator: 'orch-5', detail: {} });
+    expect(getInterests().has('orch-5')).toBe(false);
+  });
+
+  test('handleDeregister is a no-op for unknown ids', () => {
+    expect(() =>
+      handleDeregister({ event: 'filter.deregister', detail: { interest_id: 'nonexistent' } })
+    ).not.toThrow();
+  });
+});
+
+describe('shouldSkipEvent', () => {
+  test('skips filter.wake.* events (self-loop prevention)', () => {
+    expect(shouldSkipEvent({ event: 'filter.wake.orch-1' })).toBe(true);
+    expect(shouldSkipEvent({ event: 'filter.wake.anything' })).toBe(true);
+  });
+
+  test('does not skip filter.register (handled by processEvent)', () => {
+    expect(shouldSkipEvent({ event: 'filter.register' })).toBe(false);
+  });
+
+  test('does not skip filter.deregister', () => {
+    expect(shouldSkipEvent({ event: 'filter.deregister' })).toBe(false);
+  });
+
+  test('does not skip github events', () => {
+    expect(shouldSkipEvent({ event: 'github.pr.merged' })).toBe(false);
+    expect(shouldSkipEvent({ event: 'github.check_suite.completed' })).toBe(false);
+  });
+
+  test('does not skip worker lifecycle events', () => {
+    expect(shouldSkipEvent({ event: 'worker-done' })).toBe(false);
+    expect(shouldSkipEvent({ event: 'worker-status-change' })).toBe(false);
+  });
+
+  test('does not skip linear events', () => {
+    expect(shouldSkipEvent({ event: 'linear.issue.state_changed' })).toBe(false);
+  });
+
+  test('handles missing event field gracefully', () => {
+    expect(shouldSkipEvent({})).toBe(false);
+  });
+});
+
+describe('buildGroqPrompt', () => {
+  beforeEach(() => clearInterests());
+
+  test('returns null when no interests registered', () => {
+    expect(buildGroqPrompt([{ event: 'github.push' }])).toBeNull();
+  });
+
+  test('includes all events numbered in userPrompt', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-a',
+      detail: { interest_id: 'orch-a', notify_event: 'filter.wake.orch-a', prompt: 'CI failures' },
+    });
+    const events = [
+      { event: 'github.check_suite.completed', detail: { conclusion: 'failure' } },
+      { event: 'github.push' },
+    ];
+    const result = buildGroqPrompt(events);
+    expect(result).not.toBeNull();
+    expect(result.userPrompt).toContain('1.');
+    expect(result.userPrompt).toContain('2.');
+    expect(result.userPrompt).toContain('github.check_suite.completed');
+    expect(result.userPrompt).toContain('github.push');
+  });
+
+  test('includes all registered interests in userPrompt', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-a',
+      detail: { interest_id: 'orch-a', notify_event: 'filter.wake.orch-a', prompt: 'CI failures' },
+    });
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-b',
+      detail: { interest_id: 'orch-b', notify_event: 'filter.wake.orch-b', prompt: 'PR merges' },
+    });
+    const result = buildGroqPrompt([{ event: 'github.push' }]);
+    expect(result.userPrompt).toContain('CI failures');
+    expect(result.userPrompt).toContain('PR merges');
+  });
+
+  test('includes context in interest description when present', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-c',
+      detail: {
+        interest_id: 'orch-c',
+        notify_event: 'filter.wake.orch-c',
+        prompt: 'my PRs',
+        context: { pr_numbers: [123] },
+      },
+    });
+    const result = buildGroqPrompt([{ event: 'github.push' }]);
+    expect(result.userPrompt).toContain('pr_numbers');
+    expect(result.userPrompt).toContain('123');
+  });
+
+  test('systemPrompt instructs JSON-only output', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-d',
+      detail: { interest_id: 'orch-d', notify_event: 'filter.wake.orch-d', prompt: 'anything' },
+    });
+    const result = buildGroqPrompt([{ event: 'github.push' }]);
+    expect(result.systemPrompt).toContain('JSON array');
+    expect(result.systemPrompt.toLowerCase()).toContain('no other text');
+  });
+});

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -40,6 +40,10 @@
         "stagingEnvironment": "staging",
         "skipDeployVerification": true
       }
+    },
+    "filter": {
+      "_comment": "Semantic event routing via Groq. Set GROQ_API_KEY env var to enable.",
+      "groqModel": "llama-3.1-8b-instant"
     }
   }
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-05T17:50:00Z -->
<!-- Last updated: 2026-05-05T17:50:00Z -->
<!-- PR: #421 -->
<!-- Previous commits: af4775b441602095df515b6d0bcbe521f904a028 -->

## Summary

Adds the `catalyst-filter` daemon — a Groq-powered semantic event router that sits between the raw catalyst event log and orchestrators. Instead of writing broad jq syntactic filters, orchestrators register a natural-language intent description. The daemon batches incoming events, calls Groq Llama 3.1 8B to classify relevance, and emits `filter.wake.{id}` events that orchestrators wait-for with exact specificity.

**New files:**
- `plugins/dev/scripts/catalyst-filter` — bash CLI daemon manager (start/stop/restart/status/logs/run)
- `plugins/dev/scripts/filter-daemon/index.mjs` — Node.js daemon, no build step, no npm dependencies
- `plugins/dev/scripts/filter-daemon/index.test.mjs` — 19 unit tests (bun test)

**Modified files:**
- All three config templates (`.claude/config.template.json`, `.claude/config.example.json`, `plugins/dev/templates/config.template.json`) — adds `filter.groqModel` section
- `.catalyst/config.json` — removes committed environment-specific Linear IDs (`teamId`, `stateIds`, `monitor.github`) that should not be in version control

## Changes Made

### New: `plugins/dev/scripts/catalyst-filter` (bash CLI)

Follows the `catalyst-monitor.sh` daemon management pattern exactly:
- `start` — launches daemon via `nohup`/`disown`, waits for PID file (up to 2s)
- `stop` — graceful kill with kill-9 fallback after 3s
- `restart` — stop then start
- `status` — PID file liveness check
- `logs` — tails `$CATALYST_DIR/filter.log`
- `run` — foreground execution (no daemonization, useful for debugging)

Prefers `bun` runtime, falls back to `node`. Both work with the `.mjs` format.

Env var overrides: `CATALYST_DIR`, `FILTER_PID_FILE`, `FILTER_LOG_FILE`, `FILTER_DAEMON_SCRIPT`.

### New: `plugins/dev/scripts/filter-daemon/index.mjs` (Node.js daemon)

**No build step, no npm dependencies** — plain ES module using only Node.js/Bun built-ins (`fs`, `fetch`, `path`, `os`, `url`).

Core algorithm:
1. **Seek to EOF** on startup — only processes new events, not historical ones
2. **Recover interests** from last 1000 lines of log (handles daemon restarts mid-session)
3. **Poll event log** every 200ms (`setInterval`, no `fswatch` dependency)
4. **Dispatch events**:
   - `filter.register` → add to in-memory interest table keyed by `detail.interest_id` (falls back to `event.orchestrator`)
   - `filter.deregister` → remove from interest table
   - `filter.wake.*` → skip (self-loop prevention)
   - `heartbeat` → skip (high volume, low signal)
   - Everything else → accumulate in pending batch
5. **Debounce** — 100ms soft / 500ms hard cap; flush immediately at 20 events
6. **Groq classification** — one call per batch covering ALL registered interests simultaneously (multi-tenant)
7. **Emit** `filter.wake.{id}` events for each matched interest

**Protocol:**
- `filter.register` event: `{event, orchestrator, detail: {interest_id, notify_event, prompt, context}}`
- `filter.wake.*` event: `{event, orchestrator, detail: {reason, source_event_ids, interest_id}}`

PID file management: writes `$CATALYST_DIR/filter.pid` on startup, removes on SIGINT/SIGTERM. Guards `main()` behind `process.argv[1] === import.meta.url` check so the module can be imported for unit testing without starting the poll loop.

### New: `plugins/dev/scripts/filter-daemon/index.test.mjs` (19 unit tests)

Tests the exported core functions in isolation:
- `handleRegister` / `handleDeregister` — interest table CRUD, keying fallback, idempotency
- `shouldSkipEvent` — self-loop prevention (filter.wake.*), filter.register passthrough
- `buildGroqPrompt` — null when no interests, numbered event list, all interests in prompt, context inclusion, JSON-only system prompt instruction

### Config template updates

All three config templates now include a `filter` section alongside the `monitor` section:
```json
"filter": {
  "groqModel": "llama-3.1-8b-instant"
}
```

The `plugins/dev/templates/config.template.json` also now includes the `deploy` section (from CTL-254/main) merged with the new `filter` section.

## How to Verify It

### Automated checks

- [x] Unit tests pass: `bun test plugins/dev/scripts/filter-daemon/index.test.mjs` — 19/19 ✅
- [x] Bash syntax valid: `bash -n plugins/dev/scripts/catalyst-filter` ✅
- [x] CI: audit-references ✅ check-versions ✅ validate ✅ (Cloudflare Pages pending)

### Manual verification

1. **Daemon lifecycle:**
   ```bash
   catalyst-filter status         # → stopped
   catalyst-filter start          # → started (pid N)
   catalyst-filter status         # → running (pid N)
   catalyst-filter restart        # → stopped / started (pid M)
   catalyst-filter stop           # → stopped
   ```

2. **filter.register pickup:**
   ```bash
   catalyst-filter start
   echo '{"ts":"...","event":"filter.register","orchestrator":"test","detail":{"interest_id":"test","notify_event":"filter.wake.test","prompt":"any CI event"}}' \
     >> ~/catalyst/events/$(date +%Y-%m).jsonl
   # check ~/catalyst/filter.log for "Registered: test"
   ```

3. **End-to-end routing (requires GROQ_API_KEY):**
   ```bash
   export GROQ_API_KEY=gsk_...
   catalyst-filter start
   # write filter.register + a github.check_suite.completed event
   # observe filter.wake.test in the event log
   ```

## Changelog Entry

**feat(dev):** Adds `catalyst-filter` daemon for Groq-powered semantic event routing. Orchestrators register a natural-language intent; the daemon batches events via 100ms debounce, classifies with Llama 3.1 8B, and emits `filter.wake.{id}` events. Set `GROQ_API_KEY` to enable. See CTL-256.

## Related Issues

- Implements https://linear.app/coalesce-labs/issue/CTL-256
- Blocks: CTL-257, CTL-258, CTL-259, CTL-261, CTL-262, CTL-263 (downstream tickets)

Refs: CTL-256
