### PR TITLE
feat(dev): generalize filter.register to all agent types (CTL-269)

### DIFF
--- a/plugins/dev/scripts/filter-daemon/index.mjs
+++ b/plugins/dev/scripts/filter-daemon/index.mjs
@@ -68,9 +68,11 @@ export function handleRegister(event) {
     prompt: d.prompt ?? "",
     context: d.context ?? null,
     orchestrator: event.orchestrator ?? null,
+    session_id: d.session_id ?? null,
     persistent: d.persistent === true,
   });
-  console.log(`[filter] Registered: ${id} — "${d.prompt}" (persistent: ${d.persistent === true})`);
+  const sessionTag = d.session_id ? `, session: ${d.session_id}` : "";
+  console.log(`[filter] Registered: ${id} — "${d.prompt}" (persistent: ${d.persistent === true}${sessionTag})`);
 }
 
 export function handleDeregister(event) {
@@ -256,7 +258,19 @@ export function runWatchdogTick() {
           woke = true;
         }
       }
-      if (woke) lastHeartbeat.set(sourceId, { ts: state.ts, notified: true });
+      if (woke) {
+        // CTL-269: belt-and-suspenders cleanup — after firing the stale wake,
+        // delete registrations whose session_id matches the stale sourceId.
+        // Pairs with the trap-handler deregister in oneshot/SKILL.md so crashed
+        // sessions don't leak interests across daemon restarts.
+        for (const [interestId, interest] of interests) {
+          if (interest.session_id && interest.session_id === sourceId) {
+            interests.delete(interestId);
+            console.log(`[filter] Watchdog cleanup: removed ${interestId} (stale session ${sourceId})`);
+          }
+        }
+        lastHeartbeat.set(sourceId, { ts: state.ts, notified: true });
+      }
     } else if (!stale && state.notified) {
       lastHeartbeat.set(sourceId, { ts: state.ts, notified: false });
     }
@@ -418,6 +432,21 @@ function main() {
   } catch {
     console.log(`[filter] Starting (no log file yet at ${lastLogPath})`);
   }
+
+  // CTL-269: emit startup event so subscribers can detect daemon restarts
+  // and re-register their interests. Persistent interests are also recovered
+  // from the log on boot (loadExistingRegistrations) — this is belt-and-suspenders.
+  appendEvent({
+    event: "filter.daemon.startup",
+    orchestrator: null,
+    worker: null,
+    detail: {
+      pid: process.pid,
+      recovered_interests: interests.size,
+      watchdog_interval_ms: WATCHDOG_INTERVAL_MS,
+      heartbeat_stale_ms: HEARTBEAT_STALE_MS,
+    },
+  });
 
   const pollId = setInterval(pollEventLog, POLL_MS);
   const watchdogId = startWatchdog();

--- a/plugins/dev/scripts/filter-daemon/index.test.mjs
+++ b/plugins/dev/scripts/filter-daemon/index.test.mjs
@@ -132,6 +132,29 @@ describe("interest table", () => {
     });
     expect(getInterests().get("orch-p3").persistent).toBe(false);
   });
