### PR TITLE
CTL-498: fix phase-triage bash-baseline acronyms + summary extraction

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -24,15 +24,27 @@ EMIT_HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
 PASS=0
 FAIL=0
 
-ok()   { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
-fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "$2"; }
+ok() {
+	PASS=$((PASS + 1))
+	printf '  PASS: %s\n' "$1"
+}
+fail() {
+	FAIL=$((FAIL + 1))
+	printf '  FAIL: %s\n    %s\n' "$1" "$2"
+}
 
 assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
 assert_nonempty() { if [ -n "$2" ]; then ok "$1"; else fail "$1" "expected non-empty value"; fi; }
 assert_file_exists() { if [ -f "$2" ]; then ok "$1"; else fail "$1" "missing file: $2"; fi; }
 
-[ -f "$SKILL_FILE" ]   || { echo "FAIL: skill missing: $SKILL_FILE";   exit 1; }
-[ -f "$EMIT_HELPER" ]  || { echo "FAIL: helper missing: $EMIT_HELPER"; exit 1; }
+[ -f "$SKILL_FILE" ] || {
+	echo "FAIL: skill missing: $SKILL_FILE"
+	exit 1
+}
+[ -f "$EMIT_HELPER" ] || {
+	echo "FAIL: helper missing: $EMIT_HELPER"
+	exit 1
+}
 
 # Extract the executable bash body delimited by ```bash phase-triage-body``` fences.
 SKILL_BODY_FILE="$(mktemp -t phase-triage-body.XXXXXX.sh)"
@@ -40,11 +52,11 @@ awk '
   /^```bash phase-triage-body$/ {capture=1; next}
   /^```$/ {if (capture) {capture=0}}
   capture { print }
-' "$SKILL_FILE" > "$SKILL_BODY_FILE"
+' "$SKILL_FILE" >"$SKILL_BODY_FILE"
 
 if [ ! -s "$SKILL_BODY_FILE" ]; then
-  echo "FAIL: could not extract phase-triage-body block from $SKILL_FILE" >&2
-  exit 1
+	echo "FAIL: could not extract phase-triage-body block from $SKILL_FILE" >&2
+	exit 1
 fi
 
 # Per-case runner. $1=case-name, $2=fixture-json-path, $3=ticket, $4=expected-status
@@ -52,12 +64,12 @@ TMPROOT="$(mktemp -d -t phase-triage-test.XXXXXX)"
 trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
 
 run_case() {
-  local case_name="$1" fixture="$2" ticket="$3"
-  local case_dir="$TMPROOT/$case_name"
-  mkdir -p "$case_dir/bin"
+	local case_name="$1" fixture="$2" ticket="$3"
+	local case_dir="$TMPROOT/$case_name"
+	mkdir -p "$case_dir/bin"
 
-  # Build the `linearis` stub.
-  cat > "$case_dir/bin/linearis" <<EOF
+	# Build the `linearis` stub.
+	cat >"$case_dir/bin/linearis" <<EOF
 #!/usr/bin/env bash
 LOG="$case_dir/linearis-calls.log"
 case "\$1" in
@@ -88,22 +100,22 @@ case "\$1" in
     ;;
 esac
 EOF
-  chmod +x "$case_dir/bin/linearis"
+	chmod +x "$case_dir/bin/linearis"
 
-  # Run the skill body with the stub on PATH.
-  local events_file="$case_dir/events.jsonl"
+	# Run the skill body with the stub on PATH.
+	local events_file="$case_dir/events.jsonl"
 
-  PATH="$case_dir/bin:$PATH" \
-  TICKET="$ticket" \
-  WORKER_DIR="$case_dir/worker" \
-  CATALYST_EVENTS_FILE="$events_file" \
-  PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
-  PHASE_EMIT_HELPER="$EMIT_HELPER" \
-    bash "$SKILL_BODY_FILE" > "$case_dir/stdout.log" 2> "$case_dir/stderr.log"
-  echo $? > "$case_dir/exit-code"
+	PATH="$case_dir/bin:$PATH" \
+		TICKET="$ticket" \
+		WORKER_DIR="$case_dir/worker" \
+		CATALYST_EVENTS_FILE="$events_file" \
+		PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
+		PHASE_EMIT_HELPER="$EMIT_HELPER" \
+		bash "$SKILL_BODY_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+	echo $? >"$case_dir/exit-code"
 
-  # Stash for later assertions
-  echo "$case_dir"
+	# Stash for later assertions
+	echo "$case_dir"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -112,7 +124,7 @@ EOF
 echo "phase-triage e2e tests"
 
 FIXTURE_HAPPY="$TMPROOT/fixture-happy.json"
-cat > "$FIXTURE_HAPPY" <<'EOF'
+cat >"$FIXTURE_HAPPY" <<'EOF'
 {
   "identifier": "CTL-9999",
   "title": "Add OTel exporter for the CLI",
@@ -132,43 +144,43 @@ TRIAGE_FILE="$CASE_DIR/worker/triage.json"
 assert_file_exists "happy: triage.json created" "$TRIAGE_FILE"
 
 if [ -f "$TRIAGE_FILE" ]; then
-  CLASSIFICATION="$(jq -r '.classification' "$TRIAGE_FILE")"
-  case "$CLASSIFICATION" in
-    feature|bug|docs|refactor|chore) ok "happy: classification is a valid enum value" ;;
-    *) fail "happy: classification enum" "got '$CLASSIFICATION'" ;;
-  esac
+	CLASSIFICATION="$(jq -r '.classification' "$TRIAGE_FILE")"
+	case "$CLASSIFICATION" in
+	feature | bug | docs | refactor | chore) ok "happy: classification is a valid enum value" ;;
+	*) fail "happy: classification enum" "got '$CLASSIFICATION'" ;;
+	esac
 
