### PR TITLE
feat(dev): HUD Workers/Orchestrators tabs — sortable columns (CTL-425)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
@@ -17,9 +17,14 @@ import {
 } from "../lib/dashboard-format.ts";
 
 import { InterestList } from "./InterestList.tsx";
-import { WorkerList } from "./WorkerList.tsx";
-import { OrchList } from "./OrchList.tsx";
+import { WorkerList, type WorkerSortKey } from "./WorkerList.tsx";
+import { OrchList, type OrchSortKey } from "./OrchList.tsx";
 import { RunsList } from "./RunsList.tsx";
+
+type SortDir = "asc" | "desc";
+
+const WORKER_SORT_CYCLE: WorkerSortKey[] = ["heartbeat", "status", "phase", "pr", "worker"];
+const ORCH_SORT_CYCLE: OrchSortKey[] = ["started", "active", "wave"];
 
 interface DashboardProps {
   visibleRows: number;
@@ -65,16 +70,77 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
   const [scrollOffset, setScrollOffset] = useState(0);
   const [showDetail, setShowDetail] = useState(false);
   const [detailScrollTop, setDetailScrollTop] = useState(0);
+  const [workerSortKey, setWorkerSortKey] = useState<WorkerSortKey>("heartbeat");
+  const [workerSortDir, setWorkerSortDir] = useState<SortDir>("desc");
+  const [orchSortKey, setOrchSortKey] = useState<OrchSortKey>("started");
+  const [orchSortDir, setOrchSortDir] = useState<SortDir>("desc");
 
   useEffect(() => {
     const id = setInterval(() => setData(readAll()), 5000);
     return () => clearInterval(id);
   }, []);
 
-  const total = rowCount(view, data);
+  const sortedWorkers = useMemo(() => {
+    const arr = [...data.workers];
+    const dir = workerSortDir === "asc" ? 1 : -1;
+    arr.sort((a, b) => {
+      let av: number | string, bv: number | string;
+      switch (workerSortKey) {
+        case "worker": av = a.workerName ?? ""; bv = b.workerName ?? ""; break;
+        case "status": av = a.status ?? ""; bv = b.status ?? ""; break;
+        case "phase": av = a.phase ?? (dir > 0 ? Infinity : -Infinity); bv = b.phase ?? (dir > 0 ? Infinity : -Infinity); break;
+        case "pr": av = a.pr?.number ?? (dir > 0 ? Infinity : -Infinity); bv = b.pr?.number ?? (dir > 0 ? Infinity : -Infinity); break;
+        case "heartbeat": {
+          const at = a.lastHeartbeat ? Date.parse(a.lastHeartbeat) : NaN;
+          const bt = b.lastHeartbeat ? Date.parse(b.lastHeartbeat) : NaN;
+          av = isNaN(at) ? (dir > 0 ? Infinity : -Infinity) : at;
+          bv = isNaN(bt) ? (dir > 0 ? Infinity : -Infinity) : bt;
+          break;
+        }
+      }
+      if (av < bv) return -1 * dir;
+      if (av > bv) return 1 * dir;
+      return 0;
+    });
+    return arr;
+  }, [data.workers, workerSortKey, workerSortDir]);
+
+  const sortedOrchs = useMemo(() => {
+    const arr = [...data.orchs];
+    const dir = orchSortDir === "asc" ? 1 : -1;
+    arr.sort((a, b) => {
+      let av: number | string, bv: number | string;
+      switch (orchSortKey) {
+        case "orch": av = a.orchestrator ?? a.id ?? ""; bv = b.orchestrator ?? b.id ?? ""; break;
+        case "wave": av = a.currentWave ?? (dir > 0 ? Infinity : -Infinity); bv = b.currentWave ?? (dir > 0 ? Infinity : -Infinity); break;
+        case "active": av = a.workersCount.active; bv = b.workersCount.active; break;
+        case "queue": av = a.queueLength; bv = b.queueLength; break;
+        case "started": {
+          const at = a.startedAt ? Date.parse(a.startedAt) : NaN;
+          const bt = b.startedAt ? Date.parse(b.startedAt) : NaN;
+          av = isNaN(at) ? (dir > 0 ? Infinity : -Infinity) : at;
+          bv = isNaN(bt) ? (dir > 0 ? Infinity : -Infinity) : bt;
+          break;
+        }
+        case "parallel": av = a.maxParallel ?? (dir > 0 ? Infinity : -Infinity); bv = b.maxParallel ?? (dir > 0 ? Infinity : -Infinity); break;
+      }
+      if (av < bv) return -1 * dir;
+      if (av > bv) return 1 * dir;
+      return 0;
+    });
+    return arr;
+  }, [data.orchs, orchSortKey, orchSortDir]);
+
+  const sortedData = useMemo<DashboardState>(() => ({
+    ...data,
+    workers: sortedWorkers,
+    orchs: sortedOrchs,
+  }), [data, sortedWorkers, sortedOrchs]);
+
+  const total = rowCount(view, sortedData);
 
   useEffect(() => {
-    if (selectedIndex >= total) setSelectedIndex(Math.max(0, total - 1));
+    if (selectedIndex >= total && total > 0) setSelectedIndex(Math.max(0, total - 1));
   }, [total, selectedIndex]);
 
   // Reserve rows for the tab bar (1), the bottom footer hint (1), and the
@@ -96,9 +162,9 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
   }, [selectedIndex, scrollOffset, listBodyRows]);
 
   const selectedRowJson = useMemo(() => {
-    const row = pickSelectedRow(view, data, selectedIndex);
+    const row = pickSelectedRow(view, sortedData, selectedIndex);
     return JSON.stringify(row, null, 2);
-  }, [view, data, selectedIndex]);
+  }, [view, sortedData, selectedIndex]);
 
   const detailLines = useMemo(() => selectedRowJson.split("\n"), [selectedRowJson]);
   const detailContentRows = Math.max(1, detailFootprint - 2);
