### PR TITLE
fix(dev): drop comms.message.posted from Groq queue when no deterministic match (CTL-397)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -132,7 +132,7 @@ const __PLUGIN_JSON_PATH = resolve(
   "..",
   "..",
   ".claude-plugin",
-  "plugin.json",
+  "plugin.json"
 );
 let __pluginVersionCached = null;
 
@@ -151,14 +151,7 @@ export function pluginVersion() {
 // so receiving agents have enough context to act without re-fetching state
 // from GitHub/Linear/git. `lookup_jq` is a ready-to-run query against the
 // monthly-rotated event log for callers who do need full event details.
-const PAYLOAD_EXCERPT_KEYS = [
-  "state",
-  "stateType",
-  "conclusion",
-  "title",
-  "merged",
-  "action",
-];
+const PAYLOAD_EXCERPT_KEYS = ["state", "stateType", "conclusion", "title", "merged", "action"];
 
 export function summarizeEvent(event) {
   const id = event.id ?? synthesizeEventId(event);
@@ -168,7 +161,7 @@ export function summarizeEvent(event) {
   const payload =
     event.body && typeof event.body === "object" && "payload" in event.body
       ? event.body.payload
-      : event.detail ?? null;
+      : (event.detail ?? null);
   const scope = event.scope ?? {};
   const month = typeof ts === "string" ? ts.slice(0, 7) : "";
   const excerpt = {};
@@ -177,9 +170,7 @@ export function summarizeEvent(event) {
       if (payload[k] !== undefined) excerpt[k] = payload[k];
     }
   }
-  const message = typeof event.body?.message === "string"
-    ? event.body.message.slice(0, 200)
-    : "";
+  const message = typeof event.body?.message === "string" ? event.body.message.slice(0, 200) : "";
   const pr = attrs["vcs.pr.number"] ?? scope.pr ?? null;
   const repo = attrs["vcs.repository.name"] ?? scope.repo ?? null;
   return {
@@ -269,9 +260,15 @@ const DEGRADED_THRESHOLD_MS = 5 * 60 * 1000;
 
 // Test-only setters. Production paths only ever set these via main() and the
 // hook points below; tests use these to time-travel without touching Date.now().
-export function __setBrokerStartedAtForTest(iso) { brokerStartedAt = iso; }
-export function __resetBrokerStartedAtForTest() { brokerStartedAt = null; }
-export function __resetDegradedEmittedForTest() { degradedEmittedAt = null; }
+export function __setBrokerStartedAtForTest(iso) {
+  brokerStartedAt = iso;
+}
+export function __resetBrokerStartedAtForTest() {
+  brokerStartedAt = null;
+}
+export function __resetDegradedEmittedForTest() {
+  degradedEmittedAt = null;
+}
 export function __resetBrokerLivenessForTest() {
   brokerStartedAt = null;
   lastWakeAt = null;
@@ -304,10 +301,7 @@ function migrateLegacyInterestsFile() {
   try {
     if (existsSync(legacyFile) && !existsSync(interestsFile)) {
       renameSync(legacyFile, interestsFile);
-      log.info(
-        { from: legacyFile, to: interestsFile },
-        "migrated legacy interests file"
-      );
+      log.info({ from: legacyFile, to: interestsFile }, "migrated legacy interests file");
     }
   } catch (err) {
     log.error({ err: err.message }, "failed to migrate legacy interests file");
@@ -350,7 +344,7 @@ export function saveInterests() {
       }
       log.warn(
         { previousCount },
-        "refusing to save empty interests file — on-disk preserved (set CATALYST_BROKER_ALLOW_EMPTY_SAVE=1 to override)",
+        "refusing to save empty interests file — on-disk preserved (set CATALYST_BROKER_ALLOW_EMPTY_SAVE=1 to override)"
       );
       return;
     }
@@ -360,7 +354,11 @@ export function saveInterests() {
       writeFileSync(tmp, JSON.stringify(filtered, null, 2));
       renameSync(tmp, interestsFile);
     } catch (err) {
-      try { unlinkSync(tmp); } catch { /* tmp already gone */ }
+      try {
+        unlinkSync(tmp);
+      } catch {
+        /* tmp already gone */
+      }
       throw err;
     }
   } catch (err) {
@@ -376,10 +374,7 @@ export function loadPersistedInterests() {
     for (const [id, reg] of entries) {
       if (reg?.session_id && PROSE_TEST_SESSION.test(reg.session_id)) {
         skipped++;
-        log.warn(
-          { interestId: id, sessionId: reg.session_id },
-          "skipping prose-* test residue"
-        );
+        log.warn({ interestId: id, sessionId: reg.session_id }, "skipping prose-* test residue");
         continue;
       }
       interests.set(id, reg);
@@ -413,7 +408,7 @@ export function maybeEmitProseDisabled() {
   if (process.env.CATALYST_BROKER_PROSE_ENABLED === "1") return;
   if (_proseDisabledEmitted) return;
   const proseEntries = [...interests.entries()].filter(
-    ([, reg]) => !DETERMINISTIC_INTEREST_TYPES.has(reg?.interest_type ?? null),
+    ([, reg]) => !DETERMINISTIC_INTEREST_TYPES.has(reg?.interest_type ?? null)
   );
   if (proseEntries.length === 0) return;
   appendEvent({
@@ -483,14 +478,22 @@ export function handleRegister(event) {
     // comms_lifecycle fields (CTL-357)
     channel: isCommsLifecycle ? (d.channel ?? null) : null,
     subscriber_kind: isCommsLifecycle ? (d.subscriber_kind ?? null) : null,
-    owned_workers: isCommsLifecycle ? (Array.isArray(d.owned_workers) ? d.owned_workers : null) : null,
+    owned_workers: isCommsLifecycle
+      ? Array.isArray(d.owned_workers)
+        ? d.owned_workers
+        : null
+      : null,
     subscriber_ticket: isCommsLifecycle ? (d.subscriber_ticket ?? null) : null,
-    types_of_interest: isCommsLifecycle ? (Array.isArray(d.types_of_interest) ? d.types_of_interest : null) : null,
+    types_of_interest: isCommsLifecycle
+      ? Array.isArray(d.types_of_interest)
+        ? d.types_of_interest
+        : null
+      : null,
   });
 
   if (isPrLifecycle) {
     try {
-      for (const prNumber of (d.pr_numbers ?? [])) {
+      for (const prNumber of d.pr_numbers ?? []) {
         upsertFilterStateOpen({ interestId: id, prNumber, repo: d.repo ?? "" });
       }
     } catch {
@@ -502,12 +505,12 @@ export function handleRegister(event) {
   if (isPrLifecycle) {
     log.info(
       { interestId: id, type: "pr_lifecycle", prs: d.pr_numbers ?? [], persistent },
-      "registered",
+      "registered"
     );
   } else if (isTicketLifecycle) {
     log.info(
       { interestId: id, type: "ticket_lifecycle", tickets: d.tickets ?? [], persistent },
-      "registered",
+      "registered"
     );
   } else if (isCommsLifecycle) {
     log.info(
@@ -518,7 +521,7 @@ export function handleRegister(event) {
         subscriberKind: d.subscriber_kind,
         persistent,
       },
-      "registered",
+      "registered"
     );
   } else {
     log.info({ interestId: id, prompt: d.prompt, persistent }, "registered");
@@ -537,7 +540,11 @@ export function handleDeregister(event) {
   const reg = interests.get(id);
   if (interests.delete(id)) {
     if (reg && reg.interest_type === "pr_lifecycle") {
-      try { deleteFilterState(id); } catch { /* DB not opened */ }
+      try {
+        deleteFilterState(id);
+      } catch {
+        /* DB not opened */
+      }
     }
     log.info({ interestId: id }, "deregistered");
     saveInterests();
@@ -552,12 +559,16 @@ export function handleOrchestratorTerminated(event) {
   for (const [id, reg] of interests) {
     if (reg.orchestrator === orchId) {
       if (reg.interest_type === "pr_lifecycle") {
-        try { deleteFilterState(id); } catch { /* DB not opened */ }
+        try {
+          deleteFilterState(id);
+        } catch {
+          /* DB not opened */
+        }
       }
       interests.delete(id);
       log.info(
         { interestId: id, orchestrator: orchId },
-        "auto-deregistered (orchestrator terminated)",
+        "auto-deregistered (orchestrator terminated)"
       );
       changed = true;
     }
@@ -601,10 +612,7 @@ export function handleAgentCheckin(event) {
     _autoRegisterPrLifecycle(sessionId, claimedPr, orchestrator, ticket);
   }
 
-  log.info(
-    { agentName, sessionId, ticket, claimedPr },
-    "agent checked in",
-  );
+  log.info({ agentName, sessionId, ticket, claimedPr }, "agent checked in");
 }
 
 // Auto-register a pr_lifecycle interest when we learn agent ↔ PR mapping.
@@ -628,7 +636,9 @@ function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket) {
 
   try {
     upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: "" });
-  } catch { /* DB not opened */ }
+  } catch {
+    /* DB not opened */
+  }
 
   log.info({ sessionId, prNumber }, "auto-correlated pr_lifecycle for session");
   saveInterests();
@@ -644,14 +654,22 @@ export function handleAgentCheckout(event) {
 
   const finalStatus = d.status ?? "done";
 
-  try { markAgentDone(sessionId, finalStatus); } catch { /* DB not opened */ }
+  try {
+    markAgentDone(sessionId, finalStatus);
+  } catch {
+    /* DB not opened */
+  }
 
   // Deregister auto-derived pr_lifecycle interest so the watchdog doesn't
   // fire stale wakes after the agent exits.
   const reg = interests.get(sessionId);
   if (reg && reg.interest_type === "pr_lifecycle") {
     interests.delete(sessionId);
-    try { deleteFilterState(sessionId); } catch { /* DB not opened */ }
+    try {
+      deleteFilterState(sessionId);
+    } catch {
+      /* DB not opened */
+    }
     saveInterests();
     persistBrokerState();
   }
@@ -675,7 +693,8 @@ export function handleAgentHeartbeat(event) {
 function botPrefix(author, kind) {
   const isBot = author?.type === "Bot";
   if (kind === "review") return isBot ? "Automated review comment from " : "Changes requested by ";
-  if (kind === "comment") return isBot ? "Automated review comment from " : "New review comment from ";
+  if (kind === "comment")
+    return isBot ? "Automated review comment from " : "New review comment from ";
   return "";
 }
 
@@ -730,11 +749,30 @@ export function tryDeterministicRoute(event, interestsMap) {
 
   let deployMatchedInterest = null;
   if (name === "github.deployment.created") {
-    try { deployMatchedInterest = setFilterStateDeploying(scope.sha, detail.deploymentId, scope.environment); } catch { /* DB not opened */ }
+    try {
+      deployMatchedInterest = setFilterStateDeploying(
+        scope.sha,
+        detail.deploymentId,
+        scope.environment
+      );
+    } catch {
+      /* DB not opened */
+    }
   } else if (name === "github.deployment_status.success") {
-    try { deployMatchedInterest = setFilterStateDeployed(detail.deploymentId); } catch { /* DB not opened */ }
-  } else if (name === "github.deployment_status.failure" || name === "github.deployment_status.error") {
-    try { deployMatchedInterest = setFilterStateFailed(detail.deploymentId); } catch { /* DB not opened */ }
+    try {
+      deployMatchedInterest = setFilterStateDeployed(detail.deploymentId);
+    } catch {
+      /* DB not opened */
+    }
+  } else if (
+    name === "github.deployment_status.failure" ||
+    name === "github.deployment_status.error"
+  ) {
+    try {
+      deployMatchedInterest = setFilterStateFailed(detail.deploymentId);
+    } catch {
+      /* DB not opened */
+    }
   }
 
   for (const [interestId, reg] of interestsMap) {
@@ -773,7 +811,11 @@ export function tryDeterministicRoute(event, interestsMap) {
         const sha = detail.mergeCommitSha ?? "unknown";
         reason = `PR #${scope.pr} merged (merge commit: ${sha}). Now waiting for deployment — do not close out until deployment succeeds.`;
         if (detail.mergeCommitSha) {
-          try { setFilterStateMerged(interestId, detail.mergeCommitSha); } catch { /* DB not opened */ }
+          try {
+            setFilterStateMerged(interestId, detail.mergeCommitSha);
+          } catch {
+            /* DB not opened */
+          }
         }
       }
     } else if (name === "github.pr.closed") {
@@ -815,7 +857,10 @@ export function tryDeterministicRoute(event, interestsMap) {
       if (deployMatchedInterest && deployMatchedInterest.interestId === interestId) {
         reason = `Deployment succeeded on ${scope.environment}. Work is complete.`;
       }
-    } else if (name === "github.deployment_status.failure" || name === "github.deployment_status.error") {
+    } else if (
+      name === "github.deployment_status.failure" ||
+      name === "github.deployment_status.error"
+    ) {
       if (deployMatchedInterest && deployMatchedInterest.interestId === interestId) {
         const url = detail.targetUrl ?? "(no target URL)";
         reason = `Deployment failed on ${scope.environment}. URL: ${url}`;
@@ -854,7 +899,12 @@ export function tryDeterministicRoute(event, interestsMap) {
 //             status_changed, comment_added
 
 const TICKET_LIFECYCLE_ALL_WAKE_ON = [
-  "pr_opened", "pr_merged", "status_done", "status_in_review", "status_changed", "comment_added",
+  "pr_opened",
+  "pr_merged",
+  "status_done",
+  "status_in_review",
+  "status_changed",
+  "comment_added",
 ];
 
 export function tryTicketLifecycleRoute(event, interestsMap) {
@@ -873,10 +923,7 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
   // Extract the ticket this event concerns. Linear canonical events carry
   // `attributes["linear.issue.identifier"]`; legacy/flat events use `detail.ticket`.
   const eventTicket =
-    attrs["linear.issue.identifier"] ??
-    detail.ticket ??
-    detail.identifier ??
-    null;
+    attrs["linear.issue.identifier"] ?? detail.ticket ?? detail.identifier ?? null;
 
   // For GitHub PR events extract ticket refs from PR body / title / branch ref.
   let prBodyTickets = [];
@@ -889,12 +936,20 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
   // Side effect: update ticket_state for known state-change events.
   if (name === "linear.issue.state_changed" && eventTicket) {
     const newState = detail.state ?? detail.stateName ?? null;
-    try { upsertTicketState({ ticket: eventTicket, linearState: newState }); } catch { /* DB not opened */ }
+    try {
+      upsertTicketState({ ticket: eventTicket, linearState: newState });
+    } catch {
+      /* DB not opened */
+    }
   }
   if ((name === "github.pr.opened" || name === "github.pr.merged") && prBodyTickets.length > 0) {
     const prNum = typeof scope.pr === "number" ? scope.pr : null;
     for (const t of prBodyTickets) {
-      try { upsertTicketState({ ticket: t, prNumber: prNum }); } catch { /* DB not opened */ }
+      try {
+        upsertTicketState({ ticket: t, prNumber: prNum });
+      } catch {
+        /* DB not opened */
+      }
     }
   }
 
@@ -908,7 +963,11 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
     let reason = null;
     let matchedTicket = null;
 
-    if (name === "linear.issue.state_changed" && eventTicket && watchedTickets.includes(eventTicket)) {
+    if (
+      name === "linear.issue.state_changed" &&
+      eventTicket &&
+      watchedTickets.includes(eventTicket)
+    ) {
       matchedTicket = eventTicket;
       const newState = detail.state ?? detail.stateName ?? "unknown";
       if (wakeOn.includes("status_done") && /done/i.test(newState)) {
@@ -918,12 +977,20 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
       } else if (wakeOn.includes("status_changed")) {
         reason = `Ticket ${eventTicket} state changed to ${newState}`;
       }
-    } else if (name === "linear.issue.updated" && eventTicket && watchedTickets.includes(eventTicket)) {
+    } else if (
+      name === "linear.issue.updated" &&
+      eventTicket &&
+      watchedTickets.includes(eventTicket)
+    ) {
       if (wakeOn.includes("status_changed")) {
         matchedTicket = eventTicket;
         reason = `Ticket ${eventTicket} updated`;
       }
-    } else if (name === "linear.comment.created" && eventTicket && watchedTickets.includes(eventTicket)) {
+    } else if (
+      name === "linear.comment.created" &&
+      eventTicket &&
+      watchedTickets.includes(eventTicket)
+    ) {
       if (wakeOn.includes("comment_added")) {
         matchedTicket = eventTicket;
         const author = detail.author ?? attrs["linear.actor.id"] ?? "someone";
@@ -969,7 +1036,11 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
 // interest whose orchestrator matches one of those agents.
 function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
   let agents = [];
-  try { agents = getAgentsByTicket(ticket); } catch { return; }
+  try {
+    agents = getAgentsByTicket(ticket);
+  } catch {
+    return;
+  }
 
   let changed = false;
 
@@ -993,12 +1064,13 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
       wake_on: null,
     });
 
-    try { upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: "" }); } catch { /* DB not opened */ }
+    try {
+      upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: "" });
+    } catch {
+      /* DB not opened */
+    }
 
-    log.info(
-      { sessionId, ticket, prNumber },
-      "auto-correlated pr_lifecycle from ticket",
-    );
+    log.info({ sessionId, ticket, prNumber }, "auto-correlated pr_lifecycle from ticket");
     changed = true;
   }
 
@@ -1008,9 +1080,7 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
   // worker has opened a PR — so pr_numbers starts empty. Without this update,
   // the deterministic route in tryDeterministicRoute never matches incoming
   // PR/CI/review events for the new PR.
-  const orchsForTicket = new Set(
-    agents.map((a) => a.orchestrator).filter((o) => o != null),
-  );
+  const orchsForTicket = new Set(agents.map((a) => a.orchestrator).filter((o) => o != null));
   for (const [interestId, reg] of interestsMap) {
     if (reg.interest_type !== "pr_lifecycle") continue;
     if (reg.session_id !== null) continue; // worker-level — skip
@@ -1018,10 +1088,14 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
     const prs = reg.pr_numbers ?? [];
     if (prs.includes(prNumber)) continue;
     reg.pr_numbers = [...prs, prNumber];
-    try { upsertFilterStateOpen({ interestId, prNumber, repo: reg.repo ?? "" }); } catch { /* DB not opened */ }
+    try {
+      upsertFilterStateOpen({ interestId, prNumber, repo: reg.repo ?? "" });
+    } catch {
+      /* DB not opened */
+    }
     log.info(
       { interestId, ticket, prNumber, orchestrator: reg.orchestrator },
-      "appended PR to orchestrator pr_lifecycle interest",
+      "appended PR to orchestrator pr_lifecycle interest"
     );
     changed = true;
   }
@@ -1061,7 +1135,7 @@ export function buildGroqPrompt(events) {
     ([, reg]) =>
       reg.interest_type !== "pr_lifecycle" &&
       reg.interest_type !== "ticket_lifecycle" &&
-      reg.interest_type !== "comms_lifecycle",
+      reg.interest_type !== "comms_lifecycle"
   );
   if (proseInterests.length === 0) return null;
 
@@ -1224,6 +1298,17 @@ let pendingBatch = [];
 let debounceTimer = null;
 let hardCapTimer = null;
 
+export function __getPendingBatchForTest() {
+  return [...pendingBatch];
+}
+export function __clearPendingBatchForTest() {
+  clearTimeout(debounceTimer);
+  clearTimeout(hardCapTimer);
+  debounceTimer = null;
+  hardCapTimer = null;
+  pendingBatch.splice(0);
+}
+
 async function flushBatch() {
   clearTimeout(debounceTimer);
   clearTimeout(hardCapTimer);
@@ -1310,10 +1395,7 @@ export function runWatchdogTick() {
               interest_id: interestId,
             },
           });
-          log.info(
-            { notifyEvent: interest.notify_event, reason },
-            "watchdog wake",
-          );
+          log.info({ notifyEvent: interest.notify_event, reason }, "watchdog wake");
           woke = true;
           watchdogWoke = true;
         }
@@ -1323,10 +1405,7 @@ export function runWatchdogTick() {
         for (const [interestId, interest] of interests) {
           if (interest.session_id && interest.session_id === sourceId) {
             interests.delete(interestId);
-            log.info(
-              { interestId, sourceId },
-              "watchdog cleanup: removed stale session",
-            );
+            log.info({ interestId, sourceId }, "watchdog cleanup: removed stale session");
           }
         }
         lastHeartbeat.set(sourceId, { ts: state.ts, notified: true });
@@ -1417,14 +1496,15 @@ export function processEvent(event) {
         ...(m.ticket ? { ticket: m.ticket } : {}),
       },
     });
-    log.info(
-      { notifyEvent: reg.notify_event, reason: m.reason },
-      "direct wake",
-    );
+    log.info({ notifyEvent: reg.notify_event, reason: m.reason }, "direct wake");
     if (!reg.persistent) {
       interests.delete(m.interestId);
       if (reg.interest_type === "pr_lifecycle") {
-        try { deleteFilterState(m.interestId); } catch { /* DB not opened */ }
+        try {
+          deleteFilterState(m.interestId);
+        } catch {
+          /* DB not opened */
+        }
       }
       saveInterests();
       log.info({ interestId: m.interestId }, "auto-deregistered (one-shot)");
@@ -1436,6 +1516,13 @@ export function processEvent(event) {
     persistBrokerState();
     return;
   }
+
+  // CTL-397: comms.message.posted is handled deterministically via comms_lifecycle
+  // interests. If no deterministic match fired (types_of_interest filtered it out,
+  // sender not in owned_workers, etc.), drop the event rather than passing it to
+  // the Groq queue — info-type phase-narration heartbeats would otherwise generate
+  // spurious filter.wake events when prose interests are present.
+  if (getEventName(event) === "comms.message.posted") return;
 
   queueEvent(event);
 }
@@ -1483,7 +1570,11 @@ function readNewEvents() {
     for (const line of lines) {
       if (!line.trim()) continue;
       let event;
-      try { event = JSON.parse(line); } catch { continue; }
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
       processEvent(event);
     }
   } catch {
@@ -1507,7 +1598,11 @@ function loadExistingRegistrations() {
     const lines = content.split("\n").filter((l) => l.trim());
     for (const line of lines.slice(-LOOKBACK_LINES)) {
       let event;
-      try { event = JSON.parse(line); } catch { continue; }
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
       const name = getEventName(event);
       if (name === "filter.register") handleRegister(event);
       if (name === "filter.deregister") handleDeregister(event);
@@ -1545,7 +1640,11 @@ function writePidFile() {
 
 function removePidFile() {
   if (!PID_FILE_PATH) return;
-  try { unlinkSync(PID_FILE_PATH); } catch { /* already gone */ }
+  try {
+    unlinkSync(PID_FILE_PATH);
+  } catch {
+    /* already gone */
+  }
 }
 
 // --- State file (CTL-343) ---
@@ -1619,11 +1718,23 @@ export function logKeyHealthAtStartup() {
     for (const line of warning.split("\n")) log.warn(line);
   } else {
     log.info(
-      { source: GROQ_KEY_SOURCE, prefix: GROQ_KEY_PREFIX, model: GROQ_MODEL, endpoint: GROQ_ENDPOINT },
-      formatLoadedKeyInfo({ name: "GROQ_API_KEY", source: GROQ_KEY_SOURCE, prefix: GROQ_KEY_PREFIX }),
+      {
+        source: GROQ_KEY_SOURCE,
+        prefix: GROQ_KEY_PREFIX,
+        model: GROQ_MODEL,
+        endpoint: GROQ_ENDPOINT,
+      },
+      formatLoadedKeyInfo({
+        name: "GROQ_API_KEY",
+        source: GROQ_KEY_SOURCE,
+        prefix: GROQ_KEY_PREFIX,
+      })
     );
     if (GROQ_GATEWAY_ENABLED) {
-      log.info({ baseUrl: GROQ_GATEWAY_BASE_URL }, "GROQ gateway enabled — routing chat completions through configured baseUrl");
+      log.info(
+        { baseUrl: GROQ_GATEWAY_BASE_URL },
+        "GROQ gateway enabled — routing chat completions through configured baseUrl"
+      );
     }
   }
 }
@@ -1645,7 +1756,10 @@ export async function runStartupProbe() {
       log.error({ err: probe.error }, "Groq probe FAILED — semantic routing disabled");
       break;
     case "error":
-      log.warn({ err: probe.error }, "Groq probe could not complete — semantic routing may be impaired");
+      log.warn(
+        { err: probe.error },
+        "Groq probe could not complete — semantic routing may be impaired"
+      );
       break;
     case "missing":
       // already warned at startup
@@ -1700,7 +1814,11 @@ function main() {
       watchdog_interval_ms: WATCHDOG_INTERVAL_MS,
       heartbeat_stale_ms: HEARTBEAT_STALE_MS,
       broker: true,
-      key_health: { source: GROQ_KEY_SOURCE, prefix: GROQ_KEY_PREFIX, gateway: GROQ_GATEWAY_ENABLED },
+      key_health: {
+        source: GROQ_KEY_SOURCE,
+        prefix: GROQ_KEY_PREFIX,
+        gateway: GROQ_GATEWAY_ENABLED,
+      },
     },
   });
 
@@ -1712,15 +1830,17 @@ function main() {
       watchdogIntervalMs: WATCHDOG_INTERVAL_MS,
       heartbeatStaleMs: HEARTBEAT_STALE_MS,
     },
-    "catalyst-broker daemon started",
+    "catalyst-broker daemon started"
   );
 
   // Fire the Groq /v1/models probe asynchronously so it doesn't gate startup.
-  runStartupProbe().then((probe) => {
-    writeBrokerStateFile(buildBrokerState({ probe }));
-  }).catch((err) => {
-    log.warn({ err: err.message }, "probe error suppressed");
-  });
+  runStartupProbe()
+    .then((probe) => {
+      writeBrokerStateFile(buildBrokerState({ probe }));
+    })
+    .catch((err) => {
+      log.warn({ err: err.message }, "probe error suppressed");
+    });
 
   const shutdown = (signal) => {
     eventsWatcher?.close();
@@ -1749,7 +1869,11 @@ function main() {
     }
     closeBrokerStateDb();
     removePidFile();
-    try { unlinkSync(BROKER_STATE_FILE); } catch { /* already gone */ }
+    try {
+      unlinkSync(BROKER_STATE_FILE);
+    } catch {
+      /* already gone */
+    }
     process.exit(0);
   };
   process.on("SIGINT", () => shutdown("SIGINT"));

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -28,6 +28,8 @@ import {
   summarizeEvent,
   buildBrokerState,
   writeBrokerStateFile,
+  __getPendingBatchForTest,
+  __clearPendingBatchForTest,
 } from "./index.mjs";
 import {
   openBrokerStateDb,
@@ -117,42 +119,54 @@ describe("tryTicketLifecycleRoute — Linear state changes", () => {
   });
 
   test("fires status_done on linear.issue.state_changed with 'Done' state", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "linear.issue.state_changed",
-      attributes: { "linear.issue.identifier": "CTL-275" },
-      detail: { state: "Done" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "linear.issue.state_changed",
+        attributes: { "linear.issue.identifier": "CTL-275" },
+        detail: { state: "Done" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].interestId).toBe("watch-ctl-275");
     expect(matches[0].reason).toContain("marked Done");
   });
 
   test("fires status_in_review on 'In Review' state", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "linear.issue.state_changed",
-      attributes: { "linear.issue.identifier": "CTL-275" },
-      detail: { state: "In Review" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "linear.issue.state_changed",
+        attributes: { "linear.issue.identifier": "CTL-275" },
+        detail: { state: "In Review" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("In Review");
   });
 
   test("fires status_changed for non-terminal state changes", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "linear.issue.state_changed",
-      attributes: { "linear.issue.identifier": "CTL-275" },
-      detail: { state: "In Progress" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "linear.issue.state_changed",
+        attributes: { "linear.issue.identifier": "CTL-275" },
+        detail: { state: "In Progress" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("In Progress");
   });
 
   test("does not fire for unregistered ticket", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "linear.issue.state_changed",
-      attributes: { "linear.issue.identifier": "CTL-999" },
-      detail: { state: "Done" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "linear.issue.state_changed",
+        attributes: { "linear.issue.identifier": "CTL-999" },
+        detail: { state: "Done" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(0);
   });
 
@@ -169,11 +183,14 @@ describe("tryTicketLifecycleRoute — Linear state changes", () => {
         persistent: true,
       },
     });
-    const matches = tryTicketLifecycleRoute({
-      event: "linear.issue.state_changed",
-      attributes: { "linear.issue.identifier": "CTL-275" },
-      detail: { state: "Done" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "linear.issue.state_changed",
+        attributes: { "linear.issue.identifier": "CTL-275" },
+        detail: { state: "Done" },
+      },
+      getInterests()
+    );
     const narrowMatch = matches.find((m) => m.interestId === "narrow-watch");
     expect(narrowMatch).toBeUndefined();
   });
@@ -196,22 +213,28 @@ describe("tryTicketLifecycleRoute — Linear comments", () => {
   });
 
   test("fires on linear.comment.created for watched ticket", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "linear.comment.created",
-      attributes: { "linear.issue.identifier": "CTL-275" },
-      detail: { author: "ryan" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "linear.comment.created",
+        attributes: { "linear.issue.identifier": "CTL-275" },
+        detail: { author: "ryan" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("ryan");
     expect(matches[0].reason).toContain("CTL-275");
   });
 
   test("does not fire for unwatched ticket", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "linear.comment.created",
-      attributes: { "linear.issue.identifier": "CTL-999" },
-      detail: { author: "ryan" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "linear.comment.created",
+        attributes: { "linear.issue.identifier": "CTL-999" },
+        detail: { author: "ryan" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(0);
   });
 });
@@ -233,42 +256,58 @@ describe("tryTicketLifecycleRoute — GitHub PR events with ticket link", () => 
   });
 
   test("fires pr_opened when PR body references watched ticket", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "github.pr.opened",
-      scope: { pr: 501 },
-      detail: { body: "Implements CTL-275\n\nThis PR does stuff", title: "fix thing", headRef: "ryan/ctl-275" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "github.pr.opened",
+        scope: { pr: 501 },
+        detail: {
+          body: "Implements CTL-275\n\nThis PR does stuff",
+          title: "fix thing",
+          headRef: "ryan/ctl-275",
+        },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("501");
     expect(matches[0].reason).toContain("CTL-275");
   });
 
   test("fires pr_merged when PR body references watched ticket", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "github.pr.merged",
-      scope: { pr: 501 },
-      detail: { body: "Fixes CTL-275", title: "", headRef: "" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "github.pr.merged",
+        scope: { pr: 501 },
+        detail: { body: "Fixes CTL-275", title: "", headRef: "" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("merged");
     expect(matches[0].ticket).toBe("CTL-275");
   });
 
   test("does not fire when PR body has no ticket reference", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "github.pr.opened",
-      scope: { pr: 502 },
-      detail: { body: "General cleanup PR", title: "cleanup", headRef: "ryan/cleanup" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "github.pr.opened",
+        scope: { pr: 502 },
+        detail: { body: "General cleanup PR", title: "cleanup", headRef: "ryan/cleanup" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(0);
   });
 
   test("includes ticket field in match result", () => {
-    const matches = tryTicketLifecycleRoute({
-      event: "github.pr.opened",
-      scope: { pr: 505 },
-      detail: { body: "CTL-275 implementation", title: "", headRef: "" },
-    }, getInterests());
+    const matches = tryTicketLifecycleRoute(
+      {
+        event: "github.pr.opened",
+        scope: { pr: 505 },
+        detail: { body: "CTL-275 implementation", title: "", headRef: "" },
+      },
+      getInterests()
+    );
     expect(matches[0].ticket).toBe("CTL-275");
   });
 });
@@ -286,11 +325,14 @@ describe("tryTicketLifecycleRoute — ticket_state side effects", () => {
         persistent: true,
       },
     });
-    tryTicketLifecycleRoute({
-      event: "linear.issue.state_changed",
-      attributes: { "linear.issue.identifier": "CTL-280" },
-      detail: { state: "Done" },
-    }, getInterests());
+    tryTicketLifecycleRoute(
+      {
+        event: "linear.issue.state_changed",
+        attributes: { "linear.issue.identifier": "CTL-280" },
+        detail: { state: "Done" },
+      },
+      getInterests()
+    );
     const ts = getTicketState("CTL-280");
     expect(ts).not.toBeNull();
     expect(ts.linearState).toBe("Done");
@@ -516,7 +558,12 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
   test("agent checked in with ticket gets pr_lifecycle when PR opens", () => {
     handleAgentCheckin({
       event: "agent.checkin",
-      detail: { session_id: "sess-auto", agent_name: "worker", ticket: "CTL-275", claimed_pr: null },
+      detail: {
+        session_id: "sess-auto",
+        agent_name: "worker",
+        ticket: "CTL-275",
+        claimed_pr: null,
+      },
     });
     expect(getInterests().has("sess-auto")).toBe(false);
 
@@ -533,11 +580,14 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
       },
     });
 
-    tryTicketLifecycleRoute({
-      event: "github.pr.opened",
-      scope: { pr: 601 },
-      detail: { body: "Implements CTL-275", title: "", headRef: "" },
-    }, getInterests());
+    tryTicketLifecycleRoute(
+      {
+        event: "github.pr.opened",
+        scope: { pr: 601 },
+        detail: { body: "Implements CTL-275", title: "", headRef: "" },
+      },
+      getInterests()
+    );
 
     const reg = getInterests().get("sess-auto");
     expect(reg).toBeDefined();
@@ -548,7 +598,12 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
   test("agents with existing claimed_pr are skipped during auto-correlation", () => {
     handleAgentCheckin({
       event: "agent.checkin",
-      detail: { session_id: "sess-already", agent_name: "worker", ticket: "CTL-275", claimed_pr: 500 },
+      detail: {
+        session_id: "sess-already",
+        agent_name: "worker",
+        ticket: "CTL-275",
+        claimed_pr: 500,
+      },
     });
     const prBefore = getInterests().get("sess-already")?.pr_numbers;
 
@@ -564,11 +619,14 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
       },
     });
 
-    tryTicketLifecycleRoute({
-      event: "github.pr.opened",
-      scope: { pr: 601 },
-      detail: { body: "CTL-275 implementation", title: "", headRef: "" },
-    }, getInterests());
+    tryTicketLifecycleRoute(
+      {
+        event: "github.pr.opened",
+        scope: { pr: 601 },
+        detail: { body: "CTL-275 implementation", title: "", headRef: "" },
+      },
+      getInterests()
+    );
 
     expect(getInterests().get("sess-already")?.pr_numbers).toEqual(prBefore);
   });
@@ -577,7 +635,13 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
   test("orchestrator pr_lifecycle interest gets PR appended when worker on its ticket opens PR", () => {
     handleAgentCheckin({
       event: "agent.checkin",
-      detail: { session_id: "sess-w-A", agent_name: "worker", ticket: "CTL-275", orchestrator: "orch-A", claimed_pr: null },
+      detail: {
+        session_id: "sess-w-A",
+        agent_name: "worker",
+        ticket: "CTL-275",
+        orchestrator: "orch-A",
+        claimed_pr: null,
+      },
     });
 
     // Orchestrator-level pr_lifecycle interest registered with empty pr_numbers
@@ -609,11 +673,14 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
       },
     });
 
-    tryTicketLifecycleRoute({
-      event: "github.pr.opened",
-      scope: { pr: 610 },
-      detail: { body: "Implements CTL-275", title: "", headRef: "" },
-    }, getInterests());
+    tryTicketLifecycleRoute(
+      {
+        event: "github.pr.opened",
+        scope: { pr: 610 },
+        detail: { body: "Implements CTL-275", title: "", headRef: "" },
+      },
+      getInterests()
+    );
 
     const orchReg = getInterests().get("orch-A-pr-lifecycle");
     expect(orchReg).toBeDefined();
@@ -623,7 +690,13 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
   test("orchestrator pr_lifecycle interest is not duplicated if PR already present", () => {
     handleAgentCheckin({
       event: "agent.checkin",
-      detail: { session_id: "sess-w-B", agent_name: "worker", ticket: "CTL-275", orchestrator: "orch-B", claimed_pr: null },
+      detail: {
+        session_id: "sess-w-B",
+        agent_name: "worker",
+        ticket: "CTL-275",
+        orchestrator: "orch-B",
+        claimed_pr: null,
+      },
     });
 
     handleRegister({
@@ -652,11 +725,14 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
       },
     });
 
-    tryTicketLifecycleRoute({
-      event: "github.pr.opened",
-      scope: { pr: 620 },
-      detail: { body: "Implements CTL-275", title: "", headRef: "" },
-    }, getInterests());
+    tryTicketLifecycleRoute(
+      {
+        event: "github.pr.opened",
+        scope: { pr: 620 },
+        detail: { body: "Implements CTL-275", title: "", headRef: "" },
+      },
+      getInterests()
+    );
 
     const orchReg = getInterests().get("orch-B-pr-lifecycle");
     expect(orchReg.pr_numbers.filter((n) => n === 620)).toHaveLength(1);
@@ -665,7 +741,13 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
   test("orchestrator pr_lifecycle interest is NOT touched when no agent on watched ticket belongs to that orchestrator", () => {
     handleAgentCheckin({
       event: "agent.checkin",
-      detail: { session_id: "sess-w-X", agent_name: "worker", ticket: "CTL-275", orchestrator: "orch-X", claimed_pr: null },
+      detail: {
+        session_id: "sess-w-X",
+        agent_name: "worker",
+        ticket: "CTL-275",
+        orchestrator: "orch-X",
+        claimed_pr: null,
+      },
     });
 
     handleRegister({
@@ -694,11 +776,14 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
       },
     });
 
-    tryTicketLifecycleRoute({
-      event: "github.pr.opened",
-      scope: { pr: 630 },
-      detail: { body: "Implements CTL-275", title: "", headRef: "" },
-    }, getInterests());
+    tryTicketLifecycleRoute(
+      {
+        event: "github.pr.opened",
+        scope: { pr: 630 },
+        detail: { body: "Implements CTL-275", title: "", headRef: "" },
+      },
+      getInterests()
+    );
 
     const orchYReg = getInterests().get("orch-Y-pr-lifecycle");
     expect(orchYReg.pr_numbers).toEqual([]);
@@ -745,11 +830,14 @@ describe("backward compat: pr_lifecycle routing unchanged in broker", () => {
         session_id: "sess-bc",
       },
     });
-    const matches = tryDeterministicRoute({
-      event: "github.pr.merged",
-      scope: { pr: 501 },
-      detail: { mergeCommitSha: "abc123", merged: true },
-    }, getInterests());
+    const matches = tryDeterministicRoute(
+      {
+        event: "github.pr.merged",
+        scope: { pr: 501 },
+        detail: { mergeCommitSha: "abc123", merged: true },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].interestId).toBe("sess-bc");
     expect(matches[0].reason).toContain("merged");
@@ -769,10 +857,13 @@ describe("backward compat: pr_lifecycle routing unchanged in broker", () => {
         persistent: true,
       },
     });
-    const matches = tryDeterministicRoute({
-      event: "github.check_suite.completed",
-      detail: { prNumbers: [502], conclusion: "success" },
-    }, getInterests());
+    const matches = tryDeterministicRoute(
+      {
+        event: "github.check_suite.completed",
+        detail: { prNumbers: [502], conclusion: "success" },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("CI checks passing");
   });
@@ -917,48 +1008,60 @@ describe("shouldSkipEvent (broker)", () => {
 
 describe("shouldSkipEvent — broker self-emission guards (CTL-346)", () => {
   test("skips canonical filter.wake.* event (broker self-emission)", () => {
-    expect(shouldSkipEvent({
-      attributes: { "event.name": "filter.wake.orch-1" },
-      resource: { "service.name": "catalyst.broker" },
-      body: { payload: {} },
-    })).toBe(true);
+    expect(
+      shouldSkipEvent({
+        attributes: { "event.name": "filter.wake.orch-1" },
+        resource: { "service.name": "catalyst.broker" },
+        body: { payload: {} },
+      })
+    ).toBe(true);
   });
 
   test("skips canonical broker.daemon.startup event", () => {
-    expect(shouldSkipEvent({
-      attributes: { "event.name": "broker.daemon.startup" },
-      resource: { "service.name": "catalyst.broker" },
-    })).toBe(true);
+    expect(
+      shouldSkipEvent({
+        attributes: { "event.name": "broker.daemon.startup" },
+        resource: { "service.name": "catalyst.broker" },
+      })
+    ).toBe(true);
   });
 
   // CTL-351: broker.daemon.shutdown follows the same self-emission pattern.
   test("skips canonical broker.daemon.shutdown event", () => {
-    expect(shouldSkipEvent({
-      attributes: { "event.name": "broker.daemon.shutdown" },
-      resource: { "service.name": "catalyst.broker" },
-    })).toBe(true);
+    expect(
+      shouldSkipEvent({
+        attributes: { "event.name": "broker.daemon.shutdown" },
+        resource: { "service.name": "catalyst.broker" },
+      })
+    ).toBe(true);
   });
 
   test("skips any event with resource.service.name == catalyst.broker", () => {
     // Defense-in-depth: future broker.* event names still get skipped.
-    expect(shouldSkipEvent({
-      attributes: { "event.name": "broker.future.metric" },
-      resource: { "service.name": "catalyst.broker" },
-    })).toBe(true);
+    expect(
+      shouldSkipEvent({
+        attributes: { "event.name": "broker.future.metric" },
+        resource: { "service.name": "catalyst.broker" },
+      })
+    ).toBe(true);
   });
 
   test("does not skip github.* events from other services", () => {
-    expect(shouldSkipEvent({
-      attributes: { "event.name": "github.pr.merged" },
-      resource: { "service.name": "catalyst.github-webhook" },
-    })).toBe(false);
+    expect(
+      shouldSkipEvent({
+        attributes: { "event.name": "github.pr.merged" },
+        resource: { "service.name": "catalyst.github-webhook" },
+      })
+    ).toBe(false);
   });
 
   test("does not skip canonical linear.* events from other services", () => {
-    expect(shouldSkipEvent({
-      attributes: { "event.name": "linear.issue.state_changed" },
-      resource: { "service.name": "catalyst.linear-webhook" },
-    })).toBe(false);
+    expect(
+      shouldSkipEvent({
+        attributes: { "event.name": "linear.issue.state_changed" },
+        resource: { "service.name": "catalyst.linear-webhook" },
+      })
+    ).toBe(false);
   });
 
   test("BROKER_INGEST_OWN_EMISSIONS=1 opts out — broker.daemon flows through", () => {
@@ -966,15 +1069,19 @@ describe("shouldSkipEvent — broker self-emission guards (CTL-346)", () => {
     process.env.BROKER_INGEST_OWN_EMISSIONS = "1";
     try {
       // filter.* still skipped (original semantics for control-plane events)
-      expect(shouldSkipEvent({
-        attributes: { "event.name": "filter.wake.orch-1" },
-        resource: { "service.name": "catalyst.broker" },
-      })).toBe(true);
+      expect(
+        shouldSkipEvent({
+          attributes: { "event.name": "filter.wake.orch-1" },
+          resource: { "service.name": "catalyst.broker" },
+        })
+      ).toBe(true);
       // broker.daemon.* now passes through for debugging visibility
-      expect(shouldSkipEvent({
-        attributes: { "event.name": "broker.daemon.startup" },
-        resource: { "service.name": "catalyst.broker" },
-      })).toBe(false);
+      expect(
+        shouldSkipEvent({
+          attributes: { "event.name": "broker.daemon.startup" },
+          resource: { "service.name": "catalyst.broker" },
+        })
+      ).toBe(false);
     } finally {
       if (prev === undefined) delete process.env.BROKER_INGEST_OWN_EMISSIONS;
       else process.env.BROKER_INGEST_OWN_EMISSIONS = prev;
@@ -1038,10 +1145,9 @@ describe("writeBrokerStateFile (CTL-343)", () => {
   test("overwrites existing file (atomic rename)", () => {
     const target = join(tmpDir, "broker.state.json");
     writeBrokerStateFile(buildBrokerState(), { path: target });
-    writeBrokerStateFile(
-      buildBrokerState({ probe: { status: "ok", modelCount: 7 } }),
-      { path: target },
-    );
+    writeBrokerStateFile(buildBrokerState({ probe: { status: "ok", modelCount: 7 } }), {
+      path: target,
+    });
     const parsed = JSON.parse(readFileSync(target, "utf8"));
     expect(parsed.keyHealth.groq.probeStatus).toBe("ok");
     expect(parsed.keyHealth.groq.modelCount).toBe(7);
@@ -1068,12 +1174,15 @@ describe("CTL-344 read-site event.id fallback", () => {
       },
     });
     const realId = "11111111-2222-4333-8444-555555555555";
-    const matches = tryDeterministicRoute({
-      id: realId,
-      event: "github.pr.merged",
-      scope: { pr: 777 },
-      detail: { mergeCommitSha: "deadbeef", merged: true },
-    }, getInterests());
+    const matches = tryDeterministicRoute(
+      {
+        id: realId,
+        event: "github.pr.merged",
+        scope: { pr: 777 },
+        detail: { mergeCommitSha: "deadbeef", merged: true },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0].sourceEventId).toBe(realId);
   });
@@ -1093,13 +1202,16 @@ describe("CTL-344 read-site event.id fallback", () => {
         session_id: "sess-id-2",
       },
     });
-    const matches = tryDeterministicRoute({
-      ts: "2026-05-12T00:00:00Z",
-      event: "github.pr.merged",
-      scope: { pr: 778 },
-      attributes: { "event.name": "github.pr.merged" },
-      detail: { mergeCommitSha: "deadbeef", merged: true },
-    }, getInterests());
+    const matches = tryDeterministicRoute(
+      {
+        ts: "2026-05-12T00:00:00Z",
+        event: "github.pr.merged",
+        scope: { pr: 778 },
+        attributes: { "event.name": "github.pr.merged" },
+        detail: { mergeCommitSha: "deadbeef", merged: true },
+      },
+      getInterests()
+    );
     expect(matches).toHaveLength(1);
     // synth fallback is a 32-char lowercase hex, not null and not the trivial empty string
     expect(matches[0].sourceEventId).toBeString();
@@ -1120,15 +1232,18 @@ describe("CTL-344 read-site event.id fallback", () => {
         session_id: "sess-id-3",
       },
     });
-    const matches = tryTicketLifecycleRoute({
-      ts: "2026-05-12T00:00:00Z",
-      event: "linear.issue.state_changed",
-      attributes: {
-        "event.name": "linear.issue.state_changed",
-        "linear.issue.identifier": "CTL-999",
+    const matches = tryTicketLifecycleRoute(
+      {
+        ts: "2026-05-12T00:00:00Z",
+        event: "linear.issue.state_changed",
+        attributes: {
+          "event.name": "linear.issue.state_changed",
+          "linear.issue.identifier": "CTL-999",
+        },
+        detail: { ticket: "CTL-999", toState: "Done" },
       },
-      detail: { ticket: "CTL-999", toState: "Done" },
-    }, getInterests());
+      getInterests()
+    );
     expect(matches.length).toBeGreaterThan(0);
     const m = matches[0];
     expect(m.sourceEventId).toBeString();
@@ -1170,34 +1285,40 @@ describe("CTL-340 classifyMatches", () => {
     writeFileSync(
       tmpFile,
       JSON.stringify([
-        ["prose-99", {
-          notify_event: "filter.wake.prose-99",
-          prompt: "x",
-          session_id: "sess-prose-99",
-          persistent: true,
-          context: {},
-          orchestrator: null,
-          interest_type: null,
-          pr_numbers: null,
-          repo: null,
-          base_branches: null,
-          tickets: null,
-          wake_on: null,
-        }],
-        ["real-orch", {
-          notify_event: "filter.wake.real-orch",
-          prompt: "y",
-          session_id: null,
-          persistent: true,
-          context: {},
-          orchestrator: "real-orch",
-          interest_type: null,
-          pr_numbers: null,
-          repo: null,
-          base_branches: null,
-          tickets: null,
-          wake_on: null,
-        }],
+        [
+          "prose-99",
+          {
+            notify_event: "filter.wake.prose-99",
+            prompt: "x",
+            session_id: "sess-prose-99",
+            persistent: true,
+            context: {},
+            orchestrator: null,
+            interest_type: null,
+            pr_numbers: null,
+            repo: null,
+            base_branches: null,
+            tickets: null,
+            wake_on: null,
+          },
+        ],
+        [
+          "real-orch",
+          {
+            notify_event: "filter.wake.real-orch",
+            prompt: "y",
+            session_id: null,
+            persistent: true,
+            context: {},
+            orchestrator: "real-orch",
+            interest_type: null,
+            pr_numbers: null,
+            repo: null,
+            base_branches: null,
+            tickets: null,
+            wake_on: null,
+          },
+        ],
       ])
     );
     clearInterests();
@@ -1245,12 +1366,8 @@ describe("CTL-340 classifyMatches", () => {
 
   test("suppresses wake when match.event_indices is empty (regression guard for original suppression intent)", () => {
     registerProseInterest("prose-2");
-    const events = [
-      { id: "evt-1", ts: "2026-05-12T20:14:00Z", event: "foo" },
-    ];
-    const matches = [
-      { interest_id: "prose-2", reason: "groq invented match", event_indices: [] },
-    ];
+    const events = [{ id: "evt-1", ts: "2026-05-12T20:14:00Z", event: "foo" }];
+    const matches = [{ interest_id: "prose-2", reason: "groq invented match", event_indices: [] }];
     const { wakes } = classifyMatches(events, matches, getInterests());
     expect(wakes).toHaveLength(0);
   });
@@ -1261,9 +1378,7 @@ describe("CTL-340 classifyMatches", () => {
       { id: "real-id-1", ts: "2026-05-12T20:14:00Z", event: "foo" },
       { id: "real-id-2", ts: "2026-05-12T20:14:01Z", event: "bar" },
     ];
-    const matches = [
-      { interest_id: "prose-3", reason: "both", event_indices: [1, 2] },
-    ];
+    const matches = [{ interest_id: "prose-3", reason: "both", event_indices: [1, 2] }];
     const { wakes } = classifyMatches(events, matches, getInterests());
     expect(wakes).toHaveLength(1);
     expect(wakes[0].detail.source_event_ids).toEqual(["real-id-1", "real-id-2"]);
@@ -1287,9 +1402,7 @@ describe("CTL-340 classifyMatches", () => {
 
   test("skips matches with unknown interest_id", () => {
     const events = [{ id: "x", ts: "2026-05-12T20:14:00Z", event: "foo" }];
-    const matches = [
-      { interest_id: "does-not-exist", reason: "...", event_indices: [1] },
-    ];
+    const matches = [{ interest_id: "does-not-exist", reason: "...", event_indices: [1] }];
     const { wakes } = classifyMatches(events, matches, getInterests());
     expect(wakes).toHaveLength(0);
   });
@@ -1297,9 +1410,7 @@ describe("CTL-340 classifyMatches", () => {
   test("non-persistent (one-shot) interest is reported in oneShotsToDelete", () => {
     registerProseInterest("prose-5", { persistent: false });
     const events = [{ id: "x", ts: "2026-05-12T20:14:00Z", event: "foo" }];
-    const matches = [
-      { interest_id: "prose-5", reason: "match", event_indices: [1] },
-    ];
+    const matches = [{ interest_id: "prose-5", reason: "match", event_indices: [1] }];
     const { wakes, oneShotsToDelete } = classifyMatches(events, matches, getInterests());
     expect(wakes).toHaveLength(1);
     expect(oneShotsToDelete).toEqual(["prose-5"]);
@@ -1316,9 +1427,7 @@ describe("CTL-340 classifyMatches", () => {
   test("orchestrator falls back to interest_id when reg.orchestrator is null", () => {
     registerProseInterest("prose-7", { orchestrator: null });
     const events = [{ id: "x", ts: "2026-05-12T20:14:00Z", event: "foo" }];
-    const matches = [
-      { interest_id: "prose-7", reason: "match", event_indices: [1] },
-    ];
+    const matches = [{ interest_id: "prose-7", reason: "match", event_indices: [1] }];
     const { wakes } = classifyMatches(events, matches, getInterests());
     expect(wakes[0].orchestrator).toBe("prose-7");
   });
@@ -1461,9 +1570,7 @@ describe("CTL-350 source_events inlining", () => {
         body: { payload: { state: "Done" } },
       },
     ];
-    const matches = [
-      { interest_id: "prose-se", reason: "ticket done", event_indices: [1] },
-    ];
+    const matches = [{ interest_id: "prose-se", reason: "ticket done", event_indices: [1] }];
     const { wakes } = classifyMatches(events, matches, getInterests());
     expect(wakes[0].detail.source_events).toHaveLength(1);
     expect(wakes[0].detail.source_events[0].id).toBe("uuid-a");
@@ -1474,11 +1581,14 @@ describe("CTL-350 source_events inlining", () => {
   test("classifyMatches handles indices past batch end without source_events leaks", () => {
     registerProseInterest("prose-se2");
     const events = [
-      { id: "uuid-a", ts: "2026-05-12T21:08:40Z", attributes: { "event.name": "foo" }, body: { payload: {} } },
+      {
+        id: "uuid-a",
+        ts: "2026-05-12T21:08:40Z",
+        attributes: { "event.name": "foo" },
+        body: { payload: {} },
+      },
     ];
-    const matches = [
-      { interest_id: "prose-se2", reason: "match", event_indices: [1, 99] },
-    ];
+    const matches = [{ interest_id: "prose-se2", reason: "match", event_indices: [1, 99] }];
     const { wakes } = classifyMatches(events, matches, getInterests());
     expect(wakes[0].detail.source_events).toHaveLength(1);
     expect(wakes[0].detail.source_events[0].id).toBe("uuid-a");
@@ -1654,11 +1764,9 @@ describe("CTL-352 broker state + degraded event", () => {
   });
 
   test("broker.daemon.degraded emitted once when interests empty and uptime > 5 min", async () => {
-    const {
-      runWatchdogTick,
-      __setBrokerStartedAtForTest,
-      getInterests,
-    } = await import("./index.mjs");
+    const { runWatchdogTick, __setBrokerStartedAtForTest, getInterests } = await import(
+      "./index.mjs"
+    );
     clearInterests();
     const sixMinAgo = new Date(Date.now() - 6 * 60 * 1000).toISOString();
     __setBrokerStartedAtForTest(sixMinAgo);
@@ -1676,7 +1784,9 @@ describe("CTL-352 broker state + degraded event", () => {
       try {
         const evt = JSON.parse(l);
         return evt.attributes?.["event.name"] === "broker.daemon.degraded";
-      } catch { return false; }
+      } catch {
+        return false;
+      }
     });
     expect(degradedLines).toHaveLength(1);
     const evt = JSON.parse(degradedLines[0]);
@@ -1699,19 +1809,18 @@ describe("CTL-352 broker state + degraded event", () => {
     if (!existsSync(logPath)) return; // no events at all — vacuously fine
     const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
     const degradedLines = lines.filter((l) => {
-      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded"; }
-      catch { return false; }
+      try {
+        return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded";
+      } catch {
+        return false;
+      }
     });
     expect(degradedLines).toHaveLength(0);
   });
 
   test("degraded re-arms after interests come back and go empty again", async () => {
-    const {
-      runWatchdogTick,
-      __setBrokerStartedAtForTest,
-      handleRegister,
-      handleDeregister,
-    } = await import("./index.mjs");
+    const { runWatchdogTick, __setBrokerStartedAtForTest, handleRegister, handleDeregister } =
+      await import("./index.mjs");
     clearInterests();
     const sixMinAgo = new Date(Date.now() - 6 * 60 * 1000).toISOString();
     __setBrokerStartedAtForTest(sixMinAgo);
@@ -1735,8 +1844,11 @@ describe("CTL-352 broker state + degraded event", () => {
     const logPath = join(tmpDir, "events", `${ym}.jsonl`);
     const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
     const degradedLines = lines.filter((l) => {
-      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded"; }
-      catch { return false; }
+      try {
+        return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded";
+      } catch {
+        return false;
+      }
     });
     expect(degradedLines).toHaveLength(2);
   });
@@ -1848,8 +1960,13 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (orchestrator subscr
 
   test("fires when an owned worker posts attention on the watched channel", () => {
     const matches = tryDeterministicRoute(
-      buildCommsEvent({ sender: "CTL-100", channel: "orch-orch-comms-orch", type: "attention", body: "CI blocked" }),
-      getInterests(),
+      buildCommsEvent({
+        sender: "CTL-100",
+        channel: "orch-orch-comms-orch",
+        type: "attention",
+        body: "CI blocked",
+      }),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].interestId).toBe("orch-comms-orch-comms");
@@ -1860,7 +1977,7 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (orchestrator subscr
   test("fires when an owned worker posts done on the watched channel", () => {
     const matches = tryDeterministicRoute(
       buildCommsEvent({ sender: "CTL-101", channel: "orch-orch-comms-orch", type: "done" }),
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("CTL-101");
@@ -1870,7 +1987,7 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (orchestrator subscr
   test("does NOT fire when an owned worker posts info (not in types_of_interest)", () => {
     const matches = tryDeterministicRoute(
       buildCommsEvent({ sender: "CTL-100", channel: "orch-orch-comms-orch", type: "info" }),
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(0);
   });
@@ -1878,7 +1995,7 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (orchestrator subscr
   test("does NOT fire when a non-owned worker posts on the watched channel", () => {
     const matches = tryDeterministicRoute(
       buildCommsEvent({ sender: "CTL-999", channel: "orch-orch-comms-orch", type: "attention" }),
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(0);
   });
@@ -1886,7 +2003,7 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (orchestrator subscr
   test("does NOT fire on a different channel", () => {
     const matches = tryDeterministicRoute(
       buildCommsEvent({ sender: "CTL-100", channel: "orch-other-orch", type: "attention" }),
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(0);
   });
@@ -1910,20 +2027,20 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (orchestrator subscr
     expect(
       tryDeterministicRoute(
         buildCommsEvent({ sender: "CTL-555", channel: "orch-orch-default", type: "attention" }),
-        getInterests(),
-      ),
+        getInterests()
+      )
     ).toHaveLength(1);
     expect(
       tryDeterministicRoute(
         buildCommsEvent({ sender: "CTL-555", channel: "orch-orch-default", type: "done" }),
-        getInterests(),
-      ),
+        getInterests()
+      )
     ).toHaveLength(1);
     expect(
       tryDeterministicRoute(
         buildCommsEvent({ sender: "CTL-555", channel: "orch-orch-default", type: "info" }),
-        getInterests(),
-      ),
+        getInterests()
+      )
     ).toHaveLength(0);
   });
 
@@ -1932,9 +2049,11 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (orchestrator subscr
     const matches = tryDeterministicRoute(
       {
         attributes: { "event.name": "github.pr.merged", "catalyst.worker.ticket": "CTL-100" },
-        body: { payload: { channel: "orch-orch-comms-orch", type: "attention", to: "all", body: "" } },
+        body: {
+          payload: { channel: "orch-orch-comms-orch", type: "attention", to: "all", body: "" },
+        },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(0);
   });
@@ -1968,8 +2087,13 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (worker subscriber)"
 
   test("fires when payload.to equals subscriber_ticket", () => {
     const matches = tryDeterministicRoute(
-      buildCommsEvent({ sender: "orchestrator", channel: "orch-orch-comms-worker", to: "CTL-357", body: "rebase now" }),
-      getInterests(),
+      buildCommsEvent({
+        sender: "orchestrator",
+        channel: "orch-orch-comms-worker",
+        to: "CTL-357",
+        body: "rebase now",
+      }),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].interestId).toBe("worker-CTL-357");
@@ -1978,7 +2102,7 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (worker subscriber)"
   test("fires when payload.to is 'all'", () => {
     const matches = tryDeterministicRoute(
       buildCommsEvent({ sender: "orchestrator", channel: "orch-orch-comms-worker", to: "all" }),
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
   });
@@ -1986,7 +2110,7 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (worker subscriber)"
   test("does NOT fire when payload.to is a different worker", () => {
     const matches = tryDeterministicRoute(
       buildCommsEvent({ sender: "orchestrator", channel: "orch-orch-comms-worker", to: "CTL-999" }),
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(0);
   });
@@ -1994,7 +2118,7 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (worker subscriber)"
   test("does NOT fire when sender is the worker itself (self-loop guard)", () => {
     const matches = tryDeterministicRoute(
       buildCommsEvent({ sender: "CTL-357", channel: "orch-orch-comms-worker", to: "all" }),
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(0);
   });
@@ -2002,8 +2126,13 @@ describe("CTL-357 tryDeterministicRoute — comms_lifecycle (worker subscriber)"
   test("worker default fires on all types when types_of_interest omitted", () => {
     for (const type of ["info", "attention", "done"]) {
       const matches = tryDeterministicRoute(
-        buildCommsEvent({ sender: "orchestrator", channel: "orch-orch-comms-worker", type, to: "all" }),
-        getInterests(),
+        buildCommsEvent({
+          sender: "orchestrator",
+          channel: "orch-orch-comms-worker",
+          type,
+          to: "all",
+        }),
+        getInterests()
       );
       expect(matches).toHaveLength(1);
     }
@@ -2076,6 +2205,109 @@ describe("CTL-357 prose env gate (CATALYST_BROKER_PROSE_ENABLED)", () => {
   });
 });
 
+// ─── CTL-397 comms.message.posted pre-queue filter ───────────────────────────
+
+describe("CTL-397 comms.message.posted never queued for Groq when deterministic match fails", () => {
+  beforeEach(() => {
+    __clearPendingBatchForTest();
+    // Register a comms_lifecycle interest (types_of_interest filters out info)
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-397",
+      detail: {
+        interest_id: "orch-397-comms-lifecycle",
+        notify_event: "filter.wake.orch-397",
+        interest_type: "comms_lifecycle",
+        channel: "orch-397",
+        subscriber_kind: "orchestrator",
+        owned_workers: ["CTL-500"],
+        types_of_interest: ["attention", "done"],
+        persistent: true,
+      },
+    });
+    // Register a prose interest to simulate old persisted interests that would
+    // otherwise match comms events via Groq.
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-397",
+      detail: {
+        interest_id: "orch-397-prose",
+        notify_event: "filter.wake.orch-397",
+        prompt: "wake on everything including comms",
+        persistent: true,
+      },
+    });
+  });
+
+  afterEach(() => {
+    __clearPendingBatchForTest();
+  });
+
+  test("info comms event is NOT added to pending Groq batch even when prose interests exist", () => {
+    processEvent({
+      attributes: {
+        "event.name": "comms.message.posted",
+        "catalyst.worker.ticket": "CTL-500",
+      },
+      body: {
+        payload: {
+          channel: "orch-397",
+          type: "info",
+          msgId: "msg-1",
+          to: "all",
+          body: "researching",
+        },
+      },
+    });
+    expect(__getPendingBatchForTest()).toHaveLength(0);
+  });
+
+  test("done comms event from owned worker fires a deterministic wake, not queued for Groq", () => {
+    processEvent({
+      attributes: {
+        "event.name": "comms.message.posted",
+        "catalyst.worker.ticket": "CTL-500",
+      },
+      body: {
+        payload: { channel: "orch-397", type: "done", msgId: "msg-2", to: "all", body: "" },
+      },
+    });
+    // Deterministic match fired — not added to Groq queue.
+    expect(__getPendingBatchForTest()).toHaveLength(0);
+  });
+
+  test("attention comms event from owned worker fires a deterministic wake, not queued for Groq", () => {
+    processEvent({
+      attributes: {
+        "event.name": "comms.message.posted",
+        "catalyst.worker.ticket": "CTL-500",
+      },
+      body: {
+        payload: {
+          channel: "orch-397",
+          type: "attention",
+          msgId: "msg-3",
+          to: "all",
+          body: "CI blocked",
+        },
+      },
+    });
+    expect(__getPendingBatchForTest()).toHaveLength(0);
+  });
+
+  test("non-comms event with no deterministic match IS added to pending Groq batch", () => {
+    // A linear event for an untracked ticket — no deterministic match, should queue for Groq.
+    processEvent({
+      attributes: {
+        "event.name": "linear.issue.state_changed",
+        "linear.issue.identifier": "UNRELATED-1",
+      },
+      body: { payload: { state: "Done" } },
+    });
+    expect(__getPendingBatchForTest()).toHaveLength(1);
+  });
+});
+
 describe("CTL-357 broker.daemon.prose_disabled startup event", () => {
   beforeEach(async () => {
     const { __resetProseDisabledForTest } = await import("./index.mjs");
@@ -2104,8 +2336,11 @@ describe("CTL-357 broker.daemon.prose_disabled startup event", () => {
     expect(existsSync(logPath)).toBe(true);
     const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
     const proseDisabledLines = lines.filter((l) => {
-      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled"; }
-      catch { return false; }
+      try {
+        return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled";
+      } catch {
+        return false;
+      }
     });
     expect(proseDisabledLines).toHaveLength(1);
     const evt = JSON.parse(proseDisabledLines[0]);
@@ -2138,8 +2373,11 @@ describe("CTL-357 broker.daemon.prose_disabled startup event", () => {
     if (!existsSync(logPath)) return;
     const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
     const proseDisabledLines = lines.filter((l) => {
-      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled"; }
-      catch { return false; }
+      try {
+        return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled";
+      } catch {
+        return false;
+      }
     });
     expect(proseDisabledLines).toHaveLength(0);
   });
@@ -2168,8 +2406,11 @@ describe("CTL-357 broker.daemon.prose_disabled startup event", () => {
     }
     const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
     const proseDisabledLines = lines.filter((l) => {
-      try { return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled"; }
-      catch { return false; }
+      try {
+        return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.prose_disabled";
+      } catch {
+        return false;
+      }
     });
     expect(proseDisabledLines).toHaveLength(0);
     delete process.env.CATALYST_BROKER_PROSE_ENABLED;
@@ -2188,7 +2429,13 @@ describe("CTL-357 tryTicketLifecycleRoute canonical envelopes", () => {
         notify_event: "filter.wake.watch-ctl-canon",
         interest_type: "ticket_lifecycle",
         tickets: ["CTL-275"],
-        wake_on: ["status_done", "status_in_review", "status_changed", "pr_merged", "comment_added"],
+        wake_on: [
+          "status_done",
+          "status_in_review",
+          "status_changed",
+          "pr_merged",
+          "comment_added",
+        ],
         persistent: true,
       },
     });
@@ -2203,7 +2450,7 @@ describe("CTL-357 tryTicketLifecycleRoute canonical envelopes", () => {
         },
         body: { payload: { state: "Done" } },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("marked Done");
@@ -2218,7 +2465,7 @@ describe("CTL-357 tryTicketLifecycleRoute canonical envelopes", () => {
         },
         body: { payload: { author: "ryan" } },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("CTL-275");
@@ -2239,7 +2486,7 @@ describe("CTL-357 tryTicketLifecycleRoute canonical envelopes", () => {
           },
         },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].ticket).toBe("CTL-275");
@@ -2254,7 +2501,7 @@ describe("CTL-357 tryTicketLifecycleRoute canonical envelopes", () => {
         attributes: { "linear.issue.identifier": "CTL-275" },
         detail: { state: "Done" },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("marked Done");
@@ -2288,7 +2535,7 @@ describe("CTL-359 tryDeterministicRoute canonical envelopes", () => {
         body: { payload: { mergeCommitSha: "deadbeef", merged: true } },
         scope: { pr: 777 },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].interestId).toBe("sess-canon-pr");
@@ -2302,7 +2549,7 @@ describe("CTL-359 tryDeterministicRoute canonical envelopes", () => {
         attributes: { "event.name": "github.check_suite.completed" },
         body: { payload: { prNumbers: [777], conclusion: "success" } },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].interestId).toBe("sess-canon-pr");
@@ -2322,7 +2569,7 @@ describe("CTL-359 tryDeterministicRoute canonical envelopes", () => {
         },
         scope: { pr: 777 },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("Automated review comment");
@@ -2338,7 +2585,7 @@ describe("CTL-359 tryDeterministicRoute canonical envelopes", () => {
         scope: { pr: 777 },
         detail: { mergeCommitSha: "feedface", merged: true },
       },
-      getInterests(),
+      getInterests()
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].interestId).toBe("sess-canon-pr");
@@ -2404,13 +2651,7 @@ describe("CTL-370: allowlist parity with broker routing tables", () => {
     return sections;
   }
 
-  const ALLOWLIST_PATH = join(
-    import.meta.dir,
-    "..",
-    "..",
-    "references",
-    "event-name-allowlist.md",
-  );
+  const ALLOWLIST_PATH = join(import.meta.dir, "..", "..", "references", "event-name-allowlist.md");
 
   test("event-name-allowlist.md exists at plugins/dev/references/", () => {
     expect(existsSync(ALLOWLIST_PATH)).toBe(true);


### PR DESCRIPTION
## Summary

- **Bug**: Orchestrator registered `comms_lifecycle` with `types_of_interest: ["attention","done"]` but still woke on `type=info` phase-narration heartbeats
- **Root cause**: `processEvent` called `queueEvent` unconditionally after deterministic routing returned 0 matches. If old prose interests exist (pre-CTL-357) and `CATALYST_BROKER_PROSE_ENABLED=1`, Groq would match comms events to those interests and emit spurious `filter.wake.*` events
- **Fix**: Added a guard before `queueEvent` in `processEvent` to drop `comms.message.posted` events with no deterministic match — these are handled exclusively via `comms_lifecycle` interests and should never reach the Groq queue

## Changes

- `broker/index.mjs`: Guard added after `tryDeterministicRoute` returns 0 matches — `comms.message.posted` events are now dropped rather than queued for Groq
- `broker/index.mjs`: Added `__getPendingBatchForTest` and `__clearPendingBatchForTest` test-only exports for direct batch inspection
- `broker/index.test.mjs`: 4 new tests in `CTL-397` describe block covering: info event not queued, done/attention events fire deterministic wake (not queued), non-comms event still reaches Groq queue

## Test plan

- [x] 171 existing broker tests pass
- [x] New CTL-397 tests pass: info comms events not queued, done/attention fire deterministic wake, non-comms events still reach Groq
- [x] Trunk lint clean (`trunk check --ci --upstream origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)