### PR TITLE
fix(dev): orchestrate dispatch prompt teaches broker Pattern 3 preference (CTL-371)

### DIFF
--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -42,15 +42,30 @@ runs warn-to-stderr and proceed. If you reuse the primitives outside those skill
 the status check yourself and either start the daemon (`catalyst-monitor.sh start`) or
 plan for the polling fallback.
 
-## The two primitives
+## Pattern selection & cost tradeoffs
 
-| Primitive | When | What |
-|---|---|---|
-| `Monitor` | Long-lived in-skill watch | Claude Code built-in tool; runs a background command and surfaces stdout lines as notifications |
-| `catalyst-events wait-for` | Short-lived `claude -p` worker | Bash CLI; blocks until a matching event arrives, prints the line, exits 0 |
+Three patterns are available; pick by cost shape, not just by mechanism. Listed cheapest first.
 
-Both use `catalyst-events` under the hood. `tail` is the streaming foundation; `wait-for`
-is `tail | head -n 1` with a timeout.
+| Pattern | Mechanism | Cost shape | When to use |
+|---|---|---|---|
+| **Broker interest** (preferred) | The `catalyst-broker` daemon (see [[broker]]) classifies events between Claude turns and emits `filter.wake.{id}` only on semantic match. Deterministic interest types (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`) match by typed-field comparison; prose interests go through Groq Llama 3.1 8B. | **Lowest.** Zero turns while blocked; 1 turn per matched wake. Deterministic routes cost 0 LLM tokens; prose routes ~$0.05–0.10/M tokens at small batch sizes. Pre-filtering happens out of Claude's context entirely. | Whenever the broker daemon is running. Worker-scope (single PR) and orchestrator-scope (many PRs) both supported via the same registration mechanism. |
+| **`catalyst-events wait-for` with jq** | Blocking Bash CLI; one jq predicate; exits on first match or `--timeout`. Works without the broker. | Zero turns while blocked, 1 turn per match. Same per-match cost as `Monitor` but workers usually wait for ONE specific event, so total turn count stays low. Filter expansion (CI + reviews + push + merge) widens the per-match probability. | Short-lived `claude -p` workers when the broker is not running; standalone one-shot waits; CI scripts. |
+| **`Monitor` over `catalyst-events tail`** | Claude Code's `Monitor` tool wraps `tail --filter`; every matching line surfaces as a turn-resuming notification. | Highest. 1 wake per matching line means broad filters can dominate context. | Long-lived orchestrator only. **NOT** for short-lived `claude -p` workers — they have no long-lived turn loop to consume notifications. |
+
+> **Worker contract (matches `oneshot` Phase 5, CTL-371):** dispatched workers prefer the broker
+> (Pattern 3), fall back to `wait-for` (Pattern 2) when the daemon is down, and never use
+> `Monitor`/`tail` (Pattern 1). See `plugins/dev/skills/oneshot/SKILL.md` Phase 5 and the
+> `orchestrate` dispatch prompt for the canonical invocation.
+
+> **Note on numbering.** The "Pattern N" labels in the recipe sections below (Pattern 1 — worker
+> waits for PR merge, Pattern 2 — long-lived orchestrator wakes, Pattern 3 — reactive PR lifecycle,
+> Pattern 4 — tail by ticket) are *recipe IDs*, not the cost-tier rank in the table above. The
+> recipes pre-date the broker integration; both the broker-preferred path and the `wait-for`
+> fallback inside each recipe map to the table rows above.
+
+Both `wait-for` and `Monitor` use `catalyst-events` under the hood. `tail` is the streaming
+foundation; `wait-for` is `tail | head -n 1` with a timeout. The broker reads the same event log
+as `tail` does but classifies before waking, which is why its per-wake cost is so much lower.
 
 ## Pattern 1 — Worker waits for its PR to merge
 
@@ -559,6 +574,11 @@ Environment:
   filter; the long-lived precedent for Pattern 3
 - `catalyst-comms` — agent-to-agent pub/sub on per-channel files;
   `comms.message.posted` fan-out events go through this same log
-- [[catalyst-filter]] — Groq-backed semantic event router. Preferred wake
-  mechanism when running; collapses the per-concern jq filters in Patterns 1
-  and 2 into a single `filter.register` per agent (CTL-269)
+- [[broker]] — `catalyst-broker` daemon protocol (auto-correlation via
+  `agent.checkin`, deterministic `pr_lifecycle` / `ticket_lifecycle` /
+  `comms_lifecycle` routes). Preferred wake mechanism when running;
+  collapses the per-concern jq filters in the recipes below into a single
+  `filter.wake.{id}` per agent (CTL-303, CTL-371)
+- [[catalyst-filter]] — Groq-backed semantic event router (deprecated alias
+  for the broker; prose-classification path retained but env-gated off by
+  default since CTL-357)

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -620,11 +620,40 @@ Your success contract ENDS at (CTL-252):
   ✓ pr.mergedAt, deployment.url (if applicable), status="done" written to signal file
   ✓ Worker process exits cleanly
 
-Use catalyst-events wait-for (two-phase pattern from [[wait-for-github]]) to
-listen for PR events — this is a blocking subprocess call that works reliably
-in claude -p non-interactive sessions. NEVER use gh pr view --json in any loop
-— that burns GraphQL rate limits. Use gh api REST endpoints only for state
-checks.
+Listen for PR events using this precedence ladder (matches oneshot Phase 5):
+
+  1. PREFERRED — Broker auto-correlation (Pattern 3, lowest cost):
+     The catalyst-broker daemon classifies events between Claude turns and
+     emits filter.wake.${CATALYST_SESSION_ID} only on semantic matches.
+     The agent.checkin event emitted by catalyst-session.sh start already
+     identifies you to the broker; emit a second agent.checkin carrying
+     claimed_pr after gh pr create (the oneshot helper broker_claim_pr does
+     exactly this). The broker auto-derives a pr_lifecycle interest covering
+     CI, reviews, comments, thread resolution, merge, BEHIND pushes, and
+     deployment status — all on a single wake event. Wait on:
+       catalyst-events wait-for \
+         --filter ".attributes.\"event.name\" == \"filter.wake.${CATALYST_SESSION_ID}\"" \
+         --timeout 600
+     Deterministic routes (pr_lifecycle / ticket_lifecycle / comms_lifecycle)
+     cost zero LLM tokens. See plugins/dev/skills/broker/SKILL.md for the
+     full protocol and plugins/dev/skills/catalyst-filter/SKILL.md for
+     prose-based registration when the deterministic routes aren't enough.
+
+  2. FALLBACK — catalyst-events wait-for with explicit jq (Pattern 2):
+     When catalyst-broker status returns non-running, use the two-phase
+     pattern from plugins/dev/skills/wait-for-github/SKILL.md. Blocking
+     subprocess call; works reliably in claude -p non-interactive sessions.
+     One jq predicate covers CI / reviews / push / merge for your PR.
+
+  3. FORBIDDEN for workers — Monitor over catalyst-events tail (Pattern 1):
+     That is the orchestrator's Phase 4 pattern, not a worker pattern.
+     A short-lived claude -p worker has no long-lived turn loop to consume
+     Monitor notifications, and tail filters wake on every matching line,
+     burning context.
+
+NEVER use gh pr view --json in any loop — that burns GraphQL rate limits.
+Use gh api REST endpoints only for the authoritative state check that
+follows every wake.
 
 Write these fields into your signal file as they become available:
   pr.number


### PR DESCRIPTION
## Summary

The orchestrate worker dispatch prompt named only `catalyst-events wait-for` (Pattern 2), but `oneshot` Phase 5 — which is what actually runs as each dispatched worker — already implements **broker auto-correlation (Pattern 3) → `wait-for` (Pattern 2) → REST polling** as the precedence ladder. The dispatch prompt was stale relative to the implementation, so workers reading it would author broad jq filters against raw events instead of leaning on the broker's deterministic `pr_lifecycle` routing.

This PR aligns the dispatch prompt with `oneshot`'s already-correct listen ladder and documents the cost tradeoff between the three patterns.

## Changes

### `plugins/dev/skills/orchestrate/SKILL.md` — dispatch prompt rewrite

Replaced the single Pattern-2 paragraph (`Use catalyst-events wait-for...`) with an explicit three-tier ladder:

1. **PREFERRED** — Broker auto-correlation (Pattern 3, lowest cost). The `agent.checkin` event with `claimed_pr` (oneshot's `broker_claim_pr` helper) auto-registers `pr_lifecycle`; the worker waits on `filter.wake.${CATALYST_SESSION_ID}`. Cross-refs to `broker/SKILL.md` and `catalyst-filter/SKILL.md`.
2. **FALLBACK** — `catalyst-events wait-for` with jq (Pattern 2). Two-phase pattern from `wait-for-github` when the broker daemon is not running.
3. **FORBIDDEN for workers** — `Monitor` over `catalyst-events tail` (Pattern 1). Orchestrator-only.

Kept the existing `gh pr view --json` prohibition and REST-check requirement; both are still correct.

### `plugins/dev/skills/monitor-events/SKILL.md` — cost-tradeoff doc

Replaced "The two primitives" with "Pattern selection & cost tradeoffs":

- Three-row table (broker / `wait-for` / `Monitor`) with explicit **cost shape** column. Deterministic broker routes = 0 LLM tokens; prose routes ~$0.05–0.10/M tokens at small batch sizes; `wait-for` and `Monitor` cost 1 turn per match.
- Worker contract callout pointing to `oneshot` Phase 5 and the orchestrate dispatch prompt as the canonical invocation.
- Numbering disambiguation so the cost-tier "Pattern N" labels don't get confused with the existing "Pattern N — recipe" sections below (those pre-date the broker integration).
- Added `[[broker]]` to Related skills (was only `[[catalyst-filter]]`).

## Acceptance criteria

- [x] Dispatch prompt names Pattern 3 first, Pattern 2 second, no Pattern 1 for workers.
- [x] Cross-references to `broker/SKILL.md` and `catalyst-filter/SKILL.md` present in the dispatch prompt.
- [x] A worker spawned by `orchestrate` follows the broker path when the daemon is up. (Already true via `oneshot/SKILL.md:710-735` Phase 5; the dispatch prompt now matches.)
- [x] The dispatch prompt and `oneshot` Phase 5 listen ladder agree.

## Out of scope (per ticket)

- Refactoring `oneshot`'s Phase 5 listen loop (it's already correct).
- Removing the `catalyst-events tail --filter` path entirely (Pattern 1 has legitimate orchestrator uses; only forbidden for workers).
- A formal doc-lint asserting the dispatch prompt and `oneshot` Phase 5 agree — flagged as a future-improvement candidate, not required for this ticket.

## Testing

Documentation-only change in a markdown-only repo (no build/compile/lint suite). Validation:

- All cross-referenced file paths exist (`broker/SKILL.md`, `catalyst-filter/SKILL.md`, `wait-for-github/SKILL.md`, `oneshot/SKILL.md`, `monitor-events/SKILL.md`).
- The orchestrate dispatch prompt's `filter.wake.${CATALYST_SESSION_ID}` predicate matches the literal predicate in `oneshot/SKILL.md:728`.
- `broker_claim_pr` helper referenced in the dispatch prompt exists at `oneshot/SKILL.md:210` and is invoked at `oneshot/SKILL.md:715`.

## Related

- CTL-370 — allowlist + schema drift in worker filters. Both touch worker filter authorship; this PR is about choosing the right primitive, CTL-370 is about getting the names right.

Closes CTL-371.