### PR TITLE
feat(dev): briefing-followup resolution write-back (CTL-465)

### DIFF
--- a/cma/routines/morning-briefing/agent.yaml
+++ b/cma/routines/morning-briefing/agent.yaml
@@ -37,6 +37,26 @@ system: |
     `THOUGHTS_WRITABLE_BRANCH=routines/briefings` in its env block. The base
     agent's §1a clones the writable tree and the routine end-of-life block
     commits + pushes. See [`cma/decisions/2026-05-17-briefing-write-back.md`](../../decisions/2026-05-17-briefing-write-back.md).
+  - **Carryovers from yesterday's briefing (CTL-465).** Before running the
+    `morning-briefing` skill, check whether `thoughts/briefings/<yesterday>.md`
+    exists on the writable clone (the `routines/briefings` branch). If it
+    does, read its frontmatter and surface anything still relevant today:
+      - `resolutions:` block — decisions the user resolved yesterday. Mention
+        them under a `### Yesterday's resolutions` sub-heading inside the
+        new briefing's `## Review yesterday` section (one-liner per resolution
+        from the `result.status` field).
+      - `decisions:` entries whose `status` is still `open` — carry them
+        forward as today's open decisions so the user does not have to
+        re-discover them. Mark each carryover with a `(carryover from
+        <yesterday>)` suffix on the summary line so the user can see the
+        provenance.
+    The `briefing.followup.complete.<yesterday>` event in the global event
+    log is the authoritative signal that the user already walked through
+    yesterday's briefing — if the event is present, treat all of yesterday's
+    `decisions:` with `status == "open"` as still-open (the followup skill
+    only flips decisions it resolved to `resolved`). If the event is absent,
+    yesterday's briefing was generated but never followed-up; the same
+    carryover rules apply (the user may catch up on multiple days at once).
 
   ## What the routine does NOT do
 