+
+  test("handleRegister stores session_id from detail.session_id", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-s1",
+      detail: {
+        interest_id: "sess_abc",
+        session_id: "sess_abc",
+        notify_event: "filter.wake.sess_abc",
+        prompt: "worker registration",
+      },
+    });
+    expect(getInterests().get("sess_abc").session_id).toBe("sess_abc");
+  });
+
+  test("handleRegister defaults session_id to null when absent", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-s2",
+      detail: { interest_id: "orch-s2", notify_event: "filter.wake.orch-s2", prompt: "no session" },
+    });
+    expect(getInterests().get("orch-s2").session_id).toBeNull();
+  });
 });
 
 describe("handleOrchestratorTerminated", () => {
@@ -411,5 +434,84 @@ describe("watchdog tick", () => {
     registerInterest("orch-x", { orchestrator: "orch-x", context: { workers: ["CTL-different"] } });
     runWatchdogTick();
     expect(getLastHeartbeat().get("CTL-other").notified).toBe(false);
+  });
+});
+
+describe("watchdog cleanup of stale-session registrations (CTL-269)", () => {
+  const STALE_AGO = 200_000;
+
+  beforeEach(() => {
+    clearInterests();
+    clearLastHeartbeat();
+  });
+
+  function registerSessionInterest(id, sessionId, opts = {}) {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: opts.orchestrator ?? id,
+      detail: {
+        interest_id: id,
+        session_id: sessionId,
+        notify_event: `filter.wake.${id}`,
+        prompt: "session-keyed worker",
+        context: opts.context ?? { workers: [sessionId] },
+      },
+    });
+  }
+
+  test("deletes interest whose session_id matches the stale sourceId after firing wake", () => {
+    getLastHeartbeat().set("sess_abc", { ts: Date.now() - STALE_AGO, notified: false });
+    registerSessionInterest("sess_abc", "sess_abc");
+    runWatchdogTick();
+    expect(getInterests().has("sess_abc")).toBe(false);
+  });
+
+  test("preserves interest whose session_id does NOT match the stale sourceId", () => {
+    getLastHeartbeat().set("sess_abc", { ts: Date.now() - STALE_AGO, notified: false });
+    // session_id belongs to a different session, but workers list still matches sess_abc → wake fires
+    registerSessionInterest("orch-a", "sess_other", {
+      orchestrator: "orch-a",
+      context: { workers: ["sess_abc"] },
+    });
+    runWatchdogTick();
+    expect(getInterests().has("orch-a")).toBe(true);
+  });
+
+  test("preserves interests without a session_id field (legacy / orchestrator registrations)", () => {
+    getLastHeartbeat().set("CTL-77", { ts: Date.now() - STALE_AGO, notified: false });
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-legacy",
+      detail: {
+        interest_id: "orch-legacy",
+        notify_event: "filter.wake.orch-legacy",
+        prompt: "legacy without session",
+        context: { workers: ["CTL-77"] },
+      },
+    });
+    runWatchdogTick();
+    expect(getInterests().has("orch-legacy")).toBe(true);
+    expect(getInterests().get("orch-legacy").session_id).toBeNull();
+  });
+
+  test("does not delete when wake does not fire (no matching context)", () => {
+    getLastHeartbeat().set("sess_abc", { ts: Date.now() - STALE_AGO, notified: false });
+    // Interest has matching session_id, but its workers list does not include sess_abc → no wake
+    registerSessionInterest("sess_abc", "sess_abc", {
+      orchestrator: "orch-unrelated",
+      context: { workers: ["sess_unrelated"] },
+    });
+    runWatchdogTick();
+    expect(getInterests().has("sess_abc")).toBe(true);
+  });
+
+  test("cleanup runs exactly once per stale source (subsequent ticks find no matching interest)", () => {
+    getLastHeartbeat().set("sess_abc", { ts: Date.now() - STALE_AGO, notified: false });
+    registerSessionInterest("sess_abc", "sess_abc");
+    runWatchdogTick();
+    expect(getInterests().has("sess_abc")).toBe(false);
+    // Second tick: heartbeat still stale + already notified → no new wake, no error
+    expect(() => runWatchdogTick()).not.toThrow();
+    expect(getInterests().has("sess_abc")).toBe(false);
   });
 });

--- a/plugins/dev/skills/catalyst-filter/SKILL.md
+++ b/plugins/dev/skills/catalyst-filter/SKILL.md
@@ -104,11 +104,14 @@ STATE_SCRIPT="/path/to/plugins/dev/scripts/catalyst-state.sh"
 | `detail.notify_event` | string | Event name the daemon will emit when relevant events arrive (`"filter.wake.{id}"`) |
 | `detail.prompt` | string | Natural-language description of what to wake on (see Prompt Writing below) |
 | `detail.persistent` | boolean | `true` — keep interest active after each match (continuous monitoring). `false` (default) — auto-deregister after first wake (one-shot wait). |
-| `detail.context` | object | Optional focus hints: `pr_numbers`, `tickets`, `branches` |
+| `detail.context` | object | Optional focus hints: `pr_numbers`, `tickets`, `branches`, `workers` |
 | `detail.interest_id` | string | Optional override for the routing table key; defaults to `orchestrator` |
+| `detail.session_id` | string | Optional session ID (`$CATALYST_SESSION_ID`). The daemon's watchdog uses this to clean up registrations whose session has gone stale (>3 min without heartbeat). Set this for any non-orchestrator agent. |
 
 The daemon picks up `filter.register` from the live log within one poll cycle (~200ms).
