### PR TITLE
feat(dev): multi-output briefing fan-out (CTL-458)

### DIFF
--- a/plugins/dev/scripts/__tests__/briefing-fanout.test.sh
+++ b/plugins/dev/scripts/__tests__/briefing-fanout.test.sh
@@ -1,0 +1,663 @@
+#!/usr/bin/env bash
+# Tests for the morning-briefing multi-output fan-out (CTL-458).
+# Covers: sanitize.sh, fanout-{slack-dm,slack-channel,notion,loom-script}.sh,
+# write-output-status.sh, and the briefing-frontmatter.schema.json additions.
+#
+# Run: bash plugins/dev/scripts/__tests__/briefing-fanout.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+MB_DIR="${REPO_ROOT}/plugins/dev/scripts/morning-briefing"
+SCHEMA="${REPO_ROOT}/plugins/dev/templates/briefing-frontmatter.schema.json"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  shift
+  for line in "$@"; do echo "    $line"; done
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected: $expected" "actual:   $actual"
+  fi
+}
+
+assert_grep() {
+  local label="$1" pattern="$2" content="$3"
+  if grep -qF -- "$pattern" <<<"$content"; then
+    pass "$label"
+  else
+    fail "$label" "expected substring: $pattern" \
+      "actual: $(printf '%s' "$content" | head -20)"
+  fi
+}
+
+assert_not_grep() {
+  local label="$1" pattern="$2" content="$3"
+  if grep -qF -- "$pattern" <<<"$content"; then
+    fail "$label" "expected NOT to contain: $pattern" \
+      "actual: $(printf '%s' "$content" | head -20)"
+  else
+    pass "$label"
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected exit: $expected" "actual exit:   $actual"
+  fi
+}
+
+# Build a populated briefing fixture for sanitize / fan-out tests.
+make_briefing() {
+  local out="$1"
+  cat > "$out" <<'MD'
+---
+date: '2026-05-17'
+generated_by: morning-briefing
+decisions:
+  - id: dec-1
+    type: blocked_pr
+    summary: 'PR #800 on Acme integration is stalled awaiting Beta Corp review'
+    status: open
+  - id: dec-2
+    type: judgment_call
+    summary: 'Pick auth provider for Acme migration'
+    status: open
+meetings_yesterday:
+  - id: not_a
+    title: Sync w/ Acme team
+prs_merged_yesterday:
+  - number: 799
+    title: 'feat: scaffold'
+---
+
+# Morning Briefing — 2026-05-17
+
+## Review yesterday
+
+### Linear (state changes)
+
+- [CTL-100] Ship Acme onboarding flow
+- [CTL-101] Build Academic dashboard
+
+### GitHub (merged PRs)
+
+- [#799] feat: scaffold  <https://github.com/coalesce-labs/catalyst/pull/799>
+- [#800] feat: Acme integration  <https://github.com/coalesce-labs/catalyst/pull/800>
+
+### Granola (meetings)
+
+- Sync w/ Acme team
+
+### Drive (notes)
+
+_no data_
+
+### Calendar (events)
+
+_no data_
+
+## Surface decisions
+
+- **[blocked_pr]** PR #800 stalled (`dec-1`, status: open)
+- **[judgment_call]** Pick auth provider (`dec-2`, status: open)
+
+## Plan today
+
+### Linear in-progress
+
+- [CTL-200] Build briefing skill
+
+### Calendar today
+
+- 1:1 w/ Alice
+
+### Follow-ups
+
+- Email vendor about renewal
+
+## Suggest orchestrator runs
+
+- `CTL-300` Rewrite onboarding _(High)_
+MD
+}
+
+# ─── sanitize.sh tests ──────────────────────────────────────────────────────
+
+test_sanitize_dm_is_noop() {
+  echo "test: sanitize.sh --profile dm preserves input"
+  local in="$SCRATCH/dm-in.md" out="$SCRATCH/dm-out.md"
+  make_briefing "$in"
+  bash "$MB_DIR/sanitize.sh" --profile dm --in "$in" --out "$out" >/dev/null
+  if diff -q "$in" "$out" >/dev/null; then
+    pass "dm profile is byte-for-byte identical"
+  else
+    fail "dm profile is byte-for-byte identical" "diff found"
+  fi
+}
+
+test_sanitize_channel_strips_decision_details() {
+  echo "test: sanitize.sh --profile channel strips decision summary/status"
+  local in="$SCRATCH/c-in.md" out="$SCRATCH/c-out.md"
+  make_briefing "$in"
+  bash "$MB_DIR/sanitize.sh" --profile channel --in "$in" --out "$out" >/dev/null
+  local content; content=$(cat "$out")
+  # Frontmatter `decisions` should still parse but each item only has id+type
+  local fm; fm=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$out")
+  local first_keys
+  first_keys=$(printf '%s' "$fm" | python3 -c '
+import sys, yaml
+d = yaml.safe_load(sys.stdin)
+keys = sorted(d.get("decisions", [{}])[0].keys())
+print(",".join(keys))
+')
+  assert_eq "channel frontmatter decision keys = id,type only" "id,type" "$first_keys"
+  # `summary` and `status` from the decisions entries must be gone
+  assert_not_grep "channel frontmatter drops summary value" "Pick auth provider" "$(printf '%s' "$fm")"
+}
+
+test_sanitize_channel_rewrites_decisions_body() {
+  echo "test: sanitize.sh --profile channel rewrites Surface decisions body"
+  local in="$SCRATCH/c2-in.md" out="$SCRATCH/c2-out.md"
+  make_briefing "$in"
+  bash "$MB_DIR/sanitize.sh" --profile channel --in "$in" --out "$out" >/dev/null
+  local body; body=$(awk '/^---[[:space:]]*$/{c++; next} c==2' "$out")
+  assert_grep "Surface decisions section present" "## Surface decisions" "$body"
+  assert_grep "Surface decisions body replaced" "_redacted_" "$body"
+  assert_not_grep "decisions body no longer mentions Pick auth provider" "Pick auth provider" "$body"
+}
+
+test_sanitize_channel_redacts_customer_names() {
+  echo "test: sanitize.sh --profile channel redacts customer names (case-insensitive, whole-word)"
+  local in="$SCRATCH/c3-in.md" out="$SCRATCH/c3-out.md"
+  make_briefing "$in"
+  bash "$MB_DIR/sanitize.sh" --profile channel --redact-list "Acme,Beta Corp" \
+    --in "$in" --out "$out" >/dev/null
+  local body; body=$(awk '/^---[[:space:]]*$/{c++; next} c==2' "$out")
+  assert_not_grep "Acme is redacted from body" "Acme" "$body"
+  assert_not_grep "Beta Corp is redacted from body" "Beta Corp" "$body"
+  assert_grep "Redaction token present" "[REDACTED]" "$body"
+}
+
+test_sanitize_channel_word_boundary() {
+  echo "test: sanitize.sh respects word boundaries (Acme ≠ Academic)"
+  local in="$SCRATCH/c4-in.md" out="$SCRATCH/c4-out.md"
+  make_briefing "$in"
+  bash "$MB_DIR/sanitize.sh" --profile channel --redact-list "Acme" \
+    --in "$in" --out "$out" >/dev/null
+  local body; body=$(awk '/^---[[:space:]]*$/{c++; next} c==2' "$out")
+  assert_grep "Academic stays intact" "Academic" "$body"
+  assert_not_grep "Acme is redacted" "Acme " "$body"
+}
+
+test_sanitize_channel_redacts_pr_urls() {
+  echo "test: sanitize.sh --profile channel redacts PR URLs containing redact-list strings"
+  local in="$SCRATCH/c5-in.md" out="$SCRATCH/c5-out.md"
+  cat > "$in" <<'MD'
+---
+date: '2026-05-17'
+generated_by: morning-briefing
+decisions: []
+---
+
+# Body
+
+- safe url: <https://github.com/coalesce-labs/catalyst/pull/799>
+- branded url: <https://github.com/example/acme-integration/pull/42>
+- branded inline: see https://github.com/example/repo/pull/77/files?Acme=1 here
+MD
+  bash "$MB_DIR/sanitize.sh" --profile channel --redact-list "Acme" \
+    --in "$in" --out "$out" >/dev/null
+  local body; body=$(awk '/^---[[:space:]]*$/{c++; next} c==2' "$out")
+  assert_grep "safe URL preserved" "pull/799" "$body"
+  assert_not_grep "branded URL #42 redacted" "acme-integration" "$body"
+  assert_not_grep "branded inline URL redacted" "pull/77/files?Acme=1" "$body"
+  assert_grep "redacted URL placeholder present" "[redacted-url]" "$body"
+}
+
+test_sanitize_rejects_bad_profile() {
+  echo "test: sanitize.sh rejects missing/unknown profile"
+  local in="$SCRATCH/bp-in.md"
+  make_briefing "$in"
+  local ec
+  bash "$MB_DIR/sanitize.sh" --in "$in" >/dev/null 2>&1; ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "missing --profile exits non-zero" "got exit 0"
+  else
+    pass "missing --profile exits non-zero (got $ec)"
+  fi
+  bash "$MB_DIR/sanitize.sh" --profile bogus --in "$in" >/dev/null 2>&1; ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "unknown profile exits non-zero" "got exit 0"
+  else
+    pass "unknown profile exits non-zero (got $ec)"
+  fi
+}
+
+# ─── fanout-slack-dm.sh tests ──────────────────────────────────────────────
+
+test_fanout_slack_dm_no_creds() {
+  echo "test: fanout-slack-dm.sh skips without SLACK_BOT_TOKEN"
+  local in="$SCRATCH/dm-in.md"
+  make_briefing "$in"
+  local out
+  out=$(env -u SLACK_BOT_TOKEN bash "$MB_DIR/fanout-slack-dm.sh" \
+    --in "$in" --date 2026-05-17 2>/dev/null)
+  local status; status=$(printf '%s' "$out" | jq -r '.status // ""' 2>/dev/null)
+  local reason; reason=$(printf '%s' "$out" | jq -r '.reason // ""' 2>/dev/null)
+  assert_eq "fanout-slack-dm status = skipped" "skipped" "$status"
+  assert_eq "fanout-slack-dm reason = no_credentials" "no_credentials" "$reason"
+}
+
+test_fanout_slack_dm_no_destination() {
+  echo "test: fanout-slack-dm.sh skips without slackDmUserId"
+  local in="$SCRATCH/dm-in.md"
+  make_briefing "$in"
+  local cfg="$SCRATCH/dm-cfg.json"
+  echo '{"catalyst":{"briefing":{}}}' > "$cfg"
+  local out
+  out=$(SLACK_BOT_TOKEN=xoxb-fake bash "$MB_DIR/fanout-slack-dm.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" 2>/dev/null)
+  local reason; reason=$(printf '%s' "$out" | jq -r '.reason // ""' 2>/dev/null)
+  assert_eq "fanout-slack-dm reason = no_destination" "no_destination" "$reason"
+}
+
+test_fanout_slack_dm_dry_run_contains_full_body() {
+  echo "test: fanout-slack-dm.sh --dry-run prints payload with full briefing body"
+  local in="$SCRATCH/dm-in.md"
+  make_briefing "$in"
+  local cfg="$SCRATCH/dm-cfg2.json"
+  echo '{"catalyst":{"briefing":{"slackDmUserId":"U1234567"}}}' > "$cfg"
+  local out
+  out=$(SLACK_BOT_TOKEN=xoxb-fake bash "$MB_DIR/fanout-slack-dm.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" --dry-run 2>/dev/null)
+  # DM profile = no redaction, so the decision summary should still be present
+  assert_grep "dry-run payload mentions destination" "U1234567" "$out"
+  assert_grep "dry-run payload includes full content (Pick auth provider)" "Pick auth provider" "$out"
+  local status; status=$(printf '%s' "$out" | tail -1 | jq -r '.status // ""' 2>/dev/null)
+  assert_eq "dry-run status = posted" "posted" "$status"
+}
+
+# ─── fanout-slack-channel.sh tests ─────────────────────────────────────────
+
+test_fanout_slack_channel_no_creds() {
+  echo "test: fanout-slack-channel.sh skips without SLACK_BOT_TOKEN"
+  local in="$SCRATCH/ch-in.md"
+  make_briefing "$in"
+  local out
+  out=$(env -u SLACK_BOT_TOKEN bash "$MB_DIR/fanout-slack-channel.sh" \
+    --in "$in" --date 2026-05-17 2>/dev/null)
+  local status; status=$(printf '%s' "$out" | jq -r '.status // ""' 2>/dev/null)
+  assert_eq "fanout-slack-channel skipped without creds" "skipped" "$status"
+}
+
+test_fanout_slack_channel_no_destination() {
+  echo "test: fanout-slack-channel.sh skips without slackChannelId"
+  local in="$SCRATCH/ch-in.md"
+  make_briefing "$in"
+  local cfg="$SCRATCH/ch-cfg.json"
+  echo '{"catalyst":{"briefing":{}}}' > "$cfg"
+  local out
+  out=$(SLACK_BOT_TOKEN=xoxb-fake bash "$MB_DIR/fanout-slack-channel.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" 2>/dev/null)
+  local reason; reason=$(printf '%s' "$out" | jq -r '.reason // ""' 2>/dev/null)
+  assert_eq "fanout-slack-channel reason = no_destination" "no_destination" "$reason"
+}
+
+test_fanout_slack_channel_dry_run_is_sanitized() {
+  echo "test: fanout-slack-channel.sh --dry-run uses sanitized (channel) body"
+  local in="$SCRATCH/ch-in.md"
+  make_briefing "$in"
+  local cfg="$SCRATCH/ch-cfg2.json"
+  cat > "$cfg" <<JSON
+{"catalyst":{"briefing":{"slackChannelId":"C9999","sanitizationRedactList":["Acme","Beta Corp"]}}}
+JSON
+  local out
+  out=$(SLACK_BOT_TOKEN=xoxb-fake bash "$MB_DIR/fanout-slack-channel.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" --dry-run 2>/dev/null)
+  assert_grep "channel id appears in payload" "C9999" "$out"
+  # Channel profile redacts decision summary AND customer name
+  assert_not_grep "Pick auth provider not present (decisions redacted)" "Pick auth provider" "$out"
+  assert_not_grep "Acme not present (redact list)" "Acme" "$out"
+  assert_grep "Redaction token visible" "[REDACTED]" "$out"
+}
+
+# ─── fanout-notion.sh tests ────────────────────────────────────────────────
+
+test_fanout_notion_no_creds() {
+  echo "test: fanout-notion.sh skips without NOTION_TOKEN"
+  local in="$SCRATCH/no-in.md"
+  make_briefing "$in"
+  local out
+  out=$(env -u NOTION_TOKEN bash "$MB_DIR/fanout-notion.sh" \
+    --in "$in" --date 2026-05-17 2>/dev/null)
+  local status; status=$(printf '%s' "$out" | jq -r '.status // ""' 2>/dev/null)
+  assert_eq "fanout-notion skipped without creds" "skipped" "$status"
+}
+
+test_fanout_notion_no_destination() {
+  echo "test: fanout-notion.sh skips without notionPageId"
+  local in="$SCRATCH/no-in.md"
+  make_briefing "$in"
+  local cfg="$SCRATCH/no-cfg.json"
+  echo '{"catalyst":{"briefing":{}}}' > "$cfg"
+  local out
+  out=$(NOTION_TOKEN=secret_fake bash "$MB_DIR/fanout-notion.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" 2>/dev/null)
+  local reason; reason=$(printf '%s' "$out" | jq -r '.reason // ""' 2>/dev/null)
+  assert_eq "fanout-notion reason = no_destination" "no_destination" "$reason"
+}
+
+test_fanout_notion_dry_run_contains_marker_and_page_id() {
+  echo "test: fanout-notion.sh --dry-run contains page id + marker block"
+  local in="$SCRATCH/no-in.md"
+  make_briefing "$in"
+  local cfg="$SCRATCH/no-cfg2.json"
+  echo '{"catalyst":{"briefing":{"notionPageId":"page-abc-123"}}}' > "$cfg"
+  local out
+  out=$(NOTION_TOKEN=secret_fake bash "$MB_DIR/fanout-notion.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" --dry-run 2>/dev/null)
+  assert_grep "page id in payload" "page-abc-123" "$out"
+  assert_grep "marker block text present" "Morning Briefing" "$out"
+  # Channel sanitization applied — no decision summary
+  assert_not_grep "decision summary stripped" "Pick auth provider" "$out"
+}
+
+# ─── fanout-loom-script.sh tests ────────────────────────────────────────────
+
+test_fanout_loom_writes_default_path() {
+  echo "test: fanout-loom-script.sh writes to thoughts/briefings/<date>-loom-script.md"
+  local in="$SCRATCH/loom-in.md"
+  make_briefing "$in"
+  local fakeroot="$SCRATCH/looroot"
+  mkdir -p "$fakeroot/thoughts/briefings"
+  local out
+  out=$(bash "$MB_DIR/fanout-loom-script.sh" \
+    --in "$in" --date 2026-05-17 --root "$fakeroot" 2>/dev/null)
+  local path="$fakeroot/thoughts/briefings/2026-05-17-loom-script.md"
+  if [[ -f "$path" ]]; then
+    pass "loom script written to default path"
+  else
+    fail "loom script written to default path" "missing: $path"
+  fi
+  local status; status=$(printf '%s' "$out" | jq -r '.status // ""' 2>/dev/null)
+  assert_eq "loom fanout status = posted" "posted" "$status"
+}
+
+test_fanout_loom_dry_run_writes_tmp() {
+  echo "test: fanout-loom-script.sh --dry-run writes to /tmp"
+  local in="$SCRATCH/loom2-in.md"
+  make_briefing "$in"
+  local tmp_path="/tmp/morning-briefing-2026-05-17-loom-script.md"
+  rm -f "$tmp_path"
+  bash "$MB_DIR/fanout-loom-script.sh" --in "$in" --date 2026-05-17 --dry-run >/dev/null
+  if [[ -f "$tmp_path" ]]; then
+    pass "dry-run loom script written to /tmp"
+    rm -f "$tmp_path"
+  else
+    fail "dry-run loom script written to /tmp" "missing: $tmp_path"
+  fi
+}
+
+test_fanout_loom_contains_date() {
+  echo "test: loom script output contains the date"
+  local in="$SCRATCH/loom3-in.md"
+  make_briefing "$in"
+  local fakeroot="$SCRATCH/loom3root"
+  mkdir -p "$fakeroot/thoughts/briefings"
+  bash "$MB_DIR/fanout-loom-script.sh" --in "$in" --date 2026-05-17 --root "$fakeroot" >/dev/null
+  local content; content=$(cat "$fakeroot/thoughts/briefings/2026-05-17-loom-script.md")
+  assert_grep "loom script mentions date" "2026-05-17" "$content"
+}
+
+test_fanout_loom_word_budget() {
+  echo "test: loom script word count within target band"
+  local in="$SCRATCH/loom4-in.md"
+  make_briefing "$in"
+  local fakeroot="$SCRATCH/loom4root"
+  mkdir -p "$fakeroot/thoughts/briefings"
+  bash "$MB_DIR/fanout-loom-script.sh" --in "$in" --date 2026-05-17 \
+    --root "$fakeroot" --target-words 225 >/dev/null
+  local words
+  words=$(wc -w < "$fakeroot/thoughts/briefings/2026-05-17-loom-script.md" | tr -d ' ')
+  # Target 225, soft band [0.7*225=158, 1.3*225=292] => allow anything in [70, 300] for the loose check
+  # (the soft warning is to stderr; we just check the file is non-trivially populated)
+  if [[ "$words" -ge 50 ]] && [[ "$words" -le 400 ]]; then
+    pass "loom script word count ($words) is plausibly within Loom-script range"
+  else
+    fail "loom script word count plausibly in range" "got $words words"
+  fi
+}
+
+test_fanout_loom_mentions_all_sections() {
+  echo "test: loom script mentions yesterday / decisions / today / suggested runs"
+  local in="$SCRATCH/loom5-in.md"
+  make_briefing "$in"
+  local fakeroot="$SCRATCH/loom5root"
+  mkdir -p "$fakeroot/thoughts/briefings"
+  bash "$MB_DIR/fanout-loom-script.sh" --in "$in" --date 2026-05-17 --root "$fakeroot" >/dev/null
+  local content
+  content=$(cat "$fakeroot/thoughts/briefings/2026-05-17-loom-script.md" | tr '[:upper:]' '[:lower:]')
+  assert_grep "loom mentions yesterday" "yesterday" "$content"
+  assert_grep "loom mentions decisions" "decision" "$content"
+  assert_grep "loom mentions today" "today" "$content"
+  assert_grep "loom mentions orchestrator/suggested runs" "orchestrator" "$content"
+}
+
+# ─── End-to-end / write-output-status tests ─────────────────────────────────
+
+test_e2e_all_fanouts_produce_status_json() {
+  echo "test: all 4 fan-outs print parseable JSON status"
+  local in="$SCRATCH/e2e-in.md"
+  make_briefing "$in"
+  local fakeroot="$SCRATCH/e2eroot"
+  mkdir -p "$fakeroot/thoughts/briefings"
+  local cfg="$SCRATCH/e2e-cfg.json"
+  cat > "$cfg" <<JSON
+{"catalyst":{"briefing":{"slackDmUserId":"U1","slackChannelId":"C1","notionPageId":"P1"}}}
+JSON
+  local s1 s2 s3 s4
+  s1=$(SLACK_BOT_TOKEN=fake bash "$MB_DIR/fanout-slack-dm.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" --dry-run 2>/dev/null | tail -1)
+  s2=$(SLACK_BOT_TOKEN=fake bash "$MB_DIR/fanout-slack-channel.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" --dry-run 2>/dev/null | tail -1)
+  s3=$(NOTION_TOKEN=fake bash "$MB_DIR/fanout-notion.sh" \
+    --in "$in" --date 2026-05-17 --config "$cfg" --dry-run 2>/dev/null | tail -1)
+  s4=$(bash "$MB_DIR/fanout-loom-script.sh" \
+    --in "$in" --date 2026-05-17 --root "$fakeroot" 2>/dev/null | tail -1)
+  for s in "$s1" "$s2" "$s3" "$s4"; do
+    if jq -e . <<<"$s" >/dev/null 2>&1; then
+      pass "fanout status JSON parses: $(printf '%s' "$s" | head -c 60)"
+    else
+      fail "fanout status JSON parses" "got: $s"
+    fi
+  done
+}
+
+test_write_output_status_merges_into_frontmatter() {
+  echo "test: write-output-status.sh merges 4 status files into frontmatter"
+  local in="$SCRATCH/wos-in.md"
+  make_briefing "$in"
+  local sdir="$SCRATCH/wos-statuses"
+  mkdir -p "$sdir"
+  printf '%s\n' '{"status":"posted","destination":"slack_dm"}'      > "$sdir/slack-dm.json"
+  printf '%s\n' '{"status":"posted","destination":"slack_channel"}' > "$sdir/slack-channel.json"
+  printf '%s\n' '{"status":"skipped","destination":"notion","reason":"no_destination"}' > "$sdir/notion.json"
+  printf '%s\n' '{"status":"posted","destination":"loom_script","details":{"words":210}}' > "$sdir/loom-script.json"
+
+  bash "$MB_DIR/write-output-status.sh" --in "$in" --statuses "$sdir" >/dev/null
+
+  local fm; fm=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$in")
+  local got
+  got=$(printf '%s' "$fm" | python3 -c '
+import sys, yaml
+d = yaml.safe_load(sys.stdin)
+os = d.get("output_status", {})
+print(",".join(sorted(os.keys())))
+')
+  assert_eq "frontmatter output_status has all 4 destinations" \
+    "loom_script,notion,slack_channel,slack_dm" "$got"
+}
+
+test_write_output_status_preserves_existing_fields() {
+  echo "test: write-output-status.sh preserves existing frontmatter (decisions stay)"
+  local in="$SCRATCH/wos2-in.md"
+  make_briefing "$in"
+  local sdir="$SCRATCH/wos2-statuses"
+  mkdir -p "$sdir"
+  printf '%s\n' '{"status":"posted","destination":"loom_script"}' > "$sdir/loom-script.json"
+  bash "$MB_DIR/write-output-status.sh" --in "$in" --statuses "$sdir" >/dev/null
+  local fm; fm=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$in")
+  local decisions_len
+  decisions_len=$(printf '%s' "$fm" | python3 -c '
+import sys, yaml
+print(len(yaml.safe_load(sys.stdin).get("decisions", [])))
+')
+  assert_eq "decisions preserved (length 2)" "2" "$decisions_len"
+}
+
+test_validate_frontmatter_passes_with_output_status() {
+  echo "test: validate-frontmatter.sh still passes after output_status is added"
+  local in="$SCRATCH/vf-in.md"
+  make_briefing "$in"
+  local sdir="$SCRATCH/vf-statuses"
+  mkdir -p "$sdir"
+  printf '%s\n' '{"status":"posted","destination":"loom_script"}' > "$sdir/loom-script.json"
+  bash "$MB_DIR/write-output-status.sh" --in "$in" --statuses "$sdir" >/dev/null
+  local ec
+  bash "$MB_DIR/validate-frontmatter.sh" "$in" >/dev/null 2>&1; ec=$?
+  assert_exit "validate-frontmatter passes" "0" "$ec"
+}
+
+# ─── Schema tests ───────────────────────────────────────────────────────────
+
+test_schema_still_parses() {
+  echo "test: schema parses as JSON"
+  if jq -e . "$SCHEMA" >/dev/null 2>&1; then
+    pass "schema parses as JSON"
+  else
+    fail "schema parses as JSON" "jq failed"
+  fi
+}
+
+test_schema_permits_output_status_object() {
+  echo "test: schema accepts an output_status object with 4 known destinations"
+  local good="$SCRATCH/schema-good.json"
+  cat > "$good" <<'JSON'
+{
+  "date": "2026-05-17",
+  "generated_by": "morning-briefing",
+  "decisions": [],
+  "output_status": {
+    "slack_dm":      {"status": "posted"},
+    "slack_channel": {"status": "skipped", "reason": "no_credentials"},
+    "notion":        {"status": "failed",  "reason": "api_error"},
+    "loom_script":   {"status": "posted",  "details": {"words": 210}}
+  }
+}
+JSON
+  local ec
+  jsonschema -i "$good" "$SCHEMA" >/dev/null 2>&1; ec=$?
+  assert_exit "valid output_status passes schema" "0" "$ec"
+}
+
+test_schema_rejects_unknown_destination() {
+  echo "test: schema rejects unknown destination key under output_status"
+  local bad="$SCRATCH/schema-bad-dest.json"
+  cat > "$bad" <<'JSON'
+{
+  "date": "2026-05-17",
+  "generated_by": "morning-briefing",
+  "decisions": [],
+  "output_status": {"discord": {"status": "posted"}}
+}
+JSON
+  local ec
+  jsonschema -i "$bad" "$SCHEMA" >/dev/null 2>&1; ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "unknown destination should be rejected" "passed schema"
+  else
+    pass "unknown destination is rejected (exit $ec)"
+  fi
+}
+
+test_schema_rejects_bad_status_value() {
+  echo "test: schema rejects status outside {posted,skipped,failed}"
+  local bad="$SCRATCH/schema-bad-status.json"
+  cat > "$bad" <<'JSON'
+{
+  "date": "2026-05-17",
+  "generated_by": "morning-briefing",
+  "decisions": [],
+  "output_status": {"slack_dm": {"status": "queued"}}
+}
+JSON
+  local ec
+  jsonschema -i "$bad" "$SCHEMA" >/dev/null 2>&1; ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "bad status enum should be rejected" "passed schema"
+  else
+    pass "bad status enum is rejected (exit $ec)"
+  fi
+}
+
+# ─── Run all tests ──────────────────────────────────────────────────────────
+
+test_sanitize_dm_is_noop
+test_sanitize_channel_strips_decision_details
+test_sanitize_channel_rewrites_decisions_body
+test_sanitize_channel_redacts_customer_names
+test_sanitize_channel_word_boundary
+test_sanitize_channel_redacts_pr_urls
+test_sanitize_rejects_bad_profile
+
+test_fanout_slack_dm_no_creds
+test_fanout_slack_dm_no_destination
+test_fanout_slack_dm_dry_run_contains_full_body
+
+test_fanout_slack_channel_no_creds
+test_fanout_slack_channel_no_destination
+test_fanout_slack_channel_dry_run_is_sanitized
+
+test_fanout_notion_no_creds
+test_fanout_notion_no_destination
+test_fanout_notion_dry_run_contains_marker_and_page_id
+
+test_fanout_loom_writes_default_path
+test_fanout_loom_dry_run_writes_tmp
+test_fanout_loom_contains_date
+test_fanout_loom_word_budget
+test_fanout_loom_mentions_all_sections
+
+test_e2e_all_fanouts_produce_status_json
+test_write_output_status_merges_into_frontmatter
+test_write_output_status_preserves_existing_fields
+test_validate_frontmatter_passes_with_output_status
+
+test_schema_still_parses
+test_schema_permits_output_status_object
+test_schema_rejects_unknown_destination
+test_schema_rejects_bad_status_value
+
+echo
+echo "─────────────────────────────────────"
+echo "PASSED: $PASSES"
+echo "FAILED: $FAILURES"
+echo "─────────────────────────────────────"
+exit $(( FAILURES > 0 ? 1 : 0 ))

--- a/plugins/dev/scripts/morning-briefing/fanout-loom-script.sh
+++ b/plugins/dev/scripts/morning-briefing/fanout-loom-script.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# fanout-loom-script.sh — Render a ~60–90 second spoken script from the briefing
+# into thoughts/briefings/<date>-loom-script.md. Uses the `loom` sanitization
+# profile, then renders a deterministic prose template. Reads ~75s aloud at
+# 150 wpm = ~225 words target.
+#
+# Usage:
+#   fanout-loom-script.sh --in <briefing.md> --date YYYY-MM-DD
+#                         [--root <repo-root>] [--target-words N]
+#                         [--tone casual|formal] [--dry-run] [--config <path>]
+#
+# Prints final {"status":"posted|failed", "destination":"loom_script", ...}.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+IN=""
+DATE=""
+ROOT="."
+TARGET_WORDS=""
+TONE=""
+DRY_RUN=0
+CONFIG=".catalyst/config.json"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in)           IN="$2"; shift 2 ;;
+    --date)         DATE="$2"; shift 2 ;;
+    --root)         ROOT="$2"; shift 2 ;;
+    --target-words) TARGET_WORDS="$2"; shift 2 ;;
+    --tone)         TONE="$2"; shift 2 ;;
+    --dry-run)      DRY_RUN=1; shift ;;
+    --config)       CONFIG="$2"; shift 2 ;;
+    -h|--help)      sed -n '2,14p' "$0"; exit 0 ;;
+    *) echo "fanout-loom-script.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+emit_status() {
+  local status="$1" reason="${2:-}" details="${3:-{\}}"
+  if [[ -n "$reason" ]]; then
+    jq -nc --arg s "$status" --arg r "$reason" --argjson d "$details" \
+      '{status:$s, destination:"loom_script", reason:$r, details:$d}'
+  else
+    jq -nc --arg s "$status" --argjson d "$details" \
+      '{status:$s, destination:"loom_script", details:$d}'
+  fi
+}
+
+if [[ -z "$IN" ]] || [[ ! -f "$IN" ]]; then
+  emit_status failed input_not_found
+  exit 0
+fi
+
+if [[ -z "$DATE" ]]; then
+  DATE="$(date -u +%Y-%m-%d)"
+fi
+
+# Resolve target words + tone (flag > config > defaults).
+if [[ -z "$TARGET_WORDS" ]] && [[ -f "$CONFIG" ]]; then
+  TARGET_WORDS=$(jq -r '.catalyst.briefing.loomScript.targetWords // empty' "$CONFIG" 2>/dev/null || echo "")
+fi
+[[ -z "$TARGET_WORDS" ]] && TARGET_WORDS=225
+
+if [[ -z "$TONE" ]] && [[ -f "$CONFIG" ]]; then
+  TONE=$(jq -r '.catalyst.briefing.loomScript.tone // empty' "$CONFIG" 2>/dev/null || echo "")
+fi
+[[ -z "$TONE" ]] && TONE="casual"
+
+# Sanitize via loom profile (same rules as channel).
+SANITIZED_FILE="$(mktemp)"
+trap 'rm -f "$SANITIZED_FILE"' EXIT
+bash "$SCRIPT_DIR/sanitize.sh" --profile loom --in "$IN" --config "$CONFIG" > "$SANITIZED_FILE"
+
+# Render the loom script. Pass the sanitized content via file path (NOT stdin)
+# because the heredoc below also occupies stdin.
+SCRIPT_TEXT=$(python3 - "$DATE" "$TONE" "$SANITIZED_FILE" <<'PY'
+import re
+import sys
+
+date = sys.argv[1]
+tone = sys.argv[2] if len(sys.argv) > 2 else "casual"
+sanitized_path = sys.argv[3]
+
+with open(sanitized_path, "r", encoding="utf-8") as fh:
+    text = fh.read()
+m = re.match(r"^---\s*\n(.*?\n)---\s*\n(.*)$", text, re.DOTALL)
+fm_text = m.group(1) if m else ""
+body = m.group(2) if m else text
+
+# Parse minimal frontmatter info.
+import yaml
+fm = yaml.safe_load(fm_text) if fm_text else {}
+n_decisions = len(fm.get("decisions") or [])
+n_meetings = len(fm.get("meetings_yesterday") or [])
+n_prs = len(fm.get("prs_merged_yesterday") or [])
+
+# Count items under each top-level "## " section by looking at lines starting with "- ".
+def count_items_under(heading, body):
+    pattern = re.compile(
+        rf"## {re.escape(heading)}\n(.*?)(?=\n## |\Z)",
+        re.DOTALL,
+    )
+    m = pattern.search(body)
+    if not m:
+        return 0
+    return sum(1 for line in m.group(1).splitlines() if line.startswith("- "))
+
+n_linear_changes = count_items_under("Review yesterday", body)
+n_today_items = count_items_under("Plan today", body)
+n_suggested = count_items_under("Suggest orchestrator runs", body)
+
+greeting = "Good morning." if tone == "casual" else "Greetings."
+closer   = "Full briefing in thoughts slash briefings slash %s dot md." % date \
+    if tone == "casual" \
+    else "Refer to the canonical briefing file for full detail."
+
+def pluralize(n, word):
+    return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+lines = []
+lines.append(f"# Loom Script — {date}")
+lines.append("")
+lines.append(f"{greeting} Today is {date}.")
+lines.append("")
+
+# Yesterday paragraph
+y_parts = []
+if n_linear_changes:
+    y_parts.append(pluralize(n_linear_changes, "Linear update"))
+if n_prs:
+    y_parts.append(pluralize(n_prs, "merged pull request"))
+if n_meetings:
+    y_parts.append(pluralize(n_meetings, "meeting"))
+if y_parts:
+    lines.append("Looking at yesterday: " + ", ".join(y_parts) + ".")
+else:
+    lines.append("Yesterday was quiet, with no tracked activity to report.")
+
+# Decisions paragraph
+if n_decisions:
+    lines.append(
+        f"There {'is' if n_decisions == 1 else 'are'} {pluralize(n_decisions, 'open decision')} "
+        f"surfaced for today. Internals are redacted in this clip; "
+        f"open the briefing file for the full context."
+    )
+else:
+    lines.append("Nothing is currently waiting on a decision from you.")
+
+# Today paragraph
+if n_today_items:
+    lines.append(
+        f"For today: about {n_today_items} item{'s' if n_today_items != 1 else ''} are queued up "
+        f"across in-progress work, calendar, and follow-ups. "
+        f"Worth a quick scan before the first meeting."
+    )
+else:
+    lines.append("Your day is wide open with no items queued so far.")
+
+# Suggested runs paragraph
+if n_suggested:
+    lines.append(
+        f"Heads up: {pluralize(n_suggested, 'ticket')} look ready for an orchestrator run "
+        f"if you want to dispatch them this morning."
+    )
+else:
+    lines.append("No new tickets look ready for orchestration this morning.")
+
+lines.append("")
+lines.append(closer)
+
+out = "\n".join(lines) + "\n"
+sys.stdout.write(out)
+PY
+)
+
+# Determine output path
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  OUT_PATH="/tmp/morning-briefing-${DATE}-loom-script.md"
+else
+  OUT_DIR="${ROOT%/}/thoughts/briefings"
+  mkdir -p "$OUT_DIR"
+  OUT_PATH="${OUT_DIR}/${DATE}-loom-script.md"
+fi
+
+printf '%s' "$SCRIPT_TEXT" > "$OUT_PATH"
+
+WORDS=$(wc -w < "$OUT_PATH" | tr -d ' ')
+
+# Soft-warn if outside the [0.7 * target, 1.3 * target] band. Pass TARGET_WORDS
+# as argv (not inline) to avoid shell-substitution concerns.
+LO=$(python3 -c "import sys; print(int(int(sys.argv[1]) * 0.7))" "$TARGET_WORDS")
+HI=$(python3 -c "import sys; print(int(int(sys.argv[1]) * 1.3))" "$TARGET_WORDS")
+if (( WORDS < LO || WORDS > HI )); then
+  echo "fanout-loom-script.sh: warning: word count ${WORDS} outside [${LO}, ${HI}] band" >&2
+fi
+
+emit_status posted "" "$(jq -nc --arg p "$OUT_PATH" --argjson w "$WORDS" --argjson t "$TARGET_WORDS" \
+  '{path:$p, words:$w, targetWords:$t}')"

