### PR TITLE
feat(dev): event-source workers/*.json via broker projection (CTL-483)

### DIFF
--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -650,3 +650,111 @@ model) is the runtime fallback when the key is missing.
   [`docs/orchestrator-overview.md`](orchestrator-overview.md). Related ADRs:
   ADR-006 (global state JSON), ADR-008 (SQLite session store), ADR-014 (worker
   owns full PR lifecycle).
+
+## ADR-018: Event-Sourced Worker Signal Files via Broker Projection (CTL-483)
+
+**Status**: Accepted, 2026-05-17. Phase 1 (dual-write) shipped; Phase 2 (cutover)
+and Phase 3 (SQLite mirror) tracked separately.
+
+**Context**: `workers/<TICKET>.json` signal files are currently written directly by
+**seven different code paths**:
+
+- `orchestrate-dispatch-next` — records PID + lastHeartbeat after dispatch
+- `orchestrate-followup` — seeds new signal files for follow-up tickets
+- The worker agent itself (`oneshot/SKILL.md` — full lifecycle transitions)
+- `orchestrate-healthcheck` — marks workers failed/stalled
+- `orchestrate-revive` — manages revive retry budget
+- `orchestrate-auto-fixup` — clears/sets `blockedSince`
+- `orchestrate-auto-rebase` — clears/sets `dirtySince`
+
+All seven use the same atomic `jq ... > tmp && mv` pattern, but there is **no
+inter-process locking**. Cross-script races (e.g. healthcheck marks a worker
+`failed` while the worker is simultaneously writing `pr-created`) are undetected
+and silent.
+
+The broker already has the relevant projection precedent: `broker-interests.json`
+is fully event-sourced from `filter.register` / `filter.deregister`
+(`broker/index.mjs:handleRegister/handleDeregister/saveInterests`). ADR-008 set
+the dual-write migration pattern for sessions (JSONL → SQLite), and ADR-011
+established the filesystem-first invariant for archive artifacts.
+
+**Decision**: Move worker state mutations from "direct file write" to "emit a
+`worker.state_changed` command event; broker projects the new state to disk".
+The event carries the FULL new state in `body.payload.state` (not a patch), so
+the broker is the simple end of the contract — no merging logic.
+
+Migration is dual-write across three phases, mirroring ADR-008:
+
+**Phase 1 (additive, this ADR)**: writers continue their direct `jq ... > tmp && mv`
+AND emit a `worker.state_changed` event. The broker projects events to a
+**shadow path** — `workers/<TICKET>.json.projected` — so direct writes are never
+raced. A new `orchestrate-shadow-diff` CLI compares canonical vs shadow files
+(stripped of audit metadata) and reports drift. PoC writer is
+`orchestrate-auto-rebase` (single helper-function entry point, minimal blast
+radius). The remaining six writers are migrated to dual-write one at a time
+under follow-up tickets.
+
+**Phase 2 (cutover)**: once `orchestrate-shadow-diff` shows zero drift across a
+full orchestration cycle for ALL seven writers, direct writes are removed.
+Broker becomes sole writer at the canonical path. `worker.state_changed`
+remains in `processEvent`; the broker dispatch is unchanged.
+
+**Phase 3 (optional)**: mirror to SQLite `worker_state` table per the ADR-011
+hybrid pattern (`worker_state` table indexed by `(orch_id, ticket)`; filesystem
+files remain the durable source of truth). Enables fast cross-orchestrator
+queries without re-parsing JSON files.
+
+**Event design**:
+
+| Field | Source |
+|---|---|
+| `event.name` | `worker.state_changed` |
+| `attributes."catalyst.orchestrator.id"` | path component |
+| `attributes."catalyst.worker.ticket"` | path component |
+| `attributes."catalyst.writer"` | audit trail (which script emitted) |
+| `body.payload.state` | full new contents of `workers/<TICKET>.json` |
+
+The full envelope plus a worked example is in
+`plugins/dev/references/event-schema.md` under `## catalyst-orchestrator`. The
+event name is registered in `plugins/dev/references/event-name-allowlist.md`
+under `### worker_lifecycle`.
+
+**Broker handler**: `handleWorkerStateChanged` (exported from
+`plugins/dev/scripts/broker/index.mjs`). Reads orchestrator + ticket from the
+event, derives the shadow path via `getProjectedWorkerStatePath`, and writes
+atomically via `writeProjectedWorkerState` (the helper adds a `_projected`
+metadata object recording `{writer, ts}` for forensic audit). Path resolution
+honors `CATALYST_RUNS_DIR` (default: `${CATALYST_DIR}/runs`). Unit tests in
+`plugins/dev/scripts/broker/worker-state.test.mjs` cover canonical + legacy
+envelope shapes, missing-field drops, atomic write, and path isolation.
+
+**Writer emit helper**: `plugins/dev/scripts/lib/emit-worker-state-changed.sh`
+is sourced by writers opting into dual-write. Best-effort — every emission
+failure path is a silent return so the direct write remains authoritative
+during Phase 1.
+
+**Feedback-loop safety**: the broker does NOT emit `worker.state_changed`
+itself, so a `shouldSkipEvent` rule is unnecessary. If a future SQLite-mirror
+handler is added in Phase 3, it will consume the same event without
+re-emitting, preserving this property.
+
+**Supersedes**: ADR-006's design for the `workers/<TICKET>.json` portion only.
+The global state (`~/catalyst/state.json`) and event log
+(`~/catalyst/events/YYYY-MM.jsonl`) decisions in ADR-006 remain in force.
+
+**Consequences**:
+
+- The race surface across seven writers collapses to "broker is sole writer"
+  after Phase 2 cutover.
+- Unblocks distributed broker — workers can POST `worker.state_changed`
+  to a remote endpoint instead of writing local files, with the broker
+  projecting from the receive side.
+- Provides a single observable mutation API for worker state, which
+  downstream tools (HUD, dashboards) can subscribe to without polling files.
+- Adds an event-log entry per worker state mutation (~5–10 per worker run).
+  Negligible at current volume (a few hundred events per orchestration).
+- During Phase 1, double disk usage for worker signals (canonical + shadow
+  copy). Each file is small (<2 KB), so the absolute cost is trivial.
+- Writers gain a soft dependency on the events directory being writable;
+  failure to emit is silent (best-effort), preserving the direct-write
+  invariant.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,16 @@ orchestrators and workers write to via `catalyst-state.sh` (lock-protected).
 This is a denormalized summary layer — per-orchestrator local state in worktrees remains the
 source of truth for crash recovery. See ADR-006 for the full design decision.
 
+**Worker signal projection (in migration, ADR-018).** Per-worker
+`workers/<TICKET>.json` files are currently written directly by seven scripts
+with no inter-process locking. CTL-483 begins moving these mutations to a
+`worker.state_changed` command event consumed by the broker, which projects
+the new state to a `<TICKET>.json.projected` shadow file. Phase 1 (this PR)
+ships the broker handler, the writer-side emit helper, and dual-write for
+`orchestrate-auto-rebase`; `orchestrate-shadow-diff` verifies byte-for-byte
+agreement between canonical and shadow files. Phase 2 removes the direct
+writes; Phase 3 mirrors to SQLite per the ADR-011 hybrid pattern. See ADR-018.
+
 ## Three-Layer Memory Architecture
 
 Catalyst uses a three-layer memory architecture to manage context across multiple projects:

--- a/plugins/dev/references/event-name-allowlist.md
+++ b/plugins/dev/references/event-name-allowlist.md
@@ -67,6 +67,26 @@ A single event drives this interest:
 
 - `comms.message.posted` — filtered by `body.payload.channel`, `body.payload.type` (must be in `types_of_interest`), and recipient (`body.payload.to` matches `subscriber_ticket`, or sender is in `owned_workers` for orchestrator subscribers)
 
+## worker_lifecycle (broker projection — CTL-483)
+
+Source: `plugins/dev/scripts/broker/index.mjs:handleWorkerStateChanged`. This is a
+command event consumed by the broker for the worker-signal projection (ADR-018),
+not a wake-up target for `pr_lifecycle` / `ticket_lifecycle` interests. Worker
+agents do NOT register interests on it; the broker matches by `event.name` in
+its dispatch chain and projects the new state to
+`<orchDir>/workers/<TICKET>.json.projected`.
+
+- `worker.state_changed` — emitted by scripts that mutate
+  `workers/<TICKET>.json`. Carries the full new state in `body.payload.state`,
+  plus `attributes."catalyst.orchestrator.id"`, `attributes."catalyst.worker.ticket"`,
+  and `attributes."catalyst.writer"` (which script emitted). The broker writes
+  the state byte-for-byte (minus a `_projected` audit-metadata field) to the
+  shadow path.
+
+During Phase 1 of the ADR-018 migration, only `orchestrate-auto-rebase` emits
+this event. Phase 1 producers are being rolled out one at a time; the remaining
+six writers are tracked under follow-up tickets.
+
 ## Pitfall: bare `catalyst.orchestrator.id` clauses
 
 `plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts:635-642` stamps

--- a/plugins/dev/references/event-schema.md
+++ b/plugins/dev/references/event-schema.md
@@ -489,6 +489,70 @@ Filters that previously matched `.event == "filter.wake.${id}"` now match:
 
 ---
 
+### `worker.state_changed` — catalyst.orchestrator (CTL-483)
+
+Emitted by scripts that mutate `workers/<TICKET>.json` as part of the Phase 1
+dual-write rollout (ADR-018). Carries the full new state in `body.payload.state`
+so the broker can project to `<orchDir>/workers/<TICKET>.json.projected`
+byte-for-byte. The `_projected` audit field added by the broker is NOT part of
+the event — it's metadata stamped at write time.
+
+```json
+{
+  "ts": "2026-05-17T18:00:00.000Z",
+  "id": "33333333-4444-4555-8666-777777777777",
+  "observedTs": "2026-05-17T18:00:00.001Z",
+  "severityText": "INFO",
+  "severityNumber": 9,
+  "traceId": "922348e23aa9b22524e048006709a6a1",
+  "spanId": "1a0513b3232a6043",
+  "resource": {
+    "service.name": "catalyst.orchestrator",
+    "service.namespace": "catalyst",
+    "service.version": "9.3.0"
+  },
+  "attributes": {
+    "event.name": "worker.state_changed",
+    "event.entity": "worker",
+    "event.action": "state_changed",
+    "event.label": "worker CTL-483 state changed by orchestrate-auto-rebase",
+    "catalyst.orchestrator.id": "o-ctl-483",
+    "catalyst.worker.ticket": "CTL-483",
+    "catalyst.writer": "orchestrate-auto-rebase",
+    "catalyst.session.id": "sess_..."
+  },
+  "body": {
+    "message": "worker CTL-483 state changed by orchestrate-auto-rebase",
+    "payload": {
+      "ticket": "CTL-483",
+      "orchestrator": "o-ctl-483",
+      "writer": "orchestrate-auto-rebase",
+      "state": {
+        "ticket": "CTL-483",
+        "status": "pr-created",
+        "phase": 5,
+        "dirtySince": null,
+        "...": "full contents of workers/<TICKET>.json"
+      }
+    }
+  }
+}
+```
+
+Required broker-handler fields:
+
+| Field | Purpose |
+|---|---|
+| `attributes."catalyst.orchestrator.id"` | path component — falls back to `body.payload.orchestrator` |
+| `attributes."catalyst.worker.ticket"` | path component — falls back to `body.payload.ticket` |
+| `attributes."catalyst.writer"` | audit trail — falls back to `body.payload.writer` then `"unknown"` |
+| `body.payload.state` | full new file contents (must be a JSON object) |
+
+Missing any of `orchestrator`, `ticket`, or `state` causes the broker to drop
+the event with a `warn` log line and write no file.
+
+---
+
 ## All event names by producer
 
 ### catalyst.github
@@ -549,6 +613,7 @@ Filters that previously matched `.event == "filter.wake.${id}"` now match:
 | `orchestrator.worker.phase_advanced` | `worker` | `phase_advanced` | INFO | `body.payload` = `{windowSec, changes}` |
 | `orchestrator.attention.raised` | `attention` | `raised` | WARN | `body.payload` = `{attentionType, reason}` |
 | `orchestrator.attention.resolved` | `attention` | `resolved` | INFO | |
+| `worker.state_changed` | `worker` | `state_changed` | INFO | `body.payload` = `{ticket, orchestrator, writer, state}`; consumed by broker projection (ADR-018) |
 
 ### catalyst.comms
 

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -1746,6 +1746,13 @@ export function processEvent(event) {
     return;
   }
 
+  // CTL-483 Phase 1: project worker state mutations to a shadow file so the
+  // verification cycle can confirm byte-for-byte agreement with direct writes.
+  if (name === "worker.state_changed") {
+    handleWorkerStateChanged(event);
+    return;
+  }
+
   if (shouldSkipEvent(event)) return;
 
   if (name === "heartbeat") {
@@ -2049,6 +2056,70 @@ export function writeBrokerStateFile(state, { path } = {}) {
 // per-event calls (dozens/sec at peak) are cheap.
 function persistBrokerState({ probe } = {}) {
   writeBrokerStateFile(buildBrokerState({ probe }));
+}
+
+// CTL-483: worker state projection (Phase 1 — shadow path).
+//
+// During the dual-write migration period, scripts that mutate
+// `workers/<TICKET>.json` ALSO emit a `worker.state_changed` event carrying
+// the full new state. The broker projects that state to
+// `<canonical>.projected` so the direct write is never racing with the
+// projection. A separate verification CLI (orchestrate-shadow-diff) compares
+// canonical vs projected to confirm byte-for-byte agreement before Phase 2
+// cuts over to broker-as-sole-writer at the canonical path.
+
+export function getProjectedWorkerStatePath(orchestratorId, ticket) {
+  const runsDir =
+    process.env.CATALYST_RUNS_DIR ??
+    `${process.env.CATALYST_DIR ?? `${homedir()}/catalyst`}/runs`;
+  return resolve(runsDir, orchestratorId, "workers", `${ticket}.json.projected`);
+}
+
+export function writeProjectedWorkerState(target, state, meta = {}) {
+  try {
+    mkdirSync(dirname(target), { recursive: true });
+    const tmp = `${target}.tmp`;
+    const payload = {
+      ...state,
+      _projected: {
+        writer: meta.writer ?? "unknown",
+        ts: meta.ts ?? new Date().toISOString(),
+      },
+    };
+    try {
+      writeFileSync(tmp, JSON.stringify(payload, null, 2));
+      renameSync(tmp, target);
+    } catch (err) {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        /* tmp already gone */
+      }
+      throw err;
+    }
+  } catch (err) {
+    log.warn({ err: err.message, path: target }, "failed to write projected worker state");
+  }
+}
+
+export function handleWorkerStateChanged(event) {
+  const payload = getEventPayload(event);
+  const orchestrator = getEventOrchestrator(event);
+  const ticket = event.attributes?.["catalyst.worker.ticket"] ?? payload.ticket;
+  if (!orchestrator || !ticket) {
+    log.warn({ orchestrator, ticket }, "worker.state_changed missing orchestrator/ticket — dropping");
+    return;
+  }
+  const state = payload.state;
+  if (!state || typeof state !== "object") {
+    log.warn({ orchestrator, ticket }, "worker.state_changed missing body.payload.state — dropping");
+    return;
+  }
+  const target = getProjectedWorkerStatePath(orchestrator, ticket);
+  writeProjectedWorkerState(target, state, {
+    writer: event.attributes?.["catalyst.writer"] ?? payload.writer ?? "unknown",
+    ts: event.ts ?? event.observedTs ?? new Date().toISOString(),
+  });
 }
 
 // Logs key health at startup. Returns the resolved state-file payload

