### PR TITLE
feat(dev): briefing-followup action handlers — calendar/ticket/orchestrate/email (CTL-463)

### DIFF
--- a/cma/mcp/gmail.md
+++ b/cma/mcp/gmail.md
@@ -1,0 +1,134 @@
+# Gmail MCP wiring
+
+## URLs
+
+| Endpoint | Path | Auth | Headless |
+|----------|------|------|----------|
+| REST API | `https://gmail.googleapis.com/gmail/v1` | Bearer (OAuth access token from refresh) | **Yes** — recommended |
+| Hosted MCP | `https://gmailmcp.googleapis.com/mcp/v1` | Bearer (same OAuth access token) | Pending verification |
+| claude.ai connector | `claude.ai/customize/connectors` | OAuth user grant | Read-only; insufficient for drafts |
+
+For the briefing-followup skill (Initiative 3 / CTL-463), **use Path A**
+(OAuth refresh token + Gmail v1 REST). The hosted Gmail MCP is documented
+by Google but not yet end-to-end verified by this project. The claude.ai
+first-party Gmail connector exists but is read-only — fine for context
+gathering, insufficient for drafting messages.
+
+## Path A (recommended): OAuth refresh token + Gmail v1 REST
+
+Gmail uses the **same OAuth client** as Google Drive / Google Calendar —
+one client, one refresh token, multiple scopes. Reuse the OAuth setup
+documented in [google-drive.md](google-drive.md) (steps 1-5); when running
+the local consent flow, add the Gmail-specific scope alongside the Drive
+and Calendar scopes:
+
+```python
+SCOPES = [
+    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/gmail.compose",
+]
+```
+
+The `client_id`, `client_secret`, and `refresh_token` stored in the CMA
+vault for Drive/Calendar (`GOOGLE_OAUTH_*`) also cover Gmail — but the
+**access token exchanged from that refresh token is a separate Bearer
+token** for Gmail because the OAuth scopes are distinct.
+
+You must also **enable the Gmail API** in the same GCP project at
+<https://console.cloud.google.com/apis/library/gmail.googleapis.com>.
+
+### Environment variable contract
+
+The briefing-followup `action-email.sh` script reads
+`GMAIL_OAUTH_ACCESS_TOKEN`. It is **distinct from**
+`GOOGLE_OAUTH_ACCESS_TOKEN` to avoid silently sending email with a token
+that was minted only for Drive/Calendar scopes. Set both env vars in your
+CMA vault by exchanging the same refresh token twice — once with the
+Drive+Calendar scope subset, once with `gmail.compose` — and exporting
+each result under its own name.
+
+### Draft-message REST usage
+
+```bash
+# Create a draft message
+RAW=$(printf 'To: alice@example.com\r\nSubject: Hi\r\n\r\nHello.' \
+  | python3 -c 'import sys, base64; sys.stdout.write(
+      base64.urlsafe_b64encode(sys.stdin.buffer.read()).decode("ascii").rstrip("="))')
+
+curl -fsSL -X POST \
+  -H "Authorization: Bearer ${GMAIL_OAUTH_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc --arg raw "$RAW" '{message: {raw: $raw}}')" \
+  https://gmail.googleapis.com/gmail/v1/users/me/drafts
+```
+
+The response contains the draft `id`. To send the draft, POST to
+`/users/me/drafts/{id}/send`. The briefing-followup skill creates drafts
+only — sending is a manual review step.
+
+## Path B: Google Gmail hosted MCP (pending verification)
+
+Google ships a hosted Gmail MCP server (per Google's developer docs) in
+Developer Preview. Expected tool inventory:
+
+| Tool | Operation |
+|------|-----------|
+| `list_messages` | Search / enumerate messages |
+| `get_message` | Fetch a single message |
+| `send_message` | Send a new message |
+| `create_draft` | Create a draft (parallel to REST `drafts.create`) |
+| `update_draft` | Modify an existing draft |
+| `delete_draft` | Delete a draft |
+
+**Pending verification.** If reachable, a follow-up PR uncomments
+`gmailmcp.googleapis.com` in `cma/environment.yaml` and adds the endpoint
+to `cma/agents/base.yaml`.
+
+## Maintained community options (if Google's hosted MCP doesn't pan out)
+
+Worth knowing about:
+
+| Repo | Auth | Service account? |
+|------|------|------------------|
+| [taylorwilsdon/google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp) | OAuth 2.0/2.1 OR service account + DWD | Yes (Workspace domains only) |
+
+`google_workspace_mcp` supports gmail-only deploys with
+`uvx workspace-mcp --tools gmail`.
+
+## Network allowlist
+
+Add to `cma/environment.yaml` (alongside the existing Drive/Calendar
+hosts):
+
+- `gmail.googleapis.com` — Gmail v1 REST
+
+The OAuth host (`oauth2.googleapis.com`) is already allowlisted for
+Drive/Calendar; Gmail reuses it.
+
+## OAuth scope minimums
+
+For drafting (the only operation the briefing-followup skill performs):
+
+| Scope | Purpose |
+|-------|---------|
+| `https://www.googleapis.com/auth/gmail.compose` | Create, read, update, delete drafts; send mail |
+
+Avoid the broader `https://mail.google.com/` (full mailbox access) unless
+a future routine genuinely needs it.
+
+## Soft-skip semantics
+
+If `GMAIL_OAUTH_ACCESS_TOKEN` is unset when the briefing-followup skill
+encounters a `draft_email` action, `action-email.sh` emits
+`{"status":"skipped","reason":"GMAIL_OAUTH_ACCESS_TOKEN not set ..."}`
+and exits 0. The skill surfaces the skip to the user and continues with
+the next decision — no failure, no nag. This file is the canonical pointer
+the skip message references when the user wants to wire up Gmail.
+
+## References
+
+- [Gmail API v1 — drafts.create reference](https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/create)
+- [Gmail API v1 — drafts.send reference](https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/send)
+- [Choose Gmail API scopes](https://developers.google.com/gmail/api/auth/scopes)
+- [taylorwilsdon/google_workspace_mcp — community Workspace MCP server](https://github.com/taylorwilsdon/google_workspace_mcp)

--- a/plugins/dev/scripts/__tests__/briefing-followup-actions.test.sh
+++ b/plugins/dev/scripts/__tests__/briefing-followup-actions.test.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+# Tests for the briefing-followup skill action handlers (CTL-463 Phase 2).
+# Covers: schedule_calendar / file_ticket / dispatch_orchestrator / draft_email
+# action scripts + the resolution recorder.
+#
+# Run: bash plugins/dev/scripts/__tests__/briefing-followup-actions.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+BF_DIR="${REPO_ROOT}/plugins/dev/scripts/briefing-followup"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/briefing-followup/SKILL.md"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  shift
+  for line in "$@"; do echo "    $line"; done
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected: $expected" "actual:   $actual"
+  fi
+}
+
+assert_grep() {
+  local label="$1" pattern="$2" content="$3"
+  if grep -qF -- "$pattern" <<<"$content"; then
+    pass "$label"
+  else
+    fail "$label" "expected substring: $pattern" \
+      "actual: $(printf '%s' "$content" | head -20)"
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected exit: $expected" "actual exit:   $actual"
+  fi
+}
+
+# Install a fake curl that records its full invocation (including stdin body)
+# to FAKE_CURL_LOG and emits FAKE_CURL_RESPONSE on stdout.
+install_fake_curl() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+# Record args.
+{
+  echo "curl $*"
+  # Surface --data-binary @- bodies if present (read stdin when last arg is '@-').
+  for arg in "$@"; do
+    if [[ "$arg" == "@-" ]]; then
+      echo "BODY_START"
+      cat
+      echo "BODY_END"
+      break
+    fi
+  done
+} >> "${FAKE_CURL_LOG:-/dev/null}"
+# Emit fake response.
+printf '%s' "${FAKE_CURL_RESPONSE:-{}}"
+EOF
+  chmod +x "$bin_dir/curl"
+}
+
+install_fake_linearis() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/linearis" <<'EOF'
+#!/usr/bin/env bash
+echo "linearis $*" >> "${FAKE_LINEARIS_LOG:-/dev/null}"
+if [[ "${1:-}" == "teams" && "${2:-}" == "list" ]]; then
+  # Surface a single fake team so key→UUID resolution can succeed.
+  cat <<JSON
+[{"id":"${FAKE_LINEARIS_TEAM_UUID:-00000000-0000-0000-0000-000000000001}","key":"${FAKE_LINEARIS_TEAM_KEY:-CTL}","name":"Catalyst"}]
+JSON
+  exit 0
+fi
+if [[ "${1:-}" == "issues" && "${2:-}" == "create" ]]; then
+  if [[ "${FAKE_LINEARIS_FAIL_CREATE:-0}" == "1" ]]; then
+    echo "${FAKE_LINEARIS_FAIL_REASON:-fake auth error}" >&2
+    exit 1
+  fi
+  cat <<JSON
+{"identifier":"${FAKE_LINEARIS_ID:-TST-99}","url":"https://linear.app/x/issue/${FAKE_LINEARIS_ID:-TST-99}","title":"fake"}
+JSON
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$bin_dir/linearis"
+}
+
+install_fake_claude() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude $*" >> "${FAKE_CLAUDE_LOG:-/dev/null}"
+if [[ "${FAKE_CLAUDE_NO_ORCH:-0}" == "1" ]]; then
+  echo "${FAKE_CLAUDE_STDERR:-dispatch failed}" >&2
+  exit 1
+fi
+echo "Started orchestrator ${FAKE_CLAUDE_ORCH_ID:-orch_abc123}"
+exit 0
+EOF
+  chmod +x "$bin_dir/claude"
+}
+
+# ─── Test 1: action-schedule.sh invokes Calendar create-event with right shape ─
+test_action_schedule() {
+  echo "test 1: action-schedule.sh invokes Calendar create-event"
+  local target="$BF_DIR/action-schedule.sh"
+  local t_dir="$SCRATCH/t1"
+  local bin_dir="$t_dir/bin"
+  local log="$t_dir/curl.log"
+  mkdir -p "$t_dir"
+  install_fake_curl "$bin_dir"
+
+  local out ec
+  out=$(FAKE_CURL_LOG="$log" \
+        FAKE_CURL_RESPONSE='{"id":"evt_abc","htmlLink":"https://cal/abc"}' \
+        GOOGLE_OAUTH_ACCESS_TOKEN=fake \
+        PATH="$bin_dir:$PATH" \
+        bash "$target" --title "Foo bar" \
+                       --start 2026-05-18T09:00:00Z \
+                       --end 2026-05-18T10:00:00Z \
+                       --description "test event" 2>&1)
+  ec=$?
+
+  assert_exit "schedule exits 0" "0" "$ec"
+  assert_grep "schedule stdout has event_id" '"event_id":"evt_abc"' "$out"
+  assert_grep "schedule stdout status=scheduled" '"status":"scheduled"' "$out"
+
+  local log_content
+  log_content=$(cat "$log" 2>/dev/null || echo "")
+  assert_grep "curl invoked with bearer token" "Authorization: Bearer fake" "$log_content"
+  assert_grep "curl invoked against calendar events endpoint" \
+    "/calendar/v3/calendars/primary/events" "$log_content"
+  assert_grep "curl body contains summary" '"summary":"Foo bar"' "$log_content"
+  assert_grep "curl body contains start dateTime" \
+    '"dateTime":"2026-05-18T09:00:00Z"' "$log_content"
+
+  # Soft-skip path: no token.
+  local skip_out skip_ec
+  skip_out=$(env -u GOOGLE_OAUTH_ACCESS_TOKEN PATH="$bin_dir:$PATH" \
+    bash "$target" --title X --start 2026-05-18T09:00:00Z \
+                   --end 2026-05-18T10:00:00Z 2>&1)
+  skip_ec=$?
+  assert_exit "schedule soft-skip exits 0" "0" "$skip_ec"
+  assert_grep "schedule soft-skip status=skipped" '"status":"skipped"' "$skip_out"
+
+  # Hard-failure path: curl returns empty body (no id in response).
+  local fail_out fail_ec
+  fail_out=$(FAKE_CURL_LOG="$log" \
+             FAKE_CURL_RESPONSE='{}' \
+             GOOGLE_OAUTH_ACCESS_TOKEN=fake \
+             PATH="$bin_dir:$PATH" \
+             bash "$target" --title X --start 2026-05-18T09:00:00Z \
+                            --end 2026-05-18T10:00:00Z 2>&1)
+  fail_ec=$?
+  assert_exit "schedule failure exits 1" "1" "$fail_ec"
+  assert_grep "schedule failure status=failed" '"status":"failed"' "$fail_out"
+}
+
+# ─── Test 2: action-ticket.sh invokes `linearis issues create` ──────────────
+test_action_ticket() {
+  echo "test 2: action-ticket.sh invokes linearis issues create"
+  local target="$BF_DIR/action-ticket.sh"
+  local t_dir="$SCRATCH/t2"
+  local bin_dir="$t_dir/bin"
+  local log="$t_dir/linearis.log"
+  mkdir -p "$t_dir"
+  install_fake_linearis "$bin_dir"
+
+  local out ec
+  out=$(FAKE_LINEARIS_LOG="$log" \
+        FAKE_LINEARIS_ID=TST-101 \
+        PATH="$bin_dir:$PATH" \
+        bash "$target" --title "Test ticket" --team CTL \
+                       --description "body text" 2>&1)
+  ec=$?
+
+  assert_exit "ticket exits 0" "0" "$ec"
+  assert_grep "ticket stdout has identifier" '"identifier":"TST-101"' "$out"
+  assert_grep "ticket stdout status=filed" '"status":"filed"' "$out"
+  assert_grep "ticket stdout has url" '"url":"https://linear.app' "$out"
+
+  local log_content
+  log_content=$(cat "$log" 2>/dev/null || echo "")
+  assert_grep "linearis invoked with issues create" "issues create" "$log_content"
+  assert_grep "linearis resolved team key to UUID before create" \
+    "--team 00000000-0000-0000-0000-000000000001" "$log_content"
+  assert_grep "linearis teams list called to resolve key" \
+    "teams list" "$log_content"
+
+  # Soft-skip path: linearis not on PATH.
+  local skip_out skip_ec
+  skip_out=$(PATH="/usr/bin:/bin" bash "$target" --title X --team CTL 2>&1)
+  skip_ec=$?
+  assert_exit "ticket soft-skip exits 0" "0" "$skip_ec"
+  assert_grep "ticket soft-skip status=skipped" '"status":"skipped"' "$skip_out"
+
+  # Hard-failure path: linearis returns non-zero with stderr; reason should surface.
+  local fail_out fail_ec
+  fail_out=$(FAKE_LINEARIS_LOG="$log" \
+             FAKE_LINEARIS_FAIL_CREATE=1 \
+             FAKE_LINEARIS_FAIL_REASON="auth denied" \
+             PATH="$bin_dir:$PATH" \
+             bash "$target" --title X --team CTL 2>&1)
+  fail_ec=$?
+  assert_exit "ticket failure exits 1" "1" "$fail_ec"
+  assert_grep "ticket failure status=failed" '"status":"failed"' "$fail_out"
+  assert_grep "ticket failure surfaces stderr reason" "auth denied" "$fail_out"
+}
+
+# ─── Test 3: action-orchestrate.sh calls claude headless and returns orch_id ──
+test_action_orchestrate() {
+  echo "test 3: action-orchestrate.sh dispatches orchestrator"
+  local target="$BF_DIR/action-orchestrate.sh"
+  local t_dir="$SCRATCH/t3"
+  local bin_dir="$t_dir/bin"
+  local log="$t_dir/claude.log"
+  mkdir -p "$t_dir"
+  install_fake_claude "$bin_dir"
+
+  local out ec
+  out=$(FAKE_CLAUDE_LOG="$log" \
+        FAKE_CLAUDE_ORCH_ID="orch_test123" \
+        PATH="$bin_dir:$PATH" \
+        bash "$target" --ticket CTL-999 2>&1)
+  ec=$?
+
+  assert_exit "orchestrate exits 0" "0" "$ec"
+  assert_grep "orchestrate stdout has orchestrator_id" \
+    '"orchestrator_id":"orch_test123"' "$out"
+  assert_grep "orchestrate stdout status=dispatched" '"status":"dispatched"' "$out"
+
+  local log_content
+  log_content=$(cat "$log" 2>/dev/null || echo "")
+  assert_grep "claude invoked with -p flag" "-p" "$log_content"
+  assert_grep "claude invoked with orchestrate command" \
+    "/catalyst-dev:orchestrate CTL-999" "$log_content"
+
+  # Soft-skip path: claude not on PATH.
+  local skip_out skip_ec
+  skip_out=$(PATH="/usr/bin:/bin" bash "$target" --ticket CTL-999 2>&1)
+  skip_ec=$?
+  assert_exit "orchestrate soft-skip exits 0" "0" "$skip_ec"
+  assert_grep "orchestrate soft-skip status=skipped" '"status":"skipped"' "$skip_out"
+
+  # Hard-failure path: claude prints no orch_id and exits non-zero.
+  local fail_out fail_ec
+  fail_out=$(FAKE_CLAUDE_LOG="$log" \
+             FAKE_CLAUDE_NO_ORCH=1 \
+             FAKE_CLAUDE_STDERR="permission denied" \
+             PATH="$bin_dir:$PATH" \
+             bash "$target" --ticket CTL-999 2>&1)
+  fail_ec=$?
+  assert_exit "orchestrate failure exits 1" "1" "$fail_ec"
+  assert_grep "orchestrate failure status=failed" '"status":"failed"' "$fail_out"
+  assert_grep "orchestrate failure surfaces stderr reason" "permission denied" "$fail_out"
+}
+
+# ─── Test 4: action-email.sh invokes Gmail drafts ───────────────────────────
+test_action_email() {
+  echo "test 4: action-email.sh invokes Gmail draft-message"
+  local target="$BF_DIR/action-email.sh"
+  local t_dir="$SCRATCH/t4"
+  local bin_dir="$t_dir/bin"
+  local log="$t_dir/curl.log"
+  mkdir -p "$t_dir"
+  install_fake_curl "$bin_dir"
+
+  local out ec
+  out=$(FAKE_CURL_LOG="$log" \
+        FAKE_CURL_RESPONSE='{"id":"draft_xyz","message":{"id":"m_1"}}' \
+        GMAIL_OAUTH_ACCESS_TOKEN=fake \
+        PATH="$bin_dir:$PATH" \
+        bash "$target" --to foo@example.com --subject "Hi" \
+                       --body "test body" 2>&1)
+  ec=$?
+
+  assert_exit "email exits 0" "0" "$ec"
+  assert_grep "email stdout has draft_id" '"draft_id":"draft_xyz"' "$out"
+  assert_grep "email stdout status=drafted" '"status":"drafted"' "$out"
+
+  local log_content
+  log_content=$(cat "$log" 2>/dev/null || echo "")
+  assert_grep "curl invoked with bearer token" "Authorization: Bearer fake" "$log_content"
+  assert_grep "curl invoked against gmail drafts endpoint" \
+    "/gmail/v1/users/me/drafts" "$log_content"
+  # body contains "raw":"..." with base64-encoded message
+  assert_grep "curl body contains raw field" '"raw":' "$log_content"
+
+  # Soft-skip path: no token.
+  local skip_out skip_ec
+  skip_out=$(env -u GMAIL_OAUTH_ACCESS_TOKEN PATH="$bin_dir:$PATH" \
+    bash "$target" --to foo@example.com --subject Hi --body x 2>&1)
+  skip_ec=$?
+  assert_exit "email soft-skip exits 0" "0" "$skip_ec"
+  assert_grep "email soft-skip status=skipped" '"status":"skipped"' "$skip_out"
+}
+
+# ─── Test 5: record-resolution.sh appends to resolutions JSON ───────────────
+test_record_resolution() {
+  echo "test 5: record-resolution.sh appends to resolutions JSON"
+  local target="$BF_DIR/record-resolution.sh"
+  local t_dir="$SCRATCH/t5"
+  mkdir -p "$t_dir"
+
+  local out ec
+  out=$(bash "$target" --log-dir "$t_dir" --date 2026-05-18 \
+        --id dec-1 --action schedule_calendar \
+        --result '{"event_id":"e1","status":"scheduled"}' 2>&1)
+  ec=$?
+  assert_exit "first record exits 0" "0" "$ec"
+
+  local resolutions_file="$t_dir/briefing-followup-2026-05-18-resolutions.json"
+  if [[ -f "$resolutions_file" ]]; then
+    pass "resolutions file created"
+  else
+    fail "resolutions file created" "expected at $resolutions_file"
+    return
+  fi
+
+  local len id action event_id
+  len=$(jq 'length' "$resolutions_file")
+  assert_eq "resolutions array length after 1 record" "1" "$len"
+
+  id=$(jq -r '.[0].decision_id' "$resolutions_file")
+  assert_eq "first decision_id" "dec-1" "$id"
+
+  action=$(jq -r '.[0].action' "$resolutions_file")
+  assert_eq "first action" "schedule_calendar" "$action"
+
+  event_id=$(jq -r '.[0].result.event_id' "$resolutions_file")
+  assert_eq "first result.event_id" "e1" "$event_id"
+
+  # Timestamp present and ISO 8601 (UTC Z).
+  local ts
+  ts=$(jq -r '.[0].timestamp' "$resolutions_file")
+  if [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    pass "timestamp matches ISO 8601 UTC"
+  else
+    fail "timestamp matches ISO 8601 UTC" "actual: $ts"
+  fi
+
+  # Append a second resolution.
+  bash "$target" --log-dir "$t_dir" --date 2026-05-18 \
+    --id dec-2 --action file_ticket \
+    --result '{"identifier":"CTL-1000","status":"filed"}' >/dev/null
+
+  len=$(jq 'length' "$resolutions_file")
+  assert_eq "resolutions array length after 2 records" "2" "$len"
+
+  id=$(jq -r '.[1].decision_id' "$resolutions_file")
+  assert_eq "second decision_id" "dec-2" "$id"
+
+  # Malformed existing resolutions file: should exit 2 rather than overwrite.
+  local m_dir="$SCRATCH/t5-malformed"
+  mkdir -p "$m_dir"
+  echo "not json" > "$m_dir/briefing-followup-2026-05-18-resolutions.json"
+  local mal_ec
+  bash "$target" --log-dir "$m_dir" --date 2026-05-18 \
+    --id dec-x --action approve --result '{}' >/dev/null 2>&1
+  mal_ec=$?
+  assert_exit "malformed existing file exits 2" "2" "$mal_ec"
+  # And the original malformed file should be untouched.
+  local content
+  content=$(cat "$m_dir/briefing-followup-2026-05-18-resolutions.json")
+  assert_eq "malformed file untouched" "not json" "$content"
+
+  # Invalid --result JSON: should exit 2 (validates input shape).
+  local bad_ec
+  bash "$target" --log-dir "$SCRATCH/t5" --date 2026-05-18 \
+    --id dec-y --action approve --result 'not-json' >/dev/null 2>&1
+  bad_ec=$?
+  assert_exit "invalid --result JSON exits 2" "2" "$bad_ec"
+}
+
+# ─── Test 6: SKILL.md frontmatter still valid (no regression) ───────────────
+test_skill_md_frontmatter() {
+  echo "test 6: SKILL.md frontmatter is intact"
+  if [[ ! -f "$SKILL_MD" ]]; then
+    fail "SKILL.md exists at $SKILL_MD" "file missing"
+    return
+  fi
+  local fm
+  fm=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$SKILL_MD")
+  assert_grep "frontmatter has name" "name: briefing-followup" "$fm"
+  assert_grep "frontmatter has disable-model-invocation" \
+    "disable-model-invocation: true" "$fm"
+  assert_grep "frontmatter has user-invocable" "user-invocable: true" "$fm"
+  assert_grep "frontmatter allows Bash" "Bash" "$fm"
+}
+
+test_action_schedule
+test_action_ticket
+test_action_orchestrate
+test_action_email
+test_record_resolution
+test_skill_md_frontmatter
+
+echo "─────────────────────────────────────"
+echo "PASSED: $PASSES"
+echo "FAILED: $FAILURES"
+echo "─────────────────────────────────────"
+exit $(( FAILURES > 0 ? 1 : 0 ))

--- a/plugins/dev/scripts/briefing-followup/action-email.sh
+++ b/plugins/dev/scripts/briefing-followup/action-email.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# action-email.sh — Create a Gmail draft message.
+#
+# Usage:
+#   action-email.sh --to ADDR --subject S [--body B] [--from FROM] [--cc ADDR] [--bcc ADDR]
+#
+# Output (stdout, JSON one-liner):
+#   {"draft_id":"...","status":"drafted"}
+# or on soft-skip:
+#   {"status":"skipped","reason":"..."}
+#
+# Soft-skip when GMAIL_OAUTH_ACCESS_TOKEN is unset (Gmail scope is distinct
+# from Calendar/Drive — see cma/mcp/gmail.md) or curl is missing.
+
+set -uo pipefail
+
+TO=""
+SUBJECT=""
+BODY=""
+FROM=""
+CC=""
+BCC=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --to)       TO="$2"; shift 2 ;;
+    --subject)  SUBJECT="$2"; shift 2 ;;
+    --body)     BODY="$2"; shift 2 ;;
+    --from)     FROM="$2"; shift 2 ;;
+    --cc)       CC="$2"; shift 2 ;;
+    --bcc)      BCC="$2"; shift 2 ;;
+    -h|--help)  sed -n '2,15p' "$0"; exit 0 ;;
+    *) echo "action-email.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TO" || -z "$SUBJECT" ]]; then
+  echo "action-email.sh: --to and --subject are required" >&2
+  exit 2
+fi
+
+if [[ -z "${GMAIL_OAUTH_ACCESS_TOKEN:-}" ]]; then
+  jq -nc --arg reason "GMAIL_OAUTH_ACCESS_TOKEN not set (see cma/mcp/gmail.md)" \
+    '{status: "skipped", reason: $reason}'
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  jq -nc --arg reason "curl not on PATH" \
+    '{status: "skipped", reason: $reason}'
+  exit 0
+fi
+
+# Build RFC 2822 message and base64url-encode it.
+build_message() {
+  printf 'To: %s\r\n' "$TO"
+  [[ -n "$FROM" ]] && printf 'From: %s\r\n' "$FROM"
+  [[ -n "$CC"   ]] && printf 'Cc: %s\r\n' "$CC"
+  [[ -n "$BCC"  ]] && printf 'Bcc: %s\r\n' "$BCC"
+  printf 'Subject: %s\r\n' "$SUBJECT"
+  printf 'Content-Type: text/plain; charset=UTF-8\r\n'
+  printf '\r\n'
+  printf '%s' "$BODY"
+}
+
+RAW=$(build_message | python3 -c '
+import sys, base64
+data = sys.stdin.buffer.read()
+sys.stdout.write(base64.urlsafe_b64encode(data).decode("ascii").rstrip("="))
+' 2>/dev/null || echo "")
+
+if [[ -z "$RAW" ]]; then
+  jq -nc --arg reason "failed to encode message body" \
+    '{status: "failed", reason: $reason}'
+  exit 1
+fi
+
+BODY_JSON=$(jq -nc --arg raw "$RAW" '{message: {raw: $raw}}')
+
+STDERR_FILE=$(mktemp -t action-email-stderr.XXXXXX)
+RESP=$(printf '%s' "$BODY_JSON" | curl -fsSL --max-time 15 \
+  -H "Authorization: Bearer ${GMAIL_OAUTH_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data-binary @- \
+  "https://gmail.googleapis.com/gmail/v1/users/me/drafts" \
+  2>"$STDERR_FILE")
+CURL_EXIT=$?
+STDERR_TAIL=$(tail -c 500 "$STDERR_FILE" 2>/dev/null || echo "")
+rm -f "$STDERR_FILE"
+
+DRAFT_ID=$(echo "$RESP" | jq -r '.id // empty' 2>/dev/null || echo "")
+
+if [[ -z "$DRAFT_ID" ]]; then
+  REASON="Gmail drafts API returned no id (curl exit=$CURL_EXIT)"
+  [[ -n "$STDERR_TAIL" ]] && REASON="${REASON}: ${STDERR_TAIL}"
+  jq -nc --arg reason "$REASON" '{status: "failed", reason: $reason}'
+  exit 1
+fi
+
+jq -nc --arg id "$DRAFT_ID" '{draft_id: $id, status: "drafted"}'

--- a/plugins/dev/scripts/briefing-followup/action-orchestrate.sh
+++ b/plugins/dev/scripts/briefing-followup/action-orchestrate.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# action-orchestrate.sh — Dispatch a /catalyst-dev:orchestrate run for a ticket.
+#
+# Usage:
+#   action-orchestrate.sh --ticket TICKET-ID [--bg] [--worker-args ARGS]
+#
+# Modes:
+#   default — synchronous: invoke `claude -p /catalyst-dev:orchestrate TICKET`,
+#             parse stdout for an orch_<...> identifier.
+#   --bg    — background: nohup ... & with stdout redirected to a log file
+#             we tail briefly for the orch_id.
+#
+# Output (stdout, JSON one-liner):
+#   {"orchestrator_id":"orch_abc123","status":"dispatched"}
+# or on soft-skip:
+#   {"status":"skipped","reason":"..."}
+#
+# Soft-skip when the claude CLI (or CATALYST_DISPATCH_CLAUDE_BIN override) is
+# not on PATH.
+
+set -uo pipefail
+
+TICKET=""
+BG=0
+WORKER_ARGS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ticket)       TICKET="$2"; shift 2 ;;
+    --bg)           BG=1; shift ;;
+    --worker-args)  WORKER_ARGS="$2"; shift 2 ;;
+    -h|--help)      sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "action-orchestrate.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TICKET" ]]; then
+  echo "action-orchestrate.sh: --ticket is required" >&2
+  exit 2
+fi
+
+CLAUDE_BIN="${CATALYST_DISPATCH_CLAUDE_BIN:-claude}"
+if ! command -v "$CLAUDE_BIN" >/dev/null 2>&1; then
+  jq -nc --arg reason "$CLAUDE_BIN not on PATH" \
+    '{status: "skipped", reason: $reason}'
+  exit 0
+fi
+
+COMMAND="/catalyst-dev:orchestrate $TICKET"
+[[ -n "$WORKER_ARGS" ]] && COMMAND="$COMMAND $WORKER_ARGS"
+
+extract_orch_id() {
+  # Match orch_<id> in input; the dispatch helpers print this on success.
+  grep -oE 'orch_[a-zA-Z0-9_]+' "$@" 2>/dev/null | head -n1
+}
+
+if [[ "$BG" -eq 1 ]]; then
+  LOG_DIR="${TMPDIR:-/tmp}/catalyst-briefing-followup"
+  mkdir -p "$LOG_DIR"
+  LOG_FILE="$LOG_DIR/orchestrate-$TICKET-$(date -u +%Y%m%dT%H%M%SZ).log"
+  nohup "$CLAUDE_BIN" -p "$COMMAND" --dangerously-skip-permissions \
+    > "$LOG_FILE" 2>&1 </dev/null &
+  BG_PID=$!
+  # Briefly poll for the orch id — orchestrator dispatch typically prints it
+  # within the first second or two.
+  ORCH_ID=""
+  for _ in 1 2 3 4 5; do
+    sleep 1
+    ORCH_ID=$(extract_orch_id "$LOG_FILE")
+    [[ -n "$ORCH_ID" ]] && break
+  done
+  if [[ -z "$ORCH_ID" ]]; then
+    jq -nc --arg pid "$BG_PID" --arg log "$LOG_FILE" \
+      '{status: "dispatched-async", pid: $pid, log: $log}'
+    exit 0
+  fi
+  jq -nc --arg id "$ORCH_ID" --arg pid "$BG_PID" --arg log "$LOG_FILE" \
+    '{orchestrator_id: $id, pid: $pid, log: $log, status: "dispatched"}'
+  exit 0
+fi
+
+# Synchronous dispatch — capture stdout AND stderr so failure reasons surface.
+STDERR_FILE=$(mktemp -t action-orchestrate-stderr.XXXXXX)
+OUT=$("$CLAUDE_BIN" -p "$COMMAND" --dangerously-skip-permissions 2>"$STDERR_FILE")
+EXIT_CODE=$?
+STDERR_TAIL=$(tail -c 500 "$STDERR_FILE" 2>/dev/null || echo "")
+rm -f "$STDERR_FILE"
+
+ORCH_ID=$(printf '%s' "$OUT" | grep -oE 'orch_[a-zA-Z0-9_]+' | head -n1)
+
+if [[ -z "$ORCH_ID" ]]; then
+  REASON="no orch_id found in claude output (exit=$EXIT_CODE)"
+  [[ -n "$STDERR_TAIL" ]] && REASON="${REASON}: ${STDERR_TAIL}"
+  jq -nc --arg reason "$REASON" '{status: "failed", reason: $reason}'
+  exit 1
+fi
+
+jq -nc --arg id "$ORCH_ID" '{orchestrator_id: $id, status: "dispatched"}'

