### PR TITLE
fix(dev): keyed-format fallback for linearSmeeChannel (CTL-301)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -721,6 +721,61 @@ describe("loadWebhookConfig — linearSmeeChannel (CTL-242)", () => {
     expect(cfg!.linearSmeeChannel).toBe("https://smee.io/env-override");
   });
 
+  it("falls back to first keyed entry smeeChannel when top-level is absent (CTL-301)", () => {
+    writeHome({
+      catalyst: {
+        monitor: {
+          github: { smeeChannel: "https://smee.io/github-chan" },
+          linear: {
+            adv: { webhookId: "adv-id", smeeChannel: "https://smee.io/team-keyed" },
+            ctl: { webhookId: "ctl-id", smeeChannel: "https://smee.io/team-keyed" },
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.linearSmeeChannel).toBe("https://smee.io/team-keyed");
+  });
+
+  it("prefers top-level smeeChannel over keyed entries when both are present (CTL-301)", () => {
+    writeHome({
+      catalyst: {
+        monitor: {
+          github: { smeeChannel: "https://smee.io/github-chan" },
+          linear: {
+            smeeChannel: "https://smee.io/top-level-wins",
+            adv: { webhookId: "adv-id", smeeChannel: "https://smee.io/keyed-loses" },
+          },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSmeeChannel).toBe("https://smee.io/top-level-wins");
+  });
+
+  it("returns empty linearSmeeChannel when keyed entries have no smeeChannel (CTL-301)", () => {
+    writeHome({
+      catalyst: {
+        monitor: {
+          github: { smeeChannel: "https://smee.io/github-chan" },
+          linear: { adv: { webhookId: "adv-id" } },
+        },
+      },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "secret";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearSmeeChannel).toBe("");
+  });
+
   it("linearSmeeChannel and smeeChannel are independent (one set, other empty)", () => {
     writeHome({
       catalyst: {

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -173,6 +173,26 @@ function isRecord(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null && !Array.isArray(x);
 }
 
+// Extract the Linear smee channel URL from a linear config object. Prefers the
+// top-level smeeChannel (legacy / current normal case) and falls back to the
+// first keyed team entry that carries one (CTL-273/285 keyed format, CTL-301).
+// Returns null if no usable channel is found.
+function readLinearSmeeChannel(linear: Record<string, unknown>): string | null {
+  if (typeof linear.smeeChannel === "string" && linear.smeeChannel.length > 0) {
+    return linear.smeeChannel;
+  }
+  for (const value of Object.values(linear)) {
+    if (
+      isRecord(value) &&
+      typeof value.smeeChannel === "string" &&
+      value.smeeChannel.length > 0
+    ) {
+      return value.smeeChannel;
+    }
+  }
+  return null;
+}
+
 function readGithubSection(filePath: string): FileExtract | null {
   let raw: string;
   try {
@@ -210,10 +230,7 @@ function readGithubSection(filePath: string): FileExtract | null {
     linear.webhookSecretEnv.length > 0
       ? linear.webhookSecretEnv
       : null;
-  const linearSmeeChannel =
-    linear !== null && typeof linear.smeeChannel === "string" && linear.smeeChannel.length > 0
-      ? linear.smeeChannel
-      : null;
+  const linearSmeeChannel = linear !== null ? readLinearSmeeChannel(linear) : null;
   const linearBotUserId =
     linear !== null && typeof linear.botUserId === "string" && linear.botUserId.length > 0
       ? linear.botUserId


### PR DESCRIPTION
## Summary

- `readGithubSection` only read the top-level `catalyst.monitor.linear.smeeChannel`, so after migrating to the CTL-273/285 keyed format (per-team entries each carrying their own `smeeChannel`) the Linear smee tunnel silently disabled itself.
- New `readLinearSmeeChannel` helper prefers the top-level value (legacy/current shape `setup-webhooks.sh` writes) and falls back to the first keyed entry that has a `smeeChannel`. Mirrors the dual-shape handling already in `readAllLinearSecrets`.
- Three regression tests in `webhook-config.test.ts`: keyed-only fallback, top-level-wins precedence, and no-channel-anywhere.

Closes CTL-301.

## Test plan

- [x] `bun test __tests__/webhook-config.test.ts` — 45/45 pass (3 new + 42 pre-existing)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (one pre-existing warning in `preview-status.ts` unrelated)
- [x] `bun run knip:ci` clean
- [ ] CI green