### PR TITLE
feat(dev): populate vcs.pr.number + vcs.ref.name on check_suite/workflow_run (CTL-396)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/reactive-pr-filter.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/reactive-pr-filter.test.ts
@@ -68,6 +68,7 @@ describe.skipIf(JQ_PATH === null)("reactive PR lifecycle filter", () => {
       draft: false,
       mergeable: true,
       headRef: "",
+      headSha: "",
     })!;
     expect(env.attributes["event.name"]).toBe("github.pr.merged");
     expectMatch(REACTIVE_FILTER, env);
@@ -85,6 +86,7 @@ describe.skipIf(JQ_PATH === null)("reactive PR lifecycle filter", () => {
       draft: false,
       mergeable: true,
       headRef: "",
+      headSha: "",
     })!;
     expectNoMatch(REACTIVE_FILTER, env);
   });
@@ -97,6 +99,7 @@ describe.skipIf(JQ_PATH === null)("reactive PR lifecycle filter", () => {
       conclusion: "failure",
       status: "completed",
       headRef: "",
+      headSha: "",
     })!;
     expectMatch(REACTIVE_FILTER, env);
   });
@@ -109,6 +112,7 @@ describe.skipIf(JQ_PATH === null)("reactive PR lifecycle filter", () => {
       conclusion: "success",
       status: "completed",
       headRef: "",
+      headSha: "",
     })!;
     expectNoMatch(REACTIVE_FILTER, env);
   });