--- a/plugins/dev/scripts/briefing-followup/action-schedule.sh
+++ b/plugins/dev/scripts/briefing-followup/action-schedule.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# action-schedule.sh — Schedule a Google Calendar event.
+#
+# Usage:
+#   action-schedule.sh --title T --start ISO8601 --end ISO8601 \
+#     [--description D] [--calendar-id ID] [--location L]
+#
+# Output (stdout, JSON one-liner):
+#   {"event_id":"...","html_link":"...","status":"scheduled"}
+# or on soft-skip:
+#   {"status":"skipped","reason":"..."}
+#
+# Soft-skip when GOOGLE_OAUTH_ACCESS_TOKEN is unset or curl is missing.
+# See cma/mcp/google-calendar.md for OAuth setup.
+
+set -uo pipefail
+
+TITLE=""
+START=""
+END=""
+DESCRIPTION=""
+CAL_ID="${GOOGLE_CALENDAR_ID:-primary}"
+LOCATION=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)        TITLE="$2"; shift 2 ;;
+    --start)        START="$2"; shift 2 ;;
+    --end)          END="$2"; shift 2 ;;
+    --description)  DESCRIPTION="$2"; shift 2 ;;
+    --calendar-id)  CAL_ID="$2"; shift 2 ;;
+    --location)     LOCATION="$2"; shift 2 ;;
+    -h|--help)      sed -n '2,15p' "$0"; exit 0 ;;
+    *) echo "action-schedule.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TITLE" || -z "$START" || -z "$END" ]]; then
+  echo "action-schedule.sh: --title, --start, and --end are required" >&2
+  exit 2
+fi
+
+if [[ -z "${GOOGLE_OAUTH_ACCESS_TOKEN:-}" ]]; then
+  jq -nc --arg reason "GOOGLE_OAUTH_ACCESS_TOKEN not set (see cma/mcp/google-calendar.md)" \
+    '{status: "skipped", reason: $reason}'
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  jq -nc --arg reason "curl not on PATH" \
+    '{status: "skipped", reason: $reason}'
+  exit 0
+fi
+
+ENCODED_CAL=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' \
+  "$CAL_ID" 2>/dev/null || echo "primary")
+
+# Build event body. `--argjson` would require pre-quoted values; --arg + jq
+# string interpolation is safer for free-form titles/descriptions.
+BODY=$(jq -nc \
+  --arg summary "$TITLE" \
+  --arg description "$DESCRIPTION" \
+  --arg start "$START" \
+  --arg end "$END" \
+  --arg location "$LOCATION" \
+  '{summary: $summary,
+    start: {dateTime: $start},
+    end: {dateTime: $end}}
+   | (if $description != "" then .description = $description else . end)
+   | (if $location != "" then .location = $location else . end)')
+
+STDERR_FILE=$(mktemp -t action-schedule-stderr.XXXXXX)
+RESP=$(printf '%s' "$BODY" | curl -fsSL --max-time 15 \
+  -H "Authorization: Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data-binary @- \
+  "https://www.googleapis.com/calendar/v3/calendars/${ENCODED_CAL}/events" \
+  2>"$STDERR_FILE")
+CURL_EXIT=$?
+STDERR_TAIL=$(tail -c 500 "$STDERR_FILE" 2>/dev/null || echo "")
+rm -f "$STDERR_FILE"
+
+EVENT_ID=$(echo "$RESP" | jq -r '.id // empty' 2>/dev/null || echo "")
+HTML_LINK=$(echo "$RESP" | jq -r '.htmlLink // empty' 2>/dev/null || echo "")
+
+if [[ -z "$EVENT_ID" ]]; then
+  REASON="Calendar create-event returned no id (curl exit=$CURL_EXIT)"
+  [[ -n "$STDERR_TAIL" ]] && REASON="${REASON}: ${STDERR_TAIL}"
+  jq -nc --arg reason "$REASON" '{status: "failed", reason: $reason}'
+  exit 1
+fi
+
+jq -nc --arg id "$EVENT_ID" --arg link "$HTML_LINK" \
+  '{event_id: $id, html_link: $link, status: "scheduled"}'

