### PR TITLE
fix(dev): bottom-anchor catalyst-hud help panel (CTL-325)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -6,7 +6,11 @@ import { EventList } from "./components/EventList.tsx";
 import { FilterInput } from "./components/FilterInput.tsx";
 import { QueryInput } from "./components/QueryInput.tsx";
 import { DetailPane, buildDetailLines } from "./components/DetailPane.tsx";
-import { computeDetailLayout } from "./lib/detail-layout.ts";
+import {
+  computeBottomOverlaySize,
+  computeDetailLayout,
+  reanchorListScrollOffset,
+} from "./lib/detail-layout.ts";
 import { useEventLog } from "./hooks/useEventLog.ts";
 import { useFilter, type DslPredicate } from "./hooks/useFilter.ts";
 import { useSelection } from "./hooks/useSelection.ts";
@@ -140,10 +144,11 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   const overlayHeight = showDslOverlay && dslState ? Math.min(14, Math.floor(layoutRows / 2)) : 0;
 
   const [showHelp, setShowHelp] = useState(false);
-  const helpHeight = showHelp ? HELP_LINES.length + 2 : 0; // +2 for border
 
-  // chrome = header + status(1) + filter(1) + query(1) + overlays
-  const chromeRows = headerRows + 3 + overlayHeight + helpHeight;
+  // chrome = header + status(1) + filter(1) + query(1) + dsl overlay (if any).
+  // Help and detail are bottom-anchored *inside* visibleRows via the layout
+  // helpers below — they no longer steal rows from the top.
+  const chromeRows = headerRows + 3 + overlayHeight;
   const visibleRows = Math.max(1, layoutRows - chromeRows);
 
   const { selectedIndex, scrollOffset, moveUp, moveDown, pageUp, pageDown, jumpToBottom, autoFollow } =
@@ -177,13 +182,36 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
 
   const selectedEvent = filtered[selectedIndex] ?? null;
 
-  // When the detail pane is open it sits flush against the status row at the
-  // bottom and the event list fills all remaining height above it (CTL-324).
-  // Layout math is extracted into a pure helper for testability.
-  const inDetailMode = showDetail && !!selectedEvent;
+  // Help and detail are mutually exclusive bottom-anchored overlays. Help wins
+  // when both states would be true (opening help already swallows all input,
+  // so a simultaneously rendered detail pane would be dead state).
+  // Each overlay sits flush against the status row and the event list fills
+  // all remaining height above it (CTL-324, CTL-325). Layout math is
+  // extracted into pure helpers for testability.
+  const inDetailMode = showDetail && !!selectedEvent && !showHelp;
   const detailLines = selectedEvent ? buildDetailLines(selectedEvent, cols) : [];
