### PR TITLE
feat(dev): enrich Linear issue events with human-readable descriptions (CTL-281)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/summarize-linear-event.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/summarize-linear-event.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+import { summarizeLinearEvent } from "../lib/summarize-linear-event";
+
+describe("summarizeLinearEvent", () => {
+  describe("linear.issue.state_changed", () => {
+    it("returns 'state changed' for plain stateId", () => {
+      expect(summarizeLinearEvent("linear.issue.state_changed", "CTL-1", ["stateId"])).toBe(
+        "CTL-1: state changed",
+      );
+    });
+
+    it("returns 'started' when stateId + startedAt", () => {
+      expect(
+        summarizeLinearEvent("linear.issue.state_changed", "CTL-1", [
+          "stateId",
+          "sortOrder",
+          "startedAt",
+          "updatedAt",
+        ]),
+      ).toBe("CTL-1: started");
+    });
+
+    it("returns 'completed' when stateId + completedAt", () => {
+      expect(
+        summarizeLinearEvent("linear.issue.state_changed", "CTL-1", ["stateId", "completedAt"]),
+      ).toBe("CTL-1: completed");
+    });
+
+    it("returns 'canceled' when stateId + canceledAt", () => {
+      expect(
+        summarizeLinearEvent("linear.issue.state_changed", "CTL-1", ["stateId", "canceledAt"]),
+      ).toBe("CTL-1: canceled");
+    });
+
+    it("omits ticket prefix when ticket is undefined", () => {
+      expect(summarizeLinearEvent("linear.issue.state_changed", undefined, ["stateId"])).toBe(
+        "state changed",
+      );
+    });
+  });
+
+  describe("linear.issue.assignee_changed", () => {
+    it("returns 'reassigned'", () => {
+      expect(summarizeLinearEvent("linear.issue.assignee_changed", "CTL-2", ["assigneeId"])).toBe(
+        "CTL-2: reassigned",
+      );
+    });
+  });
+
+  describe("linear.issue.priority_changed", () => {
+    it("returns 'priority changed'", () => {
+      expect(summarizeLinearEvent("linear.issue.priority_changed", "CTL-3", ["priority"])).toBe(
+        "CTL-3: priority changed",
+      );
+    });
+  });
+
+  describe("linear.issue.updated", () => {
+    it("returns 'title changed' when title key present", () => {
+      expect(summarizeLinearEvent("linear.issue.updated", "CTL-4", ["title"])).toBe(
+        "CTL-4: title changed",
+      );
+    });
+
+    it("returns 'estimate changed' when estimate key present", () => {
+      expect(summarizeLinearEvent("linear.issue.updated", "CTL-4", ["estimate"])).toBe(
+        "CTL-4: estimate changed",
+      );
+    });
+
+    it("returns 'updated' for unknown keys", () => {
+      expect(summarizeLinearEvent("linear.issue.updated", "CTL-4", ["dueDate"])).toBe(
+        "CTL-4: updated",
+      );
+    });
+
+    it("returns 'updated' for empty keys", () => {
+      expect(summarizeLinearEvent("linear.issue.updated", "CTL-4", [])).toBe("CTL-4: updated");
+    });
+  });
+
+  describe("linear.issue.created / removed", () => {
+    it("returns 'created'", () => {
+      expect(summarizeLinearEvent("linear.issue.created", "CTL-5", [])).toBe("CTL-5: created");
+    });
+
+    it("returns 'removed'", () => {
+      expect(summarizeLinearEvent("linear.issue.removed", "CTL-5", [])).toBe("CTL-5: removed");
+    });
+  });
+
+  describe("linear.issue_label events", () => {
+    it("returns 'label updated' for linear.issue_label.updated with no ticket", () => {
+      expect(summarizeLinearEvent("linear.issue_label.updated", undefined, [])).toBe(
+        "label updated",
+      );
+    });
+
+    it("returns 'label updated' for linear.issue_label.created", () => {
+      expect(summarizeLinearEvent("linear.issue_label.created", undefined, [])).toBe(
+        "label updated",
+      );
+    });
+  });
+
+  describe("multiple keys — most significant wins via event type", () => {
+    it("state_changed + assigneeId still shows state context (stateId took priority in parser)", () => {
+      expect(
+        summarizeLinearEvent("linear.issue.state_changed", "CTL-6", ["stateId", "assigneeId"]),
+      ).toBe("CTL-6: state changed");
+    });
+  });
+
+  describe("fallback for unknown linear events", () => {
+    it("returns trimmed suffix for unknown linear events", () => {
+      expect(summarizeLinearEvent("linear.comment.created", "CTL-7", [])).toBe(
+        "CTL-7: comment.created",
+      );
+    });
+
+    it("returns just suffix when no ticket", () => {
+      expect(summarizeLinearEvent("linear.cycle.updated", undefined, [])).toBe("cycle.updated");
+    });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/summarize-linear-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/summarize-linear-event.ts
@@ -1,0 +1,39 @@
+/**
+ * Converts a linear.issue.* event into a one-line human-readable description.
+ * Reads updatedFromKeys (the field names that changed) to disambiguate sub-types.
+ *
+ * Priority for multiple keys is already encoded in the event type by the parser
+ * (stateId > assigneeId > priority), so the event type is the primary discriminator here.
+ */
+export function summarizeLinearEvent(
+  eventType: string,
+  ticket: string | undefined,
+  updatedFromKeys: string[],
+): string {
+  const prefix = ticket ? `${ticket}: ` : "";
+
+  switch (eventType) {
+    case "linear.issue.state_changed": {
+      if (updatedFromKeys.includes("startedAt")) return `${prefix}started`;
+      if (updatedFromKeys.includes("completedAt")) return `${prefix}completed`;
+      if (updatedFromKeys.includes("canceledAt")) return `${prefix}canceled`;
+      return `${prefix}state changed`;
+    }
+    case "linear.issue.assignee_changed":
+      return `${prefix}reassigned`;
+    case "linear.issue.priority_changed":
+      return `${prefix}priority changed`;
+    case "linear.issue.updated": {
+      if (updatedFromKeys.includes("title")) return `${prefix}title changed`;
+      if (updatedFromKeys.includes("estimate")) return `${prefix}estimate changed`;
+      return `${prefix}updated`;
+    }
+    case "linear.issue.created":
+      return `${prefix}created`;
+    case "linear.issue.removed":
+      return `${prefix}removed`;
+    default:
+      if (eventType.startsWith("linear.issue_label.")) return "label updated";
+      return `${prefix}${eventType.slice("linear.".length)}`.trim();
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/activity-event-row.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/activity-event-row.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import type { ActivityEvent } from "@/hooks/use-activity";
+import { summarizeLinearEvent } from "../../../lib/summarize-linear-event";
 
 function repoBasename(repo: string): string {
   const slash = repo.lastIndexOf("/");
@@ -128,33 +129,19 @@ function summarize(e: ActivityEvent): string {
     return `review ${verb} on PR #${scope.pr ?? "?"}`;
   }
   // Linear
-  if (e.event === "linear.issue.state_changed") {
-    const updatedFromKeys = (detail as { updatedFromKeys?: string[] }).updatedFromKeys ?? [];
-    const ticket = scope.ticket ?? (detail as { ticket?: string }).ticket ?? "";
-    if (updatedFromKeys.length > 0) {
-      return `${updatedFromKeys.join(", ")} changed${ticket ? " · " + ticket : ""}`;
-    }
-    const fromV = (detail as { from?: string }).from ?? "?";
-    const toV = (detail as { to?: string }).to ?? "?";
-    return `${ticket ? ticket + ": " : ""}${fromV} → ${toV}`;
-  }
   if (e.event.startsWith("linear.comment.")) {
     const action = e.event.slice("linear.comment.".length);
     const ticket = scope.ticket ?? (detail as { ticket?: string }).ticket ?? "";
     if (action === "created") return `new comment${ticket ? " · " + ticket : ""}`;
     return `comment ${action}${ticket ? " · " + ticket : ""}`;
   }
-  if (e.event.startsWith("linear.issue_label.")) {
-    return "label updated";
-  }
   if (e.event.startsWith("linear.cycle.")) {
     const action = e.event.slice("linear.cycle.".length);
     return `cycle ${action}`;
   }
-  if (e.event.startsWith("linear.issue.")) {
-    const action = e.event.slice("linear.issue.".length);
-    const ticket = scope.ticket ?? (detail as { ticket?: string }).ticket ?? "";
-    return `issue ${action}${ticket ? " · " + ticket : ""}`;
+  if (e.event.startsWith("linear.issue.") || e.event.startsWith("linear.issue_label.")) {
+    const keys = (detail as { updatedFromKeys?: string[] }).updatedFromKeys ?? [];
+    return summarizeLinearEvent(e.event, scope.ticket, keys);
   }
   if (e.event.startsWith("linear.")) {
     return `${scope.ticket ?? ""} ${e.event.slice("linear.".length)}`.trim();


### PR DESCRIPTION
## Summary

- Replaces broken `linear.issue.*` summarization in `activity-event-row.tsx` that always displayed `"CTL-X: ? → ?"` (read non-existent `detail.from`/`detail.to` fields)
- Reads `detail.updatedFromKeys` to produce one-line human-readable descriptions for all Linear issue event types
- Extracts logic to `lib/summarize-linear-event.ts` for testability; 18 unit tests cover all acceptance criteria

## Changes

**`lib/summarize-linear-event.ts`** (new) — pure function `summarizeLinearEvent(eventType, ticket, updatedFromKeys)`:
- `state_changed` + `startedAt`/`completedAt`/`canceledAt` → "started" / "completed" / "canceled"
- `state_changed` (other) → "state changed"
- `assignee_changed` → "reassigned"
- `priority_changed` → "priority changed"
- `updated` + `title`/`estimate` → "title changed" / "estimate changed"
- `updated` (other) → "updated"
- `issue_label.*` → "label updated"
- Unknown suffix → raw fallback

**`activity-event-row.tsx`** — replaces the `linear.issue.*` and `linear.issue.state_changed` branches; keeps HEAD's `linear.comment.*` and `linear.cycle.*` handlers unchanged.

**`__tests__/summarize-linear-event.test.ts`** — 18 tests covering all acceptance criteria from the ticket.

## Test plan

- [x] 18 unit tests pass: `bun test __tests__/summarize-linear-event.test.ts`
- [x] UI builds cleanly: `bun run build` in `ui/`
- [x] No new TypeScript errors in `ui/tsconfig.json`
- [x] Rebased onto main with conflict resolved

Refs: CTL-281