### PR TITLE
feat(dev): add wake-extract CLI + document wake payload schema (CTL-408)

### DIFF
--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -483,6 +483,61 @@ cmd_query() {
   fi
 }
 
+cmd_wake_extract() {
+  local input="" pretty=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --pretty|-p) pretty=1; shift ;;
+      -h|--help)   cmd_help; return 0 ;;
+      --*) echo "error: unknown wake-extract flag: $1" >&2; return 2 ;;
+      *)
+        if [[ -z "$input" ]]; then
+          input="$1"; shift
+        else
+          echo "error: too many positional arguments to wake-extract" >&2
+          return 2
+        fi
+        ;;
+    esac
+  done
+
+  local -a jq_opts=()
+  [[ -z "$pretty" ]] && jq_opts+=("-c")
+
+  local jq_program='
+    . as $wake |
+    ($wake.body.payload // {}) as $p |
+    ($p.source_events[0] // {}) as $se |
+    ($se.payload_excerpt // {}) as $ex |
+    {
+      event_name:      ($se.name // null),
+      interest_id:     ($p.interest_id // null),
+      reason:          ($p.reason // null),
+      pr_number:       ($se.pr // $wake.attributes["vcs.pr.number"] // null),
+      ticket:          ($p.ticket // $se.ticket // null),
+      repo:            ($se.repo // $wake.attributes["vcs.repository.name"] // null),
+      ci_conclusion:   ($ex.conclusion // null),
+      review_state:    ($ex.state // null),
+      merged:          ($ex.merged // null),
+      action:          ($ex.action // null),
+      source_event_id: ($p.source_event_ids[0] // null)
+    }
+  '
+
+  if [[ -n "$input" ]]; then
+    printf '%s\n' "$input" | jq "${jq_opts[@]}" "$jq_program" 2>/dev/null || {
+      echo "error: wake-extract: input is not valid JSON" >&2
+      return 2
+    }
+  else
+    jq "${jq_opts[@]}" "$jq_program" 2>/dev/null || {
+      echo "error: wake-extract: input is not valid JSON" >&2
+      return 2
+    }
+  fi
+}
+
 cmd_help() {
   cat <<'EOF'
 catalyst-events — tail, wait-for, and natural-language query over the global event log.
@@ -492,6 +547,7 @@ Usage:
   catalyst-events wait-for [--filter <jq-predicate>] [--timeout <sec>]
   catalyst-events build-orchestrator-filter <orch-dir>
   catalyst-events query <natural-language> [--explain] [--limit N] [--since DURATION]
+  catalyst-events wake-extract [<wake-event-json>] [--pretty]
   catalyst-events help
 
 Examples:
@@ -522,6 +578,14 @@ Examples:
   FILTER=$(catalyst-events build-orchestrator-filter "$ORCH_DIR")
   catalyst-events tail --filter "$FILTER"
 
+  # Normalize a broker wake event (stdin) — extract CI conclusion without REST
+  catalyst-events wait-for \
+    --filter '.attributes."event.name" | startswith("filter.wake.")' \
+    --timeout 600 | catalyst-events wake-extract
+
+  # Check if a wake was triggered by a CI failure (inline string arg)
+  catalyst-events wake-extract "$EVENT_JSON" | jq -r '.ci_conclusion'
+
 Environment:
   CATALYST_DIR          base directory (default: $HOME/catalyst)
   CATALYST_EVENTS_DIR   events directory (default: $CATALYST_DIR/events)
@@ -548,6 +612,7 @@ main() {
     wait-for)                   cmd_wait_for "$@" ;;
     build-orchestrator-filter)  cmd_build_orchestrator_filter "$@" ;;
     query)                      cmd_query "$@" ;;
+    wake-extract)               cmd_wake_extract "$@" ;;
     help|-h|--help)             cmd_help ;;
     *)
       echo "error: unknown command: $cmd" >&2

--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -226,21 +226,38 @@ jq -nc \
 
 Omit `wake_on` (or pass `null`) to fire on all of the above.
 
-### Wake Event Shape
+### Wake Event Shape (Canonical On-Disk Form)
 
 ```json
 {
-  "event": "filter.wake.sess_20260508_abcd",
-  "orchestrator": "my-orch",
-  "worker": null,
-  "detail": {
-    "reason": "Ticket CTL-275 marked Done",
-    "source_event_ids": ["..."],
-    "interest_id": "sess_20260508_abcd",
-    "ticket": "CTL-275"
+  "ts": "2026-05-08T18:25:00.000Z",
+  "id": "<uuid>",
+  "resource": { "service.name": "catalyst.broker" },
+  "attributes": {
+    "event.name": "filter.wake.sess_20260508_abcd",
+    "catalyst.orchestrator.id": "my-orch"
+  },
+  "body": {
+    "payload": {
+      "reason": "Ticket CTL-275 marked Done",
+      "source_event_ids": ["<uuid>"],
+      "source_events": [{
+        "id": "<uuid>",
+        "name": "linear.issue.state_changed",
+        "ts": "2026-05-08T18:24:58.000Z",
+        "ticket": "CTL-275",
+        "pr": null,
+        "repo": null,
+        "payload_excerpt": { "state": "Done", "stateType": "completed" }
+      }],
+      "interest_id": "sess_20260508_abcd",
+      "ticket": "CTL-275"
+    }
   }
 }
 ```
+
+See §10 for the complete field reference and `wake-extract` accessor.
 
 ### Waiting for a Ticket Wake
 
@@ -356,18 +373,37 @@ jq -nc \
 | Worker: `body.payload.to == reg.subscriber_ticket` OR `body.payload.to == "all"` | required for worker subscribers |
 | Worker: sender (`catalyst.worker.ticket`) != `reg.subscriber_ticket` | self-loop guard |
 
-### Wake Event Shape
+### Wake Event Shape (Canonical On-Disk Form)
 
 ```json
 {
-  "event": "filter.wake.orch-2026-05-12",
-  "detail": {
-    "reason": "Worker CTL-352 posted attention on orch-orch-2026-05-12",
-    "source_event_ids": ["..."],
-    "interest_id": "orch-2026-05-12-comms"
+  "ts": "2026-05-08T18:26:00.000Z",
+  "id": "<uuid>",
+  "resource": { "service.name": "catalyst.broker" },
+  "attributes": {
+    "event.name": "filter.wake.orch-2026-05-12",
+    "catalyst.orchestrator.id": "orch-2026-05-12"
+  },
+  "body": {
+    "payload": {
+      "reason": "Worker CTL-352 posted attention on orch-orch-2026-05-12",
+      "source_event_ids": ["<uuid>"],
+      "source_events": [{
+        "id": "<uuid>",
+        "name": "comms.message.posted",
+        "ts": "2026-05-08T18:25:59.000Z",
+        "ticket": "CTL-352",
+        "pr": null,
+        "repo": null,
+        "payload_excerpt": { "action": "attention" }
+      }],
+      "interest_id": "orch-2026-05-12-comms"
+    }
   }
 }
 ```
+
+See §10 for the complete field reference and `wake-extract` accessor.
 
 ## 5. `pr_lifecycle` Interest Type (CTL-284 — Unchanged)
 
@@ -466,3 +502,167 @@ if ! catalyst-broker status | grep -q "^running"; then
     --timeout 300 2>/dev/null || true)
 fi
 ```
+
+## 10. Wake Event Envelope Reference
+
+All `filter.wake.*` events written to the event log use the canonical OTel envelope
+(CTL-300). This section documents every field so skills can extract data from the wake
+payload directly rather than making round-trip REST/GraphQL calls.
+
+### Canonical On-Disk Shape
+
+```json
+{
+  "ts": "2026-05-08T18:25:00.000Z",
+  "id": "<uuid>",
+  "observedTs": "2026-05-08T18:25:00.000Z",
+  "severityText": "INFO",
+  "severityNumber": 9,
+  "resource": {
+    "service.name": "catalyst.broker",
+    "service.namespace": "catalyst"
+  },
+  "attributes": {
+    "event.name": "filter.wake.<interest_id>",
+    "catalyst.orchestrator.id": "<orch-id or null>",
+    "vcs.repository.name": "<org/repo or null>"
+  },
+  "body": {
+    "payload": {
+      "reason": "<human-readable why this fired>",
+      "source_event_ids": ["<uuid>"],
+      "source_events": [ /* compact source summaries — see below */ ],
+      "interest_id": "<id>",
+      "ticket": "<CTL-XXX or null>"
+    }
+  }
+}
+```
+
+### `body.payload` Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `reason` | string | Human-readable description of why the broker fired |
+| `source_event_ids` | string[] | UUIDs of the raw events that matched the interest |
+| `source_events` | object[] | Compact summaries of the source events (CTL-350) — see below |
+| `interest_id` | string | Which interest registration matched |
+| `ticket` | string\|null | Linear ticket ID — **only set on `ticket_lifecycle` wakes** |
+
+`source_events` is empty on watchdog wakes (stale interest, dead session).
+
+### `source_events[]` Element Structure
+
+Each element is a compact summary of one matching raw event:
+
+```json
+{
+  "id": "<event-uuid>",
+  "name": "github.check_suite.completed",
+  "ts": "2026-05-08T18:24:55.000Z",
+  "ticket": null,
+  "pr": 342,
+  "repo": "org/repo",
+  "message": "github.check_suite.completed in org/repo (truncated to 200 chars)",
+  "payload_excerpt": {
+    "state": null,
+    "stateType": null,
+    "conclusion": "failure",
+    "title": null,
+    "merged": null,
+    "action": null
+  },
+  "lookup_jq": "jq 'select(.id == \"<uuid>\")' ~/catalyst/events/2026-05.jsonl"
+}
+```
+
+`payload_excerpt` always has these six keys; any key not applicable to the source event type is `null`:
+
+| Key | Populated for |
+|---|---|
+| `conclusion` | `github.check_suite.completed`, `github.workflow_run.completed` |
+| `state` | `github.pr_review.submitted` (review state), `linear.issue.state_changed` |
+| `stateType` | `linear.issue.state_changed` (Linear state type: `completed`, `started`, etc.) |
+| `merged` | `github.pr.merged` → `true` |
+| `action` | `comms.message.posted` (message type: `attention`, `info`, `done`) |
+| `title` | `github.pr.opened`, `linear.issue.*` |
+
+### Wake Reason Strings by Interest Type
+
+#### `pr_lifecycle`
+
+| Source event | `reason` pattern |
+|---|---|
+| `github.check_suite.completed` (failure/timed_out) | `"CI failing on PR #N — check_suite conclusion: failure"` |
+| `github.check_suite.completed` (success) | `"All CI checks passing on PR #N"` |
+| `github.pr.merged` | `"PR #N merged (merge commit: SHA). Now waiting for deployment..."` |
+| `github.pr.closed` (not merged) | `"PR #N closed without merging"` |
+| `github.pr_review.submitted` (bot, changes_requested) | `"Automated review comment from {reviewer} (bot): Changes requested on PR #N..."` |
+| `github.pr_review.submitted` (human, changes_requested) | `"Changes requested by {reviewer} on PR #N..."` |
+| `github.pr_review.submitted` (approved) | `"PR #N approved by {reviewer}"` |
+| `github.pr_review_comment.created` | `"{author}: '{body}'. Comment must be marked resolved..."` |
+| `github.pr_review_thread.resolved` | `"Review thread {threadId} resolved on PR #N"` |
+| `github.deployment.created` | `"Deployment started for merge commit {sha} on environment {env}"` |
+| `github.deployment_status.success` | `"Deployment succeeded on {env}. Work is complete."` |
+| `github.deployment_status.failure/error` | `"Deployment failed on {env}. URL: {url}"` |
+| `github.push` to base branch | `"Base branch {branch} updated — PR #N is now behind. Rebase may be needed."` |
+
+#### `ticket_lifecycle`
+
+| Source event | `reason` pattern |
+|---|---|
+| `linear.issue.state_changed` (Done) | `"Ticket {id} marked Done"` |
+| `linear.issue.state_changed` (In Review) | `"Ticket {id} moved to In Review"` |
+| `linear.issue.state_changed` (other) | `"Ticket {id} state changed to {state}"` |
+| `linear.issue.updated` | `"Ticket {id} updated"` |
+| `linear.comment.created` | `"New comment on {id} by {author}"` |
+| `github.pr.opened` (linked ticket) | `"PR #N opened on ticket {id}"` |
+| `github.pr.merged` (linked ticket) | `"PR #N on ticket {id} merged"` |
+
+#### `comms_lifecycle`
+
+| Subscriber kind | `reason` pattern |
+|---|---|
+| orchestrator | `"Worker {ticket} posted {type} on {channel}"` |
+| worker | `"Message to {ticket} ({type}) on {channel} from {sender}"` |
+
+### `wake-extract` — Typed Accessor
+
+`catalyst-events wake-extract` normalizes a `filter.wake.*` event into a flat JSON object
+so skills do not need to hand-roll `jq` paths into `source_events[0].payload_excerpt.*`:
+
+```bash
+EVENT=$(catalyst-events wait-for \
+  --filter ".attributes.\"event.name\" | startswith(\"filter.wake.${CATALYST_SESSION_ID}\")" \
+  --timeout 600)
+
+FIELDS=$(echo "$EVENT" | catalyst-events wake-extract)
+
+# Read normalized fields without knowing the source event type
+PR_NUMBER=$(echo "$FIELDS"      | jq -r '.pr_number // empty')
+CI_CONCLUSION=$(echo "$FIELDS"  | jq -r '.ci_conclusion // empty')
+REVIEW_STATE=$(echo "$FIELDS"   | jq -r '.review_state // empty')
+MERGED=$(echo "$FIELDS"         | jq -r '.merged // empty')
+REASON=$(echo "$FIELDS"         | jq -r '.reason')
+```
+
+`wake-extract` output shape:
+
+```json
+{
+  "event_name": "github.check_suite.completed",
+  "interest_id": "sess_20260508_abcd",
+  "reason": "CI failing on PR #342 — check_suite conclusion: failure",
+  "pr_number": 342,
+  "ticket": null,
+  "repo": "org/repo",
+  "ci_conclusion": "failure",
+  "review_state": null,
+  "merged": null,
+  "action": null,
+  "source_event_id": "<uuid>"
+}
+```
+
+All fields are nullable. Fields not applicable to the source event type are `null`.
+When `source_events` is empty (watchdog wakes), all fields except `interest_id` and `reason` are `null` — treat the wake as a "go re-check" signal in that case.

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -312,6 +312,51 @@ skills:
 The narration line is not for the agent — it is for the *operator reading the
 transcript later*. Treat the wake as a question; treat the line as the answer.
 
+## Reading broker wake payloads
+
+When the broker daemon is running and a `filter.wake.*` event arrives, the payload contains
+richer context than just the `reason` string. Use `catalyst-events wake-extract` to normalize
+the varied payload shapes into a single predictable object:
+
+```bash
+EVENT=$(catalyst-events wait-for \
+  --filter ".attributes.\"event.name\" | startswith(\"filter.wake.${CATALYST_SESSION_ID}\")" \
+  --timeout 600)
+
+# Narrate the wake (mandatory — see Narration section above)
+FIELDS=$(echo "$EVENT" | catalyst-events wake-extract)
+REASON=$(echo "$FIELDS"   | jq -r '.reason // "unknown"')
+INTEREST=$(echo "$FIELDS" | jq -r '.interest_id // "unknown"')
+echo "wake: filter.wake [interest=${INTEREST}] — ${REASON}"
+
+# Branch on normalized fields instead of re-querying GitHub/Linear
+CI_CONCLUSION=$(echo "$FIELDS" | jq -r '.ci_conclusion // empty')
+REVIEW_STATE=$(echo "$FIELDS"  | jq -r '.review_state // empty')
+MERGED=$(echo "$FIELDS"        | jq -r '.merged // empty')
+
+case "$CI_CONCLUSION" in
+  failure|timed_out)
+    # CI failed — pull logs, fix, push without a separate gh api call
+    ;;
+esac
+case "$MERGED" in
+  true)
+    # PR merged event in the payload — still confirm via gh api REST before declaring done
+    ;;
+esac
+```
+
+See [[broker]] §10 for the complete `wake-extract` output schema and the per-interest-type
+reason string catalogue.
+
+**When `source_events` is empty** (watchdog wakes, some Groq prose wakes): all `wake-extract`
+fields are `null` except `interest_id` and `reason`. Treat the wake as a "go re-check" signal
+and fall back to the authoritative REST check.
+
+**Pattern 2/3 fallback (no broker):** the raw event patterns in this skill use raw
+`github.*` events from `wait-for`, not `filter.wake.*` wakes — `wake-extract` does not apply
+to those paths.
+
 ## Pattern 3 — Reactive PR lifecycle (multi-event wait + classify + dispatch)
 
 Pattern 1's single-event wait is fine for the happy path: the PR merges, the


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T03:45:00Z -->
<!-- Last updated: 2026-05-15T03:45:00Z -->
<!-- PR: #726 -->
<!-- Previous commits: cc57356 -->

## Summary

- **`catalyst-events wake-extract`** — new CLI subcommand that normalizes `filter.wake.*` envelope into a flat JSON object with predictable keys regardless of which source event triggered the wake. Eliminates hand-rolled `jq` paths into `source_events[0].payload_excerpt.*` across skills.
- **`broker/SKILL.md` §10** — complete Wake Event Envelope Reference: canonical on-disk shape, `body.payload` field table, `source_events[]` schema, and per-interest-type reason string catalogue covering all 14 reason patterns across `pr_lifecycle`, `ticket_lifecycle`, and `comms_lifecycle`.
- **`broker/SKILL.md` §4 + §4a** — updated wake event examples from legacy v1 `{event, detail}` shape to canonical OTel `{attributes, body.payload}` form.
- **`monitor-events/SKILL.md`** — added "Reading broker wake payloads" section showing how to use `wake-extract` in a broker listen loop.

## Changes Made

### `plugins/dev/scripts/catalyst-events` (+65 lines)

New `cmd_wake_extract()` bash function:

```bash
# Reads filter.wake.* JSON from stdin (pipe-friendly) or as positional arg
catalyst-events wait-for --filter '...' --timeout 600 \
  | catalyst-events wake-extract

# Output — same shape regardless of source event type:
{
  "event_name": "github.check_suite.completed",
  "interest_id": "sess_abc",
  "reason": "CI failing on PR #342 — check_suite conclusion: failure",
  "pr_number": 342,
  "ticket": null,
  "repo": "org/repo",
  "ci_conclusion": "failure",
  "review_state": null,
  "merged": null,
  "action": null,
  "source_event_id": "uuid-1"
}
```

All fields nullable. `--pretty` flag for human-readable output. Added to `main()` case dispatch and `cmd_help()` usage block.

### `plugins/dev/skills/broker/SKILL.md` (+215 lines, -15 lines)

**§4 and §4a** — Wake event examples updated to canonical OTel envelope. Previously showed the legacy v1 shape (`{event, detail}`) which differed from what the broker actually writes to disk. Both now show the correct `{attributes, body.payload}` form with `source_events[]`.

**§10 Wake Event Envelope Reference** (new) — complete reference covering:
- Full `body.payload` field table
- `source_events[]` element structure with all six `payload_excerpt` keys
- Per-interest-type reason string catalogue (14 patterns)
- `wake-extract` usage with output schema

### `plugins/dev/skills/monitor-events/SKILL.md` (+45 lines)

New "Reading broker wake payloads" section inserted after the Narration section. Shows the canonical pattern for using `wake-extract` in the broker listen loop with `case` branching on `ci_conclusion` / `merged` / `review_state`, plus guidance for empty `source_events` (watchdog wakes) and the fallback note that raw-event Pattern 2/3 paths don't use `wake-extract`.

## How to Verify It

- [x] `bash -n plugins/dev/scripts/catalyst-events` — syntax clean
- [x] CI failure wake: `echo '<ci-failure-json>' | catalyst-events wake-extract | jq '{ci_conclusion,pr_number}'` → `{"ci_conclusion":"failure","pr_number":342}`
- [x] Watchdog wake (empty `source_events`): all nullable fields are `null`, `interest_id` populated
- [x] Ticket lifecycle wake: `ticket=CTL-275` extracted correctly
- [x] Comms lifecycle wake: `action=attention` extracted correctly
- [x] Inline string arg: `catalyst-events wake-extract "$EVENT_JSON"` works
- [x] `--pretty` flag: emits human-readable JSON
- [x] Help text: `catalyst-events help | grep wake-extract` → 3 matches
- [x] No v1 legacy shapes in broker/SKILL.md: `grep '"event": "filter.wake' broker/SKILL.md` → 0 matches
- [x] Canonical shapes present: `grep '"event.name": "filter.wake' broker/SKILL.md` → 3 matches

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-408
- Pairs with CTL-399 (reason strings — adds more state; this normalizes how skills read it)

## Refs

CTL-408
