### PR TITLE
docs(meta): root CLAUDE.md + architecture.md phase-agents currency pass (CTL-481, refs CTL-474)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,24 @@ Two-layer config system:
 Edit plugin files in `plugins/*/`, test locally (symlinks make changes immediate), restart Claude
 Code to reload. Changes are distributed via the Claude Code plugin marketplace.
 
+## Orchestration
+
+Catalyst orchestrators (`/catalyst-dev:orchestrate`) ship work as **phase-agent workers** — one
+short-lived `claude --bg` job per phase, walking a 9-phase pipeline (triage → research → plan →
+implement → verify → review → pr → monitor-merge → monitor-deploy). Legacy `oneshot-legacy` mode
+(one long-lived `claude -p /catalyst-dev:oneshot` per ticket) is preserved as a fallback. The
+mode is selected by `.catalyst/config.json → catalyst.orchestration.dispatchMode`.
+
+Cross-process communication is built on a **single unified event log** at
+`~/catalyst/events/YYYY-MM.jsonl`. Workers, the phase dispatcher, the broker, the webhook
+receiver, and `catalyst-comms send` all append; the broker daemon, the HUD, the orch-monitor web
+dashboard, and `catalyst-events wait-for` all read. The broker self-filters its own emissions via
+`shouldSkipEvent` (`plugins/dev/scripts/broker/index.mjs:1338`) so the same file can safely be
+both its input and its output.
+
+See `docs/orchestrator-overview.md` for the end-to-end run lifecycle and the Phase-Agent
+Communication section in `docs/architecture.md` for the unified data-flow diagram.
+
 @import docs/architecture.md
 
 @import docs/adrs.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,6 +198,66 @@ The contract: every worker produces ≥4 messages per run. Signal files remain t
 state — comms is observability and cross-worker coordination. See
 `plugins/dev/skills/catalyst-comms/SKILL.md` for the full protocol.
 
