### PR TITLE
feat(dev): add verifying/reviewing transition keys for phase-agent observability (CTL-454)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -9,9 +9,11 @@
       "stateMap": {
         "backlog": "Backlog",
         "todo": "Backlog",
-        "research": "In Progress",
-        "planning": "In Progress",
+        "research": "Research",
+        "planning": "Planning",
         "inProgress": "In Progress",
+        "verifying": "In Progress",
+        "reviewing": "In Progress",
         "inReview": "In Review",
         "done": "Done",
         "canceled": "Canceled"

--- a/plugins/dev/scripts/__tests__/linear-transition.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-transition.test.sh
@@ -54,6 +54,8 @@ build_config() {
         "research": "In Progress",
         "planning": "In Progress",
         "inProgress": "In Progress",
+        "verifying": "In Progress",
+        "reviewing": "In Progress",
         "inReview": "In Review",
         "done": "Done",
         "canceled": "Canceled",
@@ -386,6 +388,108 @@ run "oneshot SKILL.md references linear-transition.sh" \
 MERGE_SKILL="${REPO_ROOT}/plugins/dev/skills/merge-pr/SKILL.md"
 run "merge-pr SKILL.md uses linear-transition.sh" \
   bash -c "grep -q 'linear-transition.sh' '$MERGE_SKILL'"
+
+# ─── Test 20: verifying transition uses stateMap.verifying from config ────
+# Phase-agent observability (CTL-454). New transition keys for the verify and
+# review phase agents. Until the user creates dedicated Linear states, both
+# default to "In Progress" so dispatching the new transitions never errors.
+WORK20="${SCRATCH}/t20"
+BIN20="${SCRATCH}/t20/bin"
+LOG20="${SCRATCH}/t20/log"
+build_config "$WORK20"
+install_fake_linearis "$BIN20"
+touch "$LOG20"
+
+run "verifying transition uses stateMap.verifying from config" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG20' PATH='$BIN20:$PATH' \
+    '$TRANSITION' --ticket TST-20 --transition verifying --config '$WORK20/.catalyst/config.json'"
+
+run "verifying update call recorded with correct status" \
+  expect_contains "$LOG20" "linearis issues update TST-20 --status In Progress"
+
+# ─── Test 21: reviewing transition uses stateMap.reviewing from config ────
+WORK21="${SCRATCH}/t21"
+BIN21="${SCRATCH}/t21/bin"
+LOG21="${SCRATCH}/t21/log"
+build_config "$WORK21"
+install_fake_linearis "$BIN21"
+touch "$LOG21"
+
+run "reviewing transition uses stateMap.reviewing from config" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG21' PATH='$BIN21:$PATH' \
+    '$TRANSITION' --ticket TST-21 --transition reviewing --config '$WORK21/.catalyst/config.json'"
+
+run "reviewing update call recorded with correct status" \
+  expect_contains "$LOG21" "linearis issues update TST-21 --status In Progress"
+
+# ─── Test 22: verifying falls back to default 'In Progress' when stateMap missing
+# A bare-bones config without the verifying key must still resolve via
+# default_state_for() rather than erroring with "could not resolve target state".
+WORK22="${SCRATCH}/t22"
+BIN22="${SCRATCH}/t22/bin"
+LOG22="${SCRATCH}/t22/log"
+mkdir -p "${WORK22}/.catalyst"
+cat > "${WORK22}/.catalyst/config.json" <<'EOF'
+{"catalyst":{"linear":{}}}
+EOF
+install_fake_linearis "$BIN22"
+touch "$LOG22"
+
+run "falls back to default 'In Progress' for verifying when stateMap missing" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG22' PATH='$BIN22:$PATH' \
+    '$TRANSITION' --ticket TST-22 --transition verifying --config '$WORK22/.catalyst/config.json'"
+
+run "default In Progress used for verifying when config has no stateMap" \
+  expect_contains "$LOG22" "linearis issues update TST-22 --status In Progress"
+
+# ─── Test 23: reviewing falls back to default 'In Progress' when stateMap missing
+WORK23="${SCRATCH}/t23"
+BIN23="${SCRATCH}/t23/bin"
+LOG23="${SCRATCH}/t23/log"
+mkdir -p "${WORK23}/.catalyst"
+cat > "${WORK23}/.catalyst/config.json" <<'EOF'
+{"catalyst":{"linear":{}}}
+EOF
+install_fake_linearis "$BIN23"
+touch "$LOG23"
+
+run "falls back to default 'In Progress' for reviewing when stateMap missing" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG23' PATH='$BIN23:$PATH' \
+    '$TRANSITION' --ticket TST-23 --transition reviewing --config '$WORK23/.catalyst/config.json'"
+
+run "default In Progress used for reviewing when config has no stateMap" \
+  expect_contains "$LOG23" "linearis issues update TST-23 --status In Progress"
+
+# ─── Test 24: verifying honors custom configured state name ────────────────
+# Post-Linear-admin behavior: once the user creates a "Verifying" workflow
+# state in Linear and points stateMap.verifying at it, the script must pass
+# that name through to linearis instead of the default.
+WORK24="${SCRATCH}/t24"
+BIN24="${SCRATCH}/t24/bin"
+LOG24="${SCRATCH}/t24/log"
+mkdir -p "${WORK24}/.catalyst"
+cat > "${WORK24}/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "linear": {
+      "teamKey": "TST",
+      "stateMap": {
+        "verifying": "Verifying",
+        "reviewing": "Reviewing"
+      }
+    }
+  }
+}
+EOF
+install_fake_linearis "$BIN24"
+touch "$LOG24"
+
+run "verifying honors custom 'Verifying' state name from config" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG24' PATH='$BIN24:$PATH' \
+    '$TRANSITION' --ticket TST-24 --transition verifying --config '$WORK24/.catalyst/config.json'"
+
+run "custom Verifying state passed to linearis" \
+  expect_contains "$LOG24" "linearis issues update TST-24 --status Verifying"
 
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/linear-transition.sh
+++ b/plugins/dev/scripts/linear-transition.sh
@@ -10,8 +10,9 @@
 #
 #   --ticket <ID>        Linear ticket identifier (required)
 #   --transition <name>  State map key to look up (one of: backlog, todo,