-  const { detailContentRows, listRows, listScrollOffset } =
-    computeDetailLayout({
+
+  let listRows: number;
+  let listScrollOffset: number;
+  let detailContentRows = 0;
+  // Visible content rows inside the help panel (excludes the 2 borders and the
+  // 1-row title). 0 when help is closed.
+  let helpVisibleRows = 0;
+
+  if (showHelp) {
+    // Natural height = HELP_LINES + title row + 2 borders.
+    const natural = HELP_LINES.length + 1 + 2;
+    const size = computeBottomOverlaySize(visibleRows, natural);
+    helpVisibleRows = Math.max(1, size.paneRows - 3);
+    listRows = size.listRows;
+    listScrollOffset = reanchorListScrollOffset(
+      selectedIndex,
+      filtered.length,
+      listRows,
+      scrollOffset,
+    );
+  } else {
+    const detail = computeDetailLayout({
       visibleRows,
       inDetailMode,
       detailLineCount: detailLines.length,
@@ -191,6 +219,10 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
       totalEvents: filtered.length,
       currentScrollOffset: scrollOffset,
     });
+    detailContentRows = detail.detailContentRows;
+    listRows = detail.listRows;
+    listScrollOffset = detail.listScrollOffset;
+  }
 
   const dslLines = dslState ? JSON.stringify(dslState.dsl, null, 2).split("\n") : [];
   const dslVisibleLines = Math.max(1, overlayHeight - 2);
@@ -335,14 +367,22 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
         scrollOffset={listScrollOffset}
         visibleRows={listRows}
         columns={cols}
-        compact={inDetailMode}
+        compact={inDetailMode || showHelp}
       />
-      {showDetail && selectedEvent && (
+      {inDetailMode && selectedEvent && (
         <DetailPane
           event={selectedEvent}
           scrollTop={detailScrollTop}
           maxHeight={detailContentRows}
         />
+      )}
+      {showHelp && (
+        <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+          <Text color="cyan" bold>{"Keybindings — h or Esc to close"}</Text>
+          {HELP_LINES.slice(0, helpVisibleRows).map((line, i) => (
+            <Text key={i} dimColor={!line.startsWith("  ")}>{line || " "}</Text>
+          ))}
+        </Box>
       )}
       <Box flexDirection="row">
         <Text dimColor>{`  ${filtered.length}/${events.length} events`}</Text>
@@ -358,14 +398,6 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           <Text color="magenta" bold>{`Generated DSL · j/k scroll · ? to hide (${dslScrollTop + 1}/${dslLines.length}):`}</Text>
           {dslLines.slice(dslScrollTop, dslScrollTop + dslVisibleLines).map((line, i) => (
             <Text key={i} dimColor={i > 0}>{line}</Text>
-          ))}
-        </Box>
-      )}
-      {showHelp && (
-        <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
-          <Text color="cyan" bold>{"Keybindings — h or Esc to close"}</Text>
-          {HELP_LINES.map((line, i) => (
-            <Text key={i} dimColor={!line.startsWith("  ")}>{line || " "}</Text>
           ))}
         </Box>
       )}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.test.ts
@@ -1,9 +1,13 @@
 // detail-layout.test.ts — verifies the layout math that decides how many rows
-// the event list vs. the detail pane get when the detail pane is open. Pure
-// math, no Ink rendering required.
+// the event list vs. the bottom overlay (detail pane, help panel) get when an
+// overlay is open. Pure math, no Ink rendering required.
 
 import { describe, test, expect } from "bun:test";
-import { computeDetailLayout } from "./detail-layout.ts";
+import {
+  computeBottomOverlaySize,
+  computeDetailLayout,
+  reanchorListScrollOffset,
+} from "./detail-layout.ts";
 
 describe("computeDetailLayout", () => {
   test("not in detail mode: list gets full visibleRows, scrollOffset unchanged", () => {
@@ -126,5 +130,73 @@ describe("computeDetailLayout", () => {
       currentScrollOffset: -5,
     });
     expect(r.listScrollOffset).toBe(0);
+  });
+});
+
+describe("computeBottomOverlaySize", () => {
+  test("natural fit: pane gets full natural height, list takes the rest", () => {
+    const r = computeBottomOverlaySize(80, 22);
+    expect(r.paneRows).toBe(22);
+    expect(r.listRows).toBe(58);
+    expect(r.fits).toBe(true);
+  });
+
+  test("capped: pane bounded so list keeps minListRows", () => {
+    const r = computeBottomOverlaySize(80, 200);
+    // cappedMax = max(7, 80-5) = 75; pane = min(200, 75) = 75
+    expect(r.paneRows).toBe(75);
+    expect(r.listRows).toBe(5);
+    expect(r.fits).toBe(false);
+  });
+
+  test("tiny terminal: minListRows + 2 floor keeps overlay visible", () => {
+    const r = computeBottomOverlaySize(10, 30);
+    // cappedMax = max(7, 5) = 7; pane = min(30, 7) = 7
+    expect(r.paneRows).toBe(7);
+    expect(r.listRows).toBe(3);
+    expect(r.fits).toBe(false);
+  });
+
+  test("custom minListRows", () => {
+    const r = computeBottomOverlaySize(40, 100, 10);
+    // cappedMax = max(12, 30) = 30
+    expect(r.paneRows).toBe(30);
+    expect(r.listRows).toBe(10);
+    expect(r.fits).toBe(false);
+  });
+
+  test("listRows floors at 1 when pane fills everything", () => {
+    const r = computeBottomOverlaySize(10, 100, 3);
+    // cappedMax = max(5, 7) = 7; pane = 7; list = 3 (above floor)
+    expect(r.listRows).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("reanchorListScrollOffset", () => {
+  test("selected already in view: offset clamped but unchanged otherwise", () => {
+    const offset = reanchorListScrollOffset(50, 200, 71, 30);
+    expect(offset).toBe(30);
+  });
+
+  test("selected falls off the bottom: recenter around selection", () => {
+    // listRows=5, selected=70 not in [20, 25) → recenter to 70 - 2 = 68
+    const offset = reanchorListScrollOffset(70, 200, 5, 20);
+    expect(offset).toBe(68);
+  });
+
+  test("clamps to maxOffset when totalEvents is small", () => {
+    // maxOffset = 100 - 71 = 29; selected=50 in [29, 100) → stays at 29
+    const offset = reanchorListScrollOffset(50, 100, 71, 50);
+    expect(offset).toBe(29);
+  });
+
+  test("negative currentScrollOffset is treated as 0", () => {
+    const offset = reanchorListScrollOffset(3, 100, 71, -5);
+    expect(offset).toBe(0);
+  });
+
+  test("listRows >= totalEvents: maxOffset is 0", () => {
+    const offset = reanchorListScrollOffset(2, 5, 10, 7);
+    expect(offset).toBe(0);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.ts
@@ -26,46 +26,82 @@ export interface DetailLayoutResult {
   listScrollOffset: number;
 }
 
+export interface BottomOverlaySize {
+  /** Rows the overlay occupies (content + borders). */
+  paneRows: number;
+  /** Rows allocated to the EventList above the overlay. */
+  listRows: number;
+  /** True when the overlay's natural height fit without capping. */
+  fits: boolean;
+}
+
+// Generic bottom-anchored overlay sizing. The overlay (detail pane, help
+// panel, future modals) renders at its natural height, but is capped so the
+// list above always retains at least `minListRows` rows.
+export function computeBottomOverlaySize(
+  visibleRows: number,
+  naturalRows: number,
+  minListRows: number = 5,
+): BottomOverlaySize {
+  const cappedMax = Math.max(minListRows + 2, visibleRows - minListRows);
+  const paneRows = Math.min(naturalRows, cappedMax);
+  const fits = naturalRows <= cappedMax;
+  const listRows = Math.max(1, visibleRows - paneRows);
+  return { paneRows, listRows, fits };
+}
+
+// Keep the selection visible after the list shrinks (an overlay opened, etc.).
+// Returns a scrollOffset clamped to [0, maxOffset]; recenters around the
+// selection only when it would otherwise fall outside the visible window.
+export function reanchorListScrollOffset(
+  selectedIndex: number,
+  totalEvents: number,
+  listRows: number,
+  currentScrollOffset: number,
+): number {
+  const safeScroll = Math.max(0, currentScrollOffset);
+  const maxOffset = Math.max(0, totalEvents - listRows);
+  let offset = Math.min(safeScroll, maxOffset);
+  if (selectedIndex < offset || selectedIndex >= offset + listRows) {
+    offset = Math.max(0, Math.min(selectedIndex - Math.floor(listRows / 2), maxOffset));
+  }
+  return offset;
+}
+
 // When in detail mode, the DetailPane renders inside a single-border Box as:
 //   borders(2) + title(1) + min(scrollable, maxHeight) + scrollbar(1 iff overflow)
 // We size the pane to its natural content height, but cap it so the list
 // always retains at least `minListRows` rows.
 export function computeDetailLayout(input: DetailLayoutInput): DetailLayoutResult {
   const minListRows = input.minListRows ?? 5;
-  const safeScroll = Math.max(0, input.currentScrollOffset);
 
   if (!input.inDetailMode) {
     return {
       detailPaneRows: 0,
       detailContentRows: 0,
       listRows: Math.max(1, input.visibleRows),
-      listScrollOffset: safeScroll,
+      listScrollOffset: Math.max(0, input.currentScrollOffset),
     };
   }
 
-  const cappedMax = Math.max(minListRows + 2, input.visibleRows - minListRows);
   const natural = input.detailLineCount + 2; // +2 for top+bottom borders
-  const paneRows = Math.min(natural, cappedMax);
-  const fits = natural <= cappedMax;
+  const { paneRows, listRows, fits } = computeBottomOverlaySize(
+    input.visibleRows,
+    natural,
+    minListRows,
+  );
   // When content fits, no scrollbar — usable scrollable = detailLineCount - 1 (title sticky).
   // When capped, layout is borders(2) + title(1) + visible + scrollbar(1) = paneRows
   //   → visible = paneRows - 4.
   const detailContentRows = fits
     ? Math.max(1, input.detailLineCount - 1)
     : Math.max(1, paneRows - 4);
-  const listRows = Math.max(1, input.visibleRows - paneRows);
-
-  const maxOffset = Math.max(0, input.totalEvents - listRows);
-  let listScrollOffset = Math.min(safeScroll, maxOffset);
-  if (
-    input.selectedIndex < listScrollOffset ||
-    input.selectedIndex >= listScrollOffset + listRows
-  ) {
-    listScrollOffset = Math.max(
-      0,
-      Math.min(input.selectedIndex - Math.floor(listRows / 2), maxOffset),
-    );
-  }
+  const listScrollOffset = reanchorListScrollOffset(
+    input.selectedIndex,
+    input.totalEvents,
+    listRows,
+    input.currentScrollOffset,
+  );
 
   return { detailPaneRows: paneRows, detailContentRows, listRows, listScrollOffset };
 }


### PR DESCRIPTION
## Summary

Apply CTL-324's bottom-anchor treatment to the help panel (`h`). Consumes the layout primitive from CTL-324 rather than duplicating the math, as the ticket requested.

Closes [CTL-325](https://linear.app/coalesce-labs/issue/CTL-325).

## Changes

- **`cli/lib/detail-layout.ts`** — extract two pure helpers:
  - `computeBottomOverlaySize(visibleRows, naturalRows, minListRows?)` — generic capped-overlay sizing for any bottom-anchored overlay (detail pane, help panel, future modals).
  - `reanchorListScrollOffset(selectedIndex, totalEvents, listRows, currentScrollOffset)` — keeps the selected event visible when the list shrinks.
  - `computeDetailLayout` is refactored to delegate to these helpers. Its public API is unchanged and all 8 existing tests pass byte-for-byte.

- **`cli/hud.tsx`** — wire the help panel to bottom-anchor:
  - `helpHeight` removed from `chromeRows`; help is allocated inside `visibleRows` via `computeBottomOverlaySize`.
  - Help and detail are mutually exclusive overlays (help wins — opening help already swallows all input).
  - Help overlay JSX moves from below the status row to above it, matching the detail-pane placement.
  - `EventList`'s `compact` prop is also true when help is open so it sits at natural `listRows` instead of flex-growing past the help panel.

- **`cli/lib/detail-layout.test.ts`** — 10 new tests covering the extracted helpers (5 for `computeBottomOverlaySize`, 5 for `reanchorListScrollOffset`). All 18 detail-layout tests pass.

## Behavior

- Press `h` → help panel anchors to the bottom of the viewport; event list above expands to fill all remaining height.
- Press `h` (or `Esc`) again → panel closes; list returns to full height.
- Tiny terminal → help is capped so the list keeps at least 5 rows; visible HELP_LINES are sliced to fit (no scroll-in-help in this ticket).

## Note on the ticket text

The CTL-325 ticket prose says the trigger is `?`, but the actual binding in `hud.tsx` is `h` (the `?` key opens the generated-DSL overlay). This PR honors the current code, not the prose.

## Test plan

- [x] `bun test cli/lib/detail-layout.test.ts` — 18 pass (8 pre-existing + 10 new)
- [x] `bun run typecheck` — no new errors (2 pre-existing `marked`/`dompurify` errors in `ui/`)
- [x] `bun run lint` — 0 errors (1 pre-existing warning unrelated)
- [x] Reward-hacking scan — clean (no `as any`, `@ts-ignore`, `!` non-null, `forEach(async`)