### PR TITLE
feat(dev): briefing-followup ADR-drift resolution flow (CTL-464)

### DIFF
--- a/plugins/dev/scripts/__tests__/briefing-followup-adr-drift.test.sh
+++ b/plugins/dev/scripts/__tests__/briefing-followup-adr-drift.test.sh
@@ -1,0 +1,476 @@
+#!/usr/bin/env bash
+# Tests for the briefing-followup ADR-drift resolution flow (CTL-464 Phase 3).
+# Covers: action-adr.sh sub-modes update / ticket / defer + the SKILL.md
+# adr_drift case arm.
+#
+# Run: bash plugins/dev/scripts/__tests__/briefing-followup-adr-drift.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+BF_DIR="${REPO_ROOT}/plugins/dev/scripts/briefing-followup"
+TARGET="${BF_DIR}/action-adr.sh"
+RECORD="${BF_DIR}/record-resolution.sh"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/briefing-followup/SKILL.md"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  shift
+  for line in "$@"; do echo "    $line"; done
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected: $expected" "actual:   $actual"
+  fi
+}
+
+assert_grep() {
+  local label="$1" pattern="$2" content="$3"
+  if grep -qF -- "$pattern" <<<"$content"; then
+    pass "$label"
+  else
+    fail "$label" "expected substring: $pattern" \
+      "actual: $(printf '%s' "$content" | head -20)"
+  fi
+}
+
+assert_regex() {
+  local label="$1" pattern="$2" content="$3"
+  if [[ "$content" =~ $pattern ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected regex match: $pattern" "actual: $content"
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected exit: $expected" "actual exit:   $actual"
+  fi
+}
+
+# Build a sandbox git repo containing a single ADR with frontmatter.
+setup_repo() {
+  local repo="$1"
+  mkdir -p "$repo/docs/adrs"
+  cat > "$repo/docs/adrs/0001-test.md" <<'ADR'
+---
+adr_id: ADR-001
+title: Test ADR
+date: 2026-05-17
+---
+
+# Test ADR
+
+Body of the ADR.
+ADR
+  (
+    cd "$repo" \
+      && git init -q -b main 2>/dev/null || git init -q \
+      && git config user.email "test@example.com" \
+      && git config user.name "Test User" \
+      && git add . \
+      && git commit -q -m "init"
+  )
+}
+
+# Fake $EDITOR. FAKE_EDITOR_SCRIPT runs with $1 = the file path.
+install_fake_editor() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/editor" <<'EOF'
+#!/usr/bin/env bash
+echo "editor $*" >> "${FAKE_EDITOR_LOG:-/dev/null}"
+if [[ -n "${FAKE_EDITOR_SCRIPT:-}" ]]; then
+  bash -c "$FAKE_EDITOR_SCRIPT" -- "$1"
+fi
+EOF
+  chmod +x "$bin_dir/editor"
+}
+
+install_fake_linearis() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/linearis" <<'EOF'
+#!/usr/bin/env bash
+echo "linearis $*" >> "${FAKE_LINEARIS_LOG:-/dev/null}"
+if [[ "${1:-}" == "teams" && "${2:-}" == "list" ]]; then
+  cat <<JSON
+[{"id":"${FAKE_LINEARIS_TEAM_UUID:-00000000-0000-0000-0000-000000000001}","key":"${FAKE_LINEARIS_TEAM_KEY:-CTL}","name":"Catalyst"}]
+JSON
+  exit 0
+fi
+if [[ "${1:-}" == "issues" && "${2:-}" == "create" ]]; then
+  if [[ "${FAKE_LINEARIS_FAIL_CREATE:-0}" == "1" ]]; then
+    echo "${FAKE_LINEARIS_FAIL_REASON:-fake auth error}" >&2
+    exit 1
+  fi
+  cat <<JSON
+{"identifier":"${FAKE_LINEARIS_ID:-TST-99}","url":"https://linear.app/x/issue/${FAKE_LINEARIS_ID:-TST-99}","title":"fake"}
+JSON
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$bin_dir/linearis"
+}
+
+# ─── Test 1: action-adr.sh --mode update ─────────────────────────────────────
+test_action_adr_update() {
+  echo "test 1: action-adr.sh --mode update"
+  local t_dir="$SCRATCH/t1"
+  local repo="$t_dir/repo"
+  local bin_dir="$t_dir/bin"
+  local editor_log="$t_dir/editor.log"
+  mkdir -p "$t_dir"
+  setup_repo "$repo"
+  install_fake_editor "$bin_dir"
+
+  local adr_file="$repo/docs/adrs/0001-test.md"
+
+  # Happy path: editor appends a line. action-adr.sh should commit.
+  local out ec
+  out=$(FAKE_EDITOR_LOG="$editor_log" \
+        FAKE_EDITOR_SCRIPT='printf "\nNew section.\n" >> "$1"' \
+        EDITOR="editor" \
+        PATH="$bin_dir:$PATH" \
+        bash "$TARGET" --mode update --adr-file "$adr_file" 2>&1)
+  ec=$?
+
+  assert_exit "update happy exits 0" "0" "$ec"
+  assert_grep "update happy status=updated" '"status":"updated"' "$out"
+  assert_grep "update happy adr_id surfaced" '"adr_id":"ADR-001"' "$out"
+  assert_grep "update happy commit_sha present" '"commit_sha":"' "$out"
+
+  # Verify git history.
+  local subj
+  subj=$(git -C "$repo" log -1 --pretty=%s)
+  assert_eq "update commit subject" "docs(adr): resolve drift in ADR-001" "$subj"
+
+  # No-edit path: re-run with a no-op editor; should skip with "no changes".
+  local out2 ec2
+  out2=$(FAKE_EDITOR_LOG="$editor_log" \
+         FAKE_EDITOR_SCRIPT='' \
+         EDITOR="editor" \
+         PATH="$bin_dir:$PATH" \
+         bash "$TARGET" --mode update --adr-file "$adr_file" 2>&1)
+  ec2=$?
+  assert_exit "update no-edit exits 0" "0" "$ec2"
+  assert_grep "update no-edit status=skipped" '"status":"skipped"' "$out2"
+  assert_grep "update no-edit reason mentions no changes" "no changes" "$out2"
+
+  # Soft-skip: EDITOR unset.
+  local out3 ec3
+  out3=$(env -u EDITOR PATH="$bin_dir:$PATH" \
+         bash "$TARGET" --mode update --adr-file "$adr_file" 2>&1)
+  ec3=$?
+  assert_exit "update no-EDITOR exits 0" "0" "$ec3"
+  assert_grep "update no-EDITOR status=skipped" '"status":"skipped"' "$out3"
+  assert_grep "update no-EDITOR reason mentions EDITOR" "EDITOR" "$out3"
+}
+
+# ─── Test 2: action-adr.sh --mode ticket ─────────────────────────────────────
+test_action_adr_ticket() {
+  echo "test 2: action-adr.sh --mode ticket"
+  local t_dir="$SCRATCH/t2"
+  local repo="$t_dir/repo"
+  local bin_dir="$t_dir/bin"
+  local log="$t_dir/linearis.log"
+  mkdir -p "$t_dir"
+  setup_repo "$repo"
+  install_fake_linearis "$bin_dir"
+
+  local adr_file="$repo/docs/adrs/0001-test.md"
+
+  # Happy path.
+  local out ec
+  out=$(FAKE_LINEARIS_LOG="$log" \
+        FAKE_LINEARIS_ID=TST-101 \
+        PATH="$bin_dir:$PATH" \
+        bash "$TARGET" --mode ticket --adr-file "$adr_file" --team CTL \
+                       --summary "Code lacks worktree convention" \
+                       --drift-status "code_ahead_of_adr" 2>&1)
+  ec=$?
+
+  assert_exit "ticket happy exits 0" "0" "$ec"
+  assert_grep "ticket happy identifier" '"identifier":"TST-101"' "$out"
+  assert_grep "ticket happy adr_id" '"adr_id":"ADR-001"' "$out"
+  assert_grep "ticket happy status=filed" '"status":"filed"' "$out"
+  assert_grep "ticket happy url" '"url":"https://linear.app' "$out"
+
+  local log_content
+  log_content=$(cat "$log" 2>/dev/null || echo "")
+  assert_grep "linearis invoked: issues create" "issues create" "$log_content"
+  assert_grep "linearis team resolved to UUID" \
+    "00000000-0000-0000-0000-000000000001" "$log_content"
+  assert_grep "linearis title references ADR-001" "ADR-001" "$log_content"
+  assert_grep "linearis description references adr file path" \
+    "/docs/adrs/0001-test.md" "$log_content"
+
+  # Soft-skip: linearis not on PATH.
+  local skip_out skip_ec
+  skip_out=$(PATH="/usr/bin:/bin" \
+             bash "$TARGET" --mode ticket --adr-file "$adr_file" --team CTL 2>&1)
+  skip_ec=$?
+  assert_exit "ticket soft-skip exits 0" "0" "$skip_ec"
+  assert_grep "ticket soft-skip status=skipped" '"status":"skipped"' "$skip_out"
+
+  # Hard fail.
+  local fail_out fail_ec
+  fail_out=$(FAKE_LINEARIS_LOG="$log" \
+             FAKE_LINEARIS_FAIL_CREATE=1 \
+             FAKE_LINEARIS_FAIL_REASON="auth denied" \
+             PATH="$bin_dir:$PATH" \
+             bash "$TARGET" --mode ticket --adr-file "$adr_file" --team CTL 2>&1)
+  fail_ec=$?
+  assert_exit "ticket fail exits 1" "1" "$fail_ec"
+  assert_grep "ticket fail status=failed" '"status":"failed"' "$fail_out"
+  assert_grep "ticket fail surfaces stderr reason" "auth denied" "$fail_out"
+}
+
+# ─── Test 3: action-adr.sh --mode defer ──────────────────────────────────────
+test_action_adr_defer() {
+  echo "test 3: action-adr.sh --mode defer"
+  local t_dir="$SCRATCH/t3"
+  local repo="$t_dir/repo"
+  mkdir -p "$t_dir"
+  setup_repo "$repo"
+
+  local adr_file="$repo/docs/adrs/0001-test.md"
+
+  # Happy path: explicit date + reason.
+  local out ec
+  out=$(bash "$TARGET" --mode defer --adr-file "$adr_file" \
+        --reason "intentional divergence" --date 2026-05-17 2>&1)
+  ec=$?
+
+  assert_exit "defer happy exits 0" "0" "$ec"
+  assert_grep "defer happy status=deferred" '"status":"deferred"' "$out"
+  assert_grep "defer happy adr_id" '"adr_id":"ADR-001"' "$out"
+  assert_grep "defer happy commit_sha present" '"commit_sha":"' "$out"
+
+  local file_content
+  file_content=$(cat "$adr_file")
+  assert_grep "defer appended drift-noted comment" \
+    "<!-- drift-noted: 2026-05-17: intentional divergence -->" "$file_content"
+
+  local subj
+  subj=$(git -C "$repo" log -1 --pretty=%s)
+  assert_eq "defer commit subject" "docs(adr): defer drift on ADR-001" "$subj"
+
+  # Default date: omit --date, should use today's UTC date.
+  local out2 ec2
+  out2=$(bash "$TARGET" --mode defer --adr-file "$adr_file" \
+         --reason "another deferral" 2>&1)
+  ec2=$?
+  assert_exit "defer default-date exits 0" "0" "$ec2"
+  local file_content2
+  file_content2=$(cat "$adr_file")
+  # Must contain a drift-noted comment with today's date — match by regex.
+  local today
+  today=$(date -u +%Y-%m-%d)
+  assert_grep "defer default-date used today UTC" \
+    "<!-- drift-noted: ${today}: another deferral -->" "$file_content2"
+
+  # Missing --reason: invocation error.
+  local bad_ec
+  bash "$TARGET" --mode defer --adr-file "$adr_file" >/dev/null 2>&1
+  bad_ec=$?
+  assert_exit "defer missing --reason exits 2" "2" "$bad_ec"
+}
+
+# ─── Test 4: action-adr.sh integrates with record-resolution.sh ──────────────
+test_action_adr_record_resolution() {
+  echo "test 4: action-adr.sh result JSON feeds record-resolution.sh"
+  local t_dir="$SCRATCH/t4"
+  local repo="$t_dir/repo"
+  local log_dir="$t_dir/logs"
+  local bin_dir="$t_dir/bin"
+  mkdir -p "$t_dir" "$log_dir"
+  setup_repo "$repo"
+
+  local adr_file="$repo/docs/adrs/0001-test.md"
+
+  # Defer mode (no external deps) — guarantees a successful action.
+  local action_out
+  action_out=$(bash "$TARGET" --mode defer --adr-file "$adr_file" \
+               --reason "test integration" --date 2026-05-17 2>&1)
+
+  bash "$RECORD" --log-dir "$log_dir" --date 2026-05-17 \
+    --id "adr-drift-0001-test-0" --action "adr_defer" \
+    --result "$action_out" >/dev/null
+
+  local resfile="$log_dir/briefing-followup-2026-05-17-resolutions.json"
+  if [[ -f "$resfile" ]]; then
+    pass "resolutions file written for defer"
+  else
+    fail "resolutions file written for defer" "expected at $resfile"
+    return
+  fi
+
+  local action recorded_status
+  action=$(jq -r '.[0].action' "$resfile")
+  assert_eq "recorded action is adr_defer" "adr_defer" "$action"
+  recorded_status=$(jq -r '.[0].result.status' "$resfile")
+  assert_eq "recorded result.status is deferred" "deferred" "$recorded_status"
+
+  # Update mode — chain editor stub then record-resolution.
+  install_fake_editor "$bin_dir"
+  local update_out
+  update_out=$(FAKE_EDITOR_SCRIPT='printf "\nMore.\n" >> "$1"' \
+               EDITOR="editor" \
+               PATH="$bin_dir:$PATH" \
+               bash "$TARGET" --mode update --adr-file "$adr_file" 2>&1)
+
+  bash "$RECORD" --log-dir "$log_dir" --date 2026-05-17 \
+    --id "adr-drift-0001-test-0" --action "adr_update" \
+    --result "$update_out" >/dev/null
+
+  local len updated_status
+  len=$(jq 'length' "$resfile")
+  assert_eq "resolutions file now has 2 entries" "2" "$len"
+  updated_status=$(jq -r '.[1].result.status' "$resfile")
+  assert_eq "recorded result.status is updated" "updated" "$updated_status"
+}
+
+# ─── Test 5: SKILL.md adr_drift arm wired to action-adr.sh ───────────────────
+test_skill_md_adr_arm() {
+  echo "test 5: SKILL.md adr_drift case arm references action-adr.sh"
+  if [[ ! -f "$SKILL_MD" ]]; then
+    fail "SKILL.md exists at $SKILL_MD" "file missing"
+    return
+  fi
+  local content
+  content=$(cat "$SKILL_MD")
+
+  # Placeholder text must be gone.
+  if grep -qF "Phase 3 / CTL-464 will wire ADR actions" "$SKILL_MD"; then
+    fail "SKILL.md placeholder removed" \
+      "still contains 'Phase 3 / CTL-464 will wire ADR actions'"
+  else
+    pass "SKILL.md placeholder removed"
+  fi
+
+  # adr_drift arm references action-adr.sh.
+  assert_grep "SKILL.md handler table lists adr_update" "adr_update" "$content"
+  assert_grep "SKILL.md handler table lists adr_ticket" "adr_ticket" "$content"
+  assert_grep "SKILL.md handler table lists adr_defer" "adr_defer" "$content"
+  assert_grep "SKILL.md references action-adr.sh" "action-adr.sh" "$content"
+}
+
+# ─── Test 6: soft-skip when ADR file isn't in a git repo ─────────────────────
+test_action_adr_not_in_git_repo() {
+  echo "test 6: action-adr.sh soft-skips when ADR file isn't in a git repo"
+  local t_dir="$SCRATCH/t6"
+  local bin_dir="$t_dir/bin"
+  mkdir -p "$t_dir/loose"
+  install_fake_editor "$bin_dir"
+
+  local adr_file="$t_dir/loose/0001-test.md"
+  cat > "$adr_file" <<'ADR'
+---
+adr_id: ADR-001
+---
+body
+ADR
+
+  # update mode
+  local out ec
+  out=$(FAKE_EDITOR_SCRIPT='printf "x\n" >> "$1"' EDITOR="editor" \
+        PATH="$bin_dir:$PATH" \
+        bash "$TARGET" --mode update --adr-file "$adr_file" 2>&1)
+  ec=$?
+  assert_exit "update non-repo exits 0" "0" "$ec"
+  assert_grep "update non-repo status=skipped" '"status":"skipped"' "$out"
+  assert_grep "update non-repo reason mentions git repo" "git repo" "$out"
+
+  # defer mode (separate adr file to keep state clean)
+  local adr_file2="$t_dir/loose/0002-test.md"
+  cat > "$adr_file2" <<'ADR'
+---
+adr_id: ADR-002
+---
+body
+ADR
+  local out2 ec2
+  out2=$(bash "$TARGET" --mode defer --adr-file "$adr_file2" \
+         --reason "outside repo" 2>&1)
+  ec2=$?
+  assert_exit "defer non-repo exits 0" "0" "$ec2"
+  assert_grep "defer non-repo status=skipped" '"status":"skipped"' "$out2"
+  assert_grep "defer non-repo reason mentions git repo" "git repo" "$out2"
+
+  # File must NOT have been modified (the soft-skip happens before append).
+  local body
+  body=$(cat "$adr_file2")
+  if grep -qF "drift-noted" <<<"$body"; then
+    fail "defer non-repo did not append to file" \
+      "file was modified despite soft-skip"
+  else
+    pass "defer non-repo did not append to file"
+  fi
+}
+
+# ─── Test 7: adr_id fallback to basename when frontmatter missing ────────────
+test_action_adr_basename_fallback() {
+  echo "test 7: action-adr.sh derives adr_id from basename when frontmatter absent"
+  local t_dir="$SCRATCH/t7"
+  local repo="$t_dir/repo"
+  mkdir -p "$repo/docs/adrs"
+  cat > "$repo/docs/adrs/0042-no-frontmatter.md" <<'ADR'
+# ADR with no YAML frontmatter
+
+Body text only.
+ADR
+  (
+    cd "$repo" \
+      && git init -q -b main 2>/dev/null || git init -q
+    git -C "$repo" config user.email "test@example.com"
+    git -C "$repo" config user.name "Test"
+    git -C "$repo" add . && git -C "$repo" commit -q -m "init"
+  )
+
+  local adr_file="$repo/docs/adrs/0042-no-frontmatter.md"
+
+  # Defer mode — easy path with no external deps.
+  local out
+  out=$(bash "$TARGET" --mode defer --adr-file "$adr_file" \
+        --reason "no fm" --date 2026-05-17 2>&1)
+
+  assert_grep "adr_id falls back to basename" \
+    '"adr_id":"0042-no-frontmatter"' "$out"
+
+  local subj
+  subj=$(git -C "$repo" log -1 --pretty=%s)
+  assert_eq "defer commit subject uses basename adr_id" \
+    "docs(adr): defer drift on 0042-no-frontmatter" "$subj"
+}
+
+test_action_adr_update
+test_action_adr_ticket
+test_action_adr_defer
+test_action_adr_record_resolution
+test_skill_md_adr_arm
+test_action_adr_not_in_git_repo
+test_action_adr_basename_fallback
+
+echo "─────────────────────────────────────"
+echo "PASSED: $PASSES"
+echo "FAILED: $FAILURES"
+echo "─────────────────────────────────────"
+exit $(( FAILURES > 0 ? 1 : 0 ))

