### PR TITLE
feat(dev): expand REPO column coverage across canonical event emitters (CTL-385)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-comms.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-comms.test.sh
@@ -217,6 +217,63 @@ run "send succeeds when state script unavailable" bash -c "
   grep -q 'no events writer' '${CATALYST_COMMS_DIR}/channels/resilient-ch.jsonl'
 "
 
+# ── 19. send --repo stamps vcs.repository.name on fan-out event (CTL-385) ──
+reset_comms
+rm -rf "${CATALYST_DIR}/events"
+"$COMMS" join repo-flag-ch --as alice --ttl 300 > /dev/null
+MSG_ID_FLAG=$("$COMMS" send repo-flag-ch "explicit flag" \
+  --as alice --type info --repo "coalesce-labs/catalyst")
+EVENTS_FILE_FLAG="${CATALYST_DIR}/events/$(date -u +%Y-%m).jsonl"
+run "--repo flag stamps vcs.repository.name" bash -c "
+  jq -e --arg id '$MSG_ID_FLAG' \
+    'select(.attributes.\"event.name\" == \"comms.message.posted\" and .body.payload.msgId == \$id)
+       | .attributes.\"vcs.repository.name\" == \"coalesce-labs/catalyst\"' \
+    '$EVENTS_FILE_FLAG' >/dev/null
+"
+
+# ── 20. send falls back to $REPO env when --repo not passed (CTL-385) ──────
+reset_comms
+rm -rf "${CATALYST_DIR}/events"
+"$COMMS" join repo-env-ch --as alice --ttl 300 > /dev/null
+MSG_ID_ENV=$(REPO="coalesce-labs/from-env" \
+  "$COMMS" send repo-env-ch "env fallback" --as alice --type info)
+EVENTS_FILE_ENV="${CATALYST_DIR}/events/$(date -u +%Y-%m).jsonl"
+run "\$REPO env stamps vcs.repository.name when --repo omitted" bash -c "
+  jq -e --arg id '$MSG_ID_ENV' \
+    'select(.attributes.\"event.name\" == \"comms.message.posted\" and .body.payload.msgId == \$id)
+       | .attributes.\"vcs.repository.name\" == \"coalesce-labs/from-env\"' \
+    '$EVENTS_FILE_ENV' >/dev/null
+"
+
+# ── 21. --repo flag wins over $REPO env (CTL-385) ──────────────────────────
+reset_comms
+rm -rf "${CATALYST_DIR}/events"
+"$COMMS" join repo-prec-ch --as alice --ttl 300 > /dev/null
+MSG_ID_PREC=$(REPO="coalesce-labs/env-loser" \
+  "$COMMS" send repo-prec-ch "flag wins" --as alice --type info \
+  --repo "coalesce-labs/flag-winner")
+EVENTS_FILE_PREC="${CATALYST_DIR}/events/$(date -u +%Y-%m).jsonl"
+run "--repo flag overrides \$REPO env" bash -c "
+  jq -e --arg id '$MSG_ID_PREC' \
+    'select(.attributes.\"event.name\" == \"comms.message.posted\" and .body.payload.msgId == \$id)
+       | .attributes.\"vcs.repository.name\" == \"coalesce-labs/flag-winner\"' \
+    '$EVENTS_FILE_PREC' >/dev/null
+"
+
+# ── 22. no --repo, no $REPO: attribute absent (CTL-385) ────────────────────
+reset_comms
+rm -rf "${CATALYST_DIR}/events"
+"$COMMS" join repo-absent-ch --as alice --ttl 300 > /dev/null
+MSG_ID_ABS=$(unset REPO && "$COMMS" send repo-absent-ch "no repo" \
+  --as alice --type info)
+EVENTS_FILE_ABS="${CATALYST_DIR}/events/$(date -u +%Y-%m).jsonl"
+run "no repo source leaves vcs.repository.name unset" bash -c "
+  jq -e --arg id '$MSG_ID_ABS' \
+    'select(.attributes.\"event.name\" == \"comms.message.posted\" and .body.payload.msgId == \$id)
+       | (.attributes | has(\"vcs.repository.name\")) == false' \
+    '$EVENTS_FILE_ABS' >/dev/null
+"
+
 echo ""
 echo "Results: $PASSES passed, $FAILURES failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
@@ -187,6 +187,37 @@ else
   ok "emit-context errors on unknown session id"
 fi
 
+# ─── 11. $REPO env populates vcs.repository.name on session events (CTL-385) ─
+SID_REPO="$(bash "$SESSION_SCRIPT" start --skill repotest \
+            --claude-session-id "uuid-repo-1")"
+expect_not_empty "start returns id for REPO test" "$SID_REPO"
+
+REPO="coalesce-labs/catalyst" bash "$SESSION_SCRIPT" phase "$SID_REPO" \
+  "implementing" --phase 3 >/dev/null
+
+REPO_LINE="$(grep '"session.phase"' "$EF" | grep "$SID_REPO" | tail -n 1)"
+expect_not_empty "session.phase event recorded for REPO test" "$REPO_LINE"
+
+REPO_ATTR="$(printf '%s' "$REPO_LINE" | jq -r '.attributes."vcs.repository.name" // ""')"
+expect_eq "session.phase carries vcs.repository.name from \$REPO env" \
+  "coalesce-labs/catalyst" "$REPO_ATTR"
+
+# ─── 12. Absent $REPO leaves vcs.repository.name unset (CTL-385) ────────────
+SID_NOREPO="$(bash "$SESSION_SCRIPT" start --skill norepotest \
+              --claude-session-id "uuid-norepo-1")"
+expect_not_empty "start returns id for no-REPO test" "$SID_NOREPO"
+
+# Explicitly unset REPO so the parent shell's env doesn't leak in.
+(unset REPO && bash "$SESSION_SCRIPT" phase "$SID_NOREPO" \
+  "implementing" --phase 3 >/dev/null)
+
+NOREPO_LINE="$(grep '"session.phase"' "$EF" | grep "$SID_NOREPO" | tail -n 1)"
+expect_not_empty "session.phase event recorded for no-REPO test" "$NOREPO_LINE"
+
+NOREPO_HAS="$(printf '%s' "$NOREPO_LINE" | jq -r '.attributes | has("vcs.repository.name")')"
+expect_eq "session.phase omits vcs.repository.name when \$REPO unset" \
+  "false" "$NOREPO_HAS"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
 exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/catalyst-state.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-state.test.sh
@@ -267,6 +267,104 @@ else
   fail "no event JSONL written for no-repo test"
 fi
 
+# ─── Test 13: event_append extracts detail.repo (CTL-385) ───────────────────
+# Covers events that carry the repo nested inside `.detail` rather than at the
+# top level — e.g. `agent.checkin` from oneshot broker_claim_pr, or any
+# `filter.register` whose detail block names a repo.
+echo ""
+echo "--- Test 13: event_append falls back to detail.repo ---"
+export CATALYST_DIR="$SCRATCH/cat13"
+"$STATE_SCRIPT" init >/dev/null
+
+"$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-14T12:00:00Z",
+  orchestrator: "orch-ctl-test",
+  worker: "CTL-385",
+  event: "worker-done",
+  detail: { repo: "coalesce-labs/catalyst" }
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE13=$(ls "$SCRATCH/cat13/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE13" ]]; then
+  REPO=$(jq -r 'select(.attributes."event.name" == "orchestrator.worker.done") | .attributes."vcs.repository.name" // ""' "$EVENT_FILE13" | head -1)
+  assert_eq "coalesce-labs/catalyst" "$REPO" "detail.repo populates attributes[\"vcs.repository.name\"]"
+else
+  fail "no event JSONL written for detail.repo test"
+fi
+
+# ─── Test 14: event_append falls back to $REPO env (CTL-385) ────────────────
+# Covers synthesized emits inside catalyst-state.sh that build JSON without a
+# repo field (e.g. cmd_attention, cmd_archive). Orchestrator/worker contexts
+# can set $REPO once and every subsequent event picks it up.
+echo ""
+echo "--- Test 14: event_append falls back to \$REPO env var ---"
+export CATALYST_DIR="$SCRATCH/cat14"
+"$STATE_SCRIPT" init >/dev/null
+
+REPO="coalesce-labs/from-env" "$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-14T12:00:00Z",
+  orchestrator: "orch-env-test",
+  worker: "CTL-385",
+  event: "worker-done",
+  detail: null
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE14=$(ls "$SCRATCH/cat14/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE14" ]]; then
+  REPO=$(jq -r 'select(.attributes."event.name" == "orchestrator.worker.done") | .attributes."vcs.repository.name" // ""' "$EVENT_FILE14" | head -1)
+  assert_eq "coalesce-labs/from-env" "$REPO" "\$REPO env populates attributes[\"vcs.repository.name\"]"
+else
+  fail "no event JSONL written for \$REPO env test"
+fi
+unset REPO
+
+# ─── Test 15: precedence — top-level > detail.repo > $REPO env (CTL-385) ────
+echo ""
+echo "--- Test 15: top-level .repo overrides detail.repo and \$REPO env ---"
+export CATALYST_DIR="$SCRATCH/cat15"
+"$STATE_SCRIPT" init >/dev/null
+
+REPO="coalesce-labs/env-loser" "$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-14T12:00:00Z",
+  orchestrator: "orch-precedence",
+  worker: "CTL-385",
+  event: "worker-done",
+  repo: "coalesce-labs/top-winner",
+  detail: { repo: "coalesce-labs/detail-loser" }
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE15=$(ls "$SCRATCH/cat15/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE15" ]]; then
+  REPO=$(jq -r 'select(.attributes."event.name" == "orchestrator.worker.done") | .attributes."vcs.repository.name" // ""' "$EVENT_FILE15" | head -1)
+  assert_eq "coalesce-labs/top-winner" "$REPO" "top-level .repo beats detail.repo and \$REPO env"
+else
+  fail "no event JSONL written for precedence test"
+fi
+unset REPO
+
+# Confirm detail.repo beats $REPO env when top-level absent.
+echo ""
+echo "--- Test 16: detail.repo overrides \$REPO env when top-level absent ---"
+export CATALYST_DIR="$SCRATCH/cat16"
+"$STATE_SCRIPT" init >/dev/null
+
+REPO="coalesce-labs/env-loser" "$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-14T12:00:00Z",
+  orchestrator: "orch-detail-vs-env",
+  worker: "CTL-385",
+  event: "worker-done",
+  detail: { repo: "coalesce-labs/detail-winner" }
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE16=$(ls "$SCRATCH/cat16/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE16" ]]; then
+  REPO=$(jq -r 'select(.attributes."event.name" == "orchestrator.worker.done") | .attributes."vcs.repository.name" // ""' "$EVENT_FILE16" | head -1)
+  assert_eq "coalesce-labs/detail-winner" "$REPO" "detail.repo beats \$REPO env"
+else
+  fail "no event JSONL written for detail-vs-env test"
+fi
+unset REPO
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "══════════════════════════════════════════════"

