### PR TITLE
feat(dev): wire Linear webhook events into HUD activity feed (CTL-275)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/activity-event-row.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/activity-event-row.tsx
@@ -89,9 +89,32 @@ function summarize(e: ActivityEvent): string {
   }
   // Linear
   if (e.event === "linear.issue.state_changed") {
+    const updatedFromKeys = (detail as { updatedFromKeys?: string[] }).updatedFromKeys ?? [];
+    const ticket = scope.ticket ?? (detail as { ticket?: string }).ticket ?? "";
+    if (updatedFromKeys.length > 0) {
+      return `${updatedFromKeys.join(", ")} changed${ticket ? " · " + ticket : ""}`;
+    }
     const fromV = (detail as { from?: string }).from ?? "?";
     const toV = (detail as { to?: string }).to ?? "?";
-    return `${scope.ticket ?? "?"}: ${fromV} → ${toV}`;
+    return `${ticket ? ticket + ": " : ""}${fromV} → ${toV}`;
+  }
+  if (e.event.startsWith("linear.comment.")) {
+    const action = e.event.slice("linear.comment.".length);
+    const ticket = scope.ticket ?? (detail as { ticket?: string }).ticket ?? "";
+    if (action === "created") return `new comment${ticket ? " · " + ticket : ""}`;
+    return `comment ${action}${ticket ? " · " + ticket : ""}`;
+  }
+  if (e.event.startsWith("linear.issue_label.")) {
+    return "label updated";
+  }
+  if (e.event.startsWith("linear.cycle.")) {
+    const action = e.event.slice("linear.cycle.".length);
+    return `cycle ${action}`;
+  }
+  if (e.event.startsWith("linear.issue.")) {
+    const action = e.event.slice("linear.issue.".length);
+    const ticket = scope.ticket ?? (detail as { ticket?: string }).ticket ?? "";
+    return `issue ${action}${ticket ? " · " + ticket : ""}`;
   }
   if (e.event.startsWith("linear.")) {
     return `${scope.ticket ?? ""} ${e.event.slice("linear.".length)}`.trim();
@@ -143,6 +166,7 @@ export function ActivityEventRow({ event, onPivot }: Props) {
   const repo = scope.repo ?? null;
   const pr = scope.pr ?? null;
 
+  const isLinear = event.event.startsWith("linear.");
   const canPivot = !!(onPivot && orch && worker);
 
   return (
@@ -158,6 +182,11 @@ export function ActivityEventRow({ event, onPivot }: Props) {
       </span>
       <span className="min-w-0 flex-1 truncate text-fg">{summarize(event)}</span>
       <span className="flex shrink-0 items-center gap-1">
+        {isLinear && (
+          <span className="rounded bg-[#3a1a5a] px-1.5 py-px text-[10px] text-[#b08af8]">
+            Linear
+          </span>
+        )}
         {canPivot && (
           <button
             type="button"
@@ -178,7 +207,7 @@ export function ActivityEventRow({ event, onPivot }: Props) {
             {ticket}
           </span>
         )}
-        {repo && pr !== null && (
+        {!isLinear && repo && pr !== null && (
           <span className="rounded bg-surface-3 px-1.5 py-px text-[10px] text-muted">
             {repo}#{pr}
           </span>


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-07T11:34:00Z -->
<!-- Last updated: 2026-05-07T11:34:00Z -->
<!-- PR: #463 -->
<!-- Previous commits: 66df236795043cfb769d543bd3f8d24844648daf -->

## Summary

Wires `linear.webhook` events (already arriving from the webhook source) into the HUD activity feed with proper display, summarization, and scope chips. Previously, `ActivityEvent.source` was projected from the wire envelope but silently unused — Linear events would render with a generic one-liner from the catch-all branch.

**Changes:**
- Add specific `summarize()` cases for `linear.issue.*`, `linear.comment.*`, `linear.cycle.*`, and `linear.issue_label.*` events
- Add a purple **Linear** source chip rendered for all `linear.*` events
- Scope chip now shows `scope.ticket` (e.g. `ADV-546`) for linear events; the `repo#pr` chip is suppressed (linear events don't carry repo/PR scope)

## Changes Made

### Frontend Changes (`activity-event-row.tsx`)

**`summarize()` — new linear event cases:**

| Event | Output format |
|---|---|
| `linear.issue.state_changed` (with `updatedFromKeys`) | `"state changed · ADV-546"` |
| `linear.issue.state_changed` (fallback) | `"ADV-546: In Progress → Done"` |
| `linear.comment.created` | `"new comment · ADV-546"` |
| `linear.comment.<action>` | `"comment <action> · ADV-546"` |
| `linear.issue_label.updated` | `"label updated"` |
| `linear.cycle.<action>` | `"cycle <action>"` |
| `linear.issue.<action>` | `"issue <action> · ADV-546"` |
| `linear.*` (catch-all) | `"ADV-546 <sub-event-name>"` |

**Source chip:** Purple chip (`bg-[#3a1a5a] text-[#b08af8]`) labeled **Linear** rendered for all `linear.*` events.

**Scope chip:** `repo#pr` chip suppressed for linear events via `!isLinear &&` guard. `scope.ticket` chip renders normally.

## How to Verify It

- [ ] Open the orch-monitor activity feed with live Linear webhook events flowing
- [ ] Confirm `linear.issue.state_changed` events show "field changed · TICKET" when `updatedFromKeys` is populated
- [ ] Confirm `linear.comment.created` shows "new comment · TICKET"
- [ ] Confirm `linear.issue_label.updated` shows "label updated" with no ticket chip
- [ ] Confirm all `linear.*` events show a purple "Linear" source chip
- [ ] Confirm `linear.*` events do not show a `repo#pr` scope chip

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-275
- Blocks resolution of CTL-281 (source color-coding — shares the 'Linear' chip style)
