### PR TITLE
CTL-507: Gate orchestrator.status replay during broker startup recovery

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -115,6 +115,14 @@ const MAX_BATCH_SIZE = parseInt(process.env.FILTER_BATCH_SIZE ?? "20", 10);
 const LOOKBACK_LINES = 1000;
 const WATCHDOG_INTERVAL_MS = parseInt(process.env.FILTER_WATCHDOG_INTERVAL_MS ?? "60000", 10);
 const HEARTBEAT_STALE_MS = parseInt(process.env.FILTER_HEARTBEAT_STALE_MS ?? "180000", 10);
+// CTL-507: replayed orchestrator.status events older than this are skipped on
+// startup so a crashed-without-terminate orchestrator is not resurrected into
+// activeOrchestrators. Generous default (6h) — far longer than the gap between
+// an orchestrator's phase-transition status emissions, so a live orchestrator is
+// never dropped; only prunes ancient entries on quiet systems where the
+// 1000-line replay window spans days.
+const ORCH_STATUS_REPLAY_STALE_MS = parseInt(
+  process.env.FILTER_ORCH_STATUS_REPLAY_STALE_MS ?? "21600000", 10);
 
 // --- Event log ---
 function getEventLogPath() {
@@ -884,6 +892,15 @@ export function handleOrchestratorStatus(event) {
 
   log.info({ orchId, phase: entry.phase, wave: entry.wave, activeWorkers: entry.activeWorkers }, "orchestrator status");
   persistBrokerState();
+}
+
+// CTL-507: replay-only freshness check. Live status events are always fresh;
+// this guards only loadExistingRegistrations(). Missing/unparseable ts → stale
+// (cannot verify age — conservative; matches pre-fix empty-state behavior).
+export function isOrchestratorStatusFresh(event, nowMs = Date.now()) {
+  const tsMs = Date.parse(event?.ts ?? "");
+  if (Number.isNaN(tsMs)) return false;
+  return nowMs - tsMs <= ORCH_STATUS_REPLAY_STALE_MS;
 }
 
 // --- Deterministic routing: pr_lifecycle (CTL-284) ---------------------------
@@ -1975,8 +1992,12 @@ export function loadExistingRegistrations(logPath = lastLogPath) {
         handleAgentCheckout(event);
       // CTL-507: replay orchestrator.status so activeOrchestrators survives a
       // broker restart. Chronological replay + the terminate block below mean a
-      // status followed by a completed/failed resolves to set-then-delete.
-      if (name === "orchestrator.status") handleOrchestratorStatus(event);
+      // status followed by a completed/failed resolves to set-then-delete. The
+      // freshness gate skips ancient status events so a long-dead orchestrator
+      // is not resurrected.
+      if (name === "orchestrator.status" && isOrchestratorStatusFresh(event)) {
+        handleOrchestratorStatus(event);
+      }
       if (name === "orchestrator-completed" || name === "orchestrator-failed") {
         handleOrchestratorTerminated(event);
       }

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -1954,9 +1954,9 @@ function startTailing() {
   });
 }
 
