### PR TITLE
fix(dev): HUD interests footer drops 'ago' suffix on null timestamps (CTL-432)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
@@ -21,12 +21,12 @@ function interestTypeLabel(t: BrokerInterest["interest_type"]): string {
   return t ?? "prose";
 }
 
-function footerSummary(interests: BrokerInterest[], brokerState: BrokerState | null, now: number = Date.now()): string {
+export function footerSummary(interests: BrokerInterest[], brokerState: BrokerState | null, now: number = Date.now()): string {
   const n = interests.length;
-  const lastWake = brokerState?.lastWakeAt ? formatRelativeTime(brokerState.lastWakeAt, now) : "—";
-  const lastReg = brokerState?.lastRegisterAt ? formatRelativeTime(brokerState.lastRegisterAt, now) : "—";
+  const lastWake = brokerState?.lastWakeAt ? `${formatRelativeTime(brokerState.lastWakeAt, now)} ago` : "—";
+  const lastReg = brokerState?.lastRegisterAt ? `${formatRelativeTime(brokerState.lastRegisterAt, now)} ago` : "—";
   const uptime = brokerState?.startedAt ? formatRelativeTime(brokerState.startedAt, now) : "—";
-  return `${n} interest${n === 1 ? "" : "s"}  ·  last wake ${lastWake} ago  ·  last register ${lastReg} ago  ·  daemon up ${uptime}`;
+  return `${n} interest${n === 1 ? "" : "s"}  ·  last wake ${lastWake}  ·  last register ${lastReg}  ·  daemon up ${uptime}`;
 }
 
 export function InterestList({

--- a/plugins/dev/scripts/orch-monitor/cli/components/interest-list-footer.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/interest-list-footer.test.ts
@@ -1,0 +1,45 @@
+// interest-list-footer.test.ts — verifies footerSummary in InterestList.tsx
+// renders " ago" only when the underlying timestamp is non-null (CTL-432).
+
+import { describe, test, expect } from "bun:test";
+import { footerSummary } from "./InterestList.tsx";
+import type { BrokerState } from "../lib/broker-key-health.ts";
+
+const NOW = Date.parse("2026-05-15T15:00:00Z");
+
+describe("footerSummary", () => {
+  test("null brokerState — no ' ago' on em-dash placeholders", () => {
+    const out = footerSummary([], null, NOW);
+    expect(out).toContain("last wake —  ·");
+    expect(out).toContain("last register —  ·");
+    expect(out).not.toContain("— ago");
+  });
+
+  test("both timestamps present — ' ago' suffix appears", () => {
+    const state: BrokerState = {
+      lastWakeAt: "2026-05-15T14:55:00Z",
+      lastRegisterAt: "2026-05-15T14:50:00Z",
+    };
+    const out = footerSummary([], state, NOW);
+    expect(out).toMatch(/last wake \S+ ago {2}·/);
+    expect(out).toMatch(/last register \S+ ago {2}·/);
+  });
+
+  test("mixed — wake set, register null — only wake gets ' ago'", () => {
+    const state: BrokerState = {
+      lastWakeAt: "2026-05-15T14:55:00Z",
+      lastRegisterAt: null,
+    };
+    const out = footerSummary([], state, NOW);
+    expect(out).toMatch(/last wake \S+ ago {2}·/);
+    expect(out).toContain("last register —  ·");
+    expect(out).not.toContain("— ago");
+  });
+
+  test("daemon up segment never carries ' ago' even when startedAt is set", () => {
+    const state: BrokerState = { startedAt: "2026-05-15T13:00:00Z" };
+    const out = footerSummary([], state, NOW);
+    expect(out).toMatch(/daemon up \S+$/);
+    expect(out).not.toMatch(/daemon up \S+ ago/);
+  });
+});


### PR DESCRIPTION
## What

Drops the stray " ago" suffix in the orch-monitor HUD interests footer when `brokerState.lastWakeAt` or `lastRegisterAt` is null.

Before:
```
3 interests  ·  last wake — ago  ·  last register — ago  ·  daemon up 4h
```

After:
```
3 interests  ·  last wake —  ·  last register —  ·  daemon up 4h
```

## Why

The footer template appended " ago" unconditionally, even when the underlying timestamp was null and the value had defaulted to an em-dash. `last wake — ago` doesn't make sense — there's no time to be "ago" relative to.

## How

`plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx`:

- Move the " ago" suffix inside the ternary that picks between the formatted relative time and the `—` placeholder, so it only appears when there's a real timestamp to qualify.
- Drop the trailing " ago" from the template string so it doesn't double up.
- Export `footerSummary` so the new test can import it without driving Ink (same pattern `footer-hints.test.ts` uses for `PromptInput.tsx`).

The `daemon up …` segment is unchanged — it never carried " ago" (because "daemon up 2h" reads as "for 2 hours").

## Test plan

- [x] New unit test `interest-list-footer.test.ts` — 4 cases (null state, both timestamps set, mixed wake-only, daemon-up never gets ago)
- [x] Test fails against current `main` (verified via TDD red), passes after the fix
- [x] Full `cli/` test suite: 228/228 pass
- [x] `bun run typecheck` clean
- [x] No reward-hacking patterns (no `as any`, `@ts-ignore`, non-null `!`, etc.)

Closes CTL-432.