### PR TITLE
CTL-491: register filter interests before dispatching workers (close race window)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-phase-ordering.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-phase-ordering.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Structural regression test for orchestrate/SKILL.md document order (CTL-491).
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-phase-ordering.test.sh
+#
+# Asserts that the orchestrate-register-interests.sh invocation textually
+# precedes the orchestrate-dispatch-next invocation in orchestrate/SKILL.md.
+# A future edit that re-orders them re-introduces the CTL-491 race window —
+# this test fails before reaching dogfood.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/orchestrate/SKILL.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+[ -f "$SKILL_MD" ] || { echo "MISSING: $SKILL_MD"; exit 2; }
+
+# Line number of the first occurrence of each invocation.
+REG_LINE=$(grep -n 'orchestrate-register-interests.sh' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+DISP_LINE=$(grep -n 'orchestrate-dispatch-next' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+
+echo "test 9: orchestrate-register-interests.sh appears BEFORE orchestrate-dispatch-next"
+[ -n "$REG_LINE" ] && pass "register-interests reference present" || fail "register-interests reference present" "no match in $SKILL_MD"
+[ -n "$DISP_LINE" ] && pass "dispatch-next reference present" || fail "dispatch-next reference present"
+if [ -n "$REG_LINE" ] && [ -n "$DISP_LINE" ]; then
+  if [ "$REG_LINE" -lt "$DISP_LINE" ]; then
+    pass "register-interests (line $REG_LINE) precedes dispatch-next (line $DISP_LINE)"
+  else
+    fail "register-interests precedes dispatch-next" "register=$REG_LINE dispatch=$DISP_LINE — CTL-491 race re-introduced"
+  fi
+fi
+
+echo "test 10: exactly ONE pre-dispatch register-interests invocation between Phase 2 and Phase 3"
+# Phase 2/3 markers in SKILL.md
+PHASE2_LINE=$(grep -nE '^### Phase 2:' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+PHASE3_LINE=$(grep -nE '^### Phase 3:' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+[ -n "$PHASE2_LINE" ] && [ -n "$PHASE3_LINE" ] && pass "Phase 2/3 headers located" \
+  || fail "Phase 2/3 headers located" "p2=$PHASE2_LINE p3=$PHASE3_LINE"
+if [ -n "$PHASE2_LINE" ] && [ -n "$PHASE3_LINE" ]; then
+  # Count register-interests.sh invocations strictly between Phase 2 header
+  # and the orchestrate-dispatch-next invocation. The helper is allowed to
+  # appear elsewhere (Phase 4 refresh) so we don't count the whole file.
+  COUNT_BETWEEN=$(awk -v p2="$PHASE2_LINE" -v dn="$DISP_LINE" 'NR > p2 && NR < dn' "$SKILL_MD" \
+    | grep -c 'orchestrate-register-interests.sh' || true)
+  [ "$COUNT_BETWEEN" -ge 1 ] && pass "at least one register-interests invocation before dispatch-next (got $COUNT_BETWEEN)" \
+    || fail "at least one register-interests invocation before dispatch-next" "found 0 between lines $PHASE2_LINE..$DISP_LINE"
+fi
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-register-interests.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-register-interests.test.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-register-interests (CTL-491).
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-register-interests.test.sh
+#
+# The helper emits the four broker filter.register events the orchestrator
+# needs (pr_lifecycle, ticket_lifecycle, comms_lifecycle, phase_lifecycle)
+# and is invoked both at Phase 2.5 (pre-dispatch) and Phase 4 (refresh).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+REGISTER="${REPO_ROOT}/plugins/dev/scripts/orchestrate-register-interests.sh"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+# Scratch setup: temp ORCH_DIR + fake catalyst-state.sh that logs argv.
+scratch_setup() {
+  SCRATCH="$(mktemp -d)"
+  ORCH_DIR="${SCRATCH}/orch"
+  mkdir -p "${ORCH_DIR}/workers" "${SCRATCH}/bin"
+
+  cat > "${SCRATCH}/bin/catalyst-state.sh" <<'EOF'
+#!/usr/bin/env bash
+# Fake catalyst-state.sh — for `event <json>` calls, append the json to a log.
+if [ "${1:-}" = "event" ]; then
+  shift
+  printf '%s\n' "$@" >> "$STATE_LOG"
+fi
+EOF
+  chmod +x "${SCRATCH}/bin/catalyst-state.sh"
+  export STATE_LOG="${SCRATCH}/state.log"
+  : > "$STATE_LOG"
+  export CATALYST_STATE_SCRIPT="${SCRATCH}/bin/catalyst-state.sh"
+
+  # Fake catalyst-broker — claim it is up so the helper proceeds.
+  cat > "${SCRATCH}/bin/catalyst-broker" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "${SCRATCH}/bin/catalyst-broker"
+  # Fake gh (used for repo full name lookup)
+  cat > "${SCRATCH}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "owner/repo"
+EOF
+  chmod +x "${SCRATCH}/bin/gh"
+  export PATH="${SCRATCH}/bin:$PATH"
+
+  # Minimal config file (defaults to phase-agents — most tests use this)
+  CONFIG_FILE="${SCRATCH}/config.json"
+  cat > "$CONFIG_FILE" <<'EOF'
+{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}
+EOF
+}
+
+scratch_teardown() {
+  rm -rf "$SCRATCH"
+  unset SCRATCH ORCH_DIR STATE_LOG CONFIG_FILE
+  unset CATALYST_STATE_SCRIPT
+}
+
+# write_worker_signal TICKET [PR_NUMBER]
+write_worker_signal() {
+  local t="$1" pr="${2:-null}"
+  local file="${ORCH_DIR}/workers/${t}.json"
+  if [ "$pr" = "null" ]; then
+    jq -nc --arg t "$t" '{ticket:$t, status:"running", pr:null}' > "$file"
+  else
+    jq -nc --arg t "$t" --argjson pr "$pr" '{ticket:$t, status:"running", pr:{number:$pr, baseRefName:"main"}}' > "$file"
+  fi
+}
+
+run_register() {
+  "$REGISTER" --orch-dir "$ORCH_DIR" --orch-id "demo" --config "$CONFIG_FILE" "$@"
+}
+
+# Count emitted filter.register events by interest_type.
+count_events_of_type() {
+  jq -r '.detail.interest_type' "$STATE_LOG" 2>/dev/null \
+    | grep -c "^${1}$" || true
+}
+
+# ─── Phase 1 tests (1-8) — basic registration semantics ─────────────────────
+
+echo "test 1: phase-agents mode with 2 tickets emits 3 deterministic + 2 phase_lifecycle = 5 events"
+scratch_setup
+write_worker_signal "CTL-491"
+write_worker_signal "CTL-492"
+run_register >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0" || fail "exit 0" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+TOTAL=$(wc -l < "$STATE_LOG" | tr -d ' ')
+[ "$TOTAL" = "5" ] && pass "5 total events" || fail "5 total events" "got $TOTAL events: $(cat "$STATE_LOG")"
+PR_COUNT=$(count_events_of_type "pr_lifecycle")
+TICKET_COUNT=$(count_events_of_type "ticket_lifecycle")
+COMMS_COUNT=$(count_events_of_type "comms_lifecycle")
+PHASE_COUNT=$(count_events_of_type "phase_lifecycle")
+[ "$PR_COUNT" = "1" ] && pass "1 pr_lifecycle event" || fail "1 pr_lifecycle event" "got $PR_COUNT"
+[ "$TICKET_COUNT" = "1" ] && pass "1 ticket_lifecycle event" || fail "1 ticket_lifecycle event" "got $TICKET_COUNT"
+[ "$COMMS_COUNT" = "1" ] && pass "1 comms_lifecycle event" || fail "1 comms_lifecycle event" "got $COMMS_COUNT"
+[ "$PHASE_COUNT" = "2" ] && pass "2 phase_lifecycle events" || fail "2 phase_lifecycle events" "got $PHASE_COUNT"
+scratch_teardown
+
+echo "test 2: oneshot-legacy mode emits 3 deterministic interests, no phase_lifecycle"
+scratch_setup
+cat > "$CONFIG_FILE" <<'EOF'
+{"catalyst":{"orchestration":{"dispatchMode":"oneshot-legacy"}}}
+EOF
+write_worker_signal "CTL-491"
+write_worker_signal "CTL-492"
+run_register >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 in oneshot-legacy" || fail "exit 0 in oneshot-legacy" "rc=$RC"
+TOTAL=$(wc -l < "$STATE_LOG" | tr -d ' ')
+[ "$TOTAL" = "3" ] && pass "3 total events (no phase_lifecycle)" || fail "3 total events (no phase_lifecycle)" "got $TOTAL events: $(cat "$STATE_LOG")"
+PHASE_COUNT=$(count_events_of_type "phase_lifecycle")
+[ "$PHASE_COUNT" = "0" ] && pass "0 phase_lifecycle events" || fail "0 phase_lifecycle events" "got $PHASE_COUNT"
+scratch_teardown
+
+echo "test 3: each phase_lifecycle event carries the 9 canonical phase names"
+scratch_setup
+write_worker_signal "CTL-491"
+run_register >/dev/null 2>"${SCRATCH}/err"
+PHASE_NAMES_JSON=$(jq -c 'select(.detail.interest_type == "phase_lifecycle") | .detail.phase_names' "$STATE_LOG")
+EXPECTED='["triage","research","plan","implement","verify","review","pr","monitor-merge","monitor-deploy"]'
+[ "$PHASE_NAMES_JSON" = "$EXPECTED" ] && pass "9 canonical phase names" || fail "9 canonical phase names" "got $PHASE_NAMES_JSON"
+scratch_teardown
+
+echo "test 4: each event carries notify_event = filter.wake.<ORCH_NAME>"
+scratch_setup
+write_worker_signal "CTL-491"
+run_register >/dev/null 2>"${SCRATCH}/err"
+ALL_NOTIFY=$(jq -r '.detail.notify_event' "$STATE_LOG" | sort -u)
+[ "$ALL_NOTIFY" = "filter.wake.demo" ] && pass "all events carry filter.wake.demo" || fail "all events carry filter.wake.demo" "got: $ALL_NOTIFY"
+scratch_teardown
+
+echo "test 5: --refresh without prior .last-registration.json re-emits all interests"
+# (When the baseline file is missing, --refresh has nothing to diff against and
+# falls back to initial-style registration. This is the Phase 1 contract; the
+# Phase 3 diff semantics kick in only when the baseline exists.)
+scratch_setup
+write_worker_signal "CTL-491"
+# Note: no initial run, so .last-registration.json doesn't exist yet.
+run_register --refresh >/dev/null 2>"${SCRATCH}/err"
+TOTAL=$(wc -l < "$STATE_LOG" | tr -d ' ')
+[ "$TOTAL" = "4" ] && pass "refresh w/o baseline emits all 4 (3 + 1 phase_lifecycle)" \
+  || fail "refresh w/o baseline emits all 4" "got $TOTAL events: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test 6: missing --orch-id exits non-zero with clear error"
+scratch_setup
+OUT=$("$REGISTER" --orch-dir "$ORCH_DIR" --config "$CONFIG_FILE" 2>&1 >/dev/null)
+RC=$?
+[ "$RC" != "0" ] && pass "non-zero exit on missing --orch-id" || fail "non-zero exit on missing --orch-id" "rc=$RC"
+echo "$OUT" | grep -qi "orch-id" && pass "stderr mentions orch-id" || fail "stderr mentions orch-id" "got: $OUT"
+scratch_teardown
+
+echo "test 7: empty workers/ dir → 0 phase_lifecycle events but emits 3 deterministic"
+scratch_setup
+# No worker signals written.
+run_register >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 with empty workers" || fail "exit 0 with empty workers" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+TOTAL=$(wc -l < "$STATE_LOG" | tr -d ' ')
+[ "$TOTAL" = "3" ] && pass "3 deterministic events when workers/ empty" || fail "3 deterministic events when workers/ empty" "got $TOTAL"
+PHASE_COUNT=$(count_events_of_type "phase_lifecycle")
+[ "$PHASE_COUNT" = "0" ] && pass "0 phase_lifecycle when workers/ empty" || fail "0 phase_lifecycle when workers/ empty" "got $PHASE_COUNT"
+scratch_teardown
+
+echo "test 8: stamps .last-registration.json with tickets + timestamp"
+scratch_setup
+write_worker_signal "CTL-491"
+write_worker_signal "CTL-492"
+run_register >/dev/null 2>"${SCRATCH}/err"
+LAST_FILE="${ORCH_DIR}/.last-registration.json"
+[ -f "$LAST_FILE" ] && pass ".last-registration.json exists" || fail ".last-registration.json exists" "missing"
+TICKETS=$(jq -c '.tickets | sort' "$LAST_FILE" 2>/dev/null || echo '[]')
+[ "$TICKETS" = '["CTL-491","CTL-492"]' ] && pass "tickets recorded sorted" || fail "tickets recorded sorted" "got: $TICKETS"
+REG_AT=$(jq -r '.registeredAt // ""' "$LAST_FILE" 2>/dev/null || echo "")
+[ -n "$REG_AT" ] && pass "registeredAt non-empty" || fail "registeredAt non-empty" "got: '$REG_AT'"
+scratch_teardown
+
+# ─── Phase 3 tests (12-15) appended in a later commit ───────────────────────
+# Tests 12-15 exercise the --refresh diff semantics (no-op when nothing
+# changed; emit only new phase_lifecycles when tickets are added). They are
+# added in the Phase 3 commit alongside the helper's --refresh evolution.
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-register-interests.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-register-interests.test.sh
@@ -185,10 +185,63 @@ REG_AT=$(jq -r '.registeredAt // ""' "$LAST_FILE" 2>/dev/null || echo "")
 [ -n "$REG_AT" ] && pass "registeredAt non-empty" || fail "registeredAt non-empty" "got: '$REG_AT'"
 scratch_teardown
 
-# ─── Phase 3 tests (12-15) appended in a later commit ───────────────────────
-# Tests 12-15 exercise the --refresh diff semantics (no-op when nothing
-# changed; emit only new phase_lifecycles when tickets are added). They are
-# added in the Phase 3 commit alongside the helper's --refresh evolution.
+# ─── Phase 3 tests (12-15) — --refresh diff semantics ─────────────────────
+# These tests exercise the --refresh path's diff logic: emit nothing if
+# nothing changed; emit only new phase_lifecycles when wave 2 dispatches new
+# tickets; respect the dispatchMode gate.
+
+echo "test 12: --refresh with [CTL-491] → [CTL-491, CTL-494] re-emits 3 deterministic + 1 phase_lifecycle for CTL-494 only"
+scratch_setup
+write_worker_signal "CTL-491"
+run_register >/dev/null 2>"${SCRATCH}/err"  # initial: 4 events (3 + 1 phase_lifecycle CTL-491)
+: > "$STATE_LOG"
+write_worker_signal "CTL-494"  # add wave 2 ticket
+run_register --refresh >/dev/null 2>"${SCRATCH}/err"
+TOTAL=$(wc -l < "$STATE_LOG" | tr -d ' ')
+[ "$TOTAL" = "4" ] && pass "refresh emits 4 events (3 deterministic + 1 new phase_lifecycle)" \
+  || fail "refresh emits 4 events" "got $TOTAL events: $(cat "$STATE_LOG")"
+NEW_PHASE_TICKET=$(jq -r 'select(.detail.interest_type == "phase_lifecycle") | .detail.ticket' "$STATE_LOG" | sort -u)
+[ "$NEW_PHASE_TICKET" = "CTL-494" ] && pass "only new ticket CTL-494 gets phase_lifecycle" \
+  || fail "only new ticket CTL-494 gets phase_lifecycle" "got: $NEW_PHASE_TICKET"
+scratch_teardown
+
+echo "test 13: --refresh with no change in PR set or ticket set → 0 events (no-op)"
+scratch_setup
+write_worker_signal "CTL-491" 100
+run_register >/dev/null 2>"${SCRATCH}/err"  # initial registration
+: > "$STATE_LOG"
+run_register --refresh >/dev/null 2>"${SCRATCH}/err"
+TOTAL=$(wc -l < "$STATE_LOG" | tr -d ' ')
+[ "$TOTAL" = "0" ] && pass "no-op refresh emits 0 events" \
+  || fail "no-op refresh emits 0 events" "got $TOTAL events: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test 14: --refresh after wave 2 dispatch updates .last-registration.json"
+scratch_setup
+write_worker_signal "CTL-491"
+run_register >/dev/null 2>"${SCRATCH}/err"
+write_worker_signal "CTL-494"
+run_register --refresh >/dev/null 2>"${SCRATCH}/err"
+LAST_FILE="${ORCH_DIR}/.last-registration.json"
+TICKETS=$(jq -c '.tickets | sort' "$LAST_FILE" 2>/dev/null || echo '[]')
+[ "$TICKETS" = '["CTL-491","CTL-494"]' ] && pass "post-refresh baseline has both tickets" \
+  || fail "post-refresh baseline has both tickets" "got: $TICKETS"
+scratch_teardown
+
+echo "test 15: --refresh in oneshot-legacy mode never emits phase_lifecycle (mode gate)"
+scratch_setup
+cat > "$CONFIG_FILE" <<'EOF'
+{"catalyst":{"orchestration":{"dispatchMode":"oneshot-legacy"}}}
+EOF
+write_worker_signal "CTL-491"
+run_register >/dev/null 2>"${SCRATCH}/err"
+: > "$STATE_LOG"
+write_worker_signal "CTL-494"
+run_register --refresh >/dev/null 2>"${SCRATCH}/err"
+PHASE_COUNT=$(count_events_of_type "phase_lifecycle")
+[ "$PHASE_COUNT" = "0" ] && pass "oneshot-legacy refresh emits 0 phase_lifecycle" \
+  || fail "oneshot-legacy refresh emits 0 phase_lifecycle" "got $PHASE_COUNT events: $(cat "$STATE_LOG")"
+scratch_teardown
 
 echo ""
 echo "─────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/orchestrate-replay-phase-events.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-replay-phase-events.test.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-replay-phase-events (CTL-491).
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-replay-phase-events.test.sh
+#
+# The replay helper is invoked on Phase 4 monitor entry. It reads
+# state.json.race.startLineCursor + startEventsFile, scans the event log
+# between that baseline and current EOF, and routes each
+# phase.<name>.{complete,failed,turn-cap-exhausted}.<TICKET> event for
+# in-orch tickets through orchestrate-phase-advance (complete) or
+# orchestrate-revive (failed | turn-cap-exhausted).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+REPLAY="${REPO_ROOT}/plugins/dev/scripts/orchestrate-replay-phase-events.sh"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+# Scratch setup: temp ORCH_DIR + temp events dir + fake advance/revive scripts.
+scratch_setup() {
+  SCRATCH="$(mktemp -d)"
+  ORCH_DIR="${SCRATCH}/orch"
+  EVENTS_DIR="${SCRATCH}/events"
+  mkdir -p "${ORCH_DIR}/workers" "$EVENTS_DIR" "${SCRATCH}/bin"
+
+  # Fake orchestrate-phase-advance — log argv to a file.
+  cat > "${SCRATCH}/bin/orchestrate-phase-advance" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$ADVANCE_LOG"
+EOF
+  chmod +x "${SCRATCH}/bin/orchestrate-phase-advance"
+  export ADVANCE_LOG="${SCRATCH}/advance.log"
+  : > "$ADVANCE_LOG"
+  export CATALYST_PHASE_ADVANCE_BIN="${SCRATCH}/bin/orchestrate-phase-advance"
+
+  # Fake orchestrate-revive — log argv to a file.
+  cat > "${SCRATCH}/bin/orchestrate-revive" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$REVIVE_LOG"
+EOF
+  chmod +x "${SCRATCH}/bin/orchestrate-revive"
+  export REVIVE_LOG="${SCRATCH}/revive.log"
+  : > "$REVIVE_LOG"
+  export CATALYST_REVIVE_BIN="${SCRATCH}/bin/orchestrate-revive"
+
+  # Initial empty events file.
+  CURRENT_MONTH=$(date -u +%Y-%m)
+  EVENTS_FILE="${EVENTS_DIR}/${CURRENT_MONTH}.jsonl"
+  : > "$EVENTS_FILE"
+}
+
+scratch_teardown() {
+  rm -rf "$SCRATCH"
+  unset SCRATCH ORCH_DIR EVENTS_DIR ADVANCE_LOG REVIVE_LOG EVENTS_FILE CURRENT_MONTH
+  unset CATALYST_PHASE_ADVANCE_BIN CATALYST_REVIVE_BIN
+}
+
+write_worker() {
+  local t="$1"
+  jq -nc --arg t "$t" '{ticket:$t, status:"running"}' > "${ORCH_DIR}/workers/${t}.json"
+}
+
+# Emit a canonical-shaped event line for phase.<phase>.<status>.<ticket>.
+emit_phase_event() {
+  local phase="$1" status="$2" ticket="$3"
+  local name="phase.${phase}.${status}.${ticket}"
+  jq -nc \
+    --arg name "$name" \
+    --arg ticket "$ticket" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      "@timestamp": $ts,
+      attributes: {"event.name": $name, "catalyst.ticket": $ticket}
+    }' >> "$EVENTS_FILE"
+}
+
+# Write state.json with race baseline at current EOF of EVENTS_FILE.
+write_state_with_baseline() {
+  local cursor
+  cursor=$(wc -l < "$EVENTS_FILE" | tr -d ' ')
+  jq -nc \
+    --argjson cursor "$cursor" \
+    --arg file "$EVENTS_FILE" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{orchestrator:"demo", startedAt:$ts,
+      race:{startLineCursor:$cursor, startEventsFile:$file}}' \
+    > "${ORCH_DIR}/state.json"
+}
+
+run_replay() {
+  "$REPLAY" --orch-dir "$ORCH_DIR" --orch-id "demo" "$@"
+}
+
+# ─── Test cases ───────────────────────────────────────────────────────────────
+
+echo "test 1: empty race window (cursor == EOF) → exits 0 with no invocations"
+scratch_setup
+write_worker "CTL-491"
+write_state_with_baseline  # cursor = 0, file empty
+OUT=$(run_replay 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 on empty window" || fail "exit 0 on empty window" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+[ ! -s "$ADVANCE_LOG" ] && pass "phase-advance NOT invoked" || fail "phase-advance NOT invoked" "log: $(cat "$ADVANCE_LOG")"
+[ ! -s "$REVIVE_LOG" ] && pass "revive NOT invoked" || fail "revive NOT invoked"
+scratch_teardown
+
+echo "test 2: phase.triage.complete.CTL-491 in window → invokes orchestrate-phase-advance once"
+scratch_setup
+write_worker "CTL-491"
+write_state_with_baseline
+emit_phase_event "triage" "complete" "CTL-491"
+run_replay >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0" || fail "exit 0" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+INVOCATION_COUNT=$(wc -l < "$ADVANCE_LOG" | tr -d ' ')
+[ "$INVOCATION_COUNT" = "1" ] && pass "phase-advance invoked once" || fail "phase-advance invoked once" "log: $(cat "$ADVANCE_LOG")"
+grep -q -- "--completed-phase triage" "$ADVANCE_LOG" && pass "--completed-phase triage forwarded" || fail "--completed-phase triage" "log: $(cat "$ADVANCE_LOG")"
+grep -q -- "--ticket CTL-491" "$ADVANCE_LOG" && pass "--ticket CTL-491 forwarded" || fail "--ticket CTL-491" "log: $(cat "$ADVANCE_LOG")"
+[ ! -s "$REVIVE_LOG" ] && pass "revive NOT invoked for complete" || fail "revive NOT invoked for complete"
+scratch_teardown
+
+echo "test 3: phase.research.failed.CTL-492 in window → invokes orchestrate-revive once"
+scratch_setup
+write_worker "CTL-492"
+write_state_with_baseline
+emit_phase_event "research" "failed" "CTL-492"
+run_replay >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 for failed event" || fail "exit 0 for failed event" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+INVOCATION_COUNT=$(wc -l < "$REVIVE_LOG" | tr -d ' ')
+[ "$INVOCATION_COUNT" = "1" ] && pass "revive invoked once" || fail "revive invoked once" "log: $(cat "$REVIVE_LOG")"
+[ ! -s "$ADVANCE_LOG" ] && pass "phase-advance NOT invoked for failed" || fail "phase-advance NOT invoked for failed"
+scratch_teardown
+
+echo "test 4: phase.implement.turn-cap-exhausted.CTL-493 in window → invokes orchestrate-revive once"
+scratch_setup
+write_worker "CTL-493"
+write_state_with_baseline
+emit_phase_event "implement" "turn-cap-exhausted" "CTL-493"
+run_replay >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 for turn-cap-exhausted" || fail "exit 0 for turn-cap-exhausted" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+INVOCATION_COUNT=$(wc -l < "$REVIVE_LOG" | tr -d ' ')
+[ "$INVOCATION_COUNT" = "1" ] && pass "revive invoked once (continuation path)" || fail "revive invoked once" "log: $(cat "$REVIVE_LOG")"
+scratch_teardown
+
+echo "test 5: phase.triage.complete.OUT-OF-ORCH-99 ticket not in workers/ → IGNORED"
+scratch_setup
+write_worker "CTL-491"
+write_state_with_baseline
+emit_phase_event "triage" "complete" "OUT-99"  # not in workers/
+run_replay >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 with cross-orchestrator event" || fail "exit 0 with cross-orchestrator event" "rc=$RC"
+[ ! -s "$ADVANCE_LOG" ] && pass "phase-advance NOT invoked for foreign ticket" || fail "phase-advance NOT invoked for foreign ticket" "log: $(cat "$ADVANCE_LOG")"
+scratch_teardown
+
+echo "test 6: multiple events same ticket (complete then failed) replay in order"
+scratch_setup
+write_worker "CTL-491"
+write_state_with_baseline
+emit_phase_event "triage" "complete" "CTL-491"
+emit_phase_event "research" "failed" "CTL-491"
+run_replay >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 multi-event" || fail "exit 0 multi-event" "rc=$RC"
+ADV_COUNT=$(wc -l < "$ADVANCE_LOG" | tr -d ' ')
+REV_COUNT=$(wc -l < "$REVIVE_LOG" | tr -d ' ')
+[ "$ADV_COUNT" = "1" ] && pass "phase-advance invoked once (for complete)" || fail "phase-advance invoked once" "log: $(cat "$ADVANCE_LOG")"
+[ "$REV_COUNT" = "1" ] && pass "revive invoked once (for failed)" || fail "revive invoked once" "log: $(cat "$REVIVE_LOG")"
+scratch_teardown
+
+echo "test 7: malformed JSON line in event log → skipped with warning, replay continues"
+scratch_setup
+write_worker "CTL-491"
+write_state_with_baseline
+echo "not valid json {" >> "$EVENTS_FILE"
+emit_phase_event "triage" "complete" "CTL-491"
+run_replay >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 despite malformed line" || fail "exit 0 despite malformed line" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+ADV_COUNT=$(wc -l < "$ADVANCE_LOG" | tr -d ' ')
+[ "$ADV_COUNT" = "1" ] && pass "valid event still processed" || fail "valid event still processed" "log: $(cat "$ADVANCE_LOG")"
+scratch_teardown
+
+echo "test 8: race.startLineCursor missing from state.json → exits non-zero with baseline-missing"
+scratch_setup
+write_worker "CTL-491"
+# state.json without .race
+jq -nc '{orchestrator:"demo"}' > "${ORCH_DIR}/state.json"
+OUT=$(run_replay 2>&1)
+RC=$?
+[ "$RC" != "0" ] && pass "non-zero exit on missing baseline" || fail "non-zero exit on missing baseline" "rc=$RC out=$OUT"
+echo "$OUT" | grep -qi "baseline" && pass "stderr mentions baseline" || fail "stderr mentions baseline" "got: $OUT"
+scratch_teardown
+
+echo "test 9: month rollover — baseline points to last month, current EOF is in new month"
+scratch_setup
+write_worker "CTL-491"
+# Old month events file with 2 lines
+OLD_FILE="${EVENTS_DIR}/2026-04.jsonl"
+echo "noise" > "$OLD_FILE"
+echo "noise2" >> "$OLD_FILE"
+# Baseline at line 2 of old file (no events past it in old file)
+jq -nc --arg file "$OLD_FILE" \
+  '{orchestrator:"demo", race:{startLineCursor:2, startEventsFile:$file}}' \
+  > "${ORCH_DIR}/state.json"
+# Current month file with one new phase event
+emit_phase_event "triage" "complete" "CTL-491"
+# Override CATALYST_EVENTS_DIR so the helper resolves current-month correctly.
+CATALYST_EVENTS_DIR="$EVENTS_DIR" run_replay >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 across month rollover" || fail "exit 0 across month rollover" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+ADV_COUNT=$(wc -l < "$ADVANCE_LOG" | tr -d ' ')
+[ "$ADV_COUNT" = "1" ] && pass "current month event processed" || fail "current month event processed" "log: $(cat "$ADVANCE_LOG")"
+scratch_teardown
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-startup-baseline.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-startup-baseline.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Structural regression test for the Phase 2 baseline-capture block + the
+# Phase 4 replay invocation in orchestrate/SKILL.md (CTL-491).
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-startup-baseline.test.sh
+#
+# The orchestrate skill is a markdown runbook and cannot be unit-tested at the
+# bash level. These tests greps the SKILL.md to confirm that:
+#   (a) Phase 2 sets up state.json.race.{startLineCursor,startEventsFile}
+#   (b) Phase 4 invokes orchestrate-replay-phase-events.sh before the live
+#       Monitor/wait-for loop.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/orchestrate/SKILL.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+[ -f "$SKILL_MD" ] || { echo "MISSING: $SKILL_MD"; exit 2; }
+
+echo "test 10: SKILL.md captures state.json.race baseline before Phase 3 dispatch"
+# We assert that the literal jq filter for .race.startLineCursor appears in
+# the SKILL.md AND that it appears before the dispatch-next invocation.
+BASELINE_LINE=$(grep -n 'startLineCursor' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+DISP_LINE=$(grep -n 'orchestrate-dispatch-next' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+REPLAY_LINE=$(grep -n 'orchestrate-replay-phase-events' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+
+[ -n "$BASELINE_LINE" ] && pass "race.startLineCursor referenced" \
+  || fail "race.startLineCursor referenced" "no match in $SKILL_MD"
+[ -n "$DISP_LINE" ] && pass "dispatch-next referenced" \
+  || fail "dispatch-next referenced"
+if [ -n "$BASELINE_LINE" ] && [ -n "$DISP_LINE" ]; then
+  if [ "$BASELINE_LINE" -lt "$DISP_LINE" ]; then
+    pass "baseline capture (line $BASELINE_LINE) precedes dispatch-next (line $DISP_LINE)"
+  else
+    fail "baseline capture precedes dispatch-next" "baseline=$BASELINE_LINE dispatch=$DISP_LINE"
+  fi
+fi
+
+echo "test 11: SKILL.md invokes orchestrate-replay-phase-events.sh on Phase 4 entry (before wait-for)"
+[ -n "$REPLAY_LINE" ] && pass "replay helper referenced" \
+  || fail "replay helper referenced" "no match in $SKILL_MD"
+# Locate the Phase 4 wait-for invocation specifically (the one bound to
+# filter.wake.${ORCH_NAME} — the Monitor loop entry that this orchestrator
+# blocks on). Other wait-for references upstream are in instructional /
+# fallback blocks and aren't part of the live invocation path.
+WAITFOR_LINE=$(grep -n 'WAKE_EVENT=.*catalyst-events wait-for' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+[ -n "$WAITFOR_LINE" ] && pass "Phase 4 wait-for invocation located" || fail "Phase 4 wait-for invocation located" "no match"
+if [ -n "$REPLAY_LINE" ] && [ -n "$WAITFOR_LINE" ]; then
+  if [ "$REPLAY_LINE" -lt "$WAITFOR_LINE" ]; then
+    pass "replay (line $REPLAY_LINE) precedes Phase 4 wait-for (line $WAITFOR_LINE)"
+  else
+    fail "replay precedes Phase 4 wait-for" "replay=$REPLAY_LINE wait-for=$WAITFOR_LINE"
+  fi
+fi
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/orchestrate-register-interests.sh
+++ b/plugins/dev/scripts/orchestrate-register-interests.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# orchestrate-register-interests.sh (CTL-491) — emit the four broker
+# filter.register events (pr_lifecycle, ticket_lifecycle, comms_lifecycle,
+# phase_lifecycle). Idempotent at the broker (upserts by interest_id).
+#
+# Hoisted out of plugins/dev/skills/orchestrate/SKILL.md Phase 4 so it can run
+# BEFORE Phase 3 dispatches workers — the original ordering opened a race
+# window where phase-agent completions landed in the event log with zero
+# matching interests and were dropped by broker/index.mjs:1782.
+#
+# Usage:
+#   orchestrate-register-interests.sh --orch-dir <path> --orch-id <id>
+#                                     [--config <path>] [--refresh]
+#
+# Both modes emit all interests and stamp ${ORCH_DIR}/.last-registration.json
+# with the current ticket set + ts. Phase 3 (CTL-491) extends --refresh with
+# diff semantics; for now --refresh is equivalent to the unconditional path.
+#
+# Exit codes: 0 (success or broker-down no-op), 2 (bad args).
+#
+# Environment overrides (for tests):
+#   CATALYST_STATE_SCRIPT  path to catalyst-state.sh (default: sibling)
+#   PATH                   any fake catalyst-broker / catalyst-filter / gh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
+
+ORCH_DIR=""
+ORCH_ID=""
+CONFIG_PATH=""
+REFRESH=0
+
+usage() {
+  sed -n '2,25p' "$0"
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir) ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)  ORCH_ID="$2";  shift 2 ;;
+    --config)   CONFIG_PATH="$2"; shift 2 ;;
+    --refresh)  REFRESH=1; shift ;;
+    -h|--help)  usage 0 ;;
+    *)          echo "ERROR: unknown arg: $1" >&2; usage 2 ;;
+  esac
+done
+
+[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
+[ -z "$ORCH_ID" ]  && { echo "ERROR: --orch-id required" >&2; exit 2; }
+[ ! -d "$ORCH_DIR" ] && { echo "ERROR: orch-dir does not exist: $ORCH_DIR" >&2; exit 2; }
+
+# Broker gate — same as the inline block in orchestrate/SKILL.md. If neither
+# the broker nor the filter daemon is running, registration is a no-op
+# (consumers fall back to direct catalyst-events wait-for).
+if ! command -v catalyst-broker >/dev/null 2>&1 \
+   && ! command -v catalyst-filter >/dev/null 2>&1; then
+  exit 0
+fi
+if ! catalyst-broker status >/dev/null 2>&1 \
+   && ! catalyst-filter status >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Read dispatchMode from config (default: oneshot-legacy — matches the
+# original SKILL.md gate; phase_lifecycle interests only emit in phase-agents).
+DISPATCH_MODE="oneshot-legacy"
+if [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ]; then
+  DISPATCH_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // "oneshot-legacy"' \
+    "$CONFIG_PATH" 2>/dev/null || echo "oneshot-legacy")
+fi
+
+# Compute the active ticket / PR set from worker signal files.
+shopt -s nullglob
+WORKER_FILES=( "${ORCH_DIR}/workers/"*.json )
+shopt -u nullglob
+
+if [ ${#WORKER_FILES[@]} -gt 0 ]; then
+  ACTIVE_PRS=$(jq -rs '[.[].pr.number // empty] | unique' "${WORKER_FILES[@]}" 2>/dev/null || echo '[]')
+  ACTIVE_TICKETS=$(jq -rs '[.[].ticket // empty]' "${WORKER_FILES[@]}" 2>/dev/null || echo '[]')
+  ACTIVE_BASES=$(jq -rs '[
+    .[] | select(.pr.number != null and .pr.baseRefName != null)
+        | {pr: .pr.number, base: .pr.baseRefName}
+  ]' "${WORKER_FILES[@]}" 2>/dev/null || echo '[]')
+else
+  ACTIVE_PRS='[]'
+  ACTIVE_TICKETS='[]'
+  ACTIVE_BASES='[]'
+fi
+
+REPO_FULL_NAME=""
+if command -v gh >/dev/null 2>&1; then
+  REPO_FULL_NAME=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+fi
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+emit_event() {
+  if [ -x "$STATE_SCRIPT" ]; then
+    "$STATE_SCRIPT" event "$1" >/dev/null 2>&1 || true
+  fi
+}
+
+# ─── Emit deterministic interests (pr / ticket / comms) ─────────────────────
+
+emit_event "$(jq -nc \
+  --arg orch "$ORCH_ID" \
+  --arg id   "${ORCH_ID}-pr-lifecycle" \
+  --arg notify "filter.wake.${ORCH_ID}" \
+  --arg ts "$(now_iso)" \
+  --arg repo "$REPO_FULL_NAME" \
+  --argjson prs "$ACTIVE_PRS" \
+  --argjson bases "$ACTIVE_BASES" \
+  '{
+    ts: $ts,
+    event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $id,
+      interest_type: "pr_lifecycle",
+      notify_event: $notify,
+      persistent: true,
+      pr_numbers: $prs,
+      repo: $repo,
+      base_branches: $bases
+    }
+  }')"
+
+emit_event "$(jq -nc \
+  --arg orch "$ORCH_ID" \
+  --arg id   "${ORCH_ID}-ticket-lifecycle" \
+  --arg notify "filter.wake.${ORCH_ID}" \
+  --arg ts "$(now_iso)" \
+  --argjson tickets "$ACTIVE_TICKETS" \
+  '{
+    ts: $ts,
+    event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $id,
+      interest_type: "ticket_lifecycle",
+      notify_event: $notify,
+      persistent: true,
+      tickets: $tickets,
+      wake_on: ["status_done", "status_in_review", "status_changed"]
+    }
+  }')"
+
+emit_event "$(jq -nc \
+  --arg orch "$ORCH_ID" \
+  --arg id   "${ORCH_ID}-comms-lifecycle" \
+  --arg notify "filter.wake.${ORCH_ID}" \
+  --arg ts "$(now_iso)" \
+  --arg channel "$ORCH_ID" \
+  --argjson workers "$ACTIVE_TICKETS" \
+  '{
+    ts: $ts,
+    event: "filter.register",
+    orchestrator: $orch,
+    worker: null,
+    detail: {
+      interest_id: $id,
+      interest_type: "comms_lifecycle",
+      notify_event: $notify,
+      persistent: true,
+      channel: $channel,
+      subscriber_kind: "orchestrator",
+      owned_workers: $workers,
+      types_of_interest: ["attention", "done"]
+    }
+  }')"
+
+# ─── Emit phase_lifecycle interests (one per ticket, gated by mode) ─────────
+
+if [ "$DISPATCH_MODE" = "phase-agents" ]; then
+  COUNT=$(jq 'length' <<< "$ACTIVE_TICKETS" 2>/dev/null || echo 0)
+  if [ "$COUNT" -gt 0 ]; then
+    while IFS= read -r T; do
+      [ -z "$T" ] && continue
+      emit_event "$(jq -nc \
+        --arg orch "$ORCH_ID" \
+        --arg id   "${ORCH_ID}-phase-lifecycle-${T}" \
+        --arg notify "filter.wake.${ORCH_ID}" \
+        --arg ts "$(now_iso)" \
+        --arg ticket "$T" \
+        --argjson phases '["triage","research","plan","implement","verify","review","pr","monitor-merge","monitor-deploy"]' \
+        '{
+          ts: $ts,
+          event: "filter.register",
+          orchestrator: $orch,
+          worker: null,
+          detail: {
+            interest_id: $id,
+            interest_type: "phase_lifecycle",
+            notify_event: $notify,
+            persistent: true,
+            ticket: $ticket,
+            phase_names: $phases
+          }
+        }')"
+    done < <(jq -r '.[]' <<< "$ACTIVE_TICKETS")
+  fi
+fi
+
+# ─── Write/update .last-registration.json ───────────────────────────────────
+# Always rewrite on success so the Phase 4 refresh can diff against current.
+LAST_FILE="${ORCH_DIR}/.last-registration.json"
+TMP="${LAST_FILE}.tmp.$$"
+jq -nc \
+  --argjson prs "$ACTIVE_PRS" \
+  --argjson tickets "$ACTIVE_TICKETS" \
+  --arg ts "$(now_iso)" \
+  '{prs: $prs, tickets: ($tickets | unique), registeredAt: $ts}' \
+  > "$TMP" 2>/dev/null && mv "$TMP" "$LAST_FILE" || rm -f "$TMP"
+
+exit 0

