### PR TITLE
docs(dev): document phase-agent orchestrator pipeline (CTL-453)

### DIFF
--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -14,10 +14,19 @@ version: 3.0.0
 
 # Oneshot
 
-End-to-end autonomous workflow that chains research → plan → implement → validate → ship → merge
-in a single session. All phases run sequentially in the current Claude Code session, invoking
-skills directly. Context is managed naturally via Claude's automatic compaction, and the
-thoughts/ system provides persistent handoff documents between phases.
+End-to-end autonomous workflow that chains research → plan → implement → validate → ship → merge in
+a single session. All phases run sequentially in the current Claude Code session, invoking skills
+directly. Context is managed naturally via Claude's automatic compaction, and the thoughts/ system
+provides persistent handoff documents between phases.
+
+> **Legacy mode for the orchestrator (post-2026-06-15).** `oneshot` remains the canonical
+> single-shot lifecycle for direct user invocation. The orchestrator's default worker dispatch is
+> also still `oneshot-legacy` — opt in to the per-phase pipeline by setting
+> `catalyst.orchestration.dispatchMode` to `"phase-agents"` in `.catalyst/config.json`, which runs
+> nine short-lived `claude --bg` skills (`phase-triage` … `phase-monitor-deploy`) instead of one
+> long `claude -p` `oneshot` worker. See
+> [Phase agents](https://catalyst.coalesce-labs.com/reference/orchestration/phase-agents/) for the
+> pipeline, model assignment, and cost economics.
 
 ## Prerequisites
 
@@ -57,44 +66,44 @@ Uses the provided text as the research query directly.
 
 ## Flags
 
-| Flag                   | Description                                            |
-| ---------------------- | ------------------------------------------------------ |
-| `--team`               | Use agent teams for parallel implementation in Phase 3 |
+| Flag                   | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `--team`               | Use agent teams for parallel implementation in Phase 3        |
 | `--label <text>`       | Custom display label for the session (overrides auto-derived) |
-| `--no-merge`           | Stop after PR creation — do NOT enter listen loop or merge |
-| `--no-ticket`          | Skip Linear ticket creation in freeform mode           |
-| `--skip-validation`    | Skip Phase 4 entirely                                  |
-| `--skip-quality-gates` | Run `/validate-plan` but skip quality gate loop        |
+| `--no-merge`           | Stop after PR creation — do NOT enter listen loop or merge    |
+| `--no-ticket`          | Skip Linear ticket creation in freeform mode                  |
+| `--skip-validation`    | Skip Phase 4 entirely                                         |
+| `--skip-quality-gates` | Run `/validate-plan` but skip quality gate loop               |
 
 ## Orchestrator Mode
 
-When running under an `/orchestrate` coordinator, oneshot writes status updates to a **worker
-signal file** so the orchestrator can track progress and run adversarial verification.
+When running under an `/orchestrate` coordinator, oneshot writes status updates to a **worker signal
+file** so the orchestrator can track progress and run adversarial verification.
 
-**Single-ticket scope contract (READ FIRST — CTL-208).** Your assigned scope is exactly the
-ticket ID passed as the first positional argument (`$1`). This is the SOLE source of truth
-for what work to do. The orchestrator state directory (`$ORCH_DIR`), wave briefings, sibling
-worker signal files, and comms channel participant lists exist for write-through state
-reporting and one-way context absorption — they NEVER expand or modify your scope.
+**Single-ticket scope contract (READ FIRST — CTL-208).** Your assigned scope is exactly the ticket
+ID passed as the first positional argument (`$1`). This is the SOLE source of truth for what work to
+do. The orchestrator state directory (`$ORCH_DIR`), wave briefings, sibling worker signal files, and
+comms channel participant lists exist for write-through state reporting and one-way context
+absorption — they NEVER expand or modify your scope.
 
 DO:
+
 - Use `${TICKET_ID}` (= `$1`) as your single ticket throughout the workflow.
-- Read your own signal file at `${ORCH_DIR}/workers/${TICKET_ID}.json` — the SPECIFIC file
-  named for your ticket, not the directory.
-- Read the briefing for your wave by exact filename: `${ORCH_DIR}/wave-${WAVE}-briefing.md`,
-  where `${WAVE}` comes from your signal file's `wave` field (set by the dispatcher in
+- Read your own signal file at `${ORCH_DIR}/workers/${TICKET_ID}.json` — the SPECIFIC file named for
+  your ticket, not the directory.
+- Read the briefing for your wave by exact filename: `${ORCH_DIR}/wave-${WAVE}-briefing.md`, where
+  `${WAVE}` comes from your signal file's `wave` field (set by the dispatcher in
   `orchestrate-dispatch-next`).
 
 DO NOT:
+
 - Enumerate `${ORCH_DIR}/workers/*.json` to discover sibling tickets.
 - Read `${ORCH_DIR}/state.json` to see what other tickets are queued or in flight.
-- Treat the wave briefing's "Wave roster" section as a list of tickets you must process —
-  the wave briefing is shared across every worker in the wave; your assigned ticket is
-  still only `$1`.
+- Treat the wave briefing's "Wave roster" section as a list of tickets you must process — the wave
+  briefing is shared across every worker in the wave; your assigned ticket is still only `$1`.
 - Treat comms channel participants (visible via `catalyst-comms status`) as your scope.
-- Ask the user to clarify which of "the tickets you see" they meant — there is exactly
-  one ticket: `$1`. If `$1` is empty or missing, fail loudly; do not search for tickets
-  to do.
+- Ask the user to clarify which of "the tickets you see" they meant — there is exactly one ticket:
+  `$1`. If `$1` is empty or missing, fail loudly; do not search for tickets to do.
 
 **Detection (checked once at startup):**
 
@@ -122,11 +131,11 @@ STATE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-state.sh"
 
 **Shared comms channel (CTL-111 / CTL-249):** if `CATALYST_COMMS_CHANNEL` is set by the
 orchestrator, the worker joins the shared channel, posts real traffic at each lifecycle boundary,
-and reads inbound messages (directed to `$TICKET_ID`) after each phase transition.
-Best-effort — every call is wrapped so a missing `catalyst-comms` CLI never crashes the worker.
-The worker posts at **minimum 4 messages** per run: start + phase transitions + done.
-Inbound reads are driven by `comms_check` (see below) — a non-blocking poll that checks for
-`abort`, `use-event-driven`, and `reprioritize` signals from the orchestrator.
+and reads inbound messages (directed to `$TICKET_ID`) after each phase transition. Best-effort —
+every call is wrapped so a missing `catalyst-comms` CLI never crashes the worker. The worker posts
+at **minimum 4 messages** per run: start + phase transitions + done. Inbound reads are driven by
+`comms_check` (see below) — a non-blocking poll that checks for `abort`, `use-event-driven`, and
+`reprioritize` signals from the orchestrator.
 
 ```bash
 # Resolve the catalyst-comms binary. Prefer the plugin-shipped copy so installs
@@ -316,22 +325,22 @@ trap 'filter_deregister_worker' EXIT INT TERM
 
 If `ORCH_DIR` is detected, the worker:
 
-1. **Reads its signal file** from `${ORCH_DIR}/workers/${TICKET_ID}.json` (the single named
-   file for this worker — do NOT list other files in the workers/ directory)
+1. **Reads its signal file** from `${ORCH_DIR}/workers/${TICKET_ID}.json` (the single named file for
+   this worker — do NOT list other files in the workers/ directory)
 2. **Updates status at each phase transition** — writes `status`, `phase`, and `updatedAt` to both
    the local signal file AND the global state at `~/catalyst/state.json`
 3. **Derives and writes `label`** to the signal file at startup (see Label Derivation below)
 4. **Emits events** to the global event log at each phase transition
 5. **Fills `definitionOfDone`** at Phase 4 (validation) and Phase 5 (ship) with actual results
 6. **Reads its wave briefing** at `${ORCH_DIR}/wave-${WAVE}-briefing.md` if it exists, where
-   `${WAVE}` is read from the worker's own signal file's `wave` field (set by dispatcher).
-   Do NOT glob `wave-*-briefing.md` — only the worker's own wave is in scope. If the signal
-   file has no `wave` field (older orchestrators), skip briefing read entirely.
+   `${WAVE}` is read from the worker's own signal file's `wave` field (set by dispatcher). Do NOT
+   glob `wave-*-briefing.md` — only the worker's own wave is in scope. If the signal file has no
+   `wave` field (older orchestrators), skip briefing read entirely.
 
 **Label Derivation** (at startup, before first phase transition):
 
-The `label` field in the signal file gives the session a human-readable display name. It is
-derived automatically unless overridden with `--label`:
+The `label` field in the signal file gives the session a human-readable display name. It is derived
+automatically unless overridden with `--label`:
 
 ```bash
 # If --label flag was provided, use it directly
@@ -404,9 +413,9 @@ fi
 comms_check
 ```
 
-**When worker creates a PR**, also update global state with PR details. Record
-`prOpenedAt` immediately so the dashboard can show how long the PR has been open
-separately from how long it took to merge:
+**When worker creates a PR**, also update global state with PR details. Record `prOpenedAt`
+immediately so the dashboard can show how long the PR has been open separately from how long it took
+to merge:
 
 ```bash
 PR_OPENED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -427,15 +436,14 @@ comms_post info "pr:#${PR_NUMBER} opened"
 
 The worker actively merges its own PR after the listen loop confirms the PR is CLEAN (CI green +
 reviews satisfied). The worker writes `pr.mergedAt` + `status: "done"` to the signal file and
-transitions the Linear ticket. The **orchestrator's Phase 4** is a safety-net fallback for
-workers that stalled or crashed before completing their own merge.
+transitions the Linear ticket. The **orchestrator's Phase 4** is a safety-net fallback for workers
+that stalled or crashed before completing their own merge.
 
 **When worker reaches terminal state** (done or failed):
 
-**Mandatory `attention` on block** (per [[catalyst-comms]] § Posting Discipline §3): in
-addition to the failure path below, the worker MUST also `comms_post attention "<reason>"`
-when it hits any of the following mid-flight, even if it is not yet writing
-`status: "failed"`:
+**Mandatory `attention` on block** (per [[catalyst-comms]] § Posting Discipline §3): in addition to
+the failure path below, the worker MUST also `comms_post attention "<reason>"` when it hits any of
+the following mid-flight, even if it is not yet writing `status: "failed"`:
 
 - scope conflict with a sibling worker
 - missing required access (CLI / credential / API)
@@ -443,9 +451,9 @@ when it hits any of the following mid-flight, even if it is not yet writing
 - same test/CI failure 3+ times after distinct fix attempts
 - writing `status: "stalled"` (any phase)
 
-Use a single `attention` per blocker (do not retry). Continue with whatever work is still
-possible, or exit if the blocker is total. The orchestrator's poll loop will promote the
-message to a state-level NEEDS ATTENTION item.
+Use a single `attention` per blocker (do not retry). Continue with whatever work is still possible,
+or exit if the blocker is total. The orchestrator's poll loop will promote the message to a
+state-level NEEDS ATTENTION item.
 
 ```bash
 if [ -n "$ORCH_ID" ] && [ -f "$STATE_SCRIPT" ]; then
@@ -468,28 +476,28 @@ fi
 
 **Phase-to-status mapping for signal file:**
 
-| Phase | Signal Status | Writer |
-|-------|--------------|--------|
-| 1 start | `researching` | worker |
-| 2 start | `planning` | worker |
-| 3 start | `implementing` | worker |
-| 4 start | `validating` | worker |
-| 5 start | `shipping` | worker |
-| 5 PR opened | `pr-created` + `pr.prOpenedAt` + `pr.ciStatus: "pending"` | worker |
-| 5 PR listen loop: inline blocker handled | (worker fixes CI/reviews and loops) | worker |
-| 5 PR listen loop: human changes-requested | `status: "stalled"` + attention | worker |
-| 5 PR listen loop: unresolvable conflicts | `status: "stalled"` + attention | worker |
-| 5 PR merged by worker (skipDeployVerification=true or no deploy config) | `pr.ciStatus: "merged"` + `pr.mergedAt` + `status: "done"` + `completedAt` | worker |
-| 5 PR merged by worker (skipDeployVerification=false, CTL-211) | `pr.ciStatus: "merged"` + `pr.mergedAt` + `pr.mergeCommitSha` + `deploy.startedAt` + `deploy.environment` → waits for `deployment_status` | worker |
-| 5 deployment_status.success on production env | `status: "done"` + `deploy.completedAt` + `deploy.result: "success"` | worker (orchestrator Phase 4 as fallback) |
-| 5 deployment_status.failure on production env | `status: "deploy-failed"` + `deploy.failedAttempts` + attention | worker (orchestrator Phase 4 as fallback) |
-| 5 worker stalled/crashed — merge fallback | `pr.ciStatus: "merged"` + `pr.mergedAt` + `status: "done"` | orchestrator Phase 4 (safety net) |
-| Any failure | `failed` | worker |
+| Phase                                                                   | Signal Status                                                                                                                             | Writer                                    |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| 1 start                                                                 | `researching`                                                                                                                             | worker                                    |
+| 2 start                                                                 | `planning`                                                                                                                                | worker                                    |
+| 3 start                                                                 | `implementing`                                                                                                                            | worker                                    |
+| 4 start                                                                 | `validating`                                                                                                                              | worker                                    |
+| 5 start                                                                 | `shipping`                                                                                                                                | worker                                    |
+| 5 PR opened                                                             | `pr-created` + `pr.prOpenedAt` + `pr.ciStatus: "pending"`                                                                                 | worker                                    |
+| 5 PR listen loop: inline blocker handled                                | (worker fixes CI/reviews and loops)                                                                                                       | worker                                    |
+| 5 PR listen loop: human changes-requested                               | `status: "stalled"` + attention                                                                                                           | worker                                    |
+| 5 PR listen loop: unresolvable conflicts                                | `status: "stalled"` + attention                                                                                                           | worker                                    |
+| 5 PR merged by worker (skipDeployVerification=true or no deploy config) | `pr.ciStatus: "merged"` + `pr.mergedAt` + `status: "done"` + `completedAt`                                                                | worker                                    |
+| 5 PR merged by worker (skipDeployVerification=false, CTL-211)           | `pr.ciStatus: "merged"` + `pr.mergedAt` + `pr.mergeCommitSha` + `deploy.startedAt` + `deploy.environment` → waits for `deployment_status` | worker                                    |
+| 5 deployment_status.success on production env                           | `status: "done"` + `deploy.completedAt` + `deploy.result: "success"`                                                                      | worker (orchestrator Phase 4 as fallback) |
+| 5 deployment_status.failure on production env                           | `status: "deploy-failed"` + `deploy.failedAttempts` + attention                                                                           | worker (orchestrator Phase 4 as fallback) |
+| 5 worker stalled/crashed — merge fallback                               | `pr.ciStatus: "merged"` + `pr.mergedAt` + `status: "done"`                                                                                | orchestrator Phase 4 (safety net)         |
+| Any failure                                                             | `failed`                                                                                                                                  | worker                                    |
 
 ## Session Tracking
 
-Start a catalyst-session at the very beginning of the workflow, before Phase 1. This session
-spans the entire oneshot lifecycle and records phase transitions, PR creation, and completion.
+Start a catalyst-session at the very beginning of the workflow, before Phase 1. This session spans
+the entire oneshot lifecycle and records phase transitions, PR creation, and completion.
 
 ```bash
 SESSION_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-session.sh"
@@ -511,8 +519,8 @@ if [[ -x "$SESSION_SCRIPT" ]]; then
 fi
 ```
 
-**At each phase transition**, call BOTH the signal file update helper (above) AND the session
-phase call. The session phase call is additive — it never replaces the signal file write:
+**At each phase transition**, call BOTH the signal file update helper (above) AND the session phase
+call. The session phase call is additive — it never replaces the signal file write:
 
 ```bash
 if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
@@ -538,8 +546,8 @@ fi
 ```
 
 **Iteration counter** (see CTL-158): bump `--kind plan` whenever the plan is re-entered
-(validate-plan kicks back to create-plan) and `--kind fix` whenever an automated fix retry runs
-in Phase 4 (quality gates) or Phase 5 (CI auto-fix). The counts are flushed to OTLP as
+(validate-plan kicks back to create-plan) and `--kind fix` whenever an automated fix retry runs in
+Phase 4 (quality gates) or Phase 5 (CI auto-fix). The counts are flushed to OTLP as
 `claude_code_iteration_count_total{linear_key,kind}` at session end so downstream estimation can
 read rework signal per ticket:
 
@@ -570,8 +578,9 @@ This phase runs in the current session to allow user interaction during research
    Research complete. Would you like to create a Linear ticket from these findings?
    [y/N]
    ```
-   If yes, create a ticket via the Linearis CLI (run `linearis issues usage` for create syntax) using the research summary as description,
-   then register the ticket ID: `workflow-context.sh set-ticket "NEW-TICKET-ID"`
+   If yes, create a ticket via the Linearis CLI (run `linearis issues usage` for create syntax)
+   using the research summary as description, then register the ticket ID:
+   `workflow-context.sh set-ticket "NEW-TICKET-ID"`
 5. **Conduct research** — follow the `/catalyst-dev:research-codebase` process exactly. This is the
    single source of truth for how codebase research works (including DeepWiki orientation, sub-agent
    spawning, synthesis, and document creation). The research document MUST be written to
@@ -711,21 +720,20 @@ EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --j
 **Step 2: Active PR Listen Loop — Wait for CLEAN then Merge (replaces auto-merge)**
 
 After the PR is created, enter an event-driven listen loop. The preferred wake mechanism (CTL-269)
-is a single `filter.register` covering CI, comms inbound, reviews, BEHIND, and Linear ticket
-changes — the worker then waits on `filter.wake.${CATALYST_SESSION_ID}` and the Groq-backed filter
-daemon decides which raw events match. When the daemon is not running, the loop falls back to the
+is a single `filter.register` covering CI, comms inbound, reviews, BEHIND, and Linear ticket changes
+— the worker then waits on `filter.wake.${CATALYST_SESSION_ID}` and the Groq-backed filter daemon
+decides which raw events match. When the daemon is not running, the loop falls back to the
 [[wait-for-github]] two-phase pattern with per-concern jq filters. See [[catalyst-filter]] for
 registration recipes. The worker actively resolves blockers (CI failures, bot review threads,
 BEHIND) inline and proceeds to Step 3 only when the PR is CLEAN (CI green + reviews satisfied). On
 unrecoverable blockers (human changes-requested, persistent DIRTY) the worker writes
 `status: "stalled"` and exits; the orchestrator's Phase 4 is a safety-net fallback.
 
