### PR TITLE
feat(dev): include message body in comms.message.posted events (CTL-279)

### DIFF
--- a/plugins/dev/scripts/catalyst-comms
+++ b/plugins/dev/scripts/catalyst-comms
@@ -242,6 +242,11 @@ cmd_send() {
   # tail, monitor-events skill) can observe comms traffic without subscribing
   # to every channel file. Best-effort — failures here must NOT fail the send.
   # Per-channel files remain authoritative for agent-to-agent pub/sub. CTL-210.
+  local body_trunc="$body"
+  if [[ "$type" != "attention" && ${#body} -gt 120 ]]; then
+    body_trunc="${body:0:120}"
+    body_trunc="${body_trunc% *}…"
+  fi
   emit_global_event() {
     local script="${CATALYST_STATE_SCRIPT:-}"
     if [[ -z "$script" ]]; then
@@ -258,12 +263,13 @@ cmd_send() {
       --arg type "$type" \
       --arg id "$id" \
       --arg to "$to" \
+      --arg body "$body_trunc" \
       '{
         ts: $ts,
         event: $event,
         orchestrator: (if $orch == "" then null else $orch end),
         worker: $from,
-        detail: { channel: $ch, type: $type, msgId: $id, to: $to }
+        detail: { channel: $ch, type: $type, msgId: $id, to: $to, body: $body }
       }') || return 0
     "$script" event "$envelope" >/dev/null 2>&1 || true
   }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/activity-event-row.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/activity-event-row.tsx
@@ -163,8 +163,10 @@ function summarize(e: ActivityEvent): string {
   if (e.event === "comms.message.posted") {
     const channel = (detail as { channel?: string }).channel ?? "?";
     const type = (detail as { type?: string }).type ?? "info";
+    const body = (detail as { body?: string }).body ?? "";
     const from = e.worker ?? "";
-    return `[${type}] ${channel}${from ? ` (${from})` : ""}`;
+    const prefix = `[${type}] ${channel}${from ? ` (${from})` : ""}`;
+    return body ? `${prefix}: ${body}` : prefix;
   }
   // Catalyst session lifecycle
   if (e.event === "phase-changed") {


### PR DESCRIPTION
## Summary

- Add `detail.body` to `comms.message.posted` global event envelopes so the HUD activity feed can show message content instead of just `[info] channel (worker)`
- Truncate body to 120 chars at a word boundary for `info`/`done` messages; `attention` messages get the full body since they're the highest-signal type (only ~3/month)
- Update HUD `summarize()` to render `[type] channel (from): body text here` when body is present; falls back gracefully for older events without body

## Technical Notes

**Backend** (`plugins/dev/scripts/catalyst-comms`): body was already in scope in `cmd_send()` — the global event emission in `emit_global_event()` just wasn't passing it to jq. Added 4 lines: truncation logic + `--arg body "$body_trunc"` + `body: $body` in the detail object.

**Frontend** (`activity-event-row.tsx`): reads `detail.body` via the same inline cast pattern used throughout the file. Falls back to `""` for events that predate this change.

## Test plan

- [ ] Run `catalyst-comms send <channel> "test message" --as test --type info` and verify `detail.body` appears in `catalyst-events tail` output
- [ ] Verify HUD activity feed shows body text after the `[info] channel (worker):` prefix
- [ ] Verify `attention` type messages show full body without truncation
- [ ] Verify events without body (old format) still render correctly

Fixes CTL-279

🤖 Generated with [Claude Code](https://claude.com/claude-code)