-  SCOPE="$(jq -r '.estimated_scope' "$TRIAGE_FILE")"
-  case "$SCOPE" in
-    small|medium|large|epic) ok "happy: estimated_scope is a valid enum value" ;;
-    *) fail "happy: scope enum" "got '$SCOPE'" ;;
-  esac
+	SCOPE="$(jq -r '.estimated_scope' "$TRIAGE_FILE")"
+	case "$SCOPE" in
+	small | medium | large | epic) ok "happy: estimated_scope is a valid enum value" ;;
+	*) fail "happy: scope enum" "got '$SCOPE'" ;;
+	esac
 
-  ACRONYM_COUNT="$(jq '.acronyms_expanded | length' "$TRIAGE_FILE")"
-  if [ "${ACRONYM_COUNT:-0}" -ge 1 ]; then
-    ok "happy: at least one acronym expanded (OTel/CLI/API/PR/MVP/E2E all present)"
-  else
-    fail "happy: acronym count" "expected ≥1 acronym, got $ACRONYM_COUNT"
-  fi
+	ACRONYM_COUNT="$(jq '.acronyms_expanded | length' "$TRIAGE_FILE")"
+	if [ "${ACRONYM_COUNT:-0}" -ge 1 ]; then
+		ok "happy: at least one acronym expanded (OTel/CLI/API/PR/MVP/E2E all present)"
+	else
+		fail "happy: acronym count" "expected ≥1 acronym, got $ACRONYM_COUNT"
+	fi
 
-  DEPS="$(jq -c '.dependencies' "$TRIAGE_FILE")"
-  # Expect CTL-447 and CTL-448, but NOT CTL-9999 (self).
-  EXPECTED_DEPS='["CTL-447","CTL-448"]'
-  assert_eq "happy: dependencies match (excludes self)" "$EXPECTED_DEPS" "$DEPS"
+	DEPS="$(jq -c '.dependencies' "$TRIAGE_FILE")"
+	# Expect CTL-447 and CTL-448, but NOT CTL-9999 (self).
+	EXPECTED_DEPS='["CTL-447","CTL-448"]'
+	assert_eq "happy: dependencies match (excludes self)" "$EXPECTED_DEPS" "$DEPS"
 fi
 
 # Assert: linearis discuss + update were called
 LINEARIS_LOG="$CASE_DIR/linearis-calls.log"
 if grep -q '^discuss$' "$LINEARIS_LOG" 2>/dev/null; then
