### PR TITLE
fix(dev): align Linear webhook URL key with consumers (CTL-274)

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh
@@ -3,10 +3,15 @@
 #
 # CTL-238 adds Layer 2 record persistence for Linear webhook registration:
 # after webhookCreate succeeds, the helper writes
-# catalyst.monitor.linear.{webhookId,webhookUrl,registeredAt,resourceTypes}
+# catalyst.monitor.linear.{webhookId,smeeChannel,registeredAt,resourceTypes}
 # to ~/.config/catalyst/config.json. Re-running with the same URL no-ops
 # based on the local record (no Linear API call). --linear-deregister
 # reads the local record to call webhookDelete and clears it.
+#
+# CTL-274 renamed the URL field from `webhookUrl` to `smeeChannel` so the
+# producer matches what every consumer reads. Records written by older
+# script versions (with `webhookUrl`) still round-trip via a read fallback
+# that migrates the field on first re-run.
 #
 # Test approach: stub `curl` with a script that:
 #   • routes by GraphQL query name (parses stdin JSON .query)
@@ -227,16 +232,19 @@ test_register_writes_layer2_record() {
   local rec; rec=$(read_layer2 "$env")
   [[ -n "$rec" ]] || { echo "Layer 2 record missing"; return 1; }
   local id; id=$(printf '%s' "$rec" | jq -r '.webhookId')
-  local url; url=$(printf '%s' "$rec" | jq -r '.webhookUrl')
+  local url; url=$(printf '%s' "$rec" | jq -r '.smeeChannel')
   local ts; ts=$(printf '%s' "$rec" | jq -r '.registeredAt')
   local rt; rt=$(printf '%s' "$rec" | jq -c '.resourceTypes')
   expect_eq "webhookId" "w1" "$id" || return 1
-  expect_eq "webhookUrl" "https://foo.test/api/webhook/linear" "$url" || return 1
+  expect_eq "smeeChannel" "https://foo.test/api/webhook/linear" "$url" || return 1
   # ISO-8601 UTC timestamp shape
   if ! [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
     echo "registeredAt malformed: $ts"; return 1
   fi
   expect_eq "resourceTypes" '["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]' "$rt" || return 1
+  # Legacy field must NOT be written by the new code path.
+  local has_legacy; has_legacy=$(printf '%s' "$rec" | jq 'has("webhookUrl")')
+  expect_eq "no legacy webhookUrl" "false" "$has_legacy" || return 1
 }
 
 # ─── Test 2 — idempotent re-run with same URL: no API call ─────────────────
@@ -249,7 +257,7 @@ test_idempotent_rerun_no_api_call() {
     "monitor": {
       "linear": {
         "webhookId": "w1",
-        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "smeeChannel": "https://foo.test/api/webhook/linear",
         "registeredAt": "2026-05-04T20:00:00Z",
         "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
       }
@@ -277,7 +285,7 @@ test_rerun_different_url_errors_without_force() {
     "monitor": {
       "linear": {
         "webhookId": "w1",
-        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "smeeChannel": "https://foo.test/api/webhook/linear",
         "registeredAt": "2026-05-04T20:00:00Z",
         "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
       }
@@ -308,7 +316,7 @@ test_force_overwrites_layer2_record() {
     "monitor": {
       "linear": {
         "webhookId": "w1",
-        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "smeeChannel": "https://foo.test/api/webhook/linear",
         "registeredAt": "2026-05-04T20:00:00Z",
         "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
       }
@@ -325,9 +333,9 @@ EOF
     >/dev/null 2>&1 || return 1
 
   local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
-  local url; url=$(read_layer2 "$env" | jq -r '.webhookUrl')
+  local url; url=$(read_layer2 "$env" | jq -r '.smeeChannel')
   expect_eq "webhookId now w2" "w2" "$id" || return 1
-  expect_eq "webhookUrl now bar" "https://bar.test/api/webhook/linear" "$url" || return 1
+  expect_eq "smeeChannel now bar" "https://bar.test/api/webhook/linear" "$url" || return 1
 
   # Exactly one delete + one create. NO list call (Layer 2 short-circuit avoids it).
   expect_eq "delete count" "1" "$(count_calls "$env" delete)" || return 1
@@ -344,7 +352,7 @@ test_deregister_uses_layer2_id() {
     "monitor": {
       "linear": {
         "webhookId": "w1",
-        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "smeeChannel": "https://foo.test/api/webhook/linear",
         "registeredAt": "2026-05-04T20:00:00Z",
         "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
       }
@@ -426,12 +434,113 @@ test_register_falls_back_to_api_dedup_when_layer2_missing() {
   # because we couldn't observe them from a list response.
   local rec; rec=$(read_layer2 "$env")
   local id; id=$(printf '%s' "$rec" | jq -r '.webhookId')
-  local url; url=$(printf '%s' "$rec" | jq -r '.webhookUrl')
+  local url; url=$(printf '%s' "$rec" | jq -r '.smeeChannel')
   expect_eq "webhookId from list" "wOld" "$id" || return 1
-  expect_eq "webhookUrl from list" "https://foo.test/api/webhook/linear" "$url" || return 1
+  expect_eq "smeeChannel from list" "https://foo.test/api/webhook/linear" "$url" || return 1
   # resourceTypes should be absent (we don't fabricate them).
   local has_rt; has_rt=$(printf '%s' "$rec" | jq 'has("resourceTypes")')
   expect_eq "resourceTypes absent" "false" "$has_rt" || return 1
+}
+
+# ─── Test 9 — legacy webhookUrl record short-circuits + migrates (CTL-274) ─
+# A record written by the pre-CTL-274 producer uses `webhookUrl` instead of
+# `smeeChannel`. The new code must:
+#   1. Recognize it as a usable record (read fallback)
+#   2. Short-circuit on same-URL re-run (no API call)
+#   3. NOT migrate the field on a no-op short-circuit (we don't write when we
+#      have nothing new to write — keeps the no-API-call invariant simple)
+test_legacy_webhookurl_record_short_circuits() {
+  local env; env=$(make_test_env t9)
+  cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "webhookId": "wLegacy",
+        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "registeredAt": "2026-05-01T00:00:00Z",
+        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+      }
+    }
+  }
+}
+EOF
+  # Same URL — should short-circuit on the legacy record (no API call).
+  run_helper "$env" --webhook-url "https://foo.test/api/webhook/linear" >/dev/null 2>&1 || return 1
+
+  local n; n=$(total_calls "$env")
+  expect_eq "total curl calls" "0" "$n" || return 1
+
+  # Record retains the legacy webhookId — short-circuit didn't rewrite.
+  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  expect_eq "webhookId preserved" "wLegacy" "$id" || return 1
+}
+
+# ─── Test 10 — legacy webhookUrl record migrates on --force (CTL-274) ──────
+# When --force triggers a fresh create, the new write_linear_record must
+# write `smeeChannel` AND drop the legacy `webhookUrl` field.
+test_legacy_webhookurl_record_migrates_on_force() {
+  local env; env=$(make_test_env t10)
+  cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "webhookId": "wLegacy",
+        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "registeredAt": "2026-05-01T00:00:00Z",
+        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+      }
+    }
+  }
+}
+EOF
+  local DEL_RESP="${env}/del.json" CR_RESP="${env}/cr.json"
+  write_response_delete_success "$DEL_RESP"
+  write_response_create_success "$CR_RESP" "wNew" "https://foo.test/api/webhook/linear"
+  STUB_RESPONSE_DELETE="$DEL_RESP" \
+  STUB_RESPONSE_CREATE="$CR_RESP" \
+  run_helper "$env" --webhook-url "https://foo.test/api/webhook/linear" --force \
+    >/dev/null 2>&1 || return 1
+
+  local rec; rec=$(read_layer2 "$env")
+  local has_legacy; has_legacy=$(printf '%s' "$rec" | jq 'has("webhookUrl")')
+  local has_canonical; has_canonical=$(printf '%s' "$rec" | jq 'has("smeeChannel")')
+  expect_eq "legacy webhookUrl removed" "false" "$has_legacy" || return 1
+  expect_eq "canonical smeeChannel present" "true" "$has_canonical" || return 1
+  local url; url=$(printf '%s' "$rec" | jq -r '.smeeChannel')
+  expect_eq "smeeChannel value" "https://foo.test/api/webhook/linear" "$url" || return 1
+}
+
+# ─── Test 11 — legacy webhookUrl record deregisters cleanly (CTL-274) ──────
+# `--deregister` reading a legacy record must call webhookDelete with the
+# stored ID and clear both legacy and canonical keys from the record.
+test_legacy_webhookurl_record_deregisters() {
+  local env; env=$(make_test_env t11)
+  cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "webhookId": "wLegacy",
+        "webhookUrl": "https://foo.test/api/webhook/linear",
+        "registeredAt": "2026-05-01T00:00:00Z",
+        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+      }
+    }
+  }
+}
+EOF
+  echo "old_secret" > "${env}/home/.config/catalyst/linear-webhook-secret"
+
+  local DEL_RESP="${env}/del.json"
+  write_response_delete_success "$DEL_RESP"
+  STUB_RESPONSE_DELETE="$DEL_RESP" \
+  run_helper "$env" --deregister >/dev/null 2>&1 || return 1
+
+  local rec; rec=$(read_layer2 "$env")
+  [[ -z "$rec" || "$rec" == "null" ]] || { echo "Layer 2 record not cleared: $rec"; return 1; }
+  expect_eq "delete count" "1" "$(count_calls "$env" delete)" || return 1
 }
 
 # ─── Run all ──────────────────────────────────────────────────────────────
