### PR TITLE
feat(dev): --version flag on every catalyst-* CLI + commit hash (CTL-390)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-version.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-version.test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Shell tests for plugins/dev/scripts/lib/catalyst-version.sh (CTL-390).
+# Run: bash plugins/dev/scripts/__tests__/catalyst-version.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-version.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Each test seeds a fake plugin tree under $SCRATCH/<name>/plugins/dev/ and
+# invokes the helper via a freshly-sourced subshell. The subshell sets
+# BASH_SOURCE so the helper resolves the fake plugin root.
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    echo "    actual:"
+    printf '%s\n' "$haystack" | sed 's/^/      /'
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    must NOT contain: $needle"
+    echo "    actual:"
+    printf '%s\n' "$haystack" | sed 's/^/      /'
+  else
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  fi
+}
+
+# Build a fake plugin tree.
+#   $1 = scratch subdir name
+#   $2 = version.txt contents (use "" to skip the file)
+#   $3 = commit.txt contents (use "" to skip the file)
+#   $4 = "git" to create a .git dir at the tree root, "" otherwise
+# Echoes the fake script path so the test can pass it to the helper.
+make_fake_plugin() {
+  local name="$1" version="$2" commit="$3" git_flag="$4"
+  local root="$SCRATCH/$name"
+  local plugin="$root/plugins/dev"
+  mkdir -p "$plugin/.claude-plugin" "$plugin/scripts/lib"
+  echo '{"name":"catalyst-dev","version":"x"}' > "$plugin/.claude-plugin/plugin.json"
+  [[ -n "$version" ]] && printf '%s\n' "$version" > "$plugin/version.txt"
+  [[ -n "$commit"  ]] && printf '%s\n' "$commit"  > "$plugin/commit.txt"
+  if [[ "$git_flag" == "git" ]]; then
+    git -C "$root" init --quiet --initial-branch=test-branch 2>/dev/null || git -C "$root" init --quiet
+    git -C "$root" config user.email "t@t" 2>/dev/null
+    git -C "$root" config user.name  "t"   2>/dev/null
+    git -C "$root" checkout -B test-branch --quiet 2>/dev/null || true
+    : > "$root/seed"
+    git -C "$root" add seed 2>/dev/null
+    git -C "$root" commit --quiet -m "seed" 2>/dev/null
+  fi
+  # The "script" is a no-op file inside scripts/. Tests pass its path to
+  # catalyst_print_version as the second arg.
+  local fake="$plugin/scripts/catalyst-fake"
+  : > "$fake"
+  echo "$fake"
+}
+
+run_helper() {
+  local cli_name="$1" fake_script="$2"
+  # shellcheck disable=SC1090
+  ( . "$HELPER" && catalyst_print_version "$cli_name" "$fake_script" )
+}
+
+echo "catalyst-version tests"
+
+# ── 1. version.txt + commit.txt present, no .git → embedded commit ─────────
+fake=$(make_fake_plugin t1 "9.2.0" "abc123def456" "")
+out=$(run_helper "catalyst-events" "$fake")
+assert_contains "$out" "catalyst-events 9.2.0" "t1: prints version line"
+assert_contains "$out" "commit: abc123def456"  "t1: prints embedded commit"
+assert_not_contains "$out" "local:" "t1: no local: prefix when no .git"
+
+# ── 2. version.txt present, commit.txt absent, no .git → commit: unknown ───
+fake=$(make_fake_plugin t2 "9.2.0" "" "")
+out=$(run_helper "catalyst-broker" "$fake")
+assert_contains "$out" "catalyst-broker 9.2.0" "t2: prints version line"
+assert_contains "$out" "commit: unknown" "t2: falls back to commit: unknown"
+
+# ── 3. .git ancestor present → local: commit with branch ────────────────────
+if command -v git >/dev/null 2>&1; then
+  fake=$(make_fake_plugin t3 "9.2.0" "" "git")
+  out=$(run_helper "catalyst-hud" "$fake")
+  assert_contains "$out" "catalyst-hud 9.2.0" "t3: prints version line"
+  assert_contains "$out" "commit: local:" "t3: prefixes commit with local:"
+  assert_contains "$out" "worktree: test-branch" "t3: includes worktree branch"
+else
+  echo "  SKIP: t3 (git not available)"
+fi
+
+# ── 4. version.txt missing → version: unknown ───────────────────────────────
+fake=$(make_fake_plugin t4 "" "abc123" "")
+out=$(run_helper "catalyst-events" "$fake")
+assert_contains "$out" "catalyst-events unknown" "t4: version unknown when version.txt missing"
+
+# ── 5. whitespace trimmed in version.txt and commit.txt ─────────────────────
+fake=$(make_fake_plugin t5 "  9.2.0  " "  abc123  " "")
+out=$(run_helper "catalyst-comms" "$fake")
+assert_contains "$out" "catalyst-comms 9.2.0" "t5: version whitespace trimmed"
+assert_contains "$out" "commit: abc123" "t5: commit whitespace trimmed"
+
+# macOS resolves /var → /private/var; resolve expected paths the same way the
+# helper does so the equality holds on both Linux and macOS.
+_realpath() { cd -P "$1" 2>/dev/null && pwd; }
+
+# ── 6. source: line points to plugin root in non-git case ───────────────────
+fake=$(make_fake_plugin t6 "9.2.0" "abc123" "")
+out=$(run_helper "catalyst-events" "$fake")
+plugin_root=$(_realpath "${SCRATCH}/t6/plugins/dev")
+assert_contains "$out" "source: ${plugin_root}" "t6: source line points to plugin root"
+
+# ── 7. source: line points to script dir in local-source case ──────────────
+if command -v git >/dev/null 2>&1; then
+  fake=$(make_fake_plugin t7 "9.2.0" "" "git")
+  out=$(run_helper "catalyst-events" "$fake")
+  script_dir=$(_realpath "${SCRATCH}/t7/plugins/dev/scripts")
+  assert_contains "$out" "source: ${script_dir}" "t7: source is script dir when local"
+fi
+
+# ── 8. .git takes priority over commit.txt (worktree wins) ──────────────────
+if command -v git >/dev/null 2>&1; then
+  fake=$(make_fake_plugin t8 "9.2.0" "embedded-sha" "git")
+  out=$(run_helper "catalyst-events" "$fake")
+  assert_contains "$out" "commit: local:" "t8: .git overrides commit.txt"
+  assert_not_contains "$out" "embedded-sha" "t8: embedded ignored when .git present"
+fi
+
+# ── 9. exit 0 ──────────────────────────────────────────────────────────────
+fake=$(make_fake_plugin t9 "9.2.0" "abc" "")
+if run_helper "catalyst-events" "$fake" > /dev/null; then
+  PASSES=$((PASSES + 1)); echo "  PASS: t9: exit 0"
+else
+  FAILURES=$((FAILURES + 1)); echo "  FAIL: t9: exit non-zero"
+fi
+
+# ── 10. integration: invoke real catalyst-events --version ─────────────────
+# Verifies the early --version branch we inject into each CLI works end-to-end
+# from the actual installed scripts (sources lib/catalyst-version.sh, prints,
+# exits 0 — without touching the script's regular argv parsing).
+EVENTS_SCRIPT="${REPO_ROOT}/plugins/dev/scripts/catalyst-events"
+if [[ -x "$EVENTS_SCRIPT" ]]; then
+  out=$("$EVENTS_SCRIPT" --version 2>&1)
+  rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    PASSES=$((PASSES + 1)); echo "  PASS: t10: catalyst-events --version exits 0"
+  else
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: t10: exit=$rc"
+    printf '%s\n' "$out" | sed 's/^/      /'
+  fi
+  assert_contains "$out" "catalyst-events " "t10: prints catalyst-events line"
+  assert_contains "$out" "commit: "         "t10: prints commit line"
+  assert_contains "$out" "source: "         "t10: prints source line"
+
+  # -V short form
+  out_short=$("$EVENTS_SCRIPT" -V 2>&1)
+  assert_contains "$out_short" "catalyst-events " "t10: -V short form works"
+else
+  echo "  SKIP: t10 (catalyst-events not executable)"
+fi
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/install-cli.test.sh
+++ b/plugins/dev/scripts/__tests__/install-cli.test.sh
@@ -520,6 +520,44 @@ run "second install run produces identical rc file" bash -c "
   diff -q '$SCRATCH/zshrc-after-first' '$HOME28/.zshrc'
 "
 