-  ok "happy: linearis issues discuss was called"
+	ok "happy: linearis issues discuss was called"
 else
-  fail "happy: discuss call" "no 'discuss' entry in linearis log:$(printf '\n%s' "$(cat "$LINEARIS_LOG" 2>/dev/null)")"
+	fail "happy: discuss call" "no 'discuss' entry in linearis log:$(printf '\n%s' "$(cat "$LINEARIS_LOG" 2>/dev/null)")"
 fi
 
 if grep -q '^update$' "$LINEARIS_LOG" 2>/dev/null; then
-  ok "happy: linearis issues update was called"
+	ok "happy: linearis issues update was called"
 else
-  fail "happy: update call" "no 'update' entry in linearis log"
+	fail "happy: update call" "no 'update' entry in linearis log"
 fi
 
 # Assert: emitted event has the right shape
@@ -189,7 +201,7 @@ assert_nonempty "happy: event payload includes classification" "$EVENT_CLASS"
 # Asserts the case-insensitive match and the extended dictionary.
 
 FIXTURE_ACRONYMS="$TMPROOT/fixture-acronyms.json"
-cat > "$FIXTURE_ACRONYMS" <<'EOF'
+cat >"$FIXTURE_ACRONYMS" <<'EOF'
 {
   "identifier": "CTL-9998",
   "title": "Wire OTEL exporter and PromQL queries",
@@ -206,15 +218,15 @@ TRIAGE_ACR="$CASE_DIR_ACR/worker/triage.json"
 assert_file_exists "acronyms: triage.json created" "$TRIAGE_ACR"
 
 if [ -f "$TRIAGE_ACR" ]; then
-  # Build a space-separated string of acronyms for substring assertions.
-  ACR_LIST="$(jq -r '.acronyms_expanded[].acronym' "$TRIAGE_ACR" | tr '\n' ' ')"
+	# Build a space-separated string of acronyms for substring assertions.
+	ACR_LIST="$(jq -r '.acronyms_expanded[].acronym' "$TRIAGE_ACR" | tr '\n' ' ')"
 
-  for needed in OTEL PromQL bg HUD ADR; do
-    case " $ACR_LIST " in
-      *" $needed "*) ok "acronyms: detected $needed" ;;
-      *)             fail "acronyms: missing $needed" "got: '$ACR_LIST'" ;;
-    esac
-  done
+	for needed in OTEL PromQL bg HUD ADR; do
+		case " $ACR_LIST " in
+		*" $needed "*) ok "acronyms: detected $needed" ;;
+		*) fail "acronyms: missing $needed" "got: '$ACR_LIST'" ;;
+		esac
+	done
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -222,7 +234,7 @@ fi
 # Asserts the summary skips a leading "## Problem" header and starts with prose.
 
 FIXTURE_MD="$TMPROOT/fixture-markdown.json"
-cat > "$FIXTURE_MD" <<'EOF'
+cat >"$FIXTURE_MD" <<'EOF'
 {
   "identifier": "CTL-9997",
   "title": "Surface phase-triage summary correctly",
@@ -239,28 +251,30 @@ TRIAGE_MD="$CASE_DIR_MD/worker/triage.json"
 assert_file_exists "markdown: triage.json created" "$TRIAGE_MD"
 
 if [ -f "$TRIAGE_MD" ]; then
-  SUMMARY_MD="$(jq -r '.summary' "$TRIAGE_MD")"
+	SUMMARY_MD="$(jq -r '.summary' "$TRIAGE_MD")"
 
-  # Summary must NOT be the literal "## Problem" header.
-  case "$SUMMARY_MD" in
-    "## Problem"*) fail "markdown: summary skipped header" "summary='$SUMMARY_MD' (still starts with literal header)" ;;
-    *) ok "markdown: summary does not start with markdown header" ;;
-  esac
+	# Summary must NOT be the literal "## Problem" header.
+	case "$SUMMARY_MD" in
+	"## Problem"*) fail "markdown: summary skipped header" "summary='$SUMMARY_MD' (still starts with literal header)" ;;
+	*) ok "markdown: summary does not start with markdown header" ;;
+	esac
 
