### PR TITLE
fix(dev): broker interests integrity + empty-state observability (CTL-352)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -245,6 +245,31 @@ export function clearInterests() {
   interests.clear();
 }
 
+// --- Broker liveness stats (CTL-352) -----------------------------------------
+// Mutable module state that buildBrokerState() surfaces in broker.state.json so
+// operators (and the HUD pill in Phase 3) can tell at a glance whether the
+// broker has any registered interests and when it last did real work.
+let brokerStartedAt = null;
+let lastWakeAt = null;
+let lastRegisterAt = null;
+// One-shot guard for broker.daemon.degraded — set on emission, cleared whenever
+// interests.size > 0 so a future empty window re-arms.
+let degradedEmittedAt = null;
+
+const DEGRADED_THRESHOLD_MS = 5 * 60 * 1000;
+
+// Test-only setters. Production paths only ever set these via main() and the
+// hook points below; tests use these to time-travel without touching Date.now().
+export function __setBrokerStartedAtForTest(iso) { brokerStartedAt = iso; }
+export function __resetBrokerStartedAtForTest() { brokerStartedAt = null; }
+export function __resetDegradedEmittedForTest() { degradedEmittedAt = null; }
+export function __resetBrokerLivenessForTest() {
+  brokerStartedAt = null;
+  lastWakeAt = null;
+  lastRegisterAt = null;
+  degradedEmittedAt = null;
+}
+
 // --- Interest persistence ---
 // CTL-350: resolve paths per-call so tests can redirect by setting CATALYST_DIR.
 // Production daemons still pin a stable value at launch.
@@ -280,11 +305,55 @@ function migrateLegacyInterestsFile() {
   }
 }
 
+// CTL-352: defense-in-depth for the on-disk interests file.
+//   1. Skip prose-* test residue at save (mirror of the CTL-350 load guard).
+//   2. Refuse to write an empty array unless CATALYST_BROKER_ALLOW_EMPTY_SAVE=1
+//      — protects against silent flatten-to-zero events. The on-disk file is
+//      preserved and a warn line records previousCount for forensics.
+//   3. Atomic write via tmp + rename so a crash mid-write never leaves a
+//      partial file on disk.
 export function saveInterests() {
   const interestsFile = getInterestsFile();
   try {
     mkdirSync(dirname(interestsFile), { recursive: true });
-    writeFileSync(interestsFile, JSON.stringify([...interests.entries()], null, 2));
+
+    const allEntries = [...interests.entries()];
+    const filtered = [];
+    let skipped = 0;
+    for (const [id, reg] of allEntries) {
+      if (reg?.session_id && PROSE_TEST_SESSION.test(reg.session_id)) {
+        skipped++;
+        continue;
+      }
+      filtered.push([id, reg]);
+    }
+    if (skipped > 0) {
+      log.info({ skipped }, "saveInterests: dropped prose-* test residue");
+    }
+
+    if (filtered.length === 0 && process.env.CATALYST_BROKER_ALLOW_EMPTY_SAVE !== "1") {
+      let previousCount = 0;
+      try {
+        const existing = JSON.parse(readFileSync(interestsFile, "utf8"));
+        previousCount = Array.isArray(existing) ? existing.length : 0;
+      } catch {
+        // no existing file or parse error — previousCount stays 0
+      }
+      log.warn(
+        { previousCount },
+        "refusing to save empty interests file — on-disk preserved (set CATALYST_BROKER_ALLOW_EMPTY_SAVE=1 to override)",
+      );
+      return;
+    }
+
+    const tmp = `${interestsFile}.tmp`;
+    try {
+      writeFileSync(tmp, JSON.stringify(filtered, null, 2));
+      renameSync(tmp, interestsFile);
+    } catch (err) {
+      try { unlinkSync(tmp); } catch { /* tmp already gone */ }
+      throw err;
+    }
   } catch (err) {
     log.error({ err: err.message }, "failed to save interests");
   }
@@ -392,6 +461,10 @@ export function handleRegister(event) {
     log.info({ interestId: id, prompt: d.prompt, persistent }, "registered");
   }
   saveInterests();
+  lastRegisterAt = new Date().toISOString();
+  // CTL-352: a fresh registration arms a future degraded event.
+  degradedEmittedAt = null;
+  persistBrokerState();
 }
 
 export function handleDeregister(event) {
@@ -405,6 +478,7 @@ export function handleDeregister(event) {
     }
     log.info({ interestId: id }, "deregistered");
     saveInterests();
+    persistBrokerState();
   }
 }
 
@@ -425,7 +499,10 @@ export function handleOrchestratorTerminated(event) {
       changed = true;
     }
   }
-  if (changed) saveInterests();
+  if (changed) {
+    saveInterests();
+    persistBrokerState();
+  }
 }
 
 // --- Agent identity (CTL-303) ------------------------------------------------
