### PR TITLE
feat(dev): evolve filter daemon into broker — structured agent identity, auto-correlation, ticket_lifecycle routing (CTL-303)

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -1,0 +1,287 @@
+// broker-state.mjs — Structured agent identity + ticket routing store (CTL-303).
+//
+// Extends filter-state.db with two new tables:
+//
+//   agents       — one row per active/recent agent; indexed by session_id.
+//                  Enables auto-correlation: when an agent checks in with a
+//                  ticket, the broker auto-derives pr_lifecycle interests when
+//                  PR ↔ ticket links appear in subsequent events.
+//
+//   ticket_state — lightweight routing index for ticket_lifecycle interests.
+//                  Keyed on ticket identifier (e.g. "CTL-275"). Updated by
+//                  Linear webhook events so deterministic routing doesn't need
+//                  a Groq round-trip.
+//
+// The filter_state table (from CTL-284) lives in the same DB file under the
+// same openBrokerStateDb / closeBrokerStateDb umbrella so callers only open
+// one SQLite handle.
+
+import { Database } from "bun:sqlite";
+import { homedir } from "node:os";
+import { resolve, dirname } from "node:path";
+import { mkdirSync } from "node:fs";
+
+let db = null;
+
+const CATALYST_DIR = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+const DEFAULT_DB_PATH = resolve(CATALYST_DIR, "filter-state.db");
+
+export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
+  if (db) return db;
+  mkdirSync(dirname(dbPath), { recursive: true });
+  db = new Database(dbPath, { create: true });
+  db.run("PRAGMA journal_mode=WAL");
+
+  // Legacy filter_state table (CTL-284) — still needed for PR↔deploy correlation.
+  db.run(`
+    CREATE TABLE IF NOT EXISTS filter_state (
+      interest_id      TEXT PRIMARY KEY,
+      pr_number        INTEGER NOT NULL,
+      repo             TEXT NOT NULL,
+      merge_commit_sha TEXT,
+      deployment_id    INTEGER,
+      environment      TEXT,
+      status           TEXT NOT NULL DEFAULT 'open',
+      updated_at       TEXT NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_filter_state_sha
+      ON filter_state(merge_commit_sha)
+      WHERE merge_commit_sha IS NOT NULL
+  `);
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_filter_state_deployment
+      ON filter_state(deployment_id)
+      WHERE deployment_id IS NOT NULL
+  `);
+
+  // CTL-303: structured agent identity table.
+  db.run(`
+    CREATE TABLE IF NOT EXISTS agents (
+      agent_id      TEXT PRIMARY KEY,
+      agent_name    TEXT NOT NULL,
+      session_id    TEXT NOT NULL,
+      orchestrator  TEXT,
+      ticket        TEXT,
+      claimed_pr    INTEGER,
+      cwd           TEXT,
+      status        TEXT NOT NULL DEFAULT 'active',
+      checked_in_at TEXT NOT NULL,
+      updated_at    TEXT NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_agents_ticket
+      ON agents(ticket)
+      WHERE ticket IS NOT NULL
+  `);
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_agents_orchestrator
+      ON agents(orchestrator)
+      WHERE orchestrator IS NOT NULL
+  `);
+
+  // CTL-303: ticket routing state for ticket_lifecycle interests.
+  db.run(`
+    CREATE TABLE IF NOT EXISTS ticket_state (
+      ticket       TEXT PRIMARY KEY,
+      linear_state TEXT,
+      pr_number    INTEGER,
+      updated_at   TEXT NOT NULL
+    )
+  `);
+
+  return db;
+}
+
+export function closeBrokerStateDb() {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+function ensure() {
+  if (!db) throw new Error("broker-state DB not opened — call openBrokerStateDb() first");
+  return db;
+}
+
+const nowIso = () => new Date().toISOString();
+
+// ─── filter_state helpers (verbatim from CTL-284 filter-state.mjs) ──────────
+
+export function upsertFilterStateOpen({ interestId, prNumber, repo }) {
+  ensure().run(
+    `INSERT INTO filter_state (interest_id, pr_number, repo, status, updated_at)
+     VALUES (?, ?, ?, 'open', ?)
+     ON CONFLICT(interest_id) DO UPDATE SET
+       pr_number = excluded.pr_number,
+       repo = excluded.repo,
+       status = 'open',
+       merge_commit_sha = NULL,
+       deployment_id = NULL,
+       environment = NULL,
+       updated_at = excluded.updated_at`,
+    [interestId, prNumber, repo, nowIso()],
+  );
+}
+
+export function setFilterStateMerged(interestId, mergeCommitSha) {
+  const result = ensure().run(
+    `UPDATE filter_state
+       SET merge_commit_sha = ?, status = 'merged', updated_at = ?
+       WHERE interest_id = ?`,
+    [mergeCommitSha, nowIso(), interestId],
+  );
+  return result.changes > 0 ? { interestId } : null;
+}
+
+export function setFilterStateDeploying(mergeCommitSha, deploymentId, environment) {
+  const row = ensure()
+    .prepare(`SELECT interest_id FROM filter_state WHERE merge_commit_sha = ? LIMIT 1`)
+    .get(mergeCommitSha);
+  if (!row) return null;
+  ensure().run(
+    `UPDATE filter_state
+       SET deployment_id = ?, environment = ?, status = 'deploying', updated_at = ?
+       WHERE interest_id = ?`,
+    [deploymentId, environment, nowIso(), row.interest_id],
+  );
+  return { interestId: row.interest_id };
+}
+
+export function setFilterStateDeployed(deploymentId) {
+  const row = ensure()
+    .prepare(`SELECT interest_id FROM filter_state WHERE deployment_id = ? LIMIT 1`)
+    .get(deploymentId);
+  if (!row) return null;
+  ensure().run(
+    `UPDATE filter_state SET status = 'deployed', updated_at = ? WHERE interest_id = ?`,
+    [nowIso(), row.interest_id],
+  );
+  return { interestId: row.interest_id };
+}
+
+export function setFilterStateFailed(deploymentId) {
+  const row = ensure()
+    .prepare(`SELECT interest_id FROM filter_state WHERE deployment_id = ? LIMIT 1`)
+    .get(deploymentId);
+  if (!row) return null;
+  ensure().run(
+    `UPDATE filter_state SET status = 'failed', updated_at = ? WHERE interest_id = ?`,
+    [nowIso(), row.interest_id],
+  );
+  return { interestId: row.interest_id };
+}
+
+export function deleteFilterState(interestId) {
+  ensure().run(`DELETE FROM filter_state WHERE interest_id = ?`, [interestId]);
+}
+
+export function getFilterStateByInterest(interestId) {
+  const row = ensure()
+    .prepare(`SELECT * FROM filter_state WHERE interest_id = ?`)
+    .get(interestId);
+  if (!row) return null;
+  return {
+    interestId: row.interest_id,
+    prNumber: row.pr_number,
+    repo: row.repo,
+    mergeCommitSha: row.merge_commit_sha,
+    deploymentId: row.deployment_id,
+    environment: row.environment,
+    status: row.status,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ─── agents helpers ──────────────────────────────────────────────────────────
+
+export function upsertAgent({ agentId, agentName, sessionId, orchestrator, ticket, claimedPr, cwd }) {
+  const ts = nowIso();
+  ensure().run(
+    `INSERT INTO agents
+       (agent_id, agent_name, session_id, orchestrator, ticket, claimed_pr, cwd, status, checked_in_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+     ON CONFLICT(agent_id) DO UPDATE SET
+       agent_name    = excluded.agent_name,
+       orchestrator  = excluded.orchestrator,
+       ticket        = excluded.ticket,
+       claimed_pr    = excluded.claimed_pr,
+       cwd           = excluded.cwd,
+       status        = 'active',
+       updated_at    = excluded.updated_at`,
+    [agentId, agentName, sessionId, orchestrator ?? null, ticket ?? null, claimedPr ?? null, cwd ?? null, ts, ts],
+  );
+}
+
+export function markAgentDone(agentId, status = "done") {
+  ensure().run(
+    `UPDATE agents SET status = ?, updated_at = ? WHERE agent_id = ?`,
+    [status, nowIso(), agentId],
+  );
+}
+
+export function getAgentBySession(sessionId) {
+  const row = ensure()
+    .prepare(`SELECT * FROM agents WHERE session_id = ? AND status = 'active' ORDER BY checked_in_at DESC LIMIT 1`)
+    .get(sessionId);
+  return row ? rowToAgent(row) : null;
+}
+
+export function getAgentsByTicket(ticket) {
+  return ensure()
+    .prepare(`SELECT * FROM agents WHERE ticket = ? AND status = 'active' ORDER BY checked_in_at DESC`)
+    .all(ticket)
+    .map(rowToAgent);
+}
+
+export function getAgentsByOrchestrator(orchestrator) {
+  return ensure()
+    .prepare(`SELECT * FROM agents WHERE orchestrator = ? AND status = 'active' ORDER BY checked_in_at DESC`)
+    .all(orchestrator)
+    .map(rowToAgent);
+}
+
+function rowToAgent(row) {
+  return {
+    agentId: row.agent_id,
+    agentName: row.agent_name,
+    sessionId: row.session_id,
+    orchestrator: row.orchestrator,
+    ticket: row.ticket,
+    claimedPr: row.claimed_pr,
+    cwd: row.cwd,
+    status: row.status,
+    checkedInAt: row.checked_in_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ─── ticket_state helpers ─────────────────────────────────────────────────────
+
+export function upsertTicketState({ ticket, linearState, prNumber }) {
+  ensure().run(
+    `INSERT INTO ticket_state (ticket, linear_state, pr_number, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(ticket) DO UPDATE SET
+       linear_state = COALESCE(excluded.linear_state, linear_state),
+       pr_number    = COALESCE(excluded.pr_number, pr_number),
+       updated_at   = excluded.updated_at`,
+    [ticket, linearState ?? null, prNumber ?? null, nowIso()],
+  );
+}
+
+export function getTicketState(ticket) {
+  const row = ensure()
+    .prepare(`SELECT * FROM ticket_state WHERE ticket = ?`)
+    .get(ticket);
+  if (!row) return null;
+  return {
+    ticket: row.ticket,
+    linearState: row.linear_state,
+    prNumber: row.pr_number,
+    updatedAt: row.updated_at,
+  };
+}

--- a/plugins/dev/scripts/broker/broker-state.test.mjs
+++ b/plugins/dev/scripts/broker/broker-state.test.mjs
@@ -1,0 +1,203 @@
+// Unit tests for broker-state.mjs (CTL-303).
+// Covers agents table and ticket_state table; filter_state helpers are
+// inherited from CTL-284 and tested in filter-state.test.mjs.
+// Run: bun test plugins/dev/scripts/broker/broker-state.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  // agents
+  upsertAgent,
+  markAgentDone,
+  getAgentBySession,
+  getAgentsByTicket,
+  getAgentsByOrchestrator,
+  // ticket_state
+  upsertTicketState,
+  getTicketState,
+  // filter_state (backward compat)
+  upsertFilterStateOpen,
+  setFilterStateMerged,
+  getFilterStateByInterest,
+} from "./broker-state.mjs";
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "broker-state-test-"));
+  openBrokerStateDb(join(tmpDir, "test.db"));
+});
+
+afterEach(() => {
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── agents table ────────────────────────────────────────────────────────────
+
+describe("upsertAgent", () => {
+  test("inserts a new agent row", () => {
+    upsertAgent({
+      agentId: "sess-1",
+      agentName: "ctl-275-worker",
+      sessionId: "sess-1",
+      orchestrator: "orch-2026",
+      ticket: "CTL-275",
+      claimedPr: 501,
+      cwd: "/path/to/wt",
+    });
+    const agent = getAgentBySession("sess-1");
+    expect(agent).not.toBeNull();
+    expect(agent.agentName).toBe("ctl-275-worker");
+    expect(agent.ticket).toBe("CTL-275");
+    expect(agent.claimedPr).toBe(501);
+    expect(agent.orchestrator).toBe("orch-2026");
+    expect(agent.cwd).toBe("/path/to/wt");
+    expect(agent.status).toBe("active");
+  });
+
+  test("upsert is idempotent — updates on conflict", () => {
+    upsertAgent({ agentId: "sess-2", agentName: "w1", sessionId: "sess-2", ticket: "CTL-275", claimedPr: null });
+    upsertAgent({ agentId: "sess-2", agentName: "w1-updated", sessionId: "sess-2", ticket: "CTL-275", claimedPr: 501 });
+    const agent = getAgentBySession("sess-2");
+    expect(agent.agentName).toBe("w1-updated");
+    expect(agent.claimedPr).toBe(501);
+  });
+
+  test("accepts null for optional fields", () => {
+    upsertAgent({ agentId: "sess-3", agentName: "w", sessionId: "sess-3" });
+    const agent = getAgentBySession("sess-3");
+    expect(agent.ticket).toBeNull();
+    expect(agent.claimedPr).toBeNull();
+    expect(agent.orchestrator).toBeNull();
+    expect(agent.cwd).toBeNull();
+  });
+});
+
+describe("markAgentDone", () => {
+  test("marks agent as done — getAgentBySession returns null", () => {
+    upsertAgent({ agentId: "sess-4", agentName: "w", sessionId: "sess-4" });
+    markAgentDone("sess-4", "done");
+    expect(getAgentBySession("sess-4")).toBeNull();
+  });
+
+  test("supports failed status", () => {
+    upsertAgent({ agentId: "sess-5", agentName: "w", sessionId: "sess-5" });
+    markAgentDone("sess-5", "failed");
+    expect(getAgentBySession("sess-5")).toBeNull();
+  });
+
+  test("is a no-op for unknown agent", () => {
+    expect(() => markAgentDone("no-such-agent")).not.toThrow();
+  });
+});
+
+describe("getAgentsByTicket", () => {
+  test("returns active agents for ticket", () => {
+    upsertAgent({ agentId: "ta", agentName: "a", sessionId: "ta", ticket: "CTL-400" });
+    upsertAgent({ agentId: "tb", agentName: "b", sessionId: "tb", ticket: "CTL-400" });
+    upsertAgent({ agentId: "tc", agentName: "c", sessionId: "tc", ticket: "CTL-999" });
+    const agents = getAgentsByTicket("CTL-400");
+    expect(agents).toHaveLength(2);
+    expect(agents.map((a) => a.agentId).sort()).toEqual(["ta", "tb"].sort());
+  });
+
+  test("excludes done agents", () => {
+    upsertAgent({ agentId: "done-a", agentName: "a", sessionId: "done-a", ticket: "CTL-400" });
+    markAgentDone("done-a", "done");
+    expect(getAgentsByTicket("CTL-400")).toHaveLength(0);
+  });
+
+  test("returns empty array for unknown ticket", () => {
+    expect(getAgentsByTicket("CTL-NOPE")).toHaveLength(0);
+  });
+});
+
+describe("getAgentsByOrchestrator", () => {
+  test("returns active agents for orchestrator", () => {
+    upsertAgent({ agentId: "oa", agentName: "a", sessionId: "oa", orchestrator: "orch-main" });
+    upsertAgent({ agentId: "ob", agentName: "b", sessionId: "ob", orchestrator: "orch-main" });
+    upsertAgent({ agentId: "oc", agentName: "c", sessionId: "oc", orchestrator: "orch-other" });
+    const agents = getAgentsByOrchestrator("orch-main");
+    expect(agents).toHaveLength(2);
+  });
+
+  test("returns empty array for unknown orchestrator", () => {
+    expect(getAgentsByOrchestrator("orch-nope")).toHaveLength(0);
+  });
+});
+
+// ─── ticket_state table ───────────────────────────────────────────────────────
+
+describe("upsertTicketState", () => {
+  test("inserts a new ticket_state row", () => {
+    upsertTicketState({ ticket: "CTL-275", linearState: "In Progress", prNumber: null });
+    const ts = getTicketState("CTL-275");
+    expect(ts).not.toBeNull();
+    expect(ts.ticket).toBe("CTL-275");
+    expect(ts.linearState).toBe("In Progress");
+    expect(ts.prNumber).toBeNull();
+  });
+
+  test("updates linearState on conflict", () => {
+    upsertTicketState({ ticket: "CTL-275", linearState: "In Progress" });
+    upsertTicketState({ ticket: "CTL-275", linearState: "Done" });
+    expect(getTicketState("CTL-275").linearState).toBe("Done");
+  });
+
+  test("updates prNumber on conflict", () => {
+    upsertTicketState({ ticket: "CTL-275", linearState: "In Progress" });
+    upsertTicketState({ ticket: "CTL-275", prNumber: 501 });
+    const ts = getTicketState("CTL-275");
+    expect(ts.prNumber).toBe(501);
+    expect(ts.linearState).toBe("In Progress");
+  });
+
+  test("preserves existing values for null fields (COALESCE behavior)", () => {
+    upsertTicketState({ ticket: "CTL-300", linearState: "Done", prNumber: 502 });
+    upsertTicketState({ ticket: "CTL-300", linearState: null, prNumber: null });
+    const ts = getTicketState("CTL-300");
+    // COALESCE means null new values don't overwrite existing non-null values.
+    expect(ts.linearState).toBe("Done");
+    expect(ts.prNumber).toBe(502);
+  });
+});
+
+describe("getTicketState", () => {
+  test("returns null for unknown ticket", () => {
+    expect(getTicketState("CTL-NOPE")).toBeNull();
+  });
+});
+
+// ─── filter_state backward compat ────────────────────────────────────────────
+
+describe("filter_state (CTL-284 backward compat)", () => {
+  test("upsertFilterStateOpen works in the same DB", () => {
+    upsertFilterStateOpen({ interestId: "sess-bc", prNumber: 501, repo: "org/repo" });
+    const state = getFilterStateByInterest("sess-bc");
+    expect(state).not.toBeNull();
+    expect(state.prNumber).toBe(501);
+    expect(state.status).toBe("open");
+  });
+
+  test("setFilterStateMerged transitions to merged", () => {
+    upsertFilterStateOpen({ interestId: "sess-bc2", prNumber: 502, repo: "org/repo" });
+    setFilterStateMerged("sess-bc2", "sha-abc");
+    const state = getFilterStateByInterest("sess-bc2");
+    expect(state.status).toBe("merged");
+    expect(state.mergeCommitSha).toBe("sha-abc");
+  });
+
+  test("both tables coexist in the same DB file", () => {
+    upsertFilterStateOpen({ interestId: "coexist-1", prNumber: 1, repo: "r" });
+    upsertAgent({ agentId: "coexist-agent", agentName: "a", sessionId: "coexist-agent" });
+    upsertTicketState({ ticket: "CTL-1", linearState: "Done" });
+    expect(getFilterStateByInterest("coexist-1")).not.toBeNull();
+    expect(getAgentBySession("coexist-agent")).not.toBeNull();
+    expect(getTicketState("CTL-1")).not.toBeNull();
+  });
+});

--- a/plugins/dev/scripts/broker/filter-state.mjs
+++ b/plugins/dev/scripts/broker/filter-state.mjs
@@ -1,0 +1,150 @@
+// Persistent SHA → PR-interest correlation store for the filter daemon (CTL-284).
+//
+// Tracks each `pr_lifecycle` interest through its merge → deploy lifecycle so
+// `github.deployment.created` (carries SHA) and `github.deployment_status.*`
+// (carries deploymentId) can be correlated back to the originating PR after
+// daemon restarts. Mirrors the singleton pattern from
+// `orch-monitor/lib/annotations.ts`.
+
+import { Database } from "bun:sqlite";
+import { homedir } from "node:os";
+import { resolve, dirname } from "node:path";
+import { mkdirSync } from "node:fs";
+
+let db = null;
+
+const CATALYST_DIR = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+const DEFAULT_DB_PATH = resolve(CATALYST_DIR, "filter-state.db");
+
+export function openFilterStateDb(dbPath = DEFAULT_DB_PATH) {
+  if (db) return db;
+  mkdirSync(dirname(dbPath), { recursive: true });
+  db = new Database(dbPath, { create: true });
+  db.run("PRAGMA journal_mode=WAL");
+  db.run(`
+    CREATE TABLE IF NOT EXISTS filter_state (
+      interest_id      TEXT PRIMARY KEY,
+      pr_number        INTEGER NOT NULL,
+      repo             TEXT NOT NULL,
+      merge_commit_sha TEXT,
+      deployment_id    INTEGER,
+      environment      TEXT,
+      status           TEXT NOT NULL DEFAULT 'open',
+      updated_at       TEXT NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_filter_state_sha
+      ON filter_state(merge_commit_sha)
+      WHERE merge_commit_sha IS NOT NULL
+  `);
+  db.run(`
+    CREATE INDEX IF NOT EXISTS idx_filter_state_deployment
+      ON filter_state(deployment_id)
+      WHERE deployment_id IS NOT NULL
+  `);
+  return db;
+}
+
+export function closeFilterStateDb() {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+function ensure() {
+  if (!db) throw new Error("filter-state DB not opened — call openFilterStateDb() first");
+  return db;
+}
+
+function rowToObj(row) {
+  if (!row) return null;
+  return {
+    interestId: row.interest_id,
+    prNumber: row.pr_number,
+    repo: row.repo,
+    mergeCommitSha: row.merge_commit_sha,
+    deploymentId: row.deployment_id,
+    environment: row.environment,
+    status: row.status,
+    updatedAt: row.updated_at,
+  };
+}
+
+const nowIso = () => new Date().toISOString();
+
+export function upsertFilterStateOpen({ interestId, prNumber, repo }) {
+  ensure().run(
+    `INSERT INTO filter_state (interest_id, pr_number, repo, status, updated_at)
+     VALUES (?, ?, ?, 'open', ?)
+     ON CONFLICT(interest_id) DO UPDATE SET
+       pr_number = excluded.pr_number,
+       repo = excluded.repo,
+       status = 'open',
+       merge_commit_sha = NULL,
+       deployment_id = NULL,
+       environment = NULL,
+       updated_at = excluded.updated_at`,
+    [interestId, prNumber, repo, nowIso()],
+  );
+}
+
+export function setFilterStateMerged(interestId, mergeCommitSha) {
+  const result = ensure().run(
+    `UPDATE filter_state
+       SET merge_commit_sha = ?, status = 'merged', updated_at = ?
+       WHERE interest_id = ?`,
+    [mergeCommitSha, nowIso(), interestId],
+  );
+  return result.changes > 0 ? { interestId } : null;
+}
+
+export function setFilterStateDeploying(mergeCommitSha, deploymentId, environment) {
+  const row = ensure()
+    .prepare(`SELECT interest_id FROM filter_state WHERE merge_commit_sha = ? LIMIT 1`)
+    .get(mergeCommitSha);
+  if (!row) return null;
+  ensure().run(
+    `UPDATE filter_state
+       SET deployment_id = ?, environment = ?, status = 'deploying', updated_at = ?
+       WHERE interest_id = ?`,
+    [deploymentId, environment, nowIso(), row.interest_id],
+  );
+  return { interestId: row.interest_id };
+}
+
+export function setFilterStateDeployed(deploymentId) {
+  const row = ensure()
+    .prepare(`SELECT interest_id FROM filter_state WHERE deployment_id = ? LIMIT 1`)
+    .get(deploymentId);
+  if (!row) return null;
+  ensure().run(
+    `UPDATE filter_state SET status = 'deployed', updated_at = ? WHERE interest_id = ?`,
+    [nowIso(), row.interest_id],
+  );
+  return { interestId: row.interest_id };
+}
+
+export function setFilterStateFailed(deploymentId) {
+  const row = ensure()
+    .prepare(`SELECT interest_id FROM filter_state WHERE deployment_id = ? LIMIT 1`)
+    .get(deploymentId);
+  if (!row) return null;
+  ensure().run(
+    `UPDATE filter_state SET status = 'failed', updated_at = ? WHERE interest_id = ?`,
+    [nowIso(), row.interest_id],
+  );
+  return { interestId: row.interest_id };
+}
+
+export function deleteFilterState(interestId) {
+  ensure().run(`DELETE FROM filter_state WHERE interest_id = ?`, [interestId]);
+}
+
+export function getFilterStateByInterest(interestId) {
+  const row = ensure()
+    .prepare(`SELECT * FROM filter_state WHERE interest_id = ?`)
+    .get(interestId);
+  return rowToObj(row);
+}

--- a/plugins/dev/scripts/broker/filter-state.test.mjs
+++ b/plugins/dev/scripts/broker/filter-state.test.mjs
@@ -1,0 +1,148 @@
+// Unit tests for filter-daemon SQLite state store (CTL-284).
+// Run: bun test plugins/dev/scripts/filter-daemon/filter-state.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openFilterStateDb,
+  closeFilterStateDb,
+  upsertFilterStateOpen,
+  setFilterStateMerged,
+  setFilterStateDeploying,
+  setFilterStateDeployed,
+  setFilterStateFailed,
+  deleteFilterState,
+  getFilterStateByInterest,
+} from "./filter-state.mjs";
+
+let tmpDir;
+let dbPath;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "filter-state-test-"));
+  dbPath = join(tmpDir, "filter-state.db");
+  openFilterStateDb(dbPath);
+});
+
+afterEach(() => {
+  closeFilterStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("upsertFilterStateOpen", () => {
+  test("creates a new row with status=open and updated_at set", () => {
+    upsertFilterStateOpen({ interestId: "i1", prNumber: 42, repo: "o/r" });
+    const row = getFilterStateByInterest("i1");
+    expect(row).not.toBeNull();
+    expect(row.interestId).toBe("i1");
+    expect(row.prNumber).toBe(42);
+    expect(row.repo).toBe("o/r");
+    expect(row.status).toBe("open");
+    expect(row.mergeCommitSha).toBeNull();
+    expect(row.deploymentId).toBeNull();
+    expect(row.environment).toBeNull();
+    expect(row.updatedAt).toBeTruthy();
+  });
+
+  test("is idempotent — replaces existing row for same interestId", () => {
+    upsertFilterStateOpen({ interestId: "i2", prNumber: 1, repo: "o/r" });
+    upsertFilterStateOpen({ interestId: "i2", prNumber: 99, repo: "o/r" });
+    const row = getFilterStateByInterest("i2");
+    expect(row.prNumber).toBe(99);
+    expect(row.status).toBe("open");
+  });
+});
+
+describe("setFilterStateMerged", () => {
+  test("updates SHA and status; returns interestId", () => {
+    upsertFilterStateOpen({ interestId: "i3", prNumber: 1, repo: "o/r" });
+    const got = setFilterStateMerged("i3", "abc123");
+    expect(got).toEqual({ interestId: "i3" });
+    const row = getFilterStateByInterest("i3");
+    expect(row.mergeCommitSha).toBe("abc123");
+    expect(row.status).toBe("merged");
+  });
+
+  test("returns null when interestId not found", () => {
+    expect(setFilterStateMerged("missing", "abc")).toBeNull();
+  });
+});
+
+describe("setFilterStateDeploying", () => {
+  test("matches by SHA, sets deploymentId/environment/status='deploying'", () => {
+    upsertFilterStateOpen({ interestId: "i4", prNumber: 1, repo: "o/r" });
+    setFilterStateMerged("i4", "shaXYZ");
+    const got = setFilterStateDeploying("shaXYZ", 9001, "production");
+    expect(got).toEqual({ interestId: "i4" });
+    const row = getFilterStateByInterest("i4");
+    expect(row.deploymentId).toBe(9001);
+    expect(row.environment).toBe("production");
+    expect(row.status).toBe("deploying");
+  });
+
+  test("returns null when SHA doesn't match any row", () => {
+    upsertFilterStateOpen({ interestId: "i5", prNumber: 1, repo: "o/r" });
+    setFilterStateMerged("i5", "shaA");
+    expect(setFilterStateDeploying("shaB", 1, "production")).toBeNull();
+  });
+});
+
+describe("setFilterStateDeployed", () => {
+  test("matches by deploymentId, sets status='deployed'", () => {
+    upsertFilterStateOpen({ interestId: "i6", prNumber: 1, repo: "o/r" });
+    setFilterStateMerged("i6", "shaQ");
+    setFilterStateDeploying("shaQ", 4242, "production");
+    const got = setFilterStateDeployed(4242);
+    expect(got).toEqual({ interestId: "i6" });
+    expect(getFilterStateByInterest("i6").status).toBe("deployed");
+  });
+
+  test("returns null when deploymentId not found", () => {
+    expect(setFilterStateDeployed(99999)).toBeNull();
+  });
+});
+
+describe("setFilterStateFailed", () => {
+  test("matches by deploymentId, sets status='failed'", () => {
+    upsertFilterStateOpen({ interestId: "i7", prNumber: 1, repo: "o/r" });
+    setFilterStateMerged("i7", "shaR");
+    setFilterStateDeploying("shaR", 7, "production");
+    const got = setFilterStateFailed(7);
+    expect(got).toEqual({ interestId: "i7" });
+    expect(getFilterStateByInterest("i7").status).toBe("failed");
+  });
+});
+
+describe("deleteFilterState", () => {
+  test("removes the row", () => {
+    upsertFilterStateOpen({ interestId: "i8", prNumber: 1, repo: "o/r" });
+    deleteFilterState("i8");
+    expect(getFilterStateByInterest("i8")).toBeNull();
+  });
+
+  test("is a no-op when interestId is unknown", () => {
+    expect(() => deleteFilterState("never-existed")).not.toThrow();
+  });
+});
+
+describe("persistence across reopen", () => {
+  test("state survives close + reopen", () => {
+    upsertFilterStateOpen({ interestId: "i9", prNumber: 1, repo: "o/r" });
+    setFilterStateMerged("i9", "persistedSha");
+    closeFilterStateDb();
+    openFilterStateDb(dbPath);
+    const row = getFilterStateByInterest("i9");
+    expect(row.mergeCommitSha).toBe("persistedSha");
+    expect(row.status).toBe("merged");
+  });
+});
+
+describe("openFilterStateDb idempotency", () => {
+  test("returns the same instance on repeated calls", () => {
+    const first = openFilterStateDb(dbPath);
+    const second = openFilterStateDb(dbPath);
+    expect(first).toBe(second);
+  });
+});

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -1,0 +1,992 @@
+#!/usr/bin/env node
+// broker/index.mjs — Catalyst event broker (CTL-303).
+//
+// Evolved from filter-daemon (CTL-284): adds structured agent identity
+// (agent.checkin/checkout), auto-correlation of ticket↔PR interests, and
+// deterministic ticket_lifecycle routing for Linear webhook events. Groq-based
+// prose classification remains for everything ambiguous.
+
+import {
+  readFileSync,
+  appendFileSync,
+  writeFileSync,
+  unlinkSync,
+  mkdirSync,
+  watch,
+  openSync,
+  fstatSync,
+  readSync,
+  closeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  // filter_state (CTL-284 — PR↔deploy correlation)
+  upsertFilterStateOpen,
+  setFilterStateMerged,
+  setFilterStateDeploying,
+  setFilterStateDeployed,
+  setFilterStateFailed,
+  deleteFilterState,
+  // agents (CTL-303 — structured identity)
+  upsertAgent,
+  markAgentDone,
+  getAgentsByTicket,
+  // ticket_state (CTL-303 — ticket routing)
+  upsertTicketState,
+} from "./broker-state.mjs";
+
+// --- Config ---
+const CATALYST_DIR = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+
+export function readGroqApiKeyFromConfig(configPath) {
+  const path = configPath ?? resolve(homedir(), ".config/catalyst/config.json");
+  try {
+    const cfg = JSON.parse(readFileSync(path, "utf8"));
+    return cfg?.groq?.apiKey ?? "";
+  } catch {
+    return "";
+  }
+}
+
+const GROQ_API_KEY = process.env.GROQ_API_KEY || readGroqApiKeyFromConfig();
+const GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions";
+const GROQ_MODEL = process.env.FILTER_GROQ_MODEL ?? "llama-3.1-8b-instant";
+const DEBOUNCE_MS = parseInt(process.env.FILTER_DEBOUNCE_MS ?? "100", 10);
+const HARD_CAP_MS = parseInt(process.env.FILTER_HARD_CAP_MS ?? "500", 10);
+const MAX_BATCH_SIZE = parseInt(process.env.FILTER_BATCH_SIZE ?? "20", 10);
+const LOOKBACK_LINES = 1000;
+const WATCHDOG_INTERVAL_MS = parseInt(process.env.FILTER_WATCHDOG_INTERVAL_MS ?? "60000", 10);
+const HEARTBEAT_STALE_MS = parseInt(process.env.FILTER_HEARTBEAT_STALE_MS ?? "180000", 10);
+
+// --- Event log ---
+function getEventLogPath() {
+  const now = new Date();
+  const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  return resolve(CATALYST_DIR, "events", `${ym}.jsonl`);
+}
+
+function appendEvent(event) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), ...event }) + "\n");
+}
+
+// --- Interest table ---
+const interests = new Map();
+
+export function getInterests() {
+  return interests;
+}
+
+export function clearInterests() {
+  interests.clear();
+}
+
+// --- Interest persistence ---
+const INTERESTS_FILE = resolve(CATALYST_DIR, "filter-interests.json");
+
+export function saveInterests() {
+  try {
+    mkdirSync(dirname(INTERESTS_FILE), { recursive: true });
+    writeFileSync(INTERESTS_FILE, JSON.stringify([...interests.entries()], null, 2));
+  } catch (err) {
+    console.error("[broker] Failed to save interests:", err.message);
+  }
+}
+
+export function loadPersistedInterests() {
+  try {
+    const entries = JSON.parse(readFileSync(INTERESTS_FILE, "utf8"));
+    for (const [id, reg] of entries) {
+      interests.set(id, reg);
+    }
+    if (interests.size) {
+      console.log(`[broker] Loaded ${interests.size} persisted interest(s)`);
+    }
+  } catch {
+    // No file yet or parse error — fine
+  }
+}
+
+// --- Heartbeat tracking ---
+// sourceId → { ts: number (Date.now()), notified: boolean }
+const lastHeartbeat = new Map();
+// worker/session id → orchestrator id (inferred from heartbeat event fields)
+const workerToOrchestrator = new Map();
+
+export function getLastHeartbeat() {
+  return lastHeartbeat;
+}
+
+export function clearLastHeartbeat() {
+  lastHeartbeat.clear();
+  workerToOrchestrator.clear();
+}
+
+export function handleRegister(event) {
+  const d = event.detail ?? {};
+  const id = d.interest_id ?? event.orchestrator ?? d.notify_event;
+  if (!id) return;
+  const isPrLifecycle = d.interest_type === "pr_lifecycle";
+  const isTicketLifecycle = d.interest_type === "ticket_lifecycle";
+  interests.set(id, {
+    notify_event: d.notify_event ?? `filter.wake.${id}`,
+    prompt: d.prompt ?? "",
+    context: d.context ?? null,
+    orchestrator: event.orchestrator ?? null,
+    session_id: d.session_id ?? null,
+    persistent: d.persistent === true,
+    interest_type: d.interest_type ?? null,
+    // pr_lifecycle fields (CTL-284)
+    pr_numbers: isPrLifecycle ? (Array.isArray(d.pr_numbers) ? d.pr_numbers : []) : null,
+    repo: isPrLifecycle ? (d.repo ?? null) : null,
+    base_branches: isPrLifecycle ? (Array.isArray(d.base_branches) ? d.base_branches : []) : null,
+    // ticket_lifecycle fields (CTL-303)
+    tickets: isTicketLifecycle ? (Array.isArray(d.tickets) ? d.tickets : []) : null,
+    wake_on: isTicketLifecycle ? (Array.isArray(d.wake_on) ? d.wake_on : null) : null,
+  });
+
+  if (isPrLifecycle) {
+    try {
+      for (const prNumber of (d.pr_numbers ?? [])) {
+        upsertFilterStateOpen({ interestId: id, prNumber, repo: d.repo ?? "" });
+      }
+    } catch {
+      // filter_state DB not opened — okay for tests
+    }
+  }
+
+  if (isPrLifecycle) {
+    const prs = (d.pr_numbers ?? []).join(",");
+    console.log(`[broker] Registered: ${id} [pr_lifecycle pr=${prs}] (persistent: ${d.persistent === true})`);
+  } else if (isTicketLifecycle) {
+    const tix = (d.tickets ?? []).join(",");
+    console.log(`[broker] Registered: ${id} [ticket_lifecycle tickets=${tix}] (persistent: ${d.persistent === true})`);
+  } else {
+    console.log(`[broker] Registered: ${id} — "${d.prompt}" (persistent: ${d.persistent === true})`);
+  }
+  saveInterests();
+}
+
+export function handleDeregister(event) {
+  const id = (event.detail ?? {}).interest_id ?? event.orchestrator;
+  if (!id) return;
+  const reg = interests.get(id);
+  if (interests.delete(id)) {
+    if (reg && reg.interest_type === "pr_lifecycle") {
+      try { deleteFilterState(id); } catch { /* DB not opened */ }
+    }
+    console.log(`[broker] Deregistered: ${id}`);
+    saveInterests();
+  }
+}
+
+export function handleOrchestratorTerminated(event) {
+  const orchId = event.orchestrator;
+  if (!orchId) return;
+  let changed = false;
+  for (const [id, reg] of interests) {
+    if (reg.orchestrator === orchId) {
+      if (reg.interest_type === "pr_lifecycle") {
+        try { deleteFilterState(id); } catch { /* DB not opened */ }
+      }
+      interests.delete(id);
+      console.log(`[broker] Auto-deregistered: ${id} (orchestrator ${orchId} terminated)`);
+      changed = true;
+    }
+  }
+  if (changed) saveInterests();
+}
+
+// --- Agent identity (CTL-303) ------------------------------------------------
+
+// Handle agent.checkin: store identity and auto-derive pr_lifecycle if claimed_pr is set.
+export function handleAgentCheckin(event) {
+  const d = event.detail ?? {};
+  const sessionId = d.session_id;
+  if (!sessionId) return;
+
+  const agentName = d.agent_name ?? sessionId;
+  const ticket = d.ticket ?? null;
+  const claimedPr = d.claimed_pr ?? null;
+  const orchestrator = d.orchestrator ?? event.orchestrator ?? null;
+  const cwd = d.cwd ?? null;
+
+  try {
+    upsertAgent({ agentId: sessionId, agentName, sessionId, orchestrator, ticket, claimedPr, cwd });
+  } catch {
+    // DB not opened — fine for tests
+  }
+
+  // Update heartbeat map so the watchdog tracks this agent.
+  const existing = lastHeartbeat.get(sessionId);
+  lastHeartbeat.set(sessionId, { ts: Date.now(), notified: existing?.notified ?? false });
+  if (orchestrator && sessionId !== orchestrator) {
+    workerToOrchestrator.set(sessionId, orchestrator);
+  }
+
+  // Auto-correlate: if the agent has already claimed a PR, register a
+  // pr_lifecycle interest on its behalf — no explicit filter.register needed.
+  if (claimedPr) {
+    _autoRegisterPrLifecycle(sessionId, claimedPr, orchestrator, ticket);
+  }
+
+  console.log(`[broker] Agent checked in: ${agentName} (session: ${sessionId}, ticket: ${ticket ?? "none"}, pr: ${claimedPr ?? "none"})`);
+}
+
+// Auto-register a pr_lifecycle interest when we learn agent ↔ PR mapping.
+function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket) {
+  if (interests.has(sessionId)) return; // don't overwrite explicit registration
+
+  interests.set(sessionId, {
+    notify_event: `filter.wake.${sessionId}`,
+    prompt: "",
+    context: { pr_numbers: [prNumber], tickets: ticket ? [ticket] : [], workers: [sessionId] },
+    orchestrator: orchestrator ?? null,
+    session_id: sessionId,
+    persistent: true,
+    interest_type: "pr_lifecycle",
+    pr_numbers: [prNumber],
+    repo: null,
+    base_branches: [],
+    tickets: null,
+    wake_on: null,
+  });
+
+  try {
+    upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: "" });
+  } catch { /* DB not opened */ }
+
+  console.log(`[broker] Auto-correlated pr_lifecycle for session ${sessionId} on PR #${prNumber}`);
+  saveInterests();
+}
+
+export function handleAgentCheckout(event) {
+  const d = event.detail ?? {};
+  const sessionId = d.session_id;
+  if (!sessionId) return;
+
+  const finalStatus = d.status ?? "done";
+
+  try { markAgentDone(sessionId, finalStatus); } catch { /* DB not opened */ }
+
+  // Deregister auto-derived pr_lifecycle interest so the watchdog doesn't
+  // fire stale wakes after the agent exits.
+  const reg = interests.get(sessionId);
+  if (reg && reg.interest_type === "pr_lifecycle") {
+    interests.delete(sessionId);
+    try { deleteFilterState(sessionId); } catch { /* DB not opened */ }
+    saveInterests();
+  }
+
+  console.log(`[broker] Agent checked out: ${sessionId} (status: ${finalStatus})`);
+}
+
+export function handleAgentHeartbeat(event) {
+  const sessionId = event.session ?? event.worker ?? event.orchestrator;
+  if (!sessionId) return;
+  const existing = lastHeartbeat.get(sessionId);
+  lastHeartbeat.set(sessionId, { ts: Date.now(), notified: existing?.notified ?? false });
+  const orchId = event.orchestrator;
+  if (orchId && sessionId !== orchId) {
+    workerToOrchestrator.set(sessionId, orchId);
+  }
+}
+
+// --- Deterministic routing: pr_lifecycle (CTL-284) ---------------------------
+
+function botPrefix(author, kind) {
+  const isBot = author?.type === "Bot";
+  if (kind === "review") return isBot ? "Automated review comment from " : "Changes requested by ";
+  if (kind === "comment") return isBot ? "Automated review comment from " : "New review comment from ";
+  return "";
+}
+
+export function tryDeterministicRoute(event, interestsMap) {
+  const matches = [];
+  const name = event.event ?? "";
+  const detail = event.detail ?? {};
+  const scope = event.scope ?? {};
+  const eventId = event.id ?? null;
+
+  let deployMatchedInterest = null;
+  if (name === "github.deployment.created") {
+    try { deployMatchedInterest = setFilterStateDeploying(scope.sha, detail.deploymentId, scope.environment); } catch { /* DB not opened */ }
+  } else if (name === "github.deployment_status.success") {
+    try { deployMatchedInterest = setFilterStateDeployed(detail.deploymentId); } catch { /* DB not opened */ }
+  } else if (name === "github.deployment_status.failure" || name === "github.deployment_status.error") {
+    try { deployMatchedInterest = setFilterStateFailed(detail.deploymentId); } catch { /* DB not opened */ }
+  }
+
+  for (const [interestId, reg] of interestsMap) {
+    if (reg.interest_type !== "pr_lifecycle") continue;
+
+    let reason = null;
+    const prList = reg.pr_numbers ?? [];
+
+    if (name === "github.check_suite.completed") {
+      const eventPrs = Array.isArray(detail.prNumbers) ? detail.prNumbers : [];
+      const matchedPr = eventPrs.find((n) => prList.includes(n));
+      if (matchedPr !== undefined) {
+        if (detail.conclusion === "failure") {
+          reason = `CI failing on PR #${matchedPr} — check_suite conclusion: failure`;
+        } else if (detail.conclusion === "success") {
+          reason = `All CI checks passing on PR #${matchedPr}`;
+        }
+      }
+    } else if (name === "github.pr.merged") {
+      if (prList.includes(scope.pr)) {
+        const sha = detail.mergeCommitSha ?? "unknown";
+        reason = `PR #${scope.pr} merged (merge commit: ${sha}). Now waiting for deployment — do not close out until deployment succeeds.`;
+        if (detail.mergeCommitSha) {
+          try { setFilterStateMerged(interestId, detail.mergeCommitSha); } catch { /* DB not opened */ }
+        }
+      }
+    } else if (name === "github.pr.closed") {
+      if (prList.includes(scope.pr) && detail.merged === false) {
+        reason = `PR #${scope.pr} closed without merging`;
+      }
+    } else if (name === "github.pr_review.submitted") {
+      if (prList.includes(scope.pr)) {
+        const reviewer = detail.reviewer ?? "unknown";
+        const isBot = detail.author?.type === "Bot";
+        if (detail.state === "changes_requested") {
+          if (isBot) {
+            reason = `Automated review comment from ${reviewer} (bot): Changes requested on PR #${scope.pr}. PR is blocked from merging until review comments are resolved.`;
+          } else {
+            reason = `Changes requested by ${reviewer} on PR #${scope.pr}. PR is blocked from merging until review comments are resolved.`;
+          }
+        } else if (detail.state === "approved") {
+          const tag = isBot ? " (bot)" : "";
+          reason = `PR #${scope.pr} approved by ${reviewer}${tag}`;
+        }
+      }
+    } else if (name === "github.pr_review_comment.created") {
+      if (prList.includes(scope.pr)) {
+        const author = detail.author?.login ?? "unknown";
+        const isBot = detail.author?.type === "Bot";
+        const prefix = botPrefix(detail.author, "comment");
+        const tag = isBot ? " (bot)" : "";
+        reason = `${prefix}${author}${tag} (comment ID: ${detail.commentId}): "${detail.body}". Comment must be marked resolved before merging. URL: ${detail.htmlUrl}`;
+      }
+    } else if (name === "github.pr_review_thread.resolved") {
+      if (prList.includes(scope.pr)) {
+        reason = `Review thread ${detail.threadId} resolved on PR #${scope.pr}`;
+      }
+    } else if (name === "github.deployment.created") {
+      if (deployMatchedInterest && deployMatchedInterest.interestId === interestId) {
+        reason = `Deployment started for merge commit ${scope.sha} on environment ${scope.environment}`;
+      }
+    } else if (name === "github.deployment_status.success") {
+      if (deployMatchedInterest && deployMatchedInterest.interestId === interestId) {
+        reason = `Deployment succeeded on ${scope.environment}. Work is complete.`;
+      }
+    } else if (name === "github.deployment_status.failure" || name === "github.deployment_status.error") {
+      if (deployMatchedInterest && deployMatchedInterest.interestId === interestId) {
+        const url = detail.targetUrl ?? "(no target URL)";
+        reason = `Deployment failed on ${scope.environment}. URL: ${url}`;
+      }
+    } else if (name === "github.push") {
+      const ref = scope.ref ?? "";
+      const branch = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+      const matchedBase = (reg.base_branches ?? []).find((b) => b.base === branch);
+      if (matchedBase) {
+        reason = `Base branch ${branch} updated — PR #${matchedBase.pr} is now behind. Rebase may be needed.`;
+      }
+    }
+
+    if (reason) matches.push({ interestId, reason, sourceEventId: eventId });
+  }
+
+  return matches;
+}
+
+// --- Deterministic routing: ticket_lifecycle (CTL-303) -----------------------
+//
+// Handles Linear webhook events and GitHub PR events that carry ticket links.
+// No Groq round-trip for known event shapes.
+//
+// ticket_lifecycle interest schema (registered via filter.register):
+//   tickets:  string[]      — ticket identifiers to watch (e.g. ["CTL-275"])
+//   wake_on:  string[]|null — event kinds to fire on; null = all
+//     Values: pr_opened, pr_merged, status_done, status_in_review,
+//             status_changed, comment_added
+
+const TICKET_LIFECYCLE_ALL_WAKE_ON = [
+  "pr_opened", "pr_merged", "status_done", "status_in_review", "status_changed", "comment_added",
+];
+
+export function tryTicketLifecycleRoute(event, interestsMap) {
+  const matches = [];
+  const name = event.event ?? "";
+  const detail = event.detail ?? {};
+  const scope = event.scope ?? {};
+  const attrs = event.attributes ?? {};
+  const eventId = event.id ?? null;
+
+  // Extract the ticket this event concerns. Linear canonical events carry
+  // `attributes["linear.issue.identifier"]`; legacy/flat events use `detail.ticket`.
+  const eventTicket =
+    attrs["linear.issue.identifier"] ??
+    detail.ticket ??
+    detail.identifier ??
+    null;
+
+  // For GitHub PR events extract ticket refs from PR body / title / branch ref.
+  let prBodyTickets = [];
+  if (name === "github.pr.merged" || name === "github.pr.opened" || name === "github.pr.closed") {
+    const bodyText = [detail.body ?? "", detail.title ?? "", detail.headRef ?? ""].join(" ");
+    const found = bodyText.match(/\b([A-Z]{1,10}-\d+)\b/g) ?? [];
+    prBodyTickets = [...new Set(found)];
+  }
+
+  // Side effect: update ticket_state for known state-change events.
+  if (name === "linear.issue.state_changed" && eventTicket) {
+    const newState = detail.state ?? detail.stateName ?? null;
+    try { upsertTicketState({ ticket: eventTicket, linearState: newState }); } catch { /* DB not opened */ }
+  }
+  if ((name === "github.pr.opened" || name === "github.pr.merged") && prBodyTickets.length > 0) {
+    const prNum = typeof scope.pr === "number" ? scope.pr : null;
+    for (const t of prBodyTickets) {
+      try { upsertTicketState({ ticket: t, prNumber: prNum }); } catch { /* DB not opened */ }
+    }
+  }
+
+  for (const [interestId, reg] of interestsMap) {
+    if (reg.interest_type !== "ticket_lifecycle") continue;
+
+    const watchedTickets = reg.tickets ?? [];
+    if (watchedTickets.length === 0) continue;
+
+    const wakeOn = reg.wake_on ?? TICKET_LIFECYCLE_ALL_WAKE_ON;
+    let reason = null;
+    let matchedTicket = null;
+
+    if (name === "linear.issue.state_changed" && eventTicket && watchedTickets.includes(eventTicket)) {
+      matchedTicket = eventTicket;
+      const newState = detail.state ?? detail.stateName ?? "unknown";
+      if (wakeOn.includes("status_done") && /done/i.test(newState)) {
+        reason = `Ticket ${eventTicket} marked Done`;
+      } else if (wakeOn.includes("status_in_review") && /in.?review/i.test(newState)) {
+        reason = `Ticket ${eventTicket} moved to In Review`;
+      } else if (wakeOn.includes("status_changed")) {
+        reason = `Ticket ${eventTicket} state changed to ${newState}`;
+      }
+    } else if (name === "linear.issue.updated" && eventTicket && watchedTickets.includes(eventTicket)) {
+      if (wakeOn.includes("status_changed")) {
+        matchedTicket = eventTicket;
+        reason = `Ticket ${eventTicket} updated`;
+      }
+    } else if (name === "linear.comment.created" && eventTicket && watchedTickets.includes(eventTicket)) {
+      if (wakeOn.includes("comment_added")) {
+        matchedTicket = eventTicket;
+        const author = detail.author ?? attrs["linear.actor.id"] ?? "someone";
+        reason = `New comment on ${eventTicket} by ${author}`;
+      }
+    } else if (name === "github.pr.opened") {
+      const linked = prBodyTickets.find((t) => watchedTickets.includes(t));
+      if (linked && wakeOn.includes("pr_opened")) {
+        matchedTicket = linked;
+        const pr = scope.pr ?? "?";
+        reason = `PR #${pr} opened on ticket ${linked}`;
+        // Auto-correlate: give agents watching this ticket a pr_lifecycle interest.
+        if (typeof scope.pr === "number") {
+          _autoPrLifecycleFromTicket(linked, scope.pr, interestsMap);
+        }
+      }
+    } else if (name === "github.pr.merged") {
+      const linked = prBodyTickets.find((t) => watchedTickets.includes(t));
+      if (linked && wakeOn.includes("pr_merged")) {
+        matchedTicket = linked;
+        const pr = scope.pr ?? "?";
+        reason = `PR #${pr} on ticket ${linked} merged`;
+      }
+    }
+
+    if (reason) {
+      matches.push({ interestId, reason, sourceEventId: eventId, ticket: matchedTicket });
+    }
+  }
+
+  return matches;
+}
+
+// When a PR opens linked to a ticket, auto-register pr_lifecycle for any agent
+// that checked in with that ticket but hasn't been linked to a PR yet.
+function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
+  let agents = [];
+  try { agents = getAgentsByTicket(ticket); } catch { return; }
+
+  for (const agent of agents) {
+    if (agent.claimedPr) continue;
+    const sessionId = agent.sessionId;
+    if (interestsMap.has(sessionId)) continue;
+
+    interests.set(sessionId, {
+      notify_event: `filter.wake.${sessionId}`,
+      prompt: "",
+      context: { pr_numbers: [prNumber], tickets: [ticket], workers: [sessionId] },
+      orchestrator: agent.orchestrator ?? null,
+      session_id: sessionId,
+      persistent: true,
+      interest_type: "pr_lifecycle",
+      pr_numbers: [prNumber],
+      repo: null,
+      base_branches: [],
+      tickets: null,
+      wake_on: null,
+    });
+
+    try { upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: "" }); } catch { /* DB not opened */ }
+
+    console.log(`[broker] Auto-correlated pr_lifecycle for agent ${sessionId} (ticket ${ticket} → PR #${prNumber})`);
+    saveInterests();
+  }
+}
+
+// --- Event classification ---
+
+export function shouldSkipEvent(event) {
+  const name = event.event ?? "";
+  return name.startsWith("filter.");
+}
+
+export function buildGroqPrompt(events) {
+  if (!interests.size) return null;
+
+  // Deterministic-routed interest types are excluded from the Groq prompt.
+  const proseInterests = [...interests.entries()].filter(
+    ([, reg]) => reg.interest_type !== "pr_lifecycle" && reg.interest_type !== "ticket_lifecycle",
+  );
+  if (proseInterests.length === 0) return null;
+
+  const interestLines = proseInterests
+    .map(([id, reg]) => {
+      const ctx = reg.context ? ` (context: ${JSON.stringify(reg.context)})` : "";
+      return `- ${id}: "${reg.prompt}"${ctx}`;
+    })
+    .join("\n");
+
+  const eventLines = events.map((e, i) => `${i + 1}. ${JSON.stringify(e)}`).join("\n");
+
+  const systemPrompt =
+    "You are a semantic event router for a developer automation system. " +
+    "Given a list of events and registered orchestrator interests, determine which events are relevant to which interests.\n\n" +
+    "Respond with a JSON array of matches. Each element: " +
+    '{"interest_id":"...","reason":"one sentence why","event_indices":[1,2,...]}.\n' +
+    "Only include interests with at least one matching event. Return [] if nothing matches.\n" +
+    "Return ONLY the JSON array, no other text.";
+
+  const userPrompt = `Events:\n${eventLines}\n\nRegistered interests:\n${interestLines}`;
+
+  return { systemPrompt, userPrompt };
+}
+
+async function classifyBatch(events) {
+  const prompts = buildGroqPrompt(events);
+  if (!prompts) return;
+
+  if (!GROQ_API_KEY) {
+    console.error("[broker] GROQ_API_KEY not set — skipping batch of", events.length, "events");
+    return;
+  }
+
+  let responseText;
+  try {
+    const res = await fetch(GROQ_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${GROQ_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: GROQ_MODEL,
+        messages: [
+          { role: "system", content: prompts.systemPrompt },
+          { role: "user", content: prompts.userPrompt },
+        ],
+        temperature: 0,
+        max_tokens: 512,
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[broker] Groq error ${res.status}:`, await res.text());
+      return;
+    }
+    const data = await res.json();
+    responseText = data.choices?.[0]?.message?.content ?? "[]";
+  } catch (err) {
+    console.error("[broker] Groq fetch failed:", err.message);
+    return;
+  }
+
+  let matches;
+  try {
+    matches = JSON.parse(responseText);
+  } catch {
+    console.error("[broker] Failed to parse Groq response:", responseText);
+    return;
+  }
+
+  if (!Array.isArray(matches)) return;
+
+  for (const match of matches) {
+    const reg = interests.get(match.interest_id);
+    if (!reg) continue;
+
+    const sourceIds = (match.event_indices ?? []).map((i) => events[i - 1]?.id).filter(Boolean);
+
+    if (!sourceIds.length) {
+      console.log(`[broker] No source events for ${reg.notify_event} — suppressing empty wake`);
+      continue;
+    }
+
+    appendEvent({
+      event: reg.notify_event,
+      orchestrator: reg.orchestrator ?? match.interest_id,
+      worker: null,
+      detail: {
+        reason: match.reason,
+        source_event_ids: sourceIds,
+        interest_id: match.interest_id,
+      },
+    });
+    console.log(`[broker] Wake: ${reg.notify_event} — ${match.reason}`);
+    if (!reg.persistent) {
+      interests.delete(match.interest_id);
+      console.log(`[broker] Auto-deregistered (one-shot): ${match.interest_id}`);
+    }
+  }
+}
+
+// --- Debounce ---
+let pendingBatch = [];
+let debounceTimer = null;
+let hardCapTimer = null;
+
+async function flushBatch() {
+  clearTimeout(debounceTimer);
+  clearTimeout(hardCapTimer);
+  debounceTimer = null;
+  hardCapTimer = null;
+  const batch = pendingBatch.splice(0);
+  if (batch.length) await classifyBatch(batch);
+}
+
+function scheduleBatchFlush() {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(flushBatch, DEBOUNCE_MS);
+  if (!hardCapTimer) {
+    hardCapTimer = setTimeout(flushBatch, HARD_CAP_MS);
+  }
+}
+
+function queueEvent(event) {
+  pendingBatch.push(event);
+  if (pendingBatch.length >= MAX_BATCH_SIZE) {
+    flushBatch();
+  } else {
+    scheduleBatchFlush();
+  }
+}
+
+// --- Heartbeat watchdog ---
+
+export function runWatchdogTick() {
+  const now = Date.now();
+  for (const [sourceId, state] of lastHeartbeat) {
+    const stale = now - state.ts > HEARTBEAT_STALE_MS;
+    if (stale && !state.notified) {
+      const minsAgo = Math.round((now - state.ts) / 60_000);
+      const reason = `No heartbeat from ${sourceId} for >${minsAgo} min`;
+      let woke = false;
+      for (const [interestId, interest] of interests) {
+        const workers = interest.context?.workers;
+        const orchForSource = workerToOrchestrator.get(sourceId);
+        const orchMatch = orchForSource != null && orchForSource === interest.orchestrator;
+        if ((workers != null && workers.includes(sourceId)) || (workers == null && orchMatch)) {
+          appendEvent({
+            event: interest.notify_event,
+            orchestrator: interest.orchestrator ?? interestId,
+            worker: null,
+            detail: { reason, source_event_ids: [], interest_id: interestId },
+          });
+          console.log(`[broker] Watchdog wake: ${interest.notify_event} — ${reason}`);
+          woke = true;
+        }
+      }
+      if (woke) {
+        // Belt-and-suspenders: clean up interests for the stale session.
+        for (const [interestId, interest] of interests) {
+          if (interest.session_id && interest.session_id === sourceId) {
+            interests.delete(interestId);
+            console.log(`[broker] Watchdog cleanup: removed ${interestId} (stale session ${sourceId})`);
+          }
+        }
+        lastHeartbeat.set(sourceId, { ts: state.ts, notified: true });
+      }
+    } else if (!stale && state.notified) {
+      lastHeartbeat.set(sourceId, { ts: state.ts, notified: false });
+    }
+  }
+}
+
+function startWatchdog() {
+  return setInterval(runWatchdogTick, WATCHDOG_INTERVAL_MS);
+}
+
+// --- Event processing ---
+export function processEvent(event) {
+  const name = event.event ?? "";
+
+  if (name === "filter.register") {
+    handleRegister(event);
+    return;
+  }
+  if (name === "filter.deregister") {
+    handleDeregister(event);
+    return;
+  }
+
+  // CTL-303: structured agent identity events.
+  if (name === "agent.checkin") {
+    handleAgentCheckin(event);
+    return;
+  }
+  if (name === "agent.checkout") {
+    handleAgentCheckout(event);
+    return;
+  }
+  if (name === "agent.heartbeat") {
+    handleAgentHeartbeat(event);
+    return;
+  }
+
+  if (shouldSkipEvent(event)) return;
+
+  if (name === "heartbeat") {
+    const sourceId = event.worker ?? event.session ?? event.orchestrator;
+    if (sourceId) {
+      const existing = lastHeartbeat.get(sourceId);
+      lastHeartbeat.set(sourceId, { ts: Date.now(), notified: existing?.notified ?? false });
+      const orchId = event.orchestrator;
+      if (orchId && sourceId !== orchId) {
+        workerToOrchestrator.set(sourceId, orchId);
+      }
+    }
+    return;
+  }
+
+  if (name === "orchestrator-completed" || name === "orchestrator-failed") {
+    handleOrchestratorTerminated(event);
+  }
+
+  if (!interests.size) return;
+
+  // Deterministic short-circuit: pr_lifecycle (CTL-284) and ticket_lifecycle (CTL-303).
+  const prMatches = tryDeterministicRoute(event, interests);
+  const ticketMatches = tryTicketLifecycleRoute(event, interests);
+  const directMatches = [...prMatches, ...ticketMatches];
+
+  for (const m of directMatches) {
+    const reg = interests.get(m.interestId);
+    if (!reg) continue;
+    appendEvent({
+      event: reg.notify_event,
+      orchestrator: reg.orchestrator ?? m.interestId,
+      worker: null,
+      detail: {
+        reason: m.reason,
+        source_event_ids: m.sourceEventId ? [m.sourceEventId] : [],
+        interest_id: m.interestId,
+        ...(m.ticket ? { ticket: m.ticket } : {}),
+      },
+    });
+    console.log(`[broker] Direct wake: ${reg.notify_event} — ${m.reason}`);
+    if (!reg.persistent) {
+      interests.delete(m.interestId);
+      if (reg.interest_type === "pr_lifecycle") {
+        try { deleteFilterState(m.interestId); } catch { /* DB not opened */ }
+      }
+      saveInterests();
+      console.log(`[broker] Auto-deregistered (one-shot): ${m.interestId}`);
+    }
+  }
+
+  if (directMatches.length > 0) return;
+
+  queueEvent(event);
+}
+
+// --- Reactive event log tailing ---
+let lastByteOffset = 0;
+let lastLogPath = "";
+let leftoverBuf = "";
+let eventsWatcher = null;
+
+function readNewEvents() {
+  const logPath = getEventLogPath();
+
+  if (logPath !== lastLogPath) {
+    lastLogPath = logPath;
+    leftoverBuf = "";
+    try {
+      const fd = openSync(logPath, "r");
+      const stat = fstatSync(fd);
+      lastByteOffset = stat.size;
+      closeSync(fd);
+    } catch {
+      lastByteOffset = 0;
+    }
+    return;
+  }
+
+  try {
+    const fd = openSync(logPath, "r");
+    const stat = fstatSync(fd);
+    if (stat.size <= lastByteOffset) {
+      closeSync(fd);
+      return;
+    }
+    const newByteCount = stat.size - lastByteOffset;
+    const buf = Buffer.alloc(newByteCount);
+    readSync(fd, buf, 0, newByteCount, lastByteOffset);
+    closeSync(fd);
+    lastByteOffset = stat.size;
+
+    const text = leftoverBuf + buf.toString("utf8");
+    const lines = text.split("\n");
+    leftoverBuf = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let event;
+      try { event = JSON.parse(line); } catch { continue; }
+      processEvent(event);
+    }
+  } catch {
+    // Log file not yet created or transient read error
+  }
+}
+
+function startTailing() {
+  const eventsDir = resolve(CATALYST_DIR, "events");
+  mkdirSync(eventsDir, { recursive: true });
+  eventsWatcher = watch(eventsDir, (eventType, filename) => {
+    if (eventType !== "change") return;
+    if (filename !== null && filename !== basename(getEventLogPath())) return;
+    readNewEvents();
+  });
+}
+
+function loadExistingRegistrations() {
+  try {
+    const content = readFileSync(lastLogPath, "utf8");
+    const lines = content.split("\n").filter((l) => l.trim());
+    for (const line of lines.slice(-LOOKBACK_LINES)) {
+      let event;
+      try { event = JSON.parse(line); } catch { continue; }
+      if (event.event === "filter.register") handleRegister(event);
+      if (event.event === "filter.deregister") handleDeregister(event);
+      if (event.event === "agent.checkin") handleAgentCheckin(event);
+      if (event.event === "agent.checkout") handleAgentCheckout(event);
+      if (event.event === "orchestrator-completed" || event.event === "orchestrator-failed") {
+        handleOrchestratorTerminated(event);
+      }
+    }
+    if (interests.size) {
+      console.log(`[broker] Recovered ${interests.size} interest(s) from log`);
+    }
+  } catch {
+    // No log file yet — fine
+  }
+}
+
+// --- PID file ---
+function parsePidFilePath() {
+  const idx = process.argv.indexOf("--pid-file");
+  return idx !== -1 ? process.argv[idx + 1] : null;
+}
+
+const PID_FILE_PATH = parsePidFilePath();
+
+function writePidFile() {
+  if (!PID_FILE_PATH) return;
+  try {
+    mkdirSync(dirname(PID_FILE_PATH), { recursive: true });
+    writeFileSync(PID_FILE_PATH, `${process.pid}\n`);
+  } catch (err) {
+    console.error("[broker] Failed to write PID file:", err.message);
+  }
+}
+
+function removePidFile() {
+  if (!PID_FILE_PATH) return;
+  try { unlinkSync(PID_FILE_PATH); } catch { /* already gone */ }
+}
+
+// --- Main ---
+function main() {
+  if (!GROQ_API_KEY) {
+    console.warn(
+      "[broker] WARN: GROQ_API_KEY not set and groq.apiKey absent from ~/.config/catalyst/config.json — semantic filtering disabled"
+    );
+  }
+
+  writePidFile();
+
+  lastLogPath = getEventLogPath();
+  loadPersistedInterests();
+  loadExistingRegistrations();
+
+  openBrokerStateDb();
+
+  try {
+    const fd = openSync(lastLogPath, "r");
+    const stat = fstatSync(fd);
+    lastByteOffset = stat.size;
+    closeSync(fd);
+    console.log(`[broker] Starting from byte ${lastByteOffset} of ${lastLogPath}`);
+  } catch {
+    console.log(`[broker] Starting (no log file yet at ${lastLogPath})`);
+  }
+
+  appendEvent({
+    event: "filter.daemon.startup",
+    orchestrator: null,
+    worker: null,
+    detail: {
+      pid: process.pid,
+      recovered_interests: interests.size,
+      watchdog_interval_ms: WATCHDOG_INTERVAL_MS,
+      heartbeat_stale_ms: HEARTBEAT_STALE_MS,
+      broker: true,
+    },
+  });
+
+  startTailing();
+  const watchdogId = startWatchdog();
+  console.log(
+    `[broker] catalyst-broker daemon started (pid ${process.pid}, watchdog: ${WATCHDOG_INTERVAL_MS}ms, stale: ${HEARTBEAT_STALE_MS}ms)`
+  );
+
+  const shutdown = () => {
+    eventsWatcher?.close();
+    clearInterval(watchdogId);
+    clearTimeout(debounceTimer);
+    clearTimeout(hardCapTimer);
+    closeBrokerStateDb();
+    removePidFile();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -1,0 +1,656 @@
+// Unit tests for catalyst-broker core logic (CTL-303).
+// Covers new functionality: agent.checkin/checkout, ticket_lifecycle routing,
+// auto-correlation, and updated [broker] log prefix.
+// Run: bun test plugins/dev/scripts/broker/index.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  handleRegister,
+  handleAgentCheckin,
+  handleAgentCheckout,
+  handleAgentHeartbeat,
+  shouldSkipEvent,
+  buildGroqPrompt,
+  getInterests,
+  clearInterests,
+  getLastHeartbeat,
+  clearLastHeartbeat,
+  processEvent,
+  tryDeterministicRoute,
+  tryTicketLifecycleRoute,
+} from "./index.mjs";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  getAgentBySession,
+  getAgentsByTicket,
+  getTicketState,
+} from "./broker-state.mjs";
+
+// ─── Shared DB setup ─────────────────────────────────────────────────────────
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "broker-test-"));
+  openBrokerStateDb(join(tmpDir, "test.db"));
+  clearInterests();
+  clearLastHeartbeat();
+});
+
+afterEach(() => {
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── ticket_lifecycle interest registration ───────────────────────────────────
+
+describe("ticket_lifecycle registration", () => {
+  test("handleRegister stores ticket_lifecycle interest with tickets and wake_on", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "watcher-1",
+        notify_event: "filter.wake.watcher-1",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275", "CTL-300"],
+        wake_on: ["status_done", "pr_merged"],
+        persistent: true,
+      },
+    });
+    const reg = getInterests().get("watcher-1");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("ticket_lifecycle");
+    expect(reg.tickets).toEqual(["CTL-275", "CTL-300"]);
+    expect(reg.wake_on).toEqual(["status_done", "pr_merged"]);
+    expect(reg.pr_numbers).toBeNull();
+  });
+
+  test("ticket_lifecycle interest is excluded from Groq prompt", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "tl-1",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-100"],
+        wake_on: null,
+        persistent: true,
+      },
+    });
+    const prompt = buildGroqPrompt([{ event: "linear.issue.state_changed" }]);
+    expect(prompt).toBeNull();
+  });
+});
+
+// ─── tryTicketLifecycleRoute ─────────────────────────────────────────────────
+
+describe("tryTicketLifecycleRoute — Linear state changes", () => {
+  beforeEach(() => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "watch-ctl-275",
+        notify_event: "filter.wake.watch-ctl-275",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["status_done", "status_in_review", "status_changed", "comment_added"],
+        persistent: true,
+      },
+    });
+  });
+
+  test("fires status_done on linear.issue.state_changed with 'Done' state", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "linear.issue.state_changed",
+      attributes: { "linear.issue.identifier": "CTL-275" },
+      detail: { state: "Done" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("watch-ctl-275");
+    expect(matches[0].reason).toContain("marked Done");
+  });
+
+  test("fires status_in_review on 'In Review' state", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "linear.issue.state_changed",
+      attributes: { "linear.issue.identifier": "CTL-275" },
+      detail: { state: "In Review" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("In Review");
+  });
+
+  test("fires status_changed for non-terminal state changes", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "linear.issue.state_changed",
+      attributes: { "linear.issue.identifier": "CTL-275" },
+      detail: { state: "In Progress" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("In Progress");
+  });
+
+  test("does not fire for unregistered ticket", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "linear.issue.state_changed",
+      attributes: { "linear.issue.identifier": "CTL-999" },
+      detail: { state: "Done" },
+    }, getInterests());
+    expect(matches).toHaveLength(0);
+  });
+
+  test("respects wake_on filter — does not fire when kind not in wake_on", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "narrow-watch",
+        notify_event: "filter.wake.narrow-watch",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["pr_merged"],
+        persistent: true,
+      },
+    });
+    const matches = tryTicketLifecycleRoute({
+      event: "linear.issue.state_changed",
+      attributes: { "linear.issue.identifier": "CTL-275" },
+      detail: { state: "Done" },
+    }, getInterests());
+    const narrowMatch = matches.find((m) => m.interestId === "narrow-watch");
+    expect(narrowMatch).toBeUndefined();
+  });
+});
+
+describe("tryTicketLifecycleRoute — Linear comments", () => {
+  beforeEach(() => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "comment-watch",
+        notify_event: "filter.wake.comment-watch",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["comment_added"],
+        persistent: true,
+      },
+    });
+  });
+
+  test("fires on linear.comment.created for watched ticket", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "linear.comment.created",
+      attributes: { "linear.issue.identifier": "CTL-275" },
+      detail: { author: "ryan" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("ryan");
+    expect(matches[0].reason).toContain("CTL-275");
+  });
+
+  test("does not fire for unwatched ticket", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "linear.comment.created",
+      attributes: { "linear.issue.identifier": "CTL-999" },
+      detail: { author: "ryan" },
+    }, getInterests());
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("tryTicketLifecycleRoute — GitHub PR events with ticket link", () => {
+  beforeEach(() => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "pr-watch",
+        notify_event: "filter.wake.pr-watch",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["pr_opened", "pr_merged"],
+        persistent: true,
+      },
+    });
+  });
+
+  test("fires pr_opened when PR body references watched ticket", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 501 },
+      detail: { body: "Implements CTL-275\n\nThis PR does stuff", title: "fix thing", headRef: "ryan/ctl-275" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("501");
+    expect(matches[0].reason).toContain("CTL-275");
+  });
+
+  test("fires pr_merged when PR body references watched ticket", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "github.pr.merged",
+      scope: { pr: 501 },
+      detail: { body: "Fixes CTL-275", title: "", headRef: "" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("merged");
+    expect(matches[0].ticket).toBe("CTL-275");
+  });
+
+  test("does not fire when PR body has no ticket reference", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 502 },
+      detail: { body: "General cleanup PR", title: "cleanup", headRef: "ryan/cleanup" },
+    }, getInterests());
+    expect(matches).toHaveLength(0);
+  });
+
+  test("includes ticket field in match result", () => {
+    const matches = tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 505 },
+      detail: { body: "CTL-275 implementation", title: "", headRef: "" },
+    }, getInterests());
+    expect(matches[0].ticket).toBe("CTL-275");
+  });
+});
+
+describe("tryTicketLifecycleRoute — ticket_state side effects", () => {
+  test("upserts ticket_state on linear.issue.state_changed", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "ts-watch",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-280"],
+        wake_on: ["status_changed"],
+        persistent: true,
+      },
+    });
+    tryTicketLifecycleRoute({
+      event: "linear.issue.state_changed",
+      attributes: { "linear.issue.identifier": "CTL-280" },
+      detail: { state: "Done" },
+    }, getInterests());
+    const ts = getTicketState("CTL-280");
+    expect(ts).not.toBeNull();
+    expect(ts.linearState).toBe("Done");
+  });
+});
+
+// ─── agent.checkin / agent.checkout ──────────────────────────────────────────
+
+describe("agent.checkin", () => {
+  test("stores agent identity in DB", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: {
+        session_id: "sess-abc",
+        agent_name: "ctl-275-worker",
+        ticket: "CTL-275",
+        orchestrator: "orch-2026",
+        claimed_pr: null,
+        cwd: "/some/path",
+      },
+    });
+    const agent = getAgentBySession("sess-abc");
+    expect(agent).not.toBeNull();
+    expect(agent.agentName).toBe("ctl-275-worker");
+    expect(agent.ticket).toBe("CTL-275");
+    expect(agent.status).toBe("active");
+  });
+
+  test("updates heartbeat map on checkin", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-hb", agent_name: "worker", ticket: null, claimed_pr: null },
+    });
+    expect(getLastHeartbeat().has("sess-hb")).toBe(true);
+  });
+
+  test("auto-registers pr_lifecycle interest when claimed_pr is set", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: {
+        session_id: "sess-pr",
+        agent_name: "worker",
+        ticket: "CTL-275",
+        orchestrator: "orch-1",
+        claimed_pr: 501,
+      },
+    });
+    const reg = getInterests().get("sess-pr");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("pr_lifecycle");
+    expect(reg.pr_numbers).toEqual([501]);
+    expect(reg.notify_event).toBe("filter.wake.sess-pr");
+  });
+
+  test("does not override explicit pr_lifecycle registration with auto-correlation", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "sess-explicit",
+        notify_event: "filter.wake.explicit",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [999],
+        repo: "org/repo",
+        base_branches: [{ pr: 999, base: "main" }],
+        persistent: true,
+      },
+    });
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-explicit", agent_name: "worker", claimed_pr: 501 },
+    });
+    const reg = getInterests().get("sess-explicit");
+    expect(reg.pr_numbers).toEqual([999]);
+    expect(reg.notify_event).toBe("filter.wake.explicit");
+  });
+
+  test("no-op when session_id missing", () => {
+    expect(() => handleAgentCheckin({ event: "agent.checkin", detail: {} })).not.toThrow();
+  });
+});
+
+describe("agent.checkout", () => {
+  test("marks agent done in DB (getAgentBySession returns null for done agents)", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-co", agent_name: "worker", claimed_pr: null },
+    });
+    handleAgentCheckout({
+      event: "agent.checkout",
+      detail: { session_id: "sess-co", status: "done" },
+    });
+    const agent = getAgentBySession("sess-co");
+    expect(agent).toBeNull();
+  });
+
+  test("removes auto-correlated pr_lifecycle interest on checkout", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-clean", agent_name: "worker", claimed_pr: 501 },
+    });
+    expect(getInterests().has("sess-clean")).toBe(true);
+    handleAgentCheckout({
+      event: "agent.checkout",
+      detail: { session_id: "sess-clean", status: "done" },
+    });
+    expect(getInterests().has("sess-clean")).toBe(false);
+  });
+
+  test("preserves unrelated registrations on checkout", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "explicit-key",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [501],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+    handleAgentCheckout({
+      event: "agent.checkout",
+      detail: { session_id: "sess-other", status: "done" },
+    });
+    expect(getInterests().has("explicit-key")).toBe(true);
+  });
+
+  test("no-op when session_id missing", () => {
+    expect(() => handleAgentCheckout({ event: "agent.checkout", detail: {} })).not.toThrow();
+  });
+});
+
+describe("agent.heartbeat", () => {
+  test("updates heartbeat map via session field", () => {
+    handleAgentHeartbeat({ event: "agent.heartbeat", session: "sess-hb", orchestrator: null });
+    expect(getLastHeartbeat().has("sess-hb")).toBe(true);
+  });
+
+  test("falls back to worker field", () => {
+    handleAgentHeartbeat({ event: "agent.heartbeat", worker: "CTL-275" });
+    expect(getLastHeartbeat().has("CTL-275")).toBe(true);
+  });
+});
+
+// ─── processEvent dispatching ────────────────────────────────────────────────
+
+describe("processEvent dispatches agent identity events", () => {
+  test("agent.checkin updates heartbeat map", () => {
+    processEvent({
+      event: "agent.checkin",
+      detail: { session_id: "sess-proc", agent_name: "worker", claimed_pr: null },
+    });
+    expect(getLastHeartbeat().has("sess-proc")).toBe(true);
+  });
+
+  test("agent.checkout removes auto-correlated interest", () => {
+    processEvent({
+      event: "agent.checkin",
+      detail: { session_id: "sess-out", agent_name: "w", claimed_pr: 1 },
+    });
+    processEvent({
+      event: "agent.checkout",
+      detail: { session_id: "sess-out", status: "done" },
+    });
+    expect(getInterests().has("sess-out")).toBe(false);
+  });
+
+  test("agent.heartbeat is handled", () => {
+    processEvent({ event: "agent.heartbeat", session: "sess-hb2", orchestrator: null });
+    expect(getLastHeartbeat().has("sess-hb2")).toBe(true);
+  });
+
+  test("ticket_lifecycle match does not throw", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "tl-pe",
+        notify_event: "filter.wake.tl-pe",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-500"],
+        wake_on: ["status_done"],
+        persistent: true,
+      },
+    });
+    expect(() =>
+      processEvent({
+        event: "linear.issue.state_changed",
+        attributes: { "linear.issue.identifier": "CTL-500" },
+        detail: { state: "Done" },
+      })
+    ).not.toThrow();
+    expect(getInterests().has("tl-pe")).toBe(true);
+  });
+
+  test("one-shot ticket_lifecycle interest is auto-deregistered after wake", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "tl-oneshot",
+        notify_event: "filter.wake.tl-oneshot",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-501"],
+        wake_on: ["status_done"],
+        persistent: false,
+      },
+    });
+    processEvent({
+      event: "linear.issue.state_changed",
+      attributes: { "linear.issue.identifier": "CTL-501" },
+      detail: { state: "Done" },
+    });
+    expect(getInterests().has("tl-oneshot")).toBe(false);
+  });
+});
+
+// ─── Auto-correlation: ticket → PR ──────────────────────────────────────────
+
+describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-watching agents", () => {
+  test("agent checked in with ticket gets pr_lifecycle when PR opens", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-auto", agent_name: "worker", ticket: "CTL-275", claimed_pr: null },
+    });
+    expect(getInterests().has("sess-auto")).toBe(false);
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "tl-auto",
+        notify_event: "filter.wake.tl-auto",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["pr_opened"],
+        persistent: true,
+      },
+    });
+
+    tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 601 },
+      detail: { body: "Implements CTL-275", title: "", headRef: "" },
+    }, getInterests());
+
+    const reg = getInterests().get("sess-auto");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("pr_lifecycle");
+    expect(reg.pr_numbers).toEqual([601]);
+  });
+
+  test("agents with existing claimed_pr are skipped during auto-correlation", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-already", agent_name: "worker", ticket: "CTL-275", claimed_pr: 500 },
+    });
+    const prBefore = getInterests().get("sess-already")?.pr_numbers;
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "tl-skip",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["pr_opened"],
+        persistent: true,
+      },
+    });
+
+    tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 601 },
+      detail: { body: "CTL-275 implementation", title: "", headRef: "" },
+    }, getInterests());
+
+    expect(getInterests().get("sess-already")?.pr_numbers).toEqual(prBefore);
+  });
+});
+
+// ─── getAgentsByTicket ───────────────────────────────────────────────────────
+
+describe("getAgentsByTicket", () => {
+  test("returns active agents for a ticket", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-t1", agent_name: "w1", ticket: "CTL-400", claimed_pr: null },
+    });
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-t2", agent_name: "w2", ticket: "CTL-400", claimed_pr: null },
+    });
+    const agents = getAgentsByTicket("CTL-400");
+    expect(agents).toHaveLength(2);
+    expect(agents.map((a) => a.sessionId).sort()).toEqual(["sess-t1", "sess-t2"].sort());
+  });
+
+  test("returns empty array for unknown ticket", () => {
+    expect(getAgentsByTicket("CTL-NOPE")).toHaveLength(0);
+  });
+});
+
+// ─── Backward compat: pr_lifecycle routing unchanged ────────────────────────
+
+describe("backward compat: pr_lifecycle routing unchanged in broker", () => {
+  test("github.pr.merged fires pr_lifecycle interest", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-bc",
+      detail: {
+        interest_id: "sess-bc",
+        notify_event: "filter.wake.sess-bc",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [501],
+        repo: "org/repo",
+        base_branches: [{ pr: 501, base: "main" }],
+        persistent: true,
+        session_id: "sess-bc",
+      },
+    });
+    const matches = tryDeterministicRoute({
+      event: "github.pr.merged",
+      scope: { pr: 501 },
+      detail: { mergeCommitSha: "abc123", merged: true },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("sess-bc");
+    expect(matches[0].reason).toContain("merged");
+  });
+
+  test("github.check_suite.completed fires pr_lifecycle interest", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-bc",
+      detail: {
+        interest_id: "ci-watch",
+        notify_event: "filter.wake.ci-watch",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [502],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+    const matches = tryDeterministicRoute({
+      event: "github.check_suite.completed",
+      detail: { prNumbers: [502], conclusion: "success" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("CI checks passing");
+  });
+});
+
+// ─── shouldSkipEvent (broker) ─────────────────────────────────────────────────
+
+describe("shouldSkipEvent (broker)", () => {
+  test("skips filter.* events", () => {
+    expect(shouldSkipEvent({ event: "filter.wake.x" })).toBe(true);
+    expect(shouldSkipEvent({ event: "filter.register" })).toBe(true);
+  });
+
+  test("does not skip agent.* events", () => {
+    expect(shouldSkipEvent({ event: "agent.checkin" })).toBe(false);
+    expect(shouldSkipEvent({ event: "agent.checkout" })).toBe(false);
+  });
+
+  test("does not skip linear.* events", () => {
+    expect(shouldSkipEvent({ event: "linear.issue.state_changed" })).toBe(false);
+    expect(shouldSkipEvent({ event: "linear.comment.created" })).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/catalyst-broker
+++ b/plugins/dev/scripts/catalyst-broker
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
-# catalyst-filter — DEPRECATED: alias for catalyst-broker (CTL-303)
+# catalyst-broker — manage the Catalyst event broker daemon (CTL-303)
 #
-# catalyst-filter has been superseded by catalyst-broker, which adds structured
-# agent identity (agent.checkin/checkout), ticket_lifecycle routing, and
-# auto-correlation. All functionality is preserved; the daemon now runs from
-# plugins/dev/scripts/broker/ instead of filter-daemon/.
+# The broker extends the filter daemon with structured agent identity
+# (agent.checkin/checkout), auto-correlation of ticket↔PR interests, and
+# deterministic ticket_lifecycle routing for Linear webhook events.
 #
-# This shim delegates to catalyst-broker so existing scripts continue to work.
-# Update callers to use `catalyst-broker` directly.
+# Commands:
+#   start      Start broker daemon in background (idempotent)
+#   stop       Stop broker daemon
+#   restart    Stop then start
+#   status     Print running/stopped + pid
+#   logs       Tail daemon log
+#   run [args] Run daemon in foreground (debugging)
 
 set -uo pipefail
 
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+PID_FILE="${BROKER_PID_FILE:-$CATALYST_DIR/broker.pid}"
+LOG_FILE="${BROKER_LOG_FILE:-$CATALYST_DIR/broker.log}"
 _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
-BROKER="${SCRIPT_DIR}/catalyst-broker"
-
-if [[ ! -x "$BROKER" ]]; then
-  echo "error: catalyst-broker not found at $BROKER" >&2
-  exit 1
-fi
-
-exec "$BROKER" "$@"
+DAEMON_SCRIPT="${BROKER_DAEMON_SCRIPT:-$SCRIPT_DIR/broker/index.mjs}"
 
 is_alive() { kill -0 "$1" 2>/dev/null; }
 
@@ -47,7 +47,7 @@ resolve_runtime() {
 
 cmd_start() {
   if read_pid > /dev/null 2>&1; then
-    echo "catalyst-filter already running (pid $(read_pid))"
+    echo "catalyst-broker already running (pid $(read_pid))"
     return 0
   fi
   local runtime
@@ -63,7 +63,7 @@ cmd_start() {
   local waited=0
   while [[ $waited -lt 20 ]]; do
     if [[ -f "$PID_FILE" ]]; then
-      echo "catalyst-filter started (pid $(cat "$PID_FILE"))"
+      echo "catalyst-broker started (pid $(cat "$PID_FILE"))"
       return 0
     fi
     sleep 0.1
@@ -71,17 +71,17 @@ cmd_start() {
   done
   if is_alive "$server_pid"; then
     echo "$server_pid" > "$PID_FILE"
-    echo "catalyst-filter started (pid $server_pid)"
+    echo "catalyst-broker started (pid $server_pid)"
     return 0
   fi
-  echo "error: catalyst-filter failed to start — check $LOG_FILE" >&2
+  echo "error: catalyst-broker failed to start — check $LOG_FILE" >&2
   return 1
 }
 
 cmd_stop() {
   local pid
   if ! pid=$(read_pid); then
-    echo "catalyst-filter not running"
+    echo "catalyst-broker not running"
     return 0
   fi
   kill "$pid" 2>/dev/null || true
@@ -92,7 +92,7 @@ cmd_stop() {
   done
   is_alive "$pid" && kill -9 "$pid" 2>/dev/null || true
   rm -f "$PID_FILE" 2>/dev/null
-  echo "catalyst-filter stopped"
+  echo "catalyst-broker stopped"
 }
 
 cmd_restart() {
@@ -131,7 +131,7 @@ case "${1:-}" in
   logs)    cmd_logs ;;
   run)     shift; cmd_run "$@" ;;
   *)
-    echo "Usage: catalyst-filter {start|stop|restart|status|logs|run}" >&2
+    echo "Usage: catalyst-broker {start|stop|restart|status|logs|run}" >&2
     exit 1
     ;;
 esac

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -257,6 +257,26 @@ cmd_start() {
       status:$status}')
   emit_event "$sid" "session-started" "$payload"
 
+  # CTL-303: emit agent.checkin so the broker can auto-correlate ticket↔PR interests.
+  local checkin_ts; checkin_ts="$(now_iso)"
+  local checkin_cwd="${cwd:-$(pwd 2>/dev/null || true)}"
+  local checkin_payload
+  checkin_payload=$(jq -nc \
+    --arg session_id "$sid" \
+    --arg agent_name "${label:-${skill}}" \
+    --arg ticket "$ticket" \
+    --arg orchestrator "${workflow:-${CATALYST_ORCHESTRATOR_ID:-}}" \
+    --arg cwd "$checkin_cwd" \
+    '{session_id:$session_id,
+      agent_name:$agent_name,
+      ticket:(if $ticket == "" then null else $ticket end),
+      orchestrator:(if $orchestrator == "" then null else $orchestrator end),
+      claimed_pr:null,
+      cwd:$cwd}')
+  canonical_jsonl_append "$EVENTS_DIR" \
+    "$(jq -nc --arg ts "$checkin_ts" --argjson detail "$checkin_payload" \
+      '{ts:$ts,event:"agent.checkin",detail:$detail}' 2>/dev/null)" 2>/dev/null || true
+
   echo "$sid"
 }
 
@@ -495,6 +515,12 @@ cmd_end() {
   local sev="INFO"
   [[ "$status" == "failed" ]] && sev="ERROR"
   __session_emit_canonical "$sid" "session-ended" "$payload" "$end_ts" "$sev"
+
+  # CTL-303: emit agent.checkout so the broker can clean up auto-correlated interests.
+  local checkout_ts; checkout_ts="$(now_iso)"
+  canonical_jsonl_append "$EVENTS_DIR" \
+    "$(jq -nc --arg ts "$checkout_ts" --arg sid "$sid" --arg st "$status" \
+      '{ts:$ts,event:"agent.checkout",detail:{session_id:$sid,status:$st}}' 2>/dev/null)" 2>/dev/null || true
 
   # CTL-157: emit claude_code.session.outcome to OTLP.
   local emit_bin="${CATALYST_EMIT_OTEL_BIN:-$SCRIPT_DIR/emit-otel-event.sh}"

--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: broker
+description:
+  Protocol reference for the Catalyst event broker daemon. Covers agent identity (agent.checkin/
+  checkout), auto-correlation of ticket↔PR interests, ticket_lifecycle deterministic routing for
+  Linear events, and the existing pr_lifecycle + Groq prose routing paths. Use when an agent needs
+  to wait for events related to its own ticket/PR, watch another ticket's lifecycle, or register
+  any semantic interest in the event stream.
+---
+
+# Catalyst Event Broker — Protocol Reference (CTL-303)
+
+The broker daemon evolved from the `catalyst-filter` daemon (CTL-284). It adds:
+
+1. **Structured agent identity** — `agent.checkin` / `agent.checkout` events so the broker knows
+   who is working on what. The broker auto-derives `pr_lifecycle` interests from check-in data.
+2. **`ticket_lifecycle` interest type** — deterministic routing for Linear webhook events keyed on
+   ticket identifiers. No Groq round-trip for state changes, comments, and PR links.
+3. **Auto-correlation** — when an agent checks in with a ticket, the broker auto-registers a
+   `pr_lifecycle` interest the moment a PR linking that ticket appears. Agents no longer need to
+   call `filter.register pr_lifecycle` explicitly.
+4. **Backward compat** — all CTL-284 `pr_lifecycle` explicit registration still works unchanged.
+   Groq prose classification remains for ambiguous / multi-condition interests.
+
+## Daemon Management
+
+```bash
+# Check status (broker and filter are aliases)
+catalyst-broker status   # → "running (pid N)" or "stopped"
+catalyst-filter status   # deprecated alias — delegates to catalyst-broker
+
+# Start / stop / restart
+catalyst-broker start
+catalyst-broker stop
+catalyst-broker restart
+
+# View logs
+catalyst-broker logs
+```
+
+## Interest Types Summary
+
+| Interest type | Routing | Use case |
+|---|---|---|
+| `pr_lifecycle` | Deterministic | Watch CI, reviews, merge, deployment for a known PR number |
+| `ticket_lifecycle` | Deterministic | Watch Linear state changes, comments, PR links for a ticket |
+| (prose prompt) | Groq LLM | Anything ambiguous, cross-cutting, or complex |
+
+## 1. Auto-Correlation (The Common Case — No Registration Needed)
+
+**When an agent's own ticket/PR** is the concern, registration is automatic:
+
+```bash
+# catalyst-session.sh start emits agent.checkin automatically:
+CATALYST_SESSION_ID=$(catalyst-session.sh start --skill oneshot --ticket CTL-275)
+# ↑ The broker records: agent CTL-275 with no claimed_pr yet.
+
+# When you later create the PR, update claimed_pr via agent.checkin:
+cat >> ~/catalyst/events/$(date -u +%Y-%m).jsonl <<EOF
+{"ts":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","event":"agent.checkin","detail":{"session_id":"$CATALYST_SESSION_ID","ticket":"CTL-275","claimed_pr":$PR_NUMBER,"orchestrator":"${CATALYST_ORCHESTRATOR_ID:-}"}}
+EOF
+# ↑ The broker sees claimed_pr → auto-registers pr_lifecycle for filter.wake.$CATALYST_SESSION_ID
+```
+
+The `oneshot` skill now uses this pattern instead of calling `filter.register` directly. The
+explicit `filter_register_worker` function is kept for backward compat but is no longer the
+recommended path for new work.
+
+## 2. `agent.checkin` Event
+
+Emitted by `catalyst-session.sh start` and optionally after PR creation. Shape:
+
+```json
+{
+  "ts": "2026-05-08T07:00:00Z",
+  "event": "agent.checkin",
+  "detail": {
+    "session_id": "sess_20260508_abcd",
+    "agent_name": "ctl-275-worker",
+    "ticket": "CTL-275",
+    "orchestrator": "orch-2026-05-08",
+    "claimed_pr": 501,
+    "cwd": "/path/to/worktree"
+  }
+}
+```
+
+Fields:
+- `session_id` — required. Primary key in the broker's `agents` table.
+- `agent_name` — human label (defaults to `session_id` if missing).
+- `ticket` — Linear ticket identifier (e.g. `"CTL-275"`). Enables `ticket_lifecycle` auto-correlation.
+- `orchestrator` — parent orchestrator ID; enables stale-session watchdog routing.
+- `claimed_pr` — if set, broker immediately auto-registers `pr_lifecycle` for this agent.
+- `cwd` — working directory; included for diagnostics.
+
+## 3. `agent.checkout` Event
+
+Emitted by `catalyst-session.sh end`. Shape:
+
+```json
+{
+  "ts": "2026-05-08T09:00:00Z",
+  "event": "agent.checkout",
+  "detail": {
+    "session_id": "sess_20260508_abcd",
+    "status": "done"
+  }
+}
+```
+
+On checkout, the broker:
+- Marks the agent as `done` in the `agents` SQLite table.
+- Removes any auto-correlated `pr_lifecycle` interest (explicit registrations are preserved).
+
+## 4. `ticket_lifecycle` Interest Type
+
+Register to watch a ticket's Linear events and PR links deterministically:
+
+```bash
+# Register via filter.register event
+ORCH_ID="${CATALYST_ORCHESTRATOR_ID:-my-orch}"
+jq -nc \
+  --arg orch "$ORCH_ID" \
+  --arg sid "$CATALYST_SESSION_ID" \
+  '{ts: (now | todate), event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $sid,
+      notify_event: ("filter.wake." + $sid),
+      interest_type: "ticket_lifecycle",
+      tickets: ["CTL-275"],
+      wake_on: ["status_done", "pr_opened", "pr_merged"],
+      persistent: true,
+      session_id: $sid
+    }}' >> ~/catalyst/events/$(date -u +%Y-%m).jsonl
+```
+
+### `wake_on` Values
+
+| Value | Fires on |
+|---|---|
+| `status_done` | `linear.issue.state_changed` where state matches `/done/i` |
+| `status_in_review` | `linear.issue.state_changed` where state matches `/in.?review/i` |
+| `status_changed` | Any `linear.issue.state_changed` or `linear.issue.updated` |
+| `comment_added` | `linear.comment.created` for the ticket |
+| `pr_opened` | `github.pr.opened` whose body/title/branch references the ticket |
+| `pr_merged` | `github.pr.merged` whose body/title/branch references the ticket |
+
+Omit `wake_on` (or pass `null`) to fire on all of the above.
+
+### Wake Event Shape
+
+```json
+{
+  "event": "filter.wake.sess_20260508_abcd",
+  "orchestrator": "my-orch",
+  "worker": null,
+  "detail": {
+    "reason": "Ticket CTL-275 marked Done",
+    "source_event_ids": ["..."],
+    "interest_id": "sess_20260508_abcd",
+    "ticket": "CTL-275"
+  }
+}
+```
+
+### Waiting for a Ticket Wake
+
+```bash
+EVENT=$(catalyst-events wait-for \
+  --filter ".attributes.\"event.name\" == \"filter.wake\" and .attributes.\"event.label\" == \"${CATALYST_SESSION_ID}\"" \
+  --timeout 600 2>/dev/null || true)
+```
+
+## 5. `pr_lifecycle` Interest Type (CTL-284 — Unchanged)
+
+Explicit PR-number registration still works:
+
+```bash
+jq -nc \
+  --arg orch "${CATALYST_ORCHESTRATOR_ID:-}" \
+  --arg sid "$CATALYST_SESSION_ID" \
+  --argjson pr "$PR_NUMBER" \
+  --arg repo "$(gh repo view --json nameWithOwner --jq '.nameWithOwner')" \
+  --arg base "main" \
+  '{ts: (now | todate), event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $sid,
+      interest_type: "pr_lifecycle",
+      notify_event: ("filter.wake." + $sid),
+      persistent: true,
+      pr_numbers: [$pr],
+      repo: $repo,
+      base_branches: [{pr: $pr, base: $base}],
+      session_id: $sid
+    }}' >> ~/catalyst/events/$(date -u +%Y-%m).jsonl
+```
+
+Events matched: `github.check_suite.completed`, `github.pr.merged`, `github.pr.closed`,
+`github.pr_review.submitted`, `github.pr_review_comment.created`, `github.pr_review_thread.resolved`,
+`github.deployment.created`, `github.deployment_status.*`, `github.push` (base-branch pushes).
+
+## 6. Groq Prose Registration (Unchanged)
+
+For complex / multi-condition interests, register with a natural-language prompt:
+
+```bash
+jq -nc \
+  --arg orch "${CATALYST_ORCHESTRATOR_ID:-}" \
+  --arg sid "$CATALYST_SESSION_ID" \
+  '{ts: (now | todate), event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $sid,
+      notify_event: ("filter.wake." + $sid),
+      prompt: "Wake me when any of my workers has a CI failure or gets changes-requested",
+      context: {pr_numbers: [501, 502], tickets: ["CTL-275", "CTL-276"]},
+      persistent: true
+    }}' >> ~/catalyst/events/$(date -u +%Y-%m).jsonl
+```
+
+Requires `GROQ_API_KEY` or `groq.apiKey` in `~/.config/catalyst/config.json`.
+
+## 7. Deregistration
+
+```bash
+jq -nc --arg sid "$CATALYST_SESSION_ID" \
+  '{ts: (now | todate), event: "filter.deregister",
+    detail: {interest_id: $sid}}' >> ~/catalyst/events/$(date -u +%Y-%m).jsonl
+```
+
+Auto-deregistration happens on:
+- `agent.checkout` for auto-correlated interests
+- Orchestrator termination (`orchestrator-completed` / `orchestrator-failed`)
+- One-shot interests after their first wake
+- Watchdog stale-session cleanup
+
+## 8. Querying Agent State
+
+The broker persists agent identity to SQLite (`~/catalyst/filter-state.db`). You can query it:
+
+```bash
+sqlite3 ~/catalyst/filter-state.db \
+  "SELECT agent_name, ticket, claimed_pr, status FROM agents WHERE status = 'active';"
+```
+
+## 9. Fallback When Broker Is Not Running
+
+```bash
+if ! catalyst-broker status | grep -q "^running"; then
+  # jq direct wait — no broker, no Groq
+  EVENT=$(catalyst-events wait-for \
+    --filter ".attributes.\"vcs.pr.number\" == ${PR_NUMBER}" \
+    --timeout 300 2>/dev/null || true)
+fi
+```

--- a/plugins/dev/skills/catalyst-comms/SKILL.md
+++ b/plugins/dev/skills/catalyst-comms/SKILL.md
@@ -7,6 +7,12 @@ description:
   other agent", or workers need to share state without HTTP.
 ---
 
+> **Consolidation in progress (CTL-303):** `catalyst-comms` is being subsumed into the
+> broker. Agent-to-agent messages already fan out to the broker's event log as
+> `comms.message.posted` events (every `send` writes to `~/catalyst/events/`), so the broker
+> can route messages using the same agent identity model as `agent.checkin`. The CLI verbs
+> documented here remain stable; this notice tracks the ongoing consolidation.
+
 # catalyst-comms — Agent Communication Protocol
 
 A file-based messaging system: each channel is a JSONL log at

--- a/plugins/dev/skills/catalyst-filter/SKILL.md
+++ b/plugins/dev/skills/catalyst-filter/SKILL.md
@@ -8,6 +8,12 @@ description:
   not running.
 ---
 
+> **Deprecated (CTL-303):** `catalyst-filter` has been superseded by `catalyst-broker`.
+> The broker daemon adds structured agent identity, `ticket_lifecycle` routing for Linear events,
+> and auto-correlation of ticket↔PR interests. All `filter.register` / `pr_lifecycle` / Groq prose
+> registration documented here continues to work unchanged — the daemon script (`catalyst-filter`)
+> is now a thin alias for `catalyst-broker`. See [[broker]] for the full updated reference.
+
 # catalyst-filter — Semantic Event Routing Protocol
 
 The `catalyst-filter` daemon sits between the raw catalyst event log and orchestrators. Instead

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -193,54 +193,56 @@ if [ -n "${CATALYST_COMMS_CHANNEL:-}" ] && [ -n "$COMMS_BIN" ]; then
   [ -f "$COMMS_CHANNEL_FILE" ] && COMMS_LAST_READ=$(wc -l < "$COMMS_CHANNEL_FILE" | tr -d ' ')
 fi
 
-# CTL-269: catalyst-filter registration helpers. The worker registers a single
-# semantic interest after PR creation that covers CI, comms, reviews, BEHIND,
-# and Linear ticket changes. The Phase 5 listen loop then waits on a single
-# `filter.wake.${CATALYST_SESSION_ID}` event instead of the per-concern jq
-# filters. When the daemon is not running, the loop falls back to the existing
-# direct `catalyst-events wait-for` pattern.
+# CTL-303: broker registration helpers. The worker uses agent.checkin auto-correlation
+# instead of explicit filter.register calls. After PR creation, a second agent.checkin
+# with claimed_pr set is all the broker needs to auto-derive a pr_lifecycle interest.
+# The Phase 5 listen loop waits on filter.wake.${CATALYST_SESSION_ID} as before.
+# When the daemon is not running, the loop falls back to direct catalyst-events wait-for.
 
-filter_daemon_running() {
-  command -v catalyst-filter >/dev/null 2>&1 || return 1
-  catalyst-filter status >/dev/null 2>&1
+broker_daemon_running() {
+  command -v catalyst-broker >/dev/null 2>&1 || \
+    command -v catalyst-filter >/dev/null 2>&1 || return 1
+  { catalyst-broker status 2>/dev/null || catalyst-filter status 2>/dev/null; } | grep -q "^running"
 }
 
-filter_register_worker() {
+# CTL-303: update claimed_pr in the broker via a second agent.checkin.
+# The broker auto-derives pr_lifecycle from the check-in — no explicit filter.register needed.
+broker_claim_pr() {
   # Args: $1 = PR_NUMBER, $2 = TICKET_ID, $3 = BRANCH_NAME, $4 = REPO (org/name), $5 = BASE_BRANCH (default: main)
-  # CTL-284: registers a built-in pr_lifecycle interest. The daemon routes PR
-  # events deterministically — no Groq round-trip — and persists merge-SHA →
-  # deployment correlations across restarts.
-  filter_daemon_running || return 1
+  broker_daemon_running || return 1
   [ -n "${CATALYST_SESSION_ID:-}" ] || return 1
-  local pr="$1" ticket="$2" branch="$3" repo="$4" base="${5:-main}"
+  local pr="$1" ticket="$2" repo="$4" base="${5:-main}"
+  local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   "$STATE_SCRIPT" event "$(jq -nc \
+    --arg ts "$ts" \
     --arg sid "$CATALYST_SESSION_ID" \
     --arg orch "${CATALYST_ORCHESTRATOR_ID:-}" \
-    --arg notify "filter.wake.${CATALYST_SESSION_ID}" \
     --argjson pr "$pr" \
     --arg ticket "$ticket" \
-    --arg branch "$branch" \
     --arg repo "$repo" \
     --arg base "$base" \
-    '{ts: (now | todate), event: "filter.register",
-      orchestrator: (if $orch == "" then null else $orch end),
-      worker: null,
+    '{ts: $ts, event: "agent.checkin",
       detail: {
-        interest_id: $sid,
         session_id: $sid,
-        interest_type: "pr_lifecycle",
-        notify_event: $notify,
-        persistent: true,
-        pr_numbers: [$pr],
+        ticket: (if $ticket == "" then null else $ticket end),
+        orchestrator: (if $orch == "" then null else $orch end),
+        claimed_pr: $pr,
         repo: $repo,
-        base_branches: [{pr: $pr, base: $base}],
-        context: {pr_numbers: [$pr], tickets: [$ticket], branches: [$branch], workers: [$sid]}
+        base_branches: [{pr: $pr, base: $base}]
       }}')" 2>/dev/null || return 1
   return 0
 }
 
+# Keep filter_register_worker as an alias for backward compat.
+# New code should use broker_claim_pr instead.
+filter_daemon_running() { broker_daemon_running; }
+filter_register_worker() {
+  local pr="$1" ticket="$2" branch="$3" repo="$4" base="${5:-main}"
+  broker_claim_pr "$pr" "$ticket" "$branch" "$repo" "$base"
+}
+
 filter_deregister_worker() {
-  filter_daemon_running || return 0
+  broker_daemon_running || return 0
   [ -n "${CATALYST_SESSION_ID:-}" ] || return 0
   "$STATE_SCRIPT" event "$(jq -nc \
     --arg sid "$CATALYST_SESSION_ID" \
@@ -661,18 +663,14 @@ TUNNEL=$(echo "$INFRA_STATUS" | jq -r '.webhookTunnel.state // "unknown"' 2>/dev
 USE_REST=false
 [ "$TUNNEL" != "running" ] && { echo "WARN: tunnel not running — using REST fallback"; USE_REST=true; }
 
-# CTL-269: register a single semantic interest covering CI, comms, reviews,
-# BEHIND, and Linear ticket changes. When this succeeds, the loop waits on a
-# single `filter.wake.${CATALYST_SESSION_ID}` event instead of running separate
-# jq filters for each concern. When it fails (daemon not running, no session id),
-# the loop falls back to the existing two-phase pattern below.
+# CTL-303: use broker auto-correlation. Emit a second agent.checkin with claimed_pr
+# so the broker auto-derives a pr_lifecycle interest — no explicit filter.register needed.
+# When the broker is not running, the loop falls back to the two-phase pattern below.
 USE_FILTER_DAEMON=false
-# CTL-284: pass repo + base branch so the daemon can populate filter_state for
-# deployment correlation and route base-branch pushes (PR is BEHIND).
 PR_BASE_BRANCH=$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "main")
-if filter_register_worker "$PR_NUMBER" "$TICKET_ID" "$(git branch --show-current)" "$REPO" "$PR_BASE_BRANCH"; then
+if broker_claim_pr "$PR_NUMBER" "$TICKET_ID" "$(git branch --show-current)" "$REPO" "$PR_BASE_BRANCH"; then
   USE_FILTER_DAEMON=true
-  echo "[Phase 5] Registered filter interest for session ${CATALYST_SESSION_ID}"
+  echo "[Phase 5] Broker registered pr_lifecycle for session ${CATALYST_SESSION_ID} on PR #${PR_NUMBER}"
 fi
 
 CI_FIX_ATTEMPTS=0

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -695,13 +695,15 @@ if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
 fi
 ```
 