--- a/plugins/dev/scripts/briefing-followup/action-adr.sh
+++ b/plugins/dev/scripts/briefing-followup/action-adr.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# action-adr.sh — Resolve an ADR-drift decision via one of three sub-modes:
+#   update : open the ADR file in $EDITOR; commit on save.
+#   ticket : file a Linear ticket scoped to the drift.
+#   defer  : append <!-- drift-noted: DATE: REASON --> to the ADR and commit.
+#
+# Usage:
+#   action-adr.sh --mode update|ticket|defer --adr-file PATH [...]
+#
+# Mode-specific flags:
+#   update : (none required; uses $EDITOR)
+#   ticket : --team K  [--title T] [--description D] [--summary S] [--drift-status DS]
+#   defer  : --reason R  [--date YYYY-MM-DD]
+#
+# Common optional: --adr-id ID  (defaults to frontmatter adr_id, else basename).
+#
+# Output (stdout, one JSON line):
+#   update : {"adr_file":"...","adr_id":"...","commit_sha":"...","status":"updated"}
+#   ticket : {"identifier":"CTL-1000","url":"...","adr_id":"...","status":"filed"}
+#   defer  : {"adr_file":"...","adr_id":"...","commit_sha":"...","status":"deferred"}
+# Soft-skip: {"status":"skipped","reason":"..."} (exit 0)
+# Hard fail: {"status":"failed","reason":"..."}  (exit 1)
+# Bad args : stderr message + exit 2
+
+set -uo pipefail
+
+MODE=""
+ADR_FILE=""
+ADR_ID=""
+# ticket-mode
+TEAM=""
+TITLE=""
+DESCRIPTION=""
+SUMMARY=""
+DRIFT_STATUS=""
+# defer-mode
+REASON=""
+DATE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)         MODE="$2"; shift 2 ;;
+    --adr-file)     ADR_FILE="$2"; shift 2 ;;
+    --adr-id)       ADR_ID="$2"; shift 2 ;;
+    --team)         TEAM="$2"; shift 2 ;;
+    --title)        TITLE="$2"; shift 2 ;;
+    --description)  DESCRIPTION="$2"; shift 2 ;;
+    --summary)      SUMMARY="$2"; shift 2 ;;
+    --drift-status) DRIFT_STATUS="$2"; shift 2 ;;
+    --reason)       REASON="$2"; shift 2 ;;
+    --date)         DATE="$2"; shift 2 ;;
+    -h|--help)      sed -n '2,24p' "$0"; exit 0 ;;
+    *) echo "action-adr.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$MODE" in
+  update|ticket|defer) ;;
+  "") echo "action-adr.sh: --mode is required (update|ticket|defer)" >&2; exit 2 ;;
+  *)  echo "action-adr.sh: --mode must be update|ticket|defer (got: $MODE)" >&2; exit 2 ;;
+esac
+
+if [[ -z "$ADR_FILE" ]]; then
+  echo "action-adr.sh: --adr-file is required" >&2
+  exit 2
+fi
+
+if [[ ! -f "$ADR_FILE" ]]; then
+  jq -nc --arg reason "adr-file not found: $ADR_FILE" \
+    '{status: "skipped", reason: $reason}'
+  exit 0
+fi
+
+# Derive ADR_ID from frontmatter `adr_id:` scalar; fall back to basename.
+if [[ -z "$ADR_ID" ]]; then
+  ADR_ID=$(grep -m1 '^adr_id:' "$ADR_FILE" 2>/dev/null \
+    | sed -E 's/^adr_id:[[:space:]]*//; s/^"//; s/"$//; s/^'\''//; s/'\''$//')
+  [[ -z "$ADR_ID" ]] && ADR_ID="$(basename "$ADR_FILE" .md)"
+fi
+
+# Resolve the git repo root containing the ADR. Empty when the file isn't in a repo.
+adr_dir() { cd "$(dirname "$ADR_FILE")" && pwd; }
+REPO_TOP=$(git -C "$(adr_dir)" rev-parse --show-toplevel 2>/dev/null || echo "")
+
+case "$MODE" in
+
+  update)
+    if [[ -z "${EDITOR:-}" ]]; then
+      jq -nc --arg reason "EDITOR not set" \
+        '{status: "skipped", reason: $reason}'
+      exit 0
+    fi
+
+    if [[ -z "$REPO_TOP" ]]; then
+      jq -nc --arg reason "adr-file not in a git repo: $ADR_FILE" \
+        '{status: "skipped", reason: $reason}'
+      exit 0
+    fi
+
+    PRE_HASH=$(git -C "$REPO_TOP" hash-object "$ADR_FILE" 2>/dev/null || echo "")
+
+    # Invoke editor. Word-split $EDITOR so compound values like "code --wait"
+    # work the same way git does for GIT_EDITOR. $ADR_FILE is intentionally
+    # quoted so paths with shell metacharacters never get re-interpreted.
+    # shellcheck disable=SC2086
+    $EDITOR "$ADR_FILE"
+
+    POST_HASH=$(git -C "$REPO_TOP" hash-object "$ADR_FILE" 2>/dev/null || echo "")
+
+    if [[ -z "$POST_HASH" || "$PRE_HASH" == "$POST_HASH" ]]; then
+      jq -nc --arg reason "no changes saved by editor" \
+        '{status: "skipped", reason: $reason}'
+      exit 0
+    fi
+
+    if ! git -C "$REPO_TOP" add -- "$ADR_FILE" >/dev/null 2>&1; then
+      jq -nc --arg reason "git add failed" \
+        '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+
+    STDERR_FILE=$(mktemp -t action-adr-update-stderr.XXXXXX)
+    if ! git -C "$REPO_TOP" commit -q \
+           -m "docs(adr): resolve drift in $ADR_ID" \
+           -- "$ADR_FILE" 2>"$STDERR_FILE"; then
+      STDERR_TAIL=$(tail -c 500 "$STDERR_FILE" 2>/dev/null || echo "")
+      rm -f "$STDERR_FILE"
+      REASON_MSG="git commit failed"
+      [[ -n "$STDERR_TAIL" ]] && REASON_MSG="${REASON_MSG}: ${STDERR_TAIL}"
+      jq -nc --arg reason "$REASON_MSG" '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+    rm -f "$STDERR_FILE"
+
+    COMMIT_SHA=$(git -C "$REPO_TOP" rev-parse HEAD)
+    jq -nc \
+      --arg adr_file "$ADR_FILE" \
+      --arg adr_id "$ADR_ID" \
+      --arg sha "$COMMIT_SHA" \
+      '{adr_file: $adr_file, adr_id: $adr_id, commit_sha: $sha, status: "updated"}'
+    ;;
+
+  ticket)
+    if [[ -z "$TEAM" ]]; then
+      echo "action-adr.sh: --team is required for ticket mode" >&2
+      exit 2
+    fi
+
+    if ! command -v linearis >/dev/null 2>&1; then
+      jq -nc --arg reason "linearis not on PATH" \
+        '{status: "skipped", reason: $reason}'
+      exit 0
+    fi
+
+    # Compose defaults from any provided context. The title surfaces the ADR id;
+    # the body links the drift to the ADR file path so a reviewer can find both.
+    if [[ -z "$TITLE" ]]; then
+      if [[ -n "$SUMMARY" ]]; then
+        TITLE="Resolve drift from ${ADR_ID}: ${SUMMARY}"
+      else
+        TITLE="Resolve drift from ${ADR_ID}"
+      fi
+    fi
+    if [[ -z "$DESCRIPTION" ]]; then
+      DESCRIPTION="Code drift detected against ${ADR_ID}."$'\n\n'
+      DESCRIPTION+="ADR file: ${ADR_FILE}"$'\n'
+      DESCRIPTION+="ADR id: ${ADR_ID}"$'\n'
+      [[ -n "$DRIFT_STATUS" ]] && DESCRIPTION+="Drift status: ${DRIFT_STATUS}"$'\n'
+      [[ -n "$SUMMARY"      ]] && DESCRIPTION+="Summary: ${SUMMARY}"$'\n'
+      DESCRIPTION+=$'\n'"This ticket tracks the code work required to bring the implementation back in line with the ADR."
+    fi
+
+    # linearis upstream bug czottmann/linearis#56: --team must be a UUID, not a
+    # key/name. Resolve key→UUID up front (mirrors action-ticket.sh).
+    RESOLVED_TEAM="$TEAM"
+    if ! [[ "$TEAM" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+      TEAMS_JSON=$(linearis teams list 2>/dev/null || true)
+      CANDIDATE=$(echo "$TEAMS_JSON" \
+        | jq -r --arg k "$TEAM" \
+            '.[]? | select(.key == $k or .name == $k) | .id' 2>/dev/null \
+        | head -n1)
+      if [[ -n "$CANDIDATE" ]]; then
+        RESOLVED_TEAM="$CANDIDATE"
+      fi
+    fi
+
+    ARGS=( issues create "$TITLE" --team "$RESOLVED_TEAM" --description "$DESCRIPTION" )
+
+    STDERR_FILE=$(mktemp -t action-adr-ticket-stderr.XXXXXX)
+    CREATE_JSON=$(linearis "${ARGS[@]}" 2>"$STDERR_FILE")
+    EXIT_CODE=$?
+    STDERR_TAIL=$(tail -c 500 "$STDERR_FILE" 2>/dev/null || echo "")
+    rm -f "$STDERR_FILE"
+
+    IDENT=$(echo "$CREATE_JSON" | jq -r '.identifier // empty' 2>/dev/null || echo "")
+    URL=$(echo "$CREATE_JSON" | jq -r '.url // empty' 2>/dev/null || echo "")
+
+    if [[ -z "$IDENT" ]]; then
+      REASON_MSG="linearis issues create returned no identifier (exit=$EXIT_CODE)"
+      [[ -n "$STDERR_TAIL" ]] && REASON_MSG="${REASON_MSG}: ${STDERR_TAIL}"
+      jq -nc --arg reason "$REASON_MSG" '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+
+    jq -nc \
+      --arg id "$IDENT" \
+      --arg url "$URL" \
+      --arg adr_id "$ADR_ID" \
+      '{identifier: $id, url: $url, adr_id: $adr_id, status: "filed"}'
+    ;;
+
+  defer)
+    if [[ -z "$REASON" ]]; then
+      echo "action-adr.sh: --reason is required for defer mode" >&2
+      exit 2
+    fi
+    [[ -z "$DATE" ]] && DATE=$(date -u +%Y-%m-%d)
+
+    if [[ -z "$REPO_TOP" ]]; then
+      jq -nc --arg reason "adr-file not in a git repo: $ADR_FILE" \
+        '{status: "skipped", reason: $reason}'
+      exit 0
+    fi
+
+    # Ensure file ends with a newline so the appended comment isn't merged onto
+    # the last existing line.
+    if [[ -n "$(tail -c1 "$ADR_FILE" 2>/dev/null)" ]]; then
+      printf '\n' >> "$ADR_FILE"
+    fi
+    printf '<!-- drift-noted: %s: %s -->\n' "$DATE" "$REASON" >> "$ADR_FILE"
+
+    if ! git -C "$REPO_TOP" add -- "$ADR_FILE" >/dev/null 2>&1; then
+      jq -nc --arg reason "git add failed" \
+        '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+
+    STDERR_FILE=$(mktemp -t action-adr-defer-stderr.XXXXXX)
+    if ! git -C "$REPO_TOP" commit -q \
+           -m "docs(adr): defer drift on $ADR_ID" \
+           -- "$ADR_FILE" 2>"$STDERR_FILE"; then
+      STDERR_TAIL=$(tail -c 500 "$STDERR_FILE" 2>/dev/null || echo "")
+      rm -f "$STDERR_FILE"
+      REASON_MSG="git commit failed"
+      [[ -n "$STDERR_TAIL" ]] && REASON_MSG="${REASON_MSG}: ${STDERR_TAIL}"
+      jq -nc --arg reason "$REASON_MSG" '{status: "failed", reason: $reason}'
+      exit 1
+    fi
+    rm -f "$STDERR_FILE"
+
+    COMMIT_SHA=$(git -C "$REPO_TOP" rev-parse HEAD)
+    jq -nc \
+      --arg adr_file "$ADR_FILE" \
+      --arg adr_id "$ADR_ID" \
+      --arg sha "$COMMIT_SHA" \
+      '{adr_file: $adr_file, adr_id: $adr_id, commit_sha: $sha, status: "deferred"}'
+    ;;
+esac

--- a/plugins/dev/skills/briefing-followup/SKILL.md
+++ b/plugins/dev/skills/briefing-followup/SKILL.md
@@ -5,9 +5,9 @@ description:
   thoughts/briefings/YYYY-MM-DD.md (built by [[morning-briefing]]), parses the structured
   decisions: frontmatter, walks the user through each open decision, and executes the
   selected action via supported handlers — schedule calendar entry, file Linear ticket,
-  dispatch orchestrator, draft email. Phase 2 wires the real action handlers; Phase 3
-  (CTL-464) wires ADR-drift-specific actions; Phase 4 (CTL-465) writes resolutions back
-  to the briefing markdown.
+  dispatch orchestrator, draft email, plus ADR-drift-specific actions (update ADR / file
+  code-drift ticket / defer with a drift note). Phase 4 (CTL-465) writes resolutions
+  back to the briefing markdown.
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Task, mcp__*
@@ -155,7 +155,7 @@ echo "$DECISIONS_JSON" | jq -c '.[]' | while IFS= read -r dec; do
       echo "Actions: [a]pprove · [r]eject · [d]efer · [o]rchestrate · [s]kip · [q]uit"
       ;;
     adr_drift)