--- a/plugins/dev/scripts/orchestrate-register-interests.sh
+++ b/plugins/dev/scripts/orchestrate-register-interests.sh
@@ -104,8 +104,10 @@ fi
 # (emits everything) so a mid-run upgrade still produces durable interests.
 
 LAST_FILE="${ORCH_DIR}/.last-registration.json"
-EMIT_DETERMINISTIC=1
 # Default phase_lifecycle emission set = all active tickets (initial mode).
+# The 3 deterministic interests (pr/ticket/comms) are always emitted when we
+# reach the emit block below — the only thing the refresh diff narrows is the
+# phase_lifecycle set.
 PHASE_TICKETS_JSON="$ACTIVE_TICKETS"
 
 if [ "$REFRESH" = "1" ] && [ -f "$LAST_FILE" ]; then
@@ -243,12 +245,18 @@ fi
 
 # ─── Write/update .last-registration.json ───────────────────────────────────
 # Always rewrite on success so the Phase 4 refresh can diff against current.
+# Use an explicit if/else rather than && || (SC2015) so a successful jq write
+# whose mv happens to fail is never mistaken for a jq failure.
 TMP="${LAST_FILE}.tmp.$$"
-jq -nc \
-  --argjson prs "$ACTIVE_PRS" \
-  --argjson tickets "$ACTIVE_TICKETS" \
-  --arg ts "$(now_iso)" \
-  '{prs: $prs, tickets: ($tickets | unique), registeredAt: $ts}' \
-  > "$TMP" 2>/dev/null && mv "$TMP" "$LAST_FILE" || rm -f "$TMP"
+if jq -nc \
+     --argjson prs "$ACTIVE_PRS" \
+     --argjson tickets "$ACTIVE_TICKETS" \
+     --arg ts "$(now_iso)" \
+     '{prs: $prs, tickets: ($tickets | unique), registeredAt: $ts}' \
+     > "$TMP" 2>/dev/null; then
+  mv "$TMP" "$LAST_FILE"
+else
+  rm -f "$TMP"
+fi
 
 exit 0