@@ -492,6 +569,9 @@ function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket) {
 
   log.info({ sessionId, prNumber }, "auto-correlated pr_lifecycle for session");
   saveInterests();
+  lastRegisterAt = new Date().toISOString();
+  degradedEmittedAt = null;
+  persistBrokerState();
 }
 
 export function handleAgentCheckout(event) {
@@ -510,6 +590,7 @@ export function handleAgentCheckout(event) {
     interests.delete(sessionId);
     try { deleteFilterState(sessionId); } catch { /* DB not opened */ }
     saveInterests();
+    persistBrokerState();
   }
 
   log.info({ sessionId, status: finalStatus }, "agent checked out");
@@ -822,7 +903,12 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
     changed = true;
   }
 
-  if (changed) saveInterests();
+  if (changed) {
+    saveInterests();
+    lastRegisterAt = new Date().toISOString();
+    degradedEmittedAt = null;
+    persistBrokerState();
+  }
 }
 
 // --- Event classification ---
@@ -927,9 +1013,17 @@ async function classifyBatch(events) {
     appendEvent(wake);
     log.info({ notifyEvent: wake.event, reason: wake.detail.reason }, "wake");
   }
+  if (wakes.length > 0) {
+    lastWakeAt = new Date().toISOString();
+    persistBrokerState();
+  }
   for (const id of oneShotsToDelete) {
     interests.delete(id);
     log.info({ interestId: id }, "auto-deregistered (one-shot)");
+  }
+  if (oneShotsToDelete.length > 0) {
+    saveInterests();
+    persistBrokerState();
   }
 }
 
@@ -1025,6 +1119,35 @@ function queueEvent(event) {
 
 export function runWatchdogTick() {
   const now = Date.now();
+
+  // CTL-352: empty-interests observability. Warn on every tick when the table
+  // is empty so a silently-dead broker is loud in broker.log, and emit a
+  // one-shot broker.daemon.degraded event after the 5-minute startup grace so
+  // downstream consumers (HUD, alerts) can pair startup ↔ degraded.
+  if (interests.size === 0) {
+    const startedTs = brokerStartedAt ? new Date(brokerStartedAt).getTime() : now;
+    const uptimeMs = now - startedTs;
+    log.warn({ uptimeMs }, "watchdog: no registered interests");
+    if (uptimeMs > DEGRADED_THRESHOLD_MS && degradedEmittedAt === null) {
+      appendEvent({
+        event: "broker.daemon.degraded",
+        orchestrator: null,
+        worker: null,
+        severity: "WARN",
+        detail: {
+          reason: "no registered interests",
+          uptimeMs,
+          brokerStartedAt,
+        },
+      });
+      degradedEmittedAt = new Date().toISOString();
+      persistBrokerState();
+    }
+  } else if (degradedEmittedAt !== null) {
+    degradedEmittedAt = null;
+  }
+
+  let watchdogWoke = false;
   for (const [sourceId, state] of lastHeartbeat) {
     const stale = now - state.ts > HEARTBEAT_STALE_MS;
     if (stale && !state.notified) {
@@ -1054,6 +1177,7 @@ export function runWatchdogTick() {
             "watchdog wake",
           );
           woke = true;
+          watchdogWoke = true;
         }
       }
       if (woke) {
@@ -1072,6 +1196,11 @@ export function runWatchdogTick() {
     } else if (!stale && state.notified) {
       lastHeartbeat.set(sourceId, { ts: state.ts, notified: false });
     }
+  }
+
+  if (watchdogWoke) {
+    lastWakeAt = new Date().toISOString();
+    persistBrokerState();
   }
 }
 
@@ -1161,7 +1290,11 @@ export function processEvent(event) {
     }
   }
 
-  if (directMatches.length > 0) return;
+  if (directMatches.length > 0) {
+    lastWakeAt = new Date().toISOString();
+    persistBrokerState();
+    return;
+  }
 
   queueEvent(event);
 }
