### PR TITLE
fix(dev): unbreak phase-agent dispatch end-to-end (CTL-490)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -46,16 +46,27 @@ if [[ ! -x "$DISPATCH" ]]; then
 fi
 
 # ─── Stub claude binary ─────────────────────────────────────────────────────
-# The stub writes a fake bg job ID to stdout and logs its args + env to
-# $CLAUDE_STUB_LOG for assertions. The bg job ID can be overridden via
-# $CLAUDE_STUB_JOB_ID for the "records the bg job id" test.
+# The stub mimics today's real `claude --bg` stdout format (CTL-490):
+#
+#   backgrounded · <hex>
+#     claude agents             list sessions
+#     claude attach <hex>       open in this terminal
+#
+# It also logs its args + env to $CLAUDE_STUB_LOG for assertions. The bg job
+# ID can be overridden via $CLAUDE_STUB_JOB_ID — must be a lowercase 8-char hex
+# string so the dispatcher's `grep -oE '[a-f0-9]{8}'` matches it.
+#
+# NOTE: This stub asserts the dispatcher's `BG_JOB_ID` parser. It does NOT
+# exercise the `claude --bg "/catalyst-dev:phase-X ..."` skill-resolution path
+# (Bug 1 in CTL-490) — that gap requires a real `claude --bg` round-trip and
+# is verified manually per the ticket's acceptance test.
 setup_claude_stub() {
   local stub_dir="$1"
   mkdir -p "$stub_dir"
   cat > "$stub_dir/claude" <<'STUB'
 #!/usr/bin/env bash
 LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
-JOB_ID="${CLAUDE_STUB_JOB_ID:-job-stub-abc123}"
+JOB_ID="${CLAUDE_STUB_JOB_ID:-f124220a}"
 {
   echo "--ARGS--"
   printf '%s\n' "$@"
@@ -63,7 +74,13 @@ JOB_ID="${CLAUDE_STUB_JOB_ID:-job-stub-abc123}"
   env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
   echo "--END--"
 } > "$LOG"
-printf '%s\n' "$JOB_ID"
+# Mimic today's `claude --bg` multi-line stdout — the hex job ID lives on
+# line 1 after the bullet character; subsequent lines list helper commands.
+cat <<EOF
+backgrounded · ${JOB_ID}
+  claude agents             list sessions
+  claude attach ${JOB_ID}    open in this terminal
+EOF
 exit "${CLAUDE_STUB_EXIT:-0}"
 STUB
   chmod +x "$stub_dir/claude"
@@ -80,7 +97,7 @@ fresh_env() {
   mkdir -p "$STUB_DIR" "$WORKER_DIR" "$CONFIG_DIR"
   setup_claude_stub "$STUB_DIR"
   export CLAUDE_STUB_LOG="${TEST_DIR}/claude-stub.log"
-  export CLAUDE_STUB_JOB_ID="job-stub-abc123"
+  export CLAUDE_STUB_JOB_ID="f124220a"
   unset CLAUDE_STUB_EXIT
   export PATH="${STUB_DIR}:${PATH}"
 }
@@ -124,13 +141,13 @@ assert_contains "$LOG" "CATALYST_TICKET=CTL-100" "env carries CATALYST_TICKET"
 echo ""
 echo "Test 3: dispatcher records bg_job_id in signal file + stdout"
 fresh_env t3
-export CLAUDE_STUB_JOB_ID="job-xyz-789"
+export CLAUDE_STUB_JOB_ID="a1b2c3d4"
 STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
 SIGNAL="${WORKER_DIR}/phase-triage.json"
 JOB_IN_SIGNAL=$(jq -r '.bg_job_id' "$SIGNAL")
 JOB_IN_STDOUT=$(echo "$STDOUT" | jq -r '.bg_job_id')
-assert_eq "job-xyz-789" "$JOB_IN_SIGNAL" "signal.bg_job_id matches claude stub output"
-assert_eq "job-xyz-789" "$JOB_IN_STDOUT" "stdout JSON includes bg_job_id"
+assert_eq "a1b2c3d4" "$JOB_IN_SIGNAL" "signal.bg_job_id matches claude stub output"
+assert_eq "a1b2c3d4" "$JOB_IN_STDOUT" "stdout JSON includes bg_job_id"
 
 # ─── Test 4: dispatcher is idempotent (re-dispatch in-flight phase no-ops)
 echo ""
@@ -273,6 +290,36 @@ assert_contains "$LOG" "CATALYST_ORCHESTRATOR_DIR=" "env propagates CATALYST_ORC
 assert_contains "$LOG" "CATALYST_ORCHESTRATOR_ID="  "env propagates CATALYST_ORCHESTRATOR_ID"
 assert_contains "$LOG" "CATALYST_PHASE=triage"      "env propagates CATALYST_PHASE"
 assert_contains "$LOG" "CATALYST_TICKET=CTL-100"    "env propagates CATALYST_TICKET"
+
+# ─── Test 9: BG_JOB_ID parser extracts hex from realistic `claude --bg` output
+# Regression guard for CTL-490 Bug 2. The bug was `awk 'NR==1 {print $1}'`
+# capturing the literal word "backgrounded" from today's CLI format. This test
+# uses a hand-crafted fixture that mirrors the exact stdout shape from the
+# ticket repro, independent of the stub claude binary, so it stays accurate
+# even if the stub format ever drifts.
+echo ""
+echo "Test 9: BG_JOB_ID parser handles realistic claude --bg stdout format"
+fresh_env t9
+# Override the stub with one that emits the verbatim format from CTL-490's
+# forensic transcript. The hex token here is the real job ID from that
+# failed run — using it makes the regression report grep-able to the ticket.
+cat > "${STUB_DIR}/claude" <<'STUB'
+#!/usr/bin/env bash
+cat <<EOF
+backgrounded · f124220a
+  claude agents             list sessions
+  claude attach f124220a    open in this terminal
+  claude kill   f124220a    stop the session
+EOF
+exit 0
+STUB
+chmod +x "${STUB_DIR}/claude"
+STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+JOB_IN_SIGNAL=$(jq -r '.bg_job_id' "$SIGNAL")
+JOB_IN_STDOUT=$(echo "$STDOUT" | jq -r '.bg_job_id')
+assert_eq "f124220a" "$JOB_IN_SIGNAL" "parser extracts hex from 'backgrounded · <hex>' line"
+assert_eq "f124220a" "$JOB_IN_STDOUT" "parser does NOT capture the literal word 'backgrounded'"
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -96,8 +96,12 @@ echo "Test 1: phase-implement SKILL.md contract (plan path + TDD per-phase + com
 assert_file "$SKILL_IMPLEMENT" "phase-implement/SKILL.md exists"
 if [[ -f "$SKILL_IMPLEMENT" ]]; then
   assert_grep '^name: phase-implement$' "$SKILL_IMPLEMENT" "frontmatter: name: phase-implement"
-  assert_grep '^disable-model-invocation: true' "$SKILL_IMPLEMENT" "frontmatter: disable-model-invocation: true"
-  assert_grep '^user-invocable: false' "$SKILL_IMPLEMENT" "frontmatter: user-invocable: false"
+  # CTL-490: phase skills are dispatched via `claude --bg "/catalyst-dev:phase-X ..."`,
+  # which the bg session parses as a user slash command. Both flags must permit
+  # invocation by humans (slash) AND the model (Skill tool) so the dispatcher
+  # path and any direct invocation both resolve.
+  assert_grep '^user-invocable: true' "$SKILL_IMPLEMENT" "frontmatter: user-invocable: true (CTL-490)"
+  assert_grep '^disable-model-invocation: false' "$SKILL_IMPLEMENT" "frontmatter: disable-model-invocation: false (CTL-490)"
   # Reads the plan from the canonical thoughts/ location (per plan §"per-phase artifact").
   # phase-agent-dispatch already validates the prior artifact glob, but the skill
   # body must also reference the path so it can read+pass it to implement-plan.
@@ -229,12 +233,18 @@ mkdir -p "${T7}/orch/workers/output" "${T7}/wt/demo-T-1" "${T7}/bin"
 # "/catalyst-dev:phase-implement T-1 …".
 cat > "${T7}/bin/claude" <<'STUB'
 #!/usr/bin/env bash
+# CTL-490: mimic today's real `claude --bg` stdout shape so the dispatcher's
+# hex-grep parser finds an 8-char hex job ID (e7f8a9b0 here).
 LOG="${CLAUDE_STUB_LOG}"
 {
   echo "args: $*"
   env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET|COMMS_CHANNEL|SESSION_ID)=' | sort
 } >> "$LOG"