--- a/plugins/dev/scripts/orchestrate-register-interests.sh
+++ b/plugins/dev/scripts/orchestrate-register-interests.sh
@@ -95,6 +95,39 @@ if command -v gh >/dev/null 2>&1; then
   REPO_FULL_NAME=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 fi
 
+# ─── Refresh-mode diff (CTL-491 Phase 3) ────────────────────────────────────
+# When --refresh is set AND a previous registration exists at
+# .last-registration.json, diff the current active set against the prior set.
+# If nothing changed, exit 0 without emitting events. Otherwise emit the 3
+# deterministic interests AND a phase_lifecycle ONLY for newly-added tickets.
+# If no baseline exists, --refresh behaves like the initial registration
+# (emits everything) so a mid-run upgrade still produces durable interests.
+
+LAST_FILE="${ORCH_DIR}/.last-registration.json"
+EMIT_DETERMINISTIC=1
+# Default phase_lifecycle emission set = all active tickets (initial mode).
+PHASE_TICKETS_JSON="$ACTIVE_TICKETS"
+
+if [ "$REFRESH" = "1" ] && [ -f "$LAST_FILE" ]; then
+  LAST_PRS=$(jq -c '.prs // []' "$LAST_FILE" 2>/dev/null || echo '[]')
+  LAST_TICKETS=$(jq -c '.tickets // []' "$LAST_FILE" 2>/dev/null || echo '[]')
+
+  CUR_PRS_N=$(jq -cS '.' <<< "$ACTIVE_PRS" 2>/dev/null || echo "$ACTIVE_PRS")
+  CUR_TKT_N=$(jq -cS '.' <<< "$ACTIVE_TICKETS" 2>/dev/null || echo "$ACTIVE_TICKETS")
+  LAST_PRS_N=$(jq -cS '.' <<< "$LAST_PRS" 2>/dev/null || echo "$LAST_PRS")
+  LAST_TKT_N=$(jq -cS '.' <<< "$LAST_TICKETS" 2>/dev/null || echo "$LAST_TICKETS")
+
+  if [ "$CUR_PRS_N" = "$LAST_PRS_N" ] && [ "$CUR_TKT_N" = "$LAST_TKT_N" ]; then
+    # Nothing changed — emit nothing, leave .last-registration.json alone.
+    exit 0
+  fi
+
+  # Phase_lifecycle is emitted only for NEW tickets (the broker already has
+  # interests for existing tickets via the initial pre-dispatch registration).
+  PHASE_TICKETS_JSON=$(jq -c --argjson old "$LAST_TICKETS" '. - $old' \
+    <<< "$ACTIVE_TICKETS" 2>/dev/null || echo "$ACTIVE_TICKETS")
+fi
+
 now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 emit_event() {
@@ -175,9 +208,11 @@ emit_event "$(jq -nc \
   }')"
 
 # ─── Emit phase_lifecycle interests (one per ticket, gated by mode) ─────────
+# In --refresh mode, PHASE_TICKETS_JSON contains only newly-added tickets;
+# in initial mode, it equals ACTIVE_TICKETS.
 
 if [ "$DISPATCH_MODE" = "phase-agents" ]; then
-  COUNT=$(jq 'length' <<< "$ACTIVE_TICKETS" 2>/dev/null || echo 0)
+  COUNT=$(jq 'length' <<< "$PHASE_TICKETS_JSON" 2>/dev/null || echo 0)
   if [ "$COUNT" -gt 0 ]; then
     while IFS= read -r T; do
       [ -z "$T" ] && continue
@@ -202,13 +237,12 @@ if [ "$DISPATCH_MODE" = "phase-agents" ]; then
             phase_names: $phases
           }
         }')"