-#                        research, planning, inProgress, inReview, done,
-#                        canceled, duplicate). Required unless --state given.
+#                        research, planning, inProgress, verifying, reviewing,
+#                        inReview, done, canceled, duplicate). Required unless
+#                        --state given.
 #   --state <literal>    Literal state name (takes precedence over --transition)
 #   --config <path>      Path to .catalyst/config.json. Default: auto-discover
 #                        by walking up from CWD.
@@ -38,6 +39,8 @@ default_state_for() {
     research)    echo "In Progress" ;;
     planning)    echo "In Progress" ;;
     inProgress)  echo "In Progress" ;;
+    verifying)   echo "In Progress" ;;
+    reviewing)   echo "In Progress" ;;
     inReview)    echo "In Review" ;;
     done)        echo "Done" ;;
     canceled)    echo "Canceled" ;;

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -105,6 +105,8 @@ Catalyst maps workflow phases to your Linear workspace states via `stateMap` in
 | Research started | In Progress   | `stateMap.research`   |
 | Planning started | In Progress   | `stateMap.planning`   |
 | Implementation   | In Progress   | `stateMap.inProgress` |
+| Verify phase     | In Progress   | `stateMap.verifying`  |
+| Review phase     | In Progress   | `stateMap.reviewing`  |
 | PR created       | In Review     | `stateMap.inReview`   |
 | Completed        | Done          | `stateMap.done`       |
 | Canceled         | Canceled      | `stateMap.canceled`   |

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -35,6 +35,8 @@ project structure, ticket conventions, and workflow state mapping.
         "research": "In Progress",
         "planning": "In Progress",
         "inProgress": "In Progress",
+        "verifying": "In Progress",
+        "reviewing": "In Progress",
         "inReview": "In Review",
         "done": "Done",
         "canceled": "Canceled"
@@ -74,11 +76,21 @@ workflow:
 | `research`   | Running `research-codebase`          | In Progress |
 | `planning`   | Running `create-plan`                | In Progress |
 | `inProgress` | Running `implement-plan`             | In Progress |
+| `verifying`  | Phase-agent verify step running      | In Progress |
+| `reviewing`  | Phase-agent review step running      | In Progress |
 | `inReview`   | Running `create-pr` or `describe-pr` | In Review   |
 | `done`       | Running `merge-pr`                   | Done        |
 | `canceled`   | Manual cancellation                  | Canceled    |
 
 Set any key to `null` to skip that automatic transition.
