### PR TITLE
feat(dev): add phase_lifecycle interest type to broker daemon (CTL-447)

### DIFF
--- a/plugins/dev/scripts/__tests__/broker-phase-lifecycle.test.sh
+++ b/plugins/dev/scripts/__tests__/broker-phase-lifecycle.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Shell test for broker phase_lifecycle interest type (CTL-447).
+# Run: bash plugins/dev/scripts/__tests__/broker-phase-lifecycle.test.sh
+#
+# Delegates to the bun test runner so the assertions live in idiomatic JS
+# alongside the broker source. The acceptance criterion in the plan
+# (§Initiative 1 Phase 1) is "6 tests pass" — the matching describe block
+# in phase-lifecycle.test.mjs contains exactly 6 test() calls.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+TEST_FILE="${REPO_ROOT}/plugins/dev/scripts/broker/phase-lifecycle.test.mjs"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "SKIP: bun not on PATH — phase_lifecycle tests require bun" >&2
+  exit 0
+fi
+
+if [[ ! -f "$TEST_FILE" ]]; then
+  echo "FAIL: test file not found: $TEST_FILE" >&2
+  exit 1
+fi
+
+echo "broker phase_lifecycle tests"
+
+OUT_FILE="$(mktemp)"
+trap 'rm -f "$OUT_FILE"' EXIT
+
+# Run only the core phase_lifecycle describe block so the count assertion below
+# matches the acceptance criterion of "6 tests pass" exactly.
+( cd "$REPO_ROOT" && bun test "$TEST_FILE" --test-name-pattern "phase_lifecycle interest type" ) \
+  > "$OUT_FILE" 2>&1
+RC=$?
+
+cat "$OUT_FILE"
+
+if [ "$RC" -ne 0 ]; then
+  echo
+  echo "FAIL: bun test exited with rc=$RC"
+  exit 1
+fi
+
+PASS_COUNT=$(grep -cE '^[[:space:]]*[0-9]+ pass' "$OUT_FILE" | head -1)
+PASS_NUM=$(grep -oE '[0-9]+ pass' "$OUT_FILE" | head -1 | awk '{print $1}')
+
+if [ -z "$PASS_NUM" ] || [ "$PASS_NUM" -lt 6 ]; then
+  echo
+  echo "FAIL: expected 6 tests to pass, got ${PASS_NUM:-0}"
+  exit 1
+fi
+
+echo
+echo "Results: $PASS_NUM passed"
+exit 0

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -427,6 +427,7 @@ const DETERMINISTIC_INTEREST_TYPES = new Set([
   "pr_lifecycle",
   "ticket_lifecycle",
   "comms_lifecycle",
+  "phase_lifecycle",
 ]);
 let _proseDisabledEmitted = false;
 
