### PR TITLE
feat(dev): HUD — show raw event.name in EVENT column; split icon into its own 1-char column (CTL-391)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
@@ -109,9 +109,13 @@ describe("computeColumnWidths", () => {
   // CTL-364: SOURCE column dropped; EVENT column grew + became responsive so
   // the merged `${glyph} ${label}` content (longest: "CTL-330: attention" with
   // a 2-char glyph prefix = 20 chars) always fits without truncation.
-  test("event column has no minimum below 22 and caps at 30 on wide terminals", () => {
-    expect(computeColumnWidths(80).event).toBeGreaterThanOrEqual(22);
-    expect(computeColumnWidths(400).event).toBeLessThanOrEqual(30);
+  // CTL-391: EVENT now carries the raw event.name. Raw names are longer
+  // than the legacy labels (`github.pr_review_comment.created` is 32 chars,
+  // `filter.wake.<sessionId>` is 44+) so the responsive range grows to
+  // 24–40 — EVENT is the most informative column on the row.
+  test("event column has no minimum below 24 and caps at 40 on wide terminals", () => {
+    expect(computeColumnWidths(80).event).toBeGreaterThanOrEqual(24);
+    expect(computeColumnWidths(400).event).toBeLessThanOrEqual(40);
   });
 
   test("event column grows monotonically with terminal width", () => {
@@ -122,6 +126,16 @@ describe("computeColumnWidths", () => {
     expect(w160).toBeGreaterThanOrEqual(w80);
     expect(w240).toBeGreaterThanOrEqual(w160);
     expect(w400).toBeGreaterThanOrEqual(w240);
+  });
+
+  // CTL-391: 1-cell ICON column to the left of EVENT carries the source-family
+  // Nerd Font glyph. Always rendered — even at the narrowest supported width
+  // and even when no Nerd Font is detected — so columns stay aligned across
+  // rows regardless of which events the terminal has rendered so far.
+  test("icon column is a fixed 1 cell at every terminal width", () => {
+    for (const cols of [80, 100, 160, 180, 200, 300, 400]) {
+      expect(computeColumnWidths(cols).icon).toBe(1);
+    }
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx
@@ -1,8 +1,9 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import type { ReactElement, ReactNode } from "react";
 import { EventRow } from "../cli/components/EventRow.tsx";
-import { formatDetails } from "../cli/lib/format.ts";
+import { formatDetails, formatEvent, formatIcon } from "../cli/lib/format.ts";
 import { computeColumnWidths } from "../cli/lib/column-widths.ts";
+import { _resetNerdFontCacheForTesting } from "../cli/lib/nerd-font.ts";
 import type { CanonicalEvent } from "../lib/canonical-event.ts";
 
 // CTL-361: long DETAILS strings must never reflow onto the next terminal line.
@@ -206,5 +207,181 @@ describe("EventRow ORCH cell (CTL-383)", () => {
     if (!orchText) throw new Error("ORCH Text node not found");
     const children = (orchText.props as { children?: unknown }).children;
     expect(children).toBe(longOrchId);
+  });
+});
+
+// CTL-391: ICON column is the first Box in the row with width === w.icon (1).
+// Walk the tree and capture every Box's width + child Text content so tests
+// can assert structural ordering and content independently.
+interface CellSnapshot {
+  width: number;
+  text: string;
+  wrap?: string;
+}
+
+function collectFixedWidthCells(root: ReactNode): CellSnapshot[] {
+  // Ink's <Box> defaults flexGrow to 0, so a fixed-width cell has both an
+  // explicit width and flexGrow === 0 (or unset). The DETAILS Box opts in
+  // with flexGrow === 1 — exclude it here so this helper isolates the
+  // fixed-width column row.
+  const cells: CellSnapshot[] = [];
+  function isReactElement(node: unknown): node is ReactElement {
+    return typeof node === "object" && node !== null && "props" in node && "type" in node;
+  }
+  function walk(node: ReactNode): void {
+    if (!isReactElement(node)) return;
+    const props = node.props as {
+      width?: number;
+      flexGrow?: number;
+      children?: ReactNode;
+    };
+    if (typeof props.width === "number" && props.flexGrow !== 1) {
+      const child = props.children;
+      if (isReactElement(child)) {
+        const childProps = child.props as { children?: unknown; wrap?: string };
+        const text = typeof childProps.children === "string" ? childProps.children : "";
+        cells.push({ width: props.width, text, wrap: childProps.wrap });
+      }
+    }
+    const children = props.children;
+    if (Array.isArray(children)) {
+      for (const c of children) walk(c as ReactNode);
+    } else if (children !== undefined && children !== null) {
+      walk(children);
+    }
+  }
+  walk(root);
+  return cells;
+}
+
+describe("EventRow ICON + EVENT columns (CTL-391)", () => {
+  const prevEnv = process.env.CATALYST_NERD_FONT;
+  beforeAll(() => {
+    process.env.CATALYST_NERD_FONT = "0";
+    _resetNerdFontCacheForTesting();
+  });
+  afterAll(() => {
+    if (prevEnv === undefined) delete process.env.CATALYST_NERD_FONT;
+    else process.env.CATALYST_NERD_FONT = prevEnv;
+    _resetNerdFontCacheForTesting();
+  });
+
+  const ghEvent: CanonicalEvent = {
+    ts: "2026-05-14T13:40:00.000Z",
+    id: "22222222-3333-4444-8555-666666666666",
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: null,
+    spanId: null,
+    resource: {
+      "service.name": "test",
+      "service.namespace": "catalyst",
+      "service.version": "0.0.0",
+    },
+    attributes: {
+      "event.name": "github.pr.merged",
+      "vcs.repository.name": "coalesce-labs/catalyst",
+      "vcs.pr.number": 501,
+    },
+    body: { message: "PR merged", payload: {} },
+  };
+
+  // Helper: assert a cell was found, narrowing the type for the test body.
+  // The fixed-width cell collector returns `CellSnapshot | undefined` (from
+  // Array#find), so the test asserts presence first and then reads fields.
+  function mustExist(cell: CellSnapshot | undefined, label: string): CellSnapshot {
+    if (cell === undefined) throw new Error(`expected to find cell: ${label}`);
+    return cell;
+  }
+
+  test("renders ICON cell (width 1) immediately before EVENT cell", () => {
+    const element = EventRow({ event: ghEvent, selected: false, columns: 200, paused: true });
+    const cells = collectFixedWidthCells(element);
+    const widths = computeColumnWidths(200);
+    const iconIdx = cells.findIndex((c) => c.width === widths.icon && c.width === 1);
+    expect(iconIdx).toBeGreaterThanOrEqual(0);
+    // The cell immediately after the ICON column must be EVENT (width matches
+    // the computed EVENT width and its Text uses wrap="truncate").
+    const eventCell = mustExist(cells[iconIdx + 1], "EVENT cell after ICON");
+    expect(eventCell.width).toBe(widths.event);
+    expect(eventCell.wrap).toBe("truncate");
+  });
+
+  test("ICON cell renders the formatIcon output (blank when no Nerd Font)", () => {
+    const element = EventRow({ event: ghEvent, selected: false, columns: 200, paused: true });
+    const cells = collectFixedWidthCells(element);
+    const iconCell = mustExist(cells.find((c) => c.width === 1), "ICON cell");
+    // CATALYST_NERD_FONT=0 → formatIcon returns "" so the cell text is empty.
+    expect(iconCell.text).toBe(formatIcon(ghEvent));
+    expect(iconCell.text).toBe("");
+  });
+
+  test("EVENT cell renders the raw event.name (no friendly label substitution)", () => {
+    const element = EventRow({ event: ghEvent, selected: false, columns: 200, paused: true });
+    const cells = collectFixedWidthCells(element);
+    const widths = computeColumnWidths(200);
+    const eventCell = mustExist(
+      cells.find((c) => c.width === widths.event && c.wrap === "truncate"),
+      "EVENT cell",
+    );
+    expect(eventCell.text).toBe(formatEvent(ghEvent));
+    expect(eventCell.text).toBe("github.pr.merged");
+  });
+
+  test("EVENT cell carries the full filter.wake.<sessionId> name verbatim", () => {
+    const wakeEvent: CanonicalEvent = {
+      ...ghEvent,
+      id: "33333333-4444-4555-8666-777777777777",
+      attributes: { "event.name": "filter.wake.sess_20260511T203845_16d33281" },
+      body: { payload: { reason: "ci passed" } },
+    };
+    const element = EventRow({ event: wakeEvent, selected: false, columns: 200, paused: true });
+    const cells = collectFixedWidthCells(element);
+    const widths = computeColumnWidths(200);
+    const eventCell = mustExist(
+      cells.find((c) => c.width === widths.event && c.wrap === "truncate"),
+      "EVENT cell (filter.wake)",
+    );
+    expect(eventCell.text).toBe("filter.wake.sess_20260511T203845_16d33281");
+  });
+});
+
+describe("EventRow ICON column (CTL-391, Nerd Font enabled)", () => {
+  const prevEnv = process.env.CATALYST_NERD_FONT;
+  beforeAll(() => {
+    process.env.CATALYST_NERD_FONT = "1";
+    _resetNerdFontCacheForTesting();
+  });
+  afterAll(() => {
+    if (prevEnv === undefined) delete process.env.CATALYST_NERD_FONT;
+    else process.env.CATALYST_NERD_FONT = prevEnv;
+    _resetNerdFontCacheForTesting();
+  });
+
+  test("ICON cell renders the source-family glyph alone (no trailing space)", () => {
+    const ghEvent: CanonicalEvent = {
+      ts: "2026-05-14T13:40:00.000Z",
+      id: "44444444-5555-4666-8777-888888888888",
+      severityText: "INFO",
+      severityNumber: 9,
+      traceId: null,
+      spanId: null,
+      resource: {
+        "service.name": "test",
+        "service.namespace": "catalyst",
+        "service.version": "0.0.0",
+      },
+      attributes: {
+        "event.name": "github.pr.merged",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+      },
+      body: { payload: {} },
+    };
+    const element = EventRow({ event: ghEvent, selected: false, columns: 200, paused: true });
+    const cells = collectFixedWidthCells(element);
+    const iconCell = cells.find((c) => c.width === 1);
+    if (iconCell === undefined) throw new Error("expected to find ICON cell");
+    expect(iconCell.text.length).toBe(1);
+    expect(iconCell.text.codePointAt(0)).toBe(0xf09b); // nf-fa-github
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -5,7 +5,7 @@ import {
   formatDateTime,
   formatRepo,
   formatSource,
-  formatSourceEvent,
+  formatIcon,
   formatEvent,
   formatRef,
   formatDetails,
@@ -230,12 +230,17 @@ describe("formatSource", () => {
   });
 });
 
+// CTL-391: formatEvent now returns the raw `event.name` attribute verbatim.
+// The pre-CTL-391 friendly-label table (merged, ci pass, wake, filter reg, …)
+// is gone — operators asked to see the actual event name as emitted. The
+// formatter never truncates; Ink's `wrap="truncate"` on the EVENT cell clips
+// long names with an ellipsis at render time.
 describe("formatEvent", () => {
-  test("maps github.pr.merged to 'merged'", () => {
-    expect(formatEvent(baseEvent)).toBe("merged");
+  test("returns raw github.pr.merged verbatim", () => {
+    expect(formatEvent(baseEvent)).toBe("github.pr.merged");
   });
 
-  test("maps github.check_suite.completed/failure to 'ci fail'", () => {
+  test("returns raw github.check_suite.completed regardless of conclusion", () => {
     const e = {
       ...baseEvent,
       attributes: {
@@ -243,118 +248,77 @@ describe("formatEvent", () => {
         "cicd.pipeline.run.conclusion": "failure",
       },
     } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("ci fail");
+    expect(formatEvent(e)).toBe("github.check_suite.completed");
   });
 
-  test("maps github.check_suite.completed/success to 'ci pass'", () => {
+  test("returns raw github.pr.opened verbatim", () => {
     const e = {
       ...baseEvent,
-      attributes: {
-        "event.name": "github.check_suite.completed",
-        "cicd.pipeline.run.conclusion": "success",
-      },
+      attributes: { ...baseEvent.attributes, "event.name": "github.pr.opened" },
+    };
+    expect(formatEvent(e)).toBe("github.pr.opened");
+  });
+
+  test("does not truncate long event names (renderer clips, formatter does not)", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "github.pr_review_comment.created" },
     } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("ci pass");
+    expect(formatEvent(e)).toBe("github.pr_review_comment.created");
   });
 
-  test("maps github.pr.opened to 'pr open'", () => {
-    const e = { ...baseEvent, attributes: { ...baseEvent.attributes, "event.name": "github.pr.opened" } };
-    expect(formatEvent(e)).toBe("pr open");
+  test("returns raw orchestrator.worker.done verbatim", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "orchestrator.worker.done" },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("orchestrator.worker.done");
   });
 
-  test("truncates unknown event names to 15 chars", () => {
-    const e = { ...baseEvent, attributes: { "event.name": "some.very.long.event.name.here" } } as unknown as CanonicalEvent;
-    const result = formatEvent(e);
-    expect(result.length).toBeLessThanOrEqual(15);
+  test("returns raw filter.register verbatim", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.register" },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("filter.register");
   });
 
-  test("maps orchestrator.worker.done to 'done'", () => {
-    const e = { ...baseEvent, attributes: { "event.name": "orchestrator.worker.done" } } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("done");
+  test("returns raw filter.deregister verbatim", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "filter.deregister" },
+    } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("filter.deregister");
   });
 
-  // CTL-331: filter daemon lifecycle labels.
-  test("maps filter.register to 'filter reg'", () => {
-    const e = { ...baseEvent, attributes: { "event.name": "filter.register" } } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("filter reg");
-  });
-
-  test("maps filter.deregister to 'filter dereg'", () => {
-    const e = { ...baseEvent, attributes: { "event.name": "filter.deregister" } } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("filter dereg");
-  });
-
-  test("maps filter.wake to 'wake'", () => {
-    const e = { ...baseEvent, attributes: { "event.name": "filter.wake" } } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("wake");
-  });
-
-  test("maps prefixed filter.wake.{sessionId} to 'wake' (not truncated)", () => {
+  test("returns the full filter.wake.<sessionId> name (no shortening)", () => {
     const e = {
       ...baseEvent,
       attributes: { "event.name": "filter.wake.sess_20260511T203845_16d33281" },
     } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("wake");
+    expect(formatEvent(e)).toBe("filter.wake.sess_20260511T203845_16d33281");
   });
 
-  test("maps legacy orchestrator.filter.register alias to 'filter reg'", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "orchestrator.filter.register" },
-    } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("filter reg");
-  });
-
-  test("maps legacy orchestrator.filter.wake.* alias to 'wake'", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "orchestrator.filter.wake.sess_xyz" },
-    } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("wake");
-  });
-
-  test("maps broker.daemon.startup to 'broker start'", () => {
+  test("returns raw broker.daemon.startup verbatim", () => {
     const e = {
       ...baseEvent,
       attributes: { "event.name": "broker.daemon.startup" },
     } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("broker start");
+    expect(formatEvent(e)).toBe("broker.daemon.startup");
   });
 
-  test("maps comms.message.posted with type='info' to 'info'", () => {
+  test("returns raw comms.message.posted verbatim regardless of payload type", () => {
     const e = {
       ...baseEvent,
       attributes: { "event.name": "comms.message.posted" },
       body: { payload: { type: "info", channel: "orch-demo", to: "all" } },
     } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("info");
+    expect(formatEvent(e)).toBe("comms.message.posted");
   });
 
-  test("maps comms.message.posted with type='attention' to 'attention'", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "comms.message.posted" },
-      body: { payload: { type: "attention", channel: "orch-demo", to: "all" } },
-    } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("attention");
-  });
-
-  test("maps comms.message.posted with type='done' to 'done'", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "comms.message.posted" },
-      body: { payload: { type: "done", channel: "orch-demo", to: "all" } },
-    } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("done");
-  });
-
-  test("falls back to 'comms' when comms event has no payload type", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "comms.message.posted" },
-      body: { payload: {} },
-    } as unknown as CanonicalEvent;
-    expect(formatEvent(e)).toBe("comms");
+  test("falls back to '(legacy)' when event.name attribute is missing", () => {
+    const e = { ...baseEvent, attributes: {} } as unknown as CanonicalEvent;
+    expect(formatEvent(e)).toBe("(legacy)");
   });
 });
 
@@ -878,6 +842,70 @@ describe("formatDetails (filter.wake)", () => {
   });
 });
 
+describe("formatDetails (comms.message.posted, CTL-391)", () => {
+  // CTL-391: EVENT now shows the raw event.name (`comms.message.posted`), so
+  // the sender+type composition that used to live in the EVENT cell
+  // ("ADV-939: info") moves into DETAILS. The body, when present, follows
+  // the prefix after an em-dash.
+  test("prepends '<sender>: <type> — ' when sender and body are present", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "event.label": "CTL-330",
+        "catalyst.worker.ticket": "CTL-330",
+      },
+      body: { message: "stalled: CI failed", payload: { type: "attention", channel: "orch-demo", to: "all" } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("CTL-330: attention — stalled: CI failed");
+  });
+
+  test("falls back to catalyst.worker.ticket when event.label is missing", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "catalyst.worker.ticket": "CTL-330",
+      },
+      body: { message: "hi", payload: { type: "info" } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("CTL-330: info — hi");
+  });
+
+  test("omits the sender prefix when no event.label or worker ticket is present", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "comms.message.posted" },
+      body: { message: "broadcast", payload: { type: "info" } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("info — broadcast");
+  });
+
+  test("falls back to 'comms' type when payload.type is missing", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "event.label": "CTL-330",
+      },
+      body: { message: "msg", payload: {} },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("CTL-330: comms — msg");
+  });
+
+  test("renders only the prefix when the message body is empty", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "comms.message.posted",
+        "event.label": "CTL-330",
+      },
+      body: { payload: { type: "attention" } },
+    } as unknown as CanonicalEvent;
+    expect(formatDetails(e)).toBe("CTL-330: attention");
+  });
+});
+
 describe("formatDetails (broker.daemon)", () => {
   // CTL-348: broker.daemon.* events sometimes carry a free-form payload.detail
   // string; surface it in DETAIL when present, fall through otherwise.
@@ -1088,12 +1116,12 @@ describe("formatSource / formatRef — CTL-355 Nerd Font enabled", () => {
   });
 });
 
