### PR TITLE
fix(dev): restore symlink-following SCRIPT_DIR resolution in catalyst-filter (CTL-267)

### DIFF
--- a/plugins/dev/scripts/catalyst-filter
+++ b/plugins/dev/scripts/catalyst-filter
@@ -14,7 +14,10 @@ set -uo pipefail
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 PID_FILE="${FILTER_PID_FILE:-$CATALYST_DIR/filter.pid}"
 LOG_FILE="${FILTER_LOG_FILE:-$CATALYST_DIR/filter.log}"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
+SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+unset _SRC
 DAEMON_SCRIPT="${FILTER_DAEMON_SCRIPT:-$SCRIPT_DIR/filter-daemon/index.mjs}"
 
 is_alive() { kill -0 "$1" 2>/dev/null; }


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-05T22:29:00Z -->
<!-- Last updated: 2026-05-05T22:29:00Z -->
<!-- PR: #432 -->
<!-- Previous commits: 8a3f268 -->

## Summary

Fixes a symlink resolution regression in `catalyst-filter` introduced by the CTL-256 rewrite. When `catalyst-filter` is installed as a symlink (the normal install path via `~/.local/bin/`), `BASH_SOURCE[0]` resolves to the symlink rather than the script's real location, causing `DAEMON_SCRIPT` to point at a non-existent path and preventing the daemon from starting.

## Changes Made

### `plugins/dev/scripts/catalyst-filter`

Replaces the simplified `SCRIPT_DIR` assignment:
```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
```

With the symlink-following loop that correctly resolves through any chain of symlinks to the actual script location:
```bash
_SRC="${BASH_SOURCE[0]}"
while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
unset _SRC
```

## Root Cause

The CTL-256 orchestrator replaced the original PM branch's symlink-aware resolution with the simpler `dirname "${BASH_SOURCE[0]}"` form. While simpler, this form only works when the script is executed directly from its real location — not via a symlink, which is the standard install path (`~/.local/bin/catalyst-filter → ~/.local/share/catalyst/cache/.../catalyst-filter`).

## How to Verify

1. Install `catalyst-filter` via symlink: `ln -sf /path/to/cache/catalyst-filter ~/.local/bin/catalyst-filter`
2. Run `catalyst-filter status` — should not error with `filter-daemon/index.mjs: No such file or directory`
3. `SCRIPT_DIR` should resolve to the cache directory, not `~/.local/bin/`

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-267