### PR TITLE
feat(dev): ADR-drift detector for morning-briefing Step 3 (CTL-459)

### DIFF
--- a/plugins/dev/scripts/__tests__/adr-drift-detector.test.sh
+++ b/plugins/dev/scripts/__tests__/adr-drift-detector.test.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Tests for adr-drift.sh — the ADR-drift detector (CTL-459).
+# Run: bash plugins/dev/scripts/__tests__/adr-drift-detector.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/plugins/dev/scripts/morning-briefing/adr-drift.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_json_eq() {
+  local label="$1" expected_jq="$2" actual_json="$3" expected_val="$4"
+  local val
+  val=$(jq -r "$expected_jq" <<<"$actual_json" 2>/dev/null || echo "JQ_ERR")
+  assert_eq "$label" "$expected_val" "$val"
+}
+
+assert_exit_code() {
+  local label="$1" expected="$2" actual="$3"
+  assert_eq "$label" "$expected" "$actual"
+}
+
+# ---- fixture builders ---------------------------------------------------------
+
+# Build a project tree with an ADR directory and a code tree.
+#   $1 — project root dir
+make_project() {
+  local root="$1"
+  mkdir -p "$root/docs/adrs" "$root/src" "$root/.catalyst"
+  cat > "$root/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "test",
+    "adrs": { "directory": "docs/adrs" }
+  }
+}
+EOF
+}
+
+write_adr() {
+  local path="$1" frontmatter="$2" body="${3:-}"
+  cat > "$path" <<EOF
+---
+${frontmatter}
+---
+
+# $(basename "$path" .md)
+
+${body}
+EOF
+}
+
+# ---- Test 1: empty / missing dir produces no decisions ------------------------
+
+echo "Test 1: missing adrs-dir produces no false positives"
+PROJ="$SCRATCH/proj1"
+mkdir -p "$PROJ"
+# No docs/adrs, no .catalyst config
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+RC=$?
+assert_exit_code "1.1 exit 0 when no ADRs dir" "0" "$RC"
+assert_json_eq "1.2 decisions empty" '.decisions | length' "$OUT" "0"
+
+# ---- Test 2: ADR with passing assertion → no drift ----------------------------
+
+echo "Test 2: ADR assertion matches code → no drift"
+PROJ="$SCRATCH/proj2"
+make_project "$PROJ"
+echo "function getThing() { return 42; }" > "$PROJ/src/lib.js"
+write_adr "$PROJ/docs/adrs/0001-getthing.md" 'adr_id: ADR-001
+code_assertions:
+  - pattern: "getThing"
+    expectation: found
+    description: "getThing function exists"'
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+RC=$?
+assert_exit_code "2.1 exit 0" "0" "$RC"
+assert_json_eq "2.2 decisions empty (assertion held)" '.decisions | length' "$OUT" "0"
+
+# ---- Test 3: adr_ahead_of_code drift ------------------------------------------
+
+echo "Test 3: pattern not in code, expectation=found → adr_ahead_of_code"
+PROJ="$SCRATCH/proj3"
+make_project "$PROJ"
+echo "// no relevant code here" > "$PROJ/src/lib.js"
+write_adr "$PROJ/docs/adrs/0002-missing.md" 'adr_id: ADR-002
+code_assertions:
+  - pattern: "MissingFunction"
+    expectation: found
+    description: "ADR requires MissingFunction in codebase"'
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+RC=$?
+assert_exit_code "3.1 exit 0" "0" "$RC"
+assert_json_eq "3.2 one decision" '.decisions | length' "$OUT" "1"
+assert_json_eq "3.3 type=adr_drift" '.decisions[0].type' "$OUT" "adr_drift"
+assert_json_eq "3.4 drift_status correct" '.decisions[0].drift_status' "$OUT" "adr_ahead_of_code"
+assert_json_eq "3.5 status=open" '.decisions[0].status' "$OUT" "open"
+assert_json_eq "3.6 has summary" '.decisions[0].summary | length > 0' "$OUT" "true"
+assert_json_eq "3.7 has id" '.decisions[0].id | length > 0' "$OUT" "true"
+assert_json_eq "3.8 adr path set" '.decisions[0].adr | test("0002-missing.md$")' "$OUT" "true"
+
+# ---- Test 4: code_ahead_of_adr drift ------------------------------------------
+
+echo "Test 4: pattern in code, expectation=not_found → code_ahead_of_adr"
+PROJ="$SCRATCH/proj4"
+make_project "$PROJ"
+echo "const NEW_API = require('./new-api');" > "$PROJ/src/lib.js"
+write_adr "$PROJ/docs/adrs/0003-stale.md" 'adr_id: ADR-003
+code_assertions:
+  - pattern: "NEW_API"
+    expectation: not_found
+    description: "Old ADR forbade NEW_API but it has shipped"'
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+RC=$?
+assert_exit_code "4.1 exit 0" "0" "$RC"
+assert_json_eq "4.2 one decision" '.decisions | length' "$OUT" "1"
+assert_json_eq "4.3 drift_status correct" '.decisions[0].drift_status' "$OUT" "code_ahead_of_adr"
+
+# ---- Test 5: ADR without code_assertions is skipped ---------------------------
+
+echo "Test 5: ADR without code_assertions → no decisions"
+PROJ="$SCRATCH/proj5"
+make_project "$PROJ"
+write_adr "$PROJ/docs/adrs/0004-narrative.md" 'adr_id: ADR-004
+title: "Decision without assertions"'
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+RC=$?
+assert_exit_code "5.1 exit 0" "0" "$RC"
+assert_json_eq "5.2 no decisions" '.decisions | length' "$OUT" "0"
+
+# ---- Test 6: multiple assertions, mixed pass/fail -----------------------------
+
+echo "Test 6: multiple assertions in one ADR"
+PROJ="$SCRATCH/proj6"
+make_project "$PROJ"
+echo "function alpha() {}" > "$PROJ/src/code.js"
+# alpha: found (passes), beta: not found (fails), gamma: not found, expects not_found (passes)
+write_adr "$PROJ/docs/adrs/0005-multi.md" 'adr_id: ADR-005
+code_assertions:
+  - pattern: "alpha"
+    expectation: found
+    description: "alpha exists"
+  - pattern: "beta"
+    expectation: found
+    description: "beta exists"
+  - pattern: "gamma"
+    expectation: not_found
+    description: "gamma not yet introduced"'
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+RC=$?
+assert_exit_code "6.1 exit 0" "0" "$RC"
+assert_json_eq "6.2 exactly one drift (beta)" '.decisions | length' "$OUT" "1"
+assert_json_eq "6.3 drift is for beta" '.decisions[0].summary | test("beta")' "$OUT" "true"
+
+# ---- Test 7: schema-conforming output -----------------------------------------
+
+echo "Test 7: output conforms to briefing schema (id/type/summary/status required)"
+PROJ="$SCRATCH/proj7"
+make_project "$PROJ"
+write_adr "$PROJ/docs/adrs/0006-schema.md" 'adr_id: ADR-006
+code_assertions:
+  - pattern: "ThisWillNotExist123"
+    expectation: found
+    description: "required field test"'
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+assert_json_eq "7.0 at least one decision produced" '.decisions | length >= 1' "$OUT" "true"
+# Every decision must have id, type, summary, status — all strings, non-empty
+assert_json_eq "7.1 all decisions have id" '([.decisions[] | select(.id and (.id | length > 0))] | length) == (.decisions | length)' "$OUT" "true"
+assert_json_eq "7.2 all decisions have type=adr_drift" '([.decisions[] | select(.type == "adr_drift")] | length) == (.decisions | length)' "$OUT" "true"
+assert_json_eq "7.3 all decisions have summary" '([.decisions[] | select(.summary and (.summary | length > 0))] | length) == (.decisions | length)' "$OUT" "true"
+assert_json_eq "7.4 all decisions have status" '([.decisions[] | select(.status)] | length) == (.decisions | length)' "$OUT" "true"
+
+# ---- Test 8: malformed YAML doesn't crash the run -----------------------------
+
+echo "Test 8: malformed YAML in one ADR is tolerated"
+PROJ="$SCRATCH/proj8"
+make_project "$PROJ"
+# One good ADR + one with broken YAML
+write_adr "$PROJ/docs/adrs/0007-good.md" 'adr_id: ADR-007
+code_assertions:
+  - pattern: "ZetaZetaZeta"
+    expectation: found
+    description: "missing"'
+cat > "$PROJ/docs/adrs/0008-broken.md" <<'EOF'
+---
+adr_id: ADR-008
+code_assertions:
+  - pattern: "[invalid yaml here
+    expectation: bad
+EOF
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+RC=$?
+assert_exit_code "8.1 exit 0 despite bad YAML" "0" "$RC"
+# Good ADR's drift should still appear (broken one skipped)
+assert_json_eq "8.2 at least one decision (good ADR processed)" '.decisions | length >= 1' "$OUT" "true"
+
+# ---- Test 9: config-driven adrs.directory -------------------------------------
+
+echo "Test 9: catalyst.adrs.directory config is honored"
+PROJ="$SCRATCH/proj9"
+mkdir -p "$PROJ/custom/adrs-here" "$PROJ/src" "$PROJ/.catalyst"
+cat > "$PROJ/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "test",
+    "adrs": { "directory": "custom/adrs-here" }
+  }
+}
+EOF
+write_adr "$PROJ/custom/adrs-here/0009-cfg.md" 'adr_id: ADR-009
+code_assertions:
+  - pattern: "ConfigDrivenMissing"
+    expectation: found
+    description: "checks config-driven path"'
+OUT=$(bash "$SCRIPT" --root "$PROJ" 2>&1)
+RC=$?
+assert_exit_code "9.1 exit 0" "0" "$RC"
+assert_json_eq "9.2 finds drift via configured dir" '.decisions | length' "$OUT" "1"
+
+# ---- Test 10: --adrs-dir flag overrides config --------------------------------
+
+echo "Test 10: --adrs-dir flag overrides config"
+PROJ="$SCRATCH/proj10"
+make_project "$PROJ"  # configures docs/adrs (empty)
+mkdir -p "$PROJ/other/adrs"
+write_adr "$PROJ/other/adrs/0010-other.md" 'adr_id: ADR-010
+code_assertions:
+  - pattern: "FlagOverride"
+    expectation: found
+    description: "flag wins"'
+OUT=$(bash "$SCRIPT" --root "$PROJ" --adrs-dir "$PROJ/other/adrs" 2>&1)
+RC=$?
+assert_exit_code "10.1 exit 0" "0" "$RC"
+assert_json_eq "10.2 flag-specified dir used" '.decisions | length' "$OUT" "1"
+
+# ---- summary ------------------------------------------------------------------
+
+echo
+echo "============================================="
+echo "  PASSES:   $PASSES"
+echo "  FAILURES: $FAILURES"
+echo "============================================="
+
+[[ "$FAILURES" -eq 0 ]] || exit 1
+exit 0

