### PR TITLE
feat(dev): broker comms_lifecycle + env-gate Groq prose path (CTL-357)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -383,6 +383,42 @@ export function loadPersistedInterests() {
   }
 }
 
+// CTL-357: one-shot startup event. If the Groq prose path is gated off (the
+// default) and any non-deterministic interests are sitting in the interests
+// table (loaded from disk for backward compat), emit a single
+// broker.daemon.prose_disabled event so the operator can see at a glance that
+// those entries exist but will never fire. Idempotent across the process
+// lifetime — once emitted, subsequent calls are no-ops.
+const DETERMINISTIC_INTEREST_TYPES = new Set([
+  "pr_lifecycle",
+  "ticket_lifecycle",
+  "comms_lifecycle",
+]);
+let _proseDisabledEmitted = false;
+
+export function __resetProseDisabledForTest() {
+  _proseDisabledEmitted = false;
+}
+
+export function maybeEmitProseDisabled() {
+  if (process.env.CATALYST_BROKER_PROSE_ENABLED === "1") return;
+  if (_proseDisabledEmitted) return;
+  const proseEntries = [...interests.entries()].filter(
+    ([, reg]) => !DETERMINISTIC_INTEREST_TYPES.has(reg?.interest_type ?? null),
+  );
+  if (proseEntries.length === 0) return;
+  appendEvent({
+    event: "broker.daemon.prose_disabled",
+    orchestrator: null,
+    worker: null,
+    detail: {
+      count: proseEntries.length,
+      sample: proseEntries.slice(0, 3).map(([id]) => id),
+    },
+  });
+  _proseDisabledEmitted = true;
+}
+
 // --- Heartbeat tracking ---
 // sourceId → { ts: number (Date.now()), notified: boolean }
 const lastHeartbeat = new Map();
