### PR TITLE
feat(dev): natural-language event query for catalyst-events + TUI (CTL-313)

### DIFF
--- a/plugins/dev/references/event-schema.md
+++ b/plugins/dev/references/event-schema.md
@@ -7,6 +7,11 @@ Derived directly from `plugins/dev/scripts/orch-monitor/lib/canonical-event.ts` 
 Use this when writing `catalyst-events wait-for --filter` or `catalyst-events tail --filter`
 expressions to avoid guessing field names. Wrong field names silently never match.
 
+For interactive/exploratory queries, use `catalyst-events query "<natural language>"`
+(see [[catalyst-events-query]]) — it translates English to a structured filter via Groq and
+validates field names against the same canonical schema documented here, so unknown fields
+fail loudly with a "did you mean" suggestion.
+
 This schema was introduced as a breaking cutover in CTL-300. All producers emit the canonical
 envelope. Legacy v1/v2 files on disk were rotated to `*.legacy.jsonl` on first canonical write.
 A future OTLP exporter sidecar (CTL-306) will transcode canonical JSONL to OTLP wire format.

--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -21,6 +21,8 @@
 #   tail [--filter <jq>] [--since-line <N>]
 #   wait-for [--filter <jq>] [--timeout <sec>]
 #   build-orchestrator-filter <orch-dir>
+#   query <natural-language>     [--explain] [--limit N] [--since DURATION]
+#                                [--dsl '<json>']  (Groq-bypass, for tests)
 #   help
 
 set -uo pipefail
@@ -331,17 +333,108 @@ cmd_build_orchestrator_filter() {
   printf ')\n'
 }
 
+# Translate a natural-language query through Groq into a structured DSL,
+# compile it to a jq predicate, and run it against the current month's event
+# log. With --explain, prints the DSL + compiled jq and exits without running.
+# With --dsl '<json>', skips Groq entirely (used by tests and power users).
+cmd_query() {
+  local nl="" explain="" limit="" since="" dsl_override=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --explain) explain=1; shift ;;
+      --limit)   limit="$2"; shift 2 ;;
+      --since)   since="$2"; shift 2 ;;
+      --dsl)     dsl_override="$2"; shift 2 ;;
+      -h|--help) cmd_help; return 0 ;;
+      --*) echo "error: unknown query flag: $1" >&2; return 2 ;;
+      *)
+        if [[ -z "$nl" ]]; then
+          nl="$1"; shift
+        else
+          echo "error: too many positional arguments to query" >&2
+          return 2
+        fi
+        ;;
+    esac
+  done
+
+  if [[ -z "$nl" && -z "$dsl_override" ]]; then
+    echo "error: query requires a natural-language argument or --dsl" >&2
+    return 2
+  fi
+
+  # Resolve the compiler script path relative to this bash script.
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local cli="$script_dir/lib/dsl-cli.mjs"
+  if [[ ! -f "$cli" ]]; then
+    echo "error: dsl-cli.mjs not found at $cli" >&2
+    return 1
+  fi
+
+  local cli_args=()
+  [[ -n "$nl" ]] && cli_args+=(--query "$nl")
+  [[ -n "$dsl_override" ]] && cli_args+=(--dsl "$dsl_override")
+  [[ -n "$explain" ]] && cli_args+=(--explain)
+  [[ -n "$limit" ]] && cli_args+=(--limit "$limit")
+  [[ -n "$since" ]] && cli_args+=(--since "$since")
+
+  # `local var=$(cmd)` masks $? on some bash versions; capture rc explicitly.
+  local compile_out rc
+  compile_out=$(node "$cli" "${cli_args[@]}")
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    return $rc
+  fi
+
+  if [[ -n "$explain" ]]; then
+    # Pretty-print for human consumption when explain mode is requested.
+    echo "$compile_out" | jq .
+    return 0
+  fi
+
+  local predicate sort_jq limit_jq
+  predicate=$(echo "$compile_out" | jq -r '.jqPredicate')
+  sort_jq=$(echo "$compile_out" | jq -r '.jqSort // empty')
+  limit_jq=$(echo "$compile_out" | jq -r '.jqLimit // empty')
+
+  local file
+  file="$(events_file_path)"
+  [[ ! -s "$file" ]] && return 0
+
+  if [[ -n "$sort_jq" || -n "$limit_jq" ]]; then
+    # sort/limit need the full match set, so we slurp via -s. The pipeline:
+    # 1. apply_filter narrows to matches, 2. -s collects them into an array,
+    # 3. apply sort_by | reverse / limit, 4. .[] re-streams as one-per-line.
+    local post=""
+    [[ -n "$sort_jq" ]] && post="${sort_jq}"
+    if [[ -n "$limit_jq" ]]; then
+      [[ -n "$post" ]] && post="${post} | ${limit_jq}" || post="${limit_jq}"
+    fi
+    apply_filter "$predicate" < "$file" | jq -sc "${post} | .[]"
+  else
+    apply_filter "$predicate" < "$file"
+  fi
+}
+
 cmd_help() {
   cat <<'EOF'
-catalyst-events — tail and wait-for primitives over the global event log.
+catalyst-events — tail, wait-for, and natural-language query over the global event log.
 
 Usage:
   catalyst-events tail [--filter <jq-predicate>] [--since-line <N>]
   catalyst-events wait-for [--filter <jq-predicate>] [--timeout <sec>]
   catalyst-events build-orchestrator-filter <orch-dir>
+  catalyst-events query <natural-language> [--explain] [--limit N] [--since DURATION]
   catalyst-events help
 
 Examples:
+  # Natural-language query (uses Groq + GROQ_API_KEY)
+  catalyst-events query "errors in the last hour"
+  catalyst-events query "all PR events for ADV-292 and ADV-293" --explain
+  catalyst-events query --dsl '{"filter":{"field":"severityText","eq":"ERROR"}}'
+
   # Tail all GitHub events live
   catalyst-events tail --filter '.event | startswith("github.")'
 
@@ -370,9 +463,15 @@ Environment:
   CATALYST_EVENTS_FILE  override file path entirely (used by tests)
 
 Exit codes:
-  0   wait-for: matched a line
+  0   wait-for: matched a line; query: success (zero matches is not an error)
   1   wait-for: timed out
-  2   usage error
+  2   usage error (unknown flag, missing required arg, bad --timeout)
+  3   query: Groq HTTP / parse / refused error
+  4   query: DSL validation error (unknown field, bad operator)
+
+Environment for query:
+  GROQ_API_KEY   Groq API key (falls back to ~/.config/catalyst/config.json::groq.apiKey)
+  FILTER_GROQ_MODEL  Groq model override (default: llama-3.1-8b-instant)
 EOF
 }
 
@@ -383,6 +482,7 @@ main() {
     tail)                       cmd_tail "$@" ;;
     wait-for)                   cmd_wait_for "$@" ;;
     build-orchestrator-filter)  cmd_build_orchestrator_filter "$@" ;;
+    query)                      cmd_query "$@" ;;
     help|-h|--help)             cmd_help ;;
     *)
       echo "error: unknown command: $cmd" >&2

