### PR TITLE
CTL-499: fix phase-monitor-deploy SHA resolution

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
@@ -83,16 +83,52 @@ write_deploy_event() {
 
 run_case() {
   local case_name="$1" sha="$2" deploy_state="$3" canary_status="$4" \
-        timeout_sec="$5" emit_event="$6"
+        timeout_sec="$5" emit_event="$6" \
+        signal_sha="${7-__USE_SHA__}" write_pr="${8:-no}" gh_sha="${9-}"
+
+  # signal_sha defaults to "$sha" when caller omits it; pass an explicit ""
+  # to force an empty signal (Phase 2 fallback tests).
+  if [ "$signal_sha" = "__USE_SHA__" ]; then
+    signal_sha="$sha"
+  fi
 
   local case_dir="$TMPROOT/$case_name"
   local worker="$case_dir/worker"
   mkdir -p "$worker" "$case_dir/bin"
 
-  # Fixture phase-pr.json
-  jq -nc --arg sha "$sha" '{
-    pr: {number: 1234, url: "https://example.com/pr/1234", mergeCommitSha: $sha}
-  }' > "$worker/phase-pr.json"
+  # Fixture phase-monitor-merge.json (primary input for phase-monitor-deploy).
+  jq -nc --arg sha "$signal_sha" '{
+    pr: {
+      mergedAt: "2026-05-18T22:00:00Z",
+      ciStatus: "merged",
+      mergeCommitSha: $sha
+    }
+  }' > "$worker/phase-monitor-merge.json"
+
+  # Optionally fixture phase-pr.json for the REST fallback path (Phase 2).
+  if [ "$write_pr" = "yes" ]; then
+    jq -nc '{
+      pr: {number: 1234, url: "https://example.com/pr/1234"}
+    }' > "$worker/phase-pr.json"
+  fi
+
+  # If a gh_sha was provided, stub `gh` on PATH so the fallback can resolve.
+  if [ -n "$gh_sha" ]; then
+    cat > "$case_dir/bin/gh" <<EOF
+#!/usr/bin/env bash
+# Minimal gh stub for phase-monitor-deploy fallback path.
+case "\$*" in
+  *"repo view"*)
+    jq -nc '{nameWithOwner: "owner/repo"}'
+    ;;
+  *"api repos/"*"/pulls/"*)
+    jq -nc --arg s "$gh_sha" '{merge_commit_sha: \$s}'
+    ;;
+  *) exit 1 ;;
+esac
+EOF
+    chmod +x "$case_dir/bin/gh"
+  fi
 
   local events_file="$case_dir/events.jsonl"
   : > "$events_file"  # create empty so wait-for sees no history
@@ -212,10 +248,10 @@ assert_eq "skipped: emitted skipped event" \
   "phase.monitor-deploy.skipped.CTL-9999" "$SKIP_EVENT"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Case 4: phase-pr.json missing → failed event + non-zero
+# Case 4: phase-monitor-merge.json missing → failed event + non-zero
 
 MISS_DIR="$TMPROOT/missing"
-mkdir -p "$MISS_DIR/worker"  # but NO phase-pr.json
+mkdir -p "$MISS_DIR/worker"  # but NO phase-monitor-merge.json
 
 PATH="$PATH" \
 TICKET=CTL-8888 \
@@ -228,15 +264,24 @@ PHASE_EMIT_HELPER="$EMIT_HELPER" \
 MISS_EXIT=$?
 
 if [ "$MISS_EXIT" -ne 0 ]; then
-  ok "missing-pr: exits non-zero when phase-pr.json is absent"
+  ok "missing-merge: exits non-zero when phase-monitor-merge.json is absent"
 else
-  fail "missing-pr: exit code" "expected non-zero, got $MISS_EXIT"
+  fail "missing-merge: exit code" "expected non-zero, got $MISS_EXIT"
 fi
 
 MISS_EVENT="$(jq -r '.attributes."event.name"' "$MISS_DIR/events.jsonl" 2>/dev/null \
               | tail -1)"
