### PR TITLE
fix(dev): surface wake target + reason in HUD rows (CTL-348)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -479,6 +479,26 @@ describe("formatRef", () => {
   });
 });
 
+describe("formatRef (filter.wake)", () => {
+  // CTL-348: filter.wake events route to a specific session/orchestrator id —
+  // surface it in REF so the operator can tell whose wake fired.
+  test("returns the session id stripped of the filter.wake. prefix", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("orch-foo");
+  });
+
+  test("handles the legacy orchestrator.filter.wake.* alias", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.filter.wake.orch-bar" },
+    } as unknown as CanonicalEvent;
+    expect(formatRef(e)).toBe("orch-bar");
+  });
+});
+
 describe("formatDetails", () => {
   test("returns payload title when present", () => {
     const e = { ...baseEvent, body: { message: "ignored", payload: { title: "feat: add thing" } } };
@@ -699,6 +719,78 @@ describe("formatDetails (filter.register)", () => {
       body: { message: "fallback message", payload: {} },
     } as unknown as CanonicalEvent;
     expect(formatDetails(e)).toBe("fallback message");
+  });
+});
+
+describe("formatDetails (filter.wake)", () => {
+  // CTL-348: render "wake → ${reason_short}" so the HUD shows why the broker
+  // woke an orchestrator instead of an empty DETAIL cell.
+  test("renders 'wake → {reason}' from body.payload.reason", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: { payload: { reason: "some reason", source_event_ids: [] } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("wake → some reason");
+  });
+
+  test("truncates long reasons to 40 chars", () => {
+    const long = "x".repeat(60);
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: { payload: { reason: long, source_event_ids: [] } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("wake → " + "x".repeat(40));
+  });
+
+  test("appends (n) when source_event_ids has more than one entry", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: { payload: { reason: "ci_completed", source_event_ids: ["a", "b", "c"] } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("wake → ci_completed (3)");
+  });
+
+  test("omits the arrow when reason is empty", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: { payload: { reason: "", source_event_ids: ["a", "b"] } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("wake (2)");
+  });
+
+  test("handles the legacy orchestrator.filter.wake.* alias", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.filter.wake.orch-foo" },
+      body: { payload: { reason: "ticket changed", source_event_ids: [] } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("wake → ticket changed");
+  });
+});
+
+describe("formatDetails (broker.daemon)", () => {
+  // CTL-348: broker.daemon.* events sometimes carry a free-form payload.detail
+  // string; surface it in DETAIL when present, fall through otherwise.
+  test("renders payload.detail when present", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "broker.daemon.startup" },
+      body: { payload: { detail: "started pid=123" } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("started pid=123");
+  });
+
+  test("falls through to message when no payload.detail", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "broker.daemon.startup" },
+      body: { message: "broker started", payload: { pid: 7170 } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("broker started");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -132,6 +132,14 @@ export function formatRef(event: CanonicalEvent): string {
     if (typeof channel === "string" && channel.length > 0) return channel;
     return "";
   }
+  // CTL-348: filter.wake.* events route to a specific session/orchestrator id —
+  // surface that id in REF so the operator can tell whose wake fired. The
+  // SOURCE column already says "broker", so REF only needs the target id with
+  // the "filter.wake." prefix stripped for readability.
+  if (name?.startsWith("filter.wake.") || name?.startsWith("orchestrator.filter.wake.")) {
+    const stripped = name.replace(/^(orchestrator\.)?filter\.wake\./, "");
+    if (stripped.length > 0) return stripped;
+  }
   // CTL-337: filter.register events watch a specific set of tickets (semantic
   // interest) or a specific repo (structured interest like pr_lifecycle).
   // Surface that in REF so the user sees what the registration observes.
@@ -258,6 +266,34 @@ export function formatDetails(event: CanonicalEvent): string {
   if (cached !== undefined) return cached;
   const name = event.attributes?.["event.name"];
   const payload = event.body?.payload;
+  // CTL-348: filter.wake.* events carry a human-readable reason and an array of
+  // source event ids. Render "wake → ${reason_short}" with an optional "(n)"
+  // suffix when more than one source event triggered the wake so operators can
+  // tell *why* the broker woke the orchestrator instead of seeing a blank cell.
+  if (name?.startsWith("filter.wake.") || name?.startsWith("orchestrator.filter.wake.")) {
+    const p = payload as Record<string, unknown> | undefined;
+    const reasonRaw = typeof p?.["reason"] === "string" ? p["reason"] : "";
+    const ids = p?.["source_event_ids"];
+    const count = Array.isArray(ids) ? ids.length : 0;
+    const reasonShort = sanitize(reasonRaw, "oneline").slice(0, 40);
+    const suffix = count > 1 ? ` (${count})` : "";
+    const out = reasonShort ? `wake → ${reasonShort}${suffix}` : `wake${suffix}`;
+    detailsCache.set(event, out);
+    return out;
+  }
+  // CTL-348: broker.daemon.* events occasionally carry a free-form detail
+  // string in their payload. Surface it when present; otherwise fall through
+  // to the generic payload/message handler below so structured payloads
+  // (pid, recovered_interests, …) still produce a non-empty cell.
+  if (name?.startsWith("broker.daemon.")) {
+    const p = payload as Record<string, unknown> | undefined;
+    const detail = p?.["detail"];
+    if (typeof detail === "string" && detail.length > 0) {
+      const out = sanitize(detail, "oneline");
+      detailsCache.set(event, out);
+      return out;
+    }
+  }
   // CTL-337: filter.register events carry a human-readable prompt (semantic
   // interest) or an interest_type + repo (structured interest). Surface that
   // in DETAILS so the user sees *why* the registration was made.


### PR DESCRIPTION
## Summary

- `filter.wake.*` rows in `catalyst-hud` previously rendered with only `broker` in SOURCE and `wake` in EVENT — REF and DETAIL columns were empty. The CTL-346 wake feedback loop was invisible until thousands of Groq calls had fired because the HUD never surfaced which orchestrator was woken or why.
- `formatRef` now returns the `event.name` suffix (stripped of `filter.wake.`) so the wake target shows in REF. Handles the legacy `orchestrator.filter.wake.*` alias.
- `formatDetails` renders `wake → ${reason_short}` from `body.payload.reason` (sanitized + 40-char cap) with an optional `(n)` suffix when `source_event_ids` has more than one entry. Also surfaces `body.payload.detail` for `broker.daemon.*` events when present, falling through to the generic handler otherwise so structured startup payloads still render.

Resolves [CTL-348](https://linear.app/coalesce-labs/issue/CTL-348). Related: CTL-342 (last touch on this row formatter), CTL-337 (the `filter.register` formatter pattern reused here), CTL-346 (the wake feedback-loop incident this fix makes visible).

## Test plan

- [x] `bun test __tests__/hud-format.test.ts` — 109/109 pass, including 8 new tests:
  - `formatRef (filter.wake)`: strips prefix; handles legacy alias
  - `formatDetails (filter.wake)`: reason rendering, 40-char truncation, `(n)` suffix on multi-source, empty-reason fallback, legacy alias
  - `formatDetails (broker.daemon)`: payload.detail rendering, message fall-through
- [x] `bun run typecheck` — clean (the two `ui/src/lib/briefings.ts` errors that appeared briefly were because `ui/node_modules` was uninstalled in this worktree; installing them resolves it and they pre-date this branch)
- [x] `bunx eslint cli/lib/format.ts __tests__/hud-format.test.ts` — clean
- [x] Manual sanity: replayed real `filter.wake.tl-pe` / `filter.wake.orch-1` log lines from `~/catalyst/events/2026-05.jsonl` against the formatters — REF now shows `tl-pe` / `orch-1`, DETAIL now shows `wake → Ticket CTL-500 marked Done`.

## Out of scope

- The React/web orch-monitor UI (`ui/src/components/activity-event-row.tsx`) — separate component tree, separate ticket if it needs the same fix.
- Adding `event.label` as a proper attribute on `filter.wake` events at emit time. The current emission shape (suffix in `event.name`) is the contract everywhere else; this PR reads what's already there rather than changing the emitter.