### PR TITLE
fix(meta): release-please scheduled-merge UNKNOWN race + health-check shared-PR detection (CTL-486)

### DIFF
--- a/.github/workflows/release-please-scheduled-merge.yml
+++ b/.github/workflows/release-please-scheduled-merge.yml
@@ -33,11 +33,31 @@ jobs:
 
           echo "Found open release PR #$PR_NUMBER"
 
-          PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-            --json state,mergeStateStatus,mergeable)
-          STATE=$(echo "$PR_STATE" | jq -r '.state')
-          MERGE_STATE=$(echo "$PR_STATE" | jq -r '.mergeStateStatus')
-          MERGEABLE=$(echo "$PR_STATE" | jq -r '.mergeable')
+          # GitHub returns mergeStateStatus=UNKNOWN transiently while it computes
+          # mergeability after a recent push. Poll until it resolves (or give up
+          # after ~3 minutes — well past GitHub's typical sub-minute computation).
+          MAX_ATTEMPTS=18
+          ATTEMPT=0
+          while : ; do
+            PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+              --json state,mergeStateStatus,mergeable)
+            STATE=$(echo "$PR_STATE" | jq -r '.state')
+            MERGE_STATE=$(echo "$PR_STATE" | jq -r '.mergeStateStatus')
+            MERGEABLE=$(echo "$PR_STATE" | jq -r '.mergeable')
+
+            if [[ "$MERGE_STATE" != "UNKNOWN" ]]; then
+              break
+            fi
+
+            ATTEMPT=$((ATTEMPT + 1))
+            if [[ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]]; then
+              echo "::warning::PR #$PR_NUMBER mergeStateStatus stayed UNKNOWN after ${MAX_ATTEMPTS} probes (~3 min)"
+              break
+            fi
+
+            echo "PR #$PR_NUMBER mergeStateStatus=UNKNOWN (attempt $ATTEMPT/$MAX_ATTEMPTS), waiting 10s..."
+            sleep 10
+          done
 
           echo "PR #$PR_NUMBER state=$STATE mergeStateStatus=$MERGE_STATE mergeable=$MERGEABLE"
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -132,6 +132,26 @@ Tags follow `<component>-v<version>` format:
 5. To verify without waiting for the cron, run
    `gh workflow run release-please-scheduled-merge.yml`
 
+## Reading the workflow logs
+
+The `release-please.yml` workflow walks every configured plugin in turn. For each plugin you'll see
+either:
+
+- `❯ component: catalyst-X` followed by no `skipping` line — that plugin contributed commits and
+  will appear in the release PR.
+- `✔ No user facing commits found since <sha> - skipping` — **per-plugin**, not global. Means
+  that specific plugin had no `feat:` / `fix:` / `perf:` commits touching its `plugins/X/` paths
+  since its last tag, so release-please correctly skips it. The `<sha>` is that plugin's
+  last-release SHA; two plugins bootstrapped together can legitimately show the same SHA.
+
+The action ends with `✔ PR https://github.com/.../pull/N` (created or remained the same) — that PR
+is the authoritative summary of what's pending. `gh pr list --label "autorelease: pending"` lists
+it directly.
+
+If you suspect releases are stuck, run `bash scripts/check-release-health.sh` (also runs daily via
+`.github/workflows/release-health.yml`). It reads the same `autorelease: pending` label and
+reports `UNHEALTHY` only when releasable commits exist with no open release PR.
+
 ## How Commit Routing Works
 
 Release-please routes commits to plugins by **file paths changed**, not by commit message scope:

--- a/scripts/check-release-health.sh
+++ b/scripts/check-release-health.sh
@@ -52,55 +52,50 @@ if [[ ! -f "$CONFIG" ]]; then
   exit 1
 fi
 
-OPEN_RELEASE_PRS=$(gh pr list --label "autorelease: pending" --state open --json headRefName --jq '.[].headRefName' 2>/dev/null || true)
+OPEN_RELEASE_PRS=$(gh pr list --label "autorelease: pending" --state open --json number,headRefName --jq '.[]' 2>/dev/null || true)
 
-STRANDED=()
+# `autorelease: pending` is release-please's canonical signal — when this label is
+# on an open PR, release-please considers all pending commits covered. This works
+# for both `separate-pull-requests: true` (per-component branches) and `false`
+# (a single shared branch like `release-please--branches--main`).
+if [[ -n "$OPEN_RELEASE_PRS" ]]; then
+  PR_NUMS=$(echo "$OPEN_RELEASE_PRS" | jq -r '.number' | paste -sd ',' -)
+  pass "Open release PR(s) present (#${PR_NUMS}) — release-please is tracking pending commits"
+else
+  # No release PR open — check whether any package has releasable commits anyway.
+  # If yes, release-please missed them and the workflow is stuck.
+  STRANDED=()
 
-for pkg in $(jq -r '.packages | keys[]' "$CONFIG"); do
-  component=$(jq -r --arg pkg "$pkg" '.packages[$pkg].component // empty' "$CONFIG")
-  if [[ -z "$component" ]]; then
-    continue
-  fi
+  for pkg in $(jq -r '.packages | keys[]' "$CONFIG"); do
+    component=$(jq -r --arg pkg "$pkg" '.packages[$pkg].component // empty' "$CONFIG")
+    if [[ -z "$component" ]]; then
+      continue
+    fi
 