-echo "stub-bg-job-id-7"
+cat <<EOF
+backgrounded · e7f8a9b0
+  claude agents             list sessions
+  claude attach e7f8a9b0    open in this terminal
+EOF
 exit 0
 STUB
 chmod +x "${T7}/bin/claude"

--- a/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
@@ -34,7 +34,10 @@ assert_file_exists "$SKILL" "SKILL.md exists at plugins/dev/skills/phase-plan/SK
 if [[ -f "$SKILL" ]]; then
   BODY=$(cat "$SKILL")
   assert_contains "$BODY" "name: phase-plan" "frontmatter declares name: phase-plan"
-  assert_contains "$BODY" "user-invocable: false" "frontmatter sets user-invocable: false"
+  # CTL-490: phase skills are dispatched via `claude --bg "/catalyst-dev:phase-X ..."`,
+  # which the bg session parses as a user slash command. user-invocable MUST be true.
+  assert_contains "$BODY" "user-invocable: true" "frontmatter sets user-invocable: true (CTL-490)"
+  assert_contains "$BODY" "disable-model-invocation: false" "frontmatter sets disable-model-invocation: false — invocable by model + user"
   assert_contains "$BODY" "CATALYST_ORCHESTRATOR_DIR" "prelude reads CATALYST_ORCHESTRATOR_DIR"
   assert_contains "$BODY" "CATALYST_TICKET" "prelude reads CATALYST_TICKET"
 
