### PR TITLE
fix(dev): populate REPO column for linear.* and filter.wake events (CTL-412)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -636,6 +636,7 @@ export function handleAgentCheckin(event) {
   const claimedPr = d.claimed_pr ?? null;
   const orchestrator = d.orchestrator ?? event.orchestrator ?? null;
   const cwd = d.cwd ?? null;
+  const repo = d.repo ?? null;
 
   try {
     upsertAgent({ agentId: sessionId, agentName, sessionId, orchestrator, ticket, claimedPr, cwd });
@@ -653,14 +654,14 @@ export function handleAgentCheckin(event) {
   // Auto-correlate: if the agent has already claimed a PR, register a
   // pr_lifecycle interest on its behalf — no explicit filter.register needed.
   if (claimedPr) {
-    _autoRegisterPrLifecycle(sessionId, claimedPr, orchestrator, ticket);
+    _autoRegisterPrLifecycle(sessionId, claimedPr, orchestrator, ticket, repo);
   }
 
   log.info({ agentName, sessionId, ticket, claimedPr }, "agent checked in");
 }
 
 // Auto-register a pr_lifecycle interest when we learn agent ↔ PR mapping.
-function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket) {
+function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket, repo) {
   if (interests.has(sessionId)) return; // don't overwrite explicit registration
 
   interests.set(sessionId, {
@@ -672,14 +673,14 @@ function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket) {
     persistent: true,
     interest_type: "pr_lifecycle",
     pr_numbers: [prNumber],
-    repo: null,
+    repo: repo ?? null,
     base_branches: [],
     tickets: null,
     wake_on: null,
   });
 
   try {
-    upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: "" });
+    upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: repo ?? "" });
   } catch {
     /* DB not opened */
   }
