### PR TITLE
fix(dev): post-checkout hook fires false positive during git worktree add (CTL-264)

### DIFF
--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Warn loudly when leaving 'main' in this clone.
+#
+# This clone has historically been the local marketplace source for the
+# installed catalyst plugin. Branch work here used to silently freeze the
+# installed plugin at this branch's HEAD (the "local marketplace trap").
+# The marketplace has since been migrated to a GitHub source, but the
+# convention still holds: do branch work in worktrees, not in this clone.
+#
+# git arg contract: $1=prev_head $2=new_head $3=branch_change (1|0)
+
+prev_head="$1"
+new_head="$2"
+branch_change="$3"
+
+[ "$branch_change" = "1" ] || exit 0
+
+# Don't warn when hook fires inside a git worktree (e.g. during 'git worktree add').
+# In a linked worktree --git-dir returns a worktree-specific path; in the main clone they match.
+git_dir="$(git rev-parse --git-dir 2>/dev/null || echo '')"
+git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || echo '')"
+[ "$git_dir" != "$git_common_dir" ] && exit 0
+
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+[ "$current_branch" = "main" ] && exit 0
+[ -z "$current_branch" ] && exit 0
+
+if [ -t 2 ]; then
+  red=$'\033[1;31m'
+  yellow=$'\033[1;33m'
+  reset=$'\033[0m'
+else
+  red=""
+  yellow=""
+  reset=""
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "?")"
+project_key="$(jq -r '.catalyst.projectKey // empty' "${repo_root}/.catalyst/config.json" 2>/dev/null || echo "")"
+if [ -n "$project_key" ]; then
+  worktree_base="$HOME/catalyst/wt/${project_key}"
+else
+  worktree_base="$(dirname "$repo_root")"
+fi
+worktree_path="${worktree_base}/${current_branch//\//-}"
+
+cat >&2 <<EOF
+
+${red}╔════════════════════════════════════════════════════════════════════╗
+║  WARNING — left 'main' in the catalyst marketplace source clone    ║
+╚════════════════════════════════════════════════════════════════════╝${reset}
+
+You are now on '${yellow}${current_branch}${reset}' in:
+  ${repo_root}
+
+${yellow}Convention:${reset} this clone stays on 'main'. Do branch work in worktrees.
+
+To recover:
+  ${yellow}git switch main${reset}
+  ${yellow}git worktree add ${worktree_path} ${current_branch}${reset}
+  ${yellow}cd ${worktree_path}${reset}
+
+EOF
+
+exit 0

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -60,3 +60,14 @@ if [[ -x "$HOME/.claude/scripts/trust-workspace.sh" ]]; then
 	echo "Running: ~/.claude/scripts/trust-workspace.sh \"${REPO_ROOT}\""
 	"$HOME/.claude/scripts/trust-workspace.sh" "${REPO_ROOT}"
 fi
+
+HOOKS_SRC="${SCRIPT_DIR}/hooks"
+HOOKS_DST="${REPO_ROOT}/.git/hooks"
+if [[ -d "$HOOKS_SRC" && -d "$HOOKS_DST" ]]; then
+	echo "Installing git hooks from scripts/hooks/"
+	for hook_file in "$HOOKS_SRC"/*; do
+		hook_name="$(basename "$hook_file")"
+		install -m 755 "$hook_file" "${HOOKS_DST}/${hook_name}"
+		echo "  Installed: $hook_name"
+	done
+fi


### PR DESCRIPTION
## Summary

- **Primary fix**: Add worktree detection guard to `post-checkout` hook — exits silently when `--git-dir != --git-common-dir`, which is the case whenever git fires the hook inside a linked worktree (e.g. during `git worktree add`). This eliminates the scary WARNING box that appeared in every orchestrator Warp tab launch.
- **Secondary fix**: Fix the suggested `git worktree add` path in the warning — reads `projectKey` from `.catalyst/config.json` to compute `~/catalyst/wt/<project>/<branch>` instead of the incorrect `<repo-parent>/catalyst-<branch>` path.
- **Source control**: Move hook source into `scripts/hooks/post-checkout` so it's tracked in git. Update `setup-workspace.sh` to install/update hooks from this directory on each run.

## Apply immediately

```bash
bash scripts/setup-workspace.sh
```

Fixes CTL-264

🤖 Generated with [Claude Code](https://claude.com/claude-code)