### PR TITLE
feat(dev): research-curate contradiction detection + CONTRADICTIONS.md (CTL-468)

### DIFF
--- a/plugins/dev/scripts/__tests__/research-curate-contradictions.test.sh
+++ b/plugins/dev/scripts/__tests__/research-curate-contradictions.test.sh
@@ -1,0 +1,460 @@
+#!/usr/bin/env bash
+# Tests for plugins/dev/scripts/research-curate/{cluster,contradict,append-contradictions}.sh
+# plus the run.sh extensions added in CTL-468.
+#
+# Builds isolated fixtures under $SCRATCH so the real corpus is never touched.
+# Tests use a stub --llm-cmd to avoid spending tokens.
+#
+# Run: bash plugins/dev/scripts/__tests__/research-curate-contradictions.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CURATE_DIR="${REPO_ROOT}/plugins/dev/scripts/research-curate"
+INVENTORY="${CURATE_DIR}/inventory.sh"
+CLUSTER="${CURATE_DIR}/cluster.sh"
+CONTRADICT="${CURATE_DIR}/contradict.sh"
+APPEND="${CURATE_DIR}/append-contradictions.sh"
+RUN="${CURATE_DIR}/run.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+ok() {
+  PASSES=$((PASSES+1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $1"
+  echo "    $2"
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    ok "$name"
+  else
+    fail "$name" "expected '$expected' got '$actual'"
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    ok "$name"
+  else
+    fail "$name" "missing '$needle' in: $(head -c 200 <<<"$haystack")"
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    fail "$name" "unexpectedly found '$needle'"
+  else
+    ok "$name"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helpers — fixture corpora and mock LLM
+# ---------------------------------------------------------------------------
+
+# Two-cluster corpus: 3 docs tagged [orchestrator, state], 3 tagged [broker, events].
+seed_two_cluster_corpus() {
+  local dir="$1"
+  mkdir -p "$dir"
+  for i in 1 2 3; do
+    cat > "$dir/2026-05-0${i}-orch-${i}.md" <<EOF
+---
+date: 2026-05-0${i}
+topic: "Orchestrator state notes ${i}"
+tags: [orchestrator, state, workers]
+type: research
+---
+
+# Orchestrator state ${i}
+
+Worker ${i} writes to the orchestrator state file.
+EOF
+  done
+  for i in 1 2 3; do
+    cat > "$dir/2026-05-1${i}-broker-${i}.md" <<EOF
+---
+date: 2026-05-1${i}
+topic: "Broker events ${i}"
+tags: [broker, events, daemon]
+type: research
+---
+
+# Broker events ${i}
+
+The broker daemon emits events.
+EOF
+  done
+}
+
+# Small corpus: 2 docs that would cluster together — should be dropped.
+seed_too_small_corpus() {
+  local dir="$1"
+  mkdir -p "$dir"
+  for i in 1 2; do
+    cat > "$dir/2026-05-0${i}-pair-${i}.md" <<EOF
+---
+date: 2026-05-0${i}
+topic: "Pair ${i}"
+tags: [pair, alpha, beta]
+type: research
+---
+
+# Pair ${i}
+
+Content.
+EOF
+  done
+}
+
+# Mega corpus: 12 docs all sharing one tag, should be split → 10 max.
+seed_too_large_corpus() {
+  local dir="$1"
+  mkdir -p "$dir"
+  for i in $(seq 1 12); do
+    local padded=$(printf '%02d' "$i")
+    cat > "$dir/2026-05-${padded}-mega-${padded}.md" <<EOF
+---
+date: 2026-05-${padded}
+topic: "Mega ${padded}"
+tags: [mega, shared, common]
+type: research
+---
+
+# Mega ${padded}
+
+Body ${i}.
+EOF
+  done
+}
+
+# Write a mock LLM script that emits a fixed JSON response.
+# Usage: make_mock_llm <output-path> <fixture-json-path>
+make_mock_llm() {
+  local out="$1" fixture="$2"
+  cat > "$out" <<EOF
+#!/usr/bin/env bash
+# Mock LLM: ignore stdin (the prompt), emit fixture JSON on stdout.
+# Record the prompt size to a sibling .log file for assertions.
+PROMPT=\$(cat)
+echo "\${#PROMPT}" >> "${out}.log"
+cat "$fixture"
+EOF
+  chmod +x "$out"
+}
+
+# Make a fixture JSON for cluster contradictions.
+make_fixture_json() {
+  local out="$1" slug_a="$2" slug_b="$3"
+  cat > "$out" <<EOF
+{"contradictions":[{"between":["${slug_a}","${slug_b}"],"claim_a":"A says X","claim_b":"B says not-X","explanation":"They disagree on X."}]}
+EOF
+}
+
+make_empty_fixture() {
+  echo '{"contradictions":[]}' > "$1"
+}
+
+make_garbage_fixture() {
+  echo 'not json at all' > "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: cluster.sh produces 2 clusters of 3 docs each (Jaccard ≥ 0.4)
+# ---------------------------------------------------------------------------
+FIX1="$SCRATCH/case1"
+seed_two_cluster_corpus "$FIX1"
+
+CLUSTERS1=$(bash "$INVENTORY" "$FIX1" 2>/dev/null | bash "$CLUSTER" 2>/dev/null)
+CCOUNT=$(printf '%s\n' "$CLUSTERS1" | grep -c '^{' || true)
+assert_eq "cluster.sh: two-cluster corpus → 2 clusters" "2" "$CCOUNT"
+
+# Each cluster has exactly 3 docs
+SIZES=$(printf '%s\n' "$CLUSTERS1" | jq -r '.docs | length' | sort | tr '\n' ',')
+assert_eq "cluster.sh: cluster sizes are 3,3" "3,3," "$SIZES"
+
+# Tag separation: orchestrator and broker should not be in same cluster
+SAME=$(printf '%s\n' "$CLUSTERS1" \
+  | jq -r 'select((.docs | map(.tags) | flatten | contains(["orchestrator"]))
+                  and (.docs | map(.tags) | flatten | contains(["broker"])))
+           | .cluster_id' \
+  | wc -l | tr -d ' ')
+assert_eq "cluster.sh: orchestrator and broker not in same cluster" "0" "$SAME"
+
+# ---------------------------------------------------------------------------
+# Test 2: cluster.sh drops clusters of size < 3
+# ---------------------------------------------------------------------------
+FIX2="$SCRATCH/case2"
+seed_too_small_corpus "$FIX2"
+
+CLUSTERS2=$(bash "$INVENTORY" "$FIX2" 2>/dev/null | bash "$CLUSTER" 2>/dev/null)
+CCOUNT2=$(printf '%s\n' "$CLUSTERS2" | grep -c '^{' || true)
+assert_eq "cluster.sh: 2-doc corpus → 0 clusters" "0" "$CCOUNT2"
+
+# ---------------------------------------------------------------------------
+# Test 3: cluster.sh caps cluster size at 10
+# ---------------------------------------------------------------------------
+FIX3="$SCRATCH/case3"
+seed_too_large_corpus "$FIX3"
+
+CLUSTERS3=$(bash "$INVENTORY" "$FIX3" 2>/dev/null | bash "$CLUSTER" 2>/dev/null)
+CCOUNT3=$(printf '%s\n' "$CLUSTERS3" | grep -c '^{' || true)
+assert_eq "cluster.sh: 12-doc mega corpus → 1 cluster" "1" "$CCOUNT3"
+
+SIZE3=$(printf '%s\n' "$CLUSTERS3" | jq -r '.docs | length')
+assert_eq "cluster.sh: mega cluster capped at 10 docs" "10" "$SIZE3"
+
+# ---------------------------------------------------------------------------
+# Test 4: contradict.sh invokes --llm-cmd once per cluster with bounded prompt
+# ---------------------------------------------------------------------------
+MOCK_LOG_DIR="$SCRATCH/case4"
+mkdir -p "$MOCK_LOG_DIR"
+FIXTURE4="$MOCK_LOG_DIR/response.json"
+make_fixture_json "$FIXTURE4" "2026-05-01-orch-1" "2026-05-02-orch-2"
+MOCK4="$MOCK_LOG_DIR/llm.sh"
+make_mock_llm "$MOCK4" "$FIXTURE4"
+
+CONTRA4=$(printf '%s\n' "$CLUSTERS1" \
+  | bash "$CONTRADICT" --llm-cmd "$MOCK4" --inventory-dir "$FIX1" 2>"$MOCK_LOG_DIR/stderr.log")
+CCOUNT4=$(printf '%s\n' "$CONTRA4" | grep -c '^{' || true)
+assert_eq "contradict.sh: emits one record per cluster with contradictions" "2" "$CCOUNT4"
+
+# Mock LLM was called twice (one prompt-size line per call)
+CALL_COUNT=$(wc -l < "${MOCK4}.log" 2>/dev/null | tr -d ' ')
+assert_eq "contradict.sh: mock LLM invoked twice" "2" "$CALL_COUNT"
+
+# Each prompt size ≤ token-budget cap. 10 docs × 1500 chars sample + overhead < 20000 bytes.
+MAX_PROMPT=$(sort -n "${MOCK4}.log" | tail -1)
+if [[ -n "$MAX_PROMPT" && "$MAX_PROMPT" -le 20000 ]]; then
+  ok "contradict.sh: prompt size bounded (max=$MAX_PROMPT bytes)"
+else
+  fail "contradict.sh: prompt size bounded" "max prompt size $MAX_PROMPT > 20000 bytes"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: contradict.sh handles empty contradictions
+# ---------------------------------------------------------------------------
+FIXTURE5="$MOCK_LOG_DIR/empty.json"
+make_empty_fixture "$FIXTURE5"
+MOCK5="$MOCK_LOG_DIR/llm-empty.sh"
+make_mock_llm "$MOCK5" "$FIXTURE5"
+
+CONTRA5=$(printf '%s\n' "$CLUSTERS1" \
+  | bash "$CONTRADICT" --llm-cmd "$MOCK5" --inventory-dir "$FIX1" 2>/dev/null)
+EMPTY_COUNT=$(printf '%s\n' "$CONTRA5" | grep -c '^{' || true)
+assert_eq "contradict.sh: empty contradictions → zero output records" "0" "$EMPTY_COUNT"
+
+# ---------------------------------------------------------------------------
+# Test 6: contradict.sh survives malformed JSON
+# ---------------------------------------------------------------------------
+FIXTURE6="$MOCK_LOG_DIR/garbage.json"
+make_garbage_fixture "$FIXTURE6"
+MOCK6="$MOCK_LOG_DIR/llm-garbage.sh"
+make_mock_llm "$MOCK6" "$FIXTURE6"
+
+set +e
+CONTRA6=$(printf '%s\n' "$CLUSTERS1" \
+  | bash "$CONTRADICT" --llm-cmd "$MOCK6" --inventory-dir "$FIX1" 2>"$MOCK_LOG_DIR/garbage-stderr.log")
+EC6=$?
+set -e
+GARBAGE_COUNT=$(printf '%s\n' "$CONTRA6" | grep -c '^{' || true)
+assert_eq "contradict.sh: malformed JSON → zero records emitted" "0" "$GARBAGE_COUNT"
+assert_eq "contradict.sh: malformed JSON → exit 0" "0" "$EC6"
+
+if grep -q 'warn\|non-JSON' "$MOCK_LOG_DIR/garbage-stderr.log" 2>/dev/null; then
+  ok "contradict.sh: warns on malformed JSON"
+else
+  fail "contradict.sh: warns on malformed JSON" "no warning in stderr"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: append-contradictions.sh preserves existing content
+# ---------------------------------------------------------------------------
+DEST7="$SCRATCH/case7-CONTRADICTIONS.md"
+cat > "$DEST7" <<'EOF'
+# Contradictions — research corpus
+
+Hand-curated note from 2026-04-01.
+
+## 2026-04-01 — manual
+
+- [[doc-x]] ↔ [[doc-y]]: existing entry kept intact.
+EOF
+ORIGINAL_HASH=$(shasum "$DEST7" | awk '{print $1}')
+
+# Pipe one contradiction record
+echo '{"cluster_id":"c1","topic":"alpha+beta","contradictions":[{"between":["A","B"],"claim_a":"X","claim_b":"not X","explanation":"They differ."}]}' \
+  | bash "$APPEND" --date 2026-05-17 "$DEST7" >/dev/null 2>&1
+
+# Original content still present byte-for-byte
+HEAD_BYTES=$(head -c "$(stat -f%z "$DEST7" 2>/dev/null || stat -c%s "$DEST7")" "$DEST7" | head -8)
+if grep -q "existing entry kept intact" "$DEST7"; then
+  ok "append-contradictions.sh: original entries preserved"
+else
+  fail "append-contradictions.sh: original entries preserved" "original line missing"
+fi
+
+# Pre-existing line numbers untouched — easier: diff a snapshot
+NEW_HASH=$(shasum "$DEST7" | awk '{print $1}')
+if [[ "$ORIGINAL_HASH" != "$NEW_HASH" ]]; then
+  ok "append-contradictions.sh: file grew (new entry appended)"
+else
+  fail "append-contradictions.sh: file grew (new entry appended)" "file unchanged"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: Format of appended entry
+# ---------------------------------------------------------------------------
+assert_contains "append: heading is '## YYYY-MM-DD — <topic>'" \
+  "$(cat "$DEST7")" "## 2026-05-17 — alpha+beta"
+assert_contains "append: body cites [[A]] ↔ [[B]] with explanation" \
+  "$(cat "$DEST7")" "[[A]] ↔ [[B]]: They differ."
+
+# ---------------------------------------------------------------------------
+# Test 9: append-contradictions.sh is no-op on zero input
+# ---------------------------------------------------------------------------
+DEST9="$SCRATCH/case9-CONTRADICTIONS.md"
+echo "preexisting" > "$DEST9"
+BEFORE9=$(shasum "$DEST9" | awk '{print $1}')
+printf '' | bash "$APPEND" --date 2026-05-17 "$DEST9" >/dev/null 2>&1
+AFTER9=$(shasum "$DEST9" | awk '{print $1}')
+assert_eq "append-contradictions.sh: empty stdin → file unchanged" "$BEFORE9" "$AFTER9"
+
+# ---------------------------------------------------------------------------
+# Test 10: run.sh --skip-contradictions does NOT invoke cluster/contradict
+# ---------------------------------------------------------------------------
+FIX10="$SCRATCH/case10"
+seed_two_cluster_corpus "$FIX10"
+
+# Initialize a git repo so score.sh ref-validation works
+cd "$SCRATCH"
+[ -d .git ] || git init -q -b main
+git config user.email "test@example.com" >/dev/null 2>&1
+git config user.name "test" >/dev/null 2>&1
+git add -A >/dev/null 2>&1
+git commit -q -m "fixture" --allow-empty >/dev/null 2>&1
+
+# Wrap cluster.sh with a sentinel script that touches a file when called
+SENTINEL10="$SCRATCH/case10-cluster-called"
+WRAP10="$SCRATCH/case10-cluster-wrap.sh"
+cat > "$WRAP10" <<EOF
+#!/usr/bin/env bash
+touch "$SENTINEL10"
+exec bash "$CLUSTER" "\$@"
+EOF
+chmod +x "$WRAP10"
+
+# Run with --skip-contradictions
+bash "$RUN" --skip-contradictions --reference-date 2026-05-17 \
+  --git-dir "$SCRATCH" "$FIX10" >/dev/null 2>&1 || true
+
+if [[ -f "$SENTINEL10" ]]; then
+  fail "run.sh: --skip-contradictions blocks clustering" "sentinel exists"
+else
+  ok "run.sh: --skip-contradictions blocks clustering"
+fi
+if [[ -f "$FIX10/INDEX.md" ]]; then
+  ok "run.sh: --skip-contradictions still writes INDEX.md"
+else
+  fail "run.sh: --skip-contradictions still writes INDEX.md" "INDEX.md missing"
+fi
+if [[ ! -f "$FIX10/CONTRADICTIONS.md" ]]; then
+  ok "run.sh: --skip-contradictions does not create CONTRADICTIONS.md"
+else
+  fail "run.sh: --skip-contradictions does not create CONTRADICTIONS.md" "file present"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: run.sh end-to-end writes INDEX.md AND appends to CONTRADICTIONS.md
+# ---------------------------------------------------------------------------
+FIX11="$SCRATCH/case11"
+seed_two_cluster_corpus "$FIX11"
+
+FIXTURE11="$SCRATCH/case11-llm-response.json"
+make_fixture_json "$FIXTURE11" "2026-05-01-orch-1" "2026-05-02-orch-2"
+MOCK11="$SCRATCH/case11-llm.sh"
+make_mock_llm "$MOCK11" "$FIXTURE11"
+
+git add -A >/dev/null 2>&1
+git commit -q -m "case11 fixture" --allow-empty >/dev/null 2>&1
+
+bash "$RUN" --reference-date 2026-05-17 --git-dir "$SCRATCH" \
+  --llm-cmd "$MOCK11" "$FIX11" >/dev/null 2>&1 || true
+
+if [[ -f "$FIX11/INDEX.md" ]] && grep -q "## Current" "$FIX11/INDEX.md"; then
+  ok "run.sh: end-to-end writes INDEX.md with sections"
+else
+  fail "run.sh: end-to-end writes INDEX.md with sections" "INDEX.md missing or malformed"
+fi
+
+if [[ -f "$FIX11/CONTRADICTIONS.md" ]] && grep -q "^## 2026-05-17" "$FIX11/CONTRADICTIONS.md"; then
+  ok "run.sh: end-to-end appends to CONTRADICTIONS.md"
+else
+  fail "run.sh: end-to-end appends to CONTRADICTIONS.md" "CONTRADICTIONS.md missing or no entry"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 12: CONTRADICTIONS.md diff-only-additions invariant (acceptance)
+# ---------------------------------------------------------------------------
+FIX12="$SCRATCH/case12"
+seed_two_cluster_corpus "$FIX12"
+
+# Pre-seed CONTRADICTIONS.md with hand-curated content + commit it
+cat > "$FIX12/CONTRADICTIONS.md" <<'EOF'
+# Contradictions — research corpus
+
+## 2026-04-01 — hand-written
+
+- [[old-doc-a]] ↔ [[old-doc-b]]: pre-existing entry.
+EOF
+
+git add -A >/dev/null 2>&1
+git commit -q -m "case12 fixture + seed CONTRADICTIONS" --allow-empty >/dev/null 2>&1
+
+FIXTURE12="$SCRATCH/case12-llm-response.json"
+make_fixture_json "$FIXTURE12" "2026-05-01-orch-1" "2026-05-02-orch-2"
+MOCK12="$SCRATCH/case12-llm.sh"
+make_mock_llm "$MOCK12" "$FIXTURE12"
+
+bash "$RUN" --reference-date 2026-05-17 --git-dir "$SCRATCH" \
+  --llm-cmd "$MOCK12" "$FIX12" >/dev/null 2>&1 || true
+
+# Diff CONTRADICTIONS.md against the committed version; expect only additions.
+DIFF=$(cd "$SCRATCH" && git diff -- "$FIX12/CONTRADICTIONS.md" 2>/dev/null || true)
+# Count actual removal lines (start with `-` but not `---` header).
+# Wrap pipelines with `|| true` so that grep finding zero matches (exit 1)
+# combined with `pipefail` doesn't kill the test script.
+REMOVALS=$( { printf '%s\n' "$DIFF" | grep -cE '^-[^-]' || true; } | tr -d ' ')
+ADDITIONS=$( { printf '%s\n' "$DIFF" | grep -cE '^\+[^+]' || true; } | tr -d ' ')
+assert_eq "run.sh: CONTRADICTIONS.md diff has zero removals" "0" "$REMOVALS"
+
+if [[ "$ADDITIONS" -gt 0 ]]; then
+  ok "run.sh: CONTRADICTIONS.md diff has additions (${ADDITIONS} lines)"
+else
+  fail "run.sh: CONTRADICTIONS.md diff has additions" "no + lines"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "  Passed: $PASSES"
+echo "  Failed: $FAILURES"
+
+if [[ $FAILURES -eq 0 && $PASSES -gt 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/plugins/dev/scripts/research-curate/append-contradictions.sh
+++ b/plugins/dev/scripts/research-curate/append-contradictions.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Usage: append-contradictions.sh [--date YYYY-MM-DD] <output-file>
+#
+# Reads contradiction JSONL on stdin (from contradict.sh). Appends one
+# markdown block per record to <output-file>. If <output-file> doesn't
+# exist, prepends a one-time header on the first write.
+#
+# Format per block:
+#   ## YYYY-MM-DD — <cluster.topic>
+#
+#   - [[slug-A]] ↔ [[slug-B]]: <explanation>
+#   - [[slug-C]] ↔ [[slug-D]]: <explanation>
+#
+# Append-only contract: opens <output-file> in `>>` mode; never overwrites.
+# Empty stdin is a no-op (file unchanged byte-for-byte).
+#
+# --date defaults to today (UTC); tests pin it for determinism.
+
+set -uo pipefail
+
+DATE="$(date -u +%Y-%m-%d)"
+DEST=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) DATE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+    --) shift; DEST="${1:-}"; shift ;;
+    -*) echo "append-contradictions.sh: unknown flag: $1" >&2; exit 2 ;;
+    *) DEST="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$DEST" ]]; then
+  echo "append-contradictions.sh: missing <output-file>" >&2
+  exit 2
+fi
+
+# Buffer stdin so we can detect the empty-input case before touching the file.
+INPUT="$(cat)"
+if [[ -z "${INPUT//[[:space:]]/}" ]]; then
+  # No contradictions → no-op
+  exit 0
+fi
+
+# Count actual JSON records
+RECORDS=$(printf '%s\n' "$INPUT" | grep -c '^{' || true)
+if [[ "$RECORDS" -eq 0 ]]; then
+  exit 0
+fi
+
+# Render one block per record
+render_block() {
+  local rec="$1"
+  local topic
+  topic=$(jq -r '.topic // .cluster_id' <<<"$rec")
+  printf '## %s — %s\n\n' "$DATE" "$topic"
+  jq -r '.contradictions[] | "- [[\(.between[0])]] ↔ [[\(.between[1])]]: \(.explanation)"' <<<"$rec"
+  printf '\n'
+}
+
+# If file doesn't exist, write a one-time header before any blocks.
+{
+  if [[ ! -f "$DEST" ]]; then
+    printf '# Contradictions — research corpus\n\n'
+    printf 'Append-only. Each `##` block is one weekly curation run.\n\n'
+  fi
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    [[ "${line:0:1}" != "{" ]] && continue
+    render_block "$line"
+  done <<<"$INPUT"
+} >> "$DEST"