+# ── 29. CTL-390: cache-mode wrappers handle --version with resolution path ──
+HOME29="$SCRATCH/home29"
+BIN29="$HOME29/.catalyst/bin"
+FAKE_CACHE29="$HOME29/.claude/plugins/cache/catalyst/catalyst-dev/9.2.0/scripts"
+mkdir -p "$BIN29" "$FAKE_CACHE29"
+# Seed the cached CLI so the wrapper's exec target exists.
+cat > "$FAKE_CACHE29/catalyst-events" <<'CLI'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" || "${1:-}" == "-V" ]]; then
+  echo "catalyst-events 9.2.0"
+  echo "commit: stub-sha"
+  echo "source: stub-source"
+  exit 0
+fi
+echo "stub real"
+CLI
+chmod +x "$FAKE_CACHE29/catalyst-events"
+# install-cli writes wrappers only when SOURCE_DIR is the cache.
+run "wrapper-mode: install + --version prints resolution + delegated version" bash -c "
+  HOME='$HOME29' CATALYST_CLI_SOURCE='$FAKE_CACHE29' CATALYST_BIN_DIR='$BIN29' \
+    $INSTALL_CLI > '$SCRATCH/out29' 2>&1
+  out=\$(HOME='$HOME29' '$BIN29/catalyst-events' --version)
+  echo \"\$out\" | grep -qF 'catalyst-events wrapper' \\
+    && echo \"\$out\" | grep -qF 'resolves to' \\
+    && echo \"\$out\" | grep -qF 'forwarding' \\
+    && echo \"\$out\" | grep -qF 'catalyst-events 9.2.0' \\
+    && echo \"\$out\" | grep -qF 'commit: stub-sha'
+"
+run "wrapper-mode: -V short form works" bash -c "
+  out=\$(HOME='$HOME29' '$BIN29/catalyst-events' -V)
+  echo \"\$out\" | grep -qF 'catalyst-events wrapper' \\
+    && echo \"\$out\" | grep -qF 'catalyst-events 9.2.0'
+"
+run "wrapper-mode: non-version args still forwarded to underlying CLI" bash -c "
+  out=\$(HOME='$HOME29' '$BIN29/catalyst-events' run)
+  echo \"\$out\" | grep -qF 'stub real'
+"
+
 # ── Summary ────────────────────────────────────────────────────────────────
 echo ""
 TOTAL=$((PASSES + FAILURES))

