### PR TITLE
docs(dev): refresh website docs for CTL-303 through CTL-315 (CTL-316)

### DIFF
--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -23,7 +23,7 @@ The setup script checks for and installs additional dependencies automatically:
 | GitHub CLI (gh) | Optional | Opens install page |
 | Linearis CLI | Optional | Shows npm install command |
 | agent-browser | Optional | Shows npm install command |
-| Bun | Optional | For orch-monitor dashboard |
+| Bun | Required | For the broker, forwarder, HUD, and orch-monitor dashboard |
 | direnv | Recommended | Per-project env vars, API key isolation |
 
 ## Run the Setup Script
@@ -57,7 +57,7 @@ Restart Claude Code after installing.
 
 ## Install the catalyst-* CLIs
 
-Several Catalyst skills invoke shell tools by bare name (`catalyst-events`, `catalyst-comms`, `catalyst-session`, ...). Install symlinks to them on your PATH:
+Several Catalyst skills invoke shell tools by bare name (`catalyst-broker`, `catalyst-comms`, `catalyst-events`, `catalyst-filter`, `catalyst-session`, `catalyst-state`, `catalyst-db`, `catalyst-monitor`, `catalyst-thoughts`, `catalyst-claude`, `catalyst-hud`, `catalyst-hud-classic`, ...). Install symlinks to them on your PATH:
 
 ```bash
 bash ~/.claude/plugins/cache/catalyst/catalyst-dev/*/scripts/install-cli.sh
@@ -72,7 +72,11 @@ Verify the install:
 ```bash
 which catalyst-events
 catalyst-events help
+catalyst-broker --help    # canonical event broker (CTL-315)
 ```
+
+`catalyst-filter` is preserved as a backward-compatibility shim that delegates to
+`catalyst-broker` — existing scripts keep working unchanged.
 
 If you previously ran the installer and have `alias catalyst-*=...` lines in `~/.zshrc` or `~/.bashrc` pointing at a local clone, remove them — they shadow the marketplace install.
 

--- a/website/src/content/docs/getting-started/the-stack.md
+++ b/website/src/content/docs/getting-started/the-stack.md
@@ -35,6 +35,9 @@ This is **not** a one-click installer. It's not a polished, end-to-end package t
 
 | Tool | Role |
 |------|------|
+| `catalyst-broker` | Local event broker — canonical OTel-shaped envelope, agent identity, ticket/PR auto-correlation (CTL-303) |
+| `catalyst-otel-forward` | Tail-and-forward daemon — fans canonical events out to OTLP, PostHog, and Cloudflare AE (CTL-306) |
+| `catalyst-hud` | Ink-based terminal HUD — live event stream with scrollback, filter, detail pane, trace pivot |
 | [OpenTelemetry](https://opentelemetry.io) | Structured telemetry from agent runs |
 | [Grafana](https://grafana.com) | Dashboards, alerting, log exploration |
 | SQLite | Local session store and cost tracking |
@@ -68,6 +71,7 @@ Catalyst grew out of friction I hit using other orchestration tools. A short tou
 
 - Warp
 - [Catalyst Monitor](/observability/monitor/) (web UI) — live view of orchestration waves and worker status
+- `catalyst-hud` (terminal) — live event stream from the broker
 - Linear — tickets and cycle state
 - Grafana — Claude OpenTelemetry dashboard for token and cost monitoring
 - GitHub (or [GitKraken](https://www.gitkraken.com)) — to watch PRs open, CI run, and merges land

--- a/website/src/content/docs/guided-workflows/phases.md
+++ b/website/src/content/docs/guided-workflows/phases.md
@@ -27,10 +27,11 @@ Phase 2 (plan)      reads research doc path from workflow context
 Phase 3 (implement) reads plan doc path from workflow context
 Phase 4 (validate)  reads plan doc + the implementation diff
 Phase 5 (ship)      reads everything above to write the PR description, then
-                    enters a catalyst-events wait-for listen loop — resolves CI
-                    failures, bot review threads, and BEHIND inline — executes
-                    gh pr merge --squash --delete-branch when CLEAN, writes
-                    status: done, and exits
+                    enters a `catalyst-events wait-for` listen loop (powered by
+                    the [`catalyst-broker`](/observability/catalyst-broker/)
+                    daemon) — resolves CI failures, bot review threads, and
+                    BEHIND inline — executes gh pr merge --squash --delete-branch
+                    when CLEAN, writes status: done, and exits
 ```
 
 This is why "the thoughts/ directory is the handoff mechanism" — artifacts live there so **any future session**, not just this one, can pick up where the current one left off.

--- a/website/src/content/docs/observability/catalyst-broker.md
+++ b/website/src/content/docs/observability/catalyst-broker.md
@@ -98,6 +98,9 @@ catalyst-broker run      # foreground mode (useful for debugging)
 ```
 
 The daemon writes its PID to `~/catalyst/broker.pid` and logs to `~/catalyst/broker.log`.
+Logs are emitted as pino-formatted structured JSON lines (CTL-314) — pipe through `pino-pretty`
+for human-readable output, or query directly with `jq`. The log level is controlled by the
+`LOG_LEVEL` environment variable (see Configuration Reference).
 It persists registered interests to `~/catalyst/broker-interests.json` so they survive a
 restart. On first start after upgrading from CTL-303, the daemon migrates a legacy
 `filter-interests.json` to the new path automatically.
@@ -205,6 +208,36 @@ or comms messages addressed to your orchestrator:
 The `context` object is included in the Groq prompt alongside the intent so the LLM knows which
 PR numbers and tickets belong to this interest.
 
+#### ticket_lifecycle — deterministic Linear routing
+
+Mirroring `pr_lifecycle` for GitHub PRs, `ticket_lifecycle` is a deterministic interest type for
+Linear ticket events. Use it when you want to wake on state changes, comments, or PR links for a
+known ticket without paying for a Groq round-trip:
+
+```json
+{
+  "ts": "2026-05-08T07:00:00Z",
+  "event": "filter.register",
+  "orchestrator": "orch-ctl-api-2026-05-08",
+  "worker": null,
+  "detail": {
+    "interest_id": "sess_20260508_abc123",
+    "session_id": "sess_20260508_abc123",
+    "interest_type": "ticket_lifecycle",
+    "notify_event": "filter.wake.sess_20260508_abc123",
+    "persistent": true,
+    "tickets": ["CTL-253"],
+    "wake_on": ["status_done", "pr_opened", "pr_merged"]
+  }
+}
+```
+
+Supported `wake_on` values include `status_done`, `status_in_review`, `status_changed`,
+`comment_added`, `pr_opened`, and `pr_merged`. Omit `wake_on` to fire on any of them. Like
+`pr_lifecycle`, this path requires no Groq API key. See the
+[`broker` skill](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/broker/SKILL.md)
+for the full agent-facing protocol.
+
 ### filter.wake
 
 When the daemon finds a match, it appends a `filter.wake.<id>` event to the log:
@@ -254,6 +287,41 @@ The daemon also auto-deregisters interests when:
 - `orchestrator-completed` or `orchestrator-failed` events arrive with a matching orchestrator ID
 - A `session_id` has not produced a heartbeat for more than 3 minutes (watchdog cleanup)
 - `persistent: false` is set and the first wake has fired
+
+## Agent Identity and Auto-Correlation
+
+CTL-303 introduced a structured agent-identity protocol on top of the interest registration above.
+Instead of every agent hand-rolling a `filter.register`, agents emit `agent.checkin` at startup
+and `agent.checkout` at exit. The broker watches for these events and auto-derives the obvious
+interests — most notably a `pr_lifecycle` interest from a `claimed_pr` field.
+
+```json
+{
+  "ts": "2026-05-08T07:00:00Z",
+  "event": "agent.checkin",
+  "detail": {
+    "session_id": "sess_20260508_abc123",
+    "ticket": "CTL-253",
+    "orchestrator": "orch-ctl-api-2026-05-08",
+    "claimed_pr": 445,
+    "repo": "coalesce-labs/catalyst",
+    "base_branches": [{"pr": 445, "base": "main"}]
+  }
+}
+```
+
+When the broker sees `claimed_pr` in an `agent.checkin`, it registers a `pr_lifecycle` interest
+keyed on `session_id` automatically — the worker can then `wait-for` on
+`filter.wake.${session_id}` without ever calling `filter.register` itself.
+
+A second `agent.checkin` for the same `session_id` updates the existing identity (used to claim a
+PR after the worker discovers its number). On `agent.checkout` (or after the watchdog declares
+the session stale via heartbeat absence), the broker auto-deregisters all interests derived from
+that identity.
+
+The agent-facing protocol — recommended emit timing, identity fields, fallback behavior when the
+broker is not running — is documented in the [`broker`
+skill](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/broker/SKILL.md).
 
 ## Writing Effective Intent Prompts
 
@@ -337,6 +405,7 @@ for backward compatibility — the broker reads the same names.
 | `FILTER_WATCHDOG_INTERVAL_MS` | `60000` | How often the watchdog checks for stale sessions |
 | `FILTER_HEARTBEAT_STALE_MS` | `180000` | Session idle timeout before interest auto-deregistration |
 | `CATALYST_DIR` | `~/catalyst` | Directory for PID file, log, interests file, and SQLite DB |
+| `LOG_LEVEL` | `info` | pino log level: `trace` / `debug` / `info` / `warn` / `error` (CTL-314) |
 
 ## Relationship to catalyst-events wait-for
 
@@ -400,6 +469,9 @@ catalyst-events wait-for \
 
 - [Event Architecture](./events/) — the global event log and `catalyst-events` CLI that
   `catalyst-broker` reads and writes.
+- [Tail-and-forward (catalyst-otel-forward)](./forwarder/) — sibling daemon that ships canonical
+  events to OTLP / PostHog / Cloudflare Analytics Engine.
+- [Terminal HUD (catalyst-hud)](./hud/) — Ink TUI for viewing the same event stream.
 - [GitHub Webhooks](./webhooks/) — how raw GitHub events enter the event log.
 - [Orchestration](../reference/orchestration/) — how orchestrators register prose interests to
   monitor their entire worker wave.

--- a/website/src/content/docs/observability/catalyst-events.md
+++ b/website/src/content/docs/observability/catalyst-events.md
@@ -37,20 +37,29 @@ pretty-printed JSON object. Runs until interrupted.
 # All events in real time
 catalyst-events tail
 
-# Only GitHub webhook events
-catalyst-events tail --filter '.event | startswith("github.")'
+# Only GitHub webhook events (canonical envelope, CTL-300)
+catalyst-events tail --filter '.attributes."event.name" | startswith("github.")'
 
 # Linear issue state changes for a specific ticket
-catalyst-events tail --filter '.event == "linear.issue.state_changed" and .body.payload.identifier == "CTL-48"'
+catalyst-events tail --filter '.attributes."event.name" == "linear.issue.state_changed" and .body.payload.identifier == "CTL-48"'
 
-# All worker lifecycle events
+# All worker lifecycle events (v1 envelope writers)
 catalyst-events tail --filter '.event | startswith("worker-")'
 
 # Events for one orchestrator
-catalyst-events tail --filter '.orchestrator == "orch-ctl-2026-05-01"'
+catalyst-events tail --filter '.attributes."catalyst.orchestrator.id" == "orch-ctl-2026-05-01"'
 
 # Comms messages on a specific channel
-catalyst-events tail --filter '.event == "comms.message.posted" and .attributes."comms.channel" == "orch-ctl-ux"'
+catalyst-events tail --filter '.attributes."event.name" == "comms.message.posted" and .attributes."comms.channel" == "orch-ctl-ux"'
+
+# Agent checkin / checkout (CTL-303)
+catalyst-events tail --filter '.attributes."event.name" == "agent.checkin" or .attributes."event.name" == "agent.checkout"'
+
+# Broker daemon startup
+catalyst-events tail --filter '.attributes."event.name" == "broker.daemon.startup"'
+
+# All ticket_lifecycle wake events (CTL-303)
+catalyst-events tail --filter '.attributes."event.name" | startswith("filter.wake.")'
 ```
 
 ### `wait-for`