+
+**Finer-grained phase visibility.** The `verifying` and `reviewing` keys default to
+`In Progress` so dispatching a phase-agent transition is always safe. If you want a
+dedicated Linear lane for those phases, create `Verifying` and `Reviewing` workflow states
+in Linear admin first, then point `stateMap.verifying` and `stateMap.reviewing` at the new
+names and re-run `plugins/dev/scripts/resolve-linear-ids.sh --force` to refresh the cached
+UUIDs. Pointing `stateMap` at a state that does not exist in Linear will cause the next
+transition call to fail at the linearis layer.
 
 **`stateMap` values are auto-detected from Linear** — when you run `setup-catalyst.sh` with a Linear
 API token, the script fetches your team's actual workflow states and populates `stateMap` with the


### PR DESCRIPTION
Closes CTL-454.

## Summary

- Adds `verifying` and `reviewing` transition keys to `linear-transition.sh` so phase
  agents (Phase 5 Verify / Phase 6 Review under the [phase-agent architecture plan][plan])
  can update Linear with finer-grained status during a run.
- Both keys default to `"In Progress"` so dispatching the new transitions is safe even
  before any Linear admin work — they degrade gracefully into the existing lane.
- Wires the existing-but-unused `Research` and `Planning` Linear states into this repo's
  `stateMap.research` / `stateMap.planning`. The UUIDs were already in `stateIds`, so this
  is a zero-admin visibility upgrade for catalyst-workspace tickets.

## Why this matters

Per the [parent plan][plan] §"Open question 5", all 9 phase agents currently map to
`In Progress`, which collapses Researching/Planning/Verifying/Reviewing onto a single
Linear lane. CTL-454 prepares the infrastructure so finer-grained visibility can land
incrementally, gated on the user's preferred timing for Linear admin work.

## Files changed

| File | Change |
|---|---|
| `plugins/dev/scripts/linear-transition.sh` | Two new cases in `default_state_for()` + usage block update |
| `plugins/dev/scripts/__tests__/linear-transition.test.sh` | Five new test cases (T20-T24) + `build_config()` keys added |
| `.catalyst/config.json` | `research` → `"Research"`, `planning` → `"Planning"`, add `verifying`/`reviewing` keys |
| `website/src/content/docs/reference/configuration.md` | Two new rows in stateMap table + finer-grained visibility note |
| `plugins/dev/skills/linear/SKILL.md` | Two new rows in workflow-mapping table |

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/linear-transition.test.sh` — **46 passed, 0 failed** (41 original + 5 new)
- [x] `jq -e '.catalyst.linear.stateMap.verifying == "In Progress" and .catalyst.linear.stateMap.reviewing == "In Progress" and .catalyst.linear.stateMap.research == "Research" and .catalyst.linear.stateMap.planning == "Planning"' .catalyst/config.json` exits 0
- [x] `linear-transition.sh --ticket CTL-454 --transition verifying --config .catalyst/config.json --dry-run` resolves to `"In Progress"` and exits 0
- [x] CI checks (added below)

## Out of scope (intentional)

- **No Linear admin via API.** Linearis has no `workflow-states` command and creating
  workspace-level workflow states isn't an action an autonomous agent should take. See
  manual follow-up below.
- **No wiring into existing skills** (oneshot / orchestrate / merge-pr). They still call
  `--transition done` / `--transition inReview` / `--transition inProgress`. The new
  keys are infrastructure for the phase agents from [CTL-443][parent], which don't exist
  in the codebase yet.

## Manual follow-up (when you want the finer-grained lanes)

1. In Linear, open team CTL → Workflow settings → add two states between `In Progress` and
   `In Review`: `Verifying` and `Reviewing`. Put both in the "started" category so they
   count toward in-flight metrics.
2. Run `plugins/dev/scripts/resolve-linear-ids.sh --force` to refresh cached UUIDs.
3. Edit `.catalyst/config.json` to point `stateMap.verifying` → `"Verifying"` and
   `stateMap.reviewing` → `"Reviewing"`.
4. Commit as a one-line follow-up.

Until step 1 lands, the new transitions just hit `"In Progress"` — no errors, no
surprises.

[plan]: https://github.com/coalesce-labs/catalyst/blob/main/thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md
[parent]: https://linear.app/coalesce-labs/issue/CTL-443