### PR TITLE
fix(dev): broker prose-match suppression gate uses Groq intent (CTL-340)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -792,15 +792,48 @@ async function classifyBatch(events) {
     return;
   }
 
-  if (!Array.isArray(matches)) return;
+  const { wakes, oneShotsToDelete } = classifyMatches(events, matches, interests);
+  for (const wake of wakes) {
+    appendEvent(wake);
+    log.info({ notifyEvent: wake.event, reason: wake.detail.reason }, "wake");
+  }
+  for (const id of oneShotsToDelete) {
+    interests.delete(id);
+    log.info({ interestId: id }, "auto-deregistered (one-shot)");
+  }
+}
+
+/**
+ * Pure prose-match classifier (CTL-340). Given a batch of events, the raw
+ * Groq match array, and the interests map, returns the wakes that should be
+ * appended and the one-shot interest ids that should be deleted.
+ *
+ * Gating change vs. pre-CTL-340: the suppression guard now triggers when
+ * Groq's own `event_indices` is empty, not when post-filter id extraction
+ * produced an empty array. Indices pointing past the batch end are still
+ * dropped from `source_event_ids`, but `matched_indices_count` preserves
+ * what Groq intended for observability.
+ */
+export function classifyMatches(events, matches, interestsMap) {
+  const wakes = [];
+  const oneShotsToDelete = [];
+  if (!Array.isArray(matches)) return { wakes, oneShotsToDelete };
 
   for (const match of matches) {
-    const reg = interests.get(match.interest_id);
+    const reg = interestsMap.get(match.interest_id);
     if (!reg) continue;
+
+    const indices = match.event_indices ?? [];
+    if (indices.length === 0) {
+      // Groq returned a match without any event references — keep the
+      // original bug-catching suppression. Don't log; it fired 779×/hr in
+      // production pre-fix and drowned out real failures.
+      continue;
+    }
 
     // CTL-344: prefer real event.id; fall back to synthesized id for legacy
     // events. .filter(Boolean) strips any indices pointing past the batch end.
-    const sourceIds = (match.event_indices ?? [])
+    const sourceIds = indices
       .map((i) => {
         const e = events[i - 1];
         if (!e) return null;
@@ -808,30 +841,22 @@ async function classifyBatch(events) {
       })
       .filter(Boolean);
 
-    if (!sourceIds.length) {
-      log.info(
-        { notifyEvent: reg.notify_event },
-        "no source events — suppressing empty wake",
-      );
-      continue;
-    }
-
-    appendEvent({
+    wakes.push({
       event: reg.notify_event,
       orchestrator: reg.orchestrator ?? match.interest_id,
       worker: null,
       detail: {
         reason: match.reason,
         source_event_ids: sourceIds,
+        matched_indices_count: indices.length,
         interest_id: match.interest_id,
       },
     });
-    log.info({ notifyEvent: reg.notify_event, reason: match.reason }, "wake");
-    if (!reg.persistent) {
-      interests.delete(match.interest_id);
-      log.info({ interestId: match.interest_id }, "auto-deregistered (one-shot)");
-    }
+
+    if (!reg.persistent) oneShotsToDelete.push(match.interest_id);
   }
+
+  return { wakes, oneShotsToDelete };
 }
 
 // --- Debounce ---

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -23,6 +23,7 @@ import {
   processEvent,
   tryDeterministicRoute,
   tryTicketLifecycleRoute,
+  classifyMatches,
   buildBrokerState,
   writeBrokerStateFile,
 } from "./index.mjs";
@@ -927,5 +928,141 @@ describe("CTL-344 read-site event.id fallback", () => {
     expect(m.sourceEventId).toBeString();
     expect(m.sourceEventId.length).toBe(32);
     expect(/^[0-9a-f]{32}$/.test(m.sourceEventId)).toBe(true);
+  });
+});
+
+// ─── classifyMatches prose-routing suppression gate (CTL-340) ────────────────
+
+describe("CTL-340 classifyMatches", () => {
+  function registerProseInterest(id, { persistent = true, orchestrator = null } = {}) {
+    handleRegister({
+      event: "filter.register",
+      orchestrator,
+      detail: {
+        interest_id: id,
+        notify_event: `filter.wake.${id}`,
+        prompt: "match anything relevant",
+        context: {},
+        persistent,
+        session_id: `sess-${id}`,
+      },
+    });
+  }
+
+  test("emits wake for canonical events without .id (uses synthesizeEventId)", () => {
+    registerProseInterest("prose-1");
+    const events = [
+      {
+        ts: "2026-05-12T20:14:00Z",
+        traceId: "1d0338f8f2ec2acf633e0d95618dee70",
+        spanId: "d30d48f47d343921",
+        resource: { "service.name": "catalyst.session" },
+        attributes: { "event.name": "session.heartbeat" },
+        body: { payload: null },
+      },
+      {
+        ts: "2026-05-12T20:14:01Z",
+        traceId: "2d0338f8f2ec2acf633e0d95618dee70",
+        spanId: "e30d48f47d343921",
+        resource: { "service.name": "catalyst.broker" },
+        attributes: { "event.name": "broker.event" },
+        body: { payload: null },
+      },
+    ];
+    const matches = [
+      { interest_id: "prose-1", reason: "both events relevant", event_indices: [1, 2] },
+    ];
+    const { wakes, oneShotsToDelete } = classifyMatches(events, matches, getInterests());
+
+    expect(wakes).toHaveLength(1);
+    const wake = wakes[0];
+    expect(wake.event).toBe("filter.wake.prose-1");
+    expect(wake.detail.source_event_ids).toHaveLength(2);
+    for (const id of wake.detail.source_event_ids) {
+      expect(/^[0-9a-f]{32}$/.test(id)).toBe(true);
+    }
+    expect(wake.detail.matched_indices_count).toBe(2);
+    expect(wake.detail.interest_id).toBe("prose-1");
+    expect(oneShotsToDelete).toEqual([]);
+  });
+
+  test("suppresses wake when match.event_indices is empty (regression guard for original suppression intent)", () => {
+    registerProseInterest("prose-2");
+    const events = [
+      { id: "evt-1", ts: "2026-05-12T20:14:00Z", event: "foo" },
+    ];
+    const matches = [
+      { interest_id: "prose-2", reason: "groq invented match", event_indices: [] },
+    ];
+    const { wakes } = classifyMatches(events, matches, getInterests());
+    expect(wakes).toHaveLength(0);
+  });
+
+  test("legacy events with real .id still resolve to that .id (regression guard)", () => {
+    registerProseInterest("prose-3");
+    const events = [
+      { id: "real-id-1", ts: "2026-05-12T20:14:00Z", event: "foo" },
+      { id: "real-id-2", ts: "2026-05-12T20:14:01Z", event: "bar" },
+    ];
+    const matches = [
+      { interest_id: "prose-3", reason: "both", event_indices: [1, 2] },
+    ];
+    const { wakes } = classifyMatches(events, matches, getInterests());
+    expect(wakes).toHaveLength(1);
+    expect(wakes[0].detail.source_event_ids).toEqual(["real-id-1", "real-id-2"]);
+    expect(wakes[0].detail.matched_indices_count).toBe(2);
+  });
+
+  test("indices pointing past batch end emit wake with filtered ids + accurate matched_indices_count", () => {
+    registerProseInterest("prose-4");
+    const events = [
+      { id: "a", ts: "2026-05-12T20:14:00Z", event: "foo" },
+      { id: "b", ts: "2026-05-12T20:14:01Z", event: "bar" },
+    ];
+    const matches = [
+      { interest_id: "prose-4", reason: "groq returned invalid index", event_indices: [1, 2, 99] },
+    ];
+    const { wakes } = classifyMatches(events, matches, getInterests());
+    expect(wakes).toHaveLength(1);
+    expect(wakes[0].detail.source_event_ids).toEqual(["a", "b"]);
+    expect(wakes[0].detail.matched_indices_count).toBe(3);
+  });
+
+  test("skips matches with unknown interest_id", () => {
+    const events = [{ id: "x", ts: "2026-05-12T20:14:00Z", event: "foo" }];
+    const matches = [
+      { interest_id: "does-not-exist", reason: "...", event_indices: [1] },
+    ];
+    const { wakes } = classifyMatches(events, matches, getInterests());
+    expect(wakes).toHaveLength(0);
+  });
+
+  test("non-persistent (one-shot) interest is reported in oneShotsToDelete", () => {
+    registerProseInterest("prose-5", { persistent: false });
+    const events = [{ id: "x", ts: "2026-05-12T20:14:00Z", event: "foo" }];
+    const matches = [
+      { interest_id: "prose-5", reason: "match", event_indices: [1] },
+    ];
+    const { wakes, oneShotsToDelete } = classifyMatches(events, matches, getInterests());
+    expect(wakes).toHaveLength(1);
+    expect(oneShotsToDelete).toEqual(["prose-5"]);
+  });
+
+  test("handles non-array matches gracefully (returns empty result)", () => {
+    registerProseInterest("prose-6");
+    const events = [{ id: "x", ts: "2026-05-12T20:14:00Z", event: "foo" }];
+    const { wakes, oneShotsToDelete } = classifyMatches(events, null, getInterests());
+    expect(wakes).toHaveLength(0);
+    expect(oneShotsToDelete).toEqual([]);
+  });
+
+  test("orchestrator falls back to interest_id when reg.orchestrator is null", () => {
+    registerProseInterest("prose-7", { orchestrator: null });
+    const events = [{ id: "x", ts: "2026-05-12T20:14:00Z", event: "foo" }];
+    const matches = [
+      { interest_id: "prose-7", reason: "match", event_indices: [1] },
+    ];
+    const { wakes } = classifyMatches(events, matches, getInterests());
+    expect(wakes[0].orchestrator).toBe("prose-7");
   });
 });


### PR DESCRIPTION
## Summary

- Refactor the per-match processing loop in `classifyBatch` into a pure exported helper `classifyMatches(events, matches, interestsMap)` returning `{wakes, oneShotsToDelete}`, mirroring the pattern of `tryDeterministicRoute` / `tryTicketLifecycleRoute`.
- Fix the suppression gate to trigger on `match.event_indices.length === 0` (Groq returned a match with no event references) instead of `sourceIds.length` (the post-filter array).
- Add `matched_indices_count` to the wake `detail` so observability preserves Groq's intent when indices point past the batch end.
- Drop the "suppressing empty wake" log line — fired 779×/hr in production pre-fix and drowned out real failures.

## Context

[CTL-340](https://linear.app/rozich/issue/CTL-340) — broker suppressed every prose-matched `filter.wake.*` event when source events were canonical OTel envelopes lacking a top-level `id` field. CTL-344 added the `synthesizeEventId` fallback at all three read sites, but the suppression gate in `classifyBatch` was still semantically wrong — it gated on the post-filter array rather than on Groq's intent. This PR fixes the gate and extracts the pure helper for testability.

Related: CTL-336 (sibling field-extraction bug), CTL-344 (canonical event.id emission + read-site fallback).

## Test plan

- [x] All existing broker tests still pass (53 baseline in `index.test.mjs` → 53 still passing)
- [x] 8 new `classifyMatches` tests pass:
  - emits wake for canonical events without `.id` (uses `synthesizeEventId`)
  - suppresses wake when `match.event_indices` is empty (regression guard)
  - legacy `.id`-bearing events resolve to their real `.id` (regression guard)
  - indices pointing past batch end emit wake with filtered ids + accurate `matched_indices_count`
  - unknown `interest_id` skipped
  - one-shot interests reported for deletion
  - non-array `matches` handled gracefully
  - orchestrator falls back to `interest_id` when `reg.orchestrator` is null
- [x] Full broker test suite: 103 pass, 0 fail across 4 files
- [ ] Post-merge: live `broker.log` shows `msg:"wake"` lines for orchestrator prose interests
- [ ] Post-merge: HUD / dashboard renders `filter.wake.orch-*` events for prose matches

## Out of scope

- Adding top-level `id` field to canonical envelopes — CTL-344 did this; this change keeps the defensive `?? synthesizeEventId` fallback for legacy events still in flight.
- pr_lifecycle interest refresh when workers open PRs — separate ticket.