-  # Find latest release tag for this component
-  latest_tag=$(git tag --list "${component}-v*" --sort=-version:refname | head -1)
+    latest_tag=$(git tag --list "${component}-v*" --sort=-version:refname | head -1)
+    if [[ -z "$latest_tag" ]]; then
+      continue
+    fi
 
-  if [[ -z "$latest_tag" ]]; then
-    # No tags yet — skip, bootstrap hasn't completed
-    continue
-  fi
+    scope="${component#catalyst-}"
 
-  # Extract the scope from the component name (e.g. catalyst-dev -> dev)
-  scope="${component#catalyst-}"
+    releasable_commits=$(git log "${latest_tag}..origin/main" --oneline --format='%s' -- "$pkg" 2>/dev/null \
+      | grep -cE "^(feat|fix|perf)(\($scope\))?!?:" || true)
 
-  # Check for releasable conventional commits since the last tag
-  releasable_commits=$(git log "${latest_tag}..origin/main" --oneline --format='%s' -- "$pkg" 2>/dev/null \
-    | grep -cE "^(feat|fix|perf)(\($scope\))?!?:" || true)
-
-  if [[ "$releasable_commits" -gt 0 ]]; then
-    # Check if there's an open release PR for this component
-    has_pr=false
-    for pr_branch in $OPEN_RELEASE_PRS; do
-      if [[ "$pr_branch" == *"$component"* ]]; then
-        has_pr=true
-        break
-      fi
-    done
-
-    if [[ "$has_pr" == "false" ]]; then
+    if [[ "$releasable_commits" -gt 0 ]]; then
       STRANDED+=("$component: $releasable_commits releasable commit(s) since $latest_tag with no open release PR")
     fi
-  fi
-done
-
-if [[ ${#STRANDED[@]} -gt 0 ]]; then
-  fail "Releasable commits on main with no open release PR"
-  for msg in "${STRANDED[@]}"; do
-    echo "  - $msg"
   done
-  echo "  This usually means the release-please workflow is failing."
-else
-  pass "No stranded releasable commits (all packages have release PRs or are up to date)"
+
+  if [[ ${#STRANDED[@]} -gt 0 ]]; then
+    fail "Releasable commits on main with no open release PR"
+    for msg in "${STRANDED[@]}"; do
+      echo "  - $msg"
+    done
+    echo "  This usually means the release-please workflow is failing."
+  else
+    pass "No stranded releasable commits (all packages are up to date)"
+  fi
 fi
 
 # --- Check 3: plugin.json versions match manifest ---


### PR DESCRIPTION
## Why

The daily `release-please-scheduled-merge` workflow has **failed three days running** (May 15, 16, 17) because it treats GitHub's transient `mergeStateStatus=UNKNOWN` as a permanent failure. UNKNOWN appears briefly after a PR is updated while GitHub computes mergeability; the workflow probed once, saw UNKNOWN, and exited 1. Result: no daily release cut since v9.3.0, marketplace cache stuck.

A second bug compounded the confusion: `scripts/check-release-health.sh` couldn't see the shared release PR because `separate-pull-requests: false` puts everything on a single branch (`release-please--branches--main`) that doesn't contain any component name. So substring-on-branch detection always reported "26 releasable commits with no open release PR" — false alarm that masked the real (scheduled-merge) failure and led to CTL-486 being filed with the wrong root cause.

The ticket's premise (manifest "stuck at 35f6f8c") turned out to be a misread of release-please's per-package "skipping" log line. Full diagnosis in [thoughts/shared/research/2026-05-17-CTL-486-release-please-stuck.md](thoughts/shared/research/2026-05-17-CTL-486-release-please-stuck.md).

## What

| File | Change |
|---|---|
| `.github/workflows/release-please-scheduled-merge.yml` | Poll `mergeStateStatus` while UNKNOWN for up to ~3 minutes (18 × 10s) before falling through to the existing error path. Real UNKNOWNs still escalate. |
| `scripts/check-release-health.sh` | Short-circuit to PASS when any `autorelease: pending` PR is open. That label is release-please's canonical "pending commits are tracked" signal and works for both shared-PR and per-component layouts. The per-package stranded-commits walk still runs when no PR is open. |
| `docs/releases.md` | New "Reading the workflow logs" section explaining the per-plugin "No user facing commits found since X — skipping" message and how to verify pending releases via `gh pr list --label "autorelease: pending"`. |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow file → OK
- [x] `bash -n scripts/check-release-health.sh` → OK
- [x] `bash scripts/check-release-health.sh` against current main → was `UNHEALTHY (1 issue)`, now `HEALTHY`
- [x] `bash scripts/validate-release-config.sh` → ALL CHECKS PASSED
- [ ] After merge: wait for next scheduled cron at 05:00 UTC, confirm it merges PR #756 instead of failing on UNKNOWN. (Or trigger manually via `gh workflow run release-please-scheduled-merge.yml`.)

## Non-goals (explicit)

- **Not** forcing v10.0.0 for catalyst-dev. v9.4.0 is the correct conventional-commits result; the v10.0.0 expectation in the ticket appears to be downstream of the misread logs.
- **Not** rescuing CTL-435 from the release notes. The conventional-commits parser dropped it due to `useRef(Date.now())` in the body — upstream library limitation, not actionable here.
- **Not** touching the marketplace cache. Resolves itself once PR #756 merges.

Closes CTL-486