### PR TITLE
feat(dev): propagate OTEL_RESOURCE_ATTRIBUTES to phase-agent claude --bg children (CTL-492)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -71,7 +71,7 @@ JOB_ID="${CLAUDE_STUB_JOB_ID:-f124220a}"
   echo "--ARGS--"
   printf '%s\n' "$@"
   echo "--ENV--"
-  env | grep -E '^CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)=' | sort
+  env | grep -E '^(CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)|OTEL_RESOURCE_ATTRIBUTES)=' | sort
   echo "--END--"
 } > "$LOG"
 # Mimic today's `claude --bg` multi-line stdout — the hex job ID lives on
@@ -475,6 +475,121 @@ JOB_IN_SIGNAL=$(jq -r '.bg_job_id' "$SIGNAL")
 JOB_IN_STDOUT=$(echo "$STDOUT" | jq -r '.bg_job_id')
 assert_eq "f124220a" "$JOB_IN_SIGNAL" "parser extracts hex from 'backgrounded · <hex>' line"
 assert_eq "f124220a" "$JOB_IN_STDOUT" "parser does NOT capture the literal word 'backgrounded'"
+
+# ─── Test 10: OTEL_RESOURCE_ATTRIBUTES propagation with projectKey present (CTL-492)
+echo ""
+echo "Test 10: OTEL_RESOURCE_ATTRIBUTES composed when projectKey is set"
+fresh_env t10
+cat > "${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+    >/dev/null 2>&1 )
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" \
+  "OTEL_RESOURCE_ATTRIBUTES=project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100" \
+  "OTEL attrs composed with projectKey + tier-2 branch fallback"
+
+# ─── Test 11: OTEL_RESOURCE_ATTRIBUTES three-attr form when projectKey absent
+echo ""
+echo "Test 11: OTEL_RESOURCE_ATTRIBUTES falls back to three-attr form when no projectKey"
+fresh_env t11
+# Dispatch from a directory with NO .catalyst/config.json — TEST_DIR/proj has
+# an empty .catalyst dir created by fresh_env but no config.json file.
+rm -rf "${CONFIG_DIR}"
+( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+    >/dev/null 2>&1 )
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" \
+  "OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test" \
+  "OTEL attrs three-attr form when no projectKey"
+if [[ "$LOG" == *"OTEL_RESOURCE_ATTRIBUTES="*"project="* ]]; then
+  fail "OTEL attrs three-attr form must omit project="
+else
+  pass "OTEL attrs three-attr form omits project="
+fi
+if [[ "$LOG" == *"OTEL_RESOURCE_ATTRIBUTES="*"branch="* ]]; then
+  fail "OTEL attrs three-attr form must omit branch="
+else
+  pass "OTEL attrs three-attr form omits branch="
+fi
+
+# ─── Test 12: tier-1 authoritative branch via git -C beats tier-2 constructed name
+echo ""
+echo "Test 12: tier-1 git -C branch resolution wins over tier-2 constructed name"
+fresh_env t12
+cat > "${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+# Build a real git repo at the worker-worktree location the helper computes.
+HOME_FIXTURE="${TEST_DIR}/home"
+WORKER_WT="${HOME_FIXTURE}/catalyst/wt/test-proj/orch-test-CTL-100"
+mkdir -p "$WORKER_WT"
+(
+  cd "$WORKER_WT"
+  git init -q --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git commit --allow-empty -q -m "init"
+  git checkout -q -b bespoke-branch
+)
+HOME="$HOME_FIXTURE" \
+  bash -c "cd '${TEST_DIR}/proj' && '$DISPATCH' --phase triage --ticket CTL-100 --orch-dir '$ORCH_DIR' --orch-id orch-test >/dev/null 2>&1"
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" ",branch=bespoke-branch" \
+  "tier-1 git branch (bespoke-branch) wins over tier-2 fallback"
+
+# ─── Test 13 (CTL-492 follow-up): tier-1 → tier-2 fall-through when worker-wt
+#                                  path exists but is not a git repo
+echo ""
+echo "Test 13: tier-2 wins when worker-wt path exists without a .git entry"
+fresh_env t13
+cat > "${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+HOME_FIXTURE="${TEST_DIR}/home"
+# Materialise the worker-wt directory but DO NOT init a git repo. Mirrors
+# the real-world degradation where a previous worktree create failed mid-way
+# and left a bare directory.
+mkdir -p "${HOME_FIXTURE}/catalyst/wt/test-proj/orch-test-CTL-100"
+HOME="$HOME_FIXTURE" \
+  bash -c "cd '${TEST_DIR}/proj' && '$DISPATCH' --phase triage --ticket CTL-100 --orch-dir '$ORCH_DIR' --orch-id orch-test >/dev/null 2>&1"
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" ",branch=orch-test-CTL-100" \
+  "tier-2 constructed branch used when worker-wt has no .git"
+
+# ─── Test 14: --dry-run JSON env array contains the OTEL entry
+echo ""
+echo "Test 14: --dry-run JSON env array carries OTEL_RESOURCE_ATTRIBUTES"
+fresh_env t14
+cat > "${CONFIG_DIR}/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-proj"
+  }
+}
+EOF
+DRY=$( cd "${TEST_DIR}/proj" && \
+  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run 2>/dev/null )
+OTEL_ENTRY=$(echo "$DRY" | jq -r '.env[] | select(startswith("OTEL_RESOURCE_ATTRIBUTES="))')
+assert_eq \
+  "OTEL_RESOURCE_ATTRIBUTES=project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100" \
+  "$OTEL_ENTRY" \
+  "dry-run JSON env array carries the composed OTEL attribute string"
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -154,6 +154,51 @@ config_value() {
   echo "$v"
 }
 
