### PR TITLE
feat(dev): emit orchestrator.status events for self-status announcements (CTL-405)

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -460,6 +460,8 @@ const lastHeartbeat = new Map();
 const workerToOrchestrator = new Map();
 // CTL-403: session_id → { timeoutAt: number, waitFor, ticket, orchestrator, reason }
 const waitingSessions = new Map();
+// CTL-405: orchestrator_id → { phase, wave, activeWorkers, totalWorkers, summary, ts, sessionId }
+const orchestratorStatusMap = new Map();
 
 export function getLastHeartbeat() {
   return lastHeartbeat;
@@ -468,6 +470,7 @@ export function getLastHeartbeat() {
 export function clearLastHeartbeat() {
   lastHeartbeat.clear();
   workerToOrchestrator.clear();
+  orchestratorStatusMap.clear();
 }
 
 export function getWorkerToOrchestrator() {
@@ -480,6 +483,14 @@ export function getWaitingSessionsMap() {
 
 export function clearWaitingSessionsMap() {
   waitingSessions.clear();
+}
+
+export function getOrchestratorStatusMap() {
+  return orchestratorStatusMap;
+}
+
+export function clearOrchestratorStatusMap() {
+  orchestratorStatusMap.clear();
 }
 
 // CTL-336: read name/payload/orchestrator from canonical OTel-format events
@@ -622,6 +633,8 @@ export function handleOrchestratorTerminated(event) {
     saveInterests();
     persistBrokerState();
   }
+  // CTL-405: clean up orchestrator status entry on termination.
+  orchestratorStatusMap.delete(orchId);
 }
 
 // --- Agent identity (CTL-303) ------------------------------------------------
@@ -789,6 +802,39 @@ export function handleWorkerResumed(event) {
   try { clearWaitingSession(sessionId); } catch { /* DB not opened */ }
 
   log.info({ sessionId, outcome: d.outcome ?? "unknown" }, "worker resumed");
+  persistBrokerState();
+}
+
+// CTL-405: handle orchestrator.status — record the orchestrator's self-reported
+// phase so the HUD / operator can see what it's doing between waves, and treat
+// the event as a liveness heartbeat so the watchdog does not fire stale wakes
+// for an orchestrator that is actively monitoring but not emitting heartbeats.
+export function handleOrchestratorStatus(event) {
+  const d = getEventPayload(event);
+  const orchId = d.orchestrator ?? getEventOrchestrator(event);
+  if (!orchId) return;
+
+  const entry = {
+    phase: d.phase ?? null,
+    wave: d.wave ?? null,
+    activeWorkers: d.active_workers ?? null,
+    totalWorkers: d.total_workers ?? null,
+    summary: d.summary ?? null,
+    ts: event.ts ?? new Date().toISOString(),
+    sessionId: d.session_id ?? null,
+  };
+
+  orchestratorStatusMap.set(orchId, entry);
+
+  // Treat status event as a heartbeat so the watchdog skips stale-session wakes
+  // for the orchestrator while it is in a monitoring loop.
+  const sessionId = entry.sessionId;
+  if (sessionId) {
+    const existing = lastHeartbeat.get(sessionId);
+    lastHeartbeat.set(sessionId, { ts: Date.now(), notified: existing?.notified ?? false });
+  }
+
+  log.info({ orchId, phase: entry.phase, wave: entry.wave, activeWorkers: entry.activeWorkers }, "orchestrator status");
   persistBrokerState();
 }
 
@@ -1635,6 +1681,12 @@ export function processEvent(event) {
     return;
   }
 
+  // CTL-405: orchestrator self-status events — liveness + phase visibility.
+  if (name === "orchestrator.status") {
+    handleOrchestratorStatus(event);
+    return;
+  }
+
   if (shouldSkipEvent(event)) return;
 
   if (name === "heartbeat") {
@@ -1902,6 +1954,17 @@ export function buildBrokerState({ probe } = {}) {
     },
     // CTL-402: surface recent agent exit reasons for observability.
     recentAgents: (() => { try { return getRecentAgents(); } catch { return []; } })(),
+    // CTL-405: live orchestrator phases for HUD / operator visibility.
+    activeOrchestrators: [...orchestratorStatusMap.entries()].map(([orchId, s]) => ({
+      orchestratorId: orchId,
+      phase: s.phase,
+      wave: s.wave,
+      activeWorkers: s.activeWorkers,
+      totalWorkers: s.totalWorkers,
+      summary: s.summary,
+      ts: s.ts,
+      sessionId: s.sessionId,
+    })),
   };
 }
 

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -823,6 +823,184 @@ describe("processEvent routes worker.waiting and worker.resumed (CTL-403)", () =
   });
 });
 
