### PR TITLE
feat(meta): research-curate CMA Routine wiring — Sunday 9pm cadence (CTL-469)

### DIFF
--- a/cma/decisions/2026-05-17-briefing-write-back.md
+++ b/cma/decisions/2026-05-17-briefing-write-back.md
@@ -1,10 +1,15 @@
 # ADR: Per-routine thoughts write-back via routine-scoped branch
 
-- **Status:** Accepted (tactical exception — superseded by [CTL-295](https://linear.app/coalesce-labs/issue/CTL-295))
+- **Status:** Accepted (tactical exception — superseded by
+  [CTL-295](https://linear.app/coalesce-labs/issue/CTL-295))
 - **Date:** 2026-05-17
-- **Ticket:** [CTL-460](https://linear.app/coalesce-labs/issue/CTL-460)
-- **Source plan:** [`thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md`](../../thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md) §Initiative 2 Phase 5
-- **Supersedes / extends:** [`2026-05-07-thoughts-strategy.md`](./2026-05-07-thoughts-strategy.md) (read posture unchanged)
+- **Tickets:** [CTL-460](https://linear.app/coalesce-labs/issue/CTL-460) (morning-briefing),
+  [CTL-469](https://linear.app/coalesce-labs/issue/CTL-469) (research-curate)
+- **Source plan:**
+  [`thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md`](../../thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md)
+  §Initiative 2 Phase 5 + §Initiative 4 Phase 3
+- **Supersedes / extends:** [`2026-05-07-thoughts-strategy.md`](./2026-05-07-thoughts-strategy.md)
+  (read posture unchanged)
 
 ## Context
 
@@ -13,87 +18,85 @@ The morning-briefing routine ([CTL-457](https://linear.app/coalesce-labs/issue/C
 [CTL-459](https://linear.app/coalesce-labs/issue/CTL-459) ADR-drift detector) writes
 `thoughts/briefings/<date>.md` once per scheduled run. The accepted ADR
 ([`2026-05-07-thoughts-strategy.md`](./2026-05-07-thoughts-strategy.md)) clones
-`coalesce-labs/thoughts` **read-only** at session start. That decision unblocks read-heavy
-Phase 1 Routines (backlog triage, daily async update) but blocks the morning briefing, which
-needs to persist a markdown file per run so the user can pull and review on their laptop.
+`coalesce-labs/thoughts` **read-only** at session start. That decision unblocks read-heavy Phase 1
+Routines (backlog triage, daily async update) but blocks the morning briefing, which needs to
+persist a markdown file per run so the user can pull and review on their laptop.
 
 Two write-back paths already exist in the base agent's system prompt:
 
 1. **§1 humanlayer path** (CTL-448) — `humanlayer thoughts init` against the read-only clone,
-   followed by `humanlayer thoughts sync` from the routine. This pushes to `main` via the
-   humanlayer machinery and is the right home for research, plans, and other long-lived
-   artifacts that belong on `main`.
-2. **Direct `git commit + push` to `main`** — rejected. Routines firing daily would dump
-   one commit per weekday to `main`, polluting the history humans browse.
+   followed by `humanlayer thoughts sync` from the routine. This pushes to `main` via the humanlayer
+   machinery and is the right home for research, plans, and other long-lived artifacts that belong
+   on `main`.
+2. **Direct `git commit + push` to `main`** — rejected. Routines firing daily would dump one commit
+   per weekday to `main`, polluting the history humans browse.
 
-Morning briefings are per-day ephemeral artifacts the user reviews and discards. They do not
-belong on `main`; a routine-scoped branch is the right home. The same shape will work for the
-upcoming research-curate routine ([CTL-469](https://linear.app/coalesce-labs/issue/CTL-469))
-on `routines/curation`.
+Morning briefings are per-day ephemeral artifacts the user reviews and discards. They do not belong
+on `main`; a routine-scoped branch is the right home. The same shape will work for the upcoming
+research-curate routine ([CTL-469](https://linear.app/coalesce-labs/issue/CTL-469)) on
+`routines/curation`.
 
-The session container has outbound network access, the GitHub PAT is already provisioned for
-the read-only clone, and a second clone fits inside the existing 5–15s startup overhead
-budget. The marginal cost of a second clone is small (the writable clone is full-depth so
-subsequent rebase + push work, but the thoughts repo is small enough — ~5.6MB — that this
-is unmeasurable in routine wall-clock time).
+The session container has outbound network access, the GitHub PAT is already provisioned for the
+read-only clone, and a second clone fits inside the existing 5–15s startup overhead budget. The
+marginal cost of a second clone is small (the writable clone is full-depth so subsequent rebase +
+push work, but the thoughts repo is small enough — ~5.6MB — that this is unmeasurable in routine
+wall-clock time).
 
 ## Decision
 
-**Add an opt-in §1a writable clone path to the base agent's system prompt.** When a routine
-sets `WRITABLE_THOUGHTS=true` and `THOUGHTS_WRITABLE_BRANCH=<branch>` in its `env:` block,
-the base agent's session-startup ritual also:
+**Add an opt-in §1a writable clone path to the base agent's system prompt.** When a routine sets
+`WRITABLE_THOUGHTS=true` and `THOUGHTS_WRITABLE_BRANCH=<branch>` in its `env:` block, the base
+agent's session-startup ritual also:
 
-1. Clones `coalesce-labs/thoughts` writable at `/workspace/thoughts-writable/` (separate
-   working copy from the read-only `/workspace/thoughts-repo/`).
+1. Clones `coalesce-labs/thoughts` writable at `/workspace/thoughts-writable/` (separate working
+   copy from the read-only `/workspace/thoughts-repo/`).
 2. Checks out the routine-scoped branch (creates it from `main` if it does not exist).
 3. Symlinks `/workspace/thoughts/briefings` to the writable clone's
-   `repos/${THOUGHTS_DIR}/shared/briefings` so skills writing canonical paths land in the
-   writable tree.
+   `repos/${THOUGHTS_DIR}/shared/briefings` so skills writing canonical paths land in the writable
+   tree.
 
 At routine end (before session exit), the same base block calls a write-back routine:
 
 1. `git add -A` in the writable clone.
 2. `git commit -m "routine(${ROUTINE_NAME}): ${RUN_DATE}"`.
-3. `git push origin ${THOUGHTS_WRITABLE_BRANCH}`. On push failure, `fetch` + `rebase` once
-   and retry. Hard failure exits non-zero so the run is visibly broken in
-   `claude.ai/code/routines`.
+3. `git push origin ${THOUGHTS_WRITABLE_BRANCH}`. On push failure, `fetch` + `rebase` once and
+   retry. Hard failure exits non-zero so the run is visibly broken in `claude.ai/code/routines`.
 
 Read-only routines (the existing default) leave `WRITABLE_THOUGHTS` unset and see no change.
 
-The PAT scope on `coalesce-labs/thoughts` upgrades from `Contents: Read` to
-`Contents: Read+Write` for the vault that backs routines opting in. The multi-PAT pattern
-documented in [`cma/mcp/github.md`](../mcp/github.md) is the documented escape hatch when leak
-blast radius matters more than vault-setup simplicity.
+The PAT scope on `coalesce-labs/thoughts` upgrades from `Contents: Read` to `Contents: Read+Write`
+for the vault that backs routines opting in. The multi-PAT pattern documented in
+[`cma/mcp/github.md`](../mcp/github.md) is the documented escape hatch when leak blast radius
+matters more than vault-setup simplicity.
 
 ## Considered options
 
-| Option | Why considered | Why rejected |
-|---|---|---|
-| **A. Push from the read-only clone** | Saves a second clone | Mixes read and write contexts; PAT scope on a single working tree blurs the read-only contract documented in `2026-05-07-thoughts-strategy.md` |
-| **B. Memory Store** | Already discussed as a future direction | 5.6 MB / 329-file corpus exceeds the 100 KB-per-file × 8-store envelope — same reason it was rejected for the read ADR |
-| **C. humanlayer thoughts sync to main** (already in §1) | The mechanism exists | Routes daily briefing commits to `main`, polluting the branch humans browse. Right home for research/plans; wrong home for daily artifacts |
-| **D. Per-routine writable second clone on a routine-scoped branch (chosen)** | Isolates the routine's commit stream, leaves `main` untouched, sits next to the existing read clone, opt-in | Adds 5–15s to startup latency for routines that opt in (acceptable for scheduled runs); requires PAT scope upgrade (documented) |
+| Option                                                                       | Why considered                                                                                              | Why rejected                                                                                                                                   |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A. Push from the read-only clone**                                         | Saves a second clone                                                                                        | Mixes read and write contexts; PAT scope on a single working tree blurs the read-only contract documented in `2026-05-07-thoughts-strategy.md` |
+| **B. Memory Store**                                                          | Already discussed as a future direction                                                                     | 5.6 MB / 329-file corpus exceeds the 100 KB-per-file × 8-store envelope — same reason it was rejected for the read ADR                         |
+| **C. humanlayer thoughts sync to main** (already in §1)                      | The mechanism exists                                                                                        | Routes daily briefing commits to `main`, polluting the branch humans browse. Right home for research/plans; wrong home for daily artifacts     |
+| **D. Per-routine writable second clone on a routine-scoped branch (chosen)** | Isolates the routine's commit stream, leaves `main` untouched, sits next to the existing read clone, opt-in | Adds 5–15s to startup latency for routines that opt in (acceptable for scheduled runs); requires PAT scope upgrade (documented)                |
 
 ## Rationale
 
-1. **Routine-scoped branches keep `main` clean.** `main` is the branch humans browse. Daily
-   weekday commits from the morning-briefing routine would pollute the history. A
-   `routines/briefings` branch holds the same content under a name that signals "machine
-   output, review before merging."
-2. **A second working copy isolates write state.** Adding write capability to the read clone
-   would couple two distinct postures in one directory tree. Skills that resolve paths
-   relative to `/workspace/thoughts/shared/` should never accidentally stage changes; the
-   second clone makes "is this read or write?" answerable by directory inspection.
-3. **The mechanism generalizes to other routines.** `THOUGHTS_WRITABLE_BRANCH` and
-   `ROUTINE_NAME` are routine-supplied. CTL-469 (research-curate) sets these to
-   `routines/curation` and `research-curate` respectively — same block, different branch.
-4. **It does not invalidate the parent ADR.** The accepted Option C decision is still the
-   read posture. §1a is explicitly additive and opt-in; the read clone, symlinks, and
+1. **Routine-scoped branches keep `main` clean.** `main` is the branch humans browse. Daily weekday
+   commits from the morning-briefing routine would pollute the history. A `routines/briefings`
+   branch holds the same content under a name that signals "machine output, review before merging."
+2. **A second working copy isolates write state.** Adding write capability to the read clone would
+   couple two distinct postures in one directory tree. Skills that resolve paths relative to
+   `/workspace/thoughts/shared/` should never accidentally stage changes; the second clone makes "is
+   this read or write?" answerable by directory inspection.
+3. **The mechanism generalizes to other routines.** `THOUGHTS_WRITABLE_BRANCH` and `ROUTINE_NAME`
+   are routine-supplied. CTL-469 (research-curate) sets these to `routines/curation` and
+   `research-curate` respectively — same block, different branch.
+4. **It does not invalidate the parent ADR.** The accepted Option C decision is still the read
+   posture. §1a is explicitly additive and opt-in; the read clone, symlinks, and
    `Treat thoughts as read-only` guidance for the default case all remain.
-5. **CTL-295 remains the long-term home.** All five open questions in the parent ADR
-   (write-back model, per-write vs per-session push, conflict handling, Memory Store split,
-   PAT scope split) remain open. This ADR is a tactical step that ships morning-briefing
-   without prejudging any of them.
+5. **CTL-295 remains the long-term home.** All five open questions in the parent ADR (write-back
+   model, per-write vs per-session push, conflict handling, Memory Store split, PAT scope split)
+   remain open. This ADR is a tactical step that ships morning-briefing without prejudging any of
+   them.
 
 ## Consequences
 
@@ -102,51 +105,51 @@ blast radius matters more than vault-setup simplicity.
 - Morning-briefing ships without a second-system rewrite of the read posture.
 - The `routines/briefings` branch is independently reviewable, mergeable, and squashable.
 - Generalizes to research-curate (CTL-469) with one env-var override.
-- Failure modes are loud: push failures exit non-zero, which `claude.ai/code/routines` surfaces
-  as a failed run.
+- Failure modes are loud: push failures exit non-zero, which `claude.ai/code/routines` surfaces as a
+  failed run.
 
 ### Negative
 
-- PAT scope on `coalesce-labs/thoughts` widens to `Contents: Read+Write` for vaults backing
-  opt-in routines. A leak compromises the routines-branches namespace (but still not
-  `main` — push protections on `main` are unchanged).
-- One commit per scheduled run accumulates on `routines/briefings`. The parent plan's
-  refactor note proposes a weekly squash; deferred to CTL-295 / a follow-up.
-- The clone is full-depth (not `--depth=1`) so the rebase path works. Adds ~5–15s to startup
-  for opt-in routines. Acceptable for scheduled runs; would not be for interactive UX.
+- PAT scope on `coalesce-labs/thoughts` widens to `Contents: Read+Write` for vaults backing opt-in
+  routines. A leak compromises the routines-branches namespace (but still not `main` — push
+  protections on `main` are unchanged).
+- One commit per scheduled run accumulates on `routines/briefings`. The parent plan's refactor note
+  proposes a weekly squash; deferred to CTL-295 / a follow-up.
+- The clone is full-depth (not `--depth=1`) so the rebase path works. Adds ~5–15s to startup for
+  opt-in routines. Acceptable for scheduled runs; would not be for interactive UX.
 
 ### Neutral
 
 - The routine-scoped branch needs to be created by the first opt-in run if it does not exist
-  upstream. The §1a block handles this with `git ls-remote --exit-code` + `git checkout -b`.
-  No human pre-creation step required.
+  upstream. The §1a block handles this with `git ls-remote --exit-code` + `git checkout -b`. No
+  human pre-creation step required.
 - `humanlayer thoughts init` is **not** invoked in the writable clone. Routines that need
-  research/plans on `main` continue to use the §1 humanlayer path; routines that need
-  per-run artifacts on a routine-scoped branch use §1a. The two mechanisms coexist.
+  research/plans on `main` continue to use the §1 humanlayer path; routines that need per-run
+  artifacts on a routine-scoped branch use §1a. The two mechanisms coexist.
 
 ## Open questions (deferred to CTL-295)
 
 All five open questions from the parent ADR remain open:
 
-1. **Write-back model.** Does the platform converge on per-routine branches, per-session
-   pushes to `main` via humanlayer, Memory Store, or a hybrid?
-2. **Per-write vs per-session push.** §1a pushes once at routine end. Is that the right
-   granularity, or should it be per-write for routines that produce multiple artifacts?
-3. **Conflict handling.** §1a rebases once on push failure. Is that sufficient? What does
-   a second-tier failure path look like?
-4. **Memory Store split.** Is Memory Store the right home for a small mutable subset
-   (preferences, exclusions, learned state) layered alongside the git-clone bulk corpus?
-5. **PAT scope split.** Should the writable-clone PAT be split from the read PAT to limit
-   leak blast radius? The multi-PAT pattern in `cma/mcp/github.md` is already documented;
-   the question is when to require it operationally.
+1. **Write-back model.** Does the platform converge on per-routine branches, per-session pushes to
+   `main` via humanlayer, Memory Store, or a hybrid?
+2. **Per-write vs per-session push.** §1a pushes once at routine end. Is that the right granularity,
+   or should it be per-write for routines that produce multiple artifacts?
+3. **Conflict handling.** §1a rebases once on push failure. Is that sufficient? What does a
+   second-tier failure path look like?
+4. **Memory Store split.** Is Memory Store the right home for a small mutable subset (preferences,
+   exclusions, learned state) layered alongside the git-clone bulk corpus?
+5. **PAT scope split.** Should the writable-clone PAT be split from the read PAT to limit leak blast
+   radius? The multi-PAT pattern in `cma/mcp/github.md` is already documented; the question is when
+   to require it operationally.
 
 This ADR explicitly does NOT resolve any of these. It is a tactical exception that ships
 morning-briefing on the existing infrastructure pending CTL-295.
 
 ## Implementation
 
-- `cma/agents/base-system-prompt.md` §1a — the writable clone + write-back blocks shown
-  above. Re-inlined into `cma/agents/base.yaml`'s `system` body via the documented
+- `cma/agents/base-system-prompt.md` §1a — the writable clone + write-back blocks shown above.
+  Re-inlined into `cma/agents/base.yaml`'s `system` body via the documented
   `yq -i '.system = load_str("cma/agents/base-system-prompt.md")'` flow.
 - `cma/routines/morning-briefing/routine.yaml` sets:
 
@@ -157,14 +160,53 @@ morning-briefing on the existing infrastructure pending CTL-295.
     ROUTINE_NAME: "morning-briefing"
   ```
 
-- `cma/mcp/github.md` footnotes the PAT scope upgrade on the thoughts repo for vaults
-  backing opt-in routines.
+  The morning-briefing routine writes a single artifact under `thoughts/briefings/<date>.md`. §1a's
+  `mkdir -p` + `ln -sfn` block sets up that exact path: `/workspace/thoughts/briefings` becomes a
+  symlink into the writable clone's `repos/${THOUGHTS_DIR}/shared/briefings` subtree. Skills
+  resolving the canonical `thoughts/briefings/` path therefore land in the writable tree without
+  further wiring.
+
+- `cma/routines/research-curate/routine.yaml` sets:
+
+  ```yaml
+  env:
+    WRITABLE_THOUGHTS: "true"
+    THOUGHTS_WRITABLE_BRANCH: "routines/curation"
+    ROUTINE_NAME: "research-curate"
+  ```
+
+  The research-curate routine writes to `thoughts/shared/research/{INDEX,CONTRADICTIONS}.md` and
+  `thoughts/shared/plans/{INDEX,CONTRADICTIONS}.md` — four artifacts under the `shared/` subtree
+  served by the read-only clone. Because `shared/` is read-only, the §1a `briefings` symlink does
+  not help here. Instead, the routine prompt invokes `run.sh` with absolute paths into the writable
+  clone:
+
+  ```bash
+  THOUGHTS_DIR="${CATALYST_THOUGHTS_DIRECTORY:-catalyst-workspace}"
+  WCLONE="/workspace/thoughts-writable/repos/${THOUGHTS_DIR}"
+  bash plugins/dev/scripts/research-curate/run.sh \
+    --git-dir /workspace/thoughts-writable "${WCLONE}/shared/research"
+  bash plugins/dev/scripts/research-curate/run.sh \
+    --git-dir /workspace/thoughts-writable "${WCLONE}/shared/plans"
+  ```
+
+  The §1a write-back block (`git add -A; git commit; git push`) picks up writes anywhere under
+  `/workspace/thoughts-writable/` — no symlink is required. The §1a `briefings` symlink remains a
+  harmless no-op for this routine (it creates an empty subdir that git never sees).
+
+- `cma/mcp/github.md` footnotes the PAT scope upgrade on the thoughts repo for vaults backing opt-in
+  routines (covers both routines — same vault).
 
 ## Follow-ups
 
-- [CTL-469](https://linear.app/coalesce-labs/issue/CTL-469) — research-curate routine reuses
-  §1a with `THOUGHTS_WRITABLE_BRANCH=routines/curation`.
-- [CTL-295](https://linear.app/coalesce-labs/issue/CTL-295) — the durable long-term write-back
-  model that may supersede this ADR.
-- Weekly squash on `routines/briefings` to keep the branch from growing one-commit-per-day
-  forever. Tracked in CTL-295 follow-ups.
+- [CTL-470](https://linear.app/coalesce-labs/issue/CTL-470) — follow-on to research-curate (blocked
+  by CTL-469). Likely needs the same §1a path.
+- [CTL-295](https://linear.app/coalesce-labs/issue/CTL-295) — the durable long-term write-back model
+  that may supersede this ADR.
+- Periodic squash on `routines/briefings` (daily commits) and `routines/curation` (weekly commits)
+  to keep the branches from growing without bound. Tracked in CTL-295 follow-ups.
+- Generalise §1a's `briefings` symlink. The parent plan §Initiative 4 Phase 3 §Refactor proposes
+  extracting the write-back step into a shared helper agent the base agent can include. The two
+  current users (briefings, curation) sit at different depths in the thoughts tree and use different
+  path strategies (symlink vs absolute path); a real helper extraction becomes worthwhile once a
+  third routine surfaces a missing parameter. Deferred until then to avoid premature abstraction.

--- a/cma/routines/research-curate/README.md
+++ b/cma/routines/research-curate/README.md
@@ -1,0 +1,188 @@
+# Research-Curate — CMA Routine
+
+The cloud-scheduled wrapper around the
+[`/catalyst-dev:research-curate`](../../../plugins/dev/skills/research-curate/SKILL.md) skill. Fires
+every Sunday at 9pm America/New_York, regenerates `INDEX.md` and updates `CONTRADICTIONS.md` for
+both `thoughts/shared/research/` and `thoughts/shared/plans/`, and pushes the result to the
+`routines/curation` branch on `coalesce-labs/thoughts`.
+
+This is Phase 3 of Initiative 4 (Weekly thoughts curation Routine) in
+[`thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md`](../../../thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md).
+Tracked in [CTL-469](https://linear.app/coalesce-labs/issue/CTL-469).
+
+## Files
+
+| File                               | Purpose                                                            |
+| ---------------------------------- | ------------------------------------------------------------------ |
+| `routine.yaml`                     | CMA Routine definition (schedule + repos + prompt + env)           |
+| `agent.yaml`                       | Per-routine agent (extends `cma/agents/base.yaml` via composition) |
+| `__tests__/routine-config.test.sh` | Local schema + contract checks                                     |
+| `README.md`                        | This file                                                          |
+
+The skill code itself lives at
+[`plugins/dev/skills/research-curate/`](../../../plugins/dev/skills/research-curate/) and is the
+source of truth for what the routine does on each run. This directory is purely the cloud wiring.
+
+## What it does
+
+Every Sunday at 9pm (`0 21 * * 0`, America/New_York):
+
+1. CMA starts a new session against the per-routine agent
+2. The base agent runs its startup ritual (clones target repo + thoughts read-only, materializes
+   `/workspace/project-context.md`)
+3. Because `routine.yaml` sets `WRITABLE_THOUGHTS=true`, the base agent's §1a block also clones
+   thoughts writable at `/workspace/thoughts-writable/` on the `routines/curation` branch (creating
+   the branch from `main` if it does not yet exist)
+4. The routine prompt invokes
+   [`plugins/dev/scripts/research-curate/run.sh`](../../../plugins/dev/scripts/research-curate/run.sh)
+   twice — once against `/workspace/thoughts-writable/repos/<dir>/shared/research`, once against
+   `/workspace/thoughts-writable/repos/<dir>/shared/plans`. The skill regenerates each directory's
+   `INDEX.md` (overwrites) and appends to `CONTRADICTIONS.md` (append-only). Source markdown is
+   never modified
+5. At session exit, the base agent's §1a write-back block commits and pushes `routines/curation` to
+   `coalesce-labs/thoughts`. Rebase + retry once on push failure; hard exit if the retry also fails
+
+### Why absolute paths instead of the §1a symlink
+
+The §1a block in `cma/agents/base-system-prompt.md` creates a `/workspace/thoughts/briefings`
+symlink that is specific to the morning-briefing routine. Research-curate writes into
+`shared/research/` and `shared/plans/`, both of which sit under `shared/` — a subtree that the
+read-only clone serves. Symlinking into a read-only mount does not work, and generalising §1a to
+support multiple writable subpaths would require re-inlining morning-briefing's `agent.yaml` and
+`base.yaml`.
+
+The simpler approach (chosen here): the routine prompt calls `run.sh` with absolute paths into the
+writable clone (`/workspace/thoughts-writable/repos/<dir>/...`). The §1a write-back block picks up
+the changes from anywhere under `/workspace/thoughts-writable/` via `git add -A`, so no symlink is
+needed for this routine. The §1a `briefings` symlink is a harmless no-op when
+`WRITABLE_THOUGHTS=true` and the routine writes outside of `briefings/`.
+
+The write-back contract is documented in
+[`cma/decisions/2026-05-17-briefing-write-back.md`](../../decisions/2026-05-17-briefing-write-back.md).
+
+## Register
+
+Routine and agent registration happen separately. Register the agent first, then the routine.
+
+```bash
+# 0. (Pre-req) Environment + vault are shared across all routines. Register
+#    them once per cma/README.md if you haven't:
+#      ant beta:environments create -f cma/environment.yaml
+#      ant beta:vaults create -f ~/.config/catalyst/cma-vault.yaml
+#    Make sure the vault's coalesce-labs/thoughts PAT has Contents: Read+Write
+#    (the write-back ADR documents the scope upgrade — same vault used by
+#    morning-briefing).
+
+# 1. Run the local contract tests
+bash cma/routines/research-curate/__tests__/routine-config.test.sh
+
+# 2. Register the per-routine agent
+AGENT_ID=$(ant beta:agents create \
+  -f cma/routines/research-curate/agent.yaml --json | jq -r '.id')
+
+# 3. Register the routine (references the agent by ID)
+ROUTINE_ID=$(ant beta:routines create \
+  -f cma/routines/research-curate/routine.yaml --json | jq -r '.id')
+
+# 4. Capture the IDs locally (NEVER commit)
+jq --arg routine "$ROUTINE_ID" --arg agent "$AGENT_ID" \
+  '.agents["catalyst-research-curate-agent"] = $agent
+   | .routines["catalyst-research-curate"] = $routine' \
+  ~/.config/catalyst/cma.json > /tmp/cma.json && mv /tmp/cma.json ~/.config/catalyst/cma.json
+```
+
+The exact `ant beta:routines` verb may evolve while CMA Routines remain in research preview; the
+parent plan accepts "or equivalent CMA validation command." If `ant` rejects a field, match the
+shape to whatever `ant beta:routines validate -f routine.yaml` reports.
+
+## Change cadence
+
+Edit `routine.yaml`'s `schedule.cron` to the new expression. Standard 5-field cron
+(`min hour dom month dow`). The minimum interval CMA accepts is 1 hour (per the Claude Code Routines
+docs); weekly is well above that.
+
+```bash
+# Edit, then re-register
+${EDITOR:-vim} cma/routines/research-curate/routine.yaml
+ant beta:routines update "$ROUTINE_ID" -f cma/routines/research-curate/routine.yaml
+```
+
+Common edits:
+
+| Goal                           | `schedule.cron` |
+| ------------------------------ | --------------- |
+| Sundays 9pm (default)          | `0 21 * * 0`    |
+| Saturdays 6pm                  | `0 18 * * 6`    |
+| First of the month, 9pm        | `0 21 1 * *`    |
+| Every Sunday and Wednesday 9pm | `0 21 * * 0,3`  |
+
+To pause without deleting: toggle the **Repeats** switch on the routine's
+[claude.ai/code/routines](https://claude.ai/code/routines) detail page, or run
+`/schedule update <routine-id>` in the Claude Code CLI and disable.
+
+## Re-inline the agent's system body
+
+`agent.yaml`'s `system` field is the routine-specific extension block + the entire
+`cma/agents/base-system-prompt.md` body. After editing either, re-inline:
+
+```bash
+python3 - <<'PY'
+import yaml
+
+ROUTINE_EXTENSION = '''# Research-Curate — Routine extension
+
+You are the **Research-Curate** routine, a Catalyst Pattern Routine that
+runs weekly on Sunday 9pm via CMA. ...
+'''  # keep this in sync with the existing block at the top of agent.yaml's system
+
+with open('cma/agents/base-system-prompt.md') as f:
+    base = f.read()
+
+with open('cma/routines/research-curate/agent.yaml') as f:
+    agent = yaml.safe_load(f)
+
+agent['system'] = ROUTINE_EXTENSION + base
+
+with open('cma/routines/research-curate/agent.yaml', 'w') as f:
+    yaml.dump(agent, f, default_flow_style=False, sort_keys=False, width=120, allow_unicode=True)
+PY
+```
+
+Then run the tests to confirm:
+
+```bash
+bash cma/routines/research-curate/__tests__/routine-config.test.sh
+```
+
+## Debug
+
+| Symptom                                    | Likely cause                                                                                                                    | Fix                                                                                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Push to `routines/curation` fails with 403 | PAT lacks `Contents: Read+Write` on `coalesce-labs/thoughts`                                                                    | Provision a new PAT per [`cma/mcp/github.md`](../../mcp/github.md); rebind the vault                                                  |
+| `git push --rebase` aborts on conflict     | Two routines pushed the same minute (extremely unlikely — weekly cadence on a dedicated branch)                                 | Re-run; the rebase will succeed once the first push lands                                                                             |
+| Source markdown changed unexpectedly       | Bug in `score.sh` or `inventory.sh` — they should never write into the target dir except for `INDEX.md` and `CONTRADICTIONS.md` | Check `git diff` for paths under `shared/research/` / `shared/plans/` other than `INDEX.md` and `CONTRADICTIONS.md`; file a skill bug |
+| `CONTRADICTIONS.md` grows without bound    | Expected — entries are append-only by design. CTL-471 (follow-on) will add a pruning policy                                     | No fix needed in this routine                                                                                                         |
+| LLM contradiction step fails or times out  | `claude -p` rate-limited or unavailable                                                                                         | Pass `--skip-contradictions` to `run.sh` to drop back to inventory-only and surface in the run output                                 |
+| Routine doesn't fire at the scheduled time | Schedule paused, or routine deleted, or daily run cap hit                                                                       | Open [claude.ai/code/routines](https://claude.ai/code/routines) and check the **Repeats** toggle + the day's run history              |
+
+## Related
+
+- [`cma/decisions/2026-05-17-briefing-write-back.md`](../../decisions/2026-05-17-briefing-write-back.md)
+  — the ADR for the routine-scoped write-back path (covers both routines)
+- [`cma/decisions/2026-05-07-thoughts-strategy.md`](../../decisions/2026-05-07-thoughts-strategy.md)
+  — the parent ADR (read posture)
+- [`cma/agents/base-system-prompt.md`](../../agents/base-system-prompt.md) — §1a is the
+  writable-clone block this routine uses
+- [`cma/routines/morning-briefing/`](../morning-briefing/) — the sibling routine on
+  `routines/briefings`
+- [`plugins/dev/skills/research-curate/SKILL.md`](../../../plugins/dev/skills/research-curate/SKILL.md)
+  — the skill the routine wraps
+- [`thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md`](../../../thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md)
+  §Initiative 4 Phase 3 — the parent plan
+- [`thoughts/shared/plans/2026-05-17-CTL-469-research-curate-routine-wiring.md`](../../../thoughts/shared/plans/2026-05-17-CTL-469-research-curate-routine-wiring.md)
+  — the implementation plan for this routine
+- [CTL-469](https://linear.app/coalesce-labs/issue/CTL-469) — this ticket
+- [CTL-470](https://linear.app/coalesce-labs/issue/CTL-470) — follow-on (blocked by this)
+- [CTL-446](https://linear.app/coalesce-labs/issue/CTL-446) — parent ticket
+- [CTL-295](https://linear.app/coalesce-labs/issue/CTL-295) — the long-term thoughts write-back /
+  Memory Store model that may supersede the write-back ADR

--- a/cma/routines/research-curate/__tests__/routine-config.test.sh
+++ b/cma/routines/research-curate/__tests__/routine-config.test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Tests for the research-curate CMA Routine wiring (CTL-469).
+# Run: bash cma/routines/research-curate/__tests__/routine-config.test.sh
+#
+# Asserts the contract from
+# thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md
+# §Initiative 4 Phase 3:
+#   1. routine.yaml has the required top-level keys
+#   2. agent.yaml's system body includes the full base prompt
+#   3. schedule.cron defaults to Sunday 9pm (0 21 * * 0)
+#   4. The prompt references the committed research-curate skill
+#   5. routine.yaml's env.THOUGHTS_WRITABLE_BRANCH equals routines/curation
+# Plus two structural assertions mirroring morning-briefing:
+#   6. README.md exists and is non-empty
+#   7. The write-back ADR mentions research-curate + routines/curation
+#      (i.e. the ADR was updated to cover both Routines)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+ROUTINE_DIR="${REPO_ROOT}/cma/routines/research-curate"
+ROUTINE_YAML="${ROUTINE_DIR}/routine.yaml"
+AGENT_YAML="${ROUTINE_DIR}/agent.yaml"
+BASE_PROMPT="${REPO_ROOT}/cma/agents/base-system-prompt.md"
+WRITE_BACK_ADR="${REPO_ROOT}/cma/decisions/2026-05-17-briefing-write-back.md"
+
+FAILURES=0
+PASSES=0
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -gt 1 ] && echo "    $2"
+}
+
+read_yaml_field() {
+	# Args: <yaml-file> <python-expression-on-`data`>
+	# Returns the field as a string. Empty string if missing or null.
+	python3 -c "
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f) or {}
+val = $2
+if val is None:
+    print('')
+elif isinstance(val, (dict, list)):
+    print(yaml.safe_dump(val))
+else:
+    print(val)
+" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Assertion 1: routine.yaml has the required top-level keys
+# ---------------------------------------------------------------------------
+echo "Assertion 1: routine.yaml schema"
+if [ ! -f "$ROUTINE_YAML" ]; then
+	fail "routine.yaml exists" "expected at ${ROUTINE_YAML}"
+else
+	MISSING_KEYS=$(python3 -c "
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f) or {}
+required = ['name', 'agent', 'schedule', 'repositories', 'prompt']
+missing = [k for k in required if k not in data]
+print(','.join(missing))
+" "$ROUTINE_YAML")
+	if [ -z "$MISSING_KEYS" ]; then
+		pass "routine.yaml has required top-level keys (name, agent, schedule, repositories, prompt)"
+	else
+		fail "routine.yaml missing keys" "missing: ${MISSING_KEYS}"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 2: agent.yaml's system body includes the full base prompt
+# ---------------------------------------------------------------------------
+echo "Assertion 2: agent.yaml extends base system prompt"
+if [ ! -f "$AGENT_YAML" ]; then
+	fail "agent.yaml exists" "expected at ${AGENT_YAML}"
+elif [ ! -f "$BASE_PROMPT" ]; then
+	fail "base-system-prompt.md exists" "expected at ${BASE_PROMPT}"
+else
+	SYSTEM_BODY=$(read_yaml_field "$AGENT_YAML" "data.get('system', '')")
+	# The base prompt's H1 and §9 heading are stable markers — both must appear.
+	if grep -qF "Catalyst Pattern Base — System Prompt" <<<"$SYSTEM_BODY" &&
+		grep -qF "## 9. Operating principles" <<<"$SYSTEM_BODY"; then
+		pass "agent.yaml system body includes base prompt heading + §9"
+	else
+		fail "agent.yaml system body missing base prompt markers" \
+			"expected 'Catalyst Pattern Base — System Prompt' and '## 9. Operating principles'"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 3: schedule.cron defaults to Sunday 9pm (0 21 * * 0)
+# ---------------------------------------------------------------------------
+echo "Assertion 3: schedule.cron default"
+if [ -f "$ROUTINE_YAML" ]; then
+	CRON=$(read_yaml_field "$ROUTINE_YAML" "data.get('schedule', {}).get('cron', '')")
+	CRON_TRIMMED=$(printf '%s' "$CRON" | tr -d '\n')
+	if [ "$CRON_TRIMMED" = "0 21 * * 0" ]; then
+		pass "schedule.cron default is '0 21 * * 0' (Sunday 9pm)"
+	else
+		fail "schedule.cron default" "expected '0 21 * * 0', got '${CRON_TRIMMED}'"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 4: prompt references the committed research-curate skill
+# ---------------------------------------------------------------------------
+echo "Assertion 4: prompt references committed skill"
+if [ -f "$ROUTINE_YAML" ]; then
+	PROMPT=$(read_yaml_field "$ROUTINE_YAML" "data.get('prompt', '')")
+	if grep -qF "plugins/dev/skills/research-curate/SKILL.md" <<<"$PROMPT"; then
+		pass "prompt references plugins/dev/skills/research-curate/SKILL.md"
+	else
+		fail "prompt missing skill reference" \
+			"expected 'plugins/dev/skills/research-curate/SKILL.md' substring"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 5: env.THOUGHTS_WRITABLE_BRANCH = routines/curation
+# ---------------------------------------------------------------------------
+echo "Assertion 5: write-back branch is routines/curation"
+if [ -f "$ROUTINE_YAML" ]; then
+	BRANCH=$(read_yaml_field "$ROUTINE_YAML" "data.get('env', {}).get('THOUGHTS_WRITABLE_BRANCH', '')")
+	BRANCH_TRIMMED=$(printf '%s' "$BRANCH" | tr -d '\n')
+	if [ "$BRANCH_TRIMMED" = "routines/curation" ]; then
+		pass "env.THOUGHTS_WRITABLE_BRANCH = 'routines/curation'"
+	else
+		fail "env.THOUGHTS_WRITABLE_BRANCH" "expected 'routines/curation', got '${BRANCH_TRIMMED}'"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 6: README.md exists and is non-empty
+# ---------------------------------------------------------------------------
+echo "Assertion 6: README.md exists"
+if [ -s "${ROUTINE_DIR}/README.md" ]; then
+	pass "README.md exists and is non-empty"
+else
+	fail "README.md missing or empty" "expected at ${ROUTINE_DIR}/README.md"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 7: write-back ADR mentions research-curate + routines/curation
+# (proves the ADR was updated to cover both Routines)
+# ---------------------------------------------------------------------------
+echo "Assertion 7: write-back ADR covers research-curate"
+if [ ! -f "$WRITE_BACK_ADR" ]; then
+	fail "write-back ADR exists" "expected at ${WRITE_BACK_ADR}"
+else
+	HAS_NAME=$(grep -c 'research-curate' "$WRITE_BACK_ADR" 2>/dev/null || echo 0)
+	HAS_BRANCH=$(grep -c 'routines/curation' "$WRITE_BACK_ADR" 2>/dev/null || echo 0)
+	if [ "${HAS_NAME:-0}" -gt 0 ] && [ "${HAS_BRANCH:-0}" -gt 0 ]; then
+		pass "write-back ADR mentions research-curate and routines/curation"
+	else
+		fail "write-back ADR missing research-curate coverage" \
+			"research-curate count=${HAS_NAME}, routines/curation count=${HAS_BRANCH}"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "------------------------------------------------------------"
+echo "  Passed: ${PASSES}"
+echo "  Failed: ${FAILURES}"
+echo "------------------------------------------------------------"
+
+if [ "$FAILURES" -gt 0 ]; then
+	exit 1
+fi
+exit 0

--- a/cma/routines/research-curate/agent.yaml
+++ b/cma/routines/research-curate/agent.yaml
@@ -1,0 +1,400 @@
+---
+# Research-Curate — per-routine agent (CTL-469)
+#
+# Extends cma/agents/base.yaml via prompt composition: the routine-specific
+# extension block prepends the full base system prompt body. The base prompt's
+# §8 "Routine extension pattern" formalizes this — routines extend, they do
+# not redefine.
+#
+# Register with:
+#   ant beta:agents create -f cma/routines/research-curate/agent.yaml
+#
+# Re-inline the system body after editing either the routine extension OR the
+# base prompt. The build recipe lives in this directory's README.md.
+#
+# Beta API header: managed-agents-2026-04-01
+
+name: catalyst-research-curate-agent
+model: claude-opus-4-7
+system: "# Research-Curate — Routine extension\n\nYou are the **Research-Curate** routine, a
+  Catalyst Pattern Routine that\n\
+  runs weekly on Sunday 9pm via CMA. Your job is to execute the committed\nskill at
+  `plugins/dev/skills/research-curate/SKILL.md`\
+  \ against the writable\nthoughts clone — regenerating `INDEX.md` and appending to
+  `CONTRADICTIONS.md`\nfor both `shared/research/`\
+  \ and `shared/plans/` — and push the result back\nto the `routines/curation` branch on
+  `coalesce-labs/thoughts`.\n\n## Specific\
+  \ to this routine\n\n- **Trigger:** cron `0 21 * * 0` (Sunday 9pm America/New_York,
+  user-tunable\n  in routine.yaml).\n\
+  - **Output targets:**\n  - `thoughts/shared/research/INDEX.md` (overwritten each run)\n  -
+  `thoughts/shared/research/CONTRADICTIONS.md`\
+  \ (appended; never overwritten)\n  - `thoughts/shared/plans/INDEX.md` (overwritten each run)\n  -
+  `thoughts/shared/plans/CONTRADICTIONS.md`\
+  \ (appended; never overwritten)\n  All four land on the `routines/curation` branch of
+  `coalesce-labs/thoughts`\n  via the\
+  \ §1a writable-clone path.\n- **Source files are immutable.** The skill is contractually read-only
+  for\n  source markdown\
+  \ under `shared/research/` and `shared/plans/`. If you find\n  yourself needing to modify a source
+  doc, stop — that is a\
+  \ bug in either\n  the skill or your invocation.\n- **Wall-clock budget:** under 10 minutes per
+  the base prompt's routine\n\
+  \  extension guidance. The inventory/score/index pipeline is bash-only and\n  fast; the dominant
+  cost is the LLM cluster-contradiction\
+  \ step\n  (one `claude -p` call per topic cluster, ~$0.38/run projected).\n- **Write-back:** the
+  routine sets `WRITABLE_THOUGHTS=true`\
+  \ and\n  `THOUGHTS_WRITABLE_BRANCH=routines/curation` in its env block. The base\n  agent's §1a
+  clones the writable tree\
+  \ and the session-end block commits +\n  pushes. See
+  [`cma/decisions/2026-05-17-briefing-write-back.md`](../../decisions/2026-05-17-briefing-write-back.md).\n\
+  - **Path strategy:** the §1a `briefings` symlink is morning-briefing-specific.\n  This routine
+  bypasses it entirely by invoking\
+  \ `run.sh` with absolute paths\n  into the writable clone (see the routine.yaml prompt for the
+  exact\n  commands). The §1a\
+  \ symlink becomes a harmless no-op.\n\n## What the routine does NOT do\n\n- It does not respond to
+  user input (autonomous,\
+  \ single-fire).\n- It does not modify source markdown under `shared/research/`
+  or\n  `shared/plans/`. Only `INDEX.md` and\
+  \ `CONTRADICTIONS.md` are written.\n- It does not change the read posture for other routines
+  (read-only stays\n  the default\
+  \ — only routines that opt in get the writable clone).\n- It does not touch `main` on
+  `coalesce-labs/thoughts` (only the\n\
+  \  `routines/curation` branch).\n- It does not fan-out to Slack/Notion/email. Curation output is
+  the markdown\n  artifacts\
+  \ on the routine-scoped branch — humans pull and review.\n\n---\n\n# Catalyst Pattern Base —
+  System Prompt\n\nYou are a\
+  \ Catalyst Pattern Agent running in a Claude Managed Agents (CMA) cloud\nsession. You operate on
+  whichever target repo is\
+  \ bound at session creation,\nplus the `coalesce-labs/thoughts` knowledge repository, integrated
+  with Linear\nand GitHub\
+  \ via MCP. You implement the **Catalyst pattern** — a set of\nconventions for how engineering work
+  flows through research\
+  \ → plan →\nimplement → ship — applicable to any project that has a
+  `.catalyst/config.json`.\n\nProject-specific values\
+  \ (repo, Linear team, state map, ticket prefix) are\n**resolved at session start** from the bound
+  target repo's\n`.catalyst/config.json`\
+  \ and written to `/workspace/project-context.md`. Read\nthat file before doing anything else; the
+  values there are authoritative\
+  \ for\nthis session.\n\nThe cross-project conventions encoded below (PR description format,
+  code\nreview behavior, quality\
+  \ gates, reward-hacking ban list) apply to every\nsession regardless of target.\n\n---\n\n## 0.
+  Session inputs (required)\n\
+  \nThe session creator MUST set these env vars at session creation:\n\n| Env var | Required |
+  Source / example |\n|---------|----------|------------------|\n\
+  | `CATALYST_TARGET_REPO` | yes | e.g., `coalesce-labs/catalyst` or `getadva/adva` |\n|
+  `CATALYST_THOUGHTS_DIRECTORY` | no\
+  \ — falls back to `projectKey` from the cloned target repo | e.g., `catalyst-workspace`, `adva`
+  |\n| `GITHUB_PAT` | yes\
+  \ | Bound from the per-user vault; see `cma/mcp/github.md` |\n\nIf `CATALYST_TARGET_REPO` is
+  unset, fail loudly at startup\
+  \ — do not guess.\n\n---\n\n## 1. Startup ritual\n\nRun this once at session start, before the
+  first turn:\n\n```bash\n\
+  set -euo pipefail\n\n: \"${CATALYST_TARGET_REPO:?required}\"\n: \"${GITHUB_PAT:?required}\"\n\n#
+  1. Clone the target repo\
+  \ (shallow)\ngit clone --depth=1
+  \\\n  \"https://x-access-token:${GITHUB_PAT}@github.com/${CATALYST_TARGET_REPO}.git\" \\\
+  \n  /workspace/repo\n\n# 2. Read the target's Catalyst
+  config\nCFG=/workspace/repo/.catalyst/config.json\nPROJECT_KEY=$(jq\
+  \ -r '.catalyst.projectKey' \"$CFG\")\nTICKET_PREFIX=$(jq -r '.catalyst.project.ticketPrefix //
+  empty' \"$CFG\")\nLINEAR_TEAM_KEY=$(jq\
+  \ -r '.catalyst.linear.teamKey // empty'
+  \"$CFG\")\nTHOUGHTS_DIR=\"${CATALYST_THOUGHTS_DIRECTORY:-$PROJECT_KEY}\"\nSTATE_MAP=$(jq\
+  \ -c '.catalyst.linear.stateMap' \"$CFG\")\n\n# 3. Clone thoughts and surface the project's shared
+  subtree\ngit clone --depth=1\
+  \ \\\n  \"https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git\"
+  \\\n  /workspace/thoughts-repo\n\n\
+  mkdir -p /workspace/thoughts\nln -s \"/workspace/thoughts-repo/repos/${THOUGHTS_DIR}/shared\"
+  /workspace/thoughts/shared\n\
+  ln -s /workspace/thoughts-repo/global                        /workspace/thoughts/global\n\n# 4.
+  Materialize the project\
+  \ context that the agent will read\ncat > /workspace/project-context.md <<EOF\n# Project context
+  (resolved at session start)\n\
+  \n- Target repo:        ${CATALYST_TARGET_REPO}\n- Project key:        ${PROJECT_KEY}\n- Linear
+  team key:    ${LINEAR_TEAM_KEY}\n\
+  - Ticket prefix:      ${TICKET_PREFIX}\n- Thoughts directory: ${THOUGHTS_DIR}\n\n## State map
+  (from .catalyst/config.json:linear.stateMap)\n\
+  \n\\`\\`\\`json\n${STATE_MAP}\n\\`\\`\\`\n\n## Working directories\n\n-
+  /workspace/repo            — target repo (shallow\
+  \ clone)\n- /workspace/thoughts/shared — project-specific thoughts\n- /workspace/thoughts/global —
+  cross-project thoughts\n\
+  EOF\n```\n\nAfter this runs, the directory layout matches the local Catalyst workflow for\nthe
+  bound project:\n- `/workspace/thoughts/shared/research/`\
+  \ — prior research docs\n- `/workspace/thoughts/shared/plans/` — prior implementation plans\n-
+  `/workspace/thoughts/shared/handoffs/`\
+  \ — handoff docs between sessions\n- `/workspace/thoughts/shared/prs/` — PR descriptions\n-
+  `/workspace/thoughts/shared/pm/`\
+  \ — PM artifacts\n- `/workspace/thoughts/global/` — cross-repo notes\n\n**Treat thoughts as
+  read-only in Phase 1.** Do not\
+  \ push back. CTL-295 owns the\nwrite-back design. If you discover something worth recording, queue
+  it in your\nsession output\
+  \ for the orchestrator to act on after session end.\n\n### Opt-in write side (CTL-448, for
+  routines that need to push back)\n\
+  \nRoutines that need to persist research, plans, or briefings into the\n`coalesce-labs/thoughts`
+  repo (e.g., the morning-briefing\
+  \ routine in\nInitiative 2, or the research-curation routine in Initiative 4) can
+  call\n`humanlayer thoughts init` against\
+  \ the cloned tree to wire write-side sync.\nThe CLI is installed in the container by
+  `cma/environment.yaml` (pip:\nhumanlayer).\
+  \ Routines that don't write — the default — simply skip this\nblock and the init is a
+  no-op.\n\n```bash\n# Opt-in: only\
+  \ routines with write-back responsibilities run this.\nif [[
+  \"${CATALYST_THOUGHTS_WRITE_BACK:-0}\" == \"1\" ]]; then\n\
+  \  # Initialize humanlayer against the shared subtree we symlinked above.\n  # The directory it
+  expects (per humanlayer\
+  \ thoughts) is the project's\n  # `${THOUGHTS_DIR}/shared` tree — that's exactly what
+  /workspace/thoughts/shared\n  # points\
+  \ to. `humanlayer thoughts init` is idempotent.\n  humanlayer thoughts init \\\n    --directory
+  \"/workspace/thoughts-repo/repos/${THOUGHTS_DIR}\"\
+  \ \\\n    --remote \"https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git\"
+  \\\n    >/dev/null 2>&1\
+  \ || true\n  # Routines call `humanlayer thoughts sync` at the points they want to push.\n  # Sync
+  is no-op when nothing\
+  \ changed locally, so over-calling is cheap.\nfi\n```\n\nRead-side routines must leave
+  `CATALYST_THOUGHTS_WRITE_BACK` unset.\n\
+  \n---\n\n## 1a. Optional writable thoughts clone\n\nSome routines write per-run artifacts
+  (briefings, curation indexes)\
+  \ that should\nland on a **routine-scoped branch** of `coalesce-labs/thoughts` rather
+  than\n`main`. This keeps the artifact\
+  \ stream off `main` and avoids interleaving with\nresearch/plan write-backs handled by the §1
+  humanlayer path. The\n[morning-briefing\
+  \ routine](https://linear.app/coalesce-labs/issue/CTL-460) and\n[research-curate
+  routine](https://linear.app/coalesce-labs/issue/CTL-469)\
+  \ are\nthe current users;
+  see\n[`cma/decisions/2026-05-17-briefing-write-back.md`](../decisions/2026-05-17-briefing-write-back.md)\n\
+  for the ADR.\n\nWhen a routine sets `WRITABLE_THOUGHTS=true` and
+  `THOUGHTS_WRITABLE_BRANCH=<branch>`\n(routine-specific,\
+  \ e.g. `routines/briefings`), also run this block at session\nstart:\n\n```bash\nif [
+  \"${WRITABLE_THOUGHTS:-false}\" =\
+  \ \"true\" ]; then\n  : \"${THOUGHTS_WRITABLE_BRANCH:?required when
+  WRITABLE_THOUGHTS=true}\"\n\n  # Full clone (not --depth=1)\
+  \ so subsequent rebase + push work even when\n  # the remote branch already has history.\n  git
+  clone \\\n    \"https://x-access-token:${GITHUB_PAT}@github.com/coalesce-labs/thoughts.git\"\
+  \ \\\n    /workspace/thoughts-writable\n\n  cd /workspace/thoughts-writable\n  if git ls-remote
+  --exit-code origin \"${THOUGHTS_WRITABLE_BRANCH}\"\
+  \ >/dev/null 2>&1; then\n    git checkout \"${THOUGHTS_WRITABLE_BRANCH}\"\n    git pull --rebase
+  origin \"${THOUGHTS_WRITABLE_BRANCH}\"\
+  \n  else\n    git checkout -b \"${THOUGHTS_WRITABLE_BRANCH}\"\n  fi\n  cd - >/dev/null\n\n  #
+  Surface the writable subtree\
+  \ under the canonical thoughts/ path so skills\n  # that resolve thoughts/briefings/<date>.md
+  write into the routine-scoped\n\
+  \  # branch's working tree.\n  mkdir -p
+  \"/workspace/thoughts-writable/repos/${THOUGHTS_DIR}/shared/briefings\"\n  ln -sfn\
+  \ \"/workspace/thoughts-writable/repos/${THOUGHTS_DIR}/shared/briefings\"
+  \\\n          /workspace/thoughts/briefings\n\
+  fi\n```\n\nAt routine end, before session exit, call the write-back block:\n\n```bash\nif [
+  \"${WRITABLE_THOUGHTS:-false}\"\
+  \ = \"true\" ]; then\n  cd /workspace/thoughts-writable\n  if [ -n \"$(git status --porcelain)\"
+  ]; then\n    git add -A\n\
+  \    git commit -m \"routine(${ROUTINE_NAME:-unknown}): ${RUN_DATE:-$(date -u
+  +%Y-%m-%d)}\"\n    if ! git push origin \"\
+  ${THOUGHTS_WRITABLE_BRANCH}\"; then\n      # One retry: rebase against latest remote and push
+  again.\n      git fetch origin\
+  \ \"${THOUGHTS_WRITABLE_BRANCH}\"\n      git rebase \"origin/${THOUGHTS_WRITABLE_BRANCH}\" || git
+  rebase --abort\n     \
+  \ git push origin \"${THOUGHTS_WRITABLE_BRANCH}\"\n    fi\n  fi\n  cd -
+  >/dev/null\nfi\n```\n\n`ROUTINE_NAME` is the routine\
+  \ slug from `routine.yaml:name` (e.g.,\n`morning-briefing`); `RUN_DATE` is the routine's date
+  variable (e.g., `DATE`\nin\
+  \ morning-briefing's Step 1). Both are routine-supplied env vars — the base\nblock does not
+  synthesize them.\n\nThis path\
+  \ is opt-in and additive: routines that leave `WRITABLE_THOUGHTS` unset\nbehave exactly as before.
+  The PAT scope on `coalesce-labs/thoughts`\
+  \ upgrades\nfrom `Contents: Read` to `Contents: Read+Write` for the routines vault —
+  see\n`cma/mcp/github.md` for the per-routine\
+  \ PAT split option.\n\n---\n\n## 2. Project conventions\n\nRead `/workspace/project-context.md`
+  for the values that vary\
+  \ per project:\n- Target repo name (e.g., for GitHub MCP calls)\n- Project key (used in thoughts
+  paths and config lookups)\n\
+  - Linear team key (for `mcp__linear__list_issues` filters and ticket parsing)\n- Ticket prefix
+  (e.g., `CTL-`, `ADV-`) —\
+  \ used to recognize and parse ticket\n  references in commits, branches, comments\n- Default
+  branch — read from `.catalyst/config.json:catalyst.repository`\
+  \ or\n  fall back to `main` via `git remote show origin`\n\nCross-project commit conventions
+  (apply everywhere):\n- `feat(<scope>):\
+  \ ...` — minor version bump within scope\n- `fix(<scope>): ...` — patch version bump within
+  scope\n- `chore(<scope>): ...`\
+  \ — no version bump\n- `feat(<scope>)!: ...` — major version bump (breaking change)\n\nThe set of
+  valid scopes is project-specific.\
+  \ For Catalyst they are\n`dev / pm / meta / analytics / debugging`; other projects define their
+  own.\nRead scopes from the\
+  \ target repo's CLAUDE.md or contribution docs.\n\n---\n\n## 3. Linear state machine\n\nThe state
+  map for this session is\
+  \ in `/workspace/project-context.md`,\npopulated from the target repo's
+  `.catalyst/config.json:linear.stateMap`.\n\nAlways\
+  \ resolve target state names by **semantic key** — never assume literal\nstate values across
+  projects. Different projects\
+  \ have different state names\n(e.g., one project's `inReview` may be `\"In Review\"`, another's
+  may be\n`\"Code Review\"\
+  `).\n\nSkill-to-transition map (when the routine acts as one of these):\n\n| Stage | Transition
+  key | How to resolve to\
+  \ state name |\n|-------|----------------|------------------------------|\n| research | `research`
+  | look up `stateMap.research`\
+  \ |\n| planning | `planning` | look up `stateMap.planning` |\n| implementing | `inProgress` | look
+  up `stateMap.inProgress`\
+  \ |\n| PR opened | `inReview` | look up `stateMap.inReview` |\n| PR merged | `done` | look up
+  `stateMap.done` |\n\nUse `mcp__linear__update_issue`\
+  \ with the resolved state name. Do NOT shell\nout to any local-only `linear-transition.sh`
+  script.\n\n---\n\n## 4. PR description\
+  \ format\n\nWhen writing a PR description, use these sections in order:\n\n```\n## Summary\n##
+  Problem Statement\n## Solution\n\
+  ## Changes Made\n  ### Backend Changes\n  ### Frontend Changes\n  ### Infrastructure
+  Changes\n  ### Documentation Changes\n\
+  ## Breaking Changes\n## Database Changes\n## Performance Impact\n## Security Considerations\n##
+  How to Test\n## How to Verify\
+  \ It\n  ### Automated Checks\n  ### Integration Tests\n  ### Manual Verification Required\n##
+  Rollback Plan\n## Deployment\
+  \ Notes\n## Related Issues/PRs\n## Screenshots/Videos\n## Changelog Entry\n## Reviewer Notes\n##
+  Post-Merge Tasks\n---\n\
+  **Definition of Done Checklist:**\n```\n\nLinear ref convention in **Related Issues/PRs**:\n```\n-
+  Fixes https://linear.app/{workspace}/issue/{ticket}\n\
+  ```\n\nThe `{workspace}` and `{ticket}` come from the project context — workspace\nslug from
+  Linear team metadata, ticket\
+  \ prefix from `project-context.md`.\n\n### CRITICAL: NO CLAUDE ATTRIBUTION\n\nNEVER add any of the
+  following to a PR body,\
+  \ commit message, or any\ngenerated artifact:\n- \"Generated with Claude Code\"\n-
+  \"Co-Authored-By: Claude\"\n- AI attribution\
+  \ of any kind\n- Emojis (unless the user explicitly requests them)\n\nThis rule applies to every
+  PR, every commit, every\
+  \ comment. No exceptions.\n\n---\n\n## 5. Code review behavior (`review-comments`
+  workflow)\n\nWhen responding to a PR's\
+  \ review comments:\n\n1. Fetch three comment streams:\n   - Inline review comments:
+  `mcp__github__list_pull_request_comments`\n\
+  \   - Top-level reviews: `mcp__github__list_pull_request_reviews`\n   - Issue/conversation
+  comments: `mcp__github__list_issue_comments`\n\
+  \n2. Group threads via `in_reply_to_id`.\n\n3. Categorize each thread:\n   - **Code change
+  requested** → implement the fix\n\
+  \   - **Question / clarification** → draft a reply\n   - **Suggestion (optional)** → evaluate and
+  either implement or explain\
+  \ trade-off\n   - **Approval / praise** → no action\n   - **Already resolved** → skip\n\n4. Commit
+  fixes with message: `address\
+  \ review comments from PR #${PR_NUMBER}`\n\n5. Resolve each addressed thread via GitHub GraphQL
+  `resolveReviewThread`.\n\
+  \n### Merge-blocker classification\n- `unresolved-threads` from automated reviewers (Codex,
+  scanners) → **agent-resolvable**\n\
+  - `review-required` from a human reviewer → **human gate**, do not bypass\n\n---\n\n## 6. Quality
+  gates (when shipping code)\n\
+  \nIf the routine is producing code changes that will land on a branch, run the\n5-step quality
+  gate pipeline before opening\
+  \ or merging a PR:\n\n| Step | What runs | Failure behavior
+  |\n|------|-----------|------------------|\n| 0 | tsconfig strictness\
+  \ check | informational only |\n| 1 | `<package-manager> run type-check` (or `npx tsc --noEmit`) |
+  FAIL — fix before next\
+  \ step |\n| 2 | reward-hacking pattern scan on changed files | FAIL on any CRITICAL/HIGH |\n| 3 |
+  grep tsconfig for excluded\
+  \ test files | FAIL if tests excluded |\n| 4 | `<package-manager> run test` | FAIL on any failing
+  test |\n| 5 | Detected\
+  \ linter (`trunk` / `biome` / `eslint`) | FAIL or SKIPPED |\n\nAuto-detect the package manager
+  from the lockfile:\n- `bun.lockb`\
+  \ / `bun.lock` → bun\n- `pnpm-lock.yaml` → pnpm\n- `yarn.lock` → yarn\n- `package-lock.json` →
+  npm\n\nAuto-detect the linter\
+  \ from config files:\n- `.trunk/` → `trunk check --ci --upstream origin/main`\n- `biome.json` →
+  `biome check .`\n- `eslint.config.*`\
+  \ → `eslint .`\n\n### Reward-hacking — banned patterns\n\nThese are forbidden in code changes.
+  Reward hacking means making\
+  \ a linter or\ntype-checker pass without fixing the underlying type-safety problem.\n\n| Pattern |
+  Why forbidden | Required\
+  \ fix |\n|---------|---------------|--------------|\n| `as unknown as Type` (undocumented) |
+  Erases all type info | Fix\
+  \ source to return correct type |\n| `as any` | Disables type checking entirely | Use proper
+  typing or Zod validation |\n\
+  | `void (0 as unknown as Type)` | Tricks linter into thinking type is used | Delete the unused
+  type |\n| `const _var = ...`\
+  \ (local) | Suppresses unused warning | Delete the unused variable |\n| `export type Foo` (when
+  unused elsewhere) | Suppresses\
+  \ unused warning | Remove `export` or delete the type |\n| `// @ts-ignore` / `// @ts-expect-error`
+  | Hides real type problems\
+  \ | Fix the actual type error |\n| Commented-out code | Dead code clutters | Delete (git has
+  history) |\n| Excluding files\
+  \ from tsconfig | Hides errors in those files | Include files, fix errors |\n\nPlus
+  runtime-detected:\n- `forEach(async\
+  \ ...)` — HIGH — silently drops promise results; use `for...of` with `await`\n- Unguarded non-null
+  assertion (`var!.field`,\
+  \ `var![idx]`, `var!;`) without a preceding null check — HIGH in libraries, MEDIUM in
+  apps\n\nAcceptable exceptions (each\
+  \ must be documented in code with a TODO and a\ntracking ticket reference):\n- `as unknown as`
+  with multi-line comment documenting\
+  \ library type limitation + `TODO: Remove when...` + ticket\n- `as any` in test-file mocks only\n-
+  `// @ts-expect-error`\
+  \ with a documented reason and tracking ticket\n- Non-null assertion after an explicit `if
+  (map.has(key))` or `!= null`\
+  \ guard\n\n---\n\n## 7. MCP usage\n\n| Intent | Preferred tool |\n|--------|----------------|\n|
+  Read/update Linear issue\
+  \ | `mcp__linear__*` (e.g., `get_issue`, `update_issue`, `create_comment`) |\n| Read/write GitHub
+  PR or repo | `mcp__github__*`\
+  \ (e.g., `get_pull_request`, `create_pull_request`, `add_pull_request_review`) |\n| Post Slack
+  message | `mcp__slack__send_message`\
+  \ if Slack MCP is wired and OAuth is complete; otherwise REST
+  `https://slack.com/api/chat.postMessage` with bot token |\n\
+  | Read/write Notion page | Self-hosted Notion MCP if configured; otherwise REST
+  `https://api.notion.com/v1/*` with integration\
+  \ token |\n\nWhen an MCP server is not wired (Slack OAuth not completed, Notion MCP
+  not\nself-hosted), fall back to the\
+  \ documented REST path. Use `curl` with the\nrelevant `Authorization: Bearer ${TOKEN}` header. The
+  `${TOKEN}` env vars are\n\
+  injected at session creation from the per-user vault.\n\nSlack and Notion REST fallbacks are
+  first-class working paths for\
+  \ Phase 1\nRoutines — not workarounds. Upgrade to MCP-only when the routine needs tools\nthat REST
+  does not expose.\n\n\
+  ---\n\n## 8. Routine extension pattern\n\nThis base prompt is shared by every Phase 1 Routine.
+  Per-routine agents\nappend\
+  \ their behavior on top of this base.\n\nA routine-specific prompt typically:\n- Names the routine
+  (e.g., \"You are the\
+  \ **Backlog Triage** routine\")\n- Specifies the trigger (cron, webhook, manual)\n- Specifies
+  success criteria (artifacts\
+  \ produced, state left in Linear / GitHub)\n- Names the output target (thoughts file path, Linear
+  comment, Slack/Notion\
+  \ post)\n- Sets a wall-clock budget (most routines should complete in < 10 minutes)\n\nRoutines
+  must NOT redefine the conventions\
+  \ in this base prompt; they EXTEND it.\nA routine MAY scope itself to a specific target repo
+  (e.g., the catalyst-only\n\
+  docs-drift routine), or it MAY be project-agnostic and work against whichever\ntarget the session
+  is bound to.\n\n---\n\n\
+  ## 9. Operating principles\n\n- **Documentarian, not critic.** When asked \"where is X?\" or \"how
+  does X\n  work?\", document\
+  \ what exists. Do not propose changes unless explicitly asked.\n- **Read fully, not partially.**
+  Read tickets, plans, and\
+  \ research end-to-end\n  before acting.\n- **Wait for parallel work to complete.** When you spawn
+  parallel queries\n  (e.g.,\
+  \ multiple Linear searches), wait for all to return before synthesizing.\n- **Single source of
+  truth.** Reference canonical\
+  \ files; do not duplicate their\n  contents in your output.\n- **No hallucinated identifiers.**
+  Linear ticket IDs, PR numbers,\
+  \ file paths,\n  and SHAs must come from real tool calls — not from inference.\n- **Project values
+  come from the project\
+  \ context, not from this prompt.** If\n  this prompt and `/workspace/project-context.md` disagree
+  on a project-\n  specific\
+  \ value, the project context wins.\n\nIf the user (or the orchestrator) gives a routine-specific
+  instruction that\nconflicts\
+  \ with this base prompt, follow the more specific instruction and\nflag the conflict in your final
+  output.\n"
+tools:
+  - type: agent_toolset_20260401
+  - type: mcp_toolset
+    mcp_server_name: linear
+  - type: mcp_toolset
+    mcp_server_name: github
+  - type: mcp_toolset
+    mcp_server_name: slack
+  - type: mcp_toolset
+    mcp_server_name: notion
+mcp_servers:
+  - name: linear
+    type: streamable_http
+    url: https://mcp.linear.app/mcp
+  - name: github
+    type: streamable_http
+    url: https://api.githubcopilot.com/mcp/
+  - name: slack
+    type: streamable_http
+    url: https://mcp.slack.com/mcp
+  - name: notion
+    type: streamable_http
+    url: https://placeholder.notion-mcp.invalid/mcp
+skills: []
+metadata:
+  catalyst_role: routine-agent
+  catalyst_routine: morning-briefing
+  catalyst_ticket: CTL-469
+  writable_thoughts: "true"
+  thoughts_writable_branch: routines/curation
+  catalyst_initiative: research-curate
+  catalyst_version: v1

--- a/cma/routines/research-curate/routine.yaml
+++ b/cma/routines/research-curate/routine.yaml
@@ -1,0 +1,118 @@
+---
+# Research-Curate — CMA Routine wiring (CTL-469)
+#
+# Phase 3 of Initiative 4 (Weekly thoughts curation Routine). Wraps the
+# /catalyst-dev:research-curate skill on a weekly Sunday-evening schedule.
+# The skill itself is committed at plugins/dev/skills/research-curate/SKILL.md
+# (CTL-467 inventory + INDEX.md, CTL-468 CONTRADICTIONS.md).
+#
+# Register with:
+#   ant beta:routines create -f cma/routines/research-curate/routine.yaml
+#
+# Validate locally before registration:
+#   bash cma/routines/research-curate/__tests__/routine-config.test.sh
+#   ant beta:routines validate -f cma/routines/research-curate/routine.yaml
+#
+# Beta API header: managed-agents-2026-04-01
+
+name: catalyst-research-curate
+
+# Per-routine agent definition. Register the agent separately via
+#   ant beta:agents create -f cma/routines/research-curate/agent.yaml
+# and reference the returned agent ID at routine registration time. For local
+# validation, this relative path lets the schema check resolve the agent file.
+agent: ./agent.yaml
+
+environment: catalyst-routines-base
+
+# Repository bindings. CMA clones each repo at the start of a run.
+# - coalesce-labs/catalyst: target repo (skill code, ADRs, project context).
+# - coalesce-labs/thoughts: read-only at /workspace/thoughts-repo and writable
+#   clone at /workspace/thoughts-writable
+#   (see cma/agents/base-system-prompt.md §1a).
+repositories:
+  - coalesce-labs/catalyst
+  - coalesce-labs/thoughts
+
+# Schedule. Standard 5-field cron. Sunday 9pm local. User-tunable —
+# edit this value and re-register with `ant beta:routines update`.
+# timezone is caller-local; CMA converts at run time.
+schedule:
+  cron: "0 21 * * 0"
+  timezone: "America/New_York"
+
+# Routine prompt. Routines are invoked autonomously, so the prompt must be
+# self-contained.
+prompt: |
+  You are the Research-Curate routine. Run the committed Catalyst skill at
+  `plugins/dev/skills/research-curate/SKILL.md` against the writable thoughts
+  clone for `thoughts/shared/research/` and `thoughts/shared/plans/`.
+
+  Steps the skill performs (see SKILL.md for the authoritative version):
+    1. Inventory the target directory — walks markdown, parses frontmatter,
+       extracts file:line refs.
+    2. Score each doc — age vs reference date, validate refs against HEAD,
+       count last-30d git log hits for top-3 tags.
+    3. Classify (current / needs-review / likely-stale).
+    4. Regenerate `<target-dir>/INDEX.md` (overwritten, deterministic).
+    5. Cluster by topic, run one LLM call per cluster, append findings to
+       `<target-dir>/CONTRADICTIONS.md` (append-only — never overwrites).
+
+  Invocation. The skill's `run.sh` accepts a positional target directory and
+  a `--git-dir` flag for the ref-validation step. Run it twice — once for
+  research, once for plans — against the writable clone directly so writes
+  land on the routine-scoped branch without relying on the §1a `briefings`
+  symlink (which is morning-briefing-specific):
+
+  ```bash
+  THOUGHTS_DIR="${CATALYST_THOUGHTS_DIRECTORY:-catalyst-workspace}"
+  WCLONE="/workspace/thoughts-writable/repos/${THOUGHTS_DIR}"
+
+  bash plugins/dev/scripts/research-curate/run.sh \
+    --git-dir /workspace/thoughts-writable \
+    "${WCLONE}/shared/research"
+
+  bash plugins/dev/scripts/research-curate/run.sh \
+    --git-dir /workspace/thoughts-writable \
+    "${WCLONE}/shared/plans"
+  ```
+
+  Write-back is handled by the base agent's startup ritual:
+    - §1a clones the thoughts repo writable at `/workspace/thoughts-writable/`
+      and checks out (or creates) the `routines/curation` branch.
+    - The skill's INDEX.md and CONTRADICTIONS.md writes land directly in the
+      writable clone (no symlink needed for this routine; absolute paths
+      above route writes into the writable tree).
+    - At session exit, the base agent commits and pushes the change to
+      `routines/curation` on `coalesce-labs/thoughts`. Rebase + retry on push
+      failure; non-zero exit on hard failure.
+
+  Success criteria:
+    - `${WCLONE}/shared/research/INDEX.md` and `${WCLONE}/shared/plans/INDEX.md`
+      regenerated.
+    - `${WCLONE}/shared/research/CONTRADICTIONS.md` and
+      `${WCLONE}/shared/plans/CONTRADICTIONS.md` either created (first run) or
+      appended-to (subsequent runs). Existing entries unchanged.
+    - Push to `routines/curation` succeeds.
+    - Source markdown files under `shared/research/` and `shared/plans/`
+      are NOT modified (the skill is contractually read-only for sources;
+      `git diff` for those paths should be empty).
+
+  Failure behavior:
+    - If either `run.sh` invocation exits non-zero, report the failure and do
+      NOT push partial state.
+    - If the push fails after one rebase retry, report the failure and exit.
+      A human will see the failed run in claude.ai/code/routines.
+
+# Environment variables. These tell the base agent's §1a to enable the
+# writable clone path and identify this routine for the commit message.
+env:
+  WRITABLE_THOUGHTS: "true"
+  THOUGHTS_WRITABLE_BRANCH: "routines/curation"
+  ROUTINE_NAME: "research-curate"
+
+metadata:
+  catalyst_role: routine
+  catalyst_ticket: CTL-469
+  catalyst_initiative: "research-curate"
+  catalyst_version: v1


### PR DESCRIPTION
## Summary

Wires the `/catalyst-dev:research-curate` skill (CTL-467 + CTL-468) into a CMA Routine that
fires every Sunday at 9pm America/New_York. Each run regenerates `INDEX.md` and updates
`CONTRADICTIONS.md` for `thoughts/shared/research/` and `thoughts/shared/plans/`, then pushes
the result to the `routines/curation` branch on `coalesce-labs/thoughts`.

This is Phase 3 of Initiative 4 in the parent plan and mirrors the morning-briefing pattern
shipped in [CTL-460 / #811](https://github.com/coalesce-labs/catalyst/pull/811). The §1a
writable-thoughts-clone block already in `cma/agents/base-system-prompt.md` is parameterised
on `WRITABLE_THOUGHTS`, `THOUGHTS_WRITABLE_BRANCH`, and `ROUTINE_NAME` — research-curate
plugs in via env-var overrides only, no base-prompt changes needed.

## What this adds

- `cma/routines/research-curate/routine.yaml` — CMA Routine definition (cron `0 21 * * 0` ET,
  repos, prompt, env, metadata).
- `cma/routines/research-curate/agent.yaml` — per-routine agent (research-curate-specific
  extension block prepended to the full `base-system-prompt.md` body inlined verbatim).
- `cma/routines/research-curate/README.md` — operator guide (register, re-inline, debug,
  related). Mirrors morning-briefing's README structure.
- `cma/routines/research-curate/__tests__/routine-config.test.sh` — 7-assertion contract
  check (bash + python3+PyYAML, no framework). Asserts routine schema, base-prompt inline,
  cron value, skill reference, write-back branch, README, and ADR coverage.

## What this changes

- `cma/decisions/2026-05-17-briefing-write-back.md` — broadens scope from "the morning-briefing
  routine" to cover both routines. Adds the research-curate env vars + the absolute-path
  invocation strategy to the Implementation section. Updates follow-ups.

## Design notes

The §1a block in `cma/agents/base-system-prompt.md` creates a `/workspace/thoughts/briefings`
symlink that is morning-briefing-specific. Research-curate writes under `shared/` — a subtree
served from the read-only thoughts clone — so symlinks won't work the same way. Rather than
generalise §1a (which would force re-inlining morning-briefing's `agent.yaml` and `base.yaml`),
the routine prompt invokes `run.sh` with absolute paths into the writable clone:

```bash
THOUGHTS_DIR="${CATALYST_THOUGHTS_DIRECTORY:-catalyst-workspace}"
WCLONE="/workspace/thoughts-writable/repos/${THOUGHTS_DIR}"
bash plugins/dev/scripts/research-curate/run.sh \
  --git-dir /workspace/thoughts-writable "${WCLONE}/shared/research"
bash plugins/dev/scripts/research-curate/run.sh \
  --git-dir /workspace/thoughts-writable "${WCLONE}/shared/plans"
```

The §1a write-back block picks up writes anywhere under `/workspace/thoughts-writable/` via
`git add -A`, so no symlink is needed. The §1a `briefings` symlink becomes a harmless no-op
for this routine. The rationale is documented in the README and the updated ADR.

## Acceptance criteria

- [x] `bash cma/routines/research-curate/__tests__/routine-config.test.sh` passes
      (7/7 assertions green)
- [x] Morning-briefing tests still pass (regression check)
- [x] YAML parses; agent.yaml inlined base body matches `base-system-prompt.md` exactly
      (no drift)
- [x] Trunk-clean on all 5 changed files except yamllint/line-length warnings inside
      agent.yaml's inlined base-prompt body, which match the baseline morning-briefing
      accepts (long markdown lines inside YAML literal blocks — fundamentally unfixable
      without restructuring the base prompt)
- [ ] CMA validates routine (`ant beta:routines validate -f routine.yaml`) — operator action
      after merge, documented in README
- [ ] Routine registers and one scheduled run completes — operator action after merge,
      documented in README

## Out of scope

- **First scheduled run / acceptance.** The third acceptance criterion requires `ant` CLI
  access and a vault with the upgraded thoughts PAT scope. Operator step, documented in the
  README. Same posture as CTL-460 / [PR #811](https://github.com/coalesce-labs/catalyst/pull/811).
- **Parent plan §Refactor: extract write-back into shared helper agent.** Deferred. With only
  two consumers (briefings, curation) using different path strategies, a real helper-agent
  extraction is premature — would be the right move once a third routine surfaces a missing
  parameter. Captured as a follow-up in the updated ADR.

## Test plan

```bash
# Repeat the green run locally:
bash cma/routines/research-curate/__tests__/routine-config.test.sh
bash cma/routines/morning-briefing/__tests__/routine-config.test.sh   # regression

# After merge, operator runs (per README):
ant beta:routines validate -f cma/routines/research-curate/routine.yaml
ant beta:agents create   -f cma/routines/research-curate/agent.yaml
ant beta:routines create -f cma/routines/research-curate/routine.yaml
```

## Related

- [CTL-469](https://linear.app/coalesce-labs/issue/CTL-469) — this ticket
- [CTL-460](https://linear.app/coalesce-labs/issue/CTL-460) / [#811](https://github.com/coalesce-labs/catalyst/pull/811) — morning-briefing pattern this mirrors
- [CTL-467](https://linear.app/coalesce-labs/issue/CTL-467) — research-curate skill MVP
- [CTL-468](https://linear.app/coalesce-labs/issue/CTL-468) — CONTRADICTIONS.md extension
- [CTL-470](https://linear.app/coalesce-labs/issue/CTL-470) — follow-on (blocked by this)
- [CTL-446](https://linear.app/coalesce-labs/issue/CTL-446) — parent ticket
- Parent plan: `thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md` §Initiative 4 Phase 3
- Implementation plan: `thoughts/shared/plans/2026-05-17-CTL-469-research-curate-routine-wiring.md`
- Write-back ADR (updated): `cma/decisions/2026-05-17-briefing-write-back.md`