--- a/plugins/dev/scripts/morning-briefing/fanout-notion.sh
+++ b/plugins/dev/scripts/morning-briefing/fanout-notion.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# fanout-notion.sh — Append the SANITIZED briefing to a designated Notion page.
+# Idempotency: each update inserts a marker paragraph "### Morning Briefing — <date>"
+# at the top of the appended block list. Operators can prune old marker blocks
+# manually (Phase 6 acceptance verifies one-page-no-duplicate behavior).
+#
+# Usage:
+#   fanout-notion.sh --in <briefing.md> --date YYYY-MM-DD
+#                    [--page <notion-page-id>] [--dry-run] [--config <path>]
+#
+# Credentials: NOTION_TOKEN env var.
+# Destination: --page flag wins; otherwise .catalyst.briefing.notionPageId from --config.
+# Prints final {"status":"posted|skipped|failed", "destination":"notion", ...}.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+IN=""
+DATE=""
+PAGE=""
+DRY_RUN=0
+CONFIG=".catalyst/config.json"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in)      IN="$2"; shift 2 ;;
+    --date)    DATE="$2"; shift 2 ;;
+    --page)    PAGE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --config)  CONFIG="$2"; shift 2 ;;
+    -h|--help) sed -n '2,13p' "$0"; exit 0 ;;
+    *) echo "fanout-notion.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+emit_status() {
+  local status="$1" reason="${2:-}" details="${3:-{\}}"
+  if [[ -n "$reason" ]]; then
+    jq -nc --arg s "$status" --arg r "$reason" --argjson d "$details" \
+      '{status:$s, destination:"notion", reason:$r, details:$d}'
+  else
+    jq -nc --arg s "$status" --argjson d "$details" \
+      '{status:$s, destination:"notion", details:$d}'
+  fi
+}
+
+if [[ -z "${NOTION_TOKEN:-}" ]]; then
+  emit_status skipped no_credentials
+  exit 0
+fi
+
+if [[ -z "$PAGE" ]] && [[ -f "$CONFIG" ]]; then
+  PAGE=$(jq -r '.catalyst.briefing.notionPageId // empty' "$CONFIG" 2>/dev/null || echo "")
+fi
+if [[ -z "$PAGE" ]]; then
+  emit_status skipped no_destination
+  exit 0
+fi
+
+if [[ -z "$IN" ]] || [[ ! -f "$IN" ]]; then
+  emit_status failed input_not_found
+  exit 0
+fi
+
+SANITIZED_FILE="$(mktemp)"
+trap 'rm -f "$SANITIZED_FILE"' EXIT
+bash "$SCRIPT_DIR/sanitize.sh" --profile notion --in "$IN" --config "$CONFIG" > "$SANITIZED_FILE"
+
+# Build the Notion children payload:
+#   - First block: heading_3 with text "Morning Briefing — <date>" (marker).
+#   - Subsequent blocks: one paragraph per non-empty body line (rich_text plain text).
+#   Notion's API caps blocks at 100 per request; truncate beyond that.
+# Pass sanitized content via file path (NOT stdin) — the heredoc occupies stdin.
+PAYLOAD=$(python3 - "$DATE" "$SANITIZED_FILE" <<'PY'
+import json
+import re
+import sys
+
+date = sys.argv[1] if len(sys.argv) > 1 else ""
+sanitized_path = sys.argv[2]
+with open(sanitized_path, "r", encoding="utf-8") as fh:
+    text = fh.read()
+
+# Drop the YAML frontmatter — Notion only wants the body.
+m = re.match(r"^---\s*\n.*?\n---\s*\n(.*)$", text, re.DOTALL)
+body = m.group(1) if m else text
+
+def block_paragraph(line):
+    return {
+        "object": "block",
+        "type": "paragraph",
+        "paragraph": {
+            "rich_text": [
+                {"type": "text", "text": {"content": line[:2000]}}
+            ]
+        },
+    }
+
+marker = {
+    "object": "block",
+    "type": "heading_3",
+    "heading_3": {
+        "rich_text": [
+            {"type": "text", "text": {"content": f"Morning Briefing — {date}"}}
+        ]
+    },
+}
+
+children = [marker]
+for line in body.splitlines():
+    if not line.strip():
+        continue
+    children.append(block_paragraph(line))
+    if len(children) >= 100:
+        break
+
+print(json.dumps({"children": children}))
+PY
+)
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '%s\n' "$PAYLOAD"
+  emit_status posted "" "$(jq -nc --arg p "$PAGE" --argjson b "$(jq '.children | length' <<<"$PAYLOAD")" \
+    '{dryRun:true, pageId:$p, blockCount:$b}')"
+  exit 0
+fi
+
+RESPONSE=$(printf '%s' "$PAYLOAD" | curl -sS -X PATCH \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  --data-binary @- \
+  "https://api.notion.com/v1/blocks/${PAGE}/children" 2>/dev/null)
+
+OBJ=$(printf '%s' "$RESPONSE" | jq -r '.object // ""' 2>/dev/null)
+if [[ "$OBJ" == "list" ]]; then
+  emit_status posted "" "$(jq -nc --arg p "$PAGE" '{pageId:$p}')"
+else
+  ERR=$(printf '%s' "$RESPONSE" | jq -r '.message // "api_error"' 2>/dev/null)
+  emit_status failed "$ERR" "$(jq -nc --arg r "$RESPONSE" '{response:$r}')"
+fi