-  # Summary must START WITH the first sentence of prose.
-  case "$SUMMARY_MD" in
-    "The baseline summary extraction"*)
-      ok "markdown: summary starts with the first prose sentence" ;;
-    *)
-      fail "markdown: summary content" "expected prefix 'The baseline summary extraction', got '$SUMMARY_MD'" ;;
-  esac
+	# Summary must START WITH the first sentence of prose.
+	case "$SUMMARY_MD" in
+	"The baseline summary extraction"*)
+		ok "markdown: summary starts with the first prose sentence"
+		;;
+	*)
+		fail "markdown: summary content" "expected prefix 'The baseline summary extraction', got '$SUMMARY_MD'"
+		;;
+	esac
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Case 2: explicit bug classification + small scope
 
 FIXTURE_BUG="$TMPROOT/fixture-bug.json"
-cat > "$FIXTURE_BUG" <<'EOF'
+cat >"$FIXTURE_BUG" <<'EOF'
 {
   "identifier": "CTL-7777",
   "title": "Bug: catalyst-events tail leaks fd",
@@ -274,11 +288,11 @@ EXIT_CODE2="$(cat "$CASE_DIR2/exit-code")"
 assert_eq "bug: exit code 0" 0 "$EXIT_CODE2"
 
 if [ -f "$CASE_DIR2/worker/triage.json" ]; then
-  CLASS2="$(jq -r '.classification' "$CASE_DIR2/worker/triage.json")"
-  assert_eq "bug: classified as bug" "bug" "$CLASS2"
+	CLASS2="$(jq -r '.classification' "$CASE_DIR2/worker/triage.json")"
+	assert_eq "bug: classified as bug" "bug" "$CLASS2"
 
-  SCOPE2="$(jq -r '.estimated_scope' "$CASE_DIR2/worker/triage.json")"
-  assert_eq "bug: scope is small" "small" "$SCOPE2"
+	SCOPE2="$(jq -r '.estimated_scope' "$CASE_DIR2/worker/triage.json")"
+	assert_eq "bug: scope is small" "small" "$SCOPE2"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -286,7 +300,7 @@ fi
 
 FAIL_DIR="$TMPROOT/lin-fail"
 mkdir -p "$FAIL_DIR/bin"
-cat > "$FAIL_DIR/bin/linearis" <<'EOF'
+cat >"$FAIL_DIR/bin/linearis" <<'EOF'
 #!/usr/bin/env bash
 echo "linearis stub: simulated failure" >&2
 exit 1
@@ -294,18 +308,18 @@ EOF
 chmod +x "$FAIL_DIR/bin/linearis"
 
 PATH="$FAIL_DIR/bin:$PATH" \
-TICKET=CTL-9001 \
-WORKER_DIR="$FAIL_DIR/worker" \
-CATALYST_EVENTS_FILE="$FAIL_DIR/events.jsonl" \
-PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
-PHASE_EMIT_HELPER="$EMIT_HELPER" \
-  bash "$SKILL_BODY_FILE" > "$FAIL_DIR/stdout.log" 2> "$FAIL_DIR/stderr.log"
+	TICKET=CTL-9001 \
+	WORKER_DIR="$FAIL_DIR/worker" \
+	CATALYST_EVENTS_FILE="$FAIL_DIR/events.jsonl" \
+	PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
+	PHASE_EMIT_HELPER="$EMIT_HELPER" \
+	bash "$SKILL_BODY_FILE" >"$FAIL_DIR/stdout.log" 2>"$FAIL_DIR/stderr.log"
 FAIL_EXIT=$?
 
 if [ "$FAIL_EXIT" -ne 0 ]; then
-  ok "lin-fail: exits non-zero when linearis read fails"
+	ok "lin-fail: exits non-zero when linearis read fails"
 else
-  fail "lin-fail: exit code" "expected non-zero, got $FAIL_EXIT"
+	fail "lin-fail: exit code" "expected non-zero, got $FAIL_EXIT"
 fi
 
 FAIL_EVENT="$(jq -r '.attributes."event.name"' "$FAIL_DIR/events.jsonl" 2>/dev/null | head -1)"
@@ -318,6 +332,6 @@ echo
 echo "Results: ${PASS} passed, ${FAIL} failed"
 
 if [ "$FAIL" -ne 0 ]; then
-  exit 1
+	exit 1
 fi
 exit 0

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -218,6 +218,45 @@ if [ -f "$TRIAGE_ACR" ]; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Case 1c: markdown-prefixed description (CTL-498 Bug 2).
+# Asserts the summary skips a leading "## Problem" header and starts with prose.
+
+FIXTURE_MD="$TMPROOT/fixture-markdown.json"
+cat > "$FIXTURE_MD" <<'EOF'
+{
+  "identifier": "CTL-9997",
+  "title": "Surface phase-triage summary correctly",
+  "description": "## Problem\n\nThe baseline summary extraction returns the literal markdown header instead of the first sentence of prose. This breaks downstream consumers of the summary field.\n\n## Fix sketch\n\nSkip leading header lines before applying the paragraph rule.",
+  "labels": {"nodes": []}
+}
+EOF
+
+CASE_DIR_MD="$(run_case markdown "$FIXTURE_MD" CTL-9997)"
+
+assert_eq "markdown: exit code 0" 0 "$(cat "$CASE_DIR_MD/exit-code")"
+
+TRIAGE_MD="$CASE_DIR_MD/worker/triage.json"
+assert_file_exists "markdown: triage.json created" "$TRIAGE_MD"
+
+if [ -f "$TRIAGE_MD" ]; then
+  SUMMARY_MD="$(jq -r '.summary' "$TRIAGE_MD")"
+
+  # Summary must NOT be the literal "## Problem" header.
+  case "$SUMMARY_MD" in
+    "## Problem"*) fail "markdown: summary skipped header" "summary='$SUMMARY_MD' (still starts with literal header)" ;;
+    *) ok "markdown: summary does not start with markdown header" ;;
+  esac
+
+  # Summary must START WITH the first sentence of prose.
+  case "$SUMMARY_MD" in
+    "The baseline summary extraction"*)
+      ok "markdown: summary starts with the first prose sentence" ;;
+    *)
+      fail "markdown: summary content" "expected prefix 'The baseline summary extraction', got '$SUMMARY_MD'" ;;
+  esac
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Case 2: explicit bug classification + small scope
 
 FIXTURE_BUG="$TMPROOT/fixture-bug.json"

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -185,6 +185,39 @@ EVENT_CLASS="$(jq -r '.body.payload.classification' "$CASE_DIR/events.jsonl" 2>/
 assert_nonempty "happy: event payload includes classification" "$EVENT_CLASS"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Case 1b: all-caps + project-vocab acronyms (CTL-498 Bug 1).
