### PR TITLE
feat(dev): briefing-followup skill MVP — load + present agenda (CTL-462)

### DIFF
--- a/plugins/dev/scripts/__tests__/briefing-followup-load.test.sh
+++ b/plugins/dev/scripts/__tests__/briefing-followup-load.test.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Tests for the briefing-followup skill MVP (CTL-462 Phase 1).
+# Covers: parse-briefing.sh path resolution, frontmatter loading,
+# decision extraction, error paths for missing/malformed briefings,
+# and the SKILL.md frontmatter contract.
+#
+# Run: bash plugins/dev/scripts/__tests__/briefing-followup-load.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+BF_DIR="${REPO_ROOT}/plugins/dev/scripts/briefing-followup"
+PARSER="${BF_DIR}/parse-briefing.sh"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/briefing-followup/SKILL.md"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  shift
+  for line in "$@"; do echo "    $line"; done
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected: $expected" "actual:   $actual"
+  fi
+}
+
+assert_grep() {
+  local label="$1" pattern="$2" content="$3"
+  if grep -qF -- "$pattern" <<<"$content"; then
+    pass "$label"
+  else
+    fail "$label" "expected substring: $pattern" \
+      "actual: $(printf '%s' "$content" | head -20)"
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected exit: $expected" "actual exit:   $actual"
+  fi
+}
+
+# Write a valid briefing fixture at <root>/thoughts/briefings/<date>.md.
+write_fixture() {
+  local root="$1" date="$2"
+  mkdir -p "$root/thoughts/briefings"
+  cat > "$root/thoughts/briefings/$date.md" <<MD
+---
+date: $date
+generated_by: morning-briefing
+decisions:
+  - id: dec-1
+    type: blocked_pr
+    summary: "PR #800 stalled"
+    status: open
+    pr_url: https://github.com/org/repo/pull/800
+  - id: dec-2
+    type: judgment_call
+    summary: Pick auth provider
+    status: open
+  - id: dec-3
+    type: adr_drift
+    summary: ADR-004 drift detected
+    status: resolved
+    adr: docs/adrs/0004.md
+---
+
+# Morning Briefing — $date
+
+## Review yesterday
+_no data_
+MD
+}
+
+# ─── Test 1: parser loads thoughts/briefings/<date>.md by default (today) ────
+test_load_default_today() {
+  echo "test 1: parse-briefing loads thoughts/briefings/<today>.md by default"
+  local today root
+  today=$(date -u +%Y-%m-%d)
+  root="$SCRATCH/proj1"
+  write_fixture "$root" "$today"
+  local actual ec
+  actual=$(bash "$PARSER" path --root "$root" 2>&1)
+  ec=$?
+  assert_exit "default path exits 0" "0" "$ec"
+  assert_eq "default path is today's briefing" \
+    "$root/thoughts/briefings/${today}.md" "$actual"
+
+  # Confirm we can actually load it
+  local decisions
+  decisions=$(bash "$PARSER" decisions --root "$root" 2>/dev/null)
+  ec=$?
+  assert_exit "load default briefing exits 0" "0" "$ec"
+  if printf '%s' "$decisions" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    pass "decisions output is a JSON array"
+  else
+    fail "decisions output is a JSON array" "got: $decisions"
+  fi
+}
+
+# ─── Test 2: parser loads with --date YYYY-MM-DD ─────────────────────────────
+test_load_explicit_date() {
+  echo "test 2: parse-briefing loads with explicit --date"
+  local date="2026-04-01" root="$SCRATCH/proj2"
+  write_fixture "$root" "$date"
+  local actual ec
+  actual=$(bash "$PARSER" path --date "$date" --root "$root" 2>&1)
+  ec=$?
+  assert_exit "explicit-date path exits 0" "0" "$ec"
+  assert_eq "explicit-date path resolved" \
+    "$root/thoughts/briefings/${date}.md" "$actual"
+
+  local decisions
+  decisions=$(bash "$PARSER" decisions --date "$date" --root "$root" 2>/dev/null)
+  ec=$?
+  assert_exit "load explicit-date briefing exits 0" "0" "$ec"
+  # Default status filter = open → expect 2 decisions, not 3
+  local count
+  count=$(printf '%s' "$decisions" | jq 'length')
+  assert_eq "default decisions filter = open (2 of 3)" "2" "$count"
+}
+
+# ─── Test 3: parser errors gracefully when briefing missing ─────────────────
+test_missing_briefing_error() {
+  echo "test 3: parse-briefing errors gracefully when briefing missing"
+  local date="2026-04-02" root="$SCRATCH/proj3"
+  mkdir -p "$root"
+  # Note: no briefing file written
+  local stderr ec
+  stderr=$(bash "$PARSER" decisions --date "$date" --root "$root" 2>&1 1>/dev/null)
+  ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "missing briefing should exit non-zero" "got exit 0"
+  else
+    pass "missing briefing exits non-zero (got $ec)"
+  fi
+  # Diagnostics should mention the path AND suggest running morning-briefing
+  assert_grep "error mentions briefing path" "$root/thoughts/briefings/${date}.md" "$stderr"
+  assert_grep "error suggests morning-briefing skill" "morning-briefing" "$stderr"
+}
+
+# ─── Test 4: parser extracts decisions from frontmatter ─────────────────────
+test_parse_decisions_block() {
+  echo "test 4: parse-briefing parses decisions: from frontmatter"
+  local date="2026-04-03" root="$SCRATCH/proj4"
+  write_fixture "$root" "$date"
+
+  # All-status filter should return all 3 decisions
+  local all
+  all=$(bash "$PARSER" decisions --date "$date" --root "$root" --status all 2>/dev/null)
+  local all_count
+  all_count=$(printf '%s' "$all" | jq 'length')
+  assert_eq "all-status filter returns 3 decisions" "3" "$all_count"
+
+  # Verify each required field is present on first decision
+  local first
+  first=$(printf '%s' "$all" | jq '.[0]')
+  assert_grep "decision has id field"      '"id"'      "$first"
+  assert_grep "decision has type field"    '"type"'    "$first"
+  assert_grep "decision has summary field" '"summary"' "$first"
+  assert_grep "decision has status field"  '"status"'  "$first"
+
+  # Single-decision lookup by id
+  local dec
+  dec=$(bash "$PARSER" decision --date "$date" --root "$root" --id "dec-2" 2>/dev/null)
+  local dec_summary
+  dec_summary=$(printf '%s' "$dec" | jq -r '.summary')
+  assert_eq "decision by id (dec-2) summary" "Pick auth provider" "$dec_summary"
+
+  # Unknown id → non-zero
+  local ec
+  bash "$PARSER" decision --date "$date" --root "$root" --id "no-such-id" >/dev/null 2>&1
+  ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "unknown decision id should exit non-zero" "got exit 0"
+  else
+    pass "unknown decision id exits non-zero (got $ec)"
+  fi
+
+  # Agenda subcommand renders a numbered, human-readable list
+  local agenda
+  agenda=$(bash "$PARSER" agenda --date "$date" --root "$root" 2>/dev/null)
+  assert_grep "agenda includes dec-1 summary" "PR #800 stalled" "$agenda"
+  assert_grep "agenda includes dec-2 summary" "Pick auth provider" "$agenda"
+  # dec-3 is status=resolved, so default agenda (status=open) should exclude it
+  if grep -qF "ADR-004 drift detected" <<<"$agenda"; then
+    fail "agenda default filter (open) excludes resolved decisions" \
+      "but dec-3 (status=resolved) appeared in output"
+  else
+    pass "agenda default filter (open) excludes resolved decisions"
+  fi
+}
+
+# ─── Test 5: parser survives malformed frontmatter (clear error, no crash) ──
+test_malformed_frontmatter() {
+  echo "test 5: parse-briefing surfaces a clear error on malformed frontmatter"
+  local date="2026-04-04" root="$SCRATCH/proj5"
+  mkdir -p "$root/thoughts/briefings"
+  # Malformed YAML: unterminated list, missing colon, mixed indentation
+  cat > "$root/thoughts/briefings/$date.md" <<'MD'
+---
+date: 2026-04-04
+generated_by: morning-briefing
+decisions:
+  - id dec-1
+    type: blocked_pr
+   summary: Broken YAML
+---
+
+# Body
+MD
+  local stderr ec
+  stderr=$(bash "$PARSER" decisions --date "$date" --root "$root" 2>&1 1>/dev/null)
+  ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "malformed frontmatter should exit non-zero" "got exit 0"
+  else
+    pass "malformed frontmatter exits non-zero (got $ec)"
+  fi
+  # Should mention the file path so the user knows what failed
+  assert_grep "error mentions briefing path" \
+    "$root/thoughts/briefings/${date}.md" "$stderr"
+
+  # Edge case: file exists but has no frontmatter at all
+  local date2="2026-04-05"
+  cat > "$root/thoughts/briefings/$date2.md" <<'MD'
+# Just a heading, no frontmatter
+
+Plain markdown.
+MD
+  stderr=$(bash "$PARSER" decisions --date "$date2" --root "$root" 2>&1 1>/dev/null)
+  ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "no-frontmatter file should exit non-zero" "got exit 0"
+  else
+    pass "no-frontmatter file exits non-zero (got $ec)"
+  fi
+}
+
+# ─── Test: parser rejects malformed --date ──────────────────────────────────
+test_bad_date_arg() {
+  echo "test: parse-briefing rejects malformed --date"
+  local ec
+  bash "$PARSER" path --date "not-a-date" --root "$SCRATCH" >/dev/null 2>&1
+  ec=$?
+  if [[ "$ec" -eq 0 ]]; then
+    fail "malformed --date should exit non-zero" "got exit 0"
+  else
+    pass "malformed --date exits non-zero (got $ec)"
+  fi
+}
+
+# ─── Test: --file overrides --date / --root path resolution ─────────────────
+test_explicit_file_override() {
+  echo "test: --file overrides path resolution"
+  local date="2026-04-06" root="$SCRATCH/proj6"
+  mkdir -p "$root"
+  local custom="$SCRATCH/custom-briefing.md"
+  cat > "$custom" <<MD
+---
+date: $date
+generated_by: morning-briefing
+decisions:
+  - id: only
+    type: scope_question
+    summary: From custom path
+    status: open
+---
+
+# Body
+MD
+  local decisions count
+  decisions=$(bash "$PARSER" decisions --file "$custom" 2>/dev/null)
+  count=$(printf '%s' "$decisions" | jq 'length')
+  assert_eq "--file loads decisions" "1" "$count"
+}
+
+# ─── Test: SKILL.md exists with required frontmatter ────────────────────────
+test_skill_md_frontmatter() {
+  echo "test: SKILL.md exists with correct frontmatter"
+  if [[ ! -f "$SKILL_MD" ]]; then
+    fail "SKILL.md exists" "missing: $SKILL_MD"; return
+  fi
+  pass "SKILL.md exists"
+  local fm
+  fm=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$SKILL_MD")
+  assert_grep "name: briefing-followup" "name: briefing-followup" "$fm"
+  assert_grep "disable-model-invocation: true" "disable-model-invocation: true" "$fm"
+  assert_grep "user-invocable: true" "user-invocable: true" "$fm"
+  assert_grep "allowed-tools includes Bash" "Bash" "$fm"
+}
+
+# ─── Run all tests ──────────────────────────────────────────────────────────
+test_load_default_today
+test_load_explicit_date
+test_missing_briefing_error
+test_parse_decisions_block
+test_malformed_frontmatter
+test_bad_date_arg
+test_explicit_file_override
+test_skill_md_frontmatter
+
+echo
+echo "─────────────────────────────────────"
+echo "PASSED: $PASSES"
+echo "FAILED: $FAILURES"
+echo "─────────────────────────────────────"
+exit $(( FAILURES > 0 ? 1 : 0 ))

