### PR TITLE
feat(dev): HUD :since — first-class filter (overlay, ESC, footer chip) (CTL-387)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/filter-input.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/filter-input.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatFilterHints,
+  formatSinceChipLabel,
+  WIDE_HINTS_COLS,
+} from "../cli/components/FilterInput.tsx";
+
+describe("formatSinceChipLabel", () => {
+  test("returns null when no active since label", () => {
+    expect(formatSinceChipLabel(null)).toBeNull();
+  });
+
+  test("wraps a relative spec in brackets", () => {
+    expect(formatSinceChipLabel("5m")).toBe("[since: 5m]");
+  });
+
+  test("wraps a day spec in brackets", () => {
+    expect(formatSinceChipLabel("7d")).toBe("[since: 7d]");
+  });
+
+  test("preserves an ISO-date spec verbatim inside the chip", () => {
+    expect(formatSinceChipLabel("2026-05-01")).toBe("[since: 2026-05-01]");
+  });
+
+  test("treats empty string as inactive (null result)", () => {
+    expect(formatSinceChipLabel("")).toBeNull();
+  });
+});
+
+describe("formatFilterHints", () => {
+  test("base hint set when narrow and unfocused", () => {
+    const out = formatFilterHints(80, false);
+    expect(out).toContain("/:focus");
+    expect(out).not.toContain("h:help");
+  });
+
+  test("base hint set switches to Esc:clear when focused", () => {
+    const out = formatFilterHints(80, true);
+    expect(out).toContain("Esc:clear");
+  });
+
+  test("wide-terminal hint set adds h:help / G:newest / r:reset", () => {
+    const out = formatFilterHints(WIDE_HINTS_COLS, false);
+    expect(out).toContain("h:help");
+    expect(out).toContain("G:newest");
+    expect(out).toContain("r:reset");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-since.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-since.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { parseSinceSpec } from "../cli/lib/since-spec.ts";
+
+describe("parseSinceSpec", () => {
+  test("parses minutes to an ISO string roughly N minutes ago", () => {
+    const before = Date.now();
+    const out = parseSinceSpec("5m");
+    const after = Date.now();
+    expect(out).not.toBeNull();
+    const t = new Date(out!).getTime();
+    expect(t).toBeGreaterThanOrEqual(before - 5 * 60_000 - 50);
+    expect(t).toBeLessThanOrEqual(after - 5 * 60_000 + 50);
+  });
+
+  test("parses hours", () => {
+    const out = parseSinceSpec("24h");
+    expect(out).not.toBeNull();
+    const ageMs = Date.now() - new Date(out!).getTime();
+    expect(ageMs).toBeGreaterThanOrEqual(24 * 3_600_000 - 100);
+    expect(ageMs).toBeLessThanOrEqual(24 * 3_600_000 + 100);
+  });
+
+  test("parses days", () => {
+    const out = parseSinceSpec("7d");
+    expect(out).not.toBeNull();
+    const ageMs = Date.now() - new Date(out!).getTime();
+    expect(ageMs).toBeGreaterThanOrEqual(7 * 86_400_000 - 100);
+    expect(ageMs).toBeLessThanOrEqual(7 * 86_400_000 + 100);
+  });
+
+  test("parses seconds", () => {
+    const out = parseSinceSpec("30s");
+    expect(out).not.toBeNull();
+    const ageMs = Date.now() - new Date(out!).getTime();
+    expect(ageMs).toBeGreaterThanOrEqual(30_000 - 100);
+    expect(ageMs).toBeLessThanOrEqual(30_000 + 100);
+  });
+
+  test("parses long-form units like 'minute', 'hour', 'day'", () => {
+    const out = parseSinceSpec("2hours");
+    expect(out).not.toBeNull();
+    const ageMs = Date.now() - new Date(out!).getTime();
+    expect(ageMs).toBeGreaterThanOrEqual(2 * 3_600_000 - 100);
+    expect(ageMs).toBeLessThanOrEqual(2 * 3_600_000 + 100);
+  });
+
+  test("parses an ISO date string", () => {
+    const out = parseSinceSpec("2026-05-01");
+    expect(out).not.toBeNull();
+    expect(new Date(out!).toISOString().startsWith("2026-05-01")).toBe(true);
+  });
+
+  test("returns null for unparseable spec", () => {
+    expect(parseSinceSpec("garbage")).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseSinceSpec("")).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
@@ -12,6 +12,7 @@ interface FilterInputProps {
   totalCount: number;
   autoFollow: boolean;
   statusMsg: string | null;
+  activeSinceLabel: string | null;
 }
 
 // CTL-363: wide-terminal hint set adds h:help / G:newest / r:reset.
@@ -30,6 +31,13 @@ export function formatFilterHints(cols: number, focused: boolean): string {
   return base;
 }
 
+// CTL-387: footer chip text when a user-interactive `:since` is active.
+// Returns null when no active label (chip should not render).
+export function formatSinceChipLabel(activeLabel: string | null): string | null {
+  if (!activeLabel) return null;
+  return `[since: ${activeLabel}]`;
+}
+
 export function FilterInput({
   value,
   focused,
@@ -40,11 +48,16 @@ export function FilterInput({
   totalCount,
   autoFollow,
   statusMsg,
+  activeSinceLabel,
 }: FilterInputProps) {
+  const sinceChip = formatSinceChipLabel(activeSinceLabel);
   return (
     <Box flexDirection="row">
       {pivot && (
         <Text color="cyan">{`[${pivot.type}:${pivot.id.slice(0, 12)}…] `}</Text>
+      )}
+      {sinceChip && (
+        <Text color="cyan">{`${sinceChip} `}</Text>
       )}
       <Text dimColor={!focused}>{"/ "}</Text>
       <TextInput value={value} onChange={onChange} focus={focused} placeholder="filter (substring — all fields)" />

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -17,6 +17,7 @@ import { useFilter, type DslPredicate } from "./hooks/useFilter.ts";
 import { useSelection } from "./hooks/useSelection.ts";
 import { decidePivotAction } from "./lib/pivot-decision.ts";
 import { detectNerdFont } from "./lib/nerd-font.ts";
+import { parseSinceSpec } from "./lib/since-spec.ts";
 import {
   compile,
   groqTranslate,
@@ -41,24 +42,6 @@ interface DslState {
   nlQuery: string;
 }
 
-/** Parse relative/absolute time specs like "24h", "7d", "30m", ISO dates. */
-function parseSinceSpec(raw: string): string | null {
-  const match = raw.match(/^(\d+)\s*(h|m|s|d|hour|min|minute|second|day)s?$/i);
-  if (match) {
-    const n = parseInt(match[1] ?? "0", 10);
-    const unit = (match[2] ?? "s").toLowerCase();
-    const ms = unit.startsWith("d") ? n * 86400000
-      : unit.startsWith("h") ? n * 3600000
-      : unit.startsWith("m") ? n * 60000
-      : n * 1000;
-    return new Date(Date.now() - ms).toISOString();
-  }
-  // Try parsing as an ISO date/datetime string
-  const d = new Date(raw);
-  if (!isNaN(d.getTime())) return d.toISOString();
-  return null;
-}
-
 const HELP_LINES = [
   "Navigation",
   "  j / ↓           next event         k / ↑         prev event",
@@ -73,8 +56,8 @@ const HELP_LINES = [
   "  /                substring filter — applies to all loaded events",
   "  :                natural-language query via Groq (needs GROQ_API_KEY)",
   "  :since 24h       reload events from last 24 h  (also: 7d, 2h, 30m, ISO date)",
-  "  ?                show/hide the generated DSL from last query",
-  "  Esc              clear active filter / close overlay",
+  "  ?                show generated DSL and active :since window",
+  "  Esc              clear all filters (:since, /, :query) / close overlay",
   "",
   "Scope — narrow to related events  (live mode: first press pauses; press again to apply)",
   "  t                scope to all events sharing this event's trace ID",
@@ -131,7 +114,12 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   const layoutRows = Math.max(10, rows - 2);
 
   // Interactive since — can be changed via `:since 24h` without restarting.
+  // CTL-387: `activeSinceLabel` is the human-readable spec the user typed
+  // (e.g. "5m") for the footer chip + `?` overlay. It is `null` until the
+  // user submits a `:since` interactively, and reverts to `null` on ESC so
+  // the chip disappears when the window matches HUD startup.
   const [activeSinceTs, setActiveSinceTs] = useState(initSinceTs);
+  const [activeSinceLabel, setActiveSinceLabel] = useState<string | null>(null);
 
   const { events, loading } = useEventLog({ repoFilter, predicate, sinceTs: activeSinceTs });
 
@@ -157,7 +145,9 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
 
   const [showDslOverlay, setShowDslOverlay] = useState(false);
   const [dslScrollTop, setDslScrollTop] = useState(0);
-  const overlayHeight = showDslOverlay && dslState ? Math.min(14, Math.floor(layoutRows / 2)) : 0;
+  // CTL-387: overlay shows when either a DSL is set or a since spec is active.
+  const overlayHasContent = Boolean(dslState) || Boolean(activeSinceLabel);
+  const overlayHeight = showDslOverlay && overlayHasContent ? Math.min(14, Math.floor(layoutRows / 2)) : 0;
 
   const [showHelp, setShowHelp] = useState(false);
 
@@ -271,6 +261,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
       const parsed = parseSinceSpec(spec);
       if (parsed) {
         setActiveSinceTs(parsed);
+        setActiveSinceLabel(spec);
         setQueryFocused(false);
         setQueryText("");
         showStatus(`reloaded from ${spec}`);
@@ -327,6 +318,10 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
       setFilterText("");
       setDslState(null);
       setQueryError(null);
+      // CTL-387: ESC is a full reset — revert :since to the HUD-startup value
+      // so the time window matches what the user launched with.
+      setActiveSinceTs(initSinceTs);
+      setActiveSinceLabel(null);
       return;
     }
     if (input === "q" || (key.ctrl && input === "c")) { exit(); return; }
@@ -356,7 +351,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
     if (input === "/") { setFilterFocused(true); return; }
     if (input === ":") { setQueryFocused(true); setQueryError(null); return; }
     if (input === "h") { setShowHelp(true); return; }
-    if (input === "?" && dslState) { setShowDslOverlay((v) => !v); return; }
+    if (input === "?" && overlayHasContent) { setShowDslOverlay((v) => !v); return; }
     if (key.return) { setShowDetail((v) => !v); return; }
     if (input === "o" || input === "t") {
       const action = decidePivotAction({ key: input, autoFollow, selectedEvent });
@@ -412,10 +407,17 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           ))}
         </Box>
       )}
-      {showDslOverlay && dslState && (
+      {showDslOverlay && overlayHasContent && (
         <Box flexShrink={0} flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={1}>
-          <Text color="magenta" bold>{`Generated DSL · j/k scroll · ? to hide (${dslScrollTop + 1}/${dslLines.length}):`}</Text>
-          {dslLines.slice(dslScrollTop, dslScrollTop + dslVisibleLines).map((line, i) => (
+          <Text color="magenta" bold>{
+            dslState
+              ? `Query overlay · j/k scroll · ? to hide (${dslScrollTop + 1}/${dslLines.length}):`
+              : "Query overlay · ? to hide:"
+          }</Text>
+          {activeSinceLabel && (
+            <Text>{`Time window: ${activeSinceLabel} (since ${activeSinceTs})`}</Text>
+          )}
+          {dslState && dslLines.slice(dslScrollTop, dslScrollTop + dslVisibleLines).map((line, i) => (
             <Text key={i} dimColor={i > 0}>{line}</Text>
           ))}
         </Box>
@@ -434,6 +436,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           totalCount={events.length}
           autoFollow={autoFollow}
           statusMsg={statusMsg}
+          activeSinceLabel={activeSinceLabel}
         />
       </Box>
       <Box flexShrink={0}>

--- a/plugins/dev/scripts/orch-monitor/cli/lib/since-spec.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/since-spec.ts
@@ -1,0 +1,17 @@
+/** Parse relative/absolute time specs like "24h", "7d", "30m", ISO dates. */
+export function parseSinceSpec(raw: string): string | null {
+  const match = raw.match(/^(\d+)\s*(h|m|s|d|hour|min|minute|second|day)s?$/i);
+  if (match) {
+    const n = parseInt(match[1] ?? "0", 10);
+    const unit = (match[2] ?? "s").toLowerCase();
+    const ms = unit.startsWith("d") ? n * 86400000
+      : unit.startsWith("h") ? n * 3600000
+      : unit.startsWith("m") ? n * 60000
+      : n * 1000;
+    return new Date(Date.now() - ms).toISOString();
+  }
+  // Try parsing as an ISO date/datetime string
+  const d = new Date(raw);
+  if (!isNaN(d.getTime())) return d.toISOString();
+  return null;
+}


### PR DESCRIPTION
## Summary

Brings the `:since <spec>` HUD filter to parity with the other filters (`/`, pivot, `:query`):

- `?` overlay now opens when `:since` is active (in addition to or alongside a DSL).
- `ESC` reverts `:since` to the HUD-startup value as part of the full-reset path.
- Footer now renders a cyan `[since: <spec>]` chip when the user has changed the since window interactively.
- `HELP_LINES` updated to describe the new `?` and ESC semantics.

Closes CTL-387.

## What changed

| File | Change |
|---|---|
| `cli/lib/since-spec.ts` | New module. Extracted `parseSinceSpec` from `hud.tsx` so it's testable without booting the CLI. |
| `cli/hud.tsx` | New `activeSinceLabel` state. ESC full-reset reverts `:since`. `?` toggle and DSL overlay gate on `dslState \|\| activeSinceLabel`. Overlay now prepends `Time window: <spec>` line. HELP_LINES `?` and ESC entries updated. |
| `cli/components/FilterInput.tsx` | New `activeSinceLabel` prop + cyan footer chip via `formatSinceChipLabel` helper. |
| `__tests__/hud-since.test.ts` | 8 tests for `parseSinceSpec` (minutes, hours, days, seconds, long-form units, ISO date, garbage, empty). |
| `__tests__/filter-input.test.ts` | 5 tests for `formatSinceChipLabel` + 3 for the existing `formatFilterHints` pattern. |

## Design notes

- **Chip predicate is "user has typed `:since`, label is non-null"**, not "tsTime != initTime". A null label means the time window matches HUD startup — natural for ESC reset and CLI-passed `--since`.
- **Overlay scroll math unchanged.** The since-line is rendered as a header row outside the j/k scroll loop, the same way the title row already is.
- **No `S` keybinding to clear since only.** Ticket marked it optional; ESC-clears-all matches the existing UX shape.

## Test plan

- [x] `bun test` — 1782 pass, 0 new failures (6 pre-existing flakes in `catalyst-monitor.sh` integration tests).
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean (only pre-existing security warning in `preview-status.ts`).
- [x] `bun run knip` — clean.
- [ ] Manual smoke (cannot run in CI session): launch HUD → `:since 5m` → chip visible → `?` shows time-window line → ESC → chip gone, event count restored.

## Files

- `plugins/dev/scripts/orch-monitor/cli/hud.tsx`
- `plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx`
- `plugins/dev/scripts/orch-monitor/cli/lib/since-spec.ts` (new)
- `plugins/dev/scripts/orch-monitor/__tests__/hud-since.test.ts` (new)
- `plugins/dev/scripts/orch-monitor/__tests__/filter-input.test.ts` (new)