### PR TITLE
fix(dev): pr_lifecycle interest refresh + auto-correlate at PR open (CTL-341)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -672,10 +672,14 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
 }
 
 // When a PR opens linked to a ticket, auto-register pr_lifecycle for any agent
-// that checked in with that ticket but hasn't been linked to a PR yet.
+// that checked in with that ticket but hasn't been linked to a PR yet, AND
+// (CTL-341) append the new PR number to any orchestrator-level pr_lifecycle
+// interest whose orchestrator matches one of those agents.
 function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
   let agents = [];
   try { agents = getAgentsByTicket(ticket); } catch { return; }
+
+  let changed = false;
 
   for (const agent of agents) {
     if (agent.claimedPr) continue;
@@ -703,8 +707,34 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
       { sessionId, ticket, prNumber },
       "auto-correlated pr_lifecycle from ticket",
     );
-    saveInterests();
+    changed = true;
   }
+
+  // CTL-341: Also append the PR to any orchestrator-level pr_lifecycle interest
+  // whose orchestrator owns at least one agent on this ticket. The orchestrator
+  // registers its own pr_lifecycle interest at Phase 4 start, often before any
+  // worker has opened a PR — so pr_numbers starts empty. Without this update,
+  // the deterministic route in tryDeterministicRoute never matches incoming
+  // PR/CI/review events for the new PR.
+  const orchsForTicket = new Set(
+    agents.map((a) => a.orchestrator).filter((o) => o != null),
+  );
+  for (const [interestId, reg] of interestsMap) {
+    if (reg.interest_type !== "pr_lifecycle") continue;
+    if (reg.session_id !== null) continue; // worker-level — skip
+    if (!orchsForTicket.has(reg.orchestrator)) continue;
+    const prs = reg.pr_numbers ?? [];
+    if (prs.includes(prNumber)) continue;
+    reg.pr_numbers = [...prs, prNumber];
+    try { upsertFilterStateOpen({ interestId, prNumber, repo: reg.repo ?? "" }); } catch { /* DB not opened */ }
+    log.info(
+      { interestId, ticket, prNumber, orchestrator: reg.orchestrator },
+      "appended PR to orchestrator pr_lifecycle interest",
+    );
+    changed = true;
+  }
+
+  if (changed) saveInterests();
 }
 
 // --- Event classification ---

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -566,6 +566,137 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
 
     expect(getInterests().get("sess-already")?.pr_numbers).toEqual(prBefore);
   });
