### PR TITLE
feat(dev): HUD Escape progressively undoes state — scope reset + live-tail resume (CTL-423)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -64,7 +64,7 @@ const HELP_LINES = [
   "  S                clear :since window (reset to initial)",
   "  Esc (in /mode)   clear substring filter only",
   "  Esc (in :mode)   cancel/clear query input",
-  "  Esc (top-level)  clear all active filters + close overlays",
+  "  Esc (top-level)  progressively: clear filters → reset scope → resume live tail",
   "",
   "Scope — narrow to related events  (live mode: first press pauses; press again to apply)",
   "  t                scope to all events sharing this event's trace ID",
@@ -338,14 +338,20 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
       if (showDashboard) { return; }
       if (showDetail) { setShowDetail(false); return; }
       if (showDslOverlay) { setShowDslOverlay(false); return; }
-      setPivot(null);
-      setFilterText("");
-      setDslState(null);
-      setQueryError(null);
-      // CTL-387: ESC is a full reset — revert :since to the HUD-startup value
-      // so the time window matches what the user launched with.
-      setActiveSinceTs(initSinceTs);
-      setActiveSinceLabel(null);
+      // CTL-423: progressive undo — each Esc press undoes one layer of state.
+      // Layer 5: any active filter or :since window → clear it (CTL-387 reset preserved).
+      if (filterText || dslState || queryError || activeSinceLabel || activeSinceTs !== initSinceTs) {
+        setFilterText("");
+        setDslState(null);
+        setQueryError(null);
+        setActiveSinceTs(initSinceTs);
+        setActiveSinceLabel(null);
+        return;
+      }
+      // Layer 6: scope narrowed → reset scope.
+      if (pivot !== null) { setPivot(null); return; }
+      // Layer 7: paused → resume live tail.
+      if (!autoFollow) { jumpToBottom(); return; }
       return;
     }
     if (input === "q" || (key.ctrl && input === "c")) { exit(); return; }


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T06:35:00Z -->
<!-- Last updated: 2026-05-15T06:35:00Z -->
<!-- PR: #740 -->
<!-- Previous commits: 05c3fd2a -->

## Summary

Extends the HUD's top-level Escape key from a single monolithic "clear everything" action into a progressive undo chain. Before this change, pressing Escape with no overlays open would simultaneously reset the scope pivot, clear the filter text, wipe any NLQ DSL state, and restore the `:since` window — regardless of which of those were actually active. Now each Escape press undoes exactly one layer, giving users a predictable "keep pressing until default" path without losing adjacent state they wanted to keep.

## Changes Made

### `cli/hud.tsx`

**Escape handler** (`useInput` block, normal mode):

- Replaced the monolithic final-layer reset with three discrete conditional layers:
  - **Layer 5** (existing, now conditional): clears `filterText`, `dslState`, `queryError`, `activeSinceTs`, and `activeSinceLabel` — only fires if any of those are non-default
  - **Layer 6** (new): calls `setPivot(null)` to reset scope — only fires if `pivot !== null`
  - **Layer 7** (new): calls `jumpToBottom()` to resume live tail — only fires if `!autoFollow`
- The CTL-387 `:since` reset behavior is preserved: it continues to revert `activeSinceTs` to `initSinceTs` (the HUD startup value) as part of the filter-clear layer.

**Help text** (`HELP_LINES`):

- Updated the `Esc (top-level)` entry from `"clear all active filters + close overlays"` to `"progressively: clear filters → reset scope → resume live tail"` to reflect the new layered behavior.

## Full Escape Chain After This PR

```
Esc 1: help open?          → close help
Esc 2: dashboard open?     → defer to Dashboard.tsx handler
Esc 3: detail pane open?   → close detail pane
Esc 4: DSL overlay open?   → close DSL overlay
Esc 5: filter/NLQ active?  → clear filter, NLQ, :since window
Esc 6: scope narrowed?     → reset scope (setPivot(null))  [NEW]
Esc 7: paused?             → resume live tail (jumpToBottom())  [NEW]
Esc 8: already at default  → no-op
```

`G` (direct jump-to-bottom) and `r` (direct reset scope) are unchanged — Escape is additive, not a replacement.

## How to Verify It

- [ ] Open `catalyst-hud`, apply a scope via `t` or `o`, then press Escape with no filter active — scope should clear; live tail should stay paused if it was paused
- [ ] With scope cleared and HUD paused, press Escape again — live tail resumes (same as pressing `G`)
- [ ] With both a filter and a scope active, press Escape once — only the filter clears; scope remains; press again — scope clears
- [ ] With no overlays, no filter, no scope, and live tail running: Escape is a no-op
- [ ] Press `h` to open help — confirm the `Esc (top-level)` line reads the new progressive description
- [ ] Confirm `G` and `r` still work as direct shortcuts independently of Escape

## Related Issues

- Fixes https://linear.app/catalyst/issue/CTL-423
