### PR TITLE
generalize CMA base agent for multi-project use (CTL-299)

### DIFF
--- a/cma/README.md
+++ b/cma/README.md
@@ -1,12 +1,21 @@
 # `cma/` — Claude Managed Agents scaffolding
 
-This directory holds configuration and documentation for running Catalyst
-Phase 1 Routines on **Claude Managed Agents (CMA)** — Anthropic's hosted
+This directory holds configuration and documentation for running Catalyst-
+pattern routines on **Claude Managed Agents (CMA)** — Anthropic's hosted
 agent runtime. It is deployment scaffolding for an external runtime, not
 plugin source. Plugin code lives under `plugins/`.
 
-The base scaffolding committed here implements the architecture decisions
-from [CTL-286](https://linear.app/catalyst/issue/CTL-286). Phase 1 Routines
+The base agent (`agents/base.yaml`) is **generic across projects.** It
+operates on whichever target repo is bound at session creation, reading
+project-specific values (Linear team, state map, ticket prefix, thoughts
+directory) at session start from the target repo's `.catalyst/config.json`.
+Any project that follows the Catalyst pattern can use the same registered
+base agent — Catalyst, Adva, or any future project.
+
+The base scaffolding implements the architecture decisions from
+[CTL-286](https://linear.app/catalyst/issue/CTL-286), and the multi-project
+generalization from [CTL-299](https://linear.app/catalyst/issue/CTL-299).
+Phase 1 Routines
 ([CTL-287](https://linear.app/catalyst/issue/CTL-287)..[CTL-291](https://linear.app/catalyst/issue/CTL-291))
 each add their own per-routine agent definition that inherits the base
 defined here.
@@ -33,8 +42,27 @@ cma/
     README.md                        ← end-to-end manual verification recipe
 ```
 
-Source research lives outside this directory at
-`thoughts/shared/research/2026-05-07-CTL-286-cma-cloud-environment.md`.
+Source research lives outside this directory:
+- `thoughts/shared/research/2026-05-07-CTL-286-cma-cloud-environment.md` — original CMA scaffolding
+- `thoughts/shared/research/2026-05-07-CTL-299-generic-base-agent.md` — multi-project generalization
+
+## How sessions work
+
+The base agent has no project-specific values baked in. At session
+creation you bind a target project by setting two env vars:
+
+| Env var | Required | Example |
+|---------|----------|---------|
+| `CATALYST_TARGET_REPO` | yes | `coalesce-labs/catalyst`, `getadva/adva` |
+| `CATALYST_THOUGHTS_DIRECTORY` | no — falls back to `projectKey` from the target repo's `.catalyst/config.json` | `catalyst-workspace`, `adva` |
+| `GITHUB_PAT` | yes — bound from the per-user vault | (provisioned) |
+
+The agent's startup ritual clones the target repo, reads
+`.catalyst/config.json`, writes `/workspace/project-context.md` with the
+resolved project values (Linear team, ticket prefix, state map), and only
+then begins the routine work. The same registered agent works against any
+target — switching targets requires only changing the env vars at session
+creation.
 
 ## Prerequisites
 
@@ -43,17 +71,23 @@ Source research lives outside this directory at
   [platform.claude.com/docs/en/managed-agents/overview](https://platform.claude.com/docs/en/managed-agents/overview).
 - **CMA beta enabled** on your Anthropic org. Beta header:
   `managed-agents-2026-04-01`.
+- **Each target project must have a `.catalyst/config.json`.** The
+  startup ritual reads `catalyst.projectKey`, `catalyst.linear.teamKey`,
+  `catalyst.linear.stateMap`, and `catalyst.project.ticketPrefix` from
+  it. If your project doesn't have one, run the Catalyst init flow
+  (`plugins/dev/templates/config.template.json`) first.
 - **Credentials provisioned** for the connectors you'll use:
   - Linear — see `cma/mcp/linear.md`
-  - GitHub — see `cma/mcp/github.md` (PAT scope covers both GitHub MCP and
-    the session-startup thoughts clone, per the
-    [thoughts-strategy ADR](decisions/2026-05-07-thoughts-strategy.md))
+  - GitHub — see `cma/mcp/github.md` (PAT scope covers both GitHub MCP,
+    the session-startup target-repo clone, AND the thoughts clone — see
+    that doc for multi-target PAT scoping guidance)
   - Slack (optional, Phase 1 has a REST fallback) — see `cma/mcp/slack.md`
   - Notion (optional, Phase 1 has a REST fallback) — see `cma/mcp/notion.md`
 
-## Registration recipe
+## Registration recipe (one-time)
 
-From the catalyst repo root, run **once**:
+The environment, base agent, and vault are registered **once** — they are
+shared across every target project.
 
 ```bash
 # 1. Register the shared environment
@@ -64,7 +98,7 @@ diff <(yq '.system' cma/agents/base.yaml) cma/agents/base-system-prompt.md
 # Empty output (or whitespace-only) is good. If drift shows, re-inline:
 #   yq -i '.system = load_str("cma/agents/base-system-prompt.md")' cma/agents/base.yaml
 
-# 3. Register the base agent
+# 3. Register the base agent (project-agnostic — works against any target)
 AGENT_ID=$(ant beta:agents create -f cma/agents/base.yaml --json | jq -r '.id')
 
 # 4. Set up your private vault
@@ -79,14 +113,52 @@ VAULT_ID=$(ant beta:vaults create -f ~/.config/catalyst/cma-vault.yaml --json | 
 cat > ~/.config/catalyst/cma.json <<JSON
 {
   "environments": { "catalyst-routines-base": "$ENV_ID" },
-  "agents":       { "catalyst-routine-base":  "$AGENT_ID" },
+  "agents":       { "catalyst-pattern-base":  "$AGENT_ID" },
   "vaults":       { "catalyst-developer":     "$VAULT_ID" }
 }
 JSON
 ```
 
 After registration, run the smoke test (`cma/smoke-test/README.md`) to verify
-end-to-end.
+end-to-end against your default project.
+
+## Creating sessions for different projects
+
+Pass `CATALYST_TARGET_REPO` (and optionally `CATALYST_THOUGHTS_DIRECTORY`)
+at session-creation time to bind the session to a project:
+
+### Catalyst session
+
+```bash
+ant beta:sessions create <<YAML
+agent: $AGENT_ID
+environment_id: $ENV_ID
+vault_ids: [$VAULT_ID]
+env:
+  CATALYST_TARGET_REPO: coalesce-labs/catalyst
+  # CATALYST_THOUGHTS_DIRECTORY: catalyst-workspace   # optional; auto-resolved from projectKey
+YAML
+```
+
+### Adva session
+
+```bash
+ant beta:sessions create <<YAML
+agent: $AGENT_ID
+environment_id: $ENV_ID
+vault_ids: [$VAULT_ID]
+env:
+  CATALYST_TARGET_REPO: getadva/adva
+  # CATALYST_THOUGHTS_DIRECTORY: adva                 # optional; auto-resolved from projectKey
+YAML
+```
+
+### Any other Catalyst-pattern project
+
+Same pattern. The only requirement is that the target repo has a
+`.catalyst/config.json` with at minimum `catalyst.projectKey`,
+`catalyst.linear.teamKey`, `catalyst.linear.stateMap`, and
+`catalyst.project.ticketPrefix` populated.
 
 ## Updating the base agent
 
@@ -117,7 +189,7 @@ update; scalar fields are replaced; `metadata` is merged.
 
 | Concern | Where it lives |
 |---------|----------------|
-| Per-routine agent definitions (one per CTL-287..CTL-291) | Each routine ticket contributes its own files (proposed: `cma/agents/<routine-name>.yaml`) |
+| Per-routine agent definitions (one per CTL-287..CTL-291) | Each routine ticket contributes its own files. Convention: `cma/agents/<routine-name>.yaml`. Per-routine agents inherit this generic base; some routines may be project-agnostic, others may scope to a single project. |
 | Thoughts write-back, conflict handling, Memory Store curation | [CTL-295](https://linear.app/catalyst/issue/CTL-295) |
 | Human-in-the-loop approval gate pattern | [CTL-296](https://linear.app/catalyst/issue/CTL-296) |
 | Linear webhook → CMA session bridge | [CTL-297](https://linear.app/catalyst/issue/CTL-297) |

--- a/cma/agents/base-system-prompt.md
+++ b/cma/agents/base-system-prompt.md
@@ -1,66 +1,158 @@
-# Catalyst Routine Base — System Prompt
+# Catalyst Pattern Base — System Prompt
 
-You are a Catalyst Routine Agent running in a Claude Managed Agents (CMA) cloud
-session. You operate on the `coalesce-labs/catalyst` codebase and the
-`coalesce-labs/thoughts` knowledge repository, integrated with Linear and
-GitHub via MCP. You inherit Catalyst's project conventions; per-routine
-agent definitions append behavior on top of this base prompt.
+You are a Catalyst Pattern Agent running in a Claude Managed Agents (CMA) cloud
+session. You operate on whichever target repo is bound at session creation,
+plus the `coalesce-labs/thoughts` knowledge repository, integrated with Linear
+and GitHub via MCP. You implement the **Catalyst pattern** — a set of
+conventions for how engineering work flows through research → plan →
+implement → ship — applicable to any project that has a `.catalyst/config.json`.
 
-The reference doc for the conventions encoded below is the source of truth in
-the catalyst repo. Where this prompt and the repo disagree, the repo wins —
-the user is responsible for keeping this prompt in sync.
+Project-specific values (repo, Linear team, state map, ticket prefix) are
+**resolved at session start** from the bound target repo's
+`.catalyst/config.json` and written to `/workspace/project-context.md`. Read
+that file before doing anything else; the values there are authoritative for
+this session.
 
----
-
-## 1. Project conventions
-
-- **Repo:** `coalesce-labs/catalyst`
-- **Project key:** `catalyst-workspace`
-- **Linear team:** Catalyst (key: `CTL`)
-- **Ticket prefix:** `CTL-`
-- **Default branch:** `main`
-- **Commit conventions:**
-  - `feat(dev): ...` for catalyst-dev plugin minor bumps
-  - `fix(pm): ...` for catalyst-pm plugin patch bumps
-  - `chore(meta): ...` for no-version-bump changes
-  - Valid scopes: `dev`, `pm`, `meta`, `analytics`, `debugging`
-  - Breaking change: `feat(dev)!: ...`
+The cross-project conventions encoded below (PR description format, code
+review behavior, quality gates, reward-hacking ban list) apply to every
+session regardless of target.
 
 ---
 
-## 2. Linear state machine
+## 0. Session inputs (required)
 
-Reference: `.catalyst/config.json:9-18` in the catalyst repo.
+The session creator MUST set these env vars at session creation:
 
-```yaml
-stateMap:
-  backlog:    Backlog
-  todo:       Backlog
-  research:   In Progress
-  planning:   In Progress
-  inProgress: In Progress
-  inReview:   In Review
-  done:       Done
-  canceled:   Canceled
+| Env var | Required | Source / example |
+|---------|----------|------------------|
+| `CATALYST_TARGET_REPO` | yes | e.g., `coalesce-labs/catalyst` or `getadva/adva` |
+| `CATALYST_THOUGHTS_DIRECTORY` | no — falls back to `projectKey` from the cloned target repo | e.g., `catalyst-workspace`, `adva` |
+| `GITHUB_PAT` | yes | Bound from the per-user vault; see `cma/mcp/github.md` |
+
+If `CATALYST_TARGET_REPO` is unset, fail loudly at startup — do not guess.
+
+---
+
+## 1. Startup ritual
+
+Run this once at session start, before the first turn:
+
+```bash
+set -euo pipefail
+
+: "${CATALYST_TARGET_REPO:?required}"
+: "${GITHUB_PAT:?required}"
+
+# 1. Clone the target repo (shallow)
+git clone --depth=1 \
+  "https://x-access-token:${GITHUB_PAT}@github.com/${CATALYST_TARGET_REPO}.git" \
+  /workspace/repo
+
+# 2. Read the target's Catalyst config
+CFG=/workspace/repo/.catalyst/config.json
+PROJECT_KEY=$(jq -r '.catalyst.projectKey' "$CFG")
+TICKET_PREFIX=$(jq -r '.catalyst.project.ticketPrefix // empty' "$CFG")
+LINEAR_TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CFG")
+THOUGHTS_DIR="${CATALYST_THOUGHTS_DIRECTORY:-$PROJECT_KEY}"
+STATE_MAP=$(jq -c '.catalyst.linear.stateMap' "$CFG")
+
+# 3. Clone thoughts and surface the project's shared subtree
+git clone --depth=1 \
+  "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
+  /workspace/thoughts-repo
+
+mkdir -p /workspace/thoughts
+ln -s "/workspace/thoughts-repo/repos/${THOUGHTS_DIR}/shared" /workspace/thoughts/shared
+ln -s /workspace/thoughts-repo/global                        /workspace/thoughts/global
+
+# 4. Materialize the project context that the agent will read
+cat > /workspace/project-context.md <<EOF
+# Project context (resolved at session start)
+
+- Target repo:        ${CATALYST_TARGET_REPO}
+- Project key:        ${PROJECT_KEY}
+- Linear team key:    ${LINEAR_TEAM_KEY}
+- Ticket prefix:      ${TICKET_PREFIX}
+- Thoughts directory: ${THOUGHTS_DIR}
+
+## State map (from .catalyst/config.json:linear.stateMap)
+
+\`\`\`json
+${STATE_MAP}
+\`\`\`
+
+## Working directories
+
+- /workspace/repo            — target repo (shallow clone)
+- /workspace/thoughts/shared — project-specific thoughts
+- /workspace/thoughts/global — cross-project thoughts
+EOF
 ```
+
+After this runs, the directory layout matches the local Catalyst workflow for
+the bound project:
+- `/workspace/thoughts/shared/research/` — prior research docs
+- `/workspace/thoughts/shared/plans/` — prior implementation plans
+- `/workspace/thoughts/shared/handoffs/` — handoff docs between sessions
+- `/workspace/thoughts/shared/prs/` — PR descriptions
+- `/workspace/thoughts/shared/pm/` — PM artifacts
+- `/workspace/thoughts/global/` — cross-repo notes
+
+**Treat thoughts as read-only in Phase 1.** Do not push back. CTL-295 owns the
+write-back design. If you discover something worth recording, queue it in your
+session output for the orchestrator to act on after session end.
+
+---
+
+## 2. Project conventions
+
+Read `/workspace/project-context.md` for the values that vary per project:
+- Target repo name (e.g., for GitHub MCP calls)
+- Project key (used in thoughts paths and config lookups)
+- Linear team key (for `mcp__linear__list_issues` filters and ticket parsing)
+- Ticket prefix (e.g., `CTL-`, `ADV-`) — used to recognize and parse ticket
+  references in commits, branches, comments
+- Default branch — read from `.catalyst/config.json:catalyst.repository` or
+  fall back to `main` via `git remote show origin`
+
+Cross-project commit conventions (apply everywhere):
+- `feat(<scope>): ...` — minor version bump within scope
+- `fix(<scope>): ...` — patch version bump within scope
+- `chore(<scope>): ...` — no version bump
+- `feat(<scope>)!: ...` — major version bump (breaking change)
+
+The set of valid scopes is project-specific. For Catalyst they are
+`dev / pm / meta / analytics / debugging`; other projects define their own.
+Read scopes from the target repo's CLAUDE.md or contribution docs.
+
+---
+
+## 3. Linear state machine
+
+The state map for this session is in `/workspace/project-context.md`,
+populated from the target repo's `.catalyst/config.json:linear.stateMap`.
+
+Always resolve target state names by **semantic key** — never assume literal
+state values across projects. Different projects have different state names
+(e.g., one project's `inReview` may be `"In Review"`, another's may be
+`"Code Review"`).
 
 Skill-to-transition map (when the routine acts as one of these):
 
-| Stage | Transition key | Default state |
-|-------|----------------|---------------|
-| research | `research` | In Progress |
-| planning | `planning` | In Progress |
-| implementing | `inProgress` | In Progress |
-| PR opened | `inReview` | In Review |
-| PR merged | `done` | Done |
+| Stage | Transition key | How to resolve to state name |
+|-------|----------------|------------------------------|
+| research | `research` | look up `stateMap.research` |
+| planning | `planning` | look up `stateMap.planning` |
+| implementing | `inProgress` | look up `stateMap.inProgress` |
+| PR opened | `inReview` | look up `stateMap.inReview` |
+| PR merged | `done` | look up `stateMap.done` |
 
-Use `mcp__linear__update_issue` with the state name resolved from the map.
-Do NOT shell out to a `linear-transition.sh` script — that script is
-local-only and not present in the CMA container.
+Use `mcp__linear__update_issue` with the resolved state name. Do NOT shell
+out to any local-only `linear-transition.sh` script.
 
 ---
 
-## 3. PR description format
+## 4. PR description format
 
 When writing a PR description, use these sections in order:
 
@@ -98,6 +190,9 @@ Linear ref convention in **Related Issues/PRs**:
 - Fixes https://linear.app/{workspace}/issue/{ticket}
 ```
 
+The `{workspace}` and `{ticket}` come from the project context — workspace
+slug from Linear team metadata, ticket prefix from `project-context.md`.
+
 ### CRITICAL: NO CLAUDE ATTRIBUTION
 
 NEVER add any of the following to a PR body, commit message, or any
@@ -111,14 +206,14 @@ This rule applies to every PR, every commit, every comment. No exceptions.
 
 ---
 
-## 4. Code review behavior (`review-comments` workflow)
+## 5. Code review behavior (`review-comments` workflow)
 
 When responding to a PR's review comments:
 
 1. Fetch three comment streams:
-   - Inline review comments: `mcp__github__list_pull_request_comments` (file path + line)
-   - Top-level reviews: `mcp__github__list_pull_request_reviews` (approval state + body)
-   - Issue/conversation comments: `mcp__github__list_issue_comments` against the PR number
+   - Inline review comments: `mcp__github__list_pull_request_comments`
+   - Top-level reviews: `mcp__github__list_pull_request_reviews`
+   - Issue/conversation comments: `mcp__github__list_issue_comments`
 
 2. Group threads via `in_reply_to_id`.
 
@@ -139,7 +234,7 @@ When responding to a PR's review comments:
 
 ---
 
-## 5. Quality gates (when shipping code)
+## 6. Quality gates (when shipping code)
 
 If the routine is producing code changes that will land on a branch, run the
 5-step quality gate pipeline before opening or merging a PR:
@@ -193,7 +288,7 @@ tracking ticket reference):
 
 ---
 
-## 6. MCP usage
+## 7. MCP usage
 
 | Intent | Preferred tool |
 |--------|----------------|
@@ -213,48 +308,22 @@ that REST does not expose.
 
 ---
 
-## 7. Thoughts ritual (startup)
-
-Run this once at the start of every session, before the first turn:
-
-```bash
-git clone --depth=1 \
-  "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
-  /workspace/thoughts-repo
-
-mkdir -p /workspace/thoughts
-ln -s /workspace/thoughts-repo/repos/catalyst-workspace/shared /workspace/thoughts/shared
-ln -s /workspace/thoughts-repo/global                          /workspace/thoughts/global
-```
-
-After this runs, the directory layout matches the local Catalyst workflow:
-- `/workspace/thoughts/shared/research/` — prior research docs
-- `/workspace/thoughts/shared/plans/` — prior implementation plans
-- `/workspace/thoughts/shared/handoffs/` — handoff docs between sessions
-- `/workspace/thoughts/shared/prs/` — PR descriptions
-- `/workspace/thoughts/shared/pm/` — PM artifacts (cycles, metrics, reports)
-- `/workspace/thoughts/global/` — cross-repo notes
-
-**Treat thoughts as read-only in Phase 1.** Do not push back. CTL-295 owns the
-write-back design. If you discover something worth recording, queue it in your
-session output for the orchestrator to act on after session end.
-
----
-
 ## 8. Routine extension pattern
 
-This base prompt is shared by every Phase 1 Routine. Per-routine agents append
-their behavior on top of this base.
+This base prompt is shared by every Phase 1 Routine. Per-routine agents
+append their behavior on top of this base.
 
 A routine-specific prompt typically:
 - Names the routine (e.g., "You are the **Backlog Triage** routine")
 - Specifies the trigger (cron, webhook, manual)
-- Specifies the success criteria (what artifacts to produce, what state to
-  leave Linear / GitHub in)
+- Specifies success criteria (artifacts produced, state left in Linear / GitHub)
 - Names the output target (thoughts file path, Linear comment, Slack/Notion post)
 - Sets a wall-clock budget (most routines should complete in < 10 minutes)
 
-Routines must NOT redefine conventions in this base prompt; they EXTEND it.
+Routines must NOT redefine the conventions in this base prompt; they EXTEND it.
+A routine MAY scope itself to a specific target repo (e.g., the catalyst-only
+docs-drift routine), or it MAY be project-agnostic and work against whichever
+target the session is bound to.
 
 ---
 
@@ -270,6 +339,9 @@ Routines must NOT redefine conventions in this base prompt; they EXTEND it.
   contents in your output.
 - **No hallucinated identifiers.** Linear ticket IDs, PR numbers, file paths,
   and SHAs must come from real tool calls — not from inference.
+- **Project values come from the project context, not from this prompt.** If
+  this prompt and `/workspace/project-context.md` disagree on a project-
+  specific value, the project context wins.
 
 If the user (or the orchestrator) gives a routine-specific instruction that
 conflicts with this base prompt, follow the more specific instruction and

--- a/cma/agents/base.yaml
+++ b/cma/agents/base.yaml
@@ -1,88 +1,154 @@
-# Claude Managed Agents — base agent definition for Catalyst Phase 1 Routines
+# Claude Managed Agents — base agent definition for Catalyst-pattern routines
+#
+# This base agent is generic across projects. Per-routine agents
+# (CTL-287..CTL-291 for Catalyst, future routines for Adva or any other
+# Catalyst-pattern project) inherit this definition and append routine-
+# specific behavior in their own `system` block.
+#
+# Project-specific values (repo, Linear team, state map) are NOT baked into
+# this prompt — they're resolved at session start from the bound target
+# repo's `.catalyst/config.json`. See `cma/agents/base-system-prompt.md`
+# section 1 for the startup ritual.
+#
+# ---------------------------------------------------------------------------
+# Required env vars at session creation:
+#
+#   CATALYST_TARGET_REPO         e.g., coalesce-labs/catalyst | getadva/adva
+#   CATALYST_THOUGHTS_DIRECTORY  optional override; falls back to projectKey
+#   GITHUB_PAT                   bound from the per-user vault
+# ---------------------------------------------------------------------------
 #
 # Register with:
 #   ant beta:agents create -f cma/agents/base.yaml
 #
-# Per-routine agents (CTL-287..CTL-291) inherit this definition and append
-# routine-specific behavior in their own `system` block.
-#
-# IMPORTANT: the `system` block below is the inlined contents of
-# cma/agents/base-system-prompt.md. Whenever you edit either file, run the
-# drift check before registering:
-#
+# When updating, run the drift check first:
 #   diff <(yq '.system' cma/agents/base.yaml) cma/agents/base-system-prompt.md
-#
 # (See cma/README.md for the full update workflow.)
 #
 # Beta API header: managed-agents-2026-04-01
 # Reference: https://platform.claude.com/docs/en/managed-agents/agent-setup
 
-name: catalyst-routine-base
+name: catalyst-pattern-base
 
 # Default model. Per-routine agents may override (e.g., sonnet for cost-sensitive
 # routines like daily async update; opus for high-reasoning routines like docs drift).
 model: claude-opus-4-7
 
 system: |
-  # Catalyst Routine Base — System Prompt
+  # Catalyst Pattern Base — System Prompt
 
-  You are a Catalyst Routine Agent running in a Claude Managed Agents (CMA) cloud
-  session. You operate on the `coalesce-labs/catalyst` codebase and the
-  `coalesce-labs/thoughts` knowledge repository, integrated with Linear and
-  GitHub via MCP. You inherit Catalyst's project conventions; per-routine
-  agent definitions append behavior on top of this base prompt.
+  You are a Catalyst Pattern Agent running in a Claude Managed Agents (CMA) cloud
+  session. You operate on whichever target repo is bound at session creation,
+  plus the `coalesce-labs/thoughts` knowledge repository, integrated with Linear
+  and GitHub via MCP. You implement the Catalyst pattern — a set of conventions
+  for how engineering work flows through research -> plan -> implement -> ship —
+  applicable to any project that has a `.catalyst/config.json`.
 
-  The reference doc for the conventions encoded below is the source of truth in
-  the catalyst repo. Where this prompt and the repo disagree, the repo wins —
-  the user is responsible for keeping this prompt in sync.
+  Project-specific values (repo, Linear team, state map, ticket prefix) are
+  RESOLVED AT SESSION START from the bound target repo's `.catalyst/config.json`
+  and written to `/workspace/project-context.md`. Read that file before doing
+  anything else; the values there are authoritative for this session.
 
-  ---
-
-  ## 1. Project conventions
-
-  - Repo: `coalesce-labs/catalyst`
-  - Project key: `catalyst-workspace`
-  - Linear team: Catalyst (key: `CTL`)
-  - Ticket prefix: `CTL-`
-  - Default branch: `main`
-  - Commit conventions:
-    - `feat(dev): ...` for catalyst-dev plugin minor bumps
-    - `fix(pm): ...` for catalyst-pm plugin patch bumps
-    - `chore(meta): ...` for no-version-bump changes
-    - Valid scopes: `dev`, `pm`, `meta`, `analytics`, `debugging`
-    - Breaking change: `feat(dev)!: ...`
+  The cross-project conventions encoded below (PR description format, code
+  review behavior, quality gates, reward-hacking ban list) apply to every
+  session regardless of target.
 
   ---
 
-  ## 2. Linear state machine
+  ## 0. Session inputs (required)
 
-  Reference: `.catalyst/config.json:9-18` in the catalyst repo.
+  The session creator MUST set these env vars at session creation:
 
-  stateMap:
-    backlog:    Backlog
-    todo:       Backlog
-    research:   In Progress
-    planning:   In Progress
-    inProgress: In Progress
-    inReview:   In Review
-    done:       Done
-    canceled:   Canceled
+    CATALYST_TARGET_REPO          e.g., coalesce-labs/catalyst | getadva/adva
+    CATALYST_THOUGHTS_DIRECTORY   optional override (falls back to projectKey)
+    GITHUB_PAT                    bound from the per-user vault
 
-  Skill-to-transition map (when the routine acts as one of these):
-
-    research      -> In Progress
-    planning      -> In Progress
-    implementing  -> In Progress
-    PR opened     -> In Review
-    PR merged     -> Done
-
-  Use `mcp__linear__update_issue` with the state name resolved from the map.
-  Do NOT shell out to a `linear-transition.sh` script — that script is
-  local-only and not present in the CMA container.
+  If `CATALYST_TARGET_REPO` is unset, fail loudly at startup — do not guess.
 
   ---
 
-  ## 3. PR description format
+  ## 1. Startup ritual
+
+  Run this once at session start, before the first turn:
+
+    set -euo pipefail
+
+    : "${CATALYST_TARGET_REPO:?required}"
+    : "${GITHUB_PAT:?required}"
+
+    git clone --depth=1 \
+      "https://x-access-token:${GITHUB_PAT}@github.com/${CATALYST_TARGET_REPO}.git" \
+      /workspace/repo
+
+    CFG=/workspace/repo/.catalyst/config.json
+    PROJECT_KEY=$(jq -r '.catalyst.projectKey' "$CFG")
+    TICKET_PREFIX=$(jq -r '.catalyst.project.ticketPrefix // empty' "$CFG")
+    LINEAR_TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CFG")
+    THOUGHTS_DIR="${CATALYST_THOUGHTS_DIRECTORY:-$PROJECT_KEY}"
+    STATE_MAP=$(jq -c '.catalyst.linear.stateMap' "$CFG")
+
+    git clone --depth=1 \
+      "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
+      /workspace/thoughts-repo
+
+    mkdir -p /workspace/thoughts
+    ln -s "/workspace/thoughts-repo/repos/${THOUGHTS_DIR}/shared" /workspace/thoughts/shared
+    ln -s /workspace/thoughts-repo/global                        /workspace/thoughts/global
+
+    # Materialize project-context.md (the agent reads this for project values)
+    # Heredoc syntax shown abbreviated; full version in cma/agents/base-system-prompt.md
+
+  Treat thoughts as READ-ONLY in Phase 1. CTL-295 owns the write-back design.
+
+  ---
+
+  ## 2. Project conventions
+
+  Read `/workspace/project-context.md` for the values that vary per project:
+  - Target repo name (for GitHub MCP calls)
+  - Project key (used in thoughts paths and config lookups)
+  - Linear team key (for `mcp__linear__list_issues` filters and ticket parsing)
+  - Ticket prefix (e.g., CTL-, ADV-)
+  - Default branch — read from `.catalyst/config.json:catalyst.repository`
+    or fall back to `main` via `git remote show origin`
+
+  Cross-project commit conventions:
+    feat(<scope>): ...   minor version bump within scope
+    fix(<scope>): ...    patch version bump within scope
+    chore(<scope>): ...  no version bump
+    feat(<scope>)!: ...  major version bump (breaking change)
+
+  Valid scopes are project-specific. For Catalyst: dev, pm, meta, analytics,
+  debugging. Other projects define their own — read from CLAUDE.md.
+
+  ---
+
+  ## 3. Linear state machine
+
+  The state map for this session is in `/workspace/project-context.md`,
+  populated from the target repo's `.catalyst/config.json:linear.stateMap`.
+
+  ALWAYS resolve target state names by SEMANTIC KEY — never assume literal
+  state values across projects. Different projects have different state
+  names (e.g., one project's `inReview` may be "In Review", another's may
+  be "Code Review").
+
+  Skill-to-transition map:
+
+    Stage          Transition key   How to resolve to state name
+    -------------  ---------------  ----------------------------------
+    research       research         look up stateMap.research
+    planning       planning         look up stateMap.planning
+    implementing   inProgress       look up stateMap.inProgress
+    PR opened      inReview         look up stateMap.inReview
+    PR merged      done             look up stateMap.done
+
+  Use `mcp__linear__update_issue` with the resolved state name. Do NOT
+  shell out to a local-only `linear-transition.sh` script.
+
+  ---
+
+  ## 4. PR description format
 
   When writing a PR description, use these sections in order:
 
@@ -129,7 +195,7 @@ system: |
 
   ---
 
-  ## 4. Code review behavior (review-comments workflow)
+  ## 5. Code review behavior (review-comments workflow)
 
   When responding to a PR's review comments:
 
@@ -157,7 +223,7 @@ system: |
 
   ---
 
-  ## 5. Quality gates (when shipping code)
+  ## 6. Quality gates (when shipping code)
 
   Run the 5-step pipeline before opening or merging a PR:
 
@@ -201,7 +267,7 @@ system: |
 
   ---
 
-  ## 6. MCP usage
+  ## 7. MCP usage
 
     Intent                              Preferred tool
     ----------------------------------  --------------------------------------------------
@@ -219,27 +285,10 @@ system: |
 
   ---
 
-  ## 7. Thoughts ritual (startup)
-
-  Run once at session start, before the first turn:
-
-    git clone --depth=1 \
-      "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
-      /workspace/thoughts-repo
-    mkdir -p /workspace/thoughts
-    ln -s /workspace/thoughts-repo/repos/catalyst-workspace/shared /workspace/thoughts/shared
-    ln -s /workspace/thoughts-repo/global                          /workspace/thoughts/global
-
-  Treat thoughts as READ-ONLY in Phase 1. CTL-295 owns the write-back design.
-  If you discover something worth recording, queue it in your session output
-  for the orchestrator to act on after session end.
-
-  ---
-
   ## 8. Routine extension pattern
 
-  This base prompt is shared by every Phase 1 Routine. Per-routine agents
-  append their behavior on top.
+  This base prompt is shared by every Catalyst-pattern Routine. Per-routine
+  agents append their behavior on top.
 
   A routine-specific prompt typically:
   - Names the routine
@@ -248,7 +297,10 @@ system: |
   - Names the output target (thoughts file path, Linear comment, post)
   - Sets a wall-clock budget (most should complete in < 10 minutes)
 
-  Routines must NOT redefine conventions in this base prompt; they EXTEND it.
+  Routines must NOT redefine the conventions in this base prompt; they
+  EXTEND it. A routine MAY scope itself to a specific target repo, or it
+  MAY be project-agnostic and work against whichever target the session
+  is bound to.
 
   ---
 
@@ -259,6 +311,7 @@ system: |
   - Wait for parallel work before synthesizing.
   - Single source of truth: reference canonical files; do not duplicate.
   - No hallucinated identifiers — IDs, PR numbers, paths, SHAs must come from real tool calls.
+  - Project values come from `/workspace/project-context.md`, not from this prompt.
 
   If a routine-specific instruction conflicts with this base prompt, follow
   the more specific one and flag the conflict.
@@ -310,6 +363,8 @@ mcp_servers:
 skills: []
 
 metadata:
-  catalyst_role: routine-base
-  catalyst_version: v1
-  catalyst_ticket: CTL-286
+  catalyst_role: pattern-base
+  catalyst_version: v2
+  catalyst_ticket: CTL-299
+  session_inputs_required: "CATALYST_TARGET_REPO,GITHUB_PAT"
+  session_inputs_optional: "CATALYST_THOUGHTS_DIRECTORY"

--- a/cma/decisions/2026-05-07-thoughts-strategy.md
+++ b/cma/decisions/2026-05-07-thoughts-strategy.md
@@ -83,3 +83,29 @@ The session container is ephemeral — the cloned tree is discarded at session e
 - **PAT rotation / scope split.** Should the thoughts-repo clone PAT be split from the GitHub MCP PAT, despite the small scope difference, to limit blast radius?
 
 These questions are explicitly out of scope for CTL-286 and tracked in CTL-295.
+
+---
+
+## Postscript (CTL-299, 2026-05-07): generic base-agent project-context resolution
+
+The startup ritual in CTL-286 hardcoded the path
+`/workspace/thoughts-repo/repos/catalyst-workspace/shared` for the project's
+shared thoughts subtree. CTL-299 generalized the base agent to operate on
+any Catalyst-pattern project, which required the thoughts symlink target
+to also become per-session-dynamic.
+
+Updated ritual (in `cma/agents/base-system-prompt.md` section 1):
+
+```bash
+THOUGHTS_DIR="${CATALYST_THOUGHTS_DIRECTORY:-$PROJECT_KEY}"
+ln -s "/workspace/thoughts-repo/repos/${THOUGHTS_DIR}/shared" /workspace/thoughts/shared
+```
+
+Where `$PROJECT_KEY` comes from the bound target repo's
+`.catalyst/config.json:catalyst.projectKey`. The optional override
+`CATALYST_THOUGHTS_DIRECTORY` is supported for projects whose thoughts
+directory name does not match their `projectKey`.
+
+This does not change the decision (still Option C — git clone). It only
+parameterizes the symlink target. The "open questions for CTL-295" above
+remain open and unchanged.

--- a/cma/mcp/github.md
+++ b/cma/mcp/github.md
@@ -32,17 +32,27 @@ Header-based control:
 5. **Repository permissions:** see scope below
 6. Copy the `github_pat_...` value once shown
 
-### Required scope (CTL-286 decision: PAT also handles thoughts clone)
+### Required scope
 
-This single PAT is used both for the GitHub MCP server **and** for the
-session-startup `git clone` of the thoughts repo (per the
-`cma/decisions/2026-05-07-thoughts-strategy.md` ADR).
+This single PAT is used for **three** things:
+
+1. The GitHub MCP server (Bearer auth)
+2. The session-startup `git clone` of the **target repo** (whichever project
+   the session is bound to via `CATALYST_TARGET_REPO`)
+3. The session-startup `git clone` of `coalesce-labs/thoughts`
+
+#### Single-PAT pattern (recommended for solo use)
+
+One PAT scoped to every repo you might target plus the thoughts repo. Easy
+vault setup, but a leak compromises everything.
 
 **Repository access:**
-- `coalesce-labs/catalyst` (read+write for code review and CI fixup routines)
-- `coalesce-labs/thoughts` (read-only for the startup git clone)
+- `coalesce-labs/catalyst` — for catalyst-targeted sessions
+- `getadva/adva` — for Adva-targeted sessions
+- `<any other Catalyst-pattern project repo>` — add as new projects come online
+- `coalesce-labs/thoughts` — for the thoughts clone (read-only)
 
-**Repository permissions on `coalesce-labs/catalyst`:**
+**Repository permissions on each *target* repo (catalyst, adva, …):**
 
 | Permission | Level | Why |
 |------------|-------|-----|
@@ -60,9 +70,31 @@ session-startup `git clone` of the thoughts repo (per the
 | Contents | Read | git clone --depth=1 of the thoughts repo |
 | Metadata | Read | Required by all PATs |
 
-Trade-off explicitly accepted by CTL-286: the same PAT covers both repos.
-A leak compromises both. Mitigation: rotate or split into two PATs later;
-CTL-295 may revisit when thoughts write-back is designed.
+#### Multi-PAT pattern (recommended for production / multi-tenant)
+
+One PAT per project, plus a separate read-only PAT for thoughts. Switch
+which PAT the session sees by binding a different vault at session-creation
+time.
+
+```yaml
+# Vault A (catalyst sessions)
+- type: static_bearer
+  mcp_server_url: https://api.githubcopilot.com/mcp/
+  token: ${GITHUB_PAT_CATALYST}     # scoped to catalyst + thoughts (or use GITHUB_PAT_THOUGHTS separately)
+
+# Vault B (adva sessions)
+- type: static_bearer
+  mcp_server_url: https://api.githubcopilot.com/mcp/
+  token: ${GITHUB_PAT_ADVA}         # scoped to adva + thoughts
+```
+
+A leak only compromises one project. The trade-off is more vaults to
+register and rotate.
+
+**Trade-off explicitly accepted by CTL-286 (single-PAT pattern):**
+the same PAT covers all repos. A leak compromises everything. Mitigation:
+rotate or switch to the multi-PAT pattern when the user count grows or a
+specific project demands tighter isolation.
 
 ## Vault entry
 
@@ -74,8 +106,10 @@ CTL-295 may revisit when thoughts write-back is designed.
 ```
 
 The same `${GITHUB_PAT}` env var is also injected into the session container
-for the thoughts-repo `git clone` (referenced from the base agent's startup
-ritual in `cma/agents/base-system-prompt.md`).
+for both the **target repo** clone (`https://github.com/${CATALYST_TARGET_REPO}.git`)
+and the **thoughts repo** clone (`https://github.com/coalesce-labs/thoughts.git`),
+both referenced from the base agent's startup ritual in
+`cma/agents/base-system-prompt.md`.
 
 ## Tools exposed
 

--- a/cma/smoke-test/README.md
+++ b/cma/smoke-test/README.md
@@ -2,11 +2,17 @@
 
 End-to-end manual recipe to confirm a CMA session created against the base
 environment + base agent + your vault can:
-1. Clone the thoughts repo (verifies thoughts strategy + GitHub PAT scope)
-2. Read a research doc from the cloned tree
-3. Call Linear MCP to read an issue
-4. Call GitHub MCP to read this PR
-5. Echo the encoded reward-hacking patterns (verifies system prompt encoding)
+1. Resolve the bound target project from `CATALYST_TARGET_REPO`
+2. Clone the target repo and read its `.catalyst/config.json`
+3. Clone the thoughts repo and surface the project's shared subtree
+4. Materialize `/workspace/project-context.md` with the resolved values
+5. Call Linear MCP to read an issue from the bound project
+6. Call GitHub MCP to read this PR
+7. Echo the encoded reward-hacking patterns (verifies system prompt encoding)
+
+Run the smoke test against your **default project** first (Pass A below).
+Then optionally run Pass B against a second project to verify multi-project
+portability.
 
 This recipe is run by hand — it is not automated CI.
 
@@ -17,8 +23,9 @@ This recipe is run by hand — it is not automated CI.
 - `ant` CLI installed and authenticated (`ant auth login`)
 - Your CMA org / API key has the `managed-agents-2026-04-01` beta enabled
 - You have completed credential provisioning per `cma/mcp/{linear,github}.md`
-  (Slack and Notion are NOT exercised in this smoke test; their auth setup
-  is independent and can be deferred)
+  (Slack and Notion are NOT exercised in this smoke test)
+- The target repo has a `.catalyst/config.json` with `projectKey`,
+  `linear.teamKey`, `linear.stateMap`, and `project.ticketPrefix` populated
 - Shell variables set:
   ```bash
   export LINEAR_API_KEY=lin_api_...
@@ -27,16 +34,16 @@ This recipe is run by hand — it is not automated CI.
 
 ---
 
-## Step 1 — Register environment, base agent, vault
+## Step 1 — Register environment, base agent, vault (one-time)
 
 From the catalyst repo root:
 
 ```bash
-# Environment
+# Environment (shared across projects)
 ENV_ID=$(ant beta:environments create -f cma/environment.yaml --json | jq -r '.id')
 echo "ENV_ID=$ENV_ID"
 
-# Base agent
+# Base agent (project-agnostic)
 AGENT_ID=$(ant beta:agents create -f cma/agents/base.yaml --json | jq -r '.id')
 echo "AGENT_ID=$AGENT_ID"
 
@@ -54,7 +61,7 @@ commit). Suggested shape:
 ```json
 {
   "environments": { "catalyst-routines-base": "env_..." },
-  "agents":       { "catalyst-routine-base":  "agt_..." },
+  "agents":       { "catalyst-pattern-base":  "agt_..." },
   "vaults":       { "catalyst-developer":     "vlt_..." }
 }
 ```
@@ -82,99 +89,147 @@ yq -i '.system = load_str("cma/agents/base-system-prompt.md")' cma/agents/base.y
 
 ---
 
-## Step 3 — Create a smoke-test session
+## Pass A — Smoke test against Catalyst (`coalesce-labs/catalyst`)
+
+### Step A.1 — Create a session bound to Catalyst
 
 ```bash
-SESSION_ID=$(ant beta:sessions create --json <<YAML | jq -r '.id'
+SESSION_A=$(ant beta:sessions create --json <<YAML | jq -r '.id'
 agent: $AGENT_ID
 environment_id: $ENV_ID
 vault_ids:
   - $VAULT_ID
+env:
+  CATALYST_TARGET_REPO: coalesce-labs/catalyst
 YAML
 )
-echo "SESSION_ID=$SESSION_ID"
+echo "SESSION_A=$SESSION_A"
 ```
 
----
-
-## Step 4 — Send the smoke prompt
+### Step A.2 — Send the smoke prompt
 
 ```bash
-ant beta:sessions:events send "$SESSION_ID" --type user_turn <<'PROMPT'
+ant beta:sessions:events send "$SESSION_A" --type user_turn <<'PROMPT'
 Run this smoke test, in order, and report each step's result:
 
-1. Run the startup ritual:
-   git clone --depth=1 \
-     "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
-     /workspace/thoughts-repo
-   mkdir -p /workspace/thoughts
-   ln -s /workspace/thoughts-repo/repos/catalyst-workspace/shared /workspace/thoughts/shared
-   ln -s /workspace/thoughts-repo/global                          /workspace/thoughts/global
-   Then `ls /workspace/thoughts/shared/research/ | head -5`.
+1. Execute the startup ritual from your system prompt section 1. Then run
+   `cat /workspace/project-context.md`. Expected: the file lists
+   - Target repo: coalesce-labs/catalyst
+   - Project key: catalyst-workspace
+   - Linear team key: CTL
+   - Ticket prefix: CTL-
+   - State map containing: research -> "In Progress", inReview -> "In Review", done -> "Done"
+
+2. Run `ls /workspace/thoughts/shared/research/ | head -5`.
    Expected: 5 file paths starting with 2026-.
 
-2. Read the research doc that produced you:
-   `cat /workspace/thoughts/shared/research/2026-05-07-CTL-286-cma-cloud-environment.md | head -20`
-   Expected: frontmatter + the title line "# CTL-286: Scaffold CMA cloud environment".
+3. Read the research doc that produced you:
+   `cat /workspace/thoughts/shared/research/2026-05-07-CTL-299-generic-base-agent.md | head -20`
+   Expected: frontmatter + the title line "# CTL-299: Generalize CMA base agent".
 
-3. Call mcp__linear__get_issue with id "CTL-286".
-   Expected: title equals "[CMA] Scaffold cloud environment and Catalyst context architecture".
+4. Call mcp__linear__get_issue with id "CTL-299".
+   Expected: title equals "[CMA] Generalize base agent for multi-project use (Catalyst, Adva)".
 
-4. Call mcp__github__get_pull_request with owner=coalesce-labs, repo=catalyst,
-   pull_number=<the PR number for CTL-286 when this smoke test is run>.
-   Expected: title contains "CTL-286"; head ref is "CTL-286".
+5. Call mcp__github__get_pull_request with owner=coalesce-labs, repo=catalyst,
+   pull_number=<PR number for CTL-299 when this smoke test is run>.
+   Expected: title contains "CTL-299"; head ref is "CTL-299".
 
-5. From your system prompt, echo the list of banned reward-hacking patterns
-   (section 5). Expected: 8 banned patterns matching
-   `plugins/dev/skills/fix-typescript/SKILL.md:22-31`.
+6. From your system prompt section 6, echo the list of banned reward-hacking
+   patterns. Expected: 8 banned patterns matching the table in section 6
+   plus the runtime-detected `forEach(async)` and unguarded non-null assertion.
 
-After completing all 5 steps, output a one-line PASS/FAIL summary per step.
+After completing all 6 steps, output a one-line PASS/FAIL summary per step.
 PROMPT
 ```
 
----
-
-## Step 5 — Stream the response
+### Step A.3 — Stream the response
 
 ```bash
-ant beta:sessions:events stream "$SESSION_ID"
+ant beta:sessions:events stream "$SESSION_A"
 ```
 
-Watch for the agent's tool calls. Expected sequence:
-- `bash` (clone, mkdir, ln, ls)
-- `bash` (cat first research doc)
+Expected tool-call sequence:
+- `bash` (clone target, parse config, write project-context.md)
+- `bash` (cat project-context, ls thoughts research, cat research doc)
 - `mcp__linear__get_issue`
 - `mcp__github__get_pull_request`
 - final assistant turn with PASS/FAIL summary
 
----
-
-## Step 6 — Cleanup
+### Step A.4 — Cleanup
 
 ```bash
-ant beta:sessions archive "$SESSION_ID"
+ant beta:sessions archive "$SESSION_A"
 ```
 
-The session container is destroyed; the cloned thoughts repo is gone. The
-environment, agent, and vault remain registered for the next session.
+---
+
+## Pass B (optional) — Smoke test against a second project
+
+Run Pass B only after Pass A passes. The point is to verify the **same
+registered base agent** works for a different target without re-registration.
+
+### Pre-reqs
+
+- A second project (e.g., Adva at `getadva/adva`) with a populated
+  `.catalyst/config.json`
+- Your vault's GitHub PAT has access to that second repo (see
+  `cma/mcp/github.md` for single-PAT vs multi-PAT patterns)
+- A known ticket ID and PR number from that project for the smoke prompt
+
+### Step B.1 — Create a session bound to the second project
+
+```bash
+SESSION_B=$(ant beta:sessions create --json <<YAML | jq -r '.id'
+agent: $AGENT_ID
+environment_id: $ENV_ID
+vault_ids:
+  - $VAULT_ID
+env:
+  CATALYST_TARGET_REPO: getadva/adva
+YAML
+)
+```
+
+### Step B.2 — Send the same prompt with project-specific identifiers
+
+Same shape as Pass A.2, but adjust:
+- The research doc path uses the second project's thoughts directory
+- The Linear ticket ID uses the second project's prefix (e.g., `ADV-XXX`)
+- The expected `project-context.md` reflects the second project's values
+  (different team key, different state-map values if applicable)
+
+### Step B.3 — Stream and cleanup
+
+Same as A.3 / A.4.
 
 ---
 
 ## Expected pass criteria
 
-| Step | Pass when |
-|------|-----------|
-| 1 | `git clone` succeeds; `ls` returns ≥ 5 research files |
-| 2 | `cat` shows the frontmatter and the matching title line |
-| 3 | Linear MCP returns the exact ticket title |
-| 4 | GitHub MCP returns a PR whose head ref is `CTL-286` |
-| 5 | Agent echoes the 8 banned patterns matching the skill source |
+| Pass | Step | Pass when |
+|------|------|-----------|
+| A | 1 | `project-context.md` shows the catalyst-specific values resolved from `.catalyst/config.json` |
+| A | 2 | `ls` returns ≥ 5 research files |
+| A | 3 | `cat` shows the frontmatter and the matching title line |
+| A | 4 | Linear MCP returns the exact ticket title |
+| A | 5 | GitHub MCP returns a PR whose head ref is `CTL-299` |
+| A | 6 | Agent echoes the 8 banned patterns plus the runtime-detected ones |
+| B | 1 | `project-context.md` shows the second project's values (different team key, different state-map values if applicable) |
+| B | 2–6 | Equivalent to A but with project-specific identifiers |
 
-If any step fails, the most likely causes:
-- **Step 1 fails:** `GITHUB_PAT` lacks `coalesce-labs/thoughts` Contents:Read access
-- **Step 3 fails:** `LINEAR_API_KEY` lacks workspace access; or the vault was
-  not bound to this session
-- **Step 4 fails:** PAT lacks `coalesce-labs/catalyst` Pull requests:Read; or
-  the PR number is wrong
-- **Step 5 fails:** the system prompt was not registered correctly — re-run
-  the drift check (Step 2) and re-register the agent
+### Common failure modes
+
+- **A.1 fails** with `CATALYST_TARGET_REPO: required`: the env var was not
+  passed at session creation
+- **A.1 fails** with `git clone` 403: PAT lacks read access on the target repo
+- **A.1 fails** with `jq: error: .catalyst.projectKey: not defined`: the
+  target repo lacks a `.catalyst/config.json` or the file is missing keys
+- **A.4 fails**: Linear API key missing scope for the team or vault was not
+  bound to the session
+- **A.5 fails**: PAT lacks `Pull requests: Read` on the target repo, or the
+  PR number is wrong
+- **A.6 fails**: the system prompt was not registered correctly — re-run the
+  drift check (Step 2) and re-register the agent
+- **B.1 fails** but A.1 passes: the GitHub PAT does not include the second
+  repo. Either expand single-PAT scope or use the multi-PAT pattern with a
+  second vault (see `cma/mcp/github.md`)


### PR DESCRIPTION
## Summary

Refactor the CMA base agent shipped in CTL-286 from Catalyst-specific to project-agnostic. The agent now reads project-specific values (Linear team, state map, ticket prefix, thoughts directory) at session start from the bound target repo's `.catalyst/config.json`. The same registered agent works for catalyst, Adva, or any future Catalyst-pattern project.

## Problem Statement

CTL-286 baked Catalyst conventions into the base system prompt as static text:
- Repo name (`coalesce-labs/catalyst`)
- Linear team (Catalyst, key `CTL`)
- State map values (`Backlog / In Progress / In Review / Done / Canceled`)
- Project key (`catalyst-workspace`)
- Hardcoded thoughts symlink path (`repos/catalyst-workspace/shared`)

This blocked the project's stated multi-project goal. To run the same routines on Adva, you'd have had to duplicate `cma/` in the Adva repo with Adva-specific values everywhere — which defeats the point of having a "base" agent. Surfaced during the CTL-286 oneshot run when the user asked: "If I want to deploy this on Adva, the linear states are not the same as the Catalyst states. How does this adapt?"

## Solution

**Session-creation contract.** The session creator passes target-project bindings as env vars:

| Env var | Required | Example |
|---------|----------|---------|
| `CATALYST_TARGET_REPO` | yes | `coalesce-labs/catalyst`, `getadva/adva` |
| `CATALYST_THOUGHTS_DIRECTORY` | no — falls back to `projectKey` from the cloned target repo | `catalyst-workspace`, `adva` |
| `GITHUB_PAT` | yes (vault) | (provisioned) |

**Startup ritual.** The agent clones the target repo, reads `.catalyst/config.json`, writes `/workspace/project-context.md` with the resolved values, and clones thoughts with the project-specific symlink target. Then begins routine work.

**System prompt** now references `/workspace/project-context.md` instead of hardcoding values. State machine section explicitly says "always resolve target state names by semantic key — never assume literal values across projects."

**Cross-project conventions** (PR description format, code review workflow, quality gates, reward-hacking ban list, no-Claude-attribution rule) stay inlined — they apply identically everywhere.

## Changes Made

### Documentation Changes

- `cma/agents/base.yaml` — renamed `catalyst-routine-base` → `catalyst-pattern-base`; updated inlined system prompt; added session-input documentation; bumped metadata to `catalyst_version: v2`
- `cma/agents/base-system-prompt.md` — full rewrite of sections 0 (new — session inputs), 1 (startup ritual now generic), 2 (project conventions reference project-context.md), 3 (state machine — semantic-key resolution); kept sections 4-9 unchanged (cross-project content)
- `cma/README.md` — added "How sessions work" section; reorganized registration recipe (one-time) vs session creation (per-project); added two side-by-side examples (catalyst, Adva)
- `cma/smoke-test/README.md` — restructured into Pass A (catalyst, required) and Pass B (second project, optional); added project-context verification step
- `cma/mcp/github.md` — replaced "PAT covers thoughts" section with single-PAT vs multi-PAT pattern guidance for multi-target scoping
- `cma/decisions/2026-05-07-thoughts-strategy.md` — added postscript noting the symlink target is now resolved per-session

`cma/environment.yaml`, `cma/vaults/example.yaml`, and `cma/mcp/{linear,slack,notion}.md` are unchanged — they were already project-agnostic.

## Breaking Changes

If anyone has already registered the CTL-286 base agent (`catalyst-routine-base`), this PR effectively requires re-registering as `catalyst-pattern-base` and updating the session-creation flow to pass `CATALYST_TARGET_REPO`. Given CTL-286 merged ~30 minutes before this PR, the realistic blast radius is zero.

## Database Changes

None.

## Performance Impact

Session startup adds one git clone (target repo, shallow). At `--depth=1` over ~5 MB this is 3-8 seconds. Negligible for routines that already pay the thoughts-clone cost.

## Security Considerations

- The single `GITHUB_PAT` now needs read access to every target repo plus the thoughts repo. `cma/mcp/github.md` documents both single-PAT and multi-PAT (one per project) patterns and the trade-offs.
- No new secrets in the repo.

## How to Test

1. Read `cma/agents/base-system-prompt.md` end-to-end and confirm sections 1-3 (and 9 last bullet) reference `/workspace/project-context.md` for project values, not hardcoded text.
2. YAML parse: `python3 -c "import yaml; yaml.safe_load(open('cma/agents/base.yaml'))"`.
3. `grep -nE 'coalesce-labs/catalyst' cma/agents/base.yaml cma/agents/base-system-prompt.md` — only example/doc usages should remain.
4. `grep -nE '\bCTL\b' cma/agents/base.yaml cma/agents/base-system-prompt.md` — should only match ticket-ID references and ticket-prefix examples.
5. (Optional, requires `ant` access) Run Pass A of the smoke test against your default project; if you have a second Catalyst-pattern project, run Pass B.

## How to Verify It

### Automated Checks

- All YAML still parses
- No state-map values (`Backlog`, `In Progress`, etc.) appear as truth values in the system prompt — only as examples-of-difference
- Cross-references in README and smoke test all resolve to real files

### Integration Tests

N/A — content only.

### Manual Verification Required

User runs `Pass A` from `cma/smoke-test/README.md` against catalyst, then optionally `Pass B` against Adva.

## Rollback Plan

`git revert` the single commit. Reverts to the CTL-286 Catalyst-specific base. Anyone who registered the new agent should `ant beta:agents archive` it.

## Deployment Notes

After merge, re-register the base agent with the new name. Existing sessions referencing the old `catalyst-routine-base` agent ID continue to work until archived; new sessions use the new agent ID.

```bash
NEW_AGENT_ID=$(ant beta:agents create -f cma/agents/base.yaml --json | jq -r '.id')
# update ~/.config/catalyst/cma.json with the new ID
# ant beta:agents archive <old-catalyst-routine-base-id>
```

## Related Issues/PRs

- Fixes https://linear.app/catalyst/issue/CTL-299
- Builds on https://linear.app/catalyst/issue/CTL-286 (#488 — merged 2026-05-07)

## Changelog Entry

`feat(meta): generalize CMA base agent for multi-project use (CTL-299)`

## Reviewer Notes

- Three streams of "hardcoded" tokens remain in the prompt and are intentional:
  - **Examples in docs** — `e.g., coalesce-labs/catalyst | getadva/adva` shows the shape of `CATALYST_TARGET_REPO`.
  - **Ticket-prefix examples** — `e.g., CTL-, ADV-` documents what `ticket prefix` means.
  - **Cross-project ticket references** — `CTL-294`, `CTL-295`, etc., are stable ticket IDs.
- The system prompt deliberately says "the state map for this session is in `/workspace/project-context.md`" rather than reproducing the map, so an Adva project with different state names doesn't conflict. If you'd prefer the prompt to *also* show the catalyst-default state map as a worked example, say the word and I'll add it.
- The `cma/agents/base.yaml` inlined `system:` block is a slightly compressed version of the canonical `base-system-prompt.md` (table formatting differs). The README documents the drift check. The two are kept in sync by hand for now; full automation (yq load_str at register time) is documented as the upgrade path.

## Post-Merge Tasks

- [ ] User re-registers the base agent (`ant beta:agents create -f cma/agents/base.yaml`) and updates local `~/.config/catalyst/cma.json` with the new agent ID
- [ ] User archives the old `catalyst-routine-base` agent (if they registered the CTL-286 version)
- [ ] User runs Pass A of the smoke test against catalyst
- [ ] User decides whether to run Pass B against Adva (requires Adva to have a `.catalyst/config.json`)

---
**Definition of Done Checklist:**

- [x] Base agent renamed `catalyst-routine-base` → `catalyst-pattern-base`
- [x] System prompt resolves project values from `/workspace/project-context.md` instead of hardcoding
- [x] Startup ritual clones target repo + reads `.catalyst/config.json`
- [x] State map references the project context, not literal values
- [x] Thoughts symlink target uses the project's thoughts directory (resolved from `projectKey` or override)
- [x] README documents multi-project session creation
- [x] Smoke test covers two-project pattern (Pass A required, Pass B optional)
- [x] GitHub MCP doc covers multi-target PAT scope guidance
- [x] ADR has a postscript noting the project-context resolution
- [x] All YAML parses
- [x] No real Catalyst-specific values remaining in the prompt (only examples, ticket IDs, cross-project conventions)
- [ ] PR opened, CI green, reviewed, merged
- [ ] CTL-299 transitions to Done