### PR TITLE
fix(dev): enrich filter.wake reasons for check_suite non-success/failure conclusions (CTL-399)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -905,16 +905,18 @@ export function tryDeterministicRoute(event, interestsMap) {
     if (name === "github.check_suite.completed") {
       const eventPrs = Array.isArray(detail.prNumbers) ? detail.prNumbers : [];
       const matchedPr = eventPrs.find((n) => prList.includes(n));
-      if (matchedPr !== undefined) {
-        if (detail.conclusion === "failure") {
-          reason = `CI failing on PR #${matchedPr} — check_suite conclusion: failure`;
-          wakeStateKey = `ci_conclusion:${matchedPr}`;
-          wakeStateValue = "failure";
-        } else if (detail.conclusion === "success") {
-          reason = `All CI checks passing on PR #${matchedPr}`;
-          wakeStateKey = `ci_conclusion:${matchedPr}`;
-          wakeStateValue = "success";
+      if (matchedPr !== undefined && detail.conclusion != null) {
+        const isFailing =
+          detail.conclusion === "failure" ||
+          detail.conclusion === "timed_out" ||
+          detail.conclusion === "action_required";
+        if (isFailing) {
+          reason = `CI failing on PR #${matchedPr} — check_suite conclusion: ${detail.conclusion}`;
+        } else {
+          reason = `All CI checks passing on PR #${matchedPr} — conclusion: ${detail.conclusion}`;
         }
+        wakeStateKey = `ci_conclusion:${matchedPr}`;
+        wakeStateValue = detail.conclusion;
       }
     } else if (name === "github.pr.merged") {
       if (prList.includes(scope.pr)) {

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -1264,6 +1264,7 @@ describe("backward compat: pr_lifecycle routing unchanged in broker", () => {
     );
     expect(matches).toHaveLength(1);
     expect(matches[0].reason).toContain("CI checks passing");
+    expect(matches[0].reason).toContain("conclusion: success");
     expect(matches[0].wakeStateKey).toBe("ci_conclusion:502");
     expect(matches[0].wakeStateValue).toBe("success");
   });
@@ -1291,6 +1292,31 @@ describe("backward compat: pr_lifecycle routing unchanged in broker", () => {
     expect(matches[0].wakeStateValue).toBe("failure");
   });
 
+  test("github.check_suite.completed timed_out fires with CI failing reason (CTL-399)", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-bc",
+      detail: {
+        interest_id: "ci-watch-timeout",
+        notify_event: "filter.wake.ci-watch-timeout",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [506],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+    const matches = tryDeterministicRoute({
+      event: "github.check_suite.completed",
+      detail: { prNumbers: [506], conclusion: "timed_out" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("CI failing");
+    expect(matches[0].reason).toContain("timed_out");
+    expect(matches[0].wakeStateKey).toBe("ci_conclusion:506");
+    expect(matches[0].wakeStateValue).toBe("timed_out");
+  });
+
   test("non-CI events have wakeStateKey null (always emit)", () => {
     handleRegister({
       event: "filter.register",
@@ -1312,6 +1338,52 @@ describe("backward compat: pr_lifecycle routing unchanged in broker", () => {
     }, getInterests());
     expect(matches).toHaveLength(1);
     expect(matches[0].wakeStateKey).toBeNull();
+  });
+
+  test("github.check_suite.completed neutral fires with CI checks passing reason (CTL-399)", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-bc",
+      detail: {
+        interest_id: "ci-watch-neutral",
+        notify_event: "filter.wake.ci-watch-neutral",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [507],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+    const matches = tryDeterministicRoute({
+      event: "github.check_suite.completed",
+      detail: { prNumbers: [507], conclusion: "neutral" },
+    }, getInterests());
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("CI checks passing");
+    expect(matches[0].reason).toContain("neutral");
+    expect(matches[0].wakeStateKey).toBe("ci_conclusion:507");
+    expect(matches[0].wakeStateValue).toBe("neutral");
+  });
+
+  test("github.check_suite.completed null conclusion does not fire (CTL-399)", () => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-bc",
+      detail: {
+        interest_id: "ci-watch-null",
+        notify_event: "filter.wake.ci-watch-null",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [508],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+      },
+    });
+    const matches = tryDeterministicRoute({
+      event: "github.check_suite.completed",
+      detail: { prNumbers: [508], conclusion: null },
+    }, getInterests());
+    expect(matches).toHaveLength(0);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -412,6 +412,52 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
     expect(env!.attributes["event.action"]).toBe("state_changed");
   });
 
+  it("state_changed event forwards toState into body.payload (CTL-399)", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "update",
+        topic: "linear.issue.state_changed",
+        ticket: "CTL-1",
+        teamKey: "CTL",
+        data: {},
+        updatedFromKeys: ["stateId"],
+        actorId: null,
+        actorName: null,
+        toState: "In Review",
+        toPriority: null,
+        toAssigneeId: null,
+        toAssigneeName: null,
+      },
+      TS,
+    );
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload["toState"]).toBe("In Review");
+  });
+
+  it("state_changed event with null toState has toState null in payload (CTL-399)", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "update",
+        topic: "linear.issue.state_changed",
+        ticket: "CTL-1",
+        teamKey: "CTL",
+        data: {},
+        updatedFromKeys: ["stateId"],
+        actorId: null,
+        actorName: null,
+        toState: null,
+        toPriority: null,
+        toAssigneeId: null,
+        toAssigneeName: null,
+      },
+      TS,
+    );
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload["toState"]).toBeNull();
+  });
+
   it("Issue event includes actorId in body.payload + attributes when actor is present", () => {
     const env = buildLinearEventLogEnvelope(
       {


### PR DESCRIPTION
## Summary

- Handle all non-null `check_suite.completed` conclusions (`timed_out`, `action_required`, `neutral`, `cancelled`, etc.) in `tryDeterministicRoute` — previously only `failure` and `success` woke subscribers; other conclusions silently dropped the wake
- Include the actual `conclusion` value in the success reason string (e.g. `"All CI checks passing on PR #123 — conclusion: success"`) so workers can read the conclusion without a `gh api` re-query
- Wire `wakeStateKey`/`wakeStateValue` (CTL-407 dedup) to `detail.conclusion` for all non-null conclusions

Note: the Linear state `"unknown"` bug was already fixed in CTL-424 (#721). This PR scopes to the CI-flip improvements only.

Refs: CTL-399

## Test plan

- [x] Broker tests: 207 pass (new tests for `timed_out`, `neutral`, `null` conclusions, `wakeStateKey` for non-standard conclusions)
- [x] Linear webhook handler tests: 41 pass (updated CTL-399 tests to use `toState` per CTL-424 type changes)
- [x] No conflict markers; clean rebase onto main after CTL-424 merged