### PR TITLE
feat(dev): broker wait-loop visibility — worker.waiting/resumed events (CTL-403)

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -92,6 +92,23 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
     )
   `);
 
+  // CTL-403: waiting_sessions tracks active wait-for loops so the watchdog can
+  // distinguish 'silently dead' (no heartbeat AND no active wait) from
+  // 'legitimately waiting' (no heartbeat BUT wait has not yet timed out).
+  db.run(`
+    CREATE TABLE IF NOT EXISTS waiting_sessions (
+      session_id   TEXT PRIMARY KEY,
+      orchestrator TEXT,
+      ticket       TEXT,
+      wait_for     TEXT,
+      timeout_ms   INTEGER NOT NULL,
+      since        TEXT NOT NULL,
+      timeout_at   TEXT NOT NULL,
+      reason       TEXT,
+      updated_at   TEXT NOT NULL
+    )
+  `);
+
   return db;
 }
 
@@ -255,6 +272,59 @@ function rowToAgent(row) {
     cwd: row.cwd,
     status: row.status,
     checkedInAt: row.checked_in_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ─── waiting_sessions helpers (CTL-403) ──────────────────────────────────────
+
+export function upsertWaitingSession({ sessionId, orchestrator, ticket, waitFor, timeoutMs, since, reason }) {
+  const timeoutAt = new Date(new Date(since).getTime() + timeoutMs).toISOString();
+  ensure().run(
+    `INSERT INTO waiting_sessions
+       (session_id, orchestrator, ticket, wait_for, timeout_ms, since, timeout_at, reason, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(session_id) DO UPDATE SET
+       orchestrator = excluded.orchestrator,
+       ticket       = excluded.ticket,
+       wait_for     = excluded.wait_for,
+       timeout_ms   = excluded.timeout_ms,
+       since        = excluded.since,
+       timeout_at   = excluded.timeout_at,
+       reason       = excluded.reason,
+       updated_at   = excluded.updated_at`,
+    [sessionId, orchestrator ?? null, ticket ?? null, waitFor ?? null, timeoutMs, since, timeoutAt, reason ?? null, nowIso()],
+  );
+}
+
+export function clearWaitingSession(sessionId) {
+  ensure().run(`DELETE FROM waiting_sessions WHERE session_id = ?`, [sessionId]);
+}
+
+export function getWaitingSession(sessionId) {
+  const row = ensure()
+    .prepare(`SELECT * FROM waiting_sessions WHERE session_id = ?`)
+    .get(sessionId);
+  return row ? rowToWaitingSession(row) : null;
+}
+
+export function getActiveWaitingSessions(nowIso = new Date().toISOString()) {
+  return ensure()
+    .prepare(`SELECT * FROM waiting_sessions WHERE timeout_at > ? ORDER BY since`)
+    .all(nowIso)
+    .map(rowToWaitingSession);
+}
+
+function rowToWaitingSession(row) {
+  return {
+    sessionId: row.session_id,
+    orchestrator: row.orchestrator,
+    ticket: row.ticket,
+    waitFor: row.wait_for,
+    timeoutMs: row.timeout_ms,
+    since: row.since,
+    timeoutAt: row.timeout_at,
+    reason: row.reason,
     updatedAt: row.updated_at,
   };
 }

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -40,6 +40,10 @@ import {
   getAgentsByTicket,
   // ticket_state (CTL-303 — ticket routing)
   upsertTicketState,
+  // waiting_sessions (CTL-403 — wait-loop visibility)
+  upsertWaitingSession,
+  clearWaitingSession,
+  getActiveWaitingSessions,
 } from "./broker-state.mjs";
 import {
   resolveApiKey,
@@ -453,6 +457,8 @@ export function maybeEmitProseDisabled() {
 const lastHeartbeat = new Map();
 // worker/session id → orchestrator id (inferred from heartbeat event fields)
 const workerToOrchestrator = new Map();
+// CTL-403: session_id → { timeoutAt: number, waitFor, ticket, orchestrator, reason }
+const waitingSessions = new Map();
 
 export function getLastHeartbeat() {
   return lastHeartbeat;
@@ -465,6 +471,14 @@ export function clearLastHeartbeat() {
 
 export function getWorkerToOrchestrator() {
   return workerToOrchestrator;
+}
+
+export function getWaitingSessionsMap() {
+  return waitingSessions;
+}
+
+export function clearWaitingSessionsMap() {
+  waitingSessions.clear();
 }
 
 // CTL-336: read name/payload/orchestrator from canonical OTel-format events
@@ -694,6 +708,61 @@ export function handleAgentHeartbeat(event) {
   if (orchId && sessionId !== orchId) {
     workerToOrchestrator.set(sessionId, orchId);
   }
+}
+
+// CTL-403: handle worker.waiting — record that a session is blocking in a wait
+// loop. Resets the watchdog timer and stores full detail so the watchdog can
+// skip stale-heartbeat wakes while the session is legitimately waiting.
+export function handleWorkerWaiting(event) {
+  const d = event.detail ?? {};
+  const sessionId = d.session_id;
+  if (!sessionId) return;
+
+  const timeoutMs = typeof d.timeout_ms === "number" ? d.timeout_ms : 0;
+  const since = d.since ?? new Date().toISOString();
+  const timeoutAt = new Date(new Date(since).getTime() + timeoutMs).getTime();
+
+  waitingSessions.set(sessionId, {
+    timeoutAt,
+    waitFor: d.wait_for ?? null,
+    ticket: d.ticket ?? null,
+    orchestrator: d.orchestrator ?? event.orchestrator ?? null,
+    reason: d.reason ?? null,
+  });
+
+  // Reset watchdog so the session doesn't immediately appear stale.
+  const existing = lastHeartbeat.get(sessionId);
+  lastHeartbeat.set(sessionId, { ts: Date.now(), notified: existing?.notified ?? false });
+
+  try {
+    upsertWaitingSession({
+      sessionId,
+      orchestrator: d.orchestrator ?? event.orchestrator ?? null,
+      ticket: d.ticket ?? null,
+      waitFor: d.wait_for ?? null,
+      timeoutMs,
+      since,
+      reason: d.reason ?? null,
+    });
+  } catch { /* DB not opened */ }
+
+  log.info({ sessionId, waitFor: d.wait_for, timeoutMs }, "worker waiting");
+  persistBrokerState();
+}
+
+// CTL-403: handle worker.resumed — clear the waiting record so the watchdog
+// resumes normal heartbeat-staleness tracking for this session.
+export function handleWorkerResumed(event) {
+  const d = event.detail ?? {};
+  const sessionId = d.session_id;
+  if (!sessionId) return;
+
+  waitingSessions.delete(sessionId);
+
+  try { clearWaitingSession(sessionId); } catch { /* DB not opened */ }
+
+  log.info({ sessionId, outcome: d.outcome ?? "unknown" }, "worker resumed");
+  persistBrokerState();
 }
 
 // --- Deterministic routing: pr_lifecycle (CTL-284) ---------------------------
@@ -1314,6 +1383,19 @@ export function runWatchdogTick() {
   let watchdogWoke = false;
   for (const [sourceId, state] of lastHeartbeat) {
     const stale = now - state.ts > HEARTBEAT_STALE_MS;
+    // CTL-403: skip stale-wake if this session has an active wait whose timeout
+    // has not yet elapsed. The session is legitimately blocking — not dead.
+    if (stale && waitingSessions.has(sourceId)) {
+      const ws = waitingSessions.get(sourceId);
+      if (ws.timeoutAt > now) {
+        const secsLeft = Math.round((ws.timeoutAt - now) / 1000);
+        log.debug({ sourceId, secsLeft, waitFor: ws.waitFor }, "watchdog: skipping stale check — session is legitimately waiting");
+        continue;
+      }
+      // Wait timed out — treat as stale and clean up the waiting record.
+      waitingSessions.delete(sourceId);
+      try { clearWaitingSession(sourceId); } catch { /* DB not opened */ }
+    }
     if (stale && !state.notified) {
       const minsAgo = Math.round((now - state.ts) / 60_000);
       const reason = `No heartbeat from ${sourceId} for >${minsAgo} min`;
@@ -1406,6 +1488,16 @@ export function processEvent(event) {
   // than the top-level flat field; handleAgentHeartbeat now reads both shapes.
   if (name === "session.heartbeat") {
     handleAgentHeartbeat(event);
+    return;
+  }
+
+  // CTL-403: worker wait-loop visibility events.
+  if (name === "worker.waiting") {
+    handleWorkerWaiting(event);
+    return;
+  }
+  if (name === "worker.resumed") {
+    handleWorkerResumed(event);
     return;
   }
 
@@ -1600,6 +1692,20 @@ export function getBrokerStateFilePath() {
 }
 
 export function buildBrokerState({ probe } = {}) {
+  // CTL-403: snapshot current waiting sessions for broker.state.json so the HUD
+  // can show 'waiting for X (timeout in Y)' without a separate query.
+  const now = Date.now();
+  const activeWaiting = [...waitingSessions.entries()]
+    .filter(([, ws]) => ws.timeoutAt > now)
+    .map(([sessionId, ws]) => ({
+      sessionId,
+      ticket: ws.ticket,
+      orchestrator: ws.orchestrator,
+      waitFor: ws.waitFor,
+      timeoutAt: new Date(ws.timeoutAt).toISOString(),
+      reason: ws.reason,
+    }));
+
   return {
     pid: process.pid,
     startedAt: brokerStartedAt ?? new Date().toISOString(),
@@ -1608,6 +1714,8 @@ export function buildBrokerState({ probe } = {}) {
     interestCount: interests.size,
     lastWakeAt,
     lastRegisterAt,
+    // CTL-403: active wait-loop sessions (empty array when no active waits).
+    waitingSessions: activeWaiting,
     keyHealth: {
       groq: {
         present: GROQ_KEY_SOURCE !== null,
@@ -1720,6 +1828,23 @@ function main() {
   maybeEmitProseDisabled();
 
   openBrokerStateDb();
+
+  // CTL-403: rehydrate waiting sessions from SQLite so the watchdog respects
+  // active waits that survived a broker restart.
+  try {
+    for (const ws of getActiveWaitingSessions()) {
+      waitingSessions.set(ws.sessionId, {
+        timeoutAt: new Date(ws.timeoutAt).getTime(),
+        waitFor: ws.waitFor,
+        ticket: ws.ticket,
+        orchestrator: ws.orchestrator,
+        reason: ws.reason,
+      });
+    }
+    if (waitingSessions.size > 0) {
+      log.info({ count: waitingSessions.size }, "rehydrated waiting sessions from DB");
+    }
+  } catch { /* DB might not have the table yet on old installs */ }
 
   try {
     const fd = openSync(lastLogPath, "r");

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -14,6 +14,10 @@ import {
   handleAgentCheckin,
   handleAgentCheckout,
   handleAgentHeartbeat,
+  handleWorkerWaiting,
+  handleWorkerResumed,
+  getWaitingSessionsMap,
+  clearWaitingSessionsMap,
   shouldSkipEvent,
   buildGroqPrompt,
   getInterests,
@@ -37,6 +41,8 @@ import {
   getAgentBySession,
   getAgentsByTicket,
   getTicketState,
+  getWaitingSession,
+  getActiveWaitingSessions,
 } from "./broker-state.mjs";
 
 // ─── Shared DB setup ─────────────────────────────────────────────────────────
@@ -52,6 +58,7 @@ beforeEach(() => {
   clearInterests();
   clearLastHeartbeat();
   __clearEmittedWakeCacheForTest();
+  clearWaitingSessionsMap();
 });
 
 afterEach(() => {
@@ -486,6 +493,258 @@ describe("session.heartbeat (canonical OTel)", () => {
         resource: { "service.name": "catalyst.session" },
       }),
     ).toBe(true);
+  });
+});
+
+// ─── CTL-403: worker.waiting / worker.resumed ────────────────────────────────
+
+describe("worker.waiting", () => {
+  test("stores session in in-memory map with computed timeoutAt", () => {
+    const since = new Date().toISOString();
+    handleWorkerWaiting({
+      event: "worker.waiting",
+      detail: {
+        session_id: "sess-waiting",
+        orchestrator: "orch-1",
+        ticket: "CTL-403",
+        wait_for: "github.pr.merged",
+        timeout_ms: 3600000,
+        since,
+        reason: "phase 5 listen loop",
+      },
+    });
+    const map = getWaitingSessionsMap();
+    expect(map.has("sess-waiting")).toBe(true);
+    const entry = map.get("sess-waiting");
+    expect(entry.waitFor).toBe("github.pr.merged");
+    expect(entry.ticket).toBe("CTL-403");
+    expect(entry.timeoutAt).toBeGreaterThan(Date.now());
+  });
+
+  test("resets heartbeat timer for the session", () => {
+    const since = new Date().toISOString();
+    handleWorkerWaiting({
+      event: "worker.waiting",
+      detail: { session_id: "sess-hb-reset", timeout_ms: 3600000, since },
+    });
+    expect(getLastHeartbeat().has("sess-hb-reset")).toBe(true);
+  });
+
+  test("persists to waiting_sessions SQLite table", () => {
+    const since = new Date().toISOString();
+    handleWorkerWaiting({
+      event: "worker.waiting",
+      detail: {
+        session_id: "sess-db",
+        orchestrator: "orch-x",
+        ticket: "CTL-403",
+        wait_for: ".attributes.\"event.name\" == \"github.pr.merged\"",
+        timeout_ms: 7200000,
+        since,
+        reason: "test",
+      },
+    });
+    const row = getWaitingSession("sess-db");
+    expect(row).not.toBeNull();
+    expect(row.ticket).toBe("CTL-403");
+    expect(row.waitFor).toBe(".attributes.\"event.name\" == \"github.pr.merged\"");
+    expect(typeof row.timeoutAt).toBe("string");
+  });
+
+  test("no-op when session_id missing", () => {
+    expect(() =>
+      handleWorkerWaiting({ event: "worker.waiting", detail: { timeout_ms: 1000, since: new Date().toISOString() } })
+    ).not.toThrow();
+    expect(getWaitingSessionsMap().size).toBe(0);
+  });
+
+  test("getActiveWaitingSessions returns only non-expired sessions", () => {
+    const future = new Date().toISOString();
+    handleWorkerWaiting({ event: "worker.waiting", detail: { session_id: "sess-past", timeout_ms: 1, since: new Date(Date.now() - 10000).toISOString() } });
+    handleWorkerWaiting({ event: "worker.waiting", detail: { session_id: "sess-future", timeout_ms: 3600000, since: future } });
+    const active = getActiveWaitingSessions();
+    const ids = active.map((s) => s.sessionId);
+    expect(ids).not.toContain("sess-past");
+    expect(ids).toContain("sess-future");
+  });
+});
+
+describe("worker.resumed", () => {
+  test("removes session from in-memory map", () => {
+    const since = new Date().toISOString();
+    handleWorkerWaiting({ event: "worker.waiting", detail: { session_id: "sess-r", timeout_ms: 3600000, since } });
+    expect(getWaitingSessionsMap().has("sess-r")).toBe(true);
+    handleWorkerResumed({ event: "worker.resumed", detail: { session_id: "sess-r", outcome: "matched" } });
+    expect(getWaitingSessionsMap().has("sess-r")).toBe(false);
+  });
+
+  test("removes session from SQLite table", () => {
+    const since = new Date().toISOString();
+    handleWorkerWaiting({ event: "worker.waiting", detail: { session_id: "sess-db-r", timeout_ms: 3600000, since } });
+    expect(getWaitingSession("sess-db-r")).not.toBeNull();
+    handleWorkerResumed({ event: "worker.resumed", detail: { session_id: "sess-db-r", outcome: "timed_out" } });
+    expect(getWaitingSession("sess-db-r")).toBeNull();
+  });
+
+  test("no-op when session_id missing", () => {
+    expect(() =>
+      handleWorkerResumed({ event: "worker.resumed", detail: {} })
+    ).not.toThrow();
+  });
+});
+
+describe("watchdog skips legitimately waiting sessions (CTL-403)", () => {
+  test("session with active wait is not woken when heartbeat is stale", async () => {
+    const { runWatchdogTick } = await import("./index.mjs");
+
+    // Register an interest watching sess-wait
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-w",
+      detail: {
+        interest_id: "orch-w",
+        notify_event: "filter.wake.orch-w",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [42],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+        context: { pr_numbers: [42], tickets: [], workers: ["sess-wait"] },
+        session_id: null,
+      },
+    });
+
+    // Simulate stale heartbeat by backdating the entry
+    const staleTs = Date.now() - 300_000;
+    getLastHeartbeat().set("sess-wait", { ts: staleTs, notified: false });
+
+    // Mark as actively waiting with timeout in the future
+    getWaitingSessionsMap().set("sess-wait", {
+      timeoutAt: Date.now() + 3_600_000,
+      waitFor: "github.pr.merged",
+      ticket: "CTL-403",
+      orchestrator: "orch-w",
+      reason: "test",
+    });
+
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+
+    runWatchdogTick();
+
+    // No filter.wake event should have been emitted for this session
+    if (existsSync(logPath)) {
+      const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+      const wakes = lines.filter((l) => {
+        try {
+          const evt = JSON.parse(l);
+          const evtName = evt.event ?? evt.attributes?.["event.name"] ?? "";
+          return evtName === "filter.wake.orch-w";
+        } catch { return false; }
+      });
+      expect(wakes).toHaveLength(0);
+    }
+    // Heartbeat entry still present (not cleaned up)
+    expect(getLastHeartbeat().has("sess-wait")).toBe(true);
+  });
+
+  test("session with EXPIRED wait IS woken as stale", async () => {
+    const { runWatchdogTick } = await import("./index.mjs");
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-exp",
+      detail: {
+        interest_id: "orch-exp",
+        notify_event: "filter.wake.orch-exp",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [99],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+        context: { pr_numbers: [99], tickets: [], workers: ["sess-exp"] },
+        session_id: null,
+      },
+    });
+
+    const staleTs = Date.now() - 300_000;
+    getLastHeartbeat().set("sess-exp", { ts: staleTs, notified: false });
+
+    // Expired wait (timeoutAt in the past)
+    getWaitingSessionsMap().set("sess-exp", {
+      timeoutAt: Date.now() - 1000,
+      waitFor: "github.pr.merged",
+      ticket: "CTL-403",
+      orchestrator: "orch-exp",
+      reason: "test",
+    });
+
+    runWatchdogTick();
+
+    // Expired wait should be cleaned up
+    expect(getWaitingSessionsMap().has("sess-exp")).toBe(false);
+  });
+});
+
+describe("buildBrokerState includes waitingSessions (CTL-403)", () => {
+  test("empty when no active waits", () => {
+    const state = buildBrokerState();
+    expect(Array.isArray(state.waitingSessions)).toBe(true);
+    expect(state.waitingSessions).toHaveLength(0);
+  });
+
+  test("includes active sessions with correct shape", () => {
+    const since = new Date().toISOString();
+    handleWorkerWaiting({
+      event: "worker.waiting",
+      detail: {
+        session_id: "sess-bst",
+        ticket: "CTL-403",
+        orchestrator: "orch-bst",
+        wait_for: "github.pr.merged",
+        timeout_ms: 3600000,
+        since,
+        reason: "test",
+      },
+    });
+    const state = buildBrokerState();
+    expect(state.waitingSessions).toHaveLength(1);
+    const ws = state.waitingSessions[0];
+    expect(ws.sessionId).toBe("sess-bst");
+    expect(ws.ticket).toBe("CTL-403");
+    expect(ws.waitFor).toBe("github.pr.merged");
+    expect(typeof ws.timeoutAt).toBe("string");
+  });
+
+  test("excludes expired sessions", () => {
+    getWaitingSessionsMap().set("sess-expired", {
+      timeoutAt: Date.now() - 5000,
+      waitFor: "anything",
+      ticket: "CTL-000",
+      orchestrator: null,
+      reason: null,
+    });
+    const state = buildBrokerState();
+    const ids = state.waitingSessions.map((s) => s.sessionId);
+    expect(ids).not.toContain("sess-expired");
+  });
+});
+
+describe("processEvent routes worker.waiting and worker.resumed (CTL-403)", () => {
+  test("worker.waiting is handled via processEvent", () => {
+    const since = new Date().toISOString();
+    processEvent({
+      event: "worker.waiting",
+      detail: { session_id: "sess-pe-w", timeout_ms: 3600000, since },
+    });
+    expect(getWaitingSessionsMap().has("sess-pe-w")).toBe(true);
+  });
+
+  test("worker.resumed is handled via processEvent", () => {
+    const since = new Date().toISOString();
+    processEvent({ event: "worker.waiting", detail: { session_id: "sess-pe-r", timeout_ms: 3600000, since } });
+    processEvent({ event: "worker.resumed", detail: { session_id: "sess-pe-r", outcome: "matched" } });
+    expect(getWaitingSessionsMap().has("sess-pe-r")).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -170,6 +170,27 @@ cmd_tail() {
   fi
 }
 
+_emit_wait_event() {
+  local event_name="$1" extra_fields="${2:-}"
+  [[ -n "${CATALYST_SESSION_ID:-}" ]] || return 0
+  local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local event_json
+  event_json="$(jq -cn \
+    --arg ts "$ts" \
+    --arg ev "$event_name" \
+    --arg sid "$CATALYST_SESSION_ID" \
+    --arg orch "${CATALYST_ORCHESTRATOR_ID:-}" \
+    --arg ticket "${CATALYST_TICKET_ID:-}" \
+    --argjson extra "${extra_fields:-{}}" \
+    '{ts: $ts, event: $ev, detail: ({session_id: $sid}
+       + (if $orch != "" then {orchestrator: $orch} else {} end)
+       + (if $ticket != "" then {ticket: $ticket} else {} end)
+       + $extra)}' 2>/dev/null)" || return 0
+  local dest; dest="$(events_file_path)"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || true
+  printf '%s\n' "$event_json" >> "$dest" 2>/dev/null || true
+}
+
 cmd_wait_for() {
   local filter="" timeout="1800"
 
@@ -191,6 +212,19 @@ cmd_wait_for() {
   file="$(events_file_path)"
   local deadline=$(( $(date +%s) + timeout ))
 
+  # CTL-403: emit worker.waiting so the broker knows this session is legitimately
+  # blocking and the watchdog should not treat it as silently dead.
+  local since_iso timeout_ms waiting_extra
+  since_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  timeout_ms=$(( timeout * 1000 ))
+  waiting_extra="$(jq -cn \
+    --arg wf "$filter" \
+    --argjson tms "$timeout_ms" \
+    --arg since "$since_iso" \
+    --arg reason "catalyst-events wait-for" \
+    '{wait_for: $wf, timeout_ms: $tms, since: $since, reason: $reason}' 2>/dev/null || echo '{}')"
+  _emit_wait_event "worker.waiting" "$waiting_extra"
+
   # If the file doesn't exist yet, wait for it AND treat all of its lines as
   # "new" once it appears (the consumer started before the writer).
   local file_existed_at_start=1
@@ -198,6 +232,7 @@ cmd_wait_for() {
     file_existed_at_start=0
   fi
   if ! wait_for_file "$file" "$deadline"; then
+    _emit_wait_event "worker.resumed" '{"outcome":"timed_out"}'
     return 1
   fi
   file="$(events_file_path)"
@@ -211,6 +246,7 @@ cmd_wait_for() {
 
   while :; do
     if [[ "$(date +%s)" -ge "$deadline" ]]; then
+      _emit_wait_event "worker.resumed" '{"outcome":"timed_out"}'
       return 1
     fi
 
@@ -223,6 +259,7 @@ cmd_wait_for() {
       match="$(emit_lines_since "$file" "$last_lines" "$filter")"
       if [[ -n "$match" ]]; then
         # Only emit the FIRST matching line, then exit.
+        _emit_wait_event "worker.resumed" '{"outcome":"matched"}'
         echo "$match" | head -n 1
         return 0
       fi

--- a/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
@@ -165,6 +165,7 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
             scrollOffset={scrollOffset}
             visibleRows={listBodyRows}
             cols={cols - 4}
+            waitingSessions={brokerState?.waitingSessions}
           />
         )}
         {view === "orchs" && (

--- a/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from "ink";
+import type { WaitingSession } from "../lib/broker-key-health.ts";
 import type { WorkerSignal } from "../lib/worker-signals-reader.ts";
 import {
   formatRelativeTime,
@@ -14,6 +15,26 @@ interface WorkerListProps {
   scrollOffset: number;
   visibleRows: number;
   cols: number;
+  waitingSessions?: WaitingSession[];
+}
+
+function findWaitingSession(ticket: string, sessions: WaitingSession[], nowMs: number): WaitingSession | null {
+  for (const ws of sessions) {
+    if (ws.ticket === ticket && ws.timeoutAt && Date.parse(ws.timeoutAt) > nowMs) {
+      return ws;
+    }
+  }
+  return null;
+}
+
+function formatTimeoutRemaining(timeoutAt: string, nowMs: number): string {
+  const ms = Date.parse(timeoutAt) - nowMs;
+  if (ms <= 0) return "0s";
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.round(mins / 60)}h`;
 }
 
 const COL_WORKER = 32;