-assert_eq "missing-pr: emits failed event" \
+assert_eq "missing-merge: emits failed event" \
   "phase.monitor-deploy.failed.CTL-8888" "$MISS_EVENT"
+
+# Failure reason should cite the new file, not phase-pr.json. The emit helper
+# stores the --reason text in body.message of the canonical event line.
+MISS_REASON="$(jq -r '.body.message // empty' \
+              "$MISS_DIR/events.jsonl" 2>/dev/null | tail -1)"
+case "$MISS_REASON" in
+  *phase-monitor-merge.json*) ok "missing-merge: failure reason cites phase-monitor-merge.json" ;;
+  *) fail "missing-merge: failure reason" "expected reason to mention phase-monitor-merge.json, got: $MISS_REASON" ;;
+esac
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Summary

--- a/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
@@ -84,7 +84,7 @@ write_deploy_event() {
 run_case() {
   local case_name="$1" sha="$2" deploy_state="$3" canary_status="$4" \
         timeout_sec="$5" emit_event="$6" \
-        signal_sha="${7-__USE_SHA__}" write_pr="${8:-no}" gh_sha="${9-}"
+        signal_sha="${7-__USE_SHA__}" write_pr="${8:-no}" gh_sha="${9-__NO_STUB__}"
 
   # signal_sha defaults to "$sha" when caller omits it; pass an explicit ""
   # to force an empty signal (Phase 2 fallback tests).
@@ -112,17 +112,24 @@ run_case() {
     }' > "$worker/phase-pr.json"
   fi
 
-  # If a gh_sha was provided, stub `gh` on PATH so the fallback can resolve.
-  if [ -n "$gh_sha" ]; then
+  # Stub `gh` on PATH when caller wants the fallback path exercised
+  # deterministically. Pass gh_sha="" to stub with an empty merge_commit_sha
+  # (Case 6); pass a non-empty SHA to stub with that SHA (Case 5); omit the
+  # argument entirely (sentinel __NO_STUB__) to skip the stub.
+  #
+  # The SKILL body calls `gh repo view --json X --jq '.X'` and `gh api ... --jq '.X'`,
+  # so the stub returns the scalar value directly (mimicking what --jq would emit).
+  if [ "$gh_sha" != "__NO_STUB__" ]; then
     cat > "$case_dir/bin/gh" <<EOF
 #!/usr/bin/env bash
-# Minimal gh stub for phase-monitor-deploy fallback path.
+# Minimal gh stub for phase-monitor-deploy fallback path. Returns scalar
+# strings (not JSON) to mimic gh's --jq scalar extraction.
 case "\$*" in
   *"repo view"*)
-    jq -nc '{nameWithOwner: "owner/repo"}'
+    printf '%s\n' "owner/repo"
     ;;
   *"api repos/"*"/pulls/"*)
-    jq -nc --arg s "$gh_sha" '{merge_commit_sha: \$s}'
+    printf '%s\n' "$gh_sha"
     ;;
   *) exit 1 ;;
 esac
@@ -281,6 +288,54 @@ MISS_REASON="$(jq -r '.body.message // empty' \
 case "$MISS_REASON" in
   *phase-monitor-merge.json*) ok "missing-merge: failure reason cites phase-monitor-merge.json" ;;
   *) fail "missing-merge: failure reason" "expected reason to mention phase-monitor-merge.json, got: $MISS_REASON" ;;
