### PR TITLE
fix(dev): reconcile orchestrate Phase 4 grep pipe with monitor-events prohibition (CTL-372)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-events.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-events.test.sh
@@ -334,6 +334,35 @@ EVENT_L='{"attributes":{"event.name":"github.check_run.created","catalyst.orches
 run "filter rejects github webhook tagged with orch id but no PR/ref match (CTL-370)" \
   assert_no_match "$EVENT_L" "$FILTER_FILE"
 
+# ── 16b. canonical-only broker emissions — not matched (CTL-372) ────────────
+#
+# `filter.wake.*` and `broker.daemon.*` events are emitted by the broker as
+# canonical OTel envelopes. They carry the orchestrator id at
+# `attributes."catalyst.orchestrator.id"` but the orchestrator-filter's
+# orch-id clause requires the event name to start with `orchestrator.`
+# (per the CTL-370 guard above), so these emissions are dropped before
+# they reach the consumer of `catalyst-events tail`.
+#
+# Consequence for the Monitor-tail recipe in `orchestrate/SKILL.md`: no manual
+# `| grep -v 'filter.wake'` post-pipe is needed. Such a pipe is wrong on two
+# counts — (a) the events never reach the consumer to begin with, and
+# (b) the grep pattern would also strip the orchestrator's OWN intended
+# wake event `filter.wake.${ORCH_NAME}` if that ever did reach the pipe.
+# See `plugins/dev/skills/monitor-events/SKILL.md` for the prohibition on
+# downstream filtering pipes; the rule's primary reason is keeping `--filter`
+# the single source of truth, not the secondary 4 KB buffering concern
+# (`grep --line-buffered` + `jq --unbuffered` mechanically flush per line).
+
+# (m) canonical filter.wake.${ORCH_NAME} envelope — not matched
+EVENT_M='{"ts":"2026-05-14T00:00:00Z","resource":{"service.name":"catalyst.broker"},"attributes":{"event.name":"filter.wake.orch-test-2026-05-04","catalyst.orchestrator.id":"orch-test-2026-05-04"},"body":{"payload":{"reason":"PR #501 ready","interest_id":"pr-501"}}}'
+run "filter rejects canonical filter.wake envelope (CTL-372)" \
+  assert_no_match "$EVENT_M" "$FILTER_FILE"
+
+# (n) canonical broker.daemon.startup envelope — not matched
+EVENT_N='{"ts":"2026-05-14T00:00:00Z","resource":{"service.name":"catalyst.broker"},"attributes":{"event.name":"broker.daemon.startup"},"body":{"payload":{"version":"9.1.0"}}}'
+run "filter rejects canonical broker.daemon envelope (CTL-372)" \
+  assert_no_match "$EVENT_N" "$FILTER_FILE"
+
 # ── 17. build-orchestrator-filter — no PRs yet (early-stage orchestrator) ───
 EARLY_ORCH="$SCRATCH/orch-early-2026-05-04"
 mkdir -p "$EARLY_ORCH/workers"

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -423,14 +423,36 @@ treated as human-authored — the safer default.
 - **Iteration cap.** `MAX_ITER=20` prevents runaway loops on a stuck failure
   mode. Apply per-failure-type fix budgets inside each handler too (e.g. give
   up after 3 distinct fix attempts on the same CI check).
