### PR TITLE
fix(dev): wire orchestrate-roll-usage into monitor loop + enable phase-agents dispatch (CTL-487)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -48,6 +48,9 @@
         ]
       }
     },
+    "orchestration": {
+      "dispatchMode": "phase-agents"
+    },
     "feedback": {
       "autoFile": true,
       "githubRepo": "coalesce-labs/catalyst",

--- a/plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Shell tests for update-dashboard.sh --roll-usage (CTL-487).
+#
+# Verifies the audit-trace contract from CTL-487 DoD item 4: the orchestrator
+# monitor loop invokes orchestrate-roll-usage.sh per worker per wake-up. We
+# enforce this mechanically by wiring update-dashboard.sh (which IS called
+# every wake-up) to drive the rollup via --roll-usage. This test asserts:
+#
+#   1. update-dashboard.sh --roll-usage populates signal.cost for a worker
+#      whose stream has a result event and whose signal.cost is null.
+#   2. The .roll-usage.log audit file records "wrote-cost" for that ticket.
+#   3. A second invocation is a no-op (idempotency) — .roll-usage.log gains
+#      an "already-rolled" entry and signal.cost is unchanged.
+#   4. Without --roll-usage the flag's behavior is opt-in: signal.cost stays
+#      null. This proves the old SKILL.md-only contract was indeed dead code.
+#
+# Run: bash plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/scripts/update-dashboard.sh"
+STATE_SCRIPT="${REPO_ROOT}/plugins/dev/scripts/catalyst-state.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Isolate state — tests must not touch the user's real ~/catalyst.
+export CATALYST_DIR="${SCRATCH}/catalyst"
+export CATALYST_STATE_FILE="${CATALYST_DIR}/state.json"
+mkdir -p "$CATALYST_DIR"
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+build_stream_with_result() {
+  local out="$1" cost="$2" itok="$3" otok="$4" turns="$5" dur="$6"
+  cat > "$out" <<EOF
+{"type":"system","subtype":"init","session_id":"test"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}
+{"type":"result","subtype":"success","usage":{"input_tokens":${itok},"output_tokens":${otok},"cache_read_input_tokens":10,"cache_creation_input_tokens":20},"total_cost_usd":${cost},"num_turns":${turns},"duration_ms":${dur},"duration_api_ms":$((dur / 2)),"modelUsage":{"claude-opus-4-7":{"costUSD":${cost}}}}
+EOF
+}
+
+build_signal() {
+  # Note: no .cost field — that is what the rollup is supposed to populate.
+  local out="$1" ticket="$2" wave="${3:-1}"
+  cat > "$out" <<EOF
+{
+  "ticket": "${ticket}",
+  "orchestrator": "test-orch",
+  "workerName": "test-orch-${ticket}",
+  "wave": ${wave},
+  "status": "done",
+  "phase": 5,
+  "startedAt": "2026-05-17T12:00:00Z",
+  "updatedAt": "2026-05-17T12:30:00Z",
+  "phaseTimestamps": { "researching": "2026-05-17T12:00:00Z" },
+  "pr": { "number": 100, "url": "https://github.com/test/test/pull/100" },
+  "definitionOfDone": {}
+}
+EOF
+}
+
+setup_orch() {
+  local orch_id="$1"
+  local orch_dir="${SCRATCH}/runs/${orch_id}"
+  mkdir -p "${orch_dir}/workers/output"
+  # Per-orch state.json the dashboard renders from.
+  cat > "${orch_dir}/state.json" <<EOF
+{
+  "orchestrator": "${orch_id}",
+  "startedAt": "2026-05-17T12:00:00Z",
+  "baseBranch": "main",
+  "totalTickets": 1,
+  "totalWaves": 1,
+  "currentWave": 1,
+  "maxParallel": 1,
+  "waves": [{"wave":1,"status":"running","tickets":["TEST-1"]}],
+  "workers": {}
+}
+EOF
+  # Global state — register the orch so projectKey lookup works.
+  rm -f "$CATALYST_STATE_FILE"
+  "$STATE_SCRIPT" init >/dev/null
+  "$STATE_SCRIPT" register "$orch_id" "$(jq -nc --arg id "$orch_id" \
+    '{id: $id, projectKey: "test-proj", status: "active",
+      startedAt: "2026-05-17T12:00:00Z",
+      progress: {totalTickets: 1, completedTickets: 0, failedTickets: 0, inProgressTickets: 1, currentWave: 1, totalWaves: 1},
+      usage: {inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, costUSD: 0, numTurns: 0, durationMs: 0, durationApiMs: 0, model: null},
+      workers: {}, attention: []}')" >/dev/null
+  echo "$orch_dir"
+}
+
+# ─── Test 1: dashboard helper exists and accepts --roll-usage ─────────────────
+run "helper script exists" bash -c "[ -f '$HELPER' ]"
+run "helper script is executable" bash -c "[ -x '$HELPER' ]"
+run "helper accepts --roll-usage in usage block" \
+  bash -c "'$HELPER' --help 2>&1 | grep -q -- '--roll-usage' || '$HELPER' -h 2>&1 | grep -q -- '--roll-usage'"
+
+# ─── Test 2: --roll-usage populates signal.cost for a worker with a result ────
+ORCH_DIR=$(setup_orch "orch-cd1")
+build_stream_with_result "${ORCH_DIR}/workers/output/TEST-1-stream.jsonl" \
+  "1.23" "100" "50" "3" "4000"
+build_signal "${ORCH_DIR}/workers/TEST-1.json" "TEST-1"
+
+# Sanity: signal starts without a .cost field
+run "before run: signal.cost is null" \
+  bash -c "[ \"\$(jq -r '.cost // \"null\"' '${ORCH_DIR}/workers/TEST-1.json')\" = 'null' ]"
+
+# Run with --roll-usage. --stdout suppresses the DASHBOARD.md write so we
+# isolate the rollup behaviour.
+"$HELPER" --orch "orch-cd1" --orch-dir "$ORCH_DIR" --roll-usage --stdout >/dev/null
+
+run "after --roll-usage: signal.cost.costUSD == 1.23" \
+  bash -c "[ \"\$(jq -r '.cost.costUSD' '${ORCH_DIR}/workers/TEST-1.json')\" = '1.23' ]"
+run "after --roll-usage: signal.cost.inputTokens == 100" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/TEST-1.json')\" = '100' ]"
+run "after --roll-usage: signal.cost.outputTokens == 50" \
+  bash -c "[ \"\$(jq -r '.cost.outputTokens' '${ORCH_DIR}/workers/TEST-1.json')\" = '50' ]"
+
+# ─── Test 3: .roll-usage.log captures the action codes (audit trace) ──────────
+run ".roll-usage.log exists" \
+  bash -c "[ -f '${ORCH_DIR}/.roll-usage.log' ]"
+run ".roll-usage.log records wrote-cost for TEST-1" \
+  bash -c "grep -q 'roll-usage\\[ticket=TEST-1\\]: wrote-cost' '${ORCH_DIR}/.roll-usage.log'"
+
+# ─── Test 4: idempotency — second invocation logs already-rolled ──────────────
+"$HELPER" --orch "orch-cd1" --orch-dir "$ORCH_DIR" --roll-usage --stdout >/dev/null
+
+run "second invocation: signal.cost.costUSD unchanged (still 1.23)" \
+  bash -c "[ \"\$(jq -r '.cost.costUSD' '${ORCH_DIR}/workers/TEST-1.json')\" = '1.23' ]"
+run "second invocation: .roll-usage.log records already-rolled" \
+  bash -c "grep -q 'roll-usage\\[ticket=TEST-1\\]: already-rolled' '${ORCH_DIR}/.roll-usage.log'"
+
+# ─── Test 5: orchestrator-level state.usage rolled correctly ──────────────────
+run "orch.usage.costUSD == 1.23 in global state" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-cd1\"].usage.costUSD' '$CATALYST_STATE_FILE')\" = '1.23' ]"
+run "orch.usage.inputTokens == 100 in global state" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-cd1\"].usage.inputTokens' '$CATALYST_STATE_FILE')\" = '100' ]"
+
+# ─── Test 6: opt-in flag — without --roll-usage, signal.cost stays null ───────
+# Proves that the rollup is wired through the flag and not always-on. Also
+# documents the contrast with the pre-CTL-487 SKILL.md-only contract: without
+# the flag, no rollup happens.
+ORCH_DIR=$(setup_orch "orch-cd2")
+build_stream_with_result "${ORCH_DIR}/workers/output/TEST-1-stream.jsonl" \
+  "0.5" "200" "100" "2" "2000"
+build_signal "${ORCH_DIR}/workers/TEST-1.json" "TEST-1"
+
+"$HELPER" --orch "orch-cd2" --orch-dir "$ORCH_DIR" --stdout >/dev/null
+
+run "without --roll-usage: signal.cost stays null" \
+  bash -c "[ \"\$(jq -r '.cost // \"null\"' '${ORCH_DIR}/workers/TEST-1.json')\" = 'null' ]"
+run "without --roll-usage: no .roll-usage.log written" \
+  bash -c "[ ! -f '${ORCH_DIR}/.roll-usage.log' ]"
+
+# ─── Test 7: multi-worker safety-net sweep ────────────────────────────────────
+# Build 3 workers — one with cost already set (already-rolled), one with a
+# result event but null cost (needs rollup), one with no result event yet
+# (still running). Single --roll-usage call must handle all three correctly.
+ORCH_DIR=$(setup_orch "orch-cd3")
+# Worker A — already rolled (signal.cost already populated)
+build_stream_with_result "${ORCH_DIR}/workers/output/A-stream.jsonl" \
+  "0.10" "10" "5" "1" "100"
+cat > "${ORCH_DIR}/workers/A.json" <<EOF
+{
+  "ticket": "A", "wave": 1, "status": "done", "phase": 5,
+  "startedAt": "2026-05-17T12:00:00Z", "updatedAt": "2026-05-17T12:30:00Z",
+  "cost": { "costUSD": 0.10, "inputTokens": 10, "outputTokens": 5,
+    "cacheReadTokens": 0, "cacheCreationTokens": 0, "numTurns": 1,
+    "durationMs": 100, "durationApiMs": 50, "model": null }
+}
+EOF
+# Worker B — needs rollup
+build_stream_with_result "${ORCH_DIR}/workers/output/B-stream.jsonl" \
+  "0.20" "20" "10" "2" "200"
+build_signal "${ORCH_DIR}/workers/B.json" "B"
+# Worker C — still running (no result event yet)
+cat > "${ORCH_DIR}/workers/output/C-stream.jsonl" <<EOF
+{"type":"system","subtype":"init","session_id":"running"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"still working"}]}}
+EOF
+build_signal "${ORCH_DIR}/workers/C.json" "C"
+
+"$HELPER" --orch "orch-cd3" --orch-dir "$ORCH_DIR" --roll-usage --stdout >/dev/null
+
+run "A: signal.cost.costUSD unchanged (already-rolled)" \
+  bash -c "[ \"\$(jq -r '.cost.costUSD' '${ORCH_DIR}/workers/A.json')\" = '0.10' ]"
+run "B: signal.cost.costUSD populated (needs-rollup → wrote-cost)" \
+  bash -c "[ \"\$(jq -r '.cost.costUSD' '${ORCH_DIR}/workers/B.json')\" = '0.20' ]"
+run "C: signal.cost stays null (no result event yet)" \
+  bash -c "[ \"\$(jq -r '.cost // \"null\"' '${ORCH_DIR}/workers/C.json')\" = 'null' ]"
+run ".roll-usage.log records A already-rolled" \
+  bash -c "grep -q 'roll-usage\\[ticket=A\\]: already-rolled' '${ORCH_DIR}/.roll-usage.log'"
+run ".roll-usage.log records B wrote-cost" \
+  bash -c "grep -q 'roll-usage\\[ticket=B\\]: wrote-cost' '${ORCH_DIR}/.roll-usage.log'"
+run ".roll-usage.log records C no-result-yet" \
+  bash -c "grep -q 'roll-usage\\[ticket=C\\]: no-result-yet' '${ORCH_DIR}/.roll-usage.log'"
+
+# ─── Test 8: --roll-usage still renders the dashboard (smoke check) ───────────
+# The flag is additive — dashboard rendering must still happen alongside the
+# rollup. Use --stdout to avoid writing files; just confirm we get a header.
+ORCH_DIR=$(setup_orch "orch-cd4")
+build_stream_with_result "${ORCH_DIR}/workers/output/TEST-1-stream.jsonl" \
+  "0.7" "70" "30" "2" "1500"
+build_signal "${ORCH_DIR}/workers/TEST-1.json" "TEST-1"
+
+OUT=$("$HELPER" --orch "orch-cd4" --orch-dir "$ORCH_DIR" --roll-usage --stdout 2>/dev/null)
+run "--roll-usage still renders dashboard header" \
+  bash -c "grep -q '# Orchestration Dashboard' <<<\"$OUT\""
+run "--roll-usage still rendered after the rollup populated signal.cost" \
+  bash -c "[ \"\$(jq -r '.cost.costUSD' '${ORCH_DIR}/workers/TEST-1.json')\" = '0.7' ]"
+
+# ─── Test 9: missing orchestrate-roll-usage.sh is non-fatal ───────────────────
+# If the rollup script ever moves or is somehow unavailable, the dashboard
+# render must still succeed. The flag should degrade gracefully.
+ORCH_DIR=$(setup_orch "orch-cd5")
+build_signal "${ORCH_DIR}/workers/TEST-1.json" "TEST-1"
+# Don't build a stream — gives the inner helper no work, but exercises the
+# outer loop's per-worker iteration. The dashboard render must still complete.
+
+run "--roll-usage with no stream files: helper still exits 0" \
+  "$HELPER" --orch "orch-cd5" --orch-dir "$ORCH_DIR" --roll-usage --stdout
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/update-dashboard.sh
+++ b/plugins/dev/scripts/update-dashboard.sh
@@ -31,7 +31,7 @@ EVENTS_DIR="${CATALYST_DIR}/events"
 
 usage() {
   cat >&2 <<'EOF'
-usage: update-dashboard.sh --orch <id> [--orch-dir <dir>] [--stdout]
+usage: update-dashboard.sh --orch <id> [--orch-dir <dir>] [--stdout] [--roll-usage]
 
 required:
   --orch <id>         orchestrator id
@@ -39,17 +39,23 @@ required:
 optional:
   --orch-dir <dir>    override default ~/catalyst/runs/<orch>/
   --stdout            write to stdout instead of DASHBOARD.md
+  --roll-usage        before rendering, invoke orchestrate-roll-usage.sh -v
+                      for every signal file in ${ORCH_DIR}/workers/. Bounded
+                      and idempotent — fast no-op when signal.cost is already
+                      populated. Stderr appends to ${ORCH_DIR}/.roll-usage.log
+                      so silent skips remain auditable (CTL-487).
 EOF
   exit 2
 }
 