--- a/plugins/dev/scripts/morning-briefing/fanout-slack-channel.sh
+++ b/plugins/dev/scripts/morning-briefing/fanout-slack-channel.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# fanout-slack-channel.sh — Post the SANITIZED briefing to a Slack channel
+# using chat.postMessage. Uses the `channel` sanitization profile (decision
+# internals stripped, customer names + PR URLs redacted).
+#
+# Usage:
+#   fanout-slack-channel.sh --in <briefing.md> --date YYYY-MM-DD
+#                           [--channel <slack-channel-id>] [--dry-run] [--config <path>]
+#
+# Credentials: SLACK_BOT_TOKEN env var.
+# Destination: --channel flag wins; otherwise .catalyst.briefing.slackChannelId from --config.
+# Prints final {"status":"posted|skipped|failed", "destination":"slack_channel", ...}.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+IN=""
+DATE=""
+CHANNEL=""
+DRY_RUN=0
+CONFIG=".catalyst/config.json"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in)      IN="$2"; shift 2 ;;
+    --date)    DATE="$2"; shift 2 ;;
+    --channel) CHANNEL="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --config)  CONFIG="$2"; shift 2 ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "fanout-slack-channel.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+emit_status() {
+  local status="$1" reason="${2:-}" details="${3:-{\}}"
+  if [[ -n "$reason" ]]; then
+    jq -nc --arg s "$status" --arg r "$reason" --argjson d "$details" \
+      '{status:$s, destination:"slack_channel", reason:$r, details:$d}'
+  else
+    jq -nc --arg s "$status" --argjson d "$details" \
+      '{status:$s, destination:"slack_channel", details:$d}'
+  fi
+}
+
+if [[ -z "${SLACK_BOT_TOKEN:-}" ]]; then
+  emit_status skipped no_credentials
+  exit 0
+fi
+
+if [[ -z "$CHANNEL" ]] && [[ -f "$CONFIG" ]]; then
+  CHANNEL=$(jq -r '.catalyst.briefing.slackChannelId // empty' "$CONFIG" 2>/dev/null || echo "")
+fi
+if [[ -z "$CHANNEL" ]]; then
+  emit_status skipped no_destination
+  exit 0
+fi
+
+if [[ -z "$IN" ]] || [[ ! -f "$IN" ]]; then
+  emit_status failed input_not_found
+  exit 0
+fi
+
+# Channel profile = sanitized. Strip YAML frontmatter — Slack channels don't
+# want raw frontmatter in a message body.
+SANITIZED=$(bash "$SCRIPT_DIR/sanitize.sh" --profile channel --in "$IN" --config "$CONFIG")
+
+BODY=$(printf '%s' "$SANITIZED" | python3 -c '
+import re, sys
+text = sys.stdin.read()
+text = re.sub(r"^---\s*\n.*?\n---\s*\n", "", text, count=1, flags=re.DOTALL)
+limit = 2900
+if len(text) > limit:
+    text = text[:limit] + "\n…(truncated)"
+print(text, end="")
+')
+
+PAYLOAD=$(jq -nc \
+  --arg channel "$CHANNEL" \
+  --arg text "Morning briefing — $DATE" \
+  --arg body "$BODY" \
+  '{
+    channel: $channel,
+    text: $text,
+    unfurl_links: false,
+    blocks: [
+      {"type":"section","text":{"type":"mrkdwn","text":$body}}
+    ]
+  }')
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '%s\n' "$PAYLOAD"
+  emit_status posted "" "$(jq -nc --arg c "$CHANNEL" '{dryRun:true, channel:$c}')"
+  exit 0
+fi
+
+RESPONSE=$(printf '%s' "$PAYLOAD" | curl -sS -X POST \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-type: application/json; charset=utf-8" \
+  --data-binary @- \
+  https://slack.com/api/chat.postMessage 2>/dev/null)
+
+OK=$(printf '%s' "$RESPONSE" | jq -r '.ok // false' 2>/dev/null || echo "false")
+if [[ "$OK" == "true" ]]; then
+  TS=$(printf '%s' "$RESPONSE" | jq -r '.ts // ""' 2>/dev/null)
+  emit_status posted "" "$(jq -nc --arg c "$CHANNEL" --arg ts "$TS" '{channel:$c, ts:$ts}')"
+else
+  ERR=$(printf '%s' "$RESPONSE" | jq -r '.error // "api_error"' 2>/dev/null)
+  emit_status failed "$ERR" "$(jq -nc --arg r "$RESPONSE" '{response:$r}')"
+fi

--- a/plugins/dev/scripts/morning-briefing/fanout-slack-dm.sh
+++ b/plugins/dev/scripts/morning-briefing/fanout-slack-dm.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# fanout-slack-dm.sh — Post the briefing markdown to the operator's Slack DM
+# using the chat.postMessage Web API. DM profile = no sanitization (full content).
+#
+# Usage:
+#   fanout-slack-dm.sh --in <briefing.md> --date YYYY-MM-DD
+#                      [--user <slack-user-id>] [--dry-run] [--config <path>]
+#
+# Credentials: SLACK_BOT_TOKEN env var.
+# Destination: --user flag wins; otherwise .catalyst.briefing.slackDmUserId from --config.
+# Prints final {"status":"posted|skipped|failed", "destination":"slack_dm", ...}.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+IN=""
+DATE=""
+USER_ID=""
+DRY_RUN=0
+CONFIG=".catalyst/config.json"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in)      IN="$2"; shift 2 ;;
+    --date)    DATE="$2"; shift 2 ;;
+    --user)    USER_ID="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --config)  CONFIG="$2"; shift 2 ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "fanout-slack-dm.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+emit_status() {
+  # $1 = status, $2 = optional reason, $3 = optional details JSON
+  local status="$1" reason="${2:-}" details="${3:-{\}}"
+  if [[ -n "$reason" ]]; then
+    jq -nc --arg s "$status" --arg r "$reason" --argjson d "$details" \
+      '{status:$s, destination:"slack_dm", reason:$r, details:$d}'
+  else
+    jq -nc --arg s "$status" --argjson d "$details" \
+      '{status:$s, destination:"slack_dm", details:$d}'
+  fi
+}
+
+# Credential check
+if [[ -z "${SLACK_BOT_TOKEN:-}" ]]; then
+  emit_status skipped no_credentials
+  exit 0
+fi
+
+# Destination resolution
+if [[ -z "$USER_ID" ]] && [[ -f "$CONFIG" ]]; then
+  USER_ID=$(jq -r '.catalyst.briefing.slackDmUserId // empty' "$CONFIG" 2>/dev/null || echo "")
+fi
+if [[ -z "$USER_ID" ]]; then
+  emit_status skipped no_destination
+  exit 0
+fi
+
+if [[ -z "$IN" ]] || [[ ! -f "$IN" ]]; then
+  emit_status failed input_not_found
+  exit 0
+fi
+
+# DM profile = full content. Strip YAML frontmatter before sending — Slack
+# users don't want raw frontmatter in a message.
+SANITIZED=$(bash "$SCRIPT_DIR/sanitize.sh" --profile dm --in "$IN")
+
+# Slack section blocks cap at 3000 chars; truncate with a footer pointer.
+BODY=$(printf '%s' "$SANITIZED" | python3 -c '
+import re, sys
+text = sys.stdin.read()
+text = re.sub(r"^---\s*\n.*?\n---\s*\n", "", text, count=1, flags=re.DOTALL)
+limit = 2900
+if len(text) > limit:
+    text = text[:limit] + "\n…(truncated, see briefing file)"
+print(text, end="")
+')
+
+PAYLOAD=$(jq -nc \
+  --arg channel "$USER_ID" \
+  --arg text "Morning briefing — $DATE" \
+  --arg body "$BODY" \
+  '{
+    channel: $channel,
+    text: $text,
+    unfurl_links: false,
+    blocks: [
+      {"type":"section","text":{"type":"mrkdwn","text":$body}}
+    ]
+  }')
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '%s\n' "$PAYLOAD"
+  emit_status posted "" "$(jq -nc --arg u "$USER_ID" '{dryRun:true, channel:$u}')"
+  exit 0
+fi
+
+RESPONSE=$(printf '%s' "$PAYLOAD" | curl -sS -X POST \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-type: application/json; charset=utf-8" \
+  --data-binary @- \
+  https://slack.com/api/chat.postMessage 2>/dev/null)
+
+OK=$(printf '%s' "$RESPONSE" | jq -r '.ok // false' 2>/dev/null || echo "false")
+if [[ "$OK" == "true" ]]; then
+  TS=$(printf '%s' "$RESPONSE" | jq -r '.ts // ""' 2>/dev/null)
+  emit_status posted "" "$(jq -nc --arg u "$USER_ID" --arg ts "$TS" '{channel:$u, ts:$ts}')"
+else
+  ERR=$(printf '%s' "$RESPONSE" | jq -r '.error // "api_error"' 2>/dev/null)
+  emit_status failed "$ERR" "$(jq -nc --arg r "$RESPONSE" '{response:$r}')"
+fi

--- a/plugins/dev/scripts/morning-briefing/sanitize.sh
+++ b/plugins/dev/scripts/morning-briefing/sanitize.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# sanitize.sh — Apply a sanitization profile to a briefing markdown file.
+#
+# Usage:
+#   sanitize.sh --profile {dm|channel|notion|loom} --in <briefing.md>
+#               [--out <path>] [--redact-list "A,B,C"] [--config <path>]
+#
+# Profiles:
+#   dm      — no-op (full content preserved)
+#   channel — strip decision summary/status + redact customer names + redact PR URLs
+#   notion  — same rules as channel
+#   loom    — same rules as channel (downstream loom-script renders prose)
+#
+# `--redact-list` overrides .catalyst/config.json's catalyst.briefing.sanitizationRedactList.
+#
+# Writes the sanitized briefing to --out (or stdout if --out omitted).
+
+set -euo pipefail
+
+PROFILE=""
+IN=""
+OUT=""
+REDACT_LIST=""
+CONFIG=".catalyst/config.json"
+REDACT_FLAG_SET=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)     PROFILE="$2"; shift 2 ;;
+    --in)          IN="$2"; shift 2 ;;
+    --out)         OUT="$2"; shift 2 ;;
+    --redact-list) REDACT_LIST="$2"; REDACT_FLAG_SET=1; shift 2 ;;
+    --config)      CONFIG="$2"; shift 2 ;;
+    -h|--help)     sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "sanitize.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$PROFILE" in
+  dm|channel|notion|loom) ;;
+  "") echo "sanitize.sh: --profile is required" >&2; exit 2 ;;
+  *)  echo "sanitize.sh: unknown profile: $PROFILE" >&2; exit 2 ;;
+esac
+
+if [[ -z "$IN" ]]; then
+  echo "sanitize.sh: --in is required" >&2
+  exit 2
+fi
+if [[ ! -f "$IN" ]]; then
+  echo "sanitize.sh: input file not found: $IN" >&2
+  exit 2
+fi
+
+# Resolve redact list: --redact-list flag wins over config file.
+if [[ "$REDACT_FLAG_SET" -eq 0 ]] && [[ -f "$CONFIG" ]]; then
+  REDACT_LIST=$(jq -r '
+    (.catalyst.briefing.sanitizationRedactList // []) | join(",")
+  ' "$CONFIG" 2>/dev/null || echo "")
+fi
+
+emit() {
+  if [[ -n "$OUT" ]]; then
+    mkdir -p "$(dirname "$OUT")"
+    cat > "$OUT"
+  else
+    cat
+  fi
+}
+
+# DM profile = byte-for-byte passthrough.
+if [[ "$PROFILE" == "dm" ]]; then
+  cat "$IN" | emit
+  exit 0
+fi
+
+# All other profiles share these transforms:
+#   1. Frontmatter: keep only id + type per decision item.
+#   2. Body `## Surface decisions` section: replace with `_redacted_`.
+#   3. Body: redact customer names from REDACT_LIST (case-insensitive, whole-word).
+#   4. Body: redact PR URLs whose body contains a redact-list string.
+
+python3 - "$IN" "$REDACT_LIST" <<'PY' | emit
+import sys
+import re
+import yaml
+
+path = sys.argv[1]
+redact_csv = sys.argv[2] if len(sys.argv) > 2 else ""
+redact_terms = [t.strip() for t in redact_csv.split(",") if t.strip()]
+
+with open(path, "r", encoding="utf-8") as fh:
+    raw = fh.read()
+
+# Split the first --- ... --- block from the body.
+m = re.match(r"^---\s*\n(.*?\n)---\s*\n(.*)$", raw, re.DOTALL)
+if not m:
+    # No frontmatter — emit unchanged.
+    sys.stdout.write(raw)
+    sys.exit(0)
+
+fm_text = m.group(1)
+body = m.group(2)
+
+# 1. Frontmatter: strip decision details.
+fm = yaml.safe_load(fm_text) or {}
+if isinstance(fm.get("decisions"), list):
+    fm["decisions"] = [
+        {k: v for k, v in d.items() if k in ("id", "type")}
+        for d in fm["decisions"]
+        if isinstance(d, dict)
+    ]
+
+# 2. Body: rewrite "## Surface decisions" block to "_redacted_".
+def rewrite_decisions_section(text):
+    pattern = re.compile(
+        r"(## Surface decisions\n)(.*?)(?=\n## |\Z)",
+        re.DOTALL,
+    )
+    return pattern.sub(r"\1\n_redacted_\n", text)
+
+body = rewrite_decisions_section(body)
+
+# 3. PR-URL redaction (must run before customer-name redaction so the
+#    customer string is still detectable inside the raw URL).
+if redact_terms:
+    url_re = re.compile(r"https?://[^\s<>)\"]+")
+    lowered = [t.lower() for t in redact_terms]
+    def maybe_redact(match):
+        url = match.group(0)
+        low = url.lower()
+        return "[redacted-url]" if any(t in low for t in lowered) else url
+    body = url_re.sub(maybe_redact, body)
+
+# 4. Customer-name redaction (whole-word, case-insensitive).
+if redact_terms:
+    escaped = [re.escape(t) for t in redact_terms]
+    pattern = re.compile(r"\b(" + "|".join(escaped) + r")\b", re.IGNORECASE)
+    body = pattern.sub("[REDACTED]", body)
+
+# Re-emit. yaml.safe_dump with sort_keys=False preserves insertion order.
+new_fm = yaml.safe_dump(fm, default_flow_style=False, sort_keys=False, allow_unicode=True)
+sys.stdout.write("---\n")
+sys.stdout.write(new_fm)
+sys.stdout.write("---\n")
+sys.stdout.write(body)
+PY

--- a/plugins/dev/scripts/morning-briefing/write-output-status.sh
+++ b/plugins/dev/scripts/morning-briefing/write-output-status.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# write-output-status.sh — Merge per-fan-out status JSON files into the
+# briefing markdown's frontmatter under an `output_status:` key. Preserves
+# every other frontmatter field. Idempotent — running again overwrites the
+# existing output_status block.
+#
+# Usage:
+#   write-output-status.sh --in <briefing.md> --statuses <dir-with-*.json>
+#
+# The status dir is expected to contain any subset of:
+#   slack-dm.json, slack-channel.json, notion.json, loom-script.json
+# Each file is a single JSON object with at least {status, destination}.
+
+set -euo pipefail
+
+IN=""
+STATUSES=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in)       IN="$2"; shift 2 ;;
+    --statuses) STATUSES="$2"; shift 2 ;;
+    -h|--help)  sed -n '2,13p' "$0"; exit 0 ;;
+    *) echo "write-output-status.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$IN"       ]] || { echo "write-output-status.sh: --in is required"       >&2; exit 2; }
+[[ -n "$STATUSES" ]] || { echo "write-output-status.sh: --statuses is required" >&2; exit 2; }
+[[ -f "$IN"       ]] || { echo "write-output-status.sh: input file not found: $IN" >&2; exit 2; }
+[[ -d "$STATUSES" ]] || { echo "write-output-status.sh: statuses dir not found: $STATUSES" >&2; exit 2; }
+
+python3 - "$IN" "$STATUSES" <<'PY'
+import json
+import os
+import re
+import sys
+
+import yaml
+
+briefing_path = sys.argv[1]
+status_dir = sys.argv[2]
+
+# Map filename -> frontmatter key
+file_to_key = {
+    "slack-dm.json":      "slack_dm",
+    "slack-channel.json": "slack_channel",
+    "notion.json":        "notion",
+    "loom-script.json":   "loom_script",
+}
+
+output_status = {}
+for fname, key in file_to_key.items():
+    fpath = os.path.join(status_dir, fname)
+    if not os.path.exists(fpath):
+        continue
+    try:
+        with open(fpath, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        continue
+    # Drop the `destination` field — it duplicates the key.
+    cleaned = {k: v for k, v in data.items() if k != "destination"}
+    output_status[key] = cleaned
+
+with open(briefing_path, "r", encoding="utf-8") as fh:
+    raw = fh.read()
+
+m = re.match(r"^---\s*\n(.*?\n)---\s*\n(.*)$", raw, re.DOTALL)
+if not m:
+    sys.stderr.write(f"write-output-status.sh: no frontmatter in {briefing_path}\n")
+    sys.exit(1)
+
+fm = yaml.safe_load(m.group(1)) or {}
+fm["output_status"] = output_status
+
+new_fm = yaml.safe_dump(fm, default_flow_style=False, sort_keys=False, allow_unicode=True)
+new_text = "---\n" + new_fm + "---\n" + m.group(2)
+
+with open(briefing_path, "w", encoding="utf-8") as fh:
+    fh.write(new_text)
+PY

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -3,21 +3,21 @@ name: morning-briefing
 description:
   Generate a daily briefing markdown at thoughts/briefings/YYYY-MM-DD.md with four sections —
   Review yesterday, Surface decisions, Plan today, Suggest orchestrator runs — synthesized from
-  Linear, GitHub, Granola, Google Drive, and Google Calendar in parallel. User-invoked from
-  `/catalyst-dev:morning-briefing` for ad-hoc runs. The CMA Routine wraps the same skill on a
-  weekday-morning schedule (Phase 5 of the parent plan).
+  Linear, GitHub, Granola, Google Drive, and Google Calendar in parallel. Then fans the briefing
+  out to four destinations (Slack DM, Slack channel, Notion page, Loom script file). User-invoked
+  from `/catalyst-dev:morning-briefing` for ad-hoc runs. The CMA Routine wraps the same skill on
+  a weekday-morning schedule (Phase 5 of the parent plan).
 disable-model-invocation: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, mcp__linear__*, mcp__notion__*
 ---
 
-# Morning Briefing — canonical markdown MVP
+# Morning Briefing — canonical markdown + fan-out
 
 ## When to use
 
-Invoke as `/catalyst-dev:morning-briefing` to produce today's briefing locally. Multi-output
-fan-out (Slack DM, Notion, channel post, Loom script) is **Phase 3** of the parent plan
-([[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 2 Phase 3) and lives in different
-files; this skill only emits the canonical markdown.
+Invoke as `/catalyst-dev:morning-briefing` to produce today's briefing locally and fan it out
+to Slack DM, Slack channel, Notion page, and a Loom recording script
+([[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 2 Phase 3).
 
 ## Flags
 
@@ -144,10 +144,50 @@ bash "$SCRIPT_DIR/render.sh" --input "$SCRATCH/input.json" --output "$OUT_PATH"
 bash "$SCRIPT_DIR/validate-frontmatter.sh" "$OUT_PATH"
 ```
 
-## Step 7: End session
+## Step 7: Fan-out (CTL-458)
+
+Run the four fan-outs in parallel against the canonical briefing file. Each script writes a
+status JSON document on stdout; the helper merges those into an `output_status:` block in the
+briefing frontmatter. Each fan-out degrades silently to `{"status":"skipped"}` if its
+credentials or destination ID are missing — the briefing always lands locally regardless.
 
 ```bash
-"$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done --reason "morning-briefing rendered"
+mkdir -p "$SCRATCH/output-status"
+
+bash "$SCRIPT_DIR/fanout-slack-dm.sh"      --in "$OUT_PATH" --date "$DATE" > "$SCRATCH/output-status/slack-dm.json"      &
+bash "$SCRIPT_DIR/fanout-slack-channel.sh" --in "$OUT_PATH" --date "$DATE" > "$SCRATCH/output-status/slack-channel.json" &
+bash "$SCRIPT_DIR/fanout-notion.sh"        --in "$OUT_PATH" --date "$DATE" > "$SCRATCH/output-status/notion.json"        &
+bash "$SCRIPT_DIR/fanout-loom-script.sh"   --in "$OUT_PATH" --date "$DATE" > "$SCRATCH/output-status/loom-script.json"   &
+wait
+
+bash "$SCRIPT_DIR/write-output-status.sh" --in "$OUT_PATH" --statuses "$SCRATCH/output-status"
+
+# Re-validate after fan-out — output_status is optional in the schema but we
+# want to fail loudly if a fan-out wrote malformed JSON.
+bash "$SCRIPT_DIR/validate-frontmatter.sh" "$OUT_PATH"
+```
+
+Fan-out destinations and their config keys:
+
+| Script                       | Credentials env var | Destination key (`.catalyst.briefing.*`) | Profile  |
+|------------------------------|---------------------|------------------------------------------|----------|
+| `fanout-slack-dm.sh`         | `SLACK_BOT_TOKEN`   | `slackDmUserId`                          | `dm`     |
+| `fanout-slack-channel.sh`    | `SLACK_BOT_TOKEN`   | `slackChannelId`                         | `channel`|
+| `fanout-notion.sh`           | `NOTION_TOKEN`      | `notionPageId`                           | `notion` |
+| `fanout-loom-script.sh`      | (none — local file) | (writes `<date>-loom-script.md`)         | `loom`   |
+
+Sanitization profiles (see `sanitize.sh`):
+
+- `dm` — full content preserved.
+- `channel` / `notion` / `loom` — strip `decisions[].summary` and `decisions[].status`, rewrite
+  the `## Surface decisions` body section to `_redacted_`, redact customer names from
+  `.catalyst.briefing.sanitizationRedactList` (case-insensitive, whole-word), and redact PR URLs
+  whose body contains any redact-list string.
+
+## Step 8: End session
+
+```bash
+"$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done --reason "morning-briefing rendered + fan-out"
 echo "Wrote: $OUT_PATH"
 ```
 
@@ -155,8 +195,8 @@ echo "Wrote: $OUT_PATH"
 
 The rendered markdown has YAML frontmatter validated against
 `plugins/dev/templates/briefing-frontmatter.schema.json` (required fields: `date`,
-`generated_by`, `decisions`). Four `## ...` sections follow. Empty sources render
-`_no data_` rather than failing.
+`generated_by`, `decisions`; optional `output_status` block populated by Step 7).
+Four `## ...` sections follow. Empty sources render `_no data_` rather than failing.
 
-Downstream Phase 3 fan-out scripts read this file as their sole input — they MUST NOT
-re-query the source MCPs.
+A companion `<date>-loom-script.md` lands beside the briefing whenever Step 7's loom fan-out
+runs (always, since it has no credential prerequisite).

--- a/plugins/dev/templates/briefing-frontmatter.schema.json
+++ b/plugins/dev/templates/briefing-frontmatter.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MorningBriefingFrontmatter",
-  "description": "YAML frontmatter contract for thoughts/briefings/YYYY-MM-DD.md (CTL-457)",
+  "description": "YAML frontmatter contract for thoughts/briefings/YYYY-MM-DD.md (CTL-457 + CTL-458)",
   "type": "object",
   "required": ["date", "generated_by", "decisions"],
   "properties": {
@@ -17,7 +17,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "type", "summary", "status"],
+        "required": ["id", "type"],
         "properties": {
           "id": { "type": "string", "minLength": 1 },
           "type": {
@@ -46,11 +46,30 @@
     },
     "output_status": {
       "type": "object",
-      "additionalProperties": {
-        "type": "string",
-        "enum": ["success", "failed", "skipped"]
+      "additionalProperties": false,
+      "properties": {
+        "slack_dm":      { "$ref": "#/definitions/fanoutStatus" },
+        "slack_channel": { "$ref": "#/definitions/fanoutStatus" },
+        "notion":        { "$ref": "#/definitions/fanoutStatus" },
+        "loom_script":   { "$ref": "#/definitions/fanoutStatus" }
       }
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "definitions": {
+    "fanoutStatus": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["posted", "skipped", "failed"]
+        },
+        "destination": { "type": "string" },
+        "reason":      { "type": "string" },
+        "details":     { "type": "object" }
+      },
+      "additionalProperties": false
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Implements **CTL-458 — Phase 3: Multi-output fan-out (Slack DM, Notion, Slack channel, Loom script)** from the parent plan ([thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md §Initiative 2 Phase 3](thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md)).

Takes the canonical briefing markdown produced by CTL-457 (PR #804) and fans it out to four destinations. Each fan-out is independent — credentials/destination missing → script emits `{"status":"skipped"}` and exits 0. The briefing always lands locally regardless of fan-out failures.

## Destinations

| Script | Credentials | Destination key | Sanitization |
|---|---|---|---|
| `fanout-slack-dm.sh` | `SLACK_BOT_TOKEN` | `.catalyst.briefing.slackDmUserId` | `dm` (full content) |
| `fanout-slack-channel.sh` | `SLACK_BOT_TOKEN` | `.catalyst.briefing.slackChannelId` | `channel` |
| `fanout-notion.sh` | `NOTION_TOKEN` | `.catalyst.briefing.notionPageId` | `notion` |
| `fanout-loom-script.sh` | (none — local write) | `<date>-loom-script.md` | `loom` |

The skill's Step 7 runs all four in parallel; `write-output-status.sh` merges per-destination status JSON into an `output_status:` block on the briefing's frontmatter.

## Sanitization profiles (`sanitize.sh`)

- **dm** — passthrough (full content preserved).
- **channel / notion / loom** —
  - Strip `decisions[].summary` and `decisions[].status` from frontmatter (keep `id` + `type`).
  - Rewrite the `## Surface decisions` body section to `_redacted_`.
  - Redact customer names from `.catalyst.briefing.sanitizationRedactList` (case-insensitive, whole-word — `Acme` does not match `Academic`).
  - Redact PR URLs whose body contains any redact-list string.

## Schema additions (`briefing-frontmatter.schema.json`)

- New optional `output_status` object keyed by the four destination names; `additionalProperties: false` to reject unknown keys.
- New `definitions.fanoutStatus`: `{ status: posted | skipped | failed, reason?, details? }`.
- `decisions[]` now requires only `id` + `type` (`summary` / `status` are optional) so sanitized briefings still validate. Pre-existing CTL-457 tests (which always supply both fields) continue to pass.

## Files

```
plugins/dev/scripts/morning-briefing/sanitize.sh
plugins/dev/scripts/morning-briefing/fanout-slack-dm.sh
plugins/dev/scripts/morning-briefing/fanout-slack-channel.sh
plugins/dev/scripts/morning-briefing/fanout-notion.sh
plugins/dev/scripts/morning-briefing/fanout-loom-script.sh
plugins/dev/scripts/morning-briefing/write-output-status.sh
plugins/dev/scripts/__tests__/briefing-fanout.test.sh
plugins/dev/skills/morning-briefing/SKILL.md         (Step 7 + Step 8 renumber)
plugins/dev/templates/briefing-frontmatter.schema.json
```

## What's NOT in this PR (deferred to later phases)

- ADR drift detector (CTL-459 / Initiative 2 Phase 4)
- CMA Routine wiring + cron schedule (CTL-469 / Initiative 2 Phase 5)
- Real Slack/Notion credential provisioning (operator one-time setup, tracked in Phase 5)
- LLM-polished Loom prose (deterministic template is MVP; Phase 6 manual-acceptance gate)
- Notion idempotency by archiving old marker blocks — current script always appends; Phase 6 will verify single-page-no-duplicate behavior on real runs and may add the archive step if needed.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/briefing-fanout.test.sh` — 54/54 passing
  - `sanitize.sh`: dm passthrough, channel decision-stripping, body rewrite, customer-name redaction, word-boundary (Acme ≠ Academic), PR-URL redaction, bad-profile rejection
  - `fanout-slack-dm.sh`: no-creds skip, no-destination skip, dry-run payload contains full body
  - `fanout-slack-channel.sh`: no-creds skip, no-destination skip, dry-run uses sanitized body
  - `fanout-notion.sh`: no-creds skip, no-destination skip, dry-run contains page id + marker
  - `fanout-loom-script.sh`: default path, dry-run path, date in output, word budget, all 4 sections mentioned
  - End-to-end: all 4 fan-outs print parseable status JSON, `write-output-status.sh` merges into frontmatter, `validate-frontmatter.sh` still passes
  - Schema: parses, accepts valid output_status, rejects unknown destination, rejects bad status enum
- [x] `bash plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh` — 36/36 still passing (CTL-457 regression check)
- [x] `bash -n` clean on all 7 new shell scripts
- [x] End-to-end skill flow exercised against an empty-credentials run — produces briefing + loom script + skipped statuses; `output_status` block validates against schema
- [ ] Manual verification with real Slack/Notion credentials wired up — operator task, deferred to Phase 6 acceptance gate.

Refs CTL-458.