### PR TITLE
chore(meta): sharpen 3 skill descriptions for routing (salvaged from #309)

### DIFF
--- a/plugins/analytics/skills/segment-analysis/SKILL.md
+++ b/plugins/analytics/skills/segment-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: segment-analysis
-description: Analyze user segments and cohorts for targeted insights
+description: "Analyze user segments, cohorts, and customer groups using PostHog data. Creates retention tables, compares segment behavior, and generates group breakdowns. Use when the user asks about customer segmentation, cohort retention, user group comparison, churn analysis, or funnel analysis by segment."
 disable-model-invocation: false
 allowed-tools: Task, TodoWrite
 version: 1.0.0

--- a/plugins/debugging/skills/debug-production-error/SKILL.md
+++ b/plugins/debugging/skills/debug-production-error/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug-production-error
-description: Debug production errors using Sentry error tracking and analysis
+description: "Debug production errors using Sentry MCP tools. Searches issues, analyzes stack traces, identifies root causes, and suggests fixes. Use when the user mentions a Sentry error, production exception, stack trace, error monitoring, crash report, or unhandled exception."
 disable-model-invocation: false
 allowed-tools: Task, TodoWrite
 version: 1.0.0

--- a/plugins/pm/skills/prd-draft/SKILL.md
+++ b/plugins/pm/skills/prd-draft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-draft
-description: Create a modern, AI-era PRD for features and initiatives. Guides through clarifying questions, generates draft, and offers multi-agent review.
+description: "Create a PRD (product requirements document) for features and initiatives. Guides through clarifying questions, generates a structured draft with hypothesis, strategic fit, non-goals, success metrics, and rollout plan, then offers multi-agent review. Use when the user asks to create a PRD, product spec, feature spec, requirements doc, or product brief."
 disable-model-invocation: false
 user-invocable: true
 ---


### PR DESCRIPTION
## Summary

- Cherry-picks the load-bearing improvements from #309 (which is blocked by hard conflict and the author appears dormant)
- Sharpens descriptions for **3 skills** so Claude routes invocations more reliably:
  - `segment-analysis` — names PostHog + concrete outputs (retention tables, segment comparisons)
  - `debug-production-error` — names Sentry MCP tools + trigger phrases (stack trace, crash report, etc.)
  - `prd-draft` — describes the actual PRD shape (hypothesis, strategic fit, success metrics) instead of "modern AI-era PRD"
- Skips the conflicted `disable-model-invocation` flag flip from #309 (already landed in #312)
- Skips two other files (`code-first-draft`, `validate-frontmatter`) whose new descriptions were lower-value

## Why not just rebase #309

PR #309 has hard conflicts with #312 (disable-model-invocation flip) and is mostly ~270 lines of doc-cleanup deletions. The description rewrites are the only substantive improvement; cherry-picking them is faster than rebasing the conflicted branch.

## Test plan

- [ ] CI is green
- [ ] Spot-check: `claude` correctly invokes `prd-draft` on "draft a product spec"
- [ ] Spot-check: `claude` correctly invokes `debug-production-error` on "investigate this Sentry issue"

Closes #309 (in spirit — separate close with credit message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)