### PR TITLE
feat(dev): phase-agent skill scaffold + dispatch helper (CTL-448)

### DIFF
--- a/cma/agents/base-system-prompt.md
+++ b/cma/agents/base-system-prompt.md
@@ -102,6 +102,34 @@ the bound project:
 write-back design. If you discover something worth recording, queue it in your
 session output for the orchestrator to act on after session end.
 
+### Opt-in write side (CTL-448, for routines that need to push back)
+
+Routines that need to persist research, plans, or briefings into the
+`coalesce-labs/thoughts` repo (e.g., the morning-briefing routine in
+Initiative 2, or the research-curation routine in Initiative 4) can call
+`humanlayer thoughts init` against the cloned tree to wire write-side sync.
+The CLI is installed in the container by `cma/environment.yaml` (pip:
+humanlayer). Routines that don't write — the default — simply skip this
+block and the init is a no-op.
+
+```bash
+# Opt-in: only routines with write-back responsibilities run this.
+if [[ "${CATALYST_THOUGHTS_WRITE_BACK:-0}" == "1" ]]; then
+  # Initialize humanlayer against the shared subtree we symlinked above.
+  # The directory it expects (per humanlayer thoughts) is the project's
+  # `${THOUGHTS_DIR}/shared` tree — that's exactly what /workspace/thoughts/shared
+  # points to. `humanlayer thoughts init` is idempotent.
+  humanlayer thoughts init \
+    --directory "/workspace/thoughts-repo/repos/${THOUGHTS_DIR}" \
+    --remote "https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git" \
+    >/dev/null 2>&1 || true
+  # Routines call `humanlayer thoughts sync` at the points they want to push.
+  # Sync is no-op when nothing changed locally, so over-calling is cheap.
+fi
+```
+
+Read-side routines must leave `CATALYST_THOUGHTS_WRITE_BACK` unset.
+
 ---
 
 ## 2. Project conventions

--- a/cma/environment.yaml
+++ b/cma/environment.yaml
@@ -27,7 +27,12 @@ config:
       - gh         # GitHub CLI (used by Catalyst skills via Bash(gh *))
     npm:
       - bun        # bun runtime (used by Catalyst dev/test scripts)
-    pip: []
+    pip:
+      - humanlayer # CTL-448: thoughts sync — write-side counterpart to the
+                   # read-only clone in cma/agents/base-system-prompt.md's
+                   # startup ritual. Routines that need to persist research,
+                   # plans, or briefings call `humanlayer thoughts sync` to
+                   # push back to coalesce-labs/thoughts.
     cargo: []
     gem: []
     go: []

--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -309,6 +309,73 @@ expect_eq "no --claude-turn → key absent" "false" "$HAS_TURN"
 HAS_COST_ATTR="$(echo "$CLAUDE_LINE" | jq '.attributes | has("claude.cost.usd")')"
 expect_eq "claude.cost.usd is NEVER a typed attribute (PII gate)" "false" "$HAS_COST_ATTR"
 
+# ── CTL-448: phase-agent event shape validation ────────────────────────────
+# The phase-agent dispatcher (Initiative 1 Phase 2) emits two new event names
+# via build_canonical_line through phase-agent-emit-complete:
+#   phase.<name>.complete.<ticket>
+#   phase.<name>.failed.<ticket>
+# The broker's phase_lifecycle interest type (CTL-447) only routes events
+# matching the regex below — these tests guard the shape against drift.
+
+PHASE_COMPLETE_LINE="$(build_canonical_line \
+  --ts "2026-05-17T00:00:00Z" \
+  --severity INFO \
+  --service "catalyst.phase-agent" \
+  --event-name "phase.research.complete.CTL-100" \
+  --entity "phase" \
+  --action "complete" \
+  --orch "orch-test" \
+  --worker "CTL-100" \
+  --linear-ticket "CTL-100" \
+  --payload-json '{"phase":"research","ticket":"CTL-100","status":"complete"}')"
+
+PHASE_EVENT_NAME="$(echo "$PHASE_COMPLETE_LINE" | jq -r '.attributes."event.name"')"
+expect_eq "phase.complete event.name" "phase.research.complete.CTL-100" "$PHASE_EVENT_NAME"
+
+PHASE_PATTERN_MATCH="$(printf '%s' "$PHASE_EVENT_NAME" \
+  | grep -cE '^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-[0-9]+)$' || true)"
+expect_eq "phase.complete event.name matches broker regex" "1" "$PHASE_PATTERN_MATCH"
+
+PHASE_WORKER="$(echo "$PHASE_COMPLETE_LINE" | jq -r '.attributes."catalyst.worker.ticket"')"
+expect_eq "phase.complete worker ticket attribute" "CTL-100" "$PHASE_WORKER"
+
+PHASE_LINEAR="$(echo "$PHASE_COMPLETE_LINE" | jq -r '.attributes."linear.issue.identifier"')"
+expect_eq "phase.complete linear.issue.identifier" "CTL-100" "$PHASE_LINEAR"
+
+PHASE_PAYLOAD_STATUS="$(echo "$PHASE_COMPLETE_LINE" | jq -r '.body.payload.status')"
+expect_eq "phase.complete body.payload.status" "complete" "$PHASE_PAYLOAD_STATUS"
+
+PHASE_FAILED_LINE="$(build_canonical_line \
+  --ts "2026-05-17T00:00:00Z" \
+  --severity WARN \
+  --service "catalyst.phase-agent" \
+  --event-name "phase.verify.failed.CTL-200" \
+  --entity "phase" \
+  --action "failed" \
+  --orch "orch-test" \
+  --worker "CTL-200" \
+  --linear-ticket "CTL-200" \
+  --payload-json '{"phase":"verify","ticket":"CTL-200","status":"failed","failure_reason":"goal cap"}')"
+
+PHASE_FAILED_NAME="$(echo "$PHASE_FAILED_LINE" | jq -r '.attributes."event.name"')"
+expect_eq "phase.failed event.name" "phase.verify.failed.CTL-200" "$PHASE_FAILED_NAME"
+
+PHASE_FAILED_MATCH="$(printf '%s' "$PHASE_FAILED_NAME" \
+  | grep -cE '^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-[0-9]+)$' || true)"
+expect_eq "phase.failed event.name matches broker regex" "1" "$PHASE_FAILED_MATCH"
+
+PHASE_FAILED_SEVERITY="$(echo "$PHASE_FAILED_LINE" | jq -r '.severityText')"
+expect_eq "phase.failed severity = WARN" "WARN" "$PHASE_FAILED_SEVERITY"
+
+PHASE_FAILED_REASON="$(echo "$PHASE_FAILED_LINE" | jq -r '.body.payload.failure_reason')"
+expect_eq "phase.failed body.payload.failure_reason" "goal cap" "$PHASE_FAILED_REASON"
+
+# A malformed phase event name (no ticket suffix) must NOT match the regex.
+BAD_PHASE_NAME="phase.research.complete"
+BAD_MATCH="$(printf '%s' "$BAD_PHASE_NAME" \
+  | grep -cE '^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-[0-9]+)$' || true)"
+expect_eq "malformed phase event name does NOT match broker regex" "0" "$BAD_MATCH"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
 exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/phase-agent-comms.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-comms.test.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Tests for phase-agent comms contract (CTL-448 Initiative 1 Phase 2).
