### PR TITLE
fix(dev): HUD polish + broker.daemon.shutdown event (CTL-351)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -1426,18 +1426,38 @@ function main() {
     log.warn({ err: err.message }, "probe error suppressed");
   });
 
-  const shutdown = () => {
+  const shutdown = (signal) => {
     eventsWatcher?.close();
     clearInterval(watchdogId);
     clearTimeout(debounceTimer);
     clearTimeout(hardCapTimer);
+    // CTL-351: emit a parallel shutdown event so subscribers can pair
+    // broker.daemon.startup/broker.daemon.shutdown and switch their
+    // catalyst-events wait-for path to REST polling while the daemon is down.
+    // appendEvent is synchronous (appendFileSync) so the event is flushed
+    // before process.exit, even though the rest of shutdown is best-effort.
+    try {
+      appendEvent({
+        event: "broker.daemon.shutdown",
+        orchestrator: null,
+        worker: null,
+        detail: {
+          pid: process.pid,
+          signal: typeof signal === "string" ? signal : null,
+          active_interests: interests.size,
+          broker: true,
+        },
+      });
+    } catch {
+      // Best-effort — never block shutdown on telemetry.
+    }
     closeBrokerStateDb();
     removePidFile();
     try { unlinkSync(BROKER_STATE_FILE); } catch { /* already gone */ }
     process.exit(0);
   };
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -931,6 +931,14 @@ describe("shouldSkipEvent — broker self-emission guards (CTL-346)", () => {
     })).toBe(true);
   });
 
