### PR TITLE
fix(dev): bottom-anchor catalyst-hud detail pane (CTL-324)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -6,6 +6,7 @@ import { EventList } from "./components/EventList.tsx";
 import { FilterInput } from "./components/FilterInput.tsx";
 import { QueryInput } from "./components/QueryInput.tsx";
 import { DetailPane, buildDetailLines } from "./components/DetailPane.tsx";
+import { computeDetailLayout } from "./lib/detail-layout.ts";
 import { useEventLog } from "./hooks/useEventLog.ts";
 import { useFilter, type DslPredicate } from "./hooks/useFilter.ts";
 import { useSelection } from "./hooks/useSelection.ts";
@@ -176,33 +177,26 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
 
   const selectedEvent = filtered[selectedIndex] ?? null;
 
-  // In detail mode, show a compact context window of rows around the selected event.
-  // The detail pane fills all remaining space (no half-screen cap).
-  const CONTEXT_ROWS = 5;
-  const CONTEXT_BEFORE = Math.floor(CONTEXT_ROWS / 2);
+  // When the detail pane is open it sits flush against the status row at the
+  // bottom and the event list fills all remaining height above it (CTL-324).
+  // Layout math is extracted into a pure helper for testability.
   const inDetailMode = showDetail && !!selectedEvent;
-
-  const maxDetailPaneRows = inDetailMode
-    ? Math.max(10, layoutRows - chromeRows - CONTEXT_ROWS)
-    : Math.max(10, Math.min(Math.floor(layoutRows / 2), layoutRows - chromeRows - 5));
-  const detailPaneRows = inDetailMode ? maxDetailPaneRows : 0;
-  const detailContentRows = Math.max(1, detailPaneRows - 4);
-
-  // Context mode: always show CONTEXT_ROWS centered on selectedIndex.
-  // Normal mode: fill all available space.
-  const listRows = inDetailMode
-    ? Math.min(CONTEXT_ROWS, filtered.length)
-    : Math.max(1, visibleRows - detailPaneRows);
-  const listScrollOffset = inDetailMode
-    ? Math.max(0, Math.min(selectedIndex - CONTEXT_BEFORE, Math.max(0, filtered.length - CONTEXT_ROWS)))
-    : scrollOffset;
+  const detailLines = selectedEvent ? buildDetailLines(selectedEvent, cols) : [];
+  const { detailContentRows, listRows, listScrollOffset } =
+    computeDetailLayout({
+      visibleRows,
+      inDetailMode,
+      detailLineCount: detailLines.length,
+      selectedIndex,
+      totalEvents: filtered.length,
+      currentScrollOffset: scrollOffset,
+    });
 
   const dslLines = dslState ? JSON.stringify(dslState.dsl, null, 2).split("\n") : [];
   const dslVisibleLines = Math.max(1, overlayHeight - 2);
   const maxDslScroll = Math.max(0, dslLines.length - dslVisibleLines);
 
   // title row is sticky in DetailPane, so scrollable = detailLines minus the title
