### PR TITLE
fix(dev): HUD + broker observability rework (CTL-350)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -147,6 +147,54 @@ export function pluginVersion() {
   return __pluginVersionCached;
 }
 
+// CTL-350: compact summary of a triggering event, inlined into wake payloads
+// so receiving agents have enough context to act without re-fetching state
+// from GitHub/Linear/git. `lookup_jq` is a ready-to-run query against the
+// monthly-rotated event log for callers who do need full event details.
+const PAYLOAD_EXCERPT_KEYS = [
+  "state",
+  "stateType",
+  "conclusion",
+  "title",
+  "merged",
+  "action",
+];
+
+export function summarizeEvent(event) {
+  const id = event.id ?? synthesizeEventId(event);
+  const attrs = event.attributes ?? {};
+  const ts = event.ts ?? new Date().toISOString();
+  const name = event.event ?? attrs["event.name"] ?? "";
+  const payload =
+    event.body && typeof event.body === "object" && "payload" in event.body
+      ? event.body.payload
+      : event.detail ?? null;
+  const scope = event.scope ?? {};
+  const month = typeof ts === "string" ? ts.slice(0, 7) : "";
+  const excerpt = {};
+  if (payload && typeof payload === "object") {
+    for (const k of PAYLOAD_EXCERPT_KEYS) {
+      if (payload[k] !== undefined) excerpt[k] = payload[k];
+    }
+  }
+  const message = typeof event.body?.message === "string"
+    ? event.body.message.slice(0, 200)
+    : "";
+  const pr = attrs["vcs.pr.number"] ?? scope.pr ?? null;
+  const repo = attrs["vcs.repository.name"] ?? scope.repo ?? null;
+  return {
+    id,
+    name,
+    ts,
+    ticket: attrs["linear.issue.identifier"] ?? payload?.ticket ?? null,
+    pr,
+    repo,
+    message,
+    payload_excerpt: excerpt,
+    lookup_jq: `jq 'select(.id == "${id}")' ~/catalyst/events/${month}.jsonl`,
+  };
+}
+
 // Translate the broker's internal {event, orchestrator, worker, detail} shape
 // into a canonical OTel-style envelope. Severity defaults to INFO — broker
 // emissions today (filter.wake.*, broker.daemon.startup) are all info-level.
@@ -198,16 +246,32 @@ export function clearInterests() {
 }
 
 // --- Interest persistence ---