--- a/plugins/dev/scripts/catalyst-events.query.test.sh
+++ b/plugins/dev/scripts/catalyst-events.query.test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# catalyst-events.query.test.sh — integration tests for the `query` subcommand.
+#
+# Tests use --dsl (Groq-bypass) so they never hit the network. They override
+# CATALYST_EVENTS_FILE to a temp fixture, exercise the predicate compilation
+# and output paths end-to-end, and assert exit codes match the documented
+# contract.
+#
+# Run: bash plugins/dev/scripts/catalyst-events.query.test.sh
+# Exits 0 on success, 1 on first failure.
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EVENTS_BIN="$SCRIPT_DIR/catalyst-events"
+
+if [[ ! -x "$EVENTS_BIN" ]]; then
+  echo "FAIL: $EVENTS_BIN not executable" >&2
+  exit 1
+fi
+
+# Disable broker daemon side effects from any inherited env.
+unset CATALYST_DIR
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FIXTURE="$TMP/events.jsonl"
+export CATALYST_EVENTS_FILE="$FIXTURE"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  ok: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected='$expected' actual='$actual'")
+    echo "  FAIL: $name"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    echo "  ok: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: missing needle='$needle' in '$haystack'")
+    echo "  FAIL: $name"
+    echo "    needle:   $needle"
+    echo "    haystack: $haystack"
+  fi
+}
+
+# ─── Fixture setup ────────────────────────────────────────────────────────────
+
+cat > "$FIXTURE" <<'JSONL'
+{"ts":"2026-05-08T14:00:00Z","severityText":"INFO","severityNumber":9,"traceId":null,"spanId":null,"resource":{"service.name":"catalyst.github"},"attributes":{"event.name":"github.pr.merged","vcs.pr.number":342,"vcs.repository.name":"coalesce-labs/catalyst","catalyst.worker.ticket":"CTL-313"},"body":{"message":"PR #342 merged","payload":{}}}
+{"ts":"2026-05-08T13:00:00Z","severityText":"ERROR","severityNumber":17,"traceId":null,"spanId":null,"resource":{"service.name":"catalyst.github"},"attributes":{"event.name":"github.workflow_run.completed","vcs.pr.number":343,"cicd.pipeline.run.conclusion":"failure"},"body":{"message":"CI failed","payload":{}}}
+{"ts":"2026-05-08T12:00:00Z","severityText":"INFO","severityNumber":9,"traceId":null,"spanId":null,"resource":{"service.name":"catalyst.linear"},"attributes":{"event.name":"linear.issue.state_changed","linear.issue.identifier":"ADV-292"},"body":{"message":"Issue moved","payload":{}}}
+{"ts":"2026-05-08T11:00:00Z","severityText":"INFO","severityNumber":9,"traceId":null,"spanId":null,"resource":{"service.name":"catalyst.session"},"attributes":{"event.name":"session.phase","catalyst.session.id":"sess_abc","catalyst.phase":3},"body":{"message":"implementing","payload":{}}}
+JSONL
+
+# ─── 1. --explain prints DSL + compiled jq ────────────────────────────────────
+
+echo "test: --explain prints compiled jq"
+EXPLAIN_DSL=$(cat <<'EOF'
+{"filter":{"field":"attributes.\"event.name\"","eq":"github.pr.merged"}}
+EOF
+)
+out=$("$EVENTS_BIN" query --explain --dsl "$EXPLAIN_DSL" 2>&1)
+rc=$?
+assert_eq "explain exit code" "0" "$rc"
+assert_contains "explain output contains jqPredicate" "jqPredicate" "$out"
+assert_contains "explain output contains compiled selector" 'github.pr.merged' "$out"
+
+# ─── 2. --dsl no-Groq round-trip filters the fixture ──────────────────────────
+
+echo "test: --dsl filters fixture (severity ERROR → 1 line)"
+out=$("$EVENTS_BIN" query --dsl '{"filter":{"field":"severityText","eq":"ERROR"}}')
+rc=$?
+assert_eq "filter exit code" "0" "$rc"
+line_count=$(printf '%s\n' "$out" | grep -c '^{')
+assert_eq "filter line count" "1" "$line_count"
+assert_contains "filter output contains the ERROR row" "github.workflow_run.completed" "$out"
+
+# ─── 3. zero matches returns exit 0, no output ────────────────────────────────
+
+echo "test: zero matches → exit 0, empty stdout"
+out=$("$EVENTS_BIN" query --dsl '{"filter":{"field":"severityText","eq":"NEVER"}}' 2>&1)
+rc=$?
+assert_eq "no-match exit code" "0" "$rc"
+assert_eq "no-match output empty" "" "$out"
+
+# ─── 4. unknown field → exit 4, error on stderr ───────────────────────────────
+
+echo "test: unknown field → exit 4"
+out=$("$EVENTS_BIN" query --dsl '{"filter":{"field":"bogus.field","eq":1}}' 2>&1)
+rc=$?
+assert_eq "unknown-field exit code" "4" "$rc"
+assert_contains "unknown-field error names the bad path" "bogus.field" "$out"
+
+# ─── 5. invalid DSL → exit 3 (Groq-response style error) ──────────────────────
+
+echo "test: malformed DSL JSON → exit 3"
+out=$("$EVENTS_BIN" query --dsl 'not valid json' 2>&1)
+rc=$?
+assert_eq "malformed-json exit code" "3" "$rc"
+
+# ─── 6. missing args → exit 2 ─────────────────────────────────────────────────
+
+echo "test: no query and no --dsl → exit 2"
+out=$("$EVENTS_BIN" query 2>&1)
+rc=$?
+assert_eq "no-args exit code" "2" "$rc"
+
+# ─── 7. unknown flag → exit 2 ─────────────────────────────────────────────────
+
+echo "test: unknown flag → exit 2"
+out=$("$EVENTS_BIN" query --bogus 2>&1)
+rc=$?
+assert_eq "unknown-flag exit code" "2" "$rc"
+
+# ─── 8. sort + limit operate over the slurped match set ───────────────────────
+
+echo "test: sort desc + limit 1 returns the most recent fixture event"
+out=$("$EVENTS_BIN" query --dsl '{"filter":{},"sort":{"field":"ts","order":"desc"},"limit":1}')
+rc=$?
+assert_eq "sort+limit exit code" "0" "$rc"
+line_count=$(printf '%s\n' "$out" | grep -c '^{')
+assert_eq "sort+limit line count" "1" "$line_count"
+assert_contains "sort+limit picked the most-recent ts" '"2026-05-08T14:00:00Z"' "$out"
+
+# ─── 9. --since pre-trims by ts ───────────────────────────────────────────────
+
+echo "test: --since 1s cuts off all fixture events"
+# Fixture events have fixed past timestamps (≤ 2026-05-08T14:00:00Z). --since 1s
+# means cutoff = now - 1s, which is in the future relative to the fixture, so
+# the cutoff is later than every event → 0 results.
+out=$("$EVENTS_BIN" query --dsl '{"filter":{}}' --since 1s)
+rc=$?
+assert_eq "--since exit code" "0" "$rc"
+line_count=$(printf '%s\n' "$out" | grep -c '^{')
+assert_eq "--since 1s cuts all old events" "0" "$line_count"
+
+echo "test: --since 365d keeps all fixture events"
+out=$("$EVENTS_BIN" query --dsl '{"filter":{}}' --since 365d)
+rc=$?
+assert_eq "--since 365d exit code" "0" "$rc"
+line_count=$(printf '%s\n' "$out" | grep -c '^{')
+assert_eq "--since 365d keeps all fixture events" "4" "$line_count"
+
+# ─── 10. complex AND filter on attribute path ─────────────────────────────────
+
+echo "test: AND of event.name + ticket"
+DSL=$(cat <<'EOF'
+{"filter":{"and":[{"field":"attributes.\"event.name\"","startsWith":"github.pr."},{"field":"attributes.\"catalyst.worker.ticket\"","eq":"CTL-313"}]}}
+EOF
+)
+out=$("$EVENTS_BIN" query --dsl "$DSL")
+rc=$?
+assert_eq "and-filter exit code" "0" "$rc"
+line_count=$(printf '%s\n' "$out" | grep -c '^{')
+assert_eq "and-filter matches one row" "1" "$line_count"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo
+echo "Pass: $PASS"
+echo "Fail: $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/lib/dsl-cli.mjs
+++ b/plugins/dev/scripts/lib/dsl-cli.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// dsl-cli.mjs — thin wrapper that the bash `cmd_query` shells to.
+//
+// Reads `--query "<nl>"` (Groq-translated) or `--dsl '<json>'` (Groq-bypassed)
+// and emits one JSON object on stdout:
+//   { dsl, jqPredicate, jqSort, jqLimit }
+//
+// On `--explain`, the same JSON is emitted but the bash caller skips
+// running the predicate. On error, prints a structured error to stderr and
+// exits with one of:
+//   2 — usage error
+//   3 — Groq HTTP / parse / refused error
+//   4 — DSL validation error (unknown field, bad operator)
+
+import {
+  compile,
+  groqTranslate,
+  parseGroqResponse,
+  readGroqApiKeyFromConfig,
+  rewriteNode,
+  DslError,
+  GroqHttpError,
+  GroqResponseError,
+} from "./dsl-compile.mjs";
+import { SYSTEM_PROMPT } from "./dsl-prompt.mjs";
+
+function parseArgs(argv) {
+  const out = { query: null, dsl: null, explain: false, limit: null, since: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--query":   out.query = argv[++i]; break;
+      case "--dsl":     out.dsl = argv[++i]; break;
+      case "--explain": out.explain = true; break;
+      case "--limit":   out.limit = parseInt(argv[++i], 10); break;
+      case "--since":   out.since = argv[++i]; break;
+      case "-h":
+      case "--help":
+        printUsage();
+        process.exit(0);
+      default:
+        process.stderr.write(`error: unknown flag: ${a}\n`);
+        process.exit(2);
+    }
+  }
+  return out;
+}
+
+function printUsage() {
+  process.stderr.write(`usage: dsl-cli.mjs (--query "<nl>" | --dsl '<json>') [--explain] [--limit N] [--since DURATION]\n`);
+}
+
+// Convert --since "1h" / "30m" / "today" into an extra ts gte clause
+// AND-merged onto the DSL filter. Relative only in v1.
+function applySinceFlag(dsl, since) {
+  if (!since) return dsl;
+  let isoCutoff;
+  if (since === "today") {
+    const d = new Date();
+    isoCutoff = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())).toISOString();
+  } else {
+    const m = since.match(/^(\d+)([smhd])$/);
+    if (!m) {
+      throw new DslError(`--since must be 'today' or N[smhd] (e.g. '30m', '2h')`, { code: "invalid" });
+    }
+    const n = parseInt(m[1], 10);
+    const mult = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2]];
+    isoCutoff = new Date(Date.now() - n * mult).toISOString();
+  }
+  const cutoffLeaf = { field: "ts", gte: isoCutoff };
+  const existing = dsl.filter ?? {};
+  const merged = Object.keys(existing).length === 0
+    ? cutoffLeaf
+    : { and: [existing, cutoffLeaf] };
+  return { ...dsl, filter: merged };
+}
+
+function applyLimitFlag(dsl, limit) {
+  if (limit === null || limit === undefined) return dsl;
+  return { ...dsl, limit };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.query == null && args.dsl == null) {
+    process.stderr.write("error: --query or --dsl required\n");
+    printUsage();
+    process.exit(2);
+  }
+
+  let dsl;
+  try {
+    if (args.dsl != null) {
+      dsl = parseGroqResponse(args.dsl);
+    } else {
+      const apiKey = process.env.GROQ_API_KEY || readGroqApiKeyFromConfig();
+      dsl = await groqTranslate(args.query, { apiKey, systemPrompt: SYSTEM_PROMPT });
+    }
+  } catch (err) {
+    return reportError(err);
+  }
+
+  // Time placeholders → ISO; --since → extra ts clause; --limit override.
+  if (dsl.filter) dsl.filter = rewriteNode(dsl.filter);
+  if (args.since) {
+    try { dsl = applySinceFlag(dsl, args.since); } catch (err) { return reportError(err); }
+  }
+  if (args.limit !== null) dsl = applyLimitFlag(dsl, args.limit);
+
+  let compiled;
+  try {
+    compiled = compile(dsl);
+  } catch (err) {
+    return reportError(err);
+  }
+
+  process.stdout.write(JSON.stringify({
+    dsl,
+    jqPredicate: compiled.jqPredicate,
+    jqSort: compiled.jqSort,
+    jqLimit: compiled.jqLimit,
+    explain: args.explain,
+  }) + "\n");
+}
+
+function reportError(err) {
+  if (err instanceof DslError) {
+    const payload = { error: err.message, code: err.code };
+    if (err.field) payload.field = err.field;
+    if (err.suggestion) payload.suggestion = err.suggestion;
+    process.stderr.write(JSON.stringify(payload) + "\n");
+    process.exit(err.code === "unknown_field" || err.code === "invalid" ? 4 : 3);
+  }
+  if (err instanceof GroqHttpError) {
+    process.stderr.write(JSON.stringify({
+      error: err.message, code: "groq_http", status: err.status, body: err.body,
+    }) + "\n");
+    process.exit(3);
+  }
+  if (err instanceof GroqResponseError) {
+    process.stderr.write(JSON.stringify({
+      error: err.message, code: "groq_response", raw: err.raw,
+    }) + "\n");
+    process.exit(3);
+  }
+  process.stderr.write(`error: ${err.message ?? String(err)}\n`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  process.stderr.write(`fatal: ${err.stack ?? err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/plugins/dev/scripts/lib/dsl-compile.d.mts
+++ b/plugins/dev/scripts/lib/dsl-compile.d.mts
@@ -1,0 +1,77 @@
+// Type declarations for dsl-compile.mjs — kept in sync manually with the
+// runtime module. The TUI consumes these; the bash CLI does not need types.
+
+export class DslError extends Error {
+  code: "invalid" | "unknown_field" | "refused" | "groq_rejected";
+  field?: string;
+  suggestion?: string | null;
+  constructor(message: string, opts?: { code?: DslError["code"]; field?: string; suggestion?: string | null });
+}
+
+export class GroqHttpError extends Error {
+  status: number;
+  body?: string;
+  constructor(message: string, opts?: { status?: number; body?: string });
+}
+
+export class GroqResponseError extends Error {
+  raw?: string;
+  constructor(message: string, opts?: { raw?: string; cause?: unknown });
+}
+
+export interface DslLeaf {
+  field: string;
+  eq?: unknown; ne?: unknown;
+  gt?: unknown; gte?: unknown; lt?: unknown; lte?: unknown;
+  in?: unknown[];
+  startsWith?: string; endsWith?: string; contains?: string;
+  exists?: boolean;
+}
+
+export type DslNode =
+  | { and: DslNode[] }
+  | { or: DslNode[] }
+  | { not: DslNode }
+  | DslLeaf
+  | Record<string, never>;
+
+export interface Dsl {
+  filter?: DslNode;
+  sort?: { field: string; order?: "asc" | "desc" } | null;
+  limit?: number | null;
+  error?: string;
+}
+
+export interface CompiledDsl {
+  jqPredicate: string;
+  jqSort: string | null;
+  jqLimit: string | null;
+  jsPredicate: (event: unknown) => boolean;
+}
+
+export function validateField(path: string): { ok: true } | { ok: false; error: string; suggestion: string | null };
+export function getField(event: unknown, path: string): unknown;
+export function evalJs(node: DslNode, event: unknown): boolean;
+export function compileJq(node: DslNode): string;
+export function compileSort(spec: { field: string; order?: "asc" | "desc" } | null | undefined): string | null;
+export function compileLimit(n: number | null | undefined): string | null;
+export function compile(dsl: Dsl): CompiledDsl;
+
+export function readGroqApiKeyFromConfig(configPath?: string): string;
+export function parseGroqResponse(raw: string): Dsl;
+export function groqTranslate(
+  nlText: string,
+  opts: {
+    apiKey: string;
+    model?: string;
+    fetchImpl?: typeof fetch;
+    systemPrompt: string;
+  },
+): Promise<Dsl>;
+
+export function rewriteTimePlaceholders(value: unknown): unknown;
+export function rewriteNode<T>(node: T): T;
+
+export const CANONICAL_FIELDS: ReadonlyArray<{ path: string; type: string; description: string }>;
+export const FIELD_PATH_SET: ReadonlySet<string>;
+export function suggestField(path: string, maxDistance?: number): string | null;

--- a/plugins/dev/scripts/lib/dsl-compile.mjs
+++ b/plugins/dev/scripts/lib/dsl-compile.mjs
@@ -1,0 +1,374 @@
+// dsl-compile.mjs — DSL → jq predicate (CLI), DSL → JS predicate (TUI), and
+// Groq translation entry point for CTL-313.
+//
+// Single source of truth for query semantics. The bash CLI and the Ink TUI
+// both import from this module so behavior cannot drift.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import {
+  CANONICAL_FIELDS,
+  FIELD_PATH_SET,
+  isWhitelistedField,
+  suggestField,
+} from "./dsl-fields.mjs";
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+//
+// We expose three distinct error classes so callers (the CLI, the TUI) can
+// branch on cause without parsing message text. CLAUDE.md no-silent-fallbacks:
+// every internal failure surfaces as one of these, never as a fall-through.
+
+export class DslError extends Error {
+  constructor(message, { code, field, suggestion } = {}) {
+    super(message);
+    this.name = "DslError";
+    this.code = code ?? "invalid";
+    if (field !== undefined) this.field = field;
+    if (suggestion !== undefined) this.suggestion = suggestion;
+  }
+}
+
+export class GroqHttpError extends Error {
+  constructor(message, { status, body } = {}) {
+    super(message);
+    this.name = "GroqHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export class GroqResponseError extends Error {
+  constructor(message, { raw, cause } = {}) {
+    super(message);
+    this.name = "GroqResponseError";
+    this.raw = raw;
+    if (cause) this.cause = cause;
+  }
+}
+
+// ─── Field validation ────────────────────────────────────────────────────────
+
+export function validateField(path) {
+  if (typeof path !== "string" || path.length === 0) {
+    return { ok: false, error: "field must be a non-empty string", suggestion: null };
+  }
+  if (isWhitelistedField(path)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    error: `unknown field: ${path}`,
+    suggestion: suggestField(path),
+  };
+}
+
+// ─── Path access (JS evaluator helper) ───────────────────────────────────────
+//
+// Splits a jq-style path like `attributes."event.name"` or
+// `resource."service.name"` into segments and walks the event object.
+// We only need to support the exact paths in CANONICAL_FIELDS; we don't
+// implement the full jq grammar.
+
+function splitPath(path) {
+  const segments = [];
+  let i = 0;
+  while (i < path.length) {
+    if (path[i] === ".") { i++; continue; }
+    if (path[i] === '"') {
+      const end = path.indexOf('"', i + 1);
+      if (end === -1) throw new Error(`unterminated quoted segment in path: ${path}`);
+      segments.push(path.slice(i + 1, end));
+      i = end + 1;
+    } else {
+      let end = i;
+      while (end < path.length && path[end] !== "." && path[end] !== '"') end++;
+      segments.push(path.slice(i, end));
+      i = end;
+    }
+  }
+  return segments;
+}
+
+export function getField(event, path) {
+  const segments = splitPath(path);
+  let cur = event;
+  for (const seg of segments) {
+    if (cur === null || cur === undefined) return undefined;
+    cur = cur[seg];
+  }
+  return cur;
+}
+
+// ─── JS evaluator (TUI) ──────────────────────────────────────────────────────
+
+export function evalJs(node, event) {
+  if (!node || typeof node !== "object") {
+    throw new DslError("filter node must be an object", { code: "invalid" });
+  }
+  if (Array.isArray(node)) {
+    throw new DslError("filter node cannot be an array", { code: "invalid" });
+  }
+  if ("and" in node) {
+    if (!Array.isArray(node.and)) throw new DslError("'and' must be an array", { code: "invalid" });
+    return node.and.every((sub) => evalJs(sub, event));
+  }
+  if ("or" in node) {
+    if (!Array.isArray(node.or)) throw new DslError("'or' must be an array", { code: "invalid" });
+    return node.or.some((sub) => evalJs(sub, event));
+  }
+  if ("not" in node) {
+    return !evalJs(node.not, event);
+  }
+  if (Object.keys(node).length === 0) {
+    return true;
+  }
+  if (typeof node.field !== "string") {
+    throw new DslError("leaf node missing 'field'", { code: "invalid" });
+  }
+  const v = getField(event, node.field);
+  return evalLeaf(node, v);
+}
+
+function evalLeaf(leaf, v) {
+  if ("eq" in leaf)         return v === leaf.eq;
+  if ("ne" in leaf)         return v !== leaf.ne;
+  if ("gt" in leaf)         return v !== undefined && v !== null && v > leaf.gt;
+  if ("gte" in leaf)        return v !== undefined && v !== null && v >= leaf.gte;
+  if ("lt" in leaf)         return v !== undefined && v !== null && v < leaf.lt;
+  if ("lte" in leaf)        return v !== undefined && v !== null && v <= leaf.lte;
+  if ("in" in leaf) {
+    if (!Array.isArray(leaf.in)) throw new DslError("'in' must be an array", { code: "invalid" });
+    return leaf.in.includes(v);
+  }
+  if ("startsWith" in leaf) return typeof v === "string" && v.startsWith(leaf.startsWith);
+  if ("endsWith" in leaf)   return typeof v === "string" && v.endsWith(leaf.endsWith);
+  if ("contains" in leaf)   return typeof v === "string" && v.includes(leaf.contains);
+  if ("exists" in leaf)     return leaf.exists ? (v !== undefined && v !== null) : (v === undefined || v === null);
+  const ops = Object.keys(leaf).filter((k) => k !== "field");
+  throw new DslError(`unknown leaf operator: ${ops.join(", ")}`, { code: "invalid" });
+}
+
+// ─── jq compiler (CLI) ───────────────────────────────────────────────────────
+//
+// Each leaf compiles to a parenthesized jq fragment. We use `// ""` then
+// `tostring` for string operators so a null/missing field yields false rather
+// than a runtime jq error — but the comparison still requires the LHS to
+// actually be a string. (`null | tostring` → `"null"` which would silently
+// match `startsWith("n")`; we avoid that by using `// ""` first.)
+
+function jqLiteral(v) {
+  if (v === null) return "null";
+  if (typeof v === "string") return JSON.stringify(v);
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  throw new DslError(`unsupported literal type: ${typeof v}`, { code: "invalid" });
+}
+
+function jqLiteralStream(arr) {
+  return arr.map(jqLiteral).join(", ");
+}
+
+function compileLeaf(leaf) {
+  if (typeof leaf.field !== "string") {
+    throw new DslError("leaf node missing 'field'", { code: "invalid" });
+  }
+  const v = validateField(leaf.field);
+  if (!v.ok) {
+    throw new DslError(v.error, { code: "unknown_field", field: leaf.field, suggestion: v.suggestion });
+  }
+  const path = `.${leaf.field}`;
+  if ("eq" in leaf)  return `(${path} == ${jqLiteral(leaf.eq)})`;
+  if ("ne" in leaf)  return `(${path} != ${jqLiteral(leaf.ne)})`;
+  if ("gt" in leaf)  return `(${path} != null and ${path} > ${jqLiteral(leaf.gt)})`;
+  if ("gte" in leaf) return `(${path} != null and ${path} >= ${jqLiteral(leaf.gte)})`;
+  if ("lt" in leaf)  return `(${path} != null and ${path} < ${jqLiteral(leaf.lt)})`;
+  if ("lte" in leaf) return `(${path} != null and ${path} <= ${jqLiteral(leaf.lte)})`;
+  if ("in" in leaf) {
+    if (!Array.isArray(leaf.in)) throw new DslError("'in' must be an array", { code: "invalid" });
+    return `(${path} | IN(${jqLiteralStream(leaf.in)}))`;
+  }
+  if ("startsWith" in leaf) return `((${path} // "") | tostring | startswith(${jqLiteral(leaf.startsWith)}))`;
+  if ("endsWith" in leaf)   return `((${path} // "") | tostring | endswith(${jqLiteral(leaf.endsWith)}))`;
+  if ("contains" in leaf)   return `((${path} // "") | tostring | contains(${jqLiteral(leaf.contains)}))`;
+  if ("exists" in leaf)     return leaf.exists ? `(${path} != null)` : `(${path} == null)`;
+  const ops = Object.keys(leaf).filter((k) => k !== "field");
+  throw new DslError(`unknown leaf operator: ${ops.join(", ")}`, { code: "invalid" });
+}
+
+export function compileJq(node) {
+  if (!node || typeof node !== "object" || Array.isArray(node)) {
+    throw new DslError("filter node must be an object", { code: "invalid" });
+  }
+  if ("and" in node) {
+    if (!Array.isArray(node.and)) throw new DslError("'and' must be an array", { code: "invalid" });
+    if (node.and.length === 0) return "true";
+    return `(${node.and.map(compileJq).join(" and ")})`;
+  }
+  if ("or" in node) {
+    if (!Array.isArray(node.or)) throw new DslError("'or' must be an array", { code: "invalid" });
+    if (node.or.length === 0) return "false";
+    return `(${node.or.map(compileJq).join(" or ")})`;
+  }
+  if ("not" in node) {
+    // jq's `not` is a postfix filter: `value | not`, not a prefix function.
+    return `((${compileJq(node.not)}) | not)`;
+  }
+  if (Object.keys(node).length === 0) return "true";
+  return compileLeaf(node);
+}
+
+export function compileSort(spec) {
+  if (spec === null || spec === undefined) return null;
+  if (typeof spec !== "object" || Array.isArray(spec)) {
+    throw new DslError("sort must be an object or null", { code: "invalid" });
+  }
+  if (typeof spec.field !== "string") {
+    throw new DslError("sort.field must be a string", { code: "invalid" });
+  }
+  const v = validateField(spec.field);
+  if (!v.ok) {
+    throw new DslError(v.error, { code: "unknown_field", field: spec.field, suggestion: v.suggestion });
+  }
+  const order = spec.order ?? "asc";
+  if (order !== "asc" && order !== "desc") {
+    throw new DslError(`sort.order must be 'asc' or 'desc'`, { code: "invalid" });
+  }
+  const base = `sort_by(.${spec.field})`;
+  return order === "desc" ? `${base} | reverse` : base;
+}
+
+export function compileLimit(n) {
+  if (n === null || n === undefined) return null;
+  if (typeof n !== "number" || !Number.isInteger(n) || n < 0) {
+    throw new DslError("limit must be a non-negative integer", { code: "invalid" });
+  }
+  return `.[:${n}]`;
+}
+
+// ─── Time-placeholder rewriting ──────────────────────────────────────────────
+//
+// The Groq prompt instructs the model to emit placeholders like `{NOW-1h}` or
+// `{TODAY}` rather than concrete ISO timestamps, since the model has no
+// reliable clock. Callers (CLI and TUI) rewrite these to real ISO strings
+// after parsing the DSL and before compiling, so the predicate is always
+// resolved against the time of *evaluation*, not of generation.
+
+export function rewriteTimePlaceholders(value) {
+  if (typeof value !== "string") return value;
+  if (value === "{TODAY}") {
+    const d = new Date();
+    return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())).toISOString();
+  }
+  const m = value.match(/^\{NOW(?:-(\d+)([smhd]))?\}$/);
+  if (!m) return value;
+  const n = m[1] ? parseInt(m[1], 10) : 0;
+  const unit = m[2] ?? "s";
+  const mult = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[unit] ?? 1000;
+  return new Date(Date.now() - n * mult).toISOString();
+}
+
+export function rewriteNode(node) {
+  if (!node || typeof node !== "object") return node;
+  if (Array.isArray(node)) return node.map(rewriteNode);
+  const out = {};
+  for (const [k, v] of Object.entries(node)) {
+    if (k === "and" || k === "or") out[k] = v.map(rewriteNode);
+    else if (k === "not") out[k] = rewriteNode(v);
+    else if (typeof v === "string") out[k] = rewriteTimePlaceholders(v);
+    else out[k] = v;
+  }
+  return out;
+}
+
+// ─── Top-level entry point ───────────────────────────────────────────────────
+
+export function compile(dsl) {
+  if (!dsl || typeof dsl !== "object" || Array.isArray(dsl)) {
+    throw new DslError("dsl must be an object", { code: "invalid" });
+  }
+  const filter = dsl.filter ?? {};
+  const jqPredicate = compileJq(filter);
+  const jqSort = compileSort(dsl.sort ?? null);
+  const jqLimit = compileLimit(dsl.limit ?? null);
+  const jsPredicate = (event) => evalJs(filter, event);
+  return { jqPredicate, jqSort, jqLimit, jsPredicate };
+}
+
+// ─── Groq client ─────────────────────────────────────────────────────────────
+
+const GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions";
+const DEFAULT_GROQ_MODEL = "llama-3.1-8b-instant";
+
+export function readGroqApiKeyFromConfig(configPath) {
+  const path = configPath ?? resolve(homedir(), ".config/catalyst/config.json");
+  try {
+    const cfg = JSON.parse(readFileSync(path, "utf8"));
+    return cfg?.groq?.apiKey ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function parseGroqResponse(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new GroqResponseError("Groq returned non-JSON output", { raw, cause: err });
+  }
+  if (parsed && typeof parsed === "object" && typeof parsed.error === "string") {
+    const reason = parsed.error.toLowerCase();
+    let code = "refused";
+    if (reason.includes("unknown field")) code = "unknown_field";
+    else if (reason.startsWith("refused")) code = "refused";
+    else code = "groq_rejected";
+    throw new DslError(parsed.error, { code });
+  }
+  return parsed;
+}
+
+export async function groqTranslate(nlText, opts = {}) {
+  const { apiKey, model, fetchImpl, systemPrompt } = opts;
+  if (!apiKey) {
+    throw new GroqHttpError("GROQ_API_KEY is not set — cannot translate query", { status: 0 });
+  }
+  if (!systemPrompt) {
+    throw new Error("groqTranslate requires opts.systemPrompt — see lib/dsl-prompt.mjs");
+  }
+  const f = fetchImpl ?? globalThis.fetch;
+  const res = await f(GROQ_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: model ?? DEFAULT_GROQ_MODEL,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: nlText },
+      ],
+      temperature: 0,
+      max_tokens: 512,
+      response_format: { type: "json_object" },
+    }),
+  });
+  if (!res.ok) {
+    const body = await safeText(res);
+    throw new GroqHttpError(`Groq HTTP ${res.status}`, { status: res.status, body });
+  }
+  const json = await res.json();
+  const content = json?.choices?.[0]?.message?.content;
+  if (typeof content !== "string") {
+    throw new GroqResponseError("Groq response missing choices[0].message.content", { raw: JSON.stringify(json) });
+  }
+  return parseGroqResponse(content);
+}
+
+async function safeText(res) {
+  try { return await res.text(); } catch { return "<unreadable response body>"; }
+}
+
+// Re-export so the test file and the CLI have one import path.
+export { CANONICAL_FIELDS, FIELD_PATH_SET, suggestField };