+# ─── OTEL resource attributes (CTL-492) ────────────────────────────────────
+#
+# Compose OTEL_RESOURCE_ATTRIBUTES for the dispatched `claude --bg` child,
+# mirroring what `~/.config/direnv/lib/otel.sh` produces for the interactive
+# orchestrator. Without this the worker emits Claude-Code metrics/logs with
+# empty `linear_key`, `branch`, `catalyst_orchestration`, and `project`
+# labels — silently dropped by Grafana panels that filter on non-empty
+# `linear_key`.
+#
+# Composition order (stable across both code paths):
+#   project=<key>,linear.key=<TICKET>,catalyst.orchestration=<ORCH_ID>[,branch=<branch>]
+#
+# Branch is resolved via a 3-tier fallback:
+#   1. authoritative `git -C <worker-wt> branch --show-current` if the
+#      worker worktree already exists (create-worktree.sh sets branch ==
+#      worktree-basename by construction);
+#   2. constructed name `<orch-id>-<ticket>` (matches the creation convention);
+#   3. omitted if `projectKey` itself is unresolvable.
+#
+# Always emits a non-empty line to stdout — at minimum the two-attribute
+# form `linear.key=<TICKET>,catalyst.orchestration=<ORCH_ID>` because both
+# values are required CLI flags by the time this runs. The caller still
+# guards on `-n` to remain defensive against future helper changes.
+compose_otel_resource_attrs() {
+  local project_key worker_wt worker_branch attrs
+  project_key="$(config_value '.catalyst.projectKey' '')"
+
+  worker_branch=""
+  if [[ -n "$project_key" ]]; then
+    worker_wt="${HOME}/catalyst/wt/${project_key}/${ORCH_ID}-${TICKET}"
+    if [[ -e "${worker_wt}/.git" ]] && command -v git >/dev/null 2>&1; then
+      worker_branch="$(git -C "$worker_wt" branch --show-current 2>/dev/null || true)"
+    fi
+    [[ -z "$worker_branch" ]] && worker_branch="${ORCH_ID}-${TICKET}"
+  fi
+
+  if [[ -n "$project_key" ]]; then
+    attrs="project=${project_key},linear.key=${TICKET},catalyst.orchestration=${ORCH_ID}"
+    [[ -n "$worker_branch" ]] && attrs="${attrs},branch=${worker_branch}"
+  else
+    attrs="linear.key=${TICKET},catalyst.orchestration=${ORCH_ID}"
+  fi
+  printf '%s\n' "$attrs"
+}
+
 # ─── Resolve model: CLI > modelOverrides > models > default ────────────────
 
 resolve_model() {
@@ -298,12 +343,21 @@ PROMPT="/catalyst-dev:phase-${PHASE} ${TICKET} --orch-dir ${ORCH_DIR}"
 # Pass the resolved env through so the phase agent inherits orchestrator
 # context + the humanlayer-friendly thoughts repo location. The dispatch
 # scaffold contract documents these as the implicit interface.
+#
+# We also forward `OTEL_RESOURCE_ATTRIBUTES` (CTL-492) so Claude Code's OTEL
+# SDK stamps the worker's metrics/logs with `project`, `linear.key`,
+# `catalyst.orchestration` (and `branch` when resolvable) — matching what
+# direnv produces for the interactive orchestrator.
+OTEL_RES_ATTRS="$(compose_otel_resource_attrs)"
+
 DISPATCH_ENV=(
   "CATALYST_ORCHESTRATOR_DIR=${ORCH_DIR}"
   "CATALYST_ORCHESTRATOR_ID=${ORCH_ID}"
   "CATALYST_PHASE=${PHASE}"
   "CATALYST_TICKET=${TICKET}"
 )
+[[ -n "$OTEL_RES_ATTRS" ]] && \
+  DISPATCH_ENV+=( "OTEL_RESOURCE_ATTRIBUTES=${OTEL_RES_ATTRS}" )
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
   # Dry-run prints the command it would have run without spawning anything.


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-18T15:30:00Z -->
<!-- Last updated: 2026-05-18T15:30:00Z -->
<!-- PR: #862 -->
<!-- Previous commits: 65646524d6e84ac936a3ccff6c6e4c9eea1c1df2 -->

## Summary

Phase-agent workers spawned via `claude --bg` were emitting OTEL metrics/logs with empty `linear_key`, `branch`, `catalyst_orchestration`, and `project` labels. The Grafana "Cost by Linear Ticket" panel filters on a non-empty `linear_key`, so phase-agent worker cost was silently dropped — the prior dogfood run (orch-ctl-489-473-2026-05-17) under-attributed ~75% of phase-agent spend (CTL-473 missing entirely; CTL-489 captured only the interactive orchestrator's $20.23 of $48.20+ actual).

Root cause: `phase-agent-dispatch` builds an explicit `DISPATCH_ENV` array (only `CATALYST_*` vars) and invokes `env -i … claude --bg`, so the orchestrator's direnv-supplied `OTEL_RESOURCE_ATTRIBUTES` never crosses the process boundary.

Fix: compose the same attribute string the orchestrator gets from `~/.config/direnv/lib/otel.sh` — using values already in scope (`TICKET`, `ORCH_ID`, `projectKey` from `.catalyst/config.json`, branch via 3-tier resolution) — and append it to `DISPATCH_ENV` before the bg invocation.

## Changes Made

### `plugins/dev/scripts/phase-agent-dispatch`

- New `compose_otel_resource_attrs()` helper composes `project=…,linear.key=…,catalyst.orchestration=…,branch=…` from the existing scope. Output matches direnv's format byte-for-byte so the same labels surface across orchestrator and worker sessions.
- Branch resolution is tiered:
  1. **Authoritative**: `git -C <worker-wt> branch --show-current` when the worker worktree exists (matches `create-worktree.sh` semantics — branch name == worktree basename).
  2. **Constructed**: `<orch-id>-<ticket>` (the convention `create-worktree.sh` itself uses).
  3. **Omitted entirely** if `projectKey` is unresolvable — produces a three-attr string with only `linear.key` + `catalyst.orchestration` rather than poisoning the label with `unknown`.
- `OTEL_RESOURCE_ATTRIBUTES=…` is appended to the existing `DISPATCH_ENV` array (lines 264–269 surface from research), so the propagation mechanism reuses the established env-passing path — no new conditional branch in the dispatch invocation.

### `plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh`

Six new tests covering:

- **Test 10**: happy path — `projectKey` present, full four-attr string composed with tier-2 branch fallback.
- **Test 11**: no `projectKey` — three-attr fallback omits both `project=` and `branch=` (the latter because branch only carries meaning relative to a project).
- **Test 12**: tier-1 wins — when the worker worktree exists as a real git repo on a bespoke branch (`bespoke-branch`), tier-1 resolution beats the tier-2 constructed name.
- **Test 13** (follow-up): tier-1 → tier-2 fall-through when the worker-wt path exists but has no `.git` entry (the real-world degradation mode where a previous `create-worktree` failed mid-way).
- **Test 14**: `--dry-run` JSON `env` array carries the OTEL entry — keeps the orchestrate-side dry-run contract honest.

55 assertions across 14 tests, all passing. No new shellcheck warnings vs the rebased main baseline.

## How to Verify It

- [x] **Test suite passes**: `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` → 55 passed, 0 failed ✅
- [x] **Bash syntax clean**: `bash -n plugins/dev/scripts/phase-agent-dispatch` ✅
- [x] **Bash syntax clean (tests)**: `bash -n plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` ✅
- [x] **Rebased cleanly on `main`** after CTL-490's BG_JOB_ID parser fix landed (Test 9 preserved from main; CTL-492's tests renumbered 10–14 in this rebase) ✅
- [ ] **Live verification** (post-merge): next phase-agent dogfood run should show non-empty `linear_key` in `claude_code_cost_usage_USD_total{session_id=~"<bg_job_id>.*"}` on `https://prometheus.otel.rozich.com`, and the Grafana "Cost by Linear Ticket" panel should attribute phase-agent worker cost to its ticket.

## Related

- Fixes [CTL-492](https://linear.app/coalesce-labs/issue/CTL-492)
- Sister-gap to CTL-487 (orchestrate-roll-usage instrumentation) — both made phase-agent runs invisible to cost analytics. With this and CTL-487 landed, the phase-agents dispatch mode achieves full cost-attribution parity with `oneshot-legacy`.
- Research: `thoughts/shared/research/2026-05-18-ctl-492.md`
- Plan: `thoughts/shared/plans/2026-05-18-ctl-492.md`

## Reviewer Notes

The rebase resolved a non-trivial conflict in `phase-agent-dispatch.test.sh` against CTL-490's Test 9 (BG_JOB_ID parser, merged to main as #848). Both test blocks were preserved — CTL-490's Test 9 stays at slot 9, CTL-492's tests renumber to 10–14. The auto-merge in `plugins/dev/scripts/phase-agent-dispatch` itself was clean (the OTEL composition logic and the BG_JOB_ID `grep -oE` parser fix don't overlap textually).
