### PR TITLE
fix(dev): catalyst-hud — make comms rows self-explanatory (CTL-330)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -77,8 +77,34 @@ describe("formatSource", () => {
     expect(formatSource(baseEvent)).toBe("github");
   });
 
-  test("maps comms.message.posted to 'comms'", () => {
-    const e = { ...baseEvent, attributes: { ...baseEvent.attributes, "event.name": "comms.message.posted" } };
+  test("maps comms.message.posted to sender from event.label", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "event.label": "CTL-330",
+        "catalyst.worker.ticket": "CTL-330",
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("CTL-330");
+  });
+
+  test("falls back to worker ticket when comms event has no label", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "catalyst.worker.ticket": "CTL-330",
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("CTL-330");
+  });
+
+  test("falls back to 'comms' when comms event has no label or worker", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+    } as unknown as CanonicalEvent;
     expect(formatSource(e)).toBe("comms");
   });
 
@@ -246,6 +272,42 @@ describe("formatEvent", () => {
     } as unknown as CanonicalEvent;
     expect(formatEvent(e)).toBe("broker start");
   });
+
+  test("maps comms.message.posted with type='info' to 'info'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: { type: "info", channel: "orch-demo", to: "all" } },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("info");
+  });
+
+  test("maps comms.message.posted with type='attention' to 'attention'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: { type: "attention", channel: "orch-demo", to: "all" } },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("attention");
+  });
+
+  test("maps comms.message.posted with type='done' to 'done'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: { type: "done", channel: "orch-demo", to: "all" } },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("done");
+  });
+
+  test("falls back to 'comms' when comms event has no payload type", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: {} },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("comms");
+  });
 });
 
 describe("formatRef", () => {
@@ -278,6 +340,42 @@ describe("formatRef", () => {
 
   test("returns empty string when no ref info", () => {
     const e = { ...baseEvent, attributes: { "event.name": "heartbeat" } } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("");
+  });
+
+  test("formats comms recipient with → prefix", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: { type: "info", channel: "orch-demo", to: "CTL-330" } },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("→CTL-330");
+  });
+
+  test("formats comms broadcast recipient with → prefix", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: { type: "info", channel: "orch-demo", to: "all" } },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("→all");
+  });
+
+  test("falls back to channel for comms when recipient is missing", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: { type: "info", channel: "orch-demo" } },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("orch-demo");
+  });
+
+  test("returns empty string for comms with no recipient or channel", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: {} },
+    } as unknown as CanonicalEvent;
     expect(formatRef(e)).toBe("");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -52,7 +52,13 @@ export function formatSource(event: CanonicalEvent): string {
   if (!name) return "legacy";
   if (name.startsWith("github.")) return "github";
   if (name.startsWith("linear.")) return "linear";
-  if (name === "comms.message.posted") return "comms";
+  if (name === "comms.message.posted") {
+    const label = event.attributes["event.label"];
+    if (label) return label;
+    const worker = event.attributes["catalyst.worker.ticket"];
+    if (worker) return worker;
+    return "comms";
+  }
   // CTL-331: recognise filter.* and the legacy orchestrator.filter.* alias.
   // Surface the orchestrator id when present so users can correlate filter
   // events back to a specific orchestrator run.
@@ -75,7 +81,6 @@ const EVENT_LABELS: Record<string, string> = {
   "orchestrator.worker.done": "done",
   "orchestrator.worker.failed": "failed",
   "orchestrator.attention.raised": "attention",
-  "comms.message.posted": "comms",
   "session.phase": "phase",
   // CTL-331: filter daemon lifecycle events.
   "filter.register": "filter reg",
@@ -96,6 +101,12 @@ export function formatEvent(event: CanonicalEvent): string {
     const c = event.attributes["cicd.pipeline.run.conclusion"];
     return c === "success" ? "ci pass" : "ci fail";
   }
+  if (name === "comms.message.posted") {
+    const payload = event.body?.payload as Record<string, unknown> | undefined;
+    const type = payload?.["type"];
+    if (typeof type === "string" && type.length > 0) return type.slice(0, 15);
+    return "comms";
+  }
   // CTL-331: wake events are session-scoped (filter.wake.{sessionId}).
   // EVENT_LABELS is exact-match, so handle the prefixed family explicitly.
   if (name.startsWith("filter.wake.") || name.startsWith("orchestrator.filter.wake.")) {
@@ -106,6 +117,14 @@ export function formatEvent(event: CanonicalEvent): string {
 }
 
 export function formatRef(event: CanonicalEvent): string {
+  if (event.attributes?.["event.name"] === "comms.message.posted") {
+    const payload = event.body?.payload as Record<string, unknown> | undefined;
+    const to = payload?.["to"];
+    if (typeof to === "string" && to.length > 0) return `→${to}`;
+    const channel = payload?.["channel"];
+    if (typeof channel === "string" && channel.length > 0) return channel;
+    return "";
+  }
   const pr = event.attributes["vcs.pr.number"];
   if (pr) return `#${pr}`;
   const ticket = event.attributes["linear.issue.identifier"];


### PR DESCRIPTION
## Summary

Fixes [CTL-330](https://linear.app/coalesce-labs/issue/CTL-330) — comms events (`comms.message.posted`) were nearly opaque in the HUD table. SOURCE and EVENT were hardcoded to `"comms"` and REF was empty, forcing the user to drill into the detail pane to see sender, recipient, or message type.

Three targeted changes in `plugins/dev/scripts/orch-monitor/cli/lib/format.ts`:

| Column | Before | After |
| -- | -- | -- |
| SOURCE | `comms` | sender from `event.label` (fallback: `catalyst.worker.ticket`) |
| EVENT  | `comms` | message type — `info` / `attention` / `done` (from `body.payload.type`) |
| REF    | (empty) | `→<recipient>` (fallback: channel name) |

`attention` now appears as its own value in the EVENT column, visually distinct from `info` and `done` heartbeats.

## What changed

- `formatSource` — special-cases `comms.message.posted` to pull the sender from `event.label`, falling back to `catalyst.worker.ticket`, then "comms" as a last resort.
- `formatEvent` — removed static `"comms"` mapping from `EVENT_LABELS`; now reads `body.payload.type` and returns the type verbatim (truncated to 15 chars).
- `formatRef` — early-returns for comms events: `→<to>` if recipient present, else channel name, else empty.

## What I did not change

- **`catalyst-comms` `--vcs-repo`** — the ticket suggested "consider" passing it so REPO populates. Comms is cross-cutting (agent-to-agent pub/sub), not naturally repo-scoped, and the acceptance criteria only required SOURCE/EVENT/REF. Leaving REPO empty for comms is honest about what the event represents.
- **UI-side `formatters.ts`** — that file is for status color/phase mapping, not table-row formatting. The web HUD renders comms differently and is not affected.

## Test plan

- [x] `bun test __tests__/hud-format.test.ts` — 43 pass, 0 fail. Added 10 new test cases:
  - `formatSource`: 3 cases (event.label → label, fallback to worker, fallback to "comms")
  - `formatEvent`: 4 cases (info / attention / done / missing-type fallback)
  - `formatRef`: 3 cases (→to / →all / channel fallback / empty)
- [x] Full suite delta: +10 passes (1501 → 1511), same 7 pre-existing `catalyst-monitor.sh` failures on main
- [x] `bun run typecheck` clean for my changes (pre-existing `ui/src/lib/briefings.ts` errors unrelated)
- [x] `bun run lint` clean for my changes (pre-existing warning in `preview-status.ts` unrelated)