### PR TITLE
fix(dev): HUD filter row display — DETAILS, REF, and SOURCE (CTL-337)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -143,7 +143,7 @@ describe("formatSource", () => {
 
   // CTL-331: filter events surface the orchestrator id when present so users
   // can correlate filter events back to a specific orchestrator run.
-  test("maps filter.* with orchestrator id to that orch id", () => {
+  test("maps filter.register with orchestrator id to that orch id", () => {
     const e = {
       ...baseEvent,
       attributes: {
@@ -154,15 +154,15 @@ describe("formatSource", () => {
     expect(formatSource(e)).toBe("orch-abc");
   });
 
-  test("maps filter.* without orchestrator id to 'filter'", () => {
+  test("maps filter.register without orchestrator id to 'filter'", () => {
     const e = {
       ...baseEvent,
-      attributes: { "event.name": "filter.wake.sess_x" },
+      attributes: { "event.name": "filter.register" },
     } as unknown as CanonicalEvent;
     expect(formatSource(e)).toBe("filter");
   });
 
-  test("maps legacy orchestrator.filter.* alias to the orchestrator id", () => {
+  test("maps legacy orchestrator.filter.register alias to the orchestrator id", () => {
     const e = {
       ...baseEvent,
       attributes: {
@@ -171,6 +171,35 @@ describe("formatSource", () => {
       },
     } as unknown as CanonicalEvent;
     expect(formatSource(e)).toBe("orch-abc");
+  });
+
+  // CTL-337: filter.wake events are always emitted by the broker, so the SOURCE
+  // column shows "broker" regardless of which orchestrator the wake is routed to.
+  test("maps filter.wake.* to 'broker'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.sess_x" },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("broker");
+  });
+
+  test("maps filter.wake.* to 'broker' even when orchestrator id is present", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "filter.wake.sess_x",
+        "catalyst.orchestrator.id": "orch-abc",
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("broker");
+  });
+
+  test("maps legacy orchestrator.filter.wake.* alias to 'broker'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.filter.wake.sess_x" },
+    } as unknown as CanonicalEvent;
+    expect(formatSource(e)).toBe("broker");
   });
 
   test("maps broker.daemon.startup to 'broker'", () => {
@@ -378,6 +407,75 @@ describe("formatRef", () => {
     } as unknown as CanonicalEvent;
     expect(formatRef(e)).toBe("");
   });
+
+  // CTL-337: filter.register events surface the tickets / repo being watched
+  // so the REF column tells the user *what* the registration is observing.
+  test("formats filter.register tickets array as comma-joined list", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: {
+        payload: {
+          prompt: "Wake me when…",
+          context: { tickets: ["ADV-904", "ADV-905"], pr_numbers: [], branches: [] },
+        },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("ADV-904,ADV-905");
+  });
+
+  test("formats filter.register single ticket", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: { payload: { context: { tickets: ["CTL-337"] } } },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("CTL-337");
+  });
+
+  test("formats filter.register repo as basename when no tickets", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: {
+        payload: {
+          interest_id: "orch-abc-pr-lifecycle",
+          interest_type: "pr_lifecycle",
+          repo: "rightsite-cloud/Adva",
+        },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("Adva");
+  });
+
+  test("returns repo as-is for filter.register when it has no slash", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: { payload: { repo: "myrepo" } },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("myrepo");
+  });
+
+  test("falls back to existing behaviour when filter.register has no tickets or repo", () => {
+    // Preserve the baseEvent vcs.pr.number so we can verify the filter.register
+    // branch falls through to the PR fallback when its own context is empty.
+    const e = {
+      ...baseEvent,
+      attributes: { ...baseEvent.attributes, "event.name": "filter.register" },
+      body: { payload: {} },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("#501");
+  });
+
+  test("handles legacy orchestrator.filter.register tickets", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.filter.register" },
+      body: { payload: { context: { tickets: ["ADV-878", "ADV-877"] } } },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("ADV-878,ADV-877");
+  });
 });
 
 describe("formatDetails", () => {
@@ -522,6 +620,84 @@ describe("formatDetails (sanitizer)", () => {
   test("returns empty string when body is missing", () => {
     const e = { ...baseEvent, body: undefined } as unknown as CanonicalEvent;
     expect(formatDetails(e)).toBe("");
+  });
+});
+
+describe("formatDetails (filter.register)", () => {
+  // CTL-337: filter.register events surface human-readable criteria so the
+  // DETAILS column tells the user *why* the registration was made.
+  test("returns sanitised prompt when present", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: {
+        message: "ignored",
+        payload: {
+          prompt: "Wake me when: any of my workers posts a comms message of type attention",
+          context: { tickets: ["ADV-904"] },
+        },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe(
+      "Wake me when: any of my workers posts a comms message of type attention",
+    );
+  });
+
+  test("returns interest_type + repo when no prompt", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: {
+        message: "ignored",
+        payload: {
+          interest_id: "orch-abc-pr-lifecycle",
+          interest_type: "pr_lifecycle",
+          repo: "rightsite-cloud/Adva",
+        },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("pr_lifecycle rightsite-cloud/Adva");
+  });
+
+  test("returns interest_type alone when no repo and no prompt", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: {
+        message: "ignored",
+        payload: { interest_type: "pr_lifecycle" },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("pr_lifecycle");
+  });
+
+  test("sanitises markdown and HTML in the prompt", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: {
+        payload: { prompt: "Wake me when **PR merged** or <p>CI passes</p>" },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("Wake me when PR merged or CI passes");
+  });
+
+  test("handles legacy orchestrator.filter.register prompt", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.filter.register" },
+      body: { payload: { prompt: "Wake me when ticket changes" } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("Wake me when ticket changes");
+  });
+
+  test("falls back to generic payload handling when filter.register has neither prompt nor interest_type", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+      body: { message: "fallback message", payload: {} },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("fallback message");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -59,6 +59,12 @@ export function formatSource(event: CanonicalEvent): string {
     if (worker) return worker;
     return "comms";
   }
+  // CTL-337: filter.wake events are always emitted by the broker; the
+  // orchestrator id on the wake is the recipient, not the source. Return
+  // "broker" so the SOURCE column shows who actually sent the event.
+  if (name.startsWith("filter.wake.") || name.startsWith("orchestrator.filter.wake.")) {
+    return "broker";
+  }
   // CTL-331: recognise filter.* and the legacy orchestrator.filter.* alias.
   // Surface the orchestrator id when present so users can correlate filter
   // events back to a specific orchestrator run.
@@ -117,13 +123,29 @@ export function formatEvent(event: CanonicalEvent): string {
 }
 
 export function formatRef(event: CanonicalEvent): string {
-  if (event.attributes?.["event.name"] === "comms.message.posted") {
+  const name = event.attributes?.["event.name"];
+  if (name === "comms.message.posted") {
     const payload = event.body?.payload as Record<string, unknown> | undefined;
     const to = payload?.["to"];
     if (typeof to === "string" && to.length > 0) return `→${to}`;
     const channel = payload?.["channel"];
     if (typeof channel === "string" && channel.length > 0) return channel;
     return "";
+  }
+  // CTL-337: filter.register events watch a specific set of tickets (semantic
+  // interest) or a specific repo (structured interest like pr_lifecycle).
+  // Surface that in REF so the user sees what the registration observes.
+  if (name?.startsWith("filter.register") || name?.startsWith("orchestrator.filter.register")) {
+    const payload = event.body?.payload as Record<string, unknown> | undefined;
+    const ctx = payload?.["context"] as Record<string, unknown> | undefined;
+    const tickets = ctx?.["tickets"];
+    if (Array.isArray(tickets) && tickets.length > 0) {
+      return (tickets as string[]).join(",");
+    }
+    const repo = payload?.["repo"];
+    if (typeof repo === "string" && repo.length > 0) {
+      return repo.includes("/") ? (repo.split("/").pop() ?? repo) : repo;
+    }
   }
   const pr = event.attributes["vcs.pr.number"];
   if (pr) return `#${pr}`;
@@ -234,7 +256,28 @@ const bodyCache = new WeakMap<CanonicalEvent, string>();
 export function formatDetails(event: CanonicalEvent): string {
   const cached = detailsCache.get(event);
   if (cached !== undefined) return cached;
+  const name = event.attributes?.["event.name"];
   const payload = event.body?.payload;
+  // CTL-337: filter.register events carry a human-readable prompt (semantic
+  // interest) or an interest_type + repo (structured interest). Surface that
+  // in DETAILS so the user sees *why* the registration was made.
+  if (name?.startsWith("filter.register") || name?.startsWith("orchestrator.filter.register")) {
+    const p = payload as Record<string, unknown> | undefined;
+    const prompt = p?.["prompt"];
+    if (typeof prompt === "string" && prompt.length > 0) {
+      const out = sanitize(prompt, "oneline");
+      detailsCache.set(event, out);
+      return out;
+    }
+    const itype = p?.["interest_type"];
+    if (typeof itype === "string" && itype.length > 0) {
+      const repo = p?.["repo"];
+      const text = typeof repo === "string" && repo.length > 0 ? `${itype} ${repo}` : itype;
+      const out = sanitize(text, "oneline");
+      detailsCache.set(event, out);
+      return out;
+    }
+  }
   const msg = event.body?.message ?? "";
   let raw = msg;
   if (payload && typeof payload === "object") {


### PR DESCRIPTION
## Summary

Three display gaps for `filter.*` events in the orch-monitor HUD ([CTL-337](https://linear.app/rozich/issue/CTL-337)):

| Column | Event | Before | After |
| --- | --- | --- | --- |
| `DETAILS` | `filter.register` | blank | registration prompt, or `interest_type repo` |
| `REF` | `filter.register` | blank | `context.tickets` joined, or repo basename |
| `SOURCE` | `filter.wake.*` | orchestrator id (the recipient) | `broker` (the actual emitter) |

## Changes

- **`formatDetails`** — adds a `filter.register` branch above the generic payload handler. Prefers `payload.prompt` (semantic interests like the one written by oneshot's listen loop), falls back to `payload.interest_type [+ payload.repo]` (broker-derived structured interests like `pr_lifecycle`). Sanitised through the existing `sanitize(_, "oneline")` so HTML/markdown in prompts renders cleanly.
- **`formatRef`** — adds a `filter.register` branch between the comms handler and the existing PR / ticket / branch fallback. Joins `context.tickets` with commas, or surfaces `repo` as basename (matching the existing `formatRepo` convention).
- **`formatSource`** — adds a `filter.wake.*` branch above the existing `filter.*` branch. Returns `broker` regardless of whether `catalyst.orchestrator.id` is present, since the orchestrator id on a wake is the recipient, not the source. `filter.register` continues to surface the orchestrator id.

Legacy `orchestrator.filter.*` aliases are handled in every branch so older log lines still render correctly.

## Test plan

- [x] `bun test __tests__/hud-format.test.ts` — 100/100 pass (14 new cases for the three formatters)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (1 pre-existing warning in `lib/preview-status.ts`)
- [x] No production-code shortcuts (`as any`, `@ts-ignore`, non-null assertions) — verified by diff scan
- [x] Existing `formatSource` filter test split into non-wake (still `'filter'`) and new wake (`'broker'`) cases — no silent behaviour regression

Real payload shapes (sampled from `~/catalyst/events/2026-05.jsonl`) drove the field selection; both the semantic `prompt + context.tickets` shape and the structured `interest_type + repo` shape are covered.

Refs: [CTL-337](https://linear.app/rozich/issue/CTL-337). Supersedes [CTL-338](https://linear.app/rozich/issue/CTL-338).