@@ -1110,7 +1111,7 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
         reason = `PR #${pr} opened on ticket ${linked}`;
         // Auto-correlate: give agents watching this ticket a pr_lifecycle interest.
         if (typeof scope.pr === "number") {
-          _autoPrLifecycleFromTicket(linked, scope.pr, interestsMap);
+          _autoPrLifecycleFromTicket(linked, scope.pr, interestsMap, attrs["vcs.repository.name"] ?? null);
         }
       }
     } else if (name === "github.pr.merged") {
@@ -1140,7 +1141,7 @@ export function tryTicketLifecycleRoute(event, interestsMap) {
 // that checked in with that ticket but hasn't been linked to a PR yet, AND
 // (CTL-341) append the new PR number to any orchestrator-level pr_lifecycle
 // interest whose orchestrator matches one of those agents.
-function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
+function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap, repo) {
   let agents = [];
   try {
     agents = getAgentsByTicket(ticket);
@@ -1164,14 +1165,14 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap) {
       persistent: true,
       interest_type: "pr_lifecycle",
       pr_numbers: [prNumber],
-      repo: null,
+      repo: repo ?? null,
       base_branches: [],
       tickets: null,
       wake_on: null,
     });
 
     try {
-      upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: "" });
+      upsertFilterStateOpen({ interestId: sessionId, prNumber, repo: repo ?? "" });
     } catch {
       /* DB not opened */
     }

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -423,6 +423,39 @@ describe("agent.checkin", () => {
   test("no-op when session_id missing", () => {
     expect(() => handleAgentCheckin({ event: "agent.checkin", detail: {} })).not.toThrow();
   });
+
+  test("stores repo in auto-correlated pr_lifecycle interest when provided", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: {
+        session_id: "sess-repo",
+        agent_name: "worker",
+        ticket: "CTL-412",
+        orchestrator: "orch-1",
+        claimed_pr: 714,
+        repo: "coalesce-labs/catalyst",
+      },
+    });
+    const reg = getInterests().get("sess-repo");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("pr_lifecycle");
+    expect(reg.repo).toBe("coalesce-labs/catalyst");
+  });
+
+  test("auto-correlated pr_lifecycle repo is null when not provided", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: {
+        session_id: "sess-norepo",
+        agent_name: "worker",
+        ticket: "CTL-412",
+        claimed_pr: 715,
+      },
+    });
+    const reg = getInterests().get("sess-norepo");
+    expect(reg).toBeDefined();
+    expect(reg.repo).toBeNull();
+  });
 });
 
 describe("agent.checkout", () => {
@@ -991,6 +1024,36 @@ describe("auto-correlation: github.pr.opened triggers pr_lifecycle for ticket-wa
     expect(reg).toBeDefined();
     expect(reg.interest_type).toBe("pr_lifecycle");
     expect(reg.pr_numbers).toEqual([601]);
+  });
+
+  test("auto-correlated pr_lifecycle inherits repo from github.pr.opened event", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-repo-inherit", agent_name: "worker", ticket: "CTL-412", claimed_pr: null },
+    });
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-1",
+      detail: {
+        interest_id: "tl-repo",
+        interest_type: "ticket_lifecycle",
+        tickets: ["CTL-412"],
+        wake_on: ["pr_opened"],
+        persistent: true,
+      },
+    });
+
+    tryTicketLifecycleRoute({
+      event: "github.pr.opened",
+      scope: { pr: 714 },
+      attributes: { "vcs.repository.name": "coalesce-labs/catalyst" },
+      detail: { body: "Implements CTL-412", title: "", headRef: "" },
+    }, getInterests());
+
+    const reg = getInterests().get("sess-repo-inherit");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("pr_lifecycle");
+    expect(reg.repo).toBe("coalesce-labs/catalyst");
   });
 
   test("agents with existing claimed_pr are skipped during auto-correlation", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -89,6 +89,26 @@ describe("formatRepo", () => {
     const e = { ...baseEvent, attributes: { "event.name": "heartbeat" } } as unknown as CanonicalEvent;
     expect(formatRepo(e)).toBe("");
   });
+
+  test("falls back to linear.team.key for linear events without vcs.repository.name", () => {
+    const e = {
+      ...baseEvent,
+      attributes: { "event.name": "linear.issue.updated", "linear.team.key": "CTL" },
+    } as unknown as CanonicalEvent;
+    expect(formatRepo(e)).toBe("CTL");
+  });
+
+  test("prefers vcs.repository.name over linear.team.key when both present", () => {
+    const e = {
+      ...baseEvent,
+      attributes: {
+        "event.name": "linear.issue.updated",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+        "linear.team.key": "CTL",
+      },
+    } as unknown as CanonicalEvent;
+    expect(formatRepo(e)).toBe("catalyst");
+  });
 });
 
 describe("formatSource", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -54,7 +54,10 @@ export function formatDateTime(event: CanonicalEvent): string {
 }
 
 export function formatRepo(event: CanonicalEvent): string {
-  const repo = event.attributes["vcs.repository.name"] ?? "";
+  const repo =
+    event.attributes["vcs.repository.name"] ??
+    event.attributes["linear.team.key"] ??
+    "";
   return repo.includes("/") ? (repo.split("/").pop() ?? repo) : repo;
 }
 


### PR DESCRIPTION
## Summary

- `formatRepo()` falls back to `linear.team.key` when `vcs.repository.name` is absent, covering all linear.* events regardless of team-to-repo mapping config
- Broker `_autoRegisterPrLifecycle` now accepts and stores `repo` from `agent.checkin` detail, so auto-correlated pr_lifecycle wakes populate the REPO column
- Broker `_autoPrLifecycleFromTicket` now accepts and stores `repo` from the `github.pr.opened` event's `vcs.repository.name` attribute

## Test plan

- [ ] Existing broker tests pass (132/132 in index.test.mjs)
- [ ] New broker tests: `stores repo in auto-correlated pr_lifecycle interest when provided` and `auto-correlated pr_lifecycle repo is null when not provided`
- [ ] Existing hud-format tests pass (132/132)
- [ ] New hud-format tests: `falls back to linear.team.key for linear events without vcs.repository.name` and `prefers vcs.repository.name over linear.team.key when both present`
- [ ] REPO column shows team key (e.g. "CTL") for linear.issue.* events in HUD
- [ ] REPO column shows repo name for filter.wake events when agent checked in with repo

Refs: CTL-412