### PR TITLE
feat(dev): HUD footer cleanup — right-align event count, separator, width hints (CTL-363)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
@@ -7,9 +7,37 @@ interface FilterInputProps {
   focused: boolean;
   onChange: (v: string) => void;
   pivot: PivotMode;
+  cols: number;
+  filteredCount: number;
+  totalCount: number;
+  autoFollow: boolean;
+  statusMsg: string | null;
 }
 
-export function FilterInput({ value, focused, onChange, pivot }: FilterInputProps) {
+// CTL-363: wide-terminal hint set adds h:help / G:newest / r:reset.
+// Threshold of 160 cols matches the ticket's example width.
+export const WIDE_HINTS_COLS = 160;
+
+export function formatFilterHints(cols: number, focused: boolean): string {
+  const focus = focused ? "Esc:clear" : "/:focus";
+  const base = `${focus} | t:trace o:orch | Enter:detail q:quit`;
+  if (cols >= WIDE_HINTS_COLS) {
+    return `${base} | h:help G:newest r:reset`;
+  }
+  return base;
+}
+
+export function FilterInput({
+  value,
+  focused,
+  onChange,
+  pivot,
+  cols,
+  filteredCount,
+  totalCount,
+  autoFollow,
+  statusMsg,
+}: FilterInputProps) {
   return (
     <Box flexDirection="row">
       {pivot && (
@@ -17,11 +45,15 @@ export function FilterInput({ value, focused, onChange, pivot }: FilterInputProp
       )}
       <Text dimColor={!focused}>{"/ "}</Text>
       <TextInput value={value} onChange={onChange} focus={focused} placeholder="filter (substring or .jq)" />
-      <Text dimColor wrap="truncate-end">
-        {"  "}
-        {focused ? "Esc:clear" : "/:focus"}
-        {" | t:trace o:orch | Enter:detail q:quit"}
-      </Text>
+      <Box flexGrow={1} marginLeft={2}>
+        <Text dimColor wrap="truncate-end">{formatFilterHints(cols, focused)}</Text>
+      </Box>
+      {statusMsg && <Text color="yellow">{` ${statusMsg} `}</Text>}
+      <Text dimColor>{` ${filteredCount}/${totalCount} events`}</Text>
+      {autoFollow
+        ? <Text color="green">{" [LIVE]"}</Text>
+        : <Text dimColor>{" [PAUSED — G to follow]"}</Text>
+      }
     </Box>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/cli/components/QueryInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/QueryInput.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import TextInput from "ink-text-input";
+import { WIDE_HINTS_COLS } from "./FilterInput.tsx";
 
 interface QueryInputProps {
   value: string;
@@ -7,11 +8,29 @@ interface QueryInputProps {
   busy: boolean;
   error: string | null;
   hasDsl: boolean;
+  cols: number;
   onChange: (v: string) => void;
   onSubmit: (v: string) => void;
 }
 
-export function QueryInput({ value, focused, busy, error, hasDsl, onChange, onSubmit }: QueryInputProps) {
+export function formatQueryHints(
+  cols: number,
+  focused: boolean,
+  busy: boolean,
+  hasDsl: boolean,
+): string {
+  const core = busy
+    ? "translating…"
+    : focused
+      ? "Enter:run Esc:cancel"
+      : ":focus";
+  let out = core;
+  if (hasDsl) out += " | ?:show DSL";
+  if (cols >= WIDE_HINTS_COLS && !focused && !busy) out += " | h:help";
+  return out;
+}
+
+export function QueryInput({ value, focused, busy, error, hasDsl, cols, onChange, onSubmit }: QueryInputProps) {
   return (
     <Box flexDirection="column">
       <Box flexDirection="row">
@@ -25,8 +44,7 @@ export function QueryInput({ value, focused, busy, error, hasDsl, onChange, onSu
         />
         <Text dimColor wrap="truncate-end">
           {"  "}
-          {busy ? "translating…" : focused ? "Enter:run Esc:cancel" : ":focus"}
-          {hasDsl ? " | ?:show DSL" : ""}
+          {formatQueryHints(cols, focused, busy, hasDsl)}
         </Text>
       </Box>
       {error !== null && (

--- a/plugins/dev/scripts/orch-monitor/cli/components/footer-hints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/footer-hints.test.ts
@@ -1,0 +1,79 @@
+// footer-hints.test.ts — verifies the width-conditional hint formatters used
+// by FilterInput and QueryInput. Pure string logic, no Ink rendering.
+
+import { describe, test, expect } from "bun:test";
+import { formatFilterHints, WIDE_HINTS_COLS } from "./FilterInput.tsx";
+import { formatQueryHints } from "./QueryInput.tsx";
+
+describe("formatFilterHints", () => {
+  test("narrow terminal — base hints only, focus label adapts", () => {
+    const narrow = formatFilterHints(100, false);
+    expect(narrow).toContain("/:focus");
+    expect(narrow).toContain("t:trace o:orch");
+    expect(narrow).toContain("Enter:detail q:quit");
+    expect(narrow).not.toContain("h:help");
+    expect(narrow).not.toContain("G:newest");
+    expect(narrow).not.toContain("r:reset");
+
+    const focused = formatFilterHints(100, true);
+    expect(focused).toContain("Esc:clear");
+    expect(focused).not.toContain("/:focus");
+  });
+
+  test("wide terminal — adds h:help / G:newest / r:reset", () => {
+    const wide = formatFilterHints(200, false);
+    expect(wide).toContain("h:help");
+    expect(wide).toContain("G:newest");
+    expect(wide).toContain("r:reset");
+    expect(wide).toContain("t:trace o:orch");
+  });
+
+  test("threshold edge: at WIDE_HINTS_COLS is wide, just below is narrow", () => {
+    expect(formatFilterHints(WIDE_HINTS_COLS, false)).toContain("h:help");
+    expect(formatFilterHints(WIDE_HINTS_COLS - 1, false)).not.toContain("h:help");
+  });
+});
+
+describe("formatQueryHints", () => {
+  test("not focused, no DSL — short label", () => {
+    const out = formatQueryHints(100, false, false, false);
+    expect(out).toBe(":focus");
+  });
+
+  test("focused — Enter:run / Esc:cancel", () => {
+    const out = formatQueryHints(100, true, false, false);
+    expect(out).toContain("Enter:run");
+    expect(out).toContain("Esc:cancel");
+  });
+
+  test("busy — translating label, wins over focus", () => {
+    const out = formatQueryHints(100, true, true, false);
+    expect(out).toBe("translating…");
+  });
+
+  test("hasDsl — appends ?:show DSL", () => {
+    const out = formatQueryHints(100, false, false, true);
+    expect(out).toContain(":focus");
+    expect(out).toContain("?:show DSL");
+  });
+
+  test("wide and idle — appends h:help", () => {
+    const out = formatQueryHints(200, false, false, false);
+    expect(out).toContain("h:help");
+  });
+
+  test("wide but focused — no h:help (don't clutter active input)", () => {
+    const out = formatQueryHints(200, true, false, false);
+    expect(out).not.toContain("h:help");
+  });
+
+  test("wide but busy — no h:help", () => {
+    const out = formatQueryHints(200, false, true, false);
+    expect(out).not.toContain("h:help");
+  });
+
+  test("threshold edge", () => {
+    expect(formatQueryHints(WIDE_HINTS_COLS, false, false, false)).toContain("h:help");
+    expect(formatQueryHints(WIDE_HINTS_COLS - 1, false, false, false)).not.toContain("h:help");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -160,7 +160,9 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
 
   const [showHelp, setShowHelp] = useState(false);
 
-  // chrome = header + status(1) + filter(1) + query(1) + dsl overlay (if any).
+  // chrome = header + separator(1) + filter(1) + query(1) + dsl overlay (if any).
+  // CTL-363: the standalone status row was folded into FilterInput and a `─`
+  // separator now sits above the footer, mirroring Header.tsx's top separator.
   // Help and detail are bottom-anchored *inside* visibleRows via the layout
   // helpers below — they no longer steal rows from the top.
   const chromeRows = headerRows + 3 + overlayHeight;
@@ -406,15 +408,6 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           ))}
         </Box>
       )}
-      <Box flexDirection="row" flexShrink={0}>
-        <Text dimColor>{`  ${filtered.length}/${events.length} events`}</Text>
-        {autoFollow
-          ? <Text color="green">{"  [LIVE]"}</Text>
-          : <Text dimColor>{"  [PAUSED — G to follow]"}</Text>
-        }
-        {pivot && <Text color="cyan">{`  [${pivot.type} pivot: ${pivot.id.slice(0, 14)}… — r:reset]`}</Text>}
-        {statusMsg && <Text color="yellow">{`  ${statusMsg}`}</Text>}
-      </Box>
       {showDslOverlay && dslState && (
         <Box flexShrink={0} flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={1}>
           <Text color="magenta" bold>{`Generated DSL · j/k scroll · ? to hide (${dslScrollTop + 1}/${dslLines.length}):`}</Text>
@@ -424,11 +417,19 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
         </Box>
       )}
       <Box flexShrink={0}>
+        <Text dimColor>{"─".repeat(Math.max(0, cols - 1))}</Text>
+      </Box>
+      <Box flexShrink={0}>
         <FilterInput
           value={filterText}
           focused={filterFocused}
           onChange={setFilterText}
           pivot={pivot}
+          cols={cols}
+          filteredCount={filtered.length}
+          totalCount={events.length}
+          autoFollow={autoFollow}
+          statusMsg={statusMsg}
         />
       </Box>
       <Box flexShrink={0}>
@@ -438,6 +439,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           busy={querySubmitting}
           error={queryError}
           hasDsl={dslState !== null}
+          cols={cols}
           onChange={setQueryText}
           onSubmit={(v) => { void submitQuery(v); }}
         />


### PR DESCRIPTION
## Summary

Compacts the HUD footer per [CTL-363](https://linear.app/coalesce-labs/issue/CTL-363):

- **Folds the standalone status row into FilterInput.** Event count `N/M events` and the `[LIVE]` / `[PAUSED — G to follow]` chip move to the right of the `/` row via a `flexGrow` spacer. Recoups the visual line for cleaner footer chrome.
- **Adds a `─` separator above the footer**, mirroring `Header.tsx`'s top separator. `chromeRows` accounting is unchanged (status+filter+query → separator+filter+query).
- **Width-responsive hints.** `FilterInput` and `QueryInput` now take `cols`; pure hint formatters widen the strings at cols ≥ 160 to surface `h:help`, `G:newest`, `r:reset` (FilterInput) and `h:help` (QueryInput, only when idle and not busy).
- The pivot indicator continues to render as a `[pivot.type:id…]` prefix on the LEFT of FilterInput; the duplicated status-row pivot text was dropped to make room. `statusMsg` keeps its yellow transient styling, now on the right side of the FilterInput row.

## Acceptance criteria

- [x] Bottom of HUD is **2 lines** (filter + query), not 3, in normal mode — separator is above the footer.
- [x] A `─` separator appears between the last event row and the footer.
- [x] At cols ≥ 160, FilterInput's hint string includes `h:help`, `G:newest`, `r:reset` not shown at cols < 160.
- [x] No regressions to the detail/help overlay paths — both still render as flexShrink=0 boxes above the new separator.

## Test plan

- [x] `bun run typecheck` — clean for the `cli/` tree. (Pre-existing `ui/src/lib/briefings.ts` `marked`/`dompurify` typeerrors are unrelated.)
- [x] `bun run lint` — clean.
- [x] `bun test cli/components/footer-hints.test.ts` — 11/11 pass.
- [x] `bun test` (full suite) — 1686/1693 pass, 7 fails are pre-existing (catalyst-monitor.sh daemon tests + 1 SQLite session-store test, all unrelated to the HUD).
- [x] Reward-hacking scan: no `as any`, `as unknown as`, `@ts-ignore`, `@ts-expect-error`, `forEach(async`, or `!`-assertion in the changed files.
- [ ] Manual visual check on a 200-col and 100-col terminal (requires running `catalyst-hud` interactively).

## Out of scope

- Centralized hotkey registry (separate refactor — noted in CTL-363).
- Column changes (separate ticket).

Plan: [thoughts/shared/plans/2026-05-13-CTL-363-hud-footer-cleanup.md](thoughts/shared/plans/2026-05-13-CTL-363-hud-footer-cleanup.md)
Research: [thoughts/shared/research/2026-05-13-hud-cleanup.md](thoughts/shared/research/2026-05-13-hud-cleanup.md) (Area 3)