### PR TITLE
feat(dev): webhook teardown script + auto-startup docs (CTL-219)

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-webhooks.test.sh
@@ -50,16 +50,23 @@ EOF
   cat > "${dir}/stubbin/gh" <<'EOF'
 #!/usr/bin/env bash
 # Scriptable gh stub for setup-webhooks tests.
-#   GH_STUB_DIR/list-response.json — body returned for `gh api repos/X/hooks` (GET)
-#   GH_STUB_DIR/post-response.json — body returned for `gh api -X POST repos/X/hooks`
-#   GH_STUB_DIR/list-exit         — exit code for GET (default 0)
-#   GH_STUB_DIR/post-exit         — exit code for POST (default 0)
-#   GH_STUB_DIR/calls.log         — append-only call log
+#   GH_STUB_DIR/list-response.json   — body returned for `gh api repos/X/hooks` (GET)
+#   GH_STUB_DIR/post-response.json   — body returned for `gh api -X POST repos/X/hooks`
+#   GH_STUB_DIR/delete-response.json — body returned for `gh api -X DELETE repos/X/hooks/ID`
+#   GH_STUB_DIR/list-exit            — exit code for GET (default 0)
+#   GH_STUB_DIR/post-exit            — exit code for POST (default 0)
+#   GH_STUB_DIR/delete-exit          — exit code for DELETE (default 0)
+#   GH_STUB_DIR/calls.log            — append-only call log
 if [[ -z "${GH_STUB_DIR:-}" ]]; then
   echo "FAIL: gh invoked but GH_STUB_DIR is unset (test setup error)" >&2
   exit 88
 fi
 echo "$*" >> "${GH_STUB_DIR}/calls.log"
