### PR TITLE
feat(dev): HUD Claude Code-style full-width input bar with separate status line (CTL-417)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/PromptInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/PromptInput.tsx
@@ -230,38 +230,41 @@ export function PromptInput({
   const countStr = formatEventCount(filteredCount, totalCount);
 
   return (
-    <Box borderStyle="round" borderColor={focused ? "cyan" : "gray"} paddingX={1} flexDirection="row">
-      {mode === "filter" && <Text color="yellow">{">"}</Text>}
-      {mode === "query" && <Text color="yellow">{"~"}</Text>}
-      {focused && <Text>{" "}</Text>}
-      {focused ? (
-        <>
-          <Text>{before}</Text>
-          <Text inverse>{atCursor}</Text>
-          <Text>{after}</Text>
-        </>
-      ) : (
-        <Text dimColor>{statusMsg ?? "press / to filter, : to query"}</Text>
-      )}
-      <Box flexGrow={1} marginLeft={2}>
-        {error !== null ? (
-          <Text color="red" wrap="truncate-end">{error}</Text>
+    <Box flexDirection="column">
+      <Box borderStyle="round" borderColor={focused ? "cyan" : "gray"} paddingX={1} flexDirection="row">
+        {mode === "query" ? <Text color="yellow">{"~"}</Text> : <Text color="yellow">{">"}</Text>}
+        <Text>{" "}</Text>
+        {focused ? (
+          <>
+            <Text>{before}</Text>
+            <Text inverse>{atCursor}</Text>
+            <Text>{after}</Text>
+          </>
         ) : (
-          <Text dimColor wrap="truncate-end">{hints}</Text>
+          <Text dimColor>{statusMsg ?? "filter or query…"}</Text>
         )}
       </Box>
-      {focused && statusMsg !== null && error === null && (
-        <Text color="yellow">{` ${statusMsg} `}</Text>
-      )}
-      <Text dimColor>{` ${countStr}`}</Text>
-      {chips.map((chip, i) => (
-        <Text key={i} color={chip.color}>{` [${chip.label}]`}</Text>
-      ))}
-      {autoFollow
-        ? <Text color="green">{" [LIVE]"}</Text>
-        : <Text dimColor>{" [PAUSED — G to follow]"}</Text>
-      }
-      {wrapMode === 'wrap' && <Text color="cyan">{" [WRAP]"}</Text>}
+      <Box flexDirection="row" paddingX={1}>
+        <Box flexGrow={1}>
+          {error !== null ? (
+            <Text color="red" wrap="truncate-end">{error}</Text>
+          ) : (
+            <Text dimColor wrap="truncate-end">{hints}</Text>
+          )}
+        </Box>
+        {focused && statusMsg !== null && error === null && (
+          <Text color="yellow">{` ${statusMsg} `}</Text>
+        )}
+        <Text dimColor>{` ${countStr}`}</Text>
+        {chips.map((chip, i) => (
+          <Text key={i} color={chip.color}>{` [${chip.label}]`}</Text>
+        ))}
+        {autoFollow
+          ? <Text color="green">{" [LIVE]"}</Text>
+          : <Text dimColor>{" [PAUSED — G to follow]"}</Text>
+        }
+        {wrapMode === 'wrap' && <Text color="cyan">{" [WRAP]"}</Text>}
+      </Box>
     </Box>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -183,10 +183,10 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   // CTL-392: full-screen dashboard overlay that takes over the event list area.
   const [showDashboard, setShowDashboard] = useState(false);
 
-  // chrome = header + prompt-box(3 rows: top-border + content + bottom-border) + dsl overlay (if any).
+  // chrome = header + prompt-box(3 rows: top-border + content + bottom-border) + status-line(1) + dsl overlay (if any).
   // CTL-386: replaced separator(1) + filter(1) + query(1) with a single rounded PromptInput box(3).
-  // Net row count is unchanged — the box border replaces the standalone separator.
-  const chromeRows = headerRows + 3 + overlayHeight;
+  // CTL-417: split PromptInput into input-row(3) + status-row(1) = 4 rows total.
+  const chromeRows = headerRows + 4 + overlayHeight;
   const visibleRows = Math.max(1, layoutRows - chromeRows);
 
   const {


### PR DESCRIPTION
## Summary

- Split the single `PromptInput` bordered box into two dedicated rows
- **Input row** (top): full-width rounded-border box with `>` prefix always visible; shows typed text with cursor when active, or dim placeholder `filter or query…` when idle
- **Status row** (bottom): borderless single line — key hints (left, truncates first on narrow terminals), mode chips `[LIVE]`/`[PAUSED]`/`[WRAP]`/filter chips, and event count

## Changes

- `PromptInput.tsx`: restructure JSX from one `<Box borderStyle="round">` to a `<Box flexDirection="column">` wrapping a bordered input row and a plain status row
- `hud.tsx:189`: bump `chromeRows` from `headerRows + 3` to `headerRows + 4` to account for the new status row

## Test plan

- [ ] Run `bun test` in `plugins/dev/scripts/orch-monitor/` — all footer/filter-chip tests pass
- [ ] Launch HUD (`catalyst-hud`) and verify input row spans full width in normal, filter, and query modes
- [ ] Verify status line shows hints on left, chips and count on right
- [ ] Resize terminal narrow — confirm hints truncate gracefully, input box stays full-width
- [ ] Toggle wrap mode (`w`) — verify `[WRAP]` chip appears in status row
- [ ] Navigate events — verify `[LIVE]`/`[PAUSED]` appear in status row

Refs: CTL-417