-  const detailLines = selectedEvent ? buildDetailLines(selectedEvent, cols) : [];
   const maxDetailScroll = Math.max(0, (detailLines.length - 1) - detailContentRows);
 
   const submitQuery = useCallback(async (raw: string) => {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.test.ts
@@ -1,0 +1,130 @@
+// detail-layout.test.ts — verifies the layout math that decides how many rows
+// the event list vs. the detail pane get when the detail pane is open. Pure
+// math, no Ink rendering required.
+
+import { describe, test, expect } from "bun:test";
+import { computeDetailLayout } from "./detail-layout.ts";
+
+describe("computeDetailLayout", () => {
+  test("not in detail mode: list gets full visibleRows, scrollOffset unchanged", () => {
+    const r = computeDetailLayout({
+      visibleRows: 80,
+      inDetailMode: false,
+      detailLineCount: 0,
+      selectedIndex: 10,
+      totalEvents: 100,
+      currentScrollOffset: 7,
+    });
+    expect(r).toEqual({
+      detailPaneRows: 0,
+      detailContentRows: 0,
+      listRows: 80,
+      listScrollOffset: 7,
+    });
+  });
+
+  test("natural fit: 20-line event in a 93-row viewport leaves room for the list", () => {
+    const r = computeDetailLayout({
+      visibleRows: 93,
+      inDetailMode: true,
+      detailLineCount: 20,
+      selectedIndex: 50,
+      totalEvents: 200,
+      currentScrollOffset: 30,
+    });
+    expect(r.detailPaneRows).toBe(22); // 20 lines + 2 borders
+    expect(r.detailContentRows).toBe(19); // detailLineCount - 1 (title sticky)
+    expect(r.listRows).toBe(71);
+    // selected (50) is within [30, 30+71) so offset stays
+    expect(r.listScrollOffset).toBe(30);
+  });
+
+  test("capped long event: pane is bounded so list keeps minListRows", () => {
+    const r = computeDetailLayout({
+      visibleRows: 93,
+      inDetailMode: true,
+      detailLineCount: 200,
+      selectedIndex: 100,
+      totalEvents: 500,
+      currentScrollOffset: 98,
+    });
+    expect(r.detailPaneRows).toBe(88); // visibleRows - minListRows(5)
+    expect(r.listRows).toBe(5);
+    expect(r.detailContentRows).toBe(84); // paneRows - 4 (borders + title + scrollbar)
+  });
+
+  test("tiny terminal: minListRows + 2 floor keeps detail pane visible", () => {
+    const r = computeDetailLayout({
+      visibleRows: 10,
+      inDetailMode: true,
+      detailLineCount: 20,
+      selectedIndex: 5,
+      totalEvents: 30,
+      currentScrollOffset: 0,
+    });
+    // cappedMax = max(minListRows+2=7, visibleRows-minListRows=5) = 7
+    // natural   = 22
+    // paneRows  = min(22, 7) = 7
+    expect(r.detailPaneRows).toBe(7);
+    expect(r.listRows).toBe(3); // 10 - 7
+    expect(r.detailContentRows).toBe(3); // paneRows - 4 = 3
+  });
+
+  test("selected already in view: scrollOffset is clamped but otherwise unchanged", () => {
+    const r = computeDetailLayout({
+      visibleRows: 93,
+      inDetailMode: true,
+      detailLineCount: 20,
+      selectedIndex: 50,
+      totalEvents: 200,
+      currentScrollOffset: 20,
+    });
+    expect(r.listScrollOffset).toBe(20);
+  });
+
+  test("selected falls off the bottom of the smaller list: recenter", () => {
+    // Before detail opens, scrollOffset=20 was fine for visibleRows=93 list with sel=70.
+    // After detail opens, listRows=5, so [20, 25) does NOT contain 70 → recenter.
+    const r = computeDetailLayout({
+      visibleRows: 93,
+      inDetailMode: true,
+      detailLineCount: 200, // forces capped pane → listRows=5
+      selectedIndex: 70,
+      totalEvents: 200,
+      currentScrollOffset: 20,
+    });
+    expect(r.listRows).toBe(5);
+    // recenter target = selectedIndex - floor(listRows/2) = 70 - 2 = 68
+    // maxOffset = 200 - 5 = 195 → 68 stays
+    expect(r.listScrollOffset).toBe(68);
+    // selected (70) lands in [68, 73) ✓
+    expect(70).toBeGreaterThanOrEqual(r.listScrollOffset);
+    expect(70).toBeLessThan(r.listScrollOffset + r.listRows);
+  });
+
+  test("scrollOffset clamped to maxOffset when totalEvents is small", () => {
+    const r = computeDetailLayout({
+      visibleRows: 93,
+      inDetailMode: true,
+      detailLineCount: 20, // paneRows=22, listRows=71
+      selectedIndex: 50,
+      totalEvents: 100,
+      currentScrollOffset: 50, // beyond maxOffset = 100-71 = 29
+    });
+    // maxOffset=29; selected(50) falls outside [50, 50+71)... actually 50 is between
+    // 50 and 121 — but capped to 29 first, then 50 is in [29, 100), in view.
+    expect(r.listScrollOffset).toBe(29);
+  });
+
+  test("negative currentScrollOffset is treated as 0", () => {
+    const r = computeDetailLayout({
+      visibleRows: 93,
+      inDetailMode: true,
+      detailLineCount: 20,
+      selectedIndex: 3,
+      totalEvents: 100,
+      currentScrollOffset: -5,
+    });
+    expect(r.listScrollOffset).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.ts
@@ -1,0 +1,71 @@
+export interface DetailLayoutInput {
+  /** Combined height available to the event list + detail pane. */
+  visibleRows: number;
+  /** Whether the detail pane is open. */
+  inDetailMode: boolean;
+  /** Length of buildDetailLines(...) for the selected event (includes title). */
+  detailLineCount: number;
+  /** Currently selected event index in the filtered list. */
+  selectedIndex: number;
+  /** Total events in the filtered list. */
+  totalEvents: number;
+  /** Pre-detail scrollOffset from useSelection. */
+  currentScrollOffset: number;
+  /** Floor for list height when the pane is open. Default 5. */
+  minListRows?: number;
+}
+
+export interface DetailLayoutResult {
+  /** Rows the DetailPane occupies (borders + title + content). 0 when closed. */
+  detailPaneRows: number;
+  /** maxHeight prop for DetailPane (scrollable rows shown). 0 when closed. */
+  detailContentRows: number;
+  /** Rows allocated to the EventList above the pane. */
+  listRows: number;
+  /** scrollOffset to pass into EventList so the selection stays visible. */
+  listScrollOffset: number;
+}
+
+// When in detail mode, the DetailPane renders inside a single-border Box as:
+//   borders(2) + title(1) + min(scrollable, maxHeight) + scrollbar(1 iff overflow)
+// We size the pane to its natural content height, but cap it so the list
+// always retains at least `minListRows` rows.
+export function computeDetailLayout(input: DetailLayoutInput): DetailLayoutResult {
+  const minListRows = input.minListRows ?? 5;
+  const safeScroll = Math.max(0, input.currentScrollOffset);
+
+  if (!input.inDetailMode) {
+    return {
+      detailPaneRows: 0,
+      detailContentRows: 0,
+      listRows: Math.max(1, input.visibleRows),
+      listScrollOffset: safeScroll,
+    };
+  }
+
+  const cappedMax = Math.max(minListRows + 2, input.visibleRows - minListRows);
+  const natural = input.detailLineCount + 2; // +2 for top+bottom borders
+  const paneRows = Math.min(natural, cappedMax);
+  const fits = natural <= cappedMax;
+  // When content fits, no scrollbar — usable scrollable = detailLineCount - 1 (title sticky).
+  // When capped, layout is borders(2) + title(1) + visible + scrollbar(1) = paneRows
+  //   → visible = paneRows - 4.
+  const detailContentRows = fits
+    ? Math.max(1, input.detailLineCount - 1)
+    : Math.max(1, paneRows - 4);
+  const listRows = Math.max(1, input.visibleRows - paneRows);
+
+  const maxOffset = Math.max(0, input.totalEvents - listRows);
+  let listScrollOffset = Math.min(safeScroll, maxOffset);
+  if (
+    input.selectedIndex < listScrollOffset ||
+    input.selectedIndex >= listScrollOffset + listRows
+  ) {
+    listScrollOffset = Math.max(
+      0,
+      Math.min(input.selectedIndex - Math.floor(listRows / 2), maxOffset),
+    );
+  }
+
+  return { detailPaneRows: paneRows, detailContentRows, listRows, listScrollOffset };
+}


### PR DESCRIPTION
## Summary

- Detail pane now anchors flush against the status row at the bottom; the event list fills all remaining height above it.
- Layout math extracted into `cli/lib/detail-layout.ts` so the boundary cases (natural fit / capped / tiny terminal / selection clamping) have unit tests.
- No changes to `DetailPane.tsx` or `EventList.tsx` — they already accepted the props we needed.

Closes CTL-324.

## What changed

Previously `inDetailMode` reserved everything except 5 context rows for the detail pane, but `DetailPane` only renders to its content size (not the allocated `maxHeight`), so the unused allocation appeared as empty space below the pane. On a tall terminal this left the bottom half blank with the event list clipped to 5 rows above the pane.

The new layout computes the pane's **actual** content height (`detailLineCount + 2` for borders), caps it so the list always keeps at least `minListRows = 5`, and gives the list whatever remains. When content overflows the cap, the existing scrollbar takes over inside the pane and the list shrinks to its minimum.

`listScrollOffset` keeps the selected event visible: if it's still inside the shrunken window we leave the scroll alone; otherwise we recenter on the selected index.

## Test plan

- [x] `bun test cli/lib/detail-layout.test.ts` — 8 cases (natural fit, capped, tiny terminal, in-view, off-bottom recenter, max-offset clamp, negative scroll, no-detail-mode)
- [x] `bun run typecheck` — no new errors (pre-existing `ui/src/lib/briefings.ts` `marked`/`dompurify` errors unrelated)
- [x] `bun run lint` — no errors
- [x] Smoke: `bun cli/hud.tsx --help` parses CLI args and exits cleanly
- [ ] Manual check on a tall terminal: open detail on a 20-line event → pane sits at bottom, list fills above, selected row visible; long event → pane caps with scrollbar, list shrinks to 5 rows; Enter again → list returns to full height

🤖 Generated with [Claude Code](https://claude.com/claude-code)