### PR TITLE
feat(dev): per-event-class DETAILS formatting for GitHub and Linear events (CTL-418)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-row.test.tsx
@@ -29,7 +29,7 @@ const longDetailsEvent: CanonicalEvent = {
     "service.version": "0.0.0",
   },
   attributes: {
-    "event.name": "github.pr.merged",
+    "event.name": "orchestrator.worker.done",
     "vcs.repository.name": "coalesce-labs/catalyst",
     "vcs.pr.number": 501,
   },

--- a/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/hud-format.test.ts
@@ -481,27 +481,34 @@ describe("formatRef (filter.wake)", () => {
   });
 });
 
+// Generic fallback event — does not match any specific handler added in CTL-418.
+// Using orchestrator.worker.done so tests exercise the generic fallback path.
+const genericEvent: CanonicalEvent = {
+  ...baseEvent,
+  attributes: { ...baseEvent.attributes, "event.name": "orchestrator.worker.done" },
+};
+
 describe("formatDetails", () => {
   test("returns payload title when present", () => {
-    const e = { ...baseEvent, body: { message: "ignored", payload: { title: "feat: add thing" } } };
+    const e = { ...genericEvent, body: { message: "ignored", payload: { title: "feat: add thing" } } };
     expect(formatDetails(e)).toBe("feat: add thing");
   });
 
   test("returns message when no payload title", () => {
-    const e = { ...baseEvent, body: { message: "Something happened", payload: {} } };
+    const e = { ...genericEvent, body: { message: "Something happened", payload: {} } };
     expect(formatDetails(e)).toBe("Something happened");
   });
 
   test("returns long messages in full (scrollable detail pane handles overflow)", () => {
     const long = "x".repeat(100);
-    const e = { ...baseEvent, body: { message: long } };
+    const e = { ...genericEvent, body: { message: long } };
     expect(formatDetails(e)).toBe(long);
   });
 });
 
 describe("formatDetails (sanitizer)", () => {
   function withMessage(msg: string): CanonicalEvent {
-    return { ...baseEvent, body: { message: msg, payload: {} } };
+    return { ...genericEvent, body: { message: msg, payload: {} } };
   }
 
   test("decodes named HTML entities", () => {
@@ -597,7 +604,7 @@ describe("formatDetails (sanitizer)", () => {
 
   test("sanitizes payload.title", () => {
     const e = {
-      ...baseEvent,
+      ...genericEvent,
       body: { message: "ignored", payload: { title: "## <strong>feat</strong>: thing" } },
     };
     expect(formatDetails(e)).toBe("feat: thing");
@@ -605,7 +612,7 @@ describe("formatDetails (sanitizer)", () => {
 
   test("sanitizes payload.body and truncates the raw input at 300 chars before cleanup", () => {
     const raw = "x".repeat(295) + "<p>tail</p>";
-    const e = { ...baseEvent, body: { message: "", payload: { body: raw } } };
+    const e = { ...genericEvent, body: { message: "", payload: { body: raw } } };
     const out = formatDetails(e);
     // First 295 'x', then sanitised slice of the rest within the 300-char raw window.
     expect(out.startsWith("x".repeat(295))).toBe(true);
@@ -621,7 +628,7 @@ describe("formatDetails (sanitizer)", () => {
   });
 
   test("returns empty string when body is missing", () => {
-    const e = { ...baseEvent, body: undefined } as unknown as CanonicalEvent;
+    const e = { ...genericEvent, body: undefined } as unknown as CanonicalEvent;
     expect(formatDetails(e)).toBe("");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.test.ts
@@ -1,9 +1,29 @@
-// CTL-419: unit tests for formatDetails wake-event rendering.
-// Tests cover the batched stale_sessions payload and the recipient-short suffix
-// appended to all filter.wake.* DETAILS cells.
+// format.test.ts — unit tests for per-event-class DETAILS formatting.
+// CTL-418: github/linear structured details
+// CTL-419: filter.wake wake-event rendering with recipient-short suffix
+
 import { describe, test, expect } from "bun:test";
 import { formatDetails, formatRef } from "./format";
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
+
+function makeEvent(
+  name: string,
+  attributes: Record<string, unknown> = {},
+  payload?: unknown,
+  message?: string,
+): CanonicalEvent {
+  return {
+    ts: "2026-05-14T00:00:00.000Z",
+    id: "test-id",
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: null,
+    spanId: null,
+    resource: { "service.name": "catalyst", "service.namespace": "catalyst", "service.version": "0.0.0" },
+    attributes: { "event.name": name, ...attributes } as CanonicalEvent["attributes"],
+    body: { message, payload },
+  };
+}
 
 function makeWakeEvent(
   recipientSessId: string,
@@ -22,6 +42,141 @@ function makeWakeEvent(
     body: { payload },
   } as unknown as CanonicalEvent;
 }
+
+describe("formatDetails — github.pr.* (CTL-418)", () => {
+  test("merged: PR #N merged (event.name suffix is canonical)", () => {
+    const ev = makeEvent("github.pr.merged", { "vcs.pr.number": 724 });
+    expect(formatDetails(ev)).toBe("PR #724 merged");
+  });
+
+  test("opened: PR #N opened", () => {
+    const ev = makeEvent("github.pr.opened", { "vcs.pr.number": 723 });
+    expect(formatDetails(ev)).toBe("PR #723 opened");
+  });
+
+  test("synchronize → pushed", () => {
+    const ev = makeEvent("github.pr.synchronize", { "vcs.pr.number": 700 });
+    expect(formatDetails(ev)).toBe("PR #700 pushed");
+  });
+
+  test("ready_for_review → ready", () => {
+    const ev = makeEvent("github.pr.ready_for_review", { "vcs.pr.number": 701 });
+    expect(formatDetails(ev)).toBe("PR #701 ready");
+  });
+
+  test("closed (not merged)", () => {
+    const ev = makeEvent("github.pr.closed", { "vcs.pr.number": 702 });
+    expect(formatDetails(ev)).toBe("PR #702 closed");
+  });
+
+  test("falls back to generic when no pr number", () => {
+    const ev = makeEvent("github.pr.merged", {}, undefined, "github.pr.merged for org/repo PR #99");
+    expect(formatDetails(ev)).toBe("github.pr.merged for org/repo PR #99");
+  });
+});
+
+describe("formatDetails — github.check_suite.* (CTL-418)", () => {
+  test("success from attributes", () => {
+    const ev = makeEvent("github.check_suite.completed", {
+      "cicd.pipeline.run.conclusion": "success",
+    });
+    expect(formatDetails(ev)).toBe("CI: success");
+  });
+
+  test("failure from attributes", () => {
+    const ev = makeEvent("github.check_suite.completed", {
+      "cicd.pipeline.run.conclusion": "failure",
+    });
+    expect(formatDetails(ev)).toBe("CI: failure");
+  });
+
+  test("conclusion from payload when attribute absent", () => {
+    const ev = makeEvent("github.check_suite.completed", {}, { conclusion: "timed_out" });
+    expect(formatDetails(ev)).toBe("CI: timed_out");
+  });
+
+  test("falls back to generic when no conclusion", () => {
+    const ev = makeEvent("github.check_suite.completed", {}, undefined, "github.check_suite.completed for repo");
+    expect(formatDetails(ev)).toBe("github.check_suite.completed for repo");
+  });
+});
+
+describe("formatDetails — github.workflow_run.* (CTL-418)", () => {
+  test("workflow name + conclusion", () => {
+    const ev = makeEvent("github.workflow_run.completed", {
+      "cicd.pipeline.name": "Deploy Website",
+      "cicd.pipeline.run.conclusion": "success",
+    });
+    expect(formatDetails(ev)).toBe("Deploy Website: success");
+  });
+
+  test("workflow name only when no conclusion", () => {
+    const ev = makeEvent("github.workflow_run.completed", {
+      "cicd.pipeline.name": "CI",
+    });
+    expect(formatDetails(ev)).toBe("CI");
+  });
+
+  test("name + conclusion from payload fallback", () => {
+    const ev = makeEvent("github.workflow_run.completed", {}, { name: "Lint", conclusion: "failure" });
+    expect(formatDetails(ev)).toBe("Lint: failure");
+  });
+
+  test("falls back to generic when no name", () => {
+    const ev = makeEvent("github.workflow_run.completed", {}, undefined, "github.workflow_run.completed");
+    expect(formatDetails(ev)).toBe("github.workflow_run.completed");
+  });
+});
+
+describe("formatDetails — linear.issue.* (CTL-418)", () => {
+  test("state_changed with identifier from attributes", () => {
+    const ev = makeEvent("linear.issue.state_changed", {
+      "linear.issue.identifier": "ADV-987",
+    });
+    expect(formatDetails(ev)).toBe("ADV-987: state changed");
+  });
+
+  test("updated with identifier", () => {
+    const ev = makeEvent("linear.issue.updated", {
+      "linear.issue.identifier": "ADV-985",
+    });
+    expect(formatDetails(ev)).toBe("ADV-985: updated");
+  });
+
+  test("identifier from payload ticket when attribute absent", () => {
+    const ev = makeEvent("linear.issue.state_changed", {}, { ticket: "CTL-210" });
+    expect(formatDetails(ev)).toBe("CTL-210: state changed");
+  });
+
+  test("priority_changed", () => {
+    const ev = makeEvent("linear.issue.priority_changed", {
+      "linear.issue.identifier": "CTL-99",
+    });
+    expect(formatDetails(ev)).toBe("CTL-99: priority changed");
+  });
+
+  test("falls back to generic when no identifier", () => {
+    const ev = makeEvent("linear.issue.updated", {}, undefined, "linear.issue.updated CTL-100");
+    expect(formatDetails(ev)).toBe("linear.issue.updated CTL-100");
+  });
+});
+
+describe("formatDetails — session.phase (CTL-418)", () => {
+  test("shows phase name from payload.to", () => {
+    const ev = makeEvent("session.phase", {}, { to: "researching", phase: 1 });
+    expect(formatDetails(ev)).toBe("researching");
+  });
+
+  test("implementing phase", () => {
+    const ev = makeEvent("session.phase", {}, { to: "implementing", phase: 3 });
+    expect(formatDetails(ev)).toBe("implementing");
+  });
+
+  test("falls back to generic when no payload.to", () => {
+    const ev = makeEvent("session.phase", {}, undefined, "session.phase");
+    expect(formatDetails(ev)).toBe("session.phase");
+  });
+});
 
 describe("formatDetails — filter.wake events (CTL-419)", () => {
   test("single stale session: shows reason with recipient short suffix", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -449,6 +449,69 @@ export function formatDetails(event: CanonicalEvent): string {
     detailsCache.set(event, sanitized);
     return sanitized;
   }
+  // CTL-418: per-event-class structured DETAILS for GitHub and Linear events.
+  // Attributes are authoritative; payload fields used as fallback when needed.
+  if (name?.startsWith("github.pr.")) {
+    const prNum = event.attributes?.["vcs.pr.number"];
+    // Derive verb from event.name suffix (already normalized: "closed"+"merged"→"merged")
+    let verb = name.slice("github.pr.".length);
+    if (verb === "synchronize") verb = "pushed";
+    if (verb === "ready_for_review") verb = "ready";
+    if (typeof prNum === "number") {
+      const out = sanitize(`PR #${prNum} ${verb}`, "oneline");
+      detailsCache.set(event, out);
+      return out;
+    }
+  }
+  if (name?.startsWith("github.check_suite.")) {
+    const p = payload as Record<string, unknown> | undefined;
+    const conclusion =
+      event.attributes?.["cicd.pipeline.run.conclusion"] ?? p?.["conclusion"];
+    if (typeof conclusion === "string" && conclusion.length > 0) {
+      const out = sanitize(`CI: ${conclusion}`, "oneline");
+      detailsCache.set(event, out);
+      return out;
+    }
+  }
+  if (name?.startsWith("github.workflow_run.")) {
+    const p = payload as Record<string, unknown> | undefined;
+    const wfName =
+      event.attributes?.["cicd.pipeline.name"] ??
+      (typeof p?.["name"] === "string" ? p["name"] : undefined);
+    const conclusion =
+      event.attributes?.["cicd.pipeline.run.conclusion"] ??
+      (typeof p?.["conclusion"] === "string" ? p["conclusion"] : undefined);
+    if (typeof wfName === "string" && wfName.length > 0) {
+      const suffix =
+        typeof conclusion === "string" && conclusion.length > 0
+          ? `: ${conclusion}`
+          : "";
+      const out = sanitize(`${wfName}${suffix}`, "oneline");
+      detailsCache.set(event, out);
+      return out;
+    }
+  }
+  if (name?.startsWith("linear.issue.")) {
+    const p = payload as Record<string, unknown> | undefined;
+    const identifier =
+      event.attributes?.["linear.issue.identifier"] ??
+      (typeof p?.["ticket"] === "string" ? p["ticket"] : undefined);
+    const suffix = name.slice("linear.issue.".length).replace(/_/g, " ");
+    if (typeof identifier === "string" && identifier.length > 0) {
+      const out = sanitize(`${identifier}: ${suffix}`, "oneline");
+      detailsCache.set(event, out);
+      return out;
+    }
+  }
+  if (name === "session.phase") {
+    const p = payload as Record<string, unknown> | undefined;
+    const phaseName = typeof p?.["to"] === "string" ? p["to"] : "";
+    if (phaseName.length > 0) {
+      const out = sanitize(phaseName, "oneline");
+      detailsCache.set(event, out);
+      return out;
+    }
+  }
   const msg = event.body?.message ?? "";
   let raw = msg;
   if (payload && typeof payload === "object") {


### PR DESCRIPTION
## Summary

- formatDetails() now shows structured per-event-class summaries in the HUD DETAILS column instead of repeating the event name verbatim from body.msg
- GitHub PR events: PR #N opened, PR #N merged, PR #N pushed, PR #N ready, PR #N closed
- CI events: CI: success/failure for check_suite; WorkflowName: conclusion for workflow_run
- Linear events: IDENTIFIER: state changed/updated/priority changed
- Session phase events: phase name from payload.to (e.g. researching, implementing)
- filter.wake unchanged (already informative)
- Full raw msg still visible in the detail pane via formatDetailBody

Updates hud-format.test.ts generic fallback tests to use a non-github event base (orchestrator.worker.done) so they correctly test the fallback path.

## Test plan

- 22 new tests in cli/lib/format.test.ts covering all 5 new event classes (28 total, including CTL-419 wake tests)
- Updated __tests__/hud-format.test.ts generic fallback tests
- bun test passes; pre-existing failures unchanged

Refs: CTL-418