-// CTL-364: SOURCE + EVENT columns merged into a single EVENT column rendered
-// as `${sourceIcon}${label}`. formatSourceEvent composes the visible label;
-// formatSource and formatEvent remain exported for the filter haystack and
-// other consumers. This block covers the bare-mode (no Nerd Font) label
-// composition; the Nerd Font prefix is asserted in its own block below.
-describe("formatSourceEvent (CTL-364, bare mode)", () => {
+// CTL-391: the SOURCE icon — previously concatenated inside the EVENT column
+// string by formatSourceEvent — moves into its own 1-cell ICON column to the
+// left of EVENT. formatIcon returns just the BMP glyph (no trailing space)
+// when a Nerd Font is detected, or "" when not, so the cell can render
+// blank without disturbing column alignment.
+describe("formatIcon (CTL-391, bare mode)", () => {
   // The earlier "CTL-355 Nerd Font enabled" block's afterAll deletes
   // CATALYST_NERD_FONT and resets the detection cache, so a fresh probe
   // here would see whatever Nerd Fonts the host machine has installed.
@@ -1109,87 +1137,22 @@ describe("formatSourceEvent (CTL-364, bare mode)", () => {
     _resetNerdFontCacheForTesting();
   });
 
-  test("github events render the event label without a source prefix", () => {
-    expect(formatSourceEvent(baseEvent)).toBe("merged");
-  });
-
-  test("linear events render the mapped event label", () => {
-    const e = {
+  test("returns empty string for any event when no Nerd Font is detected", () => {
+    expect(formatIcon(baseEvent)).toBe("");
+    const linear = {
       ...baseEvent,
       attributes: { ...baseEvent.attributes, "event.name": "linear.issue.updated" },
     } as CanonicalEvent;
-    expect(formatSourceEvent(e)).toBe(formatEvent(e));
-  });
-
-  test("filter.register renders 'filter reg'", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "filter.register" },
-    } as unknown as CanonicalEvent;
-    expect(formatSourceEvent(e)).toBe("filter reg");
-  });
-
-  test("filter.wake.{sessionId} renders 'wake'", () => {
-    const e = {
+    expect(formatIcon(linear)).toBe("");
+    const wake = {
       ...baseEvent,
       attributes: { "event.name": "filter.wake.sess_x" },
     } as unknown as CanonicalEvent;
-    expect(formatSourceEvent(e)).toBe("wake");
-  });
-
-  test("orchestrator.worker.done renders 'done'", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "orchestrator.worker.done" },
-    } as unknown as CanonicalEvent;
-    expect(formatSourceEvent(e)).toBe("done");
-  });
-
-  test("comms.message.posted with event.label sender embeds sender into the label", () => {
-    const e = {
-      ...baseEvent,
-      attributes: {
-        "event.name": "comms.message.posted",
-        "event.label": "CTL-330",
-        "catalyst.worker.ticket": "CTL-330",
-      },
-      body: { payload: { type: "attention", channel: "orch-demo", to: "all" } },
-    } as unknown as CanonicalEvent;
-    expect(formatSourceEvent(e)).toBe("CTL-330: attention");
-  });
-
-  test("comms.message.posted falls back to catalyst.worker.ticket when no event.label", () => {
-    const e = {
-      ...baseEvent,
-      attributes: {
-        "event.name": "comms.message.posted",
-        "catalyst.worker.ticket": "CTL-330",
-      },
-      body: { payload: { type: "info", channel: "orch-demo", to: "all" } },
-    } as unknown as CanonicalEvent;
-    expect(formatSourceEvent(e)).toBe("CTL-330: info");
-  });
-
-  test("comms.message.posted with no sender falls through to the bare event label", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "comms.message.posted" },
-      body: { payload: { type: "info" } },
-    } as unknown as CanonicalEvent;
-    expect(formatSourceEvent(e)).toBe("info");
-  });
-
-  test("unknown event names match formatEvent's 15-char truncation", () => {
-    const e = {
-      ...baseEvent,
-      attributes: { "event.name": "some.very.long.event.name.here" },
-    } as unknown as CanonicalEvent;
-    expect(formatSourceEvent(e)).toBe(formatEvent(e));
-    expect(formatSourceEvent(e).length).toBeLessThanOrEqual(15);
+    expect(formatIcon(wake)).toBe("");
   });
 });
 
