### PR TITLE
fix(dev): broker tryDeterministicRoute canonical-envelope read (CTL-359)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -707,8 +707,14 @@ function matchCommsLifecycle(reg, event) {
 
 export function tryDeterministicRoute(event, interestsMap) {
   const matches = [];
-  const name = event.event ?? "";
-  const detail = event.detail ?? {};
+  // CTL-359: read event name + payload via the canonical-aware helpers so
+  // canonical OTel envelopes (where the name lives under
+  // attributes["event.name"] and the payload under body.payload) match the
+  // same routing rules as legacy flat events. Mirrors the CTL-357 fix to
+  // tryTicketLifecycleRoute. CTL-354's canonical-envelope audit caught the
+  // matching gap in tryTicketLifecycleRoute; this catches the PR/comms route.
+  const name = getEventName(event);
+  const detail = getEventPayload(event);
   const scope = event.scope ?? {};
   // CTL-344: real id on new envelopes, synthetic id for legacy events.
   const eventId = event.id ?? synthesizeEventId(event);

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -2260,3 +2260,89 @@ describe("CTL-357 tryTicketLifecycleRoute canonical envelopes", () => {
     expect(matches[0].reason).toContain("marked Done");
   });
 });
+
+// ─── CTL-359 tryDeterministicRoute canonical envelopes ───────────────────────
+
+describe("CTL-359 tryDeterministicRoute canonical envelopes", () => {
+  beforeEach(() => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-canon-pr",
+      detail: {
+        interest_id: "sess-canon-pr",
+        notify_event: "filter.wake.sess-canon-pr",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [777],
+        repo: "org/repo",
+        base_branches: [{ pr: 777, base: "main" }],
+        persistent: true,
+        session_id: "sess-canon-pr",
+      },
+    });
+  });
+
+  test("matches canonical github.pr.merged event", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: { "event.name": "github.pr.merged" },
+        body: { payload: { mergeCommitSha: "deadbeef", merged: true } },
+        scope: { pr: 777 },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("sess-canon-pr");
+    expect(matches[0].reason).toContain("merged");
+    expect(matches[0].reason).toContain("deadbeef");
+  });
+
+  test("matches canonical github.check_suite.completed event", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: { "event.name": "github.check_suite.completed" },
+        body: { payload: { prNumbers: [777], conclusion: "success" } },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("sess-canon-pr");
+    expect(matches[0].reason).toContain("CI checks passing");
+  });
+
+  test("matches canonical github.pr_review.submitted (changes_requested by bot)", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: { "event.name": "github.pr_review.submitted" },
+        body: {
+          payload: {
+            reviewer: "coderabbitai",
+            state: "changes_requested",
+            author: { login: "coderabbitai", type: "Bot" },
+          },
+        },
+        scope: { pr: 777 },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("Automated review comment");
+    expect(matches[0].reason).toContain("coderabbitai");
+    expect(matches[0].reason).toContain("blocked from merging");
+  });
+
+  test("legacy envelope github.pr.merged continues to pass (backward compat)", () => {
+    // Re-run the existing legacy shape explicitly to lock in backward compat.
+    const matches = tryDeterministicRoute(
+      {
+        event: "github.pr.merged",
+        scope: { pr: 777 },
+        detail: { mergeCommitSha: "feedface", merged: true },
+      },
+      getInterests(),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("sess-canon-pr");
+    expect(matches[0].reason).toContain("merged");
+    expect(matches[0].reason).toContain("feedface");
+  });
+});


### PR DESCRIPTION
## Summary

`tryDeterministicRoute` was reading `event.event` and `event.detail` directly, missing canonical OTel envelopes (where the name lives under `attributes["event.name"]` and the payload under `body.payload`). Route both reads through the existing `getEventName(event)` / `getEventPayload(event)` helpers. Mirrors the CTL-357 fix to `tryTicketLifecycleRoute` (CTL-354's canonical-envelope audit caught the matching gap there; this catches the PR/comms route).

**Impact:** inbound canonical-envelope GitHub webhooks (`github.pr.merged`, `github.check_suite.completed`, `github.pr_review.submitted`, `github.pr_review_comment.created`, `github.pr_review_thread.resolved`, `github.deployment.*`, `github.push`, `github.pr.closed`) now reliably wake `pr_lifecycle` and `comms_lifecycle` interests on the real-time deterministic route instead of relying on the 10-minute idle fallback scan.

## Changes

- `plugins/dev/scripts/broker/index.mjs`: in `tryDeterministicRoute`, replace `event.event ?? ""` with `getEventName(event)` and `event.detail ?? {}` with `getEventPayload(event)`. `scope` and `attributes` handling are intentionally untouched — out of scope per the ticket and matches how `tryTicketLifecycleRoute` still reads `scope` post-CTL-357.
- `plugins/dev/scripts/broker/index.test.mjs`: new `CTL-359 tryDeterministicRoute canonical envelopes` describe block with four tests (canonical `github.pr.merged`, canonical `github.check_suite.completed`, canonical `github.pr_review.submitted` changes_requested by bot, plus a legacy flat-envelope regression).

## Out of scope (filed as a finding)

`handleAgentCheckin` and `handleAgentCheckout` (lines ~566, ~632) still read `event.detail ?? {}` directly — same canonical-envelope payload-read gap in two separate handlers. Filed as a finding (severity: low) during the audit. Not fixed here to keep this PR narrowly scoped to the ticket.

## Test plan

- [x] `bun test plugins/dev/scripts/broker/` — **161 pass** (4 new), 0 fail
- [x] Pre-fix: new canonical-envelope tests fail with 0 matches (TDD red)
- [x] Post-fix: same tests pass; legacy regression test passes (TDD green)
- [ ] Live verify after merge: register a `pr_lifecycle` interest, push to its base branch, observe `filter.wake.*` within seconds rather than via the 10-minute idle fallback

Refs CTL-354 (filter.wake predicate + canonical envelope read gap), CTL-357 (parent fix that spotted this).