### PR TITLE
CTL-496: capture cost for phase-agent claude --bg workers

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -290,6 +290,42 @@ per-ticket subdirectories, picks the most recent non-terminal phase, and overlay
 its `phaseName`/`status` onto the flat signal so the PHASE column shows the live
 phase (e.g. `implement`, `monitor-merge`).
 
+## Cost capture
+
+Both dispatch modes write the same four cost surfaces — `signal.cost`,
+`state.workers[ticket].usage`, `state.usage`, and the `session_metrics` SQLite
+mirror — but the USAGE source differs by mode. `orchestrate-roll-usage.sh`,
+invoked by `update-dashboard.sh --roll-usage` on every monitor wake-up,
+abstracts the difference.
+
+**Legacy (`oneshot-legacy` dispatch).** Workers run as `claude -p
+--output-format stream-json`. The CLI streams a final `"type":"result"` event
+carrying `total_cost_usd`, `usage`, `num_turns`, and `duration_ms` into
+`workers/output/<TICKET>-stream.jsonl`. roll-usage parses that event into a
+USAGE record.
+
+**Phase-agent (`phase-agents` dispatch, CTL-496).** Workers run as `claude
+--bg` jobs. There is no `result` event because there is no `--output-format
+stream-json` flag on the bg invocation; instead the CLI writes the full
+conversation to `~/.claude/projects/<wt>/<sessionId>.jsonl`. roll-usage
+resolves the JSONL path via `~/.claude/jobs/<bg_job_id>/state.json
+-> linkScanPath` and shells `extract-cost-from-jsonl.sh --jsonl <path>
+--pricing claude-pricing.json` to aggregate per-assistant-event `usage` by
+model, split cache_creation by 5m / 1h TTL, and apply the per-model rates
+from a versioned `plugins/dev/scripts/claude-pricing.json`. The four
+downstream writes are then unchanged from legacy.
+
+Phase mode aggregates `state.workers[ticket].usage` across phases (`+=`),
+not overwriting, so `state.workers[T].usage.costUSD == sum(phase.cost.costUSD)`
+for that ticket. The `session_metrics` mirror finds the right row via
+`signal.catalystSessionId` (persisted by the phase-agent prelude) or, for
+in-flight runs that predate that persistence, a DB lookup keyed on
+`ticket_key + skill_name = 'phase-<name>'`.
+
+The sweep loop in `update-dashboard.sh` iterates both layouts on every
+wake-up. Killed-worker sidecars (`workers/<T>/phase-<name>.json.dead-<id>.json`)
+are skipped so booked cost is never double-counted.
+
 ## On Claude Code's "agent view" / agents sidebar
 
 Phase-agent workers run as `claude --bg` jobs and live under
@@ -319,6 +355,8 @@ it exposes.
 | `~/catalyst/runs/<id>/workers/<TICKET>.json` | `orchestrate-dispatch-next` + worker | top-level worker signal |
 | `~/catalyst/runs/<id>/workers/<TICKET>/phase-<name>.json` | `phase-agent-dispatch` | per-phase signal (phase-agents mode only) |
 | `~/catalyst/runs/<id>/workers/output/<TICKET>-{stream.jsonl,bg-stdout.log,stderr.log}` | spawned worker | worker stdio capture |
+| `~/catalyst/runs/<id>/.roll-usage.log` | `orchestrate-roll-usage.sh -v` (via `update-dashboard.sh --roll-usage`) | per-sweep audit trail of cost rollups (action codes: `wrote-cost`, `already-rolled`, `bg-state-missing`, `jsonl-missing`, `wrote-metric`, etc.) |
+| `plugins/dev/scripts/claude-pricing.json` | manual edit (version-pinned, see file header) | per-model token pricing table consumed by `extract-cost-from-jsonl.sh` in phase mode |
 | `~/catalyst/runs/<id>/findings.jsonl` | both | shared findings queue |
 | `~/catalyst/state.json` | `catalyst-state.sh` register/update/worker/heartbeat | global active-runs registry |
 | `~/catalyst/catalyst.db` | `catalyst-archive.ts sweep` + skill instrumentation | SQLite sessions + metrics + archive index |

--- a/plugins/dev/scripts/__tests__/extract-cost-from-jsonl.test.sh
+++ b/plugins/dev/scripts/__tests__/extract-cost-from-jsonl.test.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Shell tests for extract-cost-from-jsonl.sh (CTL-496).
+#
+# Verifies the pure-function JSONL extractor that reads a Claude bg-session
+# conversation JSONL and emits a USAGE record matching the shape produced by
+# orchestrate-roll-usage.sh for legacy stream-json `result` events. The
+# extractor is the cost source for the phase-agent dispatch mode where the
+# CLI does not write the stream-json `result` event (no --output-format flag).
+#
+# Run: bash plugins/dev/scripts/__tests__/extract-cost-from-jsonl.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/scripts/extract-cost-from-jsonl.sh"
+PRICING="${REPO_ROOT}/plugins/dev/scripts/claude-pricing.json"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+JSONL="${SCRATCH}/sess.jsonl"
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+# Build a JSONL with N assistant events for one model, summing to the
+# specified per-event totals. Cache creation is split into 5m and 1h buckets
+# so callers can exercise the pricing split.
+build_jsonl_single_model() {
+  local out="$1"; shift
+  local model="claude-opus-4-7" events=1 input=0 output=0 cache_read=0 cache_5m=0 cache_1h=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --model)              model="$2"; shift 2 ;;
+      --assistant-events)   events="$2"; shift 2 ;;
+      --input-tokens)       input="$2"; shift 2 ;;
+      --output-tokens)      output="$2"; shift 2 ;;
+      --cache-read)         cache_read="$2"; shift 2 ;;
+      --cache-creation-5m)  cache_5m="$2"; shift 2 ;;
+      --cache-creation-1h)  cache_1h="$2"; shift 2 ;;
+      *) echo "build_jsonl_single_model: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  : > "$out"
+  local i pi po pcr p5 p1
+  # Distribute totals across events as evenly as the integer math allows;
+  # the LAST event absorbs the remainder so the global sums match exactly.
+  pi=$(( input / events ));      ri=$(( input - pi * (events-1) ))
+  po=$(( output / events ));     ro=$(( output - po * (events-1) ))
+  pcr=$(( cache_read / events )); rcr=$(( cache_read - pcr * (events-1) ))
+  p5=$(( cache_5m / events ));   r5=$(( cache_5m - p5 * (events-1) ))
+  p1=$(( cache_1h / events ));   r1=$(( cache_1h - p1 * (events-1) ))
+  for (( i=1; i<=events; i++ )); do
+    local ei eo ecr e5 e1
+    if [ "$i" -lt "$events" ]; then
+      ei=$pi; eo=$po; ecr=$pcr; e5=$p5; e1=$p1
+    else
+      ei=$ri; eo=$ro; ecr=$rcr; e5=$r5; e1=$r1
+    fi
+    jq -nc \
+      --arg model "$model" \
+      --argjson input "$ei" --argjson output "$eo" --argjson cache_read "$ecr" \
+      --argjson cache_5m "$e5" --argjson cache_1h "$e1" \
+      '{type:"assistant",
+        message:{
+          model:$model,
+          stop_reason:"tool_use",
+          usage:{
+            input_tokens:$input,
+            output_tokens:$output,
+            cache_read_input_tokens:$cache_read,
+            cache_creation:{
+              ephemeral_5m_input_tokens:$cache_5m,
+              ephemeral_1h_input_tokens:$cache_1h
+            }
+          }
+        }
+      }' >> "$out"
+  done
+}
+
+# Build a JSONL with two models: opus and sonnet.
+build_jsonl_multi_model() {
+  local out="$1"; shift
+  local opus_in=0 opus_out=0 sonnet_in=0 sonnet_out=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --opus-input)   opus_in="$2"; shift 2 ;;
+      --opus-output)  opus_out="$2"; shift 2 ;;
+      --sonnet-input) sonnet_in="$2"; shift 2 ;;
+      --sonnet-output) sonnet_out="$2"; shift 2 ;;
+      *) echo "build_jsonl_multi_model: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  : > "$out"
+  jq -nc \
+    --argjson input "$opus_in" --argjson output "$opus_out" \
+    '{type:"assistant",
+      message:{model:"claude-opus-4-7",stop_reason:"tool_use",
+        usage:{input_tokens:$input,output_tokens:$output,
+          cache_read_input_tokens:0,
+          cache_creation:{ephemeral_5m_input_tokens:0,ephemeral_1h_input_tokens:0}}}}' >> "$out"
+  jq -nc \
+    --argjson input "$sonnet_in" --argjson output "$sonnet_out" \
+    '{type:"assistant",
+      message:{model:"claude-sonnet-4-6",stop_reason:"tool_use",
+        usage:{input_tokens:$input,output_tokens:$output,
+          cache_read_input_tokens:0,
+          cache_creation:{ephemeral_5m_input_tokens:0,ephemeral_1h_input_tokens:0}}}}' >> "$out"
+}
+
+# Build a JSONL whose only assistant event splits cache creation across 5m+1h.
+build_jsonl_cache_split() {
+  local out="$1"; shift
+  local cache_5m=0 cache_1h=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --cache-creation-5m) cache_5m="$2"; shift 2 ;;
+      --cache-creation-1h) cache_1h="$2"; shift 2 ;;
+      *) echo "build_jsonl_cache_split: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  build_jsonl_single_model "$out" --model claude-opus-4-7 --assistant-events 1 \
+    --cache-creation-5m "$cache_5m" --cache-creation-1h "$cache_1h"
+}
+
+# Build a JSONL with N assistant events AND a single system.turn_duration
+# event carrying the total duration in milliseconds.
+build_jsonl_with_durations() {
+  local out="$1"; shift
+  local turns=1 total_ms=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --turns)    turns="$2"; shift 2 ;;
+      --total-ms) total_ms="$2"; shift 2 ;;
+      *) echo "build_jsonl_with_durations: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  build_jsonl_single_model "$out" --assistant-events "$turns" \
+    --input-tokens 0 --output-tokens 0
+  jq -nc --argjson ms "$total_ms" \
+    '{type:"system",subtype:"turn_duration",durationMs:$ms}' >> "$out"
+}
+
+# Build a JSONL with N assistant events + N user events; the user events
+# must NOT contribute to numTurns.
+build_jsonl_with_turns() {
+  local out="$1"; shift
+  local assistant=1 user=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --assistant-events) assistant="$2"; shift 2 ;;
+      --user-events)      user="$2"; shift 2 ;;
+      *) echo "build_jsonl_with_turns: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  build_jsonl_single_model "$out" --assistant-events "$assistant" \
+    --input-tokens 0 --output-tokens 0
+  local i
+  for (( i=1; i<=user; i++ )); do
+    jq -nc '{type:"user",message:{role:"user",content:[{type:"text",text:"hi"}]}}' >> "$out"
+  done
+}
+
+# Build a JSONL with a single assistant event for an unknown (unpriced) model.
+build_jsonl_unknown_model() {
+  local out="$1"; shift
+  local model="fictional-model-9" input=0 output=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --model)  model="$2"; shift 2 ;;
+      --input)  input="$2"; shift 2 ;;
+      --output) output="$2"; shift 2 ;;
+      *) echo "build_jsonl_unknown_model: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  build_jsonl_single_model "$out" --model "$model" --assistant-events 1 \
+    --input-tokens "$input" --output-tokens "$output"
+}
+
+# ───────────────────────────────────────────────────────────────────────────────
+echo "extract-cost-from-jsonl tests"
+echo ""
+
+# ─── Test 1: helper exists and is executable ──────────────────────────────────
+run "extractor exists"        bash -c "[ -f '$HELPER' ]"
+run "extractor is executable" bash -c "[ -x '$HELPER' ]"
+run "pricing table exists"    bash -c "[ -f '$PRICING' ]"
+
+# ─── Test 2: single-model JSONL → correct USAGE record ────────────────────────
+build_jsonl_single_model "$JSONL" \
+  --model claude-opus-4-7 \
+  --assistant-events 3 \
+  --input-tokens 1000 --output-tokens 500 \
+  --cache-read 200 --cache-creation-5m 100 --cache-creation-1h 0
+USAGE=$("$HELPER" --jsonl "$JSONL" --pricing "$PRICING")
+run "input_tokens summed" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '1000' ]"
+run "output_tokens summed" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .outputTokens)\" = '500' ]"
+run "cache_read summed" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .cacheReadTokens)\" = '200' ]"
+run "cache_creation summed (5m+1h)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .cacheCreationTokens)\" = '100' ]"
+run "model captured" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .model)\" = 'claude-opus-4-7' ]"
+# cost = 1000*15/1e6 + 500*75/1e6 + 200*1.5/1e6 + 100*18.75/1e6
+#      = 0.015 + 0.0375 + 0.0003 + 0.001875 = 0.054675
+run "costUSD computed (opus, 5m cache-creation)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .costUSD)\" = '0.054675' ]"
+
+# ─── Test 3: multi-model JSONL → cost is per-model sum ────────────────────────
+build_jsonl_multi_model "$JSONL" \
+  --opus-input 1000 --opus-output 500 \
+  --sonnet-input 2000 --sonnet-output 1000
+USAGE=$("$HELPER" --jsonl "$JSONL" --pricing "$PRICING")
+# opus  = 1000*15/1e6 + 500*75/1e6 = 0.015 + 0.0375 = 0.0525
+# sonnet = 2000*3/1e6 + 1000*15/1e6 = 0.006 + 0.015 = 0.021
+# total = 0.0735
+run "multi-model costUSD (opus+sonnet)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .costUSD)\" = '0.0735' ]"
+run "primary model is highest-cost (opus)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .model)\" = 'claude-opus-4-7' ]"
+
+# ─── Test 4: cache_creation_5m vs cache_creation_1h split (different prices) ──
+build_jsonl_cache_split "$JSONL" \
+  --cache-creation-5m 100 --cache-creation-1h 100
+# 100*18.75/1e6 + 100*30/1e6 = 0.001875 + 0.003 = 0.004875
+USAGE=$("$HELPER" --jsonl "$JSONL" --pricing "$PRICING")
+run "cache 5m+1h pricing differentiated" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .costUSD)\" = '0.004875' ]"
+
+# ─── Test 5: duration_ms is sum of system.turn_duration events ────────────────
+build_jsonl_with_durations "$JSONL" --turns 3 --total-ms 45000
+USAGE=$("$HELPER" --jsonl "$JSONL" --pricing "$PRICING")
+run "durationMs aggregated from system.turn_duration" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .durationMs)\" = '45000' ]"
+
+# ─── Test 6: numTurns counts assistant events only ────────────────────────────
+build_jsonl_with_turns "$JSONL" --assistant-events 5 --user-events 5
+USAGE=$("$HELPER" --jsonl "$JSONL" --pricing "$PRICING")
+run "numTurns counts assistant events (not user)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .numTurns)\" = '5' ]"
+
+# ─── Test 7: empty JSONL → zeroed USAGE record (not error) ────────────────────
+: > "$JSONL"
+USAGE=$("$HELPER" --jsonl "$JSONL" --pricing "$PRICING")
+run "empty JSONL costUSD=0" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .costUSD)\" = '0' ]"
+run "empty JSONL model=null" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .model)\" = 'null' ]"
+run "empty JSONL inputTokens=0" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '0' ]"
+
+# ─── Test 8: missing JSONL file → exit 1, no stdout ───────────────────────────
+run "missing JSONL exits non-zero" \
+  bash -c "! '$HELPER' --jsonl /no/such/file --pricing '$PRICING' 2>/dev/null"
+
+# ─── Test 9: missing pricing file → exit 1 ────────────────────────────────────
+run "missing pricing exits non-zero" \
+  bash -c "! '$HELPER' --jsonl '$JSONL' --pricing /no/such/pricing 2>/dev/null"
+
+# ─── Test 10: unknown model → cost 0 for that model, tokens still counted ─────
+build_jsonl_unknown_model "$JSONL" --model fictional-model-9 \
+  --input 1000 --output 500
+USAGE=$("$HELPER" --jsonl "$JSONL" --pricing "$PRICING" 2>/dev/null)
+run "unknown model contributes 0 cost" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .costUSD)\" = '0' ]"
+run "unknown model tokens still counted" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '1000' ]"
+
+# ─── Test 11: real-world fixture → sane USAGE ─────────────────────────────────
+# Synthesize a real-shape fixture rather than depending on a live JSONL path
+# that may not exist when this test runs in CI. The real schema includes
+# server_tool_use, iterations[], service_tier, etc.; the extractor must
+# tolerate them.
+FIXTURE="${SCRATCH}/real-shape.jsonl"
+cat > "$FIXTURE" <<'EOF'
+{"type":"agent-name","name":"main"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"go"}]}}
+{"type":"assistant","message":{"model":"claude-opus-4-7","stop_reason":"tool_use","usage":{"input_tokens":5,"output_tokens":349,"cache_read_input_tokens":24482,"cache_creation_input_tokens":26173,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":26173},"server_tool_use":{"web_search_requests":0,"web_fetch_requests":0},"service_tier":"standard","iterations":[]}}}
+{"type":"assistant","message":{"model":"claude-opus-4-7","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":200,"cache_read_input_tokens":100,"cache_creation":{"ephemeral_5m_input_tokens":50,"ephemeral_1h_input_tokens":0}}}}
+{"type":"system","subtype":"turn_duration","durationMs":1406556}
+{"type":"system","subtype":"stop_hook_summary"}
+EOF
+USAGE=$("$HELPER" --jsonl "$FIXTURE" --pricing "$PRICING")
+run "real fixture has positive cost" \
+  bash -c "[ \"\$(echo '$USAGE' | jq '.costUSD > 0')\" = 'true' ]"
+run "real fixture inputTokens summed" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '15' ]"
+run "real fixture outputTokens summed" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .outputTokens)\" = '549' ]"
+run "real fixture cacheReadTokens summed" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .cacheReadTokens)\" = '24582' ]"
+run "real fixture cacheCreationTokens (5m + 1h)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .cacheCreationTokens)\" = '26223' ]"
+run "real fixture model is opus" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .model)\" = 'claude-opus-4-7' ]"
+run "real fixture durationMs from turn_duration" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .durationMs)\" = '1406556' ]"
+run "real fixture numTurns counts only assistant" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .numTurns)\" = '2' ]"
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh
@@ -510,8 +510,255 @@ run "DB-fallback: session_metrics.input_tokens populated via ticket lookup" \
 run "DB-fallback: session_metrics.duration_ms populated via ticket lookup" \
   bash -c "[ \"\$(sqlite3 '$CATALYST_DB' \"SELECT duration_ms FROM session_metrics WHERE session_id='${SID_18}';\")\" = '75000' ]"
 