-function loadExistingRegistrations() {
+export function loadExistingRegistrations(logPath = lastLogPath) {
   try {
-    const content = readFileSync(lastLogPath, "utf8");
+    const content = readFileSync(logPath, "utf8");
     const lines = content.split("\n").filter((l) => l.trim());
     for (const line of lines.slice(-LOOKBACK_LINES)) {
       let event;
@@ -1973,6 +1973,10 @@ function loadExistingRegistrations() {
         handleAgentCheckin(event);
       if (name === "agent.checkout" || name === "orchestrator.agent.checkout")
         handleAgentCheckout(event);
+      // CTL-507: replay orchestrator.status so activeOrchestrators survives a
+      // broker restart. Chronological replay + the terminate block below mean a
+      // status followed by a completed/failed resolves to set-then-delete.
+      if (name === "orchestrator.status") handleOrchestratorStatus(event);
       if (name === "orchestrator-completed" || name === "orchestrator-failed") {
         handleOrchestratorTerminated(event);
       }

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -1001,6 +1001,65 @@ describe("watchdog treats orchestrator.status as liveness (CTL-405)", () => {
   });
 });
 
+// ─── CTL-507: loadExistingRegistrations replays orchestrator.status ───────────
+
+import { loadExistingRegistrations } from "./index.mjs";
+
+describe("loadExistingRegistrations replays orchestrator.status (CTL-507)", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ctl507-"));
+    clearOrchestratorStatusMap();
+    clearInterests();
+  });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  function writeLog(events) {
+    const path = join(tmpDir, "events.jsonl");
+    writeFileSync(path, events.map((e) => JSON.stringify(e)).join("\n") + "\n");
+    return path;
+  }
+
+  test("populates orchestratorStatusMap from a logged status event", () => {
+    const path = writeLog([
+      { event: "orchestrator.status", orchestrator: "orch-r1",
+        ts: new Date().toISOString(),
+        detail: { orchestrator: "orch-r1", phase: "monitoring", wave: 2,
+                  active_workers: 3, total_workers: 5, summary: "wave 2",
+                  session_id: "sess-r1" } },
+    ]);
+    loadExistingRegistrations(path);
+    const entry = getOrchestratorStatusMap().get("orch-r1");
+    expect(entry).toBeDefined();
+    expect(entry.phase).toBe("monitoring");
+    expect(entry.wave).toBe(2);
+  });
+
+  test("status then orchestrator-completed leaves the map empty", () => {
+    const path = writeLog([
+      { event: "orchestrator.status", orchestrator: "orch-r2",
+        ts: new Date().toISOString(),
+        detail: { orchestrator: "orch-r2", phase: "monitoring", wave: 1 } },
+      { event: "orchestrator-completed", orchestrator: "orch-r2" },
+    ]);
+    loadExistingRegistrations(path);
+    expect(getOrchestratorStatusMap().has("orch-r2")).toBe(false);
+  });
+
+  test("last status wins when an orchestrator reports twice", () => {
+    const path = writeLog([
+      { event: "orchestrator.status", orchestrator: "orch-r3",
+        ts: new Date().toISOString(),
+        detail: { orchestrator: "orch-r3", phase: "dispatching", wave: 1 } },
+      { event: "orchestrator.status", orchestrator: "orch-r3",
+        ts: new Date().toISOString(),
+        detail: { orchestrator: "orch-r3", phase: "monitoring", wave: 1 } },
+    ]);
+    loadExistingRegistrations(path);
+    expect(getOrchestratorStatusMap().get("orch-r3").phase).toBe("monitoring");
+  });
+});
+
 // ─── processEvent dispatching ────────────────────────────────────────────────
 
 describe("processEvent dispatches agent identity events", () => {

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -1003,7 +1003,7 @@ describe("watchdog treats orchestrator.status as liveness (CTL-405)", () => {
 
 // ─── CTL-507: loadExistingRegistrations replays orchestrator.status ───────────
 
-import { loadExistingRegistrations } from "./index.mjs";
+import { loadExistingRegistrations, isOrchestratorStatusFresh } from "./index.mjs";
 
 describe("loadExistingRegistrations replays orchestrator.status (CTL-507)", () => {
   let tmpDir;
@@ -1057,6 +1057,43 @@ describe("loadExistingRegistrations replays orchestrator.status (CTL-507)", () =
     ]);
     loadExistingRegistrations(path);
     expect(getOrchestratorStatusMap().get("orch-r3").phase).toBe("monitoring");
+  });
+
+  // ─── CTL-507 Phase 2: freshness gate ───────────────────────────────────────
+
+  test("fresh status (recent ts) is considered fresh", () => {
+    expect(isOrchestratorStatusFresh(
+      { ts: new Date().toISOString() }, Date.now())).toBe(true);
+  });
+
+  test("ancient status (ts well past the window) is stale", () => {
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    expect(isOrchestratorStatusFresh({ ts: old }, Date.now())).toBe(false);
+  });
+
+  test("missing or unparseable ts is treated as stale", () => {
+    expect(isOrchestratorStatusFresh({}, Date.now())).toBe(false);
+    expect(isOrchestratorStatusFresh({ ts: "not-a-date" }, Date.now())).toBe(false);
+  });
+
+  test("replay skips an ancient status event", () => {
+    const path = writeLog([
+      { event: "orchestrator.status", orchestrator: "orch-old",
+        ts: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+        detail: { orchestrator: "orch-old", phase: "monitoring", wave: 1 } },
+    ]);
+    loadExistingRegistrations(path);
+    expect(getOrchestratorStatusMap().has("orch-old")).toBe(false);
+  });
+
+  test("replay keeps a recent status event", () => {
+    const path = writeLog([
+      { event: "orchestrator.status", orchestrator: "orch-new",
+        ts: new Date().toISOString(),
+        detail: { orchestrator: "orch-new", phase: "monitoring", wave: 1 } },
+    ]);
+    loadExistingRegistrations(path);
+    expect(getOrchestratorStatusMap().has("orch-new")).toBe(true);
   });
 });
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-21T02:49:37Z -->
<!-- Last updated: 2026-05-21T02:49:37Z -->
<!-- PR: #931 -->
<!-- Previous commits: 58af79a6635bb211117b267f383f79e13a140705,e53be0e26443e703a4cc712cf72337c37a29988f -->

## Summary

The broker's `activeOrchestrators` state (persisted to `broker.state.json`) was
empty after a broker restart, even though PR wake-routing continued to work.
The cause: `loadExistingRegistrations()` replayed `filter.register`,
`filter.deregister`, `agent.checkin`, `agent.checkout`, and orchestrator
terminate events from the event log, but never replayed `orchestrator.status`.
On restart the orchestrator status map started empty and only repopulated when
a live orchestrator emitted its next status event.

This PR adds `orchestrator.status` to the startup replay path so the
orchestrator status map survives a broker restart, and gates that replay with a
freshness window so a long-dead orchestrator that crashed without emitting a
terminate event is not resurrected into `activeOrchestrators`.

## Changes Made

### Broker startup recovery (`plugins/dev/scripts/broker/index.mjs`)

- `loadExistingRegistrations()` now replays `orchestrator.status` events from the
  event log. Chronological replay combined with the existing
  `orchestrator-completed` / `orchestrator-failed` terminate handling means a
  status followed by a terminate resolves to set-then-delete, leaving the map
  correct.
- Added `isOrchestratorStatusFresh(event, nowMs)` — a replay-only freshness
  check. Status events older than `ORCH_STATUS_REPLAY_STALE_MS` (default 6h,
  overridable via `FILTER_ORCH_STATUS_REPLAY_STALE_MS`) are skipped on startup so
  a crashed-without-terminate orchestrator is not resurrected. Missing or
  unparseable timestamps are treated as stale (conservative — cannot verify age,
  matches the pre-fix empty-state behavior).
- Live `orchestrator.status` events are unaffected — the freshness gate guards
  only `loadExistingRegistrations()`, not the live event path.
- `loadExistingRegistrations()` now accepts an optional `logPath` parameter
  (defaults to `lastLogPath`) and is exported, enabling deterministic tests
  against a fixture log file.

### Tests (`plugins/dev/scripts/broker/index.test.mjs`)

- New `loadExistingRegistrations replays orchestrator.status (CTL-507)` suite
  covering: status replay populates the map, status-then-completed leaves the map
  empty, last-status-wins on duplicate reports.
- Freshness gate coverage: fresh `ts` is fresh, ancient `ts` is stale, missing /
  unparseable `ts` is stale, replay skips an ancient event, replay keeps a recent
  event.

## How to Verify It

- [x] Broker test suite passes: `bun test plugins/dev/scripts/broker/index.test.mjs` (203 pass, 0 fail)
- [x] Broker script parses: `node --check plugins/dev/scripts/broker/index.mjs`

## Related Issues/PRs

- Fixes CTL-507 — catalyst-broker: activeOrchestrators in broker.state.json is
  empty after restart, even though wake-routing works.

Refs: CTL-507
