### PR TITLE
fix(dev): route bare durations to since-filter in HUD query input (CTL-414)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-since.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-since.test.ts
@@ -50,6 +50,32 @@ describe("parseSinceSpec", () => {
     expect(new Date(out!).toISOString().startsWith("2026-05-01")).toBe(true);
   });
 
+  test("strips leading ~ prefix", () => {
+    const out = parseSinceSpec("~30m");
+    expect(out).not.toBeNull();
+    const ageMs = Date.now() - new Date(out!).getTime();
+    expect(ageMs).toBeGreaterThanOrEqual(30 * 60_000 - 100);
+    expect(ageMs).toBeLessThanOrEqual(30 * 60_000 + 100);
+  });
+
+  test("parses compound duration 2h30m", () => {
+    const out = parseSinceSpec("2h30m");
+    expect(out).not.toBeNull();
+    const ageMs = Date.now() - new Date(out!).getTime();
+    const expected = (2 * 3600 + 30 * 60) * 1000;
+    expect(ageMs).toBeGreaterThanOrEqual(expected - 100);
+    expect(ageMs).toBeLessThanOrEqual(expected + 100);
+  });
+
+  test("parses compound duration 1h30m45s", () => {
+    const out = parseSinceSpec("1h30m45s");
+    expect(out).not.toBeNull();
+    const ageMs = Date.now() - new Date(out!).getTime();
+    const expected = (3600 + 30 * 60 + 45) * 1000;
+    expect(ageMs).toBeGreaterThanOrEqual(expected - 100);
+    expect(ageMs).toBeLessThanOrEqual(expected + 100);
+  });
+
   test("returns null for unparseable spec", () => {
     expect(parseSinceSpec("garbage")).toBeNull();
   });

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -58,6 +58,7 @@ const HELP_LINES = [
   "Filters",
   "  /                substring filter — applies to all loaded events",
   "  :                natural-language query via Groq (needs GROQ_API_KEY)",
+  "  :30m / :2h30m    reload events from last N   (bare duration — no 'since' needed)",
   "  :since 24h       reload events from last 24 h  (also: 7d, 2h, 30m, ISO date)",
   "  ?                show generated DSL and active :since window",
   "  S                clear :since window (reset to initial)",
@@ -282,10 +283,11 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
     setQuerySubmitting(true);
     setQueryError(null);
 
-    // :since <spec> — reload events from a different point in time
+    // :since <spec> or bare duration (e.g. ":30m", ":2h30m", ":~1h") — reload from a time window
     const sinceMatch = text.match(/^since\s+(.+)/i);
-    if (sinceMatch) {
-      const spec = (sinceMatch[1] ?? "").trim();
+    const bareDuration = !sinceMatch && /^~?(?:\d+[hmsd])+$/i.test(text);
+    if (sinceMatch || bareDuration) {
+      const spec = sinceMatch ? (sinceMatch[1] ?? "").trim() : text.replace(/^~\s*/, "");
       const parsed = parseSinceSpec(spec);
       if (parsed) {
         setActiveSinceTs(parsed);

--- a/plugins/dev/scripts/orch-monitor/cli/lib/since-spec.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/since-spec.ts
@@ -1,17 +1,28 @@
-/** Parse relative/absolute time specs like "24h", "7d", "30m", ISO dates. */
+/** Parse relative/absolute time specs like "24h", "7d", "30m", "2h30m", ISO dates.
+ *  Accepts an optional leading "~" prefix (e.g. "~30m"). */
 export function parseSinceSpec(raw: string): string | null {
-  const match = raw.match(/^(\d+)\s*(h|m|s|d|hour|min|minute|second|day)s?$/i);
-  if (match) {
-    const n = parseInt(match[1] ?? "0", 10);
-    const unit = (match[2] ?? "s").toLowerCase();
+  const s = raw.trim().replace(/^~\s*/, "");
+  // Simple duration: "30m", "2h", "24h", "7d", "30s", "2hours", etc.
+  const simple = s.match(/^(\d+)\s*(h|m|s|d|hour|min|minute|second|day)s?$/i);
+  if (simple) {
+    const n = parseInt(simple[1] ?? "0", 10);
+    const unit = (simple[2] ?? "s").toLowerCase();
     const ms = unit.startsWith("d") ? n * 86400000
       : unit.startsWith("h") ? n * 3600000
       : unit.startsWith("m") ? n * 60000
       : n * 1000;
     return new Date(Date.now() - ms).toISOString();
   }
+  // Compound duration: "2h30m", "1h15m30s", "30m15s", etc.
+  const compound = s.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (compound && (compound[1] || compound[2] || compound[3])) {
+    const h = parseInt(compound[1] ?? "0", 10);
+    const m = parseInt(compound[2] ?? "0", 10);
+    const sec = parseInt(compound[3] ?? "0", 10);
+    return new Date(Date.now() - (h * 3600000 + m * 60000 + sec * 1000)).toISOString();
+  }
   // Try parsing as an ISO date/datetime string
-  const d = new Date(raw);
+  const d = new Date(s);
   if (!isNaN(d.getTime())) return d.toISOString();
   return null;
 }


### PR DESCRIPTION
## Summary

- Bare durations like `:30m`, `:1h`, `:2h30m` in the HUD query input now route to the since-filter instead of being sent to Groq NLQ
- `parseSinceSpec` now accepts a leading `~` prefix and handles compound durations (e.g. `2h30m`, `1h30m45s`)
- Help text updated to document bare duration shorthand

## Changes

- `hud.tsx`: `submitQuery` detects bare duration patterns (`/^~?(?:\d+[hmsd])+$/i`) and routes them alongside `:since <spec>` to `parseSinceSpec`
- `since-spec.ts`: strips leading `~` prefix; adds compound duration support via a second regex pass
- `hud-since.test.ts`: adds 3 new tests for `~` prefix, `2h30m`, and `1h30m45s`

## Test plan

- [ ] `:30m` → `[since: 30m]` chip appears, events visible (no Groq call)
- [ ] `:1h` → `[since: 1h]` chip appears
- [ ] `:2h30m` → `[since: 2h30m]` chip appears
- [ ] `:since 30m` → still works
- [ ] `:garbage query` → still routes to Groq NLQ
- [ ] `bun test __tests__/hud-since.test.ts` passes (11/11)

Refs: CTL-414