### PR TITLE
feat(dev): HUD WORKER column strips orch prefix (CTL-431)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
@@ -1,7 +1,12 @@
 import { Box, Text } from "ink";
 import type { BrokerInterest } from "../lib/broker-interests-reader.ts";
 import type { BrokerState } from "../lib/broker-key-health.ts";
-import { formatRelativeTime, interestWatches, truncateRight } from "../lib/dashboard-format.ts";
+import {
+  formatRelativeTime,
+  formatWorkerCell,
+  interestWatches,
+  truncateRight,
+} from "../lib/dashboard-format.ts";
 
 interface InterestListProps {
   interests: BrokerInterest[];
@@ -66,7 +71,11 @@ export function InterestList({
         const orch = truncateRight(i.orchestrator ?? "—", COL_ORCH);
         // Show the session ID that will actually receive the wake event.
         // When session_id equals orchestrator (orchestrator-level interests), label it "orchestrator".
-        const workerRaw = i.session_id === i.orchestrator ? "orchestrator" : (i.session_id ?? i.key);
+        // Otherwise compress the worker/interest identifier so it isn't a near-duplicate of the
+        // ORCHESTRATOR column (workers and per-orch interest keys both start with the orch ID).
+        const workerRaw = i.session_id === i.orchestrator
+          ? "orchestrator"
+          : formatWorkerCell(i.session_id ?? i.key, i.orchestrator);
         const worker = truncateRight(workerRaw, COL_WORKER);
         const type = truncateRight(interestTypeLabel(i.interest_type), COL_TYPE);
         const watches = truncateRight(interestWatches(i), COL_WATCHES);

--- a/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
@@ -3,6 +3,7 @@ import type { WaitingSession } from "../lib/broker-key-health.ts";
 import type { WorkerSignal } from "../lib/worker-signals-reader.ts";
 import {
   formatRelativeTime,
+  formatWorkerCell,
   isStaleHeartbeat,
   lastPathSegment,
   truncateRight,
@@ -86,7 +87,7 @@ export function WorkerList({
         const ws = findWaitingSession(w.ticket, waitingSessions, nowMs);
         const statusColor = ws ? "magenta" : workerStatusColor(w.status);
         const statusText = ws ? `wait:${formatTimeoutRemaining(ws.timeoutAt, nowMs)}` : w.status;
-        const worker = truncateRight(w.workerName, COL_WORKER);
+        const worker = truncateRight(formatWorkerCell(w.workerName, w.orchestrator), COL_WORKER);
         const status = truncateRight(statusText, COL_STATUS);
         const phase = truncateRight(w.phase !== null ? String(w.phase) : "—", COL_PHASE);
         const pr = truncateRight(w.pr ? `#${w.pr.number}` : "—", COL_PR);

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.test.ts
@@ -11,6 +11,8 @@ import {
   lastPathSegment,
   DASHBOARD_VIEWS,
   dashboardViewLabel,
+  shortOrchId,
+  formatWorkerCell,
 } from "./dashboard-format.ts";
 import type { BrokerInterest } from "./broker-interests-reader.ts";
 
@@ -181,6 +183,59 @@ describe("lastPathSegment", () => {
   test("no slash → whole string", () => expect(lastPathSegment("plain")).toBe("plain"));
   test("null → em-dash", () => expect(lastPathSegment(null)).toBe("—"));
   test("empty string → em-dash", () => expect(lastPathSegment("")).toBe("—"));
+});
+
+describe("shortOrchId", () => {
+  test("returns a 4-char string", () => {
+    expect(shortOrchId("o-tl-431-ctl-432")).toHaveLength(4);
+  });
+  test("is deterministic", () => {
+    const id = "o-tl-431-ctl-432-ctl-433-ctl-434-CTL-431";
+    expect(shortOrchId(id)).toBe(shortOrchId(id));
+  });
+  test("returns base36 chars only", () => {
+    expect(shortOrchId("orch-adv-944-946")).toMatch(/^[0-9a-z]{4}$/);
+  });
+  test("distinct inputs produce distinct outputs (regression guard)", () => {
+    expect(shortOrchId("orch-a")).not.toBe(shortOrchId("orch-b"));
+    expect(shortOrchId("o-tl-431-ctl-432")).not.toBe(shortOrchId("o-tl-431-ctl-433"));
+  });
+});
+
+describe("formatWorkerCell", () => {
+  test("strips orchestrator prefix and prepends short fingerprint", () => {
+    const orch = "o-tl-431-ctl-432-ctl-433";
+    const result = formatWorkerCell(`${orch}-CTL-431`, orch);
+    expect(result).toBe(`${shortOrchId(orch)}:CTL-431`);
+  });
+
+  test("null orchestrator → workerName unchanged", () => {
+    expect(formatWorkerCell("standalone-worker", null)).toBe("standalone-worker");
+  });
+
+  test("empty orchestrator → workerName unchanged", () => {
+    expect(formatWorkerCell("standalone-worker", "")).toBe("standalone-worker");
+  });
+
+  test("worker does not start with orchestrator prefix → unchanged", () => {
+    expect(formatWorkerCell("unrelated-worker", "o-foo")).toBe("unrelated-worker");
+  });
+
+  test("worker equals orchestrator exactly → unchanged (no `-` to strip)", () => {
+    expect(formatWorkerCell("o-foo", "o-foo")).toBe("o-foo");
+  });
+
+  test("worker matches orchestrator prefix without `-` separator → unchanged", () => {
+    // "o-foo-bar" starts with "o-foo" but the next char isn't `-`, so don't strip.
+    expect(formatWorkerCell("o-foobar", "o-foo")).toBe("o-foobar");
+  });
+
+  test("interest key with -pr-lifecycle suffix is stripped to lifecycle name", () => {
+    const orch = "orch-adv-944-946-947";
+    expect(formatWorkerCell(`${orch}-pr-lifecycle`, orch)).toBe(
+      `${shortOrchId(orch)}:pr-lifecycle`,
+    );
+  });
 });
 
 describe("DASHBOARD_VIEWS + dashboardViewLabel", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.ts
@@ -76,6 +76,29 @@ export function lastPathSegment(p: string | null): string {
   return idx >= 0 ? stripped.slice(idx + 1) : stripped;
 }
 
+// FNV-1a 32-bit hash → base36, padded to 4 chars. Disambiguates workers from
+// different orchestrators in the WORKER column without lengthening the cell —
+// the full orchestrator ID is still visible in the adjacent ORCHESTRATOR column.
+export function shortOrchId(orchestrator: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < orchestrator.length; i++) {
+    h ^= orchestrator.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return ((h >>> 0) % 1679616).toString(36).padStart(4, "0");
+}
+
+// Compress a worker/interest identifier for the HUD WORKER column. Worker names
+// follow `{orchestrator}-{ticket}`, so the raw value otherwise looks nearly
+// identical to the adjacent ORCHESTRATOR column once truncated. When the raw
+// value carries the orchestrator prefix, replace it with a short fingerprint.
+export function formatWorkerCell(rawWorker: string, orchestrator: string | null): string {
+  if (!orchestrator) return rawWorker;
+  const prefix = `${orchestrator}-`;
+  if (!rawWorker.startsWith(prefix)) return rawWorker;
+  return `${shortOrchId(orchestrator)}:${rawWorker.slice(prefix.length)}`;
+}
+
 export const DASHBOARD_VIEWS = ["interests", "workers", "orchs", "runs"] as const;
 export type DashboardView = (typeof DASHBOARD_VIEWS)[number];
 


### PR DESCRIPTION
## Summary

In the HUD Interests and Workers tabs, the WORKER column was showing the full worker name (e.g. `o-tl-431-ctl-432-ctl-433-ctl-434-CTL-431`) or the full interest key. Since worker names follow `{orchestrator-id}-{ticket}` and per-orch interest keys start with the orchestrator ID, the WORKER column looked nearly identical to the adjacent ORCHESTRATOR column once both were truncated.

This PR adds two helpers in `dashboard-format.ts` and applies them at the WORKER cell render sites:

- `shortOrchId(orchestrator)` — deterministic 4-char base36 fingerprint of the orchestrator ID (FNV-1a 32-bit hash → `mod 36^4` → base36, padded). Disambiguates workers from different orchestrators without lengthening the cell.
- `formatWorkerCell(rawWorker, orchestrator)` — strips the `{orchestrator}-` prefix from the raw value and prepends `{shortOrchId}:`. Pass-through when there's no orchestrator, no matching prefix, or no `-` separator after the prefix.

Display becomes `{orch-short}:CTL-431` (12 chars) instead of `o-tl-431-ctl-432-ctl-433-c…` (28+ chars). The full orchestrator ID is still visible in the adjacent ORCHESTRATOR column for cross-reference. The existing "orchestrator-level interest" special case in `InterestList` (label `"orchestrator"` when `session_id === orchestrator`) is preserved.

## Closes
[CTL-431](https://linear.app/coalesce-labs/issue/CTL-431)

## Test plan
- [x] 11 new unit tests in `dashboard-format.test.ts` cover `shortOrchId` (determinism, length, base36, distinctness) and `formatWorkerCell` (prefix strip, null/empty orch, no-match passthrough, exact-equal passthrough, prefix-without-separator passthrough, interest-key suffix variant)
- [x] All 235 cli/ tests pass; no regressions
- [x] `bun run typecheck` clean
- [x] `bun run lint` 0 errors