@@ -419,6 +455,7 @@ export function handleRegister(event) {
   if (!id) return;
   const isPrLifecycle = d.interest_type === "pr_lifecycle";
   const isTicketLifecycle = d.interest_type === "ticket_lifecycle";
+  const isCommsLifecycle = d.interest_type === "comms_lifecycle";
   interests.set(id, {
     notify_event: d.notify_event ?? `filter.wake.${id}`,
     prompt: d.prompt ?? "",
@@ -434,6 +471,12 @@ export function handleRegister(event) {
     // ticket_lifecycle fields (CTL-303)
     tickets: isTicketLifecycle ? (Array.isArray(d.tickets) ? d.tickets : []) : null,
     wake_on: isTicketLifecycle ? (Array.isArray(d.wake_on) ? d.wake_on : null) : null,
+    // comms_lifecycle fields (CTL-357)
+    channel: isCommsLifecycle ? (d.channel ?? null) : null,
+    subscriber_kind: isCommsLifecycle ? (d.subscriber_kind ?? null) : null,
+    owned_workers: isCommsLifecycle ? (Array.isArray(d.owned_workers) ? d.owned_workers : null) : null,
+    subscriber_ticket: isCommsLifecycle ? (d.subscriber_ticket ?? null) : null,
+    types_of_interest: isCommsLifecycle ? (Array.isArray(d.types_of_interest) ? d.types_of_interest : null) : null,
   });
 
   if (isPrLifecycle) {
@@ -455,6 +498,17 @@ export function handleRegister(event) {
   } else if (isTicketLifecycle) {
     log.info(
       { interestId: id, type: "ticket_lifecycle", tickets: d.tickets ?? [], persistent },
+      "registered",
+    );
+  } else if (isCommsLifecycle) {
+    log.info(
+      {
+        interestId: id,
+        type: "comms_lifecycle",
+        channel: d.channel,
+        subscriberKind: d.subscriber_kind,
+        persistent,
+      },
       "registered",
     );
   } else {
@@ -616,6 +670,41 @@ function botPrefix(author, kind) {
   return "";
 }
 
+// CTL-357: default `types_of_interest` for comms_lifecycle subscribers.
+// Orchestrators only care about attention/done by default (no info-heartbeat
+// firehose). Workers default to all types — orchestrator→worker traffic is
+// rare and intentional, so we never want to silently drop it.
+const COMMS_DEFAULT_TYPES_BY_KIND = {
+  orchestrator: ["attention", "done"],
+  worker: null,
+};
+
+function matchCommsLifecycle(reg, event) {
+  if (getEventName(event) !== "comms.message.posted") return null;
+  const payload = getEventPayload(event);
+  if (!payload || typeof payload !== "object") return null;
+  if (payload.channel !== reg.channel) return null;
+
+  const allowedTypes = reg.types_of_interest ?? COMMS_DEFAULT_TYPES_BY_KIND[reg.subscriber_kind];
+  if (Array.isArray(allowedTypes) && !allowedTypes.includes(payload.type)) return null;
+
+  const sender = event.attributes?.["catalyst.worker.ticket"] ?? payload.from ?? null;
+
+  if (reg.subscriber_kind === "orchestrator") {
+    if (!Array.isArray(reg.owned_workers) || !reg.owned_workers.includes(sender)) return null;
+    return `Worker ${sender} posted ${payload.type} on ${payload.channel}`;
+  }
+
+  if (reg.subscriber_kind === "worker") {
+    if (sender && sender === reg.subscriber_ticket) return null; // self-loop guard
+    const to = payload.to;
+    if (to !== reg.subscriber_ticket && to !== "all") return null;
+    return `Message to ${reg.subscriber_ticket} (${payload.type}) on ${payload.channel} from ${sender ?? "unknown"}`;
+  }
+
+  return null;
+}
+
 export function tryDeterministicRoute(event, interestsMap) {
   const matches = [];
   const name = event.event ?? "";
@@ -634,6 +723,21 @@ export function tryDeterministicRoute(event, interestsMap) {
   }
 
   for (const [interestId, reg] of interestsMap) {
+    // CTL-357: comms_lifecycle is also deterministic — handled in this same
+    // routing pass so a single `tryDeterministicRoute` call covers both kinds.
+    if (reg.interest_type === "comms_lifecycle") {
+      const reason = matchCommsLifecycle(reg, event);
+      if (reason) {
+        matches.push({
+          interestId,
+          reason,
+          sourceEventId: eventId,
+          sourceEvent: summarizeEvent(event),
+        });
+      }
+      continue;
+    }
+
     if (reg.interest_type !== "pr_lifecycle") continue;
 
     let reason = null;
@@ -740,8 +844,12 @@ const TICKET_LIFECYCLE_ALL_WAKE_ON = [
 
 export function tryTicketLifecycleRoute(event, interestsMap) {
   const matches = [];
-  const name = event.event ?? "";
-  const detail = event.detail ?? {};
+  // CTL-357: read event name + payload via the canonical-aware helpers so
+  // canonical OTel envelopes (where the name lives under
+  // attributes["event.name"] and the payload under body.payload) match the
+  // same routing rules as legacy flat events. CTL-354 caught this gap.
+  const name = getEventName(event);
+  const detail = getEventPayload(event);
   const scope = event.scope ?? {};
   const attrs = event.attributes ?? {};
   // CTL-344: real id on new envelopes, synthetic id for legacy events.
@@ -935,7 +1043,10 @@ export function buildGroqPrompt(events) {
 
   // Deterministic-routed interest types are excluded from the Groq prompt.
   const proseInterests = [...interests.entries()].filter(
-    ([, reg]) => reg.interest_type !== "pr_lifecycle" && reg.interest_type !== "ticket_lifecycle",
+    ([, reg]) =>
+      reg.interest_type !== "pr_lifecycle" &&
+      reg.interest_type !== "ticket_lifecycle" &&
+      reg.interest_type !== "comms_lifecycle",
   );
   if (proseInterests.length === 0) return null;
 
@@ -961,7 +1072,12 @@ export function buildGroqPrompt(events) {
   return { systemPrompt, userPrompt };
 }
 
-async function classifyBatch(events) {
+export async function classifyBatch(events) {
+  // CTL-357: env-gate the Groq prose path. Default is off; existing prose
+  // interests on disk are accepted (for backward compat) but never matched
+  // against events. Flip to "1" only when the per-interest prompt is known
+  // to produce real signal, not the historical ~95% false-positive firehose.
+  if (process.env.CATALYST_BROKER_PROSE_ENABLED !== "1") return;
   const prompts = buildGroqPrompt(events);
   if (!prompts) return;
 
@@ -1531,6 +1647,11 @@ function main() {
   lastLogPath = getEventLogPath();
   loadPersistedInterests();
   loadExistingRegistrations();
+
+  // CTL-357: surface stale prose interests left on disk now that the Groq path
+  // is off by default. Single-shot info event so the HUD/operator can see them
+  // without grepping broker-interests.json.
+  maybeEmitProseDisabled();
 
   openBrokerStateDb();
 

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -1741,3 +1741,522 @@ describe("CTL-352 broker state + degraded event", () => {
     expect(degradedLines).toHaveLength(2);
   });
 });
+
+// ─── CTL-357 comms_lifecycle interest type ───────────────────────────────────
+
+describe("CTL-357 comms_lifecycle registration", () => {
+  test("handleRegister stores comms_lifecycle interest fields (legacy envelope)", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-comms-1",
+      detail: {
+        interest_id: "orch-comms-1-comms",
+        notify_event: "filter.wake.orch-comms-1",
+        interest_type: "comms_lifecycle",
+        channel: "orch-orch-comms-1",
+        subscriber_kind: "orchestrator",
+        owned_workers: ["CTL-100", "CTL-101"],
+        types_of_interest: ["attention", "done"],
+        persistent: true,
+      },
+    });
+    const reg = getInterests().get("orch-comms-1-comms");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("comms_lifecycle");
+    expect(reg.channel).toBe("orch-orch-comms-1");
+    expect(reg.subscriber_kind).toBe("orchestrator");
+    expect(reg.owned_workers).toEqual(["CTL-100", "CTL-101"]);
+    expect(reg.types_of_interest).toEqual(["attention", "done"]);
+    expect(reg.persistent).toBe(true);
+    // pr_lifecycle/ticket_lifecycle fields stay null
+    expect(reg.pr_numbers).toBeNull();
+    expect(reg.tickets).toBeNull();
+  });
+
+  test("handleRegister stores comms_lifecycle interest fields (canonical envelope)", () => {
+    handleRegister({
+      attributes: {
+        "event.name": "filter.register",
+        "catalyst.orchestrator.id": "orch-comms-canon",
+      },
+      body: {
+        payload: {
+          interest_id: "worker-CTL-200",
+          notify_event: "filter.wake.worker-CTL-200",
+          interest_type: "comms_lifecycle",
+          channel: "orch-orch-comms-canon",
+          subscriber_kind: "worker",
+          subscriber_ticket: "CTL-200",
+          persistent: true,
+        },
+      },
+    });
+    const reg = getInterests().get("worker-CTL-200");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("comms_lifecycle");
+    expect(reg.subscriber_kind).toBe("worker");
+    expect(reg.subscriber_ticket).toBe("CTL-200");
+    expect(reg.channel).toBe("orch-orch-comms-canon");
+  });
+
+  test("comms_lifecycle interest is excluded from Groq prompt", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-comms-2",
+      detail: {
+        interest_id: "comms-only",
+        interest_type: "comms_lifecycle",
+        channel: "orch-orch-comms-2",
+        subscriber_kind: "orchestrator",
+        owned_workers: ["CTL-300"],
+        persistent: true,
+      },
+    });
+    // No prose interest exists, so the prompt should be null entirely.
+    const prompt = buildGroqPrompt([{ event: "comms.message.posted" }]);
+    expect(prompt).toBeNull();
+  });
+});
+
+describe("CTL-357 tryDeterministicRoute — comms_lifecycle (orchestrator subscriber)", () => {
+  beforeEach(() => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-comms-orch",
+      detail: {
+        interest_id: "orch-comms-orch-comms",
+        notify_event: "filter.wake.orch-comms-orch",
+        interest_type: "comms_lifecycle",
+        channel: "orch-orch-comms-orch",
+        subscriber_kind: "orchestrator",
+        owned_workers: ["CTL-100", "CTL-101"],
+        types_of_interest: ["attention", "done"],
+        persistent: true,
+      },
+    });
+  });
+
+  const buildCommsEvent = ({ sender, channel, type, to = "all", body = "test" }) => ({
+    attributes: {
+      "event.name": "comms.message.posted",
+      "catalyst.worker.ticket": sender,
+    },
+    body: {
+      payload: { channel, type, msgId: "msg-test", to, body },
+    },
+  });
+
+  test("fires when an owned worker posts attention on the watched channel", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "CTL-100", channel: "orch-orch-comms-orch", type: "attention", body: "CI blocked" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("orch-comms-orch-comms");
+    expect(matches[0].reason).toContain("CTL-100");
+    expect(matches[0].reason).toContain("attention");
+  });
+
+  test("fires when an owned worker posts done on the watched channel", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "CTL-101", channel: "orch-orch-comms-orch", type: "done" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("CTL-101");
+    expect(matches[0].reason).toContain("done");
+  });
+
+  test("does NOT fire when an owned worker posts info (not in types_of_interest)", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "CTL-100", channel: "orch-orch-comms-orch", type: "info" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  test("does NOT fire when a non-owned worker posts on the watched channel", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "CTL-999", channel: "orch-orch-comms-orch", type: "attention" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  test("does NOT fire on a different channel", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "CTL-100", channel: "orch-other-orch", type: "attention" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  test("orchestrator default types_of_interest is ['attention','done'] when omitted", () => {
+    clearInterests();
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-default",
+      detail: {
+        interest_id: "orch-default-comms",
+        notify_event: "filter.wake.orch-default",
+        interest_type: "comms_lifecycle",
+        channel: "orch-orch-default",
+        subscriber_kind: "orchestrator",
+        owned_workers: ["CTL-555"],
+        // types_of_interest omitted
+        persistent: true,
+      },
+    });
+    expect(
+      tryDeterministicRoute(
+        buildCommsEvent({ sender: "CTL-555", channel: "orch-orch-default", type: "attention" }),
+        getInterests(),
+      ),
+    ).toHaveLength(1);
+    expect(
+      tryDeterministicRoute(
+        buildCommsEvent({ sender: "CTL-555", channel: "orch-orch-default", type: "done" }),
+        getInterests(),
+      ),
+    ).toHaveLength(1);
+    expect(
+      tryDeterministicRoute(
+        buildCommsEvent({ sender: "CTL-555", channel: "orch-orch-default", type: "info" }),
+        getInterests(),
+      ),
+    ).toHaveLength(0);
+  });
+
+  test("only matches comms.message.posted events", () => {
+    // A different event name on the watched channel should not match a comms interest.
+    const matches = tryDeterministicRoute(
+      {
+        attributes: { "event.name": "github.pr.merged", "catalyst.worker.ticket": "CTL-100" },
+        body: { payload: { channel: "orch-orch-comms-orch", type: "attention", to: "all", body: "" } },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("CTL-357 tryDeterministicRoute — comms_lifecycle (worker subscriber)", () => {
+  beforeEach(() => {
+    handleRegister({
+      event: "filter.register",
+      detail: {
+        interest_id: "worker-CTL-357",
+        notify_event: "filter.wake.worker-CTL-357",
+        interest_type: "comms_lifecycle",
+        channel: "orch-orch-comms-worker",
+        subscriber_kind: "worker",
+        subscriber_ticket: "CTL-357",
+        persistent: true,
+      },
+    });
+  });
+
+  const buildCommsEvent = ({ sender, channel, type = "info", to, body = "test" }) => ({
+    attributes: {
+      "event.name": "comms.message.posted",
+      "catalyst.worker.ticket": sender,
+    },
+    body: {
+      payload: { channel, type, msgId: "msg-test", to, body },
+    },
+  });
+
+  test("fires when payload.to equals subscriber_ticket", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "orchestrator", channel: "orch-orch-comms-worker", to: "CTL-357", body: "rebase now" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("worker-CTL-357");
+  });
+
+  test("fires when payload.to is 'all'", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "orchestrator", channel: "orch-orch-comms-worker", to: "all" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+  });
+
+  test("does NOT fire when payload.to is a different worker", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "orchestrator", channel: "orch-orch-comms-worker", to: "CTL-999" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  test("does NOT fire when sender is the worker itself (self-loop guard)", () => {
+    const matches = tryDeterministicRoute(
+      buildCommsEvent({ sender: "CTL-357", channel: "orch-orch-comms-worker", to: "all" }),
+      getInterests(),
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  test("worker default fires on all types when types_of_interest omitted", () => {
+    for (const type of ["info", "attention", "done"]) {
+      const matches = tryDeterministicRoute(
+        buildCommsEvent({ sender: "orchestrator", channel: "orch-orch-comms-worker", type, to: "all" }),
+        getInterests(),
+      );
+      expect(matches).toHaveLength(1);
+    }
+  });
+});
+
+// ─── CTL-357 prose env gate ──────────────────────────────────────────────────
+
+describe("CTL-357 prose env gate (CATALYST_BROKER_PROSE_ENABLED)", () => {
+  let savedEnv;
+  let savedFetch;
+
+  beforeEach(() => {
+    savedEnv = process.env.CATALYST_BROKER_PROSE_ENABLED;
+    savedFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.CATALYST_BROKER_PROSE_ENABLED;
+    else process.env.CATALYST_BROKER_PROSE_ENABLED = savedEnv;
+    globalThis.fetch = savedFetch;
+  });
+
+  test("when disabled, classifyBatch does NOT call Groq fetch", async () => {
+    delete process.env.CATALYST_BROKER_PROSE_ENABLED;
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return { ok: true, json: async () => ({ choices: [{ message: { content: "[]" } }] }) };
+    };
+    // Register a prose interest so classifyBatch has something to chew on.
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-prose-gate",
+      detail: {
+        interest_id: "prose-gate-1",
+        notify_event: "filter.wake.prose-gate-1",
+        prompt: "wake on anything",
+        persistent: true,
+      },
+    });
+    const { classifyBatch } = await import("./index.mjs");
+    await classifyBatch([{ event: "linear.issue.state_changed", detail: { state: "Done" } }]);
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("when CATALYST_BROKER_PROSE_ENABLED=1, classifyBatch DOES call Groq fetch", async () => {
+    process.env.CATALYST_BROKER_PROSE_ENABLED = "1";
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return { ok: true, json: async () => ({ choices: [{ message: { content: "[]" } }] }) };
+    };
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-prose-on",
+      detail: {
+        interest_id: "prose-on-1",
+        notify_event: "filter.wake.prose-on-1",
+        prompt: "wake on anything",
+        persistent: true,
+      },
+    });
+    // classifyBatch requires GROQ_API_KEY too; export the fake.
+    process.env.GROQ_API_KEY = "test-key";
+    const { classifyBatch } = await import("./index.mjs");
+    await classifyBatch([{ event: "linear.issue.state_changed", detail: { state: "Done" } }]);
+    expect(fetchCalled).toBe(true);
+    delete process.env.GROQ_API_KEY;
+  });
+});
+
+describe("CTL-357 broker.daemon.prose_disabled startup event", () => {
+  beforeEach(async () => {
+    const { __resetProseDisabledForTest } = await import("./index.mjs");
+    __resetProseDisabledForTest?.();
+  });
+
+  test("emits exactly one prose_disabled event when prose interests exist and gate is off", async () => {
+    delete process.env.CATALYST_BROKER_PROSE_ENABLED;
+    const { maybeEmitProseDisabled, __resetProseDisabledForTest } = await import("./index.mjs");
+    __resetProseDisabledForTest();
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-prose-stale",
+      detail: {
+        interest_id: "stale-prose-1",
+        notify_event: "filter.wake.stale-prose-1",
+        prompt: "legacy prose interest",
+        persistent: true,
+      },
+    });
+    maybeEmitProseDisabled();
+    maybeEmitProseDisabled(); // idempotent — should not double-emit
+
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    expect(existsSync(logPath)).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+    const proseDisabledLines = lines.filter((l) => {
+      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled"; }
+      catch { return false; }
+    });
+    expect(proseDisabledLines).toHaveLength(1);
+    const evt = JSON.parse(proseDisabledLines[0]);
+    expect(evt.body.payload.count).toBe(1);
+    expect(evt.body.payload.sample).toContain("stale-prose-1");
+  });
+
+  test("emits nothing when no prose interests exist", async () => {
+    delete process.env.CATALYST_BROKER_PROSE_ENABLED;
+    const { maybeEmitProseDisabled, __resetProseDisabledForTest } = await import("./index.mjs");
+    __resetProseDisabledForTest();
+    // Only register a deterministic interest.
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-no-prose",
+      detail: {
+        interest_id: "pr-only-1",
+        interest_type: "pr_lifecycle",
+        notify_event: "filter.wake.pr-only-1",
+        pr_numbers: [1],
+        repo: "x/y",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+    maybeEmitProseDisabled();
+
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    if (!existsSync(logPath)) return;
+    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+    const proseDisabledLines = lines.filter((l) => {
+      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled"; }
+      catch { return false; }
+    });
+    expect(proseDisabledLines).toHaveLength(0);
+  });
+
+  test("emits nothing when gate is on", async () => {
+    process.env.CATALYST_BROKER_PROSE_ENABLED = "1";
+    const { maybeEmitProseDisabled, __resetProseDisabledForTest } = await import("./index.mjs");
+    __resetProseDisabledForTest();
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-prose-on-2",
+      detail: {
+        interest_id: "prose-on-2-1",
+        notify_event: "filter.wake.prose-on-2-1",
+        prompt: "still prose",
+        persistent: true,
+      },
+    });
+    maybeEmitProseDisabled();
+
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    if (!existsSync(logPath)) {
+      delete process.env.CATALYST_BROKER_PROSE_ENABLED;
+      return;
+    }
+    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+    const proseDisabledLines = lines.filter((l) => {
+      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled"; }
+      catch { return false; }
+    });
+    expect(proseDisabledLines).toHaveLength(0);
+    delete process.env.CATALYST_BROKER_PROSE_ENABLED;
+  });
+});
+
+// ─── CTL-357 tryTicketLifecycleRoute canonical envelopes ─────────────────────
+
+describe("CTL-357 tryTicketLifecycleRoute canonical envelopes", () => {
+  beforeEach(() => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-canon-ticket",
+      detail: {
+        interest_id: "watch-ctl-canon",
+        notify_event: "filter.wake.watch-ctl-canon",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-275"],
+        wake_on: ["status_done", "status_in_review", "status_changed", "pr_merged", "comment_added"],
+        persistent: true,
+      },
+    });
+  });
+
+  test("matches canonical linear.issue.state_changed event", () => {
+    const matches = tryTicketLifecycleRoute(
+      {
+        attributes: {
+          "event.name": "linear.issue.state_changed",
+          "linear.issue.identifier": "CTL-275",
+        },
+        body: { payload: { state: "Done" } },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("marked Done");
+  });
+
+  test("matches canonical linear.comment.created event", () => {
+    const matches = tryTicketLifecycleRoute(
+      {
+        attributes: {
+          "event.name": "linear.comment.created",
+          "linear.issue.identifier": "CTL-275",
+        },
+        body: { payload: { author: "ryan" } },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("CTL-275");
+  });
+
+  test("matches canonical github.pr.merged event with ticket reference in body", () => {
+    const matches = tryTicketLifecycleRoute(
+      {
+        attributes: {
+          "event.name": "github.pr.merged",
+          "vcs.pr.number": 999,
+        },
+        body: {
+          payload: {
+            body: "Fixes CTL-275",
+            title: "fix thing",
+            headRef: "ryan/ctl-275",
+          },
+        },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].ticket).toBe("CTL-275");
+    expect(matches[0].reason).toContain("merged");
+  });
+
+  test("legacy envelope tests continue to pass after canonical fix", () => {
+    // Re-run the existing legacy pattern explicitly to lock in backward compat.
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "linear.issue.state_changed",
+        attributes: { "linear.issue.identifier": "CTL-275" },
+        detail: { state: "Done" },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("marked Done");
+  });
+});

--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -44,7 +44,8 @@ catalyst-broker logs
 |---|---|---|
 | `pr_lifecycle` | Deterministic | Watch CI, reviews, merge, deployment for a known PR number |
 | `ticket_lifecycle` | Deterministic | Watch Linear state changes, comments, PR links for a ticket |
-| (prose prompt) | Groq LLM | Anything ambiguous, cross-cutting, or complex |
+| `comms_lifecycle` | Deterministic | Watch comms-channel messages (worker → orchestrator attention/done, orchestrator → worker directives) |
+| (prose prompt) | Groq LLM (env-gated off; CTL-357) | Anything ambiguous, cross-cutting, or complex — set `CATALYST_BROKER_PROSE_ENABLED=1` to re-enable |
 
 ## 1. Auto-Correlation (The Common Case — No Registration Needed)
 
@@ -173,6 +174,125 @@ EVENT=$(catalyst-events wait-for \
   --timeout 600 2>/dev/null || true)
 ```
 
+## 4a. `comms_lifecycle` Interest Type (CTL-357)
+
+Deterministic routing for `comms.message.posted` events on a shared comms channel. Replaces the
+Groq prose interest the orchestrator used to register for "any of my workers posts an attention
+message". The routing is keyed on channel + sender + message-type, with no model call.
+
+### Subscriber kinds
+
+- **`subscriber_kind: "orchestrator"`** — wakes when one of the orchestrator's `owned_workers`
+  posts a message of an interesting type. Default `types_of_interest` is `["attention", "done"]`
+  (matches `attention` and `done`, ignores `info` heartbeats).
+- **`subscriber_kind: "worker"`** — wakes when a peer posts a message addressed to this worker
+  (`to=<subscriber_ticket>`) or to all (`to=all`). Self-posts are ignored (self-loop guard).
+  Workers default to all message types — orchestrator → worker traffic is rare and intentional.
+
+### Schema
+
+```json
+{
+  "interest_id": "<id>",
+  "interest_type": "comms_lifecycle",
+  "notify_event": "filter.wake.<id>",
+  "persistent": true,
+  "channel": "orch-<orch-id>",
+  "subscriber_kind": "orchestrator",
+  "owned_workers": ["CTL-352", "CTL-354"],
+  "types_of_interest": ["attention", "done"]
+}
+```
+
+Worker variant:
+```json
+{
+  "interest_id": "<sess-id>-comms",
+  "interest_type": "comms_lifecycle",
+  "notify_event": "filter.wake.<sess-id>",
+  "persistent": true,
+  "channel": "orch-<orch-id>",
+  "subscriber_kind": "worker",
+  "subscriber_ticket": "CTL-357"
+}
+```
+
+### Registering (orchestrator)
+
+```bash
+jq -nc \
+  --arg orch "${CATALYST_ORCHESTRATOR_ID}" \
+  --arg id "${CATALYST_ORCHESTRATOR_ID}-comms" \
+  --arg channel "orch-${CATALYST_ORCHESTRATOR_ID}" \
+  --argjson workers '["CTL-352","CTL-354"]' \
+  '{ts: (now | todate), event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $id,
+      interest_type: "comms_lifecycle",
+      notify_event: ("filter.wake." + $orch),
+      persistent: true,
+      channel: $channel,
+      subscriber_kind: "orchestrator",
+      owned_workers: $workers,
+      types_of_interest: ["attention", "done"]
+    }}' >> ~/catalyst/events/$(date -u +%Y-%m).jsonl
+```
+
+### Registering (worker)
+
+The worker uses interest_id `"${CATALYST_SESSION_ID}-comms"` (NOT just the session_id) so it
+coexists with the broker's auto-correlated `pr_lifecycle` interest (interest_id =
+session_id). Both share `notify_event: "filter.wake.${CATALYST_SESSION_ID}"`, so the
+existing `wait-for` predicate is unchanged.
+
+```bash
+jq -nc \
+  --arg sid "$CATALYST_SESSION_ID" \
+  --arg id "${CATALYST_SESSION_ID}-comms" \
+  --arg orch "${CATALYST_ORCHESTRATOR_ID}" \
+  --arg channel "$CATALYST_COMMS_CHANNEL" \
+  --arg ticket "$TICKET_ID" \
+  '{ts: (now | todate), event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $id,
+      interest_type: "comms_lifecycle",
+      notify_event: ("filter.wake." + $sid),
+      persistent: true,
+      session_id: $sid,
+      channel: $channel,
+      subscriber_kind: "worker",
+      subscriber_ticket: $ticket
+    }}' >> ~/catalyst/events/$(date -u +%Y-%m).jsonl
+```
+
+### Match logic (no Groq call)
+
+| Trigger | Condition |
+|---|---|
+| `event.name == "comms.message.posted"` | always required |
+| `body.payload.channel == reg.channel` | always required |
+| `body.payload.type` ∈ `reg.types_of_interest` | required (defaults: orchestrator → `["attention","done"]`, worker → all types) |
+| Orchestrator: `attributes."catalyst.worker.ticket"` ∈ `reg.owned_workers` | required for orchestrator subscribers |
+| Worker: `body.payload.to == reg.subscriber_ticket` OR `body.payload.to == "all"` | required for worker subscribers |
+| Worker: sender (`catalyst.worker.ticket`) != `reg.subscriber_ticket` | self-loop guard |
+
+### Wake Event Shape
+
+```json
+{
+  "event": "filter.wake.orch-2026-05-12",
+  "detail": {
+    "reason": "Worker CTL-352 posted attention on orch-orch-2026-05-12",
+    "source_event_ids": ["..."],
+    "interest_id": "orch-2026-05-12-comms"
+  }
+}
+```
+
 ## 5. `pr_lifecycle` Interest Type (CTL-284 — Unchanged)
 
 Explicit PR-number registration still works:
@@ -203,9 +323,21 @@ Events matched: `github.check_suite.completed`, `github.pr.merged`, `github.pr.c
 `github.pr_review.submitted`, `github.pr_review_comment.created`, `github.pr_review_thread.resolved`,
 `github.deployment.created`, `github.deployment_status.*`, `github.push` (base-branch pushes).
 
