### PR TITLE
fix(dev): HUD DETAILS column truncates instead of wrapping (CTL-361)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx
@@ -1,0 +1,109 @@
+import { describe, test, expect } from "bun:test";
+import type { ReactElement, ReactNode } from "react";
+import { EventRow } from "../cli/components/EventRow.tsx";
+import { formatDetails } from "../cli/lib/format.ts";
+import type { CanonicalEvent } from "../lib/canonical-event.ts";
+
+// CTL-361: long DETAILS strings must never reflow onto the next terminal line.
+// Ink reflows by default (wrap="wrap"); EventRow's DETAILS cell must opt into
+// wrap="truncate" so excess content hard-clips at the cell's right edge.
+//
+// The formatter (formatDetails) intentionally returns the full string — clipping
+// is the renderer's job. These tests verify the rendering contract directly by
+// walking the React element tree EventRow returns.
+
+const longDetails = "x".repeat(800);
+
+const longDetailsEvent: CanonicalEvent = {
+  ts: "2026-05-13T13:40:00.000Z",
+  id: "11111111-2222-4333-8444-555555555555",
+  severityText: "INFO",
+  severityNumber: 9,
+  traceId: null,
+  spanId: null,
+  resource: {
+    "service.name": "test",
+    "service.namespace": "catalyst",
+    "service.version": "0.0.0",
+  },
+  attributes: {
+    "event.name": "github.pr.merged",
+    "vcs.repository.name": "coalesce-labs/catalyst",
+    "vcs.pr.number": 501,
+  },
+  body: { message: longDetails, payload: {} },
+};
+
+// EventRow returns <Box>...{children}</Box>. The DETAILS cell is the one Box
+// in the tree with flexGrow === 1 (see EventRow.tsx). Its child is the Text
+// node whose wrap prop governs reflow behaviour.
+function findDetailsTextNode(root: ReactNode): ReactElement | null {
+  function isReactElement(node: unknown): node is ReactElement {
+    return (
+      typeof node === "object" &&
+      node !== null &&
+      "props" in node &&
+      "type" in node
+    );
+  }
+  function walk(node: ReactNode): ReactElement | null {
+    if (!isReactElement(node)) return null;
+    const props = node.props as { flexGrow?: number; children?: ReactNode };
+    if (props.flexGrow === 1) {
+      // The DETAILS Box. Its only child is the DETAILS Text node.
+      const child = props.children;
+      return isReactElement(child) ? child : null;
+    }
+    const children = props.children;
+    if (Array.isArray(children)) {
+      for (const c of children) {
+        const found = walk(c as ReactNode);
+        if (found) return found;
+      }
+    } else if (children !== undefined && children !== null) {
+      return walk(children);
+    }
+    return null;
+  }
+  return walk(root);
+}
+
+describe("EventRow DETAILS cell (CTL-361)", () => {
+  test("DETAILS Text uses wrap=\"truncate\" at narrow terminal width", () => {
+    const element = EventRow({
+      event: longDetailsEvent,
+      selected: false,
+      columns: 80,
+      paused: true,
+    });
+    const detailsText = findDetailsTextNode(element);
+    if (!detailsText) throw new Error("DETAILS Text node not found");
+    expect((detailsText.props as { wrap?: string }).wrap).toBe("truncate");
+  });
+
+  test("DETAILS Text uses wrap=\"truncate\" at wide terminal width", () => {
+    const element = EventRow({
+      event: longDetailsEvent,
+      selected: false,
+      columns: 200,
+      paused: true,
+    });
+    const detailsText = findDetailsTextNode(element);
+    if (!detailsText) throw new Error("DETAILS Text node not found");
+    expect((detailsText.props as { wrap?: string }).wrap).toBe("truncate");
+  });
+
+  test("DETAILS Text receives the full formatDetails output (renderer clips, formatter does not)", () => {
+    const element = EventRow({
+      event: longDetailsEvent,
+      selected: false,
+      columns: 80,
+      paused: true,
+    });
+    const detailsText = findDetailsTextNode(element);
+    if (!detailsText) throw new Error("DETAILS Text node not found");
+    const children = (detailsText.props as { children?: unknown }).children;
+    expect(children).toBe(formatDetails(longDetailsEvent));
+    expect(children).toBe(longDetails);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -751,9 +751,12 @@ describe("formatDetails (filter.wake)", () => {
     expect(formatDetails(e)).toBe("wake → some reason");
   });
 
-  // CTL-350: 40-char truncation removed — Phase 3 <Text wrap="wrap"> handles
-  // long reasons by wrapping to multiple lines in the actual rendered row.
-  test("preserves long reasons (no truncation; row wraps in render)", () => {
+  // CTL-350 / CTL-361: 40-char truncation was removed from the formatter — it
+  // returns the full reason. CTL-361 then changed the DETAILS <Text> from
+  // wrap="wrap" to wrap="truncate", so the renderer hard-clips the cell at the
+  // right edge instead of reflowing. The formatter contract this test pins
+  // (full string, no truncation) is unchanged regardless of renderer behaviour.
+  test("preserves long reasons (no truncation; renderer clips the DETAILS cell)", () => {
     const long = "x".repeat(60);
     const e = {
       ...baseEvent,

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -29,8 +29,13 @@ interface EventRowProps {
 // cannot drift. `<Box width flexShrink={0}>` lets Ink truncate long content
 // instead of the previous `.slice(N-1).padEnd(N)` strings, which defeated
 // Ink's flex layout and forced orchestrator IDs to chop at `orch-adv-` on
-// wide terminals. DETAILS uses `flexGrow={1}` + `wrap="wrap"` so a long
-// Groq reason wraps to multiple lines instead of being silently clipped.
+// wide terminals.
+// CTL-361: DETAILS uses `flexGrow={1}` + `wrap="truncate"` so an overly long
+// payload hard-clips at the cell's right edge instead of reflowing onto the
+// next terminal line and visually overdrawing the next event row — which is
+// what happens with `wrap="wrap"` during aggressive terminal resizes when the
+// React `cols` state lags the physical width. Operators who need the full
+// DETAILS content open the scrollable detail pane with Enter.
 // CTL-351: every fixed-width column has a 1-col right margin so the columns
 // breathe and abutting cells (TIME↔REPO, EVENT↔REF) don't visually run
 // together on rows with short content.
@@ -90,7 +95,7 @@ export function EventRow({ event, selected, columns, paused = true }: EventRowPr
         </Box>
       )}
       <Box flexGrow={1}>
-        <Text color={color} inverse={inverse} wrap="wrap">{formatDetails(event)}</Text>
+        <Text color={color} inverse={inverse} wrap="truncate">{formatDetails(event)}</Text>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

Long DETAILS strings in the orch-monitor HUD `EventRow` were reflowing onto multiple terminal lines (Ink's default `wrap="wrap"` behaviour), which visually overdrew the next event row — especially under aggressive terminal resize windows when React's `cols` state lags the physical terminal width.

This PR switches the DETAILS `<Text>` to `wrap="truncate"` so excess content hard-clips at the cell's right edge instead of reflowing.

Operators who need to read the full DETAILS content open the scrollable detail pane with `Enter` — that path is unchanged.

## Why the ticket's `-2` constant note doesn't need a code change

The ticket called out an unexplained `-2` constant in `EventRow.tsx:25`'s `detailsWidth` formula. That constant was already removed under [CTL-350](https://github.com/coalesce-labs/catalyst/pull/592) when the widths moved into `computeColumnWidths()`. The only remaining work for CTL-361 is the `wrap` prop change.

## Changes

- `plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx`
  - `wrap="wrap"` → `wrap="truncate"` on the DETAILS `<Text>` (line 93).
  - Updated the surrounding CTL-350 comment block to describe the new behaviour and the rationale (overdraw on resize).
- `plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx` (new)
  - Walks the React element tree `EventRow(props)` returns and asserts the DETAILS `Text` has `wrap="truncate"` at both narrow (80 col) and wide (200 col) terminal widths.
  - Confirms `formatDetails(event)` still returns the full string (renderer clips; formatter does not).
- `plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts`
  - Updated the stale CTL-350 comment around the "preserves long reasons" test; test body unchanged.

## Test plan

- [x] `bun test __tests__/event-row.test.tsx __tests__/hud-format.test.ts __tests__/column-widths.test.ts` — 141 pass / 0 fail
- [x] `bun run lint` — 0 new warnings (only pre-existing `preview-status.ts` warning remains)
- [x] `bun run typecheck` — no new errors (pre-existing `ui/src/lib/briefings.ts` errors are unrelated to this change)
- [ ] Manual repro — resize a terminal aggressively while events with long DETAILS stream in; no row overdraw should be visible

## Linear

Closes CTL-361.

Research: [thoughts/shared/research/2026-05-13-CTL-361-eventrow-details-truncate.md](../../tree/orch-ctl-361-2026-05-13-CTL-361/thoughts/shared/research/2026-05-13-CTL-361-eventrow-details-truncate.md)
Plan: [thoughts/shared/plans/2026-05-13-CTL-361-hud-details-truncate.md](../../tree/orch-ctl-361-2026-05-13-CTL-361/thoughts/shared/plans/2026-05-13-CTL-361-hud-details-truncate.md)