### PR TITLE
feat(dev): phase-implement + phase-pr + phase-monitor-merge skills (CTL-449)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# Tests for the Phase-3 phase-agent skills (CTL-449 Initiative 1 Phase 3):
+#   - plugins/dev/skills/phase-implement/SKILL.md
+#   - plugins/dev/skills/phase-pr/SKILL.md
+#   - plugins/dev/skills/phase-monitor-merge/SKILL.md
+# and the `--phase` flag added to plugins/dev/scripts/orchestrate-dispatch-next.
+#
+# Approach (per plan §Initiative 1 Phase 3):
+#   * Structural contract — grep each SKILL.md to assert the template prelude,
+#     /goal line, prior-artifact gate, delegation to the canonical skill, and
+#     the standard phase-agent-emit-complete end block are present.
+#   * Event-emission contract — invoke phase-agent-emit-complete with each new
+#     phase name (implement / pr / monitor-merge) and assert the resulting
+#     canonical JSONL line carries the right event.name + payload.phase. This
+#     end-to-end test catches regressions in the broker phase_lifecycle route
+#     keying off the event name pattern (CTL-447).
+#
+# The full "phase agent runs claude --bg, reads plan, commits, opens PR"
+# round-trip cannot be exercised in a unit test (it requires a live claude
+# session, a writable LinearAPI token, a real GitHub repo, and real-time
+# webhook delivery). We assert the agent-side contract that the dispatcher
+# (CTL-448) + canonical event log (CTL-300) + broker route (CTL-447) depend
+# on; the actual `--bg` round-trip is covered by the manual verification
+# steps in the plan's Success Criteria.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+EMIT_SCRIPT="${REPO_ROOT}/plugins/dev/scripts/phase-agent-emit-complete"
+DISPATCH_SCRIPT="${REPO_ROOT}/plugins/dev/scripts/orchestrate-dispatch-next"
+PHASE_DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+SKILL_IMPLEMENT="${REPO_ROOT}/plugins/dev/skills/phase-implement/SKILL.md"
+SKILL_PR="${REPO_ROOT}/plugins/dev/skills/phase-pr/SKILL.md"
+SKILL_MONITOR_MERGE="${REPO_ROOT}/plugins/dev/skills/phase-monitor-merge/SKILL.md"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-implement-e2e-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+assert_file() {
+  local path="$1" label="$2"
+  if [[ -f "$path" ]]; then
+    pass "$label"
+  else
+    fail "$label — file missing: $path"
+  fi
+}
+
+assert_grep() {
+  local pattern="$1" file="$2" label="$3"
+  if grep -q -E "$pattern" "$file" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label — pattern '$pattern' not found in $(basename "$file")"
+  fi
+}
+
+# Per-test sandbox for emit-complete invocations.
+fresh_env() {
+  local tag="$1"
+  TEST_DIR="${SCRATCH}/${tag}"
+  mkdir -p "${TEST_DIR}/catalyst/events"
+  mkdir -p "${TEST_DIR}/orch/workers/CTL-449"
+  export CATALYST_DIR="${TEST_DIR}/catalyst"
+  export CATALYST_ORCHESTRATOR_DIR="${TEST_DIR}/orch"
+  export CATALYST_ORCHESTRATOR_ID="orch-e2e"
+  export CATALYST_SESSION_ID="sess_e2e_${tag}"
+}
+
+read_event_line() {
+  local month
+  month=$(date -u +%Y-%m)
+  local logfile="${CATALYST_DIR}/events/${month}.jsonl"
+  [[ -f "$logfile" ]] || { echo ""; return 1; }
+  grep -F '"event.name":"phase.' "$logfile" | tail -n 1
+}
+
+# ─── Test 1: phase-implement SKILL.md exists + reads plan + commits per phase
+echo "Test 1: phase-implement SKILL.md contract (plan path + TDD per-phase + commits)"
+assert_file "$SKILL_IMPLEMENT" "phase-implement/SKILL.md exists"
+if [[ -f "$SKILL_IMPLEMENT" ]]; then
+  assert_grep '^name: phase-implement$' "$SKILL_IMPLEMENT" "frontmatter: name: phase-implement"
+  assert_grep '^disable-model-invocation: true' "$SKILL_IMPLEMENT" "frontmatter: disable-model-invocation: true"
+  assert_grep '^user-invocable: false' "$SKILL_IMPLEMENT" "frontmatter: user-invocable: false"
+  # Reads the plan from the canonical thoughts/ location (per plan §"per-phase artifact").
+  # phase-agent-dispatch already validates the prior artifact glob, but the skill
+  # body must also reference the path so it can read+pass it to implement-plan.
+  assert_grep 'thoughts/shared/plans' "$SKILL_IMPLEMENT" "skill body references thoughts/shared/plans"
+  # Delegates the heavy lifting to the canonical skill (architectural
+  # commitment #3 in plan §"Implementation Approach").
+  assert_grep '/catalyst-dev:implement-plan' "$SKILL_IMPLEMENT" "delegates to /catalyst-dev:implement-plan"
+fi
+
+# ─── Test 2: phase-implement updates Linear to inProgress + has correct /goal
+echo ""
+echo "Test 2: phase-implement transitions Linear to inProgress and declares /goal"
+if [[ -f "$SKILL_IMPLEMENT" ]]; then
+  # Linear transition. Uses the shared linear-transition.sh helper (CTL-69)
+  # rather than rolling its own GraphQL call.
+  assert_grep 'linear-transition\.sh' "$SKILL_IMPLEMENT" "calls linear-transition.sh"
+  assert_grep 'inProgress' "$SKILL_IMPLEMENT" "transitions Linear to inProgress"
+  # /goal condition exists and matches the plan's transcript-evaluable shape
+  # (git diff non-empty AND tests pass AND Linear=inProgress).
+  assert_grep '^/goal' "$SKILL_IMPLEMENT" "declares a /goal line"
+  assert_grep 'git diff' "$SKILL_IMPLEMENT" "/goal references git diff (diff non-empty)"
+fi
+
+# ─── Test 3: phase-implement emits phase.implement.complete.<TICKET> on success
+echo ""
+echo "Test 3: phase-agent-emit-complete --phase implement emits correct event shape"
+fresh_env t3
+"$EMIT_SCRIPT" --phase implement --ticket CTL-449 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z "$LINE" ]]; then
+  fail "Test 3: no event emitted for phase=implement"
+else
+  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+  SEVERITY=$(echo "$LINE" | jq -r '.severityText')
+  PAYLOAD_PHASE=$(echo "$LINE" | jq -r '.body.payload.phase')
+  PAYLOAD_TICKET=$(echo "$LINE" | jq -r '.body.payload.ticket')
+  assert_eq "phase.implement.complete.CTL-449" "$EVENT_NAME" "event.name = phase.implement.complete.CTL-449"
+  assert_eq "INFO"      "$SEVERITY"       "complete → INFO severity"
+  assert_eq "implement" "$PAYLOAD_PHASE"  "body.payload.phase = implement"
+  assert_eq "CTL-449"   "$PAYLOAD_TICKET" "body.payload.ticket = CTL-449"
+fi
+
+# ─── Test 4: phase-implement emits phase.implement.failed on /goal turn-cap hit
+echo ""
+echo "Test 4: phase-agent-emit-complete --phase implement --status failed carries failure_reason"
+fresh_env t4
+"$EMIT_SCRIPT" --phase implement --ticket CTL-449 --status failed --reason "turn cap hit (75)" >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z "$LINE" ]]; then
+  fail "Test 4: no event emitted for phase=implement (failed)"
+else
+  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+  SEVERITY=$(echo "$LINE" | jq -r '.severityText')
+  REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason')
+  assert_eq "phase.implement.failed.CTL-449" "$EVENT_NAME" "event.name = phase.implement.failed.CTL-449"
+  assert_eq "WARN"               "$SEVERITY" "failed → WARN severity"
+  assert_eq "turn cap hit (75)"  "$REASON"   "body.payload.failure_reason carries reason"
+fi
+
+# ─── Test 5: phase-pr — delegates to /catalyst-dev:create-pr + emits phase.pr.complete
+echo ""
+echo "Test 5: phase-pr SKILL.md contract + emit-complete event shape"
+assert_file "$SKILL_PR" "phase-pr/SKILL.md exists"
+if [[ -f "$SKILL_PR" ]]; then
+  assert_grep '^name: phase-pr$' "$SKILL_PR" "frontmatter: name: phase-pr"
+  # Delegates to create-pr which auto-runs describe-pr and moves Linear to
+  # inReview (plan §"Phase agents wrap canonical skills").
+  assert_grep '/catalyst-dev:create-pr' "$SKILL_PR" "delegates to /catalyst-dev:create-pr"
+  assert_grep '^/goal' "$SKILL_PR" "declares a /goal line"
+fi
+
+fresh_env t5
+"$EMIT_SCRIPT" --phase pr --ticket CTL-449 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z "$LINE" ]]; then
+  fail "Test 5: no event emitted for phase=pr"
+else
+  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+  PAYLOAD_PHASE=$(echo "$LINE" | jq -r '.body.payload.phase')
+  assert_eq "phase.pr.complete.CTL-449" "$EVENT_NAME" "event.name = phase.pr.complete.CTL-449"
+  assert_eq "pr"                        "$PAYLOAD_PHASE" "body.payload.phase = pr"
+fi
+
+# ─── Test 6: phase-monitor-merge — reactive PR lifecycle + emits phase.monitor-merge.complete
+echo ""
+echo "Test 6: phase-monitor-merge SKILL.md reactive listen loop + emit-complete event shape"
+assert_file "$SKILL_MONITOR_MERGE" "phase-monitor-merge/SKILL.md exists"
+if [[ -f "$SKILL_MONITOR_MERGE" ]]; then
+  assert_grep '^name: phase-monitor-merge$' "$SKILL_MONITOR_MERGE" "frontmatter: name: phase-monitor-merge"
+  # Reuses the reactive PR-lifecycle pattern (CTL-228 monitor-events Pattern 3).
+  # The listen loop must wait on events rather than polling, so the skill body
+  # must reference catalyst-events wait-for and the GitHub event filter.
+  assert_grep 'catalyst-events wait-for' "$SKILL_MONITOR_MERGE" "uses catalyst-events wait-for (event-driven loop)"
+  assert_grep 'github\.pr\.merged|github\.check_suite|github\.pr_review' "$SKILL_MONITOR_MERGE" \
+    "references GitHub PR-lifecycle event names"
+  # Transitions Linear to done on merge (per plan §Linear Integration table).
+  assert_grep 'linear-transition\.sh' "$SKILL_MONITOR_MERGE" "calls linear-transition.sh"
+  assert_grep '\bdone\b' "$SKILL_MONITOR_MERGE" "transitions Linear to done"
+  assert_grep '^/goal' "$SKILL_MONITOR_MERGE" "declares a /goal line"
+fi
+
+fresh_env t6
+"$EMIT_SCRIPT" --phase monitor-merge --ticket CTL-449 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z "$LINE" ]]; then
+  fail "Test 6: no event emitted for phase=monitor-merge"
+else
+  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+  PAYLOAD_PHASE=$(echo "$LINE" | jq -r '.body.payload.phase')
+  assert_eq "phase.monitor-merge.complete.CTL-449" "$EVENT_NAME" "event.name = phase.monitor-merge.complete.CTL-449"
+  assert_eq "monitor-merge"                        "$PAYLOAD_PHASE" "body.payload.phase = monitor-merge"
+fi
+
+# ─── Test 7: orchestrate-dispatch-next --phase routes through phase-agent-dispatch
+# The legacy path runs `claude -p` directly; the new --phase path delegates to
+# phase-agent-dispatch which runs `claude --bg`. We exercise the dispatcher
+# end-to-end with a stub claude that captures argv and assert the --bg flag is
+# present iff --phase is set. Backward compatibility (no --phase) is covered by
+# the existing orchestrate-dispatch-next.test.sh — this test only covers the new
+# routing branch.
+echo ""
+echo "Test 7: orchestrate-dispatch-next --phase delegates to phase-agent-dispatch (--bg path)"
+T7="${SCRATCH}/t7"
+mkdir -p "${T7}/orch/workers/output" "${T7}/wt/demo-T-1" "${T7}/bin"
+
+# Stub claude — logs argv. The dispatch path is:
+#   orchestrate-dispatch-next --phase implement → phase-agent-dispatch → claude --bg
+# so the captured argv must include "--bg" plus the phase prompt
+# "/catalyst-dev:phase-implement T-1 …".
+cat > "${T7}/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${CLAUDE_STUB_LOG}"
+{
+  echo "args: $*"
+  env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET|COMMS_CHANNEL|SESSION_ID)=' | sort
+} >> "$LOG"
+echo "stub-bg-job-id-7"
+exit 0
+STUB
+chmod +x "${T7}/bin/claude"
+CLAUDE_STUB_LOG_T7="${T7}/claude.log"
+: > "$CLAUDE_STUB_LOG_T7"
+
+# Fake catalyst-state.sh — eats argv (we don't assert on it here; covered by
+# the existing dispatch test suite).
+cat > "${T7}/bin/catalyst-state.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${T7}/bin/catalyst-state.sh"
+
+# Minimal state.json with one ticket in wave1Pending.
+cat > "${T7}/orch/state.json" <<EOF
+{
+  "orchestrator": "demo",
+  "startedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "baseBranch": "main",
+  "worktreeBase": "${T7}/wt",
+  "maxParallel": 1,
+  "totalWaves": 1,
+  "currentWave": 1,
+  "queue": {"wave1Pending": ["T-1"]},
+  "workers": {}
+}
+EOF
+
+# Required: the worker's wave briefing dir / artifact existence is the prior-
+# artifact gate's concern, NOT orchestrate-dispatch-next's. The dispatcher only
+# checks for the worktree dir, which we made above. For --phase implement, the
+# downstream phase-agent-dispatch will refuse because thoughts/shared/plans/*-t-1.md
+# doesn't exist. So we exercise --phase triage instead (no prior artifact gate
+# per phase-agent-dispatch's prior_artifact_for_phase table).
+CLAUDE_STUB_LOG="$CLAUDE_STUB_LOG_T7" \
+  CATALYST_STATE_SCRIPT="${T7}/bin/catalyst-state.sh" \
+  CATALYST_DISPATCH_CLAUDE_BIN="${T7}/bin/claude" \
+  CATALYST_DISPATCH_HEALTHCHECK="" \
+  "$DISPATCH_SCRIPT" \
+    --orch-dir "${T7}/orch" \
+    --phase triage \
+    >"${T7}/out" 2>"${T7}/err"
+RC=$?
+
+assert_eq "0" "$RC" "dispatcher exits 0 with --phase triage"
+SIGNAL_TRIAGE="${T7}/orch/workers/T-1/phase-triage.json"
+[[ -f "$SIGNAL_TRIAGE" ]] && pass "phase-triage.json signal written" \
+  || fail "phase-triage.json signal written — expected at $SIGNAL_TRIAGE"
+LOG=$(cat "$CLAUDE_STUB_LOG_T7" 2>/dev/null || echo "")
+if [[ -n "$LOG" ]]; then
+  if grep -q -- "--bg" <<<"$LOG"; then
+    pass "claude invoked with --bg (event-driven dispatch path)"
+  else
+    fail "claude invoked with --bg (event-driven dispatch path) — log: $LOG"
+  fi
+  if grep -q "/catalyst-dev:phase-triage T-1" <<<"$LOG"; then
+    pass "prompt is /catalyst-dev:phase-triage with ticket"
+  else
+    fail "prompt is /catalyst-dev:phase-triage with ticket — log: $LOG"
+  fi
+  if grep -q "CATALYST_PHASE=triage" <<<"$LOG"; then
+    pass "env carries CATALYST_PHASE=triage"
+  else
+    fail "env carries CATALYST_PHASE=triage — log: $LOG"
+  fi
+else
+  fail "claude stub captured no invocation"
+fi
+
+# ─── Test 8: orchestrate-dispatch-next without --phase preserves legacy path
+echo ""
+echo "Test 8: orchestrate-dispatch-next without --phase uses legacy /catalyst-dev:oneshot path"
+T8="${SCRATCH}/t8"
+mkdir -p "${T8}/orch/workers/output" "${T8}/wt/demo-T-1" "${T8}/bin"
+
+# Same stub set as Test 7 but the dispatch path is legacy (-p oneshot) — no --bg.
+cat > "${T8}/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${CLAUDE_STUB_LOG}"
+echo "args: $*" >> "$LOG"
+sleep 30 &
+disown $! 2>/dev/null || true
+STUB
+chmod +x "${T8}/bin/claude"
+CLAUDE_STUB_LOG_T8="${T8}/claude.log"
+: > "$CLAUDE_STUB_LOG_T8"
+
+cat > "${T8}/bin/catalyst-state.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${T8}/bin/catalyst-state.sh"
+
+cat > "${T8}/orch/state.json" <<EOF
+{
+  "orchestrator": "demo",
+  "startedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "baseBranch": "main",
+  "worktreeBase": "${T8}/wt",
+  "maxParallel": 1,
+  "totalWaves": 1,
+  "currentWave": 1,
+  "queue": {"wave1Pending": ["T-1"]},
+  "workers": {}
+}
+EOF
+
+CLAUDE_STUB_LOG="$CLAUDE_STUB_LOG_T8" \
+  CATALYST_STATE_SCRIPT="${T8}/bin/catalyst-state.sh" \
+  CATALYST_DISPATCH_CLAUDE_BIN="${T8}/bin/claude" \
+  CATALYST_DISPATCH_HEALTHCHECK="" \
+  "$DISPATCH_SCRIPT" \
+    --orch-dir "${T8}/orch" \
+    >"${T8}/out" 2>"${T8}/err"
+RC=$?
+
+assert_eq "0" "$RC" "dispatcher exits 0 without --phase (legacy path)"
+# Legacy signal file at workers/T-1.json, not workers/T-1/phase-*.json
+[[ -f "${T8}/orch/workers/T-1.json" ]] && pass "legacy worker signal file written" \
+  || fail "legacy worker signal file written"
+LOG=$(cat "$CLAUDE_STUB_LOG_T8" 2>/dev/null || echo "")
+if [[ -n "$LOG" ]]; then
+  if grep -q -- "-p .*catalyst-dev:oneshot" <<<"$LOG"; then
+    pass "legacy path runs claude -p /catalyst-dev:oneshot"
+  else
+    fail "legacy path runs claude -p /catalyst-dev:oneshot — log: $LOG"
+  fi
+  if grep -q -- "--bg" <<<"$LOG"; then
+    fail "legacy path must NOT use --bg — log: $LOG"
+  else
+    pass "legacy path does NOT use --bg"
+  fi
+else
+  fail "claude stub captured no invocation"
+fi
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-implement-e2e: ${PASSES} passed, ${FAILURES} failed"
+echo "─────────────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -15,6 +15,9 @@
 #                             [--worker-command <cmd>]    # default "/catalyst-dev:oneshot"
 #                             [--worker-args <str>]       # default "--auto-merge"
 #                             [--comms-channel <name>]    # default "orch-<orch-id>"