+esac
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 5: phase-monitor-merge.json present but .pr.mergeCommitSha empty →
+#         skill falls back to `gh api repos/.../pulls/<n>` and proceeds.
+#
+# Args: case=fallback, sha-for-deploy-event=fallbeef, deploy=success,
+#       canary=success, timeout=5s, emit=yes,
+#       signal_sha=""  (empty in signal file — triggers fallback),
+#       write_pr=yes   (so fallback can read .pr.number from phase-pr.json),
+#       gh_sha=fallbeef (what the stubbed `gh api` returns).
+
+CASE_DIR5="$(run_case fallback fallbeef success success 5 yes "" yes fallbeef)"
+
+EXIT5="$(cat "$CASE_DIR5/exit-code")"
+assert_eq "fallback: exit code 0" 0 "$EXIT5"
+
+if [ -f "$CASE_DIR5/worker/phase-monitor-deploy.json" ]; then
+  DSHA5="$(jq -r '.deploy_sha' "$CASE_DIR5/worker/phase-monitor-deploy.json")"
+  assert_eq "fallback: deploy_sha came from gh REST fallback" \
+    "fallbeef" "$DSHA5"
+fi
+
+CMPL5="$(jq -r '.attributes."event.name"' "$CASE_DIR5/events.jsonl" \
+         | tail -1)"
+assert_eq "fallback: emitted complete event after fallback" \
+  "phase.monitor-deploy.complete.CTL-9999" "$CMPL5"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 6: signal empty AND gh fallback also returns empty → still fails clean.
+#
+# write_pr=yes so the fallback gets a PR number; gh_sha="" stubs gh to return
+# {merge_commit_sha: ""} so the fallback resolves to empty too.
+
+CASE_DIR6="$(run_case fallback-fail "" success success 1 no "" yes "")"
+
+EXIT6="$(cat "$CASE_DIR6/exit-code")"
+if [ "$EXIT6" -ne 0 ]; then
+  ok "fallback-fail: exits non-zero when both signal and gh return empty"
+else
+  fail "fallback-fail: exit code" "expected non-zero, got $EXIT6"
+fi
+
+REASON6="$(jq -r '.body.message // empty' \
+          "$CASE_DIR6/events.jsonl" 2>/dev/null | tail -1)"
+case "$REASON6" in
+  *gh*|*REST*|*fallback*|*empty*) ok "fallback-fail: failure reason mentions fallback path" ;;
+  *) fail "fallback-fail: reason" "expected reason to mention gh/REST/fallback/empty, got: $REASON6" ;;
 esac
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -35,6 +35,12 @@ Environment:
   a stub that emits a fixture canary result.
 - `CATALYST_ORCHESTRATOR_ID`, `CATALYST_SESSION_ID` — used for event trace/span id derivation.
 
+`gh` CLI on `$PATH`, authenticated against the GitHub repo, is required only
+when `phase-monitor-merge.json` exists but `.pr.mergeCommitSha` is empty (the
+REST fallback path). In the common case (where `phase-monitor-merge` recorded
+the SHA successfully), `gh` is not invoked. The fallback also reads PR number
+from `phase-pr.json`.
+
 ## phase-monitor-merge.json contract (input shape)
 
 ```json
@@ -89,9 +95,30 @@ fi
 
 MERGE_SHA="$(jq -r '.pr.mergeCommitSha // empty' "$MERGE_FILE" 2>/dev/null)"
 if [[ -z "$MERGE_SHA" ]]; then
-  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
-    --reason "phase-monitor-merge.json has empty .pr.mergeCommitSha"
-  exit 1
+  # Fall back to gh REST. Mirrors orchestrate-verify.sh:131-156. PR number
+  # comes from phase-pr.json (phase-monitor-merge.json does not record it).
+  PR_FILE="$WORKER_DIR/phase-pr.json"
+  PR_NUMBER=""
+  if [[ -f "$PR_FILE" ]]; then
+    PR_NUMBER="$(jq -r '.pr.number // empty' "$PR_FILE" 2>/dev/null)"
+  fi
+  if [[ -z "$PR_NUMBER" ]]; then
+    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+      --reason "phase-monitor-merge.json has empty .pr.mergeCommitSha and no PR number available for gh REST fallback"
+    exit 1
+  fi
+  REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")"
+  if [[ -z "$REPO" ]]; then
+    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+      --reason "phase-monitor-merge.json has empty .pr.mergeCommitSha and gh repo view returned empty"
+    exit 1
+  fi
+  MERGE_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merge_commit_sha // empty' 2>/dev/null || echo "")"
+  if [[ -z "$MERGE_SHA" ]]; then
+    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+      --reason "phase-monitor-merge.json has empty .pr.mergeCommitSha and gh REST fallback also returned empty for pr#${PR_NUMBER}"
+    exit 1
+  fi
 fi
 
 # 2. Subscribe to deployment_status events for this SHA. The filter accepts any

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phase-monitor-deploy
-description: Phase agent that watches the post-merge deployment for a ticket. Reads the merge SHA from phase-pr.json, subscribes via `catalyst-events wait-for` to deploy events on that SHA, then delegates a live verification check to the /canary skill (gstack). Emits phase.monitor-deploy.complete.<TICKET> on canary success, phase.monitor-deploy.failed.<TICKET> on deploy or canary failure, and phase.monitor-deploy.skipped.<TICKET> when no deploy event arrives before the timeout. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-monitor-deploy ..."` resolves.
+description: Phase agent that watches the post-merge deployment for a ticket. Reads the merge SHA from phase-monitor-merge.json (the signal file phase-monitor-merge writes after `gh pr merge` confirms via REST), subscribes via `catalyst-events wait-for` to deploy events on that SHA, then delegates a live verification check to the /canary skill (gstack). Emits phase.monitor-deploy.complete.<TICKET> on canary success, phase.monitor-deploy.failed.<TICKET> on deploy or canary failure, and phase.monitor-deploy.skipped.<TICKET> when no deploy event arrives before the timeout. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-monitor-deploy ..."` resolves.
 user-invocable: true
 disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools: Bash, Read, Write