+# ───────────────────────────────────────────────────────────────────────────────
+# Phase-agent mode tests (CTL-496) — `--phase <name>` sources cost from the
+# bg session JSONL via extract-cost-from-jsonl.sh instead of stream-json.
+# ───────────────────────────────────────────────────────────────────────────────
+
+PRICING="${REPO_ROOT}/plugins/dev/scripts/claude-pricing.json"
+BG_JOBS_DIR="${SCRATCH}/claude-jobs"
+mkdir -p "$BG_JOBS_DIR"
+export CATALYST_BG_JOBS_DIR="$BG_JOBS_DIR"
+
+# Build a phase-mode signal file at workers/<TICKET>/phase-<NAME>.json.
+# CTL-496 contract: bg_job_id (resolves bg state.json), catalystSessionId
+# (mirrors into session_metrics), ticket, phase, status.
+build_phase_signal() {
+  local out="$1" ticket="$2"; shift 2
+  local bg_job_id="" catalyst_sid=""
+  local phase_name
+  phase_name="$(basename "$out" .json)"
+  phase_name="${phase_name#phase-}"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --bg-job-id)            bg_job_id="$2"; shift 2 ;;
+      --catalyst-session-id)  catalyst_sid="$2"; shift 2 ;;
+      *) echo "build_phase_signal: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  mkdir -p "$(dirname "$out")"
+  jq -n \
+    --arg ticket "$ticket" \
+    --arg phase "$phase_name" \
+    --arg bg "$bg_job_id" \
+    --arg sid "$catalyst_sid" \
+    '{
+      ticket: $ticket,
+      phase: $phase,
+      orchestrator: "orch-test",
+      status: "running",
+      startedAt: "2026-05-18T09:00:00Z",
+      updatedAt: "2026-05-18T09:30:00Z"
+    }
+    | if $bg != "" then .bg_job_id = $bg else . end
+    | if $sid != "" then .catalystSessionId = $sid else . end' > "$out"
+}
+
+# Build a fake ~/.claude/jobs/<id>/state.json so phase mode can resolve the
+# linkScanPath without requiring a real Claude CLI bg session.
+build_fake_bg_state() {
+  local bg_id="$1"; shift
+  local session_id="" link_scan_path=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --session-id)     session_id="$2"; shift 2 ;;
+      --link-scan-path) link_scan_path="$2"; shift 2 ;;
+      *) echo "build_fake_bg_state: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  mkdir -p "${BG_JOBS_DIR}/${bg_id}"
+  jq -n \
+    --arg sid "$session_id" \
+    --arg lsp "$link_scan_path" \
+    '{state:"working", sessionId:$sid, linkScanPath:$lsp, daemonShort:$sid|.[0:8]}' \
+    > "${BG_JOBS_DIR}/${bg_id}/state.json"
+}
+
+# Build a JSONL at the specified path matching the Claude conversation schema
+# that extract-cost-from-jsonl.sh consumes.
+build_jsonl_at() {
+  local out="$1"; shift
+  local model="claude-opus-4-7" input=0 output=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --model)  model="$2"; shift 2 ;;
+      --input)  input="$2"; shift 2 ;;
+      --output) output="$2"; shift 2 ;;
+      *) echo "build_jsonl_at: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  mkdir -p "$(dirname "$out")"
+  jq -nc \
+    --arg model "$model" \
+    --argjson input "$input" --argjson output "$output" \
+    '{type:"assistant",
+      message:{model:$model,stop_reason:"end_turn",
+        usage:{input_tokens:$input,output_tokens:$output,
+          cache_read_input_tokens:0,
+          cache_creation:{ephemeral_5m_input_tokens:0,ephemeral_1h_input_tokens:0}}}}' > "$out"
+}
+
+# Insert a session row for a specific skill_name (mirrors what catalyst-session.sh
+# start would create when invoked from the phase-agent prelude).
+build_fake_session_row() {
+  local sid="$1"; shift
+  local ticket="" skill=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --ticket) ticket="$2"; shift 2 ;;
+      --skill)  skill="$2"; shift 2 ;;
+      *) echo "build_fake_session_row: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  sqlite3 "$CATALYST_DB" "INSERT INTO sessions
+    (session_id, ticket_key, skill_name, status, started_at, updated_at)
+    VALUES ('${sid}', '${ticket}', '${skill}', 'running',
+            '2026-05-18T09:00:00Z', '2026-05-18T09:00:00Z');"
+}
+
+# ─── Test 19: --phase resolves correct signal file path; signal.cost populated ─
+ORCH_DIR=$(setup_orch "orch-p1")
+init_test_db
+build_phase_signal "${ORCH_DIR}/workers/CTL-T1/phase-research.json" "CTL-T1" \
+  --bg-job-id "fake-bg-1" --catalyst-session-id "sess_test_research"
+build_fake_bg_state "fake-bg-1" --session-id "fake-claude-sess-1" \
+  --link-scan-path "${SCRATCH}/fake-cwd/fake-claude-sess-1.jsonl"
+build_jsonl_at "${SCRATCH}/fake-cwd/fake-claude-sess-1.jsonl" \
+  --model claude-opus-4-7 --input 1000 --output 500
+build_fake_session_row "sess_test_research" --ticket "CTL-T1" --skill "phase-research"
+
+"$HELPER" --orch "orch-p1" --ticket "CTL-T1" --phase "research" --orch-dir "$ORCH_DIR"
+run "phase: signal.cost.inputTokens populated" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/CTL-T1/phase-research.json')\" = '1000' ]"
+run "phase: signal.cost.outputTokens populated" \
+  bash -c "[ \"\$(jq -r '.cost.outputTokens' '${ORCH_DIR}/workers/CTL-T1/phase-research.json')\" = '500' ]"
+run "phase: signal.cost.model populated" \
+  bash -c "[ \"\$(jq -r '.cost.model' '${ORCH_DIR}/workers/CTL-T1/phase-research.json')\" = 'claude-opus-4-7' ]"
+run "phase: signal.cost.costUSD > 0" \
+  bash -c "[ \"\$(jq '.cost.costUSD > 0' '${ORCH_DIR}/workers/CTL-T1/phase-research.json')\" = 'true' ]"
+run "phase: flat signal file NOT created" \
+  bash -c "[ ! -f '${ORCH_DIR}/workers/CTL-T1.json' ]"
+
+# ─── Test 20: phase mode is idempotent ────────────────────────────────────────
+"$HELPER" --orch "orch-p1" --ticket "CTL-T1" --phase "research" --orch-dir "$ORCH_DIR"
+run "phase idempotent: inputTokens unchanged after re-roll" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/CTL-T1/phase-research.json')\" = '1000' ]"
+
+# ─── Test 21: phase mode aggregates across phases for state.workers[T].usage ──
+build_phase_signal "${ORCH_DIR}/workers/CTL-T1/phase-plan.json" "CTL-T1" \
+  --bg-job-id "fake-bg-2" --catalyst-session-id "sess_test_plan"
+build_fake_bg_state "fake-bg-2" --session-id "fake-claude-sess-2" \
+  --link-scan-path "${SCRATCH}/fake-cwd/fake-claude-sess-2.jsonl"
+build_jsonl_at "${SCRATCH}/fake-cwd/fake-claude-sess-2.jsonl" \
+  --model claude-opus-4-7 --input 2000 --output 1000
+build_fake_session_row "sess_test_plan" --ticket "CTL-T1" --skill "phase-plan"
+
+"$HELPER" --orch "orch-p1" --ticket "CTL-T1" --phase "plan" --orch-dir "$ORCH_DIR"
+run "phase agg: state.workers[CTL-T1].usage.inputTokens == 3000 (research+plan)" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-p1\"].workers[\"CTL-T1\"].usage.inputTokens' '$CATALYST_STATE_FILE')\" = '3000' ]"
+run "phase agg: state.workers[CTL-T1].usage.outputTokens == 1500 (500+1000)" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-p1\"].workers[\"CTL-T1\"].usage.outputTokens' '$CATALYST_STATE_FILE')\" = '1500' ]"
+
+# ─── Test 22: missing bg state.json → bg-state-missing action, exit 0 ─────────
+ORCH_DIR=$(setup_orch "orch-p2")
+build_phase_signal "${ORCH_DIR}/workers/CTL-T2/phase-research.json" "CTL-T2" \
+  --bg-job-id "no-such-bg"
+LOG="${SCRATCH}/orch-p2.stderr"
+"$HELPER" --orch "orch-p2" --ticket "CTL-T2" --phase "research" --orch-dir "$ORCH_DIR" -v 2>"$LOG" >/dev/null || true
+run "phase: bg-state-missing logged" \
+  bash -c "grep -q 'bg-state-missing' '$LOG'"
+run "phase: bg-state-missing leaves signal.cost null" \
+  bash -c "[ \"\$(jq -r '.cost' '${ORCH_DIR}/workers/CTL-T2/phase-research.json')\" = 'null' ]"
+
+# ─── Test 23: missing JSONL (linkScanPath) → jsonl-missing action, exit 0 ─────
+build_fake_bg_state "no-jsonl-bg" --session-id "x" --link-scan-path "/no/such/file"
+build_phase_signal "${ORCH_DIR}/workers/CTL-T2/phase-plan.json" "CTL-T2" \
+  --bg-job-id "no-jsonl-bg"
+LOG="${SCRATCH}/orch-p2-jsonl.stderr"
+"$HELPER" --orch "orch-p2" --ticket "CTL-T2" --phase "plan" --orch-dir "$ORCH_DIR" -v 2>"$LOG" >/dev/null || true
+run "phase: jsonl-missing logged" \
+  bash -c "grep -q 'jsonl-missing' '$LOG'"
+
+# ─── Test 24: session_metrics row updated via catalystSessionId from signal ────
+SID_19="sess_test_research"
+run "phase metrics: session_metrics.cost_usd > 0" \
+  bash -c "[ \"\$(sqlite3 '$CATALYST_DB' \"SELECT cost_usd > 0 FROM session_metrics WHERE session_id='${SID_19}';\")\" = '1' ]"
+run "phase metrics: session_metrics.input_tokens populated" \
+  bash -c "[ \"\$(sqlite3 '$CATALYST_DB' \"SELECT input_tokens FROM session_metrics WHERE session_id='${SID_19}';\")\" = '1000' ]"
+
+# ─── Test 25: DB fallback by ticket+skill_name when signal lacks catalystSessionId ─
+ORCH_DIR=$(setup_orch "orch-p3")
+init_test_db
+build_phase_signal "${ORCH_DIR}/workers/CTL-T3/phase-verify.json" "CTL-T3" \
+  --bg-job-id "fake-bg-3"  # no catalyst-session-id in signal
+build_fake_bg_state "fake-bg-3" --session-id "fake-claude-sess-3" \
+  --link-scan-path "${SCRATCH}/fake-cwd/fake-claude-sess-3.jsonl"
+build_jsonl_at "${SCRATCH}/fake-cwd/fake-claude-sess-3.jsonl" \
+  --model claude-opus-4-7 --input 100 --output 50
+build_fake_session_row "sess_test_verify" --ticket "CTL-T3" --skill "phase-verify"
+
+"$HELPER" --orch "orch-p3" --ticket "CTL-T3" --phase "verify" --orch-dir "$ORCH_DIR"
+run "phase DB-fallback: session_metrics.cost_usd > 0 via ticket+skill lookup" \
+  bash -c "[ \"\$(sqlite3 '$CATALYST_DB' \"SELECT cost_usd > 0 FROM session_metrics WHERE session_id='sess_test_verify';\")\" = '1' ]"
+
+# ─── Test 26: DB fallback isolates phase by skill_name ────────────────────────
+# Two sessions for same ticket but different phases. phase=verify must NOT
+# mirror cost into the phase-research row.
+build_fake_session_row "sess_isolated_research" --ticket "CTL-T3" --skill "phase-research"
+# Sanity precondition: phase-research session_metrics is still empty
+run "phase isolation precondition: phase-research row absent" \
+  bash -c "[ \"\$(sqlite3 '$CATALYST_DB' 'SELECT COUNT(*) FROM session_metrics WHERE session_id=\"sess_isolated_research\";')\" = '0' ]"
+# Now do a phase-verify roll on a fresh signal; this should NOT write to the
+# research row.
+build_phase_signal "${ORCH_DIR}/workers/CTL-T3/phase-verify.json" "CTL-T3" \
+  --bg-job-id "fake-bg-3"  # re-create signal (.cost now null again)
+"$HELPER" --orch "orch-p3" --ticket "CTL-T3" --phase "verify" --orch-dir "$ORCH_DIR"
+run "phase isolation: phase-verify roll did not touch phase-research row" \
+  bash -c "[ \"\$(sqlite3 '$CATALYST_DB' 'SELECT COUNT(*) FROM session_metrics WHERE session_id=\"sess_isolated_research\";')\" = '0' ]"
+
+# ─── Test 27: verbose phase action codes ──────────────────────────────────────
+ORCH_DIR=$(setup_orch "orch-p4")
+build_phase_signal "${ORCH_DIR}/workers/CTL-T4/phase-research.json" "CTL-T4" \
+  --bg-job-id "fake-bg-4" --catalyst-session-id "sess_p4_research"
+build_fake_bg_state "fake-bg-4" --session-id "fake-claude-sess-4" \
+  --link-scan-path "${SCRATCH}/fake-cwd/fake-claude-sess-4.jsonl"
+build_jsonl_at "${SCRATCH}/fake-cwd/fake-claude-sess-4.jsonl" \
+  --model claude-opus-4-7 --input 1000 --output 500
+LOG="${SCRATCH}/orch-p4.stderr"
+"$HELPER" --orch "orch-p4" --ticket "CTL-T4" --phase "research" --orch-dir "$ORCH_DIR" -v 2>"$LOG" >/dev/null || true
+run "phase verbose: wrote-cost on successful roll" \
+  bash -c "grep -q 'roll-usage\\[ticket=CTL-T4,phase=research\\]: wrote-cost' '$LOG'"
+# Second invocation → already-rolled
+LOG="${SCRATCH}/orch-p4-2.stderr"
+"$HELPER" --orch "orch-p4" --ticket "CTL-T4" --phase "research" --orch-dir "$ORCH_DIR" -v 2>"$LOG" >/dev/null || true
+run "phase verbose: already-rolled on second invocation" \
+  bash -c "grep -q 'roll-usage\\[ticket=CTL-T4,phase=research\\]: already-rolled' '$LOG'"
+# Signal missing
+LOG="${SCRATCH}/orch-p4-3.stderr"
+"$HELPER" --orch "orch-p4" --ticket "CTL-NO-SIG" --phase "research" --orch-dir "$ORCH_DIR" -v 2>"$LOG" >/dev/null || true
+run "phase verbose: signal-missing when no signal file" \
+  bash -c "grep -q 'roll-usage\\[ticket=CTL-NO-SIG,phase=research\\]: signal-missing' '$LOG'"
+
+# ─── Test 28: zero-cost JSONL → zero-cost-retry, signal.cost stays null ───────
+# A bg session that started but hasn't produced any assistant events yet
+# will have an empty JSONL → extractor emits costUSD=0. Don't poison signal.
+ORCH_DIR=$(setup_orch "orch-p5")
+build_phase_signal "${ORCH_DIR}/workers/CTL-T5/phase-research.json" "CTL-T5" \
+  --bg-job-id "fake-bg-5"
+build_fake_bg_state "fake-bg-5" --session-id "fake-claude-sess-5" \
+  --link-scan-path "${SCRATCH}/fake-cwd/empty.jsonl"
+: > "${SCRATCH}/fake-cwd/empty.jsonl"
+mkdir -p "${SCRATCH}/fake-cwd"
+LOG="${SCRATCH}/orch-p5.stderr"
+"$HELPER" --orch "orch-p5" --ticket "CTL-T5" --phase "research" --orch-dir "$ORCH_DIR" -v 2>"$LOG" >/dev/null || true
+run "phase: zero-cost JSONL → zero-cost-retry" \
+  bash -c "grep -q 'zero-cost-retry' '$LOG'"
+run "phase: zero-cost-retry leaves signal.cost null" \
+  bash -c "[ \"\$(jq -r '.cost' '${ORCH_DIR}/workers/CTL-T5/phase-research.json')\" = 'null' ]"
+
 # Reset env so subsequent (none here) tests don't inherit the override.
 unset CATALYST_DB_FILE
