### PR TITLE
fix(dev): apply wrap=truncate to all HUD columns to eliminate ghost chars (CTL-416)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/EventRow.tsx
@@ -31,6 +31,9 @@ interface EventRowProps {
 // CTL-395: explicit `width={w.details}` replaces `flexGrow={1}` so Ink pads
 // the cell to a fixed width and writes trailing spaces over any ghost chars
 // left by a prior longer string.
+// CTL-416: all columns now use wrap="truncate" (via col.wrap or the ?? fallback
+// in EventRow) so Ink writes exactly col.width chars per cell on every render,
+// overwriting stale terminal chars when shorter content replaces longer content.
 // CTL-394: columns are now data-driven via resolveColumns() — EventRow
 // iterates the resolved list so custom column order/visibility/widths from
 // ~/.config/catalyst/monitor.json are honoured without touching this file.
@@ -57,7 +60,7 @@ export function EventRow({ event, selected, columns, paused = true, wrapMode = '
       {resolved.map((col) => {
         const isDetails = col.id === "details";
         const text = col.id === "ref" ? displayRef : col.format(event);
-        const wrap = isDetails ? wrapMode : col.wrap;
+        const wrap = isDetails ? wrapMode : (col.wrap ?? "truncate");
         return (
           <Box key={col.id} width={col.width} flexShrink={0} marginRight={isDetails ? 0 : 1}>
             <Text color={color} inverse={inverse} wrap={wrap} dimColor={col.dimColor}>

--- a/plugins/dev/scripts/orch-monitor/cli/components/event-row.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/event-row.test.ts
@@ -5,10 +5,17 @@
 // this mirror updating — they are intentionally adjacent in the file tree.
 
 import { describe, test, expect } from "bun:test";
+import { COLUMN_DESCRIPTORS } from "../lib/columns.ts";
 
 // Mirror of EventRow.tsx: DETAILS <Text> uses wrap={wrapMode}; default 'truncate'.
 function detailsWrap(wrapMode: 'truncate' | 'wrap' = 'truncate'): 'truncate' | 'wrap' {
   return wrapMode;
+}
+
+// Mirror of EventRow.tsx line 60: `col.wrap ?? "truncate"`.
+// All non-DETAILS columns must resolve to "truncate" to prevent ghost chars (CTL-416).
+function effectiveWrap(colWrap: 'truncate' | 'wrap' | undefined): 'truncate' | 'wrap' {
+  return colWrap ?? 'truncate';
 }
 
 describe("EventRow wrapMode prop (CTL-384)", () => {
@@ -22,5 +29,15 @@ describe("EventRow wrapMode prop (CTL-384)", () => {
 
   test("wrapMode='wrap' passes through as wrap", () => {
     expect(detailsWrap('wrap')).toBe('wrap');
+  });
+});
+
+describe("EventRow column wrap — no ghost chars (CTL-416)", () => {
+  test("all non-DETAILS columns resolve to truncate via col.wrap or fallback", () => {
+    for (const [id, desc] of Object.entries(COLUMN_DESCRIPTORS)) {
+      if (id === "details") continue; // DETAILS wrap is controlled by wrapMode prop
+      const resolved = effectiveWrap(desc.wrap);
+      expect(resolved, `column '${id}' must resolve to truncate to prevent ghost chars`).toBe('truncate');
+    }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/columns.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/columns.ts
@@ -26,7 +26,7 @@ export interface ColumnDescriptor {
   computeWidth: (terminalCols: number) => number;
   /** Format function for row cells. */
   format: (event: CanonicalEvent) => string;
-  /** Ink Text wrap mode. Defaults to Ink's default ("wrap") when absent. */
+  /** Ink Text wrap mode. EventRow defaults to "truncate" when absent (CTL-416). */
   wrap?: "truncate" | "wrap";
   /** Render cell text dimmed. */
   dimColor?: boolean;
@@ -42,6 +42,7 @@ export const COLUMN_DESCRIPTORS: Record<string, ColumnDescriptor> = {
     minTerminalWidth: 100,
     computeWidth: () => 3,
     format: formatStatus,
+    wrap: "truncate",
   },
   time: {
     id: "time",
@@ -50,6 +51,7 @@ export const COLUMN_DESCRIPTORS: Record<string, ColumnDescriptor> = {
     minTerminalWidth: 0,
     computeWidth: () => 10,
     format: formatTime,
+    wrap: "truncate",
   },
   repo: {
     id: "repo",
@@ -58,6 +60,7 @@ export const COLUMN_DESCRIPTORS: Record<string, ColumnDescriptor> = {
     minTerminalWidth: 0,
     computeWidth: (cols) => Math.min(14, Math.max(10, Math.floor(cols * 0.07))),
     format: formatRepo,
+    wrap: "truncate",
   },
   icon: {
     id: "icon",
@@ -68,6 +71,7 @@ export const COLUMN_DESCRIPTORS: Record<string, ColumnDescriptor> = {
     minTerminalWidth: 0,
     computeWidth: () => 1,
     format: formatIcon,
+    wrap: "truncate",
   },
   event: {
     id: "event",
@@ -88,6 +92,7 @@ export const COLUMN_DESCRIPTORS: Record<string, ColumnDescriptor> = {
     minTerminalWidth: 0,
     computeWidth: (cols) => Math.min(20, Math.max(10, Math.floor(cols * 0.08))),
     format: formatRef,
+    wrap: "truncate",
   },
   orch: {
     id: "orch",
@@ -106,6 +111,7 @@ export const COLUMN_DESCRIPTORS: Record<string, ColumnDescriptor> = {
     minTerminalWidth: 180,
     computeWidth: () => 16,
     format: formatWorker,
+    wrap: "truncate",
   },
   details: {
     id: "details",


### PR DESCRIPTION
## Changes

- Apply `wrap="truncate"` to all column descriptors that were missing it (`status`, `time`, `repo`, `icon`, `ref`, `worker`)
- Add `?? "truncate"` fallback in `EventRow.tsx` so future column descriptors default to truncate
- Add test asserting every non-DETAILS column resolves to `"truncate"`

## Background

CTL-395 fixed ghost chars in the DETAILS column by replacing `flexGrow={1}` with an explicit `width`. The root cause of ghost chars is that Ink must write exactly `col.width` characters per cell on every render — without `wrap="truncate"`, Ink renders only the content length and doesn't pad to the full column width. When shorter content replaces longer content, the previous terminal characters remain visible.

EVENT and ORCH already had `wrap: "truncate"` in their descriptors; the remaining 6 columns did not.

Refs: CTL-416