### PR TITLE
fix(dev): broker skips self-emitted filter.wake/broker.daemon events (CTL-346)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -709,9 +709,21 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
 
 // --- Event classification ---
 
+// CTL-346: skip events the broker itself emitted so we never re-ingest
+// our own filter.wake.*/broker.daemon.* output (the 2026-05-12 wake feedback
+// loop). The original `event.event` read missed canonical OTel envelopes
+// where the name lives at attributes["event.name"]; the new check uses
+// getEventName + a service.name guard that catches every broker emission.
+// Opt out via BROKER_INGEST_OWN_EMISSIONS=1 for debugging.
 export function shouldSkipEvent(event) {
-  const name = event.event ?? "";
-  return name.startsWith("filter.");
+  if (process.env.BROKER_INGEST_OWN_EMISSIONS === "1") {
+    return getEventName(event).startsWith("filter.");
+  }
+  if (event.resource?.["service.name"] === "catalyst.broker") return true;
+  const name = getEventName(event);
+  if (name.startsWith("filter.")) return true;
+  if (name.startsWith("broker.daemon")) return true;
+  return false;
 }
 
 export function buildGroqPrompt(events) {

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -776,6 +776,67 @@ describe("shouldSkipEvent (broker)", () => {
   });
 });
 
+// ─── shouldSkipEvent — broker self-emission guards (CTL-346) ─────────────────
+
+describe("shouldSkipEvent — broker self-emission guards (CTL-346)", () => {
+  test("skips canonical filter.wake.* event (broker self-emission)", () => {
+    expect(shouldSkipEvent({
+      attributes: { "event.name": "filter.wake.orch-1" },
+      resource: { "service.name": "catalyst.broker" },
+      body: { payload: {} },
+    })).toBe(true);
+  });
+
+  test("skips canonical broker.daemon.startup event", () => {
+    expect(shouldSkipEvent({
+      attributes: { "event.name": "broker.daemon.startup" },
+      resource: { "service.name": "catalyst.broker" },
+    })).toBe(true);
+  });
+
+  test("skips any event with resource.service.name == catalyst.broker", () => {
+    // Defense-in-depth: future broker.* event names still get skipped.
+    expect(shouldSkipEvent({
+      attributes: { "event.name": "broker.future.metric" },
+      resource: { "service.name": "catalyst.broker" },
+    })).toBe(true);
+  });
+
+  test("does not skip github.* events from other services", () => {
+    expect(shouldSkipEvent({
+      attributes: { "event.name": "github.pr.merged" },
+      resource: { "service.name": "catalyst.github-webhook" },
+    })).toBe(false);
+  });
+
+  test("does not skip canonical linear.* events from other services", () => {
+    expect(shouldSkipEvent({
+      attributes: { "event.name": "linear.issue.state_changed" },
+      resource: { "service.name": "catalyst.linear-webhook" },
+    })).toBe(false);
+  });
+
+  test("BROKER_INGEST_OWN_EMISSIONS=1 opts out — broker.daemon flows through", () => {
+    const prev = process.env.BROKER_INGEST_OWN_EMISSIONS;
+    process.env.BROKER_INGEST_OWN_EMISSIONS = "1";
+    try {
+      // filter.* still skipped (original semantics for control-plane events)
+      expect(shouldSkipEvent({
+        attributes: { "event.name": "filter.wake.orch-1" },
+        resource: { "service.name": "catalyst.broker" },
+      })).toBe(true);
+      // broker.daemon.* now passes through for debugging visibility
+      expect(shouldSkipEvent({
+        attributes: { "event.name": "broker.daemon.startup" },
+        resource: { "service.name": "catalyst.broker" },
+      })).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.BROKER_INGEST_OWN_EMISSIONS;
+      else process.env.BROKER_INGEST_OWN_EMISSIONS = prev;
+    }
+  });
+});
+
 // ─── Broker state file (CTL-343 — API key health) ───────────────────────────
 
 describe("buildBrokerState (CTL-343)", () => {


### PR DESCRIPTION
## Summary

Fixes [CTL-346](https://linear.app/coalesce-labs/issue/CTL-346) — wake feedback loop where the broker re-ingests its own `filter.wake.*` / `broker.daemon.*` emissions and re-classifies them through Groq against sibling orchestrators' prose interests.

## Root cause

`shouldSkipEvent` in `plugins/dev/scripts/broker/index.mjs` read `event.event` directly. After CTL-344 made every broker emission a canonical OTel envelope (name lives at `attributes["event.name"]`, not `event`), the legacy read returned `""` for every self-emission — the `filter.` prefix check then said "not a filter event, classify it." Groq false-positives a match against every prose interest text, broker emits another `filter.wake.*`, loop continues.

Pre-CTL-340 these loops were silently absorbed by the empty-id suppression guard; CTL-340 correctly tightened that gate and exposed the live loop. Neither CTL-340 nor CTL-344 is the bug — both surfaced this one.

## Fix

`shouldSkipEvent` now:

1. Uses the shape-agnostic `getEventName` helper (canonical envelopes work).
2. **Primary guard:** skips anything with `resource.service.name == "catalyst.broker"`. The broker is the only service that emits with this name, so this single check covers every self-emission regardless of the event name.
3. **Defensive name prefixes:** still skips `filter.*` (original behavior) and `broker.daemon.*` (new — covers `broker.daemon.startup` and future broker.daemon.* events).
4. `BROKER_INGEST_OWN_EMISSIONS=1` opts out for debugging visibility.

## Tests

Six new unit cases in `index.test.mjs` under `shouldSkipEvent — broker self-emission guards (CTL-346)`:

- canonical `filter.wake.*` envelope → skipped
- canonical `broker.daemon.startup` → skipped
- any event with `service.name == catalyst.broker` → skipped (defense-in-depth)
- `github.pr.merged` from `github-webhook` → flows through (regression guard)
- canonical `linear.issue.state_changed` from `linear-webhook` → flows through (regression guard)
- `BROKER_INGEST_OWN_EMISSIONS=1` → `broker.daemon.*` flows through, `filter.*` still skipped

Full broker suite: **109/109 green** (was 101/101 pre-rebase; CTL-340's 8 new cases land in the same suite).

## Test plan

- [x] `bun test plugins/dev/scripts/broker/` — 109 pass / 0 fail
- [x] Manual diff review — single function changed, signature preserved
- [x] No other broker `shouldSkipEvent` callers exist (orch-monitor and filter-daemon have their own copies; out of scope per the ticket)