### PR TITLE
CTL-513: fail fast in create-worktree.sh when thoughts init produces no symlinks

### DIFF
--- a/plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Tests for the CTL-513 thoughts-init sanity check in create-worktree.sh.
+# Run: bash plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CREATE_WT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+
+FAILURES=0
+PASSES=0
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+assert_eq() {
+	if [[ $1 == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi
+}
+assert_contains() {
+	if [[ $1 == *"$2"* ]]; then pass "$3"; else fail "$3 — '$2' not in output"; fi
+}
+
+# Builds an isolated repo + stub humanlayer, runs the real create-worktree.sh.
+#   $1 INIT_MODE: fail | noop-ok | real
+#   $2 SETUP_JSON: optional catalyst.worktree.setup array (selects config-driven path)
+# Sets globals: OUTPUT, EXIT, WT_PATH, SRC, SCRATCH
+run_create_worktree() {
+	local INIT_MODE="$1" SETUP_JSON="${2-}"
+	SCRATCH="$(mktemp -d -t cwt-ctl513-XXXXXX)"
+	SRC="$SCRATCH/src"
+	local WT="$SCRATCH/wt" BIN="$SCRATCH/bin" FAKEHOME="$SCRATCH/home"
+	mkdir -p "$SRC" "$WT" "$BIN" "$FAKEHOME" "$SRC/.catalyst"
+	git -C "$SRC" init -q
+	git -C "$SRC" config user.email t@t.t && git -C "$SRC" config user.name t
+	git -C "$SRC" commit -q --allow-empty -m init
+	if [[ -n $SETUP_JSON ]]; then
+		printf '{"catalyst":{"projectKey":"t","worktree":{"setup":%s}}}\n' "$SETUP_JSON" \
+			>"$SRC/.catalyst/config.json"
+	else
+		printf '{"catalyst":{"projectKey":"t"}}\n' >"$SRC/.catalyst/config.json"
+	fi
+	cat >"$BIN/humanlayer" <<STUB
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "thoughts status") echo "Profile: testprofile" ;;
+  "thoughts init")
+    case "$INIT_MODE" in
+      fail)    exit 1 ;;
+      noop-ok) exit 0 ;;
+      real)    mkdir -p thoughts/shared && echo x > thoughts/shared/.keep ;;
+    esac ;;
+  *) exit 0 ;;
+esac
+STUB
+	chmod +x "$BIN/humanlayer"
+	OUTPUT="$(cd "$SRC" && PATH="$BIN:$PATH" HOME="$FAKEHOME" \
+		bash "$CREATE_WT" t-CTL-999 main --worktree-dir "$WT" 2>&1)"
+	EXIT=$?
+	WT_PATH="$WT/t-CTL-999"
+}
+
+# Case 1 — auto-detected path, init FAILS → exit 1 + worktree torn down.
+echo "Test 1: auto-detected path, failed thoughts init fails fast"
+run_create_worktree fail ""
+assert_eq "1" "$EXIT" "exits 1 when auto-detected thoughts init fails"
+assert_contains "$OUTPUT" "thoughts/shared" "error names thoughts/shared"
+if [[ ! -d $WT_PATH ]]; then pass "worktree removed"; else fail "worktree not removed"; fi
+if [[ -z "$(git -C "$SRC" branch --list t-CTL-999)" ]]; then pass "branch deleted"; else fail "branch left"; fi
+rm -rf "$SCRATCH"
+
+# Case 2 — config-driven path, thoughts init in setup FAILS → exit 1 (currently UNGUARDED).
+echo "Test 2: config-driven path, failed thoughts init fails fast"
+run_create_worktree fail '["humanlayer thoughts init --directory t"]'
+assert_eq "1" "$EXIT" "exits 1 when config-driven thoughts init fails"
+assert_contains "$OUTPUT" "thoughts/shared" "error names thoughts/shared"
+if [[ ! -d $WT_PATH ]]; then pass "worktree removed"; else fail "worktree not removed"; fi
+rm -rf "$SCRATCH"
+
+# Case 3 — auto-detected path, init SUCCEEDS → exit 0, worktree + thoughts/shared present.
+echo "Test 3: successful thoughts init still succeeds"
+run_create_worktree real ""
+assert_eq "0" "$EXIT" "exits 0 on successful init"
+if [[ -d "$WT_PATH/thoughts/shared" ]]; then pass "thoughts/shared present"; else fail "thoughts/shared missing"; fi
+rm -rf "$SCRATCH"
+
+# Case 4 — config-driven setup that never calls thoughts init → no false positive, exit 0.
+echo "Test 4: no false positive when thoughts init is not attempted"
+run_create_worktree fail '["echo skip-thoughts"]'
+assert_eq "0" "$EXIT" "exits 0 when no thoughts init was attempted"
+if [[ -d $WT_PATH ]]; then pass "worktree created"; else fail "worktree missing"; fi
+rm -rf "$SCRATCH"
+
+# Case 5 — regression guard: existing auto-detected check still catches init-OK-but-empty.
+echo "Test 5: existing thoughts/shared check still fires on noop-ok init"
+run_create_worktree noop-ok ""
+assert_eq "1" "$EXIT" "exits 1 when init reports OK but creates nothing"
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Passed: $PASSES  Failed: $FAILURES"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh
@@ -27,9 +27,10 @@ assert_contains() {
 # Builds an isolated repo + stub humanlayer, runs the real create-worktree.sh.
 #   $1 INIT_MODE: fail | noop-ok | real
 #   $2 SETUP_JSON: optional catalyst.worktree.setup array (selects config-driven path)
+#   $3 HOOKS_JSON: optional --hooks-json array (exercises the orchestration-hooks path)
 # Sets globals: OUTPUT, EXIT, WT_PATH, SRC, SCRATCH
 run_create_worktree() {
-	local INIT_MODE="$1" SETUP_JSON="${2-}"
+	local INIT_MODE="$1" SETUP_JSON="${2-}" HOOKS_JSON="${3-}"
 	SCRATCH="$(mktemp -d -t cwt-ctl513-XXXXXX)"
 	SRC="$SCRATCH/src"
 	local WT="$SCRATCH/wt" BIN="$SCRATCH/bin" FAKEHOME="$SCRATCH/home"
@@ -57,8 +58,12 @@ case "\$1 \$2" in
 esac
 STUB
 	chmod +x "$BIN/humanlayer"
+	local -a CW_ARGS=(t-CTL-999 main --worktree-dir "$WT")
+	if [[ -n $HOOKS_JSON ]]; then
+		CW_ARGS+=(--hooks-json "$HOOKS_JSON")
+	fi
 	OUTPUT="$(cd "$SRC" && PATH="$BIN:$PATH" HOME="$FAKEHOME" \
-		bash "$CREATE_WT" t-CTL-999 main --worktree-dir "$WT" 2>&1)"
+		bash "$CREATE_WT" "${CW_ARGS[@]}" 2>&1)"
 	EXIT=$?
 	WT_PATH="$WT/t-CTL-999"
 }