-## 6. Groq Prose Registration (Unchanged)
+## 6. Groq Prose Registration (Env-gated off — CTL-357)
 
-For complex / multi-condition interests, register with a natural-language prompt:
+> **Off by default.** `CATALYST_BROKER_PROSE_ENABLED=0` is the new default. Empirical evidence
+> (`orch-ctl-352-354-2026-05-12`) showed a ~95% false-positive rate on prose wakes — every
+> session heartbeat, every unrelated Linear ticket change, and every info comms post matched
+> nominally narrow interests. Prose interests already on disk are loaded but never matched against
+> events. On startup, if any prose interests are found, the broker emits a single
+> `broker.daemon.prose_disabled` info event so the operator can see them at a glance.
+>
+> Set `CATALYST_BROKER_PROSE_ENABLED=1` in the environment when launching the daemon to re-enable
+> Groq classification for prompt-based interests. Prefer the deterministic types
+> (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`) for anything routine.
+
+For complex / multi-condition interests that genuinely need fuzzy matching, register with a
+natural-language prompt:
 
 ```bash
 jq -nc \

--- a/plugins/dev/skills/catalyst-filter/SKILL.md
+++ b/plugins/dev/skills/catalyst-filter/SKILL.md
@@ -8,11 +8,14 @@ description:
   not running.
 ---
 
-> **Deprecated (CTL-303):** `catalyst-filter` has been superseded by `catalyst-broker`.
-> The broker daemon adds structured agent identity, `ticket_lifecycle` routing for Linear events,
-> and auto-correlation of ticket↔PR interests. All `filter.register` / `pr_lifecycle` / Groq prose
-> registration documented here continues to work unchanged — the daemon script (`catalyst-filter`)
-> is now a thin alias for `catalyst-broker`. See [[broker]] for the full updated reference.
+> **Deprecated (CTL-303, updated CTL-357):** `catalyst-filter` has been superseded by
+> `catalyst-broker`. The broker daemon adds structured agent identity, `ticket_lifecycle` routing
+> for Linear events, `comms_lifecycle` routing for shared comms channels, and auto-correlation of
+> ticket↔PR interests. The Groq prose path described in this doc is now **env-gated off** by
+> default (`CATALYST_BROKER_PROSE_ENABLED=0`); prose interests on disk are accepted for backward
+> compat but never fire. The `filter.register` / `pr_lifecycle` / `ticket_lifecycle` /
+> `comms_lifecycle` paths are all deterministic and unchanged. See [[broker]] for the full updated
+> reference.
 
 # catalyst-filter — Semantic Event Routing Protocol
 
@@ -58,18 +61,29 @@ catalyst-filter logs
 ## Protocol Overview
 
 ```
-Orchestrator                         filter daemon                     Event log
-    │                                     │                                │
-    │── emit filter.register ────────────►│                                │
-    │                                     │  polls every 200ms ◄───────────│
-    │                                     │  batches events (100ms debounce)
-    │                                     │  calls Groq: "is this relevant?"
-    │                                     │── append filter.wake.{id} ────►│
-    │                                     │                                │
-    │◄── catalyst-events wait-for ────────────────────────────────────────│
-    │    (.attributes."event.name" == "filter.wake.{id}")                                      │                                │
-    │                                     │                                │
-    │── emit filter.deregister ──────────►│                                │
+Orchestrator                          broker daemon                       Event log
+    │                                     │                                  │
+    │── emit filter.register ────────────►│                                  │
+    │                                     │  polls every 200ms ◄─────────────│
+    │                                     │                                  │
+    │                                     │  deterministic match?            │
+    │                                     │   ├─ pr_lifecycle ──┐            │
+    │                                     │   ├─ ticket_lifecycle ┐          │
+    │                                     │   └─ comms_lifecycle ─┤          │
+    │                                     │                       ▼          │
+    │                                     │── append filter.wake.{id} ──────►│
+    │                                     │                                  │
+    │                                     │  prose path (env-gated; OFF      │
+    │                                     │  by default since CTL-357):      │
+    │                                     │   • batches events (100ms        │
+    │                                     │     debounce)                    │
+    │                                     │   • calls Groq for prose         │
+    │                                     │     interests                    │
+    │                                     │                                  │
+    │◄── catalyst-events wait-for ─────────────────────────────────────────-│
+    │    (.attributes."event.name" == "filter.wake.{id}")                    │
+    │                                     │                                  │
+    │── emit filter.deregister ──────────►│                                  │
 ```
 
 ## Step 1 — Register

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -244,10 +244,54 @@ filter_register_worker() {
 filter_deregister_worker() {
   broker_daemon_running || return 0
   [ -n "${CATALYST_SESSION_ID:-}" ] || return 0
+  # Deregister the auto-correlated pr_lifecycle interest (interest_id = sid).
   "$STATE_SCRIPT" event "$(jq -nc \
     --arg sid "$CATALYST_SESSION_ID" \
     '{ts: (now | todate), event: "filter.deregister", orchestrator: null, worker: null, detail: {interest_id: $sid}}')" 2>/dev/null || true
+  # CTL-357: also deregister the comms_lifecycle interest (interest_id = sid-comms).
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg id "${CATALYST_SESSION_ID}-comms" \
+    '{ts: (now | todate), event: "filter.deregister", orchestrator: null, worker: null, detail: {interest_id: $id}}')" 2>/dev/null || true
 }
+
+# CTL-357: register a comms_lifecycle worker subscription so the broker wakes
+# the worker on messages directed at it (`to=$TICKET_ID` or `to=all`) on the
+# shared channel. The interest_id is "${CATALYST_SESSION_ID}-comms" — distinct
+# from the broker's auto-correlated pr_lifecycle interest (which uses just
+# the session_id) so the two interests coexist. Both share the same
+# notify_event = filter.wake.${CATALYST_SESSION_ID}, so the Phase 5 listen
+# loop predicate is unchanged. Best-effort; broker absence is fine.
+broker_register_comms() {
+  broker_daemon_running || return 0
+  [ -n "${CATALYST_SESSION_ID:-}" ] || return 0
+  [ -n "${CATALYST_COMMS_CHANNEL:-}" ] || return 0
+  [ -n "${TICKET_ID:-}" ] || return 0
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg sid "$CATALYST_SESSION_ID" \
+    --arg id "${CATALYST_SESSION_ID}-comms" \
+    --arg orch "${CATALYST_ORCHESTRATOR_ID:-}" \
+    --arg notify "filter.wake.${CATALYST_SESSION_ID}" \
+    --arg channel "$CATALYST_COMMS_CHANNEL" \
+    --arg ticket "$TICKET_ID" \
+    '{ts: (now | todate), event: "filter.register",
+      orchestrator: (if $orch == "" then null else $orch end),
+      worker: null,
+      detail: {
+        interest_id: $id,
+        interest_type: "comms_lifecycle",
+        notify_event: $notify,
+        persistent: true,
+        session_id: $sid,
+        channel: $channel,
+        subscriber_kind: "worker",
+        subscriber_ticket: $ticket
+      }}')" 2>/dev/null || true
+}
+
+# Register the worker's comms subscription once at startup. The wait-for
+# filter (filter.wake.${CATALYST_SESSION_ID}) is unchanged — this just gives
+# the broker a second deterministic reason to fire that wake.
+broker_register_comms
 
 # Belt-and-suspenders: trap on EXIT/INT/TERM ensures graceful deregister.
 # Watchdog cleanup in the daemon handles crash cases via session_id matching.

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -695,12 +695,19 @@ if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
 fi
 ```
 
-**Register with catalyst-broker daemon (CTL-257, updated CTL-303):** When `catalyst-broker status`
-returns 0, emit `filter.register` at Phase 4 start so the daemon pre-filters incoming events and
-emits targeted `filter.wake.{ORCH_NAME}` events. Workers auto-correlate their own `pr_lifecycle`
-interests via `agent.checkin` — the orchestrator only needs to register the prose interest for
-comms-attention/ticket-status routing and the `pr_lifecycle` interest for orchestrator-level
-aggregation across all workers.
+**Register with catalyst-broker daemon (CTL-257, updated CTL-303, CTL-357):** When
+`catalyst-broker status` returns 0, emit `filter.register` events at Phase 4 start so the daemon
+pre-filters incoming events and emits targeted `filter.wake.{ORCH_NAME}` events. Workers
+auto-correlate their own `pr_lifecycle` interests via `agent.checkin`; the orchestrator registers
+three deterministic interests for itself — all of them route without Groq:
+
+- `pr_lifecycle` — orchestrator-level aggregation across all worker PRs.
+- `ticket_lifecycle` — Linear ticket state changes for the orchestrator's tickets.
+- `comms_lifecycle` — worker-posted `attention` / `done` messages on the shared channel.
+
+CTL-357 retired the Groq prose interest (~95% false-positive rate). All three replacements share
+the same `notify_event: "filter.wake.${ORCH_NAME}"`, so the orchestrator's `wait-for` filter does
+not change.
 
 ```bash
 if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
