### PR TITLE
fix(dev): HUD glyph polish — SOURCE icon prefix, PR symbol, REF/ORCH dedup (CTL-355)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import type { CanonicalEvent } from "../lib/canonical-event.ts";
 import {
   formatTime,
@@ -11,6 +11,23 @@ import {
   formatDetailBody,
   shouldSkipEvent,
 } from "../cli/lib/format.ts";
+import { _resetNerdFontCacheForTesting } from "../cli/lib/nerd-font.ts";
+
+// CTL-355: this test file asserts the pure label/text contracts of the
+// formatters. Pin CATALYST_NERD_FONT=0 across the whole suite so the icon
+// prefix added in CTL-355 doesn't leak into the bare-label assertions; the
+// icon path is exercised separately in nerd-font.test.ts and the in-file
+// "CTL-355 Nerd Font enabled" describe block at the bottom.
+const _prevEnv = process.env.CATALYST_NERD_FONT;
+beforeAll(() => {
+  process.env.CATALYST_NERD_FONT = "0";
+  _resetNerdFontCacheForTesting();
+});
+afterAll(() => {
+  if (_prevEnv === undefined) delete process.env.CATALYST_NERD_FONT;
+  else process.env.CATALYST_NERD_FONT = _prevEnv;
+  _resetNerdFontCacheForTesting();
+});
 
 const baseEvent: CanonicalEvent = {
   ts: "2026-05-08T07:23:01.000Z",
@@ -991,5 +1008,71 @@ describe("shouldSkipEvent", () => {
       body: { payload: { reason: "ci_completed" } },
     } as unknown as CanonicalEvent;
     expect(shouldSkipEvent(e)).toBe(false);
+  });
+});
+
+// CTL-355: when Nerd Font is detected, formatSource prepends a 2-char "icon "
+// prefix and formatRef swaps "#" for the PR symbol. These tests pin
+// CATALYST_NERD_FONT=1, reset the cache, and assert the prefixed output.
+describe("formatSource / formatRef — CTL-355 Nerd Font enabled", () => {
+  const outerEnv = process.env.CATALYST_NERD_FONT;
+  beforeAll(() => {
+    process.env.CATALYST_NERD_FONT = "1";
+    _resetNerdFontCacheForTesting();
+  });
+  afterAll(() => {
+    if (outerEnv === undefined) delete process.env.CATALYST_NERD_FONT;
+    else process.env.CATALYST_NERD_FONT = outerEnv;
+    _resetNerdFontCacheForTesting();
+  });
+
+  test("formatSource prepends GitHub icon for github.* events", () => {
+    const out = formatSource(baseEvent);
+    expect(out).toBe(`\u{F09B} github`);
+    // First char is the icon (BMP, single codepoint); second char is a space;
+    // remaining chars are the bare label.
+    expect(out.codePointAt(0)).toBe(0xf09b);
+    expect(out.charAt(1)).toBe(" ");
+    expect(out.slice(2)).toBe("github");
+  });
+
+  test("formatSource prepends linear icon for linear.* events", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { ...baseEvent.attributes, "event.name": "linear.issue.state_changed" },
+    } as CanonicalEvent;
+    const out = formatSource(e);
+    expect(out.codePointAt(0)).toBe(0xf4ff);
+    expect(out.slice(2)).toBe("linear");
+  });
+
+  test("formatSource prepends broker bolt for filter.wake.* events", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-abc" },
+    } as CanonicalEvent;
+    const out = formatSource(e);
+    expect(out.codePointAt(0)).toBe(0xf0e7);
+    expect(out.slice(2)).toBe("broker");
+  });
+
+  test("formatSource prepends robot for orchestrator-derived source", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "session.phase",
+        "catalyst.orchestrator.id": "orch-abc",
+        "catalyst.worker.ticket": "CTL-312",
+      },
+    } as CanonicalEvent;
+    const out = formatSource(e);
+    expect(out.codePointAt(0)).toBe(0xf544);
+    expect(out.slice(2)).toBe("orch-abc/CTL-312");
+  });
+
+  test("formatRef uses PR glyph instead of '#' for github.pr.* events", () => {
+    const out = formatRef(baseEvent);
+    expect(out.codePointAt(0)).toBe(0xf407);
+    expect(out.slice(1)).toBe("501");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -42,6 +42,16 @@ export function EventRow({ event, selected, columns, paused = true }: EventRowPr
   const inverse = selected && paused;
   const w = computeColumnWidths(columns);
 
+  // CTL-355: when REF would render the same value as ORCH (common for
+  // filter.wake.<orch-id> rows where the wake target IS the orchestrator id),
+  // blank REF so the operator doesn't read the same id twice on every wide
+  // row. Only takes effect when the ORCH column is visible; on narrow
+  // terminals (no ORCH) REF still shows the value because there's nowhere
+  // else to see it.
+  const refText = formatRef(event);
+  const orchText = formatOrch(event);
+  const displayRef = w.showOrch && refText !== "" && refText === orchText ? "" : refText;
+
   return (
     <Box flexDirection="row">
       {w.showStatus && (
@@ -62,11 +72,11 @@ export function EventRow({ event, selected, columns, paused = true }: EventRowPr
         <Text color={color} inverse={inverse}>{formatEvent(event)}</Text>
       </Box>
       <Box width={w.ref} flexShrink={0} marginRight={1}>
-        <Text color={color} inverse={inverse}>{formatRef(event)}</Text>
+        <Text color={color} inverse={inverse}>{displayRef}</Text>
       </Box>
       {w.showOrch && (
         <Box width={w.orch} flexShrink={0} marginRight={1}>
-          <Text color={color} inverse={inverse}>{formatOrch(event)}</Text>
+          <Text color={color} inverse={inverse}>{orchText}</Text>
         </Box>
       )}
       {w.showWorker && (

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -1,5 +1,5 @@
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
-import { inProgressGlyph } from "./nerd-font.ts";
+import { inProgressGlyph, sourceIcon, prPrefix } from "./nerd-font.ts";
 
 const SKIP_EVENTS = new Set([
   "session.heartbeat",
@@ -48,7 +48,11 @@ export function formatRepo(event: CanonicalEvent): string {
   return repo.includes("/") ? (repo.split("/").pop() ?? repo) : repo;
 }
 
-export function formatSource(event: CanonicalEvent): string {
+// CTL-355: classifySource is the pure label resolver — single source of truth
+// for what the SOURCE column says. formatSource adds the Nerd Font icon
+// prefix on top. Tests cover both functions so a future icon-only mode
+// (deferred) can rely on classifySource alone.
+function classifySource(event: CanonicalEvent): string {
   const name = event.attributes?.["event.name"];
   if (!name) return "legacy";
   if (name.startsWith("github.")) return "github";
@@ -73,12 +77,17 @@ export function formatSource(event: CanonicalEvent): string {
     const orchId = event.attributes["catalyst.orchestrator.id"];
     return orchId ?? "filter";
   }
-  if (name === "broker.daemon.startup") return "broker";
+  if (name.startsWith("broker.daemon")) return "broker";
   const orchId = event.attributes["catalyst.orchestrator.id"];
   const worker = event.attributes["catalyst.worker.ticket"];
   if (orchId && worker) return `${orchId}/${worker}`;
   if (orchId) return orchId;
   return "system";
+}
+
+export function formatSource(event: CanonicalEvent): string {
+  const label = classifySource(event);
+  return `${sourceIcon(label)}${label}`;
 }
 
 const EVENT_LABELS: Record<string, string> = {
@@ -197,8 +206,10 @@ export function formatRef(event: CanonicalEvent): string {
       return repo.includes("/") ? (repo.split("/").pop() ?? repo) : repo;
     }
   }
+  // CTL-355: PR numbers get a glyph prefix —  (nf-cod-git_pull_request)
+  // when Nerd Font is detected, "#" otherwise.
   const pr = event.attributes["vcs.pr.number"];
-  if (pr) return `#${pr}`;
+  if (pr) return `${prPrefix()}${pr}`;
   const ticket = event.attributes["linear.issue.identifier"];
   if (ticket) return ticket;
   const branch = event.attributes["vcs.ref.name"];

--- a/plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts
@@ -140,3 +140,52 @@ export function _resetNerdFontCacheForTesting(): void {
 export function inProgressGlyph(): string {
   return detectNerdFont().detected ? NERD_FONT_IN_PROGRESS : FALLBACK_IN_PROGRESS;
 }
+
+// CTL-355: SOURCE column icon prefixes. Keys match the strings formatSource()
+// returns (or a known prefix of them — see sourceIcon() for the matching
+// logic). All glyphs are BMP single-cell Nerd Font codepoints so they render
+// in one terminal cell next to the source label.
+// PUA glyphs are written as \u{…} escapes so the source file survives
+// editor / clipboard round-trips that occasionally strip non-BMP-ish chars.
+const SOURCE_ICONS: Record<string, string> = {
+  github: "\u{F09B}",     // nf-fa-github
+  linear: "\u{F4FF}",     // nf-md-arrange_send_to_back (linear-y arrow)
+  broker: "\u{F0E7}",     // nf-fa-bolt — broker = wake router
+  catalyst: "\u{F544}",   // nf-md-robot — catalyst orchestration engine
+  system: "\u{F013}",     // nf-fa-cog — generic system events
+  comms: "\u{F086}",      // nf-fa-comments — agent comms channel
+  filter: "\u{F0B0}",     // nf-fa-filter — legacy filter source
+  legacy: "\u{F128}",     // nf-fa-question — unknown / pre-canonical events
+};
+
+/**
+ * Returns a 2-char "icon + space" prefix for the given source label when a
+ * Nerd Font is detected, else "" so the label renders bare.
+ *
+ * Matches by exact label first, then by prefix family ("orch-*" → catalyst,
+ * "CTL-*" / "ADV-*" / ticket-shaped → linear ticket). Unknown sources fall
+ * through to the system cog so every row has some icon when Nerd Font is on.
+ */
+export function sourceIcon(source: string): string {
+  if (!detectNerdFont().detected) return "";
+  const exact = SOURCE_ICONS[source];
+  if (exact) return `${exact} `;
+  // Orchestrator-derived sources (e.g. "orch-ctl-352-354-2026-05-12" or
+  // "orch-ctl-352-354-2026-05-12/CTL-354") show the catalyst robot.
+  if (source.startsWith("orch-") || source.includes("/")) {
+    return `${SOURCE_ICONS.catalyst} `;
+  }
+  // Anything else (worker tickets like CTL-352 used as comms source) gets the
+  // generic system cog rather than no icon at all — keeps the column aligned.
+  return `${SOURCE_ICONS.system} `;
+}
+
+// CTL-355: U+F407 nf-cod-git_pull_request — BMP, single-cell. Replaces "#"
+// before PR numbers in the REF column when a Nerd Font is detected.
+export const NERD_FONT_PR_PREFIX = "\u{F407}";
+export const FALLBACK_PR_PREFIX = "#";
+
+/** Returns the PR-number prefix glyph for the REF column. */
+export function prPrefix(): string {
+  return detectNerdFont().detected ? NERD_FONT_PR_PREFIX : FALLBACK_PR_PREFIX;
+}


### PR DESCRIPTION
## Summary

Three small HUD polish items following CTL-353 screenshot review.

1. **SOURCE column icon prefix** — `nerd-font.ts` gains a `SOURCE_ICONS` map and `sourceIcon(source)` helper. `formatSource` splits into `classifySource` (pure label resolver) and the icon-prepending public `formatSource`. When Nerd Font is detected, github events render ` github`, broker ` broker`, linear ` linear`, catalyst-derived sources ` orch-…/CTL-…`, etc. Bare labels when not detected. Width is already accommodated by the existing 16–22 cell SOURCE box.
2. **PR symbol in REF** — `nerd-font.ts` adds `prPrefix()` returning `` (U+F407 `nf-cod-git_pull_request`) when detected, `#` otherwise. `formatRef` uses it in place of the hardcoded `#`.
3. **REF / ORCH dedup** — when `refText === orchText` AND the ORCH column is visible, `EventRow` blanks REF. Fixes the common `filter.wake.<orch-id>` case where REF and ORCH duplicated the same string side by side (visible all over the screenshot in CTL-353).

Also widens `formatSource`'s broker.daemon match from exact (`.startup`) to prefix so the new `broker.daemon.shutdown` event (CTL-351) also routes to `broker`.

All PUA glyphs are written as `\u{…}` escapes so the source survives editor / clipboard round-trips that occasionally strip non-ASCII chars.

Linear: https://linear.app/coalesce-labs/issue/CTL-355

## Test plan

- [x] `bun test __tests__/hud-format.test.ts __tests__/nerd-font.test.ts __tests__/column-widths.test.ts __tests__/canonical-event.test.ts` → 170 pass, 0 fail
- [ ] Manual: open `catalyst-hud` on a Mac with Hack Nerd Font set — SOURCE column shows  github,  broker, etc.; PR refs render as `<>501`; on filter.wake rows the REF column is blank and ORCH shows the orch id (no more duplication)
- [ ] Manual: `CATALYST_NERD_FONT=0 catalyst-hud` — SOURCE bare, REF uses `#501`, dedup still applies