### PR TITLE
feat(dev): wire SubagentStop/Stop hooks as agent.checkout fallback (CTL-404)

### DIFF
--- a/plugins/dev/hooks/emit-lifecycle-event.sh
+++ b/plugins/dev/hooks/emit-lifecycle-event.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# emit-lifecycle-event.sh — Claude Code SubagentStop/Stop lifecycle hook (CTL-404).
+#
+# Fallback agent.checkout emitter for when the model exits without calling
+# catalyst-session.sh end. The Claude Code harness fires this on Stop (main
+# agent finishes a turn) and SubagentStop (subagent finishes), regardless of
+# model behavior — providing a deterministic last-resort signal to the broker.
+#
+# Guards:
+#   1. Exits silently when CATALYST_SESSION_ID is unset (non-Catalyst subagents:
+#      planner, researcher, code-reviewer, etc. that have no broker context)
+#   2. Exits silently when sessions.completed_at is already set (model called
+#      catalyst-session.sh end normally — no double-emit)
+#
+# Install: must be added to global ~/.claude/settings.json (cannot be scoped
+# to a plugin via hooks.toml). See check-setup.sh "Global Lifecycle Hooks" for
+# the exact snippet and /update-config for automated installation.
+
+set -uo pipefail
+
+# Guard 1: only fire for Catalyst sessions.
+CATALYST_SESSION_ID="${CATALYST_SESSION_ID:-}"
+[[ -n "$CATALYST_SESSION_ID" ]] || exit 0
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+DB_FILE="${CATALYST_DB_FILE:-$CATALYST_DIR/catalyst.db}"
+EVENTS_DIR="${CATALYST_DIR}/events"
+
+# Resolve canonical-event.sh relative to this script.
+# Works for both source-clone (plugins/dev/hooks/) and version-aware wrappers
+# installed by install-cli.sh (${_LATEST}/hooks/), because the sibling scripts/
+# directory is always at ../scripts/ relative to hooks/.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_CANONICAL="${SCRIPT_DIR}/../scripts/lib/canonical-event.sh"
+[[ -r "$LIB_CANONICAL" ]] || exit 0
+# shellcheck source=../scripts/lib/canonical-event.sh
+source "$LIB_CANONICAL"
+
+# Guard 2: skip if the session already completed normally.
+if command -v sqlite3 >/dev/null 2>&1 && [[ -f "$DB_FILE" ]]; then
+  completed=$(sqlite3 "$DB_FILE" \
+    "SELECT COALESCE(completed_at,'') FROM sessions
+     WHERE session_id = '${CATALYST_SESSION_ID}' LIMIT 1;" \
+    2>/dev/null || echo "")
+  [[ -z "$completed" ]] || exit 0
+fi
+
+# Emit flat agent.checkout — same shape as catalyst-session.sh cmd_end().
+# status=failed because an unclean exit is always a failure from the broker's
+# perspective; reason field distinguishes this path from a normal end call.
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+canonical_jsonl_append "$EVENTS_DIR" \
+  "$(jq -nc \
+    --arg ts "$ts" \
+    --arg sid "$CATALYST_SESSION_ID" \
+    '{ts:$ts,event:"agent.checkout",detail:{session_id:$sid,status:"failed",reason:"lifecycle-hook-stop"}}' \
+    2>/dev/null)" 2>/dev/null || true

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -290,7 +290,7 @@ if [[ -f "$HOME_CONFIG_PATH" ]]; then
         else
             # Keyed-object format (CTL-273) — surface all registered webhooks
             while IFS= read -r key; do
-                webhook_id=$(echo "$linear_config" | jq -r ".\"$key\".webhookId // empty" 2>/dev/null)
+                webhook_id=$(echo "$linear_config" | jq -r ".\"$key\".webhookId // empty" 2>/dev/null || true)
                 if [[ -n "$webhook_id" ]]; then
                     if [[ "$key" == "workspace" ]]; then
                         pass "Linear webhook registered (workspace-wide, id: ${webhook_id:0:8}…)"
@@ -611,6 +611,39 @@ if [[ -f "CLAUDE.md" ]]; then
     fi
 else
     warn "No CLAUDE.md — agents won't have project-level workflow context"
+fi
+
+# ─── 11. Global Lifecycle Hooks ─────────────────────────────────────────────
+
+header "Global Lifecycle Hooks (agent.checkout fallback)"
+
+GLOBAL_SETTINGS="${HOME}/.claude/settings.json"
+
+if [[ -f "$GLOBAL_SETTINGS" ]] && command -v jq &>/dev/null; then
+    # Hooks are nested: .hooks.<Event>[].hooks[].command
+    if jq -r '.hooks.Stop[]?.hooks[]?.command // empty' "$GLOBAL_SETTINGS" 2>/dev/null \
+            | grep -q "emit-lifecycle-event" 2>/dev/null; then
+        pass "Stop hook → emit-lifecycle-event"
+    else
+        warn "Stop hook not wired — broker won't receive agent.checkout on unclean session exit"
+        info "Add to ~/.claude/settings.json via: /update-config"
+        info '  hooks.Stop entry: {"type":"command","command":"~/.catalyst/bin/emit-lifecycle-event"}'
+    fi
+
+    if jq -r '.hooks.SubagentStop[]?.hooks[]?.command // empty' "$GLOBAL_SETTINGS" 2>/dev/null \
+            | grep -q "emit-lifecycle-event" 2>/dev/null; then
+        pass "SubagentStop hook → emit-lifecycle-event"
+    else
+        warn "SubagentStop hook not wired — broker won't receive agent.checkout on subagent crash"
+        info "Add to ~/.claude/settings.json via: /update-config"
+        info '  hooks.SubagentStop entry: {"type":"command","command":"~/.catalyst/bin/emit-lifecycle-event"}'
+    fi
+else
+    if [[ ! -f "$GLOBAL_SETTINGS" ]]; then
+        warn "~/.claude/settings.json not found — cannot verify global lifecycle hooks"
+    else
+        warn "jq not available — skipping global lifecycle hook check"
+    fi
 fi
 
 # ─── Summary ────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -47,6 +47,7 @@ CLI_ENTRIES=(
   "workflow-context.sh:workflow-context"
   "catalyst-hud:catalyst-hud"
   "catalyst-hud-classic.sh:catalyst-hud-classic"
+  "../hooks/emit-lifecycle-event.sh:emit-lifecycle-event"
 )
 
 # Marker embedded in generated wrapper shims so the ~/.local/bin sweep can


