### PR TITLE
fix(dev): HUD glyph fixes — NF v3 codepoint move + PR space (CTL-358)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -1036,13 +1036,15 @@ describe("formatSource / formatRef — CTL-355 Nerd Font enabled", () => {
     expect(out.slice(2)).toBe("github");
   });
 
-  test("formatSource prepends linear icon for linear.* events", () => {
+  test("formatSource prepends linear ticket icon for linear.* events", () => {
     const e = {
       ...baseEvent,
       attributes: { ...baseEvent.attributes, "event.name": "linear.issue.state_changed" },
     } as CanonicalEvent;
     const out = formatSource(e);
-    expect(out.codePointAt(0)).toBe(0xf4ff);
+    // CTL-358: nf-fa-ticket (U+F145) — Linear has no native NF logo; ticket
+    // is the closest semantic match and lives in stable FA4 BMP range.
+    expect(out.codePointAt(0)).toBe(0xf145);
     expect(out.slice(2)).toBe("linear");
   });
 
@@ -1056,7 +1058,7 @@ describe("formatSource / formatRef — CTL-355 Nerd Font enabled", () => {
     expect(out.slice(2)).toBe("broker");
   });
 
-  test("formatSource prepends robot for orchestrator-derived source", () => {
+  test("formatSource prepends cogs for orchestrator-derived source", () => {
     const e = {
       ...baseEvent,
       attributes: {
@@ -1066,13 +1068,18 @@ describe("formatSource / formatRef — CTL-355 Nerd Font enabled", () => {
       },
     } as CanonicalEvent;
     const out = formatSource(e);
-    expect(out.codePointAt(0)).toBe(0xf544);
+    // CTL-358: nf-fa-cogs (U+F085, multiple gears) — orchestration. The
+    // previous nf-md-robot (U+F544) was repurposed in Nerd Fonts v3 and
+    // rendered as a down-arrow.
+    expect(out.codePointAt(0)).toBe(0xf085);
     expect(out.slice(2)).toBe("orch-abc/CTL-312");
   });
 
-  test("formatRef uses PR glyph instead of '#' for github.pr.* events", () => {
+  test("formatRef uses PR glyph + trailing space instead of '#' for github.pr.* events", () => {
     const out = formatRef(baseEvent);
+    // CTL-358: prefix is " " (glyph + space), so out == " 501"
     expect(out.codePointAt(0)).toBe(0xf407);
-    expect(out.slice(1)).toBe("501");
+    expect(out.charAt(1)).toBe(" ");
+    expect(out.slice(2)).toBe("501");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts
@@ -145,13 +145,24 @@ export function inProgressGlyph(): string {
 // returns (or a known prefix of them — see sourceIcon() for the matching
 // logic). All glyphs are BMP single-cell Nerd Font codepoints so they render
 // in one terminal cell next to the source label.
+//
+// CTL-358: stay inside the Font Awesome 4 BMP block (U+F000-F2E0) so glyphs
+// are stable across Nerd Fonts v2 and v3. The v3 patcher moved Material
+// Design icons (MDI) from BMP U+F500-FD46 to the supplementary plane
+// U+F0001-F1AF7 and repurposed the old codepoints — earlier MDI picks here
+// (nf-md-robot at F544, nf-md-arrange_send_to_back at F4FF) rendered as
+// arrow / silhouette glyphs in Hack Nerd Font (the current brew cask, v3).
+// Linear has no dedicated brand glyph in Nerd Fonts; the ticket icon is the
+// closest semantic match. Catalyst uses cogs (multiple gears) since
+// orchestration of many workers is the core idea.
+//
 // PUA glyphs are written as \u{…} escapes so the source file survives
 // editor / clipboard round-trips that occasionally strip non-BMP-ish chars.
 const SOURCE_ICONS: Record<string, string> = {
   github: "\u{F09B}",     // nf-fa-github
-  linear: "\u{F4FF}",     // nf-md-arrange_send_to_back (linear-y arrow)
+  linear: "\u{F145}",     // nf-fa-ticket — closest semantic match (no Linear logo in NF)
   broker: "\u{F0E7}",     // nf-fa-bolt — broker = wake router
-  catalyst: "\u{F544}",   // nf-md-robot — catalyst orchestration engine
+  catalyst: "\u{F085}",   // nf-fa-cogs — orchestrator coordinates many workers
   system: "\u{F013}",     // nf-fa-cog — generic system events
   comms: "\u{F086}",      // nf-fa-comments — agent comms channel
   filter: "\u{F0B0}",     // nf-fa-filter — legacy filter source
@@ -182,10 +193,20 @@ export function sourceIcon(source: string): string {
 
 // CTL-355: U+F407 nf-cod-git_pull_request — BMP, single-cell. Replaces "#"
 // before PR numbers in the REF column when a Nerd Font is detected.
+//
+// CTL-358: prPrefix() returns the full prefix (including a trailing space
+// when Nerd Font is detected, so the glyph and number don't visually fuse).
+// The fallback "#" stays bare since "#501" is the conventional shape.
 export const NERD_FONT_PR_PREFIX = "\u{F407}";
 export const FALLBACK_PR_PREFIX = "#";
 
-/** Returns the PR-number prefix glyph for the REF column. */
+/**
+ * Returns the PR-number prefix for the REF column —
+ *   "{glyph} " when Nerd Font is detected (e.g. " 501")
+ *   "#"       otherwise (e.g. "#501")
+ */
 export function prPrefix(): string {
-  return detectNerdFont().detected ? NERD_FONT_PR_PREFIX : FALLBACK_PR_PREFIX;
+  return detectNerdFont().detected
+    ? `${NERD_FONT_PR_PREFIX} `
+    : FALLBACK_PR_PREFIX;
 }


### PR DESCRIPTION
## Summary

Three small follow-ups to CTL-355 from screenshot review.

1. **Nerd Fonts v3 codepoint move** — v3 moved Material Design icons (MDI) from BMP U+F500–FD46 to the supplementary plane U+F0001–F1AF7 and repurposed the old codepoints. Hack Nerd Font (the brew cask) is v3, so two SOURCE_ICONS picks broke:
   - `catalyst`: U+F544 (was `nf-md-robot` in v2) rendered as a **down-arrow**
   - `linear`: U+F4FF (was `nf-md-arrange_send_to_back`) rendered as a **person silhouette**

   Fix: stay inside FA4 BMP block (U+F000–F2E0) which is stable across v2 and v3:
   - `catalyst` →  U+F085 `nf-fa-cogs` (multiple gears = orchestration)
   - `linear` →  U+F145 `nf-fa-ticket` (no native Linear logo in NF; ticket is the closest semantic match)

2. **PR number prefix gets a trailing space**. `prPrefix()` now returns ` ` (glyph + space) when Nerd Font is detected, so REF renders ` 501` instead of `501`. Fallback `#` stays bare since `#501` is the conventional shape and adding a space would look like spurious whitespace.

3. Updated tests to assert the new codepoints (0xF085 cogs, 0xF145 ticket) and the new PR prefix shape (glyph + space + number).

Linear: https://linear.app/coalesce-labs/issue/CTL-358

## Test plan

- [x] `bun test __tests__/hud-format.test.ts __tests__/nerd-font.test.ts __tests__/column-widths.test.ts` → 146 pass, 0 fail
- [ ] Manual: open `catalyst-hud` — catalyst rows show  (cogs), linear rows show  (ticket), broker stays  (bolt), github stays  (octocat); PR refs render as ` 501` not `501`
- [ ] Manual: `CATALYST_NERD_FONT=0 catalyst-hud` — bare labels and `#501` PR shape unchanged