### PR TITLE
CTL-360: broker reads canonical envelope payload in agent checkin/checkout

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -657,7 +657,9 @@ export function handleOrchestratorTerminated(event) {
 
 // Handle agent.checkin: store identity and auto-derive pr_lifecycle if claimed_pr is set.
 export function handleAgentCheckin(event) {
-  const d = event.detail ?? {};
+  // CTL-360: read the payload shape-agnostically — getEventPayload accepts both
+  // the legacy flat { detail } shape and the canonical { body.payload } envelope.
+  const d = getEventPayload(event);
   const sessionId = d.session_id;
   if (!sessionId) return;
 
@@ -723,7 +725,8 @@ function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket, rep
 }
 
 export function handleAgentCheckout(event) {
-  const d = event.detail ?? {};
+  // CTL-360: read the payload shape-agnostically (see handleAgentCheckin).
+  const d = getEventPayload(event);
   const sessionId = d.session_id;
   if (!sessionId) return;
 

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -3678,3 +3678,109 @@ describe("CTL-419 watchdog batching", () => {
     expect(readWakeEvents("filter.wake.orch-notified")).toHaveLength(1);
   });
 });
+
+// ─── CTL-360 agent.checkin / agent.checkout canonical envelopes ──────────────
+//
+// handleAgentCheckin/handleAgentCheckout must read the payload shape-agnostically
+// via getEventPayload — accepting both the legacy flat { event, detail } shape
+// and the canonical OTel { attributes, body.payload } envelope.
+
+describe("CTL-360 agent.checkin/checkout canonical envelopes", () => {
+  test("handleAgentCheckin stores agent identity from canonical envelope", () => {
+    handleAgentCheckin({
+      attributes: { "event.name": "agent.checkin" },
+      body: {
+        payload: {
+          session_id: "sess-canon-ci",
+          agent_name: "ctl-360-worker",
+          ticket: "CTL-360",
+          orchestrator: "orch-canon",
+          claimed_pr: null,
+          cwd: "/work",
+        },
+      },
+    });
+    const agent = getAgentBySession("sess-canon-ci");
+    expect(agent).not.toBeNull();
+    expect(agent.agentName).toBe("ctl-360-worker");
+    expect(agent.ticket).toBe("CTL-360");
+    expect(agent.status).toBe("active");
+  });
+
+  test("handleAgentCheckin updates heartbeat map from canonical envelope", () => {
+    handleAgentCheckin({
+      attributes: { "event.name": "agent.checkin" },
+      body: {
+        payload: { session_id: "sess-canon-hb", agent_name: "worker", ticket: null, claimed_pr: null },
+      },
+    });
+    expect(getLastHeartbeat().has("sess-canon-hb")).toBe(true);
+  });
+
+  test("handleAgentCheckin auto-registers pr_lifecycle from canonical envelope", () => {
+    handleAgentCheckin({
+      attributes: { "event.name": "agent.checkin" },
+      body: {
+        payload: {
+          session_id: "sess-canon-pr",
+          agent_name: "worker",
+          ticket: "CTL-360",
+          orchestrator: "orch-canon",
+          claimed_pr: 808,
+        },
+      },
+    });
+    const reg = getInterests().get("sess-canon-pr");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("pr_lifecycle");
+    expect(reg.pr_numbers).toEqual([808]);
+    expect(reg.notify_event).toBe("filter.wake.sess-canon-pr");
+  });
+
+  test("handleAgentCheckin legacy flat envelope still works (backward compat)", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-legacy-ci", agent_name: "worker", ticket: "CTL-360", claimed_pr: null },
+    });
+    const agent = getAgentBySession("sess-legacy-ci");
+    expect(agent).not.toBeNull();
+    expect(agent.agentName).toBe("worker");
+  });
+
+  test("handleAgentCheckout marks agent done from canonical envelope", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-canon-co", agent_name: "worker", claimed_pr: null },
+    });
+    handleAgentCheckout({
+      attributes: { "event.name": "agent.checkout" },
+      body: { payload: { session_id: "sess-canon-co", status: "done" } },
+    });
+    expect(getAgentBySession("sess-canon-co")).toBeNull();
+  });
+
+  test("handleAgentCheckout removes auto-correlated pr_lifecycle from canonical envelope", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-canon-clean", agent_name: "worker", claimed_pr: 501 },
+    });
+    expect(getInterests().has("sess-canon-clean")).toBe(true);
+    handleAgentCheckout({
+      attributes: { "event.name": "agent.checkout" },
+      body: { payload: { session_id: "sess-canon-clean", status: "done" } },
+    });
+    expect(getInterests().has("sess-canon-clean")).toBe(false);
+  });
+
+  test("handleAgentCheckout legacy flat envelope still works (backward compat)", () => {
+    handleAgentCheckin({
+      event: "agent.checkin",
+      detail: { session_id: "sess-legacy-co", agent_name: "worker", claimed_pr: null },
+    });
+    handleAgentCheckout({
+      event: "agent.checkout",
+      detail: { session_id: "sess-legacy-co", status: "done" },
+    });
+    expect(getAgentBySession("sess-legacy-co")).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-20T22:15:00Z -->
<!-- Last updated: 2026-05-20T22:15:00Z -->
<!-- PR: #898 -->
<!-- Previous commits: aabb389eda3a48e477713f6af744a42284ccd68f -->

## Summary

The broker's `handleAgentCheckin` and `handleAgentCheckout` handlers read their
payload via `event.detail ?? {}`, which only understands the legacy flat event
shape. Dispatch in `processEvent` already routes canonical OTel envelopes
(`{ attributes, body.payload }`) to these handlers via `getEventName(event)`, but
the handlers themselves then failed to find the payload — `d` resolved to `{}`,
`session_id` to `undefined`, and the handler returned early. The result: agents
that check in with a canonical envelope were never registered.

This PR replaces `event.detail ?? {}` with `getEventPayload(event)` in both
handlers, which reads the payload shape-agnostically — accepting both the legacy
flat shape and the canonical envelope. This mirrors the existing CTL-336 /
CTL-357 / CTL-359 fixes for `handleRegister`, `handleDeregister`, and
`tryDeterministicRoute`.

## Changes Made

### Broker (`plugins/dev/scripts/broker/index.mjs`)

- `handleAgentCheckin`: read payload via `getEventPayload(event)` instead of
  `event.detail ?? {}`.
- `handleAgentCheckout`: same shape-agnostic read.

### Tests (`plugins/dev/scripts/broker/index.test.mjs`)

- New `CTL-360 agent.checkin/checkout canonical envelopes` describe block (7 tests):
  - `handleAgentCheckin` stores agent identity from a canonical envelope.
  - `handleAgentCheckin` updates the heartbeat map from a canonical envelope.
  - `handleAgentCheckin` auto-registers `pr_lifecycle` from a canonical envelope.
  - `handleAgentCheckin` legacy flat envelope still works (backward compat).
  - `handleAgentCheckout` marks an agent done from a canonical envelope.
  - `handleAgentCheckout` removes the auto-correlated `pr_lifecycle` from a
    canonical envelope.
  - `handleAgentCheckout` legacy flat envelope still works (backward compat).

## How to Verify It

- [x] Broker test suite passes: `bun test plugins/dev/scripts/broker/index.test.mjs` — 181 pass, 0 fail
- [x] New canonical-envelope tests cover both checkin and checkout paths
- [x] Legacy flat-envelope tests confirm backward compatibility

## Related Issues/PRs

- Fixes CTL-360
- Related to CTL-359 (matching fix for `tryDeterministicRoute`)
- Mirrors the CTL-336 / CTL-357 canonical-envelope pattern

Refs: CTL-360
