### PR TITLE
fix(dev): replace --since with --since-line and add prNumbers fallback in event diagnostics

### DIFF
--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -77,14 +77,16 @@ else
   STALLED=false
   FILTER_MISMATCH=false
 
-  HEARTBEATS=$(catalyst-events tail --since "5 minutes ago" 2>/dev/null \
+  _LOG_FILE=~/catalyst/events/$(date -u +%Y-%m).jsonl
+  _LOG_LINES=$(wc -l < "$_LOG_FILE" 2>/dev/null | tr -d ' ')
+  _SINCE_LINE=$(( ${_LOG_LINES:-0} > 500 ? ${_LOG_LINES:-0} - 500 : 0 ))
+  HEARTBEATS=$(catalyst-events tail --since-line "$_SINCE_LINE" 2>/dev/null \
     | jq -c 'select(.event == "heartbeat")' | wc -l | tr -d ' ')
   [ "${HEARTBEATS:-0}" -eq 0 ] && { echo "WARN: No heartbeats — event log may be stalled"; STALLED=true; }
 
-  RAW_HIT=$(catalyst-events tail --since "15 minutes ago" 2>/dev/null | jq -c \
+  RAW_HIT=$(catalyst-events tail --since-line "$_SINCE_LINE" 2>/dev/null | jq -c \
     --argjson pr "$PR_NUMBER" \
-    'select((.scope.pr == $pr) or (.detail.number == $pr) or
-            (.detail.pull_request.number == $pr) or (tostring | contains($pr | tostring)))' | head -1)
+    'select((.scope.pr == $pr) or (.detail.prNumbers // [] | contains([$pr])))' | head -1)
   if [ -n "$RAW_HIT" ]; then
     echo "WARN: Event arrived but filter did not match. Raw event:"; echo "$RAW_HIT" | jq .
     FILTER_MISMATCH=true

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -609,7 +609,7 @@ while [ "$PR_DONE" = "false" ]; do
   # detail.prNumbers, not scope.pr. PR/review events DO populate scope.pr.
   if [ "$USE_REST" != "true" ]; then
     EVENT=$(catalyst-events wait-for \
-      --filter "(.scope.pr == ${PR_NUMBER}) and (
+      --filter "(.scope.pr == ${PR_NUMBER} or (.detail.prNumbers // [] | contains([${PR_NUMBER}]))) and (
         .event == \"github.pr.merged\" or
         .event == \"github.check_suite.completed\" or
         (.event | startswith(\"github.pull_request_review\")) or
@@ -619,7 +619,10 @@ while [ "$PR_DONE" = "false" ]; do
 
     if [ -z "$EVENT" ]; then
       # Phase 1 timed out — run diagnostics (see [[wait-for-github]] diagnostic block)
-      HEARTBEATS=$(catalyst-events tail --since "5 minutes ago" 2>/dev/null \
+      _LOG_FILE=~/catalyst/events/$(date -u +%Y-%m).jsonl
+      _LOG_LINES=$(wc -l < "$_LOG_FILE" 2>/dev/null | tr -d ' ')
+      _SINCE_LINE=$(( ${_LOG_LINES:-0} > 500 ? ${_LOG_LINES:-0} - 500 : 0 ))
+      HEARTBEATS=$(catalyst-events tail --since-line "$_SINCE_LINE" 2>/dev/null \
         | jq -c 'select(.event == "heartbeat")' | wc -l | tr -d ' ')
       TUNNEL_NOW=$(catalyst-monitor status --json 2>/dev/null \
         | jq -r '.webhookTunnel.state // "unknown"')
@@ -629,7 +632,7 @@ while [ "$PR_DONE" = "false" ]; do
       else
         # Infrastructure healthy — extend to Phase 2 (7200s)
         EVENT=$(catalyst-events wait-for \
-          --filter "(.scope.pr == ${PR_NUMBER}) and (
+          --filter "(.scope.pr == ${PR_NUMBER} or (.detail.prNumbers // [] | contains([${PR_NUMBER}]))) and (
             .event == \"github.pr.merged\" or
             .event == \"github.check_suite.completed\" or
             (.event | startswith(\"github.pull_request_review\")) or

--- a/plugins/dev/skills/wait-for-github/SKILL.md
+++ b/plugins/dev/skills/wait-for-github/SKILL.md
@@ -65,7 +65,10 @@ if [ "$USE_REST" != "true" ]; then
     FILTER_MISMATCH=false
 
     # Diagnostic 1: heartbeat check
-    HEARTBEATS=$(catalyst-events tail --since "5 minutes ago" 2>/dev/null \
+    _LOG_FILE=~/catalyst/events/$(date -u +%Y-%m).jsonl
+    _LOG_LINES=$(wc -l < "$_LOG_FILE" 2>/dev/null | tr -d ' ')
+    _SINCE_LINE=$(( ${_LOG_LINES:-0} > 500 ? ${_LOG_LINES:-0} - 500 : 0 ))
+    HEARTBEATS=$(catalyst-events tail --since-line "$_SINCE_LINE" 2>/dev/null \
       | jq -c 'select(.event == "heartbeat")' | wc -l | tr -d ' ')
     if [ "${HEARTBEATS:-0}" -eq 0 ]; then
       echo "WARN: No heartbeats in the last 5 min — event log may be stalled"
@@ -74,13 +77,11 @@ if [ "$USE_REST" != "true" ]; then
 
     # Diagnostic 2: raw event search without the filter
     # Look for the PR by multiple fields to detect filter mismatches
-    RAW_HIT=$(catalyst-events tail --since "15 minutes ago" 2>/dev/null | jq -c \
+    RAW_HIT=$(catalyst-events tail --since-line "$_SINCE_LINE" 2>/dev/null | jq -c \
       --argjson pr "$PR_NUMBER" \
       'select(
         (.scope.pr == $pr) or
-        (.detail.number == $pr) or
-        (.detail.pull_request.number == $pr) or
-        (tostring | contains($pr | tostring))
+        (.detail.prNumbers // [] | contains([$pr]))
       )' | head -1)
 
     if [ -n "$RAW_HIT" ]; then


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-06T02:30:00Z -->
<!-- Last updated: 2026-05-06T02:30:00Z -->
<!-- PR: #437 -->
<!-- Previous commits: d5ab37be76cf006b943253c74099dadcaa90fc9b -->

## Summary

- Replaces invalid `catalyst-events tail --since "5 minutes ago"` with a `--since-line` calculation in all 5 diagnostic locations across 3 skill files — the `--since` flag does not exist, silently returns zero output, and was causing every worker to unconditionally fall back to REST polling
- Fixes the Phase 1 and Phase 2 event wait filters in `oneshot` to match `github.check_suite.completed` events by adding a `.detail.prNumbers` fallback — these events never populate `.scope.pr`, so the old filter never matched CI completion signals
- Fixes the raw-hit diagnostic in `wait-for-github` and `monitor-events` to use `.detail.prNumbers` instead of the non-existent `.detail.number` / `.detail.pull_request.number` fields

## Why

Two compounding bugs caused the event-driven CI wait path to never work for any worker:

1. **Bug 1 (silent `--since` flag):** `catalyst-events tail` only supports `--since-line <N>` (a line number). Passing `--since "5 minutes ago"` silently ignores the flag and starts at EOF, returning zero lines. The diagnostic checkpoint then always concluded "0 heartbeats, no events" and set `DIAG_FAILED=true`, triggering REST fallback even when the webhook tunnel was perfectly healthy.

2. **Bug 2 (wrong PR field):** `github.check_suite.completed` events don't populate `.scope.pr` — the PR number lives in `detail.prNumbers` as an integer array. The wait filter `(.scope.pr == PR_NUMBER)` never matched these events, so workers waiting for CI completion via event-driven path never received the signal.

Both bugs compound: Bug 1 prevented the diagnostic from ever reporting healthy infrastructure, and Bug 2 meant even a correct fallback decision would miss CI events. Every worker was REST-polling regardless of tunnel state.

## Changes

**`plugins/dev/skills/oneshot/SKILL.md`**

- Phase 1 and Phase 2 `catalyst-events wait-for` filters: added `(.detail.prNumbers // [] | contains([${PR_NUMBER}]))` as OR fallback to `.scope.pr == ${PR_NUMBER}` so `check_suite.completed` events are matched
- Diagnostic heartbeat check: replaced `--since "5 minutes ago"` with `--since-line` computed from `wc -l` on the current monthly log file (last 500 lines)

**`plugins/dev/skills/wait-for-github/SKILL.md`**

- Diagnostic 1 (heartbeat check): replaced `--since "5 minutes ago"` with `--since-line "$_SINCE_LINE"` using shared line calculation
- Diagnostic 2 (raw hit check): replaced `--since "15 minutes ago"` with `--since-line "$_SINCE_LINE"` and replaced `.detail.number` / `.detail.pull_request.number` with `.detail.prNumbers // [] | contains([$pr])`
- `_SINCE_LINE` is calculated once from the log file and reused for both diagnostic reads

**`plugins/dev/skills/monitor-events/SKILL.md`**

- Same heartbeat and raw-hit diagnostic fixes as `wait-for-github`

## How to verify

- [x] No `--since "` string remains in the 3 skill files — all replaced with `--since-line`
- [x] Both Phase 1 and Phase 2 wait filters in `oneshot` include `(.detail.prNumbers // [] | contains([${PR_NUMBER}]))`
- [x] Raw-hit diagnostics in `wait-for-github` and `monitor-events` use `.detail.prNumbers`
- [ ] Worker with tunnel connected uses event-driven path after fix (behavioral verification — requires live tunnel)

## Related

Closes CTL-265
