### PR TITLE
fix(dev): orchestrate-verify.sh false-positive on post-merge branch lookup (CTL-400)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
@@ -216,6 +216,49 @@ scratch_teardown
 echo
 
 # ---------------------------------------------------------------
+# NEW: Signal file pr.number+mergeCommitSha overrides empty gh pr list (CTL-400)
+# ---------------------------------------------------------------
+echo "test: signal-file pr.number+mergeCommitSha used when branch is deleted (CTL-400)"
+scratch_setup
+echo "feature" >> README.md
+git add -A && git commit -q -m "feature"
+CTL400_SHA=$(git rev-parse HEAD)
+
+# gh pr list returns [] — simulates deleted head branch after --delete-branch
+cat > "${SCRATCH}/bin/gh" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"pr list"* ]]; then echo "[]"; exit 0; fi
+echo "stub gh: unexpected call: \$*" >&2; exit 99
+EOF
+chmod +x "${SCRATCH}/bin/gh"
+export PATH="${SCRATCH}/bin:${PATH}"
+
+# Signal file already has pr.number + pr.mergeCommitSha (written by worker before merge)
+cat > "${ORCH_DIR}/workers/TICK-CTL400.json" <<EOF
+{
+  "ticket": "TICK-CTL400",
+  "pr": {
+    "number": 698,
+    "url": "https://github.com/org/repo/pull/698",
+    "mergedAt": "2026-05-14T16:00:00Z",
+    "mergeCommitSha": "${CTL400_SHA}",
+    "ciStatus": "merged"
+  },
+  "definitionOfDone": {
+    "testsWrittenFirst": false,
+    "unitTests": {"exists": false, "count": 0},
+    "apiTests": {"exists": false, "count": 0},
+    "functionalTests": {"exists": false, "count": 0}
+  }
+}
+EOF
+run_verify "TICK-CTL400" "backend"
+echo "$OUT" | grep -q "PR #698 is MERGED" && pass "signal-file: merged PR detected via pr.number+sha" || fail "signal-file: merged PR detected" "$OUT"
+echo "$OUT" | grep -q "No PR found for branch" && fail "no false-positive when branch is deleted" "$OUT" || pass "no false-positive on deleted branch"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
 echo
 if [ $FAILURES -eq 0 ]; then
   echo "ALL PASSED ($PASSES)"

--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -123,7 +123,41 @@ DIFF_RANGE="${BASE_BRANCH}..."
 PR_NUMBER=""
 PR_STATE=""
 PR_MERGE_SHA=""
-if [ -n "$BRANCH" ]; then
+
+# Prefer signal file PR metadata over branch-based lookup. After --delete-branch,
+# gh pr list --head returns nothing even with --state all, and git diff base... is
+# empty. The worker writes pr.number + pr.mergeCommitSha to the signal file before
+# deleting the branch, so use those when available.
+if [ -n "$SIGNAL_FILE" ] && [ -f "$SIGNAL_FILE" ]; then
+  SIG_PR=$(jq -r '.pr.number // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+  SIG_SHA=$(jq -r '.pr.mergeCommitSha // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+  if [ -n "$SIG_PR" ]; then
+    PR_NUMBER="$SIG_PR"
+    if [ -n "$SIG_SHA" ]; then
+      PR_MERGE_SHA="$SIG_SHA"
+      PR_STATE="MERGED"
+      DIFF_RANGE="${PR_MERGE_SHA}~..${PR_MERGE_SHA}"
+    else
+      # Have PR number but no merge SHA — ask REST API for authoritative state
+      REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+      if [ -n "$REPO" ]; then
+        PR_REST=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" 2>/dev/null || echo "{}")
+        if echo "$PR_REST" | jq -e '.merged == true' >/dev/null 2>&1; then
+          PR_STATE="MERGED"
+          PR_MERGE_SHA=$(echo "$PR_REST" | jq -r '.merge_commit_sha // empty' 2>/dev/null || echo "")
+          [ -n "$PR_MERGE_SHA" ] && DIFF_RANGE="${PR_MERGE_SHA}~..${PR_MERGE_SHA}"
+        elif echo "$PR_REST" | jq -e '.state == "open"' >/dev/null 2>&1; then
+          PR_STATE="OPEN"
+        else
+          PR_STATE="CLOSED"
+        fi
+      fi
+    fi
+  fi
+fi
+
+# Fall back to branch-based lookup when signal file has no pr.number
+if [ -z "$PR_NUMBER" ] && [ -n "$BRANCH" ]; then
   PR_LIST_JSON=$(gh pr list --head "$BRANCH" --state all --json number,state,mergedAt --limit 5 2>/dev/null || echo "[]")
   if [ -n "$PR_LIST_JSON" ] && [ "$PR_LIST_JSON" != "[]" ]; then
     # Prefer MERGED, then OPEN, then CLOSED


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T06:27:00Z -->
<!-- Last updated: 2026-05-15T06:27:00Z -->
<!-- PR: #735 -->
<!-- Previous commits: 0e677568d2832f537893734f08a99b9d3d671db2 -->

## Summary

Fixes a false-positive failure in `orchestrate-verify.sh` when a worker PR was merged with `--delete-branch`. The script's PR lookup and diff range setup both relied on `gh pr list --head <branch>`, which returns empty after the head branch is deleted — even with `--state all`. This caused step 8 (PR Merge State) to report `FAIL: No PR found for branch ...` on every cleanly-merged worker, defeating the script's anti-reward-hacking purpose.

**Root cause:** two linked issues in the diff range setup block (lines 121–140):
1. `gh pr list --head <branch> --state all` returns `[]` after `--delete-branch`
2. When PR_NUMBER is empty, `DIFF_RANGE` stays as `base...` → zero changed files, masking coverage checks

**Fix:** read `pr.number` and `pr.mergeCommitSha` from the worker signal file first (the worker writes these before deleting the branch). Fall back to the branch-based lookup only when the signal file has no `pr.number`. When both fields are present, set DIFF_RANGE to `sha~..sha` directly — no GitHub API calls needed.

## Changes Made

### `plugins/dev/scripts/orchestrate-verify.sh`

- Added signal-file-first lookup block before the existing `gh pr list --head` block
- When `--signal-file` has `pr.number` + `pr.mergeCommitSha`: sets `PR_NUMBER`, `PR_MERGE_SHA`, `PR_STATE=MERGED`, `DIFF_RANGE=sha~..sha` directly
- When `--signal-file` has `pr.number` but no `pr.mergeCommitSha`: calls `gh api repos/<repo>/pulls/<number>` (REST) to get authoritative state + merge SHA
- Converted the existing `gh pr list` block to a fallback guarded by `[ -z "$PR_NUMBER" ]`
- Section 8 (PR Merge State check) required no changes — it already uses `PR_NUMBER`/`PR_STATE`

### `plugins/dev/scripts/__tests__/orchestrate-verify.test.sh`

- Added test case 7: seeds signal file with `pr.number=698` + `pr.mergeCommitSha`, stubs `gh pr list` to return `[]`, verifies:
  - `PR #698 is MERGED` is in output
  - `No PR found for branch` is NOT in output

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/orchestrate-verify.test.sh` — all 11 tests pass

## Backward Compatibility

- Scripts called without `--signal-file` are unaffected — the new block is guarded by `[ -n "$SIGNAL_FILE" ] && [ -f "$SIGNAL_FILE" ]`
- Scripts with signal files that lack `pr.number` fall through to the existing branch lookup
- All existing tests still pass

Refs: CTL-400