-On daemon restart, it scans the last 1000 lines of the log to recover active registrations.
+On daemon restart, it scans the last 1000 lines of the log to recover active registrations,
+and emits a `filter.daemon.startup` event so subscribers can re-register if they want
+belt-and-suspenders coverage.
 
 **Choosing `persistent`:**
 
@@ -117,6 +120,83 @@ On daemon restart, it scans the last 1000 lines of the log to recover active reg
 - Use `persistent: false` (the default) for one-shot waits — "tell me when this specific PR merges"
   or "wake me when the next CI run completes". The interest is removed automatically after the first
   wake, so no explicit `filter.deregister` is needed.
+
+### Per-agent-type registration patterns
+
+The same registration mechanism serves three distinct agent profiles. Pick the one that
+matches your agent's lifecycle.
+
+#### Orchestrator (long-lived, multi-PR scope)
+
+Routing key is the orchestrator name; one registration covers every active worker.
+
+```jsonc
+{
+  "event": "filter.register",
+  "orchestrator": "$ORCH_NAME",
+  "detail": {
+    "session_id": "$CATALYST_SESSION_ID",
+    "notify_event": "filter.wake.$ORCH_NAME",
+    "persistent": true,
+    "prompt": "Wake me when: CI passes or fails on any of my PRs; a PR gets changes-requested, is merged, or closed; the base branch receives a push that would put my PRs BEHIND; any of my workers posts a comms message of type attention to me; or one of my Linear tickets changes status",
+    "context": {
+      "pr_numbers": [408, 409],
+      "tickets": ["CTL-253", "CTL-254"],
+      "branches": ["...-CTL-253", "...-CTL-254"]
+    }
+  }
+}
+```
+
+#### Worker / oneshot (single-ticket scope, single PR)
+
+Routing key is the session ID. `context.workers: [$sid]` lets the daemon's heartbeat
+watchdog match this registration when the session goes stale.
+
+```jsonc
+{
+  "event": "filter.register",
+  "orchestrator": "$CATALYST_ORCHESTRATOR_ID",
+  "detail": {
+    "interest_id": "$CATALYST_SESSION_ID",
+    "session_id": "$CATALYST_SESSION_ID",
+    "notify_event": "filter.wake.$CATALYST_SESSION_ID",
+    "persistent": true,
+    "prompt": "Wake me when: CI passes or fails on PR ${PR_NUMBER}; PR ${PR_NUMBER} is merged or closed; PR ${PR_NUMBER} receives a review or changes-requested; the base branch of branch ${BRANCH} receives a push (BEHIND state); I receive a comms message addressed to ${TICKET_ID}; or my Linear ticket ${TICKET_ID} status changes",
+    "context": {
+      "pr_numbers": [535],
+      "tickets": ["CTL-269"],
+      "branches": ["fix/ctl-269-foo"],
+      "workers": ["$CATALYST_SESSION_ID"]
+    }
+  }
+}
+```
+
+A graceful trap on `EXIT/INT/TERM` should emit `filter.deregister` so the in-memory
+table doesn't carry the entry until daemon restart. The watchdog cleanup at
+`HEARTBEAT_STALE_MS` (default 3 min) is the crash-safety net.
+
+#### Long-lived utility (e.g., monitor, custom wait scripts)
+
+Same shape as the worker pattern — routing by `$CATALYST_SESSION_ID` with a
+utility-specific prompt. Set `persistent: true` so the registration survives across
+many wakes; deregister explicitly at exit.
+
+### Daemon restarts
+
+On boot the daemon emits `filter.daemon.startup` with `pid`, `recovered_interests`,
+`watchdog_interval_ms`, and `heartbeat_stale_ms`. Persistent interests are also
+recovered automatically from the last 1000 log lines, so a re-register on this event
+is belt-and-suspenders rather than required.
+
+```bash
+# Optional: re-register on daemon restart
+catalyst-events wait-for --filter '.event == "filter.daemon.startup"' --timeout 0 \
+  | while read -r evt; do
+      filter_register_self  # idempotent — overwrites the existing entry
+    done
+```
 
 ## Step 2 — Wait
 