@@ -28,9 +49,11 @@ export function WorkerList({
   scrollOffset,
   visibleRows,
   cols,
+  waitingSessions = [],
 }: WorkerListProps) {
   const worktreeW = Math.max(8, cols - COL_WORKER - COL_STATUS - COL_PHASE - COL_PR - COL_HEARTBEAT - 6);
   const visible = workers.slice(scrollOffset, scrollOffset + visibleRows);
+  const nowMs = Date.now();
 
   return (
     <Box flexDirection="column" flexGrow={1}>
@@ -50,33 +73,44 @@ export function WorkerList({
         const realIdx = scrollOffset + idx;
         const selected = realIdx === selectedIndex;
         const stale = isStaleHeartbeat(w.lastHeartbeat);
-        const statusColor = workerStatusColor(w.status);
+        const ws = findWaitingSession(w.ticket, waitingSessions, nowMs);
+        const statusColor = ws ? "magenta" : workerStatusColor(w.status);
+        const statusText = ws ? `wait:${formatTimeoutRemaining(ws.timeoutAt, nowMs)}` : w.status;
         const worker = truncateRight(w.workerName, COL_WORKER);
-        const status = truncateRight(w.status, COL_STATUS);
+        const status = truncateRight(statusText, COL_STATUS);
         const phase = truncateRight(w.phase !== null ? String(w.phase) : "—", COL_PHASE);
         const pr = truncateRight(w.pr ? `#${w.pr.number}` : "—", COL_PR);
         const heartbeat = truncateRight(formatRelativeTime(w.lastHeartbeat), COL_HEARTBEAT);
         const worktree = truncateRight(lastPathSegment(w.worktreePath), worktreeW);
         return (
-          <Box key={`${w.workerName}-${realIdx}`} flexDirection="row">
-            <Box width={COL_WORKER} flexShrink={0} marginRight={1}>
-              <Text color={selected ? "black" : "white"} inverse={selected}>{worker}</Text>
+          <Box key={`${w.workerName}-${realIdx}`} flexDirection="column">
+            <Box flexDirection="row">
+              <Box width={COL_WORKER} flexShrink={0} marginRight={1}>
+                <Text color={selected ? "black" : "white"} inverse={selected}>{worker}</Text>
+              </Box>
+              <Box width={COL_STATUS} flexShrink={0} marginRight={1}>
+                <Text color={statusColor} inverse={selected}>{status}</Text>
+              </Box>
+              <Box width={COL_PHASE} flexShrink={0} marginRight={1}>
+                <Text dimColor={!selected} inverse={selected}>{phase}</Text>
+              </Box>
+              <Box width={COL_PR} flexShrink={0} marginRight={1}>
+                <Text color={w.pr ? "cyan" : "gray"} inverse={selected}>{pr}</Text>
+              </Box>
+              <Box width={COL_HEARTBEAT} flexShrink={0} marginRight={1}>
+                <Text color={stale && !ws ? "yellow" : undefined} dimColor={!stale && !selected} inverse={selected}>{heartbeat}</Text>
+              </Box>
+              <Box flexGrow={1}>
+                <Text dimColor={!selected} inverse={selected}>{worktree}</Text>
+              </Box>
             </Box>
-            <Box width={COL_STATUS} flexShrink={0} marginRight={1}>
-              <Text color={statusColor} inverse={selected}>{status}</Text>
-            </Box>
-            <Box width={COL_PHASE} flexShrink={0} marginRight={1}>
-              <Text dimColor={!selected} inverse={selected}>{phase}</Text>
-            </Box>
-            <Box width={COL_PR} flexShrink={0} marginRight={1}>
-              <Text color={w.pr ? "cyan" : "gray"} inverse={selected}>{pr}</Text>
-            </Box>
-            <Box width={COL_HEARTBEAT} flexShrink={0} marginRight={1}>
-              <Text color={stale ? "yellow" : undefined} dimColor={!stale && !selected} inverse={selected}>{heartbeat}</Text>
-            </Box>
-            <Box flexGrow={1}>
-              <Text dimColor={!selected} inverse={selected}>{worktree}</Text>
-            </Box>
+            {ws && selected && (
+              <Box paddingX={1}>
+                <Text color="magenta" dimColor>
+                  {`  ⏳ waiting for: ${ws.waitFor ? truncateRight(ws.waitFor, cols - 20) : "(unknown)"}`}
+                </Text>
+              </Box>
+            )}
           </Box>
         );
       })}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts
@@ -18,6 +18,16 @@ export interface BrokerKeyHealth {
   };
 }
 
