### PR TITLE
CTL-493: orchestrate-revive phase-agent decision tree + per-phase iteration

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-state-attention.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-state-attention.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Shell tests for catalyst-state.sh attention --actionable flag (CTL-493 Phase 1).
+#
+# The new flag lets `orchestrate-revive`'s phase-agent recovery branch emit
+# unrecoverable failures with detail.actionable=false so HUD/monitor can render
+# them distinctly from operator-actionable attentions.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-state-attention.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+STATE_SCRIPT="${REPO_ROOT}/plugins/dev/scripts/catalyst-state.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t catalyst-state-attention-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+# Each test gets its own CATALYST_DIR so events files don't bleed across cases.
+mk_dir() {
+  local d="$SCRATCH/$1"
+  mkdir -p "$d"
+  echo "$d"
+}
+
+# Find this test run's most recent event line from the events dir.
+last_event_line() {
+  local events_dir="$1/events"
+  local f
+  f=$(ls -t "$events_dir"/*.jsonl 2>/dev/null | head -1)
+  [ -z "$f" ] && return 1
+  tail -n 1 "$f"
+}
+
+# Register a minimal orchestrator so cmd_attention has a target to mutate.
+register_orch() {
+  local orch_id="$1"
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  "$STATE_SCRIPT" register "$orch_id" "$(jq -nc \
+    --arg id "$orch_id" --arg ts "$ts" \
+    '{id:$id,projectKey:"k",repository:"r",baseBranch:"main",
+      status:"active",startedAt:$ts,lastHeartbeat:$ts,
+      worktreeDir:"/tmp",stateFile:"/tmp/x.json",progress:{},usage:{},
+      workers:{"T-x":{ticket:"T-x"}},attention:[]}')" >/dev/null
+}
+
+# ─── Test 1: --actionable false → detail.actionable == false ─────────────────
+echo "--- Test 1: --actionable false stamps actionable=false ---"
+export CATALYST_DIR="$(mk_dir cat1)"
+"$STATE_SCRIPT" init >/dev/null
+register_orch "orch-1"
+"$STATE_SCRIPT" attention "orch-1" "phase-failed-unrecoverable" "T-x" "msg" \
+  --actionable false >/dev/null
+LINE=$(last_event_line "$CATALYST_DIR" || echo "")
+if [ -z "$LINE" ]; then
+  fail "no event line written"
+else
+  # Note: `//` treats boolean `false` as absent, so use a presence-aware path
+  # that walks all known shapes and prints "" when the field is missing.
+  ACT=$(echo "$LINE" | jq -r '
+    if (.body.payload // null) | type == "object" and has("actionable") then
+      .body.payload.actionable | tostring
+    elif (.body // null) | type == "object" and has("actionable") then
+      .body.actionable | tostring
+    elif (.body.detail // null) | type == "object" and has("actionable") then
+      .body.detail.actionable | tostring
+    elif (.attributes // null) | type == "object" and has("event.actionable") then
+      .attributes."event.actionable" | tostring
+    else
+      ""
+    end')
+  if [ "$ACT" = "false" ]; then
+    pass "actionable=false stamped on event"
+  else
+    fail "actionable=false expected, got: '$ACT'" "line: $LINE"
+  fi
+fi
+
+# ─── Test 2: default (no flag) → actionable == true ──────────────────────────
+echo "--- Test 2: default flag-less invocation stamps actionable=true ---"
+export CATALYST_DIR="$(mk_dir cat2)"
+"$STATE_SCRIPT" init >/dev/null
+register_orch "orch-2"
+"$STATE_SCRIPT" attention "orch-2" "state-json-stale" "T-x" "stalled msg" >/dev/null
+LINE=$(last_event_line "$CATALYST_DIR" || echo "")
+if [ -z "$LINE" ]; then
+  fail "no event line written"
+else
+  # Note: `//` treats boolean `false` as absent, so use a presence-aware path
+  # that walks all known shapes and prints "" when the field is missing.
+  ACT=$(echo "$LINE" | jq -r '
+    if (.body.payload // null) | type == "object" and has("actionable") then
+      .body.payload.actionable | tostring
+    elif (.body // null) | type == "object" and has("actionable") then
+      .body.actionable | tostring
+    elif (.body.detail // null) | type == "object" and has("actionable") then
+      .body.detail.actionable | tostring
+    elif (.attributes // null) | type == "object" and has("event.actionable") then
+      .attributes."event.actionable" | tostring
+    else
+      ""
+    end')
+  if [ "$ACT" = "true" ]; then
+    pass "default actionable=true stamped on event"
+  else
+    fail "actionable=true expected by default, got: '$ACT'" "line: $LINE"
+  fi
+fi
+
+# ─── Test 3: invalid --actionable value rejected with non-zero exit ──────────
+echo "--- Test 3: invalid --actionable value rejected ---"
+export CATALYST_DIR="$(mk_dir cat3)"
+"$STATE_SCRIPT" init >/dev/null
+register_orch "orch-3"
+set +e
+"$STATE_SCRIPT" attention "orch-3" "phase-failed-unrecoverable" "T-x" "msg" \
+  --actionable maybe >/dev/null 2>&1
+RC=$?
+set -e
+if [ "$RC" -ne 0 ]; then
+  pass "invalid --actionable value exits non-zero"
+else
+  fail "invalid --actionable value should exit non-zero, got rc=$RC"
+fi
+
+# ─── Test 4: --actionable true explicit → actionable == true ─────────────────
+echo "--- Test 4: --actionable true (explicit) stamps actionable=true ---"
+export CATALYST_DIR="$(mk_dir cat4)"
+"$STATE_SCRIPT" init >/dev/null
+register_orch "orch-4"
+"$STATE_SCRIPT" attention "orch-4" "state-json-stale" "T-x" "msg" \
+  --actionable true >/dev/null
+LINE=$(last_event_line "$CATALYST_DIR" || echo "")
+if [ -z "$LINE" ]; then
+  fail "no event line written"
+else
+  # Note: `//` treats boolean `false` as absent, so use a presence-aware path
+  # that walks all known shapes and prints "" when the field is missing.
+  ACT=$(echo "$LINE" | jq -r '
+    if (.body.payload // null) | type == "object" and has("actionable") then
+      .body.payload.actionable | tostring
+    elif (.body // null) | type == "object" and has("actionable") then
+      .body.actionable | tostring
+    elif (.body.detail // null) | type == "object" and has("actionable") then
+      .body.detail.actionable | tostring
+    elif (.attributes // null) | type == "object" and has("event.actionable") then
+      .attributes."event.actionable" | tostring
+    else
+      ""
+    end')
+  if [ "$ACT" = "true" ]; then
+    pass "explicit --actionable true stamped"
+  else
+    fail "explicit --actionable true expected, got: '$ACT'" "line: $LINE"
+  fi
+fi
+
+echo ""
+echo "──────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "──────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-revive-phase-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive-phase-e2e.test.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# End-to-end tests for orchestrate-revive phase-agent recovery (CTL-493 Phase 4).
+#
+# Exercises the full healthcheck → revive → re-dispatch chain using fake
+# claude/state/dispatch binaries. Each scenario:
+#
+#   1. Creates a per-phase signal (status=running) + a stale state.json under
+#      ~/.claude/jobs/<bg_job_id>/ (via CATALYST_HEALTHCHECK_JOBS_ROOT).
+#   2. Runs orchestrate-healthcheck — confirms the signal transitions to
+#      status=stalled with attentionReason=state-json-stale.
+#   3. Runs orchestrate-revive — confirms the correct decision branch fired
+#      (re-dispatch | emit-complete | escalate).
+#
+# The actual scripts under test are unmodified; only the binaries they call
+# are stubbed so we don't touch real Claude state. If Phases 1–3 are correct,
+# this file passes without further code changes (per the plan).
+#
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-revive-phase-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HEALTHCHECK="${REPO_ROOT}/plugins/dev/scripts/orchestrate-healthcheck"
+REVIVE="${REPO_ROOT}/plugins/dev/scripts/orchestrate-revive"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+scratch_setup() {
+  SCRATCH="$(mktemp -d -t orchestrate-revive-phase-e2e-XXXXXX)"
+  ORCH_DIR="${SCRATCH}/orch"
+  FIXTURE_BIN="${SCRATCH}/bin"
+  JOBS_ROOT="${SCRATCH}/jobs"
+  WORKTREE_BASE="${SCRATCH}/worktrees"
+  DISPATCH_LOG="${SCRATCH}/dispatch.log"
+  EMIT_LOG="${SCRATCH}/emit.log"
+  STATE_LOG="${SCRATCH}/state.log"
+  mkdir -p "${ORCH_DIR}/workers/output" "$FIXTURE_BIN" "$JOBS_ROOT" "$WORKTREE_BASE"
+  : > "$DISPATCH_LOG"
+  : > "$EMIT_LOG"
+  : > "$STATE_LOG"
+
+  cat > "${FIXTURE_BIN}/catalyst-state.sh" <<EOF2
+#!/usr/bin/env bash
+echo "\$@" >> "$STATE_LOG"
+EOF2
+  chmod +x "${FIXTURE_BIN}/catalyst-state.sh"
+  export CATALYST_STATE_SCRIPT="${FIXTURE_BIN}/catalyst-state.sh"
+
+  cat > "${FIXTURE_BIN}/phase-agent-dispatch" <<EOF2
+#!/usr/bin/env bash
+echo "dispatch-called: \$*" >> "$DISPATCH_LOG"
+# Mutate signal: status → dispatched, fresh bg_job_id, mirroring the real
+# script's contract.
+PHASE=""
+TICKET=""
+OD=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --phase) PHASE="\$2"; shift 2 ;;
+    --ticket) TICKET="\$2"; shift 2 ;;
+    --orch-dir) OD="\$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+SIG="\$OD/workers/\$TICKET/phase-\$PHASE.json"
+if [ -f "\$SIG" ]; then
+  TS=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  jq --arg ts "\$TS" --arg bg "fresh-bg-\$\$" \
+     '.status = "dispatched" | .bg_job_id = \$bg | .updatedAt = \$ts' \
+     "\$SIG" > "\$SIG.tmp" 2>/dev/null && mv "\$SIG.tmp" "\$SIG"
+fi
+exit 0
+EOF2
+  chmod +x "${FIXTURE_BIN}/phase-agent-dispatch"
+  export CATALYST_PHASE_DISPATCH_BIN="${FIXTURE_BIN}/phase-agent-dispatch"
+
+  cat > "${FIXTURE_BIN}/phase-agent-emit-complete" <<EOF2
+#!/usr/bin/env bash
+echo "emit-complete-called: \$*" >> "$EMIT_LOG"
+exit 0
+EOF2
+  chmod +x "${FIXTURE_BIN}/phase-agent-emit-complete"
+  export CATALYST_PHASE_EMIT_COMPLETE_BIN="${FIXTURE_BIN}/phase-agent-emit-complete"
+
+  export CATALYST_HEALTHCHECK_JOBS_ROOT="$JOBS_ROOT"
+  export CATALYST_REVIVE_WORKTREE_BASE="$WORKTREE_BASE"
+}
+
+scratch_teardown() {
+  rm -rf "$SCRATCH"
+  unset SCRATCH ORCH_DIR FIXTURE_BIN JOBS_ROOT WORKTREE_BASE
+  unset DISPATCH_LOG EMIT_LOG STATE_LOG
+  unset CATALYST_STATE_SCRIPT CATALYST_PHASE_DISPATCH_BIN
+  unset CATALYST_PHASE_EMIT_COMPLETE_BIN CATALYST_HEALTHCHECK_JOBS_ROOT
+  unset CATALYST_REVIVE_WORKTREE_BASE
+}
+
+# make_per_phase_signal TICKET PHASE STATUS BG_ID
+make_per_phase_signal() {
+  local ticket="$1" phase="$2" status="$3" bg="${4:-bg-$$}"
+  local ts; ts=$(now_iso)
+  mkdir -p "$ORCH_DIR/workers/$ticket"
+  jq -n \
+    --arg t "$ticket" --arg p "$phase" --arg s "$status" \
+    --arg bg "$bg" --arg ts "$ts" \
+    '{ticket:$t, phase:$p, status:$s, orchestrator:"e2e-orch",
+      model:"opus", turnCap:25, bg_job_id:$bg,
+      startedAt:$ts, updatedAt:$ts}' \
+    > "$ORCH_DIR/workers/$ticket/phase-$phase.json"
+}
+
+# make_stale_state_json BG_ID — write a state.json under JOBS_ROOT/<bg>/ with
+# an mtime 10 minutes in the past so healthcheck's --stale-bg-seconds 60 flags it.
+#
+# `touch -t` interprets its argument as local time (not UTC), which means a
+# `date -u -v-10M` round-trip ends up writing a *future* timestamp on hosts
+# whose TZ is east of UTC. Use the relative-offset forms instead:
+#   - macOS/BSD: `touch -A -001000` (subtract 10 minutes)
+#   - GNU:       `touch -d '10 minutes ago'`
+make_stale_state_json() {
+  local bg="$1"
+  mkdir -p "$JOBS_ROOT/$bg"
+  echo '{"state":"running","id":"'"$bg"'"}' > "$JOBS_ROOT/$bg/state.json"
+  # macOS first; fall back to GNU.
+  touch -A -001000 "$JOBS_ROOT/$bg/state.json" 2>/dev/null \
+    || touch -d '10 minutes ago' "$JOBS_ROOT/$bg/state.json" 2>/dev/null \
+    || true
+}
+
+# ─── Scenario 1: healthcheck marks stalled → revive re-dispatches ───────────
+echo "scenario 1 (CTL-493 Phase 4): stalled → re-dispatch"
+scratch_setup
+make_per_phase_signal "E-1" "implement" "running" "bg-e1"
+make_stale_state_json "bg-e1"
+
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "e2e-orch" \
+  --grace-seconds 0 --stale-bg-seconds 1 > "${SCRATCH}/hc.out" 2>"${SCRATCH}/hc.err"
+STATUS_AFTER_HC=$(jq -r '.status' "$ORCH_DIR/workers/E-1/phase-implement.json")
+if [ "$STATUS_AFTER_HC" = "stalled" ]; then
+  pass "healthcheck transitions running→stalled"
+else
+  fail "healthcheck transitions to stalled" "got: $STATUS_AFTER_HC stderr: $(cat "${SCRATCH}/hc.err")"
+fi
+
+PATH="${FIXTURE_BIN}:$PATH" \
+  "$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "e2e-orch" \
+  > "${SCRATCH}/rev.out" 2>"${SCRATCH}/rev.err"
+
+if grep -q "dispatch-called.*implement.*E-1" "$DISPATCH_LOG"; then
+  pass "revive re-dispatches the stalled phase agent"
+else
+  fail "revive re-dispatches" "dispatch log: $(cat "$DISPATCH_LOG") rev stderr: $(cat "${SCRATCH}/rev.err")"
+fi
+
+PRC=$(jq -r '.phaseReviveCount' "$ORCH_DIR/workers/E-1/phase-implement.json")
+if [ "$PRC" = "1" ]; then
+  pass "phaseReviveCount bumped to 1 after first revive"
+else
+  fail "phaseReviveCount=1" "got: $PRC"
+fi
+
+STATUS_AFTER_REVIVE=$(jq -r '.status' "$ORCH_DIR/workers/E-1/phase-implement.json")
+if [ "$STATUS_AFTER_REVIVE" = "dispatched" ]; then
+  pass "signal transitions stalled→dispatched after re-dispatch"
+else
+  fail "signal transitions stalled→dispatched" "got: $STATUS_AFTER_REVIVE"
+fi
+scratch_teardown
+
+# ─── Scenario 2: budget exhaustion across multiple revive cycles ────────────
+echo "scenario 2 (CTL-493 Phase 4): third revive exhausts budget"
+scratch_setup
+make_per_phase_signal "E-2" "verify" "stalled" "bg-e2"
+# Pre-set phaseReviveCount to 3 so the next revive hits the budget cap.
+jq '. + {phaseReviveCount: 3}' "$ORCH_DIR/workers/E-2/phase-verify.json" \
+  > "$ORCH_DIR/workers/E-2/phase-verify.json.tmp" \
+  && mv "$ORCH_DIR/workers/E-2/phase-verify.json.tmp" \
+        "$ORCH_DIR/workers/E-2/phase-verify.json"
+
+PATH="${FIXTURE_BIN}:$PATH" \
+  "$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "e2e-orch" \
+  --max-phase-revives 3 > "${SCRATCH}/rev.out" 2>"${SCRATCH}/rev.err"
+
+if grep -q "attention.*phase-failed-unrecoverable.*E-2" "$STATE_LOG" \
+   && grep -q -- "--actionable false" "$STATE_LOG"; then
+  pass "budget-exhausted → attention --actionable false"
+else
+  fail "budget-exhausted attention" "state log: $(cat "$STATE_LOG")"
+fi
+
+if ! grep -q "dispatch-called.*E-2" "$DISPATCH_LOG"; then
+  pass "dispatch NOT called after budget exhaustion"
+else
+  fail "dispatch must not fire when budget exhausted" "log: $(cat "$DISPATCH_LOG")"
+fi
+scratch_teardown
+
+# ─── Scenario 3: revive iterates multiple workers in one cycle ──────────────
+echo "scenario 3 (CTL-493 Phase 4): revive handles multiple stalled workers in one pass"
+scratch_setup
+make_per_phase_signal "E-3a" "research" "stalled" "bg-e3a"
+make_per_phase_signal "E-3b" "verify" "stalled" "bg-e3b"
+make_per_phase_signal "E-3c" "plan" "stalled" "bg-e3c"
+# Mark E-3b as truly-failed via .failureReason so it should escalate, not re-dispatch.
+jq '. + {failureReason: "tests-non-zero-exit"}' \
+   "$ORCH_DIR/workers/E-3b/phase-verify.json" > "${SCRATCH}/tmp" \
+   && mv "${SCRATCH}/tmp" "$ORCH_DIR/workers/E-3b/phase-verify.json"
+
+PATH="${FIXTURE_BIN}:$PATH" \
+  "$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "e2e-orch" \
+  > "${SCRATCH}/rev.out" 2>"${SCRATCH}/rev.err"
+
+PMW=$(jq -r '.phaseModeWorkers' "${SCRATCH}/rev.out")
+PEL=$(jq -r '.phaseEligible' "${SCRATCH}/rev.out")
+PREV=$(jq -r '.phaseRevived' "${SCRATCH}/rev.out")
+PESC=$(jq -r '.phaseEscalated' "${SCRATCH}/rev.out")
+
+[ "$PMW" = "3" ] \
+  && pass "phaseModeWorkers=3 (all three signals counted)" \
+  || fail "phaseModeWorkers=3" "got: $PMW out: $(cat "${SCRATCH}/rev.out")"
+[ "$PEL" = "3" ] \
+  && pass "phaseEligible=3 (all three stalled)" \
+  || fail "phaseEligible=3" "got: $PEL"
+[ "$PREV" = "2" ] \
+  && pass "phaseRevived=2 (E-3a + E-3c re-dispatched)" \
+  || fail "phaseRevived=2" "got: $PREV"
+[ "$PESC" = "1" ] \
+  && pass "phaseEscalated=1 (E-3b truly-failed)" \
+  || fail "phaseEscalated=1" "got: $PESC"
+
+grep -q "dispatch-called.*research.*E-3a" "$DISPATCH_LOG" \
+  && pass "E-3a re-dispatched" \
+  || fail "E-3a re-dispatched" "log: $(cat "$DISPATCH_LOG")"
+grep -q "attention.*phase-failed-unrecoverable.*E-3b" "$STATE_LOG" \
+  && pass "E-3b escalated (truly-failed)" \
+  || fail "E-3b escalated" "state log: $(cat "$STATE_LOG")"
+grep -q "dispatch-called.*plan.*E-3c" "$DISPATCH_LOG" \
+  && pass "E-3c re-dispatched" \
+  || fail "E-3c re-dispatched" "log: $(cat "$DISPATCH_LOG")"
+scratch_teardown
+
+# ─── Scenario 4: missing config still doesn't crash revive ──────────────────
+# Documents the worktree-derivation fallback: when no config is present and
+# CATALYST_REVIVE_WORKTREE_BASE is unset, the meaningful-progress check
+# silently returns "no progress" so the worker is re-dispatched.
+echo "scenario 4 (CTL-493 Phase 4): missing config → revive still runs safely"
+scratch_setup
+unset CATALYST_REVIVE_WORKTREE_BASE
+make_per_phase_signal "E-4" "implement" "stalled" "bg-e4"
+
+PATH="${FIXTURE_BIN}:$PATH" \
+  "$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "e2e-orch" \
+  > "${SCRATCH}/rev.out" 2>"${SCRATCH}/rev.err"
+RC=$?
+
+[ "$RC" = "0" ] \
+  && pass "revive exits 0 even without worktree-base config" \
+  || fail "revive exits 0" "rc=$RC stderr=$(cat "${SCRATCH}/rev.err")"
+grep -q "dispatch-called.*implement.*E-4" "$DISPATCH_LOG" \
+  && pass "fallback path → re-dispatch fires" \
+  || fail "fallback re-dispatch" "log: $(cat "$DISPATCH_LOG")"
+scratch_teardown
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "E2E Results: ${PASSES} pass, ${FAILURES} fail"
+echo "────────────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-revive phase-agent recovery branch (CTL-493).
+#
+# Phase 2 (this file): structural per-phase iteration. The script must detect
+# per-phase signals at workers/<T>/phase-*.json (independent of the legacy
+# top-level workers/<T>.json) and report eligible/total counts in its JSON
+# summary. No recovery action yet — Phase 3 (added in a follow-up commit)
+# layers the decision tree.
+#
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+REVIVE="${REPO_ROOT}/plugins/dev/scripts/orchestrate-revive"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+scratch_setup() {
+  SCRATCH="$(mktemp -d -t orchestrate-revive-phase-XXXXXX)"
+  ORCH_DIR="${SCRATCH}/orch"
+  FIXTURE_BIN="${SCRATCH}/bin"
+  DISPATCH_LOG="${SCRATCH}/dispatch.log"
+  EMIT_LOG="${SCRATCH}/emit.log"
+  STATE_LOG="${SCRATCH}/state.log"
+  mkdir -p "${ORCH_DIR}/workers/output" "$FIXTURE_BIN" "${SCRATCH}/worktrees"
+  : > "$DISPATCH_LOG"
+  : > "$EMIT_LOG"
+  : > "$STATE_LOG"
+
+  # Fake state script — logs argv. Tests that need to assert no recovery action
+  # was triggered just check this log stays empty.
+  cat > "${FIXTURE_BIN}/catalyst-state.sh" <<EOF2
+#!/usr/bin/env bash
+echo "\$@" >> "$STATE_LOG"
+EOF2
+  chmod +x "${FIXTURE_BIN}/catalyst-state.sh"
+  export CATALYST_STATE_SCRIPT="${FIXTURE_BIN}/catalyst-state.sh"
+
+  # Fake phase-agent-dispatch — logs argv. Phase 2 must NOT invoke this.
+  cat > "${FIXTURE_BIN}/phase-agent-dispatch" <<EOF2
+#!/usr/bin/env bash
+echo "dispatch-called: \$*" >> "$DISPATCH_LOG"
+exit 0
+EOF2
+  chmod +x "${FIXTURE_BIN}/phase-agent-dispatch"
+  export CATALYST_PHASE_DISPATCH_BIN="${FIXTURE_BIN}/phase-agent-dispatch"
+
+  # Fake phase-agent-emit-complete — logs argv. Phase 2 must NOT invoke this.
+  cat > "${FIXTURE_BIN}/phase-agent-emit-complete" <<EOF2
+#!/usr/bin/env bash
+echo "emit-complete-called: \$*" >> "$EMIT_LOG"
+exit 0
+EOF2
+  chmod +x "${FIXTURE_BIN}/phase-agent-emit-complete"
+  export CATALYST_PHASE_EMIT_COMPLETE_BIN="${FIXTURE_BIN}/phase-agent-emit-complete"
+
+  # Stub a never-used claude binary — phase 2 iteration must NOT spawn claude.
+  cat > "${FIXTURE_BIN}/claude" <<'EOF2'
+#!/usr/bin/env bash
+echo "claude-should-not-be-called: $*" >&2
+exit 99
+EOF2
+  chmod +x "${FIXTURE_BIN}/claude"
+  export CATALYST_REVIVE_CLAUDE_BIN="${FIXTURE_BIN}/claude"
+}
+
+scratch_teardown() {
+  rm -rf "$SCRATCH"
+  unset SCRATCH ORCH_DIR FIXTURE_BIN DISPATCH_LOG EMIT_LOG STATE_LOG
+  unset CATALYST_STATE_SCRIPT CATALYST_PHASE_DISPATCH_BIN
+  unset CATALYST_PHASE_EMIT_COMPLETE_BIN CATALYST_REVIVE_CLAUDE_BIN
+}
+
+# make_per_phase_signal TICKET PHASE STATUS [EXTRA_JQ]
+# Writes ${ORCH_DIR}/workers/<TICKET>/phase-<PHASE>.json with the production
+# signal shape (matches phase-agent-dispatch's signal contract).
+make_per_phase_signal() {
+  local ticket="$1" phase="$2" status="$3" extra="${4:-.}"
+  local ts; ts=$(now_iso)
+  mkdir -p "$ORCH_DIR/workers/$ticket"
+  jq -n \
+    --arg t "$ticket" --arg p "$phase" --arg s "$status" --arg ts "$ts" \
+    --arg pid "$$" \
+    '{ticket:$t, phase:$p, status:$s, orchestrator:"test-orch",
+      model:"opus", turnCap:25, bg_job_id:("fake-bg-"+$pid),
+      startedAt:$ts, updatedAt:$ts}' \
+    | jq "$extra" \
+    > "$ORCH_DIR/workers/$ticket/phase-$phase.json"
+}
+
+# run_revive_dry [extra args...] — runs orchestrate-revive --dry-run, capturing
+# stdout (the JSON summary) into $OUT_JSON and stderr into $OUT_ERR.
+run_revive_dry() {
+  OUT_JSON="${SCRATCH}/out.json"
+  OUT_ERR="${SCRATCH}/out.err"
+  PATH="${FIXTURE_BIN}:$PATH" \
+    "$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "test-orch" --dry-run "$@" \
+    > "$OUT_JSON" 2>"$OUT_ERR"
+}
+
+# ─── Test 1: structural detection — workers/<T>/phase-*.json triggers branch ─
+echo "test 1 (CTL-493 Phase 2): structural detection reports phase-mode worker"
+scratch_setup
+make_per_phase_signal "T-1" "implement" "stalled"
+run_revive_dry
+PHASE_MODE=$(jq -r '.phaseModeWorkers // empty' "$OUT_JSON")
+[ "$PHASE_MODE" = "1" ] \
+  && pass "phaseModeWorkers=1 reported" \
+  || fail "phaseModeWorkers=1" "got: '$PHASE_MODE' stdout: $(cat "$OUT_JSON") stderr: $(cat "$OUT_ERR")"
+grep -q "phase-mode worker detected: T-1" "$OUT_ERR" \
+  && pass "stderr logs detection" \
+  || fail "stderr logs detection" "stderr: $(cat "$OUT_ERR")"
+scratch_teardown
+
+# ─── Test 2: no per-phase dir → no false positives ───────────────────────────
+echo "test 2 (CTL-493 Phase 2): no phase-* signals → phaseModeWorkers=0"
+scratch_setup
+# Empty orch dir — no signals at all.
+run_revive_dry
+PHASE_MODE=$(jq -r '.phaseModeWorkers // 0' "$OUT_JSON")
+[ "$PHASE_MODE" = "0" ] \
+  && pass "phaseModeWorkers=0 when no signals exist" \
+  || fail "phaseModeWorkers=0" "got: '$PHASE_MODE'"
+scratch_teardown
+
+# ─── Test 3: signal exists but status != stalled → not eligible ──────────────
+echo "test 3 (CTL-493 Phase 2): status=running → phaseModeWorkers=1, eligible=0"
+scratch_setup
+make_per_phase_signal "T-2" "implement" "running"
+run_revive_dry
+PHASE_MODE=$(jq -r '.phaseModeWorkers // empty' "$OUT_JSON")
+ELIGIBLE=$(jq -r '.phaseEligible // empty' "$OUT_JSON")
+[ "$PHASE_MODE" = "1" ] \
+  && pass "phaseModeWorkers=1 (signal counted)" \
+  || fail "phaseModeWorkers=1" "got: '$PHASE_MODE'"
+[ "$ELIGIBLE" = "0" ] \
+  && pass "phaseEligible=0 (running ≠ stalled)" \
+  || fail "phaseEligible=0" "got: '$ELIGIBLE'"
+scratch_teardown
+
+# ─── Test 4: mixed signals — one stalled + one running across two tickets ───
+echo "test 4 (CTL-493 Phase 2): mixed statuses → only stalled counted as eligible"
+scratch_setup
+make_per_phase_signal "T-3" "research" "stalled"
+make_per_phase_signal "T-4" "implement" "running"
+run_revive_dry
+PHASE_MODE=$(jq -r '.phaseModeWorkers // empty' "$OUT_JSON")
+ELIGIBLE=$(jq -r '.phaseEligible // empty' "$OUT_JSON")
+[ "$PHASE_MODE" = "2" ] \
+  && pass "phaseModeWorkers=2 (both signals counted)" \
+  || fail "phaseModeWorkers=2" "got: '$PHASE_MODE'"
+[ "$ELIGIBLE" = "1" ] \
+  && pass "phaseEligible=1 (only stalled)" \
+  || fail "phaseEligible=1" "got: '$ELIGIBLE'"
+scratch_teardown
+
+# ─── Test 5: Phase 2 must NOT spawn claude or call dispatch/emit-complete ────
+echo "test 5 (CTL-493 Phase 2): dry-run only — no recovery action triggered"
+scratch_setup
+make_per_phase_signal "T-5" "verify" "stalled"
+run_revive_dry
+if [ -s "$DISPATCH_LOG" ]; then
+  fail "dispatch must not be called in Phase 2 dry-run" "log: $(cat "$DISPATCH_LOG")"
+else
+  pass "dispatch NOT invoked"
+fi
+if [ -s "$EMIT_LOG" ]; then
+  fail "emit-complete must not be called in Phase 2 dry-run" "log: $(cat "$EMIT_LOG")"
+else
+  pass "emit-complete NOT invoked"
+fi
+scratch_teardown
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh
@@ -3,9 +3,11 @@
 #
 # Phase 2 (this file): structural per-phase iteration. The script must detect
 # per-phase signals at workers/<T>/phase-*.json (independent of the legacy
-# top-level workers/<T>.json) and report eligible/total counts in its JSON
-# summary. No recovery action yet — Phase 3 (added in a follow-up commit)
-# layers the decision tree.
+# top-level workers/<T>.json) and report eligible/total counts in its
+# dry-run JSON summary. No recovery action yet — Phase 3 adds the decision
+# tree.
+#
+# Phase 3 cases live at the bottom of this file (extends the same fixture).
 #
 # Run: bash plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh
 
@@ -35,8 +37,8 @@ scratch_setup() {
   : > "$EMIT_LOG"
   : > "$STATE_LOG"
 
-  # Fake state script — logs argv. Tests that need to assert no recovery action
-  # was triggered just check this log stays empty.
+  # Fake state script — logs argv. We need it executable and on PATH for the
+  # CTL-493 escalate branch (calls catalyst-state.sh attention ...).
   cat > "${FIXTURE_BIN}/catalyst-state.sh" <<EOF2
 #!/usr/bin/env bash
 echo "\$@" >> "$STATE_LOG"
@@ -44,7 +46,9 @@ EOF2
   chmod +x "${FIXTURE_BIN}/catalyst-state.sh"
   export CATALYST_STATE_SCRIPT="${FIXTURE_BIN}/catalyst-state.sh"
 
-  # Fake phase-agent-dispatch — logs argv. Phase 2 must NOT invoke this.
+  # Fake phase-agent-dispatch — logs argv. We override the canonical script
+  # by placing this on PATH first; orchestrate-revive resolves dispatch via
+  # PLUGIN_ROOT (its own SCRIPT_DIR), so we also accept an env override.
   cat > "${FIXTURE_BIN}/phase-agent-dispatch" <<EOF2
 #!/usr/bin/env bash
 echo "dispatch-called: \$*" >> "$DISPATCH_LOG"
@@ -53,10 +57,29 @@ EOF2
   chmod +x "${FIXTURE_BIN}/phase-agent-dispatch"
   export CATALYST_PHASE_DISPATCH_BIN="${FIXTURE_BIN}/phase-agent-dispatch"
 
-  # Fake phase-agent-emit-complete — logs argv. Phase 2 must NOT invoke this.
+  # Fake phase-agent-emit-complete — logs argv and mutates the per-phase
+  # signal (.status = "done") to match the canonical script's contract.
   cat > "${FIXTURE_BIN}/phase-agent-emit-complete" <<EOF2
 #!/usr/bin/env bash
 echo "emit-complete-called: \$*" >> "$EMIT_LOG"
+# Parse --phase, --ticket, --orch-dir from argv
+P=""
+T=""
+OD=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --phase) P="\$2"; shift 2 ;;
+    --ticket) T="\$2"; shift 2 ;;
+    --orch-dir) OD="\$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+SIG="\$OD/workers/\$T/phase-\$P.json"
+if [ -f "\$SIG" ]; then
+  TS=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  jq --arg ts "\$ts" '.status = "done" | .completedAt = "\$TS" | .updatedAt = "\$TS"' \
+    "\$SIG" > "\$SIG.tmp" 2>/dev/null && mv "\$SIG.tmp" "\$SIG" || true
+fi
 exit 0
 EOF2
   chmod +x "${FIXTURE_BIN}/phase-agent-emit-complete"
@@ -96,7 +119,7 @@ make_per_phase_signal() {
     > "$ORCH_DIR/workers/$ticket/phase-$phase.json"
 }
 
-# run_revive_dry [extra args...] — runs orchestrate-revive --dry-run, capturing
+# run_revive [extra args...] — runs orchestrate-revive --dry-run, capturing
 # stdout (the JSON summary) into $OUT_JSON and stderr into $OUT_ERR.
 run_revive_dry() {
   OUT_JSON="${SCRATCH}/out.json"
@@ -176,6 +199,145 @@ if [ -s "$EMIT_LOG" ]; then
   fail "emit-complete must not be called in Phase 2 dry-run" "log: $(cat "$EMIT_LOG")"
 else
   pass "emit-complete NOT invoked"
+fi
+scratch_teardown
+
+# ─── Phase 3 tests ─────────────────────────────────────────────────────────────
+#
+# Phase 3 adds the decision tree (meaningful-progress | re-dispatch | escalate).
+# Tests below exercise the real (non-dry-run) iteration loop.
+
+# run_revive [extra args...] — non-dry-run.
+run_revive() {
+  OUT_JSON="${SCRATCH}/out.json"
+  OUT_ERR="${SCRATCH}/out.err"
+  PATH="${FIXTURE_BIN}:$PATH" \
+    "$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "test-orch" "$@" \
+    > "$OUT_JSON" 2>"$OUT_ERR"
+}
+
+# make_fake_worktree_with_commits TICKET N — create a fake git worktree with
+# N commits ahead of origin/main. Used to simulate "meaningful progress".
+make_fake_worktree_with_commits() {
+  local ticket="$1" n="$2"
+  local wt="$WORKTREE_BASE/test-orch-$ticket"
+  mkdir -p "$wt"
+  git init -q "$wt"
+  git -C "$wt" config user.email "test@test"
+  git -C "$wt" config user.name "Test"
+  git -C "$wt" config commit.gpgsign false
+  git -C "$wt" commit --allow-empty -m base -q
+  git -C "$wt" branch -m main 2>/dev/null || true
+  # Create a fake origin/main pointing at the base commit so rev-list count > 0.
+  git -C "$wt" branch -f origin/main HEAD 2>/dev/null || true
+  # rev-list expects refs/remotes/origin/main — create that ref directly.
+  mkdir -p "$wt/.git/refs/remotes/origin"
+  git -C "$wt" rev-parse HEAD > "$wt/.git/refs/remotes/origin/main"
+  for i in $(seq 1 "$n"); do
+    git -C "$wt" commit --allow-empty -m "c$i" -q
+  done
+}
+
+# Helper: set REPO_ROOT-equivalent env so phase_has_meaningful_progress can
+# resolve worktreeBase from the test's fake config.
+set_repo_root_for_revive() {
+  REPO_ROOT_FOR_TEST="${SCRATCH}/repo"
+  mkdir -p "$REPO_ROOT_FOR_TEST/.catalyst"
+  cat > "$REPO_ROOT_FOR_TEST/.catalyst/config.json" <<EOF2
+{
+  "catalyst": {
+    "git": { "baseBranch": "main" },
+    "orchestration": { "worktreeBase": "$WORKTREE_BASE" }
+  }
+}
+EOF2
+  export CATALYST_REVIVE_REPO_ROOT="$REPO_ROOT_FOR_TEST"
+  WORKTREE_BASE="${SCRATCH}/worktrees"
+  mkdir -p "$WORKTREE_BASE"
+  export CATALYST_REVIVE_WORKTREE_BASE="$WORKTREE_BASE"
+}
+
+# ─── Test A: meaningful progress (commits ahead) → emit-complete invoked ─────
+echo "test A (CTL-493 Phase 3): commits ahead → emit-complete invoked"
+scratch_setup
+WORKTREE_BASE="${SCRATCH}/worktrees"
+set_repo_root_for_revive
+make_per_phase_signal "T-A" "implement" "stalled"
+make_fake_worktree_with_commits "T-A" 2
+run_revive
+grep -q "emit-complete-called.*implement.*T-A" "$EMIT_LOG" \
+  && pass "emit-complete invoked for commits-ahead case" \
+  || fail "emit-complete invoked for commits-ahead case" "emit log: $(cat "$EMIT_LOG") stderr: $(cat "$OUT_ERR")"
+if [ -s "$DISPATCH_LOG" ]; then
+  fail "dispatch must NOT fire when progress is meaningful" "log: $(cat "$DISPATCH_LOG")"
+else
+  pass "dispatch NOT called (correct: progress signal short-circuited)"
+fi
+scratch_teardown
+
+# ─── Test B: meaningful progress (.artifact set) → emit-complete invoked ─────
+echo "test B (CTL-493 Phase 3): .artifact set → emit-complete invoked"
+scratch_setup
+WORKTREE_BASE="${SCRATCH}/worktrees"
+set_repo_root_for_revive
+make_per_phase_signal "T-B" "plan" "stalled" '. + {artifact: "/tmp/plan.md"}'
+run_revive
+grep -q "emit-complete-called.*plan.*T-B" "$EMIT_LOG" \
+  && pass "emit-complete invoked when artifact field present" \
+  || fail "emit-complete invoked when artifact field present" "emit log: $(cat "$EMIT_LOG") stderr: $(cat "$OUT_ERR")"
+scratch_teardown
+
+# ─── Test C: no progress → phase-agent-dispatch invoked, phaseReviveCount=1 ─
+echo "test C (CTL-493 Phase 3): no progress → dispatch + phaseReviveCount=1"
+scratch_setup
+WORKTREE_BASE="${SCRATCH}/worktrees"
+set_repo_root_for_revive
+make_per_phase_signal "T-C" "research" "stalled"
+# No worktree, no artifact — pure no-progress case.
+run_revive
+grep -q "dispatch-called.*research.*T-C" "$DISPATCH_LOG" \
+  && pass "dispatch invoked for no-progress case" \
+  || fail "dispatch invoked for no-progress case" "dispatch log: $(cat "$DISPATCH_LOG") stderr: $(cat "$OUT_ERR")"
+RC=$(jq -r '.phaseReviveCount' "$ORCH_DIR/workers/T-C/phase-research.json")
+[ "$RC" = "1" ] \
+  && pass "phaseReviveCount bumped to 1" \
+  || fail "phaseReviveCount=1" "got: '$RC' signal: $(cat "$ORCH_DIR/workers/T-C/phase-research.json")"
+scratch_teardown
+
+# ─── Test D: phaseReviveCount >= MAX → attention with actionable=false ───────
+echo "test D (CTL-493 Phase 3): budget exhausted → attention --actionable false"
+scratch_setup
+WORKTREE_BASE="${SCRATCH}/worktrees"
+set_repo_root_for_revive
+make_per_phase_signal "T-D" "verify" "stalled" '. + {phaseReviveCount: 3}'
+run_revive --max-phase-revives 3
+grep -q "attention.*phase-failed-unrecoverable.*T-D" "$STATE_LOG" \
+  && pass "attention call mentions T-D + phase-failed-unrecoverable" \
+  || fail "attention call mentions T-D" "state log: $(cat "$STATE_LOG")"
+grep -q -- "--actionable false" "$STATE_LOG" \
+  && pass "attention call passes --actionable false" \
+  || fail "attention call passes --actionable false" "state log: $(cat "$STATE_LOG")"
+if grep -q "dispatch-called.*T-D" "$DISPATCH_LOG"; then
+  fail "dispatch must NOT be called when budget exhausted" "log: $(cat "$DISPATCH_LOG")"
+else
+  pass "dispatch NOT called (budget exhausted)"
+fi
+scratch_teardown
+
+# ─── Test E: explicit failureReason → truly-failed branch (no dispatch) ─────
+echo "test E (CTL-493 Phase 3): failureReason set → escalate without retry"
+scratch_setup
+WORKTREE_BASE="${SCRATCH}/worktrees"
+set_repo_root_for_revive
+make_per_phase_signal "T-E" "verify" "stalled" '. + {failureReason: "non-zero-exit"}'
+run_revive
+grep -q "attention.*phase-failed-unrecoverable.*T-E" "$STATE_LOG" \
+  && pass "truly-failed escalates via attention" \
+  || fail "truly-failed escalates via attention" "state log: $(cat "$STATE_LOG")"
+if grep -q "dispatch-called.*T-E" "$DISPATCH_LOG"; then
+  fail "dispatch must NOT be called for truly-failed" "log: $(cat "$DISPATCH_LOG")"
+else
+  pass "dispatch NOT called for truly-failed"
 fi
 scratch_teardown
 

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -326,17 +326,38 @@ cmd_attention() {
   local attn_type="$2"
   local ticket_id="$3"
   local message="$4"
+  shift 4
+
+  # CTL-493: optional --actionable true|false. Default true.
+  # Lets orchestrate-revive's phase-agent recovery branch flag unrecoverable
+  # failures distinctly so HUD/monitor consumers can render them differently
+  # from operator-actionable attentions.
+  local actionable="true"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --actionable)
+        case "${2:-}" in
+          true|false) actionable="$2" ;;
+          *) echo "attention: --actionable must be 'true' or 'false' (got: '${2:-}')" >&2; return 2 ;;
+        esac
+        shift 2 ;;
+      *)
+        echo "attention: unknown flag '$1'" >&2
+        return 2 ;;
+    esac
+  done
 
   # Add attention item to the orchestrator and mark the worker
   state_write \
-    '.orchestrators[$oid].attention = ([{type: $atype, ticketId: $tid, message: $msg, since: $now}] + .orchestrators[$oid].attention)
+    '.orchestrators[$oid].attention = ([{type: $atype, ticketId: $tid, message: $msg, since: $now, actionable: ($act == "true")}] + .orchestrators[$oid].attention)
      | .orchestrators[$oid].workers[$tid].needsAttention = true
      | .orchestrators[$oid].workers[$tid].attentionReason = $msg
      | .orchestrators[$oid].updatedAt = $now' \
     --arg oid "$orch_id" \
     --arg atype "$attn_type" \
     --arg tid "$ticket_id" \
-    --arg msg "$message"
+    --arg msg "$message" \
+    --arg act "$actionable"
 
   # Emit event
   event_append "$(jq -nc \
@@ -345,7 +366,8 @@ cmd_attention() {
     --arg worker "$ticket_id" \
     --arg atype "$attn_type" \
     --arg msg "$message" \
-    '{ts: $ts, orchestrator: $orch, worker: $worker, event: "attention-raised", detail: {attentionType: $atype, reason: $msg}}')"
+    --arg act "$actionable" \
+    '{ts: $ts, orchestrator: $orch, worker: $worker, event: "attention-raised", detail: {attentionType: $atype, reason: $msg, actionable: ($act == "true")}}')"
 }
 
 cmd_resolve_attention() {

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -353,6 +353,21 @@ active_phase_of() {
   jq -r '.activePhase // ""' "${ORCH_DIR}/workers/${ticket}.json" 2>/dev/null || echo ""
 }
 
+# CTL-493 Phase 2: structural variant — true iff workers/<TICKET>/ contains
+# phase-*.json signals. Independent of the legacy top-level workers/<T>.json
+# (which phase-mode runs never write). Used by the per-phase iteration branch
+# below to find stalled signals the main loop misses.
+is_phase_mode_structural() {
+  local ticket="$1"
+  local dir="${ORCH_DIR}/workers/${ticket}"
+  [ -d "$dir" ] || return 1
+  local f
+  for f in "$dir"/phase-*.json; do
+    [ -e "$f" ] && return 0
+  done
+  return 1
+}
+
 # ─── Main loop ────────────────────────────────────────────────────────────────
 
 CHECKED=0
@@ -701,9 +716,47 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
   echo "REVIVED: ${TICKET} (sid=${SESSION_ID}, pid=${NEW_PID}, count=${NEW_REVIVE_COUNT}, reason=${REVIVE_REASON})" >&2
 done
 
+# ─── CTL-493 Phase 2: per-phase iteration branch (structural-only) ───────────
+#
+# Walks every workers/<T>/phase-*.json signal independently of the legacy
+# top-level workers/<T>.json loop above. Phase-mode orchestrations don't write
+# the top-level signal, so the previous loop is a structural no-op for them.
+#
+# This phase ONLY counts and logs — no recovery action is taken. Phase 3
+# layers the meaningful-progress / re-dispatch / escalate decision tree on top.
+
+PHASE_MODE_WORKERS=0
+PHASE_ELIGIBLE=0
+
+shopt -s nullglob
+for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
+  [ -e "$PHASE_SIGNAL" ] || continue
+
+  P_TICKET=$(jq -r '.ticket // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+  P_PHASE=$(jq -r '.phase // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+  P_STATUS=$(jq -r '.status // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+  [ -z "$P_TICKET" ] && continue
+  [ -z "$P_PHASE" ] && continue
+
+  PHASE_MODE_WORKERS=$((PHASE_MODE_WORKERS + 1))
+
+  if [ "$P_STATUS" != "stalled" ]; then
+    continue
+  fi
+
+  PHASE_ELIGIBLE=$((PHASE_ELIGIBLE + 1))
+  echo "phase-mode worker detected: ${P_TICKET}/${P_PHASE} (status=${P_STATUS})" >&2
+
+  # Phase 3 inserts the decision tree here (truly-failed | meaningful-progress
+  # | budget-exhausted | re-dispatch).
+done
+
 jq -nc \
   --argjson c "$CHECKED" \
   --argjson r "$REVIVED" \
   --argjson s "$STALLED" \
   --argjson k "$SKIPPED" \
-  '{checked:$c, revived:$r, stalled:$s, skipped:$k}'
+  --argjson pmw "$PHASE_MODE_WORKERS" \
+  --argjson pel "$PHASE_ELIGIBLE" \
+  '{checked:$c, revived:$r, stalled:$s, skipped:$k,
+    phaseModeWorkers:$pmw, phaseEligible:$pel}'

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -37,6 +37,10 @@ MAX_REVIVES=10
 # not reviveCount — the operator can tell "this worker is making steady
 # progress and just needs more turns" apart from "this worker is failing".
 MAX_CONTINUATIONS=3
+# CTL-493: per-phase revive budget. Distinct from MAX_REVIVES (whole-worker
+# budget for legacy oneshot signals) so a phase-agent run can independently
+# track how many times each phase has been re-dispatched.
+MAX_PHASE_REVIVES=3
 STALE_HEARTBEAT_SECONDS=900
 WORKER_COMMAND="/catalyst-dev:oneshot"
 MODEL="opus"
@@ -53,6 +57,7 @@ while [[ $# -gt 0 ]]; do
     --orch-id)                  ORCH_ID="$2"; shift 2 ;;
     --max-revives)              MAX_REVIVES="$2"; shift 2 ;;
     --max-continuations)        MAX_CONTINUATIONS="$2"; shift 2 ;;
+    --max-phase-revives)        MAX_PHASE_REVIVES="$2"; shift 2 ;;
     --stale-heartbeat-seconds)  STALE_HEARTBEAT_SECONDS="$2"; shift 2 ;;
     --worker-command)           WORKER_COMMAND="$2"; shift 2 ;;
     --model)                    MODEL="$2"; shift 2 ;;
@@ -353,10 +358,73 @@ active_phase_of() {
   jq -r '.activePhase // ""' "${ORCH_DIR}/workers/${ticket}.json" 2>/dev/null || echo ""
 }
 
-# CTL-493 Phase 2: structural variant — true iff workers/<TICKET>/ contains
-# phase-*.json signals. Independent of the legacy top-level workers/<T>.json
-# (which phase-mode runs never write). Used by the per-phase iteration branch
-# below to find stalled signals the main loop misses.
+# ─── CTL-493: phase-agent recovery helpers ──────────────────────────────────
+#
+# These power the iteration loop that walks every workers/<T>/phase-*.json
+# signal (independent of the legacy top-level workers/<T>.json gate). Each
+# stalled signal goes through a three-way decision tree:
+#
+#   1. truly-failed (failureReason set) → escalate via attention, no retry
+#   2. meaningful-progress (commits/artifact/uncommitted) → emit synthetic complete
+#   3. budget exhausted → escalate via attention
+#   4. fresh stall → re-dispatch via phase-agent-dispatch, bump phaseReviveCount
+
+# Resolve the repo root the revive script should read .catalyst/config.json from.
+# Precedence: CATALYST_REVIVE_REPO_ROOT > REPO_ROOT > orchestrator state.json's
+# `repoRoot` field > the script's parent-of-parent ancestor. Tests override via
+# the env var; production gets it from the orchestrator state.
+revive_repo_root() {
+  if [ -n "${CATALYST_REVIVE_REPO_ROOT:-}" ]; then
+    echo "$CATALYST_REVIVE_REPO_ROOT"; return 0
+  fi
+  if [ -n "${REPO_ROOT:-}" ] && [ -d "${REPO_ROOT}/.catalyst" ]; then
+    echo "$REPO_ROOT"; return 0
+  fi
+  # Walk up from SCRIPT_DIR looking for the nearest .catalyst dir.
+  local d="$SCRIPT_DIR"
+  while [ "$d" != "/" ] && [ -n "$d" ]; do
+    if [ -d "$d/.catalyst" ]; then
+      echo "$d"; return 0
+    fi
+    d=$(dirname "$d")
+  done
+  # No config found — emit empty (callers tolerate missing config).
+  echo ""
+}
+
+# Resolve the worktree base directory for phase-mode workers.
+# Precedence: CATALYST_REVIVE_WORKTREE_BASE > .catalyst/config.json's
+# catalyst.orchestration.worktreeBase. Empty means "no detection possible";
+# the meaningful-progress check returns false in that case.
+revive_worktree_base() {
+  if [ -n "${CATALYST_REVIVE_WORKTREE_BASE:-}" ]; then
+    echo "$CATALYST_REVIVE_WORKTREE_BASE"; return 0
+  fi
+  local repo
+  repo=$(revive_repo_root)
+  if [ -n "$repo" ] && [ -f "$repo/.catalyst/config.json" ]; then
+    jq -r '.catalyst.orchestration.worktreeBase // ""' "$repo/.catalyst/config.json" 2>/dev/null \
+      || echo ""
+    return 0
+  fi
+  echo ""
+}
+
+# Resolve the base branch for ahead-of-base detection.
+revive_base_branch() {
+  local repo
+  repo=$(revive_repo_root)
+  if [ -n "$repo" ] && [ -f "$repo/.catalyst/config.json" ]; then
+    jq -r '.catalyst.git.baseBranch // "main"' "$repo/.catalyst/config.json" 2>/dev/null \
+      || echo "main"
+    return 0
+  fi
+  echo "main"
+}
+
+# is_phase_mode_structural TICKET
+# True iff ${ORCH_DIR}/workers/<TICKET>/ exists and contains phase-*.json
+# signals. Independent of the legacy top-level workers/<T>.json check.
 is_phase_mode_structural() {
   local ticket="$1"
   local dir="${ORCH_DIR}/workers/${ticket}"
@@ -366,6 +434,133 @@ is_phase_mode_structural() {
     [ -e "$f" ] && return 0
   done
   return 1
+}
+
+# phase_has_meaningful_progress TICKET PHASE SIGNAL_FILE
+# Returns 0 + reason on stderr iff one of:
+#   - signal's .artifact field is set
+#   - worktree has commits ahead of origin/<baseBranch>
+#   - worktree has uncommitted changes against HEAD
+# Returns 1 otherwise.
+phase_has_meaningful_progress() {
+  local ticket="$1" phase="$2" signal="$3"
+
+  # Signal 1: .artifact already populated.
+  local artifact
+  artifact=$(jq -r '.artifact // empty' "$signal" 2>/dev/null || echo "")
+  if [ -n "$artifact" ]; then
+    echo "artifact=${artifact}" >&2
+    return 0
+  fi
+
+  # Resolve worktree path: ${WORKTREE_BASE}/${ORCH_ID}-${TICKET}.
+  local wt_base
+  wt_base=$(revive_worktree_base)
+  [ -z "$wt_base" ] && return 1
+  local wt="${wt_base}/${ORCH_ID}-${ticket}"
+  if [ ! -d "$wt/.git" ] && [ ! -f "$wt/.git" ]; then
+    return 1
+  fi
+
+  local base
+  base=$(revive_base_branch)
+  local ahead
+  ahead=$(git -C "$wt" rev-list --count "origin/${base}..HEAD" 2>/dev/null || echo 0)
+  if [ "${ahead:-0}" -gt 0 ]; then
+    echo "commits-ahead=${ahead}" >&2
+    return 0
+  fi
+  # Uncommitted-but-staged → also meaningful (Q2 resolution in the plan).
+  if ! git -C "$wt" diff --quiet HEAD 2>/dev/null; then
+    echo "uncommitted-changes" >&2
+    return 0
+  fi
+  if ! git -C "$wt" diff --quiet --cached 2>/dev/null; then
+    echo "uncommitted-staged-changes" >&2
+    return 0
+  fi
+  return 1
+}
+
+# phase_is_truly_failed SIGNAL_FILE
+# True iff the signal has a .failureReason field. Set by
+# phase-agent-emit-complete --status failed when a phase agent exits with a
+# real error (distinct from healthcheck's status=stalled, attentionReason=...).
+phase_is_truly_failed() {
+  local signal="$1"
+  local fr
+  fr=$(jq -r '.failureReason // empty' "$signal" 2>/dev/null || echo "")
+  [ -n "$fr" ]
+}
+
+# phase_revive_escalate TICKET PHASE REASON
+# Helper: raise an unrecoverable attention with --actionable false. Best-effort
+# state script invocation (silenced on missing/failed).
+phase_revive_escalate() {
+  local ticket="$1" phase="$2" reason="$3"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] phase-revive: escalate ${ticket}/${phase} (${reason})" >&2
+    return 0
+  fi
+  if [ -x "$STATE_SCRIPT" ]; then
+    "$STATE_SCRIPT" attention "$ORCH_ID" "phase-failed-unrecoverable" \
+      "$ticket" "phase=${phase} reason=${reason}" --actionable false \
+      >/dev/null 2>&1 || true
+  fi
+}
+
+# phase_revive_emit_complete TICKET PHASE PROGRESS_REASON
+# Calls phase-agent-emit-complete to publish the synthetic complete event +
+# mutate the signal status to "done". Best-effort.
+phase_revive_emit_complete() {
+  local ticket="$1" phase="$2" progress_reason="$3"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] phase-revive: emit-complete ${ticket}/${phase} (${progress_reason})" >&2
+    return 0
+  fi
+  local bin
+  bin="${CATALYST_PHASE_EMIT_COMPLETE_BIN:-${SCRIPT_DIR}/phase-agent-emit-complete}"
+  if [ -x "$bin" ]; then
+    "$bin" --phase "$phase" --ticket "$ticket" --status complete \
+      --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+      --reason "synthesized-by-revive: ${progress_reason}" \
+      >/dev/null 2>&1 || true
+  fi
+}
+
+# phase_revive_redispatch TICKET PHASE SIGNAL_FILE
+# Bumps phaseReviveCount on the signal, then calls phase-agent-dispatch.
+# phase-agent-dispatch's existing idempotency guard already lets stalled signals
+# fall through, so a separate signal reset is unnecessary — the dispatcher
+# overwrites it.
+phase_revive_redispatch() {
+  local ticket="$1" phase="$2" signal="$3" current_count="$4"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] phase-revive: re-dispatch ${ticket}/${phase} (count→$((current_count+1)))" >&2
+    return 0
+  fi
+  local ts next tmp
+  ts=$(now_iso)
+  next=$((current_count + 1))
+  tmp="${signal}.tmp.$$"
+  if jq --arg ts "$ts" --argjson rc "$next" \
+       '.phaseReviveCount = $rc | .updatedAt = $ts' \
+       "$signal" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$signal"
+  else
+    rm -f "$tmp"
+  fi
+
+  local bin
+  bin="${CATALYST_PHASE_DISPATCH_BIN:-${SCRIPT_DIR}/phase-agent-dispatch}"
+  if [ -x "$bin" ]; then
+    CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
+    CATALYST_ORCHESTRATOR_ID="$ORCH_ID" \
+    CATALYST_IS_CONTINUATION=true \
+      "$bin" --phase "$phase" --ticket "$ticket" \
+        --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+        >/dev/null 2>&1 || true
+  fi
 }
 
 # ─── Main loop ────────────────────────────────────────────────────────────────
@@ -716,17 +911,24 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
   echo "REVIVED: ${TICKET} (sid=${SESSION_ID}, pid=${NEW_PID}, count=${NEW_REVIVE_COUNT}, reason=${REVIVE_REASON})" >&2
 done
 
-# ─── CTL-493 Phase 2: per-phase iteration branch (structural-only) ───────────
+# ─── CTL-493: per-phase iteration branch ─────────────────────────────────────
 #
 # Walks every workers/<T>/phase-*.json signal independently of the legacy
 # top-level workers/<T>.json loop above. Phase-mode orchestrations don't write
-# the top-level signal, so the previous loop is a structural no-op for them.
+# the top-level signal, so the previous loop is a structural no-op for them —
+# this loop is what gives phase-agents an actual recovery path.
 #
-# This phase ONLY counts and logs — no recovery action is taken. Phase 3
-# layers the meaningful-progress / re-dispatch / escalate decision tree on top.
+# Decision tree per stalled signal:
+#   1. truly-failed (.failureReason set)     → escalate, no retry
+#   2. meaningful progress (commits/artifact) → emit synthetic complete
+#   3. budget exhausted                       → escalate
+#   4. fresh stall                            → re-dispatch, bump count
 
 PHASE_MODE_WORKERS=0
 PHASE_ELIGIBLE=0
+PHASE_REVIVED=0
+PHASE_EMIT_COMPLETE=0
+PHASE_ESCALATED=0
 
 shopt -s nullglob
 for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
@@ -747,8 +949,36 @@ for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
   PHASE_ELIGIBLE=$((PHASE_ELIGIBLE + 1))
   echo "phase-mode worker detected: ${P_TICKET}/${P_PHASE} (status=${P_STATUS})" >&2
 
-  # Phase 3 inserts the decision tree here (truly-failed | meaningful-progress
-  # | budget-exhausted | re-dispatch).
+  PHASE_REVIVE_COUNT=$(jq -r '.phaseReviveCount // 0' "$PHASE_SIGNAL" 2>/dev/null || echo 0)
+
+  # Branch 1: truly failed → escalate, no retry.
+  if phase_is_truly_failed "$PHASE_SIGNAL"; then
+    REASON=$(jq -r '.failureReason' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+    phase_revive_escalate "$P_TICKET" "$P_PHASE" "$REASON"
+    PHASE_ESCALATED=$((PHASE_ESCALATED + 1))
+    continue
+  fi
+
+  # Branch 2: meaningful progress → emit synthetic complete.
+  PROGRESS_REASON=""
+  if PROGRESS_REASON=$(phase_has_meaningful_progress "$P_TICKET" "$P_PHASE" "$PHASE_SIGNAL" 2>&1 >/dev/null); then
+    [ -z "$PROGRESS_REASON" ] && PROGRESS_REASON="meaningful-progress"
+    phase_revive_emit_complete "$P_TICKET" "$P_PHASE" "$PROGRESS_REASON"
+    PHASE_EMIT_COMPLETE=$((PHASE_EMIT_COMPLETE + 1))
+    continue
+  fi
+
+  # Branch 3: budget exhausted → escalate.
+  if [ "$PHASE_REVIVE_COUNT" -ge "$MAX_PHASE_REVIVES" ]; then
+    phase_revive_escalate "$P_TICKET" "$P_PHASE" \
+      "phase-revive-budget-exhausted count=${PHASE_REVIVE_COUNT}"
+    PHASE_ESCALATED=$((PHASE_ESCALATED + 1))
+    continue
+  fi
+
+  # Branch 4: fresh stall → re-dispatch.
+  phase_revive_redispatch "$P_TICKET" "$P_PHASE" "$PHASE_SIGNAL" "$PHASE_REVIVE_COUNT"
+  PHASE_REVIVED=$((PHASE_REVIVED + 1))
 done
 
 jq -nc \
@@ -758,5 +988,9 @@ jq -nc \
   --argjson k "$SKIPPED" \
   --argjson pmw "$PHASE_MODE_WORKERS" \
   --argjson pel "$PHASE_ELIGIBLE" \
+  --argjson prv "$PHASE_REVIVED" \
+  --argjson pec "$PHASE_EMIT_COMPLETE" \
+  --argjson pes "$PHASE_ESCALATED" \
   '{checked:$c, revived:$r, stalled:$s, skipped:$k,
-    phaseModeWorkers:$pmw, phaseEligible:$pel}'
+    phaseModeWorkers:$pmw, phaseEligible:$pel,
+    phaseRevived:$prv, phaseEmitComplete:$pec, phaseEscalated:$pes}'

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -503,9 +503,11 @@ phase_revive_escalate() {
     return 0
   fi
   if [ -x "$STATE_SCRIPT" ]; then
-    "$STATE_SCRIPT" attention "$ORCH_ID" "phase-failed-unrecoverable" \
-      "$ticket" "phase=${phase} reason=${reason}" --actionable false \
-      >/dev/null 2>&1 || true
+    if ! "$STATE_SCRIPT" attention "$ORCH_ID" "phase-failed-unrecoverable" \
+         "$ticket" "phase=${phase} reason=${reason}" --actionable false \
+         >/dev/null 2>&1; then
+      echo "phase-revive: ${ticket}/${phase} helper=catalyst-state-attention exit=$?" >&2
+    fi
   fi
 }
 
@@ -521,10 +523,12 @@ phase_revive_emit_complete() {
   local bin
   bin="${CATALYST_PHASE_EMIT_COMPLETE_BIN:-${SCRIPT_DIR}/phase-agent-emit-complete}"
   if [ -x "$bin" ]; then
-    "$bin" --phase "$phase" --ticket "$ticket" --status complete \
-      --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
-      --reason "synthesized-by-revive: ${progress_reason}" \
-      >/dev/null 2>&1 || true
+    if ! "$bin" --phase "$phase" --ticket "$ticket" --status complete \
+         --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+         --reason "synthesized-by-revive: ${progress_reason}" \
+         >/dev/null 2>&1; then
+      echo "phase-revive: ${ticket}/${phase} helper=phase-agent-emit-complete exit=$?" >&2
+    fi
   fi
 }
 
@@ -548,18 +552,25 @@ phase_revive_redispatch() {
        "$signal" > "$tmp" 2>/dev/null; then
     mv "$tmp" "$signal"
   else
+    # jq failed: signal is unreadable/corrupt. Falling through to dispatch
+    # without bumping the counter would let MAX_PHASE_REVIVES be unreachable.
     rm -f "$tmp"
+    echo "phase-revive: ${ticket}/${phase} signal_corrupt — escalating" >&2
+    phase_revive_escalate "$ticket" "$phase" "signal_corrupt"
+    return 1
   fi
 
   local bin
   bin="${CATALYST_PHASE_DISPATCH_BIN:-${SCRIPT_DIR}/phase-agent-dispatch}"
   if [ -x "$bin" ]; then
-    CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
-    CATALYST_ORCHESTRATOR_ID="$ORCH_ID" \
-    CATALYST_IS_CONTINUATION=true \
-      "$bin" --phase "$phase" --ticket "$ticket" \
-        --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
-        >/dev/null 2>&1 || true
+    if ! CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
+         CATALYST_ORCHESTRATOR_ID="$ORCH_ID" \
+         CATALYST_IS_CONTINUATION=true \
+         "$bin" --phase "$phase" --ticket "$ticket" \
+           --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+           >/dev/null 2>&1; then
+      echo "phase-revive: ${ticket}/${phase} helper=phase-agent-dispatch exit=$?" >&2
+    fi
   fi
 }
 
@@ -976,9 +987,13 @@ for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
     continue
   fi
 
-  # Branch 4: fresh stall → re-dispatch.
-  phase_revive_redispatch "$P_TICKET" "$P_PHASE" "$PHASE_SIGNAL" "$PHASE_REVIVE_COUNT"
-  PHASE_REVIVED=$((PHASE_REVIVED + 1))
+  # Branch 4: fresh stall → re-dispatch. A non-zero return means the signal
+  # was unreadable and the helper already escalated.
+  if phase_revive_redispatch "$P_TICKET" "$P_PHASE" "$PHASE_SIGNAL" "$PHASE_REVIVE_COUNT"; then
+    PHASE_REVIVED=$((PHASE_REVIVED + 1))
+  else
+    PHASE_ESCALATED=$((PHASE_ESCALATED + 1))
+  fi
 done
 
 jq -nc \


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-18T15:25:00Z -->
<!-- Last updated: 2026-05-18T15:25:00Z -->
<!-- PR: #861 -->
<!-- Previous commits: b4df5371,0f257ef2,b04e8eee,5e448e39,3a3048b3 -->

## Summary

Implements the phase-agent recovery path in `orchestrate-revive` so stalled phase workers are recovered automatically instead of requiring manual `phase-agent-dispatch` re-invocation.

Before this change, when a phase-agent worker stalled (bg job died, signal-file heartbeat went stale, dispatch was refused), the orchestrator fired `orchestrator.attention.raised` correctly but `orchestrate-revive` was a structural no-op for `dispatchMode = phase-agents`: the main loop iterated `${ORCH_DIR}/workers/*.json` (flat per-ticket signals), but phase-mode runs only write `${ORCH_DIR}/workers/<TICKET>/phase-<PHASE>.json` (nested per-phase signals).

The fix wires a per-phase iteration branch with a three-way decision tree onto the existing primitives (`phase-agent-dispatch`, `phase-agent-emit-complete`, `catalyst-state.sh attention`).

Refs: CTL-493

## Changes Made

### Phase 1 — `catalyst-state attention --actionable` flag (`b4df5371`)

- `plugins/dev/scripts/catalyst-state.sh`: added `--actionable` boolean flag to `cmd_attention`. Defaults to `true`, must be explicitly set to `false` for terminal escalations (truly-failed workers). The flag is propagated into the event detail so downstream readers (HUD, orch-monitor) can distinguish "recoverable" from "human-must-decide" attention states.
- Tests: `plugins/dev/scripts/__tests__/catalyst-state-attention.test.sh`.

### Phase 2 — per-phase iteration loop (`0f257ef2`)

- `plugins/dev/scripts/orchestrate-revive`: added a phase-mode iteration branch that globs `${ORCH_DIR}/workers/*/phase-*.json` instead of the legacy flat `workers/*.json`. The branch is selected when `.catalyst/config.json → orchestration.dispatchMode = "phase-agents"`. Existing CTL-484 (turn-cap continuation) and CTL-452 (oneshot-legacy revive) branches remain reachable via their own conditions.

### Phase 3 — decision tree + budget (`b04e8eee`)

- `plugins/dev/scripts/orchestrate-revive`: implemented the three-way decision tree for each stalled phase signal:
  1. **Meaningful progress** (worktree has commits ahead of base OR `.artifact` is set OR transcript shows tool activity past dispatch) → call `phase-agent-emit-complete --status complete` to publish the synthetic completion event.
  2. **No progress, budget remaining** (`.phaseReviveCount < MAX_PHASE_REVIVES`, default 3) → call `phase-agent-dispatch` to re-dispatch the same phase + ticket; the dispatcher's existing idempotency guard already lets `stalled`/`failed` fall through and overwrite. Increment `.phaseReviveCount` on the now-dispatched signal.
  3. **Truly failed** (budget exhausted OR clear error in transcript) → call `catalyst-state.sh attention --actionable=false` to surface for human triage.

### Phase 4 — E2E tests (`5e448e39`)

- `plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh`: unit-level fixture tests covering each decision-tree branch.
- `plugins/dev/scripts/__tests__/orchestrate-revive-phase-e2e.test.sh`: end-to-end test that synthesizes a stalled phase signal, runs `orchestrate-revive`, and asserts the expected event was emitted and signal mutated.

### Phase 5 — review remediations (`3a3048b3`)

- Addresses the `/review` skill's findings on Phases 1–4: tightens the budget-check ordering so the revive-count is only incremented after a successful re-dispatch, hardens transcript scanning against missing bg job ids, and adds a guard against re-emitting completion when the synthetic event is already present in the event log.

## How to Verify It

- [ ] `plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh` passes (decision-tree branches).
- [ ] `plugins/dev/scripts/__tests__/orchestrate-revive-phase-e2e.test.sh` passes (end-to-end stall → revive).
- [ ] `plugins/dev/scripts/__tests__/catalyst-state-attention.test.sh` passes (new `--actionable` flag).
- [ ] Manual: kill a phase-implement bg job mid-flight; confirm `orchestrate-revive` re-dispatches it without human intervention. (Original CTL-493 acceptance criterion.)

## Related Issues/PRs

- Fixes [CTL-493](https://linear.app/coalesce/issue/CTL-493) — orchestrate-revive: implement phase-agent recovery path
- Related: CTL-484 (turn-cap exhaustion handoff — analogous recovery path, already automated)
- Related: CTL-452 (oneshot-legacy revive — preserved, now sibling branch in the same dispatcher)

## Reviewer Notes

- The five-phase commit structure mirrors the implementation plan at `thoughts/shared/plans/2026-05-18-ctl-493.md`. Reviewing commit-by-commit is feasible.
- Phase 5 is the result of running `/review` against Phases 1–4 — those findings and their fixes are summarized in `${ORCH_DIR}/workers/CTL-493/review.json` (review-step artifact).