--- a/plugins/dev/scripts/broker/worker-state.test.mjs
+++ b/plugins/dev/scripts/broker/worker-state.test.mjs
@@ -1,0 +1,207 @@
+// Unit tests for catalyst-broker worker.state_changed projection (CTL-483).
+// Run: bun test plugins/dev/scripts/broker/worker-state.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import {
+  handleWorkerStateChanged,
+  getProjectedWorkerStatePath,
+  writeProjectedWorkerState,
+} from "./index.mjs";
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "broker-worker-state-test-"));
+  process.env.CATALYST_DIR = tmpDir;
+  process.env.CATALYST_RUNS_DIR = join(tmpDir, "runs");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.CATALYST_DIR;
+  delete process.env.CATALYST_RUNS_DIR;
+});
+
+function makeCanonicalEvent({
+  orchestrator = "orch-1",
+  ticket = "CTL-100",
+  writer = "orchestrate-auto-rebase",
+  state = { ticket: "CTL-100", status: "pr-created", phase: 5, dirtySince: null },
+  ts = "2026-05-17T18:00:00.000Z",
+} = {}) {
+  return {
+    ts,
+    id: "00000000-0000-4000-8000-000000000001",
+    observedTs: ts,
+    severityText: "INFO",
+    severityNumber: 9,
+    resource: { "service.name": "catalyst.orchestrator" },
+    attributes: {
+      "event.name": "worker.state_changed",
+      "catalyst.orchestrator.id": orchestrator,
+      "catalyst.worker.ticket": ticket,
+      "catalyst.writer": writer,
+    },
+    body: {
+      message: `worker ${ticket} state changed by ${writer}`,
+      payload: { ticket, orchestrator, writer, state },
+    },
+  };
+}
+
+function makeLegacyEvent({
+  orchestrator = "orch-1",
+  ticket = "CTL-100",
+  writer = "orchestrate-auto-rebase",
+  state = { ticket: "CTL-100", status: "pr-created" },
+  ts = "2026-05-17T18:00:00.000Z",
+} = {}) {
+  return {
+    event: "worker.state_changed",
+    ts,
+    orchestrator,
+    detail: { ticket, writer, state },
+  };
+}
+
+describe("worker.state_changed projection (CTL-483)", () => {
+  test("getProjectedWorkerStatePath honors CATALYST_RUNS_DIR", () => {
+    const p = getProjectedWorkerStatePath("orch-A", "CTL-1");
+    expect(p).toBe(join(tmpDir, "runs", "orch-A", "workers", "CTL-1.json.projected"));
+  });
+
+  test("getProjectedWorkerStatePath falls back to CATALYST_DIR/runs when CATALYST_RUNS_DIR unset", () => {
+    delete process.env.CATALYST_RUNS_DIR;
+    const p = getProjectedWorkerStatePath("orch-A", "CTL-1");
+    expect(p).toBe(join(tmpDir, "runs", "orch-A", "workers", "CTL-1.json.projected"));
+  });
+
+  test("happy path: canonical event writes shadow file with state contents + _projected meta", () => {
+    const event = makeCanonicalEvent({
+      orchestrator: "orch-1",
+      ticket: "CTL-100",
+      state: { ticket: "CTL-100", status: "pr-created", phase: 5, dirtySince: null },
+    });
+    handleWorkerStateChanged(event);
+
+    const target = getProjectedWorkerStatePath("orch-1", "CTL-100");
+    expect(existsSync(target)).toBe(true);
+
+    const written = JSON.parse(readFileSync(target, "utf8"));
+    expect(written.ticket).toBe("CTL-100");
+    expect(written.status).toBe("pr-created");
+    expect(written.phase).toBe(5);
+    expect(written.dirtySince).toBeNull();
+    expect(written._projected).toEqual({
+      writer: "orchestrate-auto-rebase",
+      ts: "2026-05-17T18:00:00.000Z",
+    });
+  });
+
+  test("legacy flat envelope (event/detail/orchestrator) is also accepted", () => {
+    const event = makeLegacyEvent({
+      orchestrator: "orch-2",
+      ticket: "CTL-200",
+      state: { ticket: "CTL-200", status: "implementing" },
+    });
+    handleWorkerStateChanged(event);
+
+    const target = getProjectedWorkerStatePath("orch-2", "CTL-200");
+    expect(existsSync(target)).toBe(true);
+    const written = JSON.parse(readFileSync(target, "utf8"));
+    expect(written.status).toBe("implementing");
+    expect(written._projected.writer).toBe("orchestrate-auto-rebase");
+  });
+
+  test("missing orchestrator: drops event, no file written", () => {
+    const event = makeCanonicalEvent();
+    delete event.attributes["catalyst.orchestrator.id"];
+    delete event.body.payload.orchestrator;
+    handleWorkerStateChanged(event);
+
+    const target = getProjectedWorkerStatePath("orch-1", "CTL-100");
+    expect(existsSync(target)).toBe(false);
+  });
+
+  test("missing ticket: drops event, no file written", () => {
+    const event = makeCanonicalEvent();
+    delete event.attributes["catalyst.worker.ticket"];
+    delete event.body.payload.ticket;
+    handleWorkerStateChanged(event);
+
+    // Path won't resolve cleanly anyway, but the key invariant is that the
+    // runs/orch-1/workers/ dir contains no files for this run.
+    const workersDir = join(tmpDir, "runs", "orch-1", "workers");
+    if (existsSync(workersDir)) {
+      const fs = require("node:fs");
+      expect(fs.readdirSync(workersDir).length).toBe(0);
+    }
+  });
+
+  test("missing state payload: drops event, no file written", () => {
+    const event = makeCanonicalEvent();
+    delete event.body.payload.state;
+    handleWorkerStateChanged(event);
+
+    const target = getProjectedWorkerStatePath("orch-1", "CTL-100");
+    expect(existsSync(target)).toBe(false);
+  });
+
+  test("state is not an object: drops event, no file written", () => {
+    const event = makeCanonicalEvent();
+    event.body.payload.state = "not-an-object";
+    handleWorkerStateChanged(event);
+
+    const target = getProjectedWorkerStatePath("orch-1", "CTL-100");
+    expect(existsSync(target)).toBe(false);
+  });
+
+  test("writeProjectedWorkerState: atomic write removes tmp on success", () => {
+    const target = getProjectedWorkerStatePath("orch-3", "CTL-300");
+    writeProjectedWorkerState(target, { ticket: "CTL-300", status: "done" }, {
+      writer: "test",
+      ts: "2026-05-17T19:00:00.000Z",
+    });
+
+    expect(existsSync(target)).toBe(true);
+    expect(existsSync(`${target}.tmp`)).toBe(false);
+  });
+
+  test("writeProjectedWorkerState: overwrites existing projected file", () => {
+    const target = getProjectedWorkerStatePath("orch-4", "CTL-400");
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, JSON.stringify({ stale: true }));
+
+    writeProjectedWorkerState(target, { ticket: "CTL-400", status: "implementing" }, {
+      writer: "test",
+      ts: "2026-05-17T19:00:00.000Z",
+    });
+
+    const written = JSON.parse(readFileSync(target, "utf8"));
+    expect(written.stale).toBeUndefined();
+    expect(written.status).toBe("implementing");
+  });
+
+  test("_projected meta is derived from attributes.catalyst.writer when present", () => {
+    const event = makeCanonicalEvent({ writer: "orchestrate-dispatch-next" });
+    handleWorkerStateChanged(event);
+
+    const target = getProjectedWorkerStatePath("orch-1", "CTL-100");
+    const written = JSON.parse(readFileSync(target, "utf8"));
+    expect(written._projected.writer).toBe("orchestrate-dispatch-next");
+  });
+
+  test("_projected meta falls back to 'unknown' when writer is absent everywhere", () => {
+    const event = makeCanonicalEvent();
+    delete event.attributes["catalyst.writer"];
+    delete event.body.payload.writer;
+    handleWorkerStateChanged(event);
+
+    const target = getProjectedWorkerStatePath("orch-1", "CTL-100");
+    const written = JSON.parse(readFileSync(target, "utf8"));
+    expect(written._projected.writer).toBe("unknown");
+  });
+});