-describe("formatSourceEvent (CTL-364, Nerd Font enabled)", () => {
+describe("formatIcon (CTL-391, Nerd Font enabled)", () => {
   const outerEnv = process.env.CATALYST_NERD_FONT;
   beforeAll(() => {
     process.env.CATALYST_NERD_FONT = "1";
@@ -1201,53 +1164,83 @@ describe("formatSourceEvent (CTL-364, Nerd Font enabled)", () => {
     _resetNerdFontCacheForTesting();
   });
 
-  test("github events get the octocat glyph + space + label", () => {
-    const out = formatSourceEvent(baseEvent);
+  test("github events get the octocat glyph alone (no trailing space)", () => {
+    const out = formatIcon(baseEvent);
+    expect(out.length).toBe(1);
     expect(out.codePointAt(0)).toBe(0xf09b);
-    expect(out.charAt(1)).toBe(" ");
-    expect(out.slice(2)).toBe("merged");
   });
 
-  test("filter.wake.* gets the broker bolt glyph + 'wake'", () => {
+  test("linear events get the linear ticket glyph", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { ...baseEvent.attributes, "event.name": "linear.issue.state_changed" },
+    } as CanonicalEvent;
+    const out = formatIcon(e);
+    expect(out.length).toBe(1);
+    expect(out.codePointAt(0)).toBe(0xf145);
+  });
+
+  test("filter.wake.* gets the broker bolt glyph (broker is the wake source)", () => {
     const e = {
       ...baseEvent,
       attributes: { "event.name": "filter.wake.orch-abc" },
     } as unknown as CanonicalEvent;
-    const out = formatSourceEvent(e);
+    const out = formatIcon(e);
+    expect(out.length).toBe(1);
     expect(out.codePointAt(0)).toBe(0xf0e7);
-    expect(out.slice(2)).toBe("wake");
   });
 
-  test("comms.message.posted with sender gets the comments glyph + 'CTL-330: attention'", () => {
+  test("comms.message.posted anchors on the comments speech-bubble glyph regardless of sender", () => {
+    // Even when classifySource would return the sender's ticket label (e.g.
+    // "CTL-330"), the icon stays the speech bubble — the glyph belongs to
+    // the comms channel, not to the worker that posted the message.
     const e = {
       ...baseEvent,
       attributes: {
         "event.name": "comms.message.posted",
         "event.label": "CTL-330",
+        "catalyst.worker.ticket": "CTL-330",
       },
       body: { payload: { type: "attention" } },
     } as unknown as CanonicalEvent;
-    const out = formatSourceEvent(e);
+    const out = formatIcon(e);
+    expect(out.length).toBe(1);
     expect(out.codePointAt(0)).toBe(0xf086);
-    expect(out.slice(2)).toBe("CTL-330: attention");
+  });
+
+  test("orchestrator-derived sources get the catalyst cogs glyph", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "session.phase",
+        "catalyst.orchestrator.id": "orch-abc",
+        "catalyst.worker.ticket": "CTL-312",
+      },
+    } as CanonicalEvent;
+    const out = formatIcon(e);
+    expect(out.length).toBe(1);
+    expect(out.codePointAt(0)).toBe(0xf085);
   });
 });
 
 describe("session.context display (CTL-374)", () => {
-  test("formatEvent returns 'ctx' for session.context", () => {
+  // CTL-391: formatEvent returns the raw event.name verbatim. The compact
+  // "ctx" / "ctx warn" labels are gone — context details still land in the
+  // DETAILS cell via the formatDetails arms below.
+  test("formatEvent returns raw session.context verbatim", () => {
     const e: CanonicalEvent = {
       ...baseEvent,
       attributes: { "event.name": "session.context" },
     };
-    expect(formatEvent(e)).toBe("ctx");
+    expect(formatEvent(e)).toBe("session.context");
   });
 
-  test("formatEvent returns 'ctx warn' for attention.context_pressure", () => {
+  test("formatEvent returns raw attention.context_pressure verbatim", () => {
     const e: CanonicalEvent = {
       ...baseEvent,
       attributes: { "event.name": "attention.context_pressure" },
     };
-    expect(formatEvent(e)).toBe("ctx warn");
+    expect(formatEvent(e)).toBe("attention.context_pressure");
   });
 
   test("formatDetails for session.context renders compact context summary", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -3,7 +3,8 @@ import type { CanonicalEvent } from "../../lib/canonical-event.ts";
 import {
   formatTime,
   formatRepo,
-  formatSourceEvent,
+  formatIcon,
+  formatEvent,
   formatRef,
   formatDetails,
   formatStatus,
@@ -32,6 +33,11 @@ interface EventRowProps {
 // instead of the previous `.slice(N-1).padEnd(N)` strings, which defeated
 // Ink's flex layout and forced orchestrator IDs to chop at `orch-adv-` on
 // wide terminals.
+// CTL-391: ICON column carries the source-family Nerd Font glyph in its
+// own 1-cell box to the left of EVENT, freeing EVENT to show the raw
+// `event.name` attribute verbatim. When no Nerd Font is detected the
+// cell renders blank but its width stays reserved so columns stay
+// aligned across heterogeneous rows.
 // CTL-361: DETAILS uses `flexGrow={1}` + `wrap="truncate"` so an overly long
 // payload hard-clips at the cell's right edge instead of reflowing onto the
 // next terminal line and visually overdrawing the next event row — which is
@@ -72,8 +78,11 @@ export function EventRow({ event, selected, columns, paused = true, wrapMode = '
       <Box width={w.repo} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{formatRepo(event)}</Text>
       </Box>
+      <Box width={w.icon} flexShrink={0} marginRight={1}>
+        <Text color={color} inverse={inverse}>{formatIcon(event)}</Text>
+      </Box>
       <Box width={w.event} flexShrink={0} marginRight={1}>
-        <Text color={color} inverse={inverse} wrap="truncate">{formatSourceEvent(event)}</Text>
+        <Text color={color} inverse={inverse} wrap="truncate">{formatEvent(event)}</Text>
       </Box>
       <Box width={w.ref} flexShrink={0} marginRight={1}>
         <Text color={color} inverse={inverse}>{displayRef}</Text>

--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -73,6 +73,14 @@ export function Header({ columns = 120, nlQuery, brokerState, version }: HeaderP
         <Box width={w.repo} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"REPO"}</Text>
         </Box>
+        {/*
+          CTL-391: ICON column header is intentionally blank. The icons
+          themselves convey their meaning and a single-char header label
+          would clutter the row without adding information.
+        */}
+        <Box width={w.icon} flexShrink={0} marginRight={1}>
+          <Text bold color="cyan">{" "}</Text>
+        </Box>
         <Box width={w.event} flexShrink={0} marginRight={1}>
           <Text bold color="cyan">{"EVENT"}</Text>
         </Box>

--- a/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
@@ -26,12 +26,27 @@
  * bubble / system cog) and the label is the event-name-derived friendly
  * string. EVENT width grew from a fixed 16 to a responsive 22–30 range so
  * the worst-case composed label (`{glyph} CTL-XXXX: attention`) always fits.
+ *
+ * CTL-391: SOURCE icon split back out into its own 1-cell ICON column to
+ * the left of EVENT, and EVENT now carries the raw `event.name` attribute
+ * (`github.pr.merged`, `filter.wake.<sessionId>`, `comms.message.posted`,
+ * …) instead of a friendly label. Raw names are longer than the legacy
+ * labels (`github.pr_review_comment.created` is 32 chars; `filter.wake.`
+ * + 32-char sessionId is 44+) so EVENT's responsive range grows to
+ * 24–40 — EVENT is now the most informative column on the row and earns
+ * the extra width. Overflow still clips via `wrap="truncate"`; nothing
+ * reflows.
  */
 
 export interface ColumnWidths {
   status: number;
   time: number;
   repo: number;
+  // CTL-391: 1-cell column carrying the source-family Nerd Font glyph.
+  // Always rendered — when no Nerd Font is detected formatIcon returns
+  // "" and the cell is visually blank, but the width stays reserved so
+  // columns below the header stay aligned.
+  icon: number;
   event: number;
   ref: number;
   orch: number;
@@ -52,7 +67,8 @@ export function computeColumnWidths(columns: number): ColumnWidths {
     status: showStatus ? 3 : 0,
     time: 10,
     repo: Math.min(14, Math.max(10, Math.floor(columns * 0.07))),
-    event: Math.min(30, Math.max(22, Math.floor(columns * 0.13))),
+    icon: 1,
+    event: Math.min(40, Math.max(24, Math.floor(columns * 0.18))),
     ref: Math.min(20, Math.max(10, Math.floor(columns * 0.08))),
     // CTL-383: cap tightened from 24 → 18. Long multi-ticket orchestrator ids
     // truncate with an ellipsis (see EventRow.tsx wrap="truncate" on the ORCH

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -90,77 +90,38 @@ export function formatSource(event: CanonicalEvent): string {
   return `${sourceIcon(label)}${label}`;
 }
 
-const EVENT_LABELS: Record<string, string> = {
-  "github.pr.merged": "merged",
-  "github.pr.opened": "pr open",
-  "github.pr.closed": "pr closed",
-  "orchestrator.worker.done": "done",
-  "orchestrator.worker.failed": "failed",
-  "orchestrator.attention.raised": "attention",
-  "session.phase": "phase",
-  // CTL-374: Claude Code context pressure surfaced as events.
-  "session.context": "ctx",
-  "attention.context_pressure": "ctx warn",
-  // CTL-331: filter daemon lifecycle events.
-  "filter.register": "filter reg",
-  "filter.deregister": "filter dereg",
-  "filter.wake": "wake",
-  "broker.daemon.startup": "broker start",
-  // Legacy aliases for events written before catalyst-state.sh preserved the
-  // bare filter.* name (CTL-331). Keeps older log lines readable.
-  "orchestrator.filter.register": "filter reg",
-  "orchestrator.filter.deregister": "filter dereg",
-  "orchestrator.filter.wake": "wake",
-};
-
+// CTL-391: EVENT column now shows the raw `event.name` attribute verbatim.
+// The pre-CTL-391 friendly-label map (`merged`, `ci pass`, `wake`, etc.) is
+// gone — operators asked to see the actual event name as emitted, not an
+// interpreted gloss. Overflow is the renderer's problem; Ink's
+// `wrap="truncate"` on the EVENT cell clips with ellipsis instead of
+// reflowing onto the next visual row.
 export function formatEvent(event: CanonicalEvent): string {
   const name = event.attributes?.["event.name"];
-  if (!name) return "(legacy)";
-  if (name === "github.check_suite.completed") {
-    const c = event.attributes["cicd.pipeline.run.conclusion"];
-    return c === "success" ? "ci pass" : "ci fail";
-  }
-  if (name === "comms.message.posted") {
-    const payload = event.body?.payload as Record<string, unknown> | undefined;
-    const type = payload?.["type"];
-    if (typeof type === "string" && type.length > 0) return type.slice(0, 15);
-    return "comms";
-  }
-  // CTL-331: wake events are session-scoped (filter.wake.{sessionId}).
-  // EVENT_LABELS is exact-match, so handle the prefixed family explicitly.
-  if (name.startsWith("filter.wake.") || name.startsWith("orchestrator.filter.wake.")) {
-    return "wake";
-  }
-  const label = EVENT_LABELS[name] ?? name;
-  return label.slice(0, 15);
+  return name ?? "(legacy)";
 }
 
-// CTL-364: merged SOURCE + EVENT column renderer. Returns
-// `${sourceIcon}${label}` where the icon is the Nerd Font glyph for the
-// source family (bare in non-Nerd-Font mode) and the label is the event
-// label — with the comms-specific embellishment of preserving the sender
-// ticket into the label so SOURCE-only info isn't lost when the column
-// disappears. formatSource and formatEvent stay exported for the filter
-// haystack and other layout-independent consumers.
-export function formatSourceEvent(event: CanonicalEvent): string {
+// CTL-391: ICON column renderer. Returns a single Nerd Font glyph for the
+// event's source family, or "" when no Nerd Font is detected (the cell
+// renders blank but its width is still reserved so the rest of the row
+// stays column-aligned). Pre-CTL-391 this glyph was concatenated inside the
+// EVENT column string by `formatSourceEvent`; pulling it back out into its
+// own 1-cell column lets EVENT show the full raw name without losing the
+// at-a-glance source signal.
+//
+// Comms messages anchor on the speech-bubble glyph rather than running
+// through `classifySource` (which returns the sender's worker ticket for
+// comms events) so the icon stays semantically correct regardless of which
+// worker sent the message.
+export function formatIcon(event: CanonicalEvent): string {
   const name = event.attributes?.["event.name"];
-  if (name === "comms.message.posted") {
-    const sender = event.attributes["event.label"]
-      ?? event.attributes["catalyst.worker.ticket"];
-    const payload = event.body?.payload as Record<string, unknown> | undefined;
-    const rawType = payload?.["type"];
-    const type = typeof rawType === "string" && rawType.length > 0 ? rawType : "comms";
-    // Glyph is anchored to the comms source family rather than classifySource's
-    // sender-ticket output so the icon stays semantically correct (speech
-    // bubble) regardless of which worker sent the message.
-    const icon = sourceIcon("comms");
-    if (sender && typeof sender === "string" && sender.length > 0) {
-      return `${icon}${sender}: ${type}`;
-    }
-    return `${icon}${type}`;
-  }
-  const sourceLabel = classifySource(event);
-  return `${sourceIcon(sourceLabel)}${formatEvent(event)}`;
+  const family = name === "comms.message.posted" ? "comms" : classifySource(event);
+  const raw = sourceIcon(family); // "{glyph} " or "" depending on Nerd Font detection
+  // sourceIcon returns "{glyph} " (glyph + trailing space) sized for inline
+  // composition with a label. The ICON column has its own marginRight, so
+  // strip the trailing space and emit just the BMP glyph.
+  const cp = raw.codePointAt(0);
+  return cp === undefined ? "" : String.fromCodePoint(cp);
 }
 
 // CTL-350: STATUS column glyph. One char + trailing space so the column width
@@ -479,7 +440,23 @@ export function formatDetails(event: CanonicalEvent): string {
       if (typeof body === "string") raw = body.slice(0, 300);
     }
   }
-  const out = sanitize(raw, "oneline");
+  let out = sanitize(raw, "oneline");
+  // CTL-391: comms.message.posted used to compose sender + type into the
+  // EVENT cell ("ADV-939: info"). EVENT now shows the raw event.name
+  // ("comms.message.posted"), so the sender + type would otherwise vanish.
+  // Prepend "<sender>: <type> — " to DETAILS so the information lands in
+  // the natural place — DETAILS already carries the message body for comms
+  // events, and the prefix reads cleanly with the body.
+  if (name === "comms.message.posted") {
+    const sender = event.attributes?.["event.label"]
+      ?? event.attributes?.["catalyst.worker.ticket"];
+    const p = payload as Record<string, unknown> | undefined;
+    const rawType = p?.["type"];
+    const type = typeof rawType === "string" && rawType.length > 0 ? rawType : "comms";
+    const senderText = typeof sender === "string" && sender.length > 0 ? `${sender}: ` : "";
+    const prefix = `${senderText}${type}`;
+    out = out.length > 0 ? `${prefix} — ${out}` : prefix;
+  }
   detailsCache.set(event, out);
   return out;
 }


### PR DESCRIPTION
Closes [CTL-391](https://linear.app/coalesce-labs/issue/CTL-391/).

## Summary

- EVENT column now shows the raw `event.attributes["event.name"]` verbatim instead of a friendly-label substitution (`merged`, `ci pass`, `wake`, `filter reg`, …). Operators asked to see the actual event name as emitted.
- The source-family Nerd Font glyph that used to live concatenated inside the EVENT string (`formatSourceEvent`) splits back out into its own 1-cell **ICON** column to the left of EVENT.
- The sender + type info that used to live in EVENT for `comms.message.posted` (`ADV-939: info`) moves into DETAILS as a `<sender>: <type> — <body>` prefix.

## Behavior diff

| Event | Before (EVENT cell) | After (ICON + EVENT cells) |
| --- | --- | --- |
| `github.pr.merged` |  merged |  + `github.pr.merged` |
| `github.check_suite.completed` (success) |  ci pass |  + `github.check_suite.completed` |
| `filter.wake.sess_abc…` |  wake |  + `filter.wake.sess_abc…` |
| `orchestrator.worker.done` |  done |  + `orchestrator.worker.done` |
| `comms.message.posted` (ADV-939, info) |  ADV-939: info |  + `comms.message.posted` (sender + type now prefix DETAILS) |
| missing `event.name` | `(legacy)` | ICON blank + EVENT `(legacy)` |

The icon column renders blank when no Nerd Font is detected; its width is still reserved so columns stay aligned across rows.

## Column-widths bump

Raw event names are longer than the legacy labels (`github.pr_review_comment.created` is 32 chars; `filter.wake.<sessionId>` is 44+), so EVENT's responsive range grows from `min(30, max(22, floor(cols * 0.13)))` to `min(40, max(24, floor(cols * 0.18)))`. Overflow still clips via `wrap="truncate"` (per CTL-361) — nothing reflows.

## Files

- `plugins/dev/scripts/orch-monitor/cli/lib/format.ts` — delete `EVENT_LABELS` + the friendly-label arms; `formatEvent` is now a verbatim pass-through; replace `formatSourceEvent` with `formatIcon`; `formatDetails` prepends `<sender>: <type> — ` for comms events.
- `plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts` — add `icon: 1` (always rendered); bump EVENT to 24–40.
- `plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx` — render the new ICON cell between REPO and EVENT; EVENT now reads `formatEvent` directly.
- `plugins/dev/scripts/orch-monitor/cli/components/Header.tsx` — matching blank ICON header cell.
- `plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts` — `formatEvent` assertions switch to raw names; `formatSourceEvent` describe blocks replaced by `formatIcon` tests; new comms `formatDetails` prepend coverage.
- `plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts` — updated EVENT bounds, new ICON column tests.
- `plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx` — tree-walk asserts ICON and EVENT render as distinct cells with the expected widths and content (raw event.name, full filter.wake.<sessionId>, octocat glyph when Nerd Font is on, blank when off).

## Test plan

- [x] `bun test` for the three touched files — 160/160 pass.
- [x] `bun run lint` — 0 errors (1 pre-existing warning in `lib/preview-status.ts`).
- [x] `bun run typecheck` — only pre-existing errors in excluded `ui/` package (same on `main`).
- [x] `bun test` for the whole monitor — 1757/1764 pass; the 7 failures are pre-existing on `main` (catalyst-monitor server tests + a session-store SQLite test).
- [ ] Eyeball HUD on a wide terminal with `CATALYST_NERD_FONT=1` — ICON cell should show distinct glyphs, EVENT should show full raw names.

## Out of scope

- A keybinding to toggle between raw and friendly names (separate ticket; would build on the wrap-toggle precedent from CTL-384).
- Renaming any other column or migrating other formatters.