+unset CATALYST_BG_JOBS_DIR
 
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh
@@ -784,6 +784,33 @@ run "phase race: state.workers[CTL-T6].usage.inputTokens == 1000 (not 5000)" \
 run "phase race: state.usage.inputTokens == 1000 (not 5000)" \
   bash -c "[ \"\$(jq -r '.orchestrators[\"orch-p6\"].usage.inputTokens' '$CATALYST_STATE_FILE')\" = '1000' ]"
 
+# ─── Test 30: unknown-model JSONL → tokens persist, no infinite retry ────────
+# An unknown model (e.g. pricing.json missed an update) is priced at zero but
+# the assistant did real work — there are non-zero tokens. The retry gate must
+# NOT short-circuit as zero-cost-retry; signal.cost must populate with
+# costUSD=0 + the actual token counts. Otherwise that phase's tokens are
+# permanently lost.
+ORCH_DIR=$(setup_orch "orch-p7")
+build_phase_signal "${ORCH_DIR}/workers/CTL-T7/phase-research.json" "CTL-T7" \
+  --bg-job-id "fake-bg-7"
+build_fake_bg_state "fake-bg-7" --session-id "fake-claude-sess-7" \
+  --link-scan-path "${SCRATCH}/fake-cwd/fake-claude-sess-7.jsonl"
+build_jsonl_at "${SCRATCH}/fake-cwd/fake-claude-sess-7.jsonl" \
+  --model claude-model-not-in-pricing-table --input 1234 --output 567
+LOG="${SCRATCH}/orch-p7.stderr"
+"$HELPER" --orch "orch-p7" --ticket "CTL-T7" --phase "research" --orch-dir "$ORCH_DIR" -v 2>"$LOG" >/dev/null || true
+
+run "phase: unknown-model does NOT short-circuit as zero-cost-retry" \
+  bash -c "! grep -q 'zero-cost-retry' '$LOG'"
+run "phase: unknown-model writes wrote-cost" \
+  bash -c "grep -q 'wrote-cost' '$LOG'"
+run "phase: unknown-model signal.cost.costUSD == 0" \
+  bash -c "[ \"\$(jq -r '.cost.costUSD' '${ORCH_DIR}/workers/CTL-T7/phase-research.json')\" = '0' ]"
+run "phase: unknown-model signal.cost.inputTokens == 1234 (tokens persisted)" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/CTL-T7/phase-research.json')\" = '1234' ]"
+run "phase: unknown-model signal.cost.outputTokens == 567" \
+  bash -c "[ \"\$(jq -r '.cost.outputTokens' '${ORCH_DIR}/workers/CTL-T7/phase-research.json')\" = '567' ]"
+
 # Reset env so subsequent (none here) tests don't inherit the override.
 unset CATALYST_DB_FILE
 unset CATALYST_BG_JOBS_DIR

--- a/plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh
@@ -756,6 +756,34 @@ run "phase: zero-cost JSONL → zero-cost-retry" \
 run "phase: zero-cost-retry leaves signal.cost null" \
   bash -c "[ \"\$(jq -r '.cost' '${ORCH_DIR}/workers/CTL-T5/phase-research.json')\" = 'null' ]"
 
+# ─── Test 29: parallel rolls on the SAME phase signal do not double-count ────
+# Without the flock at the top of roll-usage, two parallel sweeps could both
+# pass the `signal.cost == null` check, both compute USAGE, both invoke
+# `catalyst-state.sh worker` with `+=`, and double-count state.workers[T].usage.
+# Phase mode hits this faster than legacy because phase mode uses `+=` for the
+# state-workers aggregate. (Legacy mode used overwrite-assignment, which was
+# naturally idempotent on retry.) The lock makes both modes safe.
+ORCH_DIR=$(setup_orch "orch-p6")
+build_phase_signal "${ORCH_DIR}/workers/CTL-T6/phase-research.json" "CTL-T6" \
+  --bg-job-id "fake-bg-6"
+build_fake_bg_state "fake-bg-6" --session-id "fake-claude-sess-6" \
+  --link-scan-path "${SCRATCH}/fake-cwd/fake-claude-sess-6.jsonl"
+build_jsonl_at "${SCRATCH}/fake-cwd/fake-claude-sess-6.jsonl" \
+  --model claude-opus-4-7 --input 1000 --output 500
+
+# Fire 5 in parallel on the same per-phase signal.
+for i in 1 2 3 4 5; do
+  "$HELPER" --orch "orch-p6" --ticket "CTL-T6" --phase "research" --orch-dir "$ORCH_DIR" &
+done
+wait
+
+run "phase race: signal.cost.inputTokens == 1000 (not 5000)" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/CTL-T6/phase-research.json')\" = '1000' ]"
+run "phase race: state.workers[CTL-T6].usage.inputTokens == 1000 (not 5000)" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-p6\"].workers[\"CTL-T6\"].usage.inputTokens' '$CATALYST_STATE_FILE')\" = '1000' ]"
+run "phase race: state.usage.inputTokens == 1000 (not 5000)" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-p6\"].usage.inputTokens' '$CATALYST_STATE_FILE')\" = '1000' ]"
+
 # Reset env so subsequent (none here) tests don't inherit the override.
 unset CATALYST_DB_FILE
 unset CATALYST_BG_JOBS_DIR