@@ -718,39 +725,13 @@ if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2
   ACTIVE_BRANCHES_JSON=$(printf '%s\n' "${ACTIVE_BRANCHES_ARR[@]}" \
     | jq -Rnc '[inputs]' 2>/dev/null || echo '[]')
 
-  "$STATE_SCRIPT" event "$(jq -nc \
-    --arg orch "${ORCH_NAME}" \
-    --arg sid "${CATALYST_SESSION_ID:-}" \
-    --arg notify "filter.wake.${ORCH_NAME}" \
-    --argjson prs "${ACTIVE_PRS}" \
-    --argjson tickets "${ACTIVE_TICKETS}" \
-    --argjson branches "${ACTIVE_BRANCHES_JSON}" \
-    '{
-      ts: (now | todate),
-      event: "filter.register",
-      orchestrator: $orch,
-      worker: null,
-      detail: {
-        session_id: (if $sid == "" then null else $sid end),
-        notify_event: $notify,
-        prompt: "Wake me when: any of my workers posts a comms message of type attention to me; or one of my Linear tickets changes status",
-        persistent: true,
-        context: {pr_numbers: $prs, tickets: $tickets, branches: $branches}
-      }
-    }')"
-
-  # CTL-284: register a SECOND interest using the built-in pr_lifecycle type.
-  # The deterministic router handles all PR/CI/review/deployment events without
-  # Groq. The prose interest above only covers the residual concerns
-  # (comms-attention and Linear ticket status changes). Both interests use the
-  # same notify_event so the wait-for filter is unchanged — wakes from either
-  # path arrive on filter.wake.${ORCH_NAME}.
   REPO_FULL_NAME=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
   ACTIVE_BASES_JSON=$(jq -rs '[
     .[] | select(.pr.number != null and .pr.baseRefName != null)
         | {pr: .pr.number, base: .pr.baseRefName}
   ]' "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
 