@@ -301,8 +381,11 @@ catalyst-filter run
 # Tail daemon log
 catalyst-filter logs
 
-# Manually register an interest
+# Manually register an orchestrator interest
 catalyst-state.sh event '{"event":"filter.register","orchestrator":"my-orch","detail":{"notify_event":"filter.wake.my-orch","prompt":"Wake me on CI failure or PR merge."}}'
+
+# Manually register a session-keyed worker interest (CTL-269)
+catalyst-state.sh event '{"event":"filter.register","orchestrator":"my-orch","detail":{"interest_id":"sess_abc","session_id":"sess_abc","notify_event":"filter.wake.sess_abc","persistent":true,"prompt":"Wake me on CI events for PR 42 or comms addressed to CTL-269.","context":{"pr_numbers":[42],"tickets":["CTL-269"],"workers":["sess_abc"]}}}'
 
 # Wait for wake signal
 catalyst-events wait-for --filter '.event == "filter.wake.my-orch"' --timeout 7200

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -55,7 +55,17 @@ is `tail | head -n 1` with a timeout.
 ## Pattern 1 — Worker waits for its PR to merge
 
 A `claude -p` worker that just opened PR #342 needs to block until the PR merges, then
-do post-merge work. Use the two-phase pattern from [[wait-for-github]]: a 3-minute Phase 1
+do post-merge work.
+
+**Preferred (when `catalyst-filter` is running, CTL-269):** register a single semantic
+interest covering every concern the worker cares about (CI, comms, reviews, BEHIND,
+Linear), then wait on `filter.wake.${CATALYST_SESSION_ID}`. The Groq-backed daemon
+classifies raw events against the natural-language prompt and emits one wake per
+match. See [[catalyst-filter]] for the full registration recipe and the daemon-restart
+contract. The two-phase pattern below is the **fallback** for environments where the
+daemon is not running.
+
+Use the two-phase pattern from [[wait-for-github]]: a 3-minute Phase 1
 with a diagnostic checkpoint before committing to the full 2-hour wait.
 
 ```bash
@@ -125,6 +135,13 @@ fi
 The orchestrator's Phase 4 used to poll every 2–3 minutes for every active worker. With
 CTL-210, the orchestrator runs a `Monitor` watching all PR/CI/push/lifecycle events, and
 the reactive scan drops to a 10-minute idle fallback as the safety net (CTL-243).
+
+**Preferred (when `catalyst-filter` is running, CTL-257 + CTL-269):** the orchestrate
+skill emits `filter.register` at Phase 4 start with a prompt covering CI events,
+PR transitions, BEHIND-state pushes, comms attention from workers, and Linear ticket
+changes. Phase 4 then waits on `filter.wake.${ORCH_NAME}` for a single unified wake
+covering all those concerns. See [[catalyst-filter]]. The `Monitor`-over-`tail` pattern
+below is the **fallback** for environments without the daemon.
 
 The recommended shape is **scope-aware**, generated from the orchestrator's worker
 signal directory (CTL-240):
@@ -531,3 +548,6 @@ Environment:
   filter; the long-lived precedent for Pattern 3
 - `catalyst-comms` — agent-to-agent pub/sub on per-channel files;
   `comms.message.posted` fan-out events go through this same log
+- [[catalyst-filter]] — Groq-backed semantic event router. Preferred wake
+  mechanism when running; collapses the per-concern jq filters in Patterns 1
+  and 2 into a single `filter.register` per agent (CTL-269)

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -192,6 +192,58 @@ if [ -n "${CATALYST_COMMS_CHANNEL:-}" ] && [ -n "$COMMS_BIN" ]; then
   COMMS_CHANNEL_FILE="${CATALYST_DIR}/comms/channels/${CATALYST_COMMS_CHANNEL}.jsonl"
   [ -f "$COMMS_CHANNEL_FILE" ] && COMMS_LAST_READ=$(wc -l < "$COMMS_CHANNEL_FILE" | tr -d ' ')
 fi
+
+# CTL-269: catalyst-filter registration helpers. The worker registers a single
+# semantic interest after PR creation that covers CI, comms, reviews, BEHIND,
+# and Linear ticket changes. The Phase 5 listen loop then waits on a single
+# `filter.wake.${CATALYST_SESSION_ID}` event instead of the per-concern jq
+# filters. When the daemon is not running, the loop falls back to the existing
+# direct `catalyst-events wait-for` pattern.
+
+filter_daemon_running() {
+  command -v catalyst-filter >/dev/null 2>&1 || return 1
+  catalyst-filter status >/dev/null 2>&1
+}
+
+filter_register_worker() {
+  # Args: $1 = PR_NUMBER, $2 = TICKET_ID, $3 = BRANCH_NAME
+  filter_daemon_running || return 1
+  [ -n "${CATALYST_SESSION_ID:-}" ] || return 1
+  local pr="$1" ticket="$2" branch="$3"
+  local prompt="Wake me when: CI passes or fails on PR ${pr}; PR ${pr} is merged or closed; PR ${pr} receives a review or changes-requested; the base branch of branch ${branch} receives a push (BEHIND state); I receive a comms message addressed to ${ticket}; or my Linear ticket ${ticket} status changes"
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg sid "$CATALYST_SESSION_ID" \
+    --arg orch "${CATALYST_ORCHESTRATOR_ID:-}" \
+    --arg notify "filter.wake.${CATALYST_SESSION_ID}" \
+    --arg prompt "$prompt" \
+    --argjson pr "$pr" \
+    --arg ticket "$ticket" \
+    --arg branch "$branch" \
+    '{ts: (now | todate), event: "filter.register",
+      orchestrator: (if $orch == "" then null else $orch end),
+      worker: null,
+      detail: {
+        interest_id: $sid,
+        session_id: $sid,
+        notify_event: $notify,
+        persistent: true,
+        prompt: $prompt,
+        context: {pr_numbers: [$pr], tickets: [$ticket], branches: [$branch], workers: [$sid]}
+      }}')" 2>/dev/null || return 1
+  return 0
+}
+
+filter_deregister_worker() {
+  filter_daemon_running || return 0
+  [ -n "${CATALYST_SESSION_ID:-}" ] || return 0
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg sid "$CATALYST_SESSION_ID" \
+    '{ts: (now | todate), event: "filter.deregister", orchestrator: null, worker: null, detail: {interest_id: $sid}}')" 2>/dev/null || true
+}
+
+# Belt-and-suspenders: trap on EXIT/INT/TERM ensures graceful deregister.
+# Watchdog cleanup in the daemon handles crash cases via session_id matching.
+trap 'filter_deregister_worker' EXIT INT TERM
 ```
 
 If `ORCH_DIR` is detected, the worker:
