### PR TITLE
fix(dev): catalyst-events tail/wait-for exit when parent dies (CTL-439)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-events.signal.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-events.signal.test.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Shell tests for catalyst-events signal handling and PPID liveness — CTL-439.
+#
+# Verifies that `tail` and `wait-for` exit promptly when:
+#   1. Their parent process is killed and they get reparented to init (PPID
+#      becomes stale; trap doesn't fire because no signal is delivered).
+#   2. They receive SIGTERM directly (trap fires, exits 0).
+#
+# Without the fix, both processes would block in their `sleep 1` polling loops
+# until either a downstream event arrived (tail) or their --timeout fired
+# (wait-for, default 1800 s).
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-events.signal.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+EVENTS="${REPO_ROOT}/plugins/dev/scripts/catalyst-events"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+export CATALYST_DIR="$SCRATCH"
+export CATALYST_EVENTS_DIR="$SCRATCH/events"
+mkdir -p "$CATALYST_EVENTS_DIR"
+EVENTS_FILE="$CATALYST_EVENTS_DIR/$(date -u +%Y-%m).jsonl"
+: > "$EVENTS_FILE"
+
+# Track child PIDs so we can clean up even on test failure.
+CHILDREN=()
+cleanup() {
+  for pid in "${CHILDREN[@]}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+
+# Poll for process exit. Returns 0 if the process is gone within $timeout
+# seconds, 1 otherwise. Resolution is 100 ms.
+wait_for_exit() {
+  local pid="$1" timeout="$2"
+  local elapsed_ms=0
+  local timeout_ms=$(( timeout * 1000 ))
+  while [ "$elapsed_ms" -lt "$timeout_ms" ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+    elapsed_ms=$(( elapsed_ms + 100 ))
+  done
+  return 1
+}
+
+pass() {
+  PASSES=$((PASSES+1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $1"
+}
+
+echo "catalyst-events signal handling tests"
+
+# ── 1. tail exits ≤2s when parent dies (orphan-to-init path) ───────────────
+# Spawn a wrapper bash subshell that exec's catalyst-events tail. Killing the
+# wrapper would normally orphan the tail (PPID becomes 1 on Linux/macOS).
+# The fix: tail polls `kill -0 $PPID` each loop iteration and exits when its
+# original parent disappears.
+{
+  WRAPPER_OUT="$SCRATCH/wrapper.out"
+  WRAPPER_PIDFILE="$SCRATCH/wrapper.pid"
+  TAIL_PIDFILE="$SCRATCH/tail.pid"
+
+  # Wrapper: launch tail in background, record both PIDs, then sleep so the
+  # wrapper outlives the launch. Use `setsid` if available so the wrapper is
+  # its own session leader (otherwise SIGTERM to wrapper would propagate to
+  # tail and we wouldn't be testing the PPID path).
+  bash -c '
+    "$1" tail >/dev/null 2>&1 &
+    echo $! > "$2"
+    echo $$ > "$3"
+    sleep 30
+  ' _ "$EVENTS" "$TAIL_PIDFILE" "$WRAPPER_PIDFILE" &
+  WRAPPER_PID=$!
+  CHILDREN+=("$WRAPPER_PID")
+
+  # Give the wrapper a moment to write the pidfiles.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -s "$TAIL_PIDFILE" ] && [ -s "$WRAPPER_PIDFILE" ] && break
+    sleep 0.1
+  done
+
+  TAIL_PID=""
+  [ -s "$TAIL_PIDFILE" ] && TAIL_PID=$(cat "$TAIL_PIDFILE")
+  if [ -z "$TAIL_PID" ]; then
+    fail "tail orphan: could not capture tail PID from wrapper"
+  elif ! kill -0 "$TAIL_PID" 2>/dev/null; then
+    fail "tail orphan: tail process never started (pid $TAIL_PID)"
+  else
+    CHILDREN+=("$TAIL_PID")
+    # SIGKILL the wrapper without warning — the tail child gets reparented
+    # to init and receives no signal.
+    kill -KILL "$WRAPPER_PID" 2>/dev/null
+    if wait_for_exit "$TAIL_PID" 3; then
+      pass "tail exits ≤3s after parent SIGKILL (orphan-to-init)"
+    else
+      fail "tail did not exit after parent SIGKILL (still alive after 3s)"
+      kill -KILL "$TAIL_PID" 2>/dev/null
+    fi
+  fi
+}
+
+# ── 2. tail exits cleanly on SIGTERM ───────────────────────────────────────
+{
+  "$EVENTS" tail >/dev/null 2>&1 &
+  TAIL_PID=$!
+  CHILDREN+=("$TAIL_PID")
+  sleep 0.3   # let the script enter its loop
+  if ! kill -0 "$TAIL_PID" 2>/dev/null; then
+    fail "tail SIGTERM: tail exited before we could signal it"
+  else
+    kill -TERM "$TAIL_PID" 2>/dev/null
+    if wait_for_exit "$TAIL_PID" 2; then
+      pass "tail exits ≤2s on SIGTERM"
+    else
+      fail "tail did not exit on SIGTERM (still alive after 2s)"
+      kill -KILL "$TAIL_PID" 2>/dev/null
+    fi
+  fi
+}
+
+# ── 3. wait-for exits ≤3s when parent dies (orphan path) ──────────────────
+# wait-for with a long --timeout would otherwise sit for ~30 minutes after
+# its parent goes away.
+{
+  WAITFOR_PIDFILE="$SCRATCH/waitfor.pid"
+  WRAPPER_PIDFILE="$SCRATCH/wf-wrapper.pid"
+
+  bash -c '
+    "$1" wait-for --timeout 3600 --filter ".event == \"never-matches-anything-12345\"" >/dev/null 2>&1 &
+    echo $! > "$2"
+    echo $$ > "$3"
+    sleep 30
+  ' _ "$EVENTS" "$WAITFOR_PIDFILE" "$WRAPPER_PIDFILE" &
+  WRAPPER_PID=$!
+  CHILDREN+=("$WRAPPER_PID")
+
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -s "$WAITFOR_PIDFILE" ] && break
+    sleep 0.1
+  done
+
+  WAITFOR_PID=""
+  [ -s "$WAITFOR_PIDFILE" ] && WAITFOR_PID=$(cat "$WAITFOR_PIDFILE")
+  if [ -z "$WAITFOR_PID" ]; then
+    fail "wait-for orphan: could not capture wait-for PID"
+  elif ! kill -0 "$WAITFOR_PID" 2>/dev/null; then
+    fail "wait-for orphan: wait-for never started"
+  else
+    CHILDREN+=("$WAITFOR_PID")
+    kill -KILL "$WRAPPER_PID" 2>/dev/null
+    if wait_for_exit "$WAITFOR_PID" 3; then
+      pass "wait-for exits ≤3s after parent SIGKILL (orphan-to-init)"
+    else
+      fail "wait-for did not exit after parent SIGKILL (still alive after 3s)"
+      kill -KILL "$WAITFOR_PID" 2>/dev/null
+    fi
+  fi
+}
+
+# ── 4. wait-for exits cleanly on SIGTERM ──────────────────────────────────
+{
+  "$EVENTS" wait-for --timeout 3600 --filter '.event == "never-matches-anything-12345"' >/dev/null 2>&1 &
+  WAITFOR_PID=$!
+  CHILDREN+=("$WAITFOR_PID")
+  sleep 0.3
+  if ! kill -0 "$WAITFOR_PID" 2>/dev/null; then
+    fail "wait-for SIGTERM: wait-for exited before we could signal it"
+  else
+    kill -TERM "$WAITFOR_PID" 2>/dev/null
+    if wait_for_exit "$WAITFOR_PID" 2; then
+      pass "wait-for exits ≤2s on SIGTERM"
+    else
+      fail "wait-for did not exit on SIGTERM (still alive after 2s)"
+      kill -KILL "$WAITFOR_PID" 2>/dev/null
+    fi
+  fi
+}
+
+echo
+echo "Results: $PASSES passed, $FAILURES failed"
+if [ "$FAILURES" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -115,6 +115,12 @@ cmd_tail() {
     esac
   done
 
+  # CTL-439: exit promptly on common termination signals. Bash's default
+  # SIGTERM handling already exits, but installing a trap also covers SIGHUP
+  # (parent shell close) and SIGPIPE (downstream consumer closed the pipe)
+  # which otherwise wouldn't propagate out of the polling loops.
+  trap 'exit 0' TERM HUP PIPE INT
+
   local file
   file="$(events_file_path)"
 
@@ -134,9 +140,16 @@ cmd_tail() {
     last_lines="$(line_count "$file")"
   fi
 
+  # CTL-439: $PPID is captured at process start and is not updated when the
+  # parent dies. When our parent is reaped without delivering a signal (the
+  # orphan-to-init case), kill -0 returns non-zero and we exit cleanly.
   if command -v fswatch >/dev/null 2>&1; then
     # fswatch -o emits an event count; we re-check line count on each.
+    # The PPID check fires on each fswatch wake; the events file sees regular
+    # traffic (heartbeats, lifecycle events) so the check runs frequently
+    # enough in practice to catch orphan-to-init within the heartbeat window.
     fswatch -o "$file" 2>/dev/null | while read -r _; do
+      kill -0 "$PPID" 2>/dev/null || exit 0
       local cur
       cur="$(line_count "$file")"
       if [[ "$cur" -gt "$last_lines" ]]; then
@@ -153,6 +166,7 @@ cmd_tail() {
     done
   else
     while :; do
+      kill -0 "$PPID" 2>/dev/null || exit 0
       sleep 1
       local cur
       cur="$(line_count "$file")"
@@ -208,6 +222,10 @@ cmd_wait_for() {
     return 2
   fi
 
+  # CTL-439: symmetric with cmd_tail — exit on common termination signals
+  # so a killed Monitor / wait-for caller doesn't leave a leaked process.
+  trap 'exit 0' TERM HUP PIPE INT
+
   local file
   file="$(events_file_path)"
   local deadline=$(( $(date +%s) + timeout ))
@@ -245,6 +263,11 @@ cmd_wait_for() {
   fi
 
   while :; do
+    # CTL-439: PPID liveness check — if our parent has been reaped without
+    # delivering a signal (orphan-to-init), exit cleanly instead of blocking
+    # until --timeout (default 30 minutes).
+    kill -0 "$PPID" 2>/dev/null || exit 0
+
     if [[ "$(date +%s)" -ge "$deadline" ]]; then
       _emit_wait_event "worker.resumed" '{"outcome":"timed_out"}'
       return 1


### PR DESCRIPTION
## Summary

Fixes [CTL-439](https://linear.app/coalesce-labs/issue/CTL-439). `catalyst-events tail` and `wait-for` had no signal trap and no PPID liveness check, so child processes outlived their parent shells. One machine had 27 orphan tails — oldest 3.5 days old — pinned to retired plugin cache versions. Every event arrival re-ran `jq` across every leaked tail, which is what tipped the user off (laptop sluggishness).

## Fix

Two lines per function in `plugins/dev/scripts/catalyst-events`:

```bash
trap 'exit 0' TERM HUP PIPE INT
kill -0 "$PPID" 2>/dev/null || exit 0   # at the top of each polling loop
```

- **`$PPID` is captured at process start and never updated by bash**, so once the original parent is reaped, `kill -0 "$PPID"` returns non-zero and the script exits cleanly. This is the load-bearing fix — it catches the orphan-to-init case where no signal is delivered.
- **The trap** covers graceful shutdown paths the default doesn't propagate well out of the polling loop: SIGHUP (parent shell close), SIGPIPE (downstream consumer closed the pipe), INT (Ctrl-C).
- Both `cmd_tail` (sleep branch + fswatch branch) and `cmd_wait_for` get the same treatment.
- The trap installed inside `cmd_tail` / `cmd_wait_for` also covers the `wait_for_file` helper that they invoke — bash traps propagate through function calls in the same shell.

## Why the fswatch branch keeps the bare `while read -r _`

I initially tried `read -t 2` to give the fswatch loop a 2 s heartbeat for PPID polling, but **macOS bash 3.2 returns rc=1 for both timeout and EOF** — only bash 4+ uses rc>128 for timeout. Distinguishing them portably would either busy-loop on a closed pipe (bad) or require non-trivial extra plumbing (out of scope). In practice the events file sees regular traffic (heartbeats, worker lifecycle, GitHub/Linear webhooks) so the PPID check inside the fswatch body fires frequently enough in real-world use.

## Tests

New: `plugins/dev/scripts/__tests__/catalyst-events.signal.test.sh` — 4 cases, runs in ~7 s total.

1. `tail` exits ≤3 s after parent SIGKILL (orphan-to-init path; this is the test that failed pre-fix on the sleep branch).
2. `tail` exits ≤2 s on SIGTERM (passed pre-fix too — bash default handles this; included for symmetry).
3. `wait-for` exits ≤3 s after parent SIGKILL (without the fix it would sit for `--timeout` seconds, default 1800).
4. `wait-for` exits ≤2 s on SIGTERM.

```
$ bash plugins/dev/scripts/__tests__/catalyst-events.signal.test.sh
Results: 4 passed, 0 failed
```

Existing `plugins/dev/scripts/__tests__/catalyst-events.test.sh`: still 35/36. The one failing test (`help exits 0 and prints usage`) was already failing on `main` — it greps for the literal `'tail and wait-for'` but the help string was updated in [CTL-313](https://linear.app/coalesce-labs/issue/CTL-313) to `'tail, wait-for, and natural-language query'`. Filed as a separate finding for a one-liner follow-up — out of scope here per the bug-fix-doesn't-need-cleanup rule.

## Reaping pre-existing orphans

Developer machines with leaked tails from older sessions can clean up with:

```bash
pkill -f 'catalyst-events tail'
pkill -f 'catalyst-events wait-for'
```

## Out of scope

Broker-fanout-via-signal-file (eliminating per-agent tails entirely by having `catalyst-broker` write per-session wake files that agents `fswatch`) — separate larger refactor per the ticket.

## Test plan

- [x] New signal tests pass (`bash plugins/dev/scripts/__tests__/catalyst-events.signal.test.sh`)
- [x] Existing tests still pass (`bash plugins/dev/scripts/__tests__/catalyst-events.test.sh` — 35/36, pre-existing `help` drift unchanged)
- [x] Bash syntax check (`bash -n plugins/dev/scripts/catalyst-events`)
- [x] Manual reproduction:
  ```bash
  bash -c 'catalyst-events tail &  echo $! > /tmp/p; sleep 30' &
  PARENT=$!; sleep 0.3
  kill -9 $PARENT
  sleep 3
  kill -0 "$(cat /tmp/p)" 2>/dev/null && echo "LEAK" || echo "OK"
  ```