### PR TITLE
fix(dev): event filter bugs — Codex reviews silently dropped (CTL-270)

### DIFF
--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -235,7 +235,8 @@ while [ $ITER -lt $MAX_ITER ]; do
          and (.detail.conclusion == "failure" or .detail.conclusion == "timed_out")) or
       (.event == "github.pr_review.submitted"
          and .scope.pr == '"$pr_number"'
-         and .detail.state == "changes_requested") or
+         and (.detail.state == "changes_requested"
+              or (.detail.state == "commented" and (.detail.author.type // "") == "Bot"))) or
       (.event == "github.push" and .scope.ref == "refs/heads/'"$BASE_BRANCH"'")
     ' \
     --timeout 600 || true)
@@ -256,12 +257,15 @@ while [ $ITER -lt $MAX_ITER ]; do
       # CI failed — diagnose via merge-blocker-diagnosis.md, push fix.
       ;;
     github.pr_review.submitted)
-      # Changes requested. Bot reviewers are addressable inline; humans
-      # require operator action. detail.author.type is "Bot" or "User".
+      # Bot reviewers (Codex, claude-code-review) are addressable inline;
+      # humans require operator action. detail.author.type is "Bot" or "User".
+      # Codex submits inline-thread reviews as state="commented", not
+      # "changes_requested" — handle both via /catalyst-dev:review-comments,
+      # which addresses the code AND resolves threads via the GraphQL
+      # resolveReviewThread mutation.
       AUTHOR_TYPE=$(echo "$EVENT_JSON" | jq -r '.detail.author.type // "User"')
       if [ "$AUTHOR_TYPE" = "Bot" ]; then
-        # Run /catalyst-dev:review-comments to address inline.
-        :
+        /catalyst-dev:review-comments "$pr_number"
       fi
       ;;
     github.push)

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -254,7 +254,8 @@ while [ $ITER -lt $MAX_ITER ]; do
          and (.detail.conclusion == "failure" or .detail.conclusion == "timed_out")) or
       (.event == "github.pr_review.submitted"
          and .scope.pr == '"$PR_NUMBER"'
-         and .detail.state == "changes_requested") or
+         and (.detail.state == "changes_requested"
+              or (.detail.state == "commented" and (.detail.author.type // "") == "Bot"))) or
       (.event == "github.push" and .scope.ref == "refs/heads/'"$BASE_BRANCH"'")
     ' \
     --timeout 1800 || true)
@@ -272,7 +273,12 @@ while [ $ITER -lt $MAX_ITER ]; do
       # Pull failure logs, classify, fix, push. Then re-enter the loop.
       ;;
     github.pr_review.submitted)
-      # Bot vs human — handle differently. See heuristic below.
+      # Bot reviewers are addressable inline; humans require operator action.
+      # See "Bot vs human authorship" below for the routing heuristic.
+      AUTHOR_TYPE=$(echo "$EVENT_JSON" | jq -r '.detail.author.type // "User"')
+      if [ "$AUTHOR_TYPE" = "Bot" ]; then
+        /catalyst-dev:review-comments "$PR_NUMBER"
+      fi
       ;;
     github.push)
       gh pr update-branch "$PR_NUMBER" || true

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -692,7 +692,7 @@ while [ "$PR_DONE" = "false" ]; do
       --filter "(.scope.pr == ${PR_NUMBER} or (.detail.prNumbers // [] | contains([${PR_NUMBER}]))) and (
         .event == \"github.pr.merged\" or
         .event == \"github.check_suite.completed\" or
-        (.event | startswith(\"github.pull_request_review\")) or
+        (.event | startswith(\"github.pr_review\")) or
         .event == \"github.push\"
       )" \
       --timeout 180 2>/dev/null || true)
@@ -715,7 +715,7 @@ while [ "$PR_DONE" = "false" ]; do
           --filter "(.scope.pr == ${PR_NUMBER} or (.detail.prNumbers // [] | contains([${PR_NUMBER}]))) and (
             .event == \"github.pr.merged\" or
             .event == \"github.check_suite.completed\" or
-            (.event | startswith(\"github.pull_request_review\")) or
+            (.event | startswith(\"github.pr_review\")) or
             .event == \"github.push\"
           )" \
           --timeout 7200 2>/dev/null || true)

--- a/plugins/dev/skills/wait-for-github/SKILL.md
+++ b/plugins/dev/skills/wait-for-github/SKILL.md
@@ -186,7 +186,7 @@ catalyst-events wait-for \
 
 # Review submitted
 catalyst-events wait-for \
-  --filter "(.event | startswith(\"github.pull_request_review.\")) and .scope.pr == ${PR_NUMBER}" \
+  --filter "(.event | startswith(\"github.pr_review.\")) and .scope.pr == ${PR_NUMBER}" \
   --timeout 180
 
 # REST: check PR merge state (never in a tight loop)


### PR DESCRIPTION
## Summary

Three bugs in `catalyst-dev` event filters caused PR review events to be silently
ignored, leaving agents unable to self-heal merge blockers. Discovered by [audit][1]
of all `catalyst-events wait-for --filter` expressions against the live event log
(~95k events). Closes [CTL-270][2].

[1]: ../tree/CTL-270/thoughts/shared/research/2026-05-06-event-filter-audit.md
[2]: https://linear.app/coalesce-labs/issue/CTL-270

## Bugs fixed

**Bug 1 — `pr_review` filter excluded all bot reviews** (`merge-pr`, `monitor-events`)
- Filter required `state == "changes_requested"`, but Codex always submits
  inline-thread reviews as `state == "commented"`.
- Live event log: zero `"changes_requested"` occurrences, only `"commented"` from
  `chatgpt-codex-connector[bot]`.
- **Fix**: extend filter to also match bot `"commented"` reviews.

**Bug 2 — bot review handler was a no-op** (`merge-pr`, `monitor-events`)
- `merge-pr` handler body was a literal `:` (bash no-op) despite a comment
  saying to call `/catalyst-dev:review-comments`.
- `monitor-events` had a placeholder comment with no implementation.
- **Fix**: wire both to actually invoke `/catalyst-dev:review-comments`, which
  addresses code AND resolves threads via the GraphQL `resolveReviewThread`
  mutation.

**Bug 3 — wrong event prefix in review filter** (`oneshot`, `wait-for-github`)
- Filter used `startswith("github.pull_request_review")` but actual event names
  start with `"github.pr_review"`. The prefix never matched.
- **Fix**: change prefix to `startswith("github.pr_review")` (oneshot) and
  `startswith("github.pr_review.")` (wait-for-github reference).
- Note: `wait-for-github/SKILL.md:189` is not in the original ticket but has the
  same root cause (file did not exist when research was done). Folded in to
  prevent the bug from propagating from the canonical reference.

## Validation

`jq -e` against fixture events:
- Bot `commented` review → MATCHES (Bug 1 fixed)
- Human `commented` review → does NOT match (no false positives)
- `github.pr_review.submitted` → matches `startswith("github.pr_review")` (Bug 3 fixed)

## Out of scope

- `orchestrate` skill — uses semantic filter daemon, unaffected.
- `monitor-events/SKILL.md:479` cookbook entry — misleading documentation but
  not a runtime bug. Defer.

## Test plan

- [x] All bug patterns removed from source (grep verification)
- [x] jq syntax check on modified filter expressions with positive and negative fixtures
- [ ] Smoke test: next time a Codex review fires on a real PR, confirm `merge-pr` wakes and runs `/catalyst-dev:review-comments`