+  # CTL-284: pr_lifecycle interest (deterministic PR/CI/review/deployment routing)
   "$STATE_SCRIPT" event "$(jq -nc \
     --arg orch "${ORCH_NAME}" \
     --arg id "${ORCH_NAME}-pr-lifecycle" \
@@ -771,6 +752,55 @@ if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2
         pr_numbers: $prs,
         repo: $repo,
         base_branches: $bases
+      }
+    }')"
+
+  # CTL-303: ticket_lifecycle interest (deterministic Linear routing — replaces
+  # the "Linear ticket status changes" part of the old prose prompt)
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg orch "${ORCH_NAME}" \
+    --arg id "${ORCH_NAME}-ticket-lifecycle" \
+    --arg notify "filter.wake.${ORCH_NAME}" \
+    --argjson tickets "${ACTIVE_TICKETS}" \
+    '{
+      ts: (now | todate),
+      event: "filter.register",
+      orchestrator: $orch,
+      worker: null,
+      detail: {
+        interest_id: $id,
+        interest_type: "ticket_lifecycle",
+        notify_event: $notify,
+        persistent: true,
+        tickets: $tickets,
+        wake_on: ["status_done", "status_in_review", "status_changed"]
+      }
+    }')"
+
+  # CTL-357: comms_lifecycle interest (deterministic comms routing — replaces
+  # the "any of my workers posts a comms message of type attention" part of the
+  # old prose prompt). Defaults types_of_interest to ["attention","done"] at the
+  # broker; we set it explicitly here for clarity.
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg orch "${ORCH_NAME}" \
+    --arg id "${ORCH_NAME}-comms-lifecycle" \
+    --arg notify "filter.wake.${ORCH_NAME}" \
+    --arg channel "orch-${ORCH_NAME}" \
+    --argjson workers "${ACTIVE_TICKETS}" \
+    '{
+      ts: (now | todate),
+      event: "filter.register",
+      orchestrator: $orch,
+      worker: null,
+      detail: {
+        interest_id: $id,
+        interest_type: "comms_lifecycle",
+        notify_event: $notify,
+        persistent: true,
+        channel: $channel,
+        subscriber_kind: "orchestrator",
+        owned_workers: $workers,
+        types_of_interest: ["attention", "done"]
       }
     }')"
 fi