--- a/plugins/dev/scripts/morning-briefing/adr-drift.sh
+++ b/plugins/dev/scripts/morning-briefing/adr-drift.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# adr-drift.sh — Detect drift between ADR `code_assertions` and the current codebase.
+#
+# Usage:
+#   adr-drift.sh [--adrs-dir DIR] [--root DIR] [--deep-adr-check]
+#
+# Reads ADR markdown files with YAML frontmatter:
+#   ---
+#   adr_id: ADR-005
+#   code_assertions:
+#     - pattern: "regex"
+#       expectation: found | not_found
+#       description: "human label"
+#   ---
+#
+# For each assertion, greps the codebase. Emits drift records to stdout:
+#   {"decisions": [{"id": ..., "type": "adr_drift", "summary": ..., "status": "open",
+#                   "adr": ..., "drift_status": ..., "pattern": ...}, ...]}
+#
+# Always exits 0. Silent no-op when the configured ADRs directory does not exist —
+# this satisfies the "zero false positives on the catalyst single-file legacy layout"
+# acceptance criterion.
+#
+# See plugins/dev/skills/morning-briefing/ADR-DRIFT.md for the full convention.
+
+set -uo pipefail
+
+ADRS_DIR=""
+ROOT="."
+DEEP=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --adrs-dir) ADRS_DIR="$2"; shift 2 ;;
+    --root) ROOT="$2"; shift 2 ;;
+    --deep-adr-check) DEEP=true; shift ;;
+    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "adr-drift.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+# Normalize root to an absolute path so subsequent paths are unambiguous.
+if [[ -d "$ROOT" ]]; then
+  ROOT="$(cd "$ROOT" && pwd)"
+fi
+
+# Resolve adrs-dir: flag wins, then .catalyst/config.json, then default.
+if [[ -z "$ADRS_DIR" ]]; then
+  if [[ -f "$ROOT/.catalyst/config.json" ]] && command -v jq >/dev/null 2>&1; then
+    ADRS_DIR=$(jq -r '.catalyst.adrs.directory // "docs/adrs"' "$ROOT/.catalyst/config.json" 2>/dev/null || echo "docs/adrs")
+  else
+    ADRS_DIR="docs/adrs"
+  fi
+fi
+[[ "$ADRS_DIR" = /* ]] || ADRS_DIR="$ROOT/$ADRS_DIR"
+
+# Silent no-op when the configured directory doesn't exist. Single-file ADR layouts
+# (e.g. catalyst's own docs/adrs.md) intentionally fall here — they're informational
+# only and produce zero structured drift records.
+if [[ ! -d "$ADRS_DIR" ]]; then
+  echo '{"decisions": []}'
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo '{"decisions": []}'
+  exit 0
+fi
+
+# Extract code_assertions for one ADR file as a JSON array. Empty array if no
+# frontmatter, no code_assertions, or YAML is malformed (logged to stderr).
+extract_assertions() {
+  local file="$1"
+  python3 - "$file" <<'PY' 2>/dev/null || echo '[]'
+import json, sys
+try:
+    import yaml
+except ImportError:
+    print("[]")
+    sys.exit(0)
+path = sys.argv[1]
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+except Exception:
+    print("[]")
+    sys.exit(0)
+if not text.startswith("---"):
+    print("[]")
+    sys.exit(0)
+end = text.find("\n---", 3)
+if end == -1:
+    print("[]")
+    sys.exit(0)
+fm = text[3:end].lstrip("\n")
+try:
+    data = yaml.safe_load(fm) or {}
+except yaml.YAMLError as e:
+    sys.stderr.write(f"adr-drift: skipping {path}: bad YAML ({e})\n")
+    print("[]")
+    sys.exit(0)
+if not isinstance(data, dict):
+    print("[]")
+    sys.exit(0)
+assertions = data.get("code_assertions") or []
+if not isinstance(assertions, list):
+    print("[]")
+    sys.exit(0)
+clean = []
+for a in assertions:
+    if not isinstance(a, dict):
+        continue
+    pattern = a.get("pattern")
+    if not isinstance(pattern, str) or not pattern:
+        continue
+    expectation = a.get("expectation", "found")
+    if expectation not in ("found", "not_found"):
+        expectation = "found"
+    description = a.get("description") or ""
+    if not isinstance(description, str):
+        description = str(description)
+    clean.append({"pattern": pattern, "expectation": expectation, "description": description})
+print(json.dumps(clean))
+PY
+}
+
+# Check whether $1 matches anywhere under $ROOT. Excludes vendor / generated dirs
+# AND the ADRs directory itself (so an assertion's own pattern text isn't a self-hit).
+pattern_present() {
+  local pattern="$1"
+  local adrs_basename
+  adrs_basename=$(basename "$ADRS_DIR")
+  grep -rE \
+    --exclude-dir=.git \
+    --exclude-dir=node_modules \
+    --exclude-dir=thoughts \
+    --exclude-dir=dist \
+    --exclude-dir=build \
+    --exclude-dir=.next \
+    --exclude-dir=.venv \
+    --exclude-dir=__pycache__ \
+    --exclude-dir="$adrs_basename" \
+    -l "$pattern" "$ROOT" >/dev/null 2>&1
+}
+
+DRIFTS='[]'
+
+shopt -s nullglob
+for adr in "$ADRS_DIR"/*.md; do
+  [[ -f "$adr" ]] || continue
+  ASSERTS=$(extract_assertions "$adr")
+  COUNT=$(jq 'length' <<<"$ASSERTS" 2>/dev/null || echo 0)
+  [[ "$COUNT" -gt 0 ]] || continue
+
+  ADR_BASE=$(basename "$adr" .md)
+  IDX=0
+  while IFS= read -r ASSERT; do
+    [[ -z "$ASSERT" ]] && continue
+    PATTERN=$(jq -r '.pattern' <<<"$ASSERT")
+    EXPECTATION=$(jq -r '.expectation' <<<"$ASSERT")
+    DESCRIPTION=$(jq -r '.description' <<<"$ASSERT")
+
+    if pattern_present "$PATTERN"; then
+      FOUND=true
+    else
+      FOUND=false
+    fi
+
+    DRIFT=""
+    case "$EXPECTATION" in
+      found)     [[ "$FOUND" == "false" ]] && DRIFT="adr_ahead_of_code" ;;
+      not_found) [[ "$FOUND" == "true"  ]] && DRIFT="code_ahead_of_adr" ;;
+    esac
+
+    if [[ -n "$DRIFT" ]]; then
+      SUMMARY="ADR ${ADR_BASE} drift (${DRIFT}): ${DESCRIPTION:-$PATTERN}"
+      DRIFTS=$(jq \
+        --arg id "adr-drift-${ADR_BASE}-${IDX}" \
+        --arg summary "$SUMMARY" \
+        --arg adr "$adr" \
+        --arg drift_status "$DRIFT" \
+        --arg pattern "$PATTERN" \
+        '. + [{
+          id: $id,
+          type: "adr_drift",
+          summary: $summary,
+          status: "open",
+          adr: $adr,
+          drift_status: $drift_status,
+          pattern: $pattern
+        }]' <<<"$DRIFTS")
+    fi
+    IDX=$((IDX + 1))
+  done < <(jq -c '.[]' <<<"$ASSERTS")
+done
+shopt -u nullglob
+
+# LLM-driven path (--deep-adr-check) is documented in ADR-DRIFT.md but out of scope
+# for this MVP. The flag is parsed so the orchestrator can plumb it through today.
+if [[ "$DEEP" == "true" ]]; then
+  echo "adr-drift: --deep-adr-check is not yet implemented (MVP supports structured assertions only)" >&2
+fi
+
+jq -c '{decisions: .}' <<<"$DRIFTS"

--- a/plugins/dev/skills/morning-briefing/ADR-DRIFT.md
+++ b/plugins/dev/skills/morning-briefing/ADR-DRIFT.md
@@ -1,0 +1,142 @@
+# ADR-Drift Detector
+
+`adr-drift.sh` compares ADR documents to the current code state and emits `adr_drift`
+decisions for the morning briefing. Invoked by `morning-briefing` Step 3.
+
+## What it does
+
+For each ADR markdown file under the configured `adrs.directory`, the detector:
+
+1. Parses YAML frontmatter
+2. Reads `code_assertions` (a list of `{pattern, expectation, description}`)
+3. Greps the codebase for each pattern (excluding `.git`, `node_modules`, `thoughts`,
+   `dist`, `build`, `.next`, `.venv`, `__pycache__`, and the ADRs directory itself)
+4. Records a drift decision when an assertion does not hold
+
+ADRs without `code_assertions` are skipped from the structured path. The acceptance
+contract is: **zero false positives** on legacy ADR sets that have no frontmatter, and
+**at least one true positive** when an assertion is intentionally violated.
+
+## The `code_assertions` frontmatter
+
+ADR files use standard YAML frontmatter at the top of the file:
+
+```yaml
+---
+adr_id: ADR-005
+title: Configurable Worktree Convention
+date: 2026-04-15
+code_assertions:
+  - pattern: "WORKTREE_BASE_DIR"
+    expectation: found
+    description: "code references the configurable worktree base dir"
+  - pattern: "/Users/[a-z]+/code-repos/.*/wt"
+    expectation: not_found
+    description: "no hardcoded worktree paths remain"
+---
+
+# ADR-005: Configurable Worktree Convention
+
+...
+```
+
+Fields:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `pattern` | string | yes | Extended regex passed to `grep -rE`. |
+| `expectation` | `found` \| `not_found` | no | Default `found`. |
+| `description` | string | no | Human label used in the drift summary. |
+
+Each assertion produces at most one drift record per detector run.
+
+## Drift status values
+
+| `drift_status` | Meaning |
+|---|---|
+| `adr_ahead_of_code` | The ADR asserts a pattern should be found but it is missing. The decision needs implementation (or the ADR needs updating). |
+| `code_ahead_of_adr` | The ADR asserts a pattern should NOT be found but it is present. The ADR is stale and needs revision. |
+
+## Output shape
+
+```json
+{
+  "decisions": [
+    {
+      "id": "adr-drift-0005-worktree-1",
+      "type": "adr_drift",
+      "summary": "ADR 0005-worktree drift (code_ahead_of_adr): no hardcoded worktree paths remain",
+      "status": "open",
+      "adr": "/abs/path/docs/adrs/0005-worktree.md",
+      "drift_status": "code_ahead_of_adr",
+      "pattern": "/Users/[a-z]+/code-repos/.*/wt"
+    }
+  ]
+}
+```
+
+The shape conforms to `plugins/dev/templates/briefing-frontmatter.schema.json` —
+`type: adr_drift` is already in the schema's enum and `adr` is a permitted optional
+property. The renderer surfaces these in the "Surface decisions" section of the
+canonical briefing markdown.
+
+## Configuration
+
+The ADRs directory is resolved in this order:
+
+1. `--adrs-dir DIR` flag (explicit override)
+2. `.catalyst/config.json` → `catalyst.adrs.directory` (relative to `--root`)
+3. Default: `docs/adrs/`
+
+If the resolved directory does not exist, the detector emits
+`{"decisions": []}` and exits 0 — single-file ADR layouts (e.g. catalyst's own
+`docs/adrs.md`) intentionally fall here.
+
+Example `.catalyst/config.json` fragment:
+
+```json
+{
+  "catalyst": {
+    "adrs": { "directory": "docs/adrs" }
+  }
+}
+```
+
+## Single-file ADR layouts
+
+Repositories that keep ADRs in a single file (e.g. `docs/adrs.md` with many `## ADR-NNN:`
+sections) cannot use the structured path because YAML frontmatter is by definition a
+file-level header. The detector treats single-file layouts as informational/legacy and
+produces zero structured drift records for them. To opt into structured drift detection,
+migrate to a directory of per-ADR files.
+
+## `--deep-adr-check` (LLM-driven path) — future work
+
+The parent plan ([[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 2 Phase 4)
+describes a second, LLM-driven path that samples each ADR alongside a code stat
+(file count, top imports) and asks the LLM whether the ADR's decision still describes
+how the code works. This path is gated behind a `--deep-adr-check` flag so it can be
+run weekly rather than daily (cost amortization).
+
+For this MVP, the flag is parsed but emits a stderr note and does no LLM work. Wiring
+the LLM path is a follow-up.
+
+## Invocation
+
+Standalone:
+
+```bash
+bash plugins/dev/scripts/morning-briefing/adr-drift.sh --root .
+```
+
+From a morning-briefing run, Step 3 of the skill calls the detector and merges the
+result into the `decisions:` block of the briefing's YAML frontmatter.
+
+## Testing
+
+`plugins/dev/scripts/__tests__/adr-drift-detector.test.sh` exercises the detector
+against isolated fixture projects covering: missing directory, passing assertions,
+both drift directions, ADRs without frontmatter, multiple assertions in one ADR,
+schema conformance, malformed YAML tolerance, and config-driven directory resolution.
+
+Run with `bash plugins/dev/scripts/__tests__/adr-drift-detector.test.sh`.

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -66,22 +66,26 @@ If a richer Linear or Notion query is needed beyond what the CLI/REST helpers ex
 
 ## Step 3: Gather "decisions"
 
-For the MVP, populate the `decisions:` array from two heuristics:
+Populate the `decisions:` array from three sources:
 
-1. **Blocked PRs** — `gh search prs --review-requested @me --state open --json …` filtered to
+1. **ADR drift** — `adr-drift.sh` reads ADR `code_assertions` frontmatter and surfaces patterns
+   that drift from the codebase. See [ADR-DRIFT.md](./ADR-DRIFT.md).
+2. **Blocked PRs** — `gh search prs --review-requested @me --state open --json …` filtered to
    PRs with no commit in the last 48h. Each becomes one `{type: blocked_pr, …}` decision.
-2. **Judgment-call Linear tickets** — `linearis issues list --team <team> --status "Triage,In Progress" --label needs-decision` (label name is informational; substitute whatever signal the operator uses).
-
-ADR drift detection is **Phase 4** of the parent plan — do NOT implement it here. Emit an empty
-list if no signals are found.
+3. **Judgment-call Linear tickets** — `linearis issues list --team <team> --status "Triage,In Progress" --label needs-decision` (label name is informational; substitute whatever signal the operator uses).
 
 Synthesize into a `decisions.json` fragment:
 
 ```bash
-cat > "$SCRATCH/decisions.json" <<JSON
-{"decisions": []}
-JSON
-# Append blocked-PR decisions / judgment-call decisions as discovered.
+# ADR drift detection (CTL-459)
+bash "$SCRIPT_DIR/adr-drift.sh" --root "$(pwd)" > "$SCRATCH/adr-drift.json"
+
+# Blocked-PR + judgment-call sources are still TODO — start with an empty fragment.
+echo '{"decisions": []}' > "$SCRATCH/decisions-other.json"
+
+# Merge all decision sources into one fragment
+jq -s '{decisions: (((.[0] // {}).decisions // []) + ((.[1] // {}).decisions // []))}' \
+  "$SCRATCH/adr-drift.json" "$SCRATCH/decisions-other.json" > "$SCRATCH/decisions.json"
 ```
 
 ## Step 4: Gather "today"


### PR DESCRIPTION
## Summary

Adds a structured ADR-drift detector that hooks into morning-briefing Step 3 (Surface decisions).
For each ADR with `code_assertions` YAML frontmatter, the detector greps the codebase and emits
`adr_drift` decisions into the canonical briefing markdown.

Implements parent plan §Initiative 2 Phase 4 ([thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md](thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md)).

## What's new

- `plugins/dev/scripts/morning-briefing/adr-drift.sh` — the detector
- `plugins/dev/skills/morning-briefing/ADR-DRIFT.md` — `code_assertions` convention + output schema
- `plugins/dev/scripts/__tests__/adr-drift-detector.test.sh` — 31 assertions across 10 scenarios
- `plugins/dev/skills/morning-briefing/SKILL.md` — Step 3 wiring (replaces placeholder heredoc)

## Acceptance

- [x] `bash plugins/dev/scripts/__tests__/adr-drift-detector.test.sh` — 31 PASS / 0 FAIL
- [x] Real run on catalyst's ADR set: **zero false positives** — `docs/adrs.md` is a single-file
      layout with no per-ADR frontmatter, so the detector correctly emits `{"decisions": []}`
- [x] Demonstrated true-positive on a synthetic fixture ADR targeting real catalyst code

## Behavior

- ADRs directory resolved from `--adrs-dir` flag → `.catalyst/config.json` → default `docs/adrs/`
- Silent no-op when the directory doesn't exist (zero-false-positive contract)
- Tolerates malformed YAML (logs to stderr, continues on next ADR)
- Excludes `.git`, `node_modules`, `thoughts`, `dist`, `build`, `.next`, `.venv`, `__pycache__`,
  and the ADRs directory itself from grep (so the assertion text isn't a self-hit)
- Always exits 0 (drift is data, not an error)
- `--deep-adr-check` flag is parsed but stubbed — LLM-driven path is documented as future work
  per the parent plan's Refactor section

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/adr-drift-detector.test.sh` (31 assertions)
- [x] `bash plugins/dev/scripts/morning-briefing/adr-drift.sh --root .` produces `{"decisions": []}`
- [x] Synthetic fixture demonstrates `adr_ahead_of_code` and `code_ahead_of_adr` drift directions
- [x] `bash -n` syntax check on both scripts

Closes CTL-459.