@@ -121,6 +125,7 @@ describe.skipIf(JQ_PATH === null)("reactive PR lifecycle filter", () => {
       conclusion: "failure",
       status: "completed",
       headRef: "",
+      headSha: "",
     })!;
     expectNoMatch(REACTIVE_FILTER, env);
   });

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-events.test.ts
@@ -171,13 +171,14 @@ describe("parseWebhookEvent", () => {
   });
 
   describe("check_suite", () => {
-    it("extracts pr numbers, conclusion, and head_branch", () => {
+    it("extracts pr numbers, conclusion, head_branch, and head_sha", () => {
       const got = parseWebhookEvent("check_suite", {
         ...REPO,
         check_suite: {
           status: "completed",
           conclusion: "success",
           head_branch: "orch-foo-CTL-99",
+          head_sha: "deadbeef1234",
           pull_requests: [{ number: 70 }, { number: 71 }],
         },
       });
@@ -187,9 +188,10 @@ describe("parseWebhookEvent", () => {
       expect(got.conclusion).toBe("success");
       expect(got.status).toBe("completed");
       expect(got.headRef).toBe("orch-foo-CTL-99");
+      expect(got.headSha).toBe("deadbeef1234");
     });
 
-    it("handles empty pr list", () => {
+    it("handles empty pr list and missing head_sha", () => {
       const got = parseWebhookEvent("check_suite", {
         ...REPO,
         check_suite: { status: "in_progress", pull_requests: [] },
@@ -199,6 +201,7 @@ describe("parseWebhookEvent", () => {
       expect(got.prNumbers).toEqual([]);
       expect(got.conclusion).toBeNull();
       expect(got.headRef).toBe("");
+      expect(got.headSha).toBe("");
     });
   });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../lib/webhook-handler";
 import type { EventLogWriter } from "../lib/event-log";
 import type { CanonicalEvent } from "../lib/canonical-event";
+import type { PrCacheLike } from "../lib/pr-cache";
 
 const SECRET = "test-secret";
 
@@ -72,6 +73,18 @@ class FakeEventLog implements EventLogWriter {
     }
     this.appends.push(envelope);
     return Promise.resolve();
+  }
+}
+
+class FakePrCache implements PrCacheLike {
+  store = new Map<string, number>();
+  puts: Array<{ repo: string; headSha: string; headBranch: string; prNumber: number }> = [];
+  put(repo: string, headSha: string, headBranch: string, prNumber: number): void {
+    this.store.set(`${repo}:${headSha}`, prNumber);
+    this.puts.push({ repo, headSha, headBranch, prNumber });
+  }
+  get(repo: string, headSha: string): number | null {
+    return this.store.get(`${repo}:${headSha}`) ?? null;
   }
 }
 
@@ -556,6 +569,148 @@ describe("createWebhookHandler", () => {
   });
 });
 
+// CTL-396: pr-cache integration tests
+describe("createWebhookHandler — pr-cache (CTL-396)", () => {
+  it("pull_request.opened populates the pr cache", async () => {
+    const prCache = new FakePrCache();
+    const eventLog = new FakeEventLog();
+    const handler = createWebhookHandler({
+      secret: SECRET,
+      prFetcher: new FakeFetcher(),
+      eventLog,
+      prCache,
+    });
+    await handler.handle(
+      makeReq({
+        ...REPO,
+        action: "opened",
+        pull_request: {
+          number: 55,
+          merged: false,
+          head: { ref: "feature-branch", sha: "abc111" },
+        },
+      }),
+    );
+    expect(prCache.puts).toEqual([
+      { repo: "owner/repo", headSha: "abc111", headBranch: "feature-branch", prNumber: 55 },
+    ]);
+  });
+
+  it("pull_request.synchronize updates the pr cache", async () => {
+    const prCache = new FakePrCache();
+    const handler = createWebhookHandler({
+      secret: SECRET,
+      prFetcher: new FakeFetcher(),
+      prCache,
+    });
+    await handler.handle(
+      makeReq({
+        ...REPO,
+        action: "synchronize",
+        pull_request: {
+          number: 56,
+          merged: false,
+          head: { ref: "feature-branch", sha: "abc222" },
+        },
+      }),
+    );
+    expect(prCache.puts.length).toBe(1);
+    expect(prCache.puts[0]).toMatchObject({ headSha: "abc222", prNumber: 56 });
+  });
+
+  it("check_suite with empty prNumbers uses cache to set vcs.pr.number", async () => {
+    const prCache = new FakePrCache();
+    prCache.store.set("owner/repo:deadbeef", 77);
+    const eventLog = new FakeEventLog();
+    const handler = createWebhookHandler({
+      secret: SECRET,
+      prFetcher: new FakeFetcher(),
+      eventLog,
+      prCache,
+    });
+    await handler.handle(
+      makeReq(
+        {
+          ...REPO,
+          check_suite: {
+            status: "completed",
+            conclusion: "success",
+            head_sha: "deadbeef",
+            head_branch: "main",
+            pull_requests: [],
+          },
+        },
+        { "x-github-event": "check_suite" },
+      ),
+    );
+    expect(eventLog.appends.length).toBe(1);
+    expect(eventLog.appends[0]?.attributes["vcs.pr.number"]).toBe(77);
+  });
+
+  it("workflow_run with empty prNumbers uses cache to set vcs.pr.number", async () => {
+    const prCache = new FakePrCache();
+    prCache.store.set("owner/repo:sha999", 88);
+    const eventLog = new FakeEventLog();
+    const handler = createWebhookHandler({
+      secret: SECRET,
+      prFetcher: new FakeFetcher(),
+      eventLog,
+      prCache,
+    });
+    await handler.handle(
+      makeReq(
+        {
+          ...REPO,
+          action: "completed",
+          workflow_run: {
+            id: 888,
+            workflow_id: 1,
+            name: "CI",
+            head_sha: "sha999",
+            head_branch: "main",
+            status: "completed",
+            conclusion: "success",
+            run_number: 1,
+            html_url: "https://github.com/owner/repo/actions/runs/888",
+            pull_requests: [],
+          },
+        },
+        { "x-github-event": "workflow_run" },
+      ),
+    );
+    expect(eventLog.appends.length).toBe(1);
+    expect(eventLog.appends[0]?.attributes["vcs.pr.number"]).toBe(88);
+  });
+
+  it("check_suite without cache hit leaves vcs.pr.number undefined", async () => {
+    const prCache = new FakePrCache();
+    const eventLog = new FakeEventLog();
+    const handler = createWebhookHandler({
+      secret: SECRET,
+      prFetcher: new FakeFetcher(),
+      eventLog,
+      prCache,
+    });
+    await handler.handle(
+      makeReq(
+        {
+          ...REPO,
+          check_suite: {
+            status: "completed",
+            conclusion: "success",
+            head_sha: "nomatch",
+            head_branch: "main",
+            pull_requests: [],
+          },
+        },
+        { "x-github-event": "check_suite" },
+      ),
+    );
+    expect(eventLog.appends.length).toBe(1);
+    expect(eventLog.appends[0]?.attributes["vcs.pr.number"]).toBeUndefined();
+  });
+});
+
 describe("buildEventLogEnvelope (canonical)", () => {
   it("maps pull_request.closed (merged=true) → github.pr.merged with vcs attributes", () => {
     const env = buildEventLogEnvelope(
@@ -570,6 +725,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
         draft: false,
         mergeable: true,
         headRef: "",
+        headSha: "",
       },
       TS,
     );
@@ -597,6 +753,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
         draft: false,
         mergeable: null,
         headRef: "",
+        headSha: "",
       },
       TS,
     );
@@ -616,6 +773,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
         draft: false,
         mergeable: null,
         headRef: "",
+        headSha: "",
       },
       TS,
     );
@@ -635,6 +793,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
         draft: false,
         mergeable: null,
         headRef: "",
+        headSha: "",
       },
       TS,
     );
@@ -654,6 +813,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
         draft: false,
         mergeable: null,
         headRef: "",
+        headSha: "",
       },
       TS,
     );
@@ -734,7 +894,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
     expect(env!.attributes["cicd.pipeline.run.conclusion"]).toBeUndefined();
   });
 