-**Wake narration (MANDATORY, CTL-369).** Every iteration of the listen loop —
-both on a `wait-for` return AND on each `mergeable_state` re-check — must
-produce a single short line of assistant text before re-entering the wait. This
-defeats the `Human:\n<task-id>` rendering bleed that occurs when the agent
-returns an `end_turn` containing only `thinking` blocks after a Monitor-wrapped
-wake. The line shape is:
+**Wake narration (MANDATORY, CTL-369).** Every iteration of the listen loop — both on a `wait-for`
+return AND on each `mergeable_state` re-check — must produce a single short line of assistant text
+before re-entering the wait. This defeats the `Human:\n<task-id>` rendering bleed that occurs when
+the agent returns an `end_turn` containing only `thinking` blocks after a Monitor-wrapped wake. The
+line shape is:
 
 ```text
 wake: <event.name> #<PR_NUMBER> [interest=<type>] — <action being taken>
@@ -734,11 +742,10 @@ wake: <event.name> — already addressed, no-op
 wake: rest-poll — broker down, polling gh api
 ```
 
-Surface `.body.payload.interest_id` and `.body.payload.reason` from the wake
-envelope when present (broker wakes carry both); for hand-rolled two-phase
-filter wakes, surface the matched `event.name` and `#${PR_NUMBER}` instead. See
-`plugins/dev/skills/monitor-events/SKILL.md` § Narration for the full rule and
-the good-vs-bad transcript fixture.
+Surface `.body.payload.interest_id` and `.body.payload.reason` from the wake envelope when present
+(broker wakes carry both); for hand-rolled two-phase filter wakes, surface the matched `event.name`
+and `#${PR_NUMBER}` instead. See `plugins/dev/skills/monitor-events/SKILL.md` § Narration for the
+full rule and the good-vs-bad transcript fixture.
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
@@ -1036,9 +1043,9 @@ fi
 
 **Step 4: Optional Rollup Fragment Contribution (CTL-108)**
 
-Before exiting, under orchestrator mode only (`ORCH_DIR` set), the worker MAY write a
-short markdown fragment describing anything surprising, risky, or worth flagging to human
-reviewers of the whole orchestrator's output:
+Before exiting, under orchestrator mode only (`ORCH_DIR` set), the worker MAY write a short markdown
+fragment describing anything surprising, risky, or worth flagging to human reviewers of the whole
+orchestrator's output:
 
 ```bash
 if [ -n "$ORCH_DIR" ] && [ -d "$ORCH_DIR/workers" ]; then
@@ -1054,11 +1061,11 @@ fi
 
 - **File name**: MUST match `${TICKET_ID}-rollup.md` exactly — the orch-monitor scans for this
   pattern to assemble the orchestrator-level rollup briefing.
-- **Content**: keep it short. The first non-blank line becomes the one-liner in the "What
-  shipped" list in the orch-monitor UI. The rest appears under a `### ${TICKET_ID}` heading in
-  the "Gotchas" section.
-- **Optional**: skip the fragment if there is nothing reviewers need to know beyond the PR
-  title — not having a fragment is the norm, not the exception.
+- **Content**: keep it short. The first non-blank line becomes the one-liner in the "What shipped"
+  list in the orch-monitor UI. The rest appears under a `### ${TICKET_ID}` heading in the "Gotchas"
+  section.
+- **Optional**: skip the fragment if there is nothing reviewers need to know beyond the PR title —
+  not having a fragment is the norm, not the exception.
 - **No orchestrator mode**: do nothing (standalone oneshot runs do not write fragments).
 
 The orchestrator's Phase 4 poll loop transitions the Linear ticket to `stateMap.done` when it
@@ -1069,19 +1076,19 @@ confirms `state=MERGED` via the shared helper (CTL-69):
   --ticket "$TICKET_ID" --transition done --config .catalyst/config.json
 ```
 
-In standalone mode (no orchestrator), the user runs `/catalyst-dev:merge-pr` which handles
-this transition.
+In standalone mode (no orchestrator), the user runs `/catalyst-dev:merge-pr` which handles this
+transition.
 
 **Step 5: File improvement findings (CTL-176 / CTL-183 routing)**
 
-Drain the findings queue and file one ticket per entry. Orchestrator-dispatched oneshot runs
-share the orchestrator's queue (`$CATALYST_FINDINGS_FILE=$ORCH_DIR/findings.jsonl`) and the
-orchestrator's Phase 7 files everything — this step is still safe to run and will find an
-empty queue in that case. Standalone oneshot runs (no orchestrator) use a session-scoped
-queue path derived from `$CATALYST_SESSION_ID`, falling back to `.catalyst/findings/current.jsonl`.
+Drain the findings queue and file one ticket per entry. Orchestrator-dispatched oneshot runs share
+the orchestrator's queue (`$CATALYST_FINDINGS_FILE=$ORCH_DIR/findings.jsonl`) and the orchestrator's
+Phase 7 files everything — this step is still safe to run and will find an empty queue in that case.
+Standalone oneshot runs (no orchestrator) use a session-scoped queue path derived from
+`$CATALYST_SESSION_ID`, falling back to `.catalyst/findings/current.jsonl`.
 
-**Recording findings during the run.** The moment you notice friction worth fixing (workflow
-gaps, bugs spotted in adjacent code, recurring manual steps), record it on the queue:
+**Recording findings during the run.** The moment you notice friction worth fixing (workflow gaps,
+bugs spotted in adjacent code, recurring manual steps), record it on the queue:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/add-finding.sh" \
@@ -1090,16 +1097,15 @@ gaps, bugs spotted in adjacent code, recurring manual steps), record it on the q
   --skill oneshot --severity low
 ```
 
-Record inline, not as a post-run retrospective — context compaction loses observations that
-wait. Don't prompt the user; don't batch. Step 5 below files the whole queue in one pass.
+Record inline, not as a post-run retrospective — context compaction loses observations that wait.
+Don't prompt the user; don't batch. Step 5 below files the whole queue in one pass.
 
-**What counts:** friction the maintainer would want fixed, bugs in adjacent catalyst code
-spotted incidentally, gaps in tooling, manual steps that should be automated.
-**What doesn't:** this ticket's own follow-up TODOs (PR body), user preferences that should
-be durable memory, routine debugging. In orchestrator-dispatched workers, stdin is not a TTY
-and `CATALYST_AUTONOMOUS=1` is expected to be set — the helper silently skips filing when
-consent is not already granted, never prompts. Standalone oneshot runs prompt interactively
-once and persist "yes":
+**What counts:** friction the maintainer would want fixed, bugs in adjacent catalyst code spotted
+incidentally, gaps in tooling, manual steps that should be automated. **What doesn't:** this
+ticket's own follow-up TODOs (PR body), user preferences that should be durable memory, routine
+debugging. In orchestrator-dispatched workers, stdin is not a TTY and `CATALYST_AUTONOMOUS=1` is
+expected to be set — the helper silently skips filing when consent is not already granted, never
+prompts. Standalone oneshot runs prompt interactively once and persist "yes":
 
 ```bash
 FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
@@ -1131,7 +1137,8 @@ if [ -x "$FEEDBACK" ] && [ -f "$FINDINGS_FILE" ] && [ -s "$FINDINGS_FILE" ]; the
 fi
 ```
 
-**If `--no-merge` was set**, skip Steps 2–3 (listen loop and merge) entirely and report PR status instead:
+**If `--no-merge` was set**, skip Steps 2–3 (listen loop and merge) entirely and report PR status
+instead:
 
 ```
 PR ready: https://github.com/org/repo/pull/{number}
@@ -1152,8 +1159,8 @@ only as a fallback for stalled workers.
 ### Phase 6: (deprecated)
 
 Phase 6 used to run `/merge-pr` separately. Workers now exit at `status: "done"` after actively
-merging their own PR and verifying deployment (CTL-252). `/merge-pr` is still useful as a
-standalone tool for merging a PR opened outside the oneshot flow.
+merging their own PR and verifying deployment (CTL-252). `/merge-pr` is still useful as a standalone
+tool for merging a PR opened outside the oneshot flow.
 
 ## Team Mode (Optional)
 
@@ -1287,14 +1294,13 @@ State transitions throughout the lifecycle:
 | 5 (PR created)                     | → inReview   | `stateMap.inReview`   | "In Review"   |
 | 5 (PR merged by worker)            | → done       | `stateMap.done`       | "Done"        |
 
-The worker transitions the ticket to `stateMap.done` after actively merging the PR in Step 3.
-The orchestrator's Phase 4 handles this transition only as a fallback for workers that stalled
-before completing their own merge (CTL-252).
+The worker transitions the ticket to `stateMap.done` after actively merging the PR in Step 3. The
+orchestrator's Phase 4 handles this transition only as a fallback for workers that stalled before
+completing their own merge (CTL-252).
 
 ## Error Handling
 
-**All error paths must end the session.** Before presenting errors or creating handoffs, always
-run:
+**All error paths must end the session.** Before presenting errors or creating handoffs, always run:
 
 ```bash
 if [[ -n "${CATALYST_SESSION_ID:-}" && -x "$SESSION_SCRIPT" ]]; then
@@ -1325,8 +1331,10 @@ fi
 
 **If CI checks fail in Phase 5:**
 
-- Worker detects the CI failure in the active listen loop (Step 2) via REST check on `mergeable_state`
-- Worker attempts automated fix (up to 3 times) — analyzes CI failure, pushes fix commit, continues loop
+- Worker detects the CI failure in the active listen loop (Step 2) via REST check on
+  `mergeable_state`
+- Worker attempts automated fix (up to 3 times) — analyzes CI failure, pushes fix commit, continues
+  loop
 - After 3 failed fix attempts, worker writes `status: "stalled"` and posts `attention` to comms
 - The orchestrator's Phase 4 then dispatches a fix-up worker via `orchestrate-auto-fixup` (CTL-64)
 
@@ -1342,36 +1350,38 @@ error, context exhaustion):
 ## Important
 
 - **All phases run in the current session** — no separate processes are spawned
-- **thoughts/ is the handoff mechanism** — all documents persist between phases and survive compaction
+- **thoughts/ is the handoff mechanism** — all documents persist between phases and survive
+  compaction
 - **NEVER add Claude attribution** to any generated artifacts
 - **Use wiki-links** for cross-references between thoughts documents (e.g., `[[filename]]`), not
   full paths
 - **Phase 3 does NOT commit** — all git operations are deferred to Phase 5
-- **Worker's success contract is `status: "done"` (CTL-252)** — the worker opens the PR,
-  enters an event-driven listen loop using `catalyst-events wait-for`, resolves CI/review
-  blockers inline, merges when CLEAN with `gh pr merge --squash --delete-branch` (no `--auto`),
-  and writes `status: "done"` with `pr.mergedAt` and `deployment.url` (if applicable). Workers
-  do NOT use `ScheduleWakeup` (unreliable in `-p` mode) — they use `catalyst-events wait-for`
-  which is a blocking subprocess call that works reliably in non-interactive sessions
+- **Worker's success contract is `status: "done"` (CTL-252)** — the worker opens the PR, enters an
+  event-driven listen loop using `catalyst-events wait-for`, resolves CI/review blockers inline,
+  merges when CLEAN with `gh pr merge --squash --delete-branch` (no `--auto`), and writes
+  `status: "done"` with `pr.mergedAt` and `deployment.url` (if applicable). Workers do NOT use
+  `ScheduleWakeup` (unreliable in `-p` mode) — they use `catalyst-events wait-for` which is a
+  blocking subprocess call that works reliably in non-interactive sessions
 - **Worker handles BEHIND, CI failures, and bot review threads inline** — in the Phase 5 listen
-  loop; the orchestrator's Phase 4 is a safety-net fallback for workers that write `status: "stalled"`
+  loop; the orchestrator's Phase 4 is a safety-net fallback for workers that write
+  `status: "stalled"`
 - **Worker writes `pr.mergedAt` + `status: "done"`** — after actively merging the PR in Phase 5
   Step 3. The orchestrator's Phase 4 handles this only for workers that stalled before completing
-- **Worker exits cleanly after writing `status: "done"`** — this is the expected success path.
-  The orchestrator distinguishes this from stalls (no PR, no progress for 15+ minutes)
-- **Worker comms discipline** — when posting to the shared comms channel, follow the rules
-  in [[catalyst-comms]] § Posting Discipline: `info` is the default heartbeat (phase
-  transitions only, ~5–7 per session), `attention` is reserved for orchestrator action
-  (0–2 per session, MANDATORY on the escalation triggers listed there — scope conflict,
-  missing access, ambiguous spec, 3+ repeated CI failures, `status="stalled"`), `done`
-  fires once at terminal success via the `done` subcommand. The existing `comms_post`
-  helper in this skill already routes correctly — these rules govern *when* you call it.
-- **Worker inbound reads (CTL-249)** — `comms_check` is called after each phase transition via
-  the signal-file update block. It polls for messages directed to `$TICKET_ID` (skipping
-  pre-worker history via `$COMMS_LAST_READ`), logs all inbound messages, and exits on `abort`.
+- **Worker exits cleanly after writing `status: "done"`** — this is the expected success path. The
+  orchestrator distinguishes this from stalls (no PR, no progress for 15+ minutes)
+- **Worker comms discipline** — when posting to the shared comms channel, follow the rules in
+  [[catalyst-comms]] § Posting Discipline: `info` is the default heartbeat (phase transitions only,
+  ~5–7 per session), `attention` is reserved for orchestrator action (0–2 per session, MANDATORY on
+  the escalation triggers listed there — scope conflict, missing access, ambiguous spec, 3+ repeated
+  CI failures, `status="stalled"`), `done` fires once at terminal success via the `done` subcommand.
+  The existing `comms_post` helper in this skill already routes correctly — these rules govern
+  _when_ you call it.
+- **Worker inbound reads (CTL-249)** — `comms_check` is called after each phase transition via the
+  signal-file update block. It polls for messages directed to `$TICKET_ID` (skipping pre-worker
+  history via `$COMMS_LAST_READ`), logs all inbound messages, and exits on `abort`.
   `catalyst-comms send` already emits `comms.message.posted` events to the global event log
-  (CTL-210), so Option B event emission is complete — extending `catalyst-events wait-for`
-  to include `comms.message` filters is tracked in CTL-247 (wait-for-github skill).
+  (CTL-210), so Option B event emission is complete — extending `catalyst-events wait-for` to
+  include `comms.message` filters is tracked in CTL-247 (wait-for-github skill).
 
 **IMPORTANT: Document Storage Rules**
 

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -15,6 +15,15 @@ worktrees, dispatches `/oneshot` workers, tracks progress via a dashboard, and e
 gates through adversarial verification. **The orchestrator NEVER writes application code** — it only
 coordinates, monitors, and verifies.
 
