### PR TITLE
fix(dev): read Linear webhookId from cross-project Layer 2 (CTL-272)

### DIFF
--- a/plugins/dev/scripts/__tests__/check-project-setup.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tests for check-project-setup.sh — focuses on the CTL-253 webhook-pipeline checks
-# (smee binary, smeeChannel in cross-project Layer 2, Linear webhookId in per-project Layer 2).
+# (smee binary, smeeChannel + Linear webhookId both in cross-project Layer 2 — see CTL-272).
 # Run: bash plugins/dev/scripts/__tests__/check-project-setup.test.sh
 
 set -uo pipefail
@@ -84,13 +84,15 @@ test_smee_missing() {
   local proj="$SCRATCH/proj-smee" key="proj-smee"
   make_project "$proj" "$key"
   mkdir -p "$SCRATCH/xdg/catalyst"
-  # Configured smeeChannel + webhookId so only the smee binary check fires
+  # Configured smeeChannel + webhookId (both in cross-project Layer 2) so only the
+  # smee binary check fires
   cat > "$SCRATCH/xdg/catalyst/config.json" <<EOF
-{ "catalyst": { "monitor": { "github": { "smeeChannel": "https://smee.io/abc" } } } }
+{ "catalyst": { "monitor": {
+  "github": { "smeeChannel": "https://smee.io/abc" },
+  "linear": { "webhookId": "wh_test_123" }
+} } }
 EOF
-  cat > "$SCRATCH/xdg/catalyst/config-${key}.json" <<EOF
-{ "catalyst": { "monitor": { "linear": { "webhookId": "wh_test_123" } } } }
-EOF
+  echo '{}' > "$SCRATCH/xdg/catalyst/config-${key}.json"
 
   local out
   out=$(run_script "$proj" 2>&1)
@@ -107,11 +109,11 @@ test_smee_channel_missing() {
   local proj="$SCRATCH/proj-channel" key="proj-channel"
   make_project "$proj" "$key"
   mkdir -p "$SCRATCH/xdg/catalyst"
-  # Empty home config — no smeeChannel
-  echo '{}' > "$SCRATCH/xdg/catalyst/config.json"
-  cat > "$SCRATCH/xdg/catalyst/config-${key}.json" <<EOF
+  # Home config has linear webhookId but no smeeChannel (so we isolate the smeeChannel warn)
+  cat > "$SCRATCH/xdg/catalyst/config.json" <<EOF
 { "catalyst": { "monitor": { "linear": { "webhookId": "wh_test_123" } } } }
 EOF
+  echo '{}' > "$SCRATCH/xdg/catalyst/config-${key}.json"
 
   local out
   out=$(run_script "$proj" 2>&1)
@@ -134,14 +136,14 @@ test_home_config_missing() {
 
 # ─── Test: Linear webhookId missing → warn ──────────────────────────────────
 test_linear_webhook_missing() {
-  echo "test: Linear webhookId missing in per-project Layer 2 → warn"
+  echo "test: Linear webhookId missing in cross-project Layer 2 → warn"
   local proj="$SCRATCH/proj-linear" key="proj-linear"
   make_project "$proj" "$key"
   mkdir -p "$SCRATCH/xdg/catalyst"
+  # smeeChannel present, webhookId absent — only the Linear warn should fire
   cat > "$SCRATCH/xdg/catalyst/config.json" <<EOF
 { "catalyst": { "monitor": { "github": { "smeeChannel": "https://smee.io/abc" } } } }
 EOF
-  # Per-project secrets file exists but has no webhookId
   echo '{}' > "$SCRATCH/xdg/catalyst/config-${key}.json"
 
   local out
@@ -157,11 +159,12 @@ test_all_configured() {
   make_project "$proj" "$key"
   mkdir -p "$SCRATCH/xdg/catalyst"
   cat > "$SCRATCH/xdg/catalyst/config.json" <<EOF
-{ "catalyst": { "monitor": { "github": { "smeeChannel": "https://smee.io/abc" } } } }
+{ "catalyst": { "monitor": {
+  "github": { "smeeChannel": "https://smee.io/abc" },
+  "linear": { "webhookId": "wh_test_456" }
+} } }
 EOF
-  cat > "$SCRATCH/xdg/catalyst/config-${key}.json" <<EOF
-{ "catalyst": { "monitor": { "linear": { "webhookId": "wh_test_456" } } } }
-EOF
+  echo '{}' > "$SCRATCH/xdg/catalyst/config-${key}.json"
 
   local out
   out=$(run_script "$proj" 2>&1)

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -156,15 +156,14 @@ if [[ -n $CONFIG_PATH ]]; then
 		fi
 	fi
 
-	# Check Linear webhook registration (CTL-253) — gates whether Linear events reach the event log
-	if [[ -n $PROJECT_KEY ]]; then
-		SECRETS_FILE="$CATALYST_CONFIG/config-${PROJECT_KEY}.json"
-		if [[ -f $SECRETS_FILE ]]; then
-			LINEAR_WEBHOOK_ID=$(jq -r '.catalyst.monitor.linear.webhookId // empty' "$SECRETS_FILE" 2>/dev/null)
-			if [[ -z $LINEAR_WEBHOOK_ID ]]; then
-				warnings+=("Missing catalyst.monitor.linear.webhookId in $SECRETS_FILE — Linear events won't reach the event log")
-				warnings+=("  Register: bash plugins/dev/scripts/setup-webhooks.sh --linear-register")
-			fi
+	# Check Linear webhook registration (CTL-253) — gates whether Linear events reach the event log.
+	# The record lives in the cross-project Layer 2 file ($HOME_CONFIG_PATH); per-project secrets
+	# files (config-<projectKey>.json) hold the API token only. See setup-linear-webhook.sh.
+	if [[ -f $HOME_CONFIG_PATH ]]; then
+		LINEAR_WEBHOOK_ID=$(jq -r '.catalyst.monitor.linear.webhookId // empty' "$HOME_CONFIG_PATH" 2>/dev/null)
+		if [[ -z $LINEAR_WEBHOOK_ID ]]; then
+			warnings+=("Missing catalyst.monitor.linear.webhookId in $HOME_CONFIG_PATH — Linear events won't reach the event log")
+			warnings+=("  Register: bash plugins/dev/scripts/setup-webhooks.sh --linear-register")
 		fi
 	fi
 

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -274,8 +274,8 @@ else
     info "Run: bash plugins/dev/scripts/setup-webhooks.sh"
 fi
 
-if [[ -n "${PROJECT_KEY:-}" && -f "${SECRETS_FILE:-}" ]]; then
-    linear_webhook_id=$(jq -r '.catalyst.monitor.linear.webhookId // empty' "$SECRETS_FILE" 2>/dev/null)
+if [[ -f "$HOME_CONFIG_PATH" ]]; then
+    linear_webhook_id=$(jq -r '.catalyst.monitor.linear.webhookId // empty' "$HOME_CONFIG_PATH" 2>/dev/null)
     if [[ -n "$linear_webhook_id" ]]; then
         pass "Linear webhook registered (id: ${linear_webhook_id:0:8}…)"
     else


### PR DESCRIPTION
## Summary

Fixes [CTL-272](https://linear.app/coalesce-labs/issue/CTL-272). `setup-linear-webhook.sh` writes the Linear webhook record (`webhookId`, `webhookUrl`, `registeredAt`, `resourceTypes`) to the cross-project Layer 2 file `~/.config/catalyst/config.json` (consistent with where the GitHub `smeeChannel` lives). Two readers — `check-setup.sh:278` and `check-project-setup.sh:163` — were looking for it in the per-project secrets file `~/.config/catalyst/config-<projectKey>.json`, so they emitted `"Linear webhook not registered"` on every workflow command even after `setup-webhooks.sh --linear-register` succeeded.

## Changes

- `plugins/dev/scripts/check-project-setup.sh` — read `webhookId` from `$HOME_CONFIG_PATH` (the same variable already used by the smeeChannel check 60 lines above). Drop the unused `PROJECT_KEY` guard.
- `plugins/dev/scripts/check-setup.sh` — same fix; reuses the `$HOME_CONFIG_PATH` declared 13 lines above for the smeeChannel check.
- `plugins/dev/scripts/__tests__/check-project-setup.test.sh` — three test fixtures were writing `webhookId` to the per-project file to compensate for the bug, which masked the regression. They now write to `config.json` (the real location). Header comment corrected.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/check-project-setup.test.sh` — 12/12 pass
- [x] Manual repro from ticket — `webhookId` in `~/.config/catalyst/config.json` → `check-project-setup.sh` no longer warns; `check-setup.sh` reports `"Linear webhook registered (id: …)"`
- [x] Negative case — `webhookId` missing → both scripts emit the warning, pointing at the correct file path

## Out of scope

- Writer side (`setup-linear-webhook.sh`) is unchanged — already writes to the right place (`HOME_CONFIG_PATH`, line 163).
- Writer-side test (`setup-linear-webhook-layer2.test.sh`) is unchanged — already exercises the cross-project file correctly.