### PR TITLE
feat(dev): orchestrator-id short form `o-<repo>-<tickets>` (CTL-373)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,23 +171,23 @@ workers (inbound); workers poll for directed messages at each phase boundary.
 
 ```bash
 # Orchestrator side (Phase 1 init)
-catalyst-comms join "orch-${ORCH_NAME}" --as orchestrator --capabilities "coordinates workers"
+catalyst-comms join "${ORCH_NAME}" --as orchestrator --capabilities "coordinates workers"
 
 # Worker dispatch env
-CATALYST_COMMS_CHANNEL="orch-${ORCH_NAME}" exec claude -p "/oneshot ${TICKET_ID}"
+CATALYST_COMMS_CHANNEL="${ORCH_NAME}" exec claude -p "/oneshot ${TICKET_ID}"
 
 # Worker side (oneshot startup)
 catalyst-comms join "$CATALYST_COMMS_CHANNEL" --as "$TICKET_ID" --parent orchestrator
 
 # Outbound: orchestrator sends to a specific worker
-catalyst-comms send "orch-${ORCH_NAME}" "CTL-101: skip the migration" \
+catalyst-comms send "${ORCH_NAME}" "CTL-101: skip the migration" \
   --as orchestrator --to CTL-101 --type info
 
 # Inbound: worker polls for messages addressed to it (at each phase boundary)
-catalyst-comms poll "orch-${ORCH_NAME}" --filter-to "$TICKET_ID" --since "$COMMS_LAST_READ"
+catalyst-comms poll "${ORCH_NAME}" --filter-to "$TICKET_ID" --since "$COMMS_LAST_READ"
 
 # Live tailing (human auditor)
-catalyst-comms watch "orch-${ORCH_NAME}"
+catalyst-comms watch "${ORCH_NAME}"
 ```
 
 `catalyst-comms send` also emits a `comms.message.posted` event to the unified event log