-const INTERESTS_FILE = resolve(CATALYST_DIR, "broker-interests.json");
-const LEGACY_INTERESTS_FILE = resolve(CATALYST_DIR, "filter-interests.json");
+// CTL-350: resolve paths per-call so tests can redirect by setting CATALYST_DIR.
+// Production daemons still pin a stable value at launch.
+function getInterestsFile() {
+  const catalystDir = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+  return resolve(catalystDir, "broker-interests.json");
+}
+
+function getLegacyInterestsFile() {
+  const catalystDir = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+  return resolve(catalystDir, "filter-interests.json");
+}
+
+// CTL-350: load-time guard. Test-only session_ids matching this pattern are
+// skipped so historical residue (sess-prose-7 etc.) does not get loaded into
+// production state and included in every Groq classification batch.
+const PROSE_TEST_SESSION = /^sess-prose-\d+$/;
 
 // One-time rename: legacy filter-interests.json → broker-interests.json on startup.
 function migrateLegacyInterestsFile() {
+  const interestsFile = getInterestsFile();
+  const legacyFile = getLegacyInterestsFile();
   try {
-    if (existsSync(LEGACY_INTERESTS_FILE) && !existsSync(INTERESTS_FILE)) {
-      renameSync(LEGACY_INTERESTS_FILE, INTERESTS_FILE);
+    if (existsSync(legacyFile) && !existsSync(interestsFile)) {
+      renameSync(legacyFile, interestsFile);
       log.info(
-        { from: LEGACY_INTERESTS_FILE, to: INTERESTS_FILE },
+        { from: legacyFile, to: interestsFile },
         "migrated legacy interests file"
       );
     }
@@ -217,22 +281,33 @@ function migrateLegacyInterestsFile() {
 }
 
 export function saveInterests() {
+  const interestsFile = getInterestsFile();
   try {
-    mkdirSync(dirname(INTERESTS_FILE), { recursive: true });
-    writeFileSync(INTERESTS_FILE, JSON.stringify([...interests.entries()], null, 2));
+    mkdirSync(dirname(interestsFile), { recursive: true });
+    writeFileSync(interestsFile, JSON.stringify([...interests.entries()], null, 2));
   } catch (err) {
     log.error({ err: err.message }, "failed to save interests");
   }
 }
 
 export function loadPersistedInterests() {
+  const interestsFile = getInterestsFile();
   try {
-    const entries = JSON.parse(readFileSync(INTERESTS_FILE, "utf8"));
+    const entries = JSON.parse(readFileSync(interestsFile, "utf8"));
+    let skipped = 0;
     for (const [id, reg] of entries) {
+      if (reg?.session_id && PROSE_TEST_SESSION.test(reg.session_id)) {
+        skipped++;
+        log.warn(
+          { interestId: id, sessionId: reg.session_id },
+          "skipping prose-* test residue"
+        );
+        continue;
+      }
       interests.set(id, reg);
     }
-    if (interests.size) {
-      log.info({ count: interests.size }, "loaded persisted interests");
+    if (interests.size || skipped) {
+      log.info({ count: interests.size, skipped }, "loaded persisted interests");
     }
   } catch {
     // No file yet or parse error — fine
@@ -554,7 +629,14 @@ export function tryDeterministicRoute(event, interestsMap) {
       }
     }
 
-    if (reason) matches.push({ interestId, reason, sourceEventId: eventId });
+    if (reason) {
+      matches.push({
+        interestId,
+        reason,
+        sourceEventId: eventId,
+        sourceEvent: summarizeEvent(event),
+      });
+    }
   }
 
   return matches;
@@ -664,7 +746,13 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
     }
 
     if (reason) {
-      matches.push({ interestId, reason, sourceEventId: eventId, ticket: matchedTicket });
+      matches.push({
+        interestId,
+        reason,
+        sourceEventId: eventId,
+        sourceEvent: summarizeEvent(event),
+        ticket: matchedTicket,
+      });
     }
   }
 
@@ -875,13 +963,13 @@ export function classifyMatches(events, matches, interestsMap) {
 
     // CTL-344: prefer real event.id; fall back to synthesized id for legacy
     // events. .filter(Boolean) strips any indices pointing past the batch end.
-    const sourceIds = indices
-      .map((i) => {
-        const e = events[i - 1];
-        if (!e) return null;
-        return e.id ?? synthesizeEventId(e);
-      })
-      .filter(Boolean);
+    // CTL-350: also build a parallel source_events array with structured
+    // metadata so receivers don't need to re-fetch from GitHub/Linear/git.
+    const sourceEvents = indices
+      .map((i) => events[i - 1])
+      .filter(Boolean)
+      .map((e) => summarizeEvent(e));
+    const sourceIds = sourceEvents.map((s) => s.id);
 
     wakes.push({
       event: reg.notify_event,
@@ -890,6 +978,7 @@ export function classifyMatches(events, matches, interestsMap) {
       detail: {
         reason: match.reason,
         source_event_ids: sourceIds,
+        source_events: sourceEvents,
         matched_indices_count: indices.length,
         interest_id: match.interest_id,
       },
@@ -951,7 +1040,14 @@ export function runWatchdogTick() {
             event: interest.notify_event,
             orchestrator: interest.orchestrator ?? interestId,
             worker: null,
-            detail: { reason, source_event_ids: [], interest_id: interestId },
+            // CTL-350: watchdog wakes have no triggering event, so source_events
+            // is always empty — receivers should fall back to the reason string.
+            detail: {
+              reason,
+              source_event_ids: [],
+              source_events: [],
+              interest_id: interestId,
+            },
           });
           log.info(
             { notifyEvent: interest.notify_event, reason },
@@ -1046,6 +1142,7 @@ export function processEvent(event) {
       detail: {
         reason: m.reason,
         source_event_ids: m.sourceEventId ? [m.sourceEventId] : [],
+        source_events: m.sourceEvent ? [m.sourceEvent] : [],
         interest_id: m.interestId,
         ...(m.ticket ? { ticket: m.ticket } : {}),
       },

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -4,7 +4,7 @@
 // Run: bun test plugins/dev/scripts/broker/index.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { existsSync, readFileSync, rmSync as rmFile } from "node:fs";
@@ -20,10 +20,12 @@ import {
   clearInterests,
   getLastHeartbeat,
   clearLastHeartbeat,
+  loadPersistedInterests,
   processEvent,
   tryDeterministicRoute,
   tryTicketLifecycleRoute,
   classifyMatches,
+  summarizeEvent,
   buildBrokerState,
   writeBrokerStateFile,
 } from "./index.mjs";
@@ -41,6 +43,9 @@ let tmpDir;
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "broker-test-"));
+  // CTL-350: redirect CATALYST_DIR so tests never write to the production
+  // ~/catalyst/broker-interests.json path during persistence operations.
+  process.env.CATALYST_DIR = tmpDir;
   openBrokerStateDb(join(tmpDir, "test.db"));
   clearInterests();
   clearLastHeartbeat();
@@ -49,6 +54,7 @@ beforeEach(() => {
 afterEach(() => {
   closeBrokerStateDb();
   rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.CATALYST_DIR;
 });
 
 // ─── ticket_lifecycle interest registration ───────────────────────────────────
@@ -1141,6 +1147,57 @@ describe("CTL-340 classifyMatches", () => {
     });
   }
 
+  // CTL-350 Phase 1: ensure tests cannot write to ~/catalyst/broker-interests.json
+  test("prose-* registrations do not write to production interests file", () => {
+    const homeDir = process.env.HOME ?? "/tmp";
+    const liveInterestsPath = join(homeDir, "catalyst", "broker-interests.json");
+    const before = existsSync(liveInterestsPath) ? readFileSync(liveInterestsPath, "utf8") : "";
+    registerProseInterest("prose-canary");
+    const after = existsSync(liveInterestsPath) ? readFileSync(liveInterestsPath, "utf8") : "";
+    expect(after).toBe(before);
+  });
+
+  test("loadPersistedInterests skips entries with session_id matching /^sess-prose-\\d+$/", () => {
+    const tmpFile = join(tmpDir, "broker-interests.json");
+    writeFileSync(
+      tmpFile,
+      JSON.stringify([
+        ["prose-99", {
+          notify_event: "filter.wake.prose-99",
+          prompt: "x",
+          session_id: "sess-prose-99",
+          persistent: true,
+          context: {},
+          orchestrator: null,
+          interest_type: null,
+          pr_numbers: null,
+          repo: null,
+          base_branches: null,
+          tickets: null,
+          wake_on: null,
+        }],
+        ["real-orch", {
+          notify_event: "filter.wake.real-orch",
+          prompt: "y",
+          session_id: null,
+          persistent: true,
+          context: {},
+          orchestrator: "real-orch",
+          interest_type: null,
+          pr_numbers: null,
+          repo: null,
+          base_branches: null,
+          tickets: null,
+          wake_on: null,
+        }],
+      ])
+    );
+    clearInterests();
+    loadPersistedInterests();
+    expect(getInterests().has("prose-99")).toBe(false);
+    expect(getInterests().has("real-orch")).toBe(true);
+  });
+
   test("emits wake for canonical events without .id (uses synthesizeEventId)", () => {
     registerProseInterest("prose-1");
     const events = [
@@ -1256,5 +1313,168 @@ describe("CTL-340 classifyMatches", () => {
     ];
     const { wakes } = classifyMatches(events, matches, getInterests());
     expect(wakes[0].orchestrator).toBe("prose-7");
+  });
+});
+
+// ─── CTL-350 Phase 2: source_events inlining ────────────────────────────────
+
+describe("CTL-350 source_events inlining", () => {
+  function registerProseInterest(id, { persistent = true, orchestrator = null } = {}) {
+    handleRegister({
+      event: "filter.register",
+      orchestrator,
+      detail: {
+        interest_id: id,
+        notify_event: `filter.wake.${id}`,
+        prompt: "match anything relevant",
+        context: {},
+        persistent,
+        session_id: `sess-${id}`,
+      },
+    });
+  }
+
+  test("summarizeEvent extracts compact fields with lookup_jq", () => {
+    const event = {
+      id: "11111111-1111-1111-1111-111111111111",
+      ts: "2026-05-12T21:08:40.000Z",
+      attributes: {
+        "event.name": "linear.issue.state_changed",
+        "linear.issue.identifier": "ADV-87",
+      },
+      body: {
+        message: "Ticket marked Done",
+        payload: { state: "Done", stateType: "completed" },
+      },
+    };
+    const s = summarizeEvent(event);
+    expect(s.id).toBe(event.id);
+    expect(s.name).toBe("linear.issue.state_changed");
+    expect(s.ts).toBe(event.ts);
+    expect(s.ticket).toBe("ADV-87");
+    expect(s.message).toBe("Ticket marked Done");
+    expect(s.payload_excerpt).toEqual({ state: "Done", stateType: "completed" });
+    expect(s.lookup_jq).toContain("2026-05.jsonl");
+    expect(s.lookup_jq).toContain(event.id);
+  });
+
+  test("summarizeEvent synthesizes id and handles legacy event shapes", () => {
+    const event = {
+      ts: "2026-05-12T21:08:40Z",
+      event: "github.pr.merged",
+      scope: { pr: 42 },
+      detail: { merged: true, mergeCommitSha: "deadbeef" },
+    };
+    const s = summarizeEvent(event);
+    expect(s.id).toBeString();
+    expect(s.id.length).toBe(32);
+    expect(s.name).toBe("github.pr.merged");
+    expect(s.payload_excerpt.merged).toBe(true);
+    expect(s.lookup_jq).toContain(s.id);
+  });
+
+  test("summarizeEvent truncates long message bodies to 200 chars", () => {
+    const event = {
+      id: "evt-long",
+      ts: "2026-05-12T21:08:40Z",
+      attributes: { "event.name": "github.pr_review_comment.created" },
+      body: { message: "x".repeat(500), payload: {} },
+    };
+    const s = summarizeEvent(event);
+    expect(s.message.length).toBe(200);
+  });
+
+  test("ticket_lifecycle wake includes sourceEvent with ticket+state", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-x",
+      detail: {
+        interest_id: "watcher-x",
+        notify_event: "filter.wake.watcher-x",
+        interest_type: "ticket_lifecycle",
+        tickets: ["ADV-87"],
+        wake_on: ["status_done"],
+        persistent: true,
+      },
+    });
+    const event = {
+      id: "uuid-1",
+      ts: "2026-05-12T21:08:40Z",
+      event: "linear.issue.state_changed",
+      detail: { state: "Done" },
+      attributes: { "linear.issue.identifier": "ADV-87" },
+    };
+    const matches = tryTicketLifecycleRoute(event, getInterests());
+    expect(matches[0].sourceEvent).toBeDefined();
+    expect(matches[0].sourceEvent.id).toBe("uuid-1");
+    expect(matches[0].sourceEvent.ticket).toBe("ADV-87");
+    expect(matches[0].sourceEvent.payload_excerpt.state).toBe("Done");
+  });
+
+  test("pr_lifecycle deterministic route attaches sourceEvent to matches", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-pr",
+      detail: {
+        interest_id: "pr-watcher",
+        notify_event: "filter.wake.pr-watcher",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [123],
+        repo: "owner/repo",
+        base_branches: [{ pr: 123, base: "main" }],
+        persistent: true,
+      },
+    });
+    const event = {
+      id: "uuid-pr",
+      ts: "2026-05-12T21:08:40Z",
+      event: "github.pr.merged",
+      scope: { pr: 123 },
+      attributes: { "event.name": "github.pr.merged", "vcs.pr.number": 123 },
+      detail: { mergeCommitSha: "deadbeef", merged: true },
+    };
+    const matches = tryDeterministicRoute(event, getInterests());
+    expect(matches[0].sourceEvent).toBeDefined();
+    expect(matches[0].sourceEvent.id).toBe("uuid-pr");
+    expect(matches[0].sourceEvent.name).toBe("github.pr.merged");
+    expect(matches[0].sourceEvent.pr).toBe(123);
+  });
+
+  test("classifyMatches builds source_events parallel to source_event_ids", () => {
+    registerProseInterest("prose-se");
+    const events = [
+      {
+        id: "uuid-a",
+        ts: "2026-05-12T21:08:40Z",
+        attributes: {
+          "event.name": "linear.issue.state_changed",
+          "linear.issue.identifier": "ADV-87",
+        },
+        body: { payload: { state: "Done" } },
+      },
+    ];
+    const matches = [
+      { interest_id: "prose-se", reason: "ticket done", event_indices: [1] },
+    ];
+    const { wakes } = classifyMatches(events, matches, getInterests());
+    expect(wakes[0].detail.source_events).toHaveLength(1);
+    expect(wakes[0].detail.source_events[0].id).toBe("uuid-a");
+    expect(wakes[0].detail.source_events[0].ticket).toBe("ADV-87");
+    expect(wakes[0].detail.source_event_ids).toEqual(["uuid-a"]);
+  });
+
+  test("classifyMatches handles indices past batch end without source_events leaks", () => {
+    registerProseInterest("prose-se2");
+    const events = [
+      { id: "uuid-a", ts: "2026-05-12T21:08:40Z", attributes: { "event.name": "foo" }, body: { payload: {} } },
+    ];
+    const matches = [
+      { interest_id: "prose-se2", reason: "match", event_indices: [1, 99] },
+    ];
+    const { wakes } = classifyMatches(events, matches, getInterests());
+    expect(wakes[0].detail.source_events).toHaveLength(1);
+    expect(wakes[0].detail.source_events[0].id).toBe("uuid-a");
+    expect(wakes[0].detail.source_event_ids).toEqual(["uuid-a"]);
+    expect(wakes[0].detail.matched_indices_count).toBe(2);
   });
 });

