### PR TITLE
feat(dev): morning-briefing skill MVP (CTL-457)

### DIFF
--- a/plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh
+++ b/plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Tests for the morning-briefing skill MVP (CTL-457).
+# Covers: render.sh, output-path.sh, validate-frontmatter.sh, the gather-*.sh
+# credential-absent paths, the SKILL.md frontmatter contract, and the
+# briefing-frontmatter.schema.json file itself.
+#
+# Run: bash plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+MB_DIR="${REPO_ROOT}/plugins/dev/scripts/morning-briefing"
+SCHEMA="${REPO_ROOT}/plugins/dev/templates/briefing-frontmatter.schema.json"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/morning-briefing/SKILL.md"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  shift
+  for line in "$@"; do echo "    $line"; done
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected: $expected" "actual:   $actual"
+  fi
+}
+
+assert_grep() {
+  local label="$1" pattern="$2" content="$3"
+  if grep -qF -- "$pattern" <<<"$content"; then
+    pass "$label"
+  else
+    fail "$label" "expected substring: $pattern" \
+      "actual: $(printf '%s' "$content" | head -20)"
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected exit: $expected" "actual exit:   $actual"
+  fi
+}
+
+# ─── Test: schema exists and parses ──────────────────────────────────────────
+test_schema_exists() {
+  echo "test: schema file exists and is valid JSON"
+  if [[ ! -f "$SCHEMA" ]]; then
+    fail "schema file exists" "missing: $SCHEMA"; return
+  fi
+  pass "schema file exists"
+  if jq -e . "$SCHEMA" >/dev/null 2>&1; then
+    pass "schema parses as JSON"
+  else
+    fail "schema parses as JSON" "jq failed"
+  fi
+  local required
+  required=$(jq -r '.required | join(",")' "$SCHEMA")
+  assert_eq "schema declares required: date,generated_by,decisions" \
+    "date,generated_by,decisions" "$required"
+}
+
+# ─── Test: render.sh produces 4 sections + populated decisions block ────────
+test_render_produces_4_sections() {
+  echo "test: render.sh produces 4 sections"
+  local fixture="$SCRATCH/fixture.json"
+  cat > "$fixture" <<'JSON'
+{
+  "date": "2026-05-17",
+  "yesterday": {
+    "linear":   [{"id":"CTL-100","title":"Ship X","state":"Done"}],
+    "github":   [{"number":799,"title":"feat: scaffold","url":"https://github.com/org/repo/pull/799"}],
+    "granola":  [{"id":"not_abc","title":"Sync w/ team","created_at":"2026-05-16T15:00:00Z"}],
+    "drive":    [],
+    "calendar": []
+  },
+  "decisions": [
+    {"id":"dec-1","type":"blocked_pr","summary":"PR #800 stalled","status":"open"},
+    {"id":"dec-2","type":"judgment_call","summary":"Pick auth provider","status":"open"}
+  ],
+  "today": {
+    "linear_in_progress": [{"id":"CTL-200","title":"Build briefing skill"}],
+    "calendar":           [{"title":"1:1 w/ Alice","start":"2026-05-17T14:00:00Z"}],
+    "followups":          [{"action":"Email vendor about renewal"}]
+  },
+  "suggested_runs": [{"id":"CTL-300","title":"Rewrite onboarding","priority":"High"}]
+}
+JSON
+  local out="$SCRATCH/render-1.md"
+  bash "$MB_DIR/render.sh" --input "$fixture" --output "$out" >/dev/null
+  local content
+  content=$(cat "$out")
+  assert_grep "Heading: Morning Briefing" "# Morning Briefing — 2026-05-17" "$content"
+  assert_grep "Section: Review yesterday"        "## Review yesterday" "$content"
+  assert_grep "Section: Surface decisions"       "## Surface decisions" "$content"
+  assert_grep "Section: Plan today"              "## Plan today" "$content"
+  assert_grep "Section: Suggest orchestrator runs" "## Suggest orchestrator runs" "$content"
+  assert_grep "Linear item rendered"             "[CTL-100] Ship X" "$content"
+  assert_grep "GitHub item rendered"             "[#799] feat: scaffold" "$content"
+  assert_grep "Suggested run rendered"           "CTL-300" "$content"
+}
+
+# ─── Test: render.sh writes decisions array in frontmatter ─────────────────
+test_render_writes_decisions_block() {
+  echo "test: render.sh emits decisions array in frontmatter"
+  local fixture="$SCRATCH/fixture-dec.json"
+  cat > "$fixture" <<'JSON'
+{
+  "date": "2026-05-17",
+  "decisions": [
+    {"id":"dec-a","type":"blocked_pr","summary":"A","status":"open"},
+    {"id":"dec-b","type":"adr_drift","summary":"B","status":"open"}
+  ]
+}
+JSON
+  local out="$SCRATCH/render-dec.md"
+  bash "$MB_DIR/render.sh" --input "$fixture" --output "$out" >/dev/null
+  # Extract frontmatter and count decisions
+  local fm count
+  fm=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$out")
+  count=$(printf '%s\n' "$fm" \
+    | python3 -c 'import sys,yaml; print(len(yaml.safe_load(sys.stdin).get("decisions", [])))')
+  assert_eq "frontmatter decisions length" "2" "$count"
+  assert_grep "decisions block surfaces 'A'" "A" "$(printf '%s' "$fm")"
+  assert_grep "decisions block surfaces 'B'" "B" "$(printf '%s' "$fm")"
+}
+
+# ─── Test: render.sh shows _no data_ for empty sections ─────────────────────
+test_render_no_data_placeholder() {
+  echo "test: render.sh shows _no data_ on empty input"
+  local fixture="$SCRATCH/fixture-empty.json"
+  echo '{"date":"2026-05-17","decisions":[]}' > "$fixture"
+  local out="$SCRATCH/render-empty.md"
+  bash "$MB_DIR/render.sh" --input "$fixture" --output "$out" >/dev/null
+  local content
+  content=$(cat "$out")
+  # At least one '_no data_' per empty section
+  local count
+  count=$(grep -c '^_no data_$' "$out")
+  if [[ "$count" -ge 4 ]]; then
+    pass "_no data_ appears in at least 4 places (got $count)"
+  else
+    fail "_no data_ appears in at least 4 places" "got $count" "content:" "$content"
+  fi
+}
+
+# ─── Test: output-path.sh default ───────────────────────────────────────────
+test_output_path_default() {
+  echo "test: output-path.sh --date prints thoughts/briefings/<date>.md"
+  local actual
+  actual=$(bash "$MB_DIR/output-path.sh" --date 2026-05-17 --root /tmp/proj)
+  assert_eq "default output path" "/tmp/proj/thoughts/briefings/2026-05-17.md" "$actual"
+}
+
+# ─── Test: output-path.sh dry-run ───────────────────────────────────────────
+test_output_path_dry_run() {
+  echo "test: output-path.sh --dry-run goes to /tmp"
+  local actual
+  actual=$(bash "$MB_DIR/output-path.sh" --dry-run --date 2026-05-17)
+  assert_eq "dry-run path" "/tmp/morning-briefing-2026-05-17.md" "$actual"
+}
+
+# ─── Test: output-path.sh defaults --date to today ─────────────────────────
+test_output_path_default_date() {
+  echo "test: output-path.sh defaults --date to today UTC"
+  local today actual
+  today=$(date -u +%Y-%m-%d)
+  actual=$(bash "$MB_DIR/output-path.sh" --root /tmp/proj)
+  assert_eq "default date path" "/tmp/proj/thoughts/briefings/${today}.md" "$actual"
+}
+
+# ─── Test: output-path.sh rejects bad date ──────────────────────────────────
+test_output_path_rejects_bad_date() {
+  echo "test: output-path.sh rejects malformed --date"
+  local ec
+  bash "$MB_DIR/output-path.sh" --date "not-a-date" >/dev/null 2>&1
+  ec=$?
+  assert_exit "bad date exits non-zero" "2" "$ec"
+}
+
+# ─── Test: validate-frontmatter passes on rendered fixture ─────────────────
+test_validate_frontmatter_passes() {
+  echo "test: validate-frontmatter.sh succeeds on rendered fixture"
+  local fixture="$SCRATCH/v-fixture.json"
+  cat > "$fixture" <<'JSON'
+{
+  "date": "2026-05-17",
+  "decisions": [{"id":"d","type":"blocked_pr","summary":"x","status":"open"}]
+}
+JSON
+  local out="$SCRATCH/v-render.md"
+  bash "$MB_DIR/render.sh" --input "$fixture" --output "$out" >/dev/null
+  local ec
+  bash "$MB_DIR/validate-frontmatter.sh" "$out" >/dev/null 2>&1
+  ec=$?
+  assert_exit "valid frontmatter exits 0" "0" "$ec"
+}
+
+# ─── Test: validate-frontmatter rejects missing required field ─────────────
+test_validate_frontmatter_fails_on_bad_schema() {
+  echo "test: validate-frontmatter.sh rejects bad frontmatter"
+  local bad="$SCRATCH/bad.md"
+  cat > "$bad" <<'MD'
+---
+generated_by: morning-briefing
+decisions: []
+---
+
+# missing date field
+MD
+  local ec
+  bash "$MB_DIR/validate-frontmatter.sh" "$bad" >/dev/null 2>&1
+  ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "invalid frontmatter should exit non-zero" "got exit 0"
+  else
+    pass "invalid frontmatter exits non-zero (got $ec)"
+  fi
+}
+
+# ─── Test: gather-*.sh degrade to {} when creds absent ──────────────────────
+# Run with PATH stripped of linearis/gh and with env vars cleared.
+test_gather_no_creds() {
+  local name="$1" script="$2" envunset_var="$3"
+  echo "test: ${name} returns {} when creds absent"
+  local out ec
+  out=$(env -i HOME="$HOME" PATH="/usr/bin:/bin" bash "$script" --date 2026-05-17 2>/dev/null)
+  ec=$?
+  assert_exit "${name} exits 0 without creds" "0" "$ec"
+  assert_eq "${name} prints {} without creds" "{}" "$out"
+}
+
+test_gather_linear_no_creds()   { test_gather_no_creds "gather-linear"   "$MB_DIR/gather-linear.sh"   "LINEAR_API_KEY"; }
+test_gather_github_no_creds()   { test_gather_no_creds "gather-github"   "$MB_DIR/gather-github.sh"   "GH_TOKEN"; }
+test_gather_granola_no_creds()  { test_gather_no_creds "gather-granola"  "$MB_DIR/gather-granola.sh"  "GRANOLA_API_KEY"; }
+test_gather_drive_no_creds()    { test_gather_no_creds "gather-drive"    "$MB_DIR/gather-drive.sh"    "GOOGLE_OAUTH_ACCESS_TOKEN"; }
+test_gather_calendar_no_creds() { test_gather_no_creds "gather-calendar" "$MB_DIR/gather-calendar.sh" "GOOGLE_OAUTH_ACCESS_TOKEN"; }
+
+# ─── Test: SKILL.md exists with required frontmatter ────────────────────────
+test_skill_md_exists_with_correct_frontmatter() {
+  echo "test: SKILL.md exists with correct frontmatter"
+  if [[ ! -f "$SKILL_MD" ]]; then
+    fail "SKILL.md exists" "missing: $SKILL_MD"; return
+  fi
+  pass "SKILL.md exists"
+  local fm
+  fm=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$SKILL_MD")
+  assert_grep "name: morning-briefing" "name: morning-briefing" "$fm"
+  assert_grep "disable-model-invocation: true" "disable-model-invocation: true" "$fm"
+  assert_grep "allowed-tools includes Bash" "allowed-tools: Bash" "$fm"
+}
+
+# ─── Test: end-to-end — gather (empty) → render → validate ─────────────────
+test_end_to_end_empty_creds() {
+  echo "test: end-to-end pipeline with no creds produces a valid briefing"
+  local d="$SCRATCH/e2e"
+  mkdir -p "$d"
+  # Gather everything (no creds → all {})
+  env -i HOME="$HOME" PATH="/usr/bin:/bin" bash "$MB_DIR/gather-linear.sh"   --date 2026-05-17 > "$d/linear.json"
+  env -i HOME="$HOME" PATH="/usr/bin:/bin" bash "$MB_DIR/gather-github.sh"   --date 2026-05-17 > "$d/github.json"
+  env -i HOME="$HOME" PATH="/usr/bin:/bin" bash "$MB_DIR/gather-granola.sh"  --date 2026-05-17 > "$d/granola.json"
+  env -i HOME="$HOME" PATH="/usr/bin:/bin" bash "$MB_DIR/gather-drive.sh"    --date 2026-05-17 > "$d/drive.json"
+  env -i HOME="$HOME" PATH="/usr/bin:/bin" bash "$MB_DIR/gather-calendar.sh" --date 2026-05-17 > "$d/calendar.json"
+  echo '{"decisions":[]}' > "$d/decisions.json"
+  echo '{"today":{"linear_in_progress":[],"calendar":[],"followups":[]}}' > "$d/today.json"
+  echo '{"suggested_runs":[]}' > "$d/suggested.json"
+
+  jq -s --arg date "2026-05-17" '
+    {date: $date}
+    + {yesterday: ((.[0] // {}) + (.[1] // {}) + (.[2] // {}) + (.[3] // {}) + (.[4] // {}))}
+    + (.[5] // {}) + (.[6] // {}) + (.[7] // {})
+  ' "$d/linear.json" "$d/github.json" "$d/granola.json" "$d/drive.json" "$d/calendar.json" \
+    "$d/decisions.json" "$d/today.json" "$d/suggested.json" \
+    > "$d/input.json"
+
+  bash "$MB_DIR/render.sh" --input "$d/input.json" --output "$d/briefing.md" >/dev/null
+  local ec
+  bash "$MB_DIR/validate-frontmatter.sh" "$d/briefing.md" >/dev/null 2>&1
+  ec=$?
+  assert_exit "end-to-end produces schema-valid briefing" "0" "$ec"
+}
+
+# ─── Run all tests ──────────────────────────────────────────────────────────
+test_schema_exists
+test_render_produces_4_sections
+test_render_writes_decisions_block
+test_render_no_data_placeholder
+test_output_path_default
+test_output_path_dry_run
+test_output_path_default_date
+test_output_path_rejects_bad_date
+test_validate_frontmatter_passes
+test_validate_frontmatter_fails_on_bad_schema
+test_gather_linear_no_creds
+test_gather_github_no_creds
+test_gather_granola_no_creds
+test_gather_drive_no_creds
+test_gather_calendar_no_creds
+test_skill_md_exists_with_correct_frontmatter
+test_end_to_end_empty_creds
+
+echo
+echo "─────────────────────────────────────"
+echo "PASSED: $PASSES"
+echo "FAILED: $FAILURES"
+echo "─────────────────────────────────────"
+exit $(( FAILURES > 0 ? 1 : 0 ))

--- a/plugins/dev/scripts/morning-briefing/gather-calendar.sh
+++ b/plugins/dev/scripts/morning-briefing/gather-calendar.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# gather-calendar.sh — Pull Google Calendar events for a target day.
+#
+# Usage:
+#   gather-calendar.sh [--date YYYY-MM-DD] [--calendar-id ID]
+#
+# Requires GOOGLE_OAUTH_ACCESS_TOKEN. Optional GOOGLE_CALENDAR_ID (defaults to
+# 'primary'). Degrades silently to {} when creds are missing or network fails.
+
+set -uo pipefail
+
+DATE=""
+CAL_ID="${GOOGLE_CALENDAR_ID:-primary}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) DATE="$2"; shift 2 ;;
+    --calendar-id) CAL_ID="$2"; shift 2 ;;
+    -h|--help) sed -n '2,9p' "$0"; exit 0 ;;
+    *) echo "gather-calendar.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "${GOOGLE_OAUTH_ACCESS_TOKEN:-}" ]]; then
+  echo '{}'
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo '{}'
+  exit 0
+fi
+
+if [[ -z "$DATE" ]]; then
+  DATE="$(date -u +%Y-%m-%d)"
+fi
+
+# Day window: 00:00:00Z of $DATE through 23:59:59Z of $DATE.
+TIME_MIN="${DATE}T00:00:00Z"
+TIME_MAX="${DATE}T23:59:59Z"
+
+ENCODED_CAL=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$CAL_ID" 2>/dev/null || echo "primary")
+
+RESP=$(curl -fsSL --max-time 10 \
+  -H "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+  "https://www.googleapis.com/calendar/v3/calendars/${ENCODED_CAL}/events?timeMin=${TIME_MIN}&timeMax=${TIME_MAX}&singleEvents=true&orderBy=startTime" \
+  2>/dev/null || echo "")
+
+if [[ -z "$RESP" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+echo "$RESP" | jq -c '
+  {calendar: (
+    (.items // [])
+    | map({
+        id: (.id // ""),
+        title: (.summary // "(no title)"),
+        start: (.start.dateTime // .start.date // ""),
+        end: (.end.dateTime // .end.date // "")
+      })
+    | map(select(.id != ""))
+  )}
+' 2>/dev/null || echo '{}'

--- a/plugins/dev/scripts/morning-briefing/gather-drive.sh
+++ b/plugins/dev/scripts/morning-briefing/gather-drive.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# gather-drive.sh — Pull Google Drive files modified yesterday in the designated folder.
+#
+# Usage:
+#   gather-drive.sh [--date YYYY-MM-DD] [--folder-id FOLDERID] [--limit N]
+#
+# Requires GOOGLE_OAUTH_ACCESS_TOKEN in env (the caller is responsible for
+# refresh; MVP doesn't manage the refresh dance). Optional GOOGLE_DRIVE_FOLDER_ID
+# narrows to a folder (e.g. the meeting notes folder).
+# Degrades silently to {} when creds are missing or network fails.
+
+set -uo pipefail
+
+DATE=""
+FOLDER_ID="${GOOGLE_DRIVE_FOLDER_ID:-}"
+LIMIT=20
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) DATE="$2"; shift 2 ;;
+    --folder-id) FOLDER_ID="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    -h|--help) sed -n '2,11p' "$0"; exit 0 ;;
+    *) echo "gather-drive.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "${GOOGLE_OAUTH_ACCESS_TOKEN:-}" ]]; then
+  echo '{}'
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo '{}'
+  exit 0
+fi
+
+if [[ -z "$DATE" ]]; then
+  DATE="$(date -u +%Y-%m-%d)"
+fi
+
+YESTERDAY=$(date -u -d "${DATE} -1 day" +%Y-%m-%d 2>/dev/null \
+  || date -u -j -v-1d -f "%Y-%m-%d" "$DATE" +%Y-%m-%d 2>/dev/null \
+  || echo "")
+if [[ -z "$YESTERDAY" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+QUERY="modifiedTime >= '${YESTERDAY}T00:00:00Z' and modifiedTime < '${DATE}T00:00:00Z'"
+if [[ -n "$FOLDER_ID" ]]; then
+  QUERY="${QUERY} and '${FOLDER_ID}' in parents"
+fi
+
+# URL-encode the query — Drive API is picky.
+ENCODED_Q=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1]))' "$QUERY" 2>/dev/null || echo "")
+if [[ -z "$ENCODED_Q" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+RESP=$(curl -fsSL --max-time 10 \
+  -H "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+  "https://www.googleapis.com/drive/v3/files?q=${ENCODED_Q}&pageSize=${LIMIT}&fields=files(id,name,modifiedTime,webViewLink)" \
+  2>/dev/null || echo "")
+
+if [[ -z "$RESP" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+echo "$RESP" | jq -c '
+  {drive: (
+    (.files // [])
+    | map({
+        id: (.id // ""),
+        title: (.name // ""),
+        modified: (.modifiedTime // ""),
+        url: (.webViewLink // "")
+      })
+    | map(select(.id != ""))
+  )}
+' 2>/dev/null || echo '{}'

--- a/plugins/dev/scripts/morning-briefing/gather-github.sh
+++ b/plugins/dev/scripts/morning-briefing/gather-github.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# gather-github.sh — Pull merged PRs from the configured repo for the prior day.
+#
+# Usage:
+#   gather-github.sh [--date YYYY-MM-DD] [--repo OWNER/NAME] [--limit N]
+#
+# Prints {"github": [{"number":...,"title":...,"url":...,"author":...}, ...]}.
+# If `gh` is not on PATH or repo cannot be resolved, prints {} and exits 0.
+
+set -uo pipefail
+
+DATE=""
+REPO=""
+LIMIT=30
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) DATE="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "gather-github.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo '{}'
+  exit 0
+fi
+
+if [[ -z "$DATE" ]]; then
+  DATE="$(date -u +%Y-%m-%d)"
+fi
+
+YESTERDAY=$(date -u -d "${DATE} -1 day" +%Y-%m-%d 2>/dev/null \
+  || date -u -j -v-1d -f "%Y-%m-%d" "$DATE" +%Y-%m-%d 2>/dev/null \
+  || echo "")
+if [[ -z "$YESTERDAY" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Resolve repo from gh context (we're inside the worktree).
+if [[ -z "$REPO" ]]; then
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+fi
+if [[ -z "$REPO" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+GH_OUT=$(gh search prs \
+  --repo "$REPO" \
+  --merged-at "${YESTERDAY}..${DATE}" \
+  --limit "$LIMIT" \
+  --json number,title,url,author \
+  2>/dev/null || echo "[]")
+
+echo "$GH_OUT" | jq -c '
+  {github: (
+    . // []
+    | map({
+        number: (.number // 0),
+        title: (.title // ""),
+        url: (.url // ""),
+        author: (.author.login // "")
+      })
+    | map(select(.number != 0))
+  )}
+' 2>/dev/null || echo '{}'

--- a/plugins/dev/scripts/morning-briefing/gather-granola.sh
+++ b/plugins/dev/scripts/morning-briefing/gather-granola.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# gather-granola.sh — Pull yesterday's Granola meeting notes via REST.
+#
+# Usage:
+#   gather-granola.sh [--date YYYY-MM-DD] [--limit N]
+#
+# Requires GRANOLA_API_KEY in env. Prints {"granola": [...]} or {} when key is
+# absent / network fails. Never blocks the briefing.
+
+set -uo pipefail
+
+DATE=""
+LIMIT=10
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) DATE="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    -h|--help) sed -n '2,9p' "$0"; exit 0 ;;
+    *) echo "gather-granola.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "${GRANOLA_API_KEY:-}" ]]; then
+  echo '{}'
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo '{}'
+  exit 0
+fi
+
+if [[ -z "$DATE" ]]; then
+  DATE="$(date -u +%Y-%m-%d)"
+fi
+
+YESTERDAY=$(date -u -d "${DATE} -1 day" +%Y-%m-%d 2>/dev/null \
+  || date -u -j -v-1d -f "%Y-%m-%d" "$DATE" +%Y-%m-%d 2>/dev/null \
+  || echo "")
+if [[ -z "$YESTERDAY" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+CREATED_AFTER="${YESTERDAY}T00:00:00Z"
+CREATED_BEFORE="${DATE}T00:00:00Z"
+
+# Page size 1-30; default to 10 like the API. Network failures (timeout, 4xx, 5xx)
+# all degrade silently to {} so the briefing always renders.
+RESP=$(curl -fsSL --max-time 10 \
+  -H "Authorization: Bearer ${GRANOLA_API_KEY}" \
+  "https://public-api.granola.ai/v1/notes?page_size=${LIMIT}&created_after=${CREATED_AFTER}&created_before=${CREATED_BEFORE}" \
+  2>/dev/null || echo "")
+
+if [[ -z "$RESP" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+echo "$RESP" | jq -c '
+  {granola: (
+    (.notes // [])
+    | map({
+        id: (.id // ""),
+        title: (.title // ""),
+        created_at: (.created_at // "")
+      })
+    | map(select(.id != ""))
+  )}
+' 2>/dev/null || echo '{}'

--- a/plugins/dev/scripts/morning-briefing/gather-linear.sh
+++ b/plugins/dev/scripts/morning-briefing/gather-linear.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# gather-linear.sh — Pull yesterday's Linear state changes for the configured team.
+#
+# Usage:
+#   gather-linear.sh [--date YYYY-MM-DD] [--team TEAMKEY] [--limit N]
+#
+# Prints a JSON object: {"linear": [{"id":...,"title":...,"state":...,"url":...}, ...]}.
+# If `linearis` is not on PATH, or if no team is resolvable, prints {} and exits 0.
+# This script never blocks the briefing — credential/setup gaps degrade to no-data.
+
+set -uo pipefail
+
+DATE=""
+TEAM=""
+LIMIT=50
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) DATE="$2"; shift 2 ;;
+    --team) TEAM="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "gather-linear.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v linearis >/dev/null 2>&1; then
+  echo '{}'
+  exit 0
+fi
+
+if [[ -z "$DATE" ]]; then
+  DATE="$(date -u +%Y-%m-%d)"
+fi
+
+# Compute "yesterday" cutoff (24h before target date midnight UTC).
+# Portable approach — try GNU date first, fall back to BSD date.
+YESTERDAY=$(date -u -d "${DATE} -1 day" +%Y-%m-%d 2>/dev/null \
+  || date -u -j -v-1d -f "%Y-%m-%d" "$DATE" +%Y-%m-%d 2>/dev/null \
+  || echo "")
+if [[ -z "$YESTERDAY" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Resolve team key from .catalyst/config.json if not provided.
+if [[ -z "$TEAM" ]] && [[ -f .catalyst/config.json ]]; then
+  TEAM=$(jq -r '.catalyst.linear.teamKey // empty' .catalyst/config.json 2>/dev/null || echo "")
+fi
+if [[ -z "$TEAM" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Query Linear — updated since yesterday, limit results to keep briefing small.
+LIN_OUT=$(linearis issues list \
+  --team "$TEAM" \
+  --updated-after "$YESTERDAY" \
+  --limit "$LIMIT" 2>/dev/null || echo "")
+
+if [[ -z "$LIN_OUT" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Normalize. linearis outputs either an array or {"nodes": [...]} depending on subcommand.
+echo "$LIN_OUT" | jq -c '
+  ({linear:
+    ((. | type) as $t
+     | if $t == "array" then .
+       elif .nodes then .nodes
+       elif .issues then .issues
+       else [] end
+     | map({
+         id: (.identifier // .id // ""),
+         title: (.title // ""),
+         state: (.state.name // .status // ""),
+         url: (.url // "")
+       })
+     | map(select(.id != ""))
+    )
+  })
+' 2>/dev/null || echo '{}'

--- a/plugins/dev/scripts/morning-briefing/output-path.sh
+++ b/plugins/dev/scripts/morning-briefing/output-path.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# output-path.sh — Resolve the output path for the morning briefing markdown.
+#
+# Usage:
+#   output-path.sh [--date YYYY-MM-DD] [--dry-run] [--root DIR]
+#
+# Prints an absolute (or root-relative) path. Default root is the repo CWD;
+# dry-run uses /tmp.
+
+set -euo pipefail
+
+DATE=""
+DRY_RUN=0
+ROOT="${PWD}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) DATE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --root) ROOT="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,8p' "$0"; exit 0 ;;
+    *)
+      echo "output-path.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$DATE" ]]; then
+  DATE="$(date -u +%Y-%m-%d)"
+fi
+
+if ! [[ "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "output-path.sh: --date must be YYYY-MM-DD, got: $DATE" >&2
+  exit 2
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '/tmp/morning-briefing-%s.md\n' "$DATE"
+else
+  printf '%s/thoughts/briefings/%s.md\n' "$ROOT" "$DATE"
+fi

--- a/plugins/dev/scripts/morning-briefing/render.sh
+++ b/plugins/dev/scripts/morning-briefing/render.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# render.sh — Render the canonical morning-briefing markdown from a JSON input.
+#
+# Usage:
+#   render.sh --input <json-file> --output <md-file>
+#   cat data.json | render.sh --output <md-file>
+#
+# Input JSON shape:
+# {
+#   "date": "YYYY-MM-DD",
+#   "yesterday": {
+#     "linear":   [{"id":"CTL-100","title":"...","state":"Done"}, ...],
+#     "github":   [{"number":799,"title":"...","url":"..."}, ...],
+#     "granola":  [{"id":"not_...","title":"...","created_at":"..."}, ...],
+#     "drive":    [{"id":"...","title":"...","modified":"..."}, ...],
+#     "calendar": [{"id":"...","title":"...","start":"..."}, ...]
+#   },
+#   "decisions": [{"id":"...","type":"...","summary":"...","status":"..."}, ...],
+#   "today": {
+#     "linear_in_progress": [{"id":"CTL-200","title":"..."}, ...],
+#     "calendar":           [{"title":"...","start":"..."}, ...],
+#     "followups":          [{"source":"granola","action":"..."}, ...]
+#   },
+#   "suggested_runs": [{"id":"CTL-300","title":"...","priority":"High"}, ...]
+# }
+
+set -euo pipefail
+
+INPUT=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input) INPUT="$2"; shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "render.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$OUTPUT" ]]; then
+  echo "render.sh: --output is required" >&2
+  exit 2
+fi
+
+# Load input JSON (file or stdin)
+if [[ -n "$INPUT" ]]; then
+  [[ -f "$INPUT" ]] || { echo "render.sh: --input file not found: $INPUT" >&2; exit 2; }
+  DATA=$(cat "$INPUT")
+else
+  DATA=$(cat)
+fi
+
+# Validate it parses as JSON
+if ! jq -e . >/dev/null 2>&1 <<<"$DATA"; then
+  echo "render.sh: input is not valid JSON" >&2
+  exit 2
+fi
+
+DATE=$(jq -r '.date // empty' <<<"$DATA")
+if [[ -z "$DATE" ]]; then
+  echo "render.sh: input JSON must have a .date field" >&2
+  exit 2
+fi
+
+# Ensure output dir exists
+mkdir -p "$(dirname "$OUTPUT")"
+
+# Render the frontmatter — emit YAML by hand for stable formatting.
+# Items are JSON-encoded so they survive special characters.
+render_section() {
+  local section_key="$1"
+  local heading="$2"
+  local items
+  items=$(jq -c "(${section_key}) // []" <<<"$DATA")
+  local count
+  count=$(jq -r 'length' <<<"$items")
+
+  echo "## ${heading}"
+  echo
+  if [[ "$count" -eq 0 ]]; then
+    echo "_no data_"
+    echo
+    return
+  fi
+
+  jq -r '.[] | "- " + (
+    if .title and .id then "[\(.id)] \(.title)"
+    elif .title and .number then "[#\(.number)] \(.title)"
+    elif .title then .title
+    elif .summary then .summary
+    elif .action then .action
+    else (. | tostring) end
+  ) + (if (.url // "") != "" then "  <\(.url)>" else "" end)' <<<"$items"
+  echo
+}
+
+{
+  echo "---"
+  # Use python yaml for safe serialization of arbitrary structure
+  jq -n \
+    --arg date "$DATE" \
+    --argjson decisions "$(jq -c '.decisions // []' <<<"$DATA")" \
+    --argjson meetings "$(jq -c '.yesterday.granola // []' <<<"$DATA")" \
+    --argjson prs "$(jq -c '.yesterday.github // []' <<<"$DATA")" \
+    '{
+      date: $date,
+      generated_by: "morning-briefing",
+      decisions: $decisions,
+      meetings_yesterday: $meetings,
+      prs_merged_yesterday: $prs
+    }' | python3 -c 'import sys, json, yaml; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False, sort_keys=False)'
+  echo "---"
+  echo
+  echo "# Morning Briefing — ${DATE}"
+  echo
+
+  echo "## Review yesterday"
+  echo
+  render_section '.yesterday.linear'  'Linear (state changes)' | sed 's/^## /### /'
+  render_section '.yesterday.github'  'GitHub (merged PRs)'    | sed 's/^## /### /'
+  render_section '.yesterday.granola' 'Granola (meetings)'     | sed 's/^## /### /'
+  render_section '.yesterday.drive'   'Drive (notes)'          | sed 's/^## /### /'
+  render_section '.yesterday.calendar' 'Calendar (events)'     | sed 's/^## /### /'
+
+  echo "## Surface decisions"
+  echo
+  decisions_count=$(jq -r '(.decisions // []) | length' <<<"$DATA")
+  if [[ "$decisions_count" -eq 0 ]]; then
+    echo "_no data_"
+    echo
+  else
+    jq -r '.decisions[] | "- **[" + .type + "]** " + .summary + " (`" + .id + "`, status: " + .status + ")"' <<<"$DATA"
+    echo
+  fi
+
+  echo "## Plan today"
+  echo
+  render_section '.today.linear_in_progress' 'Linear in-progress' | sed 's/^## /### /'
+  render_section '.today.calendar'           'Calendar today'     | sed 's/^## /### /'
+  render_section '.today.followups'          'Follow-ups'         | sed 's/^## /### /'
+
+  echo "## Suggest orchestrator runs"
+  echo
+  runs_count=$(jq -r '(.suggested_runs // []) | length' <<<"$DATA")
+  if [[ "$runs_count" -eq 0 ]]; then
+    echo "_no data_"
+  else
+    jq -r '.suggested_runs[] | "- `" + .id + "` " + .title + (if .priority then " _(\(.priority))_" else "" end)' <<<"$DATA"
+  fi
+  echo
+} > "$OUTPUT"
+
+printf '%s\n' "$OUTPUT"

--- a/plugins/dev/scripts/morning-briefing/validate-frontmatter.sh
+++ b/plugins/dev/scripts/morning-briefing/validate-frontmatter.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# validate-frontmatter.sh — Validate the YAML frontmatter of a briefing markdown
+# file against plugins/dev/templates/briefing-frontmatter.schema.json.
+#
+# Usage:
+#   validate-frontmatter.sh <briefing.md>
+#
+# Exit 0 = valid, exit 1 = invalid (with diagnostics on stderr).
+
+set -euo pipefail
+
+FILE="${1:-}"
+if [[ -z "$FILE" ]]; then
+  echo "validate-frontmatter.sh: missing path argument" >&2
+  exit 2
+fi
+if [[ ! -f "$FILE" ]]; then
+  echo "validate-frontmatter.sh: file not found: $FILE" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA="${SCRIPT_DIR}/../../templates/briefing-frontmatter.schema.json"
+if [[ ! -f "$SCHEMA" ]]; then
+  echo "validate-frontmatter.sh: schema not found at $SCHEMA" >&2
+  exit 2
+fi
+
+# Extract the first --- ... --- block.
+FRONTMATTER=$(awk '
+  /^---[[:space:]]*$/ {
+    if (in_block) { exit }
+    in_block = 1; next
+  }
+  in_block { print }
+' "$FILE")
+
+if [[ -z "$FRONTMATTER" ]]; then
+  echo "validate-frontmatter.sh: no frontmatter block found in $FILE" >&2
+  exit 1
+fi
+
+# YAML → JSON via python, then validate via jsonschema.
+JSON=$(printf '%s\n' "$FRONTMATTER" | python3 -c 'import sys, json, yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout)') || {
+  echo "validate-frontmatter.sh: failed to parse YAML frontmatter" >&2
+  exit 1
+}
+
+# jsonschema CLI takes the instance from stdin via -i - in some versions; use a tempfile for portability.
+INSTANCE_TMP=$(mktemp)
+trap 'rm -f "$INSTANCE_TMP"' EXIT
+printf '%s' "$JSON" > "$INSTANCE_TMP"
+
+if ! jsonschema -i "$INSTANCE_TMP" "$SCHEMA" 2>/tmp/.morning-briefing-validate-err.$$; then
+  echo "validate-frontmatter.sh: schema validation failed for $FILE" >&2
+  cat /tmp/.morning-briefing-validate-err.$$ >&2
+  rm -f /tmp/.morning-briefing-validate-err.$$
+  exit 1
+fi
+rm -f /tmp/.morning-briefing-validate-err.$$
+
+echo "ok"
+exit 0

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: morning-briefing
+description:
+  Generate a daily briefing markdown at thoughts/briefings/YYYY-MM-DD.md with four sections —
+  Review yesterday, Surface decisions, Plan today, Suggest orchestrator runs — synthesized from
+  Linear, GitHub, Granola, Google Drive, and Google Calendar in parallel. User-invoked from
+  `/catalyst-dev:morning-briefing` for ad-hoc runs. The CMA Routine wraps the same skill on a
+  weekday-morning schedule (Phase 5 of the parent plan).
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, mcp__linear__*, mcp__notion__*
+---
+
+# Morning Briefing — canonical markdown MVP
+
+## When to use
+
+Invoke as `/catalyst-dev:morning-briefing` to produce today's briefing locally. Multi-output
+fan-out (Slack DM, Notion, channel post, Loom script) is **Phase 3** of the parent plan
+([[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 2 Phase 3) and lives in different
+files; this skill only emits the canonical markdown.
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--date YYYY-MM-DD` | Target date. Default: today (UTC). |
+| `--dry-run` | Write to `/tmp/morning-briefing-<date>.md` instead of `thoughts/briefings/`. |
+
+## Step 1: Prelude — start session, resolve date
+
+```bash
+SCRIPT_DIR="${CLAUDE_PLUGIN_ROOT:-plugins/dev}/scripts/morning-briefing"
+SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT:-plugins/dev}/scripts/catalyst-session.sh"
+
+CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "morning-briefing" \
+  --ticket "" --workflow "${CATALYST_SESSION_ID:-}")
+export CATALYST_SESSION_ID
+
+# Resolve target date + output path. Pass --dry-run / --date through from the user.
+OUT_PATH=$(bash "$SCRIPT_DIR/output-path.sh" "$@")
+DATE=$(basename "$OUT_PATH" .md | sed 's/^morning-briefing-//')
+echo "Target date: $DATE"
+echo "Output path: $OUT_PATH"
+```
+
+## Step 2: Gather "yesterday" — parallel MCP/CLI queries
+
+Launch the five gather helpers in parallel. Each prints a JSON fragment to its own scratch file;
+each degrades silently to `{}` if its credentials are absent so the briefing always renders.
+
+```bash
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+bash "$SCRIPT_DIR/gather-linear.sh"   --date "$DATE" > "$SCRATCH/linear.json"   &
+bash "$SCRIPT_DIR/gather-github.sh"   --date "$DATE" > "$SCRATCH/github.json"   &
+bash "$SCRIPT_DIR/gather-granola.sh"  --date "$DATE" > "$SCRATCH/granola.json"  &
+bash "$SCRIPT_DIR/gather-drive.sh"    --date "$DATE" > "$SCRATCH/drive.json"    &
+bash "$SCRIPT_DIR/gather-calendar.sh" --date "$DATE" > "$SCRATCH/calendar.json" &
+wait
+```
+
+If a richer Linear or Notion query is needed beyond what the CLI/REST helpers expose, use the
+`mcp__linear__*` / `mcp__notion__*` tools directly from this skill — write the result to
+`$SCRATCH/<source>.json` in the same shape (`{"<source>": [...]}`).
+
+## Step 3: Gather "decisions"
+
+For the MVP, populate the `decisions:` array from two heuristics:
+
+1. **Blocked PRs** — `gh search prs --review-requested @me --state open --json …` filtered to
+   PRs with no commit in the last 48h. Each becomes one `{type: blocked_pr, …}` decision.
+2. **Judgment-call Linear tickets** — `linearis issues list --team <team> --status "Triage,In Progress" --label needs-decision` (label name is informational; substitute whatever signal the operator uses).
+
+ADR drift detection is **Phase 4** of the parent plan — do NOT implement it here. Emit an empty
+list if no signals are found.
+
+Synthesize into a `decisions.json` fragment:
+
+```bash
+cat > "$SCRATCH/decisions.json" <<JSON
+{"decisions": []}
+JSON
+# Append blocked-PR decisions / judgment-call decisions as discovered.
+```
+
+## Step 4: Gather "today"
+
+- In-progress Linear tickets — `linearis issues list --team <team> --status "In Progress" --limit 20`
+- Today's calendar — already gathered in Step 2, reuse `$SCRATCH/calendar.json`
+- Follow-ups — extract action items from the prior day's Granola notes (`$SCRATCH/granola.json`)
+  via a Claude-side synthesis pass
+
+```bash
+cat > "$SCRATCH/today.json" <<JSON
+{"today": {"linear_in_progress": [], "calendar": [], "followups": []}}
+JSON
+```
+
+## Step 5: Suggest orchestrator runs
+
+Query Linear for tickets that look ready for `/catalyst-dev:orchestrate`:
+
+```bash
+linearis issues list \
+  --team "$(jq -r '.catalyst.linear.teamKey' .catalyst/config.json)" \
+  --status "Triage,Backlog" \
+  --priority 1 --priority 2 \
+  --limit 10 \
+  2>/dev/null \
+  | jq -c '{suggested_runs: ([.[] | select(.relations.nodes // [] | map(select(.type=="blocked_by")) | length == 0)] | map({id: .identifier, title: .title, priority: (.priority|tostring)}))}' \
+  > "$SCRATCH/suggested.json" 2>/dev/null || echo '{"suggested_runs": []}' > "$SCRATCH/suggested.json"
+```
+
+## Step 6: Render the markdown
+
+Merge all fragments into one input JSON, then call `render.sh`.
+
+```bash
+jq -s --arg date "$DATE" '
+  {date: $date}
+  + {yesterday: ((.[0] // {}) + (.[1] // {}) + (.[2] // {}) + (.[3] // {}) + (.[4] // {}))}
+  + (.[5] // {})
+  + (.[6] // {})
+  + (.[7] // {})
+' \
+  "$SCRATCH/linear.json" \
+  "$SCRATCH/github.json" \
+  "$SCRATCH/granola.json" \
+  "$SCRATCH/drive.json" \
+  "$SCRATCH/calendar.json" \
+  "$SCRATCH/decisions.json" \
+  "$SCRATCH/today.json" \
+  "$SCRATCH/suggested.json" \
+  > "$SCRATCH/input.json"
+
+bash "$SCRIPT_DIR/render.sh" --input "$SCRATCH/input.json" --output "$OUT_PATH"
+
+# Sanity-check the frontmatter against the schema before declaring success.
+bash "$SCRIPT_DIR/validate-frontmatter.sh" "$OUT_PATH"
+```
+
+## Step 7: End session
+
+```bash
+"$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done --reason "morning-briefing rendered"
+echo "Wrote: $OUT_PATH"
+```
+
+## Output contract
+
+The rendered markdown has YAML frontmatter validated against
+`plugins/dev/templates/briefing-frontmatter.schema.json` (required fields: `date`,
+`generated_by`, `decisions`). Four `## ...` sections follow. Empty sources render
+`_no data_` rather than failing.
+
+Downstream Phase 3 fan-out scripts read this file as their sole input — they MUST NOT
+re-query the source MCPs.

--- a/plugins/dev/templates/briefing-frontmatter.schema.json
+++ b/plugins/dev/templates/briefing-frontmatter.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MorningBriefingFrontmatter",
+  "description": "YAML frontmatter contract for thoughts/briefings/YYYY-MM-DD.md (CTL-457)",
+  "type": "object",
+  "required": ["date", "generated_by", "decisions"],
+  "properties": {
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "generated_by": {
+      "type": "string",
+      "const": "morning-briefing"
+    },
+    "decisions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "summary", "status"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "type": {
+            "type": "string",
+            "enum": ["adr_drift", "blocked_pr", "judgment_call", "scope_question"]
+          },
+          "summary": { "type": "string", "minLength": 1 },
+          "status": {
+            "type": "string",
+            "enum": ["open", "resolved", "deferred"]
+          },
+          "pr_url": { "type": "string" },
+          "ticket": { "type": "string" },
+          "adr": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "meetings_yesterday": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "prs_merged_yesterday": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "output_status": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["success", "failed", "skipped"]
+      }
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary

Implements **CTL-457 — Phase 2: morning-briefing skill MVP (canonical markdown only)** from the parent plan ([thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md §Initiative 2 Phase 2](thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md)).

- Adds `/catalyst-dev:morning-briefing` — user-invocable skill that produces `thoughts/briefings/YYYY-MM-DD.md` with 4 sections (Review yesterday / Surface decisions / Plan today / Suggest orchestrator runs) plus structured YAML frontmatter (`date`, `generated_by`, `decisions[]`).
- Source data fans in from 5 per-source gather helpers: Linear (via `linearis`), GitHub (via `gh`), Granola (REST + `GRANOLA_API_KEY`), Google Drive + Calendar (REST + OAuth access token). Each helper **degrades silently to `{}` when its credentials are absent** so the briefing always renders.
- Rendering + validation are pure shell — `render.sh`, `output-path.sh`, `validate-frontmatter.sh` — backed by a JSON Schema at `plugins/dev/templates/briefing-frontmatter.schema.json`.

## What's NOT in this PR (deferred to later phases)

- Slack DM / Notion / Slack channel / Loom script fan-out (Initiative 2 Phase 3)
- ADR drift detector (Initiative 2 Phase 4)
- CMA Routine wiring + schedule (Initiative 2 Phase 5)
- OAuth refresh-token plumbing for Drive/Calendar — MVP reads env vars directly

## Files

```
plugins/dev/skills/morning-briefing/SKILL.md
plugins/dev/scripts/morning-briefing/render.sh
plugins/dev/scripts/morning-briefing/output-path.sh
plugins/dev/scripts/morning-briefing/validate-frontmatter.sh
plugins/dev/scripts/morning-briefing/gather-{linear,github,granola,drive,calendar}.sh
plugins/dev/templates/briefing-frontmatter.schema.json
plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh
```

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh` — 36/36 passing
- [x] Frontmatter validates against `briefing-frontmatter.schema.json` (covered by `test_validate_frontmatter_passes` + the end-to-end test)
- [x] Real local smoke test with `--dry-run` produces a readable briefing populated with real Linear + GitHub data; sources without configured creds show as `_no data_`
- [ ] Manual verification on a normal workday with Granola/Drive/Calendar creds wired (out of scope — those creds aren't provisioned yet)

Refs CTL-457.