### PR TITLE
feat(dev): phase-research + phase-plan + phase-verify + phase-review skills (CTL-450)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Tests for the phase-plan skill (CTL-450 Initiative 1 Phase 4).
+#
+# Approach mirrors phase-research-e2e: contract checks on SKILL.md plus an
+# integration check against phase-agent-dispatch with claude stubbed. The
+# prior-phase artifact for plan is the research document at
+# thoughts/shared/research/*-<ticket>.md.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL="${REPO_ROOT}/plugins/dev/skills/phase-plan/SKILL.md"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-plan-e2e-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$1', got '$2'"; }
+assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
+assert_file_exists() { [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"; }
+
+# ─── Contract ───────────────────────────────────────────────────────────────
+echo "Test 1: phase-plan SKILL.md contract"
+assert_file_exists "$SKILL" "SKILL.md exists at plugins/dev/skills/phase-plan/SKILL.md"
+
+if [[ -f "$SKILL" ]]; then
+  BODY=$(cat "$SKILL")
+  assert_contains "$BODY" "name: phase-plan" "frontmatter declares name: phase-plan"
+  assert_contains "$BODY" "user-invocable: false" "frontmatter sets user-invocable: false"
+  assert_contains "$BODY" "CATALYST_ORCHESTRATOR_DIR" "prelude reads CATALYST_ORCHESTRATOR_DIR"
+  assert_contains "$BODY" "CATALYST_TICKET" "prelude reads CATALYST_TICKET"
+
+  # Prior artifact: the research doc
+  assert_contains "$BODY" "thoughts/shared/research/" "body references prior research document"
+
+  # Delegates to canonical create-plan
+  assert_contains "$BODY" "/catalyst-dev:create-plan" "body invokes /catalyst-dev:create-plan"
+
+  # Output artifact: plan document
+  assert_contains "$BODY" "thoughts/shared/plans/" "body writes to thoughts/shared/plans/"
+
+  assert_contains "$BODY" "phase-agent-emit-complete" "body calls phase-agent-emit-complete"
+  assert_contains "$BODY" '--status complete' "body emits --status complete on success"
+  assert_contains "$BODY" '--status failed' "body emits --status failed on error path"
+
+  # Linear intermediate state — plan uses 'planning' (existing state, not new)
+  assert_contains "$BODY" "planning" "body transitions Linear ticket to planning state"
+
+  assert_contains "$BODY" "/goal" "body declares a /goal block"
+fi
+
+# ─── E2E: dispatcher launches phase-plan when research doc present ─────────
+echo ""
+echo "Test 2: phase-agent-dispatch --phase plan succeeds with research doc present"
+
+TEST_DIR="${SCRATCH}/t2"
+STUB_DIR="${TEST_DIR}/bin"
+PROJ_DIR="${TEST_DIR}/proj"
+ORCH_DIR="${PROJ_DIR}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-450"
+RESEARCH_DIR="${PROJ_DIR}/thoughts/shared/research"
+mkdir -p "$STUB_DIR" "$WORKER_DIR" "$RESEARCH_DIR"
+
+cat > "$STUB_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
+{
+  echo "--ARGS--"; printf '%s\n' "$@"
+  echo "--ENV--"; env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
+  echo "--END--"
+} > "$LOG"
+echo "job-plan-002"
+STUB
+chmod +x "$STUB_DIR/claude"
+
+export CLAUDE_STUB_LOG="${TEST_DIR}/claude.log"
+export PATH="${STUB_DIR}:${PATH}"
+
+# Plan's prior-artifact gate is a glob: thoughts/shared/research/*-<ticket-lower>.md
+# The dispatcher cd's into its caller's cwd to resolve the glob, so we cd into proj.
+touch "${RESEARCH_DIR}/2026-05-17-ctl-450.md"
+
+OUT=$(cd "$PROJ_DIR" && "$DISPATCH" --phase plan --ticket CTL-450 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC=$?
+assert_eq "0" "$RC" "dispatch exit code 0"
+SIGNAL="${WORKER_DIR}/phase-plan.json"
+assert_file_exists "$SIGNAL" "signal file phase-plan.json written"
+
+if [[ -f "$SIGNAL" ]]; then
+  assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "signal.status = running"
+  assert_eq "plan" "$(jq -r '.phase' "$SIGNAL")" "signal.phase = plan"
+  assert_eq "job-plan-002" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches stub"
+fi
+
+LOG=$(cat "$CLAUDE_STUB_LOG" 2>/dev/null || echo "")
+assert_contains "$LOG" "/catalyst-dev:phase-plan CTL-450" "claude invoked with phase-plan skill prompt"
+assert_contains "$LOG" "CATALYST_PHASE=plan" "env carries CATALYST_PHASE=plan"
+
+# ─── E2E: dispatcher refuses when research doc is missing ──────────────────
+echo ""
+echo "Test 3: phase-agent-dispatch refuses phase-plan without research doc"
+
+TEST_DIR="${SCRATCH}/t3"
+PROJ_DIR="${TEST_DIR}/proj"
+ORCH_DIR="${PROJ_DIR}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-450"
+mkdir -p "$WORKER_DIR" "${PROJ_DIR}/thoughts/shared/research"
+# Note: no research doc placed for CTL-450
+
+OUT=$(cd "$PROJ_DIR" && "$DISPATCH" --phase plan --ticket CTL-450 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC=$?
+REFUSED=$(echo "$OUT" | jq -r '.status' 2>/dev/null || echo "")
+assert_eq "2" "$RC" "exit code 2 when research doc missing"
+assert_eq "refused" "$REFUSED" "stdout status = refused"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-plan-e2e: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -gt 0 ]] && exit 1
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Tests for the phase-research skill (CTL-450 Initiative 1 Phase 4).
+#
+# These are contract/E2E tests that verify the skill's SKILL.md adheres to the
+# phase-agent template (CTL-448) and that dispatching it via phase-agent-dispatch
+# does the right plumbing (claude is stubbed). We can't actually execute the
+# skill body in bash — the body is LLM prose — so we verify:
+#   - SKILL.md exists with the right frontmatter
+#   - The body declares the prelude env-var contract
+#   - The body invokes /catalyst-dev:research-codebase (not a reimplementation)
+#   - The body calls phase-agent-emit-complete with --phase research
+#   - The body references the expected artifact path
+#     (thoughts/shared/research/*-<ticket>.md)
+#   - Dispatching with --phase research --ticket <T> spawns claude --bg with the
+#     right prompt + env when triage.json exists
+#   - Dispatching refuses when triage.json is missing
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL="${REPO_ROOT}/plugins/dev/skills/phase-research/SKILL.md"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-research-e2e-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  [[ "$expected" == "$actual" ]] && pass "$label" || fail "$label — expected '$expected', got '$actual'"
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  [[ "$haystack" == *"$needle"* ]] && pass "$label" || fail "$label — '$needle' not found"
+}
+assert_file_exists() {
+  [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"
+}
+
+# ─── Contract: SKILL.md frontmatter + body ─────────────────────────────────
+echo "Test 1: phase-research SKILL.md contract"
+assert_file_exists "$SKILL" "SKILL.md exists at plugins/dev/skills/phase-research/SKILL.md"
+
+if [[ -f "$SKILL" ]]; then
+  BODY=$(cat "$SKILL")
+  # Frontmatter
+  assert_contains "$BODY" "name: phase-research" "frontmatter declares name: phase-research"
+  assert_contains "$BODY" "user-invocable: false" "frontmatter sets user-invocable: false"
+  assert_contains "$BODY" "Task" "allowed-tools includes Task (for invoking research-codebase)"
+  assert_contains "$BODY" "Bash" "allowed-tools includes Bash"
+
+  # Prelude contract — must declare all four env vars from the template
+  assert_contains "$BODY" "CATALYST_ORCHESTRATOR_DIR" "prelude reads CATALYST_ORCHESTRATOR_DIR"
+  assert_contains "$BODY" "CATALYST_ORCHESTRATOR_ID"  "prelude reads CATALYST_ORCHESTRATOR_ID"
+  assert_contains "$BODY" "CATALYST_PHASE"            "prelude reads CATALYST_PHASE"
+  assert_contains "$BODY" "CATALYST_TICKET"           "prelude reads CATALYST_TICKET"
+
+  # Prior-phase artifact gate: triage.json
+  assert_contains "$BODY" "triage.json" "body references prior triage.json artifact"
+
+  # Body delegates to canonical research-codebase skill
+  assert_contains "$BODY" "/catalyst-dev:research-codebase" "body invokes /catalyst-dev:research-codebase"
+
+  # Output artifact path
+  assert_contains "$BODY" "thoughts/shared/research/" "body writes to thoughts/shared/research/"
+
+  # Terminal emitter
+  assert_contains "$BODY" "phase-agent-emit-complete" "body calls phase-agent-emit-complete"
+  assert_contains "$BODY" '--status complete' "body emits --status complete on success"
+  assert_contains "$BODY" '--status failed' "body emits --status failed on error path"
+
+  # Linear state transition (CTL-454 intermediate states)
+  assert_contains "$BODY" "researching" "body transitions Linear ticket to researching state"
+
+  # /goal block (turn cap)
+  assert_contains "$BODY" "/goal" "body declares a /goal block"
+fi
+
+# ─── E2E: dispatcher launches phase-research when triage.json exists ───────
+echo ""
+echo "Test 2: phase-agent-dispatch --phase research succeeds with triage.json present"
+
+TEST_DIR="${SCRATCH}/t2"
+STUB_DIR="${TEST_DIR}/bin"
+ORCH_DIR="${TEST_DIR}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-450"
+mkdir -p "$STUB_DIR" "$WORKER_DIR"
+
+cat > "$STUB_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
+{
+  echo "--ARGS--"
+  printf '%s\n' "$@"
+  echo "--ENV--"
+  env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
+  echo "--END--"
+} > "$LOG"
+echo "job-research-001"
+STUB
+chmod +x "$STUB_DIR/claude"
+
+export CLAUDE_STUB_LOG="${TEST_DIR}/claude.log"
+export PATH="${STUB_DIR}:${PATH}"
+
+# Place a triage.json so the dispatcher's prior-artifact gate passes.
+echo '{"ticket":"CTL-450","status":"done","classification":"feature"}' > "${WORKER_DIR}/triage.json"
+
+OUT=$("$DISPATCH" --phase research --ticket CTL-450 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC=$?
+assert_eq "0" "$RC" "dispatch exit code 0"
+SIGNAL="${WORKER_DIR}/phase-research.json"
+assert_file_exists "$SIGNAL" "signal file phase-research.json written"
+
+if [[ -f "$SIGNAL" ]]; then
+  STATUS=$(jq -r '.status' "$SIGNAL")
+  PHASE=$(jq -r '.phase' "$SIGNAL")
+  JOB=$(jq -r '.bg_job_id' "$SIGNAL")
+  assert_eq "running" "$STATUS" "signal.status = running after spawn"
+  assert_eq "research" "$PHASE" "signal.phase = research"
+  assert_eq "job-research-001" "$JOB" "signal.bg_job_id = stub job id"
+fi
+
+LOG=$(cat "$CLAUDE_STUB_LOG" 2>/dev/null || echo "")
+assert_contains "$LOG" "/catalyst-dev:phase-research CTL-450" "claude invoked with phase-research skill prompt"
+assert_contains "$LOG" "CATALYST_PHASE=research" "env carries CATALYST_PHASE=research"
+assert_contains "$LOG" "CATALYST_TICKET=CTL-450" "env carries CATALYST_TICKET=CTL-450"
+
+# ─── E2E: dispatcher refuses when triage.json is missing ───────────────────
+echo ""
+echo "Test 3: phase-agent-dispatch refuses phase-research without triage.json"
+
+TEST_DIR="${SCRATCH}/t3"
+ORCH_DIR="${TEST_DIR}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-450"
+mkdir -p "$WORKER_DIR"
+
+OUT=$("$DISPATCH" --phase research --ticket CTL-450 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC=$?
+REFUSED=$(echo "$OUT" | jq -r '.status' 2>/dev/null || echo "")
+assert_eq "2" "$RC" "exit code 2 when triage.json missing"
+assert_eq "refused" "$REFUSED" "stdout status = refused"
+SIGNAL_EXISTS="no"
+[[ -f "${WORKER_DIR}/phase-research.json" ]] && SIGNAL_EXISTS="yes"
+assert_eq "no" "$SIGNAL_EXISTS" "no signal file written on refusal"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-research-e2e: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Tests for the phase-review skill (CTL-450 Initiative 1 Phase 4).
+#
+# phase-review wraps the gstack /review skill (NOT /ultrareview — that one stays
+# user-triggered). It reads the prior verify.json, runs /review against the diff,
+# writes ${ORCH_DIR}/workers/<TICKET>/review.json, and creates at most ONE
+# remediation commit for HIGH-severity findings with deterministic fixes.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL="${REPO_ROOT}/plugins/dev/skills/phase-review/SKILL.md"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-review-e2e-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$1', got '$2'"; }
+assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 — '$2' WAS present (must not be)"; }
+assert_file_exists() { [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"; }
+
+# ─── Contract ───────────────────────────────────────────────────────────────
+echo "Test 1: phase-review SKILL.md contract"
+assert_file_exists "$SKILL" "SKILL.md exists at plugins/dev/skills/phase-review/SKILL.md"
+
+if [[ -f "$SKILL" ]]; then
+  BODY=$(cat "$SKILL")
+  assert_contains "$BODY" "name: phase-review" "frontmatter declares name: phase-review"
+  assert_contains "$BODY" "user-invocable: false" "frontmatter sets user-invocable: false"
+
+  # Allowed-tools must include Edit (since we may write remediation commits)
+  assert_contains "$BODY" "Edit" "allowed-tools includes Edit (for remediation commits)"
+
+  # Prelude
+  assert_contains "$BODY" "CATALYST_ORCHESTRATOR_DIR" "prelude reads CATALYST_ORCHESTRATOR_DIR"
+  assert_contains "$BODY" "CATALYST_TICKET" "prelude reads CATALYST_TICKET"
+
+  # Prior artifact: verify.json from phase-verify
+  assert_contains "$BODY" "verify.json" "body reads prior verify.json artifact"
+
+  # Output artifact: review.json
+  assert_contains "$BODY" "review.json" "body writes review.json artifact"
+
+  # Schema fields
+  assert_contains "$BODY" "remediationCommit" "review.json schema includes remediationCommit"
+  assert_contains "$BODY" "reviewPassed"      "review.json schema includes reviewPassed"
+
+  # Delegates to /review — must not invoke /ultrareview
+  assert_contains "$BODY" "/review" "body invokes /review (gstack)"
+  assert_not_contains "$BODY" "Invoke /ultrareview" "body does NOT instruct invoking /ultrareview"
+  # Either no mention of ultrareview or only a no-op directive — assert the
+  # body acknowledges and forbids it.
+  assert_contains "$BODY" "ultrareview" "body acknowledges ultrareview (to forbid it)"
+
+  assert_contains "$BODY" "phase-agent-emit-complete" "body calls phase-agent-emit-complete"
+  assert_contains "$BODY" '--status complete' "body emits --status complete on success"
+
+  # Linear intermediate state — reviewing (CTL-454)
+  assert_contains "$BODY" "reviewing" "body transitions Linear ticket to reviewing state"
+
+  assert_contains "$BODY" "/goal" "body declares a /goal block"
+
+  # Remediation commit cap: at most ONE
+  assert_contains "$BODY" "at most ONE" "body documents at-most-one-remediation-commit constraint"
+fi
+
+# ─── E2E: dispatcher launches phase-review when verify.json present ────────
+echo ""
+echo "Test 2: phase-agent-dispatch --phase review succeeds with verify.json present"
+
+TEST_DIR="${SCRATCH}/t2"
+STUB_DIR="${TEST_DIR}/bin"
+ORCH_DIR="${TEST_DIR}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-450"
+mkdir -p "$STUB_DIR" "$WORKER_DIR"
+
+cat > "$STUB_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
+{
+  echo "--ARGS--"; printf '%s\n' "$@"
+  echo "--ENV--"; env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
+  echo "--END--"
+} > "$LOG"
+echo "job-review-004"
+STUB
+chmod +x "$STUB_DIR/claude"
+
+export CLAUDE_STUB_LOG="${TEST_DIR}/claude.log"
+export PATH="${STUB_DIR}:${PATH}"
+
+cat > "${WORKER_DIR}/verify.json" <<EOF
+{"regression_risk": 3, "findings": [], "tests_attempted": 0, "gates": {}}
+EOF
+
+OUT=$("$DISPATCH" --phase review --ticket CTL-450 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC=$?
+assert_eq "0" "$RC" "dispatch exit code 0"
+SIGNAL="${WORKER_DIR}/phase-review.json"
+assert_file_exists "$SIGNAL" "signal file phase-review.json written"
+
+if [[ -f "$SIGNAL" ]]; then
+  assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "signal.status = running"
+  assert_eq "review" "$(jq -r '.phase' "$SIGNAL")" "signal.phase = review"
+  assert_eq "25" "$(jq -r '.turnCap' "$SIGNAL")" "signal.turnCap defaults to 25 (review)"
+  assert_eq "job-review-004" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches stub"
+fi
+
+LOG=$(cat "$CLAUDE_STUB_LOG" 2>/dev/null || echo "")
+assert_contains "$LOG" "/catalyst-dev:phase-review CTL-450" "claude invoked with phase-review skill prompt"
+assert_contains "$LOG" "CATALYST_PHASE=review" "env carries CATALYST_PHASE=review"
+
+# ─── E2E: dispatcher refuses without verify.json ───────────────────────────
+echo ""
+echo "Test 3: phase-agent-dispatch refuses phase-review without verify.json"
+
+TEST_DIR="${SCRATCH}/t3"
+ORCH_DIR="${TEST_DIR}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-450"
+mkdir -p "$WORKER_DIR"
+
+OUT=$("$DISPATCH" --phase review --ticket CTL-450 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC=$?
+REFUSED=$(echo "$OUT" | jq -r '.status' 2>/dev/null || echo "")
+assert_eq "2" "$RC" "exit code 2 when verify.json missing"
+assert_eq "refused" "$REFUSED" "stdout status = refused"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-review-e2e: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -gt 0 ]] && exit 1
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tests for the phase-verify skill (CTL-450 Initiative 1 Phase 4).
+#
+# phase-verify is the only NEW skill in Phase 4 (the others wrap canonical skills).
+# It is read-only against application code — it produces a verify.json artifact
+# and may only create test files, never application code.
+#
+# These tests verify:
+#   - SKILL.md exists with the right frontmatter + read-only constraint
+#   - The body declares the prelude env-var contract
+#   - The body reads phase-implement.json as its prior artifact
+#   - The body documents the regression_risk / findings / tests_attempted schema
+#   - The body explicitly states it does NOT write application code
+#   - The body calls phase-agent-emit-complete with --phase verify
+#   - Dispatching with --phase verify succeeds when phase-implement.json exists
+#   - Dispatching refuses when phase-implement.json is missing
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL="${REPO_ROOT}/plugins/dev/skills/phase-verify/SKILL.md"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-verify-e2e-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$1', got '$2'"; }
+assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
+assert_file_exists() { [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"; }
+
+# ─── Contract ───────────────────────────────────────────────────────────────
+echo "Test 1: phase-verify SKILL.md contract"
+assert_file_exists "$SKILL" "SKILL.md exists at plugins/dev/skills/phase-verify/SKILL.md"
+
+if [[ -f "$SKILL" ]]; then
+  BODY=$(cat "$SKILL")
+  assert_contains "$BODY" "name: phase-verify" "frontmatter declares name: phase-verify"
+  assert_contains "$BODY" "user-invocable: false" "frontmatter sets user-invocable: false"
+
+  # Prelude
+  assert_contains "$BODY" "CATALYST_ORCHESTRATOR_DIR" "prelude reads CATALYST_ORCHESTRATOR_DIR"
+  assert_contains "$BODY" "CATALYST_TICKET" "prelude reads CATALYST_TICKET"
+
+  # CRITICAL: read-only constraint must be loud
+  assert_contains "$BODY" "NEVER write application code" \
+    "body declares 'NEVER write application code' constraint"
+
+  # Prior artifact: phase-implement.json
+  assert_contains "$BODY" "phase-implement.json" "body reads phase-implement.json as prior artifact"
+
+  # Output artifact: verify.json
+  assert_contains "$BODY" "verify.json" "body writes verify.json artifact"
+
+  # Required schema fields
+  assert_contains "$BODY" "regression_risk" "verify.json schema includes regression_risk"
+  assert_contains "$BODY" "findings"        "verify.json schema includes findings"
+  assert_contains "$BODY" "tests_attempted" "verify.json schema includes tests_attempted"
+
+  # Gates referenced
+  assert_contains "$BODY" "validate-type-safety"  "body references validate-type-safety gate"
+  assert_contains "$BODY" "scan-reward-hacking"   "body references scan-reward-hacking gate"
+  assert_contains "$BODY" "code-reviewer"         "body references code-reviewer agent"
+  assert_contains "$BODY" "pr-test-analyzer"      "body references pr-test-analyzer agent"
+  assert_contains "$BODY" "silent-failure-hunter" "body references silent-failure-hunter agent"
+
+  assert_contains "$BODY" "phase-agent-emit-complete" "body calls phase-agent-emit-complete"
+  assert_contains "$BODY" '--status complete' "body emits --status complete on success"
+
+  # Linear intermediate state — verifying (CTL-454)
+  assert_contains "$BODY" "verifying" "body transitions Linear ticket to verifying state"
+
+  assert_contains "$BODY" "/goal" "body declares a /goal block"
+fi
+
+# ─── E2E: dispatcher launches phase-verify when phase-implement.json exists ─
+echo ""
+echo "Test 2: phase-agent-dispatch --phase verify succeeds with phase-implement.json present"
+
+TEST_DIR="${SCRATCH}/t2"
+STUB_DIR="${TEST_DIR}/bin"
+ORCH_DIR="${TEST_DIR}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-450"
+mkdir -p "$STUB_DIR" "$WORKER_DIR"
+
+cat > "$STUB_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
+{
+  echo "--ARGS--"; printf '%s\n' "$@"
+  echo "--ENV--"; env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
+  echo "--END--"
+} > "$LOG"
+echo "job-verify-003"
+STUB
+chmod +x "$STUB_DIR/claude"
+
+export CLAUDE_STUB_LOG="${TEST_DIR}/claude.log"
+export PATH="${STUB_DIR}:${PATH}"
+
+echo '{"ticket":"CTL-450","phase":"implement","status":"done"}' > "${WORKER_DIR}/phase-implement.json"
+
+OUT=$("$DISPATCH" --phase verify --ticket CTL-450 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC=$?
+assert_eq "0" "$RC" "dispatch exit code 0"
+SIGNAL="${WORKER_DIR}/phase-verify.json"
+assert_file_exists "$SIGNAL" "signal file phase-verify.json written"
+
+if [[ -f "$SIGNAL" ]]; then
+  assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "signal.status = running"
+  assert_eq "verify" "$(jq -r '.phase' "$SIGNAL")" "signal.phase = verify"
+  assert_eq "20" "$(jq -r '.turnCap' "$SIGNAL")" "signal.turnCap defaults to 20 (verify)"
+  assert_eq "job-verify-003" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches stub"
+fi
+
+LOG=$(cat "$CLAUDE_STUB_LOG" 2>/dev/null || echo "")
+assert_contains "$LOG" "/catalyst-dev:phase-verify CTL-450" "claude invoked with phase-verify skill prompt"
+assert_contains "$LOG" "CATALYST_PHASE=verify" "env carries CATALYST_PHASE=verify"
+
+# ─── E2E: dispatcher refuses without phase-implement.json ──────────────────
+echo ""
+echo "Test 3: phase-agent-dispatch refuses phase-verify without phase-implement.json"
+
+TEST_DIR="${SCRATCH}/t3"
+ORCH_DIR="${TEST_DIR}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-450"
+mkdir -p "$WORKER_DIR"
+
+OUT=$("$DISPATCH" --phase verify --ticket CTL-450 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC=$?
+REFUSED=$(echo "$OUT" | jq -r '.status' 2>/dev/null || echo "")
+assert_eq "2" "$RC" "exit code 2 when phase-implement.json missing"
+assert_eq "refused" "$REFUSED" "stdout status = refused"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-verify-e2e: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -gt 0 ]] && exit 1
+exit 0

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: phase-plan
+description: |
+  Phase agent for the plan step of the 9-phase orchestrator pipeline (CTL-450).
+  Wraps /catalyst-dev:create-plan and produces
+  thoughts/shared/plans/<date>-<ticket>.md, then emits phase.plan.complete.<ticket>.
+  Reads the prior research document from thoughts/shared/research/ as its
+  prior-phase artifact. Spawned via plugins/dev/scripts/phase-agent-dispatch;
+  not normally user-invoked.
+disable-model-invocation: false
+user-invocable: false
+allowed-tools:
+  - Read
+  - Write
+  - Grep
+  - Glob
+  - Task
+  - Bash
+  - mcp__deepwiki__ask_question
+  - mcp__deepwiki__read_wiki_structure
+---
+
+# phase-plan
+
+You are the **plan phase agent**. You run inside `claude --bg` and own a single
+responsibility: produce `thoughts/shared/plans/<date>-<ticket>.md` that meets the
+schema enforced by [[create-plan]], then emit `phase.plan.complete.<ticket>` and
+exit. Built on the [[_phase-agent-template]] contract.
+
+Plans are TDD-structured: Tests First (Red) → Implementation (Green) → Refactor →
+Success Criteria for every phase, with success criteria split into Automated and
+Manual Verification.
+
+## Prelude
+
+```bash
+set -uo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required (set by phase-agent-dispatch)}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="orch-${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+
+# Join comms channel (best-effort).
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-${PHASE}: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-plan started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+# Start session.
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-${PHASE}" \
+    --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+
+# Prior-phase artifact: the research document. Dispatcher gates this via glob;
+# we re-read it here so we can fail loudly on race.
+shopt -s nullglob
+RESEARCH_MATCHES=( thoughts/shared/research/*-${TICKET,,}.md )
+shopt -u nullglob
+if [[ ${#RESEARCH_MATCHES[@]} -eq 0 ]]; then
+  echo "phase-plan: research document missing for $TICKET" >&2
+  "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+    --phase "$PHASE" --ticket "$TICKET" --status failed \
+    --reason "prior_artifact_missing:research_doc"
+  exit 1
+fi
+RESEARCH_DOC="${RESEARCH_MATCHES[-1]}"
+```
+
+## Linear state transition
+
+```bash
+LT="${PLUGIN_ROOT}/scripts/linear-transition.sh"
+if [[ -x "$LT" ]]; then
+  "$LT" --ticket "$TICKET" --transition planning --config .catalyst/config.json \
+    >/dev/null 2>&1 || true
+fi
+```
+
+## /goal
+
+```
+/goal "I have written thoughts/shared/plans/<date>-${ticket-lower}.md containing the
+       full plan with: Overview, Phase 1..N sections each with Tests First (Red),
+       Implementation (Green), Refactor, and Success Criteria (Automated + Manual).
+       I have printed the path on stdout. OR I have stopped after 25 turns and
+       printed a clear partial-progress summary."
+```
+
+## Work block
+
+Generate the plan by **invoking the canonical skill** rather than reimplementing it.
+The body of [[create-plan]] is the single source of truth.
+
+Phase agents run inside `claude --bg` — there is no interactive user. Pass the
+research document as the input and operate non-interactively:
+
+1. Read `$RESEARCH_DOC` to understand the problem.
+2. Invoke `/catalyst-dev:create-plan` against the research document. When that skill
+   asks for clarifications, answer from the research document; if the research
+   document is silent on a point, default to the most conservative reasonable choice
+   and record the assumption in the plan's "Open questions" section.
+3. Confirm the artifact exists:
+   ```bash
+   shopt -s nullglob
+   PLAN_MATCHES=( thoughts/shared/plans/*-${TICKET,,}.md )
+   shopt -u nullglob
+   [[ ${#PLAN_MATCHES[@]} -gt 0 ]] || {
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "plan_doc_not_written"
+     exit 1
+   }
+   PLAN_DOC="${PLAN_MATCHES[-1]}"
+   ```
+
+If [[create-plan]] runs into a question it cannot resolve from the research
+document, post a `question` comms message to the orchestrator with `--re <msg_id>`
+correlation; do not block waiting for a reply — record the assumption and proceed.
+
+## End block
+
+```bash
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" --arg doc "$PLAN_DOC" \
+  '.updatedAt = $ts | .artifact = $doc' \
+  "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+
+"${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+  --phase "$PHASE" --ticket "$TICKET" --status complete
+
+[[ -n "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+```bash
+"${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+  --phase "$PHASE" --ticket "$TICKET" --status failed \
+  --reason "<short reason>"
+[[ -n "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-plan failed: <reason>" --as "$TICKET" --type attention \
+  --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: phase-research
+description: |
+  Phase agent for the research step of the 9-phase orchestrator pipeline (CTL-450).
+  Wraps /catalyst-dev:research-codebase and produces
+  thoughts/shared/research/<date>-<ticket>.md, then emits phase.research.complete.<ticket>.
+  Reads triage.json from the worker dir as its prior-phase artifact.
+  Spawned via plugins/dev/scripts/phase-agent-dispatch; not normally user-invoked.
+disable-model-invocation: false
+user-invocable: false
+allowed-tools:
+  - Read
+  - Write
+  - Grep
+  - Glob
+  - Task
+  - Bash
+  - mcp__deepwiki__ask_question
+  - mcp__deepwiki__read_wiki_structure
+---
+
+# phase-research
+
+You are the **research phase agent**. You run inside `claude --bg` and own a single
+responsibility: produce `thoughts/shared/research/<date>-<ticket>.md` that meets the
+schema enforced by [[research-codebase]], then emit
+`phase.research.complete.<ticket>` and exit. Built on the [[_phase-agent-template]]
+contract.
+
+You are a documentarian, not a critic. Document what EXISTS. No suggestions for
+improvements. No architectural critiques.
+
+## Prelude
+
+```bash
+set -uo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required (set by phase-agent-dispatch)}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="orch-${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+
+# Join the shared comms channel (best-effort).
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-${PHASE}: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-research started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+# Start a catalyst-session for cost/token instrumentation.
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-${PHASE}" \
+    --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+# Mark signal file running.
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+
+# Read the prior-phase artifact (triage.json). The dispatcher already gated this,
+# so the file MUST exist — fail loudly if not (race condition / out-of-band run).
+TRIAGE_FILE="${ORCH_DIR}/workers/${TICKET}/triage.json"
+if [[ ! -f "$TRIAGE_FILE" ]]; then
+  echo "phase-research: prior triage.json missing at $TRIAGE_FILE" >&2
+  "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+    --phase "$PHASE" --ticket "$TICKET" --status failed \
+    --reason "prior_artifact_missing:triage.json"
+  exit 1
+fi
+TRIAGE_SUMMARY=$(jq -r '.summary // .classification // ""' "$TRIAGE_FILE" 2>/dev/null || echo "")
+```
+
+## Linear state transition
+
+Move the ticket to the `researching` state added in CTL-454. Best-effort; if the
+transition fails (state map missing, network), the phase continues — Linear state
+is observability, not gating.
+
+```bash
+LT="${PLUGIN_ROOT}/scripts/linear-transition.sh"
+if [[ -x "$LT" ]]; then
+  "$LT" --ticket "$TICKET" --transition researching --config .catalyst/config.json \
+    >/dev/null 2>&1 || true
+fi
+```
+
+## /goal
+
+```
+/goal "I have written thoughts/shared/research/<date>-${ticket-lower}.md with valid
+       frontmatter, a 'Summary' section, a 'Findings' section containing at least 10
+       file:line references, and a 'References' section linking related thoughts/plans.
+       I have printed the path on stdout. OR I have stopped after 35 turns and printed
+       a clear partial-progress summary."
+```
+
+Replace `<date>` with `$(date -u +%Y-%m-%d)` and `<ticket-lower>` with the lowercased
+`$TICKET` (`ctl-450` for `CTL-450`).
+
+## Work block
+
+Conduct the research by **invoking the canonical skill** rather than reimplementing
+it. The body of [[research-codebase]] is the single source of truth for how research
+is performed.
+
+1. Read the Linear ticket via `linearis issues read $TICKET --with-attachments` to
+   get the title, description, and any linked plan reference.
+2. Read the triage summary from `$TRIAGE_FILE` to understand classification and
+   surfaced dependencies.
+3. Invoke `/catalyst-dev:research-codebase` against the ticket's research question.
+   That skill spawns parallel sub-agents, synthesizes findings, and writes the
+   document. Do not duplicate its logic.
+4. Confirm the artifact exists at the expected path before continuing:
+   ```bash
+   RESEARCH_DOC=$(ls thoughts/shared/research/*-${TICKET,,}.md 2>/dev/null | tail -1)
+   [[ -f "$RESEARCH_DOC" ]] || {
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "research_doc_not_written"
+     exit 1
+   }
+   ```
+
+If [[research-codebase]] hits a question it cannot resolve, post a `question` comms
+message and continue with the best-effort answer — do not block the pipeline.
+
+## End block
+
+```bash
+# Update the signal file with the artifact path so downstream phases can find it.
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" --arg doc "$RESEARCH_DOC" \
+  '.updatedAt = $ts | .artifact = $doc' \
+  "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+
+# Emit phase-complete event, close signal file, end catalyst-session.
+"${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+  --phase "$PHASE" --ticket "$TICKET" --status complete
+
+# Final comms send.
+[[ -n "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+Any non-recoverable failure (turn cap hit, [[research-codebase]] returns no document,
+prior-artifact gate fails after dispatcher race):
+
+```bash
+"${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+  --phase "$PHASE" --ticket "$TICKET" --status failed \
+  --reason "<short human-readable reason>"
+[[ -n "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-research failed: <reason>" --as "$TICKET" --type attention \
+  --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```
+
+The orchestrator's Phase 4 monitor receives the failed event via the broker
+`phase_lifecycle` route and dispatches a fix-up phase agent (one retry, then
+escalates to user via `attention`).

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: phase-review
+description: |
+  Phase agent for the review step of the 9-phase orchestrator pipeline (CTL-450).
+  Wraps the /review skill (gstack) — explicitly skips /ultrareview per user decision.
+  Reads verify.json from the prior phase, runs /review against the diff, writes
+  ${ORCH_DIR}/workers/<TICKET>/review.json, and creates a remediation commit for
+  any HIGH-severity finding that has a deterministic fix. Emits
+  phase.review.complete.<ticket>. Spawned via phase-agent-dispatch; not user-invoked.
+disable-model-invocation: false
+user-invocable: false
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Task
+  - Bash
+---
+
+# phase-review
+
+You are the **review phase agent**. You run inside `claude --bg` and own a single
+responsibility: pre-landing review of the worker branch using the gstack
+[[review]] skill, producing `${ORCH_DIR}/workers/<TICKET>/review.json` and at most
+one remediation commit. You then emit `phase.review.complete.<ticket>` and exit.
+Built on the [[_phase-agent-template]] contract.
+
+You **do not** invoke `/ultrareview` — that command is reserved for the user to
+trigger interactively (it costs real money via the multi-agent cloud review).
+
+## Prelude
+
+```bash
+set -uo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required (set by phase-agent-dispatch)}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="orch-${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-${PHASE}: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-review started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-${PHASE}" \
+    --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+
+# Prior-phase artifact: verify.json from phase-verify.
+VERIFY_ARTIFACT="${ORCH_DIR}/workers/${TICKET}/verify.json"
+if [[ ! -f "$VERIFY_ARTIFACT" ]]; then
+  echo "phase-review: prior verify.json missing" >&2
+  "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+    --phase "$PHASE" --ticket "$TICKET" --status failed \
+    --reason "prior_artifact_missing:verify.json"
+  exit 1
+fi
+REGRESSION_RISK=$(jq -r '.regression_risk // 0' "$VERIFY_ARTIFACT")
+```
+
+## Linear state transition
+
+Move the ticket to `reviewing` (added in CTL-454).
+
+```bash
+LT="${PLUGIN_ROOT}/scripts/linear-transition.sh"
+if [[ -x "$LT" ]]; then
+  "$LT" --ticket "$TICKET" --transition reviewing --config .catalyst/config.json \
+    >/dev/null 2>&1 || true
+fi
+```
+
+## /goal
+
+```
+/goal "I have written ${ORCH_DIR}/workers/${TICKET}/review.json with
+       {findings:[...], remediationCommit:string|null, reviewPassed:bool} AND any
+       HIGH-severity finding with a deterministic fix has a corresponding
+       remediation commit on HEAD. I have printed the path on stdout. OR I have
+       stopped after 25 turns and recorded a partial review.json."
+```
+
+## Work block
+
+### 1. Run /review (gstack) — never /ultrareview
+
+```text
+Invoke the /review skill via the Task tool. It analyzes the diff against the base
+branch for SQL safety, LLM trust boundary violations, conditional side effects,
+and other structural issues. Capture its output as raw text and parse into the
+review findings array.
+```
+
+DO NOT invoke `/ultrareview` from this phase. If a future iteration wants
+multi-agent cloud review, the user runs it interactively before merge.
+
+### 2. Merge findings from verify.json
+
+The `findings` array in `verify.json` (from [[phase-verify]]) is the upstream
+source of truth. Treat each verify finding as a candidate review item:
+
+- HIGH severity + deterministic fix → remediation commit
+- HIGH severity + ambiguous fix → record in `review.json` for human attention
+- MEDIUM / LOW → record but do not commit
+
+The fix decision is deterministic when:
+
+- The finding's `recommendation` is a single concrete code change with a clear
+  before/after, AND
+- The fix is local (no cross-file refactor), AND
+- The fix doesn't change a public API or test expectation.
+
+### 3. Create at most ONE remediation commit
+
+If you make any code changes, batch them into a single commit:
+
+```bash
+git add -A
+git commit -m "fix(${ticket-scope}): phase-review remediations for ${TICKET}
+
+Addresses HIGH-severity findings surfaced by phase-verify and /review:
+- <one line per finding>
+
+Refs: ${TICKET}"
+```
+
+Scope (`dev`/`pm`/`meta` etc.) comes from the project's existing convention; if
+unclear, use `dev`. Never use `--no-verify` or `--no-gpg-sign`.
+
+### 4. Write the artifact
+
+```bash
+ARTIFACT="${ORCH_DIR}/workers/${TICKET}/review.json"
+REMEDIATION_SHA=$(git log -1 --grep="phase-review remediations for ${TICKET}" \
+  --format=%H 2>/dev/null || echo "")
+REVIEW_PASSED=$([[ -z "$BLOCKING_FINDINGS" ]] && echo "true" || echo "false")
+
+jq -nc \
+  --argjson findings "$REVIEW_FINDINGS_JSON" \
+  --arg sha "$REMEDIATION_SHA" \
+  --argjson passed "$REVIEW_PASSED" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{findings: $findings,
+    remediationCommit: (if $sha == "" then null else $sha end),
+    reviewPassed: $passed,
+    generatedAt: $ts}' > "${ARTIFACT}.tmp" \
+  && mv "${ARTIFACT}.tmp" "$ARTIFACT"
+```
+
+**Findings array shape** — each entry mirrors phase-verify's shape plus an
+`addressedBy` field:
+
+```json
+{
+  "severity": "high|medium|low",
+  "kind": "review|sql|trust-boundary|side-effect|...",
+  "file": "path/to/file.ts",
+  "line": 42,
+  "message": "Short description",
+  "addressedBy": "remediation-commit|deferred-to-human|none"
+}
+```
+
+## End block
+
+```bash
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" --arg artifact "$ARTIFACT" \
+  '.updatedAt = $ts | .artifact = $artifact' \
+  "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+
+"${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+  --phase "$PHASE" --ticket "$TICKET" --status complete
+
+[[ -n "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+```bash
+"${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+  --phase "$PHASE" --ticket "$TICKET" --status failed \
+  --reason "<short reason>"
+[[ -n "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-review failed: <reason>" --as "$TICKET" --type attention \
+  --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: phase-verify
+description: |
+  Phase agent for the verify step of the 9-phase orchestrator pipeline (CTL-450).
+  NEW skill — has no canonical wrapper. Runs read-only adversarial verification
+  against the implement-phase diff: tsc, tests, lint, security scan, reward-hacking
+  scan, code review, test coverage, silent-failure hunt. Writes
+  ${ORCH_DIR}/workers/<TICKET>/verify.json then emits phase.verify.complete.<ticket>.
+  Reads phase-implement.json as its prior-phase artifact. NEVER writes application
+  code — only test files allowed. Spawned via phase-agent-dispatch; not user-invoked.
+disable-model-invocation: false
+user-invocable: false
+allowed-tools:
+  - Read
+  - Write
+  - Grep
+  - Glob
+  - Task
+  - Bash
+---
+
+# phase-verify
+
+You are the **verify phase agent**. You run inside `claude --bg` and own a single
+responsibility: read-only adversarial verification of the implement phase's diff,
+producing `${ORCH_DIR}/workers/<TICKET>/verify.json` with `regression_risk`,
+`findings`, and `tests_attempted` fields. You then emit
+`phase.verify.complete.<ticket>` and exit. Built on the [[_phase-agent-template]]
+contract.
+
+## CRITICAL CONSTRAINT: NEVER write application code
+
+You are a **read-only verifier**. The only files you may create or edit are:
+
+- Test files (under `**/__tests__/`, `*.test.*`, `*.spec.*`, `test/**`, `tests/**`)
+- The `verify.json` artifact in the worker directory
+- Signal files via the standard emitter helper
+
+Editing application code from this phase is a contract violation. If verification
+surfaces a bug that requires code changes, you **record the finding** and let
+[[phase-review]] (which IS allowed to write remediation commits) act on it.
+
+## Prelude
+
+```bash
+set -uo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required (set by phase-agent-dispatch)}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="orch-${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-${PHASE}: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-verify started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-${PHASE}" \
+    --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+
+# Prior-phase artifact: phase-implement.json.
+IMPLEMENT_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-implement.json"
+if [[ ! -f "$IMPLEMENT_SIGNAL" ]]; then
+  echo "phase-verify: prior phase-implement.json missing" >&2
+  "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+    --phase "$PHASE" --ticket "$TICKET" --status failed \
+    --reason "prior_artifact_missing:phase-implement.json"
+  exit 1
+fi
+```
+
+## Linear state transition
+
+Move the ticket to `verifying` (added in CTL-454).
+
+```bash
+LT="${PLUGIN_ROOT}/scripts/linear-transition.sh"
+if [[ -x "$LT" ]]; then
+  "$LT" --ticket "$TICKET" --transition verifying --config .catalyst/config.json \
+    >/dev/null 2>&1 || true
+fi
+```
+
+## /goal
+
+```
+/goal "I have written ${ORCH_DIR}/workers/${TICKET}/verify.json with the schema
+       {regression_risk:int, findings:[...], tests_attempted:int, gates:{...}} AND
+       I have NOT modified any application source files (only test files). I have
+       printed the path on stdout. OR I have stopped after 20 turns and recorded
+       a partial verify.json with whatever I have."
+```
+
+## Work block
+
+Run the same adversarial verification suite the current `oneshot` Phase 4 runs,
+but record findings instead of attempting fixes.
+
+### 1. Determine the base branch and diff
+
+```bash
+BASE_BRANCH=$(git remote show origin 2>/dev/null \
+  | grep "HEAD branch" | awk '{print $NF}')
+BASE_BRANCH="${BASE_BRANCH:-main}"
+DIFF_RANGE="origin/${BASE_BRANCH}...HEAD"
+```
+
+### 2. Run read-only gates
+
+Run each gate; record pass/fail/skip into the in-memory results map. Do not stop
+on first failure — verification is exhaustive.
+
+| Gate | Tool | Skill / agent |
+|---|---|---|
+| Type check | `tsc --noEmit` (or project's `typecheckCommand`) | [[validate-type-safety]] |
+| Reward-hacking scan | grep-based pattern check | [[scan-reward-hacking]] |
+| Unit tests | project test command | [[validate-type-safety]] |
+| Lint | project lint command | [[validate-type-safety]] |
+| Security review | dependency + secret scan | `/security-review` (built-in) |
+| Code review | style/guideline adherence | [[pr-review-toolkit:code-reviewer]] agent |
+| Test coverage | per-file coverage on diff | [[pr-review-toolkit:pr-test-analyzer]] agent |
+| Silent failures | unchecked try/catch + fallback hunting | [[pr-review-toolkit:silent-failure-hunter]] agent |
+
+For each gate, run via `Bash` for the CLI ones and the `Task` tool for the agent
+ones. Capture exit code + a one-line summary per gate.
+
+### 3. Compute `regression_risk` (0–10)
+
+Aggregate signal:
+
+| Signal | Risk delta |
+|---|---|
+| Any required CLI gate failed (tsc/test/lint/security) | +3 each |
+| `scan-reward-hacking` flagged a HIGH-severity pattern | +3 |
+| `code-reviewer` flagged a structural issue | +2 |
+| `pr-test-analyzer` reports < 50% diff coverage | +2 |
+| `silent-failure-hunter` flagged unchecked catch / fallback | +2 |
+| Any agent surfaced a `must-fix` finding | +3 |
+
+Clamp to `[0, 10]`. A regression_risk ≥ 5 means [[phase-review]] should create
+remediation commits before the PR opens.
+
+### 4. Optionally write **test-only** files
+
+If `pr-test-analyzer` identifies an uncovered code path that has obvious tests, you
+MAY add tests under `**/__tests__/` or `**/*.test.*`. Track each file added in the
+`tests_attempted` count. **Do not edit application code under any circumstance**;
+silent-failure-hunter's findings go into `findings`, never into a fix.
+
+### 5. Write the artifact
+
+```bash
+ARTIFACT="${ORCH_DIR}/workers/${TICKET}/verify.json"
+# Build $RESULTS_JSON in-memory and write atomically.
+jq -nc \
+  --argjson risk "$REGRESSION_RISK" \
+  --argjson findings "$FINDINGS_JSON" \
+  --argjson tests "$TESTS_ATTEMPTED" \
+  --argjson gates "$GATES_JSON" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{regression_risk: $risk, findings: $findings, tests_attempted: $tests,
+    gates: $gates, generatedAt: $ts}' > "${ARTIFACT}.tmp" \
+  && mv "${ARTIFACT}.tmp" "$ARTIFACT"
+```
+
+**Findings array shape** — each entry:
+
+```json
+{
+  "severity": "high|medium|low",
+  "kind": "type|test|lint|security|review|coverage|silent-failure|reward-hacking",
+  "file": "path/to/file.ts",
+  "line": 42,
+  "message": "Short human-readable description",
+  "recommendation": "What phase-review should do about this"
+}
+```
+
+**Gates object shape** — keyed by gate name:
+
+```json
+{
+  "typecheck": { "status": "pass|fail|skip", "exitCode": 0, "summary": "..." },
+  "tests":     { "status": "pass", "exitCode": 0, "summary": "..." }
+}
+```
+
+## End block
+
+```bash
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" --arg artifact "$ARTIFACT" \
+  '.updatedAt = $ts | .artifact = $artifact' \
+  "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+
+"${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+  --phase "$PHASE" --ticket "$TICKET" --status complete
+
+[[ -n "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+A failure here means verification itself broke (e.g., a gate process crashed),
+not that a gate failed — gate failures are recorded into `findings` and the phase
+still emits `complete`.
+
+```bash
+"${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+  --phase "$PHASE" --ticket "$TICKET" --status failed \
+  --reason "<short reason>"
+[[ -n "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-verify failed: <reason>" --as "$TICKET" --type attention \
+  --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```
+
+## Why this is a separate skill from validate-plan
+
+[[validate-plan]] checks that a plan was executed against a known plan document.
+phase-verify is adversarial — it doesn't read the plan; it reads the diff and
+hunts for regressions. The orchestrator's pipeline may run both (validate-plan
+inside implement, then verify on the resulting branch).


### PR DESCRIPTION
## Summary

Initiative 1 Phase 4 of the phase-agent architecture (CTL-443). Builds the four mid-pipeline phase agents on top of CTL-448's scaffold so the orchestrator can run a full 9-phase pipeline.

Linked: CTL-450. Blocks: CTL-452.

## What ships

**Four new phase-agent skills** (`plugins/dev/skills/`):

| Skill | Wraps | Reads | Writes |
|---|---|---|---|
| `phase-research` | `/catalyst-dev:research-codebase` | `triage.json` | `thoughts/shared/research/<date>-<ticket>.md` |
| `phase-plan` | `/catalyst-dev:create-plan` | research doc | `thoughts/shared/plans/<date>-<ticket>.md` |
| `phase-verify` | _(new — no canonical wrapper)_ | `phase-implement.json` | `verify.json` with `{regression_risk, findings, tests_attempted, gates}` |
| `phase-review` | gstack `/review` (skips `/ultrareview`) | `verify.json` | `review.json` + at most ONE remediation commit |

Each skill follows the [[_phase-agent-template]] contract:
- Prelude: comms join, signal-file update, `catalyst-session` start
- Linear intermediate state transition (`researching` / `verifying` / `reviewing` from CTL-454; `planning` unchanged)
- Explicit `/goal` condition with the phase's artifact path
- Body delegates to canonical skill via the Task tool
- End block calls `phase-agent-emit-complete --status complete`
- Failure paths emit `--status failed` with a reason

**Hard contract for phase-verify**: NEVER writes application code. The skill body declares this loudly; only test files may be created. Any actionable finding lands in `verify.json` for [[phase-review]] to act on.

**Hard contract for phase-review**: NEVER invokes `/ultrareview`. Multi-agent cloud review stays user-triggered.

## Acceptance criteria (from plan §Initiative 1 Phase 4)

| Test file | Plan target | Result |
|---|---|---|
| `phase-research-e2e.test.sh` | E2E + Linear update | **28 pass** (3 test groups, 31 assertions) |
| `phase-plan-e2e.test.sh` | E2E | **22 pass** |
| `phase-verify-e2e.test.sh` | E2E + read-only constraint + schema | **30 pass** |
| `phase-review-e2e.test.sh` | E2E + `/ultrareview` forbidden | **28 pass** |
| `orchestrate-verify.test.sh` | existing — must still pass | **11 pass** (unchanged) |

Each E2E test covers:
1. SKILL.md contract — frontmatter (`name`, `user-invocable: false`, `allowed-tools`), prelude env-var contract, prior-artifact reference, output artifact path, `/goal` block, terminal emitter call.
2. Dispatch integration — `phase-agent-dispatch --phase <name> --ticket CTL-450` with `claude` stubbed: signal file shape, `bg_job_id`, prompt + env propagation.
3. Refusal path — dispatcher exits 2 + `status: refused` when prior artifact is missing.

Note: `broker-phase-lifecycle.test.sh` fails on this branch with `Cannot find package 'pino'` — confirmed pre-existing on origin/main, unrelated to these changes (this PR is markdown + bash only).

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/phase-research-e2e.test.sh` — 28 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh` — 22 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh` — 30 pass
- [x] `bash plugins/dev/scripts/__tests__/phase-review-e2e.test.sh` — 28 pass
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-verify.test.sh` — 11 pass (regression)
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` — 30 pass (regression)
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — 15 pass (regression)
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-comms.test.sh` — 16 pass (regression)
- [ ] Manual: run phase-verify against a known-buggy diff in a fixture worktree; verify `regression_risk ≥ 5` (deferred — needs CTL-449 phase-implement first to produce a real `phase-implement.json` upstream)
- [ ] Manual: run phase-review against a known-formatting-issue commit; verify it creates the remediation commit (deferred — needs CTL-449)