--- a/plugins/dev/scripts/__tests__/god-gather-classify.test.sh
+++ b/plugins/dev/scripts/__tests__/god-gather-classify.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tests for god-gather.sh — classify_worktree() function (CTL-373).
+# Run: bash plugins/dev/scripts/__tests__/god-gather-classify.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+GOD="${REPO_ROOT}/plugins/dev/scripts/god-gather.sh"
+
+# god-gather.sh runs work at top level when sourced. Extract just the
+# classify_worktree() function body and eval it in a fresh subshell.
+
+FN_BODY=$(awk '/^classify_worktree\(\) \{/,/^}/' "$GOD")
+if [[ -z $FN_BODY ]]; then
+	echo "FAIL: could not extract classify_worktree from $GOD" >&2
+	exit 1
+fi
+
+classify() {
+	bash -c "$FN_BODY"$'\n'"classify_worktree \"\$1\"" _ "$1"
+}
+
+FAILURES=0
+PASSES=0
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+check() {
+	local name="$1" expected="$2" got
+	got=$(classify "$name")
+	if [[ $got == "$expected" ]]; then
+		pass "$name → $expected"
+	else
+		fail "$name → $expected" "got: $got"
+	fi
+}
+
+echo "▶ new format (o-*)"
+check "o-adv-931-932-933" orchestrator
+check "o-ctl-373" orchestrator
+check "o-cycle-1" orchestrator
+check "o-adv-931-CTL-99" worker
+check "o-ctl-373-CTL-373" worker
+
+echo "▶ legacy format (orch-*)"
+check "orch-adv-931-2026-05-12" orchestrator
+check "orch-adv-931-2026-05-12-CTL-99" worker
+check "orch-foo-2026-05-12" orchestrator
+
+echo "▶ other"
+check "CTL-373" oneshot
+check "PM" pm
+check "main" other
+check "random" other
+
+echo ""
+echo "PASSES=$PASSES FAILURES=$FAILURES"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/orchestrate-comms-integration.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-comms-integration.test.sh
@@ -49,8 +49,9 @@ assert_eq() {
 echo "CTL-111 orchestrate-comms integration tests"
 echo "==========================================="
 
-ORCH_ID="orch-test-$$"
-CH="orch-${ORCH_ID}"
+# CTL-373: orch-id uses the `o-…` short form; channel name IS the orch-id.
+ORCH_ID="o-test-$$"
+CH="${ORCH_ID}"
 CH_FILE="$CATALYST_COMMS_DIR/channels/${CH}.jsonl"
 
 # ── 1. Orchestrator join creates channel ──────────────────────────────────
@@ -162,19 +163,20 @@ echo "────────────────────────�
 # Regexes accept either the new `"$COMMS_BIN" <subcmd>` form (CTL-127) or the
 # legacy bare `catalyst-comms <subcmd>` form so the test is resilient to the
 # binary resolution refactor.
-grep -qE '(catalyst-comms|\$COMMS_BIN") join "orch-\$\{ORCH_NAME\}"' "$ORCH_SKILL" \
+# CTL-373: channel name is the orch-id directly (legacy was `orch-${ORCH_NAME}`).
+grep -qE '(catalyst-comms|\$COMMS_BIN") join "\$\{ORCH_NAME\}"' "$ORCH_SKILL" \
   && pass "orchestrate: Phase 1 join hook present" \
   || fail "orchestrate: Phase 1 join hook missing"
 
-grep -q 'CATALYST_COMMS_CHANNEL="orch-\${ORCH_NAME}"' "$ORCH_SKILL" \
+grep -q 'CATALYST_COMMS_CHANNEL="\${ORCH_NAME}"' "$ORCH_SKILL" \
   && pass "orchestrate: Phase 3 dispatch env hook present" \
   || fail "orchestrate: Phase 3 dispatch env hook missing"
 
-grep -qE '(catalyst-comms|\$COMMS_BIN") poll "orch-\$\{ORCH_NAME\}"' "$ORCH_SKILL" \
+grep -qE '(catalyst-comms|\$COMMS_BIN") poll "\$\{ORCH_NAME\}"' "$ORCH_SKILL" \
   && pass "orchestrate: Phase 4 attention poll hook present" \
   || fail "orchestrate: Phase 4 attention poll hook missing"
 
-grep -qE '(catalyst-comms|\$COMMS_BIN") done "orch-\$\{ORCH_NAME\}" --as orchestrator' "$ORCH_SKILL" \
+grep -qE '(catalyst-comms|\$COMMS_BIN") done "\$\{ORCH_NAME\}" --as orchestrator' "$ORCH_SKILL" \
   && pass "orchestrate: Phase 7 done hook present" \
   || fail "orchestrate: Phase 7 done hook missing"
 

--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -295,7 +295,8 @@ run_dispatch --session-id "sess-abc" --worker-command "/catalyst-dev:oneshot" \
 grep -q "ORCH_ID=demo" "$CLAUDE_LOG" && pass "ORCH_ID forwarded" || fail "ORCH_ID forwarded" "log: $(cat "$CLAUDE_LOG")"
 grep -q "ORCH_DIR=${ORCH_DIR}" "$CLAUDE_LOG" && pass "ORCH_DIR forwarded" || fail "ORCH_DIR forwarded"
 grep -q "SESSION=sess-abc" "$CLAUDE_LOG" && pass "SESSION_ID forwarded" || fail "SESSION_ID forwarded"
-grep -q "COMMS=orch-demo" "$CLAUDE_LOG" && pass "COMMS channel forwarded (default orch-<id>)" || fail "COMMS channel forwarded"
+# CTL-373: channel name is the orch-id directly (legacy was `orch-${orch-id}`).
+grep -q "COMMS=demo" "$CLAUDE_LOG" && pass "COMMS channel forwarded (default = orch-id)" || fail "COMMS channel forwarded"
 grep -q -- "T-1 --auto-merge --extra" "$CLAUDE_LOG" && pass "worker args forwarded" || fail "worker args forwarded" "log: $(cat "$CLAUDE_LOG")"
 scratch_teardown
 

--- a/plugins/dev/scripts/__tests__/setup-orchestrator-name.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-orchestrator-name.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Tests for setup-orchestrator.sh — orch-id short-form generation (CTL-373).
+# Run: bash plugins/dev/scripts/__tests__/setup-orchestrator-name.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SETUP="${REPO_ROOT}/plugins/dev/scripts/setup-orchestrator.sh"
+
+FAILURES=0
+PASSES=0
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+# Run setup-orchestrator.sh in --quiet mode against a throwaway git repo and
+# parse the emitted ORCH_ID line. Returns the orch-id on stdout.
+run_setup() {
+	local out
+	out=$(cd "$REPO_FAKE" && bash "$SETUP" "$@" --quiet 2>/dev/null) || return 1
+	printf '%s' "$out" | grep '^ORCH_ID=' | head -1 | cut -d= -f2-
+}
+
+# ─── Fixture: minimal repo with .catalyst/config.json + worktree dir override ──
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_FAKE="${SCRATCH}/repo"
+mkdir -p "${REPO_FAKE}/.catalyst"
+(cd "$REPO_FAKE" && git init -q && git commit --allow-empty -q -m "init")
+
+# Tell setup-orchestrator.sh where to place worktrees (avoid ~/catalyst/wt)
+cat >"${REPO_FAKE}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test",
+    "project": {"ticketPrefix": "CTL"},
+    "orchestration": {"worktreeDir": "${SCRATCH}/wt"}
+  }
+}
+EOF
+
+# Use a private state dir so we don't pollute ~/catalyst/.
+export CATALYST_DIR="${SCRATCH}/catalyst-state"
+mkdir -p "$CATALYST_DIR"
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+echo "▶ single ticket"
+ID=$(run_setup --tickets CTL-373)
+[[ $ID == "o-ctl-373" ]] && pass "single CTL-373 → o-ctl-373" ||
+	fail "single CTL-373 → o-ctl-373" "got: $ID"
+
+echo "▶ multi-ticket same prefix"
+ID=$(run_setup --tickets "ADV-931 ADV-932 ADV-933")
+[[ $ID == "o-adv-931-932-933" ]] && pass "multi same-prefix → o-adv-931-932-933" ||
+	fail "multi same-prefix → o-adv-931-932-933" "got: $ID"
+
+echo "▶ multi-ticket mixed prefix"
+ID=$(run_setup --tickets "CTL-1 ADV-2")
+[[ $ID == "o-ctl-1-adv-2" ]] && pass "mixed prefix → o-ctl-1-adv-2" ||
+	fail "mixed prefix → o-ctl-1-adv-2" "got: $ID"
+
+echo "▶ project mode (no date)"
+ID=$(run_setup --project cycle-1)
+[[ $ID == "o-cycle-1" ]] && pass "project cycle-1 → o-cycle-1" ||
+	fail "project cycle-1 → o-cycle-1" "got: $ID"
+
+echo "▶ cycle mode (no date)"
+ID=$(run_setup --cycle current)
+[[ $ID == "o-cycle-current" ]] && pass "cycle current → o-cycle-current" ||
+	fail "cycle current → o-cycle-current" "got: $ID"
+
+echo "▶ auto mode (no date)"
+ID=$(run_setup --auto 5)
+[[ $ID == "o-auto-5" ]] && pass "auto 5 → o-auto-5" ||
+	fail "auto 5 → o-auto-5" "got: $ID"
+
+echo "▶ collision suffix"
+# Pre-create a colliding worktree directory
+mkdir -p "${SCRATCH}/wt/o-ctl-99"
+ID=$(run_setup --tickets CTL-99)
+[[ $ID == "o-ctl-99-2" ]] && pass "collision → o-ctl-99-2" ||
+	fail "collision → o-ctl-99-2" "got: $ID"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "PASSES=$PASSES FAILURES=$FAILURES"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/god-gather.sh
+++ b/plugins/dev/scripts/god-gather.sh
@@ -51,10 +51,11 @@ elapsed_human() {
 }
 
 # Classify a worktree directory name into: orchestrator, worker, pm, oneshot, other
