### PR TITLE
fix(dev): resolve symlink before deriving SCRIPT_DIR in catalyst-hud

### DIFF
--- a/plugins/dev/scripts/catalyst-hud
+++ b/plugins/dev/scripts/catalyst-hud
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # catalyst-hud — Ink TUI for the catalyst event stream.
 # For SSH-from-iPad / minimal-deps fallback, use: catalyst-hud-classic
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 exec bun run "${SCRIPT_DIR}/orch-monitor/cli/hud.tsx" "$@"


### PR DESCRIPTION
## Summary
- `catalyst-hud` (the new Ink TUI entrypoint) used `${BASH_SOURCE[0]}` to derive `SCRIPT_DIR`, which resolves to the symlink's location rather than the real script. Running via a symlink in `~/.local/bin/` caused bun to look for `hud.tsx` in `~/.local/bin/orch-monitor/cli/` instead of the plugin cache.
- Fix: use `readlink -f` to resolve the symlink before computing `SCRIPT_DIR`.

## Test plan
- [ ] `ln -sf <plugin-cache>/scripts/catalyst-hud ~/.local/bin/catalyst-hud && catalyst-hud` launches the Ink TUI without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)