### PR DESCRIPTION
## Summary

- Adds `plugins/dev/hooks/emit-lifecycle-event.sh` — a Claude Code lifecycle hook that fires on `Stop` and `SubagentStop` events as a deterministic fallback `agent.checkout` emitter when the model exits without calling `catalyst-session.sh end`
- Adds `emit-lifecycle-event` to `install-cli.sh` CLI_ENTRIES so it installs to `~/.catalyst/bin/` with the same version-aware wrapper pattern as other Catalyst CLIs
- Adds "Global Lifecycle Hooks" health check section to `check-setup.sh` that warns when `Stop`/`SubagentStop` hooks aren't wired, with actionable `/update-config` instructions
- Fixes a pre-existing `set -e` crash in `check-setup.sh` where `jq` exits non-zero when accessing `.webhookId` on the `smeeChannel` string key, causing everything after the webhook section (CLAUDE.md, summary) to be skipped

## Hook behavior

The hook script has two guards:
1. **CATALYST_SESSION_ID unset** → silent exit (non-Catalyst subagents: planners, researchers, code-reviewers have no broker context)
2. **sessions.completed_at already set** → silent exit (model called `catalyst-session.sh end` normally — no double-emit)

If neither guard triggers, emits `agent.checkout` with `status: "failed"` and `reason: "lifecycle-hook-stop"` matching the shape produced by `catalyst-session.sh cmd_end()`.

## Required global settings.json update

Per Claude Code hook scoping constraints, lifecycle hooks cannot be registered in `plugins/dev/hooks.toml` (plugin-scoped). Users must add to `~/.claude/settings.json`:

```json
"Stop":        [{"matcher":"","hooks":[{"type":"command","command":"~/.catalyst/bin/emit-lifecycle-event"}]}],
"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":"~/.catalyst/bin/emit-lifecycle-event"}]}]
```

Run `/update-config` or follow the warnings from `check-setup.sh` Section 11.

## Test plan

- [x] `CATALYST_SESSION_ID` unset → exits 0, no events emitted
- [x] Session with `completed_at` set → exits 0, no events emitted (idempotency)
- [x] Session with `completed_at NULL` and no DB → emits `agent.checkout` with correct shape
- [x] Session with `completed_at NULL` and real SQLite → emits `agent.checkout`
- [x] `install-cli.sh --bin-dir /tmp/test` installs `emit-lifecycle-event` symlink correctly
- [x] `check-setup.sh` Global Lifecycle Hooks section warns when hooks not wired
- [x] `check-setup.sh` runs to completion (Summary section now appears, fixing pre-existing crash)
- [x] `bash -n` syntax check passes on hook script

Closes CTL-404