### PR TITLE
feat(dev): vcs.repository.name enrichment for linear/orchestrator/broker events (CTL-362)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-state.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-state.test.sh
@@ -198,6 +198,75 @@ else
   fail "orchestrator not archived: $HIST_ENTRIES entries in history"
 fi
 
+# ─── Test 10: event_append forwards vcsRepo → vcs.repository.name (CTL-362) ─
+# Confirms the orchestrator-side bash emitter populates the HUD's REPO column.
+echo ""
+echo "--- Test 10: event_append carries vcsRepo into the canonical envelope ---"
+export CATALYST_DIR="$SCRATCH/cat10"
+"$STATE_SCRIPT" init >/dev/null
+
+"$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-13T12:00:00Z",
+  orchestrator: "orch-ctl-test",
+  worker: "CTL-362",
+  event: "worker-done",
+  vcsRepo: "coalesce-labs/catalyst",
+  detail: null
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE=$(ls "$SCRATCH/cat10/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE" ]]; then
+  REPO=$(jq -r 'select(.attributes."event.name" == "orchestrator.worker.done") | .attributes."vcs.repository.name" // ""' "$EVENT_FILE" | head -1)
+  assert_eq "coalesce-labs/catalyst" "$REPO" "vcsRepo stamped onto attributes[\"vcs.repository.name\"]"
+else
+  fail "no event JSONL written for vcsRepo test"
+fi
+
+# Also confirm the `.repo` alias works.
+echo ""
+echo "--- Test 11: event_append accepts .repo as an alias for .vcsRepo ---"
+export CATALYST_DIR="$SCRATCH/cat11"
+"$STATE_SCRIPT" init >/dev/null
+
+"$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-13T12:00:00Z",
+  orchestrator: "orch-adv-test",
+  worker: "ADV-1",
+  event: "worker-done",
+  repo: "coalesce-labs/adva",
+  detail: null
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE11=$(ls "$SCRATCH/cat11/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE11" ]]; then
+  REPO=$(jq -r 'select(.attributes."event.name" == "orchestrator.worker.done") | .attributes."vcs.repository.name" // ""' "$EVENT_FILE11" | head -1)
+  assert_eq "coalesce-labs/adva" "$REPO" ".repo alias stamped onto attributes[\"vcs.repository.name\"]"
+else
+  fail "no event JSONL written for .repo alias test"
+fi
+
+# Confirm absence of vcsRepo leaves the attribute unset.
+echo ""
+echo "--- Test 12: event_append without vcsRepo omits the attribute ---"
+export CATALYST_DIR="$SCRATCH/cat12"
+"$STATE_SCRIPT" init >/dev/null
+
+"$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-13T12:00:00Z",
+  orchestrator: "orch-bare-test",
+  worker: "CTL-1",
+  event: "worker-done",
+  detail: null
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE12=$(ls "$SCRATCH/cat12/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE12" ]]; then
+  HAS_REPO=$(jq -r 'select(.attributes."event.name" == "orchestrator.worker.done") | (.attributes | has("vcs.repository.name"))' "$EVENT_FILE12" | head -1)
+  assert_eq "false" "$HAS_REPO" "no vcs.repository.name attribute when input omits it"
+else
+  fail "no event JSONL written for no-repo test"
+fi
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "══════════════════════════════════════════════"

--- a/plugins/dev/scripts/broker/canonical-events.test.mjs
+++ b/plugins/dev/scripts/broker/canonical-events.test.mjs
@@ -133,6 +133,61 @@ describe("buildCanonicalEnvelope", () => {
     });
     expect(nullDetail.body.payload).toBeNull();
   });