@@ -22,9 +22,9 @@ the live URL).
 
 Environment:
 - `TICKET` — Linear identifier (e.g. `CTL-451`). Required.
-- `WORKER_DIR` — directory containing `phase-pr.json` (read) and where
-  `phase-monitor-deploy.json` (write) lands. Defaults to
-  `${ORCH_DIR}/workers/${TICKET}` if set, else `$(pwd)`.
+- `WORKER_DIR` — directory containing `phase-monitor-merge.json` (read,
+  primary input) and where `phase-monitor-deploy.json` (write) lands. Defaults
+  to `${ORCH_DIR}/workers/${TICKET}` if set, else `$(pwd)`.
 - `PHASE_DEPLOY_TIMEOUT_SEC` — seconds to wait for a `deployment_status` event matching
   the merge SHA. Default `1800` (30 minutes). Setting to a small value is the
   documented way to skip deploy verification in test/dev environments.
@@ -35,19 +35,22 @@ Environment:
   a stub that emits a fixture canary result.
 - `CATALYST_ORCHESTRATOR_ID`, `CATALYST_SESSION_ID` — used for event trace/span id derivation.
 
-## phase-pr.json contract (input shape)
+## phase-monitor-merge.json contract (input shape)
 
 ```json
 {
   "pr": {
-    "number": 1234,
-    "url": "https://github.com/org/repo/pull/1234",
+    "mergedAt": "2026-05-18T22:00:00Z",
+    "ciStatus": "merged",
     "mergeCommitSha": "abc123..."
   }
 }
 ```
 
 The skill reads `.pr.mergeCommitSha` only; everything else is informational.
+The file is written by [[phase-monitor-merge]] after `gh pr merge --squash`
+confirms via REST (`gh api repos/<owner>/<repo>/pulls/<num>` returns
+`.merged == true`).
 
 ## Body
 
@@ -76,18 +79,18 @@ DEPLOY_TIMEOUT="${PHASE_DEPLOY_TIMEOUT_SEC:-1800}"
 DEPLOY_ENV="${PHASE_DEPLOY_ENV:-production}"
 CANARY_CMD="${PHASE_CANARY_CMD:-claude --model haiku -p /canary --output-format json}"
 
-# 1. Read merge SHA from the prior phase artifact.
-PR_FILE="$WORKER_DIR/phase-pr.json"
-if [[ ! -f "$PR_FILE" ]]; then
+# 1. Read merge SHA from phase-monitor-merge.json (the prior phase artifact).
+MERGE_FILE="$WORKER_DIR/phase-monitor-merge.json"
+if [[ ! -f "$MERGE_FILE" ]]; then
   emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
