### PR TITLE
fix(dev): HUD — truncate long orchestrator IDs in ORCH column (CTL-383)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
@@ -81,9 +81,22 @@ describe("computeColumnWidths", () => {
     expect(wide.ref).toBeLessThanOrEqual(20);
   });
 
-  test("orch width clamps at 24 even on very wide terminals", () => {
+  // CTL-383: ORCH cap tightened from 24 → 18 so wide terminals leave more
+  // room for DETAILS. Long orchestrator ids are still legible because the row
+  // truncates with an ellipsis (see CTL-383 ORCH cell test in event-row.test.tsx)
+  // and the substring filter (CTL-367) covers deep search.
+  test("orch width clamps at 18 even on very wide terminals (CTL-383)", () => {
     const w = computeColumnWidths(400);
-    expect(w.orch).toBeLessThanOrEqual(24);
+    expect(w.orch).toBeLessThanOrEqual(18);
+  });
+
+  test("orch width stays in the 16-18 range whenever ORCH is shown (CTL-383)", () => {
+    for (const cols of [160, 180, 200, 240, 320, 400]) {
+      const w = computeColumnWidths(cols);
+      expect(w.showOrch).toBe(true);
+      expect(w.orch).toBeGreaterThanOrEqual(16);
+      expect(w.orch).toBeLessThanOrEqual(18);
+    }
   });
 
   test("time column stays fixed at 10", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 import type { ReactElement, ReactNode } from "react";
 import { EventRow } from "../cli/components/EventRow.tsx";
 import { formatDetails } from "../cli/lib/format.ts";
+import { computeColumnWidths } from "../cli/lib/column-widths.ts";
 import type { CanonicalEvent } from "../lib/canonical-event.ts";
 
 // CTL-361: long DETAILS strings must never reflow onto the next terminal line.
@@ -105,5 +106,105 @@ describe("EventRow DETAILS cell (CTL-361)", () => {
     const children = (detailsText.props as { children?: unknown }).children;
     expect(children).toBe(formatDetails(longDetailsEvent));
     expect(children).toBe(longDetails);
+  });
+});
+
+// CTL-383: long orchestrator IDs (e.g. multi-ticket o-adv-944-946-947-… runs)
+// must not reflow the ORCH cell onto a second terminal line. The fix is the
+// same pattern used for EVENT (CTL-364) and DETAILS (CTL-361): set
+// wrap="truncate" on the ORCH <Text>. Ink emits an ellipsis at the cell's
+// right edge instead of wrapping. formatOrch is intentionally left
+// untruncated — clipping is the renderer's job.
+
+const longOrchId = "o-adv-944-946-947-949-950-939-937-938-903-ADV-937";
+
+const longOrchEvent: CanonicalEvent = {
+  ts: "2026-05-14T13:40:00.000Z",
+  id: "22222222-3333-4444-8555-666666666666",
+  severityText: "INFO",
+  severityNumber: 9,
+  traceId: null,
+  spanId: null,
+  resource: {
+    "service.name": "test",
+    "service.namespace": "catalyst",
+    "service.version": "0.0.0",
+  },
+  attributes: {
+    "event.name": "orchestrator.worker.done",
+    "catalyst.orchestrator.id": longOrchId,
+    "catalyst.worker.ticket": "ADV-937",
+  },
+  body: { payload: {} },
+};
+
+// The ORCH cell is the Box whose `width` matches `computeColumnWidths(cols).orch`
+// AND whose only child is a Text node carrying the orchestrator id. Identifying
+// by both width and content avoids false positives from other columns that
+// happen to share the same width at certain terminal sizes.
+function findOrchTextNode(root: ReactNode, expectedWidth: number, expectedContent: string): ReactElement | null {
+  function isReactElement(node: unknown): node is ReactElement {
+    return (
+      typeof node === "object" &&
+      node !== null &&
+      "props" in node &&
+      "type" in node
+    );
+  }
+  function walk(node: ReactNode): ReactElement | null {
+    if (!isReactElement(node)) return null;
+    const props = node.props as { width?: number; children?: ReactNode };
+    if (props.width === expectedWidth) {
+      const child = props.children;
+      if (isReactElement(child)) {
+        const childProps = child.props as { children?: unknown };
+        if (childProps.children === expectedContent) return child;
+      }
+    }
+    const children = props.children;
+    if (Array.isArray(children)) {
+      for (const c of children) {
+        const found = walk(c as ReactNode);
+        if (found) return found;
+      }
+    } else if (children !== undefined && children !== null) {
+      return walk(children);
+    }
+    return null;
+  }
+  return walk(root);
+}
+
+describe("EventRow ORCH cell (CTL-383)", () => {
+  test("ORCH Text uses wrap=\"truncate\" so long orchestrator ids do not reflow", () => {
+    const cols = 200;
+    const w = computeColumnWidths(cols);
+    expect(w.showOrch).toBe(true);
+
+    const element = EventRow({
+      event: longOrchEvent,
+      selected: false,
+      columns: cols,
+      paused: true,
+    });
+    const orchText = findOrchTextNode(element, w.orch, longOrchId);
+    if (!orchText) throw new Error("ORCH Text node not found");
+    expect((orchText.props as { wrap?: string }).wrap).toBe("truncate");
+  });
+
+  test("ORCH Text receives the full orch id (renderer clips, formatter does not)", () => {
+    const cols = 200;
+    const w = computeColumnWidths(cols);
+
+    const element = EventRow({
+      event: longOrchEvent,
+      selected: false,
+      columns: cols,
+      paused: true,
+    });
+    const orchText = findOrchTextNode(element, w.orch, longOrchId);
+    if (!orchText) throw new Error("ORCH Text node not found");
+    const children = (orchText.props as { children?: unknown }).children;
+    expect(children).toBe(longOrchId);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -77,7 +77,10 @@ export function EventRow({ event, selected, columns, paused = true }: EventRowPr
       </Box>
       {w.showOrch && (
         <Box width={w.orch} flexShrink={0} marginRight={1}>
-          <Text color={color} inverse={inverse}>{orchText}</Text>
+          {/* CTL-383: long multi-ticket orchestrator ids reflow into a second
+              terminal line without wrap="truncate", doubling row height.
+              Same fix shape as EVENT (CTL-364) and DETAILS (CTL-361). */}
+          <Text color={color} inverse={inverse} wrap="truncate">{orchText}</Text>
         </Box>
       )}
       {w.showWorker && (

--- a/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
@@ -11,7 +11,8 @@
  *   STATUS    ≥100 cols   one-glyph success/failure/in-progress indicator.
  *                         3 cells wide because ⏳ (U+23F3) renders 2 cells
  *                         in most terminals and we want a trailing gutter.
- *   ORCH      ≥160 cols   full catalyst.orchestrator.id
+ *   ORCH      ≥160 cols   catalyst.orchestrator.id (truncated to 16-18 cells
+ *                         with ellipsis on long multi-ticket ids; CTL-383)
  *   WORKER    ≥180 cols   catalyst.worker.ticket
  *   EVENT-ID  ≥200 cols   first 8 chars of the per-event UUIDv4 (CTL-344)
  *
@@ -53,7 +54,10 @@ export function computeColumnWidths(columns: number): ColumnWidths {
     repo: Math.min(14, Math.max(10, Math.floor(columns * 0.07))),
     event: Math.min(30, Math.max(22, Math.floor(columns * 0.13))),
     ref: Math.min(20, Math.max(10, Math.floor(columns * 0.08))),
-    orch: showOrch ? Math.min(24, Math.max(16, Math.floor(columns * 0.12))) : 0,
+    // CTL-383: cap tightened from 24 → 18. Long multi-ticket orchestrator ids
+    // truncate with an ellipsis (see EventRow.tsx wrap="truncate" on the ORCH
+    // <Text>); the saved cells widen DETAILS at terminals ≥240 cols.
+    orch: showOrch ? Math.min(18, Math.max(16, Math.floor(columns * 0.12))) : 0,
     worker: showWorker ? 16 : 0,
     eventId: showEventId ? 10 : 0,
     showStatus,


### PR DESCRIPTION
## Summary

Long multi-ticket orchestrator IDs (e.g. `o-adv-944-946-947-949-950-939-937-938-903-ADV-937`) reflowed onto a second terminal line inside the fixed-width ORCH cell, doubling row height for affected events. Add `wrap=\"truncate\"` to the ORCH `<Text>` so Ink emits an ellipsis at the cell boundary instead of wrapping. Tighten the ORCH column cap from 24 → 18 cells (range now 16-18) to free 6 cells for DETAILS at wide terminals.

Linear ticket: [CTL-383](https://linear.app/coalesce-labs/issue/CTL-383)

## Changes

- `cli/components/EventRow.tsx` — add `wrap=\"truncate\"` to the ORCH `<Text>` (matches EVENT cell from CTL-364 and DETAILS cell from CTL-361).
- `cli/lib/column-widths.ts` — `Math.min(24, …)` → `Math.min(18, …)`. Updated the top-of-file column doc.
- `__tests__/event-row.test.tsx` — new `EventRow ORCH cell (CTL-383)` describe block (2 tests) walks the React tree to assert `wrap=\"truncate\"` and that `formatOrch` is left untruncated (renderer clips, formatter does not — same contract as DETAILS).
- `__tests__/column-widths.test.ts` — updated cap test (24 → 18) and added a coverage test for the 16-18 range across 6 terminal widths.

## Approach decision

The ticket offered two options: (a) `wrap=\"truncate\"` on the `<Text>`, (b) pre-truncate in `formatOrch` to 15 chars. Chose (a) for codebase consistency — EVENT (CTL-364) and DETAILS (CTL-361) both follow this pattern. Header doesn't need to change because it uses fixed-width Boxes already.

## Test plan

- [x] `bun test __tests__/event-row.test.tsx __tests__/column-widths.test.ts __tests__/hud-format.test.ts` — 164/164 pass
- [x] `bun run typecheck` — no new errors (pre-existing `marked`/`dompurify` errors in `ui/` are unrelated)
- [x] `bun x eslint cli/components/EventRow.tsx cli/lib/column-widths.ts __tests__/event-row.test.tsx __tests__/column-widths.test.ts` — clean
- [x] No reward-hacking patterns (`as any` / `@ts-ignore` / `!.` etc.) in the diff
- [ ] Manual repro after merge: invoke a multi-ticket orchestrator and confirm every row stays one terminal line tall

## Plan

`thoughts/shared/plans/2026-05-14-CTL-383-hud-truncate-orch-column.md`