--- a/plugins/dev/scripts/lib/emit-worker-state-changed.sh
+++ b/plugins/dev/scripts/lib/emit-worker-state-changed.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# emit-worker-state-changed.sh — emit a canonical `worker.state_changed` event
+# carrying the full new contents of a worker signal file (CTL-483 Phase 1
+# dual-write).
+#
+# Sourceable helper. Best-effort: emission failures NEVER fail the caller —
+# the direct write to workers/<TICKET>.json remains authoritative during
+# Phase 1. The broker's projectWorkerState handler materializes the event
+# to a SHADOW path (workers/<TICKET>.json.projected) so the verification
+# cycle can confirm byte-for-byte agreement with the direct write before
+# Phase 2 cuts the broker over to sole-writer at the canonical path.
+#
+# Usage (after sourcing):
+#   emit_worker_state_changed <signal-path> <writer-name>
+#
+# Required env (read; never required):
+#   CATALYST_SESSION_ID        used for span_id derivation
+#   CATALYST_ORCHESTRATOR_ID   used for trace_id derivation (also overrides
+#                              the signal-file orchestrator field if set)
+#   CATALYST_EVENTS_FILE       test override; takes precedence over CATALYST_EVENTS_DIR
+#   CATALYST_EVENTS_DIR        directory to append YYYY-MM.jsonl into
+#                              (default: $CATALYST_DIR/events, default: $HOME/catalyst/events)
+
+if [[ -n "${__CATALYST_EMIT_WSC_SOURCED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+__CATALYST_EMIT_WSC_SOURCED=1
+
+__EWSC_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# canonical-event.sh provides build_canonical_line / canonical_jsonl_append /
+# derive_trace_id / derive_span_id.
+# shellcheck disable=SC1091
+. "${__EWSC_LIB_DIR}/canonical-event.sh"
+
+emit_worker_state_changed() {
+  local signal="${1:-}"
+  local writer="${2:-unknown}"
+
+  [[ -n "$signal" ]] || return 0
+  [[ -r "$signal" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local ticket orchestrator state_json
+  ticket="$(jq -r '.ticket // empty' "$signal" 2>/dev/null)" || return 0
+  [[ -n "$ticket" ]] || return 0
+
+  orchestrator="${CATALYST_ORCHESTRATOR_ID:-}"
+  if [[ -z "$orchestrator" ]]; then
+    orchestrator="$(jq -r '.orchestrator // empty' "$signal" 2>/dev/null)"
+  fi
+  [[ -n "$orchestrator" ]] || return 0
+
+  state_json="$(cat "$signal" 2>/dev/null)" || return 0
+
+  local payload
+  payload="$(jq -nc \
+    --arg ticket "$ticket" \
+    --arg orchestrator "$orchestrator" \
+    --arg writer "$writer" \
+    --argjson state "$state_json" \
+    '{ticket: $ticket, orchestrator: $orchestrator, writer: $writer, state: $state}')" || return 0
+
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+
+  local trace_id span_id
+  trace_id="$(derive_trace_id "$orchestrator" "${CATALYST_SESSION_ID:-}")"
+  span_id="$(derive_span_id "$ticket" "${CATALYST_SESSION_ID:-}")"
+
+  local line
+  line="$(build_canonical_line \
+    --ts "$ts" \
+    --severity "INFO" \
+    --service "catalyst.orchestrator" \
+    --event-name "worker.state_changed" \
+    --trace-id "$trace_id" \
+    --span-id "$span_id" \
+    --entity "worker" \
+    --action "state_changed" \
+    --label "worker $ticket state changed by $writer" \
+    --orch "$orchestrator" \
+    --worker "$ticket" \
+    --session "${CATALYST_SESSION_ID:-}" \
+    --message "worker $ticket state changed by $writer" \
+    --payload-json "$payload")" || return 0
+
+  if [[ -n "${CATALYST_EVENTS_FILE:-}" ]]; then
+    mkdir -p "$(dirname "$CATALYST_EVENTS_FILE")" 2>/dev/null || true
+    printf '%s\n' "$line" >> "$CATALYST_EVENTS_FILE" 2>/dev/null || return 0
+    return 0
+  fi
+
+  local events_dir
+  events_dir="${CATALYST_EVENTS_DIR:-${CATALYST_DIR:-$HOME/catalyst}/events}"
+  canonical_jsonl_append "$events_dir" "$line" 2>/dev/null || return 0
+}
+
+# When run as a script (not sourced), expose the function via CLI shimming.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  emit_worker_state_changed "$@"
+fi

--- a/plugins/dev/scripts/orchestrate-auto-rebase
+++ b/plugins/dev/scripts/orchestrate-auto-rebase
@@ -87,10 +87,24 @@ parse_repo() {
   echo "$url" | sed -nE 's|https?://github\.com/([^/]+)/([^/]+)/pull/.*|\1/\2|p'
 }
 
+# CTL-483 Phase 1 dual-write: source the emit helper (best-effort — never
+# fails the script). When sourced successfully, every update_signal call
+# emits a worker.state_changed event so the broker can project the new state
+# to <signal>.projected for byte-for-byte verification before Phase 2 cutover.
+__EMIT_WSC="${SCRIPT_DIR}/lib/emit-worker-state-changed.sh"
+if [[ -r "$__EMIT_WSC" ]]; then
+  # shellcheck disable=SC1090
+  . "$__EMIT_WSC" 2>/dev/null || true
+fi
+
 update_signal() {
   local signal="$1"; shift
   local expr="$1"; shift
   jq "$@" "$expr" "$signal" > "${signal}.tmp" && mv "${signal}.tmp" "$signal"
+  if [[ "$DRY_RUN" -ne 1 ]] && command -v emit_worker_state_changed >/dev/null 2>&1; then
+    CATALYST_ORCHESTRATOR_ID="${ORCH_ID:-${CATALYST_ORCHESTRATOR_ID:-}}" \
+      emit_worker_state_changed "$signal" "orchestrate-auto-rebase" || true
+  fi
 }
 
 fetch_pr_view() {

--- a/plugins/dev/scripts/orchestrate-shadow-diff
+++ b/plugins/dev/scripts/orchestrate-shadow-diff
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# orchestrate-shadow-diff — verify CTL-483 Phase 1 dual-write invariant.
+#
+# Walks an orchestrator's workers/*.json files, diffs each against its
+# matching <name>.json.projected shadow file (stripped of the broker's
+# `_projected` audit metadata), and reports drift.
+#
+# Usage:
+#   orchestrate-shadow-diff [--json] <orchId-or-orch-dir>
+#
+# Exit codes:
+#   0 — all pairs match (or no shadow files yet — see --strict)
+#   1 — drift detected on at least one pair
+#   2 — no canonical signal files found
+#
+# By default missing shadow files are reported but do NOT fail (Phase 1
+# producers are being rolled out one at a time). Pass --strict to fail
+# when any canonical file lacks a shadow.
+
+set -uo pipefail
+
+JSON_OUT=0
+STRICT=0
+ARG=""
+
+usage() {
+  sed -n '2,18p' "$0"
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)   JSON_OUT=1; shift ;;
+    --strict) STRICT=1; shift ;;
+    -h|--help) usage 0 ;;
+    -*) echo "unknown flag: $1" >&2; usage ;;
+    *)  if [[ -z "$ARG" ]]; then ARG="$1"; shift; else echo "unexpected arg: $1" >&2; usage; fi ;;
+  esac
+done
+
+[[ -z "$ARG" ]] && { echo "ERROR: orchestrator id or directory required" >&2; usage; }
+
+if [[ -d "$ARG" ]]; then
+  ORCH_DIR="$ARG"
+else
+  RUNS_DIR="${CATALYST_RUNS_DIR:-${CATALYST_DIR:-$HOME/catalyst}/runs}"
+  ORCH_DIR="${RUNS_DIR}/${ARG}"
+fi
+WORKERS_DIR="${ORCH_DIR}/workers"
+
+[[ -d "$WORKERS_DIR" ]] || { echo "ERROR: no workers dir at $WORKERS_DIR" >&2; exit 2; }
+
+shopt -s nullglob
+CANONICALS=("$WORKERS_DIR"/*.json)
+# Filter out .projected files that match the glob
+FILTERED=()
+for f in "${CANONICALS[@]}"; do
+  [[ "$f" == *.projected ]] && continue
+  FILTERED+=("$f")
+done
+CANONICALS=("${FILTERED[@]}")
+
+if [[ "${#CANONICALS[@]}" -eq 0 ]]; then
+  echo "ERROR: no canonical worker signal files in $WORKERS_DIR" >&2
+  exit 2
+fi
+
+CHECKED=0
+MATCH=0
+DRIFT=0
+MISSING=0
+declare -a DRIFTS
+declare -a MISSINGS
+
+for canonical in "${CANONICALS[@]}"; do
+  ticket=$(basename "$canonical" .json)
+  shadow="${canonical}.projected"
+  CHECKED=$((CHECKED + 1))
+
+  if [[ ! -f "$shadow" ]]; then
+    MISSING=$((MISSING + 1))
+    MISSINGS+=("$ticket")
+    continue
+  fi
+
+  # Strip the broker's audit metadata before diffing
+  canon_norm=$(jq -S 'del(._projected)' "$canonical" 2>/dev/null)
+  shadow_norm=$(jq -S 'del(._projected)' "$shadow" 2>/dev/null)
+
+  if [[ "$canon_norm" == "$shadow_norm" ]]; then
+    MATCH=$((MATCH + 1))
+  else
+    DRIFT=$((DRIFT + 1))
+    DRIFTS+=("$ticket")
+  fi
+done
+
+if [[ "$JSON_OUT" -eq 1 ]]; then
+  jq -nc \
+    --argjson checked "$CHECKED" \
+    --argjson match "$MATCH" \
+    --argjson drift "$DRIFT" \
+    --argjson missing "$MISSING" \
+    --arg orchDir "$ORCH_DIR" \
+    --argjson drifts "$(printf '%s\n' "${DRIFTS[@]:-}" | jq -R . | jq -s .)" \
+    --argjson missings "$(printf '%s\n' "${MISSINGS[@]:-}" | jq -R . | jq -s .)" \
+    '{orchDir: $orchDir, checked: $checked, match: $match, drift: $drift, missing: $missing, driftTickets: ($drifts | map(select(. != ""))), missingTickets: ($missings | map(select(. != "")))}'
+else
+  echo "orchestrate-shadow-diff: $ORCH_DIR"
+  echo "  checked: $CHECKED"
+  echo "  match:   $MATCH"
+  echo "  drift:   $DRIFT"
+  echo "  missing: $MISSING (shadow file not yet emitted)"
+  if [[ "$DRIFT" -gt 0 ]]; then
+    echo "  drift tickets:"
+    for t in "${DRIFTS[@]:-}"; do
+      [[ -z "$t" ]] && continue
+      echo "    - $t"
+    done
+  fi
+  if [[ "$MISSING" -gt 0 ]] && [[ "$STRICT" -eq 1 ]]; then
+    echo "  missing tickets:"
+    for t in "${MISSINGS[@]:-}"; do
+      [[ -z "$t" ]] && continue
+      echo "    - $t"
+    done
+  fi
+fi
+
+if [[ "$DRIFT" -gt 0 ]]; then
+  exit 1
+fi
+if [[ "$STRICT" -eq 1 ]] && [[ "$MISSING" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/website/src/content/docs/observability/catalyst-broker.md
+++ b/website/src/content/docs/observability/catalyst-broker.md
@@ -530,6 +530,41 @@ catalyst-events wait-for \
   --timeout 0
 ```
 
+## Worker State Projection (Phase 1, CTL-483)
+
+The broker projects `worker.state_changed` events into `<orchDir>/workers/<TICKET>.json.projected`
+shadow files. During Phase 1 of the ADR-018 migration, writers continue to write the canonical
+`<TICKET>.json` directly AND emit a `worker.state_changed` event carrying the full new state.
+The broker's `handleWorkerStateChanged` handler resolves the path via `CATALYST_RUNS_DIR` and
+writes the state byte-for-byte (with a small `_projected` audit field appended).
+
+To verify byte-for-byte agreement between canonical and shadow files for one orchestrator:
+
+```bash
+orchestrate-shadow-diff <orchId>            # human-readable summary
+orchestrate-shadow-diff --json <orchId>     # machine-readable
+orchestrate-shadow-diff --strict <orchId>   # fail when shadow files are missing
+```
+
+Exit code 0 means all pairs match (or no shadow files yet — see `--strict`). Exit code 1 means
+drift detected on at least one pair. Exit code 2 means no canonical signal files found at all.
+
+Phase 1 producers (writers that emit the event):
+
+| Writer | Status |
+|---|---|
+| `orchestrate-auto-rebase` | ✅ shipped (PoC) |
+| `orchestrate-auto-fixup` | follow-up ticket |
+| `orchestrate-dispatch-next` | follow-up ticket |
+| `orchestrate-followup` | follow-up ticket |
+| `orchestrate-healthcheck` | follow-up ticket |
+| `orchestrate-revive` | follow-up ticket |
+| oneshot skill | follow-up ticket |
+
+Once all seven writers are dual-writing and `orchestrate-shadow-diff` shows zero drift across a
+full orchestration cycle, Phase 2 removes the direct writes and the broker becomes sole writer
+at the canonical path. See ADR-018 for the full migration plan.
+
 ## Related
 
 - [Event Architecture](./events/) — the global event log and `catalyst-events` CLI that


### PR DESCRIPTION
## Summary

Phase 1 of the ADR-018 migration to move `workers/<TICKET>.json` from "7 scripts write directly with no inter-process lock" to "scripts emit `worker.state_changed` command events; broker projects to disk".

- `workers/*.json` signal files are written by **7 different code paths** today, with no cross-process locking. Cross-script races (e.g. healthcheck marking a worker `failed` while it's simultaneously writing `pr-created`) are undetected and silent.
- The broker already has the relevant projection precedent: `broker-interests.json` is fully event-sourced from `filter.register` / `filter.deregister`. ADR-008 set the dual-write migration pattern; ADR-011 established the filesystem-first invariant.
- This PR ships **Phase 1 (additive dual-write)** for one writer as a PoC. The remaining six writers migrate under follow-up tickets. Phase 2 (cutover, remove direct writes) and Phase 3 (SQLite mirror per ADR-011) are out of scope here.

(Note: this PR was originally written as ADR-017; a sibling worker in the same wave landed an unrelated ADR-017 first, so this one was renumbered to ADR-018 during conflict resolution. No semantic change.)

## What's in the PR

- **ADR-018** (`docs/adrs.md`) — full design + three-phase migration plan, supersedes ADR-006 for the `workers/*.json` portion only.
- **`worker.state_changed`** registered in `plugins/dev/references/event-name-allowlist.md` (new `worker_lifecycle` section) and `plugins/dev/references/event-schema.md` (worked example + producer table row).
- **Broker handler** `handleWorkerStateChanged` in `plugins/dev/scripts/broker/index.mjs`, with helpers `getProjectedWorkerStatePath` + `writeProjectedWorkerState`. Path resolution honors `CATALYST_RUNS_DIR`. Writes a shadow file at `<canonical>.json.projected` with a `_projected` audit field recording `{writer, ts}`.
- **12-test unit suite** at `plugins/dev/scripts/broker/worker-state.test.mjs` — canonical + legacy envelope shapes, missing-field drops, atomic write, path isolation, writer fallback.
- **Writer-side helper** `plugins/dev/scripts/lib/emit-worker-state-changed.sh` — sourceable bash helper, best-effort emission (silent on failure so the direct write remains authoritative).
- **Dual-write PoC** in `orchestrate-auto-rebase` — wired into the existing `update_signal` helper function (one place, 4 call sites all routed through it).
- **Verification CLI** `orchestrate-shadow-diff` — walks an orchestrator's workers and diffs canonical vs shadow files (stripped of `_projected` metadata). Exit 1 on drift, exit 2 if no canonical files. `--json` and `--strict` modes.
- **Docs updates** in `docs/architecture.md` (1-paragraph note + ADR link) and `website/src/content/docs/observability/catalyst-broker.md` (new "Worker State Projection" section).

## Migration table

| Writer | Phase 1 status |
|---|---|
| `orchestrate-auto-rebase` | ✅ shipped (this PR) |
| `orchestrate-auto-fixup` | follow-up |
| `orchestrate-dispatch-next` | follow-up |
| `orchestrate-followup` | follow-up |
| `orchestrate-healthcheck` | follow-up |
| `orchestrate-revive` | follow-up |
| oneshot skill | follow-up |

## Test plan

- [x] `bun test plugins/dev/scripts/broker/` — 239 pass, 0 fail (12 new + 227 regression)
- [x] `bash -n` syntax check on all 3 shell files
- [x] End-to-end PoC: synthetic writer mutates signal → emits event → broker projects → `orchestrate-shadow-diff` reports `match: 1, drift: 0`
- [x] `orchestrate-auto-rebase --dry-run` smoke against live orchestrator (no behavioral change)
- [x] Envelope schema sanity check (`event.name`, severity, resource, attributes, body.payload.state shape)

Refs: [CTL-483](https://linear.app/coalesce-labs/issue/CTL-483)