### PR TITLE
feat(dev): add /god skill — cross-project omniscient status view (CTL-193)

### DIFF
--- a/plugins/dev/scripts/god-gather.sh
+++ b/plugins/dev/scripts/god-gather.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# god-gather.sh — collect cross-project Catalyst state and emit JSON
+#
+# Reads: ~/catalyst/state.json, ~/catalyst/runs/*/state.json,
+#        ~/catalyst/runs/*/workers/*.json, ~/catalyst/wt/, ~/.claude/projects/,
+#        ~/catalyst/catalyst.db (via catalyst-session.sh), ~/catalyst/events/YYYY-MM.jsonl
+#
+# Outputs a single JSON object:
+#   ts           — ISO timestamp of this snapshot
+#   global       — aggregate orchestrator counts
+#   orchestrators — map from global state.json
+#   projects     — array of {name, path, worktrees[]}
+#   workers      — array of worker signal file contents
+#   runs         — array of per-run state.json summaries
+#   sessions     — active Claude sessions (from catalyst-session.sh)
+#   recentEvents — events from last 30 min
+
+set -uo pipefail
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+CLAUDE_PROJECTS_DIR="${HOME}/.claude/projects"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EPOCH_NOW=$(date +%s)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+# macOS-safe "N minutes ago" ISO timestamp
+minutes_ago_iso() {
+  local n="$1"
+  date -u -v"-${n}M" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+    date -u --date="${n} minutes ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+    echo ""
+}
+
+# mtime of a path in seconds since epoch (macOS + Linux)
+path_mtime() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+}
+
+# Elapsed seconds → human string
+elapsed_human() {
+  local secs="$1"
+  if [ "$secs" -lt 60 ]; then
+    echo "${secs}s ago"
+  elif [ "$secs" -lt 3600 ]; then
+    echo "$((secs / 60)) min ago"
+  else
+    local h=$((secs / 3600)) m=$(( (secs % 3600) / 60 ))
+    echo "${h}h ${m}min ago"
+  fi
+}
+
+# Classify a worktree directory name into: orchestrator, worker, pm, oneshot, other
+classify_worktree() {
+  local name="$1"
+  case "$name" in
+    orch-*)
+      # worker: ends with TICKET-NUM (uppercase letters dash digits)
+      if echo "$name" | grep -qE '[A-Z][A-Z0-9]+-[0-9]+$'; then
+        echo "worker"
+      else
+        echo "orchestrator"
+      fi
+      ;;
+    PM|pm|Pm)
+      echo "pm"
+      ;;
+    *)
+      # standalone oneshot: TICKET-NUM pattern
+      if echo "$name" | grep -qE '^[A-Z][A-Z0-9]+-[0-9]+$'; then
+        echo "oneshot"
+      else
+        echo "other"
+      fi
+      ;;
+  esac
+}
+
+# ── 1. Global state.json ─────────────────────────────────────────────────────
+
+GLOBAL_STATE_FILE="${CATALYST_DIR}/state.json"
+GLOBAL_STATE='{"orchestrators":{},"lastUpdated":null}'
+if [ -f "$GLOBAL_STATE_FILE" ]; then
+  GLOBAL_STATE=$(jq -c '{orchestrators: (.orchestrators // {}), lastUpdated: .lastUpdated}' \
+    "$GLOBAL_STATE_FILE" 2>/dev/null) || GLOBAL_STATE='{"orchestrators":{},"lastUpdated":null}'
+fi
+
+GLOBAL_COUNTS=$(echo "$GLOBAL_STATE" | jq -c '
+  .orchestrators as $o |
+  {
+    totalOrchestrators: ($o | length),
+    activeOrchestrators: ($o | to_entries | map(select(.value.status == "active")) | length),
+    completedOrchestrators: ($o | to_entries | map(select(.value.status == "completed")) | length)
+  }' 2>/dev/null) || GLOBAL_COUNTS='{"totalOrchestrators":0,"activeOrchestrators":0,"completedOrchestrators":0}'
+
+# ── 2. Per-run states ────────────────────────────────────────────────────────
+
+RUNS_DIR="${CATALYST_DIR}/runs"
+RUNS_JSON="[]"
+if [ -d "$RUNS_DIR" ]; then
+  RUNS_JSON=$(
+    find "$RUNS_DIR" -maxdepth 2 -name "state.json" 2>/dev/null | sort | \
+    while IFS= read -r sf; do
+      jq -c --arg dir "$(dirname "$sf")" '{
+        orchestrator: (.orchestrator // ""),
+        dir: $dir,
+        startedAt: .startedAt,
+        currentWave: (.currentWave // 0),
+        totalWaves: (.totalWaves // 0),
+        waves: [(.waves // [])[] | {wave: .wave, status: .status, tickets: (.tickets // [])}],
+        attention: (.attention // [])
+      }' "$sf" 2>/dev/null
+    done | jq -cs '.'
+  ) || RUNS_JSON="[]"
+fi
+
+# ── 3. Worker signal files ────────────────────────────────────────────────────
+
+WORKERS_JSON="[]"
+if [ -d "$RUNS_DIR" ]; then
+  WORKERS_JSON=$(
+    find "$RUNS_DIR" -maxdepth 3 -path "*/workers/*.json" 2>/dev/null | \
+    grep -v -- '-rollup' | sort | \
+    while IFS= read -r wf; do
+      jq -c '{
+        ticket: (.ticket // .workerName // "unknown"),
+        orchestrator: (.orchestrator // null),
+        wave: (.wave // null),
+        label: (.label // null),
+        status: (.status // "unknown"),
+        phase: (.phase // 0),
+        pr: (.pr // null),
+        needsAttention: (.needsAttention // false),
+        attentionReason: (.attentionReason // null),
+        lastHeartbeat: (.lastHeartbeat // null),
+        pid: (.pid // null),
+        worktreePath: (.worktreePath // null),
+        startedAt: (.startedAt // null),
+        updatedAt: (.updatedAt // null)
+      }' "$wf" 2>/dev/null
+    done | jq -cs '.'
+  ) || WORKERS_JSON="[]"
+fi
+
+# ── 4. Worktree inventory ────────────────────────────────────────────────────
+
+WT_BASE="${CATALYST_DIR}/wt"
+PROJECTS_JSON="[]"
+
+if [ -d "$WT_BASE" ]; then
+  PROJECTS_JSON=$(
+    for project in $(ls -1 "$WT_BASE" 2>/dev/null); do
+      PROJECT_DIR="${WT_BASE}/${project}"
+      [ -d "$PROJECT_DIR" ] || continue
+      WORKTREES_JSON="[]"
+      for wt in $(ls -1 "$PROJECT_DIR" 2>/dev/null); do
+        WT_PATH="${PROJECT_DIR}/${wt}"
+        [ -d "$WT_PATH" ] || continue
+        TYPE=$(classify_worktree "$wt")
+
+        # Find corresponding Claude session dir
+        SESSION_DIR="${CLAUDE_PROJECTS_DIR}/-Users-ryan-catalyst-wt-${project}-${wt}"
+        SESSION_MTIME=0
+        ELAPSED_STR="unknown"
+        if [ -d "$SESSION_DIR" ]; then
+          SESSION_MTIME=$(path_mtime "$SESSION_DIR")
+          if [ "$SESSION_MTIME" -gt 0 ]; then
+            ELAPSED=$(( EPOCH_NOW - SESSION_MTIME ))
+            ELAPSED_STR=$(elapsed_human "$ELAPSED")
+          fi
+        fi
+
+        WORKTREES_JSON=$(echo "$WORKTREES_JSON" | jq -c \
+          --arg name "$wt" --arg type "$TYPE" --arg path "$WT_PATH" \
+          --argjson mtime "$SESSION_MTIME" --arg elapsed "$ELAPSED_STR" \
+          '. + [{name: $name, type: $type, path: $path, sessionMtime: $mtime, lastActive: $elapsed}]')
+      done
+      echo "{\"name\": $(echo "$project" | jq -R .), \"path\": $(echo "$PROJECT_DIR" | jq -R .), \"worktrees\": $WORKTREES_JSON}"
+    done | jq -cs '.'
+  ) || PROJECTS_JSON="[]"
+fi
+
+# ── 5. Active sessions ────────────────────────────────────────────────────────
+
+SESSIONS_JSON="[]"
+SESS_SCRIPT=$(ls ~/.claude/plugins/cache/catalyst/catalyst-dev/*/scripts/catalyst-session.sh 2>/dev/null | head -1 || true)
+if [ -n "$SESS_SCRIPT" ] && [ -x "$SESS_SCRIPT" ]; then
+  SESSIONS_JSON=$("$SESS_SCRIPT" list --active --json 2>/dev/null | jq -c '.' 2>/dev/null) || SESSIONS_JSON="[]"
+fi
+
+# ── 6. Recent events (last 30 min) ───────────────────────────────────────────
+
+EVENTS_JSON="[]"
+EVENTS_FILE="${CATALYST_DIR}/events/$(date +%Y-%m).jsonl"
+CUTOFF=$(minutes_ago_iso 30)
+
+if [ -f "$EVENTS_FILE" ] && [ -n "$CUTOFF" ]; then
+  TOTAL=$(wc -l < "$EVENTS_FILE" | tr -d ' ')
+  SINCE=$(( TOTAL > 3000 ? TOTAL - 3000 : 0 ))
+  EVENTS_JSON=$(
+    tail -n +"$((SINCE + 1))" "$EVENTS_FILE" 2>/dev/null | \
+    jq -c --arg cutoff "$CUTOFF" '
+      select(.ts >= $cutoff) | select(
+        (.event | startswith("worker-")) or
+        (.event | startswith("filter.wake")) or
+        .event == "github.pr.merged" or
+        .event == "github.check_suite.completed" or
+        .event == "github.workflow_run.completed" or
+        .event == "attention-raised" or
+        .event == "attention-resolved" or
+        .event == "linear.issue.state_changed" or
+        (.event == "comms.message.posted" and ((.detail.type // "") == "attention"))
+      ) | {ts, event, orchestrator, worker,
+           scope: (.scope // null),
+           detail: (.detail // null)}
+    ' 2>/dev/null | jq -cs '.'
+  ) || EVENTS_JSON="[]"
+fi
+
+# ── 7. Emit ───────────────────────────────────────────────────────────────────
+
+jq -cn \
+  --arg ts "$NOW" \
+  --argjson global "$GLOBAL_COUNTS" \
+  --argjson orchestrators "$(echo "$GLOBAL_STATE" | jq '.orchestrators')" \
+  --argjson projects "$PROJECTS_JSON" \
+  --argjson workers "$WORKERS_JSON" \
+  --argjson runs "$RUNS_JSON" \
+  --argjson sessions "$SESSIONS_JSON" \
+  --argjson recentEvents "$EVENTS_JSON" \
+  '{ts: $ts, global: $global, orchestrators: $orchestrators, projects: $projects,
+    workers: $workers, runs: $runs, sessions: $sessions, recentEvents: $recentEvents}'

--- a/plugins/dev/skills/god/SKILL.md
+++ b/plugins/dev/skills/god/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: god
+description:
+  "Cross-project omniscient status view — like `top` for Catalyst work streams. **ALWAYS use when**
+  the user says '/god', 'what's happening across projects', 'what's running', 'show me all active
+  work', 'what orchestrators are active', 'what sessions are running', or asks a free-form question
+  about cross-project Catalyst state (e.g. 'what PRs are open?', 'which workers are stuck?',
+  'what happened in the last hour?'). Shows orchestrators with wave/worker progress, active PM and
+  oneshot sessions with recency, and recent event activity (last 30 min) from the event log.
+  Encodes all data-source locations and naming conventions as skill knowledge."
+disable-model-invocation: false
+allowed-tools: Read, Glob, Bash(ls *), Bash(find *), Bash(git *), Bash(gh *), Bash(jq *), Bash(linearis *), Bash(stat *), Bash(wc *), Bash(date *), Bash(tail *), Bash(cat *), Bash(plugins/dev/scripts/god-gather.sh *), Bash(kill *)
+version: 1.0.0
+---
+
+# god — Cross-Project Omniscient Status View
+
+Combines static state (where things are) with the live event log (how they got there and what's
+happening right now). Default invocation produces a full dashboard; args narrow the scope or
+switch interaction mode.
+
+## Invocation
+
+```
+/god                        — full multi-project status dashboard
+/god <project>              — filter to one project (e.g., adva, catalyst)
+/god <orch-name>            — deep-dive into one orchestrator
+/god restart                — list crashed/interrupted sessions with restart commands
+free-form question          — "what PRs are open?", "which workers are stuck?",
+                              "what happened in the last hour?"
+```
+
+## Data Sources
+
+| Source | Path / Command | What it gives |
+|---|---|---|
+| Global orchestrator state | `~/catalyst/state.json` | All orchestrators, progress, worker map |
+| Per-run state | `~/catalyst/runs/<orch-id>/state.json` | Wave breakdown, queue, current wave |
+| Worker signal files | `~/catalyst/runs/<orch-id>/workers/*.json` | Phase, PR, heartbeat, needsAttention |
+| Session database | `catalyst-session.sh list --active --json` | Active Claude sessions |
+| Worktree inventory | `ls ~/catalyst/wt/` | Projects and their worktrees |
+| Claude session recency | `ls -lt ~/.claude/projects/` | Which sessions were recently active (by mtime) |
+| Event log | `~/catalyst/events/YYYY-MM.jsonl` | Last 30–60 min of activity |
+| Orchestrator dashboard | `~/catalyst/runs/<orch-id>/DASHBOARD.md` | Human-readable orch summary |
+| Rollup fragments | `~/catalyst/runs/<orch-id>/workers/<TICKET>-rollup.md` | Post-completion summaries |
+
+### Naming conventions
+
+- `~/catalyst/wt/<project>/` — top-level project directories (e.g., `adva/`, `catalyst-workspace/`)
+- `orch-<slug>` — orchestrator leader worktree (no ticket suffix)
+- `orch-<slug>-<TICKET>` — orchestrator worker worktree
+- `PM` / `pm` — persistent PM session worktree
+- `<TICKET>` (e.g., `ADV-454`) — standalone oneshot worktree
+- `~/catalyst/runs/<orch-id>/` — orchestrator run state dir (matches `orch-<slug>` above)
+- `~/.claude/projects/-Users-ryan-catalyst-wt-<project>-<worktree>/` — Claude Code session data
+
+## Procedure
+
+### Step 0: Parse invocation mode
+
+Determine mode from the argument:
+- No argument → **default dashboard**
+- Known project directory name (matches `ls ~/catalyst/wt/`) → **project filter**
+- Starts with `orch-` → **orchestrator deep-dive**
+- Exactly `restart` → **restart mode**
+- Otherwise → **free-form Q&A** (treat the full input as a question)
+
+### Step 1: Run the data-gather helper
+
+The helper script collects all state in one pass and outputs JSON:
+
+```bash
+plugins/dev/scripts/god-gather.sh 2>/dev/null
+```
+
+The script returns a JSON object with keys: `ts`, `projects`, `sessions`, `recentEvents`,
+`global`. Parse it with `jq` for the sections you need.
+
+If the helper is unavailable or errors, fall back to gathering data directly (see
+**Manual fallback commands** below).
+
+### Step 2: Present the dashboard
+
+Format the output using the **Dashboard format** section below. Use the gathered JSON.
+
+For project-filter mode, skip all sections not matching the requested project.
+For orchestrator deep-dive, show the full worker table and the DASHBOARD.md contents.
+For restart mode, follow the **Restart mode** section.
+For free-form questions, answer naturally using the gathered data as context.
+
+---
+
+## Dashboard Format
+
+Use Unicode box-drawing characters for section headers. Present in this order:
+
+```
+[as of 2026-05-07T11:44:00Z]
+
+═══ ADVA (2 orchestrators, 1 PM, 1 oneshot) ═══
+
+ORCH  orch-deal-to-opportunity-2026-04-24    Wave 2/7   active
+  ├── ADV-462  pr-created   PR #291 ✅ CI passing
+  ├── ADV-474  implementing  (no PR yet)
+  └── ADV-475  implementing  (no PR yet)
+
+ORCH  orch-industry-packs-2026-04-24         Wave 1/2   active
+  ├── ADV-480  pr-created   PR #293 ❌ CI failing
+  ├── ADV-481  researching
+  ├── ADV-482  queued
+  └── ADV-483  queued
+
+PM    ~/catalyst/wt/adva/PM                  last active: 2 min ago
+SHOT  ADV-454 (design tokens in docs)        last active: 8 min ago
+
+═══ CATALYST (1 orchestrator, 1 PM) ═══
+
+ORCH  orch-ctl-275-2026-05-07                Wave 1/2   active
+  ├── CTL-280  done         PR #465 ✅ merged
+  └── CTL-193  implementing  (no PR yet)
+
+PM    ~/catalyst/wt/catalyst-workspace/PM    last active: 3 min ago
+
+─── Recent activity (last 30 min) ─────────────────────────────
+
+  ADV-480: implementing → pr-created [PR #293, CI pending]
+  CTL-280: pr-created → done [PR #465 merged]
+  github: 3× check_suite completed (2 passing, 1 failing)
+  Linear: ADV-474 state → In Review
+```
+
+### Status icons
+
+| CI state | Icon |
+|---|---|
+| passing / merged | ✅ |
+| pending / in-progress | ⏳ |
+| failing | ❌ |
+| no PR yet / unknown | (omit icon) |
+
+### Worker status values
+
+Map signal-file `status` to display text:
+- `dispatched` → `queued`
+- `researching` → `researching`
+- `planning` → `planning`
+- `implementing` → `implementing`
+- `validating` → `validating`
+- `shipping` → `shipping`
+- `pr-created` → `pr-created` (append PR info)
+- `done` → `done`
+- `failed` → `❌ failed`
+- `stalled` → `⚠️ stalled`
+- `deploy-failed` → `❌ deploy-failed`
+
+Workers with `needsAttention: true` get a `⚠️` prefix regardless of status.
+
+---
+
+## Orchestrator Deep-Dive (`/god <orch-name>`)
+
+When the arg matches an orchestrator name, show:
+
+1. Header with orch ID, project, status, start time, elapsed
+2. Wave breakdown table from per-run `state.json`:
+   ```
+   Wave 1/2  ✅ done   (CTL-275, CTL-276, CTL-277, CTL-278, CTL-279)
+   Wave 2/2  🔵 active (CTL-280, CTL-193)
+   ```
+3. Full worker table with phase, PR, CI status, last heartbeat
+4. Attention items if any
+5. Contents of `~/catalyst/runs/<orch-id>/DASHBOARD.md` (verbatim, truncated to 60 lines)
+6. Recent events for this orchestrator (last 60 min, filtered by `.orchestrator == "<orch-id>"`)
+
+---
+
+## Restart Mode (`/god restart`)
+
+Show sessions that appear interrupted (were active but have no running process):
+
+### Detection
+
+```bash
+# Find worker signal files with non-terminal status but stale heartbeat
+find ~/catalyst/runs -name "*.json" -path "*/workers/*.json" 2>/dev/null | while read f; do
+  jq -r --arg f "$f" \
+    'select(.status != "done" and .status != "failed" and .status != null) |
+     "\(.status) \(.lastHeartbeat // "unknown") \(.pid // "?") \(.ticket // .workerName) \($f)"' \
+    "$f" 2>/dev/null
+done
+```
+
+For each candidate:
+1. Check if the PID is still running: `kill -0 <pid> 2>/dev/null && echo "running" || echo "dead"`
+2. Calculate time since last heartbeat
+3. Mark as crashed if: PID dead AND heartbeat > 15 min ago
+
+For each crashed session, show the restart command:
+
+```
+⚠️  CTL-193 (implementing) — last heartbeat 42 min ago, PID 81220 dead
+    Worktree: ~/catalyst/wt/catalyst-workspace/orch-ctl-275-2026-05-07-CTL-193
+    Resume:   cd ~/catalyst/wt/catalyst-workspace/orch-ctl-275-2026-05-07-CTL-193
+              claude --resume
+
+⚠️  ADV-474 (planning) — last heartbeat 23 min ago, PID 79441 dead
+    Resume:   cd ~/catalyst/wt/adva/orch-deal-to-opportunity-2026-04-24-ADV-474
+              claude --resume
+```
+
+If no crashed sessions: print `✅ All active sessions appear healthy.`
+
+---
+
+## Free-Form Q&A
+
+When the input is a question, gather the relevant data and answer naturally:
+
+| Question type | Data to gather |
+|---|---|
+| "what PRs are open?" | `gh pr list --repo <each-repo>` or parse `pr` field from worker signal files |
+| "which workers are stuck?" | Worker signal files where `needsAttention: true` or `status == "stalled"` |
+| "what happened in the last hour?" | Event log tail, last 60 min |
+| "which orchestrators are done?" | `state.json` orchestrators where `status == "completed"` |
+| "how much did the last orch cost?" | `state.json` `.orchestrators[<orch-id>].usage.costUSD` |
+| "what's the CI status of PR #N?" | `gh api repos/<repo>/pulls/<N>` |
+
+Always gather the specific data first, then answer. Do not speculate from memory.
+
+---
+
+## Manual Fallback Commands
+
+If `god-gather.sh` is unavailable:
+
+```bash
+# Global orchestrator state
+cat ~/catalyst/state.json 2>/dev/null | jq '.orchestrators | to_entries[] | {
+  id: .key,
+  status: .value.status,
+  projectKey: .value.projectKey,
+  progress: .value.progress,
+  worktreeDir: .value.worktreeDir
+}' 2>/dev/null
+
+# Worktree inventory
+for project in $(ls ~/catalyst/wt/ 2>/dev/null); do
+  echo "=== $project ==="; ls ~/catalyst/wt/"$project"/ 2>/dev/null
+done
+
+# Active sessions (if catalyst-session.sh is available)
+SESS=$(ls ~/.claude/plugins/cache/catalyst/catalyst-dev/*/scripts/catalyst-session.sh 2>/dev/null | head -1)
+[ -x "$SESS" ] && "$SESS" list --active --json 2>/dev/null | jq '.' || echo "session tracking unavailable"
+
+# Recent Claude session activity (mtime of project dirs)
+ls -lt ~/.claude/projects/ 2>/dev/null | grep "catalyst-wt" | head -15
+
+# Recent events (last 30 min)
+EVENTS_FILE=~/catalyst/events/$(date +%Y-%m).jsonl
+if [ -f "$EVENTS_FILE" ]; then
+  TOTAL=$(wc -l < "$EVENTS_FILE" | tr -d ' ')
+  SINCE=$(( TOTAL > 2000 ? TOTAL - 2000 : 0 ))
+  CUTOFF=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+           date -u --date='30 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+  tail -n +"$((SINCE + 1))" "$EVENTS_FILE" 2>/dev/null | jq -c \
+    --arg cutoff "$CUTOFF" '
+    select(.ts >= $cutoff) | select(
+      (.event | startswith("worker-")) or
+      (.event | startswith("filter.wake")) or
+      .event == "github.pr.merged" or
+      .event == "github.check_suite.completed" or
+      .event == "attention-raised" or
+      .event == "linear.issue.state_changed" or
+      (.event == "comms.message.posted" and (.detail.type // "") == "attention")
+    )' 2>/dev/null
+fi
+
+# Per-run state (waves and worker list)
+for STATE in $(find ~/catalyst/runs -name "state.json" -maxdepth 2 2>/dev/null); do
+  jq '{run: .orchestrator, currentWave: .currentWave, totalWaves: .totalWaves, waves: [.waves[] | {wave: .wave, status: .status, tickets: .tickets}]}' "$STATE" 2>/dev/null
+done
+
+# Worker signal files for active orchestrators
+find ~/catalyst/runs -name "*.json" -path "*/workers/*.json" -not -name "*-rollup.md" 2>/dev/null | \
+  xargs jq -c '{ticket: .ticket, status: .status, phase: .phase, pr: .pr, needsAttention: .needsAttention, lastHeartbeat: .lastHeartbeat, pid: .pid}' 2>/dev/null
+```
+
+---
+
+## Related
+
+- `orchestrate` — launches multi-ticket orchestrators whose state `/god` reads
+- `oneshot` — launches standalone workers whose state `/god` tracks
+- `teardown` — archives completed orchestrators (moves them out of `~/catalyst/runs/`)
+- [[monitor-events]] — event-log patterns and filter cookbook
+- [[catalyst-filter]] — Groq-backed semantic event router (filter daemon)
+- [[catalyst-comms]] — agent-to-agent pub/sub; `attention` posts surface in `/god restart`
+- `CTL-282` — HUD-panel / 30-minute briefing variant of this skill (child ticket)
+- `CTL-192` — session state tracking and crash-resilient restart (related)


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-07T11:53:00Z -->
<!-- Last updated: 2026-05-07T11:53:00Z -->
<!-- PR: #466 -->
<!-- Previous commits: efbd8f5 -->

## Summary

- Add `/god` skill — a cross-project omniscient status view that acts like `top` for Catalyst work streams
- Combines static state (orchestrator waves, worker phases, PR status) with the live event log (last 30 min of activity)
- Ships a `god-gather.sh` data-gathering helper that reads 7+ data sources in one pass and emits structured JSON

## Changes Made

### New skill: `plugins/dev/skills/god/SKILL.md`

- **Invocation modes**: default full dashboard, `/god <project>` filter, `/god <orch-name>` deep-dive, `/god restart` crash detection, and free-form Q&A
- **Dashboard format**: groups orchestrators by project with wave progress and per-worker status; shows PM and oneshot sessions with session recency; recent event activity (last 30 min) filtered to meaningful signals
- **Data source table**: documents all 10 data source paths and what each provides, with naming conventions for worktrees, runs, and Claude session dirs
- **Restart detection**: explains how to find crashed workers by checking PID liveness vs. signal-file heartbeat staleness, with per-session `claude --resume` commands
- **Free-form Q&A**: maps common question types to the specific data sources needed to answer them
- **Manual fallback commands**: complete set of raw bash commands if `god-gather.sh` is unavailable
- **Status icons and worker status mapping**: `✅ ⏳ ❌ ⚠️` mapped to CI state; full signal-file status vocabulary mapped to display text

### New script: `plugins/dev/scripts/god-gather.sh`

- Reads 7 data sources: global `state.json`, per-run `runs/*/state.json`, worker signal files, worktree directory listing, Claude session dir mtimes, `catalyst-session.sh` active sessions, event log
- `classify_worktree()` function categorizes each worktree as: `orchestrator`, `worker`, `pm`, `oneshot`, or `other` using `case`-based pattern matching
- Session recency: correlates `~/.claude/projects/-Users-ryan-catalyst-wt-<project>-<wt>/` mtime with each worktree to show "2 min ago"-style recency
- Event log: tails the last 3000 lines of the current month's JSONL, filters to events from the last 30 minutes, and selects only meaningful event types (worker lifecycle, filter wakes, PR merges, CI completions, attention-raised, Linear state changes)
- macOS + Linux compatible (`stat -f %m` / `stat -c %Y`, `date -v` / `date --date`)
- Emits a single consolidated JSON object for Claude to parse and render

## How to Verify

- [ ] Run `bash plugins/dev/scripts/god-gather.sh | jq '{ts, global}'` — should emit valid JSON with `ts` and `global.totalOrchestrators`
- [ ] Check project count: `bash plugins/dev/scripts/god-gather.sh | jq '.projects | length'` — should match number of dirs in `~/catalyst/wt/`
- [ ] Check worker classification: `bash plugins/dev/scripts/god-gather.sh | jq '[.projects[].worktrees[].type] | unique'` — should include `orchestrator`, `worker`, `pm`, `oneshot`, `other`
- [ ] Invoke `/god` in Claude Code after plugin reload — should produce a formatted status dashboard

## Related Issues/PRs

- Fixes https://linear.app/rozich/issue/CTL-193/feat-god-skill-cross-project-omniscient-status-view
- Related to CTL-282 (god mode 30-minute briefing variant, child ticket)
- Related to CTL-192 (session state tracking + crash-resilient restart)