-    done < <(jq -r '.[]' <<< "$ACTIVE_TICKETS")
+    done < <(jq -r '.[]' <<< "$PHASE_TICKETS_JSON")
   fi
 fi
 
 # ─── Write/update .last-registration.json ───────────────────────────────────
 # Always rewrite on success so the Phase 4 refresh can diff against current.
-LAST_FILE="${ORCH_DIR}/.last-registration.json"
 TMP="${LAST_FILE}.tmp.$$"
 jq -nc \
   --argjson prs "$ACTIVE_PRS" \

--- a/plugins/dev/scripts/orchestrate-replay-phase-events.sh
+++ b/plugins/dev/scripts/orchestrate-replay-phase-events.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# orchestrate-replay-phase-events.sh (CTL-491) — one-shot replay of any
+# phase.*.{complete,failed,turn-cap-exhausted}.<TICKET> events that landed in
+# the catalyst event log between the orchestrator's startup line cursor and
+# the current end-of-file. Routes each event through orchestrate-phase-advance
+# (complete) or orchestrate-revive (failed | turn-cap-exhausted).
+#
+# Defends against any future re-introduction of the CTL-491 race window. With
+# the Phase 1 fix in place, this script's output should be empty in steady
+# state — but its idempotent behavior means running it on every Phase 4 entry
+# is safe and cheap.
+#
+# Usage:
+#   orchestrate-replay-phase-events.sh --orch-dir <path> --orch-id <id>
+#
+# Reads from:
+#   ${ORCH_DIR}/state.json    .race.startLineCursor (number), .race.startEventsFile (path)
+#   ${ORCH_DIR}/workers/*.json    active ticket set (cross-orch filter)
+#   ${CATALYST_EVENTS_DIR}/$(date +%Y-%m).jsonl    current month's event log
+#
+# Exit codes:
+#   0  success (including empty window)
+#   1  baseline missing from state.json (refuses to silently scan entire log)
+#   2  bad args
+#
+# Environment overrides (for tests):
+#   CATALYST_PHASE_ADVANCE_BIN  path to orchestrate-phase-advance (default: sibling)
+#   CATALYST_REVIVE_BIN         path to orchestrate-revive (default: sibling)
+#   CATALYST_EVENTS_DIR         events directory (default: $HOME/catalyst/events)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADVANCE_BIN="${CATALYST_PHASE_ADVANCE_BIN:-${SCRIPT_DIR}/orchestrate-phase-advance}"
+REVIVE_BIN="${CATALYST_REVIVE_BIN:-${SCRIPT_DIR}/orchestrate-revive}"
+EVENTS_DIR="${CATALYST_EVENTS_DIR:-${HOME}/catalyst/events}"
+
+ORCH_DIR=""
+ORCH_ID=""
+
+usage() {
+  sed -n '2,28p' "$0"
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir) ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)  ORCH_ID="$2";  shift 2 ;;
+    -h|--help)  usage 0 ;;
+    *)          echo "ERROR: unknown arg: $1" >&2; usage 2 ;;
+  esac
+done
+
+[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
+[ -z "$ORCH_ID" ]  && { echo "ERROR: --orch-id required" >&2; exit 2; }
+[ ! -d "$ORCH_DIR" ] && { echo "ERROR: orch-dir does not exist: $ORCH_DIR" >&2; exit 2; }
+
+STATE_FILE="${ORCH_DIR}/state.json"
+[ -f "$STATE_FILE" ] || { echo "ERROR: state.json missing at $STATE_FILE — baseline-missing" >&2; exit 1; }
+
+# Read baseline cursor + file from state.json. Both must be present or we
+# refuse to scan the whole log silently.
+START_CURSOR=$(jq -r '.race.startLineCursor // empty' "$STATE_FILE" 2>/dev/null || echo "")
+START_FILE=$(jq -r '.race.startEventsFile // empty' "$STATE_FILE" 2>/dev/null || echo "")
+if [ -z "$START_CURSOR" ] || [ -z "$START_FILE" ]; then
+  echo "ERROR: state.json.race.{startLineCursor,startEventsFile} missing — baseline-missing" >&2
+  exit 1
+fi
+
+# Active ticket set from workers/*.json.
+shopt -s nullglob
+WORKER_FILES=( "${ORCH_DIR}/workers/"*.json )
+shopt -u nullglob
+if [ ${#WORKER_FILES[@]} -eq 0 ]; then
+  # No active workers — nothing to route to. Exit 0 (empty window).
+  exit 0
+fi
+ACTIVE_TICKETS_JSON=$(jq -rs '[.[].ticket // empty] | unique' "${WORKER_FILES[@]}" 2>/dev/null || echo '[]')
+
+# Current month's events file. Derived from the SAME directory as the
+# baseline file (so callers don't need to keep $CATALYST_EVENTS_DIR in sync
+# with whatever path was captured at startup). If the baseline file is the
+# same as the current file, scan it from $START_CURSOR forward. Otherwise
+# (month rollover) scan the tail of the baseline file from $START_CURSOR to
+# its EOF, then scan the current file from line 1.
+CURRENT_MONTH=$(date -u +%Y-%m)
+CURRENT_FILE="$(dirname "$START_FILE")/${CURRENT_MONTH}.jsonl"
+
+# Stream the matching event lines to stdout for processing.
+stream_events() {
+  if [ "$START_FILE" = "$CURRENT_FILE" ]; then
+    if [ -f "$START_FILE" ]; then
+      tail -n +$((START_CURSOR + 1)) "$START_FILE"
+    fi
+  else
+    # Month rollover: tail the baseline file from cursor+1, then the current
+    # file from the beginning.
+    [ -f "$START_FILE" ]   && tail -n +$((START_CURSOR + 1)) "$START_FILE"
+    [ -f "$CURRENT_FILE" ] && cat "$CURRENT_FILE"
+  fi
+}
+
+# Match the canonical event-name regex from broker/index.mjs:1302.
+# phase.<phase>.<status>.<ticket>
+PHASE_REGEX='^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted)\.([A-Za-z][A-Za-z0-9_]*-[0-9]+)$'
+
+REVIVE_TRIGGERED=0  # we only need to invoke revive ONCE per replay regardless
+                    # of how many failed/turn-cap events we see — revive scans
+                    # all workers itself.
+
+while IFS= read -r LINE; do
+  [ -z "$LINE" ] && continue
+
+  # Extract event name. Tolerate malformed JSON lines by skipping with stderr.
+  NAME=$(echo "$LINE" | jq -r '.attributes."event.name" // .name // ""' 2>/dev/null)
+  if [ -z "$NAME" ]; then
+    # Could be malformed JSON or non-OTel envelope. Warn and continue.
+    if ! echo "$LINE" | jq -e . >/dev/null 2>&1; then
+      echo "WARN: skipping malformed event-log line" >&2
+    fi
+    continue
+  fi
+
+  # Quick prefix check before the regex.
+  case "$NAME" in
+    phase.*) ;;
+    *) continue ;;
+  esac
+
+  if [[ "$NAME" =~ $PHASE_REGEX ]]; then
+    PHASE_NAME="${BASH_REMATCH[1]}"
+    STATUS="${BASH_REMATCH[2]}"
+    TICKET="${BASH_REMATCH[3]}"
+  else
+    continue
+  fi
+
+  # Filter out cross-orchestrator tickets.
+  IN_ORCH=$(echo "$ACTIVE_TICKETS_JSON" | jq --arg t "$TICKET" 'index($t) != null' 2>/dev/null)
+  [ "$IN_ORCH" = "true" ] || continue
+
+  case "$STATUS" in
+    complete)
+      if [ -x "$ADVANCE_BIN" ]; then
+        "$ADVANCE_BIN" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+          --ticket "$TICKET" --completed-phase "$PHASE_NAME" >/dev/null 2>&1 || true
+      fi
+      ;;
+    failed|turn-cap-exhausted)
+      # orchestrate-revive scans all workers itself; we only need to invoke
+      # it once. Coalescing multiple failed/turn-cap events into a single
+      # invocation matches the live broker wake-handler behavior in
+      # orchestrate/SKILL.md (one revive call per wake regardless of how
+      # many failed workers).
+      if [ "$REVIVE_TRIGGERED" -eq 0 ] && [ -x "$REVIVE_BIN" ]; then
+        "$REVIVE_BIN" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+          >/dev/null 2>&1 || true
+        REVIVE_TRIGGERED=1
+      fi
+      ;;
+  esac
+done < <(stream_events)
+
+exit 0

