### PR TITLE
fix(dev): require wake narration line per Monitor wake (CTL-369)

### DIFF
--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -232,6 +232,86 @@ works for **both** worker-lifecycle events (already attributed) and webhook even
 to any active orchestrator (human-merged PRs to main, dependabot PRs, etc.) keep
 `.orchestrator == null` and are filtered out, which is the desired behaviour.
 
+## Narration: one short line per wake (CTL-369)
+
+Every Monitor wake and every event-driven `wait-for` return MUST be acknowledged
+with a single short line of assistant text before the agent returns to waiting.
+This is the canonical way to defeat the `Human:\n<task-id>` rendering bleed —
+without it, transcripts become unreadable.
+
+**Why this is non-negotiable.** The Claude Code harness wraps every Monitor wake
+in a user-role `<task-notification>` XML message whose `<summary>` is the
+`description` field you passed to the `Monitor` tool. If the assistant returns
+an `end_turn` containing only `thinking` blocks (no `text` content) — which
+happens when the model decides the event is routine and has "nothing to say" —
+the UI renders the next `<task-notification>` raw and the `<task-id>` element
+leaks into the visible transcript as a phantom user message:
+
+```
+⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
+⏺ Human:
+  ba18h9cyy
+⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
+⏺ Human:
+  ba18h9cyy
+```
+
+The "`ba18h9cyy`" lines look like the human user spoke but are actually harness
+XML element content. The fix is on the agent side, not the harness side: emit
+any text content in the response turn and the rendering artifact disappears.
+
+**Required line shapes.** Pick the one that matches the wake. Each is a single
+line under ~120 characters; both "what arrived" and "what we're doing about it"
+must appear (even if "what we're doing" is "nothing").
+
+| Situation | Line shape |
+|---|---|
+| Actionable wake | `wake: <event.name> #<pr> [interest=<type>] — <action being taken>` |
+| Non-actionable / routine | `wake: <event.name> — routine, staying in event loop` |
+| Already addressed (stale broker re-fire) | `wake: <event.name> — already addressed, no-op` |
+| Idle-timeout safety-net scan | `wake: idle-timeout — running periodic reconciliation scan` |
+| Daemon-down / REST fallback | `wake: rest-poll — broker down, polling gh api` |
+
+**Include the matched filter clause or interest type when available.** Broker
+wakes (`filter.wake.<sid>`) carry `.body.payload.interest_id` and
+`.body.payload.reason`; surface both. Hand-rolled `tail` / `wait-for` filters
+have no interest_id — surface the event name and the matched PR/ticket scope
+instead. The audience for this line is a human reading the transcript later
+trying to reconstruct why the agent fired now and what it decided to do.
+
+**Wake-narration fixture (good vs bad).** Use this as the acceptance check
+when reviewing a transcript:
+
+```text
+# BAD — orchestrator returned thinking-only end_turn, task-id leaks
+
+⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
+⏺ Human:
+  ba18h9cyy
+⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
+⏺ Human:
+  c9a4f2x1q
+
+# GOOD — orchestrator narrates every wake; no task-id bleed
+
+⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
+⏺ wake: github.check_suite.completed #412 [interest=pr_lifecycle] —
+       CI failed on PR #412, dispatching auto-fixup
+⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
+⏺ wake: orchestrator.worker.phase_advanced — routine, staying in event loop
+```
+
+This requirement applies to **every** event-driven listen loop in Catalyst
+skills:
+
+- `orchestrate` Phase 4 (orchestrator's own Monitor over `catalyst-events tail`)
+- `orchestrate` worker dispatch prompt (each worker's listen loop)
+- `oneshot` Phase 5 (worker's PR listen loop)
+- Any new skill that wraps `Monitor` or `catalyst-events wait-for`
+
+The narration line is not for the agent — it is for the *operator reading the
+transcript later*. Treat the wake as a question; treat the line as the answer.
+
 ## Pattern 3 — Reactive PR lifecycle (multi-event wait + classify + dispatch)
 
 Pattern 1's single-event wait is fine for the happy path: the PR merges, the

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -693,6 +693,26 @@ BEHIND) inline and proceeds to Step 3 only when the PR is CLEAN (CI green + revi
 unrecoverable blockers (human changes-requested, persistent DIRTY) the worker writes
 `status: "stalled"` and exits; the orchestrator's Phase 4 is a safety-net fallback.
 
+**Wake narration (MANDATORY, CTL-369).** Every iteration of the listen loop —
+both on a `wait-for` return AND on each `mergeable_state` re-check — must
+produce a single short line of assistant text before re-entering the wait. This
+defeats the `Human:\n<task-id>` rendering bleed that occurs when the agent
+returns an `end_turn` containing only `thinking` blocks after a Monitor-wrapped
+wake. The line shape is:
+
+```text
+wake: <event.name> #<PR_NUMBER> [interest=<type>] — <action being taken>
+wake: <event.name> — routine, staying in event loop
+wake: <event.name> — already addressed, no-op
+wake: rest-poll — broker down, polling gh api
+```
+
+Surface `.body.payload.interest_id` and `.body.payload.reason` from the wake
+envelope when present (broker wakes carry both); for hand-rolled two-phase
+filter wakes, surface the matched `event.name` and `#${PR_NUMBER}` instead. See
+`plugins/dev/skills/monitor-events/SKILL.md` § Narration for the full rule and
+the good-vs-bad transcript fixture.
+
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 PR_OPENED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -655,6 +655,20 @@ NEVER use gh pr view --json in any loop — that burns GraphQL rate limits.
 Use gh api REST endpoints only for the authoritative state check that
 follows every wake.
 
+WAKE NARRATION (MANDATORY, CTL-369): every Monitor wake and every wait-for
+return must be acknowledged with a single short line of assistant text before
+returning to the wait. A thinking-only end_turn after a Monitor wake makes the
+harness's next <task-notification> XML leak as a confusing "Human:\n<task-id>"
+phantom user message. The line shape is:
+
+  wake: <event.name> #<pr> [interest=<type>] — <action being taken>
+  wake: <event.name> — routine, staying in event loop
+  wake: <event.name> — already addressed, no-op
+
+Include the matched filter clause / interest_id when the wake is from the
+broker (.body.payload.interest_id, .body.payload.reason). See
+plugins/dev/skills/monitor-events/SKILL.md § Narration for the full rule.
+
 Write these fields into your signal file as they become available:
   pr.number
   pr.url
@@ -934,6 +948,34 @@ orchestrators sharing the repo will also fire wake-ups; prefer
 > **Orchestrator-scoped filtering (CTL-234):** `github.*` events now carry `.attributes."catalyst.orchestrator.id"`
 > (stamped at receive time by the webhook handler). You may safely add
 > `(.attributes."catalyst.orchestrator.id" == "${ORCH_NAME}") and (...)` to narrow the filter to this run's PRs only.
+
+**Wake narration (MANDATORY, CTL-369).** Every Monitor wake — including ones
+classified as routine or already-addressed — must produce a single short line of
+assistant text before returning to the wait. The Claude Code harness wraps each
+Monitor stdout line in a `<task-notification>` XML user message; if the
+orchestrator's response is `end_turn` with only `thinking` blocks and no `text`
+content, the UI renders the next `<task-notification>`'s `<task-id>` as a
+phantom `Human:\n<task-id>` line in the transcript. The narration line defeats
+that artifact and gives the operator reading the transcript later a record of
+what fired and what was decided.
+
+Line shape (pick one; keep it under ~120 characters):
+
+```text
+wake: <event.name> #<pr> [interest=<type>] — <action being taken>
+wake: <event.name> — routine, staying in event loop
+wake: <event.name> — already addressed, no-op
+wake: idle-timeout — running periodic reconciliation scan
+```
+
+Surface the matched interest when wake came from the broker
+(`filter.wake.${ORCH_NAME}`): include `.body.payload.interest_id` (or its type:
+`pr_lifecycle` / `ticket_lifecycle` / `comms_lifecycle`) and a one-clause
+restatement of `.body.payload.reason`. For broad-form `catalyst-events tail`
+wakes, surface the raw `event.name` and the PR/ticket scope instead.
+
+See `plugins/dev/skills/monitor-events/SKILL.md` § Narration for the full rule
+and the good-vs-bad transcript fixture.
 
 **Wake-up classification.** When a line arrives on the Monitor, classify it before
 re-entering the scan so the response stays proportional. Every reaction reads


### PR DESCRIPTION
## Summary

Every Monitor wake and event-driven `wait-for` return must now emit a single short line of assistant text before re-entering the wait. A thinking-only `end_turn` after a Monitor wake makes the Claude Code harness's next `<task-notification>` XML render as a phantom `Human:\n<task-id>` line in the transcript. The narration line defeats that artifact and gives an operator reading the transcript later a record of what fired and what was decided.

Linear: CTL-369

## What changed

- **monitor-events/SKILL.md** — new `## Narration: one short line per wake (CTL-369)` section between Pattern 2 and Pattern 3. Documents the rendering bleed anatomy, required line shapes (actionable / routine / no-op / idle-timeout / rest-poll), and a good-vs-bad transcript fixture as the acceptance check. Names this as the canonical fix for the bleed.
- **orchestrate/SKILL.md** —
  - Worker dispatch prompt block (lines 604-674): adds `WAKE NARRATION (MANDATORY, CTL-369)` paragraph instructing each dispatched worker to narrate every wake.
  - Orchestrator's own Phase 4 (before the Wake-up classification table): adds a `Wake narration (MANDATORY)` paragraph with line-shape templates and broker-vs-broad guidance. Surfaces `.body.payload.interest_id` and `.reason` for broker wakes.
- **oneshot/SKILL.md** — Phase 5 listen loop description gains a `Wake narration (MANDATORY)` paragraph requiring narration on every loop iteration (both `wait-for` return and each `mergeable_state` re-check).

All three files cross-link to `monitor-events/SKILL.md § Narration` as the single source of truth.

## Acceptance check

The good-vs-bad fixture in `monitor-events/SKILL.md` is the manual acceptance artifact:

```text
# BAD — orchestrator returned thinking-only end_turn, task-id leaks
⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
⏺ Human:
  ba18h9cyy

# GOOD — orchestrator narrates every wake; no task-id bleed
⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
⏺ wake: github.check_suite.completed #412 [interest=pr_lifecycle] —
       CI failed on PR #412, dispatching auto-fixup
⏺ Monitor event: "orch-adv-931 events (PR/CI/worker/comms)"
⏺ wake: orchestrator.worker.phase_advanced — routine, staying in event loop
```

## Test plan

- [ ] Run a small orchestrate flow; observe transcript no longer has bare `Human:\n<task-id>` lines.
- [ ] Verify orchestrator's Phase 4 wakes each produce a single `wake: ...` line.
- [ ] Verify a dispatched oneshot worker's Phase 5 listen loop produces a `wake: ...` line per iteration.

## Out of scope

- Changing the Claude Code harness's `<task-notification>` XML rendering (we don't control that).
- Enriching the broker's wake payload with action suggestions (separate, see CTL-370).

🔗 Linear ticket: https://linear.app/coalesce-labs/issue/CTL-369