--- a/plugins/dev/scripts/lib/dsl-compile.test.mjs
+++ b/plugins/dev/scripts/lib/dsl-compile.test.mjs
@@ -1,0 +1,686 @@
+// dsl-compile.test.mjs — DSL compiler + evaluator tests for CTL-313.
+// Run: bun test plugins/dev/scripts/lib/dsl-compile.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  CANONICAL_FIELDS,
+  FIELD_PATH_SET,
+  isWhitelistedField,
+  suggestField,
+  levenshtein,
+} from "./dsl-fields.mjs";
+
+import {
+  validateField,
+  getField,
+  evalJs,
+  compileJq,
+  compileSort,
+  compileLimit,
+  compile,
+  parseGroqResponse,
+  DslError,
+  GroqResponseError,
+} from "./dsl-compile.mjs";
+
+// ─── Phase 1 — whitelist ─────────────────────────────────────────────────────
+
+describe("CANONICAL_FIELDS whitelist", () => {
+  test("contains the documented count of canonical fields", () => {
+    expect(CANONICAL_FIELDS.length).toBe(31);
+    expect(FIELD_PATH_SET.size).toBe(31);
+  });
+
+  test("includes core attribute paths", () => {
+    expect(isWhitelistedField('attributes."event.name"')).toBe(true);
+    expect(isWhitelistedField('attributes."vcs.pr.number"')).toBe(true);
+    expect(isWhitelistedField('attributes."catalyst.worker.ticket"')).toBe(true);
+    expect(isWhitelistedField('attributes."deployment.environment"')).toBe(true);
+  });
+
+  test("includes top-level fields", () => {
+    expect(isWhitelistedField("ts")).toBe(true);
+    expect(isWhitelistedField("severityText")).toBe(true);
+    expect(isWhitelistedField("severityNumber")).toBe(true);
+    expect(isWhitelistedField("traceId")).toBe(true);
+    expect(isWhitelistedField('resource."service.name"')).toBe(true);
+    expect(isWhitelistedField("body.message")).toBe(true);
+  });
+
+  test("rejects arbitrary body.payload paths", () => {
+    expect(isWhitelistedField("body.payload.foo")).toBe(false);
+    expect(isWhitelistedField("body.payload")).toBe(false);
+  });
+});
+
+describe("validateField", () => {
+  test("accepts whitelisted paths", () => {
+    expect(validateField('attributes."event.name"').ok).toBe(true);
+    expect(validateField("severityText").ok).toBe(true);
+  });
+
+  test("rejects unknown fields with the bad path in the error", () => {
+    const r = validateField('attributes."foo.bar"');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('attributes."foo.bar"');
+  });
+
+  test("offers a near-miss suggestion when one exists", () => {
+    const r = validateField('attributes."vcs.pr.numbr"');
+    expect(r.ok).toBe(false);
+    expect(r.suggestion).toBe('attributes."vcs.pr.number"');
+  });
+
+  test("offers no suggestion when nothing is close", () => {
+    const r = validateField('completely.different.path.with.no.relation');
+    expect(r.ok).toBe(false);
+    expect(r.suggestion).toBeNull();
+  });
+
+  test("rejects empty / non-string inputs", () => {
+    expect(validateField("").ok).toBe(false);
+    expect(validateField(null).ok).toBe(false);
+    expect(validateField(undefined).ok).toBe(false);
+    expect(validateField(42).ok).toBe(false);
+  });
+});
+
+describe("levenshtein", () => {
+  test("computes simple distances", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+    expect(levenshtein("foo", "foo")).toBe(0);
+    expect(levenshtein("", "foo")).toBe(3);
+    expect(levenshtein("foo", "")).toBe(3);
+  });
+});
+
+describe("suggestField", () => {
+  test("returns null when no entry is within maxDistance", () => {
+    expect(suggestField("xxxxxxxx", 1)).toBeNull();
+  });
+
+  test("returns the closest whitelisted path within distance", () => {
+    expect(suggestField('attributes."vcs.pr.numbr"', 4)).toBe('attributes."vcs.pr.number"');
+  });
+});
+
+// ─── Phase 1 — getField path walk ────────────────────────────────────────────
+
+describe("getField path walk", () => {
+  const event = {
+    ts: "2026-05-08T14:00:00Z",
+    severityText: "INFO",
+    severityNumber: 9,
+    resource: { "service.name": "catalyst.github" },
+    attributes: {
+      "event.name": "github.pr.merged",
+      "vcs.pr.number": 342,
+      "catalyst.worker.ticket": "CTL-313",
+    },
+    body: { message: "PR #342 merged", payload: { merged: true } },
+  };
+
+  test("walks unquoted segments", () => {
+    expect(getField(event, "ts")).toBe("2026-05-08T14:00:00Z");
+    expect(getField(event, "severityText")).toBe("INFO");
+    expect(getField(event, "severityNumber")).toBe(9);
+    expect(getField(event, "body.message")).toBe("PR #342 merged");
+  });
+
+  test("walks quoted dotted segments", () => {
+    expect(getField(event, 'attributes."event.name"')).toBe("github.pr.merged");
+    expect(getField(event, 'attributes."vcs.pr.number"')).toBe(342);
+    expect(getField(event, 'resource."service.name"')).toBe("catalyst.github");
+  });
+
+  test("returns undefined for missing path components", () => {
+    expect(getField(event, "missing")).toBeUndefined();
+    expect(getField(event, 'attributes."does.not.exist"')).toBeUndefined();
+    expect(getField(event, "body.message.foo")).toBeUndefined();
+  });
+
+  test("does not coerce nulls into objects", () => {
+    expect(getField({ a: null }, "a.b")).toBeUndefined();
+  });
+});
+
+// ─── Phase 1 — JS evaluator ──────────────────────────────────────────────────
+
+const sampleEvent = {
+  ts: "2026-05-08T14:07:37.105Z",
+  severityText: "INFO",
+  severityNumber: 9,
+  traceId: null,
+  spanId: null,
+  resource: { "service.name": "catalyst.github" },
+  attributes: {
+    "event.name": "github.pr.merged",
+    "event.entity": "pr",
+    "vcs.repository.name": "coalesce-labs/catalyst",
+    "vcs.pr.number": 342,
+    "catalyst.worker.ticket": "CTL-313",
+  },
+  body: { message: "PR #342 merged in coalesce-labs/catalyst", payload: { merged: true } },
+};
+
+describe("evalJs leaf operators", () => {
+  test("eq matches strings and numbers", () => {
+    expect(evalJs({ field: 'attributes."event.name"', eq: "github.pr.merged" }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: 'attributes."vcs.pr.number"', eq: 342 }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: 'attributes."vcs.pr.number"', eq: "342" }, sampleEvent)).toBe(false);
+  });
+
+  test("ne is the inverse of eq", () => {
+    expect(evalJs({ field: 'attributes."event.name"', ne: "github.pr.merged" }, sampleEvent)).toBe(false);
+    expect(evalJs({ field: 'attributes."event.name"', ne: "github.pr.opened" }, sampleEvent)).toBe(true);
+  });
+
+  test("gt/gte/lt/lte handle numbers and strings (ISO timestamps)", () => {
+    expect(evalJs({ field: "severityNumber", gte: 9 }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: "severityNumber", gt: 9 }, sampleEvent)).toBe(false);
+    expect(evalJs({ field: "severityNumber", lt: 13 }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: "ts", gte: "2026-05-08T00:00:00Z" }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: "ts", lt: "2026-05-08T00:00:00Z" }, sampleEvent)).toBe(false);
+  });
+
+  test("gt/gte do not match null/undefined silently", () => {
+    expect(evalJs({ field: "traceId", gt: "" }, sampleEvent)).toBe(false);
+  });
+
+  test("in matches set membership", () => {
+    expect(evalJs({ field: 'attributes."catalyst.worker.ticket"', in: ["CTL-313", "CTL-300"] }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: 'attributes."catalyst.worker.ticket"', in: ["CTL-1"] }, sampleEvent)).toBe(false);
+  });
+
+  test("startsWith / endsWith / contains handle null without coercion", () => {
+    expect(evalJs({ field: 'attributes."event.name"', startsWith: "github.pr." }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: 'attributes."event.name"', endsWith: ".merged" }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: 'attributes."event.name"', contains: "pr.mer" }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: "traceId", startsWith: "n" }, sampleEvent)).toBe(false);
+    expect(evalJs({ field: "missing.path.here", startsWith: "" }, sampleEvent)).toBe(false);
+  });
+
+  test("exists distinguishes null/undefined from present", () => {
+    expect(evalJs({ field: 'attributes."event.name"', exists: true }, sampleEvent)).toBe(true);
+    expect(evalJs({ field: "traceId", exists: true }, sampleEvent)).toBe(false);
+    expect(evalJs({ field: "traceId", exists: false }, sampleEvent)).toBe(true);
+  });
+
+  test("unknown leaf operator throws DslError naming the operator", () => {
+    expect(() => evalJs({ field: "ts", unknownOp: 1 }, sampleEvent)).toThrow(DslError);
+    try {
+      evalJs({ field: "ts", unknownOp: 1 }, sampleEvent);
+    } catch (e) {
+      expect(e.message).toContain("unknownOp");
+    }
+  });
+});
+
+describe("evalJs combinators", () => {
+  test("and short-circuits on false", () => {
+    let calls = 0;
+    const rec = (val) => {
+      const node = { field: "ts", eq: val };
+      const wrapper = new Proxy(node, { get(t, k) { calls++; return t[k]; } });
+      return wrapper;
+    };
+    void rec; // sentinel to keep proxies referenced
+    expect(evalJs({
+      and: [
+        { field: "severityText", eq: "DEBUG" },
+        { field: 'attributes."event.name"', eq: "github.pr.merged" },
+      ],
+    }, sampleEvent)).toBe(false);
+  });
+
+  test("or short-circuits on true", () => {
+    expect(evalJs({
+      or: [
+        { field: "severityText", eq: "INFO" },
+        { field: "severityText", eq: "WARN" },
+      ],
+    }, sampleEvent)).toBe(true);
+  });
+
+  test("not negates", () => {
+    expect(evalJs({ not: { field: "severityText", eq: "INFO" } }, sampleEvent)).toBe(false);
+    expect(evalJs({ not: { field: "severityText", eq: "WARN" } }, sampleEvent)).toBe(true);
+  });
+
+  test("empty filter matches everything", () => {
+    expect(evalJs({}, sampleEvent)).toBe(true);
+  });
+});
+
+// ─── Phase 2 — jq compiler ───────────────────────────────────────────────────
+
+describe("compileJq leaf operators", () => {
+  test("eq emits parenthesized comparison", () => {
+    expect(compileJq({ field: 'attributes."event.name"', eq: "github.pr.merged" }))
+      .toBe('(.attributes."event.name" == "github.pr.merged")');
+    expect(compileJq({ field: 'attributes."vcs.pr.number"', eq: 342 }))
+      .toBe('(.attributes."vcs.pr.number" == 342)');
+  });
+
+  test("in emits IN(...) over the canonical jq idiom", () => {
+    expect(compileJq({ field: 'attributes."catalyst.worker.ticket"', in: ["CTL-300", "CTL-313"] }))
+      .toBe('(.attributes."catalyst.worker.ticket" | IN("CTL-300", "CTL-313"))');
+    expect(compileJq({ field: 'attributes."vcs.pr.number"', in: [501, 502] }))
+      .toBe('(.attributes."vcs.pr.number" | IN(501, 502))');
+  });
+
+  test("startsWith / endsWith / contains use null-safe // \"\" guard", () => {
+    expect(compileJq({ field: 'attributes."event.name"', startsWith: "github.pr." }))
+      .toBe('((.attributes."event.name" // "") | tostring | startswith("github.pr."))');
+    expect(compileJq({ field: 'attributes."event.name"', endsWith: ".merged" }))
+      .toBe('((.attributes."event.name" // "") | tostring | endswith(".merged"))');
+    expect(compileJq({ field: "body.message", contains: "merged" }))
+      .toBe('((.body.message // "") | tostring | contains("merged"))');
+  });
+
+  test("exists emits null-vs-non-null comparison", () => {
+    expect(compileJq({ field: "traceId", exists: true })).toBe("(.traceId != null)");
+    expect(compileJq({ field: "traceId", exists: false })).toBe("(.traceId == null)");
+  });
+
+  test("comparison operators guard against null on the LHS", () => {
+    expect(compileJq({ field: "severityNumber", gt: 9 })).toBe("(.severityNumber != null and .severityNumber > 9)");
+    expect(compileJq({ field: "ts", gte: "2026-05-08T00:00:00Z" })).toBe('(.ts != null and .ts >= "2026-05-08T00:00:00Z")');
+  });
+
+  test("validation runs before compilation; unknown field throws DslError with suggestion", () => {
+    let err;
+    try { compileJq({ field: 'attributes."vcs.pr.numbr"', eq: 1 }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(DslError);
+    expect(err.code).toBe("unknown_field");
+    expect(err.field).toBe('attributes."vcs.pr.numbr"');
+    expect(err.suggestion).toBe('attributes."vcs.pr.number"');
+  });
+});
+
+describe("compileJq combinators", () => {
+  test("and joins with space-and-space", () => {
+    const out = compileJq({
+      and: [
+        { field: 'attributes."event.name"', startsWith: "github.pr." },
+        { field: 'attributes."vcs.pr.number"', eq: 342 },
+      ],
+    });
+    expect(out).toBe(
+      '(((.attributes."event.name" // "") | tostring | startswith("github.pr.")) and (.attributes."vcs.pr.number" == 342))'
+    );
+  });
+
+  test("or joins with space-or-space", () => {
+    const out = compileJq({
+      or: [
+        { field: 'attributes."event.name"', startsWith: "github.pr." },
+        { field: 'attributes."event.name"', startsWith: "github.check_" },
+      ],
+    });
+    expect(out).toBe(
+      '(((.attributes."event.name" // "") | tostring | startswith("github.pr.")) or ((.attributes."event.name" // "") | tostring | startswith("github.check_")))'
+    );
+  });
+
+  test("not wraps in ((...) | not) — jq's postfix not", () => {
+    expect(compileJq({ not: { field: "severityText", eq: "DEBUG" } }))
+      .toBe('(((.severityText == "DEBUG")) | not)');
+  });
+
+  test("empty filter compiles to true", () => {
+    expect(compileJq({})).toBe("true");
+  });
+
+  test("empty 'and' compiles to true; empty 'or' compiles to false", () => {
+    expect(compileJq({ and: [] })).toBe("true");
+    expect(compileJq({ or: [] })).toBe("false");
+  });
+});
+
+describe("compileSort and compileLimit", () => {
+  test("desc sort emits sort_by | reverse", () => {
+    expect(compileSort({ field: "ts", order: "desc" })).toBe("sort_by(.ts) | reverse");
+  });
+
+  test("asc sort (default order) emits sort_by", () => {
+    expect(compileSort({ field: "severityNumber" })).toBe("sort_by(.severityNumber)");
+    expect(compileSort({ field: "severityNumber", order: "asc" })).toBe("sort_by(.severityNumber)");
+  });
+
+  test("null sort returns null", () => {
+    expect(compileSort(null)).toBeNull();
+    expect(compileSort(undefined)).toBeNull();
+  });
+
+  test("invalid sort.order throws", () => {
+    expect(() => compileSort({ field: "ts", order: "sideways" })).toThrow(DslError);
+  });
+
+  test("unknown sort field throws with suggestion", () => {
+    let err;
+    try { compileSort({ field: "tss" }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(DslError);
+    expect(err.code).toBe("unknown_field");
+  });
+
+  test("compileLimit emits .[:N]", () => {
+    expect(compileLimit(10)).toBe(".[:10]");
+    expect(compileLimit(0)).toBe(".[:0]");
+  });
+
+  test("null/undefined limit returns null", () => {
+    expect(compileLimit(null)).toBeNull();
+    expect(compileLimit(undefined)).toBeNull();
+  });
+
+  test("invalid limit throws", () => {
+    expect(() => compileLimit(-1)).toThrow(DslError);
+    expect(() => compileLimit(1.5)).toThrow(DslError);
+    expect(() => compileLimit("10")).toThrow(DslError);
+  });
+});
+
+describe("compile() top-level", () => {
+  test("returns all four artifacts and a working JS predicate", () => {
+    const out = compile({
+      filter: { field: 'attributes."event.name"', eq: "github.pr.merged" },
+      sort: { field: "ts", order: "desc" },
+      limit: 5,
+    });
+    expect(out.jqPredicate).toBe('(.attributes."event.name" == "github.pr.merged")');
+    expect(out.jqSort).toBe("sort_by(.ts) | reverse");
+    expect(out.jqLimit).toBe(".[:5]");
+    expect(out.jsPredicate(sampleEvent)).toBe(true);
+  });
+
+  test("empty dsl produces a match-all predicate", () => {
+    const out = compile({});
+    expect(out.jqPredicate).toBe("true");
+    expect(out.jsPredicate(sampleEvent)).toBe(true);
+  });
+});
+
+// ─── Phase 2 — agreement test (JS predicate ↔ jq predicate) ──────────────────
+
+describe("JS / jq agreement", () => {
+  // We pre-build a tmpdir, write a JSONL fixture, then compare the JS
+  // predicate's matches to running `jq` over the same file with the compiled
+  // jq predicate. Both must produce the same matching set per fixture DSL.
+
+  const fixtureEvents = [
+    {
+      ts: "2026-05-08T14:00:00Z",
+      severityText: "INFO", severityNumber: 9, traceId: null, spanId: null,
+      resource: { "service.name": "catalyst.github" },
+      attributes: {
+        "event.name": "github.pr.merged",
+        "vcs.pr.number": 342,
+        "vcs.repository.name": "coalesce-labs/catalyst",
+        "catalyst.worker.ticket": "CTL-313",
+      },
+      body: { message: "PR #342 merged", payload: {} },
+    },
+    {
+      ts: "2026-05-08T13:00:00Z",
+      severityText: "ERROR", severityNumber: 17, traceId: null, spanId: null,
+      resource: { "service.name": "catalyst.github" },
+      attributes: {
+        "event.name": "github.workflow_run.completed",
+        "vcs.pr.number": 343,
+        "vcs.repository.name": "coalesce-labs/catalyst",
+        "cicd.pipeline.run.conclusion": "failure",
+      },
+      body: { message: "CI failed", payload: {} },
+    },
+    {
+      ts: "2026-05-08T12:00:00Z",
+      severityText: "INFO", severityNumber: 9, traceId: null, spanId: null,
+      resource: { "service.name": "catalyst.linear" },
+      attributes: {
+        "event.name": "linear.issue.state_changed",
+        "linear.issue.identifier": "ADV-292",
+      },
+      body: { message: "Issue moved", payload: {} },
+    },
+    {
+      ts: "2026-05-08T11:00:00Z",
+      severityText: "INFO", severityNumber: 9, traceId: null, spanId: null,
+      resource: { "service.name": "catalyst.session" },
+      attributes: {
+        "event.name": "session.phase",
+        "catalyst.session.id": "sess_abc",
+        "catalyst.phase": 3,
+      },
+      body: { message: "implementing", payload: {} },
+    },
+  ];
+
+  let dir;
+  let fixturePath;
+
+  test("setup fixture file", () => {
+    dir = mkdtempSync(join(tmpdir(), "dsl-fixture-"));
+    fixturePath = join(dir, "events.jsonl");
+    writeFileSync(fixturePath, fixtureEvents.map((e) => JSON.stringify(e)).join("\n") + "\n");
+  });
+
+  const cases = [
+    {
+      name: "event-name eq",
+      dsl: { filter: { field: 'attributes."event.name"', eq: "github.pr.merged" } },
+    },
+    {
+      name: "in over tickets",
+      dsl: { filter: { field: 'attributes."linear.issue.identifier"', in: ["ADV-292", "ADV-293"] } },
+    },
+    {
+      name: "startsWith on event.name",
+      dsl: { filter: { field: 'attributes."event.name"', startsWith: "github." } },
+    },
+    {
+      name: "or of two startsWith",
+      dsl: {
+        filter: {
+          or: [
+            { field: 'attributes."event.name"', startsWith: "github.pr." },
+            { field: 'attributes."event.name"', startsWith: "github.workflow_" },
+          ],
+        },
+      },
+    },
+    {
+      name: "and of severity + repo",
+      dsl: {
+        filter: {
+          and: [
+            { field: "severityText", eq: "ERROR" },
+            { field: 'attributes."vcs.repository.name"', eq: "coalesce-labs/catalyst" },
+          ],
+        },
+      },
+    },
+    {
+      name: "not over event.name",
+      dsl: { filter: { not: { field: 'attributes."event.name"', startsWith: "github." } } },
+    },
+    {
+      name: "exists true on linear identifier",
+      dsl: { filter: { field: 'attributes."linear.issue.identifier"', exists: true } },
+    },
+    {
+      name: "exists false on traceId",
+      dsl: { filter: { field: "traceId", exists: false } },
+    },
+    {
+      name: "gte on severityNumber",
+      dsl: { filter: { field: "severityNumber", gte: 13 } },
+    },
+    {
+      name: "ts gte time window",
+      dsl: { filter: { field: "ts", gte: "2026-05-08T13:00:00Z" } },
+    },
+    {
+      name: "in over PR numbers",
+      dsl: { filter: { field: 'attributes."vcs.pr.number"', in: [342, 999] } },
+    },
+    {
+      name: "empty filter (match all)",
+      dsl: { filter: {} },
+    },
+    {
+      name: "complex and+or+not nested",
+      dsl: {
+        filter: {
+          and: [
+            {
+              or: [
+                { field: 'attributes."event.name"', startsWith: "github.pr." },
+                { field: 'attributes."event.name"', startsWith: "github.check_" },
+                { field: 'attributes."event.name"', startsWith: "github.workflow_" },
+              ],
+            },
+            { not: { field: "severityText", eq: "ERROR" } },
+          ],
+        },
+      },
+    },
+  ];
+
+  for (const c of cases) {
+    test(`agreement: ${c.name}`, () => {
+      const compiled = compile(c.dsl);
+      const jsMatches = fixtureEvents.filter(compiled.jsPredicate);
+
+      const jqOut = spawnSync("jq", ["-c", `select(${compiled.jqPredicate})`, fixturePath], {
+        encoding: "utf8",
+      });
+      expect(jqOut.status).toBe(0);
+      const jqMatches = jqOut.stdout.split("\n").filter(Boolean).map((l) => JSON.parse(l));
+
+      // Compare by ts (each fixture event has a unique ts).
+      const jsTs = jsMatches.map((e) => e.ts).sort();
+      const jqTs = jqMatches.map((e) => e.ts).sort();
+      expect(jsTs).toEqual(jqTs);
+    });
+  }
+
+  test("teardown fixture", () => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ─── Phase 3 — Groq response parsing (no real round-trip) ────────────────────
+
+describe("parseGroqResponse", () => {
+  test("parses a valid DSL JSON response", () => {
+    const out = parseGroqResponse('{"filter":{"field":"ts","eq":"x"},"sort":null,"limit":null}');
+    expect(out).toEqual({ filter: { field: "ts", eq: "x" }, sort: null, limit: null });
+  });
+
+  test("non-JSON response throws GroqResponseError with the raw text attached", () => {
+    let err;
+    try { parseGroqResponse("not json"); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(GroqResponseError);
+    expect(err.raw).toBe("not json");
+  });
+
+  test("error response with 'refused' code", () => {
+    let err;
+    try { parseGroqResponse('{"error":"refused: query is read-only"}'); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(DslError);
+    expect(err.code).toBe("refused");
+    expect(err.message).toContain("read-only");
+  });
+
+  test("error response naming an unknown field", () => {
+    let err;
+    try { parseGroqResponse('{"error":"unknown field: foo.bar"}'); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(DslError);
+    expect(err.code).toBe("unknown_field");
+  });
+});
+
+// ─── Phase 3 — groqTranslate with an injected fetch (no network) ─────────────
+
+import { groqTranslate, GroqHttpError } from "./dsl-compile.mjs";
+import { SYSTEM_PROMPT } from "./dsl-prompt.mjs";
+
+describe("groqTranslate (mocked fetch)", () => {
+  function mockFetch(response) {
+    return async () => response;
+  }
+
+  test("returns parsed DSL on success", async () => {
+    const fetchImpl = mockFetch({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: '{"filter":{"field":"ts","eq":"x"},"sort":null,"limit":null}' } }],
+      }),
+    });
+    const out = await groqTranslate("show me everything", { apiKey: "k", fetchImpl, systemPrompt: SYSTEM_PROMPT });
+    expect(out.filter.field).toBe("ts");
+  });
+
+  test("non-2xx throws GroqHttpError with status and body", async () => {
+    const fetchImpl = mockFetch({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    });
+    let err;
+    try {
+      await groqTranslate("query", { apiKey: "k", fetchImpl, systemPrompt: SYSTEM_PROMPT });
+    } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(GroqHttpError);
+    expect(err.status).toBe(401);
+    expect(err.body).toBe("Unauthorized");
+  });
+
+  test("missing API key throws GroqHttpError before any fetch", async () => {
+    let called = false;
+    const fetchImpl = async () => { called = true; return null; };
+    let err;
+    try {
+      await groqTranslate("q", { apiKey: "", fetchImpl, systemPrompt: SYSTEM_PROMPT });
+    } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(GroqHttpError);
+    expect(err.status).toBe(0);
+    expect(called).toBe(false);
+  });
+
+  test("missing systemPrompt is a programming error (not a DSL error)", async () => {
+    const fetchImpl = mockFetch({ ok: true, json: async () => ({ choices: [{ message: { content: "{}" } }] }) });
+    let err;
+    try {
+      await groqTranslate("q", { apiKey: "k", fetchImpl });
+    } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("systemPrompt");
+  });
+});
+
+// ─── Phase 3 — system prompt sanity ──────────────────────────────────────────
+
+describe("SYSTEM_PROMPT", () => {
+  test("includes every canonical field in the documented schema block", () => {
+    for (const f of CANONICAL_FIELDS) {
+      expect(SYSTEM_PROMPT).toContain(f.path);
+    }
+  });
+
+  test("documents the DSL grammar's leaf operators", () => {
+    for (const op of ["eq", "ne", "in", "startsWith", "endsWith", "contains", "exists"]) {
+      expect(SYSTEM_PROMPT).toContain(op);
+    }
+  });
+
+  test("instructs JSON-only output", () => {
+    expect(SYSTEM_PROMPT.toLowerCase()).toContain("json");
+  });
+});

--- a/plugins/dev/scripts/lib/dsl-fields.mjs
+++ b/plugins/dev/scripts/lib/dsl-fields.mjs
@@ -1,0 +1,101 @@
+// dsl-fields.mjs — canonical field whitelist for the catalyst-events query DSL (CTL-313).
+//
+// Hand-derived from `plugins/dev/references/event-schema.md` (the human-authored
+// reference doc). Auto-generation from event-schema.md is a follow-up.
+//
+// To add a field:
+//   1. Add the field to `plugins/dev/references/event-schema.md`.
+//   2. Add a matching entry here.
+//   3. The Groq system prompt and the validator both read from this file —
+//      they will not drift.
+//
+// `path` is the jq access path. Quoted segments use the canonical
+// `."dotted.key"` form so consumers can drop them straight into a jq predicate.
+
+export const CANONICAL_FIELDS = [
+  // ─── Top-level envelope fields ────────────────────────────────────────────
+  { path: "ts",                            type: "string",  description: "ISO 8601 event timestamp" },
+  { path: "observedTs",                    type: "string",  description: "ISO 8601 timestamp the writer observed the event" },
+  { path: "severityText",                  type: "enum",    description: "DEBUG | INFO | WARN | ERROR" },
+  { path: "severityNumber",                type: "number",  description: "OTel severity number (5/9/13/17)" },
+  { path: "traceId",                       type: "string",  description: "32-hex trace ID, or null for ambient events" },
+  { path: "spanId",                        type: "string",  description: "16-hex span ID, or null for ambient events" },
+  { path: "parentSpanId",                  type: "string",  description: "16-hex parent span ID when present" },
+  { path: 'resource."service.name"',       type: "enum",    description: "catalyst.github | catalyst.linear | catalyst.session | catalyst.orchestrator | catalyst.comms | catalyst.filter" },
+  { path: "body.message",                  type: "string",  description: "Human-readable summary of the event" },
+
+  // ─── attributes.event.* ───────────────────────────────────────────────────
+  { path: 'attributes."event.name"',       type: "string",  description: "Dotted event identifier, e.g. github.pr.merged, session.phase" },
+  { path: 'attributes."event.entity"',     type: "string",  description: "Entity type: pr, issue, check_suite, session, worker, attention, …" },
+  { path: 'attributes."event.action"',     type: "string",  description: "Action verb: merged, opened, phase, attention, dispatched, …" },
+  { path: 'attributes."event.label"',      type: "string",  description: "Primary identifier: PR #342, CTL-210, a session id" },
+  { path: 'attributes."event.value"',      type: "any",     description: "Secondary value (string or number)" },
+  { path: 'attributes."event.channel"',    type: "enum",    description: "webhook | sme.io" },
+
+  // ─── attributes.catalyst.* ────────────────────────────────────────────────
+  { path: 'attributes."catalyst.orchestrator.id"', type: "string", description: "Orchestration run identifier" },
+  { path: 'attributes."catalyst.worker.ticket"',   type: "string", description: "Worker ticket key (e.g. CTL-210)" },
+  { path: 'attributes."catalyst.session.id"',      type: "string", description: "Claude session ID" },
+  { path: 'attributes."catalyst.phase"',           type: "number", description: "Worker phase number" },
+
+  // ─── attributes.vcs.* ─────────────────────────────────────────────────────
+  { path: 'attributes."vcs.repository.name"', type: "string", description: 'Repository in "org/repo" form' },
+  { path: 'attributes."vcs.pr.number"',       type: "number", description: "Pull-request number" },
+  { path: 'attributes."vcs.ref.name"',        type: "string", description: "Branch or tag ref (e.g. refs/heads/main)" },
+  { path: 'attributes."vcs.revision"',        type: "string", description: "Commit SHA" },
+
+  // ─── attributes.cicd.* ────────────────────────────────────────────────────
+  { path: 'attributes."cicd.pipeline.run.id"',         type: "number", description: "GitHub Actions run ID" },
+  { path: 'attributes."cicd.pipeline.run.conclusion"', type: "string", description: "success | failure | cancelled | skipped | timed_out" },
+  { path: 'attributes."cicd.pipeline.name"',           type: "string", description: "Workflow name (e.g. CI)" },
+
+  // ─── attributes.linear.* ──────────────────────────────────────────────────
+  { path: 'attributes."linear.issue.identifier"', type: "string", description: "Linear issue identifier (e.g. CTL-210)" },
+  { path: 'attributes."linear.team.key"',         type: "string", description: "Linear team key (e.g. CTL)" },
+  { path: 'attributes."linear.actor.id"',         type: "string", description: "Linear user UUID who triggered the action" },
+
+  // ─── attributes.deployment.* ──────────────────────────────────────────────
+  { path: 'attributes."deployment.environment"', type: "string", description: "production | staging | …" },
+  { path: 'attributes."deployment.id"',          type: "number", description: "GitHub deployment ID" },
+];
+
+export const FIELD_PATH_SET = new Set(CANONICAL_FIELDS.map((f) => f.path));
+
+export function isWhitelistedField(path) {
+  return FIELD_PATH_SET.has(path);
+}
+
+// Levenshtein distance between two strings — used to suggest a near-miss when
+// validation rejects an unknown field. Pure helper; no allocations beyond the
+// O(min(m,n)) row, since whitelist entries are short and we run it ≤ 40 times
+// per validation failure.
+export function levenshtein(a, b) {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = new Array(b.length + 1);
+  let curr = new Array(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length];
+}
+
+export function suggestField(path, maxDistance = 4) {
+  let best = null;
+  let bestDist = maxDistance + 1;
+  for (const f of CANONICAL_FIELDS) {
+    const d = levenshtein(path, f.path);
+    if (d < bestDist) {
+      best = f.path;
+      bestDist = d;
+    }
+  }
+  return bestDist <= maxDistance ? best : null;
+}

--- a/plugins/dev/scripts/lib/dsl-prompt.d.mts
+++ b/plugins/dev/scripts/lib/dsl-prompt.d.mts
@@ -1,0 +1,2 @@
+export const SYSTEM_PROMPT: string;
+export const FEW_SHOT_EXAMPLES: ReadonlyArray<{ user: string; assistant: object }>;

--- a/plugins/dev/scripts/lib/dsl-prompt.mjs
+++ b/plugins/dev/scripts/lib/dsl-prompt.mjs
@@ -1,0 +1,129 @@
+// dsl-prompt.mjs — Groq system prompt + few-shot examples for CTL-313.
+//
+// Built from CANONICAL_FIELDS so the schema block cannot drift from the
+// validator.
+
+import { CANONICAL_FIELDS } from "./dsl-fields.mjs";
+
+function fieldsBlock() {
+  return CANONICAL_FIELDS
+    .map((f) => `  - ${f.path}  (${f.type}) — ${f.description}`)
+    .join("\n");
+}
+
+export const FEW_SHOT_EXAMPLES = [
+  {
+    user: "show all gh events for ADV-292 and ADV-293 that are PR or CI",
+    assistant: {
+      filter: {
+        and: [
+          { field: 'attributes."catalyst.worker.ticket"', in: ["ADV-292", "ADV-293"] },
+          {
+            or: [
+              { field: 'attributes."event.name"', startsWith: "github.pr." },
+              { field: 'attributes."event.name"', startsWith: "github.check_" },
+              { field: 'attributes."event.name"', startsWith: "github.workflow_run." },
+            ],
+          },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 200,
+    },
+  },
+  {
+    user: "errors in the last hour",
+    assistant: {
+      // The "last hour" timestamp is a placeholder; the CLI rewrites time
+      // expressions before sending to Groq, so the model just emits a literal
+      // ISO string — the validator and downstream caller handle it.
+      filter: {
+        and: [
+          { field: "severityText", eq: "ERROR" },
+          { field: "ts", gte: "{NOW-1h}" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 200,
+    },
+  },
+  {
+    user: "all events for orch-adv-852-2026-05-07",
+    assistant: {
+      filter: { field: 'attributes."catalyst.orchestrator.id"', eq: "orch-adv-852-2026-05-07" },
+      sort: { field: "ts", order: "asc" },
+      limit: 500,
+    },
+  },
+  {
+    user: "failed CI on main branch",
+    assistant: {
+      filter: {
+        and: [
+          { field: 'attributes."event.name"', startsWith: "github.check_" },
+          { field: 'attributes."cicd.pipeline.run.conclusion"', eq: "failure" },
+          { field: 'attributes."vcs.ref.name"', eq: "refs/heads/main" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 100,
+    },
+  },
+  {
+    user: "trace events for PR #501",
+    assistant: {
+      // Trace pivot from PR is not supported in v1 — the model is instructed
+      // (in the system prompt) to return an error in that case.
+      error: "trace pivot from PR not yet supported; query by traceId directly",
+    },
+  },
+  {
+    user: "delete all heartbeat events",
+    assistant: {
+      error: "refused: query is read-only",
+    },
+  },
+];
+
+const FEW_SHOT_BLOCK = FEW_SHOT_EXAMPLES
+  .map((ex) => `User: ${ex.user}\nAssistant: ${JSON.stringify(ex.assistant)}`)
+  .join("\n\n");
+
+export const SYSTEM_PROMPT = `You translate natural-language event queries into a strict JSON DSL. Return ONLY a single JSON object, no other text.
+
+The events you query come from \`~/catalyst/events/YYYY-MM.jsonl\`. Each line is a canonical OpenTelemetry-shaped envelope with these top-level fields and attribute paths:
+
+${fieldsBlock()}
+
+DSL grammar (TypeScript-style):
+
+  type Dsl = { filter: Node; sort?: SortSpec | null; limit?: number | null }
+            | { error: string };
+
+  type Node = And | Or | Not | Leaf | {};
+  type And  = { and: Node[] };
+  type Or   = { or:  Node[] };
+  type Not  = { not: Node };
+  type Leaf = { field: string } & (
+      { eq: any } | { ne: any }
+    | { gt: any } | { gte: any } | { lt: any } | { lte: any }
+    | { in: any[] }
+    | { startsWith: string } | { endsWith: string } | { contains: string }
+    | { exists: boolean }
+  );
+  type SortSpec = { field: string; order?: "asc" | "desc" };
+
+Rules:
+1. \`field\` MUST be one of the paths above, written EXACTLY as shown (including the quotes around dotted attribute keys: \`attributes."event.name"\`).
+2. NEVER invent fields. If the user references a concept that has no corresponding field, return \`{"error":"unknown field: <best-guess>"}\`.
+3. If the user asks to delete, modify, write, or trigger any action, return \`{"error":"refused: query is read-only"}\`.
+4. If the user asks for trace correlation from a PR number, return \`{"error":"trace pivot from PR not yet supported; query by traceId directly"}\`.
+5. For relative time windows ("last hour", "today", "yesterday"), emit a literal placeholder string \`"{NOW-1h}"\` / \`"{TODAY}"\` etc. on the \`gte\`/\`lte\` clause — the caller will rewrite these to ISO timestamps before running the filter.
+6. Always set a \`limit\` (default 200 if the user didn't specify).
+7. Always set a \`sort\` (default \`{field: "ts", order: "desc"}\`).
+
+Few-shot examples:
+
+${FEW_SHOT_BLOCK}
+
+Return only the JSON object. No prose, no code fences, no commentary.`;

--- a/plugins/dev/scripts/orch-monitor/cli/components/QueryInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/QueryInput.tsx
@@ -1,0 +1,39 @@
+import { Box, Text } from "ink";
+import TextInput from "ink-text-input";
+
+interface QueryInputProps {
+  value: string;
+  focused: boolean;
+  busy: boolean;
+  error: string | null;
+  hasDsl: boolean;
+  onChange: (v: string) => void;
+  onSubmit: (v: string) => void;
+}
+
+export function QueryInput({ value, focused, busy, error, hasDsl, onChange, onSubmit }: QueryInputProps) {
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="row">
+        <Text dimColor={!focused} color={focused ? "magenta" : undefined}>{": "}</Text>
+        <TextInput
+          value={value}
+          onChange={onChange}
+          onSubmit={onSubmit}
+          focus={focused && !busy}
+          placeholder='natural-language query (e.g. "errors today")'
+        />
+        <Text dimColor>
+          {"  "}
+          {busy ? "translating…" : focused ? "Enter:run Esc:cancel" : ":focus"}
+          {hasDsl ? " | ?:show DSL" : ""}
+        </Text>
+      </Box>
+      {error !== null && (
+        <Box>
+          <Text color="red">{`  query error: ${error}`}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.test.ts
@@ -1,0 +1,98 @@
+// useFilter.test.ts — verifies that the hook's filter pipeline composes
+// pivot, substring, and DSL filters correctly. Pure-JS test — does not
+// render any Ink components, so no testing-library dependency required.
+
+import { describe, test, expect } from "bun:test";
+import type { CanonicalEvent } from "../../lib/canonical-event.ts";
+
+// Bun's test runner does not ship a React-hook test helper. The hook's
+// `filtered` derivation is just a `useMemo` over inputs, so we re-implement
+// the pipeline here as a pure function and test that. Any divergence from
+// useFilter.ts is caught when the hook source is changed without updating
+// this mirror — they are intentionally adjacent in the file tree.
+
+function applyPipeline(
+  events: CanonicalEvent[],
+  filterText: string,
+  pivot: { type: "trace"; id: string } | { type: "orch"; id: string } | null,
+  dslPredicate: ((e: CanonicalEvent) => boolean) | null,
+): CanonicalEvent[] {
+  let result = events;
+  if (pivot?.type === "trace") {
+    result = result.filter((e) => e.traceId === pivot.id);
+  } else if (pivot?.type === "orch") {
+    result = result.filter((e) => e.attributes["catalyst.orchestrator.id"] === pivot.id);
+  }
+  if (dslPredicate) {
+    result = result.filter(dslPredicate);
+  }
+  if (filterText) {
+    const text = filterText.toLowerCase();
+    result = result.filter((e) => JSON.stringify(e).toLowerCase().includes(text));
+  }
+  return result;
+}
+
+const fixture: CanonicalEvent[] = [
+  {
+    ts: "2026-05-08T14:00:00Z", severityText: "INFO", severityNumber: 9, traceId: "t1", spanId: null,
+    resource: { "service.name": "catalyst.github", "service.namespace": "catalyst", "service.version": "8.2.0" },
+    attributes: { "event.name": "github.pr.merged", "vcs.pr.number": 342, "catalyst.orchestrator.id": "orch-A" },
+    body: { message: "PR #342 merged", payload: {} },
+  },
+  {
+    ts: "2026-05-08T13:00:00Z", severityText: "ERROR", severityNumber: 17, traceId: "t1", spanId: null,
+    resource: { "service.name": "catalyst.github", "service.namespace": "catalyst", "service.version": "8.2.0" },
+    attributes: { "event.name": "github.workflow_run.completed", "vcs.pr.number": 343, "catalyst.orchestrator.id": "orch-A" },
+    body: { message: "CI failed", payload: {} },
+  },
+  {
+    ts: "2026-05-08T12:00:00Z", severityText: "INFO", severityNumber: 9, traceId: "t2", spanId: null,
+    resource: { "service.name": "catalyst.linear", "service.namespace": "catalyst", "service.version": "8.2.0" },
+    attributes: { "event.name": "linear.issue.state_changed", "linear.issue.identifier": "ADV-292", "catalyst.orchestrator.id": "orch-B" },
+    body: { message: "Issue moved", payload: {} },
+  },
+];
+
+describe("useFilter pipeline", () => {
+  test("no filters → all events", () => {
+    expect(applyPipeline(fixture, "", null, null)).toHaveLength(3);
+  });
+
+  test("DSL predicate only", () => {
+    const onlyErrors = (e: CanonicalEvent) => e.severityText === "ERROR";
+    const out = applyPipeline(fixture, "", null, onlyErrors);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.severityText).toBe("ERROR");
+  });
+
+  test("DSL AND substring", () => {
+    const ghOnly = (e: CanonicalEvent) => e.attributes["event.name"]?.startsWith("github.") ?? false;
+    const out = applyPipeline(fixture, "merged", null, ghOnly);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.attributes["event.name"]).toBe("github.pr.merged");
+  });
+
+  test("trace pivot AND DSL", () => {
+    const ghOnly = (e: CanonicalEvent) => e.attributes["event.name"]?.startsWith("github.") ?? false;
+    const out = applyPipeline(fixture, "", { type: "trace", id: "t1" }, ghOnly);
+    expect(out).toHaveLength(2);
+  });
+
+  test("orch pivot AND DSL", () => {
+    const onlyInfo = (e: CanonicalEvent) => e.severityText === "INFO";
+    const out = applyPipeline(fixture, "", { type: "orch", id: "orch-A" }, onlyInfo);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.ts).toBe("2026-05-08T14:00:00Z");
+  });
+
+  test("DSL predicate that matches nothing → empty", () => {
+    const never = () => false;
+    expect(applyPipeline(fixture, "", null, never)).toHaveLength(0);
+  });
+
+  test("DSL predicate that throws is the caller's bug — pipeline does not swallow", () => {
+    const broken = () => { throw new Error("boom"); };
+    expect(() => applyPipeline(fixture, "", null, broken)).toThrow("boom");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.ts
@@ -4,7 +4,9 @@ import { formatRepo, formatSource, formatEvent, formatRef, formatDetails } from 
 
 export type PivotMode = { type: "trace"; id: string } | { type: "orch"; id: string } | null;
 
-export function useFilter(events: CanonicalEvent[]) {
+export type DslPredicate = ((event: CanonicalEvent) => boolean) | null;
+
+export function useFilter(events: CanonicalEvent[], dslPredicate: DslPredicate = null) {
   const [filterText, setFilterText] = useState("");
   const [pivot, setPivot] = useState<PivotMode>(null);
 
@@ -15,6 +17,10 @@ export function useFilter(events: CanonicalEvent[]) {
       result = result.filter((e) => e.traceId === pivot.id);
     } else if (pivot?.type === "orch") {
       result = result.filter((e) => e.attributes["catalyst.orchestrator.id"] === pivot.id);
+    }
+
+    if (dslPredicate) {
+      result = result.filter(dslPredicate);
     }
 
     if (!filterText) return result;
@@ -32,7 +38,7 @@ export function useFilter(events: CanonicalEvent[]) {
         .toLowerCase();
       return row.includes(text);
     });
-  }, [events, filterText, pivot]);
+  }, [events, filterText, pivot, dslPredicate]);
 
   return { filterText, setFilterText, pivot, setPivot, filtered };
 }

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -1,18 +1,35 @@
 #!/usr/bin/env bun
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { render, useApp, useInput, useStdout, Box, Text } from "ink";
 import { Header } from "./components/Header.tsx";
 import { EventList } from "./components/EventList.tsx";
 import { FilterInput } from "./components/FilterInput.tsx";
+import { QueryInput } from "./components/QueryInput.tsx";
 import { DetailPane } from "./components/DetailPane.tsx";
 import { useEventLog } from "./hooks/useEventLog.ts";
-import { useFilter } from "./hooks/useFilter.ts";
+import { useFilter, type DslPredicate } from "./hooks/useFilter.ts";
 import { useSelection } from "./hooks/useSelection.ts";
+import {
+  compile,
+  groqTranslate,
+  rewriteNode,
+  readGroqApiKeyFromConfig,
+  DslError,
+  GroqHttpError,
+  GroqResponseError,
+} from "../../lib/dsl-compile.mjs";
+import { SYSTEM_PROMPT } from "../../lib/dsl-prompt.mjs";
+import type { CanonicalEvent } from "../lib/canonical-event.ts";
 
 interface AppProps {
   repoFilter: string;
   predicate: string;
   sinceTs: string;
+}
+
+interface DslState {
+  dsl: object;
+  jsPredicate: (event: CanonicalEvent) => boolean;
 }
 
 function App({ repoFilter, predicate, sinceTs }: AppProps) {
@@ -22,19 +39,67 @@ function App({ repoFilter, predicate, sinceTs }: AppProps) {
   const cols = stdout?.columns ?? 120;
 
   const { events, loading } = useEventLog({ repoFilter, predicate, sinceTs });
-  const { filterText, setFilterText, pivot, setPivot, filtered } = useFilter(events);
 
-  // Reserve rows: header(1) + status(1) + filter(1) = 3 chrome rows
-  const visibleRows = Math.max(1, rows - 3);
+  const [dslState, setDslState] = useState<DslState | null>(null);
+  const dslPredicate: DslPredicate = dslState?.jsPredicate ?? null;
+  const { filterText, setFilterText, pivot, setPivot, filtered } = useFilter(events, dslPredicate);
+
+  // Reserve rows: header(1) + status(1) + filter(1) + query(1) + dsl-overlay(maybe) = 4-7
+  const [showDslOverlay, setShowDslOverlay] = useState(false);
+  const overlayHeight = showDslOverlay && dslState ? Math.min(15, Math.floor(rows / 2)) : 0;
+  const chromeRows = 4 + overlayHeight;
+  const visibleRows = Math.max(1, rows - chromeRows);
   const { selectedIndex, scrollOffset, moveUp, moveDown, pageUp, pageDown, jumpToBottom } =
     useSelection(filtered.length, visibleRows);
 
   const [filterFocused, setFilterFocused] = useState(false);
+  const [queryFocused, setQueryFocused] = useState(false);
+  const [queryText, setQueryText] = useState("");
+  const [queryError, setQueryError] = useState<string | null>(null);
+  const [querySubmitting, setQuerySubmitting] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
 
   const selectedEvent = filtered[selectedIndex] ?? null;
 
+  const submitQuery = useCallback(async (raw: string) => {
+    const text = raw.trim();
+    if (!text) return;
+    setQuerySubmitting(true);
+    setQueryError(null);
+    try {
+      const apiKey = process.env["GROQ_API_KEY"] || readGroqApiKeyFromConfig();
+      const dsl = await groqTranslate(text, { apiKey, systemPrompt: SYSTEM_PROMPT });
+      const rewritten = { ...dsl, filter: dsl.filter ? rewriteNode(dsl.filter) : {} };
+      const compiled = compile(rewritten);
+      setDslState({ dsl: rewritten, jsPredicate: compiled.jsPredicate });
+      setQueryFocused(false);
+      setQueryText("");
+    } catch (err) {
+      let msg = "unknown error";
+      if (err instanceof DslError) {
+        msg = err.suggestion ? `${err.message} (did you mean ${err.suggestion}?)` : err.message;
+      } else if (err instanceof GroqHttpError) {
+        msg = `Groq HTTP ${err.status}: ${err.message}`;
+      } else if (err instanceof GroqResponseError) {
+        msg = `Groq response: ${err.message}`;
+      } else if (err instanceof Error) {
+        msg = err.message;
+      }
+      setQueryError(msg);
+    } finally {
+      setQuerySubmitting(false);
+    }
+  }, []);
+
   useInput((input, key) => {
+    if (queryFocused) {
+      if (key.escape) {
+        setQueryFocused(false);
+        setQueryText("");
+        setQueryError(null);
+      }
+      return;
+    }
     if (filterFocused) {
       if (key.escape) {
         setFilterFocused(false);
@@ -46,8 +111,11 @@ function App({ repoFilter, predicate, sinceTs }: AppProps) {
 
     if (key.escape) {
       setShowDetail(false);
+      setShowDslOverlay(false);
       setPivot(null);
       setFilterText("");
+      setDslState(null);
+      setQueryError(null);
       return;
     }
     if (input === "q" || (key.ctrl && input === "c")) {
@@ -60,6 +128,8 @@ function App({ repoFilter, predicate, sinceTs }: AppProps) {
     if (key.pageUp) { pageUp(); return; }
     if (input === "G") { jumpToBottom(); return; }
     if (input === "/") { setFilterFocused(true); return; }
+    if (input === ":") { setQueryFocused(true); setQueryError(null); return; }
+    if (input === "?" && dslState) { setShowDslOverlay((v) => !v); return; }
     if (key.return) { setShowDetail((v) => !v); return; }
     if (input === "t" && selectedEvent?.traceId) {
       setPivot({ type: "trace", id: selectedEvent.traceId });
@@ -97,12 +167,32 @@ function App({ repoFilter, predicate, sinceTs }: AppProps) {
         {pivot && (
           <Text color="cyan">{`  [${pivot.type} pivot active — r to reset]`}</Text>
         )}
+        {dslState && (
+          <Text color="magenta">{"  [DSL filter active — Esc to clear]"}</Text>
+        )}
       </Box>
+      {showDslOverlay && dslState && (
+        <Box flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={1}>
+          <Text color="magenta" bold>Generated DSL (press ? to hide):</Text>
+          {JSON.stringify(dslState.dsl, null, 2).split("\n").slice(0, overlayHeight - 2).map((line, i) => (
+            <Text key={i}>{line}</Text>
+          ))}
+        </Box>
+      )}
       <FilterInput
         value={filterText}
         focused={filterFocused}
         onChange={setFilterText}
         pivot={pivot}
+      />
+      <QueryInput
+        value={queryText}
+        focused={queryFocused}
+        busy={querySubmitting}
+        error={queryError}
+        hasDsl={dslState !== null}
+        onChange={setQueryText}
+        onSubmit={(v) => { void submitQuery(v); }}
       />
     </Box>
   );
@@ -149,8 +239,10 @@ for (let i = 0; i < args.length; i++) {
     console.info("  ↑/↓ or j/k   move selection");
     console.info("  PgUp/PgDn    page through history");
     console.info("  Enter        toggle detail pane");
-    console.info("  /            focus filter input");
-    console.info("  Esc          clear filter / exit detail");
+    console.info("  /            focus substring filter");
+    console.info("  :            focus natural-language query (Groq)");
+    console.info("  ?            toggle generated DSL overlay (after a query is set)");
+    console.info("  Esc          clear filter / exit detail / drop DSL filter");
     console.info("  t            pivot to selected row's traceId");
     console.info("  o            pivot to selected row's orchestratorId");
     console.info("  r            clear pivot, back to live tail");

--- a/plugins/dev/skills/catalyst-events-query/SKILL.md
+++ b/plugins/dev/skills/catalyst-events-query/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: catalyst-events-query
+description:
+  Reference for the natural-language query subcommand of `catalyst-events`. Translates English
+  queries through Groq into a structured DSL, compiles to a jq predicate, and runs against the
+  canonical event log. Also documents the `:` / `?` keys in `catalyst-hud` (TUI) that drive the
+  same compiler. Use when an agent needs to triage events without composing jq predicates by hand,
+  or when documenting how to surface event subsets in dashboards.
+disable-model-invocation: true
+---
+
+# catalyst-events query — natural-language event triage
+
+## TL;DR
+
+```bash
+catalyst-events query "errors in the last hour"
+catalyst-events query "show all gh events for ADV-292 and ADV-293 that are PR or CI" --explain
+catalyst-events query "failed CI on main branch" --since 1d --limit 50
+```
+
+In the TUI (`catalyst-hud`):
+
+| Key | Action |
+|-----|--------|
+| `:` | Open natural-language query input |
+| `Enter` (in input) | Send to Groq, apply DSL filter to current view |
+| `?` | Toggle the generated DSL overlay (only shown after a query is set) |
+| `Esc` | Cancel input or drop the active DSL filter |
+
+## When to use this
+
+- You want to triage events across orchestrators / tickets / PRs and don't want to memorize the jq attribute paths.
+- You're explaining a query in a doc or skill and want a copy-pasteable command.
+- You're building a dashboard or report and want a one-liner that returns the right slice of the event log.
+
+## When NOT to use this
+
+- You're inside an automated waiter — use `catalyst-events wait-for --filter '<jq>'` directly. The `query` subcommand pays a Groq round-trip; waiters need to be deterministic.
+- You're filtering by a single canonical attribute path you already know — `catalyst-events tail --filter '...'` is faster.
+
+## DSL grammar
+
+The compiler accepts a strict JSON DSL. You don't normally write this by hand — Groq emits it — but `--explain` shows it to you, and `--dsl` lets you bypass Groq for tests / scripts.
+
+```ts
+type Dsl = {
+  filter: Node;
+  sort?:  { field: string; order?: "asc" | "desc" } | null;
+  limit?: number | null;
+} | { error: string };
+
+type Node = And | Or | Not | Leaf | {};
+type And  = { and: Node[] };
+type Or   = { or:  Node[] };
+type Not  = { not: Node };
+type Leaf = { field: string } & (
+    { eq: any } | { ne: any }
+  | { gt: any } | { gte: any } | { lt: any } | { lte: any }
+  | { in: any[] }
+  | { startsWith: string } | { endsWith: string } | { contains: string }
+  | { exists: boolean }
+);
+```
+
+`field` MUST be a path from the canonical event schema — see [[event-schema]] for the
+authoritative list. Top-level fields (`ts`, `severityText`, `severityNumber`, `traceId`,
+`spanId`, `resource."service.name"`, `body.message`) and all `attributes."<key>"` paths are
+accepted. The validator rejects anything else with a "did you mean" suggestion.
+
+## Acceptance examples (these all work)
+
+| English | Generated DSL (abbreviated) |
+|---|---|
+| `show all gh events for ADV-292 and ADV-293 that are PR or CI` | `{filter: {and: [{field: 'attributes."catalyst.worker.ticket"', in: ["ADV-292","ADV-293"]}, {or: [{field:'attributes."event.name"', startsWith: "github.pr."}, {field:'attributes."event.name"', startsWith: "github.check_"}, {field:'attributes."event.name"', startsWith: "github.workflow_run."}]}]}, sort: {field:"ts", order:"desc"}, limit: 200}` |
+| `errors in the last hour` | `{filter: {and: [{field:"severityText", eq:"ERROR"}, {field:"ts", gte:"{NOW-1h}"}]}, sort: {field:"ts", order:"desc"}, limit: 200}` |
+| `all events for orch-adv-852-2026-05-07` | `{filter: {field:'attributes."catalyst.orchestrator.id"', eq:"orch-adv-852-2026-05-07"}, sort: {field:"ts", order:"asc"}, limit: 500}` |
+| `failed CI on main branch` | `{filter: {and: [{field:'attributes."event.name"', startsWith:"github.check_"}, {field:'attributes."cicd.pipeline.run.conclusion"', eq:"failure"}, {field:'attributes."vcs.ref.name"', eq:"refs/heads/main"}]}, sort:{field:"ts",order:"desc"}, limit:100}` |
+| `delete all heartbeat events` | `{error: "refused: query is read-only"}` (refused — query is read-only by design) |
+
+The `{NOW-1h}` / `{TODAY}` placeholders are rewritten to ISO timestamps by the caller (CLI or TUI) before evaluation, so the model can stay deterministic.
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--explain` | Print the parsed DSL + compiled jq predicate, exit without running. Useful for debugging or auditing what Groq returned. |
+| `--limit N` | Override the limit Groq chose. |
+| `--since DURATION` | Pre-trim by `ts >= now - DURATION`. Accepts `Ns`, `Nm`, `Nh`, `Nd`, or `today`. Relative only in v1. |
+| `--dsl '<json>'` | Skip Groq entirely; pass a hand-written DSL. The validator and compiler still run. Used by tests and power users who don't want the round-trip. |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (zero matches is success — no output, exit 0) |
+| 2 | Usage error (unknown flag, missing required arg) |
+| 3 | Groq HTTP error, malformed JSON, or refusal (`{"error": "refused: …"}`) |
+| 4 | DSL validation error (unknown field, bad operator) |
+
+The compiler error always names the bad field on stderr:
+
+```
+$ catalyst-events query --dsl '{"filter":{"field":"bogus.field","eq":1}}'
+{"error":"unknown field: bogus.field","code":"unknown_field","field":"bogus.field"}
+```
+
+## Configuration
+
+| Env var | Purpose |
+|---|---|
+| `GROQ_API_KEY` | Groq API key. Falls back to `~/.config/catalyst/config.json::groq.apiKey`. |
+| `FILTER_GROQ_MODEL` | Override the model. Default `llama-3.1-8b-instant` (sub-second, ~$0.05/M input). |
+
+## Internals
+
+- The CLI is `plugins/dev/scripts/catalyst-events::cmd_query`. It shells to `plugins/dev/scripts/lib/dsl-cli.mjs` (Node), which calls Groq, parses, validates, and emits compiled artifacts on stdout. The bash wrapper then splices the jq predicate into the existing `apply_filter` pipeline.
+- The TUI imports the same `compile()` and `groqTranslate()` from `plugins/dev/scripts/lib/dsl-compile.mjs` directly — no subprocess. The DSL produces a JS predicate function evaluated in-memory against the TUI's event backbuffer.
+- The system prompt + few-shot examples live in `plugins/dev/scripts/lib/dsl-prompt.mjs` and the canonical field whitelist in `plugins/dev/scripts/lib/dsl-fields.mjs`. Both are read by tests, so prompt/validator drift is caught.
+- See [[event-schema]] for the canonical attribute paths the DSL targets, and [[wait-for-github]] for the deterministic-filter pattern when you need to block on a known event shape.
+
+## Out of scope
+
+- Trace pivot from PR number ("show events with the same trace as PR #501") — needs a two-step lookup (PR → traceId → query). Returns `refused` for now; future ticket will add a `{lookup, then}` DSL.
+- Streaming / `--follow` mode — `query` is one-shot; use `catalyst-events tail --filter '<jq>'` for live tail.
+- Free-text NLP over `body.payload` — the DSL is structured-attribute only.
+
+## Related
+
+- [[event-schema]] — canonical envelope and attribute reference
+- [[monitor-events]] — wait-for / tail patterns for automated waiters
+- [[wait-for-github]] — REST + event-tunnel two-phase wait for PR/CI lifecycle
+- [[broker]] — the daemon that uses Groq for semantic event routing (not event queries)


### PR DESCRIPTION
## Summary

Adds `catalyst-events query "<NL>"` plus `:` / `?` keys in `catalyst-hud` that translate English into a strict JSON DSL via Groq (Llama 3.1 8B, JSON mode), validate field names against the canonical event schema, and compile to either a jq predicate (CLI) or an in-memory JS predicate (TUI). Both code paths share a single compiler module so behavior cannot drift.

Closes [CTL-313](https://linear.app/coalesce-labs/issue/CTL-313).

## Architecture

```
NL string ──► Groq (JSON mode, llama-3.1-8b-instant)
                │
                ▼
        DSL JSON (validated against canonical field whitelist)
                │
        ┌───────┴────────┐
        ▼                ▼
   jq predicate    JS predicate fn
   (used by CLI)   (used by TUI)
        │                │
        ▼                ▼
   apply_filter     events.filter(fn)
   on JSONL log     in catalyst-hud
```

The DSL field whitelist (`plugins/dev/scripts/lib/dsl-fields.mjs`, 31 canonical paths) is the single source of truth — both the Groq system prompt and the validator import it, so prompt/validator drift is caught at test time.

## Acceptance examples

All five ticket-spec example queries are covered by tests (`--dsl` Groq-bypass) and confirmed against the live event log via `--explain`:

| Query | Behavior |
|---|---|
| `show all gh events for ADV-292 and ADV-293 that are PR or CI` | AND of ticket IN + event.name startsWith(github.pr./check_/workflow_run.) |
| `errors in the last hour` | severityText eq "ERROR" AND ts gte `{NOW-1h}` (placeholder rewritten by caller) |
| `all events for orch-adv-852-2026-05-07` | attributes."catalyst.orchestrator.id" eq "<id>" |
| `failed CI on main branch` | event.name startsWith github.check_ AND conclusion eq failure AND ref eq refs/heads/main |
| `delete all heartbeat events` | refused with `{"error":"refused: query is read-only"}` |

No silent fallbacks: unknown field exits 4 with the bad path and a Levenshtein-suggested replacement; malformed Groq output exits 3 with the raw text; HTTP errors exit 3 with status + body.

## TUI keys (catalyst-hud)

| Key | Action |
|---|---|
| `:` | Open NL query input bar |
| `Enter` (in input) | Send to Groq, apply DSL filter to current view |
| `?` | Toggle generated DSL overlay (after a query is set) |
| `Esc` | Cancel input or drop the active DSL filter |

The DSL filter ANDs with the existing substring filter and trace/orch pivot in `useFilter`.

## Test plan

- [x] `bun test plugins/dev/scripts/lib/dsl-compile.test.mjs` — 75 pass / 195 expects (whitelist, validator, JS evaluator, jq compiler, JS↔jq agreement on 13 fixtures, Groq response parsing, system-prompt sanity)
- [x] `bash plugins/dev/scripts/catalyst-events.query.test.sh` — 22 pass (full CLI surface against a fixture log via `--dsl`)
- [x] `bun test plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.test.ts` — 7 pass (pivot ∧ DSL ∧ substring composition)
- [x] `cd plugins/dev/scripts/orch-monitor && bun run typecheck` — clean (only pre-existing `ui/src/lib/briefings.ts` errors unrelated to this PR)
- [x] `bun run lint` — clean (only pre-existing `preview-status.ts` warning)
- [x] Reward-hacking scan — no `as any`, `as unknown as`, `@ts-ignore`, non-null `!`, `forEach(async`, void tricks in any new file
- [x] Live `catalyst-events query --explain` against `~/catalyst/events/2026-05.jsonl` — produces correct DSL JSON
- [x] Live `catalyst-events query --dsl '<filter>'` against the production log — returns matching events
- [ ] Manual TUI smoke test: launch `catalyst-hud`, press `:`, type "errors today", Enter, verify filter applies; press `?`, verify DSL overlay; press Esc, verify filter clears

## Files

**New (11)**
- `plugins/dev/scripts/lib/dsl-fields.mjs` — canonical path whitelist
- `plugins/dev/scripts/lib/dsl-compile.mjs` — validator, JS evaluator, jq compiler, Groq client
- `plugins/dev/scripts/lib/dsl-compile.d.mts` — TypeScript declarations for TUI consumers
- `plugins/dev/scripts/lib/dsl-prompt.mjs` — system prompt + few-shot examples (built from CANONICAL_FIELDS)
- `plugins/dev/scripts/lib/dsl-prompt.d.mts`
- `plugins/dev/scripts/lib/dsl-cli.mjs` — Node entry the bash CLI shells to
- `plugins/dev/scripts/lib/dsl-compile.test.mjs` — 75 unit tests
- `plugins/dev/scripts/catalyst-events.query.test.sh` — 22 shell integration tests
- `plugins/dev/scripts/orch-monitor/cli/components/QueryInput.tsx` — Ink NL input bar
- `plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.test.ts` — pipeline composition tests
- `plugins/dev/skills/catalyst-events-query/SKILL.md` — protocol reference + acceptance examples

**Modified (4)**
- `plugins/dev/scripts/catalyst-events` — new `cmd_query` subcommand + dispatch arm + help text
- `plugins/dev/scripts/orch-monitor/cli/hud.tsx` — `:` / `?` key handlers, async submit, DSL overlay
- `plugins/dev/scripts/orch-monitor/cli/hooks/useFilter.ts` — accepts a `dslPredicate` and ANDs into `filtered`
- `plugins/dev/references/event-schema.md` — one-paragraph cross-link to the new query subcommand

## Out of scope (deferred)

- Trace pivot from PR number ("show events with the same trace as PR #501") — needs two-step lookup; v1 returns refused
- Streaming `query --tail` — one-shot only
- Auto-generation of `dsl-fields.mjs` from `event-schema.md` — manual mapping in v1
- Updating `cmd_help` examples in `catalyst-events` to canonical paths — pre-existing doc debt

## Configuration

| Env var | Purpose |
|---|---|
| `GROQ_API_KEY` | Groq API key. Falls back to `~/.config/catalyst/config.json::groq.apiKey`. |
| `FILTER_GROQ_MODEL` | Model override (default: `llama-3.1-8b-instant`) |