--- a/plugins/dev/scripts/briefing-followup/action-ticket.sh
+++ b/plugins/dev/scripts/briefing-followup/action-ticket.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# action-ticket.sh — File a Linear ticket via linearis issues create.
+#
+# Usage:
+#   action-ticket.sh --title T --team K [--description D] [--priority N] [--project P]
+#
+# Output (stdout, JSON one-liner):
+#   {"identifier":"CTL-1000","url":"https://linear.app/...","status":"filed"}
+# or on soft-skip:
+#   {"status":"skipped","reason":"..."}
+#
+# Soft-skip when `linearis` is not on PATH.
+# See plugins/dev/skills/linearis/SKILL.md for the canonical create syntax.
+
+set -uo pipefail
+
+TITLE=""
+TEAM=""
+DESCRIPTION=""
+PRIORITY=""
+PROJECT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)        TITLE="$2"; shift 2 ;;
+    --team)         TEAM="$2"; shift 2 ;;
+    --description)  DESCRIPTION="$2"; shift 2 ;;
+    --priority)     PRIORITY="$2"; shift 2 ;;
+    --project)      PROJECT="$2"; shift 2 ;;
+    -h|--help)      sed -n '2,15p' "$0"; exit 0 ;;
+    *) echo "action-ticket.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TITLE" || -z "$TEAM" ]]; then
+  echo "action-ticket.sh: --title and --team are required" >&2
+  exit 2
+fi
+
+if ! command -v linearis >/dev/null 2>&1; then
+  jq -nc --arg reason "linearis not on PATH" \
+    '{status: "skipped", reason: $reason}'
+  exit 0
+fi
+
+# linearis upstream bug czottmann/linearis#56: `issues create` silently routes
+# to the workspace default team when --team is a key/name instead of a UUID.
+# Resolve key → UUID up front when it looks like a key (not a UUID).
+RESOLVED_TEAM="$TEAM"
+if ! [[ "$TEAM" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+  TEAMS_JSON=$(linearis teams list 2>/dev/null || true)
+  CANDIDATE=$(echo "$TEAMS_JSON" \
+    | jq -r --arg k "$TEAM" \
+        '.[]? | select(.key == $k or .name == $k) | .id' 2>/dev/null \
+    | head -n1)
+  if [[ -n "$CANDIDATE" ]]; then
+    RESOLVED_TEAM="$CANDIDATE"
+  fi
+fi
+
+ARGS=( issues create "$TITLE" --team "$RESOLVED_TEAM" )
+[[ -n "$DESCRIPTION" ]] && ARGS+=( --description "$DESCRIPTION" )
+[[ -n "$PRIORITY"    ]] && ARGS+=( --priority "$PRIORITY" )
+[[ -n "$PROJECT"     ]] && ARGS+=( --project "$PROJECT" )
+
+STDERR_FILE=$(mktemp -t action-ticket-stderr.XXXXXX)
+CREATE_JSON=$(linearis "${ARGS[@]}" 2>"$STDERR_FILE")
+EXIT_CODE=$?
+STDERR_TAIL=$(tail -c 500 "$STDERR_FILE" 2>/dev/null || echo "")
+rm -f "$STDERR_FILE"
+
+IDENT=$(echo "$CREATE_JSON" | jq -r '.identifier // empty' 2>/dev/null || echo "")
+URL=$(echo "$CREATE_JSON" | jq -r '.url // empty' 2>/dev/null || echo "")
+
+if [[ -z "$IDENT" ]]; then
+  REASON="linearis issues create returned no identifier (exit=$EXIT_CODE)"
+  [[ -n "$STDERR_TAIL" ]] && REASON="${REASON}: ${STDERR_TAIL}"
+  jq -nc --arg reason "$REASON" '{status: "failed", reason: $reason}'
+  exit 1
+fi
+
+jq -nc --arg id "$IDENT" --arg url "$URL" \
+  '{identifier: $id, url: $url, status: "filed"}'

--- a/plugins/dev/scripts/briefing-followup/record-resolution.sh
+++ b/plugins/dev/scripts/briefing-followup/record-resolution.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# record-resolution.sh — Append a resolution record to the day's
+# briefing-followup resolutions JSON. Phase 4 (CTL-465) reads this file to
+# write the resolutions: block back to the briefing markdown frontmatter.
+#
+# Usage:
+#   record-resolution.sh --log-dir DIR --date YYYY-MM-DD \
+#     --id DECISION_ID --action ACTION_NAME --result JSON
+#
+# Resolution shape (one element per call):
+#   {
+#     "decision_id": "dec-1",
+#     "action": "schedule_calendar",
+#     "timestamp": "2026-05-17T20:30:00Z",
+#     "result": { ... }
+#   }
+#
+# Writes (creates if missing) a JSON array at:
+#   $LOG_DIR/briefing-followup-$DATE-resolutions.json
+
+set -uo pipefail
+
+LOG_DIR=""
+DATE=""
+DEC_ID=""
+ACTION=""
+RESULT_JSON=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log-dir)   LOG_DIR="$2"; shift 2 ;;
+    --date)      DATE="$2"; shift 2 ;;
+    --id)        DEC_ID="$2"; shift 2 ;;
+    --action)    ACTION="$2"; shift 2 ;;
+    --result)    RESULT_JSON="$2"; shift 2 ;;
+    -h|--help)   sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "record-resolution.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+for required in LOG_DIR DATE DEC_ID ACTION RESULT_JSON; do
+  if [[ -z "${!required}" ]]; then
+    echo "record-resolution.sh: --${required,,} is required" >&2
+    exit 2
+  fi
+done
+
+# Validate that RESULT_JSON is valid JSON. Empty objects are allowed.
+if ! echo "$RESULT_JSON" | jq empty >/dev/null 2>&1; then
+  echo "record-resolution.sh: --result is not valid JSON" >&2
+  exit 2
+fi
+
+mkdir -p "$LOG_DIR"
+FILE="$LOG_DIR/briefing-followup-$DATE-resolutions.json"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+NEW_ENTRY=$(jq -nc \
+  --arg id "$DEC_ID" \
+  --arg action "$ACTION" \
+  --arg ts "$TIMESTAMP" \
+  --argjson result "$RESULT_JSON" \
+  '{decision_id: $id, action: $action, timestamp: $ts, result: $result}')
+
+if [[ -f "$FILE" ]]; then
+  # Append to existing array. If the file is malformed, fail loudly rather than
+  # overwriting prior records silently.
+  if ! UPDATED=$(jq --argjson entry "$NEW_ENTRY" '. + [$entry]' "$FILE" 2>/dev/null); then
+    echo "record-resolution.sh: existing resolutions file is malformed: $FILE" >&2
+    exit 2
+  fi
+  printf '%s\n' "$UPDATED" > "$FILE"
+else
+  printf '%s\n' "[$NEW_ENTRY]" | jq '.' > "$FILE"
+fi