+## Phase-Agent Communication
+
+Orchestrators dispatched in `dispatchMode = "phase-agents"` spawn one short-lived `claude --bg`
+job per phase, walking the 9-phase pipeline (triage → research → plan → implement → verify →
+review → pr → monitor-merge → monitor-deploy — see `docs/orchestrator-overview.md`). Phase
+agents do **not** message each other directly. They communicate by **appending typed events to a
+single shared JSONL log** at `~/catalyst/events/YYYY-MM.jsonl`. The orchestrator wakes on those
+events via the broker (`filter.wake.<ORCH_NAME>`), advances the ticket through the canonical
+sequence in `orchestrate-phase-advance`, and dispatches the next `--bg` job.
+
+### Unified data-flow
+
+The same event log is the cross-process backbone for every observation surface:
+
+```mermaid
+flowchart LR
+  subgraph Writers
+    OS[Orchestrator skill] --> DM[~/catalyst/runs/&lt;id&gt;/<br/>DASHBOARD.md]
+    OS --> SJ[~/catalyst/runs/&lt;id&gt;/<br/>state.json]
+    PAD[phase-agent-dispatch] --> PSF[workers/&lt;TICKET&gt;/<br/>phase-&lt;name&gt;.json]
+    BROKER[broker daemon] --> BI[~/catalyst/broker-interests.json]
+    BROKER --> EL[~/catalyst/events/<br/>YYYY-MM.jsonl]
+  end
+
+  subgraph Surfaces
+    HUD[catalyst-hud<br/>Ink TUI]
+    OM[orch-monitor<br/>web dashboard]
+    CE[catalyst-events tail<br/>raw stream]
+  end
+
+  SJ --> HUD
+  PSF -.not yet scanned.-> HUD
+  BI --> HUD
+  DM --> OM
+  EL --> CE
+```
+
+Writers — phase-agent workers, `phase-agent-dispatch`, the broker daemon, the TypeScript webhook
+receiver, and `catalyst-comms send` — all append to `~/catalyst/events/YYYY-MM.jsonl`. Readers —
+`catalyst-events tail`, `catalyst-events wait-for`, the broker daemon, `catalyst-hud`, and the
+orch-monitor web dashboard — consume that log (plus per-run state files and broker registry)
+without coordinating with one another.
+
+### `shouldSkipEvent` self-filter
+
+Because the broker both **reads** and **writes** the same JSONL log, it would otherwise re-ingest
+the `filter.wake.*` and `broker.daemon.*` events it just emitted, creating a feedback loop
+(observed during the 2026-05-12 incident behind CTL-346). To prevent this, the broker classifies
+every event through `shouldSkipEvent` (`plugins/dev/scripts/broker/index.mjs:1338`) before
+processing it. The filter drops:
+
+- Anything where `resource."service.name" === "catalyst.broker"` (the broker's own emissions)
+- Event names starting with `filter.` (wakes, registrations, deregistrations)
+- Event names starting with `broker.daemon` (daemon lifecycle)
+- `session.heartbeat` (liveness pings — also short-circuited earlier in `processEvent`)
+
+`BROKER_INGEST_OWN_EMISSIONS=1` flips the rule to "accept only `filter.*` events" for debugging.
+This self-filter is what makes the single unified log safe to use as both the broker's input and
+its output.
+
 ## Context Management Principles
 
 1. **Context is precious** — Use specialized agents, not monoliths


### PR DESCRIPTION
## Summary

Part of the CTL-474 docs-currency pass. Updates the two highest-leverage docs in the repo so
contributors landing in a fresh Claude Code session immediately see the phase-agents architecture.

- **`CLAUDE.md`** (loaded into every Claude Code session) — new "Orchestration" H2 noting:
  - `phase-agents` (9-phase `claude --bg` pipeline) vs `oneshot-legacy` dispatch modes, gated by `.catalyst/config.json → catalyst.orchestration.dispatchMode`
  - `~/catalyst/events/YYYY-MM.jsonl` as the unified cross-process communication backbone
  - `shouldSkipEvent` (`plugins/dev/scripts/broker/index.mjs:1338`) self-filter that makes the same log safe as both broker input and output
  - Pointers to `docs/orchestrator-overview.md` and the new architecture subsection

- **`docs/architecture.md`** (imported by `CLAUDE.md`) — new "Phase-Agent Communication" H2 after the existing catalyst-comms section:
  - Frames phase agents as event-only communicators (no direct messaging) and ties wakes back to `orchestrate-phase-advance`
  - Lifts the unified data-flow `flowchart LR` from `docs/orchestrator-overview.md:163-184` verbatim — same mermaid, so the two docs stay in lockstep
  - Documents the four `shouldSkipEvent` drop rules (service-name guard, `filter.*`, `broker.daemon.*`, `session.heartbeat`) and the `BROKER_INGEST_OWN_EMISSIONS=1` debug escape

## Reference material consulted

- `docs/orchestrator-overview.md` (CTL-474 keystone, merged in #820)
- `thoughts/shared/research/2026-05-17-orchestrator-end-to-end.md` — research-doc twin of the above
- `plugins/dev/scripts/broker/index.mjs:1338` — current `shouldSkipEvent` implementation

## Test plan

- [ ] CI green (markdown / lint only — docs-only diff)
- [ ] Eyeball the rendered `## Orchestration` section in CLAUDE.md
- [ ] Eyeball the rendered `## Phase-Agent Communication` section in docs/architecture.md (mermaid block balanced — `grep -c '^\`\`\`' docs/architecture.md` → 12)
- [ ] All file:line references checked: `docs/orchestrator-overview.md`, `plugins/dev/scripts/broker/index.mjs:1338`, `orchestrate-phase-advance`, `phase-agent-dispatch`, `plugins/dev/skills/catalyst-comms/SKILL.md` all exist on this branch

Refs: CTL-474