+#                             [--phase <name>]            # CTL-449: dispatch a phase-agent via
+#                                                         # phase-agent-dispatch (claude --bg)
+#                                                         # instead of the legacy -p oneshot path
 #                             [--dry-run]
 #                             [--skip-healthcheck]
 #
@@ -55,11 +58,16 @@ SESSION_ID=""
 WORKER_COMMAND="/catalyst-dev:oneshot"
 WORKER_ARGS="--auto-merge"
 COMMS_CHANNEL=""
+PHASE=""
 DRY_RUN=0
 SKIP_HEALTHCHECK=0
 
+# CTL-449: phase-agent-dispatch is the helper invoked when --phase is set.
+# Env-overridable so tests can stub the spawn behavior.
+PHASE_DISPATCH_BIN="${CATALYST_PHASE_AGENT_DISPATCH:-${SCRIPT_DIR}/phase-agent-dispatch}"
+
 usage() {
-  sed -n '2,36p' "$0"
+  sed -n '2,39p' "$0"
   exit "${1:-1}"
 }
 
@@ -73,6 +81,7 @@ while [[ $# -gt 0 ]]; do
     --worker-command)  WORKER_COMMAND="$2"; shift 2 ;;
     --worker-args)     WORKER_ARGS="$2"; shift 2 ;;
     --comms-channel)   COMMS_CHANNEL="$2"; shift 2 ;;
