### PR TITLE
docs(dev): update event-driven system docs and fix lifecycle inaccuracies (CTL-255)

### DIFF
--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -378,8 +378,126 @@ event ingestion via a smee.io tunnel, with polling kept as a 10-minute fallback.
   missed during downtime are reconciled without operator action.
 - Event-log fan-out: every accepted webhook event is appended to
   `~/catalyst/events/YYYY-MM.jsonl` with topic namespace `<source>.<noun>.<verb>`
-  (e.g. `github.pr.merged`). This seeds the unified event-bus that CTL-210 (Linear
-  webhooks + consumer-side `catalyst-events` CLI) and CTL-211 (worker definition-of-
-  done = production deploy success) build on.
+  (e.g. `github.pr.merged`). This seeded the unified event-bus that CTL-210 (**shipped** —
+  Linear webhooks + consumer-side `catalyst-events` CLI) and CTL-211 (**shipped** — worker
+  definition-of-done = production deploy success) build on.
 - Steady-state GitHub API budget: 200+ tracked PRs × < 50 calls/hr (well under both
   the GraphQL and REST 5,000 calls/hr ceilings).
+
+---
+
+## ADR-013: Event-Driven Worker Waits (`wait-for-github` two-phase pattern)
+
+**Decision**: Replace all `gh pr view --json` poll loops inside worker skills with a
+`catalyst-events wait-for` blocking call that consumes the unified event log, with a
+REST-authoritative check after each wake.
+
+**Rationale**:
+
+- `gh pr view --json` uses GraphQL. A busy orchestrator with 50+ workers polling every 30s
+  exhausted the 5,000-call/hr GitHub GraphQL budget in under 11 minutes (CTL-209
+  root-cause analysis). Polling was the only viable option before the event log existed.
+- The unified event log (ADR-012) now gives workers a low-cost wake source: a single
+  `tail -f` covers all event types (CI, reviews, pushes, merges) at zero API budget cost.
+- Workers should not use GraphQL for state checks. REST (`gh api repos/{repo}/pulls/{n}`)
+  is cheaper and returns `.mergeable_state`, which encodes CI + review status in one field.
+
+**Design (two-phase)**:
+
+1. **Phase 1** (`--timeout 180`): `catalyst-events wait-for` waits for any relevant event
+   (check-suite, pr-review, push, pr-merged). On match, do a REST authoritative check.
+   On timeout (3 min without an event), run diagnostics.
+2. **Diagnostics**: count heartbeats in the last 500 log lines; re-check tunnel state. If
+   infrastructure is healthy, extend to Phase 2. If not, switch to REST fallback.
+3. **Phase 2** (`--timeout 7200`): same filter, 2-hour window. Infrastructure confirmed
+   healthy — a long wait is normal (CI queued, reviewer slow to act).
+4. **REST fallback** (`sleep 300` loop): if tunnel is down, poll every 5 min via
+   `gh api repos/{repo}/pulls/{n}`. Avoids GraphQL, stays under budget.
+
+**Consequences**:
+
+- Every skill that previously polled `gh pr view` must be rewritten to use `wait-for`.
+- The filter jq expression must cover both v1 and v2 envelope shapes (`.event` vs
+  `.attributes."event.name"`).
+- Workers must never use `.mergeable_state` as the sole decision signal — it's
+  eventually-consistent. Always follow with a REST re-check before acting.
+- The REST fallback is required for environments without a configured webhook tunnel.
+
+---
+
+## ADR-014: Worker Owns Full PR Lifecycle (CTL-252)
+
+**Decision**: Remove `gh pr merge --auto` from all worker skills. Workers enter an
+event-driven listen loop after opening a PR, resolve blockers inline, execute
+`gh pr merge --squash --delete-branch` directly when the PR is CLEAN, and write
+`status: "done"` before exiting. The orchestrator's Phase 4 is a safety-net fallback
+only for workers that stalled before completing their own merge.
+
+**Rationale**:
+
+- `gh pr merge --auto` arms GitHub's auto-merge, which merges asynchronously after all
+  required checks pass. This forces the worker to exit at `pr-created` and leaves the
+  merge to GitHub (or the orchestrator's poll loop).
+- With ADR-013's event-driven loop in place, the worker is already watching for exactly
+  the events that signal "ready to merge" (CI green, no blocking reviews, no BEHIND). At
+  that point executing `gh pr merge --squash` directly is simpler and eliminates the
+  delay between "auto-merge armed" and "GitHub actually merges."
+- Removing `--auto` shrinks the state machine: `pr-created → done` replaces
+  `pr-created → (auto-merge armed) → (orchestrator detects merged) → done`. The
+  orchestrator's Phase 4 polling loop is reduced to a fallback for crashed workers.
+
+**Consequences**:
+
+- `autoMergeArmedAt` field removed from the `pr` signal-file subobject.
+- Workers must never use `--auto` in any `gh pr merge` invocation.
+- The orchestrator's Phase 4 is now a safety net, not the primary merge path. Its poll
+  interval can be relaxed (was 30s; 10-min polling is now acceptable for fallback-only use).
+- Signal file `status: "done"` is written by the worker in the normal case. The
+  orchestrator writes it only when it detects a previously stalled worker's PR is merged.
+- Skills and documentation that said "the orchestrator polls until merged" must be updated.
+
+---
+
+## ADR-015: Bidirectional catalyst-comms (CTL-249)
+
+**Decision**: Add inbound message reads to workers. Workers poll the shared comms channel
+at each phase boundary for messages directed to `--filter-to <ticket-id>`, using a
+`COMMS_LAST_READ` cursor to skip pre-join history.
+
+**Rationale**:
+
+- Before CTL-249, comms was one-direction: workers broadcast status, the orchestrator
+  observed. The orchestrator had no way to send runtime instructions to a specific worker
+  (e.g., "skip the migration, CTL-99 is handling it").
+- Adding `--filter-to <ticket-id>` to `catalyst-comms poll` and advancing a cursor
+  at each phase transition is a minimal change: no new infrastructure, no new file format,
+  no guaranteed delivery required for the current use cases.
+
+**Design**:
+
+- Workers initialize `COMMS_LAST_READ` to the channel file's current line count at join
+  time, so pre-join history is skipped.
+- After each phase transition (signal file write), the worker calls
+  `catalyst-comms poll --filter-to $TICKET_ID --since $COMMS_LAST_READ` and advances
+  the cursor.
+- Recognized inbound signals: `abort` (worker exits immediately), future signals TBD.
+
+**ACK gap**:
+
+There is no delivery guarantee. A worker may have passed a phase boundary before an
+orchestrator-to-worker message arrives. The worker processes it only if it polls again
+before exiting. CTL-253 tracks adding an explicit ACK mechanism.
+
+**Event log integration**:
+
+`catalyst-comms send` now emits a `comms.message.posted` event to the unified event log
+(v2 OTel envelope) so orchestrators and monitoring tools can observe all comms traffic
+without polling the channel file directly.
+
+**Consequences**:
+
+- Workers produce ≥4 comms messages per run: start, N phase transitions, done (or
+  attention on block). The inbound read at each phase boundary adds no new messages but
+  adds a `poll` call per phase transition (~5 calls per run).
+- `catalyst-events wait-for` can now filter on `comms.message.posted` events to observe
+  comms traffic from within the event log pipeline.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,7 +76,15 @@ orchestrators and workers write to via `catalyst-state.sh` (lock-protected).
 - **state.json**: Registry of active orchestrators with progress, worker status, and attention
   items. Queryable with `jq`. Schema: `plugins/dev/templates/global-state.json`.
 - **events/**: Every phase transition, PR creation, verification result, and attention item is
-  logged as a JSONL entry. Schema: `plugins/dev/templates/global-event.json`.
+  logged as a JSONL entry. Schema: `plugins/dev/templates/global-event.json`. The log has
+  multiple writers:
+  - **Bash skill layer** (`catalyst-state.sh event`) — writes v1 envelopes: `{ts, event, orchestrator, worker, detail}`
+  - **TypeScript webhook receiver** (`lib/webhook-events.ts`) — writes v2 OTel-shaped envelopes:
+    `{ts, attributes, body, resource}` for `github.*` and `linear.*` events
+  - **catalyst-comms send** — writes v2 envelopes for `comms.message.posted` events
+  Both shapes coexist in the same files. `catalyst-events` CLI and skills handle both.
+  Consumer interface: `catalyst-events tail` (streaming) and `catalyst-events wait-for`
+  (blocking single-event wait). See `website/src/content/docs/observability/catalyst-events.md`.
 - **history/**: Full orchestrator snapshots archived on completion, failure, or stale detection.
 - **Heartbeat**: Orchestrators write `lastHeartbeat` every 2-3 min. Stale entries (>10 min) are
   garbage-collected as `abandoned`.
@@ -157,10 +165,9 @@ Best practices:
 ## Agent Communication (catalyst-comms)
 
 Agents coordinate across worktrees via `catalyst-comms`, a file-based JSONL messaging system at
-`~/catalyst/comms/channels/<name>.jsonl`. Orchestrators create a shared channel
-`orch-<orchId>` at startup and export `CATALYST_COMMS_CHANNEL` to every dispatched worker's
-environment. Workers auto-join on startup and post `info` messages at each lifecycle boundary
-(start, phase transitions, PR opened), `attention` when blocked, and `done` on settle.
+`~/catalyst/comms/channels/<name>.jsonl`. The protocol is **bidirectional** (CTL-249):
+orchestrators broadcast to workers (outbound) and can also send messages directed to individual
+workers (inbound); workers poll for directed messages at each phase boundary.
 
 ```bash
 # Orchestrator side (Phase 1 init)
@@ -172,9 +179,20 @@ CATALYST_COMMS_CHANNEL="orch-${ORCH_NAME}" exec claude -p "/oneshot ${TICKET_ID}
 # Worker side (oneshot startup)
 catalyst-comms join "$CATALYST_COMMS_CHANNEL" --as "$TICKET_ID" --parent orchestrator
 
+# Outbound: orchestrator sends to a specific worker
+catalyst-comms send "orch-${ORCH_NAME}" "CTL-101: skip the migration" \
+  --as orchestrator --to CTL-101 --type info
+
+# Inbound: worker polls for messages addressed to it (at each phase boundary)
+catalyst-comms poll "orch-${ORCH_NAME}" --filter-to "$TICKET_ID" --since "$COMMS_LAST_READ"
+
 # Live tailing (human auditor)
 catalyst-comms watch "orch-${ORCH_NAME}"
 ```
+
+`catalyst-comms send` also emits a `comms.message.posted` event to the unified event log
+(v2 OTel envelope), so monitoring tools and `catalyst-events wait-for` can observe comms
+traffic from the same log file they use for GitHub/Linear events.
 
 The contract: every worker produces ≥4 messages per run. Signal files remain the authoritative
 state — comms is observability and cross-worker coordination. See

--- a/website/src/content/docs/guided-workflows/phases.md
+++ b/website/src/content/docs/guided-workflows/phases.md
@@ -15,8 +15,8 @@ The guided workflow has six phases. Each one does something discrete, writes an 
 | 2 | **Plan** | `/catalyst-dev:create-plan` | `thoughts/shared/plans/YYYY-MM-DD-{ticket}-{desc}.md` | 5–20 min (interactive) |
 | 3 | **Implement** | `/catalyst-dev:implement-plan` | Code changes + tests (not committed yet) | 10–90 min |
 | 4 | **Validate** | `/catalyst-dev:validate-plan` | Validation report + quality-gate output | 2–10 min |
-| 5 | **Ship** | `/catalyst-dev:create-pr` | Commits, pushed branch, GitHub PR | 2–5 min |
-| 6 | **Merge** | `/catalyst-dev:merge-pr` | Merged PR, deleted branch, Linear state=Done | 1–20 min (waits for CI) |
+| 5 | **Ship** | `/catalyst-dev:create-pr` → active listen loop | Commits, pushed branch, GitHub PR, merged PR, deleted branch, Linear state=Done | 5–30 min |
+| 6 | **Merge** | `/catalyst-dev:merge-pr` | Merged PR, deleted branch, Linear state=Done — *standalone only* | 1–20 min |
 
 ## What each phase reads
 
@@ -27,7 +27,10 @@ Phase 2 (plan)      reads research doc path from workflow context
 Phase 3 (implement) reads plan doc path from workflow context
 Phase 4 (validate)  reads plan doc + the implementation diff
 Phase 5 (ship)      reads everything above to write the PR description, then
-                    polls gh pr view until state=MERGED before exiting
+                    enters a catalyst-events wait-for listen loop — resolves CI
+                    failures, bot review threads, and BEHIND inline — executes
+                    gh pr merge --squash --delete-branch when CLEAN, writes
+                    status: done, and exits
 ```
 
 This is why "the thoughts/ directory is the handoff mechanism" — artifacts live there so **any future session**, not just this one, can pick up where the current one left off.
@@ -76,10 +79,17 @@ If the current ticket is linked, each phase transitions it through Linear states
 | 1 Research | In Progress |
 | 2 Plan | In Progress |
 | 3 Implement | In Progress |
-| 5 Ship | In Review |
-| 6 Merge | Done |
+| 5 Ship (PR opened) | In Review |
+| 5 Ship (PR merged) | Done |
+| 6 Merge (standalone only) | Done |
 
 Phase 4 (validate) doesn't transition state — it's an internal quality check, not a milestone visible to others. Phases 1–3 stay in the same state by default because "In Progress" already covers the whole active-work span; override `stateMap.research`, `stateMap.planning`, and `stateMap.inProgress` in config if you want finer granularity.
+
+## Phase 6 and oneshot
+
+In `/catalyst-dev:oneshot` and `/catalyst-dev:orchestrate` worker runs, **Phase 6 is folded into Phase 5**. The worker enters an event-driven listen loop immediately after opening the PR, resolves any blockers inline, and executes the merge itself before exiting. There is no separate merge phase.
+
+`/catalyst-dev:merge-pr` remains available as a standalone tool for PRs that were opened outside the oneshot flow — for example, if you ran `/create-pr` manually and stopped there.
 
 ## Stopping mid-workflow
 

--- a/website/src/content/docs/observability/catalyst-events.md
+++ b/website/src/content/docs/observability/catalyst-events.md
@@ -1,0 +1,238 @@
+---
+title: catalyst-events CLI
+description: Command-line interface for reading and waiting on the unified event log at ~/catalyst/events/YYYY-MM.jsonl.
+sidebar:
+  order: 6
+---
+
+`catalyst-events` is the command-line interface for the unified event log at
+`~/catalyst/events/YYYY-MM.jsonl`. It supports streaming subscription, blocking waits for
+specific events, and filter construction helpers. Skills use it to synchronize on external
+events (CI results, PR merges, webhook deliveries) without polling.
+
+:::tip[Skill-author reference]
+If you're writing a Catalyst skill and need the full protocol for building jq filters and
+handling the two-phase fallback, see
+[`plugins/dev/skills/monitor-events/SKILL.md`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/monitor-events/SKILL.md).
+This page covers the user-facing CLI interface.
+:::
+
+## Commands
+
+### `tail`
+
+```bash
+catalyst-events tail [--filter <jq>] [--since-line <N>]
+```
+
+Streams the current month's event log as new lines arrive. Prints each matching line as a
+pretty-printed JSON object. Runs until interrupted.
+
+| Flag | Description |
+|------|-------------|
+| `--filter <jq>` | jq expression — only print lines where the expression returns truthy |
+| `--since-line <N>` | Skip the first N lines of the file (resume from a cursor) |
+
+```bash
+# All events in real time
+catalyst-events tail
+
+# Only GitHub webhook events
+catalyst-events tail --filter '.event | startswith("github.")'
+
+# Linear issue state changes for a specific ticket
+catalyst-events tail --filter '.event == "linear.issue.state_changed" and .body.payload.identifier == "CTL-48"'
+
+# All worker lifecycle events
+catalyst-events tail --filter '.event | startswith("worker-")'
+
+# Events for one orchestrator
+catalyst-events tail --filter '.orchestrator == "orch-ctl-2026-05-01"'
+
+# Comms messages on a specific channel
+catalyst-events tail --filter '.event == "comms.message.posted" and .attributes."comms.channel" == "orch-ctl-ux"'
+```
+
+### `wait-for`
+
+```bash
+catalyst-events wait-for --filter <jq> [--timeout <seconds>]
+```
+
+Blocks until a matching event appears in the log, then prints it and exits. Returns non-zero
+on timeout or infrastructure error. Used by skills that need to synchronize on a specific
+external event without busy-polling.
+
+| Flag | Description |
+|------|-------------|
+| `--filter <jq>` | Required. jq expression — block until a line where this returns truthy |
+| `--timeout <seconds>` | Max wait time in seconds. Default: 600 (10 minutes) |
+
+```bash
+# Wait up to 120s for a CI result on PR #87
+catalyst-events wait-for \
+  --filter '.event == "github.check_suite.completed" and (.body.payload.prNumbers // [] | contains([87]))' \
+  --timeout 120
+
+# Wait for a specific PR to merge
+catalyst-events wait-for \
+  --filter '.event == "github.pr.merged" and .attributes."vcs.pr.number" == 87'
+
+# Wait for a filter daemon wake event (CTL-269 semantic interests)
+catalyst-events wait-for \
+  --filter '.attributes."event.name" == "filter.wake" and .attributes."event.label" == "sess_abc123"' \
+  --timeout 600
+```
+
+#### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | A matching event was found |
+| `1` | Timeout elapsed without a match |
+| `2` | Infrastructure error (log file unreadable, malformed JSON line) |
+
+When the orch-monitor is running with webhooks configured, `wait-for` returns within ~1s of
+the event arriving via GitHub/Linear webhook. Without the monitor tunnel, the daemon falls
+back to polling the event log file at 10-minute intervals — up to 600s maximum latency. See
+[Setting up the webhook tunnel](./setup/#5-set-up-the-webhook-tunnel).
+
+### `build-orchestrator-filter`
+
+```bash
+catalyst-events build-orchestrator-filter --orch <orch-id> [--wave <N>]
+```
+
+Generates the canonical jq filter string used by the orchestrator's Phase 4 polling loop.
+The output is a jq expression ready to pass directly to `--filter` on `wait-for` or `tail`.
+
+```bash
+FILTER=$(catalyst-events build-orchestrator-filter --orch orch-ctl-2026-05-01)
+catalyst-events wait-for --filter "$FILTER" --timeout 3600
+```
+
+## Event Envelope Schemas
+
+The unified event log contains events from multiple writers. Two envelope shapes coexist:
+
+### v1 envelope (legacy)
+
+Written by `catalyst-state.sh event` and most bash skills:
+
+```json
+{
+  "ts": "2026-05-01T12:00:00Z",
+  "event": "worker-pr-created",
+  "orchestrator": "orch-ctl-2026-05-01",
+  "worker": "CTL-48",
+  "detail": {
+    "pr": 87,
+    "url": "https://github.com/org/repo/pull/87"
+  }
+}
+```
+
+Top-level fields: `ts`, `event`, `orchestrator` (nullable), `worker` (nullable), `detail` (nullable object).
+
+### v2 envelope (OTel-shaped)
+
+Written by the webhook receiver (`lib/webhook-events.ts`) and `catalyst-comms send` (CTL-300):
+
+```json
+{
+  "ts": "2026-05-01T12:00:00Z",
+  "attributes": {
+    "event.name": "github.pr.merged",
+    "vcs.pr.number": 87,
+    "vcs.revision": "abc123def456"
+  },
+  "body": {
+    "payload": { "...full webhook payload..." }
+  },
+  "resource": {
+    "service.name": "orch-monitor"
+  }
+}
+```
+
+Top-level fields: `ts`, `attributes` (OTel attribute map), `body`, `resource`. The `.event`
+shorthand field is absent — use `.attributes."event.name"` instead.
+
+### Identifying the envelope version
+
+```bash
+# v1 events have a top-level .event field
+catalyst-events tail --filter '.event != null'
+
+# v2 events have .attributes."event.name"
+catalyst-events tail --filter '.attributes."event.name" != null'
+```
+
+Both shapes coexist indefinitely. New tools should write v2; `catalyst-state.sh event`
+continues to write v1 for backward compatibility.
+
+## jq Filter Cookbook
+
+### Match by PR number
+
+```bash
+# v2 GitHub webhook events
+--filter '.attributes."vcs.pr.number" == 87'
+
+# v2 check suite (uses prNumbers array, not vcs.pr.number)
+--filter '(.body.payload.prNumbers // [] | contains([87]))'
+
+# Either (covers both)
+--filter '(.attributes."vcs.pr.number" == 87) or (.body.payload.prNumbers // [] | contains([87]))'
+```
+
+### Match by event prefix
+
+```bash
+--filter '.event | startswith("worker-")'                     # v1 worker lifecycle
+--filter '.attributes."event.name" | startswith("github.")'  # v2 GitHub webhook
+--filter '.attributes."event.name" | startswith("linear.")'  # v2 Linear webhook
+```
+
+### Match by orchestrator scope
+
+```bash
+# v1 orchestrator events
+--filter '.orchestrator == "orch-ctl-2026-05-01"'
+
+# v2 events don't carry .orchestrator — filter by session or ticket instead
+--filter '.attributes."worker.ticket" == "CTL-48"'
+```
+
+### PR lifecycle — wait for any status change
+
+```bash
+catalyst-events wait-for \
+  --filter '(
+    (.attributes."vcs.pr.number" == 87 or (.body.payload.prNumbers // [] | contains([87])))
+    and (
+      .attributes."event.name" == "github.pr.merged" or
+      .attributes."event.name" == "github.check_suite.completed" or
+      (.attributes."event.name" | startswith("github.pr_review")) or
+      .attributes."event.name" == "github.push"
+    )
+  )' \
+  --timeout 180
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CATALYST_DIR` | `~/catalyst` | Root directory for all Catalyst runtime state |
+| `CATALYST_EVENTS_DIR` | `$CATALYST_DIR/events` | Directory containing monthly JSONL log files |
+
+Setting `CATALYST_EVENTS_DIR` overrides the log file location without changing other runtime
+paths. Useful when testing with a separate log directory.
+
+## Related
+
+- [Event architecture](./events/) — how signal files, global state, and the SSE stream connect
+- [Event flow](./event-flow/) — end-to-end: how a GitHub push becomes a `wait-for` wake
+- [GitHub webhooks for orch-monitor](./webhooks/) — configure near-real-time event delivery
+- Skill-author reference: `plugins/dev/skills/monitor-events/SKILL.md`

--- a/website/src/content/docs/observability/event-flow.md
+++ b/website/src/content/docs/observability/event-flow.md
@@ -1,0 +1,136 @@
+---
+title: Event flow — GitHub to worker
+description: End-to-end explanation of how a GitHub or Linear event travels from the source to a waiting worker process.
+sidebar:
+  order: 7
+---
+
+When a Catalyst worker calls `catalyst-events wait-for`, it blocks until a specific event appears
+in the unified log at `~/catalyst/events/YYYY-MM.jsonl`. This page explains exactly how an event
+gets from GitHub (or Linear) to that log so the waiting process wakes up.
+
+## The three paths
+
+```
+┌─────────────┐
+│   GitHub    │ ──webhook──> smee.io ──SSE──> orch-monitor POST /api/webhook
+└─────────────┘                                     │
+                                              HMAC verify
+                                                    │
+                                             event-log append
+                                        ~/catalyst/events/YYYY-MM.jsonl
+                                                    │
+                                         catalyst-events wait-for ──> worker wakes
+```
+
+```
+┌─────────────┐
+│   Linear    │ ──webhook──> smee.io (separate channel)
+└─────────────┘                     │
+                          orch-monitor POST /api/webhook/linear
+                                    │
+                             HMAC verify + Linear-specific parsing
+                                    │
+                             event-log append (same file)
+                        ~/catalyst/events/YYYY-MM.jsonl
+```
+
+```
+┌──────────────────┐
+│  bash skill      │ ──catalyst-state.sh event '{"event":"worker-done",...}'──>
+│  (v1 writer)     │        event-log append
+└──────────────────┘   ~/catalyst/events/YYYY-MM.jsonl
+```
+
+All three paths converge on the same monthly JSONL file. A worker using `catalyst-events wait-for`
+monitors that file regardless of which path produced the event.
+
+## Step-by-step: a GitHub PR merge
+
+1. **PR is merged on GitHub.** GitHub fires a `pull_request` webhook payload with `action: "closed"` and `merged: true`.
+
+2. **GitHub delivers the payload to smee.io.** The smee channel URL was registered as the webhook target for the repo (either by `setup-webhooks.sh` at setup time, or lazily when the monitor first saw a worker referencing that repo).
+
+3. **smee.io forwards the payload to orch-monitor.** The orch-monitor daemon keeps an outbound EventSource connection open to `https://smee.io/<channel-id>`. Deliveries arrive over this connection — no inbound port needed.
+
+4. **orch-monitor verifies the HMAC signature.** Each delivery is signed by GitHub using the shared secret configured in the env var named by `catalyst.monitor.github.webhookSecretEnv` (default: `CATALYST_WEBHOOK_SECRET`). Deliveries that fail HMAC verification are dropped.
+
+5. **orch-monitor normalizes the event.** The webhook handler maps the raw GitHub payload to a v2 OTel-shaped envelope:
+   ```json
+   {
+     "ts": "2026-05-01T14:22:01Z",
+     "attributes": {
+       "event.name": "github.pr.merged",
+       "vcs.pr.number": 87,
+       "vcs.revision": "abc123def"
+     },
+     "body": { "payload": { "...full webhook payload..." } },
+     "resource": { "service.name": "orch-monitor" }
+   }
+   ```
+
+6. **orch-monitor appends the event to the log.** The normalized envelope is appended to `~/catalyst/events/YYYY-MM.jsonl` using a POSIX atomic append (small writes are atomic under POSIX).
+
+7. **`catalyst-events wait-for` sees the new line.** The waiting worker has an open `tail -f` on the current month's log file. The new line appears, the jq filter matches, and `wait-for` prints the event and exits with code 0.
+
+8. **The worker acts.** With the PR confirmed merged, the worker records `pr.mergedAt`, transitions the Linear ticket to Done, and writes `status: "done"` to its signal file.
+
+## What happens without webhooks
+
+If the smee tunnel is not configured, step 2 never happens. The orch-monitor falls back to polling GitHub's REST API every **10 minutes** and appending `github.*` events from poll results. `catalyst-events wait-for` will wake, but with up to 600s latency instead of ~1s.
+
+Skills detect this automatically: the oneshot Phase 5 listen loop checks tunnel status before entering the event-driven path and switches to the REST fallback if the tunnel is not running.
+
+See [Setting up the webhook tunnel](./setup/#5-set-up-the-webhook-tunnel) to configure near-real-time delivery.
+
+## Linear webhook path
+
+Linear webhooks follow the same pattern with two differences:
+
+- A **separate smee channel** is used (one channel per source — GitHub and Linear cannot share a channel because their payload shapes differ).
+- The orch-monitor listens on `POST /api/webhook/linear` and applies Linear-specific HMAC verification using the secret named by `catalyst.monitor.linear.webhookSecretEnv`.
+- Topics are namespaced `linear.*` (e.g., `linear.issue.state_changed`, `linear.comment.created`).
+
+```bash
+# Watch Linear events in real time
+catalyst-events tail --filter '.attributes."event.name" | startswith("linear.")'
+```
+
+## Skill-writer path (v1 envelopes)
+
+Bash skills write events directly via `catalyst-state.sh event`, bypassing the webhook path entirely:
+
+```bash
+catalyst-state.sh event "$(jq -nc \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg orch "$ORCH_ID" --arg w "$TICKET_ID" \
+  '{ts: $ts, event: "worker-done", orchestrator: $orch, worker: $w, detail: null}')"
+```
+
+These produce v1 envelopes (`.event` top-level field, no `.attributes`). `catalyst-events wait-for`
+handles both v1 and v2 shapes — the jq filter sees the raw line, so write filters that match the
+actual field location:
+
+```bash
+# Match v1 worker-done
+--filter '.event == "worker-done" and .worker == "CTL-48"'
+
+# Match v2 github.pr.merged
+--filter '.attributes."event.name" == "github.pr.merged"'
+```
+
+## Replay on monitor startup
+
+When the orch-monitor starts (or restarts after a crash), it replays the last **1 hour** of
+webhook deliveries from GitHub's delivery history API. This reconciles any events that arrived
+while the daemon was down, without operator action.
+
+The replay uses the same handler as live deliveries (including HMAC verification with a
+synthetic signature — the orch-monitor owns the secret it uses to re-sign). Replayed events
+are appended to the log only if they're not already present (deduplication by delivery ID).
+
+## Related
+
+- [catalyst-events CLI](./catalyst-events/) — command reference and jq filter cookbook
+- [Event architecture](./events/) — signal files, global state, and SSE stream overview
+- [GitHub webhooks for orch-monitor](./webhooks/) — full webhook setup guide

--- a/website/src/content/docs/observability/events.md
+++ b/website/src/content/docs/observability/events.md
@@ -21,7 +21,7 @@ Snapshots answer "what is the state right now?" — the event log answers "what 
 
 An earlier design used only the signal file. It was insufficient because:
 
-1. **Workers exit before merge** — the subprocess running `/oneshot` reliably terminates at its final tool-use, which happens before PR merge completes. If `pr.mergedAt` lived only in the signal file, it would never be written by the worker itself.
+1. **Workers write `mergedAt` but may crash before doing so** — under normal operation the worker stays alive through merge and writes `pr.mergedAt` itself. However, if the worker crashes or stalls, that write never happens. The orchestrator's fallback Phase 4 reconciles the merge and writes `done` — but it needs a fleet-wide view to know which workers to check, which the per-worker signal file alone cannot provide.
 2. **Multi-orchestrator aggregation** — a single signal file describes one worker. The dashboard needs to query across all orchestrators to show "how many waves are active right now?"
 3. **Audit trails** — status snapshots overwrite each other. The event log keeps the full history (`researching → planning → implementing → ...`) even when the worker is long gone.
 

--- a/website/src/content/docs/observability/index.md
+++ b/website/src/content/docs/observability/index.md
@@ -55,6 +55,8 @@ bun run plugins/dev/scripts/orch-monitor/server.ts --terminal
 - [GitHub webhooks for orch-monitor](./webhooks/) — sub-5-second PR / review / deployment updates via smee.io tunnel
 - [Using the terminal UI](./terminal/) — when to prefer ANSI over the browser
 - [Event architecture](./events/) — how SSE streams and the global event log fit together
+- [catalyst-events CLI](./catalyst-events/) — command reference and jq filter cookbook for the event log
+- [Event flow — GitHub to worker](./event-flow/) — end-to-end: how a GitHub push becomes a `wait-for` wake
 - [Agent communication (`catalyst-comms`)](../reference/catalyst-comms/) — how workers coordinate with each other across worktrees
 
 ## When Not to Enable Observability

--- a/website/src/content/docs/observability/monitor.md
+++ b/website/src/content/docs/observability/monitor.md
@@ -79,7 +79,7 @@ One row per worker showing:
 
 ### Row 3 — Event stream
 
-Real-time event log from `~/catalyst/events.jsonl` and filesystem watches, rendered as a timeline. Filters: event type, worker ticket, orchestrator, date range.
+Real-time event log from `~/catalyst/events/YYYY-MM.jsonl` and filesystem watches, rendered as a timeline. Filters: event type, worker ticket, orchestrator, date range.
 
 ![Timeline tab showing a Gantt-style view with colored phase bars per worker across research, plan, implement, validate, ship, and merged states](https://assets.coalescelabs.ai/images/screenshots/timeline-2026-04-17%20at%2009.08.04.png)
 
@@ -138,9 +138,9 @@ You can share a filtered URL with someone else running the same monitor — the 
 
 The PID-liveness check uses `kill -0 <pid>`. If the worker is running under a different user, the check fails. The worker is actually alive — the monitor just can't see it. Additionally, the monitor can tail the worker's stream-json output file (`workers/<ticket>-stream.jsonl`) to see real-time tool calls and progress.
 
-**PR status says "merged" but the signal file says "pr-created"**:
+**Signal file stuck at `pr-created` even though PR is merged**:
 
-This is expected and intentional. The worker subprocess reliably exits at its last tool-use, before merge completes. The orchestrator (or the monitor itself) is the authoritative source for `pr.mergedAt`. The signal-file `status` stays at `pr-created` until the orchestrator updates it.
+This is a symptom of a **stalled or crashed worker**, not the happy path. Under normal operation, the worker stays alive through merge: it enters a `catalyst-events wait-for` listen loop, executes `gh pr merge --squash --delete-branch` when the PR is CLEAN, and writes `status: "done"` before exiting. A signal file that remains at `pr-created` after a GitHub merge means the worker exited before completing that sequence. Check the worker's liveness indicator — if it shows `!` (dead PID), the orchestrator's fallback Phase 4 will reconcile the merge and write `done`. If the worker is still alive but stuck, check its activity feed for a `stalled` attention item.
 
 **Monitor misses an orchestrator**:
 

--- a/website/src/content/docs/observability/setup.md
+++ b/website/src/content/docs/observability/setup.md
@@ -125,7 +125,21 @@ This enables the `/api/otel/query` and `/api/otel/logs` endpoints on the monitor
 
 Alternatively, set environment variables: `OTEL_ENABLED=true`, `PROMETHEUS_URL`, `LOKI_URL`.
 
-### 5. Import the Grafana dashboard
+### 5. Set up the webhook tunnel
+
+The orch-monitor can receive GitHub and Linear events in near-real-time via a smee.io webhook tunnel. Without this step, skills that use `catalyst-events wait-for` — including `/catalyst-dev:orchestrate` Phase 4, `/catalyst-dev:oneshot` Phase 5, and `/catalyst-dev:wait-for-github` — silently fall back to REST polling with up to **10-minute latency** per event.
+
+With the tunnel configured, the same events arrive within **~1 second** of GitHub or Linear posting them.
+
+Run the setup script once per machine:
+
+```bash
+bash plugins/dev/scripts/setup-webhooks.sh
+```
+
+This creates a smee.io channel, writes the channel URL to `~/.config/catalyst/config.json`, generates an HMAC secret, and registers a webhook on each repo listed in `catalyst.monitor.github.watchRepos`. See [GitHub webhooks for orch-monitor](../webhooks/) for the full setup guide and configuration reference.
+
+### 6. Import the Grafana dashboard
 
 The claude-code-otel repo ships with a pre-built Grafana dashboard at `dashboards/claude-code.json`. Import it via Grafana → Dashboards → New → Import → Upload JSON file.
 

--- a/website/src/content/docs/reference/catalyst-comms.md
+++ b/website/src/content/docs/reference/catalyst-comms.md
@@ -270,6 +270,46 @@ Orchestrators that want their workers to coordinate should:
 
 The orchestrator can monitor progress with `catalyst-comms watch` in a dedicated terminal pane.
 
+## Bidirectional Messaging
+
+Workers do not just broadcast status — the orchestrator can also send messages **directed to individual workers** (CTL-249). A worker reads inbound messages at each phase boundary without blocking.
+
+### Sending to a worker (orchestrator side)
+
+```bash
+catalyst-comms send orch-ctl-ux-apr20-wave-1 "CTL-101: please skip the migration in your scope, CTL-99 is handling it" \
+  --as orchestrator --to CTL-101 --type info
+```
+
+The `--to <ticket-id>` flag targets the message. Other workers can see the message in the channel log but are not the intended recipient.
+
+### Reading inbound messages (worker side)
+
+Workers track a `COMMS_LAST_READ` cursor (initialized to the channel file's line count at join time, so pre-join history is skipped) and poll after each phase transition:
+
+```bash
+msgs=$(catalyst-comms poll "$CHANNEL" --filter-to "$TICKET_ID" --since "$COMMS_LAST_READ")
+COMMS_LAST_READ=$(wc -l < "$CHANNEL_FILE" | tr -d ' ')
+```
+
+The cursor advances atomically — messages arriving during a read are captured on the next poll.
+
+### ACK gap
+
+There is currently **no delivery guarantee**: a worker may have already passed a phase boundary before the orchestrator's message arrives. CTL-253 tracks adding an explicit ACK mechanism. For now, treat orchestrator-to-worker messages as advisory (the worker may or may not act on them before its next check).
+
+### Event log integration
+
+`catalyst-comms send` emits a `comms.message.posted` event to the unified event log (`~/catalyst/events/YYYY-MM.jsonl`) using the v2 OTel-shaped envelope. This means orchestrators and tools that monitor the event log see all comms traffic without polling the channel file directly:
+
+```bash
+# Watch all comms messages on a channel
+catalyst-events tail --filter '.event == "comms.message.posted" and .attributes."comms.channel" == "orch-ctl-ux-apr20-wave-1"'
+
+# Messages directed at a specific worker
+catalyst-events tail --filter '.event == "comms.message.posted" and .body.payload.to == "CTL-101"'
+```
+
 ## Sub-agent Pattern
 
 When spawning a sub-agent via `Agent(...)`, pass the channel name in the prompt:

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -267,7 +267,6 @@ The orchestrator:
 | ------------------------ | ------------------------------------------------ |
 | `--name <name>`          | Name this orchestrator (default: auto-generated) |
 | `--auto <N>`             | Auto-pick top N Todo tickets (urgent/high priority first, newer first). Default N=3. |
-| `--auto-merge`           | Workers auto-merge when CI + verification pass   |
 | `--max-parallel <n>`     | Override max concurrent workers (default: 3)     |
 | `--base-branch <branch>` | Base branch for worktrees (default: main)        |
 | `--dry-run`              | Show wave plan without executing                 |
@@ -349,7 +348,8 @@ initializes worker signal files.
 Workers are dispatched by `orchestrate-dispatch-next`, which reads the `waveNPending` queues,
 validates the `workerCommand` format (must be `/<plugin>:<skill>`), and launches `claude -p`
 with `--output-format stream-json --verbose` to produce real-time NDJSON the monitor tails
-for live worker activity. Each runs `/catalyst-dev:oneshot <ticket> --auto-merge` autonomously.
+for live worker activity. Each runs `/catalyst-dev:oneshot <ticket>` autonomously — workers
+own their full PR lifecycle including merge; there is no `--auto-merge` flag.
 
 The dispatch prompt includes **mandatory testing requirements** — not suggestions. Workers are told
 their output will be independently verified. The `CATALYST_ORCHESTRATOR_DIR` environment variable is
@@ -643,6 +643,23 @@ grep '"q2-api-redesign"' ~/catalyst/events/*.jsonl | jq -r '"\(.ts) \(.worker //
 # Event types
 cat ~/catalyst/events/*.jsonl | jq -r '.event' | sort | uniq -c | sort -rn
 ```
+
+:::note[Filtering github.* and linear.* events]
+`github.*` and `linear.*` events (delivered via webhook) share the same JSONL files as
+orchestrator/worker events, but they do **not** carry `.orchestrator` or `.worker` fields.
+Filter them by event prefix or by the PR/repo context embedded in each webhook payload:
+
+```bash
+# GitHub PR events for a specific repo
+cat ~/catalyst/events/*.jsonl | jq 'select(.event | startswith("github.pr")) | select(.detail.repo == "acme-corp/api")'
+
+# Linear issue state changes
+cat ~/catalyst/events/*.jsonl | jq 'select(.event | startswith("linear.issue.state"))'
+
+# All GitHub check suite completions for a specific PR
+cat ~/catalyst/events/*.jsonl | jq 'select(.event == "github.check_suite.completed") | select(.body.payload.prNumbers // [] | contains([87]))'
+```
+:::
 
 ### The catalyst-state.sh CLI
 

--- a/website/src/content/docs/reference/orchestration/workers.md
+++ b/website/src/content/docs/reference/orchestration/workers.md
@@ -18,16 +18,17 @@ Orchestrator                   Worker subprocess
      │                                 │   Phase 2: planning
      │                                 │   Phase 3: implementing
      │                                 │   Phase 4: validating
-     │                                 │   Phase 5: shipping (opens PR, arms auto-merge)
+     │                                 │   Phase 5: shipping
+     │                                 │     opens PR → enters catalyst-events wait-for loop
+     │                                 │     resolves CI failures, bot review threads, BEHIND
+     │                                 │     gh pr merge --squash --delete-branch
+     │                                 │     writes pr.mergedAt + status: done → exits
      │                                 │
-     │<─ signal file: pr-created ──────│
-     │                                 │ exits
-     │                                 │
-     │ (Phase 4 poll loop, orchestrator side)
-     │    gh pr view → merged? ──> yes: writes mergedAt, Linear=Done
+     │<─ signal file: done ────────────│
+     │   (orchestrator's Phase 4 is a safety-net fallback for stalled/crashed workers)
 ```
 
-The split between worker and orchestrator matters: the worker subprocess reliably exits at its final tool-use, before merge completes. **Polling until merged is the orchestrator's responsibility**, not the worker's. A worker that claims to poll-until-merged burns tokens and produces false signals.
+The worker owns the full PR lifecycle end-to-end: it opens the PR, enters an event-driven listen loop via `catalyst-events wait-for`, resolves blockers (CI failures, bot review threads, BEHIND) inline, executes `gh pr merge --squash --delete-branch` when the PR is CLEAN, and writes `status: "done"` before exiting. The orchestrator's Phase 4 is a fallback that handles workers that stalled before completing their own merge.
 
 ## The signal file
 
@@ -62,31 +63,30 @@ Located at `<orchestrator-dir>/workers/<ticket>.json`. The orchestrator creates 
   "url": "https://github.com/org/repo/pull/123",
   "ciStatus": "pending",
   "prOpenedAt": "2026-04-14T19:15:30Z",
-  "autoMergeArmedAt": "2026-04-14T19:15:32Z",
   "mergedAt": null
 }
 ```
 
 - `ciStatus`: `pending` | `passing` | `failing` | `unknown` | `merged`
 - `prOpenedAt` — set by worker the moment the PR is created
-- `autoMergeArmedAt` — set by worker after `gh pr merge --squash --auto`
-- `mergedAt` — **always** set by the orchestrator (or standalone `/merge-pr`), never by the worker
+- `mergedAt` — set by the worker after `gh pr merge --squash --delete-branch` completes; set by the orchestrator (fallback) for stalled workers
 
 ### State machine
 
 ```
 dispatched → researching → planning → implementing → validating → shipping → pr-created
                                                                                    │
-                                                                         (orchestrator polls)
+                                                                     (worker listen loop)
+                                                                       resolves blockers
                                                                                    │
                                                                                    v
-                                                                              merging → done
-                                                                                   │
+                                                                                 done  ← worker (primary path)
+                                                                                   │     orchestrator (fallback for stalled workers)
                                                                                    v
                                                           (at any stage) → failed | stalled
 ```
 
-The worker writes statuses up through `pr-created`. The orchestrator writes `merging` and `done` (or `failed`/`stalled` if the wave times out or verification fails).
+The worker writes all statuses through `done`. In the `pr-created` → `done` transition, the worker enters a `catalyst-events wait-for` listen loop, resolves CI failures and review blockers inline, and executes `gh pr merge --squash --delete-branch` when the PR is CLEAN. The orchestrator writes `done` only as a safety-net fallback for workers that wrote `stalled` or crashed before completing their own merge.
 
 ## The global state
 
@@ -128,9 +128,9 @@ A worker reaches a terminal state in one of three ways:
 
 | State | Means | Signal writer |
 |-------|-------|---------------|
-| `done` | PR merged, Linear=Done | Orchestrator (after observing merge) |
+| `done` | PR merged, Linear=Done | Worker (after executing merge); Orchestrator (fallback for stalled workers) |
 | `failed` | Unrecoverable error, quality gates exhausted, or human escalation | Worker (writes attention reason) |
-| `stalled` | No heartbeat / no progress for 15+ min | Orchestrator |
+| `stalled` | Worker could not resolve a blocker (CI, reviews, conflicts) or no heartbeat for 15+ min | Worker (on unrecoverable blocker); Orchestrator (on heartbeat timeout) |
 
 Terminal states set `completedAt`. No further writes to the signal file happen once terminal is reached.
 


### PR DESCRIPTION
## Summary

Fixes actively misleading documentation left by CTL-252's lifecycle inversion and adds missing reference content for the event-driven system.

**Part 1 — Actively misleading fixes:**
- `workers.md`: Rewrites lifecycle diagram to show worker-owns-merge; removes `autoMergeArmedAt`; fixes state machine and terminal-states table; removes stale "orchestrator polls until merged" language
- `phases.md`: Phase 5 now describes the `catalyst-events wait-for` listen loop (not `gh pr view` poll); adds note that Phase 6 is folded into Phase 5 in oneshot/orchestrated runs
- `orchestration.md`: Removes `--auto-merge` from dispatch example and flags table; adds note that `github.*`/`linear.*` events don't carry `.orchestrator` — use `.scope.repo` or event prefix filtering
- `monitor.md`: Fixes troubleshooting item ("pr-created is normal" → signals a stalled/crashed worker); fixes event log path (`events.jsonl` → `events/YYYY-MM.jsonl`)
- `events.md`: Fixes "Why three, not one" rationale — workers now stay through merge (CTL-252 change)

**Part 2 — Net-new content:**
- `catalyst-events.md` (NEW): Full CLI reference — `tail`, `wait-for`, `build-orchestrator-filter`, v1/v2 envelope schemas, jq filter cookbook, env vars, exit codes
- `event-flow.md` (NEW): Conceptual end-to-end flow diagram — GitHub → smee.io → orch-monitor → event log → `wait-for` → worker action; includes Linear and skill-writer paths
- `catalyst-comms.md`: Bidirectional Messaging section — orchestrator→worker directed sends, `COMMS_LAST_READ` cursor pattern, ACK gap note, event log integration
- `setup.md`: Step 5 — webhook tunnel setup with latency impact note (without it: 10-min REST polling fallback)
- `adrs.md`: ADR-013 (event-driven waits), ADR-014 (worker owns PR lifecycle), ADR-015 (bidirectional comms); ADR-012 forward refs marked shipped
- `architecture.md`: Expands event log section (all writers, v1/v2 duality, `catalyst-events` as consumer interface); updates catalyst-comms section for bidirectional protocol

## Test plan

- [ ] All acceptance criteria from CTL-255 verified against changed files
- [ ] No broken internal links (new files referenced from `observability/index.md`)
- [ ] `autoMergeArmedAt` removed from workers.md (grep confirms 0 occurrences)
- [ ] `--auto-merge` removed from orchestration.md worker dispatch and flags table
- [ ] `events.jsonl` (singular) replaced with `events/YYYY-MM.jsonl` in monitor.md

Fixes CTL-255

🤖 Generated with [Claude Code](https://claude.com/claude-code)