### PR TITLE
feat(dev): lift cicd.pipeline.run.status to typed canonical attribute (CTL-366)

### DIFF
--- a/plugins/dev/references/event-schema.md
+++ b/plugins/dev/references/event-schema.md
@@ -124,7 +124,16 @@ Attribute names contain dots. In jq, always double-quote them: `.attributes."eve
 | `catalyst.orchestrator.id` | string | Orchestration run identifier |
 | `catalyst.worker.ticket` | string | Worker ticket key (e.g. `CTL-210`) |
 | `catalyst.session.id` | string | Claude session ID (human-readable, for joining) |
-| `catalyst.phase` | number | Current phase number |
+| `catalyst.phase` | number | Current phase number — see note below |
+
+**Note on `catalyst.phase` as the OTel "stage/step" analogue.** Stable OTel CI/CD semconv
+defines `cicd.pipeline.run.id`, `cicd.pipeline.name`, and `cicd.pipeline.run.result` — no
+LogRecord-level "stage" or "step" field. `catalyst.phase` (integer) is our project-local
+stage analogue: an ordinal that identifies which phase of a multi-step workflow emitted
+the event. Today it is emitted only by `session.phase` events (with the human-readable
+phase name in `body.payload.to`), but the attribute is reserved for any catalyst component
+that wants to label events with a stage ordinal. No new schema field is needed for the
+stage/step concept.
 
 ### `vcs.*` — OTel VCS semconv
 
@@ -140,6 +149,7 @@ Attribute names contain dots. In jq, always double-quote them: `.attributes."eve
 | Attribute | Type | Description |
 |---|---|---|
 | `cicd.pipeline.run.id` | number | GitHub Actions run ID |
+| `cicd.pipeline.run.status` | string | `"queued"`, `"in_progress"`, `"completed"` — lifecycle state on `workflow_run` and `check_suite` envelopes |
 | `cicd.pipeline.run.conclusion` | string | `"success"`, `"failure"`, `"cancelled"`, `"skipped"`, `"timed_out"` |
 | `cicd.pipeline.name` | string | Workflow name (e.g. `"CI"`) |
 
@@ -468,7 +478,7 @@ Filters that previously matched `.event == "filter.wake.${id}"` now match:
 | `github.pr.{action}` | `pr` | `{action}` | INFO | yes | merged, opened, closed, synchronize, labeled, etc. |
 | `github.pr_review.{action}` | `pr_review` | `{action}` | INFO | yes | submitted, dismissed, edited |
 | `github.pr_review_thread.{state}` | `pr_review_thread` | `{state}` | INFO | yes | resolved, unresolved |
-| `github.check_suite.{status}` | `check_suite` | `{status}` | INFO (WARN if conclusion=failure) | only if single PR | `body.payload.prNumbers` for multi-PR |
+| `github.check_suite.{status}` | `check_suite` | `{status}` | INFO (WARN if conclusion=failure) | only if single PR | `cicd.pipeline.run.status`, `body.payload.prNumbers` for multi-PR |
 | `github.status.{state}` | `status` | `{state}` | INFO/WARN/ERROR | no | `vcs.revision` = sha |
 | `github.push` | `push` | `pushed` | INFO | no | `vcs.ref.name`, `vcs.revision` |
 | `github.issue_comment.{action}` | `issue_comment` | `{action}` | INFO | yes | PR-attached only |
@@ -476,7 +486,7 @@ Filters that previously matched `.event == "filter.wake.${id}"` now match:
 | `github.deployment.created` | `deployment` | `created` | INFO | no | `deployment.environment`, `deployment.id` |
 | `github.deployment_status.{state}` | `deployment_status` | `{state}` | INFO/ERROR | no | ERROR on failure/error states |
 | `github.release.{action}` | `release` | `{action}` | INFO | no | `event.label` = tag name |
-| `github.workflow_run.{action}` | `workflow_run` | `{action}` | INFO (WARN if conclusion=failure) | only if single PR | `cicd.pipeline.run.id`, `cicd.pipeline.name` |
+| `github.workflow_run.{action}` | `workflow_run` | `{action}` | INFO (WARN if conclusion=failure) | only if single PR | `cicd.pipeline.run.id`, `cicd.pipeline.run.status`, `cicd.pipeline.name` |
 
 ### catalyst.linear
 

--- a/plugins/dev/scripts/lib/dsl-fields.mjs
+++ b/plugins/dev/scripts/lib/dsl-fields.mjs
@@ -47,6 +47,7 @@ export const CANONICAL_FIELDS = [
 
   // ─── attributes.cicd.* ────────────────────────────────────────────────────
   { path: 'attributes."cicd.pipeline.run.id"',         type: "number", description: "GitHub Actions run ID" },
+  { path: 'attributes."cicd.pipeline.run.status"',     type: "string", description: "queued | in_progress | completed (lifecycle state on workflow_run / check_suite)" },
   { path: 'attributes."cicd.pipeline.run.conclusion"', type: "string", description: "success | failure | cancelled | skipped | timed_out" },
   { path: 'attributes."cicd.pipeline.name"',           type: "string", description: "Workflow name (e.g. CI)" },
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
@@ -159,6 +159,22 @@ describe("buildCanonicalEvent", () => {
     });
     expect(ev.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
   });
