### PR TITLE
fix(dev): build-orchestrator-filter drops github.pr.merged when PR not yet in signal files (CTL-398)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-events.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-events.test.sh
@@ -300,6 +300,19 @@ EVENT_F='{"attributes":{"event.name":"linear.issue.state_changed","linear.issue.
 run "filter matches linear event for in-orch ticket" \
   assert_match "$EVENT_F" "$FILTER_FILE"
 
+# (f2) CTL-398: github.pr.merged attributed to this orch via head-ref resolution —
+# PR #999 is NOT in the known set (only 501 is), but catalyst.orchestrator.id
+# is stamped by the webhook handler from the worker head-ref, so the new
+# github.pr.* orch-id clause must match it.
+EVENT_F2='{"attributes":{"event.name":"github.pr.merged","catalyst.orchestrator.id":"orch-test-2026-05-04","vcs.repository.name":"o/r","vcs.pr.number":999}}'
+run "filter matches github.pr.merged with orch id even when PR not in known set (CTL-398)" \
+  assert_match "$EVENT_F2" "$FILTER_FILE"
+
+# (f3) CTL-398: github.pr.opened for an unknown PR — same orch id attribution path
+EVENT_F3='{"attributes":{"event.name":"github.pr.opened","catalyst.orchestrator.id":"orch-test-2026-05-04","vcs.repository.name":"o/r","vcs.pr.number":888}}'
+run "filter matches github.pr.opened with orch id even when PR not in known set (CTL-398)" \
+  assert_match "$EVENT_F3" "$FILTER_FILE"
+
 # ── 16. emitted predicate — reject cases ────────────────────────────────────
 
 # (g) catalyst event from a different orchestrator
@@ -333,6 +346,18 @@ run "filter rejects linear event for foreign ticket" \
 EVENT_L='{"attributes":{"event.name":"github.check_run.created","catalyst.orchestrator.id":"orch-test-2026-05-04","vcs.repository.name":"o/r"},"body":{"payload":{}}}'
 run "filter rejects github webhook tagged with orch id but no PR/ref match (CTL-370)" \
   assert_no_match "$EVENT_L" "$FILTER_FILE"
+
+# (l2) CTL-398: github.pr.merged with NO catalyst.orchestrator.id and PR NOT
+# in known set — must NOT match (no orch attribution, no PR number fallback).
+EVENT_L2='{"attributes":{"event.name":"github.pr.merged","vcs.repository.name":"o/r","vcs.pr.number":999}}'
+run "filter rejects github.pr.merged with no orch id and unknown PR (CTL-398)" \
+  assert_no_match "$EVENT_L2" "$FILTER_FILE"
+
+# (l3) CTL-398: github.pr.merged attributed to a DIFFERENT orchestrator —
+# must NOT match (orch id doesn't match this orch's name).
+EVENT_L3='{"attributes":{"event.name":"github.pr.merged","catalyst.orchestrator.id":"orch-other-2026-05-04","vcs.repository.name":"o/r","vcs.pr.number":999}}'
+run "filter rejects github.pr.merged attributed to a foreign orchestrator (CTL-398)" \
+  assert_no_match "$EVENT_L3" "$FILTER_FILE"
 
 # ── 16b. canonical-only broker emissions — not matched (CTL-372) ────────────
 #