--- a/plugins/dev/scripts/__tests__/phase-agent-template.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-template.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Shell tests for the catalystSessionId persistence step in the phase-agent
+# preludes (CTL-496).
+#
+# The 8 phase SKILL.md files (_phase-agent-template + the 7 Claude-session
+# phase skills) all include the same `jq` merge that writes
+# .catalystSessionId into the per-phase signal file alongside .status = "running"
+# and .updatedAt. orchestrate-roll-usage.sh --phase reads .catalystSessionId
+# to mirror cost into the right session_metrics row.
+#
+# This test exercises that jq merge in isolation against a synthesized signal
+# file, both with and without CATALYST_SESSION_ID set, to verify:
+#   1. when CATALYST_SESSION_ID is non-empty, .catalystSessionId is written
+#   2. when CATALYST_SESSION_ID is unset/empty, the signal is NOT mutated
+#      with an empty catalystSessionId (which would later confuse the DB
+#      fallback by appearing "set")
+#
+# We also assert every phase SKILL.md that calls catalyst-session.sh contains
+# the catalystSessionId merge so future template clones don't drift.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-agent-template.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILLS_DIR="${REPO_ROOT}/plugins/dev/skills"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+# Apply the canonical jq merge that lives in every phase SKILL prelude.
+# This must stay byte-identical to the body inside `jq --arg ts ...` in the
+# phase SKILLs (only the surrounding bash variables differ).
+apply_phase_prelude_jq() {
+  local signal="$1" ts="$2" sid="$3"
+  local tmp="${signal}.tmp.$$"
+  jq --arg ts "$ts" --arg sid "$sid" '
+    .status = "running"
+    | .updatedAt = $ts
+    | if $sid != "" then .catalystSessionId = $sid else . end
+  ' "$signal" > "$tmp" && mv "$tmp" "$signal"
+}
+
+# ───────────────────────────────────────────────────────────────────────────────
+echo "phase-agent-template catalystSessionId persistence tests"
+echo ""
+
+# ─── Test 1: CATALYST_SESSION_ID set → .catalystSessionId written ─────────────
+SIGNAL="${SCRATCH}/signal-with-sid.json"
+cat > "$SIGNAL" <<'EOF'
+{
+  "ticket": "CTL-T1",
+  "phase": "research",
+  "orchestrator": "orch-test",
+  "status": "pending",
+  "bg_job_id": "fake-bg-1",
+  "startedAt": "2026-05-18T09:00:00Z",
+  "updatedAt": "2026-05-18T09:00:00Z"
+}
+EOF
+apply_phase_prelude_jq "$SIGNAL" "2026-05-18T09:30:00Z" "sess_test_abcd"
+run "with SID: catalystSessionId set" \
+  bash -c "[ \"\$(jq -r '.catalystSessionId' '$SIGNAL')\" = 'sess_test_abcd' ]"
+run "with SID: status flipped to running" \
+  bash -c "[ \"\$(jq -r '.status' '$SIGNAL')\" = 'running' ]"
+run "with SID: updatedAt updated" \
+  bash -c "[ \"\$(jq -r '.updatedAt' '$SIGNAL')\" = '2026-05-18T09:30:00Z' ]"
+run "with SID: ticket preserved" \
+  bash -c "[ \"\$(jq -r '.ticket' '$SIGNAL')\" = 'CTL-T1' ]"
+run "with SID: bg_job_id preserved" \
+  bash -c "[ \"\$(jq -r '.bg_job_id' '$SIGNAL')\" = 'fake-bg-1' ]"
+
+# ─── Test 2: CATALYST_SESSION_ID empty → .catalystSessionId NOT written ───────
+# The DB fallback in orchestrate-roll-usage treats catalystSessionId="" as
+# "set but blank" if we naively write it, defeating the ticket+skill_name
+# lookup. The `if $sid != "" then ... else . end` guard prevents this.
+SIGNAL2="${SCRATCH}/signal-without-sid.json"
+cat > "$SIGNAL2" <<'EOF'
+{
+  "ticket": "CTL-T2",
+  "phase": "research",
+  "orchestrator": "orch-test",
+  "status": "pending",
+  "bg_job_id": "fake-bg-2",
+  "startedAt": "2026-05-18T09:00:00Z",
+  "updatedAt": "2026-05-18T09:00:00Z"
+}
+EOF
+apply_phase_prelude_jq "$SIGNAL2" "2026-05-18T09:30:00Z" ""
+run "no SID: catalystSessionId absent (not added as empty string)" \
+  bash -c "[ \"\$(jq 'has(\"catalystSessionId\")' '$SIGNAL2')\" = 'false' ]"
+run "no SID: status still flipped to running" \
+  bash -c "[ \"\$(jq -r '.status' '$SIGNAL2')\" = 'running' ]"
+run "no SID: updatedAt still updated" \
+  bash -c "[ \"\$(jq -r '.updatedAt' '$SIGNAL2')\" = '2026-05-18T09:30:00Z' ]"
+
+# ─── Test 3: re-running with same SID is idempotent ───────────────────────────
+SIGNAL3="${SCRATCH}/signal-rerun.json"
+cat > "$SIGNAL3" <<'EOF'
+{"ticket":"CTL-T3","phase":"plan","orchestrator":"orch-test","status":"pending","bg_job_id":"bg-3","startedAt":"2026-05-18T09:00:00Z","updatedAt":"2026-05-18T09:00:00Z"}
+EOF
+apply_phase_prelude_jq "$SIGNAL3" "2026-05-18T09:30:00Z" "sess_idempotent"
+apply_phase_prelude_jq "$SIGNAL3" "2026-05-18T09:30:00Z" "sess_idempotent"
+run "rerun: catalystSessionId still set correctly" \
+  bash -c "[ \"\$(jq -r '.catalystSessionId' '$SIGNAL3')\" = 'sess_idempotent' ]"
+
+# ─── Test 4: every phase SKILL that starts a catalyst-session has the merge ───
+# Drift guard: if someone clones the template into a new phase skill and
+# forgets to copy the catalystSessionId line, this test catches it.
+for skill in _phase-agent-template phase-research phase-plan phase-implement \
+             phase-verify phase-review phase-pr phase-monitor-merge; do
+  skill_file="${SKILLS_DIR}/${skill}/SKILL.md"
+  run "drift: ${skill}/SKILL.md contains catalystSessionId merge" \
+    bash -c "grep -q '\.catalystSessionId = \\\$sid' '$skill_file'"
+done
+
+# ─── Test 5: phase-triage and phase-monitor-deploy are shell-only and
+#             intentionally do NOT call catalyst-session.sh ─────────────────────
+# These two phases are deterministic shell programs; no Claude turns, no
+# session_metrics row, no catalystSessionId to persist. Document the
+# expectation so a future contributor doesn't add a bogus session-start to
+# them just for symmetry.
+for shell_only in phase-triage phase-monitor-deploy; do
+  skill_file="${SKILLS_DIR}/${shell_only}/SKILL.md"
+  run "shell-only: ${shell_only}/SKILL.md does NOT start a catalyst-session" \
+    bash -c "! grep -q 'SESSION_SCRIPT.*start' '$skill_file'"
+done
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh
@@ -237,6 +237,178 @@ build_signal "${ORCH_DIR}/workers/TEST-1.json" "TEST-1"
 run "--roll-usage with no stream files: helper still exits 0" \
   "$HELPER" --orch "orch-cd5" --orch-dir "$ORCH_DIR" --roll-usage --stdout
 
+# ───────────────────────────────────────────────────────────────────────────────
+# Phase-agent sweep loop tests (CTL-496)
+# Verifies that --roll-usage also walks workers/<TICKET>/phase-<NAME>.json
+# alongside the existing flat workers/<TICKET>.json layout.
+# ───────────────────────────────────────────────────────────────────────────────
+
+BG_JOBS_DIR="${SCRATCH}/claude-jobs"
+mkdir -p "$BG_JOBS_DIR"
+export CATALYST_BG_JOBS_DIR="$BG_JOBS_DIR"
+
+build_phase_signal() {
+  local out="$1" ticket="$2"; shift 2
+  local bg_job_id="" catalyst_sid=""
+  local phase_name
+  phase_name="$(basename "$out" .json)"
+  phase_name="${phase_name#phase-}"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --bg-job-id)            bg_job_id="$2"; shift 2 ;;
+      --catalyst-session-id)  catalyst_sid="$2"; shift 2 ;;
+      *) echo "build_phase_signal: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  mkdir -p "$(dirname "$out")"
+  jq -n \
+    --arg ticket "$ticket" \
+    --arg phase "$phase_name" \
+    --arg bg "$bg_job_id" \
+    --arg sid "$catalyst_sid" \
+    '{
+      ticket: $ticket,
+      phase: $phase,
+      orchestrator: "orch-test",
+      status: "running",
+      startedAt: "2026-05-18T09:00:00Z",
+      updatedAt: "2026-05-18T09:30:00Z"
+    }
+    | if $bg != "" then .bg_job_id = $bg else . end
+    | if $sid != "" then .catalystSessionId = $sid else . end' > "$out"
+}
+
+build_fake_bg_state() {
+  local bg_id="$1"; shift
+  local session_id="" link_scan_path=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --session-id)     session_id="$2"; shift 2 ;;
+      --link-scan-path) link_scan_path="$2"; shift 2 ;;
+      *) echo "build_fake_bg_state: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  mkdir -p "${BG_JOBS_DIR}/${bg_id}"
+  jq -n --arg sid "$session_id" --arg lsp "$link_scan_path" \
+    '{state:"working", sessionId:$sid, linkScanPath:$lsp}' \
+    > "${BG_JOBS_DIR}/${bg_id}/state.json"
+}
+
+build_phase_jsonl() {
+  local out="$1"; shift
+  local input=0 output=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --input)  input="$2"; shift 2 ;;
+      --output) output="$2"; shift 2 ;;
+      *) echo "build_phase_jsonl: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  mkdir -p "$(dirname "$out")"
+  jq -nc \
+    --argjson input "$input" --argjson output "$output" \
+    '{type:"assistant",
+      message:{model:"claude-opus-4-7",stop_reason:"end_turn",
+        usage:{input_tokens:$input,output_tokens:$output,
+          cache_read_input_tokens:0,
+          cache_creation:{ephemeral_5m_input_tokens:0,ephemeral_1h_input_tokens:0}}}}' > "$out"
+}
+
+# ─── Test 10: sweep discovers per-phase signal files and rolls each ───────────
+ORCH_DIR=$(setup_orch "orch-ph1")
+mkdir -p "${ORCH_DIR}/workers/PH-1"
+build_phase_signal "${ORCH_DIR}/workers/PH-1/phase-research.json" "PH-1" \
+  --bg-job-id "bg-ph1a"
+build_phase_signal "${ORCH_DIR}/workers/PH-1/phase-plan.json" "PH-1" \
+  --bg-job-id "bg-ph1b"
+build_fake_bg_state "bg-ph1a" --session-id "x1" \
+  --link-scan-path "${SCRATCH}/ph1a.jsonl"
+build_fake_bg_state "bg-ph1b" --session-id "x2" \
+  --link-scan-path "${SCRATCH}/ph1b.jsonl"
+build_phase_jsonl "${SCRATCH}/ph1a.jsonl" --input 1000 --output 500
+build_phase_jsonl "${SCRATCH}/ph1b.jsonl" --input 2000 --output 1000
+
+"$HELPER" --orch "orch-ph1" --orch-dir "$ORCH_DIR" --roll-usage --stdout >/dev/null
+
+run "phase sweep: phase-research signal.cost populated" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/PH-1/phase-research.json')\" = '1000' ]"
+run "phase sweep: phase-plan signal.cost populated" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/PH-1/phase-plan.json')\" = '2000' ]"
+run "phase sweep: state.workers[PH-1].usage.inputTokens == 3000 (sum across phases)" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-ph1\"].workers[\"PH-1\"].usage.inputTokens' '$CATALYST_STATE_FILE')\" = '3000' ]"
+run "phase sweep: .roll-usage.log records both phases" \
+  bash -c "grep -q 'ticket=PH-1,phase=research.*wrote-cost' '${ORCH_DIR}/.roll-usage.log' && grep -q 'ticket=PH-1,phase=plan.*wrote-cost' '${ORCH_DIR}/.roll-usage.log'"
+
+# ─── Test 11: sweep handles mixed layout (legacy flat + phase per-ticket) ─────
+ORCH_DIR=$(setup_orch "orch-ph2")
+# Legacy ticket with flat layout
+build_stream_with_result "${ORCH_DIR}/workers/output/L-1-stream.jsonl" \
+  "0.5" "5000" "500" "5" "10000"
+build_signal "${ORCH_DIR}/workers/L-1.json" "L-1"
+# Phase ticket
+mkdir -p "${ORCH_DIR}/workers/PH-2"
+build_phase_signal "${ORCH_DIR}/workers/PH-2/phase-triage.json" "PH-2" \
+  --bg-job-id "bg-ph2"
+build_fake_bg_state "bg-ph2" --session-id "y1" \
+  --link-scan-path "${SCRATCH}/ph2.jsonl"
+build_phase_jsonl "${SCRATCH}/ph2.jsonl" --input 500 --output 100
+
+"$HELPER" --orch "orch-ph2" --orch-dir "$ORCH_DIR" --roll-usage --stdout >/dev/null
+
+run "mixed: legacy L-1 flat signal.cost populated" \
+  bash -c "[ \"\$(jq -r '.cost.costUSD' '${ORCH_DIR}/workers/L-1.json')\" = '0.5' ]"
+run "mixed: phase PH-2 signal.cost populated" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/PH-2/phase-triage.json')\" = '500' ]"
+
+# ─── Test 12: phase sweep idempotent — re-running does not double-count ───────
+COST_BEFORE=$(jq -r '.orchestrators["orch-ph2"].usage.costUSD' "$CATALYST_STATE_FILE")
+"$HELPER" --orch "orch-ph2" --orch-dir "$ORCH_DIR" --roll-usage --stdout >/dev/null
+COST_AFTER=$(jq -r '.orchestrators["orch-ph2"].usage.costUSD' "$CATALYST_STATE_FILE")
+run "phase sweep idempotent: state.usage.costUSD unchanged" \
+  bash -c "[ \"$COST_BEFORE\" = \"$COST_AFTER\" ]"
+
+# ─── Test 13: .dead-*.json sidecars are skipped ───────────────────────────────
+# phase-agent-dispatch renames killed worker signals to phase-X.json.dead-*.json
+# for archival. The sweep glob must not pick these up — re-rolling them after
+# the live signal already booked the cost would double-count.
+ORCH_DIR=$(setup_orch "orch-ph3")
+mkdir -p "${ORCH_DIR}/workers/PH-3"
+build_phase_signal "${ORCH_DIR}/workers/PH-3/phase-research.json" "PH-3" \
+  --bg-job-id "bg-ph3"
+build_fake_bg_state "bg-ph3" --session-id "z1" \
+  --link-scan-path "${SCRATCH}/ph3.jsonl"
+build_phase_jsonl "${SCRATCH}/ph3.jsonl" --input 1000 --output 500
+# Create a .dead-*.json sidecar identical to the live signal
+cp "${ORCH_DIR}/workers/PH-3/phase-research.json" \
+   "${ORCH_DIR}/workers/PH-3/phase-research.json.dead-deadbeef.json"
+
+"$HELPER" --orch "orch-ph3" --orch-dir "$ORCH_DIR" --roll-usage --stdout >/dev/null
+
+run "dead sidecar: live phase-research processed" \
+  bash -c "[ \"\$(jq -r '.cost.inputTokens' '${ORCH_DIR}/workers/PH-3/phase-research.json')\" = '1000' ]"
+run "dead sidecar: .dead-*.json NOT processed (cost stays null)" \
+  bash -c "[ \"\$(jq -r '.cost // \"null\"' '${ORCH_DIR}/workers/PH-3/phase-research.json.dead-deadbeef.json')\" = 'null' ]"
+run "dead sidecar: state.workers[PH-3].usage NOT double-counted" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-ph3\"].workers[\"PH-3\"].usage.inputTokens' '$CATALYST_STATE_FILE')\" = '1000' ]"
+
+# ─── Test 14: no --roll-usage flag → phase signals untouched ──────────────────
+ORCH_DIR=$(setup_orch "orch-ph4")
+mkdir -p "${ORCH_DIR}/workers/PH-4"
+build_phase_signal "${ORCH_DIR}/workers/PH-4/phase-research.json" "PH-4" \
+  --bg-job-id "bg-ph4"
+build_fake_bg_state "bg-ph4" --session-id "w1" \
+  --link-scan-path "${SCRATCH}/ph4.jsonl"
+build_phase_jsonl "${SCRATCH}/ph4.jsonl" --input 1000 --output 500
+
+"$HELPER" --orch "orch-ph4" --orch-dir "$ORCH_DIR" --stdout >/dev/null
+
+run "no --roll-usage: phase signal.cost stays null" \
+  bash -c "[ \"\$(jq -r '.cost // \"null\"' '${ORCH_DIR}/workers/PH-4/phase-research.json')\" = 'null' ]"
+run "no --roll-usage: no .roll-usage.log written" \
+  bash -c "[ ! -f '${ORCH_DIR}/.roll-usage.log' ]"
+
+unset CATALYST_BG_JOBS_DIR
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh
@@ -391,6 +391,27 @@ run "dead sidecar: .dead-*.json NOT processed (cost stays null)" \
 run "dead sidecar: state.workers[PH-3].usage NOT double-counted" \
   bash -c "[ \"\$(jq -r '.orchestrators[\"orch-ph3\"].workers[\"PH-3\"].usage.inputTokens' '$CATALYST_STATE_FILE')\" = '1000' ]"
 