--- a/plugins/dev/scripts/catalyst-comms
+++ b/plugins/dev/scripts/catalyst-comms
@@ -13,7 +13,7 @@
 #
 # Commands:
 #   join <ch> --as <name> [--capabilities S] [--parent P] [--orch O] [--ttl N] [--topic T]
-#   send <ch> <body> [--as <name>] [--type TYPE] [--to N|all] [--re MSG_ID] [--parent P] [--orch O]
+#   send <ch> <body> [--as <name>] [--type TYPE] [--to N|all] [--re MSG_ID] [--parent P] [--orch O] [--repo NAME]
 #   poll <ch> [--since N] [--filter-to N] [--wait] [--limit N]
 #   done <ch> --as <name>
 #   leave <ch> --as <name>
@@ -183,7 +183,7 @@ cmd_join() {
 }
 
 cmd_send() {
-  local channel="" body="" name="" type="info" to="all" re="" parent="" orch=""
+  local channel="" body="" name="" type="info" to="all" re="" parent="" orch="" repo=""
 
   [[ $# -lt 2 ]] && { echo "error: send requires <channel> <body>" >&2; return 1; }
   channel="$1"; shift
@@ -197,9 +197,14 @@ cmd_send() {
       --re)     re="$2"; shift 2 ;;
       --parent) parent="$2"; shift 2 ;;
       --orch)   orch="$2"; shift 2 ;;
+      --repo)   repo="$2"; shift 2 ;;
       *) echo "error: unknown send flag: $1" >&2; return 1 ;;
     esac
   done
