### PR TITLE
feat(dev): add catalyst-filter to plugin install scripts (CTL-259)

### DIFF
--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -82,7 +82,7 @@ done
 header "Catalyst CLI Install"
 
 CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
-CLI_NAMES=(catalyst-comms catalyst-events catalyst-session catalyst-state catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude)
+CLI_NAMES=(catalyst-comms catalyst-events catalyst-filter catalyst-session catalyst-state catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude)
 
 if [[ -d "$CLI_BIN_DIR" ]]; then
     pass "Bin dir exists: $CLI_BIN_DIR"

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -26,6 +26,7 @@ set -uo pipefail
 CLI_ENTRIES=(
   "catalyst-comms:catalyst-comms"
   "catalyst-events:catalyst-events"
+  "catalyst-filter:catalyst-filter"
   "catalyst-session.sh:catalyst-session"
   "catalyst-state.sh:catalyst-state"
   "catalyst-db.sh:catalyst-db"


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-05T17:58:00Z -->
<!-- Last updated: 2026-05-05T17:58:00Z -->
<!-- PR: #423 -->
<!-- Previous commits: c7c15885faa7eeb13c3296dc065b6acc235e56d2 -->

## Summary

Wires `catalyst-filter` into the plugin install system so it is automatically symlinked to `~/.catalyst/bin/catalyst-filter` when `install-cli.sh` runs. Also adds it to the `check-setup.sh` health-check list so `check-setup.sh` reports whether the symlink is in place.

The `catalyst-filter` binary and its `filter-daemon/` were introduced in CTL-256 (#421). This PR completes the installation story so new developer setups get the daemon without a manual symlink step.

## Changes

- **`plugins/dev/scripts/install-cli.sh`**: Add `"catalyst-filter:catalyst-filter"` to `CLI_ENTRIES` allowlist (between `catalyst-events` and `catalyst-session`)
- **`plugins/dev/scripts/check-setup.sh`**: Add `catalyst-filter` to `CLI_NAMES` array so the health check validates the symlink

## How to Verify

- [ ] Run `CATALYST_CLI_BIN_DIR=/tmp/test-install CATALYST_CLI_SOURCE=plugins/dev/scripts bash plugins/dev/scripts/install-cli.sh --force` — output should show `9 catalyst CLI symlink(s) installed` and `catalyst-filter` should appear in `/tmp/test-install/`
- [ ] Run `plugins/dev/scripts/check-setup.sh` — "Catalyst CLI Install" section should include a `catalyst-filter` line
- [ ] Verify `~/.catalyst/bin/catalyst-filter` resolves to the correct script after running `install-cli.sh`

## Related Issues

Refs: CTL-259
Depends on: CTL-256 (#421, merged)