+# ─── Test 13b: legacy flat-layout .dead-*.json sidecar is skipped ─────────────
+# Symmetric coverage for the phase-layout dead-sidecar guard (test 13). If a
+# future change ever produces .dead-*.json sidecars at the flat workers/
+# layer, the legacy sweep must skip them too — same double-count concern.
+ORCH_DIR=$(setup_orch "orch-ph3b")
+build_stream_with_result "${ORCH_DIR}/workers/output/L-DEAD-stream.jsonl" \
+  "0.5" "5000" "500" "5" "10000"
+build_signal "${ORCH_DIR}/workers/L-DEAD.json" "L-DEAD"
+# Create a flat .dead-*.json sidecar identical to the live signal.
+cp "${ORCH_DIR}/workers/L-DEAD.json" \
+   "${ORCH_DIR}/workers/L-DEAD.json.dead-deadbeef.json"
+
+"$HELPER" --orch "orch-ph3b" --orch-dir "$ORCH_DIR" --roll-usage --stdout >/dev/null
+
+run "legacy dead sidecar: live L-DEAD processed" \
+  bash -c "[ \"\$(jq -r '.cost.costUSD' '${ORCH_DIR}/workers/L-DEAD.json')\" = '0.5' ]"
+run "legacy dead sidecar: .dead-*.json NOT processed (cost stays null)" \
+  bash -c "[ \"\$(jq -r '.cost // \"null\"' '${ORCH_DIR}/workers/L-DEAD.json.dead-deadbeef.json')\" = 'null' ]"
+run "legacy dead sidecar: state.usage.costUSD NOT double-counted" \
+  bash -c "[ \"\$(jq -r '.orchestrators[\"orch-ph3b\"].usage.costUSD' '$CATALYST_STATE_FILE')\" = '0.5' ]"
+
 # ─── Test 14: no --roll-usage flag → phase signals untouched ──────────────────
 ORCH_DIR=$(setup_orch "orch-ph4")
 mkdir -p "${ORCH_DIR}/workers/PH-4"

--- a/plugins/dev/scripts/claude-pricing.json
+++ b/plugins/dev/scripts/claude-pricing.json
@@ -1,0 +1,27 @@
+{
+  "version": "2026-05-18",
+  "source": "https://www.anthropic.com/pricing (manual update)",
+  "models": {
+    "claude-opus-4-7": {
+      "inputPerMillion": 15.0,
+      "outputPerMillion": 75.0,
+      "cacheReadPerMillion": 1.5,
+      "cacheCreation5mPerMillion": 18.75,
+      "cacheCreation1hPerMillion": 30.0
+    },
+    "claude-sonnet-4-6": {
+      "inputPerMillion": 3.0,
+      "outputPerMillion": 15.0,
+      "cacheReadPerMillion": 0.3,
+      "cacheCreation5mPerMillion": 3.75,
+      "cacheCreation1hPerMillion": 6.0
+    },
+    "claude-haiku-4-5-20251001": {
+      "inputPerMillion": 1.0,
+      "outputPerMillion": 5.0,
+      "cacheReadPerMillion": 0.1,
+      "cacheCreation5mPerMillion": 1.25,
+      "cacheCreation1hPerMillion": 2.0
+    }
+  }
+}