+# Asserts the case-insensitive match and the extended dictionary.
+
+FIXTURE_ACRONYMS="$TMPROOT/fixture-acronyms.json"
+cat > "$FIXTURE_ACRONYMS" <<'EOF'
+{
+  "identifier": "CTL-9998",
+  "title": "Wire OTEL exporter and PromQL queries",
+  "description": "Trace the bg job via OTEL spans and surface them in the HUD. Capture metrics with PromQL; document the decision in an ADR.",
+  "labels": {"nodes": []}
+}
+EOF
+
+CASE_DIR_ACR="$(run_case acronyms "$FIXTURE_ACRONYMS" CTL-9998)"
+
+assert_eq "acronyms: exit code 0" 0 "$(cat "$CASE_DIR_ACR/exit-code")"
+
+TRIAGE_ACR="$CASE_DIR_ACR/worker/triage.json"
+assert_file_exists "acronyms: triage.json created" "$TRIAGE_ACR"
+
+if [ -f "$TRIAGE_ACR" ]; then
+  # Build a space-separated string of acronyms for substring assertions.
+  ACR_LIST="$(jq -r '.acronyms_expanded[].acronym' "$TRIAGE_ACR" | tr '\n' ' ')"
+
+  for needed in OTEL PromQL bg HUD ADR; do
+    case " $ACR_LIST " in
+      *" $needed "*) ok "acronyms: detected $needed" ;;
+      *)             fail "acronyms: missing $needed" "got: '$ACR_LIST'" ;;
+    esac
+  done
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Case 2: explicit bug classification + small scope
 
 FIXTURE_BUG="$TMPROOT/fixture-bug.json"

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -9,35 +9,36 @@ version: 1.0.0
 
 # phase-triage
 
