### PR TITLE
fix(dev): populate vcs.repository.name for Linear events via linearTeams config (CTL-436)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -38,6 +38,12 @@
         "repoColors": {
           "coalesce-labs/catalyst": "green"
         }
+      },
+      "linear": {
+        "teams": [
+          { "key": "CTL", "vcsRepo": "coalesce-labs/catalyst" },
+          { "key": "ADV", "vcsRepo": "coalesce-labs/adva" }
+        ]
       }
     },
     "feedback": {


### PR DESCRIPTION
## Summary

CTL-436. The CTL-362 plumbing for stamping `attributes["vcs.repository.name"]` on Linear
event envelopes relies on `.catalyst/config.json#catalyst.monitor.linear.teams[]` to map
team keys (`"CTL"`, `"ADV"`, …) to canonical `owner/repo` strings. That map was never
populated in this workspace, so the handler always took the no-match branch and Linear
events arrived with the attribute unset — the HUD's REPO column read empty for Linear
rows while GitHub rows correctly showed `catalyst`.

This adds the two team→repo entries whose mappings are already canonical in the test
fixtures (`plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts:1061-1062`)
and the configuration reference docs:

- `CTL` → `coalesce-labs/catalyst`
- `ADV` → `coalesce-labs/adva`

`SLI`, `OTL`, `EVR` (also seen in `~/catalyst/events/<month>.jsonl`) are deferred — their
owner/repo addresses aren't documented anywhere in this repo. Each can be filed as its own
follow-up.

## Why no code change

The handler (`plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts:131-190`),
loader (`plugins/dev/scripts/orch-monitor/lib/webhook-config.ts:188-223,390`), and display
path (`plugins/dev/scripts/orch-monitor/cli/lib/format.ts:56-59` + the web UI row) were all
already correct from CTL-362. The only thing missing was the data they consume. The
ticket explicitly directs the fix at the config file ("should come from the catalyst config
file, not be hardcoded"), so adding entries — not adding code — is the contract-faithful
fix.

## Test plan

- [x] `bun test __tests__/webhook-config.test.ts` (51 pass) — loader contract.
- [x] `bun test __tests__/linear-webhook-handler.test.ts` (41 pass) — handler stamps
      `vcs.repository.name` from a populated `teamsMap` for issue/comment/cycle.
- [x] Smoke test: `loadWebhookConfig` returns `linearTeams: [{ key: "CTL", … }, { key: "ADV", … }]`
      when pointed at this branch's `.catalyst/config.json`.
- [ ] Post-merge: trigger a Linear webhook for a CTL or ADV issue; verify the resulting
      line in `~/catalyst/events/<month>.jsonl` carries `"vcs.repository.name": "coalesce-labs/catalyst"`
      (or `coalesce-labs/adva`) and the HUD REPO column shows `catalyst` / `adva`.