### PR TITLE
fix(dev): HUD in-progress glyph uses Nerd Font when available, else ellipsis (CTL-353)

### DIFF
--- a/plugins/dev/scripts/install-nerd-fonts.sh
+++ b/plugins/dev/scripts/install-nerd-fonts.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# CTL-353: One-shot installer for a Nerd Font + fontconfig on macOS/Linux.
+#
+# After running, restart your terminal and (if applicable) set the terminal's
+# font to the installed Nerd Font (e.g. "Hack Nerd Font Mono") so that PUA
+# glyphs render. The HUD's runtime detection probes fc-list and the system
+# font directories, so any installed Nerd Font works — Hack is just the
+# default this script installs.
+
+set -euo pipefail
+
+CASK="${CATALYST_NERD_FONT_CASK:-font-hack-nerd-font}"
+
+echo "==> catalyst nerd-font installer"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "ERROR: brew is required on macOS. Install from https://brew.sh and rerun." >&2
+    exit 1
+  fi
+  # fontconfig provides `fc-list`, which is the HUD's primary detection probe.
+  if ! command -v fc-list >/dev/null 2>&1; then
+    echo "==> installing fontconfig (provides fc-list)"
+    brew install fontconfig
+  fi
+  if brew list --cask "$CASK" >/dev/null 2>&1; then
+    echo "==> $CASK already installed"
+  else
+    echo "==> installing cask $CASK"
+    brew install --cask "$CASK"
+  fi
+elif [[ "$(uname -s)" == "Linux" ]]; then
+  # Most distros ship fc-list in fontconfig; user installs Nerd Fonts manually.
+  if ! command -v fc-list >/dev/null 2>&1; then
+    echo "ERROR: install fontconfig (provides fc-list), then rerun. " >&2
+    echo "  apt:    sudo apt install fontconfig" >&2
+    echo "  dnf:    sudo dnf install fontconfig" >&2
+    echo "  pacman: sudo pacman -S fontconfig" >&2
+    exit 1
+  fi
+  if fc-list 2>/dev/null | grep -qi "nerd font"; then
+    echo "==> a Nerd Font is already installed (fc-list)"
+  else
+    cat <<'EOF'
+==> No Nerd Font detected. Linux installation isn't automated by this script.
+
+   Recommended: download a release ZIP from
+     https://github.com/ryanoasis/nerd-fonts/releases/latest
+   Then:
+     mkdir -p ~/.local/share/fonts
+     unzip Hack.zip -d ~/.local/share/fonts
+     fc-cache -fv
+EOF
+    exit 1
+  fi
+else
+  echo "ERROR: unsupported platform $(uname -s). Install a Nerd Font manually." >&2
+  exit 1
+fi
+
+echo ""
+echo "==> verifying detection"
+if command -v fc-list >/dev/null 2>&1; then
+  if fc-list 2>/dev/null | grep -qi "nerd font"; then
+    echo "    fc-list confirms a Nerd Font is installed."
+  else
+    echo "    WARN: fc-list didn't see a Nerd Font yet — your shell may need to be restarted."
+  fi
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Set your terminal's font to the installed Nerd Font (e.g. 'Hack Nerd Font Mono')."
+echo "  2. Restart your terminal (or open a new tab)."
+echo "  3. Run 'catalyst-hud' — the startup banner will say 'nerdfont detected'."
+echo ""
+echo "To force-enable or disable detection at runtime:"
+echo "  CATALYST_NERD_FONT=1 catalyst-hud   # force on"
+echo "  CATALYST_NERD_FONT=0 catalyst-hud   # force off (use ellipsis fallback)"

--- a/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
@@ -130,6 +130,49 @@ describe("status/orch/worker/event-id formatters", () => {
     expect(formatStatus(makeEvent())).toBe("· ");
   });
 
