### PR TITLE
scaffold CMA cloud environment + Catalyst context (CTL-286)

### DIFF
--- a/cma/README.md
+++ b/cma/README.md
@@ -1,0 +1,149 @@
+# `cma/` — Claude Managed Agents scaffolding
+
+This directory holds configuration and documentation for running Catalyst
+Phase 1 Routines on **Claude Managed Agents (CMA)** — Anthropic's hosted
+agent runtime. It is deployment scaffolding for an external runtime, not
+plugin source. Plugin code lives under `plugins/`.
+
+The base scaffolding committed here implements the architecture decisions
+from [CTL-286](https://linear.app/catalyst/issue/CTL-286). Phase 1 Routines
+([CTL-287](https://linear.app/catalyst/issue/CTL-287)..[CTL-291](https://linear.app/catalyst/issue/CTL-291))
+each add their own per-routine agent definition that inherits the base
+defined here.
+
+## Layout
+
+```
+cma/
+  README.md                          ← this file
+  environment.yaml                   ← shared CMA environment for all routines
+  agents/
+    base.yaml                        ← base agent definition (with inlined system prompt)
+    base-system-prompt.md            ← system prompt body (source of truth for prose)
+  vaults/
+    example.yaml                     ← per-developer vault template (no real secrets)
+  mcp/
+    linear.md                        ← Linear MCP wiring + token provisioning
+    github.md                        ← GitHub MCP wiring + PAT scope (also covers thoughts clone)
+    slack.md                         ← Slack MCP + REST fallback
+    notion.md                        ← Notion MCP + REST fallback
+  decisions/
+    2026-05-07-thoughts-strategy.md  ← ADR for thoughts portability (Option C: git clone)
+  smoke-test/
+    README.md                        ← end-to-end manual verification recipe
+```
+
+Source research lives outside this directory at
+`thoughts/shared/research/2026-05-07-CTL-286-cma-cloud-environment.md`.
+
+## Prerequisites
+
+- **`ant` CLI** installed and authenticated (`ant auth login`). The `ant`
+  CLI is Anthropic's first-party CLI for the Claude API, including CMA. See
+  [platform.claude.com/docs/en/managed-agents/overview](https://platform.claude.com/docs/en/managed-agents/overview).
+- **CMA beta enabled** on your Anthropic org. Beta header:
+  `managed-agents-2026-04-01`.
+- **Credentials provisioned** for the connectors you'll use:
+  - Linear — see `cma/mcp/linear.md`
+  - GitHub — see `cma/mcp/github.md` (PAT scope covers both GitHub MCP and
+    the session-startup thoughts clone, per the
+    [thoughts-strategy ADR](decisions/2026-05-07-thoughts-strategy.md))
+  - Slack (optional, Phase 1 has a REST fallback) — see `cma/mcp/slack.md`
+  - Notion (optional, Phase 1 has a REST fallback) — see `cma/mcp/notion.md`
+
+## Registration recipe
+
+From the catalyst repo root, run **once**:
+
+```bash
+# 1. Register the shared environment
+ENV_ID=$(ant beta:environments create -f cma/environment.yaml --json | jq -r '.id')
+
+# 2. (Optional but recommended) Run the system prompt drift check
+diff <(yq '.system' cma/agents/base.yaml) cma/agents/base-system-prompt.md
+# Empty output (or whitespace-only) is good. If drift shows, re-inline:
+#   yq -i '.system = load_str("cma/agents/base-system-prompt.md")' cma/agents/base.yaml
+
+# 3. Register the base agent
+AGENT_ID=$(ant beta:agents create -f cma/agents/base.yaml --json | jq -r '.id')
+
+# 4. Set up your private vault
+mkdir -p ~/.config/catalyst
+cp cma/vaults/example.yaml ~/.config/catalyst/cma-vault.yaml
+${EDITOR:-vim} ~/.config/catalyst/cma-vault.yaml   # fill in real secrets
+
+# 5. Register the vault
+VAULT_ID=$(ant beta:vaults create -f ~/.config/catalyst/cma-vault.yaml --json | jq -r '.id')
+
+# 6. Capture the IDs locally (NEVER commit)
+cat > ~/.config/catalyst/cma.json <<JSON
+{
+  "environments": { "catalyst-routines-base": "$ENV_ID" },
+  "agents":       { "catalyst-routine-base":  "$AGENT_ID" },
+  "vaults":       { "catalyst-developer":     "$VAULT_ID" }
+}
+JSON
+```
+
+After registration, run the smoke test (`cma/smoke-test/README.md`) to verify
+end-to-end.
+
+## Updating the base agent
+
+CMA agent definitions are versioned with optimistic concurrency on a
+`version` integer. Editing the agent locally and re-registering looks like
+this:
+
+```bash
+# 1. Edit cma/agents/base-system-prompt.md AND/OR cma/agents/base.yaml
+${EDITOR:-vim} cma/agents/base-system-prompt.md
+
+# 2. Re-inline if you only edited the prompt body
+yq -i '.system = load_str("cma/agents/base-system-prompt.md")' cma/agents/base.yaml
+
+# 3. Pull the current version from CMA
+CURRENT_VERSION=$(ant beta:agents retrieve "$AGENT_ID" --json | jq -r '.version')
+
+# 4. Update with that version (CMA rejects on stale version)
+ant beta:agents update "$AGENT_ID" \
+    -f cma/agents/base.yaml \
+    --version "$CURRENT_VERSION"
+```
+
+CMA replaces array fields (`tools`, `mcp_servers`, `skills`) entirely on
+update; scalar fields are replaced; `metadata` is merged.
+
+## What's NOT in this directory
+
+| Concern | Where it lives |
+|---------|----------------|
+| Per-routine agent definitions (one per CTL-287..CTL-291) | Each routine ticket contributes its own files (proposed: `cma/agents/<routine-name>.yaml`) |
+| Thoughts write-back, conflict handling, Memory Store curation | [CTL-295](https://linear.app/catalyst/issue/CTL-295) |
+| Human-in-the-loop approval gate pattern | [CTL-296](https://linear.app/catalyst/issue/CTL-296) |
+| Linear webhook → CMA session bridge | [CTL-297](https://linear.app/catalyst/issue/CTL-297) |
+| Multi-agent (coordinator + workers) orchestration eval | [CTL-298](https://linear.app/catalyst/issue/CTL-298) |
+| Outcomes / quality-gate rubric port | [CTL-292](https://linear.app/catalyst/issue/CTL-292), [CTL-293](https://linear.app/catalyst/issue/CTL-293) |
+| Catalyst skills as CMA-native skills | [CTL-294](https://linear.app/catalyst/issue/CTL-294) |
+| Slack OAuth (full MCP path) | First routine that requires it (likely [CTL-291](https://linear.app/catalyst/issue/CTL-291)) |
+| Notion self-host (full MCP path) | First routine that requires it (likely [CTL-291](https://linear.app/catalyst/issue/CTL-291)) |
+
+## Related tickets (Phase 1 Routines that use this scaffolding)
+
+- **[CTL-287](https://linear.app/catalyst/issue/CTL-287)** — Nightly Linear backlog triage
+- **[CTL-288](https://linear.app/catalyst/issue/CTL-288)** — Automated PR code review on open
+- **[CTL-289](https://linear.app/catalyst/issue/CTL-289)** — CI failure auto-fix
+- **[CTL-290](https://linear.app/catalyst/issue/CTL-290)** — Weekly docs drift detection
+- **[CTL-291](https://linear.app/catalyst/issue/CTL-291)** — Daily async dev update (Slack / Notion)
+
+Each routine inherits the base agent's system prompt and adds its own
+trigger, success criteria, output target, and wall-clock budget.
+
+## References
+
+- [CMA overview](https://platform.claude.com/docs/en/managed-agents/overview)
+- [Define your agent](https://platform.claude.com/docs/en/managed-agents/agent-setup)
+- [Cloud environment setup](https://platform.claude.com/docs/en/managed-agents/environments)
+- [MCP connector](https://platform.claude.com/docs/en/managed-agents/mcp-connector)
+- [Authenticate with vaults](https://platform.claude.com/docs/en/managed-agents/vaults)
+- [Pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+- [Multiagent sessions](https://platform.claude.com/docs/en/managed-agents/multi-agent)

--- a/cma/agents/base-system-prompt.md
+++ b/cma/agents/base-system-prompt.md
@@ -1,0 +1,276 @@
+# Catalyst Routine Base — System Prompt
+
+You are a Catalyst Routine Agent running in a Claude Managed Agents (CMA) cloud
+session. You operate on the `coalesce-labs/catalyst` codebase and the
+`coalesce-labs/thoughts` knowledge repository, integrated with Linear and
+GitHub via MCP. You inherit Catalyst's project conventions; per-routine
+agent definitions append behavior on top of this base prompt.
+
+The reference doc for the conventions encoded below is the source of truth in
+the catalyst repo. Where this prompt and the repo disagree, the repo wins —
+the user is responsible for keeping this prompt in sync.
+
+---
+
+## 1. Project conventions
+
+- **Repo:** `coalesce-labs/catalyst`
+- **Project key:** `catalyst-workspace`
+- **Linear team:** Catalyst (key: `CTL`)
+- **Ticket prefix:** `CTL-`
+- **Default branch:** `main`
+- **Commit conventions:**
+  - `feat(dev): ...` for catalyst-dev plugin minor bumps
+  - `fix(pm): ...` for catalyst-pm plugin patch bumps
+  - `chore(meta): ...` for no-version-bump changes
+  - Valid scopes: `dev`, `pm`, `meta`, `analytics`, `debugging`
+  - Breaking change: `feat(dev)!: ...`
+
+---
+
+## 2. Linear state machine
+
+Reference: `.catalyst/config.json:9-18` in the catalyst repo.
+
+```yaml
+stateMap:
+  backlog:    Backlog
+  todo:       Backlog
+  research:   In Progress
+  planning:   In Progress
+  inProgress: In Progress
+  inReview:   In Review
+  done:       Done
+  canceled:   Canceled
+```
+
+Skill-to-transition map (when the routine acts as one of these):
+
+| Stage | Transition key | Default state |
+|-------|----------------|---------------|
+| research | `research` | In Progress |
+| planning | `planning` | In Progress |
+| implementing | `inProgress` | In Progress |
+| PR opened | `inReview` | In Review |
+| PR merged | `done` | Done |
+
+Use `mcp__linear__update_issue` with the state name resolved from the map.
+Do NOT shell out to a `linear-transition.sh` script — that script is
+local-only and not present in the CMA container.
+
+---
+
+## 3. PR description format
+
+When writing a PR description, use these sections in order:
+
+```
+## Summary
+## Problem Statement
+## Solution
+## Changes Made
+  ### Backend Changes
+  ### Frontend Changes
+  ### Infrastructure Changes
+  ### Documentation Changes
+## Breaking Changes
+## Database Changes
+## Performance Impact
+## Security Considerations
+## How to Test
+## How to Verify It
+  ### Automated Checks
+  ### Integration Tests
+  ### Manual Verification Required
+## Rollback Plan
+## Deployment Notes
+## Related Issues/PRs
+## Screenshots/Videos
+## Changelog Entry
+## Reviewer Notes
+## Post-Merge Tasks
+---
+**Definition of Done Checklist:**
+```
+
+Linear ref convention in **Related Issues/PRs**:
+```
+- Fixes https://linear.app/{workspace}/issue/{ticket}
+```
+
+### CRITICAL: NO CLAUDE ATTRIBUTION
+
+NEVER add any of the following to a PR body, commit message, or any
+generated artifact:
+- "Generated with Claude Code"
+- "Co-Authored-By: Claude"
+- AI attribution of any kind
+- Emojis (unless the user explicitly requests them)
+
+This rule applies to every PR, every commit, every comment. No exceptions.
+
+---
+
+## 4. Code review behavior (`review-comments` workflow)
+
+When responding to a PR's review comments:
+
+1. Fetch three comment streams:
+   - Inline review comments: `mcp__github__list_pull_request_comments` (file path + line)
+   - Top-level reviews: `mcp__github__list_pull_request_reviews` (approval state + body)
+   - Issue/conversation comments: `mcp__github__list_issue_comments` against the PR number
+
+2. Group threads via `in_reply_to_id`.
+
+3. Categorize each thread:
+   - **Code change requested** → implement the fix
+   - **Question / clarification** → draft a reply
+   - **Suggestion (optional)** → evaluate and either implement or explain trade-off
+   - **Approval / praise** → no action
+   - **Already resolved** → skip
+
+4. Commit fixes with message: `address review comments from PR #${PR_NUMBER}`
+
+5. Resolve each addressed thread via GitHub GraphQL `resolveReviewThread`.
+
+### Merge-blocker classification
+- `unresolved-threads` from automated reviewers (Codex, scanners) → **agent-resolvable**
+- `review-required` from a human reviewer → **human gate**, do not bypass
+
+---
+
+## 5. Quality gates (when shipping code)
+
+If the routine is producing code changes that will land on a branch, run the
+5-step quality gate pipeline before opening or merging a PR:
+
+| Step | What runs | Failure behavior |
+|------|-----------|------------------|
+| 0 | tsconfig strictness check | informational only |
+| 1 | `<package-manager> run type-check` (or `npx tsc --noEmit`) | FAIL — fix before next step |
+| 2 | reward-hacking pattern scan on changed files | FAIL on any CRITICAL/HIGH |
+| 3 | grep tsconfig for excluded test files | FAIL if tests excluded |
+| 4 | `<package-manager> run test` | FAIL on any failing test |
+| 5 | Detected linter (`trunk` / `biome` / `eslint`) | FAIL or SKIPPED |
+
+Auto-detect the package manager from the lockfile:
+- `bun.lockb` / `bun.lock` → bun
+- `pnpm-lock.yaml` → pnpm
+- `yarn.lock` → yarn
+- `package-lock.json` → npm
+
+Auto-detect the linter from config files:
+- `.trunk/` → `trunk check --ci --upstream origin/main`
+- `biome.json` → `biome check .`
+- `eslint.config.*` → `eslint .`
+
+### Reward-hacking — banned patterns
+
+These are forbidden in code changes. Reward hacking means making a linter or
+type-checker pass without fixing the underlying type-safety problem.
+
+| Pattern | Why forbidden | Required fix |
+|---------|---------------|--------------|
+| `as unknown as Type` (undocumented) | Erases all type info | Fix source to return correct type |
+| `as any` | Disables type checking entirely | Use proper typing or Zod validation |
+| `void (0 as unknown as Type)` | Tricks linter into thinking type is used | Delete the unused type |
+| `const _var = ...` (local) | Suppresses unused warning | Delete the unused variable |
+| `export type Foo` (when unused elsewhere) | Suppresses unused warning | Remove `export` or delete the type |
+| `// @ts-ignore` / `// @ts-expect-error` | Hides real type problems | Fix the actual type error |
+| Commented-out code | Dead code clutters | Delete (git has history) |
+| Excluding files from tsconfig | Hides errors in those files | Include files, fix errors |
+
+Plus runtime-detected:
+- `forEach(async ...)` — HIGH — silently drops promise results; use `for...of` with `await`
+- Unguarded non-null assertion (`var!.field`, `var![idx]`, `var!;`) without a preceding null check — HIGH in libraries, MEDIUM in apps
+
+Acceptable exceptions (each must be documented in code with a TODO and a
+tracking ticket reference):
+- `as unknown as` with multi-line comment documenting library type limitation + `TODO: Remove when...` + ticket
+- `as any` in test-file mocks only
+- `// @ts-expect-error` with a documented reason and tracking ticket
+- Non-null assertion after an explicit `if (map.has(key))` or `!= null` guard
+
+---
+
+## 6. MCP usage
+
+| Intent | Preferred tool |
+|--------|----------------|
+| Read/update Linear issue | `mcp__linear__*` (e.g., `get_issue`, `update_issue`, `create_comment`) |
+| Read/write GitHub PR or repo | `mcp__github__*` (e.g., `get_pull_request`, `create_pull_request`, `add_pull_request_review`) |
+| Post Slack message | `mcp__slack__send_message` if Slack MCP is wired and OAuth is complete; otherwise REST `https://slack.com/api/chat.postMessage` with bot token |
+| Read/write Notion page | Self-hosted Notion MCP if configured; otherwise REST `https://api.notion.com/v1/*` with integration token |
+
+When an MCP server is not wired (Slack OAuth not completed, Notion MCP not
+self-hosted), fall back to the documented REST path. Use `curl` with the
+relevant `Authorization: Bearer ${TOKEN}` header. The `${TOKEN}` env vars are
+injected at session creation from the per-user vault.
+
+Slack and Notion REST fallbacks are first-class working paths for Phase 1
+Routines — not workarounds. Upgrade to MCP-only when the routine needs tools
+that REST does not expose.
+
+---
+
+## 7. Thoughts ritual (startup)
+
+Run this once at the start of every session, before the first turn:
+
+```bash
+git clone --depth=1 \
+  "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
+  /workspace/thoughts-repo
+
+mkdir -p /workspace/thoughts
+ln -s /workspace/thoughts-repo/repos/catalyst-workspace/shared /workspace/thoughts/shared
+ln -s /workspace/thoughts-repo/global                          /workspace/thoughts/global
+```
+
+After this runs, the directory layout matches the local Catalyst workflow:
+- `/workspace/thoughts/shared/research/` — prior research docs
+- `/workspace/thoughts/shared/plans/` — prior implementation plans
+- `/workspace/thoughts/shared/handoffs/` — handoff docs between sessions
+- `/workspace/thoughts/shared/prs/` — PR descriptions
+- `/workspace/thoughts/shared/pm/` — PM artifacts (cycles, metrics, reports)
+- `/workspace/thoughts/global/` — cross-repo notes
+
+**Treat thoughts as read-only in Phase 1.** Do not push back. CTL-295 owns the
+write-back design. If you discover something worth recording, queue it in your
+session output for the orchestrator to act on after session end.
+
+---
+
+## 8. Routine extension pattern
+
+This base prompt is shared by every Phase 1 Routine. Per-routine agents append
+their behavior on top of this base.
+
+A routine-specific prompt typically:
+- Names the routine (e.g., "You are the **Backlog Triage** routine")
+- Specifies the trigger (cron, webhook, manual)
+- Specifies the success criteria (what artifacts to produce, what state to
+  leave Linear / GitHub in)
+- Names the output target (thoughts file path, Linear comment, Slack/Notion post)
+- Sets a wall-clock budget (most routines should complete in < 10 minutes)
+
+Routines must NOT redefine conventions in this base prompt; they EXTEND it.
+
+---
+
+## 9. Operating principles
+
+- **Documentarian, not critic.** When asked "where is X?" or "how does X
+  work?", document what exists. Do not propose changes unless explicitly asked.
+- **Read fully, not partially.** Read tickets, plans, and research end-to-end
+  before acting.
+- **Wait for parallel work to complete.** When you spawn parallel queries
+  (e.g., multiple Linear searches), wait for all to return before synthesizing.
+- **Single source of truth.** Reference canonical files; do not duplicate their
+  contents in your output.
+- **No hallucinated identifiers.** Linear ticket IDs, PR numbers, file paths,
+  and SHAs must come from real tool calls — not from inference.
+
+If the user (or the orchestrator) gives a routine-specific instruction that
+conflicts with this base prompt, follow the more specific instruction and
+flag the conflict in your final output.

--- a/cma/agents/base.yaml
+++ b/cma/agents/base.yaml
@@ -1,0 +1,315 @@
+# Claude Managed Agents — base agent definition for Catalyst Phase 1 Routines
+#
+# Register with:
+#   ant beta:agents create -f cma/agents/base.yaml
+#
+# Per-routine agents (CTL-287..CTL-291) inherit this definition and append
+# routine-specific behavior in their own `system` block.
+#
+# IMPORTANT: the `system` block below is the inlined contents of
+# cma/agents/base-system-prompt.md. Whenever you edit either file, run the
+# drift check before registering:
+#
+#   diff <(yq '.system' cma/agents/base.yaml) cma/agents/base-system-prompt.md
+#
+# (See cma/README.md for the full update workflow.)
+#
+# Beta API header: managed-agents-2026-04-01
+# Reference: https://platform.claude.com/docs/en/managed-agents/agent-setup
+
+name: catalyst-routine-base
+
+# Default model. Per-routine agents may override (e.g., sonnet for cost-sensitive
+# routines like daily async update; opus for high-reasoning routines like docs drift).
+model: claude-opus-4-7
+
+system: |
+  # Catalyst Routine Base — System Prompt
+
+  You are a Catalyst Routine Agent running in a Claude Managed Agents (CMA) cloud
+  session. You operate on the `coalesce-labs/catalyst` codebase and the
+  `coalesce-labs/thoughts` knowledge repository, integrated with Linear and
+  GitHub via MCP. You inherit Catalyst's project conventions; per-routine
+  agent definitions append behavior on top of this base prompt.
+
+  The reference doc for the conventions encoded below is the source of truth in
+  the catalyst repo. Where this prompt and the repo disagree, the repo wins —
+  the user is responsible for keeping this prompt in sync.
+
+  ---
+
+  ## 1. Project conventions
+
+  - Repo: `coalesce-labs/catalyst`
+  - Project key: `catalyst-workspace`
+  - Linear team: Catalyst (key: `CTL`)
+  - Ticket prefix: `CTL-`
+  - Default branch: `main`
+  - Commit conventions:
+    - `feat(dev): ...` for catalyst-dev plugin minor bumps
+    - `fix(pm): ...` for catalyst-pm plugin patch bumps
+    - `chore(meta): ...` for no-version-bump changes
+    - Valid scopes: `dev`, `pm`, `meta`, `analytics`, `debugging`
+    - Breaking change: `feat(dev)!: ...`
+
+  ---
+
+  ## 2. Linear state machine
+
+  Reference: `.catalyst/config.json:9-18` in the catalyst repo.
+
+  stateMap:
+    backlog:    Backlog
+    todo:       Backlog
+    research:   In Progress
+    planning:   In Progress
+    inProgress: In Progress
+    inReview:   In Review
+    done:       Done
+    canceled:   Canceled
+
+  Skill-to-transition map (when the routine acts as one of these):
+
+    research      -> In Progress
+    planning      -> In Progress
+    implementing  -> In Progress
+    PR opened     -> In Review
+    PR merged     -> Done
+
+  Use `mcp__linear__update_issue` with the state name resolved from the map.
+  Do NOT shell out to a `linear-transition.sh` script — that script is
+  local-only and not present in the CMA container.
+
+  ---
+
+  ## 3. PR description format
+
+  When writing a PR description, use these sections in order:
+
+    ## Summary
+    ## Problem Statement
+    ## Solution
+    ## Changes Made
+      ### Backend Changes
+      ### Frontend Changes
+      ### Infrastructure Changes
+      ### Documentation Changes
+    ## Breaking Changes
+    ## Database Changes
+    ## Performance Impact
+    ## Security Considerations
+    ## How to Test
+    ## How to Verify It
+      ### Automated Checks
+      ### Integration Tests
+      ### Manual Verification Required
+    ## Rollback Plan
+    ## Deployment Notes
+    ## Related Issues/PRs
+    ## Screenshots/Videos
+    ## Changelog Entry
+    ## Reviewer Notes
+    ## Post-Merge Tasks
+    ---
+    **Definition of Done Checklist:**
+
+  Linear ref convention in Related Issues/PRs:
+    - Fixes https://linear.app/{workspace}/issue/{ticket}
+
+  ### CRITICAL: NO CLAUDE ATTRIBUTION
+
+  NEVER add any of the following to a PR body, commit message, or any
+  generated artifact:
+  - "Generated with Claude Code"
+  - "Co-Authored-By: Claude"
+  - AI attribution of any kind
+  - Emojis (unless the user explicitly requests them)
+
+  This rule applies to every PR, every commit, every comment. No exceptions.
+
+  ---
+
+  ## 4. Code review behavior (review-comments workflow)
+
+  When responding to a PR's review comments:
+
+  1. Fetch three comment streams:
+     - Inline review comments: `mcp__github__list_pull_request_comments`
+     - Top-level reviews: `mcp__github__list_pull_request_reviews`
+     - Issue/conversation comments: `mcp__github__list_issue_comments`
+
+  2. Group threads via `in_reply_to_id`.
+
+  3. Categorize each thread:
+     - Code change requested -> implement the fix
+     - Question / clarification -> draft a reply
+     - Suggestion (optional) -> evaluate; implement or explain trade-off
+     - Approval / praise -> no action
+     - Already resolved -> skip
+
+  4. Commit fixes with message: `address review comments from PR #${PR_NUMBER}`
+
+  5. Resolve each addressed thread via GitHub GraphQL `resolveReviewThread`.
+
+  Merge-blocker classification:
+    - `unresolved-threads` from automated reviewers -> agent-resolvable
+    - `review-required` from a human reviewer -> human gate; do not bypass
+
+  ---
+
+  ## 5. Quality gates (when shipping code)
+
+  Run the 5-step pipeline before opening or merging a PR:
+
+    Step 0  tsconfig strictness check          (informational only)
+    Step 1  <pkg-mgr> run type-check           (FAIL halts pipeline)
+    Step 2  reward-hacking pattern scan        (FAIL on CRITICAL/HIGH)
+    Step 3  grep tsconfig for excluded tests   (FAIL if tests excluded)
+    Step 4  <pkg-mgr> run test                 (FAIL on any failing test)
+    Step 5  detected linter (trunk/biome/eslint)  (FAIL or SKIPPED)
+
+  Auto-detect package manager from lockfile:
+    bun.lockb / bun.lock -> bun
+    pnpm-lock.yaml -> pnpm
+    yarn.lock -> yarn
+    package-lock.json -> npm
+
+  ### Reward-hacking — banned patterns
+
+  These are forbidden in code changes:
+
+    Pattern                                    Required fix
+    -----------------------------------------  ----------------------------------------------
+    `as unknown as Type` (undocumented)        Fix source to return correct type
+    `as any`                                   Use proper typing or Zod validation
+    `void (0 as unknown as Type)`              Delete the unused type
+    `const _var = ...` (local)                 Delete the unused variable
+    `export type Foo` (when unused elsewhere)  Remove `export` or delete the type
+    `// @ts-ignore` / `// @ts-expect-error`    Fix the actual type error
+    Commented-out code                         Delete (git has history)
+    Excluding files from tsconfig              Include files, fix errors
+
+  Plus runtime-detected:
+    forEach(async ...)   HIGH — silently drops promise results; use for...of + await
+    Unguarded var!       HIGH in libs / MEDIUM in apps; require null guard
+
+  Acceptable exceptions (each documented in code with TODO + ticket):
+    - `as unknown as` with multi-line comment + TODO + ticket
+    - `as any` in test-file mocks only
+    - `// @ts-expect-error` with documented reason + ticket
+    - Non-null assertion after explicit `if (map.has(key))` / `!= null` guard
+
+  ---
+
+  ## 6. MCP usage
+
+    Intent                              Preferred tool
+    ----------------------------------  --------------------------------------------------
+    Read/update Linear issue            mcp__linear__* (get_issue, update_issue, etc.)
+    Read/write GitHub PR/repo           mcp__github__* (get_pull_request, etc.)
+    Post Slack message                  mcp__slack__send_message if MCP wired;
+                                          else REST https://slack.com/api/chat.postMessage
+                                          with bot token
+    Read/write Notion page              Self-hosted Notion MCP if wired;
+                                          else REST https://api.notion.com/v1/*
+                                          with integration token
+
+  Slack/Notion REST fallbacks are first-class working paths — not workarounds.
+  Upgrade to MCP-only when richer tools are needed.
+
+  ---
+
+  ## 7. Thoughts ritual (startup)
+
+  Run once at session start, before the first turn:
+
+    git clone --depth=1 \
+      "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
+      /workspace/thoughts-repo
+    mkdir -p /workspace/thoughts
+    ln -s /workspace/thoughts-repo/repos/catalyst-workspace/shared /workspace/thoughts/shared
+    ln -s /workspace/thoughts-repo/global                          /workspace/thoughts/global
+
+  Treat thoughts as READ-ONLY in Phase 1. CTL-295 owns the write-back design.
+  If you discover something worth recording, queue it in your session output
+  for the orchestrator to act on after session end.
+
+  ---
+
+  ## 8. Routine extension pattern
+
+  This base prompt is shared by every Phase 1 Routine. Per-routine agents
+  append their behavior on top.
+
+  A routine-specific prompt typically:
+  - Names the routine
+  - Specifies the trigger (cron, webhook, manual)
+  - Specifies success criteria (artifacts produced, state left in Linear/GH)
+  - Names the output target (thoughts file path, Linear comment, post)
+  - Sets a wall-clock budget (most should complete in < 10 minutes)
+
+  Routines must NOT redefine conventions in this base prompt; they EXTEND it.
+
+  ---
+
+  ## 9. Operating principles
+
+  - Documentarian, not critic. Document what exists; do not propose changes unless asked.
+  - Read fully, not partially.
+  - Wait for parallel work before synthesizing.
+  - Single source of truth: reference canonical files; do not duplicate.
+  - No hallucinated identifiers — IDs, PR numbers, paths, SHAs must come from real tool calls.
+
+  If a routine-specific instruction conflicts with this base prompt, follow
+  the more specific one and flag the conflict.
+
+# Tools the agent can call
+tools:
+  # Built-in CMA tools (file ops, code execution, web fetch)
+  - type: agent_toolset_20260401
+
+  # Surface MCP tools for each declared MCP server below.
+  - type: mcp_toolset
+    mcp_server_name: linear
+  - type: mcp_toolset
+    mcp_server_name: github
+  - type: mcp_toolset
+    mcp_server_name: slack
+  - type: mcp_toolset
+    mcp_server_name: notion
+
+# MCP server declarations. Credentials bind at session creation via vault_ids,
+# NOT here. See cma/vaults/example.yaml for the per-user vault template.
+mcp_servers:
+  - name: linear
+    type: streamable_http
+    url: https://mcp.linear.app/mcp
+
+  - name: github
+    type: streamable_http
+    url: https://api.githubcopilot.com/mcp/
+
+  - name: slack
+    # Slack's confidential OAuth dance must be completed before this MCP
+    # endpoint can be used. Until then, routines fall back to Slack REST
+    # (slack.com is in the env allowlist). See cma/mcp/slack.md.
+    type: streamable_http
+    url: https://mcp.slack.com/mcp
+
+  - name: notion
+    # The hosted Notion MCP at https://mcp.notion.com/mcp explicitly forbids
+    # bearer-token auth and is unreachable from a headless CMA session.
+    # Until a self-hosted notion-mcp-server is deployed, leave this URL set
+    # to the placeholder below and rely on Notion REST. See cma/mcp/notion.md.
+    type: streamable_http
+    url: https://placeholder.notion-mcp.invalid/mcp
+
+# CMA-native skills (different concept from Catalyst skills). Catalyst-style
+# skill semantics (research-codebase, validate-type-safety, etc.) are encoded
+# in the system prompt above. Porting them as CMA skills is tracked in CTL-294.
+skills: []
+
+metadata:
+  catalyst_role: routine-base
+  catalyst_version: v1
+  catalyst_ticket: CTL-286

--- a/cma/decisions/2026-05-07-thoughts-strategy.md
+++ b/cma/decisions/2026-05-07-thoughts-strategy.md
@@ -1,0 +1,85 @@
+# ADR: Thoughts context strategy for CMA cloud sessions
+
+- **Status:** Accepted (tentative — supersedable by [CTL-295](https://linear.app/catalyst/issue/CTL-295))
+- **Date:** 2026-05-07
+- **Ticket:** [CTL-286](https://linear.app/catalyst/issue/CTL-286)
+- **Source research:** `thoughts/shared/research/2026-05-07-CTL-286-cma-cloud-environment.md`
+
+## Context
+
+`thoughts/shared/` is a 5.6 MB / 329-file collection of research, plans, decisions, PR descriptions, and PM artifacts. In the local Catalyst workflow it is a symlink to `~/code-repos/github/coalesce-labs/thoughts/repos/catalyst-workspace/shared` (a separate git repository, `coalesce-labs/thoughts`), provisioned by the `humanlayer` CLI on worktree creation. Skills read the directory by direct file path; PostToolUse hooks register every Write into the workflow context.
+
+Inside a Claude Managed Agents (CMA) cloud session, none of that local infrastructure exists. The container has `git`, `curl`, `jq`, and a freshly-built rootfs based on Ubuntu 22.04. There is no `humanlayer` binary and no symlink target to point at. Phase 1 Routines (CTL-287..CTL-291) need to read the same context the local Catalyst workflow does — historical research, project state, prior plans — but the container has none of it on disk at boot.
+
+The CMA session container does have outbound network access (subject to environment allowlist), a `git` binary on PATH, and the ability to mount Memory Stores at `/mnt/memory/<name>/`. The base CMA agent definition can include a startup ritual that runs before the agent's first turn.
+
+## Decision
+
+**Adopt Option C (git clone) for Phase 1.** The base agent's startup ritual shallow-clones the `coalesce-labs/thoughts` repo into the session container and surfaces it under the same `thoughts/{shared,global}` paths that local skills expect.
+
+```bash
+# Runs once per session, before the agent's first turn.
+git clone --depth=1 \
+  "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
+  /workspace/thoughts-repo
+
+mkdir -p /workspace/thoughts
+ln -s /workspace/thoughts-repo/repos/catalyst-workspace/shared /workspace/thoughts/shared
+ln -s /workspace/thoughts-repo/global                          /workspace/thoughts/global
+```
+
+Phase 1 routines treat the resulting tree as **read-only**. Write-back, conflict handling, and the question of whether Memory Store should hold a curated mutable subset are all out of scope here and tracked in CTL-295.
+
+## Considered options
+
+| Dimension | A: Memory Store seed | B: rclone / S3 sync | C: git clone (chosen) |
+|-----------|----------------------|---------------------|-----------------------|
+| Captures full corpus | No — 100 KB/file × 8 stores = ~800 KB max; current shared is 5.6 MB / 329 files | Yes (mirror) | Yes (full repo + history) |
+| Setup complexity | High — needs curation logic + sync-to-store pipeline | High — S3 bucket + IAM + rclone in env + sync script | Low — `git clone` against existing repo |
+| Session start overhead | None (pre-mounted) | 30–120 s for 5.6 MB / 329 files | 5–15 s (`--depth=1`) |
+| Persistence model | Full read-write, immediate cross-session visibility | Read-write only after re-sync; conflicts hard | Read-write into local clone; push-back deferred |
+| Multi-session concurrency | First-class — Memory Store has SHA-256 optimistic concurrency | Brittle — last-writer-wins on S3 unless wrapped | Brittle — concurrent pushes need merge logic |
+| New credential surface | None | AWS access key in vault | None — reuses GitHub PAT (already needed for GitHub MCP) |
+| AI-optimized read pattern | Yes — short paths, mounted natively | No | No |
+| Best fit for | Cross-session learned state (preferences, "do not retriage these tickets") | Snapshot read of fixed corpus | Project-state read with full repo context |
+| Worst fit for | Bulk historical context | Real-time concurrent writes | Cross-session learned state without merge discipline |
+
+## Rationale
+
+1. **Simplicity unblocks Phase 1.** Git is pre-installed in the CMA environment. The GitHub PAT is already required for the GitHub MCP server. Cloning the thoughts repo at session start is one shell command in the system prompt. No separate infrastructure to provision.
+2. **Phase 1 routines are read-heavy.** `groom-backlog`, `report-daily`, `research-codebase`-style routines all read prior context. None of CTL-287..CTL-291 strictly require write-back during the session itself. Read-only access is sufficient.
+3. **Memory Store is for a different problem.** Memory Store fits a small, evolving, structured set of facts — agent preferences, ticket-triage exclusions, cross-session learned state. Forcing a 5.6 MB / 329-file repo into 100 KB-per-file × 8-store envelope means heavy curation work that this ticket should not attempt. Memory Store is better reserved for Phase 2+ shared-state needs.
+4. **Option B adds infrastructure without payoff.** S3 sync gives nothing git clone doesn't, plus introduces an S3 bucket and IAM credentials.
+5. **CTL-295 is the long-term answer.** This decision is explicitly tentative. CTL-295 is the dedicated ticket for the deeper exploration: write-back model, conflict handling, hybrid (git for read + Memory Store for cross-session mutable state).
+
+## Consequences
+
+### Positive
+- Simplest possible implementation — one shell command in the startup ritual.
+- Full thoughts content available, not a curated subset.
+- No new credentials beyond the GitHub PAT already needed for the GitHub MCP connector.
+- `git log` available inside the container for any routine that wants history.
+
+### Negative
+- Read-only by default; routines that want to record findings must defer write-back to a separate post-session step (handled by orchestrator, not by routines).
+- Cloning at session start adds 5–15 s to first-turn latency. Acceptable for routines that run on a schedule, not interactive UX.
+- Reuses the GitHub MCP PAT for thoughts access — a leak compromises both. Documented as a known trade-off in `cma/mcp/github.md`. Mitigation: rotate or split the PAT later (CTL-295 may revisit).
+
+### Neutral
+- The clone lives at `/workspace/thoughts-repo/`; symlinks at `/workspace/thoughts/{shared,global}` mirror the local Catalyst layout. Routines do not need to know whether they are running locally or in CMA.
+
+## Implementation
+
+The startup ritual is encoded in the base agent's system prompt (see `cma/agents/base-system-prompt.md`). The PAT is sourced from the GitHub MCP vault entry — exposed to the container as `GITHUB_PAT` env var at session creation. The required PAT scope is documented in `cma/mcp/github.md`: `Repository access` includes both `coalesce-labs/catalyst` and `coalesce-labs/thoughts`; `Repository permissions` for the thoughts repo is `Contents: Read` only.
+
+The session container is ephemeral — the cloned tree is discarded at session end. There is no cleanup step required.
+
+## Open questions for CTL-295
+
+- **Write-back model.** Do routines write back? If yes, does each routine push directly, or does the orchestrator collect fragments and push as a single commit?
+- **Per-write vs per-session push.** If write-back exists, does it happen per session (push at session end) or in-process (push every N writes)?
+- **Conflict handling.** What happens when two concurrent sessions write the same file?
+- **Memory Store split.** Is Memory Store the better long-term home for the small mutable subset (agent preferences, ticket triage exclusions, cross-session learned state)? Hybrid: git for read of historical corpus + Memory Store for mutable shared state?
+- **PAT rotation / scope split.** Should the thoughts-repo clone PAT be split from the GitHub MCP PAT, despite the small scope difference, to limit blast radius?
+
+These questions are explicitly out of scope for CTL-286 and tracked in CTL-295.

--- a/cma/environment.yaml
+++ b/cma/environment.yaml
@@ -1,0 +1,73 @@
+# Claude Managed Agents — shared environment for Catalyst Phase 1 Routines
+#
+# Register with:
+#   ant beta:environments create -f cma/environment.yaml
+#
+# Capture the returned environment_id and store it in your local
+# ~/.config/catalyst/cma.json (NEVER commit). Reference it at session
+# creation time as `environment_id: $ENV_ID`.
+#
+# All Phase 1 Routines (CTL-287..CTL-291) reference this single environment.
+# Per-routine differentiation lives in per-routine agent definitions, not here.
+#
+# Beta API header: managed-agents-2026-04-01
+# Reference: https://platform.claude.com/docs/en/managed-agents/environments
+
+name: catalyst-routines-base
+config:
+  type: cloud
+
+  # Base image: Ubuntu 22.04 LTS, x86_64.
+  # Pre-installed: python 3.12+, node 20+, go, rust, java, ruby, php,
+  #   git, curl, wget, jq, tar, zip, ssh, make, cmake, ripgrep, vim,
+  #   sed, awk, grep, diff.
+  # NOT pre-installed: bun, gh — added below.
+  packages:
+    apt:
+      - gh         # GitHub CLI (used by Catalyst skills via Bash(gh *))
+    npm:
+      - bun        # bun runtime (used by Catalyst dev/test scripts)
+    pip: []
+    cargo: []
+    gem: []
+    go: []
+
+  networking:
+    # `limited` enforces an explicit allowlist. Surfaces integration breakage
+    # as policy decisions rather than silent network access.
+    type: limited
+
+    allowed_hosts:
+      # GitHub family
+      - api.github.com                    # GitHub REST API
+      - github.com                        # git clone (thoughts repo) and gh CLI auth
+      - objects.githubusercontent.com     # GitHub release assets / large objects
+      - raw.githubusercontent.com         # raw file fetches
+      - api.githubcopilot.com             # GitHub MCP server endpoint
+
+      # Linear family
+      - api.linear.app                    # Linear REST API (also used by Linear MCP backend)
+      - mcp.linear.app                    # Linear MCP server endpoint
+
+      # Slack family
+      - mcp.slack.com                     # Slack MCP server endpoint
+      - slack.com                         # Slack REST API (bot-token fallback path)
+
+      # Notion family
+      - api.notion.com                    # Notion REST API (integration-token fallback path)
+      - mcp.notion.com                    # Notion hosted MCP (OAuth-only; future)
+
+      # Package registries (covered by allow_package_managers below, listed for clarity)
+      - registry.npmjs.org
+      - registry.yarnpkg.com
+
+    # Allows declared mcp_servers URLs to be reached even if not in allowed_hosts.
+    allow_mcp_servers: true
+
+    # Allows public package registries (PyPI, npm, etc.) for runtime installs.
+    allow_package_managers: true
+
+metadata:
+  catalyst_role: routine-base
+  catalyst_version: v1
+  catalyst_ticket: CTL-286

--- a/cma/mcp/github.md
+++ b/cma/mcp/github.md
@@ -1,0 +1,139 @@
+# GitHub MCP wiring
+
+## URL
+
+`https://api.githubcopilot.com/mcp/` — GitHub-managed remote MCP server.
+Streamable HTTP transport. Zero-install.
+
+URL path modifiers (alternative to header-based control):
+- `/readonly` — global read-only mode
+- `/x/<toolset>` — restrict to a specific toolset (e.g. `/x/issues`)
+- `/insiders` — enable experimental tools
+
+Header-based control:
+- `X-MCP-Toolsets: repos,issues,pull_requests`
+- `X-MCP-Readonly: true`
+- `X-MCP-Insiders: true`
+
+## Auth model
+
+| Mode | Use case | CMA fit |
+|------|----------|---------|
+| OAuth via GitHub App | Interactive hosts | No — requires browser |
+| Personal Access Token (fine-grained) | Headless agents | Yes — recommended |
+| Personal Access Token (classic) | Legacy | Acceptable; fine-grained preferred |
+
+### How to provision the PAT
+
+1. GitHub -> **Settings** -> **Developer settings** -> **Personal access tokens** -> **Fine-grained tokens** -> **Generate new token**
+2. Name it (e.g., `cma-routines-base`)
+3. Set expiration (90 days recommended; rotate before expiry)
+4. **Repository access:** select the specific repos this token covers
+5. **Repository permissions:** see scope below
+6. Copy the `github_pat_...` value once shown
+
+### Required scope (CTL-286 decision: PAT also handles thoughts clone)
+
+This single PAT is used both for the GitHub MCP server **and** for the
+session-startup `git clone` of the thoughts repo (per the
+`cma/decisions/2026-05-07-thoughts-strategy.md` ADR).
+
+**Repository access:**
+- `coalesce-labs/catalyst` (read+write for code review and CI fixup routines)
+- `coalesce-labs/thoughts` (read-only for the startup git clone)
+
+**Repository permissions on `coalesce-labs/catalyst`:**
+
+| Permission | Level | Why |
+|------------|-------|-----|
+| Contents | Read+Write | Push fix commits in CI auto-fix routine |
+| Pull requests | Read+Write | Open/comment/review/merge PRs |
+| Issues | Read+Write | Open issues from drift detection routine |
+| Metadata | Read | Required by all PATs |
+| Actions | Read | Read CI logs for failure diagnosis |
+| Checks | Read | Read CI check status |
+
+**Repository permissions on `coalesce-labs/thoughts`:**
+
+| Permission | Level | Why |
+|------------|-------|-----|
+| Contents | Read | git clone --depth=1 of the thoughts repo |
+| Metadata | Read | Required by all PATs |
+
+Trade-off explicitly accepted by CTL-286: the same PAT covers both repos.
+A leak compromises both. Mitigation: rotate or split into two PATs later;
+CTL-295 may revisit when thoughts write-back is designed.
+
+## Vault entry
+
+```yaml
+# cma/vaults/example.yaml
+- type: static_bearer
+  mcp_server_url: https://api.githubcopilot.com/mcp/
+  token: ${GITHUB_PAT}            # github_pat_... fine-grained token
+```
+
+The same `${GITHUB_PAT}` env var is also injected into the session container
+for the thoughts-repo `git clone` (referenced from the base agent's startup
+ritual in `cma/agents/base-system-prompt.md`).
+
+## Tools exposed
+
+30+ tools across 15+ toolsets. Default toolsets enabled:
+
+| Toolset | Sample tools |
+|---------|--------------|
+| `context` | `get_me`, `get_teams` (read-only) |
+| `repos` | `search_repositories`, `get_file_contents`, `list_commits`, `list_branches`, `create_or_update_file`, `create_repository`, `fork_repository`, `create_branch`, `push_files`, `delete_file`, `star_repository` |
+| `issues` | `list_issues`, `search_issues`, `create_issue`, `add_issue_comment` |
+| `pull_requests` | `list_pull_requests`, `create_pull_request`, `merge_pull_request`, `update_pull_request_branch`, `add_pull_request_review` |
+| `users` | `search_users` (read-only) |
+| `copilot` | `assign_copilot_to_issue`, `request_copilot_review` |
+
+Optional toolsets (require explicit enable via `X-MCP-Toolsets` or URL path):
+- `actions` — workflow runs/jobs/logs (needed by CI auto-fix routine)
+- `code_security`, `dependabot` — security alerts
+- `discussions`, `gists`, `labels`, `notifications`, `orgs`, `projects`,
+  `security_advisories`
+
+For the **CI failure auto-fix routine** (CTL-289), enable the `actions`
+toolset by setting `X-MCP-Toolsets: actions,context,repos,issues,pull_requests`
+on the agent's MCP wiring (or use URL path `/x/actions` if header control
+isn't preferred).
+
+## Network allowlist
+
+Already in `cma/environment.yaml`:
+- `api.githubcopilot.com` — MCP endpoint
+- `api.github.com` — REST fallback
+- `github.com` — git clone, gh CLI auth
+- `objects.githubusercontent.com` — release assets / large objects
+- `raw.githubusercontent.com` — raw file fetches
+
+## Fallback (gh CLI)
+
+The environment installs `gh` (GitHub CLI) via the apt package list. Pre-CMA-
+session setup:
+
+```bash
+# Use the same PAT as the MCP server
+echo "${GITHUB_PAT}" | gh auth login --with-token
+```
+
+Once `gh auth` is set, all Catalyst skills that shell out via `Bash(gh *)`
+work the same as locally.
+
+## Known limitations
+
+- Read-only mode (`X-MCP-Readonly: true` or `/readonly`) is global —
+  cannot mix read-only and write tools in one connection.
+- Classic PATs do startup scope filtering (tools requiring missing scopes
+  are hidden); fine-grained PATs do dynamic scope challenges per call.
+- Some toolsets are remote-only (`copilot_spaces`, `github_support_docs_search`)
+  and not available if you switch to the self-hosted Docker image.
+
+## References
+
+- [GitHub MCP Server repo](https://github.com/github/github-mcp-server)
+- [Remote server docs](https://github.com/github/github-mcp-server/blob/main/docs/remote-server.md)
+- [Toolset reference](https://github.com/github/github-mcp-server/blob/main/docs/toolsets.md)

--- a/cma/mcp/linear.md
+++ b/cma/mcp/linear.md
@@ -1,0 +1,90 @@
+# Linear MCP wiring
+
+## URL
+
+`https://mcp.linear.app/mcp` — Streamable HTTP transport. (Legacy SSE endpoint
+`https://mcp.linear.app/sse` is being phased out; do not use for new wiring.)
+
+Hosted by Linear in partnership with Cloudflare and Anthropic. Centrally
+maintained — no self-hosting needed.
+
+## Auth model
+
+Linear MCP supports two modes; for headless CMA sessions use **API key**.
+
+| Mode | Use case | CMA fit |
+|------|----------|---------|
+| OAuth 2.1 + dynamic client registration | Interactive hosts (Claude Desktop) | No — requires browser |
+| Bearer (API key) | Headless agents | Yes — recommended |
+
+### How to provision the API key
+
+1. Linear UI -> **Settings** -> **Account** -> **Security & Access**
+2. Create a personal API key (or a workspace-scoped restricted key for
+   per-routine least privilege)
+3. Copy the `lin_api_...` value
+
+Recommended practice: create a separate restricted API key with read+write
+on the Catalyst team only. Do not reuse a personal account-wide key.
+
+## Vault entry
+
+```yaml
+# cma/vaults/example.yaml
+- type: static_bearer
+  mcp_server_url: https://mcp.linear.app/mcp
+  token: ${LINEAR_API_KEY}        # lin_api_... from Linear settings
+```
+
+## Tools exposed
+
+21+ tools, all read+write. Categories:
+
+| Category | Tools |
+|----------|-------|
+| Issues | `list_issues`, `get_issue`, `create_issue`, `update_issue`, `list_my_issues` |
+| Projects | `list_projects`, `get_project`, `create_project`, `update_project` |
+| Teams | `list_teams`, `get_team` |
+| Users | `list_users`, `get_user` |
+| Comments | `list_comments`, `create_comment` |
+| Status / labels | `list_issue_statuses`, `get_issue_status`, `manage_project_labels` |
+| Initiatives (added Feb 2026) | `create_initiative`, `edit_initiative`, `create_initiative_update` |
+| Milestones (added Feb 2026) | `create_project_milestone`, `edit_project_milestone`, `create_project_update` |
+
+Read-only restrictions are enforced via key scoping in the Linear UI, not by
+the MCP server.
+
+## Network allowlist
+
+Already in `cma/environment.yaml`:
+- `mcp.linear.app` — MCP endpoint
+- `api.linear.app` — REST fallback / underlying API
+
+## Fallback (REST)
+
+If the MCP path is unreachable for any reason, agents can call the Linear REST
+API directly:
+
+```bash
+curl -H "Authorization: ${LINEAR_API_KEY}" \
+     -H "Content-Type: application/json" \
+     -d '{"query":"query { issue(id: \"CTL-286\") { title state { name } } }"}' \
+     https://api.linear.app/graphql
+```
+
+This is the same path the Catalyst-local `linearis` CLI takes today.
+
+## Known limitations
+
+- No published rate limits; follows Linear's standard API limits (sufficient
+  for routine workloads; not for high-frequency polling)
+- Cannot scope tools at the MCP layer — all 21+ tools are surfaced to any
+  agent attached to the connector. Use Linear UI restricted keys to limit
+  blast radius.
+- API key has no native rotation flow; rotate manually when needed.
+
+## References
+
+- [Linear MCP server docs](https://linear.app/docs/mcp)
+- [Linear MCP launch changelog (May 2025)](https://linear.app/changelog/2025-05-01-mcp)
+- [Initiative & milestone tools (Feb 2026)](https://linear.app/changelog/2026-02-05-linear-mcp-for-product-management)

--- a/cma/mcp/notion.md
+++ b/cma/mcp/notion.md
@@ -1,0 +1,132 @@
+# Notion MCP wiring
+
+## URLs
+
+| Endpoint | Path | Auth | Headless |
+|----------|------|------|----------|
+| Hosted | `https://mcp.notion.com/mcp` | OAuth user-only | **No** — explicitly forbids bearer tokens |
+| Self-host | Your URL — `makenotion/notion-mcp-server` Docker image | `NOTION_TOKEN` env var | Yes |
+
+The hosted endpoint at `mcp.notion.com` cannot be used by a headless CMA
+session. Notion's docs explicitly state it does not support bearer-token auth.
+
+## Two paths for Phase 1
+
+### Path A (recommended for now): Notion REST with an integration token
+
+This is simpler, takes ~3 minutes, and works headlessly.
+
+1. Notion -> **Settings** -> **Connections** -> **Develop or manage integrations**
+2. **+ New integration** -> Internal, choose your workspace
+3. Give it a name (e.g., `Catalyst Routines`)
+4. Capabilities: Read, Update, Insert (set per least-privilege need)
+5. Copy the **Internal Integration Secret** (starts with `secret_` or `ntn_`)
+6. **Critical:** Share each page or database the integration needs to access
+   in Notion's UI. Open the page -> click `...` -> **Connections** -> add the
+   integration. The integration cannot access anything not explicitly shared.
+
+Vault entry:
+
+```yaml
+# cma/vaults/example.yaml
+- type: static_bearer
+  mcp_server_url: https://api.notion.com/v1/
+  token: ${NOTION_TOKEN}          # secret_... or ntn_...
+```
+
+REST usage from the agent:
+
+```bash
+# Read a page
+curl -H "Authorization: Bearer ${NOTION_TOKEN}" \
+     -H "Notion-Version: 2025-09-03" \
+     https://api.notion.com/v1/pages/${PAGE_ID}
+
+# Append blocks (e.g., post a daily-update entry)
+curl -X PATCH \
+  -H "Authorization: Bearer ${NOTION_TOKEN}" \
+  -H "Notion-Version: 2025-09-03" \
+  -H "Content-Type: application/json" \
+  --data '{"children":[{"object":"block","type":"paragraph","paragraph":{"rich_text":[{"type":"text","text":{"content":"..."}}]}}]}' \
+  https://api.notion.com/v1/blocks/${PAGE_ID}/children
+```
+
+Pin a specific `Notion-Version` header per Notion's API versioning policy.
+
+### Path B: Self-hosted Notion MCP
+
+Required when a routine needs the AI-optimized tooling that the OSS server
+provides (markdown-flavored page CRUD, structured search) without re-implementing it
+on top of REST.
+
+Setup:
+
+1. Deploy the OSS server `makenotion/notion-mcp-server` to a public endpoint:
+   - Docker: `ghcr.io/makenotion/notion-mcp-server:latest`
+   - Host options: Fly.io, Cloud Run, AWS ECS Fargate, any Docker host
+2. Configure environment variables on the deployment:
+   - `NOTION_TOKEN=secret_...` (the integration token from Path A)
+   - `AUTH_TOKEN=<your-own-bearer-secret>` (the bearer the CMA agent presents
+     to the MCP server itself; rotate this independent of the Notion token)
+3. Expose on HTTPS at `https://your-notion-mcp.example.com/mcp`
+4. Update `cma/agents/base.yaml`:
+   ```yaml
+   mcp_servers:
+     - name: notion
+       type: streamable_http
+       url: https://your-notion-mcp.example.com/mcp
+   ```
+5. Add to vault:
+   ```yaml
+   - type: static_bearer
+     mcp_server_url: https://your-notion-mcp.example.com/mcp
+     token: ${NOTION_MCP_AUTH_TOKEN}   # the AUTH_TOKEN from step 2
+   ```
+6. Add `your-notion-mcp.example.com` to `cma/environment.yaml`'s
+   `allowed_hosts` (or rely on `allow_mcp_servers: true`)
+
+The hosted-endpoint URL placeholder in `cma/agents/base.yaml`
+(`https://placeholder.notion-mcp.invalid/mcp`) is a deliberate canary — if
+a session attempts to call it, the network allowlist will reject the call,
+making the unwired state visible rather than silently failing later.
+
+## Tools exposed (Path B only)
+
+13 tools derived from Notion's OpenAPI:
+
+| Category | Tools |
+|----------|-------|
+| Users | `get_user`, `get_users` |
+| Pages | `retrieve_a_page`, `retrieve_a_page_property`, `create_a_page`, `patch_page` |
+| Databases | `get_databases`, `post_database_query`, `retrieve_a_database`, `create_a_database`, `update_a_database` |
+| Blocks | `get_block_children`, `retrieve_a_block`, `patch_block_children`, `update_a_block`, `delete_a_block` |
+| Comments | `retrieve_a_comment`, `create_a_comment` |
+| Search | `post_search` |
+
+The hosted `mcp.notion.com` endpoint adds AI-optimized tools (`create_pages`,
+`update_page`, markdown-aware `search`) that the OSS self-host does not have.
+Database deletion is intentionally excluded everywhere.
+
+## Network allowlist
+
+Already in `cma/environment.yaml`:
+- `api.notion.com` — REST API (Path A)
+- `mcp.notion.com` — hosted MCP (allowlist entry; not currently usable headlessly)
+
+For Path B, add the self-host URL host to `allowed_hosts` when you deploy.
+
+## Known limitations
+
+- Path A: integration token only sees pages/databases explicitly shared with
+  it in Notion's UI. Discoverability is limited — `post_search` only returns
+  shared resources.
+- Path B: requires you to host and maintain a separate MCP server.
+- The hosted `mcp.notion.com` endpoint may eventually support bearer tokens;
+  if Notion ships that, this doc should be updated and Path A becomes optional.
+
+## References
+
+- [Notion MCP getting started](https://developers.notion.com/guides/mcp/get-started-with-mcp)
+- [Hosting a local MCP server](https://developers.notion.com/docs/hosting-open-source-mcp)
+- [makenotion/notion-mcp-server (GitHub)](https://github.com/makenotion/notion-mcp-server)
+- [Notion's hosted MCP server: an inside look](https://www.notion.com/blog/notions-hosted-mcp-server-an-inside-look)

--- a/cma/mcp/slack.md
+++ b/cma/mcp/slack.md
@@ -1,0 +1,150 @@
+# Slack MCP wiring
+
+## URL
+
+`https://mcp.slack.com/mcp` — Streamable HTTP (JSON-RPC 2.0). GA since
+2026-02-17.
+
+## Auth model
+
+Slack MCP requires **confidential OAuth 2.0** with a user-token flow against
+a Slack app that is either:
+- Published in the Slack App Directory, OR
+- Installed as an internal app in the user's workspace
+
+There is **no API-key / bearer-token shortcut** for the MCP server. Headless
+CMA sessions cannot complete the OAuth dance autonomously — a one-time
+human-driven flow is required, after which the resulting access + refresh
+tokens are stored in the vault.
+
+For Phase 1 routines, the recommended path is the **bot-token REST fallback**
+(see below) until a routine actually needs a tool that REST does not expose
+(canvas operations, full message search). The MCP path can be wired later
+without re-architecting.
+
+## Two paths for Phase 1
+
+### Path A (recommended for now): Slack REST with a bot token
+
+This is simpler, takes ~5 minutes, and works headlessly.
+
+1. Create a Slack app at <https://api.slack.com/apps> -> **Create New App** -> **From scratch**
+2. Name it (e.g., `Catalyst Routines`)
+3. Choose your workspace
+4. Under **OAuth & Permissions** -> **Bot Token Scopes**, add the scopes the
+   routine needs. Common minimum:
+   - `chat:write` — post messages
+   - `channels:read`, `channels:history` — read public channel messages
+   - `users:read` — look up users by name
+5. Click **Install to Workspace**, approve
+6. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
+7. Invite the bot to each channel it will post in: `/invite @Catalyst Routines`
+   from inside Slack
+
+Vault entry:
+
+```yaml
+# cma/vaults/example.yaml
+- type: static_bearer
+  mcp_server_url: https://slack.com/api/
+  token: ${SLACK_BOT_TOKEN}       # xoxb-...
+```
+
+(The vault's `mcp_server_url` field is purely a credential index here — the
+agent calls Slack REST directly, not via an MCP server.)
+
+REST usage from the agent:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data '{"channel":"C012345","text":"Daily update: ..."}' \
+  https://slack.com/api/chat.postMessage
+```
+
+### Path B: Slack MCP (hosted, OAuth)
+
+Required when a routine needs:
+- `search_messages_and_files` (workspace-wide message search)
+- `create_canvas` / `update_canvas` / `read_canvas` (Slack canvases)
+- User-token operations (acting as a specific user, not a bot)
+
+Setup:
+
+1. Build a Slack app (same as Path A) OR use a directory-published app
+2. Configure OAuth in the app:
+   - Authorization endpoint: `https://slack.com/oauth/v2_user/authorize`
+   - Token endpoint: `https://slack.com/api/oauth.v2.user.access`
+3. Add **User Token Scopes** (these are different from bot scopes):
+   - `search:read.public`, `search:read.private`, `search:read.mpim`,
+     `search:read.im`, `search:read.files` — message/file search
+   - `search:read.users` — user search
+   - `channels:history`, `groups:history`, `mpim:history`, `im:history`
+     — channel/thread reads
+   - `chat:write` — send message as user
+   - `canvases:read`, `canvases:write` — canvas ops
+   - `users:read`, `users:read.email` — profile reads
+4. Install the app in workspace and complete the OAuth user-authorize flow
+   manually once. Capture `access_token` and `refresh_token` from the
+   `oauth.v2.user.access` response.
+5. Store in vault as `mcp_oauth`:
+
+```yaml
+# Add to vault AFTER OAuth dance is complete
+- type: mcp_oauth
+  mcp_server_url: https://mcp.slack.com/mcp
+  client_id: ${SLACK_CLIENT_ID}
+  client_secret: ${SLACK_CLIENT_SECRET}
+  access_token: ${SLACK_ACCESS_TOKEN}
+  refresh_token: ${SLACK_REFRESH_TOKEN}
+```
+
+CMA refreshes access tokens server-side using the refresh token.
+
+## Tools exposed (Path B only)
+
+11 tools, mix of read+write:
+
+| Tool | Type |
+|------|------|
+| `search_messages_and_files` | read |
+| `search_users` | read |
+| `search_channels` | read |
+| `send_message` | write |
+| `read_channel` | read |
+| `read_thread` | read |
+| `draft_message` | write |
+| `create_canvas` | write |
+| `update_canvas` | write |
+| `read_canvas` | read |
+| `read_user_profile` | read |
+
+## Network allowlist
+
+Already in `cma/environment.yaml`:
+- `mcp.slack.com` — MCP endpoint (Path B)
+- `slack.com` — REST API (Path A)
+
+## Rate limits
+
+Tier 2 (20+/min): user/channel searches, canvas creation
+Tier 3 (50+/min): channel reads, canvas updates
+Tier 4 (100+/min): canvas reads, profile reads
+
+For daily-update routines (CTL-291), Tier 4 is fine; Tier 2 limits
+search-heavy routines to ~1200 ops/hour.
+
+## Known limitations
+
+- Path B requires a Slack workspace admin to install or directory-publish
+  the app. Unpublished dev apps cannot use the remote MCP.
+- Bot tokens (Path A) cannot do message search, cannot impersonate users,
+  and require explicit channel invites for `chat:write`.
+- User tokens (Path B) act as a specific user; rate limits are per-user.
+
+## References
+
+- [Announcing the Slack MCP server (Feb 2026)](https://docs.slack.dev/changelog/2026/02/17/slack-mcp/)
+- [Slack MCP overview](https://docs.slack.dev/ai/slack-mcp-server/)
+- [Guide to the Slack MCP server](https://slack.com/help/articles/48855576908307-Guide-to-the-Slack-MCP-server)

--- a/cma/smoke-test/README.md
+++ b/cma/smoke-test/README.md
@@ -1,0 +1,180 @@
+# CMA base scaffold — smoke test
+
+End-to-end manual recipe to confirm a CMA session created against the base
+environment + base agent + your vault can:
+1. Clone the thoughts repo (verifies thoughts strategy + GitHub PAT scope)
+2. Read a research doc from the cloned tree
+3. Call Linear MCP to read an issue
+4. Call GitHub MCP to read this PR
+5. Echo the encoded reward-hacking patterns (verifies system prompt encoding)
+
+This recipe is run by hand — it is not automated CI.
+
+---
+
+## Prerequisites
+
+- `ant` CLI installed and authenticated (`ant auth login`)
+- Your CMA org / API key has the `managed-agents-2026-04-01` beta enabled
+- You have completed credential provisioning per `cma/mcp/{linear,github}.md`
+  (Slack and Notion are NOT exercised in this smoke test; their auth setup
+  is independent and can be deferred)
+- Shell variables set:
+  ```bash
+  export LINEAR_API_KEY=lin_api_...
+  export GITHUB_PAT=github_pat_...
+  ```
+
+---
+
+## Step 1 — Register environment, base agent, vault
+
+From the catalyst repo root:
+
+```bash
+# Environment
+ENV_ID=$(ant beta:environments create -f cma/environment.yaml --json | jq -r '.id')
+echo "ENV_ID=$ENV_ID"
+
+# Base agent
+AGENT_ID=$(ant beta:agents create -f cma/agents/base.yaml --json | jq -r '.id')
+echo "AGENT_ID=$AGENT_ID"
+
+# Vault — copy the example to a private location and substitute real values
+cp cma/vaults/example.yaml ~/.config/catalyst/cma-vault.yaml
+${EDITOR:-vim} ~/.config/catalyst/cma-vault.yaml   # replace ${...} placeholders
+
+VAULT_ID=$(ant beta:vaults create -f ~/.config/catalyst/cma-vault.yaml --json | jq -r '.id')
+echo "VAULT_ID=$VAULT_ID"
+```
+
+Capture all three IDs in your local `~/.config/catalyst/cma.json` (NEVER
+commit). Suggested shape:
+
+```json
+{
+  "environments": { "catalyst-routines-base": "env_..." },
+  "agents":       { "catalyst-routine-base":  "agt_..." },
+  "vaults":       { "catalyst-developer":     "vlt_..." }
+}
+```
+
+---
+
+## Step 2 — Drift check before first run
+
+The base agent's `system` prompt is inlined into `cma/agents/base.yaml` from
+`cma/agents/base-system-prompt.md`. Run the drift check before registering or
+re-registering:
+
+```bash
+diff <(yq '.system' cma/agents/base.yaml) cma/agents/base-system-prompt.md
+```
+
+Should be empty (or whitespace-only differences from YAML literal-block
+formatting). If it shows drift, re-inline before registering:
+
+```bash
+yq -i '.system = load_str("cma/agents/base-system-prompt.md")' cma/agents/base.yaml
+```
+
+(Verify the result before committing.)
+
+---
+
+## Step 3 — Create a smoke-test session
+
+```bash
+SESSION_ID=$(ant beta:sessions create --json <<YAML | jq -r '.id'
+agent: $AGENT_ID
+environment_id: $ENV_ID
+vault_ids:
+  - $VAULT_ID
+YAML
+)
+echo "SESSION_ID=$SESSION_ID"
+```
+
+---
+
+## Step 4 — Send the smoke prompt
+
+```bash
+ant beta:sessions:events send "$SESSION_ID" --type user_turn <<'PROMPT'
+Run this smoke test, in order, and report each step's result:
+
+1. Run the startup ritual:
+   git clone --depth=1 \
+     "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
+     /workspace/thoughts-repo
+   mkdir -p /workspace/thoughts
+   ln -s /workspace/thoughts-repo/repos/catalyst-workspace/shared /workspace/thoughts/shared
+   ln -s /workspace/thoughts-repo/global                          /workspace/thoughts/global
+   Then `ls /workspace/thoughts/shared/research/ | head -5`.
+   Expected: 5 file paths starting with 2026-.
+
+2. Read the research doc that produced you:
+   `cat /workspace/thoughts/shared/research/2026-05-07-CTL-286-cma-cloud-environment.md | head -20`
+   Expected: frontmatter + the title line "# CTL-286: Scaffold CMA cloud environment".
+
+3. Call mcp__linear__get_issue with id "CTL-286".
+   Expected: title equals "[CMA] Scaffold cloud environment and Catalyst context architecture".
+
+4. Call mcp__github__get_pull_request with owner=coalesce-labs, repo=catalyst,
+   pull_number=<the PR number for CTL-286 when this smoke test is run>.
+   Expected: title contains "CTL-286"; head ref is "CTL-286".
+
+5. From your system prompt, echo the list of banned reward-hacking patterns
+   (section 5). Expected: 8 banned patterns matching
+   `plugins/dev/skills/fix-typescript/SKILL.md:22-31`.
+
+After completing all 5 steps, output a one-line PASS/FAIL summary per step.
+PROMPT
+```
+
+---
+
+## Step 5 — Stream the response
+
+```bash
+ant beta:sessions:events stream "$SESSION_ID"
+```
+
+Watch for the agent's tool calls. Expected sequence:
+- `bash` (clone, mkdir, ln, ls)
+- `bash` (cat first research doc)
+- `mcp__linear__get_issue`
+- `mcp__github__get_pull_request`
+- final assistant turn with PASS/FAIL summary
+
+---
+
+## Step 6 — Cleanup
+
+```bash
+ant beta:sessions archive "$SESSION_ID"
+```
+
+The session container is destroyed; the cloned thoughts repo is gone. The
+environment, agent, and vault remain registered for the next session.
+
+---
+
+## Expected pass criteria
+
+| Step | Pass when |
+|------|-----------|
+| 1 | `git clone` succeeds; `ls` returns ≥ 5 research files |
+| 2 | `cat` shows the frontmatter and the matching title line |
+| 3 | Linear MCP returns the exact ticket title |
+| 4 | GitHub MCP returns a PR whose head ref is `CTL-286` |
+| 5 | Agent echoes the 8 banned patterns matching the skill source |
+
+If any step fails, the most likely causes:
+- **Step 1 fails:** `GITHUB_PAT` lacks `coalesce-labs/thoughts` Contents:Read access
+- **Step 3 fails:** `LINEAR_API_KEY` lacks workspace access; or the vault was
+  not bound to this session
+- **Step 4 fails:** PAT lacks `coalesce-labs/catalyst` Pull requests:Read; or
+  the PR number is wrong
+- **Step 5 fails:** the system prompt was not registered correctly — re-run
+  the drift check (Step 2) and re-register the agent

--- a/cma/vaults/example.yaml
+++ b/cma/vaults/example.yaml
@@ -1,0 +1,70 @@
+# Per-developer vault template for the Catalyst CMA base agent.
+#
+# DO NOT COMMIT REAL CREDENTIALS.
+#
+# Workflow:
+#   1. Copy this file to a private location, e.g.
+#        ~/.config/catalyst/cma-vault.yaml
+#      OR keep it in a private gist / 1Password secure note.
+#   2. Replace each ${...} placeholder with the real credential value.
+#   3. Register: ant beta:vaults create -f ~/.config/catalyst/cma-vault.yaml
+#   4. Capture the returned vault_id; pass at session creation as
+#        vault_ids: [<vault_id>]
+#   5. Rotate credentials when expiry is near; re-register OR use
+#        ant beta:vaults:credentials update
+#
+# Secret fields (token, access_token, refresh_token, client_secret) are
+# write-only — never returned by the CMA API after creation.
+
+name: catalyst-developer-${USER}
+
+credentials:
+  # ----- Linear MCP -----
+  # See cma/mcp/linear.md for provisioning steps.
+  - type: static_bearer
+    mcp_server_url: https://mcp.linear.app/mcp
+    token: ${LINEAR_API_KEY}        # lin_api_... from Linear -> Settings -> Account -> Security & Access
+
+  # ----- GitHub MCP (and thoughts-repo clone PAT) -----
+  # See cma/mcp/github.md for required scope. CTL-286 explicitly reuses this
+  # PAT for the session-startup git clone of coalesce-labs/thoughts.
+  - type: static_bearer
+    mcp_server_url: https://api.githubcopilot.com/mcp/
+    token: ${GITHUB_PAT}            # github_pat_... fine-grained PAT
+
+  # ----- Slack: REST fallback (Phase 1 default) -----
+  # See cma/mcp/slack.md, "Path A". Bot token from your Slack app.
+  # The mcp_server_url here is a credential-index path, not an MCP endpoint —
+  # the agent calls Slack REST directly with this token.
+  - type: static_bearer
+    mcp_server_url: https://slack.com/api/
+    token: ${SLACK_BOT_TOKEN}       # xoxb-...
+
+  # ----- Slack MCP: Path B (uncomment after OAuth dance is complete) -----
+  # See cma/mcp/slack.md, "Path B". Required only when a routine needs
+  # canvas tools, message search, or user-token operations.
+  # - type: mcp_oauth
+  #   mcp_server_url: https://mcp.slack.com/mcp
+  #   client_id: ${SLACK_CLIENT_ID}
+  #   client_secret: ${SLACK_CLIENT_SECRET}
+  #   access_token: ${SLACK_ACCESS_TOKEN}
+  #   refresh_token: ${SLACK_REFRESH_TOKEN}
+
+  # ----- Notion: REST fallback (Phase 1 default) -----
+  # See cma/mcp/notion.md, "Path A". Internal integration token from
+  # Notion -> Settings -> Connections -> Develop or manage integrations.
+  - type: static_bearer
+    mcp_server_url: https://api.notion.com/v1/
+    token: ${NOTION_TOKEN}          # secret_... or ntn_...
+
+  # ----- Notion MCP: Path B (uncomment when self-hosting MCP server) -----
+  # See cma/mcp/notion.md, "Path B". Required only when richer Notion
+  # tooling is needed.
+  # - type: static_bearer
+  #   mcp_server_url: https://your-notion-mcp.example.com/mcp
+  #   token: ${NOTION_MCP_AUTH_TOKEN}
+
+metadata:
+  catalyst_user: ${USER}
+  catalyst_role: routine-base-vault
+  catalyst_ticket: CTL-286


### PR DESCRIPTION
## Summary

Foundation for the [Claude Managed Agents Evaluation](https://linear.app/catalyst/project/claude-managed-agents-evaluation) project. Adds a top-level `cma/` directory containing the configuration and documentation needed to register a working CMA environment + base agent definition for Phase 1 Routines (CTL-287..CTL-291).

This is content-only (markdown + YAML); no TS code, no plugin source.

## Problem Statement

CTL-286 establishes the cloud environment all Phase 1 Routines will run on. Without it, every routine ticket would have to re-derive: the CMA environment shape, MCP connector wiring, the base system prompt encoding Catalyst conventions, and the thoughts-portability decision. The ticket explicitly enumerates three options for thoughts (Memory Store / S3 sync / git clone) and asks for a decision doc, an environment config, and a working base agent definition.

## Solution

Top-level `cma/` directory:

```
cma/
  README.md                          ← registration recipe + smoke test pointer
  environment.yaml                   ← shared CMA environment (one for all routines)
  agents/
    base.yaml                        ← base agent definition (system prompt inlined)
    base-system-prompt.md            ← system prompt body (source of truth for prose)
  vaults/example.yaml                ← per-developer vault template
  mcp/{linear,github,slack,notion}.md ← per-connector wiring + token provisioning
  decisions/2026-05-07-thoughts-strategy.md  ← ADR (Option C: git clone)
  smoke-test/README.md               ← end-to-end manual verification recipe
```

Per-routine agent definitions (one per CTL-287..CTL-291) inherit the base agent's system prompt and append routine-specific behavior. Live `ant` registration is documented but not performed by this PR — the user runs the registration commands locally once.

### Key decisions

- **Thoughts strategy: Option C (git clone) for Phase 1.** ADR documents the decision and explicitly defers the deeper write-back design to [CTL-295](https://linear.app/catalyst/issue/CTL-295).
- **GitHub PAT scope reused for thoughts clone.** A single fine-grained PAT covers GitHub MCP and the session-startup `git clone` of `coalesce-labs/thoughts`.
- **Slack/Notion wired with REST fallback as the working default.** MCP path documented (Slack OAuth + internal app; Notion self-host) but not the recommended Phase 1 path because Slack OAuth needs a Slack admin and Notion's hosted MCP forbids bearer tokens.
- **System prompt source of truth split.** `base-system-prompt.md` is the readable source; `base.yaml` inlines a copy. README documents a `diff` check before registering.

## Changes Made

### Documentation Changes

11 new files under `cma/` (1659 lines). No changes to existing files.

### Linear updates

Posted a comment on each of CTL-287..CTL-291 pointing to this scaffolding, the ADR, and the registration recipe.

## Breaking Changes

None — net new directory, no existing files modified.

## Database Changes

None.

## Performance Impact

None (no runtime code).

## Security Considerations

- `cma/vaults/example.yaml` contains only `${PLACEHOLDER}` env-var references; no real secrets.
- `cma/mcp/github.md` documents the trade-off of reusing the GitHub MCP PAT for thoughts-repo access — explicitly accepted in CTL-286, revisitable in CTL-295.
- `cma/environment.yaml` uses `networking.type: limited` with an explicit allowlist — surfaces integration breakage as policy decisions rather than silent network access.

## How to Test

1. Read the ADR (`cma/decisions/2026-05-07-thoughts-strategy.md`) for the thoughts-strategy rationale.
2. Read the base system prompt (`cma/agents/base-system-prompt.md`) and confirm it encodes the Catalyst state map, PR description format, code review workflow, quality gate sequence, and reward-hacking ban list.
3. Run the YAML parse smoke check:
   ```bash
   yq '.name, .config.networking.type' cma/environment.yaml
   yq '.name, (.mcp_servers | map(.name))' cma/agents/base.yaml
   yq '.name' cma/vaults/example.yaml
   ```
4. (Optional, requires `ant` CLI access) Run `cma/smoke-test/README.md` end-to-end against your CMA org.

## How to Verify It

### Automated Checks

- All YAML parses (verified locally with `yq` + `python3 yaml`)
- Cross-references in README all resolve to real files
- Linear state map keys in the system prompt match `.catalyst/config.json:9-18` exactly

### Integration Tests

N/A — this is configuration content, not runtime code.

### Manual Verification Required

The user runs the registration recipe in `cma/README.md` against their own CMA org, captures the returned IDs into `~/.config/catalyst/cma.json`, and runs the smoke test in `cma/smoke-test/README.md`.

## Rollback Plan

`git revert` the single commit. Nothing else in the repo depends on `cma/` yet (Phase 1 Routine tickets are unblocked but not implemented).

## Deployment Notes

No deploy. The user's local `ant beta:agents create -f cma/agents/base.yaml` is the next step after this lands.

## Related Issues/PRs

- Fixes https://linear.app/catalyst/issue/CTL-286
- Unblocks https://linear.app/catalyst/issue/CTL-287
- Unblocks https://linear.app/catalyst/issue/CTL-288
- Unblocks https://linear.app/catalyst/issue/CTL-289
- Unblocks https://linear.app/catalyst/issue/CTL-290
- Unblocks https://linear.app/catalyst/issue/CTL-291
- Refs (deferred work) https://linear.app/catalyst/issue/CTL-292 https://linear.app/catalyst/issue/CTL-293 https://linear.app/catalyst/issue/CTL-294 https://linear.app/catalyst/issue/CTL-295 https://linear.app/catalyst/issue/CTL-296 https://linear.app/catalyst/issue/CTL-297 https://linear.app/catalyst/issue/CTL-298

## Changelog Entry

`feat(meta): scaffold CMA cloud environment + Catalyst context (CTL-286)`

## Reviewer Notes

- Quality gates were N/A: this PR contains markdown + YAML only, no TypeScript. The standard `validate-type-safety` pipeline (tsc / scan-reward-hacking / tests / lint) runs on no changed source files.
- The ADR makes the thoughts strategy choice **explicitly tentative**, supersedable by CTL-295. If you'd rather lock it in, say so and we can flip the status.
- Slack OAuth and Notion self-host MCP are documented but deferred. The base agent declares all four MCP servers in its config; when a routine actually needs the Slack OAuth tokens or self-hosted Notion endpoint, it adds the credential to the vault and (for Notion) updates the placeholder URL in `base.yaml`.

## Post-Merge Tasks

- [ ] User runs registration recipe locally (`cma/README.md`)
- [ ] User runs smoke test (`cma/smoke-test/README.md`)
- [ ] Implement first routine — recommended start: CTL-287 (backlog triage) — to validate the base scaffolding under real load

---
**Definition of Done Checklist:**

- [x] `cma/decisions/2026-05-07-thoughts-strategy.md` written, status: Accepted (tentative)
- [x] `cma/environment.yaml` parses with yq, contains required hosts in allowlist
- [x] `cma/agents/base.yaml` and `cma/agents/base-system-prompt.md` written, encode canonical state map and reward-hacking pattern list
- [x] `cma/mcp/{linear,github,slack,notion}.md` all exist; Slack and Notion docs each surface MCP path AND REST fallback
- [x] `cma/vaults/example.yaml` written with placeholder credentials only
- [x] `cma/smoke-test/README.md` written with executable recipe
- [x] `cma/README.md` written; registration recipe references real file paths
- [x] CTL-287..CTL-291 each have a Linear comment pointing to this scaffolding
- [ ] PR opened, CI green, reviewed, merged
- [ ] CTL-286 transitions to Done