--- a/plugins/dev/scripts/catalyst-broker
+++ b/plugins/dev/scripts/catalyst-broker
@@ -15,6 +15,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-broker" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 PID_FILE="${BROKER_PID_FILE:-$CATALYST_DIR/broker.pid}"
 LOG_FILE="${BROKER_LOG_FILE:-$CATALYST_DIR/broker.log}"

--- a/plugins/dev/scripts/catalyst-claude.sh
+++ b/plugins/dev/scripts/catalyst-claude.sh
@@ -23,6 +23,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-claude" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 # ─── Locate catalyst-session.sh ──────────────────────────────────────────────
 
 SOURCE="${BASH_SOURCE[0]}"

--- a/plugins/dev/scripts/catalyst-comms
+++ b/plugins/dev/scripts/catalyst-comms
@@ -25,6 +25,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-comms" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -L "$SOURCE" ]; do
   DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"

--- a/plugins/dev/scripts/catalyst-db.sh
+++ b/plugins/dev/scripts/catalyst-db.sh
@@ -30,6 +30,22 @@
 
 set -euo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-db" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 DB_FILE="${CATALYST_DB_FILE:-$CATALYST_DIR/catalyst.db}"
 SOURCE="${BASH_SOURCE[0]}"

--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -27,6 +27,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-events" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 EVENTS_DIR="${CATALYST_EVENTS_DIR:-$CATALYST_DIR/events}"
 

--- a/plugins/dev/scripts/catalyst-filter
+++ b/plugins/dev/scripts/catalyst-filter
@@ -11,6 +11,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-filter" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"

--- a/plugins/dev/scripts/catalyst-hud
+++ b/plugins/dev/scripts/catalyst-hud
@@ -4,6 +4,19 @@
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 HUD_DIR="${SCRIPT_DIR}/orch-monitor"
 
+# CTL-390: --version handling (intercept before triggering bun install / exec).
+case "${1:-}" in
+  --version|-V)
+    if [[ -f "${SCRIPT_DIR}/lib/catalyst-version.sh" ]]; then
+      . "${SCRIPT_DIR}/lib/catalyst-version.sh"
+      catalyst_print_version "catalyst-hud" "${BASH_SOURCE[0]}"
+      exit 0
+    fi
+    echo "error: catalyst-version helper missing at ${SCRIPT_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 # Auto-install deps on first run after a plugin upgrade
 if [[ ! -d "${HUD_DIR}/node_modules" ]]; then
   echo "catalyst-hud: installing dependencies (first run after upgrade)…" >&2

--- a/plugins/dev/scripts/catalyst-hud-classic.sh
+++ b/plugins/dev/scripts/catalyst-hud-classic.sh
@@ -9,6 +9,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-hud-classic" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 R=$'\033[0m'
 BOLD=$'\033[1m'
 DIM=$'\033[2m'

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -10,6 +10,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-monitor" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 DEFAULT_PORT=7400
 PORT="${MONITOR_PORT:-$DEFAULT_PORT}"

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -48,6 +48,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-session" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 DB_FILE="${CATALYST_DB_FILE:-$CATALYST_DIR/catalyst.db}"
 EVENTS_DIR="${CATALYST_DIR}/events"

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -22,6 +22,22 @@
 
 set -euo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-state" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 STATE_FILE="${CATALYST_STATE_FILE:-$CATALYST_DIR/state.json}"
 LOCK_FILE="${STATE_FILE}.lock"

--- a/plugins/dev/scripts/catalyst-thoughts.sh
+++ b/plugins/dev/scripts/catalyst-thoughts.sh
@@ -18,6 +18,22 @@
 
 set -uo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing or stdin reads).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "catalyst-thoughts" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 CMD="${1:-}"
 shift || true
 

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -272,12 +272,22 @@ for entry in "${CLI_ENTRIES[@]}"; do
     # version at invocation time — survives plugin upgrades without re-install.
     # The first comment line is the WRAPPER_MARKER detection signal for the
     # ~/.local/bin sweep above.
+    # CTL-390: wrapper intercepts --version|-V, prints its own resolution path,
+    # then exec's the resolved CLI with --version so the underlying tool's
+    # three-line version block follows.
     {
       echo '#!/usr/bin/env bash'
       echo "# ${WRAPPER_MARKER} (version-auto) — do not edit"
       echo '_CACHE="${HOME}/.claude/plugins/cache/catalyst/catalyst-dev"'
       echo '_LATEST=$(ls -d "${_CACHE}"/[0-9]*.*.*/ 2>/dev/null | sort -V | tail -1 | sed '"'"'s|/$||'"'"')'
       echo '[[ -z "${_LATEST}" ]] && { echo "error: catalyst-dev plugin not found in ${_CACHE}" >&2; exit 1; }'
+      echo 'case "${1:-}" in --version|-V)'
+      echo "  echo \"${dest_name} wrapper (\${BASH_SOURCE[0]})\""
+      echo "  echo \"resolves to: \${_LATEST}/scripts/${src_name}\""
+      echo '  echo "forwarding to underlying CLI for full version info..."'
+      echo '  echo ""'
+      echo "  exec \"\${_LATEST}/scripts/${src_name}\" --version ;;"
+      echo 'esac'
       echo "exec \"\${_LATEST}/scripts/${src_name}\" \"\$@\""
     } > "$link"
     chmod +x "$link"

