### PR TITLE
feat(dev): persistent interests + explicit deregistration in filter daemon (CTL-262)

### DIFF
--- a/plugins/dev/scripts/filter-daemon/index.mjs
+++ b/plugins/dev/scripts/filter-daemon/index.mjs
@@ -51,8 +51,9 @@ export function handleRegister(event) {
     prompt: d.prompt ?? '',
     context: d.context ?? null,
     orchestrator: event.orchestrator ?? null,
+    persistent: d.persistent === true,
   });
-  console.log(`[filter] Registered: ${id} — "${d.prompt}"`);
+  console.log(`[filter] Registered: ${id} — "${d.prompt}" (persistent: ${d.persistent === true})`);
 }
 
 export function handleDeregister(event) {
@@ -63,14 +64,26 @@ export function handleDeregister(event) {
   }
 }
 
+export function handleOrchestratorTerminated(event) {
+  const orchId = event.orchestrator;
+  if (!orchId) return;
+  for (const [id, reg] of interests) {
+    if (reg.orchestrator === orchId) {
+      interests.delete(id);
+      console.log(`[filter] Auto-deregistered: ${id} (orchestrator ${orchId} terminated)`);
+    }
+  }
+}
+
 // --- Event classification ---
 
 // Returns true if this event should be completely ignored (not batched, not dispatched)
 export function shouldSkipEvent(event) {
   const name = event.event ?? '';
-  // Self-loop prevention: skip wake events the daemon itself emitted.
-  // filter.register and filter.deregister are dispatched to handlers, not skipped here.
-  return name.startsWith('filter.wake.');
+  // Self-loop prevention: skip all filter.* events the daemon produces or handles.
+  // filter.register and filter.deregister are dispatched to handlers before this is called,
+  // but skipping all filter.* here ensures no future filter.* variants reach Groq.
+  return name.startsWith('filter.');
 }
 
 export function buildGroqPrompt(events) {
@@ -165,6 +178,10 @@ async function classifyBatch(events) {
       },
     });
     console.log(`[filter] Wake: ${reg.notify_event} — ${match.reason}`);
+    if (!reg.persistent) {
+      interests.delete(match.interest_id);
+      console.log(`[filter] Auto-deregistered (one-shot): ${match.interest_id}`);
+    }
   }
 }
 