@@ -71,14 +80,14 @@ external event without busy-polling.
 ```bash
 # Wait up to 120s for a CI result on PR #87
 catalyst-events wait-for \
-  --filter '.event == "github.check_suite.completed" and (.body.payload.prNumbers // [] | contains([87]))' \
+  --filter '.attributes."event.name" == "github.check_suite.completed" and (.body.payload.prNumbers // [] | contains([87]))' \
   --timeout 120
 
 # Wait for a specific PR to merge
 catalyst-events wait-for \
-  --filter '.event == "github.pr.merged" and .attributes."vcs.pr.number" == 87'
+  --filter '.attributes."event.name" == "github.pr.merged" and .attributes."vcs.pr.number" == 87'
 
-# Wait for a filter daemon wake event (CTL-269 semantic interests)
+# Wait for a broker wake event (CTL-303 — semantic interests)
 catalyst-events wait-for \
   --filter '.attributes."event.name" == "filter.wake" and .attributes."event.label" == "sess_abc123"' \
   --timeout 600
@@ -95,7 +104,7 @@ catalyst-events wait-for \
 When the orch-monitor is running with webhooks configured, `wait-for` returns within ~1s of
 the event arriving via GitHub/Linear webhook. Without the monitor tunnel, the daemon falls
 back to polling the event log file at 10-minute intervals — up to 600s maximum latency. See
-[Setting up the webhook tunnel](./setup/#5-set-up-the-webhook-tunnel).
+[Setting up the webhook tunnel](./setup/#7-set-up-the-webhook-tunnel).
 
 ### `build-orchestrator-filter`
 
@@ -113,11 +122,53 @@ catalyst-events wait-for --filter "$FILTER" --timeout 3600
 
 ## Event Envelope Schemas
 
-The unified event log contains events from multiple writers. Two envelope shapes coexist:
+The unified event log contains events from multiple writers. Two envelope shapes coexist —
+the canonical OTel-shaped envelope (CTL-300) is the default for new emitters, and the
+legacy v1 envelope is preserved for `catalyst-state.sh event` and the bash skills that call
+it.
+
+### Canonical envelope (CTL-300, default)
+
+Written by the webhook receiver (`lib/webhook-events.ts`), `catalyst-comms send`,
+`catalyst-broker`, `catalyst-otel-forward`, `catalyst-session.sh`, and the OTel emit scripts
+under `plugins/dev/scripts/orch-monitor/lib/`:
+
+```json
+{
+  "ts": "2026-05-01T12:00:00Z",
+  "observedTs": "2026-05-01T12:00:00Z",
+  "severityText": "INFO",
+  "severityNumber": 9,
+  "traceId": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+  "spanId": "1122334455667788",
+  "parentSpanId": null,
+  "resource": {
+    "service.name": "orch-monitor",
+    "service.namespace": "catalyst",
+    "service.version": "8.1.0"
+  },
+  "attributes": {
+    "event.name": "github.pr.merged",
+    "event.entity": "pr",
+    "event.action": "merged",
+    "vcs.pr.number": 87,
+    "vcs.revision": "abc123def456"
+  },
+  "body": {
+    "message": "PR #87 merged",
+    "payload": { "...full webhook payload..." }
+  }
+}
+```
+
+Top-level fields: `ts`, `observedTs`, `severityText`, `severityNumber`, `traceId`, `spanId`,
+`parentSpanId`, `resource`, `attributes`, `body`. The bare `.event` shorthand is absent —
+use `.attributes."event.name"`. The `traceId` is populated by webhook-emitted events
+(CTL-310) and is derived deterministically from orchestrator/worker identifiers.
 
 ### v1 envelope (legacy)
 
-Written by `catalyst-state.sh event` and most bash skills:
+Written by `catalyst-state.sh event` and the older bash skills that call it:
 
 ```json
 {
@@ -134,42 +185,18 @@ Written by `catalyst-state.sh event` and most bash skills:
 
 Top-level fields: `ts`, `event`, `orchestrator` (nullable), `worker` (nullable), `detail` (nullable object).
 
-### v2 envelope (OTel-shaped)
-
-Written by the webhook receiver (`lib/webhook-events.ts`) and `catalyst-comms send` (CTL-300):
-
-```json
-{
-  "ts": "2026-05-01T12:00:00Z",
-  "attributes": {
-    "event.name": "github.pr.merged",
-    "vcs.pr.number": 87,
-    "vcs.revision": "abc123def456"
-  },
-  "body": {
-    "payload": { "...full webhook payload..." }
-  },
-  "resource": {
-    "service.name": "orch-monitor"
-  }
-}
-```
-
-Top-level fields: `ts`, `attributes` (OTel attribute map), `body`, `resource`. The `.event`
-shorthand field is absent — use `.attributes."event.name"` instead.
-
 ### Identifying the envelope version
 
 ```bash
 # v1 events have a top-level .event field
 catalyst-events tail --filter '.event != null'
 
-# v2 events have .attributes."event.name"
+# Canonical events have .attributes."event.name"
 catalyst-events tail --filter '.attributes."event.name" != null'
 ```
 
-Both shapes coexist indefinitely. New tools should write v2; `catalyst-state.sh event`
-continues to write v1 for backward compatibility.
+Both shapes coexist indefinitely. New tools write the canonical envelope;
+`catalyst-state.sh event` continues to write v1 for backward compatibility.
 
 ## jq Filter Cookbook
 
@@ -189,19 +216,43 @@ continues to write v1 for backward compatibility.
 ### Match by event prefix
 
 ```bash
---filter '.event | startswith("worker-")'                     # v1 worker lifecycle
---filter '.attributes."event.name" | startswith("github.")'  # v2 GitHub webhook
---filter '.attributes."event.name" | startswith("linear.")'  # v2 Linear webhook
+--filter '.event | startswith("worker-")'                     # v1 worker lifecycle (legacy)
+--filter '.attributes."event.name" | startswith("github.")'  # canonical GitHub webhook
+--filter '.attributes."event.name" | startswith("linear.")'  # canonical Linear webhook
+--filter '.attributes."event.name" | startswith("agent.")'   # broker agent identity (CTL-303)
+--filter '.attributes."event.name" | startswith("filter.")'  # broker register/deregister/wake
+--filter '.attributes."event.name" | startswith("broker.")'  # broker daemon lifecycle
 ```
 
 ### Match by orchestrator scope
 
 ```bash
-# v1 orchestrator events
+# v1 orchestrator events (legacy)
 --filter '.orchestrator == "orch-ctl-2026-05-01"'
 
-# v2 events don't carry .orchestrator — filter by session or ticket instead
+# Canonical envelope — orchestrator id lives under attributes
+--filter '.attributes."catalyst.orchestrator.id" == "orch-ctl-2026-05-01"'
+
+# Canonical envelope — filter by ticket
 --filter '.attributes."worker.ticket" == "CTL-48"'
+```
+
+### Match a ticket_lifecycle interest (CTL-303)
+
+```bash
+# Wait for any state change on a Linear ticket — the broker's deterministic
+# ticket_lifecycle router computes the wake.
+catalyst-events wait-for \
+  --filter '.attributes."event.name" | startswith("filter.wake.")' \
+  --timeout 600
+```
+
+### Match the comms feed
+
+```bash
+# broker wake event (CTL-303) — emitted when comms.message.posted arrives for a watched channel
+catalyst-events tail \
+  --filter '.attributes."event.name" == "comms.message.posted" and .attributes."comms.channel" == "orch-ctl-ux"'
 ```
 
 ### PR lifecycle — wait for any status change

--- a/website/src/content/docs/observability/event-flow.md
+++ b/website/src/content/docs/observability/event-flow.md
@@ -9,7 +9,7 @@ When a Catalyst worker calls `catalyst-events wait-for`, it blocks until a speci
 in the unified log at `~/catalyst/events/YYYY-MM.jsonl`. This page explains exactly how an event
 gets from GitHub (or Linear) to that log so the waiting process wakes up.
 
-## The three paths
+## The paths in and out of the event log
 
 ```
 ┌─────────────┐
@@ -42,8 +42,31 @@ gets from GitHub (or Linear) to that log so the waiting process wakes up.
 └──────────────────┘   ~/catalyst/events/YYYY-MM.jsonl
 ```
 
-All three paths converge on the same monthly JSONL file. A worker using `catalyst-events wait-for`
-monitors that file regardless of which path produced the event.
+```
+┌──────────────────┐
+│ catalyst-broker  │ ──fs.watch on event log──> deterministic + Groq routing
+│ (CTL-303 daemon) │ ──filter.wake.<id> append──>
+└──────────────────┘   ~/catalyst/events/YYYY-MM.jsonl
+                                    │
+                       catalyst-events wait-for ──> registered agent wakes
+```
+
+```
+┌────────────────────────┐
+│ catalyst-otel-forward  │ ──byte-offset tail──>
+│ (CTL-306 daemon)       │   ~/catalyst/events/YYYY-MM.jsonl
+└────────────────────────┘
+            │
+            ├──> OTLP/HTTP collector
+            ├──> PostHog
+            └──> Cloudflare Analytics Engine
+```
+
+All inbound paths converge on the same monthly JSONL file. The broker daemon is both a
+**reader** (tails the log via `fs.watch`) and a **writer** (appends `filter.wake.<id>` events
+when a registered interest matches). The forwarder is a pure outbound consumer — it never
+writes back. Workers using `catalyst-events wait-for` monitor that file regardless of which
+path produced the event.
 
 ## Step-by-step: a GitHub PR merge
 
@@ -55,17 +78,30 @@ monitors that file regardless of which path produced the event.
 
 4. **orch-monitor verifies the HMAC signature.** Each delivery is signed by GitHub using the shared secret configured in the env var named by `catalyst.monitor.github.webhookSecretEnv` (default: `CATALYST_WEBHOOK_SECRET`). Deliveries that fail HMAC verification are dropped.
 
-5. **orch-monitor normalizes the event.** The webhook handler maps the raw GitHub payload to a v2 OTel-shaped envelope:
+5. **orch-monitor normalizes the event.** The webhook handler maps the raw GitHub payload to the
+   canonical OTel-shaped envelope (CTL-300). Filters use `.attributes."event.name"` — the
+   bare `.event` shorthand is absent. As of CTL-310, webhook-emitted events also carry a
+   top-level `traceId` so cross-service correlation against OTel traces is possible:
    ```json
    {
      "ts": "2026-05-01T14:22:01Z",
+     "severityText": "INFO",
+     "severityNumber": 9,
+     "traceId": "a1b2c3d4e5f6…",
+     "spanId": "1122334455667788",
      "attributes": {
        "event.name": "github.pr.merged",
+       "event.entity": "pr",
+       "event.action": "merged",
        "vcs.pr.number": 87,
        "vcs.revision": "abc123def"
      },
      "body": { "payload": { "...full webhook payload..." } },
-     "resource": { "service.name": "orch-monitor" }
+     "resource": {
+       "service.name": "orch-monitor",
+       "service.namespace": "catalyst",
+       "service.version": "8.1.0"
+     }
    }
    ```
 
@@ -81,7 +117,7 @@ If the smee tunnel is not configured, step 2 never happens. The orch-monitor fal
 
 Skills detect this automatically: the oneshot Phase 5 listen loop checks tunnel status before entering the event-driven path and switches to the REST fallback if the tunnel is not running.
 
-See [Setting up the webhook tunnel](./setup/#5-set-up-the-webhook-tunnel) to configure near-real-time delivery.
+See [Setting up the webhook tunnel](./setup/#7-set-up-the-webhook-tunnel) to configure near-real-time delivery.
 
 ## Linear webhook path
 
@@ -108,16 +144,57 @@ catalyst-state.sh event "$(jq -nc \
 ```
 
 These produce v1 envelopes (`.event` top-level field, no `.attributes`). `catalyst-events wait-for`
-handles both v1 and v2 shapes — the jq filter sees the raw line, so write filters that match the
-actual field location:
+handles both v1 and canonical shapes — the jq filter sees the raw line, so write filters that
+match the actual field location:
 
 ```bash
-# Match v1 worker-done
+# Match v1 worker-done (legacy)
 --filter '.event == "worker-done" and .worker == "CTL-48"'
 
-# Match v2 github.pr.merged
+# Match canonical github.pr.merged (CTL-300)
 --filter '.attributes."event.name" == "github.pr.merged"'
 ```
+
+## Canonical envelopes (CTL-300)
+
+All new emitters write the canonical shape — the webhook receiver
+(`lib/webhook-events.ts`), `catalyst-comms send`, `catalyst-broker`, `catalyst-session.sh`,
+and the OTel emit scripts under `plugins/dev/scripts/orch-monitor/lib/`. The shape mirrors
+OTel `LogRecord` so downstream forwarders can transcode to OTLP without translation:
+
+```json
+{
+  "ts": "2026-05-01T14:22:01Z",
+  "observedTs": "2026-05-01T14:22:01Z",
+  "severityText": "INFO",
+  "severityNumber": 9,
+  "traceId": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+  "spanId": "1122334455667788",
+  "parentSpanId": null,
+  "resource": {
+    "service.name": "orch-monitor",
+    "service.namespace": "catalyst",
+    "service.version": "8.1.0"
+  },
+  "attributes": {
+    "event.name": "github.pr.merged",
+    "event.entity": "pr",
+    "event.action": "merged",
+    "vcs.pr.number": 87,
+    "vcs.revision": "abc123def"
+  },
+  "body": {
+    "message": "PR #87 merged",
+    "payload": { "...full webhook payload..." }
+  }
+}
+```
+
+Top-level fields: `ts`, `observedTs`, `severityText`, `severityNumber`, `traceId`, `spanId`,
+`parentSpanId`, `resource`, `attributes`, `body`. The `.event` shorthand is absent — use
+`.attributes."event.name"`. The `traceId` is populated by webhook emitters as of CTL-310 and
+is derived deterministically from orchestrator/worker identifiers so any producer can compute
+the same ID without coordination.
 
 ## Replay on monitor startup
 

--- a/website/src/content/docs/observability/events.md
+++ b/website/src/content/docs/observability/events.md
@@ -9,11 +9,11 @@ Catalyst's observability layer has three tiers of durability, and frontends (web
 
 ## The three sources of truth
 
-| Source | Kind | Writer | Lifetime |
-|--------|------|--------|----------|
+| Source | Kind | Writers | Lifetime |
+|--------|------|---------|----------|
 | **Worker signal file** (`<orch-dir>/workers/<ticket>.json`) | Mutable snapshot | Worker, orchestrator | Archived with the orchestrator dir |
 | **Global state** (`~/catalyst/state.json`) | Mutable snapshot | `catalyst-state.sh worker` / `orchestrator` | Persists across all orchestrations |
-| **Global event log** (`~/catalyst/events/YYYY-MM.jsonl`) | Append-only (monthly rotation) | `catalyst-state.sh event` | Never truncated automatically |
+| **Global event log** (`~/catalyst/events/YYYY-MM.jsonl`) | Append-only (monthly rotation) | webhook receiver (`lib/webhook-events.ts`), `catalyst-state.sh event` (v1 envelope, legacy), `catalyst-comms send`, `catalyst-broker` daemon, `catalyst-otel-forward` daemon, `catalyst-session.sh`, OTel emit scripts under `plugins/dev/scripts/orch-monitor/lib/` | Never truncated automatically |
 
 Snapshots answer "what is the state right now?" — the event log answers "what happened and when?". Both matter.
 
@@ -118,17 +118,23 @@ Tails the current month's event log, printing each new line as it arrives. Use `
 any jq expression to narrow output:
 
 ```bash
-# All GitHub webhook events
-catalyst-events tail --filter '.source == "github.webhook"'
+# All GitHub webhook events (canonical envelope, CTL-300)
+catalyst-events tail --filter '.attributes."event.name" | startswith("github.")'
 
 # Linear issue state changes
-catalyst-events tail --filter '.event | startswith("linear.issue.state")'
+catalyst-events tail --filter '.attributes."event.name" | startswith("linear.issue.state")'
 
-# Events for a specific ticket
-catalyst-events tail --filter '.worker == "CTL-48"'
+# Events for a specific ticket (canonical envelope)
+catalyst-events tail --filter '.attributes."worker.ticket" == "CTL-48"'
 
-# Worker lifecycle events only
+# Worker lifecycle events written via the v1 envelope (legacy `.event` field)
 catalyst-events tail --filter '.event | startswith("worker-")'
+
+# Agent identity (CTL-303)
+catalyst-events tail --filter '.attributes."event.name" == "agent.checkin"'
+
+# Broker daemon startup
+catalyst-events tail --filter '.attributes."event.name" == "broker.daemon.startup"'
 ```
 
 ### `wait-for`
@@ -141,8 +147,8 @@ Blocks until a matching event appears (or timeout expires). Used internally by s
 need to synchronize on external events:
 
 ```bash
-# Wait up to 120s for a PR merge event for ticket CTL-48
-catalyst-events wait-for --filter '.event == "github.pr.merged" and .worker == "CTL-48"' --timeout 120
+# Wait up to 120s for a PR merge event for ticket CTL-48 (canonical envelope)
+catalyst-events wait-for --filter '.attributes."event.name" == "github.pr.merged" and .attributes."worker.ticket" == "CTL-48"' --timeout 120
 ```
 
 When the orch-monitor is running with webhooks configured, `wait-for` returns within ~1s of the
@@ -151,7 +157,9 @@ intervals (600s maximum latency).
 
 ## Event topics in the log
 
-Every record in `~/catalyst/events/YYYY-MM.jsonl` has an `event` field with a dot-namespaced topic:
+Every record in `~/catalyst/events/YYYY-MM.jsonl` carries a topic. Canonical envelopes
+(CTL-300) put it at `.attributes."event.name"`; v1 envelopes (`catalyst-state.sh event`) put
+it at `.event`.
 
 | Topic pattern | Source | Description |
 |---------------|--------|-------------|
@@ -166,7 +174,11 @@ Every record in `~/catalyst/events/YYYY-MM.jsonl` has an `event` field with a do
 | `linear.comment.created` | Linear webhook | Comment on a Linear issue |
 | `linear.cycle.*` | Linear webhook | Cycle create/update/remove |
 | `comms.message.posted` | catalyst-comms | Agent coordination message |
-| `worker-dispatched` / `worker-pr-created` / `worker-done` | Orchestrator | Worker lifecycle |
+| `agent.checkin` / `agent.checkout` | catalyst-broker (CTL-303) | Agent identity register / unregister |
+| `broker.daemon.startup` | catalyst-broker (CTL-303) | Broker daemon started; legacy alias `filter.daemon.startup` |
+| `filter.register` / `filter.deregister` | catalyst-broker | Interest registered or deregistered |
+| `filter.wake.<id>` | catalyst-broker | Wake event delivered to a registered interest |
+| `worker-dispatched` / `worker-pr-created` / `worker-done` | Orchestrator (v1 envelope) | Worker lifecycle |
 | `catalyst.*` | catalyst-session | Skill/session lifecycle events |
 
 GitHub and Linear topics arrive via webhooks when the monitor is configured (see

--- a/website/src/content/docs/observability/forwarder.md
+++ b/website/src/content/docs/observability/forwarder.md
@@ -1,0 +1,251 @@
+---
+title: Event Forwarder (catalyst-otel-forward)
+description: Tail-and-forward daemon that ships canonical Catalyst events to OTLP, PostHog, and Cloudflare Analytics Engine.
+sidebar:
+  order: 7
+---
+
+`catalyst-otel-forward` is a long-running daemon that tails the canonical Catalyst event log
+(`~/catalyst/events/YYYY-MM.jsonl`) and fans events out to up to three independent
+destinations — an OTLP/HTTP endpoint, PostHog, and Cloudflare Analytics Engine — so the same
+event stream that drives `catalyst-broker` and `catalyst-hud` also lands in your existing
+observability and product-analytics stack.
+
+## Architecture
+
+```mermaid
+graph LR
+  EL[(Event log\n~/catalyst/events/\nYYYY-MM.jsonl)] -->|byte-offset tail\n200 ms poll| FW[catalyst-otel-forward\ndaemon]
+
+  FW -->|/v1/logs| OTLP[OTLP/HTTP\ncollector]
+  FW -->|/batch| PH[PostHog]
+  FW -->|datasets/&lt;name&gt;| CAE[Cloudflare\nAnalytics Engine]
+
+  OTLP -.->|on failure| DLQ1[(otel-forward-dlq-otlp.jsonl)]
+  PH -.->|on failure| DLQ2[(otel-forward-dlq-posthog.jsonl)]
+  CAE -.->|on failure| DLQ3[(otel-forward-dlq-cae.jsonl)]
+
+  CK[(otel-forward.checkpoint.json)] -.->|read on start\nwrite every 10 s| FW
+```
+
+The three senders are independent — one destination failing never blocks the others, and each
+has its own dead-letter queue that auto-replays on the next successful flush.
+
+Only canonical events (lines with a top-level `attributes` key, per CTL-300) are forwarded.
+Legacy format lines are counted as `skipped` and dropped.
+
+## Quick Start
+
+```bash
+# 1. Add destination credentials to ~/.config/catalyst/config-{projectKey}.json
+#    (see Configuration below — all forwarders are disabled by default)
+
+# 2. Start the daemon in the background
+catalyst-monitor.sh forward-start
+
+# 3. Confirm it's running
+catalyst-monitor.sh forward-status
+# → running (pid 12345)
+
+# 4. Tail logs
+tail -f ~/catalyst/otel-forward.log
+```
+
+## Configuration
+
+Config lives in `~/.config/catalyst/config-{projectKey}.json` under
+`catalyst.observability.forwarders`. All forwarders are disabled by default.
+
+### OTLP
+
+```json
+{
+  "catalyst": {
+    "observability": {
+      "forwarders": {
+        "otlp": {
+          "enabled": true,
+          "endpoint": "http://localhost:4318",
+          "batchSize": 100,
+          "flushIntervalMs": 5000
+        }
+      }
+    }
+  }
+}
+```
+
+The `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable overrides `endpoint` (port 4317 is
+automatically rewritten to 4318 for HTTP).
+
+### PostHog
+
+```json
+{
+  "catalyst": {
+    "observability": {
+      "forwarders": {
+        "posthog": {
+          "enabled": true,
+          "apiKey": "phc_YOUR_API_KEY",
+          "host": "https://us.i.posthog.com",
+          "batchSize": 50,
+          "flushIntervalMs": 10000
+        }
+      }
+    }
+  }
+}
+```
+
+### Cloudflare Analytics Engine
+
+```json
+{
+  "catalyst": {
+    "observability": {
+      "forwarders": {
+        "cloudflareAE": {
+          "enabled": true,
+          "accountId": "YOUR_CF_ACCOUNT_ID",
+          "apiToken": "YOUR_CF_API_TOKEN",
+          "dataset": "catalyst_events",
+          "batchSize": 100,
+          "flushIntervalMs": 5000
+        }
+      }
+    }
+  }
+}
+```
+
+## Lifecycle
+
+```bash
+# Start daemon in background
+catalyst-monitor.sh forward-start
+
+# Check status
+catalyst-monitor.sh forward-status
+
+# Stop daemon
+catalyst-monitor.sh forward-stop
+
+# Foreground mode (useful for debugging)
+catalyst-otel-forward
+```
+
+The lifecycle subcommands write a PID file and log path under `~/catalyst/`. The direct
+`catalyst-otel-forward` entry runs in the foreground and exits cleanly on `SIGTERM` or `SIGINT`,
+flushing any buffered batches before stopping.
+
+## Checkpoint Behavior
+
+The daemon persists its read position to `~/catalyst/otel-forward.checkpoint.json` every
+10 seconds. On restart it resumes from the last checkpoint, which means up to 10 seconds of
+events may be re-delivered after a crash or restart — destinations are expected to be
+idempotent.
+
+To reset and reprocess from the beginning of the current month:
+
+```bash
+rm ~/catalyst/otel-forward.checkpoint.json
+```
+
+## Dead-Letter Queues
+
+When a destination fails after all retry attempts, events are appended to a per-destination
+DLQ file:
+
+- `~/catalyst/otel-forward-dlq-otlp.jsonl`
+- `~/catalyst/otel-forward-dlq-posthog.jsonl`
+- `~/catalyst/otel-forward-dlq-cae.jsonl`
+
+Pending DLQ batches are automatically replayed on the next successful flush to that destination.
+A failure on OTLP never affects PostHog or Cloudflare AE — each sender owns its own DLQ.
+
+To discard a DLQ without replaying:
+
+```bash
+rm ~/catalyst/otel-forward-dlq-otlp.jsonl
+```
+
+## Logging
+
+The daemon writes pino-structured JSON logs to stderr (CTL-314). Set the verbosity with the
+`LOG_LEVEL` environment variable before starting:
+
+```bash
+LOG_LEVEL=debug catalyst-monitor.sh forward-start
+```
+
+Valid levels are pino's standard set — `trace`, `debug`, `info` (default), `warn`, `error`,
+`fatal`. Each log entry carries a `name: "forwarder"` field, and per-destination senders add
+a `destination` child binding (`otlp`, `posthog`, or `cae`) so you can filter by sender:
+
+```bash
+tail -f ~/catalyst/otel-forward.log | jq 'select(.destination == "otlp")'
+```
+
+## Debugging
+
+```bash
+# Tail daemon logs
+tail -f ~/catalyst/otel-forward.log
+
+# Verify OTLP connectivity (requires a running collector on :4318)
+curl -s http://localhost:4318/v1/logs \
+  -H "Content-Type: application/json" \
+  -d '{"resourceLogs":[]}' | jq .
+
+# Count events in current log
+wc -l ~/catalyst/events/$(date +%Y-%m).jsonl
+
+# Count canonical vs legacy
+grep -c '"attributes"' ~/catalyst/events/$(date +%Y-%m).jsonl || true
+```
+
+## Validation Queries
+
+### PostHog
+
+In the PostHog UI, filter by event name `session.heartbeat` or build a funnel:
+
+```
+Source: session.heartbeat
+→ worker.done (where distinct_id matches)
+```
+
+### Cloudflare Analytics Engine
+
+```sql
+SELECT
+  blob1 as event_json,
+  index1 as event_name,
+  index2 as service_name,
+  count() as total
+FROM catalyst_events
+WHERE timestamp > NOW() - INTERVAL '1' HOUR
+GROUP BY event_name, service_name
+ORDER BY total DESC
+LIMIT 20
+```
+
+## Source
+
+- CLI wrapper: [`plugins/dev/scripts/catalyst-otel-forward`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-otel-forward)
+- Daemon entry: [`plugins/dev/scripts/otel-forward/index.ts`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/otel-forward/index.ts)
+- Config loader: [`plugins/dev/scripts/otel-forward/lib/config.ts`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/otel-forward/lib/config.ts)
+- OTLP sender: [`plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts)
+- PostHog sender: [`plugins/dev/scripts/otel-forward/lib/destinations/posthog.ts`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/otel-forward/lib/destinations/posthog.ts)
+- Cloudflare AE sender: [`plugins/dev/scripts/otel-forward/lib/destinations/cloudflare-ae.ts`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/otel-forward/lib/destinations/cloudflare-ae.ts)
+
+## Related
+
+- [Event Architecture](./events/) — the global event log this daemon tails.
+- [catalyst-broker](./catalyst-broker/) — sibling daemon that routes events to orchestrators
+  and workers via semantic matching.
+- [Configuration → Forwarders](../reference/configuration/) — full key reference and Layer-2
+  secret storage.
+- [GitHub Webhooks](./webhooks/) — how raw GitHub events enter the event log upstream of
+  the forwarder.

--- a/website/src/content/docs/observability/hud.md
+++ b/website/src/content/docs/observability/hud.md
@@ -1,0 +1,143 @@
+---
+title: Terminal HUD (catalyst-hud)
+description: Ink-based React TUI for the canonical Catalyst event stream — scrollback, filter, detail pane, trace pivot.
+sidebar:
+  order: 8
+---
+
+`catalyst-hud` is a full-screen React TUI built on [Ink](https://github.com/vadimdemedes/ink)
+that tails the canonical Catalyst event log directly from disk and lets you scroll, filter,
+inspect, and pivot on the live event stream. Unlike the [web monitor](./monitor/) — which
+subscribes to an SSE feed of orchestrator state — `catalyst-hud` reads
+`~/catalyst/events/YYYY-MM.jsonl` line-by-line, so it shows every canonical event in the system
+(GitHub, Linear, broker, comms, sessions) and works in a plain terminal with no HTTP server.
+
+## Architecture
+
+```mermaid
+graph LR
+  GH[GitHub webhook] --> EL[(Event log\n~/catalyst/events/\nYYYY-MM.jsonl)]
+  LN[Linear webhook] --> EL
+  CC[Claude Code\nOTel events] --> EL
+  BR[catalyst-broker] --> EL
+
+  EL -->|backlog read +\nfs.watch tail| HUD[catalyst-hud\nInk TUI]
+  EL -->|line-by-line tail\nno SSE| CLS[catalyst-hud-classic.sh\nshell fallback]
+
+  HUD -->|t / o keys| PIVOT[trace / orch\npivot view]
+  HUD -->|Enter| DET[detail pane\nfull JSON]
+  HUD -->|/ key| FLT[substring\nfilter]
+```
+
+Both `catalyst-hud` (Ink) and `catalyst-hud-classic.sh` (shell) read the same JSONL log; they
+do not depend on the web monitor's HTTP server. Each canonical event is rendered as one row;
+the Ink build adds scrollback, a detail pane, and pivots that the classic shell renderer does
+not have.
+
+## Launching
+
+```bash
+# Ink TUI (preferred)
+catalyst-hud
+
+# Optional flags
+catalyst-hud --repo coalesce-labs/catalyst   # filter to one repo
+catalyst-hud --since 30m                     # only show events from last 30 min
+catalyst-hud --filter '.attributes."event.name" | startswith("github.")'
+
+# Classic shell fallback (minimal deps, no Bun required)
+catalyst-hud-classic
+```
+
+The Ink entry is a one-line `bun run` wrapper around `orch-monitor/cli/hud.tsx`. Bun is
+required for the Ink build; the classic shell version runs on bash alone.
+
+## Keybindings
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move selection down one row |
+| `k` / `↑` | Move selection up one row |
+| `PageDown` | Scroll down one page |
+| `PageUp` | Scroll up one page |
+| `G` | Jump to bottom (latest event) |
+| `/` | Focus the filter input |
+| `Enter` | Toggle the detail pane for the selected event |
+| `t` | Pivot to the `traceId` of the selected event (CTL-310) |
+| `o` | Pivot to the `catalyst.orchestrator.id` of the selected event |
+| `r` | Reset all pivots, return to live tail |
+| `Esc` | Close detail pane, clear filter, clear pivot |
+| `q` / `Ctrl-C` | Exit |
+
+## Columns
+
+Each row renders six columns aligned to fixed widths (CTL-308 / CTL-311):
+
+| Column | Width | Source attribute |
+|--------|-------|------------------|
+| `TIME` | 8 | `ts` formatted as `HH:MM:SS` |
+| `REPO` | 12 | `vcs.repository.name` (last segment) |
+| `SOURCE` | 20 | `event.name` prefix (`github`, `linear`, `comms`, `filter`) — falls back to `catalyst.orchestrator.id[/worker.ticket]` for orchestrator events |
+| `EVENT` | 14 | Friendly label for `event.name` (e.g. `github.pr.merged` → `merged`, `github.check_suite.completed` → `ci pass`/`ci fail`); truncated to fit |
+| `REF` | 14 | First non-empty of `vcs.pr.number` (`#445`), `linear.issue.identifier` (`CTL-316`), or `vcs.ref.name` (`→branch`) |
+| `DETAILS` | flex | `body.payload.title`, `body.payload.body`, or `body.message` (truncated to remaining width) |
+
+Row colors are derived from event severity and source, and the selected row is highlighted with
+a blue background.
+
+A handful of high-volume events are filtered out before rendering by `shouldSkipEvent`:
+`session.heartbeat`, `orchestrator.archived`, `session.started`, `session.ended`, successful
+`github.check_run.completed` results, and `filter.wake` events whose payload reason is
+`"No matching events found"`.
+
+## Filtering and Pivots
+
+The `/` key focuses the filter input at the bottom of the screen. As you type, every visible
+column is joined into a single string and substring-matched (case-insensitive) against your
+input. Filtering is purely client-side and applied on top of any active pivot.
+
+Two pivots are available:
+
+- **Trace pivot (`t`)** — narrows the list to every event sharing the selected row's
+  `traceId`. Useful for following a single ticket end-to-end across orchestrator/worker/PR
+  boundaries.
+- **Orchestrator pivot (`o`)** — narrows the list to events with the selected row's
+  `catalyst.orchestrator.id`. Useful when one wave is running alongside other work in the
+  same log.
+
+Both pivots are exclusive — only one is active at a time. The current pivot is shown above the
+filter input as `[trace:abc123…]` or `[orch:orch-2026-05-08…]`. Press `r` to reset the pivot
+and return to the full live tail, or `Esc` to clear pivot, filter, and detail pane in one
+keystroke.
+
+## Classic Shell Fallback
+
+`catalyst-hud-classic.sh` is the original bash renderer, kept as a minimal-deps fallback for
+environments where the Ink build cannot run:
+
+- SSH-from-iPad sessions (Blink, Termius) where Bun isn't installed
+- Small VMs or container shells with no Node/Bun runtime
+- Quick "is the wave still moving?" checks on a remote host
+
+The classic version uses ANSI escapes, the same color coding, and the same column layout, but
+it does **not** include scrollback, the detail pane, the trace/orch pivots, or the substring
+filter input — it is a streaming append-only renderer. See [Terminal UI](./terminal/) for the
+classic renderer's full feature set and limitations.
+
+## Source
+
+- CLI wrapper (Ink): [`plugins/dev/scripts/catalyst-hud`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-hud)
+- Main: [`plugins/dev/scripts/orch-monitor/cli/hud.tsx`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/orch-monitor/cli/hud.tsx)
+- Components: [`plugins/dev/scripts/orch-monitor/cli/components/`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/orch-monitor/cli/components/) (`Header.tsx`, `EventList.tsx`, `EventRow.tsx`, `FilterInput.tsx`, `DetailPane.tsx`)
+- Hooks: [`plugins/dev/scripts/orch-monitor/cli/hooks/`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/orch-monitor/cli/hooks/) (`useEventLog.ts`, `useFilter.ts`, `useSelection.ts`)
+- Classic shell fallback: [`plugins/dev/scripts/catalyst-hud-classic.sh`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-hud-classic.sh)
+
+## Related
+
+- [Web Monitor](./monitor/) — browser-based wave dashboard backed by SSE.
+- [Terminal UI](./terminal/) — classic shell renderer details and limitations.
+- [catalyst-broker](./catalyst-broker/) — semantic event router that produces many of the
+  `filter.wake` events visible in the HUD.
+- [Event Forwarder](./forwarder/) — sibling daemon that ships the same event stream to OTLP,
+  PostHog, and Cloudflare Analytics Engine.
+- [Event Architecture](./events/) — canonical OTel envelope, attribute schema, and CLI.

--- a/website/src/content/docs/observability/index.md
+++ b/website/src/content/docs/observability/index.md
@@ -7,14 +7,18 @@ sidebar:
 
 Catalyst ships with an **agent observability stack** so you can see what autonomous workers are doing in real time — which phase they're in, whether their PR is still open, whether their process is still alive, and how long each phase took.
 
-The stack has four layers:
+The stack has these layers:
 
 | Layer | What it does | Where it runs |
 |-------|--------------|---------------|
 | **Instrumentation** | Claude Code emits OTLP telemetry (events, metrics, logs) via `claude-code-otel` | Per-worker, in the Claude Code process |
 | **Signal files + global state** | Workers write JSON status to `workers/<ticket>.json`; orchestrator aggregates into `~/catalyst/state.json` | Filesystem |
-| **orch-monitor web dashboard** | Aggregates signal files, polls GitHub, serves a live web UI with SSE event streams | Single Bun process |
-| **Terminal UI** | ANSI-rendered compact dashboard for headless environments | Same process (optional) |
+| **Event log** | Append-only JSONL at `~/catalyst/events/YYYY-MM.jsonl` — canonical OTel-shaped envelopes from webhooks, comms, sessions, and OTel emit scripts | Filesystem |
+| **`catalyst-broker` daemon** (CTL-303) | Semantic event broker — tails the event log and emits targeted `filter.wake.<id>` events for registered orchestrators and workers. Supports deterministic `pr_lifecycle` / `ticket_lifecycle` routing and Groq-backed prose routing. Tracks agent identity via `agent.checkin` / `agent.checkout` | Single Bun process |
+| **`catalyst-otel-forward` daemon** (CTL-306) | Tail-and-forward daemon that ships canonical events to OTLP/HTTP, PostHog, and Cloudflare Analytics Engine | Single Bun process |
+| **`orch-monitor` web dashboard** | Aggregates signal files, polls GitHub, serves a live web UI with SSE event streams | Single Bun process |
+| **`catalyst-hud` Ink TUI** (CTL-312) | Ink-based React terminal renderer with scrollback, filter, detail pane, and trace pivot | Terminal |
+| **`catalyst-hud-classic` ANSI fallback** | Pure-bash ANSI renderer for environments where the full Ink HUD cannot run | Terminal |
 
 ## What You'll See
 
@@ -53,11 +57,13 @@ bun run plugins/dev/scripts/orch-monitor/server.ts --terminal
 - [Making agents record data properly](./recording/) — shell wrapper, resource attributes, environment variables
 - [Using the web monitor](./monitor/) — dashboard walkthrough, API endpoints, filters
 - [GitHub webhooks for orch-monitor](./webhooks/) — sub-5-second PR / review / deployment updates via smee.io tunnel
-- [Using the terminal UI](./terminal/) — when to prefer ANSI over the browser
+- [`catalyst-hud` Ink TUI](./hud/) — terminal HUD with scrollback, filter, detail pane, and trace pivot (`terminal.md` is now the classic-only fallback)
+- [`catalyst-hud-classic` ANSI renderer](./terminal/) — pure-bash ANSI fallback for SSH-from-iPad and minimal-deps environments
 - [Event architecture](./events/) — how SSE streams and the global event log fit together
 - [catalyst-events CLI](./catalyst-events/) — command reference and jq filter cookbook for the event log
 - [Event flow — GitHub to worker](./event-flow/) — end-to-end: how a GitHub push becomes a `wait-for` wake
-- [Semantic event routing (`catalyst-broker`)](./catalyst-broker/) — daemon that routes raw events to workers and orchestrators via Groq-backed semantic matching
+- [Semantic event routing (`catalyst-broker`)](./catalyst-broker/) — daemon that routes raw events to workers and orchestrators via deterministic and Groq-backed matching
+- [Event forwarder (`catalyst-otel-forward`)](./forwarder/) — ship canonical events to OTLP/HTTP, PostHog, and Cloudflare Analytics Engine
 - [Agent communication (`catalyst-comms`)](../reference/catalyst-comms/) — how workers coordinate with each other across worktrees
 
 ## When Not to Enable Observability

--- a/website/src/content/docs/observability/monitor.md
+++ b/website/src/content/docs/observability/monitor.md
@@ -7,6 +7,8 @@ sidebar:
 
 `orch-monitor` is a Bun-based HTTP server that aggregates worker signal files, receives GitHub and Linear events via webhooks (with polling fallback), and serves a live dashboard with server-sent event streams. One process powers both the web UI and the terminal UI.
 
+For a terminal-side equivalent, see [`catalyst-hud`](./hud/).
+
 ![Orchestrator overview showing active waves, completion percentage, total cost, wall clock, and the worker list](https://assets.coalescelabs.ai/images/screenshots/orchestrator-2026-04-17%20at%2008.05.20%402x.png)
 
 *Orchestrator overview — waves, workers, cost, and wall-clock time at a glance.*

--- a/website/src/content/docs/observability/recording.md
+++ b/website/src/content/docs/observability/recording.md
@@ -85,7 +85,9 @@ The signal file records `pid` when the worker starts. The orch-monitor runs `kil
 
 ## Global Event Log
 
-The third source of truth is `~/catalyst/events.jsonl` — an append-only log of events across all orchestrators. Events are emitted by `catalyst-state.sh event` with schema:
+The third source of truth is `~/catalyst/events/$(date -u +%Y-%m).jsonl` — an append-only,
+monthly-rotated log of events across all orchestrators. Events are emitted by
+`catalyst-state.sh event` (v1 envelope) and by canonical CTL-300 emitters with schema:
 
 ```json
 {"ts":"2026-04-14T19:15:32Z","orchestrator":"orch-...","worker":"CTL-48","event":"worker-pr-created","detail":{"pr":123,"url":"..."}}
@@ -98,8 +100,17 @@ Event types:
 - `worker-phase-advanced`, `worker-status-terminal`, `worker-pr-created`, `worker-done`, `worker-failed`
 - `verification-started`, `verification-passed`, `verification-failed`
 - `attention-raised`, `attention-resolved`
+- `agent.checkin`, `agent.checkout` (CTL-303 — broker agent identity)
+- `broker.daemon.startup` (CTL-303 — legacy alias `filter.daemon.startup`)
+- `filter.register`, `filter.deregister`, `filter.wake.<id>` (CTL-303 — broker routing)
 
-The events.jsonl log is what backs the `/events` SSE stream exposed by the orch-monitor HTTP server — see [Event architecture](../events/) for how that flows to connected frontends.
+The newer canonical envelope shape (CTL-300) is the default for new emitters — the webhook
+receiver, `catalyst-comms send`, `catalyst-broker`, `catalyst-otel-forward`, and
+`catalyst-session.sh` all write canonical events. The v1 envelope above is preserved for
+`catalyst-state.sh event`.
+
+The monthly log is what backs the `/events` SSE stream exposed by the orch-monitor HTTP
+server — see [Event architecture](../events/) for how that flows to connected frontends.
 
 ## Verifying Everything Is Wired
 
@@ -113,7 +124,7 @@ docker compose logs -f otel-collector | grep orchestrator.id
 watch -n 5 'cat ~/catalyst/wt/<orch-dir>/workers/<ticket>.json | jq .status'
 
 # 3. Global events appending
-tail -f ~/catalyst/events.jsonl
+tail -f ~/catalyst/events/$(date -u +%Y-%m).jsonl
 
 # 4. Orch-monitor SSE stream
 curl -N http://localhost:7400/events

--- a/website/src/content/docs/observability/setup.md
+++ b/website/src/content/docs/observability/setup.md
@@ -125,7 +125,49 @@ This enables the `/api/otel/query` and `/api/otel/logs` endpoints on the monitor
 
 Alternatively, set environment variables: `OTEL_ENABLED=true`, `PROMETHEUS_URL`, `LOKI_URL`.
 
-### 5. Set up the webhook tunnel
+### 5. Start the broker daemon (optional)
+
+`catalyst-broker` (CTL-303) is the semantic event broker — it tails the canonical event log
+and emits targeted `filter.wake.<id>` events for registered orchestrators and workers. Skills
+that wait for ticket lifecycle changes, PR lifecycle changes, or comms messages register
+interests with the broker instead of writing bespoke jq predicates.
+
+```bash
+catalyst-broker start
+```
+
+Logs are pino-structured (CTL-314) and written to `~/catalyst/broker.log`. Set `LOG_LEVEL`
+to control verbosity:
+
+```bash
+LOG_LEVEL=info catalyst-broker start    # default
+LOG_LEVEL=debug catalyst-broker start   # full trace
+```
+
+The legacy `catalyst-filter` command is preserved as a backward-compat shim (CTL-315) and
+execs `catalyst-broker` with the same arguments. See
+[Semantic event routing (`catalyst-broker`)](./catalyst-broker/) for the full protocol.
+
+### 6. Start the event forwarder (optional)
+
+`catalyst-otel-forward` (CTL-306) is a tail-and-forward daemon that ships canonical events
+to OTLP/HTTP, PostHog, and Cloudflare Analytics Engine. Start it via the monitor wrapper:
+
+```bash
+bash plugins/dev/scripts/catalyst-monitor.sh forward-start
+```
+
+Or run it directly:
+
+```bash
+catalyst-otel-forward
+```
+
+Logs are pino-structured (CTL-314) and respect `LOG_LEVEL`. See
+[Event forwarder (`catalyst-otel-forward`)](./forwarder/) for destination configuration and
+DLQ semantics.
+
+### 7. Set up the webhook tunnel
 
 The orch-monitor can receive GitHub and Linear events in near-real-time via a smee.io webhook tunnel. Without this step, skills that use `catalyst-events wait-for` — including `/catalyst-dev:orchestrate` Phase 4, `/catalyst-dev:oneshot` Phase 5, and `/catalyst-dev:wait-for-github` — silently fall back to REST polling with up to **10-minute latency** per event.
 
@@ -139,7 +181,7 @@ bash plugins/dev/scripts/setup-webhooks.sh
 
 This creates a smee.io channel, writes the channel URL to `~/.config/catalyst/config.json`, generates an HMAC secret, and registers a webhook on each repo listed in `catalyst.monitor.github.watchRepos`. See [GitHub webhooks for orch-monitor](../webhooks/) for the full setup guide and configuration reference.
 
-### 6. Import the Grafana dashboard
+### 8. Import the Grafana dashboard
 
 The claude-code-otel repo ships with a pre-built Grafana dashboard at `dashboards/claude-code.json`. Import it via Grafana → Dashboards → New → Import → Upload JSON file.
 

--- a/website/src/content/docs/observability/terminal.md
+++ b/website/src/content/docs/observability/terminal.md
@@ -1,19 +1,29 @@
 ---
-title: Terminal UI
-description: When you want the orch-monitor view without a browser — ANSI-rendered, compact, and streams in-place.
+title: Terminal Renderer (catalyst-hud-classic)
+description: Pure-bash ANSI fallback renderer for environments where the full Ink-based catalyst-hud cannot run.
 sidebar:
-  order: 4
+  order: 9
 ---
 
-The orch-monitor ships with an ANSI terminal renderer for headless environments, SSH sessions, tmux panes, or quick status checks without opening a browser.
+`catalyst-hud-classic` is a pure-bash ANSI renderer for environments where the full
+Ink-based [`catalyst-hud`](./hud/) cannot run — SSH from iPad, minimal-deps boxes,
+locked-down CI. For day-to-day use, prefer [`catalyst-hud`](./hud/).
 
 ## Running it
 
 ```bash
-bun run plugins/dev/scripts/orch-monitor/server.ts --terminal
+catalyst-hud-classic
 ```
 
-This flag:
+The installed symlink is the canonical entry point. If you need the legacy server-driven
+mode (the `--terminal` flag on the orch-monitor server itself), invoke the monitor wrapper
+directly:
+
+```bash
+bash plugins/dev/scripts/catalyst-monitor.sh start --terminal
+```
+
+This:
 
 - Clears the screen and draws a compact 80-column dashboard
 - Subscribes to the same SSE event stream that powers the web UI
@@ -42,19 +52,36 @@ Events (most recent first):
   19:13:44  CTL-48  worker-failed           crashed — PID gone
 ```
 
-Color coding matches the web UI: blue for in-progress phases, green for done, red for failed/dead, amber for validating/shipping.
+Color coding matches the web UI: blue for in-progress phases, green for done, red for
+failed/dead, amber for validating/shipping.
 
-## When to prefer the terminal UI
+## When to prefer classic over the Ink HUD
 
-| Situation | Why terminal |
-|-----------|--------------|
-| SSH'd into a server, can't port-forward | Browser-free |
-| Running in a tmux/screen pane alongside other work | Fits in an 80-column pane |
-| You want a CI-style log trail to scroll back through | Events render as append-only text |
-| Low-bandwidth remote session | ANSI is tiny vs a websocket-heavy SPA |
+| Situation | Why classic |
+|-----------|-------------|
+| SSH from iPad / iOS terminal app where Ink's input handling misbehaves | Pure ANSI, no `readline` quirks |
+| Minimal-deps box where you can't install Bun + Node + Ink | Bash + standard `tput` only |
+| Locked-down CI where binary downloads are blocked | Ships as text in the plugin |
+| Low-bandwidth remote session | ANSI is tiny vs Ink's screen-redraw payloads |
 | You just want "is it done yet?" at a glance | Redraws on every event |
 
-The web UI is richer — filters, click-through to Linear/GitHub, Gantt view — but for 90% of "is my wave still healthy?" checks, the terminal view is all you need.
+The Ink HUD is richer — scrollback, regex filter, detail pane, trace pivot, canonical
+SVC/SEV/TRACE columns — but for read-only "is my wave still healthy?" checks from a
+constrained environment, the classic view is sufficient.
+
+## Differences from the Ink HUD
+
+The classic renderer is intentionally a smaller surface than `catalyst-hud`:
+
+- **No scrollback.** The dashboard redraws the visible window; events scroll off the top.
+  Use `tail -f ~/catalyst/events/$(date -u +%Y-%m).jsonl` in a separate pane for
+  persistent scroll.
+- **No filters.** The classic renderer shows all active orchestrators. Use the web UI's
+  URL filters (`?orch=...`) or the Ink HUD's filter pane if you need to isolate one wave.
+- **80-column assumption.** Narrower terminals will clip the ticket/status columns. Widen
+  your pane or switch to the web UI.
+- **No trace pivot.** Use the Ink HUD or the web UI to pivot from an event to its
+  enclosing trace.
 
 ## Non-interactive snapshot
 
@@ -64,10 +91,5 @@ If you just want a one-shot dump (no live updates), use the JSON API instead:
 curl -s http://localhost:7400/api/snapshot | jq
 ```
 
-That gives you a machine-readable snapshot suitable for piping into scripts, cron jobs, or other monitoring systems.
-
-## Known limitations
-
-- **80-column assumption** — narrower terminals will clip the ticket/status columns. Widen your pane or use the web UI.
-- **No scrollback** — the dashboard redraws the visible window; events scroll off the top. Use `tail -f ~/catalyst/events.jsonl` in a separate pane for persistent scroll.
-- **No filters** — the terminal UI shows all active orchestrators. Use the web UI's URL filters (`?orch=...`) if you have multiple concurrent waves and want to isolate one.
+That gives you a machine-readable snapshot suitable for piping into scripts, cron jobs, or
+other monitoring systems.

--- a/website/src/content/docs/observability/webhooks.md
+++ b/website/src/content/docs/observability/webhooks.md
@@ -263,21 +263,28 @@ After exporting the secret and restarting the daemon, check the log:
 ```
 
 Trigger a `pull_request.synchronize` event by pushing to a tracked PR. The dashboard should
-update within a few seconds. You can also watch the event log:
+update within a few seconds. You can also watch the event log (canonical envelope, CTL-300):
 
 ```bash
-tail -F ~/catalyst/events/$(date -u +%Y-%m).jsonl | jq 'select(.source == "github.webhook")'
+tail -F ~/catalyst/events/$(date -u +%Y-%m).jsonl | jq 'select(.attributes."event.name" | startswith("github."))'
 ```
+
+As of CTL-310, every webhook-emitted event also carries a top-level `traceId` so the same
+event can be correlated across the broker, forwarder, and OTel-side traces without rejoining
+on `vcs.pr.number`.
 
 ## Daemon liveness prerequisite
 
-The orch-monitor daemon is the only writer to `~/catalyst/events/`, so any skill that
-consumes events depends on it being alive. The Tier-1 event-driven skills are:
+The orch-monitor daemon is one of two writers to `~/catalyst/events/` (the other is
+`catalyst-broker`, which appends `filter.wake.<id>` events). Any skill that consumes events
+depends on the monitor being alive. The Tier-1 event-driven skills are:
 
 - `orchestrate` — Phase 4 watcher and auto-fixup classifier consume events
 - `oneshot` — Phase 5 deploy-monitoring loop consumes events
 - `merge-pr` — Phase 6 wait-for-merged consumes events
 - `monitor-events` — the canonical pattern doc; reused everywhere the primitives are needed
+- `broker` (CTL-303) — the broker daemon is itself a Tier-1 consumer/producer; it tails
+  the event log via `fs.watch` and writes `filter.wake.<id>` events back into it
 
 If the daemon is stopped, `catalyst-events wait-for` blocks until its 600 s timeout and
 exits non-zero. Callers fall back to `gh pr view` polling, which is functionally correct
@@ -709,7 +716,7 @@ per delivery.
 
 ```bash
 # After configuring the secret and starting the daemon:
-catalyst-events tail --filter '.event | startswith("linear.")'
+catalyst-events tail --filter '.attributes."event.name" | startswith("linear.")'
 
 # In another shell, cause a Linear ticket state change.
 # The first shell should print the matching event line within seconds.

--- a/website/src/content/docs/reference/catalyst-comms.md
+++ b/website/src/content/docs/reference/catalyst-comms.md
@@ -300,15 +300,19 @@ There is currently **no delivery guarantee**: a worker may have already passed a
 
 ### Event log integration
 
-`catalyst-comms send` emits a `comms.message.posted` event to the unified event log (`~/catalyst/events/YYYY-MM.jsonl`) using the v2 OTel-shaped envelope. This means orchestrators and tools that monitor the event log see all comms traffic without polling the channel file directly:
+`catalyst-comms send` emits a `comms.message.posted` event to the unified event log (`~/catalyst/events/YYYY-MM.jsonl`) using the canonical OTel envelope (CTL-300). This means orchestrators and tools that monitor the event log see all comms traffic without polling the channel file directly:
 
 ```bash
 # Watch all comms messages on a channel
-catalyst-events tail --filter '.event == "comms.message.posted" and .attributes."comms.channel" == "orch-ctl-ux-apr20-wave-1"'
+catalyst-events tail --filter '.attributes."event.name" == "comms.message.posted" and .attributes."comms.channel" == "orch-ctl-ux-apr20-wave-1"'
 
 # Messages directed at a specific worker
-catalyst-events tail --filter '.event == "comms.message.posted" and .body.payload.to == "CTL-101"'
+catalyst-events tail --filter '.attributes."event.name" == "comms.message.posted" and .body.payload.to == "CTL-101"'
 ```
+
+Comms posts ride the same `traceId` propagation rules as other canonical events (CTL-310): if a
+caller threads a `traceId` through, downstream consumers can pivot from comms traffic to the
+PR/CI/agent timeline that triggered it.
 
 ## Sub-agent Pattern
 

--- a/website/src/content/docs/reference/catalyst-session.md
+++ b/website/src/content/docs/reference/catalyst-session.md
@@ -22,7 +22,7 @@ Skills call it at start, at each phase transition, and at completion. The orches
 | `tool` | `<session-id> <tool-name> [--duration MS]` | Increment tool usage histogram. |
 | `iteration` | `<session-id> --kind plan\|fix [--by N]` | Increment plan-replan or implement-fix iteration counter. |
 | `pr` | `<session-id> --number N --url URL [--ci STATUS]` | Record PR creation. Emits `pr-opened` event. |
-| `end` | `<session-id> [--status done\|failed] [--reason TEXT]` | Mark session complete. Emits `session-ended` event and a `claude_code.session.outcome` OTLP metric. |
+| `end` | `<session-id> [--status done\|failed] [--reason TEXT]` | Mark session complete. Emits `session-ended` and `session.outcome` events (canonical envelope, CTL-300) to the JSONL event log. |
 | `heartbeat` | `<session-id>` | Bump `updated_at` and emit a heartbeat event to the JSONL log. |
 | `list` | `[--active] [--skill NAME] [--ticket KEY] [--limit N]` | List sessions as JSON. |
 | `read` | `<session-id>` | Print full session state (session + metrics + tools + events + PRs). |
@@ -59,12 +59,19 @@ All session data lives in `~/catalyst/catalyst.db`:
 
 ## OTLP Emission
 
-On `end`, catalyst-session emits two OTLP payloads (when an OTLP endpoint is configured):
+`catalyst-session` itself does **not** call OTLP collectors directly. On `end` it appends two
+canonical events (CTL-300) to the JSONL event log at `~/catalyst/events/YYYY-MM.jsonl`:
 
-- **`claude_code.session.outcome`** log — carries `outcome`, `session_id`, `linear.key`, optional
-  `reason`. Used for Loki queries and alerting on failure rates (CTL-157).
-- **`claude_code.session.iterations`** metric — flushes the plan-replan and implement-fix
-  iteration counters accumulated during the session (CTL-158).
+- **`session.outcome`** — carries `outcome`, `session_id`, `linear.key`, optional `reason`. Used
+  for Loki queries and alerting on failure rates (CTL-157).
+- **`session.iterations`** — captures the plan-replan and implement-fix iteration counters
+  accumulated during the session (CTL-158).
+
+The [`catalyst-otel-forward`](/observability/forwarder/) daemon (CTL-306) tails the event log and
+ships these events to OTLP, PostHog, and Cloudflare Analytics Engine — so OTLP backends still
+receive `session.outcome` and `session.iterations`, but through the forwarder rather than from
+`catalyst-session` itself. The split keeps the session CLI fast and dependency-free, and lets a
+single forwarder fan events out to multiple destinations.
 
 ## Typical Usage in Skills
 
@@ -94,3 +101,4 @@ script is unavailable (e.g., in CI environments without the dev plugin installed
 - [Agent Communication (catalyst-comms)](./catalyst-comms/) — sibling CLI for cross-agent messaging
 - [Setup Health Check](./setup-health-check/) — verifies the session database schema and WAL mode
 - [Observability Events](../observability/events/) — the JSONL event log catalyst-session writes to
+- [Event Forwarding](/observability/forwarder/) — `catalyst-otel-forward` ships `session.outcome` and `session.iterations` to OTLP / PostHog / Cloudflare AE (CTL-306)

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -256,14 +256,52 @@ Never committed. One file per project, linked by `projectKey`.
 
 ### Integration Fields
 
-| Integration | Required Fields               | Used By                          |
-| ----------- | ----------------------------- | -------------------------------- |
-| Linear      | `apiToken`, `teamKey`         | catalyst-dev, catalyst-pm        |
-| Sentry      | `org`, `project`, `authToken` | catalyst-debugging               |
-| PostHog     | `apiKey`, `projectId`         | catalyst-analytics               |
-| Exa         | `apiKey`                      | catalyst-dev (external research) |
+| Integration | Required Fields               | Used By                                                     |
+| ----------- | ----------------------------- | ----------------------------------------------------------- |
+| Linear      | `apiToken`, `teamKey`         | catalyst-dev, catalyst-pm                                   |
+| Sentry      | `org`, `project`, `authToken` | catalyst-debugging                                          |
+| PostHog     | `apiKey`, `projectId`         | catalyst-analytics (read), `catalyst-otel-forward` (write)  |
+| Exa         | `apiKey`                      | catalyst-dev (external research)                            |
+| Groq        | `apiKey`                      | `catalyst-broker` (semantic-prose routing, CTL-303)         |
 
 Only configure the integrations you use. The setup script prompts for each one.
+
+### Broker (`catalyst.broker` / `groq`)
+
+The `catalyst-broker` daemon (CTL-303) is the local event broker that registered agents and skills
+wait on for relevant events. It evolved from the earlier `catalyst-filter` daemon — `catalyst-filter`
+remains as a backward-compat shim that delegates to `catalyst-broker` (CTL-315).
+
+Layer-2 secrets (`~/.config/catalyst/config-{projectKey}.json` or the cross-project
+`~/.config/catalyst/config.json`):
+
+```json
+{
+  "groq": {
+    "apiKey": "gsk_..."
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `groq.apiKey` | string | Groq API key used by `catalyst-broker` for semantic-prose classification of ambiguous events. Not required for deterministic routes (`pr_lifecycle`, `ticket_lifecycle`). Override with the `GROQ_API_KEY` env var. |
+
+Runtime files (created on demand under `$CATALYST_DIR`, default `~/catalyst/`):
+
+| Path | Purpose |
+|------|---------|
+| `~/catalyst/broker.pid` | Liveness PID file written by the daemon |
+| `~/catalyst/broker.log` | Pino structured log output (CTL-314) |
+| `~/catalyst/broker-interests.json` | Persistent interest registry |
+
+`LOG_LEVEL` (default `info`) controls broker log verbosity through pino (CTL-314). The same env
+var also gates verbosity in `catalyst-otel-forward`.
+
+On first start, `catalyst-broker` performs a one-shot rename from the legacy
+`~/catalyst/filter-interests.json` to `~/catalyst/broker-interests.json` if the legacy file
+exists. The startup line written to the event log was renamed from `filter.daemon.startup` to
+`broker.daemon.startup` at the same time; the legacy event name is no longer emitted.
 
 ### Monitor OTel Config
 
@@ -300,9 +338,13 @@ Cloud, Datadog, etc.), point these URLs at your hosted Prometheus/Loki-compatibl
 
 See [Setting up the OTel stack](/observability/setup/) for the full installation guide.
 
-### Forwarders (`catalyst.observability.forwarders`)
+### Forwarders (`catalyst.observability.forwarders`, CTL-306)
 
-Config lives in `~/.config/catalyst/config-{projectKey}.json` under `catalyst.observability.forwarders`.
+The `catalyst-otel-forward` daemon (CTL-306) tails the canonical event log
+(`~/catalyst/events/YYYY-MM.jsonl`) and fans events out to OTLP, PostHog, and Cloudflare
+Analytics Engine. Config lives in `~/.config/catalyst/config-{projectKey}.json` under
+`catalyst.observability.forwarders`; the daemon also reads the cross-project
+`~/.config/catalyst/config.json` as a fallback.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -322,7 +364,29 @@ Config lives in `~/.config/catalyst/config-{projectKey}.json` under `catalyst.ob
 | `forwarders.cloudflareAE.batchSize` | number | `100` | Max events per write batch |
 | `forwarders.cloudflareAE.flushIntervalMs` | number | `5000` | Flush interval in ms |
 
-See [Event Forwarding Reference](../../plugins/dev/references/event-forwarding.md) for full setup and operations guide.
+See [Event Forwarding](/observability/forwarder/) for full setup and operations guide.
+
+### Environment Variables
+
+A reference of the env vars Catalyst's daemons honor at runtime. File-based config wins unless
+the env var is set.
+
+| Variable | Daemon / scope | Description |
+|----------|----------------|-------------|
+| `CATALYST_DIR` | All | Base directory for runtime files. Default `~/catalyst/`. |
+| `LOG_LEVEL` | `catalyst-broker`, `catalyst-otel-forward` | Pino log level (CTL-314). Default `info`. |
+| `BROKER_PID_FILE` | `catalyst-broker` | Override broker PID path. Default `$CATALYST_DIR/broker.pid`. |
+| `BROKER_LOG_FILE` | `catalyst-broker` | Override broker log path. Default `$CATALYST_DIR/broker.log`. |
+| `GROQ_API_KEY` | `catalyst-broker` | Groq API key (overrides `groq.apiKey` in config). |
+| `FILTER_GROQ_MODEL` | `catalyst-broker` | Groq model for semantic-prose classification. Default `llama-3.1-8b-instant`. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `catalyst-otel-forward` | OTLP endpoint URL. Port `4317` is auto-rewritten to `4318` for HTTP transport. |
+| `OTEL_ENABLED`, `PROMETHEUS_URL`, `LOKI_URL` | `orch-monitor` | See [Monitor OTel Config](#monitor-otel-config). |
+| `MONITOR_PORT` | `orch-monitor` | HTTP port. Default `7400`. |
+| `CATALYST_SMEE_CHANNEL` | `orch-monitor` | Override `monitor.github.smeeChannel`. |
+| `CATALYST_DB_FILE` | All | SQLite session DB path. Default `$CATALYST_DIR/catalyst.db`. |
+| `CATALYST_ARCHIVE_ROOT` | `catalyst-archive` | Archive root. Default `$CATALYST_DIR/archives`. |
+| `CATALYST_RUNS_DIR` | `catalyst-archive` | Orchestrator runtime root. Default `$CATALYST_DIR/runs`. |
+| `CATALYST_COMMS_DIR` | `catalyst-comms` | Comms channel root. Default `$CATALYST_DIR/comms/channels`. |
 
 ### Monitor Webhook Config
 

--- a/website/src/content/docs/reference/integrations.md
+++ b/website/src/content/docs/reference/integrations.md
@@ -108,6 +108,100 @@ Product analytics via the `catalyst-analytics` plugin.
 
 **Related skills**: `/catalyst-analytics:analyze-user-behavior`, `/catalyst-analytics:segment-analysis`, `/catalyst-analytics:product-metrics`
 
+PostHog is used in two distinct ways inside Catalyst:
+
+- **Read** — the `catalyst-analytics` plugin queries PostHog for product metrics and user behavior.
+- **Write** — the `catalyst-otel-forward` daemon (CTL-306) ships canonical events to PostHog as a
+  forwarder destination. See [Event Forwarding](/observability/forwarder/) and the
+  [Forwarders configuration](/reference/configuration/#forwarders-catalystobservabilityforwarders-ctl-306).
+
+## Groq
+
+Semantic event routing for the `catalyst-broker` daemon (CTL-303).
+
+**Setup**: Add `apiKey` to `~/.config/catalyst/config.json` (Layer-2 secret):
+
+```json
+{
+  "groq": {
+    "apiKey": "gsk_..."
+  }
+}
+```
+
+**Default model**: `llama-3.1-8b-instant`. Override per-project with the `FILTER_GROQ_MODEL` env
+var or `GROQ_API_KEY` for the key itself.
+
+**Purpose**: `catalyst-broker` resolves deterministic interest types
+(`pr_lifecycle`, `ticket_lifecycle`) without calling Groq. For ambiguous prose interests it
+batches one request per debounce window and asks Groq to classify which registered interests
+match — keeping latency low and cost minimal.
+
+**Related skills / tools**: `catalyst-broker`, `catalyst-events wait-for` (downstream consumer),
+the `broker` skill protocol reference.
+
+## Cloudflare Analytics Engine
+
+Forwarder destination for the `catalyst-otel-forward` daemon (CTL-306). Cloudflare Analytics
+Engine (AE) accepts high-cardinality time-series writes via Workers HTTP API.
+
+**Setup**: under `catalyst.observability.forwarders.cloudflareAE` in
+`~/.config/catalyst/config-{projectKey}.json`:
+
+```json
+{
+  "catalyst": {
+    "observability": {
+      "forwarders": {
+        "cloudflareAE": {
+          "enabled": true,
+          "accountId": "...",
+          "apiToken": "...",
+          "dataset": "catalyst_events"
+        }
+      }
+    }
+  }
+}
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `accountId` | Yes | — | Cloudflare account ID |
+| `apiToken` | Yes | — | API token with Analytics Engine write scope |
+| `dataset` | No | `catalyst_events` | AE dataset name |
+
+See [Event Forwarding](/observability/forwarder/) for the full schema and end-to-end setup.
+
+## OTLP
+
+Forwarder destination for `catalyst-otel-forward` (CTL-306). Sends canonical events as
+OpenTelemetry signals over HTTP.
+
+**Setup**: configure under `catalyst.observability.forwarders.otlp`, or set the standard
+`OTEL_EXPORTER_OTLP_ENDPOINT` env var. The daemon auto-rewrites `:4317` (gRPC) to `:4318` (HTTP)
+when the env var is used, so the same endpoint string works whether your collector advertises the
+gRPC or HTTP port.
+
+```json
+{
+  "catalyst": {
+    "observability": {
+      "forwarders": {
+        "otlp": {
+          "enabled": true,
+          "endpoint": "http://localhost:4318"
+        }
+      }
+    }
+  }
+}
+```
+
+The local `claude-code-otel` Compose stack exposes the OTLP/HTTP collector on `:4318` by default.
+For hosted backends (Grafana Cloud, Honeycomb, etc.), point the endpoint at the vendor URL and
+configure auth headers via collector environment.
+
 ## Exa
 
 Optional web search and code-search augmentation for research agents via the Exa MCP server.

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -355,6 +355,20 @@ The dispatch prompt includes **mandatory testing requirements** — not suggesti
 their output will be independently verified. The `CATALYST_ORCHESTRATOR_DIR` environment variable is
 set so workers know where to write their signal files.
 
+## Broker Integration
+
+Workers do **not** register filter interests by hand. Instead, each worker emits `agent.checkin`
+when it boots — including a `claimed_pr` field once the PR exists — and the
+[`catalyst-broker`](/observability/catalyst-broker/) daemon (CTL-303) auto-derives a
+`pr_lifecycle` interest from that identity record. When the worker shuts down (success or
+failure) it emits `agent.checkout`, and the broker auto-deregisters every interest it derived
+for that agent.
+
+This auto-correlation is what makes the worker's PR listen loop work without any manual
+`filter.register` plumbing. Workers can also subscribe to `ticket_lifecycle` to follow a Linear
+ticket's state changes, and to ad-hoc prose interests when they need richer routing — see the
+[`catalyst-broker` protocol reference](/observability/catalyst-broker/) for the wire format.
+
 ## Testing Enforcement (3 Layers)
 
 The orchestrator addresses a specific failure mode: **agents ship PRs with minimal tests and
@@ -656,8 +670,8 @@ cat ~/catalyst/events/*.jsonl | jq 'select(.event | startswith("github.pr")) | s
 # Linear issue state changes
 cat ~/catalyst/events/*.jsonl | jq 'select(.event | startswith("linear.issue.state"))'
 
-# All GitHub check suite completions for a specific PR
-cat ~/catalyst/events/*.jsonl | jq 'select(.event == "github.check_suite.completed") | select(.body.payload.prNumbers // [] | contains([87]))'
+# All GitHub check suite completions for a specific PR (canonical envelope, CTL-300)
+cat ~/catalyst/events/*.jsonl | jq 'select(.attributes."event.name" == "github.check_suite.completed") | select(.body.payload.prNumbers // [] | contains([87]))'
 ```
 :::
 
@@ -898,6 +912,7 @@ The monitor watches `~/catalyst/wt/` for orchestrator directories (matching `orc
 | GitHub API (`gh pr view`)              | PR state (open/merged/closed), merge timestamp     | Every 10 minutes (fallback when webhook not configured) |
 | Process table (`kill -0 <pid>`)        | Whether the worker's Claude process is still alive | Every 5 seconds            |
 | Orchestrator `state.json`              | Wave count, progress, attention items              | Instant (filesystem watch) |
+| Broker / forwarder pipeline (`catalyst-events tail`) | Canonical event stream — `agent.checkin/checkout`, `pr_lifecycle`, `ticket_lifecycle`, comms, webhooks | Real-time push (CTL-303 / CTL-306) |
 
 **Dead process detection:** If a worker's PID is recorded in its signal file but `kill -0` fails,
 the monitor marks it with a `!` indicator. This catches silently crashed workers that stopped

--- a/website/src/content/docs/reference/orchestration/workers.md
+++ b/website/src/content/docs/reference/orchestration/workers.md
@@ -19,10 +19,12 @@ Orchestrator                   Worker subprocess
      │                                 │   Phase 3: implementing
      │                                 │   Phase 4: validating
      │                                 │   Phase 5: shipping
+     │                                 │     emits agent.checkin {claimed_pr} →
+     │                                 │       broker auto-registers pr_lifecycle interest (CTL-303)
      │                                 │     opens PR → enters catalyst-events wait-for loop
      │                                 │     resolves CI failures, bot review threads, BEHIND
      │                                 │     gh pr merge --squash --delete-branch
-     │                                 │     writes pr.mergedAt + status: done → exits
+     │                                 │     writes pr.mergedAt + status: done → emits agent.checkout → exits
      │                                 │
      │<─ signal file: done ────────────│
      │   (orchestrator's Phase 4 is a safety-net fallback for stalled/crashed workers)
@@ -87,6 +89,12 @@ dispatched → researching → planning → implementing → validating → ship
 ```
 
 The worker writes all statuses through `done`. In the `pr-created` → `done` transition, the worker enters a `catalyst-events wait-for` listen loop, resolves CI failures and review blockers inline, and executes `gh pr merge --squash --delete-branch` when the PR is CLEAN. The orchestrator writes `done` only as a safety-net fallback for workers that wrote `stalled` or crashed before completing their own merge.
+
+The listen loop is enabled by [`catalyst-broker`](/observability/catalyst-broker/)
+auto-correlation (CTL-303): the worker's `agent.checkin {claimed_pr}` event causes the broker to
+derive a `pr_lifecycle` interest for that PR, so `wait-for` receives PR/CI/review events without
+the worker calling `filter.register` manually. On `agent.checkout` the broker auto-deregisters
+the derived interests.
 
 ## The global state
 

--- a/website/src/content/docs/reference/setup-health-check.md
+++ b/website/src/content/docs/reference/setup-health-check.md
@@ -41,13 +41,20 @@ targets. The following CLIs are installed as symlinks:
 
 | CLI | Purpose |
 |-----|---------|
+| `catalyst-broker` | Local event broker — canonical OTel envelope, agent identity, ticket/PR auto-correlation (CTL-303). Primary CLI as of CTL-315. |
 | `catalyst-comms` | Agent coordination channels |
+| `catalyst-events` | Event log tail / wait-for / append CLI |
+| `catalyst-filter` | Backward-compat shim — delegates to `catalyst-broker` (CTL-315). Existing scripts keep working. |
 | `catalyst-session` | Session lifecycle tracking |
 | `catalyst-state` | Global orchestrator state |
 | `catalyst-db` | SQLite database operations |
-| `catalyst-monitor` | orch-monitor start/stop/status |
+| `catalyst-monitor` | orch-monitor start/stop/status (also exposes `forward-status` for the forwarder daemon) |
 | `catalyst-thoughts` | HumanLayer thoughts shortcuts |
 | `catalyst-claude` | Claude Code wrapper with context injection |
+| `register-thought` | Register a path with the thoughts system |
+| `workflow-context` | Read/write `.catalyst/.workflow-context.json` |
+| `catalyst-hud` | Ink-based React TUI for the live event stream (CTL-308/CTL-311/CTL-312) |
+| `catalyst-hud-classic` | Shell fallback for `catalyst-hud` |
 
 If `~/.catalyst/bin` is not on your `PATH`, the check prints the one line to add to your shell
 profile:
@@ -55,9 +62,6 @@ profile:
 ```bash
 export PATH="$HOME/.catalyst/bin:$PATH"
 ```
-
-Note: `catalyst-events` is not yet wired into `install-cli.sh`'s `CLI_NAMES` array. Until it is,
-run it via the full path: `plugins/dev/scripts/catalyst-events`.
 
 ### Tools
 
@@ -89,6 +93,41 @@ Whether OTel Docker containers are running and reachable. This is entirely optio
 works without observability. If not configured, the check notes it and points to the
 [claude-code-otel](https://github.com/ryanrozich/claude-code-otel) repo to set it up.
 Automatically detects remapped ports from Docker when configured.
+
+### Broker Daemon
+
+Whether the `catalyst-broker` daemon (CTL-303) is alive. The check verifies that
+`~/catalyst/broker.pid` references a live process and surfaces the broker's status.
+
+```bash
+catalyst-broker status
+```
+
+The broker's structured (pino) logs are written to `~/catalyst/broker.log`. Set `LOG_LEVEL`
+(default `info`) to control verbosity (CTL-314). On first start the broker performs a one-shot
+rename from the legacy `~/catalyst/filter-interests.json` to `~/catalyst/broker-interests.json` —
+nothing further is required from the user.
+
+### Forwarder Daemon
+
+Whether the `catalyst-otel-forward` daemon (CTL-306) is running. Status is reported through the
+monitor wrapper:
+
+```bash
+bash plugins/dev/scripts/catalyst-monitor.sh forward-status
+```
+
+The forwarder reads `catalyst.observability.forwarders` from
+`~/.config/catalyst/config-{projectKey}.json` (or the cross-project fallback) and tails the event
+log forward to OTLP, PostHog, and Cloudflare Analytics Engine. It honors `LOG_LEVEL` for pino
+output (CTL-314) and `OTEL_EXPORTER_OTLP_ENDPOINT` as an override for OTLP destinations.
+
+### Event Log Envelope
+
+Events written to `~/catalyst/events/YYYY-MM.jsonl` use the canonical OTel-shaped envelope
+(CTL-300): `attributes['event.name']` carries the event type, payload sits under
+`body.payload.*`, and `traceId` is propagated end-to-end — including on webhook-emitted
+canonical events (CTL-310).
 
 ### Orchestration Monitor (Optional)
 


### PR DESCRIPTION
## Summary

Brings `website/src/content/docs/` in sync with the CTL-303..315 changes that landed on `main`.

**New pages**
- `observability/forwarder.md` — `catalyst-otel-forward` daemon (CTL-306). Canonical events → OTLP / PostHog / Cloudflare Analytics Engine.
- `observability/hud.md` — Ink-based React TUI for the canonical event stream (CTL-308 / CTL-311 / CTL-312). Scrollback, filter, detail pane, trace/orch pivots, keybindings.

**Repurposed**
- `observability/terminal.md` is now the documentation for the `catalyst-hud-classic.sh` shell renderer (the old "ANSI terminal renderer" page) — Ink HUD details have moved to the new `hud.md`.

**Major refreshes**
- `observability/index.md` — four-layer table expanded to call out broker / forwarder / Ink HUD.
- `observability/event-flow.md` — diagrams updated with broker (reader+writer) and forwarder (outbound) paths; canonical CTL-300 envelope shown.
- `observability/events.md`, `observability/catalyst-events.md`, `observability/recording.md` — cookbook examples migrated from legacy `.event` filters to canonical `.attributes."event.name"` form (CTL-300). Path `~/catalyst/events.jsonl` corrected to `~/catalyst/events/YYYY-MM.jsonl` (monthly rotation).
- `observability/setup.md` — adds broker (`catalyst-broker start`) and forwarder (`catalyst-monitor.sh forward-start`) startup steps with `LOG_LEVEL` note (CTL-314).
- `reference/configuration.md` — new Broker section (`groq.apiKey`, `LOG_LEVEL`, PID/log paths, `filter-interests.json` → `broker-interests.json` migration); fixed broken forwarder link; new Environment Variables summary.
- `reference/setup-health-check.md` — CLI table expanded to all 14 install-cli.sh entries, distinguishing `catalyst-broker` (primary, CTL-315) from `catalyst-filter` (backward-compat shim). Removed stale "catalyst-events not yet wired" note. Added broker/forwarder daemon health-check sections.
- `reference/integrations.md` — added Groq, Cloudflare Analytics Engine, OTLP integration sections; PostHog dual-use (analytics read vs forwarder write) clarified.

**Touch-ups**
- `observability/catalyst-broker.md` — adds Agent Identity / Auto-Correlation section (CTL-303), `ticket_lifecycle` interest type, `LOG_LEVEL` config row (CTL-314), forwarder + HUD cross-links.
- `observability/webhooks.md` — canonical envelope predicates; `traceId` note (CTL-310); `broker` added to Tier-1 consumers.
- `observability/monitor.md` — one-line cross-ref to HUD as TUI alternative.
- `reference/orchestration.md` — Broker integration subsection; canonical envelope filter examples; broker/forwarder pipeline row in monitor-tracks table.
- `reference/orchestration/workers.md` — `agent.checkin {claimed_pr}` step in lifecycle; broker auto-correlation paragraph.
- `reference/catalyst-comms.md` — "v2 OTel-shaped envelope" → "canonical OTel envelope (CTL-300)"; canonical filter examples; `traceId` propagation note.
- `reference/catalyst-session.md` — clarifies that catalyst-session writes JSONL only; `catalyst-otel-forward` ships to OTLP/PostHog/Cloudflare AE.
- `getting-started/the-stack.md` — Observability table includes broker / forwarder / Ink HUD; "what's open on my screen" includes catalyst-hud.
- `getting-started/index.md` — Bun marked Required; CLI list expanded; `catalyst-broker --help` verification line; backward-compat-shim note.
- `guided-workflows/phases.md` — Phase 5 listen loop links to `/observability/catalyst-broker/`.

## Linear

CTL-316

## Test plan

- [x] `npm run build` in `website/` — 279 pages built clean.
- [x] No remaining stale references to legacy names in user-facing prose. Migration/legacy mentions retained only where explicitly framed as such.
- [x] `grep` sweeps for `filter-daemon`, `~/catalyst/events.jsonl`, `v2 OTel-shaped`, `catalyst-events is not yet wired` all clean.
- [ ] Visual review on the deployed preview to confirm Mermaid diagrams render and Starlight slug links resolve.