@@ -98,6 +103,18 @@ rm -rf "$SCRATCH"
 echo "Test 5: existing thoughts/shared check still fires on noop-ok init"
 run_create_worktree noop-ok ""
 assert_eq "1" "$EXIT" "exits 1 when init reports OK but creates nothing"
+rm -rf "$SCRATCH"
+
+# Case 6 — orchestration-hooks path (--hooks-json), thoughts init FAILS → exit 1.
+# A config-driven setup with no thoughts init keeps the auto-detected path (and
+# its command-v-humanlayer flag) out of the picture, isolating the --hooks-json
+# branch as the sole THOUGHTS_INIT_EXPECTED setter. This is the path the
+# orchestrator actually uses, so it must be guarded.
+echo "Test 6: orchestration-hooks (--hooks-json) failed thoughts init fails fast"
+run_create_worktree fail '["echo config-step"]' '["humanlayer thoughts init --directory t"]'
+assert_eq "1" "$EXIT" "exits 1 when --hooks-json thoughts init fails"
+assert_contains "$OUTPUT" "thoughts/shared" "error names thoughts/shared"
+if [[ ! -d $WT_PATH ]]; then pass "worktree removed"; else fail "worktree not removed"; fi
 rm -rf "$SCRATCH"
 
 echo ""

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -283,9 +283,17 @@ if [ -n "$CONFIG_FILE" ]; then
 	SETUP_COMMANDS=$(jq -c '.catalyst.worktree.setup // empty' "$CONFIG_FILE" 2>/dev/null)
 fi
 
+# CTL-513: track whether `humanlayer thoughts init` is attempted by any setup
+# path, so the post-setup sanity check below fires only when thoughts/ is
+# genuinely expected (no false positives for projects that don't use thoughts).
+THOUGHTS_INIT_EXPECTED=false
+
 if [ -n "$SETUP_COMMANDS" ] && [ "$SETUP_COMMANDS" != "null" ] && [ "$SETUP_COMMANDS" != "[]" ]; then
 	# ── Config-driven setup ──
 	echo -e "${YELLOW}🔧 Running project setup from config...${NC}"
+	if [[ "$SETUP_COMMANDS" == *"thoughts init"* ]]; then
+		THOUGHTS_INIT_EXPECTED=true
+	fi
 	run_hook_array "$SETUP_COMMANDS" "setup"
 else
 	# ── Auto-detected setup (backwards compatibility) ──
@@ -313,6 +321,7 @@ else
 
 	# 2. Initialize thoughts
 	if command -v humanlayer >/dev/null 2>&1; then
+		THOUGHTS_INIT_EXPECTED=true
 		INIT_CMD="humanlayer thoughts init --directory $THOUGHTS_DIRECTORY"
 		if [ -n "$THOUGHTS_PROFILE" ]; then
 			INIT_CMD="$INIT_CMD --profile $THOUGHTS_PROFILE"