-- **Do NOT pipe `catalyst-events tail` through `awk`/`sed`/`grep` (CTL-240).**
-  BSD awk and similar line-oriented tools buffer stdout in 4 KB blocks when
-  stdout is not a TTY (the Monitor harness captures it). With the typical
-  ~1–3 events/min orchestrator cadence the buffer never fills and notifications
-  stall silently for 15+ minutes despite live PR activity. All filtering belongs
-  inside the `--filter` jq predicate. Use `catalyst-events build-orchestrator-filter
-  "$ORCH_DIR"` to generate a complete scope-aware predicate from the worker signal
-  directory instead of hand-rolling secondary pipes.
+- **All filtering belongs inside the `--filter` jq predicate (CTL-240, CTL-372).**
+  Do NOT add a downstream `| grep …` / `| awk …` / `| sed …` / `| jq …`
+  post-pipe to a `catalyst-events tail` invocation. The primary reason is
+  clarity: `--filter` is the single place a reader can look to know what
+  reaches the consumer. Splitting filter logic across two stages hides
+  conditions and invites small regressions (someone drops the
+  `--line-buffered` flag, or the post-pipe pattern no longer matches the
+  canonical envelope). Use `catalyst-events build-orchestrator-filter
+  "$ORCH_DIR"` to generate a complete scope-aware predicate from the worker
+  signal directory instead of hand-rolling secondary pipes.
+
+  Secondary reason (the historical CTL-240 concern): BSD `awk`, unflagged
+  BSD `grep`, and unflagged `sed` buffer stdout in 4 KB blocks when stdout
+  is not a TTY (the Monitor harness captures it). With the typical
+  ~1–3 events/min orchestrator cadence the buffer never fills and
+  notifications stall silently for 15+ minutes despite live PR activity.
+  `grep --line-buffered` and `jq --unbuffered` DO mechanically flush per
+  line on macOS and Linux (per their man pages), so the buffering failure
+  mode is conditional, not absolute — but you should still not need either
+  flag, because filtering belongs in `--filter`.
+
+  Anti-pattern: `| grep -v '"event.name":"filter.wake"'` on the
+  orchestrator's Monitor (observed in real sessions). Wrong for two reasons:
+  (a) `filter.wake.*` envelopes are canonical-only and do not satisfy any
+  clause of `build-orchestrator-filter`'s v1 predicate, so they never reach
+  the consumer in the first place. (b) The pattern would also strip the
+  orchestrator's OWN intended `filter.wake.${ORCH_NAME}` wake — the event
+  the orchestrator registered for. Since CTL-346 the broker no longer
+  re-classifies its own emissions, so there is no feedback loop to defend
+  against on the consumer side either.
 - **`github.*` events carry `orchestrator: null` and `worker: null` (CTL-240).**
   Real webhook events are scoped only by `.attributes."vcs.repository.name"`,
   `.attributes."vcs.ref.name"`, `.attributes."vcs.pr.number"`,

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -878,6 +878,10 @@ FILTER=$(catalyst-events build-orchestrator-filter "$ORCH_DIR")
 catalyst-events tail --filter "$FILTER"
 ```
 
+Use this command EXACTLY as shown — do NOT improvise a `| grep …` or `| jq …`
+post-pipe (see "Filter discipline" below for why, including the specific
+`| grep -v 'filter.wake'` anti-pattern).
+
 **catalyst-filter alternative (CTL-257):** When the filter daemon is running, you can replace
 the broad `catalyst-events tail` with a targeted `catalyst-events wait-for` on
 `filter.wake.{ORCH_NAME}`. The daemon batches raw events through Groq, classifies which are
@@ -907,12 +911,32 @@ whose `detail.prNumbers` intersect the PR set, and linear events for any in-orch
 ticket. Re-build it after `orchestrate-dispatch-next` adds new workers so the
 PR/ticket sets stay in sync.
 
-**Filter discipline (CTL-240).** All noise filtering belongs **inside** `--filter`.
-Do NOT pipe `catalyst-events tail` through `awk`/`sed`/`grep` for additional
-filtering: BSD awk (and most other line-oriented filters) buffer stdout in 4 KB
-blocks when stdout is not a TTY (the Monitor harness captures it). With the typical
-~1–3 events/min orchestrator cadence the buffer never fills and notifications stall
-silently for 15+ minutes despite live PR activity.
+**Filter discipline (CTL-240, CTL-372).** All noise filtering belongs **inside**
+`--filter`. Do NOT pipe `catalyst-events tail` through a downstream
+`awk`/`sed`/`grep`/`jq` stage for additional filtering or projection. The
+primary reason is clarity — `--filter` is the single place a reader can look
+to see what reaches the consumer. The secondary reason is buffering: BSD
+`awk` (and unflagged `grep`/`sed`) buffer stdout in 4 KB blocks when stdout
+is not a TTY, and with the typical ~1–3 events/min orchestrator cadence the
+buffer never fills and notifications stall silently for 15+ minutes despite
+live PR activity. `grep --line-buffered` and `jq --unbuffered` DO line-flush
+mechanically (per their macOS/Linux man pages), but you should still not
+need either flag because filtering belongs in `--filter`.
+
+**Anti-pattern (CTL-372):** `… | grep -v '"event.name":"filter.wake"'`.
+Observed in a real orchestrator session and is wrong for two reasons:
+(a) `filter.wake.*` events are emitted by the broker as canonical OTel
+envelopes with no top-level `.event`, `.orchestrator`, or `.scope` field.
+`build-orchestrator-filter`'s predicate reads only v1 paths, so canonical
+`filter.wake.*` events never satisfy any clause and never reach the consumer
+in the first place. (b) The grep pattern would also strip this orchestrator's
+OWN intended `filter.wake.${ORCH_NAME}` wake — the very event registered
+with the broker. Since CTL-346 the broker no longer re-classifies its own
+emissions, so there is no feedback loop to defend against on the consumer
+side either. If you find yourself wanting to remove filter.wake noise from
+`tail` output, the answer is to use `build-orchestrator-filter` (which
+already excludes them) and avoid any hand-rolled `--filter` that adds a
+`.attributes."catalyst.orchestrator.id"` clause without an event-type guard.
 
 **GitHub event schema (CTL-240).** `github.*` webhook events carry
 `orchestrator: null` and `worker: null` on every line — they are scoped only by


### PR DESCRIPTION
## Summary

[CTL-372](https://linear.app/coalesce-labs/issue/CTL-372) — The orchestrator's Phase 4 `Monitor` command was observed in a real session piping `catalyst-events tail` through `grep --line-buffered -v '"event.name":"filter.wake"' | jq -rc --unbuffered …`, contradicting the blanket prohibition in `monitor-events/SKILL.md:333-338`. This PR reconciles the prohibition with the runtime observation.

## Root analysis

The grep was both **unnecessary AND incorrect**:

- **Unnecessary**: `filter.wake.*` events are emitted by the broker as canonical OTel envelopes (no top-level `.event`, `.orchestrator`, or `.scope` field). `build-orchestrator-filter` reads only v1 paths, so canonical filter.wake envelopes never satisfy any clause — they don't reach the consumer in the first place.
- **Incorrect**: the grep pattern `"event.name":"filter.wake"` matches all filter.wake events including the orchestrator's OWN intended `filter.wake.${ORCH_NAME}` wake — the very event it registered with the broker.

On buffering: `grep --line-buffered` and `jq --unbuffered` DO flush per line per their macOS/Linux man pages, so the 4 KB-stall failure mode is conditional, not absolute. But the prohibition's real value is single-source-of-truth — `--filter` should be the only place filter logic lives.

CTL-346 (broker self-ingest guard) is unrelated to the consumer-side concern; both protections coexist. CTL-346 stops broker re-classification of its own emissions; this PR stops orchestrator-side stripping that was suppressing the orchestrator's own wake.

## Changes

- `plugins/dev/skills/monitor-events/SKILL.md:331-360` — refine the prohibition. Lead with single-source-of-truth, demote buffering to a secondary (conditional) reason, add explicit anti-pattern call-out for `| grep -v 'filter.wake'`.
- `plugins/dev/skills/orchestrate/SKILL.md:829-832, 863-887` — inline "use EXACTLY as shown" note above the Phase 4 canonical command, extend "Filter discipline" with the same anti-pattern explanation scoped to the orchestrator context.
- `plugins/dev/scripts/__tests__/catalyst-events.test.sh:329-353` — two new regression-guard cases: canonical `filter.wake.*` and `broker.daemon.*` envelopes are NOT matched by `build-orchestrator-filter`. Long comment block documents the buffering behavior expectation per acceptance criterion 3.

## Acceptance criteria

- [x] Prohibition refined (not lifted); conditions documented (`grep --line-buffered`/`jq --unbuffered` mechanics).
- [x] Phase 4 Monitor command in `orchestrate/SKILL.md` matches the chosen path (command stays pipe-free; anti-pattern explicit).
- [x] Test cases + comment in `__tests__/catalyst-events.test.sh` document the buffering behavior expectation.

## Out of scope (per ticket)

- Replacing the Monitor tool.
- Touching `broker/index.mjs` self-ingestion logic (CTL-346 done).
- Fixing `build-orchestrator-filter` schema drift (CTL-370 owns that).

## Research

- [thoughts/shared/research/2026-05-14-CTL-372-grep-prohibition-reconciliation.md](../blob/orch-ctl-361-2026-05-13-CTL-372/thoughts/shared/research/2026-05-14-CTL-372-grep-prohibition-reconciliation.md)
- Predecessor research [2026-05-13-hud-cleanup.md] Area 9 (bonus finding) and Area 11

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/catalyst-events.test.sh` — 35/35 of the relevant cases pass (one unrelated pre-existing failure on a stale help-text grep; same 1 fail before this PR)
- [x] Visual diff review — both skill docs preserve neighboring anchors and link integrity
- [ ] CI gates green