@@ -1203,18 +1233,18 @@ REMEDIATION_EOF
 done
 ```
 
-**Refresh broker registration when PR set has changed (CTL-341).** The Phase 4 start block
-above registers the orchestrator's `pr_lifecycle` interest with whatever PRs the worker signal
-files happen to expose at that moment — often the empty set, because workers have not yet
+**Refresh broker registration when PR set has changed (CTL-341, CTL-357).** The Phase 4 start
+block above registers the orchestrator's `pr_lifecycle` interest with whatever PRs the worker
+signal files happen to expose at that moment — often the empty set, because workers have not yet
 opened PRs. Without an unconditional refresh, that empty `pr_numbers` list would persist for
 the entire orchestration run and the deterministic route in `tryDeterministicRoute` would
 never match. The merge-confirmation loop above can discover a missing `pr.number` from a
 worker's branch, but that path does not run when the worker writes its own `pr.number` before
 the orchestrator wakes (the common case in the worker-driven flow). This block runs every
 Phase 4 wake-up, computes the union of `worker.pr.number` across the signal files, diffs
-against the set last sent to the broker, and re-emits both `filter.register` events only when
-the set has changed. Idempotent at the broker (upserts by `interest_id`); the diff just keeps
-the event log quiet.
+against the set last sent to the broker, and re-emits all three deterministic `filter.register`
+events (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`) only when the set has changed.
+Idempotent at the broker (upserts by `interest_id`); the diff just keeps the event log quiet.
 
 ```bash
 if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
@@ -1231,27 +1261,6 @@ if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2
           | {pr: .pr.number, base: .pr.baseRefName}
     ]' "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
     _UPD_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
-
-    # Prose interest (residual concerns: comms-attention, ticket status)
-    "$STATE_SCRIPT" event "$(jq -nc \
-      --arg orch "${ORCH_NAME}" \
-      --arg sid "${CATALYST_SESSION_ID:-}" \
-      --arg notify "filter.wake.${ORCH_NAME}" \
-      --argjson prs "${_UPD_PRS}" \
-      --argjson tickets "${_UPD_TICKETS}" \
-      '{
-        ts: (now | todate),
-        event: "filter.register",
-        orchestrator: $orch,
-        worker: null,
-        detail: {
-          session_id: (if $sid == "" then null else $sid end),
-          notify_event: $notify,
-          prompt: "Wake me when: any of my workers posts a comms message of type attention to me; or one of my Linear tickets changes status",
-          persistent: true,
-          context: {pr_numbers: $prs, tickets: $tickets}
-        }
-      }')" 2>/dev/null || true
 
     # CTL-284: pr_lifecycle interest (deterministic PR/CI/review/deployment routing)
     "$STATE_SCRIPT" event "$(jq -nc \
@@ -1274,6 +1283,52 @@ if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2
           pr_numbers: $prs,
           repo: $repo,
           base_branches: $bases
+        }
+      }')" 2>/dev/null || true
+
+    # CTL-303: ticket_lifecycle interest (deterministic Linear routing)
+    "$STATE_SCRIPT" event "$(jq -nc \
+      --arg orch "${ORCH_NAME}" \
+      --arg id "${ORCH_NAME}-ticket-lifecycle" \
+      --arg notify "filter.wake.${ORCH_NAME}" \
+      --argjson tickets "${_UPD_TICKETS}" \
+      '{
+        ts: (now | todate),
+        event: "filter.register",
+        orchestrator: $orch,
+        worker: null,
+        detail: {
+          interest_id: $id,
+          interest_type: "ticket_lifecycle",
+          notify_event: $notify,
+          persistent: true,
+          tickets: $tickets,
+          wake_on: ["status_done", "status_in_review", "status_changed"]
+        }
+      }')" 2>/dev/null || true
+
+    # CTL-357: comms_lifecycle interest (deterministic comms routing — replaces
+    # the retired Groq prose interest for attention/done message routing)
+    "$STATE_SCRIPT" event "$(jq -nc \
+      --arg orch "${ORCH_NAME}" \
+      --arg id "${ORCH_NAME}-comms-lifecycle" \
+      --arg notify "filter.wake.${ORCH_NAME}" \
+      --arg channel "orch-${ORCH_NAME}" \
+      --argjson workers "${_UPD_TICKETS}" \
+      '{
+        ts: (now | todate),
+        event: "filter.register",
+        orchestrator: $orch,
+        worker: null,
+        detail: {
+          interest_id: $id,
+          interest_type: "comms_lifecycle",
+          notify_event: $notify,
+          persistent: true,
+          channel: $channel,
+          subscriber_kind: "orchestrator",
+          owned_workers: $workers,
+          types_of_interest: ["attention", "done"]
         }
       }')" 2>/dev/null || true
 

--- a/website/src/content/docs/observability/catalyst-broker.md
+++ b/website/src/content/docs/observability/catalyst-broker.md
@@ -14,10 +14,14 @@ a natural-language intent once and the daemon handles the matching.
 
 The daemon supports two routing paths:
 
-- **Deterministic (`pr_lifecycle`)** — pure field comparison for PR/CI/review/BEHIND events. No
-  Groq call, no latency beyond local I/O.
+- **Deterministic (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`)** — pure field
+  comparison for PR/CI/review/BEHIND events, Linear state changes, and comms-channel messages.
+  No Groq call, no latency beyond local I/O.
 - **Prose (Groq-backed)** — a natural-language `prompt` you write; evaluated by
