### PR TITLE
feat(dev): HUD — relocate EVENT-ID from row to detail pane (CTL-393)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/column-widths.test.ts
@@ -5,7 +5,6 @@ import {
   formatStatus,
   formatOrch,
   formatWorker,
-  formatEventIdShort,
 } from "../cli/lib/format.ts";
 
 const makeEvent = (overrides: Partial<CanonicalEvent> = {}): CanonicalEvent => ({
@@ -26,16 +25,14 @@ const makeEvent = (overrides: Partial<CanonicalEvent> = {}): CanonicalEvent => (
 });
 
 describe("computeColumnWidths", () => {
-  test("at 80 cols hides STATUS, ORCH, WORKER, EVENT-ID", () => {
+  test("at 80 cols hides STATUS, ORCH, WORKER", () => {
     const w = computeColumnWidths(80);
     expect(w.showStatus).toBe(false);
     expect(w.showOrch).toBe(false);
     expect(w.showWorker).toBe(false);
-    expect(w.showEventId).toBe(false);
     expect(w.status).toBe(0);
     expect(w.orch).toBe(0);
     expect(w.worker).toBe(0);
-    expect(w.eventId).toBe(0);
   });
 
   test("at 100 cols enables STATUS only", () => {
@@ -59,17 +56,14 @@ describe("computeColumnWidths", () => {
   test("at 180 cols enables STATUS + ORCH + WORKER", () => {
     const w = computeColumnWidths(180);
     expect(w.showWorker).toBe(true);
-    expect(w.showEventId).toBe(false);
     expect(w.worker).toBe(16);
   });
 
-  test("at 200 cols enables all optional columns", () => {
+  test("at 200 cols enables STATUS + ORCH + WORKER", () => {
     const w = computeColumnWidths(200);
     expect(w.showStatus).toBe(true);
     expect(w.showOrch).toBe(true);
     expect(w.showWorker).toBe(true);
-    expect(w.showEventId).toBe(true);
-    expect(w.eventId).toBe(10);
   });
 
   test("repo and ref widths clamp to sensible bounds", () => {
@@ -139,7 +133,7 @@ describe("computeColumnWidths", () => {
   });
 });
 
-describe("status/orch/worker/event-id formatters", () => {
+describe("status/orch/worker formatters", () => {
   test("formatStatus: CI success → ✓", () => {
     expect(
       formatStatus(makeEvent({
@@ -238,13 +232,4 @@ describe("status/orch/worker/event-id formatters", () => {
     expect(formatWorker(makeEvent())).toBe("");
   });
 
-  test("formatEventIdShort returns first 8 chars of UUID", () => {
-    expect(formatEventIdShort(makeEvent())).toBe("11111111");
-  });
-
-  test("formatEventIdShort returns empty string when id missing", () => {
-    const evt = makeEvent();
-    evt.id = "";
-    expect(formatEventIdShort(evt)).toBe("");
-  });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -10,7 +10,6 @@ import {
   formatStatus,
   formatOrch,
   formatWorker,
-  formatEventIdShort,
 } from "../lib/format.ts";
 import { getRowColor } from "../lib/colors.ts";
 import { computeColumnWidths } from "../lib/column-widths.ts";
@@ -96,11 +95,6 @@ export function EventRow({ event, selected, columns, paused = true, wrapMode = '
       {w.showWorker && (
         <Box width={w.worker} flexShrink={0} marginRight={1}>
           <Text color={color} inverse={inverse}>{formatWorker(event)}</Text>
-        </Box>
-      )}
-      {w.showEventId && (
-        <Box width={w.eventId} flexShrink={0} marginRight={1}>
-          <Text color={color} inverse={inverse} dimColor>{formatEventIdShort(event)}</Text>
         </Box>
       )}
       <Box width={w.details} flexShrink={0}>

--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -97,11 +97,6 @@ export function Header({ columns = 120, nlQuery, brokerState, version }: HeaderP
             <Text bold color="cyan">{"WORKER"}</Text>
           </Box>
         )}
-        {w.showEventId && (
-          <Box width={w.eventId} flexShrink={0} marginRight={1}>
-            <Text bold color="cyan">{"EVENT-ID"}</Text>
-          </Box>
-        )}
         <Box width={w.details} flexShrink={0}>
           <Text bold color="cyan">{"DETAILS"}</Text>
         </Box>

--- a/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.test.ts
@@ -16,14 +16,13 @@ describe("computeColumnWidths — details field (CTL-395)", () => {
     for (const cols of [80, 100, 120, 160, 180, 200, 250, 300]) {
       const w = computeColumnWidths(cols);
       const marginCount =
-        4 + // time, repo, event, ref
+        5 + // time, repo, icon, event, ref always present
         (w.showStatus ? 1 : 0) +
         (w.showOrch ? 1 : 0) +
-        (w.showWorker ? 1 : 0) +
-        (w.showEventId ? 1 : 0);
+        (w.showWorker ? 1 : 0);
       const total =
-        w.status + w.time + w.repo + w.event + w.ref +
-        w.orch + w.worker + w.eventId + w.details + marginCount;
+        w.status + w.time + w.repo + w.icon + w.event + w.ref +
+        w.orch + w.worker + w.details + marginCount;
       expect(total).toBeLessThanOrEqual(cols);
     }
   });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/column-widths.ts
@@ -14,7 +14,6 @@
  *   ORCH      ≥160 cols   catalyst.orchestrator.id (truncated to 16-18 cells
  *                         with ellipsis on long multi-ticket ids; CTL-383)
  *   WORKER    ≥180 cols   catalyst.worker.ticket
- *   EVENT-ID  ≥200 cols   first 8 chars of the per-event UUIDv4 (CTL-344)
  *
  * Numeric widths for non-optional columns are clamped between sensible min
  * and max so very narrow terminals stay readable and very wide ones don't
@@ -51,20 +50,17 @@ export interface ColumnWidths {
   ref: number;
   orch: number;
   worker: number;
-  eventId: number;
   // CTL-395: explicit width so Ink writes trailing spaces and clears ghost chars
   details: number;
   showStatus: boolean;
   showOrch: boolean;
   showWorker: boolean;
-  showEventId: boolean;
 }
 
 export function computeColumnWidths(columns: number): ColumnWidths {
   const showStatus = columns >= 100;
   const showOrch = columns >= 160;
   const showWorker = columns >= 180;
-  const showEventId = columns >= 200;
 
   const status = showStatus ? 3 : 0;
   const time = 10;
@@ -77,7 +73,6 @@ export function computeColumnWidths(columns: number): ColumnWidths {
   // <Text>); the saved cells widen DETAILS at terminals ≥240 cols.
   const orch = showOrch ? Math.min(18, Math.max(16, Math.floor(columns * 0.12))) : 0;
   const worker = showWorker ? 16 : 0;
-  const eventId = showEventId ? 10 : 0;
 
   // CTL-395: each visible column (except DETAILS) has marginRight={1}.
   // CTL-391 added icon as an always-present column, so 5 always-present columns
@@ -85,9 +80,8 @@ export function computeColumnWidths(columns: number): ColumnWidths {
   const marginCount = 5 // time, repo, icon, event, ref always present
     + (showStatus ? 1 : 0)
     + (showOrch ? 1 : 0)
-    + (showWorker ? 1 : 0)
-    + (showEventId ? 1 : 0);
-  const fixedTotal = status + time + repo + icon + event + ref + orch + worker + eventId + marginCount;
+    + (showWorker ? 1 : 0);
+  const fixedTotal = status + time + repo + icon + event + ref + orch + worker + marginCount;
   const details = Math.max(20, columns - fixedTotal);
 
   return {
@@ -99,11 +93,9 @@ export function computeColumnWidths(columns: number): ColumnWidths {
     ref,
     orch,
     worker,
-    eventId,
     details,
     showStatus,
     showOrch,
     showWorker,
-    showEventId,
   };
 }

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -156,15 +156,6 @@ export function formatWorker(event: CanonicalEvent): string {
   return event.attributes?.["catalyst.worker.ticket"] ?? "";
 }
 
-// CTL-344 made every canonical event carry a UUIDv4 .id. The full UUID is too
-// long for an inline column; the first 8 chars are still unique enough to
-// correlate against the `lookup_jq` query in source_events.
-export function formatEventIdShort(event: CanonicalEvent): string {
-  const id = event.id;
-  if (!id) return "";
-  return id.slice(0, 8);
-}
-
 export function formatRef(event: CanonicalEvent): string {
   const name = event.attributes?.["event.name"];
   if (name === "comms.message.posted") {


### PR DESCRIPTION
## Summary

- Removes the EVENT-ID inline column from `EventRow` and `Header`, freeing 10 columns of horizontal space at ≥200-col terminals for DETAILS (via `flexGrow={1}`)
- Deletes `formatEventIdShort` helper from `format.ts` — no longer needed since EVENT-ID is row-only; the detail pane already shows the full 36-char UUID at `DetailPane.tsx:72`
- Removes `showEventId`/`eventId` fields from `ColumnWidths` interface and `computeColumnWidths()`, eliminating the ≥200-col threshold
- Updates `column-widths.test.ts` to remove EVENT-ID assertions and the `formatEventIdShort` test cases

## Test plan

- [ ] Confirm `bun test __tests__/column-widths.test.ts` passes (19/19)
- [ ] Confirm EVENT-ID no longer appears in HUD rows at any terminal width
- [ ] Confirm full UUID (36-char) is visible in detail pane (Enter on any row)
- [ ] Confirm DETAILS column receives the reclaimed horizontal space at wide terminals

Refs: CTL-393