@@ -444,6 +553,9 @@ run "--deregister clears Layer 2 + secret" test_deregister_uses_layer2_id
 run "--deregister with no record errors" test_deregister_no_record_errors
 run "Layer 2 missing → API list+create" test_register_falls_back_to_api_when_layer2_missing
 run "Layer 2 missing → API list dedup" test_register_falls_back_to_api_dedup_when_layer2_missing
+run "legacy webhookUrl short-circuits (CTL-274)" test_legacy_webhookurl_record_short_circuits
+run "legacy webhookUrl migrates on --force (CTL-274)" test_legacy_webhookurl_record_migrates_on_force
+run "legacy webhookUrl deregisters cleanly (CTL-274)" test_legacy_webhookurl_record_deregisters
 
 echo
 echo "Passed: $PASSES, Failed: $FAILURES"

--- a/plugins/dev/scripts/setup-linear-webhook.sh
+++ b/plugins/dev/scripts/setup-linear-webhook.sh
@@ -3,9 +3,14 @@
 #
 # CTL-224 introduced the GraphQL plumbing. CTL-238 added Layer 2 record
 # persistence: after webhookCreate succeeds, the helper writes
-# catalyst.monitor.linear.{webhookId,webhookUrl,registeredAt,resourceTypes}
+# catalyst.monitor.linear.{webhookId,smeeChannel,registeredAt,resourceTypes}
 # to ~/.config/catalyst/config.json so re-runs decide idempotency locally and
 # --deregister has a clean handle to call webhookDelete with.