--- a/plugins/dev/skills/briefing-followup/SKILL.md
+++ b/plugins/dev/skills/briefing-followup/SKILL.md
@@ -3,10 +3,11 @@ name: briefing-followup
 description:
   Interactive walk-through of today's morning briefing. Loads the briefing markdown at
   thoughts/briefings/YYYY-MM-DD.md (built by [[morning-briefing]]), parses the structured
-  decisions: frontmatter, and walks the user through each open decision one at a time with
-  placeholder Approve / Reject / Defer actions. Phase 1 MVP — Phase 2 wires real action
-  handlers (calendar / ticket / orchestrator / email); Phase 4 writes resolutions back to
-  the briefing markdown.
+  decisions: frontmatter, walks the user through each open decision, and executes the
+  selected action via supported handlers — schedule calendar entry, file Linear ticket,
+  dispatch orchestrator, draft email. Phase 2 wires the real action handlers; Phase 3
+  (CTL-464) wires ADR-drift-specific actions; Phase 4 (CTL-465) writes resolutions back
+  to the briefing markdown.
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Task, mcp__*
@@ -18,9 +19,10 @@ allowed-tools: Read, Write, Edit, Bash, Task, mcp__*
 
 Invoke as `/catalyst-dev:briefing-followup` after `/catalyst-dev:morning-briefing` has
 produced today's briefing. The skill reads that briefing's `decisions:` block and walks
