### PR TITLE
fix(dev): batch stale-heartbeat wakes + HUD wake recipient visibility (CTL-419)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -296,6 +296,11 @@ const DEGRADED_THRESHOLD_MS = 5 * 60 * 1000;
 export function __setBrokerStartedAtForTest(iso) { brokerStartedAt = iso; }
 export function __resetBrokerStartedAtForTest() { brokerStartedAt = null; }
 export function __resetDegradedEmittedForTest() { degradedEmittedAt = null; }
+// CTL-419: backdate a session's heartbeat timestamp so tests can simulate staleness.
+export function __setHeartbeatForTest(sessionId, tsMs) {
+  const existing = lastHeartbeat.get(sessionId);
+  lastHeartbeat.set(sessionId, { ts: tsMs, notified: existing?.notified ?? false });
+}
 export function __resetBrokerLivenessForTest() {
   brokerStartedAt = null;
   lastWakeAt = null;
@@ -1395,6 +1400,12 @@ export function runWatchdogTick() {
   }
 
   let watchdogWoke = false;
+
+  // CTL-419: collect all currently-stale not-yet-notified sessions first.
+  // Then iterate interests (outer) and batch all matching stale sessions into
+  // a single appendEvent call per interest — avoids N identical wake rows in
+  // the HUD when N sessions go stale simultaneously.
+  const staleNow = new Map(); // sourceId → { ts, minsAgo }
   for (const [sourceId, state] of lastHeartbeat) {
     const stale = now - state.ts > HEARTBEAT_STALE_MS;
     // CTL-403: skip stale-wake if this session has an active wait whose timeout
@@ -1412,52 +1423,79 @@ export function runWatchdogTick() {
     }
     if (stale && !state.notified) {
       const minsAgo = Math.round((now - state.ts) / 60_000);
-      const reason = `No heartbeat from ${sourceId} for >${minsAgo} min`;
-      let woke = false;
-      for (const [interestId, interest] of interests) {
-        const workers = interest.context?.workers;
-        const orchForSource = workerToOrchestrator.get(sourceId);
-        const orchMatch = orchForSource != null && orchForSource === interest.orchestrator;
-        if ((workers != null && workers.includes(sourceId)) || (workers == null && orchMatch)) {
-          appendEvent({
-            event: interest.notify_event,
-            orchestrator: interest.orchestrator ?? interestId,
-            worker: null,
-            // CTL-362: forward the interest's repo so the watchdog wake
-            // envelope carries vcs.repository.name when known.
-            repo: interest.repo ?? null,
-            // CTL-350: watchdog wakes have no triggering event, so source_events
-            // is always empty — receivers should fall back to the reason string.
-            detail: {
-              reason,
-              source_event_ids: [],
-              source_events: [],
-              interest_id: interestId,
-            },
-          });
-          log.info(
-            { notifyEvent: interest.notify_event, reason },
-            "watchdog wake",
-          );
-          woke = true;
-          watchdogWoke = true;
-        }
-      }
-      if (woke) {
-        // Belt-and-suspenders: clean up interests for the stale session.
-        for (const [interestId, interest] of interests) {
-          if (interest.session_id && interest.session_id === sourceId) {
-            interests.delete(interestId);
-            log.info(
-              { interestId, sourceId },
-              "watchdog cleanup: removed stale session",
-            );
-          }
-        }
-        lastHeartbeat.set(sourceId, { ts: state.ts, notified: true });
-      }
+      staleNow.set(sourceId, { ts: state.ts, minsAgo });
     } else if (!stale && state.notified) {
       lastHeartbeat.set(sourceId, { ts: state.ts, notified: false });
+    }
+  }
+
+  // Track which sessions were actually woken so we can mark + clean up after.
+  const notifiedSessions = new Set();
+
+  for (const [interestId, interest] of interests) {
+    const matched = []; // { sourceId, ts, minsAgo }
+    for (const [sourceId, info] of staleNow) {
+      const workers = interest.context?.workers;
+      const orchForSource = workerToOrchestrator.get(sourceId);
+      const orchMatch = orchForSource != null && orchForSource === interest.orchestrator;
+      if ((workers != null && workers.includes(sourceId)) || (workers == null && orchMatch)) {
+        matched.push({ sourceId, ...info });
+      }
+    }
+    if (matched.length === 0) continue;
+
+    const isSingle = matched.length === 1;
+    const singleId = matched[0].sourceId;
+    const reason = isSingle
+      ? `No heartbeat from ${singleId} for >${matched[0].minsAgo} min`
+      : `${matched.length} sessions stale`;
+
+    appendEvent({
+      event: interest.notify_event,
+      orchestrator: interest.orchestrator ?? interestId,
+      worker: null,
+      // CTL-362: forward the interest's repo so the watchdog wake
+      // envelope carries vcs.repository.name when known.
+      repo: interest.repo ?? null,
+      // CTL-350: watchdog wakes have no triggering event, so source_events
+      // is always empty — receivers should fall back to the reason/stale_sessions.
+      // CTL-419: include stale_sessions[] and stale_count for HUD batched display.
+      detail: {
+        reason,
+        stale_sessions: matched.map((m) => m.sourceId),
+        stale_count: matched.length,
+        source_event_ids: [],
+        source_events: [],
+        interest_id: interestId,
+      },
+    });
+    log.info(
+      { notifyEvent: interest.notify_event, staleSessions: matched.map((m) => m.sourceId) },
+      "watchdog wake (batched)",
+    );
+    watchdogWoke = true;
+
+    for (const { sourceId } of matched) {
+      notifiedSessions.add(sourceId);
+    }
+  }
+
+  // Mark notified sessions and clean up their own registered interests.
+  // Done after the interests loop to avoid concurrent-modification issues.
+  if (notifiedSessions.size > 0) {
+    const toDelete = [];
+    for (const [interestId, interest] of interests) {
+      if (interest.session_id && notifiedSessions.has(interest.session_id)) {
+        toDelete.push({ interestId, sourceId: interest.session_id });
+      }
+    }
+    for (const { interestId, sourceId } of toDelete) {
+      interests.delete(interestId);
+      log.info({ interestId, sourceId }, "watchdog cleanup: removed stale session");
+    }
+    for (const sourceId of notifiedSessions) {
+      const info = staleNow.get(sourceId);
+      lastHeartbeat.set(sourceId, { ts: info.ts, notified: true });
     }
   }
 

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -3008,3 +3008,119 @@ describe("CTL-370: allowlist parity with broker routing tables", () => {
     expect([...documented].sort()).toEqual([...TICKET_LIFECYCLE_ROUTED].sort());
   });
 });