@@ -138,6 +204,27 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
     if (key.pageDown) { setSelectedIndex((i) => Math.min(Math.max(0, total - 1), i + listBodyRows)); return; }
     if (key.pageUp) { setSelectedIndex((i) => Math.max(0, i - listBodyRows)); return; }
     if (input === "G") { setSelectedIndex(Math.max(0, total - 1)); return; }
+    if (input === "s") {
+      if (view === "workers") {
+        const next = WORKER_SORT_CYCLE[(WORKER_SORT_CYCLE.indexOf(workerSortKey) + 1) % WORKER_SORT_CYCLE.length] ?? "heartbeat";
+        setWorkerSortKey(next);
+        setSelectedIndex(0);
+        setScrollOffset(0);
+      } else if (view === "orchs") {
+        const next = ORCH_SORT_CYCLE[(ORCH_SORT_CYCLE.indexOf(orchSortKey) + 1) % ORCH_SORT_CYCLE.length] ?? "started";
+        setOrchSortKey(next);
+        setSelectedIndex(0);
+        setScrollOffset(0);
+      }
+      return;
+    }
+    if (input === "S") {
+      if (view === "workers") setWorkerSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      else if (view === "orchs") setOrchSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      setSelectedIndex(0);
+      setScrollOffset(0);
+      return;
+    }
     if (key.return) { setShowDetail(true); return; }
   });
 
@@ -158,7 +245,7 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
       <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor="cyan" paddingX={1}>
         {view === "interests" && (
           <InterestList
-            interests={data.interests}
+            interests={sortedData.interests}
             selectedIndex={selectedIndex}
             scrollOffset={scrollOffset}
             visibleRows={listBodyRows}
@@ -168,21 +255,25 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
         )}
         {view === "workers" && (
           <WorkerList
-            workers={data.workers}
+            workers={sortedData.workers}
             selectedIndex={selectedIndex}
             scrollOffset={scrollOffset}
             visibleRows={listBodyRows}
             cols={cols - 4}
             waitingSessions={brokerState?.waitingSessions}
+            sortKey={workerSortKey}
+            sortDir={workerSortDir}
           />
         )}
         {view === "orchs" && (
           <OrchList
-            orchs={data.orchs}
+            orchs={sortedData.orchs}
             selectedIndex={selectedIndex}
             scrollOffset={scrollOffset}
             visibleRows={listBodyRows}
             cols={cols - 4}
+            sortKey={orchSortKey}
+            sortDir={orchSortDir}
           />
         )}
         {view === "runs" && (
@@ -204,7 +295,7 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
         </Box>
       )}
       <Box flexShrink={0} paddingX={1}>
