### PR TITLE
docs(meta): config-reference cluster updates for phase-agents (CTL-474)

### DIFF
--- a/website/src/content/docs/observability/catalyst-broker.md
+++ b/website/src/content/docs/observability/catalyst-broker.md
@@ -14,9 +14,9 @@ a natural-language intent once and the daemon handles the matching.
 
 The daemon supports two routing paths:
 
-- **Deterministic (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`)** — pure field
-  comparison for PR/CI/review/BEHIND events, Linear state changes, and comms-channel messages.
-  No Groq call, no latency beyond local I/O.
+- **Deterministic (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`, `phase_lifecycle`)** —
+  pure field comparison for PR/CI/review/BEHIND events, Linear state changes, comms-channel
+  messages, and phase-agent boundary events. No Groq call, no latency beyond local I/O.
 - **Prose (Groq-backed)** — a natural-language `prompt` you write; evaluated by
   `llama-3.1-8b-instant` in a single batched API call. **Gated off by default since CTL-357**
   (`CATALYST_BROKER_PROSE_ENABLED=0`) due to empirically ~95% false-positive rate. Prose
@@ -241,6 +241,67 @@ Supported `wake_on` values include `status_done`, `status_in_review`, `status_ch
 `pr_lifecycle`, this path requires no Groq API key. See the
 [`broker` skill](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/skills/broker/SKILL.md)
 for the full agent-facing protocol.
+
+#### phase_lifecycle — deterministic phase-agent routing
+
+Introduced in CTL-447 to support the [phase-agent
+pipeline](/reference/orchestration/phase-agents/). Use it when an orchestrator running
+`dispatchMode = "phase-agents"` needs to wake on the boundary events its phase agents emit
+(`phase.<name>.complete.<TICKET>` and `phase.<name>.failed.<TICKET>`):
+
+```json
+{
+  "ts": "2026-05-17T07:00:00Z",
+  "event": "filter.register",
+  "orchestrator": "orch-ctl-api-2026-05-17",
+  "worker": null,
+  "detail": {
+    "interest_id": "orch-ctl-api-2026-05-17-phase-lifecycle-CTL-253",
+    "session_id": "sess_20260517_abc123",
+    "interest_type": "phase_lifecycle",
+    "notify_event": "filter.wake.orch-ctl-api-2026-05-17",
+    "persistent": true,
+    "ticket": "CTL-253",
+    "phase_names": [
+      "triage", "research", "plan", "implement", "verify",
+      "review", "pr", "monitor-merge", "monitor-deploy"
+    ]
+  }
+}
+```
+
+| Field           | Required | Purpose                                                                                       |
+| --------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `interest_type` | yes      | Must be `"phase_lifecycle"`.                                                                  |
+| `ticket`        | yes      | Linear ticket ID this interest is bound to (e.g. `CTL-253`).                                  |
+| `phase_names`   | yes      | Array of phase names that should produce a wake. Empty array matches nothing.                 |
+| `notify_event`  | yes      | Wake event the orchestrator's `wait-for` listens on — usually `filter.wake.<ORCH_NAME>`.      |
+| `persistent`    | no       | When `true`, the interest survives the first wake. Orchestrators set this to `true`.          |
+
+The broker matches against the regex
+`^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-\d+)$` and fires `notify_event` when
+**all three** of these are true:
+
+- the event name matches the pattern,
+- the captured ticket equals `ticket`, and
+- the captured phase name is in `phase_names`.
+
+Routing is purely deterministic — no Groq call, no prose evaluation. The wake `reason` field
+reads `"Phase <name> complete on <TICKET>"` (or `"failed"`) so the orchestrator's wake handler
+(typically [`orchestrate-phase-advance`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/orchestrate-phase-advance))
+can route to the next phase without re-reading the source event.
+
+Cardinality is **one `phase_lifecycle` interest per ticket** — the orchestrator registers a fresh
+interest at Phase 4 dispatch and the broker auto-cleans it when the orchestrator emits
+`agent.checkout` (or after the watchdog declares the session stale). This is the only deterministic
+interest type gated on `dispatchMode`: in `oneshot-legacy` mode there are no `phase.*` events to
+match, so no `phase_lifecycle` interests are ever registered.
+
+The matcher lives at
+[`broker/index.mjs:1299`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/broker/index.mjs)
+(`tryPhaseLifecycleRoute`); see [Orchestrator overview › Phase 4
+monitor](https://github.com/coalesce-labs/catalyst/blob/main/docs/orchestrator-overview.md#phase-4-monitor--broker-interests--event-flow)
+for how this fits into the broader broker-interest layout.
 
 ### filter.wake
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -731,8 +731,24 @@ Optional. Add this block to enable `/orchestrate` — see [Orchestration](/refer
         "setup": ["bun install"],
         "teardown": []
       },
+      "dispatchMode": "oneshot-legacy",
       "workerCommand": "/catalyst-dev:oneshot",
       "workerModel": "opus",
+      "phaseAgents": {
+        "models": {
+          "implement": "sonnet",
+          "pr": "sonnet",
+          "monitor-deploy": "haiku"
+        },
+        "modelOverrides": {
+          "implement": {
+            "CTL-501": "opus"
+          }
+        },
+        "turnCaps": {
+          "implement": 100
+        }
+      },
       "testRequirements": {
         "backend": ["unit"],
         "frontend": ["unit"],
@@ -751,11 +767,17 @@ Optional. Add this block to enable `/orchestrate` — see [Orchestration](/refer
 | `maxParallel` | number | 3 | Max concurrent workers |
 | `hooks.setup` | string[] | `[]` | Run after worktree creation (supports `${WORKTREE_PATH}`, `${BRANCH_NAME}`, `${TICKET_ID}`, `${REPO_NAME}`, `${DIRECTORY}` variables) |
 | `hooks.teardown` | string[] | `[]` | Run before worktree removal |
-| `workerCommand` | string | `/catalyst-dev:oneshot` | Plugin-namespaced skill to dispatch in each worker. Must be in `/<plugin>:<skill>` form — bare slashes (e.g. `/oneshot`) are rejected at dispatch. |
-| `workerModel` | string | `opus` | Model for worker sessions |
+| `dispatchMode` | string | `"oneshot-legacy"` | Worker spawn strategy. `"oneshot-legacy"` runs one long `claude -p /catalyst-dev:oneshot` per ticket (pre-CTL-452 model). `"phase-agents"` dispatches nine short-lived `claude --bg` jobs per ticket, one per phase, advancing on `phase.<name>.complete.<TICKET>` broker events. See [Phase agents](/reference/orchestration/phase-agents/) for the full pipeline. |
+| `workerCommand` | string | `/catalyst-dev:oneshot` | Plugin-namespaced skill to dispatch in each worker (applies only when `dispatchMode = "oneshot-legacy"`). Must be in `/<plugin>:<skill>` form — bare slashes (e.g. `/oneshot`) are rejected at dispatch. |
+| `workerModel` | string | `opus` | Model for legacy oneshot worker sessions (applies only when `dispatchMode = "oneshot-legacy"`). For phase-agents mode, use `phaseAgents.models` instead. |
+| `phaseAgents.models[phase]` | string | `"opus"` | Per-phase default model when `dispatchMode = "phase-agents"`. Keys are phase names: `triage`, `research`, `plan`, `implement`, `verify`, `review`, `pr`, `monitor-merge`, `monitor-deploy`. Values are `opus`, `sonnet`, or `haiku`. |
+| `phaseAgents.modelOverrides[phase][ticket]` | string | none | Per-phase, per-ticket model override. Highest precedence after the `--model` CLI flag. Useful for one-off escape hatches (e.g., bumping a particularly ambiguous plan back to Opus). |
+| `phaseAgents.turnCaps[phase]` | number | per-phase default | Override the hard cap on Claude turns per phase. Per-phase defaults: triage 10, research 35, plan 25, implement 75, verify 20, review 25, pr 12, monitor-merge 50, monitor-deploy 30. |
 | `testRequirements` | object | See above | Required test types by scope (backend/frontend/fullstack) |
 | `verifyBeforeMerge` | boolean | `true` | Run adversarial verification on merged commits (post-merge) |
 | `allowSelfReportedCompletion` | boolean | `false` | When `true`, verification failures are advisory (wave advances). When `false` (default), verification failures block wave advancement until remediation is filed |
+
+Resolution order for both `phaseAgents.models` and `phaseAgents.turnCaps` is **CLI flag > `modelOverrides[phase][ticket]` > `models[phase]` (or `turnCaps[phase]`) > built-in default**. The dispatcher reads `dispatchMode` at [`plugins/dev/scripts/orchestrate-dispatch-next:117`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/orchestrate-dispatch-next); per-phase resolution lives in [`phase-agent-dispatch:158-176`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/phase-agent-dispatch).
 
 ## Feedback Config
 

--- a/website/src/content/docs/reference/orchestration.md
+++ b/website/src/content/docs/reference/orchestration.md
@@ -491,8 +491,10 @@ gets caught.
 | `maxParallel`                 | number       | 3                            | Max concurrent workers per wave                                                                                                                     |
 | `hooks.setup`                 | string[]     | `[]`                         | Extra commands after base `worktree.setup` (orchestration-only)                                                                                     |
 | `hooks.teardown`              | string[]     | `[]`                         | Commands before worktree removal on wave advancement                                                                                                |
-| `workerCommand`               | string       | `/catalyst-dev:oneshot`      | Plugin-namespaced skill to run in each worker. Must be `/<plugin>:<skill>`; bare slashes rejected at dispatch.                                      |
-| `workerModel`                 | string       | `opus`                       | Model for worker sessions                                                                                                                           |
+| `dispatchMode`                | string       | `"oneshot-legacy"`           | Worker spawn strategy. `"oneshot-legacy"` runs one long `claude -p` worker per ticket. `"phase-agents"` dispatches nine short-lived `claude --bg` jobs per ticket — see [Phase agents](./orchestration/phase-agents/) for the pipeline, model assignment, and cost economics. |
+| `workerCommand`               | string       | `/catalyst-dev:oneshot`      | Plugin-namespaced skill to run in each worker (applies only when `dispatchMode = "oneshot-legacy"`). Must be `/<plugin>:<skill>`; bare slashes rejected at dispatch. |
+| `workerModel`                 | string       | `opus`                       | Model for legacy oneshot worker sessions. For phase-agents mode use `phaseAgents.models` instead.                                                   |
+| `phaseAgents`                 | object       | `{}`                         | Per-phase model and turn-cap overrides for `dispatchMode = "phase-agents"`. Nested keys: `models[phase]`, `modelOverrides[phase][ticket]`, `turnCaps[phase]`. See [Configuration › Orchestration Config](/reference/configuration/#orchestration-config) for the full schema and [Phase agents › Configuration](./orchestration/phase-agents/#configuration) for the canonical reference. |
 | `testRequirements`            | object       | `{"backend":["unit"]}`       | Required test types by scope                                                                                                                        |
 | `verifyBeforeMerge`           | boolean      | `true`                       | Run adversarial verification on merged commits (post-merge)                                                                                         |
 | `allowSelfReportedCompletion` | boolean      | `false`                      | When `true`, verification failures are advisory (wave advances). When `false` (default), failures block wave advancement until remediation is filed |
@@ -816,6 +818,25 @@ cat ~/catalyst/history/*.json | jq -s '[.[].usage.costUSD / .[].progress.totalTi
   process exits
 
 As these tools evolve to expose usage data, the schema is ready to accept it.
+
+#### Phase-agents cost tracking
+
+When `catalyst.orchestration.dispatchMode` is `"phase-agents"`, the worker run is decomposed into
+nine short-lived `claude --bg` jobs (one per phase) instead of a single long `claude -p` session.
+Cost rolls up the same way — each phase agent's final `result` event is captured into the
+`session_metrics` table in `~/catalyst/catalyst.db`, keyed by the phase's `session_id` and joined
+to the parent workflow via `sessions.workflow_id`.
+
+This gives you per-phase attribution that the legacy mode can't: you can see how much of a ticket's
+total cost went to `phase-implement` vs `phase-monitor-merge`, and decide whether to flip
+individual phases to Sonnet via `phaseAgents.models[phase]`. The aggregation query and the
+projected vs. actual cost table live on the [Phase agents](./orchestration/phase-agents/#cost-economics)
+page along with the per-phase model assignment guidance.
+
+:::caution[Measurement gap] As of 2026-05-17, `session_metrics.cost_usd` shows `$0` across recent
+`oneshot`, `orchestrate`, and `phase-*` rows — the CTL-455 fix to populate the table from worker
+stream data is merged but no run since the fix has flushed real numbers into the DB. Phase-agents
+cost tracking is wired end-to-end; validate it has data before relying on the per-phase numbers. :::
 
 ## Orchestration Monitor
 


### PR DESCRIPTION
## Summary

Part of the CTL-474 docs-currency pass. Updates three config-reference docs to accurately reflect the phase-agent architecture already shipped in `origin/main` (CTL-447, CTL-452).

- **`website/src/content/docs/reference/configuration.md`** — under `catalyst.orchestration`, add `dispatchMode` and the `phaseAgents.{models, modelOverrides, turnCaps}` block (with per-phase default turn caps). Documents the model/turn-cap resolution precedence (`CLI > modelOverrides[phase][ticket] > models[phase] > built-in default`) and links to the dispatcher and `phase-agent-dispatch` source.
- **`website/src/content/docs/reference/orchestration.md`** — add `dispatchMode` and `phaseAgents` rows to the Configuration Reference table (the prose Worker Dispatch section already mentioned the modes; the structured table did not). Add a new "Phase-agents cost tracking" subsection inside the existing Token Usage & Cost Tracking section, pointing at `phase-agents.md`'s `session_metrics` aggregation runbook.
- **`website/src/content/docs/observability/catalyst-broker.md`** — list `phase_lifecycle` alongside the other deterministic interest types in the intro; add a full `phase_lifecycle` subsection to Protocol Reference (registration shape, field semantics, the regex matcher, cardinality of one interest per ticket, gating on `dispatchMode = "phase-agents"`), with source-file pointers to `broker/index.mjs:1299` (`tryPhaseLifecycleRoute`).

The deep-dive content (per-phase tables, cost projection, end-to-end runbook) continues to live on the existing `phase-agents.md` page — these edits just make the three config-reference cluster docs cross-link to it instead of pretending phase-agents doesn't exist.

Closes CTL-478. Part of CTL-474.

## Test plan

- [x] `bun run build` in `website/` — 297 pages built, no errors, no broken-link warnings on the three edited routes
- [x] `bash plugins/meta/scripts/audit-references.sh --ci` — zero issues attributable to the three edited files (the 59 pre-existing warnings are all in unrelated source files)
- [x] Anchor verification on built HTML — `#orchestration-config`, `#configuration`, `#cost-economics` all resolve
- [ ] Cloudflare Pages CI green on the PR
- [ ] `audit-references`, `check-versions`, `validate` CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)