### PR TITLE
docs(meta): observability cluster updates for phase-agents + ADR-014 (CTL-479)

### DIFF
--- a/website/src/content/docs/observability/catalyst-events.md
+++ b/website/src/content/docs/observability/catalyst-events.md
@@ -60,6 +60,9 @@ catalyst-events tail --filter '.attributes."event.name" == "broker.daemon.startu
 
 # All ticket_lifecycle wake events (CTL-303)
 catalyst-events tail --filter '.attributes."event.name" | startswith("filter.wake.")'
+
+# All phase-agent pipeline events (CTL-452) — only emitted when dispatchMode = "phase-agents"
+catalyst-events tail --filter '.attributes."event.name" | startswith("phase.")'
 ```
 
 ### `wait-for`
@@ -90,6 +93,11 @@ catalyst-events wait-for \
 # Wait for a broker wake event (CTL-303 — semantic interests)
 catalyst-events wait-for \
   --filter '.attributes."event.name" == "filter.wake" and .attributes."event.label" == "sess_abc123"' \
+  --timeout 600
+
+# Wait for a specific phase-agent phase to complete (CTL-452)
+catalyst-events wait-for \
+  --filter '.attributes."event.name" == "phase.research.complete.CTL-48"' \
   --timeout 600
 ```
 
@@ -222,6 +230,7 @@ Both shapes coexist indefinitely. New tools write the canonical envelope;
 --filter '.attributes."event.name" | startswith("agent.")'   # broker agent identity (CTL-303)
 --filter '.attributes."event.name" | startswith("filter.")'  # broker register/deregister/wake
 --filter '.attributes."event.name" | startswith("broker.")'  # broker daemon lifecycle
+--filter '.attributes."event.name" | startswith("phase.")'   # phase-agent pipeline (CTL-452)
 ```
 
 ### Match by orchestrator scope
@@ -235,6 +244,32 @@ Both shapes coexist indefinitely. New tools write the canonical envelope;
 
 # Canonical envelope — filter by ticket
 --filter '.attributes."worker.ticket" == "CTL-48"'
+```
+
+### Match by phase event (CTL-452 — phase-agent pipeline)
+
+Phase-agent events follow the deterministic shape
+`phase.<name>.<action>.<TICKET>` where `<name>` is one of the nine canonical phases
+(triage, research, plan, implement, verify, review, pr, monitor-merge, monitor-deploy),
+`<action>` is `dispatched`, `complete`, or `failed`, and `<TICKET>` is the Linear key
+(e.g. `CTL-48`). The broker's `phase_lifecycle` interest matches the same regex
+deterministically — see [Phase agents](/reference/orchestration/phase-agents/).
+
+```bash
+# All phase-agent events
+--filter '.attributes."event.name" | startswith("phase.")'
+
+# All phase events for one ticket
+--filter '(.attributes."event.name" | startswith("phase.")) and (.attributes."event.name" | endswith(".CTL-48"))'
+
+# A single phase complete (exact match)
+--filter '.attributes."event.name" == "phase.research.complete.CTL-48"'
+
+# All phase failures across every ticket
+--filter '.attributes."event.name" | test("^phase\\.[^.]+\\.failed\\.")'
+
+# All `implement` phase events across every ticket (any action, any ticket)
+--filter '.attributes."event.name" | test("^phase\\.implement\\.")'
 ```
 
 ### Match a ticket_lifecycle interest (CTL-303)

--- a/website/src/content/docs/observability/event-flow.md
+++ b/website/src/content/docs/observability/event-flow.md
@@ -111,6 +111,67 @@ path produced the event.
 
 8. **The worker acts.** With the PR confirmed merged, the worker records `pr.mergedAt`, transitions the Linear ticket to Done, and writes `status: "done"` to its signal file.
 