-        <Text dimColor>Tab: switch view  ·  1-4: jump  ·  j/k: move  ·  Enter: detail  ·  Esc / i: close</Text>
+        <Text dimColor>Tab: switch view  ·  1-4: jump  ·  j/k: move  ·  s/S: sort col/dir  ·  Enter: detail  ·  Esc / i: close</Text>
       </Box>
     </Box>
   );

--- a/plugins/dev/scripts/orch-monitor/cli/components/OrchList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/OrchList.tsx
@@ -2,12 +2,16 @@ import { Box, Text } from "ink";
 import type { OrchState } from "../lib/orch-state-reader.ts";
 import { formatRelativeTime, truncateRight } from "../lib/dashboard-format.ts";
 
+export type OrchSortKey = "orch" | "wave" | "active" | "queue" | "started" | "parallel";
+
 interface OrchListProps {
   orchs: OrchState[];
   selectedIndex: number;
   scrollOffset: number;
   visibleRows: number;
   cols: number;
+  sortKey?: OrchSortKey;
+  sortDir?: "asc" | "desc";
 }
 
 const COL_ORCH = 38;
@@ -22,24 +26,30 @@ function waveLabel(o: OrchState): string {
   return `${o.currentWave ?? "?"}/${o.totalWaves ?? "?"}`;
 }
 
