### PR TITLE
fix(dev): HUD detail pane no longer pins selected event at list top (CTL-420)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.test.ts
@@ -86,9 +86,9 @@ describe("computeDetailLayout", () => {
     expect(r.listScrollOffset).toBe(20);
   });
 
-  test("selected falls off the bottom of the smaller list: recenter", () => {
-    // Before detail opens, scrollOffset=20 was fine for visibleRows=93 list with sel=70.
-    // After detail opens, listRows=5, so [20, 25) does NOT contain 70 → recenter.
+  test("selected falls off the smaller list: scroll stays, detail pane provides context", () => {
+    // CTL-420: detail pane open — keep current scroll rather than pinning selection
+    // at row 0. The detail pane already shows the selected event's content.
     const r = computeDetailLayout({
       visibleRows: 93,
       inDetailMode: true,
@@ -98,12 +98,8 @@ describe("computeDetailLayout", () => {
       currentScrollOffset: 20,
     });
     expect(r.listRows).toBe(5);
-    // recenter target = selectedIndex - floor(listRows/2) = 70 - 2 = 68
-    // maxOffset = 200 - 5 = 195 → 68 stays
-    expect(r.listScrollOffset).toBe(68);
-    // selected (70) lands in [68, 73) ✓
-    expect(70).toBeGreaterThanOrEqual(r.listScrollOffset);
-    expect(70).toBeLessThan(r.listScrollOffset + r.listRows);
+    // scroll stays at 20 (clamped to maxOffset=195, which 20 is below)
+    expect(r.listScrollOffset).toBe(20);
   });
 
   test("scrollOffset clamped to maxOffset when totalEvents is small", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/detail-layout.ts
@@ -96,12 +96,13 @@ export function computeDetailLayout(input: DetailLayoutInput): DetailLayoutResul
   const detailContentRows = fits
     ? Math.max(1, input.detailLineCount - 1)
     : Math.max(1, paneRows - 4);
-  const listScrollOffset = reanchorListScrollOffset(
-    input.selectedIndex,
-    input.totalEvents,
-    listRows,
-    input.currentScrollOffset,
-  );
+  // CTL-420: when the detail pane is open, keep the EventList at its current
+  // scroll position rather than jumping to pin the selected event at row 0.
+  // The detail pane already shows the selected event's content; forcing the
+  // list to scroll creates a "pinned row" effect that visually confuses the
+  // render order (selected row appears in the header area).
+  const maxListOffset = Math.max(0, input.totalEvents - listRows);
+  const listScrollOffset = Math.min(Math.max(0, input.currentScrollOffset), maxListOffset);
 
   return { detailPaneRows: paneRows, detailContentRows, listRows, listScrollOffset };
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T04:40:00Z -->
<!-- Last updated: 2026-05-15T04:40:00Z -->
<!-- PR: #733 -->
<!-- Previous commits: 139d4a999e8bad438281d560279d62fbe5f66d5d -->

## Summary

Fixes the HUD rendering issue where opening the detail pane caused the selected event row to visually appear "pinned" between the column headers and the detail pane. When the detail pane opened, `computeDetailLayout` was calling `reanchorListScrollOffset` which jumped the EventList scroll to place the selected event at row 0, creating a confused render order. Since the detail pane already shows the selected event's full content, the EventList now simply keeps its current scroll position.

## Changes Made

### `cli/lib/detail-layout.ts`

- **`computeDetailLayout`**: when `inDetailMode=true`, the EventList scroll offset is no longer re-anchored to the selected event. Instead, `currentScrollOffset` is clamped to `maxListOffset = max(0, totalEvents - listRows)`, keeping the list at its pre-detail-open position.
- `reanchorListScrollOffset` is still used for the help overlay path in `hud.tsx` and remains exported unchanged.

### `cli/lib/detail-layout.test.ts`

- Updated the "selected falls off the smaller list" test case to assert the new behavior: scroll stays at the current position (20) rather than recentering to the selection (68).
- Removed assertions that verified the selected event was always visible in the compact list (those assertions described the old, unwanted behavior).

## Root Cause

`reanchorListScrollOffset` centers the view around `selectedIndex` whenever the selection falls outside the current visible window. When the detail pane opens and shrinks `listRows` from ~80 to ~5, the selection frequently falls out of the new window, triggering a jump to `selectedIndex - floor(listRows/2)`. With few rows visible, this made the selected event appear as the only event between the column headers and the detail pane — visually identical to a "pinned row" floating above the data rows.

## How to Verify It

- [x] `bun test cli/lib/detail-layout.test.ts` — 18 tests pass
- [ ] Open `catalyst-hud`, scroll to any event, press Enter to open the detail pane — the EventList should stay at its current scroll position; no row should appear visually "pinned" above the column headers
- [ ] Navigate with j/k while the detail pane is open — detail pane updates; EventList stays stable

## Related Issues

- Fixes https://linear.app/catalyst/issue/CTL-420
