### PR TITLE
fix(dev): read groq.apiKey from config.json when GROQ_API_KEY env var is absent

### DIFF
--- a/plugins/dev/scripts/filter-daemon/index.mjs
+++ b/plugins/dev/scripts/filter-daemon/index.mjs
@@ -20,7 +20,18 @@ import { fileURLToPath } from "node:url";
 
 // --- Config ---
 const CATALYST_DIR = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
-const GROQ_API_KEY = process.env.GROQ_API_KEY ?? "";
+
+export function readGroqApiKeyFromConfig(configPath) {
+  const path = configPath ?? resolve(homedir(), ".config/catalyst/config.json");
+  try {
+    const cfg = JSON.parse(readFileSync(path, "utf8"));
+    return cfg?.groq?.apiKey ?? "";
+  } catch {
+    return "";
+  }
+}
+
+const GROQ_API_KEY = process.env.GROQ_API_KEY || readGroqApiKeyFromConfig();
 const GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions";
 const GROQ_MODEL = process.env.FILTER_GROQ_MODEL ?? "llama-3.1-8b-instant";
 const DEBOUNCE_MS = parseInt(process.env.FILTER_DEBOUNCE_MS ?? "100", 10);
@@ -488,7 +499,9 @@ function removePidFile() {
 // --- Main ---
 function main() {
   if (!GROQ_API_KEY) {
-    console.warn("[filter] WARN: GROQ_API_KEY not set — semantic filtering disabled until set");
+    console.warn(
+      "[filter] WARN: GROQ_API_KEY not set and groq.apiKey absent from ~/.config/catalyst/config.json — semantic filtering disabled"
+    );
   }
 
   writePidFile();

--- a/plugins/dev/scripts/filter-daemon/index.test.mjs
+++ b/plugins/dev/scripts/filter-daemon/index.test.mjs
@@ -2,9 +2,9 @@
 // Run: bun test plugins/dev/scripts/filter-daemon/index.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, unlinkSync } from "node:fs";
-import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { existsSync, unlinkSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { resolve, join } from "node:path";
 import {
   handleRegister,
   handleDeregister,
@@ -19,6 +19,7 @@ import {
   runWatchdogTick,
   saveInterests,
   loadPersistedInterests,
+  readGroqApiKeyFromConfig,
 } from "./index.mjs";
 
 describe("interest table", () => {
@@ -603,5 +604,42 @@ describe("interest persistence (saveInterests / loadPersistedInterests)", () => 
     clearInterests();
     loadPersistedInterests();
     expect(getInterests().has("orch-v1")).toBe(false);
+  });
+});
+
+describe("readGroqApiKeyFromConfig", () => {
+  const tmpDir = join(tmpdir(), "filter-daemon-test-" + process.pid);
+  const configPath = join(tmpDir, "config.json");
+
+  beforeEach(() => {
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  test("returns groq.apiKey from a valid config file", () => {
+    writeFileSync(configPath, JSON.stringify({ groq: { apiKey: "test-key-123" } }));
+    expect(readGroqApiKeyFromConfig(configPath)).toBe("test-key-123");
+    rmSync(configPath);
+  });
+
+  test("returns empty string when file does not exist", () => {
+    expect(readGroqApiKeyFromConfig(join(tmpDir, "nonexistent.json"))).toBe("");
+  });
+
+  test("returns empty string when config has no groq key", () => {
+    writeFileSync(configPath, JSON.stringify({ linear: { apiKey: "other" } }));
+    expect(readGroqApiKeyFromConfig(configPath)).toBe("");
+    rmSync(configPath);
+  });
+
+  test("returns empty string when groq.apiKey is null", () => {
+    writeFileSync(configPath, JSON.stringify({ groq: { apiKey: null } }));
+    expect(readGroqApiKeyFromConfig(configPath)).toBe("");
+    rmSync(configPath);
+  });
+
+  test("returns empty string on invalid JSON", () => {
+    writeFileSync(configPath, "not-valid-json{{{");
+    expect(readGroqApiKeyFromConfig(configPath)).toBe("");
+    rmSync(configPath);
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-06T22:15:00Z -->
<!-- Last updated: 2026-05-06T22:15:00Z -->
<!-- PR: #445 -->
<!-- Previous commits: f4245b6514c7db5e13c651f8f16b0bc74d9bb3fd -->

## Summary

The `catalyst-filter` daemon only read the Groq API key from the `GROQ_API_KEY` environment variable. The skill doc already promises users can configure this via Layer 2 config (`~/.config/catalyst/config.json`), but the daemon never read that file — making the config entry a no-op.

This is especially problematic because the daemon is launched via `nohup` in the background, inheriting the spawning shell's env. If that shell doesn't have `direnv` loaded for the catalyst directory (e.g. invoked from a different directory), `GROQ_API_KEY` is absent even when it's set in `.envrc`.

## Changes Made

### `plugins/dev/scripts/filter-daemon/index.mjs`

- Adds `readGroqApiKeyFromConfig(configPath?)` — reads `groq.apiKey` from `~/.config/catalyst/config.json` (or a custom path for testing). Falls back silently to `""` on any error (missing file, invalid JSON, null value).
- Changes `GROQ_API_KEY` initialization from `process.env.GROQ_API_KEY ?? ""` to `process.env.GROQ_API_KEY || readGroqApiKeyFromConfig()`, giving the env var priority.
- Updates the startup WARN message to name both sources, so users know where to set the key.
- Exports `readGroqApiKeyFromConfig` so unit tests can inject a temp file path without mocking `node:fs`.

### `plugins/dev/scripts/filter-daemon/index.test.mjs`

Adds 5 unit tests in a new `readGroqApiKeyFromConfig` suite:
- Returns `groq.apiKey` from a valid config file
- Returns `""` when the file does not exist
- Returns `""` when the config has no `groq` key
- Returns `""` when `groq.apiKey` is `null`
- Returns `""` on invalid JSON

## How to Verify It

- [x] Tests pass: `bun test plugins/dev/scripts/filter-daemon/index.test.mjs` → 51 pass, 0 fail ✅
- [x] CI checks pass (audit-references, validate, check-versions, Cloudflare Pages) ✅
- [ ] Manual: start the daemon without `GROQ_API_KEY` in env but with `groq.apiKey` in `~/.config/catalyst/config.json` — daemon should operate normally (no WARN logged)
- [ ] Manual: start the daemon with neither source set — WARN message should mention both the env var and the config file path

## Related Issues

- Fixes [CTL-271](https://linear.app/coalesce-labs/issue/CTL-271)