### PR TITLE
CTL-381: Fix canonical webhook routing for auto-correlated PR-lifecycle interests

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-state.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-state.test.sh
@@ -365,6 +365,50 @@ else
 fi
 unset REPO
 
+# ─── Test 17: event_append keeps agent.checkin's bare name (CTL-381) ─────────
+# The orchestrator.* wildcard in __orch_canonical_for must NOT rename
+# agent.checkin — the broker dispatches on the exact name "agent.checkin".
+echo ""
+echo "--- Test 17: event_append keeps agent.checkin's bare name ---"
+export CATALYST_DIR="$SCRATCH/cat17"
+"$STATE_SCRIPT" init >/dev/null
+
+"$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-20T12:00:00Z",
+  event: "agent.checkin",
+  detail: { session_id: "sess-ctl381", claimed_pr: 627, repo: "coalesce-labs/catalyst" }
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE17=$(ls "$SCRATCH/cat17/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE17" ]]; then
+  NAME=$(jq -r '.attributes."event.name"' "$EVENT_FILE17" | head -1)
+  assert_eq "agent.checkin" "$NAME" "agent.checkin keeps its bare canonical name"
+else
+  fail "no event JSONL written for agent.checkin test"
+fi
+
+# ─── Test 18: event_append keeps agent.checkout's bare name (CTL-381) ────────
+# Same exemption for agent.checkout — the broker dispatches on the exact
+# name "agent.checkout".
+echo ""
+echo "--- Test 18: event_append keeps agent.checkout's bare name ---"
+export CATALYST_DIR="$SCRATCH/cat18"
+"$STATE_SCRIPT" init >/dev/null
+
+"$STATE_SCRIPT" event "$(jq -nc '{
+  ts: "2026-05-20T12:00:00Z",
+  event: "agent.checkout",
+  detail: { session_id: "sess-ctl381", status: "done" }
+}')" >/dev/null 2>&1 || true
+
+EVENT_FILE18=$(ls "$SCRATCH/cat18/events"/*.jsonl 2>/dev/null | head -1)
+if [[ -n "$EVENT_FILE18" ]]; then
+  NAME=$(jq -r '.attributes."event.name"' "$EVENT_FILE18" | head -1)
+  assert_eq "agent.checkout" "$NAME" "agent.checkout keeps its bare canonical name"
+else
+  fail "no event JSONL written for agent.checkout test"
+fi
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "══════════════════════════════════════════════"

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -699,15 +699,26 @@ export function handleAgentCheckin(event) {
 
   // Auto-correlate: if the agent has already claimed a PR, register a
   // pr_lifecycle interest on its behalf — no explicit filter.register needed.
+  // CTL-381: thread d.base_branches through so github.push rebase detection
+  // works for the auto-registered interest.
   if (claimedPr) {
-    _autoRegisterPrLifecycle(sessionId, claimedPr, orchestrator, ticket, repo);
+    _autoRegisterPrLifecycle(
+      sessionId,
+      claimedPr,
+      orchestrator,
+      ticket,
+      repo,
+      d.base_branches
+    );
   }
 
   log.info({ agentName, sessionId, ticket, claimedPr }, "agent checked in");
 }
 
 // Auto-register a pr_lifecycle interest when we learn agent ↔ PR mapping.
-function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket, repo) {
+// CTL-381: baseBranches is the base_branches array broker_claim_pr sends —
+// preserve it so the github.push rebase-detection branch can match.
+function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket, repo, baseBranches) {
   if (interests.has(sessionId)) return; // don't overwrite explicit registration
 
   interests.set(sessionId, {
@@ -720,7 +731,7 @@ function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket, rep
     interest_type: "pr_lifecycle",
     pr_numbers: [prNumber],
     repo: repo ?? null,
-    base_branches: [],
+    base_branches: Array.isArray(baseBranches) ? baseBranches : [],
     tickets: null,
     wake_on: null,
   });

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -1720,11 +1720,14 @@ export function processEvent(event) {
   }
 
   // CTL-303: structured agent identity events.
-  if (name === "agent.checkin") {
+  // CTL-381: also accept the orchestrator.-prefixed name that pre-fix
+  // catalyst-state.sh wrote, so check-in events replayed on broker restart
+  // during the rollout window still route to the right handler.
+  if (name === "agent.checkin" || name === "orchestrator.agent.checkin") {
     handleAgentCheckin(event);
     return;
   }
-  if (name === "agent.checkout") {
+  if (name === "agent.checkout" || name === "orchestrator.agent.checkout") {
     handleAgentCheckout(event);
     return;
   }
@@ -1937,8 +1940,11 @@ function loadExistingRegistrations() {
       const name = getEventName(event);
       if (name === "filter.register") handleRegister(event);
       if (name === "filter.deregister") handleDeregister(event);
-      if (name === "agent.checkin") handleAgentCheckin(event);
-      if (name === "agent.checkout") handleAgentCheckout(event);
+      // CTL-381: accept the legacy orchestrator.-prefixed alias on replay too.
+      if (name === "agent.checkin" || name === "orchestrator.agent.checkin")
+        handleAgentCheckin(event);
+      if (name === "agent.checkout" || name === "orchestrator.agent.checkout")
+        handleAgentCheckout(event);
       if (name === "orchestrator-completed" || name === "orchestrator-failed") {
         handleOrchestratorTerminated(event);
       }

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -508,6 +508,20 @@ function getEventOrchestrator(event) {
   return event.orchestrator ?? event.attributes?.["catalyst.orchestrator.id"] ?? null;
 }
 
+// CTL-381: canonical OTel webhook envelopes carry no top-level `scope`.
+// Resolve PR/ref/sha/environment from `event.scope` (legacy) OR `attributes`
+// (canonical), mirroring how getEventPayload bridges detail / body.payload.
+function getEventScope(event) {
+  const scope = event.scope ?? {};
+  const attrs = event.attributes ?? {};
+  return {
+    pr: scope.pr ?? attrs["vcs.pr.number"] ?? undefined,
+    ref: scope.ref ?? attrs["vcs.ref.name"] ?? undefined,
+    sha: scope.sha ?? attrs["vcs.revision"] ?? undefined,
+    environment: scope.environment ?? attrs["deployment.environment"] ?? undefined,
+  };
+}
+
 export function handleRegister(event) {
   const d = getEventPayload(event);
   const orchestrator = getEventOrchestrator(event);
@@ -916,7 +930,10 @@ export function tryDeterministicRoute(event, interestsMap) {
   // matching gap in tryTicketLifecycleRoute; this catches the PR/comms route.
   const name = getEventName(event);
   const detail = getEventPayload(event);
-  const scope = event.scope ?? {};
+  // CTL-381: canonical-aware — resolves PR/ref/sha/environment from
+  // `attributes` on true-canonical OTel envelopes that carry no top-level
+  // `scope`, while still reading legacy `event.scope` when present.
+  const scope = getEventScope(event);
   // CTL-344: real id on new envelopes, synthetic id for legacy events.
   const eventId = event.id ?? synthesizeEventId(event);
 

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -3977,3 +3977,103 @@ describe("CTL-381 tryDeterministicRoute — true canonical envelopes (no scope)"
     expect(matches[0].reason).toContain("merged");
   });
 });
+
+// ─── CTL-381 base_branches preserved on auto-registration ────────────────────
+//
+// _autoRegisterPrLifecycle hardcoded base_branches: [], discarding the
+// base_branches array broker_claim_pr sends — so the github.push rebase
+// detection branch could never match an auto-correlated interest.
+
+describe("CTL-381 base_branches preserved on auto-registration", () => {
+  test("handleAgentCheckin carries base_branches into the auto-registered interest", () => {
+    handleAgentCheckin({
+      attributes: { "event.name": "agent.checkin" },
+      body: {
+        payload: {
+          session_id: "sess-bb",
+          claimed_pr: 808,
+          base_branches: [{ pr: 808, base: "main" }],
+        },
+      },
+    });
+    expect(getInterests().get("sess-bb").base_branches).toEqual([{ pr: 808, base: "main" }]);
+  });
+
+  test("handleAgentCheckin defaults base_branches to [] when absent", () => {
+    handleAgentCheckin({
+      attributes: { "event.name": "agent.checkin" },
+      body: { payload: { session_id: "sess-bb-none", claimed_pr: 809 } },
+    });
+    expect(getInterests().get("sess-bb-none").base_branches).toEqual([]);
+  });
+});
+
+// ─── CTL-381 end-to-end: check-in → canonical webhook → filter.wake ──────────
+//
+// The capstone test that proves all three layers compose: an agent.checkin
+// auto-registers a pr_lifecycle interest carrying base_branches, then
+// canonical webhook events (no top-level scope) each emit a filter.wake to
+// the JSONL event log — the chain the CTL-381 failing run never completed.
+
+describe("CTL-381 end-to-end: check-in → canonical webhook → filter.wake", () => {
+  function countWakesInLog(notifyEvent) {
+    const ym = new Date().toISOString().slice(0, 7);
+    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    if (!existsSync(logPath)) return 0;
+    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+    return lines.filter((l) => {
+      try {
+        const evt = JSON.parse(l);
+        return evt.attributes?.["event.name"] === notifyEvent;
+      } catch {
+        return false;
+      }
+    }).length;
+  }
+
+  test("agent.checkin then canonical check_suite/pr.merged/push each emit filter.wake", () => {
+    // Layer 1: broker_claim_pr-style check-in auto-registers a pr_lifecycle
+    // interest carrying base_branches.
+    processEvent({
+      attributes: { "event.name": "agent.checkin" },
+      body: {
+        payload: {
+          session_id: "sess-e2e",
+          claimed_pr: 900,
+          base_branches: [{ pr: 900, base: "main" }],
+        },
+      },
+    });
+    const reg = getInterests().get("sess-e2e");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("pr_lifecycle");
+    expect(reg.base_branches).toEqual([{ pr: 900, base: "main" }]);
+
+    // Layer 2 + 3: each true-canonical webhook event (no top-level scope)
+    // routes and appends a filter.wake.sess-e2e to the log.
+
+    // canonical check_suite.completed → reads body.payload.prNumbers
+    processEvent({
+      id: "e2e-cs-1",
+      attributes: { "event.name": "github.check_suite.completed" },
+      body: { payload: { prNumbers: [900], conclusion: "success" } },
+    });
+    expect(countWakesInLog("filter.wake.sess-e2e")).toBe(1);
+
+    // canonical github.pr.merged → reads attributes["vcs.pr.number"]
+    processEvent({
+      id: "e2e-merged-1",
+      attributes: { "event.name": "github.pr.merged", "vcs.pr.number": 900 },
+      body: { payload: { mergeCommitSha: "abc1234", merged: true } },
+    });
+    expect(countWakesInLog("filter.wake.sess-e2e")).toBe(2);
+
+    // canonical github.push to base branch → reads attributes["vcs.ref.name"]
+    processEvent({
+      id: "e2e-push-1",
+      attributes: { "event.name": "github.push", "vcs.ref.name": "main" },
+      body: { payload: {} },
+    });
+    expect(countWakesInLog("filter.wake.sess-e2e")).toBe(3);
+  });
+});

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -3784,3 +3784,43 @@ describe("CTL-360 agent.checkin/checkout canonical envelopes", () => {
     expect(getAgentBySession("sess-legacy-co")).toBeNull();
   });
 });
+
+// ─── CTL-381 broker routes orchestrator.-prefixed agent check-ins ────────────
+//
+// Pre-fix catalyst-state.sh renamed agent.checkin/checkout to
+// orchestrator.agent.checkin/checkout via its wildcard canonicalizer. Events
+// already written to the log (replayed on broker restart during the rollout
+// window) must still route to handleAgentCheckin/handleAgentCheckout.
+
+describe("CTL-381 broker routes orchestrator.-prefixed agent check-ins", () => {
+  test("processEvent routes orchestrator.agent.checkin to handleAgentCheckin", () => {
+    processEvent({
+      attributes: { "event.name": "orchestrator.agent.checkin" },
+      body: { payload: { session_id: "sess-ctl381-a", claimed_pr: 627, ticket: "CTL-381" } },
+    });
+    const reg = getInterests().get("sess-ctl381-a");
+    expect(reg).toBeDefined();
+    expect(reg.interest_type).toBe("pr_lifecycle");
+    expect(reg.pr_numbers).toEqual([627]);
+  });
+
+  test("processEvent still routes bare agent.checkin (regression)", () => {
+    processEvent({
+      attributes: { "event.name": "agent.checkin" },
+      body: { payload: { session_id: "sess-ctl381-b", claimed_pr: 628 } },
+    });
+    expect(getInterests().has("sess-ctl381-b")).toBe(true);
+  });
+
+  test("processEvent routes orchestrator.agent.checkout to handleAgentCheckout", () => {
+    processEvent({
+      attributes: { "event.name": "agent.checkin" },
+      body: { payload: { session_id: "sess-ctl381-c", claimed_pr: 629 } },
+    });
+    processEvent({
+      attributes: { "event.name": "orchestrator.agent.checkout" },
+      body: { payload: { session_id: "sess-ctl381-c", status: "done" } },
+    });
+    expect(getInterests().has("sess-ctl381-c")).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -3824,3 +3824,156 @@ describe("CTL-381 broker routes orchestrator.-prefixed agent check-ins", () => {
     expect(getInterests().has("sess-ctl381-c")).toBe(false);
   });
 });
+
+// ─── CTL-381 tryDeterministicRoute — true canonical envelopes (no scope) ─────
+//
+// The canonical OTel webhook envelope carries no top-level `scope`. The PR
+// number lives at attributes["vcs.pr.number"], the ref at
+// attributes["vcs.ref.name"], the sha at attributes["vcs.revision"], and the
+// environment at attributes["deployment.environment"]. tryDeterministicRoute
+// must resolve those via getEventScope so canonical events route correctly.
+
+describe("CTL-381 tryDeterministicRoute — true canonical envelopes (no scope)", () => {
+  beforeEach(() => {
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-canon-pr",
+      detail: {
+        interest_id: "sess-canon-pr",
+        notify_event: "filter.wake.sess-canon-pr",
+        interest_type: "pr_lifecycle",
+        pr_numbers: [777],
+        repo: "org/repo",
+        base_branches: [{ pr: 777, base: "main" }],
+        persistent: true,
+        session_id: "sess-canon-pr",
+      },
+    });
+  });
+
+  test("github.pr.merged routes via attributes['vcs.pr.number']", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: { "event.name": "github.pr.merged", "vcs.pr.number": 777 },
+        body: { payload: { mergeCommitSha: "deadbeef", merged: true } },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].interestId).toBe("sess-canon-pr");
+    expect(matches[0].reason).toContain("merged");
+  });
+
+  test("github.pr.closed routes via attributes['vcs.pr.number']", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: { "event.name": "github.pr.closed", "vcs.pr.number": 777 },
+        body: { payload: { merged: false } },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("closed without merging");
+  });
+
+  test("github.pr_review.submitted routes via attributes['vcs.pr.number']", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: { "event.name": "github.pr_review.submitted", "vcs.pr.number": 777 },
+        body: {
+          payload: {
+            reviewer: "alice",
+            state: "changes_requested",
+            author: { login: "alice", type: "User" },
+          },
+        },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("Changes requested");
+    expect(matches[0].reason).toContain("blocked from merging");
+  });
+
+  test("github.pr_review_comment.created routes via attributes['vcs.pr.number']", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: {
+          "event.name": "github.pr_review_comment.created",
+          "vcs.pr.number": 777,
+        },
+        body: {
+          payload: {
+            author: { login: "bob", type: "User" },
+            commentId: 12345,
+            body: "please fix this",
+            htmlUrl: "https://github.com/org/repo/pull/777#discussion_r12345",
+          },
+        },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("bob");
+    expect(matches[0].reason).toContain("12345");
+  });
+
+  test("github.pr_review_thread.resolved routes via attributes['vcs.pr.number']", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: {
+          "event.name": "github.pr_review_thread.resolved",
+          "vcs.pr.number": 777,
+        },
+        body: { payload: { threadId: "thread-9" } },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("resolved");
+    expect(matches[0].reason).toContain("777");
+  });
+
+  test("github.push routes via attributes['vcs.ref.name']", () => {
+    const matches = tryDeterministicRoute(
+      {
+        attributes: { "event.name": "github.push", "vcs.ref.name": "main" },
+        body: { payload: {} },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("Base branch main updated");
+  });
+
+  test("github.deployment.created routes via attributes vcs.revision/environment", () => {
+    // deployment matching relies on filter-state DB rows; assert the event
+    // resolves sha + environment from attributes without throwing and produces
+    // a deterministic (possibly empty) match list.
+    const matches = tryDeterministicRoute(
+      {
+        attributes: {
+          "event.name": "github.deployment.created",
+          "vcs.revision": "deadbeef",
+          "deployment.environment": "production",
+        },
+        body: { payload: { deploymentId: "deploy-1" } },
+      },
+      getInterests()
+    );
+    expect(Array.isArray(matches)).toBe(true);
+  });
+
+  test("legacy scope.pr still routes (backward compat)", () => {
+    const matches = tryDeterministicRoute(
+      {
+        event: "github.pr.merged",
+        scope: { pr: 777 },
+        detail: { mergeCommitSha: "feedface", merged: true },
+      },
+      getInterests()
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].reason).toContain("merged");
+  });
+});

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -166,6 +166,12 @@ __orch_canonical_for() {
     filter.register)         echo "filter.register filter register INFO" ;;
     filter.deregister)       echo "filter.deregister filter deregister INFO" ;;
     filter.wake)             echo "filter.wake filter wake INFO" ;;
+    # Agent identity events (CTL-381): keep the bare name — the broker
+    # dispatches on an exact `agent.checkin` / `agent.checkout` match.
+    # The wildcard fallthrough would rename them orchestrator.agent.*,
+    # which processEvent never routes to handleAgentCheckin.
+    agent.checkin)           echo "agent.checkin agent checkin INFO" ;;
+    agent.checkout)          echo "agent.checkout agent checkout INFO" ;;
     *)                       echo "orchestrator.$1 orchestrator $1 INFO" ;;
   esac
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-20T23:02:58Z -->
<!-- Last updated: 2026-05-20T23:02:58Z -->
<!-- PR: #902 -->
<!-- Previous commits: e152e232fc0f4f11a584eac9a75375f86472c570,f4d075a0db566fe2b8dbc21084f64f40da478d3d,9faf82026d2feedce47f33b2d6afc23fb6a7a02e -->

## Summary

Fixes three broker routing defects that broke the canonical OTel webhook event path for
auto-correlated PR-lifecycle interests. Together they restore the chain an agent check-in
relies on: check-in → auto-registered interest → canonical webhook event → `filter.wake`.

Building on CTL-360 (broker reads canonical envelope payload in agent checkin/checkout),
this PR closes the remaining gaps where canonical envelopes were either misrouted or
silently dropped.

## Changes Made

### Phase 1 — Route agent check-ins to `handleAgentCheckin`

Pre-fix `catalyst-state.sh` renamed `agent.checkin` / `agent.checkout` to
`orchestrator.agent.checkin` / `orchestrator.agent.checkout` via its `orchestrator.*`
wildcard canonicalizer. Events already written to the log and replayed on broker restart
during the rollout window failed to route.

- `processEvent` and `loadExistingRegistrations` now accept both the bare names and the
  legacy `orchestrator.`-prefixed aliases, routing both to
  `handleAgentCheckin` / `handleAgentCheckout`.
- `catalyst-state.sh` exempts `agent.checkin` / `agent.checkout` from the wildcard
  rename so newly written events keep their bare canonical name (the name the broker
  dispatches on).

### Phase 2 — Canonical-aware scope reads in `tryDeterministicRoute`

True-canonical OTel webhook envelopes carry no top-level `scope` object — PR number,
ref, sha, and environment live under `attributes`.

- New `getEventScope(event)` helper resolves `pr` / `ref` / `sha` / `environment` from
  `event.scope` (legacy) **or** `attributes` (`vcs.pr.number`, `vcs.ref.name`,
  `vcs.revision`, `deployment.environment`), mirroring how `getEventPayload` bridges
  `detail` / `body.payload`.
- `tryDeterministicRoute` uses `getEventScope` so canonical `github.pr.*`,
  `github.push`, and `github.deployment.*` events route correctly. Legacy `scope.pr`
  events still route unchanged.

### Phase 3 — Preserve `base_branches` on auto-registered interests

`_autoRegisterPrLifecycle` hardcoded `base_branches: []`, discarding the
`base_branches` array `broker_claim_pr` sends — so the `github.push` rebase-detection
branch could never match an auto-correlated interest.

- `handleAgentCheckin` threads `d.base_branches` through to `_autoRegisterPrLifecycle`.
- `_autoRegisterPrLifecycle` stores the array (defaulting to `[]` when absent or
  non-array).

## How to Verify It

- [x] Broker unit tests pass: `bun test plugins/dev/scripts/broker/index.test.mjs` ✅
- [x] `catalyst-state.sh` shell tests pass:
  `plugins/dev/scripts/__tests__/catalyst-state.test.sh` ✅
- [x] `validate` CI check passes ✅
- [x] `check-versions` CI check passes ✅

## Test Coverage

- `broker/index.test.mjs` — 4 new describe blocks (~293 lines): orchestrator-prefixed
  check-in routing, canonical-envelope `tryDeterministicRoute` (8 event types + legacy
  back-compat), `base_branches` preservation, and an end-to-end capstone proving
  check-in → canonical webhook → `filter.wake` composes.
- `catalyst-state.test.sh` — Tests 17 & 18 assert `agent.checkin` / `agent.checkout`
  keep their bare canonical names through `event_append`.

## Related Issues/PRs

- Fixes CTL-381
- Builds on CTL-360 (#898)

Refs: CTL-381
