### PR TITLE
feat(dev): live operational metrics chips on HUD status line (CTL-435)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/PromptInput.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/PromptInput.tsx
@@ -40,6 +40,26 @@ export function buildActiveChips(opts: {
   return chips;
 }
 
+export type MetricChip = { label: string; color: "green" | "gray" };
+
+// CTL-435: live operational metrics shown at the right of the status line.
+// Always returns 4 chips so the row width is predictable. Non-zero
+// workers/orchs/PRs render green; the heartbeat counter is always gray —
+// it's a cumulative tally, not an alert signal.
+export function buildMetricsChips(opts: {
+  activeWorkers: number;
+  activeOrchestrators: number;
+  heartbeats: number;
+  openPRs: number;
+}): MetricChip[] {
+  return [
+    { label: `workers: ${opts.activeWorkers}`, color: opts.activeWorkers > 0 ? "green" : "gray" },
+    { label: `orchs: ${opts.activeOrchestrators}`, color: opts.activeOrchestrators > 0 ? "green" : "gray" },
+    { label: `hb: ${opts.heartbeats}`, color: "gray" },
+    { label: `PRs: ${opts.openPRs}`, color: opts.openPRs > 0 ? "green" : "gray" },
+  ];
+}
+
 // CTL-389: collapse N/M when all events are visible.
 export function formatEventCount(filteredCount: number, totalCount: number): string {
   if (filteredCount === totalCount) return `${totalCount} events`;
@@ -95,6 +115,13 @@ interface PromptInputProps {
   dslLabel: string;
   // CTL-384: wrap mode chip
   wrapMode?: 'truncate' | 'wrap';
+  // CTL-435: live operational metrics shown at the right edge.
+  metrics?: {
+    activeWorkers: number;
+    activeOrchestrators: number;
+    heartbeats: number;
+    openPRs: number;
+  };
 }
 
 export function PromptInput({
@@ -117,6 +144,7 @@ export function PromptInput({
   dslActive,
   dslLabel,
   wrapMode = 'truncate',
+  metrics,
 }: PromptInputProps) {
   const [cursorPos, setCursorPos] = useState(0);
   const filterHistory = useRef<string[]>([]);
@@ -264,6 +292,11 @@ export function PromptInput({
           : <Text dimColor>{" [PAUSED — G to follow]"}</Text>
         }
         {wrapMode === 'wrap' && <Text color="cyan">{" [WRAP]"}</Text>}
+        {metrics && buildMetricsChips(metrics).map((chip, i) => (
+          chip.color === "green"
+            ? <Text key={`m${i}`} color="green">{` [${chip.label}]`}</Text>
+            : <Text key={`m${i}`} dimColor>{` [${chip.label}]`}</Text>
+        ))}
       </Box>
     </Box>
   );

--- a/plugins/dev/scripts/orch-monitor/cli/components/filter-chips.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/filter-chips.test.ts
@@ -2,7 +2,7 @@
 // introduced in CTL-389. Pure function tests; no Ink rendering required.
 
 import { describe, test, expect } from "bun:test";
-import { buildActiveChips, formatEventCount } from "./PromptInput.tsx";
+import { buildActiveChips, buildMetricsChips, formatEventCount } from "./PromptInput.tsx";
 
 describe("buildActiveChips", () => {
   const none = { activeSinceLabel: null, filterText: "", dslActive: false, dslLabel: "", pivot: null };
@@ -85,6 +85,56 @@ describe("buildActiveChips", () => {
   test("filter text chip truncates at 20 chars", () => {
     const chips = buildActiveChips({ ...none, filterText: "a".repeat(25) });
     expect(chips[0]?.label).toBe("/" + "a".repeat(20) + "…");
+  });
+});
+
+describe("buildMetricsChips", () => {
+  // CTL-435: status-line live operational metrics — always 4 chips, order
+  // fixed (workers, orchs, hb, PRs). Non-zero workers/orchs/PRs render green;
+  // hb is always gray (it's a cumulative counter, not an alert).
+  const zero = { activeWorkers: 0, activeOrchestrators: 0, heartbeats: 0, openPRs: 0 };
+
+  test("all zero → 4 chips, all gray", () => {
+    const chips = buildMetricsChips(zero);
+    expect(chips).toHaveLength(4);
+    expect(chips.every((c) => c.color === "gray")).toBe(true);
+    expect(chips.map((c) => c.label)).toEqual([
+      "workers: 0",
+      "orchs: 0",
+      "hb: 0",
+      "PRs: 0",
+    ]);
+  });
+
+  test("non-zero workers/orchs/PRs → green; hb stays gray", () => {
+    const chips = buildMetricsChips({
+      activeWorkers: 3,
+      activeOrchestrators: 1,
+      heartbeats: 47,
+      openPRs: 2,
+    });
+    expect(chips[0]).toMatchObject({ label: "workers: 3", color: "green" });
+    expect(chips[1]).toMatchObject({ label: "orchs: 1", color: "green" });
+    expect(chips[2]).toMatchObject({ label: "hb: 47", color: "gray" });
+    expect(chips[3]).toMatchObject({ label: "PRs: 2", color: "green" });
+  });
+
+  test("only some metrics non-zero — colors flip per chip independently", () => {
+    const chips = buildMetricsChips({
+      activeWorkers: 0,
+      activeOrchestrators: 1,
+      heartbeats: 5,
+      openPRs: 0,
+    });
+    expect(chips[0]).toMatchObject({ label: "workers: 0", color: "gray" });
+    expect(chips[1]).toMatchObject({ label: "orchs: 1", color: "green" });
+    expect(chips[2]).toMatchObject({ label: "hb: 5", color: "gray" });
+    expect(chips[3]).toMatchObject({ label: "PRs: 0", color: "gray" });
+  });
+
+  test("hb is gray even when very large", () => {
+    const chips = buildMetricsChips({ ...zero, heartbeats: 9999 });
+    expect(chips[2]).toMatchObject({ label: "hb: 9999", color: "gray" });
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useHudMetrics.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useHudMetrics.test.ts
@@ -1,0 +1,102 @@
+// useHudMetrics.test.ts — verifies the pure metric-computation logic for
+// CTL-435 status-line chips. The hook itself wraps node:fs reads and a 5s
+// setInterval; we test the pure function it delegates to.
+
+import { describe, test, expect } from "bun:test";
+import { computePollMetrics } from "./useHudMetrics.ts";
+import type { WorkerSignal } from "../lib/worker-signals-reader.ts";
+import type { OrchState } from "../lib/orch-state-reader.ts";
+
+function worker(overrides: Partial<WorkerSignal>): WorkerSignal {
+  return {
+    ticket: "X-1",
+    orchestrator: "o-1",
+    wave: 1,
+    workerName: "o-1-X-1",
+    label: null,
+    status: "researching",
+    phase: 1,
+    phaseTimestamps: {},
+    lastHeartbeat: null,
+    startedAt: null,
+    updatedAt: null,
+    completedAt: null,
+    worktreePath: null,
+    pr: null,
+    linearState: null,
+    definitionOfDone: null,
+    raw: null,
+    ...overrides,
+  };
+}
+
+function orch(active: number, total: number = active): OrchState {
+  return {
+    id: "o-1",
+    orchestrator: "o-1",
+    currentWave: 1,
+    totalWaves: 1,
+    queueLength: 0,
+    maxParallel: 3,
+    baseBranch: "main",
+    startedAt: null,
+    workersCount: { active, total },
+    raw: null,
+  };
+}
+
+describe("computePollMetrics", () => {
+  test("empty inputs → all zeros", () => {
+    expect(computePollMetrics([], [])).toEqual({
+      activeWorkers: 0,
+      activeOrchestrators: 0,
+      openPRs: 0,
+    });
+  });
+
+  test("counts only non-terminal workers as active", () => {
+    const workers = [
+      worker({ status: "researching" }),
+      worker({ status: "implementing" }),
+      worker({ status: "pr-created" }),
+      worker({ status: "done" }),
+      worker({ status: "failed" }),
+      worker({ status: "stalled" }),
+      worker({ status: "deploy-failed" }),
+    ];
+    const m = computePollMetrics(workers, []);
+    expect(m.activeWorkers).toBe(3);
+  });
+
+  test("counts only orchestrators with active workers > 0", () => {
+    const orchs = [orch(0, 5), orch(2, 4), orch(1, 1), orch(0, 0)];
+    const m = computePollMetrics([], orchs);
+    expect(m.activeOrchestrators).toBe(2);
+  });
+
+  test("counts open PRs as those with pr set and mergedAt falsy", () => {
+    const workers = [
+      worker({ status: "pr-created", pr: { number: 1, url: "u", mergedAt: null } }),
+      worker({ status: "pr-created", pr: { number: 2, url: "u" } }), // mergedAt absent → open
+      worker({ status: "done", pr: { number: 3, url: "u", mergedAt: "2026-05-15T00:00:00Z" } }),
+      worker({ status: "researching", pr: null }),
+    ];
+    const m = computePollMetrics(workers, []);
+    expect(m.openPRs).toBe(2);
+  });
+
+  test("realistic mix produces correct totals", () => {
+    const workers = [
+      worker({ status: "researching", pr: null }),
+      worker({ status: "implementing", pr: null }),
+      worker({ status: "pr-created", pr: { number: 9, url: "u", mergedAt: null } }),
+      worker({ status: "done", pr: { number: 8, url: "u", mergedAt: "2026-05-14T00:00:00Z" } }),
+    ];
+    const orchs = [orch(3, 4), orch(0, 2)];
+    expect(computePollMetrics(workers, orchs)).toEqual({
+      activeWorkers: 3,
+      activeOrchestrators: 1,
+      openPRs: 1,
+    });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useHudMetrics.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useHudMetrics.ts
@@ -1,0 +1,45 @@
+// useHudMetrics.ts — drives the CTL-435 status-line metric chips. Polls the
+// same on-disk state used by the dashboard (worker signal files + per-orch
+// state.json) every 5s — matching the cadence of the broker-state and
+// dashboard refreshes elsewhere in the HUD.
+//
+// The pure `computePollMetrics` reduction is split out so the chip totals
+// can be unit-tested without spinning up node:fs or fake timers.
+
+import { useEffect, useState } from "react";
+import { readWorkerSignals, type WorkerSignal } from "../lib/worker-signals-reader.ts";
+import { readOrchStates, type OrchState } from "../lib/orch-state-reader.ts";
+
+export interface HudPollMetrics {
+  activeWorkers: number;
+  activeOrchestrators: number;
+  openPRs: number;
+}
+
+const TERMINAL_STATUSES = new Set(["done", "failed", "stalled", "deploy-failed"]);
+
+export function computePollMetrics(
+  workers: WorkerSignal[],
+  orchs: OrchState[],
+): HudPollMetrics {
+  return {
+    activeWorkers: workers.filter((w) => !TERMINAL_STATUSES.has(w.status)).length,
+    activeOrchestrators: orchs.filter((o) => o.workersCount.active > 0).length,
+    openPRs: workers.filter((w) => w.pr !== null && !w.pr.mergedAt).length,
+  };
+}
+
+export function useHudMetrics(): HudPollMetrics {
+  const [metrics, setMetrics] = useState<HudPollMetrics>({
+    activeWorkers: 0,
+    activeOrchestrators: 0,
+    openPRs: 0,
+  });
+  useEffect(() => {
+    const refresh = () => setMetrics(computePollMetrics(readWorkerSignals(), readOrchStates()));
+    refresh();
+    const id = setInterval(refresh, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return metrics;
+}

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -15,6 +15,7 @@ import {
 } from "./lib/detail-layout.ts";
 import { useEventLog } from "./hooks/useEventLog.ts";
 import { useFilter, type DslPredicate } from "./hooks/useFilter.ts";
+import { useHudMetrics } from "./hooks/useHudMetrics.ts";
 import { useSelection } from "./hooks/useSelection.ts";
 import { decidePivotAction } from "./lib/pivot-decision.ts";
 import { detectNerdFont } from "./lib/nerd-font.ts";
@@ -158,6 +159,27 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   // CTL-390: plugin version chip. Resolved once at startup — release-please
   // bumps version.txt + commit.txt only between HUD invocations.
   const versionChip = useRef(readPluginVersion()).current;
+
+  // CTL-435: live operational metrics chips. The hook polls worker signal
+  // files + per-orch state.json every 5s. Heartbeats are derived from the
+  // events stream below.
+  const pollMetrics = useHudMetrics();
+  const hudStartTsRef = useRef<number>(Date.now());
+
+  // CTL-435: heartbeats received since the HUD process mounted. Counted
+  // against the same `events` array the rest of the HUD consumes, filtered
+  // to entries whose ts is at or after our mount time — so the chip is a
+  // "since you started watching" counter rather than a backlog tally.
+  const heartbeatCount = useMemo(() => {
+    const startMs = hudStartTsRef.current;
+    let n = 0;
+    for (const e of events) {
+      if (e.attributes?.["event.name"] !== "heartbeat") continue;
+      const ms = Date.parse(e.ts);
+      if (Number.isFinite(ms) && ms >= startMs) n++;
+    }
+    return n;
+  }, [events]);
 
   const [dslState, setDslState] = useState<DslState | null>(null);
   const dslPredicate: DslPredicate = dslState?.jsPredicate ?? null;
@@ -516,6 +538,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           dslActive={dslState !== null}
           dslLabel={dslState?.nlQuery ?? ""}
           hasDsl={dslState !== null}
+          metrics={{ ...pollMetrics, heartbeats: heartbeatCount }}
         />
       </Box>
     </Box>


### PR DESCRIPTION
## Summary

Adds four compact live-metric chips to the right edge of the HUD status row:

- `[workers: N]` — active workers (non-terminal status)
- `[orchs: N]` — orchestrators with at least one active worker
- `[hb: N]` — heartbeats received since the HUD process mounted
- `[PRs: N]` — open worker PRs (`pr` set, `mergedAt` falsy)

Closes [CTL-435](https://linear.app/coalesce-labs/issue/CTL-435).

## Design

- **Sources reuse existing readers.** `readWorkerSignals()` and `readOrchStates()` already power the dashboard. The new `useHudMetrics` hook polls both on a 5 s `setInterval` — same cadence as the broker-state and dashboard refreshes.
- **Heartbeats derive from the existing event stream.** A mount-time `useRef(Date.now())` is captured once in `App`. The heartbeat count is a `useMemo` over the `events` array, filtered to `event.name === "heartbeat"` AND `Date.parse(e.ts) >= startMs`, so the counter reflects "since you started watching" rather than the entire backlog.
- **Pure helpers, pure tests.** `computePollMetrics()` and `buildMetricsChips()` are pure functions tested with `bun:test`. No Ink rendering or fake-timer setup.
- **Always-on layout.** All four chips render even at zero (gray) so the row width is predictable; non-zero workers/orchs/PRs flip to green. `hb` is always gray — it's a cumulative tally, not an alert signal.

## Files

| File | Change |
| --- | --- |
| `cli/hooks/useHudMetrics.ts` | New hook + `computePollMetrics` pure helper |
| `cli/hooks/useHudMetrics.test.ts` | 5 tests covering empty / terminal / mixed / PR variants |
| `cli/components/PromptInput.tsx` | New `buildMetricsChips` helper, optional `metrics` prop, render chips after `[LIVE]`/`[WRAP]` |
| `cli/components/filter-chips.test.ts` | 4 new tests for `buildMetricsChips` |
| `cli/hud.tsx` | Wire hook + heartbeat memo, pass into `<PromptInput />` |

## Test plan

- [x] `bun test cli/components/filter-chips.test.ts cli/hooks/useHudMetrics.test.ts` → 23/23 pass
- [x] `bun run typecheck` clean for changed files (pre-existing UI errors unchanged)
- [x] `bun run lint` clean for changed files (pre-existing warnings unchanged)
- [x] `bun run cli/hud.tsx --version` loads without errors
- [ ] Visual smoke test with active workers in `catalyst-hud`