### PR TITLE
fix(dev): add wait-for-github and catalyst-filter to CLAUDE_SNIPPET.md (CTL-268)

### DIFF
--- a/plugins/dev/templates/CLAUDE_SNIPPET.md
+++ b/plugins/dev/templates/CLAUDE_SNIPPET.md
@@ -25,12 +25,18 @@ This project uses [Catalyst](https://github.com/coalesce-labs/catalyst) for AI-a
 /create-pr            # Create PR with Linear integration
 /describe-pr          # Generate/update PR description
 /merge-pr             # Merge with verification
+/wait-for-github      # Event-driven CI/PR wait — NEVER poll gh pr view/checks directly
 ```
 
 **CI Commands (non-interactive, for automation):**
 ```
 /ci-commit            # Autonomous commit (no prompts)
 /ci-describe-pr       # Autonomous PR description
+```
+
+**Orchestration:**
+```
+/catalyst-filter      # Register semantic event interests (orchestrators only)
 ```
 
 ### Agent Teams
@@ -68,3 +74,4 @@ This project uses the thoughts system for persistent context:
 - PR descriptions → `thoughts/shared/prs/`
 
 **IMPORTANT**: NEVER write to `thoughts/searchable/` — it's a read-only search index.
+


### PR DESCRIPTION
## Summary

- Adds `/wait-for-github` to the Git & PR Lifecycle section in `CLAUDE_SNIPPET.md` with a note that polling `gh pr view/checks` directly is forbidden
- Adds a new **Orchestration** section listing `/catalyst-filter` for orchestrators

## Why

Workers that don't see these skills upfront fall back to scripting `gh api` polling loops (burning GraphQL quota) or miss `catalyst-filter` entirely. Evidence: an Adva worker on ADV-671 said "I wasn't aware of a /wait-for-github skill. I was reaching for gh api polling loops because that's what I know how to do directly." The Adva project CLAUDE.md was patched manually as a hotfix (already has `wait-for-github`); this PR adds `catalyst-filter` to that project's CLAUDE.md as well.

Closes CTL-268.

## Test plan

- [ ] Verify `plugins/dev/templates/CLAUDE_SNIPPET.md` has `/wait-for-github` in Git & PR Lifecycle section with anti-polling note
- [ ] Verify `plugins/dev/templates/CLAUDE_SNIPPET.md` has new Orchestration section with `/catalyst-filter`
- [ ] Review that no other files were unintentionally modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)