### PR TITLE
fix(dev): catalyst-hud detail header — 24h datetime, prevent timestamp wrap (CTL-327)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/detail-pane-title.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/detail-pane-title.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import type { CanonicalEvent } from "../lib/canonical-event.ts";
+import { buildDetailLines } from "../cli/components/DetailPane.tsx";
+
+const baseEvent: CanonicalEvent = {
+  ts: "2026-05-11T11:51:07.000Z",
+  severityText: "INFO",
+  severityNumber: 9,
+  traceId: "abc123def456abc123def456abc123de",
+  spanId: "abc123de456abc12",
+  resource: {
+    "service.name": "github-webhook",
+    "service.namespace": "catalyst",
+    "service.version": "8.4.0",
+  },
+  attributes: {
+    "event.name": "github.workflow_run.in_progress",
+    "vcs.repository.name": "coalesce-labs/catalyst",
+  },
+  body: { message: "" },
+};
+
+describe("DetailPane title line", () => {
+  test("first line is a title with a 19-char fixed-width datetime", () => {
+    const lines = buildDetailLines(baseEvent, 120);
+    const first = lines[0];
+    expect(first).toBeDefined();
+    expect(first.k).toBe("title");
+    if (first.k !== "title") return;
+    expect(first.ts).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    expect(first.ts.length).toBe(19);
+    expect(first.name).toBe("github.workflow_run.in_progress");
+    expect(first.sev).toBe("INFO");
+  });
+
+  test("title datetime contains no AM/PM at any width", () => {
+    for (const cols of [80, 100, 120, 160, 200]) {
+      const first = buildDetailLines(baseEvent, cols)[0];
+      if (first?.k === "title") {
+        expect(first.ts).not.toMatch(/AM|PM/i);
+      }
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { CanonicalEvent } from "../lib/canonical-event.ts";
 import {
   formatTime,
+  formatDateTime,
   formatRepo,
   formatSource,
   formatEvent,
@@ -34,6 +35,24 @@ describe("formatTime", () => {
   test("formats ISO ts as HH:MM:SS", () => {
     const result = formatTime(baseEvent);
     expect(result).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+});
+
+describe("formatDateTime", () => {
+  test("formats ISO ts as YYYY-MM-DD HH:MM:SS", () => {
+    const result = formatDateTime(baseEvent);
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  test("is always 19 characters", () => {
+    expect(formatDateTime(baseEvent).length).toBe(19);
+  });
+
+  test("uses 24h time and never emits AM/PM", () => {
+    const evening = { ...baseEvent, ts: "2026-05-11T23:51:07.000Z" };
+    const result = formatDateTime(evening);
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    expect(result).not.toMatch(/AM|PM/i);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useStdout } from "ink";
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
-import { formatDetailBody } from "../lib/format.ts";
+import { formatDateTime, formatDetailBody } from "../lib/format.ts";
 
 export interface DetailPaneProps {
   event: CanonicalEvent;
@@ -24,11 +24,7 @@ const LABEL_W = 14;
 export function buildDetailLines(event: CanonicalEvent, cols: number): Line[] {
   const attrs = event.attributes ?? {};
   const name = attrs["event.name"] ?? "(unknown)";
-  const d = new Date(event.ts);
-  const ts = d.toLocaleString(undefined, {
-    month: "short", day: "numeric",
-    hour: "2-digit", minute: "2-digit", second: "2-digit",
-  });
+  const ts = formatDateTime(event);
   const sev = event.severityText ?? "INFO";
   const lines: Line[] = [];
 
@@ -107,12 +103,19 @@ function renderLine(line: Line, i: number, cols: number): React.ReactNode {
       return <Text key={i} dimColor>{"  " + "─".repeat(Math.max(0, maxW))}</Text>;
     case "title": {
       const sevColor = (SEV_COLOR[line.sev] ?? "gray") as Parameters<typeof Text>[0]["color"];
-      const nameW = Math.max(0, maxW - 14);
+      // Compute name width from actual ts/sev lengths so the timestamp never wraps.
+      // sevText = "  <sev>" (2 leading spaces); +1 keeps a gap between name and ts.
+      const sevText = `  ${line.sev}`;
+      const budget = line.ts.length + sevText.length + 1;
+      const nameW = Math.max(0, maxW - budget);
+      const name = line.name.length > nameW
+        ? line.name.slice(0, Math.max(0, nameW - 1)) + "…"
+        : line.name.padEnd(nameW);
       return (
         <Box key={i} flexDirection="row" paddingX={1}>
-          <Text bold color="white">{line.name.slice(0, nameW).padEnd(nameW)}</Text>
+          <Text bold color="white">{name}</Text>
           <Text color="cyan">{line.ts}</Text>
-          <Text color={sevColor}>{`  ${line.sev}`}</Text>
+          <Text color={sevColor}>{sevText}</Text>
         </Box>
       );
     }

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -31,6 +31,17 @@ export function formatTime(event: CanonicalEvent): string {
   return `${hh}:${mm}:${ss}`;
 }
 
+export function formatDateTime(event: CanonicalEvent): string {
+  const d = new Date(event.ts);
+  const yyyy = String(d.getFullYear());
+  const MM = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${yyyy}-${MM}-${dd} ${hh}:${mm}:${ss}`;
+}
+
 export function formatRepo(event: CanonicalEvent): string {
   const repo = event.attributes["vcs.repository.name"] ?? "";
   return repo.includes("/") ? (repo.split("/").pop() ?? repo) : repo;


### PR DESCRIPTION
## Summary

The catalyst-hud detail pane was rendering its title-row timestamp through
`toLocaleString()` in 12-hour form (`May 11 at 11:51:07 AM`, ~21 chars) into a
row that hard-coded a 14-char budget for ts + severity. At typical terminal
widths (80–120 cols), the trailing `AM` wrapped onto its own line. The list view
already used a short 24-hour `HH:MM:SS` format, so the two surfaces were also
inconsistent.

This change:

- Adds `formatDateTime()` to `cli/lib/format.ts` — returns a fixed-width
  `YYYY-MM-DD HH:MM:SS` (19 chars), 24-hour, no locale variance.
- Uses it in `DetailPane.tsx` and computes the event-name width from the actual
  ts/severity string lengths instead of the hard-coded 14. The event name is
  now truncated with `…` ellipsis when the row would otherwise overflow, and
  severity stays flush right.
- List view (`EventRow.tsx`, `formatTime()`) is unchanged — list still uses
  `HH:MM:SS` and both surfaces now share the same 24-hour time format.

## Acceptance

- ✅ List TIME column and detail header use the same 24-hour time format.
- ✅ Detail header fits on one line at terminal widths 80–200.
- ✅ No `AM`/`PM` stranded — `formatDateTime` never emits them.
- ✅ `event.name` truncates with ellipsis rather than wrapping the timestamp.
- ✅ Severity stays flush right.

## Test plan

- [x] `bun test __tests__/hud-format.test.ts __tests__/detail-pane-title.test.ts` — 38 pass / 0 fail
- [x] `bun run typecheck` — no new errors (2 pre-existing `ui/` errors are unrelated)
- [x] `bun run lint` — 0 errors (1 pre-existing security warning unrelated)
- [x] Reward-hacking scan on diff — clean (no `as any`, `@ts-ignore`, `!`, `forEach(async`, or void tricks)

Closes CTL-327.