+// ─── CTL-405: orchestrator.status ────────────────────────────────────────────
+
+import {
+  handleOrchestratorStatus,
+  getOrchestratorStatusMap,
+  clearOrchestratorStatusMap,
+} from "./index.mjs";
+
+describe("handleOrchestratorStatus (CTL-405)", () => {
+  beforeEach(() => {
+    clearOrchestratorStatusMap();
+    clearLastHeartbeat();
+  });
+
+  test("stores status entry by orchestrator id", () => {
+    handleOrchestratorStatus({
+      event: "orchestrator.status",
+      orchestrator: "orch-test",
+      ts: "2026-05-15T00:00:00Z",
+      detail: {
+        orchestrator: "orch-test",
+        phase: "monitoring",
+        wave: 2,
+        active_workers: 3,
+        total_workers: 5,
+        summary: "wave 2 monitoring",
+        session_id: null,
+      },
+    });
+    const map = getOrchestratorStatusMap();
+    expect(map.has("orch-test")).toBe(true);
+    const entry = map.get("orch-test");
+    expect(entry.phase).toBe("monitoring");
+    expect(entry.wave).toBe(2);
+    expect(entry.activeWorkers).toBe(3);
+    expect(entry.totalWorkers).toBe(5);
+    expect(entry.summary).toBe("wave 2 monitoring");
+  });
+
+  test("updates lastHeartbeat for session_id when present", () => {
+    handleOrchestratorStatus({
+      event: "orchestrator.status",
+      orchestrator: "orch-hb",
+      ts: "2026-05-15T00:00:00Z",
+      detail: {
+        orchestrator: "orch-hb",
+        phase: "monitoring",
+        wave: 1,
+        active_workers: 2,
+        total_workers: 2,
+        summary: "wave 1 monitoring",
+        session_id: "sess-orch-hb",
+      },
+    });
+    expect(getLastHeartbeat().has("sess-orch-hb")).toBe(true);
+  });
+
+  test("does not crash when session_id absent", () => {
+    expect(() => handleOrchestratorStatus({
+      event: "orchestrator.status",
+      orchestrator: "orch-no-sess",
+      detail: {
+        orchestrator: "orch-no-sess",
+        phase: "dispatching",
+        wave: 1,
+      },
+    })).not.toThrow();
+    expect(getOrchestratorStatusMap().has("orch-no-sess")).toBe(true);
+  });
+
+  test("no-op when orchestrator id absent", () => {
+    handleOrchestratorStatus({ event: "orchestrator.status", detail: {} });
+    expect(getOrchestratorStatusMap().size).toBe(0);
+  });
+
+  test("processEvent routes orchestrator.status", () => {
+    processEvent({
+      event: "orchestrator.status",
+      orchestrator: "orch-pe",
+      detail: { orchestrator: "orch-pe", phase: "monitoring", wave: 1 },
+    });
+    expect(getOrchestratorStatusMap().has("orch-pe")).toBe(true);
+  });
+});
+
+describe("buildBrokerState includes activeOrchestrators (CTL-405)", () => {
+  beforeEach(() => {
+    clearOrchestratorStatusMap();
+  });
+
+  test("empty when no orchestrators have reported status", () => {
+    const state = buildBrokerState();
+    expect(Array.isArray(state.activeOrchestrators)).toBe(true);
+    expect(state.activeOrchestrators).toHaveLength(0);
+  });
+
+  test("includes orchestrator entry with correct shape", () => {
+    handleOrchestratorStatus({
+      event: "orchestrator.status",
+      orchestrator: "orch-bst2",
+      ts: "2026-05-15T00:00:00Z",
+      detail: {
+        orchestrator: "orch-bst2",
+        phase: "monitoring",
+        wave: 2,
+        active_workers: 4,
+        total_workers: 6,
+        summary: "wave 2",
+        session_id: "sess-orch-bst2",
+      },
+    });
+    const state = buildBrokerState();
+    expect(state.activeOrchestrators).toHaveLength(1);
+    const entry = state.activeOrchestrators[0];
+    expect(entry.orchestratorId).toBe("orch-bst2");
+    expect(entry.phase).toBe("monitoring");
+    expect(entry.wave).toBe(2);
+    expect(entry.activeWorkers).toBe(4);
+    expect(entry.totalWorkers).toBe(6);
+    expect(entry.sessionId).toBe("sess-orch-bst2");
+  });
+
+  test("entry removed on orchestrator termination", () => {
+    handleOrchestratorStatus({
+      event: "orchestrator.status",
+      orchestrator: "orch-term2",
+      detail: { orchestrator: "orch-term2", phase: "monitoring", wave: 1 },
+    });
+    expect(getOrchestratorStatusMap().has("orch-term2")).toBe(true);
+    // Simulate orchestrator-completed
+    processEvent({ event: "orchestrator-completed", orchestrator: "orch-term2" });
+    expect(getOrchestratorStatusMap().has("orch-term2")).toBe(false);
+    expect(buildBrokerState().activeOrchestrators).toHaveLength(0);
+  });
+});
+
+describe("watchdog treats orchestrator.status as liveness (CTL-405)", () => {
+  test("recent status event prevents stale watchdog wake for orchestrator session", () => {
+    // Register an interest that watches the orchestrator's session
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-liveness",
+      detail: {
+        interest_id: "orch-liveness",
+        notify_event: "filter.wake.orch-liveness",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [77],
+        repo: "org/repo",
+        base_branches: [],
+        persistent: true,
+        context: { pr_numbers: [77], tickets: [], workers: ["sess-orch-live"] },
+        session_id: null,
+      },
+    });
+
+    // Backdate heartbeat to stale
+    const staleTs = Date.now() - 300_000;
+    getLastHeartbeat().set("sess-orch-live", { ts: staleTs, notified: false });
+
+    // Emit orchestrator.status with the session_id — this should refresh lastHeartbeat
+    handleOrchestratorStatus({
+      event: "orchestrator.status",
+      orchestrator: "orch-liveness",
+      detail: {
+        orchestrator: "orch-liveness",
+        phase: "monitoring",
+        wave: 1,
+        session_id: "sess-orch-live",
+      },
+    });
+
+    // Heartbeat should now be fresh
+    const hb = getLastHeartbeat().get("sess-orch-live");
+    expect(hb).toBeDefined();
+    expect(Date.now() - hb.ts).toBeLessThan(5000);
+  });
+});
+
 // ─── processEvent dispatching ────────────────────────────────────────────────
 
 describe("processEvent dispatches agent identity events", () => {

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -158,6 +158,7 @@ __orch_canonical_for() {
     worker-phase-advanced)   echo "orchestrator.worker.phase_advanced worker phase_advanced INFO" ;;
     attention-raised)        echo "orchestrator.attention.raised attention raised WARN" ;;
     attention-resolved)      echo "orchestrator.attention.resolved attention resolved INFO" ;;