@@ -71,13 +74,20 @@ mkdir -p "$STUB_DIR" "$WORKER_DIR" "$RESEARCH_DIR"
 
 cat > "$STUB_DIR/claude" <<'STUB'
 #!/usr/bin/env bash
+# CTL-490: stub mimics today's real `claude --bg` stdout shape so the
+# dispatcher's hex-grep parser finds the job ID. Job ID is the 8-char hex
+# 'b2c4d6e8' — embedded in the realistic "backgrounded · <hex>" line.
 LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
 {
   echo "--ARGS--"; printf '%s\n' "$@"
   echo "--ENV--"; env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
   echo "--END--"
 } > "$LOG"
-echo "job-plan-002"
+cat <<EOF
+backgrounded · b2c4d6e8
+  claude agents             list sessions
+  claude attach b2c4d6e8    open in this terminal
+EOF
 STUB
 chmod +x "$STUB_DIR/claude"
 
@@ -97,7 +107,7 @@ assert_file_exists "$SIGNAL" "signal file phase-plan.json written"
 if [[ -f "$SIGNAL" ]]; then
   assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "signal.status = running"
   assert_eq "plan" "$(jq -r '.phase' "$SIGNAL")" "signal.phase = plan"
-  assert_eq "job-plan-002" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches stub"
+  assert_eq "b2c4d6e8" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches hex from stub (CTL-490)"
 fi
 
 LOG=$(cat "$CLAUDE_STUB_LOG" 2>/dev/null || echo "")

