### PR TITLE
fix(dev): orchestrate-verify uses `bun run test` not `bun test` (CTL-317)

### DIFF
--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -221,7 +221,9 @@ else
   if [ -f "package.json" ]; then
     TEST_CMD=""
     if command -v bun >/dev/null 2>&1 && grep -q '"test"' package.json; then
-      TEST_CMD="bun test"
+      # `bun run test` defers to package.json#scripts.test (vitest, jest, etc).
+      # Bare `bun test` invokes Bun's native runner and hangs on vitest's `vi.*` mocks.
+      TEST_CMD="bun run test"
     elif grep -q '"test"' package.json; then
       TEST_CMD="npm test"
     fi

--- a/plugins/dev/scripts/test-orchestrate-verify.sh
+++ b/plugins/dev/scripts/test-orchestrate-verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Regression tests for orchestrate-verify.sh. CTL-317.
+#
+# Static assertions. No subprocess invocation of the verify script —
+# its real path executes `git diff` against an orchestrator base ref
+# that doesn't exist in test fixtures. We assert the test-command
+# selection logic stays correct.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERIFY_SCRIPT="$SCRIPT_DIR/orchestrate-verify.sh"
+
+PASS=true
+TESTS=0
+FAILURES=0
+
+fail() { echo "  FAIL: $1"; PASS=false; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  PASS: $1"; }
+run_test() { TESTS=$((TESTS + 1)); echo ""; echo "--- Test $TESTS: $1 ---"; }
+
+# ───────────────────────────────────────────────────────────────────────────
+
+run_test "verify script exists and is readable"
+[ -f "$VERIFY_SCRIPT" ] && pass "found at $VERIFY_SCRIPT" || fail "missing: $VERIFY_SCRIPT"
+
+run_test "Bun branch uses 'bun run test', not bare 'bun test' (CTL-317)"
+# Grep just the assignment. Bare `bun test` invokes Bun's native runner,
+# which breaks vitest's `vi` namespace and hangs on heavy SDK auto-discovery.
+if grep -E '^\s*TEST_CMD="bun run test"\s*$' "$VERIFY_SCRIPT" >/dev/null; then
+	pass "TEST_CMD=\"bun run test\" present"
+else
+	fail "expected TEST_CMD=\"bun run test\" in verify script"
+fi
+
+if grep -E '^\s*TEST_CMD="bun test"\s*$' "$VERIFY_SCRIPT" >/dev/null; then
+	fail "regression: bare TEST_CMD=\"bun test\" reintroduced (see CTL-317)"
+else
+	pass "no bare TEST_CMD=\"bun test\" assignment"
+fi
+
+run_test "npm fallback branch unchanged"
+if grep -E '^\s*TEST_CMD="npm test"\s*$' "$VERIFY_SCRIPT" >/dev/null; then
+	pass "npm fallback present"
+else
+	fail "expected TEST_CMD=\"npm test\" fallback branch"
+fi
+
+# ───────────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "════════════════════════════════════════════════════════════════"
+if [ "$PASS" = true ]; then
+	echo "✅ All $TESTS tests passed"
+	exit 0
+else
+	echo "❌ $FAILURES of $TESTS tests failed"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Closes [CTL-317](https://linear.app/catalyst-labs/issue/CTL-317).

`plugins/dev/scripts/orchestrate-verify.sh` step 3 (Test Suite) hangs forever on Vitest+Bun monorepos because it invokes Bun's native test runner instead of the project's `package.json#scripts.test`.

```diff
-      TEST_CMD="bun test"
+      TEST_CMD="bun run test"
```

## Root cause

Bare `bun test` runs Bun's built-in test runner, which:

1. Doesn't understand vitest's `vi` namespace (`vi.mock`, `vi.hoisted`, etc. resolve to `undefined`).
2. Auto-discovers `*.test.ts` across the whole monorepo and transitively loads heavy SDKs (AWS, etc.) just to register tests.
3. Doesn't force-exit after test load failures — lingering connection pools keep the event loop alive.
4. Survives worktree teardown and re-parents to PID 1, accumulating zombie processes (14 found on this machine, oldest 6+ days old).

`bun run test` defers to `package.json#scripts.test` (typically `turbo test` → vitest), which is the project's authoritative test command. Projects that genuinely want Bun's native runner can spell it `bun test` inside their own `scripts.test`.

## Test plan

- [x] One-line fix at `plugins/dev/scripts/orchestrate-verify.sh:224`
- [x] Inline comment explains the why (so a future "cleanup" doesn't reintroduce it)
- [x] New regression test `plugins/dev/scripts/test-orchestrate-verify.sh` asserts:
  - `TEST_CMD="bun run test"` is present
  - bare `TEST_CMD="bun test"` is absent
  - npm fallback branch unchanged
- [x] `bash -n` syntax check on both scripts
- [x] Audited all `plugins/**/*.sh` and `scripts/**/*.sh` — only one buggy occurrence; other `bun test` references are inside sub-project `package.json` files (`orch-monitor`, `broker`, `otel-forward`) that legitimately use Bun's native runner for their own `*.test.mjs` suites.

## Impact

Bug exists in catalyst-dev 7.12.2, 8.0.0, 8.1.0, 8.2.0, 8.3.0, and HEAD. Affects every orchestrator run that reaches Phase 5 verification on a Vitest+Bun monorepo. Without the fix, the orchestrator silently hangs indefinitely and the user has to manually kill the verify subprocess.