-    --reason "phase-pr.json missing at $PR_FILE"
+    --reason "phase-monitor-merge.json missing at $MERGE_FILE"
   exit 1
 fi
 
-MERGE_SHA="$(jq -r '.pr.mergeCommitSha // empty' "$PR_FILE" 2>/dev/null)"
+MERGE_SHA="$(jq -r '.pr.mergeCommitSha // empty' "$MERGE_FILE" 2>/dev/null)"
 if [[ -z "$MERGE_SHA" ]]; then
   emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
-    --reason "phase-pr.json has empty .pr.mergeCommitSha"
+    --reason "phase-monitor-merge.json has empty .pr.mergeCommitSha"
   exit 1
 fi
 


### PR DESCRIPTION
# CTL-499: fix phase-monitor-deploy SHA resolution

## Summary

`phase-monitor-deploy` was reading the merge SHA from `phase-pr.json`, but that
file only carries the PR's head SHA (pre-squash) — it never had
`.pr.mergeCommitSha`. Every dispatch failed fast with `empty .pr.mergeCommitSha`
and the deploy phase never armed its `wait-for` subscription.

This PR points the skill at `phase-monitor-merge.json` instead — the signal file
`phase-monitor-merge` writes after `gh pr merge --squash` is confirmed via REST
— and adds a `gh api repos/:owner/:repo/pulls/:n --jq .merge_commit_sha`
fallback for the race where `phase-monitor-deploy` starts before
`phase-monitor-merge` has finished writing.

## Why

Without this fix, the 9-phase orchestrator pipeline never reaches deploy
verification — every ticket ends at the merge phase with no canary check, and
the orchestrator logs a misleading `failed` event for the deploy phase even
though the underlying deploy succeeded.

## Changes

### Phase 1 — primary input swap (`731b72b3`)

- `plugins/dev/skills/phase-monitor-deploy/SKILL.md` — input contract switched
  from `phase-pr.json` to `phase-monitor-merge.json`. Updated `WORKER_DIR`
  docstring, contract example, and the read block. Failure reason now cites
  the new file name.
- Test fixture in `phase-monitor-deploy-e2e.test.sh` writes
  `phase-monitor-merge.json` instead of `phase-pr.json`; Case 4 renamed
  `missing-pr` → `missing-merge` and asserts the failure reason cites the new
  file.

### Phase 2 — REST fallback for race (`2d9d36fb`)

- When `phase-monitor-merge.json` exists but `.pr.mergeCommitSha` is empty
  (race: deploy phase started before merge phase finished writing), the skill
  now falls back to `gh api repos/:owner/:repo/pulls/:n --jq .merge_commit_sha`.
  PR number is read from `phase-pr.json` (the only signal file that records
  it). Mirrors the pattern in `orchestrate-verify.sh:131-156`.
- Two new e2e test cases:
  - **Case 5 (`fallback`)** — empty signal, stubbed `gh` returns a SHA; skill
    proceeds and emits `complete`. Asserts `deploy_sha` was sourced from the
    fallback.
  - **Case 6 (`fallback-fail`)** — empty signal AND stubbed `gh` returns empty;
    skill fails cleanly with a reason mentioning the fallback path.
- `run_case` extended with three optional positional args (`signal_sha`,
  `write_pr`, `gh_sha`) to support exercising the fallback path
  deterministically without touching real GitHub.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh` — all 6 cases pass (happy path, deploy failed, canary failed, skipped, missing-merge, fallback, fallback-fail).
- [x] Failure reasons cite `phase-monitor-merge.json` (not the old `phase-pr.json`).
- [x] Fallback path only triggers when the signal file's SHA is empty; the happy path does not invoke `gh`.

## Verification gates (from verify phase)

- `regression_risk = 0`
- 0 critical / 0 informational findings from `/review`
- One LOW finding: informational manual-verification item in the plan doc

## Refs

- CTL-499
- Depends on CTL-491 (introduced `phase-monitor-merge.json` signal file)