-**Register with catalyst-filter daemon (CTL-257):** When `catalyst-filter status` returns 0,
-emit `filter.register` at Phase 4 start so the daemon pre-filters incoming events through Groq
-LLM and emits targeted `filter.wake.{ORCH_NAME}` events. This reduces the rate of wake-ups
-(and downstream `gh pr view` calls) compared to reacting to every raw GitHub webhook.
+**Register with catalyst-broker daemon (CTL-257, updated CTL-303):** When `catalyst-broker status`
+returns 0, emit `filter.register` at Phase 4 start so the daemon pre-filters incoming events and
+emits targeted `filter.wake.{ORCH_NAME}` events. Workers auto-correlate their own `pr_lifecycle`
+interests via `agent.checkin` — the orchestrator only needs to register the prose interest for
+comms-attention/ticket-status routing and the `pr_lifecycle` interest for orchestrator-level
+aggregation across all workers.
 
 ```bash
-if catalyst-filter status >/dev/null 2>&1; then
+if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
   ACTIVE_PRS=$(jq -rs '[.[].pr.number // empty] | unique' \
     "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
   ACTIVE_TICKETS=$(jq -rs '[.[].ticket // empty]' \
@@ -1025,10 +1027,12 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
       '.pr = ((.pr // {}) | .number = ($n | tonumber) | .url = $u)' \
       "$WORKER_SIGNAL" > "$WORKER_SIGNAL.tmp" && mv "$WORKER_SIGNAL.tmp" "$WORKER_SIGNAL"
 
-    # Refresh filter context with the newly discovered PR number (CTL-257).
+    # Refresh broker context with the newly discovered PR number (CTL-257, updated CTL-303).
     # Re-emitting filter.register with the same orchestrator key overwrites the prior registration.
     # CTL-284: also refresh the pr_lifecycle interest with the new PR number.
-    if catalyst-filter status >/dev/null 2>&1; then
+    # Note: workers auto-correlate their own pr_lifecycle via agent.checkin; this keeps the
+    # orchestrator-level aggregated interest up to date.
+    if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
       _UPD_PRS=$(jq -rs '[.[].pr.number // empty] | unique' \
         "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
       _UPD_TICKETS=$(jq -rs '[.[].ticket // empty]' \
@@ -1581,12 +1585,12 @@ Signal-file fields the script reads/writes:
 | `lastRebaseDispatchedAt` | orchestrate-auto-rebase    | Timestamp of the most recent dispatch (for the dashboard)  |
 | `rebaseCommit`           | rebase worker              | SHA of the rebased HEAD (written by the dispatched worker) |
 
-**Deregister from catalyst-filter (CTL-257):** When all workers in the current wave reach a
-terminal state and Phase 4 exits, emit `filter.deregister` so the daemon stops routing events
-to this orchestrator:
+**Deregister from catalyst-broker (CTL-257, updated CTL-303):** When all workers in the current
+wave reach a terminal state and Phase 4 exits, emit `filter.deregister` so the daemon stops
+routing events to this orchestrator:
 
 ```bash