--- a/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
@@ -52,7 +52,10 @@ if [[ -f "$SKILL" ]]; then
   BODY=$(cat "$SKILL")
   # Frontmatter
   assert_contains "$BODY" "name: phase-research" "frontmatter declares name: phase-research"
-  assert_contains "$BODY" "user-invocable: false" "frontmatter sets user-invocable: false"
+  # CTL-490: phase skills are dispatched via `claude --bg "/catalyst-dev:phase-X ..."`,
+  # which the bg session parses as a user slash command. user-invocable MUST be true
+  # for the dispatch to resolve.
+  assert_contains "$BODY" "user-invocable: true" "frontmatter sets user-invocable: true (CTL-490)"
   assert_contains "$BODY" "Task" "allowed-tools includes Task (for invoking research-codebase)"
   assert_contains "$BODY" "Bash" "allowed-tools includes Bash"
 
@@ -95,6 +98,8 @@ mkdir -p "$STUB_DIR" "$WORKER_DIR"
 
 cat > "$STUB_DIR/claude" <<'STUB'
 #!/usr/bin/env bash
+# CTL-490: stub mimics today's real `claude --bg` stdout shape so the
+# dispatcher's hex-grep parser finds the job ID. Hex token 'a1b2c3d4'.
 LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
 {
   echo "--ARGS--"
@@ -103,7 +108,11 @@ LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
   env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
   echo "--END--"
 } > "$LOG"
-echo "job-research-001"
+cat <<EOF
+backgrounded · a1b2c3d4
+  claude agents             list sessions
+  claude attach a1b2c3d4    open in this terminal
+EOF
 STUB
 chmod +x "$STUB_DIR/claude"
 
@@ -125,7 +134,7 @@ if [[ -f "$SIGNAL" ]]; then
   JOB=$(jq -r '.bg_job_id' "$SIGNAL")
   assert_eq "running" "$STATUS" "signal.status = running after spawn"
   assert_eq "research" "$PHASE" "signal.phase = research"
-  assert_eq "job-research-001" "$JOB" "signal.bg_job_id = stub job id"
+  assert_eq "a1b2c3d4" "$JOB" "signal.bg_job_id = hex from stub (CTL-490)"
 fi
 
 LOG=$(cat "$CLAUDE_STUB_LOG" 2>/dev/null || echo "")

--- a/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
@@ -35,7 +35,10 @@ assert_file_exists "$SKILL" "SKILL.md exists at plugins/dev/skills/phase-review/
 if [[ -f "$SKILL" ]]; then
   BODY=$(cat "$SKILL")
   assert_contains "$BODY" "name: phase-review" "frontmatter declares name: phase-review"
-  assert_contains "$BODY" "user-invocable: false" "frontmatter sets user-invocable: false"
+  # CTL-490: phase skills are dispatched via `claude --bg "/catalyst-dev:phase-X ..."`,
+  # which the bg session parses as a user slash command. user-invocable MUST be true.
+  assert_contains "$BODY" "user-invocable: true" "frontmatter sets user-invocable: true (CTL-490)"
+  assert_contains "$BODY" "disable-model-invocation: false" "frontmatter sets disable-model-invocation: false — invocable by model + user"
 
   # Allowed-tools must include Edit (since we may write remediation commits)
   assert_contains "$BODY" "Edit" "allowed-tools includes Edit (for remediation commits)"
@@ -85,13 +88,18 @@ mkdir -p "$STUB_DIR" "$WORKER_DIR"
 
 cat > "$STUB_DIR/claude" <<'STUB'
 #!/usr/bin/env bash
+# CTL-490: stub mimics today's real `claude --bg` stdout shape. Hex 'd4e5f607'.
 LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
 {
   echo "--ARGS--"; printf '%s\n' "$@"
   echo "--ENV--"; env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
   echo "--END--"
 } > "$LOG"