-      echo "Actions: [d]efer · [s]kip · [q]uit  (Phase 3 / CTL-464 will wire ADR actions)"
+      echo "Actions: [u]pdate ADR · [t]icket (code drift) · [D]efer · [s]kip · [q]uit"
       ;;
     *)
       echo "Actions: [a]pprove · [r]eject · [d]efer · [c]alendar · [t]icket · [o]rchestrate · [e]mail · [s]kip · [q]uit"
@@ -177,6 +177,9 @@ to action handlers as follows:
 | file a ticket / open Linear issue | `action-ticket.sh` → `record_resolution "$ID" file_ticket "$JSON"` | TSV + JSON |
 | dispatch orchestrator / kick off the work / run oneshot | `action-orchestrate.sh --bg` → `record_resolution "$ID" dispatch_orchestrator "$JSON"` | TSV + JSON |
 | draft email / send a note to X / message Y | `action-email.sh` → `record_resolution "$ID" draft_email "$JSON"` | TSV + JSON |
+| edit / update the ADR (adr_drift only) | `action-adr.sh --mode update --adr-file "$ADR"` → `record_resolution "$ID" adr_update "$JSON"` | TSV + JSON |
+| file code-drift ticket / fix the code (adr_drift only) | `action-adr.sh --mode ticket --adr-file "$ADR" --team CTL --summary "$SUMMARY" --drift-status "$DRIFT_STATUS"` → `record_resolution "$ID" adr_ticket "$JSON"` | TSV + JSON |
+| defer / note as intentional (adr_drift only) | `action-adr.sh --mode defer --adr-file "$ADR" --reason "$REASON"` → `record_resolution "$ID" adr_defer "$JSON"` | TSV + JSON |
 | skip | move on without logging |
 | quit / stop / done | break out of the loop |
 
