### PR TITLE
fix(dev): remove unnecessary type assertions left by CTL-394 worker

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-columns.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-columns.test.ts
@@ -289,8 +289,8 @@ describe("loadHudConfig", () => {
     const result = loadHudConfig(path);
     expect(result).not.toBeNull();
     expect(result).toHaveLength(2);
-    expect(result![0]!.id).toBe("time");
-    expect(result![1]!.id).toBe("details");
+    expect(result![0].id).toBe("time");
+    expect(result![1].id).toBe("details");
   });
 
   test("parses width and minTerminalWidth fields", () => {
@@ -304,8 +304,8 @@ describe("loadHudConfig", () => {
       },
     }));
     const result = loadHudConfig(path);
-    expect(result![0]!.width).toBe(8);
-    expect(result![0]!.minTerminalWidth).toBe(50);
+    expect(result![0].width).toBe(8);
+    expect(result![0].minTerminalWidth).toBe(50);
   });
 
   test("parses width:'auto'", () => {
@@ -314,7 +314,7 @@ describe("loadHudConfig", () => {
       hud: { columns: [{ id: "repo", width: "auto" }, { id: "details" }] },
     }));
     const result = loadHudConfig(path);
-    expect(result![0]!.width).toBe("auto");
+    expect(result![0].width).toBe("auto");
   });
 
   test("skips entries with unknown id", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/monitor-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/monitor-config.ts
@@ -113,7 +113,7 @@ export function loadHudConfig(monitorJsonPath: string): HudColumnConfig[] | null
     const entry: HudColumnConfig = { id: col.id as HudColumnId };
     if (typeof col.visible === "boolean") entry.visible = col.visible;
     if (typeof col.width === "number" || col.width === "auto") {
-      entry.width = col.width as number | "auto";
+      entry.width = col.width;
     }
     if (typeof col.minTerminalWidth === "number") {
       entry.minTerminalWidth = col.minTerminalWidth;


### PR DESCRIPTION
## Summary

- Removes 5 redundant `!` non-null assertions after array indexing in `hud-columns.test.ts` (the guard already narrows the type)
- Removes unnecessary `as number | "auto"` cast in `monitor-config.ts` (the `if` condition already narrows `col.width`)

These were committed by the CTL-394 worker but auto-merge fired before the worker's self-fix commit could push.

## Test plan

- [x] `bun run lint` exits 0 in `orch-monitor/`
- [x] No functional changes — type assertions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)