### PR TITLE
fix(dev): broker writes canonical filter.wake events + HUD shows filter.* labels (CTL-331)

### DIFF
--- a/plugins/dev/scripts/broker/canonical-events.test.mjs
+++ b/plugins/dev/scripts/broker/canonical-events.test.mjs
@@ -1,0 +1,186 @@
+// CTL-331: verify broker appendEvent emits OTel-shaped canonical envelopes
+// so the HUD's shouldSkipEvent guard doesn't drop them.
+//
+// Run: bun test plugins/dev/scripts/broker/canonical-events.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmpDir;
+let originalCatalystDir;
+
+// Re-import the broker fresh in each test so the CATALYST_DIR env var is
+// picked up by the module's `getEventLogPath` (it reads process.env at call
+// time, so a single import is fine — but we set/restore the env per test).
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "broker-canonical-test-"));
+  originalCatalystDir = process.env.CATALYST_DIR;
+  process.env.CATALYST_DIR = tmpDir;
+});
+
+afterEach(() => {
+  if (originalCatalystDir === undefined) {
+    delete process.env.CATALYST_DIR;
+  } else {
+    process.env.CATALYST_DIR = originalCatalystDir;
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function eventLogPath() {
+  const now = new Date();
+  const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  return join(tmpDir, "events", `${ym}.jsonl`);
+}
+
+function readEvents() {
+  const path = eventLogPath();
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+describe("buildCanonicalEnvelope", () => {
+  test("produces canonical shape with attributes wrapper", async () => {
+    const { buildCanonicalEnvelope } = await import("./index.mjs");
+    const envelope = buildCanonicalEnvelope({
+      event: "filter.wake.sess_abc",
+      orchestrator: "orch_1",
+      worker: null,
+      detail: { reason: "PR #1 merged", interest_id: "sess_abc" },
+    });
+
+    expect(envelope.attributes["event.name"]).toBe("filter.wake.sess_abc");
+    expect(envelope.attributes["catalyst.orchestrator.id"]).toBe("orch_1");
+    expect(envelope.severityText).toBe("INFO");
+    expect(envelope.severityNumber).toBe(9);
+    expect(envelope.resource["service.name"]).toBe("catalyst.broker");
+    expect(envelope.resource["service.namespace"]).toBe("catalyst");
+    expect(envelope.body.payload).toEqual({ reason: "PR #1 merged", interest_id: "sess_abc" });
+    expect(envelope.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(envelope.spanId).toBeNull();
+  });
+
+  test("omits orchestrator/worker attributes when null", async () => {
+    const { buildCanonicalEnvelope } = await import("./index.mjs");
+    const envelope = buildCanonicalEnvelope({
+      event: "broker.daemon.startup",
+      orchestrator: null,
+      worker: null,
+      detail: { pid: 12345 },
+    });
+
+    expect(envelope.attributes["event.name"]).toBe("broker.daemon.startup");
+    expect(envelope.attributes["catalyst.orchestrator.id"]).toBeUndefined();
+    expect(envelope.attributes["catalyst.worker.ticket"]).toBeUndefined();
+    expect(envelope.traceId).toBeNull();
+    expect(envelope.spanId).toBeNull();
+    expect(envelope.body.payload).toEqual({ pid: 12345 });
+  });
+
+  test("populates worker.ticket and spanId when worker is set", async () => {
+    const { buildCanonicalEnvelope } = await import("./index.mjs");
+    const envelope = buildCanonicalEnvelope({
+      event: "filter.wake.sess_x",
+      orchestrator: "orch_1",
+      worker: "CTL-331",
+      detail: null,
+    });
+
+    expect(envelope.attributes["catalyst.worker.ticket"]).toBe("CTL-331");
+    expect(envelope.spanId).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("trace/span derivation is deterministic", async () => {
+    const { buildCanonicalEnvelope } = await import("./index.mjs");
+    const a = buildCanonicalEnvelope({ event: "x", orchestrator: "orch_1", worker: null });
+    const b = buildCanonicalEnvelope({ event: "y", orchestrator: "orch_1", worker: null });
+    expect(a.traceId).toBe(b.traceId);
+
+    const c = buildCanonicalEnvelope({ event: "x", orchestrator: "orch_2", worker: null });
+    expect(a.traceId).not.toBe(c.traceId);
+  });
+
+  test("body.payload is null when detail is null/undefined", async () => {
+    const { buildCanonicalEnvelope } = await import("./index.mjs");
+    const noDetail = buildCanonicalEnvelope({ event: "x", orchestrator: null, worker: null });
+    expect(noDetail.body.payload).toBeNull();
+
+    const nullDetail = buildCanonicalEnvelope({
+      event: "x",
+      orchestrator: null,
+      worker: null,
+      detail: null,
+    });
+    expect(nullDetail.body.payload).toBeNull();
+  });
+});
+
+describe("appendEvent — writes canonical envelopes to JSONL", () => {
+  test("writes a canonical line that passes shouldSkipEvent shape check", async () => {
+    const { appendEvent } = await import("./index.mjs");
+    appendEvent({
+      event: "filter.wake.sess_abc",
+      orchestrator: "orch_1",
+      worker: null,
+      detail: { reason: "PR #1 merged" },
+    });
+
+    const events = readEvents();
+    expect(events).toHaveLength(1);
+    const e = events[0];
+
+    // The exact shape requirement that broke before: attributes["event.name"]
+    // must be set so HUD's shouldSkipEvent doesn't discard the event.
+    expect(e.attributes).toBeDefined();
+    expect(e.attributes["event.name"]).toBe("filter.wake.sess_abc");
+
+    // Full canonical fields present.
+    expect(e.ts).toBeString();
+    expect(e.observedTs).toBeString();
+    expect(e.severityText).toBe("INFO");
+    expect(e.severityNumber).toBe(9);
+    expect(e.resource["service.name"]).toBe("catalyst.broker");
+    expect(e.body.payload.reason).toBe("PR #1 merged");
+  });
+
+  test("writes broker.daemon.startup as canonical", async () => {
+    const { appendEvent } = await import("./index.mjs");
+    appendEvent({
+      event: "broker.daemon.startup",
+      orchestrator: null,
+      worker: null,
+      detail: { pid: 99, recovered_interests: 0 },
+    });
+
+    const events = readEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].attributes["event.name"]).toBe("broker.daemon.startup");
+    expect(events[0].body.payload.pid).toBe(99);
+  });
+
+  test("appended lines are valid JSON with no legacy v1 fields at the top level", async () => {
+    const { appendEvent } = await import("./index.mjs");
+    appendEvent({
+      event: "filter.wake.x",
+      orchestrator: "orch_1",
+      worker: null,
+      detail: { reason: "x" },
+    });
+
+    const events = readEvents();
+    const e = events[0];
+    // Legacy v1 shape had `event` and `detail` at the top level — these must
+    // NOT appear on the canonical envelope itself; they live inside
+    // attributes/body now.
+    expect(e.event).toBeUndefined();
+    expect(e.detail).toBeUndefined();
+    expect(e.orchestrator).toBeUndefined();
+    expect(e.worker).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -23,6 +23,7 @@ import {
 import { homedir } from "node:os";
 import { resolve, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 import pino from "pino";
 import {
   openBrokerStateDb,
@@ -75,13 +76,92 @@ const HEARTBEAT_STALE_MS = parseInt(process.env.FILTER_HEARTBEAT_STALE_MS ?? "18
 function getEventLogPath() {
   const now = new Date();
   const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-  return resolve(CATALYST_DIR, "events", `${ym}.jsonl`);
+  // Re-read CATALYST_DIR per call so tests can redirect by setting the env
+  // var. Production deployments still pin a stable value via daemon launch.
+  const catalystDir = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+  return resolve(catalystDir, "events", `${ym}.jsonl`);
 }
 
-function appendEvent(event) {
+// Canonical envelope helpers (mirrors lib/canonical-event.sh and
+// orch-monitor/lib/canonical-event.ts so trace/span IDs match deterministically
+// across producers — CTL-331).
+
+const __PLUGIN_JSON_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  ".claude-plugin",
+  "plugin.json",
+);
+let __pluginVersionCached = null;
+
+export function pluginVersion() {
+  if (__pluginVersionCached !== null) return __pluginVersionCached;
+  try {
+    const parsed = JSON.parse(readFileSync(__PLUGIN_JSON_PATH, "utf8"));
+    __pluginVersionCached = typeof parsed?.version === "string" ? parsed.version : "0.0.0";
+  } catch {
+    __pluginVersionCached = "0.0.0";
+  }
+  return __pluginVersionCached;
+}
+
+function sha256Hex(input) {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function deriveTraceId(orchestratorId) {
+  if (orchestratorId && orchestratorId.length > 0) {
+    return sha256Hex(orchestratorId).slice(0, 32);
+  }
+  return null;
+}
+
+function deriveSpanId(workerTicket) {
+  if (workerTicket && workerTicket.length > 0) {
+    return sha256Hex(workerTicket).slice(0, 16);
+  }
+  return null;
+}
+
+const __SEVERITY_NUMBERS = { DEBUG: 5, INFO: 9, WARN: 13, ERROR: 17 };
+
+// Translate the broker's internal {event, orchestrator, worker, detail} shape
+// into a canonical OTel-style envelope. Severity defaults to INFO — broker
+// emissions today (filter.wake.*, broker.daemon.startup) are all info-level.
+export function buildCanonicalEnvelope(legacy) {
+  const eventName = legacy.event ?? "";
+  const orch = legacy.orchestrator ?? null;
+  const worker = legacy.worker ?? null;
+  const severity = legacy.severity ?? "INFO";
+  const ts = legacy.ts ?? new Date().toISOString();
+
+  const attributes = { "event.name": eventName };
+  if (orch) attributes["catalyst.orchestrator.id"] = orch;
+  if (worker) attributes["catalyst.worker.ticket"] = worker;
+
+  return {
+    ts,
+    observedTs: ts,
+    severityText: severity,
+    severityNumber: __SEVERITY_NUMBERS[severity] ?? __SEVERITY_NUMBERS.INFO,
+    traceId: deriveTraceId(orch),
+    spanId: deriveSpanId(worker),
+    resource: {
+      "service.name": "catalyst.broker",
+      "service.namespace": "catalyst",
+      "service.version": pluginVersion(),
+    },
+    attributes,
+    body: { payload: legacy.detail ?? null },
+  };
+}
+
+export function appendEvent(event) {
   const logPath = getEventLogPath();
   mkdirSync(dirname(logPath), { recursive: true });
-  appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), ...event }) + "\n");
+  const canonical = buildCanonicalEnvelope(event);
+  appendFileSync(logPath, JSON.stringify(canonical) + "\n");
 }
 
 // --- Interest table ---

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -143,6 +143,12 @@ __orch_canonical_for() {
     attention-raised)        echo "orchestrator.attention.raised attention raised WARN" ;;
     attention-resolved)      echo "orchestrator.attention.resolved attention resolved INFO" ;;
     archive)                 echo "orchestrator.archived orchestrator archived INFO" ;;
+    # Filter daemon lifecycle (CTL-331): keep the bare filter.* name so the HUD
+    # can label them; the wildcard fallthrough would otherwise rename them
+    # orchestrator.filter.* which has no display label.
+    filter.register)         echo "filter.register filter register INFO" ;;
+    filter.deregister)       echo "filter.deregister filter deregister INFO" ;;
+    filter.wake)             echo "filter.wake filter wake INFO" ;;
     *)                       echo "orchestrator.$1 orchestrator $1 INFO" ;;
   esac
 }

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -114,6 +114,46 @@ describe("formatSource", () => {
     const e = { ...baseEvent, attributes: { "event.name": "some.unknown.event" } } as unknown as CanonicalEvent;
     expect(formatSource(e)).toBe("system");
   });
+
+  // CTL-331: filter events surface the orchestrator id when present so users
+  // can correlate filter events back to a specific orchestrator run.
+  test("maps filter.* with orchestrator id to that orch id", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "filter.register",
+        "catalyst.orchestrator.id": "orch-abc",
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("orch-abc");
+  });
+
+  test("maps filter.* without orchestrator id to 'filter'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.sess_x" },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("filter");
+  });
+
+  test("maps legacy orchestrator.filter.* alias to the orchestrator id", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "orchestrator.filter.register",
+        "catalyst.orchestrator.id": "orch-abc",
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("orch-abc");
+  });
+
+  test("maps broker.daemon.startup to 'broker'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "broker.daemon.startup" },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("broker");
+  });
 });
 
 describe("formatEvent", () => {
@@ -157,6 +197,54 @@ describe("formatEvent", () => {
   test("maps orchestrator.worker.done to 'done'", () => {
     const e = { ...baseEvent, attributes: { "event.name": "orchestrator.worker.done" } } as unknown as CanonicalEvent;
     expect(formatEvent(e)).toBe("done");
+  });
+
+  // CTL-331: filter daemon lifecycle labels.
+  test("maps filter.register to 'filter reg'", () => {
+    const e = { ...baseEvent, attributes: { "event.name": "filter.register" } } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("filter reg");
+  });
+
+  test("maps filter.deregister to 'filter dereg'", () => {
+    const e = { ...baseEvent, attributes: { "event.name": "filter.deregister" } } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("filter dereg");
+  });
+
+  test("maps filter.wake to 'wake'", () => {
+    const e = { ...baseEvent, attributes: { "event.name": "filter.wake" } } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("wake");
+  });
+
+  test("maps prefixed filter.wake.{sessionId} to 'wake' (not truncated)", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.sess_20260511T203845_16d33281" },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("wake");
+  });
+
+  test("maps legacy orchestrator.filter.register alias to 'filter reg'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.filter.register" },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("filter reg");
+  });
+
+  test("maps legacy orchestrator.filter.wake.* alias to 'wake'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.filter.wake.sess_xyz" },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("wake");
+  });
+
+  test("maps broker.daemon.startup to 'broker start'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "broker.daemon.startup" },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("broker start");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -53,7 +53,14 @@ export function formatSource(event: CanonicalEvent): string {
   if (name.startsWith("github.")) return "github";
   if (name.startsWith("linear.")) return "linear";
   if (name === "comms.message.posted") return "comms";
-  if (name.startsWith("filter.")) return "filter";
+  // CTL-331: recognise filter.* and the legacy orchestrator.filter.* alias.
+  // Surface the orchestrator id when present so users can correlate filter
+  // events back to a specific orchestrator run.
+  if (name.startsWith("filter.") || name.startsWith("orchestrator.filter.")) {
+    const orchId = event.attributes["catalyst.orchestrator.id"];
+    return orchId ?? "filter";
+  }
+  if (name === "broker.daemon.startup") return "broker";
   const orchId = event.attributes["catalyst.orchestrator.id"];
   const worker = event.attributes["catalyst.worker.ticket"];
   if (orchId && worker) return `${orchId}/${worker}`;
@@ -70,6 +77,16 @@ const EVENT_LABELS: Record<string, string> = {
   "orchestrator.attention.raised": "attention",
   "comms.message.posted": "comms",
   "session.phase": "phase",
+  // CTL-331: filter daemon lifecycle events.
+  "filter.register": "filter reg",
+  "filter.deregister": "filter dereg",
+  "filter.wake": "wake",
+  "broker.daemon.startup": "broker start",
+  // Legacy aliases for events written before catalyst-state.sh preserved the
+  // bare filter.* name (CTL-331). Keeps older log lines readable.
+  "orchestrator.filter.register": "filter reg",
+  "orchestrator.filter.deregister": "filter dereg",
+  "orchestrator.filter.wake": "wake",
 };
 
 export function formatEvent(event: CanonicalEvent): string {
@@ -78,6 +95,11 @@ export function formatEvent(event: CanonicalEvent): string {
   if (name === "github.check_suite.completed") {
     const c = event.attributes["cicd.pipeline.run.conclusion"];
     return c === "success" ? "ci pass" : "ci fail";
+  }
+  // CTL-331: wake events are session-scoped (filter.wake.{sessionId}).
+  // EVENT_LABELS is exact-match, so handle the prefixed family explicitly.
+  if (name.startsWith("filter.wake.") || name.startsWith("orchestrator.filter.wake.")) {
+    return "wake";
   }
   const label = EVENT_LABELS[name] ?? name;
   return label.slice(0, 15);


### PR DESCRIPTION
## Summary

Three independent fixes so filter daemon lifecycle events finally render in catalyst-hud (CTL-331). Today 40 `filter.wake` events show up in the live log and 0 reach the HUD; another 8 `filter.register` events render as the unrecognizable 15-char truncation `"orchestrator.fi"`.

- **`broker/index.mjs` `appendEvent`** now writes OTel-shaped canonical envelopes (mirroring `lib/canonical-event.sh` / `orch-monitor/lib/canonical-event.ts`). The previous v1 shape had no `attributes` wrapper, so the HUD's `shouldSkipEvent` guard at `format.ts:12` silently dropped every event the broker emitted (`filter.wake.*`, `broker.daemon.startup`).
- **`catalyst-state.sh` `__orch_canonical_for`** adds explicit arms for `filter.register`, `filter.deregister`, and `filter.wake`. The wildcard fallthrough was renaming them `orchestrator.filter.*`, which passes `shouldSkipEvent` but has no `EVENT_LABELS` entry.
- **`orch-monitor/cli/lib/format.ts`** adds `EVENT_LABELS` for `filter.register` → `"filter reg"`, `filter.deregister` → `"filter dereg"`, `filter.wake` → `"wake"`, plus prefix-aware handling for the session-scoped `filter.wake.{sessionId}` family. Adds `broker.daemon.startup` → `"broker start"`. Extends `formatSource` to recognise `filter.*` and surface the orchestrator id when present, plus the legacy `orchestrator.filter.*` alias so already-written log lines still render correctly.

## Test plan

- [x] `bun test plugins/dev/scripts/broker/` — 79 pass (incl. 11 new canonical envelope tests)
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts` — 44 pass (incl. 11 new label/source tests)
- [x] Smoke: `CATALYST_DIR=... catalyst-state.sh event '{"event":"filter.register",...}'` now produces canonical line with `attributes["event.name"] === "filter.register"` (not `orchestrator.filter.register`).
- [x] Reward-hacking grep clean (no `as any`, `@ts-ignore`, `!`-non-null, `forEach(async`).
- [x] Full orch-monitor test suite baseline diffed — only pre-existing `catalyst-monitor.sh` subprocess flakes (6 fail on `main`, unrelated to this change).
- [x] Typecheck baseline diffed — `ui/src/lib/briefings.ts` missing-module errors pre-existing and outside this PR's scope.

## Notes

- `activity-briefing.ts` projects via `projectCanonical` which already reads `attributes["event.name"]`, so the broker shape change improves briefings (previously dropped legacy events) without code changes there.
- `STRIP_EVENTS` in `activity-briefing.ts` was dead code for filter.* (because catalyst-state.sh was renaming them away); this PR makes it active — `filter.register`/`filter.deregister` get correctly stripped from activity briefings.
- Legacy log lines (written before this change) continue to be filtered out by `shouldSkipEvent`'s missing-attributes guard. Existing scrub scripts that read the v1 `.event` field still work on accumulated legacy bloat.

Research: `thoughts/shared/research/2026-05-11-filter-event-hud-visibility.md`
Plan: `thoughts/shared/plans/2026-05-11-CTL-331-broker-canonical-filter-events.md`

Closes CTL-331