+> **Two dispatch modes.** With the default `catalyst.orchestration.dispatchMode: "oneshot-legacy"`,
+> each ticket gets one long `claude -p` `/catalyst-dev:oneshot` worker that runs the full lifecycle.
+> With `dispatchMode: "phase-agents"`, the orchestrator dispatches nine short-lived `claude --bg`
+> phase skills (`phase-triage` … `phase-monitor-deploy`) per ticket, advancing on
+> `phase.<name>.complete.<ticket>` broker events. The phase-agents mode is the post-2026-06-15 path
+> that keeps worker dispatch on the subscription pool. See
+> [Phase agents](https://catalyst.coalesce-labs.com/reference/orchestration/phase-agents/) for the
+> pipeline, model assignment, cost economics, and the end-to-end runbook.
+
 ## Prerequisites
 
 ```bash
@@ -62,19 +71,19 @@ fi
 
 ## Flags
 
-| Flag                     | Description                                                            |
-| ------------------------ | ---------------------------------------------------------------------- |
-| `--project <name>`       | Pull tickets from a Linear project                                     |
-| `--cycle current`        | Pull tickets from the current Linear cycle                             |
-| `--file <path>`          | Read ticket IDs from a file (one per line)                             |
-| `--auto <N>`             | Auto-pick top N Todo tickets: urgent/high priority first, newer first. Default N=3. |
-| `--auto-merge`           | Workers auto-merge PRs when CI + verification pass                     |
-| `--max-parallel <n>`     | Override config `maxParallel` (default: 3)                             |
-| `--base-branch <branch>` | Base branch for worktrees (default: main)                              |
-| `--interactive`          | Include PM intake phase before orchestration                           |
-| `--prd <path>`           | Run PRD review panel + ticket creation before orchestration            |
-| `--dry-run`              | Show wave plan without executing                                       |
-| `--state-on-merge <name>` | Linear state to set on PR merge. Default: `stateMap.done` (typically "Done") |
+| Flag                      | Description                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| `--project <name>`        | Pull tickets from a Linear project                                                  |
+| `--cycle current`         | Pull tickets from the current Linear cycle                                          |
+| `--file <path>`           | Read ticket IDs from a file (one per line)                                          |
+| `--auto <N>`              | Auto-pick top N Todo tickets: urgent/high priority first, newer first. Default N=3. |
+| `--auto-merge`            | Workers auto-merge PRs when CI + verification pass                                  |
+| `--max-parallel <n>`      | Override config `maxParallel` (default: 3)                                          |
+| `--base-branch <branch>`  | Base branch for worktrees (default: main)                                           |
+| `--interactive`           | Include PM intake phase before orchestration                                        |
+| `--prd <path>`            | Run PRD review panel + ticket creation before orchestration                         |
+| `--dry-run`               | Show wave plan without executing                                                    |
+| `--state-on-merge <name>` | Linear state to set on PR merge. Default: `stateMap.done` (typically "Done")        |
 
 ## Configuration
 
@@ -112,17 +121,15 @@ doesn't exist). Falls back to sensible defaults if no orchestration block exists
 
 **`dispatchMode` (CTL-452):**
 
-- `"phase-agents"` (default after Phase 6 lands) — the orchestrator dispatches
-  9 short-lived phase agents per ticket via `claude --bg` (subscription pool).
-  Phase 4 monitor subscribes a broker `phase_lifecycle` interest per ticket
-  and advances on `phase.<name>.complete.<TICKET>` events via the
-  `orchestrate-phase-advance` helper.
-- `"oneshot-legacy"` — the orchestrator dispatches one long `claude -p oneshot`
-  worker per ticket. Kept for rollback safety; flipping a single config key
-  reverts to the pre-CTL-452 behavior.
+- `"phase-agents"` (default after Phase 6 lands) — the orchestrator dispatches 9 short-lived phase
+  agents per ticket via `claude --bg` (subscription pool). Phase 4 monitor subscribes a broker
+  `phase_lifecycle` interest per ticket and advances on `phase.<name>.complete.<TICKET>` events via
+  the `orchestrate-phase-advance` helper.
+- `"oneshot-legacy"` — the orchestrator dispatches one long `claude -p oneshot` worker per ticket.
+  Kept for rollback safety; flipping a single config key reverts to the pre-CTL-452 behavior.
 
-The `workerCommand` field is still honored in legacy mode. In phase-agents
-mode it is unused (each phase has its own canonical skill).
+The `workerCommand` field is still honored in legacy mode. In phase-agents mode it is unused (each
+phase has its own canonical skill).
 
 See config template for full schema documentation.
 
@@ -154,9 +161,9 @@ It NEVER:
    - `--project`: list issues filtered by project name
    - `--cycle current`: list the active cycle, then list its issues
    - `--file`: read IDs from file, then read each ticket's details
-   - `--auto <N>`: list `status=Todo` issues, then select the top N. Ranking: urgent/high
-     priority first (Linear priority 1 = Urgent → 4 = Low, with 0 = "No priority" sorted
-     LAST), then newest `createdAt` first. Example jq after `linearis issues list --status Todo`:
+   - `--auto <N>`: list `status=Todo` issues, then select the top N. Ranking: urgent/high priority
+     first (Linear priority 1 = Urgent → 4 = Low, with 0 = "No priority" sorted LAST), then newest
+     `createdAt` first. Example jq after `linearis issues list --status Todo`:
      `sort_by((if .priority == 0 then 5 else .priority end), (-(.createdAt | fromdateiso8601))) | .[:N]`
      Present the auto-picked tickets to the user as part of the wave plan before proceeding.
 
@@ -337,9 +344,9 @@ With `worktreeDir: "~/catalyst/api"` explicitly configured:
 mkdir -p "${ORCH_DIR}/workers/output"
 ```
 
-Render the initial `DASHBOARD.md` (CTL-230) — the renderer reads `state.json` +
-`workers/*.json` signals + the events log every cycle, so calling it now produces a real
-header + empty worker table + waves outline rather than a template skeleton:
+Render the initial `DASHBOARD.md` (CTL-230) — the renderer reads `state.json` + `workers/*.json`
+signals + the events log every cycle, so calling it now produces a real header + empty worker
+table + waves outline rather than a template skeleton:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/update-dashboard.sh" \
@@ -365,11 +372,11 @@ ${ORCH_DIR}/                                    # ~/catalyst/runs/${ORCH_NAME}/
         └── ${TICKET_2}-stderr.log
 ```
 
-**Note on the runs/ split (CTL-59):** `ORCH_DIR` lives at `~/catalyst/runs/${ORCH_NAME}/` and
-is decoupled from the git worktree at `${ORCH_WORKTREE}` (e.g.
+**Note on the runs/ split (CTL-59):** `ORCH_DIR` lives at `~/catalyst/runs/${ORCH_NAME}/` and is
+decoupled from the git worktree at `${ORCH_WORKTREE}` (e.g.
 `~/catalyst/wt/${PROJECT_KEY}/${ORCH_NAME}/`). This lets state survive worktree cleanup and keeps
-`git status` clean. Claude CLI output (stream + stderr) lands in `workers/output/` to keep
-file watchers that scan `workers/*.json` free of noise from large stream files.
+`git status` clean. Claude CLI output (stream + stderr) lands in `workers/output/` to keep file
+watchers that scan `workers/*.json` free of noise from large stream files.
 
 **Debugging silent worker exits:** If `workers/output/${TICKET_ID}-stream.jsonl` is 0 bytes AND
 `workers/output/${TICKET_ID}-stderr.log` is 0 bytes, the worker exited before emitting its first
@@ -500,11 +507,11 @@ TOTAL_WORKERS=$(jq -r '.progress.totalTickets // 0' "${ORCH_DIR}/state.json" 2>/
 
 **Preferred entrypoint — `orchestrate-dispatch-next` (CTL-116):**
 
-The canonical dispatcher drains `state.json`'s `.queue.waveNPending` for every `N`
-(dynamically, so wave 1/2/3/…/N all work without code changes), respects
-`maxParallel - currentlyRunning`, writes dispatched/phase-0 signal files, launches
-workers via `nohup`, updates global state, removes dispatched tickets from whichever
-`waveNPending` list they lived in, and runs the post-dispatch healthcheck:
+The canonical dispatcher drains `state.json`'s `.queue.waveNPending` for every `N` (dynamically, so
+wave 1/2/3/…/N all work without code changes), respects `maxParallel - currentlyRunning`, writes
+dispatched/phase-0 signal files, launches workers via `nohup`, updates global state, removes
+dispatched tickets from whichever `waveNPending` list they lived in, and runs the post-dispatch
+healthcheck:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-dispatch-next" \
@@ -525,10 +532,10 @@ workers via `nohup`, updates global state, removes dispatched tickets from which
 # `--phase <name> --ticket <T>` and bypass the dispatchMode default.
 ```
 
-Call this once when the current wave is ready to dispatch, and again whenever a
-worker slot frees up. It supersedes the hand-rolled `dispatch-next.sh` pattern from
-pre-CTL-116 orchestration runs (which hardcoded `wave1Pending + wave2Pending + wave3Pending`).
-The inline block below is preserved as reference for the underlying machinery.
+Call this once when the current wave is ready to dispatch, and again whenever a worker slot frees
+up. It supersedes the hand-rolled `dispatch-next.sh` pattern from pre-CTL-116 orchestration runs
+(which hardcoded `wave1Pending + wave2Pending + wave3Pending`). The inline block below is preserved
+as reference for the underlying machinery.
 
 **Phase advancement on `phase.<name>.complete.<TICKET>` wake (CTL-452):**
 
@@ -617,13 +624,13 @@ worker activity. Key event types:
 | `{"type":"system","subtype":"api_retry"}`                                                                         | Worker hit rate limit / error; shows attempt and delay          |
 | `{"type":"result"}`                                                                                               | Worker finished; contains final answer and usage stats          |
 
-**Worker usage / cost is rolled in by the monitor pass (CTL-115).** The dispatch shell
-backgrounds workers with `&` and never `wait`s on them, so usage/cost extraction cannot
-happen here. Phase 4 invokes `plugins/dev/scripts/orchestrate-roll-usage.sh` once per
-worker per wake-up to parse the final `result` event from the worker's stream file and:
+**Worker usage / cost is rolled in by the monitor pass (CTL-115).** The dispatch shell backgrounds
+workers with `&` and never `wait`s on them, so usage/cost extraction cannot happen here. Phase 4
+invokes `plugins/dev/scripts/orchestrate-roll-usage.sh` once per worker per wake-up to parse the
+final `result` event from the worker's stream file and:
 
-1. Mirror cost into the worker's signal file (`.cost = USAGE`) — the dashboard reads
-   signal files (not global state) for per-worker cost columns.
+1. Mirror cost into the worker's signal file (`.cost = USAGE`) — the dashboard reads signal files
+   (not global state) for per-worker cost columns.
 2. Write `state.workers[ticket].usage`.
 3. Roll the delta into `state.usage` for the orchestrator-level aggregate.
 
@@ -642,14 +649,13 @@ The helper is idempotent (gated on `signal.cost == null`) and safe to call every
 
 **Post-dispatch health check (CTL-87):**
 
-After the wave's per-worker dispatch loop has completed, run the batch health check
-**once per wave**. It sleeps briefly (default 15s — configurable via `--grace-seconds`),
-then verifies that every worker still sitting at `status="dispatched"`/`phase=0` has a
-live PID. Any worker whose PID has already died is transitioned to `status="failed"`
-with `failureReason="launch-failure"`, an attention item of type `launch-failure` is
-raised, and a `worker-launch-failed` event is emitted. This means dead-on-arrival
-workers surface in under 30 seconds instead of after the 15-minute stalled-worker
-timeout, and the orchestrator can re-dispatch them (via `orchestrate-fixup` or a
+After the wave's per-worker dispatch loop has completed, run the batch health check **once per
+wave**. It sleeps briefly (default 15s — configurable via `--grace-seconds`), then verifies that
+every worker still sitting at `status="dispatched"`/`phase=0` has a live PID. Any worker whose PID
+has already died is transitioned to `status="failed"` with `failureReason="launch-failure"`, an
+attention item of type `launch-failure` is raised, and a `worker-launch-failed` event is emitted.
+This means dead-on-arrival workers surface in under 30 seconds instead of after the 15-minute
+stalled-worker timeout, and the orchestrator can re-dispatch them (via `orchestrate-fixup` or a
 manual redispatch) in the same wave.
 
 ```bash
@@ -662,11 +668,10 @@ manual redispatch) in the same wave.
 # events in the global state log.
 ```
 
-Healthy workers are untouched. Workers that have already advanced past `dispatched`
-(e.g. into `researching`) are skipped because reaching a later status is itself
-proof of life. This check complements the 15-minute stalled-worker detection in
-Phase 4 — healthcheck catches launch failures, the stalled-worker scan catches
-workers that die mid-run.
+Healthy workers are untouched. Workers that have already advanced past `dispatched` (e.g. into
+`researching`) are skipped because reaching a later status is itself proof of life. This check
+complements the 15-minute stalled-worker detection in Phase 4 — healthcheck catches launch failures,
+the stalled-worker scan catches workers that die mid-run.
 
 **Worker dispatch prompt includes mandatory testing AND lifecycle requirements:**
 
@@ -832,9 +837,9 @@ four deterministic interests for itself — all of them route without Groq:
 - `phase_lifecycle` (CTL-452) — `phase.<name>.complete.<TICKET>` / `phase.<name>.failed.<TICKET>`
   events emitted by phase agents. One interest per active ticket, covering all 9 phase names.
 
-CTL-357 retired the Groq prose interest (~95% false-positive rate). All four interests share
-the same `notify_event: "filter.wake.${ORCH_NAME}"`, so the orchestrator's `wait-for` filter does
-not change.
+CTL-357 retired the Groq prose interest (~95% false-positive rate). All four interests share the
+same `notify_event: "filter.wake.${ORCH_NAME}"`, so the orchestrator's `wait-for` filter does not
+change.
 
 ```bash
 if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
@@ -970,37 +975,33 @@ if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2
 fi
 ```
 
-**Phase 4 is event-driven, not poll-driven (CTL-210, CTL-243).** The orchestrator
-subscribes to the unified event log via `catalyst-events tail` (wrapped in the
-`Monitor` tool) and wakes on every relevant GitHub / Linear / orchestrator-lifecycle
-event. A 10-minute idle timer is the **safety-net fallback** for daemon-down or
-missed-event scenarios — never the primary mechanism. Do NOT self-pace with sleeps
-or "wake in N minutes" framing — that defeats the event-driven contract and burns
-context to no purpose. See `plugins/dev/skills/monitor-events/SKILL.md` for the
-full pattern.
+**Phase 4 is event-driven, not poll-driven (CTL-210, CTL-243).** The orchestrator subscribes to the
+unified event log via `catalyst-events tail` (wrapped in the `Monitor` tool) and wakes on every
+relevant GitHub / Linear / orchestrator-lifecycle event. A 10-minute idle timer is the **safety-net
+fallback** for daemon-down or missed-event scenarios — never the primary mechanism. Do NOT self-pace
+with sleeps or "wake in N minutes" framing — that defeats the event-driven contract and burns
+context to no purpose. See `plugins/dev/skills/monitor-events/SKILL.md` for the full pattern.
 
-**Launch the Monitor before entering the reactive scan.** Wrap this command with the
-`Monitor` tool — each emitted line is a wake-up.
+**Launch the Monitor before entering the reactive scan.** Wrap this command with the `Monitor` tool
+— each emitted line is a wake-up.
 
-The recommended filter is **scope-aware**: build it from the orchestrator's worker
-signal directory using `catalyst-events build-orchestrator-filter`, then pass the
-result verbatim as `--filter`:
+The recommended filter is **scope-aware**: build it from the orchestrator's worker signal directory
+using `catalyst-events build-orchestrator-filter`, then pass the result verbatim as `--filter`:
 
 ```text
 FILTER=$(catalyst-events build-orchestrator-filter "$ORCH_DIR")
 catalyst-events tail --filter "$FILTER"
 ```
 
-Use this command EXACTLY as shown — do NOT improvise a `| grep …` or `| jq …`
-post-pipe (see "Filter discipline" below for why, including the specific
-`| grep -v 'filter.wake'` anti-pattern).
+Use this command EXACTLY as shown — do NOT improvise a `| grep …` or `| jq …` post-pipe (see "Filter
+discipline" below for why, including the specific `| grep -v 'filter.wake'` anti-pattern).
 
-**catalyst-filter alternative (CTL-257):** When the filter daemon is running, you can replace
-the broad `catalyst-events tail` with a targeted `catalyst-events wait-for` on
-`filter.wake.{ORCH_NAME}`. The daemon batches raw events through Groq, classifies which are
-relevant to this orchestrator's context, and emits a single wake event — so the reactive scan
-runs only on semantically meaningful events rather than on every raw webhook. The 10-minute
-timeout acts as the safety-net fallback for daemon-down scenarios.
+**catalyst-filter alternative (CTL-257):** When the filter daemon is running, you can replace the
+broad `catalyst-events tail` with a targeted `catalyst-events wait-for` on
+`filter.wake.{ORCH_NAME}`. The daemon batches raw events through Groq, classifies which are relevant
+to this orchestrator's context, and emits a single wake event — so the reactive scan runs only on
+semantically meaningful events rather than on every raw webhook. The 10-minute timeout acts as the
+safety-net fallback for daemon-down scenarios.
 
 ```bash
 WAKE_EVENT=$(catalyst-events wait-for \
@@ -1016,52 +1017,44 @@ fi
 Use `WAKE_REASON` for logging only; the reactive scan below reads authoritative state from
 `gh pr view`, `git rev-list`, and the signal file regardless of how the wake was triggered.
 
-The helper reads `${ORCH_DIR}/workers/*.json` and emits a single jq predicate that
-matches catalyst-origin events for this orchestrator, worker lifecycle events for
-any in-orch ticket, github events scoped by branch-ref prefix
-(`refs/heads/<orch>-...`) or PR-number set, `check_suite`/`workflow_run` events
-whose `detail.prNumbers` intersect the PR set, and linear events for any in-orch
-ticket. Re-build it after `orchestrate-dispatch-next` adds new workers so the
+The helper reads `${ORCH_DIR}/workers/*.json` and emits a single jq predicate that matches
+catalyst-origin events for this orchestrator, worker lifecycle events for any in-orch ticket, github
+events scoped by branch-ref prefix (`refs/heads/<orch>-...`) or PR-number set,
+`check_suite`/`workflow_run` events whose `detail.prNumbers` intersect the PR set, and linear events
+for any in-orch ticket. Re-build it after `orchestrate-dispatch-next` adds new workers so the
 PR/ticket sets stay in sync.
 
-**Filter discipline (CTL-240, CTL-372).** All noise filtering belongs **inside**
-`--filter`. Do NOT pipe `catalyst-events tail` through a downstream
-`awk`/`sed`/`grep`/`jq` stage for additional filtering or projection. The
-primary reason is clarity — `--filter` is the single place a reader can look
-to see what reaches the consumer. The secondary reason is buffering: BSD
-`awk` (and unflagged `grep`/`sed`) buffer stdout in 4 KB blocks when stdout
-is not a TTY, and with the typical ~1–3 events/min orchestrator cadence the
-buffer never fills and notifications stall silently for 15+ minutes despite
-live PR activity. `grep --line-buffered` and `jq --unbuffered` DO line-flush
-mechanically (per their macOS/Linux man pages), but you should still not
-need either flag because filtering belongs in `--filter`.
+**Filter discipline (CTL-240, CTL-372).** All noise filtering belongs **inside** `--filter`. Do NOT
+pipe `catalyst-events tail` through a downstream `awk`/`sed`/`grep`/`jq` stage for additional
+filtering or projection. The primary reason is clarity — `--filter` is the single place a reader can
+look to see what reaches the consumer. The secondary reason is buffering: BSD `awk` (and unflagged
+`grep`/`sed`) buffer stdout in 4 KB blocks when stdout is not a TTY, and with the typical ~1–3
+events/min orchestrator cadence the buffer never fills and notifications stall silently for 15+
+minutes despite live PR activity. `grep --line-buffered` and `jq --unbuffered` DO line-flush
+mechanically (per their macOS/Linux man pages), but you should still not need either flag because
+filtering belongs in `--filter`.
 
-**Anti-pattern (CTL-372):** `… | grep -v '"event.name":"filter.wake"'`.
-Observed in a real orchestrator session and is wrong for two reasons:
-(a) `filter.wake.*` events are emitted by the broker as canonical OTel
-envelopes with no top-level `.event`, `.orchestrator`, or `.scope` field.
-`build-orchestrator-filter`'s predicate reads only v1 paths, so canonical
-`filter.wake.*` events never satisfy any clause and never reach the consumer
-in the first place. (b) The grep pattern would also strip this orchestrator's
-OWN intended `filter.wake.${ORCH_NAME}` wake — the very event registered
-with the broker. Since CTL-346 the broker no longer re-classifies its own
-emissions, so there is no feedback loop to defend against on the consumer
-side either. If you find yourself wanting to remove filter.wake noise from
-`tail` output, the answer is to use `build-orchestrator-filter` (which
-already excludes them) and avoid any hand-rolled `--filter` that adds a
-`.attributes."catalyst.orchestrator.id"` clause without an event-type guard.
+**Anti-pattern (CTL-372):** `… | grep -v '"event.name":"filter.wake"'`. Observed in a real
+orchestrator session and is wrong for two reasons: (a) `filter.wake.*` events are emitted by the
+broker as canonical OTel envelopes with no top-level `.event`, `.orchestrator`, or `.scope` field.
+`build-orchestrator-filter`'s predicate reads only v1 paths, so canonical `filter.wake.*` events
+never satisfy any clause and never reach the consumer in the first place. (b) The grep pattern would
+also strip this orchestrator's OWN intended `filter.wake.${ORCH_NAME}` wake — the very event
+registered with the broker. Since CTL-346 the broker no longer re-classifies its own emissions, so
+there is no feedback loop to defend against on the consumer side either. If you find yourself
+wanting to remove filter.wake noise from `tail` output, the answer is to use
+`build-orchestrator-filter` (which already excludes them) and avoid any hand-rolled `--filter` that
+adds a `.attributes."catalyst.orchestrator.id"` clause without an event-type guard.
 
-**GitHub event schema (CTL-240).** `github.*` webhook events carry
-`orchestrator: null` and `worker: null` on every line — they are scoped only by
-`.attributes."vcs.repository.name"`, `.attributes."vcs.ref.name"`, `.attributes."vcs.pr.number"`,
-`.attributes."vcs.revision"`, and (for `check_suite` / `workflow_run`) `body.payload.prNumbers`.
-Predicates that try to scope github events by
-`.attributes."catalyst.orchestrator.id" == "<orch>"` will silently drop every github event.
-`build-orchestrator-filter` handles this correctly — prefer it over hand-rolled
-filters.
+**GitHub event schema (CTL-240).** `github.*` webhook events carry `orchestrator: null` and
+`worker: null` on every line — they are scoped only by `.attributes."vcs.repository.name"`,
+`.attributes."vcs.ref.name"`, `.attributes."vcs.pr.number"`, `.attributes."vcs.revision"`, and (for
+`check_suite` / `workflow_run`) `body.payload.prNumbers`. Predicates that try to scope github events
+by `.attributes."catalyst.orchestrator.id" == "<orch>"` will silently drop every github event.
+`build-orchestrator-filter` handles this correctly — prefer it over hand-rolled filters.
 
-If you need to write a filter by hand (e.g. for one-off `wait-for` calls), the
-broad event-type recommendation is:
+If you need to write a filter by hand (e.g. for one-off `wait-for` calls), the broad event-type
+recommendation is:
 
 ```text
 catalyst-events tail --filter '
@@ -1083,26 +1076,24 @@ catalyst-events tail --filter '
 '
 ```
 
-This list extends the pre-CTL-240 recommendation with `pr_review_comment` (Codex
-review threads land here — needed for CTL-64 BLOCKED auto-fixup detection),
-`issue_comment` (general PR comments), and `workflow_run` (the most reliable
-CI-done signal). The broad form has no scope filter, so events from sibling
-orchestrators sharing the repo will also fire wake-ups; prefer
+This list extends the pre-CTL-240 recommendation with `pr_review_comment` (Codex review threads land
+here — needed for CTL-64 BLOCKED auto-fixup detection), `issue_comment` (general PR comments), and
+`workflow_run` (the most reliable CI-done signal). The broad form has no scope filter, so events
+from sibling orchestrators sharing the repo will also fire wake-ups; prefer
 `build-orchestrator-filter` when you have an `$ORCH_DIR` to draw on.
 
-> **Orchestrator-scoped filtering (CTL-234):** `github.*` events now carry `.attributes."catalyst.orchestrator.id"`
-> (stamped at receive time by the webhook handler). You may safely add
-> `(.attributes."catalyst.orchestrator.id" == "${ORCH_NAME}") and (...)` to narrow the filter to this run's PRs only.
+> **Orchestrator-scoped filtering (CTL-234):** `github.*` events now carry
+> `.attributes."catalyst.orchestrator.id"` (stamped at receive time by the webhook handler). You may
+> safely add `(.attributes."catalyst.orchestrator.id" == "${ORCH_NAME}") and (...)` to narrow the
+> filter to this run's PRs only.
 
-**Wake narration (MANDATORY, CTL-369).** Every Monitor wake — including ones
-classified as routine or already-addressed — must produce a single short line of
-assistant text before returning to the wait. The Claude Code harness wraps each
-Monitor stdout line in a `<task-notification>` XML user message; if the
-orchestrator's response is `end_turn` with only `thinking` blocks and no `text`
-content, the UI renders the next `<task-notification>`'s `<task-id>` as a
-phantom `Human:\n<task-id>` line in the transcript. The narration line defeats
-that artifact and gives the operator reading the transcript later a record of
-what fired and what was decided.
+**Wake narration (MANDATORY, CTL-369).** Every Monitor wake — including ones classified as routine
+or already-addressed — must produce a single short line of assistant text before returning to the
+wait. The Claude Code harness wraps each Monitor stdout line in a `<task-notification>` XML user
+message; if the orchestrator's response is `end_turn` with only `thinking` blocks and no `text`
+content, the UI renders the next `<task-notification>`'s `<task-id>` as a phantom
+`Human:\n<task-id>` line in the transcript. The narration line defeats that artifact and gives the
+operator reading the transcript later a record of what fired and what was decided.
 
 Line shape (pick one; keep it under ~120 characters):
 
@@ -1113,44 +1104,41 @@ wake: <event.name> — already addressed, no-op
 wake: idle-timeout — running periodic reconciliation scan
 ```
 
-Surface the matched interest when wake came from the broker
-(`filter.wake.${ORCH_NAME}`): include `.body.payload.interest_id` (or its type:
-`pr_lifecycle` / `ticket_lifecycle` / `comms_lifecycle`) and a one-clause
-restatement of `.body.payload.reason`. For broad-form `catalyst-events tail`
-wakes, surface the raw `event.name` and the PR/ticket scope instead.
+Surface the matched interest when wake came from the broker (`filter.wake.${ORCH_NAME}`): include
+`.body.payload.interest_id` (or its type: `pr_lifecycle` / `ticket_lifecycle` / `comms_lifecycle`)
+and a one-clause restatement of `.body.payload.reason`. For broad-form `catalyst-events tail` wakes,
+surface the raw `event.name` and the PR/ticket scope instead.
 
-See `plugins/dev/skills/monitor-events/SKILL.md` § Narration for the full rule
-and the good-vs-bad transcript fixture.
+See `plugins/dev/skills/monitor-events/SKILL.md` § Narration for the full rule and the good-vs-bad
+transcript fixture.
 
-**Wake-up classification.** When a line arrives on the Monitor, classify it before
-re-entering the scan so the response stays proportional. Every reaction reads
-authoritative state from `gh pr view`, `git rev-list`, or the signal file — events
-are wake-up triggers, never sources of truth.
+**Wake-up classification.** When a line arrives on the Monitor, classify it before re-entering the
+scan so the response stays proportional. Every reaction reads authoritative state from `gh pr view`,
+`git rev-list`, or the signal file — events are wake-up triggers, never sources of truth.
 
-| Event | Reaction |
-|---|---|
-| `orchestrator.worker.phase_advanced` | Routine in-flight progress; re-render `DASHBOARD.md`. Coalesced — `.body.payload.changes` carries the batch (CTL-229) |
-| `orchestrator.worker.status_terminal`, `orchestrator.worker.done`, `orchestrator.worker.failed` | Terminal transition; re-render `DASHBOARD.md` and run `orchestrate-dispatch-next` to fill freed slots. PR-bearing transitions carry `.body.payload.pr.{number,url}` (CTL-229) |
-| `orchestrator.worker.pr_created` | Reconcile the PR number into signal/state; re-render `DASHBOARD.md` |
-| `orchestrator.attention.raised`, `orchestrator.attention.resolved` | Re-render the `DASHBOARD.md` NEEDS ATTENTION banner |
-| `github.pr.merged`, `github.pr.closed` | Run the merge-confirmation scan for that PR |
-| `github.pr.synchronize`, `github.push` | Re-evaluate `mergeStateStatus` for the affected PR; if DIRTY ≥2 min, `orchestrate-auto-rebase` may dispatch a rebase worker (BEHIND auto-resolves via auto-merge) |
-| `github.check_*`, `github.workflow_run.completed` | Re-check CI; if BLOCKED ≥10 min, `orchestrate-auto-fixup` may dispatch a fix-up. `workflow_run.completed` is the most reliable CI-done signal |
-| `github.pr_review*`, `github.pr_review_comment*`, `github.issue_comment.created` | Re-evaluate `mergeStateStatus`; surface review activity on the dashboard. Codex review threads land as `pr_review_comment.created` — required for CTL-64 BLOCKED auto-fixup detection |
-| `github.deployment*` | Record deploy outcome on the worker's signal file |
-| `linear.issue.state_changed` | Reconcile Linear state with the worker signal |
-| `filter.wake.${ORCH_NAME}` (matched on full dotted `event.name`) | Daemon-filtered semantic wake: read `.body.payload.reason` for log context, then run the full reactive scan. The reason describes what triggered the daemon (e.g., "CI failed on PR #416") but is never the authoritative source |
-| `phase.<name>.complete.<TICKET>` (via phase_lifecycle, CTL-452) | Resolve the next phase via `orchestrate-phase-advance --ticket <T> --completed-phase <name>`; that helper looks up the next phase in the canonical 9-phase sequence and calls `orchestrate-dispatch-next --phase <next> --ticket <T>`. If `completed-phase=monitor-deploy`, no advance (terminal). The advance is idempotent under redundant wakes |
-| `phase.<name>.failed.<TICKET>` (via phase_lifecycle, CTL-452) | Run `orchestrate-revive` once for the affected ticket; on the **second** failure (reviveCount ≥ MAX_REVIVES), mark worker `stalled` and post `attention` to the shared comms channel. Matches the existing one-retry-then-escalate handling for legacy oneshot workers |
-| 10-minute idle (no event) | Run the full reactive scan as a safety net |
+| Event                                                                                           | Reaction                                                                                                                                                                                                                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `orchestrator.worker.phase_advanced`                                                            | Routine in-flight progress; re-render `DASHBOARD.md`. Coalesced — `.body.payload.changes` carries the batch (CTL-229)                                                                                                                                                                                                                              |
+| `orchestrator.worker.status_terminal`, `orchestrator.worker.done`, `orchestrator.worker.failed` | Terminal transition; re-render `DASHBOARD.md` and run `orchestrate-dispatch-next` to fill freed slots. PR-bearing transitions carry `.body.payload.pr.{number,url}` (CTL-229)                                                                                                                                                                      |
+| `orchestrator.worker.pr_created`                                                                | Reconcile the PR number into signal/state; re-render `DASHBOARD.md`                                                                                                                                                                                                                                                                                |
+| `orchestrator.attention.raised`, `orchestrator.attention.resolved`                              | Re-render the `DASHBOARD.md` NEEDS ATTENTION banner                                                                                                                                                                                                                                                                                                |
+| `github.pr.merged`, `github.pr.closed`                                                          | Run the merge-confirmation scan for that PR                                                                                                                                                                                                                                                                                                        |
+| `github.pr.synchronize`, `github.push`                                                          | Re-evaluate `mergeStateStatus` for the affected PR; if DIRTY ≥2 min, `orchestrate-auto-rebase` may dispatch a rebase worker (BEHIND auto-resolves via auto-merge)                                                                                                                                                                                  |
+| `github.check_*`, `github.workflow_run.completed`                                               | Re-check CI; if BLOCKED ≥10 min, `orchestrate-auto-fixup` may dispatch a fix-up. `workflow_run.completed` is the most reliable CI-done signal                                                                                                                                                                                                      |
+| `github.pr_review*`, `github.pr_review_comment*`, `github.issue_comment.created`                | Re-evaluate `mergeStateStatus`; surface review activity on the dashboard. Codex review threads land as `pr_review_comment.created` — required for CTL-64 BLOCKED auto-fixup detection                                                                                                                                                              |
+| `github.deployment*`                                                                            | Record deploy outcome on the worker's signal file                                                                                                                                                                                                                                                                                                  |
+| `linear.issue.state_changed`                                                                    | Reconcile Linear state with the worker signal                                                                                                                                                                                                                                                                                                      |
+| `filter.wake.${ORCH_NAME}` (matched on full dotted `event.name`)                                | Daemon-filtered semantic wake: read `.body.payload.reason` for log context, then run the full reactive scan. The reason describes what triggered the daemon (e.g., "CI failed on PR #416") but is never the authoritative source                                                                                                                   |
+| `phase.<name>.complete.<TICKET>` (via phase_lifecycle, CTL-452)                                 | Resolve the next phase via `orchestrate-phase-advance --ticket <T> --completed-phase <name>`; that helper looks up the next phase in the canonical 9-phase sequence and calls `orchestrate-dispatch-next --phase <next> --ticket <T>`. If `completed-phase=monitor-deploy`, no advance (terminal). The advance is idempotent under redundant wakes |
+| `phase.<name>.failed.<TICKET>` (via phase_lifecycle, CTL-452)                                   | Run `orchestrate-revive` once for the affected ticket; on the **second** failure (reviveCount ≥ MAX_REVIVES), mark worker `stalled` and post `attention` to the shared comms channel. Matches the existing one-retry-then-escalate handling for legacy oneshot workers                                                                             |
+| 10-minute idle (no event)                                                                       | Run the full reactive scan as a safety net                                                                                                                                                                                                                                                                                                         |
 
-**Ground truth is git + PR, not the signal file.** The signal file is *advisory* — it reports
-the worker's self-described phase. Authoritative decisions (done, stalled) come from
-`gh pr view` / `gh pr list --head <branch>` and `git rev-list --count <base>..<branch>`. A
-merged upstream PR on a worker's branch means the worker is done, regardless of what the signal
-file says. A worker with a live upstream PR is not stalled even if its signal file is stale.
-When the signal disagrees with git/PR, the orchestrator reconciles the signal from the
-authoritative source.
+**Ground truth is git + PR, not the signal file.** The signal file is _advisory_ — it reports the
+worker's self-described phase. Authoritative decisions (done, stalled) come from `gh pr view` /
+`gh pr list --head <branch>` and `git rev-list --count <base>..<branch>`. A merged upstream PR on a
+worker's branch means the worker is done, regardless of what the signal file says. A worker with a
+live upstream PR is not stalled even if its signal file is stale. When the signal disagrees with
+git/PR, the orchestrator reconciles the signal from the authoritative source.
 
 **Reactive scan (per wake-up):**
 
@@ -1180,10 +1168,9 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
 done
 ```
 
-**Update `DASHBOARD.md` on each wake-up** using the dashboard template — every incoming
-event re-renders the file. The orch-monitor daemon file-watches `DASHBOARD.md` and forwards
-changes to connected UI clients via SSE, so per-event writes propagate to operators
-immediately. Include:
+**Update `DASHBOARD.md` on each wake-up** using the dashboard template — every incoming event
+re-renders the file. The orch-monitor daemon file-watches `DASHBOARD.md` and forwards changes to
+connected UI clients via SSE, so per-event writes propagate to operators immediately. Include:
 
 - Wave progress (current wave, tickets per wave)
 - Per-worker status table (ticket, status, PR, test coverage columns)
@@ -1236,8 +1223,8 @@ Workers now exit at `status: "done"` after actively merging their own PR (CTL-25
 orchestrator's merge confirmation scan is a **safety-net fallback** for workers that stalled or
 crashed before completing their own merge. Every Monitor wake-up triggered by `github.pr.merged`,
 `github.pr.closed`, `github.push`, or `github.check_suite.completed` runs this scan, and the
-10-minute idle fallback re-runs it so daemon-down windows do not block indefinitely. For each
-worker whose signal shows `pr.number` but not yet `pr.mergedAt`, ping GitHub directly:
+10-minute idle fallback re-runs it so daemon-down windows do not block indefinitely. For each worker
+whose signal shows `pr.number` but not yet `pr.mergedAt`, ping GitHub directly:
 
 ```bash
 for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
@@ -1451,18 +1438,18 @@ REMEDIATION_EOF
 done
 ```
 
-**Refresh broker registration when PR set has changed (CTL-341, CTL-357).** The Phase 4 start
-block above registers the orchestrator's `pr_lifecycle` interest with whatever PRs the worker
-signal files happen to expose at that moment — often the empty set, because workers have not yet
-opened PRs. Without an unconditional refresh, that empty `pr_numbers` list would persist for
-the entire orchestration run and the deterministic route in `tryDeterministicRoute` would
-never match. The merge-confirmation loop above can discover a missing `pr.number` from a
-worker's branch, but that path does not run when the worker writes its own `pr.number` before
-the orchestrator wakes (the common case in the worker-driven flow). This block runs every
-Phase 4 wake-up, computes the union of `worker.pr.number` across the signal files, diffs
-against the set last sent to the broker, and re-emits all three deterministic `filter.register`
-events (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`) only when the set has changed.
-Idempotent at the broker (upserts by `interest_id`); the diff just keeps the event log quiet.
+**Refresh broker registration when PR set has changed (CTL-341, CTL-357).** The Phase 4 start block
+above registers the orchestrator's `pr_lifecycle` interest with whatever PRs the worker signal files
+happen to expose at that moment — often the empty set, because workers have not yet opened PRs.
+Without an unconditional refresh, that empty `pr_numbers` list would persist for the entire
+orchestration run and the deterministic route in `tryDeterministicRoute` would never match. The
+merge-confirmation loop above can discover a missing `pr.number` from a worker's branch, but that
+path does not run when the worker writes its own `pr.number` before the orchestrator wakes (the
+common case in the worker-driven flow). This block runs every Phase 4 wake-up, computes the union of
+`worker.pr.number` across the signal files, diffs against the set last sent to the broker, and
+re-emits all three deterministic `filter.register` events (`pr_lifecycle`, `ticket_lifecycle`,
+`comms_lifecycle`) only when the set has changed. Idempotent at the broker (upserts by
+`interest_id`); the diff just keeps the event log quiet.
 
 ```bash
 if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
@@ -1558,11 +1545,10 @@ if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2
 fi
 ```
 
-**Deploy state-machine sub-loop (CTL-211)** — runs on each wake-up for any worker
-in `merged` or `deploying`. Wakes on `github.deployment*` events from the event log;
-otherwise the 10-minute fallback sweep catches missed events. The authoritative
-source is `gh api repos/<repo>/deployments` and `/deployments/<id>/statuses`.
-Events are wake-up triggers only.
+**Deploy state-machine sub-loop (CTL-211)** — runs on each wake-up for any worker in `merged` or
+`deploying`. Wakes on `github.deployment*` events from the event log; otherwise the 10-minute
+fallback sweep catches missed events. The authoritative source is `gh api repos/<repo>/deployments`
+and `/deployments/<id>/statuses`. Events are wake-up triggers only.
 
 ```bash
 for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
@@ -1662,33 +1648,30 @@ done
 ```
 
 The state-machine transition logic is mirrored in
-`plugins/dev/scripts/orch-monitor/lib/deploy-state-machine.ts` as a pure
-function (`nextDeployState`) so the transitions are mechanically verified by
-unit tests independently of this bash glue.
+`plugins/dev/scripts/orch-monitor/lib/deploy-state-machine.ts` as a pure function
+(`nextDeployState`) so the transitions are mechanically verified by unit tests independently of this
+bash glue.
 
 Since CTL-252, workers exit at `status: "done"` after actively merging their own PR — this
-orchestrator scan is a safety-net fallback that writes `pr.mergedAt` + `status: "done"` for
-workers that stalled before completing their own merge.
+orchestrator scan is a safety-net fallback that writes `pr.mergedAt` + `status: "done"` for workers
+that stalled before completing their own merge.
 
 **Drain shared comms channel for attention (CTL-111, CTL-269):**
 
-Workers post `type:attention` messages to `${ORCH_NAME}` when blocked. On each
-wake-up, the orchestrator drains new messages from the channel and promotes any
-`attention` to a state-level attention item so the dashboard's NEEDS ATTENTION
-banner surfaces it (with author + reason).
+Workers post `type:attention` messages to `${ORCH_NAME}` when blocked. On each wake-up, the
+orchestrator drains new messages from the channel and promotes any `attention` to a state-level
+attention item so the dashboard's NEEDS ATTENTION banner surfaces it (with author + reason).
 
-The wake mechanism for comms attention is now **unified with the filter daemon**
-(CTL-269): when a worker posts to comms, `catalyst-comms send` emits a
-`comms.message.posted` event to the unified event log; the filter daemon matches
-it against the orchestrator's `filter.register` prompt (which now mentions "any
-of my workers posts a comms message of type attention to me") and emits
-`filter.wake.${ORCH_NAME}`. The orchestrator wakes from that single event and
-runs this drain step to act on the attention.
+The wake mechanism for comms attention is now **unified with the filter daemon** (CTL-269): when a
+worker posts to comms, `catalyst-comms send` emits a `comms.message.posted` event to the unified
+event log; the filter daemon matches it against the orchestrator's `filter.register` prompt (which
+now mentions "any of my workers posts a comms message of type attention to me") and emits
+`filter.wake.${ORCH_NAME}`. The orchestrator wakes from that single event and runs this drain step
+to act on the attention.
 
-A small cursor file `${ORCH_DIR}/.comms-cursor` tracks the line count already
-processed so repeated wake-ups don't re-surface the same message. Single-writer
-(this scan) so no race. The cursor-based drain remains the **action** mechanism
-even though wakes come via `filter.wake`.
+A small cursor file `${ORCH_DIR}/.comms-cursor` tracks the line count already processed so repeated
+wake-ups don't re-surface the same message. Single-writer (this scan) so no race. The cursor-based
+drain remains the **action** mechanism even though wakes come via `filter.wake`.
 
 ```bash
 if [ -n "$COMMS_BIN" ]; then
@@ -1720,10 +1703,10 @@ fi
 
 **Detect stalled workers and raise attention:**
 
-Before raising `stalled`, consult git + PR state. A stale signal file is not stall evidence on
-its own — if the worker's upstream branch has an OPEN or MERGED PR, the worker is progressing
-(or finished) regardless of what the signal file says. Only escalate when no authoritative
-source shows activity.
+Before raising `stalled`, consult git + PR state. A stale signal file is not stall evidence on its
+own — if the worker's upstream branch has an OPEN or MERGED PR, the worker is progressing (or
+finished) regardless of what the signal file says. Only escalate when no authoritative source shows
+activity.
 
 ```bash
 for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
@@ -1777,10 +1760,9 @@ done
 
 **Auto-revive dead/wedged workers (CTL-63, CTL-62):**
 
-After the stalled-worker scan, attempt to resume any dead, heartbeat-stale,
-or API-stream-idle-timeout'd worker from its original `session_id`. Resumed
-sessions preserve tool-call history, plan context, and PR state at ~10×
-lower cost than a fresh redispatch.
+After the stalled-worker scan, attempt to resume any dead, heartbeat-stale, or
+API-stream-idle-timeout'd worker from its original `session_id`. Resumed sessions preserve tool-call
+history, plan context, and PR state at ~10× lower cost than a fresh redispatch.
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-revive" \
@@ -1791,29 +1773,25 @@ lower cost than a fresh redispatch.
 The script checks every non-terminal worker signal and revives when any of:
 
 1. **PID dead** — `kill -0 <pid>` fails (CTL-63)
-2. **Heartbeat stale** — `lastHeartbeat` older than 15 minutes (catches
-   zombie-sleep PIDs whose process is alive but idle) (CTL-63)
-3. **API stream idle timeout** — the tail of
-   `workers/output/<ticket>-stream.jsonl` contains a `type=result`,
-   `is_error=true` event whose `api_error_status` or `result` mentions
-   `Stream idle timeout` or `partial response received`, and whose `uuid`
-   differs from the signal's `lastApiErrorUuid` (CTL-62)
+2. **Heartbeat stale** — `lastHeartbeat` older than 15 minutes (catches zombie-sleep PIDs whose
+   process is alive but idle) (CTL-63)
+3. **API stream idle timeout** — the tail of `workers/output/<ticket>-stream.jsonl` contains a
+   `type=result`, `is_error=true` event whose `api_error_status` or `result` mentions
+   `Stream idle timeout` or `partial response received`, and whose `uuid` differs from the signal's
+   `lastApiErrorUuid` (CTL-62)
 
-Each successful revive records `lastReviveReason`
-(`pid-dead` / `heartbeat-stale` / `api-stream-idle-timeout`) in the signal
-file and emits a `worker-revived` event with the same reason in its detail.
-The per-ticket revive budget (default 10) applies across all reasons
-combined. Workers whose budget is exhausted or whose session_id cannot be
-found transition to `status=stalled` with an attention item so you can
-decide between manual intervention and a fresh redispatch. Session resume
-uses `workers/output/<ticket>-stream.jsonl` (with legacy / transcript
-fallbacks) to find the original `session_id`.
+Each successful revive records `lastReviveReason` (`pid-dead` / `heartbeat-stale` /
+`api-stream-idle-timeout`) in the signal file and emits a `worker-revived` event with the same
+reason in its detail. The per-ticket revive budget (default 10) applies across all reasons combined.
+Workers whose budget is exhausted or whose session_id cannot be found transition to `status=stalled`
+with an attention item so you can decide between manual intervention and a fresh redispatch. Session
+resume uses `workers/output/<ticket>-stream.jsonl` (with legacy / transcript fallbacks) to find the
+original `session_id`.
 
 **Auto-dispatch fix-up workers for BLOCKED PRs (CTL-64):**
 
-After revive, a second pass detects PRs stuck in `state=OPEN,
-mergeStateStatus=BLOCKED` and either auto-dispatches `orchestrate-fixup`
-or escalates to an attention item depending on the cause.
+After revive, a second pass detects PRs stuck in `state=OPEN, mergeStateStatus=BLOCKED` and either
+auto-dispatches `orchestrate-fixup` or escalates to an attention item depending on the cause.
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-auto-fixup" \
@@ -1821,39 +1799,36 @@ or escalates to an attention item depending on the cause.
   --orch-id "$ORCH_NAME"
 ```
 
-The script records `blockedSince` on the worker signal the first time it
-observes BLOCKED, then — once the state has been stable for
-`--stable-minutes` (default 10) — classifies the cause via `gh pr view`
-and an `api graphql` query for unresolved review threads:
+The script records `blockedSince` on the worker signal the first time it observes BLOCKED, then —
+once the state has been stable for `--stable-minutes` (default 10) — classifies the cause via
+`gh pr view` and an `api graphql` query for unresolved review threads:
 
-| Classification       | Trigger                                               | Action                                                                   |
-| -------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------ |
-| `ci-running`         | any check `status ∈ {IN_PROGRESS, QUEUED, PENDING}`   | defer — try again next tick                                              |
-| `checks-failing`     | any check `conclusion ∈ {FAILURE, TIMED_OUT, …}`      | raise `checks-failing` attention (worker's own loop / revive handles it) |
-| `threads-unresolved` | checks pass AND unresolved review threads exist       | dispatch `orchestrate-fixup` with `--issues` composed from thread bodies |
-| `review-required`    | checks pass AND `reviewDecision = REVIEW_REQUIRED`    | raise `review-required` attention (human must approve)                   |
-| `blocked-unknown`    | none of the above (rare — shape not yet classified)   | raise `blocked-unknown` attention                                        |
+| Classification       | Trigger                                             | Action                                                                   |
+| -------------------- | --------------------------------------------------- | ------------------------------------------------------------------------ |
+| `ci-running`         | any check `status ∈ {IN_PROGRESS, QUEUED, PENDING}` | defer — try again next tick                                              |
+| `checks-failing`     | any check `conclusion ∈ {FAILURE, TIMED_OUT, …}`    | raise `checks-failing` attention (worker's own loop / revive handles it) |
+| `threads-unresolved` | checks pass AND unresolved review threads exist     | dispatch `orchestrate-fixup` with `--issues` composed from thread bodies |
+| `review-required`    | checks pass AND `reviewDecision = REVIEW_REQUIRED`  | raise `review-required` attention (human must approve)                   |
+| `blocked-unknown`    | none of the above (rare — shape not yet classified) | raise `blocked-unknown` attention                                        |
 
-Each auto-dispatch bumps `fixupAttempts` on the signal. When
-`fixupAttempts ≥ --max-fixups` (default 2), the script raises
-`fixup-budget-exhausted` attention instead of dispatching again, so a
-human can decide between manual intervention and abandonment.
+Each auto-dispatch bumps `fixupAttempts` on the signal. When `fixupAttempts ≥ --max-fixups` (default
+2), the script raises `fixup-budget-exhausted` attention instead of dispatching again, so a human
+can decide between manual intervention and abandonment.
 
 Signal-file fields the script reads/writes:
 
-| Field                    | Written by                | Purpose                                                    |
-| ------------------------ | ------------------------- | ---------------------------------------------------------- |
-| `blockedSince`           | orchestrate-auto-fixup    | First observation of BLOCKED; cleared when PR leaves BLOCKED |
-| `fixupAttempts`          | orchestrate-auto-fixup    | Auto-dispatch counter (max = `--max-fixups`)               |
-| `lastFixupDispatchedAt`  | orchestrate-auto-fixup    | Timestamp of the most recent dispatch (for the dashboard)  |
+| Field                   | Written by             | Purpose                                                      |
+| ----------------------- | ---------------------- | ------------------------------------------------------------ |
+| `blockedSince`          | orchestrate-auto-fixup | First observation of BLOCKED; cleared when PR leaves BLOCKED |
+| `fixupAttempts`         | orchestrate-auto-fixup | Auto-dispatch counter (max = `--max-fixups`)                 |
+| `lastFixupDispatchedAt` | orchestrate-auto-fixup | Timestamp of the most recent dispatch (for the dashboard)    |
 
 **Auto-dispatch rebase workers for DIRTY PRs (CTL-232):**
 
-After auto-fixup, a third pass detects PRs stuck in `state=OPEN,
-mergeStateStatus=DIRTY` (merge conflicts that GitHub's auto-merge cannot
-resolve on its own — it can only handle BEHIND, never DIRTY) and dispatches
-`orchestrate-rebase` to spawn a worker that rebases the PR branch onto
-current base, resolves conflicts, and force-pushes (`--force-with-lease`).
+After auto-fixup, a third pass detects PRs stuck in `state=OPEN, mergeStateStatus=DIRTY` (merge
+conflicts that GitHub's auto-merge cannot resolve on its own — it can only handle BEHIND, never
+DIRTY) and dispatches `orchestrate-rebase` to spawn a worker that rebases the PR branch onto current
+base, resolves conflicts, and force-pushes (`--force-with-lease`).
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-auto-rebase" \
@@ -1861,29 +1836,27 @@ current base, resolves conflicts, and force-pushes (`--force-with-lease`).
   --orch-id "$ORCH_NAME"
 ```
 
-The script records `dirtySince` on the worker signal the first time it
-observes DIRTY, then — once the state has been stable for `--stable-minutes`
-(default 2; DIRTY is unambiguous so the window is much shorter than
-auto-fixup's 10) — reads `baseRefName` from `gh pr view` and dispatches
+The script records `dirtySince` on the worker signal the first time it observes DIRTY, then — once
+the state has been stable for `--stable-minutes` (default 2; DIRTY is unambiguous so the window is
+much shorter than auto-fixup's 10) — reads `baseRefName` from `gh pr view` and dispatches
 `orchestrate-rebase --base-branch <ref>`.
 
-Each auto-dispatch bumps `rebaseAttempts` on the signal. When
-`rebaseAttempts ≥ --max-rebases` (default 2), the script raises
-`rebase-budget-exhausted` attention instead of dispatching again. A
+Each auto-dispatch bumps `rebaseAttempts` on the signal. When `rebaseAttempts ≥ --max-rebases`
+(default 2), the script raises `rebase-budget-exhausted` attention instead of dispatching again. A
 dispatch failure raises `rebase-dispatch-failed` attention.
 
 Signal-file fields the script reads/writes:
 
-| Field                    | Written by                 | Purpose                                                    |
-| ------------------------ | -------------------------- | ---------------------------------------------------------- |
-| `dirtySince`             | orchestrate-auto-rebase    | First observation of DIRTY; cleared when PR leaves DIRTY   |
-| `rebaseAttempts`         | orchestrate-auto-rebase    | Auto-dispatch counter (max = `--max-rebases`)              |
-| `lastRebaseDispatchedAt` | orchestrate-auto-rebase    | Timestamp of the most recent dispatch (for the dashboard)  |
-| `rebaseCommit`           | rebase worker              | SHA of the rebased HEAD (written by the dispatched worker) |
+| Field                    | Written by              | Purpose                                                    |
+| ------------------------ | ----------------------- | ---------------------------------------------------------- |
+| `dirtySince`             | orchestrate-auto-rebase | First observation of DIRTY; cleared when PR leaves DIRTY   |
+| `rebaseAttempts`         | orchestrate-auto-rebase | Auto-dispatch counter (max = `--max-rebases`)              |
+| `lastRebaseDispatchedAt` | orchestrate-auto-rebase | Timestamp of the most recent dispatch (for the dashboard)  |
+| `rebaseCommit`           | rebase worker           | SHA of the rebased HEAD (written by the dispatched worker) |
 
-**Deregister from catalyst-broker (CTL-257, updated CTL-303):** When all workers in the current
-wave reach a terminal state and Phase 4 exits, emit `filter.deregister` so the daemon stops
-routing events to this orchestrator:
+**Deregister from catalyst-broker (CTL-257, updated CTL-303):** When all workers in the current wave
+reach a terminal state and Phase 4 exits, emit `filter.deregister` so the daemon stops routing
+events to this orchestrator:
 
 ```bash
 if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
@@ -1905,30 +1878,30 @@ fi
   --summary "wave ${CURRENT_WAVE:-1} post-merge verification" 2>/dev/null || true
 ```
 
-**Context (CTL-130, updated by CTL-252):** Workers actively merge their own PRs via `gh pr
-merge --squash --delete-branch` (no `--auto`) after the listen loop confirms CLEAN. The merge
+**Context (CTL-130, updated by CTL-252):** Workers actively merge their own PRs via
+`gh pr merge --squash --delete-branch` (no `--auto`) after the listen loop confirms CLEAN. The merge
 happens the moment the worker's listen loop confirms CI passed and reviews are satisfied.
-Verification therefore runs **post-merge** — it surfaces gaps for remediation rather than
-gating merge.
+Verification therefore runs **post-merge** — it surfaces gaps for remediation rather than gating
+merge.
 
-The Phase 4 merge-confirmation scan (MERGED branch) already runs `orchestrate-verify.sh` on
-every merged PR when `verifyBeforeMerge` is `true` (default). Phase 5 aggregates those results
-and handles remediation for any failures.
+The Phase 4 merge-confirmation scan (MERGED branch) already runs `orchestrate-verify.sh` on every
+merged PR when `verifyBeforeMerge` is `true` (default). Phase 5 aggregates those results and handles
+remediation for any failures.
 
-**Aggregation:** For each worker in the current wave, read `postMergeVerification.result` from
-its signal file. Three possible states:
+**Aggregation:** For each worker in the current wave, read `postMergeVerification.result` from its
+signal file. Three possible states:
 
 1. `"passed"` — verification ran and succeeded, no action needed
 2. `"failed"` — verification ran and found gaps, remediation needed
-3. `null` — verification hasn't run yet (worker merged between wake-ups, worktree already
-   cleaned up, or `verifyBeforeMerge` is `false`)
+3. `null` — verification hasn't run yet (worker merged between wake-ups, worktree already cleaned
+   up, or `verifyBeforeMerge` is `false`)
 
 **On failure — file a remediation ticket:**
 
 Since the code is already on main, the orchestrator cannot "send the worker back." Instead:
 
-1. Read the remediation file at `${ORCH_DIR}/workers/${TICKET_ID}-remediation.md` (written by
-   Phase 4 on verification failure)
+1. Read the remediation file at `${ORCH_DIR}/workers/${TICKET_ID}-remediation.md` (written by Phase
+   4 on verification failure)
 2. File a follow-up remediation ticket via Linearis CLI with the verification gaps as the
    description
 3. Record the ticket ID in the signal file:
@@ -1940,11 +1913,11 @@ Since the code is already on main, the orchestrator cannot "send the worker back
 
 **Wave advancement gating** (interacts with `allowSelfReportedCompletion`):
 
-- If `ALLOW_SELF_REPORTED` is `"false"` (default) AND any worker has `result: "failed"`:
-  block wave advancement until all remediation tickets are filed. The wave does not advance
-  until every worker either passes verification or has a filed remediation ticket.
-- If `ALLOW_SELF_REPORTED` is `"true"` AND any worker has `result: "failed"`: log a warning,
-  file remediation tickets, but allow wave advancement to proceed. Verification is advisory.
+- If `ALLOW_SELF_REPORTED` is `"false"` (default) AND any worker has `result: "failed"`: block wave
+  advancement until all remediation tickets are filed. The wave does not advance until every worker
+  either passes verification or has a filed remediation ticket.
+- If `ALLOW_SELF_REPORTED` is `"true"` AND any worker has `result: "failed"`: log a warning, file
+  remediation tickets, but allow wave advancement to proceed. Verification is advisory.
 
 The verification script checks:
 
@@ -1965,28 +1938,27 @@ The verification script checks:
   1. Updates dashboard with specific failures
   2. Files a remediation ticket with verification gaps (code is already on main)
   3. Records remediation ticket ID in signal file
-  4. Blocks wave advancement if `allowSelfReportedCompletion` is `false` (until remediation
-     ticket is filed — not until it is resolved, which would be a future cycle's work)
+  4. Blocks wave advancement if `allowSelfReportedCompletion` is `false` (until remediation ticket
+     is filed — not until it is resolved, which would be a future cycle's work)
 
 ### Phase 6: Wave Advancement
 
 When ALL tickets in the current wave are merged and verified:
 
-1. **Confirm merges and verification (CTL-130)**: Before advancing the wave, check every worker
-   in this wave:
-
+1. **Confirm merges and verification (CTL-130)**: Before advancing the wave, check every worker in
+   this wave:
    - `status="done"` with a non-null `pr.mergedAt` — confirms the PR merged
    - If `VERIFY_BEFORE_MERGE` is `"true"`: `postMergeVerification.result` must not be `null`
      (verification must have run)
    - If `ALLOW_SELF_REPORTED` is `"false"` (default) AND any worker has
-     `postMergeVerification.result: "failed"`: block wave advancement until all failed workers
-     have a non-null `postMergeVerification.remediationTicket` (the remediation ticket has been
-     filed). The ticket does not need to be *resolved* — filing it is sufficient to unblock.
-   - If `ALLOW_SELF_REPORTED` is `"true"` AND any worker has `result: "failed"`: log a warning
-     but allow wave advancement (verification is advisory)
-   - If any worker still shows `pr-created` or `merging`, run one more Phase 4 reactive scan
-     before proceeding. If `--auto-merge` is off, flag these PRs for human review on the
-     dashboard instead of advancing.
+     `postMergeVerification.result: "failed"`: block wave advancement until all failed workers have
+     a non-null `postMergeVerification.remediationTicket` (the remediation ticket has been filed).
+     The ticket does not need to be _resolved_ — filing it is sufficient to unblock.
+   - If `ALLOW_SELF_REPORTED` is `"true"` AND any worker has `result: "failed"`: log a warning but
+     allow wave advancement (verification is advisory)
+   - If any worker still shows `pr-created` or `merging`, run one more Phase 4 reactive scan before
+     proceeding. If `--auto-merge` is off, flag these PRs for human review on the dashboard instead
+     of advancing.
 
 2. **Write wave briefing** for the next wave (see Wave Briefing section below). Then persist a copy
    to the thoughts repository so it survives worktree cleanup:
@@ -2064,8 +2036,8 @@ When all waves are complete:
    - Timeline (start to finish, per-wave durations)
    - Any verification failures that required remediation
 
-   Then render the dashboard one final time so the persisted handoff copy reflects the
-   run's terminal state (CTL-230), and persist both alongside any remaining briefings:
+   Then render the dashboard one final time so the persisted handoff copy reflects the run's
+   terminal state (CTL-230), and persist both alongside any remaining briefings:
 
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/update-dashboard.sh" \
@@ -2084,30 +2056,30 @@ When all waves are complete:
 2. **Archive orchestrator artifacts** (CTL-110).
 
    Before any worktree cleanup, sweep artifacts from the runs dir and worktrees into
-   `~/catalyst/archives/${ORCH_NAME}/` and index them in `~/catalyst/catalyst.db`. The sweep
-   is **filesystem-first**: blobs are written to the archive root BEFORE the SQLite rows are
-   inserted. If SQLite write fails, the filesystem artifacts remain on disk (syncable later
-   via `catalyst-archive sync`).
+   `~/catalyst/archives/${ORCH_NAME}/` and index them in `~/catalyst/catalyst.db`. The sweep is
+   **filesystem-first**: blobs are written to the archive root BEFORE the SQLite rows are inserted.
+   If SQLite write fails, the filesystem artifacts remain on disk (syncable later via
+   `catalyst-archive sync`).
 
    ```bash
    bun "${CLAUDE_PLUGIN_ROOT}/scripts/orch-monitor/catalyst-archive.ts" sweep "${ORCH_NAME}"
    ```
 
-   The sweep is idempotent (`ON CONFLICT` upserts). Re-running is safe. If it fails, capture
-   the exit code and `stderr` but proceed with the remaining cleanup steps — artifacts can be
-   re-swept later before teardown.
+   The sweep is idempotent (`ON CONFLICT` upserts). Re-running is safe. If it fails, capture the
+   exit code and `stderr` but proceed with the remaining cleanup steps — artifacts can be re-swept
+   later before teardown.
 
 3. **Verify Linear states**: Check all tickets are in `stateMap.done`. If any are stuck, update them
    using the Linearis CLI (run `linearis issues usage` for update syntax).
 
-4. **File improvement findings (CTL-176 / CTL-183 routing):** Drain the shared findings queue
-   and file one ticket per entry. The orchestrator and every dispatched worker share one queue
-   (dispatch sets `CATALYST_FINDINGS_FILE=$ORCH_DIR/findings.jsonl`), so this one pass covers
-   everything surfaced across the whole run. Runs as a no-op when the queue is empty.
+4. **File improvement findings (CTL-176 / CTL-183 routing):** Drain the shared findings queue and
+   file one ticket per entry. The orchestrator and every dispatched worker share one queue (dispatch
+   sets `CATALYST_FINDINGS_FILE=$ORCH_DIR/findings.jsonl`), so this one pass covers everything
+   surfaced across the whole run. Runs as a no-op when the queue is empty.
 
-   **Recording findings during the run.** The moment you or a worker notices friction worth
-   fixing (workflow gaps, bugs spotted in adjacent code, recurring manual steps, gaps in
-   tooling), record it on the shared queue:
+   **Recording findings during the run.** The moment you or a worker notices friction worth fixing
+   (workflow gaps, bugs spotted in adjacent code, recurring manual steps, gaps in tooling), record
+   it on the shared queue:
 
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/add-finding.sh" \
@@ -2116,14 +2088,14 @@ When all waves are complete:
      --skill orchestrate --severity low
    ```
 
-   Record inline, the moment it's observed — context compaction loses it otherwise. Don't
-   prompt the user mid-run; don't wait for the end; don't batch. Step 4 below files the whole
-   queue in one pass.
+   Record inline, the moment it's observed — context compaction loses it otherwise. Don't prompt the
+   user mid-run; don't wait for the end; don't batch. Step 4 below files the whole queue in one
+   pass.
 
-   **What counts:** friction the maintainer would want fixed, bugs in adjacent catalyst code
-   spotted incidentally, gaps in tooling, manual steps that should be automated.
-   **What doesn't:** this run's own ticket TODOs (those go in the PR body), user preferences
-   that should be durable memory, routine debugging.
+   **What counts:** friction the maintainer would want fixed, bugs in adjacent catalyst code spotted
+   incidentally, gaps in tooling, manual steps that should be automated. **What doesn't:** this
+   run's own ticket TODOs (those go in the PR body), user preferences that should be durable memory,
+   routine debugging.
 
    ```bash
    FEEDBACK="${CLAUDE_PLUGIN_ROOT}/scripts/file-feedback.sh"
@@ -2159,9 +2131,9 @@ When all waves are complete:
    fi
    ```
 
-5. **Clean up all worktrees** (including orchestrator worktree, unless user wants to keep it).
-   Use `/catalyst-dev:teardown ${ORCH_NAME}` for a safe, archive-gated deletion. Teardown
-   refuses to run unless step 2's sweep succeeded (use `--force` to override).
+5. **Clean up all worktrees** (including orchestrator worktree, unless user wants to keep it). Use
+   `/catalyst-dev:teardown ${ORCH_NAME}` for a safe, archive-gated deletion. Teardown refuses to run
+   unless step 2's sweep succeeded (use `--force` to override).
 
 6. **Sync thoughts**: `humanlayer thoughts sync` to persist any shared documents.
 
@@ -2282,23 +2254,22 @@ Gas Town Polecats don't share findings. Wave briefings mean:
 ## Orchestrator Rollup Briefing (CTL-108)
 
 In addition to per-wave briefings (which summarize upstream for downstream workers), the
-orchestrator also exposes an **aggregate rollup briefing** for humans reviewing the whole run.
-The rollup is **not written by the orchestrator** — it is derived on-read by the orch-monitor
-from:
+orchestrator also exposes an **aggregate rollup briefing** for humans reviewing the whole run. The
+rollup is **not written by the orchestrator** — it is derived on-read by the orch-monitor from:
 
-1. Worker signal files (`${ORCH_DIR}/workers/${ticket}.json`) — provides the "what shipped"
-   list (any worker with `pr.number` set).
-2. Per-worker rollup fragments (`${ORCH_DIR}/workers/${ticket}-rollup.md`) — optional markdown
-   files written by workers after a successful merge (see `oneshot/SKILL.md` Phase 5 Step 4).
-   Each fragment contributes a `### ${ticket}` section to the "Gotchas" area and its first
-   non-blank line becomes the one-liner next to the shipped PR.
+1. Worker signal files (`${ORCH_DIR}/workers/${ticket}.json`) — provides the "what shipped" list
+   (any worker with `pr.number` set).
+2. Per-worker rollup fragments (`${ORCH_DIR}/workers/${ticket}-rollup.md`) — optional markdown files
+   written by workers after a successful merge (see `oneshot/SKILL.md` Phase 5 Step 4). Each
+   fragment contributes a `### ${ticket}` section to the "Gotchas" area and its first non-blank line
+   becomes the one-liner next to the shipped PR.
 
-The orch-monitor assembles these on every snapshot — there is no persisted rollup file to
-maintain, no sync step for the orchestrator to run. Workers that do not write a fragment
-simply appear in "What shipped" with PR title only.
+The orch-monitor assembles these on every snapshot — there is no persisted rollup file to maintain,
+no sync step for the orchestrator to run. Workers that do not write a fragment simply appear in
+"What shipped" with PR title only.
 
-The rollup surfaces in the orch-monitor UI under the existing Briefing tab (first section,
-above per-wave briefings) and as a small `rollup` pill on the orchestrator dashboard card.
+The rollup surfaces in the orch-monitor UI under the existing Briefing tab (first section, above
+per-wave briefings) and as a small `rollup` pill on the orchestrator dashboard card.
 
 ## Testing Enforcement (3 Layers)
 
@@ -2323,8 +2294,8 @@ it's scored on catching gaps, not shipping fast.
 
 ## Dashboard
 
-The orchestrator maintains a live dashboard at `${ORCH_DIR}/DASHBOARD.md`. Re-rendered on
-each Monitor wake-up (per-event), not on a poll cycle. Uses the template from
+The orchestrator maintains a live dashboard at `${ORCH_DIR}/DASHBOARD.md`. Re-rendered on each
+Monitor wake-up (per-event), not on a poll cycle. Uses the template from
 `plugins/dev/templates/orchestrate-dashboard.md`.
 
 The dashboard includes:
@@ -2355,8 +2326,8 @@ The orchestrator also adds comments to tickets for visibility using the Linearis
 All Linear state transitions go through `plugins/dev/scripts/linear-transition.sh`. Since CTL-133,
 the orchestrator's Phase 4 monitor is the primary source of `done` transitions (workers exit at
 `merging` before merge completes). The helper reads `stateMap` from `.catalyst/config.json`, is
-idempotent (no-op when the ticket is already in the target state), and exits 0 when the
-`linearis` CLI is not installed (graceful skip).
+idempotent (no-op when the ticket is already in the target state), and exits 0 when the `linearis`
+CLI is not installed (graceful skip).
 
 ```bash
 # Transition via transition-key (reads stateMap.done from config):
@@ -2373,8 +2344,8 @@ The `--state-on-merge` flag on orchestrate is passed through to this helper when
 ### Retroactive bulk-close: `orchestrate-bulk-close`
 
 For runs that predated the state-transition wiring (or where the orchestrator's monitor exited
-before reconciling tickets), run the bulk-close helper. It walks `workers/*.json`, inspects each
-PR via `gh`, and transitions tickets via `linear-transition.sh`:
+before reconciling tickets), run the bulk-close helper. It walks `workers/*.json`, inspects each PR
+via `gh`, and transitions tickets via `linear-transition.sh`:
 
 - Merged PR with non-empty diff → `stateMap.done`
 - Merged PR with zero diff (subsumed) → `stateMap.canceled`
@@ -2447,8 +2418,8 @@ fi
 
 ## Recovery Paths: Fix-up Worker vs Follow-up Ticket
 
-Under the CTL-80 contract, workers poll until `state=MERGED` and exit at `done`. If a worker
-exits earlier (`stalled`, `failed`, or process crash), or if findings surface after merge, the
+Under the CTL-80 contract, workers poll until `state=MERGED` and exit at `done`. If a worker exits
+earlier (`stalled`, `failed`, or process crash), or if findings surface after merge, the
 orchestrator triages them. Two recovery patterns cover the cases that came up in
 `orch-data-import-2026-04-13` Round 2:
 
@@ -2508,13 +2479,13 @@ The fix-up worker:
 - Pushes ONE commit with message `fix(...): resolve review feedback on #${PR}`
 - Resolves review threads via `gh api graphql resolveReviewThread`
 - Writes its commit SHA to the worker signal file as `fixupCommit`
-- Polls until `state=MERGED` (CTL-80 contract), writes `pr.mergedAt` + `status: "done"`,
-  transitions Linear, then exits
+- Polls until `state=MERGED` (CTL-80 contract), writes `pr.mergedAt` + `status: "done"`, transitions
+  Linear, then exits
 
-The orchestrator's Phase 4 monitor is the authoritative merge watcher: if the fix-up worker
-exits before merge, the orchestrator observes the eventual `MERGED` state via the next
-`github.pr.merged` event (or 10-minute idle fallback) and writes the merge signal.
-`fixupCommit` is metadata for the dashboard.
+The orchestrator's Phase 4 monitor is the authoritative merge watcher: if the fix-up worker exits
+before merge, the orchestrator observes the eventual `MERGED` state via the next `github.pr.merged`
+event (or 10-minute idle fallback) and writes the merge signal. `fixupCommit` is metadata for the
+dashboard.
 
 **Typical cost:** ~$2 (much cheaper than a fresh worker because scope is narrow).
 

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -15,6 +15,8 @@ quality through adversarial verification.
 
 - [Workers and signal files](./orchestration/workers/) — lifecycle, signal-file schema, state
   machine
+- [Phase agents](./orchestration/phase-agents/) — the nine-phase `claude --bg` worker pipeline that
+  replaces the long `oneshot` worker once `dispatchMode` is `"phase-agents"`
 - [Verification and reward-hacking defense](./orchestration/verification/) — how the orchestrator
   adversarially checks worker output
 - [Observability overview](/observability/) — monitoring orchestrations in real time :::
@@ -263,14 +265,14 @@ The orchestrator:
 
 ### Flags
 
-| Flag                     | Description                                      |
-| ------------------------ | ------------------------------------------------ |
-| `--name <name>`          | Name this orchestrator (default: auto-generated) |
+| Flag                     | Description                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `--name <name>`          | Name this orchestrator (default: auto-generated)                                     |
 | `--auto <N>`             | Auto-pick top N Todo tickets (urgent/high priority first, newer first). Default N=3. |
-| `--max-parallel <n>`     | Override max concurrent workers (default: 3)     |
-| `--base-branch <branch>` | Base branch for worktrees (default: main)        |
-| `--dry-run`              | Show wave plan without executing                 |
-| `--interactive`          | Include PM intake phase before orchestration     |
+| `--max-parallel <n>`     | Override max concurrent workers (default: 3)                                         |
+| `--base-branch <branch>` | Base branch for worktrees (default: main)                                            |
+| `--dry-run`              | Show wave plan without executing                                                     |
+| `--interactive`          | Include PM intake phase before orchestration                                         |
 
 ## Wave-Based Parallelism
 
@@ -346,10 +348,18 @@ initializes worker signal files.
 ## Worker Dispatch
 
 Workers are dispatched by `orchestrate-dispatch-next`, which reads the `waveNPending` queues,
-validates the `workerCommand` format (must be `/<plugin>:<skill>`), and launches `claude -p`
-with `--output-format stream-json --verbose` to produce real-time NDJSON the monitor tails
-for live worker activity. Each runs `/catalyst-dev:oneshot <ticket>` autonomously — workers
-own their full PR lifecycle including merge; there is no `--auto-merge` flag.
+validates the `workerCommand` format (must be `/<plugin>:<skill>`), and routes to one of two
+dispatch paths based on `catalyst.orchestration.dispatchMode`:
+
+- **`"oneshot-legacy"` (default)** — launches one long `claude -p` worker per ticket with
+  `--output-format stream-json --verbose`, producing real-time NDJSON the monitor tails for live
+  worker activity. Each runs `/catalyst-dev:oneshot <ticket>` autonomously and owns the full PR
+  lifecycle through merge.
+- **`"phase-agents"`** — dispatches nine short-lived `claude --bg` jobs per ticket, one per phase,
+  advancing on `phase.<name>.complete.<ticket>` broker events. See
+  [Phase agents](./orchestration/phase-agents/) for the full pipeline, model assignment, and cost
+  economics. This is the post–2026-06-15 path that keeps the worker dispatch on the subscription
+  pool instead of Agent-SDK-Credit.
 
 The dispatch prompt includes **mandatory testing requirements** — not suggestions. Workers are told
 their output will be independently verified. The `CATALYST_ORCHESTRATOR_DIR` environment variable is
@@ -359,10 +369,9 @@ set so workers know where to write their signal files.
 
 Workers do **not** register filter interests by hand. Instead, each worker emits `agent.checkin`
 when it boots — including a `claimed_pr` field once the PR exists — and the
-[`catalyst-broker`](/observability/catalyst-broker/) daemon (CTL-303) auto-derives a
-`pr_lifecycle` interest from that identity record. When the worker shuts down (success or
-failure) it emits `agent.checkout`, and the broker auto-deregisters every interest it derived
-for that agent.
+[`catalyst-broker`](/observability/catalyst-broker/) daemon (CTL-303) auto-derives a `pr_lifecycle`
+interest from that identity record. When the worker shuts down (success or failure) it emits
+`agent.checkout`, and the broker auto-deregisters every interest it derived for that agent.
 
 This auto-correlation is what makes the worker's PR listen loop work without any manual
 `filter.register` plumbing. Workers can also subscribe to `ticket_lifecycle` to follow a Linear
@@ -476,16 +485,16 @@ gets caught.
 
 ### Orchestration Fields
 
-| Field                         | Type         | Default                      | Description                                                     |
-| ----------------------------- | ------------ | ---------------------------- | --------------------------------------------------------------- |
-| `worktreeDir`                 | string\|null | `~/catalyst/wt/<projectKey>` | Base directory for worktrees                                    |
-| `maxParallel`                 | number       | 3                            | Max concurrent workers per wave                                 |
-| `hooks.setup`                 | string[]     | `[]`                         | Extra commands after base `worktree.setup` (orchestration-only) |
-| `hooks.teardown`              | string[]     | `[]`                         | Commands before worktree removal on wave advancement            |
-| `workerCommand`               | string       | `/catalyst-dev:oneshot`      | Plugin-namespaced skill to run in each worker. Must be `/<plugin>:<skill>`; bare slashes rejected at dispatch. |
-| `workerModel`                 | string       | `opus`                       | Model for worker sessions                                       |
-| `testRequirements`            | object       | `{"backend":["unit"]}`       | Required test types by scope                                    |
-| `verifyBeforeMerge`           | boolean      | `true`                       | Run adversarial verification on merged commits (post-merge)     |
+| Field                         | Type         | Default                      | Description                                                                                                                                         |
+| ----------------------------- | ------------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `worktreeDir`                 | string\|null | `~/catalyst/wt/<projectKey>` | Base directory for worktrees                                                                                                                        |
+| `maxParallel`                 | number       | 3                            | Max concurrent workers per wave                                                                                                                     |
+| `hooks.setup`                 | string[]     | `[]`                         | Extra commands after base `worktree.setup` (orchestration-only)                                                                                     |
+| `hooks.teardown`              | string[]     | `[]`                         | Commands before worktree removal on wave advancement                                                                                                |
+| `workerCommand`               | string       | `/catalyst-dev:oneshot`      | Plugin-namespaced skill to run in each worker. Must be `/<plugin>:<skill>`; bare slashes rejected at dispatch.                                      |
+| `workerModel`                 | string       | `opus`                       | Model for worker sessions                                                                                                                           |
+| `testRequirements`            | object       | `{"backend":["unit"]}`       | Required test types by scope                                                                                                                        |
+| `verifyBeforeMerge`           | boolean      | `true`                       | Run adversarial verification on merged commits (post-merge)                                                                                         |
 | `allowSelfReportedCompletion` | boolean      | `false`                      | When `true`, verification failures are advisory (wave advances). When `false` (default), failures block wave advancement until remediation is filed |
 
 ### Hook Variables
@@ -658,10 +667,10 @@ grep '"q2-api-redesign"' ~/catalyst/events/*.jsonl | jq -r '"\(.ts) \(.worker //
 cat ~/catalyst/events/*.jsonl | jq -r '.event' | sort | uniq -c | sort -rn
 ```
 
-:::note[Filtering github.* and linear.* events]
-`github.*` and `linear.*` events (delivered via webhook) share the same JSONL files as
-orchestrator/worker events, but they do **not** carry `.orchestrator` or `.worker` fields.
-Filter them by event prefix or by the PR/repo context embedded in each webhook payload:
+:::note[Filtering github.* and linear.* events] `github.*` and `linear.*` events (delivered via
+webhook) share the same JSONL files as orchestrator/worker events, but they do **not** carry
+`.orchestrator` or `.worker` fields. Filter them by event prefix or by the PR/repo context embedded
+in each webhook payload:
 
 ```bash
 # GitHub PR events for a specific repo
@@ -673,6 +682,7 @@ cat ~/catalyst/events/*.jsonl | jq 'select(.event | startswith("linear.issue.sta
 # All GitHub check suite completions for a specific PR (canonical envelope, CTL-300)
 cat ~/catalyst/events/*.jsonl | jq 'select(.attributes."event.name" == "github.check_suite.completed") | select(.body.payload.prNumbers // [] | contains([87]))'
 ```
+
 :::
 
 ### The catalyst-state.sh CLI
@@ -778,8 +788,8 @@ consumption and cost:
 }
 ```
 
-**How it works**: Workers launched via the `claude` CLI with `--output-format stream-json` produce
-a streaming NDJSON output that includes a final `result` event with full token counts, cost, and
+**How it works**: Workers launched via the `claude` CLI with `--output-format stream-json` produce a
+streaming NDJSON output that includes a final `result` event with full token counts, cost, and
 timing. After a worker process exits, the orchestrator parses this output and writes the usage data
 to both the worker's entry and the orchestrator's aggregate.
 
@@ -905,14 +915,14 @@ web access from a single process.
 
 The monitor watches `~/catalyst/wt/` for orchestrator directories (matching `orch-*`) and reads:
 
-| Source                                 | Data                                               | Refresh                    |
-| -------------------------------------- | -------------------------------------------------- | -------------------------- |
-| Worker signal files (`workers/*.json`) | Status, phase, PR number, definition of done       | Instant (filesystem watch) |
-| GitHub webhook (via smee.io)           | PR state, CI status, review events                 | Within ~1s when configured |
-| GitHub API (`gh pr view`)              | PR state (open/merged/closed), merge timestamp     | Every 10 minutes (fallback when webhook not configured) |
-| Process table (`kill -0 <pid>`)        | Whether the worker's Claude process is still alive | Every 5 seconds            |
-| Orchestrator `state.json`              | Wave count, progress, attention items              | Instant (filesystem watch) |
-| Broker / forwarder pipeline (`catalyst-events tail`) | Canonical event stream — `agent.checkin/checkout`, `pr_lifecycle`, `ticket_lifecycle`, comms, webhooks | Real-time push (CTL-303 / CTL-306) |
+| Source                                               | Data                                                                                                   | Refresh                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| Worker signal files (`workers/*.json`)               | Status, phase, PR number, definition of done                                                           | Instant (filesystem watch)                              |
+| GitHub webhook (via smee.io)                         | PR state, CI status, review events                                                                     | Within ~1s when configured                              |
+| GitHub API (`gh pr view`)                            | PR state (open/merged/closed), merge timestamp                                                         | Every 10 minutes (fallback when webhook not configured) |
+| Process table (`kill -0 <pid>`)                      | Whether the worker's Claude process is still alive                                                     | Every 5 seconds                                         |
+| Orchestrator `state.json`                            | Wave count, progress, attention items                                                                  | Instant (filesystem watch)                              |
+| Broker / forwarder pipeline (`catalyst-events tail`) | Canonical event stream — `agent.checkin/checkout`, `pr_lifecycle`, `ticket_lifecycle`, comms, webhooks | Real-time push (CTL-303 / CTL-306)                      |
 
 **Dead process detection:** If a worker's PID is recorded in its signal file but `kill -0` fails,
 the monitor marks it with a `!` indicator. This catches silently crashed workers that stopped

--- a/website/src/content/docs/reference/orchestration/phase-agents.md
+++ b/website/src/content/docs/reference/orchestration/phase-agents.md
@@ -1,0 +1,321 @@
+---
+title: Phase agents
+description:
+  Nine short-lived skills the orchestrator dispatches per ticket — each runs in its own `claude
+  --bg` job, advances on a broker event, and bills against the subscription pool instead of
+  Agent-SDK-Credit.
+sidebar:
+  order: 2
+---
+
+The **phase-agent pipeline** decomposes a worker run from one long `claude -p` `oneshot` session
+into nine short-lived skills the orchestrator dispatches one at a time. Each phase is its own
+`claude --bg` job: it starts with empty context, reads the prior phase's artifact, does one thing,
+emits a `phase.<name>.complete.<ticket>` event, and exits. The orchestrator wakes on the event and
+dispatches the next phase.
+
+The decomposition is the answer to the **2026-06-15 Agent-SDK-Credit billing change**. After that
+date every `claude -p` call bills against the Agent-SDK-Credit budget; `claude --bg` jobs continue
+to draw from the Max 20x subscription pool. Moving worker dispatch off `-p` to `--bg` keeps a
+typical orchestrator run inside the $200/month Max 20x envelope.
+
+:::note[Default vs phase-agents] The orchestrator still ships with `dispatchMode: "oneshot-legacy"`
+as the default — a single long `claude -p` worker per ticket running
+[`/catalyst-dev:oneshot`](/reference/orchestration/workers/). Opt into the phase-agent pipeline by
+setting `catalyst.orchestration.dispatchMode` to `"phase-agents"` in `.catalyst/config.json`. The
+legacy oneshot path is preserved indefinitely for single-shot interactive use and as a fallback. :::
+
+## The 9 phases
+
+| #   | Skill                                             | Model             | Turn cap | Goal artifact                                 | Linear state    | Delegates to                      |
+| --- | ------------------------------------------------- | ----------------- | -------- | --------------------------------------------- | --------------- | --------------------------------- |
+| 1   | [`phase-triage`](#1-phase-triage)                 | Opus              | 10       | `triage.json`                                 | label `triaged` | —                                 |
+| 2   | [`phase-research`](#2-phase-research)             | Opus              | 35       | `thoughts/shared/research/<date>-<ticket>.md` | `researching`   | `/catalyst-dev:research-codebase` |
+| 3   | [`phase-plan`](#3-phase-plan)                     | Opus              | 25       | `thoughts/shared/plans/<date>-<ticket>.md`    | `planning`      | `/catalyst-dev:create-plan`       |
+| 4   | [`phase-implement`](#4-phase-implement)           | Opus _(see Cost)_ | 75       | commits + `phase-implement.json`              | `inProgress`    | `/catalyst-dev:implement-plan`    |
+| 5   | [`phase-verify`](#5-phase-verify)                 | Opus              | 20       | `verify.json`                                 | `verifying`     | gates + adversarial sub-agents    |
+| 6   | [`phase-review`](#6-phase-review)                 | Opus              | 25       | `review.json` + remediation commit            | `reviewing`     | `/review` (gstack)                |
+| 7   | [`phase-pr`](#7-phase-pr)                         | Opus              | 12       | open PR + `phase-pr.json`                     | `inReview`      | `/catalyst-dev:create-pr`         |
+| 8   | [`phase-monitor-merge`](#8-phase-monitor-merge)   | Opus              | 50       | merged PR + `phase-monitor-merge.json`        | `done`          | (lifts oneshot Phase 5 loop)      |
+| 9   | [`phase-monitor-deploy`](#9-phase-monitor-deploy) | Haiku             | 30       | `phase-monitor-deploy.json`                   | —               | `/canary` (gstack)                |
+
+Default models come from `phase-agent-dispatch:51` (Opus) plus the per-phase override in
+`phase-agent-dispatch:55-66`. Resolution order is `--model` CLI flag >
+`catalyst.orchestration.phaseAgents.modelOverrides[phase][ticket]` >
+`catalyst.orchestration.phaseAgents.models[phase]` > default Opus.
+
+Turn caps follow the same precedence: `--turn-cap` CLI flag >
+`catalyst.orchestration.phaseAgents.turnCaps[phase]` > the per-phase default above.
+
+### 1. `phase-triage`
+
+Entry phase. Reads the Linear ticket, expands acronyms, classifies it
+(`feature`/`bug`/`docs`/`refactor`/`chore`), identifies dependencies, estimates scope, writes
+`${ORCH_DIR}/workers/${TICKET}/triage.json`, posts a triaged comment to Linear, and applies the
+`triaged` label. Emits `phase.triage.complete.<TICKET>`.
+
+The bash body does the deterministic work; Opus is used to refine ambiguous fields.
+
+### 2. `phase-research`
+
+Reads `triage.json` from the prior phase, delegates to
+[`/catalyst-dev:research-codebase`](/plugins/catalyst-dev/), and emits
+`phase.research.complete.<TICKET>` once `thoughts/shared/research/<date>-<ticket>.md` exists with
+the standard frontmatter, Summary, Findings (≥10 `file:line` references), and References sections.
+
+### 3. `phase-plan`
+
+Reads the research document by glob (`thoughts/shared/research/*-<ticket>.md`), delegates to
+[`/catalyst-dev:create-plan`](/plugins/catalyst-dev/), and emits `phase.plan.complete.<TICKET>` once
+`thoughts/shared/plans/<date>-<ticket>.md` exists with Overview plus phased Tests First (Red) →
+Implementation (Green) → Refactor → Success Criteria sections.
+
+### 4. `phase-implement`
+
+Reads the plan, delegates to [`/catalyst-dev:implement-plan`](/plugins/catalyst-dev/) via the Task
+tool, commits each plan phase as it lands. `/goal` succeeds when `git diff <base>..HEAD` is
+non-empty AND the targeted tests pass. Emits `phase.implement.complete.<TICKET>`.
+
+The cost projection assumes Sonnet on this phase — that's a config flip
+(`catalyst.orchestration.phaseAgents.models.implement = "sonnet"`), not a code change. The shipped
+default is Opus; switch it once you have a baseline to compare against. Per-ticket overrides via
+`modelOverrides.implement.<TICKET>` give you an escape hatch when a particularly ambiguous plan
+needs Opus.
+
+### 5. `phase-verify`
+
+Read-only adversarial verification. Runs tsc, tests, lint, security scan, reward-hacking scan, plus
+the `code-reviewer`, `pr-test-analyzer`, and `silent-failure-hunter` sub-agents. Writes
+`${ORCH_DIR}/workers/${TICKET}/verify.json` with a `regression_risk` score and findings list. Never
+writes application code; test files are the only writable target. Emits
+`phase.verify.complete.<TICKET>`.
+
+This is the **independent verification layer** that replaces the orchestrator's adversarial recheck
+— see [Verification and reward-hacking defense](/reference/orchestration/verification/).
+
+### 6. `phase-review`
+
+Reads `verify.json`, runs the `/review` skill (gstack) against the diff, writes
+`${ORCH_DIR}/workers/${TICKET}/review.json`, and creates a remediation commit for any HIGH-severity
+finding with a deterministic fix. Emits `phase.review.complete.<TICKET>`.
+
+Explicitly skips `/ultrareview` (per the source plan); operator can still run it manually after the
+PR opens.
+
+### 7. `phase-pr`
+
+Delegates to [`/catalyst-dev:create-pr`](/plugins/catalyst-dev/) (which already runs `describe-pr`
+and transitions Linear to `inReview`), then writes PR number + URL into `phase-pr.json` so the
+downstream `phase-monitor-merge` skips a redundant `gh` query. Emits `phase.pr.complete.<TICKET>`.
+
+### 8. `phase-monitor-merge`
+
+The **active listen loop**. Lifts the body of `oneshot` Phase 5 Step 2 verbatim: event-driven wait
+on `catalyst-events wait-for`, inline resolution of CI failures, bot review threads, and BEHIND
+rebases, then `gh pr merge --squash --delete-branch` when the PR reaches CLEAN. Transitions Linear
+to `done` and emits `phase.monitor-merge.complete.<TICKET>`.
+
+Stalls (CI red after 3 fix attempts, unresolvable conflicts, human changes-requested) write
+`status: "stalled"` and post `attention` to the comms channel — the orchestrator's monitor loop
+handles dispatch from there.
+
+### 9. `phase-monitor-deploy`
+
+Optional. Subscribes via `catalyst-events wait-for` to `deployment_status` events on the merge SHA
+matching `$PHASE_DEPLOY_ENV` (default `production`), then runs the `/canary` skill (gstack) to
+verify the live deployment. Writes `phase-monitor-deploy.json` and emits
+`phase.monitor-deploy.complete.<TICKET>`, `.failed.<TICKET>`, or `.skipped.<TICKET>`. Uses Haiku by
+default — most of the work is polling and reading deployment status events.
+
+Skipped automatically when no deploy event arrives within the wall-clock timeout, so projects
+without deployment hooks don't block on this phase forever.
+
+## Broker `phase_lifecycle` interest
+
+The orchestrator subscribes once per ticket via
+[`catalyst-broker`](/observability/catalyst-broker/)'s deterministic `phase_lifecycle` interest
+type:
+
+| Field           | Value                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------------- |
+| `interest_type` | `phase_lifecycle`                                                                                  |
+| `ticket`        | the Linear ticket ID, e.g. `CTL-123`                                                               |
+| `phase_names`   | `["triage","research","plan","implement","verify","review","pr","monitor-merge","monitor-deploy"]` |
+| `notify_event`  | `filter.wake.<ORCH_NAME>`                                                                          |
+
+Event pattern matched: `phase.<name>.(complete|failed).<TICKET>`. Routing is purely deterministic —
+no Groq call, no prose evaluation. The broker auto-cleans the interest when the orchestrator emits
+`agent.checkout`.
+
+## Dispatch flow
+
+```text
+Orchestrator               phase-agent-dispatch         Phase agent (claude --bg)
+     │                              │                              │
+     ├─ creates worker signal ──────>│                              │
+     │   workers/CTL-N.json          │                              │
+     │                              ├─ writes phase signal:        │
+     │                              │   workers/CTL-N/phase-triage.json
+     │                              │   {status: "dispatched"}     │
+     │                              ├─ launches claude --bg ───────>│
+     │                              │   /catalyst-dev:phase-triage  │  reads triage.json
+     │                              │   --orch-dir …                │  does its one job
+     │                              │                              │  writes artifact
+     │                              │                              │  emits phase.triage.complete.CTL-N
+     │<─── filter.wake.<ORCH_NAME> ──┴──────────────────────────────│  → broker matches, fires wake
+     │                                                              │  exits
+     ├─ orchestrate-phase-advance --completed-phase triage           │
+     │   --ticket CTL-N                                              │
+     │     → phase_next(triage) = research                           │
+     │     → orchestrate-dispatch-next --phase research --ticket CTL-N
+     │     → (loops back to phase-agent-dispatch for next phase)     │
+     ▼
+```
+
+Each phase agent is **idempotent**: if `phase-agent-dispatch` finds an existing signal with `status`
+of `dispatched`, `running`, or `done`, it exits 0 without re-spawning. Only `failed` signals are
+overwritten.
+
+## Configuration
+
+All phase-agent config lives under `catalyst.orchestration` in `.catalyst/config.json`:
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "dispatchMode": "phase-agents",
+      "phaseAgents": {
+        "models": {
+          "implement": "sonnet",
+          "pr": "sonnet",
+          "monitor-deploy": "haiku"
+        },
+        "modelOverrides": {
+          "implement": {
+            "CTL-501": "opus"
+          }
+        },
+        "turnCaps": {
+          "implement": 100
+        }
+      }
+    }
+  }
+}
+```
+
+| Key                                         | Default            | Purpose                                                                                                     |
+| ------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `dispatchMode`                              | `"oneshot-legacy"` | `"phase-agents"` enables the pipeline; `"oneshot-legacy"` keeps a single long `claude -p` worker per ticket |
+| `phaseAgents.models[phase]`                 | `"opus"`           | Per-phase default model                                                                                     |
+| `phaseAgents.modelOverrides[phase][ticket]` | none               | Per-phase, per-ticket override (highest precedence after CLI)                                               |
+| `phaseAgents.turnCaps[phase]`               | see table above    | Hard cap on Claude turns per phase                                                                          |
+
+Resolution order — both for model and turn-cap — is **CLI flag > `modelOverrides[phase][ticket]` >
+`models[phase]` > built-in default**.
+
+## Cost economics
+
+The pipeline is a billing change first and an architecture change second. Two things matter:
+
+1. **Subscription-pool dispatch.** Every phase agent runs as `claude --bg`, which draws from the Max
+   20x subscription pool. The orchestrator itself is the only `-p` call on the dispatch path, and
+   it's a short coordination loop. Per-run Agent-SDK-Credit spend on the worker path: **$0**.
+2. **Per-phase model assignment.** The fresh context per phase costs ~$2.25 of "rehydration tax" per
+   run (each phase re-reads prior artifacts). That tax is recouped by assigning Sonnet to Phase 4
+   (implement) and Phase 7 (pr) and Haiku to Phase 9 (monitor-deploy).
+
+**Cost projection** (Opus 4.7 = $5/$25 per Mtok in/out; Sonnet 4.6 ≈ $3/$15; Haiku 4.5 ≈ $0.80/$4,
+sourced from the planning research; **subject to actual measurement** — see the gap below):
+
+| Phase            | Model  | Est. turns | Cost (mixed) | Cost (all-Opus) |
+| ---------------- | ------ | ---------- | ------------ | --------------- |
+| 1 Triage         | Opus   | 5–8        | $0.30        | $0.30           |
+| 2 Research       | Opus   | 25–30      | $2.50        | $2.50           |
+| 3 Plan           | Opus   | 15–20      | $1.50        | $1.50           |
+| 4 Implement      | Sonnet | 40–60      | $2.70        | $4.50           |
+| 5 Verify         | Opus   | 10–15      | $0.80        | $0.80           |
+| 6 Review         | Opus   | 15–20      | $1.20        | $1.20           |
+| 7 PR             | Sonnet | 5–8        | $0.18        | $0.30           |
+| 8 Monitor-merge  | Opus   | 10–30      | $0.50        | $0.50           |
+| 9 Monitor-deploy | Haiku  | 5–15       | $0.03        | $0.20           |
+| **Total**        | mixed  | ~150       | **~$9.71**   | $11.80          |
+
+:::caution[Measurement gap — track via follow-up ticket] As of 2026-05-17 the `session_metrics`
+table in `~/catalyst/catalyst.db` shows `$0` cost across every `oneshot`, `orchestrate`, and
+`research-codebase` row over the last 30 days (535 + 51 + 34 sessions respectively). The CTL-455 fix
+to populate the table from worker stream data is merged but no run since the fix has flushed real
+numbers into the DB. The projection above is **unvalidated by real measurement** — track this as a
+follow-up before relying on the per-phase numbers. :::
+
+## Observing a run
+
+Real-time:
+
+- **HUD** — `catalyst-hud` shows per-ticket phase, signal status, and (once `session_metrics` is
+  populated) cumulative cost.
+- **Events** — `catalyst-events tail` streams `phase.<name>.complete.<TICKET>` as each phase lands.
+- **Signal files** — `${ORCH_DIR}/workers/<TICKET>/phase-<name>.json` records dispatch state,
+  artifact path, and timing for every phase.
+
+After the run:
+
+```bash
+# Aggregate cost per workflow (once session_metrics has data)
+sqlite3 ~/catalyst/catalyst.db -header -column <<'SQL'
+SELECT s.workflow_id,
+       s.ticket_key,
+       s.skill_name,
+       printf('$%.4f', sm.cost_usd) AS cost,
+       sm.input_tokens,
+       sm.output_tokens,
+       sm.duration_ms / 1000 AS dur_s
+FROM sessions s
+LEFT JOIN session_metrics sm ON s.session_id = sm.session_id
+WHERE s.skill_name LIKE 'phase-%'
+  AND s.workflow_id = '<your-orchestrator-session-id>'
+ORDER BY s.started_at;
+SQL
+```
+
+```bash
+# Count completion events emitted by a ticket's full run
+catalyst-events tail --since 24h \
+  | jq -c 'select(.attributes."event.name" | startswith("phase.")
+                  and (.attributes."event.name" | endswith(".CTL-N")))' \
+  | wc -l
+# Expect 9 (one per phase) for a successful run.
+```
+
+## End-to-end runbook
+
+For the first real run against a low-risk ticket:
+
+1. **Pick a small ticket** (docs fix, small refactor, no external deps).
+2. **Set dispatch mode** in `.catalyst/config.json`:
+   ```json
+   { "catalyst": { "orchestration": { "dispatchMode": "phase-agents" } } }
+   ```
+3. **Verify `session_metrics` populates** with a single test session before committing to a full
+   run. The CTL-455 fix is what populates the table; if `cost_usd` is still `0` after a short
+   `claude --bg` job, the fix needs investigation before cost measurement is meaningful.
+4. **Dispatch the orchestrator**:
+   ```bash
+   /catalyst-dev:orchestrate <TICKET> --auto-merge --max-parallel 1
+   ```
+5. **Watch the HUD** through to merge. Expect 9 `phase.<name>.complete.<TICKET>` events in
+   `catalyst-events tail`.
+6. **Pull cost data** via the SQL query above. Compare per-phase numbers to the projection table;
+   deltas >1.5× warrant tightening the relevant phase's turn cap or trimming its system prompt.
+
+## Related
+
+- [Workers and signal files](/reference/orchestration/workers/) — signal-file schema (shared between
+  oneshot and phase-agent workers)
+- [Verification and reward-hacking defense](/reference/orchestration/verification/) — the
+  `phase-verify` and `phase-review` adversarial layers
+- [Semantic event routing (catalyst-broker)](/observability/catalyst-broker/) — protocol for
+  `phase_lifecycle` and related interest types
+- [Orchestration overview](/reference/orchestration/) — Level 2/3 orchestration model and full
+  config reference

--- a/website/src/content/docs/reference/orchestration/workers.md
+++ b/website/src/content/docs/reference/orchestration/workers.md
@@ -1,11 +1,23 @@
 ---
 title: Workers and signal files
-description: How the orchestrator dispatches workers, how they report progress, and the full signal-file schema.
+description:
+  How the orchestrator dispatches workers, how they report progress, and the full signal-file
+  schema.
 sidebar:
   order: 1
 ---
 
-When `/catalyst-dev:orchestrate` runs a wave, it dispatches one **worker** per ticket. Each worker is a separate Claude Code subprocess running `/catalyst-dev:oneshot` inside a dedicated git worktree. The worker communicates progress back to the orchestrator exclusively through its **signal file**.
+When `/catalyst-dev:orchestrate` runs a wave, it dispatches one **worker** per ticket. Each worker
+is a separate Claude Code subprocess running `/catalyst-dev:oneshot` inside a dedicated git
+worktree. The worker communicates progress back to the orchestrator exclusively through its **signal
+file**.
+
+:::note[Two dispatch modes share this file] This page describes the **legacy `oneshot` worker** —
+the full lifecycle in a single `claude -p` session. The newer
+[phase-agent pipeline](../phase-agents/) dispatches nine short-lived `claude --bg` jobs per ticket
+instead; each phase writes its own `phase-<name>.json` alongside the main `<ticket>.json` signal
+file described below. The state machine, status field, and field semantics on `<ticket>.json` are
+unchanged across both modes. :::
 
 ## Worker lifecycle
 
@@ -30,32 +42,37 @@ Orchestrator                   Worker subprocess
      │   (orchestrator's Phase 4 is a safety-net fallback for stalled/crashed workers)
 ```
 
-The worker owns the full PR lifecycle end-to-end: it opens the PR, enters an event-driven listen loop via `catalyst-events wait-for`, resolves blockers (CI failures, bot review threads, BEHIND) inline, executes `gh pr merge --squash --delete-branch` when the PR is CLEAN, and writes `status: "done"` before exiting. The orchestrator's Phase 4 is a fallback that handles workers that stalled before completing their own merge.
+The worker owns the full PR lifecycle end-to-end: it opens the PR, enters an event-driven listen
+loop via `catalyst-events wait-for`, resolves blockers (CI failures, bot review threads, BEHIND)
+inline, executes `gh pr merge --squash --delete-branch` when the PR is CLEAN, and writes
+`status: "done"` before exiting. The orchestrator's Phase 4 is a fallback that handles workers that
+stalled before completing their own merge.
 
 ## The signal file
 
-Located at `<orchestrator-dir>/workers/<ticket>.json`. The orchestrator creates an empty skeleton; the worker writes into it.
+Located at `<orchestrator-dir>/workers/<ticket>.json`. The orchestrator creates an empty skeleton;
+the worker writes into it.
 
 ### Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `ticket` | string | The ticket ID (e.g., `CTL-48`) |
-| `orchestrator` | string | Orchestrator ID |
-| `workerName` | string | Human-readable worker name (used for tmux titles, etc.) |
-| `status` | string | Current status — see state machine below |
-| `phase` | number | 0–6, matching oneshot phases |
-| `startedAt` | ISO string | When the worker was dispatched |
-| `updatedAt` | ISO string | Last write to the signal file |
-| `lastHeartbeat` | ISO string | Most recent heartbeat (~60s cadence during long phases) |
-| `completedAt` | ISO string or `null` | Set when terminal state reached |
-| `worktreePath` | string | Absolute path to the worker's git worktree |
-| `phaseTimestamps` | object | Map of status → ISO timestamp; populated at each transition |
-| `pr` | object or `null` | Populated at Phase 5 PR creation |
-| `linearState` | string or `null` | Current Linear state name |
-| `definitionOfDone` | object | Populated at Phase 4 + 5 with real results |
-| `pid` | number | Worker's Claude process PID |
-| `cost` | object\|null | Usage/cost object populated by `orchestrate-roll-usage.sh` after the worker stream contains a `result` event. Shape: `{ inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUSD, numTurns, durationMs }` |
+| Field              | Type                 | Description                                                                                                                                                                                                               |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ticket`           | string               | The ticket ID (e.g., `CTL-48`)                                                                                                                                                                                            |
+| `orchestrator`     | string               | Orchestrator ID                                                                                                                                                                                                           |
+| `workerName`       | string               | Human-readable worker name (used for tmux titles, etc.)                                                                                                                                                                   |
+| `status`           | string               | Current status — see state machine below                                                                                                                                                                                  |
+| `phase`            | number               | 0–6, matching oneshot phases                                                                                                                                                                                              |
+| `startedAt`        | ISO string           | When the worker was dispatched                                                                                                                                                                                            |
+| `updatedAt`        | ISO string           | Last write to the signal file                                                                                                                                                                                             |
+| `lastHeartbeat`    | ISO string           | Most recent heartbeat (~60s cadence during long phases)                                                                                                                                                                   |
+| `completedAt`      | ISO string or `null` | Set when terminal state reached                                                                                                                                                                                           |
+| `worktreePath`     | string               | Absolute path to the worker's git worktree                                                                                                                                                                                |
+| `phaseTimestamps`  | object               | Map of status → ISO timestamp; populated at each transition                                                                                                                                                               |
+| `pr`               | object or `null`     | Populated at Phase 5 PR creation                                                                                                                                                                                          |
+| `linearState`      | string or `null`     | Current Linear state name                                                                                                                                                                                                 |
+| `definitionOfDone` | object               | Populated at Phase 4 + 5 with real results                                                                                                                                                                                |
+| `pid`              | number               | Worker's Claude process PID                                                                                                                                                                                               |
+| `cost`             | object\|null         | Usage/cost object populated by `orchestrate-roll-usage.sh` after the worker stream contains a `result` event. Shape: `{ inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUSD, numTurns, durationMs }` |
 
 ### The `pr` subobject
 
@@ -71,7 +88,8 @@ Located at `<orchestrator-dir>/workers/<ticket>.json`. The orchestrator creates 
 
 - `ciStatus`: `pending` | `passing` | `failing` | `unknown` | `merged`
 - `prOpenedAt` — set by worker the moment the PR is created
-- `mergedAt` — set by the worker after `gh pr merge --squash --delete-branch` completes; set by the orchestrator (fallback) for stalled workers
+- `mergedAt` — set by the worker after `gh pr merge --squash --delete-branch` completes; set by the
+  orchestrator (fallback) for stalled workers
 
 ### State machine
 
@@ -88,17 +106,23 @@ dispatched → researching → planning → implementing → validating → ship
                                                           (at any stage) → failed | stalled
 ```
 
-The worker writes all statuses through `done`. In the `pr-created` → `done` transition, the worker enters a `catalyst-events wait-for` listen loop, resolves CI failures and review blockers inline, and executes `gh pr merge --squash --delete-branch` when the PR is CLEAN. The orchestrator writes `done` only as a safety-net fallback for workers that wrote `stalled` or crashed before completing their own merge.
+The worker writes all statuses through `done`. In the `pr-created` → `done` transition, the worker
+enters a `catalyst-events wait-for` listen loop, resolves CI failures and review blockers inline,
+and executes `gh pr merge --squash --delete-branch` when the PR is CLEAN. The orchestrator writes
+`done` only as a safety-net fallback for workers that wrote `stalled` or crashed before completing
+their own merge.
 
-The listen loop is enabled by [`catalyst-broker`](/observability/catalyst-broker/)
-auto-correlation (CTL-303): the worker's `agent.checkin {claimed_pr}` event causes the broker to
-derive a `pr_lifecycle` interest for that PR, so `wait-for` receives PR/CI/review events without
-the worker calling `filter.register` manually. On `agent.checkout` the broker auto-deregisters
-the derived interests.
+The listen loop is enabled by [`catalyst-broker`](/observability/catalyst-broker/) auto-correlation
+(CTL-303): the worker's `agent.checkin {claimed_pr}` event causes the broker to derive a
+`pr_lifecycle` interest for that PR, so `wait-for` receives PR/CI/review events without the worker
+calling `filter.register` manually. On `agent.checkout` the broker auto-deregisters the derived
+interests.
 
 ## The global state
 
-In parallel with the signal file, workers also write to `~/catalyst/state.json` via `catalyst-state.sh worker`. This is the fleet-wide aggregate that the dashboard reads — it unifies workers across multiple orchestrators. Writes are atomic (jq + mkdir-based locking).
+In parallel with the signal file, workers also write to `~/catalyst/state.json` via
+`catalyst-state.sh worker`. This is the fleet-wide aggregate that the dashboard reads — it unifies
+workers across multiple orchestrators. Writes are atomic (jq + mkdir-based locking).
 
 Schema:
 
@@ -112,43 +136,51 @@ Schema:
       "wave": 2,
       "totalWaves": 3,
       "workers": {
-        "CTL-48": { /* same shape as signal file */ }
+        "CTL-48": {
+          /* same shape as signal file */
+        }
       },
