### PR TITLE
fix(dev): dedupe filter.wake emissions by (source_event_id, interest_id) (CTL-406)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -243,6 +243,26 @@ export function appendEvent(event) {
   appendFileSync(logPath, JSON.stringify(canonical) + "\n");
 }
 
+// CTL-406: idempotency cache for filter.wake emissions. Prevents the same
+// (source_event_id, interest_id) pair from producing more than one wake within
+// the TTL window — guards against double-ingest of the same log line and
+// intra-call duplicate matches across routing functions.
+const _emittedWakeCache = new Map(); // key -> expiry timestamp (ms)
+const WAKE_CACHE_TTL_MS = 60_000;
+
+function shouldSkipWake(sourceEventId, interestId) {
+  if (!sourceEventId) return false;
+  const key = `${sourceEventId}:${interestId}`;
+  const expiry = _emittedWakeCache.get(key);
+  if (expiry !== undefined && Date.now() < expiry) return true;
+  _emittedWakeCache.set(key, Date.now() + WAKE_CACHE_TTL_MS);
+  return false;
+}
+
+export function __clearEmittedWakeCacheForTest() {
+  _emittedWakeCache.clear();
+}
+
 // --- Interest table ---
 const interests = new Map();
 
@@ -1418,6 +1438,11 @@ export function processEvent(event) {
   for (const m of directMatches) {
     const reg = interests.get(m.interestId);
     if (!reg) continue;
+    // CTL-406: skip duplicate (source_event_id, interest_id) pairs.
+    if (shouldSkipWake(m.sourceEventId, m.interestId)) {
+      log.debug({ interestId: m.interestId, sourceEventId: m.sourceEventId }, "dedup: skipping duplicate wake");
+      continue;
+    }
     appendEvent({
       event: reg.notify_event,
       orchestrator: reg.orchestrator ?? m.interestId,

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -29,6 +29,7 @@ import {
   summarizeEvent,
   buildBrokerState,
   writeBrokerStateFile,
+  __clearEmittedWakeCacheForTest,
 } from "./index.mjs";
 import {
   openBrokerStateDb,
@@ -50,6 +51,7 @@ beforeEach(() => {
   openBrokerStateDb(join(tmpDir, "test.db"));
   clearInterests();
   clearLastHeartbeat();
+  __clearEmittedWakeCacheForTest();
 });
 
 afterEach(() => {
@@ -557,6 +559,93 @@ describe("processEvent dispatches agent identity events", () => {
       detail: { state: "Done" },
     });
     expect(getInterests().has("tl-oneshot")).toBe(false);
+  });
+});
+
+// ─── CTL-406: filter.wake deduplication ─────────────────────────────────────
+
+describe("filter.wake deduplication (CTL-406)", () => {
+  function wakeLinesFromLog() {
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .flatMap((l) => {
+        try {
+          const evt = JSON.parse(l);
+          return evt.attributes?.["event.name"]?.startsWith("filter.wake") ? [evt] : [];
+        } catch { return []; }
+      });
+  }
+
+  test("same source event ingested twice emits at most one wake per interest", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-dedup",
+      detail: {
+        interest_id: "pr-dedup-1",
+        notify_event: "filter.wake.orch-dedup",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [999],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+
+    const sourceEvent = {
+      id: "src-dedup-abc123",
+      attributes: { "event.name": "github.pr.merged" },
+      scope: { pr: 999 },
+      body: { payload: { action: "closed", merged: true } },
+    };
+
+    processEvent(sourceEvent);
+    processEvent(sourceEvent); // same event ingested again
+
+    const wakes = wakeLinesFromLog();
+    const dedupWakes = wakes.filter((w) =>
+      w.body?.payload?.interest_id === "pr-dedup-1"
+    );
+    expect(dedupWakes).toHaveLength(1);
+  });
+
+  test("different source events each produce their own wake", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-dedup2",
+      detail: {
+        interest_id: "pr-dedup-2",
+        notify_event: "filter.wake.orch-dedup2",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [998],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+
+    processEvent({
+      id: "src-event-aaa",
+      attributes: { "event.name": "github.pr.merged" },
+      scope: { pr: 998 },
+      body: { payload: { action: "closed", merged: true } },
+    });
+    processEvent({
+      id: "src-event-bbb",
+      attributes: { "event.name": "github.pr.merged" },
+      scope: { pr: 998 },
+      body: { payload: { action: "closed", merged: true } },
+    });
+
+    const wakes = wakeLinesFromLog();
+    const dedupWakes = wakes.filter((w) =>
+      w.body?.payload?.interest_id === "pr-dedup-2"
+    );
+    expect(dedupWakes).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds an idempotency cache (`_emittedWakeCache`) in the broker keyed on `(source_event_id, interest_id)` with a 60-second TTL
- Duplicate `filter.wake` emissions for the same `(source_event_id, interest_id)` pair are silently skipped before `appendEvent` is called
- Adds two tests: same event ingested twice → exactly one wake per interest; different events → each gets its own wake

## Root Cause (CTL-406)

`processEvent` calls `tryDeterministicRoute` and `tryTicketLifecycleRoute` independently and concatenates their results. Both routing functions can match the same source event (e.g., a `github.pr.merged` event can match a `pr_lifecycle` interest AND a `ticket_lifecycle` interest simultaneously), and neither prevents the same source event from being re-processed if it appears twice in the log.

The cache guards against both:
1. **Intra-call double-match**: same source event matched by two routing functions for the same interest
2. **Cross-call double-ingest**: same source event line appearing twice in the JSONL log

## Test plan
- [x] `bun test plugins/dev/scripts/broker/index.test.mjs` — 124 tests pass
- [x] `bun test` (full suite) — 169 tests pass across 4 files
- [x] Test: same input event ingested twice → at most one wake per `pr_lifecycle` interest
- [x] Test: two different source events → each gets its own wake

Refs: CTL-406