--- a/plugins/dev/scripts/extract-cost-from-jsonl.sh
+++ b/plugins/dev/scripts/extract-cost-from-jsonl.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# extract-cost-from-jsonl.sh — Compute a USAGE record from a Claude bg-session
+# conversation JSONL (CTL-496).
+#
+# In `phase-agents` dispatch mode workers run as `claude --bg` sessions. The
+# Claude CLI does not emit a stream-json `result` event for these sessions
+# (no --output-format flag), so orchestrate-roll-usage.sh has no `result`
+# event to parse. Instead, the CLI writes a conversation JSONL to
+# ~/.claude/projects/<wt>/<sessionId>.jsonl containing one assistant event
+# per turn with the model's `usage` block.
+#
+# This script aggregates `message.usage` across all assistant events,
+# splits cache_creation by 5m/1h TTL, applies per-model pricing from
+# claude-pricing.json, and emits a single USAGE object on stdout matching
+# the schema in orchestrate-roll-usage.sh:88–104.
+#
+# Exits 0 on success (even for empty JSONL — emits a zeroed record).
+# Exits 1 on missing/unreadable JSONL or pricing files.
+# Exits 2 on invalid invocation.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: extract-cost-from-jsonl.sh --jsonl <path> --pricing <path>
+
+required:
+  --jsonl <path>     Claude conversation JSONL (~/.claude/projects/.../<sid>.jsonl)
+  --pricing <path>   pricing table JSON (see plugins/dev/scripts/claude-pricing.json)
+
+Emits a USAGE record on stdout matching the orchestrate-roll-usage.sh schema:
+  { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens,
+    costUSD, numTurns, durationMs, durationApiMs, model }
+
+Unknown models are kept in the token sums but priced at zero (one stderr
+warning per unknown model).
+EOF
+  exit 2
+}
+
+JSONL="" PRICING=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --jsonl)   JSONL="$2";   shift 2 ;;
+    --pricing) PRICING="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$JSONL" ]   || usage
+[ -n "$PRICING" ] || usage
+[ -f "$JSONL" ]   || { echo "jsonl not found: $JSONL"     >&2; exit 1; }
+[ -f "$PRICING" ] || { echo "pricing not found: $PRICING" >&2; exit 1; }
+
+# Single jq pass: slurps the JSONL into an array, slurps pricing as a side
+# input, computes per-model token bucket → per-model cost → aggregate USAGE.
+# The reduce-over-assistant-events is the hot path; everything else is a
+# constant-time post-pass.
+jq -s --slurpfile pricing "$PRICING" '
+  ($pricing[0].models) as $p
+  # Per-model token bucket
+  | ([.[] | select(.type == "assistant" and .message.usage != null)]
+     | reduce .[] as $e ({};
+         .[$e.message.model] //= {
+           input: 0, output: 0, cacheRead: 0, cacheCreate5m: 0, cacheCreate1h: 0
+         }
+         | .[$e.message.model].input         += ($e.message.usage.input_tokens // 0)
+         | .[$e.message.model].output        += ($e.message.usage.output_tokens // 0)
+         | .[$e.message.model].cacheRead     += ($e.message.usage.cache_read_input_tokens // 0)
+         | .[$e.message.model].cacheCreate5m += ($e.message.usage.cache_creation.ephemeral_5m_input_tokens // 0)
+         | .[$e.message.model].cacheCreate1h += ($e.message.usage.cache_creation.ephemeral_1h_input_tokens // 0)
+       )) as $bymodel
+  # Per-model cost using pricing table
+  | ($bymodel | to_entries | map(
+      . as $m
+      | ($p[$m.key] // {
+          inputPerMillion: 0, outputPerMillion: 0, cacheReadPerMillion: 0,
+          cacheCreation5mPerMillion: 0, cacheCreation1hPerMillion: 0
+        }) as $rate
+      | ($m.value.input         * $rate.inputPerMillion             / 1000000) as $ci
+      | ($m.value.output        * $rate.outputPerMillion            / 1000000) as $co
+      | ($m.value.cacheRead     * $rate.cacheReadPerMillion         / 1000000) as $cr
+      | ($m.value.cacheCreate5m * $rate.cacheCreation5mPerMillion   / 1000000) as $cc5
+      | ($m.value.cacheCreate1h * $rate.cacheCreation1hPerMillion   / 1000000) as $cc1
+      | {model: $m.key,
+         costUSD: ($ci + $co + $cr + $cc5 + $cc1),
+         input: $m.value.input, output: $m.value.output,
+         cacheRead: $m.value.cacheRead,
+         cacheCreate: ($m.value.cacheCreate5m + $m.value.cacheCreate1h)}
+    )) as $costs
+  # Primary model = the model with the largest cost contribution.
+  | ($costs | sort_by(-.costUSD) | first) as $primary
+  | {
+      inputTokens:         ($costs | map(.input)       | add // 0),
+      outputTokens:        ($costs | map(.output)      | add // 0),
+      cacheReadTokens:     ($costs | map(.cacheRead)   | add // 0),
+      cacheCreationTokens: ($costs | map(.cacheCreate) | add // 0),
+      costUSD:             (($costs | map(.costUSD)    | add // 0) | . * 1000000 | round / 1000000),
+      numTurns:            ([.[] | select(.type == "assistant")] | length),
+      durationMs:          ([.[] | select(.type == "system" and .subtype == "turn_duration") | .durationMs // 0] | add // 0),
+      durationApiMs:       0,
+      model:               ($primary.model // null)
+    }
+' "$JSONL"

--- a/plugins/dev/scripts/orchestrate-roll-usage.sh
+++ b/plugins/dev/scripts/orchestrate-roll-usage.sh
@@ -140,7 +140,13 @@ fi
 LOCK_FILE="${SIGNAL_FILE}.lock"
 exec 9>"$LOCK_FILE"
 if command -v flock >/dev/null 2>&1; then
-  flock -w 30 9 || { log_action "lock-timeout"; exit 0; }
+  # 30s contention is not idempotency — surface to stderr unconditionally so the
+  # caller's roll-log captures it even when invoked without -v.
+  flock -w 30 9 || {
+    echo "roll-usage[ticket=${TICKET_ID}${PHASE:+,phase=${PHASE}}]: lock-timeout" >&2
+    log_action "lock-timeout"
+    exit 0
+  }
 fi
 # Re-evaluate idempotency under the lock. If another sweep claimed this
 # signal between our existence check and now, bail cleanly.
@@ -163,16 +169,26 @@ if [ -n "$PHASE" ]; then
   [ -x "$EXTRACTOR" ] && [ -f "$PRICING" ] \
     || { log_action "extract-failed"; exit 0; }
 
-  USAGE=$("$EXTRACTOR" --jsonl "$JSONL" --pricing "$PRICING" 2>/dev/null || echo "")
-  [ -n "$USAGE" ] || { log_action "extract-failed"; exit 0; }
+  # Let extractor stderr pass through to our stderr (which update-dashboard.sh
+  # tees into $ROLL_LOG). Capture exit code explicitly so a crash is
+  # distinguishable from a clean run that produced empty stdout.
+  EXTRACT_RC=0
+  USAGE=$("$EXTRACTOR" --jsonl "$JSONL" --pricing "$PRICING") || EXTRACT_RC=$?
+  if [ "$EXTRACT_RC" -ne 0 ]; then
+    log_action "extract-crashed"; exit 0
+  fi
+  [ -n "$USAGE" ] || { log_action "extract-empty"; exit 0; }
 
   # Zero-cost guard: an empty / not-yet-flushed JSONL legitimately produces a
-  # zeroed USAGE record. Don't poison signal.cost with zeros — next sweep can
-  # retry. (For a truly costless phase like phase-monitor-deploy, the signal
-  # never reaches this script in the first place because no catalyst-session
-  # was started.)
-  COSTUSD=$(echo "$USAGE" | jq -r '.costUSD')
-  if [ "$COSTUSD" = "0" ] || [ "$COSTUSD" = "0.0" ]; then
+  # zeroed USAGE record with zero tokens. Don't poison signal.cost — next
+  # sweep can retry. Gate on the token-sum (not costUSD): an unknown-model
+  # JSONL prices at zero but has non-zero tokens, and is genuine cost data we
+  # must persist rather than infinitely retry.
+  TOKEN_SUM=$(echo "$USAGE" | jq -r '
+    (.inputTokens // 0) + (.outputTokens // 0)
+    + (.cacheReadTokens // 0) + (.cacheCreationTokens // 0)
+  ')
+  if [ "$TOKEN_SUM" = "0" ]; then
     log_action "zero-cost-retry"; exit 0
   fi
 else

--- a/plugins/dev/scripts/orchestrate-roll-usage.sh
+++ b/plugins/dev/scripts/orchestrate-roll-usage.sh
@@ -128,6 +128,22 @@ fi
 
 # Common no-op gates.
 [ -f "$SIGNAL_FILE" ] || { log_action "signal-missing"; exit 0; }
+
+# Take an exclusive lock on the signal file for the entire read-modify-write
+# cycle. Without this, two parallel sweeps (e.g. two overlapping monitor
+# wake-ups) can both pass the `signal.cost == null` check, both compute USAGE,
+# both invoke `catalyst-state.sh worker` with `+=`, and double-count
+# `state.workers[T].usage`. Phase mode hits this faster than legacy because
+# its state-workers aggregator uses `+=` (across phases), where legacy used
+# overwrite-assignment that was naturally idempotent. The lock makes both
+# modes safe. flock auto-releases when the FD closes (script exit).
+LOCK_FILE="${SIGNAL_FILE}.lock"
+exec 9>"$LOCK_FILE"
+if command -v flock >/dev/null 2>&1; then
+  flock -w 30 9 || { log_action "lock-timeout"; exit 0; }
+fi
+# Re-evaluate idempotency under the lock. If another sweep claimed this
+# signal between our existence check and now, bail cleanly.
 EXISTING=$(jq -r '.cost // "null"' "$SIGNAL_FILE")
 [ "$EXISTING" = "null" ] || { log_action "already-rolled"; exit 0; }
 
@@ -187,9 +203,12 @@ fi
 # ─── Common writes ────────────────────────────────────────────────────────────
 
 # 1. Mirror to signal file (atomic tmp+rename). Dashboard reads signal files,
-#    not state.json, for per-worker cost columns.
-jq --argjson cost "$USAGE" '.cost = $cost' "$SIGNAL_FILE" \
-  > "${SIGNAL_FILE}.tmp" && mv "${SIGNAL_FILE}.tmp" "$SIGNAL_FILE"
+#    not state.json, for per-worker cost columns. PID-suffixed tmp so a
+#    crashed parallel writer can't poison ours (the flock above already
+#    prevents the contention from happening under normal operation).
+SIGNAL_TMP="${SIGNAL_FILE}.tmp.$$"
+jq --argjson cost "$USAGE" '.cost = $cost' "$SIGNAL_FILE" > "$SIGNAL_TMP" \
+  && mv "$SIGNAL_TMP" "$SIGNAL_FILE"
 
 # 2. Per-worker entry in global state. Legacy mode overwrites (one worker per
 #    ticket per run). Phase mode aggregates so state.workers[T].usage is the

--- a/plugins/dev/scripts/orchestrate-roll-usage.sh
+++ b/plugins/dev/scripts/orchestrate-roll-usage.sh
@@ -1,22 +1,47 @@
 #!/usr/bin/env bash
 # orchestrate-roll-usage.sh — Roll a worker's final usage/cost into orch state.
 #
-# Reads the worker's stream-json output, extracts the final `result` event's
-# usage/cost fields, and writes them to:
-#   1. the worker's signal file              (.cost = USAGE)
-#   2. state.json's per-worker entry         (.workers[ticket].usage = USAGE)
-#   3. state.json's orchestrator-level total (.usage += USAGE)
+# Two modes, selected by the presence of --phase:
 #
-# Idempotent: signal.cost being non-null is the marker that this worker has
-# already been rolled. Safe to invoke from every monitor poll cycle for every
-# worker — does work exactly once per worker, when its stream first contains
-# a result event.
+# (a) Legacy (no --phase) — for `oneshot-legacy` dispatch mode. Reads the
+#     worker's stream-json output (workers/output/<T>-stream.jsonl), extracts
+#     the final `result` event's usage/cost fields, and writes them to:
+#       1. the worker's signal file              (.cost = USAGE)
+#       2. state.json's per-worker entry         (.workers[ticket].usage = USAGE)
+#       3. state.json's orchestrator-level total (.usage += USAGE)
+#       4. session_metrics SQLite mirror via catalyst-session.sh metric
+#
+# (b) Phase (--phase <name>) — for `phase-agents` dispatch mode (CTL-496).
+#     `claude --bg` workers do not write a stream-json result event (no
+#     --output-format flag), so we source USAGE from the conversation JSONL
+#     that the Claude CLI writes to ~/.claude/projects/<wt>/<sid>.jsonl
+#     instead. The path is resolved via:
+#       <jobsDir>/<bg_job_id>/state.json -> .linkScanPath
+#     where <jobsDir> defaults to $HOME/.claude/jobs (overridable via
+#     CATALYST_BG_JOBS_DIR for tests). The USAGE record is computed by
+#     extract-cost-from-jsonl.sh against the resolved JSONL.
+#
+#     The four downstream writes are reused unchanged — only the USAGE
+#     source differs. One per-phase signal lives at
+#     ${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json. The per-worker
+#     state.workers[ticket].usage aggregates across phases (+= not =) so
+#     state.workers[T].usage.costUSD == sum(phase.cost.costUSD) for that
+#     ticket.
+#
+# Idempotent in both modes: signal.cost being non-null is the marker that
+# this signal has already been rolled. Safe to invoke per worker per phase
+# per monitor cycle — does work exactly once per signal, when its
+# upstream source first becomes available.
 #
 # No-op (exits 0) when:
-#   - signal file missing
-#   - stream file missing
-#   - stream has no `result` event yet (worker still running, or died early)
-#   - signal.cost already populated (already rolled)
+#   - signal file missing                            (signal-missing)
+#   - [legacy] stream file missing                   (stream-missing)
+#   - [legacy] stream has no `result` event yet      (no-result-yet)
+#   - [phase]  bg state.json missing                 (bg-state-missing)
+#   - [phase]  resolved JSONL missing                (jsonl-missing)
+#   - [phase]  extract returned zero cost (still running, retry next sweep)
+#                                                    (zero-cost-retry)
+#   - signal.cost already populated                  (already-rolled)
 #
 # Exits non-zero only on truly broken input (missing required args).
 
@@ -24,36 +49,52 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE_SCRIPT="${SCRIPT_DIR}/catalyst-state.sh"
+EXTRACTOR="${SCRIPT_DIR}/extract-cost-from-jsonl.sh"
+PRICING="${SCRIPT_DIR}/claude-pricing.json"
 
 usage() {
   cat >&2 <<'EOF'
-usage: orchestrate-roll-usage.sh --orch <id> --ticket <id> [--orch-dir <dir>] [-v]
+usage: orchestrate-roll-usage.sh --orch <id> --ticket <id>
+                                 [--phase <name>] [--orch-dir <dir>] [-v]
 
 required:
   --orch <id>        orchestrator id (e.g. o-ctl-115-116)
   --ticket <id>      worker ticket id (e.g. CTL-115)
 
 optional:
+  --phase <name>     activate phase-agent mode (CTL-496). Reads per-phase
+                     signal at <orch-dir>/workers/<ticket>/phase-<name>.json
+                     and sources USAGE from the bg session JSONL via
+                     extract-cost-from-jsonl.sh. state.workers[ticket].usage
+                     aggregates across phases (+= not =).
   --orch-dir <dir>   override default ~/catalyst/runs/<orch>/
   -v, --verbose      log one-line action codes to stderr (CTL-233):
-                       wrote-cost, already-rolled, signal-missing,
-                       stream-missing, no-result-yet, extract-failed
+                       legacy:  wrote-cost, already-rolled, signal-missing,
+                                stream-missing, no-result-yet, extract-failed,
+                                wrote-metric, metric-skipped, metric-write-failed
+                       phase:   wrote-cost, already-rolled, signal-missing,
+                                bg-state-missing, jsonl-missing, zero-cost-retry,
+                                extract-failed, wrote-metric, metric-skipped,
+                                metric-write-failed
 
-Reads ${ORCH_DIR}/workers/output/${TICKET}-stream.jsonl and
-${ORCH_DIR}/workers/${TICKET}.json; writes signal.cost,
-state.workers[ticket].usage, and rolls into state.usage.
+env:
+  CATALYST_BG_JOBS_DIR   override <jobsDir> base for phase mode (default
+                         $HOME/.claude/jobs).
+  CATALYST_DB_FILE       override SQLite db path (default ~/catalyst/catalyst.db).
 
-Idempotent: no-op when signal.cost is already populated.
+Idempotent: no-op when signal.cost is already populated. Safe to invoke
+per worker per (phase) per monitor cycle.
 EOF
   exit 2
 }
 
-ORCH_ID="" TICKET_ID="" ORCH_DIR="" VERBOSE=0
+ORCH_ID="" TICKET_ID="" ORCH_DIR="" VERBOSE=0 PHASE=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --orch)        ORCH_ID="$2"; shift 2 ;;
     --ticket)      TICKET_ID="$2"; shift 2 ;;
     --orch-dir)    ORCH_DIR="$2"; shift 2 ;;
+    --phase)       PHASE="$2"; shift 2 ;;
     -v|--verbose)  VERBOSE=1; shift ;;
     -h|--help)     usage ;;
     *) echo "unknown arg: $1" >&2; usage ;;
@@ -69,50 +110,106 @@ done
 # orchestrator can capture stderr to a per-orch audit file (CTL-233).
 log_action() {
   [ "$VERBOSE" = "1" ] || return 0
-  echo "roll-usage[ticket=${TICKET_ID}]: $1" >&2
+  if [ -n "$PHASE" ]; then
+    echo "roll-usage[ticket=${TICKET_ID},phase=${PHASE}]: $1" >&2
+  else
+    echo "roll-usage[ticket=${TICKET_ID}]: $1" >&2
+  fi
 }
 
-SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET_ID}.json"
-STREAM_FILE="${ORCH_DIR}/workers/output/${TICKET_ID}-stream.jsonl"
+# ─── Resolve signal + USAGE source ────────────────────────────────────────────
 
-# No-op gates — silent so the monitor loop doesn't spew per-pass (verbose mode
-# emits one line per gate so silent skips are auditable).
+if [ -n "$PHASE" ]; then
+  SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET_ID}/phase-${PHASE}.json"
+else
+  SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET_ID}.json"
+  STREAM_FILE="${ORCH_DIR}/workers/output/${TICKET_ID}-stream.jsonl"
+fi
+
+# Common no-op gates.
 [ -f "$SIGNAL_FILE" ] || { log_action "signal-missing"; exit 0; }
-[ -f "$STREAM_FILE" ] || { log_action "stream-missing"; exit 0; }
-
-# Idempotency: if signal already has .cost (non-null), nothing to do.
 EXISTING=$(jq -r '.cost // "null"' "$SIGNAL_FILE")
 [ "$EXISTING" = "null" ] || { log_action "already-rolled"; exit 0; }
 
-# Extract final result event from the stream
-RESULT_LINE=$(grep '"type":"result"' "$STREAM_FILE" | tail -1 || true)
-[ -n "$RESULT_LINE" ] || { log_action "no-result-yet"; exit 0; }
+USAGE=""
+if [ -n "$PHASE" ]; then
+  # Phase mode: resolve bg state.json -> linkScanPath -> JSONL -> extractor.
+  BG_JOB_ID=$(jq -r '.bg_job_id // empty' "$SIGNAL_FILE")
+  [ -n "$BG_JOB_ID" ] || { log_action "bg-state-missing"; exit 0; }
 
-# Defensive on `.modelUsage`: older Claude CLI versions or error-during-execution
-# results may omit it. `null | keys[0]` errors with "null has no keys", so coalesce
-# to {} first.
-USAGE=$(echo "$RESULT_LINE" | jq -c '{
-  inputTokens:         (.usage.input_tokens // 0),
-  outputTokens:        (.usage.output_tokens // 0),
-  cacheReadTokens:     (.usage.cache_read_input_tokens // 0),
-  cacheCreationTokens: (.usage.cache_creation_input_tokens // 0),
-  costUSD:             (.total_cost_usd // 0),
-  numTurns:            (.num_turns // 0),
-  durationMs:          (.duration_ms // 0),
-  durationApiMs:       (.duration_api_ms // 0),
-  model:               ((.modelUsage // {}) | keys[0] // null)
-}' 2>/dev/null || echo 'null')
+  BG_JOBS_DIR="${CATALYST_BG_JOBS_DIR:-${HOME}/.claude/jobs}"
+  BG_STATE="${BG_JOBS_DIR}/${BG_JOB_ID}/state.json"
+  [ -f "$BG_STATE" ] || { log_action "bg-state-missing"; exit 0; }
 
-[ "$USAGE" != "null" ] || { log_action "extract-failed"; exit 0; }
+  JSONL=$(jq -r '.linkScanPath // empty' "$BG_STATE")
+  [ -n "$JSONL" ] && [ -f "$JSONL" ] || { log_action "jsonl-missing"; exit 0; }
+
+  [ -x "$EXTRACTOR" ] && [ -f "$PRICING" ] \
+    || { log_action "extract-failed"; exit 0; }
+
+  USAGE=$("$EXTRACTOR" --jsonl "$JSONL" --pricing "$PRICING" 2>/dev/null || echo "")
+  [ -n "$USAGE" ] || { log_action "extract-failed"; exit 0; }
+
+  # Zero-cost guard: an empty / not-yet-flushed JSONL legitimately produces a
+  # zeroed USAGE record. Don't poison signal.cost with zeros — next sweep can
+  # retry. (For a truly costless phase like phase-monitor-deploy, the signal
+  # never reaches this script in the first place because no catalyst-session
+  # was started.)
+  COSTUSD=$(echo "$USAGE" | jq -r '.costUSD')
+  if [ "$COSTUSD" = "0" ] || [ "$COSTUSD" = "0.0" ]; then
+    log_action "zero-cost-retry"; exit 0
+  fi
+else
+  # Legacy mode: extract the final result event from the stream.
+  [ -f "$STREAM_FILE" ] || { log_action "stream-missing"; exit 0; }
+
+  RESULT_LINE=$(grep '"type":"result"' "$STREAM_FILE" | tail -1 || true)
+  [ -n "$RESULT_LINE" ] || { log_action "no-result-yet"; exit 0; }
+
+  # Defensive on `.modelUsage`: older Claude CLI versions or error-during-execution
+  # results may omit it. `null | keys[0]` errors with "null has no keys", so coalesce
+  # to {} first.
+  USAGE=$(echo "$RESULT_LINE" | jq -c '{
+    inputTokens:         (.usage.input_tokens // 0),
+    outputTokens:        (.usage.output_tokens // 0),
+    cacheReadTokens:     (.usage.cache_read_input_tokens // 0),
+    cacheCreationTokens: (.usage.cache_creation_input_tokens // 0),
+    costUSD:             (.total_cost_usd // 0),
+    numTurns:            (.num_turns // 0),
+    durationMs:          (.duration_ms // 0),
+    durationApiMs:       (.duration_api_ms // 0),
+    model:               ((.modelUsage // {}) | keys[0] // null)
+  }' 2>/dev/null || echo 'null')
+
+  [ "$USAGE" != "null" ] || { log_action "extract-failed"; exit 0; }
+fi
+
+# ─── Common writes ────────────────────────────────────────────────────────────
 
 # 1. Mirror to signal file (atomic tmp+rename). Dashboard reads signal files,
 #    not state.json, for per-worker cost columns.
 jq --argjson cost "$USAGE" '.cost = $cost' "$SIGNAL_FILE" \
   > "${SIGNAL_FILE}.tmp" && mv "${SIGNAL_FILE}.tmp" "$SIGNAL_FILE"
 
-# 2. Per-worker entry in global state. The state script handles its own lock.
-"$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET_ID" \
-  '.usage = $u' --argjson u "$USAGE" >/dev/null
+# 2. Per-worker entry in global state. Legacy mode overwrites (one worker per
+#    ticket per run). Phase mode aggregates so state.workers[T].usage is the
+#    sum across all this ticket's phases.
+if [ -n "$PHASE" ]; then
+  "$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET_ID" \
+    '.usage.inputTokens         = ((.usage.inputTokens // 0)         + $u.inputTokens)
+     | .usage.outputTokens        = ((.usage.outputTokens // 0)        + $u.outputTokens)
+     | .usage.cacheReadTokens     = ((.usage.cacheReadTokens // 0)     + $u.cacheReadTokens)
+     | .usage.cacheCreationTokens = ((.usage.cacheCreationTokens // 0) + $u.cacheCreationTokens)
+     | .usage.costUSD             = ((.usage.costUSD // 0)             + $u.costUSD)
+     | .usage.numTurns            = ((.usage.numTurns // 0)            + $u.numTurns)
+     | .usage.durationMs          = ((.usage.durationMs // 0)          + $u.durationMs)
+     | .usage.durationApiMs       = ((.usage.durationApiMs // 0)       + ($u.durationApiMs // 0))
+     | .usage.model               = $u.model' \
+    --argjson u "$USAGE" >/dev/null
+else
+  "$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET_ID" \
+    '.usage = $u' --argjson u "$USAGE" >/dev/null
+fi
 
 # 3. Orchestrator-level aggregate.
 "$STATE_SCRIPT" update "$ORCH_ID" \
@@ -123,7 +220,7 @@ jq --argjson cost "$USAGE" '.cost = $cost' "$SIGNAL_FILE" \
    | .usage.costUSD             += $u.costUSD
    | .usage.numTurns            += $u.numTurns
    | .usage.durationMs          += $u.durationMs
-   | .usage.durationApiMs       += $u.durationApiMs' \
+   | .usage.durationApiMs       += ($u.durationApiMs // 0)' \
   --argjson u "$USAGE" >/dev/null
 
 log_action "wrote-cost"
@@ -137,14 +234,23 @@ SESSION_SH="${SCRIPT_DIR}/catalyst-session.sh"
 CATALYST_SID="$(jq -r '.catalystSessionId // ""' "$SIGNAL_FILE")"
 
 if [ -z "$CATALYST_SID" ]; then
-  # Fallback: most-recent session for this ticket. The orchestrator dispatches
-  # one worker per ticket per run, so DESC-by-started_at picks the right row.
+  # DB fallback: most-recent session for this ticket. In phase mode also
+  # filter by skill_name so phase-X cost only mirrors into the phase-X
+  # session_metrics row.
   CATALYST_DB="${CATALYST_DB_FILE:-${HOME}/catalyst/catalyst.db}"
   if [ -f "$CATALYST_DB" ]; then
-    CATALYST_SID=$(sqlite3 "$CATALYST_DB" \
-      "SELECT session_id FROM sessions
-       WHERE ticket_key = '${TICKET_ID//\'/\'\'}'
-       ORDER BY started_at DESC LIMIT 1;" 2>/dev/null || true)
+    if [ -n "$PHASE" ]; then
+      CATALYST_SID=$(sqlite3 "$CATALYST_DB" \
+        "SELECT session_id FROM sessions
+         WHERE ticket_key = '${TICKET_ID//\'/\'\'}'
+           AND skill_name = 'phase-${PHASE//\'/\'\'}'
+         ORDER BY started_at DESC LIMIT 1;" 2>/dev/null || true)
+    else
+      CATALYST_SID=$(sqlite3 "$CATALYST_DB" \
+        "SELECT session_id FROM sessions
+         WHERE ticket_key = '${TICKET_ID//\'/\'\'}'
+         ORDER BY started_at DESC LIMIT 1;" 2>/dev/null || true)
+    fi
   fi
 fi
 

--- a/plugins/dev/scripts/update-dashboard.sh
+++ b/plugins/dev/scripts/update-dashboard.sh
@@ -86,12 +86,31 @@ if [ "$ROLL_USAGE" = "1" ] && [ -d "$WORKERS_DIR" ]; then
   ROLL_SCRIPT="${SCRIPT_DIR}/orchestrate-roll-usage.sh"
   if [ -x "$ROLL_SCRIPT" ]; then
     ROLL_LOG="${ORCH_DIR}/.roll-usage.log"
+
+    # Legacy flat layout: workers/<TICKET>.json (oneshot-legacy dispatch).
     for sig in "$WORKERS_DIR"/*.json; do
       [ -f "$sig" ] || continue
       tkt=$(jq -r '.ticket // empty' "$sig" 2>/dev/null || true)
       [ -n "$tkt" ] || continue
       "$ROLL_SCRIPT" --orch "$ORCH_ID" --ticket "$tkt" --orch-dir "$ORCH_DIR" -v \
         >/dev/null 2>>"$ROLL_LOG" || true
+    done
+
+    # Phase-agent layout: workers/<TICKET>/phase-<NAME>.json (CTL-496).
+    # phase-agent-dispatch may also rename killed worker signals to
+    # phase-<NAME>.json.dead-<id>.json — skip those (live signal already
+    # booked the cost; re-rolling the sidecar would double-count).
+    for sig in "$WORKERS_DIR"/*/phase-*.json; do
+      [ -f "$sig" ] || continue
+      case "$(basename "$sig")" in
+        *.dead-*.json) continue ;;
+      esac
+      tkt=$(jq -r '.ticket // empty' "$sig" 2>/dev/null || true)
+      phase=$(jq -r '.phase // empty' "$sig" 2>/dev/null || true)
+      [ -n "$tkt" ] || continue
+      [ -n "$phase" ] || continue
+      "$ROLL_SCRIPT" --orch "$ORCH_ID" --ticket "$tkt" --phase "$phase" \
+        --orch-dir "$ORCH_DIR" -v >/dev/null 2>>"$ROLL_LOG" || true
     done
   fi
 fi

--- a/plugins/dev/scripts/update-dashboard.sh
+++ b/plugins/dev/scripts/update-dashboard.sh
@@ -88,8 +88,14 @@ if [ "$ROLL_USAGE" = "1" ] && [ -d "$WORKERS_DIR" ]; then
     ROLL_LOG="${ORCH_DIR}/.roll-usage.log"
 
     # Legacy flat layout: workers/<TICKET>.json (oneshot-legacy dispatch).
+    # Also skip *.dead-*.json sidecars (defensive — phase-agent-dispatch
+    # produces those today and writes them under workers/<T>/, but the
+    # filter belongs in both passes so future rename paths don't double-count).
     for sig in "$WORKERS_DIR"/*.json; do
       [ -f "$sig" ] || continue
+      case "$(basename "$sig")" in
+        *.dead-*.json) continue ;;
+      esac
       tkt=$(jq -r '.ticket // empty' "$sig" 2>/dev/null || true)
       [ -n "$tkt" ] || continue
       "$ROLL_SCRIPT" --orch "$ORCH_ID" --ticket "$tkt" --orch-dir "$ORCH_DIR" -v \

--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -102,10 +102,17 @@ if [[ -x "$SESSION_SCRIPT" ]]; then
   export CATALYST_SESSION_ID
 fi
 
-# 3. Mark the signal file as "running" + record the start timestamp.
+# 3. Mark the signal file as "running" + record the start timestamp +
+#    persist catalystSessionId (CTL-496: orchestrate-roll-usage --phase
+#    reads this to attribute cost to the right session_metrics row without
+#    relying on the ticket+skill_name DB-lookup heuristic).
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
-jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 ```
 

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -94,10 +94,15 @@ if [[ -x "$SESSION_SCRIPT" ]]; then
   export CATALYST_SESSION_ID
 fi
 
-# 3. Mark the signal file as running.
+# 3. Mark the signal file as running + persist catalystSessionId (CTL-496:
+#    orchestrate-roll-usage --phase reads this to attribute cost).
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
-jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 
 # 4. Locate the approved plan. The dispatcher already validated this glob;

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -81,9 +81,14 @@ REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || ec
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
-jq --arg ts "$TS" --argjson pr "$PR_NUMBER" \
-  '.status = "running" | .updatedAt = $ts | .pr = {number: $pr}' \
-  "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+# CTL-496: persist catalystSessionId so orchestrate-roll-usage --phase can
+# attribute cost to the right session_metrics row.
+jq --arg ts "$TS" --argjson pr "$PR_NUMBER" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | .pr = {number: $pr}
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
 ```
 
 ## /goal condition

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -75,7 +75,13 @@ fi
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
-jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+# CTL-496: persist catalystSessionId so orchestrate-roll-usage --phase can
+# attribute cost to the right session_metrics row.
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 
 # Prior-phase artifact: the research document. Dispatcher gates this via glob;

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -74,7 +74,13 @@ fi
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
-jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+# CTL-496: persist catalystSessionId so orchestrate-roll-usage --phase can
+# attribute cost to the right session_metrics row.
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 ```
 

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -73,10 +73,14 @@ if [[ -x "$SESSION_SCRIPT" ]]; then
   export CATALYST_SESSION_ID
 fi
 
-# Mark signal file running.
+# Mark signal file running + persist catalystSessionId (CTL-496).
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
-jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 
 # Read the prior-phase artifact (triage.json). The dispatcher already gated this,

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -73,7 +73,13 @@ fi
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
-jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+# CTL-496: persist catalystSessionId so orchestrate-roll-usage --phase can
+# attribute cost to the right session_metrics row.
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 
 # Prior-phase artifact: verify.json from phase-verify.

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -83,7 +83,13 @@ fi
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
-jq --arg ts "$TS" '.status = "running" | .updatedAt = $ts' "$SIGNAL_FILE" > "$TMP" \
+# CTL-496: persist catalystSessionId so orchestrate-roll-usage --phase can
+# attribute cost to the right session_metrics row.
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 
 # Prior-phase artifact: phase-implement.json.

--- a/website/src/content/docs/reference/orchestration/phase-agents.md
+++ b/website/src/content/docs/reference/orchestration/phase-agents.md
@@ -261,20 +261,32 @@ documented per-run rehydration tax (~$2.25) plus coordinator overhead accounts f
 gap. The order-of-magnitude is right; the per-phase split still needs a phase-agents run to
 validate row-by-row.
 
-:::note[Validation status (2026-05-17)] **CTL-455 fix is mechanically verified.** Running
-`plugins/dev/scripts/orchestrate-roll-usage.sh -v` against any completed worker writes
-`signal.cost` and a real `session_metrics` row with `cost_usd > 0`. Confirmed against 7 sibling
-workers; see
-[`thoughts/shared/research/2026-05-17-ctl-485-phase-agent-cost-validation.md`](https://github.com/coalesce-labs/catalyst/blob/main/thoughts/shared/research/2026-05-17-ctl-485-phase-agent-cost-validation.md).
+:::note[Validation status (2026-05-18)] **End-to-end cost capture for `phase-agents` mode is
+landed (CTL-496).** `update-dashboard.sh --roll-usage` sweeps both `workers/<TICKET>.json`
+(legacy) and `workers/<TICKET>/phase-<NAME>.json` (phase-agents) on every monitor wake-up via
+the CTL-487 wiring, populating `signal.cost`, `state.workers[T].usage` (aggregated across phases
+with `+=`), `state.usage`, and per-phase `session_metrics` rows.
 
-Two gaps remain, tracked separately:
+Phase-mode USAGE is sourced from the bg session conversation JSONL
+(`~/.claude/projects/<wt>/<sid>.jsonl`) by
+[`extract-cost-from-jsonl.sh`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/extract-cost-from-jsonl.sh)
+because `claude --bg` does not emit the stream-json `result` event that legacy roll-usage
+parses. The extractor reads per-message `usage` blocks, splits cache_creation by 5m/1h TTL, and
+applies per-model pricing from
+[`plugins/dev/scripts/claude-pricing.json`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/claude-pricing.json)
+(version-pinned, manually updated when Anthropic publishes rate changes).
 
-- [CTL-487](https://linear.app/coalesce-labs/issue/CTL-487) — the orchestrator monitor loop is
-  not currently invoking `orchestrate-roll-usage.sh` per worker per wake-up. Until that lands,
-  the CTL-455 fix only produces data when invoked manually.
+`session_metrics` attribution is by `session_id`. Each phase agent starts its own
+`catalyst-session.sh` row with `skill_name = phase-<name>`, and the prelude persists
+`catalystSessionId` into the phase signal so roll-usage mirrors cost into the right row without
+DB heuristics. A `ticket_key + skill_name` fallback handles in-flight runs that predate the
+prelude change.
+
+Open follow-up:
+
 - [CTL-488](https://linear.app/coalesce-labs/issue/CTL-488) — per-phase rows in the projection
-  table still need an end-to-end `dispatchMode: "phase-agents"` run to validate row-by-row.
-  Blocked on CTL-487. :::
+  table still need an end-to-end `dispatchMode: "phase-agents"` run to validate row-by-row now
+  that the data path is reliable. This is now a data-collection task, not a wiring gap. :::
 
 ## Observing a run
 
@@ -325,12 +337,14 @@ For the first real run against a low-risk ticket:
    { "catalyst": { "orchestration": { "dispatchMode": "phase-agents" } } }
    ```
 3. **Verify `session_metrics` populates** with a single test session before committing to a full
-   run. The CTL-455 fix populates the table via `orchestrate-roll-usage.sh`, which the
-   orchestrator's monitor loop calls per worker per wake-up. If `cost_usd` is still `0` after a
-   worker reaches `status: "done"`, check `${ORCH_DIR}/.roll-usage.log` — empty means the
-   invocation never happened (see [CTL-487](https://linear.app/coalesce-labs/issue/CTL-487)) and
-   you can manually flush by running `orchestrate-roll-usage.sh --orch <orch-id> --ticket
-   <TICKET> -v` to validate the data path independently.
+   run. The orchestrator's monitor loop calls `update-dashboard.sh --roll-usage` on every
+   wake-up, which sweeps both `workers/<TICKET>.json` (legacy) and `workers/<TICKET>/phase-<NAME>.json`
+   (phase-agents) and writes through to signal + state + DB. If `cost_usd` is still `0` after a
+   phase reaches `status: "done"`, check `${ORCH_DIR}/.roll-usage.log` — `bg-state-missing` or
+   `jsonl-missing` action codes point at a stale or relocated `~/.claude/jobs/<bg>/state.json`;
+   `extract-failed` points at the `extract-cost-from-jsonl.sh` script. You can manually flush a
+   single phase with `orchestrate-roll-usage.sh --orch <orch-id> --ticket <TICKET> --phase
+   <NAME> -v` to validate the data path independently.
 4. **Dispatch the orchestrator**:
    ```bash
    /catalyst-dev:orchestrate <TICKET> --auto-merge --max-parallel 1


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-18T15:54:00Z -->
<!-- Last updated: 2026-05-18T15:54:00Z -->
<!-- PR: #864 -->
<!-- Previous commits: f72364dd,53e8e371,600c9eaa,08eeb07c,698543dc,bdda57ef -->

## Summary

Wires cost capture for phase-agent workers. Before this PR, the
`orchestrate-roll-usage.sh` auto-flush inside the monitor loop was a
**silent no-op** for every `claude --bg` worker: the script looked for a
stream-json `result` event at `workers/output/<ticket>-stream.jsonl`, but
phase-agent-dispatch never writes that file (it writes the conversation
JSONL to `~/.claude/projects/<wt>/<sessid>.jsonl` instead). In the first
phase-agents dogfood, **zero** `session_metrics` rows landed for any of
the 19 phase-agent bg sessions and `.roll-usage.log` was never created;
cost was only recoverable by directly querying Prometheus by session_id.

This PR closes that data-path gap end-to-end in four phases plus two
remediation passes:

1. **JSONL-native cost extractor** (`extract-cost-from-jsonl.sh`) sums
   per-message `usage` directly from the conversation transcript and
   prices via a versioned `claude-pricing.json` table.
2. **Phase-aware roll-usage** (`--phase <name>` flag) sources USAGE from
   the extractor instead of the stream-json result event, aggregates
   `state.workers[T].usage` with `+=` so per-worker totals are summed
   across phases, and filters DB-fallback `session_metrics` by
   `skill_name = 'phase-<NAME>'`.
3. **Dashboard sweep** picks up `workers/<TICKET>/phase-<NAME>.json`
   signals every monitor wake-up alongside the legacy flat layout.
4. **Docs** explain the new path, the per-phase aggregation rule, the
   pricing-table artifact, and the new action codes.

Then two correctness fixes surfaced by phase-verify and pr-test-analyzer:

5. **Per-signal flock + dead-sidecar guard** on the legacy sweep — closes
   a same-signal race that double-counted `state.workers[T].usage` in
   phase mode (`+=` exposes what legacy `=` masked) and adds the
   `.dead-*.json` skip to the legacy pass for defensive symmetry.
6. **HIGH-severity remediations** from the phase-review pass — gate
   zero-cost retry on **token sums** not `costUSD` (so unknown-model
   JSONLs aren't short-circuited forever), surface 30s flock contention
   to stderr unconditionally, and split extractor failure into distinct
   `extract-crashed` vs `extract-empty` action codes.

After this PR the data-path is wired: every phase-agent worker emits one
`session_metrics` row per phase with a non-zero `cost_usd`, the
`.roll-usage.log` audit file is populated, and per-phase cost is
queryable from `session_metrics` directly with no Prometheus dependency.

Fixes [CTL-496](https://linear.app/coalesce-labs/issue/CTL-496).

## Changes Made

### Phase 1 — JSONL cost extractor + pricing table (`f72364dd`)

- New `plugins/dev/scripts/extract-cost-from-jsonl.sh` — pure-function
  script that aggregates per-message `usage` from a Claude bg-session
  conversation JSONL and emits a USAGE record matching the existing
  `orchestrate-roll-usage.sh` schema.
- Sums input / output / cache-read / cache-creation tokens per model,
  splits `cache_creation` by 5m/1h TTL, applies per-model pricing from
  `claude-pricing.json`, picks the highest-cost model as primary, and
  pulls `durationMs` from `system.turn_duration` events.
- New `plugins/dev/scripts/claude-pricing.json` — versioned per-model
  pricing table (input/output/cache-read/cache-creation 5m/1h rates)
  for opus, sonnet, haiku-3, haiku-3.5, haiku-4.5.
- Unknown-model graceful path: tokens are still counted, cost reports
  zero so the row is captured and a follow-up pricing-table update can
  reconcile it.
- **Tests**: 29 new tests in
  `__tests__/extract-cost-from-jsonl.test.sh` — single-model sums,
  multi-model cost split, 5m vs 1h cache pricing, duration aggregation,
  assistant-only turn count, empty-JSONL zero record, missing-file
  exit, unknown-model graceful pricing, and a real-shape fixture
  mirroring the live schema (server_tool_use, iterations[],
  stop_reason, etc.).
- **Manual**: ran against the live CTL-496 phase-research JSONL — 82K
  input, 100K output, 5.77M cache-read tokens, $41.47 cost (the plan's
  $5–8 estimate underweighted cache-read contribution).

### Phase 2 — Phase-aware orchestrate-roll-usage (`53e8e371`)

- Adds `--phase <name>` to `plugins/dev/scripts/orchestrate-roll-usage.sh`.
  When set, sources USAGE from the bg session JSONL via
  `extract-cost-from-jsonl.sh` instead of the stream-json result event.
- Aggregates `state.workers[T].usage` across phases (`+=` not `=`) so
  the per-worker total is the sum across all that ticket's phases.
- Phase-mode signal layout: `workers/<TICKET>/phase-<NAME>.json`. Phase
  mode resolves the JSONL via
  `<jobsDir>/<bg_job_id>/state.json -> linkScanPath`, where `<jobsDir>`
  defaults to `~/.claude/jobs` (`CATALYST_BG_JOBS_DIR` overrides for
  tests).
- All four downstream writes (`signal.cost`, `state.workers`,
  `state.usage`, `session_metrics`) are reused unchanged — the contract
  is identical to the legacy path; only the USAGE source differs.
- DB-fallback for `session_metrics` now filters by
  `skill_name = 'phase-<NAME>'` in phase mode, so a phase-verify roll
  doesn't mirror into the phase-research `session_metrics` row when
  multiple phase sessions share a ticket.
- Persists `catalystSessionId` in every phase signal file via a
  `prelude` jq merge applied in `_phase-agent-template.md` and the 7
  Claude-session phase SKILLs (research / plan / implement / verify /
  review / pr / monitor-merge). Triage and monitor-deploy don't call
  `catalyst-session.sh` (pure shell, no turns to bill) so they're
  untouched.
- **Tests**:
  - `orchestrate-roll-usage.test.sh` — 62 legacy + 21 new phase = 83
    total (phase mode flag, idempotency, cross-phase aggregation,
    `bg-state-missing`, `jsonl-missing`, `session_metrics` by
    `catalystSessionId`, DB fallback by ticket+skill, phase isolation,
    verbose action codes, zero-cost JSONL retry guard).
  - New `phase-agent-template.test.sh` — 19 tests covering the prelude
    jq with/without `CATALYST_SESSION_ID`, idempotent re-runs, and
    drift guards that fail CI if a Claude-session phase SKILL omits the
    merge (or a shell-only phase adds one).
- Legacy `oneshot-legacy` dispatch path is unchanged byte-for-byte.

### Phase 3 — Dashboard sweep for phase signals (`600c9eaa`)

- Extends the CTL-487 roll-usage sweep loop in
  `plugins/dev/scripts/update-dashboard.sh` with a second pass over
  `workers/<TICKET>/phase-<NAME>.json` so phase-agent dispatch-mode
  runs get their per-phase signals rolled into state on every monitor
  wake-up, same as the legacy flat `workers/<TICKET>.json` layout.
- Skips `workers/*/phase-*.json.dead-*.json` sidecars —
  `phase-agent-dispatch` renames killed worker signals with a
  `.dead-<id>.json` suffix and their cost is already booked on the
  live signal; re-rolling them would double-count
  `state.workers[T].usage`.
- The two passes are intentionally separate (rather than a single
  `find`) because they invoke `roll-usage` with different flags
  (`--phase` only in the second pass). Both honor the same
  `ROLL_USAGE=1` gate and `.roll-usage.log` audit sink, so the
  observability contract is identical.
- **Tests**: extended `update-dashboard-rolls-usage.test.sh` with 13
  new phase sweep tests (10–14) — discovery + per-phase rollup,
  mixed legacy + phase layout in one run, idempotent re-sweep,
  `.dead-*.json` sidecar skip, and the `--roll-usage` opt-in gate.

### Phase 4 — Docs (`08eeb07c`)

- New "Cost capture" section in `docs/orchestrator-overview.md`
  contrasts the legacy stream-json `result`-event extraction with the
  phase-agent JSONL-extractor path and documents the per-phase
  aggregation rule.
- Added `claude-pricing.json` and `.roll-usage.log` to the canonical
  artifact-locations table.
- Refreshed the "Validation status" callout in
  `website/.../phase-agents.md` to reflect that the end-to-end data
  path is now wired. Removed the stale CTL-487 entry (landed) and
  reworded the `session_metrics` troubleshooting steps to cover the
  new phase-mode action codes (`bg-state-missing`, `jsonl-missing`,
  `extract-failed`) and the `--phase <NAME>` manual-flush invocation.

### Phase 5 — Per-signal flock + dead-sidecar guard (`698543dc`)

Two correctness fixes surfaced by `pr-test-analyzer`:

1. **Same-signal concurrent rollup race**. Without protection, two
   parallel monitor sweeps could both pass the `signal.cost == null`
   check, both compute USAGE, both call `catalyst-state.sh worker`
   with `+=` (in phase mode), and double-count
   `state.workers[T].usage`. Legacy mode escaped because it used
   overwrite-assignment (idempotent on retry); phase mode aggregates
   across phases so the `+=` exposes the race.

   Added an exclusive `flock` on `${SIGNAL_FILE}.lock` covering the
   entire read-modify-write cycle, with a 30s timeout. Re-evaluates
   idempotency under the lock so the loser of a race bails as
   `already-rolled` cleanly. PID-suffixed `.tmp` filename so a
   crashed parallel writer can't leave stale tmp files that block the
   `mv` (matches the convention used in every phase SKILL prelude).

2. **Legacy flat-layout `.dead-*.json` filter**. The phase-layout
   sweep skips `*.dead-*.json` sidecars; the legacy flat sweep had no
   such filter. Today only `phase-agent-dispatch` produces those
   sidecars (and only under the per-ticket subdirectory), but the
   guard belongs in both passes so a future rename path can't
   double-count.

- **Tests**: Test 29 backgrounds 5 rolls on the same phase signal and
  asserts state matches one execution. Test 13b drops a
  `workers/<T>.json.dead-*.json` next to a flat signal and asserts
  state is not double-counted.

### Phase 6 — Phase-review HIGH-severity remediations (`bdda57ef`)

Three findings from the phase-verify / phase-review passes that had
deterministic fixes:

- `orchestrate-roll-usage.sh`: gate zero-cost-retry on **token sums**,
  not `costUSD`. An unknown-model JSONL prices at zero (priced by
  `claude-pricing.json`) but has real token counts; the prior gate
  short-circuited those rolls forever and lost the cost row.
  Regression test added (Test 30, unknown-model fixture).
- `orchestrate-roll-usage.sh`: lock-timeout now emits to stderr
  unconditionally (in addition to the verbose action code) so a 30s
  flock contention surfaces in the caller's roll-log even without
  `-v`. 30s contention is a real signal, not idempotency.
- `orchestrate-roll-usage.sh`: drop `2>/dev/null` on the extractor
  invocation. Extractor stderr now passes through
  (`update-dashboard.sh` already tees stderr into `$ROLL_LOG`). The
  retry-decision splits into two distinct action codes —
  `extract-crashed` (non-zero exit) vs `extract-empty` (clean run,
  empty stdout) — so operators can tell a crash from a not-yet-flushed
  JSONL.

Deferred (recorded in `review.json`, not auto-fixable):
- `extract-cost-from-jsonl.sh:35` — unknown-model stderr warning. The
  verify recommendation prefers implementing over deleting the
  docstring; choice is non-trivial and left for human review.
- Medium / low findings (signal-then-state ordering,
  `.usage.model` nondeterminism, cache-creation flat field, SKILL.md
  drift, etc.) not addressed in this remediation pass.

## How to Verify It

- [x] Phase 1 unit tests pass: `bash plugins/dev/scripts/__tests__/extract-cost-from-jsonl.test.sh` → 29/29 ✅
- [x] Phase 2 unit tests pass: `bash plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh` → 91/91 ✅ (62 legacy + 29 new phase incl. remediation regression)
- [x] Phase 2 template tests pass: `bash plugins/dev/scripts/__tests__/phase-agent-template.test.sh` → 19/19 ✅
- [x] Phase 3 dashboard sweep tests pass: `bash plugins/dev/scripts/__tests__/update-dashboard-rolls-usage.test.sh` → 39/39 ✅
- [x] Manual extractor run against live CTL-496 phase-research JSONL produced expected $41.47 cost record
- [ ] Live phase-agents orchestrator run produces `session_metrics` rows for every bg phase worker (manual — verify post-merge in next dogfood)
- [ ] `.roll-usage.log` appears in a live orch run dir and is appended on each monitor wake (manual — verify post-merge)
- [ ] Per-worker `state.workers[T].usage.costUSD` matches sum across phases for that ticket (manual — verify post-merge)

## Changelog Entry

**feat(dev)**: capture per-phase cost for phase-agent orchestrator workers via JSONL extractor + phase-aware roll-usage + dashboard sweep. Closes the silent no-op where phase-agent `claude --bg` workers produced zero `session_metrics` rows.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-496
- Builds on CTL-487 (monitor-loop roll-usage wiring)
- Related: CTL-492 (OTEL `resource-attribute` gap for the same bg workers)

## Post-Merge Tasks

- [ ] Run a fresh phase-agents dogfood and confirm `session_metrics` is populated for every bg phase worker
- [ ] Tail `.roll-usage.log` for one full orchestrator lifecycle to confirm action codes and absence of `extract-crashed` / `bg-state-missing` outside the expected first-cycle window
- [ ] Decide on the deferred phase-review medium / low findings (separate ticket if any are accepted)

## Reviewer Notes

- The legacy `oneshot-legacy` dispatch path is touched only by the
  `.dead-*.json` skip filter in the flat sweep; no behavioral change to
  pre-existing stream-json `result`-event extraction.
- `extract-cost-from-jsonl.sh` is intentionally pure — no DB writes, no
  state mutation. The pricing dependency is the only external input,
  bundled in `claude-pricing.json` for reproducibility.
- The `+=` aggregation in phase mode is the load-bearing change in the
  semantics of `state.workers[T].usage` — per-worker is now a sum
  across phases for phase-agents mode, while it remains a single
  per-worker total for legacy oneshot. The flock fix in commit
  `698543dc` is what makes `+=` safe under concurrent monitor sweeps.