+
+  // CTL-341: orchestrator-level pr_lifecycle interest should also pick up new PRs.
+  test("orchestrator pr_lifecycle interest gets PR appended when worker on its ticket opens PR", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-w-A", agent_name: "worker", ticket: "CTL-275", orchestrator: "orch-A", claimed_pr: null },
+    });
+
+    // Orchestrator-level pr_lifecycle interest registered with empty pr_numbers
+    // (this is the CTL-341 bug shape — registered before any PR opened).
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-A",
+      detail: {
+        interest_id: "orch-A-pr-lifecycle",
+        interest_type: "pr_lifecycle",
+        notify_event: "filter.wake.orch-A",
+        pr_numbers: [],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+
+    // Ticket_lifecycle interest is what triggers tryTicketLifecycleRoute on pr_opened.
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-A",
+      detail: {
+        interest_id: "tl-orch-A",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["pr_opened"],
+        persistent: true,
+      },
+    });
+
+    tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 610 },
+      detail: { body: "Implements CTL-275", title: "", headRef: "" },
+    }, getInterests());
+
+    const orchReg = getInterests().get("orch-A-pr-lifecycle");
+    expect(orchReg).toBeDefined();
+    expect(orchReg.pr_numbers).toContain(610);
+  });
+
+  test("orchestrator pr_lifecycle interest is not duplicated if PR already present", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-w-B", agent_name: "worker", ticket: "CTL-275", orchestrator: "orch-B", claimed_pr: null },
+    });
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-B",
+      detail: {
+        interest_id: "orch-B-pr-lifecycle",
+        interest_type: "pr_lifecycle",
+        notify_event: "filter.wake.orch-B",
+        pr_numbers: [620],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-B",
+      detail: {
+        interest_id: "tl-orch-B",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["pr_opened"],
+        persistent: true,
+      },
+    });
+
+    tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 620 },
+      detail: { body: "Implements CTL-275", title: "", headRef: "" },
+    }, getInterests());
+
+    const orchReg = getInterests().get("orch-B-pr-lifecycle");
+    expect(orchReg.pr_numbers.filter((n) => n === 620)).toHaveLength(1);
+  });
+
+  test("orchestrator pr_lifecycle interest is NOT touched when no agent on watched ticket belongs to that orchestrator", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-w-X", agent_name: "worker", ticket: "CTL-275", orchestrator: "orch-X", claimed_pr: null },
+    });
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-Y",
+      detail: {
+        interest_id: "orch-Y-pr-lifecycle",
+        interest_type: "pr_lifecycle",
+        notify_event: "filter.wake.orch-Y",
+        pr_numbers: [],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-X",
+      detail: {
+        interest_id: "tl-orch-X",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["pr_opened"],
+        persistent: true,
+      },
+    });
+
+    tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 630 },
+      detail: { body: "Implements CTL-275", title: "", headRef: "" },
+    }, getInterests());
+
+    const orchYReg = getInterests().get("orch-Y-pr-lifecycle");
+    expect(orchYReg.pr_numbers).toEqual([]);
+  });
 });
 
 // ─── getAgentsByTicket ───────────────────────────────────────────────────────

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -1027,67 +1027,8 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
       '.pr = ((.pr // {}) | .number = ($n | tonumber) | .url = $u)' \
       "$WORKER_SIGNAL" > "$WORKER_SIGNAL.tmp" && mv "$WORKER_SIGNAL.tmp" "$WORKER_SIGNAL"
 
-    # Refresh broker context with the newly discovered PR number (CTL-257, updated CTL-303).
-    # Re-emitting filter.register with the same orchestrator key overwrites the prior registration.
-    # CTL-284: also refresh the pr_lifecycle interest with the new PR number.
-    # Note: workers auto-correlate their own pr_lifecycle via agent.checkin; this keeps the
-    # orchestrator-level aggregated interest up to date.
-    if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
-      _UPD_PRS=$(jq -rs '[.[].pr.number // empty] | unique' \
-        "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-      _UPD_TICKETS=$(jq -rs '[.[].ticket // empty]' \
-        "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-      _UPD_BASES=$(jq -rs '[
-        .[] | select(.pr.number != null and .pr.baseRefName != null)
-            | {pr: .pr.number, base: .pr.baseRefName}
-      ]' "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-      _UPD_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
-
-      # Prose interest (residual concerns: comms-attention, ticket status)
-      "$STATE_SCRIPT" event "$(jq -nc \
-        --arg orch "${ORCH_NAME}" \
-        --arg sid "${CATALYST_SESSION_ID:-}" \
-        --arg notify "filter.wake.${ORCH_NAME}" \
-        --argjson prs "${_UPD_PRS}" \
-        --argjson tickets "${_UPD_TICKETS}" \
-        '{
-          ts: (now | todate),
-          event: "filter.register",
-          orchestrator: $orch,
-          worker: null,
-          detail: {
-            session_id: (if $sid == "" then null else $sid end),
-            notify_event: $notify,
-            prompt: "Wake me when: any of my workers posts a comms message of type attention to me; or one of my Linear tickets changes status",
-            persistent: true,
-            context: {pr_numbers: $prs, tickets: $tickets}
-          }
-        }')" 2>/dev/null || true
-
-      # CTL-284: pr_lifecycle interest (deterministic PR/CI/review/deployment routing)
-      "$STATE_SCRIPT" event "$(jq -nc \
-        --arg orch "${ORCH_NAME}" \
-        --arg id "${ORCH_NAME}-pr-lifecycle" \
-        --arg notify "filter.wake.${ORCH_NAME}" \
-        --arg repo "${_UPD_REPO}" \
-        --argjson prs "${_UPD_PRS}" \
-        --argjson bases "${_UPD_BASES}" \
-        '{
-          ts: (now | todate),
-          event: "filter.register",
-          orchestrator: $orch,
-          worker: null,
-          detail: {
-            interest_id: $id,
-            interest_type: "pr_lifecycle",
-            notify_event: $notify,
-            persistent: true,
-            pr_numbers: $prs,
-            repo: $repo,
-            base_branches: $bases
-          }
-        }')" 2>/dev/null || true
-    fi
+    # CTL-341: refresh handled by the unconditional refresh block after this
+    # loop. The signal file update above (.pr.number = $n) feeds into it.
   fi
 
   # Parse repo from PR URL (e.g. https://github.com/org/repo/pull/123)
