### PR TITLE
fix(dev): widen HUD Interests TYPE column to 18 + add margin before WATCHES (CTL-438)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/InterestList.tsx
@@ -19,7 +19,7 @@ interface InterestListProps {
 
 const COL_ORCH = 25;
 const COL_WORKER = 28;
-const COL_TYPE = 16;
+const COL_TYPE = 18;
 const COL_WATCHES = 28;
 
 function interestTypeLabel(t: BrokerInterest["interest_type"]): string {
@@ -42,7 +42,7 @@ export function InterestList({
   cols,
   brokerState,
 }: InterestListProps) {
-  const promptW = Math.max(8, cols - COL_ORCH - COL_WORKER - COL_TYPE - COL_WATCHES - 5);
+  const promptW = Math.max(8, cols - COL_ORCH - COL_WORKER - COL_TYPE - COL_WATCHES - 6);
   const visible = interests.slice(scrollOffset, scrollOffset + visibleRows);
   const hasProse = interests.some((i) => i.interest_type === null);
   // proseEnabled is only false (not undefined) when the broker has explicitly written the field.
@@ -53,7 +53,7 @@ export function InterestList({
       <Box flexDirection="row">
         <Box width={COL_ORCH} flexShrink={0} marginRight={1}><Text bold color="cyan">ORCHESTRATOR</Text></Box>
         <Box width={COL_WORKER} flexShrink={0} marginRight={1}><Text bold color="cyan">WORKER</Text></Box>
-        <Box width={COL_TYPE} flexShrink={0} marginRight={1}><Text bold color="cyan">TYPE</Text></Box>
+        <Box width={COL_TYPE} flexShrink={0} marginRight={2}><Text bold color="cyan">TYPE</Text></Box>
         <Box width={COL_WATCHES} flexShrink={0} marginRight={1}><Text bold color="cyan">WATCHES</Text></Box>
         <Box flexGrow={1}>
           <Text bold color="cyan">PROMPT</Text>
@@ -88,7 +88,7 @@ export function InterestList({
             <Box width={COL_WORKER} flexShrink={0} marginRight={1}>
               <Text dimColor={isInactiveProse && !selected} color={selected ? "black" : "magenta"} inverse={selected}>{worker}</Text>
             </Box>
-            <Box width={COL_TYPE} flexShrink={0} marginRight={1}>
+            <Box width={COL_TYPE} flexShrink={0} marginRight={2}>
               <Text dimColor={isInactiveProse && !selected} color={i.interest_type ? "green" : "yellow"} inverse={selected}>{type}</Text>
             </Box>
             <Box width={COL_WATCHES} flexShrink={0} marginRight={1}>


### PR DESCRIPTION
## Summary

[CTL-438](https://linear.app/coalesce-labs/issue/CTL-438): The Interests tab in the orch-monitor HUD rendered the TYPE column at 16 chars right next to the WATCHES column with only a 1-char gutter. Values like `ticket_lifecycle` (exactly 16 chars) butted into WATCHES with no visual separation.

- `COL_TYPE`: 16 → 18 (so the longest current label, `ticket_lifecycle`, leaves a 2-char trailing pad).
- TYPE `marginRight`: 1 → 2 (one extra char between TYPE and WATCHES).
- `promptW` subtractor: 5 → 6 (PROMPT now accounts for the extra char of margin so it doesn't push WATCHES into the prompt cell on narrow terminals).

The "consider making these widths responsive" note in the ticket is left for a future change — the small fixed columns are intentionally fixed, only the ORCH/PROMPT side adapts to terminal width via `promptW`.

## Test plan

- [x] `bun run typecheck` — no new errors (`ui/src/lib/briefings.ts` errors are pre-existing on `main`, caused by `ui/`'s own `node_modules` not being installed in the parent tsconfig scope).
- [x] `bun run lint cli/components/InterestList.tsx` — clean.
- [x] `bun test` — 1964 pass / 7 fail / 1 error (the 7 failures are pre-existing flakes in `__tests__/session-store.test.ts` that reproduce on `main` without this change; running that file in isolation passes 11/11).
- [ ] Post-merge smoke: run `orch-monitor` HUD, switch to Interests tab, confirm `ticket_lifecycle` and `comms_lifecycle` no longer touch the WATCHES column.

The file has no Ink-rendering test surface, and no exported pure function changed — the existing component tests in `cli/components/` cover row formatting and filter chip helpers, not Ink layout box widths. Following the same pattern as recent visual-only fixes (CTL-420, CTL-416), this lands without a new test.