-  it("workflow_run with multiple PRs omits vcs.pr.number (multi-PR ambiguity)", () => {
+  it("workflow_run with multiple PRs uses the first PR number (first-match policy)", () => {
     const env = buildEventLogEnvelope(
       {
         kind: "workflow_run",
@@ -753,7 +913,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
       },
       TS,
     );
-    expect(env!.attributes["vcs.pr.number"]).toBeUndefined();
+    expect(env!.attributes["vcs.pr.number"]).toBe(326);
     const payload = env!.body.payload as { prNumbers: number[] };
     expect(payload.prNumbers).toEqual([326, 327]);
   });
@@ -767,6 +927,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
         status: "completed",
         conclusion: "failure",
         headRef: "",
+        headSha: "",
       },
       TS,
     );
@@ -787,6 +948,7 @@ describe("buildEventLogEnvelope (canonical)", () => {
         status: "in_progress",
         conclusion: null,
         headRef: "feature-branch",
+        headSha: "",
       },
       TS,
     );
@@ -928,6 +1090,105 @@ describe("buildEventLogEnvelope (canonical)", () => {
     expect(env!.attributes["vcs.ref.name"]).toBe("refs/heads/main");
     expect(env!.attributes["vcs.revision"]).toBe("bbb");
   });
+
+  // CTL-396: check_suite with multiple PRs uses first match
+  it("check_suite with multiple PRs uses first PR number (first-match policy)", () => {
+    const env = buildEventLogEnvelope(
+      {
+        kind: "check_suite",
+        repo: "o/r",
+        prNumbers: [100, 101],
+        status: "completed",
+        conclusion: "success",
+        headRef: "orch-foo-CTL-99",
+        headSha: "abc456",
+      },
+      TS,
+    );
+    expect(env!.attributes["vcs.pr.number"]).toBe(100);
+  });
+
+  // CTL-396: check_suite headSha → vcs.revision
+  it("check_suite with headSha sets vcs.revision", () => {
+    const env = buildEventLogEnvelope(
+      {
+        kind: "check_suite",
+        repo: "o/r",
+        prNumbers: [],
+        status: "completed",
+        conclusion: "success",
+        headRef: "main",
+        headSha: "deadbeef1234",
+      },
+      TS,
+    );
+    expect(env!.attributes["vcs.revision"]).toBe("deadbeef1234");
+  });
+
+  // CTL-396: workflow_run with no PR but headBranch → vcs.ref.name
+  it("workflow_run with no PR and headBranch sets vcs.ref.name", () => {
+    const env = buildEventLogEnvelope(
+      {
+        kind: "workflow_run",
+        repo: "o/r",
+        action: "completed",
+        workflowId: 99,
+        runId: 600,
+        name: "Deploy",
+        headSha: "abc999",
+        headBranch: "main",
+        status: "completed",
+        conclusion: "success",
+        runNumber: 10,
+        htmlUrl: "https://github.com/o/r/actions/runs/600",
+        prNumbers: [],
+      },
+      TS,
+    );
+    expect(env!.attributes["vcs.pr.number"]).toBeUndefined();
+    expect(env!.attributes["vcs.ref.name"]).toBe("main");
+  });
+
+  // CTL-396: cachedPrNumber opt falls through when prNumbers is empty
+  it("check_suite with empty prNumbers uses cachedPrNumber from opts", () => {
+    const env = buildEventLogEnvelope(
+      {
+        kind: "check_suite",
+        repo: "o/r",
+        prNumbers: [],
+        status: "completed",
+        conclusion: "success",
+        headRef: "main",
+        headSha: "aabbcc",
+      },
+      TS,
+      { cachedPrNumber: 42 },
+    );
+    expect(env!.attributes["vcs.pr.number"]).toBe(42);
+  });
+
+  it("workflow_run with empty prNumbers uses cachedPrNumber from opts", () => {
+    const env = buildEventLogEnvelope(
+      {
+        kind: "workflow_run",
+        repo: "o/r",
+        action: "completed",
+        workflowId: 1,
+        runId: 700,
+        name: "CI",
+        headSha: "aabbcc",
+        headBranch: "main",
+        status: "completed",
+        conclusion: "success",
+        runNumber: 1,
+        htmlUrl: "https://github.com/o/r/actions/runs/700",
+        prNumbers: [],
+      },
+      TS,
+      { cachedPrNumber: 99 },
+    );
+    expect(env!.attributes["vcs.pr.number"]).toBe(99);
+  });
 });
 
 describe("attributionInputFor", () => {
@@ -943,6 +1204,7 @@ describe("attributionInputFor", () => {
       draft: false,
       mergeable: null,
       headRef: "orch-foo-CTL-1",
+      headSha: "",
     });
     expect(got).toEqual({ repo: "o/r", pr: 42, headRef: "orch-foo-CTL-1" });
   });