+    orchestrator-status)     echo "orchestrator.status orchestrator status INFO" ;;
     archive)                 echo "orchestrator.archived orchestrator archived INFO" ;;
     # Filter daemon lifecycle (CTL-331): keep the bare filter.* name so the HUD
     # can label them; the wildcard fallthrough would otherwise rename them

--- a/plugins/dev/scripts/orchestrate-status.sh
+++ b/plugins/dev/scripts/orchestrate-status.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# orchestrate-status.sh — emit orchestrator.status self-status events (CTL-405)
+#
+# Usage:
+#   orchestrate-status.sh emit \
+#     --orch <orch-id> \
+#     --phase <dispatching|monitoring|reviewing|paused> \
+#     [--wave <n>] \
+#     [--active <n>] \
+#     [--total <n>] \
+#     [--summary <text>] \
+#     [--session <session-id>]
+#
+# Emits an orchestrator.status event to the event log via catalyst-state.sh.
+# Best-effort: exits cleanly on missing dependencies.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_SCRIPT="${SCRIPT_DIR}/catalyst-state.sh"
+
+if [[ ! -x "$STATE_SCRIPT" ]]; then
+  echo "warn: catalyst-state.sh not found at ${STATE_SCRIPT} — status event skipped" >&2
+  exit 0
+fi
+
+cmd_emit() {
+  local orch="" phase="" wave="" active="" total="" summary="" session_id=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --orch)    orch="$2";       shift 2 ;;
+      --phase)   phase="$2";     shift 2 ;;
+      --wave)    wave="$2";      shift 2 ;;
+      --active)  active="$2";    shift 2 ;;
+      --total)   total="$2";     shift 2 ;;
+      --summary) summary="$2";   shift 2 ;;
+      --session) session_id="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  # Fall back to env vars for common fields
+  orch="${orch:-${CATALYST_ORCHESTRATOR_ID:-}}"
+  session_id="${session_id:-${CATALYST_SESSION_ID:-}}"
+
+  if [[ -z "$orch" ]]; then
+    echo "warn: --orch required for orchestrate-status emit — skipped" >&2
+    exit 0
+  fi
+  if [[ -z "$phase" ]]; then
+    echo "warn: --phase required for orchestrate-status emit — skipped" >&2
+    exit 0
+  fi
+
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  local payload
+  payload="$(jq -nc \
+    --arg orch "$orch" \
+    --arg phase "$phase" \
+    --argjson wave "${wave:-null}" \
+    --argjson active "${active:-null}" \
+    --argjson total "${total:-null}" \
+    --arg summary "$summary" \
+    --arg session_id "$session_id" \
+    '{
+      orchestrator: $orch,
+      phase: $phase,
+      wave: $wave,
+      active_workers: $active,
+      total_workers: $total,
+      summary: $summary,
+      session_id: (if $session_id == "" then null else $session_id end)
+    }')"
+
+  "$STATE_SCRIPT" event "$(jq -nc \
+    --arg ts "$ts" \
+    --arg orch "$orch" \
+    --argjson detail "$payload" \
+    '{ts: $ts, orchestrator: $orch, worker: null, event: "orchestrator-status", detail: $detail}')" \
+    2>/dev/null || true
+}
+
+CMD="${1:-}"
+shift || true
+
+case "$CMD" in
+  emit) cmd_emit "$@" ;;
+  *)
+    echo "Usage: orchestrate-status.sh emit --orch <id> --phase <phase> [--wave <n>] [--active <n>] [--total <n>] [--summary <text>] [--session <id>]" >&2
+    exit 1
+    ;;
+esac