+#
+# Exercises the wire protocol over catalyst-comms:
+#   - Outbound from phase agent: info, attention, done, question (new for phase agents)
+#   - Inbound to phase agent: directive, pause, abort (all new for phase agents)
+#
+# Strategy: redirect $CATALYST_DIR to a scratch tmpdir so a fresh channel is
+# created per test, then drive catalyst-comms as the phase agent and the
+# orchestrator alternately. Assertions read from the JSONL channel file
+# directly so we never depend on poll's --wait semantics.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-agent-comms.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+COMMS="${REPO_ROOT}/plugins/dev/scripts/catalyst-comms"
+STATE="${REPO_ROOT}/plugins/dev/scripts/catalyst-state.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-agent-comms-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+if [[ ! -x "$COMMS" ]]; then
+  echo "FATAL: $COMMS not found or not executable" >&2
+  exit 1
+fi
+
+# Fresh per-test fixture. We isolate $CATALYST_DIR so each test gets its own
+# comms/state file tree.
+fresh_env() {
+  local tag="$1"
+  TEST_DIR="${SCRATCH}/${tag}"
+  mkdir -p "${TEST_DIR}/catalyst/comms/channels"
+  export CATALYST_DIR="${TEST_DIR}/catalyst"
+  export CHANNEL="orch-${tag}"
+  CHANNEL_FILE="${CATALYST_DIR}/comms/channels/${CHANNEL}.jsonl"
+}
+
+# All phase agents join the same channel on entry.
+join_as() {
+  local who="$1"
+  "$COMMS" join "$CHANNEL" --as "$who" --capabilities "phase-agent: ${who}" \
+    --orch orch-test --parent orchestrator --ttl 3600 >/dev/null 2>&1
+}
+
+# Read messages from the channel file filtered by --type field.
+# (We read the file directly rather than `poll` to keep the test deterministic.)
+messages_of_type() {
+  local type="$1"
+  [[ -f "$CHANNEL_FILE" ]] || { echo ""; return; }
+  jq -c "select(.type == \"${type}\")" "$CHANNEL_FILE" 2>/dev/null
+}
+
+# ─── Test 1: phase agent posts `attention` on scope-conflict trigger
+echo "Test 1: phase agent posts attention on scope-conflict trigger"
+fresh_env t1
+join_as CTL-100
+# Simulating the scope-conflict trigger — the phase agent posts an attention
+# message instructing the orchestrator that scope is wrong.
+"$COMMS" send "$CHANNEL" \
+  "scope conflict: ticket asks for X but plan requires unrelated Y; halting" \
+  --as CTL-100 --type attention --orch orch-test >/dev/null 2>&1
+ATTN_LINES=$(messages_of_type attention)
+ATTN_COUNT=$(echo "$ATTN_LINES" | grep -c '"type":"attention"' || echo 0)
+ATTN_FROM=$(echo "$ATTN_LINES" | jq -r '.from' | head -1)
+ATTN_BODY=$(echo "$ATTN_LINES" | jq -r '.body' | head -1)
+assert_eq "1" "$ATTN_COUNT" "exactly one attention message posted"
+assert_eq "CTL-100" "$ATTN_FROM" "attention.from = phase-agent ticket"
+case "$ATTN_BODY" in
+  *"scope conflict"*) pass "attention body preserves full scope-conflict text" ;;
+  *) fail "attention body preserves full scope-conflict text — got '$ATTN_BODY'" ;;
+esac
+
+# ─── Test 2: phase agent posts `question` with correlatable question_id
+echo ""
+echo "Test 2: phase agent posts question whose msg_id is the correlation key"
+fresh_env t2
+join_as CTL-200
+# The msg_id printed to stdout is the correlation key the orchestrator will
+# echo back via --re on its directive reply.
+QID=$("$COMMS" send "$CHANNEL" \
+  "plan refs helper X but I cannot find it; create or revise plan?" \
+  --as CTL-200 --type question --orch orch-test 2>/dev/null)
+QID_TRIMMED="${QID//$'\n'/}"
+QUESTION_LINES=$(messages_of_type question)
+QUESTION_COUNT=$(echo "$QUESTION_LINES" | grep -c '"type":"question"' || echo 0)
+QUESTION_ID=$(echo "$QUESTION_LINES" | jq -r '.id' | head -1)
+QUESTION_FROM=$(echo "$QUESTION_LINES" | jq -r '.from' | head -1)
+assert_eq "1" "$QUESTION_COUNT" "exactly one question message posted"
+assert_eq "$QID_TRIMMED" "$QUESTION_ID" "stdout msg_id matches channel record id"
+assert_eq "CTL-200" "$QUESTION_FROM" "question.from = phase-agent ticket"
+
+# ─── Test 3: phase agent receives `directive` correlated by question_id
+echo ""
+echo "Test 3: orchestrator directive correlates to question via --re"
+fresh_env t3
+join_as CTL-300
+join_as orchestrator
+QID=$("$COMMS" send "$CHANNEL" "ambiguous spec — should X be flag or attribute?" \
+  --as CTL-300 --type question --orch orch-test 2>/dev/null)
+QID="${QID//$'\n'/}"
+# Orchestrator answers with a directive that references the question id.
+"$COMMS" send "$CHANNEL" \
+  "use the attribute form — drop X from plan and add to schema instead" \
+  --as orchestrator --type directive --to CTL-300 --re "$QID" \
+  --orch orch-test >/dev/null 2>&1
+DIRECTIVE_LINES=$(messages_of_type directive)
+DIRECTIVE_COUNT=$(echo "$DIRECTIVE_LINES" | grep -c '"type":"directive"' || echo 0)
+DIRECTIVE_RE=$(echo "$DIRECTIVE_LINES" | jq -r '.re' | head -1)
+DIRECTIVE_TO=$(echo "$DIRECTIVE_LINES" | jq -r '.to' | head -1)
+assert_eq "1" "$DIRECTIVE_COUNT" "exactly one directive message posted"
+assert_eq "$QID" "$DIRECTIVE_RE" "directive.re = question id (correlation)"
+assert_eq "CTL-300" "$DIRECTIVE_TO" "directive.to = phase-agent ticket"
+
+# ─── Test 4: phase agent receives `abort` and cleans up correctly
+echo ""
+echo "Test 4: abort message routes to the right phase-agent ticket"
+fresh_env t4
+join_as CTL-400
+join_as orchestrator
+"$COMMS" send "$CHANNEL" "abort: parent orchestrator was killed" \
+  --as orchestrator --type abort --to CTL-400 --orch orch-test >/dev/null 2>&1
+ABORT_LINES=$(messages_of_type abort)
+ABORT_COUNT=$(echo "$ABORT_LINES" | grep -c '"type":"abort"' || echo 0)
+ABORT_TO=$(echo "$ABORT_LINES" | jq -r '.to' | head -1)
+ABORT_BODY=$(echo "$ABORT_LINES" | jq -r '.body' | head -1)
+assert_eq "1" "$ABORT_COUNT" "exactly one abort message posted"
+assert_eq "CTL-400" "$ABORT_TO" "abort.to = phase-agent ticket"
+case "$ABORT_BODY" in
+  *"parent orchestrator"*) pass "abort body preserves orchestrator reason" ;;
+  *) fail "abort body preserves orchestrator reason — got '$ABORT_BODY'" ;;
+esac
+
+# Verify that all three orchestrator-→agent types are accepted.
+"$COMMS" send "$CHANNEL" "pause for human review" \
+  --as orchestrator --type pause --to CTL-400 --orch orch-test >/dev/null 2>&1
+PAUSE_COUNT=$(messages_of_type pause | grep -c '"type":"pause"' || echo 0)
+assert_eq "1" "$PAUSE_COUNT" "pause type accepted by send"
+
+# ─── Test 5: orchestrator surfaces unanswerable questions via state.json `attention`
+echo ""
+echo "Test 5: orchestrator records needsAttention in global state for unanswerable question"
+fresh_env t5
+join_as CTL-500
+QID=$("$COMMS" send "$CHANNEL" "unanswerable: legal review required before X" \
+  --as CTL-500 --type question --orch orch-test 2>/dev/null)
+QID="${QID//$'\n'/}"
+# The orchestrator's monitor (real implementation in orch-monitor) writes an
+# attention record into ~/catalyst/state.json when it cannot resolve a question
+# locally. We simulate that write here using the same helper the monitor uses.
+if [[ -x "$STATE" ]]; then
+  # The orchestrator must exist before attention can be flagged on it.
+  "$STATE" init >/dev/null 2>&1 || true
+  "$STATE" register orch-test '{"orchId":"orch-test","status":"running","workers":{"CTL-500":{"ticket":"CTL-500","status":"researching","phase":1}}}' \
+    >/dev/null 2>&1 || true
+  "$STATE" attention orch-test "needs-clarification" "CTL-500" \
+    "unanswerable question (qid=${QID})" >/dev/null 2>&1 || true
+  GLOBAL_STATE="${CATALYST_DIR}/state.json"
+  if [[ -f "$GLOBAL_STATE" ]]; then
+    # Schema (catalyst-state.sh cmd_attention):
+    #   .orchestrators[$oid].attention[0].{type,ticketId,message,since}
+    #   .orchestrators[$oid].workers[$tid].needsAttention = true
+    ATTN_TYPE=$(jq -r '.orchestrators."orch-test".attention[0].type // empty' \
+      "$GLOBAL_STATE" 2>/dev/null)
+    ATTN_WORKER=$(jq -r '.orchestrators."orch-test".attention[0].ticketId // empty' \
+      "$GLOBAL_STATE" 2>/dev/null)
+    NEEDS=$(jq -r '.orchestrators."orch-test".workers."CTL-500".needsAttention // false' \
+      "$GLOBAL_STATE" 2>/dev/null)
+    assert_eq "needs-clarification" "$ATTN_TYPE" "global state records attention type"
+    assert_eq "CTL-500" "$ATTN_WORKER" "global state records correct worker ticket"
+    assert_eq "true" "$NEEDS" "worker.needsAttention flag set"
+  else
+    fail "global state.json was not written"
+  fi
+else
+  echo "  SKIP: catalyst-state.sh not executable — test 5 needs the helper to demonstrate the contract"
+fi
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-agent-comms: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Tests for phase-agent-dispatch (CTL-448 Initiative 1 Phase 2).
+#
+# Approach: stub the `claude` binary on PATH with a script that captures its
+# arguments and writes a fake bg job ID to stdout. Build a fresh scratch
+# orch dir per test. Exercise the dispatcher against this fixture and assert
+# on the signal file, stdout JSON, and captured `claude` invocation args.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-agent-dispatch-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$label"
+  else
+    fail "$label — '$needle' not found in '$haystack'"
+  fi
+}
+
+if [[ ! -x "$DISPATCH" ]]; then
+  echo "FATAL: $DISPATCH not found or not executable" >&2
+  exit 1
+fi
+
+# ─── Stub claude binary ─────────────────────────────────────────────────────
+# The stub writes a fake bg job ID to stdout and logs its args + env to
+# $CLAUDE_STUB_LOG for assertions. The bg job ID can be overridden via
+# $CLAUDE_STUB_JOB_ID for the "records the bg job id" test.
+setup_claude_stub() {
+  local stub_dir="$1"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
+JOB_ID="${CLAUDE_STUB_JOB_ID:-job-stub-abc123}"
+{
+  echo "--ARGS--"
+  printf '%s\n' "$@"
+  echo "--ENV--"
+  env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
+  echo "--END--"
+} > "$LOG"
+printf '%s\n' "$JOB_ID"
+exit "${CLAUDE_STUB_EXIT:-0}"
+STUB
+  chmod +x "$stub_dir/claude"
+}
+
+# Build a fresh per-test orch fixture and put the stub claude on PATH first.
+fresh_env() {
+  local tag="$1"
+  TEST_DIR="${SCRATCH}/${tag}"
+  STUB_DIR="${TEST_DIR}/bin"
+  ORCH_DIR="${TEST_DIR}/orch"
+  WORKER_DIR="${ORCH_DIR}/workers/CTL-100"
+  CONFIG_DIR="${TEST_DIR}/proj/.catalyst"
+  mkdir -p "$STUB_DIR" "$WORKER_DIR" "$CONFIG_DIR"
+  setup_claude_stub "$STUB_DIR"
+  export CLAUDE_STUB_LOG="${TEST_DIR}/claude-stub.log"
+  export CLAUDE_STUB_JOB_ID="job-stub-abc123"
+  unset CLAUDE_STUB_EXIT
+  export PATH="${STUB_DIR}:${PATH}"
+}
+
+# ─── Test 1: dispatcher writes the per-phase signal file with the right schema
+echo "Test 1: dispatcher writes signal file with correct schema"
+fresh_env t1
+OUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>&1)
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+if [[ ! -f "$SIGNAL" ]]; then
+  fail "signal file created: $SIGNAL"
+else
+  pass "signal file created at expected path"
+  TICKET_FIELD=$(jq -r '.ticket' "$SIGNAL")
+  PHASE_FIELD=$(jq -r '.phase' "$SIGNAL")
+  MODEL_FIELD=$(jq -r '.model' "$SIGNAL")
+  TURN_CAP_FIELD=$(jq -r '.turnCap' "$SIGNAL")
+  STATUS_FIELD=$(jq -r '.status' "$SIGNAL")
+  assert_eq "CTL-100" "$TICKET_FIELD" "signal.ticket"
+  assert_eq "triage"  "$PHASE_FIELD"  "signal.phase"
+  assert_eq "opus"    "$MODEL_FIELD"  "signal.model defaulted to opus"
+  assert_eq "10"      "$TURN_CAP_FIELD" "signal.turnCap defaulted to 10 (triage)"
+  assert_eq "running" "$STATUS_FIELD" "signal.status = running after bg spawn"
+fi
+
+# ─── Test 2: dispatcher launches claude --bg with the right env vars
+echo ""
+echo "Test 2: dispatcher invokes claude --bg with the right args + env"
+fresh_env t2
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" "--bg" "claude invoked with --bg flag"
+assert_contains "$LOG" "--dangerously-skip-permissions" "claude invoked with --dangerously-skip-permissions"
+assert_contains "$LOG" "--model" "claude invoked with --model flag"
+assert_contains "$LOG" "/catalyst-dev:phase-triage CTL-100 --orch-dir" "prompt includes phase skill + ticket + orch-dir"
+assert_contains "$LOG" "CATALYST_ORCHESTRATOR_DIR=${ORCH_DIR}" "env carries CATALYST_ORCHESTRATOR_DIR"
+assert_contains "$LOG" "CATALYST_PHASE=triage" "env carries CATALYST_PHASE"
+assert_contains "$LOG" "CATALYST_TICKET=CTL-100" "env carries CATALYST_TICKET"
+
+# ─── Test 3: dispatcher records the --bg job ID in the signal file
+echo ""
+echo "Test 3: dispatcher records bg_job_id in signal file + stdout"
+fresh_env t3
+export CLAUDE_STUB_JOB_ID="job-xyz-789"
+STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+JOB_IN_SIGNAL=$(jq -r '.bg_job_id' "$SIGNAL")
+JOB_IN_STDOUT=$(echo "$STDOUT" | jq -r '.bg_job_id')
+assert_eq "job-xyz-789" "$JOB_IN_SIGNAL" "signal.bg_job_id matches claude stub output"
+assert_eq "job-xyz-789" "$JOB_IN_STDOUT" "stdout JSON includes bg_job_id"
+
+# ─── Test 4: dispatcher is idempotent (re-dispatch in-flight phase no-ops)
+echo ""
+echo "Test 4: dispatcher is idempotent for in-flight phases"
+fresh_env t4
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1
+# Clear the stub log so we can detect a second invocation.
+rm -f "$CLAUDE_STUB_LOG"
+STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+IDEMPOTENT=$(echo "$STDOUT" | jq -r '.idempotent // false')
+LOG_REWRITTEN="no"
+[[ -f "$CLAUDE_STUB_LOG" ]] && LOG_REWRITTEN="yes"
+assert_eq "true" "$IDEMPOTENT" "second dispatch reports idempotent: true"
+assert_eq "no"   "$LOG_REWRITTEN" "second dispatch did NOT re-invoke claude --bg"
+
+# ─── Test 5: dispatcher refuses to launch if prior phase artifact is missing
+echo ""
+echo "Test 5: dispatcher refuses to launch when prior artifact missing"
+fresh_env t5
+# Research requires triage.json — don't create one.
+"$DISPATCH" --phase research --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >"${TEST_DIR}/research.out" 2>"${TEST_DIR}/research.err"
+RC=$?
+STDOUT_JSON=$(cat "${TEST_DIR}/research.out")
+REFUSED_STATUS=$(echo "$STDOUT_JSON" | jq -r '.status' 2>/dev/null || echo "")
+SIGNAL_RESEARCH="${WORKER_DIR}/phase-research.json"
+SIGNAL_EXISTS="no"
+[[ -f "$SIGNAL_RESEARCH" ]] && SIGNAL_EXISTS="yes"
+assert_eq "2" "$RC" "exit code 2 when prior artifact missing"
+assert_eq "refused" "$REFUSED_STATUS" "stdout JSON status = refused"
+assert_eq "no" "$SIGNAL_EXISTS" "no signal file written when refused"
+
+# ─── Test 6: dispatcher resolves model from config (default + override paths)
+echo ""
+echo "Test 6: dispatcher resolves model from config (default and override)"
+fresh_env t6
+cat > "${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "orchestration": {
+      "phaseAgents": {
+        "models": { "implement": "sonnet" },
+        "modelOverrides": {
+          "implement": { "CTL-999": "opus" }
+        }
+      }
+    }
+  }
+}
+EOF
+# Create the plan artifact so the implement gate passes.
+mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
+touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-16-ctl-100.md"
+# Default path: ticket = CTL-100 → models.implement = sonnet
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+    >"${TEST_DIR}/m1.out" 2>/dev/null )
+MODEL_DEFAULT=$(jq -r '.model' "${TEST_DIR}/m1.out")
+assert_eq "sonnet" "$MODEL_DEFAULT" "models.implement default → sonnet"
+
+# Override path: ticket = CTL-999 → modelOverrides.implement.CTL-999 = opus
+touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-16-ctl-999.md"
+mkdir -p "${ORCH_DIR}/workers/CTL-999"
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase implement --ticket CTL-999 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+    >"${TEST_DIR}/m2.out" 2>/dev/null )
+MODEL_OVERRIDE=$(jq -r '.model' "${TEST_DIR}/m2.out")
+assert_eq "opus" "$MODEL_OVERRIDE" "modelOverrides.implement.CTL-999 beats default"
+
+# CLI flag wins both
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --model haiku \
+    >"${TEST_DIR}/m3.out" 2>/dev/null )
+mkdir -p "${ORCH_DIR}/workers/CTL-100"
+# Clean prior signal so this isn't idempotent no-op
+rm -f "${ORCH_DIR}/workers/CTL-100/phase-implement.json"
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --model haiku \
+    >"${TEST_DIR}/m3.out" 2>/dev/null )
+MODEL_CLI=$(jq -r '.model' "${TEST_DIR}/m3.out")
+assert_eq "haiku" "$MODEL_CLI" "CLI --model beats config"
+
+# ─── Test 7: dispatcher resolves turn cap from config
+echo ""
+echo "Test 7: dispatcher resolves turn cap from config"
+fresh_env t7
+cat > "${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "orchestration": {
+      "phaseAgents": {
+        "turnCaps": { "triage": 99 }
+      }
+    }
+  }
+}
+EOF
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+    >"${TEST_DIR}/tc.out" 2>/dev/null )
+TC_CONFIG=$(jq -r '.turnCap' "${TEST_DIR}/tc.out")
+assert_eq "99" "$TC_CONFIG" "config turnCaps.triage = 99 applied"
+
+# CLI overrides config
+rm -f "${ORCH_DIR}/workers/CTL-100/phase-triage.json"
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --turn-cap 42 \
+    >"${TEST_DIR}/tc2.out" 2>/dev/null )
+TC_CLI=$(jq -r '.turnCap' "${TEST_DIR}/tc2.out")
+assert_eq "42" "$TC_CLI" "CLI --turn-cap beats config"
+
+# Fallback per-phase default
+fresh_env t7b
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase research --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+    >"${TEST_DIR}/tc3.out" 2>"${TEST_DIR}/tc3.err" )
+RC=$?
+# research requires triage.json — create it first then re-dispatch
+echo '{"ticket":"CTL-100","status":"done"}' > "${WORKER_DIR}/triage.json"
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase research --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+    >"${TEST_DIR}/tc3.out" 2>/dev/null )
+TC_FALLBACK=$(jq -r '.turnCap' "${TEST_DIR}/tc3.out")
+assert_eq "35" "$TC_FALLBACK" "per-phase default for research is 35"
+
+# ─── Test 8: dispatcher passes humanlayer/thoughts env vars to phase agent
+echo ""
+echo "Test 8: dispatcher passes CATALYST_* env vars to phase agent process"
+fresh_env t8
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1
+LOG=$(cat "$CLAUDE_STUB_LOG")
+# These are the four contract env vars the phase agent reads:
+#   CATALYST_ORCHESTRATOR_DIR — where signal files live
+#   CATALYST_ORCHESTRATOR_ID  — broker session correlation
+#   CATALYST_PHASE            — which phase this agent is
+#   CATALYST_TICKET           — which ticket
+# (Thoughts integration is via humanlayer thoughts init at session start —
+# the env var name is the same regardless and the env carries the orch dir
+# the phase agent uses to resolve all other paths.)
+assert_contains "$LOG" "CATALYST_ORCHESTRATOR_DIR=" "env propagates CATALYST_ORCHESTRATOR_DIR"
+assert_contains "$LOG" "CATALYST_ORCHESTRATOR_ID="  "env propagates CATALYST_ORCHESTRATOR_ID"
+assert_contains "$LOG" "CATALYST_PHASE=triage"      "env propagates CATALYST_PHASE"
+assert_contains "$LOG" "CATALYST_TICKET=CTL-100"    "env propagates CATALYST_TICKET"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Tests for phase-agent-emit-complete (CTL-448 Initiative 1 Phase 2).
+#
+# Approach: redirect $CATALYST_DIR to a scratch tmpdir, run the script, then
+# parse the emitted JSONL line from <tmp>/events/YYYY-MM.jsonl. The script
+# emits the broker-routable phase.<name>.{complete,failed}.<ticket> canonical
+# event (CTL-300 shape).
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+EMIT_SCRIPT="${REPO_ROOT}/plugins/dev/scripts/phase-agent-emit-complete"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-agent-emit-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+if [[ ! -x "$EMIT_SCRIPT" ]]; then
+  echo "FATAL: $EMIT_SCRIPT not found or not executable" >&2
+  exit 1
+fi
+
+# Each test gets a fresh CATALYST_DIR and ORCH_DIR. The emit script writes to
+# $CATALYST_DIR/events/YYYY-MM.jsonl (canonical_jsonl_append uses CATALYST_DIR
+# transitively via the EVENTS_DIR derivation inside the script).
+fresh_env() {
+  local tag="$1"
+  TEST_DIR="${SCRATCH}/${tag}"
+  mkdir -p "${TEST_DIR}/catalyst/events"
+  mkdir -p "${TEST_DIR}/orch/workers/CTL-100"
+  export CATALYST_DIR="${TEST_DIR}/catalyst"
+  export CATALYST_ORCHESTRATOR_DIR="${TEST_DIR}/orch"
+  export CATALYST_ORCHESTRATOR_ID="orch-test"
+  export CATALYST_SESSION_ID="sess_test_${tag}"
+}
+
+# Read the phase event line from this test's event log. catalyst-session.sh end
+# (which the emit script also invokes) appends session.ended + agent.checkout
+# lines after, so we grep for the phase event prefix instead of tailing.
+read_event_line() {
+  local month
+  month=$(date -u +%Y-%m)
+  local logfile="${CATALYST_DIR}/events/${month}.jsonl"
+  [[ -f "$logfile" ]] || { echo ""; return 1; }
+  grep -F '"event.name":"phase.' "$logfile" | tail -n 1
+}
+
+echo "Test 1: phase-complete emitter writes the canonical event shape"
+fresh_env t1
+"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z "$LINE" ]]; then
+  fail "Test 1: no event line emitted"
+else
+  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+  assert_eq "phase.research.complete.CTL-100" "$EVENT_NAME" "event.name matches phase.<name>.complete.<ticket>"
+  HAS_ATTRS=$(echo "$LINE" | jq -r 'has("attributes")')
+  assert_eq "true" "$HAS_ATTRS" "canonical shape — attributes present"
+  HAS_BODY=$(echo "$LINE" | jq -r 'has("body")')
+  assert_eq "true" "$HAS_BODY" "canonical shape — body present"
+  SEVERITY=$(echo "$LINE" | jq -r '.severityText')
+  assert_eq "INFO" "$SEVERITY" "complete → INFO severity"
+fi
+
+echo ""
+echo "Test 2: phase-complete includes session.id, orchestrator, ticket, phase"
+fresh_env t2
+"$EMIT_SCRIPT" --phase implement --ticket CTL-200 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+SESS=$(echo "$LINE" | jq -r '.attributes."catalyst.session.id"')
+ORCH=$(echo "$LINE" | jq -r '.attributes."catalyst.orchestrator.id"')
+WORKER=$(echo "$LINE" | jq -r '.attributes."catalyst.worker.ticket"')
+LINEAR=$(echo "$LINE" | jq -r '.attributes."linear.issue.identifier"')
+PAYLOAD_PHASE=$(echo "$LINE" | jq -r '.body.payload.phase')
+assert_eq "sess_test_t2" "$SESS" "catalyst.session.id propagated from env"
+assert_eq "orch-test"    "$ORCH" "catalyst.orchestrator.id propagated from env"
+assert_eq "CTL-200"      "$WORKER" "catalyst.worker.ticket = ticket"
+assert_eq "CTL-200"      "$LINEAR" "linear.issue.identifier = ticket"
+assert_eq "implement"    "$PAYLOAD_PHASE" "body.payload.phase = phase name"
+
+echo ""
+echo "Test 3: failure variant uses .failed suffix and includes failure_reason"
+fresh_env t3
+"$EMIT_SCRIPT" --phase verify --ticket CTL-300 --status failed --reason "tests red after 3 attempts" >/dev/null 2>&1
+LINE=$(read_event_line)
+EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+SEVERITY=$(echo "$LINE" | jq -r '.severityText')
+REASON_FIELD=$(echo "$LINE" | jq -r '.body.payload.failure_reason')
+PAYLOAD_STATUS=$(echo "$LINE" | jq -r '.body.payload.status')
+assert_eq "phase.verify.failed.CTL-300" "$EVENT_NAME" "failure event uses .failed suffix"
+assert_eq "WARN" "$SEVERITY" "failed → WARN severity"
+assert_eq "tests red after 3 attempts" "$REASON_FIELD" "body.payload.failure_reason carries reason"
+assert_eq "failed" "$PAYLOAD_STATUS" "body.payload.status = failed"
+
+# Bonus assertions covering the signal file update path on success.
+echo ""
+echo "Test 4 (bonus): signal file is updated to status=done on complete"
+fresh_env t4
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"in-progress","ticket":"CTL-100","phase":"research"}' > "$SIGNAL"
+"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+NEW_STATUS=$(jq -r '.status' "$SIGNAL")
+HAS_COMPLETED=$(jq -r 'has("completedAt")' "$SIGNAL")
+assert_eq "done" "$NEW_STATUS" "signal file status updated to done"
+assert_eq "true" "$HAS_COMPLETED" "signal file gained completedAt timestamp"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/catalyst-comms
+++ b/plugins/dev/scripts/catalyst-comms
@@ -226,8 +226,10 @@ cmd_send() {
   require_channel "$channel" || return 1
 
   case "$type" in
-    proposal|question|answer|ack|info|attention|done) ;;
-    *) echo "error: invalid --type '$type' (must be one of: proposal|question|answer|ack|info|attention|done)" >&2; return 1 ;;
+    # CTL-448: directive|pause|abort are inbound types used by the orchestrator
+    # to respond to phase-agent question messages and to pause/abort runs.
+    proposal|question|answer|ack|info|attention|done|directive|pause|abort) ;;
+    *) echo "error: invalid --type '$type' (must be one of: proposal|question|answer|ack|info|attention|done|directive|pause|abort)" >&2; return 1 ;;
   esac
 
   local id
