### PR TITLE
fix(dev): consolidate HUD Header chip row onto single line (CTL-434)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/Header.tsx
@@ -1,14 +1,9 @@
 import { Box, Text } from "ink";
 import type { BrokerState } from "../lib/broker-key-health.ts";
-import {
-  chipColor,
-  chipLabel,
-  brokerInterestStatus,
-  interestChipColor,
-  interestChipLabel,
-} from "../lib/broker-key-health.ts";
+import { brokerInterestStatus } from "../lib/broker-key-health.ts";
 import { resolveColumns } from "../lib/column-widths.ts";
 import type { HudColumnConfig } from "../../lib/monitor-config.ts";
+import { layoutHeaderChips } from "./header-chips.ts";
 
 interface HeaderProps {
   columns?: number;
@@ -32,36 +27,33 @@ interface HeaderProps {
 // CTL-390: the row also renders when a version chip is provided.
 // CTL-394: column headers are now data-driven via resolveColumns() so
 // custom column configs are automatically reflected in the header row.
+// CTL-434: chip layout is computed by layoutHeaderChips() which keeps the
+// row on a single line by abbreviating labels rather than wrapping.
 export function Header({ columns = 120, nlQuery, brokerState, version, columnConfig }: HeaderProps) {
   const sep = "─".repeat(Math.max(0, columns - 1));
   const groq = brokerState?.groq;
   const interestStatus = brokerInterestStatus(brokerState ?? null);
-  const showInterestChip = interestStatus !== "unknown";
-  const showVersionChip = version !== undefined;
+  const chips = layoutHeaderChips({
+    columns,
+    groqStatus: groq ? groq.probeStatus : null,
+    groqPresent: groq?.present ?? false,
+    groqPrefix: groq?.prefix ?? null,
+    groqSource: groq?.source ?? null,
+    interestStatus,
+    interestCount: brokerState?.interestCount ?? null,
+    versionDisplay: version?.display ?? null,
+    versionIsLocal: version?.isLocal ?? false,
+  });
   const resolved = resolveColumns(columns, columnConfig);
   return (
     <Box flexDirection="column">
-      {(groq || showInterestChip || showVersionChip) && (
+      {chips.segments.length > 0 && (
         <Box flexDirection="row">
-          {groq && (
-            <Text color={chipColor(groq.probeStatus)}>{`[Groq: ${chipLabel(groq.probeStatus)}]`}</Text>
-          )}
-          {groq && groq.present && groq.prefix && (
-            <Text dimColor>{`  ${groq.prefix}... (${groq.source ?? "unknown"})`}</Text>
-          )}
-          {showInterestChip && (
-            <Text
-              color={interestChipColor(interestStatus)}
-              inverse={interestStatus === "degraded"}
-            >
-              {`${groq ? "  " : ""}[broker: ${interestChipLabel(brokerState ?? null, interestStatus)}]`}
+          {chips.segments.map((s, i) => (
+            <Text key={i} color={s.color} inverse={s.inverse} dimColor={s.dim}>
+              {s.text}
             </Text>
-          )}
-          {showVersionChip && (
-            <Text color={version.isLocal ? "yellow" : "gray"}>
-              {`${(groq || showInterestChip) ? "  " : ""}[${version.display}]`}
-            </Text>
-          )}
+          ))}
         </Box>
       )}
       <Box flexDirection="row">

--- a/plugins/dev/scripts/orch-monitor/cli/components/header-chips.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/header-chips.test.ts
@@ -1,0 +1,263 @@
+// header-chips.test.ts — tests for the Header chip-row layout helper (CTL-434).
+// Run from plugins/dev/scripts/orch-monitor: bun test cli/components/header-chips.test.ts
+
+import { describe, test, expect } from "bun:test";
+import { layoutHeaderChips } from "./header-chips.ts";
+import type { HeaderChipInput } from "./header-chips.ts";
+
+const base: HeaderChipInput = {
+  columns: 200,
+  groqStatus: "ok",
+  groqPresent: true,
+  groqPrefix: "gsk_abc",
+  groqSource: "env",
+  interestStatus: "ok",
+  interestCount: 5,
+  versionDisplay: "v9.2.0 · local:523b6fe",
+  versionIsLocal: true,
+};
+
+function texts(segments: { text: string }[]): string[] {
+  return segments.map((s) => s.text);
+}
+
+describe("layoutHeaderChips — empty cases", () => {
+  test("nothing visible → empty segments", () => {
+    const result = layoutHeaderChips({
+      columns: 120,
+      groqStatus: null,
+      groqPresent: false,
+      groqPrefix: null,
+      groqSource: null,
+      interestStatus: "unknown",
+      interestCount: null,
+      versionDisplay: null,
+      versionIsLocal: false,
+    });
+    expect(result.segments).toEqual([]);
+    expect(result.width).toBe(0);
+  });
+
+  test("only groq present", () => {
+    const result = layoutHeaderChips({
+      ...base,
+      groqPresent: false,
+      groqPrefix: null,
+      groqSource: null,
+      interestStatus: "unknown",
+      interestCount: null,
+      versionDisplay: null,
+    });
+    expect(texts(result.segments)).toEqual(["[Groq: OK]"]);
+  });
+
+  test("only broker present", () => {
+    const result = layoutHeaderChips({
+      ...base,
+      groqStatus: null,
+      groqPresent: false,
+      groqPrefix: null,
+      groqSource: null,
+      versionDisplay: null,
+    });
+    expect(texts(result.segments)).toEqual(["[broker: 5 interests]"]);
+  });
+
+  test("only version present", () => {
+    const result = layoutHeaderChips({
+      ...base,
+      groqStatus: null,
+      groqPresent: false,
+      groqPrefix: null,
+      groqSource: null,
+      interestStatus: "unknown",
+      interestCount: null,
+    });
+    expect(texts(result.segments)).toEqual(["[v9.2.0 · local:523b6fe]"]);
+  });
+});
+
+describe("layoutHeaderChips — wide width (L0 — full fidelity)", () => {
+  test("all chips + decoration at 200 cols", () => {
+    const result = layoutHeaderChips({ ...base, columns: 200 });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  gsk_abc... (env)",
+      "  [broker: 5 interests]",
+      "  [v9.2.0 · local:523b6fe]",
+    ]);
+  });
+
+  test("decoration omitted when groqPrefix is null even at wide widths", () => {
+    const result = layoutHeaderChips({ ...base, columns: 200, groqPrefix: null });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 interests]",
+      "  [v9.2.0 · local:523b6fe]",
+    ]);
+  });
+
+  test("decoration omitted when groqPresent is false", () => {
+    const result = layoutHeaderChips({ ...base, columns: 200, groqPresent: false });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 interests]",
+      "  [v9.2.0 · local:523b6fe]",
+    ]);
+  });
+
+  test("unknown source falls back to 'unknown' in decoration", () => {
+    const result = layoutHeaderChips({ ...base, columns: 200, groqSource: null });
+    expect(result.segments[1]?.text).toBe("  gsk_abc... (unknown)");
+  });
+});
+
+describe("layoutHeaderChips — progressive abbreviation", () => {
+  // Full-fidelity width at base: 10 + 18 + 23 + 26 = 77 chars
+  // L1 (no deco):                  10 + 23 + 26 = 59 chars
+  // L2 (short broker):             10 + 18 + 26 = 54 chars  (broker becomes "[broker: 5 ints]")
+  // L3 (med version):              10 + 18 + 20 = 48 chars  ("[v9.2.0 · 523b6fe]")
+  // L4 (min version):              10 + 18 + 10 = 38 chars  ("[v9.2.0]")
+
+  test("L1 — drops groq decoration when row would overflow", () => {
+    // 75 cols: full = 77 overflows by 2; dropping deco → 59 fits
+    const result = layoutHeaderChips({ ...base, columns: 75 });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 interests]",
+      "  [v9.2.0 · local:523b6fe]",
+    ]);
+    expect(result.width).toBe(59);
+  });
+
+  test("L2 — shortens broker label", () => {
+    // 55 cols: L1 = 59 overflows; L2 = 54 fits
+    const result = layoutHeaderChips({ ...base, columns: 55 });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 ints]",
+      "  [v9.2.0 · local:523b6fe]",
+    ]);
+    expect(result.width).toBe(54);
+  });
+
+  test("L3 — drops 'local:' prefix from version", () => {
+    // 50 cols: L2 = 54 overflows; L3 = 47 fits
+    const result = layoutHeaderChips({ ...base, columns: 50 });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 ints]",
+      "  [v9.2.0 · 523b6fe]",
+    ]);
+    expect(result.width).toBe(48);
+  });
+
+  test("L4 — drops SHA portion entirely", () => {
+    // 40 cols: L3 = 47 overflows; L4 = 38 fits
+    const result = layoutHeaderChips({ ...base, columns: 40 });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 ints]",
+      "  [v9.2.0]",
+    ]);
+    expect(result.width).toBe(38);
+  });
+
+  test("extreme widths still keep all three core chips", () => {
+    // 30 cols: even L4 (38) overflows; we accept the overflow rather than dropping chips
+    const result = layoutHeaderChips({ ...base, columns: 30 });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 ints]",
+      "  [v9.2.0]",
+    ]);
+  });
+
+  test("release version (no 'local:' prefix) collapses to L4 directly", () => {
+    // versionDisplay starts as "v9.2.0 · abc1234" (release), no "local:" to drop.
+    // L2 width = 10 + 18 + 18 = 46. L4 (min) = 10 + 18 + 10 = 38.
+    const result = layoutHeaderChips({
+      ...base,
+      versionDisplay: "v9.2.0 · abc1234",
+      versionIsLocal: false,
+      columns: 40,
+    });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 ints]",
+      "  [v9.2.0]",
+    ]);
+  });
+
+  test("version with no separator (already minimal) is left as-is", () => {
+    const result = layoutHeaderChips({
+      ...base,
+      versionDisplay: "v9.2.0",
+      versionIsLocal: false,
+      columns: 30,
+    });
+    expect(texts(result.segments)).toEqual([
+      "[Groq: OK]",
+      "  [broker: 5 ints]",
+      "  [v9.2.0]",
+    ]);
+  });
+});
+
+describe("layoutHeaderChips — short broker label by status", () => {
+  test("startup short label includes 'start' suffix", () => {
+    const result = layoutHeaderChips({
+      ...base,
+      interestStatus: "startup",
+      interestCount: 0,
+      columns: 50, // force short broker
+    });
+    const brokerSeg = result.segments.find((s) => s.text.includes("broker"));
+    expect(brokerSeg?.text).toBe("  [broker: 0 start]");
+  });
+
+  test("degraded short label uses 'ints' suffix and inverse flag", () => {
+    const result = layoutHeaderChips({
+      ...base,
+      interestStatus: "degraded",
+      interestCount: 0,
+      columns: 50, // force short broker
+    });
+    const brokerSeg = result.segments.find((s) => s.text.includes("broker"));
+    expect(brokerSeg?.text).toBe("  [broker: 0 ints]");
+    expect(brokerSeg?.inverse).toBe(true);
+  });
+});
+
+describe("layoutHeaderChips — colors and flags", () => {
+  test("groq chip color reflects probe status", () => {
+    const result = layoutHeaderChips({ ...base, groqStatus: "missing" });
+    expect(result.segments[0]?.color).toBe("yellow");
+  });
+
+  test("decoration segment is marked dim", () => {
+    const result = layoutHeaderChips({ ...base });
+    const deco = result.segments[1];
+    expect(deco?.dim).toBe(true);
+  });
+
+  test("version is yellow when isLocal, gray otherwise", () => {
+    const local = layoutHeaderChips({ ...base, versionIsLocal: true });
+    const versionSeg = local.segments.find((s) => s.text.includes("v9.2.0"));
+    expect(versionSeg?.color).toBe("yellow");
+
+    const release = layoutHeaderChips({
+      ...base,
+      versionDisplay: "v9.2.0",
+      versionIsLocal: false,
+    });
+    const releaseSeg = release.segments.find((s) => s.text.includes("v9.2.0"));
+    expect(releaseSeg?.color).toBe("gray");
+  });
+
+  test("singular vs plural broker label at full fidelity", () => {
+    const one = layoutHeaderChips({ ...base, interestCount: 1 });
+    const oneSeg = one.segments.find((s) => s.text.includes("broker"));
+    expect(oneSeg?.text).toBe("  [broker: 1 interest]");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/components/header-chips.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/header-chips.ts
@@ -1,0 +1,158 @@
+// header-chips.ts — pure layout helper for the HUD Header chip row (CTL-434).
+//
+// The chip row contains up to three status pills (Groq probe, broker
+// interests, plugin version) plus an optional dim decoration after the Groq
+// pill. At narrow terminal widths the full-fidelity row overflows and Ink
+// wraps the second-line chips below the first, which reads as a duplicate
+// status bar.
+//
+// This helper builds the row at progressively shorter fidelity levels until
+// the total width fits within `columns`, dropping decorations and
+// abbreviating labels rather than wrapping. The three core pills always
+// coexist on one row, even at extreme widths where the result still
+// overflows (we accept overflow rather than dropping required information).
+
+import type { BrokerInterestStatus, ProbeStatus } from "../lib/broker-key-health.ts";
+import { chipColor, chipLabel, interestChipColor } from "../lib/broker-key-health.ts";
+
+export interface HeaderChipInput {
+  /** Terminal columns available for the chip row. */
+  columns: number;
+  /** Groq probe status; null suppresses the pill entirely. */
+  groqStatus: ProbeStatus | null;
+  /** True when a Groq key is configured (controls decoration visibility). */
+  groqPresent: boolean;
+  /** First chars of the configured key (e.g. "gsk_abc"); null suppresses decoration. */
+  groqPrefix: string | null;
+  /** Source of the configured key (e.g. "env"); shown in decoration parens. */
+  groqSource: string | null;
+  /** Broker interest pill status. "unknown" suppresses the pill. */
+  interestStatus: BrokerInterestStatus;
+  /** Broker interest count for the pill label. */
+  interestCount: number | null;
+  /** Version display string (e.g. "v9.2.0 · local:523b6fe"); null suppresses the pill. */
+  versionDisplay: string | null;
+  /** Whether the version chip should render in yellow (worktree source). */
+  versionIsLocal: boolean;
+}
+
+export interface HeaderChipSegment {
+  /** Rendered text including any leading separator. */
+  text: string;
+  /** Ink color name. */
+  color: string;
+  /** Inverse video flag (used for the degraded broker pill). */
+  inverse?: boolean;
+  /** Dim flag (used for the Groq decoration). */
+  dim?: boolean;
+}
+
+export interface HeaderChipLayout {
+  segments: HeaderChipSegment[];
+  /** Total width including separators. Useful for tests. */
+  width: number;
+}
+
+const SEP = "  "; // two-space separator between chips, matching the previous inline rendering
+
+type BrokerFidelity = "full" | "short";
+type VersionFidelity = "full" | "med" | "min";
+
+function brokerLabel(
+  status: BrokerInterestStatus,
+  count: number | null,
+  fidelity: BrokerFidelity,
+): string {
+  if (count === null) return "?";
+  if (fidelity === "full") {
+    if (status === "ok") return `${count} interest${count === 1 ? "" : "s"}`;
+    if (status === "startup") return `${count} (starting)`;
+    return `${count} interests`;
+  }
+  if (status === "startup") return `${count} start`;
+  return `${count} ints`;
+}
+
+function versionLabel(display: string, fidelity: VersionFidelity): string {
+  if (fidelity === "full") return display;
+  if (fidelity === "med") return display.replace("local:", "");
+  const idx = display.indexOf(" · ");
+  return idx >= 0 ? display.slice(0, idx) : display;
+}
+
+function buildSegments(
+  input: HeaderChipInput,
+  opts: { includeDeco: boolean; broker: BrokerFidelity; version: VersionFidelity },
+): HeaderChipSegment[] {
+  const segments: HeaderChipSegment[] = [];
+  const showGroq = input.groqStatus !== null;
+  const showBroker = input.interestStatus !== "unknown";
+  const showVersion = input.versionDisplay !== null;
+  let prior = false;
+
+  if (showGroq && input.groqStatus !== null) {
+    segments.push({
+      text: `[Groq: ${chipLabel(input.groqStatus)}]`,
+      color: chipColor(input.groqStatus),
+    });
+    prior = true;
+
+    if (opts.includeDeco && input.groqPresent && input.groqPrefix !== null) {
+      const source = input.groqSource ?? "unknown";
+      segments.push({
+        text: `${SEP}${input.groqPrefix}... (${source})`,
+        color: "white",
+        dim: true,
+      });
+    }
+  }
+
+  if (showBroker) {
+    const label = brokerLabel(input.interestStatus, input.interestCount, opts.broker);
+    segments.push({
+      text: `${prior ? SEP : ""}[broker: ${label}]`,
+      color: interestChipColor(input.interestStatus),
+      inverse: input.interestStatus === "degraded",
+    });
+    prior = true;
+  }
+
+  if (showVersion && input.versionDisplay !== null) {
+    const label = versionLabel(input.versionDisplay, opts.version);
+    segments.push({
+      text: `${prior ? SEP : ""}[${label}]`,
+      color: input.versionIsLocal ? "yellow" : "gray",
+    });
+  }
+
+  return segments;
+}
+
+function totalWidth(segments: HeaderChipSegment[]): number {
+  let n = 0;
+  for (const s of segments) n += s.text.length;
+  return n;
+}
+
+const FIDELITY_LADDER: Array<{
+  includeDeco: boolean;
+  broker: BrokerFidelity;
+  version: VersionFidelity;
+}> = [
+  { includeDeco: true, broker: "full", version: "full" },   // L0
+  { includeDeco: false, broker: "full", version: "full" },  // L1 — drop decoration
+  { includeDeco: false, broker: "short", version: "full" }, // L2 — short broker
+  { includeDeco: false, broker: "short", version: "med" },  // L3 — drop "local:" from version
+  { includeDeco: false, broker: "short", version: "min" },  // L4 — version only
+];
+
+export function layoutHeaderChips(input: HeaderChipInput): HeaderChipLayout {
+  let chosen: HeaderChipSegment[] = [];
+  let chosenWidth = 0;
+  for (const level of FIDELITY_LADDER) {
+    chosen = buildSegments(input, level);
+    chosenWidth = totalWidth(chosen);
+    if (chosenWidth <= input.columns) break;
+  }
+  return { segments: chosen, width: chosenWidth };
+}


### PR DESCRIPTION
## Summary

At narrower terminal widths the HUD Header chip row (Groq status + broker
interests + version chip) wrapped onto two lines, appearing as a duplicate
status bar. The fix consolidates all three core pills onto a single row at
every terminal width by progressively abbreviating instead of wrapping.

Closes CTL-434.

## What changed

- **New `layoutHeaderChips()` helper** (`cli/components/header-chips.ts`) —
  pure function that returns chip segments after applying a fidelity ladder:
  1. Drop the dim Groq decoration (`abc... (env)`).
  2. Shorten the broker label (`5 interests` → `5 ints`,
     `0 (starting)` → `0 start`).
  3. Drop the `local:` prefix from the version display.
  4. Drop the SHA from the version display entirely (`v9.2.0`).
  The three core pills (Groq, broker, version) always coexist on one row,
  even when the result still overflows at extreme widths.
- **`Header.tsx`** now delegates layout to `layoutHeaderChips()` and renders
  the returned segments. Sizing decisions live entirely in the pure helper.
- **21 new unit tests** in `header-chips.test.ts` covering empty cases, each
  fidelity level, short-label variants for `startup`/`degraded` broker
  states, and color/inverse/dim flag propagation.

## Test plan

- [x] `bun test cli/components/header-chips.test.ts` — 21/21 pass
- [x] `bun run lint` — 0 errors on changed files
- [x] Project tests — no new regressions (6 pre-existing
      `catalyst-monitor.sh` failures unrelated to this change)
- [ ] Manual verification: HUD Header renders on one line at 60/80/100/120
      cols once branch is deployed