+function sortIndicator(col: OrchSortKey, sortKey: OrchSortKey, sortDir: "asc" | "desc"): string {
+  return col === sortKey ? (sortDir === "asc" ? " ▲" : " ▼") : "";
+}
+
 export function OrchList({
   orchs,
   selectedIndex,
   scrollOffset,
   visibleRows,
   cols,
+  sortKey = "started",
+  sortDir = "desc",
 }: OrchListProps) {
   const visible = orchs.slice(scrollOffset, scrollOffset + visibleRows);
 
   return (
     <Box flexDirection="column" flexGrow={1}>
       <Box flexDirection="row">
-        <Box width={COL_ORCH} flexShrink={0} marginRight={1}><Text bold color="cyan">ORCHESTRATOR</Text></Box>
-        <Box width={COL_WAVE} flexShrink={0} marginRight={1}><Text bold color="cyan">WAVE</Text></Box>
-        <Box width={COL_ACTIVE} flexShrink={0} marginRight={1}><Text bold color="cyan">ACTIVE</Text></Box>
-        <Box width={COL_QUEUE} flexShrink={0} marginRight={1}><Text bold color="cyan">QUEUE</Text></Box>
-        <Box width={COL_STARTED} flexShrink={0} marginRight={1}><Text bold color="cyan">STARTED</Text></Box>
-        <Box width={COL_PARALLEL} flexShrink={0}><Text bold color="cyan">PARALLEL</Text></Box>
+        <Box width={COL_ORCH} flexShrink={0} marginRight={1}><Text bold color="cyan">{`ORCHESTRATOR${sortIndicator("orch", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_WAVE} flexShrink={0} marginRight={1}><Text bold color="cyan">{`WAVE${sortIndicator("wave", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_ACTIVE} flexShrink={0} marginRight={1}><Text bold color="cyan">{`ACTIVE${sortIndicator("active", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_QUEUE} flexShrink={0} marginRight={1}><Text bold color="cyan">{`QUEUE${sortIndicator("queue", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_STARTED} flexShrink={0} marginRight={1}><Text bold color="cyan">{`STARTED${sortIndicator("started", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_PARALLEL} flexShrink={0}><Text bold color="cyan">{`PARALLEL${sortIndicator("parallel", sortKey, sortDir)}`}</Text></Box>
       </Box>
       <Text dimColor>{"─".repeat(Math.max(0, cols - 1))}</Text>
       {visible.length === 0 && (

--- a/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
@@ -9,6 +9,8 @@ import {
   workerStatusColor,
 } from "../lib/dashboard-format.ts";
 
+export type WorkerSortKey = "worker" | "status" | "phase" | "pr" | "heartbeat";
+
 interface WorkerListProps {
   workers: WorkerSignal[];
   selectedIndex: number;
@@ -16,6 +18,8 @@ interface WorkerListProps {
   visibleRows: number;
   cols: number;
   waitingSessions?: WaitingSession[];
+  sortKey?: WorkerSortKey;
+  sortDir?: "asc" | "desc";
 }
 
 function findWaitingSession(ticket: string, sessions: WaitingSession[], nowMs: number): WaitingSession | null {
@@ -43,6 +47,10 @@ const COL_PHASE = 5;
 const COL_PR = 6;
 const COL_HEARTBEAT = 10;
 
+function sortIndicator(col: WorkerSortKey, sortKey: WorkerSortKey, sortDir: "asc" | "desc"): string {
+  return col === sortKey ? (sortDir === "asc" ? " ▲" : " ▼") : "";
+}
+
 export function WorkerList({
   workers,
   selectedIndex,
@@ -50,6 +58,8 @@ export function WorkerList({
   visibleRows,
   cols,
   waitingSessions = [],
+  sortKey = "heartbeat",
+  sortDir = "desc",
 }: WorkerListProps) {
   const worktreeW = Math.max(8, cols - COL_WORKER - COL_STATUS - COL_PHASE - COL_PR - COL_HEARTBEAT - 6);
   const visible = workers.slice(scrollOffset, scrollOffset + visibleRows);
@@ -58,11 +68,11 @@ export function WorkerList({
   return (
     <Box flexDirection="column" flexGrow={1}>
       <Box flexDirection="row">
-        <Box width={COL_WORKER} flexShrink={0} marginRight={1}><Text bold color="cyan">WORKER</Text></Box>
-        <Box width={COL_STATUS} flexShrink={0} marginRight={1}><Text bold color="cyan">STATUS</Text></Box>
-        <Box width={COL_PHASE} flexShrink={0} marginRight={1}><Text bold color="cyan">PHASE</Text></Box>
-        <Box width={COL_PR} flexShrink={0} marginRight={1}><Text bold color="cyan">PR</Text></Box>
-        <Box width={COL_HEARTBEAT} flexShrink={0} marginRight={1}><Text bold color="cyan">HEARTBEAT</Text></Box>
+        <Box width={COL_WORKER} flexShrink={0} marginRight={1}><Text bold color="cyan">{`WORKER${sortIndicator("worker", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_STATUS} flexShrink={0} marginRight={1}><Text bold color="cyan">{`STATUS${sortIndicator("status", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_PHASE} flexShrink={0} marginRight={1}><Text bold color="cyan">{`PHASE${sortIndicator("phase", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_PR} flexShrink={0} marginRight={1}><Text bold color="cyan">{`PR${sortIndicator("pr", sortKey, sortDir)}`}</Text></Box>
+        <Box width={COL_HEARTBEAT} flexShrink={0} marginRight={1}><Text bold color="cyan">{`HEARTBEAT${sortIndicator("heartbeat", sortKey, sortDir)}`}</Text></Box>
         <Box flexGrow={1}><Text bold color="cyan">WORKTREE</Text></Box>
       </Box>
       <Text dimColor>{"─".repeat(Math.max(0, cols - 1))}</Text>


### PR DESCRIPTION
## Summary

- Add `s` key to cycle through sort columns (HEARTBEAT → STATUS → PHASE → PR → WORKER for workers; STARTED → ACTIVE → WAVE for orchs)
- Add `S` (shift+s) to toggle ascending/descending sort direction
- Default sort: HEARTBEAT descending for Workers tab (most recently active first), STARTED descending for Orchestrators tab
- Sorted column header shows ▲/▼ arrow indicator
- Sort state is per-tab and independent; resets to position 0 on sort change

## Implementation

- `Dashboard.tsx`: sort state (`workerSortKey`, `workerSortDir`, `orchSortKey`, `orchSortDir`) + `useMemo` sort applied before passing arrays to list components + keyboard handlers for `s`/`S`
- `WorkerList.tsx`: exports `WorkerSortKey` type, accepts `sortKey`/`sortDir` props, renders indicator on sorted column header
- `OrchList.tsx`: exports `OrchSortKey` type, accepts `sortKey`/`sortDir` props, renders indicator on sorted column header
- Null values sort to end regardless of direction

Refs: CTL-425