+# `gh api -X DELETE repos/X/hooks/ID`
+if [[ "$1" == "api" && "$2" == "-X" && "$3" == "DELETE" ]]; then
+  cat "${GH_STUB_DIR}/delete-response.json" 2>/dev/null || echo '{}'
+  exit "$(cat "${GH_STUB_DIR}/delete-exit" 2>/dev/null || echo 0)"
+fi
 # `gh api -X POST repos/X/hooks ...`
 if [[ "$1" == "api" && "$2" == "-X" && "$3" == "POST" && "$4" == repos/*/hooks ]]; then
   cat "${GH_STUB_DIR}/post-response.json" 2>/dev/null || echo '{"id":1}'
@@ -661,6 +668,242 @@ test_template_has_monitor_block() {
   fi
 }
 
+# ─── Tests 26-33 — --uninstall flag (CTL-219) ─────────────────────────────
+#
+# `run_setup_uninstall` seeds home config with smeeChannel so no curl/openssl
+# needed, passes GH_STUB_DIR, and runs --uninstall --yes to skip confirmation.
+run_setup_uninstall() {
+  local env_dir="$1"; shift
+  ( cd "${env_dir}/project" && \
+    HOME="${env_dir}/home" \
+    XDG_CONFIG_HOME="${env_dir}/home/.config" \
+    PATH="${env_dir}/stubbin:${PATH}" \
+    GH_STUB_DIR="${env_dir}/gh_stub" \
+    bash "$SETUP" --uninstall "$@" )
+}
+
+# Seed home config with a smee channel so uninstall has something to read.
+seed_smee_channel() {
+  local env="$1" channel="${2:-https://smee.io/test-channel}"
+  mkdir -p "${env}/home/.config/catalyst"
+  cat > "${env}/home/.config/catalyst/config.json" <<EOF
+{"catalyst":{"monitor":{"github":{"smeeChannel":"${channel}"}}}}
+EOF
+}
+
+# Seed project config with webhookSecretEnv.
+seed_secret_env() {
+  local env="$1"
+  mkdir -p "${env}/project/.catalyst"
+  cat > "${env}/project/.catalyst/config.json" <<EOF
+{"catalyst":{"monitor":{"github":{"webhookSecretEnv":"CATALYST_WEBHOOK_SECRET"}}}}
+EOF
+}
+
+# ─── Test 26 — uninstall with no smee channel exits cleanly ────────────────
+test_uninstall_no_channel() {
+  local env; env=$(make_test_env t26)
+  if ! run_setup_uninstall "$env" --yes > "${SCRATCH}/t26.out" 2>&1; then
+    echo "expected exit 0 when nothing to uninstall" >&2
+    cat "${SCRATCH}/t26.out" >&2
+    return 1
+  fi
+  if ! grep -qi "nothing to uninstall" "${SCRATCH}/t26.out"; then
+    echo "expected output to mention 'nothing to uninstall'" >&2
+    cat "${SCRATCH}/t26.out" >&2
+    return 1
+  fi
+}
+
+# ─── Test 27 — --dry-run shows would-be deletion without calling DELETE ────
+test_uninstall_dry_run() {
+  local env; env=$(make_test_env t27)
+  seed_smee_channel "$env"
+  seed_watch_repos "$env" "acme/api"
+  cat > "${env}/gh_stub/list-response.json" <<'EOF'
+[{"id":42,"config":{"url":"https://smee.io/test-channel","content_type":"json"}}]
+EOF
+  if ! run_setup_uninstall "$env" --dry-run --yes > "${SCRATCH}/t27.out" 2>&1; then
+    echo "expected exit 0 for dry-run" >&2
+    cat "${SCRATCH}/t27.out" >&2
+    return 1
+  fi
+  if ! grep -q "dry-run" "${SCRATCH}/t27.out"; then
+    echo "expected dry-run mention in output" >&2
+    cat "${SCRATCH}/t27.out" >&2
+    return 1
+  fi
+  if grep -q "api -X DELETE" "${env}/gh_stub/calls.log" 2>/dev/null; then
+    echo "dry-run must not issue any DELETE calls" >&2
+    cat "${env}/gh_stub/calls.log" >&2
+    return 1
+  fi
+  # Config must remain untouched
+  local channel; channel=$(jq -r '.catalyst.monitor.github.smeeChannel // ""' \
+    "${env}/home/.config/catalyst/config.json")
+  if [[ -z "$channel" ]]; then
+    echo "dry-run must not remove smeeChannel from home config" >&2
+    return 1
+  fi
+}
+
+# ─── Test 28 — uninstall deletes hook and cleans up config ─────────────────
+test_uninstall_deletes_hook_and_config() {
+  local env; env=$(make_test_env t28)
+  seed_smee_channel "$env"
+  seed_secret "$env"
+  seed_secret_env "$env"
+  # watchRepos and webhookSecretEnv both in project config
+  cat > "${env}/project/.catalyst/config.json" <<'EOF'
+{"catalyst":{"monitor":{"github":{
+  "webhookSecretEnv":"CATALYST_WEBHOOK_SECRET",
+  "watchRepos":["acme/api"]
+}}}}
+EOF
+  cat > "${env}/gh_stub/list-response.json" <<'EOF'
+[{"id":42,"config":{"url":"https://smee.io/test-channel","content_type":"json"}}]
+EOF
+  if ! run_setup_uninstall "$env" --yes > "${SCRATCH}/t28.out" 2>&1; then
+    echo "expected exit 0" >&2
+    cat "${SCRATCH}/t28.out" >&2
+    return 1
+  fi
+  # DELETE must have been issued
+  if ! grep -q "api -X DELETE repos/acme/api/hooks/42" "${env}/gh_stub/calls.log" 2>/dev/null; then
+    echo "expected DELETE repos/acme/api/hooks/42 in calls.log" >&2
+    cat "${env}/gh_stub/calls.log" 2>/dev/null >&2
+    return 1
+  fi
+  # smeeChannel removed from home config
+  local channel; channel=$(jq -r '.catalyst.monitor.github.smeeChannel // ""' \
+    "${env}/home/.config/catalyst/config.json" 2>/dev/null || echo "MISSING_FILE")
+  if [[ -n "$channel" && "$channel" != "null" && "$channel" != "" ]]; then
+    echo "smeeChannel should be removed from home config, got: '$channel'" >&2
+    return 1
+  fi
+  # webhookSecretEnv removed from project config
+  local env_key; env_key=$(jq -r '.catalyst.monitor.github.webhookSecretEnv // ""' \
+    "${env}/project/.catalyst/config.json" 2>/dev/null || echo "")
+  if [[ -n "$env_key" ]]; then
+    echo "webhookSecretEnv should be removed from project config, got: '$env_key'" >&2
+    return 1
+  fi
+  # Secret file removed
+  if [[ -f "${env}/home/.config/catalyst/webhook-secret" ]]; then
+    echo "secret file should have been removed" >&2
+    return 1
+  fi
+}
+
+# ─── Test 29 — uninstall idempotent when hook not found ────────────────────
+test_uninstall_idempotent_no_hook() {
+  local env; env=$(make_test_env t29)
+  seed_smee_channel "$env"
+  seed_watch_repos "$env" "acme/api"
+  echo "[]" > "${env}/gh_stub/list-response.json"
+  if ! run_setup_uninstall "$env" --yes > "${SCRATCH}/t29.out" 2>&1; then
+    echo "expected exit 0 when no hook found (idempotent)" >&2
+    cat "${SCRATCH}/t29.out" >&2
+    return 1
+  fi
+  if ! grep -q "no webhook found" "${SCRATCH}/t29.out"; then
+    echo "expected 'no webhook found' message" >&2
+    cat "${SCRATCH}/t29.out" >&2
+    return 1
+  fi
+  if grep -q "api -X DELETE" "${env}/gh_stub/calls.log" 2>/dev/null; then
+    echo "expected no DELETE when hook does not exist" >&2
+    cat "${env}/gh_stub/calls.log" >&2
+    return 1
+  fi
+}
+
+# ─── Test 30 — --repo limits uninstall scope ───────────────────────────────
+test_uninstall_repo_filter() {
+  local env; env=$(make_test_env t30)
+  seed_smee_channel "$env"
+  # Two repos in watchRepos, but we only uninstall one
+  cat > "${env}/project/.catalyst/config.json" <<'EOF'
+{"catalyst":{"monitor":{"github":{"watchRepos":["acme/api","acme/web"]}}}}
+EOF
+  cat > "${env}/gh_stub/list-response.json" <<'EOF'
+[{"id":42,"config":{"url":"https://smee.io/test-channel","content_type":"json"}}]
+EOF
+  if ! run_setup_uninstall "$env" --repo acme/api --yes > "${SCRATCH}/t30.out" 2>&1; then
+    echo "expected exit 0" >&2
+    cat "${SCRATCH}/t30.out" >&2
+    return 1
+  fi
+  # Only one DELETE (for acme/api)
+  local delete_count; delete_count=$(grep -c "api -X DELETE" "${env}/gh_stub/calls.log" 2>/dev/null || echo 0)
+  if [[ "$delete_count" -ne 1 ]]; then
+    echo "expected exactly 1 DELETE, got $delete_count" >&2
+    cat "${env}/gh_stub/calls.log" 2>/dev/null >&2
+    return 1
+  fi
+  if ! grep -q "api -X DELETE repos/acme/api/hooks" "${env}/gh_stub/calls.log" 2>/dev/null; then
+    echo "expected DELETE for acme/api" >&2
+    cat "${env}/gh_stub/calls.log" 2>/dev/null >&2
+    return 1
+  fi
+}
+
+# ─── Test 31 — uninstall removes secret file ───────────────────────────────
+test_uninstall_removes_secret_file() {
+  local env; env=$(make_test_env t31)
+  seed_smee_channel "$env"
+  seed_secret "$env"
+  echo "[]" > "${env}/gh_stub/list-response.json"
+  if ! run_setup_uninstall "$env" --yes > "${SCRATCH}/t31.out" 2>&1; then
+    echo "expected exit 0" >&2
+    cat "${SCRATCH}/t31.out" >&2
+    return 1
+  fi
+  if [[ -f "${env}/home/.config/catalyst/webhook-secret" ]]; then
+    echo "secret file should have been removed" >&2
+    return 1
+  fi
+}
+
+# ─── Test 32 — --dry-run does not modify config keys ───────────────────────
+test_uninstall_dry_run_preserves_config() {
+  local env; env=$(make_test_env t32)
+  seed_smee_channel "$env"
+  seed_secret "$env"
+  seed_secret_env "$env"
+  echo "[]" > "${env}/gh_stub/list-response.json"
+  if ! run_setup_uninstall "$env" --dry-run --yes > "${SCRATCH}/t32.out" 2>&1; then
+    echo "expected exit 0" >&2
+    cat "${SCRATCH}/t32.out" >&2
+    return 1
+  fi
+  local channel; channel=$(jq -r '.catalyst.monitor.github.smeeChannel // ""' \
+    "${env}/home/.config/catalyst/config.json" 2>/dev/null || echo "")
+  if [[ -z "$channel" ]]; then
+    echo "dry-run must not remove smeeChannel" >&2
+    return 1
+  fi
+  if [[ ! -f "${env}/home/.config/catalyst/webhook-secret" ]]; then
+    echo "dry-run must not remove secret file" >&2
+    return 1
+  fi
+}
+
+# ─── Test 33 — --uninstall and --register-github-hooks are mutually exclusive
+test_uninstall_register_mutex() {
+  local env; env=$(make_test_env t33)
+  if run_setup_uninstall "$env" --register-github-hooks > "${SCRATCH}/t33.out" 2>&1; then
+    echo "expected non-zero exit for --uninstall + --register-github-hooks" >&2
+    cat "${SCRATCH}/t33.out" >&2
+    return 1
+  fi
+  if ! grep -qi "mutually exclusive" "${SCRATCH}/t33.out"; then
+    echo "expected 'mutually exclusive' error message" >&2
+    cat "${SCRATCH}/t33.out" >&2
+    return 1
+  fi
+}
+
 # ─── Run all ──────────────────────────────────────────────────────────────
 echo "Running setup-webhooks --add-repo tests…"
 run "single add bootstraps watchRepos" test_single_add
@@ -688,6 +931,17 @@ run "--register-github-hooks is idempotent" test_register_idempotent
 run "no gh calls in --add-repo only mode" test_add_repo_only_no_gh_calls
 run "config.example.json has monitor block" test_example_template_has_monitor_block
 run "config.template.json has monitor block" test_template_has_monitor_block
+
+echo
+echo "Running setup-webhooks --uninstall tests…"
+run "uninstall with no channel exits cleanly" test_uninstall_no_channel
+run "uninstall --dry-run shows deletion without calling DELETE" test_uninstall_dry_run
+run "uninstall deletes hook and cleans up config" test_uninstall_deletes_hook_and_config
+run "uninstall idempotent when hook not found" test_uninstall_idempotent_no_hook
+run "uninstall --repo limits scope to one repo" test_uninstall_repo_filter
+run "uninstall removes secret file" test_uninstall_removes_secret_file
+run "uninstall --dry-run preserves config keys" test_uninstall_dry_run_preserves_config
+run "--uninstall and --register-github-hooks are mutually exclusive" test_uninstall_register_mutex
 
 echo
 echo "Passed: $PASSES, Failed: $FAILURES"

--- a/plugins/dev/scripts/orch-monitor/dist/ai.coalesce.catalyst-monitor.plist
+++ b/plugins/dev/scripts/orch-monitor/dist/ai.coalesce.catalyst-monitor.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent template for catalyst-monitor (macOS).
+
+  Instructions:
+    1. Copy this file to ~/Library/LaunchAgents/ai.coalesce.catalyst-monitor.plist
+    2. Replace REPLACE_WITH_WRAPPER_PATH with the absolute path to
+       catalyst-monitor-launchd.sh (the wrapper that reads the secret from disk).
+    3. Replace REPLACE_WITH_HOME with your home directory path (e.g. /Users/you).
+    4. Load the agent:
+         launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.coalesce.catalyst-monitor.plist
+    5. Verify it started:
+         launchctl list | grep catalyst-monitor
+         tail -f ~/catalyst/monitor.log
+
+  To stop and unload:
+    launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.coalesce.catalyst-monitor.plist
+
+  See: website/src/content/docs/observability/webhooks.md — "Persistent setup"
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.coalesce.catalyst-monitor</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_WRAPPER_PATH/catalyst-monitor-launchd.sh</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_WITH_HOME/catalyst/monitor.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>REPLACE_WITH_HOME/catalyst/monitor.log</string>
+</dict>
+</plist>

--- a/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
+++ b/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Wrapper script for launchd (macOS). Reads CATALYST_WEBHOOK_SECRET from the
+# secret file at startup so the value never needs to appear in the plist.
+#
+# Usage: copy this file to an absolute path on disk, edit the SCRIPT_DIR line
+# if needed, then reference it from your LaunchAgent plist.
+#
+# See: website/src/content/docs/observability/webhooks.md — "Persistent setup"
+
+SECRET_FILE="${HOME}/.config/catalyst/webhook-secret"
+if [[ -f "$SECRET_FILE" ]]; then
+  export CATALYST_WEBHOOK_SECRET
+  CATALYST_WEBHOOK_SECRET="$(cat "$SECRET_FILE")"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/../catalyst-monitor.sh" start

--- a/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor.service
+++ b/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor.service
@@ -1,0 +1,37 @@
+# systemd user unit for catalyst-monitor (Linux).
+#
+# Instructions:
+#   1. Copy this file to ~/.config/systemd/user/catalyst-monitor.service
+#      (create the directory if it doesn't exist)
+#   2. Replace REPLACE_WITH_MONITOR_PATH with the absolute path to catalyst-monitor.sh
+#      (e.g. /home/you/.claude/plugins/cache/catalyst/catalyst-dev/X.Y.Z/scripts/catalyst-monitor.sh)
+#   3. Create ~/.config/catalyst/webhook.env containing:
+#        CATALYST_WEBHOOK_SECRET=<the hex secret from ~/.config/catalyst/webhook-secret>
+#        CATALYST_DIR=/home/you/catalyst
+#   4. Enable and start:
+#        systemctl --user daemon-reload
+#        systemctl --user enable --now catalyst-monitor.service
+#   5. Verify:
+#        systemctl --user status catalyst-monitor.service
+#        journalctl --user -u catalyst-monitor.service -f
+#
+# To stop:
+#   systemctl --user stop catalyst-monitor.service
+#
+# See: website/src/content/docs/observability/webhooks.md — "Persistent setup"
+
+[Unit]
+Description=Catalyst Monitor Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=REPLACE_WITH_MONITOR_PATH start
+EnvironmentFile=%h/.config/catalyst/webhook.env
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:%h/catalyst/monitor.log
+StandardError=append:%h/catalyst/monitor.log
+
+[Install]
+WantedBy=default.target

--- a/plugins/dev/scripts/setup-webhooks.sh
+++ b/plugins/dev/scripts/setup-webhooks.sh
@@ -33,6 +33,10 @@ LINEAR_DEREGISTER=0
 LINEAR_ALL_PUBLIC_TEAMS=0
 LINEAR_WEBHOOK_URL=""
 REGISTER_GITHUB_HOOKS=0
+UNINSTALL=0
+DRY_RUN=0
+UNINSTALL_YES=0
+UNINSTALL_REPOS=()
 REPO_SHAPE='^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
 ENV_VAR_SHAPE='^[A-Z_][A-Z0-9_]*$'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -100,6 +104,15 @@ Options:
                              default — without this flag the script only reports
                              registration status. Requires \`gh\` to be installed
                              and authenticated with admin access to each repo.
+  --uninstall                Remove GitHub webhooks from all watched repos (or
+                             the repos specified with --repo) and clean up local
+                             config keys and secret file. Interactive confirmation
+                             by default; use --yes to skip.
+  --dry-run                  With --uninstall: print what would be deleted without
+                             making any changes.
+  --repo <owner/repo>        With --uninstall: limit webhook removal to one repo.
+                             Repeatable. When omitted, all watchRepos are processed.
+  --yes                      With --uninstall: skip the confirmation prompt.
   -h|--help                  Show this message
 
 Environment:
@@ -141,6 +154,18 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --register-github-hooks) REGISTER_GITHUB_HOOKS=1; shift ;;
+    --uninstall) UNINSTALL=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --yes) UNINSTALL_YES=1; shift ;;
+    --repo)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --repo requires an argument" >&2
+        usage
+        exit 1
+      fi
+      UNINSTALL_REPOS+=("$2")
+      shift 2
+      ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
   esac
@@ -155,6 +180,14 @@ for repo in "${ADD_REPOS[@]}"; do
   fi
 done
 
+# Validate --repo arguments (used with --uninstall).
+for repo in "${UNINSTALL_REPOS[@]}"; do
+  if [[ ! "$repo" =~ $REPO_SHAPE ]]; then
+    echo "ERROR: --repo value '$repo' must match owner/repo (e.g. coalesce-labs/catalyst)" >&2
+    exit 1
+  fi
+done
+
 # Validate --linear-secret-env name shape (env-var conventions: uppercase,
 # alphanumeric, underscores, must not start with a digit).
 if [[ -n "$LINEAR_SECRET_ENV" ]]; then
@@ -162,6 +195,16 @@ if [[ -n "$LINEAR_SECRET_ENV" ]]; then
     echo "ERROR: --linear-secret-env value '$LINEAR_SECRET_ENV' must be a valid env-var name (uppercase letters, digits, underscores; cannot start with a digit)" >&2
     exit 1
   fi
+fi
+
+# Validate --uninstall flag combinations.
+if [[ $UNINSTALL -eq 1 && $REGISTER_GITHUB_HOOKS -eq 1 ]]; then
+  echo "ERROR: --uninstall and --register-github-hooks are mutually exclusive" >&2
+  exit 1
+fi
+if [[ $UNINSTALL -eq 1 && ${#ADD_REPOS[@]} -gt 0 ]]; then
+  echo "ERROR: use --repo with --uninstall, not --add-repo" >&2
+  exit 1
 fi
 
 # Validate Linear flag combinations (CTL-238).
@@ -348,6 +391,135 @@ verify_github_hook() {
   fi
   rm -f "$err_file"
 }
+
+# Delete the GitHub webhook on `repo` that delivers to `channel`.
+# With DRY_RUN=1, prints what would be deleted without acting.
+# Idempotent: if no matching hook exists, logs "nothing to remove" and returns 0.
+#
+# Arguments:
+#   $1 — owner/repo
+#   $2 — smee channel URL
+delete_github_hook() {
+  local repo="$1" channel="$2"
+  local hooks_json hook_id
+  if ! hooks_json=$(gh api "repos/${repo}/hooks" 2>&1); then
+    echo "  ⚠ ${repo}: could not list hooks (gh not authenticated, or no admin access)"
+    echo "    ${hooks_json}" | sed 's/^/      /'
+    return 0
+  fi
+  hook_id=$(jq -r --arg ch "$channel" \
+    '[.[] | select(.config.url == $ch)] | .[0].id // empty' <<<"$hooks_json" 2>/dev/null || true)
+  if [[ -z "$hook_id" ]]; then
+    echo "  • ${repo}: no webhook found for ${channel} (already removed or never registered)"
+    return 0
+  fi
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "  [dry-run] would delete ${repo} hook #${hook_id} (${channel})"
+    return 0
+  fi
+  local err_file; err_file=$(mktemp)
+  if gh api -X DELETE "repos/${repo}/hooks/${hook_id}" >/dev/null 2>"$err_file"; then
+    echo "  ✓ ${repo}: deleted hook #${hook_id}"
+  else
+    echo "  ✗ ${repo}: failed to delete hook #${hook_id}"
+    sed 's/^/      /' "$err_file" 2>/dev/null || true
+  fi
+  rm -f "$err_file"
+}
+
+# Remove GitHub webhooks and clean up local config. Reads the smee channel
+# from Layer 2 and watchRepos from Layer 1 to determine what to remove.
+run_uninstall() {
+  local target_repos=()
+
+  if [[ ${#UNINSTALL_REPOS[@]} -gt 0 ]]; then
+    target_repos=("${UNINSTALL_REPOS[@]}")
+  else
+    mapfile -t target_repos < <(jq -r '.catalyst.monitor.github.watchRepos[]?' \
+      "$PROJECT_CONFIG_PATH" 2>/dev/null || true)
+  fi
+
+  local channel
+  channel=$(jq -r '.catalyst.monitor.github.smeeChannel // ""' "$HOME_CONFIG_PATH" 2>/dev/null || true)
+
+  if [[ -z "$channel" ]]; then
+    echo "No smee channel configured in $HOME_CONFIG_PATH — nothing to uninstall."
+    exit 0
+  fi
+
+  echo "Uninstall plan:"
+  echo "  Channel: $channel"
+  if [[ ${#target_repos[@]} -gt 0 ]]; then
+    echo "  Repos (${#target_repos[@]}):"
+    printf '    • %s\n' "${target_repos[@]}"
+  else
+    echo "  Repos: none in watchRepos"
+  fi
+  [[ $DRY_RUN -eq 1 ]] && echo "  Mode: dry-run (no changes will be made)"
+  echo
+
+  if [[ $DRY_RUN -eq 0 && $UNINSTALL_YES -eq 0 ]]; then
+    read -r -p "Remove GitHub webhooks and local config? [y/N] " yn
+    case "$yn" in [Yy]*) ;; *) echo "Aborted."; exit 0 ;; esac
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "⚠ Skipping GitHub webhook deletion — \`gh\` is not installed."
+  elif [[ ${#target_repos[@]} -gt 0 ]]; then
+    echo "Removing GitHub webhooks…"
+    for repo in "${target_repos[@]}"; do
+      delete_github_hook "$repo" "$channel"
+    done
+  else
+    echo "No repos in watchRepos — skipping GitHub webhook deletion."
+  fi
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo
+    echo "Dry-run complete. No changes made."
+    exit 0
+  fi
+
+  if [[ -f "$HOME_CONFIG_PATH" ]]; then
+    local tmp; tmp=$(mktemp)
+    jq '
+      del(.catalyst.monitor.github.smeeChannel)
+      | if (.catalyst.monitor.github // {}) == {} then del(.catalyst.monitor.github) else . end
+      | if (.catalyst.monitor // {}) == {} then del(.catalyst.monitor) else . end
+      | if (.catalyst // {}) == {} then del(.catalyst) else . end
+    ' "$HOME_CONFIG_PATH" > "$tmp"
+    mv "$tmp" "$HOME_CONFIG_PATH"
+    echo "Removed catalyst.monitor.github.smeeChannel from $HOME_CONFIG_PATH"
+  fi
+
+  if [[ -f "$PROJECT_CONFIG_PATH" ]]; then
+    local tmp; tmp=$(mktemp)
+    jq '
+      del(.catalyst.monitor.github.webhookSecretEnv)
+      | if (.catalyst.monitor.github // {}) == {} then del(.catalyst.monitor.github) else . end
+      | if (.catalyst.monitor // {}) == {} then del(.catalyst.monitor) else . end
+      | if (.catalyst // {}) == {} then del(.catalyst) else . end
+    ' "$PROJECT_CONFIG_PATH" > "$tmp"
+    mv "$tmp" "$PROJECT_CONFIG_PATH"
+    echo "Removed catalyst.monitor.github.webhookSecretEnv from $PROJECT_CONFIG_PATH"
+  fi
+
+  if [[ -f "$SECRET_PATH" ]]; then
+    rm -f "$SECRET_PATH"
+    echo "Removed secret file $SECRET_PATH"
+  fi
+
+  echo
+  echo "Uninstall complete."
+  echo "If any webhooks remain on GitHub, remove them at:"
+  echo "  https://github.com/<org>/<repo>/settings/hooks"
+}
+
+if [[ $UNINSTALL -eq 1 ]]; then
+  require_cmd jq
+  run_uninstall
+  exit 0
+fi
 
 if [[ $SKIP_GITHUB_SETUP -eq 1 ]]; then
   if [[ ${#ADD_REPOS[@]} -gt 0 ]]; then

--- a/website/src/content/docs/observability/webhooks.md
+++ b/website/src/content/docs/observability/webhooks.md
@@ -305,6 +305,171 @@ plugins/dev/scripts/catalyst-monitor.sh start             # idempotent — no-op
 The `status --json` exit code is `0` when running and `1` when stopped, so scripts can
 gate cheaply via `if catalyst-monitor.sh status --json &>/dev/null; then ...`.
 
+## Persistent setup (auto-start on login)
+
+The daemon starts on demand via `catalyst-monitor.sh start`, but it does not survive a
+reboot or login without explicit configuration. This section covers how to keep it alive
+automatically using the platform's service manager.
+
+### The secret problem
+
+You normally export the HMAC secret in your shell rc file:
+
+```bash
+export CATALYST_WEBHOOK_SECRET="$(cat ~/.config/catalyst/webhook-secret)"
+```
+
+This works for interactive shells, but **launchd and systemd do not source your shell rc**.
+They launch processes with a minimal, static environment — so the secret must reach the
+daemon another way.
+
+### macOS — launchd
+
+A wrapper script reads the secret from the file at startup, then execs the monitor.
+Template files live in `plugins/dev/scripts/orch-monitor/dist/`.
+
+**1. Copy the wrapper and plist templates:**
+
+```bash
+# Create a local copy of the wrapper (edit paths as needed)
+cp plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh \
+  ~/.local/bin/catalyst-monitor-launchd.sh
+chmod +x ~/.local/bin/catalyst-monitor-launchd.sh
+
+# Copy the plist template
+cp plugins/dev/scripts/orch-monitor/dist/ai.coalesce.catalyst-monitor.plist \
+  ~/Library/LaunchAgents/ai.coalesce.catalyst-monitor.plist
+```
+
+**2. Edit the plist** — replace the two placeholder values:
+
+```bash
+# macOS sed in-place (no backup)
+WRAPPER="$HOME/.local/bin/catalyst-monitor-launchd.sh"
+sed -i '' \
+  "s|REPLACE_WITH_WRAPPER_PATH/catalyst-monitor-launchd.sh|${WRAPPER}|" \
+  ~/Library/LaunchAgents/ai.coalesce.catalyst-monitor.plist
+
+sed -i '' \
+  "s|REPLACE_WITH_HOME|${HOME}|g" \
+  ~/Library/LaunchAgents/ai.coalesce.catalyst-monitor.plist
+```
+
+**3. Edit the wrapper** — verify `SCRIPT_DIR` resolves to the directory containing
+`catalyst-monitor.sh` (defaults to the wrapper's own directory, so keep both files
+adjacent or adjust the path):
+
+```bash
+# The wrapper executes: ${SCRIPT_DIR}/../catalyst-monitor.sh start
+# If you moved it to ~/.local/bin, point SCRIPT_DIR at the actual scripts dir:
+MONITOR="$HOME/.claude/plugins/cache/catalyst/catalyst-dev/$(cat $HOME/.claude/plugins/cache/catalyst/catalyst-dev/version.txt 2>/dev/null || echo 'latest')/scripts"
+sed -i '' "s|SCRIPT_DIR=.*|SCRIPT_DIR=\"${MONITOR}\"|" \
+  ~/.local/bin/catalyst-monitor-launchd.sh
+```
+
+Or just hardcode the absolute path to `catalyst-monitor.sh` in the wrapper. The wrapper
+is simple enough to edit by hand.
+
+**4. Load the LaunchAgent:**
+
+```bash
+launchctl bootstrap gui/$(id -u) \
+  ~/Library/LaunchAgents/ai.coalesce.catalyst-monitor.plist
+```
+
+**5. Verify:**
+
+```bash
+launchctl list | grep catalyst-monitor   # should show the label
+tail -f ~/catalyst/monitor.log           # watch for "Server started on port 7400"
+plugins/dev/scripts/catalyst-monitor.sh status
+```
+
+**To stop and unload:**
+
+```bash
+launchctl bootout gui/$(id -u) \
+  ~/Library/LaunchAgents/ai.coalesce.catalyst-monitor.plist
+```
+
+**When you rotate the HMAC secret** (via `setup-webhooks.sh --force`), the wrapper
+automatically picks up the new value on next restart — no plist edit needed, since it
+reads the file at launch time, not at plist-install time.
+
+### Linux — systemd user unit
+
+**1. Create the env file** with the secret value:
+
+```bash
+mkdir -p ~/.config/catalyst
+# Write the secret value (not the export expression — systemd reads values literally)
+cat > ~/.config/catalyst/webhook.env <<EOF
+CATALYST_WEBHOOK_SECRET=$(cat ~/.config/catalyst/webhook-secret)
+CATALYST_DIR=$HOME/catalyst
+EOF
+chmod 600 ~/.config/catalyst/webhook.env
+```
+
+**2. Copy and edit the service unit:**
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp plugins/dev/scripts/orch-monitor/dist/catalyst-monitor.service \
+  ~/.config/systemd/user/catalyst-monitor.service
+
+# Replace the placeholder with the absolute path to catalyst-monitor.sh
+MONITOR=$(realpath plugins/dev/scripts/catalyst-monitor.sh)
+sed -i "s|REPLACE_WITH_MONITOR_PATH|${MONITOR}|" \
+  ~/.config/systemd/user/catalyst-monitor.service
+```
+
+**3. Enable and start:**
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now catalyst-monitor.service
+```
+
+**4. Verify:**
+
+```bash
+systemctl --user status catalyst-monitor.service
+journalctl --user -u catalyst-monitor.service -f
+```
+
+**When you rotate the HMAC secret**, update `~/.config/catalyst/webhook.env` and
+restart the service:
+
+```bash
+echo "CATALYST_WEBHOOK_SECRET=$(cat ~/.config/catalyst/webhook-secret)" \
+  >> ~/.config/catalyst/webhook.env  # or edit manually
+systemctl --user restart catalyst-monitor.service
+```
+
+## Uninstalling webhooks
+
+To remove all GitHub webhooks pointing at your smee channel and clean up local config:
+
+```bash
+# Interactive — prompts for confirmation
+plugins/dev/scripts/setup-webhooks.sh --uninstall
+
+# Non-interactive
+plugins/dev/scripts/setup-webhooks.sh --uninstall --yes
+
+# Preview without deleting
+plugins/dev/scripts/setup-webhooks.sh --uninstall --dry-run --yes
+
+# Remove from one repo only
+plugins/dev/scripts/setup-webhooks.sh --uninstall --repo owner/repo --yes
+```
+
+The script reads the smee channel URL from `~/.config/catalyst/config.json` and the repo
+list from `.catalyst/config.json`, then for each repo: queries the GitHub Hooks API for a
+matching webhook and deletes it. After hook removal it also removes the `smeeChannel` key
+from the home config, the `webhookSecretEnv` key from the project config, and the secret
+file at `~/.config/catalyst/webhook-secret`.
+
 ## Failure modes and recovery
 
 - **smee tunnel drops**: the daemon retries automatically. Up to 60 minutes of missed


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-08T07:09:29Z -->
<!-- Last updated: 2026-05-08T07:09:29Z -->
<!-- PR: #513 -->
<!-- Previous commits: 30c16fef938b92fb1f780649bdc510a56a5649bc -->

## Summary

Closes two operational gaps surfaced during CTL-209 dogfooding:

1. **Webhook cleanup path** — `setup-webhooks.sh --uninstall` removes GitHub webhooks from every subscribed repo and cleans up local config/secret state. Without this, changing smee channels or decommissioning a project left orphan webhooks permanently registered on GitHub.

2. **Auto-startup documentation** — `webhooks.md` now explains how to keep `orch-monitor` alive across reboots using launchd (macOS) or systemd (Linux), including how to handle the HMAC secret (which doesn't propagate from shell rc to service managers). Ships template files users can copy and edit.

## Changes Made

### `plugins/dev/scripts/setup-webhooks.sh` (+172 lines)

**New flags**: `--uninstall`, `--dry-run`, `--repo <owner/repo>`, `--yes`

**New functions**:

- `delete_github_hook(repo, channel)` — lists hooks on the repo via `gh api`, finds the one whose `config.url` matches the smee channel, issues `gh api -X DELETE`. Dry-run aware; idempotent when no hook found.
- `run_uninstall()` — orchestrates the teardown:
  1. Reads smee channel from `~/.config/catalyst/config.json` (Layer 2) — exits cleanly if not configured
  2. Builds target repo list from `watchRepos` in `.catalyst/config.json` (Layer 1), or from `--repo` flags
  3. Interactive confirmation unless `--yes`; skips all writes/deletes in `--dry-run` mode
  4. Calls `delete_github_hook()` for each repo
  5. Removes `catalyst.monitor.github.smeeChannel` from home config (via `jq del()`)
  6. Removes `catalyst.monitor.github.webhookSecretEnv` from project config
  7. Removes `~/.config/catalyst/webhook-secret`

**Validation**: `--uninstall` + `--register-github-hooks` are mutually exclusive. `--repo` values validated against the same `REPO_SHAPE` regex as `--add-repo`.

**Entry point**: `if [[ $UNINSTALL -eq 1 ]]; then run_uninstall; exit 0; fi` — runs before the normal setup path, requires only `jq` and `gh`.

### `plugins/dev/scripts/__tests__/setup-webhooks.test.sh` (+259 lines, -5)

Extended the `gh` stub in `make_test_env()` to handle `DELETE` calls:
- `GH_STUB_DIR/delete-response.json` — scripted DELETE response body
- `GH_STUB_DIR/delete-exit` — scripted DELETE exit code
- DELETE calls logged to `calls.log` alongside GET/POST

New helpers: `run_setup_uninstall()`, `seed_smee_channel()`, `seed_secret_env()`

**8 new test cases** (Tests 26–33):

| # | Test | What it verifies |
|---|------|-----------------|
| 26 | No smee channel | Exits 0 with "nothing to uninstall" — no gh calls |
| 27 | `--dry-run` | Prints dry-run message, no DELETE in calls.log, config unchanged |
| 28 | Full deletion | DELETE issued for hook, smeeChannel removed, webhookSecretEnv removed, secret file removed |
| 29 | Idempotent (hook missing) | GET returns `[]`, no DELETE, exit 0, "no webhook found" |
| 30 | `--repo` scope filter | Two repos in watchRepos; only targeted repo gets DELETE |
| 31 | Secret file removal | Secret file absent after uninstall |
| 32 | `--dry-run` config preservation | Config keys and secret file intact after dry-run |
| 33 | Mutex | `--uninstall --register-github-hooks` → non-zero exit, "mutually exclusive" |

### `website/src/content/docs/observability/webhooks.md` (+165 lines)

**New section: "Persistent setup (auto-start on login)"**

Opens by explaining the core problem: `CATALYST_WEBHOOK_SECRET` exported in shell rc does not propagate to launchd/systemd agents, so a naive approach leaves the daemon unable to read the secret at startup.

**macOS (launchd)** — step-by-step:
1. Copy wrapper script and plist template from `orch-monitor/dist/`
2. Edit two `REPLACE_WITH_*` placeholders in the plist (wrapper path + home dir path)
3. Note about wrapper's `SCRIPT_DIR` for relocated installs
4. `launchctl bootstrap gui/$(id -u) ...`
5. Verify with `launchctl list` and `tail -f ~/catalyst/monitor.log`
6. Secret rotation: wrapper reads file at startup, no plist edit needed

**Linux (systemd)** — step-by-step:
1. Create `~/.config/catalyst/webhook.env` with the literal secret value (not the shell `$(cat ...)` expression)
2. Copy and edit `catalyst-monitor.service` (one `REPLACE_WITH_MONITOR_PATH` placeholder)
3. `systemctl --user daemon-reload && systemctl --user enable --now`
4. Secret rotation: update `.env` and `systemctl --user restart`

**New section: "Uninstalling webhooks"**

Shows the four invocation patterns: plain (interactive), `--yes`, `--dry-run --yes`, `--repo owner/repo --yes`. Brief prose describing what the script reads and removes.

### `plugins/dev/scripts/orch-monitor/dist/` (3 new files)

| File | Purpose |
|------|---------|
| `catalyst-monitor-launchd.sh` (executable) | Reads `webhook-secret` from disk, exports `CATALYST_WEBHOOK_SECRET`, execs `catalyst-monitor.sh start`. Keeps the secret out of the plist. |
| `ai.coalesce.catalyst-monitor.plist` | macOS LaunchAgent template. Two placeholders: `REPLACE_WITH_WRAPPER_PATH` and `REPLACE_WITH_HOME`. `RunAtLoad: true`, `KeepAlive: true`. |
| `catalyst-monitor.service` | Linux systemd user unit. `EnvironmentFile=%h/.config/catalyst/webhook.env`, `Restart=on-failure`, `RestartSec=5`. One placeholder: `REPLACE_WITH_MONITOR_PATH`. |

## How to Verify

- [x] `bash -n plugins/dev/scripts/setup-webhooks.sh` — syntax clean ✅
- [x] `bash plugins/dev/scripts/__tests__/setup-webhooks.test.sh` — 32 pass, 1 pre-existing failure (Test 13: `--linear-register requires --webhook-url` tests for behavior superseded by CTL-242's auto-provisioning; unrelated to this PR) ✅
- [x] `setup-webhooks.sh --help` shows `--uninstall`, `--dry-run`, `--repo`, `--yes` ✅
- [x] Template files have correct permissions (`catalyst-monitor-launchd.sh` is executable) ✅
- [ ] Manual: `setup-webhooks.sh --uninstall --dry-run --yes` on a machine with smeeChannel configured — verify output lists repos and shows dry-run message, no actual changes
- [ ] Manual: launchd flow on macOS — copy, edit, `launchctl bootstrap`, verify `monitor.log`
- [ ] Manual: systemd flow on Linux — create webhook.env, copy service, `systemctl --user enable --now`

## Reviewer Notes

**On the pre-existing test failure**: Test 13 (`--linear-register requires --webhook-url`) was already failing before this PR — it expects an error when `--linear-register` is passed without `--webhook-url`, but CTL-242 changed that to auto-provision a smee channel instead. Fixing it is out of scope here.

**On `--uninstall` not clearing `watchRepos`**: The uninstall removes the smee channel, secret, and webhook registrations — but intentionally leaves `watchRepos` in `.catalyst/config.json`. The repo list is team config (committed, shared); the smee subscription is per-developer state. Clearing watchRepos would require a separate `--remove-repo` flag (a different operation).

**On template file placeholders vs scripts**: I considered auto-generating these with a `setup-webhooks.sh --install-launchd` sub-command, but the manual-copy approach is safer for a first cut — fewer failure modes, easier to audit, and the docs walk through each step.

## Related

- CTL-209 (parent — webhook receiver infrastructure)
- CTL-217 (Layer 2 config placement — uninstall reads the same locations)
- CTL-219 (this ticket)

Refs: CTL-219