-echo "job-review-004"
+cat <<EOF
+backgrounded · d4e5f607
+  claude agents             list sessions
+  claude attach d4e5f607    open in this terminal
+EOF
 STUB
 chmod +x "$STUB_DIR/claude"
 
@@ -112,7 +120,7 @@ if [[ -f "$SIGNAL" ]]; then
   assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "signal.status = running"
   assert_eq "review" "$(jq -r '.phase' "$SIGNAL")" "signal.phase = review"
   assert_eq "25" "$(jq -r '.turnCap' "$SIGNAL")" "signal.turnCap defaults to 25 (review)"
-  assert_eq "job-review-004" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches stub"
+  assert_eq "d4e5f607" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches hex from stub (CTL-490)"
 fi
 
 LOG=$(cat "$CLAUDE_STUB_LOG" 2>/dev/null || echo "")

--- a/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
@@ -43,7 +43,10 @@ assert_file_exists "$SKILL" "SKILL.md exists at plugins/dev/skills/phase-verify/
 if [[ -f "$SKILL" ]]; then
   BODY=$(cat "$SKILL")
   assert_contains "$BODY" "name: phase-verify" "frontmatter declares name: phase-verify"
-  assert_contains "$BODY" "user-invocable: false" "frontmatter sets user-invocable: false"
+  # CTL-490: phase skills are dispatched via `claude --bg "/catalyst-dev:phase-X ..."`,
+  # which the bg session parses as a user slash command. user-invocable MUST be true.
+  assert_contains "$BODY" "user-invocable: true" "frontmatter sets user-invocable: true (CTL-490)"
+  assert_contains "$BODY" "disable-model-invocation: false" "frontmatter sets disable-model-invocation: false — invocable by model + user"
 
   # Prelude
   assert_contains "$BODY" "CATALYST_ORCHESTRATOR_DIR" "prelude reads CATALYST_ORCHESTRATOR_DIR"
@@ -92,13 +95,18 @@ mkdir -p "$STUB_DIR" "$WORKER_DIR"
 
 cat > "$STUB_DIR/claude" <<'STUB'
 #!/usr/bin/env bash
+# CTL-490: stub mimics today's real `claude --bg` stdout shape. Hex 'c3d4e5f6'.
 LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
 {
   echo "--ARGS--"; printf '%s\n' "$@"
   echo "--ENV--"; env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
   echo "--END--"
 } > "$LOG"
-echo "job-verify-003"
+cat <<EOF
+backgrounded · c3d4e5f6
+  claude agents             list sessions
+  claude attach c3d4e5f6    open in this terminal
+EOF
 STUB
 chmod +x "$STUB_DIR/claude"
 
@@ -117,7 +125,7 @@ if [[ -f "$SIGNAL" ]]; then
   assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "signal.status = running"
   assert_eq "verify" "$(jq -r '.phase' "$SIGNAL")" "signal.phase = verify"
   assert_eq "20" "$(jq -r '.turnCap' "$SIGNAL")" "signal.turnCap defaults to 20 (verify)"
-  assert_eq "job-verify-003" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches stub"
+  assert_eq "c3d4e5f6" "$(jq -r '.bg_job_id' "$SIGNAL")" "signal.bg_job_id matches hex from stub (CTL-490)"
 fi
 
 LOG=$(cat "$CLAUDE_STUB_LOG" 2>/dev/null || echo "")

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -310,8 +310,11 @@ if [[ $RC -ne 0 ]]; then
   exit 1
 fi
 
-# Extract the bg job id — first whitespace-bounded token on stdout.
-BG_JOB_ID=$(awk 'NR==1 {print $1; exit}' "$BG_OUT")
+# Extract the bg job id — first 8-char lowercase hex on stdout (CTL-490).
+# Today's `claude --bg` prints `backgrounded · <hex>\n  claude agents ...`;
+# the previous `awk NR==1 {print $1}` captured the literal word "backgrounded".
+# Hex grep stays correct as long as job IDs remain hex tokens.
+BG_JOB_ID=$(grep -oE '[a-f0-9]{8}' "$BG_OUT" | head -1)
 [[ -n "$BG_JOB_ID" ]] || die "claude --bg returned empty job id (stdout: $(cat "$BG_OUT"))"
 
 # Record job id back into the signal file.