-the user through each open decision in turn. Phase 1 surfaces placeholder actions; the
-real action handlers ship in Phase 2 ([[2026-05-16-catalyst-phase-agent-architecture]]
-§Initiative 3 Phase 2).
+the user through each open decision in turn. Phase 2 wires the real action handlers
+listed below; ADR-drift-specific actions ship in Phase 3 (CTL-464) and resolution
+write-back to the briefing markdown ships in Phase 4 (CTL-465). See
+[[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 3 Phase 2.
 
 ## Flags
 
@@ -80,13 +82,15 @@ fi
 echo "$DECISION_COUNT open decision(s) to walk through."
 ```
 
-## Step 3: Decision-update placeholder log
+## Step 3: Resolve log dir + resolution recorder
 
 Resolve the log path before the loop. Inside an orchestrator dispatch
 (`$CATALYST_ORCHESTRATOR_DIR` is set), prefer the orchestrator's run directory so the
 record lands next to other worker artifacts; otherwise fall back to `/tmp` for local
-runs. Phase 4 of the parent plan replaces this placeholder with a real `resolutions:`
-write-back to the briefing markdown.
+runs. Phase 4 (CTL-465) of the parent plan replaces the placeholder log with a real
+`resolutions:` write-back to the briefing markdown; for now the recorder writes both
+a TSV log (Phase 1 contract) and a structured JSON file (Phase 2 contract that Phase 4
+will consume).
 
 ```bash
 if [[ -n "${CATALYST_ORCHESTRATOR_DIR:-}" ]]; then
@@ -104,14 +108,22 @@ log_response() {
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$id" "$action" "$note" \
     >> "$LOG_FILE"
 }
+
+# Structured resolution recorder — appends to a JSON array consumed by Phase 4.
+# Call after a successful action with the action name and the action's JSON output.
+record_resolution() {
+  local id="$1" action="$2" result_json="${3:-{\}}"
+  bash "$SCRIPT_DIR/record-resolution.sh" \
+    --log-dir "$LOG_DIR" --date "$DATE" \
+    --id "$id" --action "$action" --result "$result_json"
+}
 ```
 
 ## Step 4: Loop over decisions
 
-For each open decision, present the details + the placeholder action set. In Phase 1
-the action handlers are inert — they record the user's choice and continue. Phase 2
-wires real handlers ([[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 3
-Phase 2).
+For each open decision, present the details and the action set filtered by decision
+type. The action handlers live in sibling scripts and each emit a one-line JSON result
+on stdout; the skill captures that JSON and feeds it to `record_resolution`.
 
 ```bash
 DECISIONS_JSON=$(bash "$SCRIPT_DIR/parse-briefing.sh" decisions "$@")
@@ -137,25 +149,73 @@ echo "$DECISIONS_JSON" | jq -c '.[]' | while IFS= read -r dec; do
   [[ -n "$TICKET" ]] && echo "ticket:  $TICKET"
   [[ -n "$ADR"    ]] && echo "adr:     $ADR"
   echo
-  echo "Actions: [a]pprove · [r]eject · [d]efer · [s]kip · [q]uit"
+
+  case "$TYPE" in
+    blocked_pr)
+      echo "Actions: [a]pprove · [r]eject · [d]efer · [o]rchestrate · [s]kip · [q]uit"
+      ;;
+    adr_drift)
+      echo "Actions: [d]efer · [s]kip · [q]uit  (Phase 3 / CTL-464 will wire ADR actions)"
+      ;;
+    *)
+      echo "Actions: [a]pprove · [r]eject · [d]efer · [c]alendar · [t]icket · [o]rchestrate · [e]mail · [s]kip · [q]uit"
+      ;;
+  esac
 done
 ```
 
 When this skill runs in an interactive Claude Code session, present each decision as
-above and use the model to interpret the user's natural-language response. Map common
-intents to the placeholder actions:
+above and use the model to interpret the user's natural-language response. Map intents
+to action handlers as follows:
 
-| User says... | Action |
-|---|---|
-| approve / accept / yes / ship it | `approve` → `log_response "$ID" approve` |
-| reject / no / dismiss | `reject` → `log_response "$ID" reject` |
-| defer / later / skip for today | `defer`  → `log_response "$ID" defer` |
+| User intent | Handler | Captures resolution? |
+|---|---|---|
+| approve / accept / yes / ship it | `log_response "$ID" approve "$NOTE"` | TSV log only |
+| reject / no / dismiss | `log_response "$ID" reject "$NOTE"` | TSV log only |
+| defer / later / skip for today | `log_response "$ID" defer "$NOTE"` | TSV log only |
+| schedule meeting / book time / put on calendar | `action-schedule.sh` → `record_resolution "$ID" schedule_calendar "$JSON"` | TSV + JSON |
+| file a ticket / open Linear issue | `action-ticket.sh` → `record_resolution "$ID" file_ticket "$JSON"` | TSV + JSON |
+| dispatch orchestrator / kick off the work / run oneshot | `action-orchestrate.sh --bg` → `record_resolution "$ID" dispatch_orchestrator "$JSON"` | TSV + JSON |
+| draft email / send a note to X / message Y | `action-email.sh` → `record_resolution "$ID" draft_email "$JSON"` | TSV + JSON |
 | skip | move on without logging |
 | quit / stop / done | break out of the loop |
 
-After each decision the user resolves, call `log_response` with the action and any free-form
-note the user provided. Continue to the next decision until the queue is empty or the user
-quits.
+### Invoking an external action
+
+When the user picks a real action handler, call the corresponding script and pass any
+context the user supplied. Each handler emits one JSON line on stdout — capture it,
+display the relevant field to the user, then call `record_resolution` so Phase 4 can
+write it back to the briefing markdown.
+
+```bash
+# Example — schedule_calendar from a judgment_call decision:
+RESULT=$(bash "$SCRIPT_DIR/action-schedule.sh" \
+  --title "$EVENT_TITLE" \
+  --start "$START_ISO8601" \
+  --end "$END_ISO8601" \
+  --description "$EVENT_DESCRIPTION")
+
+STATUS=$(echo "$RESULT" | jq -r '.status')
+case "$STATUS" in
+  scheduled) echo "Scheduled — $(echo "$RESULT" | jq -r '.html_link')" ;;
+  skipped)   echo "Skipped: $(echo "$RESULT" | jq -r '.reason')" ;;
+  *)         echo "Failed: $(echo "$RESULT" | jq -r '.reason // "unknown"')" ;;
+esac
+record_resolution "$ID" schedule_calendar "$RESULT"
+log_response "$ID" schedule_calendar "$STATUS"
+```
+
+The same pattern applies to `action-ticket.sh`, `action-orchestrate.sh`, and
+`action-email.sh` — only the script name and the action label change. All four handlers
+soft-skip cleanly when their underlying tool is missing or unauthenticated; the
+returned `{"status": "skipped", "reason": "..."}` JSON is captured the same way as a
+success result so the resolution log faithfully records what happened.
+
+### Free-form note capture
+
+Per-decision the user may attach a one-line note (e.g., why they rejected, what the
+calendar event is for). Pass it as the third argument to `log_response` and, when
+relevant, as `--description` / `--body` to the action handler.
 
 ## Step 5: End session
 
@@ -170,15 +230,49 @@ echo "Logged $(wc -l < "$LOG_FILE" | tr -d ' ') response(s) to $LOG_FILE"
 
 - **Input**: `thoughts/briefings/YYYY-MM-DD.md` produced by [[morning-briefing]],
   validated against `plugins/dev/templates/briefing-frontmatter.schema.json`.
-- **Output (Phase 1)**: a scratch log at `$CATALYST_ORCHESTRATOR_DIR/briefing-followup-<date>.log`
-  (or `/tmp/briefing-followup-<date>.log` outside orchestrator mode), one TSV line per
-  resolved decision: `<utc-timestamp>\t<id>\t<action>\t<note>`. Phase 4 of the parent
-  plan rewrites this as a `resolutions:` block on the briefing markdown frontmatter.
+- **Output (Phase 1, retained)**: a scratch log at
+  `$CATALYST_ORCHESTRATOR_DIR/briefing-followup-<date>.log` (or `/tmp/...` outside
+  orchestrator mode), one TSV line per resolved decision:
+  `<utc-timestamp>\t<id>\t<action>\t<note>`.
+- **Output (Phase 2, new)**: a structured JSON array at
+  `$LOG_DIR/briefing-followup-<date>-resolutions.json`, one entry per resolution that
+  invoked an action handler. Each entry is
+  `{decision_id, action, timestamp, result}` where `result` is the JSON the handler
+  returned. Phase 4 (CTL-465) reads this file to write the `resolutions:` block back
+  to the briefing markdown frontmatter.
 
-## Phase 1 scope (this ticket)
+## Action handlers (Phase 2 — CTL-463)
 
-Per [[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 3 Phase 1 (CTL-462):
-load briefing, parse decisions, walk the user through each one with placeholder
-actions. **Action handlers ship in Phase 2 (CTL-463)** — schedule calendar entry, file
-Linear ticket, dispatch orchestrator, draft email. ADR-drift resolution is its own
-Phase 3 (CTL-464). Resolution write-back to the briefing is Phase 4 (CTL-465).
+Per [[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 3 Phase 2, the
+following sibling scripts implement the supported actions. Each emits one JSON line on
+stdout and exits 0 on success or soft-skip (`{"status": "skipped", "reason": "..."}`);
+non-zero exit indicates a hard failure (handler reached but the underlying API
+returned no usable result).
+
+| Action | Script | Output JSON (success) | Soft-skip trigger |
+|---|---|---|---|
+| Schedule a calendar event | `action-schedule.sh` | `{event_id, html_link, status: "scheduled"}` | `GOOGLE_OAUTH_ACCESS_TOKEN` unset |
+| File a Linear ticket | `action-ticket.sh` | `{identifier, url, status: "filed"}` | `linearis` not on PATH |
+| Dispatch orchestrator | `action-orchestrate.sh` | `{orchestrator_id, status: "dispatched"}` | `claude` (or `$CATALYST_DISPATCH_CLAUDE_BIN`) not on PATH |
+| Draft an email | `action-email.sh` | `{draft_id, status: "drafted"}` | `GMAIL_OAUTH_ACCESS_TOKEN` unset |
+
+See `cma/mcp/google-calendar.md` and `cma/mcp/gmail.md` for the OAuth setup required
+to bypass the calendar / email soft-skip paths. Linear and orchestrator handlers
+require no extra setup beyond having `linearis` / `claude` on PATH (the standard local
+dev environment provides both).
+
+Each handler accepts `--help` to print its flag set. The skill captures the JSON,
+surfaces the relevant field to the user, then calls `record_resolution "$ID" <action>
+"$JSON"` so the result lands in the resolutions JSON file for Phase 4 write-back.
+
+## Phase scope summary
+
+- **Phase 1 (CTL-462, done)**: load briefing, parse decisions, walk user through with
+  placeholder Approve / Reject / Defer.
+- **Phase 2 (CTL-463, this skill version)**: action handlers — schedule calendar, file
+  Linear ticket, dispatch orchestrator, draft email.
+- **Phase 3 (CTL-464, planned)**: ADR-drift resolution — Update ADR / Update code /
+  Defer per the parent plan.
+- **Phase 4 (CTL-465, planned)**: resolutions write-back from the JSON file to the
+  briefing markdown frontmatter `resolutions:` block.
+- **Phase 5 (CTL-466, planned)**: end-to-end real-briefing review session.


### PR DESCRIPTION
## Summary

Phase 2 of Initiative 3 (briefing-followup skill, parent CTL-445). Wires the 5
supported actions into the skill's decision loop so the user can resolve each
briefing decision with a real side effect:

| Action | Handler script | Soft-skip trigger |
|---|---|---|
| Schedule calendar event | `action-schedule.sh` | `GOOGLE_OAUTH_ACCESS_TOKEN` unset |
| File Linear ticket | `action-ticket.sh` | `linearis` not on PATH |
| Dispatch orchestrator | `action-orchestrate.sh` | `claude` not on PATH |
| Draft email | `action-email.sh` | `GMAIL_OAUTH_ACCESS_TOKEN` unset |

Each handler emits one JSON line on stdout (`{"status": "scheduled" \| "filed" \| "dispatched" \| "drafted" \| "skipped" \| "failed", ...}`) and exits 0 on success or soft-skip; non-zero exit signals a hard failure with the actual stderr surfaced in the reason field. Resolutions are appended to `$LOG_DIR/briefing-followup-<date>-resolutions.json` for Phase 4 (CTL-465) to consume.

## Key design choices

- **Linear team key → UUID resolution.** `linearis issues create` silently
  falls back to the workspace default team when `--team` is a key rather than
  a UUID (upstream bug czottmann/linearis#56). `action-ticket.sh` calls
  `linearis teams list` first and resolves the key before passing the UUID
  to create.
- **stderr capture.** Each handler captures stderr to a tempfile and includes
  a 500-char tail in the failure-reason JSON, so the user sees the real cause
  (auth denied / 403 / network) instead of a generic "no id".
- **Distinct Gmail token.** `GMAIL_OAUTH_ACCESS_TOKEN` is read separately from
  `GOOGLE_OAUTH_ACCESS_TOKEN` because the `gmail.compose` scope is distinct
  from the Calendar/Drive scopes. New `cma/mcp/gmail.md` documents the
  OAuth setup.
- **SKILL.md action-by-decision-type table.** `blocked_pr` decisions surface
  orchestrate; `adr_drift` decisions defer to Phase 3 (CTL-464) with a
  placeholder message; everything else gets the full action set.
- **TDD.** 57 assertions in `briefing-followup-actions.test.sh` — each handler
  has happy-path, soft-skip-path, and hard-failure-path coverage. The recorder
  also covers malformed-existing-file and invalid-JSON input.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/briefing-followup-actions.test.sh` (57/57 pass)
- [x] `bash plugins/dev/scripts/__tests__/briefing-followup-load.test.sh` — no regression (31/31 pass)
- [x] Shell-injection probe: `\$(...)`, backticks, and `;cmd` in --title / --to / --ticket / --result do not execute
- [x] bash -n syntax check on all 5 new scripts + the test file
- [ ] Manual: live `/catalyst-dev:briefing-followup` session schedules a calendar entry, files a ticket, dispatches an orchestrator, drafts an email in one cycle (Phase 5 / CTL-466 acceptance)

## Out of scope

- ADR drift resolution → Phase 3 / CTL-464
- Writing the resolutions JSON back to the briefing markdown → Phase 4 / CTL-465
- End-to-end live-briefing session validation → Phase 5 / CTL-466

Refs CTL-463 · Closes CTL-463 on merge