--- a/plugins/dev/scripts/clean-prose-interests.sh
+++ b/plugins/dev/scripts/clean-prose-interests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# CTL-350: one-time cleanup of prose-* test residue from production
+# ~/catalyst/broker-interests.json. Safe to re-run; idempotent.
+#
+# Older versions of broker/index.test.mjs registered test-only interests with
+# session_id matching /^sess-prose-\d+$/ through the production persistence
+# path, so they accumulated in the live file and got included in every Groq
+# classification batch.
+
+set -euo pipefail
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+FILE="${CATALYST_DIR}/broker-interests.json"
+
+if [[ ! -f "$FILE" ]]; then
+  echo "no interests file at $FILE — nothing to clean"
+  exit 0
+fi
+
+BEFORE=$(jq 'length' "$FILE")
+TMP=$(mktemp)
+jq 'map(select(.[1].session_id // "" | test("^sess-prose-\\d+$") | not))' "$FILE" > "$TMP"
+AFTER=$(jq 'length' "$TMP")
+mv "$TMP" "$FILE"
+
+REMOVED=$((BEFORE - AFTER))
+echo "removed $REMOVED prose-* entries (was $BEFORE, now $AFTER)"
+if [[ "$REMOVED" -gt 0 ]]; then
+  echo "restart the broker daemon to pick up the cleaned file"
+fi

