### PR TITLE
feat(dev): add reason field to agent.checkout payload (CTL-402)

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -71,6 +71,8 @@ export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
       updated_at    TEXT NOT NULL
     )
   `);
+  // CTL-402: add reason column to existing DBs (no-op on fresh installs).
+  try { db.run(`ALTER TABLE agents ADD COLUMN reason TEXT`); } catch { /* already exists */ }
   db.run(`
     CREATE INDEX IF NOT EXISTS idx_agents_ticket
       ON agents(ticket)
@@ -233,11 +235,20 @@ export function upsertAgent({ agentId, agentName, sessionId, orchestrator, ticke
   );
 }
 
-export function markAgentDone(agentId, status = "done") {
+export function markAgentDone(agentId, status = "done", reason = null) {
   ensure().run(
-    `UPDATE agents SET status = ?, updated_at = ? WHERE agent_id = ?`,
-    [status, nowIso(), agentId],
+    `UPDATE agents SET status = ?, updated_at = ?, reason = ? WHERE agent_id = ?`,
+    [status, nowIso(), reason ?? null, agentId],
   );
+}
+
+export function getRecentAgents(limit = 20) {
+  return ensure()
+    .prepare(
+      `SELECT agent_id, session_id, ticket, status, reason, checked_in_at, updated_at
+       FROM agents ORDER BY updated_at DESC LIMIT ?`,
+    )
+    .all(limit);
 }
 
 export function getAgentBySession(sessionId) {

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -38,6 +38,7 @@ import {
   upsertAgent,
   markAgentDone,
   getAgentsByTicket,
+  getRecentAgents,
   // ticket_state (CTL-303 — ticket routing)
   upsertTicketState,
   // waiting_sessions (CTL-403 — wait-loop visibility)
@@ -697,9 +698,10 @@ export function handleAgentCheckout(event) {
   if (!sessionId) return;
 
   const finalStatus = d.status ?? "done";
+  const reason = d.reason ?? null;
 
   try {
-    markAgentDone(sessionId, finalStatus);
+    markAgentDone(sessionId, finalStatus, reason);
   } catch {
     /* DB not opened */
   }
@@ -718,7 +720,7 @@ export function handleAgentCheckout(event) {
     persistBrokerState();
   }
 
-  log.info({ sessionId, status: finalStatus }, "agent checked out");
+  log.info({ sessionId, status: finalStatus, reason }, "agent checked out");
 }
 
 export function handleAgentHeartbeat(event) {
@@ -1895,6 +1897,8 @@ export function buildBrokerState({ probe } = {}) {
       enabled: GROQ_GATEWAY_ENABLED,
       baseUrl: GROQ_GATEWAY_BASE_URL,
     },
+    // CTL-402: surface recent agent exit reasons for observability.
+    recentAgents: (() => { try { return getRecentAgents(); } catch { return []; } })(),
   };
 }
 

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -559,10 +559,11 @@ cmd_end() {
   __session_emit_canonical "$sid" "session-ended" "$payload" "$end_ts" "$sev"
 
   # CTL-303: emit agent.checkout so the broker can clean up auto-correlated interests.
+  # CTL-402: include reason so the broker can log and persist why the session ended.
   local checkout_ts; checkout_ts="$(now_iso)"
   canonical_jsonl_append "$EVENTS_DIR" \
-    "$(jq -nc --arg ts "$checkout_ts" --arg sid "$sid" --arg st "$status" \
-      '{ts:$ts,event:"agent.checkout",detail:{session_id:$sid,status:$st}}' 2>/dev/null)" 2>/dev/null || true
+    "$(jq -nc --arg ts "$checkout_ts" --arg sid "$sid" --arg st "$status" --arg reason "$reason" \
+      '{ts:$ts,event:"agent.checkout",detail:({session_id:$sid,status:$st}+if $reason!="" then {reason:$reason} else {} end)}' 2>/dev/null)" 2>/dev/null || true
 
   # CTL-157: emit claude_code.session.outcome to OTLP.
   local emit_bin="${CATALYST_EMIT_OTEL_BIN:-$SCRIPT_DIR/emit-otel-event.sh}"

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -506,7 +506,8 @@ fi
 
 ```bash
 if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
-  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done  # or --status failed
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done --reason "PR merged"
+  # or: "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed --reason "<why>"
 fi
 ```
 
@@ -818,7 +819,7 @@ while [ "$PR_DONE" = "false" ]; do
       "$SIGNAL_FILE" > "$SIGNAL_FILE.tmp" && mv "$SIGNAL_FILE.tmp" "$SIGNAL_FILE"
     comms_post attention "stalled: ${ERROR_MSG}"
     if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
-      "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed
+      "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed --reason "changes requested by ${LAST_CR}"
     fi
     exit 1
   fi
@@ -854,7 +855,7 @@ while [ "$PR_DONE" = "false" ]; do
           "$SIGNAL_FILE" > "$SIGNAL_FILE.tmp" && mv "$SIGNAL_FILE.tmp" "$SIGNAL_FILE"
         comms_post attention "stalled: ${ERROR_MSG}"
         if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
-          "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed
+          "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed --reason "CI blocked after ${MAX_CI_FIX_ATTEMPTS} fix attempts"
         fi
         exit 1
       fi
@@ -874,7 +875,7 @@ while [ "$PR_DONE" = "false" ]; do
         "$SIGNAL_FILE" > "$SIGNAL_FILE.tmp" && mv "$SIGNAL_FILE.tmp" "$SIGNAL_FILE"
       comms_post attention "stalled: ${ERROR_MSG}"
       if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
-        "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed
+        "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed --reason "merge conflicts (DIRTY)"
       fi
       exit 1
       ;;
@@ -908,7 +909,7 @@ if [ "$MERGED_OK" != "true" ]; then
     '.status = $status | .updatedAt = $ts' \
     "$SIGNAL_FILE" > "$SIGNAL_FILE.tmp" && mv "$SIGNAL_FILE.tmp" "$SIGNAL_FILE"
   if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
-    "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed
+    "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed --reason "merge not confirmed via REST"
   fi
   exit 1
 fi
@@ -952,7 +953,7 @@ if [ "$SKIP_DEPLOY" != "true" ] && [ -n "$MERGE_COMMIT_SHA" ]; then
         "$SIGNAL_FILE" > "$SIGNAL_FILE.tmp" && mv "$SIGNAL_FILE.tmp" "$SIGNAL_FILE"
       comms_post attention "deploy-failed: ${PROD_ENV} deploy failed for PR #${PR_NUMBER}"
       if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
-        "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed
+        "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed --reason "deployment failed in ${PROD_ENV}"
       fi
       exit 1
     fi
@@ -989,7 +990,7 @@ fi
 # End session
 if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
   "$SESSION_SCRIPT" pr "$CATALYST_SESSION_ID" --number "$PR_NUMBER" --url "$PR_URL"
-  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done --reason "PR merged"
 fi
 
 # CTL-111: post done to shared comms channel
@@ -1262,7 +1263,7 @@ run:
 
 ```bash
 if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
-  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed --reason "<why it failed>"
 fi
 ```
 


### PR DESCRIPTION
## Summary

- **`catalyst-session.sh`**: stamps `--reason` into the `agent.checkout` event `detail.reason` when non-empty (reason was already parsed but silently dropped from this payload)
- **`broker-state.mjs`**: adds `reason TEXT` column to `agents` table with ALTER TABLE migration for existing DBs; updates `markAgentDone(agentId, status, reason)` to store it; adds `getRecentAgents()` for observability queries
- **`broker/index.mjs`**: `handleAgentCheckout` reads `d.reason`, passes to `markAgentDone`, includes in `log.info`; `buildBrokerState` exposes `recentAgents` so `broker status --json` surfaces exit reasons
- **`oneshot/SKILL.md`**: all `session end` calls updated with meaningful reasons: "PR merged", "CI blocked after N fix attempts", "changes requested by ${LAST_CR}", "merge conflicts (DIRTY)", "merge not confirmed via REST", "deployment failed in ${PROD_ENV}"

## Test plan

- [ ] `catalyst-session.sh end <sid> --status done --reason "PR merged"` emits `agent.checkout` with `detail.reason`
- [ ] `catalyst-session.sh end <sid> --status failed` emits `agent.checkout` without `reason` key (omit when empty)
- [ ] Broker's `handleAgentCheckout` logs `reason` field in pino output
- [ ] `filter-state.db` `agents` table has `reason` column after broker restart
- [ ] `broker status --json` includes `recentAgents` with `reason` field for checked-out sessions

Refs: CTL-402