+
+// ─── CTL-419 watchdog batching ───────────────────────────────────────────────
+
+describe("CTL-419 watchdog batching", () => {
+  // Helper: reads all parsed events from the monthly event log with a given event name.
+  function readWakeEvents(eventName) {
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .flatMap((l) => {
+        try {
+          const evt = JSON.parse(l);
+          return evt.attributes?.["event.name"] === eventName ? [evt] : [];
+        } catch { return []; }
+      });
+  }
+
+  test("two simultaneously stale sessions produce one wake event with stale_sessions[]", async () => {
+    const { runWatchdogTick, __setHeartbeatForTest } = await import("./index.mjs");
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-batch-1",
+      detail: {
+        interest_id: "orch-batch-1",
+        notify_event: "filter.wake.orch-batch-1",
+        persistent: true,
+      },
+    });
+    handleAgentCheckin({ event: "agent.checkin",
+      detail: { session_id: "worker-A", orchestrator: "orch-batch-1" } });
+    handleAgentCheckin({ event: "agent.checkin",
+      detail: { session_id: "worker-B", orchestrator: "orch-batch-1" } });
+
+    // Backdate both heartbeats so they appear stale (4 min ago > 3 min threshold)
+    __setHeartbeatForTest("worker-A", Date.now() - 4 * 60_000);
+    __setHeartbeatForTest("worker-B", Date.now() - 4 * 60_000);
+
+    runWatchdogTick();
+
+    const wakes = readWakeEvents("filter.wake.orch-batch-1");
+    expect(wakes).toHaveLength(1);
+    const p = wakes[0].body.payload;
+    expect(p.stale_sessions).toHaveLength(2);
+    expect(p.stale_sessions).toContain("worker-A");
+    expect(p.stale_sessions).toContain("worker-B");
+    expect(p.stale_count).toBe(2);
+    expect(p.reason).toMatch(/2 sessions stale/);
+  });
+
+  test("single stale session: payload has stale_sessions with one entry, single-session reason", async () => {
+    const { runWatchdogTick, __setHeartbeatForTest } = await import("./index.mjs");
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-single",
+      detail: {
+        interest_id: "orch-single",
+        notify_event: "filter.wake.orch-single",
+        persistent: true,
+      },
+    });
+    handleAgentCheckin({ event: "agent.checkin",
+      detail: { session_id: "only-worker", orchestrator: "orch-single" } });
+    __setHeartbeatForTest("only-worker", Date.now() - 4 * 60_000);
+
+    runWatchdogTick();
+
+    const wakes = readWakeEvents("filter.wake.orch-single");
+    expect(wakes).toHaveLength(1);
+    const p = wakes[0].body.payload;
+    expect(p.stale_sessions).toEqual(["only-worker"]);
+    expect(p.stale_count).toBe(1);
+    expect(p.reason).toMatch(/No heartbeat from only-worker/);
+  });
+
+  test("two orchestrators with one stale session each get independent wake events", async () => {
+    const { runWatchdogTick, __setHeartbeatForTest } = await import("./index.mjs");
+
+    handleRegister({ event: "filter.register", orchestrator: "orch-X",
+      detail: { interest_id: "orch-X", notify_event: "filter.wake.orch-X", persistent: true } });
+    handleRegister({ event: "filter.register", orchestrator: "orch-Y",
+      detail: { interest_id: "orch-Y", notify_event: "filter.wake.orch-Y", persistent: true } });
+    handleAgentCheckin({ event: "agent.checkin",
+      detail: { session_id: "worker-X1", orchestrator: "orch-X" } });
+    handleAgentCheckin({ event: "agent.checkin",
+      detail: { session_id: "worker-Y1", orchestrator: "orch-Y" } });
+
+    __setHeartbeatForTest("worker-X1", Date.now() - 4 * 60_000);
+    __setHeartbeatForTest("worker-Y1", Date.now() - 4 * 60_000);
+
+    runWatchdogTick();
+
+    expect(readWakeEvents("filter.wake.orch-X")).toHaveLength(1);
+    expect(readWakeEvents("filter.wake.orch-Y")).toHaveLength(1);
+  });
+
+  test("stale sessions not re-notified on second tick", async () => {
+    const { runWatchdogTick, __setHeartbeatForTest } = await import("./index.mjs");
+
+    handleRegister({ event: "filter.register", orchestrator: "orch-notified",
+      detail: { interest_id: "orch-notified", notify_event: "filter.wake.orch-notified", persistent: true } });
+    handleAgentCheckin({ event: "agent.checkin",
+      detail: { session_id: "stale-W", orchestrator: "orch-notified" } });
+    __setHeartbeatForTest("stale-W", Date.now() - 4 * 60_000);
+
+    runWatchdogTick();
+    runWatchdogTick();
+
+    expect(readWakeEvents("filter.wake.orch-notified")).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -713,7 +713,8 @@ describe("formatDetails (filter.wake)", () => {
       attributes: { "event.name": "filter.wake.orch-foo" },
       body: { payload: { reason: "some reason", source_event_ids: [] } },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake → some reason");
+    // CTL-419: recipient short ("orch-foo") appended after reason
+    expect(formatDetails(e)).toBe("wake → some reason → orch-foo");
   });
 
   // CTL-350 / CTL-361: 40-char truncation was removed from the formatter — it
@@ -728,7 +729,7 @@ describe("formatDetails (filter.wake)", () => {
       attributes: { "event.name": "filter.wake.orch-foo" },
       body: { payload: { reason: long, source_event_ids: [] } },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake → " + long);
+    expect(formatDetails(e)).toBe("wake → " + long + " → orch-foo");
   });
 
   test("appends (n) when source_event_ids has more than one entry", () => {
@@ -737,7 +738,7 @@ describe("formatDetails (filter.wake)", () => {
       attributes: { "event.name": "filter.wake.orch-foo" },
       body: { payload: { reason: "ci_completed", source_event_ids: ["a", "b", "c"] } },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake → ci_completed (3)");
+    expect(formatDetails(e)).toBe("wake → ci_completed (3) → orch-foo");
   });
 
   test("omits the arrow when reason is empty", () => {
@@ -746,7 +747,7 @@ describe("formatDetails (filter.wake)", () => {
       attributes: { "event.name": "filter.wake.orch-foo" },
       body: { payload: { reason: "", source_event_ids: ["a", "b"] } },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake (2)");
+    expect(formatDetails(e)).toBe("wake (2) → orch-foo");
   });
 
   test("handles the legacy orchestrator.filter.wake.* alias", () => {
@@ -755,7 +756,7 @@ describe("formatDetails (filter.wake)", () => {
       attributes: { "event.name": "orchestrator.filter.wake.orch-foo" },
       body: { payload: { reason: "ticket changed", source_event_ids: [] } },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake → ticket changed");
+    expect(formatDetails(e)).toBe("wake → ticket changed → orch-foo");
   });
 
   // CTL-350: when source_events is populated, render structured triggering
@@ -779,7 +780,8 @@ describe("formatDetails (filter.wake)", () => {
         },
       },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake ← linear.issue.state_changed ADV-87 → Done");
+    // CTL-419: recipient short appended after structured wake line
+    expect(formatDetails(e)).toBe("wake ← linear.issue.state_changed ADV-87 → Done → orch-foo");
   });
 
   test("falls back to reason when source_events is absent", () => {
@@ -788,7 +790,7 @@ describe("formatDetails (filter.wake)", () => {
       attributes: { "event.name": "filter.wake.orch-foo" },
       body: { payload: { reason: "legacy wake reason", source_event_ids: [] } },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake → legacy wake reason");
+    expect(formatDetails(e)).toBe("wake → legacy wake reason → orch-foo");
   });
 
   test("renders PR ref when source_event carries pr", () => {
@@ -822,7 +824,7 @@ describe("formatDetails (filter.wake)", () => {
         },
       },
     } as unknown as CanonicalEvent;
-    expect(formatDetails(e)).toBe("wake ← github.check_suite.completed #501 → failure");
+    expect(formatDetails(e)).toBe("wake ← github.check_suite.completed #501 → failure → orch-foo");
   });
 
   test("appends (N) when source_events has more than one entry", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
@@ -1,0 +1,97 @@
+// CTL-419: unit tests for formatDetails wake-event rendering.
+// Tests cover the batched stale_sessions payload and the recipient-short suffix
+// appended to all filter.wake.* DETAILS cells.
+import { describe, test, expect } from "bun:test";
+import { formatDetails, formatRef } from "./format";
+import type { CanonicalEvent } from "../../lib/canonical-event.ts";
+
+function makeWakeEvent(
+  recipientSessId: string,
+  payload: Record<string, unknown>,
+): CanonicalEvent {
+  return {
+    id: "test-id",
+    ts: "2026-05-14T00:00:00.000Z",
+    observedTs: "2026-05-14T00:00:00.000Z",
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: null,
+    spanId: null,
+    resource: { "service.name": "test" },
+    attributes: { "event.name": `filter.wake.${recipientSessId}` },
+    body: { payload },
+  } as unknown as CanonicalEvent;
+}
+
+describe("formatDetails — filter.wake events (CTL-419)", () => {
+  test("single stale session: shows reason with recipient short suffix", () => {
+    const event = makeWakeEvent("sess_20260511T203845_16d33281", {
+      reason: "No heartbeat from worker-A for >4 min",
+      stale_sessions: ["worker-A"],
+      stale_count: 1,
+      source_event_ids: [],
+      source_events: [],
+    });
+    const details = formatDetails(event);
+    expect(details).toContain("wake →");
+    expect(details).toContain("16d33281");
+  });
+
+  test("multi stale: shows stale count + recipient short", () => {
+    const event = makeWakeEvent("sess_20260511T203845_16d33281", {
+      reason: "3 sessions stale",
+      stale_sessions: ["worker-A", "worker-B", "worker-C"],
+      stale_count: 3,
+      source_event_ids: [],
+      source_events: [],
+    });
+    const details = formatDetails(event);
+    expect(details).toMatch(/3 sessions stale/);
+    expect(details).toContain("16d33281");
+  });
+
+  test("legacy reason without stale_sessions: still appends recipient", () => {
+    const event = makeWakeEvent("sess_abc_deadbeef", {
+      reason: "No heartbeat from old-worker for >5 min",
+      source_event_ids: [],
+      source_events: [],
+    });
+    const details = formatDetails(event);
+    expect(details).toContain("deadbeef");
+  });
+
+  test("structured source_events path: appends recipient short", () => {
+    const event = makeWakeEvent("sess_abc_feedface", {
+      source_events: [
+        {
+          name: "linear.issue.state_changed",
+          ticket: "CTL-99",
+          payload_excerpt: { state: "Done" },
+        },
+      ],
+      source_event_ids: ["evt-1"],
+    });
+    const details = formatDetails(event);
+    expect(details).toMatch(/wake ← linear\.issue\.state_changed CTL-99 → Done/);
+    expect(details).toContain("feedface");
+  });
+
+  test("session ID with no underscore: uses full id as short form", () => {
+    const event = makeWakeEvent("orchestrator-1", {
+      reason: "No heartbeat from w for >3 min",
+      stale_sessions: ["w"],
+      stale_count: 1,
+      source_event_ids: [],
+      source_events: [],
+    });
+    const details = formatDetails(event);
+    expect(details).toContain("orchestrator-1");
+  });
+});
+
+describe("formatRef — filter.wake (CTL-419 — unchanged)", () => {
+  test("still returns stripped session id", () => {
+    const event = makeWakeEvent("sess_20260511T203845_16d33281", {});
+    expect(formatRef(event)).toBe("sess_20260511T203845_16d33281");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -1,6 +1,16 @@
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
 import { inProgressGlyph, sourceIcon, prPrefix } from "./nerd-font.ts";
 
+// CTL-419: extract the short form of a wake recipient session ID.
+// "sess_20260511T203845_16d33281" → "16d33281" (last _-delimited segment).
+// Recipient ID with no underscore (e.g. "orchestrator-1") uses the full value.
+function wakeRecipientShort(eventName: string): string {
+  const sessId = eventName.replace(/^(orchestrator\.)?filter\.wake\./, "");
+  if (!sessId) return "";
+  const parts = sessId.split("_");
+  return parts.length > 1 ? (parts[parts.length - 1] ?? sessId) : sessId;
+}
+
 const SKIP_EVENTS = new Set([
   "session.heartbeat",
   "orchestrator.archived",
@@ -311,6 +321,24 @@ export function formatDetails(event: CanonicalEvent): string {
   // <Text wrap="wrap"> on the DETAILS column handles overflow at render time.
   if (name?.startsWith("filter.wake.") || name?.startsWith("orchestrator.filter.wake.")) {
     const p = payload as Record<string, unknown> | undefined;
+    // CTL-419: append a short recipient identifier to every wake DETAILS cell so
+    // operators can see who is being woken even on narrow terminals where REF clips.
+    const recipientSuffix = ` → ${wakeRecipientShort(name)}`;
+
+    // CTL-419: multi-stale batch path — broker now emits stale_sessions[] when
+    // multiple sessions go stale for the same interest simultaneously.
+    const staleSessions = Array.isArray(p?.["stale_sessions"])
+      ? (p["stale_sessions"] as string[])
+      : null;
+    if (staleSessions !== null && staleSessions.length > 1) {
+      const out = sanitize(
+        `wake → ${staleSessions.length} sessions stale${recipientSuffix}`,
+        "oneline",
+      );
+      detailsCache.set(event, out);
+      return out;
+    }
+
     const sourceEvents = Array.isArray(p?.["source_events"])
       ? (p["source_events"] as Array<Record<string, unknown>>)
       : [];
@@ -331,7 +359,7 @@ export function formatDetails(event: CanonicalEvent): string {
         || typeof state === "boolean";
       const stateSuffix = isPrimitive ? ` → ${String(state)}` : "";
       const countSuffix = sourceEvents.length > 1 ? ` (${sourceEvents.length})` : "";
-      const out = `wake ← ${evName}${ref ? ` ${ref}` : ""}${stateSuffix}${countSuffix}`
+      const out = `wake ← ${evName}${ref ? ` ${ref}` : ""}${stateSuffix}${countSuffix}${recipientSuffix}`
         .replace(/\s+/g, " ")
         .trim();
       const sanitized = sanitize(out, "oneline");
@@ -343,7 +371,9 @@ export function formatDetails(event: CanonicalEvent): string {
     const count = Array.isArray(ids) ? ids.length : 0;
     const reasonShort = sanitize(reasonRaw, "oneline");
     const suffix = count > 1 ? ` (${count})` : "";
-    const out = reasonShort ? `wake → ${reasonShort}${suffix}` : `wake${suffix}`;
+    const out = reasonShort
+      ? `wake → ${reasonShort}${suffix}${recipientSuffix}`
+      : `wake${suffix}${recipientSuffix}`;
     detailsCache.set(event, out);
     return out;
   }


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T03:00:00Z -->
<!-- Last updated: 2026-05-15T03:00:00Z -->
<!-- PR: #722 -->
<!-- Previous commits: 25fbb4c -->

## Summary

Two related improvements to wake-event handling observed in the HUD when multiple orchestrator sessions go stale simultaneously:

- **Broker batching**: Watchdog now emits **one** `filter.wake` event per interest when N sessions are simultaneously stale, instead of N separate identical-looking events. The batched payload includes `stale_sessions[]` and `stale_count`.
- **HUD recipient visibility**: `formatDetails` appends `→ <short-id>` to every wake event DETAILS cell, making it immediately clear who is being woken — even on narrow terminals where the REF column is clipped or deduped against ORCH.

## Changes

### Broker (`plugins/dev/scripts/broker/index.mjs`)

**Restructured `runWatchdogTick()`**: Inverted the nested loop order. Previously: outer loop over stale sessions, inner loop over interests → one `appendEvent` per `(session × interest)` pair. Now: collect all stale sessions first, then outer loop over interests, batching all matching sessions per interest into a single emit.

New payload shape:
```json
{
  "reason": "3 sessions stale",
  "stale_sessions": ["worker-A", "worker-B", "worker-C"],
  "stale_count": 3,
  "source_event_ids": [],
  "source_events": [],
  "interest_id": "orch-session-id"
}
```

Single-session case is backwards-compatible: `stale_sessions: ["sess_a"]`, `stale_count: 1`, `reason: "No heartbeat from sess_a for >N min"`.

Added `__setHeartbeatForTest(sessionId, tsMs)` export to allow tests to backdate heartbeat timestamps and simulate staleness.

### HUD Format (`plugins/dev/scripts/orch-monitor/cli/lib/format.ts`)

Added `wakeRecipientShort(eventName)` helper — strips the `filter.wake.` prefix, then takes the last `_`-delimited segment as the short form (`sess_20260511T203845_16d33281` → `16d33281`). Session IDs without underscores use the full value.

Updated `formatDetails()` wake branch:
- **Multi-stale path** (new): when `stale_sessions.length > 1`, renders `wake → N sessions stale → <short>`.
- **Structured path** (source_events): appends `→ <short>` after existing `wake ← event ticket → state` line.
- **Legacy/reason path**: appends `→ <short>` after reason string.

### Tests

- **`plugins/dev/scripts/broker/index.test.mjs`**: New `describe("CTL-419 watchdog batching")` block — 4 tests covering batch emission, single-session backwards compat, independent two-orchestrator isolation, and no-re-notify on second tick.
- **`plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts`** (new file): 6 unit tests for `formatDetails` and `formatRef` covering all wake paths with the new recipient suffix.
- **`plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts`**: Updated 8 existing expected strings to include the new `→ <short>` recipient suffix.

## How to Verify

### Automated
- [x] Broker tests: `cd plugins/dev/scripts/broker && bun test` — 171/171 pass
- [x] HUD tests: `cd plugins/dev/scripts/orch-monitor && bun test` — 1853 pass, 0 new failures (6 pre-existing `catalyst-monitor.sh` infrastructure failures unaffected)
- [x] Typecheck: `cd plugins/dev/scripts/orch-monitor && bun run typecheck` — 0 errors in changed files

### Manual
- [ ] Start a multi-worker orchestrator run and kill 2+ workers simultaneously — HUD should show 1 wake row with `3 sessions stale → <short>` in DETAILS, not 3 separate rows
- [ ] Verify HUD wake rows for normal PR/issue wakes show `→ <8-char-hash>` in DETAILS column

## Notes

- `formatRef()` is unchanged — REF column still shows the full stripped session ID
- No change to interest registration or the deduplication logic in `EventRow.tsx`
- The note on "multicast architecture" in the ticket (single event with `recipients: []`) is explicitly deferred — this PR uses the simpler batching approach as recommended

## Related Issues

- Fixes https://linear.app/getadva/issue/CTL-419
