### PR TITLE
feat(dev): SKILL.md for catalyst-filter — protocol docs for orchestrators (CTL-258)

### DIFF
--- a/plugins/dev/skills/catalyst-filter/SKILL.md
+++ b/plugins/dev/skills/catalyst-filter/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: catalyst-filter
+description:
+  Protocol reference for the catalyst-filter semantic event routing daemon. Use when an
+  orchestrator needs to wait for relevant events using a natural-language intent description
+  instead of a precise jq predicate. Covers registration, waiting, deregistration, the wake
+  event structure, prompt writing, context fields, and the fallback path when the daemon is
+  not running.
+---
+
+# catalyst-filter — Semantic Event Routing Protocol
+
+The `catalyst-filter` daemon sits between the raw catalyst event log and orchestrators. Instead
+of requiring a precise jq filter at registration time, callers describe their intent in plain
+language. The daemon batches incoming events, calls Groq Llama 3.1 8B to classify relevance, and
+emits `filter.wake.{id}` events that orchestrators wait for with `catalyst-events wait-for`.
+
+## When to Use
+
+- **Orchestrator Phase 4** — replacing the poll loop with an event-driven wake signal
+- **Any long-running wait** where the trigger condition is complex, multi-condition, or better
+  expressed in words than jq
+- **Multi-PR / multi-worker scenarios** — "wake me when any of my 4 PRs gets a CI failure or
+  changes-requested review"
+
+## When NOT to Use
+
+- **Very short waits (< 1 min)** — direct `catalyst-events wait-for` with a jq filter is
+  simpler and has lower latency
+- **Single, precisely expressible conditions** — `.event == "github.pr.merged" and .scope.pr == 42`
+  needs no LLM
+- **`GROQ_API_KEY` is unavailable** — use the jq fallback described at the end of this doc
+
+## Prerequisites
+
+The daemon must be running and `GROQ_API_KEY` must be set:
+
+```bash
+# Check status
+catalyst-filter status   # → "running (pid N)" or "stopped"
+
+# Start if stopped
+catalyst-filter start
+
+# View startup log
+catalyst-filter logs
+```
+
+`GROQ_API_KEY` is read from the environment. Set it in your shell profile or Layer 2 config
+(`~/.config/catalyst/config-{projectKey}.json`).
+
+## Protocol Overview
+
+```
+Orchestrator                         filter daemon                     Event log
+    │                                     │                                │
+    │── emit filter.register ────────────►│                                │
+    │                                     │  polls every 200ms ◄───────────│
+    │                                     │  batches events (100ms debounce)
+    │                                     │  calls Groq: "is this relevant?"
+    │                                     │── append filter.wake.{id} ────►│
+    │                                     │                                │
+    │◄── catalyst-events wait-for ────────────────────────────────────────│
+    │    (.event == "filter.wake.{id}")   │                                │
+    │                                     │                                │
+    │── emit filter.deregister ──────────►│                                │
+```
+
+## Step 1 — Register
+
+Emit a `filter.register` event to the catalyst event log before entering your wait:
+
+```bash
+STATE_SCRIPT="/path/to/plugins/dev/scripts/catalyst-state.sh"
+
+"$STATE_SCRIPT" event "$(jq -nc \
+  --arg orch "$ORCH_ID" \
+  --arg prompt "Wake me when: CI fails on any of my PRs, a PR gets changes-requested review, a PR merges, or a worker crashes (no heartbeat)." \
+  --argjson prs '[408, 409]' \
+  --argjson tickets '["CTL-253", "CTL-254"]' \
+  --argjson branches '["orch-ctl-253-2026-05-05-CTL-253", "orch-ctl-253-2026-05-05-CTL-254"]' \
+  '{
+    event: "filter.register",
+    orchestrator: $orch,
+    detail: {
+      notify_event: ("filter.wake." + $orch),
+      prompt: $prompt,
+      context: {
+        pr_numbers: $prs,
+        tickets: $tickets,
+        branches: $branches
+      }
+    }
+  }')"
+```
+
+### Registration event schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event` | string | Always `"filter.register"` |
+| `orchestrator` | string | Orchestrator ID — used as the routing key if `detail.interest_id` is absent |
+| `detail.notify_event` | string | Event name the daemon will emit when relevant events arrive (`"filter.wake.{id}"`) |
+| `detail.prompt` | string | Natural-language description of what to wake on (see Prompt Writing below) |
+| `detail.context` | object | Optional focus hints: `pr_numbers`, `tickets`, `branches` |
+| `detail.interest_id` | string | Optional override for the routing table key; defaults to `orchestrator` |
+
+The daemon picks up `filter.register` from the live log within one poll cycle (~200ms).
+On daemon restart, it scans the last 1000 lines of the log to recover active registrations.
+
+## Step 2 — Wait
+
+After registering, block on the corresponding wake event:
+
+```bash
+EVENT=$(catalyst-events wait-for \
+  --filter ".event == \"filter.wake.${ORCH_ID}\"" \
+  --timeout 7200 || true)
+
+# Mandatory authoritative check — always verify via REST regardless of wait outcome
+# (daemon may be down; event may have arrived before wait started)
+PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+# ... inspect PR_JSON for ground truth
+```
+
+**The authoritative check is non-negotiable.** `wait-for` is a wake-up trigger, not a source
+of truth. Always follow it with a REST/CLI check before acting on the result.
+
+## Step 3 — Read the Wake Event
+
+When the daemon finds a match it appends a `filter.wake.{id}` event:
+
+```json
+{
+  "ts": "2026-05-05T17:42:10Z",
+  "event": "filter.wake.orch-ctl-253-2026-05-05",
+  "orchestrator": "orch-ctl-253-2026-05-05",
+  "worker": null,
+  "detail": {
+    "reason": "CI failed on PR #409 — check_run conclusion: failure (build workflow)",
+    "source_event_ids": ["evt_abc123", "evt_def456"],
+    "interest_id": "orch-ctl-253-2026-05-05"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `detail.reason` | One sentence from the LLM explaining which events matched and why |
+| `detail.source_event_ids` | IDs of the raw events that triggered this wake (v2 events only) |
+| `detail.interest_id` | Routing key used to look up the interest registration |
+
+Use `reason` as context for your diagnostic step, not as a decision signal. Confirm via REST.
+
+## Step 4 — Deregister
+
+When the orchestrator is done waiting (phase complete, shutting down, or merging), emit
+`filter.deregister` to remove the interest from the routing table:
+
+```bash
+"$STATE_SCRIPT" event "$(jq -nc \
+  --arg id "$ORCH_ID" \
+  '{event: "filter.deregister", detail: {interest_id: $id}}')"
+```
+
+If the orchestrator exits without deregistering, the daemon's in-memory table retains the
+entry until the daemon restarts (it re-scans the log on restart and applies both register
+and deregister events in order).
+
+## Prompt Writing Guide
+
+The prompt is the only input the LLM uses to decide relevance. Be explicit about conditions,
+not detection mechanics.
+
+**Good prompts:**
+
+```
+Wake me when: CI fails on any of my PRs, a PR gets changes-requested review,
+a PR merges successfully, a worker crashes or goes stale, or a merge conflict
+(dirty state) is detected.
+```
+
+```
+Alert me if: the release-please PR merges, a deployment_status failure event
+arrives for the production environment, or a workflow run fails on main.
+```
+
+**What makes a prompt effective:**
+
+- **Name the conditions directly** — "CI fails", "PR merges", "worker crashes" — not "check
+  for check_run events with conclusion: failure". The LLM knows the event taxonomy.
+- **Include all conditions at once** — one registration covers all scenarios. The LLM routes
+  any matching event to your wake.
+- **Keep it short** — 50–100 words is enough. Long prompts add latency without precision gains.
+- **Don't describe the event fields** — you don't need to say "when `.event` equals
+  `github.pr.merged`". Say "when a PR merges".
+
+**Unhelpful prompts:**
+
+```
+Watch for things that might be relevant.           ← too vague; will fire on everything
+Only wake me on github.check_suite.completed       ← use jq directly instead
+```
+
+## Context Fields
+
+The `context` object focuses the LLM on your specific resources, reducing false positives
+when multiple orchestrators are registered simultaneously:
+
+| Field | Type | Effect |
+|-------|------|--------|
+| `pr_numbers` | `number[]` | PR numbers the orchestrator owns. Groq uses these to distinguish "CI failure on PR #408 (mine)" from "CI failure on PR #500 (not mine)". |
+| `tickets` | `string[]` | Linear ticket IDs (e.g., `["CTL-253", "CTL-254"]`). Helps filter `linear.*` events and worker lifecycle events scoped to those tickets. |
+| `branches` | `string[]` | Branch names. Used to distinguish `github.push` and `github.check_suite` events by branch. |
+
+All fields are optional but strongly recommended. Without context, the LLM must infer scope
+from the event payload alone and is more likely to produce false positives.
+
+## Fallback: Daemon Not Running
+
+If `catalyst-filter status` returns "stopped" (or if `GROQ_API_KEY` is not set), fall back to
+a direct `catalyst-events wait-for` with a jq predicate:
+
+```bash
+FILTER_STATUS=$(catalyst-filter status 2>/dev/null || echo "stopped")
+if [[ "$FILTER_STATUS" == "stopped" ]] || [[ -z "${GROQ_API_KEY:-}" ]]; then
+  # jq fallback — express the condition syntactically
+  EVENT=$(catalyst-events wait-for \
+    --filter "
+      (.event | startswith(\"github.pr.\")) or
+      (.event | startswith(\"github.check_suite.\")) or
+      (.event == \"worker-status-change\" and (.worker | IN(\"CTL-253\",\"CTL-254\")))
+    " \
+    --timeout 7200 || true)
+else
+  # Semantic filter path — register, wait, deregister
+  # (steps 1–4 above)
+fi
+```
+
+The jq fallback has higher noise (more events will wake the orchestrator) but zero external
+dependencies. Always follow any wake event — semantic or syntactic — with an authoritative
+REST check.
+
+## Multi-Tenant Behavior
+
+The daemon maintains one in-memory routing table for all active registrations. Each event
+batch is classified against all registered interests in a single Groq call. Adding more
+orchestrators does not increase per-orchestrator cost or latency — all interests are evaluated
+simultaneously.
+
+`filter.wake.{id}` events are per-interest: orchestrator A never receives orchestrator B's
+wake events.
+
+## Batching and Latency
+
+Events are batched with:
+- **100ms debounce**: each new event resets the timer
+- **500ms hard cap**: batch flushes regardless of arrival rate after 500ms
+- **20-event batch limit**: flushes immediately when batch reaches 20 events
+
+Effective latency from a GitHub webhook arriving to the wake event appearing in the log:
+approximately 300–600ms under normal load. At higher burst volume (GitHub CI fires multiple
+`check_run.completed` events simultaneously), all fire in the same batch — 1 Groq call for N
+simultaneous CI events.
+
+## Quick Reference
+
+```bash
+# Check if daemon is running
+catalyst-filter status
+
+# Start / stop / restart
+catalyst-filter start
+catalyst-filter stop
+catalyst-filter restart
+
+# Debug: run in foreground
+catalyst-filter run
+
+# Tail daemon log
+catalyst-filter logs
+
+# Manually register an interest
+catalyst-state.sh event '{"event":"filter.register","orchestrator":"my-orch","detail":{"notify_event":"filter.wake.my-orch","prompt":"Wake me on CI failure or PR merge."}}'
+
+# Wait for wake signal
+catalyst-events wait-for --filter '.event == "filter.wake.my-orch"' --timeout 7200
+
+# Deregister
+catalyst-state.sh event '{"event":"filter.deregister","detail":{"interest_id":"my-orch"}}'
+```
+
+## Related
+
+- [[monitor-events]] — canonical event-driven wait patterns (`wait-for` primitive reference)
+- [[catalyst-comms]] — agent-to-agent messaging protocol
+- `plugins/dev/scripts/catalyst-filter` — daemon CLI (start/stop/status/logs/run)
+- `plugins/dev/scripts/filter-daemon/index.mjs` — daemon implementation


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-05T17:56:00Z -->
<!-- Last updated: 2026-05-05T17:56:00Z -->
<!-- PR: #422 -->
<!-- Previous commits: e6205297835d20c65d00cb4630f2e6f246bb4eb8 -->

## Summary

Adds `plugins/dev/skills/catalyst-filter/SKILL.md` — full protocol reference for orchestrators
using the Groq-powered semantic filter daemon introduced in CTL-256. This is the companion
documentation that enables orchestrators to register natural-language interests, wait for
`filter.wake.{id}` events, and fall back gracefully when the daemon is unavailable.

## Changes Made

### New skill: `plugins/dev/skills/catalyst-filter/SKILL.md` (+299 lines)

Complete protocol documentation covering:

- **What catalyst-filter does** — semantic event routing using Groq Llama 3.1 8B; replaces
  broad jq predicates with intent descriptions like "wake me when CI fails on any of my PRs"
- **When to use / when not to use** — short waits (<1 min) and single-condition jq filters
  don't need the overhead
- **Prerequisites** — `GROQ_API_KEY` env var, `catalyst-filter status` check
- **Registration protocol** — full `filter.register` event schema with `notify_event`,
  `prompt`, `context` fields and `interest_id` override
- **Waiting** — `catalyst-events wait-for --filter '.event == "filter.wake.{id}"'` with
  mandatory authoritative REST check (non-negotiable per the monitor-events pattern)
- **Deregistration** — `filter.deregister` event schema
- **Wake event structure** — `reason`, `source_event_ids`, `interest_id` fields documented
  with concrete example
- **Prompt writing guide** — what makes an effective interest description (conditions, not
  field names), good/bad examples
- **Context fields** — how `pr_numbers`, `tickets`, `branches` focus routing to reduce
  false positives in multi-tenant scenarios
- **Fallback** — complete jq fallback path for when daemon is stopped or `GROQ_API_KEY`
  is unavailable
- **Multi-tenant behavior** — one Groq call covers all registered interests simultaneously
- **Batching and latency** — 100ms debounce, 500ms hard cap, 20-event batch limit, ~300-600ms
  end-to-end latency
- **Quick reference** — all CLI commands and event payloads in one place

## How to Verify

- [x] `plugins/dev/skills/catalyst-filter/SKILL.md` exists and is well-formed
- [x] SKILL.md frontmatter includes `name` and `description` fields (required by plugin format)
- [x] `audit-references` CI check passes — all `[[wiki-links]]` resolve correctly
- [x] `check-versions` CI check passes
- [x] `validate` CI check passes
- [ ] Manual: read SKILL.md and verify all protocol steps match the implementation in
      `plugins/dev/scripts/catalyst-filter` and `plugins/dev/scripts/filter-daemon/index.mjs`

## Blocks / Related

- Implements: CTL-258
- Depends on: CTL-256 (catalyst-filter daemon, already merged in #421)
- Blocks: CTL-260 (next consumer of this protocol documentation)

Refs: CTL-258