+#
+# CTL-274: the URL field is `smeeChannel` (matches what every consumer reads —
+# orch-monitor's webhook-config.ts and the sibling setup-webhooks.sh). Legacy
+# records written by earlier versions used `webhookUrl`; read paths fall back
+# to that key for back-compat and write paths migrate it on the next write.
 #
 # Reads Layer 1 .catalyst/config.json for catalyst.projectKey + catalyst.linear.teamId,
 # and Layer 2 ~/.config/catalyst/config-<projectKey>.json for linear.apiToken.
@@ -134,13 +139,19 @@ SECRET_FILE="${HOME_CONFIG_DIR}/linear-webhook-secret"
 
 # Read the Linear registration record from Layer 2 (~/.config/catalyst/config.json).
 # Outputs compact JSON or empty string when no usable record exists. A "usable"
-# record requires non-empty webhookId AND webhookUrl — partial records are ignored.
+# record requires non-empty webhookId AND a non-empty URL field — either the
+# canonical `smeeChannel` (CTL-274) or the legacy `webhookUrl` (records written
+# by pre-CTL-274 versions). The returned object is normalized to always have
+# `.smeeChannel` populated so callers don't need to handle the legacy key.
 read_linear_record() {
   [[ -f "$HOME_CONFIG_PATH" ]] || { echo ""; return 0; }
   jq -c '
-    .catalyst.monitor.linear // empty
-    | if (.webhookId // "") != "" and (.webhookUrl // "") != ""
-      then .
+    (.catalyst.monitor.linear // {}) as $r
+    | (($r.smeeChannel // "") | tostring) as $canon
+    | (($r.webhookUrl  // "") | tostring) as $legacy
+    | (if $canon != "" then $canon else $legacy end) as $url
+    | if (($r.webhookId // "") != "") and ($url != "")
+      then $r | .smeeChannel = $url
       else empty
       end
   ' "$HOME_CONFIG_PATH" 2>/dev/null
@@ -149,6 +160,9 @@ read_linear_record() {
 # Write the registration record. Pass resourceTypes as a JSON array string;
 # empty array ([]) means "unknown — omit the field" so partial records from
 # the API-list-dedup branch don't fabricate resource types.
+#
+# CTL-274: writes the canonical `smeeChannel` key and drops any legacy
+# `webhookUrl` field present from a pre-CTL-274 record.
 write_linear_record() {
   local webhook_id="$1" webhook_url="$2" resource_types_json="$3"
   local timestamp; timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -161,7 +175,8 @@ write_linear_record() {
        | .catalyst.monitor //= {}
        | .catalyst.monitor.linear //= {}
        | .catalyst.monitor.linear.webhookId = $id
-       | .catalyst.monitor.linear.webhookUrl = $url
+       | .catalyst.monitor.linear.smeeChannel = $url
+       | .catalyst.monitor.linear |= del(.webhookUrl)
        | .catalyst.monitor.linear.registeredAt = $ts
        | if ($rt | length) > 0
          then .catalyst.monitor.linear.resourceTypes = $rt
@@ -172,12 +187,14 @@ write_linear_record() {
 }
 
 # Clear the Linear registration record, preserving any sibling Layer 2 keys.
+# CTL-274: deletes both the canonical `smeeChannel` and the legacy `webhookUrl`
+# field so legacy records are also fully cleared.
 clear_linear_record() {
   [[ -f "$HOME_CONFIG_PATH" ]] || return 0
   local tmp; tmp=$(mktemp)
   jq '
     if (.catalyst.monitor.linear // null) != null
-    then .catalyst.monitor.linear |= del(.webhookId, .webhookUrl, .registeredAt, .resourceTypes)
+    then .catalyst.monitor.linear |= del(.webhookId, .smeeChannel, .webhookUrl, .registeredAt, .resourceTypes)
          | if (.catalyst.monitor.linear // {}) == {} then del(.catalyst.monitor.linear) else . end
          | if (.catalyst.monitor // {}) == {} then del(.catalyst.monitor) else . end
          | if (.catalyst // {}) == {} then del(.catalyst) else . end
@@ -255,7 +272,7 @@ if [[ $DEREGISTER -eq 1 ]]; then
     exit 1
   fi
   RECORD_ID=$(printf '%s' "$EXISTING_RECORD" | jq -r '.webhookId')
-  RECORD_URL=$(printf '%s' "$EXISTING_RECORD" | jq -r '.webhookUrl')
+  RECORD_URL=$(printf '%s' "$EXISTING_RECORD" | jq -r '.smeeChannel')
   load_api_token
   delete_via_graphql "$RECORD_ID"
   clear_linear_record
@@ -279,7 +296,7 @@ fi
 LAYER2_HANDLED=0
 EXISTING_RECORD="$(read_linear_record)"
 if [[ -n "$EXISTING_RECORD" ]]; then
-  RECORD_URL=$(printf '%s' "$EXISTING_RECORD" | jq -r '.webhookUrl')
+  RECORD_URL=$(printf '%s' "$EXISTING_RECORD" | jq -r '.smeeChannel')
   RECORD_ID=$(printf '%s' "$EXISTING_RECORD" | jq -r '.webhookId')
   if [[ "$RECORD_URL" == "$WEBHOOK_URL" && "$FORCE" -eq 0 ]]; then
     echo "Webhook already registered (id=${RECORD_ID}, url=${RECORD_URL}); skipping."


### PR DESCRIPTION
## Linear ticket

[CTL-274](https://linear.app/coalesce-labs/issue/CTL-274) — `setup-linear-webhook.sh` writes `webhookUrl` but orch-monitor reads `smeeChannel` — Linear tunnel never starts.

## Bug

After `setup-webhooks.sh --linear-register --webhook-url <smee-url>` succeeds, orch-monitor never starts the Linear smee tunnel. Linear deliveries to the smee URL go nowhere — no error, no log, just silence.

Three-way disagreement on the same JSON key:

| Role | File | Key |
|---|---|---|
| Producer | `plugins/dev/scripts/setup-linear-webhook.sh` | `webhookUrl` ❌ |
| Sibling consumer | `plugins/dev/scripts/setup-webhooks.sh` | `smeeChannel` ✅ |
| Orch-monitor consumer | `plugins/dev/scripts/orch-monitor/lib/webhook-config.ts` | `smeeChannel` ✅ |

## Fix

Rename the producer's URL field from `webhookUrl` to `smeeChannel` (matching the GitHub-side convention `catalyst.monitor.github.smeeChannel` and what every consumer reads).

- **Write site** (`write_linear_record`): writes `smeeChannel`, drops legacy `webhookUrl` on every write.
- **Read site** (`read_linear_record`): prefers `smeeChannel`, falls back to legacy `webhookUrl`. Returned object always has `.smeeChannel` populated, so caller code is uniform.
- **Clear site** (`clear_linear_record`): deletes both keys for safety.
- **Caller sites** (`--deregister`, register short-circuit): now read `.smeeChannel` from the normalized record.

Existing users with `webhookUrl` records continue to short-circuit (idempotency preserved) and migrate to `smeeChannel` on their next re-run / `--force` / `--deregister`.

## Tests

Updated `plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh`:
- 8 existing tests updated to assert/seed `smeeChannel` (not `webhookUrl`).
- Test 1 also asserts `webhookUrl` is **not** present in fresh writes.
- 3 new back-compat tests:
  - legacy `webhookUrl` short-circuits without API call
  - legacy `webhookUrl` migrates to `smeeChannel` on `--force`
  - legacy `webhookUrl` deregisters cleanly

All 11 tests pass. CTL-224's `setup-linear-webhook.test.sh` (12 tests) and the orch-monitor `webhook-*.test.ts` suites (156 tests) pass unchanged — no consumer code touched.

End-to-end verified: pre-fix legacy config produces `linearSmeeChannel: ""` in `loadWebhookConfig`; post-fix with the new producer writing `smeeChannel`, the consumer correctly reads the URL.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh` — 11/11 pass
- [x] `bash plugins/dev/scripts/__tests__/setup-linear-webhook.test.sh` — 12/12 pass (CTL-224)
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts` — 35/35 pass
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/webhook-{subscriber,tunnel,handler,events}.test.ts plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-*.test.ts` — 156/156 pass
- [x] End-to-end round-trip with synthetic legacy + post-migration config

## Out of scope

- CTL-272 (`check-setup.sh` reads `webhookId` from wrong file) — already merged on main as 5ceb79e.
- CTL-273 (workspace-wide + multi-team Linear webhook support) — separate worker.

## Pre-existing finding

`setup-webhooks.test.sh` test 13 (`--linear-register requires --webhook-url`) fails on main today — `setup-webhooks.sh` provisions a Linear smee channel before validating `--webhook-url` is supplied. Verified pre-existing by stashing this PR's diff and re-running. Filed as a follow-up; not in scope for this PR.