### PR TITLE
fix(dev): correct filter.wake predicate in skill docs (CTL-354)

### DIFF
--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -169,7 +169,7 @@ Omit `wake_on` (or pass `null`) to fire on all of the above.
 
 ```bash
 EVENT=$(catalyst-events wait-for \
-  --filter ".attributes.\"event.name\" == \"filter.wake\" and .attributes.\"event.label\" == \"${CATALYST_SESSION_ID}\"" \
+  --filter ".attributes.\"event.name\" == \"filter.wake.${CATALYST_SESSION_ID}\"" \
   --timeout 600 2>/dev/null || true)
 ```
 

--- a/plugins/dev/skills/catalyst-filter/SKILL.md
+++ b/plugins/dev/skills/catalyst-filter/SKILL.md
@@ -67,7 +67,7 @@ Orchestrator                         filter daemon                     Event log
     │                                     │── append filter.wake.{id} ────►│
     │                                     │                                │
     │◄── catalyst-events wait-for ────────────────────────────────────────│
-    │    (.attributes."event.name" == "filter.wake" and .attributes."event.label" == "{id}")   │                                │
+    │    (.attributes."event.name" == "filter.wake.{id}")                                      │                                │
     │                                     │                                │
     │── emit filter.deregister ──────────►│                                │
 ```
@@ -284,7 +284,7 @@ After registering, block on the corresponding wake event:
 
 ```bash
 EVENT=$(catalyst-events wait-for \
-  --filter ".attributes.\"event.name\" == \"filter.wake\" and .attributes.\"event.label\" == \"${ORCH_ID}\"" \
+  --filter ".attributes.\"event.name\" == \"filter.wake.${ORCH_ID}\"" \
   --timeout 7200 || true)
 
 # Mandatory authoritative check — always verify via REST regardless of wait outcome
@@ -468,7 +468,7 @@ catalyst-state.sh event '{"event":"filter.register","orchestrator":"my-orch","de
 catalyst-state.sh event '{"event":"filter.register","orchestrator":"my-orch","detail":{"interest_id":"sess_abc","session_id":"sess_abc","notify_event":"filter.wake.sess_abc","persistent":true,"prompt":"Wake me on CI events for PR 42 or comms addressed to CTL-269.","context":{"pr_numbers":[42],"tickets":["CTL-269"],"workers":["sess_abc"]}}}'
 
 # Wait for wake signal
