### PR TITLE
feat(dev): add SESSION column to HUD Interests dashboard (CTL-422)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
@@ -13,6 +13,7 @@ interface InterestListProps {
 }
 
 const COL_ORCH = 25;
+const COL_SESSION = 28;
 const COL_TYPE = 16;
 const COL_WATCHES = 28;
 
@@ -36,7 +37,7 @@ export function InterestList({
   cols,
   brokerState,
 }: InterestListProps) {
-  const promptW = Math.max(8, cols - COL_ORCH - COL_TYPE - COL_WATCHES - 4);
+  const promptW = Math.max(8, cols - COL_ORCH - COL_SESSION - COL_TYPE - COL_WATCHES - 5);
   const visible = interests.slice(scrollOffset, scrollOffset + visibleRows);
   const hasProse = interests.some((i) => i.interest_type === null);
   // proseEnabled is only false (not undefined) when the broker has explicitly written the field.
@@ -46,6 +47,7 @@ export function InterestList({
     <Box flexDirection="column" flexGrow={1}>
       <Box flexDirection="row">
         <Box width={COL_ORCH} flexShrink={0} marginRight={1}><Text bold color="cyan">ORCHESTRATOR</Text></Box>
+        <Box width={COL_SESSION} flexShrink={0} marginRight={1}><Text bold color="cyan">SESSION</Text></Box>
         <Box width={COL_TYPE} flexShrink={0} marginRight={1}><Text bold color="cyan">TYPE</Text></Box>
         <Box width={COL_WATCHES} flexShrink={0} marginRight={1}><Text bold color="cyan">WATCHES</Text></Box>
         <Box flexGrow={1}>
@@ -62,6 +64,7 @@ export function InterestList({
         const selected = realIdx === selectedIndex;
         const isInactiveProse = i.interest_type === null && proseOff;
         const orch = truncateRight(i.orchestrator ?? "—", COL_ORCH);
+        const session = truncateRight(i.key, COL_SESSION);
         const type = truncateRight(interestTypeLabel(i.interest_type), COL_TYPE);
         const watches = truncateRight(interestWatches(i), COL_WATCHES);
         const prompt = truncateRight(i.prompt || "(deterministic)", promptW);
@@ -69,6 +72,9 @@ export function InterestList({
           <Box key={`${i.key}-${realIdx}`} flexDirection="row">
             <Box width={COL_ORCH} flexShrink={0} marginRight={1}>
               <Text dimColor={isInactiveProse && !selected} color={selected ? "black" : "white"} inverse={selected}>{orch}</Text>
+            </Box>
+            <Box width={COL_SESSION} flexShrink={0} marginRight={1}>
+              <Text dimColor={isInactiveProse && !selected} color={selected ? "black" : "magenta"} inverse={selected}>{session}</Text>
             </Box>
             <Box width={COL_TYPE} flexShrink={0} marginRight={1}>
               <Text dimColor={isInactiveProse && !selected} color={i.interest_type ? "green" : "yellow"} inverse={selected}>{type}</Text>


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T06:39:00Z -->
<!-- Last updated: 2026-05-15T06:39:00Z -->
<!-- PR: #739 -->
<!-- Previous commits: 0faa2302 -->

## Summary

Adds a `SESSION` column to the HUD Interests dashboard (tab 1) in orch-monitor. Previously, all interests registered under a given orchestrator run shared the same `ORCHESTRATOR` column value, making it impossible to tell which worker was watching which PR. The new column surfaces the interest key — the session ID that receives the `filter.wake.*` event — so orchestrator-level and worker-level interests are visually distinguishable.

## Changes Made

### `plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx`

- Added `COL_SESSION = 28` width constant alongside the existing column constants
- Updated `promptW` calculation to subtract the new column width (plus one additional separator)
- Added `SESSION` header column between `ORCHESTRATOR` and `TYPE`
- Derives `session` from `i.key` (already available on every `BrokerInterest`, previously used only as the React row key)
- Renders the session value in magenta to visually distinguish it from the white orchestrator column

No changes to `broker-interests-reader.ts` or `broker-interests.json` — `i.key` was already populated from element 0 of each interest tuple and available in the component.

## How to Verify It

- [ ] Launch orch-monitor with an active orchestrator run that has spawned workers
- [ ] Open the Interests tab (tab 1)
- [ ] Confirm the table shows: `ORCHESTRATOR | SESSION | TYPE | WATCHES | PROMPT`
- [ ] Orchestrator-level interests (ticket_lifecycle) show the orchestrator session ID in the SESSION column
- [ ] Worker-level interests (pr_lifecycle, comms_lifecycle) show the worker's own session ID — different from the ORCHESTRATOR value
- [ ] The WATCHES column continues to show PR numbers and ticket IDs

## Related Issues

- Fixes CTL-422: https://linear.app/coalesce-labs/issue/CTL-422