-Greenfield phase agent shipped in CTL-451 (Initiative 1 Phase 5). Reads a Linear ticket,
-produces a structured triage analysis, and lands the analysis as a Linear comment + label
-so subsequent phase agents (research, plan, …) can rely on the classification.
+Greenfield phase agent shipped in CTL-451 (Initiative 1 Phase 5). Reads a Linear ticket, produces a
+structured triage analysis, and lands the analysis as a Linear comment + label so subsequent phase
+agents (research, plan, …) can rely on the classification.
 
 The skill is dispatched in two modes:
 
-- **Production**: An Opus phase agent reads `triage.json` placeholder fields produced by
-  the bash body below, then refines them with model-quality analysis (acronym expansion,
-  judgment-of-scope, dep inference) before the comment is posted.
-- **CI / test runner**: The bash body alone is self-sufficient — it derives all five
-  fields deterministically from the ticket JSON so e2e tests run without a model call.
+- **Production**: An Opus phase agent reads `triage.json` placeholder fields produced by the bash
+  body below, then refines them with model-quality analysis (acronym expansion, judgment-of-scope,
+  dep inference) before the comment is posted.
+- **CI / test runner**: The bash body alone is self-sufficient — it derives all five fields
+  deterministically from the ticket JSON so e2e tests run without a model call.
 
 Both modes produce the same `triage.json` shape and emit the same canonical phase event.
 
 ## Setup prerequisite
 
 The `triaged` workspace label must already exist in Linear. The skill applies it via
-`linearis issues update --labels triaged --label-mode add` and tolerates a non-zero exit
-(logs a warning, does not fail the phase). Future work in CTL-452 may add a
-`linearis labels create` call to bootstrap the label.
+`linearis issues update --labels triaged --label-mode add` and tolerates a non-zero exit (logs a
+warning, does not fail the phase). Future work in CTL-452 may add a `linearis labels create` call to
+bootstrap the label.
 
 ## Inputs
 
 Environment:
+
 - `TICKET` — Linear identifier (e.g. `CTL-451`). Required.
-- `WORKER_DIR` — output directory for `triage.json`. Defaults to
-  `${ORCH_DIR}/workers/${TICKET}` if set, else `$(pwd)`.
-- `ORCH_DIR`, `CATALYST_ORCHESTRATOR_ID`, `CATALYST_SESSION_ID` — used for trace/span
-  id derivation in the emitted event; all optional.
+- `WORKER_DIR` — output directory for `triage.json`. Defaults to `${ORCH_DIR}/workers/${TICKET}` if
+  set, else `$(pwd)`.
+- `ORCH_DIR`, `CATALYST_ORCHESTRATOR_ID`, `CATALYST_SESSION_ID` — used for trace/span id derivation
+  in the emitted event; all optional.
 
 ## Body
 
@@ -236,14 +237,14 @@ exit 0
 
 ## What an Opus-mode invocation adds
 
-The bash body above is fully self-sufficient — the e2e test exercises only that. When an
-Opus agent runs this skill, it should:
+The bash body above is fully self-sufficient — the e2e test exercises only that. When an Opus agent
+runs this skill, it should:
 
 1. Run the bash body to produce the baseline `triage.json` and Linear comment.
-2. Read the ticket back, refine the classification + scope estimate with model-quality
-   judgement, and re-write `triage.json` if anything changed.
-3. If the refined fields differ materially, post a follow-up `linearis issues discuss`
-   comment marking the refinement.
+2. Read the ticket back, refine the classification + scope estimate with model-quality judgement,
+   and re-write `triage.json` if anything changed.
+3. If the refined fields differ materially, post a follow-up `linearis issues discuss` comment
+   marking the refinement.
 