@@ -1276,14 +1409,23 @@ function removePidFile() {
 
 // --- State file (CTL-343) ---
 // ~/catalyst/broker.state.json is the single source of truth for at-a-glance
-// broker key health. Consumed by `catalyst-broker status --json`,
-// `catalyst-monitor status --json`, and the HUD header chip.
-const BROKER_STATE_FILE = resolve(CATALYST_DIR, "broker.state.json");
+// broker liveness. Consumed by `catalyst-broker status --json`,
+// `catalyst-monitor status --json`, and the HUD header chips.
+// CTL-352: resolve path per-call so tests can redirect via CATALYST_DIR.
+export function getBrokerStateFilePath() {
+  const catalystDir = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+  return resolve(catalystDir, "broker.state.json");
+}
 
 export function buildBrokerState({ probe } = {}) {
   return {
     pid: process.pid,
-    startedAt: new Date().toISOString(),
+    startedAt: brokerStartedAt ?? new Date().toISOString(),
+    // CTL-352: liveness fields so the HUD pill and operators can detect a
+    // silently-dead broker (interests.size === 0 with stale lastWakeAt).
+    interestCount: interests.size,
+    lastWakeAt,
+    lastRegisterAt,
     keyHealth: {
       groq: {
         present: GROQ_KEY_SOURCE !== null,
@@ -1302,20 +1444,23 @@ export function buildBrokerState({ probe } = {}) {
   };
 }
 
-export function writeBrokerStateFile(state, { path = BROKER_STATE_FILE } = {}) {
+export function writeBrokerStateFile(state, { path } = {}) {
+  const target = path ?? getBrokerStateFilePath();
   try {
-    mkdirSync(dirname(path), { recursive: true });
-    const tmp = `${path}.tmp`;
+    mkdirSync(dirname(target), { recursive: true });
+    const tmp = `${target}.tmp`;
     writeFileSync(tmp, JSON.stringify(state, null, 2));
-    renameSync(tmp, path);
+    renameSync(tmp, target);
   } catch (err) {
-    log.warn({ err: err.message, path }, "failed to write broker state file");
+    log.warn({ err: err.message, path: target }, "failed to write broker state file");
   }
 }
 
-// Exported so the state-file path is discoverable by tests.
-export function getBrokerStateFilePath() {
-  return BROKER_STATE_FILE;
+// CTL-352: internal helper called at every state mutation that should bump
+// liveness fields in broker.state.json. Single-line write + atomic rename, so
+// per-event calls (dozens/sec at peak) are cheap.
+function persistBrokerState({ probe } = {}) {
+  writeBrokerStateFile(buildBrokerState({ probe }));
 }
 
 // Logs key health at startup. Returns the resolved state-file payload
@@ -1370,6 +1515,11 @@ export async function runStartupProbe() {
 
 // --- Main ---
 function main() {
+  // CTL-352: pin brokerStartedAt before any state mutation so subsequent
+  // buildBrokerState() / runWatchdogTick() callers compute uptime against
+  // a stable instant rather than now().
+  brokerStartedAt = new Date().toISOString();
+
   logKeyHealthAtStartup();
 
   writePidFile();

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -1486,3 +1486,258 @@ describe("CTL-350 source_events inlining", () => {
     expect(wakes[0].detail.matched_indices_count).toBe(2);
   });
 });
+
+// ─── CTL-352 saveInterests guards ───────────────────────────────────────────
+
+describe("CTL-352 saveInterests guards", () => {
+  const REAL_REG = {
+    notify_event: "filter.wake.real-1",
+    prompt: "",
+    context: null,
+    orchestrator: "real-1",
+    session_id: null,
+    persistent: true,
+    interest_type: null,
+    pr_numbers: null,
+    repo: null,
+    base_branches: null,
+    tickets: null,
+    wake_on: null,
+  };
+
+  const PROSE_REG = {
+    notify_event: "filter.wake.prose-x",
+    prompt: "match anything",
+    context: {},
+    orchestrator: null,
+    session_id: "sess-prose-77",
+    persistent: true,
+    interest_type: null,
+    pr_numbers: null,
+    repo: null,
+    base_branches: null,
+    tickets: null,
+    wake_on: null,
+  };
+
+  afterEach(() => {
+    delete process.env.CATALYST_BROKER_ALLOW_EMPTY_SAVE;
+  });
+
+  test("prose-* rows are dropped at save (mirrors load guard)", async () => {
+    const { saveInterests } = await import("./index.mjs");
+    getInterests().set("real-1", REAL_REG);
+    getInterests().set("prose-x", PROSE_REG);
+    saveInterests();
+    const file = join(tmpDir, "broker-interests.json");
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    expect(parsed.map(([id]) => id)).toEqual(["real-1"]);
+  });
+
+  test("refuses to write empty array without escape hatch — on-disk file preserved", async () => {
+    const { saveInterests } = await import("./index.mjs");
+    const file = join(tmpDir, "broker-interests.json");
+    writeFileSync(file, JSON.stringify([["real-1", REAL_REG]], null, 2));
+    const before = readFileSync(file, "utf8");
+    clearInterests();
+    saveInterests();
+    const after = readFileSync(file, "utf8");
+    expect(after).toBe(before);
+  });
+
+  test("with CATALYST_BROKER_ALLOW_EMPTY_SAVE=1 the escape hatch permits empty write", async () => {
+    const { saveInterests } = await import("./index.mjs");
+    const file = join(tmpDir, "broker-interests.json");
+    writeFileSync(file, JSON.stringify([["real-1", REAL_REG]], null, 2));
+    clearInterests();
+    process.env.CATALYST_BROKER_ALLOW_EMPTY_SAVE = "1";
+    saveInterests();
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    expect(parsed).toEqual([]);
+  });
+
+  test("when all in-memory rows are prose-*, save is still treated as empty and refused", async () => {
+    const { saveInterests } = await import("./index.mjs");
+    const file = join(tmpDir, "broker-interests.json");
+    writeFileSync(file, JSON.stringify([["real-1", REAL_REG]], null, 2));
+    const before = readFileSync(file, "utf8");
+    clearInterests();
+    getInterests().set("prose-only", PROSE_REG);
+    saveInterests();
+    expect(readFileSync(file, "utf8")).toBe(before);
+  });
+
+  test("normal save leaves no .tmp file behind (atomic rename)", async () => {
+    const { saveInterests } = await import("./index.mjs");
+    getInterests().set("real-1", REAL_REG);
+    saveInterests();
+    const tmpFile = join(tmpDir, "broker-interests.json.tmp");
+    expect(existsSync(tmpFile)).toBe(false);
+  });
+});
+
+// ─── CTL-352 broker state + degraded event ───────────────────────────────────
+
+describe("CTL-352 broker state + degraded event", () => {
+  const STATE_FILE = () => join(tmpDir, "broker.state.json");
+
+  beforeEach(async () => {
+    const { __resetBrokerLivenessForTest } = await import("./index.mjs");
+    __resetBrokerLivenessForTest();
+  });
+
+  afterEach(async () => {
+    const { __resetBrokerLivenessForTest } = await import("./index.mjs");
+    __resetBrokerLivenessForTest();
+  });
+
+  test("buildBrokerState includes interestCount, lastWakeAt, lastRegisterAt", async () => {
+    const { buildBrokerState, __setBrokerStartedAtForTest } = await import("./index.mjs");
+    __setBrokerStartedAtForTest(new Date().toISOString());
+    const state = buildBrokerState();
+    expect(state).toHaveProperty("interestCount");
+    expect(state).toHaveProperty("lastWakeAt");
+    expect(state).toHaveProperty("lastRegisterAt");
+    expect(state.interestCount).toBe(0);
+    expect(state.lastWakeAt).toBeNull();
+    expect(state.lastRegisterAt).toBeNull();
+  });
+
+  test("handleRegister updates lastRegisterAt and persists state file", async () => {
+    const { handleRegister, buildBrokerState } = await import("./index.mjs");
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-state-1",
+      detail: { interest_id: "state-1", notify_event: "filter.wake.state-1", prompt: "p" },
+    });
+    const state = buildBrokerState();
+    expect(state.interestCount).toBe(1);
+    expect(state.lastRegisterAt).not.toBeNull();
+    expect(typeof state.lastRegisterAt).toBe("string");
+
+    expect(existsSync(STATE_FILE())).toBe(true);
+    const parsed = JSON.parse(readFileSync(STATE_FILE(), "utf8"));
+    expect(parsed.interestCount).toBe(1);
+    expect(parsed.lastRegisterAt).toBe(state.lastRegisterAt);
+  });
+
+  test("a wake firing updates lastWakeAt", async () => {
+    const { handleRegister, processEvent, buildBrokerState } = await import("./index.mjs");
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-wake-1",
+      detail: {
+        interest_id: "wake-1",
+        notify_event: "filter.wake.wake-1",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [999],
+        repo: "org/repo",
+        base_branches: [{ pr: 999, base: "main" }],
+        persistent: true,
+        session_id: "sess-wake-1",
+      },
+    });
+    const before = buildBrokerState().lastWakeAt;
+    expect(before).toBeNull();
+
+    processEvent({
+      id: "deadbeefdeadbeefdeadbeefdeadbeef",
+      ts: new Date().toISOString(),
+      event: "github.pr.merged",
+      attributes: { "event.name": "github.pr.merged" },
+      scope: { pr: 999 },
+      detail: { mergeCommitSha: "feedface", merged: true },
+    });
+    const after = buildBrokerState().lastWakeAt;
+    expect(after).not.toBeNull();
+    expect(typeof after).toBe("string");
+  });
+
+  test("broker.daemon.degraded emitted once when interests empty and uptime > 5 min", async () => {
+    const {
+      runWatchdogTick,
+      __setBrokerStartedAtForTest,
+      getInterests,
+    } = await import("./index.mjs");
+    clearInterests();
+    const sixMinAgo = new Date(Date.now() - 6 * 60 * 1000).toISOString();
+    __setBrokerStartedAtForTest(sixMinAgo);
+
+    runWatchdogTick();
+    runWatchdogTick();
+    runWatchdogTick();
+
+    // Read the month event log; assert exactly one degraded event.
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    expect(existsSync(logPath)).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+    const degradedLines = lines.filter((l) => {
+      try {
+        const evt = JSON.parse(l);
+        return evt.attributes?.["event.name"] === "broker.daemon.degraded";
+      } catch { return false; }
+    });
+    expect(degradedLines).toHaveLength(1);
+    const evt = JSON.parse(degradedLines[0]);
+    expect(evt.severityText).toBe("WARN");
+    expect(evt.body.payload.reason).toBe("no registered interests");
+    expect(typeof evt.body.payload.uptimeMs).toBe("number");
+    expect(getInterests().size).toBe(0);
+  });
+
+  test("degraded NOT emitted within the 5-minute startup grace", async () => {
+    const { runWatchdogTick, __setBrokerStartedAtForTest } = await import("./index.mjs");
+    clearInterests();
+    const oneMinAgo = new Date(Date.now() - 60 * 1000).toISOString();
+    __setBrokerStartedAtForTest(oneMinAgo);
+
+    runWatchdogTick();
+
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    if (!existsSync(logPath)) return; // no events at all — vacuously fine
+    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+    const degradedLines = lines.filter((l) => {
+      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded"; }
+      catch { return false; }
+    });
+    expect(degradedLines).toHaveLength(0);
+  });
+
+  test("degraded re-arms after interests come back and go empty again", async () => {
+    const {
+      runWatchdogTick,
+      __setBrokerStartedAtForTest,
+      handleRegister,
+      handleDeregister,
+    } = await import("./index.mjs");
+    clearInterests();
+    const sixMinAgo = new Date(Date.now() - 6 * 60 * 1000).toISOString();
+    __setBrokerStartedAtForTest(sixMinAgo);
+
+    runWatchdogTick(); // emits first degraded
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-rearm-1",
+      detail: { interest_id: "rearm-1", notify_event: "filter.wake.rearm-1", prompt: "p" },
+    });
+    handleDeregister({
+      event: "filter.deregister",
+      orchestrator: "orch-rearm-1",
+      detail: { interest_id: "rearm-1" },
+    });
+
+    runWatchdogTick(); // should re-emit (cleared on non-empty, then armed again on empty)
+
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+    const degradedLines = lines.filter((l) => {
+      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded"; }
+      catch { return false; }
+    });
+    expect(degradedLines).toHaveLength(2);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -1,27 +1,48 @@
 import { Box, Text } from "ink";
-import type { BrokerKeyHealth } from "../lib/broker-key-health.ts";
-import { chipColor, chipLabel } from "../lib/broker-key-health.ts";
+import type { BrokerState } from "../lib/broker-key-health.ts";
+import {
+  chipColor,
+  chipLabel,
+  brokerInterestStatus,
+  interestChipColor,
+  interestChipLabel,
+} from "../lib/broker-key-health.ts";
 import { computeColumnWidths } from "../lib/column-widths.ts";
 
 interface HeaderProps {
   columns?: number;
   nlQuery?: string;
-  brokerKeyHealth?: BrokerKeyHealth | null;
+  brokerState?: BrokerState | null;
 }
 
 // CTL-351: match EventRow's per-column 1-col right margin so the header
 // labels align with the row content below them at every terminal width.
-export function Header({ columns = 120, nlQuery, brokerKeyHealth }: HeaderProps) {
+// CTL-352: brokerState replaces brokerKeyHealth — same shape plus liveness
+// fields for the new interests pill. The chip row renders whenever either
+// Groq or interest data is available.
+export function Header({ columns = 120, nlQuery, brokerState }: HeaderProps) {
   const sep = "─".repeat(Math.max(0, columns - 1));
-  const groq = brokerKeyHealth?.groq;
+  const groq = brokerState?.groq;
+  const interestStatus = brokerInterestStatus(brokerState ?? null);
+  const showInterestChip = interestStatus !== "unknown";
   const w = computeColumnWidths(columns);
   return (
     <Box flexDirection="column">
-      {groq && (
+      {(groq || showInterestChip) && (
         <Box flexDirection="row">
-          <Text color={chipColor(groq.probeStatus)}>{`[Groq: ${chipLabel(groq.probeStatus)}]`}</Text>
-          {groq.present && groq.prefix && (
+          {groq && (
+            <Text color={chipColor(groq.probeStatus)}>{`[Groq: ${chipLabel(groq.probeStatus)}]`}</Text>
+          )}
+          {groq && groq.present && groq.prefix && (
             <Text dimColor>{`  ${groq.prefix}... (${groq.source ?? "unknown"})`}</Text>
+          )}
+          {showInterestChip && (
+            <Text
+              color={interestChipColor(interestStatus)}
+              inverse={interestStatus === "degraded"}
+            >
+              {`${groq ? "  " : ""}[broker: ${interestChipLabel(brokerState ?? null, interestStatus)}]`}
+            </Text>
           )}
         </Box>
       )}

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -2,7 +2,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { render, useApp, useInput, Box, Text } from "ink";
 import { Header } from "./components/Header.tsx";
-import { readBrokerKeyHealth, type BrokerKeyHealth } from "./lib/broker-key-health.ts";
+import { readBrokerState, type BrokerState } from "./lib/broker-key-health.ts";
 import { EventList } from "./components/EventList.tsx";
 import { FilterInput } from "./components/FilterInput.tsx";
 import { QueryInput } from "./components/QueryInput.tsx";
@@ -134,11 +134,12 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
 
   const { events, loading } = useEventLog({ repoFilter, predicate, sinceTs: activeSinceTs });
 
-  // CTL-343: broker key-health chip. Poll the broker state file every 5s so
-  // the chip surfaces fresh probe results without busy-reading on every render.
-  const [brokerKeyHealth, setBrokerKeyHealth] = useState<BrokerKeyHealth | null>(null);
+  // CTL-343 / CTL-352: broker state chip(s). Poll broker.state.json every 5s
+  // so the chips surface fresh probe results AND interest-count updates
+  // without busy-reading on every render.
+  const [brokerState, setBrokerState] = useState<BrokerState | null>(null);
   useEffect(() => {
-    const refresh = () => setBrokerKeyHealth(readBrokerKeyHealth());
+    const refresh = () => setBrokerState(readBrokerState());
     refresh();
     const id = setInterval(refresh, 5000);
     return () => clearInterval(id);
@@ -149,7 +150,9 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   const { filterText, setFilterText, pivot, setPivot, filtered } = useFilter(events, dslPredicate);
 
   // Header = optional chip row (0/1) + column row (1) + separator (1) + optional nlQuery row (0/1)
-  const headerRows = (brokerKeyHealth?.groq ? 1 : 0) + (dslState?.nlQuery ? 3 : 2);
+  // CTL-352: chip row is shown whenever Groq or broker-interest data is available.
+  const hasChipRow = Boolean(brokerState?.groq) || typeof brokerState?.interestCount === "number";
+  const headerRows = (hasChipRow ? 1 : 0) + (dslState?.nlQuery ? 3 : 2);
 
   const [showDslOverlay, setShowDslOverlay] = useState(false);
   const [dslScrollTop, setDslScrollTop] = useState(0);
@@ -373,7 +376,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   return (
     <Box flexDirection="column" height={layoutRows} width={cols}>
       <Box flexShrink={0}>
-        <Header columns={cols} nlQuery={dslState?.nlQuery} brokerKeyHealth={brokerKeyHealth} />
+        <Header columns={cols} nlQuery={dslState?.nlQuery} brokerState={brokerState} />
       </Box>
       <Box flexDirection="column" flexGrow={(inDetailMode || showHelp) ? 0 : 1} flexShrink={1}>
         <EventList

--- a/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.test.ts
@@ -10,6 +10,10 @@ import {
   chipLabel,
   chipColor,
   readBrokerKeyHealth,
+  readBrokerState,
+  brokerInterestStatus,
+  interestChipColor,
+  interestChipLabel,
 } from "./broker-key-health.ts";
 
 describe("chipLabel", () => {
@@ -59,5 +63,100 @@ describe("readBrokerKeyHealth", () => {
     const target = join(tmp, "no-key.json");
     writeFileSync(target, JSON.stringify({ pid: 1234 }));
     expect(readBrokerKeyHealth(target)).toBeNull();
+  });
+});
+
+describe("CTL-352 readBrokerState", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hud-bs-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("returns null when file does not exist", () => {
+    expect(readBrokerState(join(tmp, "missing.json"))).toBeNull();
+  });
+
+  test("returns interestCount, lastWakeAt, lastRegisterAt, startedAt when present", () => {
+    const target = join(tmp, "good.json");
+    writeFileSync(target, JSON.stringify({
+      pid: 1234,
+      startedAt: "2026-05-13T03:00:00Z",
+      interestCount: 3,
+      lastWakeAt: "2026-05-13T04:00:00Z",
+      lastRegisterAt: "2026-05-13T03:30:00Z",
+      keyHealth: { groq: { present: true, source: "config", prefix: "gsk_abc", probeStatus: "ok" } },
+    }));
+    const result = readBrokerState(target);
+    expect(result).not.toBeNull();
+    expect(result?.interestCount).toBe(3);
+    expect(result?.lastWakeAt).toBe("2026-05-13T04:00:00Z");
+    expect(result?.lastRegisterAt).toBe("2026-05-13T03:30:00Z");
+    expect(result?.startedAt).toBe("2026-05-13T03:00:00Z");
+    expect(result?.groq?.probeStatus).toBe("ok");
+  });
+
+  test("tolerates absent interestCount/lastWakeAt (legacy state files)", () => {
+    const target = join(tmp, "legacy.json");
+    writeFileSync(target, JSON.stringify({
+      pid: 1234,
+      startedAt: "2026-05-13T03:00:00Z",
+      keyHealth: { groq: { present: true, source: "config", prefix: "x", probeStatus: "ok" } },
+    }));
+    const result = readBrokerState(target);
+    expect(result).not.toBeNull();
+    expect(result?.interestCount).toBeUndefined();
+    expect(result?.lastWakeAt).toBeUndefined();
+    expect(result?.groq?.probeStatus).toBe("ok");
+  });
+});
+
+describe("CTL-352 brokerInterestStatus", () => {
+  const NOW = Date.parse("2026-05-13T04:00:00Z");
+
+  test("returns 'unknown' for null state", () => {
+    expect(brokerInterestStatus(null, NOW)).toBe("unknown");
+  });
+
+  test("returns 'unknown' when interestCount is missing", () => {
+    expect(brokerInterestStatus({ startedAt: "2026-05-13T03:00:00Z" }, NOW)).toBe("unknown");
+  });
+
+  test("returns 'ok' when interestCount > 0", () => {
+    expect(brokerInterestStatus({ interestCount: 2, startedAt: "2026-05-13T03:00:00Z" }, NOW)).toBe("ok");
+  });
+
+  test("returns 'startup' when interestCount === 0 within 5-min grace", () => {
+    // started 2 minutes before NOW
+    expect(brokerInterestStatus(
+      { interestCount: 0, startedAt: "2026-05-13T03:58:00Z" }, NOW,
+    )).toBe("startup");
+  });
+
+  test("returns 'degraded' when interestCount === 0 past 5-min grace", () => {
+    // started 6 minutes before NOW
+    expect(brokerInterestStatus(
+      { interestCount: 0, startedAt: "2026-05-13T03:54:00Z" }, NOW,
+    )).toBe("degraded");
+  });
+
+  test("returns 'unknown' when interestCount === 0 but startedAt is missing/malformed", () => {
+    expect(brokerInterestStatus({ interestCount: 0 }, NOW)).toBe("unknown");
+    expect(brokerInterestStatus({ interestCount: 0, startedAt: "not a date" }, NOW)).toBe("unknown");
+  });
+});
+
+describe("CTL-352 interestChipColor + interestChipLabel", () => {
+  test("color: ok → green, startup → yellow, degraded → red, unknown → gray", () => {
+    expect(interestChipColor("ok")).toBe("green");
+    expect(interestChipColor("startup")).toBe("yellow");
+    expect(interestChipColor("degraded")).toBe("red");
+    expect(interestChipColor("unknown")).toBe("gray");
+  });
+
+  test("label: 'N interests' for ok, '0 (starting)' for startup, '0 interests' for degraded, '?' for unknown", () => {
+    expect(interestChipLabel({ interestCount: 3 }, "ok")).toBe("3 interests");
+    expect(interestChipLabel({ interestCount: 1 }, "ok")).toBe("1 interest");
+    expect(interestChipLabel({ interestCount: 0 }, "startup")).toBe("0 (starting)");
+    expect(interestChipLabel({ interestCount: 0 }, "degraded")).toBe("0 interests");
+    expect(interestChipLabel(null, "unknown")).toBe("?");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts
@@ -18,6 +18,20 @@ export interface BrokerKeyHealth {
   };
 }
 
+// CTL-352: broader read of broker.state.json including the new liveness
+// fields (interestCount, lastWakeAt, lastRegisterAt, startedAt). The legacy
+// BrokerKeyHealth shape is preserved as a subset for existing consumers.
+export interface BrokerState extends BrokerKeyHealth {
+  interestCount?: number;
+  lastWakeAt?: string | null;
+  lastRegisterAt?: string | null;
+  startedAt?: string;
+}
+
+export type BrokerInterestStatus = "ok" | "startup" | "degraded" | "unknown";
+
+const DEGRADED_GRACE_MS = 5 * 60 * 1000;
+
 /** Path of the broker's state file (override via $BROKER_STATE_FILE). */
 export function brokerStateFilePath(): string {
   if (process.env.BROKER_STATE_FILE) return process.env.BROKER_STATE_FILE;
@@ -59,4 +73,67 @@ export function chipColor(status: ProbeStatus): string {
     case "error": return "red";
     case "pending": return "cyan";
   }
+}
+
+// CTL-352: broker.state.json reader that surfaces liveness fields in
+// addition to keyHealth. Returns null on missing file / parse error so
+// consumers can render an "unknown" chip without crashing.
+export function readBrokerState(path?: string): BrokerState | null {
+  const target = path ?? brokerStateFilePath();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(target, "utf8"));
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as Record<string, unknown>;
+    const kh = (obj.keyHealth ?? null) as BrokerKeyHealth | null;
+    const result: BrokerState = { ...(kh ?? {}) };
+    if (typeof obj.interestCount === "number") result.interestCount = obj.interestCount;
+    if (typeof obj.lastWakeAt === "string" || obj.lastWakeAt === null) {
+      result.lastWakeAt = obj.lastWakeAt;
+    }
+    if (typeof obj.lastRegisterAt === "string" || obj.lastRegisterAt === null) {
+      result.lastRegisterAt = obj.lastRegisterAt;
+    }
+    if (typeof obj.startedAt === "string") result.startedAt = obj.startedAt;
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+// CTL-352: classify the broker's interest table for HUD pill colouring.
+// "ok" — there is at least one registered interest.
+// "startup" — table is empty but broker has been up < 5 min (warmup grace).
+// "degraded" — table is empty AND broker has been up > 5 min (the silent-dead
+//   mode CTL-350 surfaced).
+// "unknown" — state file missing/malformed or interestCount field absent.
+export function brokerInterestStatus(
+  state: BrokerState | null,
+  nowMs: number = Date.now(),
+): BrokerInterestStatus {
+  if (!state || typeof state.interestCount !== "number") return "unknown";
+  if (state.interestCount > 0) return "ok";
+  if (!state.startedAt) return "unknown";
+  const started = Date.parse(state.startedAt);
+  if (Number.isNaN(started)) return "unknown";
+  return nowMs - started > DEGRADED_GRACE_MS ? "degraded" : "startup";
+}
+
+export function interestChipColor(status: BrokerInterestStatus): string {
+  switch (status) {
+    case "ok": return "green";
+    case "startup": return "yellow";
+    case "degraded": return "red";
+    case "unknown": return "gray";
+  }
+}
+
+export function interestChipLabel(
+  state: BrokerState | null,
+  status: BrokerInterestStatus,
+): string {
+  if (status === "unknown" || !state || typeof state.interestCount !== "number") return "?";
+  const n = state.interestCount;
+  if (status === "ok") return `${n} interest${n === 1 ? "" : "s"}`;
+  if (status === "startup") return `${n} (starting)`;
+  return `${n} interests`;
 }


### PR DESCRIPTION
Closes CTL-352. Defense-in-depth on top of [CTL-350](https://github.com/coalesce-labs/catalyst/pull/592).

After CTL-350 shipped, the broker restarted and the on-disk `~/catalyst/broker-interests.json`
had been silently flattened to a single `prose-7` row by pre-CTL-350 test runs. CTL-350's
load-time guard correctly evicted the residue, leaving the broker with **0 interests** and no
recovery path. This PR closes the three defense-in-depth gaps CTL-350 deliberately scoped out.

## Phase 1 — `saveInterests` guards

- Mirror the CTL-350 load-time `sess-prose-\d+` skip at the write side (logs `skipped` count).
- Refuse to write an empty array unless `CATALYST_BROKER_ALLOW_EMPTY_SAVE=1` is set; log
  `warn` with `previousCount` from the existing on-disk file so flatten attempts are
  forensically visible.
- Atomic write via `writeFileSync(tmp) → renameSync(tmp, interestsFile)` — a crash mid-write
  can never leave a partial file.

## Phase 2 — `broker.state.json` liveness

- Add `interestCount`, `lastWakeAt`, `lastRegisterAt`. Pin `startedAt` at `main()` entry.
- Written on every state mutation (register, deregister, auto-correlate, wake), not just startup.
- Emit a one-shot `broker.daemon.degraded` WARN event when the broker has been up >5 min
  with `interests.size === 0`. Re-arms when interests return then go empty again.
- Watchdog tick warn-logs on every empty-interests scan (previously silent).
- `getBrokerStateFilePath()` resolves `CATALYST_DIR` per call so tests redirect cleanly via
  the same path CTL-350 introduced for `broker-interests.json`.

## Phase 3 — HUD broker pill

- New `BrokerState` type + `readBrokerState()` reader that surfaces the liveness fields.
  Existing `BrokerKeyHealth` / `readBrokerKeyHealth` preserved as subsets.
- `brokerInterestStatus()` classifies as `ok` / `startup` / `degraded` / `unknown` using
  the 5-minute grace.
- `Header.tsx` renders a second chip beside Groq: **green** for healthy, **yellow** within
  startup grace, **red + inverse** when degraded.
- `hud.tsx` polls `broker.state.json` (same 5s cadence as the Groq chip).

## Test plan

- [x] `bun test plugins/dev/scripts/broker/index.test.mjs` — 91 pass (5 new save-guard,
      6 new state+degraded tests)
- [x] `bun test plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.test.ts` — 25 pass
      (14 new HUD helper tests)
- [x] `bun test plugins/dev/scripts/broker/` — 133 pass across 4 files
- [x] `bun run typecheck` / `bun run lint` on orch-monitor — clean on touched files
- [x] TDD throughout: Red (failing tests) → Green (smallest impl) → Refactor per phase

Pre-existing failures in `catalyst-monitor.sh`, SSE integration, `session-store.ts`, and
`ui/src/lib/briefings.ts` are unrelated (confirmed by stashing and re-running).

## Manual verification (post-merge)

- Register one interest, observe `~/catalyst/broker.state.json` shows `interestCount: 1` +
  fresh `lastRegisterAt`. Trigger a wake → `lastWakeAt` updates within ~1s.
- Stop the broker, clear `~/catalyst/broker-interests.json` to `[]`, start with no
  orchestrators, wait 6 min — exactly one `broker.daemon.degraded` event in the month log,
  watchdog warn line in `broker.log`, and the HUD pill flips to red + inverse.
- `saveInterests([])` against an empty in-memory map without the env var — observe warn log,
  on-disk file unchanged.

## Out of scope

- Orchestrator re-registration on eviction (bigger design — separate ticket).
- Backfill of historical `broker-interests.json` on other hosts — `clean-prose-interests.sh`
  already shipped in CTL-350 covers that.