### PR TITLE
feat(dev): add phase-triage + phase-monitor-deploy skills (CTL-451)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# E2E test for plugins/dev/skills/phase-monitor-deploy/SKILL.md (CTL-451).
+#
+# Strategy:
+#   1. Build tempdir scratch worker dir with a fixture phase-pr.json.
+#   2. Pre-write a fixture deployment_status event into CATALYST_EVENTS_FILE
+#      so `catalyst-events wait-for` matches the historical event on its first
+#      pass (no live timing required).
+#   3. Override PHASE_CANARY_CMD to a stub that writes a fixture canary result.
+#   4. Extract the executable bash body from the skill (fenced
+#      ```bash phase-monitor-deploy-body```) and run with TICKET set.
+#   5. Assert phase-monitor-deploy.json shape + emitted event + canary stub
+#      was invoked exactly once.
+#
+# Three cases:
+#   success  — deploy success + canary success → phase.monitor-deploy.complete
+#   failure  — deploy failure → phase.monitor-deploy.failed (no canary)
+#   skipped  — no deploy event before timeout → phase.monitor-deploy.skipped
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL_FILE="${REPO_ROOT}/plugins/dev/skills/phase-monitor-deploy/SKILL.md"
+EMIT_HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "$2"; }
+assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+assert_file_exists() { if [ -f "$2" ]; then ok "$1"; else fail "$1" "missing file: $2"; fi; }
+
+if ! command -v catalyst-events >/dev/null 2>&1; then
+  echo "SKIP: catalyst-events not on PATH — phase-monitor-deploy needs it" >&2
+  exit 0
+fi
+
+[ -f "$SKILL_FILE" ]  || { echo "FAIL: skill missing: $SKILL_FILE";   exit 1; }
+[ -f "$EMIT_HELPER" ] || { echo "FAIL: helper missing: $EMIT_HELPER"; exit 1; }
+
+# Extract the executable bash body delimited by ```bash phase-monitor-deploy-body```.
+SKILL_BODY_FILE="$(mktemp -t phase-monitor-deploy-body.XXXXXX.sh)"
+awk '
+  /^```bash phase-monitor-deploy-body$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL_FILE" > "$SKILL_BODY_FILE"
+
+if [ ! -s "$SKILL_BODY_FILE" ]; then
+  echo "FAIL: could not extract phase-monitor-deploy-body block from $SKILL_FILE" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d -t phase-monitor-deploy-test.XXXXXX)"
+trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
+
+# Helper: write a fixture canonical OTel event line for a deployment_status into $1.
+# $2 = sha, $3 = env, $4 = state ("success"|"failure")
+write_deploy_event() {
+  local out_file="$1" sha="$2" env="$3" state="$4"
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg sha "$sha" --arg env "$env" --arg state "$state" \
+    '{
+      ts: $ts,
+      id: "fixture-deploy-event",
+      severityText: "INFO",
+      severityNumber: 9,
+      resource: {"service.name": "github.webhook"},
+      attributes: {
+        "event.name": "github.deployment_status",
+        "vcs.revision": $sha,
+        "deployment.environment": $env,
+        "deployment.state": $state
+      },
+      body: {payload: {state: $state}}
+    }' >> "$out_file"
+}
+
+run_case() {
+  local case_name="$1" sha="$2" deploy_state="$3" canary_status="$4" \
+        timeout_sec="$5" emit_event="$6"
+
+  local case_dir="$TMPROOT/$case_name"
+  local worker="$case_dir/worker"
+  mkdir -p "$worker" "$case_dir/bin"
+
+  # Fixture phase-pr.json
+  jq -nc --arg sha "$sha" '{
+    pr: {number: 1234, url: "https://example.com/pr/1234", mergeCommitSha: $sha}
+  }' > "$worker/phase-pr.json"
+
+  local events_file="$case_dir/events.jsonl"
+  : > "$events_file"  # create empty so wait-for sees no history
+
+  # Canary stub: writes a fixture JSON to its own stdout, records invocation.
+  cat > "$case_dir/bin/canary-stub" <<EOF
+#!/usr/bin/env bash
+echo invoked >> "$case_dir/canary-invocations.log"
+jq -nc --arg s "$canary_status" '{status: \$s, observations: ["fixture"]}'
+EOF
+  chmod +x "$case_dir/bin/canary-stub"
+
+  # Run the skill body in the background so we can append the deploy event
+  # AFTER catalyst-events wait-for has begun watching from EOF. This mirrors
+  # the production flow where the deploy webhook arrives after the worker
+  # has started waiting.
+  (
+    PATH="$case_dir/bin:$PATH" \
+    TICKET=CTL-9999 \
+    WORKER_DIR="$worker" \
+    CATALYST_EVENTS_FILE="$events_file" \
+    PHASE_DEPLOY_TIMEOUT_SEC="$timeout_sec" \
+    PHASE_DEPLOY_ENV="production" \
+    PHASE_CANARY_CMD="$case_dir/bin/canary-stub" \
+    PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
+    PHASE_EMIT_HELPER="$EMIT_HELPER" \
+      bash "$SKILL_BODY_FILE" > "$case_dir/stdout.log" 2> "$case_dir/stderr.log"
+    echo $? > "$case_dir/exit-code"
+  ) &
+  local skill_pid=$!
+
+  if [ "$emit_event" = "yes" ]; then
+    # Give wait-for time to start. Its inner loop sleeps 1s, so we wait 2s
+    # after writing to make sure the next poll picks it up.
+    sleep 2
+    write_deploy_event "$events_file" "$sha" "production" "$deploy_state"
+  fi
+
+  wait "$skill_pid"
+  echo "$case_dir"
+}
+
+echo "phase-monitor-deploy e2e tests"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 1: deploy success + canary success → phase.monitor-deploy.complete
+
+CASE_DIR="$(run_case success abc123 success success 5 yes)"
+
+EXIT="$(cat "$CASE_DIR/exit-code")"
+assert_eq "success: exit code 0" 0 "$EXIT"
+
+assert_file_exists "success: phase-monitor-deploy.json created" \
+  "$CASE_DIR/worker/phase-monitor-deploy.json"
+
+if [ -f "$CASE_DIR/worker/phase-monitor-deploy.json" ]; then
+  DSHA="$(jq -r '.deploy_sha' "$CASE_DIR/worker/phase-monitor-deploy.json")"
+  assert_eq "success: deploy_sha matches phase-pr.json" "abc123" "$DSHA"
+
+  DSTATE="$(jq -r '.deploy_state' "$CASE_DIR/worker/phase-monitor-deploy.json")"
+  assert_eq "success: deploy_state recorded" "success" "$DSTATE"
+
+  CR_STATUS="$(jq -r '.canary_result.status' "$CASE_DIR/worker/phase-monitor-deploy.json")"
+  assert_eq "success: canary_result.status recorded" "success" "$CR_STATUS"
+fi
+
+# Canary stub was invoked exactly once
+INVOCATIONS="$(wc -l < "$CASE_DIR/canary-invocations.log" 2>/dev/null | tr -d ' ')"
+assert_eq "success: canary stub invoked once" "1" "${INVOCATIONS:-0}"
+
+# Emitted event shape
+EVENT_NAME="$(jq -r '.attributes."event.name"' "$CASE_DIR/events.jsonl" \
+              | tail -1)"
+assert_eq "success: emitted phase event name" \
+  "phase.monitor-deploy.complete.CTL-9999" "$EVENT_NAME"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 2: deploy failure → phase.monitor-deploy.failed, canary NOT invoked
+
+CASE_DIR2="$(run_case failure abc456 failure success 5 yes)"
+
+EXIT2="$(cat "$CASE_DIR2/exit-code")"
+if [ "$EXIT2" -ne 0 ]; then
+  ok "failure: exits non-zero"
+else
+  fail "failure: exit code" "expected non-zero, got $EXIT2"
+fi
+
+# Canary should NOT have been invoked
+if [ ! -f "$CASE_DIR2/canary-invocations.log" ]; then
+  ok "failure: canary stub was NOT invoked"
+else
+  fail "failure: canary not invoked" "canary log exists with $(wc -l < "$CASE_DIR2/canary-invocations.log") lines"
+fi
+
+FAIL_EVENT="$(jq -r '.attributes."event.name"' "$CASE_DIR2/events.jsonl" \
+              | tail -1)"
+assert_eq "failure: emitted failed event" \
+  "phase.monitor-deploy.failed.CTL-9999" "$FAIL_EVENT"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 3: no deploy event arrives within timeout → phase.monitor-deploy.skipped
+
+CASE_DIR3="$(run_case skipped abc789 success success 1 no)"
+
+EXIT3="$(cat "$CASE_DIR3/exit-code")"
+assert_eq "skipped: exit code 0" 0 "$EXIT3"
+
+if [ -f "$CASE_DIR3/worker/phase-monitor-deploy.json" ]; then
+  SSTATE="$(jq -r '.deploy_state' "$CASE_DIR3/worker/phase-monitor-deploy.json")"
+  assert_eq "skipped: deploy_state == skipped" "skipped" "$SSTATE"
+fi
+
+SKIP_EVENT="$(jq -r '.attributes."event.name"' "$CASE_DIR3/events.jsonl" \
+              | tail -1)"
+assert_eq "skipped: emitted skipped event" \
+  "phase.monitor-deploy.skipped.CTL-9999" "$SKIP_EVENT"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 4: phase-pr.json missing → failed event + non-zero
+
+MISS_DIR="$TMPROOT/missing"
+mkdir -p "$MISS_DIR/worker"  # but NO phase-pr.json
+
+PATH="$PATH" \
+TICKET=CTL-8888 \
+WORKER_DIR="$MISS_DIR/worker" \
+CATALYST_EVENTS_FILE="$MISS_DIR/events.jsonl" \
+PHASE_DEPLOY_TIMEOUT_SEC=1 \
+PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
+PHASE_EMIT_HELPER="$EMIT_HELPER" \
+  bash "$SKILL_BODY_FILE" > "$MISS_DIR/stdout.log" 2> "$MISS_DIR/stderr.log"
+MISS_EXIT=$?
+
+if [ "$MISS_EXIT" -ne 0 ]; then
+  ok "missing-pr: exits non-zero when phase-pr.json is absent"
+else
+  fail "missing-pr: exit code" "expected non-zero, got $MISS_EXIT"
+fi
+
+MISS_EVENT="$(jq -r '.attributes."event.name"' "$MISS_DIR/events.jsonl" 2>/dev/null \
+              | tail -1)"
+assert_eq "missing-pr: emits failed event" \
+  "phase.monitor-deploy.failed.CTL-8888" "$MISS_EVENT"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# E2E test for plugins/dev/skills/phase-triage/SKILL.md (CTL-451 Initiative 1 Phase 5).
+#
+# Strategy:
+#   1. Build a tempdir scratch worker dir.
+#   2. Stand up a fake `linearis` shim on PATH:
+#        - `linearis issues read <id>` → prints fixture JSON
+#        - `linearis issues discuss <id> --body <text>` → records call to a log
+#        - `linearis issues update <id> --labels ... --label-mode add` → records call
+#   3. Point CATALYST_EVENTS_FILE at a tempfile.
+#   4. Extract the executable bash body from the skill (fenced by
+#      `bash phase-triage-body`).
+#   5. Run it with TICKET set; assert artifact + comment + label + event.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL_FILE="${REPO_ROOT}/plugins/dev/skills/phase-triage/SKILL.md"
+EMIT_HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "$2"; }
+
+assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+assert_nonempty() { if [ -n "$2" ]; then ok "$1"; else fail "$1" "expected non-empty value"; fi; }
+assert_file_exists() { if [ -f "$2" ]; then ok "$1"; else fail "$1" "missing file: $2"; fi; }
+
+[ -f "$SKILL_FILE" ]   || { echo "FAIL: skill missing: $SKILL_FILE";   exit 1; }
+[ -f "$EMIT_HELPER" ]  || { echo "FAIL: helper missing: $EMIT_HELPER"; exit 1; }
+
+# Extract the executable bash body delimited by ```bash phase-triage-body``` fences.
+SKILL_BODY_FILE="$(mktemp -t phase-triage-body.XXXXXX.sh)"
+awk '
+  /^```bash phase-triage-body$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL_FILE" > "$SKILL_BODY_FILE"
+
+if [ ! -s "$SKILL_BODY_FILE" ]; then
+  echo "FAIL: could not extract phase-triage-body block from $SKILL_FILE" >&2
+  exit 1
+fi
+
+# Per-case runner. $1=case-name, $2=fixture-json-path, $3=ticket, $4=expected-status
+TMPROOT="$(mktemp -d -t phase-triage-test.XXXXXX)"
+trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
+
+run_case() {
+  local case_name="$1" fixture="$2" ticket="$3"
+  local case_dir="$TMPROOT/$case_name"
+  mkdir -p "$case_dir/bin"
+
+  # Build the `linearis` stub.
+  cat > "$case_dir/bin/linearis" <<EOF
+#!/usr/bin/env bash
+LOG="$case_dir/linearis-calls.log"
+case "\$1" in
+  issues)
+    case "\$2" in
+      read)
+        printf '%s\n' "\$@" >> "\$LOG"
+        cat "$fixture"
+        ;;
+      discuss)
+        printf '%s\n' "\$@" >> "\$LOG"
+        # Mirror linearis: return JSON-ish "ok"
+        echo '{"ok": true, "kind": "discuss"}'
+        ;;
+      update)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{"ok": true, "kind": "update"}'
+        ;;
+      *)
+        printf 'linearis stub: unsupported issues subcommand: %s\n' "\$2" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    printf 'linearis stub: unsupported domain: %s\n' "\$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "$case_dir/bin/linearis"
+
+  # Run the skill body with the stub on PATH.
+  local events_file="$case_dir/events.jsonl"
+
+  PATH="$case_dir/bin:$PATH" \
+  TICKET="$ticket" \
+  WORKER_DIR="$case_dir/worker" \
+  CATALYST_EVENTS_FILE="$events_file" \
+  PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
+  PHASE_EMIT_HELPER="$EMIT_HELPER" \
+    bash "$SKILL_BODY_FILE" > "$case_dir/stdout.log" 2> "$case_dir/stderr.log"
+  echo $? > "$case_dir/exit-code"
+
+  # Stash for later assertions
+  echo "$case_dir"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 1: happy path — a feature-classified ticket with multiple deps + acronyms.
+
+echo "phase-triage e2e tests"
+
+FIXTURE_HAPPY="$TMPROOT/fixture-happy.json"
+cat > "$FIXTURE_HAPPY" <<'EOF'
+{
+  "identifier": "CTL-9999",
+  "title": "Add OTel exporter for the CLI",
+  "description": "Wire the CLI tool to emit OTel events on every API call. See CTL-447 and CTL-448 for prior art. The PR should follow MVP scope — no fancy span sampling, just basic E2E coverage.",
+  "labels": {"nodes": []}
+}
+EOF
+
+CASE_DIR="$(run_case happy "$FIXTURE_HAPPY" CTL-9999)"
+
+# Assert: skill exited 0
+EXIT_CODE="$(cat "$CASE_DIR/exit-code")"
+assert_eq "happy: exit code 0" 0 "$EXIT_CODE"
+
+# Assert: triage.json exists and parses
+TRIAGE_FILE="$CASE_DIR/worker/triage.json"
+assert_file_exists "happy: triage.json created" "$TRIAGE_FILE"
+
+if [ -f "$TRIAGE_FILE" ]; then
+  CLASSIFICATION="$(jq -r '.classification' "$TRIAGE_FILE")"
+  case "$CLASSIFICATION" in
+    feature|bug|docs|refactor|chore) ok "happy: classification is a valid enum value" ;;
+    *) fail "happy: classification enum" "got '$CLASSIFICATION'" ;;
+  esac
+
+  SCOPE="$(jq -r '.estimated_scope' "$TRIAGE_FILE")"
+  case "$SCOPE" in
+    small|medium|large|epic) ok "happy: estimated_scope is a valid enum value" ;;
+    *) fail "happy: scope enum" "got '$SCOPE'" ;;
+  esac
+
+  ACRONYM_COUNT="$(jq '.acronyms_expanded | length' "$TRIAGE_FILE")"
+  if [ "${ACRONYM_COUNT:-0}" -ge 1 ]; then
+    ok "happy: at least one acronym expanded (OTel/CLI/API/PR/MVP/E2E all present)"
+  else
+    fail "happy: acronym count" "expected ≥1 acronym, got $ACRONYM_COUNT"
+  fi
+
+  DEPS="$(jq -c '.dependencies' "$TRIAGE_FILE")"
+  # Expect CTL-447 and CTL-448, but NOT CTL-9999 (self).
+  EXPECTED_DEPS='["CTL-447","CTL-448"]'
+  assert_eq "happy: dependencies match (excludes self)" "$EXPECTED_DEPS" "$DEPS"
+fi
+
+# Assert: linearis discuss + update were called
+LINEARIS_LOG="$CASE_DIR/linearis-calls.log"
+if grep -q '^discuss$' "$LINEARIS_LOG" 2>/dev/null; then
+  ok "happy: linearis issues discuss was called"
+else
+  fail "happy: discuss call" "no 'discuss' entry in linearis log:$(printf '\n%s' "$(cat "$LINEARIS_LOG" 2>/dev/null)")"
+fi
+
+if grep -q '^update$' "$LINEARIS_LOG" 2>/dev/null; then
+  ok "happy: linearis issues update was called"
+else
+  fail "happy: update call" "no 'update' entry in linearis log"
+fi
+
+# Assert: emitted event has the right shape
+EVENT_NAME="$(jq -r '.attributes."event.name"' "$CASE_DIR/events.jsonl" 2>/dev/null | head -1)"
+assert_eq "happy: emitted event name" "phase.triage.complete.CTL-9999" "$EVENT_NAME"
+
+EVENT_TICKET="$(jq -r '.attributes."linear.issue.identifier"' "$CASE_DIR/events.jsonl" 2>/dev/null | head -1)"
+assert_eq "happy: event has linear.issue.identifier" "CTL-9999" "$EVENT_TICKET"
+
+EVENT_PHASE="$(jq -r '.body.payload.phase_name' "$CASE_DIR/events.jsonl" 2>/dev/null | head -1)"
+assert_eq "happy: event payload has phase_name" "triage" "$EVENT_PHASE"
+
+EVENT_CLASS="$(jq -r '.body.payload.classification' "$CASE_DIR/events.jsonl" 2>/dev/null | head -1)"
+assert_nonempty "happy: event payload includes classification" "$EVENT_CLASS"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 2: explicit bug classification + small scope
+
+FIXTURE_BUG="$TMPROOT/fixture-bug.json"
+cat > "$FIXTURE_BUG" <<'EOF'
+{
+  "identifier": "CTL-7777",
+  "title": "Bug: catalyst-events tail leaks fd",
+  "description": "Found in prod. Fix the leak.",
+  "labels": {"nodes": []}
+}
+EOF
+
+CASE_DIR2="$(run_case bug "$FIXTURE_BUG" CTL-7777)"
+EXIT_CODE2="$(cat "$CASE_DIR2/exit-code")"
+assert_eq "bug: exit code 0" 0 "$EXIT_CODE2"
+
+if [ -f "$CASE_DIR2/worker/triage.json" ]; then
+  CLASS2="$(jq -r '.classification' "$CASE_DIR2/worker/triage.json")"
+  assert_eq "bug: classified as bug" "bug" "$CLASS2"
+
+  SCOPE2="$(jq -r '.estimated_scope' "$CASE_DIR2/worker/triage.json")"
+  assert_eq "bug: scope is small" "small" "$SCOPE2"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 3: linearis read fails — skill must emit failed event + nonzero exit
+
+FAIL_DIR="$TMPROOT/lin-fail"
+mkdir -p "$FAIL_DIR/bin"
+cat > "$FAIL_DIR/bin/linearis" <<'EOF'
+#!/usr/bin/env bash
+echo "linearis stub: simulated failure" >&2
+exit 1
+EOF
+chmod +x "$FAIL_DIR/bin/linearis"
+
+PATH="$FAIL_DIR/bin:$PATH" \
+TICKET=CTL-9001 \
+WORKER_DIR="$FAIL_DIR/worker" \
+CATALYST_EVENTS_FILE="$FAIL_DIR/events.jsonl" \
+PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
+PHASE_EMIT_HELPER="$EMIT_HELPER" \
+  bash "$SKILL_BODY_FILE" > "$FAIL_DIR/stdout.log" 2> "$FAIL_DIR/stderr.log"
+FAIL_EXIT=$?
+
+if [ "$FAIL_EXIT" -ne 0 ]; then
+  ok "lin-fail: exits non-zero when linearis read fails"
+else
+  fail "lin-fail: exit code" "expected non-zero, got $FAIL_EXIT"
+fi
+
+FAIL_EVENT="$(jq -r '.attributes."event.name"' "$FAIL_DIR/events.jsonl" 2>/dev/null | head -1)"
+assert_eq "lin-fail: emits phase.triage.failed event" "phase.triage.failed.CTL-9001" "$FAIL_EVENT"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/lib/phase-emit-complete.sh
+++ b/plugins/dev/scripts/lib/phase-emit-complete.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# phase-emit-complete.sh — emit a `phase.<name>.<status>.<ticket>` canonical
+# OTel event so the broker's phase_lifecycle router (CTL-447) wakes
+# whichever orchestrator interest subscribed to this phase boundary.
+#
+# Sourceable helper used by greenfield phase-agent skills shipped in CTL-451
+# (phase-triage, phase-monitor-deploy). It is intentionally the minimum
+# correct surface — Phase 6 / CTL-448 will absorb a richer
+# `phase-agent-emit-complete` script that also dispatches the next phase
+# and updates signal files. Keeping this helper small means that future
+# absorption is mechanical.
+#
+# Usage (after sourcing):
+#   emit_phase_complete --phase <name> --ticket <id> \
+#                       --status {complete|failed|skipped} \
+#                       [--reason <text>] [--payload-json <json>]
+#
+# Required env (read; never required):
+#   CATALYST_SESSION_ID        used for span_id derivation
+#   CATALYST_ORCHESTRATOR_ID   used for trace_id derivation
+#   CATALYST_EVENTS_FILE       test override; takes precedence over CATALYST_EVENTS_DIR
+#   CATALYST_EVENTS_DIR        directory to append YYYY-MM.jsonl into
+#                              (default: $CATALYST_DIR/events, default: $HOME/catalyst/events)
+
+if [[ -n "${__CATALYST_PHASE_EMIT_SOURCED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+__CATALYST_PHASE_EMIT_SOURCED=1
+
+__PEC_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# canonical-event.sh provides build_canonical_line / canonical_jsonl_append /
+# derive_trace_id / derive_span_id / plugin_version.
+# shellcheck disable=SC1091
+. "${__PEC_LIB_DIR}/canonical-event.sh"
+
+emit_phase_complete() {
+  local phase="" ticket="" status="" reason="" payload="null"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --phase)        phase="$2"; shift 2 ;;
+      --ticket)       ticket="$2"; shift 2 ;;
+      --status)       status="$2"; shift 2 ;;
+      --reason)       reason="$2"; shift 2 ;;
+      --payload-json) payload="${2:-null}"; shift 2 ;;
+      *) echo "emit_phase_complete: unknown flag: $1" >&2; return 1 ;;
+    esac
+  done
+
+  [[ -n "$phase"  ]] || { echo "emit_phase_complete: --phase required"  >&2; return 1; }
+  [[ -n "$ticket" ]] || { echo "emit_phase_complete: --ticket required" >&2; return 1; }
+  [[ -n "$status" ]] || { echo "emit_phase_complete: --status required" >&2; return 1; }
+
+  case "$status" in
+    complete|failed|skipped) ;;
+    *) echo "emit_phase_complete: --status must be complete|failed|skipped" >&2; return 1 ;;
+  esac
+
+  local severity="INFO" event_name
+  [[ "$status" == "failed" ]] && severity="WARN"
+  event_name="phase.${phase}.${status}.${ticket}"
+
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+
+  local trace_id span_id
+  trace_id="$(derive_trace_id "${CATALYST_ORCHESTRATOR_ID:-}" "${CATALYST_SESSION_ID:-}")"
+  span_id="$(derive_span_id "${ticket}" "${CATALYST_SESSION_ID:-}")"
+
+  local message="$reason"
+  if [[ -z "$message" ]]; then
+    case "$status" in
+      complete) message="Phase ${phase} complete on ${ticket}" ;;
+      failed)   message="Phase ${phase} failed on ${ticket}" ;;
+      skipped)  message="Phase ${phase} skipped on ${ticket}" ;;
+    esac
+  fi
+
+  # Merge {phase_name: <name>} into the payload so downstream consumers can
+  # filter by phase without re-parsing event.name. The phase NAME is distinct
+  # from catalyst.phase (the numeric phase index used by oneshot), so we don't
+  # pass --phase to build_canonical_line.
+  local enriched_payload
+  if [[ "$payload" == "null" || -z "$payload" ]]; then
+    enriched_payload="$(jq -nc --arg p "$phase" '{phase_name: $p}')"
+  else
+    enriched_payload="$(printf '%s' "$payload" | jq -c --arg p "$phase" '. + {phase_name: $p}')" || enriched_payload="$payload"
+  fi
+
+  local line
+  line="$(build_canonical_line \
+    --ts "$ts" \
+    --severity "$severity" \
+    --service "catalyst.phase-agent" \
+    --event-name "$event_name" \
+    --trace-id "$trace_id" \
+    --span-id "$span_id" \
+    --entity "phase" \
+    --action "$status" \
+    --linear-ticket "$ticket" \
+    --orch "${CATALYST_ORCHESTRATOR_ID:-}" \
+    --session "${CATALYST_SESSION_ID:-}" \
+    --message "$message" \
+    --payload-json "$enriched_payload")" || return 1
+
+  # Test override: write the single line directly to the file.
+  if [[ -n "${CATALYST_EVENTS_FILE:-}" ]]; then
+    mkdir -p "$(dirname "$CATALYST_EVENTS_FILE")" 2>/dev/null || true
+    printf '%s\n' "$line" >> "$CATALYST_EVENTS_FILE" || return 1
+    return 0
+  fi
+
+  # Production: append into the configured events directory's month file.
+  local events_dir
+  events_dir="${CATALYST_EVENTS_DIR:-${CATALYST_DIR:-$HOME/catalyst}/events}"
+  canonical_jsonl_append "$events_dir" "$line"
+}
+
+# When run as a script (not sourced), expose the function via CLI shimming so
+# downstream callers without bash-source semantics can still invoke it.
+# Detect script-mode by checking BASH_SOURCE[0] vs $0.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  emit_phase_complete "$@"
+fi

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: phase-monitor-deploy
+description: Phase agent that watches the post-merge deployment for a ticket. Reads the merge SHA from phase-pr.json, subscribes via `catalyst-events wait-for` to deploy events on that SHA, then delegates a live verification check to the /canary skill (gstack). Emits phase.monitor-deploy.complete.<TICKET> on canary success, phase.monitor-deploy.failed.<TICKET> on deploy or canary failure, and phase.monitor-deploy.skipped.<TICKET> when no deploy event arrives before the timeout. Dispatched by the phase-agent orchestrator (CTL-452) — not user-invocable.
+disable-model-invocation: true
+user-invocable: false
+allowed-tools: Bash, Read, Write
+version: 1.0.0
+---
+
+# phase-monitor-deploy
+
+Greenfield phase agent shipped in CTL-451 (Initiative 1 Phase 5). Runs after `phase-pr`
+has merged the PR. Subscribes to GitHub `deployment_status` events on the merge commit
+SHA, then delegates canary verification to `/canary` (gstack) once the deploy reaches a
+terminal state.
+
+Optimized for Haiku — the body is purely procedural shell. The model context is only used
+to gate the `/canary` skill invocation (which itself decides how aggressively to probe
+the live URL).
+
+## Inputs
+
+Environment:
+- `TICKET` — Linear identifier (e.g. `CTL-451`). Required.
+- `WORKER_DIR` — directory containing `phase-pr.json` (read) and where
+  `phase-monitor-deploy.json` (write) lands. Defaults to
+  `${ORCH_DIR}/workers/${TICKET}` if set, else `$(pwd)`.
+- `PHASE_DEPLOY_TIMEOUT_SEC` — seconds to wait for a `deployment_status` event matching
+  the merge SHA. Default `1800` (30 minutes). Setting to a small value is the
+  documented way to skip deploy verification in test/dev environments.
+- `PHASE_DEPLOY_ENV` — GitHub Deployment environment name to match (default
+  `production`). Set per-project as needed.
+- `PHASE_CANARY_CMD` — command line used to invoke the canary skill. Default
+  `claude --model haiku -p /canary --output-format json`. Test runners override this with
+  a stub that emits a fixture canary result.
+- `CATALYST_ORCHESTRATOR_ID`, `CATALYST_SESSION_ID` — used for event trace/span id derivation.
+
+## phase-pr.json contract (input shape)
+
+```json
+{
+  "pr": {
+    "number": 1234,
+    "url": "https://github.com/org/repo/pull/1234",
+    "mergeCommitSha": "abc123..."
+  }
+}
+```
+
+The skill reads `.pr.mergeCommitSha` only; everything else is informational.
+
+## Body
+
+```bash phase-monitor-deploy-body
+set -uo pipefail
+
+__PM_SCRIPT_PATH="${BASH_SOURCE[0]:-${0}}"
+__PM_SKILL_DIR="$(cd "$(dirname "$__PM_SCRIPT_PATH")" && pwd 2>/dev/null || pwd)"
+__PM_REPO_ROOT="${PHASE_AGENT_REPO_ROOT:-$(cd "$__PM_SKILL_DIR/../../../.." 2>/dev/null && pwd || pwd)}"
+__PM_LIB="${PHASE_EMIT_HELPER:-${__PM_REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh}"
+
+if [[ ! -r "$__PM_LIB" ]]; then
+  echo "phase-monitor-deploy: cannot find phase-emit-complete.sh at $__PM_LIB" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$__PM_LIB"
+
+: "${TICKET:?phase-monitor-deploy: TICKET env var required}"
+
+WORKER_DIR="${WORKER_DIR:-${ORCH_DIR:+${ORCH_DIR}/workers/${TICKET}}}"
+WORKER_DIR="${WORKER_DIR:-$(pwd)}"
+mkdir -p "$WORKER_DIR"
+
+DEPLOY_TIMEOUT="${PHASE_DEPLOY_TIMEOUT_SEC:-1800}"
+DEPLOY_ENV="${PHASE_DEPLOY_ENV:-production}"
+CANARY_CMD="${PHASE_CANARY_CMD:-claude --model haiku -p /canary --output-format json}"
+
+# 1. Read merge SHA from the prior phase artifact.
+PR_FILE="$WORKER_DIR/phase-pr.json"
+if [[ ! -f "$PR_FILE" ]]; then
+  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    --reason "phase-pr.json missing at $PR_FILE"
+  exit 1
+fi
+
+MERGE_SHA="$(jq -r '.pr.mergeCommitSha // empty' "$PR_FILE" 2>/dev/null)"
+if [[ -z "$MERGE_SHA" ]]; then
+  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    --reason "phase-pr.json has empty .pr.mergeCommitSha"
+  exit 1
+fi
+
+# 2. Subscribe to deployment_status events for this SHA. The filter accepts any
+#    deployment_status event whose vcs.revision matches and whose deployment.environment
+#    matches PHASE_DEPLOY_ENV. wait-for scans the file from the start (it is not a true
+#    live tail) so historical events fire immediately, which is the behavior the test
+#    runner depends on.
+DEPLOY_FILTER='(.attributes."event.name" | startswith("github.deployment_status"))
+               and .attributes."vcs.revision" == "'"$MERGE_SHA"'"
+               and .attributes."deployment.environment" == "'"$DEPLOY_ENV"'"'
+
+DEPLOY_EVENT="$(catalyst-events wait-for \
+  --filter "$DEPLOY_FILTER" \
+  --timeout "$DEPLOY_TIMEOUT" 2>/dev/null || true)"
+
+DEPLOY_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ -z "$DEPLOY_EVENT" ]]; then
+  # 2a. No deploy event observed — emit `skipped` and exit successfully. The
+  #     orchestrator treats skipped as success because the PR is already merged
+  #     and the deploy pipeline simply did not signal this code path.
+  jq -nc \
+    --arg ticket "$TICKET" \
+    --arg sha "$MERGE_SHA" \
+    --arg env "$DEPLOY_ENV" \
+    --arg ts "$DEPLOY_TIME" \
+    '{
+      ticket: $ticket,
+      deploy_sha: $sha,
+      deploy_env: $env,
+      deploy_state: "skipped",
+      deploy_time: $ts,
+      canary_result: null,
+      completed_at: $ts,
+      reason: "no deployment_status event matched within timeout"
+    }' > "$WORKER_DIR/phase-monitor-deploy.json"
+
+  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status skipped \
+    --reason "no deployment_status event for $MERGE_SHA on env $DEPLOY_ENV within ${DEPLOY_TIMEOUT}s" \
+    --payload-json "$(cat "$WORKER_DIR/phase-monitor-deploy.json")"
+  exit 0
+fi
+
+DEPLOY_STATE="$(printf '%s' "$DEPLOY_EVENT" \
+  | jq -r '.attributes."deployment.state" // .body.payload.state // empty' 2>/dev/null)"
+
+# 3. Branch on deploy state.
+case "$DEPLOY_STATE" in
+  success)
+    : # continue to canary
+    ;;
+  failure|error)
+    jq -nc \
+      --arg ticket "$TICKET" \
+      --arg sha "$MERGE_SHA" \
+      --arg env "$DEPLOY_ENV" \
+      --arg state "$DEPLOY_STATE" \
+      --arg ts "$DEPLOY_TIME" \
+      '{
+        ticket: $ticket,
+        deploy_sha: $sha,
+        deploy_env: $env,
+        deploy_state: $state,
+        deploy_time: $ts,
+        canary_result: null,
+        completed_at: $ts
+      }' > "$WORKER_DIR/phase-monitor-deploy.json"
+    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+      --reason "deployment_status reported state=$DEPLOY_STATE for $MERGE_SHA on $DEPLOY_ENV" \
+      --payload-json "$(cat "$WORKER_DIR/phase-monitor-deploy.json")"
+    exit 1
+    ;;
+  *)
+    # pending / in_progress / queued — wait-for already filtered terminal states
+    # via the test fixture, so this branch is mainly defensive. Treat as failed
+    # to escalate; future work can re-enter the wait loop instead.
+    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+      --reason "unexpected non-terminal deployment state: $DEPLOY_STATE"
+    exit 1
+    ;;
+esac
+
+# 4. Run the canary check. The default command shells out to `claude -p /canary`.
+#    The test runner overrides PHASE_CANARY_CMD to a stub that writes a fixture
+#    result. Either way, the command is expected to print JSON on stdout that
+#    parses to an object with at least a `status` field ("success"|"failed").
+CANARY_OUT_FILE="$WORKER_DIR/canary-output.json"
+CANARY_STDERR_FILE="$WORKER_DIR/canary-stderr.log"
+
+if ! eval "$CANARY_CMD" > "$CANARY_OUT_FILE" 2> "$CANARY_STDERR_FILE"; then
+  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    --reason "canary command exited non-zero (see $CANARY_STDERR_FILE)"
+  exit 1
+fi
+
+if ! jq -e . "$CANARY_OUT_FILE" >/dev/null 2>&1; then
+  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    --reason "canary stdout did not parse as JSON"
+  exit 1
+fi
+
+CANARY_STATUS="$(jq -r '.status // empty' "$CANARY_OUT_FILE")"
+
+# 5. Compose phase-monitor-deploy.json.
+RESULT_FILE="$WORKER_DIR/phase-monitor-deploy.json"
+jq -nc \
+  --arg ticket "$TICKET" \
+  --arg sha "$MERGE_SHA" \
+  --arg env "$DEPLOY_ENV" \
+  --arg ts "$DEPLOY_TIME" \
+  --slurpfile canary "$CANARY_OUT_FILE" \
+  '{
+    ticket: $ticket,
+    deploy_sha: $sha,
+    deploy_env: $env,
+    deploy_state: "success",
+    deploy_time: $ts,
+    canary_result: ($canary | first),
+    completed_at: $ts
+  }' > "$RESULT_FILE"
+
+# 6. Emit the canonical phase event based on canary status.
+if [[ "$CANARY_STATUS" == "success" ]]; then
+  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status complete \
+    --payload-json "$(cat "$RESULT_FILE")"
+  exit 0
+fi
+
+emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+  --reason "canary status=${CANARY_STATUS:-unknown}" \
+  --payload-json "$(cat "$RESULT_FILE")"
+exit 1
+```
+
+## What an Opus-mode invocation adds
+
+Haiku is the default. If the orchestrator routes this to an Opus agent (e.g., for a
+high-stakes deploy where the canary is borderline), the agent should:
+
+1. Run the bash body to drive the deploy event wait + canary invocation.
+2. Read `canary-output.json` and decide whether the canary result is materially actionable
+   beyond the binary `status` field (e.g., performance regressions worth flagging).
+3. Optionally extend the comment posted by a later phase agent with model-grade insight.
+
+The bash body alone is enough to drive the state machine. Opus-mode add-ons are pure
+upside.

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: phase-triage
+description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies dependencies, estimates scope, writes triage.json, posts a triaged comment to Linear, and applies the `triaged` label. Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) — not user-invocable.
+disable-model-invocation: true
+user-invocable: false
+allowed-tools: Bash, Read, Write, Grep
+version: 1.0.0
+---
+
+# phase-triage
+
+Greenfield phase agent shipped in CTL-451 (Initiative 1 Phase 5). Reads a Linear ticket,
+produces a structured triage analysis, and lands the analysis as a Linear comment + label
+so subsequent phase agents (research, plan, …) can rely on the classification.
+
+The skill is dispatched in two modes:
+
+- **Production**: An Opus phase agent reads `triage.json` placeholder fields produced by
+  the bash body below, then refines them with model-quality analysis (acronym expansion,
+  judgment-of-scope, dep inference) before the comment is posted.
+- **CI / test runner**: The bash body alone is self-sufficient — it derives all five
+  fields deterministically from the ticket JSON so e2e tests run without a model call.
+
+Both modes produce the same `triage.json` shape and emit the same canonical phase event.
+
+## Setup prerequisite
+
+The `triaged` workspace label must already exist in Linear. The skill applies it via
+`linearis issues update --labels triaged --label-mode add` and tolerates a non-zero exit
+(logs a warning, does not fail the phase). Future work in CTL-452 may add a
+`linearis labels create` call to bootstrap the label.
+
+## Inputs
+
+Environment:
+- `TICKET` — Linear identifier (e.g. `CTL-451`). Required.
+- `WORKER_DIR` — output directory for `triage.json`. Defaults to
+  `${ORCH_DIR}/workers/${TICKET}` if set, else `$(pwd)`.
+- `ORCH_DIR`, `CATALYST_ORCHESTRATOR_ID`, `CATALYST_SESSION_ID` — used for trace/span
+  id derivation in the emitted event; all optional.
+
+## Body
+
+```bash phase-triage-body
+set -uo pipefail
+
+# Resolve repo root from the skill location so the helper path works whether
+# run from a worktree, the plugin cache, or a checked-out clone.
+__PT_SCRIPT_PATH="${BASH_SOURCE[0]:-${0}}"
+__PT_SKILL_DIR="$(cd "$(dirname "$__PT_SCRIPT_PATH")" && pwd 2>/dev/null || pwd)"
+__PT_REPO_ROOT="${PHASE_AGENT_REPO_ROOT:-$(cd "$__PT_SKILL_DIR/../../../.." 2>/dev/null && pwd || pwd)}"
+__PT_LIB="${PHASE_EMIT_HELPER:-${__PT_REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh}"
+
+if [[ ! -r "$__PT_LIB" ]]; then
+  echo "phase-triage: cannot find phase-emit-complete.sh at $__PT_LIB" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$__PT_LIB"
+
+: "${TICKET:?phase-triage: TICKET env var required}"
+
+WORKER_DIR="${WORKER_DIR:-${ORCH_DIR:+${ORCH_DIR}/workers/${TICKET}}}"
+WORKER_DIR="${WORKER_DIR:-$(pwd)}"
+mkdir -p "$WORKER_DIR"
+
+# 1. Read ticket via linearis (test stubs override $PATH).
+TICKET_JSON_FILE="$(mktemp)"
+trap 'rm -f "$TICKET_JSON_FILE"' EXIT
+
+if ! linearis issues read "$TICKET" > "$TICKET_JSON_FILE" 2>/dev/null; then
+  emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
+    --reason "linearis issues read failed"
+  exit 1
+fi
+
+if ! jq -e . "$TICKET_JSON_FILE" >/dev/null 2>&1; then
+  emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
+    --reason "linearis returned non-JSON output"
+  exit 1
+fi
+
+TITLE="$(jq -r '.title // ""' "$TICKET_JSON_FILE")"
+DESCRIPTION="$(jq -r '.description // ""' "$TICKET_JSON_FILE")"
+COMBINED="${TITLE}
+${DESCRIPTION}"
+
+# 2. Derive the five triage fields deterministically (the bash fallback path).
+
+# 2a. Classification — first-match over a small regex table.
+classify() {
+  local txt; txt="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$txt" in
+    *' bug '*|*'fix'*|*'bugfix'*|*'broken'*|*'regression'*) echo bug ;;
+    *' doc '*|*'docs'*|*'documentation'*|*'readme'*)        echo docs ;;
+    *'refactor'*|*'rename'*|*'cleanup'*|*'extract '*)        echo refactor ;;
+    *'chore'*|*'bump'*|*'dependency update'*|*'deps:'*)      echo chore ;;
+    *)                                                       echo feature ;;
+  esac
+}
+CLASSIFICATION="$(classify " $COMBINED ")"
+
+# 2b. Estimated scope — word count thresholds.
+WORD_COUNT="$(printf '%s' "$DESCRIPTION" | wc -w | tr -d ' ')"
+if   [ "$WORD_COUNT" -lt 150  ]; then ESTIMATED_SCOPE=small
+elif [ "$WORD_COUNT" -lt 400  ]; then ESTIMATED_SCOPE=medium
+elif [ "$WORD_COUNT" -lt 1000 ]; then ESTIMATED_SCOPE=large
+else                                  ESTIMATED_SCOPE=epic
+fi
+
+# 2c. Acronym expansion — built-in dictionary; only emit acronyms actually present
+#    in the title+description.
+acronyms_json() {
+  local txt="$1"
+  jq -nc --arg t "$txt" '
+    [
+      {a:"PR",  e:"Pull Request"},
+      {a:"CI",  e:"Continuous Integration"},
+      {a:"CLI", e:"Command-Line Interface"},
+      {a:"API", e:"Application Programming Interface"},
+      {a:"MVP", e:"Minimum Viable Product"},
+      {a:"TDD", e:"Test-Driven Development"},
+      {a:"E2E", e:"End-to-End"},
+      {a:"SHA", e:"Secure Hash Algorithm"},
+      {a:"UUID",e:"Universally Unique Identifier"},
+      {a:"JSON",e:"JavaScript Object Notation"},
+      {a:"OTel",e:"OpenTelemetry"},
+      {a:"OTLP",e:"OpenTelemetry Line Protocol"}
+    ]
+    | map(.a as $acr | select($t | test("\\b" + $acr + "\\b")))
+    | map({acronym: .a, expansion: .e})
+  '
+}
+ACRONYMS_EXPANDED="$(acronyms_json "$COMBINED")"
+
+# 2d. Dependencies — other CTL-style identifiers referenced in body, excluding self.
+#     Match any TEAM-NNN pattern; dedupe; exclude the ticket itself.
+DEPENDENCIES="$(printf '%s\n' "$COMBINED" \
+  | grep -oE '[A-Z][A-Z0-9_]*-[0-9]+' 2>/dev/null \
+  | sort -u \
+  | grep -v -x "$TICKET" \
+  | jq -R . | jq -sc .)"
+DEPENDENCIES="${DEPENDENCIES:-[]}"
+
+# 2e. Summary — first paragraph of description, trimmed.
+SUMMARY="$(printf '%s' "$DESCRIPTION" | awk 'BEGIN{RS=""} {print; exit}' | head -c 400)"
+
+# 3. Compose triage.json.
+TRIAGE_FILE="$WORKER_DIR/triage.json"
+jq -nc \
+  --arg ticket "$TICKET" \
+  --arg classification "$CLASSIFICATION" \
+  --arg scope "$ESTIMATED_SCOPE" \
+  --argjson acronyms "$ACRONYMS_EXPANDED" \
+  --argjson dependencies "$DEPENDENCIES" \
+  --arg summary "$SUMMARY" \
+  --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{
+    ticket: $ticket,
+    classification: $classification,
+    estimated_scope: $scope,
+    acronyms_expanded: $acronyms,
+    dependencies: $dependencies,
+    summary: $summary,
+    generated_at: $generated_at
+  }' > "$TRIAGE_FILE"
+
+# 4. Post triage comment to Linear.
+# Render the dep + acronym lists with jq using single-quoted jq programs and
+# Unicode escapes for backticks (`) so the surrounding bash heredoc does
+# not need to escape them.
+DEPS_RENDERED="$(printf '%s' "$DEPENDENCIES" | jq -r '
+  if length == 0 then "_none detected_"
+  else map("`" + . + "`") | join(", ")
+  end
+')"
+ACR_RENDERED="$(printf '%s' "$ACRONYMS_EXPANDED" | jq -r '
+  if length == 0 then "_none detected_"
+  else map("`" + .acronym + "`=" + .expansion) | join(", ")
+  end
+')"
+
+COMMENT_BODY="$(cat <<EOF
+**Phase Triage**
+
+- **Classification**: ${CLASSIFICATION}
+- **Estimated scope**: ${ESTIMATED_SCOPE} (description word count: ${WORD_COUNT})
+- **Dependencies**: ${DEPS_RENDERED}
+- **Acronyms expanded**: ${ACR_RENDERED}
+
+_Triaged automatically by the phase-triage agent (CTL-451)._
+EOF
+)"
+
+if ! linearis issues discuss "$TICKET" --body "$COMMENT_BODY" >/dev/null 2>&1; then
+  emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
+    --reason "linearis issues discuss failed"
+  exit 1
+fi
+
+# 5. Apply the `triaged` label. Tolerate failure (label may not exist yet).
+if ! linearis issues update "$TICKET" --labels triaged --label-mode add >/dev/null 2>&1; then
+  echo "phase-triage: warning — could not apply triaged label (does it exist in the workspace?)" >&2
+fi
+
+# 6. Emit the canonical phase event.
+emit_phase_complete --phase triage --ticket "$TICKET" --status complete \
+  --payload-json "$(cat "$TRIAGE_FILE")"
+exit 0
+```
+
+## What an Opus-mode invocation adds
+
+The bash body above is fully self-sufficient — the e2e test exercises only that. When an
+Opus agent runs this skill, it should:
+
+1. Run the bash body to produce the baseline `triage.json` and Linear comment.
+2. Read the ticket back, refine the classification + scope estimate with model-quality
+   judgement, and re-write `triage.json` if anything changed.
+3. If the refined fields differ materially, post a follow-up `linearis issues discuss`
+   comment marking the refinement.
+
+The refinement step is deliberately optional — the orchestrator hand-off in CTL-452 only
+needs the `phase.triage.complete.<TICKET>` event, and the bash body already emits that.


### PR DESCRIPTION
## Summary

Two greenfield phase-agent skills shipped as **Initiative 1 Phase 5** of the phase-agent architecture (parent: CTL-443, plan: `thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md`). Both consume the broker's `phase_lifecycle` interest (CTL-447, shipped) by emitting canonical `phase.<name>.<status>.<TICKET>` events, and are wired into the orchestrator state machine in CTL-452.

### Skills

- **`phase-triage`** (Opus) — reads a Linear ticket via `linearis`, classifies (`feature` | `bug` | `docs` | `refactor` | `chore`), expands acronyms (PR / CLI / API / OTel / …), identifies cross-ticket dependencies, estimates scope (`small` | `medium` | `large` | `epic`), writes `triage.json`, posts a triage comment to Linear, applies the `triaged` label (tolerant of absence).
- **`phase-monitor-deploy`** (Haiku) — reads merge SHA from `phase-pr.json`, blocks on a `deployment_status` event via `catalyst-events wait-for`, delegates to the gstack `/canary` skill on deploy `success`, writes `phase-monitor-deploy.json`. Emits `.skipped` when no deploy event arrives before the per-skill timeout (env-configurable).

### Architecture decisions

- **No scaffold dependency.** CTL-448's planned helpers (`phase-agent-dispatch`, `phase-agent-emit-complete`, `_phase-agent-template/SKILL.md`) are not on `main` yet despite the Linear state. These two skills are self-contained: each sources a small new helper at `plugins/dev/scripts/lib/phase-emit-complete.sh` that builds the canonical OTel event through the existing `lib/canonical-event.sh`. When CTL-448 lands, its richer dispatcher can absorb this helper mechanically — the call sites do not change.
- **Skipped is success.** When the deploy pipeline does not emit a `deployment_status` event for the merge SHA, `phase-monitor-deploy` writes `phase.monitor-deploy.skipped.<TICKET>` and exits 0. The orchestrator treats `.skipped` as a forward step, not a failure — the PR is already merged.

### Files added

```
plugins/dev/scripts/lib/phase-emit-complete.sh         (helper)
plugins/dev/skills/phase-triage/SKILL.md
plugins/dev/skills/phase-monitor-deploy/SKILL.md
plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
```

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` → 17 passed, 0 failed
- [x] `bash plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh` → 15 passed, 0 failed
- [x] `bash plugins/dev/scripts/__tests__/broker-phase-lifecycle.test.sh` (regression) → 6/6 pass
- [x] `bash plugins/dev/scripts/__tests__/canonical-event.test.sh` (regression) → 46/46 pass
- [x] `bash plugins/dev/scripts/__tests__/emit-otel-event.test.sh` (regression) → 22/22 pass
- [x] `bash plugins/dev/scripts/__tests__/emit-worker-status-change.test.sh` (regression) → 45/45 pass
- [x] `bash plugins/dev/scripts/__tests__/catalyst-events.test.sh` → 40 passed, 1 pre-existing failure (`help exits 0`) unrelated to this PR

E2E tests use stub `linearis` / `claude` shims on PATH and override `CATALYST_EVENTS_FILE`; assertions never touch live infrastructure. The monitor-deploy success/failure cases spawn the skill body in the background and append the fixture `deployment_status` event AFTER `wait-for` has begun watching from EOF — matching the production sequence.

## Out of scope

- Orchestrator dispatch changes — Phase 6 / CTL-452.
- `_phase-agent-template/SKILL.md` and `phase-agent-dispatch` script — CTL-448.
- A `linearis labels create` verb — out of scope; the `triaged` label is a prerequisite, the skill warns and continues on absence.

Linear: CTL-451 / parent CTL-443 / plan §Initiative 1 Phase 5