### PR TITLE
feat(dev): HUD — merge SOURCE + EVENT columns into single wider EVENT column (CTL-364)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
@@ -86,12 +86,29 @@ describe("computeColumnWidths", () => {
     expect(w.orch).toBeLessThanOrEqual(24);
   });
 
-  test("time and event columns stay fixed at 10 and 16", () => {
+  test("time column stays fixed at 10", () => {
     for (const cols of [80, 140, 200, 300]) {
       const w = computeColumnWidths(cols);
       expect(w.time).toBe(10);
-      expect(w.event).toBe(16);
     }
+  });
+
+  // CTL-364: SOURCE column dropped; EVENT column grew + became responsive so
+  // the merged `${glyph} ${label}` content (longest: "CTL-330: attention" with
+  // a 2-char glyph prefix = 20 chars) always fits without truncation.
+  test("event column has no minimum below 22 and caps at 30 on wide terminals", () => {
+    expect(computeColumnWidths(80).event).toBeGreaterThanOrEqual(22);
+    expect(computeColumnWidths(400).event).toBeLessThanOrEqual(30);
+  });
+
+  test("event column grows monotonically with terminal width", () => {
+    const w80 = computeColumnWidths(80).event;
+    const w160 = computeColumnWidths(160).event;
+    const w240 = computeColumnWidths(240).event;
+    const w400 = computeColumnWidths(400).event;
+    expect(w160).toBeGreaterThanOrEqual(w80);
+    expect(w240).toBeGreaterThanOrEqual(w160);
+    expect(w400).toBeGreaterThanOrEqual(w240);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -5,6 +5,7 @@ import {
   formatDateTime,
   formatRepo,
   formatSource,
+  formatSourceEvent,
   formatEvent,
   formatRef,
   formatDetails,
@@ -1084,6 +1085,151 @@ describe("formatSource / formatRef — CTL-355 Nerd Font enabled", () => {
     expect(out.codePointAt(0)).toBe(0xf407);
     expect(out.charAt(1)).toBe(" ");
     expect(out.slice(2)).toBe("501");
+  });
+});
+
+// CTL-364: SOURCE + EVENT columns merged into a single EVENT column rendered
+// as `${sourceIcon}${label}`. formatSourceEvent composes the visible label;
+// formatSource and formatEvent remain exported for the filter haystack and
+// other consumers. This block covers the bare-mode (no Nerd Font) label
+// composition; the Nerd Font prefix is asserted in its own block below.
+describe("formatSourceEvent (CTL-364, bare mode)", () => {
+  // The earlier "CTL-355 Nerd Font enabled" block's afterAll deletes
+  // CATALYST_NERD_FONT and resets the detection cache, so a fresh probe
+  // here would see whatever Nerd Fonts the host machine has installed.
+  // Pin the env explicitly so this block is hermetic.
+  const innerOuterEnv = process.env.CATALYST_NERD_FONT;
+  beforeAll(() => {
+    process.env.CATALYST_NERD_FONT = "0";
+    _resetNerdFontCacheForTesting();
+  });
+  afterAll(() => {
+    if (innerOuterEnv === undefined) delete process.env.CATALYST_NERD_FONT;
+    else process.env.CATALYST_NERD_FONT = innerOuterEnv;
+    _resetNerdFontCacheForTesting();
+  });
+
+  test("github events render the event label without a source prefix", () => {
+    expect(formatSourceEvent(baseEvent)).toBe("merged");
+  });
+
+  test("linear events render the mapped event label", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { ...baseEvent.attributes, "event.name": "linear.issue.updated" },
+    } as CanonicalEvent;
+    expect(formatSourceEvent(e)).toBe(formatEvent(e));
+  });
+
+  test("filter.register renders 'filter reg'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+    } as unknown as CanonicalEvent;
+    expect(formatSourceEvent(e)).toBe("filter reg");
+  });
+
+  test("filter.wake.{sessionId} renders 'wake'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.sess_x" },
+    } as unknown as CanonicalEvent;
+    expect(formatSourceEvent(e)).toBe("wake");
+  });
+
+  test("orchestrator.worker.done renders 'done'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.worker.done" },
+    } as unknown as CanonicalEvent;
+    expect(formatSourceEvent(e)).toBe("done");
+  });
+
+  test("comms.message.posted with event.label sender embeds sender into the label", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "event.label": "CTL-330",
+        "catalyst.worker.ticket": "CTL-330",
+      },
+      body: { payload: { type: "attention", channel: "orch-demo", to: "all" } },
+    } as unknown as CanonicalEvent;
+    expect(formatSourceEvent(e)).toBe("CTL-330: attention");
+  });
+
+  test("comms.message.posted falls back to catalyst.worker.ticket when no event.label", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "catalyst.worker.ticket": "CTL-330",
+      },
+      body: { payload: { type: "info", channel: "orch-demo", to: "all" } },
+    } as unknown as CanonicalEvent;
+    expect(formatSourceEvent(e)).toBe("CTL-330: info");
+  });
+
+  test("comms.message.posted with no sender falls through to the bare event label", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { payload: { type: "info" } },
+    } as unknown as CanonicalEvent;
+    expect(formatSourceEvent(e)).toBe("info");
+  });
+
+  test("unknown event names match formatEvent's 15-char truncation", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "some.very.long.event.name.here" },
+    } as unknown as CanonicalEvent;
+    expect(formatSourceEvent(e)).toBe(formatEvent(e));
+    expect(formatSourceEvent(e).length).toBeLessThanOrEqual(15);
+  });
+});
+
+describe("formatSourceEvent (CTL-364, Nerd Font enabled)", () => {
+  const outerEnv = process.env.CATALYST_NERD_FONT;
+  beforeAll(() => {
+    process.env.CATALYST_NERD_FONT = "1";
+    _resetNerdFontCacheForTesting();
+  });
+  afterAll(() => {
+    if (outerEnv === undefined) delete process.env.CATALYST_NERD_FONT;
+    else process.env.CATALYST_NERD_FONT = outerEnv;
+    _resetNerdFontCacheForTesting();
+  });
+
+  test("github events get the octocat glyph + space + label", () => {
+    const out = formatSourceEvent(baseEvent);
+    expect(out.codePointAt(0)).toBe(0xf09b);
+    expect(out.charAt(1)).toBe(" ");
+    expect(out.slice(2)).toBe("merged");
+  });
+
+  test("filter.wake.* gets the broker bolt glyph + 'wake'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.wake.orch-abc" },
+    } as unknown as CanonicalEvent;
+    const out = formatSourceEvent(e);
+    expect(out.codePointAt(0)).toBe(0xf0e7);
+    expect(out.slice(2)).toBe("wake");
+  });
+
+  test("comms.message.posted with sender gets the comments glyph + 'CTL-330: attention'", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "event.label": "CTL-330",
+      },
+      body: { payload: { type: "attention" } },
+    } as unknown as CanonicalEvent;
+    const out = formatSourceEvent(e);
+    expect(out.codePointAt(0)).toBe(0xf086);
+    expect(out.slice(2)).toBe("CTL-330: attention");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -3,8 +3,7 @@ import type { CanonicalEvent } from "../../lib/canonical-event.ts";
 import {
   formatTime,
   formatRepo,
-  formatSource,
-  formatEvent,
+  formatSourceEvent,
   formatRef,
   formatDetails,
   formatStatus,
@@ -70,11 +69,8 @@ export function EventRow({ event, selected, columns, paused = true }: EventRowPr
       <Box width={w.repo} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{formatRepo(event)}</Text>
       </Box>
-      <Box width={w.source} flexShrink={0} marginRight={1}>
-        <Text color={color} inverse={inverse}>{formatSource(event)}</Text>
-      </Box>
       <Box width={w.event} flexShrink={0} marginRight={1}>
-        <Text color={color} inverse={inverse}>{formatEvent(event)}</Text>
+        <Text color={color} inverse={inverse} wrap="truncate">{formatSourceEvent(event)}</Text>
       </Box>
       <Box width={w.ref} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{displayRef}</Text>

--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -58,9 +58,6 @@ export function Header({ columns = 120, nlQuery, brokerState }: HeaderProps) {
         <Box width={w.repo} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"REPO"}</Text>
         </Box>
-        <Box width={w.source} flexShrink={0} marginRight={1}>
-          <Text bold color="cyan">{"SOURCE"}</Text>
-        </Box>
         <Box width={w.event} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"EVENT"}</Text>
         </Box>

--- a/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
@@ -18,13 +18,19 @@
  * Numeric widths for non-optional columns are clamped between sensible min
  * and max so very narrow terminals stay readable and very wide ones don't
  * give a single column 30% of the screen.
+ *
+ * CTL-364: SOURCE column merged into EVENT. The single combined column shows
+ * `${glyph} ${label}` where the glyph is the Nerd Font source-family icon
+ * (octocat / linear ticket / broker bolt / catalyst cogs / comms speech
+ * bubble / system cog) and the label is the event-name-derived friendly
+ * string. EVENT width grew from a fixed 16 to a responsive 22–30 range so
+ * the worst-case composed label (`{glyph} CTL-XXXX: attention`) always fits.
  */
 
 export interface ColumnWidths {
   status: number;
   time: number;
   repo: number;
-  source: number;
   event: number;
   ref: number;
   orch: number;
@@ -45,8 +51,7 @@ export function computeColumnWidths(columns: number): ColumnWidths {
     status: showStatus ? 3 : 0,
     time: 10,
     repo: Math.min(14, Math.max(10, Math.floor(columns * 0.07))),
-    source: Math.min(22, Math.max(16, Math.floor(columns * 0.1))),
-    event: 16,
+    event: Math.min(30, Math.max(22, Math.floor(columns * 0.13))),
     ref: Math.min(20, Math.max(10, Math.floor(columns * 0.08))),
     orch: showOrch ? Math.min(24, Math.max(16, Math.floor(columns * 0.12))) : 0,
     worker: showWorker ? 16 : 0,

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -135,6 +135,34 @@ export function formatEvent(event: CanonicalEvent): string {
   return label.slice(0, 15);
 }
 
+// CTL-364: merged SOURCE + EVENT column renderer. Returns
+// `${sourceIcon}${label}` where the icon is the Nerd Font glyph for the
+// source family (bare in non-Nerd-Font mode) and the label is the event
+// label — with the comms-specific embellishment of preserving the sender
+// ticket into the label so SOURCE-only info isn't lost when the column
+// disappears. formatSource and formatEvent stay exported for the filter
+// haystack and other layout-independent consumers.
+export function formatSourceEvent(event: CanonicalEvent): string {
+  const name = event.attributes?.["event.name"];
+  if (name === "comms.message.posted") {
+    const sender = event.attributes["event.label"]
+      ?? event.attributes["catalyst.worker.ticket"];
+    const payload = event.body?.payload as Record<string, unknown> | undefined;
+    const rawType = payload?.["type"];
+    const type = typeof rawType === "string" && rawType.length > 0 ? rawType : "comms";
+    // Glyph is anchored to the comms source family rather than classifySource's
+    // sender-ticket output so the icon stays semantically correct (speech
+    // bubble) regardless of which worker sent the message.
+    const icon = sourceIcon("comms");
+    if (sender && typeof sender === "string" && sender.length > 0) {
+      return `${icon}${sender}: ${type}`;
+    }
+    return `${icon}${type}`;
+  }
+  const sourceLabel = classifySource(event);
+  return `${sourceIcon(sourceLabel)}${formatEvent(event)}`;
+}
+
 // CTL-350: STATUS column glyph. One char + trailing space so the column width
 // is exactly 2 — keeps `<Box width={2}>` rendering on a single visual cell
 // even when the terminal applies bold/inverse styling. CI conclusion drives


### PR DESCRIPTION
## Summary

- Drops the SOURCE column from the orch-monitor HUD; renders a single merged **EVENT** column as `${glyph} ${label}` where the glyph is the existing Nerd Font source-family icon and the label is the event-name-derived friendly string.
- Preserves SOURCE-only info that would otherwise disappear:
  - `comms.message.posted` → label becomes `${sender}: ${type}` (e.g., `CTL-330: attention`).
  - `filter.*` events → orchestrator id stays in ORCH (≥160 cols) and REF for `filter.wake.*` (CTL-348 strip).
- EVENT width grew from a fixed 16 → responsive `min(30, max(22, floor(cols*0.13)))` so the worst-case composed label always fits. DETAILS reclaims the freed width via its existing `flexGrow={1}`.
- `formatSource` and `formatEvent` stay exported — they back the `useFilter` substring haystack and other layout-independent consumers. The merged renderer is a new `formatSourceEvent` colocated in `cli/lib/format.ts`.

Closes CTL-364.

Plan: [[2026-05-13-CTL-364-hud-merge-source-event]]
Research: [[2026-05-13-hud-cleanup]] Area 4

## Files changed

- `plugins/dev/scripts/orch-monitor/cli/lib/format.ts` — new `formatSourceEvent`.
- `plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts` — drop `source` field; bump `event` to responsive 22–30.
- `plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx` — drop SOURCE cell; wire EVENT cell to `formatSourceEvent` with `wrap="truncate"`.
- `plugins/dev/scripts/orch-monitor/cli/components/Header.tsx` — drop SOURCE heading.
- `plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts` — 12 new cases (bare + Nerd Font modes).
- `plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts` — replace fixed `event=16` assertion with new bounds + monotonic-growth test.

## Test plan

- [x] `bun test __tests__/hud-format.test.ts __tests__/column-widths.test.ts` — 158 pass, 0 fail
- [x] `bun run lint` — no new warnings (1 pre-existing warning unchanged)
- [x] `bun run typecheck` — no new errors (2 pre-existing UI errors unchanged: marked, dompurify)
- [x] No reward hacking — only `as unknown as CanonicalEvent` casts in tests match existing fixture style
- [x] Manual sanity: `w.source` references eliminated repo-wide