--- a/plugins/dev/scripts/lib/catalyst-version.sh
+++ b/plugins/dev/scripts/lib/catalyst-version.sh
@@ -1,0 +1,116 @@
+# catalyst-version.sh — shared version helper for catalyst-* CLIs (CTL-390).
+#
+# Sourced from each CLI's --version branch. Exposes a single function:
+#
+#   catalyst_print_version <cli-name> [script-path]
+#
+# Resolves the caller's plugin tree and prints three lines to stdout:
+#
+#   catalyst-<cli-name> <version>
+#   commit: <embedded-sha> | local:<sha> (worktree: <branch>) | unknown
+#   source: <plugin-root | script-dir>
+#
+# Priority for the commit hash:
+#   1. If a .git ancestor exists  → local:<sha>, source is the script's dir.
+#   2. Else if plugins/dev/commit.txt is non-empty → embedded sha.
+#   3. Else                                       → "unknown".
+#
+# Tests live at plugins/dev/scripts/__tests__/catalyst-version.test.sh.
+
+# Trim leading/trailing whitespace from a file's contents. Echoes empty when
+# the file is missing or empty. Avoids depending on GNU-only flags.
+_cv_read_trim() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  # tr strips spaces/tabs/newlines anywhere; for single-line files that's the
+  # right behavior (the file should contain one token).
+  tr -d '[:space:]' < "$file"
+}
+
+# Resolve the real (symlink-followed) path of $1. Uses readlink -f when
+# available, falls back to a portable loop.
+_cv_real_path() {
+  local path="$1"
+  if [[ -z "$path" ]]; then return 0; fi
+  # readlink -f works on Linux + macOS GNU coreutils; macOS BSD readlink does
+  # not. Try GNU first, then fall back.
+  local resolved
+  resolved=$(readlink -f "$path" 2>/dev/null) && [[ -n "$resolved" ]] && {
+    printf '%s' "$resolved"; return 0;
+  }
+  # Portable fallback — walk symlinks manually.
+  local p="$path" dir
+  while [[ -L "$p" ]]; do
+    dir=$(cd -P "$(dirname "$p")" 2>/dev/null && pwd) || break
+    p=$(readlink "$p" 2>/dev/null) || break
+    case "$p" in
+      /*) ;;
+      *) p="$dir/$p" ;;
+    esac
+  done
+  if [[ -e "$p" ]]; then
+    dir=$(cd -P "$(dirname "$p")" 2>/dev/null && pwd) || { printf '%s' "$path"; return 0; }
+    printf '%s/%s' "$dir" "$(basename "$p")"
+  else
+    printf '%s' "$path"
+  fi
+}
+
+catalyst_print_version() {
+  local cli_name="${1:-catalyst}"
+  # When called from a script's --version branch BASH_SOURCE[1] is the script
+  # itself; tests pass an explicit path as $2.
+  local script_path="${2:-${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}}"
+
+  local resolved script_dir
+  resolved=$(_cv_real_path "$script_path")
+  script_dir=$(cd -P "$(dirname "$resolved")" 2>/dev/null && pwd) || script_dir="$(dirname "$resolved")"
+
+  # Walk ancestors looking for:
+  #   plugin_root = first dir containing version.txt AND .claude-plugin/plugin.json
+  #   git_root    = first dir containing .git (dir or worktree file)
+  local search="$script_dir" plugin_root="" git_root=""
+  while [[ -n "$search" && "$search" != "/" ]]; do
+    if [[ -z "$plugin_root" && -f "$search/version.txt" && -f "$search/.claude-plugin/plugin.json" ]]; then
+      plugin_root="$search"
+    fi
+    if [[ -z "$git_root" && ( -d "$search/.git" || -f "$search/.git" ) ]]; then
+      git_root="$search"
+    fi
+    [[ -n "$plugin_root" && -n "$git_root" ]] && break
+    search=$(dirname "$search")
+  done
+
+  local version="unknown"
+  if [[ -n "$plugin_root" ]]; then
+    local v
+    v=$(_cv_read_trim "$plugin_root/version.txt")
+    [[ -n "$v" ]] && version="$v"
+  fi
+
+  local commit="unknown" worktree_note="" source_path
+  source_path="${plugin_root:-$script_dir}"
+
+  if [[ -n "$git_root" ]] && command -v git >/dev/null 2>&1; then
+    local sha branch
+    sha=$(git -C "$git_root" rev-parse HEAD 2>/dev/null || true)
+    branch=$(git -C "$git_root" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    if [[ -n "$sha" ]]; then
+      commit="local:${sha}"
+      if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
+        worktree_note=" (worktree: ${branch})"
+      fi
+      source_path="$script_dir"
+    fi
+  fi
+
+  if [[ "$commit" == "unknown" && -n "$plugin_root" ]]; then
+    local embedded
+    embedded=$(_cv_read_trim "$plugin_root/commit.txt")
+    [[ -n "$embedded" ]] && commit="$embedded"
+  fi
+
+  printf '%s %s\n' "$cli_name" "$version"
+  printf 'commit: %s%s\n' "$commit" "$worktree_note"
+  printf 'source: %s\n' "$source_path"
+}

--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -13,6 +13,13 @@ interface HeaderProps {
   columns?: number;
   nlQuery?: string;
   brokerState?: BrokerState | null;
+  /**
+   * CTL-390: optional plugin-version chip shown at the right of the chip row.
+   * `display` is the short label (e.g. "v9.2.0" or "v9.2.0 · local:523b6fe");
+   * `isLocal` switches the chip to a yellow accent so hot-patched / worktree
+   * source is visually distinct from a clean release.
+   */
+  version?: { display: string; isLocal: boolean };
 }
 
 // CTL-351: match EventRow's per-column 1-col right margin so the header
