### PR TITLE
feat(dev): surface prose interest disabled status in HUD (CTL-421)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -1743,6 +1743,8 @@ export function buildBrokerState({ probe } = {}) {
     lastRegisterAt,
     // CTL-403: active wait-loop sessions (empty array when no active waits).
     waitingSessions: activeWaiting,
+    // CTL-421: expose prose enabled state so the HUD can badge inactive prose interests.
+    proseEnabled: process.env.CATALYST_BROKER_PROSE_ENABLED === "1",
     keyHealth: {
       groq: {
         present: GROQ_KEY_SOURCE !== null,

--- a/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
@@ -38,6 +38,9 @@ export function InterestList({
 }: InterestListProps) {
   const promptW = Math.max(8, cols - COL_ORCH - COL_TYPE - COL_WATCHES - 4);
   const visible = interests.slice(scrollOffset, scrollOffset + visibleRows);
+  const hasProse = interests.some((i) => i.interest_type === null);
+  // proseEnabled is only false (not undefined) when the broker has explicitly written the field.
+  const proseOff = hasProse && brokerState?.proseEnabled === false;
 
   return (
     <Box flexDirection="column" flexGrow={1}>
@@ -45,7 +48,10 @@ export function InterestList({
         <Box width={COL_ORCH} flexShrink={0} marginRight={1}><Text bold color="cyan">ORCHESTRATOR</Text></Box>
         <Box width={COL_TYPE} flexShrink={0} marginRight={1}><Text bold color="cyan">TYPE</Text></Box>
         <Box width={COL_WATCHES} flexShrink={0} marginRight={1}><Text bold color="cyan">WATCHES</Text></Box>
-        <Box flexGrow={1}><Text bold color="cyan">PROMPT</Text></Box>
+        <Box flexGrow={1}>
+          <Text bold color="cyan">PROMPT</Text>
+          {proseOff && <Text color="yellow">  [prose: OFF]</Text>}
+        </Box>
       </Box>
       <Text dimColor>{"─".repeat(Math.max(0, cols - 1))}</Text>
       {visible.length === 0 && (
@@ -54,6 +60,7 @@ export function InterestList({
       {visible.map((i, idx) => {
         const realIdx = scrollOffset + idx;
         const selected = realIdx === selectedIndex;
+        const isInactiveProse = i.interest_type === null && proseOff;
         const orch = truncateRight(i.orchestrator ?? "—", COL_ORCH);
         const type = truncateRight(interestTypeLabel(i.interest_type), COL_TYPE);
         const watches = truncateRight(interestWatches(i), COL_WATCHES);
@@ -61,13 +68,13 @@ export function InterestList({
         return (
           <Box key={`${i.key}-${realIdx}`} flexDirection="row">
             <Box width={COL_ORCH} flexShrink={0} marginRight={1}>
-              <Text color={selected ? "black" : "white"} inverse={selected}>{orch}</Text>
+              <Text dimColor={isInactiveProse && !selected} color={selected ? "black" : "white"} inverse={selected}>{orch}</Text>
             </Box>
             <Box width={COL_TYPE} flexShrink={0} marginRight={1}>
-              <Text color={i.interest_type ? "green" : "yellow"} inverse={selected}>{type}</Text>
+              <Text dimColor={isInactiveProse && !selected} color={i.interest_type ? "green" : "yellow"} inverse={selected}>{type}</Text>
             </Box>
             <Box width={COL_WATCHES} flexShrink={0} marginRight={1}>
-              <Text color={selected ? "black" : "white"} inverse={selected}>{watches}</Text>
+              <Text dimColor={isInactiveProse && !selected} color={selected ? "black" : "white"} inverse={selected}>{watches}</Text>
             </Box>
             <Box flexGrow={1}>
               <Text dimColor={!selected} inverse={selected}>{prompt}</Text>

--- a/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/broker-key-health.ts
@@ -38,6 +38,8 @@ export interface BrokerState extends BrokerKeyHealth {
   startedAt?: string;
   // CTL-403: sessions currently blocking in a wait-for loop.
   waitingSessions?: WaitingSession[];
+  /** CTL-421: whether CATALYST_BROKER_PROSE_ENABLED=1 was set when the broker started. */
+  proseEnabled?: boolean;
 }
 
 export type BrokerInterestStatus = "ok" | "startup" | "degraded" | "unknown";
@@ -120,6 +122,7 @@ export function readBrokerState(path?: string): BrokerState | null {
         }))
         .filter((s) => s.sessionId && s.timeoutAt);
     }
+    if (typeof obj.proseEnabled === "boolean") result.proseEnabled = obj.proseEnabled;
     return result;
   } catch {
     return null;

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -426,6 +426,7 @@ the env var is set.
 | `BROKER_PID_FILE` | `catalyst-broker` | Override broker PID path. Default `$CATALYST_DIR/broker.pid`. |
 | `BROKER_LOG_FILE` | `catalyst-broker` | Override broker log path. Default `$CATALYST_DIR/broker.log`. |
 | `GROQ_API_KEY` | `catalyst-broker` | Groq API key (overrides `groq.apiKey` in config). |
+| `CATALYST_BROKER_PROSE_ENABLED` | `catalyst-broker` | Set to `1` to enable Groq-backed prose classification for open-ended interests (`interest_type: null`). Disabled by default — requires `GROQ_API_KEY` and incurs Groq API costs proportional to interest volume. When unset, prose interests persist in `broker-interests.json` but are never evaluated; the HUD marks them `[prose: OFF]`. |
 | `FILTER_GROQ_MODEL` | `catalyst-broker` | Groq model for semantic-prose classification. Default `llama-3.1-8b-instant`. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `catalyst-otel-forward` | OTLP endpoint URL. Port `4317` is auto-rewritten to `4318` for HTTP transport. |
 | `OTEL_ENABLED`, `PROMETHEUS_URL`, `LOKI_URL` | `orch-monitor` | See [Monitor OTel Config](#monitor-otel-config). |


### PR DESCRIPTION
## Summary

- Broker now writes `proseEnabled` to `broker.state.json` so the HUD can detect when prose classification is disabled without reading env vars directly
- `InterestList` shows a `[prose: OFF]` badge next to the PROMPT column header when any prose interests exist but classification is disabled
- Inactive prose interest rows are dimmed across all columns (not just yellow-colored in the TYPE cell), making their inactive state visually clear
- Docs: `CATALYST_BROKER_PROSE_ENABLED` added to configuration reference with Groq dependency and cost implications

## Test plan

- [ ] Start broker without `CATALYST_BROKER_PROSE_ENABLED=1`, verify `broker.state.json` has `proseEnabled: false`
- [ ] Register a prose interest, open HUD interests tab, verify `[prose: OFF]` badge appears next to PROMPT header
- [ ] Verify prose interest rows are dimmed (ORCHESTRATOR, TYPE, WATCHES columns)
- [ ] Start broker with `CATALYST_BROKER_PROSE_ENABLED=1`, verify badge does not appear
- [ ] Verify typecheck passes (`bun run typecheck` in `plugins/dev/scripts/orch-monitor`)

Refs: CTL-421