### PR TITLE
fix(dev): API key health — startup warning, probe, status surface, gateway (CTL-343)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -42,6 +42,13 @@ import {
   // ticket_state (CTL-303 — ticket routing)
   upsertTicketState,
 } from "./broker-state.mjs";
+import {
+  resolveApiKey,
+  formatMissingKeyWarning,
+  formatLoadedKeyInfo,
+  probeGroq,
+  deriveGroqEndpoint,
+} from "../lib/api-key-health.mjs";
 
 // --- Logger ---
 const log = pino({
@@ -51,19 +58,42 @@ const log = pino({
 
 // --- Config ---
 const CATALYST_DIR = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+const GLOBAL_CONFIG_PATH = resolve(homedir(), ".config/catalyst/config.json");
 
-export function readGroqApiKeyFromConfig(configPath) {
-  const path = configPath ?? resolve(homedir(), ".config/catalyst/config.json");
+// CTL-343: key resolution moved to lib/api-key-health.mjs. Read groq gateway
+// alongside the key so the chat-completions endpoint can route through a
+// configured proxy (e.g. Adva AI Gateway, Litellm, Helicone).
+export function readGroqConfig(configPath) {
+  const path = configPath ?? GLOBAL_CONFIG_PATH;
   try {
     const cfg = JSON.parse(readFileSync(path, "utf8"));
-    return cfg?.groq?.apiKey ?? "";
+    return cfg?.groq ?? null;
   } catch {
-    return "";
+    return null;
   }
 }
 
-const GROQ_API_KEY = process.env.GROQ_API_KEY || readGroqApiKeyFromConfig();
-const GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions";
+// Retained as a named export for any external callers; new code should use
+// resolveApiKey() from lib/api-key-health.mjs directly.
+export function readGroqApiKeyFromConfig(configPath) {
+  return readGroqConfig(configPath)?.apiKey ?? "";
+}
+
+const groqKeyResolution = resolveApiKey({
+  envName: "GROQ_API_KEY",
+  configKeyPath: "groq.apiKey",
+  configPath: GLOBAL_CONFIG_PATH,
+});
+const groqConfig = readGroqConfig();
+const groqEndpoint = deriveGroqEndpoint({ gateway: groqConfig?.gateway });
+
+const GROQ_API_KEY = groqKeyResolution.value;
+const GROQ_KEY_SOURCE = groqKeyResolution.source;
+const GROQ_KEY_PREFIX = groqKeyResolution.prefix;
+const GROQ_ENDPOINT = groqEndpoint.url;
+const GROQ_EXTRA_HEADERS = groqEndpoint.extraHeaders;
+const GROQ_GATEWAY_ENABLED = groqEndpoint.gatewayEnabled;
+const GROQ_GATEWAY_BASE_URL = GROQ_GATEWAY_ENABLED ? groqConfig?.gateway?.baseUrl : null;
 const GROQ_MODEL = process.env.FILTER_GROQ_MODEL ?? "llama-3.1-8b-instant";
 const DEBOUNCE_MS = parseInt(process.env.FILTER_DEBOUNCE_MS ?? "100", 10);
 const HARD_CAP_MS = parseInt(process.env.FILTER_HARD_CAP_MS ?? "500", 10);
@@ -735,6 +765,7 @@ async function classifyBatch(events) {
     const res = await fetch(GROQ_ENDPOINT, {
       method: "POST",
       headers: {
+        ...GROQ_EXTRA_HEADERS,
         "Content-Type": "application/json",
         Authorization: `Bearer ${GROQ_API_KEY}`,
       },
@@ -1077,15 +1108,108 @@ function removePidFile() {
   try { unlinkSync(PID_FILE_PATH); } catch { /* already gone */ }
 }
 
+// --- State file (CTL-343) ---
+// ~/catalyst/broker.state.json is the single source of truth for at-a-glance
+// broker key health. Consumed by `catalyst-broker status --json`,
+// `catalyst-monitor status --json`, and the HUD header chip.
+const BROKER_STATE_FILE = resolve(CATALYST_DIR, "broker.state.json");
+
+export function buildBrokerState({ probe } = {}) {
+  return {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    keyHealth: {
+      groq: {
+        present: GROQ_KEY_SOURCE !== null,
+        source: GROQ_KEY_SOURCE,
+        prefix: GROQ_KEY_PREFIX,
+        probeStatus: probe?.status ?? (GROQ_KEY_SOURCE === null ? "missing" : "pending"),
+        probeError: probe?.error ?? null,
+        probeAt: probe ? new Date().toISOString() : null,
+        modelCount: probe?.modelCount ?? null,
+      },
+    },
+    gateway: {
+      enabled: GROQ_GATEWAY_ENABLED,
+      baseUrl: GROQ_GATEWAY_BASE_URL,
+    },
+  };
+}
+
+export function writeBrokerStateFile(state, { path = BROKER_STATE_FILE } = {}) {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(state, null, 2));
+    renameSync(tmp, path);
+  } catch (err) {
+    log.warn({ err: err.message, path }, "failed to write broker state file");
+  }
+}
+
+// Exported so the state-file path is discoverable by tests.
+export function getBrokerStateFilePath() {
+  return BROKER_STATE_FILE;
+}
+
+// Logs key health at startup. Returns the resolved state-file payload
+// (pre-probe) so callers can persist it.
+export function logKeyHealthAtStartup() {
+  if (GROQ_KEY_SOURCE === null) {
+    const warning = formatMissingKeyWarning({
+      name: "GROQ_API_KEY",
+      envName: "GROQ_API_KEY",
+      configPath: GLOBAL_CONFIG_PATH,
+      configKeyPath: "groq.apiKey",
+      getUrl: "https://console.groq.com/keys",
+    });
+    // pino flattens multi-line strings — emit each line so operators see it cleanly.
+    for (const line of warning.split("\n")) log.warn(line);
+  } else {
+    log.info(
+      { source: GROQ_KEY_SOURCE, prefix: GROQ_KEY_PREFIX, model: GROQ_MODEL, endpoint: GROQ_ENDPOINT },
+      formatLoadedKeyInfo({ name: "GROQ_API_KEY", source: GROQ_KEY_SOURCE, prefix: GROQ_KEY_PREFIX }),
+    );
+    if (GROQ_GATEWAY_ENABLED) {
+      log.info({ baseUrl: GROQ_GATEWAY_BASE_URL }, "GROQ gateway enabled — routing chat completions through configured baseUrl");
+    }
+  }
+}
+
+export async function runStartupProbe() {
+  if (GROQ_KEY_SOURCE === null) {
+    return { status: "missing" };
+  }
+  const probe = await probeGroq({
+    apiKey: GROQ_API_KEY,
+    endpoint: GROQ_ENDPOINT,
+    extraHeaders: GROQ_EXTRA_HEADERS,
+  });
+  switch (probe.status) {
+    case "ok":
+      log.info({ modelCount: probe.modelCount }, "Groq probe OK");
+      break;
+    case "unauthorized":
+      log.error({ err: probe.error }, "Groq probe FAILED — semantic routing disabled");
+      break;
+    case "error":
+      log.warn({ err: probe.error }, "Groq probe could not complete — semantic routing may be impaired");
+      break;
+    case "missing":
+      // already warned at startup
+      break;
+  }
+  return probe;
+}
+
 // --- Main ---
 function main() {
-  if (!GROQ_API_KEY) {
-    log.warn(
-      "GROQ_API_KEY not set and groq.apiKey absent from ~/.config/catalyst/config.json — semantic filtering disabled",
-    );
-  }
+  logKeyHealthAtStartup();
 
   writePidFile();
+  // Write initial state (probeStatus: pending or missing). Updated after probe completes.
+  writeBrokerStateFile(buildBrokerState());
+
   migrateLegacyInterestsFile();
 
   lastLogPath = getEventLogPath();
@@ -1114,6 +1238,7 @@ function main() {
       watchdog_interval_ms: WATCHDOG_INTERVAL_MS,
       heartbeat_stale_ms: HEARTBEAT_STALE_MS,
       broker: true,
+      key_health: { source: GROQ_KEY_SOURCE, prefix: GROQ_KEY_PREFIX, gateway: GROQ_GATEWAY_ENABLED },
     },
   });
 
@@ -1128,6 +1253,13 @@ function main() {
     "catalyst-broker daemon started",
   );
 
+  // Fire the Groq /v1/models probe asynchronously so it doesn't gate startup.
+  runStartupProbe().then((probe) => {
+    writeBrokerStateFile(buildBrokerState({ probe }));
+  }).catch((err) => {
+    log.warn({ err: err.message }, "probe error suppressed");
+  });
+
   const shutdown = () => {
     eventsWatcher?.close();
     clearInterval(watchdogId);
@@ -1135,6 +1267,7 @@ function main() {
     clearTimeout(hardCapTimer);
     closeBrokerStateDb();
     removePidFile();
+    try { unlinkSync(BROKER_STATE_FILE); } catch { /* already gone */ }
     process.exit(0);
   };
   process.on("SIGINT", shutdown);

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -7,6 +7,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { existsSync, readFileSync, rmSync as rmFile } from "node:fs";
 import {
   handleRegister,
   handleDeregister,
@@ -22,6 +23,8 @@ import {
   processEvent,
   tryDeterministicRoute,
   tryTicketLifecycleRoute,
+  buildBrokerState,
+  writeBrokerStateFile,
 } from "./index.mjs";
 import {
   openBrokerStateDb,
@@ -769,5 +772,72 @@ describe("shouldSkipEvent (broker)", () => {
   test("does not skip linear.* events", () => {
     expect(shouldSkipEvent({ event: "linear.issue.state_changed" })).toBe(false);
     expect(shouldSkipEvent({ event: "linear.comment.created" })).toBe(false);
+  });
+});
+
+// ─── Broker state file (CTL-343 — API key health) ───────────────────────────
+
+describe("buildBrokerState (CTL-343)", () => {
+  test("has keyHealth.groq with present/source/prefix/probeStatus/gateway shape", () => {
+    const state = buildBrokerState();
+    expect(state.pid).toBe(process.pid);
+    expect(typeof state.startedAt).toBe("string");
+    expect(state.keyHealth).toBeDefined();
+    expect(state.keyHealth.groq).toBeDefined();
+    expect("present" in state.keyHealth.groq).toBe(true);
+    expect("source" in state.keyHealth.groq).toBe(true);
+    expect("prefix" in state.keyHealth.groq).toBe(true);
+    expect("probeStatus" in state.keyHealth.groq).toBe(true);
+    expect("probeError" in state.keyHealth.groq).toBe(true);
+    expect("probeAt" in state.keyHealth.groq).toBe(true);
+    expect(state.gateway).toBeDefined();
+    expect(typeof state.gateway.enabled).toBe("boolean");
+  });
+
+  test("initial state has probeStatus 'pending' or 'missing' (no probe yet)", () => {
+    const state = buildBrokerState();
+    expect(["pending", "missing"]).toContain(state.keyHealth.groq.probeStatus);
+    expect(state.keyHealth.groq.probeAt).toBeNull();
+  });
+
+  test("with probe result, surfaces probe status + probeAt timestamp", () => {
+    const state = buildBrokerState({ probe: { status: "ok", modelCount: 41 } });
+    expect(state.keyHealth.groq.probeStatus).toBe("ok");
+    expect(state.keyHealth.groq.modelCount).toBe(41);
+    expect(state.keyHealth.groq.probeAt).not.toBeNull();
+  });
+
+  test("with probe failure, surfaces error message", () => {
+    const state = buildBrokerState({
+      probe: { status: "unauthorized", error: "HTTP 401: invalid_api_key" },
+    });
+    expect(state.keyHealth.groq.probeStatus).toBe("unauthorized");
+    expect(state.keyHealth.groq.probeError).toContain("401");
+  });
+});
+
+describe("writeBrokerStateFile (CTL-343)", () => {
+  test("writes valid JSON to a custom path", () => {
+    const target = join(tmpDir, "broker.state.json");
+    const state = buildBrokerState();
+    writeBrokerStateFile(state, { path: target });
+    expect(existsSync(target)).toBe(true);
+    const parsed = JSON.parse(readFileSync(target, "utf8"));
+    expect(parsed.pid).toBe(process.pid);
+    expect(parsed.keyHealth.groq).toBeDefined();
+    rmFile(target, { force: true });
+  });
+
+  test("overwrites existing file (atomic rename)", () => {
+    const target = join(tmpDir, "broker.state.json");
+    writeBrokerStateFile(buildBrokerState(), { path: target });
+    writeBrokerStateFile(
+      buildBrokerState({ probe: { status: "ok", modelCount: 7 } }),
+      { path: target },
+    );
+    const parsed = JSON.parse(readFileSync(target, "utf8"));
+    expect(parsed.keyHealth.groq.probeStatus).toBe("ok");
+    expect(parsed.keyHealth.groq.modelCount).toBe(7);
+    rmFile(target, { force: true });
   });
 });

--- a/plugins/dev/scripts/catalyst-broker
+++ b/plugins/dev/scripts/catalyst-broker
@@ -18,6 +18,7 @@ set -uo pipefail
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 PID_FILE="${BROKER_PID_FILE:-$CATALYST_DIR/broker.pid}"
 LOG_FILE="${BROKER_LOG_FILE:-$CATALYST_DIR/broker.log}"
+STATE_FILE="${BROKER_STATE_FILE:-$CATALYST_DIR/broker.state.json}"
 _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
@@ -101,9 +102,29 @@ cmd_restart() {
 }
 
 cmd_status() {
+  local json=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) json=1; shift ;;
+      *) echo "error: unknown flag for status: $1" >&2; return 1 ;;
+    esac
+  done
+
   local pid
   if pid=$(read_pid); then
-    echo "running (pid $pid)"
+    if [[ $json -eq 1 ]]; then
+      if [[ -f "$STATE_FILE" ]] && jq -e . "$STATE_FILE" >/dev/null 2>&1; then
+        jq --argjson pid "$pid" '. + {running: true, pid: $pid}' "$STATE_FILE"
+      else
+        jq -n --argjson pid "$pid" '{running: true, pid: $pid, keyHealth: null, gateway: null}'
+      fi
+    else
+      echo "running (pid $pid)"
+    fi
+    return 0
+  fi
+  if [[ $json -eq 1 ]]; then
+    jq -n '{running: false, pid: null, keyHealth: null, gateway: null}'
   else
     echo "stopped"
   fi
@@ -127,7 +148,7 @@ case "${1:-}" in
   start)   cmd_start ;;
   stop)    cmd_stop ;;
   restart) cmd_restart ;;
-  status)  cmd_status ;;
+  status)  shift; cmd_status "$@" ;;
   logs)    cmd_logs ;;
   run)     shift; cmd_run "$@" ;;
   *)

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -274,6 +274,15 @@ cmd_status() {
   rv=$(json_quote_or_null "$RUNNING_VERSION")
   lv=$(json_quote_or_null "$LATEST_AVAILABLE_VERSION")
 
+  # CTL-343: surface broker key-health alongside monitor status so a single
+  # `catalyst-monitor status --json` call answers "is everything healthy?".
+  local brokerKeyHealth='null'
+  local brokerStateFile="${BROKER_STATE_FILE:-${CATALYST_DIR:-$HOME/catalyst}/broker.state.json}"
+  if [[ -f "$brokerStateFile" ]]; then
+    brokerKeyHealth=$(jq -c '.keyHealth // null' "$brokerStateFile" 2>/dev/null || echo 'null')
+    [[ -z "$brokerKeyHealth" ]] && brokerKeyHealth='null'
+  fi
+
   local pid
   if pid=$(read_pid); then
     if [[ $json -eq 1 ]]; then
@@ -291,7 +300,8 @@ cmd_status() {
         --argjson lv "$lv" \
         --argjson stale "$([ "$IS_STALE" = "true" ] && echo true || echo false)" \
         --argjson tunnel "$tunnel" \
-        '{running:true,pid:$pid,port:$port,url:("http://localhost:"+($port|tostring)),runningVersion:$rv,latestAvailableVersion:$lv,isStale:$stale,webhookTunnel:$tunnel}'
+        --argjson brokerKeyHealth "$brokerKeyHealth" \
+        '{running:true,pid:$pid,port:$port,url:("http://localhost:"+($port|tostring)),runningVersion:$rv,latestAvailableVersion:$lv,isStale:$stale,webhookTunnel:$tunnel,brokerKeyHealth:$brokerKeyHealth}'
     else
       echo "Monitor running (pid $pid) at http://localhost:$PORT"
     fi
@@ -303,7 +313,8 @@ cmd_status() {
         --argjson rv "$rv" \
         --argjson lv "$lv" \
         --argjson stale "$([ "$IS_STALE" = "true" ] && echo true || echo false)" \
-        '{running:false,pid:null,port:$port,url:("http://localhost:"+($port|tostring)),runningVersion:$rv,latestAvailableVersion:$lv,isStale:$stale}'
+        --argjson brokerKeyHealth "$brokerKeyHealth" \
+        '{running:false,pid:null,port:$port,url:("http://localhost:"+($port|tostring)),runningVersion:$rv,latestAvailableVersion:$lv,isStale:$stale,brokerKeyHealth:$brokerKeyHealth}'
     else
       echo "Monitor stopped"
     fi

--- a/plugins/dev/scripts/lib/api-key-health.mjs
+++ b/plugins/dev/scripts/lib/api-key-health.mjs
@@ -1,0 +1,198 @@
+// api-key-health.mjs — shared helper for Catalyst daemon API-key health (CTL-343).
+//
+// Pattern: resolve key with precedence (env → project config → global config → none),
+// format actionable startup logs, probe the upstream for a 401 within seconds of startup,
+// and parameterize endpoint/headers for optional gateway routing.
+//
+// Used by catalyst-broker today; intended for re-use by other daemons (Linear, GitHub,
+// Anthropic) as they adopt the same pattern.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+const PREFIX_LEN = 12;
+const DEFAULT_GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions";
+const DEFAULT_PROBE_TIMEOUT_MS = 5000;
+
+// ─── Config loading ──────────────────────────────────────────────────────────
+
+function readJsonOrNull(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function pathGet(obj, dotted) {
+  if (obj == null) return undefined;
+  const parts = dotted.split(".");
+  let cur = obj;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+function prefixOf(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  return value.slice(0, PREFIX_LEN);
+}
+
+// ─── resolveApiKey ───────────────────────────────────────────────────────────
+
+/**
+ * Resolve an API key with env → project-config → global-config precedence.
+ *
+ * @param {object} opts
+ * @param {string} opts.envName Env var name (e.g. "GROQ_API_KEY")
+ * @param {string} opts.configKeyPath Dotted path inside the config JSON (e.g. "groq.apiKey")
+ * @param {string} [opts.configPath] Global config file path. Defaults to ~/.config/catalyst/config.json
+ * @param {string} [opts.projectConfigPath] Optional per-project config file path
+ * @returns {{value: string, source: "env"|"project-config"|"config"|null, prefix: string|null}}
+ */
+export function resolveApiKey({ envName, configKeyPath, configPath, projectConfigPath }) {
+  // 1. env
+  const envValue = envName ? process.env[envName] : undefined;
+  if (envValue && envValue.length > 0) {
+    return { value: envValue, source: "env", prefix: prefixOf(envValue) };
+  }
+
+  // 2. project config
+  if (projectConfigPath) {
+    const projCfg = readJsonOrNull(projectConfigPath);
+    const projValue = pathGet(projCfg, configKeyPath);
+    if (typeof projValue === "string" && projValue.length > 0) {
+      return { value: projValue, source: "project-config", prefix: prefixOf(projValue) };
+    }
+  }
+
+  // 3. global config
+  const globalPath = configPath ?? resolve(homedir(), ".config/catalyst/config.json");
+  const globalCfg = readJsonOrNull(globalPath);
+  const globalValue = pathGet(globalCfg, configKeyPath);
+  if (typeof globalValue === "string" && globalValue.length > 0) {
+    return { value: globalValue, source: "config", prefix: prefixOf(globalValue) };
+  }
+
+  // 4. none
+  return { value: "", source: null, prefix: null };
+}
+
+// ─── Log formatters ──────────────────────────────────────────────────────────
+
+/**
+ * Multi-line warning string for a missing required key.
+ * Caller passes the result to log.warn / process.stderr.
+ */
+export function formatMissingKeyWarning({ name, envName, configPath, configKeyPath, getUrl }) {
+  return [
+    `${name} missing — feature disabled.`,
+    `  Set via:   ${configPath} → ${configKeyPath}`,
+    `  Or env:    export ${envName}=...`,
+    `  Get one:   ${getUrl}`,
+  ].join("\n");
+}
+
+/**
+ * Single-line info string for a successfully-loaded key.
+ * Includes prefix + source for at-a-glance "is this the right key?" sanity check.
+ */
+export function formatLoadedKeyInfo({ name, source, prefix }) {
+  return `${name} loaded — prefix=${prefix}... (source: ${source})`;
+}
+
+// ─── Endpoint derivation (gateway support) ───────────────────────────────────
+
+/**
+ * Build the effective Groq chat-completions endpoint plus any extra headers.
+ *
+ * @param {object} opts
+ * @param {{enabled: boolean, baseUrl?: string, headers?: object}|null|undefined} opts.gateway
+ * @returns {{url: string, extraHeaders: Record<string,string>, gatewayEnabled: boolean}}
+ */
+export function deriveGroqEndpoint({ gateway }) {
+  if (!gateway || gateway.enabled !== true || typeof gateway.baseUrl !== "string") {
+    return { url: DEFAULT_GROQ_ENDPOINT, extraHeaders: {}, gatewayEnabled: false };
+  }
+  const baseUrl = gateway.baseUrl.replace(/\/+$/, "");
+  return {
+    url: `${baseUrl}/chat/completions`,
+    extraHeaders: gateway.headers && typeof gateway.headers === "object" ? { ...gateway.headers } : {},
+    gatewayEnabled: true,
+  };
+}
+
+// ─── probeGroq ───────────────────────────────────────────────────────────────
+
+/**
+ * Probe Groq with a single cheap `GET /v1/models` call to surface auth errors at startup.
+ *
+ * @param {object} opts
+ * @param {string} opts.apiKey
+ * @param {string} opts.endpoint Chat-completions endpoint URL (used to derive /v1/models)
+ * @param {object} [opts.extraHeaders] Gateway headers to merge
+ * @param {Function} [opts.fetch] Injectable fetch (for tests)
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<{status: "ok"|"missing"|"unauthorized"|"error", modelCount?: number, error?: string}>}
+ */
+export async function probeGroq({
+  apiKey,
+  endpoint,
+  extraHeaders = {},
+  fetch: fetchImpl = globalThis.fetch,
+  timeoutMs = DEFAULT_PROBE_TIMEOUT_MS,
+}) {
+  if (!apiKey || typeof apiKey !== "string" || apiKey.length === 0) {
+    return { status: "missing" };
+  }
+
+  const modelsUrl = endpoint.replace(/\/chat\/completions\/?$/, "/models");
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetchImpl(modelsUrl, {
+      method: "GET",
+      headers: {
+        ...extraHeaders,
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    if (res.ok) {
+      let modelCount = 0;
+      try {
+        const body = await res.json();
+        modelCount = Array.isArray(body?.data) ? body.data.length : 0;
+      } catch {
+        // tolerate non-JSON success body
+      }
+      return { status: "ok", modelCount };
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      let bodyText = "";
+      try { bodyText = await res.text(); } catch { /* ignore */ }
+      return {
+        status: "unauthorized",
+        error: `HTTP ${res.status}${bodyText ? `: ${bodyText.slice(0, 200)}` : ""}`,
+      };
+    }
+
+    let bodyText = "";
+    try { bodyText = await res.text(); } catch { /* ignore */ }
+    return {
+      status: "error",
+      error: `HTTP ${res.status}${bodyText ? `: ${bodyText.slice(0, 200)}` : ""}`,
+    };
+  } catch (err) {
+    clearTimeout(timer);
+    return { status: "error", error: err?.message ?? String(err) };
+  }
+}

--- a/plugins/dev/scripts/lib/api-key-health.test.mjs
+++ b/plugins/dev/scripts/lib/api-key-health.test.mjs
@@ -1,0 +1,363 @@
+// api-key-health.test.mjs — tests for the shared API-key-health helper (CTL-343).
+// Run from plugins/dev/scripts/broker: bun test ../lib/api-key-health.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  resolveApiKey,
+  formatMissingKeyWarning,
+  formatLoadedKeyInfo,
+  probeGroq,
+  deriveGroqEndpoint,
+} from "./api-key-health.mjs";
+
+// ─── resolveApiKey ───────────────────────────────────────────────────────────
+
+describe("resolveApiKey", () => {
+  let tmp;
+  let savedEnv;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "akh-"));
+    savedEnv = process.env.GROQ_API_KEY;
+    delete process.env.GROQ_API_KEY;
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.GROQ_API_KEY;
+    else process.env.GROQ_API_KEY = savedEnv;
+  });
+
+  test("returns env source when env var is set (highest precedence)", () => {
+    process.env.GROQ_API_KEY = "gsk_envTest123456";
+    const cfgPath = join(tmp, "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ groq: { apiKey: "gsk_cfgTestABCDEFG" } }));
+    const result = resolveApiKey({
+      envName: "GROQ_API_KEY",
+      configKeyPath: "groq.apiKey",
+      configPath: cfgPath,
+    });
+    expect(result.source).toBe("env");
+    expect(result.value).toBe("gsk_envTest123456");
+    expect(result.prefix).toBe("gsk_envTest1");
+  });
+
+  test("falls back to project config when env not set and projectKey given", () => {
+    const projectCfgPath = join(tmp, "config-myproj.json");
+    const globalCfgPath = join(tmp, "config.json");
+    writeFileSync(projectCfgPath, JSON.stringify({ groq: { apiKey: "gsk_projABCDEFGHIJ" } }));
+    writeFileSync(globalCfgPath, JSON.stringify({ groq: { apiKey: "gsk_globalXXXXXXXXX" } }));
+    const result = resolveApiKey({
+      envName: "GROQ_API_KEY",
+      configKeyPath: "groq.apiKey",
+      configPath: globalCfgPath,
+      projectConfigPath: projectCfgPath,
+    });
+    expect(result.source).toBe("project-config");
+    expect(result.value).toBe("gsk_projABCDEFGHIJ");
+    expect(result.prefix).toBe("gsk_projABCD");
+  });
+
+  test("falls back to global config when env + project config absent", () => {
+    const globalCfgPath = join(tmp, "config.json");
+    writeFileSync(globalCfgPath, JSON.stringify({ groq: { apiKey: "gsk_globalXXXXXXXXX" } }));
+    const result = resolveApiKey({
+      envName: "GROQ_API_KEY",
+      configKeyPath: "groq.apiKey",
+      configPath: globalCfgPath,
+    });
+    expect(result.source).toBe("config");
+    expect(result.value).toBe("gsk_globalXXXXXXXXX");
+    expect(result.prefix).toBe("gsk_globalXX");
+  });
+
+  test("returns null source when nothing is set", () => {
+    const result = resolveApiKey({
+      envName: "GROQ_API_KEY",
+      configKeyPath: "groq.apiKey",
+      configPath: join(tmp, "does-not-exist.json"),
+    });
+    expect(result.source).toBeNull();
+    expect(result.value).toBe("");
+    expect(result.prefix).toBeNull();
+  });
+
+  test("handles missing project config gracefully (falls through)", () => {
+    const globalCfgPath = join(tmp, "config.json");
+    writeFileSync(globalCfgPath, JSON.stringify({ groq: { apiKey: "gsk_globalXXXXXXXXX" } }));
+    const result = resolveApiKey({
+      envName: "GROQ_API_KEY",
+      configKeyPath: "groq.apiKey",
+      configPath: globalCfgPath,
+      projectConfigPath: join(tmp, "config-missing.json"),
+    });
+    expect(result.source).toBe("config");
+    expect(result.value).toBe("gsk_globalXXXXXXXXX");
+  });
+
+  test("handles malformed config JSON gracefully", () => {
+    const cfgPath = join(tmp, "config.json");
+    writeFileSync(cfgPath, "{ not valid json");
+    const result = resolveApiKey({
+      envName: "GROQ_API_KEY",
+      configKeyPath: "groq.apiKey",
+      configPath: cfgPath,
+    });
+    expect(result.source).toBeNull();
+    expect(result.value).toBe("");
+  });
+
+  test("empty-string env value is treated as not-set (falls through to config)", () => {
+    process.env.GROQ_API_KEY = "";
+    const cfgPath = join(tmp, "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ groq: { apiKey: "gsk_fromCfgXXXXXX" } }));
+    const result = resolveApiKey({
+      envName: "GROQ_API_KEY",
+      configKeyPath: "groq.apiKey",
+      configPath: cfgPath,
+    });
+    expect(result.source).toBe("config");
+    expect(result.value).toBe("gsk_fromCfgXXXXXX");
+  });
+
+  test("nested configKeyPath traversal (a.b.c) works correctly", () => {
+    const cfgPath = join(tmp, "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ linear: { auth: { apiToken: "lin_abcdefXYZ" } } }));
+    // Use a synthetic env var name unlikely to be set on the host
+    const result = resolveApiKey({
+      envName: "CTL343_TEST_NESTED_TOKEN",
+      configKeyPath: "linear.auth.apiToken",
+      configPath: cfgPath,
+    });
+    expect(result.source).toBe("config");
+    expect(result.value).toBe("lin_abcdefXYZ");
+  });
+});
+
+// ─── formatMissingKeyWarning ─────────────────────────────────────────────────
+
+describe("formatMissingKeyWarning", () => {
+  test("includes all four required pieces", () => {
+    const out = formatMissingKeyWarning({
+      name: "GROQ_API_KEY",
+      envName: "GROQ_API_KEY",
+      configPath: "~/.config/catalyst/config.json",
+      configKeyPath: "groq.apiKey",
+      getUrl: "https://console.groq.com/keys",
+    });
+    expect(out).toContain("GROQ_API_KEY");
+    expect(out).toContain("~/.config/catalyst/config.json");
+    expect(out).toContain("groq.apiKey");
+    expect(out).toContain("https://console.groq.com/keys");
+  });
+
+  test("includes 'how to set' hints (env export + config-edit guidance)", () => {
+    const out = formatMissingKeyWarning({
+      name: "GROQ_API_KEY",
+      envName: "GROQ_API_KEY",
+      configPath: "~/.config/catalyst/config.json",
+      configKeyPath: "groq.apiKey",
+      getUrl: "https://console.groq.com/keys",
+    });
+    expect(out).toMatch(/export GROQ_API_KEY/);
+  });
+});
+
+// ─── formatLoadedKeyInfo ─────────────────────────────────────────────────────
+
+describe("formatLoadedKeyInfo", () => {
+  test("includes prefix + source", () => {
+    const out = formatLoadedKeyInfo({
+      name: "GROQ_API_KEY",
+      source: "config",
+      prefix: "gsk_jWb52Ioy",
+    });
+    expect(out).toContain("GROQ_API_KEY");
+    expect(out).toContain("gsk_jWb52Ioy");
+    expect(out).toContain("config");
+  });
+
+  test("env source is labelled clearly", () => {
+    const out = formatLoadedKeyInfo({
+      name: "GROQ_API_KEY",
+      source: "env",
+      prefix: "gsk_envXXXXX",
+    });
+    expect(out).toContain("env");
+  });
+
+  test("project-config source surfaces clearly", () => {
+    const out = formatLoadedKeyInfo({
+      name: "GROQ_API_KEY",
+      source: "project-config",
+      prefix: "gsk_projZZZZZ",
+    });
+    expect(out).toContain("project-config");
+  });
+});
+
+// ─── deriveGroqEndpoint ──────────────────────────────────────────────────────
+
+describe("deriveGroqEndpoint", () => {
+  test("returns default Groq endpoint when gateway disabled", () => {
+    const endpoint = deriveGroqEndpoint({ gateway: null });
+    expect(endpoint.url).toBe("https://api.groq.com/openai/v1/chat/completions");
+    expect(endpoint.extraHeaders).toEqual({});
+  });
+
+  test("returns default when gateway.enabled is false", () => {
+    const endpoint = deriveGroqEndpoint({
+      gateway: { enabled: false, baseUrl: "https://gateway.test/groq" },
+    });
+    expect(endpoint.url).toBe("https://api.groq.com/openai/v1/chat/completions");
+  });
+
+  test("substitutes gateway baseUrl when enabled", () => {
+    const endpoint = deriveGroqEndpoint({
+      gateway: { enabled: true, baseUrl: "https://gateway.internal/groq" },
+    });
+    expect(endpoint.url).toBe("https://gateway.internal/groq/chat/completions");
+  });
+
+  test("strips trailing slash from baseUrl", () => {
+    const endpoint = deriveGroqEndpoint({
+      gateway: { enabled: true, baseUrl: "https://gateway.internal/groq/" },
+    });
+    expect(endpoint.url).toBe("https://gateway.internal/groq/chat/completions");
+  });
+
+  test("merges gateway headers", () => {
+    const endpoint = deriveGroqEndpoint({
+      gateway: { enabled: true, baseUrl: "https://gateway.internal/groq", headers: { "X-Project": "Adva" } },
+    });
+    expect(endpoint.extraHeaders).toEqual({ "X-Project": "Adva" });
+  });
+
+  test("no extraHeaders when gateway.headers absent", () => {
+    const endpoint = deriveGroqEndpoint({
+      gateway: { enabled: true, baseUrl: "https://gateway.internal/groq" },
+    });
+    expect(endpoint.extraHeaders).toEqual({});
+  });
+
+  test("indicates gateway is in use", () => {
+    const ep1 = deriveGroqEndpoint({ gateway: { enabled: true, baseUrl: "https://g/groq" } });
+    expect(ep1.gatewayEnabled).toBe(true);
+    const ep2 = deriveGroqEndpoint({ gateway: null });
+    expect(ep2.gatewayEnabled).toBe(false);
+  });
+});
+
+// ─── probeGroq ───────────────────────────────────────────────────────────────
+
+describe("probeGroq", () => {
+  test("returns missing when apiKey is empty", async () => {
+    const result = await probeGroq({ apiKey: "", endpoint: "x", fetch: async () => ({}) });
+    expect(result.status).toBe("missing");
+  });
+
+  test("returns missing when apiKey is null", async () => {
+    const result = await probeGroq({ apiKey: null, endpoint: "x", fetch: async () => ({}) });
+    expect(result.status).toBe("missing");
+  });
+
+  test("returns ok with modelCount on 200", async () => {
+    const fakeFetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: "m1" }, { id: "m2" }, { id: "m3" }] }),
+    });
+    const result = await probeGroq({
+      apiKey: "gsk_xx",
+      endpoint: "https://api.groq.com/openai/v1/chat/completions",
+      fetch: fakeFetch,
+    });
+    expect(result.status).toBe("ok");
+    expect(result.modelCount).toBe(3);
+  });
+
+  test("returns unauthorized on 401", async () => {
+    const fakeFetch = async () => ({
+      ok: false,
+      status: 401,
+      text: async () => '{"error":{"code":"invalid_api_key"}}',
+    });
+    const result = await probeGroq({
+      apiKey: "gsk_xx",
+      endpoint: "https://api.groq.com/openai/v1/chat/completions",
+      fetch: fakeFetch,
+    });
+    expect(result.status).toBe("unauthorized");
+    expect(result.error).toContain("401");
+  });
+
+  test("returns unauthorized on 403", async () => {
+    const fakeFetch = async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "Forbidden",
+    });
+    const result = await probeGroq({
+      apiKey: "gsk_xx",
+      endpoint: "https://api.groq.com/openai/v1/chat/completions",
+      fetch: fakeFetch,
+    });
+    expect(result.status).toBe("unauthorized");
+  });
+
+  test("returns error on 5xx", async () => {
+    const fakeFetch = async () => ({
+      ok: false,
+      status: 503,
+      text: async () => "Service Unavailable",
+    });
+    const result = await probeGroq({
+      apiKey: "gsk_xx",
+      endpoint: "https://api.groq.com/openai/v1/chat/completions",
+      fetch: fakeFetch,
+    });
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("503");
+  });
+
+  test("returns error on fetch throw", async () => {
+    const fakeFetch = async () => { throw new Error("network down"); };
+    const result = await probeGroq({
+      apiKey: "gsk_xx",
+      endpoint: "https://api.groq.com/openai/v1/chat/completions",
+      fetch: fakeFetch,
+    });
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("network down");
+  });
+
+  test("calls /v1/models endpoint (derived from chat endpoint)", async () => {
+    let calledUrl;
+    const fakeFetch = async (url) => {
+      calledUrl = url;
+      return { ok: true, status: 200, json: async () => ({ data: [] }) };
+    };
+    await probeGroq({
+      apiKey: "gsk_xx",
+      endpoint: "https://api.groq.com/openai/v1/chat/completions",
+      fetch: fakeFetch,
+    });
+    expect(calledUrl).toBe("https://api.groq.com/openai/v1/models");
+  });
+
+  test("sends Authorization Bearer header", async () => {
+    let calledHeaders;
+    const fakeFetch = async (_url, init) => {
+      calledHeaders = init?.headers ?? {};
+      return { ok: true, status: 200, json: async () => ({ data: [] }) };
+    };
+    await probeGroq({
+      apiKey: "gsk_test",
+      endpoint: "https://api.groq.com/openai/v1/chat/completions",
+      fetch: fakeFetch,
+    });
+    expect(calledHeaders.Authorization).toBe("Bearer gsk_test");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -1,14 +1,26 @@
 import { Box, Text } from "ink";
+import type { BrokerKeyHealth } from "../lib/broker-key-health.ts";
+import { chipColor, chipLabel } from "../lib/broker-key-health.ts";
 
 interface HeaderProps {
   columns?: number;
   nlQuery?: string;
+  brokerKeyHealth?: BrokerKeyHealth | null;
 }
 
-export function Header({ columns = 120, nlQuery }: HeaderProps) {
+export function Header({ columns = 120, nlQuery, brokerKeyHealth }: HeaderProps) {
   const sep = "─".repeat(Math.max(0, columns - 1));
+  const groq = brokerKeyHealth?.groq;
   return (
     <Box flexDirection="column">
+      {groq && (
+        <Box flexDirection="row">
+          <Text color={chipColor(groq.probeStatus)}>{`[Groq: ${chipLabel(groq.probeStatus)}]`}</Text>
+          {groq.present && groq.prefix && (
+            <Text dimColor>{`  ${groq.prefix}... (${groq.source ?? "unknown"})`}</Text>
+          )}
+        </Box>
+      )}
       <Box flexDirection="row">
         <Text bold color="cyan">{"TIME      "}</Text>
         <Text bold color="cyan">{"REPO        "}</Text>

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -2,6 +2,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { render, useApp, useInput, Box, Text } from "ink";
 import { Header } from "./components/Header.tsx";
+import { readBrokerKeyHealth, type BrokerKeyHealth } from "./lib/broker-key-health.ts";
 import { EventList } from "./components/EventList.tsx";
 import { FilterInput } from "./components/FilterInput.tsx";
 import { QueryInput } from "./components/QueryInput.tsx";
@@ -132,12 +133,22 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
 
   const { events, loading } = useEventLog({ repoFilter, predicate, sinceTs: activeSinceTs });
 
+  // CTL-343: broker key-health chip. Poll the broker state file every 5s so
+  // the chip surfaces fresh probe results without busy-reading on every render.
+  const [brokerKeyHealth, setBrokerKeyHealth] = useState<BrokerKeyHealth | null>(null);
+  useEffect(() => {
+    const refresh = () => setBrokerKeyHealth(readBrokerKeyHealth());
+    refresh();
+    const id = setInterval(refresh, 5000);
+    return () => clearInterval(id);
+  }, []);
+
   const [dslState, setDslState] = useState<DslState | null>(null);
   const dslPredicate: DslPredicate = dslState?.jsPredicate ?? null;
   const { filterText, setFilterText, pivot, setPivot, filtered } = useFilter(events, dslPredicate);
 
-  // Header = column row (1) + separator (1) + optional nlQuery row (0 or 1)
-  const headerRows = dslState?.nlQuery ? 3 : 2;
+  // Header = optional chip row (0/1) + column row (1) + separator (1) + optional nlQuery row (0/1)
+  const headerRows = (brokerKeyHealth?.groq ? 1 : 0) + (dslState?.nlQuery ? 3 : 2);
 
   const [showDslOverlay, setShowDslOverlay] = useState(false);
   const [dslScrollTop, setDslScrollTop] = useState(0);
@@ -361,7 +372,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   return (
     <Box flexDirection="column" height={layoutRows} width={cols}>
       <Box flexShrink={0}>
-        <Header columns={cols} nlQuery={dslState?.nlQuery} />
+        <Header columns={cols} nlQuery={dslState?.nlQuery} brokerKeyHealth={brokerKeyHealth} />
       </Box>
       <Box flexDirection="column" flexGrow={(inDetailMode || showHelp) ? 0 : 1} flexShrink={1}>
         <EventList

--- a/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.test.ts
@@ -1,0 +1,63 @@
+// broker-key-health.test.ts — tests for HUD broker key-health helpers (CTL-343).
+// Run from plugins/dev/scripts/orch-monitor: bun test cli/lib/broker-key-health.test.ts
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  chipLabel,
+  chipColor,
+  readBrokerKeyHealth,
+} from "./broker-key-health.ts";
+
+describe("chipLabel", () => {
+  test("ok → 'OK'", () => expect(chipLabel("ok")).toBe("OK"));
+  test("missing → 'MISS'", () => expect(chipLabel("missing")).toBe("MISS"));
+  test("unauthorized → '401'", () => expect(chipLabel("unauthorized")).toBe("401"));
+  test("error → 'ERR'", () => expect(chipLabel("error")).toBe("ERR"));
+  test("pending → '...'", () => expect(chipLabel("pending")).toBe("..."));
+});
+
+describe("chipColor", () => {
+  test("ok → green", () => expect(chipColor("ok")).toBe("green"));
+  test("missing → yellow", () => expect(chipColor("missing")).toBe("yellow"));
+  test("unauthorized → red", () => expect(chipColor("unauthorized")).toBe("red"));
+  test("error → red", () => expect(chipColor("error")).toBe("red"));
+  test("pending → cyan", () => expect(chipColor("pending")).toBe("cyan"));
+});
+
+describe("readBrokerKeyHealth", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hud-bkh-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("returns null when file does not exist", () => {
+    expect(readBrokerKeyHealth(join(tmp, "missing.json"))).toBeNull();
+  });
+
+  test("returns null when file is malformed JSON", () => {
+    const target = join(tmp, "bad.json");
+    writeFileSync(target, "{ not valid");
+    expect(readBrokerKeyHealth(target)).toBeNull();
+  });
+
+  test("returns the keyHealth object when present", () => {
+    const target = join(tmp, "good.json");
+    writeFileSync(target, JSON.stringify({
+      pid: 1234,
+      keyHealth: { groq: { present: true, source: "config", prefix: "gsk_abc", probeStatus: "ok" } },
+    }));
+    const result = readBrokerKeyHealth(target);
+    expect(result).not.toBeNull();
+    expect(result?.groq?.present).toBe(true);
+    expect(result?.groq?.probeStatus).toBe("ok");
+  });
+
+  test("returns null when state file has no keyHealth field", () => {
+    const target = join(tmp, "no-key.json");
+    writeFileSync(target, JSON.stringify({ pid: 1234 }));
+    expect(readBrokerKeyHealth(target)).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts
@@ -1,0 +1,62 @@
+// broker-key-health.ts — read + render broker key-health for the HUD (CTL-343).
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export type ProbeStatus = "ok" | "missing" | "unauthorized" | "error" | "pending";
+
+export interface BrokerKeyHealth {
+  groq?: {
+    present: boolean;
+    source: string | null;
+    prefix: string | null;
+    probeStatus: ProbeStatus;
+    probeError?: string | null;
+    probeAt?: string | null;
+    modelCount?: number | null;
+  };
+}
+
+/** Path of the broker's state file (override via $BROKER_STATE_FILE). */
+export function brokerStateFilePath(): string {
+  if (process.env.BROKER_STATE_FILE) return process.env.BROKER_STATE_FILE;
+  const dir = process.env.CATALYST_DIR ?? resolve(homedir(), "catalyst");
+  return resolve(dir, "broker.state.json");
+}
+
+export function readBrokerKeyHealth(path?: string): BrokerKeyHealth | null {
+  const target = path ?? brokerStateFilePath();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(target, "utf8"));
+    if (parsed && typeof parsed === "object" && "keyHealth" in parsed) {
+      const kh = (parsed as { keyHealth?: BrokerKeyHealth }).keyHealth;
+      return kh ?? null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Three-letter chip label for a probe status. */
+export function chipLabel(status: ProbeStatus): string {
+  switch (status) {
+    case "ok": return "OK";
+    case "missing": return "MISS";
+    case "unauthorized": return "401";
+    case "error": return "ERR";
+    case "pending": return "...";
+  }
+}
+
+/** Ink color name for a probe status. */
+export function chipColor(status: ProbeStatus): string {
+  switch (status) {
+    case "ok": return "green";
+    case "missing": return "yellow";
+    case "unauthorized": return "red";
+    case "error": return "red";
+    case "pending": return "cyan";
+  }
+}

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -278,14 +278,61 @@ Layer-2 secrets (`~/.config/catalyst/config-{projectKey}.json` or the cross-proj
 ```json
 {
   "groq": {
-    "apiKey": "gsk_..."
+    "apiKey": "gsk_...",
+    "gateway": {
+      "enabled": false,
+      "baseUrl": "https://gateway.internal/groq",
+      "headers": { "X-Project": "Adva AI Gateway" }
+    }
   }
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `groq.apiKey` | string | Groq API key used by `catalyst-broker` for semantic-prose classification of ambiguous events. Not required for deterministic routes (`pr_lifecycle`, `ticket_lifecycle`). Override with the `GROQ_API_KEY` env var. |
+| `groq.apiKey` | string | Groq API key used by `catalyst-broker` for semantic-prose classification of ambiguous events. Not required for deterministic routes (`pr_lifecycle`, `ticket_lifecycle`). |
+| `groq.gateway.enabled` | boolean | When `true`, route Groq chat-completions through a configured gateway (e.g. Litellm, Helicone, Adva AI Gateway) so all Catalyst traffic lands in one dashboard regardless of which key owns the underlying calls. Defaults to `false` (call `https://api.groq.com` directly). |
+| `groq.gateway.baseUrl` | string | Gateway base URL. The broker appends `/chat/completions` for completions and `/v1/models` for the startup probe. Trailing slashes are stripped. |
+| `groq.gateway.headers` | object | Extra headers merged into every Groq request — useful for project-tag headers required by your gateway. |
+
+#### Key resolution precedence (CTL-343)
+
+`catalyst-broker` resolves the Groq API key with three layers, in this order:
+
+1. `process.env.GROQ_API_KEY` — highest priority. Set per-project via direnv, or for one-off
+   overrides.
+2. `~/.config/catalyst/config-<projectKey>.json` → `groq.apiKey` — per-project secrets when a
+   `projectKey` is configured.
+3. `~/.config/catalyst/config.json` → `groq.apiKey` — cross-project default.
+
+If none of the three resolve, the broker logs a multi-line warning at startup naming the missing
+key, the config path, the env var, and the Groq signup URL. Semantic-prose routing is then
+disabled until a key is provided; deterministic routes continue to work.
+
+#### Startup probe + status surface (CTL-343)
+
+At daemon start the broker issues a single `GET /v1/models` against the resolved endpoint to
+surface a 401/403 within seconds rather than hours later. The result is recorded in the runtime
+state file (below) under `keyHealth.groq.probeStatus`:
+
+| Probe status | Meaning |
+|--------------|---------|
+| `ok` | Key is valid, response 200, `modelCount` populated |
+| `unauthorized` | 401 or 403 — key is present but invalid; semantic routing disabled |
+| `error` | Network error or 5xx |
+| `missing` | No key resolved (see precedence above) |
+| `pending` | State file written, probe still in flight (~first second of startup) |
+
+Consumers:
+
+```sh
+catalyst-broker status --json     # broker-only view
+catalyst-monitor status --json    # monitor + broker key-health combined
+```
+
+The HUD (`catalyst-hud`) renders a colour-coded chip in the header — green/yellow/red — and the
+key's first 12 characters with its resolution source (`env`, `project-config`, or `config`),
+so the operator can sanity-check "is this the right key?" at a glance.
 
 Runtime files (created on demand under `$CATALYST_DIR`, default `~/catalyst/`):
 
@@ -293,6 +340,7 @@ Runtime files (created on demand under `$CATALYST_DIR`, default `~/catalyst/`):
 |------|---------|
 | `~/catalyst/broker.pid` | Liveness PID file written by the daemon |
 | `~/catalyst/broker.log` | Pino structured log output (CTL-314) |
+| `~/catalyst/broker.state.json` | Key-health + gateway state surface (CTL-343), removed on clean shutdown |
 | `~/catalyst/broker-interests.json` | Persistent interest registry |
 
 `LOG_LEVEL` (default `info`) controls broker log verbosity through pino (CTL-314). The same env


### PR DESCRIPTION
## Summary

Make the broker's `GROQ_API_KEY` handling **loud and observable**:

- **Multi-line startup warning** when keys are missing, naming the key, config path, env var, and signup URL — replaces the single buried `log.warn` line at `broker/index.mjs:1082`.
- **One-time `GET /v1/models` probe** on startup so a 401/403 surfaces within seconds, not hours later when an operator notices missing wakes.
- **`~/catalyst/broker.state.json` surface** consumed by `catalyst-broker status --json`, `catalyst-monitor status --json`, and the HUD header chip — a single file, no new sockets or HTTP endpoints.
- **Gateway routing support** — set `catalyst.groq.gateway.enabled = true` + `baseUrl` + `headers` to pipe all Catalyst Groq calls through Litellm / Helicone / Adva AI Gateway for centralized dashboards. Defaults to direct `api.groq.com` calls.
- **Key resolution precedence** documented + enforced: `process.env.GROQ_API_KEY` → `~/.config/catalyst/config-<projectKey>.json` → `~/.config/catalyst/config.json` → none.
- **HUD chip** in `Header.tsx` shows colour-coded probe status (`OK` / `MISS` / `401` / `ERR` / `…`) plus the key prefix + source so operators can sanity-check "is this the right key?" at a glance.

Addresses the 2026-05-12 incident where 779 Groq calls landed in an unintended project for ~3 days because direnv hadn't loaded the per-project key.

## Design

**One state file, many consumers.** `~/catalyst/broker.state.json` is the single source of truth; `catalyst-broker status --json` merges it with PID liveness, `catalyst-monitor status --json` embeds the `keyHealth` sub-object, and the HUD polls the file every 5s.

New helper module `plugins/dev/scripts/lib/api-key-health.mjs` exports `resolveApiKey`, `formatMissingKeyWarning`, `formatLoadedKeyInfo`, `deriveGroqEndpoint`, and `probeGroq` — testable in isolation. Linear / GitHub / Anthropic keys can adopt the same pattern opportunistically (per ticket: "extend opportunistically", out of scope to refactor all at once).

## Files

| File | Change |
|---|---|
| `plugins/dev/scripts/lib/api-key-health.mjs` | **new** — resolve / format / probe / endpoint helpers |
| `plugins/dev/scripts/lib/api-key-health.test.mjs` | **new** — 29 tests for the helper |
| `plugins/dev/scripts/broker/index.mjs` | wire to helper, write state file, run probe async, gateway endpoint substitution |
| `plugins/dev/scripts/broker/index.test.mjs` | +9 tests for `buildBrokerState` / `writeBrokerStateFile` |
| `plugins/dev/scripts/catalyst-broker` | `--json` flag on `status` reads state file |
| `plugins/dev/scripts/catalyst-monitor.sh` | `cmd_status --json` embeds `brokerKeyHealth` |
| `plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts` | **new** — chip helpers + state-file reader |
| `plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.test.ts` | **new** — 14 tests for chip helpers |
| `plugins/dev/scripts/orch-monitor/cli/components/Header.tsx` | optional chip row above column labels |
| `plugins/dev/scripts/orch-monitor/cli/hud.tsx` | 5s poll of state file, passes chip to Header |
| `website/src/content/docs/reference/configuration.md` | precedence docs, gateway schema, probe / state-file reference |

## Success criteria mapping

| Ticket criterion | Verified |
|---|---|
| Missing-key startup warning is loud + actionable | `formatMissingKeyWarning` test + visual inspection |
| Probe surfaces 401 within ~1min of startup | `probeGroq` unit tests for 401/403 + async kickoff in `main()` |
| `broker status --json` and `monitor status --json` include key health | Manual smoke + state-file shape tests |
| HUD renders key-health chip | `chipColor` / `chipLabel` tests + visual verification |
| `gateway.enabled = true` routes calls through gateway URL | `deriveGroqEndpoint` tests assert URL + header merge |
| Docs explain env-vs-config-vs-project-config precedence | `configuration.md` diff |

## Test plan

- [x] `bun test plugins/dev/scripts/broker/` — 90 pass (was 81; +9 broker state tests)
- [x] `bun test plugins/dev/scripts/lib/api-key-health.test.mjs` — 29 pass
- [x] `bun test plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.test.ts` — 14 pass
- [x] `bun run typecheck` (orch-monitor) — clean
- [x] `bun run lint` (orch-monitor) — clean (1 pre-existing warning in unrelated file)
- [x] `bun run knip:ci` (orch-monitor) — clean
- [x] Smoke: `catalyst-broker status --json` returns merged state file + PID
- [x] Smoke: `catalyst-monitor status --json` includes `brokerKeyHealth`
- [ ] Manual visual check: start broker with missing key → see multi-line warning; HUD shows yellow `[Groq: MISS]` chip
- [ ] Manual visual check: start broker with valid key → HUD shows green `[Groq: OK]` chip with prefix + source

## Out of scope (per ticket)

- Auto-rotating keys
- UI for managing keys
- Refactoring all per-daemon env reads at once — Linear, GitHub, Anthropic adopt the helper opportunistically in follow-ups

Refs CTL-343 — closes the live-case incident from 2026-05-12.