--- a/plugins/dev/scripts/orchestrate-replay-phase-events.sh
+++ b/plugins/dev/scripts/orchestrate-replay-phase-events.sh
@@ -33,7 +33,11 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ADVANCE_BIN="${CATALYST_PHASE_ADVANCE_BIN:-${SCRIPT_DIR}/orchestrate-phase-advance}"
 REVIVE_BIN="${CATALYST_REVIVE_BIN:-${SCRIPT_DIR}/orchestrate-revive}"
-EVENTS_DIR="${CATALYST_EVENTS_DIR:-${HOME}/catalyst/events}"
+# CATALYST_EVENTS_DIR overrides the directory the helper scans for the current
+# month's event log. When unset, the directory is derived from the baseline
+# file path captured in state.json.race.startEventsFile — this is the common
+# case in production. The env var is honored for tests that mock the events
+# directory and for callers who keep the events dir somewhere non-default.
 
 ORCH_DIR=""
 ORCH_ID=""
@@ -85,7 +89,10 @@ ACTIVE_TICKETS_JSON=$(jq -rs '[.[].ticket // empty] | unique' "${WORKER_FILES[@]
 # (month rollover) scan the tail of the baseline file from $START_CURSOR to
 # its EOF, then scan the current file from line 1.
 CURRENT_MONTH=$(date -u +%Y-%m)
-CURRENT_FILE="$(dirname "$START_FILE")/${CURRENT_MONTH}.jsonl"
+# Prefer CATALYST_EVENTS_DIR when set (tests + non-default deployments);
+# otherwise derive from the baseline file's directory.
+CURRENT_DIR="${CATALYST_EVENTS_DIR:-$(dirname "$START_FILE")}"
+CURRENT_FILE="${CURRENT_DIR}/${CURRENT_MONTH}.jsonl"
 
 # Stream the matching event lines to stdout for processing.
 stream_events() {

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -501,6 +501,24 @@ fi
 
 For each provisioned worker worktree, dispatch a `/oneshot` session.
 
+**Register broker filter interests BEFORE dispatch (CTL-491):** Phase-agent workers can finish in
+well under a second when their work is a no-op (e.g. an already-triaged ticket). Emitting
+`filter.register` events AFTER dispatch opens a race window where the broker's interest map is
+still empty when `phase.<name>.complete.<TICKET>` arrives — `processEvent` early-returns and the
+event is dropped silently (`broker/index.mjs:1782`). Run the registration helper here so all four
+deterministic + per-ticket interests are durable in the broker BEFORE any `claude --bg`
+invocation. Idempotent at the broker (upserts by `interest_id`); the Phase 4 entry re-invokes
+the same helper as a belt-and-suspenders.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-register-interests.sh" \
+  --orch-dir "${ORCH_DIR}" \
+  --orch-id "${ORCH_NAME}" \
+  --config "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.catalyst/config.json"
+# Soft-fail-safe: helper exits 0 when broker/filter daemon is down (no-op) and
+# 2 only on argument errors. See plugins/dev/scripts/orchestrate-register-interests.sh.
+```
+
 **Emit dispatching status (CTL-405):** Before launching workers, announce the phase:
 
 ```bash
@@ -855,11 +873,13 @@ TOTAL_COUNT=$(jq -rs 'length' "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo 0
   --summary "wave ${CURRENT_WAVE:-1} monitoring (${ACTIVE_COUNT}/${TOTAL_COUNT} active)" 2>/dev/null || true
 ```
 
-**Register with catalyst-broker daemon (CTL-257, updated CTL-303, CTL-357, CTL-452):** When
-`catalyst-broker status` returns 0, emit `filter.register` events at Phase 4 start so the daemon
-pre-filters incoming events and emits targeted `filter.wake.{ORCH_NAME}` events. Workers
-auto-correlate their own `pr_lifecycle` interests via `agent.checkin`; the orchestrator registers
-four deterministic interests for itself — all of them route without Groq:
+**Re-register with catalyst-broker daemon (CTL-257, CTL-303, CTL-357, CTL-452, CTL-491):** Phase 3
+already invoked `orchestrate-register-interests.sh` BEFORE worker dispatch (the CTL-491 race-fix
+hoist). This Phase 4 entry calls the same helper again as a belt-and-suspenders — registration is
+idempotent at the broker (upserts by `interest_id`), and a second invocation ensures the four
+interests stay fresh even if the broker restarted between Phase 3 and Phase 4.
+
+The helper emits four deterministic interests (route without Groq):
 
 - `pr_lifecycle` — orchestrator-level aggregation across all worker PRs.
 - `ticket_lifecycle` — Linear ticket state changes for the orchestrator's tickets.
@@ -868,143 +888,20 @@ four deterministic interests for itself — all of them route without Groq:
   `phase.<name>.failed.<TICKET>`, and `phase.<name>.turn-cap-exhausted.<TICKET>` events emitted
   by phase agents. One interest per active ticket, covering all 9 phase names. The turn-cap status
   routes through `orchestrate-revive`'s continuation branch (separate budget from error revives).
+  Only registered when `catalyst.orchestration.dispatchMode = "phase-agents"`.
 
 CTL-357 retired the Groq prose interest (~95% false-positive rate). All four interests share the
 same `notify_event: "filter.wake.${ORCH_NAME}"`, so the orchestrator's `wait-for` filter does not
 change.
 
 ```bash
-if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
-  ACTIVE_PRS=$(jq -rs '[.[].pr.number // empty] | unique' \
-    "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-  ACTIVE_TICKETS=$(jq -rs '[.[].ticket // empty]' \
-    "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-  ACTIVE_BRANCHES_ARR=()
-  for _WSIG in "${ORCH_DIR}/workers/"*.json; do
-    _WTKT=$(jq -r '.ticket' "$_WSIG")
-    _WDIR="${WORKTREE_BASE}/${ORCH_NAME}-${_WTKT}"
-    _WBRANCH=$(git -C "$_WDIR" branch --show-current 2>/dev/null || true)
-    [ -n "$_WBRANCH" ] && ACTIVE_BRANCHES_ARR+=("$_WBRANCH")
-  done
-  ACTIVE_BRANCHES_JSON=$(printf '%s\n' "${ACTIVE_BRANCHES_ARR[@]}" \
-    | jq -Rnc '[inputs]' 2>/dev/null || echo '[]')
-
-  REPO_FULL_NAME=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
-  ACTIVE_BASES_JSON=$(jq -rs '[
-    .[] | select(.pr.number != null and .pr.baseRefName != null)
-        | {pr: .pr.number, base: .pr.baseRefName}
-  ]' "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-
-  # CTL-284: pr_lifecycle interest (deterministic PR/CI/review/deployment routing)
-  "$STATE_SCRIPT" event "$(jq -nc \
-    --arg orch "${ORCH_NAME}" \
-    --arg id "${ORCH_NAME}-pr-lifecycle" \
-    --arg notify "filter.wake.${ORCH_NAME}" \
-    --arg repo "${REPO_FULL_NAME}" \
-    --argjson prs "${ACTIVE_PRS}" \
-    --argjson bases "${ACTIVE_BASES_JSON}" \
-    '{
-      ts: (now | todate),
-      event: "filter.register",
-      orchestrator: $orch,
-      worker: null,
-      detail: {
-        interest_id: $id,
-        interest_type: "pr_lifecycle",
-        notify_event: $notify,
-        persistent: true,
-        pr_numbers: $prs,
-        repo: $repo,
-        base_branches: $bases
-      }
-    }')"
-
-  # CTL-303: ticket_lifecycle interest (deterministic Linear routing — replaces
-  # the "Linear ticket status changes" part of the old prose prompt)
-  "$STATE_SCRIPT" event "$(jq -nc \
-    --arg orch "${ORCH_NAME}" \
-    --arg id "${ORCH_NAME}-ticket-lifecycle" \
-    --arg notify "filter.wake.${ORCH_NAME}" \
-    --argjson tickets "${ACTIVE_TICKETS}" \
-    '{
-      ts: (now | todate),
-      event: "filter.register",
-      orchestrator: $orch,
-      worker: null,
-      detail: {
-        interest_id: $id,
-        interest_type: "ticket_lifecycle",
-        notify_event: $notify,
-        persistent: true,
-        tickets: $tickets,
-        wake_on: ["status_done", "status_in_review", "status_changed"]
-      }
-    }')"
-
-  # CTL-357: comms_lifecycle interest (deterministic comms routing — replaces
-  # the "any of my workers posts a comms message of type attention" part of the
-  # old prose prompt). Defaults types_of_interest to ["attention","done"] at the
-  # broker; we set it explicitly here for clarity.
-  "$STATE_SCRIPT" event "$(jq -nc \
-    --arg orch "${ORCH_NAME}" \
-    --arg id "${ORCH_NAME}-comms-lifecycle" \
-    --arg notify "filter.wake.${ORCH_NAME}" \
-    --arg channel "${ORCH_NAME}" \
-    --argjson workers "${ACTIVE_TICKETS}" \
-    '{
-      ts: (now | todate),
-      event: "filter.register",
-      orchestrator: $orch,
-      worker: null,
-      detail: {
-        interest_id: $id,
-        interest_type: "comms_lifecycle",
-        notify_event: $notify,
-        persistent: true,
-        channel: $channel,
-        subscriber_kind: "orchestrator",
-        owned_workers: $workers,
-        types_of_interest: ["attention", "done"]
-      }
-    }')"
-
-  # CTL-452: phase_lifecycle interest — one per active ticket, covering all
-  # 9 canonical phase names. The broker fires filter.wake.${ORCH_NAME} on
-  # both phase.<name>.complete.<TICKET> and phase.<name>.failed.<TICKET>.
-  # The wake handler below resolves the next phase via orchestrate-phase-advance
-  # (complete) or escalates via orchestrate-revive then attention (failed).
-  #
-  # Only registered when catalyst.orchestration.dispatchMode = "phase-agents".
-  # In legacy oneshot-mode (the historical default), this block is a no-op.
-  DISPATCH_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // "oneshot-legacy"' \
-    "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.catalyst/config.json" \
-    2>/dev/null || echo "oneshot-legacy")
-  if [ "$DISPATCH_MODE" = "phase-agents" ]; then
-    while IFS= read -r TICKET; do
-      [ -z "$TICKET" ] && continue
-      "$STATE_SCRIPT" event "$(jq -nc \
-        --arg orch "${ORCH_NAME}" \
-        --arg id "${ORCH_NAME}-phase-lifecycle-${TICKET}" \
-        --arg notify "filter.wake.${ORCH_NAME}" \
-        --arg ticket "$TICKET" \
-        --argjson phases '["triage","research","plan","implement","verify","review","pr","monitor-merge","monitor-deploy"]' \
-        '{
-          ts: (now | todate),
-          event: "filter.register",
-          orchestrator: $orch,
-          worker: null,
-          detail: {
-            interest_id: $id,
-            interest_type: "phase_lifecycle",
-            notify_event: $notify,
-            persistent: true,
-            ticket: $ticket,
-            phase_names: $phases
-          }
-        }')"
-    done < <(jq -r '.[]' <<< "${ACTIVE_TICKETS}")
-  fi
-fi
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-register-interests.sh" \
+  --orch-dir "${ORCH_DIR}" \
+  --orch-id "${ORCH_NAME}" \
+  --config "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.catalyst/config.json"
+# Helper internals: see plugins/dev/scripts/orchestrate-register-interests.sh
+# for the exact wire format of each filter.register event. Soft-fails (exit 0)
+# when neither catalyst-broker nor catalyst-filter is running.
 ```
 
 **Phase 4 is event-driven, not poll-driven (CTL-210, CTL-243).** The orchestrator subscribes to the

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -1397,111 +1397,31 @@ REMEDIATION_EOF
 done
 ```
 
