### PR TITLE
fix(dev): route session.heartbeat to broker watchdog liveness map (CTL-401)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -443,6 +443,10 @@ export function clearLastHeartbeat() {
   workerToOrchestrator.clear();
 }
 
+export function getWorkerToOrchestrator() {
+  return workerToOrchestrator;
+}
+
 // CTL-336: read name/payload/orchestrator from canonical OTel-format events
 // (data in `attributes` + `body.payload`) as well as legacy flat events
 // (data in `event` + `detail` + `orchestrator`). Resolved here so the
@@ -660,11 +664,13 @@ export function handleAgentCheckout(event) {
 }
 
 export function handleAgentHeartbeat(event) {
-  const sessionId = event.session ?? event.worker ?? event.orchestrator;
+  const sessionId =
+    event.session ?? event.worker ?? event.orchestrator ??
+    event.attributes?.["catalyst.session.id"];
   if (!sessionId) return;
   const existing = lastHeartbeat.get(sessionId);
   lastHeartbeat.set(sessionId, { ts: Date.now(), notified: existing?.notified ?? false });
-  const orchId = event.orchestrator;
+  const orchId = event.orchestrator ?? event.attributes?.["catalyst.orchestrator.id"];
   if (orchId && sessionId !== orchId) {
     workerToOrchestrator.set(sessionId, orchId);
   }
@@ -1050,6 +1056,9 @@ export function shouldSkipEvent(event) {
   const name = getEventName(event);
   if (name.startsWith("filter.")) return true;
   if (name.startsWith("broker.daemon")) return true;
+  // CTL-401: liveness pings — handled earlier in processEvent, skip here too
+  // so they never reach the Groq queue even if the early-return path changes.
+  if (name === "session.heartbeat") return true;
   return false;
 }
 
@@ -1369,6 +1378,13 @@ export function processEvent(event) {
     return;
   }
   if (name === "agent.heartbeat") {
+    handleAgentHeartbeat(event);
+    return;
+  }
+  // CTL-401: route canonical session.heartbeat to the same watchdog liveness
+  // handler. The session ID lives in attributes["catalyst.session.id"] rather
+  // than the top-level flat field; handleAgentHeartbeat now reads both shapes.
+  if (name === "session.heartbeat") {
     handleAgentHeartbeat(event);
     return;
   }

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -19,6 +19,7 @@ import {
   getInterests,
   clearInterests,
   getLastHeartbeat,
+  getWorkerToOrchestrator,
   clearLastHeartbeat,
   loadPersistedInterests,
   processEvent,
@@ -434,6 +435,55 @@ describe("agent.heartbeat", () => {
   test("falls back to worker field", () => {
     handleAgentHeartbeat({ event: "agent.heartbeat", worker: "CTL-275" });
     expect(getLastHeartbeat().has("CTL-275")).toBe(true);
+  });
+});
+
+// CTL-401: canonical session.heartbeat routing ─────────────────────────────
+
+describe("session.heartbeat (canonical OTel)", () => {
+  test("handleAgentHeartbeat reads session ID from canonical attributes", () => {
+    handleAgentHeartbeat({
+      attributes: { "event.name": "session.heartbeat", "catalyst.session.id": "sess-canonical" },
+    });
+    expect(getLastHeartbeat().has("sess-canonical")).toBe(true);
+  });
+
+  test("handleAgentHeartbeat reads orchestrator ID from canonical attributes", () => {
+    handleAgentHeartbeat({
+      attributes: {
+        "event.name": "session.heartbeat",
+        "catalyst.session.id": "sess-w",
+        "catalyst.orchestrator.id": "orch-x",
+      },
+    });
+    expect(getWorkerToOrchestrator().get("sess-w")).toBe("orch-x");
+  });
+
+  test("flat session field still takes priority over canonical attribute", () => {
+    handleAgentHeartbeat({
+      session: "sess-flat",
+      attributes: { "catalyst.session.id": "sess-attr" },
+    });
+    expect(getLastHeartbeat().has("sess-flat")).toBe(true);
+    expect(getLastHeartbeat().has("sess-attr")).toBe(false);
+  });
+
+  test("processEvent routes session.heartbeat to lastHeartbeat", () => {
+    processEvent({
+      attributes: { "event.name": "session.heartbeat", "catalyst.session.id": "sess-proc-canonical" },
+      resource: { "service.name": "catalyst.session" },
+      body: { payload: null },
+    });
+    expect(getLastHeartbeat().has("sess-proc-canonical")).toBe(true);
+  });
+
+  test("shouldSkipEvent returns true for session.heartbeat canonical", () => {
+    expect(
+      shouldSkipEvent({
+        attributes: { "event.name": "session.heartbeat" },
+        resource: { "service.name": "catalyst.session" },
+      }),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-14T02:42:00Z -->
<!-- Last updated: 2026-05-14T02:42:00Z -->
<!-- PR: #711 -->
<!-- Previous commits: 395588c -->

## Summary

Fixes a routing gap where `session.heartbeat` events emitted by `catalyst-session.sh` fell through to the Groq prose classifier instead of refreshing the broker's watchdog liveness map. Sessions using canonical OTel heartbeats were falsely triggering stale-heartbeat wakes while active.

## Problem

`catalyst-session.sh heartbeat` emits canonical OTel `session.heartbeat` events with the session ID stored in `attributes["catalyst.session.id"]`. The broker's `processEvent` router only handled two heartbeat shapes:
- `agent.heartbeat` (flat legacy format, reads `event.session`)
- `heartbeat` (flat legacy format, reads `event.worker ?? event.session ?? event.orchestrator`)

`session.heartbeat` matched neither, passed `shouldSkipEvent` (not a broker emission, not `filter.*`, not `broker.daemon*`), and fell through to `queueEvent` for Groq classification.

**Net effect:** every session heartbeat call cost a Groq token and did **not** refresh `lastHeartbeat`, so the watchdog could fire false stale-heartbeat wakes while a session was actively running.

## Changes

### `plugins/dev/scripts/broker/index.mjs`

**`handleAgentHeartbeat`** — add canonical attribute fallbacks:
```js
// Before
const sessionId = event.session ?? event.worker ?? event.orchestrator;
const orchId = event.orchestrator;

// After
const sessionId =
  event.session ?? event.worker ?? event.orchestrator ??
  event.attributes?.["catalyst.session.id"];
const orchId = event.orchestrator ?? event.attributes?.["catalyst.orchestrator.id"];
```
Flat top-level fields still take priority, so existing `agent.heartbeat` handling is unchanged.

**`processEvent`** — add early route for `session.heartbeat` (before `shouldSkipEvent`):
```js
if (name === "session.heartbeat") {
  handleAgentHeartbeat(event);
  return;
}
```
Mirrors the existing `agent.heartbeat` route at line 1371.

**`shouldSkipEvent`** — add belt-and-suspenders guard:
```js
if (name === "session.heartbeat") return true;
```
Ensures `session.heartbeat` never reaches Groq even if the early-route path changes.

**`getWorkerToOrchestrator()`** — export the `workerToOrchestrator` map for test assertions (test-only helper, mirrors existing `getLastHeartbeat()`).

### `plugins/dev/scripts/broker/index.test.mjs`

Adds 5 tests in `describe("session.heartbeat (canonical OTel)")`:
- `handleAgentHeartbeat` reads session ID from canonical attributes
- `handleAgentHeartbeat` reads orchestrator ID from canonical attributes
- Flat `session` field still takes priority over canonical attribute
- `processEvent` routes `session.heartbeat` to `lastHeartbeat`
- `shouldSkipEvent` returns true for `session.heartbeat`

## How to Verify

- [x] `bun test` in `plugins/dev/scripts/broker/` — 172 pass, 0 fail ✅
- [x] New `describe("session.heartbeat")` block adds 5 tests, all green ✅
- [x] `session.heartbeat` no longer queued to Groq (early-return before `queueEvent`) ✅
- [x] `lastHeartbeat` map refreshed on canonical heartbeat events ✅

## Related Issues

- Fixes https://linear.app/catalyst-labs/issue/CTL-401