@@ -955,6 +1217,7 @@ describe("attributionInputFor", () => {
       conclusion: "failure",
       status: "completed",
       headRef: "orch-foo-CTL-2",
+      headSha: "",
     });
     expect(got).toEqual({ repo: "o/r", pr: 10, headRef: "orch-foo-CTL-2" });
   });

--- a/plugins/dev/scripts/orch-monitor/lib/pr-cache.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/pr-cache.ts
@@ -1,0 +1,44 @@
+import { Database } from "bun:sqlite";
+import { homedir } from "node:os";
+import { resolve, dirname } from "node:path";
+import { mkdirSync } from "node:fs";
+
+const CATALYST_DIR = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
+const DEFAULT_DB_PATH = resolve(CATALYST_DIR, "filter-state.db");
+
+export interface PrCacheLike {
+  put(repo: string, headSha: string, headBranch: string, prNumber: number): void;
+  get(repo: string, headSha: string): number | null;
+}
+
+export function createFileBasedPrCache(dbPath = DEFAULT_DB_PATH): PrCacheLike {
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath, { create: true });
+  db.run("PRAGMA journal_mode=WAL");
+  db.run(`
+    CREATE TABLE IF NOT EXISTS pr_cache (
+      repo        TEXT NOT NULL,
+      head_sha    TEXT NOT NULL,
+      head_branch TEXT NOT NULL,
+      pr_number   INTEGER NOT NULL,
+      updated_at  TEXT NOT NULL,
+      PRIMARY KEY (repo, head_sha)
+    )
+  `);
+  const insertStmt = db.prepare(
+    `INSERT OR REPLACE INTO pr_cache (repo, head_sha, head_branch, pr_number, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  const selectStmt = db.prepare<{ pr_number: number }, [string, string]>(
+    `SELECT pr_number FROM pr_cache WHERE repo = ? AND head_sha = ?`,
+  );
+  return {
+    put(repo, headSha, headBranch, prNumber) {
+      insertStmt.run(repo, headSha, headBranch, prNumber, new Date().toISOString());
+    },
+    get(repo, headSha) {
+      const row = selectStmt.get(repo, headSha);
+      return row?.pr_number ?? null;
+    },
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-events.ts
@@ -35,6 +35,8 @@ export type WebhookEvent =
       mergeable: boolean | null;
       /** Head branch name (CTL-234 — used to attribute the event to an orchestrator). Empty when payload omits it. */
       headRef: string;
+      /** Head commit SHA from `pull_request.head.sha` (CTL-396 — used to populate the SHA→PR cache for check_suite/workflow_run correlation). Empty when payload omits it. */
+      headSha: string;
     }
   | {
       kind: "pull_request_review";
@@ -62,6 +64,8 @@ export type WebhookEvent =
       conclusion: string | null;
       status: string;
       headRef: string;
+      /** Head commit SHA from `check_suite.head_sha` (CTL-396 — used for SHA→PR cache lookup). Empty when payload omits it. */
+      headSha: string;
     }
   | {
       kind: "status";
@@ -205,6 +209,11 @@ function getPrHeadRef(pr: Record<string, unknown>): string {
   return isObject(head) ? getStr(head, "ref") : "";
 }
 
+function getPrHeadSha(pr: Record<string, unknown>): string {
+  const head = pr.head;
+  return isObject(head) ? getStr(head, "sha") : "";
+}
+
 export function parseWebhookEvent(
   eventName: string,
   payload: unknown,
@@ -262,6 +271,7 @@ function parsePullRequest(
     draft: getBool(pr, "draft"),
     mergeable: getOptBool(pr, "mergeable"),
     headRef: getPrHeadRef(pr),
+    headSha: getPrHeadSha(pr),
   };
 }
 
@@ -335,6 +345,7 @@ function parseCheckSuite(
     conclusion: getOptStr(suite, "conclusion"),
     status: getStr(suite, "status"),
     headRef: getStr(suite, "head_branch"),
+    headSha: getStr(suite, "head_sha"),
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
@@ -8,6 +8,7 @@ import {
   type CanonicalEvent,
   type Attributes,
 } from "./canonical-event";
+import { type PrCacheLike } from "./pr-cache";
 
 const GITHUB_SERVICE_NAME = "catalyst.github" as const;
 
@@ -64,6 +65,10 @@ export interface WebhookHandlerDeps {
   /** Cap for the in-memory delivery-ID dedup set. Default 1000. */
   idempotencyMax?: number;
   logger?: WebhookLogger;
+  /** Optional SHA→PR cache. When provided, pull_request.opened/synchronize events
+   * populate it and check_suite/workflow_run events use it to recover PR numbers
+   * for push-triggered CI runs where pull_requests[] is empty. */
+  prCache?: PrCacheLike;
 }
 
 /**
@@ -155,6 +160,7 @@ function deploymentStatusSeverity(state: string): "INFO" | "WARN" | "ERROR" {
 export function buildEventLogEnvelope(
   event: WebhookEvent,
   ts: string = new Date().toISOString(),
+  opts?: { cachedPrNumber?: number },
 ): CanonicalEvent | null {
   switch (event.kind) {
     case "pull_request": {
@@ -231,9 +237,12 @@ export function buildEventLogEnvelope(
         "vcs.repository.name": event.repo,
         "cicd.pipeline.run.status": event.status,
       };
-      if (event.prNumbers.length === 1) {
-        attrs["vcs.pr.number"] = event.prNumbers[0];
-      }
+      if (event.headSha) attrs["vcs.revision"] = event.headSha;
+      const effectivePr =
+        event.prNumbers.length >= 1
+          ? event.prNumbers[0]
+          : opts?.cachedPrNumber ?? null;
+      if (effectivePr !== null) attrs["vcs.pr.number"] = effectivePr;
       if (event.conclusion !== null) {
         attrs["cicd.pipeline.run.conclusion"] = event.conclusion;
       }
@@ -242,8 +251,7 @@ export function buildEventLogEnvelope(
         eventName,
         entity: "check_suite",
         action: event.status,
-        label:
-          event.prNumbers.length > 0 ? `PR #${event.prNumbers[0]}` : undefined,
+        label: effectivePr !== null ? `PR #${effectivePr}` : undefined,
         severity: conclusionSeverity(event.conclusion),
         attrs,
         message: `${eventName} for ${event.repo}${
@@ -415,9 +423,12 @@ export function buildEventLogEnvelope(
         "cicd.pipeline.run.status": event.status,
         "cicd.pipeline.name": event.name,
       };
-      if (event.prNumbers.length === 1) {
-        attrs["vcs.pr.number"] = event.prNumbers[0];
-      }
+      if (event.headBranch) attrs["vcs.ref.name"] = event.headBranch;
+      const effectivePr =
+        event.prNumbers.length >= 1
+          ? event.prNumbers[0]
+          : opts?.cachedPrNumber ?? null;
+      if (effectivePr !== null) attrs["vcs.pr.number"] = effectivePr;
       if (event.conclusion !== null) {
         attrs["cicd.pipeline.run.conclusion"] = event.conclusion;
       }
@@ -427,7 +438,7 @@ export function buildEventLogEnvelope(
         entity: "workflow_run",
         action: event.action,
         label:
-          event.prNumbers.length > 0 ? `PR #${event.prNumbers[0]}` : event.name,
+          effectivePr !== null ? `PR #${effectivePr}` : event.name,
         severity: conclusionSeverity(event.conclusion),
         attrs,
         message: `${eventName} ${event.name} in ${event.repo} (${event.conclusion ?? event.status})`,
@@ -524,6 +535,18 @@ export function createWebhookHandler(
               );
             }
           }