--- a/plugins/dev/scripts/briefing-followup/parse-briefing.sh
+++ b/plugins/dev/scripts/briefing-followup/parse-briefing.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# parse-briefing.sh — Load and parse a morning briefing markdown file for the
+# briefing-followup skill (CTL-462 Phase 1).
+#
+# Subcommands:
+#   path     [--date YYYY-MM-DD] [--root DIR]
+#       Print the resolved briefing path. Does NOT check existence.
+#
+#   load     [--date YYYY-MM-DD] [--root DIR] [--file FILE]
+#       Resolve + read briefing, print frontmatter as JSON.
+#       Exits 1 if file missing (with a suggestion to run morning-briefing),
+#       2 if frontmatter is malformed or absent.
+#
+#   decisions [--date Y] [--root D] [--file F] [--status open|all]
+#       Print the decisions array as JSON. Default --status=open filters out
+#       resolved/deferred entries.
+#
+#   decision [--date Y] [--root D] [--file F] --id DEC_ID
+#       Print a single decision JSON by id. Exits 3 if id not found.
+#
+#   agenda    [--date Y] [--root D] [--file F] [--status open|all]
+#       Print a human-readable numbered agenda, one decision per line.
+
+set -uo pipefail
+
+usage() {
+  sed -n '2,30p' "$0"
+}
+
+# ─── Argument parsing helpers ───────────────────────────────────────────────
+DATE=""
+ROOT="${PWD}"
+FILE=""
+STATUS="open"
+DEC_ID=""
+
+parse_flags() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --date)   DATE="${2:-}"; shift 2 ;;
+      --root)   ROOT="${2:-}"; shift 2 ;;
+      --file)   FILE="${2:-}"; shift 2 ;;
+      --status) STATUS="${2:-}"; shift 2 ;;
+      --id)     DEC_ID="${2:-}"; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *)
+        echo "parse-briefing.sh: unknown flag: $1" >&2
+        exit 2
+        ;;
+    esac
+  done
+}
+
+resolve_path() {
+  # If --file was passed, honor it.
+  if [[ -n "$FILE" ]]; then
+    printf '%s\n' "$FILE"
+    return
+  fi
+  if [[ -z "$DATE" ]]; then
+    DATE="$(date -u +%Y-%m-%d)"
+  fi
+  if ! [[ "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    echo "parse-briefing.sh: --date must be YYYY-MM-DD, got: $DATE" >&2
+    exit 2
+  fi
+  printf '%s/thoughts/briefings/%s.md\n' "$ROOT" "$DATE"
+}
+
+# Read frontmatter from a markdown file and emit it as JSON via python3+yaml.
+# Exits 1 if file missing (writes suggestion to stderr).
+# Exits 2 if frontmatter absent or malformed (writes path to stderr).
+emit_frontmatter_json() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    cat >&2 <<ERR
+parse-briefing.sh: briefing not found: $file
+
+Generate today's briefing with:
+  /catalyst-dev:morning-briefing
+
+Or pass --date YYYY-MM-DD to target a different day.
+ERR
+    exit 1
+  fi
+
+  # Extract the first --- ... --- block.
+  local fm
+  fm=$(awk '
+    /^---[[:space:]]*$/ {
+      if (in_block) { exit }
+      in_block = 1; next
+    }
+    in_block { print }
+  ' "$file")
+
+  if [[ -z "$fm" ]]; then
+    echo "parse-briefing.sh: no YAML frontmatter found in $file" >&2
+    exit 2
+  fi
+
+  # YAML → JSON via python3 + PyYAML. `default=str` coerces YAML-native
+  # date/datetime values (e.g. `date: 2026-04-03`) into JSON strings instead
+  # of crashing json.dump on non-serializable types.
+  local err_log
+  err_log=$(mktemp)
+  if ! printf '%s\n' "$fm" | python3 -c '
+import sys, json, yaml
+try:
+    data = yaml.safe_load(sys.stdin)
+except yaml.YAMLError as e:
+    sys.stderr.write("YAML parse error: " + str(e) + "\n")
+    sys.exit(3)
+if not isinstance(data, dict):
+    sys.stderr.write("YAML root must be a mapping\n")
+    sys.exit(3)
+json.dump(data, sys.stdout, default=str)
+' 2>"$err_log"; then
+    echo "parse-briefing.sh: malformed YAML frontmatter in $file" >&2
+    [[ -s "$err_log" ]] && cat "$err_log" >&2
+    rm -f "$err_log"
+    exit 2
+  fi
+  rm -f "$err_log"
+}
+
+# Filter a decisions JSON array by status. Pass "all" to skip filtering.
+filter_decisions_json() {
+  local status="$1"
+  if [[ "$status" == "all" ]]; then
+    jq '.decisions // []'
+  else
+    jq --arg s "$status" '[(.decisions // [])[] | select(.status == $s)]'
+  fi
+}
+
+# ─── Subcommand dispatch ────────────────────────────────────────────────────
+SUBCMD="${1:-}"
+if [[ -z "$SUBCMD" ]]; then
+  usage >&2
+  exit 2
+fi
+shift
+
+case "$SUBCMD" in
+  path)
+    parse_flags "$@"
+    resolve_path
+    ;;
+
+  load)
+    parse_flags "$@"
+    FILE_PATH=$(resolve_path)
+    emit_frontmatter_json "$FILE_PATH"
+    echo
+    ;;
+
+  decisions)
+    parse_flags "$@"
+    FILE_PATH=$(resolve_path)
+    emit_frontmatter_json "$FILE_PATH" | filter_decisions_json "$STATUS"
+    ;;
+
+  decision)
+    parse_flags "$@"
+    if [[ -z "$DEC_ID" ]]; then
+      echo "parse-briefing.sh: decision subcommand requires --id" >&2
+      exit 2
+    fi
+    FILE_PATH=$(resolve_path)
+    DECISION=$(emit_frontmatter_json "$FILE_PATH" \
+      | jq --arg id "$DEC_ID" '(.decisions // [])[] | select(.id == $id)')
+    if [[ -z "$DECISION" || "$DECISION" == "null" ]]; then
+      echo "parse-briefing.sh: no decision with id=$DEC_ID in $FILE_PATH" >&2
+      exit 3
+    fi
+    printf '%s\n' "$DECISION"
+    ;;
+
+  agenda)
+    parse_flags "$@"
+    FILE_PATH=$(resolve_path)
+    emit_frontmatter_json "$FILE_PATH" \
+      | filter_decisions_json "$STATUS" \
+      | jq -r 'to_entries | .[]
+          | "\(.key + 1). [\(.value.id)] [\(.value.type)] \(.value.summary)"'
+    ;;
+
+  *)
+    echo "parse-briefing.sh: unknown subcommand: $SUBCMD" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/plugins/dev/skills/briefing-followup/SKILL.md
+++ b/plugins/dev/skills/briefing-followup/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: briefing-followup
+description:
+  Interactive walk-through of today's morning briefing. Loads the briefing markdown at
+  thoughts/briefings/YYYY-MM-DD.md (built by [[morning-briefing]]), parses the structured
+  decisions: frontmatter, and walks the user through each open decision one at a time with
+  placeholder Approve / Reject / Defer actions. Phase 1 MVP — Phase 2 wires real action
+  handlers (calendar / ticket / orchestrator / email); Phase 4 writes resolutions back to
+  the briefing markdown.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Task, mcp__*
+---
+
+# Briefing Follow-up — load + present agenda (MVP)
+
+## When to use
+
+Invoke as `/catalyst-dev:briefing-followup` after `/catalyst-dev:morning-briefing` has
+produced today's briefing. The skill reads that briefing's `decisions:` block and walks
+the user through each open decision in turn. Phase 1 surfaces placeholder actions; the
+real action handlers ship in Phase 2 ([[2026-05-16-catalyst-phase-agent-architecture]]
+§Initiative 3 Phase 2).
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--date YYYY-MM-DD` | Target briefing date. Default: today (UTC). |
+| `--file PATH` | Override path resolution entirely (test/dev usage). |
+| `--status STATUS` | Decision-status filter: `open` (default) or `all`. |
+
+## Step 1: Prelude — start session, resolve date, load briefing
+
+```bash
+SCRIPT_DIR="${CLAUDE_PLUGIN_ROOT:-plugins/dev}/scripts/briefing-followup"
+SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT:-plugins/dev}/scripts/catalyst-session.sh"
+
+CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start --skill "briefing-followup" \
+  --ticket "" --workflow "${CATALYST_SESSION_ID:-}")
+export CATALYST_SESSION_ID
+
+# Resolve briefing path. Pass --date / --file straight through from the user.
+BRIEFING_PATH=$(bash "$SCRIPT_DIR/parse-briefing.sh" path "$@")
+DATE=$(basename "$BRIEFING_PATH" .md)
+echo "Briefing date: $DATE"
+echo "Briefing path: $BRIEFING_PATH"
+
+# Load + validate frontmatter (exits 1 with a helpful suggestion if missing,
+# exits 2 if frontmatter is malformed or absent).
+if ! FRONTMATTER_JSON=$(bash "$SCRIPT_DIR/parse-briefing.sh" load "$@"); then
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed \
+    --reason "briefing not found or malformed"
+  exit 1
+fi
+```
+
+If the briefing doesn't exist, `parse-briefing.sh` prints the resolved path and a
+suggestion to run `/catalyst-dev:morning-briefing` before failing. Surface that message
+verbatim to the user.
+
+## Step 2: Present the agenda
+
+Render the open decisions as a numbered list with summary + type:
+
+```bash
+echo
+echo "─── Agenda for $DATE ───"
+bash "$SCRIPT_DIR/parse-briefing.sh" agenda "$@"
+echo "───────────────────────"
+echo
+
+DECISION_COUNT=$(bash "$SCRIPT_DIR/parse-briefing.sh" decisions "$@" | jq 'length')
+if [[ "$DECISION_COUNT" -eq 0 ]]; then
+  echo "No open decisions in this briefing. Nothing to follow up on."
+  "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done \
+    --reason "no open decisions"
+  exit 0
+fi
+echo "$DECISION_COUNT open decision(s) to walk through."
+```
+
+## Step 3: Decision-update placeholder log
+
+Resolve the log path before the loop. Inside an orchestrator dispatch
+(`$CATALYST_ORCHESTRATOR_DIR` is set), prefer the orchestrator's run directory so the
+record lands next to other worker artifacts; otherwise fall back to `/tmp` for local
+runs. Phase 4 of the parent plan replaces this placeholder with a real `resolutions:`
+write-back to the briefing markdown.
+
+```bash
+if [[ -n "${CATALYST_ORCHESTRATOR_DIR:-}" ]]; then
+  LOG_DIR="$CATALYST_ORCHESTRATOR_DIR"
+else
+  LOG_DIR="/tmp"
+fi
+LOG_FILE="$LOG_DIR/briefing-followup-$DATE.log"
+mkdir -p "$LOG_DIR"
+: > "$LOG_FILE"  # truncate any prior run from today
+
+log_response() {
+  local id="$1" action="$2" note="${3:-}"
+  printf '%s\t%s\t%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$id" "$action" "$note" \
+    >> "$LOG_FILE"
+}
+```
+
+## Step 4: Loop over decisions
+
+For each open decision, present the details + the placeholder action set. In Phase 1
+the action handlers are inert — they record the user's choice and continue. Phase 2
+wires real handlers ([[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 3
+Phase 2).
+
+```bash
+DECISIONS_JSON=$(bash "$SCRIPT_DIR/parse-briefing.sh" decisions "$@")
+
+# Iterate over the JSON array. `jq -c .[]` emits one decision per line.
+INDEX=0
+TOTAL="$DECISION_COUNT"
+echo "$DECISIONS_JSON" | jq -c '.[]' | while IFS= read -r dec; do
+  INDEX=$((INDEX + 1))
+  ID=$(echo "$dec"      | jq -r '.id')
+  TYPE=$(echo "$dec"    | jq -r '.type')
+  SUMMARY=$(echo "$dec" | jq -r '.summary')
+  PR_URL=$(echo "$dec"  | jq -r '.pr_url // empty')
+  TICKET=$(echo "$dec"  | jq -r '.ticket // empty')
+  ADR=$(echo "$dec"     | jq -r '.adr // empty')
+
+  echo
+  echo "═══ Decision $INDEX of $TOTAL ═══"
+  echo "id:      $ID"
+  echo "type:    $TYPE"
+  echo "summary: $SUMMARY"
+  [[ -n "$PR_URL" ]] && echo "pr:      $PR_URL"
+  [[ -n "$TICKET" ]] && echo "ticket:  $TICKET"
+  [[ -n "$ADR"    ]] && echo "adr:     $ADR"
+  echo
+  echo "Actions: [a]pprove · [r]eject · [d]efer · [s]kip · [q]uit"
+done
+```
+
+When this skill runs in an interactive Claude Code session, present each decision as
+above and use the model to interpret the user's natural-language response. Map common
+intents to the placeholder actions:
+
+| User says... | Action |
+|---|---|
+| approve / accept / yes / ship it | `approve` → `log_response "$ID" approve` |
+| reject / no / dismiss | `reject` → `log_response "$ID" reject` |
+| defer / later / skip for today | `defer`  → `log_response "$ID" defer` |
+| skip | move on without logging |
+| quit / stop / done | break out of the loop |
+
+After each decision the user resolves, call `log_response` with the action and any free-form
+note the user provided. Continue to the next decision until the queue is empty or the user
+quits.
+
+## Step 5: End session
+
+```bash
+echo
+echo "Logged $(wc -l < "$LOG_FILE" | tr -d ' ') response(s) to $LOG_FILE"
+"$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status done \
+  --reason "briefing-followup completed for $DATE"
+```
+
+## Output contract
+
+- **Input**: `thoughts/briefings/YYYY-MM-DD.md` produced by [[morning-briefing]],
+  validated against `plugins/dev/templates/briefing-frontmatter.schema.json`.
+- **Output (Phase 1)**: a scratch log at `$CATALYST_ORCHESTRATOR_DIR/briefing-followup-<date>.log`
+  (or `/tmp/briefing-followup-<date>.log` outside orchestrator mode), one TSV line per
+  resolved decision: `<utc-timestamp>\t<id>\t<action>\t<note>`. Phase 4 of the parent
+  plan rewrites this as a `resolutions:` block on the briefing markdown frontmatter.
+
+## Phase 1 scope (this ticket)
+
+Per [[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 3 Phase 1 (CTL-462):
+load briefing, parse decisions, walk the user through each one with placeholder
+actions. **Action handlers ship in Phase 2 (CTL-463)** — schedule calendar entry, file
+Linear ticket, dispatch orchestrator, draft email. ADR-drift resolution is its own
+Phase 3 (CTL-464). Resolution write-back to the briefing is Phase 4 (CTL-465).


### PR DESCRIPTION
## Summary

Phase 1 MVP of the `briefing-followup` skill — Initiative 3 of [[2026-05-16-catalyst-phase-agent-architecture]] (CTL-462). User-invocable interactive skill that consumes the morning-briefing markdown produced by CTL-457 and walks the operator through each open decision with placeholder Approve / Reject / Defer actions. Real action handlers (calendar / ticket / orchestrator / email) ship in Phase 2 (CTL-463); resolution write-back to the briefing arrives in Phase 4 (CTL-465).

Closes CTL-462. Unblocks CTL-463.

## What's in this PR

- `plugins/dev/skills/briefing-followup/SKILL.md` — interactive skill body, frontmatter `disable-model-invocation: true`, `user-invocable: true`, broad `allowed-tools: Read, Write, Edit, Bash, Task, mcp__*` per the plan. Five steps: prelude (resolve date + load), present agenda, decision-update placeholder log, loop over decisions, end session.
- `plugins/dev/scripts/briefing-followup/parse-briefing.sh` — subcommand parser (`path` / `load` / `decisions` / `decision` / `agenda`). Mirrors morning-briefing's `output-path.sh` path contract (`thoughts/briefings/<date>.md`, UTC today by default). YAML→JSON via `python3 + PyYAML` with `default=str` so YAML-native date scalars don't crash `json.dump`. Distinct exit codes: 1=missing-file, 2=malformed-frontmatter, 3=unknown-decision-id.
- `plugins/dev/scripts/__tests__/briefing-followup-load.test.sh` — 31 assertions across the 5 plan acceptance cases plus path/`--file` overrides and SKILL.md frontmatter contract. TDD red→green: tests were written first and failed (21 fails) before either of the production files existed.

## Plan acceptance criteria

**Automated** ([plan §Phase 1](thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md#L976-L978)):
- [x] `bash plugins/dev/scripts/__tests__/briefing-followup-load.test.sh` → **PASSED: 31, FAILED: 0**

**Manual**:
- [x] Skill walks a real briefing's decisions end-to-end with placeholder actions — verified via smoke test against a 2-decision fixture; `path`, `agenda`, `decisions`, `decision` and the missing-file error path all behave correctly.

## Output contract

Phase 1 writes a TSV scratch log at `$CATALYST_ORCHESTRATOR_DIR/briefing-followup-<date>.log` (or `/tmp/...` when run standalone), one line per resolved decision: `<utc-timestamp>\t<id>\t<action>\t<note>`. Phase 4 (CTL-465) replaces this with a real `resolutions:` block on the briefing markdown frontmatter.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/briefing-followup-load.test.sh` → 31/31 pass
- [x] `bash plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh` → 36/36 pass (no regression in adjacent code)
- [x] `bash plugins/dev/scripts/__tests__/catalyst-state.test.sh` → 24/24 pass (orchestrator infra unchanged)
- [x] Manual smoke test: parser resolves `--date`, parses `decisions:` block, filters by status, errors helpfully on missing file