### PR TITLE
feat(dev): HUD unified active-filter indicator in footer (CTL-389)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/FilterInput.tsx
@@ -15,11 +15,64 @@ interface FilterInputProps {
   activeSinceLabel: string | null;
   // CTL-384: shows [WRAP] chip when wrap mode is active.
   wrapMode?: 'truncate' | 'wrap';
+  // CTL-389: DSL (NLQ) active state for unified chip set.
+  dslActive: boolean;
+  dslLabel: string;
 }
 
 // CTL-363: wide-terminal hint set adds h:help / G:newest / r:reset.
 // Threshold of 160 cols matches the ticket's example width.
 export const WIDE_HINTS_COLS = 160;
+
+const CHIP_MAX = 20;
+const ELLIPSIS = "…";
+
+function truncChip(text: string): string {
+  return text.length > CHIP_MAX ? text.slice(0, CHIP_MAX) + ELLIPSIS : text;
+}
+
+export type FilterChip = { label: string; color: "cyan" | "yellow" | "magenta" };
+
+// CTL-387: footer chip label for an active :since window.
+// Returns null when no active label (chip should not render).
+export function formatSinceChipLabel(activeLabel: string | null): string | null {
+  if (!activeLabel) return null;
+  return `[since: ${activeLabel}]`;
+}
+
+// CTL-389: build the unified active-filter chip set shown in the footer.
+// Each active filter mechanism contributes a chip; inactive ones are absent.
+export function buildActiveChips(opts: {
+  activeSinceLabel: string | null;
+  filterText: string;
+  dslActive: boolean;
+  dslLabel: string;
+  pivot: PivotMode;
+}): FilterChip[] {
+  const chips: FilterChip[] = [];
+  if (opts.activeSinceLabel) {
+    chips.push({ label: `since: ${truncChip(opts.activeSinceLabel)}`, color: "cyan" });
+  }
+  if (opts.filterText) {
+    chips.push({ label: `/${truncChip(opts.filterText)}`, color: "yellow" });
+  }
+  if (opts.dslActive) {
+    chips.push({ label: `NLQ: ${truncChip(opts.dslLabel)}`, color: "magenta" });
+  }
+  if (opts.pivot) {
+    const id = opts.pivot.id;
+    const truncId = id.length > 12 ? `${id.slice(0, 12)}${ELLIPSIS}` : id;
+    chips.push({ label: `${opts.pivot.type}: ${truncId}`, color: "cyan" });
+  }
+  return chips;
+}
+
+// CTL-389: when all chips are inactive, filteredCount === totalCount so
+// the slash format is redundant; collapse to a single number.
+export function formatEventCount(filteredCount: number, totalCount: number): string {
+  if (filteredCount === totalCount) return `${totalCount} events`;
+  return `${filteredCount}/${totalCount} events`;
+}
 
 export function formatFilterHints(cols: number, focused: boolean): string {
   const focus = focused ? "Esc:clear" : "/:focus";
@@ -31,13 +84,6 @@ export function formatFilterHints(cols: number, focused: boolean): string {
     return `${base} | h:help G:newest r:reset`;
   }
   return base;
-}
-
-// CTL-387: footer chip text when a user-interactive `:since` is active.
-// Returns null when no active label (chip should not render).
-export function formatSinceChipLabel(activeLabel: string | null): string | null {
-  if (!activeLabel) return null;
-  return `[since: ${activeLabel}]`;
 }
 
 export function FilterInput({
@@ -52,23 +98,23 @@ export function FilterInput({
   statusMsg,
   activeSinceLabel,
   wrapMode = 'truncate',
+  dslActive,
+  dslLabel,
 }: FilterInputProps) {
-  const sinceChip = formatSinceChipLabel(activeSinceLabel);
+  const chips = buildActiveChips({ activeSinceLabel, filterText: value, dslActive, dslLabel, pivot });
+  const countStr = formatEventCount(filteredCount, totalCount);
   return (
     <Box flexDirection="row">
-      {pivot && (
-        <Text color="cyan">{`[${pivot.type}:${pivot.id.slice(0, 12)}…] `}</Text>
-      )}
-      {sinceChip && (
-        <Text color="cyan">{`${sinceChip} `}</Text>
-      )}
       <Text dimColor={!focused}>{"/ "}</Text>
       <TextInput value={value} onChange={onChange} focus={focused} placeholder="filter (substring — all fields)" />
       <Box flexGrow={1} marginLeft={2}>
         <Text dimColor wrap="truncate-end">{formatFilterHints(cols, focused)}</Text>
       </Box>
       {statusMsg && <Text color="yellow">{` ${statusMsg} `}</Text>}
-      <Text dimColor>{` ${filteredCount}/${totalCount} events`}</Text>
+      <Text dimColor>{` ${countStr}`}</Text>
+      {chips.map((chip, i) => (
+        <Text key={i} color={chip.color}>{` [${chip.label}]`}</Text>
+      ))}
       {autoFollow
         ? <Text color="green">{" [LIVE]"}</Text>
         : <Text dimColor>{" [PAUSED — G to follow]"}</Text>

--- a/plugins/dev/scripts/orch-monitor/cli/components/filter-chips.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/filter-chips.test.ts
@@ -1,0 +1,107 @@
+// filter-chips.test.ts — verifies the unified active-filter chip logic
+// introduced in CTL-389. Pure function tests; no Ink rendering required.
+
+import { describe, test, expect } from "bun:test";
+import { buildActiveChips, formatEventCount } from "./FilterInput.tsx";
+
+describe("buildActiveChips", () => {
+  const none = { activeSinceLabel: null, filterText: "", dslActive: false, dslLabel: "", pivot: null };
+
+  test("no active filters → zero chips", () => {
+    expect(buildActiveChips(none)).toEqual([]);
+  });
+
+  test("all four filters active → four chips in order", () => {
+    const chips = buildActiveChips({
+      activeSinceLabel: "5m",
+      filterText: "error",
+      dslActive: true,
+      dslLabel: "errors today",
+      pivot: { type: "orch", id: "o-adv-944-946-947-949" },
+    });
+    expect(chips).toHaveLength(4);
+    expect(chips[0]).toMatchObject({ label: "since: 5m", color: "cyan" });
+    expect(chips[1]).toMatchObject({ label: "/error", color: "yellow" });
+    expect(chips[2]).toMatchObject({ label: "NLQ: errors today", color: "magenta" });
+    expect(chips[3]).toMatchObject({ color: "cyan" });
+    expect(chips[3]?.label).toContain("orch:");
+  });
+
+  test("since chip only shows when activeSinceLabel is non-null", () => {
+    const with_ = buildActiveChips({ ...none, activeSinceLabel: "24h" });
+    expect(with_).toHaveLength(1);
+    expect(with_[0]).toMatchObject({ label: "since: 24h", color: "cyan" });
+
+    const without = buildActiveChips({ ...none, activeSinceLabel: null });
+    expect(without).toHaveLength(0);
+  });
+
+  test("filter text chip only shows when filterText non-empty", () => {
+    const with_ = buildActiveChips({ ...none, filterText: "foo" });
+    expect(with_).toHaveLength(1);
+    expect(with_[0]).toMatchObject({ label: "/foo", color: "yellow" });
+
+    const without = buildActiveChips({ ...none, filterText: "" });
+    expect(without).toHaveLength(0);
+  });
+
+  test("NLQ chip shows label and color when dslActive", () => {
+    const with_ = buildActiveChips({ ...none, dslActive: true, dslLabel: "errors in prod" });
+    expect(with_).toHaveLength(1);
+    expect(with_[0]).toMatchObject({ label: "NLQ: errors in prod", color: "magenta" });
+  });
+
+  test("NLQ label truncates at 20 chars with ellipsis", () => {
+    // "errors from orchestrators today in prod" → first 20 chars = "errors from orchestr"
+    const chips = buildActiveChips({ ...none, dslActive: true, dslLabel: "errors from orchestrators today in prod" });
+    expect(chips[0]?.label).toBe("NLQ: errors from orchestr…");
+  });
+
+  test("pivot chip renders type and truncated id", () => {
+    const chips = buildActiveChips({
+      ...none,
+      pivot: { type: "trace", id: "abc1234567890xyz" },
+    });
+    expect(chips).toHaveLength(1);
+    expect(chips[0]?.label).toBe("trace: abc123456789…");
+    expect(chips[0]?.color).toBe("cyan");
+  });
+
+  test("pivot id shorter than 12 chars renders without truncation ellipsis", () => {
+    const chips = buildActiveChips({ ...none, pivot: { type: "orch", id: "short" } });
+    expect(chips[0]?.label).toBe("orch: short");
+  });
+
+  test("since label truncates at 20 chars", () => {
+    // sinceLabel exactly 20 chars → no truncation (chip label = "since: " + full spec)
+    const exact = buildActiveChips({ ...none, activeSinceLabel: "a".repeat(20) });
+    expect(exact[0]?.label).toBe("since: " + "a".repeat(20));
+
+    // sinceLabel > 20 chars → truncated with ellipsis
+    const long = buildActiveChips({ ...none, activeSinceLabel: "a".repeat(25) });
+    expect(long[0]?.label).toBe("since: " + "a".repeat(20) + "…");
+  });
+
+  test("filter text chip truncates at 20 chars", () => {
+    const chips = buildActiveChips({ ...none, filterText: "a".repeat(25) });
+    expect(chips[0]?.label).toBe("/" + "a".repeat(20) + "…");
+  });
+});
+
+describe("formatEventCount", () => {
+  test("equal counts → single number form (no filters active)", () => {
+    expect(formatEventCount(5710, 5710)).toBe("5710 events");
+  });
+
+  test("unequal counts → slash form", () => {
+    expect(formatEventCount(2700, 5710)).toBe("2700/5710 events");
+  });
+
+  test("zero filtered", () => {
+    expect(formatEventCount(0, 100)).toBe("0/100 events");
+  });
+
+  test("all filtered out edge case (0 total)", () => {
+    expect(formatEventCount(0, 0)).toBe("0 events");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -58,7 +58,10 @@ const HELP_LINES = [
   "  :                natural-language query via Groq (needs GROQ_API_KEY)",
   "  :since 24h       reload events from last 24 h  (also: 7d, 2h, 30m, ISO date)",
   "  ?                show generated DSL and active :since window",
-  "  Esc              clear all filters (:since, /, :query) / close overlay",
+  "  S                clear :since window (reset to initial)",
+  "  Esc (in /mode)   clear substring filter only",
+  "  Esc (in :mode)   cancel/clear query input",
+  "  Esc (top-level)  clear all active filters + close overlays",
   "",
   "Scope — narrow to related events  (live mode: first press pauses; press again to apply)",
   "  t                scope to all events sharing this event's trace ID",
@@ -319,7 +322,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
       return;
     }
     if (filterFocused) {
-      if (key.escape) { setFilterFocused(false); setFilterText(""); setPivot(null); }
+      if (key.escape) { setFilterFocused(false); setFilterText(""); }
       return;
     }
 
@@ -383,6 +386,12 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
     }
     if (input === "w") {
       setWrapMode((m) => m === 'truncate' ? 'wrap' : 'truncate');
+      return;
+    }
+    if (input === "S") {
+      setActiveSinceTs(initSinceTs);
+      setActiveSinceLabel(null);
+      showStatus("since cleared");
       return;
     }
   });
@@ -461,6 +470,8 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           statusMsg={statusMsg}
           activeSinceLabel={activeSinceLabel}
           wrapMode={wrapMode}
+          dslActive={dslState !== null}
+          dslLabel={dslState?.nlQuery ?? ""}
         />
       </Box>
       <Box flexShrink={0}>


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-14T17:00:00Z -->
<!-- Last updated: 2026-05-14T17:00:00Z -->
<!-- PR: #685 -->
<!-- Previous commits: 148b8001a918a9d366a302514648b866231d1f99 -->

## Summary

- Adds a unified right-aligned chip set in the HUD footer showing all active filters in one consistent place: `[since: 5m]` (cyan), `[/text]` (yellow), `[NLQ: q]` (magenta), `[orch: id…]`/`[trace: id…]` (cyan)
- Collapses the event count to `N events` (no slash) when no filters are active — slash form only shown when filtered < total
- Adds `S` key to clear the `:since` window independently without disturbing other active filters
- Fixes Esc-in-filter-mode to clear only `filterText`, not the active pivot scope
- Updates help panel with per-filter clear key documentation
- Exports `buildActiveChips()` and `formatEventCount()` as pure functions with 14 new unit tests

Refs: https://linear.app/coalesce-labs/issue/CTL-389

## Changes Made

### `FilterInput.tsx`

- Added `dslActive: boolean` and `dslLabel: string` props for DSL/NLQ chip
- Added `CHIP_MAX = 20` and `truncChip()` for consistent truncation with `…` ellipsis
- Added `FilterChip` type (`label`, `color` union)
- Exported `buildActiveChips()` — pure function that builds the chip array from all four filter mechanisms; inactive mechanisms contribute no chip
- Exported `formatEventCount()` — collapses `N/N events` to `N events` when counts match
- Replaced ad-hoc chip placement with a single `chips.map()` loop rendering the unified chip set to the right of `[LIVE]/[PAUSED]`
- Removed the left-side pivot and since chips (now in the unified set)
- Preserved `formatSinceChipLabel()` (CTL-387 API compatibility) and `[WRAP]` chip (CTL-384)

### `hud.tsx`

- Added `S` key handler: resets `activeSinceTs` to `initSinceTs` and clears `activeSinceLabel`
- Fixed Esc handler for `filterFocused` mode: no longer calls `setPivot(null)` — only clears `filterText` and unfocuses
- Updated HELP_LINES Filters section with `S` (clear since), per-mode Esc documentation, and top-level Esc "clear everything" note
- Passes `dslActive={dslState !== null}` and `dslLabel={dslState?.nlQuery ?? ""}` to FilterInput

### `filter-chips.test.ts` (new)

- 14 unit tests for `buildActiveChips` and `formatEventCount`
- Covers: all four filters active → 4 chips in order; no filters → 0 chips; individual filter toggles; NLQ label truncation at 20 chars; pivot id truncation at 12 chars; since label truncation; filter text truncation; count collapse when equal; slash form when filtered

## How to Verify It

- [x] `bun test plugins/dev/scripts/orch-monitor/cli/components/filter-chips.test.ts` — 14 tests pass ✅
- [x] CI quality check passes ✅
- [ ] Manual: open HUD, activate all four filters, verify four chips appear right of `[LIVE]`
- [ ] Manual: with no filters active, verify count shows `5710 events` not `5710/5710 events`
- [ ] Manual: press `S` — only since chip disappears, pivot/filter/NLQ chips remain
- [ ] Manual: type in `/` filter, press Esc — filter clears, pivot chip remains in footer

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-389
- Depends on CTL-387 (`:since` chip API — `activeSinceLabel: string | null`, merged)
- Depends on CTL-384 (`[WRAP]` chip — `wrapMode` prop, merged)