+## Step-by-step: a phase-agent wake (CTL-452)
+
+When `dispatchMode = "phase-agents"`, the orchestrator dispatches one short-lived
+`claude --bg` job per phase. Each phase emits a `phase.<name>.complete.<TICKET>`
+event that wakes the orchestrator via the broker's `phase_lifecycle` interest, and
+the orchestrator dispatches the next phase. The wake chain is deterministic — no
+Groq call, no prose evaluation.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant W as Worker (claude --bg)
+  participant B as catalyst-broker
+  participant O as Orchestrator
+  participant D as orchestrate-phase-advance
+  participant P as phase-agent-dispatch
+
+  W->>B: emit phase.research.complete.CTL-101
+  B->>B: match against phase_lifecycle<br/>(ticket=CTL-101, phase_names⊇{research})
+  B->>O: fire filter.wake.<ORCH_NAME><br/>reason="Phase research complete on CTL-101"
+  O->>D: orchestrate-phase-advance --ticket CTL-101 --completed-phase research
+  D->>D: next_phase = "plan" (from canonical sequence)
+  D->>D: check idempotency<br/>(skip if phase-plan.json exists)
+  D->>P: orchestrate-dispatch-next --phase plan --ticket CTL-101
+  P->>P: claude --bg /catalyst-dev:phase-plan CTL-101
+  P->>P: capture bg_job_id from stdout
+  P->>P: write phase-plan.json with bg_job_id, status=running
+  P->>B: emit phase.plan.dispatched (re-arms phase_lifecycle interest)
+```
+
+The broker matches incoming events against the regex
+`^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-\d+)$` and routes
+them to the registered `phase_lifecycle` interest by ticket. The orchestrator
+registers exactly one `phase_lifecycle` interest per ticket at Phase 4 start;
+all four broker interests (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`,
+`phase_lifecycle`) route back as the same `filter.wake.<ORCH_NAME>` so the
+orchestrator only watches one event stream.
+
+1. **Phase agent completes its one job.** Reads the prior phase's artifact, does
+   the work (research a topic, draft a plan, implement a diff, etc.), writes its
+   own `phase-<name>.json` to `${ORCH_DIR}/workers/<TICKET>/`, and emits
+   `phase.<name>.complete.<TICKET>` via `catalyst-state.sh event`.
+2. **Broker matches the deterministic interest.** No LLM call — the broker's
+   `phase_lifecycle` matcher reads the registered `(ticket, phase_names)` tuple
+   and confirms the event is in scope.
+3. **Broker fires the wake.** Appends `filter.wake.<ORCH_NAME>` to the event log
+   with `payload.reason = "Phase <name> complete on <TICKET>"`.
+4. **Orchestrator sees the wake.** Its `catalyst-events wait-for` returns; it
+   calls `orchestrate-phase-advance --completed-phase <name> --ticket <TICKET>`.
+5. **Advance computes the next phase.** From the canonical 9-phase sequence
+   (`triage → research → plan → implement → verify → review → pr → monitor-merge →
+   monitor-deploy`). Skipped if the next phase's signal file already exists
+   (idempotency).
+6. **Dispatch the next phase.** `phase-agent-dispatch` launches a fresh
+   `claude --bg /catalyst-dev:phase-<next> <TICKET>` job, captures the `bg_job_id`,
+   writes `phase-<next>.json`, and emits `phase.<next>.dispatched.<TICKET>` to
+   re-arm the broker interest for the next completion.
+
+See [Phase agents](/reference/orchestration/phase-agents/) for the per-phase
+artifact contract and turn caps.
+
 ## What happens without webhooks
 
 If the smee tunnel is not configured, step 2 never happens. The orch-monitor falls back to polling GitHub's REST API every **10 minutes** and appending `github.*` events from poll results. `catalyst-events wait-for` will wake, but with up to 600s latency instead of ~1s.

--- a/website/src/content/docs/observability/events.md
+++ b/website/src/content/docs/observability/events.md
@@ -179,6 +179,7 @@ it at `.event`.
 | `filter.register` / `filter.deregister` | catalyst-broker | Interest registered or deregistered |
 | `filter.wake.<id>` | catalyst-broker | Wake event delivered to a registered interest |
 | `worker-dispatched` / `worker-pr-created` / `worker-done` | Orchestrator (v1 envelope) | Worker lifecycle |
