### PR TITLE
fix(dev): use Date.getTime() for since-filter comparison in HUD (CTL-413)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useEventLog.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useEventLog.test.ts
@@ -1,0 +1,59 @@
+// useEventLog.test.ts — mirrors the since-filter predicate logic inline.
+//
+// useEventLog mixes React hook machinery with filesystem I/O, so we can't
+// invoke the hook directly in bun:test. Instead we mirror the exact filter
+// predicate here and keep it adjacent to the source so drift is obvious.
+
+import { describe, test, expect } from "bun:test";
+import type { CanonicalEvent } from "../../lib/canonical-event.ts";
+
+function makeSinceFilter(sinceTs: string) {
+  const sinceMs = new Date(sinceTs).getTime();
+  return (e: CanonicalEvent) => new Date(e.ts).getTime() >= sinceMs;
+}
+
+function makeEvent(ts: string): CanonicalEvent {
+  return {
+    ts,
+    body: { payload: {} },
+    attributes: { "event.name": "test" },
+  } as unknown as CanonicalEvent;
+}
+
+// Base sinceTs in Z format (no sub-second component so +00:00 form can match exactly)
+const SINCE_Z = "2026-05-14T22:38:28.000Z";
+// Same instant in +00:00 format — string comparison wrongly treats this as less than SINCE_Z
+const SINCE_OFFSET = "2026-05-14T22:38:28+00:00";
+const AFTER_Z = "2026-05-14T22:38:29.000Z";
+const AFTER_OFFSET = "2026-05-14T22:38:29+00:00";
+const BEFORE_Z = "2026-05-14T22:38:27.000Z";
+const BEFORE_OFFSET = "2026-05-14T22:38:00+00:00";
+
+describe("since-filter date comparison", () => {
+  test("keeps Z-format events at or after sinceTs", () => {
+    const f = makeSinceFilter(SINCE_Z);
+    expect(f(makeEvent(SINCE_Z))).toBe(true);
+    expect(f(makeEvent(AFTER_Z))).toBe(true);
+    expect(f(makeEvent(BEFORE_Z))).toBe(false);
+  });
+
+  test("keeps +00:00 events at or after sinceTs", () => {
+    const f = makeSinceFilter(SINCE_Z);
+    expect(f(makeEvent(SINCE_OFFSET))).toBe(true);
+    expect(f(makeEvent(AFTER_OFFSET))).toBe(true);
+    expect(f(makeEvent(BEFORE_OFFSET))).toBe(false);
+  });
+
+  test("+00:00 event equal to sinceTs moment is NOT dropped (was the string-comparison bug)", () => {
+    // String comparison: "2026-05-14T22:38:28+00:00" < "2026-05-14T22:38:28.000Z" → drops it
+    // Date comparison: same instant → keeps it
+    const f = makeSinceFilter(SINCE_Z);
+    expect(f(makeEvent(SINCE_OFFSET))).toBe(true);
+  });
+
+  test("sinceTs in +00:00 format: Z events after the cutoff are kept", () => {
+    const f = makeSinceFilter(SINCE_OFFSET);
+    expect(f(makeEvent(AFTER_Z))).toBe(true);
+    expect(f(makeEvent(BEFORE_Z))).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useEventLog.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useEventLog.ts
@@ -35,7 +35,8 @@ export function useEventLog({ predicate = "", repoFilter = "", sinceTs }: UseEve
         .filter((e) => !shouldSkipEvent(e));
 
       if (sinceTs) {
-        initial = initial.filter((e) => e.ts >= sinceTs);
+        const sinceMs = new Date(sinceTs).getTime();
+        initial = initial.filter((e) => new Date(e.ts).getTime() >= sinceMs);
       }
       if (repoFilter) {
         initial = initial.filter((e) => {
@@ -55,7 +56,7 @@ export function useEventLog({ predicate = "", repoFilter = "", sinceTs }: UseEve
           try {
             const event = JSON.parse(line) as CanonicalEvent;
             if (shouldSkipEvent(event)) return;
-            if (sinceTs && event.ts < sinceTs) return;
+            if (sinceTs && new Date(event.ts).getTime() < new Date(sinceTs).getTime()) return;
             if (repoFilter) {
               const repo = event.attributes["vcs.repository.name"] ?? "";
               if (repo && !repo.includes(repoFilter)) return;


### PR DESCRIPTION
## Summary

- Fixes the HUD `since` filter returning 0 events when event `ts` fields use `+00:00` offset format instead of `Z`
- Root cause: `e.ts >= sinceTs` was a string comparison; `+` (ASCII 43) sorts before `.` (ASCII 46), so all `+00:00` timestamps incorrectly compared as less than any `Z` timestamp at the same moment
- Fix: replace with `new Date(e.ts).getTime() >= sinceMs` in both the backlog filter (line 38) and the tail `onEvent` handler (line 58)
- Adds `useEventLog.test.ts` with four cases covering mixed Z / `+00:00` timestamp comparisons

Refs: CTL-413