### PR TITLE
feat(meta): add Granola, Google Drive, Google Calendar MCP connectors (CTL-456)

### DIFF
--- a/cma/environment.yaml
+++ b/cma/environment.yaml
@@ -62,6 +62,20 @@ config:
       - api.notion.com                    # Notion REST API (integration-token fallback path)
       - mcp.notion.com                    # Notion hosted MCP (OAuth-only; future)
 
+      # Granola family (Path A REST; Path B MCP requires browser OAuth, not used by routines)
+      - public-api.granola.ai             # Granola REST API (primary path for routines)
+      - api.granola.ai                    # Granola internal API routes
+      - auth.granola.ai                   # Granola auth backend
+      - api.workos.com                    # WorkOS identity backend used by Granola
+      # - mcp.granola.ai                  # Granola hosted MCP (Path B; browser OAuth — not currently wireable for headless)
+
+      # Google family (Drive + Calendar; single OAuth client + REST primary)
+      - oauth2.googleapis.com             # refresh-token → access-token exchange
+      - accounts.google.com               # OAuth consent screen (initial setup only)
+      - www.googleapis.com                # Drive v3 + Calendar v3 REST
+      # - drivemcp.googleapis.com         # Google Drive hosted MCP (Path B; pending end-to-end verification)
+      # - calendarmcp.googleapis.com      # Google Calendar hosted MCP (Path B; pending end-to-end verification)
+
       # Package registries (covered by allow_package_managers below, listed for clarity)
       - registry.npmjs.org
       - registry.yarnpkg.com