+
+  # CTL-385: fall back to $REPO env when --repo not passed so workers don't
+  # have to thread the flag through every comms_post call site.
+  [[ -z "$repo" ]] && repo="${REPO:-}"
 
   require_flag "--as" "$name" || return 1
   require_channel "$channel" || return 1
@@ -282,6 +287,10 @@ cmd_send() {
     [[ -n "$orch" ]] && extra_args+=(--orch "$orch")
     [[ -n "$name" ]] && extra_args+=(--worker "$name")
     [[ -n "$value" ]] && extra_args+=(--value "$value")
+    # CTL-385: stamp vcs.repository.name when the sender knows its repo.
+    # `repo` is set on the enclosing cmd_send scope via --repo flag or the
+    # $REPO env fallback.
+    [[ -n "$repo" ]] && extra_args+=(--vcs-repo "$repo")
     local line
     line=$(build_canonical_line \
       --ts "$(now_iso)" \
@@ -581,9 +590,11 @@ Commands:
   join <ch> --as <name> [--capabilities S] [--parent P] [--orch O] [--ttl N] [--topic T]
       Join a channel (auto-creates if missing). Idempotent re-joins update lastSeen.
 
-  send <ch> <body> --as <name> [--type TYPE] [--to N|all] [--re MSG_ID]
+  send <ch> <body> --as <name> [--type TYPE] [--to N|all] [--re MSG_ID] [--repo NAME]
       Append a message to the channel log. Prints the message id to stdout.
-      TYPE is one of: proposal, question, answer, ack, info, attention, done
+      TYPE is one of: proposal, question, answer, ack, info, attention, done.
+      --repo NAME (or \$REPO env) stamps attributes["vcs.repository.name"] on
+      the canonical comms.message.posted event so the HUD's REPO column resolves.
 
   poll <ch> [--since N] [--filter-to N] [--wait] [--limit N]
       Stream matching messages to stdout as JSONL.

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -179,6 +179,11 @@ __session_emit_canonical() {
   [[ -n "$phase" ]] && extra_args+=(--phase "$phase")
   [[ -n "$vcs_pr" ]] && extra_args+=(--vcs-pr "$vcs_pr")
 
+  # CTL-385: read $REPO env to populate vcs.repository.name. Sessions table has
+  # no repo column; the env var is the lightweight shim — oneshot workers set
+  # REPO once at startup so every session.phase event carries it.
+  [[ -n "${REPO:-}" ]] && extra_args+=(--vcs-repo "$REPO")
+
   # CTL-374: attach claude.session.id when bound on the sessions row.
   local claude_sid
   claude_sid="$(__session_claude_id "$sid")"

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -178,11 +178,18 @@ event_append() {
   worker=$(echo "$input_json" | jq -r '.worker // ""')
   legacy_event=$(echo "$input_json" | jq -r '.event // ""')
   detail=$(echo "$input_json" | jq -c '.detail // null')
-  # CTL-362: optional vcs.repository.name. Accept either `.vcsRepo` (camelCase,
-  # preferred) or `.repo` (alias for parity with broker interest records). When
-  # set, gets stamped into attributes["vcs.repository.name"] so the HUD's REPO
-  # column populates for orchestrator-emitted events.
-  vcs_repo=$(echo "$input_json" | jq -r '.vcsRepo // .repo // ""')
+  # CTL-362 / CTL-385: optional vcs.repository.name. Precedence:
+  #   1. top-level `.vcsRepo` (preferred camelCase)
+  #   2. top-level `.repo` (alias for parity with broker interest records)
+  #   3. `.detail.repo` (covers agent.checkin from broker_claim_pr and any
+  #      filter.register whose detail block names a repo)
+  #   4. `$REPO` env var (fallback for synthesized emits inside this script
+  #      that build JSON without a repo field — cmd_attention, cmd_archive, etc.)
+  # When all are unset, the attribute stays absent from the canonical envelope.
+  vcs_repo=$(echo "$input_json" | jq -r '.vcsRepo // .repo // .detail.repo // ""')
+  if [[ -z "$vcs_repo" || "$vcs_repo" == "null" ]]; then
+    vcs_repo="${REPO:-}"
+  fi
   [[ -z "$ts" ]] && ts="$(now_iso)"
 
   local mapping name entity action severity


### PR DESCRIPTION
## Summary

Three bash emitters (`catalyst-state.sh`, `catalyst-session.sh`, `catalyst-comms`) now stamp `attributes["vcs.repository.name"]` when the repo is derivable from input JSON, an explicit flag, or the `$REPO` env. CTL-362 finished the schema + broker + Linear paths; this PR closes the bash-side gap so the HUD's REPO column resolves for `orchestrator.worker.*`, `session.phase`, `comms.message.posted`, and `filter.register` events that previously left it blank.

Linear: [CTL-385](https://linear.app/coalesce-labs/issue/CTL-385)
Research: `thoughts/shared/research/2026-05-14-CTL-385-repo-column-coverage.md`
Plan: `thoughts/shared/plans/2026-05-14-CTL-385-repo-column-coverage.md`

## Changes

* **`plugins/dev/scripts/catalyst-state.sh:event_append`** — `vcs_repo` extraction now walks `.vcsRepo // .repo // .detail.repo // $REPO`. The new `detail.repo` step covers `agent.checkin` events from `oneshot broker_claim_pr` and any `filter.register` whose detail block names a repo. The `$REPO` env fallback covers synthesized emits inside the script itself (`cmd_attention`, `cmd_archive`, `cmd_gc`'s orchestrator-failed event).
* **`plugins/dev/scripts/catalyst-session.sh:__session_emit_canonical`** — read `$REPO` env at emit time, pass `--vcs-repo` when set. No schema change to the sessions table.
* **`plugins/dev/scripts/catalyst-comms`** — `cmd_send` accepts new `--repo NAME` flag; falls back to `$REPO` env when omitted. Plumbed into `emit_canonical_comms_event` → `build_canonical_line --vcs-repo`. Usage strings updated.

## Out of scope (matches ticket § Out of scope)

* No schema change to multi-valued repo array.
* No new `repo` column on the sessions SQLite table — env var fallback is enough.
* No historical event backfill.
* Linear webhook handler — already done in CTL-362.
* Broker (all three wake paths) — already done in CTL-362.

## Test plan

* [x] `bash plugins/dev/scripts/__tests__/catalyst-state.test.sh` → 24/24
* [x] `bash plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh` → 30/30
* [x] `bash plugins/dev/scripts/__tests__/catalyst-comms.test.sh` → 32/32
* [x] `bash plugins/dev/scripts/__tests__/canonical-event.test.sh` → 46/46 (regression smoke)
* [x] `bash plugins/dev/scripts/__tests__/emit-otel-event.test.sh` → 22/0
* [x] `bash plugins/dev/scripts/__tests__/emit-worker-status-change.test.sh` → 45/0
* [x] `bash plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh` → 74/0
* [x] `bash plugins/dev/scripts/__tests__/orchestrate-comms-integration.test.sh` → 25/0
* [x] `bash plugins/meta/scripts/audit-references.sh --ci` → exit 0