--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -2,13 +2,15 @@
 name: _phase-agent-template
 description: |
   Reference template every phase-agent skill copies (CTL-448). The leading
-  underscore + the disable/non-invocable flags below prevent the skill loader
-  from picking this up — it is NOT a runnable skill, only a structural
-  template the nine real phase agents (phase-triage, phase-research, phase-plan,
-  phase-implement, phase-verify, phase-review, phase-pr, phase-monitor-merge,
-  phase-monitor-deploy) clone and specialize.
-disable-model-invocation: true
-user-invocable: false
+  underscore on the directory name prevents the skill loader from picking this
+  up — it is NOT a runnable skill, only a structural template the nine real
+  phase agents (phase-triage, phase-research, phase-plan, phase-implement,
+  phase-verify, phase-review, phase-pr, phase-monitor-merge, phase-monitor-deploy)
+  clone and specialize. The real phase skills MUST set `user-invocable: true`
+  so `phase-agent-dispatch`'s `claude --bg "/catalyst-dev:phase-X ..."` slash
+  command resolves (CTL-490).
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools:
   - Bash
   - Read
@@ -24,8 +26,9 @@ This is the structural template for every phase agent in Initiative 1
 (plan §"Phase-agent architecture"). It is NOT itself a skill — phase-N
 SKILL.md files copy this skeleton and fill in the placeholders marked with
 `{{...}}`. The leading underscore on this directory keeps the skill loader
-from registering it, and the `disable-model-invocation: true` /
-`user-invocable: false` flags are belt-and-suspenders.
+from registering it. The real phase skills set `user-invocable: true` because
+`phase-agent-dispatch` spawns them via `claude --bg "/catalyst-dev:phase-X ..."` —
+the bg session parses that as a user slash command (CTL-490).
 
 ## Contract
 

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -5,10 +5,10 @@ description: |
   (CTL-449 Initiative 1 Phase 3). Reads `thoughts/shared/plans/*-<ticket>.md`,
   delegates the red→green→refactor cycle to `/catalyst-dev:implement-plan`,
   commits each plan phase as it lands, and transitions the Linear ticket to
-  `inProgress`. Dispatched as a `claude --bg` job by `phase-agent-dispatch`;
-  not user-invocable.
-disable-model-invocation: true
-user-invocable: false
+  `inProgress`. Dispatched as a `claude --bg` job by `phase-agent-dispatch`,
+  which invokes it via slash command — hence `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools:
   - Bash
   - Read

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: phase-monitor-deploy
-description: Phase agent that watches the post-merge deployment for a ticket. Reads the merge SHA from phase-pr.json, subscribes via `catalyst-events wait-for` to deploy events on that SHA, then delegates a live verification check to the /canary skill (gstack). Emits phase.monitor-deploy.complete.<TICKET> on canary success, phase.monitor-deploy.failed.<TICKET> on deploy or canary failure, and phase.monitor-deploy.skipped.<TICKET> when no deploy event arrives before the timeout. Dispatched by the phase-agent orchestrator (CTL-452) — not user-invocable.
-disable-model-invocation: true
-user-invocable: false
+description: Phase agent that watches the post-merge deployment for a ticket. Reads the merge SHA from phase-pr.json, subscribes via `catalyst-events wait-for` to deploy events on that SHA, then delegates a live verification check to the /canary skill (gstack). Emits phase.monitor-deploy.complete.<TICKET> on canary success, phase.monitor-deploy.failed.<TICKET> on deploy or canary failure, and phase.monitor-deploy.skipped.<TICKET> when no deploy event arrives before the timeout. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-monitor-deploy ..."` resolves.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools: Bash, Read, Write
 version: 1.0.0
 ---

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -6,10 +6,10 @@ description: |
   body: event-driven wait on `catalyst-events wait-for`, inline resolution of
   CI fix-ups, bot review threads, and BEHIND rebases, then `gh pr merge
   --squash --delete-branch` when the PR reaches CLEAN, then transitions