+    --phase)           PHASE="$2"; shift 2 ;;
     --dry-run)         DRY_RUN=1; shift ;;
     --skip-healthcheck) SKIP_HEALTHCHECK=1; shift ;;
     -h|--help)         usage 0 ;;
@@ -85,10 +94,26 @@ done
 STATE_JSON="${ORCH_DIR}/state.json"
 [ ! -f "$STATE_JSON" ] && { echo "ERROR: state.json missing at $STATE_JSON" >&2; exit 2; }
 
+# CTL-449: --phase forks the dispatch path. Validate the name uses the same shape the
+# phase-agent-dispatch helper enforces (no dots — those are reserved for event-name
+# parsing). When --phase is set, --worker-command/--worker-args are ignored.
+if [ -n "$PHASE" ]; then
+  if [[ "$PHASE" == *.* ]] || [[ ! "$PHASE" =~ ^[a-z][a-z0-9_-]*$ ]]; then
+    echo "ERROR: --phase '$PHASE' must be lowercase letters/digits/dash/underscore, no dots." >&2
+    exit 2
+  fi
+  if [ ! -x "$PHASE_DISPATCH_BIN" ]; then
+    echo "ERROR: phase-agent-dispatch helper not executable at $PHASE_DISPATCH_BIN" >&2
+    echo "       (override via CATALYST_PHASE_AGENT_DISPATCH env var)" >&2
+    exit 2
+  fi
+fi
+
 # CTL-208: workerCommand must be plugin-namespaced (/<plugin>:<skill>). A bare slash like
 # /oneshot is passed to claude as literal prompt text — no skill expansion happens and the
 # worker silently no-ops. Fail loudly here instead of silently dispatching broken workers.