@@ -269,7 +271,10 @@ cmd_send() {
   # to every channel file. Best-effort — failures here must NOT fail the send.
   # Per-channel files remain authoritative for agent-to-agent pub/sub. CTL-210.
   local body_trunc="$body"
-  if [[ "$type" != "attention" && ${#body} -gt 120 ]]; then
+  # CTL-448: directive/pause/abort carry orchestrator instructions that can
+  # exceed the 120-char heartbeat budget, so they share attention's exemption.
+  if [[ "$type" != "attention" && "$type" != "directive" && \
+        "$type" != "pause" && "$type" != "abort" && ${#body} -gt 120 ]]; then
     body_trunc="${body:0:120}"
     body_trunc="${body_trunc% *}…"
   fi
@@ -608,7 +613,8 @@ Commands:
 
   send <ch> <body> --as <name> [--type TYPE] [--to N|all] [--re MSG_ID] [--repo NAME]
       Append a message to the channel log. Prints the message id to stdout.
-      TYPE is one of: proposal, question, answer, ack, info, attention, done.
+      TYPE is one of: proposal, question, answer, ack, info, attention, done,
+      directive, pause, abort (last three: orchestrator→phase-agent, CTL-448).
       --repo NAME (or \$REPO env) stamps attributes["vcs.repository.name"] on
       the canonical comms.message.posted event so the HUD's REPO column resolves.
 

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# phase-agent-dispatch — launch a phase agent via `claude --bg` (CTL-448).
+#
+# The orchestrator's Phase 4 monitor calls this when a phase boundary event
+# arrives. It handles the lifecycle envelope (signal file, model/turn-cap
+# resolution, prior-artifact gate) and spawns the actual phase agent in a
+# `claude --bg` job. The phase agent itself is a short SKILL.md wrapper around
+# the canonical skill it owns — see plugins/dev/skills/_phase-agent-template/SKILL.md.
+#
+# Usage:
+#   phase-agent-dispatch \
+#     --phase <name> \
+#     --ticket <id> \
+#     [--orch-dir <path>] \
+#     [--orch-id <id>] \
+#     [--model <opus|sonnet|haiku>] \
+#     [--turn-cap <n>] \
+#     [--config <path>] \
+#     [--dry-run]
+#
+# Defaults:
+#   --orch-dir = $CATALYST_ORCHESTRATOR_DIR
+#   --orch-id  = $CATALYST_ORCHESTRATOR_ID
+#   --config   = nearest ancestor .catalyst/config.json
+#
+# Output (stdout):
+#   One JSON line with keys: ticket, phase, model, turnCap, bg_job_id,
+#   signalFile, status, dryRun.
+#
+# Exit codes:
+#   0 — dispatched (or already dispatched; idempotent)
+#   1 — argument or configuration error
+#   2 — prior phase artifact missing (refuses to launch)
+
+set -uo pipefail
+
+# ─── Resolve script dir through symlinks ────────────────────────────────────
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+die() { echo "phase-agent-dispatch: $*" >&2; exit 1; }
+
+# ─── Defaults ───────────────────────────────────────────────────────────────
+
+# Hardcoded fallbacks used only when neither CLI flag nor config sets them.
+DEFAULT_MODEL="opus"
+DEFAULT_TURN_CAP=50
+
+# Per-phase default turn caps (mirrors plan §Initiative 1 Phase 6 config block).
+# Used as the last fallback before DEFAULT_TURN_CAP when config is absent.
+phase_default_turn_cap() {
+  case "$1" in
+    triage)         echo 10 ;;
+    research)       echo 35 ;;
+    plan)           echo 25 ;;
+    implement)      echo 75 ;;
+    verify)         echo 20 ;;
+    review)         echo 25 ;;
+    pr)             echo 12 ;;
+    monitor-merge)  echo 50 ;;
+    monitor-deploy) echo 30 ;;
+    *)              echo "$DEFAULT_TURN_CAP" ;;
+  esac
+}
+
+# Prior-phase artifact lookup. Returns one of two shapes:
+#   "signal:<filename>"   → file inside ${ORCH_DIR}/workers/<TICKET>/
+#   "glob:<pattern>"      → glob pattern (used for thoughts/ artifacts where
+#                           the filename includes a date)
+# Empty output means this phase is the entry point — no prior artifact.
+prior_artifact_for_phase() {
+  case "$1" in
+    triage)         echo "" ;;
+    research)       echo "signal:triage.json" ;;
+    plan)           echo "glob:thoughts/shared/research/*-${TICKET,,}.md" ;;
+    implement)      echo "glob:thoughts/shared/plans/*-${TICKET,,}.md" ;;
+    verify)         echo "signal:phase-implement.json" ;;
+    review)         echo "signal:verify.json" ;;
+    pr)             echo "signal:review.json" ;;
+    monitor-merge)  echo "signal:phase-pr.json" ;;
+    monitor-deploy) echo "signal:phase-monitor-merge.json" ;;
+    *)              echo "" ;;
+  esac
+}
+
+# ─── Parse args ─────────────────────────────────────────────────────────────
+
+PHASE=""
+TICKET=""
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
+ORCH_ID="${CATALYST_ORCHESTRATOR_ID:-}"
+MODEL_FLAG=""
+TURN_CAP_FLAG=""
+CONFIG=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --phase)     PHASE="$2"; shift 2 ;;
+    --ticket)    TICKET="$2"; shift 2 ;;
+    --orch-dir)  ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)   ORCH_ID="$2"; shift 2 ;;
+    --model)     MODEL_FLAG="$2"; shift 2 ;;
+    --turn-cap)  TURN_CAP_FLAG="$2"; shift 2 ;;
+    --config)    CONFIG="$2"; shift 2 ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    -h|--help)   grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)           die "unknown flag: $1" ;;
+  esac
+done
+
+[[ -n "$PHASE" ]]    || die "--phase is required"
+[[ -n "$TICKET" ]]   || die "--ticket is required"
+[[ -n "$ORCH_DIR" ]] || die "--orch-dir (or CATALYST_ORCHESTRATOR_DIR) is required"
+
+if [[ ! "$TICKET" =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
+  die "invalid --ticket: $TICKET (expected e.g. CTL-100)"
+fi
+if [[ "$PHASE" == *.* ]]; then
+  die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
+fi
+
+# ─── Resolve config path ────────────────────────────────────────────────────
+
+resolve_config() {
+  if [[ -n "$CONFIG" && -f "$CONFIG" ]]; then echo "$CONFIG"; return; fi
+  local dir
+  dir="$(pwd)"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "${dir}/.catalyst/config.json" ]]; then
+      echo "${dir}/.catalyst/config.json"; return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo ""
+}
+CONFIG_PATH="$(resolve_config)"
+
+config_value() {
+  local key="$1" default="$2"
+  if [[ -z "$CONFIG_PATH" ]] || ! command -v jq >/dev/null 2>&1; then
+    echo "$default"
+    return
+  fi
+  local v
+  v=$(jq -r "$key // empty" "$CONFIG_PATH" 2>/dev/null)
+  [[ -z "$v" ]] && v="$default"
+  echo "$v"
+}
+
+# ─── Resolve model: CLI > modelOverrides > models > default ────────────────
+
+resolve_model() {
+  if [[ -n "$MODEL_FLAG" ]]; then echo "$MODEL_FLAG"; return; fi
+  local override
+  override=$(config_value \
+    ".catalyst.orchestration.phaseAgents.modelOverrides[\"${PHASE}\"][\"${TICKET}\"]" \
+    "")
+  if [[ -n "$override" ]]; then echo "$override"; return; fi
+  config_value ".catalyst.orchestration.phaseAgents.models[\"${PHASE}\"]" "$DEFAULT_MODEL"
+}
+MODEL="$(resolve_model)"
+
+# ─── Resolve turn cap: CLI > config.turnCaps > per-phase default ───────────
+
+resolve_turn_cap() {
+  if [[ -n "$TURN_CAP_FLAG" ]]; then echo "$TURN_CAP_FLAG"; return; fi
+  config_value ".catalyst.orchestration.phaseAgents.turnCaps[\"${PHASE}\"]" \
+    "$(phase_default_turn_cap "$PHASE")"
+}
+TURN_CAP="$(resolve_turn_cap)"
+
+# ─── Validate prior phase artifact (gate) ───────────────────────────────────
+
+ARTIFACT_SPEC="$(prior_artifact_for_phase "$PHASE")"
+ARTIFACT_OK=1
+if [[ -n "$ARTIFACT_SPEC" ]]; then
+  case "$ARTIFACT_SPEC" in
+    signal:*)
+      ARTIFACT_FILE="${ORCH_DIR}/workers/${TICKET}/${ARTIFACT_SPEC#signal:}"
+      [[ -f "$ARTIFACT_FILE" ]] || ARTIFACT_OK=0
+      ;;
+    glob:*)
+      # Lowercase ticket per existing thoughts naming convention
+      shopt -s nullglob
+      MATCHES=( ${ARTIFACT_SPEC#glob:} )
+      shopt -u nullglob
+      [[ ${#MATCHES[@]} -gt 0 ]] || ARTIFACT_OK=0
+      ;;
+  esac
+fi
+
+if [[ "$ARTIFACT_OK" -eq 0 ]]; then
+  echo "phase-agent-dispatch: refusing to launch ${PHASE} on ${TICKET}: prior artifact missing (${ARTIFACT_SPEC})" >&2
+  jq -nc \
+    --arg ticket "$TICKET" \
+    --arg phase "$PHASE" \
+    --arg model "$MODEL" \
+    --arg artifact "$ARTIFACT_SPEC" \
+    --argjson turnCap "$TURN_CAP" \
+    --argjson dryRun "$DRY_RUN" \
+    '{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+      bg_job_id: null, signalFile: null, status: "refused",
+      reason: "prior_artifact_missing", artifact: $artifact, dryRun: ($dryRun == 1)}'
+  exit 2
+fi
+
+# ─── Write phase signal file (with idempotency) ────────────────────────────
+
+WORKER_DIR="${ORCH_DIR}/workers/${TICKET}"
+SIGNAL_FILE="${WORKER_DIR}/phase-${PHASE}.json"
+mkdir -p "$WORKER_DIR" 2>/dev/null || die "cannot create $WORKER_DIR"
+
+# Idempotency: if a signal exists and its status is one of dispatched|running|done,
+# we no-op. Failed signals are overwritten (retry path).
+EXISTING_STATUS=""
+if [[ -f "$SIGNAL_FILE" ]]; then
+  EXISTING_STATUS=$(jq -r '.status // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+fi
+
+if [[ "$EXISTING_STATUS" == "dispatched" || "$EXISTING_STATUS" == "running" || "$EXISTING_STATUS" == "done" ]]; then
+  EXISTING_JOB=$(jq -r '.bg_job_id // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+  jq -nc \
+    --arg ticket "$TICKET" \
+    --arg phase "$PHASE" \
+    --arg model "$MODEL" \
+    --argjson turnCap "$TURN_CAP" \
+    --arg job "$EXISTING_JOB" \
+    --arg signal "$SIGNAL_FILE" \
+    --arg status "$EXISTING_STATUS" \
+    --argjson dryRun "$DRY_RUN" \
+    '{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+      bg_job_id: (if $job == "" then null else $job end),
+      signalFile: $signal, status: $status, idempotent: true,
+      dryRun: ($dryRun == 1)}'
+  exit 0
+fi
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+jq -nc \
+  --arg ticket "$TICKET" \
+  --arg phase "$PHASE" \
+  --arg model "$MODEL" \
+  --argjson turnCap "$TURN_CAP" \
+  --arg orch "$ORCH_ID" \
+  --arg ts "$TS" \
+  '{ticket: $ticket, phase: $phase, orchestrator: $orch, model: $model,
+    turnCap: $turnCap, status: "dispatched", bg_job_id: null,
+    startedAt: $ts, updatedAt: $ts}' > "$SIGNAL_FILE" \
+  || die "failed to write signal file $SIGNAL_FILE"
+
+# ─── Build prompt + spawn claude --bg ──────────────────────────────────────
+
+PROMPT="/catalyst-dev:phase-${PHASE} ${TICKET} --orch-dir ${ORCH_DIR}"
+
+# Pass the resolved env through so the phase agent inherits orchestrator
+# context + the humanlayer-friendly thoughts repo location. The dispatch
+# scaffold contract documents these as the implicit interface.
+DISPATCH_ENV=(
+  "CATALYST_ORCHESTRATOR_DIR=${ORCH_DIR}"
+  "CATALYST_ORCHESTRATOR_ID=${ORCH_ID}"
+  "CATALYST_PHASE=${PHASE}"
+  "CATALYST_TICKET=${TICKET}"
+)
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  # Dry-run prints the command it would have run without spawning anything.
+  jq -nc \
+    --arg ticket "$TICKET" \
+    --arg phase "$PHASE" \
+    --arg model "$MODEL" \
+    --argjson turnCap "$TURN_CAP" \
+    --arg prompt "$PROMPT" \
+    --arg signal "$SIGNAL_FILE" \
+    --argjson env "$(printf '%s\n' "${DISPATCH_ENV[@]}" | jq -R . | jq -s .)" \
+    '{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+      bg_job_id: null, prompt: $prompt, signalFile: $signal,
+      env: $env, status: "dispatched", dryRun: true}'
+  exit 0
+fi
+
+# Spawn the phase agent. `claude --bg` writes the new job ID to stdout as
+# the first whitespace-bounded token. We capture stdout and stderr separately
+# so a stderr message can't pollute the job ID.
+BG_OUT=$(mktemp)
+BG_ERR=$(mktemp)
+trap 'rm -f "$BG_OUT" "$BG_ERR"' EXIT
+
+# Use env so we propagate the dispatch env without modifying our own shell.
+env "${DISPATCH_ENV[@]}" \
+  claude --bg --dangerously-skip-permissions --model "$MODEL" "$PROMPT" \
+  >"$BG_OUT" 2>"$BG_ERR"
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  echo "phase-agent-dispatch: claude --bg exited $RC: $(cat "$BG_ERR")" >&2
+  jq -n --arg status "failed" --arg reason "claude_bg_failed" \
+        --arg signal "$SIGNAL_FILE" \
+        '. + {status: $status, reason: $reason, signalFile: $signal}' \
+        <<<'{}'
+  exit 1
+fi
+
+# Extract the bg job id — first whitespace-bounded token on stdout.
+BG_JOB_ID=$(awk 'NR==1 {print $1; exit}' "$BG_OUT")
+[[ -n "$BG_JOB_ID" ]] || die "claude --bg returned empty job id (stdout: $(cat "$BG_OUT"))"
+
+# Record job id back into the signal file.
+TS2=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg job "$BG_JOB_ID" --arg ts "$TS2" \
+   '.bg_job_id = $job | .status = "running" | .updatedAt = $ts' \
+   "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+
+jq -nc \
+  --arg ticket "$TICKET" \
+  --arg phase "$PHASE" \
+  --arg model "$MODEL" \
+  --argjson turnCap "$TURN_CAP" \
+  --arg job "$BG_JOB_ID" \
+  --arg signal "$SIGNAL_FILE" \
+  '{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+    bg_job_id: $job, signalFile: $signal, status: "running", dryRun: false}'
+
+exit 0

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# phase-agent-emit-complete — terminal emitter for phase agents (CTL-448).
+#
+# Every phase agent calls this script exactly once before exiting. It does
+# three things in a single invocation:
+#
+#   1. Emit the broker-routable canonical event
+#        phase.<name>.complete.<ticket>   (status=complete)
+#        phase.<name>.failed.<ticket>     (status=failed)
+#      to ~/catalyst/events/YYYY-MM.jsonl using build_canonical_line from
+#      lib/canonical-event.sh. The broker's phase_lifecycle interest type
+#      (CTL-447) routes this to the orchestrator session that registered it.
+#
+#   2. Update the phase signal file
+#        ${ORCH_DIR}/workers/<TICKET>/phase-<name>.json
+#      with status=done|failed, completedAt timestamp, and (on failure) a
+#      failureReason field.
+#
+#   3. End the catalyst-session via catalyst-session.sh end so OTel session
+#      outcomes are emitted and the SQLite row is closed.
+#
+# Usage:
+#   phase-agent-emit-complete \
+#     --phase <name> \
+#     --ticket <id> \
+#     --status complete|failed \
+#     [--reason <text>] \
+#     [--orch-dir <path>] \
+#     [--orch-id <id>] \
+#     [--session-id <id>]
+#
+# Defaults: --orch-dir = $CATALYST_ORCHESTRATOR_DIR
+#           --orch-id  = $CATALYST_ORCHESTRATOR_ID
+#           --session-id = $CATALYST_SESSION_ID
+#
+# Exit codes: 0 on success, 1 on argument or execution error.
+# Best-effort: failures inside the event emit or signal-file write log a
+# warning to stderr but never abort the caller — phase agents should always
+# complete their lifecycle once they reach this script.
+
+set -uo pipefail
+
+# ─── Resolve script dir through symlinks ────────────────────────────────────
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+# shellcheck source=lib/canonical-event.sh
+source "${SCRIPT_DIR}/lib/canonical-event.sh"
+
+CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
+EVENTS_DIR="${CATALYST_DIR}/events"
+
+die() { echo "phase-agent-emit-complete: $*" >&2; exit 1; }
+warn() { echo "phase-agent-emit-complete: warn: $*" >&2; }
+
+# ─── Parse args ─────────────────────────────────────────────────────────────
+
+PHASE=""
+TICKET=""
+STATUS=""
+REASON=""
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
+ORCH_ID="${CATALYST_ORCHESTRATOR_ID:-}"
+SESSION_ID="${CATALYST_SESSION_ID:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --phase)      PHASE="$2"; shift 2 ;;
+    --ticket)     TICKET="$2"; shift 2 ;;
+    --status)     STATUS="$2"; shift 2 ;;
+    --reason)     REASON="$2"; shift 2 ;;
+    --orch-dir)   ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)    ORCH_ID="$2"; shift 2 ;;
+    --session-id) SESSION_ID="$2"; shift 2 ;;
+    -h|--help)    grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)            die "unknown flag: $1" ;;
+  esac
+done
+
+[[ -n "$PHASE" ]]  || die "--phase is required"
+[[ -n "$TICKET" ]] || die "--ticket is required"
+[[ -n "$STATUS" ]] || die "--status is required"
+
+case "$STATUS" in
+  complete|failed) ;;
+  *) die "--status must be 'complete' or 'failed' (got: $STATUS)" ;;
+esac
+
+# Validate ticket shape against the same pattern the broker uses.
+if [[ ! "$TICKET" =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
+  die "invalid --ticket: $TICKET (expected e.g. CTL-100)"
+fi
+
+# Validate phase name (no dots — they would break the event name parser).
+if [[ "$PHASE" == *.* ]]; then
+  die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
+fi
+
+# ─── 1. Emit canonical event ────────────────────────────────────────────────
+
+EVENT_NAME="phase.${PHASE}.${STATUS}.${TICKET}"
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+SEVERITY=$([[ "$STATUS" == "complete" ]] && echo INFO || echo WARN)
+TRACE_ID=$(derive_trace_id "$ORCH_ID" "$SESSION_ID")
+SPAN_ID=$(derive_span_id "$TICKET" "$SESSION_ID")
+
+# Payload mirrors what orchestrator monitors expect: phase, ticket, status,
+# optional failure_reason. The broker's tryPhaseLifecycleRoute parser reads
+# only event.name + ticket, so payload extras don't change routing.
+PAYLOAD=$(jq -nc \
+  --arg phase "$PHASE" \
+  --arg ticket "$TICKET" \
+  --arg status "$STATUS" \
+  --arg reason "$REASON" \
+  '{phase: $phase, ticket: $ticket, status: $status}
+   + (if $reason == "" then {} else {failure_reason: $reason} end)')
+
+LINE=$(build_canonical_line \
+  --ts "$TS" \
+  --severity "$SEVERITY" \
+  --service "catalyst.phase-agent" \
+  --event-name "$EVENT_NAME" \
+  --trace-id "$TRACE_ID" \
+  --span-id "$SPAN_ID" \
+  --entity "phase" \
+  --action "$STATUS" \
+  --orch "$ORCH_ID" \
+  --worker "$TICKET" \
+  --session "$SESSION_ID" \
+  --linear-ticket "$TICKET" \
+  --message "Phase ${PHASE} ${STATUS} on ${TICKET}" \
+  --payload-json "$PAYLOAD" \
+  2>/dev/null) || warn "failed to build canonical event line"
+
+if [[ -n "$LINE" ]]; then
+  canonical_jsonl_append "$EVENTS_DIR" "$LINE" || warn "failed to append event to ${EVENTS_DIR}"
+fi
+
+# ─── 2. Update phase signal file ────────────────────────────────────────────
+
+if [[ -n "$ORCH_DIR" ]]; then
+  SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+  if [[ -f "$SIGNAL_FILE" ]]; then
+    NEW_STATUS=$([[ "$STATUS" == "complete" ]] && echo done || echo failed)
+    TMP="${SIGNAL_FILE}.tmp.$$"
+    if jq --arg status "$NEW_STATUS" \
+          --arg ts "$TS" \
+          --arg reason "$REASON" \
+          '.status = $status
+           | .completedAt = $ts
+           | .updatedAt = $ts
+           | (if $reason == "" then . else .failureReason = $reason end)' \
+          "$SIGNAL_FILE" > "$TMP" 2>/dev/null; then
+      mv "$TMP" "$SIGNAL_FILE"
+    else
+      rm -f "$TMP"
+      warn "failed to update signal file $SIGNAL_FILE"
+    fi
+  else
+    warn "signal file not found: $SIGNAL_FILE (skipping update)"
+  fi
+fi
+
+# ─── 3. End catalyst-session ────────────────────────────────────────────────
+
+if [[ -n "$SESSION_ID" ]] && [[ -x "${SCRIPT_DIR}/catalyst-session.sh" ]]; then
+  SESSION_OUTCOME=$([[ "$STATUS" == "complete" ]] && echo done || echo failed)
+  REASON_FLAG=()
+  [[ -n "$REASON" ]] && REASON_FLAG=(--reason "$REASON")
+  "${SCRIPT_DIR}/catalyst-session.sh" end "$SESSION_ID" \
+    --status "$SESSION_OUTCOME" "${REASON_FLAG[@]}" >/dev/null 2>&1 \
+    || warn "catalyst-session.sh end failed for $SESSION_ID"
+fi
+
+exit 0

--- a/plugins/dev/scripts/phase-agent-watch-bg
+++ b/plugins/dev/scripts/phase-agent-watch-bg
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# phase-agent-watch-bg — map `claude --bg` jobs to phase+ticket (CTL-448).
+#
+# The orchestrator's Phase 4 monitor (after the --bg cutover in Initiative 1
+# Phase 6) needs to translate `claude --bg` job state.json paths to the phase
+# agent they represent. This script does that translation by scanning
+# ${ORCH_DIR}/workers/*/phase-*.json for `bg_job_id` keys and joining them
+# against `~/.claude/jobs/<id>/state.json`.
+#
+# Subcommands:
+#
+#   list [--orch-dir <path>] [--state running|done|all] [--json]
+#     Print one line per active phase agent. JSON mode emits objects with:
+#       { ticket, phase, bg_job_id, state, endedAt, stale, signalFile }
+#     Text mode emits TSV: <ticket> <phase> <bg_job_id> <state> <endedAt> <stale>
+#
+#   status --job <id> [--json]
+#     Print the state of a single bg job by ID. JSON mode emits the same
+#     object shape as list.
+#
+#   stale [--orch-dir <path>] [--max-idle-sec N] [--json]
+#     List phase agents whose ~/.claude/jobs/<id>/state.json mtime is older
+#     than --max-idle-sec (default 900 = 15 min) AND whose state is NOT in
+#     the terminal set (done|failed|errored|stopped). These are the
+#     candidates the healthcheck should mark as stalled.
+#
+# Defaults: --orch-dir = $CATALYST_ORCHESTRATOR_DIR
+#           jobs root  = $CLAUDE_BG_JOBS_DIR or ~/.claude/jobs
+#
+# Exit codes: 0 on success (even if no jobs found), 1 on argument error.
+
+set -uo pipefail
+
+die() { echo "phase-agent-watch-bg: $*" >&2; exit 1; }
+
+CLAUDE_BG_JOBS_DIR="${CLAUDE_BG_JOBS_DIR:-$HOME/.claude/jobs}"
+
+# Resolve mtime of a file as epoch seconds across macOS/Linux.
+file_mtime_epoch() {
+  local f="$1"
+  if [[ ! -e "$f" ]]; then echo ""; return; fi
+  if stat -f %m "$f" >/dev/null 2>&1; then
+    stat -f %m "$f"
+  else
+    stat -c %Y "$f"
+  fi
+}
+
+# Read state.json for a bg job. Echoes JSON object on stdout (state, endedAt,
+# stateFilePath, mtimeEpoch). Missing job → empty object {}.
+read_bg_state() {
+  local job_id="$1"
+  local state_file="${CLAUDE_BG_JOBS_DIR}/${job_id}/state.json"
+  if [[ ! -f "$state_file" ]]; then
+    echo "{}"
+    return
+  fi
+  local mtime
+  mtime=$(file_mtime_epoch "$state_file")
+  # Read state + endedAt from the actual file, with defensive defaults.
+  jq --arg path "$state_file" --arg mtime "$mtime" \
+    '{state: (.state // .status // "unknown"),
+      endedAt: (.endedAt // .ended_at // null),
+      stateFilePath: $path,
+      mtimeEpoch: ($mtime | tonumber? // null)}' "$state_file" 2>/dev/null \
+    || echo "{}"
+}
+
+# Terminal job states — phase agent is finished.
+is_terminal_state() {
+  case "$1" in
+    done|failed|errored|stopped) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Enumerate all signal files under ${ORCH_DIR}/workers/*/phase-*.json that
+# carry a bg_job_id. Emits one JSON object per line on stdout.
+list_phase_agents() {
+  local orch_dir="$1"
+  [[ -d "${orch_dir}/workers" ]] || return 0
+  local now signal job_id payload combined state mtime endedAt stale_sec
+  now=$(date +%s)
+  shopt -s nullglob
+  for signal in "${orch_dir}/workers"/*/phase-*.json; do
+    [[ -f "$signal" ]] || continue
+    job_id=$(jq -r '.bg_job_id // empty' "$signal" 2>/dev/null)
+    [[ -n "$job_id" ]] || continue
+    payload=$(read_bg_state "$job_id")
+    state=$(echo "$payload" | jq -r '.state // "unknown"')
+    endedAt=$(echo "$payload" | jq -r '.endedAt // empty')
+    mtime=$(echo "$payload" | jq -r '.mtimeEpoch // empty')
+
+    # Compute stale: state.json older than 15 min AND state not terminal.
+    local stale="false"
+    if [[ -n "$mtime" ]] && ! is_terminal_state "$state"; then
+      stale_sec=$(( now - mtime ))
+      if [[ $stale_sec -ge 900 ]]; then stale="true"; fi
+    fi
+
+    jq -nc \
+      --slurpfile s "$signal" \
+      --argjson payload "$payload" \
+      --arg stale "$stale" \
+      --arg signalpath "$signal" \
+      '{ticket: $s[0].ticket, phase: $s[0].phase, bg_job_id: $s[0].bg_job_id,
+        state: $payload.state, endedAt: $payload.endedAt,
+        stateFilePath: $payload.stateFilePath, mtimeEpoch: $payload.mtimeEpoch,
+        stale: ($stale == "true"), signalFile: $signalpath}' \
+      2>/dev/null
+  done
+  shopt -u nullglob
+}
+
+# ─── Parse args ─────────────────────────────────────────────────────────────
+
+SUB="${1:-}"
+[[ -n "$SUB" ]] || die "subcommand required: list|status|stale"
+shift
+
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
+STATE_FILTER="all"
+JOB_ID=""
+MAX_IDLE_SEC=900
+OUTPUT_JSON=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir)    ORCH_DIR="$2"; shift 2 ;;
+    --state)       STATE_FILTER="$2"; shift 2 ;;
+    --job)         JOB_ID="$2"; shift 2 ;;
+    --max-idle-sec) MAX_IDLE_SEC="$2"; shift 2 ;;
+    --json)        OUTPUT_JSON=1; shift ;;
+    -h|--help)     grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)             die "unknown flag: $1" ;;
+  esac
+done
+
+case "$SUB" in
+  list)
+    [[ -n "$ORCH_DIR" ]] || die "list: --orch-dir (or CATALYST_ORCHESTRATOR_DIR) is required"
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      STATE=$(echo "$line" | jq -r '.state // "unknown"')
+      case "$STATE_FILTER" in
+        all) ;;
+        running)
+          is_terminal_state "$STATE" && continue
+          ;;
+        done|failed|errored|stopped)
+          [[ "$STATE" == "$STATE_FILTER" ]] || continue
+          ;;
+      esac
+      if [[ $OUTPUT_JSON -eq 1 ]]; then
+        echo "$line"
+      else
+        TICKET=$(echo "$line" | jq -r '.ticket')
+        PHASE=$(echo "$line" | jq -r '.phase')
+        JOB=$(echo "$line" | jq -r '.bg_job_id')
+        ENDED=$(echo "$line" | jq -r '.endedAt // ""')
+        STALE=$(echo "$line" | jq -r '.stale')
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$TICKET" "$PHASE" "$JOB" "$STATE" "$ENDED" "$STALE"
+      fi
+    done < <(list_phase_agents "$ORCH_DIR")
+    ;;
+
+  status)
+    [[ -n "$JOB_ID" ]] || die "status: --job <id> is required"
+    PAYLOAD=$(read_bg_state "$JOB_ID")
+    if [[ $OUTPUT_JSON -eq 1 ]]; then
+      echo "$PAYLOAD"
+    else
+      STATE=$(echo "$PAYLOAD" | jq -r '.state // "unknown"')
+      ENDED=$(echo "$PAYLOAD" | jq -r '.endedAt // ""')
+      printf '%s\t%s\t%s\n' "$JOB_ID" "$STATE" "$ENDED"
+    fi
+    ;;
+
+  stale)
+    [[ -n "$ORCH_DIR" ]] || die "stale: --orch-dir (or CATALYST_ORCHESTRATOR_DIR) is required"
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      STALE=$(echo "$line" | jq -r '.stale')
+      [[ "$STALE" == "true" ]] || continue
+      # Override the default 900s if --max-idle-sec was set lower/higher.
+      # list_phase_agents already computed staleness at the 900s default;
+      # recompute when caller passed a custom threshold.
+      if [[ "$MAX_IDLE_SEC" -ne 900 ]]; then
+        MTIME=$(echo "$line" | jq -r '.mtimeEpoch // empty')
+        NOW=$(date +%s)
+        STATE=$(echo "$line" | jq -r '.state // "unknown"')
+        if [[ -z "$MTIME" ]] || is_terminal_state "$STATE"; then continue; fi
+        if [[ $(( NOW - MTIME )) -lt "$MAX_IDLE_SEC" ]]; then continue; fi
+      fi
+      if [[ $OUTPUT_JSON -eq 1 ]]; then
+        echo "$line"
+      else
+        TICKET=$(echo "$line" | jq -r '.ticket')
+        PHASE=$(echo "$line" | jq -r '.phase')
+        JOB=$(echo "$line" | jq -r '.bg_job_id')
+        STATE=$(echo "$line" | jq -r '.state // "unknown"')
+        printf '%s\t%s\t%s\t%s\tstale\n' "$TICKET" "$PHASE" "$JOB" "$STATE"
+      fi
+    done < <(list_phase_agents "$ORCH_DIR")
+    ;;
+
+  *)
+    die "unknown subcommand: $SUB (expected list|status|stale)"
+    ;;
+esac
+
+exit 0