@@ -345,7 +354,30 @@ fi
 # These run AFTER the base setup (config-driven or auto-detected)
 if [ -n "$HOOKS_JSON" ] && [ "$HOOKS_JSON" != "[]" ]; then
 	echo -e "${YELLOW}🔧 Running orchestration hooks...${NC}"
+	if [[ "$HOOKS_JSON" == *"thoughts init"* ]]; then
+		THOUGHTS_INIT_EXPECTED=true
+	fi
 	run_hook_array "$HOOKS_JSON" "orchestration"
+fi
+
+# CTL-513: Fail loudly if thoughts init was attempted but produced no thoughts/
+# symlinks. A failed `humanlayer thoughts init` only emits a ⚠️ warning via
+# run_hook_array (or the auto-detected else-branch) and is otherwise silent;
+# the missing thoughts/shared then surfaces ~30 min later as a phase-plan
+# `prior_artifact_missing` failure. Catch it here, at creation time, instead.
+if [ "$THOUGHTS_INIT_EXPECTED" = true ] && [ ! -d "thoughts/shared" ]; then
+	echo -e "${RED}❌ Error: thoughts/shared/ missing after setup hooks${NC}"
+	echo "  Working directory: $(pwd)"
+	echo "  Expected path: $(pwd)/thoughts/shared/"
+	echo "  'humanlayer thoughts init' was attempted but did not create the"
+	echo "  thoughts/ symlinks. Likely cause: a corrupted"
+	echo "  ~/.config/humanlayer/humanlayer.json (concurrent 'thoughts init'"
+	echo "  write race) dropped init into an interactive prompt that failed."
+	echo -e "${RED}  Cleaning up worktree...${NC}"
+	cd - >/dev/null
+	git worktree remove --force "$WORKTREE_PATH"
+	git branch -D "$WORKTREE_NAME" 2>/dev/null || true
+	exit 1
 fi
 
 # Allow direnv AFTER all setup hooks have run (hooks like setup-env.sh may modify .envrc)


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-21T03:00:00Z -->
<!-- Last updated: 2026-05-21T03:00:00Z -->
<!-- PR: #932 -->
<!-- Previous commits: 474542f1b173da938864159e730518d8ecae82ad,0119508bfe797a0f0068a33b0c963b0d43b1a6bf -->

## Summary

`create-worktree.sh` ran `humanlayer thoughts init` as a worktree setup step, but a failed init was
silent: `run_hook_array` printed a ⚠️ warning and the script still exited `0`, leaving a worktree
with no `thoughts/` symlinks. The gap only surfaced ~30 minutes later when the phase-plan dispatch
gate globbed for the research artifact and aborted with `prior_artifact_missing`.

This PR makes worktree creation fail fast and loudly the moment thoughts init produces no
`thoughts/` symlinks, instead of letting a half-built worktree leak downstream.

## Changes Made

### `plugins/dev/scripts/create-worktree.sh`

- Added a `THOUGHTS_INIT_EXPECTED` flag, set `true` only on the paths where
  `humanlayer thoughts init` is actually attempted, across all three setup paths:
  - config-driven setup (`catalyst.worktree.setup` contains `thoughts init`)
  - auto-detected setup (`humanlayer` CLI present)
  - orchestration hooks (`--hooks-json` contains `thoughts init`) — the path the orchestrator
    actually uses
- Added a post-setup backstop check: when the flag is set but `thoughts/shared/` does not resolve,
  the script prints an actionable error, tears down the half-built worktree and branch
  (`git worktree remove --force` + `git branch -D`), and `exit 1`s so the orchestrator can retry
  cleanly.

This is a fail-fast detection fix, not a race fix. The underlying TOCTOU write race on
`~/.config/humanlayer/humanlayer.json` is explicitly out of scope.

### `plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh` (new)

Integration test suite (6 cases):

1. Failed init via the auto-detected path
2. Failed init via the config-driven path
3. Successful init (no false failure)
4. No false positive when init is not attempted at all
5. Init-OK-but-empty regression guard
6. Failed init via the orchestration-hooks (`--hooks-json`) path — added so the path the
   orchestrator actually uses is covered; the harness gained an optional third `HOOKS_JSON`
   parameter

## How to Verify It

- [x] `validate` CI check passes ✅
- [x] `check-versions` CI check passes ✅
- [ ] `audit-references` CI check (running)
- [ ] `Cloudflare Pages` build (running)
- [ ] Run the new test suite locally:
  `bash plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh`

## Changelog Entry

Fixed: `create-worktree.sh` now fails fast with an actionable error and cleans up the worktree when
`humanlayer thoughts init` is attempted but produces no `thoughts/` symlinks, instead of leaving a
broken worktree that fails ~30 minutes later in phase-plan.

## Related Issues/PRs

- Refs: CTL-513