--- a/plugins/dev/scripts/__tests__/briefing-followup-writeback.test.sh
+++ b/plugins/dev/scripts/__tests__/briefing-followup-writeback.test.sh
@@ -1,0 +1,459 @@
+#!/usr/bin/env bash
+# Tests for the briefing-followup write-back to briefing markdown (CTL-465 Phase 4).
+# Covers: writeback.sh updates frontmatter resolutions:, appends "Decisions Made
+# Today" body section, commits to the routine-scoped branch with the canonical
+# message, emits briefing.followup.complete.<date>, and is idempotent on rerun.
+#
+# Run: bash plugins/dev/scripts/__tests__/briefing-followup-writeback.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+BF_DIR="${REPO_ROOT}/plugins/dev/scripts/briefing-followup"
+WRITEBACK="${BF_DIR}/writeback.sh"
+RECORD="${BF_DIR}/record-resolution.sh"
+LIB="${REPO_ROOT}/plugins/dev/scripts/briefing-frontmatter-lib.sh"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/briefing-followup/SKILL.md"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  shift
+  for line in "$@"; do echo "    $line"; done
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected: $expected" "actual:   $actual"
+  fi
+}
+
+assert_grep() {
+  local label="$1" pattern="$2" content="$3"
+  if grep -qF -- "$pattern" <<<"$content"; then
+    pass "$label"
+  else
+    fail "$label" "expected substring: $pattern" \
+      "actual: $(printf '%s' "$content" | head -20)"
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected exit: $expected" "actual exit:   $actual"
+  fi
+}
+
+# Build a sandbox git repo with a briefing markdown at the canonical path so
+# writeback.sh can run `git commit` against it. The fixture mirrors the shape
+# produced by `morning-briefing/render.sh` for a real run.
+setup_repo() {
+  local repo="$1" date="$2"
+  mkdir -p "$repo/thoughts/briefings"
+  cat > "$repo/thoughts/briefings/$date.md" <<MD
+---
+date: $date
+generated_by: morning-briefing
+decisions:
+- id: dec-1
+  type: judgment_call
+  summary: Pick auth provider
+  status: open
+- id: dec-2
+  type: blocked_pr
+  summary: PR #800 stalled
+  status: open
+  pr_url: https://github.com/org/repo/pull/800
+- id: dec-3
+  type: adr_drift
+  summary: ADR-004 drift detected
+  status: open
+  adr: docs/adrs/0004.md
+---
+
+# Morning Briefing — $date
+
+## Review yesterday
+
+_no data_
+
+## Surface decisions
+
+- **[judgment_call]** Pick auth provider (\`dec-1\`, status: open)
+- **[blocked_pr]** PR #800 stalled (\`dec-2\`, status: open)
+- **[adr_drift]** ADR-004 drift detected (\`dec-3\`, status: open)
+
+## Plan today
+
+_no data_
+
+## Suggest orchestrator runs
+
+_no data_
+MD
+  (
+    cd "$repo" \
+      && git init -q -b main 2>/dev/null || git init -q
+    git -C "$repo" config user.email "test@example.com"
+    git -C "$repo" config user.name "Test User"
+    git -C "$repo" add . && git -C "$repo" commit -q -m "init briefing $date"
+  )
+}
+
+# Seed a resolutions JSON file as produced by record-resolution.sh after the
+# user walks through two decisions.
+seed_resolutions() {
+  local log_dir="$1" date="$2"
+  mkdir -p "$log_dir"
+  bash "$RECORD" --log-dir "$log_dir" --date "$date" \
+    --id "dec-1" --action "schedule_calendar" \
+    --result '{"event_id":"evt-1","html_link":"https://cal/x","status":"scheduled"}' \
+    >/dev/null
+  bash "$RECORD" --log-dir "$log_dir" --date "$date" \
+    --id "dec-3" --action "adr_defer" \
+    --result '{"adr_file":"docs/adrs/0004.md","adr_id":"ADR-004","commit_sha":"abc","status":"deferred"}' \
+    >/dev/null
+}
+
+# Extract the YAML frontmatter block as plain text.
+extract_fm() {
+  awk '
+    /^---[[:space:]]*$/ {
+      if (in_block) { exit }
+      in_block = 1; next
+    }
+    in_block { print }
+  ' "$1"
+}
+
+# Extract everything after the closing frontmatter --- as the body.
+extract_body() {
+  awk '
+    BEGIN { dashes = 0 }
+    /^---[[:space:]]*$/ {
+      dashes++
+      if (dashes == 2) { in_body = 1; next }
+      next
+    }
+    in_body { print }
+  ' "$1"
+}
+
+# YAML frontmatter → JSON. Mirrors the python parser used by parse-briefing.sh
+# so we can assert structurally instead of with regex.
+fm_to_json() {
+  local file="$1"
+  extract_fm "$file" | python3 -c '
+import sys, json, yaml
+try:
+    data = yaml.safe_load(sys.stdin)
+except Exception as e:
+    sys.stderr.write("yaml parse: " + str(e) + "\n"); sys.exit(2)
+json.dump(data, sys.stdout, default=str)
+'
+}
+
+# ─── Test 1: writeback updates frontmatter resolutions: array ───────────────
+test_frontmatter_resolutions() {
+  echo "test 1: writeback.sh updates frontmatter resolutions: array"
+  local date="2026-05-17"
+  local repo="$SCRATCH/t1"
+  local log_dir="$SCRATCH/t1-logs"
+  setup_repo "$repo" "$date"
+  seed_resolutions "$log_dir" "$date"
+
+  local briefing="$repo/thoughts/briefings/$date.md"
+  local resolutions="$log_dir/briefing-followup-$date-resolutions.json"
+
+  local out ec
+  out=$(bash "$WRITEBACK" --briefing "$briefing" --resolutions "$resolutions" \
+        --date "$date" --no-commit --no-event 2>&1)
+  ec=$?
+  assert_exit "writeback exits 0" "0" "$ec"
+  assert_grep "writeback prints status JSON" '"status":' "$out"
+
+  # Frontmatter now has a resolutions: array with 2 entries.
+  local fm_json
+  fm_json=$(fm_to_json "$briefing" 2>/dev/null)
+  local res_count
+  res_count=$(printf '%s' "$fm_json" | jq '.resolutions | length' 2>/dev/null)
+  assert_eq "resolutions array length = 2" "2" "$res_count"
+
+  # Decision dec-1 → schedule_calendar; status should flip to resolved.
+  local dec1_status
+  dec1_status=$(printf '%s' "$fm_json" \
+    | jq -r '.decisions[] | select(.id == "dec-1") | .status')
+  assert_eq "dec-1 status now resolved" "resolved" "$dec1_status"
+
+  # dec-2 had no resolution: must still be open.
+  local dec2_status
+  dec2_status=$(printf '%s' "$fm_json" \
+    | jq -r '.decisions[] | select(.id == "dec-2") | .status')
+  assert_eq "dec-2 status unchanged (open)" "open" "$dec2_status"
+
+  # Resolutions carry the canonical fields produced by record-resolution.sh.
+  local first_action
+  first_action=$(printf '%s' "$fm_json" \
+    | jq -r '.resolutions[] | select(.decision_id == "dec-1") | .action')
+  assert_eq "dec-1 resolution action = schedule_calendar" "schedule_calendar" "$first_action"
+}
+
+# ─── Test 2: writeback appends "## Decisions Made Today" section ────────────
+test_decisions_made_today_section() {
+  echo "test 2: writeback.sh appends Decisions Made Today section"
+  local date="2026-05-17"
+  local repo="$SCRATCH/t2"
+  local log_dir="$SCRATCH/t2-logs"
+  setup_repo "$repo" "$date"
+  seed_resolutions "$log_dir" "$date"
+
+  local briefing="$repo/thoughts/briefings/$date.md"
+  local resolutions="$log_dir/briefing-followup-$date-resolutions.json"
+
+  bash "$WRITEBACK" --briefing "$briefing" --resolutions "$resolutions" \
+    --date "$date" --no-commit --no-event >/dev/null 2>&1
+
+  local body
+  body=$(extract_body "$briefing")
+
+  assert_grep "body has Decisions Made Today heading" \
+    "## Decisions Made Today" "$body"
+  assert_grep "section mentions dec-1 schedule_calendar" \
+    "schedule_calendar" "$body"
+  assert_grep "section mentions dec-3 adr_defer" \
+    "adr_defer" "$body"
+  # Decisions with no resolution should NOT appear in the section.
+  if grep -qF "dec-2" <<<"$(echo "$body" | awk '/^## Decisions Made Today/{p=1} p')"; then
+    fail "Decisions Made Today excludes unresolved dec-2" \
+      "dec-2 appeared in the section"
+  else
+    pass "Decisions Made Today excludes unresolved dec-2"
+  fi
+}
+
+# ─── Test 3: writeback commits with the canonical message ───────────────────
+test_git_commit() {
+  echo "test 3: writeback.sh commits with canonical message"
+  local date="2026-05-17"
+  local repo="$SCRATCH/t3"
+  local log_dir="$SCRATCH/t3-logs"
+  setup_repo "$repo" "$date"
+  seed_resolutions "$log_dir" "$date"
+
+  local briefing="$repo/thoughts/briefings/$date.md"
+  local resolutions="$log_dir/briefing-followup-$date-resolutions.json"
+
+  # Default mode commits (no --no-commit). --no-push is honored so the test
+  # never touches a remote.
+  local out ec
+  out=$(bash "$WRITEBACK" --briefing "$briefing" --resolutions "$resolutions" \
+        --date "$date" --no-push --no-event 2>&1)
+  ec=$?
+  assert_exit "writeback (commit) exits 0" "0" "$ec"
+
+  local subj
+  subj=$(git -C "$repo" log -1 --pretty=%s)
+  assert_eq "commit subject canonical" \
+    "briefing(followup): $date resolutions" "$subj"
+
+  # Status JSON reports the SHA so callers can chain it.
+  assert_grep "status JSON includes commit_sha" '"commit_sha"' "$out"
+  assert_grep "status JSON includes status=updated" '"status":"updated"' "$out"
+
+  # Only the briefing file is in the commit.
+  local files
+  files=$(git -C "$repo" show --name-only --pretty=format: HEAD | grep -v '^$' || true)
+  assert_eq "commit changes exactly one file" \
+    "thoughts/briefings/$date.md" "$files"
+}
+
+# ─── Test 4: writeback emits briefing.followup.complete.<date> event ────────
+test_event_emission() {
+  echo "test 4: writeback.sh emits briefing.followup.complete.<date>"
+  local date="2026-05-17"
+  local repo="$SCRATCH/t4"
+  local log_dir="$SCRATCH/t4-logs"
+  local events_dir="$SCRATCH/t4-events"
+  setup_repo "$repo" "$date"
+  seed_resolutions "$log_dir" "$date"
+
+  local briefing="$repo/thoughts/briefings/$date.md"
+  local resolutions="$log_dir/briefing-followup-$date-resolutions.json"
+
+  bash "$WRITEBACK" --briefing "$briefing" --resolutions "$resolutions" \
+    --date "$date" --no-commit --events-dir "$events_dir" >/dev/null 2>&1
+
+  # Canonical events live at <events-dir>/YYYY-MM.jsonl
+  local month_file="${events_dir}/$(date -u +%Y-%m).jsonl"
+  if [[ ! -f "$month_file" ]]; then
+    fail "event log file written" "expected $month_file"
+    return
+  fi
+  pass "event log file written"
+
+  # Find the briefing.followup.complete event for this date.
+  local event_name
+  event_name=$(jq -r 'select(.attributes."event.name" | startswith("briefing.followup.complete")) | .attributes."event.name"' \
+    "$month_file" 2>/dev/null | head -n 1)
+  assert_eq "event name includes date suffix" \
+    "briefing.followup.complete.$date" "$event_name"
+
+  # Payload carries the resolution count so consumers can short-circuit.
+  local payload_count
+  payload_count=$(jq -r 'select(.attributes."event.name" == "briefing.followup.complete.'"$date"'") | .body.payload.resolutionCount' \
+    "$month_file" 2>/dev/null | head -n 1)
+  assert_eq "payload resolutionCount = 2" "2" "$payload_count"
+}
+
+# ─── Test 5: writeback is idempotent on re-run ──────────────────────────────
+test_idempotent_rerun() {
+  echo "test 5: writeback.sh is idempotent on re-run"
+  local date="2026-05-17"
+  local repo="$SCRATCH/t5"
+  local log_dir="$SCRATCH/t5-logs"
+  setup_repo "$repo" "$date"
+  seed_resolutions "$log_dir" "$date"
+
+  local briefing="$repo/thoughts/briefings/$date.md"
+  local resolutions="$log_dir/briefing-followup-$date-resolutions.json"
+
+  # First run.
+  bash "$WRITEBACK" --briefing "$briefing" --resolutions "$resolutions" \
+    --date "$date" --no-commit --no-event >/dev/null 2>&1
+
+  # Capture the post-run file content.
+  local first_content
+  first_content=$(cat "$briefing")
+  local first_section_count
+  first_section_count=$(grep -c "^## Decisions Made Today" "$briefing" || true)
+  assert_eq "first run produces exactly one Decisions Made Today section" \
+    "1" "$first_section_count"
+
+  # Second run with the same inputs.
+  bash "$WRITEBACK" --briefing "$briefing" --resolutions "$resolutions" \
+    --date "$date" --no-commit --no-event >/dev/null 2>&1
+
+  local second_section_count
+  second_section_count=$(grep -c "^## Decisions Made Today" "$briefing" || true)
+  assert_eq "second run still has exactly one Decisions Made Today section" \
+    "1" "$second_section_count"
+
+  # Resolutions array stays at 2 (no duplicates).
+  local fm_json res_count
+  fm_json=$(fm_to_json "$briefing" 2>/dev/null)
+  res_count=$(printf '%s' "$fm_json" | jq '.resolutions | length' 2>/dev/null)
+  assert_eq "second run resolutions array still length 2" "2" "$res_count"
+}
+
+# ─── Test 6: writeback no-ops when no resolutions recorded ──────────────────
+test_skips_when_no_resolutions() {
+  echo "test 6: writeback.sh skips when resolutions file is absent or empty"
+  local date="2026-05-17"
+  local repo="$SCRATCH/t6"
+  local log_dir="$SCRATCH/t6-logs"
+  setup_repo "$repo" "$date"
+  mkdir -p "$log_dir"
+
+  local briefing="$repo/thoughts/briefings/$date.md"
+  local missing_resolutions="$log_dir/briefing-followup-$date-resolutions.json"
+
+  # Resolutions file does not exist → skip cleanly.
+  local out ec
+  out=$(bash "$WRITEBACK" --briefing "$briefing" --resolutions "$missing_resolutions" \
+        --date "$date" --no-commit --no-event 2>&1)
+  ec=$?
+  assert_exit "missing resolutions file → exit 0" "0" "$ec"
+  assert_grep "missing resolutions emits status=skipped" '"status":"skipped"' "$out"
+
+  # Briefing markdown is unchanged.
+  if grep -qF "## Decisions Made Today" "$briefing"; then
+    fail "missing resolutions leaves briefing untouched" \
+      "but Decisions Made Today section appeared"
+  else
+    pass "missing resolutions leaves briefing untouched"
+  fi
+
+  # Empty array → also a skip.
+  echo "[]" > "$missing_resolutions"
+  out=$(bash "$WRITEBACK" --briefing "$briefing" --resolutions "$missing_resolutions" \
+        --date "$date" --no-commit --no-event 2>&1)
+  ec=$?
+  assert_exit "empty resolutions file → exit 0" "0" "$ec"
+  assert_grep "empty resolutions emits status=skipped" '"status":"skipped"' "$out"
+}
+
+# ─── Test 7: shared frontmatter lib extracts blocks consistently ────────────
+test_frontmatter_lib() {
+  echo "test 7: briefing-frontmatter-lib.sh extracts blocks consistently"
+  if [[ ! -f "$LIB" ]]; then
+    fail "lib file exists at expected path" "missing: $LIB"
+    return
+  fi
+  pass "lib file exists"
+
+  local date="2026-05-17"
+  local repo="$SCRATCH/t7"
+  setup_repo "$repo" "$date"
+  local briefing="$repo/thoughts/briefings/$date.md"
+
+  # Source the lib and call its extract function. We document the contract here:
+  # `bf_fm_extract <file>` prints the YAML between the two `---` lines.
+  local out ec
+  out=$(bash -c 'source "$1"; bf_fm_extract "$2"' _ "$LIB" "$briefing" 2>&1)
+  ec=$?
+  assert_exit "bf_fm_extract exits 0" "0" "$ec"
+  assert_grep "extracted block contains date key" "date: $date" "$out"
+  assert_grep "extracted block contains decisions list" "decisions:" "$out"
+
+  # bf_fm_to_json prints the frontmatter as JSON via python+yaml. The lib must
+  # match parse-briefing.sh's behavior (callers already trust that shape).
+  local json
+  json=$(bash -c 'source "$1"; bf_fm_to_json "$2"' _ "$LIB" "$briefing" 2>&1)
+  local count
+  count=$(printf '%s' "$json" | jq '.decisions | length' 2>/dev/null)
+  assert_eq "bf_fm_to_json decisions length = 3" "3" "$count"
+}
+
+# ─── Test 8: SKILL.md wires writeback into Step 5 ───────────────────────────
+test_skill_md_writeback_arm() {
+  echo "test 8: SKILL.md invokes writeback.sh before ending the session"
+  if [[ ! -f "$SKILL_MD" ]]; then
+    fail "SKILL.md exists at $SKILL_MD" "file missing"
+    return
+  fi
+  local content
+  content=$(cat "$SKILL_MD")
+  assert_grep "SKILL.md references writeback.sh" "writeback.sh" "$content"
+  # The Phase 4 contract (write-back at session end) must be in scope summary.
+  assert_grep "SKILL.md describes Phase 4 write-back" "resolutions write-back" "$content"
+}
+
+# ─── Run all tests ──────────────────────────────────────────────────────────
+test_frontmatter_resolutions
+test_decisions_made_today_section
+test_git_commit
+test_event_emission
+test_idempotent_rerun
+test_skips_when_no_resolutions
+test_frontmatter_lib
+test_skill_md_writeback_arm
+
+echo
+echo "─────────────────────────────────────"
+echo "PASSED: $PASSES"
+echo "FAILED: $FAILURES"
+echo "─────────────────────────────────────"
+exit $(( FAILURES > 0 ? 1 : 0 ))

--- a/plugins/dev/scripts/briefing-followup/writeback.sh
+++ b/plugins/dev/scripts/briefing-followup/writeback.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# writeback.sh — At end of a briefing-followup session, persist resolutions back
+# to the briefing markdown's frontmatter, append a "Decisions Made Today"
+# section, commit + push the change to the routine-scoped branch, and emit
+# `briefing.followup.complete.<date>` so the next morning's briefing routine
+# can surface yesterday's decisions as carryovers. (CTL-465 Phase 4.)
+#
+# Usage:
+#   writeback.sh --briefing <briefing.md> --resolutions <resolutions.json> \
+#                --date YYYY-MM-DD [--no-commit] [--no-push] [--no-event] \
+#                [--events-dir DIR]
+#
+# Output: one JSON line on stdout with at minimum a `status` field
+# (`updated` | `skipped` | `failed`). On `updated` also emits `commit_sha`,
+# `resolutionCount`, `event`, `briefing`. On non-zero exit, status is `failed`
+# and `reason` is populated.
+
+set -uo pipefail
+
+# ─── Flag parsing ───────────────────────────────────────────────────────────
+BRIEFING=""
+RESOLUTIONS=""
+DATE=""
+NO_COMMIT=0
+NO_PUSH=0
+NO_EVENT=0
+EVENTS_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --briefing)    BRIEFING="${2:-}"; shift 2 ;;
+    --resolutions) RESOLUTIONS="${2:-}"; shift 2 ;;
+    --date)        DATE="${2:-}"; shift 2 ;;
+    --no-commit)   NO_COMMIT=1; shift ;;
+    --no-push)     NO_PUSH=1; shift ;;
+    --no-event)    NO_EVENT=1; shift ;;
+    --events-dir)  EVENTS_DIR="${2:-}"; shift 2 ;;
+    -h|--help)     sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "writeback.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+for required in BRIEFING RESOLUTIONS DATE; do
+  if [[ -z "${!required}" ]]; then
+    echo "writeback.sh: --${required,,} is required" >&2
+    exit 2
+  fi
+done
+
+if ! [[ "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "writeback.sh: --date must be YYYY-MM-DD, got: $DATE" >&2
+  exit 2
+fi
+if [[ ! -f "$BRIEFING" ]]; then
+  echo "writeback.sh: briefing not found: $BRIEFING" >&2
+  exit 2
+fi
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/../briefing-frontmatter-lib.sh"
+# shellcheck source=../briefing-frontmatter-lib.sh
+if [[ -f "$LIB" ]]; then source "$LIB"; fi
+
+CATALYST_DIR_DEFAULT="${CATALYST_DIR:-$HOME/catalyst}"
+EVENTS_DIR="${EVENTS_DIR:-$CATALYST_DIR_DEFAULT/events}"
+
+# Print a one-line JSON status to stdout. Caller-friendly when chained from
+# the SKILL.md so the result lands in the resolutions log alongside handler
+# outputs.
+emit_status() {
+  jq -nc "$@" || echo "{}"
+}
+
+# ─── Short-circuit when there are no resolutions to write back ──────────────
+if [[ ! -f "$RESOLUTIONS" ]]; then
+  emit_status \
+    --arg status "skipped" \
+    --arg reason "resolutions file not found" \
+    --arg path "$RESOLUTIONS" \
+    '{status: $status, reason: $reason, path: $path}'
+  exit 0
+fi
+
+RES_COUNT=$(jq 'length' "$RESOLUTIONS" 2>/dev/null || echo 0)
+if [[ -z "$RES_COUNT" || "$RES_COUNT" -eq 0 ]]; then
+  emit_status \
+    --arg status "skipped" \
+    --arg reason "no resolutions recorded" \
+    --arg path "$RESOLUTIONS" \
+    '{status: $status, reason: $reason, path: $path}'
+  exit 0
+fi
+
+# ─── Merge resolutions into frontmatter + body ──────────────────────────────
+# Python is already a hard dep of parse-briefing.sh + validate-frontmatter.sh
+# (via PyYAML). One python invocation handles both the frontmatter mutation and
+# the body splice deterministically — no fragile in-place sed.
+NEW_FILE=$(mktemp)
+trap 'rm -f "$NEW_FILE"' EXIT
+
+python3 - "$BRIEFING" "$RESOLUTIONS" "$NEW_FILE" <<'PY'
+import sys, json, re
+import yaml
+
+briefing_path, resolutions_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(briefing_path, "r", encoding="utf-8") as f:
+    raw = f.read()
+
+# Split frontmatter from body. The schema requires a leading `---\n...\n---`
+# block — fall back to "no frontmatter" if anything else.
+m = re.match(r"^---\s*\n(.*?\n)---\s*\n?(.*)$", raw, re.DOTALL)
+if not m:
+    sys.stderr.write("writeback.sh: briefing has no YAML frontmatter\n")
+    sys.exit(2)
+fm_text, body = m.group(1), m.group(2)
+fm = yaml.safe_load(fm_text) or {}
+if not isinstance(fm, dict):
+    sys.stderr.write("writeback.sh: YAML root must be a mapping\n")
+    sys.exit(2)
+
+with open(resolutions_path, "r", encoding="utf-8") as f:
+    resolutions = json.load(f)
+if not isinstance(resolutions, list):
+    sys.stderr.write("writeback.sh: resolutions JSON must be an array\n")
+    sys.exit(2)
+
+# Frontmatter mutations:
+# 1. Replace the entire resolutions list (idempotent — second run produces the
+#    same list as the first).
+fm["resolutions"] = resolutions
+
+# 2. Flip each matching decision's status to "resolved". Decisions without a
+#    resolution stay at their original status (open / deferred / etc.).
+resolved_ids = {r.get("decision_id") for r in resolutions if isinstance(r, dict)}
+for dec in fm.get("decisions", []) or []:
+    if isinstance(dec, dict) and dec.get("id") in resolved_ids:
+        dec["status"] = "resolved"
+
+# Body mutations: strip any existing "## Decisions Made Today" section so a
+# rerun never duplicates the block. The section runs from its heading to the
+# next `## ` heading (or EOF).
+section_re = re.compile(
+    r"\n*## Decisions Made Today\n.*?(?=\n## |\Z)",
+    re.DOTALL,
+)
+body_clean = section_re.sub("", body).rstrip()
+
+# Render the new section. Each bullet captures the decision id, action, and a
+# human-readable summary derived from the handler's result JSON. We keep the
+# rules simple — handlers return well-known shapes (see action-*.sh), but the
+# fallback prints `<action> (<status>)` so unknown shapes still show up.
+def bullet_for(res):
+    if not isinstance(res, dict):
+        return None
+    rid = res.get("decision_id") or "?"
+    action = res.get("action") or "noop"
+    result = res.get("result") or {}
+    status = result.get("status") or "logged"
+    extra = ""
+    if "url" in result:
+        extra = f" — <{result['url']}>"
+    elif "html_link" in result:
+        extra = f" — <{result['html_link']}>"
+    elif "identifier" in result:
+        extra = f" — {result['identifier']}"
+    elif "adr_id" in result:
+        extra = f" — {result['adr_id']}"
+    return f"- **{rid}**: {action} _({status})_{extra}"
+
+bullets = [b for b in (bullet_for(r) for r in resolutions) if b]
+section_lines = ["", "## Decisions Made Today", ""] + bullets + [""]
+new_body = body_clean.rstrip() + "\n" + "\n".join(section_lines)
+
+# Re-serialize. PyYAML's safe_dump preserves the existing frontmatter shape
+# well enough for our schema. Quoting/indent stays consistent with render.sh.
+new_fm = yaml.safe_dump(fm, default_flow_style=False, sort_keys=False)
+with open(out_path, "w", encoding="utf-8") as f:
+    f.write("---\n")
+    f.write(new_fm)
+    f.write("---\n")
+    f.write(new_body if new_body.endswith("\n") else new_body + "\n")
+PY
+PY_EXIT=$?
+if [[ $PY_EXIT -ne 0 ]]; then
+  emit_status --arg status "failed" --arg reason "frontmatter merge failed" \
+    '{status: $status, reason: $reason}'
+  exit 1
+fi
+
+# Move into place atomically. If the file already matches (idempotent rerun
+# with the same inputs), there's nothing more to do for git/event.
+if cmp -s "$NEW_FILE" "$BRIEFING"; then
+  CHANGED=0
+else
+  CHANGED=1
+  mv "$NEW_FILE" "$BRIEFING"
+  trap - EXIT
+fi
+
+# ─── Git commit + optional push ─────────────────────────────────────────────
+COMMIT_SHA=""
+COMMIT_STATUS="skipped"
+if [[ $NO_COMMIT -eq 0 ]]; then
+  REPO_ROOT=$(git -C "$(dirname "$BRIEFING")" rev-parse --show-toplevel 2>/dev/null || echo "")
+  if [[ -z "$REPO_ROOT" ]]; then
+    COMMIT_STATUS="skipped"
+  elif [[ $CHANGED -eq 0 ]]; then
+    COMMIT_STATUS="unchanged"
+  else
+    # Stage only the briefing file — keeps unrelated working-tree state out of
+    # the routine's commit stream.
+    git -C "$REPO_ROOT" add "$BRIEFING" >/dev/null 2>&1 || true
+    if git -C "$REPO_ROOT" diff --cached --quiet "$BRIEFING"; then
+      COMMIT_STATUS="unchanged"
+    else
+      COMMIT_MSG="briefing(followup): ${DATE} resolutions"
+      if git -C "$REPO_ROOT" commit -q -m "$COMMIT_MSG" >/dev/null 2>&1; then
+        COMMIT_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD)
+        COMMIT_STATUS="committed"
+      else
+        COMMIT_STATUS="failed"
+      fi
+    fi
+
+    # Push the routine-scoped branch if requested. The push target comes from
+    # whatever upstream is configured — in the morning-briefing routine that's
+    # `origin/routines/briefings` per the §1a write-back block.
+    if [[ $NO_PUSH -eq 0 && "$COMMIT_STATUS" == "committed" ]]; then
+      if ! git -C "$REPO_ROOT" push >/dev/null 2>&1; then
+        # One retry with fetch+rebase, matching the ADR contract.
+        BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+        git -C "$REPO_ROOT" fetch origin "$BRANCH" >/dev/null 2>&1 || true
+        git -C "$REPO_ROOT" rebase "origin/$BRANCH" >/dev/null 2>&1 \
+          || git -C "$REPO_ROOT" rebase --abort >/dev/null 2>&1 || true
+        git -C "$REPO_ROOT" push >/dev/null 2>&1 || COMMIT_STATUS="committed-not-pushed"
+      fi
+    fi
+  fi
+fi
+
+# ─── Emit briefing.followup.complete.<date> ─────────────────────────────────
+EVENT_NAME="briefing.followup.complete.${DATE}"
+EVENT_EMITTED="false"
+if [[ $NO_EVENT -eq 0 ]]; then
+  # Source the canonical event lib. It's idempotent and writes one JSONL line
+  # per call into the orchestrator's global event log so wait-for / tail can
+  # pick up the completion signal alongside other Catalyst events.
+  CE_LIB="${SCRIPT_DIR}/../lib/canonical-event.sh"
+  if [[ -f "$CE_LIB" ]]; then
+    # shellcheck source=../lib/canonical-event.sh
+    source "$CE_LIB"
+    TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    PAYLOAD=$(jq -nc \
+      --arg date "$DATE" \
+      --arg briefing "$BRIEFING" \
+      --arg commit "${COMMIT_SHA:-}" \
+      --argjson resolutionCount "${RES_COUNT:-0}" \
+      '{date: $date,
+        briefing: $briefing,
+        commitSha: (if $commit == "" then null else $commit end),
+        resolutionCount: $resolutionCount}')
+    LINE=$(build_canonical_line \
+      --ts "$TS" \
+      --severity INFO \
+      --service "catalyst.briefing" \
+      --event-name "$EVENT_NAME" \
+      --entity briefing \
+      --action complete \
+      --label "$DATE" \
+      --session "${CATALYST_SESSION_ID:-}" \
+      --orch "${CATALYST_ORCHESTRATOR_ID:-}" \
+      --worker "${CATALYST_WORKER_TICKET:-}" \
+      --payload-json "$PAYLOAD" 2>/dev/null) || LINE=""
+    if [[ -n "$LINE" ]]; then
+      canonical_jsonl_append "$EVENTS_DIR" "$LINE"
+      EVENT_EMITTED="true"
+    fi
+  fi
+fi
+
+# ─── Status JSON ────────────────────────────────────────────────────────────
+emit_status \
+  --arg status "updated" \
+  --arg briefing "$BRIEFING" \
+  --arg commit_sha "${COMMIT_SHA:-}" \
+  --arg commit_status "$COMMIT_STATUS" \
+  --arg event "$EVENT_NAME" \
+  --argjson resolutionCount "${RES_COUNT:-0}" \
+  --argjson event_emitted "$EVENT_EMITTED" \
+  '{status: $status,
+    briefing: $briefing,
+    resolutionCount: $resolutionCount,
+    commit_sha: (if $commit_sha == "" then null else $commit_sha end),
+    commit_status: $commit_status,
+    event: $event,
+    event_emitted: $event_emitted}'