+  // CTL-353: in-progress uses Nerd Font when available, else "…". Both
+  // branches return a 2-char string (1-cell glyph + trailing space).
+  test("formatStatus: in_progress conclusion → '… ' when CATALYST_NERD_FONT=0", async () => {
+    const { _resetNerdFontCacheForTesting } = await import("../cli/lib/nerd-font.ts");
+    const prev = process.env.CATALYST_NERD_FONT;
+    process.env.CATALYST_NERD_FONT = "0";
+    _resetNerdFontCacheForTesting();
+    try {
+      const result = formatStatus(makeEvent({
+        attributes: {
+          "event.name": "github.workflow_run.in_progress",
+          "cicd.pipeline.run.conclusion": "in_progress",
+        },
+      }));
+      expect(result).toBe("… ");
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_NERD_FONT;
+      else process.env.CATALYST_NERD_FONT = prev;
+      _resetNerdFontCacheForTesting();
+    }
+  });
+
+  test("formatStatus: in_progress conclusion → PUA hourglass when CATALYST_NERD_FONT=1", async () => {
+    const { _resetNerdFontCacheForTesting } = await import("../cli/lib/nerd-font.ts");
+    const prev = process.env.CATALYST_NERD_FONT;
+    process.env.CATALYST_NERD_FONT = "1";
+    _resetNerdFontCacheForTesting();
+    try {
+      const result = formatStatus(makeEvent({
+        attributes: {
+          "event.name": "github.workflow_run.in_progress",
+          "cicd.pipeline.run.conclusion": "in_progress",
+        },
+      }));
+      expect(result.codePointAt(0)).toBe(0xf252);
+      expect(result.charAt(1)).toBe(" ");
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_NERD_FONT;
+      else process.env.CATALYST_NERD_FONT = prev;
+      _resetNerdFontCacheForTesting();
+    }
+  });
+
   test("formatOrch returns the orchestrator id when present, else empty", () => {
     expect(
       formatOrch(makeEvent({

--- a/plugins/dev/scripts/orch-monitor/__tests__/nerd-font.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nerd-font.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  detectNerdFont,
+  inProgressGlyph,
+  NERD_FONT_IN_PROGRESS,
+  FALLBACK_IN_PROGRESS,
+  _resetNerdFontCacheForTesting,
+} from "../cli/lib/nerd-font.ts";
+
+describe("nerd-font (CTL-353)", () => {
+  const prevEnv = process.env.CATALYST_NERD_FONT;
+
+  beforeEach(() => {
+    _resetNerdFontCacheForTesting();
+  });
+
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.CATALYST_NERD_FONT;
+    else process.env.CATALYST_NERD_FONT = prevEnv;
+    _resetNerdFontCacheForTesting();
+  });
+
+  test("CATALYST_NERD_FONT=1 forces detected=true (env source)", () => {
+    process.env.CATALYST_NERD_FONT = "1";
+    const d = detectNerdFont();
+    expect(d.detected).toBe(true);
+    expect(d.source).toBe("env");
+    expect(inProgressGlyph()).toBe(NERD_FONT_IN_PROGRESS);
+  });
+
+  test("CATALYST_NERD_FONT=0 forces detected=false (env source)", () => {
+    process.env.CATALYST_NERD_FONT = "0";
+    const d = detectNerdFont();
+    expect(d.detected).toBe(false);
+    expect(d.source).toBe("env");
+    expect(inProgressGlyph()).toBe(FALLBACK_IN_PROGRESS);
+  });
+
+  test("accepts true/false/yes/no/on/off as boolean overrides", () => {
+    for (const val of ["true", "TRUE", "yes", "on"]) {
+      _resetNerdFontCacheForTesting();
+      process.env.CATALYST_NERD_FONT = val;
+      expect(detectNerdFont().detected).toBe(true);
+    }
+    for (const val of ["false", "FALSE", "no", "off"]) {
+      _resetNerdFontCacheForTesting();
+      process.env.CATALYST_NERD_FONT = val;
+      expect(detectNerdFont().detected).toBe(false);
+    }
+  });
+
+  test("invalid env override falls through to system probe (not 'env' source)", () => {
+    process.env.CATALYST_NERD_FONT = "maybe";
+    const d = detectNerdFont();
+    // We don't assert detected here — it depends on whether the test machine
+    // actually has a Nerd Font installed. We just assert that "maybe" did NOT
+    // route through the env path.
+    expect(d.source).not.toBe("env");
+  });
+
+  test("detection result is cached across calls", () => {
+    process.env.CATALYST_NERD_FONT = "1";
+    const a = detectNerdFont();
+    delete process.env.CATALYST_NERD_FONT;
+    const b = detectNerdFont();
+    // Without explicit reset, the second call returns the cached result —
+    // even though the env var is now gone.
+    expect(b).toEqual(a);
+  });
+
+  test("hint is always a non-empty string", () => {
+    process.env.CATALYST_NERD_FONT = "1";
+    expect(detectNerdFont().hint.length).toBeGreaterThan(0);
+    _resetNerdFontCacheForTesting();
+    process.env.CATALYST_NERD_FONT = "0";
+    expect(detectNerdFont().hint.length).toBeGreaterThan(0);
+  });
+
+  test("NERD_FONT_IN_PROGRESS is the BMP nf-fa-hourglass_half glyph (U+F252)", () => {
+    expect(NERD_FONT_IN_PROGRESS.codePointAt(0)).toBe(0xf252);
+    expect(NERD_FONT_IN_PROGRESS.length).toBe(1);
+  });
+
+  test("FALLBACK_IN_PROGRESS is U+2026 horizontal ellipsis", () => {
+    expect(FALLBACK_IN_PROGRESS.codePointAt(0)).toBe(0x2026);
+    expect(FALLBACK_IN_PROGRESS.length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -15,6 +15,7 @@ import {
 import { useEventLog } from "./hooks/useEventLog.ts";
 import { useFilter, type DslPredicate } from "./hooks/useFilter.ts";
 import { useSelection } from "./hooks/useSelection.ts";
+import { detectNerdFont } from "./lib/nerd-font.ts";
 import {
   compile,
   groqTranslate,
@@ -478,6 +479,17 @@ if (!process.stdin.isTTY) {
     "Open a fresh terminal tab and run catalyst-hud there.\n",
   );
   process.exit(1);
+}
+
+// CTL-353: log Nerd Font detection so the user knows whether they're seeing
+// the upgraded single-cell PUA in-progress glyph or the ellipsis fallback.
+// Writes to stderr before Ink's alternate-screen takes over — visible in the
+// parent shell's scrollback after the HUD exits.
+const nerd = detectNerdFont();
+if (nerd.detected) {
+  process.stderr.write(`catalyst-hud: nerdfont detected (${nerd.source}: ${nerd.hint})\n`);
+} else {
+  process.stderr.write(`catalyst-hud: nerdfont ${nerd.hint}\n`);
 }
 
 render(<App repoFilter={repoFilter} predicate={predicate} sinceTs={sinceTs} />);

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -1,4 +1,5 @@
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
+import { inProgressGlyph } from "./nerd-font.ts";
 
 const SKIP_EVENTS = new Set([
   "session.heartbeat",
@@ -127,6 +128,10 @@ export function formatEvent(event: CanonicalEvent): string {
 // even when the terminal applies bold/inverse styling. CI conclusion drives
 // the glyph for check_suite/check_run events; severity is the fallback for
 // everything else so error/warn rows still get a visible marker.
+// CTL-353: in-progress glyph routes through inProgressGlyph() so terminals
+// with a Nerd Font get a single-cell PUA hourglass and everything else gets a
+// single-cell ellipsis. The old ⏳ (U+23F3) is unreliable because terminals
+// disagree on its East Asian width.
 export function formatStatus(event: CanonicalEvent): string {
   const attrs = event.attributes ?? ({} as CanonicalEvent["attributes"]);
   const conclusion = attrs["cicd.pipeline.run.conclusion"];
@@ -134,7 +139,7 @@ export function formatStatus(event: CanonicalEvent): string {
   if (conclusion === "failure" || conclusion === "cancelled") return "✗ ";
   const name = attrs["event.name"];
   if (conclusion === "in_progress" || (typeof name === "string" && name.includes(".in_progress"))) {
-    return "⏳";
+    return `${inProgressGlyph()} `;
   }
   const sev = event.severityText;
   if (sev === "ERROR") return "✗ ";

--- a/plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts
@@ -1,0 +1,142 @@
+/**
+ * CTL-353: Nerd Font detection for HUD status glyphs.
+ *
+ * The CTL-351 STATUS column moved from width 2 → 3 to accommodate ⏳ (U+23F3),
+ * but ⏳ still renders jaggedly because its East_Asian_Width is N while its
+ * Emoji_Presentation is Yes — terminals disagree on whether to give it 1 or 2
+ * cells. The other status glyphs (✓ ✗ · !) are stable single-cell.
+ *
+ * Fix: when a Nerd Font is installed, render in-progress as a Private Use
+ * Area icon (U+F252 nf-fa-hourglass_half) which is guaranteed single-cell in
+ * any monospaced font that includes the Nerd Fonts patch. Otherwise fall back
+ * to "…" (U+2026 horizontal ellipsis), also guaranteed single-cell.
+ *
+ * Detection precedence:
+ *   1. CATALYST_NERD_FONT=1|0|true|false env override (CI / explicit user pref)
+ *   2. fc-list output containing "Nerd Font" (fontconfig — most reliable, works
+ *      on macOS via brew install fontconfig)
+ *   3. ~/Library/Fonts and /Library/Fonts on darwin (fallback when fontconfig
+ *      isn't installed)
+ *   4. /usr/share/fonts and /usr/local/share/fonts on linux (rare fallback)
+ *
+ * Detection runs once at module load; the result is cached in a module-level
+ * variable so EventRow's per-row formatStatus call is a single property read.
+ */
+
+import { execSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface NerdFontDetection {
+  detected: boolean;
+  source: "env" | "fc-list" | "darwin-fonts-dir" | "linux-fonts-dir" | "none";
+  // Human-readable hint for the startup log. e.g. "Hack Nerd Font Mono" or
+  // "set CATALYST_NERD_FONT=1 to force enable" — never null so the caller
+  // can log unconditionally.
+  hint: string;
+}
+
+// CTL-353: U+F252 is nf-fa-hourglass_half — BMP, single-cell, semantically
+// matches ⏳. PUA codepoints are only meaningful when the terminal font is a
+// Nerd Font, so we always pair this with a detection check.
+export const NERD_FONT_IN_PROGRESS = "";
+
+// Single-cell ellipsis fallback (East_Asian_Width=N, Emoji_Presentation=No, so
+// every terminal gives it exactly 1 cell).
+export const FALLBACK_IN_PROGRESS = "…";
+
+function readEnvOverride(): boolean | null {
+  const raw = process.env.CATALYST_NERD_FONT;
+  if (raw === undefined || raw === "") return null;
+  const norm = raw.trim().toLowerCase();
+  if (norm === "1" || norm === "true" || norm === "yes" || norm === "on") return true;
+  if (norm === "0" || norm === "false" || norm === "no" || norm === "off") return false;
+  return null;
+}
+
+function probeFcList(): { hit: boolean; firstMatch?: string } {
+  try {
+    const out = execSync("fc-list 2>/dev/null", {
+      encoding: "utf8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const lines = out.split("\n");
+    const match = lines.find((line) => /nerd font/i.test(line));
+    if (match) {
+      const family = match.split(":")[1]?.trim() ?? "Nerd Font";
+      return { hit: true, firstMatch: family };
+    }
+    return { hit: false };
+  } catch {
+    return { hit: false };
+  }
+}
+
+function probeFontsDirs(dirs: string[]): { hit: boolean; firstMatch?: string } {
+  for (const dir of dirs) {
+    try {
+      const files = readdirSync(dir);
+      const match = files.find((f) => /nerd ?font/i.test(f));
+      if (match) return { hit: true, firstMatch: match };
+    } catch {
+      // Directory doesn't exist or isn't readable — try the next one.
+    }
+  }
+  return { hit: false };
+}
+
+function runDetection(): NerdFontDetection {
+  const override = readEnvOverride();
+  if (override !== null) {
+    return {
+      detected: override,
+      source: "env",
+      hint: `CATALYST_NERD_FONT=${override ? "1" : "0"}`,
+    };
+  }
+
+  const fc = probeFcList();
+  if (fc.hit) {
+    return { detected: true, source: "fc-list", hint: fc.firstMatch ?? "Nerd Font (fc-list)" };
+  }
+
+  if (process.platform === "darwin") {
+    const userFonts = join(homedir(), "Library", "Fonts");
+    const dir = probeFontsDirs([userFonts, "/Library/Fonts"]);
+    if (dir.hit) {
+      return { detected: true, source: "darwin-fonts-dir", hint: dir.firstMatch ?? "Nerd Font" };
+    }
+  } else if (process.platform === "linux") {
+    const userFonts = join(homedir(), ".local", "share", "fonts");
+    const dir = probeFontsDirs([userFonts, "/usr/share/fonts", "/usr/local/share/fonts"]);
+    if (dir.hit) {
+      return { detected: true, source: "linux-fonts-dir", hint: dir.firstMatch ?? "Nerd Font" };
+    }
+  }
+
+  return {
+    detected: false,
+    source: "none",
+    hint: "no Nerd Font detected — set CATALYST_NERD_FONT=1 to override or install via plugins/dev/scripts/install-nerd-fonts.sh",
+  };
+}
+
+let cached: NerdFontDetection | null = null;
+
+/** Cached detection. First call probes the system; subsequent calls return the cached result. */
+export function detectNerdFont(): NerdFontDetection {
+  if (cached === null) cached = runDetection();
+  return cached;
+}
+
+/** Test-only: reset the cache so unit tests can exercise the env-override path repeatedly. */
+export function _resetNerdFontCacheForTesting(): void {
+  cached = null;
+}
+
+/** Returns the in-progress glyph appropriate for the current terminal/font. */
+export function inProgressGlyph(): string {
+  return detectNerdFont().detected ? NERD_FONT_IN_PROGRESS : FALLBACK_IN_PROGRESS;
+}


### PR DESCRIPTION
## Summary

Follow-up to CTL-351. The in-progress glyph ⏳ (U+23F3) still rendered jaggedly across terminals because it has `Emoji_Presentation=Yes` but `East_Asian_Width=N` — some terminals treat it as 1 cell, others as 2.

- **New `cli/lib/nerd-font.ts`** — detects Nerd Font via `CATALYST_NERD_FONT` env override, then `fc-list`, then `~/Library/Fonts` (darwin) / `~/.local/share/fonts` (linux). Result is cached. Exports `inProgressGlyph()` which returns `` (U+F252 `nf-fa-hourglass_half`, BMP, single-cell) when detected, else `…` (U+2026 horizontal ellipsis).
- **`formatStatus`** now routes the in-progress branch through `inProgressGlyph()` with a trailing space — both code paths return a 2-char visual string, matching the existing ✓/✗/!/· width contract.
- **HUD startup log** — `hud.tsx` writes the detection result to stderr right before `render()`. Visible in scrollback after Ink's alternate-screen exits. e.g. `catalyst-hud: nerdfont detected (fc-list: Hack Nerd Font Mono:style=Regular)` or `catalyst-hud: nerdfont no Nerd Font detected — set CATALYST_NERD_FONT=1 to override or install via plugins/dev/scripts/install-nerd-fonts.sh`.
- **`scripts/install-nerd-fonts.sh`** — opt-in installer wrapping `brew install --cask font-hack-nerd-font` plus fontconfig on darwin, prints guidance for linux. `chmod +x`, syntax-checked.
- **Tests** — `nerd-font.test.ts` covers env override (1/0/true/false/yes/no/on/off, invalid → falls through), cache behavior, codepoint sanity. `column-widths.test.ts` adds two in-progress branches for `formatStatus` (fallback + Nerd Font), each pinned via `CATALYST_NERD_FONT`.

Linear: https://linear.app/coalesce-labs/issue/CTL-353

## Test plan

- [x] `bun test __tests__/nerd-font.test.ts __tests__/column-widths.test.ts __tests__/hud-format.test.ts __tests__/canonical-event.test.ts` → 165 pass
- [ ] Manual: `CATALYST_NERD_FONT=0 catalyst-hud` → in-progress rows render `…` and STATUS column lines up with success/failure rows
- [ ] Manual: `CATALYST_NERD_FONT=1 catalyst-hud` (with Hack Nerd Font set as terminal font) → in-progress rows render `` and STATUS column lines up
- [ ] Manual: `catalyst-hud` (no override) on a Mac with `Hack Nerd Font` cask installed → startup log says `nerdfont detected (fc-list: …)` and in-progress rows render ``
- [ ] Manual: `bash plugins/dev/scripts/install-nerd-fonts.sh` on a Mac without the cask installed → installs `font-hack-nerd-font` and `fontconfig`, prints next-steps