+# Recognises both the legacy `orch-<slug>-<date>` form and the CTL-373 short form `o-<slug>`.
 classify_worktree() {
   local name="$1"
   case "$name" in
-    orch-*)
+    orch-*|o-*)
       # worker: ends with TICKET-NUM (uppercase letters dash digits)
       if echo "$name" | grep -qE '[A-Z][A-Z0-9]+-[0-9]+$'; then
         echo "worker"

--- a/plugins/dev/scripts/orch-monitor/__tests__/comms-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/comms-reader.test.ts
@@ -61,14 +61,24 @@ describe("isValidChannelName", () => {
 });
 
 describe("parseOrchIdFromChannelName", () => {
-  it("strips orch- prefix", () => {
+  it("strips orch- prefix (legacy channel naming)", () => {
     expect(parseOrchIdFromChannelName("orch-ctl-ux-apr20")).toBe("ctl-ux-apr20");
+  });
+  it("strips one orch- from double-prefixed legacy channels", () => {
+    // Today's in-flight orchestrators have channels like `orch-orch-foo-2026-05-12`
+    expect(parseOrchIdFromChannelName("orch-orch-foo-2026-05-12")).toBe("orch-foo-2026-05-12");
+  });
+  it("returns the channel verbatim for CTL-373 short-form orch-ids", () => {
+    expect(parseOrchIdFromChannelName("o-ctl-373")).toBe("o-ctl-373");
+    expect(parseOrchIdFromChannelName("o-adv-931-932-933")).toBe("o-adv-931-932-933");
+    expect(parseOrchIdFromChannelName("o-cycle-1")).toBe("o-cycle-1");
   });
   it("returns null when not an orch channel", () => {
     expect(parseOrchIdFromChannelName("demo")).toBeNull();
   });
   it("returns null when prefix only", () => {
     expect(parseOrchIdFromChannelName("orch-")).toBeNull();
+    expect(parseOrchIdFromChannelName("o-")).toBeNull();
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts
@@ -181,9 +181,14 @@ export function sourceIcon(source: string): string {
   if (!detectNerdFont().detected) return "";
   const exact = SOURCE_ICONS[source];
   if (exact) return `${exact} `;
-  // Orchestrator-derived sources (e.g. "orch-ctl-352-354-2026-05-12" or
-  // "orch-ctl-352-354-2026-05-12/CTL-354") show the catalyst robot.
-  if (source.startsWith("orch-") || source.includes("/")) {
+  // Orchestrator-derived sources show the catalyst robot. Covers both the
+  // legacy `orch-<slug>-<date>` form and the CTL-373 short form `o-<slug>`,
+  // plus the `<orch-id>/<ticket>` join used in comms source labels.
+  if (
+    source.startsWith("orch-") ||
+    source.startsWith("o-") ||
+    source.includes("/")
+  ) {
     return `${SOURCE_ICONS.catalyst} `;
   }
   // Anything else (worker tickets like CTL-352 used as comms source) gets the

--- a/plugins/dev/scripts/orch-monitor/lib/comms-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/comms-reader.ts
@@ -17,9 +17,16 @@ export function isValidChannelName(name: string): boolean {
 }
 
 export function parseOrchIdFromChannelName(name: string): string | null {
-  if (!name.startsWith("orch-")) return null;
-  const rest = name.slice(5);
-  return rest.length > 0 ? rest : null;
+  if (!name) return null;
+  if (name.startsWith("orch-")) {
+    // Legacy convention: channel = `orch-${ORCH_ID}` where ORCH_ID itself
+    // begins with "orch-". Strip one prefix.
+    const rest = name.slice(5);
+    return rest.length > 0 ? rest : null;
+  }
+  // CTL-373: new convention — channel name IS the orch-id (no re-prefix).
+  if (name.startsWith("o-") && name.length > 2) return name;
+  return null;
 }
 
 const MESSAGE_TYPE_SET = new Set<string>(COMMS_MESSAGE_TYPES);

--- a/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/App.tsx
@@ -186,7 +186,10 @@ function Monitor() {
   const handleWorkerCommsLink = useCallback(
     (ticket: string) => {
       if (!effectiveOrch) return;
-      const channelName = `orch-${effectiveOrch.id}`;
+      // CTL-373: channel name is the orch-id directly (legacy: `orch-${id}`).
+      const channelName = effectiveOrch.id.startsWith("orch-")
+        ? `orch-${effectiveOrch.id}`
+        : effectiveOrch.id;
       setCommsInitialFilter({
         channel: channelName,
         author: ticket,

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -113,7 +113,8 @@ now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 [ -z "$ORCH_ID" ]       && { echo "ERROR: orchestrator id not set (in state.json or --orch-id)" >&2; exit 2; }
 [ -z "$WORKTREE_BASE" ] && { echo "ERROR: worktreeBase not set (in state.json or --worktree-base)" >&2; exit 2; }
 
-[ -z "$COMMS_CHANNEL" ] && COMMS_CHANNEL="orch-${ORCH_ID}"
+# CTL-373: channel name is the orch-id directly (legacy: `orch-${ORCH_ID}`).
+[ -z "$COMMS_CHANNEL" ] && COMMS_CHANNEL="$ORCH_ID"
 
 # Session id: CLI > env > .session-id stash > empty (which becomes "")
 if [ -z "$SESSION_ID" ]; then

--- a/plugins/dev/scripts/orchestrate-roll-usage.sh
+++ b/plugins/dev/scripts/orchestrate-roll-usage.sh
@@ -30,7 +30,7 @@ usage() {
 usage: orchestrate-roll-usage.sh --orch <id> --ticket <id> [--orch-dir <dir>] [-v]
 
 required:
-  --orch <id>        orchestrator id (e.g. orch-ctl-115-116)
+  --orch <id>        orchestrator id (e.g. o-ctl-115-116)
   --ticket <id>      worker ticket id (e.g. CTL-115)
 
 optional:

--- a/plugins/dev/scripts/setup-orchestrator.sh
+++ b/plugins/dev/scripts/setup-orchestrator.sh
@@ -123,32 +123,62 @@ log "Initializing session database..."
 "${SCRIPT_DIR}/catalyst-db.sh" init 2>&1 | while read -r line; do log "  $line"; done
 
 # ─── Step 4: Auto-generate worktree name ──────────────────────────────────────
+# CTL-373: short-form orch-id `o-<repo>-<tickets>` (drop "orch-" prefix, drop
+# date, embed all ticket numbers). Examples:
+#   --tickets "ADV-931 ADV-932"  →  o-adv-931-932
+#   --tickets CTL-373            →  o-ctl-373
+#   --project cycle-1            →  o-cycle-1
+#   --cycle current              →  o-cycle-current
+#   --auto 5                     →  o-auto-5
 
 slugify() {
   printf '%s' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr -c '[:alnum:]-' '-' \
     | sed -E 's/-+/-/g; s/^-//; s/-$//' | cut -c1-30
 }
 
-TODAY=$(date +%Y-%m-%d)
+# Extract the numeric portion from a ticket id: "CTL-373" → "373".
+ticket_num() {
+  printf '%s' "$1" | sed -E 's/^[A-Za-z][A-Za-z0-9]+-//'
+}
 
-SLUG=""
-if [[ -n "$PROJECT" ]]; then
-  SLUG=$(slugify "$PROJECT")
-elif [[ -n "$CYCLE" ]]; then
-  SLUG="cycle-$(slugify "$CYCLE")"
-elif [[ -n "$TICKETS" ]]; then
-  # Use first ticket as slug
-  FIRST_TICKET="${TICKETS%% *}"
-  SLUG=$(slugify "$FIRST_TICKET")
-elif [[ -n "$AUTO" ]]; then
-  SLUG="auto${AUTO}"
-fi
+# Extract the lowercase team prefix from a ticket id: "CTL-373" → "ctl".
+ticket_prefix() {
+  printf '%s' "$1" | sed -E 's/-.*$//' | LC_ALL=C tr '[:upper:]' '[:lower:]'
+}
 
-if [[ -n "$SLUG" ]]; then
-  ORCH_NAME="orch-${SLUG}-${TODAY}"
-else
-  ORCH_NAME="orch-${TODAY}"
-fi
+build_orch_name() {
+  local tickets="$1" project="$2" cycle="$3" auto="$4"
+  if [[ -n "$project" ]]; then
+    printf 'o-%s' "$(slugify "$project")"; return
+  fi
+  if [[ -n "$cycle" ]]; then
+    printf 'o-cycle-%s' "$(slugify "$cycle")"; return
+  fi
+  if [[ -n "$auto" ]]; then
+    printf 'o-auto-%s' "$(slugify "$auto")"; return
+  fi
+  if [[ -n "$tickets" ]]; then
+    # Split TICKETS on whitespace into an array
+    local arr first prefix mixed=0 t parts="" nums=""
+    read -ra arr <<< "$tickets"
+    first="${arr[0]}"
+    prefix=$(ticket_prefix "$first")
+    for t in "${arr[@]}"; do
+      [[ "$(ticket_prefix "$t")" != "$prefix" ]] && mixed=1
+    done
+    if (( mixed )); then
+      for t in "${arr[@]}"; do parts+="-$(slugify "$t")"; done
+      printf 'o%s' "$parts"
+    else
+      for t in "${arr[@]}"; do nums+="-$(ticket_num "$t")"; done
+      printf 'o-%s%s' "$prefix" "$nums"
+    fi
+    return
+  fi
+  printf 'o-run'
+}
+
+ORCH_NAME=$(build_orch_name "$TICKETS" "$PROJECT" "$CYCLE" "$AUTO")
 
 WT_DIR_CONFIG=$(jq -r '.catalyst.orchestration.worktreeDir // empty' "$CONFIG_FILE" 2>/dev/null)
 if [[ -n "$WT_DIR_CONFIG" ]]; then

--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -223,7 +223,7 @@ Worker variant:
 jq -nc \
   --arg orch "${CATALYST_ORCHESTRATOR_ID}" \
   --arg id "${CATALYST_ORCHESTRATOR_ID}-comms" \
-  --arg channel "orch-${CATALYST_ORCHESTRATOR_ID}" \
+  --arg channel "${CATALYST_ORCHESTRATOR_ID}" \
   --argjson workers '["CTL-352","CTL-354"]' \
   '{ts: (now | todate), event: "filter.register",
     orchestrator: $orch,

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -64,7 +64,6 @@ fi
 
 | Flag                     | Description                                                            |
 | ------------------------ | ---------------------------------------------------------------------- |
-| `--name <name>`          | Name this orchestrator instance (default: auto-generated from tickets) |
 | `--project <name>`       | Pull tickets from a Linear project                                     |
 | `--cycle current`        | Pull tickets from the current Linear cycle                             |
 | `--file <path>`          | Read ticket IDs from a file (one per line)                             |
@@ -448,7 +447,7 @@ orchestrator does not crash if `catalyst-comms` is missing.
 ```bash
 # Shared channel for this run. Workers will join at dispatch time.
 if [ -n "$COMMS_BIN" ]; then
-  "$COMMS_BIN" join "orch-${ORCH_NAME}" \
+  "$COMMS_BIN" join "${ORCH_NAME}" \
     --as orchestrator \
     --capabilities "coordinates workers" \
     --orch "${ORCH_NAME}" \
@@ -517,7 +516,7 @@ SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET_ID}.json"
   cd "${WORKER_DIR}" || exit 1
   CATALYST_ORCHESTRATOR_DIR="${ORCH_DIR}" \
   CATALYST_ORCHESTRATOR_ID="${ORCH_NAME}" \
-  CATALYST_COMMS_CHANNEL="orch-${ORCH_NAME}" \
+  CATALYST_COMMS_CHANNEL="${ORCH_NAME}" \
   CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}" \
   exec nohup claude \
     -n "${ORCH_NAME}-${TICKET_ID}" \
@@ -836,7 +835,7 @@ if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2
     --arg orch "${ORCH_NAME}" \
     --arg id "${ORCH_NAME}-comms-lifecycle" \
     --arg notify "filter.wake.${ORCH_NAME}" \
-    --arg channel "orch-${ORCH_NAME}" \
+    --arg channel "${ORCH_NAME}" \
     --argjson workers "${ACTIVE_TICKETS}" \
     '{
       ts: (now | todate),
@@ -1416,7 +1415,7 @@ if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2
       --arg orch "${ORCH_NAME}" \
       --arg id "${ORCH_NAME}-comms-lifecycle" \
       --arg notify "filter.wake.${ORCH_NAME}" \
-      --arg channel "orch-${ORCH_NAME}" \
+      --arg channel "${ORCH_NAME}" \
       --argjson workers "${_UPD_TICKETS}" \
       '{
         ts: (now | todate),
@@ -1557,7 +1556,7 @@ workers that stalled before completing their own merge.
 
 **Drain shared comms channel for attention (CTL-111, CTL-269):**
 
-Workers post `type:attention` messages to `orch-${ORCH_NAME}` when blocked. On each
+Workers post `type:attention` messages to `${ORCH_NAME}` when blocked. On each
 wake-up, the orchestrator drains new messages from the channel and promotes any
 `attention` to a state-level attention item so the dashboard's NEEDS ATTENTION
 banner surfaces it (with author + reason).
@@ -1579,13 +1578,13 @@ even though wakes come via `filter.wake`.
 if [ -n "$COMMS_BIN" ]; then
   CURSOR_FILE="${ORCH_DIR}/.comms-cursor"
   SINCE=$(cat "$CURSOR_FILE" 2>/dev/null || echo 0)
-  CH_FILE="${HOME}/catalyst/comms/channels/orch-${ORCH_NAME}.jsonl"
+  CH_FILE="${HOME}/catalyst/comms/channels/${ORCH_NAME}.jsonl"
   TOTAL=$(wc -l < "$CH_FILE" 2>/dev/null | tr -d ' ' || echo 0)
 
   if [ "${TOTAL:-0}" -gt "${SINCE:-0}" ]; then
     # `poll` here is the catalyst-comms CLI subcommand name (read since cursor),
     # not a poll-loop metaphor — the orchestrator runs this on wake-up only.
-    "$COMMS_BIN" poll "orch-${ORCH_NAME}" --since "$SINCE" 2>/dev/null | \
+    "$COMMS_BIN" poll "${ORCH_NAME}" --since "$SINCE" 2>/dev/null | \
     while IFS= read -r MSG; do
       MSG_TYPE=$(echo "$MSG" | jq -r '.type // ""' 2>/dev/null)
       MSG_FROM=$(echo "$MSG" | jq -r '.from // ""' 2>/dev/null)
@@ -2050,7 +2049,7 @@ When all waves are complete:
 # participant and is advisory — rc is ignored. Channel cleanup is deferred to
 # CTL-110's archive sweep (do NOT call `catalyst-comms gc` here — gc is global).
 if [ -n "$COMMS_BIN" ]; then
-  "$COMMS_BIN" done "orch-${ORCH_NAME}" --as orchestrator >/dev/null 2>&1 || true
+  "$COMMS_BIN" done "${ORCH_NAME}" --as orchestrator >/dev/null 2>&1 || true
 fi
 
 # Mark completed in global state


### PR DESCRIPTION
## Summary

Rename auto-generated orchestrator IDs from `orch-<slug>-<date>` (e.g. `orch-adv-931-2026-05-12`) to a shorter, ticket-embedding form (e.g. `o-adv-931-932-933`). Drops the `orch-` prefix, drops the redundant date, and embeds every ticket number so `grep o-adv-933` finds any orchestrator running ADV-933 even in a multi-wave run.

Linear: [CTL-373](https://linear.app/coalesce-labs/issue/CTL-373/orchestrator-id-shorten-format-to-o-repo-tickets-drop-orch-drop-date)

## Format examples

| Mode | Before | After |
|------|--------|-------|
| multi-ticket | `orch-adv-931-2026-05-12` (first ticket only) | `o-adv-931-932-933` (all tickets) |
| single-ticket | `orch-ctl-373-2026-05-13` | `o-ctl-373` |
| project | `orch-cycle-1-2026-05-12` | `o-cycle-1` |
| cycle | `orch-cycle-current-2026-05-12` | `o-cycle-current` |
| auto | `orch-auto5-2026-05-12` | `o-auto-5` |
| mixed prefixes | n/a (was first-only) | `o-ctl-1-adv-2` |

Collision-avoidance suffix (`-2`, `-3`, …) is preserved.

## Touched sites

Generation (single source):
- `plugins/dev/scripts/setup-orchestrator.sh` — new `build_orch_name` + helper functions.

Hard dependencies on the prefix:
- `plugins/dev/scripts/god-gather.sh` — `classify_worktree` now matches both `orch-*` and `o-*`.
- `plugins/dev/scripts/orchestrate-dispatch-next` — comms channel = orch-id verbatim (no `orch-` re-prefix).
- `plugins/dev/scripts/orch-monitor/lib/comms-reader.ts:parseOrchIdFromChannelName` — handles both legacy `orch-` channels and new short-form orch-ids.
- `plugins/dev/scripts/orch-monitor/cli/lib/nerd-font.ts:sourceIcon` — catalyst robot icon for `o-*` sources.
- `plugins/dev/scripts/orch-monitor/ui/src/App.tsx` — channel construction matches dispatcher.

Docs / SKILL updates:
- `plugins/dev/skills/orchestrate/SKILL.md` — channel construction strings; removed the accepted-but-ignored `--name` flag from the flag table.
- `plugins/dev/skills/broker/SKILL.md` — comms_lifecycle registration example.
- `docs/architecture.md` — comms channel example.
- `plugins/dev/scripts/orchestrate-roll-usage.sh` — usage example.

## Backward compatibility

In-flight orchestrators dispatched with the old code keep working: their channel files (`orch-orch-<id>.jsonl`) are still parsed correctly by `parseOrchIdFromChannelName` (legacy branch), and `classify_worktree` still recognises `orch-*` worktrees. The new format ships only for newly-created orchestrators.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/setup-orchestrator-name.test.sh` — 7 cases (single/multi/mixed/project/cycle/auto/collision)
- [x] `bash plugins/dev/scripts/__tests__/god-gather-classify.test.sh` — 12 cases (new + legacy + edge)
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh` — 74 pass (existing COMMS expectation updated)
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-comms-integration.test.sh` — 25 pass (existing grep patterns updated)
- [x] `bun test __tests__/comms-reader.test.ts` — 37 pass (extended for new format)
- [x] `bun run typecheck` (orch-monitor)
- [x] `bun run lint` (orch-monitor) — only the pre-existing `preview-status.ts:93` warning remains; no new lint issues introduced