-ORCH_ID="" ORCH_DIR="" STDOUT_MODE=0
+ORCH_ID="" ORCH_DIR="" STDOUT_MODE=0 ROLL_USAGE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --orch)     ORCH_ID="${2:-}"; shift 2 ;;
-    --orch-dir) ORCH_DIR="${2:-}"; shift 2 ;;
-    --stdout)   STDOUT_MODE=1; shift ;;
-    -h|--help)  usage ;;
+    --orch)        ORCH_ID="${2:-}"; shift 2 ;;
+    --orch-dir)    ORCH_DIR="${2:-}"; shift 2 ;;
+    --stdout)      STDOUT_MODE=1; shift ;;
+    --roll-usage)  ROLL_USAGE=1; shift ;;
+    -h|--help)     usage ;;
     *) echo "unknown arg: $1" >&2; usage ;;
   esac
 done
@@ -65,6 +71,29 @@ DASHBOARD_FILE="${ORCH_DIR}/DASHBOARD.md"
 if [ ! -f "$STATE_FILE" ]; then
   echo "warn: state.json not found at $STATE_FILE" >&2
   exit 0
+fi
+
+# ─── Roll-usage sweep (CTL-487) ───────────────────────────────────────────────
+# The monitor loop's contract (orchestrate/SKILL.md "Worker usage / cost is
+# rolled in by the monitor pass") requires orchestrate-roll-usage.sh to fire
+# per worker per wake-up. Hosting that loop here — in the script that's
+# already called every wake-up — guarantees the contract instead of relying
+# on the SKILL-reading agent to transcribe a separate bash block. Per-worker
+# call is bounded: gated on signal.cost == null so already-rolled workers
+# return immediately. Runs before the render so the dashboard sees fresh
+# .cost values on the same pass that populates them.
+if [ "$ROLL_USAGE" = "1" ] && [ -d "$WORKERS_DIR" ]; then
+  ROLL_SCRIPT="${SCRIPT_DIR}/orchestrate-roll-usage.sh"
+  if [ -x "$ROLL_SCRIPT" ]; then
+    ROLL_LOG="${ORCH_DIR}/.roll-usage.log"
+    for sig in "$WORKERS_DIR"/*.json; do
+      [ -f "$sig" ] || continue
+      tkt=$(jq -r '.ticket // empty' "$sig" 2>/dev/null || true)
+      [ -n "$tkt" ] || continue
+      "$ROLL_SCRIPT" --orch "$ORCH_ID" --ticket "$tkt" --orch-dir "$ORCH_DIR" -v \
+        >/dev/null 2>>"$ROLL_LOG" || true
+    done
+  fi
 fi
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -350,9 +350,15 @@ table + waves outline rather than a template skeleton:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/update-dashboard.sh" \
-  --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" \
+  --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" --roll-usage \
   >/dev/null 2>>"${ORCH_DIR}/.update-dashboard.log" || true
 ```
+
+`--roll-usage` is the wire that fulfils the "Worker usage / cost is rolled in by the monitor pass"
+contract below (CTL-487): the dashboard helper iterates `${ORCH_DIR}/workers/*.json` and invokes
+`orchestrate-roll-usage.sh -v` per worker before rendering, with stderr captured to
+`${ORCH_DIR}/.roll-usage.log`. The per-worker call is bounded — already-rolled workers short-circuit
+on `signal.cost != null` and cost a single `jq` read.
 
 Create the orchestrator's status directory:
 
@@ -643,17 +649,22 @@ worker activity. Key event types:
 | `{"type":"system","subtype":"api_retry"}`                                                                         | Worker hit rate limit / error; shows attempt and delay          |
 | `{"type":"result"}`                                                                                               | Worker finished; contains final answer and usage stats          |
 
-**Worker usage / cost is rolled in by the monitor pass (CTL-115).** The dispatch shell backgrounds
-workers with `&` and never `wait`s on them, so usage/cost extraction cannot happen here. Phase 4
-invokes `plugins/dev/scripts/orchestrate-roll-usage.sh` once per worker per wake-up to parse the
-final `result` event from the worker's stream file and:
+**Worker usage / cost is rolled in by the monitor pass (CTL-115, wired through `update-dashboard.sh
+--roll-usage` since CTL-487).** The dispatch shell backgrounds workers with `&` and never `wait`s
+on them, so usage/cost extraction cannot happen here. Phase 4's `update-dashboard.sh` call passes
+`--roll-usage`, which iterates `${ORCH_DIR}/workers/*.json` and invokes
+`plugins/dev/scripts/orchestrate-roll-usage.sh -v` per worker before rendering. The helper parses
+the final `result` event from the worker's stream file and:
 
 1. Mirror cost into the worker's signal file (`.cost = USAGE`) — the dashboard reads signal files
    (not global state) for per-worker cost columns.
 2. Write `state.workers[ticket].usage`.
 3. Roll the delta into `state.usage` for the orchestrator-level aggregate.
 
-The helper is idempotent (gated on `signal.cost == null`) and safe to call every cycle.
+The helper is idempotent (gated on `signal.cost == null`) and safe to call every cycle. Because
+every dashboard render now sweeps every worker, `update-dashboard.sh --roll-usage` doubles as the
+periodic safety net for any worker whose stream contains a `result` event but whose `signal.cost`
+is still null. Audit trail lands at `${ORCH_DIR}/.roll-usage.log`.
 
 **Emit dispatch event and update global state** after each worker dispatch:
 
@@ -1218,24 +1229,16 @@ for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
     ".status = \"${W_STATUS}\" | .phase = ${W_PHASE} | .branch = \"${W_BRANCH}\" | .pr = ${W_PR}"
 done
 
-# Roll worker usage/cost into orch.usage (CTL-115, CTL-233). Idempotent: the
-# helper no-ops when signal.cost is already populated, so calling it every
-# cycle costs only a `jq` read per worker until the worker's stream first
-# contains a `result` event. The `-v` flag plus stderr-to-log redirect makes
-# silent skips auditable — tail `${ORCH_DIR}/.roll-usage.log` to see why a
-# worker's cost is still null.
-for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
-  TICKET=$(jq -r '.ticket' "$WORKER_SIGNAL")
-  "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-roll-usage.sh" \
-    --orch "${ORCH_NAME}" --ticket "${TICKET}" --orch-dir "${ORCH_DIR}" -v \
-    >/dev/null 2>>"${ORCH_DIR}/.roll-usage.log" || true
-done
-
 # Re-render DASHBOARD.md so the file artifact reflects current state (CTL-230).
-# Idempotent — same inputs produce a byte-identical file. The orch-monitor daemon
-# file-watches DASHBOARD.md and forwards changes to UI clients via SSE.
+# `--roll-usage` first iterates ${ORCH_DIR}/workers/*.json and invokes
+# orchestrate-roll-usage.sh -v per worker (CTL-115, CTL-233, CTL-487) — bounded
+# and idempotent (no-op when signal.cost is already populated) and writes the
+# audit trail to ${ORCH_DIR}/.roll-usage.log. Then renders the dashboard so the
+# refreshed signal.cost values appear in the same pass. Same inputs produce a
+# byte-identical file. The orch-monitor daemon file-watches DASHBOARD.md and
+# forwards changes to UI clients via SSE.
 "${CLAUDE_PLUGIN_ROOT}/scripts/update-dashboard.sh" \
-  --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" \
+  --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" --roll-usage \
   >/dev/null 2>>"${ORCH_DIR}/.update-dashboard.log" || true
 ```
 
@@ -2063,7 +2066,7 @@ When all waves are complete:
 
    ```bash
    "${CLAUDE_PLUGIN_ROOT}/scripts/update-dashboard.sh" \
-     --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" \
+     --orch "${ORCH_NAME}" --orch-dir "${ORCH_DIR}" --roll-usage \
      >/dev/null 2>>"${ORCH_DIR}/.update-dashboard.log" || true
 
    HANDOFF_DIR="thoughts/shared/handoffs/${ORCH_NAME}"


### PR DESCRIPTION
## Summary

Fixes the documented orchestrator monitor-loop contract that has been dead code in practice. CTL-485 confirmed the symptom on the live `o-ctl-476-...-486` run: 7 done workers, `total_cost_usd` of $4.48-$15.13 each in their stream files, but `.roll-usage.log` empty, `signal.cost` null on every worker, and `session_metrics.cost_usd = 0` everywhere. CTL-455's fix was mechanically correct but never reached.

The contract at [`orchestrate/SKILL.md:646-656`](plugins/dev/skills/orchestrate/SKILL.md) required Phase 4 to invoke `orchestrate-roll-usage.sh` per worker per wake-up. The fulfilling bash block sat deep in a long SKILL.md section ([:1227-1232 pre-edit](plugins/dev/skills/orchestrate/SKILL.md)) and was consistently skipped when the orchestrator agent paraphrased its wake-up reaction.

**Fix:** move the per-worker invocation into a compiled `update-dashboard.sh --roll-usage` flag — `update-dashboard.sh` is already called from every wake-up site, so wiring the flag through makes the contract mechanical rather than markdown-enforced. Each per-worker call is bounded and idempotent (gated on `signal.cost == null`), so already-rolled workers cost a single `jq` read. Because every dashboard render now sweeps every worker, the same mechanism is also the safety-net (DoD item 3) for any `result` event that arrives between wake-ups.

**Operator addendum** ([Linear comment](https://linear.app/coalesce-labs/issue/CTL-487)) coordinated with the primary fix:
- Add `catalyst.orchestration.dispatchMode = "phase-agents"` to `.catalyst/config.json`. The catalyst repo had no orchestration block, and `orchestrate-dispatch-next:115` defaults to `oneshot-legacy` when the key is missing — so every prior orchestration on this repo silently used legacy mode. Flipping it makes the next dogfood (CTL-473) actually exercise phase-agents and produce the per-phase measurements CTL-488 needs.

## Changes

| File | Change |
| --- | --- |
| `plugins/dev/scripts/update-dashboard.sh` | New `--roll-usage` flag: before rendering, iterate `${ORCH_DIR}/workers/*.json` and invoke `orchestrate-roll-usage.sh -v` per ticket with stderr → `${ORCH_DIR}/.roll-usage.log`. Opt-in; existing callers without the flag are unchanged. |
| `plugins/dev/skills/orchestrate/SKILL.md` | Three `update-dashboard.sh` call sites (Phase 2 init at L352, Phase 4 wake-up at L1233, Phase 7 completion at L2063) gain `--roll-usage`. Delete the dead standalone roll-usage `for`-loop. Prose at L652 updated to reflect the new wiring. |
| `.catalyst/config.json` | Add `catalyst.orchestration.dispatchMode = "phase-agents"`. |
| `plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh` | 24-assertion fixture test: confirms `--roll-usage` populates `signal.cost`, writes the audit trail, is idempotent, handles the multi-worker mixed-state sweep (already-rolled / needs-rollup / still-running), and that without the flag the rollup does NOT happen (proves the old SKILL-only contract was dead code). |

## Definition of Done (from ticket)

- [x] Root cause: contract lived only as a markdown bash block in SKILL.md prose; no compiled script called it; the SKILL-reading agent paraphrased the wake-up and elided the block. Documented in [`thoughts/shared/research/2026-05-17-ctl-487-rollup-invocation-dead-code.md`](thoughts/shared/research/2026-05-17-ctl-487-rollup-invocation-dead-code.md).
- [x] Loop runs the rollup at least once per worker per wake-up — `update-dashboard.sh --roll-usage` iterates every worker signal file.
- [x] Periodic safety-net sweep — same mechanism; every render IS a sweep, idempotent on already-rolled workers.
- [x] Audit-trace assertion — `update-dashboard-rolls-usage.test.sh` asserts the rollup fires when a worker completes mid-orchestration.
- [x] Operator addendum: `.catalyst/config.json` flipped to `phase-agents`.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh` — 24/24 pass
- [x] `bash plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh` — 62/62 pass
- [x] `bash plugins/dev/scripts/__tests__/signal-cost-write.test.sh` — 17/17 pass
- [x] `bash plugins/dev/scripts/__tests__/update-dashboard.test.sh` — 51/51 pass
- [x] End-to-end smoke test against a fixture orch dir: `signal.cost` populated, `state.usage` rolled, `.roll-usage.log` records `wrote-cost`, dashboard rendered
- [ ] CI passes

## References

- CTL-455 — the `session_metrics` write logic this PR makes reachable (PR #798)
- CTL-485 — surfaced the symptom; the research doc in this PR cites its evidence
- CTL-488 — depends on this PR for per-phase cost measurement
- CTL-473 — the planned dogfood run that will be the first real exercise of phase-agents mode on the catalyst repo
- ADR-017 — establishes phase-agents as template default with oneshot-legacy as runtime fallback for un-migrated projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)