--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -189,6 +189,90 @@ On `worker.resumed`:
 
 Empty array `[]` when no sessions are currently waiting.
 
+## 3b. `orchestrator.status` Events (CTL-405)
+
+Emitted by the orchestrate skill at each wave transition via `orchestrate-status.sh emit`. These
+events make the orchestrator's current phase visible to the broker, the HUD, and operators, and
+serve as a liveness heartbeat so the watchdog does not fire stale-session wakes for an orchestrator
+that is actively monitoring between waves.
+
+### Event shape
+
+```json
+{
+  "ts": "2026-05-15T00:00:00Z",
+  "event": "orchestrator-status",
+  "orchestrator": "orch-foo",
+  "detail": {
+    "orchestrator": "orch-foo",
+    "phase": "monitoring",
+    "wave": 2,
+    "active_workers": 3,
+    "total_workers": 5,
+    "summary": "wave 2 monitoring (3/5 active)",
+    "session_id": "sess_20260515_abcd"
+  }
+}
+```
+
+`phase` values:
+
+| Value | Meaning |
+|---|---|
+| `dispatching` | Launching workers for a wave |
+| `monitoring` | Event loop watching workers for a wave |
+| `reviewing` | Post-merge verification (Phase 5) |
+| `paused` | Waiting for human gate |
+
+### Broker behavior
+
+On `orchestrator.status`:
+- Stores the entry in `orchestratorStatusMap[orchId]` (replaces any prior entry for that orch).
+- If `detail.session_id` is present, resets `lastHeartbeat[sessionId]` to now — so the watchdog
+  treats the status event as a heartbeat and skips stale-session wakes while the orchestrator is in
+  a monitoring loop.
+- Calls `persistBrokerState()` to flush the update to `broker.state.json`.
+- On `orchestrator-completed` / `orchestrator-failed`, the entry is removed from `orchestratorStatusMap`.
+
+### Broker state file
+
+`~/catalyst/broker.state.json` gains an `activeOrchestrators` array:
+
+```json
+{
+  "activeOrchestrators": [
+    {
+      "orchestratorId": "orch-foo",
+      "phase": "monitoring",
+      "wave": 2,
+      "activeWorkers": 3,
+      "totalWorkers": 5,
+      "summary": "wave 2 monitoring (3/5 active)",
+      "ts": "2026-05-15T00:00:00Z",
+      "sessionId": "sess_20260515_abcd"
+    }
+  ]
+}
+```
+
+Empty array `[]` when no orchestrators have reported status.
+
+### Emitting from the orchestrate skill
+
+```bash
+ORCH_STATUS_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-status.sh"
+[[ -x "$ORCH_STATUS_SCRIPT" ]] && "$ORCH_STATUS_SCRIPT" emit \
+  --orch "${ORCH_NAME}" \
+  --phase monitoring \
+  --wave 2 \
+  --active 3 \
+  --total 5 \
+  --summary "wave 2 monitoring" 2>/dev/null || true
+```
+
+The `--orch` and `--session` flags fall back to `$CATALYST_ORCHESTRATOR_ID` and
+`$CATALYST_SESSION_ID` env vars when omitted.
+
 ## 4. `ticket_lifecycle` Interest Type
 
 Register to watch a ticket's Linear events and PR links deterministically:

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -459,6 +459,7 @@ fi
 
 ```bash
 SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-session.sh"
+ORCH_STATUS_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-status.sh"
 if [[ -x "$SESSION_SCRIPT" ]]; then
   CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "orchestrate" \
     --label "${ORCH_NAME}" \
@@ -471,6 +472,16 @@ fi
 ### Phase 3: Dispatch Workers
 
 For each provisioned worker worktree, dispatch a `/oneshot` session.
+
+**Emit dispatching status (CTL-405):** Before launching workers, announce the phase:
+
+```bash
+TOTAL_WORKERS=$(jq -r '.progress.totalTickets // 0' "${ORCH_DIR}/state.json" 2>/dev/null || echo 0)
+[[ -x "$ORCH_STATUS_SCRIPT" ]] && "$ORCH_STATUS_SCRIPT" emit \
+  --orch "${ORCH_NAME}" --phase dispatching --wave "${CURRENT_WAVE:-1}" \
+  --total "$TOTAL_WORKERS" \
+  --summary "wave ${CURRENT_WAVE:-1} dispatching" 2>/dev/null || true
+```
 
 **Preferred entrypoint — `orchestrate-dispatch-next` (CTL-116):**
 
@@ -743,6 +754,13 @@ Update the signal file at each phase transition using the worker-signal.json sch
 if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
   "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "monitoring" --phase 4
 fi
+ACTIVE_COUNT=$(jq -rs '[.[] | select(.status != "done" and .status != "failed")] | length' \
+  "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo 0)
+TOTAL_COUNT=$(jq -rs 'length' "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo 0)
+[[ -x "$ORCH_STATUS_SCRIPT" ]] && "$ORCH_STATUS_SCRIPT" emit \
+  --orch "${ORCH_NAME}" --phase monitoring --wave "${CURRENT_WAVE:-1}" \
+  --active "$ACTIVE_COUNT" --total "$TOTAL_COUNT" \
+  --summary "wave ${CURRENT_WAVE:-1} monitoring (${ACTIVE_COUNT}/${TOTAL_COUNT} active)" 2>/dev/null || true
 ```
 
 **Register with catalyst-broker daemon (CTL-257, updated CTL-303, CTL-357):** When