@@ -241,7 +244,7 @@ echo "Logged $(wc -l < "$LOG_FILE" | tr -d ' ') response(s) to $LOG_FILE"
   returned. Phase 4 (CTL-465) reads this file to write the `resolutions:` block back
   to the briefing markdown frontmatter.
 
-## Action handlers (Phase 2 — CTL-463)
+## Action handlers (Phase 2 — CTL-463; Phase 3 — CTL-464)
 
 Per [[2026-05-16-catalyst-phase-agent-architecture]] §Initiative 3 Phase 2, the
 following sibling scripts implement the supported actions. Each emits one JSON line on
@@ -255,6 +258,9 @@ returned no usable result).
 | File a Linear ticket | `action-ticket.sh` | `{identifier, url, status: "filed"}` | `linearis` not on PATH |
 | Dispatch orchestrator | `action-orchestrate.sh` | `{orchestrator_id, status: "dispatched"}` | `claude` (or `$CATALYST_DISPATCH_CLAUDE_BIN`) not on PATH |
 | Draft an email | `action-email.sh` | `{draft_id, status: "drafted"}` | `GMAIL_OAUTH_ACCESS_TOKEN` unset |
+| Update ADR (adr_drift) | `action-adr.sh --mode update` | `{adr_file, adr_id, commit_sha, status: "updated"}` | `$EDITOR` unset, no save, or ADR not in a git repo |
+| File code-drift ticket (adr_drift) | `action-adr.sh --mode ticket` | `{identifier, url, adr_id, status: "filed"}` | `linearis` not on PATH |
+| Defer ADR drift (adr_drift) | `action-adr.sh --mode defer` | `{adr_file, adr_id, commit_sha, status: "deferred"}` | ADR not in a git repo |
 
 See `cma/mcp/google-calendar.md` and `cma/mcp/gmail.md` for the OAuth setup required
 to bypass the calendar / email soft-skip paths. Linear and orchestrator handlers
