### PR TITLE
feat(dev): populate traceId on webhook-emitted canonical events (CTL-310)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
@@ -1173,6 +1173,55 @@ describe("createWebhookHandler — orchestrator attribution", () => {
       headRef: "orch-foo-CTL-2",
     });
   });
+
+  it("derives traceId from orchestrator ID (sha256(orchId).slice(0,32))", async () => {
+    const { createHash } = await import("node:crypto");
+    const orchId = "orch-foo-CTL-1";
+    const expectedTraceId = createHash("sha256")
+      .update(orchId)
+      .digest("hex")
+      .slice(0, 32);
+    const log = new FakeEventLog();
+    const handler = createWebhookHandler({
+      secret: SECRET,
+      prFetcher: new FakeFetcher(),
+      eventLog: log,
+      resolveOrchestrator: (input) =>
+        input.headRef === orchId ? orchId : null,
+    });
+    await handler.handle(
+      makeReq({
+        ...REPO,
+        action: "synchronize",
+        pull_request: {
+          number: 1,
+          merged: false,
+          head: { ref: orchId },
+        },
+      }),
+    );
+    expect(log.appends.length).toBe(1);
+    expect(log.appends[0]?.traceId).toBe(expectedTraceId);
+  });
+
+  it("traceId remains null when no orchestrator is resolved", async () => {
+    const log = new FakeEventLog();
+    const handler = createWebhookHandler({
+      secret: SECRET,
+      prFetcher: new FakeFetcher(),
+      eventLog: log,
+      resolveOrchestrator: () => null,
+    });
+    await handler.handle(
+      makeReq({
+        ...REPO,
+        action: "opened",
+        pull_request: { number: 999, merged: false, head: { ref: "feature/random" } },
+      }),
+    );
+    expect(log.appends.length).toBe(1);
+    expect(log.appends[0]?.traceId).toBeNull();
+  });
 });
 
 describe("createWebhookHandler — event log fan-out", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
@@ -4,6 +4,7 @@ import { parseWebhookEvent, type WebhookEvent } from "./webhook-events";
 import { type EventLogWriter } from "./event-log";
 import {
   buildCanonicalEvent,
+  deriveTraceId,
   type CanonicalEvent,
   type Attributes,
 } from "./canonical-event";
@@ -639,6 +640,7 @@ export function createWebhookHandler(
               if (orchId !== null) {
                 envelope.attributes["catalyst.orchestrator.id"] = orchId;
               }
+              envelope.traceId = deriveTraceId(orchId);
             } catch (err) {
               logger.warn?.(
                 `[webhook] orchestrator resolution failed: ${


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-08T06:35:00Z -->
<!-- Last updated: 2026-05-08T06:35:00Z -->
<!-- PR: #509 -->
<!-- Previous commits: 4a992c85aea57353180d2dd2ae72fe59f93a89ab -->

## Summary

`buildEventLogEnvelope` in `webhook-handler.ts` always emitted `traceId: null` on every GitHub event, even when the event had a resolved orchestrator. This broke the OTel-projection promise of CTL-306, broke trace-based queries in CTL-307, and caused the TRACE column in catalyst-hud to display `--------` for all webhook events (CTL-308).

`deriveTraceId()` already exists in `canonical-event.ts` (added in CTL-300). The fix is a single call: after `resolveOrchestrator` returns an `orchId`, write `envelope.traceId = deriveTraceId(orchId)`. SHA-256 inputs are identical to the bash producer in `canonical-event.sh`, so trace IDs are byte-identical across both producers.

## Changes Made

### `plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts` (+2 lines)

- Import `deriveTraceId` from `./canonical-event`
- After orchestrator resolution in `handle()`, set `envelope.traceId = deriveTraceId(orchId)` — produces a non-null 32-hex traceId when an orchestrator is resolved, `null` when not

### `plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts` (+49 lines, 0 deletions)

Two new tests in the `createWebhookHandler — orchestrator attribution` suite:

1. **`derives traceId from orchestrator ID (sha256(orchId).slice(0,32))`** — feeds a webhook fixture with `headRef = "orch-foo-CTL-1"` where the resolver returns that value as the orchId, then asserts `traceId === sha256("orch-foo-CTL-1").slice(0, 32)` (byte-parity check)
2. **`traceId remains null when no orchestrator is resolved`** — resolver returns null, asserts `traceId` is null (no-noise guarantee)

## How to Verify It

- [x] Tests pass: `bun test __tests__/webhook-handler.test.ts` → 58 pass, 0 fail ✅
- [ ] Smoke check: start orch-monitor, push a commit to an orchestrator branch, confirm `~/catalyst/events/YYYY-MM.jsonl` shows a non-null `traceId` for the resulting `github.push` event
- [ ] catalyst-hud TRACE column shows 32-hex instead of `--------` for github.* events tied to an active orchestrator

## Invariants

- `traceId` is `null` for events that don't match any active orchestrator (no spurious IDs)
- `traceId` is SHA-256 of the orchestrator ID truncated to 32 hex chars — byte-identical to the bash producer
- Existing 55 tests are unaffected; no behaviour changed for events without a resolver

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-310
- Depends on: CTL-300 (canonical event envelope)
- Enables: CTL-306 (OTLP forwarder), CTL-307 (trace queries), CTL-308 (catalyst-hud TRACE column)