+
+  it("accepts cicd.pipeline.run.status as a typed optional attribute (CTL-366)", () => {
+    const ev: CanonicalEvent = buildCanonicalEvent({
+      ts: "2026-05-08T18:00:00.000Z",
+      severityText: "INFO",
+      traceId: null,
+      spanId: null,
+      resource: { "service.name": "catalyst.github" },
+      attributes: {
+        "event.name": "github.workflow_run.in_progress",
+        "cicd.pipeline.run.status": "in_progress",
+      },
+      body: {},
+    });
+    expect(ev.attributes["cicd.pipeline.run.status"]).toBe("in_progress");
+  });
 });
 
 describe("generateEventId (CTL-344)", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/event-analysis.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-analysis.test.ts
@@ -208,6 +208,7 @@ describe("phaseTime", () => {
       phase: phaseNum,
       phaseTo: phaseName,
       ciConclusion: null,
+      ciStatus: null,
       severityText: "INFO",
       bodyMessage: null,
       raw: {},
@@ -269,6 +270,7 @@ describe("phaseTime", () => {
         phase: null,
         phaseTo: null,
         ciConclusion: null,
+        ciStatus: null,
         severityText: "INFO",
         bodyMessage: null,
         raw: {},
@@ -298,6 +300,7 @@ describe("stalls", () => {
         phase: null,
         phaseTo: null,
         ciConclusion: null,
+        ciStatus: null,
         severityText: "WARN",
         bodyMessage: null,
         raw: {
@@ -314,6 +317,7 @@ describe("stalls", () => {
         phase: null,
         phaseTo: null,
         ciConclusion: null,
+        ciStatus: null,
         severityText: "WARN",
         bodyMessage: null,
         raw: {
@@ -341,6 +345,7 @@ describe("stalls", () => {
         phase: null,
         phaseTo: null,
         ciConclusion: null,
+        ciStatus: null,
         severityText: "INFO",
         bodyMessage: null,
         raw: {
@@ -362,6 +367,7 @@ describe("stalls", () => {
         phase: null,
         phaseTo: null,
         ciConclusion: null,
+        ciStatus: null,
         severityText: "INFO",
         bodyMessage: null,
         raw: { body: { payload: { state: "approved", reviewer: "alice" } } },
@@ -396,6 +402,7 @@ describe("stalls", () => {
         phase: null,
         phaseTo: null,
         ciConclusion: null,
+        ciStatus: null,
         severityText: "WARN",
         bodyMessage: null,
         raw: {
@@ -430,6 +437,7 @@ describe("ciFunnel", () => {
       phase: null,
       phaseTo: null,
       ciConclusion: null,
+      ciStatus: null,
       severityText: "INFO",
       bodyMessage: null,
       raw: {},

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
@@ -703,10 +703,35 @@ describe("buildEventLogEnvelope (canonical)", () => {
     expect(env!.attributes["vcs.revision"]).toBe("abc123");
     expect(env!.attributes["vcs.pr.number"]).toBe(326);
     expect(env!.attributes["cicd.pipeline.run.id"]).toBe(555);
+    expect(env!.attributes["cicd.pipeline.run.status"]).toBe("completed");
     expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBe("success");
     expect(env!.attributes["cicd.pipeline.name"]).toBe("CI");
     const payload = env!.body.payload as { prNumbers: number[] };
     expect(payload.prNumbers).toEqual([326]);
+  });
+
+  it("workflow_run.in_progress lifts status but has no conclusion attr", () => {
+    const env = buildEventLogEnvelope(
+      {
+        kind: "workflow_run",
+        repo: "o/r",
+        action: "in_progress",
+        workflowId: 99,
+        runId: 556,
+        name: "CI",
+        headSha: "def456",
+        headBranch: "main",
+        status: "in_progress",
+        conclusion: null,
+        runNumber: 43,
+        htmlUrl: "https://github.com/o/r/actions/runs/556",
+        prNumbers: [328],
+      },
+      TS,
+    );
+    expect(env!.attributes["event.name"]).toBe("github.workflow_run.in_progress");
+    expect(env!.attributes["cicd.pipeline.run.status"]).toBe("in_progress");
+    expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBeUndefined();
   });
 
   it("workflow_run with multiple PRs omits vcs.pr.number (multi-PR ambiguity)", () => {
@@ -746,10 +771,28 @@ describe("buildEventLogEnvelope (canonical)", () => {
       TS,
     );
     expect(env!.attributes["event.name"]).toBe("github.check_suite.completed");
+    expect(env!.attributes["cicd.pipeline.run.status"]).toBe("completed");
     expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBe("failure");
     expect(env!.attributes["vcs.pr.number"]).toBe(1);
     expect(env!.severityText).toBe("WARN");
     expect(env!.severityNumber).toBe(13);
+  });
+
+  it("check_suite.in_progress lifts status but has no conclusion attr", () => {
+    const env = buildEventLogEnvelope(
+      {
+        kind: "check_suite",
+        repo: "o/r",
+        prNumbers: [2],
+        status: "in_progress",
+        conclusion: null,
+        headRef: "feature-branch",
+      },
+      TS,
+    );
+    expect(env!.attributes["event.name"]).toBe("github.check_suite.in_progress");
+    expect(env!.attributes["cicd.pipeline.run.status"]).toBe("in_progress");
+    expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBeUndefined();
   });
 
   it("maps deployment_status.success → github.deployment_status.success", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -64,6 +64,7 @@ export interface Attributes {
 
   // CI/CD semconv (OTel published)
   "cicd.pipeline.run.id"?: number;
+  "cicd.pipeline.run.status"?: string;
   "cicd.pipeline.run.conclusion"?: string;
   "cicd.pipeline.name"?: string;
 

--- a/plugins/dev/scripts/orch-monitor/lib/event-analysis.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-analysis.ts
@@ -19,6 +19,7 @@ export interface NormalizedEvent {
   phase: number | null;
   phaseTo: string | null;
   ciConclusion: string | null;
+  ciStatus: string | null;
   severityText: Severity | null;
   bodyMessage: string | null;
   raw: unknown;
@@ -189,6 +190,18 @@ export function normalize(line: string): NormalizedEvent | null {
     ciConclusion = asString(detail["conclusion"]);
   }
 
+  // CI status (queued | in_progress | completed) — CTL-366
+  let ciStatus: string | null = null;
+  if (isCanonical) {
+    ciStatus = asString(attrs["cicd.pipeline.run.status"]);
+  }
+  if (ciStatus === null && payload !== null) {
+    ciStatus = asString(payload["status"]);
+  }
+  if (ciStatus === null && detail !== null) {
+    ciStatus = asString(detail["status"]);
+  }
+
   const severityRaw = asString(obj.severityText);
   const severityText: Severity | null =
     severityRaw === "DEBUG" ||
@@ -210,6 +223,7 @@ export function normalize(line: string): NormalizedEvent | null {
     phase,
     phaseTo,
     ciConclusion,
+    ciStatus,
     severityText,
     bodyMessage,
     raw: obj,

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
@@ -229,6 +229,7 @@ export function buildEventLogEnvelope(
       const eventName = `github.check_suite.${event.status}`;
       const attrs: Omit<Attributes, "event.name"> = {
         "vcs.repository.name": event.repo,
+        "cicd.pipeline.run.status": event.status,
       };
       if (event.prNumbers.length === 1) {
         attrs["vcs.pr.number"] = event.prNumbers[0];
@@ -411,6 +412,7 @@ export function buildEventLogEnvelope(
         "vcs.repository.name": event.repo,
         "vcs.revision": event.headSha,
         "cicd.pipeline.run.id": event.runId,
+        "cicd.pipeline.run.status": event.status,
         "cicd.pipeline.name": event.name,
       };
       if (event.prNumbers.length === 1) {


### PR DESCRIPTION
## Summary

Promotes the lifecycle `status` field (`queued` / `in_progress` / `completed`) from
`body.payload.status` to a typed canonical attribute `cicd.pipeline.run.status` on
both `github.workflow_run.*` and `github.check_suite.*` envelopes. NL queries can
now filter on it, and `NormalizedEvent` surfaces it alongside `ciConclusion`.

Schema docs also clarify that `catalyst.phase` IS the project-local OTel
"stage/step" analogue — stable OTel CI/CD semconv has no LogRecord-level stage
field, so no new schema field is needed for the stage concept.

Closes CTL-366.

## Changes

- `canonical-event.ts`: add `"cicd.pipeline.run.status"?: string` to `Attributes`
- `webhook-handler.ts`: emit it from `event.status` on both `check_suite` and `workflow_run` cases
- `dsl-fields.mjs`: whitelist `attributes."cicd.pipeline.run.status"` for NL queries
- `event-analysis.ts`: surface `ciStatus` on `NormalizedEvent` (canonical + legacy fallbacks)
- `event-schema.md`: add `status` row to the `cicd.*` table; new note that `catalyst.phase` is the project-local stage analogue
- Tests in `canonical-event.test.ts`, `webhook-handler.test.ts`, `event-analysis.test.ts`

## Test plan

- [x] `bun test __tests__/canonical-event.test.ts __tests__/webhook-handler.test.ts __tests__/event-analysis.test.ts __tests__/webhook-events.test.ts` → 138 pass, 0 fail
- [x] Broader sweep (hud-format, column-widths, reactive-pr-filter) → 287 pass, 0 fail
- [x] Typecheck — 0 new errors (pre-existing `ui/src/lib/briefings.ts` missing-marked warning unchanged)
- [x] Lint — no new warnings
- [x] Reward-hacking scan — 0 hits (no `as any`, no `@ts-ignore`, no non-null assertions added)

## Out of scope (explicit)

- Extending `catalyst.phase` semantics to GitHub `workflow_run` events
- Reconciling `workflow_run` / `check_suite` event.name asymmetric naming
- Adding `cicd.*` flag set to `canonical-event.sh` (no bash producer emits cicd events today)
- Wiring `ciStatus` into hud-format/column-widths display surfaces (not in acceptance criteria)