+// CTL-403: active wait-loop session record surfaced in broker.state.json.
+export interface WaitingSession {
+  sessionId: string;
+  ticket?: string | null;
+  orchestrator?: string | null;
+  waitFor?: string | null;
+  timeoutAt: string;
+  reason?: string | null;
+}
+
 // CTL-352: broader read of broker.state.json including the new liveness
 // fields (interestCount, lastWakeAt, lastRegisterAt, startedAt). The legacy
 // BrokerKeyHealth shape is preserved as a subset for existing consumers.
@@ -26,6 +36,8 @@ export interface BrokerState extends BrokerKeyHealth {
   lastWakeAt?: string | null;
   lastRegisterAt?: string | null;
   startedAt?: string;
+  // CTL-403: sessions currently blocking in a wait-for loop.
+  waitingSessions?: WaitingSession[];
 }
 
 export type BrokerInterestStatus = "ok" | "startup" | "degraded" | "unknown";
@@ -94,6 +106,20 @@ export function readBrokerState(path?: string): BrokerState | null {
       result.lastRegisterAt = obj.lastRegisterAt;
     }
     if (typeof obj.startedAt === "string") result.startedAt = obj.startedAt;
+    // CTL-403: parse waitingSessions array.
+    if (Array.isArray(obj.waitingSessions)) {
+      result.waitingSessions = obj.waitingSessions
+        .filter((s): s is Record<string, unknown> => !!s && typeof s === "object")
+        .map((s) => ({
+          sessionId: typeof s.sessionId === "string" ? s.sessionId : "",
+          ticket: typeof s.ticket === "string" ? s.ticket : null,
+          orchestrator: typeof s.orchestrator === "string" ? s.orchestrator : null,
+          waitFor: typeof s.waitFor === "string" ? s.waitFor : null,
+          timeoutAt: typeof s.timeoutAt === "string" ? s.timeoutAt : "",
+          reason: typeof s.reason === "string" ? s.reason : null,
+        }))
+        .filter((s) => s.sessionId && s.timeoutAt);
+    }
     return result;
   } catch {
     return null;

--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -113,6 +113,82 @@ On checkout, the broker:
 - Marks the agent as `done` in the `agents` SQLite table.
 - Removes any auto-correlated `pr_lifecycle` interest (explicit registrations are preserved).
 
+## 3a. `worker.waiting` / `worker.resumed` Events (CTL-403)
+
+Emitted automatically by `catalyst-events wait-for` when `$CATALYST_SESSION_ID` is set. These
+events make wait loops visible to the broker so the watchdog can distinguish a legitimately
+waiting session from a silently dead one.
+
+### `worker.waiting` shape
+
+```json
+{
+  "ts": "2026-05-14T16:30:00Z",
+  "event": "worker.waiting",
+  "detail": {
+    "session_id": "sess_20260514_abcd",
+    "orchestrator": "orch-foo",
+    "ticket": "CTL-275",
+    "wait_for": ".attributes.\"event.name\" == \"github.pr.merged\"",
+    "timeout_ms": 7200000,
+    "since": "2026-05-14T16:30:00Z",
+    "reason": "catalyst-events wait-for"
+  }
+}
+```
+
+### `worker.resumed` shape
+
+```json
+{
+  "ts": "2026-05-14T18:00:00Z",
+  "event": "worker.resumed",
+  "detail": {
+    "session_id": "sess_20260514_abcd",
+    "orchestrator": "orch-foo",
+    "ticket": "CTL-275",
+    "outcome": "matched"
+  }
+}
+```
+
+`outcome` is `"matched"` when the wait returned a result, `"timed_out"` when the deadline elapsed.
+
+### Broker behavior
+
+On `worker.waiting`:
+- Stores the session in the in-memory `waitingSessions` Map and the `waiting_sessions` SQLite table.
+- Resets the heartbeat timer so the session does not appear stale during the wait.
+- During watchdog ticks, any session in `waitingSessions` whose `timeoutAt > now` is skipped — it
+  is "legitimately waiting" and should not trigger a stale-heartbeat wake.
+- The `broker.state.json` file includes an `waitingSessions` array with all currently active waits;
+  the HUD dashboard's worker list reads this to overlay `wait:Xm` in the STATUS column.
+
+On `worker.resumed`:
+- Removes the session from `waitingSessions` and the SQLite table.
+- Normal heartbeat-staleness tracking resumes.
+
+### Broker state file
+
+`~/catalyst/broker.state.json` gains a `waitingSessions` array:
+
+```json
+{
+  "waitingSessions": [
+    {
+      "sessionId": "sess_20260514_abcd",
+      "ticket": "CTL-275",
+      "orchestrator": "orch-foo",
+      "waitFor": ".attributes.\"event.name\" == \"github.pr.merged\"",
+      "timeoutAt": "2026-05-14T18:30:00Z",
+      "reason": "catalyst-events wait-for"
+    }
+  ]
+}
+```
+
+Empty array `[]` when no sessions are currently waiting.
+
 ## 4. `ticket_lifecycle` Interest Type
 
 Register to watch a ticket's Linear events and PR links deterministically:


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T02:55:00Z -->
<!-- Last updated: 2026-05-15T02:55:00Z -->
<!-- PR: #717 -->
<!-- Previous commits: 625ff5bea0544a492b4423a566dcf0d174bcab89 -->

## Summary

Workers in wait/listen states (`catalyst-events wait-for`, oneshot Phase 5 listen loop) were
previously invisible to the broker — the only signal of their liveness was heartbeat absence,
causing the watchdog to fire spurious `filter.wake` events for workers that were legitimately
blocking. This PR makes wait-loop states fully observable.

- **`catalyst-events wait-for`** emits `worker.waiting` before entering the loop (with filter,
  timeout, and reason) and `worker.resumed` on exit (with `outcome: matched | timed_out`).
- **The broker** tracks active waiting sessions in a new `waiting_sessions` SQLite table and an
  in-memory `Map`, resets the heartbeat timer on `worker.waiting` (so the session stays alive),
  and skips the watchdog's stale-wake check for sessions with a future `timeoutAt`.
- **`broker.state.json`** gains a `waitingSessions` array (active sessions only) so the HUD can
  read it without a new endpoint.
- **The HUD worker list** overlays `wait:Xm` (magenta) in the STATUS column for workers with an
  active wait matching their ticket, and shows `⏳ waiting for: <filter>` inline when the row
  is selected.

## Changes Made

### `catalyst-events` (bash)
- `_emit_wait_event()` helper — builds JSON safely via `jq -cn --arg` and appends to the events
  JSONL file; guards on `CATALYST_SESSION_ID` being set so non-worker callers are unaffected.
- `cmd_wait_for()` — emits `worker.waiting` (with `wait_for`, `timeout_ms`, `since`, `reason`)
  before the loop; emits `worker.resumed` with `outcome: matched` or `outcome: timed_out` on exit.

### `broker/broker-state.mjs`
- New `waiting_sessions` table (`session_id`, `orchestrator`, `ticket`, `wait_for`, `timeout_at`,
  `reason`, `updated_at`).
- `upsertWaitingSession(sessionId, opts)` — computes `timeoutAt = since + timeoutMs` and
  INSERTs/REPLACEs a row.
- `clearWaitingSession(sessionId)` — removes the row.
- `getWaitingSession(sessionId)` — returns one row or null.
- `getActiveWaitingSessions(nowIso?)` — returns rows where `timeout_at > nowIso`.
- `rowToWaitingSession(row)` — maps DB row to `WaitingSession` shape for state file output.

### `broker/index.mjs`
- `waitingSessions: Map<sessionId, { timeoutAt, waitFor, ticket, orchestrator, reason }>` — in-memory
  store for O(1) watchdog lookups.
- `handleWorkerWaiting(event)` — stores session in map + DB, resets heartbeat, calls
  `persistBrokerState()`.
- `handleWorkerResumed(event)` — removes session from map + DB, calls `persistBrokerState()`.
- `runWatchdogTick()` — skips stale check when session is in `waitingSessions` with
  `timeoutAt > now`; cleans up and proceeds normally when the wait has expired.
- `buildBrokerState()` — includes `waitingSessions` (active-only, ISO `timeoutAt`) in the state
  object written to `broker.state.json`.
- DB rehydration at startup: `getActiveWaitingSessions()` populates the in-memory map so a broker
  restart doesn't lose waiting state for mid-wait sessions.
- `processEvent()` routing: `worker.waiting` → `handleWorkerWaiting`, `worker.resumed` →
  `handleWorkerResumed`.
- Exports `getWaitingSessionsMap()` and `clearWaitingSessionsMap()` for test isolation.

### HUD (`orch-monitor`)
- **`broker-key-health.ts`** — `WaitingSession` interface + `waitingSessions?: WaitingSession[]`
  added to `BrokerState`; `readBrokerState()` parses the new array.
- **`WorkerList.tsx`** — `findWaitingSession(ticket, sessions, nowMs)` matches broker waiting
  sessions to worker rows by ticket; `formatTimeoutRemaining(timeoutAt, nowMs)` formats the
  countdown; STATUS column shows `wait:Xm` in magenta; selected row shows `⏳ waiting for: <filter>`.
- **`Dashboard.tsx`** — passes `brokerState?.waitingSessions` to `WorkerList`.

### `broker/SKILL.md`
- New section "3a. `worker.waiting` / `worker.resumed` Events (CTL-403)" documenting both event
  shapes, the broker's handling contract, and the `waitingSessions` field in `broker.state.json`.

### Tests (`broker/index.test.mjs`)
- 16 new tests across 5 suites: `worker.waiting`, `worker.resumed`, watchdog skip logic,
  `buildBrokerState` output, `processEvent` routing.
- CTL-401 `session.heartbeat` tests from main merged cleanly (no conflicts in test logic).
- **144 total tests passing**, 0 failing.

## How to Verify

- [x] `bun test plugins/dev/scripts/broker/index.test.mjs` — 144 pass, 0 fail ✅
- [x] `bun test plugins/dev/scripts/broker/broker-state.test.mjs` — 19 pass, 0 fail ✅
- [ ] Start broker (`catalyst-broker start`), run `catalyst-events wait-for --filter '...' --timeout 60`, confirm `broker.state.json` contains a `waitingSessions` entry; verify HUD worker list shows `wait:Xm`
- [ ] After wait resolves (timeout or match), confirm entry is removed from `broker.state.json` and HUD reverts to normal status

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-403

Refs: CTL-403