### PR TITLE
feat(dev): catalyst-hud surfaces per-phase signal files (CTL-476)

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -268,9 +268,12 @@ appears in the events log specifically so orchestrators know to re-register thei
 interests — not for human debugging. Broker errors that surface a named event go
 to both; ordinary daemon noise goes only to `broker.log`.
 
-**Known gap (as of 2026-05-17):** `catalyst-hud` scans only flat `workers/*.json`;
-per-phase `workers/<TICKET>/phase-<name>.json` files written by `phase-agent-dispatch`
-are not yet surfaced. See `worker-signals-reader.ts::scanOrchestratorWorkersDir`.
+`catalyst-hud` surfaces both layouts: flat `workers/*.json` and per-phase
+`workers/<TICKET>/phase-<name>.json`. The reader
+(`worker-signals-reader.ts::scanOrchestratorWorkersDir`) descends one level into
+per-ticket subdirectories, picks the most recent non-terminal phase, and overlays
+its `phaseName`/`status` onto the flat signal so the PHASE column shows the live
+phase (e.g. `implement`, `monitor-merge`).
 
 ## On Claude Code's "agent view" / agents sidebar
 

--- a/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/WorkerList.tsx
@@ -44,7 +44,9 @@ function formatTimeoutRemaining(timeoutAt: string, nowMs: number): string {
 
 const COL_WORKER = 32;
 const COL_STATUS = 13;
-const COL_PHASE = 5;
+// 13 chars fits the longest phase-agents phase name ("monitor-merge"). Legacy
+// oneshot-legacy rows still render their integer phase here.
+const COL_PHASE = 13;
 const COL_PR = 6;
 const COL_HEARTBEAT = 10;
 
@@ -89,7 +91,8 @@ export function WorkerList({
         const statusText = ws ? `wait:${formatTimeoutRemaining(ws.timeoutAt, nowMs)}` : w.status;
         const worker = truncateRight(formatWorkerCell(w.workerName, w.orchestrator), COL_WORKER);
         const status = truncateRight(statusText, COL_STATUS);
-        const phase = truncateRight(w.phase !== null ? String(w.phase) : "—", COL_PHASE);
+        const phaseText: string = w.phaseName ?? (w.phase !== null ? String(w.phase) : "—");
+        const phase = truncateRight(phaseText, COL_PHASE);
         const pr = truncateRight(w.pr ? `#${w.pr.number}` : "—", COL_PR);
         const heartbeat = truncateRight(formatRelativeTime(w.lastHeartbeat), COL_HEARTBEAT);
         const worktree = truncateRight(lastPathSegment(w.worktreePath), worktreeW);

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useHudMetrics.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useHudMetrics.test.ts
@@ -16,6 +16,7 @@ function worker(overrides: Partial<WorkerSignal>): WorkerSignal {
     label: null,
     status: "researching",
     phase: 1,
+    phaseName: null,
     phaseTimestamps: {},
     lastHeartbeat: null,
     startedAt: null,

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.test.ts
@@ -147,7 +147,6 @@ describe("workerStatusColor", () => {
   test("done → green", () => expect(workerStatusColor("done")).toBe("green"));
   test("failed → red", () => expect(workerStatusColor("failed")).toBe("red"));
   test("stalled → red", () => expect(workerStatusColor("stalled")).toBe("red"));
-  test("dispatched → gray", () => expect(workerStatusColor("dispatched")).toBe("gray"));
   test("in-progress → cyan", () => {
     expect(workerStatusColor("researching")).toBe("cyan");
     expect(workerStatusColor("planning")).toBe("cyan");
@@ -155,6 +154,12 @@ describe("workerStatusColor", () => {
     expect(workerStatusColor("validating")).toBe("cyan");
     expect(workerStatusColor("shipping")).toBe("cyan");
     expect(workerStatusColor("pr-created")).toBe("cyan");
+  });
+  // CTL-476: phase-agents mode per-phase signal statuses ride the same cyan
+  // bucket as legacy in-progress statuses.
+  test("phase-agents per-phase statuses → cyan", () => {
+    expect(workerStatusColor("dispatched")).toBe("cyan");
+    expect(workerStatusColor("running")).toBe("cyan");
   });
   test("unknown → gray", () => expect(workerStatusColor("frobnicating")).toBe("gray"));
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dashboard-format.ts
@@ -52,6 +52,9 @@ const IN_PROGRESS_STATUSES = new Set([
   "validating",
   "shipping",
   "pr-created",
+  // phase-agents mode per-phase statuses (CTL-476)
+  "dispatched",
+  "running",
 ]);
 
 export function workerStatusColor(status: string): WorkerStatusColor {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.test.ts
@@ -45,6 +45,39 @@ function setupOrch(root: string, orchName: string, signals: Record<string, unkno
   }
 }
 
+interface PerPhaseFixture {
+  phase: string;
+  status?: string;
+  updatedAt?: string;
+  model?: string;
+}
+
+function setupPerPhaseOrch(
+  root: string,
+  orchName: string,
+  ticket: string,
+  phases: PerPhaseFixture[],
+) {
+  const dir = join(root, orchName, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  for (const p of phases) {
+    writeFileSync(
+      join(dir, `phase-${p.phase}.json`),
+      JSON.stringify({
+        ticket,
+        phase: p.phase,
+        orchestrator: orchName,
+        model: p.model ?? "sonnet",
+        turnCap: 50,
+        status: p.status ?? "running",
+        bg_job_id: "bg-fake",
+        startedAt: p.updatedAt ?? new Date(NOW - 60_000).toISOString(),
+        updatedAt: p.updatedAt ?? new Date(NOW - 5_000).toISOString(),
+      }),
+    );
+  }
+}
+
 describe("readWorkerSignals", () => {
   let tmp: string;
   beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hud-ws-")); });
@@ -147,6 +180,126 @@ describe("readWorkerSignals", () => {
     writeFileSync(join(tmp, "orch-a", "workers", "T-bad.json"), JSON.stringify({ status: "implementing" }));
     const out = readWorkerSignals(tmp, NOW);
     expect(out).toHaveLength(1);
+  });
+});
+
+describe("readWorkerSignals (per-phase layout)", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hud-ws-pa-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("per-phase only: surfaces a single ticket as one row with phaseName", () => {
+    setupPerPhaseOrch(tmp, "orch-pa", "T-100", [{ phase: "implement" }]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    const row = out[0];
+    expect(row.ticket).toBe("T-100");
+    expect(row.phaseName).toBe("implement");
+    expect(row.status).toBe("running");
+    expect(row.workerName).toBe("orch-pa-T-100");
+  });
+
+  test("per-phase: latest non-terminal phase wins when multiple files present", () => {
+    setupPerPhaseOrch(tmp, "orch-pa", "T-100", [
+      { phase: "triage", updatedAt: new Date(NOW - 10 * 60_000).toISOString() },
+      { phase: "implement", updatedAt: new Date(NOW - 60_000).toISOString() },
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].phaseName).toBe("implement");
+    expect(out[0].updatedAt).toBe(new Date(NOW - 60_000).toISOString());
+  });
+
+  test("per-phase + flat coexist: overlay merges phaseName onto flat signal", () => {
+    setupOrch(tmp, "orch-pa", [
+      makeSignal({
+        ticket: "T-100",
+        workerName: "orch-pa-T-100",
+        orchestrator: "orch-pa",
+        status: "implementing",
+        pr: { number: 42, url: "" },
+        worktreePath: "/tmp/wt-100",
+      }),
+    ]);
+    setupPerPhaseOrch(tmp, "orch-pa", "T-100", [
+      { phase: "verify", updatedAt: new Date(NOW - 30_000).toISOString() },
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    const row = out[0];
+    expect(row.ticket).toBe("T-100");
+    expect(row.phaseName).toBe("verify");
+    expect(row.pr?.number).toBe(42);
+    expect(row.worktreePath).toBe("/tmp/wt-100");
+    expect(row.status).toBe("running"); // per-phase status wins
+  });
+
+  test("per-phase directory with no phase-*.json is skipped silently", () => {
+    setupOrch(tmp, "orch-pa", [makeSignal({ ticket: "T-flat", workerName: "orch-pa-T-flat" })]);
+    mkdirSync(join(tmp, "orch-pa", "workers", "T-empty"), { recursive: true });
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].ticket).toBe("T-flat");
+  });
+
+  test("mixed orch: flat-only ticket + per-phase-only ticket → both surface", () => {
+    setupOrch(tmp, "orch-pa", [makeSignal({ ticket: "T-A", workerName: "orch-pa-T-A", orchestrator: "orch-pa" })]);
+    setupPerPhaseOrch(tmp, "orch-pa", "T-B", [{ phase: "research" }]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(2);
+    const tickets = out.map((w) => w.ticket).sort();
+    expect(tickets).toEqual(["T-A", "T-B"]);
+    const phaseNames = out.map((w) => w.phaseName).sort();
+    expect(phaseNames).toEqual([null, "research"]);
+  });
+
+  test("per-phase: all-terminal phases fall back to most-recent overall", () => {
+    setupPerPhaseOrch(tmp, "orch-pa", "T-100", [
+      { phase: "triage", status: "done", updatedAt: new Date(NOW - 30 * 60_000).toISOString() },
+      { phase: "research", status: "done", updatedAt: new Date(NOW - 10 * 60_000).toISOString() },
+      { phase: "plan", status: "failed", updatedAt: new Date(NOW - 2 * 60_000).toISOString() },
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].phaseName).toBe("plan");
+    expect(out[0].status).toBe("failed");
+  });
+
+  test("per-phase: malformed JSON and missing required fields are skipped, valid file surfaces", () => {
+    const dir = join(tmp, "orch-pa", "workers", "T-100");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-broken.json"), "{ not valid json");
+    writeFileSync(
+      join(dir, "phase-missing-ticket.json"),
+      JSON.stringify({ phase: "verify", orchestrator: "orch-pa", status: "running" }),
+    );
+    writeFileSync(
+      join(dir, "phase-valid.json"),
+      JSON.stringify({
+        ticket: "T-100",
+        phase: "implement",
+        orchestrator: "orch-pa",
+        model: "sonnet",
+        turnCap: 50,
+        status: "running",
+        bg_job_id: "bg-good",
+        startedAt: new Date(NOW - 60_000).toISOString(),
+        updatedAt: new Date(NOW - 5_000).toISOString(),
+      }),
+    );
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].phaseName).toBe("implement");
+  });
+
+  test("legacy flat-only orch still works (no regression when no subdirs present)", () => {
+    setupOrch(tmp, "orch-legacy", [
+      makeSignal({ ticket: "T-1", workerName: "orch-legacy-T-1", orchestrator: "orch-legacy" }),
+      makeSignal({ ticket: "T-2", workerName: "orch-legacy-T-2", orchestrator: "orch-legacy", status: "researching" }),
+    ]);
+    const out = readWorkerSignals(tmp, NOW);
+    expect(out).toHaveLength(2);
+    expect(out.every((w) => w.phaseName === null)).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/worker-signals-reader.ts
@@ -25,6 +25,9 @@ export interface WorkerSignal {
   label: string | null;
   status: string;
   phase: number | null;
+  // Per-phase mode current phase name (e.g. "implement", "monitor-merge"). Null for legacy
+  // oneshot-legacy workers that only carry the integer `phase`.
+  phaseName: string | null;
   phaseTimestamps: Record<string, string>;
   lastHeartbeat: string | null;
   startedAt: string | null;
@@ -97,6 +100,7 @@ function parseSignal(raw: unknown): WorkerSignal | null {
     label: asString(r.label),
     status,
     phase: asNumber(r.phase),
+    phaseName: asString(r.phaseName),
     phaseTimestamps: parsePhaseTimestamps(r.phaseTimestamps),
     lastHeartbeat: asString(r.lastHeartbeat),
     startedAt: asString(r.startedAt),
@@ -107,6 +111,87 @@ function parseSignal(raw: unknown): WorkerSignal | null {
     linearState: asString(r.linearState),
     definitionOfDone: r.definitionOfDone ?? null,
     raw,
+  };
+}
+
+// Per-phase signal file overlay — written by phase-agent-dispatch under
+// workers/<TICKET>/phase-<name>.json. Only phase-agents mode produces these.
+interface PerPhaseOverlay {
+  ticket: string;
+  orchestrator: string;
+  phaseName: string;
+  status: string;
+  updatedAt: string | null;
+}
+
+// Status values that indicate a phase has finished. Superset of what
+// phase-agent-dispatch writes ("dispatched", "running") so the selection
+// logic stays correct if/when phase agents stamp completion themselves.
+const PER_PHASE_TERMINAL = new Set(["done", "failed", "complete", "skipped"]);
+
+function parsePerPhaseFile(raw: unknown): PerPhaseOverlay | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const ticket = asString(r.ticket);
+  const orchestrator = asString(r.orchestrator);
+  const phaseName = asString(r.phase);
+  const status = asString(r.status);
+  if (!ticket || !orchestrator || !phaseName || !status) return null;
+  return { ticket, orchestrator, phaseName, status, updatedAt: asString(r.updatedAt) };
+}
+
+function scanPerPhaseDir(perPhaseDir: string): PerPhaseOverlay | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(perPhaseDir);
+  } catch {
+    return null;
+  }
+  const overlays: PerPhaseOverlay[] = [];
+  for (const name of entries) {
+    if (!name.startsWith("phase-") || !name.endsWith(".json")) continue;
+    const full = resolve(perPhaseDir, name);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(full, "utf8"));
+    } catch {
+      continue;
+    }
+    const ov = parsePerPhaseFile(parsed);
+    if (ov) overlays.push(ov);
+  }
+  if (overlays.length === 0) return null;
+  // Prefer most-recent non-terminal phase; fall back to most-recent overall.
+  const nonTerm = overlays.filter((o) => !PER_PHASE_TERMINAL.has(o.status));
+  const pool = nonTerm.length > 0 ? nonTerm : overlays;
+  pool.sort((a, b) => {
+    const am = a.updatedAt ? Date.parse(a.updatedAt) : 0;
+    const bm = b.updatedAt ? Date.parse(b.updatedAt) : 0;
+    return bm - am;
+  });
+  return pool[0];
+}
+
+function synthesizeFromOverlay(overlay: PerPhaseOverlay): WorkerSignal {
+  return {
+    ticket: overlay.ticket,
+    orchestrator: overlay.orchestrator,
+    wave: null,
+    workerName: `${overlay.orchestrator}-${overlay.ticket}`,
+    label: null,
+    status: overlay.status,
+    phase: null,
+    phaseName: overlay.phaseName,
+    phaseTimestamps: {},
+    lastHeartbeat: overlay.updatedAt,
+    startedAt: null,
+    updatedAt: overlay.updatedAt,
+    completedAt: null,
+    worktreePath: null,
+    pr: null,
+    linearState: null,
+    definitionOfDone: null,
+    raw: overlay,
   };
 }
 
@@ -127,10 +212,26 @@ function scanOrchestratorWorkersDir(workersDir: string): WorkerSignal[] {
   } catch {
     return [];
   }
-  const out: WorkerSignal[] = [];
+
+  const flatByTicket = new Map<string, WorkerSignal>();
+  const overlayByTicket = new Map<string, PerPhaseOverlay>();
+
   for (const name of entries) {
-    if (!name.endsWith(".json") || name.endsWith("-rollup.json")) continue;
     const full = resolve(workersDir, name);
+    let entryIsDir: boolean;
+    try {
+      entryIsDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+
+    if (entryIsDir) {
+      const overlay = scanPerPhaseDir(full);
+      if (overlay) overlayByTicket.set(overlay.ticket, overlay);
+      continue;
+    }
+
+    if (!name.endsWith(".json") || name.endsWith("-rollup.json")) continue;
     let parsed: unknown;
     try {
       parsed = JSON.parse(readFileSync(full, "utf8"));
@@ -138,9 +239,27 @@ function scanOrchestratorWorkersDir(workersDir: string): WorkerSignal[] {
       continue;
     }
     const sig = parseSignal(parsed);
-    if (sig) out.push(sig);
+    if (sig) flatByTicket.set(sig.ticket, sig);
   }
-  return out;
+
+  // Apply per-phase overlays. In phase-agents mode the flat file's status/phase
+  // go stale by design — the per-phase file is the authoritative live state, so
+  // we replace `status`/`updatedAt`/`lastHeartbeat` when overlaying.
+  for (const [ticket, overlay] of overlayByTicket) {
+    const existing = flatByTicket.get(ticket);
+    if (existing) {
+      existing.phaseName = overlay.phaseName;
+      existing.status = overlay.status;
+      if (overlay.updatedAt) {
+        existing.updatedAt = overlay.updatedAt;
+        existing.lastHeartbeat = overlay.updatedAt;
+      }
+    } else {
+      flatByTicket.set(ticket, synthesizeFromOverlay(overlay));
+    }
+  }
+
+  return Array.from(flatByTicket.values());
 }
 
 export function scanOrchestratorWorkers(orchDir: string): WorkerSignal[] {


### PR DESCRIPTION
## Summary

`catalyst-hud` only scanned flat `~/catalyst/runs/<orchId>/workers/*.json`, so when an orchestration runs in `dispatchMode: "phase-agents"` (introduced by CTL-452) the Workers tab showed stale top-level signals and no per-phase progress. The per-phase files at `workers/<TICKET>/phase-<name>.json` carry the live `phase`, `status`, `model`, and `bg_job_id`.

This PR extends the reader to descend one level, merges the per-phase data onto the flat `WorkerSignal`, widens the HUD's PHASE column to fit phase names, and updates docs.

## Changes

- **Reader** (`worker-signals-reader.ts`):
  - New optional `phaseName: string | null` field on `WorkerSignal`.
  - `scanOrchestratorWorkersDir` now walks `workers/` entries via `statSync` — files keep the previous flat path; directories descend into `scanPerPhaseDir` which globs `phase-*.json`, validates each, and returns the most-recent non-terminal phase (or most-recent overall if all terminal).
  - Merge semantics: when a flat `WorkerSignal` exists for the ticket, overlay sets `phaseName` + replaces stale `status`/`updatedAt`/`lastHeartbeat`. When no flat file exists, synthesize a minimal row so the operator still sees the ticket.
- **HUD** (`WorkerList.tsx`):
  - `COL_PHASE` 5 → 13 (fits the longest phase name `monitor-merge`).
  - Cell renderer prefers `w.phaseName` (string), falls back to `w.phase` (legacy integer), else `—`.
- **Colors** (`dashboard-format.ts`):
  - `dispatched` and `running` (phase-agents lifecycle statuses) join the cyan in-progress bucket.
- **Docs** (`docs/orchestrator-overview.md`):
  - Replace the "Known gap" callout with the resolved behavior.
- **Tests** (`worker-signals-reader.test.ts` + `dashboard-format.test.ts`):
  - 7 new reader cases: per-phase only, latest non-terminal wins, flat+per-phase merge, empty subdir, mixed orch, all-terminal fallback, malformed/missing-required skip, legacy regression check.
  - Updated dashboard-format color assertion for the two new in-progress statuses.

Tests written first (red → green); manual smoke verified with a synthetic per-phase fixture surfacing both a synthesized row and a merged flat+overlay row.

## Test plan

- [x] `bun test cli/lib/worker-signals-reader.test.ts` — 21 pass (14 original + 7 new)
- [x] `bun test cli/lib/dashboard-format.test.ts` — 45 pass (including new phase-agents cyan check)
- [x] `bun test cli/hooks/useHudMetrics.test.ts` — passes after adding the new required field to the fixture
- [x] `bun run typecheck` — no new errors (pre-existing `ui/src/lib/briefings.ts` `marked`/`dompurify` errors unrelated)
- [x] `bun run lint` — no new errors (3 pre-existing warnings unrelated)
- [x] Manual: synthetic per-phase + flat fixture surfaces both row types correctly
- [x] Reward-hacking scan — clean (no `as any`, `as unknown as`, `@ts-ignore`, non-null `!`, `forEach(async`)

Closes CTL-476.