### PR TITLE
feat(dev): HUD Runs tab showing orchestrator → tickets/workers hierarchy (CTL-426)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Dashboard.tsx
@@ -7,6 +7,8 @@ import type { WorkerSignal } from "../lib/worker-signals-reader.ts";
 import { readWorkerSignals } from "../lib/worker-signals-reader.ts";
 import type { OrchState } from "../lib/orch-state-reader.ts";
 import { readOrchStates } from "../lib/orch-state-reader.ts";
+import type { RunRow } from "../lib/runs-reader.ts";
+import { readRunRows } from "../lib/runs-reader.ts";
 import type { BrokerState } from "../lib/broker-key-health.ts";
 import {
   DASHBOARD_VIEWS,
@@ -17,6 +19,7 @@ import {
 import { InterestList } from "./InterestList.tsx";
 import { WorkerList } from "./WorkerList.tsx";
 import { OrchList } from "./OrchList.tsx";
+import { RunsList } from "./RunsList.tsx";
 
 interface DashboardProps {
   visibleRows: number;
@@ -29,6 +32,7 @@ interface DashboardState {
   interests: BrokerInterest[];
   workers: WorkerSignal[];
   orchs: OrchState[];
+  runs: RunRow[];
 }
 
 function readAll(): DashboardState {
@@ -36,19 +40,22 @@ function readAll(): DashboardState {
     interests: readBrokerInterests(),
     workers: readWorkerSignals(),
     orchs: readOrchStates(),
+    runs: readRunRows(),
   };
 }
 
 function pickSelectedRow(view: DashboardView, state: DashboardState, idx: number): unknown {
   if (view === "interests") return state.interests[idx] ?? null;
   if (view === "workers") return state.workers[idx]?.raw ?? null;
-  return state.orchs[idx]?.raw ?? null;
+  if (view === "orchs") return state.orchs[idx]?.raw ?? null;
+  return state.runs[idx]?.raw ?? null;
 }
 
 function rowCount(view: DashboardView, state: DashboardState): number {
   if (view === "interests") return state.interests.length;
   if (view === "workers") return state.workers.length;
-  return state.orchs.length;
+  if (view === "orchs") return state.orchs.length;
+  return state.runs.length;
 }
 
 export function Dashboard({ visibleRows, cols, brokerState, onClose }: DashboardProps) {
@@ -119,6 +126,7 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
     if (input === "1") { setView("interests"); setSelectedIndex(0); setScrollOffset(0); return; }
     if (input === "2") { setView("workers"); setSelectedIndex(0); setScrollOffset(0); return; }
     if (input === "3") { setView("orchs"); setSelectedIndex(0); setScrollOffset(0); return; }
+    if (input === "4") { setView("runs"); setSelectedIndex(0); setScrollOffset(0); return; }
     if (input === "j" || key.downArrow) {
       setSelectedIndex((i) => Math.min(Math.max(0, total - 1), i + 1));
       return;
@@ -177,6 +185,15 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
             cols={cols - 4}
           />
         )}
+        {view === "runs" && (
+          <RunsList
+            rows={data.runs}
+            selectedIndex={selectedIndex}
+            scrollOffset={scrollOffset}
+            visibleRows={listBodyRows}
+            cols={cols - 4}
+          />
+        )}
       </Box>
       {showDetail && (
         <Box flexDirection="column" flexShrink={0} borderStyle="single" borderColor="gray" paddingX={1}>
@@ -187,7 +204,7 @@ export function Dashboard({ visibleRows, cols, brokerState, onClose }: Dashboard
         </Box>
       )}
       <Box flexShrink={0} paddingX={1}>
-        <Text dimColor>Tab: switch view  ·  1/2/3: jump  ·  j/k: move  ·  Enter: detail  ·  Esc / i: close</Text>
+        <Text dimColor>Tab: switch view  ·  1-4: jump  ·  j/k: move  ·  Enter: detail  ·  Esc / i: close</Text>
       </Box>
     </Box>
   );

--- a/plugins/dev/scripts/orch-monitor/cli/components/RunsList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/RunsList.tsx
@@ -1,0 +1,129 @@
+import { Box, Text } from "ink";
+import type { RunRow } from "../lib/runs-reader.ts";
+import {
+  formatRelativeTime,
+  truncateRight,
+  workerStatusColor,
+} from "../lib/dashboard-format.ts";
+
+interface RunsListProps {
+  rows: RunRow[];
+  selectedIndex: number;
+  scrollOffset: number;
+  visibleRows: number;
+  cols: number;
+}
+
+const COL_ORCH = 22;
+const COL_TICKET = 10;
+const COL_STATUS = 13;
+const COL_PHASE = 5;
+const COL_PR = 6;
+// margins: 5 gaps of 1 between the 6 column groups
+const FIXED_COLS = COL_ORCH + COL_TICKET + COL_STATUS + COL_PHASE + COL_PR + 5;
+
+function waveLabel(currentWave: number | null, totalWaves: number | null): string {
+  if (currentWave === null && totalWaves === null) return "";
+  return `W${currentWave ?? "?"}/${totalWaves ?? "?"}`;
+}
+
+export function RunsList({
+  rows,
+  selectedIndex,
+  scrollOffset,
+  visibleRows,
+  cols,
+}: RunsListProps) {
+  const titleW = Math.max(4, cols - FIXED_COLS);
+  const visible = rows.slice(scrollOffset, scrollOffset + visibleRows);
+
+  const orchCount = rows.filter((r) => r.kind === "orch").length;
+  const workerCount = rows.filter((r) => r.kind === "worker").length;
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="row">
+        <Box width={COL_ORCH} flexShrink={0} marginRight={1}><Text bold color="cyan">ORCHESTRATOR</Text></Box>
+        <Box width={COL_TICKET} flexShrink={0} marginRight={1}><Text bold color="cyan">TICKET</Text></Box>
+        <Box width={titleW} flexShrink={0} marginRight={1}><Text bold color="cyan">LABEL</Text></Box>
+        <Box width={COL_STATUS} flexShrink={0} marginRight={1}><Text bold color="cyan">STATUS</Text></Box>
+        <Box width={COL_PHASE} flexShrink={0} marginRight={1}><Text bold color="cyan">PHASE</Text></Box>
+        <Box width={COL_PR} flexShrink={0}><Text bold color="cyan">PR</Text></Box>
+      </Box>
+      <Text dimColor>{"─".repeat(Math.max(0, cols - 1))}</Text>
+      {visible.length === 0 && (
+        <Box paddingX={1}><Text dimColor>(no runs found)</Text></Box>
+      )}
+      {visible.map((row, idx) => {
+        const realIdx = scrollOffset + idx;
+        const selected = realIdx === selectedIndex;
+
+        if (row.kind === "orch") {
+          const wave = waveLabel(row.currentWave, row.totalWaves);
+          const active = `${row.workersCount.active}/${row.workersCount.total}`;
+          const started = formatRelativeTime(row.startedAt);
+          const orchId = truncateRight(row.orchestrator ?? row.orchId, COL_ORCH);
+          const summary = truncateRight(
+            [wave, `${active} workers`, started ? `ago:${started}` : ""].filter(Boolean).join("  "),
+            titleW,
+          );
+          return (
+            <Box key={`orch-${row.orchId}-${realIdx}`} flexDirection="row">
+              <Box width={COL_ORCH} flexShrink={0} marginRight={1}>
+                <Text color={selected ? "black" : "cyan"} bold={!selected} inverse={selected}>{orchId}</Text>
+              </Box>
+              <Box width={COL_TICKET} flexShrink={0} marginRight={1}>
+                <Text dimColor={!selected} inverse={selected}>{" "}</Text>
+              </Box>
+              <Box width={titleW} flexShrink={0} marginRight={1}>
+                <Text color={selected ? undefined : "cyan"} dimColor={!selected} inverse={selected}>{summary}</Text>
+              </Box>
+              <Box width={COL_STATUS} flexShrink={0} marginRight={1}>
+                <Text dimColor={!selected} inverse={selected}>{" "}</Text>
+              </Box>
+              <Box width={COL_PHASE} flexShrink={0} marginRight={1}>
+                <Text dimColor={!selected} inverse={selected}>{" "}</Text>
+              </Box>
+              <Box width={COL_PR} flexShrink={0}>
+                <Text dimColor={!selected} inverse={selected}>{" "}</Text>
+              </Box>
+            </Box>
+          );
+        }
+
+        // Worker row
+        const ticket = truncateRight(row.ticket, COL_TICKET);
+        const label = truncateRight(row.label ?? "—", titleW);
+        const status = truncateRight(row.status, COL_STATUS);
+        const phase = truncateRight(row.phase !== null ? String(row.phase) : "—", COL_PHASE);
+        const pr = truncateRight(row.pr ? `#${row.pr.number}` : "—", COL_PR);
+        const statusColor = workerStatusColor(row.status);
+
+        return (
+          <Box key={`worker-${row.orchId}-${row.ticket}-${realIdx}`} flexDirection="row">
+            <Box width={COL_ORCH} flexShrink={0} marginRight={1}>
+              <Text dimColor={!selected} inverse={selected}>{truncateRight("  └", COL_ORCH)}</Text>
+            </Box>
+            <Box width={COL_TICKET} flexShrink={0} marginRight={1}>
+              <Text color={selected ? "black" : "white"} inverse={selected}>{ticket}</Text>
+            </Box>
+            <Box width={titleW} flexShrink={0} marginRight={1}>
+              <Text dimColor={!selected} inverse={selected}>{label}</Text>
+            </Box>
+            <Box width={COL_STATUS} flexShrink={0} marginRight={1}>
+              <Text color={statusColor} inverse={selected}>{status}</Text>
+            </Box>
+            <Box width={COL_PHASE} flexShrink={0} marginRight={1}>
+              <Text dimColor={!selected} inverse={selected}>{phase}</Text>
+            </Box>
+            <Box width={COL_PR} flexShrink={0}>
+              <Text color={row.pr ? "cyan" : "gray"} inverse={selected}>{pr}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+      <Box flexGrow={1} />
+      <Text dimColor>{`${orchCount} run${orchCount === 1 ? "" : "s"}  ·  ${workerCount} worker${workerCount === 1 ? "" : "s"}  ·  recent window 24h`}</Text>
+    </Box>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.test.ts
@@ -184,12 +184,13 @@ describe("lastPathSegment", () => {
 });
 
 describe("DASHBOARD_VIEWS + dashboardViewLabel", () => {
-  test("has three views in order", () => {
-    expect(DASHBOARD_VIEWS).toEqual(["interests", "workers", "orchs"]);
+  test("has four views in order", () => {
+    expect(DASHBOARD_VIEWS).toEqual(["interests", "workers", "orchs", "runs"]);
   });
   test("labels for each view", () => {
     expect(dashboardViewLabel("interests")).toBe("Interests");
     expect(dashboardViewLabel("workers")).toBe("Workers");
     expect(dashboardViewLabel("orchs")).toBe("Orchestrators");
+    expect(dashboardViewLabel("runs")).toBe("Runs");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.ts
@@ -76,7 +76,7 @@ export function lastPathSegment(p: string | null): string {
   return idx >= 0 ? stripped.slice(idx + 1) : stripped;
 }
 
-export const DASHBOARD_VIEWS = ["interests", "workers", "orchs"] as const;
+export const DASHBOARD_VIEWS = ["interests", "workers", "orchs", "runs"] as const;
 export type DashboardView = (typeof DASHBOARD_VIEWS)[number];
 
 export function dashboardViewLabel(v: DashboardView): string {
@@ -84,5 +84,6 @@ export function dashboardViewLabel(v: DashboardView): string {
     case "interests": return "Interests";
     case "workers": return "Workers";
     case "orchs": return "Orchestrators";
+    case "runs": return "Runs";
   }
 }

--- a/plugins/dev/scripts/orch-monitor/cli/lib/runs-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/runs-reader.ts
@@ -1,0 +1,138 @@
+// runs-reader.ts — build a flat RunRow[] hierarchy for the HUD Runs tab (CTL-426).
+// Each orchestrator contributes one OrchRunRow followed by WorkerRunRow entries for
+// its recent workers. Orchs are sorted newest-first; workers within each orch are
+// sorted active-first (by phase desc), then terminal (by updatedAt desc).
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { runsDirPath, scanOrchestratorWorkers } from "./worker-signals-reader.ts";
+import type { WorkerPR } from "./worker-signals-reader.ts";
+
+export interface OrchRunRow {
+  kind: "orch";
+  orchId: string;
+  orchestrator: string | null;
+  currentWave: number | null;
+  totalWaves: number | null;
+  workersCount: { active: number; total: number };
+  startedAt: string | null;
+  raw: unknown;
+}
+
+export interface WorkerRunRow {
+  kind: "worker";
+  orchId: string;
+  ticket: string;
+  label: string | null;
+  status: string;
+  phase: number | null;
+  pr: WorkerPR | null;
+  updatedAt: string | null;
+  raw: unknown;
+}
+
+export type RunRow = OrchRunRow | WorkerRunRow;
+
+const TERMINAL_STATUSES = new Set(["done", "failed", "stalled", "deploy-failed"]);
+const RECENT_WINDOW_MS = 24 * 3_600_000;
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+function asNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+export function readRunRows(runsDir?: string, now: number = Date.now()): RunRow[] {
+  const dir = runsDir ?? runsDirPath();
+  if (!existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  const orchInfos: Array<{ name: string; startedAt: string | null; raw: Record<string, unknown> }> = [];
+
+  for (const name of entries) {
+    const orchDir = resolve(dir, name);
+    try {
+      if (!statSync(orchDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const stateFile = resolve(orchDir, "state.json");
+    let raw: Record<string, unknown> = {};
+    if (existsSync(stateFile)) {
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(stateFile, "utf8"));
+        if (parsed && typeof parsed === "object") raw = parsed as Record<string, unknown>;
+      } catch {
+        // leave raw empty
+      }
+    }
+    orchInfos.push({ name, startedAt: asString(raw.startedAt), raw });
+  }
+
+  orchInfos.sort((a, b) => {
+    const ta = a.startedAt ? Date.parse(a.startedAt) : 0;
+    const tb = b.startedAt ? Date.parse(b.startedAt) : 0;
+    return tb - ta;
+  });
+
+  const rows: RunRow[] = [];
+
+  for (const { name, raw } of orchInfos) {
+    const orchDir = resolve(dir, name);
+    const workers = scanOrchestratorWorkers(orchDir).filter((w) => {
+      if (!TERMINAL_STATUSES.has(w.status)) return true;
+      const ts = w.updatedAt ?? w.completedAt;
+      if (!ts) return false;
+      const ms = Date.parse(ts);
+      return Number.isFinite(ms) && now - ms <= RECENT_WINDOW_MS;
+    });
+
+    if (workers.length === 0) continue;
+
+    const active = workers.filter((w) => !TERMINAL_STATUSES.has(w.status)).length;
+
+    rows.push({
+      kind: "orch",
+      orchId: name,
+      orchestrator: asString(raw.orchestrator) ?? name,
+      currentWave: asNumber(raw.currentWave),
+      totalWaves: asNumber(raw.totalWaves),
+      workersCount: { active, total: workers.length },
+      startedAt: asString(raw.startedAt),
+      raw,
+    });
+
+    const sorted = [...workers].sort((a, b) => {
+      const aT = TERMINAL_STATUSES.has(a.status);
+      const bT = TERMINAL_STATUSES.has(b.status);
+      if (aT !== bT) return aT ? 1 : -1;
+      if (!aT) return (b.phase ?? 0) - (a.phase ?? 0);
+      const ta = a.updatedAt ? Date.parse(a.updatedAt) : 0;
+      const tb = b.updatedAt ? Date.parse(b.updatedAt) : 0;
+      return tb - ta;
+    });
+
+    for (const w of sorted) {
+      rows.push({
+        kind: "worker",
+        orchId: name,
+        ticket: w.ticket,
+        label: w.label,
+        status: w.status,
+        phase: w.phase,
+        pr: w.pr,
+        updatedAt: w.updatedAt,
+        raw: w.raw,
+      });
+    }
+  }
+
+  return rows;
+}


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-15T06:55:00Z -->
<!-- Last updated: 2026-05-15T06:55:00Z -->
<!-- PR: #742 -->
<!-- Previous commits: 949f35b8 -->

## Summary

Adds a **Runs** tab (4th Dashboard tab, key `4`) to the CLI HUD (`hud.tsx`). The tab shows a hierarchical tree view of all orchestrator runs with their worker tickets underneath — filling the gap between the aggregate Orchestrators tab and the flat Workers tab. Each orchestrator gets a bold header row with wave progress and active-worker counts; each worker below it shows ticket ID, label, status, phase, and PR number with the existing status color coding.

## Changes Made

### `cli/lib/runs-reader.ts` (new file)

Reads `~/catalyst/runs/` and produces a flat `RunRow[]` array with two row kinds:

- `OrchRunRow` (`kind: "orch"`) — one per orchestrator directory with a `state.json`; includes `orchestrator`, `currentWave/totalWaves`, `workersCount.active/total`, `startedAt`, and `raw` (for detail pane)
- `WorkerRunRow` (`kind: "worker"`) — one per worker signal file under `workers/`; includes `ticket`, `label`, `status`, `phase`, `pr`, `updatedAt`, and `raw`

Sort order: orchestrators by `startedAt` descending (newest first); workers within each orchestrator active-first (by phase desc), then terminal by `updatedAt` desc. Applies the same 24-hour recency filter as the Workers tab. Orchestrators with zero recent workers are omitted.

Re-uses `runsDirPath()` and `scanOrchestratorWorkers()` from `worker-signals-reader.ts` — no duplicated scanning logic.

### `cli/components/RunsList.tsx` (new file)

Ink component following the established list-component pattern (fixed column widths, header row, separator, body rows, footer summary, empty state). Column layout:

```
ORCHESTRATOR(22)  TICKET(10)  LABEL(flex)  STATUS(13)  PHASE(5)  PR(6)
```

**Orch header rows** (bold cyan): shows truncated orchestrator ID + wave label + active/total workers + age.

**Worker sub-rows** (indented `  └`): shows ticket, label (worker signal `label` field, falls back to `—`), status with `workerStatusColor()` color coding, numeric phase, and `#<N>` PR number when present.

Both row kinds support `j/k` navigation and Enter to open the detail pane (returns `raw` of the selected row).

### `cli/lib/dashboard-format.ts`

- Line 79: appended `"runs"` to `DASHBOARD_VIEWS` tuple
- `dashboardViewLabel`: added `case "runs": return "Runs";`

### `cli/components/Dashboard.tsx`

- Imported `RunRow`, `readRunRows` from `runs-reader.ts`; imported `RunsList`
- Added `runs: RunRow[]` to `DashboardState` interface
- Added `runs: readRunRows()` to `readAll()` (polled every 5 s)
- Added `"runs"` cases to `rowCount()` and `pickSelectedRow()`
- Added `input === "4"` key handler
- Added `{view === "runs" && <RunsList ... />}` conditional render
- Updated footer hint from `1/2/3` to `1-4`

### `cli/lib/dashboard-format.test.ts`

- Updated `DASHBOARD_VIEWS` assertion from 3-element to 4-element tuple (includes `"runs"`)
- Added `dashboardViewLabel("runs")` assertion

## How to Verify It

- [ ] Launch `orch-monitor` HUD; press `i` to open Dashboard; press `4` or Tab until Runs tab is active — column headers render correctly
- [ ] With active orchestrator runs in `~/catalyst/runs/`: bold orch header rows appear with wave/active summary; worker rows appear indented with `└` prefix and correct status colors
- [ ] With no runs or all runs older than 24h: `(no runs found)` empty state shown
- [ ] `j/k` navigation selects both orch and worker rows; Enter opens detail pane showing `raw` JSON
- [ ] Existing tabs (1/2/3) still navigate correctly; Tab key cycles through all four tabs
- [x] `bun run typecheck` passes (0 errors, only pre-existing `ui/` warnings)
- [x] `bun test cli/lib/dashboard-format.test.ts` passes (34/34)

## Related Issues

- Fixes CTL-426: https://linear.app/coalesce-labs/issue/CTL-426