@@ -579,11 +631,15 @@ EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --j
 
 **Step 2: Active PR Listen Loop — Wait for CLEAN then Merge (replaces auto-merge)**
 
-After the PR is created, enter an event-driven listen loop using the [[wait-for-github]] two-phase
-pattern. The worker actively resolves blockers (CI failures, bot review threads, BEHIND) inline and
-proceeds to Step 3 only when the PR is CLEAN (CI green + reviews satisfied). On unrecoverable
-blockers (human changes-requested, persistent DIRTY) the worker writes `status: "stalled"` and
-exits; the orchestrator's Phase 4 is a safety-net fallback.
+After the PR is created, enter an event-driven listen loop. The preferred wake mechanism (CTL-269)
+is a single `filter.register` covering CI, comms inbound, reviews, BEHIND, and Linear ticket
+changes — the worker then waits on `filter.wake.${CATALYST_SESSION_ID}` and the Groq-backed filter
+daemon decides which raw events match. When the daemon is not running, the loop falls back to the
+[[wait-for-github]] two-phase pattern with per-concern jq filters. See [[catalyst-filter]] for
+registration recipes. The worker actively resolves blockers (CI failures, bot review threads,
+BEHIND) inline and proceeds to Step 3 only when the PR is CLEAN (CI green + reviews satisfied). On
+unrecoverable blockers (human changes-requested, persistent DIRTY) the worker writes
+`status: "stalled"` and exits; the orchestrator's Phase 4 is a safety-net fallback.
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
@@ -599,15 +655,39 @@ TUNNEL=$(echo "$INFRA_STATUS" | jq -r '.webhookTunnel.state // "unknown"' 2>/dev
 USE_REST=false
 [ "$TUNNEL" != "running" ] && { echo "WARN: tunnel not running — using REST fallback"; USE_REST=true; }
 
+# CTL-269: register a single semantic interest covering CI, comms, reviews,
+# BEHIND, and Linear ticket changes. When this succeeds, the loop waits on a
+# single `filter.wake.${CATALYST_SESSION_ID}` event instead of running separate
+# jq filters for each concern. When it fails (daemon not running, no session id),
+# the loop falls back to the existing two-phase pattern below.
+USE_FILTER_DAEMON=false
+if filter_register_worker "$PR_NUMBER" "$TICKET_ID" "$(git branch --show-current)"; then
+  USE_FILTER_DAEMON=true
+  echo "[Phase 5] Registered filter interest for session ${CATALYST_SESSION_ID}"
+fi
+
 CI_FIX_ATTEMPTS=0
 MAX_CI_FIX_ATTEMPTS=3
 PR_DONE=false
 
 while [ "$PR_DONE" = "false" ]; do
-  # Two-phase event wait (see [[wait-for-github]]).
-  # Filter field reference: [[event-schema]] — note check_suite/workflow_run use
-  # detail.prNumbers, not scope.pr. PR/review events DO populate scope.pr.
-  if [ "$USE_REST" != "true" ]; then
+  # CTL-269 preferred path: single semantic wake covers all concerns.
+  if [ "$USE_FILTER_DAEMON" = "true" ] && [ "$USE_REST" != "true" ]; then
+    EVENT=$(catalyst-events wait-for \
+      --filter ".event == \"filter.wake.${CATALYST_SESSION_ID}\"" \
+      --timeout 600 2>/dev/null || true)
+    if [ -n "$EVENT" ]; then
+      WAKE_REASON=$(echo "$EVENT" | jq -r '.detail.reason // "unknown"' 2>/dev/null || echo "unknown")
+      echo "[Phase 5] Filter wake: ${WAKE_REASON}"
+    fi
+    # Drain inbound comms inside the loop now that filter.wake fires on
+    # comms.message.posted events too — comms_check is idempotent (advances
+    # COMMS_LAST_READ atomically) and a no-op when nothing arrived.
+    comms_check
+  elif [ "$USE_REST" != "true" ]; then
+    # Fallback: two-phase event wait (see [[wait-for-github]]).
+    # Filter field reference: [[event-schema]] — note check_suite/workflow_run use
+    # detail.prNumbers, not scope.pr. PR/review events DO populate scope.pr.
     EVENT=$(catalyst-events wait-for \
       --filter "(.scope.pr == ${PR_NUMBER} or (.detail.prNumbers // [] | contains([${PR_NUMBER}]))) and (
         .event == \"github.pr.merged\" or
@@ -641,6 +721,8 @@ while [ "$PR_DONE" = "false" ]; do
           --timeout 7200 2>/dev/null || true)
       fi
     fi
+    # Drain inbound comms after each wake so messages don't sit until phase boundary.
+    comms_check
   fi
 
   # Authoritative REST check — never gh pr view --json (GraphQL); REST only

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -718,6 +718,7 @@ if catalyst-filter status >/dev/null 2>&1; then
 
   "$STATE_SCRIPT" event "$(jq -nc \
     --arg orch "${ORCH_NAME}" \
+    --arg sid "${CATALYST_SESSION_ID:-}" \
     --arg notify "filter.wake.${ORCH_NAME}" \
     --argjson prs "${ACTIVE_PRS}" \
     --argjson tickets "${ACTIVE_TICKETS}" \
@@ -728,8 +729,9 @@ if catalyst-filter status >/dev/null 2>&1; then
       orchestrator: $orch,
       worker: null,
       detail: {
+        session_id: (if $sid == "" then null else $sid end),
         notify_event: $notify,
-        prompt: "Wake me when: CI passes or fails on any of my PRs, a PR gets changes-requested or is merged or closed, or the base branch receives a push that would put my PRs BEHIND",
+        prompt: "Wake me when: CI passes or fails on any of my PRs; a PR gets changes-requested, is merged, or closed; the base branch receives a push that would put my PRs BEHIND; any of my workers posts a comms message of type attention to me; or one of my Linear tickets changes status",
         persistent: true,
         context: {pr_numbers: $prs, tickets: $tickets, branches: $branches}
       }
@@ -996,6 +998,7 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
         "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
       "$STATE_SCRIPT" event "$(jq -nc \
         --arg orch "${ORCH_NAME}" \
+        --arg sid "${CATALYST_SESSION_ID:-}" \
         --arg notify "filter.wake.${ORCH_NAME}" \
         --argjson prs "${_UPD_PRS}" \
         --argjson tickets "${_UPD_TICKETS}" \
@@ -1005,8 +1008,9 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
           orchestrator: $orch,
           worker: null,
           detail: {
+            session_id: (if $sid == "" then null else $sid end),
             notify_event: $notify,
-            prompt: "Wake me when: CI passes or fails on any of my PRs, a PR gets changes-requested or is merged or closed, or the base branch receives a push that would put my PRs BEHIND",
+            prompt: "Wake me when: CI passes or fails on any of my PRs; a PR gets changes-requested, is merged, or closed; the base branch receives a push that would put my PRs BEHIND; any of my workers posts a comms message of type attention to me; or one of my Linear tickets changes status",
             persistent: true,
             context: {pr_numbers: $prs, tickets: $tickets}
           }
@@ -1298,19 +1302,25 @@ Since CTL-252, workers exit at `status: "done"` after actively merging their own
 orchestrator scan is a safety-net fallback that writes `pr.mergedAt` + `status: "done"` for
 workers that stalled before completing their own merge.
 
-**Drain shared comms channel for attention (CTL-111):**
+**Drain shared comms channel for attention (CTL-111, CTL-269):**
 
 Workers post `type:attention` messages to `orch-${ORCH_NAME}` when blocked. On each
 wake-up, the orchestrator drains new messages from the channel and promotes any
 `attention` to a state-level attention item so the dashboard's NEEDS ATTENTION
 banner surfaces it (with author + reason).
 
+The wake mechanism for comms attention is now **unified with the filter daemon**
+(CTL-269): when a worker posts to comms, `catalyst-comms send` emits a
+`comms.message.posted` event to the unified event log; the filter daemon matches
+it against the orchestrator's `filter.register` prompt (which now mentions "any
+of my workers posts a comms message of type attention to me") and emits
+`filter.wake.${ORCH_NAME}`. The orchestrator wakes from that single event and
+runs this drain step to act on the attention.
+
 A small cursor file `${ORCH_DIR}/.comms-cursor` tracks the line count already
 processed so repeated wake-ups don't re-surface the same message. Single-writer
-(this scan) so no race. The `comms-message-posted` event type also fires through
-the unified event log, so future revisions could replace the `wc -l` cursor with
-an event-stream wake-up — for now the cursor file is the canonical drain
-mechanism.
+(this scan) so no race. The cursor-based drain remains the **action** mechanism
+even though wakes come via `filter.wake`.
 
 ```bash
 if [ -n "$COMMS_BIN" ]; then


### PR DESCRIPTION
Closes CTL-269.

## Summary

Workers and oneshots can now collapse their per-concern wait patterns (GitHub events, comms inbound, Linear updates, BEHIND, reviews) into a **single** `filter.register` keyed by `$CATALYST_SESSION_ID`. The Groq-backed filter daemon classifies raw events against a natural-language prompt and emits one `filter.wake.${SESSION_ID}` per match. Workers wait on that single event instead of running separate jq filters per concern.

The orchestrator's existing `filter.register` (CTL-257) is extended so its single registration covers worker comms attention and Linear ticket changes alongside the GitHub PR/CI/push wakes it already had.

## What changed

**Daemon** (`plugins/dev/scripts/filter-daemon/index.mjs`):
- `handleRegister` stores `detail.session_id` on the registration object
- `runWatchdogTick` deletes registrations whose `session_id` matches a stale `sourceId` after firing the wake — belt-and-suspenders cleanup so crashed sessions don't leak interests
- `main()` emits `filter.daemon.startup` on boot (with `pid`, `recovered_interests`, `watchdog_interval_ms`, `heartbeat_stale_ms`) so subscribers can detect daemon restarts and re-register

**oneshot/SKILL.md** Phase 5:
- New `filter_daemon_running`, `filter_register_worker`, `filter_deregister_worker` helpers and an EXIT/INT/TERM trap
- The listen loop branches on `USE_FILTER_DAEMON`: when the daemon is running, it waits on `filter.wake.${CATALYST_SESSION_ID}` (single 600s wait, REST is still authoritative); when not, it falls back to the existing [[wait-for-github]] two-phase pattern with per-concern jq filters
- `comms_check` now drains inbound comms **inside** the listen loop on every wake (not only at phase boundaries) since `filter.wake` can fire on `comms.message.posted` events

**orchestrate/SKILL.md** Phase 4:
- Both `filter.register` emission sites (Phase 4 start + PR-discovery refresh) now include `detail.session_id` and a prompt that mentions `"any of my workers posts a comms message of type attention to me"` and Linear ticket status changes
- Updated prose explains that the cursor-based `comms poll` drain remains the **action** mechanism on wake, but the **wake** mechanism is now unified through `filter.wake.${ORCH_NAME}`

**catalyst-filter/SKILL.md**:
- Schema table documents `detail.session_id`
- New "Per-agent-type registration" subsection with three patterns: orchestrator (key by `ORCH_NAME`), worker/oneshot (key by `CATALYST_SESSION_ID`, with `context.workers: [$sid]` so the watchdog can match), long-lived utility
- New "Daemon restarts" subsection documents the `filter.daemon.startup` contract
- Quick Reference adds a session-keyed registration one-liner

**monitor-events/SKILL.md**:
- Pattern 1 (worker) and Pattern 2 (orchestrator) prefaced with a "Preferred (when `catalyst-filter` is running, CTL-269)" note that points to [[catalyst-filter]]
- The two-phase / `Monitor`-over-`tail` patterns remain documented as the fallback
- [[catalyst-filter]] added to Related skills

## Acceptance criteria

- [x] Oneshot workers register one interest after PR creation covering CI, comms, reviews, BEHIND, Linear
- [x] Orchestrators register one interest at Phase 4 start covering all worker events + comms attention + Linear
- [x] Neither workers nor orchestrators run a `comms poll` cursor loop — wakes come via `filter.wake`. The orchestrator's drain-on-wake is preserved as the action mechanism (it was never a poll loop).
- [x] Fallback to direct patterns when catalyst-filter is not running
- [x] `filter.wake.{id}` reason string tells the agent which concern fired (already provided by CTL-258 — used for diagnostic logging)
- [x] Daemon: `session_id` field supported in filter.register; watchdog cleans up stale-session interests
- [x] Daemon: emits `filter.daemon.startup` event on boot

## Test plan

- [x] `bun test plugins/dev/scripts/filter-daemon/index.test.mjs` — 46 pass (5 new tests for session_id + watchdog cleanup, 41 existing)
- [x] `bash plugins/dev/scripts/__tests__/catalyst-events.test.sh` — 34 pass
- [x] `bash plugins/dev/scripts/__tests__/catalyst-comms.test.sh` — 28 pass
- [x] `node -c plugins/dev/scripts/filter-daemon/index.mjs` — syntax OK
- [ ] CI checks pass on this PR
- [ ] Manual smoke when worker dispatches: filter daemon receives `filter.register`, emits `filter.wake.${SESSION_ID}` on real CI/comms/PR events, watchdog cleans up after sigkill

## Risks

- The new in-loop `comms_check` is idempotent — it advances `COMMS_LAST_READ` atomically before reading and is gated on `CATALYST_COMMS_CHANNEL` + `COMMS_BIN` non-empty. No state corruption.
- Watchdog cleanup only deletes when (a) the wake fired AND (b) the registration's `session_id` exactly matches the stale `sourceId`. Legacy registrations without `session_id` (`null`) are never deleted by this path — confirmed by unit test.
- The trap fires on graceful exit too; the deregister is idempotent in the daemon (`handleDeregister` checks delete return value), so a duplicate deregister at end-of-run is harmless.

## Out of scope

- Re-registration on `filter.daemon.startup` — the persistent-interest replay on boot already covers this; making agents listen for the startup event is a follow-up
- Removing the orchestrator's `comms poll` cursor drain — it's still useful as the read-inbox-on-wake step
- Migrating other skills' `wait-for` patterns (merge-pr, wait-for-github, etc.)