### PR TITLE
fix(dev): HUD highlight uses inverse video for readable contrast (CTL-342)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -18,28 +18,30 @@ interface EventRowProps {
 
 export function EventRow({ event, selected, columns }: EventRowProps) {
   const color = getRowColor(event);
-  const bg = selected ? ("blue" as const) : undefined;
+  // Inverse video swaps fg/bg at the terminal level (ANSI SGR 7), guaranteeing
+  // contrast across themes without composing same-family fg/bg pairs.
+  const inverse = selected;
   // Widths: time(10) repo(12) source(20) event(16) ref(10) = 68 fixed
   const detailsWidth = Math.max(0, columns - 10 - 12 - 20 - 16 - 10 - 2);
 
   return (
     <Box flexDirection="row">
-      <Text color={color} backgroundColor={bg}>
+      <Text color={color} inverse={inverse}>
         {formatTime(event).padEnd(10)}
       </Text>
-      <Text color={color} backgroundColor={bg}>
+      <Text color={color} inverse={inverse}>
         {formatRepo(event).slice(0, 11).padEnd(12)}
       </Text>
-      <Text color={color} backgroundColor={bg}>
+      <Text color={color} inverse={inverse}>
         {formatSource(event).slice(0, 19).padEnd(20)}
       </Text>
-      <Text color={color} backgroundColor={bg}>
+      <Text color={color} inverse={inverse}>
         {formatEvent(event).slice(0, 15).padEnd(16)}
       </Text>
-      <Text color={color} backgroundColor={bg}>
+      <Text color={color} inverse={inverse}>
         {formatRef(event).slice(0, 9).padEnd(10)}
       </Text>
-      <Text color={color} backgroundColor={bg}>
+      <Text color={color} inverse={inverse}>
         {formatDetails(event).slice(0, detailsWidth)}
       </Text>
     </Box>


### PR DESCRIPTION
## Summary

- The catalyst-hud cursor / live-tail highlight bar rendered `backgroundColor="blue"` behind row text whose foreground was one of the semantic palette colors (`blue`, `cyan`, `magenta`, `gray`). On rows like `github.pr.opened` or `comms.message.posted` this composed same-family fg/bg pairs that dropped well below WCAG AA contrast.
- Because live-tail keeps the highlight on the most recent event, the most operationally important row was always the illegible one.
- Switch the six `<Text>` cells in `EventRow.tsx` to `inverse={selected}` (Ink's SGR-7 inverse video) instead of a solid `backgroundColor`. The terminal swaps fg/bg at render time, guaranteeing contrast across themes without picking explicit colors and without losing the row's semantic color cue.

This implements Option 1 (reverse video) from the [CTL-342](https://linear.app/coalesce-labs/issue/CTL-342) ticket.

## Test plan

- [ ] `bun run typecheck` from `plugins/dev/scripts/orch-monitor` passes
- [ ] `bun run lint` passes (one pre-existing unrelated warning remains)
- [ ] `bun run knip:ci` passes
- [ ] `bun test` — pre-existing 6 flaky failures in `__tests__/catalyst-monitor.test.ts` (server start / PID file ENOENT) are not regressions of this change
- [ ] Manual: run `catalyst-hud` against live events in macOS Terminal.app default dark, iTerm2 default, and Warp default; confirm the highlighted row is readable on `github.pr.*`, `comms.message.posted`, `filter.wake`, and `orchestrator.worker.*` events
- [ ] Non-highlighted rows still show distinct per-event semantic colors

Closes CTL-342.