-  Linear to `done`. Dispatched as a `claude --bg` job by `phase-agent-dispatch`;
-  not user-invocable.
-disable-model-invocation: true
-user-invocable: false
+  Linear to `done`. Dispatched as a `claude --bg` job by `phase-agent-dispatch`,
+  which invokes it via slash command — hence `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools:
   - Bash
   - Read

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -5,10 +5,10 @@ description: |
   Wraps /catalyst-dev:create-plan and produces
   thoughts/shared/plans/<date>-<ticket>.md, then emits phase.plan.complete.<ticket>.
   Reads the prior research document from thoughts/shared/research/ as its
-  prior-phase artifact. Spawned via plugins/dev/scripts/phase-agent-dispatch;
-  not normally user-invoked.
-disable-model-invocation: false
-user-invocable: false
+  prior-phase artifact. Spawned via plugins/dev/scripts/phase-agent-dispatch,
+  which invokes it via slash command — hence `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools:
   - Read
   - Write

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -7,9 +7,10 @@ description: |
   transitions Linear to `inReview`), then writes the PR number + URL into the
   phase signal file so the downstream `phase-monitor-merge` agent can read it
   without re-querying GitHub. Dispatched as a `claude --bg` job by
-  `phase-agent-dispatch`; not user-invocable.
-disable-model-invocation: true
-user-invocable: false
+  `phase-agent-dispatch`, which invokes it via slash command — hence
+  `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools:
   - Bash
   - Read

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -5,9 +5,10 @@ description: |
   Wraps /catalyst-dev:research-codebase and produces
   thoughts/shared/research/<date>-<ticket>.md, then emits phase.research.complete.<ticket>.
   Reads triage.json from the worker dir as its prior-phase artifact.
-  Spawned via plugins/dev/scripts/phase-agent-dispatch; not normally user-invoked.
-disable-model-invocation: false
-user-invocable: false
+  Spawned via plugins/dev/scripts/phase-agent-dispatch, which invokes it via
+  slash command — hence `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools:
   - Read
   - Write

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -6,9 +6,10 @@ description: |
   Reads verify.json from the prior phase, runs /review against the diff, writes
   ${ORCH_DIR}/workers/<TICKET>/review.json, and creates a remediation commit for
   any HIGH-severity finding that has a deterministic fix. Emits
-  phase.review.complete.<ticket>. Spawned via phase-agent-dispatch; not user-invoked.
-disable-model-invocation: false
-user-invocable: false
+  phase.review.complete.<ticket>. Spawned via phase-agent-dispatch via slash
+  command — hence `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools:
   - Read
   - Write

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: phase-triage
-description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies dependencies, estimates scope, writes triage.json, posts a triaged comment to Linear, and applies the `triaged` label. Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) — not user-invocable.
-disable-model-invocation: true
-user-invocable: false
+description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies dependencies, estimates scope, writes triage.json, posts a triaged comment to Linear, and applies the `triaged` label. Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-triage ..."` resolves.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools: Bash, Read, Write, Grep
 version: 1.0.0
 ---

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -7,9 +7,10 @@ description: |
   scan, code review, test coverage, silent-failure hunt. Writes
   ${ORCH_DIR}/workers/<TICKET>/verify.json then emits phase.verify.complete.<ticket>.
   Reads phase-implement.json as its prior-phase artifact. NEVER writes application