+
+  // CTL-362: enrich filter.wake / broker.daemon envelopes with the
+  // interest's repo so the HUD's REPO column populates.
+  test("copies legacy.repo into vcs.repository.name", async () => {
+    const { buildCanonicalEnvelope } = await import("./index.mjs");
+    const envelope = buildCanonicalEnvelope({
+      event: "filter.wake.sess_repo",
+      orchestrator: "orch_1",
+      worker: null,
+      repo: "coalesce-labs/catalyst",
+      detail: { reason: "PR #1 merged", interest_id: "sess_repo" },
+    });
+    expect(envelope.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
+  });
+
+  test("accepts vcsRepo as an alias for repo", async () => {
+    const { buildCanonicalEnvelope } = await import("./index.mjs");
+    const envelope = buildCanonicalEnvelope({
+      event: "filter.wake.sess_alias",
+      orchestrator: "orch_1",
+      worker: null,
+      vcsRepo: "coalesce-labs/adva",
+      detail: null,
+    });
+    expect(envelope.attributes["vcs.repository.name"]).toBe("coalesce-labs/adva");
+  });
+
+  test("omits vcs.repository.name when repo is null/undefined/empty", async () => {
+    const { buildCanonicalEnvelope } = await import("./index.mjs");
+    const noRepo = buildCanonicalEnvelope({
+      event: "broker.daemon.startup",
+      orchestrator: null,
+      worker: null,
+      detail: { pid: 12345 },
+    });
+    expect(noRepo.attributes["vcs.repository.name"]).toBeUndefined();
+
+    const nullRepo = buildCanonicalEnvelope({
+      event: "filter.wake.sess_empty",
+      orchestrator: "orch_1",
+      worker: null,
+      repo: null,
+      detail: null,
+    });
+    expect(nullRepo.attributes["vcs.repository.name"]).toBeUndefined();
+
+    const emptyRepo = buildCanonicalEnvelope({
+      event: "filter.wake.sess_empty_str",
+      orchestrator: "orch_1",
+      worker: null,
+      repo: "",
+      detail: null,
+    });
+    expect(emptyRepo.attributes["vcs.repository.name"]).toBeUndefined();
+  });
 });
 
 describe("appendEvent — writes canonical envelopes to JSONL", () => {

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -198,16 +198,25 @@ export function summarizeEvent(event) {
 // Translate the broker's internal {event, orchestrator, worker, detail} shape
 // into a canonical OTel-style envelope. Severity defaults to INFO — broker
 // emissions today (filter.wake.*, broker.daemon.startup) are all info-level.
+//
+// CTL-362: `legacy.repo` (or the `legacy.vcsRepo` alias) populates
+// `attributes["vcs.repository.name"]` so the HUD's REPO column resolves for
+// `filter.wake.*` events. Pass it through from the interest record's `repo`
+// field at every wake-emission call site that has one.
 export function buildCanonicalEnvelope(legacy) {
   const eventName = legacy.event ?? "";
   const orch = legacy.orchestrator ?? null;
   const worker = legacy.worker ?? null;
   const severity = legacy.severity ?? "INFO";
   const ts = legacy.ts ?? new Date().toISOString();
+  const repo = legacy.repo ?? legacy.vcsRepo ?? null;
 
   const attributes = { "event.name": eventName };
   if (orch) attributes["catalyst.orchestrator.id"] = orch;
   if (worker) attributes["catalyst.worker.ticket"] = worker;
+  if (typeof repo === "string" && repo.length > 0) {
+    attributes["vcs.repository.name"] = repo;
+  }
 
   return {
     ts,
@@ -1191,6 +1200,10 @@ export function classifyMatches(events, matches, interestsMap) {
       event: reg.notify_event,
       orchestrator: reg.orchestrator ?? match.interest_id,
       worker: null,
+      // CTL-362: forward the interest's repo so the wake envelope carries
+      // vcs.repository.name when the interest tracks a specific repo (today
+      // only pr_lifecycle interests do).
+      repo: reg.repo ?? null,
       detail: {
         reason: match.reason,
         source_event_ids: sourceIds,
@@ -1285,6 +1298,9 @@ export function runWatchdogTick() {
             event: interest.notify_event,
             orchestrator: interest.orchestrator ?? interestId,
             worker: null,
+            // CTL-362: forward the interest's repo so the watchdog wake
+            // envelope carries vcs.repository.name when known.
+            repo: interest.repo ?? null,
             // CTL-350: watchdog wakes have no triggering event, so source_events
             // is always empty — receivers should fall back to the reason string.
             detail: {
@@ -1390,6 +1406,9 @@ export function processEvent(event) {
       event: reg.notify_event,
       orchestrator: reg.orchestrator ?? m.interestId,
       worker: null,
+      // CTL-362: forward the interest's repo so the wake envelope carries
+      // vcs.repository.name.
+      repo: reg.repo ?? null,
       detail: {
         reason: m.reason,
         source_event_ids: m.sourceEventId ? [m.sourceEventId] : [],

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -172,12 +172,17 @@ event_append() {
     return 0
   fi
 
-  local ts orch worker legacy_event detail
+  local ts orch worker legacy_event detail vcs_repo
   ts=$(echo "$input_json" | jq -r '.ts // ""')
   orch=$(echo "$input_json" | jq -r '.orchestrator // ""')
   worker=$(echo "$input_json" | jq -r '.worker // ""')
   legacy_event=$(echo "$input_json" | jq -r '.event // ""')
   detail=$(echo "$input_json" | jq -c '.detail // null')
+  # CTL-362: optional vcs.repository.name. Accept either `.vcsRepo` (camelCase,
+  # preferred) or `.repo` (alias for parity with broker interest records). When
+  # set, gets stamped into attributes["vcs.repository.name"] so the HUD's REPO
+  # column populates for orchestrator-emitted events.
+  vcs_repo=$(echo "$input_json" | jq -r '.vcsRepo // .repo // ""')
   [[ -z "$ts" ]] && ts="$(now_iso)"
 
   local mapping name entity action severity
@@ -192,6 +197,7 @@ event_append() {
   local extra_args=()
   [[ -n "$orch" ]] && extra_args+=(--orch "$orch")
   [[ -n "$worker" ]] && extra_args+=(--worker "$worker")
+  [[ -n "$vcs_repo" && "$vcs_repo" != "null" ]] && extra_args+=(--vcs-repo "$vcs_repo")
 
   # vcs.pr.number is found at .pr (worker-pr-created/merged) or .pr.number
   # (worker-status-terminal carries a {number,url} sub-object).

--- a/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
@@ -138,6 +138,27 @@ describe("buildCanonicalEvent", () => {
     expect(ev.attributes["event.channel"]).toBe("webhook");
     expect(ev.attributes["vcs.pr.number"]).toBe(342);
   });
+
+  // CTL-362: vcs.repository.name is the canonical attribute the HUD reads for
+  // the REPO column. Explicit assertion guards against the field being dropped
+  // or renamed during future envelope refactors.
+  it("preserves vcs.repository.name through the envelope (CTL-362)", () => {
+    const ev = buildCanonicalEvent({
+      ts: "2026-05-13T12:00:00.000Z",
+      severityText: "INFO",
+      traceId: null,
+      spanId: null,
+      resource: { "service.name": "catalyst.linear" },
+      attributes: {
+        "event.name": "linear.issue.state_changed",
+        "linear.team.key": "CTL",
+        "linear.issue.identifier": "CTL-362",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+      },
+      body: { payload: null },
+    });
+    expect(ev.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
+  });
 });
 
 describe("generateEventId (CTL-344)", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -468,3 +468,180 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
     expect(env).toBeNull();
   });
 });
+
+// CTL-362: when a teams map is supplied, the envelope gets
+// attributes["vcs.repository.name"] for events the lookup can resolve so the
+// HUD's REPO column populates for Linear events.
+describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
+  const TEAMS = new Map<string, string>([
+    ["CTL", "coalesce-labs/catalyst"],
+    ["ADV", "coalesce-labs/adva"],
+  ]);
+
+  it("issue with known team key → vcs.repository.name set", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "update",
+        topic: "linear.issue.state_changed",
+        ticket: "CTL-210",
+        teamKey: "CTL",
+        data: {},
+        updatedFromKeys: ["stateId"],
+        actorId: null,
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
+    expect(env!.attributes["linear.team.key"]).toBe("CTL");
+  });
+
+  it("issue with unknown team key → vcs.repository.name omitted", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "create",
+        topic: "linear.issue.created",
+        ticket: "FOO-1",
+        teamKey: "FOO",
+        data: {},
+        updatedFromKeys: [],
+        actorId: null,
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
+    expect(env!.attributes["linear.team.key"]).toBe("FOO");
+  });
+
+  it("issue with no team key → vcs.repository.name omitted", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "create",
+        topic: "linear.issue.created",
+        ticket: "CTL-1",
+        teamKey: null,
+        data: {},
+        updatedFromKeys: [],
+        actorId: null,
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
+  });
+
+  it("comment derives team key from ticket prefix and stamps repo + linear.team.key", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "comment",
+        action: "create",
+        ticket: "ADV-42",
+        commentId: "c1",
+        issueId: "i1",
+        data: {},
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBe("coalesce-labs/adva");
+    expect(env!.attributes["linear.team.key"]).toBe("ADV");
+    expect(env!.attributes["linear.issue.identifier"]).toBe("ADV-42");
+  });
+
+  it("comment with ticket whose prefix is unknown → no repo, no team.key", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "comment",
+        action: "create",
+        ticket: "FOO-1",
+        commentId: "c1",
+        issueId: "i1",
+        data: {},
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
+    expect(env!.attributes["linear.team.key"]).toBeUndefined();
+  });
+
+  it("comment without ticket → no repo", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "comment",
+        action: "create",
+        ticket: null,
+        commentId: "c1",
+        issueId: "i1",
+        data: {},
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
+  });
+
+  it("cycle with known team key → vcs.repository.name set", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "cycle",
+        action: "update",
+        cycleId: "c1",
+        teamKey: "CTL",
+        data: {},
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
+  });
+
+  it("reaction events are not enriched (no team context)", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "reaction",
+        action: "create",
+        reactionId: "r1",
+        data: {},
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
+  });
+
+  it("issue_label events are not enriched (no team context)", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue_label",
+        action: "create",
+        labelId: "l1",
+        data: {},
+      },
+      TS,
+      TEAMS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
+  });
+
+  it("no teamsMap supplied → no enrichment (backward-compat default)", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "create",
+        topic: "linear.issue.created",
+        ticket: "CTL-1",
+        teamKey: "CTL",
+        data: {},
+        updatedFromKeys: [],
+        actorId: null,
+      },
+      TS,
+    );
+    expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -68,6 +68,7 @@ describe("loadWebhookConfig", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -97,6 +98,7 @@ describe("loadWebhookConfig", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
     expect(warn).toHaveBeenCalledTimes(1);
     const msg = String(warn.mock.calls[0]?.[0] ?? "");
@@ -134,6 +136,7 @@ describe("loadWebhookConfig", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -165,6 +168,7 @@ describe("loadWebhookConfig", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -190,6 +194,7 @@ describe("loadWebhookConfig", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
   });
 
@@ -216,6 +221,7 @@ describe("loadWebhookConfig", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
   });
 
@@ -290,6 +296,7 @@ describe("loadWebhookConfig", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -324,6 +331,7 @@ describe("loadWebhookConfig", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
   });
 });
