### PR TITLE
fix(dev): add retry loop to broker_claim_pr and broker_register_comms (CTL-429)

### DIFF
--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -205,11 +205,23 @@ broker_daemon_running() {
   { catalyst-broker status 2>/dev/null || catalyst-filter status 2>/dev/null; } | grep -q "^running"
 }
 
+# CTL-429: retry wrapper — daemon may be starting up or momentarily unavailable.
+# Tries up to 3 times with 2s gaps before declaring the daemon absent.
+wait_for_broker_ready() {
+  local max_attempts=3 attempt=0
+  while [ $attempt -lt $max_attempts ]; do
+    broker_daemon_running && return 0
+    attempt=$((attempt + 1))
+    [ $attempt -lt $max_attempts ] && sleep 2
+  done
+  return 1
+}
+
 # CTL-303: update claimed_pr in the broker via a second agent.checkin.
 # The broker auto-derives pr_lifecycle from the check-in — no explicit filter.register needed.
 broker_claim_pr() {
   # Args: $1 = PR_NUMBER, $2 = TICKET_ID, $3 = BRANCH_NAME, $4 = REPO (org/name), $5 = BASE_BRANCH (default: main)
-  broker_daemon_running || return 1
+  wait_for_broker_ready || return 1
   [ -n "${CATALYST_SESSION_ID:-}" ] || return 1
   local pr="$1" ticket="$2" repo="$4" base="${5:-main}"
   local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -262,7 +274,7 @@ filter_deregister_worker() {
 # notify_event = filter.wake.${CATALYST_SESSION_ID}, so the Phase 5 listen
 # loop predicate is unchanged. Best-effort; broker absence is fine.
 broker_register_comms() {
-  broker_daemon_running || return 0
+  wait_for_broker_ready || return 0
   [ -n "${CATALYST_SESSION_ID:-}" ] || return 0
   [ -n "${CATALYST_COMMS_CHANNEL:-}" ] || return 0
   [ -n "${TICKET_ID:-}" ] || return 0


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T04:14:00Z -->
<!-- Last updated: 2026-05-15T04:14:00Z -->
<!-- PR: #731 -->
<!-- Previous commits: b865f66 -->

## Summary

Fixes a silent registration drop in the oneshot skill's broker integration. When the broker daemon was momentarily unavailable (starting up, restarting), `broker_claim_pr()` and `broker_register_comms()` would silently return without emitting the `agent.checkin` / `filter.register` events to the JSONL log. Workers' interests were never registered and they would never receive `filter.wake` events for their PR.

The fix adds a `wait_for_broker_ready()` helper that retries `broker_daemon_running` up to 3 times with 2-second gaps before giving up, covering the race condition where the daemon is starting up concurrently with the worker.

## Changes Made

### Skill: `plugins/dev/skills/oneshot/SKILL.md`

- **Added `wait_for_broker_ready()` helper** (after `broker_daemon_running()`): retries the daemon liveness check up to 3 times with 2-second intervals before returning failure.
- **`broker_claim_pr()`**: replaced `broker_daemon_running || return 1` with `wait_for_broker_ready || return 1` — same failure semantics, but tolerates a slow-starting daemon.
- **`broker_register_comms()`**: replaced `broker_daemon_running || return 0` with `wait_for_broker_ready || return 0` — same best-effort semantics.
- **`filter_deregister_worker()`**: unchanged — deregistration is fire-and-forget; retrying it provides no value.

## How to Verify It

- [ ] Manually: stop the broker daemon, start a oneshot worker, then start the broker within 4s — verify the interest appears in `~/catalyst/broker-interests.json`
- [ ] Inspect the oneshot SKILL.md diff: `wait_for_broker_ready` is called in exactly 2 places (broker_claim_pr and broker_register_comms); broker_daemon_running is called by the helper and by filter_daemon_running/filter_deregister_worker unchanged.

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-429

## Notes

`filter_deregister_worker()` intentionally retains the bare `broker_daemon_running || return 0` guard. Deregistration is best-effort by design — if the daemon isn't running there's nothing to deregister from, and adding a retry delay on teardown would just slow down session exit.