-      "attention": [
-        { "type": "verification-failed", "ticket": "CTL-48", "message": "..." }
-      ]
+      "attention": [{ "type": "verification-failed", "ticket": "CTL-48", "message": "..." }]
     }
   }
 }
 ```
 
-The `attention` array is the orchestrator's way of flagging something that needs human decision. Never auto-resolved by the orchestrator itself.
+The `attention` array is the orchestrator's way of flagging something that needs human decision.
+Never auto-resolved by the orchestrator itself.
 
 ## Heartbeats
 
-During long phases (implementation, CI waits), workers update `lastHeartbeat` without changing status. The orch-monitor treats a worker as stalled if `now - lastHeartbeat > 15 minutes`. A stalled worker is never auto-restarted — it becomes an attention item.
+During long phases (implementation, CI waits), workers update `lastHeartbeat` without changing
+status. The orch-monitor treats a worker as stalled if `now - lastHeartbeat > 15 minutes`. A stalled
+worker is never auto-restarted — it becomes an attention item.
 
-If you're writing a custom worker, heartbeat every ~60s at minimum. More often is fine; less often trips false stalled detections.
+If you're writing a custom worker, heartbeat every ~60s at minimum. More often is fine; less often
+trips false stalled detections.
 
 ## Terminal states
 
 A worker reaches a terminal state in one of three ways:
 
-| State | Means | Signal writer |
-|-------|-------|---------------|
-| `done` | PR merged, Linear=Done | Worker (after executing merge); Orchestrator (fallback for stalled workers) |
-| `failed` | Unrecoverable error, quality gates exhausted, or human escalation | Worker (writes attention reason) |
-| `stalled` | Worker could not resolve a blocker (CI, reviews, conflicts) or no heartbeat for 15+ min | Worker (on unrecoverable blocker); Orchestrator (on heartbeat timeout) |
+| State     | Means                                                                                   | Signal writer                                                               |
+| --------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `done`    | PR merged, Linear=Done                                                                  | Worker (after executing merge); Orchestrator (fallback for stalled workers) |
+| `failed`  | Unrecoverable error, quality gates exhausted, or human escalation                       | Worker (writes attention reason)                                            |
+| `stalled` | Worker could not resolve a blocker (CI, reviews, conflicts) or no heartbeat for 15+ min | Worker (on unrecoverable blocker); Orchestrator (on heartbeat timeout)      |
 
-Terminal states set `completedAt`. No further writes to the signal file happen once terminal is reached.
+Terminal states set `completedAt`. No further writes to the signal file happen once terminal is
+reached.
 
 ## Why signal files and not IPC
 
 File-based signals are intentionally boring:
 
 - **Debuggable** with `cat workers/*.json | jq`
-- **Survive process death** on both sides — neither the worker crashing nor the orchestrator restarting destroys state
+- **Survive process death** on both sides — neither the worker crashing nor the orchestrator
+  restarting destroys state
 - **Atomic on POSIX** via tmp+rename writes
-- **Pickled history** — old signal files live in archived orchestrator dirs, so you can audit past waves
+- **Pickled history** — old signal files live in archived orchestrator dirs, so you can audit past
+  waves
 
-The cost is polling latency — the orch-monitor uses `fs.watch` to avoid polling, but some consumers do poll. That's fine for a one-machine setup; for multi-host you'd front this with a real event bus.
+The cost is polling latency — the orch-monitor uses `fs.watch` to avoid polling, but some consumers
+do poll. That's fine for a one-machine setup; for multi-host you'd front this with a real event bus.


### PR DESCRIPTION
## Summary

Adds the user-facing documentation for the **phase-agent dispatch mode** shipped across CTL-447–CTL-452. After 2026-06-15 every `claude -p` call bills against Agent-SDK-Credit; the phase-agent pipeline moves worker dispatch onto `claude --bg` and keeps an orchestrator run inside the Max 20x subscription pool.

Closes CTL-453.

## What changed

- **New page** `website/src/content/docs/reference/orchestration/phase-agents.md`
  - 9-phase pipeline table (model, turn cap, artifact, sub-skill, Linear state)
  - `phase_lifecycle` broker interest signature and registration
  - Dispatcher precedence: `--model` CLI > `modelOverrides[phase][ticket]` > `models[phase]` > Opus
  - `dispatchMode` config (`phase-agents` vs `oneshot-legacy`)
  - Cost projection table (verbatim from plan, ~$9.71/run mixed)
  - Cost-measurement-gap callout (see below) + end-to-end runbook
- `website/src/content/docs/reference/orchestration.md` — Worker Dispatch section now describes both modes; subarticle list links the new page
- `website/src/content/docs/reference/orchestration/workers.md` — note that both modes share the signal-file schema
- `plugins/dev/skills/oneshot/SKILL.md` — "Legacy mode" callout at the top
- `plugins/dev/skills/orchestrate/SKILL.md` — "Two dispatch modes" callout at the top

## Cost measurement gap

The ticket's "Cost within projection OR documented deltas" criterion needs a real-ticket run with `session_metrics` populated. As of today every row in `~/catalyst/catalyst.db.session_metrics` reads `cost_usd = 0` (535 oneshot + 51 orchestrate + 34 research-codebase + others over the last 30 days). CTL-455 merged the population path but no run since has flushed real numbers. The new doc surfaces this as a tracked follow-up rather than hiding it — the projection table is in place and labelled unvalidated, so the next real run can drop in side-by-side without restructuring the page.

The end-to-end runbook in the new doc walks the operator through the dispatch-mode flip, a sanity-check single phase to verify `session_metrics` populates, the full orchestrator run, and the SQL for per-phase cost rollup.

## Test plan

- [x] `npm run build` (Astro) — 297 pages built, new page rendered at `/reference/orchestration/phase-agents/`
- [x] `make lint` — clean (only pre-existing warnings remain)
- [x] `make check-frontmatter` — passes
- [x] In-page anchor refs resolve (all 9 `#N-phase-X` headings present)
- [x] Cross-page links resolve (`workers/`, `verification/`, `catalyst-broker/`)
- [x] Sidebar autogen picked up the new page

## Follow-up

A separate ticket should be opened to actually run an end-to-end orchestrator with `dispatchMode: phase-agents` against a small live ticket and slot the real per-phase cost numbers into the table this PR adds. That work is intentionally out of scope here — running another orchestrator from inside an already-orchestrated oneshot worker has untested concurrency implications, and the table itself has to land before the numbers can be filled in.