### PR TITLE
fix(dev): HUD pivot keys o/t pause live mode before scoping (CTL-388)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
@@ -20,7 +20,10 @@ export const WIDE_HINTS_COLS = 160;
 
 export function formatFilterHints(cols: number, focused: boolean): string {
   const focus = focused ? "Esc:clear" : "/:focus";
-  const base = `${focus} | t:trace o:orch | Enter:detail q:quit`;
+  // CTL-388: renamed "trace/orch" → "scope-tr/scope-orch" to clarify the verb
+  // (you're scoping the view to that ID, not "pivoting" through it). The o/t
+  // handlers also gained a pause-first behavior in live mode (see hud.tsx).
+  const base = `${focus} | t:scope-tr o:scope-orch | Enter:detail q:quit`;
   if (cols >= WIDE_HINTS_COLS) {
     return `${base} | h:help G:newest r:reset`;
   }

--- a/plugins/dev/scripts/orch-monitor/cli/components/footer-hints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/footer-hints.test.ts
@@ -9,7 +9,7 @@ describe("formatFilterHints", () => {
   test("narrow terminal — base hints only, focus label adapts", () => {
     const narrow = formatFilterHints(100, false);
     expect(narrow).toContain("/:focus");
-    expect(narrow).toContain("t:trace o:orch");
+    expect(narrow).toContain("t:scope-tr o:scope-orch");
     expect(narrow).toContain("Enter:detail q:quit");
     expect(narrow).not.toContain("h:help");
     expect(narrow).not.toContain("G:newest");
@@ -25,7 +25,7 @@ describe("formatFilterHints", () => {
     expect(wide).toContain("h:help");
     expect(wide).toContain("G:newest");
     expect(wide).toContain("r:reset");
-    expect(wide).toContain("t:trace o:orch");
+    expect(wide).toContain("t:scope-tr o:scope-orch");
   });
 
   test("threshold edge: at WIDE_HINTS_COLS is wide, just below is narrow", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useSelection.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useSelection.ts
@@ -58,5 +58,22 @@ export function useSelection(totalItems: number, visibleRows: number) {
     setSelectedIndex(Math.max(0, totalItems - 1));
   }
 
-  return { selectedIndex, scrollOffset, moveUp, moveDown, pageUp, pageDown, jumpToBottom, autoFollow };
+  // CTL-388: pause live tailing without moving selectedIndex. Used by the
+  // o/t scope-key handlers in hud.tsx to make the (invisible-in-live-mode)
+  // cursor visible BEFORE the user picks an event to scope on.
+  function pauseAutoFollow() {
+    setAutoFollow(false);
+  }
+
+  return {
+    selectedIndex,
+    scrollOffset,
+    moveUp,
+    moveDown,
+    pageUp,
+    pageDown,
+    jumpToBottom,
+    pauseAutoFollow,
+    autoFollow,
+  };
 }

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -15,6 +15,7 @@ import {
 import { useEventLog } from "./hooks/useEventLog.ts";
 import { useFilter, type DslPredicate } from "./hooks/useFilter.ts";
 import { useSelection } from "./hooks/useSelection.ts";
+import { decidePivotAction } from "./lib/pivot-decision.ts";
 import { detectNerdFont } from "./lib/nerd-font.ts";
 import {
   compile,
@@ -75,10 +76,10 @@ const HELP_LINES = [
   "  ?                show/hide the generated DSL from last query",
   "  Esc              clear active filter / close overlay",
   "",
-  "Pivot — narrow to related events",
-  "  t                pivot to all events sharing this event's trace ID",
-  "  o                pivot to all events from this event's orchestrator",
-  "  r                reset pivot (show all events)",
+  "Scope — narrow to related events  (live mode: first press pauses; press again to apply)",
+  "  t                scope to all events sharing this event's trace ID",
+  "  o                scope to all events from this event's orchestrator",
+  "  r                reset scope (show all events)",
   "",
   "  h                this help          q / Ctrl-C    quit",
 ];
@@ -168,8 +169,17 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   const chromeRows = headerRows + 3 + overlayHeight;
   const visibleRows = Math.max(1, layoutRows - chromeRows);
 
-  const { selectedIndex, scrollOffset, moveUp, moveDown, pageUp, pageDown, jumpToBottom, autoFollow } =
-    useSelection(filtered.length, visibleRows);
+  const {
+    selectedIndex,
+    scrollOffset,
+    moveUp,
+    moveDown,
+    pageUp,
+    pageDown,
+    jumpToBottom,
+    pauseAutoFollow,
+    autoFollow,
+  } = useSelection(filtered.length, visibleRows);
 
   const [filterFocused, setFilterFocused] = useState(false);
   const [queryFocused, setQueryFocused] = useState(false);
@@ -348,28 +358,19 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
     if (input === "h") { setShowHelp(true); return; }
     if (input === "?" && dslState) { setShowDslOverlay((v) => !v); return; }
     if (key.return) { setShowDetail((v) => !v); return; }
-    if (input === "t") {
-      if (selectedEvent?.traceId) {
-        setPivot({ type: "trace", id: selectedEvent.traceId });
-        showStatus(`pivoted to trace ${selectedEvent.traceId.slice(0, 16)}…`);
-      } else {
-        showStatus("no trace ID on this event");
+    if (input === "o" || input === "t") {
+      const action = decidePivotAction({ key: input, autoFollow, selectedEvent });
+      if (action.kind === "pause") {
+        pauseAutoFollow();
+      } else if (action.kind === "pivot") {
+        setPivot(action.pivot);
       }
-      return;
-    }
-    if (input === "o") {
-      const orchId = selectedEvent?.attributes["catalyst.orchestrator.id"];
-      if (orchId) {
-        setPivot({ type: "orch", id: orchId });
-        showStatus(`pivoted to orchestrator ${orchId}`);
-      } else {
-        showStatus("no orchestrator ID on this event");
-      }
+      showStatus(action.status);
       return;
     }
     if (input === "r") {
       setPivot(null);
-      showStatus("pivot cleared");
+      showStatus("scope cleared");
       return;
     }
   });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/pivot-decision.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/pivot-decision.test.ts
@@ -1,0 +1,104 @@
+// pivot-decision.test.ts — CTL-388. Pure decision logic for the o/t pivot keys
+// when the HUD is in live (auto-follow) vs paused mode. The handler in hud.tsx
+// is a thin dispatcher over this function.
+
+import { describe, test, expect } from "bun:test";
+import { decidePivotAction } from "./pivot-decision";
+import type { CanonicalEvent } from "../../lib/canonical-event.ts";
+
+function mkEvent(overrides: Partial<CanonicalEvent> = {}): CanonicalEvent {
+  return {
+    ts: "2026-05-14T16:00:00Z",
+    id: "evt-1",
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: "trace-abc-1234567890abcdef",
+    spanId: null,
+    resource: { "service.name": "test", "service.namespace": "catalyst", "service.version": "0.0.0" },
+    attributes: {
+      "event.name": "test",
+      "catalyst.orchestrator.id": "o-ctl-388",
+    },
+    body: {},
+    ...overrides,
+  };
+}
+
+describe("decidePivotAction — CTL-388", () => {
+  test("o pressed while autoFollow on → pause, no pivot", () => {
+    const r = decidePivotAction({ key: "o", autoFollow: true, selectedEvent: mkEvent() });
+    expect(r.kind).toBe("pause");
+    if (r.kind === "pause") {
+      expect(r.status.toLowerCase()).toContain("paused");
+    }
+  });
+
+  test("t pressed while autoFollow on → pause, no pivot", () => {
+    const r = decidePivotAction({ key: "t", autoFollow: true, selectedEvent: mkEvent() });
+    expect(r.kind).toBe("pause");
+  });
+
+  test("o pressed while paused + orchestrator id present → pivot to orch", () => {
+    const r = decidePivotAction({ key: "o", autoFollow: false, selectedEvent: mkEvent() });
+    expect(r.kind).toBe("pivot");
+    if (r.kind === "pivot") {
+      expect(r.pivot).toEqual({ type: "orch", id: "o-ctl-388" });
+      expect(r.status).toContain("scoped to orchestrator");
+    }
+  });
+
+  test("t pressed while paused + trace id present → pivot to trace", () => {
+    const r = decidePivotAction({ key: "t", autoFollow: false, selectedEvent: mkEvent() });
+    expect(r.kind).toBe("pivot");
+    if (r.kind === "pivot") {
+      expect(r.pivot).toEqual({ type: "trace", id: "trace-abc-1234567890abcdef" });
+      expect(r.status).toContain("scoped to trace");
+    }
+  });
+
+  test("o pressed while paused + no orchestrator id → noop with explanation", () => {
+    const ev = mkEvent({ attributes: { "event.name": "noorch" } });
+    const r = decidePivotAction({ key: "o", autoFollow: false, selectedEvent: ev });
+    expect(r.kind).toBe("noop");
+    if (r.kind === "noop") {
+      expect(r.status.toLowerCase()).toContain("no orchestrator");
+    }
+  });
+
+  test("t pressed while paused + no trace id → noop with explanation", () => {
+    const ev = mkEvent({ traceId: null });
+    const r = decidePivotAction({ key: "t", autoFollow: false, selectedEvent: ev });
+    expect(r.kind).toBe("noop");
+    if (r.kind === "noop") {
+      expect(r.status.toLowerCase()).toContain("no trace");
+    }
+  });
+
+  test("null selectedEvent while paused → noop", () => {
+    const r = decidePivotAction({ key: "o", autoFollow: false, selectedEvent: null });
+    expect(r.kind).toBe("noop");
+  });
+
+  test("null selectedEvent while live → still pauses (no pivot read attempted)", () => {
+    // Even with no event, entering live mode and pressing o/t pauses so the
+    // user can see what's there once tailing stops.
+    const r = decidePivotAction({ key: "o", autoFollow: true, selectedEvent: null });
+    expect(r.kind).toBe("pause");
+  });
+
+  test("pause status mentions both o and t actions so the user knows next step", () => {
+    const r = decidePivotAction({ key: "o", autoFollow: true, selectedEvent: mkEvent() });
+    if (r.kind === "pause") {
+      expect(r.status).toMatch(/o|t/);
+    }
+  });
+
+  test("trace status truncates long trace ids to 16 chars + ellipsis", () => {
+    const ev = mkEvent({ traceId: "0123456789abcdef0123456789abcdef" });
+    const r = decidePivotAction({ key: "t", autoFollow: false, selectedEvent: ev });
+    if (r.kind === "pivot") {
+      expect(r.status).toContain("0123456789abcdef");
+      expect(r.status).toContain("…");
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/pivot-decision.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/pivot-decision.ts
@@ -1,0 +1,63 @@
+// CTL-388: pure decision logic for the o/t "scope" keys in the HUD.
+//
+// CTL-351 made the cursor invisible during live (auto-follow) tailing so the
+// streaming events don't carry distracting inverse-video highlights. CTL-388
+// closes the resulting UX gap: pressing o or t in live mode would silently
+// filter to whatever event the (invisible) cursor happened to be parked on at
+// the bottom of the list. The fix forces the user to pause first — making the
+// cursor visible — and only applies the scope on a second press.
+//
+// hud.tsx's useInput handler is a thin dispatcher; the per-key branching and
+// status-message wording live here so they can be unit-tested.
+
+import type { CanonicalEvent } from "../../lib/canonical-event.ts";
+
+export type PivotKey = "o" | "t";
+
+export type PivotAction =
+  | { kind: "pivot"; pivot: { type: "orch" | "trace"; id: string }; status: string }
+  | { kind: "pause"; status: string }
+  | { kind: "noop"; status: string };
+
+export interface DecidePivotInput {
+  key: PivotKey;
+  autoFollow: boolean;
+  selectedEvent: CanonicalEvent | null;
+}
+
+const PAUSE_STATUS =
+  "paused — use ↑/↓ to select an event, then o:scope-orch t:scope-trace, G:resume live";
+
+export function decidePivotAction(input: DecidePivotInput): PivotAction {
+  const { key, autoFollow, selectedEvent } = input;
+
+  if (autoFollow) {
+    return { kind: "pause", status: PAUSE_STATUS };
+  }
+
+  if (!selectedEvent) {
+    return { kind: "noop", status: "no event selected" };
+  }
+
+  if (key === "o") {
+    const orchId = selectedEvent.attributes["catalyst.orchestrator.id"];
+    if (!orchId) {
+      return { kind: "noop", status: "no orchestrator ID on this event" };
+    }
+    return {
+      kind: "pivot",
+      pivot: { type: "orch", id: orchId },
+      status: `scoped to orchestrator ${orchId}`,
+    };
+  }
+
+  // key === "t"
+  if (!selectedEvent.traceId) {
+    return { kind: "noop", status: "no trace ID on this event" };
+  }
+  return {
+    kind: "pivot",
+    pivot: { type: "trace", id: selectedEvent.traceId },
+    status: `scoped to trace ${selectedEvent.traceId.slice(0, 16)}…`,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes [CTL-388](https://linear.app/coalesce-labs/issue/CTL-388). In `catalyst-hud` live mode the cursor is hidden (CTL-351), but pressing `o` or `t` would still read from whatever event was at the bottom of the list — silently filtering to a scope the user could not see was about to be selected.

This PR implements **Option (b)** from the ticket — "force-visible cursor on pivot keys":

- In live mode, the **first** press of `o`/`t` pauses auto-follow and shows a status hint. The cursor becomes visible. The user picks the event they want with `↑`/`↓` and presses the key again to apply the scope.
- When auto-follow is already off (cursor visible), `o`/`t` apply the scope immediately — unchanged behavior for power users who have already paused.

Rationale (per ticket): Option (b) is simpler than the preview-and-confirm variant — no transient confirmation state, no extra UI affordance. It also reuses `useSelection`'s existing auto-follow state machine, adding just one method.

Additionally renames the user-facing copy from `pivot` → `scope` in the help panel and footer hint, addressing the ticket's "Additional cleanup" note ("Is 'pivoting' the same as filtering?"). The verb `scope` reads more naturally with the existing `r:reset scope` semantics.

## Changes

- New `plugins/dev/scripts/orch-monitor/cli/lib/pivot-decision.ts` — pure helper `decidePivotAction({ key, autoFollow, selectedEvent })` returning `pivot`/`pause`/`noop` actions. Lives outside the React tree so it's unit-testable without `useInput` mocking.
- `cli/hooks/useSelection.ts` — exposes `pauseAutoFollow()` (the hook already toggled `autoFollow` internally inside `moveUp`/`moveDown`/etc.; this is the symmetric setter to the existing `jumpToBottom`).
- `cli/hud.tsx` — `o`/`t` branch in `useInput` dispatches via the helper. `r` handler renamed `pivot cleared` → `scope cleared`. `HELP_LINES` rewritten under a "Scope" heading with the new two-press hint.
- `cli/components/FilterInput.tsx` — footer hint reads `t:scope-tr o:scope-orch`.
- Tests: 10 new unit tests for `pivot-decision`, 2 updated assertions in `footer-hints.test.ts`.

## Files NOT touched (intentional)

- `cli/components/EventRow.tsx` — `paused = !autoFollow` is correct (CTL-351). The fix lives in the pivot call sites, not the row.
- The "unified active-filter indicator" mentioned in the ticket's "Related" section is filed separately.

## Test plan

- [x] `bun test cli/lib/pivot-decision.test.ts` — 10/10 pass
- [x] `bun test cli/components/footer-hints.test.ts` — updated assertions pass
- [x] `bun test cli/hooks/useSelection.test.ts` — existing tests unchanged, still pass
- [x] `bun run typecheck` — clean for changed files (pre-existing `ui/src/lib/briefings.ts` `marked`/`dompurify` errors are unrelated; confirmed by `git stash` reproduction)
- [x] `bun run lint` — 0 errors for changed files (1 pre-existing warning in `preview-status.ts`)
- [ ] Manual smoke: launch `catalyst-hud`, verify two-press behavior in live mode, immediate-scope behavior when paused, and that footer/help copy reads "scope" everywhere.

## Research / Plan

- Research: `thoughts/shared/research/2026-05-14-CTL-388-hud-pivot-keys-live-mode.md`
- Plan: `thoughts/shared/plans/2026-05-14-CTL-388-hud-pivot-keys-force-visible-cursor.md`