-**Refresh broker registration when PR set has changed (CTL-341, CTL-357).** The Phase 4 start block
-above registers the orchestrator's `pr_lifecycle` interest with whatever PRs the worker signal files
-happen to expose at that moment — often the empty set, because workers have not yet opened PRs.
-Without an unconditional refresh, that empty `pr_numbers` list would persist for the entire
-orchestration run and the deterministic route in `tryDeterministicRoute` would never match. The
-merge-confirmation loop above can discover a missing `pr.number` from a worker's branch, but that
-path does not run when the worker writes its own `pr.number` before the orchestrator wakes (the
-common case in the worker-driven flow). This block runs every Phase 4 wake-up, computes the union of
-`worker.pr.number` across the signal files, diffs against the set last sent to the broker, and
-re-emits all three deterministic `filter.register` events (`pr_lifecycle`, `ticket_lifecycle`,
-`comms_lifecycle`) only when the set has changed. Idempotent at the broker (upserts by
-`interest_id`); the diff just keeps the event log quiet.
+**Refresh broker registration when PR or ticket set has changed (CTL-341, CTL-357, CTL-491).** On
+every Phase 4 wake-up, re-invoke the same registration helper with `--refresh`. The helper diffs
+the current active PR + ticket sets against the prior `.last-registration.json` baseline:
+
+- If nothing changed, the helper exits 0 with zero events emitted — keeps the event log quiet.
+- If the PR set changed (a worker just opened a PR), it re-emits all three deterministic
+  interests (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`) with the updated set.
+- If the ticket set grew (wave 2 dispatched new workers mid-run), it ALSO emits a
+  `phase_lifecycle` interest for each newly-added ticket. Existing tickets already have
+  per-ticket interests upserted at the broker from the initial pre-dispatch registration.
+- Idempotent at the broker (upserts by `interest_id`); the diff just keeps the event log quiet.
+
+This block replaces the older `.last-pr-registration.json` PR-only refresh path — the helper
+covers both deterministic-set refreshes AND the previously-missing `phase_lifecycle` refresh that
+would otherwise leave wave 2 tickets without broker coverage (a localized CTL-491 race).
 
 ```bash
-if catalyst-broker status >/dev/null 2>&1 || catalyst-filter status >/dev/null 2>&1; then
-  _UPD_PRS=$(jq -rs '[.[].pr.number // empty] | unique' \
-    "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-  _LAST_FILE="${ORCH_DIR}/.last-pr-registration.json"
-  _LAST_PRS=$(jq -c '.prs // []' "$_LAST_FILE" 2>/dev/null || echo '[]')
-
-  if [ "$(printf '%s' "$_UPD_PRS" | jq -cS '.')" != "$(printf '%s' "$_LAST_PRS" | jq -cS '.')" ]; then
-    _UPD_TICKETS=$(jq -rs '[.[].ticket // empty]' \
-      "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-    _UPD_BASES=$(jq -rs '[
-      .[] | select(.pr.number != null and .pr.baseRefName != null)
-          | {pr: .pr.number, base: .pr.baseRefName}
-    ]' "${ORCH_DIR}/workers/"*.json 2>/dev/null || echo '[]')
-    _UPD_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
-
-    # CTL-284: pr_lifecycle interest (deterministic PR/CI/review/deployment routing)
-    "$STATE_SCRIPT" event "$(jq -nc \
-      --arg orch "${ORCH_NAME}" \
-      --arg id "${ORCH_NAME}-pr-lifecycle" \
-      --arg notify "filter.wake.${ORCH_NAME}" \
-      --arg repo "${_UPD_REPO}" \
-      --argjson prs "${_UPD_PRS}" \
-      --argjson bases "${_UPD_BASES}" \
-      '{
-        ts: (now | todate),
-        event: "filter.register",
-        orchestrator: $orch,
-        worker: null,
-        detail: {
-          interest_id: $id,
-          interest_type: "pr_lifecycle",
-          notify_event: $notify,
-          persistent: true,
-          pr_numbers: $prs,
-          repo: $repo,
-          base_branches: $bases
-        }
-      }')" 2>/dev/null || true
-
-    # CTL-303: ticket_lifecycle interest (deterministic Linear routing)
-    "$STATE_SCRIPT" event "$(jq -nc \
-      --arg orch "${ORCH_NAME}" \
-      --arg id "${ORCH_NAME}-ticket-lifecycle" \
-      --arg notify "filter.wake.${ORCH_NAME}" \
-      --argjson tickets "${_UPD_TICKETS}" \
-      '{
-        ts: (now | todate),
-        event: "filter.register",
-        orchestrator: $orch,
-        worker: null,
-        detail: {
-          interest_id: $id,
-          interest_type: "ticket_lifecycle",
-          notify_event: $notify,
-          persistent: true,
-          tickets: $tickets,
-          wake_on: ["status_done", "status_in_review", "status_changed"]
-        }
-      }')" 2>/dev/null || true
-
-    # CTL-357: comms_lifecycle interest (deterministic comms routing — replaces
-    # the retired Groq prose interest for attention/done message routing)
-    "$STATE_SCRIPT" event "$(jq -nc \
-      --arg orch "${ORCH_NAME}" \
-      --arg id "${ORCH_NAME}-comms-lifecycle" \
-      --arg notify "filter.wake.${ORCH_NAME}" \
-      --arg channel "${ORCH_NAME}" \
-      --argjson workers "${_UPD_TICKETS}" \
-      '{
-        ts: (now | todate),
-        event: "filter.register",
-        orchestrator: $orch,
-        worker: null,
-        detail: {
-          interest_id: $id,
-          interest_type: "comms_lifecycle",
-          notify_event: $notify,
-          persistent: true,
-          channel: $channel,
-          subscriber_kind: "orchestrator",
-          owned_workers: $workers,
-          types_of_interest: ["attention", "done"]
-        }
-      }')" 2>/dev/null || true
-
-    # Record the new set so the next wake-up can diff.
-    printf '{"prs":%s,"registeredAt":"%s"}\n' \
-      "$_UPD_PRS" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${_LAST_FILE}.tmp" \
-      && mv "${_LAST_FILE}.tmp" "$_LAST_FILE"
-  fi
-fi
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-register-interests.sh" \
+  --orch-dir "${ORCH_DIR}" \
+  --orch-id "${ORCH_NAME}" \
+  --config "${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.catalyst/config.json" \
+  --refresh
+# In --refresh mode the helper is a no-op when the PR + ticket sets are
+# unchanged; otherwise it emits a minimal set of filter.register events to
+# bring the broker in sync. See plugins/dev/scripts/orchestrate-register-interests.sh.
 ```
 
 **Deploy state-machine sub-loop (CTL-211)** — runs on each wake-up for any worker in `merged` or

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -468,6 +468,25 @@ REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git
 The `CATALYST_ORCHESTRATOR_ID` is set to `${ORCH_NAME}` for use by workers (passed via environment
 variable alongside `CATALYST_ORCHESTRATOR_DIR`).
 
+**Capture event-log baseline (CTL-491):** Before any worker dispatch, snapshot the catalyst event
+log's current line count and file path. The Phase 4 replay step uses this to find any
+`phase.*.{complete,failed,turn-cap-exhausted}.<TICKET>` events that landed during the
+dispatch-to-monitor handoff. The new `state.json.race` object is opaque to older state.json
+consumers (they ignore unknown top-level fields via `.field // default` jq patterns).
+
+```bash
+EVENTS_DIR="${CATALYST_DIR:-$HOME/catalyst}/events"
+mkdir -p "$EVENTS_DIR"
+BASELINE_FILE="${EVENTS_DIR}/$(date -u +%Y-%m).jsonl"
+[[ -f "$BASELINE_FILE" ]] || : > "$BASELINE_FILE"
+BASELINE_LINE=$(wc -l < "$BASELINE_FILE" | tr -d ' ')
+TMP="${ORCH_DIR}/state.json.tmp.$$"
+jq --arg cursor "$BASELINE_LINE" --arg file "$BASELINE_FILE" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+   '.race = {startLineCursor: ($cursor | tonumber), startEventsFile: $file, capturedAt: $ts}' \
+   "${ORCH_DIR}/state.json" > "$TMP" \
+   && mv "$TMP" "${ORCH_DIR}/state.json" || rm -f "$TMP"
+```
+
 **Create the shared comms channel (CTL-111):** the orchestrator creates a file-based channel that
 every worker will auto-join via `CATALYST_COMMS_CHANNEL` in its dispatch env. Best-effort — the
 orchestrator does not crash if `catalyst-comms` is missing.
@@ -902,6 +921,24 @@ change.
 # Helper internals: see plugins/dev/scripts/orchestrate-register-interests.sh
 # for the exact wire format of each filter.register event. Soft-fails (exit 0)
 # when neither catalyst-broker nor catalyst-filter is running.
+```
+
+**Replay race-window phase events (CTL-491):** Before entering the event-driven wait loop, catch
+up on any `phase.<name>.{complete,failed,turn-cap-exhausted}.<TICKET>` events that landed between
+the Phase 2 baseline (`state.json.race.startLineCursor`) and now. With the Phase 3 pre-dispatch
+registration the window should be zero-length in steady state, but the replay is idempotent and
+cheap — it scans only the tail of the current month's event log past the baseline cursor and
+routes each match through `orchestrate-phase-advance` (for `complete`) or `orchestrate-revive`
+(for `failed` / `turn-cap-exhausted`). Cross-orchestrator events are filtered out by checking
+`workers/*.json` for the ticket.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-replay-phase-events.sh" \
+  --orch-dir "${ORCH_DIR}" \
+  --orch-id "${ORCH_NAME}" || true
+# Soft-fail with || true so a malformed event log or missing baseline can't
+# stall the orchestrator; the live Monitor/wait-for path picks up new events
+# regardless. The helper exits 1 only when state.json.race is missing.
 ```
 
 **Phase 4 is event-driven, not poll-driven (CTL-210, CTL-243).** The orchestrator subscribes to the


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-18T14:55:00Z -->
<!-- Last updated: 2026-05-18T14:55:00Z -->
<!-- PR: #859 -->
<!-- Previous commits: 02cc7630,5e9637c3,b6cf1f2e,34a4228a -->

## Summary

Closes the race window in phase-agents orchestrator mode where Phase 3 dispatched workers
**before** Phase 4 registered broker filter interests. Any worker that completed during the gap
emitted a `phase.<name>.complete.<TICKET>` event with zero matching interests at the broker, no
`filter.wake.${ORCH_NAME}` was generated, and the orchestrator silently stalled.

This was first hit in the phase-agents dogfood `orch-ctl-489-473-2026-05-17` where both triage
completions fired 30–60s before the broker had any interests to match, and recovery required
manual `orchestrate-phase-advance --completed-phase triage` for each ticket.

Fixes [CTL-491](https://linear.app/coalesce-labs/issue/CTL-491).

## Changes Made

### Ordering fix (Phase 1 — `02cc7630`)
- Hoist the four lifecycle interest registrations (`pr_lifecycle`, `ticket_lifecycle`,
  `comms_lifecycle`, `phase_lifecycle`) so they run **before** `phase-agent-dispatch` is invoked
  in the orchestrate skill's Phase 3.
- Phase 4 monitor is now armed before any worker can fire — matches the canonical convention
  from `catalyst-filter/SKILL.md:90` ("emit `filter.register` before entering your wait").
- Extracted the registration block into a dedicated helper
  `plugins/dev/scripts/orchestrate-register-interests.sh` so the same logic is reusable across
  initial-start and mid-run refresh paths.

### Belt-and-suspenders event replay (Phase 2 — `5e9637c3`)
- New helper `plugins/dev/scripts/orchestrate-replay-phase-events.sh` runs on Phase 4 entry and
  scans the event log from the orchestrator-start cursor forward, dispatching
  `orchestrate-phase-advance` / `orchestrate-revive` for any
  `phase.<name>.{complete,failed,turn-cap-exhausted}.<TICKET>` events that fired during the
  race window — even if the ordering fix above somehow leaves a gap.
- Cursor advances are persisted to `state.json.race` so a single race-window event is processed
  at most once across orchestrator restarts.
- Handles month rollover and unset/empty `startLineCursor` cases.

### Refresh helper diff semantics (Phase 3 — `b6cf1f2e`)
- `orchestrate-register-interests.sh --refresh` now diffs the current ticket set against
  `.last-registration.json` and emits exactly the interest deltas — no-op when ticket set is
  unchanged, register-only when a new ticket joins mid-run.
- Closes the gap where Phase 4's refresh block omitted `phase_lifecycle` (orchestrate
  SKILL.md:1476-1565) so mid-run ticket adds in phase-agents mode silently lost coverage for
  the new ticket.

### Cleanup (`34a4228a`)
- Clear shellcheck SC2034 (unused vars) and SC2015 (A && B || C anti-pattern) on the new
  helpers. Trunk lint now passes clean on the helper scripts.

## Tests

Four new bash test files (`plugins/dev/scripts/__tests__/`):

| File | Covers |
|---|---|
| `orchestrate-phase-ordering.test.sh` | Structural assertion that registration block precedes dispatch block in `orchestrate/SKILL.md` |
| `orchestrate-register-interests.test.sh` | Initial register emits 4 events; `--refresh` is no-op when set unchanged; `--refresh` emits only deltas for mid-run ticket adds |
| `orchestrate-replay-phase-events.test.sh` | Cursor advancement; no-op when cursor at EOF; revive coalescence on failed events; idempotent replay |
| `orchestrate-startup-baseline.test.sh` | `startLineCursor` captured correctly at orchestrator-start |

Net diff: **+1129 / -239** lines across 7 files.

## How to Verify It

- [x] All four new test files pass: `bash plugins/dev/scripts/__tests__/orchestrate-phase-ordering.test.sh && bash plugins/dev/scripts/__tests__/orchestrate-register-interests.test.sh && bash plugins/dev/scripts/__tests__/orchestrate-replay-phase-events.test.sh && bash plugins/dev/scripts/__tests__/orchestrate-startup-baseline.test.sh`
- [x] CI `audit-references`, `check-versions`, `validate` all green (job runs from this PR)
- [x] `trunk check` clean on the two new helper scripts
- [ ] Dogfood: run a second phase-agents orchestrator with two short-completing tickets — must advance both without manual `orchestrate-phase-advance` intervention (acceptance criterion from CTL-491)

## Reviewer Notes

Review left 14 deferred-to-human findings (`review.json`, all `medium`/`low` severity):
- Several relate to `jq` error suppression silently degrading the helpers to empty interest
  sets — worth addressing in a follow-up PR but not blockers for the race fix itself.
- A TOCTOU finding on `.last-registration.json` under rapid double-wake is theoretically
  possible; the broker's upsert keeps wire correctness intact even if the file write races.
- `wc -l` baseline cursor vs unterminated final newline: bounded impact since
  `orchestrate-phase-advance` / `orchestrate-revive` are documented idempotent.

These are tracked for a follow-up tidy-up pass and intentionally not bundled here to keep this
PR focused on the race fix.

## Changelog Entry

`fix(dev): close phase-agent orchestrator race window between filter-interest registration
and Phase 3 worker dispatch — workers that complete during the race window are now both
prevented (by ordering) and recovered (by event replay on Phase 4 entry). Adds
`orchestrate-register-interests.sh` and `orchestrate-replay-phase-events.sh` helpers with
covering tests.`

Refs: CTL-491