-  `llama-3.1-8b-instant` in a single batched API call covering all registered interests.
+  `llama-3.1-8b-instant` in a single batched API call. **Gated off by default since CTL-357**
+  (`CATALYST_BROKER_PROSE_ENABLED=0`) due to empirically ~95% false-positive rate. Prose
+  interests on disk are accepted for backward compat but never matched. Set
+  `CATALYST_BROKER_PROSE_ENABLED=1` to re-enable.
 
 Both paths produce the same output: a `filter.wake.<id>` event in the log that your
 `catalyst-events wait-for` call is already watching for.


### PR DESCRIPTION
## Summary

The Groq prose classifier hit ~95% false-positive rate during the parent orchestration run (`orch-ctl-352-354-2026-05-12`) — heartbeats, unrelated Linear ticket changes, and `info`-type comms posts were all classified as relevant wakes. The operator stopped the broker mid-run. This PR replaces the only legitimate prose consumer (comms-channel routing) with a deterministic `comms_lifecycle` interest type, then gates the Groq path off by default.

**The broker itself stays running** — `pr_lifecycle` and `ticket_lifecycle` continue to do real work (PR event narrowing, merge-SHA → deployment correlation, cross-orchestrator demuxing). What's gated off is just the noisy prose classifier path.

## Changes

