### PR TITLE
fix(dev): orchestrate-dispatch-next leaks parent stdin into worker (CTL-334)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -403,6 +403,38 @@ Y_WAVE=$(jq -r '.wave' "${ORCH_DIR}/workers/Y.json")
 [ "$Y_WAVE" = "10" ] && pass "Y.wave=10" || fail "Y.wave=10" "got: $Y_WAVE"
 scratch_teardown
 
+echo "test 23 (CTL-334): worker subshell does not inherit parent herestring stdin"
+scratch_setup
+# Replace the fake claude with one that captures its own stdin to a per-pid
+# file. With the stdin leak, the first worker(s) would see the leftover
+# `<wave>\t<ticket>` rows from the dispatcher's `done <<< "$PENDING"` loop.
+cat > "${SCRATCH}/bin/claude" <<EOF2
+#!/usr/bin/env bash
+# Drain stdin into a deterministic file so the test can inspect it.
+cat <&0 > "${SCRATCH}/stdin-\$\$.log" 2>/dev/null || true
+sleep 30 &
+disown \$! 2>/dev/null || true
+EOF2
+chmod +x "${SCRATCH}/bin/claude"
+write_state "demo" 4 '{"wave1Pending": ["T-1", "T-2", "T-3"]}'
+for T in T-1 T-2 T-3; do make_worktree "demo" "$T"; done
+OUT=$(run_dispatch 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "T-1,T-2,T-3" ] && pass "all 3 dispatched in one call" \
+  || fail "all 3 dispatched in one call" "got: $DISPATCHED (stdin leak symptom: only first N-1 dispatched)"
+# Every captured stdin file must be empty (no inherited herestring content).
+LEAK_COUNT=0
+for SF in "${SCRATCH}"/stdin-*.log; do
+  [ -e "$SF" ] || continue
+  if [ -s "$SF" ]; then
+    LEAK_COUNT=$((LEAK_COUNT+1))
+    echo "    LEAK in $SF: $(head -c 200 "$SF")" >&2
+  fi
+done
+[ "$LEAK_COUNT" = "0" ] && pass "no worker received leftover herestring on stdin" \
+  || fail "no worker received leftover herestring on stdin" "$LEAK_COUNT worker(s) saw stdin content"
+scratch_teardown
+
 echo ""
 echo "─────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -242,7 +242,11 @@ while IFS=$'\t' read -r W T; do
       --verbose \
       --dangerously-skip-permissions \
       -p "${WORKER_COMMAND} ${T} ${WORKER_ARGS}"
-  ) > "$STREAM" 2> "$STDERR" &
+  ) > "$STREAM" 2> "$STDERR" </dev/null &
+  # </dev/null above: claude -p reads stdin even in non-interactive mode. Without
+  # this, the worker inherits the parent's open herestring (`done <<< "$PENDING"`
+  # below) and treats leftover `<wave>\t<ticket>` lines as additional prompt
+  # input, blowing up the first AskUserQuestion. See CTL-334.
   PID=$!
 
   NOW2=$(now_iso)

--- a/plugins/dev/scripts/orchestrate-followup
+++ b/plugins/dev/scripts/orchestrate-followup
@@ -284,4 +284,4 @@ awk -v tid="$NEW_TICKET" \
 echo "Wrote prompt: $PROMPT_FILE"
 echo ""
 echo "Dispatch the follow-up worker with:"
-echo "  mkdir -p \"${ORCH_DIR}/workers/output\" && ( cd \"${WORKER_DIR}\" && exec nohup claude -n \"${WORKER_NAME}\" --output-format stream-json --verbose --dangerously-skip-permissions -p \"\$(cat ${PROMPT_FILE})\" ) > \"${ORCH_DIR}/workers/output/${NEW_TICKET}-stream.jsonl\" 2> \"${ORCH_DIR}/workers/output/${NEW_TICKET}-stderr.log\" &"
+echo "  mkdir -p \"${ORCH_DIR}/workers/output\" && ( cd \"${WORKER_DIR}\" && exec nohup claude -n \"${WORKER_NAME}\" --output-format stream-json --verbose --dangerously-skip-permissions -p \"\$(cat ${PROMPT_FILE})\" ) > \"${ORCH_DIR}/workers/output/${NEW_TICKET}-stream.jsonl\" 2> \"${ORCH_DIR}/workers/output/${NEW_TICKET}-stderr.log\" </dev/null &"