-The refinement step is deliberately optional — the orchestrator hand-off in CTL-452 only
-needs the `phase.triage.complete.<TICKET>` event, and the bash body already emits that.
+The refinement step is deliberately optional — the orchestrator hand-off in CTL-452 only needs the
+`phase.triage.complete.<TICKET>` event, and the bash body already emits that.

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -114,20 +114,27 @@ acronyms_json() {
   local txt="$1"
   jq -nc --arg t "$txt" '
     [
-      {a:"PR",  e:"Pull Request"},
-      {a:"CI",  e:"Continuous Integration"},
-      {a:"CLI", e:"Command-Line Interface"},
-      {a:"API", e:"Application Programming Interface"},
-      {a:"MVP", e:"Minimum Viable Product"},
-      {a:"TDD", e:"Test-Driven Development"},
-      {a:"E2E", e:"End-to-End"},
-      {a:"SHA", e:"Secure Hash Algorithm"},
-      {a:"UUID",e:"Universally Unique Identifier"},
-      {a:"JSON",e:"JavaScript Object Notation"},
-      {a:"OTel",e:"OpenTelemetry"},
-      {a:"OTLP",e:"OpenTelemetry Line Protocol"}
+      {a:"PR",     e:"Pull Request"},
+      {a:"CI",     e:"Continuous Integration"},
+      {a:"CLI",    e:"Command-Line Interface"},
+      {a:"API",    e:"Application Programming Interface"},
+      {a:"MVP",    e:"Minimum Viable Product"},
+      {a:"TDD",    e:"Test-Driven Development"},
+      {a:"E2E",    e:"End-to-End"},
+      {a:"SHA",    e:"Secure Hash Algorithm"},
+      {a:"UUID",   e:"Universally Unique Identifier"},
+      {a:"JSON",   e:"JavaScript Object Notation"},
+      {a:"OTEL",   e:"OpenTelemetry"},
+      {a:"OTLP",   e:"OpenTelemetry Line Protocol"},
+      {a:"PromQL", e:"Prometheus Query Language"},
+      {a:"bg",     e:"background"},
+      {a:"HUD",    e:"Heads-Up Display"},
+      {a:"ADR",    e:"Architecture Decision Record"}
     ]
-    | map(.a as $acr | select($t | test("\\b" + $acr + "\\b")))
+    | ($t | ascii_downcase) as $tl
+    | map(.a as $acr
+          | (.a | ascii_downcase) as $acl
+          | select($tl | test("\\b" + $acl + "\\b")))
     | map({acronym: .a, expansion: .e})
   '
 }

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -149,8 +149,26 @@ DEPENDENCIES="$(printf '%s\n' "$COMBINED" \
   | jq -R . | jq -sc .)"
 DEPENDENCIES="${DEPENDENCIES:-[]}"
 