-if catalyst-filter status >/dev/null 2>&1; then
+if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
   "$STATE_SCRIPT" event "$(jq -nc \
     --arg orch "${ORCH_NAME}" \
     '{ts: (now | todate), event: "filter.deregister", orchestrator: $orch, worker: null, detail: null}')" \


### PR DESCRIPTION
## Summary

- **`broker/`** replaces `filter-daemon/` with three new capabilities: structured agent identity (`agent.checkin`/`agent.checkout`), auto-correlation (no explicit `filter.register` needed for own PRs), and `ticket_lifecycle` interest type for deterministic Linear event routing
- **`catalyst-broker`** CLI added; `catalyst-filter` is now a thin `exec` shim for backward compat — all existing scripts continue to work unchanged
- **`catalyst-session.sh`** now emits `agent.checkin` on start and `agent.checkout` on end, enabling the broker to build the `agents` SQLite table automatically
- **Auto-correlation**: when an agent checks in with `claimed_pr`, broker auto-registers `pr_lifecycle`; when a PR opens linking a ticket, broker auto-registers for all ticket-watching agents
- **`ticket_lifecycle`** interest type: matches `linear.issue.state_changed`, `linear.comment.created`, `github.pr.opened/merged` with `wake_on` filtering — no Groq round-trip
- `oneshot/SKILL.md`: new `broker_claim_pr()` helper uses `agent.checkin claimed_pr` instead of explicit `filter.register`
- `orchestrate/SKILL.md`: Phase 4 checks `catalyst-broker` (falls back to `catalyst-filter` for older installs)
- Deprecation notices added to `catalyst-filter/SKILL.md` and `catalyst-comms/SKILL.md`

## Test plan

- [x] 71 broker tests pass (`bun test plugins/dev/scripts/broker/`)
- [x] 91 filter-daemon backward compat tests pass (`bun test plugins/dev/scripts/filter-daemon/`)
- [x] `catalyst-filter` shim delegates to `catalyst-broker` via `exec`
- [x] `agent.checkin` with `claimed_pr` auto-registers `pr_lifecycle`
- [x] `ticket_lifecycle` wake_on filtering (status_done, status_in_review, status_changed, comment_added, pr_opened, pr_merged)
- [x] Auto-correlation on `github.pr.opened` for ticket-watching agents
- [x] `agent.checkout` removes auto-correlated interests, preserves explicit ones

Closes CTL-303

🤖 Generated with [Claude Code](https://claude.com/claude-code)