--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -383,13 +383,20 @@ cmd_build_orchestrator_filter() {
   #      orch-id clause used to over-match ~60-70% of github webhooks (CTL-370).
   #   2. worker-lifecycle events scoped by catalyst.worker.ticket.
   #   3. github events scoped by branch ref prefix (e.g. push events).
-  #   4. github events scoped to a known PR number (single-PR webhooks).
-  #   5. check_suite / workflow_run events whose prNumbers intersect.
-  #   6. linear events scoped to an in-orch ticket.
+  #   4. github.pr.* events attributed to this orch via head-ref resolution —
+  #      NOT guarded by the orchestrator. prefix so PR-merged / PR-opened events
+  #      reach the consumer even when no PR numbers are yet recorded in signal
+  #      files. The webhook handler stamps catalyst.orchestrator.id on PR events
+  #      by resolving the worker head-ref. Scoped to github.pr.* only (not all
+  #      github.*) to avoid re-introducing the CTL-370 over-broad match. (CTL-398)
+  #   5. github events scoped to a known PR number (single-PR webhooks).
+  #   6. check_suite / workflow_run events whose prNumbers intersect.
+  #   7. linear events scoped to an in-orch ticket.
   printf '(\n'
   printf '  (.attributes."catalyst.orchestrator.id" == "%s" and (.attributes."event.name" // "" | startswith("orchestrator.")))\n' "$orch_name"
   printf '  or ((.attributes."catalyst.worker.ticket" // "") | IN(%s))\n' "$ticket_stream"
   printf '  or ((.attributes."vcs.ref.name" // "") | startswith("refs/heads/%s-"))\n' "$orch_name"
+  printf '  or (.attributes."catalyst.orchestrator.id" == "%s" and (.attributes."event.name" // "" | startswith("github.pr.")))\n' "$orch_name"
   if [[ -n "$pr_stream" ]]; then
     printf '  or ((.attributes."vcs.pr.number" // -1) | IN(%s))\n' "$pr_stream"
     printf '  or ((.body.payload.prNumbers // []) | any(IN(%s)))\n' "$pr_stream"


### PR DESCRIPTION
## Summary

- `build-orchestrator-filter` now includes a `github.pr.*` clause scoped by `catalyst.orchestrator.id` so PR events (merged, opened, synchronized) reach the orchestrator monitor even before workers write PR numbers to their signal files
- The existing clause 1 guards on `startswith("orchestrator.")` to prevent CTL-370 over-matching, which inadvertently also excluded `github.pr.*` events that carry the orch id via head-ref attribution
- The new clause is narrower than the old bare orch-id match: it only activates for `event.name` values starting with `"github.pr."`, not all github webhooks

## Root cause

In the incident (`orch-o-adv-953-954`, 2026-05-14), PR #699 merged but `github.pr.merged` never matched the orchestrator's Monitor filter because:

1. Clause 3 (`vcs.ref.name | startswith("refs/heads/ORCH-")`) — `github.pr.merged` has **no** `vcs.ref.name` field
2. Clauses 4/5 (PR number set) — PR #699 wasn't yet in signal files when the filter was last built
3. Clause 1 (orch id + `orchestrator.` prefix guard) — `"github.pr.merged"` doesn't start with `"orchestrator."`; the guard exists to prevent CTL-370 over-matching

The webhook handler **does** stamp `catalyst.orchestrator.id` on PR events by resolving the worker's head-ref branch name, but clause 1 filtered it back out.

## Fix

Add a new clause between the ref-scope and PR-number clauses:

```jq
or (.attributes."catalyst.orchestrator.id" == "ORCH" and (.attributes."event.name" // "" | startswith("github.pr.")))
```

This is CTL-370 safe: `github.check_run.created` (the original over-matcher) doesn't start with `"github.pr."` and is still rejected.

## Test plan

- [ ] Run `bash plugins/dev/scripts/__tests__/catalyst-events.test.sh` — all existing tests pass
- [ ] New test (f2): `github.pr.merged` with `catalyst.orchestrator.id` set but PR not in known set → **matches**
- [ ] New test (f3): `github.pr.opened` with `catalyst.orchestrator.id` set but PR not in known set → **matches**
- [ ] New test (l2): `github.pr.merged` with no orch id and unknown PR → **rejected**
- [ ] New test (l3): `github.pr.merged` with foreign orch id → **rejected**
- [ ] CTL-370 regression (l): `github.check_run.created` with orch id → still **rejected**

Closes CTL-398