--- a/cma/mcp/__tests__/verify-mcp-connectivity.test.sh
+++ b/cma/mcp/__tests__/verify-mcp-connectivity.test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Manual smoke test for CMA MCP connectors (CTL-456).
+#
+# Verifies the Path A REST connectivity for Granola, Google Drive, and
+# Google Calendar against real external APIs. Not run in CI — consumes
+# live credentials and external rate limits.
+#
+# Usage:
+#   bash cma/mcp/__tests__/verify-mcp-connectivity.test.sh
+#
+# Required env vars (each subtest skips if its vars are missing):
+#   Granola         : GRANOLA_API_KEY
+#   Google Drive    : GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET,
+#                     GOOGLE_OAUTH_REFRESH_TOKEN
+#   Google Calendar : same Google OAuth env vars as Drive (single OAuth
+#                     client, shared refresh token; see cma/mcp/google-drive.md)
+#
+# Exits 0 when no subtest fails. A missing-env-var subtest counts as "skip"
+# (not "fail"), so the bare invocation with no credentials exits 0.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# ---------------------------------------------------------------------------
+# Granola — Path A REST with Personal API key
+# ---------------------------------------------------------------------------
+check_granola() {
+  echo
+  echo "== Granola =="
+  if [ -z "${GRANOLA_API_KEY:-}" ]; then
+    echo "skip — GRANOLA_API_KEY not set"
+    SKIP=$((SKIP + 1))
+    return 0
+  fi
+  local body status
+  body=$(curl -s -w '\n%{http_code}' \
+    -H "Authorization: Bearer ${GRANOLA_API_KEY}" \
+    "https://public-api.granola.ai/v1/notes?page_size=3" 2>&1) || {
+      echo "fail — curl errored"
+      FAIL=$((FAIL + 1))
+      return 0
+    }
+  status=$(printf '%s' "$body" | tail -n1)
+  local payload
+  payload=$(printf '%s' "$body" | sed '$d')
+  if [ "$status" = "200" ]; then
+    local count
+    count=$(printf '%s' "$payload" | jq '.notes | length' 2>/dev/null || echo "?")
+    echo "pass — HTTP 200, ${count} notes returned"
+    PASS=$((PASS + 1))
+  else
+    echo "fail — HTTP ${status}"
+    printf '%s' "$payload" | head -c 300
+    echo
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Shared helper — exchange Google refresh_token for an access_token
+# ---------------------------------------------------------------------------
+_exchange_google_access_token() {
+  if [ -z "${GOOGLE_OAUTH_CLIENT_ID:-}" ] \
+     || [ -z "${GOOGLE_OAUTH_CLIENT_SECRET:-}" ] \
+     || [ -z "${GOOGLE_OAUTH_REFRESH_TOKEN:-}" ]; then
+    printf ''
+    return 1
+  fi
+  curl -s -X POST https://oauth2.googleapis.com/token \
+    --data-urlencode "client_id=${GOOGLE_OAUTH_CLIENT_ID}" \
+    --data-urlencode "client_secret=${GOOGLE_OAUTH_CLIENT_SECRET}" \
+    --data-urlencode "refresh_token=${GOOGLE_OAUTH_REFRESH_TOKEN}" \
+    --data-urlencode "grant_type=refresh_token" \
+    | jq -r '.access_token // empty'
+}
+
+# ---------------------------------------------------------------------------
+# Google Drive — Path A REST (Drive v3)
+# ---------------------------------------------------------------------------
+check_google_drive() {
+  echo
+  echo "== Google Drive =="
+  local token
+  token=$(_exchange_google_access_token)
+  if [ -z "$token" ]; then
+    echo "skip — GOOGLE_OAUTH_{CLIENT_ID,CLIENT_SECRET,REFRESH_TOKEN} not all set, or token exchange returned empty"
+    SKIP=$((SKIP + 1))
+    return 0
+  fi
+  local since body status payload
+  since=$(date -u +%Y-%m-01T00:00:00Z)
+  body=$(curl -s -w '\n%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    --get \
+    --data-urlencode "q=modifiedTime>'${since}'" \
+    --data-urlencode "pageSize=3" \
+    "https://www.googleapis.com/drive/v3/files" 2>&1) || {
+      echo "fail — curl errored"
+      FAIL=$((FAIL + 1))
+      return 0
+    }
+  status=$(printf '%s' "$body" | tail -n1)
+  payload=$(printf '%s' "$body" | sed '$d')
+  if [ "$status" = "200" ]; then
+    local count
+    count=$(printf '%s' "$payload" | jq '.files | length' 2>/dev/null || echo "?")
+    echo "pass — HTTP 200, ${count} files returned"
+    PASS=$((PASS + 1))
+  else
+    echo "fail — HTTP ${status}"
+    printf '%s' "$payload" | head -c 300
+    echo
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Google Calendar — Path A REST (Calendar v3)
+# ---------------------------------------------------------------------------
+check_google_calendar() {
+  echo
+  echo "== Google Calendar =="
+  local token
+  token=$(_exchange_google_access_token)
+  if [ -z "$token" ]; then
+    echo "skip — same env-var requirement as Google Drive"
+    SKIP=$((SKIP + 1))
+    return 0
+  fi
+  local today tomorrow body status payload
+  today=$(date -u +%Y-%m-%dT00:00:00Z)
+  tomorrow=$(date -u -v+1d +%Y-%m-%dT00:00:00Z 2>/dev/null \
+    || date -u -d tomorrow +%Y-%m-%dT00:00:00Z)
+  body=$(curl -s -w '\n%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    --get \
+    --data-urlencode "timeMin=${today}" \
+    --data-urlencode "timeMax=${tomorrow}" \
+    --data-urlencode "singleEvents=true" \
+    --data-urlencode "orderBy=startTime" \
+    "https://www.googleapis.com/calendar/v3/calendars/primary/events" 2>&1) || {
+      echo "fail — curl errored"
+      FAIL=$((FAIL + 1))
+      return 0
+    }
+  status=$(printf '%s' "$body" | tail -n1)
+  payload=$(printf '%s' "$body" | sed '$d')
+  if [ "$status" = "200" ]; then
+    local count
+    count=$(printf '%s' "$payload" | jq '.items | length' 2>/dev/null || echo "?")
+    echo "pass — HTTP 200, ${count} events today"
+    PASS=$((PASS + 1))
+  else
+    echo "fail — HTTP ${status}"
+    printf '%s' "$payload" | head -c 300
+    echo
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_granola
+check_google_drive
+check_google_calendar
+
+echo
+echo "Pass: ${PASS}  Fail: ${FAIL}  Skip: ${SKIP}"
+[ "${FAIL}" -eq 0 ]

--- a/cma/mcp/google-calendar.md
+++ b/cma/mcp/google-calendar.md
@@ -1,0 +1,209 @@
+# Google Calendar MCP wiring
+
+## URLs
+
+| Endpoint | Path | Auth | Headless |
+|----------|------|------|----------|
+| REST API | `https://www.googleapis.com/calendar/v3` | Bearer (OAuth access token from refresh) | **Yes** — recommended |
+| Hosted MCP | `https://calendarmcp.googleapis.com/mcp/v1` | Bearer (same OAuth access token) | Pending verification |
+| claude.ai connector | `claude.ai/customize/connectors` | OAuth user grant | Read-only; insufficient for routines that schedule events |
+
+For Phase 1 Routines, **use Path A** (OAuth refresh token + Calendar
+v3 REST). The hosted Google Calendar MCP is documented by Google but
+not yet end-to-end verified by this project. The claude.ai first-party
+Calendar connector exists and (unlike Google Drive) **does** pass
+through to Claude Code sessions, but it is read-only — fine for
+morning briefings, insufficient for the follow-up-skill use case
+(Initiative 3) that needs to create events.
+
+## Two paths for Phase 1
+
+### Path A (recommended): OAuth refresh token + Calendar v3 REST
+
+Calendar reuses the same OAuth client as Google Drive — one client,
+one refresh token, multiple scopes. **Do the OAuth setup once in
+[google-drive.md](google-drive.md)** (steps 1-5); when you run the
+local consent flow, include the calendar scopes alongside the Drive
+scope:
+
+```python
+SCOPES = [
+    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/calendar.events.readonly",
+    "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+]
+```
+
+The same `client_id`, `client_secret`, `refresh_token` stored in the
+CMA vault for Drive (`GOOGLE_OAUTH_*`) cover Calendar.
+
+You must also **enable the Calendar API** in the same GCP project at
+<https://console.cloud.google.com/apis/library/calendar-json.googleapis.com>.
+
+REST usage from the agent (after exchanging the refresh token for an
+access token — see [google-drive.md](google-drive.md) for the
+`oauth2.googleapis.com/token` exchange):
+
+```bash
+# List today's events on the primary calendar
+TODAY=$(date -u +%Y-%m-%dT00:00:00Z)
+TOMORROW=$(date -u -v+1d +%Y-%m-%dT00:00:00Z 2>/dev/null \
+  || date -u -d tomorrow +%Y-%m-%dT00:00:00Z)
+curl -s -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  --get \
+  --data-urlencode "timeMin=${TODAY}" \
+  --data-urlencode "timeMax=${TOMORROW}" \
+  --data-urlencode "singleEvents=true" \
+  --data-urlencode "orderBy=startTime" \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events" \
+  | jq '.items[] | {summary, start, end}'
+
+# List all calendars the user has access to (resolve non-primary
+# calendarId values)
+curl -s -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "https://www.googleapis.com/calendar/v3/users/me/calendarList" \
+  | jq '.items[] | {id, summary, accessRole}'
+```
+
+### Path B: Google Calendar hosted MCP (pending verification)
+
+Google ships (per Google's developer docs) a hosted MCP server at
+`https://calendarmcp.googleapis.com/mcp/v1` in Developer Preview. The
+expected tool inventory:
+
+| Tool | Operation |
+|------|-----------|
+| `list_calendars` | Enumerate accessible calendars |
+| `list_events` | Retrieve events by time range and calendar ID |
+| `get_event` | Fetch a single event |
+| `suggest_time` | Find availability across calendars |
+| `create_event` | Add an event |
+| `update_event` | Modify an existing event |
+| `delete_event` | Remove an event |
+| `respond_to_event` | Accept / decline / tentative RSVP |
+
+**Pending verification.** Same shape as the Drive Path B check —
+present the access token to the MCP server and confirm `tools/list`:
+
+```bash
+curl -s -X POST https://calendarmcp.googleapis.com/mcp/v1 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+If reachable, a follow-up PR uncomments
+`calendarmcp.googleapis.com` in `cma/environment.yaml` and adds the
+endpoint to `cma/agents/base.yaml`.
+
+## Maintained community options (if Google's hosted MCP doesn't pan out)
+
+Two OSS Google Calendar MCP servers worth knowing about:
+
+| Repo | Auth | Service account? | Last release |
+|------|------|------------------|--------------|
+| [nspady/google-calendar-mcp](https://github.com/nspady/google-calendar-mcp) | OAuth 2.0 (Desktop app), tokens stored locally | No | v2.6.1 (2026-03-02) |
+| [taylorwilsdon/google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp) | OAuth 2.0/2.1 OR service account + DWD OR external bearer | Yes (Workspace domains only) | v1.20.4 (2026-05-07) |
+
+`taylorwilsdon/google_workspace_mcp` is the more flexible option and
+supports calendar-only deploys with `uvx workspace-mcp --tools calendar`.
+Defer either of these only if Path A REST stops being sufficient.
+
+## Anthropic claude.ai first-party Calendar connector
+
+Unlike Google Drive (which has the open passthrough bug — see
+[google-drive.md](google-drive.md)), the Calendar connector at
+`claude.ai/customize/connectors` **does** pass through to Claude Code
+sessions. However:
+
+- It is **read-only** — cannot create, modify, or delete events; cannot
+  send invitations
+- It is single-account only (multi-account is the most-requested open
+  feature as of 2026-05)
+- It requires an interactive OAuth grant tied to a Claude account, not
+  a vault-stored credential
+
+For the morning-briefing Routine (read-only event listing), the
+claude.ai connector is technically sufficient and could be used as a
+backup. For the follow-up Routine (Initiative 3, schedules calendar
+entries), the claude.ai connector is insufficient — Path A REST is
+required.
+
+Standardizing on Path A REST across both Routines avoids the surface-
+area difference and keeps the vault as the single source of credentials.
+
+## Tools exposed (Path B, pending verification)
+
+See the Path B table above.
+
+## Network allowlist
+
+Already in `cma/environment.yaml` (added by CTL-456, shared with
+[google-drive.md](google-drive.md)):
+
+- `oauth2.googleapis.com` — refresh-token → access-token exchange
+- `accounts.google.com` — initial OAuth consent (setup only)
+- `www.googleapis.com` — Calendar v3 + Drive v3 REST
+
+The hosted MCP endpoint `calendarmcp.googleapis.com` is documented in
+the allowlist but commented out until end-to-end verification confirms
+it.
+
+Calendar adds no new hosts on top of Drive's allowlist — the OAuth +
+REST stack is shared.
+
+## OAuth scope minimums
+
+For the morning-briefing Routine's "list today's events" use case:
+
+| Scope | Purpose |
+|-------|---------|
+| `https://www.googleapis.com/auth/calendar.events.readonly` | View events on all calendars — minimum for `events.list` |
+| `https://www.googleapis.com/auth/calendar.calendarlist.readonly` | See subscribed calendar list — needed to resolve non-primary `calendarId` values |
+
+For Initiative 3 (follow-up routine that schedules events), add:
+
+| Scope | Purpose |
+|-------|---------|
+| `https://www.googleapis.com/auth/calendar.events` | Create / update / delete events on calendars the user owns |
+
+Avoid the broader `https://www.googleapis.com/auth/calendar` (includes
+settings + ACL management) unless a future routine genuinely needs it.
+
+## Service account vs OAuth user flow
+
+Same considerations as Google Drive (see
+[google-drive.md](google-drive.md) §"Service account vs OAuth user
+flow"). Personal `@gmail.com` accounts cannot use service account +
+Domain-Wide Delegation — OAuth refresh token is the only practical
+headless path.
+
+For Google Workspace domains, service account + DWD with the calendar
+scopes above is also a valid headless path; document and switch only
+if a Workspace-domain user adopts these Routines.
+
+## Known limitations
+
+- The hosted Google MCP (`calendarmcp.googleapis.com`) is in Developer
+  Preview per Google's docs; not first-hand verified by this project
+- The claude.ai first-party connector is read-only — fine for morning
+  briefings, insufficient for Initiative 3's scheduling routine
+- DWD requires a Google Workspace domain; personal `@gmail.com`
+  accounts cannot use service account impersonation
+- Calendar event-list responses include declined events by default;
+  the morning-briefing skill should filter by `responseStatus` if
+  needed
+- The `singleEvents=true` parameter expands recurring events — without
+  it, recurring events appear once with their RRULE and the routine
+  has to expand them client-side
+
+## References
+
+- [Configure the Calendar MCP server — Google Developers](https://developers.google.com/workspace/calendar/api/guides/configure-mcp-server)
+- [MCP Reference: calendarmcp.googleapis.com — Google Developers](https://developers.google.com/workspace/calendar/api/v3/reference/mcp)
+- [Calendar API v3 — events.list reference](https://developers.google.com/workspace/calendar/api/v3/reference/events/list)
+- [Choose Google Calendar API scopes](https://developers.google.com/workspace/calendar/api/auth)
+- [nspady/google-calendar-mcp — community MCP server](https://github.com/nspady/google-calendar-mcp)
+- [taylorwilsdon/google_workspace_mcp — community Workspace MCP server](https://github.com/taylorwilsdon/google_workspace_mcp)
+- [Google Calendar connector — claude.com docs](https://claude.com/docs/connectors/google/calendar)
+- [Use Google Workspace connectors — Claude Help Center](https://support.claude.com/en/articles/10166901-use-google-workspace-connectors)

--- a/cma/mcp/google-drive.md
+++ b/cma/mcp/google-drive.md
@@ -1,0 +1,245 @@
+# Google Drive MCP wiring
+
+## URLs
+
+| Endpoint | Path | Auth | Headless |
+|----------|------|------|----------|
+| REST API | `https://www.googleapis.com/drive/v3` | Bearer (OAuth access token from refresh) | **Yes** — recommended |
+| Hosted MCP | `https://drivemcp.googleapis.com/mcp/v1` | Bearer (same OAuth access token) | Pending verification |
+
+For Phase 1 Routines, **use Path A** (OAuth refresh token + Drive v3
+REST). The hosted Google MCP endpoint is documented by Google but has
+not been end-to-end verified by this project; once it is, the same
+Bearer token used in Path A can be presented to the MCP server.
+
+Anthropic's first-party Google Drive connector at
+`claude.ai/customize/connectors` is **not currently usable from headless
+sessions** — see "Why not the claude.ai connector" below.
+
+## Two paths for Phase 1
+
+### Path A (recommended): OAuth refresh token + Drive v3 REST
+
+A single OAuth client covers both Google Drive and Google Calendar
+(see [google-calendar.md](google-calendar.md) for the calendar
+scopes). Do this once locally, capture the refresh token, store it in
+the CMA vault.
+
+1. **Create the OAuth client** at
+   <https://console.cloud.google.com/apis/credentials>:
+   - Project: any GCP project you own (create one if needed)
+   - Credentials -> **+ Create credentials** -> **OAuth client ID**
+   - Application type: **Desktop app** (simpler consent screen than
+     Web)
+   - Name it (e.g., `Catalyst Routines`)
+   - Note the `client_id` and `client_secret`
+2. **Enable the Drive API** at
+   <https://console.cloud.google.com/apis/library/drive.googleapis.com>
+3. **Publish the OAuth consent screen** (Status: "In production")
+   so refresh tokens do not expire after 7 days. For a single-user
+   solo-dev setup, External + In production with yourself as the only
+   user is fine — the verification banner can be dismissed.
+4. **Run a local consent flow once** to obtain the `refresh_token`.
+   Any short Python or Node snippet using
+   `google-auth-oauthlib`/`googleapis` works; the minimum is:
+
+   ```python
+   from google_auth_oauthlib.flow import InstalledAppFlow
+   SCOPES = [
+       "https://www.googleapis.com/auth/drive.readonly",
+       "https://www.googleapis.com/auth/calendar.events.readonly",
+       "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+   ]
+   flow = InstalledAppFlow.from_client_secrets_file("client_secret.json", SCOPES)
+   creds = flow.run_local_server(port=0)
+   print(creds.refresh_token)
+   ```
+
+5. Store `client_id`, `client_secret`, `refresh_token` in the CMA
+   vault.
+
+Vault entry:
+
+```yaml
+# cma/vaults/example.yaml — same entry shared by Drive + Calendar
+- type: static_bearer
+  mcp_server_url: https://www.googleapis.com/
+  token: ${GOOGLE_OAUTH_ACCESS_TOKEN}   # exchanged from refresh at runtime; see below
+  # Stored alongside as separate vault fields (CMA does not yet have
+  # an `oauth_refresh` type — the agent does the exchange itself):
+  # ${GOOGLE_OAUTH_CLIENT_ID}
+  # ${GOOGLE_OAUTH_CLIENT_SECRET}
+  # ${GOOGLE_OAUTH_REFRESH_TOKEN}
+```
+
+Per-run token exchange (the agent runs this once per session before
+making Drive or Calendar calls):
+
+```bash
+ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  --data-urlencode "client_id=${GOOGLE_OAUTH_CLIENT_ID}" \
+  --data-urlencode "client_secret=${GOOGLE_OAUTH_CLIENT_SECRET}" \
+  --data-urlencode "refresh_token=${GOOGLE_OAUTH_REFRESH_TOKEN}" \
+  --data-urlencode "grant_type=refresh_token" \
+  | jq -r .access_token)
+```
+
+REST usage from the agent:
+
+```bash
+# Find a folder by name
+FOLDER_ID=$(curl -s -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  --get \
+  --data-urlencode "q=name='Meeting notes' and mimeType='application/vnd.google-apps.folder'" \
+  "https://www.googleapis.com/drive/v3/files" \
+  | jq -r '.files[0].id')
+
+# List files in that folder modified in the last 7 days
+SINCE=$(date -u -v-7d +%Y-%m-%dT00:00:00Z 2>/dev/null \
+  || date -u -d "7 days ago" +%Y-%m-%dT00:00:00Z)
+curl -s -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  --get \
+  --data-urlencode "q='${FOLDER_ID}' in parents and modifiedTime > '${SINCE}'" \
+  --data-urlencode "orderBy=modifiedTime desc" \
+  --data-urlencode "pageSize=10" \
+  "https://www.googleapis.com/drive/v3/files" \
+  | jq '.files[] | {id, name, modifiedTime}'
+```
+
+### Path B: Google Drive hosted MCP (pending verification)
+
+Google ships (per Google's developer docs) a hosted MCP server at
+`https://drivemcp.googleapis.com/mcp/v1`. The same OAuth access token
+exchanged above is presented as a Bearer header. The expected tool
+inventory includes `list_recent_files`, `search_files`,
+`get_file_metadata`, plus file-content readers.
+
+**Pending verification.** Before this project relies on the hosted
+MCP, do a one-shot manual check:
+
+```bash
+curl -s -X POST https://drivemcp.googleapis.com/mcp/v1 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+If this returns a populated `tools` array, the endpoint is reachable
+and a follow-up PR can:
+
+1. Uncomment `drivemcp.googleapis.com` in `cma/environment.yaml`
+2. Add a `mcp_servers:` entry pointing at the endpoint in
+   `cma/agents/base.yaml`
+
+Until then, Path A is the shipped path.
+
+## Why not the claude.ai connector
+
+Anthropic's first-party Google Drive connector at
+`claude.ai/customize/connectors` is account-scoped OAuth that links
+your Google account to Claude's web/desktop sessions. The connector
+docs claim it surfaces tools across "Claude, Claude Desktop, Claude
+Code, and the API". For Google Drive specifically, two open Anthropic
+bugs contradict that promise:
+
+- [anthropics/claude-code#39422](https://github.com/anthropics/claude-code/issues/39422)
+  — Google Drive connector tools **do not pass through** to Claude
+  Code sessions even when OAuth is fully authorized. Gmail and
+  Calendar do pass through. Drive is the outlier.
+- [anthropics/claude-code#53442](https://github.com/anthropics/claude-code/issues/53442)
+  — Shared Drive content returns empty results.
+
+Both are unresolved as of 2026-05. The morning-briefing Routine reads
+personal-Drive files only, so the Shared Drive bug isn't a blocker,
+but the connector-passthrough bug is — Routines run via the API and
+would not see the tools. Path A REST sidesteps both bugs and works
+under both architectures.
+
+Re-evaluate the claude.ai connector once the passthrough bug is
+closed. The runtime cost of switching from Path A REST to the
+claude.ai connector then is trivial (it's a configuration change, not
+an agent rewrite).
+
+## Tools exposed (Path B, pending verification)
+
+When the hosted MCP works, expected tools include:
+
+| Category | Tools |
+|----------|-------|
+| Discovery | `list_recent_files`, `search_files`, `get_file_metadata` |
+| Content | `read_file`, `export_file` (for Google Docs / Sheets / Slides) |
+| Folders | `list_folder`, `get_folder_metadata` |
+
+The exact inventory depends on the Google MCP server version — confirm
+via the `tools/list` check above.
+
+## Network allowlist
+
+Already in `cma/environment.yaml` (added by CTL-456):
+
+- `oauth2.googleapis.com` — refresh-token → access-token exchange
+- `accounts.google.com` — initial OAuth consent screen (setup only)
+- `www.googleapis.com` — Drive v3 + Calendar v3 REST (shared with
+  [google-calendar.md](google-calendar.md))
+
+The hosted MCP endpoint `drivemcp.googleapis.com` is documented in the
+allowlist but commented out until end-to-end verification confirms it.
+
+## OAuth scope minimums
+
+For the morning-briefing Routine's "list files in 'Meeting notes'
+folder" use case:
+
+| Scope | Purpose |
+|-------|---------|
+| `https://www.googleapis.com/auth/drive.readonly` | Read-only browsing of all files the user owns or has been shared on — the minimum that lets the routine find a folder by name and list its contents |
+
+Avoid:
+
+- `https://www.googleapis.com/auth/drive.file` — only covers files the
+  app itself created; not useful for reading pre-existing Gemini notes
+- `https://www.googleapis.com/auth/drive` — full read/write; broader
+  than the morning-briefing Routine needs
+
+If a future Routine needs to write files (e.g., upload a briefing PDF
+back to Drive), add `drive.file` to the OAuth client's scope list and
+re-run the consent flow once.
+
+## Service account vs OAuth user flow
+
+| Option | Headless | Personal Gmail | Workspace domain |
+|--------|----------|----------------|------------------|
+| OAuth refresh token (recommended) | Yes (after one-time browser consent) | Yes | Yes |
+| Service account, file-shared | Yes | Yes — but each folder must be shared with the service account's `*.gserviceaccount.com` email | Yes |
+| Service account + Domain-Wide Delegation | Yes | **No** — DWD requires a Workspace domain | Yes |
+
+For a solo dev with personal `@gmail.com`, the OAuth refresh-token
+path is the practical headless solution. Service account + DWD only
+works if you're using Google Workspace.
+
+## Known limitations
+
+- The hosted Google MCP (`drivemcp.googleapis.com`) is documented but
+  not first-hand verified by this project. Path A REST is what ships.
+- The claude.ai first-party connector has an open bug (#39422)
+  preventing tool passthrough to Claude Code / API sessions for Drive
+  specifically.
+- Shared Drive content has its own open bug (#53442) in the claude.ai
+  connector path; the routine reads personal Drive only, so this is a
+  non-issue today.
+- Service accounts cannot read personal `@gmail.com` Drive without
+  per-folder sharing — DWD only works on Google Workspace domains.
+- OAuth consent screens in test mode expire refresh tokens after 7
+  days. Publish the OAuth consent screen ("In production") to get
+  long-lived refresh tokens.
+
+## References
+
+- [Configure the Drive MCP server — Google Developers](https://developers.google.com/workspace/drive/api/guides/configure-mcp-server)
+- [MCP Reference: drivemcp.googleapis.com — Google Developers](https://developers.google.com/workspace/drive/api/reference/mcp)
+- [Drive API v3 — files.list reference](https://developers.google.com/workspace/drive/api/reference/rest/v3/files/list)
+- [Use Google Workspace connectors — Claude Help Center](https://support.claude.com/en/articles/10166901-use-google-workspace-connectors)
+- [Use connectors to extend Claude's capabilities — Claude Help Center](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities)
+- [Bug: Google Drive MCP not passed through to Claude Code — anthropics/claude-code #39422](https://github.com/anthropics/claude-code/issues/39422)
+- [Bug: Cowork Google Drive MCP cannot see Shared Drive content — anthropics/claude-code #53442](https://github.com/anthropics/claude-code/issues/53442)
+- [isaacphi/mcp-gdrive — community OSS MCP server](https://github.com/isaacphi/mcp-gdrive)

--- a/cma/mcp/granola.md
+++ b/cma/mcp/granola.md
@@ -1,0 +1,156 @@
+# Granola MCP wiring
+
+## URLs
+
+| Endpoint | Path | Auth | Headless |
+|----------|------|------|----------|
+| REST API | `https://public-api.granola.ai/v1` | Bearer (Personal API key) | **Yes** — recommended |
+| Hosted MCP | `https://mcp.granola.ai/mcp` | OAuth 2.1 + Dynamic Client Registration | No — browser-only |
+
+The hosted MCP server at `mcp.granola.ai` cannot be used by a headless
+CMA session. Granola's docs explicitly state there is no API key or
+service-account auth path for the MCP server — only OAuth 2.1 + DCR,
+which requires a live browser. For Routines, use Path A (REST).
+
+## Two paths for Phase 1
+
+### Path A (recommended for now): Granola REST with a Personal API key
+
+This is the only headless path and takes ~2 minutes.
+
+1. Open the Granola **desktop app** (the key is not provisioned from
+   the web app)
+2. **Settings** -> **Connectors** -> **API Keys** -> **Create new key**
+3. Select **Personal API key**, give it a label (e.g.,
+   `Catalyst Routines`)
+4. Copy the `grn_...` value once shown — Granola does not display it
+   again
+5. (Enterprise workspaces only) An admin must first enable personal
+   API keys at **Settings** -> **Workspace** -> **Allow personal API
+   keys**
+
+Vault entry:
+
+```yaml
+# cma/vaults/example.yaml
+- type: static_bearer
+  mcp_server_url: https://public-api.granola.ai/v1/
+  token: ${GRANOLA_API_KEY}        # grn_... Personal API key from the desktop app
+```
+
+(The vault's `mcp_server_url` is purely a credential index here — the
+agent calls Granola REST directly, not an MCP server.)
+
+REST usage from the agent:
+
+```bash
+# List the last 3 meeting notes (page_size 1-30, default 10)
+curl -s \
+  -H "Authorization: Bearer ${GRANOLA_API_KEY}" \
+  "https://public-api.granola.ai/v1/notes?page_size=3" \
+  | jq '.notes[] | {id, title, created_at}'
+
+# Get a specific note + its transcript (paid plans only for transcripts)
+curl -s \
+  -H "Authorization: Bearer ${GRANOLA_API_KEY}" \
+  "https://public-api.granola.ai/v1/notes/${NOTE_ID}?include=transcript"
+
+# List folders (paid plans for private folders; team folders never
+# accessible via the public API)
+curl -s \
+  -H "Authorization: Bearer ${GRANOLA_API_KEY}" \
+  "https://public-api.granola.ai/v1/folders"
+```
+
+Useful query params for `GET /v1/notes`:
+
+| Param | Meaning |
+|-------|---------|
+| `created_after` / `created_before` | ISO 8601 filter on note creation time |
+| `updated_after` | ISO 8601 filter on last update |
+| `page_size` | 1-30, default 10 |
+| `cursor` | pagination cursor from a prior response |
+
+Note ID format: `not_[A-Za-z0-9]{14}`. Only notes with a completed AI
+summary appear; notes still being processed return 404 on direct fetch.
+
+### Path B: Granola hosted MCP (deferred — browser OAuth only)
+
+Granola launched an official MCP server (`https://mcp.granola.ai/mcp`,
+Streamable HTTP) in early 2026. The server authenticates exclusively
+with OAuth 2.1 + Dynamic Client Registration, which requires an
+interactive browser session. There is no Bearer / API key / service
+account path documented.
+
+This makes the hosted MCP **unusable for headless CMA Routines**
+without a one-time human-in-the-loop authorization step that produces
+storable access + refresh tokens — and even then, Granola has not
+published the token endpoints required to do programmatic refresh.
+
+If a future routine genuinely needs the MCP-only tools listed below
+(e.g., paid-plan `get_meeting_transcript`), the wiring would be to
+complete the OAuth dance manually once, capture both tokens, store them
+in the vault as an `mcp_oauth` entry, and rely on Granola's
+server-side refresh. Until that's needed, stay on Path A.
+
+## Tools exposed (Path B only)
+
+| Tool | Plan tier |
+|------|-----------|
+| `list_meetings` | All |
+| `get_meetings` | All |
+| `query_granola_meetings` | All |
+| `get_account_info` | All |
+| `list_meeting_folders` | Paid only |
+| `get_meeting_transcript` | Paid only |
+
+Free plan limits: own notes only, last 30 days, no transcripts. Team
+folders are not surfaced via MCP regardless of plan.
+
+## Network allowlist
+
+Minimum set for headless REST-only use:
+
+- `public-api.granola.ai` — REST API (primary)
+- `api.granola.ai` — Granola internal API routes (some endpoints
+  cross-call into this host)
+- `auth.granola.ai` — token validation
+- `api.workos.com` — WorkOS identity backend used by Granola for auth
+
+The Path B MCP endpoint `mcp.granola.ai` is documented but not
+allowlisted by default in `cma/environment.yaml`. Uncomment it when the
+hosted MCP becomes wireable for headless sessions.
+
+## Rate limits
+
+- Burst: 25 requests in 5 seconds
+- Sustained: 5 req/s (300/min)
+- Exceeded: `429 Too Many Requests`
+
+The morning-briefing Routine makes at most a single `notes` list call
++ a handful of `notes/{id}` fetches per run — far below the limits.
+
+## Known limitations
+
+- The hosted MCP server has no headless auth path; Path A is the only
+  realistic option for cloud Routines today
+- Only AI-summarized notes are returned from `/v1/notes` — notes still
+  being summarized return 404 if fetched directly
+- Transcripts (`?include=transcript`) require a paid Granola plan
+- Team folders are never exposed via the public API, only personal and
+  shared folders
+- The Personal API key has no native rotation UI flow — rotate by
+  revoking + creating a new key when needed
+- Enterprise workspaces gate personal API keys behind a per-workspace
+  admin toggle
+
+## References
+
+- [Introducing Granola MCP — Granola Blog](https://www.granola.ai/blog/granola-mcp)
+- [Granola MCP — Official Docs](https://docs.granola.ai/help-center/sharing/integrations/mcp)
+- [Granola API Introduction — Official Docs](https://docs.granola.ai/introduction)
+- [Personal API Docs](https://docs.granola.ai/help-center/sharing/integrations/personal-api.md)
+- [List Notes Endpoint — API Reference](https://docs.granola.ai/api-reference/list-notes.md)
+- [Get Note Endpoint — API Reference](https://docs.granola.ai/api-reference/get-note.md)
+- [Network Troubleshooting & Allowlist — Granola Docs](https://docs.granola.ai/help-center/troubleshooting/network-troubleshooting)
+- [OpenAPI Spec](https://docs.granola.ai/api-reference/openapi.json)


### PR DESCRIPTION
## Summary

Configures three new CMA MCP connectors required by the morning-briefing Routine (Initiative 2 Phase 2 of the [phase-agent-architecture plan](../tree/o-project-phase-agent-architecture-CTL-456/thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md)).

**Documentation + scaffolding only.** No runtime code consumes these yet — the morning-briefing skill (CTL-457) will wire them in next.

### What ships

| File | Purpose |
|------|---------|
| `cma/mcp/granola.md` | Granola connector wiring (REST primary, hosted MCP deferred) |
| `cma/mcp/google-drive.md` | Google Drive connector wiring (REST + OAuth refresh primary) |
| `cma/mcp/google-calendar.md` | Google Calendar connector wiring (shares OAuth client with Drive) |
| `cma/mcp/__tests__/verify-mcp-connectivity.test.sh` | Manual smoke harness — exits 0 vacuously when env vars unset; hits live APIs when set |
| `cma/environment.yaml` | Allowlist now covers Granola + Google host families |

### Key design choices

1. **Path A REST primary, Path B MCP deferred.** Every connector matches `notion.md` / `slack.md` (REST-primary), not `linear.md` / `github.md` (MCP-primary). The Granola hosted MCP requires browser OAuth (no headless path). The Google hosted MCPs (`drivemcp.googleapis.com`, `calendarmcp.googleapis.com`) are documented by Google but flagged "pending verification" — the docs include a `tools/list` curl to confirm once a real access token is in hand.

2. **Single OAuth client for Drive + Calendar.** Same `client_id` / `client_secret` / `refresh_token`, with the calendar scopes added alongside the Drive scope. One vault entry, one consent flow.

3. **claude.ai connectors documented as "why not".** Drive's connector has an [open passthrough bug](https://github.com/anthropics/claude-code/issues/39422). Calendar's connector is read-only (insufficient for Initiative 3's scheduling routine).

4. **Path B endpoints commented out in `environment.yaml`.** Documented intent without silently allowing traffic.

### Live verification

The Granola Path A endpoint was confirmed reachable during validation — `GRANOLA_API_KEY=grn_test_invalid bash cma/mcp/__tests__/verify-mcp-connectivity.test.sh` returned a real `401 INVALID_API_KEY` from `public-api.granola.ai`, proving the URL is correct and the auth header shape is right.

## Test plan

- [x] `bash cma/mcp/__tests__/verify-mcp-connectivity.test.sh` exits 0 with no env vars set (3 skips, 0 fails)
- [x] `bash -n cma/mcp/__tests__/verify-mcp-connectivity.test.sh` syntax check passes
- [x] `python3 -c "import yaml; yaml.safe_load(open('cma/environment.yaml'))"` parses cleanly; new entries present, no duplicates
- [x] Cross-doc references between `google-drive.md` ↔ `google-calendar.md` resolve
- [x] Forced-fail check: `GRANOLA_API_KEY=invalid bash ...` exits 1 (real Granola 401)
- [ ] **Manual (operator)**: with real credentials in env, all three subtests print `pass — HTTP 200, N items`
- [ ] **Manual (operator)**: OAuth consent flow completed once locally; refresh token stored in vault

## Refs

- Ticket: CTL-456
- Parent plan: `thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md` §Initiative 2 Phase 1
- Research: `thoughts/shared/research/2026-05-17-CTL-456-granola-gdrive-gcal-mcp-investigation.md`
- Plan: `thoughts/shared/plans/2026-05-17-CTL-456-granola-gdrive-gcal-mcp-connectors.md`