+        }
+        if (
+          deps.prCache &&
+          event.headSha &&
+          (event.action === "opened" || event.action === "synchronize")
+        ) {
+          deps.prCache.put(
+            event.repo,
+            event.headSha,
+            event.headRef,
+            event.number,
+          );
         }
         await deps.prFetcher.force({ repo: event.repo, number: event.number });
         break;
@@ -632,7 +655,21 @@ export function createWebhookHandler(
     // Log every accepted event to the unified event log BEFORE dispatching, so
     // a crash mid-dispatch can be reconciled from the log on restart.
     if (deps.eventLog && event.kind !== "ignored") {
-      const envelope = buildEventLogEnvelope(event);
+      let cachedPrNumber: number | undefined;
+      if (
+        deps.prCache &&
+        (event.kind === "check_suite" || event.kind === "workflow_run") &&
+        event.prNumbers.length === 0 &&
+        event.headSha
+      ) {
+        cachedPrNumber =
+          deps.prCache.get(event.repo, event.headSha) ?? undefined;
+      }
+      const envelope = buildEventLogEnvelope(
+        event,
+        undefined,
+        cachedPrNumber !== undefined ? { cachedPrNumber } : undefined,
+      );
       if (envelope !== null) {
         if (deps.resolveOrchestrator) {
           const attribInput = attributionInputFor(event);

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -69,6 +69,7 @@ import {
   createWebhookHandler,
   type WebhookHandler,
 } from "./lib/webhook-handler";
+import { createFileBasedPrCache } from "./lib/pr-cache";
 import {
   resolveOrchestrator as resolveOrchestratorFn,
   type ActiveOrchestrator,
@@ -612,6 +613,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
       resolveOrchestrator: (input) =>
         resolveOrchestratorFn(input, getActiveOrchestrators()),
       emit: (type, data) => emit(type, data),
+      prCache: createFileBasedPrCache(),
       logger: {
         info: (m) => console.info(m),
         warn: (m) => console.warn(m),


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-14T00:00:00Z -->
<!-- Last updated: 2026-05-14T00:00:00Z -->
<!-- PR: #687 -->
<!-- Previous commits: 725a9e18a5f9a5d286c45cc1bdefacbecd6fbd1e -->

## Summary

Fixes a long-standing gap in the orch-monitor webhook event pipeline where `check_suite` and `workflow_run` events failed to carry `vcs.pr.number` in most real-world cases, leaving the HUD's REF column empty for CI events. The root cause was a `prNumbers.length === 1` guard in `buildEventLogEnvelope` that silently dropped the PR number when 0 or 2+ PRs were associated. This PR replaces that guard with a first-match policy (`prNumbers[0]`) and adds a SQLite-backed SHA→PR cache to recover PR numbers for push-triggered CI runs where GitHub sends `pull_requests: []`.

## Changes Made

### Core Bug Fix — first-match policy (`webhook-handler.ts`)

- Replaced `prNumbers.length === 1` guard with `prNumbers.length >= 1 ? prNumbers[0] : opts?.cachedPrNumber ?? null` in both `check_suite` and `workflow_run` envelope branches
- `vcs.pr.number` is now set on events with 1 PR (was working), 2+ PRs (now fixed — uses first match), and 0 PRs with a cache hit (new capability)
- `label` field updated to use same `effectivePr` value for consistency

### New attribute: `vcs.revision` on `check_suite` events (`webhook-handler.ts`)

- `headSha` from the check_suite payload is now written to `vcs.revision`, enabling downstream SHA-based correlation and richer event display

### New attribute: `vcs.ref.name` fallback for `workflow_run` events (`webhook-handler.ts`)

- Push-triggered `workflow_run` events have no associated PR but do carry `head_branch`; that value is now written to `vcs.ref.name` as a fallback so the HUD REF column shows the branch name instead of being blank

### New types: `headSha` on webhook event types (`webhook-events.ts`)

- Added `headSha: string` to the `pull_request` union type (extracted from `pull_request.head.sha`)
- Added `headSha: string` to the `check_suite` union type (extracted from `check_suite.head_sha`)
- Added `getPrHeadSha()` helper
- Updated `parsePullRequest` and `parseCheckSuite` to populate the new field

### New module: SHA→PR cache (`lib/pr-cache.ts`)

- `PrCacheLike` interface with `put(repo, headSha, headBranch, prNumber)` and `get(repo, headSha): number | null`
- `createFileBasedPrCache(dbPath?)` factory using `bun:sqlite` against `~/catalyst/filter-state.db` (WAL mode, shared with broker)
- Schema: `pr_cache(repo, head_sha, head_branch, pr_number, updated_at)` — `PRIMARY KEY (repo, head_sha)` with upsert
- Uses prepared statements for efficiency

### Cache population + lookup wiring (`webhook-handler.ts`, `server.ts`)

- `pull_request.opened` and `pull_request.synchronize` events populate the cache (keyed by `repo + headSha`)
- Before building a `check_suite` or `workflow_run` envelope where `prNumbers` is empty and `headSha` is non-empty, the handler does a cache lookup and passes the result as `opts.cachedPrNumber`
- `createFileBasedPrCache()` wired into `createServer()` in `server.ts`

### Test coverage (`__tests__/webhook-events.test.ts`, `__tests__/webhook-handler.test.ts`)

- Updated `check_suite` parser tests to assert `headSha` is extracted correctly
- Added `FakePrCache` in-memory test double
- 5 new integration tests for cache behavior: opened/synchronize populates cache, check_suite/workflow_run with empty prNumbers uses cache, no-cache-hit leaves `vcs.pr.number` undefined
- Added `buildEventLogEnvelope` unit tests: check_suite multiple PRs → first PR; headSha → vcs.revision; workflow_run no-PR + headBranch → vcs.ref.name; cachedPrNumber opt → vcs.pr.number for both event types
- Updated existing "workflow_run with multiple PRs" test from `toBeUndefined()` to `toBe(326)` (first-match policy)
- Added `headSha: ""` to all existing test event objects where required by the updated type

## How to Verify It

- [ ] Run tests: `cd plugins/dev/scripts/orch-monitor && bun test` — all tests pass ✅
- [ ] `check_suite` events with `pull_requests: [PR_A, PR_B]` now carry `vcs.pr.number = PR_A` (previously dropped)
- [ ] `check_suite` / `workflow_run` events triggered by a direct push (empty `pull_requests[]`) populate `vcs.pr.number` from cache once a `pull_request.opened` or `.synchronize` event has been processed for the same `head_sha`
- [ ] `workflow_run` events triggered by push (no PR) now carry `vcs.ref.name = headBranch`
- [ ] `check_suite` events carry `vcs.revision = headSha`
- [ ] HUD REF column shows PR numbers for CI events on PRs

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-396