@@ -417,6 +425,7 @@ describe("loadWebhookConfig watchRepos (CTL-216)", () => {
       linearSecrets: [],
       linearSmeeChannel: "",
       linearBotUserId: "",
+      linearTeams: [],
     });
   });
 
@@ -1036,5 +1045,144 @@ describe("loadWebhookConfig — per-team secret files (CTL-285)", () => {
     expect(cfg!.linearSecrets).toHaveLength(2);
     expect(cfg!.linearSecrets).toContainEqual({ key: "adv", secret: "adv-secret" });
     expect(cfg!.linearSecrets).toContainEqual({ key: "ctl", secret: "ctl-secret" });
+  });
+});
+
+// CTL-362: catalyst.monitor.linear.teams[] is parsed into linearTeams. The
+// handler later uses this map to stamp vcs.repository.name on canonical
+// envelopes for Linear-sourced events so the HUD's REPO column populates.
+describe("loadWebhookConfig linearTeams (CTL-362)", () => {
+  it("parses a valid teams array from Layer 1", () => {
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: {
+            teams: [
+              { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+              { key: "ADV", vcsRepo: "coalesce-labs/adva" },
+            ],
+          },
+        },
+      },
+    });
+    writeHome({
+      catalyst: { monitor: { github: { smeeChannel: "https://smee.io/h" } } },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "x";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearTeams).toEqual([
+      { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+      { key: "ADV", vcsRepo: "coalesce-labs/adva" },
+    ]);
+  });
+
+  it("returns empty linearTeams when the field is absent", () => {
+    writeHome({
+      catalyst: { monitor: { github: { smeeChannel: "https://smee.io/h" } } },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "x";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+    expect(cfg!.linearTeams).toEqual([]);
+  });
+
+  it("returns empty linearTeams when teams is not an array", () => {
+    writeProject({
+      catalyst: { monitor: { linear: { teams: "oops-not-an-array" } } },
+    });
+    writeHome({
+      catalyst: { monitor: { github: { smeeChannel: "https://smee.io/h" } } },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "x";
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+    expect(cfg!.linearTeams).toEqual([]);
+  });
+
+  it("skips entries with missing key or vcsRepo and warns", () => {
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: {
+            teams: [
+              { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+              { key: "", vcsRepo: "missing/key" },
+              { key: "NOREPO", vcsRepo: "" },
+              { vcsRepo: "no/key-field" },
+              { key: "NOTOBJ" },
+            ],
+          },
+        },
+      },
+    });
+    writeHome({
+      catalyst: { monitor: { github: { smeeChannel: "https://smee.io/h" } } },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "x";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearTeams).toEqual([
+      { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+    ]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("skips entries whose vcsRepo does not match owner/repo shape", () => {
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: {
+            teams: [
+              { key: "OK", vcsRepo: "good/repo" },
+              { key: "BAD1", vcsRepo: "no-slash" },
+              { key: "BAD2", vcsRepo: "too/many/slashes" },
+              { key: "BAD3", vcsRepo: "/empty-owner" },
+            ],
+          },
+        },
+      },
+    });
+    writeHome({
+      catalyst: { monitor: { github: { smeeChannel: "https://smee.io/h" } } },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "x";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearTeams).toEqual([{ key: "OK", vcsRepo: "good/repo" }]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("deduplicates by key — last entry wins, warn fires", () => {
+    writeProject({
+      catalyst: {
+        monitor: {
+          linear: {
+            teams: [
+              { key: "CTL", vcsRepo: "first/wins-not" },
+              { key: "CTL", vcsRepo: "second/wins" },
+            ],
+          },
+        },
+      },
+    });
+    writeHome({
+      catalyst: { monitor: { github: { smeeChannel: "https://smee.io/h" } } },
+    });
+    process.env.CATALYST_WEBHOOK_SECRET = "x";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    const cfg = loadWebhookConfig(homeDir, projectConfigPath);
+
+    expect(cfg!.linearTeams).toEqual([{ key: "CTL", vcsRepo: "second/wins" }]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -22,6 +22,13 @@ export interface LinearWebhookHandlerDeps {
    * Empty array disables the handler (returns 503).
    */
   linearSecrets: Array<{ key: string; secret: string }>;
+  /**
+   * Optional team→repo map (CTL-362). When an issue / comment / cycle webhook
+   * carries a team key that appears here, the canonical envelope gets
+   * `attributes["vcs.repository.name"]` set so the HUD's REPO column populates.
+   * Sourced from `catalyst.monitor.linear.teams[]` in project config.
+   */
+  linearTeams?: Array<{ key: string; vcsRepo: string }>;
   /** Optional pub/sub for SSE fan-out to UI clients. */
   emit?: (type: string, data: unknown) => void;
   /** Event-log fan-out — every accepted event is appended here as a canonical envelope. */
@@ -84,22 +91,45 @@ function canonical(args: LinearCanonicalArgs): CanonicalEvent {
   });
 }
 
+// CTL-362: derive a Linear team short key from a ticket identifier like
+// "CTL-210" → "CTL". Returns null when the ticket does not match the standard
+// Linear identifier shape (uppercase prefix, dash, digits).
+const TICKET_PREFIX_RE = /^([A-Z][A-Z0-9]+)-\d+$/;
+function deriveTeamKey(ticket: string | null): string | null {
+  if (ticket === null) return null;
+  const m = TICKET_PREFIX_RE.exec(ticket);
+  return m !== null && m[1] !== undefined ? m[1] : null;
+}
+
 /**
  * Map a parsed LinearWebhookEvent to a canonical event envelope. Returns null
  * for `kind: "ignored"`.
  *
  * `event.name` follows `linear.<entity>.<action>` lowercase, dot-separated.
+ *
+ * CTL-362: when `teamsMap` is provided, issue/comment/cycle events whose team
+ * key matches an entry get `attributes["vcs.repository.name"]` populated so the
+ * HUD's REPO column resolves. Comment events derive the team key from the
+ * ticket prefix (e.g. CTL-210 → "CTL") since the webhook payload does not
+ * carry it directly. Reaction and issue_label events have no team context and
+ * remain unenriched.
  */
 export function buildLinearEventLogEnvelope(
   event: LinearWebhookEvent,
   ts: string = new Date().toISOString(),
+  teamsMap: ReadonlyMap<string, string> = new Map(),
 ): CanonicalEvent | null {
+  const lookupRepo = (teamKey: string | null): string | undefined =>
+    teamKey !== null ? teamsMap.get(teamKey) : undefined;
+
   switch (event.kind) {
     case "issue": {
       const attrs: Omit<Attributes, "event.name"> = {};
       if (event.ticket !== null) attrs["linear.issue.identifier"] = event.ticket;
       if (event.teamKey !== null) attrs["linear.team.key"] = event.teamKey;
       if (event.actorId !== null) attrs["linear.actor.id"] = event.actorId;
+      const repo = lookupRepo(event.teamKey);
+      if (repo !== undefined) attrs["vcs.repository.name"] = repo;
       return canonical({
         ts,
         eventName: event.topic,
@@ -122,6 +152,14 @@ export function buildLinearEventLogEnvelope(
       const eventName = `linear.comment.${event.action}d`;
       const attrs: Omit<Attributes, "event.name"> = {};
       if (event.ticket !== null) attrs["linear.issue.identifier"] = event.ticket;
+      // Comments don't carry team data directly — derive from the ticket prefix
+      // so we can both stamp linear.team.key and look up vcs.repository.name.
+      const derivedTeamKey = deriveTeamKey(event.ticket);
+      const repo = lookupRepo(derivedTeamKey);
+      if (repo !== undefined) {
+        attrs["vcs.repository.name"] = repo;
+        if (derivedTeamKey !== null) attrs["linear.team.key"] = derivedTeamKey;
+      }
       return canonical({
         ts,
         eventName,
@@ -143,6 +181,8 @@ export function buildLinearEventLogEnvelope(
       const eventName = `linear.cycle.${event.action}d`;
       const attrs: Omit<Attributes, "event.name"> = {};
       if (event.teamKey !== null) attrs["linear.team.key"] = event.teamKey;
+      const repo = lookupRepo(event.teamKey);
+      if (repo !== undefined) attrs["vcs.repository.name"] = repo;
       return canonical({
         ts,
         eventName,
@@ -200,6 +240,11 @@ export function createLinearWebhookHandler(deps: LinearWebhookHandlerDeps): Line
   const seenDeliveries: string[] = [];
   const seenDeliveriesSet = new Set<string>();
   const logger = deps.logger ?? {};
+  // CTL-362: build the team→repo lookup once at construction so every webhook
+  // call shares the same map without re-parsing.
+  const teamsMap: ReadonlyMap<string, string> = new Map(
+    (deps.linearTeams ?? []).map((t) => [t.key, t.vcsRepo]),
+  );
 
   function rememberDelivery(deliveryId: string): void {
     if (seenDeliveriesSet.has(deliveryId)) return;
@@ -279,7 +324,7 @@ export function createLinearWebhookHandler(deps: LinearWebhookHandlerDeps): Line
     }
 
     if (deps.eventLog && event.kind !== "ignored") {
-      const envelope = buildLinearEventLogEnvelope(event);
+      const envelope = buildLinearEventLogEnvelope(event, undefined, teamsMap);
       if (envelope !== null) {
         try {
           await deps.eventLog.append(envelope);

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -40,6 +40,16 @@ export interface WebhookCliConfig {
    * Empty string when not configured — no suppression.
    */
   linearBotUserId: string;
+  /**
+   * Optional team→repo mapping read from `catalyst.monitor.linear.teams[]` in
+   * Layer 1 (project config). Each entry is `{ key, vcsRepo }` where `key` is
+   * the Linear team short key (e.g. "CTL") and `vcsRepo` is the canonical
+   * `owner/repo` string written into `attributes["vcs.repository.name"]` for
+   * issue/comment/cycle events from that team. Empty array when not configured —
+   * the Linear webhook handler then leaves the repo attribute unset (current
+   * pre-CTL-362 behaviour). CTL-362.
+   */
+  linearTeams: Array<{ key: string; vcsRepo: string }>;
 }
 
 interface FileExtract {
@@ -52,6 +62,8 @@ interface FileExtract {
   linearSmeeChannel: string | null;
   /** Linear bot user UUID for loop prevention, from Layer 1 (project). CTL-263. */
   linearBotUserId: string | null;
+  /** Linear team→repo map from Layer 1 (project). CTL-362. */
+  linearTeams: Array<{ key: string; vcsRepo: string }>;
 }
 
 let warnedDeprecatedSmeeChannel = false;
@@ -173,6 +185,43 @@ function isRecord(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null && !Array.isArray(x);
 }
 
+// CTL-362: parse `catalyst.monitor.linear.teams[]` into a list of
+// `{ key, vcsRepo }` pairs. Skips entries with missing keys or repos that
+// don't match the `owner/repo` shape — same lenient-with-warnings behaviour
+// as `readWatchRepos`. Deduplicates by `key` (last entry wins, with a warn).
+function readLinearTeams(
+  linear: Record<string, unknown>,
+): Array<{ key: string; vcsRepo: string }> {
+  const raw = linear.teams;
+  if (!Array.isArray(raw)) return [];
+  const byKey = new Map<string, string>();
+  for (const entry of raw) {
+    if (!isRecord(entry)) {
+      console.warn(`[webhook-config] Ignoring linear.teams entry — not an object: ${JSON.stringify(entry)}`);
+      continue;
+    }
+    const key = typeof entry.key === "string" ? entry.key.trim() : "";
+    const vcsRepo = typeof entry.vcsRepo === "string" ? entry.vcsRepo.trim() : "";
+    if (key.length === 0) {
+      console.warn(`[webhook-config] Ignoring linear.teams entry with empty "key"`);
+      continue;
+    }
+    if (vcsRepo.length === 0 || !REPO_SHAPE.test(vcsRepo)) {
+      console.warn(
+        `[webhook-config] Ignoring linear.teams entry for key "${key}" — vcsRepo "${vcsRepo}" must match "owner/repo".`,
+      );
+      continue;
+    }
+    if (byKey.has(key)) {
+      console.warn(
+        `[webhook-config] Duplicate linear.teams entry for key "${key}" — last entry wins ("${vcsRepo}").`,
+      );
+    }
+    byKey.set(key, vcsRepo);
+  }
+  return Array.from(byKey.entries()).map(([key, vcsRepo]) => ({ key, vcsRepo }));
+}
+
 // Extract the Linear smee channel URL from a linear config object. Prefers the
 // top-level smeeChannel (legacy / current normal case) and falls back to the
 // first keyed team entry that carries one (CTL-273/285 keyed format, CTL-301).
@@ -235,6 +284,7 @@ function readGithubSection(filePath: string): FileExtract | null {
     linear !== null && typeof linear.botUserId === "string" && linear.botUserId.length > 0
       ? linear.botUserId
       : null;
+  const linearTeams = linear !== null ? readLinearTeams(linear) : [];
 
   return {
     smeeChannel,
@@ -243,6 +293,7 @@ function readGithubSection(filePath: string): FileExtract | null {
     linearWebhookSecretEnv,
     linearSmeeChannel,
     linearBotUserId,
+    linearTeams,
   };
 }
 
@@ -335,6 +386,9 @@ export function loadWebhookConfig(
   // Linear bot user UUID for loop prevention. Layer 1 only (project/team setting). CTL-263.
   const linearBotUserId = projectExtract?.linearBotUserId ?? "";
 
+  // Linear team→repo map. Layer 1 only — team-shared, committed. CTL-362.
+  const linearTeams = projectExtract?.linearTeams ?? [];
+
   // Allow Linear-only configurations: if the GitHub channel/secret are missing
   // but Linear secrets are present, return a config that disables the GitHub
   // route but enables the Linear route. CTL-210.
@@ -348,6 +402,7 @@ export function loadWebhookConfig(
       linearSecrets,
       linearSmeeChannel,
       linearBotUserId,
+      linearTeams,
     };
   }
 
@@ -359,5 +414,6 @@ export function loadWebhookConfig(
     linearSecrets,
     linearSmeeChannel,
     linearBotUserId,
+    linearTeams,
   };
 }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -206,6 +206,11 @@ export interface CreateServerOptions {
     smeeChannel?: string;
     /** Linear bot user UUID for loop prevention. CTL-263. */
     botUserId?: string;
+    /** Linear team→repo map (CTL-362). When set, the handler stamps
+     * `attributes["vcs.repository.name"]` on issue/comment/cycle envelopes for
+     * teams that appear here so the HUD's REPO column populates for Linear
+     * events. Empty / absent = no enrichment (pre-CTL-362 behaviour). */
+    linearTeams?: Array<{ key: string; vcsRepo: string }>;
   } | null;
 }
 
@@ -652,6 +657,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     linearWebhookHandler = createLinearWebhookHandler({
       linearSecrets: linearWebhookConfig?.linearSecrets ?? [],
       botUserId: linearWebhookConfig?.botUserId,
+      linearTeams: linearWebhookConfig?.linearTeams ?? [],
       eventLog: linearEventLog,
       emit: (type, data) => emit(type, data),
       // CTL-211 — invalidate the LinearFetcher cache on issue webhook events
@@ -1920,6 +1926,7 @@ if (import.meta.main) {
           linearSecrets: fullWebhookConfig.linearSecrets,
           smeeChannel: fullWebhookConfig.linearSmeeChannel,
           botUserId: fullWebhookConfig.linearBotUserId || undefined,
+          linearTeams: fullWebhookConfig.linearTeams,
         }
       : null;
   let summarizeHandler: SummarizeHandler | null = null;

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -476,7 +476,11 @@ team-wide.
         }
       },
       "linear": {
-        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET"
+        "webhookSecretEnv": "CATALYST_LINEAR_WEBHOOK_SECRET",
+        "teams": [
+          { "key": "CTL", "vcsRepo": "coalesce-labs/catalyst" },
+          { "key": "ADV", "vcsRepo": "coalesce-labs/adva" }
+        ]
       }
     }
   }
@@ -490,6 +494,7 @@ team-wide.
 | `catalyst.monitor.github.watchRepos` | `.catalyst/config.json` | string[] | `[]` | Repos (owner/repo) subscribed at daemon startup — additive on top of worker-driven auto-discovery. See [Persistent watch list](/observability/webhooks/#persistent-watch-list). |
 | `catalyst.monitor.github.repoColors` | `.catalyst/config.json` | object | `{}` | Map of `"owner/repo"` → color name. Colors the repo chip in the HUD activity feed. Supported values: `blue`, `green`, `purple`, `amber`, `red`, `teal`, `cyan`, `lime`. |
 | `catalyst.monitor.linear.webhookSecretEnv` | `.catalyst/config.json` | string | `"CATALYST_LINEAR_WEBHOOK_SECRET"` | **Name** of the env var the Linear HMAC secret is read from. Empty/missing → `POST /api/webhook/linear` returns 503. See [Linear webhooks](/observability/webhooks/#linear-webhooks). |
+| `catalyst.monitor.linear.teams` | `.catalyst/config.json` | `{ key, vcsRepo }[]` | `[]` | Linear team→repo map (CTL-362). When a Linear webhook event carries a `team.key` that appears here (or a comment whose ticket prefix matches), the canonical envelope gets `attributes["vcs.repository.name"]` set so the HUD's REPO column populates for `linear.issue.*` / `linear.comment.*` / `linear.cycle.*` events. Each entry must have a non-empty `key` (team short key, e.g. `"CTL"`) and a `vcsRepo` in `"owner/repo"` shape; malformed entries are skipped with a warning. |
 | `catalyst.monitor.suppressVersionWarning` | `.catalyst/config.json` | boolean | `false` | Suppress the version-drift warning printed by `catalyst-monitor start` / `restart` when running an older daemon version than the highest available in the plugin cache. See [Version drift detection](/observability/webhooks/#version-drift-detection). |
 
 Environment variable overrides:


### PR DESCRIPTION
## Summary

Wire `attributes["vcs.repository.name"]` through the three event sources that don't set it today — Linear webhook events, orchestrator-emitted events (`catalyst-state.sh:event_append`), and broker-emitted `filter.wake.*` envelopes — so the HUD's REPO column populates for all of them. The GitHub webhook path already sets it; this lands the gap.

Resolves CTL-362. See [research](thoughts/shared/research/2026-05-13-hud-cleanup.md) § Area 2 for the gap analysis.

## What changed

- **Config**: `catalyst.monitor.linear.teams[]` (Layer 1) maps a Linear team short key to an `owner/repo` string. Entries must match the standard repo shape; malformed entries are skipped with a warning. Documented in `website/src/content/docs/reference/configuration.md`.
- **Linear webhook handler**: `buildLinearEventLogEnvelope` now accepts a `teamsMap`. Issue and cycle events use `event.teamKey`; comment events derive the team from the ticket prefix (e.g. `CTL-210` → `CTL`) since the webhook payload does not carry it directly. Reaction / issue_label events have no team context and stay unenriched.
- **Broker**: `buildCanonicalEnvelope` accepts `legacy.repo` (and `vcsRepo` as alias) and copies it to `attributes["vcs.repository.name"]`. Wake call sites (deterministic routes, prose batch matches, watchdog wakes) pass `reg.repo` from the interest record — today only `pr_lifecycle` interests carry a repo, but the wiring is in place.
- **Bash**: `event_append` in `catalyst-state.sh` now reads `.vcsRepo` / `.repo` from the top-level input JSON and forwards `--vcs-repo` to `build_canonical_line`. The flag itself already existed in `lib/canonical-event.sh`.

## Test plan

- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts` — adds `linearTeams` parsing (valid, missing fields, malformed `owner/repo`, dedup-by-key)
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts` — adds a 10-test block for `buildLinearEventLogEnvelope` with team lookup covering issue (known/unknown/no team), comment (matched prefix, unknown prefix, no ticket), cycle, reaction, issue_label, and no-map backward-compat
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts` — explicit `vcs.repository.name` flow-through assertion
- [x] `bun test plugins/dev/scripts/broker/canonical-events.test.mjs` — `repo` + `vcsRepo` alias + null/empty cases
- [x] `bash plugins/dev/scripts/__tests__/catalyst-state.test.sh` — Tests 10/11/12 cover the JSON-input → canonical attribute pipeline

All 276 bun tests + 20 bash tests pass. ESLint clean on touched files. The 7 unrelated failures in the full suite (`catalyst-monitor.sh` integration + SSE + `session-store`) are env-dependent and pre-existing.

## Out of scope

- HUD smoke test (REPO column populated visually for `linear.issue.*` / `orchestrator.*` / `filter.wake.*` / `broker.daemon.*`) — requires a live monitor with Linear webhooks wired; the code path is exercised by the new unit tests above.
- Inferring repo from orch-id naming (`orch-adv-*` ↔ Adva) — explicitly out of scope per the ticket. Use the new explicit config instead.