### PR TITLE
feat(dev): HUD broker/worker dashboard view (CTL-392)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
@@ -1,0 +1,193 @@
+import { useState, useEffect, useMemo } from "react";
+import { Box, Text, useInput } from "ink";
+
+import type { BrokerInterest } from "../lib/broker-interests-reader.ts";
+import { readBrokerInterests } from "../lib/broker-interests-reader.ts";
+import type { WorkerSignal } from "../lib/worker-signals-reader.ts";
+import { readWorkerSignals } from "../lib/worker-signals-reader.ts";
+import type { OrchState } from "../lib/orch-state-reader.ts";
+import { readOrchStates } from "../lib/orch-state-reader.ts";
+import type { BrokerState } from "../lib/broker-key-health.ts";
+import {
+  DASHBOARD_VIEWS,
+  dashboardViewLabel,
+  type DashboardView,
+} from "../lib/dashboard-format.ts";
+
+import { InterestList } from "./InterestList.tsx";
+import { WorkerList } from "./WorkerList.tsx";
+import { OrchList } from "./OrchList.tsx";
+
+interface DashboardProps {
+  visibleRows: number;
+  cols: number;
+  brokerState: BrokerState | null;
+  onClose: () => void;
+}
+
+interface DashboardState {
+  interests: BrokerInterest[];
+  workers: WorkerSignal[];
+  orchs: OrchState[];
+}
+
+function readAll(): DashboardState {
+  return {
+    interests: readBrokerInterests(),
+    workers: readWorkerSignals(),
+    orchs: readOrchStates(),
+  };
+}
+
+function pickSelectedRow(view: DashboardView, state: DashboardState, idx: number): unknown {
+  if (view === "interests") return state.interests[idx] ?? null;
+  if (view === "workers") return state.workers[idx]?.raw ?? null;
+  return state.orchs[idx]?.raw ?? null;
+}
+
+function rowCount(view: DashboardView, state: DashboardState): number {
+  if (view === "interests") return state.interests.length;
+  if (view === "workers") return state.workers.length;
+  return state.orchs.length;
+}
+
+export function Dashboard({ visibleRows, cols, brokerState, onClose }: DashboardProps) {
+  const [view, setView] = useState<DashboardView>("interests");
+  const [data, setData] = useState<DashboardState>(() => readAll());
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const [showDetail, setShowDetail] = useState(false);
+  const [detailScrollTop, setDetailScrollTop] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setData(readAll()), 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const total = rowCount(view, data);
+
+  useEffect(() => {
+    if (selectedIndex >= total) setSelectedIndex(Math.max(0, total - 1));
+  }, [total, selectedIndex]);
+
+  // Reserve rows for the tab bar (1), the bottom footer hint (1), and the
+  // list's own header + separator + summary row (3 inside the list). The list
+  // body — including the in-list header/separator — gets the rest.
+  const tabRow = 1;
+  const footerRow = 1;
+  const detailFootprint = showDetail ? Math.min(Math.max(8, Math.floor(visibleRows / 2)), visibleRows - 4) : 0;
+  const listRows = Math.max(3, visibleRows - tabRow - footerRow - detailFootprint);
+  // Inside the list we reserve 2 rows for headers + 1 for the footer summary.
+  const listBodyRows = Math.max(1, listRows - 3);
+
+  useEffect(() => {
+    if (selectedIndex < scrollOffset) {
+      setScrollOffset(Math.max(0, selectedIndex));
+    } else if (selectedIndex >= scrollOffset + listBodyRows) {
+      setScrollOffset(Math.max(0, selectedIndex - listBodyRows + 1));
+    }
+  }, [selectedIndex, scrollOffset, listBodyRows]);
+
+  const selectedRowJson = useMemo(() => {
+    const row = pickSelectedRow(view, data, selectedIndex);
+    return JSON.stringify(row, null, 2);
+  }, [view, data, selectedIndex]);
+
+  const detailLines = useMemo(() => selectedRowJson.split("\n"), [selectedRowJson]);
+  const detailContentRows = Math.max(1, detailFootprint - 2);
+  const maxDetailScroll = Math.max(0, detailLines.length - detailContentRows);
+
+  useEffect(() => {
+    setDetailScrollTop(0);
+  }, [selectedIndex, view, showDetail]);
+
+  useInput((input, key) => {
+    if (showDetail) {
+      if (input === "j" || key.downArrow) { setDetailScrollTop((t) => Math.min(maxDetailScroll, t + 1)); return; }
+      if (input === "k" || key.upArrow) { setDetailScrollTop((t) => Math.max(0, t - 1)); return; }
+      if (key.escape || key.return) { setShowDetail(false); return; }
+      return;
+    }
+    if (input === "i" || key.escape) { onClose(); return; }
+    if (key.tab) {
+      const next = DASHBOARD_VIEWS[(DASHBOARD_VIEWS.indexOf(view) + 1) % DASHBOARD_VIEWS.length] ?? "interests";
+      setView(next);
+      setSelectedIndex(0);
+      setScrollOffset(0);
+      return;
+    }
+    if (input === "1") { setView("interests"); setSelectedIndex(0); setScrollOffset(0); return; }
+    if (input === "2") { setView("workers"); setSelectedIndex(0); setScrollOffset(0); return; }
+    if (input === "3") { setView("orchs"); setSelectedIndex(0); setScrollOffset(0); return; }
+    if (input === "j" || key.downArrow) {
+      setSelectedIndex((i) => Math.min(Math.max(0, total - 1), i + 1));
+      return;
+    }
+    if (input === "k" || key.upArrow) {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+      return;
+    }
+    if (key.pageDown) { setSelectedIndex((i) => Math.min(Math.max(0, total - 1), i + listBodyRows)); return; }
+    if (key.pageUp) { setSelectedIndex((i) => Math.max(0, i - listBodyRows)); return; }
+    if (input === "G") { setSelectedIndex(Math.max(0, total - 1)); return; }
+    if (key.return) { setShowDetail(true); return; }
+  });
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="row" paddingX={1}>
+        {DASHBOARD_VIEWS.map((v, i) => {
+          const active = v === view;
+          return (
+            <Box key={v} marginRight={2}>
+              <Text color={active ? "cyan" : undefined} bold={active} dimColor={!active}>
+                {`${i + 1}: ${dashboardViewLabel(v)}${active ? " ◀" : ""}`}
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+      <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor="cyan" paddingX={1}>
+        {view === "interests" && (
+          <InterestList
+            interests={data.interests}
+            selectedIndex={selectedIndex}
+            scrollOffset={scrollOffset}
+            visibleRows={listBodyRows}
+            cols={cols - 4}
+            brokerState={brokerState}
+          />
+        )}
+        {view === "workers" && (
+          <WorkerList
+            workers={data.workers}
+            selectedIndex={selectedIndex}
+            scrollOffset={scrollOffset}
+            visibleRows={listBodyRows}
+            cols={cols - 4}
+          />
+        )}
+        {view === "orchs" && (
+          <OrchList
+            orchs={data.orchs}
+            selectedIndex={selectedIndex}
+            scrollOffset={scrollOffset}
+            visibleRows={listBodyRows}
+            cols={cols - 4}
+          />
+        )}
+      </Box>
+      {showDetail && (
+        <Box flexDirection="column" flexShrink={0} borderStyle="single" borderColor="gray" paddingX={1}>
+          <Text color="cyan" bold>{`Detail · j/k scroll · Enter/Esc close (${detailScrollTop + 1}/${detailLines.length})`}</Text>
+          {detailLines.slice(detailScrollTop, detailScrollTop + detailContentRows).map((line, i) => (
+            <Text key={i} dimColor>{line}</Text>
+          ))}
+        </Box>
+      )}
+      <Box flexShrink={0} paddingX={1}>
+        <Text dimColor>Tab: switch view  ·  1/2/3: jump  ·  j/k: move  ·  Enter: detail  ·  Esc / i: close</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
@@ -1,0 +1,82 @@
+import { Box, Text } from "ink";
+import type { BrokerInterest } from "../lib/broker-interests-reader.ts";
+import type { BrokerState } from "../lib/broker-key-health.ts";
+import { formatRelativeTime, interestWatches, truncateRight } from "../lib/dashboard-format.ts";
+
+interface InterestListProps {
+  interests: BrokerInterest[];
+  selectedIndex: number;
+  scrollOffset: number;
+  visibleRows: number;
+  cols: number;
+  brokerState: BrokerState | null;
+}
+
+const COL_ORCH = 25;
+const COL_TYPE = 16;
+const COL_WATCHES = 28;
+
+function interestTypeLabel(t: BrokerInterest["interest_type"]): string {
+  return t ?? "prose";
+}
+
+function footerSummary(interests: BrokerInterest[], brokerState: BrokerState | null, now: number = Date.now()): string {
+  const n = interests.length;
+  const lastWake = brokerState?.lastWakeAt ? formatRelativeTime(brokerState.lastWakeAt, now) : "—";
+  const lastReg = brokerState?.lastRegisterAt ? formatRelativeTime(brokerState.lastRegisterAt, now) : "—";
+  const uptime = brokerState?.startedAt ? formatRelativeTime(brokerState.startedAt, now) : "—";
+  return `${n} interest${n === 1 ? "" : "s"}  ·  last wake ${lastWake} ago  ·  last register ${lastReg} ago  ·  daemon up ${uptime}`;
+}
+
+export function InterestList({
+  interests,
+  selectedIndex,
+  scrollOffset,
+  visibleRows,
+  cols,
+  brokerState,
+}: InterestListProps) {
+  const promptW = Math.max(8, cols - COL_ORCH - COL_TYPE - COL_WATCHES - 4);
+  const visible = interests.slice(scrollOffset, scrollOffset + visibleRows);
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="row">
+        <Box width={COL_ORCH} flexShrink={0} marginRight={1}><Text bold color="cyan">ORCHESTRATOR</Text></Box>
+        <Box width={COL_TYPE} flexShrink={0} marginRight={1}><Text bold color="cyan">TYPE</Text></Box>
+        <Box width={COL_WATCHES} flexShrink={0} marginRight={1}><Text bold color="cyan">WATCHES</Text></Box>
+        <Box flexGrow={1}><Text bold color="cyan">PROMPT</Text></Box>
+      </Box>
+      <Text dimColor>{"─".repeat(Math.max(0, cols - 1))}</Text>
+      {visible.length === 0 && (
+        <Box paddingX={1}><Text dimColor>(no interests registered)</Text></Box>
+      )}
+      {visible.map((i, idx) => {
+        const realIdx = scrollOffset + idx;
+        const selected = realIdx === selectedIndex;
+        const orch = truncateRight(i.orchestrator ?? "—", COL_ORCH);
+        const type = truncateRight(interestTypeLabel(i.interest_type), COL_TYPE);
+        const watches = truncateRight(interestWatches(i), COL_WATCHES);
+        const prompt = truncateRight(i.prompt || "(deterministic)", promptW);
+        return (
+          <Box key={`${i.key}-${realIdx}`} flexDirection="row">
+            <Box width={COL_ORCH} flexShrink={0} marginRight={1}>
+              <Text color={selected ? "black" : "white"} inverse={selected}>{orch}</Text>
+            </Box>
+            <Box width={COL_TYPE} flexShrink={0} marginRight={1}>
+              <Text color={i.interest_type ? "green" : "yellow"} inverse={selected}>{type}</Text>
+            </Box>
+            <Box width={COL_WATCHES} flexShrink={0} marginRight={1}>
+              <Text color={selected ? "black" : "white"} inverse={selected}>{watches}</Text>
+            </Box>
+            <Box flexGrow={1}>
+              <Text dimColor={!selected} inverse={selected}>{prompt}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+      <Box flexGrow={1} />
+      <Text dimColor>{footerSummary(interests, brokerState)}</Text>
+    </Box>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/cli/components/OrchList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/OrchList.tsx
@@ -1,0 +1,84 @@
+import { Box, Text } from "ink";
+import type { OrchState } from "../lib/orch-state-reader.ts";
+import { formatRelativeTime, truncateRight } from "../lib/dashboard-format.ts";
+
+interface OrchListProps {
+  orchs: OrchState[];
+  selectedIndex: number;
+  scrollOffset: number;
+  visibleRows: number;
+  cols: number;
+}
+
+const COL_ORCH = 38;
+const COL_WAVE = 5;
+const COL_ACTIVE = 9;
+const COL_QUEUE = 6;
+const COL_STARTED = 12;
+const COL_PARALLEL = 8;
+
+function waveLabel(o: OrchState): string {
+  if (o.currentWave === null && o.totalWaves === null) return "—";
+  return `${o.currentWave ?? "?"}/${o.totalWaves ?? "?"}`;
+}
+
+export function OrchList({
+  orchs,
+  selectedIndex,
+  scrollOffset,
+  visibleRows,
+  cols,
+}: OrchListProps) {
+  const visible = orchs.slice(scrollOffset, scrollOffset + visibleRows);
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="row">
+        <Box width={COL_ORCH} flexShrink={0} marginRight={1}><Text bold color="cyan">ORCHESTRATOR</Text></Box>
+        <Box width={COL_WAVE} flexShrink={0} marginRight={1}><Text bold color="cyan">WAVE</Text></Box>
+        <Box width={COL_ACTIVE} flexShrink={0} marginRight={1}><Text bold color="cyan">ACTIVE</Text></Box>
+        <Box width={COL_QUEUE} flexShrink={0} marginRight={1}><Text bold color="cyan">QUEUE</Text></Box>
+        <Box width={COL_STARTED} flexShrink={0} marginRight={1}><Text bold color="cyan">STARTED</Text></Box>
+        <Box width={COL_PARALLEL} flexShrink={0}><Text bold color="cyan">PARALLEL</Text></Box>
+      </Box>
+      <Text dimColor>{"─".repeat(Math.max(0, cols - 1))}</Text>
+      {visible.length === 0 && (
+        <Box paddingX={1}><Text dimColor>(no orchestrators found)</Text></Box>
+      )}
+      {visible.map((o, idx) => {
+        const realIdx = scrollOffset + idx;
+        const selected = realIdx === selectedIndex;
+        const orch = truncateRight(o.orchestrator ?? o.id, COL_ORCH);
+        const wave = truncateRight(waveLabel(o), COL_WAVE);
+        const active = truncateRight(`${o.workersCount.active}/${o.workersCount.total}`, COL_ACTIVE);
+        const queue = truncateRight(String(o.queueLength), COL_QUEUE);
+        const started = truncateRight(formatRelativeTime(o.startedAt), COL_STARTED);
+        const parallel = truncateRight(o.maxParallel !== null ? String(o.maxParallel) : "—", COL_PARALLEL);
+        return (
+          <Box key={`${o.id}-${realIdx}`} flexDirection="row">
+            <Box width={COL_ORCH} flexShrink={0} marginRight={1}>
+              <Text color={selected ? "black" : "white"} inverse={selected}>{orch}</Text>
+            </Box>
+            <Box width={COL_WAVE} flexShrink={0} marginRight={1}>
+              <Text dimColor={!selected} inverse={selected}>{wave}</Text>
+            </Box>
+            <Box width={COL_ACTIVE} flexShrink={0} marginRight={1}>
+              <Text color={o.workersCount.active > 0 ? "cyan" : undefined} dimColor={!selected && o.workersCount.active === 0} inverse={selected}>{active}</Text>
+            </Box>
+            <Box width={COL_QUEUE} flexShrink={0} marginRight={1}>
+              <Text dimColor={!selected} inverse={selected}>{queue}</Text>
+            </Box>
+            <Box width={COL_STARTED} flexShrink={0} marginRight={1}>
+              <Text dimColor={!selected} inverse={selected}>{started}</Text>
+            </Box>
+            <Box width={COL_PARALLEL} flexShrink={0}>
+              <Text dimColor={!selected} inverse={selected}>{parallel}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+      <Box flexGrow={1} />
+      <Text dimColor>{`${orchs.length} orchestrator${orchs.length === 1 ? "" : "s"}`}</Text>
+    </Box>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
@@ -1,0 +1,87 @@
+import { Box, Text } from "ink";
+import type { WorkerSignal } from "../lib/worker-signals-reader.ts";
+import {
+  formatRelativeTime,
+  isStaleHeartbeat,
+  lastPathSegment,
+  truncateRight,
+  workerStatusColor,
+} from "../lib/dashboard-format.ts";
+
+interface WorkerListProps {
+  workers: WorkerSignal[];
+  selectedIndex: number;
+  scrollOffset: number;
+  visibleRows: number;
+  cols: number;
+}
+
+const COL_WORKER = 32;
+const COL_STATUS = 13;
+const COL_PHASE = 5;
+const COL_PR = 6;
+const COL_HEARTBEAT = 10;
+
+export function WorkerList({
+  workers,
+  selectedIndex,
+  scrollOffset,
+  visibleRows,
+  cols,
+}: WorkerListProps) {
+  const worktreeW = Math.max(8, cols - COL_WORKER - COL_STATUS - COL_PHASE - COL_PR - COL_HEARTBEAT - 6);
+  const visible = workers.slice(scrollOffset, scrollOffset + visibleRows);
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="row">
+        <Box width={COL_WORKER} flexShrink={0} marginRight={1}><Text bold color="cyan">WORKER</Text></Box>
+        <Box width={COL_STATUS} flexShrink={0} marginRight={1}><Text bold color="cyan">STATUS</Text></Box>
+        <Box width={COL_PHASE} flexShrink={0} marginRight={1}><Text bold color="cyan">PHASE</Text></Box>
+        <Box width={COL_PR} flexShrink={0} marginRight={1}><Text bold color="cyan">PR</Text></Box>
+        <Box width={COL_HEARTBEAT} flexShrink={0} marginRight={1}><Text bold color="cyan">HEARTBEAT</Text></Box>
+        <Box flexGrow={1}><Text bold color="cyan">WORKTREE</Text></Box>
+      </Box>
+      <Text dimColor>{"─".repeat(Math.max(0, cols - 1))}</Text>
+      {visible.length === 0 && (
+        <Box paddingX={1}><Text dimColor>(no workers found)</Text></Box>
+      )}
+      {visible.map((w, idx) => {
+        const realIdx = scrollOffset + idx;
+        const selected = realIdx === selectedIndex;
+        const stale = isStaleHeartbeat(w.lastHeartbeat);
+        const statusColor = workerStatusColor(w.status);
+        const worker = truncateRight(w.workerName, COL_WORKER);
+        const status = truncateRight(w.status, COL_STATUS);
+        const phase = truncateRight(w.phase !== null ? String(w.phase) : "—", COL_PHASE);
+        const pr = truncateRight(w.pr ? `#${w.pr.number}` : "—", COL_PR);
+        const heartbeat = truncateRight(formatRelativeTime(w.lastHeartbeat), COL_HEARTBEAT);
+        const worktree = truncateRight(lastPathSegment(w.worktreePath), worktreeW);
+        return (
+          <Box key={`${w.workerName}-${realIdx}`} flexDirection="row">
+            <Box width={COL_WORKER} flexShrink={0} marginRight={1}>
+              <Text color={selected ? "black" : "white"} inverse={selected}>{worker}</Text>
+            </Box>
+            <Box width={COL_STATUS} flexShrink={0} marginRight={1}>
+              <Text color={statusColor} inverse={selected}>{status}</Text>
+            </Box>
+            <Box width={COL_PHASE} flexShrink={0} marginRight={1}>
+              <Text dimColor={!selected} inverse={selected}>{phase}</Text>
+            </Box>
+            <Box width={COL_PR} flexShrink={0} marginRight={1}>
+              <Text color={w.pr ? "cyan" : "gray"} inverse={selected}>{pr}</Text>
+            </Box>
+            <Box width={COL_HEARTBEAT} flexShrink={0} marginRight={1}>
+              <Text color={stale ? "yellow" : undefined} dimColor={!stale && !selected} inverse={selected}>{heartbeat}</Text>
+            </Box>
+            <Box flexGrow={1}>
+              <Text dimColor={!selected} inverse={selected}>{worktree}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+      <Box flexGrow={1} />
+      <Text dimColor>{`${workers.length} worker${workers.length === 1 ? "" : "s"}  ·  recent window 24h  ·  stale = no heartbeat in 5m`}</Text>
+    </Box>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -7,6 +7,7 @@ import { EventList } from "./components/EventList.tsx";
 import { FilterInput } from "./components/FilterInput.tsx";
 import { QueryInput } from "./components/QueryInput.tsx";
 import { DetailPane, buildDetailLines } from "./components/DetailPane.tsx";
+import { Dashboard } from "./components/Dashboard.tsx";
 import {
   computeBottomOverlaySize,
   computeDetailLayout,
@@ -67,6 +68,11 @@ const HELP_LINES = [
   "",
   "Display",
   "  w                toggle wrap (truncate / wrap)",
+  "",
+  "Dashboard  (i to open/close)",
+  "  Tab / 1-3        switch view (Interests / Workers / Orchestrators)",
+  "  j / k            move selection     Enter         open JSON detail",
+  "  Esc / i          close dashboard",
   "",
   "  h                this help          q / Ctrl-C    quit",
 ];
@@ -163,6 +169,8 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   // CTL-384: global wrap mode toggle. Default truncate keeps one line per event;
   // 'wrap' reflows long DETAILS for events that need full visibility.
   const [wrapMode, setWrapMode] = useState<'truncate' | 'wrap'>('truncate');
+  // CTL-392: full-screen dashboard overlay that takes over the event list area.
+  const [showDashboard, setShowDashboard] = useState(false);
 
   // chrome = header + separator(1) + filter(1) + query(1) + dsl overlay (if any).
   // CTL-363: the standalone status row was folded into FilterInput and a `─`
@@ -325,6 +333,8 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
 
     if (key.escape) {
       if (showHelp) { setShowHelp(false); return; }
+      // Dashboard handles its own Esc (closes detail before dismissing itself).
+      if (showDashboard) { return; }
       if (showDetail) { setShowDetail(false); return; }
       if (showDslOverlay) { setShowDslOverlay(false); return; }
       setPivot(null);
@@ -342,6 +352,12 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
     if (showHelp) {
       if (input === "h") { setShowHelp(false); return; }
       return; // swallow all keys while help is open
+    }
+
+    // CTL-392: while the dashboard is open, its own useInput handles
+    // Tab/1-3/j/k/Enter/PgUp/PgDn/G/Esc/i. We swallow all parent keys.
+    if (showDashboard) {
+      return;
     }
 
     if (showDslOverlay) {
@@ -364,6 +380,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
     if (input === "/") { setFilterFocused(true); return; }
     if (input === ":") { setQueryFocused(true); setQueryError(null); return; }
     if (input === "h") { setShowHelp(true); return; }
+    if (input === "i") { setShowDashboard(true); return; }
     if (input === "?" && overlayHasContent) { setShowDslOverlay((v) => !v); return; }
     if (key.return) { setShowDetail((v) => !v); return; }
     if (input === "o" || input === "t") {
@@ -402,16 +419,25 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
         />
       </Box>
       <Box flexDirection="column" flexGrow={(inDetailMode || showHelp) ? 0 : 1} flexShrink={1}>
-        <EventList
-          events={filtered}
-          selectedIndex={selectedIndex}
-          scrollOffset={listScrollOffset}
-          visibleRows={listRows}
-          columns={cols}
-          compact={inDetailMode || showHelp}
-          paused={!autoFollow}
-          wrapMode={wrapMode}
-        />
+        {showDashboard ? (
+          <Dashboard
+            visibleRows={visibleRows}
+            cols={cols}
+            brokerState={brokerState}
+            onClose={() => setShowDashboard(false)}
+          />
+        ) : (
+          <EventList
+            events={filtered}
+            selectedIndex={selectedIndex}
+            scrollOffset={listScrollOffset}
+            visibleRows={listRows}
+            columns={cols}
+            compact={inDetailMode || showHelp}
+            paused={!autoFollow}
+            wrapMode={wrapMode}
+          />
+        )}
       </Box>
       {inDetailMode && selectedEvent && (
         <Box flexShrink={0}>

--- a/plugins/dev/scripts/orch-monitor/cli/lib/broker-interests-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/broker-interests-reader.test.ts
@@ -1,0 +1,127 @@
+// broker-interests-reader.test.ts — verifies the broker-interests.json parser.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readBrokerInterests } from "./broker-interests-reader.ts";
+
+describe("readBrokerInterests", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hud-bi-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("missing file → empty array", () => {
+    expect(readBrokerInterests(join(tmp, "missing.json"))).toEqual([]);
+  });
+
+  test("malformed JSON → empty array", () => {
+    const target = join(tmp, "bad.json");
+    writeFileSync(target, "{ not valid");
+    expect(readBrokerInterests(target)).toEqual([]);
+  });
+
+  test("non-array root → empty array", () => {
+    const target = join(tmp, "obj.json");
+    writeFileSync(target, JSON.stringify({ foo: "bar" }));
+    expect(readBrokerInterests(target)).toEqual([]);
+  });
+
+  test("parses a prose interest tuple", () => {
+    const target = join(tmp, "good.json");
+    writeFileSync(target, JSON.stringify([
+      [
+        "orch-foo",
+        {
+          notify_event: "filter.wake.orch-foo",
+          prompt: "wake when X",
+          context: { pr_numbers: [123], tickets: ["FOO-1"] },
+          orchestrator: "orch-foo",
+          session_id: null,
+          persistent: true,
+          interest_type: null,
+          pr_numbers: null,
+          repo: null,
+          base_branches: null,
+          tickets: null,
+          wake_on: null,
+        },
+      ],
+    ]));
+    const result = readBrokerInterests(target);
+    expect(result).toHaveLength(1);
+    const r = result[0];
+    expect(r.key).toBe("orch-foo");
+    expect(r.interest_type).toBeNull();
+    expect(r.prompt).toBe("wake when X");
+    expect(r.context?.pr_numbers).toEqual([123]);
+    expect(r.context?.tickets).toEqual(["FOO-1"]);
+    expect(r.persistent).toBe(true);
+  });
+
+  test("parses a structured pr_lifecycle interest", () => {
+    const target = join(tmp, "good.json");
+    writeFileSync(target, JSON.stringify([
+      [
+        "orch-bar-pr-lifecycle",
+        {
+          notify_event: "filter.wake.orch-bar",
+          prompt: "",
+          context: null,
+          orchestrator: "orch-bar",
+          session_id: null,
+          persistent: true,
+          interest_type: "pr_lifecycle",
+          pr_numbers: [599],
+          repo: "coalesce-labs/catalyst",
+          base_branches: [{ pr: 599, base: "main" }],
+          tickets: null,
+          wake_on: null,
+        },
+      ],
+    ]));
+    const result = readBrokerInterests(target);
+    expect(result).toHaveLength(1);
+    const r = result[0];
+    expect(r.interest_type).toBe("pr_lifecycle");
+    expect(r.pr_numbers).toEqual([599]);
+    expect(r.repo).toBe("coalesce-labs/catalyst");
+    expect(r.base_branches).toEqual([{ pr: 599, base: "main" }]);
+  });
+
+  test("skips malformed tuple entries (non-tuple, missing key, etc.)", () => {
+    const target = join(tmp, "mixed.json");
+    writeFileSync(target, JSON.stringify([
+      "not a tuple",
+      [42, { stuff: "ignored" }],            // key is not a string
+      ["valid", {
+        notify_event: "filter.wake.x",
+        prompt: "",
+        context: null,
+        orchestrator: "x",
+        session_id: null,
+        persistent: false,
+        interest_type: null,
+        pr_numbers: null,
+        repo: null,
+        base_branches: null,
+        tickets: null,
+        wake_on: null,
+      }],
+    ]));
+    const result = readBrokerInterests(target);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("valid");
+  });
+
+  test("tolerates absent optional fields", () => {
+    const target = join(tmp, "min.json");
+    writeFileSync(target, JSON.stringify([["k", { orchestrator: "o" }]]));
+    const result = readBrokerInterests(target);
+    expect(result).toHaveLength(1);
+    expect(result[0].orchestrator).toBe("o");
+    expect(result[0].prompt).toBe("");
+    expect(result[0].persistent).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/broker-interests-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/broker-interests-reader.ts
@@ -1,0 +1,130 @@
+// broker-interests-reader.ts — parse ~/catalyst/broker-interests.json (CTL-392).
+//
+// The broker writes its registered interests as a 2-tuple array (NOT an object
+// map): `[[interestKey, record], …]`. Each record describes one wake interest
+// (PR lifecycle, comms lifecycle, ticket lifecycle, or a free-text "prose"
+// interest). The HUD dashboard reads this file to surface what the broker is
+// actually waiting for.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export type InterestType =
+  | "pr_lifecycle"
+  | "comms_lifecycle"
+  | "ticket_lifecycle"
+  | null;
+
+export interface BrokerInterest {
+  key: string;
+  notify_event: string | null;
+  prompt: string;
+  context: {
+    pr_numbers?: number[];
+    tickets?: string[];
+  } | null;
+  orchestrator: string | null;
+  session_id: string | null;
+  persistent: boolean;
+  interest_type: InterestType;
+  pr_numbers: number[] | null;
+  repo: string | null;
+  base_branches: Array<{ pr: number; base: string }> | null;
+  tickets: string[] | null;
+  wake_on: string[] | null;
+}
+
+export function brokerInterestsFilePath(): string {
+  const dir = process.env.CATALYST_DIR ?? resolve(homedir(), "catalyst");
+  return resolve(dir, "broker-interests.json");
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+function asNumberArray(v: unknown): number[] | null {
+  if (!Array.isArray(v)) return null;
+  const out: number[] = [];
+  for (const n of v) {
+    if (typeof n === "number" && Number.isFinite(n)) out.push(n);
+  }
+  return out.length > 0 ? out : null;
+}
+function asStringArray(v: unknown): string[] | null {
+  if (!Array.isArray(v)) return null;
+  const out: string[] = [];
+  for (const s of v) {
+    if (typeof s === "string") out.push(s);
+  }
+  return out.length > 0 ? out : null;
+}
+function asInterestType(v: unknown): InterestType {
+  if (v === "pr_lifecycle" || v === "comms_lifecycle" || v === "ticket_lifecycle") return v;
+  return null;
+}
+function asBaseBranches(v: unknown): Array<{ pr: number; base: string }> | null {
+  if (!Array.isArray(v)) return null;
+  const out: Array<{ pr: number; base: string }> = [];
+  for (const e of v) {
+    if (e && typeof e === "object") {
+      const obj = e as Record<string, unknown>;
+      if (typeof obj.pr === "number" && typeof obj.base === "string") {
+        out.push({ pr: obj.pr, base: obj.base });
+      }
+    }
+  }
+  return out.length > 0 ? out : null;
+}
+function asContext(v: unknown): BrokerInterest["context"] {
+  if (!v || typeof v !== "object") return null;
+  const obj = v as Record<string, unknown>;
+  const out: NonNullable<BrokerInterest["context"]> = {};
+  const prs = asNumberArray(obj.pr_numbers);
+  const tickets = asStringArray(obj.tickets);
+  if (prs) out.pr_numbers = prs;
+  if (tickets) out.tickets = tickets;
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+function parseRecord(key: string, raw: unknown): BrokerInterest | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  return {
+    key,
+    notify_event: asString(r.notify_event),
+    prompt: typeof r.prompt === "string" ? r.prompt : "",
+    context: asContext(r.context),
+    orchestrator: asString(r.orchestrator),
+    session_id: asString(r.session_id),
+    persistent: r.persistent === true,
+    interest_type: asInterestType(r.interest_type),
+    pr_numbers: asNumberArray(r.pr_numbers),
+    repo: asString(r.repo),
+    base_branches: asBaseBranches(r.base_branches),
+    tickets: asStringArray(r.tickets),
+    wake_on: asStringArray(r.wake_on),
+  };
+}
+
+export function readBrokerInterests(path?: string): BrokerInterest[] {
+  const target = path ?? brokerInterestsFilePath();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(target, "utf8"));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: BrokerInterest[] = [];
+  for (const entry of parsed as unknown[]) {
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    const tuple = entry as unknown[];
+    const keyRaw = tuple[0];
+    const recordRaw = tuple[1];
+    if (typeof keyRaw !== "string") continue;
+    const rec = parseRecord(keyRaw, recordRaw);
+    if (rec) out.push(rec);
+  }
+  return out;
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.test.ts
@@ -1,0 +1,195 @@
+// dashboard-format.test.ts — pure formatters for the HUD dashboard (CTL-392).
+
+import { describe, test, expect } from "bun:test";
+import {
+  formatRelativeTime,
+  isStaleHeartbeat,
+  STALE_HEARTBEAT_MS,
+  interestWatches,
+  workerStatusColor,
+  truncateRight,
+  lastPathSegment,
+  DASHBOARD_VIEWS,
+  dashboardViewLabel,
+} from "./dashboard-format.ts";
+import type { BrokerInterest } from "./broker-interests-reader.ts";
+
+const NOW = Date.parse("2026-05-14T16:00:00Z");
+
+describe("formatRelativeTime", () => {
+  test("seconds → Ns", () => {
+    expect(formatRelativeTime(new Date(NOW - 5_000).toISOString(), NOW)).toBe("5s");
+  });
+  test("under-minute boundary", () => {
+    expect(formatRelativeTime(new Date(NOW - 59_000).toISOString(), NOW)).toBe("59s");
+  });
+  test("minutes → Nm", () => {
+    expect(formatRelativeTime(new Date(NOW - 90_000).toISOString(), NOW)).toBe("1m");
+    expect(formatRelativeTime(new Date(NOW - 75 * 60_000).toISOString(), NOW)).toBe("1h");
+  });
+  test("hours → Nh", () => {
+    expect(formatRelativeTime(new Date(NOW - 2 * 3_600_000).toISOString(), NOW)).toBe("2h");
+  });
+  test("days → Nd", () => {
+    expect(formatRelativeTime(new Date(NOW - 26 * 3_600_000).toISOString(), NOW)).toBe("1d");
+  });
+  test("null → em-dash", () => {
+    expect(formatRelativeTime(null, NOW)).toBe("—");
+  });
+  test("invalid date → em-dash", () => {
+    expect(formatRelativeTime("not a date", NOW)).toBe("—");
+  });
+});
+
+describe("isStaleHeartbeat", () => {
+  test("STALE_HEARTBEAT_MS is 5 minutes", () => {
+    expect(STALE_HEARTBEAT_MS).toBe(5 * 60_000);
+  });
+  test("true when older than threshold", () => {
+    expect(isStaleHeartbeat(new Date(NOW - 6 * 60_000).toISOString(), undefined, NOW)).toBe(true);
+  });
+  test("false when fresher than threshold", () => {
+    expect(isStaleHeartbeat(new Date(NOW - 4 * 60_000).toISOString(), undefined, NOW)).toBe(false);
+  });
+  test("false for null", () => {
+    expect(isStaleHeartbeat(null, undefined, NOW)).toBe(false);
+  });
+  test("false for invalid date", () => {
+    expect(isStaleHeartbeat("not a date", undefined, NOW)).toBe(false);
+  });
+});
+
+describe("interestWatches", () => {
+  test("structured pr_lifecycle with repo + pr_numbers", () => {
+    const i: BrokerInterest = {
+      key: "x",
+      notify_event: "filter.wake.foo",
+      prompt: "",
+      context: null,
+      orchestrator: "o-x",
+      session_id: null,
+      persistent: true,
+      interest_type: "pr_lifecycle",
+      pr_numbers: [599],
+      repo: "coalesce-labs/catalyst",
+      base_branches: null,
+      tickets: null,
+      wake_on: null,
+    };
+    expect(interestWatches(i)).toContain("PR#599");
+    expect(interestWatches(i)).toContain("coalesce-labs/catalyst");
+  });
+
+  test("prose interest with context.tickets + pr_numbers", () => {
+    const i: BrokerInterest = {
+      key: "x",
+      notify_event: "filter.wake.foo",
+      prompt: "wake when…",
+      context: { pr_numbers: [599], tickets: ["CTL-352", "CTL-354"] },
+      orchestrator: "o-x",
+      session_id: null,
+      persistent: true,
+      interest_type: null,
+      pr_numbers: null,
+      repo: null,
+      base_branches: null,
+      tickets: null,
+      wake_on: null,
+    };
+    const out = interestWatches(i);
+    expect(out).toContain("PR#599");
+    expect(out).toContain("CTL-352");
+    expect(out).toContain("CTL-354");
+  });
+
+  test("ticket_lifecycle with tickets only", () => {
+    const i: BrokerInterest = {
+      key: "x",
+      notify_event: "filter.wake.foo",
+      prompt: "",
+      context: null,
+      orchestrator: "o-x",
+      session_id: null,
+      persistent: true,
+      interest_type: "ticket_lifecycle",
+      pr_numbers: null,
+      repo: null,
+      base_branches: null,
+      tickets: ["CTL-1", "CTL-2"],
+      wake_on: null,
+    };
+    expect(interestWatches(i)).toBe("CTL-1, CTL-2");
+  });
+
+  test("empty / fully-null interest → em-dash", () => {
+    const i: BrokerInterest = {
+      key: "x",
+      notify_event: null,
+      prompt: "",
+      context: null,
+      orchestrator: null,
+      session_id: null,
+      persistent: false,
+      interest_type: null,
+      pr_numbers: null,
+      repo: null,
+      base_branches: null,
+      tickets: null,
+      wake_on: null,
+    };
+    expect(interestWatches(i)).toBe("—");
+  });
+});
+
+describe("workerStatusColor", () => {
+  test("done → green", () => expect(workerStatusColor("done")).toBe("green"));
+  test("failed → red", () => expect(workerStatusColor("failed")).toBe("red"));
+  test("stalled → red", () => expect(workerStatusColor("stalled")).toBe("red"));
+  test("dispatched → gray", () => expect(workerStatusColor("dispatched")).toBe("gray"));
+  test("in-progress → cyan", () => {
+    expect(workerStatusColor("researching")).toBe("cyan");
+    expect(workerStatusColor("planning")).toBe("cyan");
+    expect(workerStatusColor("implementing")).toBe("cyan");
+    expect(workerStatusColor("validating")).toBe("cyan");
+    expect(workerStatusColor("shipping")).toBe("cyan");
+    expect(workerStatusColor("pr-created")).toBe("cyan");
+  });
+  test("unknown → gray", () => expect(workerStatusColor("frobnicating")).toBe("gray"));
+});
+
+describe("truncateRight", () => {
+  test("string shorter than width → unchanged", () => {
+    expect(truncateRight("abc", 5)).toBe("abc");
+  });
+  test("string equal to width → unchanged", () => {
+    expect(truncateRight("abcde", 5)).toBe("abcde");
+  });
+  test("string longer than width → suffix ellipsis", () => {
+    expect(truncateRight("abcdefg", 4)).toBe("abc…");
+  });
+  test("width of 1 → single char only", () => {
+    expect(truncateRight("abc", 1)).toBe("…");
+  });
+  test("width of 0 → empty", () => {
+    expect(truncateRight("abc", 0)).toBe("");
+  });
+});
+
+describe("lastPathSegment", () => {
+  test("normal path", () => expect(lastPathSegment("/foo/bar/baz")).toBe("baz"));
+  test("trailing slash stripped", () => expect(lastPathSegment("/foo/bar/")).toBe("bar"));
+  test("no slash → whole string", () => expect(lastPathSegment("plain")).toBe("plain"));
+  test("null → em-dash", () => expect(lastPathSegment(null)).toBe("—"));
+  test("empty string → em-dash", () => expect(lastPathSegment("")).toBe("—"));
+});
+
+describe("DASHBOARD_VIEWS + dashboardViewLabel", () => {
+  test("has three views in order", () => {
+    expect(DASHBOARD_VIEWS).toEqual(["interests", "workers", "orchs"]);
+  });
+  test("labels for each view", () => {
+    expect(dashboardViewLabel("interests")).toBe("Interests");
+    expect(dashboardViewLabel("workers")).toBe("Workers");
+    expect(dashboardViewLabel("orchs")).toBe("Orchestrators");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.ts
@@ -1,0 +1,88 @@
+// dashboard-format.ts — pure formatters for the HUD dashboard (CTL-392).
+
+import type { BrokerInterest } from "./broker-interests-reader.ts";
+
+export const STALE_HEARTBEAT_MS = 5 * 60_000;
+
+const EM_DASH = "—";
+
+function parseIsoMs(iso: string | null): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function formatRelativeTime(iso: string | null, now: number = Date.now()): string {
+  const ms = parseIsoMs(iso);
+  if (ms === null) return EM_DASH;
+  const delta = Math.max(0, now - ms);
+  if (delta < 60_000) return `${Math.floor(delta / 1_000)}s`;
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m`;
+  if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h`;
+  return `${Math.floor(delta / 86_400_000)}d`;
+}
+
+export function isStaleHeartbeat(
+  iso: string | null,
+  thresholdMs: number = STALE_HEARTBEAT_MS,
+  now: number = Date.now(),
+): boolean {
+  const ms = parseIsoMs(iso);
+  if (ms === null) return false;
+  return now - ms > thresholdMs;
+}
+
+export function interestWatches(i: BrokerInterest): string {
+  const parts: string[] = [];
+  if (i.repo) parts.push(i.repo);
+  const prs = i.pr_numbers ?? i.context?.pr_numbers ?? null;
+  if (prs && prs.length > 0) parts.push(prs.map((n) => `PR#${n}`).join(", "));
+  const tickets = i.tickets ?? i.context?.tickets ?? null;
+  if (tickets && tickets.length > 0) parts.push(tickets.join(", "));
+  if (parts.length === 0) return EM_DASH;
+  return parts.join(" · ");
+}
+
+export type WorkerStatusColor = "green" | "red" | "cyan" | "gray" | "yellow";
+
+const IN_PROGRESS_STATUSES = new Set([
+  "researching",
+  "planning",
+  "implementing",
+  "validating",
+  "shipping",
+  "pr-created",
+]);
+
+export function workerStatusColor(status: string): WorkerStatusColor {
+  if (status === "done") return "green";
+  if (status === "failed" || status === "stalled" || status === "deploy-failed") return "red";
+  if (IN_PROGRESS_STATUSES.has(status)) return "cyan";
+  return "gray";
+}
+
+export function truncateRight(s: string, w: number): string {
+  if (w <= 0) return "";
+  if (s.length <= w) return s;
+  if (w === 1) return "…";
+  return s.slice(0, w - 1) + "…";
+}
+
+export function lastPathSegment(p: string | null): string {
+  if (!p) return EM_DASH;
+  const stripped = p.replace(/\/+$/, "");
+  if (stripped.length === 0) return EM_DASH;
+  const idx = stripped.lastIndexOf("/");
+  return idx >= 0 ? stripped.slice(idx + 1) : stripped;
+}
+
+export const DASHBOARD_VIEWS = ["interests", "workers", "orchs"] as const;
+export type DashboardView = (typeof DASHBOARD_VIEWS)[number];
+
+export function dashboardViewLabel(v: DashboardView): string {
+  switch (v) {
+    case "interests": return "Interests";
+    case "workers": return "Workers";
+    case "orchs": return "Orchestrators";
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/orch-state-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/orch-state-reader.test.ts
@@ -1,0 +1,83 @@
+// orch-state-reader.test.ts — tests for the orchestrator scan.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readOrchStates } from "./orch-state-reader.ts";
+
+const NOW = Date.parse("2026-05-14T16:00:00Z");
+
+function makeOrch(root: string, name: string, state: Record<string, unknown>, workers: Record<string, unknown>[] = []) {
+  const dir = join(root, name);
+  mkdirSync(join(dir, "workers"), { recursive: true });
+  writeFileSync(join(dir, "state.json"), JSON.stringify({ orchestrator: name, ...state }));
+  for (const w of workers) {
+    const ticket = (w["ticket"] as string) ?? "T-?";
+    writeFileSync(join(dir, "workers", `${ticket}.json`), JSON.stringify({
+      ticket,
+      orchestrator: name,
+      workerName: `${name}-${ticket}`,
+      status: "implementing",
+      ...w,
+    }));
+  }
+}
+
+describe("readOrchStates", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hud-os-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("missing runs dir → empty", () => {
+    expect(readOrchStates(join(tmp, "missing"))).toEqual([]);
+  });
+
+  test("two orchestrators → 2 states with correct counts", () => {
+    makeOrch(tmp, "orch-a", { currentWave: 1, totalWaves: 2, maxParallel: 3, queue: [1, 2, 3], startedAt: new Date(NOW - 3_600_000).toISOString(), baseBranch: "main" }, [
+      { ticket: "T-1", workerName: "orch-a-T-1", status: "implementing" },
+      { ticket: "T-2", workerName: "orch-a-T-2", status: "done" },
+      { ticket: "T-3", workerName: "orch-a-T-3", status: "researching" },
+    ]);
+    makeOrch(tmp, "orch-b", { currentWave: 1, totalWaves: 1, maxParallel: 1, queue: [], startedAt: new Date(NOW - 60_000).toISOString() }, [
+      { ticket: "T-9", workerName: "orch-b-T-9", status: "failed" },
+    ]);
+
+    const out = readOrchStates(tmp);
+    expect(out).toHaveLength(2);
+    const a = out.find((o) => o.id === "orch-a");
+    const b = out.find((o) => o.id === "orch-b");
+    if (!a || !b) throw new Error("expected both orchestrators to be present");
+    expect(a.currentWave).toBe(1);
+    expect(a.totalWaves).toBe(2);
+    expect(a.queueLength).toBe(3);
+    expect(a.maxParallel).toBe(3);
+    expect(a.baseBranch).toBe("main");
+    expect(a.workersCount.total).toBe(3);
+    expect(a.workersCount.active).toBe(2);   // implementing + researching
+    expect(b.workersCount.total).toBe(1);
+    expect(b.workersCount.active).toBe(0);   // failed → terminal
+  });
+
+  test("orchestrator without state.json is skipped", () => {
+    mkdirSync(join(tmp, "orch-no-state"), { recursive: true });
+    expect(readOrchStates(tmp)).toEqual([]);
+  });
+
+  test("malformed state.json is skipped", () => {
+    mkdirSync(join(tmp, "orch-bad"), { recursive: true });
+    writeFileSync(join(tmp, "orch-bad", "state.json"), "{ not valid");
+    expect(readOrchStates(tmp)).toEqual([]);
+  });
+
+  test("tolerates missing optional fields", () => {
+    mkdirSync(join(tmp, "orch-min"), { recursive: true });
+    writeFileSync(join(tmp, "orch-min", "state.json"), JSON.stringify({ orchestrator: "orch-min" }));
+    const out = readOrchStates(tmp);
+    expect(out).toHaveLength(1);
+    expect(out[0].queueLength).toBe(0);
+    expect(out[0].currentWave).toBeNull();
+    expect(out[0].startedAt).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/orch-state-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/orch-state-reader.ts
@@ -1,0 +1,81 @@
+// orch-state-reader.ts — scan ~/catalyst/runs/<orchId>/state.json for the HUD
+// dashboard (CTL-392). Computes active-worker counts by reading the same
+// per-worker signal files used by worker-signals-reader.ts.
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { runsDirPath, scanOrchestratorWorkers } from "./worker-signals-reader.ts";
+
+const TERMINAL_STATUSES = new Set(["done", "failed", "stalled", "deploy-failed"]);
+
+export interface OrchState {
+  id: string;
+  orchestrator: string | null;
+  currentWave: number | null;
+  totalWaves: number | null;
+  queueLength: number;
+  maxParallel: number | null;
+  baseBranch: string | null;
+  startedAt: string | null;
+  workersCount: { active: number; total: number };
+  raw: unknown;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+function asNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function parseState(id: string, raw: unknown, orchDir: string): OrchState | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const queue = Array.isArray(r.queue) ? r.queue : [];
+  const workers = scanOrchestratorWorkers(orchDir);
+  const active = workers.filter((w) => !TERMINAL_STATUSES.has(w.status)).length;
+  return {
+    id,
+    orchestrator: asString(r.orchestrator),
+    currentWave: asNumber(r.currentWave),
+    totalWaves: asNumber(r.totalWaves),
+    queueLength: queue.length,
+    maxParallel: asNumber(r.maxParallel),
+    baseBranch: asString(r.baseBranch),
+    startedAt: asString(r.startedAt),
+    workersCount: { active, total: workers.length },
+    raw,
+  };
+}
+
+export function readOrchStates(runsDir?: string): OrchState[] {
+  const dir = runsDir ?? runsDirPath();
+  if (!existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: OrchState[] = [];
+  for (const name of entries) {
+    const orchDir = resolve(dir, name);
+    try {
+      if (!statSync(orchDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const stateFile = resolve(orchDir, "state.json");
+    if (!existsSync(stateFile)) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(stateFile, "utf8"));
+    } catch {
+      continue;
+    }
+    const st = parseState(name, parsed, orchDir);
+    if (st) out.push(st);
+  }
+  return out;
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.test.ts
@@ -1,0 +1,172 @@
+// worker-signals-reader.test.ts — tests for the multi-orchestrator worker scan.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  readWorkerSignals,
+  scanOrchestratorWorkers,
+  WORKER_RECENT_WINDOW_MS,
+} from "./worker-signals-reader.ts";
+
+const NOW = Date.parse("2026-05-14T16:00:00Z");
+
+function makeSignal(over: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ticket: "T-1",
+    orchestrator: "orch-x",
+    wave: 1,
+    workerName: "orch-x-T-1",
+    label: "oneshot T-1",
+    status: "implementing",
+    phase: 3,
+    phaseTimestamps: {},
+    lastHeartbeat: new Date(NOW - 5_000).toISOString(),
+    startedAt: new Date(NOW - 60_000).toISOString(),
+    updatedAt: new Date(NOW - 5_000).toISOString(),
+    completedAt: null,
+    worktreePath: "/tmp/wt",
+    pr: null,
+    linearState: null,
+    definitionOfDone: {},
+    pid: 12345,
+    ...over,
+  };
+}
+
+function setupOrch(root: string, orchName: string, signals: Record<string, unknown>[]) {
+  const dir = join(root, orchName, "workers");
+  mkdirSync(dir, { recursive: true });
+  for (const s of signals) {
+    const ticket = (s["ticket"] as string) ?? "T-?";
+    writeFileSync(join(dir, `${ticket}.json`), JSON.stringify(s));
+  }
+}
+
+describe("readWorkerSignals", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hud-ws-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("missing runs dir → empty", () => {
+    expect(readWorkerSignals(join(tmp, "missing"), NOW)).toEqual([]);
+  });
+
+  test("single orchestrator with two workers", () => {
+    setupOrch(tmp, "orch-a", [
+      makeSignal({ ticket: "T-1", workerName: "orch-a-T-1" }),
+      makeSignal({ ticket: "T-2", workerName: "orch-a-T-2", status: "researching" }),
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(2);
+    const names = out.map((w) => w.workerName).sort();
+    expect(names).toEqual(["orch-a-T-1", "orch-a-T-2"]);
+  });
+
+  test("two orchestrators merge", () => {
+    setupOrch(tmp, "orch-a", [makeSignal({ ticket: "T-1", workerName: "orch-a-T-1" })]);
+    setupOrch(tmp, "orch-b", [
+      makeSignal({ ticket: "T-9", workerName: "orch-b-T-9", orchestrator: "orch-b" }),
+      makeSignal({ ticket: "T-8", workerName: "orch-b-T-8", orchestrator: "orch-b" }),
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(3);
+  });
+
+  test("done workers older than the recent window are filtered out", () => {
+    const oldTs = new Date(NOW - WORKER_RECENT_WINDOW_MS - 60_000).toISOString();
+    setupOrch(tmp, "orch-a", [
+      makeSignal({ ticket: "T-old", workerName: "orch-a-T-old", status: "done", updatedAt: oldTs, completedAt: oldTs }),
+      makeSignal({ ticket: "T-active", workerName: "orch-a-T-active" }),
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].workerName).toBe("orch-a-T-active");
+  });
+
+  test("recently-done workers (within window) stay visible", () => {
+    const recentTs = new Date(NOW - 5 * 60_000).toISOString();
+    setupOrch(tmp, "orch-a", [
+      makeSignal({ ticket: "T-fresh", workerName: "orch-a-T-fresh", status: "done", updatedAt: recentTs, completedAt: recentTs }),
+    ]);
+    expect(readWorkerSignals(tmp, NOW)).toHaveLength(1);
+  });
+
+  test("failed workers follow the same recent-window rule", () => {
+    const oldTs = new Date(NOW - WORKER_RECENT_WINDOW_MS - 1_000).toISOString();
+    setupOrch(tmp, "orch-a", [
+      makeSignal({ ticket: "T-failed-old", workerName: "orch-a-T-failed-old", status: "failed", updatedAt: oldTs }),
+      makeSignal({ ticket: "T-failed-new", workerName: "orch-a-T-failed-new", status: "failed", updatedAt: new Date(NOW - 60_000).toISOString() }),
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].workerName).toBe("orch-a-T-failed-new");
+  });
+
+  test("in-progress workers are kept regardless of updatedAt age", () => {
+    const ancient = new Date(NOW - 365 * 86_400_000).toISOString();
+    setupOrch(tmp, "orch-a", [
+      makeSignal({ ticket: "T-stuck", workerName: "orch-a-T-stuck", status: "implementing", updatedAt: ancient }),
+    ]);
+    expect(readWorkerSignals(tmp, NOW)).toHaveLength(1);
+  });
+
+  test("malformed JSON files are skipped, others kept", () => {
+    setupOrch(tmp, "orch-a", [makeSignal({ ticket: "T-good", workerName: "orch-a-T-good" })]);
+    writeFileSync(join(tmp, "orch-a", "workers", "T-bad.json"), "{ not valid");
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].workerName).toBe("orch-a-T-good");
+  });
+
+  test("rollup files (e.g. -rollup.md ignored implicitly, -rollup.json skipped)", () => {
+    setupOrch(tmp, "orch-a", [makeSignal({ ticket: "T-1", workerName: "orch-a-T-1" })]);
+    writeFileSync(join(tmp, "orch-a", "workers", "T-1-rollup.md"), "# notes");
+    writeFileSync(join(tmp, "orch-a", "workers", "T-1-rollup.json"), JSON.stringify({ junk: true }));
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+  });
+
+  test("dedupe by workerName when two files conflict", () => {
+    setupOrch(tmp, "orch-a", [
+      makeSignal({ ticket: "T-1", workerName: "shared", status: "implementing" }),
+    ]);
+    setupOrch(tmp, "orch-b", [
+      makeSignal({ ticket: "T-1", workerName: "shared", orchestrator: "orch-b", status: "done", updatedAt: new Date(NOW).toISOString() }),
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+  });
+
+  test("signal missing required fields is skipped", () => {
+    setupOrch(tmp, "orch-a", [
+      makeSignal({ ticket: "T-good", workerName: "orch-a-T-good" }),
+    ]);
+    writeFileSync(join(tmp, "orch-a", "workers", "T-bad.json"), JSON.stringify({ status: "implementing" }));
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe("scanOrchestratorWorkers", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hud-ws2-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("returns workers for a single orch dir without applying the recent-window filter", () => {
+    const ancient = new Date(NOW - 365 * 86_400_000).toISOString();
+    setupOrch(tmp, "orch-a", [
+      makeSignal({ ticket: "T-ancient", workerName: "orch-a-T-ancient", status: "done", updatedAt: ancient, completedAt: ancient }),
+    ]);
+    const out = scanOrchestratorWorkers(join(tmp, "orch-a"));
+    expect(out).toHaveLength(1);
+    expect(out[0].status).toBe("done");
+  });
+
+  test("missing workers/ dir → empty", () => {
+    mkdirSync(join(tmp, "orch-empty"), { recursive: true });
+    expect(scanOrchestratorWorkers(join(tmp, "orch-empty"))).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.ts
@@ -1,0 +1,173 @@
+// worker-signals-reader.ts — scan ~/catalyst/runs/<orchId>/workers/*.json for the
+// HUD dashboard (CTL-392). Each worker writes its lifecycle state to a single
+// file named `<TICKET>.json`. The dashboard surfaces a filtered view of all
+// currently-known workers: in-flight workers always show; terminal-state
+// workers stay visible for 24 hours after their last update.
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export interface WorkerPR {
+  number: number;
+  url: string;
+  ciStatus?: string;
+  prOpenedAt?: string;
+  mergedAt?: string | null;
+  mergeCommitSha?: string;
+}
+
+export interface WorkerSignal {
+  ticket: string;
+  orchestrator: string;
+  wave: number | null;
+  workerName: string;
+  label: string | null;
+  status: string;
+  phase: number | null;
+  phaseTimestamps: Record<string, string>;
+  lastHeartbeat: string | null;
+  startedAt: string | null;
+  updatedAt: string | null;
+  completedAt: string | null;
+  worktreePath: string | null;
+  pr: WorkerPR | null;
+  linearState: string | null;
+  definitionOfDone: unknown;
+  raw: unknown;
+}
+
+export const WORKER_RECENT_WINDOW_MS = 24 * 3_600_000;
+
+const TERMINAL_STATUSES = new Set(["done", "failed", "stalled", "deploy-failed"]);
+
+export function runsDirPath(): string {
+  const dir = process.env.CATALYST_DIR ?? resolve(homedir(), "catalyst");
+  return resolve(dir, "runs");
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+function asNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function parsePr(v: unknown): WorkerPR | null {
+  if (!v || typeof v !== "object") return null;
+  const o = v as Record<string, unknown>;
+  if (typeof o.number !== "number") return null;
+  const out: WorkerPR = {
+    number: o.number,
+    url: typeof o.url === "string" ? o.url : "",
+  };
+  if (typeof o.ciStatus === "string") out.ciStatus = o.ciStatus;
+  if (typeof o.prOpenedAt === "string") out.prOpenedAt = o.prOpenedAt;
+  if (typeof o.mergedAt === "string") {
+    out.mergedAt = o.mergedAt;
+  } else if (o.mergedAt === null) {
+    out.mergedAt = null;
+  }
+  if (typeof o.mergeCommitSha === "string") out.mergeCommitSha = o.mergeCommitSha;
+  return out;
+}
+
+function parsePhaseTimestamps(v: unknown): Record<string, string> {
+  if (!v || typeof v !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof val === "string") out[k] = val;
+  }
+  return out;
+}
+
+function parseSignal(raw: unknown): WorkerSignal | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const ticket = asString(r.ticket);
+  const orchestrator = asString(r.orchestrator);
+  const workerName = asString(r.workerName);
+  const status = asString(r.status);
+  if (!ticket || !orchestrator || !workerName || !status) return null;
+  return {
+    ticket,
+    orchestrator,
+    wave: asNumber(r.wave),
+    workerName,
+    label: asString(r.label),
+    status,
+    phase: asNumber(r.phase),
+    phaseTimestamps: parsePhaseTimestamps(r.phaseTimestamps),
+    lastHeartbeat: asString(r.lastHeartbeat),
+    startedAt: asString(r.startedAt),
+    updatedAt: asString(r.updatedAt),
+    completedAt: asString(r.completedAt),
+    worktreePath: asString(r.worktreePath),
+    pr: parsePr(r.pr),
+    linearState: asString(r.linearState),
+    definitionOfDone: r.definitionOfDone ?? null,
+    raw,
+  };
+}
+
+function isRecentEnough(sig: WorkerSignal, now: number): boolean {
+  if (!TERMINAL_STATUSES.has(sig.status)) return true;
+  const ts = sig.updatedAt ?? sig.completedAt;
+  if (!ts) return false;
+  const ms = Date.parse(ts);
+  if (!Number.isFinite(ms)) return false;
+  return now - ms <= WORKER_RECENT_WINDOW_MS;
+}
+
+function scanOrchestratorWorkersDir(workersDir: string): WorkerSignal[] {
+  if (!existsSync(workersDir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(workersDir);
+  } catch {
+    return [];
+  }
+  const out: WorkerSignal[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json") || name.endsWith("-rollup.json")) continue;
+    const full = resolve(workersDir, name);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(full, "utf8"));
+    } catch {
+      continue;
+    }
+    const sig = parseSignal(parsed);
+    if (sig) out.push(sig);
+  }
+  return out;
+}
+
+export function scanOrchestratorWorkers(orchDir: string): WorkerSignal[] {
+  return scanOrchestratorWorkersDir(resolve(orchDir, "workers"));
+}
+
+export function readWorkerSignals(runsDir?: string, now: number = Date.now()): WorkerSignal[] {
+  const dir = runsDir ?? runsDirPath();
+  if (!existsSync(dir)) return [];
+  let orchDirs: string[];
+  try {
+    orchDirs = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const seen = new Map<string, WorkerSignal>();
+  for (const orchName of orchDirs) {
+    const orchDir = resolve(dir, orchName);
+    try {
+      if (!statSync(orchDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    for (const sig of scanOrchestratorWorkers(orchDir)) {
+      if (!isRecentEnough(sig, now)) continue;
+      seen.set(sig.workerName, sig);
+    }
+  }
+  return Array.from(seen.values());
+}


### PR DESCRIPTION
## Summary

Adds an `i`-toggled full-screen dashboard inside `catalyst-hud` that surfaces who is alive and what they're doing right now — complementing the existing event stream which answers "what just happened?".

Three sub-views, switchable with `Tab` or `1`/`2`/`3`:

- **Interests** — every entry in `~/catalyst/broker-interests.json`: which orchestrator owns it, interest type (`prose` / `pr_lifecycle` / `comms_lifecycle` / `ticket_lifecycle`), what it watches (repo · PRs · tickets), and the wake prompt. Footer surfaces broker liveness: total count, last wake age, last register age, daemon uptime.
- **Workers** — per-worker signal files across all orchestrators in `~/catalyst/runs/*/workers/*.json`. Shows worker name, status (color-coded green/red/cyan/gray), phase, PR number, heartbeat age (yellow if >5 min stale), and last segment of the worktree path. In-flight workers always show; terminal-state workers stay visible for 24 h after their last update.
- **Orchestrators** — every `~/catalyst/runs/*/state.json`. Shows wave progress (`currentWave/totalWaves`), active worker count (status ≠ `done|failed`) / total workers, queue depth, relative `startedAt`, and `maxParallel`.

`Enter` on any row opens a JSON detail pane (`j`/`k` scrolls, `Enter`/`Esc` closes). Auto-refresh every 5 s, same cadence as the broker chip. `Esc` or `i` closes the dashboard.

Read-only by design — no editing interests, killing workers, or live log tailing in this iteration.

## File map

**New readers** (pure file-IO with empty-on-error semantics):

- `cli/lib/broker-interests-reader.ts` — parses the `[key, record]` tuple array.
- `cli/lib/worker-signals-reader.ts` — scans `runs/*/workers/*.json` with a 24 h recent-window filter and dedup-by-`workerName`.
- `cli/lib/orch-state-reader.ts` — scans `runs/*/state.json` and computes the active-worker count by re-using `scanOrchestratorWorkers`.

**New formatters** (pure):

- `cli/lib/dashboard-format.ts` — `formatRelativeTime`, `isStaleHeartbeat`, `interestWatches`, `workerStatusColor`, `truncateRight`, `lastPathSegment`, `DASHBOARD_VIEWS`, `dashboardViewLabel`.

**New components**:

- `cli/components/Dashboard.tsx` — overlay container, owns view tab state, refresh interval, detail-pane drill-down, and key dispatch (`Tab`, `1`-`3`, `j`/`k`/`G`/PgUp/PgDn, `Enter`, `Esc`, `i`).
- `cli/components/InterestList.tsx`, `WorkerList.tsx`, `OrchList.tsx` — per-view renderers.

**Touched**:

- `cli/hud.tsx` — `showDashboard` state, `i` global key, Esc precedence (dashboard handles its own Esc), help text section, and the EventList ↔ Dashboard render-conditional.

## Test plan

- [x] `bun test cli/` → 155 passing across 10 files (59 new tests across 4 files)
- [x] `bun run typecheck` → clean (pre-existing `ui/` baseline errors unrelated)
- [x] `bun run lint` → no new violations (one pre-existing warning in `lib/preview-status.ts`)
- [x] Reward-hacking scan → no `as any`, `as unknown as`, `@ts-ignore`, `!` non-null, `forEach(async`, or `void` tricks introduced
- [ ] Manual smoke: open HUD, press `i`, verify three views appear; `Tab`/`1`/`2`/`3` switches; `j`/`k` moves selection; `Enter` opens JSON detail; `Esc`/`i` closes.

Closes CTL-392