@@ -20,15 +27,18 @@ interface HeaderProps {
 // CTL-352: brokerState replaces brokerKeyHealth — same shape plus liveness
 // fields for the new interests pill. The chip row renders whenever either
 // Groq or interest data is available.
-export function Header({ columns = 120, nlQuery, brokerState }: HeaderProps) {
+// CTL-390: the row also renders when a version chip is provided, so users
+// always see which catalyst-dev build their HUD is on.
+export function Header({ columns = 120, nlQuery, brokerState, version }: HeaderProps) {
   const sep = "─".repeat(Math.max(0, columns - 1));
   const groq = brokerState?.groq;
   const interestStatus = brokerInterestStatus(brokerState ?? null);
   const showInterestChip = interestStatus !== "unknown";
+  const showVersionChip = version !== undefined;
   const w = computeColumnWidths(columns);
   return (
     <Box flexDirection="column">
-      {(groq || showInterestChip) && (
+      {(groq || showInterestChip || showVersionChip) && (
         <Box flexDirection="row">
           {groq && (
             <Text color={chipColor(groq.probeStatus)}>{`[Groq: ${chipLabel(groq.probeStatus)}]`}</Text>
@@ -42,6 +52,11 @@ export function Header({ columns = 120, nlQuery, brokerState }: HeaderProps) {
               inverse={interestStatus === "degraded"}
             >
               {`${groq ? "  " : ""}[broker: ${interestChipLabel(brokerState ?? null, interestStatus)}]`}
+            </Text>
+          )}
+          {showVersionChip && (
+            <Text color={version.isLocal ? "yellow" : "gray"}>
+              {`${(groq || showInterestChip) ? "  " : ""}[${version.display}]`}
             </Text>
           )}
         </Box>

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -28,6 +28,7 @@ import {
 } from "../../lib/dsl-compile.mjs";
 import { buildSystemPrompt } from "../../lib/dsl-prompt.mjs";
 import type { CanonicalEvent } from "../lib/canonical-event.ts";
+import { readPluginVersion, formatVersionBlock } from "./lib/version.ts";
 
 interface AppProps {
   repoFilter: string;
@@ -146,13 +147,19 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
     return () => clearInterval(id);
   }, []);
 
+  // CTL-390: plugin version chip. Resolved once at startup — release-please
+  // bumps version.txt + commit.txt only between HUD invocations.
+  const versionChip = useRef(readPluginVersion()).current;
+
   const [dslState, setDslState] = useState<DslState | null>(null);
   const dslPredicate: DslPredicate = dslState?.jsPredicate ?? null;
   const { filterText, setFilterText, pivot, setPivot, filtered } = useFilter(events, dslPredicate);
 
   // Header = optional chip row (0/1) + column row (1) + separator (1) + optional nlQuery row (0/1)
   // CTL-352: chip row is shown whenever Groq or broker-interest data is available.
-  const hasChipRow = Boolean(brokerState?.groq) || typeof brokerState?.interestCount === "number";
+  // CTL-390: the version chip is always present (resolved once at startup),
+  // so the chip row is always rendered.
+  const hasChipRow = true;
   const headerRows = (hasChipRow ? 1 : 0) + (dslState?.nlQuery ? 3 : 2);
 
   const [showDslOverlay, setShowDslOverlay] = useState(false);
@@ -382,7 +389,12 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   return (
     <Box flexDirection="column" height={layoutRows} width={cols}>
       <Box flexShrink={0}>
-        <Header columns={cols} nlQuery={dslState?.nlQuery} brokerState={brokerState} />
+        <Header
+          columns={cols}
+          nlQuery={dslState?.nlQuery}
+          brokerState={brokerState}
+          version={{ display: versionChip.display, isLocal: versionChip.isLocal }}
+        />
       </Box>
       <Box flexDirection="column" flexGrow={(inDetailMode || showHelp) ? 0 : 1} flexShrink={1}>
         <EventList
@@ -478,6 +490,12 @@ for (let i = 0; i < args.length; i++) {
     console.info("");
     console.info("Press h inside the HUD for interactive keybinding help.");
     console.info("TIME examples: 24h  7d  2h  30m  2026-05-01");
+    process.exit(0);
+  } else if (arg === "--version" || arg === "-V") {
+    // CTL-390: mirror the bash helper's three-line output. The bash wrapper
+    // (catalyst-hud) intercepts this first; we keep the TS handler so
+    // `bun run cli/hud.tsx --version` from the worktree still works.
+    console.info(formatVersionBlock("catalyst-hud", readPluginVersion()));
     process.exit(0);
   }
 }

--- a/plugins/dev/scripts/orch-monitor/cli/lib/version.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/version.test.ts
@@ -1,0 +1,141 @@
+// version.test.ts — tests for the HUD's plugin-version helper (CTL-390).
+// Run from plugins/dev/scripts/orch-monitor: bun test cli/lib/version.test.ts
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  readPluginVersion,
+  buildDisplay,
+  formatVersionBlock,
+} from "./version.ts";
+
+const gitAvailable = (() => {
+  const r = spawnSync("git", ["--version"], { encoding: "utf8" });
+  return r.status === 0;
+})();
+
+// Build a fake plugin tree at $root with the given version.txt + commit.txt.
+// Returns the script directory the HUD would start from.
+function seedFakePlugin(
+  root: string,
+  opts: { version?: string; commit?: string; gitInit?: boolean },
+): string {
+  const plugin = join(root, "plugins", "dev");
+  mkdirSync(join(plugin, ".claude-plugin"), { recursive: true });
+  mkdirSync(join(plugin, "scripts", "orch-monitor", "cli", "lib"), { recursive: true });
+  writeFileSync(
+    join(plugin, ".claude-plugin", "plugin.json"),
+    '{"name":"catalyst-dev","version":"x"}',
+  );
+  if (opts.version !== undefined) {
+    writeFileSync(join(plugin, "version.txt"), `${opts.version}\n`);
+  }
+  if (opts.commit !== undefined) {
+    writeFileSync(join(plugin, "commit.txt"), `${opts.commit}\n`);
+  }
+  if (opts.gitInit === true) {
+    spawnSync("git", ["init", "--quiet", root], { encoding: "utf8" });
+    spawnSync("git", ["-C", root, "config", "user.email", "t@t"], { encoding: "utf8" });
+    spawnSync("git", ["-C", root, "config", "user.name", "t"], { encoding: "utf8" });
+    spawnSync("git", ["-C", root, "checkout", "-B", "test-branch", "--quiet"], {
+      encoding: "utf8",
+    });
+    writeFileSync(join(root, "seed"), "x");
+    spawnSync("git", ["-C", root, "add", "seed"], { encoding: "utf8" });
+    spawnSync("git", ["-C", root, "commit", "--quiet", "-m", "seed"], { encoding: "utf8" });
+  }
+  return join(plugin, "scripts", "orch-monitor", "cli", "lib");
+}
+
+describe("readPluginVersion", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "ctl390-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("returns embedded version + commit when no .git ancestor", () => {
+    const start = seedFakePlugin(tmp, { version: "9.2.0", commit: "abc123def" });
+    const info = readPluginVersion(start);
+    expect(info.version).toBe("9.2.0");
+    expect(info.commit).toBe("abc123def");
+    expect(info.isLocal).toBe(false);
+    expect(info.worktreeBranch).toBeNull();
+    expect(info.sourcePath).toBe(join(tmp, "plugins", "dev"));
+  });
+
+  test("commit defaults to 'unknown' when commit.txt missing", () => {
+    const start = seedFakePlugin(tmp, { version: "9.2.0" });
+    const info = readPluginVersion(start);
+    expect(info.commit).toBe("unknown");
+  });
+
+  test("version defaults to 'unknown' when version.txt missing", () => {
+    const start = seedFakePlugin(tmp, { commit: "abc123" });
+    const info = readPluginVersion(start);
+    expect(info.version).toBe("unknown");
+  });
+
+  test.skipIf(!gitAvailable)(".git ancestor wins, prefixing commit with local:", () => {
+    const start = seedFakePlugin(tmp, { version: "9.2.0", commit: "release-sha", gitInit: true });
+    const info = readPluginVersion(start);
+    expect(info.isLocal).toBe(true);
+    expect(info.commit.startsWith("local:")).toBe(true);
+    // The embedded commit.txt is ignored when .git is present.
+    expect(info.commit).not.toBe("release-sha");
+    expect(info.worktreeBranch).toBe("test-branch");
+    expect(info.sourcePath).toBe(start);
+  });
+
+  test("trims whitespace from version.txt and commit.txt", () => {
+    const start = seedFakePlugin(tmp, { version: "  9.2.0\n", commit: "  abc\t" });
+    const info = readPluginVersion(start);
+    expect(info.version).toBe("9.2.0");
+    expect(info.commit).toBe("abc");
+  });
+});
+
+describe("buildDisplay", () => {
+  test("plain release", () => {
+    expect(buildDisplay("9.2.0", "0e4e26774742396c9acea7056b1989a4e74a8be2", false))
+      .toBe("v9.2.0 · 0e4e267");
+  });
+  test("local source", () => {
+    expect(buildDisplay("9.2.0", "local:523b6feef68496136446a51020256e4aed327185", true))
+      .toBe("v9.2.0 · local:523b6fe");
+  });
+  test("unknown commit drops the dot separator", () => {
+    expect(buildDisplay("9.2.0", "unknown", false)).toBe("v9.2.0");
+  });
+});
+
+describe("formatVersionBlock", () => {
+  test("renders the three-line shape the bash helper prints", () => {
+    const block = formatVersionBlock("catalyst-hud", {
+      version: "9.2.0",
+      commit: "local:523b6fe",
+      isLocal: true,
+      worktreeBranch: "feat/branch",
+      sourcePath: "/p",
+      display: "v9.2.0 · local:523b6fe",
+    });
+    expect(block).toBe(
+      "catalyst-hud 9.2.0\n" +
+      "commit: local:523b6fe (worktree: feat/branch)\n" +
+      "source: /p",
+    );
+  });
+  test("omits worktree note when branch is null", () => {
+    const block = formatVersionBlock("catalyst-hud", {
+      version: "9.2.0",
+      commit: "abc",
+      isLocal: false,
+      worktreeBranch: null,
+      sourcePath: "/p",
+      display: "v9.2.0 · abc",
+    });
+    expect(block).toBe("catalyst-hud 9.2.0\ncommit: abc\nsource: /p");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/version.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/version.ts
@@ -1,0 +1,144 @@
+// version.ts — read plugin version + commit info for the HUD (CTL-390).
+//
+// Mirrors plugins/dev/scripts/lib/catalyst-version.sh:
+//   - Walks ancestors of this file looking for the plugin root (version.txt +
+//     .claude-plugin/plugin.json) and a .git ancestor.
+//   - Local source wins: when a .git ancestor exists, prefix the SHA with
+//     "local:" and use the script directory as the source path.
+//   - Otherwise read commit.txt for the embedded release SHA.
+//   - Falls back to "unknown" for missing values.
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+export interface PluginVersionInfo {
+  /** Plugin version (e.g. "9.2.0") or "unknown". */
+  version: string;
+  /** Commit hash. Either a raw SHA, "local:<sha>", or "unknown". */
+  commit: string;
+  /** True when a .git ancestor was found (worktree / local source). */
+  isLocal: boolean;
+  /** Worktree branch when isLocal is true and the branch is not detached. */
+  worktreeBranch: string | null;
+  /** Plugin root if found, otherwise the start directory. */
+  sourcePath: string;
+  /**
+   * Display label for the HUD chip:
+   *   "v9.2.0"           — release / no commit detected
+   *   "v9.2.0 · 523b6fe" — release with embedded SHA
+   *   "v9.2.0 · local:523b6fe" — local source
+   */
+  display: string;
+}
+
+function readTrim(path: string): string | null {
+  try {
+    if (!statSync(path).isFile()) return null;
+    const txt = readFileSync(path, "utf8").trim();
+    return txt.length > 0 ? txt : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Walk ancestors looking for the plugin root and a .git ancestor. */
+function findRoots(start: string): { pluginRoot: string | null; gitRoot: string | null } {
+  let pluginRoot: string | null = null;
+  let gitRoot: string | null = null;
+  let dir = start;
+  // Loop until we hit the filesystem root.
+  for (let i = 0; i < 32; i++) {
+    if (
+      pluginRoot === null
+      && existsSync(resolve(dir, "version.txt"))
+      && existsSync(resolve(dir, ".claude-plugin", "plugin.json"))
+    ) {
+      pluginRoot = dir;
+    }
+    if (gitRoot === null && existsSync(resolve(dir, ".git"))) {
+      gitRoot = dir;
+    }
+    if (pluginRoot !== null && gitRoot !== null) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return { pluginRoot, gitRoot };
+}
+
+function gitRevParse(root: string, args: string[]): string | null {
+  try {
+    const res = spawnSync("git", ["-C", root, "rev-parse", ...args], {
+      encoding: "utf8",
+      timeout: 1000,
+    });
+    if (res.status !== 0) return null;
+    const out = (res.stdout ?? "").trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve plugin version info starting from `startPath`. Defaults to the
+ * directory of this module so the HUD's call site can omit it.
+ */
+export function readPluginVersion(startPath?: string): PluginVersionInfo {
+  const here = startPath ?? dirname(fileURLToPath(import.meta.url));
+  const { pluginRoot, gitRoot } = findRoots(here);
+
+  const version = pluginRoot
+    ? (readTrim(resolve(pluginRoot, "version.txt")) ?? "unknown")
+    : "unknown";
+
+  let commit = "unknown";
+  let isLocal = false;
+  let worktreeBranch: string | null = null;
+  let sourcePath: string = pluginRoot ?? here;
+
+  if (gitRoot !== null) {
+    const sha = gitRevParse(gitRoot, ["HEAD"]);
+    if (sha !== null) {
+      commit = `local:${sha}`;
+      isLocal = true;
+      sourcePath = here;
+      const branch = gitRevParse(gitRoot, ["--abbrev-ref", "HEAD"]);
+      if (branch !== null && branch !== "HEAD") {
+        worktreeBranch = branch;
+      }
+    }
+  }
+  if (commit === "unknown" && pluginRoot !== null) {
+    const embedded = readTrim(resolve(pluginRoot, "commit.txt"));
+    if (embedded !== null) commit = embedded;
+  }
+
+  const display = buildDisplay(version, commit, isLocal);
+  return { version, commit, isLocal, worktreeBranch, sourcePath, display };
+}
+
+/** Build the short display label for the HUD chip. */
+export function buildDisplay(version: string, commit: string, isLocal: boolean): string {
+  if (commit === "unknown") return `v${version}`;
+  if (isLocal) {
+    // commit is "local:<full-sha>" — abbreviate to 7 chars after the prefix.
+    const sha = commit.startsWith("local:") ? commit.slice(6) : commit;
+    return `v${version} · local:${sha.slice(0, 7)}`;
+  }
+  return `v${version} · ${commit.slice(0, 7)}`;
+}
+
+/** Format the three-line stdout block matching the bash helper's output. */
+export function formatVersionBlock(cliName: string, info: PluginVersionInfo): string {
+  const worktreeNote = info.worktreeBranch !== null
+    ? ` (worktree: ${info.worktreeBranch})`
+    : "";
+  return [
+    `${cliName} ${info.version}`,
+    `commit: ${info.commit}${worktreeNote}`,
+    `source: ${info.sourcePath}`,
+  ].join("\n");
+}

--- a/plugins/dev/scripts/register-thought.sh
+++ b/plugins/dev/scripts/register-thought.sh
@@ -8,6 +8,22 @@
 
 set -euo pipefail
 
+# CTL-390: --version handling (must run before the stdin read below).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "register-thought" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 INPUT=$(cat 2>/dev/null || true)
 [[ -z "$INPUT" ]] && exit 0
 

--- a/plugins/dev/scripts/workflow-context.sh
+++ b/plugins/dev/scripts/workflow-context.sh
@@ -3,6 +3,22 @@
 
 set -euo pipefail
 
+# CTL-390: --version handling (early, before any arg parsing).
+case "${1:-}" in
+  --version|-V)
+    _CV_SRC="${BASH_SOURCE[0]}"
+    while [[ -L "$_CV_SRC" ]]; do
+      _CV_D="$(cd -P "$(dirname "$_CV_SRC")" && pwd)" && _CV_SRC="$(readlink "$_CV_SRC")"
+      [[ "$_CV_SRC" != /* ]] && _CV_SRC="$_CV_D/$_CV_SRC"
+    done
+    _CV_DIR="$(cd -P "$(dirname "$_CV_SRC")" && pwd)"
+    [[ -f "${_CV_DIR}/lib/catalyst-version.sh" ]] && . "${_CV_DIR}/lib/catalyst-version.sh" \
+      && catalyst_print_version "workflow-context" "${BASH_SOURCE[0]}" && exit 0
+    echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
+    exit 1
+    ;;
+esac
+
 # Resolve project root from git, then fall back to CWD
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 


### PR DESCRIPTION
## Summary

Every `catalyst-*` CLI accepts `--version` / `-V`. The output identifies the build the user is actually running — version + commit (release SHA or `local:<sha>` for worktree source) + resolved source path.

The original use case: a user sees an HUD bug, gets told "fixed in 9.2.0", and reasonably asks "well how do I know that's what I'm running?" — and there was no way to check. Now there is. Hot-patched cache and worktree-mode invocations are visually distinguished from clean releases.

## What ships

- **Shared bash helper** at `plugins/dev/scripts/lib/catalyst-version.sh` exposing `catalyst_print_version <cli-name>`. Walks ancestors of the caller to find the plugin root (version.txt + `.claude-plugin/plugin.json`) and a `.git` ancestor. Local source wins.
- **14 CLI scripts wired up**: catalyst-broker, catalyst-claude, catalyst-comms, catalyst-db, catalyst-events, catalyst-filter, catalyst-hud, catalyst-hud-classic, catalyst-monitor, catalyst-session, catalyst-state, catalyst-thoughts, register-thought, workflow-context. Each gets the same early `case` block (before any stdin read or argv parsing).
- **Wrapper template update** in `install-cli.sh`: the generated `~/.catalyst/bin/catalyst-*` wrapper intercepts `--version` to print its own resolution path before exec'ing the underlying CLI with `--version`. Surfaces exactly the original confusion case (`./catalyst-hud` from worktree vs `catalyst-hud` from PATH).
- **HUD chip** in `orch-monitor/cli/components/Header.tsx`. Gray `[v9.2.0]` for releases, yellow `[v9.2.0 · local:523b6fe]` when running from a worktree. Resolved once at App mount via `orch-monitor/cli/lib/version.ts` (TS port of the bash helper).
- **`plugins/dev/commit.txt`** placeholder (empty). The release-please workflow change to stamp this with the merge SHA needs `workflow` OAuth scope — that ships as a follow-up. Until then, clean release installs print `commit: unknown` per the ticket's section 2.3.

## Verification

```bash
$ ./plugins/dev/scripts/catalyst-events --version
catalyst-events 9.2.0
commit: local:0e4e26774742396c9acea7056b1989a4e74a8be2 (worktree: o-ctl-383-...-CTL-390)
source: /Users/ryan/catalyst/wt/catalyst-workspace/.../plugins/dev/scripts

$ ~/.catalyst/bin/catalyst-events --version    # via cache wrapper
catalyst-events wrapper (/Users/ryan/.catalyst/bin/catalyst-events)
resolves to: /Users/ryan/.claude/plugins/cache/catalyst/catalyst-dev/9.2.0/scripts/catalyst-events
forwarding to underlying CLI for full version info...

catalyst-events 9.2.0
commit: unknown
source: /Users/ryan/.claude/plugins/cache/catalyst/catalyst-dev/9.2.0
```

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/catalyst-version.test.sh` — 21/21 (helper logic: embedded SHA, worktree detection, branch capture, whitespace trim, file-missing fallbacks)
- [x] `bash plugins/dev/scripts/__tests__/install-cli.test.sh` — 59/59 (3 new wrapper-mode tests + 56 pre-existing)
- [x] `cd plugins/dev/scripts/orch-monitor && bun run typecheck && bun test cli/lib/version.test.ts` — 10/10 (TS helper)
- [x] Smoke test all 14 installed CLIs with both `--version` and `-V` — all green
- [x] No reward-hacking patterns (`as any`, `@ts-ignore`, etc.) in new TS code
- [ ] CI typecheck + lint + tests on Linux

## Follow-up (separate PR — needs `workflow` OAuth scope)

`.github/workflows/release-please.yml`: add a `stamp-commit-hash` job gated on `releases_created` that writes `${{ github.sha }}` into each released plugin's commit.txt and pushes with `[skip ci]`. Because tags are immutable, the stamped SHA appears in the NEXT release's tarball — that's enough fingerprint for "are these two installs identical."

## Out of scope (per ticket)

- `catalyst doctor` aggregate command.
- Migration to a single multi-command binary.
- Reading version from `plugin.json` instead of `version.txt`.