### PR TITLE
fix(dev): guard against legacy events crashing catalyst-hud

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useEventLog.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useEventLog.ts
@@ -39,7 +39,7 @@ export function useEventLog({ predicate = "", repoFilter = "", sinceTs }: UseEve
       }
       if (repoFilter) {
         initial = initial.filter((e) => {
-          const repo = e.attributes["vcs.repository.name"] ?? "";
+          const repo = e.attributes?.["vcs.repository.name"] ?? "";
           return !repo || repo.includes(repoFilter);
         });
       }
@@ -71,7 +71,11 @@ export function useEventLog({ predicate = "", repoFilter = "", sinceTs }: UseEve
       });
     }
 
-    run().catch(() => {});
+    run().catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[catalyst-hud] load error: ${msg}\n`);
+      setLoading(false);
+    });
     return () => controller.abort();
   }, [predicate, repoFilter, sinceTs]);
 

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -8,7 +8,8 @@ const SKIP_EVENTS = new Set([
 ]);
 
 export function shouldSkipEvent(event: CanonicalEvent): boolean {
-  const name = event.attributes["event.name"];
+  const name = event.attributes?.["event.name"];
+  if (!name) return true; // skip legacy/malformed events missing the canonical envelope
   if (SKIP_EVENTS.has(name)) return true;
   if (name === "github.check_run.completed") {
     const c = event.attributes["cicd.pipeline.run.conclusion"];
@@ -36,7 +37,8 @@ export function formatRepo(event: CanonicalEvent): string {
 }
 
 export function formatSource(event: CanonicalEvent): string {
-  const name = event.attributes["event.name"];
+  const name = event.attributes?.["event.name"];
+  if (!name) return "legacy";
   if (name.startsWith("github.")) return "github";
   if (name.startsWith("linear.")) return "linear";
   if (name === "comms.message.posted") return "comms";
@@ -60,7 +62,8 @@ const EVENT_LABELS: Record<string, string> = {
 };
 
 export function formatEvent(event: CanonicalEvent): string {
-  const name = event.attributes["event.name"];
+  const name = event.attributes?.["event.name"];
+  if (!name) return "(legacy)";
   if (name === "github.check_suite.completed") {
     const c = event.attributes["cicd.pipeline.run.conclusion"];
     return c === "success" ? "ci pass" : "ci fail";


### PR DESCRIPTION
## Summary

- Events from before the CTL-300 OTel envelope refactor lack the `attributes` object. `shouldSkipEvent` called `event.attributes["event.name"]` without optional chaining → TypeError on any legacy event
- The old `.catch(() => {})` in `useEventLog.ts` silently swallowed the error, leaving `loading` stuck at `true` forever — the \"Loading events…\" hang in a real Warp terminal
- 220 of 7,833 events in the current monthly log are legacy-format, so the hang happened 100% of the time

## Changes

- `format.ts` — `shouldSkipEvent`, `formatSource`, `formatEvent`: use `attributes?.["event.name"]`, return skip/safe defaults for events without the canonical envelope
- `useEventLog.ts` — surface load errors to stderr + call `setLoading(false)` so future crashes are visible instead of silent

## Test plan
- [ ] Run `catalyst-hud` in a fresh Warp tab — should now load and display events instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)