-# 2e. Summary — first paragraph of description, trimmed.
-SUMMARY="$(printf '%s' "$DESCRIPTION" | awk 'BEGIN{RS=""} {print; exit}' | head -c 400)"
+# 2e. Summary — first paragraph of prose, trimmed.
+#     Skip leading markdown headers (^#+\s+) and bullet markers (^[-*+]\s+) so a
+#     description that opens with "## Problem" yields the first sentence of prose,
+#     not the literal header. Falls back to an empty summary if the description is
+#     entirely headers/bullets/blank lines.
+SUMMARY="$(printf '%s' "$DESCRIPTION" | awk '
+  BEGIN { skipping = 1; buf = "" }
+  {
+    line = $0
+    if (skipping) {
+      if (line ~ /^[[:space:]]*$/)       { next }
+      if (line ~ /^#+[[:space:]]+/)      { next }
+      if (line ~ /^[-*+][[:space:]]+/)   { next }
+      skipping = 0
+    }
+    if (line ~ /^[[:space:]]*$/) { exit }
+    buf = (buf == "" ? line : buf " " line)
+  }
+  END { print buf }
+' | head -c 400)"
 
 # 3. Compose triage.json.
 TRIAGE_FILE="$WORKER_DIR/triage.json"


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-18T22:24:34Z -->
<!-- Last updated: 2026-05-18T22:24:34Z -->
<!-- PR: #869 -->
<!-- Previous commits: e5d8e778,371f0bed,02f5f0ca -->

## Summary

Fixes two accuracy bugs in the deterministic bash baseline of the `phase-triage` skill. The Opus refinement path was masking both bugs by re-deriving the affected fields, but every triage was burning extra refinement work because the baseline was wrong.

- **Bug 1** — acronym dictionary used case-sensitive `jq test()`, so common spellings like `OTEL` never matched `\bOTel\b`. Dictionary was also missing project vocab (`PromQL`, `bg`, `HUD`, `ADR`).
- **Bug 2** — summary extractor used `awk 'BEGIN{RS=""} {print; exit}'`, which treats a leading `## Problem` header line as the first paragraph and ships the literal markdown header as the summary.

Both bugs are now fixed in the bash baseline so the Opus refinement no longer needs to re-derive these fields on every triage.

## Changes

### Bug 1 — acronyms case-insensitive + project vocab (`02f5f0ca`)

`plugins/dev/skills/phase-triage/SKILL.md` — `acronyms_json` function:

- Switched the jq `test()` call from default case-sensitive to `ascii_downcase | test(...)`, matching the existing project precedent in `pre-assign-migrations.sh:87`.
- Added missing project-vocabulary terms: `OTEL`, `OTLP` (canonical all-caps), `PromQL`, `bg` (background-mode worker), `HUD`, `ADR`.
- Output preserves the dictionary-canonical spelling so Linear comments render uniformly even when the source description uses mixed case.

### Bug 2 — summary skips markdown header prefix (`371f0bed`)

`plugins/dev/skills/phase-triage/SKILL.md` — `SUMMARY` extraction:

- Replaced the bare `awk 'BEGIN{RS=""} {print; exit}'` pipeline with a line-by-line awk that skips leading markdown headers (`^#+\s+`), bullet markers (`^[-*+]\s+`), and blank lines before collecting the first prose paragraph.
- Falls back to an empty summary when the description is entirely headers/bullets/blank.
- The outer `printf | … | head -c 400` framing is preserved exactly, so the 400-char cap is unchanged.

### Formatting fixup (`e5d8e778`)

`make check` (trunk → prettier + shfmt) reflowed the touched files to match the repo's line-length and shell-style conventions. Pure cosmetic — no semantic change. Verified by re-running the e2e suite (28/28 pass) against the reformatted code.

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` — **28/28 pass** (includes new `CTL-9998` acronym fixture and new `CTL-9997` markdown-header fixture)
- [x] `make check` — **all quality checks pass** (trunk lint clean, frontmatter valid)
- [ ] Manual: dispatch a fresh `phase-triage` against a real Linear ticket whose description starts with `## Problem` and contains `OTEL` / `PromQL` / `bg` — confirm baseline triage.json captures all three acronyms and the summary skips the header.

## Acceptance criteria (from CTL-498)

- [x] Baseline triage of a description containing `OTEL`, `PromQL`, `bg` produces those three acronyms in `acronyms_expanded` (case-insensitive match).
- [x] Baseline triage of a description that starts with `## Problem\n\nThe first sentence is here.` produces summary starting with `The first sentence is here.`, NOT `## Problem`.
- [x] Existing e2e test `plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` extended with fixtures exercising each bug (`CTL-9997` for header skip, `CTL-9998` for acronym matching).
- [x] Opus refinement path still works (this is a baseline-accuracy fix; refinement is unaffected).

## Files changed

- `plugins/dev/skills/phase-triage/SKILL.md` — bug fixes (acronyms_json, SUMMARY extraction) + lint reflow
- `plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` — two new fixtures + lint reflow

## Related

- Linear ticket: [CTL-498](https://linear.app/coalesce-labs/issue/CTL-498)
- Sibling ticket on a different phase-triage gap: CTL-497 (Linear write-back to ticket fields)
- Discovered via the in-flight phase-agent orchestrator run for CTL-491–496 (worker for CTL-492)
- Orchestrator run: `o-ctl-498-499`

Refs: CTL-498
