### PR TITLE
fix(dev): HUD filter input + status row span full terminal width (CTL-433)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/PromptInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/PromptInput.tsx
@@ -231,7 +231,7 @@ export function PromptInput({
 
   return (
     <Box flexDirection="column">
-      <Box borderStyle="round" borderColor={focused ? "cyan" : "gray"} paddingX={1} flexDirection="row">
+      <Box borderStyle="round" borderColor={focused ? "cyan" : "gray"} paddingX={1} flexDirection="row" width={cols}>
         {mode === "query" ? <Text color="yellow">{"~"}</Text> : <Text color="yellow">{">"}</Text>}
         <Text>{" "}</Text>
         {focused ? (
@@ -244,7 +244,7 @@ export function PromptInput({
           <Text dimColor>{statusMsg ?? "filter or query…"}</Text>
         )}
       </Box>
-      <Box flexDirection="row" paddingX={1}>
+      <Box flexDirection="row" paddingX={1} width={cols}>
         <Box flexGrow={1}>
           {error !== null ? (
             <Text color="red" wrap="truncate-end">{error}</Text>


### PR DESCRIPTION
## Summary

- Add `width={cols}` to both inner row Boxes inside `PromptInput` so the rounded input row AND the borderless status row span the full terminal width.
- Fixes [CTL-433](https://linear.app/coalesce-labs/issue/CTL-433): "HUD layout: filter input and status bar must span full terminal width".

## Context

After CTL-417 (#736) restructured `PromptInput` into two rows (rounded input row + borderless status row, wrapped in a column-flex Box), neither inner row had a width constraint. They collapsed to content width and did not reach the right edge of the terminal.

## Change

`plugins/dev/scripts/orch-monitor/cli/components/PromptInput.tsx` — two-line edit:

```diff
-      <Box borderStyle="round" borderColor={focused ? "cyan" : "gray"} paddingX={1} flexDirection="row">
+      <Box borderStyle="round" borderColor={focused ? "cyan" : "gray"} paddingX={1} flexDirection="row" width={cols}>
...
-      <Box flexDirection="row" paddingX={1}>
+      <Box flexDirection="row" paddingX={1} width={cols}>
```

`cols` is already a `PromptInput` prop sourced from `process.stdout.columns` via `hud.tsx` — no plumbing changes.

## Why `width` not `flexGrow`

`components/EventRow.tsx:31` documents the CTL-395 preference: explicit `width` pads each cell to a fixed character count, overwriting ghost chars when content shrinks (the status row reflows between modes and chip counts change as filters are applied / cleared). And because the parent of these two rows is a column-flex container, `flexGrow={1}` would grow them vertically rather than horizontally — so explicit `width` is the only correct primitive here.

## Test plan

- [x] `bun test cli/components/footer-hints.test.ts cli/components/filter-chips.test.ts` — 25/25 pass
- [x] `bun run lint` — 0 errors (3 pre-existing warnings unrelated)
- [x] `bun run typecheck` — same pre-existing `ui/src/lib/briefings.ts` errors as `origin/main`, no new errors from this change
- [ ] Launch `catalyst-hud` and verify the input row and status row both reach the right edge in normal, filter, and query modes at narrow and wide terminal widths