+| `phase.<name>.dispatched.<TICKET>` / `phase.<name>.complete.<TICKET>` / `phase.<name>.failed.<TICKET>` | `phase-agent-dispatch` + phase agents (CTL-452) | 9-phase pipeline lifecycle — emitted only when `dispatchMode = "phase-agents"` (see [Phase agents](/reference/orchestration/phase-agents/)) |
 | `catalyst.*` | catalyst-session | Skill/session lifecycle events |
 
 GitHub and Linear topics arrive via webhooks when the monitor is configured (see

--- a/website/src/content/docs/observability/monitor.md
+++ b/website/src/content/docs/observability/monitor.md
@@ -69,7 +69,11 @@ One row per worker showing:
 
 - **Ticket** (click to open Linear)
 - **Status** color-coded: gray (dispatched), blue (researching/planning/implementing), amber (validating/shipping), green (done), red (failed)
-- **Phase** number (0-6)
+- **Phase** — the worker's current phase. The shape depends on `dispatchMode`:
+  - `oneshot-legacy`: integer `0`–`6` (research → plan → implement → validate → ship → pr-created → done)
+  - `phase-agents` (CTL-452): one of nine named phases — `triage`, `research`, `plan`, `implement`,
+    `verify`, `review`, `pr`, `monitor-merge`, `monitor-deploy`. See
+    [Phase agents](/reference/orchestration/phase-agents/) for the canonical sequence
 - **PR** (click to open GitHub) with CI status dot
 - **Liveness** indicator: ✓ (alive), ! (dead PID), ? (no PID recorded yet)
 - **Duration** since startedAt

--- a/website/src/content/docs/observability/recording.md
+++ b/website/src/content/docs/observability/recording.md
@@ -14,10 +14,10 @@ Both layers are redundant on purpose: if OTel fails, signal files still work. If
 
 ## The Shell Wrapper
 
-When the orchestrator dispatches a worker via `claude -p`, it wraps the command in a shell script that exports Catalyst-specific resource attributes:
+When the orchestrator dispatches a worker, it wraps the spawn in a shell script that exports Catalyst-specific resource attributes. The exact command depends on `catalyst.orchestration.dispatchMode` in `.catalyst/config.json`:
 
 ```bash
-# Simplified version — the real one is in plugins/dev/skills/orchestrate/
+# Common env — set for both dispatch modes
 export OTEL_RESOURCE_ATTRIBUTES="\
 service.name=claude-code,\
 orchestrator.id=${ORCH_ID},\
@@ -25,13 +25,18 @@ worker.ticket=${TICKET_ID},\
 project.key=${PROJECT_KEY},\
 user.id=${USER}"
 
+# dispatchMode = "phase-agents" — one claude --bg job per phase (9 per ticket)
+exec claude --bg \
+  --resume "/catalyst-dev:phase-${PHASE_NAME} ${TICKET_ID} --orch-dir ${ORCH_DIR}"
+
+# dispatchMode = "oneshot-legacy" — one long-lived claude -p worker per ticket
 exec claude \
   -n "oneshot-${TICKET_ID}" \
   --output-format stream-json --verbose \
   -p "/catalyst-dev:oneshot ${TICKET_ID} --auto-merge"
 ```
 
-The `OTEL_RESOURCE_ATTRIBUTES` env var is picked up by the Claude Code OTel exporter and added to every telemetry batch. Downstream (Prometheus, Loki, Tempo) it's queryable as a label.
+The `OTEL_RESOURCE_ATTRIBUTES` env var is picked up by the Claude Code OTel exporter and added to every telemetry batch regardless of dispatch mode. Downstream (Prometheus, Loki, Tempo) it's queryable as a label. See [Phase agents](/reference/orchestration/phase-agents/) for the per-phase pipeline.
 
 ### What each attribute means
 
@@ -66,12 +71,13 @@ Independent of OTel, every worker writes a signal file at `<orchestrator-dir>/wo
     "url": "https://github.com/...",
     "ciStatus": "pending",
     "prOpenedAt": "2026-04-14T19:15:30Z",
-    "autoMergeArmedAt": "2026-04-14T19:15:32Z",
     "mergedAt": null
   },
   "pid": 63709
 }
 ```
+
+The `autoMergeArmedAt` field is no longer written. Per [ADR-014](https://github.com/coalesce-labs/catalyst/blob/main/docs/adrs.md#adr-014-worker-owns-full-pr-lifecycle-ctl-252) the worker owns the full PR lifecycle: it enters an event-driven listen loop after opening the PR, resolves CI/review blockers inline, executes `gh pr merge --squash --delete-branch` directly when the PR is CLEAN, and writes `pr.mergedAt` + `status: "done"` itself. The orchestrator's Phase 4 is a safety-net fallback only.
 
 The `phaseTimestamps` map is how the monitor builds a Gantt chart — each time a worker transitions status, it appends the new phase and its timestamp. Terminal states (`done`, `failed`, `stalled`) also set `completedAt`.
 
@@ -103,6 +109,7 @@ Event types:
 - `agent.checkin`, `agent.checkout` (CTL-303 — broker agent identity)
 - `broker.daemon.startup` (CTL-303 — legacy alias `filter.daemon.startup`)
 - `filter.register`, `filter.deregister`, `filter.wake.<id>` (CTL-303 — broker routing)
+- `phase.<name>.dispatched.<TICKET>`, `phase.<name>.complete.<TICKET>`, `phase.<name>.failed.<TICKET>` (CTL-452 — phase-agent pipeline; emitted only when `dispatchMode = "phase-agents"`)
 
 The newer canonical envelope shape (CTL-300) is the default for new emitters — the webhook
 receiver, `catalyst-comms send`, `catalyst-broker`, `catalyst-otel-forward`, and

--- a/website/src/content/docs/observability/terminal.md
+++ b/website/src/content/docs/observability/terminal.md
@@ -39,21 +39,29 @@ Quit with `q` or `Ctrl-C`.
 │ dispatched: 0  running: 2  pr-created: 3  done: 1 │
 │ attention: 0                        cost: $2.47   │
 ├────────────────────────────────────────────────────┤
-│ CTL-42  done        ✓   pr#118  merged    34m 12s │
-│ CTL-43  done        ✓   pr#119  merged    29m  4s │
-│ CTL-44  pr-created  ✓   pr#120  passing   12m 38s │
-│ CTL-45  implementing ✓                     8m 22s │
-│ CTL-46  validating  ✓                      4m 01s │
-│ CTL-48  researching !                      1m 15s │  ← dead PID
+│ CTL-42  done           ✓  pr#118  merged   34m 12s │
+│ CTL-43  done           ✓  pr#119  merged   29m  4s │
+│ CTL-44  monitor-merge  ✓  pr#120  passing  12m 38s │
+│ CTL-45  implement      ✓                    8m 22s │
+│ CTL-46  verify         ✓                    4m 01s │
+│ CTL-48  research       !                    1m 15s │  ← dead PID
 └────────────────────────────────────────────────────┘
 Events (most recent first):
-  19:15:32  CTL-44  worker-pr-created       pr#120
-  19:14:01  CTL-46  worker-phase-advanced   validating
-  19:13:44  CTL-48  worker-failed           crashed — PID gone
+  19:15:32  CTL-44  phase.pr.complete.CTL-44             pr#120 opened
+  19:14:01  CTL-46  phase.implement.complete.CTL-46      → verify dispatched
+  19:13:44  CTL-48  worker-failed                        crashed — PID gone
+  19:13:10  CTL-45  phase.plan.complete.CTL-45           → implement dispatched
 ```
 
+The example above is a `dispatchMode = "phase-agents"` run — the status column carries the
+canonical phase name (CTL-452) and the event stream surfaces
+`phase.<name>.complete.<TICKET>` directly. Under `dispatchMode = "oneshot-legacy"` the same
+columns instead show the oneshot status names (`researching`, `validating`, `pr-created`,
+etc.) and v1 envelope events (`worker-pr-created`, `worker-phase-advanced`). Both modes feed
+the same SSE event stream — the renderer is mode-agnostic.
+
 Color coding matches the web UI: blue for in-progress phases, green for done, red for
-failed/dead, amber for validating/shipping.
+failed/dead, amber for verify/review/monitor-merge (oneshot equivalents: validating/shipping).
 
 ## When to prefer classic over the Ink HUD
 


### PR DESCRIPTION
## Summary

Update six observability docs files in `website/src/content/docs/observability/` to reflect two post-2026-05-17 architectural changes: the **phase-agent pipeline** (CTL-452) and **ADR-014** (worker owns full PR lifecycle).

Part of the CTL-474 docs-currency pass. Closes CTL-479.

## What changed

| File | Change |
|------|--------|
| `recording.md` | Shell-wrapper example now shows both dispatch modes (phase-agents + oneshot-legacy); removed `autoMergeArmedAt` from the signal-file JSON example per ADR-014; added `phase.<name>.{dispatched,complete,failed}.<TICKET>` to the recorded event-types list |
| `events.md` | Added `phase.<name>.{dispatched,complete,failed}.<TICKET>` row to the canonical "Event topics in the log" table |
| `catalyst-events.md` | Added `phase.*` filter examples to both `tail` and `wait-for` example blocks; added a dedicated **Match by phase event (CTL-452)** subsection in the jq cookbook with five filter recipes (all phase events, per-ticket stream, exact match, all failures across tickets, all `implement`-phase events) |
| `event-flow.md` | Added a new **Step-by-step: a phase-agent wake** section with a mermaid sequenceDiagram (lifted from `docs/orchestrator-overview.md`) showing Worker → broker → orchestrator → `orchestrate-phase-advance` → `phase-agent-dispatch`, plus a numbered prose walkthrough |
| `monitor.md` | Replaced the hard-coded "Phase number (0-6)" copy with text that covers both `oneshot-legacy` (0-6 integer) and `phase-agents` (named string) modes |
| `terminal.md` | Refreshed example dashboard block to show phase-agent named phases in both the workers list and the events stream; added a clarifying note that the renderer is mode-agnostic |

## Verification

- [x] All 6 files updated per the ticket's "Files to update" list
- [x] `grep -n autoMergeArmedAt website/src/content/docs/observability/recording.md` shows only the new explanatory paragraph linking to ADR-014, not the removed JSON field
- [x] `bun run build` in `website/` completes cleanly — 297 pages built, 0 warnings, 0 errors
- [x] Mermaid sequence block in `event-flow.md` rendered without build errors
- [x] No broken internal links flagged by Astro/Starlight build

## References

- Parent: CTL-474 (orchestrator-overview docs)
- ADR-014: docs/adrs.md#adr-014-worker-owns-full-pr-lifecycle-ctl-252
- Phase-agent reference: `website/src/content/docs/reference/orchestration/phase-agents.md` (shipped in #812)

## Test plan

- [x] Local Starlight build green (297 pages, 0 errors)
- [ ] CI green
- [ ] Visual spot-check of changed pages on preview if available