--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: _phase-agent-template
+description: |
+  Reference template every phase-agent skill copies (CTL-448). The leading
+  underscore + the disable/non-invocable flags below prevent the skill loader
+  from picking this up — it is NOT a runnable skill, only a structural
+  template the nine real phase agents (phase-triage, phase-research, phase-plan,
+  phase-implement, phase-verify, phase-review, phase-pr, phase-monitor-merge,
+  phase-monitor-deploy) clone and specialize.
+disable-model-invocation: true
+user-invocable: false
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+---
+
+# _phase-agent-template
+
+This is the structural template for every phase agent in Initiative 1
+(plan §"Phase-agent architecture"). It is NOT itself a skill — phase-N
+SKILL.md files copy this skeleton and fill in the placeholders marked with
+`{{...}}`. The leading underscore on this directory keeps the skill loader
+from registering it, and the `disable-model-invocation: true` /
+`user-invocable: false` flags are belt-and-suspenders.
+
+## Contract
+
+Every phase agent:
+
+1. Joins the shared `orch-${CATALYST_ORCHESTRATOR_ID}` comms channel at entry
+2. Reads the **prior phase artifact** (see lookup table in
+   `plugins/dev/scripts/phase-agent-dispatch`) — abort if missing.
+3. Starts a `catalyst-session` and writes per-phase status updates.
+4. Does the phase-specific work — delegates to a canonical skill via the
+   Task tool wherever possible. See plan §"Phase agents wrap canonical
+   skills" for the mapping.
+5. On exit, calls `plugins/dev/scripts/phase-agent-emit-complete` which:
+   - Emits the canonical `phase.<name>.{complete,failed}.<ticket>` event
+     (broker `phase_lifecycle` route — CTL-447).
+   - Updates `${ORCH_DIR}/workers/<TICKET>/phase-<name>.json`.
+   - Calls `catalyst-session.sh end`.
+
+## Required env vars
+
+The dispatcher (`plugins/dev/scripts/phase-agent-dispatch`) sets these on
+the spawned `claude --bg` process. The phase agent reads them at startup:
+
+| Var | Meaning |
+|---|---|
+| `CATALYST_ORCHESTRATOR_DIR` | Where signal files live (`workers/<TICKET>/phase-<name>.json`) |
+| `CATALYST_ORCHESTRATOR_ID`  | Broker session correlation + comms channel suffix |
+| `CATALYST_PHASE`            | This phase's name (matches the skill suffix) |
+| `CATALYST_TICKET`           | The ticket this phase agent owns |
+
+## Prelude (every phase agent copies this verbatim)
+
+```bash
+set -euo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required (set by phase-agent-dispatch)}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="orch-${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-/Users/ryan/.claude/plugins/cache/catalyst/catalyst-dev/$(jq -r .version "${CLAUDE_PLUGIN_ROOT:-.}/.claude-plugin/plugin.json" 2>/dev/null || echo 0.0.0)}"
+
+# 1. Join the shared comms channel (best-effort — phase agents must not crash
+#    if catalyst-comms is unavailable).
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-${PHASE}: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-${PHASE} started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+# 2. Start a catalyst-session (cost / token instrumentation).
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-${PHASE}" \
+    --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+# 3. Mark the signal file as "running" + record the start timestamp.
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+```
+
+## /goal condition
+
+Every phase agent declares a `/goal` line at the top of its phase-specific
+work block. The condition MUST be transcript-evaluable and reference the
+artifact this phase produces (per the lookup table in `phase-agent-dispatch`).
+Example for `phase-research`:
+
+```
+/goal "I have written thoughts/shared/research/<date>-${TICKET,,}.md
+       with valid frontmatter and at least 10 file:line references AND I
+       have printed the path + a confirmation line; OR I have stopped
+       after 35 turns and printed what's done."
+```
+
+Turn caps come from `.catalyst/config.json:catalyst.orchestration.phaseAgents.turnCaps.<phase>`
+with per-phase defaults baked into `phase-agent-dispatch`.
+
+## Comms discipline (CTL-448)
+
+Outbound message types — phase agent → orchestrator:
+
+| Type        | When                                           | Cadence per session |
+|-------------|-----------------------------------------------|---------------------|
+| `info`      | Phase started / phase work milestones          | 3–5 |
+| `attention` | Scope conflict, missing access, repeated failures, stalled | 0–2 |
+| `question`  | Specific clarification needed (msg_id is correlation key) | 0–1 |
+| `done`      | Terminal success (emitted by phase-agent-emit-complete) | 1 |
+
+Inbound message types — orchestrator → phase agent (reads on every loop tick):
+
+| Type        | Effect                                                       |
+|-------------|-------------------------------------------------------------|
+| `directive` | Answer to a previously-posted `question` (correlated via `.re` field). Phase agent uses the answer and proceeds. |
+| `pause`     | Halt and poll. Resumes on `directive` or `info` resume signal. |
+| `abort`     | Phase agent cleans up, calls phase-agent-emit-complete with `--status failed --reason aborted_by_orchestrator`, exits. |
+
+Use the helper functions in `plugins/dev/scripts/catalyst-comms` directly —
+do NOT reimplement send/poll logic per phase. The contract tests live in
+`plugins/dev/scripts/__tests__/phase-agent-comms.test.sh`.
+
+## Phase-specific work block (TEMPLATE)
+
+```text
+/goal "{{ transcript-evaluable goal condition for this phase }}"
+
+{{ Phase-specific instructions. The actual work delegates to the canonical
+   skill (e.g., /catalyst-dev:research-codebase) via the Task tool wherever
+   possible. See plan §"Phase agents wrap canonical skills" for the mapping. }}
+```
+
+## End block (every phase agent copies this verbatim)
+
+```bash
+# Drain inbound comms one last time before emitting the complete event so
+# we don't miss an abort sent in the final seconds.
+if [[ -n "$COMMS" ]]; then
+  COMMS_CHANNEL_FILE="${CATALYST_DIR:-$HOME/catalyst}/comms/channels/${CHANNEL}.jsonl"
+  # (intentionally lightweight — full inbound handling is the prelude's job)
+fi
+
+# Emit phase-complete event + close signal file + end session.
+EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+if [[ -x "$EMIT" ]]; then
+  "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status complete
+fi
+
+# Best-effort: post done to the comms channel (final).
+[[ -n "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+Any non-recoverable failure (turn cap hit, prior artifact missing, scope
+conflict that the orchestrator cannot resolve):
+
+```bash
+"$EMIT" --phase "$PHASE" --ticket "$TICKET" --status failed \
+  --reason "{{ short human-readable reason }}"
+[[ -n "$COMMS" ]] && "$COMMS" send "$CHANNEL" "phase-${PHASE} failed: {{reason}}" \
+  --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```
+
+The orchestrator's Phase 4 monitor receives the `phase.<name>.failed.<ticket>`
+event via the broker `phase_lifecycle` route and dispatches a fix-up phase
+agent (same skill, `--resume` flag, prompt seeded with the prior failure
+context). One retry; second failure escalates to user via `attention`.
+
+## Why this is a template and not a base skill
+
+Claude Code skills don't support inheritance — each SKILL.md is its own
+unit. The template lives here so phase agents stay synchronized at edit
+time (when adding a new phase, copy this file, fill in the placeholders),
+not at runtime. If the contract changes, every phase SKILL.md needs to be
+manually re-aligned — there is no automatic propagation.


### PR DESCRIPTION
## Summary

Initiative 1 Phase 2 of the phase-agent architecture (CTL-443). Lays the rails — template, dispatcher, terminal emitter, and bg-job watcher — so the nine phase-specific skills (CTL-449..456) have something concrete to plug into.

Linked: CTL-448. Blocks: CTL-449, CTL-450, CTL-451, CTL-457, CTL-467.

## What ships

**New scripts** (`plugins/dev/scripts/`):

- `phase-agent-dispatch` — resolves model + turn cap from `.catalyst/config.json`, validates the prior-phase artifact, spawns `claude --bg --dangerously-skip-permissions --model <m>`, captures the bg job ID, writes `${ORCH_DIR}/workers/<TICKET>/phase-<name>.json`. Model precedence: CLI > `modelOverrides.<phase>.<TICKET>` > `models.<phase>` > opus. Turn-cap precedence: CLI > `turnCaps.<phase>` > per-phase default. Idempotent for in-flight phases.
- `phase-agent-emit-complete` — terminal emitter every phase agent calls before exit. Emits `phase.<name>.{complete,failed}.<ticket>` matching the broker's `phase_lifecycle` regex (CTL-447), updates the signal file with `status: done/failed`, and closes the `catalyst-session`.
- `phase-agent-watch-bg` — `list | status | stale` over `${ORCH_DIR}/workers/*/phase-*.json` joined with `~/.claude/jobs/<id>/state.json`. Lets the orchestrator's Phase 4 monitor detect stalled bg jobs (>15 min state.json idle + non-terminal state).

**Template** (`plugins/dev/skills/_phase-agent-template/SKILL.md`):

Underscore prefix + `disable-model-invocation: true` + `user-invocable: false` keep this out of the skill loader. Documents the contract every phase agent inherits: prelude (comms join + signal-file update + session start), `/goal` shape, comms discipline (info/attention/question outbound; directive/pause/abort inbound), and end block (`phase-agent-emit-complete --status complete`).

**Comms contract extension** (`plugins/dev/scripts/catalyst-comms`):

Adds `directive`, `pause`, `abort` to the accepted `--type` set. All three share the existing `attention` body-length exemption since orchestrator instructions can exceed 120 chars.

**CMA wiring**:

- `cma/environment.yaml` — pip-installs `humanlayer` in the routine container.
- `cma/agents/base-system-prompt.md` — opt-in `humanlayer thoughts init` block gated on `CATALYST_THOUGHTS_WRITE_BACK=1`. Read-side routines (default) are unaffected.

## Acceptance criteria (from §Initiative 1 Phase 2)

| Test file | Plan target | Result |
|---|---|---|
| `phase-agent-dispatch.test.sh` | 8 tests | **30 passed** |
| `phase-agent-comms.test.sh` | 5 tests | **16 passed** |
| `phase-agent-emit-complete.test.sh` | 3 tests | **15 passed** |
| `canonical-event.test.sh` — new phase event shapes | passes | **+10 phase-agent assertions** (56 total) |

Manual verification deferred to CTL-449 (phase-implement) where a real `claude --bg` job will be observable end-to-end.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` — 30 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — 15 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-comms.test.sh` — 16 pass
- [x] `bash plugins/dev/scripts/__tests__/canonical-event.test.sh` — 56 pass
- [x] `bash plugins/dev/scripts/__tests__/catalyst-comms.test.sh` — 32 pass (regression after type allowlist change)
- [x] `bash plugins/dev/scripts/__tests__/broker-phase-lifecycle.test.sh` — 6 pass (no broker-side changes)
- [ ] Manual: hand-dispatch a stub phase agent against a real worktree (deferred to CTL-449)