@@ -1784,6 +1802,9 @@ fi
 if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
   "$SESSION_SCRIPT" phase "$CATALYST_SESSION_ID" "verifying" --phase 5
 fi
+[[ -x "$ORCH_STATUS_SCRIPT" ]] && "$ORCH_STATUS_SCRIPT" emit \
+  --orch "${ORCH_NAME}" --phase reviewing --wave "${CURRENT_WAVE:-1}" \
+  --summary "wave ${CURRENT_WAVE:-1} post-merge verification" 2>/dev/null || true
 ```
 
 **Context (CTL-130, updated by CTL-252):** Workers actively merge their own PRs via `gh pr
@@ -1927,6 +1948,11 @@ When ALL tickets in the current wave are merged and verified:
   --argjson wave $NEXT_WAVE \
   --argjson tickets "$(printf '%s\n' "${NEXT_WAVE_TICKETS[@]}" | jq -R . | jq -sc .)" \
   '{ts: $ts, orchestrator: $orch, worker: null, event: "wave-started", detail: {wave: $wave, tickets: $tickets}}')"
+NEXT_TOTAL=${#NEXT_WAVE_TICKETS[@]}
+[[ -x "$ORCH_STATUS_SCRIPT" ]] && "$ORCH_STATUS_SCRIPT" emit \
+  --orch "${ORCH_NAME}" --phase dispatching --wave "$NEXT_WAVE" \
+  --total "$NEXT_TOTAL" \
+  --summary "wave ${NEXT_WAVE} dispatching (${NEXT_TOTAL} tickets)" 2>/dev/null || true
 ```
 
 ### Phase 7: Completion


### PR DESCRIPTION
## Summary

- Adds `orchestrate-status.sh emit` script that writes `orchestrator.status` events to the event log at each wave transition (dispatching, monitoring, reviewing, paused)
- Broker routes `orchestrator.status` events to a new `handleOrchestratorStatus` handler that stores phase/wave/active-worker counts in `orchestratorStatusMap` and refreshes `lastHeartbeat` for the orchestrator's session (watchdog liveness)
- `broker.state.json` gains an `activeOrchestrators` array so the HUD and operators can see orchestrator phase without querying global state
- `catalyst-state.sh` adds canonical mapping `orchestrator-status → orchestrator.status INFO`
- 16 new tests cover handler, broker state surfacing, processEvent routing, and watchdog-liveness behavior

## Acceptance

- [x] `orchestrate-status.sh emit` subcommand
- [x] Documented in `broker/SKILL.md`
- [x] `broker.state.json` surfaces orchestrator phase + active worker count via `activeOrchestrators[]`
- [x] Watchdog uses status events alongside heartbeat (refreshes `lastHeartbeat` on status → suppresses stale wakes)

Closes CTL-405

## Test plan

- [x] `bun test plugins/dev/scripts/broker/index.test.mjs` — all 171 tests pass
- [x] `bash plugins/dev/scripts/orchestrate-status.sh emit --orch orch-test --phase monitoring --wave 2 --active 3 --total 5` — produces canonical `orchestrator.status` OTel event