### PR TITLE
fix(dev): NL query — refresh prompt schema, add events catalog, inject current time (CTL-365)

### DIFF
--- a/plugins/dev/scripts/lib/dsl-compile.test.mjs
+++ b/plugins/dev/scripts/lib/dsl-compile.test.mjs
@@ -32,8 +32,8 @@ import {
 
 describe("CANONICAL_FIELDS whitelist", () => {
   test("contains the documented count of canonical fields", () => {
-    expect(CANONICAL_FIELDS.length).toBe(31);
-    expect(FIELD_PATH_SET.size).toBe(31);
+    expect(CANONICAL_FIELDS.length).toBe(32);
+    expect(FIELD_PATH_SET.size).toBe(32);
   });
 
   test("includes core attribute paths", () => {

--- a/plugins/dev/scripts/lib/dsl-fields.mjs
+++ b/plugins/dev/scripts/lib/dsl-fields.mjs
@@ -22,7 +22,7 @@ export const CANONICAL_FIELDS = [
   { path: "traceId",                       type: "string",  description: "32-hex trace ID, or null for ambient events" },
   { path: "spanId",                        type: "string",  description: "16-hex span ID, or null for ambient events" },
   { path: "parentSpanId",                  type: "string",  description: "16-hex parent span ID when present" },
-  { path: 'resource."service.name"',       type: "enum",    description: "catalyst.github | catalyst.linear | catalyst.session | catalyst.orchestrator | catalyst.comms | catalyst.filter" },
+  { path: 'resource."service.name"',       type: "enum",    description: "catalyst.github | catalyst.linear | catalyst.session | catalyst.orchestrator | catalyst.comms | catalyst.broker" },
   { path: "body.message",                  type: "string",  description: "Human-readable summary of the event" },
 
   // ─── attributes.event.* ───────────────────────────────────────────────────

--- a/plugins/dev/scripts/lib/dsl-prompt.d.mts
+++ b/plugins/dev/scripts/lib/dsl-prompt.d.mts
@@ -1,2 +1,3 @@
 export const SYSTEM_PROMPT: string;
 export const FEW_SHOT_EXAMPLES: ReadonlyArray<{ user: string; assistant: object }>;
+export function buildSystemPrompt(opts?: { now?: Date }): string;

--- a/plugins/dev/scripts/lib/dsl-prompt.mjs
+++ b/plugins/dev/scripts/lib/dsl-prompt.mjs
@@ -48,6 +48,19 @@ export const FEW_SHOT_EXAMPLES = [
     },
   },
   {
+    user: "errors from the last 24 hours",
+    assistant: {
+      filter: {
+        and: [
+          { field: "severityText", eq: "ERROR" },
+          { field: "ts", gte: "{NOW-24h}" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 200,
+    },
+  },
+  {
     user: "all events for orch-adv-852-2026-05-07",
     assistant: {
       filter: { field: 'attributes."catalyst.orchestrator.id"', eq: "orch-adv-852-2026-05-07" },
@@ -63,6 +76,109 @@ export const FEW_SHOT_EXAMPLES = [
           { field: 'attributes."event.name"', startsWith: "github.check_" },
           { field: 'attributes."cicd.pipeline.run.conclusion"', eq: "failure" },
           { field: 'attributes."vcs.ref.name"', eq: "refs/heads/main" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 100,
+    },
+  },
+  {
+    user: "broker filter wakes for orch-adv-931-2026-05-12",
+    assistant: {
+      filter: {
+        and: [
+          { field: 'attributes."event.name"', startsWith: "filter.wake." },
+          { field: 'attributes."catalyst.orchestrator.id"', eq: "orch-adv-931-2026-05-12" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 200,
+    },
+  },
+  {
+    user: "broker daemon startup and shutdown today",
+    assistant: {
+      filter: {
+        and: [
+          {
+            or: [
+              { field: 'attributes."event.name"', eq: "broker.daemon.startup" },
+              { field: 'attributes."event.name"', eq: "broker.daemon.shutdown" },
+            ],
+          },
+          { field: "ts", gte: "{TODAY}" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 100,
+    },
+  },
+  {
+    user: "workers that finished or failed today",
+    assistant: {
+      filter: {
+        and: [
+          {
+            or: [
+              { field: 'attributes."event.name"', eq: "orchestrator.worker.done" },
+              { field: 'attributes."event.name"', eq: "orchestrator.worker.failed" },
+            ],
+          },
+          { field: "ts", gte: "{TODAY}" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 200,
+    },
+  },
+  {
+    user: "raised attention items in the last 24 hours",
+    assistant: {
+      filter: {
+        and: [
+          { field: 'attributes."event.name"', eq: "orchestrator.attention.raised" },
+          { field: "ts", gte: "{NOW-24h}" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 200,
+    },
+  },
+  {
+    user: "session phase transitions for CTL-313",
+    assistant: {
+      filter: {
+        and: [
+          { field: 'attributes."event.name"', eq: "session.phase" },
+          { field: 'attributes."catalyst.worker.ticket"', eq: "CTL-313" },
+        ],
+      },
+      sort: { field: "ts", order: "asc" },
+      limit: 200,
+    },
+  },
+  {
+    user: "production deployment successes today",
+    assistant: {
+      filter: {
+        and: [
+          { field: 'attributes."event.name"', eq: "github.deployment_status.success" },
+          { field: 'attributes."deployment.environment"', eq: "production" },
+          { field: "ts", gte: "{TODAY}" },
+        ],
+      },
+      sort: { field: "ts", order: "desc" },
+      limit: 100,
+    },
+  },
+  {
+    user: "Linear cycle changes for team CTL today",
+    assistant: {
+      filter: {
+        and: [
+          { field: 'attributes."event.name"', startsWith: "linear.cycle." },
+          { field: 'attributes."linear.team.key"', eq: "CTL" },
+          { field: "ts", gte: "{TODAY}" },
         ],
       },
       sort: { field: "ts", order: "desc" },
@@ -118,7 +234,7 @@ Rules:
 2. NEVER invent fields. If the user references a concept that has no corresponding field, return \`{"error":"unknown field: <best-guess>"}\`.
 3. If the user asks to delete, modify, write, or trigger any action, return \`{"error":"refused: query is read-only"}\`.
 4. If the user asks for trace correlation from a PR number, return \`{"error":"trace pivot from PR not yet supported; query by traceId directly"}\`.
-5. For relative time windows ("last hour", "today", "yesterday"), emit a literal placeholder string \`"{NOW-1h}"\` / \`"{TODAY}"\` etc. on the \`gte\`/\`lte\` clause — the caller will rewrite these to ISO timestamps before running the filter.
+5. For relative time windows, emit a literal placeholder string on the \`gte\`/\`lte\` clause — the caller will rewrite these to ISO timestamps before running the filter. Worked examples: "last hour" → \`"{NOW-1h}"\`, "last 24 hours" → \`"{NOW-24h}"\`, "last 7 days" → \`"{NOW-7d}"\`, "today" → \`"{TODAY}"\`. The grammar is \`{NOW-<N><unit>}\` where unit is \`s\`/\`m\`/\`h\`/\`d\`.
 6. Always set a \`limit\` (default 200 if the user didn't specify).
 7. Always set a \`sort\` (default \`{field: "ts", order: "desc"}\`).
 
@@ -127,3 +243,18 @@ Few-shot examples:
 ${FEW_SHOT_BLOCK}
 
 Return only the JSON object. No prose, no code fences, no commentary.`;
+
+// ─── Per-request prompt augmentation (CTL-365) ───────────────────────────────
+//
+// The static SYSTEM_PROMPT above is built once at module load and cached. The
+// model has no clock, so phrases like "errors in the last 24 hours" used to
+// silently degrade to {TODAY} (UTC midnight). buildSystemPrompt() appends a
+// short trailing block with the current ISO timestamp; the cache-friendly
+// schema prefix is untouched so prompt-caching layers can still hit on it.
+//
+// Callers (hud.tsx, CLI) call this once per request and pass the result as
+// the `systemPrompt` option to groqTranslate().
+export function buildSystemPrompt(opts = {}) {
+  const now = opts.now instanceof Date ? opts.now : new Date();
+  return `${SYSTEM_PROMPT}\n\nCurrent time: ${now.toISOString()}\n`;
+}

--- a/plugins/dev/scripts/lib/dsl-prompt.test.mjs
+++ b/plugins/dev/scripts/lib/dsl-prompt.test.mjs
@@ -1,0 +1,102 @@
+// dsl-prompt.test.mjs — system prompt schema + builder tests for CTL-365.
+// Run: bun test plugins/dev/scripts/lib/dsl-prompt.test.mjs
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  SYSTEM_PROMPT,
+  FEW_SHOT_EXAMPLES,
+  buildSystemPrompt,
+} from "./dsl-prompt.mjs";
+
+describe("SYSTEM_PROMPT schema reflects live emitters (CTL-365)", () => {
+  test("service.name enum lists catalyst.broker", () => {
+    expect(SYSTEM_PROMPT).toContain("catalyst.broker");
+  });
+
+  test("service.name enum lists catalyst.orchestrator", () => {
+    expect(SYSTEM_PROMPT).toContain("catalyst.orchestrator");
+  });
+
+  test("service.name enum does NOT list catalyst.filter (dead service name)", () => {
+    // catalyst.filter has no live emitter; filter.* events come from catalyst.broker.
+    expect(SYSTEM_PROMPT).not.toMatch(/catalyst\.filter\b/);
+  });
+
+  test("rule 5 worked examples include {NOW-24h}", () => {
+    expect(SYSTEM_PROMPT).toContain("{NOW-24h}");
+  });
+});
+
+describe("FEW_SHOT_EXAMPLES covers post-CTL-313 event names (CTL-365)", () => {
+  const block = JSON.stringify(FEW_SHOT_EXAMPLES);
+
+  test("includes a filter.wake example", () => {
+    expect(block).toContain("filter.wake");
+  });
+
+  test("includes a broker.daemon example", () => {
+    expect(block).toContain("broker.daemon");
+  });
+
+  test("includes a session.phase or session.* example", () => {
+    expect(block).toMatch(/session\.(phase|started|ended|iteration)/);
+  });
+
+  test("includes an orchestrator.worker.* example", () => {
+    expect(block).toMatch(/orchestrator\.worker\./);
+  });
+
+  test("includes an orchestrator.attention.* example", () => {
+    expect(block).toMatch(/orchestrator\.attention\./);
+  });
+
+  test("includes a github.deployment.* or deployment_status example", () => {
+    expect(block).toMatch(/github\.deployment(_status)?\./);
+  });
+
+  test("includes a linear.cycle.* or linear.issue_label.* example", () => {
+    expect(block).toMatch(/linear\.(cycle|issue_label|reaction)\./);
+  });
+
+  test("includes a {NOW-24h} worked example", () => {
+    expect(block).toContain("{NOW-24h}");
+  });
+});
+
+describe("buildSystemPrompt() injects current time (CTL-365)", () => {
+  test("returns the static SYSTEM_PROMPT prefix verbatim", () => {
+    const out = buildSystemPrompt({ now: new Date("2026-05-13T15:30:00.000Z") });
+    // The schema block (cache-friendly prefix) must be present unchanged.
+    expect(out.startsWith(SYSTEM_PROMPT)).toBe(true);
+  });
+
+  test("appends a 'Current time:' line with an ISO 8601 timestamp", () => {
+    const fixed = new Date("2026-05-13T15:30:00.000Z");
+    const out = buildSystemPrompt({ now: fixed });
+    expect(out).toContain("Current time:");
+    expect(out).toContain("2026-05-13T15:30:00.000Z");
+  });
+
+  test("defaults to new Date() when now is omitted", () => {
+    const before = Date.now();
+    const out = buildSystemPrompt();
+    const after = Date.now();
+    // Extract the ISO timestamp from the "Current time:" line.
+    const match = out.match(/Current time:\s*(\S+)/);
+    expect(match).not.toBeNull();
+    const ts = new Date(match[1]).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before - 1000);
+    expect(ts).toBeLessThanOrEqual(after + 1000);
+  });
+
+  test("the static SYSTEM_PROMPT does NOT contain a current-time line (cache-friendly)", () => {
+    expect(SYSTEM_PROMPT).not.toContain("Current time:");
+  });
+
+  test("buildSystemPrompt output is distinct from SYSTEM_PROMPT", () => {
+    const out = buildSystemPrompt({ now: new Date("2026-05-13T15:30:00.000Z") });
+    expect(out).not.toBe(SYSTEM_PROMPT);
+    expect(out.length).toBeGreaterThan(SYSTEM_PROMPT.length);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -25,7 +25,7 @@ import {
   GroqHttpError,
   GroqResponseError,
 } from "../../lib/dsl-compile.mjs";
-import { SYSTEM_PROMPT } from "../../lib/dsl-prompt.mjs";
+import { buildSystemPrompt } from "../../lib/dsl-prompt.mjs";
 import type { CanonicalEvent } from "../lib/canonical-event.ts";
 
 interface AppProps {
@@ -273,7 +273,10 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
 
     try {
       const apiKey = process.env["GROQ_API_KEY"] || readGroqApiKeyFromConfig();
-      const dsl = await groqTranslate(text, { apiKey, systemPrompt: SYSTEM_PROMPT });
+      // CTL-365: inject current time per-request so "last 24 hours" etc. resolve
+      // against the wall clock rather than silently degrading to UTC midnight.
+      const systemPrompt = buildSystemPrompt({ now: new Date() });
+      const dsl = await groqTranslate(text, { apiKey, systemPrompt });
       const rewritten = { ...dsl, filter: dsl.filter ? rewriteNode(dsl.filter) : {} };
       const compiled = compile(rewritten);
       setDslState({ dsl: rewritten, jsPredicate: compiled.jsPredicate, nlQuery: text });


### PR DESCRIPTION
## Summary

The orch-monitor HUD's `: <natural-language>` query path (Groq → JSON DSL) used a static system prompt that had drifted from live event emitters. Phrases like *"errors from the last 24 hours"* silently degraded to `{TODAY}` (UTC midnight) because the model had no clock and no `{NOW-24h}` worked example.

Closes CTL-365.

## What changed

**Schema (`dsl-fields.mjs`)**
- `service.name` enum: add `catalyst.broker`; remove `catalyst.filter` (no live emitter — `filter.*` events are emitted by `catalyst.broker`).

**Prompt (`dsl-prompt.mjs`)**
- Few-shot now covers `filter.wake.*`, `broker.daemon.*`, `orchestrator.worker.*`, `orchestrator.attention.raised`, `session.phase`, `github.deployment_status.*`, and `linear.cycle.*` — all live emitters per `~/catalyst/events`.
- Rule 5 worked examples include `{NOW-24h}` (was only `{NOW-1h}` and `{TODAY}`).
- Added an `"errors from the last 24 hours"` → `{NOW-24h}` example.

**Runtime (`dsl-prompt.mjs` + `hud.tsx`)**
- New `buildSystemPrompt({ now })` appends `Current time: <ISO>` to the static prompt, so the model has a clock for every request. The schema prefix is unchanged so prompt-caching layers still hit on it.
- `hud.tsx` now calls `buildSystemPrompt({ now: new Date() })` per submit.

**Tests**
- New `dsl-prompt.test.mjs` (17 tests) — regression coverage for schema enum, few-shot coverage, rule 5 examples, current-time injection, static prompt cache purity.
- `dsl-compile.test.mjs`: bumped `CANONICAL_FIELDS.length` assertion `31 → 32`. The count was already stale from CTL-344's `event.id` addition; this PR fixes the lingering test failure.

## Test plan

- [x] `bun test plugins/dev/scripts/lib/dsl-prompt.test.mjs` — 17/17 pass
- [x] `bun test plugins/dev/scripts/lib/` — 121/121 pass
- [x] Manual smoke test: `buildSystemPrompt()` output ends with `Current time: <ISO>` and includes all 9 new emitter names + `{NOW-24h}`.
- [ ] Manual repro in the HUD: `: errors from the last 24 hours` returns a true 24-hour window rather than since-midnight.

## Acceptance criteria (from ticket)

- [x] `service.name` enum reflects actual emitters.
- [x] Few-shot covers broker / filter / session / orchestrator / deployment event names.
- [x] Rule 5 example list includes `{NOW-24h}`.
- [x] Each Groq request includes the current ISO timestamp in the system prompt.
- [x] Regression test that the system prompt builder includes a current-time line.

## Research

- [`thoughts/shared/research/2026-05-13-hud-cleanup.md`](../blob/main/thoughts/shared/research/2026-05-13-hud-cleanup.md) — Area 5