+  // CTL-351: broker.daemon.shutdown follows the same self-emission pattern.
+  test("skips canonical broker.daemon.shutdown event", () => {
+    expect(shouldSkipEvent({
+      attributes: { "event.name": "broker.daemon.shutdown" },
+      resource: { "service.name": "catalyst.broker" },
+    })).toBe(true);
+  });
+
   test("skips any event with resource.service.name == catalyst.broker", () => {
     // Defense-in-depth: future broker.* event names still get skipped.
     expect(shouldSkipEvent({

--- a/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
@@ -42,7 +42,10 @@ describe("computeColumnWidths", () => {
     const w = computeColumnWidths(100);
     expect(w.showStatus).toBe(true);
     expect(w.showOrch).toBe(false);
-    expect(w.status).toBe(2);
+    // CTL-351: ⏳ (U+23F3) renders 2 cells wide in most terminals; +1 trailing
+    // gutter = 3-wide status column so the glyph never pushes following
+    // columns right on in-progress rows.
+    expect(w.status).toBe(3);
   });
 
   test("at 160 cols enables STATUS + ORCH", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventList.tsx
@@ -9,6 +9,10 @@ interface EventListProps {
   visibleRows: number;
   columns: number;
   compact?: boolean;
+  // CTL-351: paused = !autoFollow. Plumbed through to EventRow so the
+  // selection cursor is invisible in live mode and revealed once the user
+  // navigates via Up/Down (which pauses autoFollow inside useSelection).
+  paused?: boolean;
 }
 
 export function EventList({
@@ -18,6 +22,7 @@ export function EventList({
   visibleRows,
   columns,
   compact,
+  paused = true,
 }: EventListProps) {
   const visible = events.slice(scrollOffset, scrollOffset + visibleRows);
 
@@ -29,6 +34,7 @@ export function EventList({
           event={event}
           selected={scrollOffset + i === selectedIndex}
           columns={columns}
+          paused={paused}
         />
       ))}
     </Box>

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -19,6 +19,10 @@ interface EventRowProps {
   event: CanonicalEvent;
   selected: boolean;
   columns: number;
+  // CTL-351: cursor is only meaningful when the user has paused live tailing.
+  // EventList passes the inverse of autoFollow so the row knows whether to
+  // render an inverse-video cursor. In live mode the cursor is invisible.
+  paused?: boolean;
 }
 
 // CTL-350: column widths come from a shared module so EventRow and Header
@@ -27,47 +31,51 @@ interface EventRowProps {
 // Ink's flex layout and forced orchestrator IDs to chop at `orch-adv-` on
 // wide terminals. DETAILS uses `flexGrow={1}` + `wrap="wrap"` so a long
 // Groq reason wraps to multiple lines instead of being silently clipped.
-export function EventRow({ event, selected, columns }: EventRowProps) {
+// CTL-351: every fixed-width column has a 1-col right margin so the columns
+// breathe and abutting cells (TIME↔REPO, EVENT↔REF) don't visually run
+// together on rows with short content.
+export function EventRow({ event, selected, columns, paused = true }: EventRowProps) {
   const color = getRowColor(event);
   // Inverse video swaps fg/bg at the terminal level (ANSI SGR 7), guaranteeing
-  // contrast across themes without composing same-family fg/bg pairs.
-  const inverse = selected;
+  // contrast across themes without composing same-family fg/bg pairs. Hidden
+  // in live mode so the cursor doesn't distract from streaming events.
+  const inverse = selected && paused;
   const w = computeColumnWidths(columns);
 
   return (
     <Box flexDirection="row">
       {w.showStatus && (
-        <Box width={w.status} flexShrink={0}>
+        <Box width={w.status} flexShrink={0} marginRight={1}>
           <Text color={color} inverse={inverse}>{formatStatus(event)}</Text>
         </Box>
       )}
-      <Box width={w.time} flexShrink={0}>
+      <Box width={w.time} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{formatTime(event)}</Text>
       </Box>
-      <Box width={w.repo} flexShrink={0}>
+      <Box width={w.repo} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{formatRepo(event)}</Text>
       </Box>
-      <Box width={w.source} flexShrink={0}>
+      <Box width={w.source} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{formatSource(event)}</Text>
       </Box>
-      <Box width={w.event} flexShrink={0}>
+      <Box width={w.event} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{formatEvent(event)}</Text>
       </Box>
-      <Box width={w.ref} flexShrink={0}>
+      <Box width={w.ref} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{formatRef(event)}</Text>
       </Box>
       {w.showOrch && (
-        <Box width={w.orch} flexShrink={0}>
+        <Box width={w.orch} flexShrink={0} marginRight={1}>
           <Text color={color} inverse={inverse}>{formatOrch(event)}</Text>
         </Box>
       )}
       {w.showWorker && (
-        <Box width={w.worker} flexShrink={0}>
+        <Box width={w.worker} flexShrink={0} marginRight={1}>
           <Text color={color} inverse={inverse}>{formatWorker(event)}</Text>
         </Box>
       )}
       {w.showEventId && (
-        <Box width={w.eventId} flexShrink={0}>
+        <Box width={w.eventId} flexShrink={0} marginRight={1}>
           <Text color={color} inverse={inverse} dimColor>{formatEventIdShort(event)}</Text>
         </Box>
       )}

--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -9,6 +9,8 @@ interface HeaderProps {
   brokerKeyHealth?: BrokerKeyHealth | null;
 }
 
+// CTL-351: match EventRow's per-column 1-col right margin so the header
+// labels align with the row content below them at every terminal width.
 export function Header({ columns = 120, nlQuery, brokerKeyHealth }: HeaderProps) {
   const sep = "─".repeat(Math.max(0, columns - 1));
   const groq = brokerKeyHealth?.groq;
@@ -25,37 +27,37 @@ export function Header({ columns = 120, nlQuery, brokerKeyHealth }: HeaderProps)
       )}
       <Box flexDirection="row">
         {w.showStatus && (
-          <Box width={w.status} flexShrink={0}>
-            <Text bold color="cyan">{"S "}</Text>
+          <Box width={w.status} flexShrink={0} marginRight={1}>
+            <Text bold color="cyan">{"S"}</Text>
           </Box>
         )}
-        <Box width={w.time} flexShrink={0}>
+        <Box width={w.time} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"TIME"}</Text>
         </Box>
-        <Box width={w.repo} flexShrink={0}>
+        <Box width={w.repo} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"REPO"}</Text>
         </Box>
-        <Box width={w.source} flexShrink={0}>
+        <Box width={w.source} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"SOURCE"}</Text>
         </Box>
-        <Box width={w.event} flexShrink={0}>
+        <Box width={w.event} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"EVENT"}</Text>
         </Box>
-        <Box width={w.ref} flexShrink={0}>
+        <Box width={w.ref} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"REF"}</Text>
         </Box>
         {w.showOrch && (
-          <Box width={w.orch} flexShrink={0}>
+          <Box width={w.orch} flexShrink={0} marginRight={1}>
             <Text bold color="cyan">{"ORCH"}</Text>
           </Box>
         )}
         {w.showWorker && (
-          <Box width={w.worker} flexShrink={0}>
+          <Box width={w.worker} flexShrink={0} marginRight={1}>
             <Text bold color="cyan">{"WORKER"}</Text>
           </Box>
         )}
         {w.showEventId && (
-          <Box width={w.eventId} flexShrink={0}>
+          <Box width={w.eventId} flexShrink={0} marginRight={1}>
             <Text bold color="cyan">{"EVENT-ID"}</Text>
           </Box>
         )}

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -382,6 +382,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           visibleRows={listRows}
           columns={cols}
           compact={inDetailMode || showHelp}
+          paused={!autoFollow}
         />
       </Box>
       {inDetailMode && selectedEvent && (

--- a/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
@@ -8,7 +8,9 @@
  * sizing — both row and header read from it so they cannot drift apart.
  *
  * Optional columns appear at successive terminal-width thresholds:
- *   STATUS    ≥100 cols   one-glyph success/failure/in-progress indicator
+ *   STATUS    ≥100 cols   one-glyph success/failure/in-progress indicator.
+ *                         3 cells wide because ⏳ (U+23F3) renders 2 cells
+ *                         in most terminals and we want a trailing gutter.
  *   ORCH      ≥160 cols   full catalyst.orchestrator.id
  *   WORKER    ≥180 cols   catalyst.worker.ticket
  *   EVENT-ID  ≥200 cols   first 8 chars of the per-event UUIDv4 (CTL-344)
@@ -40,7 +42,7 @@ export function computeColumnWidths(columns: number): ColumnWidths {
   const showWorker = columns >= 180;
   const showEventId = columns >= 200;
   return {
-    status: showStatus ? 2 : 0,
+    status: showStatus ? 3 : 0,
     time: 10,
     repo: Math.min(14, Math.max(10, Math.floor(columns * 0.07))),
     source: Math.min(22, Math.max(16, Math.floor(columns * 0.1))),


### PR DESCRIPTION
## Summary

Follow-up to CTL-350 based on screenshot review. Four small ergonomics fixes bundled because they all touch HUD layout and broker observability.

1. **STATUS column width** — ⏳ (U+23F3) renders 2 cells wide, pushing following columns right on in-progress rows. Bumps STATUS width from 2→3 in `computeColumnWidths` so the glyph fits with a trailing gutter at every terminal width.
2. **Column gutters** — adds `marginRight={1}` to every fixed-width column in `EventRow` and `Header` so TIME↔REPO and EVENT↔REF stop visually running together. Header's `"S "` label trims to `"S"` since the gutter now handles the spacing.
3. **Selection highlight only when paused** — `EventList` plumbs `paused` (= `!autoFollow`) through to `EventRow`, where the inverse-video cursor is gated on `selected && paused`. In live mode the cursor is invisible; `Up/k` pauses autoFollow and reveals it; `G` re-enters live mode and hides it.
4. **`broker.daemon.shutdown` event** — the broker emits `broker.daemon.startup` on launch but nothing on clean shutdown. Adds a parallel synchronous `appendEvent` in the SIGINT/SIGTERM handler so subscribers can pair the two and switch back to REST polling while the daemon is down. `appendEvent` is `appendFileSync`, so the event is flushed before `process.exit(0)`.

Linear: https://linear.app/coalesce-labs/issue/CTL-351

## Test plan

- [x] `bun test __tests__/column-widths.test.ts` (17 pass) — `w.status === 3` at ≥100 cols
- [x] `bun test plugins/dev/scripts/broker/index.test.mjs` (80 pass) — adds `shouldSkipEvent` coverage for `broker.daemon.shutdown` mirroring the existing `broker.daemon.startup` test
- [x] `bun test __tests__/canonical-event.test.ts __tests__/hud-format.test.ts __tests__/event-bus.test.ts` (142 pass) — no regressions in adjacent HUD-render tests
- [ ] Manual: open the HUD live, confirm columns no longer abut at typical widths, ⏳ doesn't push other columns right, cursor is invisible until `Up`/`k` and reappears, `G` makes it disappear again
- [ ] Manual: `kill -INT $(cat ~/catalyst/broker.pid)`, confirm `broker.daemon.shutdown` row appears in event log