@@ -515,6 +516,7 @@ export function handleRegister(event) {
   const isPrLifecycle = d.interest_type === "pr_lifecycle";
   const isTicketLifecycle = d.interest_type === "ticket_lifecycle";
   const isCommsLifecycle = d.interest_type === "comms_lifecycle";
+  const isPhaseLifecycle = d.interest_type === "phase_lifecycle";
   interests.set(id, {
     notify_event: d.notify_event ?? `filter.wake.${id}`,
     prompt: d.prompt ?? "",
@@ -540,6 +542,9 @@ export function handleRegister(event) {
       : null,
     subscriber_ticket: isCommsLifecycle ? (d.subscriber_ticket ?? null) : null,
     types_of_interest: isCommsLifecycle ? (Array.isArray(d.types_of_interest) ? d.types_of_interest : null) : null,
+    // phase_lifecycle fields (CTL-447)
+    ticket: isPhaseLifecycle ? (d.ticket ?? null) : null,
+    phase_names: isPhaseLifecycle ? (Array.isArray(d.phase_names) ? d.phase_names : []) : null,
     // CTL-407: suppress redundant wakes when downstream state unchanged.
     // Defaults true for pr_lifecycle (opt-out via suppress_identical_wakes: false).
     // False for comms_lifecycle/ticket_lifecycle (HUD and orchestrator watchers want every event).
@@ -575,6 +580,17 @@ export function handleRegister(event) {
         type: "comms_lifecycle",
         channel: d.channel,
         subscriberKind: d.subscriber_kind,
+        persistent,
+      },
+      "registered"
+    );
+  } else if (isPhaseLifecycle) {
+    log.info(
+      {
+        interestId: id,
+        type: "phase_lifecycle",
+        ticket: d.ticket,
+        phaseNames: d.phase_names ?? [],
         persistent,
       },
       "registered"
@@ -721,14 +737,18 @@ export function handleAgentCheckout(event) {
   }
 
   // Deregister auto-derived pr_lifecycle interest so the watchdog doesn't
-  // fire stale wakes after the agent exits.
+  // fire stale wakes after the agent exits. CTL-447: also clean up
+  // phase_lifecycle interests registered with this session_id — orchestrators
+  // subscribe per phase under their own session and must not leak after exit.
   const reg = interests.get(sessionId);
-  if (reg && reg.interest_type === "pr_lifecycle") {
+  if (reg && (reg.interest_type === "pr_lifecycle" || reg.interest_type === "phase_lifecycle")) {
     interests.delete(sessionId);
-    try {
-      deleteFilterState(sessionId);
-    } catch {
-      /* DB not opened */
+    if (reg.interest_type === "pr_lifecycle") {
+      try {
+        deleteFilterState(sessionId);
+      } catch {
+        /* DB not opened */
+      }
     }
     saveInterests();
     persistBrokerState();
@@ -1265,6 +1285,48 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap, repo) {
   }
 }
 
+// --- Deterministic routing: phase_lifecycle (CTL-447) -----------------------
+//
+// Wakes registered sessions on phase boundary events of the shape
+//   phase.<name>.complete.<ticket>
+//   phase.<name>.failed.<ticket>
+//
+// where <name> matches one of the interest's phase_names and <ticket> matches
+// the interest's ticket. Used by the phase-agent orchestrator to coordinate
+// hand-off between short-lived phase agents (see plan §Initiative 1).
+const PHASE_EVENT_PATTERN = /^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-\d+)$/;
+
+export function tryPhaseLifecycleRoute(event, interestsMap) {
+  const matches = [];
+  const name = getEventName(event);
+  if (!name.startsWith("phase.")) return matches;
+  const m = PHASE_EVENT_PATTERN.exec(name);
+  if (!m) return matches;
+  const [, phaseName, status, ticket] = m;
+  const eventId = event.id ?? synthesizeEventId(event);
+
+  for (const [interestId, reg] of interestsMap) {
+    if (reg.interest_type !== "phase_lifecycle") continue;
+    if (reg.ticket !== ticket) continue;
+    const phases = Array.isArray(reg.phase_names) ? reg.phase_names : [];
+    if (!phases.includes(phaseName)) continue;
+
+    const reason =
+      status === "complete"
+        ? `Phase ${phaseName} complete on ${ticket}`
+        : `Phase ${phaseName} failed on ${ticket}`;
+    matches.push({
+      interestId,
+      reason,
+      sourceEventId: eventId,
+      sourceEvent: summarizeEvent(event),
+      ticket,
+    });
+  }
+
+  return matches;
+}
+
 // --- Event classification ---
 
 // CTL-346: skip events the broker itself emitted so we never re-ingest
@@ -1292,10 +1354,7 @@ export function buildGroqPrompt(events) {
 
   // Deterministic-routed interest types are excluded from the Groq prompt.
   const proseInterests = [...interests.entries()].filter(
-    ([, reg]) =>
-      reg.interest_type !== "pr_lifecycle" &&
-      reg.interest_type !== "ticket_lifecycle" &&
-      reg.interest_type !== "comms_lifecycle"
+    ([, reg]) => !DETERMINISTIC_INTEREST_TYPES.has(reg.interest_type)
   );
   if (proseInterests.length === 0) return null;
 
@@ -1708,10 +1767,12 @@ export function processEvent(event) {
 
   if (!interests.size) return;
 
-  // Deterministic short-circuit: pr_lifecycle (CTL-284) and ticket_lifecycle (CTL-303).
+  // Deterministic short-circuit: pr_lifecycle (CTL-284), ticket_lifecycle (CTL-303),
+  // phase_lifecycle (CTL-447).
   const prMatches = tryDeterministicRoute(event, interests);
   const ticketMatches = tryTicketLifecycleRoute(event, interests);
-  const directMatches = [...prMatches, ...ticketMatches];
+  const phaseMatches = tryPhaseLifecycleRoute(event, interests);
+  const directMatches = [...prMatches, ...ticketMatches, ...phaseMatches];
 
   for (const m of directMatches) {
     const reg = interests.get(m.interestId);
@@ -1928,6 +1989,9 @@ export function buildBrokerState({ probe } = {}) {
   return {
     pid: process.pid,
     startedAt: brokerStartedAt ?? new Date().toISOString(),
+    // CTL-447: enumerate the deterministic interest types this broker supports
+    // so `catalyst-broker status --json` can advertise them to clients.
+    supportedInterestTypes: [...DETERMINISTIC_INTEREST_TYPES],
     // CTL-352: liveness fields so the HUD pill and operators can detect a
     // silently-dead broker (interests.size === 0 with stale lastWakeAt).
     interestCount: interests.size,

--- a/plugins/dev/scripts/broker/phase-lifecycle.test.mjs
+++ b/plugins/dev/scripts/broker/phase-lifecycle.test.mjs
@@ -1,0 +1,190 @@
+// Unit tests for catalyst-broker phase_lifecycle interest type (CTL-447).
+// Run: bun test plugins/dev/scripts/broker/phase-lifecycle.test.mjs
+//
+// Six tests track the success criteria in the architecture plan §Initiative 1
+// Phase 1: register, ticket isolation, phase isolation, failed-event wake,
+// checkout deregister, and persistence round-trip.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  handleRegister,
+  handleAgentCheckout,
+  tryPhaseLifecycleRoute,
+  buildGroqPrompt,
+  buildBrokerState,
+  getInterests,
+  clearInterests,
+  loadPersistedInterests,
+  saveInterests,
+  __clearEmittedWakeCacheForTest,
+} from "./index.mjs";
+import { openBrokerStateDb, closeBrokerStateDb } from "./broker-state.mjs";
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "broker-phase-test-"));
+  process.env.CATALYST_DIR = tmpDir;
+  openBrokerStateDb(join(tmpDir, "test.db"));
+  clearInterests();
+  __clearEmittedWakeCacheForTest();
+});
+
+afterEach(() => {
+  closeBrokerStateDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.CATALYST_DIR;
+});
+
+function registerPhaseInterest({
+  interestId = "watcher-1",
+  ticket = "CTL-100",
+  phaseNames = ["research", "plan"],
+  orchestrator = "orch-1",
+  sessionId = "watcher-1",
+  persistent = true,
+} = {}) {
+  handleRegister({
+    event: "filter.register",
+    orchestrator,
+    detail: {
+      interest_id: interestId,
+      notify_event: `filter.wake.${interestId}`,
+      interest_type: "phase_lifecycle",
+      ticket,
+      phase_names: phaseNames,
+      session_id: sessionId,
+      persistent,
+    },
+  });
+}
+
+describe("phase_lifecycle interest type", () => {
+  // Test 1
+  test("register + matching phase.<name>.complete.<ticket> event produces a wake match", () => {
+    registerPhaseInterest();
+    const matches = tryPhaseLifecycleRoute(
+      {
+        ts: "2026-05-17T05:00:00Z",
+        attributes: { "event.name": "phase.research.complete.CTL-100" },
+        body: { payload: { ticket: "CTL-100", phase: "research" } },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("watcher-1");
+    expect(matches[0].reason).toMatch(/phase research complete/i);
+    expect(matches[0].reason).toContain("CTL-100");
+  });
+
+  // Test 2
+  test("ignores events for other tickets", () => {
+    registerPhaseInterest({ ticket: "CTL-100" });
+    const matches = tryPhaseLifecycleRoute(
+      {
+        ts: "2026-05-17T05:00:00Z",
+        attributes: { "event.name": "phase.research.complete.CTL-999" },
+        body: { payload: { ticket: "CTL-999", phase: "research" } },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  // Test 3
+  test("ignores events for phases not in phase_names", () => {
+    registerPhaseInterest({ phaseNames: ["research", "plan"] });
+    const matches = tryPhaseLifecycleRoute(
+      {
+        ts: "2026-05-17T05:00:00Z",
+        attributes: { "event.name": "phase.implement.complete.CTL-100" },
+        body: { payload: { ticket: "CTL-100", phase: "implement" } },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  // Test 4
+  test("phase.<name>.failed.<ticket> events fire a wake with failure reason", () => {
+    registerPhaseInterest();
+    const matches = tryPhaseLifecycleRoute(
+      {
+        ts: "2026-05-17T05:00:00Z",
+        attributes: { "event.name": "phase.research.failed.CTL-100" },
+        body: { payload: { ticket: "CTL-100", phase: "research", reason: "timeout" } },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("watcher-1");
+    expect(matches[0].reason).toMatch(/phase research failed/i);
+    expect(matches[0].reason).toContain("CTL-100");
+  });
+
+  // Test 5
+  test("agent.checkout removes a phase_lifecycle interest registered with that session_id", () => {
+    registerPhaseInterest({ interestId: "sess-A", sessionId: "sess-A" });
+    expect(getInterests().has("sess-A")).toBe(true);
+    handleAgentCheckout({
+      event: "agent.checkout",
+      detail: { session_id: "sess-A", status: "done" },
+    });
+    expect(getInterests().has("sess-A")).toBe(false);
+  });
+
+  // Test 6
+  test("phase_lifecycle entries round-trip through saveInterests + loadPersistedInterests", () => {
+    registerPhaseInterest({
+      interestId: "watcher-rt",
+      ticket: "CTL-200",
+      phaseNames: ["triage", "research"],
+      sessionId: "watcher-rt",
+    });
+    saveInterests();
+
+    // Simulate restart by clearing and reloading from disk.
+    clearInterests();
+    expect(getInterests().size).toBe(0);
+    loadPersistedInterests();
+
+    const reg = getInterests().get("watcher-rt");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("phase_lifecycle");
+    expect(reg.ticket).toBe("CTL-200");
+    expect(reg.phase_names).toEqual(["triage", "research"]);
+
+    // Persistence preserves enough state to keep matching after reload.
+    const matches = tryPhaseLifecycleRoute(
+      {
+        ts: "2026-05-17T05:00:00Z",
+        attributes: { "event.name": "phase.research.complete.CTL-200" },
+        body: { payload: { ticket: "CTL-200" } },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("watcher-rt");
+  });
+});
+
+describe("phase_lifecycle integration", () => {
+  test("phase_lifecycle interests are excluded from the Groq prose prompt", () => {
+    registerPhaseInterest();
+    const prompt = buildGroqPrompt([
+      { attributes: { "event.name": "phase.research.complete.CTL-100" } },
+    ]);
+    expect(prompt).toBeNull();
+  });
+
+  test("buildBrokerState exposes phase_lifecycle in supportedInterestTypes", () => {
+    const state = buildBrokerState();
+    expect(state.supportedInterestTypes).toContain("phase_lifecycle");
+    expect(state.supportedInterestTypes).toContain("pr_lifecycle");
+    expect(state.supportedInterestTypes).toContain("ticket_lifecycle");
+    expect(state.supportedInterestTypes).toContain("comms_lifecycle");
+  });
+});

--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -45,6 +45,7 @@ catalyst-broker logs
 | `pr_lifecycle` | Deterministic | Watch CI, reviews, merge, deployment for a known PR number |
 | `ticket_lifecycle` | Deterministic | Watch Linear state changes, comments, PR links for a ticket |
 | `comms_lifecycle` | Deterministic | Watch comms-channel messages (worker → orchestrator attention/done, orchestrator → worker directives) |
+| `phase_lifecycle` | Deterministic | Watch `phase.<name>.complete.<ticket>` / `phase.<name>.failed.<ticket>` events — orchestrator hand-off between phase agents |
 | (prose prompt) | Groq LLM (env-gated off; CTL-357) | Anything ambiguous, cross-cutting, or complex — set `CATALYST_BROKER_PROSE_ENABLED=1` to re-enable |
 
 ## 1. Auto-Correlation (The Common Case — No Registration Needed)
@@ -488,6 +489,58 @@ jq -nc \
 ```
 
 See §10 for the complete field reference and `wake-extract` accessor.
+
+## 4b. `phase_lifecycle` Interest Type (CTL-447)
+
+Deterministic routing for phase-agent boundary events. The orchestrator subscribes once per
+ticket per set of phases and is woken when a phase agent emits its terminal event:
+
+- `phase.<name>.complete.<ticket>` — phase succeeded; orchestrator dispatches the next one.
+- `phase.<name>.failed.<ticket>` — phase failed; orchestrator runs the fix-up path.
+
+The match is keyed on `(ticket, phase_name)` so a single orchestrator can run many tickets
+in parallel without cross-talk.
+
+### Schema
+
+```json
+{
+  "interest_id": "<orch-id>",
+  "interest_type": "phase_lifecycle",
+  "notify_event": "filter.wake.<orch-id>",
+  "persistent": true,
+  "ticket": "CTL-100",
+  "phase_names": ["triage", "research", "plan", "implement", "validate", "ship"]
+}
+```
+
+### Registering
+
+```bash
+jq -nc \
+  --arg orch "${CATALYST_ORCHESTRATOR_ID}" \
+  --arg ticket "$TICKET_ID" \
+  --argjson phases '["triage","research","plan","implement","validate","ship"]' \
+  '{ts: (now | todate), event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $orch,
+      interest_type: "phase_lifecycle",
+      notify_event: ("filter.wake." + $orch),
+      persistent: true,
+      ticket: $ticket,
+      phase_names: $phases
+    }}' >> ~/catalyst/events/$(date -u +%Y-%m).jsonl
+```
+
+### Match logic (no Groq call)
+
+| Trigger | Condition |
+|---|---|
+| `event.name` matches `phase.<name>.(complete\|failed).<ticket>` | always required |
+| `<ticket>` == `reg.ticket` | required |
+| `<name>` ∈ `reg.phase_names` | required |
 
 ## 5. `pr_lifecycle` Interest Type (CTL-284 — Unchanged)
 

--- a/plugins/dev/skills/catalyst-filter/SKILL.md
+++ b/plugins/dev/skills/catalyst-filter/SKILL.md
@@ -69,7 +69,8 @@ Orchestrator                          broker daemon                       Event 
     │                                     │  deterministic match?            │
     │                                     │   ├─ pr_lifecycle ──┐            │
     │                                     │   ├─ ticket_lifecycle ┐          │
-    │                                     │   └─ comms_lifecycle ─┤          │
+    │                                     │   ├─ comms_lifecycle ─┤          │
+    │                                     │   └─ phase_lifecycle ─┤          │
     │                                     │                       ▼          │
     │                                     │── append filter.wake.{id} ──────►│
     │                                     │                                  │
@@ -214,6 +215,37 @@ two interests: a `pr_lifecycle` one for the typed PR-lifecycle events, and a pro
 under a different `interest_id` for residual concerns like comms-attention or
 Linear-ticket status changes that aren't covered by the deterministic table. Both
 interests use the same `notify_event`, so the wait-for filter is unchanged.
+
+#### `phase_lifecycle` (CTL-447)
+
+Deterministic routing for phase-agent boundary events. The orchestrator registers one
+interest per ticket that names every phase it cares about; the broker wakes it whenever
+a matching `phase.<name>.complete.<ticket>` or `phase.<name>.failed.<ticket>` event
+lands in the log.
+
+```jsonc
+{
+  "event": "filter.register",
+  "orchestrator": "$ORCH_NAME",
+  "detail": {
+    "interest_id": "$ORCH_NAME",
+    "interest_type": "phase_lifecycle",
+    "notify_event": "filter.wake.$ORCH_NAME",
+    "persistent": true,
+    "ticket": "CTL-100",
+    "phase_names": ["triage", "research", "plan", "implement", "validate", "ship"]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `interest_type` | `"phase_lifecycle"` | Discriminator. Required for deterministic routing. |
+| `ticket` | string | Linear ticket the orchestrator is shepherding (e.g. `"CTL-100"`). Matched against the `<ticket>` segment of the event name. |
+| `phase_names` | `string[]` | Phase names the orchestrator cares about. Events for phases not in this list are ignored. |
+
+Wake reason takes the form `"Phase <name> complete on <ticket>"` or `"Phase <name> failed
+on <ticket>"`. See [[broker]] §4b for the full event-name grammar.
 
 ### Per-agent-type registration patterns
 


### PR DESCRIPTION
## Summary

Adds the **`phase_lifecycle`** deterministic interest type to the catalyst broker daemon — fourth alongside `pr_lifecycle`, `ticket_lifecycle`, and `comms_lifecycle`.

The broker wakes a registered session on any `phase.<name>.complete.<ticket>` or `phase.<name>.failed.<ticket>` event whose `<name>` matches the interest's `phase_names` list and whose `<ticket>` matches the interest's `ticket`.

This is the foundation for the phase-agent architecture (plan §Initiative 1 Phase 1 — `thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md`). Orchestrators will subscribe per ticket per phase and route hand-offs between short-lived phase agents through broker wakes rather than file-watching signal files.

**Smallest possible PR — pure additive broker extension, no behavioral change to other routes.** Lands first; all subsequent phase-agent work depends on it.

## Changes

- `plugins/dev/scripts/broker/index.mjs` (+76 / −12)
  - Add `phase_lifecycle` to `DETERMINISTIC_INTEREST_TYPES`
  - Store `ticket` + `phase_names` fields in `handleRegister`
  - New `tryPhaseLifecycleRoute` wired into `processEvent`
  - Extend `handleAgentCheckout` to clean up `phase_lifecycle` interests by session_id
  - Surface `supportedInterestTypes` array in `buildBrokerState` so `catalyst-broker status --json` advertises the type
  - Replace the duplicated deterministic-type exclusion list in `buildGroqPrompt` with a `DETERMINISTIC_INTEREST_TYPES` membership check
- `plugins/dev/scripts/broker/phase-lifecycle.test.mjs` — new 8-test bun suite (6 in the core describe block named for the acceptance criterion + 2 integration tests)
- `plugins/dev/scripts/__tests__/broker-phase-lifecycle.test.sh` — new bash wrapper that runs the 6 named tests via bun and asserts the pass count
- `plugins/dev/skills/broker/SKILL.md` and `plugins/dev/skills/catalyst-filter/SKILL.md` — document the new interest type, schema, registration example, and match logic

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/broker-phase-lifecycle.test.sh` — **6 pass**
- [x] `bun test plugins/dev/scripts/broker/` — **227 pass / 0 fail / 541 expect() calls** (no regression)
- [x] `node --check plugins/dev/scripts/broker/index.mjs` clean
- [x] `catalyst-broker status --json` includes `phase_lifecycle` in `supportedInterestTypes`

Closes CTL-447.