-if [[ ! "$WORKER_COMMAND" =~ ^/[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$ ]]; then
+# Phase mode bypasses this check — the prompt is constructed inside phase-agent-dispatch.
+if [ -z "$PHASE" ] && [[ ! "$WORKER_COMMAND" =~ ^/[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$ ]]; then
   cat >&2 <<EOF
 ERROR: --worker-command "$WORKER_COMMAND" is not a plugin-namespaced slash command.
 
@@ -171,7 +196,16 @@ while IFS=$'\t' read -r W T; do
   [ "$SLOTS" -le 0 ] && break
 
   WORKER_DIR="${WORKTREE_BASE}/${ORCH_ID}-${T}"
-  SIGNAL_FILE="${ORCH_DIR}/workers/${T}.json"
+
+  # Idempotency key depends on which path we're on. Phase mode owns its own
+  # per-phase signal at workers/<T>/phase-<name>.json; legacy mode uses the
+  # flat workers/<T>.json. The two paths intentionally do not share state
+  # so the orchestrator can run both side-by-side during the cutover.
+  if [ -n "$PHASE" ]; then
+    SIGNAL_FILE="${ORCH_DIR}/workers/${T}/phase-${PHASE}.json"
+  else
+    SIGNAL_FILE="${ORCH_DIR}/workers/${T}.json"
+  fi
 
   if [ -f "$SIGNAL_FILE" ]; then
     # Already has a signal (idempotent — previously dispatched)
@@ -189,6 +223,62 @@ while IFS=$'\t' read -r W T; do
     continue
   fi
 
+  # ─── CTL-449: phase-agent dispatch path (claude --bg) ─────────────────────
+  if [ -n "$PHASE" ]; then
+    # Delegate the spawn to phase-agent-dispatch. It writes its own per-phase
+    # signal file, resolves model/turn-cap from .catalyst/config.json, gates
+    # on prior phase artifacts, and runs `claude --bg`. We capture its stdout
+    # JSON so we can mirror dispatch state to the global state script the
+    # same way the legacy path does.
+    PHASE_STDOUT=$(
+      cd "$WORKER_DIR" || exit 1
+      CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
+      CATALYST_ORCHESTRATOR_ID="$ORCH_ID" \
+      CATALYST_SESSION_ID="$SESSION_ID" \
+      "$PHASE_DISPATCH_BIN" \
+        --phase "$PHASE" \
+        --ticket "$T" \
+        --orch-dir "$ORCH_DIR" \
+        --orch-id "$ORCH_ID"
+    ) || {
+      echo "phase-agent-dispatch failed for $T phase=$PHASE — see stderr" >&2
+      continue
+    }
+
+    # State mirror: same shape as legacy events so existing monitors don't
+    # need a special-case for phase dispatches.
+    #
+    # Intentional divergence from the legacy path (see comment at signal-file
+    # selection above): we do NOT bump `.progress.inProgressTickets` here
+    # because a single ticket may dispatch through multiple phases — the
+    # legacy counter assumes one dispatch per ticket. Likewise the RUNNING
+    # count loop at line 154 globs `workers/*.json` and won't see phase-mode
+    # signals at `workers/<T>/phase-<name>.json`. Both divergences are
+    # acceptable in the MVP because phase-mode and legacy-mode never run
+    # against the same wave; the orchestrator state-machine rewrite in
+    # Initiative 1 Phase 6 reconciles both surfaces.
+    "$STATE_SCRIPT" worker "$ORCH_ID" "$T" '.status = "dispatched" | .phase = "'"$PHASE"'"' >/dev/null 2>&1 || true
+    "$STATE_SCRIPT" event "$(jq -nc \
+      --arg ts "$(now_iso)" --arg orch "$ORCH_ID" --arg w "$T" --arg phase "$PHASE" \
+      '{ts: $ts, orchestrator: $orch, worker: $w, event: "worker-dispatched", detail: {phase: $phase}}')" \
+      >/dev/null 2>&1 || true
+
+    # Drain the wave queue (same as the legacy path below).
+    jq --arg t "$T" '
+      .queue |= (
+        (. // {}) | with_entries(
+          if (.key | test("^wave[0-9]+Pending$"))
+          then .value |= (. - [$t])
+          else . end
+        )
+      )' "$STATE_JSON" > "${STATE_JSON}.tmp" && mv "${STATE_JSON}.tmp" "$STATE_JSON"
+
+    DISPATCHED+=("$T")
+    SLOTS=$((SLOTS-1))
+    continue
+  fi
+
+  # ─── Legacy path: claude -p oneshot ───────────────────────────────────────
   # Write signal file with the shared dispatched/phase0 template.
   # CTL-208: include `wave` so the worker can read only its own wave briefing by exact path.
   NOW=$(now_iso)

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -292,8 +292,12 @@ BG_ERR=$(mktemp)
 trap 'rm -f "$BG_OUT" "$BG_ERR"' EXIT
 
 # Use env so we propagate the dispatch env without modifying our own shell.
+# CATALYST_DISPATCH_CLAUDE_BIN mirrors the override honored by
+# orchestrate-dispatch-next so tests (and tooling) can swap the claude binary
+# without rewriting either dispatcher.
+CLAUDE_BIN="${CATALYST_DISPATCH_CLAUDE_BIN:-claude}"
 env "${DISPATCH_ENV[@]}" \
-  claude --bg --dangerously-skip-permissions --model "$MODEL" "$PROMPT" \
+  "$CLAUDE_BIN" --bg --dangerously-skip-permissions --model "$MODEL" "$PROMPT" \
   >"$BG_OUT" 2>"$BG_ERR"
 RC=$?
 

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: phase-implement
+description: |
+  Phase-agent wrapper that drives TDD implementation from an approved plan
+  (CTL-449 Initiative 1 Phase 3). Reads `thoughts/shared/plans/*-<ticket>.md`,
+  delegates the red→green→refactor cycle to `/catalyst-dev:implement-plan`,
+  commits each plan phase as it lands, and transitions the Linear ticket to
+  `inProgress`. Dispatched as a `claude --bg` job by `phase-agent-dispatch`;
+  not user-invocable.
+disable-model-invocation: true
+user-invocable: false
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Task
+---
+
+# phase-implement
+
+Phase-agent that owns the implementation half of the legacy `oneshot` cycle —
+this is the biggest single cost line of a worker run, which is why it leaves
+`-p` for `--bg` first (plan §Initiative 1 Phase 3 rationale). The skill body
+is intentionally thin: the canonical `/catalyst-dev:implement-plan` skill
+already handles TDD rhythm, quality gates, agent-team mode, and findings
+collection — phase-implement adds only the phase-agent envelope (signal file,
+comms channel, `/goal` cap, terminal emit) around it.
+
+## Prerequisites
+
+- `CATALYST_ORCHESTRATOR_DIR`, `CATALYST_ORCHESTRATOR_ID`, `CATALYST_PHASE=implement`, `CATALYST_TICKET` set by [[phase-agent-dispatch]].
+- An approved plan exists at `thoughts/shared/plans/<date>-<ticket-lowercase>.md` — the dispatcher's prior-artifact gate already validates this; this skill re-reads the file.
+- Current working directory is the ticket's worktree (orchestrator's Phase 2 provisioning).
+
+## Prelude (template — copy verbatim into the running session)
+
+```bash
+set -euo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required (set by phase-agent-dispatch)}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+
+# 1. Join the shared comms channel (best-effort).
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" && -x "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-implement: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-implement started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+# 2. Start a catalyst-session for cost/token instrumentation.
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-implement" \
+    --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+# 3. Mark the signal file as running.
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+
+# 4. Locate the approved plan. The dispatcher already validated this glob;
+#    we re-resolve to capture the actual filename for the delegated skill.
+TICKET_LC="$(printf '%s' "$TICKET" | tr '[:upper:]' '[:lower:]')"
+shopt -s nullglob
+PLAN_MATCHES=( thoughts/shared/plans/*-"${TICKET_LC}".md )
+shopt -u nullglob
+[[ ${#PLAN_MATCHES[@]} -gt 0 ]] || { echo "no plan found for ${TICKET} under thoughts/shared/plans/" >&2; exit 1; }
+PLAN_PATH="${PLAN_MATCHES[0]}"
+echo "phase-implement: plan = ${PLAN_PATH}"
+
+# 5. Transition Linear to inProgress (worker-owned state per plan §Linear
+#    Integration). Best-effort — Linear connectivity issues should not block
+#    the implementation work.
+LINEAR_TRANSITION="${PLUGIN_ROOT}/scripts/linear-transition.sh"
+if [[ -x "$LINEAR_TRANSITION" ]]; then
+  "$LINEAR_TRANSITION" --ticket "$TICKET" --transition inProgress \
+    --config .catalyst/config.json 2>/dev/null || true
+fi
+```
+
+## /goal condition
+
+Transcript-evaluable so a `/goal` evaluator (which only sees Claude's text
+output, not the filesystem) can decide pass/fail from what the agent prints.
+Plan §"Per-phase /goal conditions":
+
+```
+/goal "I have run /catalyst-dev:implement-plan on ${PLAN_PATH} to completion
+       AND `git diff <base>..HEAD` on this branch is non-empty AND the targeted
+       tests pass (I have printed the test command + `exit 0` to my transcript)
+       AND I have updated Linear to inProgress (the linear-transition.sh
+       output line is in my transcript); OR I have stopped after 75 turns
+       and printed the partial git diff stat + the last test result to my
+       transcript."
+```
+
+Turn cap defaults to 75 (from `phase-agent-dispatch:phase_default_turn_cap`)
+and is overridable via `.catalyst/config.json:catalyst.orchestration.phaseAgents.turnCaps.implement`.
+
+## Phase-specific work
+
+1. Invoke the canonical implementation skill via the Task tool. It owns TDD,
+   quality gates, agent-team mode (`--team`), findings collection, and the
+   per-phase commit cadence:
+
+   ```
+   Use the Task tool to launch /catalyst-dev:implement-plan on PLAN_PATH.
+   Pass through any --team flag if the caller set CATALYST_IMPLEMENT_TEAM=1
+   in the env. Wait for completion and surface its stdout summary.
+   ```
+
+   The canonical skill is responsible for committing each plan phase as a
+   discrete commit AND for running the post-implementation quality gates
+   (`/validate-type-safety`, `/security-review`, code-reviewer agent,
+   pr-test-analyzer agent). phase-implement does NOT add commits or gates of
+   its own. If `implement-plan` exits with errors, the failure-handling
+   block below runs.
+
+2. After the delegated skill returns, print a one-line summary to stdout so
+   the `/goal` evaluator has signal that the work landed:
+
+   ```bash
+   git diff --stat "$(git merge-base HEAD main)..HEAD"  # base depends on the
+                                                        # worktree's tracking
+   ```
+
+3. When the broader plan's Phase 4 (CTL-450) introduces dedicated
+   `phase-verify` and `phase-review` agents, this skill will pass
+   `--skip-quality-gates` to implement-plan so those concerns move into their
+   own phase agents (plan §"Phase agents wrap canonical skills"). For the
+   MVP this skill runs the gates inline via implement-plan because no
+   phase-verify exists yet — the cutover is a one-line change to the Task
+   invocation when that phase lands.
+
+## End block (terminal emit — copy verbatim)
+
+```bash
+EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+if [[ -x "$EMIT" ]]; then
+  "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status complete
+fi
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+Any non-recoverable failure (turn cap hit, `implement-plan` errored out,
+unresolvable plan ambiguity that the comms `question`/`directive` round-trip
+could not unblock):
+
+```bash
+REASON="${1:-implement-plan exited non-zero}"  # caller-supplied short string
+"$EMIT" --phase "$PHASE" --ticket "$TICKET" --status failed --reason "$REASON"
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-implement failed: ${REASON}" \
+  --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```
+
+The orchestrator's Phase 4 monitor receives `phase.implement.failed.${TICKET}`
+via the broker `phase_lifecycle` route (CTL-447) and dispatches one fix-up
+phase agent. A second failure escalates to the user via the `attention` post.
+
+## Comms discipline
+
+Inherits the contract from [[_phase-agent-template]]:
+
+| Type        | When                                                              |
+|-------------|------------------------------------------------------------------|
+| `info`      | At start; once after `implement-plan` returns. ~2 per session.    |
+| `attention` | Stalled (turn cap), missing plan, unresolved 3+ test failures.    |
+| `question`  | Plan ambiguity the agent cannot resolve unilaterally.             |
+| `done`      | Emitted by `phase-agent-emit-complete` on success.                |
+
+Read inbound `directive` / `pause` / `abort` after every Task-tool round-trip
+back from `implement-plan` — the orchestrator may abort the worker while
+implementation is in flight.
+
+## Why this is a thin wrapper
+
+Architectural commitment #3 in the plan: "phase agents are thin wrappers
+around the canonical skills." Improvements to `/catalyst-dev:implement-plan`
+(TDD agent-team mode, findings filing, quality-gate iteration limits)
+propagate to every phase-agent run without code duplication. The phase-agent
+boundary owns only the envelope: signal file, comms, `/goal` cap, terminal
+event emission. See plan §"Phase agents wrap canonical skills" for the full
+delegation table.

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: phase-monitor-merge
+description: |
+  Phase-agent that watches the open PR through to merge (CTL-449 Initiative 1
+  Phase 3). Lifts the active listen loop from the legacy `oneshot` Phase 5
+  body: event-driven wait on `catalyst-events wait-for`, inline resolution of
+  CI fix-ups, bot review threads, and BEHIND rebases, then `gh pr merge
+  --squash --delete-branch` when the PR reaches CLEAN, then transitions
+  Linear to `done`. Dispatched as a `claude --bg` job by `phase-agent-dispatch`;
+  not user-invocable.
+disable-model-invocation: true
+user-invocable: false
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Task
+---
+
+# phase-monitor-merge
+
+The reactive half of the worker lifecycle. The PR exists (opened by
+[[phase-pr]]); this phase agent drives it to MERGED and transitions Linear
+to `done`. Implementation lifts the loop from `plugins/dev/skills/oneshot/SKILL.md`
+§"Step 2: Active PR Listen Loop" — same event names, same `mergeable_state`
+state machine, same inline fix-up cap — wrapped in the phase-agent envelope
+(signal file, comms channel, terminal event emission).
+
+## Prerequisites
+
+- `CATALYST_ORCHESTRATOR_DIR`, `CATALYST_ORCHESTRATOR_ID`, `CATALYST_PHASE=monitor-merge`, `CATALYST_TICKET` set by [[phase-agent-dispatch]].
+- The prior phase's signal file `${ORCH_DIR}/workers/<TICKET>/phase-pr.json` exists with `status=done` AND `.pr.number` populated by [[phase-pr]].
+- `gh` CLI authenticated; broker daemon optionally running (the loop falls back to direct `catalyst-events wait-for` filtering when it is not — see [[wait-for-github]]).
+
+## Prelude
+
+```bash
+set -euo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PR_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-pr.json"
+PR_NUMBER=$(jq -r '.pr.number // empty' "$PR_SIGNAL" 2>/dev/null || echo "")
+[[ -n "$PR_NUMBER" ]] || { echo "phase-monitor-merge: no PR number in $PR_SIGNAL" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" && -x "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-monitor-merge: ${TICKET} pr#${PR_NUMBER}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 86400 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-monitor-merge watching pr#${PR_NUMBER}" \
+    --as "$TICKET" --type info --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-monitor-merge" --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+[[ -n "$REPO" ]] || { echo "phase-monitor-merge: cannot resolve repo" >&2; exit 1; }
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" --argjson pr "$PR_NUMBER" \
+  '.status = "running" | .updatedAt = $ts | .pr = {number: $pr}' \
+  "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+```
+
+## /goal condition
+
+Plan §"Per-phase /goal conditions":
+
+```
+/goal "`gh pr view --json merged` returns `true` for the PR linked to
+       ${TICKET} (PR #${PR_NUMBER}) AND Linear state is `Done` (I have
+       printed both confirmations to my transcript); OR I have stopped after
+       50 turns or 24 wall-clock hours."
+```
+
+Turn cap defaults to 50 — high relative to other phases because the work is
+event-driven and one wake = one turn. Wall-clock cap is 24h (per plan
+§Failure handling).
+
+## Phase-specific work — active listen loop
+
+Reuse the reactive listen loop from [[oneshot]] § Phase 5 Step 2. The full
+control flow lives there; this skill copies the body verbatim, substituting
+`phase-monitor-merge` framing in place of `oneshot`'s session-id machinery.
+Key elements that MUST be preserved:
+
+1. **Event-driven, not polling.** `catalyst-events wait-for` blocks until a
+   PR-lifecycle event fires. Filter clause matches the canonical event names
+   `github.pr.merged`, `github.check_suite.completed`, `github.pr_review*`,
+   and `github.push` keyed by `attributes."vcs.pr.number"` (PR/review events)
+   or `body.payload.prNumbers` (check_suite/workflow_run — see
+   [[event-schema]]). When the broker daemon is up, register a
+   `pr_lifecycle` interest via `agent.checkin.claimed_pr` and wait on
+   `filter.wake.${CATALYST_SESSION_ID}` instead (the single-wake path — see
+   [[monitor-events]] Pattern 3).
+
+2. **REST is authoritative.** Every loop iteration calls
+   `gh api repos/${REPO}/pulls/${PR_NUMBER}` and reads `.merged` +
+   `.mergeable_state`. Never use `gh pr view --json mergeable` (GraphQL is
+   eventually consistent for the merge-state fields and frequently lies).
+
+3. **State machine.** Branch on `mergeable_state`:
+
+   | state    | action |
+   |----------|--------|
+   | clean    | proceed to merge step |
+   | blocked  | resolve via `/catalyst-dev:review-comments` (bot threads) or run an inline CI fix-up commit (up to 3 attempts); 4th attempt → `stalled` |
+   | behind   | `git fetch && git rebase origin/<base> && git push --force-with-lease` |
+   | dirty    | merge conflicts — emit `failed` with reason "merge conflicts (DIRTY)" |
+   | unknown/unstable | continue waiting for the next event |
+
+4. **Human reviewer changes-requested.** After every wake, query
+   `gh pr view --json reviews` for the most recent `CHANGES_REQUESTED` from
+   a human reviewer (filter on `.author.login` not matching known bots). If
+   present, emit `failed` with reason "human reviewer ${LOGIN} requested
+   changes — operator action required". Do NOT attempt to address human
+   review comments programmatically.
+
+5. **Wake narration.** Every iteration produces one short line of assistant
+   text before re-entering the wait (defeats the assistant `end_turn`
+   rendering bleed described in [[monitor-events]] § Narration). Shape:
+   `wake: <event.name> #<PR_NUMBER> — <action being taken>`.
+
+## Merge + Linear `done`
+
+Once `mergeable_state == "clean"` (and the PR isn't already merged):
+
+```bash
+gh pr merge "$PR_NUMBER" --squash --delete-branch
+# REST is authoritative — confirm via REST, never GraphQL
+MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")
+[[ "$MERGED_OK" = "true" ]] || { echo "phase-monitor-merge: merge not confirmed via REST" >&2; exit 1; }
+
+MERGE_COMMIT_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merge_commit_sha // empty')
+MERGED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Record merge in signal file.
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$MERGED_AT" --arg sha "${MERGE_COMMIT_SHA:-}" \
+   '.pr.mergedAt = $ts | .pr.ciStatus = "merged"
+    | (if $sha != "" then .pr.mergeCommitSha = $sha else . end)
+    | .updatedAt = $ts' \
+   "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+
+# Transition Linear to done — worker-owned per plan §Linear Integration.
+LINEAR_TRANSITION="${PLUGIN_ROOT}/scripts/linear-transition.sh"
+if [[ -x "$LINEAR_TRANSITION" ]]; then
+  "$LINEAR_TRANSITION" --ticket "$TICKET" --transition done \
+    --config .catalyst/config.json 2>/dev/null || true
+fi
+
+echo "phase-monitor-merge: pr#${PR_NUMBER} merged at ${MERGED_AT}; Linear=done"
+```
+
+Deployment verification (`skipDeployVerification=false`) is **not** in this
+phase's scope — that is `phase-monitor-deploy` (plan §Initiative 1 Phase 5).
+This skill exits cleanly the moment the merge + Linear transition land.
+
+## End block
+
+```bash
+EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+if [[ -x "$EMIT" ]]; then
+  "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status complete
+fi
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+```bash
+REASON="${1:-listen loop terminal failure}"
+"$EMIT" --phase "$PHASE" --ticket "$TICKET" --status failed --reason "$REASON"
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-monitor-merge failed: ${REASON}" \
+  --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```
+
+Failure modes that emit `phase.monitor-merge.failed.${TICKET}`:
+
+- `dirty` (merge conflicts) — operator must rebase manually.
+- Human reviewer `CHANGES_REQUESTED` — operator must address comments.
+- CI blocked after 3 auto-fix attempts.
+- `gh pr merge` succeeded but REST confirms `.merged == false` (rare; usually
+  a branch-protection rule mismatch).
+- 24-hour wall-clock cap — orchestrator dispatches a fix-up or escalates.
+
+## Comms discipline
+
+Inherits the contract from [[_phase-agent-template]]:
+
+| Type        | When                                                              |
+|-------------|------------------------------------------------------------------|
+| `info`      | At start with PR number; after each successful inline fix-up.     |
+| `attention` | DIRTY, human changes-requested, CI blocked after 3 attempts.      |
+| `question`  | Reserved — this phase rarely needs to ask, since the work is reactive. |
+| `done`      | Emitted by `phase-agent-emit-complete` on merge confirmed.        |
+
+## Why this is a thin wrapper
+
+Plan architectural commitment #3. The listen loop logic lives in [[oneshot]]
+SKILL.md and is exercised every day. Lifting it into a phase-agent skill
+without duplicating the body keeps both paths in lockstep — when the legacy
+oneshot path retires (plan §Initiative 1 Phase 6), this skill becomes the
+sole owner.

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: phase-pr
+description: |
+  Phase-agent wrapper that opens the pull request after implementation
+  completes (CTL-449 Initiative 1 Phase 3). Delegates to
+  `/catalyst-dev:create-pr` (which already auto-runs `describe-pr` and
+  transitions Linear to `inReview`), then writes the PR number + URL into the
+  phase signal file so the downstream `phase-monitor-merge` agent can read it
+  without re-querying GitHub. Dispatched as a `claude --bg` job by
+  `phase-agent-dispatch`; not user-invocable.
+disable-model-invocation: true
+user-invocable: false
+allowed-tools:
+  - Bash
+  - Read
+  - Task
+---
+
+# phase-pr
+
+Thin wrapper around `/catalyst-dev:create-pr`. The canonical skill already
+handles: commit, push, base-branch detection, PR creation, `describe-pr`
+auto-invocation, workflow-context tracking, Linear `inReview` transition,
+and the post-PR resolution loop. Phase-pr adds only the phase-agent envelope
+plus persisting `pr.number` + `pr.url` to the signal file for
+`phase-monitor-merge`.
+
+## Prerequisites
+
+- `CATALYST_ORCHESTRATOR_DIR`, `CATALYST_ORCHESTRATOR_ID`, `CATALYST_PHASE=pr`, `CATALYST_TICKET` set by [[phase-agent-dispatch]].
+- The prior phase's signal file `${ORCH_DIR}/workers/<TICKET>/phase-review.json` exists with `status=done` — the dispatcher validates this; this skill assumes it.
+- Current working directory is the ticket's worktree on the implementation branch (not main).
+
+## Prelude
+
+```bash
+set -euo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" && -x "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-pr: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-pr started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-pr" --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+```
+
+## /goal condition
+
+Plan §"Per-phase /goal conditions":
+
+```
+/goal "`gh pr view --json number,state,headRefName` shows an open PR linked
+       to ${TICKET} AND Linear state is `In Review` AND describe-pr has run
+       successfully (I have printed the PR URL and `describe-pr ran` to my
+       transcript); OR I have stopped after 12 turns."
+```
+
+Turn cap defaults to 12 (from `phase-agent-dispatch:phase_default_turn_cap`).
+This is intentionally tight because the work is mostly tool calls — most of
+the reasoning happens upstream in `create-pr` itself.
+
+## Phase-specific work
+
+1. Invoke `/catalyst-dev:create-pr` via the Task tool. The canonical skill
+   handles: branch push, base-branch resolution, idempotent PR creation if
+   one already exists, `describe-pr` invocation, and Linear `inReview`
+   transition.
+
+2. After `create-pr` returns, capture the PR metadata via `gh` and write it
+   into the phase signal file so `phase-monitor-merge` can read it directly
+   without re-querying GitHub:
+
+   ```bash
+   PR_INFO=$(gh pr view --json number,url,headRefName,baseRefName 2>/dev/null || echo "{}")
+   PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
+   PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty')
+   if [[ -n "$PR_NUMBER" ]]; then
+     TS2=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+     TMP="${SIGNAL_FILE}.tmp.$$"
+     jq --argjson pr "$PR_NUMBER" --arg url "$PR_URL" --arg ts "$TS2" \
+        '.pr = {number: $pr, url: $url} | .updatedAt = $ts' \
+        "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+     echo "phase-pr: opened PR #${PR_NUMBER} at ${PR_URL}"
+   else
+     echo "phase-pr: gh pr view returned no PR — create-pr may have failed" >&2
+   fi
+   ```
+
+3. The post-PR active resolution loop (CI fix-up, bot review threads, BEHIND
+   rebase) is **not** run here — that is `phase-monitor-merge`'s
+   responsibility. `create-pr`'s own brief monitoring window stays inside
+   `create-pr`; phase-pr exits as soon as the PR exists in `OPEN` state.
+
+## End block
+
+```bash
+EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+if [[ -x "$EMIT" ]]; then
+  "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status complete
+fi
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+```bash
+REASON="${1:-create-pr exited non-zero}"
+"$EMIT" --phase "$PHASE" --ticket "$TICKET" --status failed --reason "$REASON"
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-pr failed: ${REASON}" \
+  --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```
+
+Common failure modes:
+
+- **Branch not pushable** (e.g., diverged, network failure): `create-pr` errors;
+  phase-pr emits `failed` with the underlying reason.
+- **PR already exists with no new commits**: not a failure — `create-pr` is
+  idempotent and returns the existing PR. The signal file gets the existing
+  PR number written, downstream phases proceed normally.
+- **`gh` not authenticated**: emit `failed` with the gh stderr; orchestrator's
+  retry path will not unstick this — escalate via `attention`.
+
+## Why this is a thin wrapper
+
+Plan architectural commitment #3. `/catalyst-dev:create-pr` is mature (504
+lines as of CTL-373) and owns workflow-context, Linear linking, describe-pr,
+and idempotency. phase-pr adds the phase-agent envelope (~80 lines) and
+nothing else — improvements to create-pr propagate for free.


### PR DESCRIPTION
## Summary

Ship the three longest-running phase agents (MVP scope of plan §Initiative 1
Phase 3), getting the `claude -p` worker path off the critical cost line
before the 2026-06-15 Agent-SDK-Credit billing change:

- **`phase-implement`** wraps `/catalyst-dev:implement-plan` with the
  phase-agent envelope. Reads the approved plan, transitions Linear to
  `inProgress`, delegates TDD + quality gates to the canonical skill.
- **`phase-pr`** wraps `/catalyst-dev:create-pr`. Persists `pr.number` and
  `pr.url` to the per-phase signal so `phase-monitor-merge` doesn't have to
  re-query GitHub.
- **`phase-monitor-merge`** lifts the active listen loop from `oneshot`'s
  Phase 5 — event-driven wait on `catalyst-events wait-for`, REST-authoritative
  `mergeable_state` state machine, inline CI/review/BEHIND resolution,
  squash-merge when CLEAN, transition Linear to `done`.
- **`orchestrate-dispatch-next --phase <name>`** opts the orchestrator into
  the new dispatch path (`phase-agent-dispatch` → `claude --bg`) per ticket.
  Backward-compatible: the legacy `claude -p` path is unchanged when
  `--phase` is absent.
- **`CATALYST_DISPATCH_CLAUDE_BIN`** is honored in `phase-agent-dispatch`
  too — single-line addition that mirrors the same override in
  `orchestrate-dispatch-next` so both dispatchers can be test-stubbed
  consistently.

## Test plan

Acceptance tests (per the ticket):

- [x] `bash plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh` — 41 assertions across 8 tests cover SKILL.md structural contracts, canonical event emission for each new phase name, the `--phase` dispatch path, and the backward-compat legacy path. All pass.
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh` — 74 assertions, all pass. Confirms the `--phase` addition is non-regressing for the legacy path (tests 1–17 unchanged; test 15b extended sed range to keep "Concurrency:" in `--help` output).
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` — 30 assertions, all pass.
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — 15 assertions, all pass.
- [x] `bash plugins/dev/scripts/__tests__/canonical-event.test.sh` — 56 assertions covering broker `phase_lifecycle` route + event-name regex, all pass.

Test totals: **216 assertions across 5 suites, 100% green.**

Manual verification still TBD per the plan's Success Criteria:

- [ ] Hand-run `phase-implement` against a real, small CTL ticket with a pre-written plan; observe successful commit + `phase.implement.complete.<ticket>` event.
- [ ] Hand-run `phase-pr` against the resulting branch; observe PR + Linear `In Review`.
- [ ] Hand-run `phase-monitor-merge` against the resulting PR; observe merge + Linear `Done`.

## Notes for reviewers

- **Phase-mode and legacy-mode intentionally do NOT share `workers/*.json` state.** Phase mode writes to `workers/<T>/phase-<name>.json`; legacy writes to `workers/<T>.json`. The `RUNNING` count loop and `.progress.inProgressTickets` counter therefore see only the legacy shape — documented inline at the dispatch site. Reconciliation lands in Initiative 1 Phase 6 when the orchestrator state machine is rewritten.
- Phase-implement runs `implement-plan`'s full quality-gate suite inline (no `--skip-quality-gates`) because dedicated `phase-verify`/`phase-review` don't exist yet — those land in CTL-450. The SKILL.md flags the one-line change needed at that point.
- The `--phase` flag bypasses the `WORKER_COMMAND` validation regex (the prompt is constructed inside `phase-agent-dispatch`, not at this layer).

Closes CTL-449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)