- **New `comms_lifecycle` interest type** (`tryDeterministicRoute` extension): subscriber_kind (`orchestrator` | `worker`), channel + owned_workers / subscriber_ticket matching, optional `types_of_interest` filter, self-loop guard for worker subscribers. Default types for orchestrators: `["attention","done"]`; workers default to all.
- **Orchestrate + oneshot wiring updates**: Phase 4 (initial + refresh) and oneshot worker block register `comms_lifecycle` + `ticket_lifecycle` (already existed, just need to register against it) instead of the prose interest. `notify_event` unchanged, so wait-for filters don't need updating.
- **Groq path env-gated off by default**: `CATALYST_BROKER_PROSE_ENABLED=0` is the new default. `classifyBatch` returns early when disabled. Prose interests on disk are still loaded (backward compat for in-flight orchestrators) but never fire.
- **New broker startup event**: `broker.daemon.prose_disabled` (info) emitted once if prose interests exist on disk and the gate is off — operators can see in one event log line whether they're running in deterministic-only mode.
- **`tryTicketLifecycleRoute` canonical-envelope fix** (caught by CTL-354): uses `getEventName` / `getEventPayload` with the same fallback the deterministic route already had. Legacy envelopes continue to work.

24 new tests in `plugins/dev/scripts/broker/index.test.mjs`. All 157 broker tests pass.

## Out of scope (filed as findings)

- `tryDeterministicRoute` (pr_lifecycle) has the same canonical-envelope read bug `tryTicketLifecycleRoute` had — filed as a separate finding during the orchestration run that produced this PR. Not in scope here.

## Test plan

- [x] `bun test plugins/dev/scripts/broker/__tests__/` — 157 pass (24 new)
- [x] Smoke: broker startup with prose interests on disk + `CATALYST_BROKER_PROSE_ENABLED=0` emits `broker.daemon.prose_disabled` exactly once
- [x] Smoke: broker startup with `CATALYST_BROKER_PROSE_ENABLED=1` does not emit `prose_disabled`
- [ ] Live verify after merge: with broker restarted and gate at default `0`, `~/catalyst/events/<month>.jsonl` shows zero `filter.wake.*` events sourced from `session.heartbeat` or unrelated Linear ticket changes

Refs CTL-340 (suppression gate), CTL-350 (silent-dead failure mode), CTL-352 (interests integrity), CTL-354 (filter.wake predicate bug, which surfaced the canonical envelope read gap).