@@ -269,10 +275,10 @@ surfaces the relevant field to the user, then calls `record_resolution "$ID" <ac
 
 - **Phase 1 (CTL-462, done)**: load briefing, parse decisions, walk user through with
   placeholder Approve / Reject / Defer.
-- **Phase 2 (CTL-463, this skill version)**: action handlers — schedule calendar, file
+- **Phase 2 (CTL-463, done)**: action handlers — schedule calendar, file
   Linear ticket, dispatch orchestrator, draft email.
-- **Phase 3 (CTL-464, planned)**: ADR-drift resolution — Update ADR / Update code /
-  Defer per the parent plan.
+- **Phase 3 (CTL-464, this skill version)**: ADR-drift resolution — `action-adr.sh`
+  with `--mode update|ticket|defer` for the three options per the parent plan.
 - **Phase 4 (CTL-465, planned)**: resolutions write-back from the JSON file to the
   briefing markdown frontmatter `resolutions:` block.
 - **Phase 5 (CTL-466, planned)**: end-to-end real-briefing review session.


### PR DESCRIPTION
## Summary

Phase 3 of Initiative 3 (Briefing Follow-up skill) — adds the ADR-drift resolution flow to the `briefing-followup` skill.

For each `adr_drift` decision in a morning briefing, the user now has three concrete options:

| Mode | What it does | Output |
|---|---|---|
| `update` | Open ADR in `$EDITOR`, commit on save | `{adr_file, adr_id, commit_sha, status: "updated"}` |
| `ticket` | File a Linear ticket scoped to the drift | `{identifier, url, adr_id, status: "filed"}` |
| `defer` | Append `<!-- drift-noted: DATE: REASON -->` and commit | `{adr_file, adr_id, commit_sha, status: "deferred"}` |

## Closes

CTL-464 (parent: CTL-445 "Briefing follow-up skill")

## Implementation

**New: `plugins/dev/scripts/briefing-followup/action-adr.sh`** — single dispatcher script that mirrors the CTL-463 action handler conventions:
- `set -uo pipefail`
- One JSON line on stdout (success / `skipped` / `failed`)
- Exit codes: 0 (success or soft-skip), 1 (hard fail), 2 (bad args)
- Soft-skip when `$EDITOR` unset, `linearis` missing, or the ADR file isn't in a git repo
- Hard-fail surfaces last 500 bytes of stderr (same as `action-ticket.sh`)
- Resolves `adr_id` from `adr_id:` frontmatter scalar, falls back to file basename

**New: `plugins/dev/scripts/__tests__/briefing-followup-adr-drift.test.sh`** — 53 assertions across 7 tests covering happy / soft-skip / hard-fail paths for all three modes, integration with `record-resolution.sh`, SKILL.md wiring, "not in a git repo" branches, and the basename fallback.

**Modified: `plugins/dev/skills/briefing-followup/SKILL.md`** — replaces the Phase 3 placeholder in the `adr_drift)` case arm with the three real options, extends the natural-language intent table and the handler reference table, updates the Phase scope summary.

## Refactor (deferred)

The parent plan suggests auditing `adr-drift.sh` (Initiative 2 Phase 4) and `action-adr.sh` for shared ADR-reading logic to factor into `plugins/dev/scripts/adr-lib.sh`. After implementation: `adr-drift.sh` extracts a YAML array (`code_assertions`) via python3+PyYAML; `action-adr.sh` extracts a single scalar (`adr_id`) via `grep`+`sed`. Different operations on different shapes — a shared lib would couple without removing duplication. Will revisit if a third ADR-reading script appears.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/briefing-followup-adr-drift.test.sh` — 53/53 (new)
- [x] `bash plugins/dev/scripts/__tests__/briefing-followup-actions.test.sh` — 57/57 (CTL-463 regression-free)
- [x] `bash plugins/dev/scripts/__tests__/briefing-followup-load.test.sh` — 31/31 (CTL-462 regression-free)
- [x] `bash plugins/dev/scripts/__tests__/adr-drift-detector.test.sh` — 31/31 (CTL-459 regression-free)
- [x] `bash plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh` — 36/36 (regression-free)
- [x] `action-adr.sh --help` prints usage and exits 0
- [ ] Manual: live session resolves a real ADR drift via each of the three options on different real drifts — deferred to CTL-466 (Initiative 3 Phase 5: end-to-end real-briefing review session)

## Code review notes

Internal code-reviewer pass surfaced two SHOULD-FIX items, both addressed in this PR:

1. Replaced `eval "$EDITOR \"\$ADR_FILE\""` with `$EDITOR "$ADR_FILE"` (word-split `$EDITOR`, intentionally quote `$ADR_FILE`) so paths with shell metacharacters never get re-interpreted. Same compound-EDITOR support (`code --wait`), tighter blast radius.
2. Added two coverage tests: "ADR file exists but not in a git repo" (update + defer modes) and "adr_id fallback to basename when frontmatter absent".