-  code — only test files allowed. Spawned via phase-agent-dispatch; not user-invoked.
-disable-model-invocation: false
-user-invocable: false
+  code — only test files allowed. Spawned via phase-agent-dispatch via slash
+  command — hence `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools:
   - Read
   - Write


### PR DESCRIPTION
Closes [CTL-490](https://linear.app/coalesce-labs/issue/CTL-490).

## Summary

First end-to-end phase-agents dogfood (`o-ctl-489-473`, 2026-05-17) failed
immediately in Phase 3 with `state-json-missing` because of two independent
bugs in the dispatch path. Both must ship together — fixing one without the
other leaves the orchestrator broken.

This means **no `claude --bg` phase worker has ever run a phase end-to-end**
in this codebase. CTL-452's test coverage exercised the broker route and
dispatch wrapper but never spawn-and-execute.

## Bug 1 — skill gate

The 9 phase skills + `_phase-agent-template` carried:

```yaml
disable-model-invocation: true
user-invocable: false
```

`claude --bg "/catalyst-dev:phase-X ..."` is parsed as a user slash command,
so `user-invocable: false` rejects it: *"This skill can only be invoked by
Claude, not directly by users."* The bg session then idles indefinitely and
the orchestrator's worker stalls.

**Fix.** Flip both axes to permit human (slash) AND model (Skill tool)
invocation:

```yaml
user-invocable: true                  # invoked by phase-agent-dispatch via slash command
disable-model-invocation: false       # invocable by model (Skill tool) AND user (slash command)
```

The dispatcher IS the legitimate user-side invoker; the original gates were
over-restrictive.

## Bug 2 — bg_job_id parser

`phase-agent-dispatch` captured the bg job ID with:

```bash
BG_JOB_ID=$(awk 'NR==1 {print $1; exit}' "$BG_OUT")
```

Today's `claude --bg` prints:

```
backgrounded · f124220a
  claude agents             list sessions
  ...
```

so the awk parse captured the literal word `backgrounded`. Healthcheck then
stat'd `~/.claude/jobs/backgrounded/state.json` (nonexistent) and flagged
`STALL_REASON=state-json-missing`. The real bg job at
`~/.claude/jobs/f124220a/state.json` was untracked.

**Fix.** Hex grep — robust to leading prose and future format changes:

```bash
BG_JOB_ID=$(grep -oE '[a-f0-9]{8}' "$BG_OUT" | head -1)
```

## Also in this PR

- `.catalyst/config.json` flips `orchestration.dispatchMode` to `phase-agents`
  (was already staged before this fix; bundled because phase-agents is only
  safe to enable once both bugs above land).

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` —
      32 pass, including new Test 9 with the verbatim "backgrounded · <hex>"
      fixture from the ticket.
- [x] `bash plugins/dev/scripts/__tests__/phase-{triage,research,plan,
      implement,verify,review,monitor-deploy}-e2e.test.sh` — all pass after
      updating stub `claude` binaries to emit the realistic multi-line format
      and flipping frontmatter contract assertions to the new values.
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-{comms,emit-complete}.test.sh`
      — sanity check on adjacent test files, no regression.
- [x] Full sweep of `plugins/dev/scripts/__tests__/*.test.sh` (61 files) —
      pre-existing failures `broker-phase-lifecycle.test.sh`,
      `catalyst-events.test.sh`, `setup-webhooks.test.sh` (all fail on
      `main` HEAD too, unrelated to this fix). No new failures.
- [ ] **Manual acceptance test (post-merge, per the ticket):**
      `/catalyst-dev:orchestrate CTL-489+CTL-473 --auto-merge --max-parallel 1`
      should walk all 9 phases, emit `phase.<name>.complete` events, populate
      `session_metrics`, and merge cleanly. This becomes the actual CTL-488
      validation run.

## Coverage gap (explicit)

The DoD bullet "test asserting phase skills resolve when invoked via slash
command" requires a real `claude --bg` round-trip — beyond what the existing
stubbed test harness exercises. The gap is documented in the test file
header and is covered by the manual acceptance test above.