### PR TITLE
fix(dev): catalyst-hud sticky column header (CTL-332)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
@@ -17,10 +17,10 @@ export function FilterInput({ value, focused, onChange, pivot }: FilterInputProp
       )}
       <Text dimColor={!focused}>{"/ "}</Text>
       <TextInput value={value} onChange={onChange} focus={focused} placeholder="filter (substring or .jq)" />
-      <Text dimColor>
+      <Text dimColor wrap="truncate-end">
         {"  "}
         {focused ? "Esc:clear" : "/:focus"}
-        {" | t:trace o:orch r:reset | Enter:detail q:quit"}
+        {" | t:trace o:orch | Enter:detail q:quit"}
       </Text>
     </Box>
   );

--- a/plugins/dev/scripts/orch-monitor/cli/components/QueryInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/QueryInput.tsx
@@ -23,7 +23,7 @@ export function QueryInput({ value, focused, busy, error, hasDsl, onChange, onSu
           focus={focused && !busy}
           placeholder='natural-language query (e.g. "errors today")'
         />
-        <Text dimColor>
+        <Text dimColor wrap="truncate-end">
           {"  "}
           {busy ? "translating…" : focused ? "Enter:run Esc:cancel" : ":focus"}
           {hasDsl ? " | ?:show DSL" : ""}

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -359,32 +359,38 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   }
 
   return (
-    <Box flexDirection="column">
-      <Header columns={cols} nlQuery={dslState?.nlQuery} />
-      <EventList
-        events={filtered}
-        selectedIndex={selectedIndex}
-        scrollOffset={listScrollOffset}
-        visibleRows={listRows}
-        columns={cols}
-        compact={inDetailMode || showHelp}
-      />
-      {inDetailMode && selectedEvent && (
-        <DetailPane
-          event={selectedEvent}
-          scrollTop={detailScrollTop}
-          maxHeight={detailContentRows}
+    <Box flexDirection="column" height={layoutRows} width={cols}>
+      <Box flexShrink={0}>
+        <Header columns={cols} nlQuery={dslState?.nlQuery} />
+      </Box>
+      <Box flexDirection="column" flexGrow={(inDetailMode || showHelp) ? 0 : 1} flexShrink={1}>
+        <EventList
+          events={filtered}
+          selectedIndex={selectedIndex}
+          scrollOffset={listScrollOffset}
+          visibleRows={listRows}
+          columns={cols}
+          compact={inDetailMode || showHelp}
         />
+      </Box>
+      {inDetailMode && selectedEvent && (
+        <Box flexShrink={0}>
+          <DetailPane
+            event={selectedEvent}
+            scrollTop={detailScrollTop}
+            maxHeight={detailContentRows}
+          />
+        </Box>
       )}
       {showHelp && (
-        <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+        <Box flexShrink={0} flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
           <Text color="cyan" bold>{"Keybindings — h or Esc to close"}</Text>
           {HELP_LINES.slice(0, helpVisibleRows).map((line, i) => (
             <Text key={i} dimColor={!line.startsWith("  ")}>{line || " "}</Text>
           ))}
         </Box>
       )}
-      <Box flexDirection="row">
+      <Box flexDirection="row" flexShrink={0}>
         <Text dimColor>{`  ${filtered.length}/${events.length} events`}</Text>
         {autoFollow
           ? <Text color="green">{"  [LIVE]"}</Text>
@@ -394,28 +400,32 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
         {statusMsg && <Text color="yellow">{`  ${statusMsg}`}</Text>}
       </Box>
       {showDslOverlay && dslState && (
-        <Box flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={1}>
+        <Box flexShrink={0} flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={1}>
           <Text color="magenta" bold>{`Generated DSL · j/k scroll · ? to hide (${dslScrollTop + 1}/${dslLines.length}):`}</Text>
           {dslLines.slice(dslScrollTop, dslScrollTop + dslVisibleLines).map((line, i) => (
             <Text key={i} dimColor={i > 0}>{line}</Text>
           ))}
         </Box>
       )}
-      <FilterInput
-        value={filterText}
-        focused={filterFocused}
-        onChange={setFilterText}
-        pivot={pivot}
-      />
-      <QueryInput
-        value={queryText}
-        focused={queryFocused}
-        busy={querySubmitting}
-        error={queryError}
-        hasDsl={dslState !== null}
-        onChange={setQueryText}
-        onSubmit={(v) => { void submitQuery(v); }}
-      />
+      <Box flexShrink={0}>
+        <FilterInput
+          value={filterText}
+          focused={filterFocused}
+          onChange={setFilterText}
+          pivot={pivot}
+        />
+      </Box>
+      <Box flexShrink={0}>
+        <QueryInput
+          value={queryText}
+          focused={queryFocused}
+          busy={querySubmitting}
+          error={queryError}
+          hasDsl={dslState !== null}
+          onChange={setQueryText}
+          onSubmit={(v) => { void submitQuery(v); }}
+        />
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

When the detail pane is open in `catalyst-hud`, the column header row
(`TIME REPO SOURCE EVENT REF DETAILS`) detaches from the top of the
viewport and is pulled down to sit just above the detail pane, with
~4 events visible between header and pane and ~50 rows of stale,
unlabeled events above. CTL-332.

## Root cause

The layout math in `hud.tsx` is correct — `headerRows + listRows +
detailPaneRows + chrome = layoutRows` — but the root Box had no explicit
`height`, so Ink rendered children at their natural heights and let the
terminal scroll when total content exceeded the visible area. Two paths
trigger overflow:

- Long chrome rows wrap in narrow terminals (FilterInput's help hint
  was ~104 chars).
- Warp split panes can under-report the visible row count.

When the terminal scrolls, the Header (top of the JSX) becomes part of
scrollback and only the bottom of the render stays visible.

## Fix

- `hud.tsx` — add `height={layoutRows} width={cols}` to the root Box.
  Wrap each fixed-height child in `Box flexShrink={0}` (Header, status,
  DSL overlay, help overlay, FilterInput, QueryInput, DetailPane). The
  EventList wrapper is the only `flexShrink={1}`, so any unmodeled
  shrinkage costs list rows rather than the header.
- `FilterInput.tsx` / `QueryInput.tsx` — `wrap="truncate-end"` on the
  trailing help-hint Text so they never spill onto a second row. Drops
  the redundant `r:reset` mention from FilterInput's hint to give narrow
  terminals more headroom.

No changes to layout math, `EventList`, `DetailPane`, or `Header`.

## Test plan

- [x] `bun run typecheck` (no new errors from these files; 2 pre-existing
      unrelated errors in `ui/src/lib/briefings.ts`)
- [x] `bun run lint` (no new warnings)
- [x] `bun test` (no regression — same 1501 pass / 7 fail as `main`;
      failures are pre-existing SQLite test-infra issues in
      `__tests__/session-store.test.ts`)
- [ ] Manual: open `bin/catalyst-hud` in a wide terminal, narrow
      terminal (~80 cols), and a Warp split pane; toggle detail pane
      and verify the column header stays pinned at row 0 in all three.

Closes CTL-332.