### PR TITLE
feat(dev): per-team Linear webhook secrets + fix pre-existing bugs (CTL-285)

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-linear-webhook-layer2.test.sh
@@ -48,12 +48,13 @@ make_test_env() {
   mkdir -p "${dir}/project/.catalyst"
   mkdir -p "${dir}/stubbin"
 
-  # Layer 1 config: projectKey + teamId
+  # Layer 1 config: projectKey + teamKey + teamId
   cat > "${dir}/project/.catalyst/config.json" <<'EOF'
 {
   "catalyst": {
     "projectKey": "test-project",
     "linear": {
+      "teamKey": "TEST",
       "teamId": "11111111-2222-3333-4444-555555555555"
     }
   }
@@ -231,10 +232,13 @@ test_register_writes_layer2_record() {
 
   local rec; rec=$(read_layer2 "$env")
   [[ -n "$rec" ]] || { echo "Layer 2 record missing"; return 1; }
-  local id; id=$(printf '%s' "$rec" | jq -r '.webhookId')
-  local url; url=$(printf '%s' "$rec" | jq -r '.smeeChannel')
-  local ts; ts=$(printf '%s' "$rec" | jq -r '.registeredAt')
-  local rt; rt=$(printf '%s' "$rec" | jq -c '.resourceTypes')
+  # After CTL-285 the record is stored under the team key ("test" = lowercase "TEST")
+  local entry; entry=$(printf '%s' "$rec" | jq -c '."test" // empty')
+  [[ -n "$entry" ]] || { echo "Layer 2 keyed entry missing (expected key \"test\")"; return 1; }
+  local id; id=$(printf '%s' "$entry" | jq -r '.webhookId')
+  local url; url=$(printf '%s' "$entry" | jq -r '.smeeChannel')
+  local ts; ts=$(printf '%s' "$entry" | jq -r '.registeredAt')
+  local rt; rt=$(printf '%s' "$entry" | jq -c '.resourceTypes')
   expect_eq "webhookId" "w1" "$id" || return 1
   expect_eq "smeeChannel" "https://foo.test/api/webhook/linear" "$url" || return 1
   # ISO-8601 UTC timestamp shape
@@ -243,23 +247,28 @@ test_register_writes_layer2_record() {
   fi
   expect_eq "resourceTypes" '["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]' "$rt" || return 1
   # Legacy field must NOT be written by the new code path.
-  local has_legacy; has_legacy=$(printf '%s' "$rec" | jq 'has("webhookUrl")')
+  local has_legacy; has_legacy=$(printf '%s' "$entry" | jq 'has("webhookUrl")')
   expect_eq "no legacy webhookUrl" "false" "$has_legacy" || return 1
+  # Secret file written with team key suffix
+  local secret_path="${env}/home/.config/catalyst/linear-webhook-secret-test"
+  [[ -f "$secret_path" ]] || { echo "per-team secret file not found: $secret_path"; return 1; }
 }
 
 # ─── Test 2 — idempotent re-run with same URL: no API call ─────────────────
 test_idempotent_rerun_no_api_call() {
   local env; env=$(make_test_env t2)
-  # Pre-seed Layer 2 record.
+  # Pre-seed Layer 2 record in keyed format (team key "test" = lowercase "TEST").
   cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
 {
   "catalyst": {
     "monitor": {
       "linear": {
-        "webhookId": "w1",
-        "smeeChannel": "https://foo.test/api/webhook/linear",
-        "registeredAt": "2026-05-04T20:00:00Z",
-        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        "test": {
+          "webhookId": "w1",
+          "smeeChannel": "https://foo.test/api/webhook/linear",
+          "registeredAt": "2026-05-04T20:00:00Z",
+          "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        }
       }
     }
   }
@@ -272,7 +281,7 @@ EOF
   expect_eq "total curl calls" "0" "$n" || return 1
 
   # Layer 2 record unchanged — webhookId still w1.
-  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  local id; id=$(read_layer2 "$env" | jq -r '."test".webhookId')
   expect_eq "record unchanged" "w1" "$id" || return 1
 }
 
@@ -284,10 +293,12 @@ test_rerun_different_url_errors_without_force() {
   "catalyst": {
     "monitor": {
       "linear": {
-        "webhookId": "w1",
-        "smeeChannel": "https://foo.test/api/webhook/linear",
-        "registeredAt": "2026-05-04T20:00:00Z",
-        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        "test": {
+          "webhookId": "w1",
+          "smeeChannel": "https://foo.test/api/webhook/linear",
+          "registeredAt": "2026-05-04T20:00:00Z",
+          "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        }
       }
     }
   }
@@ -300,7 +311,7 @@ EOF
     return 1
   fi
   # Record must be unchanged.
-  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  local id; id=$(read_layer2 "$env" | jq -r '."test".webhookId')
   expect_eq "record unchanged" "w1" "$id" || return 1
   # No Linear API call should happen.
   local n; n=$(total_calls "$env")
@@ -315,10 +326,12 @@ test_force_overwrites_layer2_record() {
   "catalyst": {
     "monitor": {
       "linear": {
-        "webhookId": "w1",
-        "smeeChannel": "https://foo.test/api/webhook/linear",
-        "registeredAt": "2026-05-04T20:00:00Z",
-        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        "test": {
+          "webhookId": "w1",
+          "smeeChannel": "https://foo.test/api/webhook/linear",
+          "registeredAt": "2026-05-04T20:00:00Z",
+          "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        }
       }
     }
   }
@@ -332,8 +345,8 @@ EOF
   run_helper "$env" --webhook-url "https://bar.test/api/webhook/linear" --force \
     >/dev/null 2>&1 || return 1
 
-  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
-  local url; url=$(read_layer2 "$env" | jq -r '.smeeChannel')
+  local id; id=$(read_layer2 "$env" | jq -r '."test".webhookId')
+  local url; url=$(read_layer2 "$env" | jq -r '."test".smeeChannel')
   expect_eq "webhookId now w2" "w2" "$id" || return 1
   expect_eq "smeeChannel now bar" "https://bar.test/api/webhook/linear" "$url" || return 1
 
@@ -346,22 +359,25 @@ EOF
 # ─── Test 5 — --deregister uses Layer 2 ID and clears record ───────────────
 test_deregister_uses_layer2_id() {
   local env; env=$(make_test_env t5)
+  # Pre-seed keyed Layer 2 record (team key "test" = lowercase "TEST").
   cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
 {
   "catalyst": {
     "monitor": {
       "linear": {
-        "webhookId": "w1",
-        "smeeChannel": "https://foo.test/api/webhook/linear",
-        "registeredAt": "2026-05-04T20:00:00Z",
-        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        "test": {
+          "webhookId": "w1",
+          "smeeChannel": "https://foo.test/api/webhook/linear",
+          "registeredAt": "2026-05-04T20:00:00Z",
+          "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        }
       }
     }
   }
 }
 EOF
-  # Pre-seed the secret file so we can verify it's removed.
-  echo "old_secret" > "${env}/home/.config/catalyst/linear-webhook-secret"
+  # Pre-seed the per-team secret file so we can verify it's removed.
+  echo "old_secret" > "${env}/home/.config/catalyst/linear-webhook-secret-test"
 
   local DEL_RESP="${env}/del.json"
   write_response_delete_success "$DEL_RESP"
@@ -370,11 +386,12 @@ EOF
 
   # Layer 2 record cleared.
   local rec; rec=$(read_layer2 "$env")
-  [[ -z "$rec" || "$rec" == "null" ]] || { echo "Layer 2 record not cleared: $rec"; return 1; }
+  local entry; entry=$(printf '%s' "$rec" | jq -c '."test" // empty' 2>/dev/null)
+  [[ -z "$entry" ]] || { echo "Layer 2 \"test\" entry not cleared: $entry"; return 1; }
 
-  # Secret file removed.
-  if [[ -f "${env}/home/.config/catalyst/linear-webhook-secret" ]]; then
-    echo "linear-webhook-secret should be removed"
+  # Per-team secret file removed.
+  if [[ -f "${env}/home/.config/catalyst/linear-webhook-secret-test" ]]; then
+    echo "linear-webhook-secret-test should be removed"
     return 1
   fi
 
@@ -407,8 +424,8 @@ test_register_falls_back_to_api_when_layer2_missing() {
   run_helper "$env" --webhook-url "https://foo.test/api/webhook/linear" \
     >/dev/null 2>&1 || return 1
 
-  # Layer 2 record now populated.
-  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  # Layer 2 record now populated under the team key "test".
+  local id; id=$(read_layer2 "$env" | jq -r '."test".webhookId')
   expect_eq "webhookId" "w1" "$id" || return 1
 
   # API was called: list + create (no Layer 2 short-circuit available).
@@ -430,15 +447,15 @@ test_register_falls_back_to_api_dedup_when_layer2_missing() {
   expect_eq "create count" "0" "$(count_calls "$env" create)" || return 1
   expect_eq "delete count" "0" "$(count_calls "$env" delete)" || return 1
 
-  # Layer 2 record written with the discovered ID; resourceTypes omitted
-  # because we couldn't observe them from a list response.
+  # Layer 2 record written with the discovered ID under the team key "test";
+  # resourceTypes omitted because we couldn't observe them from a list response.
   local rec; rec=$(read_layer2 "$env")
-  local id; id=$(printf '%s' "$rec" | jq -r '.webhookId')
-  local url; url=$(printf '%s' "$rec" | jq -r '.smeeChannel')
+  local id; id=$(printf '%s' "$rec" | jq -r '."test".webhookId')
+  local url; url=$(printf '%s' "$rec" | jq -r '."test".smeeChannel')
   expect_eq "webhookId from list" "wOld" "$id" || return 1
   expect_eq "smeeChannel from list" "https://foo.test/api/webhook/linear" "$url" || return 1
   # resourceTypes should be absent (we don't fabricate them).
-  local has_rt; has_rt=$(printf '%s' "$rec" | jq 'has("resourceTypes")')
+  local has_rt; has_rt=$(printf '%s' "$rec" | jq '."test" | has("resourceTypes")')
   expect_eq "resourceTypes absent" "false" "$has_rt" || return 1
 }
 
@@ -451,15 +468,18 @@ test_register_falls_back_to_api_dedup_when_layer2_missing() {
 #      have nothing new to write — keeps the no-API-call invariant simple)
 test_legacy_webhookurl_record_short_circuits() {
   local env; env=$(make_test_env t9)
+  # Pre-seed keyed format with legacy `webhookUrl` field (CTL-274 back-compat).
   cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
 {
   "catalyst": {
     "monitor": {
       "linear": {
-        "webhookId": "wLegacy",
-        "webhookUrl": "https://foo.test/api/webhook/linear",
-        "registeredAt": "2026-05-01T00:00:00Z",
-        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        "test": {
+          "webhookId": "wLegacy",
+          "webhookUrl": "https://foo.test/api/webhook/linear",
+          "registeredAt": "2026-05-01T00:00:00Z",
+          "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        }
       }
     }
   }
@@ -472,7 +492,7 @@ EOF
   expect_eq "total curl calls" "0" "$n" || return 1
 
   # Record retains the legacy webhookId — short-circuit didn't rewrite.
-  local id; id=$(read_layer2 "$env" | jq -r '.webhookId')
+  local id; id=$(read_layer2 "$env" | jq -r '."test".webhookId')
   expect_eq "webhookId preserved" "wLegacy" "$id" || return 1
 }
 
@@ -481,15 +501,18 @@ EOF
 # write `smeeChannel` AND drop the legacy `webhookUrl` field.
 test_legacy_webhookurl_record_migrates_on_force() {
   local env; env=$(make_test_env t10)
+  # Pre-seed keyed format with legacy `webhookUrl` field (CTL-274 back-compat).
   cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
 {
   "catalyst": {
     "monitor": {
       "linear": {
-        "webhookId": "wLegacy",
-        "webhookUrl": "https://foo.test/api/webhook/linear",
-        "registeredAt": "2026-05-01T00:00:00Z",
-        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        "test": {
+          "webhookId": "wLegacy",
+          "webhookUrl": "https://foo.test/api/webhook/linear",
+          "registeredAt": "2026-05-01T00:00:00Z",
+          "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        }
       }
     }
   }
@@ -504,11 +527,11 @@ EOF
     >/dev/null 2>&1 || return 1
 
   local rec; rec=$(read_layer2 "$env")
-  local has_legacy; has_legacy=$(printf '%s' "$rec" | jq 'has("webhookUrl")')
-  local has_canonical; has_canonical=$(printf '%s' "$rec" | jq 'has("smeeChannel")')
+  local has_legacy; has_legacy=$(printf '%s' "$rec" | jq '."test" | has("webhookUrl")')
+  local has_canonical; has_canonical=$(printf '%s' "$rec" | jq '."test" | has("smeeChannel")')
   expect_eq "legacy webhookUrl removed" "false" "$has_legacy" || return 1
   expect_eq "canonical smeeChannel present" "true" "$has_canonical" || return 1
-  local url; url=$(printf '%s' "$rec" | jq -r '.smeeChannel')
+  local url; url=$(printf '%s' "$rec" | jq -r '."test".smeeChannel')
   expect_eq "smeeChannel value" "https://foo.test/api/webhook/linear" "$url" || return 1
 }
 
@@ -517,21 +540,24 @@ EOF
 # stored ID and clear both legacy and canonical keys from the record.
 test_legacy_webhookurl_record_deregisters() {
   local env; env=$(make_test_env t11)
+  # Pre-seed keyed format with legacy `webhookUrl` field (CTL-274 back-compat).
   cat > "${env}/home/.config/catalyst/config.json" <<'EOF'
 {
   "catalyst": {
     "monitor": {
       "linear": {
-        "webhookId": "wLegacy",
-        "webhookUrl": "https://foo.test/api/webhook/linear",
-        "registeredAt": "2026-05-01T00:00:00Z",
-        "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        "test": {
+          "webhookId": "wLegacy",
+          "webhookUrl": "https://foo.test/api/webhook/linear",
+          "registeredAt": "2026-05-01T00:00:00Z",
+          "resourceTypes": ["Issue","Comment","IssueLabel","Cycle","Reaction","Project"]
+        }
       }
     }
   }
 }
 EOF
-  echo "old_secret" > "${env}/home/.config/catalyst/linear-webhook-secret"
+  echo "old_secret" > "${env}/home/.config/catalyst/linear-webhook-secret-test"
 
   local DEL_RESP="${env}/del.json"
   write_response_delete_success "$DEL_RESP"

--- a/plugins/dev/scripts/__tests__/setup-linear-webhook.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-linear-webhook.test.sh
@@ -180,8 +180,8 @@ test_fresh_registration() {
     return 1
   }
 
-  # Secret persisted at ~/.config/catalyst/linear-webhook-secret
-  local secret_path="${env}/home/.config/catalyst/linear-webhook-secret"
+  # Secret persisted at ~/.config/catalyst/linear-webhook-secret-{teamKeyLower}
+  local secret_path="${env}/home/.config/catalyst/linear-webhook-secret-test"
   if [[ ! -f "$secret_path" ]]; then
     echo "secret file not created at $secret_path" >&2
     return 1
@@ -396,7 +396,7 @@ test_secret_file_mode_is_600() {
   run_helper "$env" --webhook-url https://example.com/api/webhook/linear \
     > /dev/null 2>&1
 
-  local secret_path="${env}/home/.config/catalyst/linear-webhook-secret"
+  local secret_path="${env}/home/.config/catalyst/linear-webhook-secret-test"
   if [[ ! -f "$secret_path" ]]; then
     echo "secret file not created" >&2
     return 1
@@ -454,19 +454,77 @@ test_webhook_url_required() {
   fi
 }
 
-# ─── Test 12 — export-line printed on stdout ────────────────────────────────
+# ─── Test 12 — missing catalyst.linear.teamKey in Layer 1 ──────────────────
+test_missing_team_key() {
+  local env; env=$(make_test_env t12a)
+  cat > "${env}/project/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "test-project",
+    "linear": { "teamId": "00000000-0000-0000-0000-000000000001" }
+  }
+}
+EOF
+  cat > "${env}/home/.config/catalyst/config-test-project.json" <<'EOF'
+{ "linear": { "apiToken": "lin_api_test" } }
+EOF
+
+  if run_helper "$env" --webhook-url https://example.com/api/webhook/linear \
+      > "${SCRATCH}/t12a.out" 2>&1; then
+    echo "expected non-zero exit when teamKey missing" >&2
+    cat "${SCRATCH}/t12a.out" >&2
+    return 1
+  fi
+
+  if ! grep -qi "teamKey\|resolve-linear-ids" "${SCRATCH}/t12a.out"; then
+    echo "error should mention teamKey" >&2
+    cat "${SCRATCH}/t12a.out" >&2
+    return 1
+  fi
+}
+
+# ─── Test 13 — --all-public-teams uses flat linear-webhook-secret ────────────
+test_all_public_teams_uses_flat_secret() {
+  local env; env=$(make_test_env t13)
+  seed_configs "$env"
+  fixture_empty_list "$env"
+  fixture_create_success "$env"
+
+  run_helper "$env" --all-public-teams \
+    --webhook-url https://example.com/api/webhook/linear \
+    > "${SCRATCH}/t13.out" 2>&1 || {
+    echo "expected --all-public-teams to succeed" >&2
+    cat "${SCRATCH}/t13.out" >&2
+    return 1
+  }
+
+  # Workspace webhook: secret must be at the flat path (no team-key suffix).
+  local flat_path="${env}/home/.config/catalyst/linear-webhook-secret"
+  if [[ ! -f "$flat_path" ]]; then
+    echo "expected flat linear-webhook-secret for --all-public-teams, not found" >&2
+    return 1
+  fi
+
+  # Per-team path must NOT exist for --all-public-teams.
+  if [[ -f "${env}/home/.config/catalyst/linear-webhook-secret-test" ]]; then
+    echo "--all-public-teams should not create a team-specific secret file" >&2
+    return 1
+  fi
+}
+
+# ─── Test 14 — export-line printed on stdout ────────────────────────────────
 test_export_line_printed() {
-  local env; env=$(make_test_env t12)
+  local env; env=$(make_test_env t14)
   seed_configs "$env"
   fixture_empty_list "$env"
   fixture_create_success "$env"
 
   run_helper "$env" --webhook-url https://example.com/api/webhook/linear \
-    > "${SCRATCH}/t12.out" 2>&1
+    > "${SCRATCH}/t14.out" 2>&1
 
-  if ! grep -q "export CATALYST_LINEAR_WEBHOOK_SECRET=" "${SCRATCH}/t12.out"; then
+  if ! grep -q "export CATALYST_LINEAR_WEBHOOK_SECRET=" "${SCRATCH}/t14.out"; then
     echo "expected export CATALYST_LINEAR_WEBHOOK_SECRET=... line on stdout" >&2
-    cat "${SCRATCH}/t12.out" >&2
+    cat "${SCRATCH}/t14.out" >&2
     return 1
   fi
 }
@@ -484,6 +542,8 @@ run "GraphQL error response surfaces" test_graphql_error_response
 run "secret file mode is 600" test_secret_file_mode_is_600
 run "resourceTypes match canonical 6" test_resource_types_canonical
 run "--webhook-url is required" test_webhook_url_required
+run "missing catalyst.linear.teamKey errors clearly" test_missing_team_key
+run "--all-public-teams uses flat linear-webhook-secret" test_all_public_teams_uses_flat_secret
 run "export line printed on stdout" test_export_line_printed
 
 echo

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -803,3 +803,183 @@ describe("loadWebhookConfig — linearSmeeChannel (CTL-242)", () => {
     expect(cfg!.linearBotUserId).toBe("");
   });
 });
+
+describe("loadWebhookConfig — per-team secret files (CTL-285)", () => {
+  it("reads linearSecret from per-team file when file exists", () => {
+    writeFileSync(join(homeDir, "linear-webhook-secret-ctl"), "file-secret-ctl\n");
+    writeHome({
+      catalyst: {
+        monitor: {
+          linear: {
+            ctl: { webhookId: "linear-webhook-123" },
+          },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "MY_LINEAR_SECRET" },
+        },
+      },
+    });
+    process.env.MY_LINEAR_SECRET = "env-fallback-should-not-be-used";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearSecrets).toEqual([{ key: "ctl", secret: "file-secret-ctl" }]);
+
+    delete process.env.MY_LINEAR_SECRET;
+  });
+
+  it("falls back to env var when per-team file does not exist", () => {
+    writeHome({
+      catalyst: {
+        monitor: {
+          linear: {
+            ctl: { webhookId: "linear-webhook-123" },
+          },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "CATALYST_LINEAR_WEBHOOK_SECRET" },
+        },
+      },
+    });
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "env-secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSecrets).toEqual([{ key: "ctl", secret: "env-secret" }]);
+  });
+
+  it("reads workspace secret from linear-webhook-secret file for workspace key", () => {
+    writeFileSync(join(homeDir, "linear-webhook-secret"), "workspace-file-secret\n");
+    writeHome({
+      catalyst: {
+        monitor: {
+          linear: {
+            workspace: { webhookId: "linear-webhook-456" },
+          },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "MY_LINEAR_SECRET" },
+        },
+      },
+    });
+    process.env.MY_LINEAR_SECRET = "env-fallback-should-not-be-used";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSecrets).toEqual([{ key: "workspace", secret: "workspace-file-secret" }]);
+
+    delete process.env.MY_LINEAR_SECRET;
+  });
+
+  it("reads legacy single-object secret from linear-webhook-secret file", () => {
+    writeFileSync(join(homeDir, "linear-webhook-secret"), "legacy-file-secret\n");
+    writeHome({
+      catalyst: {
+        monitor: {
+          linear: { webhookId: "linear-webhook-legacy" },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "MY_LINEAR_SECRET" },
+        },
+      },
+    });
+    process.env.MY_LINEAR_SECRET = "env-should-not-be-used";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSecrets).toEqual([{ key: "workspace", secret: "legacy-file-secret" }]);
+
+    delete process.env.MY_LINEAR_SECRET;
+  });
+
+  it("trims trailing newlines from file-based secrets", () => {
+    writeFileSync(join(homeDir, "linear-webhook-secret-adv"), "secret-with-newline\n");
+    writeHome({
+      catalyst: {
+        monitor: {
+          linear: { adv: { webhookId: "adv-webhook-123" } },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "CATALYST_LINEAR_WEBHOOK_SECRET" },
+        },
+      },
+    });
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSecrets).toEqual([{ key: "adv", secret: "secret-with-newline" }]);
+  });
+
+  it("prefers file over env var when both are present", () => {
+    writeFileSync(join(homeDir, "linear-webhook-secret-ctl"), "file-wins\n");
+    writeHome({
+      catalyst: {
+        monitor: {
+          linear: { ctl: { webhookId: "ctl-webhook-id" } },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "CATALYST_LINEAR_WEBHOOK_SECRET" },
+        },
+      },
+    });
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "env-loses";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSecrets).toEqual([{ key: "ctl", secret: "file-wins" }]);
+  });
+
+  it("handles multiple teams each with their own secret files", () => {
+    writeFileSync(join(homeDir, "linear-webhook-secret-adv"), "adv-secret\n");
+    writeFileSync(join(homeDir, "linear-webhook-secret-ctl"), "ctl-secret\n");
+    writeHome({
+      catalyst: {
+        monitor: {
+          linear: {
+            adv: { webhookId: "adv-webhook-id" },
+            ctl: { webhookId: "ctl-webhook-id" },
+          },
+        },
+      },
+    });
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: { webhookSecretEnv: "CATALYST_LINEAR_WEBHOOK_SECRET" },
+        },
+      },
+    });
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "shared-fallback";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSecrets).toHaveLength(2);
+    expect(cfg!.linearSecrets).toContainEqual({ key: "adv", secret: "adv-secret" });
+    expect(cfg!.linearSecrets).toContainEqual({ key: "ctl", secret: "ctl-secret" });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -13,11 +13,14 @@ export interface WebhookCliConfig {
    */
   watchRepos: string[];
   /**
-   * Linear webhook signing secrets (CTL-273). Array of {key, secret} pairs,
-   * where key is "workspace" or a team UUID, and secret is the HMAC signing secret.
-   * Resolved from `catalyst.monitor.linear.webhookSecretEnv` env-var name in
-   * Layer 1, with fallback to `CATALYST_LINEAR_WEBHOOK_SECRET`. Empty array
-   * when no Linear config is present — the server then disables
+   * Linear webhook signing secrets (CTL-273, CTL-285). Array of {key, secret} pairs,
+   * where key is "workspace" or a team short key (e.g. "ctl", "adv"), and secret is
+   * the HMAC signing secret. Resolution order per key (CTL-285):
+   *   1. `~/.config/catalyst/linear-webhook-secret-{key}` (per-team file, mode 600)
+   *      — for "workspace" key, reads `linear-webhook-secret` (no suffix)
+   *   2. `process.env[linearWebhookSecretEnv]` from Layer 1 env-var name
+   *   3. `process.env.CATALYST_LINEAR_WEBHOOK_SECRET` (fallback)
+   * Empty array when no Linear config is present — the server then disables
    * `POST /api/webhook/linear`. The handler tries each secret in order until
    * one validates, supporting both workspace-wide and per-team webhooks.
    * CTL-210.
@@ -91,17 +94,49 @@ function readWatchRepos(github: Record<string, unknown>): string[] {
 // Backward compatibility: If catalyst.monitor.linear is a single object,
 // treat it as "workspace" key.
 //
+// Secret resolution order per key (CTL-285):
+//   1. Per-team file: ~/.config/catalyst/linear-webhook-secret-{key}
+//      (for "workspace" key: linear-webhook-secret, no suffix)
+//   2. Env var named by linearWebhookSecretEnv from Layer 1
+//   3. CATALYST_LINEAR_WEBHOOK_SECRET env var fallback
+//
 // Arguments:
 //   linear: the catalyst.monitor.linear object/dict from Layer 2
 //   linearWebhookSecretEnv: env-var name from Layer 1 (optional)
+//   homeConfigDir: path to ~/.config/catalyst/ for per-team secret files
 //
 // Returns: array of {key, secret} pairs
 function readAllLinearSecrets(
   linear: unknown,
   linearWebhookSecretEnv: string | null,
+  homeConfigDir: string,
 ): Array<{ key: string; secret: string }> {
   if (!isRecord(linear)) return [];
   const out: Array<{ key: string; secret: string }> = [];
+
+  const readSecretFile = (fileName: string): string => {
+    try {
+      return readFileSync(join(homeConfigDir, fileName), "utf8").trim();
+    } catch {
+      return "";
+    }
+  };
+
+  const resolveSecret = (key: string): string => {
+    const fileName =
+      key === "workspace"
+        ? "linear-webhook-secret"
+        : `linear-webhook-secret-${key}`;
+    const fileSecret = readSecretFile(fileName);
+    if (fileSecret.length > 0) return fileSecret;
+    return (
+      (linearWebhookSecretEnv !== null
+        ? process.env[linearWebhookSecretEnv]
+        : undefined) ??
+      process.env.CATALYST_LINEAR_WEBHOOK_SECRET ??
+      ""
+    );
+  };
 
   // Check if this is the old single-object format
   const isSingleObject =
@@ -110,12 +145,7 @@ function readAllLinearSecrets(
 
   if (isSingleObject) {
     // Legacy single-object format — treat as "workspace" key
-    const secret =
-      (linearWebhookSecretEnv !== null
-        ? process.env[linearWebhookSecretEnv]
-        : undefined) ??
-      process.env.CATALYST_LINEAR_WEBHOOK_SECRET ??
-      "";
+    const secret = resolveSecret("workspace");
     if (secret.length > 0) {
       out.push({ key: "workspace", secret });
     }
@@ -130,14 +160,7 @@ function readAllLinearSecrets(
     if (typeof entry.webhookId !== "string" || entry.webhookId.length === 0)
       continue;
 
-    // For now, all webhooks use the same secret env-var from Layer 1.
-    // In the future, per-team secrets could be stored in Layer 1.
-    const secret =
-      (linearWebhookSecretEnv !== null
-        ? process.env[linearWebhookSecretEnv]
-        : undefined) ??
-      process.env.CATALYST_LINEAR_WEBHOOK_SECRET ??
-      "";
+    const secret = resolveSecret(key);
     if (secret.length > 0) {
       out.push({ key, secret });
     }
@@ -267,13 +290,10 @@ export function loadWebhookConfig(
   let homeLinearConfig: unknown;
   try {
     const homeConfigRaw = readFileSync(join(homeConfigDir, "config.json"), "utf8");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const homeConfigParsed = JSON.parse(homeConfigRaw) as unknown;
     if (isRecord(homeConfigParsed) && isRecord(homeConfigParsed.catalyst)) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const monitor = homeConfigParsed.catalyst.monitor;
       if (isRecord(monitor)) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         homeLinearConfig = monitor.linear;
       }
     }
@@ -283,6 +303,7 @@ export function loadWebhookConfig(
   const linearSecrets = readAllLinearSecrets(
     homeLinearConfig ?? undefined,
     linearWebhookSecretEnv,
+    homeConfigDir,
   );
 
   // Linear smee channel. Layer 2 only (per-machine) — same split as GitHub

--- a/plugins/dev/scripts/setup-linear-webhook.sh
+++ b/plugins/dev/scripts/setup-linear-webhook.sh
@@ -211,11 +211,8 @@ write_linear_record() {
            (.catalyst.monitor.linear | if type == "object" then . else {} end)
          end) as $linear
        | .catalyst.monitor.linear = ($linear + {
-           ($key): {
-             webhookId: $id,
-             smeeChannel: $url,
-             registeredAt: $ts
-           } + (if ($rt | length) > 0 then {resourceTypes: $rt} else {} end)
+           ($key): ({webhookId: $id, smeeChannel: $url, registeredAt: $ts}
+                    | if ($rt | length) > 0 then .resourceTypes = $rt else . end)
          })
      ' "$HOME_CONFIG_PATH" > "$tmp"
   mv "$tmp" "$HOME_CONFIG_PATH"
@@ -359,15 +356,16 @@ delete_via_graphql() {
 if [[ $DEREGISTER -eq 1 ]]; then
   DEREGISTER_KEY="workspace"
   if [[ $ALL_PUBLIC_TEAMS -eq 0 ]]; then
-    # Deregister per-team webhook — need teamId
-    TEAM_ID=$(jq -r '.catalyst.linear.teamId // empty' "$CONFIG_PATH" 2>/dev/null)
-    if [[ -z "$TEAM_ID" ]]; then
-      echo "ERROR: catalyst.linear.teamId not set in $CONFIG_PATH" >&2
+    # Deregister per-team webhook — need teamKey (lowercase = Layer 2 record key)
+    TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CONFIG_PATH" 2>/dev/null)
+    if [[ -z "$TEAM_KEY" ]]; then
+      echo "ERROR: catalyst.linear.teamKey not set in $CONFIG_PATH" >&2
       echo "       To deregister a per-team webhook, set it first." >&2
       echo "       To deregister the workspace webhook, use: $0 --deregister --all-public-teams" >&2
       exit 1
     fi
-    DEREGISTER_KEY="$TEAM_ID"
+    DEREGISTER_KEY=$(printf '%s' "$TEAM_KEY" | tr '[:upper:]' '[:lower:]')
+    SECRET_FILE="${HOME_CONFIG_DIR}/linear-webhook-secret-${DEREGISTER_KEY}"
   fi
 
   EXISTING_RECORD="$(read_linear_record "$DEREGISTER_KEY")"
@@ -392,15 +390,23 @@ fi
 REGISTER_KEY="workspace"
 TEAM_ID=""
 if [[ $ALL_PUBLIC_TEAMS -eq 0 ]]; then
-  # Per-team webhook — need teamId
+  # Per-team webhook — teamKey (lowercase) is the Layer 2 key; teamId is for the mutation
+  TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CONFIG_PATH" 2>/dev/null)
   TEAM_ID=$(jq -r '.catalyst.linear.teamId // empty' "$CONFIG_PATH" 2>/dev/null)
+  if [[ -z "$TEAM_KEY" ]]; then
+    echo "ERROR: catalyst.linear.teamKey not set in $CONFIG_PATH." >&2
+    echo "       Run plugins/dev/scripts/resolve-linear-ids.sh first to populate it." >&2
+    echo "       Or use --all-public-teams to register a workspace-wide webhook." >&2
+    exit 1
+  fi
   if [[ -z "$TEAM_ID" ]]; then
     echo "ERROR: catalyst.linear.teamId not set in $CONFIG_PATH." >&2
     echo "       Run plugins/dev/scripts/resolve-linear-ids.sh first to populate it." >&2
     echo "       Or use --all-public-teams to register a workspace-wide webhook." >&2
     exit 1
   fi
-  REGISTER_KEY="$TEAM_ID"
+  REGISTER_KEY=$(printf '%s' "$TEAM_KEY" | tr '[:upper:]' '[:lower:]')
+  SECRET_FILE="${HOME_CONFIG_DIR}/linear-webhook-secret-${REGISTER_KEY}"
 fi
 
 # Step 1 (CTL-238): Layer 2 short-circuit. When a record exists we know the
@@ -464,7 +470,7 @@ if [[ "$LAYER2_HANDLED" -eq 0 ]]; then
     # is omitted (we don't fabricate).
     echo "Reusing existing webhook $EXISTING_ID for $WEBHOOK_URL"
     echo "  (use --force to delete and recreate; secret cannot be re-fetched)"
-    write_linear_record "$EXISTING_ID" "$WEBHOOK_URL" "[]"
+    write_linear_record "$REGISTER_KEY" "$EXISTING_ID" "$WEBHOOK_URL" "[]"
     echo "Wrote Layer 2 record (partial — resourceTypes/secret not retrievable from list response)"
     exit 0
   fi

--- a/website/src/content/docs/observability/webhooks.md
+++ b/website/src/content/docs/observability/webhooks.md
@@ -347,7 +347,7 @@ e.g. `linear.issue.state_changed`, `linear.comment.created`.
 | HMAC secret value | env var named above (default fallback `CATALYST_LINEAR_WEBHOOK_SECRET`) | NO (per-developer env) |
 | `smeeChannel` (Linear smee URL) | `catalyst.monitor.linear.smeeChannel` in `~/.config/catalyst/config.json` | NO (per-machine, written by `--linear-register`) |
 | Registration record (`webhookId`, `webhookUrl`, `registeredAt`, `resourceTypes`) | `catalyst.monitor.linear` in `~/.config/catalyst/config.json` | NO (per-machine, written by `--linear-register`) |
-| HMAC secret file | `~/.config/catalyst/linear-webhook-secret` (mode 600, read by `--linear-register` post-create) | NO (per-developer) |
+| HMAC secret file | `~/.config/catalyst/linear-webhook-secret-{teamKey}` for per-team (e.g. `linear-webhook-secret-ctl`), or `~/.config/catalyst/linear-webhook-secret` for workspace-wide webhooks (mode 600, written by `setup-linear-webhook.sh` post-create) | NO (per-developer) |
 
 Run `setup-webhooks.sh --linear-secret-env CATALYST_LINEAR_WEBHOOK_SECRET` to write the
 env-var name to `.catalyst/config.json`. Then `export CATALYST_LINEAR_WEBHOOK_SECRET=<your-secret>`
@@ -366,15 +366,20 @@ GitHub `smeeChannel` write).
   "catalyst": {
     "monitor": {
       "linear": {
-        "webhookId": "abc-123-uuid-from-linear",
-        "webhookUrl": "https://your-tunnel/api/webhook/linear",
-        "registeredAt": "2026-05-04T20:00:00Z",
-        "resourceTypes": ["Issue", "Comment", "IssueLabel", "Cycle", "Reaction", "Project"]
+        "ctl": {
+          "webhookId": "abc-123-uuid-from-linear",
+          "smeeChannel": "https://your-tunnel/api/webhook/linear",
+          "registeredAt": "2026-05-04T20:00:00Z",
+          "resourceTypes": ["Issue", "Comment", "IssueLabel", "Cycle", "Reaction", "Project"]
+        }
       }
     }
   }
 }
 ```
+
+Records are keyed by lowercase team key (`catalyst.linear.teamKey` from Layer 1, lowercased).
+For workspace-wide webhooks (`--all-public-teams`), the key is `"workspace"`.
 
 This is the Linear analogue of `catalyst.monitor.github.smeeChannel` — same Layer 2 file,
 same per-machine semantics. The local record is the source of truth for idempotency on
@@ -432,8 +437,11 @@ The script:
 4. Otherwise, calls `webhookCreate` with `resourceTypes` set to the canonical
    six: `Issue`, `Comment`, `IssueLabel`, `Cycle`, `Reaction`, `Project`.
    `IssueRelation` is intentionally excluded — Linear does not deliver it.
-5. Persists the returned `secret` to `~/.config/catalyst/linear-webhook-secret`
-   (mode 600), mirroring the GitHub-side `~/.config/catalyst/webhook-secret`.
+5. Persists the returned `secret` to `~/.config/catalyst/linear-webhook-secret-{teamKey}`
+   (mode 600, where `{teamKey}` is the lowercase value of `catalyst.linear.teamKey` from
+   Layer 1). For workspace-wide webhooks (`--all-public-teams`), writes to
+   `~/.config/catalyst/linear-webhook-secret` (no suffix), mirroring the GitHub-side
+   `~/.config/catalyst/webhook-secret`.
 6. Writes the registration record (`webhookId`, `webhookUrl`, `registeredAt`,
    `resourceTypes`) to `~/.config/catalyst/config.json` under
    `catalyst.monitor.linear` (CTL-238). Subsequent re-runs short-circuit on
@@ -494,8 +502,10 @@ plugins/dev/scripts/setup-webhooks.sh --linear-deregister
 ```
 
 The script reads `webhookId` from the Layer 2 registration record, calls Linear's
-`webhookDelete`, clears the record, and removes `~/.config/catalyst/linear-webhook-secret`.
-Errors cleanly with a non-zero exit when no Layer 2 record exists (nothing to delete).
+`webhookDelete`, clears the record, and removes
+`~/.config/catalyst/linear-webhook-secret-{teamKey}` (or `linear-webhook-secret` for
+workspace webhooks). Errors cleanly with a non-zero exit when no Layer 2 record exists
+(nothing to delete).
 
 `--linear-deregister` and `--linear-register` are mutually exclusive — pass one or the
 other, not both.


### PR DESCRIPTION
## Summary

- **`webhook-config.ts`**: `readAllLinearSecrets()` reads per-team secret files (`~/.config/catalyst/linear-webhook-secret-{key}`) before falling back to env vars; workspace key still uses flat `linear-webhook-secret`
- **`setup-linear-webhook.sh`**: `REGISTER_KEY`/`DEREGISTER_KEY` now derive from `catalyst.linear.teamKey` (lowercased) instead of UUID `teamId`; `SECRET_FILE` follows the per-team naming convention to match
- **Bug fixes** (pre-existing failures before CTL-285): jq 1.7.x syntax error in `write_linear_record` + wrong arg count in the API-dedup path — both caused 12 test failures on main

## Test plan

- [x] 42 TypeScript tests pass (`bun test __tests__/webhook-config.test.ts`)
- [x] 14 main shell tests pass (`setup-linear-webhook.test.sh`) — includes 2 new tests: missing `teamKey` error + `--all-public-teams` uses flat secret
- [x] 11 layer2 shell tests pass (`setup-linear-webhook-layer2.test.sh`) — all updated for new keyed record format
- [x] Type check: `tsc --noEmit` clean on changed files (pre-existing `ui/briefings.ts` missing-dep error unrelated)
- [x] ESLint: 0 errors (removed stale `eslint-disable` directives that became unnecessary after Phase 2 changes)
- [x] Security review: clean (shell injection, file permissions, input validation all verified)

## Notes

Operational follow-up (not in this PR — requires interactive token):
- Migrate live Layer 2 ADV record to keyed format
- Register OTL/SLI/EVR teams with `setup-linear-webhook.sh`
- Restart orch-monitor after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)