@@ -1260,6 +1201,88 @@ REMEDIATION_EOF
       ;;
   esac
 done
+```
+
+**Refresh broker registration when PR set has changed (CTL-341).** The Phase 4 start block
+above registers the orchestrator's `pr_lifecycle` interest with whatever PRs the worker signal
+files happen to expose at that moment — often the empty set, because workers have not yet
+opened PRs. Without an unconditional refresh, that empty `pr_numbers` list would persist for
+the entire orchestration run and the deterministic route in `tryDeterministicRoute` would
+never match. The merge-confirmation loop above can discover a missing `pr.number` from a
+worker's branch, but that path does not run when the worker writes its own `pr.number` before
+the orchestrator wakes (the common case in the worker-driven flow). This block runs every
+Phase 4 wake-up, computes the union of `worker.pr.number` across the signal files, diffs
+against the set last sent to the broker, and re-emits both `filter.register` events only when
+the set has changed. Idempotent at the broker (upserts by `interest_id`); the diff just keeps
+the event log quiet.
+
+```bash
+if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
+  _UPD_PRS=$(jq -rs '[.[].pr.number // empty] | unique' \
+    "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
+  _LAST_FILE="${ORCH_DIR}/.last-pr-registration.json"
+  _LAST_PRS=$(jq -c '.prs // []' "$_LAST_FILE" 2>/dev/null || echo '[]')
+
+  if [ "$(printf '%s' "$_UPD_PRS" | jq -cS '.')" != "$(printf '%s' "$_LAST_PRS" | jq -cS '.')" ]; then
+    _UPD_TICKETS=$(jq -rs '[.[].ticket // empty]' \
+      "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
+    _UPD_BASES=$(jq -rs '[
+      .[] | select(.pr.number != null and .pr.baseRefName != null)
+          | {pr: .pr.number, base: .pr.baseRefName}
+    ]' "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
+    _UPD_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+
+    # Prose interest (residual concerns: comms-attention, ticket status)
+    "$STATE_SCRIPT" event "$(jq -nc \
+      --arg orch "${ORCH_NAME}" \
+      --arg sid "${CATALYST_SESSION_ID:-}" \
+      --arg notify "filter.wake.${ORCH_NAME}" \
+      --argjson prs "${_UPD_PRS}" \
+      --argjson tickets "${_UPD_TICKETS}" \
+      '{
+        ts: (now | todate),
+        event: "filter.register",
+        orchestrator: $orch,
+        worker: null,
+        detail: {
+          session_id: (if $sid == "" then null else $sid end),
+          notify_event: $notify,
+          prompt: "Wake me when: any of my workers posts a comms message of type attention to me; or one of my Linear tickets changes status",
+          persistent: true,
+          context: {pr_numbers: $prs, tickets: $tickets}
+        }
+      }')" 2>/dev/null || true
+
+    # CTL-284: pr_lifecycle interest (deterministic PR/CI/review/deployment routing)
+    "$STATE_SCRIPT" event "$(jq -nc \
+      --arg orch "${ORCH_NAME}" \
+      --arg id "${ORCH_NAME}-pr-lifecycle" \
+      --arg notify "filter.wake.${ORCH_NAME}" \
+      --arg repo "${_UPD_REPO}" \
+      --argjson prs "${_UPD_PRS}" \
+      --argjson bases "${_UPD_BASES}" \
+      '{
+        ts: (now | todate),
+        event: "filter.register",
+        orchestrator: $orch,
+        worker: null,
+        detail: {
+          interest_id: $id,
+          interest_type: "pr_lifecycle",
+          notify_event: $notify,
+          persistent: true,
+          pr_numbers: $prs,
+          repo: $repo,
+          base_branches: $bases
+        }
+      }')" 2>/dev/null || true
+
+    # Record the new set so the next wake-up can diff.
+    printf '{"prs":%s,"registeredAt":"%s"}\n' \
+      "$_UPD_PRS" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${_LAST_FILE}.tmp" \
+      && mv "${_LAST_FILE}.tmp" "$_LAST_FILE"
+  fi
+fi
 ```
 
 **Deploy state-machine sub-loop (CTL-211)** — runs on each wake-up for any worker


### PR DESCRIPTION
## Problem

Orchestrators emit `filter.register` with `interest_type: "pr_lifecycle"` at Phase 4 start, but at that point no worker has opened a PR yet — so `pr_numbers: []` and `base_branches: []` get written into the interest. The deterministic route in `tryDeterministicRoute` intersects incoming event PR numbers against this empty list and never matches anything.

The orchestrate skill did refresh the registration in the merge-confirmation scan's "discovered a PR" branch, but only when `signal.pr.number` was null and the scan discovered one — it didn't run for the initial PR open by a worker that wrote `pr.number` itself before any orchestrator wake (the common case in the worker-driven flow since CTL-252).

Live evidence on 2026-05-12 (`orch-adv-898-2026-05-12`, broker pid 4717): orchestrator interest stayed at `pr_numbers: []` while workers actively opened PRs (#651 merged at 14:24 local), and broker logs confirmed 0 deterministic-route wakes for that orchestrator.

## Fix A — orchestrate skill

Hoist the broker registration refresh out of the merge-confirmation discovery branch (where it only ran when the orchestrator itself discovered a previously-unknown PR) into an **unconditional Phase 4 post-scan block**. Every wake-up, compute the union of `worker.pr.number` across signal files, diff against `${ORCH_DIR}/.last-pr-registration.json`, and re-emit both `filter.register` events (prose + pr_lifecycle) only when the set changed. Idempotent at the broker (upserts by `interest_id`); the diff just keeps the event log quiet.

## Fix B — broker

Extend `_autoPrLifecycleFromTicket` so that, in addition to creating per-worker pr_lifecycle interests, it also **appends the new PR number to any orchestrator-level pr_lifecycle interest** whose `orchestrator` matches one of the agents on the ticket and whose `session_id` is null (orchestrator-level interests have no `session_id`; worker-level interests do). Also writes a `filter_state` row for the orchestrator interest so deployment correlation downstream sees the new PR.

Either A or B closes the gap on its own. Both is best (and what the ticket recommended).

## Files

- `plugins/dev/scripts/broker/index.mjs` — extend `_autoPrLifecycleFromTicket` (+34 / −7)
- `plugins/dev/scripts/broker/index.test.mjs` — 3 new TDD cases (+131)
- `plugins/dev/skills/orchestrate/SKILL.md` — replace nested refresh with unconditional Phase 4 block (+86 / −59)

## Test plan

- [x] `bun test plugins/dev/scripts/broker/` — 106 pass / 0 fail (3 added in this PR)
- [x] TDD: 3 broker tests written before fix; first test failed pre-fix and passes post-fix
- [x] Bash syntax check on the new orchestrate refresh block (`bash -n`)
- [x] Smoke test of diff logic: first wake-up emits, second wake-up with same PR set skips
- [x] Reward-hacking scan: no `as any` / `@ts-ignore` / non-null `!.` patterns

## Out of scope (from ticket)

- CTL-340 (wake-suppression bug — already shipped as #585)
- Reworking the orchestrator-vs-worker-vs-session interest model