@@ -208,6 +225,12 @@ function processEvent(event) {
 
   if (shouldSkipEvent(event)) return;
   if (name === 'heartbeat') return;
+
+  // Implicitly deregister interests belonging to a terminated orchestrator.
+  // The event is still queued for Groq so other orchestrators watching for this event can fire.
+  if (name === 'orchestrator-completed' || name === 'orchestrator-failed') {
+    handleOrchestratorTerminated(event);
+  }
 
   if (!interests.size) return;
   queueEvent(event);
@@ -265,6 +288,9 @@ function loadExistingRegistrations() {
       try { event = JSON.parse(line); } catch { continue; }
       if (event.event === 'filter.register') handleRegister(event);
       if (event.event === 'filter.deregister') handleDeregister(event);
+      if (event.event === 'orchestrator-completed' || event.event === 'orchestrator-failed') {
+        handleOrchestratorTerminated(event);
+      }
     }
     if (interests.size) {
       console.log(`[filter] Recovered ${interests.size} interest(s) from log`);

--- a/plugins/dev/scripts/filter-daemon/index.test.mjs
+++ b/plugins/dev/scripts/filter-daemon/index.test.mjs
@@ -5,6 +5,7 @@ import { describe, test, expect, beforeEach } from 'bun:test';
 import {
   handleRegister,
   handleDeregister,
+  handleOrchestratorTerminated,
   shouldSkipEvent,
   buildGroqPrompt,
   getInterests,
@@ -90,6 +91,91 @@ describe('interest table', () => {
       handleDeregister({ event: 'filter.deregister', detail: { interest_id: 'nonexistent' } })
     ).not.toThrow();
   });
+
+  test('handleRegister stores persistent: false by default', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-p1',
+      detail: { interest_id: 'orch-p1', notify_event: 'filter.wake.orch-p1', prompt: 'x' },
+    });
+    expect(getInterests().get('orch-p1').persistent).toBe(false);
+  });
+
+  test('handleRegister stores persistent: true when passed', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-p2',
+      detail: { interest_id: 'orch-p2', notify_event: 'filter.wake.orch-p2', prompt: 'x', persistent: true },
+    });
+    expect(getInterests().get('orch-p2').persistent).toBe(true);
+  });
+
+  test('handleRegister treats persistent: false explicitly as false', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-p3',
+      detail: { interest_id: 'orch-p3', notify_event: 'filter.wake.orch-p3', prompt: 'x', persistent: false },
+    });
+    expect(getInterests().get('orch-p3').persistent).toBe(false);
+  });
+});
+
+describe('handleOrchestratorTerminated', () => {
+  beforeEach(() => clearInterests());
+
+  test('removes all interests belonging to the terminated orchestrator', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-A',
+      detail: { interest_id: 'orch-A', notify_event: 'filter.wake.orch-A', prompt: 'x' },
+    });
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-A',
+      detail: { interest_id: 'orch-A-2', notify_event: 'filter.wake.orch-A-2', prompt: 'y' },
+    });
+    handleOrchestratorTerminated({ event: 'orchestrator-completed', orchestrator: 'orch-A' });
+    expect(getInterests().has('orch-A')).toBe(false);
+    expect(getInterests().has('orch-A-2')).toBe(false);
+  });
+
+  test('does not remove interests belonging to other orchestrators', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-A',
+      detail: { interest_id: 'orch-A', notify_event: 'filter.wake.orch-A', prompt: 'x' },
+    });
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-B',
+      detail: { interest_id: 'orch-B', notify_event: 'filter.wake.orch-B', prompt: 'y' },
+    });
+    handleOrchestratorTerminated({ event: 'orchestrator-completed', orchestrator: 'orch-A' });
+    expect(getInterests().has('orch-A')).toBe(false);
+    expect(getInterests().has('orch-B')).toBe(true);
+  });
+
+  test('is a no-op when no interests match the orchestrator', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-X',
+      detail: { interest_id: 'orch-X', notify_event: 'filter.wake.orch-X', prompt: 'x' },
+    });
+    handleOrchestratorTerminated({ event: 'orchestrator-failed', orchestrator: 'orch-Y' });
+    expect(getInterests().has('orch-X')).toBe(true);
+  });
+
+  test('is a no-op when event has no orchestrator field', () => {
+    handleRegister({
+      event: 'filter.register',
+      orchestrator: 'orch-Z',
+      detail: { interest_id: 'orch-Z', notify_event: 'filter.wake.orch-Z', prompt: 'x' },
+    });
+    expect(() =>
+      handleOrchestratorTerminated({ event: 'orchestrator-completed' })
+    ).not.toThrow();
+    expect(getInterests().has('orch-Z')).toBe(true);
+  });
 });
 
 describe('shouldSkipEvent', () => {
@@ -98,12 +184,10 @@ describe('shouldSkipEvent', () => {
     expect(shouldSkipEvent({ event: 'filter.wake.anything' })).toBe(true);
   });
 
-  test('does not skip filter.register (handled by processEvent)', () => {
-    expect(shouldSkipEvent({ event: 'filter.register' })).toBe(false);
-  });
-
-  test('does not skip filter.deregister', () => {
-    expect(shouldSkipEvent({ event: 'filter.deregister' })).toBe(false);
+  test('skips all filter.* events to prevent Groq loop', () => {
+    expect(shouldSkipEvent({ event: 'filter.register' })).toBe(true);
+    expect(shouldSkipEvent({ event: 'filter.deregister' })).toBe(true);
+    expect(shouldSkipEvent({ event: 'filter.anything' })).toBe(true);
   });
 
   test('does not skip github events', () => {

--- a/plugins/dev/skills/catalyst-filter/SKILL.md
+++ b/plugins/dev/skills/catalyst-filter/SKILL.md
@@ -85,6 +85,7 @@ STATE_SCRIPT="/path/to/plugins/dev/scripts/catalyst-state.sh"
     detail: {
       notify_event: ("filter.wake." + $orch),
       prompt: $prompt,
+      persistent: true,
       context: {
         pr_numbers: $prs,
         tickets: $tickets,
@@ -102,11 +103,20 @@ STATE_SCRIPT="/path/to/plugins/dev/scripts/catalyst-state.sh"
 | `orchestrator` | string | Orchestrator ID — used as the routing key if `detail.interest_id` is absent |
 | `detail.notify_event` | string | Event name the daemon will emit when relevant events arrive (`"filter.wake.{id}"`) |
 | `detail.prompt` | string | Natural-language description of what to wake on (see Prompt Writing below) |
+| `detail.persistent` | boolean | `true` — keep interest active after each match (continuous monitoring). `false` (default) — auto-deregister after first wake (one-shot wait). |
 | `detail.context` | object | Optional focus hints: `pr_numbers`, `tickets`, `branches` |
 | `detail.interest_id` | string | Optional override for the routing table key; defaults to `orchestrator` |
 
 The daemon picks up `filter.register` from the live log within one poll cycle (~200ms).
 On daemon restart, it scans the last 1000 lines of the log to recover active registrations.
+
+**Choosing `persistent`:**
+
+- Use `persistent: true` for continuous monitoring — the orchestrator's Phase 4 loop where you want
+  to be woken on every CI event, every PR update, every worker status change throughout the run.
+- Use `persistent: false` (the default) for one-shot waits — "tell me when this specific PR merges"
+  or "wake me when the next CI run completes". The interest is removed automatically after the first
+  wake, so no explicit `filter.deregister` is needed.
 
 ## Step 2 — Wait
 
@@ -154,8 +164,17 @@ Use `reason` as context for your diagnostic step, not as a decision signal. Conf
 
 ## Step 4 — Deregister
 
-When the orchestrator is done waiting (phase complete, shutting down, or merging), emit
-`filter.deregister` to remove the interest from the routing table:
+Deregistration happens automatically in three cases:
+
+1. **One-shot (`persistent: false`, the default)** — the daemon removes the interest immediately
+   after emitting the first wake event. No explicit deregister needed.
+
+2. **Orchestrator termination** — when `orchestrator-completed` or `orchestrator-failed` appears
+   in the event log for an orchestrator ID that has active interests, the daemon removes all of
+   that orchestrator's interests automatically.
+
+3. **Explicit deregister** — emit `filter.deregister` at any time to remove the interest
+   immediately (useful for `persistent: true` interests or early cancellation):
 
 ```bash
 "$STATE_SCRIPT" event "$(jq -nc \
@@ -163,9 +182,10 @@ When the orchestrator is done waiting (phase complete, shutting down, or merging
   '{event: "filter.deregister", detail: {interest_id: $id}}')"
 ```
 
-If the orchestrator exits without deregistering, the daemon's in-memory table retains the
-entry until the daemon restarts (it re-scans the log on restart and applies both register
-and deregister events in order).
+If a `persistent: true` orchestrator exits without emitting `filter.deregister` or
+`orchestrator-completed`/`orchestrator-failed`, the daemon's in-memory table retains the entry
+until the daemon restarts (on restart it replays the last 1000 log lines and applies all
+register, deregister, and completion events in order).
 
 ## Prompt Writing Guide
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-05T18:20:00Z -->
<!-- Last updated: 2026-05-05T18:20:00Z -->
<!-- PR: #425 -->
<!-- Previous commits: 3f0b110 -->

## Summary

Adds `persistent` flag support and explicit deregistration mechanisms to the filter daemon (`index.mjs`). Previously every registered interest was implicitly persistent — it would keep firing on every matching event until the daemon restarted. This change gives callers control: `persistent: true` retains the old continuous-monitoring behavior, while `persistent: false` (the new default) auto-deregisters after the first wake. Two implicit deregistration paths are also added: explicit `filter.deregister` events (already worked), and automatic cleanup when `orchestrator-completed` or `orchestrator-failed` appears in the log.

## Changes Made

### `plugins/dev/scripts/filter-daemon/index.mjs`

- **`handleRegister`** — stores `persistent: d.persistent === true` in the interest entry (defaults `false` if omitted)
- **`classifyBatch`** — after emitting a `filter.wake.*` event, checks `reg.persistent`; if `false`, removes the interest from the in-memory table immediately (one-shot behavior)
- **New export `handleOrchestratorTerminated`** — iterates the interest table and removes all entries whose `orchestrator` field matches the terminated orchestrator ID; called from `processEvent` on `orchestrator-completed` / `orchestrator-failed`, and also replayed during `loadExistingRegistrations` on daemon restart
- **`shouldSkipEvent`** — expanded from `filter.wake.*` to `filter.*` so no current or future `filter.*` variant can reach Groq
- **`processEvent`** — invokes `handleOrchestratorTerminated` on termination events before queuing them for Groq (other orchestrators watching for the event still receive it)
- **`loadExistingRegistrations`** — also replays `orchestrator-completed`/`orchestrator-failed` events during the 1000-line recovery scan so state is correct after daemon restart

### `plugins/dev/scripts/filter-daemon/index.test.mjs`

- Imports `handleOrchestratorTerminated`
- 6 new tests for `persistent` flag storage (default false, explicit true, explicit false)
- 4 new tests for `handleOrchestratorTerminated` (multi-interest removal, cross-orchestrator isolation, no-op on mismatch, no-op on missing orchestrator field)
- `shouldSkipEvent` tests updated: removed "does not skip filter.register/deregister" tests (they now return `true`), replaced with single "skips all filter.* events" test
- **25 tests, all pass** (up from 19)

### `plugins/dev/skills/catalyst-filter/SKILL.md`

- Registration event schema table: added `detail.persistent` row with type, description, and default
- New "Choosing `persistent`" guidance block with concrete use-case examples
- "Step 4 — Deregister" section rewritten to cover all three deregistration triggers (one-shot auto, orchestrator termination, explicit) with updated code examples
- Registration example updated to include `persistent: true` (matching the persistent-monitoring use case it demonstrates)

## Acceptance Criteria

- [x] `persistent: true` interest keeps routing after each match
- [x] `persistent: false` (default) auto-deregisters after first wake
- [x] `filter.deregister` removes the interest (was already implemented, still works)
- [x] `orchestrator-completed`/`orchestrator-failed` auto-deregisters matching interest
- [x] No infinite loop: `filter.*` events never enter the Groq path

## How to Verify It

- [x] **Tests pass**: `bun test plugins/dev/scripts/filter-daemon/index.test.mjs` → 25 pass ✅
- [ ] **One-shot behavior**: register with `persistent: false`, emit a matching event → wake fires once, interest removed; second matching event → no wake
- [ ] **Persistent behavior**: register with `persistent: true`, emit two matching events → wake fires twice, interest remains
- [ ] **Orchestrator termination**: register interest, emit `orchestrator-completed` for same orchestrator → interest removed, no further wakes
- [ ] **Recovery after restart**: register → emit `orchestrator-completed` → restart daemon → interest is not in recovered table

## Related Issues

Refs: [CTL-262](https://linear.app/coalesce-labs/issue/CTL-262)