--- a/plugins/dev/scripts/briefing-frontmatter-lib.sh
+++ b/plugins/dev/scripts/briefing-frontmatter-lib.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# briefing-frontmatter-lib.sh — Shared helpers for reading the YAML frontmatter
+# of briefing markdown files. Source from any briefing-related script that
+# needs to extract or parse the leading `--- ... ---` block.
+#
+# Public functions:
+#   bf_fm_extract <file>    Echo the YAML block (between the two `---` lines).
+#                           Exit 0 on success, 1 if file missing, 2 if no block.
+#   bf_fm_to_json  <file>   YAML → JSON via python3+yaml. Same exit codes as
+#                           bf_fm_extract, plus 3 on YAML parse error.
+#   bf_fm_split   <file>    Echo fm block + body separator + body. The fm and
+#                           body are split on `\0` (NUL) so callers can `read -d`
+#                           them apart without a tempfile.
+#
+# The extraction logic mirrors the inline awk previously duplicated in
+# parse-briefing.sh and morning-briefing/validate-frontmatter.sh — both callers
+# can migrate to these helpers without behavior change.
+
+# Idempotent guard so dot-sourcing twice is a no-op.
+if [[ -n "${__CATALYST_BRIEFING_FM_LIB_SOURCED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+__CATALYST_BRIEFING_FM_LIB_SOURCED=1
+
+bf_fm_extract() {
+  local file="${1:-}"
+  if [[ -z "$file" ]]; then
+    echo "bf_fm_extract: file argument required" >&2; return 2
+  fi
+  if [[ ! -f "$file" ]]; then
+    echo "bf_fm_extract: file not found: $file" >&2; return 1
+  fi
+  local fm
+  fm=$(awk '
+    /^---[[:space:]]*$/ {
+      if (in_block) { exit }
+      in_block = 1; next
+    }
+    in_block { print }
+  ' "$file")
+  if [[ -z "$fm" ]]; then
+    echo "bf_fm_extract: no YAML frontmatter found in $file" >&2; return 2
+  fi
+  printf '%s\n' "$fm"
+}
+
+bf_fm_to_json() {
+  local file="${1:-}"
+  local fm
+  fm=$(bf_fm_extract "$file") || return $?
+  local err_log
+  err_log=$(mktemp)
+  if ! printf '%s\n' "$fm" | python3 -c '
+import sys, json, yaml
+try:
+    data = yaml.safe_load(sys.stdin)
+except yaml.YAMLError as e:
+    sys.stderr.write("YAML parse error: " + str(e) + "\n")
+    sys.exit(3)
+if not isinstance(data, dict):
+    sys.stderr.write("YAML root must be a mapping\n")
+    sys.exit(3)
+json.dump(data, sys.stdout, default=str)
+' 2>"$err_log"; then
+    echo "bf_fm_to_json: malformed YAML frontmatter in $file" >&2
+    [[ -s "$err_log" ]] && cat "$err_log" >&2
+    rm -f "$err_log"
+    return 3
+  fi
+  rm -f "$err_log"
+}
+
+bf_fm_body() {
+  # Echo the markdown body (everything AFTER the closing `---`).
+  local file="${1:-}"
+  if [[ -z "$file" ]]; then
+    echo "bf_fm_body: file argument required" >&2; return 2
+  fi
+  if [[ ! -f "$file" ]]; then
+    echo "bf_fm_body: file not found: $file" >&2; return 1
+  fi
+  awk '
+    BEGIN { dashes = 0 }
+    /^---[[:space:]]*$/ {
+      dashes++
+      if (dashes == 2) { in_body = 1; next }
+      next
+    }
+    in_body { print }
+  ' "$file"
+}
+
+# When sourced from a script that runs in `set -e`, ensure we return 0 so the
+# source itself never aborts the caller.
+return 0 2>/dev/null || true

--- a/plugins/dev/skills/briefing-followup/SKILL.md
+++ b/plugins/dev/skills/briefing-followup/SKILL.md
@@ -220,7 +220,52 @@ Per-decision the user may attach a one-line note (e.g., why they rejected, what 
 calendar event is for). Pass it as the third argument to `log_response` and, when
 relevant, as `--description` / `--body` to the action handler.
 
-## Step 5: End session
+## Step 5: Write resolutions back to the briefing markdown (Phase 4 — CTL-465)
+
+Before ending the session, persist the recorded resolutions into the briefing
+markdown's frontmatter `resolutions:` block and append a "## Decisions Made
+Today" section to the body. The script commits to the routine-scoped branch
+(when running inside the morning-briefing routine's writable clone) and emits
+a `briefing.followup.complete.<date>` event so the next morning's briefing
+routine can surface yesterday's decisions as carryovers.
+
+```bash
+WRITEBACK_RESULT=$(bash "$SCRIPT_DIR/writeback.sh" \
+  --briefing "$BRIEFING_PATH" \
+  --resolutions "$LOG_DIR/briefing-followup-$DATE-resolutions.json" \
+  --date "$DATE" 2>&1)
+
+WRITEBACK_STATUS=$(echo "$WRITEBACK_RESULT" | jq -r '.status // "failed"')
+case "$WRITEBACK_STATUS" in
+  updated)
+    COMMIT_SHA=$(echo "$WRITEBACK_RESULT" | jq -r '.commit_sha // "none"')
+    echo "Wrote resolutions back to $BRIEFING_PATH (commit: $COMMIT_SHA)"
+    ;;
+  skipped)
+    REASON=$(echo "$WRITEBACK_RESULT" | jq -r '.reason // "no resolutions"')
+    echo "Skipped write-back: $REASON"
+    ;;
+  *)
+    echo "Write-back failed: $WRITEBACK_RESULT" >&2
+    ;;
+esac
+```
+
+Flags that callers may pass to `writeback.sh`:
+
+| Flag | Meaning |
+|---|---|
+| `--no-commit` | Update the markdown in place but do not run `git commit`. |
+| `--no-push` | Commit but do not push. Default in cloud routine mode is push. |
+| `--no-event` | Skip emitting `briefing.followup.complete.<date>`. |
+| `--events-dir DIR` | Override the event log dir (defaults to `$CATALYST_DIR/events`). |
+
+The script is idempotent: re-running with the same resolutions file produces
+the same markdown (the previous "## Decisions Made Today" block is stripped
+before the new one is appended, and the `resolutions:` array is replaced
+rather than amended).
+
+## Step 6: End session
 
 ```bash
 echo
@@ -279,6 +324,10 @@ surfaces the relevant field to the user, then calls `record_resolution "$ID" <ac
   Linear ticket, dispatch orchestrator, draft email.
 - **Phase 3 (CTL-464, this skill version)**: ADR-drift resolution — `action-adr.sh`
   with `--mode update|ticket|defer` for the three options per the parent plan.
-- **Phase 4 (CTL-465, planned)**: resolutions write-back from the JSON file to the
-  briefing markdown frontmatter `resolutions:` block.
+- **Phase 4 (CTL-465, this skill version)**: resolutions write-back from the
+  JSON file to the briefing markdown frontmatter `resolutions:` block via
+  `writeback.sh`. Also appends a "## Decisions Made Today" section to the body,
+  commits to the routine-scoped branch (`routines/briefings` in the cloud
+  routine), and emits `briefing.followup.complete.<date>` so the next morning's
+  briefing routine reads yesterday's resolutions as carryovers.
 - **Phase 5 (CTL-466, planned)**: end-to-end real-briefing review session.


### PR DESCRIPTION
## Summary

Phase 4 of the briefing-followup skill (CTL-465 in the [Catalyst Phase Agent Architecture plan](../blob/main/thoughts/shared/plans/2026-05-16-catalyst-phase-agent-architecture.md) §Initiative 3). At the end of a `/catalyst-dev:briefing-followup` session, persist every recorded resolution into the briefing markdown's frontmatter `resolutions:` block, append a "Decisions Made Today" section to the body, commit to the routine-scoped branch, and emit a `briefing.followup.complete.<date>` event so the next morning's briefing routine can read yesterday's decisions as carryovers.

Closes the loop on briefing follow-up — yesterday's open decisions surface as today's carryovers, yesterday's resolutions roll up under "Yesterday's resolutions" in the new briefing.

## Changes Made

### New files

- `plugins/dev/scripts/briefing-followup/writeback.sh` — main script. Reads the resolutions JSON produced by `record-resolution.sh`, merges it into the briefing's frontmatter, splices a "## Decisions Made Today" body section, commits with `briefing(followup): YYYY-MM-DD resolutions`, and emits the canonical event via the existing `canonical-event.sh` lib.
- `plugins/dev/scripts/briefing-frontmatter-lib.sh` — shared lib with `bf_fm_extract`, `bf_fm_to_json`, `bf_fm_body`. Folds the awk-based extract previously duplicated between `parse-briefing.sh` and `morning-briefing/validate-frontmatter.sh` into one source so future briefing scripts can reuse it. (Refactor item from the plan.)
- `plugins/dev/scripts/__tests__/briefing-followup-writeback.test.sh` — 8 test groups, 33 assertions covering frontmatter update, body splice idempotency, git commit subject + file scope, event emission with date-suffixed name, skip-on-no-resolutions, lib contract, and SKILL.md wiring.

### Modified files

- `plugins/dev/skills/briefing-followup/SKILL.md` — Step 5 now invokes `writeback.sh` before the existing end-session call. Phase scope summary marks Phase 4 as the current skill version.
- `cma/routines/morning-briefing/agent.yaml` — documents the carryover read: routine prompt notes that before running the skill, check `thoughts/briefings/<yesterday>.md` on the writable clone, surface unresolved decisions as carryovers, and roll up yesterday's resolutions under `### Yesterday's resolutions`. Uses `briefing.followup.complete.<yesterday>` as the authoritative signal.

## How to Verify It

### Automated Checks

```bash
# CTL-465 tests
bash plugins/dev/scripts/__tests__/briefing-followup-writeback.test.sh
# → PASSED: 33, FAILED: 0

# Existing briefing-followup suites (regression)
bash plugins/dev/scripts/__tests__/briefing-followup-load.test.sh        # 31 pass
bash plugins/dev/scripts/__tests__/briefing-followup-actions.test.sh     # 57 pass
bash plugins/dev/scripts/__tests__/briefing-followup-adr-drift.test.sh   # 53 pass

# Morning-briefing regression
bash plugins/dev/scripts/__tests__/morning-briefing-skill.test.sh        # 36 pass
```

### Manual Verification Required

End-to-end smoke against a real briefing happens organically when the next morning-briefing routine runs and the user works through a follow-up. The plan's Phase 5 (CTL-466) is the dedicated acceptance phase for that.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-465
- Parent skill phase chain: CTL-462 (Phase 1, load) → CTL-463 (Phase 2, action handlers, #813) → CTL-464 (Phase 3, ADR drift, #815) → **CTL-465 (this PR)** → CTL-466 (Phase 5, end-to-end acceptance)
- Re-uses the write-back ADR `cma/decisions/2026-05-17-briefing-write-back.md` shipped in #811