--- a/plugins/dev/templates/dispatch-fixup.sh.template
+++ b/plugins/dev/templates/dispatch-fixup.sh.template
@@ -50,5 +50,7 @@ PROMPT_BODY="$(cat "${PROMPT_FILE}")"
     --verbose \
     --dangerously-skip-permissions \
     -p "${PROMPT_BODY}"
-) > "${STREAM_FILE}" 2> "${LOG_FILE}" &
+) > "${STREAM_FILE}" 2> "${LOG_FILE}" </dev/null &
+# </dev/null on the worker subshell prevents claude -p from inheriting the
+# parent shell's stdin (e.g. a herestring feeding a `read` loop). See CTL-334.
 echo "Dispatched fix-up worker via claude CLI (pid $!)"

--- a/plugins/dev/templates/dispatch-rebase.sh.template
+++ b/plugins/dev/templates/dispatch-rebase.sh.template
@@ -50,5 +50,7 @@ PROMPT_BODY="$(cat "${PROMPT_FILE}")"
     --verbose \
     --dangerously-skip-permissions \
     -p "${PROMPT_BODY}"
-) > "${STREAM_FILE}" 2> "${LOG_FILE}" &
+) > "${STREAM_FILE}" 2> "${LOG_FILE}" </dev/null &
+# </dev/null on the worker subshell prevents claude -p from inheriting the
+# parent shell's stdin (e.g. a herestring feeding a `read` loop). See CTL-334.
 echo "Dispatched rebase worker via claude CLI (pid $!)"


### PR DESCRIPTION
## Summary

- Closes [CTL-334](https://linear.app/coalesce-labs/issue/CTL-334)
- `orchestrate-dispatch-next` was leaking the parent shell's herestring stdin into backgrounded `claude -p` worker subshells, causing the first worker(s) in a multi-row dispatch to receive leftover `<wave>\t<ticket>` lines as prompt input and exit with launch-failure
- Two confirmed repros on the ticket — original (`hud-fixes-2026-05-11`, CTL-332) and 2026-05-12 (`orch-adv-912-2026-05-12`, ADV-916)
- Adds a regression test that fails with the bug present (only 1 of 3 dispatched, leaked stdin observable) and passes with the fix

## Root cause

The dispatch loop iterates over PENDING via `while IFS=$'\t' read -r W T; do ... done <<< "$PENDING"`. Inside the loop, the launch site is:

```bash
(
  cd "$WORKER_DIR" || exit 1
  ...
  exec nohup "$CLAUDE_BIN" ... -p "..."
) > "$STREAM" 2> "$STDERR" &
```

The backgrounded subshell inherits stdin from the parent — the herestring that `read` is draining one line at a time. `claude -p` reads stdin even in non-interactive mode and treats the leftover TSV rows as additional prompt input. The first AskUserQuestion in the worker (asking what the trailing `<wave>\t<ticket>` token means) errors out in headless `-p` mode and the worker exits as launch-failure within seconds.

## Fix

Add `</dev/null` on the launch subshell so claude can't inherit the parent's stdin. `orchestrate-revive` already does this at line 225 — the new code matches that pattern.

Files changed:

| File | What | Why |
|------|------|-----|
| `plugins/dev/scripts/orchestrate-dispatch-next` | `</dev/null` on launch subshell + explanatory comment | Primary fix |
| `plugins/dev/templates/dispatch-fixup.sh.template` | `</dev/null` on launch subshell | Defense-in-depth: future change can't regress the pattern |
| `plugins/dev/templates/dispatch-rebase.sh.template` | `</dev/null` on launch subshell | Same |
| `plugins/dev/scripts/orchestrate-followup` | `</dev/null` on the printed launch command template | Same |
| `plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh` | New test 23 (CTL-334) | Regression coverage |

The regression test redefines the fake `claude` binary to drain stdin into a per-PID file, then dispatches 3 tickets and asserts (a) all 3 are dispatched in a single call and (b) every per-worker stdin capture is empty. Verified by stashing the fix and re-running: test 23 fails with `got: T-1 (stdin leak symptom: only first N-1 dispatched)` and `LEAK ... 1\tT-2\n1\tT-3` — matches the exact symptom from the ticket repros.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh` — 74 pass, 0 fail (includes new test 23)
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-fixup.test.sh` — 21 pass
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-rebase.test.sh` — 22 pass
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-followup.test.sh` — 14 pass
- [x] Verified test 23 detects the bug (stashed fix → failed; restored → passed)