--- a/plugins/dev/scripts/research-curate/cluster.sh
+++ b/plugins/dev/scripts/research-curate/cluster.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Usage: cluster.sh [--threshold FLOAT] [--max-cluster-size N]
+#
+# Reads inventory JSONL on stdin (one doc per line from inventory.sh) and
+# emits cluster JSONL on stdout:
+#   {"cluster_id":"c1","topic":"orchestrator+state+workers",
+#    "docs":[{"filename":...,"topic":...,"tags":[...]}, ...]}
+#
+# Algorithm (v1):
+#   1. Build a token set per doc = lowercase(tags) ∪ tokenize(topic).
+#   2. For every pair (i,j), compute Jaccard. If ≥ threshold, union(i,j).
+#   3. Group by union-find root. Drop clusters of size < 3. Cap at
+#      --max-cluster-size (default 10) by keeping the first N members
+#      in the deterministic input order; the rest are dropped from this run.
+#
+# Defaults: --threshold 0.4, --max-cluster-size 10.
+
+set -uo pipefail
+
+THRESHOLD=0.4
+MAX_SIZE=10
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threshold) THRESHOLD="$2"; shift 2 ;;
+    --max-cluster-size) MAX_SIZE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "cluster.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Slurp JSONL into a JSON array
+ENTRIES=$(jq -s '.' </dev/stdin)
+N=$(jq 'length' <<<"$ENTRIES")
+
+if [[ "$N" -lt 3 ]]; then
+  # Nothing can cluster — emit nothing.
+  exit 0
+fi
+
+# Decorate each entry with `tokens` (tags ∪ tokenized topic, stopword-filtered).
+DECORATED=$(jq -c '
+  def stopwords: ["the","and","for","with","from","that","this","not","but","you","are","its","has","was","were","into","over","under","than","then","they","them","their","there","here","when","what","where","which","while","also","more","most","some","such","only","just","very","one","two","three","four","about","upon","onto","without","within","via","per","each","both","other"];
+  def tokenize(s):
+    (s // "")
+    | ascii_downcase
+    | gsub("[^a-z0-9]+"; " ")
+    | split(" ")
+    | map(select(length >= 3))
+    | map(select(. as $t | stopwords | index($t) | not));
+  map(
+    . as $e |
+    ((($e.tags // []) | map(ascii_downcase))
+      + tokenize($e.topic // "")
+      + tokenize(($e.filename // "") | gsub("\\.md$"; ""))) as $raw |
+    $e + {tokens: ($raw | unique)}
+  )
+' <<<"$ENTRIES")
+
+# Initialize union-find parent array
+declare -a parent
+for ((i=0; i<N; i++)); do parent[$i]=$i; done
+
+uf_find() {
+  local x=$1
+  while [[ "${parent[$x]}" != "$x" ]]; do
+    parent[$x]=${parent[${parent[$x]}]}
+    x=${parent[$x]}
+  done
+  printf '%s' "$x"
+}
+
+uf_union() {
+  local rx ry
+  rx=$(uf_find "$1")
+  ry=$(uf_find "$2")
+  if [[ "$rx" != "$ry" ]]; then
+    parent[$rx]=$ry
+  fi
+}
+
+# Compute pairwise Jaccard and union when ≥ threshold.
+# Streamed in one jq pass: emit "<i> <j> <jaccard>" lines for all i<j.
+PAIRS=$(jq -r --argjson n "$N" '
+  . as $d |
+  [range(0; $n)] as $idx |
+  [
+    $idx[] as $i | $idx[] as $j | select($j > $i) |
+    ($d[$i].tokens) as $a | ($d[$j].tokens) as $b |
+    ($a | length) as $la | ($b | length) as $lb |
+    (if ($la == 0 or $lb == 0) then 0
+     else
+       ([$a[], $b[]] | group_by(.) | map(select(length > 1)) | length) as $inter |
+       (($a + $b) | unique | length) as $union |
+       (if $union == 0 then 0 else ($inter / $union) end)
+     end) as $jac |
+     "\($i) \($j) \($jac)"
+  ] | .[]
+' <<<"$DECORATED")
+
+while IFS=' ' read -r i j jac; do
+  [[ -z "$i" ]] && continue
+  # Floating point comparison via awk
+  if awk "BEGIN {exit !($jac >= $THRESHOLD)}"; then
+    uf_union "$i" "$j"
+  fi
+done <<<"$PAIRS"
+
+# Group docs by root
+declare -A groups
+for ((i=0; i<N; i++)); do
+  r=$(uf_find "$i")
+  if [[ -z "${groups[$r]+x}" ]]; then
+    groups[$r]="$i"
+  else
+    groups[$r]="${groups[$r]} $i"
+  fi
+done
+
+# Sort roots numerically so cluster_ids are stable across runs on the same input
+ROOTS=$(for k in "${!groups[@]}"; do echo "$k"; done | sort -n)
+
+CID=0
+while IFS= read -r root; do
+  [[ -z "$root" ]] && continue
+  read -ra MEMBERS <<<"${groups[$root]}"
+  COUNT=${#MEMBERS[@]}
+
+  # Drop clusters smaller than 3
+  if [[ "$COUNT" -lt 3 ]]; then
+    continue
+  fi
+
+  # Cap at MAX_SIZE — keep first N by input order (deterministic).
+  if [[ "$COUNT" -gt "$MAX_SIZE" ]]; then
+    MEMBERS=("${MEMBERS[@]:0:$MAX_SIZE}")
+  fi
+
+  CID=$((CID + 1))
+
+  # Build a JSON array of the member indices
+  IDX_JSON=$(printf '%s\n' "${MEMBERS[@]}" \
+    | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)')
+
+  # Cluster topic = top-3 most common tags joined with "+"; fallback "cluster-c<N>"
+  TOPIC=$(jq -r --argjson idx "$IDX_JSON" '
+    [.[$idx[]].tags // [] | .[]]
+    | map(ascii_downcase)
+    | group_by(.)
+    | map({tag: .[0], n: length})
+    | sort_by(-.n, .tag)
+    | .[0:3] | map(.tag) | join("+")
+  ' <<<"$DECORATED")
+
+  if [[ -z "$TOPIC" ]]; then
+    TOPIC="cluster-c${CID}"
+  fi
+
+  # Emit one cluster JSON per line — strip `tokens` (internal-only).
+  jq -nc --arg cid "c${CID}" --arg topic "$TOPIC" --argjson idx "$IDX_JSON" --argjson all "$DECORATED" '
+    {cluster_id: $cid, topic: $topic,
+     docs: [$all[$idx[]] | {filename, topic, tags, path}]}
+  '
+done <<<"$ROOTS"

--- a/plugins/dev/scripts/research-curate/contradict.sh
+++ b/plugins/dev/scripts/research-curate/contradict.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Usage: contradict.sh [--llm-cmd CMD] [--sample-chars N] [--inventory-dir DIR]
+#
+# Reads cluster JSONL on stdin (from cluster.sh) and invokes --llm-cmd once
+# per cluster with a bounded prompt. Emits one record per line on stdout for
+# clusters where the LLM returned at least one contradiction:
+#   {"cluster_id":"c1","topic":"<cluster topic>",
+#    "contradictions":[{"between":["slug-A","slug-B"],
+#                       "claim_a":"...","claim_b":"...","explanation":"..."}, ...]}
+#
+# Per-cluster steps:
+#   1. Re-read each doc's body from --inventory-dir (or cluster doc.path if present).
+#   2. Strip frontmatter; take first --sample-chars bytes.
+#   3. Build a prompt asking for contradictions; pipe to $LLM_CMD on stdin.
+#   4. Parse the response as strict JSON. On parse failure, warn + skip.
+#   5. Drop clusters with zero contradictions.
+#
+# Defaults: --llm-cmd "claude -p", --sample-chars 1500.
+
+set -uo pipefail
+
+LLM_CMD="claude -p"
+SAMPLE_CHARS=1500
+INVENTORY_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --llm-cmd) LLM_CMD="$2"; shift 2 ;;
+    --sample-chars) SAMPLE_CHARS="$2"; shift 2 ;;
+    --inventory-dir) INVENTORY_DIR="$2"; shift 2 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "contradict.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Strip YAML frontmatter (lines from the first --- to the next ---) and emit
+# the first $SAMPLE_CHARS bytes of the remainder.
+extract_excerpt() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    printf '(file not found: %s)' "$file"
+    return
+  fi
+  awk 'BEGIN {in_fm=0; first=1}
+       first==1 && /^---$/ {in_fm=1; first=0; next}
+       first==1 {first=0; print; next}
+       in_fm==1 && /^---$/ {in_fm=0; next}
+       in_fm==1 {next}
+       {print}' "$file" \
+    | head -c "$SAMPLE_CHARS"
+}
+
+# Resolve a doc's filesystem path. Prefer the embedded `path` field; fall back
+# to `<inventory-dir>/<filename>`.
+resolve_doc_path() {
+  local cluster_json="$1" idx="$2"
+  local p
+  p=$(jq -r --argjson i "$idx" '.docs[$i].path // ""' <<<"$cluster_json")
+  if [[ -z "$p" || ! -f "$p" ]]; then
+    local fname
+    fname=$(jq -r --argjson i "$idx" '.docs[$i].filename' <<<"$cluster_json")
+    if [[ -n "$INVENTORY_DIR" ]]; then
+      p="${INVENTORY_DIR}/${fname}"
+    fi
+  fi
+  printf '%s' "$p"
+}
+
+# Strip .md extension from a filename to produce a wiki slug.
+slug() {
+  local s="$1"
+  s="${s%.md}"
+  printf '%s' "$s"
+}
+
+build_prompt() {
+  local cluster_json="$1"
+  local ndocs
+  ndocs=$(jq '.docs | length' <<<"$cluster_json")
+
+  printf 'You are auditing a research corpus for contradictory claims.\n\n'
+  printf 'Below are %d research notes that share related topics. Identify any places\n' "$ndocs"
+  printf 'where two notes make contradicting claims about the same subject.\n\n'
+  printf 'Respond with strict JSON only (no prose, no code fences):\n'
+  printf '{"contradictions":[{"between":["<slug-A>","<slug-B>"],"claim_a":"<text>","claim_b":"<text>","explanation":"<one sentence>"}]}\n\n'
+  printf 'If no contradictions exist, respond with {"contradictions":[]}.\n\n'
+
+  local i fname topic doc_path
+  for ((i=0; i<ndocs; i++)); do
+    fname=$(jq -r --argjson i "$i" '.docs[$i].filename' <<<"$cluster_json")
+    topic=$(jq -r --argjson i "$i" '.docs[$i].topic // ""' <<<"$cluster_json")
+    doc_path=$(resolve_doc_path "$cluster_json" "$i")
+
+    printf '### [[%s]]\n' "$(slug "$fname")"
+    if [[ -n "$topic" ]]; then
+      printf 'Topic: %s\n' "$topic"
+    fi
+    printf 'Excerpt:\n'
+    extract_excerpt "$doc_path"
+    printf '\n\n'
+  done
+}
+
+# Stream clusters from stdin; one per line.
+while IFS= read -r cluster_json; do
+  [[ -z "$cluster_json" ]] && continue
+
+  CID=$(jq -r '.cluster_id' <<<"$cluster_json")
+  TOPIC=$(jq -r '.topic' <<<"$cluster_json")
+
+  PROMPT=$(build_prompt "$cluster_json")
+
+  # Pipe prompt to LLM_CMD. Capture stdout; ignore stderr from the LLM.
+  set +e
+  RESPONSE=$(printf '%s' "$PROMPT" | eval "$LLM_CMD" 2>/dev/null)
+  LLM_EXIT=$?
+  set -e
+
+  if [[ "$LLM_EXIT" -ne 0 ]]; then
+    echo "warn: cluster ${CID} LLM exited non-zero (${LLM_EXIT}) — skipping" >&2
+    continue
+  fi
+
+  # Parse JSON defensively
+  if ! CONTRADICTIONS=$(jq -c '.contradictions // []' <<<"$RESPONSE" 2>/dev/null); then
+    echo "warn: cluster ${CID} LLM returned non-JSON — skipping" >&2
+    continue
+  fi
+
+  COUNT=$(jq 'length' <<<"$CONTRADICTIONS")
+  if [[ "$COUNT" -eq 0 ]]; then
+    continue
+  fi
+
+  jq -nc --arg cid "$CID" --arg topic "$TOPIC" --argjson c "$CONTRADICTIONS" \
+    '{cluster_id: $cid, topic: $topic, contradictions: $c}'
+done

--- a/plugins/dev/scripts/research-curate/run.sh
+++ b/plugins/dev/scripts/research-curate/run.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
-# Usage: run.sh [--dry-run] [--reference-date YYYY-MM-DD] [--git-dir DIR] <target-dir>
+# Usage: run.sh [--dry-run] [--reference-date YYYY-MM-DD] [--git-dir DIR]
+#               [--skip-contradictions] [--llm-cmd CMD] [--contradictions-dest PATH]
+#               <target-dir>
 #
-# Driver: walks <target-dir>, scores docs, writes INDEX.md.
-#   Default:   <target-dir>/INDEX.md is overwritten.
-#   --dry-run: writes to /tmp/research-curate-INDEX-<basename>.md instead.
+# Driver: walks <target-dir>, scores docs, writes INDEX.md, then (unless
+# --skip-contradictions) clusters docs and appends LLM-surfaced contradictions
+# to <target-dir>/CONTRADICTIONS.md.
+#   Default:   <target-dir>/INDEX.md is overwritten; CONTRADICTIONS.md appended.
+#   --dry-run: writes INDEX to /tmp/research-curate-INDEX-<basename>.md instead.
+#              (CONTRADICTIONS.md is NOT touched during dry runs.)
 #
-# Also emits one summary line to stdout per invocation:
-#   <target-dir>: current=N needs-review=M likely-stale=K
+# Summary lines on stdout:
+#   <target-dir>: current=N needs-review=M likely-stale=K → <index-path>
+#   <target-dir>: contradictions clusters=K appended=M → <contradictions-path>
 #
-# --reference-date and --git-dir are passed through to score.sh (useful for tests).
+# --reference-date and --git-dir are passed through to score.sh.
+# --llm-cmd CMD overrides the default LLM invocation for contradict.sh
+# (default: "claude -p"). Tests substitute a deterministic mock.
 
 set -uo pipefail
 
@@ -16,19 +24,28 @@ DRY_RUN=0
 REFERENCE_DATE=""
 GIT_DIR=""
 TARGET_DIR=""
+SKIP_CONTRADICTIONS=0
+LLM_CMD=""
+CONTRA_DEST=""
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INVENTORY="${SCRIPT_DIR}/inventory.sh"
 SCORE="${SCRIPT_DIR}/score.sh"
 GENERATE="${SCRIPT_DIR}/generate-index.sh"
+CLUSTER="${SCRIPT_DIR}/cluster.sh"
+CONTRADICT="${SCRIPT_DIR}/contradict.sh"
+APPEND="${SCRIPT_DIR}/append-contradictions.sh"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=1; shift ;;
     --reference-date) REFERENCE_DATE="$2"; shift 2 ;;
     --git-dir) GIT_DIR="$2"; shift 2 ;;
+    --skip-contradictions) SKIP_CONTRADICTIONS=1; shift ;;
+    --llm-cmd) LLM_CMD="$2"; shift 2 ;;
+    --contradictions-dest) CONTRA_DEST="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,12p' "$0"
+      sed -n '2,18p' "$0"
       exit 0
       ;;
     --)
@@ -77,3 +94,32 @@ CUR=$(echo "$SCORED" | grep -c '"status":"current"' || true)
 NR=$(echo "$SCORED" | grep -c '"status":"needs-review"' || true)
 LS=$(echo "$SCORED" | grep -c '"status":"likely-stale"' || true)
 echo "${TARGET_DIR}: current=${CUR} needs-review=${NR} likely-stale=${LS} → ${DEST}"
+
+# ---------------------------------------------------------------------------
+# Contradiction detection (CTL-468). Skipped during --dry-run or when
+# --skip-contradictions is set. Pipes inventory → cluster → contradict → append.
+# ---------------------------------------------------------------------------
+if (( ! SKIP_CONTRADICTIONS )) && (( ! DRY_RUN )); then
+  CLUSTERS=$(bash "$INVENTORY" "$TARGET_DIR" | bash "$CLUSTER")
+  CLUSTER_COUNT=$(printf '%s\n' "$CLUSTERS" | grep -c '^{' || true)
+
+  if (( CLUSTER_COUNT > 0 )); then
+    CONTRA_ARGS=(--inventory-dir "$TARGET_DIR")
+    [[ -n "$LLM_CMD" ]] && CONTRA_ARGS+=(--llm-cmd "$LLM_CMD")
+
+    CONTRA=$(printf '%s\n' "$CLUSTERS" | bash "$CONTRADICT" "${CONTRA_ARGS[@]}")
+    APPEND_COUNT=$(printf '%s\n' "$CONTRA" | grep -c '^{' || true)
+
+    CONTRA_DEST="${CONTRA_DEST:-${TARGET_DIR}/CONTRADICTIONS.md}"
+    APPEND_ARGS=()
+    [[ -n "$REFERENCE_DATE" ]] && APPEND_ARGS+=(--date "$REFERENCE_DATE")
+
+    if (( APPEND_COUNT > 0 )); then
+      printf '%s\n' "$CONTRA" | bash "$APPEND" "${APPEND_ARGS[@]}" "$CONTRA_DEST"
+    fi
+
+    echo "${TARGET_DIR}: contradictions clusters=${CLUSTER_COUNT} appended=${APPEND_COUNT} → ${CONTRA_DEST}"
+  else
+    echo "${TARGET_DIR}: contradictions clusters=0 (no eligible clusters)"
+  fi
+fi

--- a/plugins/dev/skills/research-curate/SKILL.md
+++ b/plugins/dev/skills/research-curate/SKILL.md
@@ -2,10 +2,12 @@
 name: research-curate
 description: |
   Walk thoughts/shared/research/ and thoughts/shared/plans/, score each doc's
-  staleness, and regenerate INDEX.md in each directory. Source docs are never
-  modified. Classification: current (age<90d AND refs valid), needs-review
-  (age>=90d OR broken refs), likely-stale (age>=180d AND no recent activity).
-  Deterministic — no LLM calls in v1. CTL-467 (Initiative 4 Phase 1).
+  staleness, regenerate INDEX.md, and append LLM-surfaced contradictions to
+  CONTRADICTIONS.md (append-only). Source docs are never modified.
+  Classification: current (age<90d AND refs valid), needs-review (age>=90d OR
+  broken refs), likely-stale (age>=180d AND no recent activity). Inventory is
+  deterministic; contradiction detection runs one LLM call per cluster
+  (CTL-467 + CTL-468 / Initiative 4 Phase 1+2).
 disable-model-invocation: true
 user-invocable: true
 allowed-tools:
@@ -20,9 +22,10 @@ allowed-tools:
 # research-curate
 
 Regenerates `INDEX.md` inventories for `thoughts/shared/research/` and
-`thoughts/shared/plans/`. Each doc is classified by age, file:line ref validity,
-and recent git topic activity. Source markdown is never modified — only the two
-`INDEX.md` files are written.
+`thoughts/shared/plans/`, then clusters docs by topic and asks an LLM to
+identify contradicting claims, appending findings to `CONTRADICTIONS.md`.
+Source markdown is never modified — only `INDEX.md` (overwritten) and
+`CONTRADICTIONS.md` (appended) are written.
 
 ## What it does
 
@@ -36,28 +39,43 @@ and recent git topic activity. Source markdown is never modified — only the tw
    - `likely-stale` — age >= 180d AND zero recent topic activity
 4. **Generate** — overwrites `<dir>/INDEX.md` with three sections sorted by
    date descending. Output is fully deterministic.
+5. **Cluster + contradict** (CTL-468) — tokenizes `tags` ∪ `topic`, computes
+   pairwise Jaccard similarity, unions docs with score ≥ 0.4 via union-find.
+   Clusters of size 3–10 are kept (smaller dropped, larger capped at 10).
+   For each cluster, one LLM call (default `claude -p`) receives a
+   token-bounded prompt (1500 chars/doc) asking for contradictions. New
+   findings are appended to `<dir>/CONTRADICTIONS.md` under a
+   `## YYYY-MM-DD — <topic>` heading. Existing entries are never modified.
 
 ## Invocation
 
 ```bash
-# Curate both directories in-place
+# Curate both directories in-place (inventory + contradictions)
 bash plugins/dev/scripts/research-curate/run.sh thoughts/shared/research
 bash plugins/dev/scripts/research-curate/run.sh thoughts/shared/plans
 
-# Dry run — writes to /tmp/research-curate-INDEX-<basename>.md
+# Inventory only — skip the LLM-driven contradiction pass
+bash plugins/dev/scripts/research-curate/run.sh --skip-contradictions \
+  thoughts/shared/research
+
+# Dry run — INDEX written to /tmp; contradictions never touched
 bash plugins/dev/scripts/research-curate/run.sh --dry-run thoughts/shared/research
 ```
 
-Each invocation prints a one-line summary:
+Each invocation prints summary lines:
 
 ```
 thoughts/shared/research: current=42 needs-review=83 likely-stale=80 → thoughts/shared/research/INDEX.md
+thoughts/shared/research: contradictions clusters=5 appended=3 → thoughts/shared/research/CONTRADICTIONS.md
 ```
+
+Projected cost for the weekly Routine: ~$0.38/run (75K input tokens × $5/M),
+~$1.50/month.
 
 ## Skill body
 
 When invoked as `/catalyst-dev:research-curate`, run both directories
-sequentially and report the two summary lines back to the user.
+sequentially and report the summary lines back to the user.
 
 ```bash
 set -euo pipefail
@@ -69,16 +87,21 @@ bash "$SCRIPT" thoughts/shared/plans
 ```
 
 Source-doc immutability is enforced by `inventory.sh` (which only ever reads
-source markdown) and `run.sh` (which writes exclusively to `INDEX.md` or a
-`/tmp/` dry-run path). The test suite asserts this property against a fixture
-repo via a before/after hash comparison.
+source markdown), `run.sh` (which writes exclusively to `INDEX.md` or a
+`/tmp/` dry-run path), and `append-contradictions.sh` (which opens
+`CONTRADICTIONS.md` in append-mode only). The test suite asserts this
+property against fixture repos via before/after hash comparisons.
 
 ## Out of scope (deferred)
 
-- `CONTRADICTIONS.md` clustering — Phase 2 of Initiative 4 (separate ticket).
-- CMA Routine wiring (weekly cadence) — Phase 3 of Initiative 4.
+- CMA Routine wiring (weekly cadence) — Phase 3 of Initiative 4 (CTL-469).
 - LLM-generated one-line summaries — plan permits but defers for testability.
+- LLM-driven clustering — fallback to deterministic Jaccard is preserved for
+  cost predictability (Phase 3 refactor option in the plan).
 
 ## Tests
 
-`bash plugins/dev/scripts/__tests__/research-curate-inventory.test.sh`
+```
+bash plugins/dev/scripts/__tests__/research-curate-inventory.test.sh
+bash plugins/dev/scripts/__tests__/research-curate-contradictions.test.sh
+```


### PR DESCRIPTION
## Summary

Adds Phase 2 of Initiative 4 (Weekly Thoughts Curation Routine) — extends the `research-curate` skill (CTL-467 / #805) with the deferred contradiction-detection pass.

- Clusters docs by topic via Jaccard similarity on `tags` ∪ tokenized `topic` (threshold 0.4, union-find). Drops clusters <3, caps at 10 docs.
- For each cluster, prompts an LLM (default `claude -p`, swappable via `--llm-cmd`) with a token-bounded sample (1500 chars/doc) asking for contradicting claims.
- Appends findings to `<dir>/CONTRADICTIONS.md` as `## YYYY-MM-DD — <topic>` blocks with `[[doc-a]] ↔ [[doc-b]]` cross-refs. File opened in append-mode only — existing entries never modified.
- Projected cost: ~$0.38/run (75K input × \$5/M) — ~\$1.50/month at weekly cadence, well under the \$0.50/run acceptance cap.

## What's new

| File | Purpose |
|---|---|
| `plugins/dev/scripts/research-curate/cluster.sh` | Jaccard 0.4 union-find on inventory JSONL |
| `plugins/dev/scripts/research-curate/contradict.sh` | Per-cluster LLM call (`--llm-cmd` configurable); survives malformed JSON |
| `plugins/dev/scripts/research-curate/append-contradictions.sh` | Append-only writer; no-op on empty input |
| `plugins/dev/scripts/__tests__/research-curate-contradictions.test.sh` | 25 assertions (clustering bounds, prompt size, JSON resilience, append-only invariant, end-to-end) |

## What's changed

- `plugins/dev/scripts/research-curate/run.sh` — adds `--skip-contradictions`, `--llm-cmd`, `--contradictions-dest` flags. The new step is skipped during `--dry-run`.
- `plugins/dev/skills/research-curate/SKILL.md` — documents the contradiction pass, projected cost, and drops the "deferred" line for clustering.

## Acceptance criteria

- [x] `bash plugins/dev/scripts/__tests__/research-curate-contradictions.test.sh` passes (25/25)
- [x] `bash plugins/dev/scripts/__tests__/research-curate-inventory.test.sh` still passes (29/29 — no regressions in CTL-467 behavior)
- [x] CONTRADICTIONS.md diff shows only `+` lines (test 12 asserts via `git diff`)
- [x] Token cost per run bounded by per-doc sample × cluster-size cap (well under projected \$0.50)

Manual acceptance items (≥1 real contradiction surfaced, real-corpus cost recorded) are deferred to Phase 3/4 of the Initiative (CTL-469).

## Test plan

- [x] New test file passes (25/25)
- [x] Existing inventory test still passes (29/29)
- [x] `audit-references.sh --ci` — 0 errors (55 pre-existing warnings unchanged)
- [x] `scripts/check-plugin-version.sh` — exit 0
- [x] Smoke run on real corpus with `--skip-contradictions --dry-run` — both research/ and plans/ inventory paths still work

Ticket: CTL-468
Plan: thoughts/shared/plans/2026-05-17-CTL-468-contradiction-detection.md
Builds on: #805 (CTL-467)