--- a/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect } from "bun:test";
+import { computeColumnWidths } from "../cli/lib/column-widths.ts";
+import type { CanonicalEvent } from "../lib/canonical-event.ts";
+import {
+  formatStatus,
+  formatOrch,
+  formatWorker,
+  formatEventIdShort,
+} from "../cli/lib/format.ts";
+
+const makeEvent = (overrides: Partial<CanonicalEvent> = {}): CanonicalEvent => ({
+  ts: "2026-05-12T21:08:40.000Z",
+  id: "11111111-2222-4333-8444-555555555555",
+  severityText: "INFO",
+  severityNumber: 9,
+  traceId: null,
+  spanId: null,
+  resource: {
+    "service.name": "test",
+    "service.namespace": "catalyst",
+    "service.version": "0.0.0",
+  },
+  attributes: { "event.name": "github.pr.merged" },
+  body: {},
+  ...overrides,
+});
+
+describe("computeColumnWidths", () => {
+  test("at 80 cols hides STATUS, ORCH, WORKER, EVENT-ID", () => {
+    const w = computeColumnWidths(80);
+    expect(w.showStatus).toBe(false);
+    expect(w.showOrch).toBe(false);
+    expect(w.showWorker).toBe(false);
+    expect(w.showEventId).toBe(false);
+    expect(w.status).toBe(0);
+    expect(w.orch).toBe(0);
+    expect(w.worker).toBe(0);
+    expect(w.eventId).toBe(0);
+  });
+
+  test("at 100 cols enables STATUS only", () => {
+    const w = computeColumnWidths(100);
+    expect(w.showStatus).toBe(true);
+    expect(w.showOrch).toBe(false);
+    expect(w.status).toBe(2);
+  });
+
+  test("at 160 cols enables STATUS + ORCH", () => {
+    const w = computeColumnWidths(160);
+    expect(w.showStatus).toBe(true);
+    expect(w.showOrch).toBe(true);
+    expect(w.showWorker).toBe(false);
+    expect(w.orch).toBeGreaterThanOrEqual(16);
+  });
+
+  test("at 180 cols enables STATUS + ORCH + WORKER", () => {
+    const w = computeColumnWidths(180);
+    expect(w.showWorker).toBe(true);
+    expect(w.showEventId).toBe(false);
+    expect(w.worker).toBe(16);
+  });
+
+  test("at 200 cols enables all optional columns", () => {
+    const w = computeColumnWidths(200);
+    expect(w.showStatus).toBe(true);
+    expect(w.showOrch).toBe(true);
+    expect(w.showWorker).toBe(true);
+    expect(w.showEventId).toBe(true);
+    expect(w.eventId).toBe(10);
+  });
+
+  test("repo and ref widths clamp to sensible bounds", () => {
+    const narrow = computeColumnWidths(80);
+    const wide = computeColumnWidths(400);
+    expect(narrow.repo).toBeGreaterThanOrEqual(10);
+    expect(narrow.ref).toBeGreaterThanOrEqual(10);
+    expect(wide.repo).toBeLessThanOrEqual(14);
+    expect(wide.ref).toBeLessThanOrEqual(20);
+  });
+
+  test("orch width clamps at 24 even on very wide terminals", () => {
+    const w = computeColumnWidths(400);
+    expect(w.orch).toBeLessThanOrEqual(24);
+  });
+
+  test("time and event columns stay fixed at 10 and 16", () => {
+    for (const cols of [80, 140, 200, 300]) {
+      const w = computeColumnWidths(cols);
+      expect(w.time).toBe(10);
+      expect(w.event).toBe(16);
+    }
+  });
+});
+
+describe("status/orch/worker/event-id formatters", () => {
+  test("formatStatus: CI success → ✓", () => {
+    expect(
+      formatStatus(makeEvent({
+        attributes: {
+          "event.name": "github.check_suite.completed",
+          "cicd.pipeline.run.conclusion": "success",
+        },
+      })),
+    ).toBe("✓ ");
+  });
+
+  test("formatStatus: CI failure → ✗", () => {
+    expect(
+      formatStatus(makeEvent({
+        attributes: {
+          "event.name": "github.check_suite.completed",
+          "cicd.pipeline.run.conclusion": "failure",
+        },
+      })),
+    ).toBe("✗ ");
+  });
+
+  test("formatStatus: ERROR severity → ✗", () => {
+    expect(formatStatus(makeEvent({ severityText: "ERROR" }))).toBe("✗ ");
+  });
+
+  test("formatStatus: WARN severity → !", () => {
+    expect(formatStatus(makeEvent({ severityText: "WARN" }))).toBe("! ");
+  });
+
+  test("formatStatus: default INFO → ·", () => {
+    expect(formatStatus(makeEvent())).toBe("· ");
+  });
+
+  test("formatOrch returns the orchestrator id when present, else empty", () => {
+    expect(
+      formatOrch(makeEvent({
+        attributes: {
+          "event.name": "x",
+          "catalyst.orchestrator.id": "orch-adv-925-2026-05-12",
+        },
+      })),
+    ).toBe("orch-adv-925-2026-05-12");
+    expect(formatOrch(makeEvent())).toBe("");
+  });
+
+  test("formatWorker returns the worker ticket when present", () => {
+    expect(
+      formatWorker(makeEvent({
+        attributes: { "event.name": "x", "catalyst.worker.ticket": "ADV-87" },
+      })),
+    ).toBe("ADV-87");
+    expect(formatWorker(makeEvent())).toBe("");
+  });
+
+  test("formatEventIdShort returns first 8 chars of UUID", () => {
+    expect(formatEventIdShort(makeEvent())).toBe("11111111");
+  });
+
+  test("formatEventIdShort returns empty string when id missing", () => {
+    const evt = makeEvent();
+    evt.id = "";
+    expect(formatEventIdShort(evt)).toBe("");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/detail-pane-source-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/detail-pane-source-events.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import type { CanonicalEvent } from "../lib/canonical-event.ts";
+import { buildDetailLines } from "../cli/components/DetailPane.tsx";
+
+// CTL-350 Phase 5: event-id field above trace/span, plus source_events
+// promoted from raw JSON dump to labeled rows including the lookup_jq query.
+
+const makeEvent = (overrides: Partial<CanonicalEvent> = {}): CanonicalEvent => ({
+  ts: "2026-05-12T21:08:40.000Z",
+  id: "11111111-2222-4333-8444-555555555555",
+  severityText: "INFO",
+  severityNumber: 9,
+  traceId: "abc123def456abc123def456abc123de",
+  spanId: "abc123de456abc12",
+  resource: {
+    "service.name": "catalyst.broker",
+    "service.namespace": "catalyst",
+    "service.version": "0.0.0",
+  },
+  attributes: { "event.name": "filter.wake.orch-x" },
+  body: { message: "" },
+  ...overrides,
+});
+
+describe("DetailPane event-id field (CTL-350)", () => {
+  test("shows event-id field when event has id", () => {
+    const lines = buildDetailLines(makeEvent(), 120);
+    const idField = lines.find(
+      (l) => l.k === "field" && l.label === "event-id",
+    );
+    expect(idField).toBeDefined();
+    if (idField?.k === "field") {
+      expect(idField.value).toBe("11111111-2222-4333-8444-555555555555");
+    }
+  });
+
+  test("event-id appears above trace and span", () => {
+    const lines = buildDetailLines(makeEvent(), 120);
+    const idx = (label: string) =>
+      lines.findIndex((l) => l.k === "field" && l.label === label);
+    const idIdx = idx("event-id");
+    const traceIdx = idx("trace");
+    const spanIdx = idx("span");
+    expect(idIdx).toBeGreaterThanOrEqual(0);
+    expect(traceIdx).toBeGreaterThan(idIdx);
+    expect(spanIdx).toBeGreaterThan(idIdx);
+  });
+
+  test("event-id is omitted when id is empty string", () => {
+    const evt = makeEvent();
+    evt.id = "";
+    const lines = buildDetailLines(evt, 120);
+    const idField = lines.find(
+      (l) => l.k === "field" && l.label === "event-id",
+    );
+    expect(idField).toBeUndefined();
+  });
+});
+
+describe("DetailPane source_events promotion (CTL-350)", () => {
+  test("promotes single source_event to labeled rows", () => {
+    const evt = makeEvent({
+      body: {
+        payload: {
+          reason: "ticket changed",
+          source_event_ids: ["uuid-1"],
+          source_events: [{
+            id: "uuid-1",
+            name: "linear.issue.state_changed",
+            ticket: "ADV-87",
+            lookup_jq: "jq 'select(.id == \"uuid-1\")' ~/catalyst/events/2026-05.jsonl",
+            payload_excerpt: { state: "Done" },
+          }],
+        },
+      },
+    });
+    const lines = buildDetailLines(evt, 120);
+    const labels = lines
+      .filter((l) => l.k === "field")
+      .map((l) => (l.k === "field" ? l.label : ""));
+    expect(labels).toContain("source name");
+    expect(labels).toContain("source ticket");
+    expect(labels).toContain("source id");
+    expect(labels).toContain("lookup");
+  });
+
+  test("source_events with PR field renders source pr row", () => {
+    const evt = makeEvent({
+      body: {
+        payload: {
+          source_events: [{
+            id: "uuid-2",
+            name: "github.pr.merged",
+            pr: 87,
+            lookup_jq: "jq ...",
+          }],
+        },
+      },
+    });
+    const lines = buildDetailLines(evt, 120);
+    const prField = lines.find(
+      (l) => l.k === "field" && l.label === "source pr",
+    );
+    expect(prField).toBeDefined();
+    if (prField?.k === "field") expect(prField.value).toBe("#87");
+  });
+
+  test("multiple source_events get indexed labels", () => {
+    const evt = makeEvent({
+      body: {
+        payload: {
+          source_events: [
+            { id: "uuid-1", name: "linear.issue.state_changed", ticket: "ADV-1" },
+            { id: "uuid-2", name: "linear.issue.state_changed", ticket: "ADV-2" },
+          ],
+        },
+      },
+    });
+    const lines = buildDetailLines(evt, 120);
+    const labels = lines
+      .filter((l) => l.k === "field")
+      .map((l) => (l.k === "field" ? l.label : ""));
+    expect(labels).toContain("source name [1]");
+    expect(labels).toContain("source name [2]");
+  });
+
+  test("does nothing when source_events is absent", () => {
+    const evt = makeEvent({
+      body: { payload: { reason: "x", source_event_ids: ["a"] } },
+    });
+    const lines = buildDetailLines(evt, 120);
+    const sourceField = lines.find(
+      (l) => l.k === "field" && typeof l.label === "string" && l.label.startsWith("source "),
+    );
+    expect(sourceField).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -734,14 +734,16 @@ describe("formatDetails (filter.wake)", () => {
     expect(formatDetails(e)).toBe("wake → some reason");
   });
 
-  test("truncates long reasons to 40 chars", () => {
+  // CTL-350: 40-char truncation removed — Phase 3 <Text wrap="wrap"> handles
+  // long reasons by wrapping to multiple lines in the actual rendered row.
+  test("preserves long reasons (no truncation; row wraps in render)", () => {
     const long = "x".repeat(60);
     const e = {
       ...baseEvent,
       attributes: { "event.name": "filter.wake.orch-foo" },
       body: { payload: { reason: long, source_event_ids: [] } },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake → " + "x".repeat(40));
+    expect(formatDetails(e)).toBe("wake → " + long);
   });
 
   test("appends (n) when source_event_ids has more than one entry", () => {
@@ -769,6 +771,89 @@ describe("formatDetails (filter.wake)", () => {
       body: { payload: { reason: "ticket changed", source_event_ids: [] } },
     } as unknown as CanonicalEvent;
     expect(formatDetails(e)).toBe("wake → ticket changed");
+  });
+
+  // CTL-350: when source_events is populated, render structured triggering
+  // event info instead of the Groq reason string. Receivers no longer need to
+  // re-fetch state from GitHub/Linear/git to understand what fired the wake.
+  test("prefers source_events over reason when populated", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: {
+        payload: {
+          reason: "match anything relevant",
+          source_event_ids: ["uuid-1"],
+          source_events: [{
+            id: "uuid-1",
+            name: "linear.issue.state_changed",
+            ts: "2026-05-12T21:08:40Z",
+            ticket: "ADV-87",
+            payload_excerpt: { state: "Done" },
+          }],
+        },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("wake ← linear.issue.state_changed ADV-87 → Done");
+  });
+
+  test("falls back to reason when source_events is absent", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: { payload: { reason: "legacy wake reason", source_event_ids: [] } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("wake → legacy wake reason");
+  });
+
+  test("renders PR ref when source_event carries pr", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: {
+        payload: {
+          source_events: [{
+            name: "github.pr.merged",
+            pr: 87,
+            payload_excerpt: { merged: true },
+          }],
+        },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toContain("github.pr.merged #87");
+  });
+
+  test("renders CI ref + conclusion suffix when source_event carries conclusion", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: {
+        payload: {
+          source_events: [{
+            name: "github.check_suite.completed",
+            pr: 501,
+            payload_excerpt: { conclusion: "failure" },
+          }],
+        },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("wake ← github.check_suite.completed #501 → failure");
+  });
+
+  test("appends (N) when source_events has more than one entry", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-foo" },
+      body: {
+        payload: {
+          source_events: [
+            { name: "linear.issue.state_changed", ticket: "ADV-1" },
+            { name: "linear.issue.state_changed", ticket: "ADV-2" },
+          ],
+        },
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toContain("(2)");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
@@ -66,11 +66,48 @@ export function buildDetailLines(event: CanonicalEvent, cols: number): Line[] {
   if (svcName) {
     lines.push({ k: "field", label: "service", value: svcVer ? `${svcName}  v${svcVer}` : svcName });
   }
+  // CTL-350: surface event.id (CTL-344 UUIDv4). The field is positioned above
+  // trace/span because the per-event id is the primary key operators use to
+  // correlate a HUD row with the underlying JSONL record.
+  if (event.id) lines.push({ k: "field", label: "event-id", value: event.id });
   if (event.traceId) lines.push({ k: "field", label: "trace", value: event.traceId });
   if (event.spanId) lines.push({ k: "field", label: "span", value: event.spanId });
 
   const message = formatDetailBody(event);
   const payload = event.body?.payload;
+
+  // CTL-350: promote source_events (wake-event triggering metadata) from the
+  // generic JSON dump below to labeled rows. Receivers — both human operators
+  // and downstream agents — get structured context including a copy-paste
+  // lookup_jq query for retrieving the full triggering event.
+  const sourceEvents =
+    payload && typeof payload === "object" && "source_events" in payload
+      ? (payload as Record<string, unknown>)["source_events"]
+      : undefined;
+  if (Array.isArray(sourceEvents) && sourceEvents.length > 0) {
+    lines.push({ k: "sep" });
+    sourceEvents.forEach((s, i) => {
+      const sEvt = (s ?? {}) as Record<string, unknown>;
+      const idx = sourceEvents.length > 1 ? ` [${i + 1}]` : "";
+      if (typeof sEvt["name"] === "string" && sEvt["name"].length > 0) {
+        lines.push({ k: "field", label: `source name${idx}`, value: String(sEvt["name"]) });
+      }
+      if (typeof sEvt["ticket"] === "string" && sEvt["ticket"].length > 0) {
+        lines.push({ k: "field", label: `source ticket${idx}`, value: String(sEvt["ticket"]), color: "yellow" });
+      }
+      const pr = sEvt["pr"];
+      if (typeof pr === "number" || (typeof pr === "string" && pr.length > 0)) {
+        lines.push({ k: "field", label: `source pr${idx}`, value: `#${pr}`, color: "cyan" });
+      }
+      if (typeof sEvt["id"] === "string" && sEvt["id"].length > 0) {
+        lines.push({ k: "field", label: `source id${idx}`, value: String(sEvt["id"]) });
+      }
+      if (typeof sEvt["lookup_jq"] === "string" && sEvt["lookup_jq"].length > 0) {
+        lines.push({ k: "field", label: `lookup${idx}`, value: String(sEvt["lookup_jq"]) });
+      }
+    });
+  }
+
   if (message) {
     lines.push({ k: "sep" });
     const maxW = cols - LABEL_W - 6;

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -7,8 +7,13 @@ import {
   formatEvent,
   formatRef,
   formatDetails,
+  formatStatus,
+  formatOrch,
+  formatWorker,
+  formatEventIdShort,
 } from "../lib/format.ts";
 import { getRowColor } from "../lib/colors.ts";
+import { computeColumnWidths } from "../lib/column-widths.ts";
 
 interface EventRowProps {
   event: CanonicalEvent;
@@ -16,34 +21,59 @@ interface EventRowProps {
   columns: number;
 }
 
+// CTL-350: column widths come from a shared module so EventRow and Header
+// cannot drift. `<Box width flexShrink={0}>` lets Ink truncate long content
+// instead of the previous `.slice(N-1).padEnd(N)` strings, which defeated
+// Ink's flex layout and forced orchestrator IDs to chop at `orch-adv-` on
+// wide terminals. DETAILS uses `flexGrow={1}` + `wrap="wrap"` so a long
+// Groq reason wraps to multiple lines instead of being silently clipped.
 export function EventRow({ event, selected, columns }: EventRowProps) {
   const color = getRowColor(event);
   // Inverse video swaps fg/bg at the terminal level (ANSI SGR 7), guaranteeing
   // contrast across themes without composing same-family fg/bg pairs.
   const inverse = selected;
-  // Widths: time(10) repo(12) source(20) event(16) ref(10) = 68 fixed
-  const detailsWidth = Math.max(0, columns - 10 - 12 - 20 - 16 - 10 - 2);
+  const w = computeColumnWidths(columns);
 
   return (
     <Box flexDirection="row">
-      <Text color={color} inverse={inverse}>
-        {formatTime(event).padEnd(10)}
-      </Text>
-      <Text color={color} inverse={inverse}>
-        {formatRepo(event).slice(0, 11).padEnd(12)}
-      </Text>
-      <Text color={color} inverse={inverse}>
-        {formatSource(event).slice(0, 19).padEnd(20)}
-      </Text>
-      <Text color={color} inverse={inverse}>
-        {formatEvent(event).slice(0, 15).padEnd(16)}
-      </Text>
-      <Text color={color} inverse={inverse}>
-        {formatRef(event).slice(0, 9).padEnd(10)}
-      </Text>
-      <Text color={color} inverse={inverse}>
-        {formatDetails(event).slice(0, detailsWidth)}
-      </Text>
+      {w.showStatus && (
+        <Box width={w.status} flexShrink={0}>
+          <Text color={color} inverse={inverse}>{formatStatus(event)}</Text>
+        </Box>
+      )}
+      <Box width={w.time} flexShrink={0}>
+        <Text color={color} inverse={inverse}>{formatTime(event)}</Text>
+      </Box>
+      <Box width={w.repo} flexShrink={0}>
+        <Text color={color} inverse={inverse}>{formatRepo(event)}</Text>
+      </Box>
+      <Box width={w.source} flexShrink={0}>
+        <Text color={color} inverse={inverse}>{formatSource(event)}</Text>
+      </Box>
+      <Box width={w.event} flexShrink={0}>
+        <Text color={color} inverse={inverse}>{formatEvent(event)}</Text>
+      </Box>
+      <Box width={w.ref} flexShrink={0}>
+        <Text color={color} inverse={inverse}>{formatRef(event)}</Text>
+      </Box>
+      {w.showOrch && (
+        <Box width={w.orch} flexShrink={0}>
+          <Text color={color} inverse={inverse}>{formatOrch(event)}</Text>
+        </Box>
+      )}
+      {w.showWorker && (
+        <Box width={w.worker} flexShrink={0}>
+          <Text color={color} inverse={inverse}>{formatWorker(event)}</Text>
+        </Box>
+      )}
+      {w.showEventId && (
+        <Box width={w.eventId} flexShrink={0}>
+          <Text color={color} inverse={inverse} dimColor>{formatEventIdShort(event)}</Text>
+        </Box>
+      )}
+      <Box flexGrow={1}>
+        <Text color={color} inverse={inverse} wrap="wrap">{formatDetails(event)}</Text>
+      </Box>
     </Box>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 import type { BrokerKeyHealth } from "../lib/broker-key-health.ts";
 import { chipColor, chipLabel } from "../lib/broker-key-health.ts";
+import { computeColumnWidths } from "../lib/column-widths.ts";
 
 interface HeaderProps {
   columns?: number;
@@ -11,6 +12,7 @@ interface HeaderProps {
 export function Header({ columns = 120, nlQuery, brokerKeyHealth }: HeaderProps) {
   const sep = "─".repeat(Math.max(0, columns - 1));
   const groq = brokerKeyHealth?.groq;
+  const w = computeColumnWidths(columns);
   return (
     <Box flexDirection="column">
       {groq && (
@@ -22,12 +24,44 @@ export function Header({ columns = 120, nlQuery, brokerKeyHealth }: HeaderProps)
         </Box>
       )}
       <Box flexDirection="row">
-        <Text bold color="cyan">{"TIME      "}</Text>
-        <Text bold color="cyan">{"REPO        "}</Text>
-        <Text bold color="cyan">{"SOURCE              "}</Text>
-        <Text bold color="cyan">{"EVENT           "}</Text>
-        <Text bold color="cyan">{"REF       "}</Text>
-        <Text bold color="cyan">{"DETAILS"}</Text>
+        {w.showStatus && (
+          <Box width={w.status} flexShrink={0}>
+            <Text bold color="cyan">{"S "}</Text>
+          </Box>
+        )}
+        <Box width={w.time} flexShrink={0}>
+          <Text bold color="cyan">{"TIME"}</Text>
+        </Box>
+        <Box width={w.repo} flexShrink={0}>
+          <Text bold color="cyan">{"REPO"}</Text>
+        </Box>
+        <Box width={w.source} flexShrink={0}>
+          <Text bold color="cyan">{"SOURCE"}</Text>
+        </Box>
+        <Box width={w.event} flexShrink={0}>
+          <Text bold color="cyan">{"EVENT"}</Text>
+        </Box>
+        <Box width={w.ref} flexShrink={0}>
+          <Text bold color="cyan">{"REF"}</Text>
+        </Box>
+        {w.showOrch && (
+          <Box width={w.orch} flexShrink={0}>
+            <Text bold color="cyan">{"ORCH"}</Text>
+          </Box>
+        )}
+        {w.showWorker && (
+          <Box width={w.worker} flexShrink={0}>
+            <Text bold color="cyan">{"WORKER"}</Text>
+          </Box>
+        )}
+        {w.showEventId && (
+          <Box width={w.eventId} flexShrink={0}>
+            <Text bold color="cyan">{"EVENT-ID"}</Text>
+          </Box>
+        )}
+        <Box flexGrow={1}>
+          <Text bold color="cyan">{"DETAILS"}</Text>
+        </Box>
       </Box>
       <Text dimColor>{sep}</Text>
       {nlQuery && (

--- a/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
@@ -1,0 +1,57 @@
+/**
+ * CTL-350: Responsive HUD column widths.
+ *
+ * The legacy implementation hard-coded column widths via `.padEnd(N)` strings
+ * in EventRow.tsx and Header.tsx, which defeated Ink's flex layout and forced
+ * orchestrator IDs to truncate to `orch-adv-` on wide terminals while wasting
+ * horizontal space. This module is the single source of truth for column
+ * sizing — both row and header read from it so they cannot drift apart.
+ *
+ * Optional columns appear at successive terminal-width thresholds:
+ *   STATUS    ≥100 cols   one-glyph success/failure/in-progress indicator
+ *   ORCH      ≥160 cols   full catalyst.orchestrator.id
+ *   WORKER    ≥180 cols   catalyst.worker.ticket
+ *   EVENT-ID  ≥200 cols   first 8 chars of the per-event UUIDv4 (CTL-344)
+ *
+ * Numeric widths for non-optional columns are clamped between sensible min
+ * and max so very narrow terminals stay readable and very wide ones don't
+ * give a single column 30% of the screen.
+ */
+
+export interface ColumnWidths {
+  status: number;
+  time: number;
+  repo: number;
+  source: number;
+  event: number;
+  ref: number;
+  orch: number;
+  worker: number;
+  eventId: number;
+  showStatus: boolean;
+  showOrch: boolean;
+  showWorker: boolean;
+  showEventId: boolean;
+}
+
+export function computeColumnWidths(columns: number): ColumnWidths {
+  const showStatus = columns >= 100;
+  const showOrch = columns >= 160;
+  const showWorker = columns >= 180;
+  const showEventId = columns >= 200;
+  return {
+    status: showStatus ? 2 : 0,
+    time: 10,
+    repo: Math.min(14, Math.max(10, Math.floor(columns * 0.07))),
+    source: Math.min(22, Math.max(16, Math.floor(columns * 0.1))),
+    event: 16,
+    ref: Math.min(20, Math.max(10, Math.floor(columns * 0.08))),
+    orch: showOrch ? Math.min(24, Math.max(16, Math.floor(columns * 0.12))) : 0,
+    worker: showWorker ? 16 : 0,
+    eventId: showEventId ? 10 : 0,
+    showStatus,
+    showOrch,
+    showWorker,
+    showEventId,
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -122,6 +122,43 @@ export function formatEvent(event: CanonicalEvent): string {
   return label.slice(0, 15);
 }
 
+// CTL-350: STATUS column glyph. One char + trailing space so the column width
+// is exactly 2 — keeps `<Box width={2}>` rendering on a single visual cell
+// even when the terminal applies bold/inverse styling. CI conclusion drives
+// the glyph for check_suite/check_run events; severity is the fallback for
+// everything else so error/warn rows still get a visible marker.
+export function formatStatus(event: CanonicalEvent): string {
+  const attrs = event.attributes ?? ({} as CanonicalEvent["attributes"]);
+  const conclusion = attrs["cicd.pipeline.run.conclusion"];
+  if (conclusion === "success") return "✓ ";
+  if (conclusion === "failure" || conclusion === "cancelled") return "✗ ";
+  const name = attrs["event.name"];
+  if (conclusion === "in_progress" || (typeof name === "string" && name.includes(".in_progress"))) {
+    return "⏳";
+  }
+  const sev = event.severityText;
+  if (sev === "ERROR") return "✗ ";
+  if (sev === "WARN") return "! ";
+  return "· ";
+}
+
+export function formatOrch(event: CanonicalEvent): string {
+  return event.attributes?.["catalyst.orchestrator.id"] ?? "";
+}
+
+export function formatWorker(event: CanonicalEvent): string {
+  return event.attributes?.["catalyst.worker.ticket"] ?? "";
+}
+
+// CTL-344 made every canonical event carry a UUIDv4 .id. The full UUID is too
+// long for an inline column; the first 8 chars are still unique enough to
+// correlate against the `lookup_jq` query in source_events.
+export function formatEventIdShort(event: CanonicalEvent): string {
+  const id = event.id;
+  if (!id) return "";
+  return id.slice(0, 8);
+}
+
 export function formatRef(event: CanonicalEvent): string {
   const name = event.attributes?.["event.name"];
   if (name === "comms.message.posted") {
@@ -266,16 +303,46 @@ export function formatDetails(event: CanonicalEvent): string {
   if (cached !== undefined) return cached;
   const name = event.attributes?.["event.name"];
   const payload = event.body?.payload;
-  // CTL-348: filter.wake.* events carry a human-readable reason and an array of
-  // source event ids. Render "wake → ${reason_short}" with an optional "(n)"
-  // suffix when more than one source event triggered the wake so operators can
-  // tell *why* the broker woke the orchestrator instead of seeing a blank cell.
+  // CTL-348/CTL-350: filter.wake.* events render their triggering context so
+  // operators can see *why* the broker woke an orchestrator. When the wake
+  // carries structured source_events (CTL-350 Phase 2), prefer those fields
+  // over the Groq reason string — they're authoritative and pre-extracted.
+  // Falls back to reason-based rendering for legacy events emitted before
+  // Phase 2. The 40-char truncation from CTL-348 is removed; Phase 3's
+  // <Text wrap="wrap"> on the DETAILS column handles overflow at render time.
   if (name?.startsWith("filter.wake.") || name?.startsWith("orchestrator.filter.wake.")) {
     const p = payload as Record<string, unknown> | undefined;
+    const sourceEvents = Array.isArray(p?.["source_events"])
+      ? (p["source_events"] as Array<Record<string, unknown>>)
+      : [];
+    if (sourceEvents.length > 0) {
+      const first = sourceEvents[0] ?? {};
+      const evName = typeof first["name"] === "string" ? first["name"] : "event";
+      const ticket = typeof first["ticket"] === "string" ? first["ticket"] : null;
+      const pr = first["pr"];
+      const ref = ticket
+        ?? (typeof pr === "number" || (typeof pr === "string" && pr.length > 0) ? `#${pr}` : "");
+      const excerpt = first["payload_excerpt"] as Record<string, unknown> | undefined;
+      const state = excerpt?.["state"] ?? excerpt?.["conclusion"] ?? excerpt?.["action"];
+      // Only stringify primitives so we never render "[object Object]" if a
+      // future producer puts a nested shape under one of these excerpt keys.
+      const isPrimitive =
+        typeof state === "string"
+        || typeof state === "number"
+        || typeof state === "boolean";
+      const stateSuffix = isPrimitive ? ` → ${String(state)}` : "";
+      const countSuffix = sourceEvents.length > 1 ? ` (${sourceEvents.length})` : "";
+      const out = `wake ← ${evName}${ref ? ` ${ref}` : ""}${stateSuffix}${countSuffix}`
+        .replace(/\s+/g, " ")
+        .trim();
+      const sanitized = sanitize(out, "oneline");
+      detailsCache.set(event, sanitized);
+      return sanitized;
+    }
     const reasonRaw = typeof p?.["reason"] === "string" ? p["reason"] : "";
     const ids = p?.["source_event_ids"];
     const count = Array.isArray(ids) ? ids.length : 0;
-    const reasonShort = sanitize(reasonRaw, "oneline").slice(0, 40);
+    const reasonShort = sanitize(reasonRaw, "oneline");
     const suffix = count > 1 ? ` (${count})` : "";
     const out = reasonShort ? `wake → ${reasonShort}${suffix}` : `wake${suffix}`;
     detailsCache.set(event, out);


### PR DESCRIPTION
## Summary

Five-phase rework that fixes four observed problems in the broker + HUD observability stack:

1. **`prose-*` test residue** — `broker/index.test.mjs` previously registered test interests through the production `~/catalyst/broker-interests.json` path, leaving entries like `prose-7` to be included in every Groq classification batch. Now `INTERESTS_FILE` resolves per call from `CATALYST_DIR` (tests redirect to tmpdir), and `loadPersistedInterests` skips any entry whose `session_id` matches `/^sess-prose-\d+$/`.

2. **Wake events lacked triggering-event context** — `source_event_ids` carried UUIDs that receivers discarded before re-fetching authoritative state from GitHub/Linear/git. New `summarizeEvent` helper inlines `{id, name, ts, ticket, pr, repo, message, payload_excerpt, lookup_jq}` into every wake (deterministic + prose + watchdog paths). Receivers can act without re-fetching; `lookup_jq` is a ready-to-run `jq` query for callers that do need full event data.

3. **Hard-coded HUD column widths** — `EventRow.tsx` used `.padEnd(N)` strings, defeating Ink's flex layout and truncating `orch-adv-925-2026-05-12` to `orch-adv-`. New `cli/lib/column-widths.ts` module is the single source of truth; both `EventRow` and `Header` read from it. DETAILS uses `flexGrow={1}` + `wrap="wrap"`. STATUS (≥100), ORCH (≥160), WORKER (≥180), EVENT-ID (≥200) columns appear at successive width thresholds.

4. **`formatDetails` prefers `source_events`** — wake rows now render `wake ← linear.issue.state_changed ADV-87 → Done` when structured data is present; falls back to `wake → {reason}` for legacy wakes. 40-char truncation removed (Phase 3 wrap handles overflow).

5. **`DetailPane` event-id + source_events promotion** — `event-id` labeled field appears above `trace`/`span`. `source_events` array promoted from raw JSON dump to labeled rows including a copy-paste-able `lookup` query.

Plan: \`thoughts/shared/plans/2026-05-12-hud-broker-observability-rework.md\`
Research: \`thoughts/shared/research/2026-05-12-hud-columns-and-wake-event-details.md\`
Related: CTL-344 (per-event UUID), CTL-348 (wake target in HUD), CTL-340 (Groq suppression), CTL-331 (broker envelopes)

## One-time data cleanup

After this PR merges, run on hosts that have a live broker:

\`\`\`bash
plugins/dev/scripts/clean-prose-interests.sh
catalyst-monitor restart
\`\`\`

This removes any historical \`sess-prose-\d+\` entries from \`~/catalyst/broker-interests.json\`. The load-time guard in this PR makes it idempotent — re-running on a clean file is a no-op.

## Test plan

- [x] \`bun test plugins/dev/scripts/broker\` — 121 pass, 0 fail (includes new \`prose-*\` isolation + \`source_events\` inlining tests)
- [x] \`bun test plugins/dev/scripts/orch-monitor/__tests__/{hud-format,column-widths,detail-pane-source-events,detail-pane-title}.test.ts\` — 140 pass, 0 fail
- [x] \`bun run lint\` (orch-monitor) — 0 errors
- [x] Pre-existing failures in \`catalyst-monitor.sh\` daemon tests and one \`session-store.ts\` test are unrelated (same on \`main\`)
- [ ] Manual: open \`catalyst-hud\` in 80-col terminal — layout unchanged
- [ ] Manual: open \`catalyst-hud\` in 200-col terminal — ORCH, STATUS, WORKER, EVENT-ID columns visible; orchestrator IDs full
- [ ] Manual: trigger a Linear ticket state change against a watching orchestrator — wake row renders \`wake ← linear.issue.state_changed ADV-87 → Done\`; press Enter on the wake row — DetailPane shows \`event-id\`, structured \`source_events\` rows, copy-paste-able \`lookup\`