### PR TITLE
fix(dev): reject range operators on wrong-typed fields in NLQ DSL (CTL-415)

### DIFF
--- a/plugins/dev/scripts/lib/dsl-compile.d.mts
+++ b/plugins/dev/scripts/lib/dsl-compile.d.mts
@@ -2,7 +2,7 @@
 // runtime module. The TUI consumes these; the bash CLI does not need types.
 
 export class DslError extends Error {
-  code: "invalid" | "unknown_field" | "refused" | "groq_rejected";
+  code: "invalid" | "unknown_field" | "type_mismatch" | "refused" | "groq_rejected";
   field?: string;
   suggestion?: string | null;
   constructor(message: string, opts?: { code?: DslError["code"]; field?: string; suggestion?: string | null });
@@ -49,7 +49,10 @@ export interface CompiledDsl {
   jsPredicate: (event: unknown) => boolean;
 }
 
-export function validateField(path: string): { ok: true } | { ok: false; error: string; suggestion: string | null };
+export function validateField(
+  path: string,
+  opts?: { operator?: string; value?: unknown },
+): { ok: true } | { ok: false; code?: string; error: string; suggestion: string | null };
 export function getField(event: unknown, path: string): unknown;
 export function evalJs(node: DslNode, event: unknown): boolean;
 export function compileJq(node: DslNode): string;
@@ -74,4 +77,5 @@ export function rewriteNode<T>(node: T): T;
 
 export const CANONICAL_FIELDS: ReadonlyArray<{ path: string; type: string; description: string }>;
 export const FIELD_PATH_SET: ReadonlySet<string>;
+export const TIME_FIELDS: ReadonlySet<string>;
 export function suggestField(path: string, maxDistance?: number): string | null;

--- a/plugins/dev/scripts/lib/dsl-compile.mjs
+++ b/plugins/dev/scripts/lib/dsl-compile.mjs
@@ -12,6 +12,8 @@ import {
   FIELD_PATH_SET,
   isWhitelistedField,
   suggestField,
+  getFieldMeta,
+  TIME_FIELDS,
 } from "./dsl-fields.mjs";
 
 // ─── Errors ──────────────────────────────────────────────────────────────────
@@ -50,18 +52,43 @@ export class GroqResponseError extends Error {
 
 // ─── Field validation ────────────────────────────────────────────────────────
 
-export function validateField(path) {
+const RANGE_OPS = new Set(["gt", "gte", "lt", "lte"]);
+const ISO_TS_RE = /^\d{4}-\d{2}-\d{2}T/;
+
+// validateField(path, opts?) — whitelist check + optional type-operator check.
+// opts.operator / opts.value enable rejecting range operators on enum fields or
+// timestamp values on non-time fields (CTL-415).
+export function validateField(path, opts) {
   if (typeof path !== "string" || path.length === 0) {
     return { ok: false, error: "field must be a non-empty string", suggestion: null };
   }
-  if (isWhitelistedField(path)) {
-    return { ok: true };
+  if (!isWhitelistedField(path)) {
+    return {
+      ok: false,
+      error: `unknown field: ${path}`,
+      suggestion: suggestField(path),
+    };
   }
-  return {
-    ok: false,
-    error: `unknown field: ${path}`,
-    suggestion: suggestField(path),
-  };
+  if (opts?.operator && RANGE_OPS.has(opts.operator)) {
+    const meta = getFieldMeta(path);
+    if (meta?.type === "enum") {
+      return {
+        ok: false,
+        code: "type_mismatch",
+        error: `field "${path}" has type "enum" — range operators (${opts.operator}) are not supported; did you mean "ts"?`,
+        suggestion: "ts",
+      };
+    }
+    if (typeof opts.value === "string" && ISO_TS_RE.test(opts.value) && !TIME_FIELDS.has(path)) {
+      return {
+        ok: false,
+        code: "type_mismatch",
+        error: `timestamp value applied to field "${path}" — use "ts" for time-based comparisons`,
+        suggestion: "ts",
+      };
+    }
+  }
+  return { ok: true };
 }
 
 // ─── Path access (JS evaluator helper) ───────────────────────────────────────
@@ -173,9 +200,10 @@ function compileLeaf(leaf) {
   if (typeof leaf.field !== "string") {
     throw new DslError("leaf node missing 'field'", { code: "invalid" });
   }
-  const v = validateField(leaf.field);
+  const rangeOp = ["gt", "gte", "lt", "lte"].find((o) => o in leaf);
+  const v = validateField(leaf.field, rangeOp ? { operator: rangeOp, value: leaf[rangeOp] } : undefined);
   if (!v.ok) {
-    throw new DslError(v.error, { code: "unknown_field", field: leaf.field, suggestion: v.suggestion });
+    throw new DslError(v.error, { code: v.code ?? "unknown_field", field: leaf.field, suggestion: v.suggestion });
   }
   const path = `.${leaf.field}`;
   if ("eq" in leaf)  return `(${path} == ${jqLiteral(leaf.eq)})`;
@@ -371,4 +399,4 @@ async function safeText(res) {
 }
 
 // Re-export so the test file and the CLI have one import path.
-export { CANONICAL_FIELDS, FIELD_PATH_SET, suggestField };
+export { CANONICAL_FIELDS, FIELD_PATH_SET, TIME_FIELDS, suggestField };

--- a/plugins/dev/scripts/lib/dsl-compile.test.mjs
+++ b/plugins/dev/scripts/lib/dsl-compile.test.mjs
@@ -32,8 +32,8 @@ import {
 
 describe("CANONICAL_FIELDS whitelist", () => {
   test("contains the documented count of canonical fields", () => {
-    expect(CANONICAL_FIELDS.length).toBe(32);
-    expect(FIELD_PATH_SET.size).toBe(32);
+    expect(CANONICAL_FIELDS.length).toBe(38);
+    expect(FIELD_PATH_SET.size).toBe(38);
   });
 
   test("includes core attribute paths", () => {
@@ -87,6 +87,99 @@ describe("validateField", () => {
     expect(validateField(null).ok).toBe(false);
     expect(validateField(undefined).ok).toBe(false);
     expect(validateField(42).ok).toBe(false);
+  });
+});
+
+// ─── CTL-415 — type-operator validation ──────────────────────────────────────
+
+describe("validateField type-operator validation (CTL-415)", () => {
+  const TS = "2026-05-14T22:43:48.461Z";
+
+  test("accepts range operator on ts (time field)", () => {
+    expect(validateField("ts", { operator: "gte", value: TS }).ok).toBe(true);
+    expect(validateField("ts", { operator: "lt", value: TS }).ok).toBe(true);
+  });
+
+  test("accepts range operator on observedTs (time field)", () => {
+    expect(validateField("observedTs", { operator: "gte", value: TS }).ok).toBe(true);
+  });
+
+  test("accepts range operator on numeric field", () => {
+    expect(validateField("severityNumber", { operator: "gte", value: 9 }).ok).toBe(true);
+    expect(validateField('attributes."vcs.pr.number"', { operator: "gt", value: 300 }).ok).toBe(true);
+  });
+
+  test("rejects range operator on enum field regardless of value", () => {
+    const r = validateField("severityText", { operator: "gte", value: TS });
+    expect(r.ok).toBe(false);
+    expect(r.suggestion).toBe("ts");
+    expect(r.error).toContain("enum");
+  });
+
+  test("rejects range operator on enum field with non-timestamp value", () => {
+    const r = validateField("severityText", { operator: "gt", value: "INFO" });
+    expect(r.ok).toBe(false);
+    expect(r.suggestion).toBe("ts");
+  });
+
+  test("rejects timestamp value on non-time string field (traceId)", () => {
+    const r = validateField("traceId", { operator: "gte", value: TS });
+    expect(r.ok).toBe(false);
+    expect(r.suggestion).toBe("ts");
+    expect(r.error).toContain("timestamp");
+  });
+
+  test("rejects timestamp value on non-time string field (spanId)", () => {
+    const r = validateField("spanId", { operator: "gte", value: TS });
+    expect(r.ok).toBe(false);
+    expect(r.suggestion).toBe("ts");
+  });
+
+  test("eq operator bypasses type check — any field may use eq", () => {
+    expect(validateField("severityText", { operator: "eq", value: TS }).ok).toBe(true);
+  });
+
+  test("no opts — backward-compatible (whitelist-only check)", () => {
+    expect(validateField("severityText").ok).toBe(true);
+    expect(validateField("ts").ok).toBe(true);
+  });
+});
+
+describe("compileJq type-operator rejection (CTL-415)", () => {
+  const TS = "2026-05-14T22:43:48.461Z";
+
+  test("rejects timestamp gte on severityText with suggestion 'ts'", () => {
+    let err;
+    try { compileJq({ field: "severityText", gte: TS }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(DslError);
+    expect(err.suggestion).toBe("ts");
+    expect(err.message).toContain("enum");
+  });
+
+  test("rejects timestamp gte on traceId", () => {
+    let err;
+    try { compileJq({ field: "traceId", gte: TS }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(DslError);
+    expect(err.suggestion).toBe("ts");
+  });
+
+  test("rejects timestamp gte on spanId", () => {
+    let err;
+    try { compileJq({ field: "spanId", gte: TS }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(DslError);
+    expect(err.suggestion).toBe("ts");
+  });
+
+  test("accepts timestamp gte on ts", () => {
+    expect(() => compileJq({ field: "ts", gte: TS })).not.toThrow();
+  });
+
+  test("accepts timestamp gte on observedTs", () => {
+    expect(() => compileJq({ field: "observedTs", gte: TS })).not.toThrow();
+  });
+
+  test("accepts non-timestamp gte on a string field (traceId)", () => {
+    expect(() => compileJq({ field: "traceId", gt: "" })).not.toThrow();
   });
 });
 

--- a/plugins/dev/scripts/lib/dsl-fields.mjs
+++ b/plugins/dev/scripts/lib/dsl-fields.mjs
@@ -109,3 +109,11 @@ export function suggestField(path, maxDistance = 4) {
   }
   return bestDist <= maxDistance ? best : null;
 }
+
+export function getFieldMeta(path) {
+  return CANONICAL_FIELDS.find((f) => f.path === path) ?? null;
+}
+
+// Fields whose values are ISO 8601 timestamps — the only string fields that
+// accept range comparisons (gt/gte/lt/lte) with timestamp values.
+export const TIME_FIELDS = new Set(["ts", "observedTs"]);


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T04:00:00Z -->
<!-- Last updated: 2026-05-15T04:00:00Z -->
<!-- PR: #729 -->
<!-- Previous commits: b65928ea1f846391cb174196e9d26afd59dc841a -->

## Summary

Fixes a bug where the NLQ (Natural Language Query) model occasionally hallucinates `severityText` (or other non-time fields) as the field for time-based queries, producing a predicate that silently returns 0 results.

**Root cause:** The `validateField()` function only checked whitelist membership — it didn't validate that a time value was being compared against a time-typed field. So `{ field: "severityText", gte: "2026-05-14T22:43:48.461Z" }` passed validation even though `severityText` values (`DEBUG`/`INFO`/`WARN`/`ERROR`) sort lexicographically before any ISO date string, making the predicate always false.

**Fix (two-part):**
1. `validateField()` now accepts an optional `{ operator, value }` context and rejects range operators (`gt/gte/lt/lte`) on `enum`-typed fields
2. It also rejects timestamp-shaped values on string fields that are not designated time fields (`ts`, `observedTs`)

When rejected, the user sees a clear error in the HUD query overlay: `field "severityText" has type "enum" — range operators (gte) are not supported; did you mean "ts"?`

## Changes

### `plugins/dev/scripts/lib/dsl-fields.mjs`
- Added `getFieldMeta(path)` — returns the full field metadata object (including `type`) for a path
- Added `TIME_FIELDS` set — `{ "ts", "observedTs" }` — the only string fields that should accept ISO timestamp range comparisons

### `plugins/dev/scripts/lib/dsl-compile.mjs`
- `validateField(path, opts?)` — extended with optional `{ operator, value }` context:
  - `enum`-typed fields reject range operators regardless of value (catches `severityText gte "..."`)
  - Non-time string fields reject ISO timestamp values with range operators (catches `traceId gte "2026-..."`)
  - Both return `{ code: "type_mismatch", suggestion: "ts" }` for user-visible error + suggestion
- `compileLeaf()` — detects the range operator in use and passes it with its value to `validateField`
- Added `TIME_FIELDS` to the re-export at the bottom

### `plugins/dev/scripts/lib/dsl-compile.d.mts`
- Added `"type_mismatch"` to `DslError.code` union type
- Updated `validateField` signature to include optional `opts` parameter
- Added `TIME_FIELDS` export

### `plugins/dev/scripts/lib/dsl-compile.test.mjs`
- Updated field count assertion from 32 → 38 (other tickets in branch added fields)
- Added `describe("validateField type-operator validation (CTL-415)")` — 9 tests covering:
  - Accepts range ops on `ts`, `observedTs`, numeric fields
  - Rejects range ops on `enum` fields (with and without timestamp values)
  - Rejects timestamp values on non-time string fields (`traceId`, `spanId`)
  - `eq` bypasses type check (valid on any field)
  - No-opts call is backward compatible
- Added `describe("compileJq type-operator rejection (CTL-415)")` — 6 tests covering:
  - `compileJq` rejects bad combos with `DslError` + `suggestion: "ts"`
  - `compileJq` accepts valid combos without throwing

## How to Verify

- [x] `bun test plugins/dev/scripts/lib/dsl-compile.test.mjs` — 90 tests, 0 failures
- [x] `bun test plugins/dev/scripts/lib/dsl-prompt.test.mjs` — 17 tests, 0 failures
- [x] End-to-end: `compile({ filter: { field: "severityText", gte: "2026-..." } })` throws `DslError` with `suggestion: "ts"`
- [x] End-to-end: `compile({ filter: { field: "ts", gte: "2026-..." } })` compiles correctly

## Acceptance Criteria (from ticket)

- ✅ NLQ for "30m ago", "last hour", "since 5pm" produces `{field: "ts", gte: "<ISO>"}` or gets rejected with a clear error directing to `ts`
- ✅ Invalid field+operator combos are rejected with a clear error shown in the query overlay
- ✅ Test: `severityText gte <timestamp>` → `DslError` with `suggestion: "ts"`

Fixes: CTL-415