-catalyst-events wait-for --filter '.attributes."event.name" == "filter.wake" and .attributes."event.label" == "my-orch"' --timeout 7200
+catalyst-events wait-for --filter '.attributes."event.name" == "filter.wake.my-orch"' --timeout 7200
 
 # Deregister
 catalyst-state.sh event '{"event":"filter.deregister","detail":{"interest_id":"my-orch"}}'

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -681,7 +681,7 @@ while [ "$PR_DONE" = "false" ]; do
   # CTL-269 preferred path: single semantic wake covers all concerns.
   if [ "$USE_FILTER_DAEMON" = "true" ] && [ "$USE_REST" != "true" ]; then
     EVENT=$(catalyst-events wait-for \
-      --filter ".attributes.\"event.name\" == \"filter.wake\" and .attributes.\"event.label\" == \"${CATALYST_SESSION_ID}\"" \
+      --filter ".attributes.\"event.name\" == \"filter.wake.${CATALYST_SESSION_ID}\"" \
       --timeout 600 2>/dev/null || true)
     if [ -n "$EVENT" ]; then
       WAKE_REASON=$(echo "$EVENT" | jq -r '.body.payload.reason // "unknown"' 2>/dev/null || echo "unknown")

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -806,7 +806,7 @@ timeout acts as the safety-net fallback for daemon-down scenarios.
 
 ```bash
 WAKE_EVENT=$(catalyst-events wait-for \
-  --filter ".attributes.\"event.name\" == \"filter.wake\" and .attributes.\"event.label\" == \"${ORCH_NAME}\"" \
+  --filter ".attributes.\"event.name\" == \"filter.wake.${ORCH_NAME}\"" \
   --timeout 600 2>/dev/null || true)
 if [ -n "$WAKE_EVENT" ]; then
   WAKE_REASON=$(echo "$WAKE_EVENT" | jq -r '.body.payload.reason // "unknown"' 2>/dev/null || echo "unknown")
@@ -893,7 +893,7 @@ are wake-up triggers, never sources of truth.
 | `github.pr_review*`, `github.pr_review_comment*`, `github.issue_comment.created` | Re-evaluate `mergeStateStatus`; surface review activity on the dashboard. Codex review threads land as `pr_review_comment.created` — required for CTL-64 BLOCKED auto-fixup detection |
 | `github.deployment*` | Record deploy outcome on the worker's signal file |
 | `linear.issue.state_changed` | Reconcile Linear state with the worker signal |
-| `filter.wake` (with `attributes."event.label" == ${ORCH_NAME}`) | Daemon-filtered semantic wake: read `.body.payload.reason` for log context, then run the full reactive scan. The reason describes what triggered the daemon (e.g., "CI failed on PR #416") but is never the authoritative source |
+| `filter.wake.${ORCH_NAME}` (matched on full dotted `event.name`) | Daemon-filtered semantic wake: read `.body.payload.reason` for log context, then run the full reactive scan. The reason describes what triggered the daemon (e.g., "CI failed on PR #416") but is never the authoritative source |
 | 10-minute idle (no event) | Run the full reactive scan as a safety net |
 
 **Ground truth is git + PR, not the signal file.** The signal file is *advisory* — it reports


### PR DESCRIPTION
## Summary

The broker emits `filter.wake` events as `attributes."event.name" == "filter.wake.${id}"` (full dotted form) and never sets `attributes."event.label"`. Four skill docs instructed agents to wait on:

```jq
.attributes."event.name" == "filter.wake" and .attributes."event.label" == "${ID}"
```

Both clauses are always false against real broker output — first because the actual `event.name` carries the dotted suffix, second because `event.label` is never populated. Per the research in CTL-354, **13,189 of 13,189** `filter.wake.*` events in the live log lack the `event.label` attribute the predicates require. Every Groq-classified wake silently fell through to the 600s timeout and was discarded.

## The Fix

Single substitution across **7 hits in 4 files**:

```diff
-.attributes."event.name" == "filter.wake" and .attributes."event.label" == "${ID}"
+.attributes."event.name" == "filter.wake.${ID}"
```

Direct dotted-name match works for orchestrator-id, session-id, and interest-id alike — matches exactly what `notify_event: filter.wake.${id}` writes inside `broker/index.mjs:354,475,778`.

### Files

- `plugins/dev/skills/orchestrate/SKILL.md` (L809, L896)
- `plugins/dev/skills/broker/SKILL.md` (L172)
- `plugins/dev/skills/oneshot/SKILL.md` (L684)
- `plugins/dev/skills/catalyst-filter/SKILL.md` (L70, L287, L471)

## Verification

```bash
grep -rn 'event\.label' plugins/dev/skills/   # → 0 hits
grep -rn '"filter\.wake"' plugins/dev/skills/  # → 1 hit (god skill, legacy .event field — unrelated pattern)
```

The remaining `god/SKILL.md:269` hit (`(.event | startswith("filter.wake"))`) reads the legacy top-level `.event` field with `startswith`, not the broken `attributes."event.name" == "filter.wake"` predicate. It's a different concern outside this ticket's scope.

## Out of Scope (follow-ups)

The ticket lists three minor reader-side drift items as "cheap to fix in the same pass". Skipping in this PR because:

1. `tryTicketLifecycleRoute` line citation is stale (581 → actual 662), and `tryDeterministicRoute` at L540 has the same pattern — contradicts the ticket's "deterministic route uses `getEventName`" claim. Needs separate analysis.
2. `catalyst-events` help text legacy `.event ==` examples (L446, L451) — doc-only nit.
3. `build-orchestrator-filter` legacy `.scope.*` fields — depends on whether legacy emitters remain.

Filing as follow-ups keeps this fix obviously-correct and low-risk.

## Test Plan

- [x] Verified all 4 skill files now use the dotted-name form
- [x] `grep -rn 'event\.label' plugins/dev/skills/` returns 0 hits
- [ ] Manual smoke (deferred — best done in a live orchestrator session): register an interest, trigger a matching event, run the new `wait-for` predicate, confirm wake matches within seconds instead of timing out at 600s

Linear: CTL-354