### PR TITLE
CTL-511: Emit phase.<name>.failed so a dead phase-agent job is detected and revived

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
@@ -283,6 +283,12 @@ if [ "$HAS_FR" = "false" ]; then
 else
 	fail "stalled signal has no failureReason" "got has: $HAS_FR"
 fi
+AR=$(jq -r '.attentionReason' "${ORCH_DIR}/workers/CTL-904/phase-monitor-merge.json")
+if [ "$AR" = "state-json-missing" ]; then
+	pass "stalled signal records attentionReason=state-json-missing (the cause string)"
+else
+	fail "stalled signal records attentionReason" "got: $AR"
+fi
 if grep -rqs '"phase.monitor-merge.failed.CTL-904"' "${CATALYST_DIR}/events/"; then
 	pass "healthcheck emits phase.monitor-merge.failed.CTL-904 to wake the orchestrator"
 else
@@ -325,6 +331,49 @@ if grep -rqs '"phase.implement.failed.CTL-906"' "${CATALYST_DIR}/events/"; then
 	fail "--dry-run emitted a phase.*.failed event"
 else
 	pass "--dry-run emits no phase.*.failed event"
+fi
+unset CATALYST_DIR
+scratch_teardown
+
+echo "test (CTL-511): phase signal still flips to stalled when EMIT_COMPLETE is missing"
+# The signal-file write must not depend on the event emit. If EMIT_COMPLETE
+# resolution breaks, recovery must degrade to the slow path — not silently
+# leave the signal frozen.
+scratch_setup
+export CATALYST_DIR="${SCRATCH}/catalyst"
+mkdir -p "${CATALYST_DIR}/events"
+make_phase_signal "CTL-908" "verify" "running" "bg-ctl511-e"
+export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
+mkdir -p "${SCRATCH}/jobs"
+export CATALYST_EMIT_COMPLETE="${SCRATCH}/no-such-emit-complete"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >/dev/null 2>&1
+ST=$(phase_status "CTL-908" "verify")
+if [ "$ST" = "stalled" ]; then
+	pass "signal still reaches stalled when EMIT_COMPLETE is missing (stall write independent of emit)"
+else
+	fail "signal flip depends on EMIT_COMPLETE" "got: $ST"
+fi
+unset CATALYST_DIR CATALYST_EMIT_COMPLETE
+scratch_teardown
+
+echo "test (CTL-511 Phase 4): healthcheck is idempotent — two runs emit exactly one phase.*.failed"
+# Phase 4 wires healthcheck into every reactive scan; its safety rests on
+# idempotency. The second run must see status="stalled" (a terminal state) and
+# skip — emitting no duplicate event, so the reactive-scan call site cannot
+# cause a wake storm.
+scratch_setup
+export CATALYST_DIR="${SCRATCH}/catalyst"
+mkdir -p "${CATALYST_DIR}/events"
+make_phase_signal "CTL-907" "monitor-merge" "running" "bg-ctl511-d"
+export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
+mkdir -p "${SCRATCH}/jobs"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >/dev/null 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >/dev/null 2>&1
+EVT_COUNT=$(grep -rhs '"phase.monitor-merge.failed.CTL-907"' "${CATALYST_DIR}/events/" | wc -l | tr -d ' ')
+if [ "$EVT_COUNT" = "1" ]; then
+	pass "two healthcheck runs emit exactly one phase.*.failed (stalled signal skipped on rerun)"
+else
+	fail "healthcheck not idempotent across runs" "phase.*.failed count=$EVT_COUNT (expected 1)"
 fi
 unset CATALYST_DIR
 scratch_teardown

--- a/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
@@ -12,59 +12,66 @@ FAILURES=0
 PASSES=0
 
 scratch_setup() {
-  SCRATCH="$(mktemp -d)"
-  ORCH_DIR="${SCRATCH}/orch"
-  mkdir -p "${ORCH_DIR}/workers" "${SCRATCH}/bin"
+	SCRATCH="$(mktemp -d)"
+	ORCH_DIR="${SCRATCH}/orch"
+	mkdir -p "${ORCH_DIR}/workers" "${SCRATCH}/bin"
 
-  # Fake state script: appends argv to state.log so tests can assert.
-  cat > "${SCRATCH}/bin/catalyst-state.sh" <<'EOF'
+	# Fake state script: appends argv to state.log so tests can assert.
+	cat >"${SCRATCH}/bin/catalyst-state.sh" <<'EOF'
 #!/usr/bin/env bash
 echo "$@" >> "$STATE_LOG"
 EOF
-  chmod +x "${SCRATCH}/bin/catalyst-state.sh"
-  export STATE_LOG="${SCRATCH}/state.log"
-  : > "$STATE_LOG"
-  export CATALYST_STATE_SCRIPT="${SCRATCH}/bin/catalyst-state.sh"
+	chmod +x "${SCRATCH}/bin/catalyst-state.sh"
+	export STATE_LOG="${SCRATCH}/state.log"
+	: >"$STATE_LOG"
+	export CATALYST_STATE_SCRIPT="${SCRATCH}/bin/catalyst-state.sh"
 }
 
 scratch_teardown() {
-  rm -rf "$SCRATCH"
-  unset STATE_LOG CATALYST_STATE_SCRIPT SCRATCH ORCH_DIR
+	rm -rf "$SCRATCH"
+	unset STATE_LOG CATALYST_STATE_SCRIPT SCRATCH ORCH_DIR
 }
 
 make_signal() {
-  # Usage: make_signal TICKET PID STATUS PHASE
-  local ticket="$1" pid="$2" status="$3" phase="$4"
-  jq -n \
-    --arg t "$ticket" --arg s "$status" \
-    --argjson p "$phase" \
-    --argjson pid "$pid" \
-    '{ticket:$t, status:$s, phase:$p, pid:$pid, updatedAt:"2026-04-16T00:00:00Z"}' \
-    > "${ORCH_DIR}/workers/${ticket}.json"
+	# Usage: make_signal TICKET PID STATUS PHASE
+	local ticket="$1" pid="$2" status="$3" phase="$4"
+	jq -n \
+		--arg t "$ticket" --arg s "$status" \
+		--argjson p "$phase" \
+		--argjson pid "$pid" \
+		'{ticket:$t, status:$s, phase:$p, pid:$pid, updatedAt:"2026-04-16T00:00:00Z"}' \
+		>"${ORCH_DIR}/workers/${ticket}.json"
 }
 
 make_signal_no_pid() {
-  local ticket="$1" status="$2" phase="$3"
-  jq -n \
-    --arg t "$ticket" --arg s "$status" --argjson p "$phase" \
-    '{ticket:$t, status:$s, phase:$p, pid:null, updatedAt:"2026-04-16T00:00:00Z"}' \
-    > "${ORCH_DIR}/workers/${ticket}.json"
+	local ticket="$1" status="$2" phase="$3"
+	jq -n \
+		--arg t "$ticket" --arg s "$status" --argjson p "$phase" \
+		'{ticket:$t, status:$s, phase:$p, pid:null, updatedAt:"2026-04-16T00:00:00Z"}' \
+		>"${ORCH_DIR}/workers/${ticket}.json"
 }
 
-pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
-fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
 
 # A PID guaranteed to be dead.
 DEAD_PID=99999999
-while kill -0 "$DEAD_PID" 2>/dev/null; do DEAD_PID=$((DEAD_PID+1)); done
+while kill -0 "$DEAD_PID" 2>/dev/null; do DEAD_PID=$((DEAD_PID + 1)); done
 
 # ---
 
 echo "test: alive worker is left untouched"
 scratch_setup
-ALIVE_PID=$$   # this test process itself
+ALIVE_PID=$$ # this test process itself
 make_signal "PROJ-1" "$ALIVE_PID" "dispatched" 0
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-1.json")
 [ "$STATUS" = "dispatched" ] && pass "status unchanged" || fail "status unchanged" "got: $STATUS"
 [ ! -s "$STATE_LOG" ] && pass "no state-script calls" || fail "no state-script calls" "log: $(cat "$STATE_LOG")"
@@ -73,21 +80,21 @@ scratch_teardown
 echo "test: dead worker is flagged"
 scratch_setup
 make_signal "PROJ-2" "$DEAD_PID" "dispatched" 0
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-2.json")
 REASON=$(jq -r '.failureReason' "${ORCH_DIR}/workers/PROJ-2.json")
 [ "$STATUS" = "failed" ] && pass "status transitioned to failed" || fail "status transitioned to failed" "got: $STATUS"
 [ "$REASON" = "launch-failure" ] && pass "failureReason set" || fail "failureReason set" "got: $REASON"
-grep -q "attention demo launch-failure PROJ-2" "$STATE_LOG" \
-  && pass "attention raised" || fail "attention raised" "log: $(cat "$STATE_LOG")"
-grep -q "worker-launch-failed" "$STATE_LOG" \
-  && pass "launch-failed event emitted" || fail "launch-failed event emitted" "log: $(cat "$STATE_LOG")"
+grep -q "attention demo launch-failure PROJ-2" "$STATE_LOG" &&
+	pass "attention raised" || fail "attention raised" "log: $(cat "$STATE_LOG")"
+grep -q "worker-launch-failed" "$STATE_LOG" &&
+	pass "launch-failed event emitted" || fail "launch-failed event emitted" "log: $(cat "$STATE_LOG")"
 scratch_teardown
 
 echo "test: worker past phase 0 is skipped"
 scratch_setup
 make_signal "PROJ-3" "$DEAD_PID" "implementing" 3
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-3.json")
 [ "$STATUS" = "implementing" ] && pass "advanced worker untouched" || fail "advanced worker untouched" "got: $STATUS"
 [ ! -s "$STATE_LOG" ] && pass "no state-script calls for advanced worker" || fail "no state-script calls for advanced worker"
@@ -96,7 +103,7 @@ scratch_teardown
 echo "test: worker with null pid is skipped safely"
 scratch_setup
 make_signal_no_pid "PROJ-4" "dispatched" 0
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 RC=$?
 [ $RC -eq 0 ] && pass "null pid exits zero" || fail "null pid exits zero" "rc=$RC"
 STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-4.json")
@@ -108,12 +115,12 @@ scratch_setup
 make_signal "PROJ-A" "$$" "dispatched" 0
 make_signal "PROJ-B" "$DEAD_PID" "dispatched" 0
 make_signal "PROJ-C" "$$" "dispatched" 0
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 SA=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-A.json")
 SB=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-B.json")
 SC=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-C.json")
-[ "$SA" = "dispatched" ] && [ "$SC" = "dispatched" ] && pass "alive workers untouched" \
-  || fail "alive workers untouched" "A=$SA C=$SC"
+[ "$SA" = "dispatched" ] && [ "$SC" = "dispatched" ] && pass "alive workers untouched" ||
+	fail "alive workers untouched" "A=$SA C=$SC"
 [ "$SB" = "failed" ] && pass "dead worker flagged" || fail "dead worker flagged" "B=$SB"
 DEAD_COUNT=$(grep -c "attention demo launch-failure" "$STATE_LOG" || true)
 [ "$DEAD_COUNT" = "1" ] && pass "exactly one attention call" || fail "exactly one attention call" "count=$DEAD_COUNT"
@@ -122,7 +129,7 @@ scratch_teardown
 echo "test: --dry-run detects but does not mutate"
 scratch_setup
 make_signal "PROJ-5" "$DEAD_PID" "dispatched" 0
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --dry-run > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --dry-run >"${SCRATCH}/out" 2>&1
 STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/PROJ-5.json")
 [ "$STATUS" = "dispatched" ] && pass "dry-run leaves signal unchanged" || fail "dry-run leaves signal unchanged" "got: $STATUS"
 [ ! -s "$STATE_LOG" ] && pass "dry-run makes no state-script calls" || fail "dry-run makes no state-script calls" "log: $(cat "$STATE_LOG")"
@@ -133,8 +140,8 @@ echo "test: non-worker JSON files are ignored"
 scratch_setup
 make_signal "PROJ-6" "$DEAD_PID" "dispatched" 0
 # Drop a non-signal JSON file shaped like something that could appear in workers/.
-echo '{"somethingElse": true}' > "${ORCH_DIR}/workers/not-a-signal.json"
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+echo '{"somethingElse": true}' >"${ORCH_DIR}/workers/not-a-signal.json"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 RC=$?
 [ $RC -eq 0 ] && pass "non-worker JSON does not crash" || fail "non-worker JSON does not crash" "rc=$RC; out: $(cat "${SCRATCH}/out")"
 # Still flags the real dead worker.
@@ -160,13 +167,13 @@ scratch_teardown
 # bg_job_id. Phase-mode signals live in a per-ticket subdirectory (NOT in
 # the flat workers/*.json space scanned by the legacy PID check).
 make_phase_signal() {
-  local ticket="$1" phase="$2" status="$3" bg="$4"
-  mkdir -p "${ORCH_DIR}/workers/${ticket}"
-  jq -n \
-    --arg t "$ticket" --arg p "$phase" --arg s "$status" --arg bg "$bg" \
-    '{ticket:$t, phase:$p, status:$s, bg_job_id:$bg,
+	local ticket="$1" phase="$2" status="$3" bg="$4"
+	mkdir -p "${ORCH_DIR}/workers/${ticket}"
+	jq -n \
+		--arg t "$ticket" --arg p "$phase" --arg s "$status" --arg bg "$bg" \
+		'{ticket:$t, phase:$p, status:$s, bg_job_id:$bg,
       startedAt:"2026-05-16T00:00:00Z", updatedAt:"2026-05-16T00:00:00Z"}' \
-    > "${ORCH_DIR}/workers/${ticket}/phase-${phase}.json"
+		>"${ORCH_DIR}/workers/${ticket}/phase-${phase}.json"
 }
 
 # make_bg_state JOB_ID STATE [AGE_SEC]
@@ -178,32 +185,32 @@ make_phase_signal() {
 # epochs, TZ-agnostic) consistent, we must feed touch a LOCAL-time string —
 # so `date -r EPOCH` (without -u) is the correct format command on macOS.
 make_bg_state() {
-  local job="$1" state="$2" age="${3:-0}"
-  mkdir -p "${SCRATCH}/jobs/${job}"
-  echo "{\"state\":\"${state}\",\"id\":\"${job}\"}" > "${SCRATCH}/jobs/${job}/state.json"
-  if [ "$age" -gt 0 ]; then
-    local then
-    then=$(( $(date -u +%s) - age ))
-    if date -r "$then" "+%Y%m%d%H%M.%S" >/dev/null 2>&1; then
-      touch -t "$(date -r "$then" "+%Y%m%d%H%M.%S")" "${SCRATCH}/jobs/${job}/state.json"
-    else
-      touch -d "@${then}" "${SCRATCH}/jobs/${job}/state.json" 2>/dev/null || true
-    fi
-  fi
-  export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
+	local job="$1" state="$2" age="${3:-0}"
+	mkdir -p "${SCRATCH}/jobs/${job}"
+	echo "{\"state\":\"${state}\",\"id\":\"${job}\"}" >"${SCRATCH}/jobs/${job}/state.json"
+	if [ "$age" -gt 0 ]; then
+		local then
+		then=$(($(date -u +%s) - age))
+		if date -r "$then" "+%Y%m%d%H%M.%S" >/dev/null 2>&1; then
+			touch -t "$(date -r "$then" "+%Y%m%d%H%M.%S")" "${SCRATCH}/jobs/${job}/state.json"
+		else
+			touch -d "@${then}" "${SCRATCH}/jobs/${job}/state.json" 2>/dev/null || true
+		fi
+	fi
+	export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
 }
 
 # Read status from a per-phase signal at workers/<T>/phase-<P>.json
 phase_status() {
-  local ticket="$1" phase="$2"
-  jq -r '.status' "${ORCH_DIR}/workers/${ticket}/phase-${phase}.json"
+	local ticket="$1" phase="$2"
+	jq -r '.status' "${ORCH_DIR}/workers/${ticket}/phase-${phase}.json"
 }
 
 echo "test (CTL-452): phase-mode worker with stale state.json marked stalled"
 scratch_setup
 make_phase_signal "T-A" "implement" "running" "bg-stale"
-make_bg_state "bg-stale" "running" 1200   # 20 min — older than 15 min default
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+make_bg_state "bg-stale" "running" 1200 # 20 min — older than 15 min default
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "T-A" "implement")
 [ "$ST" = "stalled" ] && pass "stale + running → stalled" || fail "stale + running → stalled" "got: $ST"
 grep -q "worker-phase-stalled" "$STATE_LOG" && pass "worker-phase-stalled event emitted" || fail "worker-phase-stalled event emitted" "log: $(cat "$STATE_LOG")"
@@ -212,8 +219,8 @@ scratch_teardown
 echo "test (CTL-452): phase-mode worker with fresh state.json untouched"
 scratch_setup
 make_phase_signal "T-B" "research" "running" "bg-fresh"
-make_bg_state "bg-fresh" "running" 30   # 30s old — well within 15 min default
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+make_bg_state "bg-fresh" "running" 30 # 30s old — well within 15 min default
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "T-B" "research")
 [ "$ST" = "running" ] && pass "fresh state.json → status untouched" || fail "fresh state.json → status untouched" "got: $ST"
 grep -q "worker-phase-stalled" "$STATE_LOG" && fail "no phase-stalled event for fresh job" || pass "no phase-stalled event for fresh job"
@@ -222,8 +229,8 @@ scratch_teardown
 echo "test (CTL-452): phase-mode worker with state=done untouched even when stale"
 scratch_setup
 make_phase_signal "T-C" "pr" "done" "bg-done"
-make_bg_state "bg-done" "done" 2000   # very stale, but terminal
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+make_bg_state "bg-done" "done" 2000 # very stale, but terminal
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "T-C" "pr")
 [ "$ST" = "done" ] && pass "terminal job state.json → status untouched" || fail "terminal job state.json → status untouched" "got: $ST"
 scratch_teardown
@@ -231,9 +238,9 @@ scratch_teardown
 echo "test (CTL-452): phase-mode worker with missing job dir → stalled"
 scratch_setup
 make_phase_signal "T-D" "verify" "running" "bg-missing"
-export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"   # exists but no per-job subdir
+export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs" # exists but no per-job subdir
 mkdir -p "${SCRATCH}/jobs"
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "T-D" "verify")
 [ "$ST" = "stalled" ] && pass "missing job dir → stalled" || fail "missing job dir → stalled" "got: $ST"
 scratch_teardown
@@ -241,9 +248,9 @@ scratch_teardown
 echo "test (CTL-452): --stale-bg-seconds tunes the threshold"
 scratch_setup
 make_phase_signal "T-E" "implement" "running" "bg-customstale"
-make_bg_state "bg-customstale" "running" 120   # 2 min
+make_bg_state "bg-customstale" "running" 120 # 2 min
 # With default 900s, this is fresh. With --stale-bg-seconds 60, it's stale.
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --stale-bg-seconds 60 > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --stale-bg-seconds 60 >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "T-E" "implement")
 [ "$ST" = "stalled" ] && pass "custom threshold flips fresh → stalled" || fail "custom threshold flips fresh → stalled" "got: $ST"
 scratch_teardown
@@ -266,20 +273,20 @@ mkdir -p "${SCRATCH}/jobs"
 "$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "CTL-904" "monitor-merge")
 if [ "$ST" = "stalled" ]; then
-  pass "healthcheck still flips signal to stalled"
+	pass "healthcheck still flips signal to stalled"
 else
-  fail "healthcheck still flips signal to stalled" "got: $ST"
+	fail "healthcheck still flips signal to stalled" "got: $ST"
 fi
 HAS_FR=$(jq -r 'has("failureReason")' "${ORCH_DIR}/workers/CTL-904/phase-monitor-merge.json")
 if [ "$HAS_FR" = "false" ]; then
-  pass "stalled signal has no failureReason (Loop 2 redispatch-eligible)"
+	pass "stalled signal has no failureReason (Loop 2 redispatch-eligible)"
 else
-  fail "stalled signal has no failureReason" "got has: $HAS_FR"
+	fail "stalled signal has no failureReason" "got has: $HAS_FR"
 fi
 if grep -rqs '"phase.monitor-merge.failed.CTL-904"' "${CATALYST_DIR}/events/"; then
-  pass "healthcheck emits phase.monitor-merge.failed.CTL-904 to wake the orchestrator"
+	pass "healthcheck emits phase.monitor-merge.failed.CTL-904 to wake the orchestrator"
 else
-  fail "healthcheck emitted no phase.monitor-merge.failed.CTL-904 event"
+	fail "healthcheck emitted no phase.monitor-merge.failed.CTL-904 event"
 fi
 unset CATALYST_DIR
 scratch_teardown
@@ -293,9 +300,9 @@ export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
 mkdir -p "${SCRATCH}/jobs"
 "$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 if grep -q "worker-phase-stalled" "$STATE_LOG"; then
-  pass "worker-phase-stalled event still emitted (regression)"
+	pass "worker-phase-stalled event still emitted (regression)"
 else
-  fail "worker-phase-stalled event still emitted" "log: $(cat "$STATE_LOG")"
+	fail "worker-phase-stalled event still emitted" "log: $(cat "$STATE_LOG")"
 fi
 unset CATALYST_DIR
 scratch_teardown
@@ -310,14 +317,14 @@ mkdir -p "${SCRATCH}/jobs"
 "$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --dry-run >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "CTL-906" "implement")
 if [ "$ST" = "running" ]; then
-  pass "--dry-run leaves phase signal unchanged"
+	pass "--dry-run leaves phase signal unchanged"
 else
-  fail "--dry-run leaves phase signal unchanged" "got: $ST"
+	fail "--dry-run leaves phase signal unchanged" "got: $ST"
 fi
 if grep -rqs '"phase.implement.failed.CTL-906"' "${CATALYST_DIR}/events/"; then
-  fail "--dry-run emitted a phase.*.failed event"
+	fail "--dry-run emitted a phase.*.failed event"
 else
-  pass "--dry-run emits no phase.*.failed event"
+	pass "--dry-run emits no phase.*.failed event"
 fi
 unset CATALYST_DIR
 scratch_teardown
@@ -331,14 +338,14 @@ scratch_teardown
 echo "test (CTL-511 Phase 4): SKILL.md runs orchestrate-healthcheck in the reactive scan, not only per-wave"
 SKILL_MD="${REPO_ROOT}/plugins/dev/skills/orchestrate/SKILL.md"
 if [ ! -f "$SKILL_MD" ]; then
-  fail "orchestrate/SKILL.md not found at $SKILL_MD"
+	fail "orchestrate/SKILL.md not found at $SKILL_MD"
 else
-  HC_COUNT=$(grep -c 'scripts/orchestrate-healthcheck' "$SKILL_MD")
-  if [ "$HC_COUNT" -ge 2 ]; then
-    pass "SKILL.md invokes orchestrate-healthcheck beyond the once-per-wave dispatch (count=$HC_COUNT)"
-  else
-    fail "orchestrate-healthcheck still appears only once (per-wave only)" "count=$HC_COUNT"
-  fi
+	HC_COUNT=$(grep -c 'scripts/orchestrate-healthcheck' "$SKILL_MD")
+	if [ "$HC_COUNT" -ge 2 ]; then
+		pass "SKILL.md invokes orchestrate-healthcheck beyond the once-per-wave dispatch (count=$HC_COUNT)"
+	else
+		fail "orchestrate-healthcheck still appears only once (per-wave only)" "count=$HC_COUNT"
+	fi
 fi
 
 echo

--- a/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
@@ -248,6 +248,64 @@ ST=$(phase_status "T-E" "implement")
 [ "$ST" = "stalled" ] && pass "custom threshold flips fresh → stalled" || fail "custom threshold flips fresh → stalled" "got: $ST"
 scratch_teardown
 
+# ─── CTL-511: phase stall also emits phase.<name>.failed to wake the orchestrator ───
+#
+# The legacy worker-phase-stalled event does not match the broker's
+# PHASE_EVENT_PATTERN, so a flipped-to-stalled signal never woke the
+# orchestrator. CTL-511 adds a phase.<name>.failed.<TICKET> emission alongside
+# it. The signal must stay at status="stalled" with NO failureReason so
+# orchestrate-revive Loop 2 redispatches it.
+
+echo "test (CTL-511): phase stall emits phase.<name>.failed event to wake the orchestrator"
+scratch_setup
+export CATALYST_DIR="${SCRATCH}/catalyst"
+mkdir -p "${CATALYST_DIR}/events"
+make_phase_signal "CTL-904" "monitor-merge" "running" "bg-ctl511-a"
+export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"   # exists, no per-job subdir → state-json-missing
+mkdir -p "${SCRATCH}/jobs"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+ST=$(phase_status "CTL-904" "monitor-merge")
+[ "$ST" = "stalled" ] && pass "healthcheck still flips signal to stalled" || fail "healthcheck still flips signal to stalled" "got: $ST"
+HAS_FR=$(jq -r 'has("failureReason")' "${ORCH_DIR}/workers/CTL-904/phase-monitor-merge.json")
+[ "$HAS_FR" = "false" ] && pass "stalled signal has no failureReason (Loop 2 redispatch-eligible)" || fail "stalled signal has no failureReason" "got has: $HAS_FR"
+EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
+if [ -z "$EVENT_FILE" ]; then
+  fail "healthcheck emitted no phase.*.failed event log"
+else
+  grep -q '"phase.monitor-merge.failed.CTL-904"' "$EVENT_FILE" \
+    && pass "healthcheck emits phase.monitor-merge.failed.CTL-904 to wake the orchestrator" \
+    || fail "healthcheck emitted no phase.monitor-merge.failed.CTL-904 event"
+fi
+unset CATALYST_DIR
+scratch_teardown
+
+echo "test (CTL-511 regression): worker-phase-stalled event still emitted alongside phase.*.failed"
+scratch_setup
+export CATALYST_DIR="${SCRATCH}/catalyst"
+mkdir -p "${CATALYST_DIR}/events"
+make_phase_signal "CTL-905" "verify" "running" "bg-ctl511-b"
+export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
+mkdir -p "${SCRATCH}/jobs"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+grep -q "worker-phase-stalled" "$STATE_LOG" && pass "worker-phase-stalled event still emitted (regression)" || fail "worker-phase-stalled event still emitted" "log: $(cat "$STATE_LOG")"
+unset CATALYST_DIR
+scratch_teardown
+
+echo "test (CTL-511): --dry-run emits no phase.*.failed event and no signal mutation"
+scratch_setup
+export CATALYST_DIR="${SCRATCH}/catalyst"
+mkdir -p "${CATALYST_DIR}/events"
+make_phase_signal "CTL-906" "implement" "running" "bg-ctl511-c"
+export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
+mkdir -p "${SCRATCH}/jobs"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --dry-run > "${SCRATCH}/out" 2>&1
+ST=$(phase_status "CTL-906" "implement")
+[ "$ST" = "running" ] && pass "--dry-run leaves phase signal unchanged" || fail "--dry-run leaves phase signal unchanged" "got: $ST"
+DRY_EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
+[ -z "$DRY_EVENT_FILE" ] && pass "--dry-run emits no phase.*.failed event" || fail "--dry-run emits no phase.*.failed event" "got: $DRY_EVENT_FILE"
+unset CATALYST_DIR
+scratch_teardown
+
 echo
 echo "Results: $PASSES passed, $FAILURES failed"
 [ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
@@ -261,20 +261,25 @@ scratch_setup
 export CATALYST_DIR="${SCRATCH}/catalyst"
 mkdir -p "${CATALYST_DIR}/events"
 make_phase_signal "CTL-904" "monitor-merge" "running" "bg-ctl511-a"
-export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"   # exists, no per-job subdir → state-json-missing
+export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs" # exists, no per-job subdir → state-json-missing
 mkdir -p "${SCRATCH}/jobs"
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "CTL-904" "monitor-merge")
-[ "$ST" = "stalled" ] && pass "healthcheck still flips signal to stalled" || fail "healthcheck still flips signal to stalled" "got: $ST"
-HAS_FR=$(jq -r 'has("failureReason")' "${ORCH_DIR}/workers/CTL-904/phase-monitor-merge.json")
-[ "$HAS_FR" = "false" ] && pass "stalled signal has no failureReason (Loop 2 redispatch-eligible)" || fail "stalled signal has no failureReason" "got has: $HAS_FR"
-EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
-if [ -z "$EVENT_FILE" ]; then
-  fail "healthcheck emitted no phase.*.failed event log"
+if [ "$ST" = "stalled" ]; then
+  pass "healthcheck still flips signal to stalled"
 else
-  grep -q '"phase.monitor-merge.failed.CTL-904"' "$EVENT_FILE" \
-    && pass "healthcheck emits phase.monitor-merge.failed.CTL-904 to wake the orchestrator" \
-    || fail "healthcheck emitted no phase.monitor-merge.failed.CTL-904 event"
+  fail "healthcheck still flips signal to stalled" "got: $ST"
+fi
+HAS_FR=$(jq -r 'has("failureReason")' "${ORCH_DIR}/workers/CTL-904/phase-monitor-merge.json")
+if [ "$HAS_FR" = "false" ]; then
+  pass "stalled signal has no failureReason (Loop 2 redispatch-eligible)"
+else
+  fail "stalled signal has no failureReason" "got has: $HAS_FR"
+fi
+if grep -rqs '"phase.monitor-merge.failed.CTL-904"' "${CATALYST_DIR}/events/"; then
+  pass "healthcheck emits phase.monitor-merge.failed.CTL-904 to wake the orchestrator"
+else
+  fail "healthcheck emitted no phase.monitor-merge.failed.CTL-904 event"
 fi
 unset CATALYST_DIR
 scratch_teardown
@@ -286,8 +291,12 @@ mkdir -p "${CATALYST_DIR}/events"
 make_phase_signal "CTL-905" "verify" "running" "bg-ctl511-b"
 export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
 mkdir -p "${SCRATCH}/jobs"
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 > "${SCRATCH}/out" 2>&1
-grep -q "worker-phase-stalled" "$STATE_LOG" && pass "worker-phase-stalled event still emitted (regression)" || fail "worker-phase-stalled event still emitted" "log: $(cat "$STATE_LOG")"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
+if grep -q "worker-phase-stalled" "$STATE_LOG"; then
+  pass "worker-phase-stalled event still emitted (regression)"
+else
+  fail "worker-phase-stalled event still emitted" "log: $(cat "$STATE_LOG")"
+fi
 unset CATALYST_DIR
 scratch_teardown
 
@@ -298,13 +307,39 @@ mkdir -p "${CATALYST_DIR}/events"
 make_phase_signal "CTL-906" "implement" "running" "bg-ctl511-c"
 export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs"
 mkdir -p "${SCRATCH}/jobs"
-"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --dry-run > "${SCRATCH}/out" 2>&1
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --dry-run >"${SCRATCH}/out" 2>&1
 ST=$(phase_status "CTL-906" "implement")
-[ "$ST" = "running" ] && pass "--dry-run leaves phase signal unchanged" || fail "--dry-run leaves phase signal unchanged" "got: $ST"
-DRY_EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
-[ -z "$DRY_EVENT_FILE" ] && pass "--dry-run emits no phase.*.failed event" || fail "--dry-run emits no phase.*.failed event" "got: $DRY_EVENT_FILE"
+if [ "$ST" = "running" ]; then
+  pass "--dry-run leaves phase signal unchanged"
+else
+  fail "--dry-run leaves phase signal unchanged" "got: $ST"
+fi
+if grep -rqs '"phase.implement.failed.CTL-906"' "${CATALYST_DIR}/events/"; then
+  fail "--dry-run emitted a phase.*.failed event"
+else
+  pass "--dry-run emits no phase.*.failed event"
+fi
 unset CATALYST_DIR
 scratch_teardown
+
+# ─── CTL-511 Phase 4: orchestrate-healthcheck runs on every reactive scan ───
+# A phase agent that dies after launch is detected only when orchestrate-healthcheck
+# next scans it. Wiring it into the orchestrator's reactive scan (every wake +
+# the 10-min idle fallback) bounds detection latency to one scan interval
+# instead of the once-per-wave-only behavior. Doc-placement assertion in the
+# style of the repo's other docs-drift tests.
+echo "test (CTL-511 Phase 4): SKILL.md runs orchestrate-healthcheck in the reactive scan, not only per-wave"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/orchestrate/SKILL.md"
+if [ ! -f "$SKILL_MD" ]; then
+  fail "orchestrate/SKILL.md not found at $SKILL_MD"
+else
+  HC_COUNT=$(grep -c 'scripts/orchestrate-healthcheck' "$SKILL_MD")
+  if [ "$HC_COUNT" -ge 2 ]; then
+    pass "SKILL.md invokes orchestrate-healthcheck beyond the once-per-wave dispatch (count=$HC_COUNT)"
+  else
+    fail "orchestrate-healthcheck still appears only once (per-wave only)" "count=$HC_COUNT"
+  fi
+fi
 
 echo
 echo "Results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -669,6 +669,15 @@ SIGNAL="${WORKER_DIR}/phase-triage.json"
 assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "launch failure leaves signal at stalled"
 assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" \
 	"launch-failure signal has no failureReason (Loop 2 redispatch-eligible)"
+assert_eq "claude-bg-launch-failed" "$(jq -r '.attentionReason' "$SIGNAL")" \
+	"launch-failure signal records attentionReason (the cause string, not failureReason)"
+# CTL-511: the signal file says "stalled" (recovery-eligible) but the dispatch
+# stdout JSON still reports status="failed" — the synchronous dispatch attempt
+# DID fail. The two intentionally diverge: orchestrate-revive reads the signal
+# file, not dispatch stdout. Pin both so a future change cannot silently
+# collapse them.
+assert_eq "failed" "$(jq -r '.status' "${TEST_DIR}/t16.out")" \
+	"dispatch stdout reports status=failed (distinct from the stalled signal file)"
 if grep -rqs '"phase.triage.failed.CTL-100"' "${CATALYST_DIR}/events/"; then
 	pass "launch failure emits phase.triage.failed.CTL-100 event"
 else
@@ -694,6 +703,8 @@ SIGNAL="${WORKER_DIR}/phase-triage.json"
 assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "empty job id leaves signal at stalled"
 assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" \
 	"empty-job-id signal has no failureReason (Loop 2 redispatch-eligible)"
+assert_eq "claude-bg-empty-job-id" "$(jq -r '.attentionReason' "$SIGNAL")" \
+	"empty-job-id signal records attentionReason (the cause string, not failureReason)"
 if grep -rqs '"phase.triage.failed.CTL-100"' "${CATALYST_DIR}/events/"; then
 	pass "empty job id emits phase.triage.failed.CTL-100 event"
 else
@@ -709,6 +720,21 @@ SIGNAL="${WORKER_DIR}/phase-triage.json"
 assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "successful launch leaves signal at running"
 assert_eq "running" "$(echo "$STDOUT" | jq -r '.status')" "successful launch stdout status=running"
 assert_eq "f124220a" "$(jq -r '.bg_job_id' "$SIGNAL")" "successful launch records bg_job_id"
+
+echo ""
+echo "Test 19 (CTL-511): launch failure still flips signal to stalled when EMIT_COMPLETE is absent"
+# The signal-file write (step 1) must not depend on the event emit (step 2).
+# If EMIT_COMPLETE resolution ever breaks, recovery must degrade to the slow
+# healthcheck path — NOT silently leave the signal frozen at "dispatched".
+fresh_env t19
+export CLAUDE_STUB_EXIT=1
+export CATALYST_EMIT_COMPLETE="${TEST_DIR}/no-such-emit-complete"
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	>/dev/null 2>&1
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" \
+	"signal still reaches stalled when EMIT_COMPLETE is missing (step 1 independent of step 2)"
+unset CLAUDE_STUB_EXIT CATALYST_EMIT_COMPLETE
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -663,13 +663,10 @@ SIGNAL="${WORKER_DIR}/phase-triage.json"
 assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "launch failure leaves signal at stalled"
 assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" \
   "launch-failure signal has no failureReason (Loop 2 redispatch-eligible)"
-EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
-if [[ -z "$EVENT_FILE" ]]; then
-  fail "launch failure emitted no event log"
+if grep -rqs '"phase.triage.failed.CTL-100"' "${CATALYST_DIR}/events/"; then
+  pass "launch failure emits phase.triage.failed.CTL-100 event"
 else
-  grep -q '"phase.triage.failed.CTL-100"' "$EVENT_FILE" \
-    && pass "launch failure emits phase.triage.failed.CTL-100 event" \
-    || fail "no phase.triage.failed.CTL-100 event on launch failure"
+  fail "no phase.triage.failed.CTL-100 event on launch failure"
 fi
 unset CLAUDE_STUB_EXIT CATALYST_DIR
 
@@ -677,7 +674,7 @@ echo ""
 echo "Test 17 (CTL-511): claude --bg with no hex job id → signal stalled + phase.*.failed emitted"
 fresh_env t17
 # Override the stub: exit 0 but print no 8-char hex token.
-cat > "${STUB_DIR}/claude" <<'STUB'
+cat >"${STUB_DIR}/claude" <<'STUB'
 #!/usr/bin/env bash
 echo "started, no job id present"
 exit 0
@@ -691,13 +688,10 @@ SIGNAL="${WORKER_DIR}/phase-triage.json"
 assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "empty job id leaves signal at stalled"
 assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" \
   "empty-job-id signal has no failureReason (Loop 2 redispatch-eligible)"
-EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
-if [[ -z "$EVENT_FILE" ]]; then
-  fail "empty job id emitted no event log"
+if grep -rqs '"phase.triage.failed.CTL-100"' "${CATALYST_DIR}/events/"; then
+  pass "empty job id emits phase.triage.failed.CTL-100 event"
 else
-  grep -q '"phase.triage.failed.CTL-100"' "$EVENT_FILE" \
-    && pass "empty job id emits phase.triage.failed.CTL-100 event" \
-    || fail "no phase.triage.failed.CTL-100 event on empty job id"
+  fail "no phase.triage.failed.CTL-100 event on empty job id"
 fi
 unset CATALYST_DIR
 

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -643,6 +643,73 @@ assert_contains "$LOG" \
   "OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test,task.type=phase-triage" \
   "task.type appended even when projectKey absent (short form)"
 
+# ─── CTL-511: claude --bg launch failure → signal stalled + phase.*.failed ───
+# A launch failure must leave the signal at status="stalled" with NO
+# failureReason (so orchestrate-revive Loop 2 redispatches it) and emit
+# phase.<name>.failed.<TICKET> (so the broker wakes the orchestrator in
+# seconds instead of waiting on the periodic healthcheck).
+
+echo ""
+echo "Test 16 (CTL-511): claude --bg non-zero exit → signal stalled + phase.*.failed emitted"
+fresh_env t16
+export CLAUDE_STUB_EXIT=1
+export CATALYST_DIR="${TEST_DIR}/catalyst-events"
+mkdir -p "${CATALYST_DIR}/events"
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+  >"${TEST_DIR}/t16.out" 2>"${TEST_DIR}/t16.err"
+RC=$?
+assert_eq "1" "$RC" "dispatch exits 1 on claude --bg launch failure"
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "launch failure leaves signal at stalled"
+assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" \
+  "launch-failure signal has no failureReason (Loop 2 redispatch-eligible)"
+EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
+if [[ -z "$EVENT_FILE" ]]; then
+  fail "launch failure emitted no event log"
+else
+  grep -q '"phase.triage.failed.CTL-100"' "$EVENT_FILE" \
+    && pass "launch failure emits phase.triage.failed.CTL-100 event" \
+    || fail "no phase.triage.failed.CTL-100 event on launch failure"
+fi
+unset CLAUDE_STUB_EXIT CATALYST_DIR
+
+echo ""
+echo "Test 17 (CTL-511): claude --bg with no hex job id → signal stalled + phase.*.failed emitted"
+fresh_env t17
+# Override the stub: exit 0 but print no 8-char hex token.
+cat > "${STUB_DIR}/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "started, no job id present"
+exit 0
+STUB
+chmod +x "${STUB_DIR}/claude"
+export CATALYST_DIR="${TEST_DIR}/catalyst-events"
+mkdir -p "${CATALYST_DIR}/events"
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+  >"${TEST_DIR}/t17.out" 2>"${TEST_DIR}/t17.err" || true
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "empty job id leaves signal at stalled"
+assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" \
+  "empty-job-id signal has no failureReason (Loop 2 redispatch-eligible)"
+EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
+if [[ -z "$EVENT_FILE" ]]; then
+  fail "empty job id emitted no event log"
+else
+  grep -q '"phase.triage.failed.CTL-100"' "$EVENT_FILE" \
+    && pass "empty job id emits phase.triage.failed.CTL-100 event" \
+    || fail "no phase.triage.failed.CTL-100 event on empty job id"
+fi
+unset CATALYST_DIR
+
+echo ""
+echo "Test 18 (CTL-511 regression): a successful launch still ends at status:running"
+fresh_env t18
+STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "successful launch leaves signal at running"
+assert_eq "running" "$(echo "$STDOUT" | jq -r '.status')" "successful launch stdout status=running"
+assert_eq "f124220a" "$(jq -r '.bg_job_id' "$SIGNAL")" "successful launch records bg_job_id"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -19,30 +19,36 @@ PASSES=0
 SCRATCH="$(mktemp -d -t phase-agent-dispatch-test-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
-pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
 
 assert_eq() {
-  local expected="$1" actual="$2" label="$3"
-  if [[ "$expected" == "$actual" ]]; then
-    pass "$label"
-  else
-    fail "$label — expected '$expected', got '$actual'"
-  fi
+	local expected="$1" actual="$2" label="$3"
+	if [[ $expected == "$actual" ]]; then
+		pass "$label"
+	else
+		fail "$label — expected '$expected', got '$actual'"
+	fi
 }
 
 assert_contains() {
-  local haystack="$1" needle="$2" label="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    pass "$label"
-  else
-    fail "$label — '$needle' not found in '$haystack'"
-  fi
+	local haystack="$1" needle="$2" label="$3"
+	if [[ $haystack == *"$needle"* ]]; then
+		pass "$label"
+	else
+		fail "$label — '$needle' not found in '$haystack'"
+	fi
 }
 
-if [[ ! -x "$DISPATCH" ]]; then
-  echo "FATAL: $DISPATCH not found or not executable" >&2
-  exit 1
+if [[ ! -x $DISPATCH ]]; then
+	echo "FATAL: $DISPATCH not found or not executable" >&2
+	exit 1
 fi
 
 # ─── Stub claude binary ─────────────────────────────────────────────────────
@@ -61,9 +67,9 @@ fi
 # (Bug 1 in CTL-490) — that gap requires a real `claude --bg` round-trip and
 # is verified manually per the ticket's acceptance test.
 setup_claude_stub() {
-  local stub_dir="$1"
-  mkdir -p "$stub_dir"
-  cat > "$stub_dir/claude" <<'STUB'
+	local stub_dir="$1"
+	mkdir -p "$stub_dir"
+	cat >"$stub_dir/claude" <<'STUB'
 #!/usr/bin/env bash
 LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
 JOB_ID="${CLAUDE_STUB_JOB_ID:-f124220a}"
@@ -83,23 +89,23 @@ backgrounded · ${JOB_ID}
 EOF
 exit "${CLAUDE_STUB_EXIT:-0}"
 STUB
-  chmod +x "$stub_dir/claude"
+	chmod +x "$stub_dir/claude"
 }
 
 # Build a fresh per-test orch fixture and put the stub claude on PATH first.
 fresh_env() {
-  local tag="$1"
-  TEST_DIR="${SCRATCH}/${tag}"
-  STUB_DIR="${TEST_DIR}/bin"
-  ORCH_DIR="${TEST_DIR}/orch"
-  WORKER_DIR="${ORCH_DIR}/workers/CTL-100"
-  CONFIG_DIR="${TEST_DIR}/proj/.catalyst"
-  mkdir -p "$STUB_DIR" "$WORKER_DIR" "$CONFIG_DIR"
-  setup_claude_stub "$STUB_DIR"
-  export CLAUDE_STUB_LOG="${TEST_DIR}/claude-stub.log"
-  export CLAUDE_STUB_JOB_ID="f124220a"
-  unset CLAUDE_STUB_EXIT
-  export PATH="${STUB_DIR}:${PATH}"
+	local tag="$1"
+	TEST_DIR="${SCRATCH}/${tag}"
+	STUB_DIR="${TEST_DIR}/bin"
+	ORCH_DIR="${TEST_DIR}/orch"
+	WORKER_DIR="${ORCH_DIR}/workers/CTL-100"
+	CONFIG_DIR="${TEST_DIR}/proj/.catalyst"
+	mkdir -p "$STUB_DIR" "$WORKER_DIR" "$CONFIG_DIR"
+	setup_claude_stub "$STUB_DIR"
+	export CLAUDE_STUB_LOG="${TEST_DIR}/claude-stub.log"
+	export CLAUDE_STUB_JOB_ID="f124220a"
+	unset CLAUDE_STUB_EXIT
+	export PATH="${STUB_DIR}:${PATH}"
 }
 
 # ─── Test 1: dispatcher writes the per-phase signal file with the right schema
@@ -107,20 +113,20 @@ echo "Test 1: dispatcher writes signal file with correct schema"
 fresh_env t1
 OUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>&1)
 SIGNAL="${WORKER_DIR}/phase-triage.json"
-if [[ ! -f "$SIGNAL" ]]; then
-  fail "signal file created: $SIGNAL"
+if [[ ! -f $SIGNAL ]]; then
+	fail "signal file created: $SIGNAL"
 else
-  pass "signal file created at expected path"
-  TICKET_FIELD=$(jq -r '.ticket' "$SIGNAL")
-  PHASE_FIELD=$(jq -r '.phase' "$SIGNAL")
-  MODEL_FIELD=$(jq -r '.model' "$SIGNAL")
-  TURN_CAP_FIELD=$(jq -r '.turnCap' "$SIGNAL")
-  STATUS_FIELD=$(jq -r '.status' "$SIGNAL")
-  assert_eq "CTL-100" "$TICKET_FIELD" "signal.ticket"
-  assert_eq "triage"  "$PHASE_FIELD"  "signal.phase"
-  assert_eq "opus"    "$MODEL_FIELD"  "signal.model defaulted to opus"
-  assert_eq "10"      "$TURN_CAP_FIELD" "signal.turnCap defaulted to 10 (triage)"
-  assert_eq "running" "$STATUS_FIELD" "signal.status = running after bg spawn"
+	pass "signal file created at expected path"
+	TICKET_FIELD=$(jq -r '.ticket' "$SIGNAL")
+	PHASE_FIELD=$(jq -r '.phase' "$SIGNAL")
+	MODEL_FIELD=$(jq -r '.model' "$SIGNAL")
+	TURN_CAP_FIELD=$(jq -r '.turnCap' "$SIGNAL")
+	STATUS_FIELD=$(jq -r '.status' "$SIGNAL")
+	assert_eq "CTL-100" "$TICKET_FIELD" "signal.ticket"
+	assert_eq "triage" "$PHASE_FIELD" "signal.phase"
+	assert_eq "opus" "$MODEL_FIELD" "signal.model defaulted to opus"
+	assert_eq "10" "$TURN_CAP_FIELD" "signal.turnCap defaulted to 10 (triage)"
+	assert_eq "running" "$STATUS_FIELD" "signal.status = running after bg spawn"
 fi
 
 # ─── Test 2: dispatcher launches claude --bg with the right env vars
@@ -159,9 +165,9 @@ rm -f "$CLAUDE_STUB_LOG"
 STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
 IDEMPOTENT=$(echo "$STDOUT" | jq -r '.idempotent // false')
 LOG_REWRITTEN="no"
-[[ -f "$CLAUDE_STUB_LOG" ]] && LOG_REWRITTEN="yes"
+[[ -f $CLAUDE_STUB_LOG ]] && LOG_REWRITTEN="yes"
 assert_eq "true" "$IDEMPOTENT" "second dispatch reports idempotent: true"
-assert_eq "no"   "$LOG_REWRITTEN" "second dispatch did NOT re-invoke claude --bg"
+assert_eq "no" "$LOG_REWRITTEN" "second dispatch did NOT re-invoke claude --bg"
 
 # ─── Test 5: dispatcher refuses to launch if prior phase artifact is missing
 echo ""
@@ -174,7 +180,7 @@ STDOUT_JSON=$(cat "${TEST_DIR}/research.out")
 REFUSED_STATUS=$(echo "$STDOUT_JSON" | jq -r '.status' 2>/dev/null || echo "")
 SIGNAL_RESEARCH="${WORKER_DIR}/phase-research.json"
 SIGNAL_EXISTS="no"
-[[ -f "$SIGNAL_RESEARCH" ]] && SIGNAL_EXISTS="yes"
+[[ -f $SIGNAL_RESEARCH ]] && SIGNAL_EXISTS="yes"
 assert_eq "2" "$RC" "exit code 2 when prior artifact missing"
 assert_eq "refused" "$REFUSED_STATUS" "stdout JSON status = refused"
 assert_eq "no" "$SIGNAL_EXISTS" "no signal file written when refused"
@@ -186,49 +192,49 @@ export CATALYST_DIR="${TEST_DIR}/catalyst-events-root"
 mkdir -p "${CATALYST_DIR}/events"
 
 # Re-run the dispatch with the isolated CATALYST_DIR active.
-rm -f "$SIGNAL_RESEARCH"  # ensure refused, not idempotent
+rm -f "$SIGNAL_RESEARCH" # ensure refused, not idempotent
 "$DISPATCH" --phase research --ticket CTL-100 \
-  --orch-dir "$ORCH_DIR" --orch-id orch-test \
-  >"${TEST_DIR}/research2.out" 2>/dev/null
+	--orch-dir "$ORCH_DIR" --orch-id orch-test \
+	>"${TEST_DIR}/research2.out" 2>/dev/null
 RC2=$?
 assert_eq "2" "$RC2" "refusal still exits 2 with isolated CATALYST_DIR"
 
 # Find the JSONL event log (one file per month).
 EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
-if [[ -z "$EVENT_FILE" ]]; then
-  fail "event log was not created on refusal"
+if [[ -z $EVENT_FILE ]]; then
+	fail "event log was not created on refusal"
 else
-  pass "event log was created on refusal"
-  EVENT_LINE=$(grep '"phase.research.failed.CTL-100"' "$EVENT_FILE" | head -1)
-  if [[ -z "$EVENT_LINE" ]]; then
-    fail "no phase.research.failed.CTL-100 event in log"
-  else
-    pass "phase.research.failed.CTL-100 event present in log"
-    EVENT_REASON=$(echo "$EVENT_LINE" | jq -r '.body.payload.failure_reason // empty')
-    assert_eq "prior_artifact_missing" "$EVENT_REASON" \
-      "failed event payload carries failure_reason=prior_artifact_missing"
-  fi
+	pass "event log was created on refusal"
+	EVENT_LINE=$(grep '"phase.research.failed.CTL-100"' "$EVENT_FILE" | head -1)
+	if [[ -z $EVENT_LINE ]]; then
+		fail "no phase.research.failed.CTL-100 event in log"
+	else
+		pass "phase.research.failed.CTL-100 event present in log"
+		EVENT_REASON=$(echo "$EVENT_LINE" | jq -r '.body.payload.failure_reason // empty')
+		assert_eq "prior_artifact_missing" "$EVENT_REASON" \
+			"failed event payload carries failure_reason=prior_artifact_missing"
+	fi
 fi
 
 # Refusal must still NOT write a signal file (existing contract preserved).
-if [[ -f "$SIGNAL_RESEARCH" ]]; then
-  fail "signal file written despite refusal"
+if [[ -f $SIGNAL_RESEARCH ]]; then
+	fail "signal file written despite refusal"
 else
-  pass "signal file still not written when refused (with event log active)"
+	pass "signal file still not written when refused (with event log active)"
 fi
 
 # CTL-494 Phase 1: --dry-run refusal must NOT emit to the event log.
 rm -f "${CATALYST_DIR}/events/"*.jsonl
 "$DISPATCH" --phase research --ticket CTL-100 \
-  --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
-  >"${TEST_DIR}/research-dry.out" 2>/dev/null
+	--orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
+	>"${TEST_DIR}/research-dry.out" 2>/dev/null
 RC_DRY=$?
 assert_eq "2" "$RC_DRY" "--dry-run refusal still exits 2"
 DRY_EVENT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
-if [[ -n "$DRY_EVENT_FILE" ]]; then
-  fail "--dry-run refusal should not emit event (got $DRY_EVENT_FILE)"
+if [[ -n $DRY_EVENT_FILE ]]; then
+	fail "--dry-run refusal should not emit event (got $DRY_EVENT_FILE)"
 else
-  pass "--dry-run refusal does not emit event"
+	pass "--dry-run refusal does not emit event"
 fi
 
 # CTL-494 Phase 1: failed-event emission is phase-agnostic — the same code
@@ -241,22 +247,22 @@ fi
 # match a real research file in the host repo.
 rm -f "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null
 mkdir -p "${TEST_DIR}/empty-proj"
-( cd "${TEST_DIR}/empty-proj" && \
-  "$DISPATCH" --phase plan --ticket CTL-100 \
-    --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >"${TEST_DIR}/plan.out" 2>/dev/null )
+(cd "${TEST_DIR}/empty-proj" &&
+	"$DISPATCH" --phase plan --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/plan.out" 2>/dev/null)
 RC_PLAN=$?
 assert_eq "2" "$RC_PLAN" "plan-phase refusal also exits 2"
 PLAN_EVT_FILE=$(ls "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | head -1)
-if [[ -z "$PLAN_EVT_FILE" ]]; then
-  fail "plan-phase refusal: event log not created"
+if [[ -z $PLAN_EVT_FILE ]]; then
+	fail "plan-phase refusal: event log not created"
 else
-  PLAN_EVT_LINE=$(grep '"phase.plan.failed.CTL-100"' "$PLAN_EVT_FILE" | head -1)
-  if [[ -n "$PLAN_EVT_LINE" ]]; then
-    pass "plan-phase refusal emits phase.plan.failed.CTL-100"
-  else
-    fail "plan-phase refusal: no phase.plan.failed.CTL-100 line in event log"
-  fi
+	PLAN_EVT_LINE=$(grep '"phase.plan.failed.CTL-100"' "$PLAN_EVT_FILE" | head -1)
+	if [[ -n $PLAN_EVT_LINE ]]; then
+		pass "plan-phase refusal emits phase.plan.failed.CTL-100"
+	else
+		fail "plan-phase refusal: no phase.plan.failed.CTL-100 line in event log"
+	fi
 fi
 
 # CTL-494 Phase 1: emit-complete failing must not mask the refusal exit code.
@@ -266,8 +272,8 @@ fi
 export CATALYST_DIR="/dev/null/cannot-create-here"
 rm -f "${ORCH_DIR}/workers/CTL-100/phase-research.json"
 "$DISPATCH" --phase research --ticket CTL-100 \
-  --orch-dir "$ORCH_DIR" --orch-id orch-test \
-  >"${TEST_DIR}/research-emit-fail.out" 2>"${TEST_DIR}/research-emit-fail.err"
+	--orch-dir "$ORCH_DIR" --orch-id orch-test \
+	>"${TEST_DIR}/research-emit-fail.out" 2>"${TEST_DIR}/research-emit-fail.err"
 RC_EMIT_FAIL=$?
 STATUS_EMIT_FAIL=$(jq -r '.status' "${TEST_DIR}/research-emit-fail.out" 2>/dev/null || echo "")
 assert_eq "2" "$RC_EMIT_FAIL" "emit-complete failure does not mask exit 2"
@@ -285,10 +291,10 @@ mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
 
 # Form A: phase-plan prose form — lowercase, ticket at end, no descriptive suffix.
 touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-18-ctl-100.md"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-100 \
-    --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
-    >"${TEST_DIR}/glob-a.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
+		>"${TEST_DIR}/glob-a.out" 2>/dev/null)
 STATUS_A=$(jq -r '.status' "${TEST_DIR}/glob-a.out")
 assert_eq "dispatched" "$STATUS_A" "Form A: lowercase ticket at end is accepted"
 
@@ -298,10 +304,10 @@ rm -f "${ORCH_DIR}/workers/CTL-100/phase-implement.json"
 
 # Form B: canonical create-plan form — uppercase ticket + descriptive suffix.
 touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-18-CTL-100-some-descriptive-name.md"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-100 \
-    --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
-    >"${TEST_DIR}/glob-b.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
+		>"${TEST_DIR}/glob-b.out" 2>/dev/null)
 STATUS_B=$(jq -r '.status' "${TEST_DIR}/glob-b.out")
 assert_eq "dispatched" "$STATUS_B" "Form B: uppercase ticket + descriptive suffix is accepted"
 
@@ -311,10 +317,10 @@ rm -f "${ORCH_DIR}/workers/CTL-100/phase-implement.json"
 
 # Form C: uppercase + suffix-style "-plan".
 touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-17-CTL-100-plan.md"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-100 \
-    --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
-    >"${TEST_DIR}/glob-c.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
+		>"${TEST_DIR}/glob-c.out" 2>/dev/null)
 STATUS_C=$(jq -r '.status' "${TEST_DIR}/glob-c.out")
 assert_eq "dispatched" "$STATUS_C" "Form C: uppercase ticket + -plan suffix is accepted"
 
@@ -325,20 +331,20 @@ rm -f "${ORCH_DIR}/workers/CTL-100/phase-implement.json"
 # Form D: lookalike file for a DIFFERENT ticket must NOT match CTL-100.
 # Guards against an overly-greedy fix that strips the ticket constraint.
 touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-18-CTL-200-something.md"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-100 \
-    --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
-    >"${TEST_DIR}/glob-d.out" 2>"${TEST_DIR}/glob-d.err" )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run \
+		>"${TEST_DIR}/glob-d.out" 2>"${TEST_DIR}/glob-d.err")
 RC_D=$?
 STATUS_D=$(jq -r '.status' "${TEST_DIR}/glob-d.out")
-assert_eq "2"       "$RC_D"     "Form D: different-ticket plan file does NOT satisfy CTL-100 gate"
+assert_eq "2" "$RC_D" "Form D: different-ticket plan file does NOT satisfy CTL-100 gate"
 assert_eq "refused" "$STATUS_D" "Form D: stdout JSON status = refused"
 
 # ─── Test 6: dispatcher resolves model from config (default + override paths)
 echo ""
 echo "Test 6: dispatcher resolves model from config (default and override)"
 fresh_env t6
-cat > "${CONFIG_DIR}/config.json" <<EOF
+cat >"${CONFIG_DIR}/config.json" <<EOF
 {
   "catalyst": {
     "orchestration": {
@@ -356,31 +362,31 @@ EOF
 mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
 touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-16-ctl-100.md"
 # Default path: ticket = CTL-100 → models.implement = sonnet
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >"${TEST_DIR}/m1.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/m1.out" 2>/dev/null)
 MODEL_DEFAULT=$(jq -r '.model' "${TEST_DIR}/m1.out")
 assert_eq "sonnet" "$MODEL_DEFAULT" "models.implement default → sonnet"
 
 # Override path: ticket = CTL-999 → modelOverrides.implement.CTL-999 = opus
 touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-16-ctl-999.md"
 mkdir -p "${ORCH_DIR}/workers/CTL-999"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-999 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >"${TEST_DIR}/m2.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-999 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/m2.out" 2>/dev/null)
 MODEL_OVERRIDE=$(jq -r '.model' "${TEST_DIR}/m2.out")
 assert_eq "opus" "$MODEL_OVERRIDE" "modelOverrides.implement.CTL-999 beats default"
 
 # CLI flag wins both
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --model haiku \
-    >"${TEST_DIR}/m3.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --model haiku \
+		>"${TEST_DIR}/m3.out" 2>/dev/null)
 mkdir -p "${ORCH_DIR}/workers/CTL-100"
 # Clean prior signal so this isn't idempotent no-op
 rm -f "${ORCH_DIR}/workers/CTL-100/phase-implement.json"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --model haiku \
-    >"${TEST_DIR}/m3.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --model haiku \
+		>"${TEST_DIR}/m3.out" 2>/dev/null)
 MODEL_CLI=$(jq -r '.model' "${TEST_DIR}/m3.out")
 assert_eq "haiku" "$MODEL_CLI" "CLI --model beats config"
 
@@ -388,7 +394,7 @@ assert_eq "haiku" "$MODEL_CLI" "CLI --model beats config"
 echo ""
 echo "Test 7: dispatcher resolves turn cap from config"
 fresh_env t7
-cat > "${CONFIG_DIR}/config.json" <<EOF
+cat >"${CONFIG_DIR}/config.json" <<EOF
 {
   "catalyst": {
     "orchestration": {
@@ -399,31 +405,31 @@ cat > "${CONFIG_DIR}/config.json" <<EOF
   }
 }
 EOF
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >"${TEST_DIR}/tc.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/tc.out" 2>/dev/null)
 TC_CONFIG=$(jq -r '.turnCap' "${TEST_DIR}/tc.out")
 assert_eq "99" "$TC_CONFIG" "config turnCaps.triage = 99 applied"
 
 # CLI overrides config
 rm -f "${ORCH_DIR}/workers/CTL-100/phase-triage.json"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --turn-cap 42 \
-    >"${TEST_DIR}/tc2.out" 2>/dev/null )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --turn-cap 42 \
+		>"${TEST_DIR}/tc2.out" 2>/dev/null)
 TC_CLI=$(jq -r '.turnCap' "${TEST_DIR}/tc2.out")
 assert_eq "42" "$TC_CLI" "CLI --turn-cap beats config"
 
 # Fallback per-phase default
 fresh_env t7b
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase research --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >"${TEST_DIR}/tc3.out" 2>"${TEST_DIR}/tc3.err" )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase research --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/tc3.out" 2>"${TEST_DIR}/tc3.err")
 RC=$?
 # research requires triage.json — create it first then re-dispatch
-echo '{"ticket":"CTL-100","status":"done"}' > "${WORKER_DIR}/triage.json"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase research --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >"${TEST_DIR}/tc3.out" 2>/dev/null )
+echo '{"ticket":"CTL-100","status":"done"}' >"${WORKER_DIR}/triage.json"
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase research --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/tc3.out" 2>/dev/null)
 TC_FALLBACK=$(jq -r '.turnCap' "${TEST_DIR}/tc3.out")
 assert_eq "35" "$TC_FALLBACK" "per-phase default for research is 35"
 
@@ -442,9 +448,9 @@ LOG=$(cat "$CLAUDE_STUB_LOG")
 # the env var name is the same regardless and the env carries the orch dir
 # the phase agent uses to resolve all other paths.)
 assert_contains "$LOG" "CATALYST_ORCHESTRATOR_DIR=" "env propagates CATALYST_ORCHESTRATOR_DIR"
-assert_contains "$LOG" "CATALYST_ORCHESTRATOR_ID="  "env propagates CATALYST_ORCHESTRATOR_ID"
-assert_contains "$LOG" "CATALYST_PHASE=triage"      "env propagates CATALYST_PHASE"
-assert_contains "$LOG" "CATALYST_TICKET=CTL-100"    "env propagates CATALYST_TICKET"
+assert_contains "$LOG" "CATALYST_ORCHESTRATOR_ID=" "env propagates CATALYST_ORCHESTRATOR_ID"
+assert_contains "$LOG" "CATALYST_PHASE=triage" "env propagates CATALYST_PHASE"
+assert_contains "$LOG" "CATALYST_TICKET=CTL-100" "env propagates CATALYST_TICKET"
 
 # ─── Test 9: BG_JOB_ID parser extracts hex from realistic `claude --bg` output
 # Regression guard for CTL-490 Bug 2. The bug was `awk 'NR==1 {print $1}'`
@@ -458,7 +464,7 @@ fresh_env t9
 # Override the stub with one that emits the verbatim format from CTL-490's
 # forensic transcript. The hex token here is the real job ID from that
 # failed run — using it makes the regression report grep-able to the ticket.
-cat > "${STUB_DIR}/claude" <<'STUB'
+cat >"${STUB_DIR}/claude" <<'STUB'
 #!/usr/bin/env bash
 cat <<EOF
 backgrounded · f124220a
@@ -480,20 +486,20 @@ assert_eq "f124220a" "$JOB_IN_STDOUT" "parser does NOT capture the literal word 
 echo ""
 echo "Test 10: OTEL_RESOURCE_ATTRIBUTES composed when projectKey is set"
 fresh_env t10
-cat > "${CONFIG_DIR}/config.json" <<EOF
+cat >"${CONFIG_DIR}/config.json" <<EOF
 {
   "catalyst": {
     "projectKey": "test-proj"
   }
 }
 EOF
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >/dev/null 2>&1 )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" \
-  "OTEL_RESOURCE_ATTRIBUTES=project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100" \
-  "OTEL attrs composed with projectKey + tier-2 branch fallback"
+	"OTEL_RESOURCE_ATTRIBUTES=project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100" \
+	"OTEL attrs composed with projectKey + tier-2 branch fallback"
 
 # ─── Test 11: OTEL_RESOURCE_ATTRIBUTES three-attr form when projectKey absent
 echo ""
@@ -502,29 +508,29 @@ fresh_env t11
 # Dispatch from a directory with NO .catalyst/config.json — TEST_DIR/proj has
 # an empty .catalyst dir created by fresh_env but no config.json file.
 rm -rf "${CONFIG_DIR}"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >/dev/null 2>&1 )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" \
-  "OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test" \
-  "OTEL attrs three-attr form when no projectKey"
-if [[ "$LOG" == *"OTEL_RESOURCE_ATTRIBUTES="*"project="* ]]; then
-  fail "OTEL attrs three-attr form must omit project="
+	"OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test" \
+	"OTEL attrs three-attr form when no projectKey"
+if [[ $LOG == *"OTEL_RESOURCE_ATTRIBUTES="*"project="* ]]; then
+	fail "OTEL attrs three-attr form must omit project="
 else
-  pass "OTEL attrs three-attr form omits project="
+	pass "OTEL attrs three-attr form omits project="
 fi
-if [[ "$LOG" == *"OTEL_RESOURCE_ATTRIBUTES="*"branch="* ]]; then
-  fail "OTEL attrs three-attr form must omit branch="
+if [[ $LOG == *"OTEL_RESOURCE_ATTRIBUTES="*"branch="* ]]; then
+	fail "OTEL attrs three-attr form must omit branch="
 else
-  pass "OTEL attrs three-attr form omits branch="
+	pass "OTEL attrs three-attr form omits branch="
 fi
 
 # ─── Test 12: tier-1 authoritative branch via git -C beats tier-2 constructed name
 echo ""
 echo "Test 12: tier-1 git -C branch resolution wins over tier-2 constructed name"
 fresh_env t12
-cat > "${CONFIG_DIR}/config.json" <<EOF
+cat >"${CONFIG_DIR}/config.json" <<EOF
 {
   "catalyst": {
     "projectKey": "test-proj"
@@ -536,25 +542,25 @@ HOME_FIXTURE="${TEST_DIR}/home"
 WORKER_WT="${HOME_FIXTURE}/catalyst/wt/test-proj/orch-test-CTL-100"
 mkdir -p "$WORKER_WT"
 (
-  cd "$WORKER_WT"
-  git init -q --initial-branch=main
-  git config user.email "test@example.com"
-  git config user.name "Test"
-  git commit --allow-empty -q -m "init"
-  git checkout -q -b bespoke-branch
+	cd "$WORKER_WT"
+	git init -q --initial-branch=main
+	git config user.email "test@example.com"
+	git config user.name "Test"
+	git commit --allow-empty -q -m "init"
+	git checkout -q -b bespoke-branch
 )
 HOME="$HOME_FIXTURE" \
-  bash -c "cd '${TEST_DIR}/proj' && '$DISPATCH' --phase triage --ticket CTL-100 --orch-dir '$ORCH_DIR' --orch-id orch-test >/dev/null 2>&1"
+	bash -c "cd '${TEST_DIR}/proj' && '$DISPATCH' --phase triage --ticket CTL-100 --orch-dir '$ORCH_DIR' --orch-id orch-test >/dev/null 2>&1"
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" ",branch=bespoke-branch" \
-  "tier-1 git branch (bespoke-branch) wins over tier-2 fallback"
+	"tier-1 git branch (bespoke-branch) wins over tier-2 fallback"
 
 # ─── Test 13 (CTL-492 follow-up): tier-1 → tier-2 fall-through when worker-wt
 #                                  path exists but is not a git repo
 echo ""
 echo "Test 13: tier-2 wins when worker-wt path exists without a .git entry"
 fresh_env t13
-cat > "${CONFIG_DIR}/config.json" <<EOF
+cat >"${CONFIG_DIR}/config.json" <<EOF
 {
   "catalyst": {
     "projectKey": "test-proj"
@@ -567,35 +573,35 @@ HOME_FIXTURE="${TEST_DIR}/home"
 # and left a bare directory.
 mkdir -p "${HOME_FIXTURE}/catalyst/wt/test-proj/orch-test-CTL-100"
 HOME="$HOME_FIXTURE" \
-  bash -c "cd '${TEST_DIR}/proj' && '$DISPATCH' --phase triage --ticket CTL-100 --orch-dir '$ORCH_DIR' --orch-id orch-test >/dev/null 2>&1"
+	bash -c "cd '${TEST_DIR}/proj' && '$DISPATCH' --phase triage --ticket CTL-100 --orch-dir '$ORCH_DIR' --orch-id orch-test >/dev/null 2>&1"
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" ",branch=orch-test-CTL-100" \
-  "tier-2 constructed branch used when worker-wt has no .git"
+	"tier-2 constructed branch used when worker-wt has no .git"
 
 # ─── Test 14: --dry-run JSON env array contains the OTEL entry
 echo ""
 echo "Test 14: --dry-run JSON env array carries OTEL_RESOURCE_ATTRIBUTES"
 fresh_env t14
-cat > "${CONFIG_DIR}/config.json" <<EOF
+cat >"${CONFIG_DIR}/config.json" <<EOF
 {
   "catalyst": {
     "projectKey": "test-proj"
   }
 }
 EOF
-DRY=$( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run 2>/dev/null )
+DRY=$(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run 2>/dev/null)
 OTEL_ENTRY=$(echo "$DRY" | jq -r '.env[] | select(startswith("OTEL_RESOURCE_ATTRIBUTES="))')
 assert_eq \
-  "OTEL_RESOURCE_ATTRIBUTES=project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage" \
-  "$OTEL_ENTRY" \
-  "dry-run JSON env array carries the composed OTEL attribute string"
+	"OTEL_RESOURCE_ATTRIBUTES=project=test-proj,linear.key=CTL-100,catalyst.orchestration=orch-test,branch=orch-test-CTL-100,task.type=phase-triage" \
+	"$OTEL_ENTRY" \
+	"dry-run JSON env array carries the composed OTEL attribute string"
 
 # ─── Test 15 (CTL-495): task.type=phase-<phase> appended to OTEL attrs
 echo ""
 echo "Test 15: task.type=phase-<phase> is always present in OTEL_RESOURCE_ATTRIBUTES"
 fresh_env t15
-cat > "${CONFIG_DIR}/config.json" <<EOF
+cat >"${CONFIG_DIR}/config.json" <<EOF
 {
   "catalyst": {
     "projectKey": "test-proj"
@@ -606,16 +612,16 @@ EOF
 # implement requires a plan artifact under thoughts/shared/plans/.
 mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
 touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-18-ctl-100.md"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >/dev/null 2>&1 )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" ",task.type=phase-implement" \
-  "task.type=phase-implement appended with projectKey present"
+	"task.type=phase-implement appended with projectKey present"
 
 # Case B: phase value flows through verbatim — monitor-deploy (the longest, hyphenated).
 fresh_env t15b
-cat > "${CONFIG_DIR}/config.json" <<EOF
+cat >"${CONFIG_DIR}/config.json" <<EOF
 {
   "catalyst": {
     "projectKey": "test-proj"
@@ -624,24 +630,24 @@ cat > "${CONFIG_DIR}/config.json" <<EOF
 EOF
 # monitor-deploy requires phase-monitor-merge.json signal.
 echo '{"ticket":"CTL-100","status":"done","pr":{"mergeCommitSha":"deadbeef"}}' \
-  > "${WORKER_DIR}/phase-monitor-merge.json"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase monitor-deploy --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >/dev/null 2>&1 )
+	>"${WORKER_DIR}/phase-monitor-merge.json"
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase monitor-deploy --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" ",task.type=phase-monitor-deploy" \
-  "task.type=phase-monitor-deploy preserves hyphenated phase name"
+	"task.type=phase-monitor-deploy preserves hyphenated phase name"
 
 # Case C: even without projectKey (short form), task.type is still present.
 fresh_env t15c
 rm -rf "${CONFIG_DIR}"
-( cd "${TEST_DIR}/proj" && \
-  "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-    >/dev/null 2>&1 )
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" \
-  "OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test,task.type=phase-triage" \
-  "task.type appended even when projectKey absent (short form)"
+	"OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,catalyst.orchestration=orch-test,task.type=phase-triage" \
+	"task.type appended even when projectKey absent (short form)"
 
 # ─── CTL-511: claude --bg launch failure → signal stalled + phase.*.failed ───
 # A launch failure must leave the signal at status="stalled" with NO
@@ -656,17 +662,17 @@ export CLAUDE_STUB_EXIT=1
 export CATALYST_DIR="${TEST_DIR}/catalyst-events"
 mkdir -p "${CATALYST_DIR}/events"
 "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-  >"${TEST_DIR}/t16.out" 2>"${TEST_DIR}/t16.err"
+	>"${TEST_DIR}/t16.out" 2>"${TEST_DIR}/t16.err"
 RC=$?
 assert_eq "1" "$RC" "dispatch exits 1 on claude --bg launch failure"
 SIGNAL="${WORKER_DIR}/phase-triage.json"
 assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "launch failure leaves signal at stalled"
 assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" \
-  "launch-failure signal has no failureReason (Loop 2 redispatch-eligible)"
+	"launch-failure signal has no failureReason (Loop 2 redispatch-eligible)"
 if grep -rqs '"phase.triage.failed.CTL-100"' "${CATALYST_DIR}/events/"; then
-  pass "launch failure emits phase.triage.failed.CTL-100 event"
+	pass "launch failure emits phase.triage.failed.CTL-100 event"
 else
-  fail "no phase.triage.failed.CTL-100 event on launch failure"
+	fail "no phase.triage.failed.CTL-100 event on launch failure"
 fi
 unset CLAUDE_STUB_EXIT CATALYST_DIR
 
@@ -683,15 +689,15 @@ chmod +x "${STUB_DIR}/claude"
 export CATALYST_DIR="${TEST_DIR}/catalyst-events"
 mkdir -p "${CATALYST_DIR}/events"
 "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
-  >"${TEST_DIR}/t17.out" 2>"${TEST_DIR}/t17.err" || true
+	>"${TEST_DIR}/t17.out" 2>"${TEST_DIR}/t17.err" || true
 SIGNAL="${WORKER_DIR}/phase-triage.json"
 assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "empty job id leaves signal at stalled"
 assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" \
-  "empty-job-id signal has no failureReason (Loop 2 redispatch-eligible)"
+	"empty-job-id signal has no failureReason (Loop 2 redispatch-eligible)"
 if grep -rqs '"phase.triage.failed.CTL-100"' "${CATALYST_DIR}/events/"; then
-  pass "empty job id emits phase.triage.failed.CTL-100 event"
+	pass "empty job id emits phase.triage.failed.CTL-100 event"
 else
-  fail "no phase.triage.failed.CTL-100 event on empty job id"
+	fail "no phase.triage.failed.CTL-100 event on empty job id"
 fi
 unset CATALYST_DIR
 
@@ -708,6 +714,6 @@ echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then
-  exit 1
+	exit 1
 fi
 exit 0

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -19,63 +19,72 @@ PASSES=0
 SCRATCH="$(mktemp -d -t phase-agent-emit-test-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
-pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
-
-assert_eq() {
-  local expected="$1" actual="$2" label="$3"
-  if [[ "$expected" == "$actual" ]]; then
-    pass "$label"
-  else
-    fail "$label — expected '$expected', got '$actual'"
-  fi
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
 }
 
-if [[ ! -x "$EMIT_SCRIPT" ]]; then
-  echo "FATAL: $EMIT_SCRIPT not found or not executable" >&2
-  exit 1
+assert_eq() {
+	local expected="$1" actual="$2" label="$3"
+	if [[ $expected == "$actual" ]]; then
+		pass "$label"
+	else
+		fail "$label — expected '$expected', got '$actual'"
+	fi
+}
+
+if [[ ! -x $EMIT_SCRIPT ]]; then
+	echo "FATAL: $EMIT_SCRIPT not found or not executable" >&2
+	exit 1
 fi
 
 # Each test gets a fresh CATALYST_DIR and ORCH_DIR. The emit script writes to
 # $CATALYST_DIR/events/YYYY-MM.jsonl (canonical_jsonl_append uses CATALYST_DIR
 # transitively via the EVENTS_DIR derivation inside the script).
 fresh_env() {
-  local tag="$1"
-  TEST_DIR="${SCRATCH}/${tag}"
-  mkdir -p "${TEST_DIR}/catalyst/events"
-  mkdir -p "${TEST_DIR}/orch/workers/CTL-100"
-  export CATALYST_DIR="${TEST_DIR}/catalyst"
-  export CATALYST_ORCHESTRATOR_DIR="${TEST_DIR}/orch"
-  export CATALYST_ORCHESTRATOR_ID="orch-test"
-  export CATALYST_SESSION_ID="sess_test_${tag}"
+	local tag="$1"
+	TEST_DIR="${SCRATCH}/${tag}"
+	mkdir -p "${TEST_DIR}/catalyst/events"
+	mkdir -p "${TEST_DIR}/orch/workers/CTL-100"
+	export CATALYST_DIR="${TEST_DIR}/catalyst"
+	export CATALYST_ORCHESTRATOR_DIR="${TEST_DIR}/orch"
+	export CATALYST_ORCHESTRATOR_ID="orch-test"
+	export CATALYST_SESSION_ID="sess_test_${tag}"
 }
 
 # Read the phase event line from this test's event log. catalyst-session.sh end
 # (which the emit script also invokes) appends session.ended + agent.checkout
 # lines after, so we grep for the phase event prefix instead of tailing.
 read_event_line() {
-  local month
-  month=$(date -u +%Y-%m)
-  local logfile="${CATALYST_DIR}/events/${month}.jsonl"
-  [[ -f "$logfile" ]] || { echo ""; return 1; }
-  grep -F '"event.name":"phase.' "$logfile" | tail -n 1
+	local month
+	month=$(date -u +%Y-%m)
+	local logfile="${CATALYST_DIR}/events/${month}.jsonl"
+	[[ -f $logfile ]] || {
+		echo ""
+		return 1
+	}
+	grep -F '"event.name":"phase.' "$logfile" | tail -n 1
 }
 
 echo "Test 1: phase-complete emitter writes the canonical event shape"
 fresh_env t1
 "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
 LINE=$(read_event_line)
-if [[ -z "$LINE" ]]; then
-  fail "Test 1: no event line emitted"
+if [[ -z $LINE ]]; then
+	fail "Test 1: no event line emitted"
 else
-  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
-  assert_eq "phase.research.complete.CTL-100" "$EVENT_NAME" "event.name matches phase.<name>.complete.<ticket>"
-  HAS_ATTRS=$(echo "$LINE" | jq -r 'has("attributes")')
-  assert_eq "true" "$HAS_ATTRS" "canonical shape — attributes present"
-  HAS_BODY=$(echo "$LINE" | jq -r 'has("body")')
-  assert_eq "true" "$HAS_BODY" "canonical shape — body present"
-  SEVERITY=$(echo "$LINE" | jq -r '.severityText')
-  assert_eq "INFO" "$SEVERITY" "complete → INFO severity"
+	EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+	assert_eq "phase.research.complete.CTL-100" "$EVENT_NAME" "event.name matches phase.<name>.complete.<ticket>"
+	HAS_ATTRS=$(echo "$LINE" | jq -r 'has("attributes")')
+	assert_eq "true" "$HAS_ATTRS" "canonical shape — attributes present"
+	HAS_BODY=$(echo "$LINE" | jq -r 'has("body")')
+	assert_eq "true" "$HAS_BODY" "canonical shape — body present"
+	SEVERITY=$(echo "$LINE" | jq -r '.severityText')
+	assert_eq "INFO" "$SEVERITY" "complete → INFO severity"
 fi
 
 echo ""
@@ -89,10 +98,10 @@ WORKER=$(echo "$LINE" | jq -r '.attributes."catalyst.worker.ticket"')
 LINEAR=$(echo "$LINE" | jq -r '.attributes."linear.issue.identifier"')
 PAYLOAD_PHASE=$(echo "$LINE" | jq -r '.body.payload.phase')
 assert_eq "sess_test_t2" "$SESS" "catalyst.session.id propagated from env"
-assert_eq "orch-test"    "$ORCH" "catalyst.orchestrator.id propagated from env"
-assert_eq "CTL-200"      "$WORKER" "catalyst.worker.ticket = ticket"
-assert_eq "CTL-200"      "$LINEAR" "linear.issue.identifier = ticket"
-assert_eq "implement"    "$PAYLOAD_PHASE" "body.payload.phase = phase name"
+assert_eq "orch-test" "$ORCH" "catalyst.orchestrator.id propagated from env"
+assert_eq "CTL-200" "$WORKER" "catalyst.worker.ticket = ticket"
+assert_eq "CTL-200" "$LINEAR" "linear.issue.identifier = ticket"
+assert_eq "implement" "$PAYLOAD_PHASE" "body.payload.phase = phase name"
 
 echo ""
 echo "Test 3: failure variant uses .failed suffix and includes failure_reason"
@@ -113,7 +122,7 @@ echo ""
 echo "Test 4 (bonus): signal file is updated to status=done on complete"
 fresh_env t4
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
-echo '{"status":"in-progress","ticket":"CTL-100","phase":"research"}' > "$SIGNAL"
+echo '{"status":"in-progress","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
 "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
 NEW_STATUS=$(jq -r '.status' "$SIGNAL")
 HAS_COMPLETED=$(jq -r 'has("completedAt")' "$SIGNAL")
@@ -127,33 +136,33 @@ echo ""
 echo "Test 5 (CTL-484): --status turn-cap-exhausted is accepted and emits a distinct event"
 fresh_env t5
 "$EMIT_SCRIPT" --phase implement --ticket CTL-400 --status turn-cap-exhausted \
-  --reason "turn cap hit (75)" \
-  --handoff-path "thoughts/shared/handoffs/CTL-400/2026-05-17_00-00-00_turn-cap-continuation.md" \
-  >/dev/null 2>&1
+	--reason "turn cap hit (75)" \
+	--handoff-path "thoughts/shared/handoffs/CTL-400/2026-05-17_00-00-00_turn-cap-continuation.md" \
+	>/dev/null 2>&1
 LINE=$(read_event_line)
-if [[ -z "$LINE" ]]; then
-  fail "Test 5: no event line emitted"
+if [[ -z $LINE ]]; then
+	fail "Test 5: no event line emitted"
 else
-  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
-  PAYLOAD_STATUS=$(echo "$LINE" | jq -r '.body.payload.status')
-  PAYLOAD_HANDOFF=$(echo "$LINE" | jq -r '.body.payload.handoff_path')
-  PAYLOAD_REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason')
-  SEVERITY=$(echo "$LINE" | jq -r '.severityText')
-  assert_eq "phase.implement.turn-cap-exhausted.CTL-400" "$EVENT_NAME" "event.name uses .turn-cap-exhausted suffix"
-  assert_eq "turn-cap-exhausted" "$PAYLOAD_STATUS" "body.payload.status = turn-cap-exhausted"
-  assert_eq "thoughts/shared/handoffs/CTL-400/2026-05-17_00-00-00_turn-cap-continuation.md" "$PAYLOAD_HANDOFF" "body.payload.handoff_path propagated"
-  assert_eq "turn cap hit (75)" "$PAYLOAD_REASON" "body.payload.failure_reason still carried"
-  assert_eq "WARN" "$SEVERITY" "turn-cap-exhausted → WARN severity"
+	EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+	PAYLOAD_STATUS=$(echo "$LINE" | jq -r '.body.payload.status')
+	PAYLOAD_HANDOFF=$(echo "$LINE" | jq -r '.body.payload.handoff_path')
+	PAYLOAD_REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason')
+	SEVERITY=$(echo "$LINE" | jq -r '.severityText')
+	assert_eq "phase.implement.turn-cap-exhausted.CTL-400" "$EVENT_NAME" "event.name uses .turn-cap-exhausted suffix"
+	assert_eq "turn-cap-exhausted" "$PAYLOAD_STATUS" "body.payload.status = turn-cap-exhausted"
+	assert_eq "thoughts/shared/handoffs/CTL-400/2026-05-17_00-00-00_turn-cap-continuation.md" "$PAYLOAD_HANDOFF" "body.payload.handoff_path propagated"
+	assert_eq "turn cap hit (75)" "$PAYLOAD_REASON" "body.payload.failure_reason still carried"
+	assert_eq "WARN" "$SEVERITY" "turn-cap-exhausted → WARN severity"
 fi
 
 echo ""
 echo "Test 6 (CTL-484): signal file is updated to status=turn-cap-exhausted and gains handoffPath"
 fresh_env t6
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
-echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' > "$SIGNAL"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' >"$SIGNAL"
 HANDOFF="thoughts/shared/handoffs/CTL-100/2026-05-17_01-23-45_turn-cap-continuation.md"
 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status turn-cap-exhausted \
-  --reason "turn cap hit (75)" --handoff-path "$HANDOFF" >/dev/null 2>&1
+	--reason "turn cap hit (75)" --handoff-path "$HANDOFF" >/dev/null 2>&1
 NEW_STATUS=$(jq -r '.status' "$SIGNAL")
 HANDOFF_FIELD=$(jq -r '.handoffPath' "$SIGNAL")
 REASON_FIELD=$(jq -r '.failureReason' "$SIGNAL")
@@ -169,29 +178,29 @@ echo "Test 7 (CTL-484 parity): lib/phase-emit-complete.sh accepts --status turn-
 # can opt into the cap-exit pattern without code changes.
 fresh_env t7
 LIB_HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
-if [[ ! -f "$LIB_HELPER" ]]; then
-  fail "Test 7: lib helper missing — expected at $LIB_HELPER"
+if [[ ! -f $LIB_HELPER ]]; then
+	fail "Test 7: lib helper missing — expected at $LIB_HELPER"
 else
-  # Override CATALYST_EVENTS_FILE so the lib writes to a known file.
-  EVENTS_T7="${TEST_DIR}/lib-emit.jsonl"
-  CATALYST_EVENTS_FILE="$EVENTS_T7" bash -c "
+	# Override CATALYST_EVENTS_FILE so the lib writes to a known file.
+	EVENTS_T7="${TEST_DIR}/lib-emit.jsonl"
+	CATALYST_EVENTS_FILE="$EVENTS_T7" bash -c "
     set -e
     . '$LIB_HELPER'
     emit_phase_complete --phase triage --ticket CTL-500 \
       --status turn-cap-exhausted --reason 'turn cap hit (10)'
   " 2>/dev/null
-  if [[ -s "$EVENTS_T7" ]]; then
-    EVENT_NAME=$(jq -r '.attributes."event.name"' "$EVENTS_T7" | tail -n 1)
-    SEVERITY=$(jq -r '.severityText' "$EVENTS_T7" | tail -n 1)
-    MSG=$(jq -r '.body.message' "$EVENTS_T7" | tail -n 1)
-    assert_eq "phase.triage.turn-cap-exhausted.CTL-500" "$EVENT_NAME" "lib emits .turn-cap-exhausted suffix"
-    assert_eq "WARN" "$SEVERITY" "lib uses WARN severity for turn-cap-exhausted"
-    # The lib uses --reason as the message when supplied, so the default-message
-    # branch only fires when --reason is empty. Verify the message echoes the reason.
-    assert_eq "turn cap hit (10)" "$MSG" "lib message echoes --reason"
-  else
-    fail "Test 7: lib emitted no event line"
-  fi
+	if [[ -s $EVENTS_T7 ]]; then
+		EVENT_NAME=$(jq -r '.attributes."event.name"' "$EVENTS_T7" | tail -n 1)
+		SEVERITY=$(jq -r '.severityText' "$EVENTS_T7" | tail -n 1)
+		MSG=$(jq -r '.body.message' "$EVENTS_T7" | tail -n 1)
+		assert_eq "phase.triage.turn-cap-exhausted.CTL-500" "$EVENT_NAME" "lib emits .turn-cap-exhausted suffix"
+		assert_eq "WARN" "$SEVERITY" "lib uses WARN severity for turn-cap-exhausted"
+		# The lib uses --reason as the message when supplied, so the default-message
+		# branch only fires when --reason is empty. Verify the message echoes the reason.
+		assert_eq "turn cap hit (10)" "$MSG" "lib message echoes --reason"
+	else
+		fail "Test 7: lib emitted no event line"
+	fi
 fi
 
 # ─── CTL-511: --no-signal-update event-only mode ────────────────────────────
@@ -205,16 +214,16 @@ fresh_env t8
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-plan.json"
 # Pre-seed the signal as orchestrate-healthcheck / the launch-failure path
 # would leave it: status:"stalled", no failureReason.
-echo '{"ticket":"CTL-100","phase":"plan","status":"stalled"}' > "$SIGNAL"
+echo '{"ticket":"CTL-100","phase":"plan","status":"stalled"}' >"$SIGNAL"
 BEFORE=$(cat "$SIGNAL")
 "$EMIT_SCRIPT" --phase plan --ticket CTL-100 --status failed \
-  --reason launch-failed --no-signal-update >/dev/null 2>&1
+	--reason launch-failed --no-signal-update >/dev/null 2>&1
 LINE=$(read_event_line)
-if [[ -z "$LINE" ]]; then
-  fail "Test 8: --no-signal-update emitted no event line"
+if [[ -z $LINE ]]; then
+	fail "Test 8: --no-signal-update emitted no event line"
 else
-  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
-  assert_eq "phase.plan.failed.CTL-100" "$EVENT_NAME" "--no-signal-update still emits phase.<name>.failed event"
+	EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+	assert_eq "phase.plan.failed.CTL-100" "$EVENT_NAME" "--no-signal-update still emits phase.<name>.failed event"
 fi
 assert_eq "$BEFORE" "$(cat "$SIGNAL")" "--no-signal-update leaves the signal file byte-identical"
 assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "--no-signal-update keeps signal status at stalled"
@@ -224,7 +233,7 @@ echo ""
 echo "Test 9 (CTL-511 regression): default mode (no flag) still mutates the signal file"
 fresh_env t9
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-plan.json"
-echo '{"ticket":"CTL-100","phase":"plan","status":"running"}' > "$SIGNAL"
+echo '{"ticket":"CTL-100","phase":"plan","status":"running"}' >"$SIGNAL"
 "$EMIT_SCRIPT" --phase plan --ticket CTL-100 --status failed >/dev/null 2>&1
 assert_eq "failed" "$(jq -r '.status' "$SIGNAL")" "default mode still flips signal status to failed"
 
@@ -232,6 +241,6 @@ echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then
-  exit 1
+	exit 1
 fi
 exit 0

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -194,6 +194,40 @@ else
   fi
 fi
 
+# ─── CTL-511: --no-signal-update event-only mode ────────────────────────────
+# Phases 2 and 3 of CTL-511 need to wake the orchestrator with a
+# phase.<name>.failed event WITHOUT mutating the signal file — the signal must
+# stay at status:"stalled" (no failureReason) so orchestrate-revive Loop 2
+# redispatches it. --no-signal-update is that shared primitive.
+echo ""
+echo "Test 8 (CTL-511): --no-signal-update emits the event but leaves the signal file untouched"
+fresh_env t8
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-plan.json"
+# Pre-seed the signal as orchestrate-healthcheck / the launch-failure path
+# would leave it: status:"stalled", no failureReason.
+echo '{"ticket":"CTL-100","phase":"plan","status":"stalled"}' > "$SIGNAL"
+BEFORE=$(cat "$SIGNAL")
+"$EMIT_SCRIPT" --phase plan --ticket CTL-100 --status failed \
+  --reason launch-failed --no-signal-update >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z "$LINE" ]]; then
+  fail "Test 8: --no-signal-update emitted no event line"
+else
+  EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+  assert_eq "phase.plan.failed.CTL-100" "$EVENT_NAME" "--no-signal-update still emits phase.<name>.failed event"
+fi
+assert_eq "$BEFORE" "$(cat "$SIGNAL")" "--no-signal-update leaves the signal file byte-identical"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "--no-signal-update keeps signal status at stalled"
+assert_eq "false" "$(jq -r 'has("failureReason")' "$SIGNAL")" "--no-signal-update does not write failureReason"
+
+echo ""
+echo "Test 9 (CTL-511 regression): default mode (no flag) still mutates the signal file"
+fresh_env t9
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-plan.json"
+echo '{"ticket":"CTL-100","phase":"plan","status":"running"}' > "$SIGNAL"
+"$EMIT_SCRIPT" --phase plan --ticket CTL-100 --status failed >/dev/null 2>&1
+assert_eq "failed" "$(jq -r '.status' "$SIGNAL")" "default mode still flips signal status to failed"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/orchestrate-healthcheck
+++ b/plugins/dev/scripts/orchestrate-healthcheck
@@ -52,29 +52,56 @@ DRY_RUN=0
 JOBS_ROOT="${CATALYST_HEALTHCHECK_JOBS_ROOT:-${HOME}/.claude/jobs}"
 
 usage() {
-  sed -n '2,35p' "$0"
-  exit "${1:-1}"
+	sed -n '2,35p' "$0"
+	exit "${1:-1}"
 }
 
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --orch-dir)         ORCH_DIR="$2"; shift 2 ;;
-    --orch-id)          ORCH_ID="$2"; shift 2 ;;
-    --grace-seconds)    GRACE_SECONDS="$2"; shift 2 ;;
-    --stale-bg-seconds) STALE_BG_SECONDS="$2"; shift 2 ;;
-    --dry-run)          DRY_RUN=1; shift ;;
-    -h|--help)          usage 0 ;;
-    *)                  echo "unknown arg: $1" >&2; usage ;;
-  esac
+	case "$1" in
+	--orch-dir)
+		ORCH_DIR="$2"
+		shift 2
+		;;
+	--orch-id)
+		ORCH_ID="$2"
+		shift 2
+		;;
+	--grace-seconds)
+		GRACE_SECONDS="$2"
+		shift 2
+		;;
+	--stale-bg-seconds)
+		STALE_BG_SECONDS="$2"
+		shift 2
+		;;
+	--dry-run)
+		DRY_RUN=1
+		shift
+		;;
+	-h | --help) usage 0 ;;
+	*)
+		echo "unknown arg: $1" >&2
+		usage
+		;;
+	esac
 done
 
-[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
-[ -z "$ORCH_ID" ]  && { echo "ERROR: --orch-id required"  >&2; exit 2; }
-[ ! -d "$ORCH_DIR/workers" ] && { echo "ERROR: no workers dir at $ORCH_DIR/workers" >&2; exit 2; }
+[ -z "$ORCH_DIR" ] && {
+	echo "ERROR: --orch-dir required" >&2
+	exit 2
+}
+[ -z "$ORCH_ID" ] && {
+	echo "ERROR: --orch-id required" >&2
+	exit 2
+}
+[ ! -d "$ORCH_DIR/workers" ] && {
+	echo "ERROR: no workers dir at $ORCH_DIR/workers" >&2
+	exit 2
+}
 
 # Give freshly-dispatched processes a moment to fail before we judge them.
 if [ "$GRACE_SECONDS" -gt 0 ]; then
-  sleep "$GRACE_SECONDS"
+	sleep "$GRACE_SECONDS"
 fi
 
 now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
@@ -84,61 +111,61 @@ DEAD_TICKETS=()
 
 shopt -s nullglob
 for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
-  # Skip non-worker JSON files (fixup prompts, misc artifacts) — a real signal
-  # has at minimum a .ticket field.
-  TICKET=$(jq -r '.ticket // empty' "$SIGNAL" 2>/dev/null || echo "")
-  [ -z "$TICKET" ] && continue
+	# Skip non-worker JSON files (fixup prompts, misc artifacts) — a real signal
+	# has at minimum a .ticket field.
+	TICKET=$(jq -r '.ticket // empty' "$SIGNAL" 2>/dev/null || echo "")
+	[ -z "$TICKET" ] && continue
 
-  STATUS=$(jq -r '.status // empty' "$SIGNAL")
-  PHASE=$(jq -r '.phase // 0' "$SIGNAL")
-  PID=$(jq -r '.pid // empty' "$SIGNAL")
+	STATUS=$(jq -r '.status // empty' "$SIGNAL")
+	PHASE=$(jq -r '.phase // 0' "$SIGNAL")
+	PID=$(jq -r '.pid // empty' "$SIGNAL")
 
-  # Only inspect workers that haven't announced themselves yet. Anything that
-  # moved off `dispatched`/phase 0 is clearly alive; anything terminal should
-  # not be relitigated.
-  [ "$STATUS" != "dispatched" ] && continue
-  [ "$PHASE" != "0" ] && continue
-  [ -z "$PID" ] && continue
+	# Only inspect workers that haven't announced themselves yet. Anything that
+	# moved off `dispatched`/phase 0 is clearly alive; anything terminal should
+	# not be relitigated.
+	[ "$STATUS" != "dispatched" ] && continue
+	[ "$PHASE" != "0" ] && continue
+	[ -z "$PID" ] && continue
 
-  CHECKED=$((CHECKED+1))
+	CHECKED=$((CHECKED + 1))
 
-  if kill -0 "$PID" 2>/dev/null; then
-    continue
-  fi
+	if kill -0 "$PID" 2>/dev/null; then
+		continue
+	fi
 
-  # PID is dead — this is a launch failure.
-  DEAD_TICKETS+=("$TICKET")
-  MSG="Worker PID ${PID} died within ${GRACE_SECONDS}s of dispatch"
+	# PID is dead — this is a launch failure.
+	DEAD_TICKETS+=("$TICKET")
+	MSG="Worker PID ${PID} died within ${GRACE_SECONDS}s of dispatch"
 
-  if [ "$DRY_RUN" -eq 1 ]; then
-    echo "[dry-run] ${TICKET}: ${MSG}" >&2
-    continue
-  fi
+	if [ "$DRY_RUN" -eq 1 ]; then
+		echo "[dry-run] ${TICKET}: ${MSG}" >&2
+		continue
+	fi
 
-  TS=$(now_iso)
-  jq --arg status "failed" \
-     --arg reason "launch-failure" \
-     --arg ts "$TS" \
-     '.status = $status
+	TS=$(now_iso)
+	jq --arg status "failed" \
+		--arg reason "launch-failure" \
+		--arg ts "$TS" \
+		'.status = $status
       | .failureReason = $reason
       | .updatedAt = $ts
       | .completedAt = $ts
       | .phaseTimestamps = ((.phaseTimestamps // {}) | .failed = $ts)' \
-     "$SIGNAL" > "${SIGNAL}.tmp" && mv "${SIGNAL}.tmp" "$SIGNAL"
+		"$SIGNAL" >"${SIGNAL}.tmp" && mv "${SIGNAL}.tmp" "$SIGNAL"
 
-  if [ -x "$STATE_SCRIPT" ]; then
-    "$STATE_SCRIPT" attention "$ORCH_ID" "launch-failure" "$TICKET" "$MSG"
-    "$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET" \
-      '.status = "failed" | .attentionReason = "'"${MSG//\"/\\\"}"'"'
-    EVT=$(jq -nc \
-      --arg ts "$TS" --arg orch "$ORCH_ID" --arg w "$TICKET" \
-      --argjson pid "$PID" --argjson grace "$GRACE_SECONDS" \
-      '{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-launch-failed",
+	if [ -x "$STATE_SCRIPT" ]; then
+		"$STATE_SCRIPT" attention "$ORCH_ID" "launch-failure" "$TICKET" "$MSG"
+		"$STATE_SCRIPT" worker "$ORCH_ID" "$TICKET" \
+			'.status = "failed" | .attentionReason = "'"${MSG//\"/\\\"}"'"'
+		EVT=$(jq -nc \
+			--arg ts "$TS" --arg orch "$ORCH_ID" --arg w "$TICKET" \
+			--argjson pid "$PID" --argjson grace "$GRACE_SECONDS" \
+			'{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-launch-failed",
         detail:{pid:$pid, graceSeconds:$grace}}')
-    "$STATE_SCRIPT" event "$EVT"
-  fi
+		"$STATE_SCRIPT" event "$EVT"
+	fi
 
-  echo "LAUNCH-FAILURE: ${TICKET} (pid=${PID})" >&2
+	echo "LAUNCH-FAILURE: ${TICKET} (pid=${PID})" >&2
 done
 
 # ─── CTL-452: phase-mode --bg state.json mtime check ─────────────────────────
@@ -152,111 +179,111 @@ STALLED_TICKETS=()
 PHASE_TERMINAL_STATES="done failed errored stopped stalled"
 
 mtime_of() {
-  # macOS `stat -f` vs GNU `stat -c` — fall back if neither accepts.
-  local f="$1"
-  stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo ""
+	# macOS `stat -f` vs GNU `stat -c` — fall back if neither accepts.
+	local f="$1"
+	stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo ""
 }
 
 # Iterate every per-phase signal under workers/<T>/phase-*.json. Tickets with
 # no phase-mode subdirectory are silently skipped (legacy oneshot workers).
 shopt -s nullglob
 for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
-  P_TICKET=$(jq -r '.ticket // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
-  [ -z "$P_TICKET" ] && continue
-  P_PHASE=$(jq -r '.phase // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
-  P_STATUS=$(jq -r '.status // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
-  P_BG=$(jq -r '.bg_job_id // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+	P_TICKET=$(jq -r '.ticket // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+	[ -z "$P_TICKET" ] && continue
+	P_PHASE=$(jq -r '.phase // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+	P_STATUS=$(jq -r '.status // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+	P_BG=$(jq -r '.bg_job_id // empty' "$PHASE_SIGNAL" 2>/dev/null || echo "")
 
-  # Skip terminal signals — nothing for the healthcheck to do.
-  case " $PHASE_TERMINAL_STATES " in *" $P_STATUS "*) continue ;; esac
+	# Skip terminal signals — nothing for the healthcheck to do.
+	case " $PHASE_TERMINAL_STATES " in *" $P_STATUS "*) continue ;; esac
 
-  # Phase agents without a bg_job_id haven't fully launched yet (or never
-  # claimed --bg). The legacy PID check already covers the no-bg case, so
-  # skip rather than double-flag.
-  [ -z "$P_BG" ] && continue
+	# Phase agents without a bg_job_id haven't fully launched yet (or never
+	# claimed --bg). The legacy PID check already covers the no-bg case, so
+	# skip rather than double-flag.
+	[ -z "$P_BG" ] && continue
 
-  STATE_FILE="${JOBS_ROOT}/${P_BG}/state.json"
-  STALL_REASON=""
-  if [ ! -f "$STATE_FILE" ]; then
-    STALL_REASON="state-json-missing"
-  else
-    # Honor terminal claude state — done/failed/errored/stopped means the
-    # process correctly reached an exit. Leave it for the operator to read.
-    CLAUDE_STATE=$(jq -r '.state // ""' "$STATE_FILE" 2>/dev/null || echo "")
-    case " done failed errored stopped " in
-      *" $CLAUDE_STATE "*) continue ;;
-    esac
-    MTIME=$(mtime_of "$STATE_FILE")
-    if [ -n "$MTIME" ]; then
-      AGE=$(( $(date -u +%s) - MTIME ))
-      if [ "$AGE" -ge "$STALE_BG_SECONDS" ]; then
-        STALL_REASON="state-json-stale"
-      fi
-    fi
-  fi
+	STATE_FILE="${JOBS_ROOT}/${P_BG}/state.json"
+	STALL_REASON=""
+	if [ ! -f "$STATE_FILE" ]; then
+		STALL_REASON="state-json-missing"
+	else
+		# Honor terminal claude state — done/failed/errored/stopped means the
+		# process correctly reached an exit. Leave it for the operator to read.
+		CLAUDE_STATE=$(jq -r '.state // ""' "$STATE_FILE" 2>/dev/null || echo "")
+		case " done failed errored stopped " in
+		*" $CLAUDE_STATE "*) continue ;;
+		esac
+		MTIME=$(mtime_of "$STATE_FILE")
+		if [ -n "$MTIME" ]; then
+			AGE=$(($(date -u +%s) - MTIME))
+			if [ "$AGE" -ge "$STALE_BG_SECONDS" ]; then
+				STALL_REASON="state-json-stale"
+			fi
+		fi
+	fi
 
-  [ -z "$STALL_REASON" ] && continue
+	[ -z "$STALL_REASON" ] && continue
 
-  STALLED_TICKETS+=("$P_TICKET")
-  if [ "$DRY_RUN" -eq 1 ]; then
-    echo "[dry-run] ${P_TICKET} phase=${P_PHASE} bg=${P_BG}: ${STALL_REASON}" >&2
-    continue
-  fi
+	STALLED_TICKETS+=("$P_TICKET")
+	if [ "$DRY_RUN" -eq 1 ]; then
+		echo "[dry-run] ${P_TICKET} phase=${P_PHASE} bg=${P_BG}: ${STALL_REASON}" >&2
+		continue
+	fi
 
-  TS=$(now_iso)
-  jq --arg ts "$TS" --arg reason "$STALL_REASON" \
-     '.status = "stalled"
+	TS=$(now_iso)
+	jq --arg ts "$TS" --arg reason "$STALL_REASON" \
+		'.status = "stalled"
       | .attentionReason = $reason
       | .updatedAt = $ts
       | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \
-     "$PHASE_SIGNAL" > "${PHASE_SIGNAL}.tmp" && mv "${PHASE_SIGNAL}.tmp" "$PHASE_SIGNAL"
+		"$PHASE_SIGNAL" >"${PHASE_SIGNAL}.tmp" && mv "${PHASE_SIGNAL}.tmp" "$PHASE_SIGNAL"
 
-  if [ -x "$STATE_SCRIPT" ]; then
-    EVT=$(jq -nc \
-      --arg ts "$TS" --arg orch "$ORCH_ID" --arg w "$P_TICKET" \
-      --arg phase "$P_PHASE" --arg bg "$P_BG" --arg reason "$STALL_REASON" \
-      '{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-phase-stalled",
+	if [ -x "$STATE_SCRIPT" ]; then
+		EVT=$(jq -nc \
+			--arg ts "$TS" --arg orch "$ORCH_ID" --arg w "$P_TICKET" \
+			--arg phase "$P_PHASE" --arg bg "$P_BG" --arg reason "$STALL_REASON" \
+			'{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-phase-stalled",
         detail:{phase:$phase, bg_job_id:$bg, reason:$reason}}')
-    "$STATE_SCRIPT" event "$EVT" >/dev/null 2>&1 || true
-    "$STATE_SCRIPT" attention "$ORCH_ID" "$STALL_REASON" "$P_TICKET" \
-      "Phase ${P_PHASE} stalled (${STALL_REASON})" >/dev/null 2>&1 || true
-  fi
+		"$STATE_SCRIPT" event "$EVT" >/dev/null 2>&1 || true
+		"$STATE_SCRIPT" attention "$ORCH_ID" "$STALL_REASON" "$P_TICKET" \
+			"Phase ${P_PHASE} stalled (${STALL_REASON})" >/dev/null 2>&1 || true
+	fi
 
-  # CTL-511: emit phase.<name>.failed.<TICKET> so the broker's phase_lifecycle
-  # route wakes the orchestrator immediately. worker-phase-stalled (above) does
-  # not match the broker's PHASE_EVENT_PATTERN, so before this the orchestrator
-  # only learned of the stall on its own 10-minute idle fallback. --no-signal-update
-  # is essential: the jq above already wrote status="stalled" and a non-event-only
-  # emit would flip it to "failed", which orchestrate-revive Loop 2 skips.
-  if [ -x "$EMIT_COMPLETE" ]; then
-    "$EMIT_COMPLETE" \
-      --phase "$P_PHASE" --ticket "$P_TICKET" --status failed \
-      --reason "$STALL_REASON" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
-      --no-signal-update >/dev/null 2>&1 || true
-  fi
+	# CTL-511: emit phase.<name>.failed.<TICKET> so the broker's phase_lifecycle
+	# route wakes the orchestrator immediately. worker-phase-stalled (above) does
+	# not match the broker's PHASE_EVENT_PATTERN, so before this the orchestrator
+	# only learned of the stall on its own 10-minute idle fallback. --no-signal-update
+	# is essential: the jq above already wrote status="stalled" and a non-event-only
+	# emit would flip it to "failed", which orchestrate-revive Loop 2 skips.
+	if [ -x "$EMIT_COMPLETE" ]; then
+		"$EMIT_COMPLETE" \
+			--phase "$P_PHASE" --ticket "$P_TICKET" --status failed \
+			--reason "$STALL_REASON" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+			--no-signal-update >/dev/null 2>&1 || true
+	fi
 
-  echo "PHASE-STALLED: ${P_TICKET} phase=${P_PHASE} bg=${P_BG} (${STALL_REASON})" >&2
+	echo "PHASE-STALLED: ${P_TICKET} phase=${P_PHASE} bg=${P_BG} (${STALL_REASON})" >&2
 done
 
 # Summary on stdout (machine-readable).
 DEAD_COUNT=${#DEAD_TICKETS[@]}
 if [ "$DEAD_COUNT" -eq 0 ]; then
-  DEAD_JSON="[]"
+	DEAD_JSON="[]"
 else
-  DEAD_JSON=$(printf '%s\n' "${DEAD_TICKETS[@]}" | jq -R . | jq -s .)
+	DEAD_JSON=$(printf '%s\n' "${DEAD_TICKETS[@]}" | jq -R . | jq -s .)
 fi
 
 STALLED_COUNT=${#STALLED_TICKETS[@]}
 if [ "$STALLED_COUNT" -eq 0 ]; then
-  STALLED_JSON="[]"
+	STALLED_JSON="[]"
 else
-  STALLED_JSON=$(printf '%s\n' "${STALLED_TICKETS[@]}" | jq -R . | jq -s .)
+	STALLED_JSON=$(printf '%s\n' "${STALLED_TICKETS[@]}" | jq -R . | jq -s .)
 fi
 
 jq -nc \
-  --argjson c "$CHECKED" \
-  --argjson d "$DEAD_COUNT" \
-  --argjson t "$DEAD_JSON" \
-  --argjson s "$STALLED_COUNT" \
-  --argjson st "$STALLED_JSON" \
-  '{checked:$c, dead:$d, deadTickets:$t, stalled:$s, stalledTickets:$st}'
+	--argjson c "$CHECKED" \
+	--argjson d "$DEAD_COUNT" \
+	--argjson t "$DEAD_JSON" \
+	--argjson s "$STALLED_COUNT" \
+	--argjson st "$STALLED_JSON" \
+	'{checked:$c, dead:$d, deadTickets:$t, stalled:$s, stalledTickets:$st}'

--- a/plugins/dev/scripts/orchestrate-healthcheck
+++ b/plugins/dev/scripts/orchestrate-healthcheck
@@ -26,6 +26,9 @@
 # Environment:
 #   CATALYST_STATE_SCRIPT             path to catalyst-state.sh (default: ../catalyst-state.sh
 #                                     next to this script). Tests override this to capture calls.
+#   CATALYST_EMIT_COMPLETE            path to phase-agent-emit-complete (default: next to this
+#                                     script). CTL-511: emits phase.<name>.failed when a phase
+#                                     signal is flipped to stalled, waking the orchestrator.
 #   CATALYST_HEALTHCHECK_JOBS_ROOT    root for --bg job state dirs (default: $HOME/.claude/jobs).
 #                                     Tests override this to avoid touching the real Claude state.
 
@@ -33,6 +36,9 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
+# CTL-511: phase-agent-emit-complete emits the broker-routable phase.<name>.failed
+# event when a phase signal is flipped to stalled. Test-overridable.
+EMIT_COMPLETE="${CATALYST_EMIT_COMPLETE:-${SCRIPT_DIR}/phase-agent-emit-complete}"
 
 ORCH_DIR=""
 ORCH_ID=""
@@ -46,7 +52,7 @@ DRY_RUN=0
 JOBS_ROOT="${CATALYST_HEALTHCHECK_JOBS_ROOT:-${HOME}/.claude/jobs}"
 
 usage() {
-  sed -n '2,32p' "$0"
+  sed -n '2,35p' "$0"
   exit "${1:-1}"
 }
 
@@ -214,6 +220,19 @@ for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
     "$STATE_SCRIPT" event "$EVT" >/dev/null 2>&1 || true
     "$STATE_SCRIPT" attention "$ORCH_ID" "$STALL_REASON" "$P_TICKET" \
       "Phase ${P_PHASE} stalled (${STALL_REASON})" >/dev/null 2>&1 || true
+  fi
+
+  # CTL-511: emit phase.<name>.failed.<TICKET> so the broker's phase_lifecycle
+  # route wakes the orchestrator immediately. worker-phase-stalled (above) does
+  # not match the broker's PHASE_EVENT_PATTERN, so before this the orchestrator
+  # only learned of the stall on its own 10-minute idle fallback. --no-signal-update
+  # is essential: the jq above already wrote status="stalled" and a non-event-only
+  # emit would flip it to "failed", which orchestrate-revive Loop 2 skips.
+  if [ -x "$EMIT_COMPLETE" ]; then
+    "$EMIT_COMPLETE" \
+      --phase "$P_PHASE" --ticket "$P_TICKET" --status failed \
+      --reason "$STALL_REASON" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+      --no-signal-update >/dev/null 2>&1 || true
   fi
 
   echo "PHASE-STALLED: ${P_TICKET} phase=${P_PHASE} bg=${P_BG} (${STALL_REASON})" >&2

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -42,7 +42,9 @@ while [ -L "$SOURCE" ]; do
 	[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
-EMIT_COMPLETE="${SCRIPT_DIR}/phase-agent-emit-complete"
+# CTL-511: CATALYST_EMIT_COMPLETE is a test override (mirrors orchestrate-healthcheck)
+# so the launch-failure tests can point at a stub or a non-existent path.
+EMIT_COMPLETE="${CATALYST_EMIT_COMPLETE:-${SCRIPT_DIR}/phase-agent-emit-complete}"
 
 die() {
 	echo "phase-agent-dispatch: $*" >&2

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -37,14 +37,17 @@ set -uo pipefail
 # ─── Resolve script dir through symlinks ────────────────────────────────────
 SOURCE="${BASH_SOURCE[0]}"
 while [ -L "$SOURCE" ]; do
-  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+	DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+	SOURCE="$(readlink "$SOURCE")"
+	[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 EMIT_COMPLETE="${SCRIPT_DIR}/phase-agent-emit-complete"
 
-die() { echo "phase-agent-dispatch: $*" >&2; exit 1; }
+die() {
+	echo "phase-agent-dispatch: $*" >&2
+	exit 1
+}
 
 # ─── Defaults ───────────────────────────────────────────────────────────────
 
@@ -55,18 +58,18 @@ DEFAULT_TURN_CAP=50
 # Per-phase default turn caps (mirrors plan §Initiative 1 Phase 6 config block).
 # Used as the last fallback before DEFAULT_TURN_CAP when config is absent.
 phase_default_turn_cap() {
-  case "$1" in
-    triage)         echo 10 ;;
-    research)       echo 35 ;;
-    plan)           echo 25 ;;
-    implement)      echo 75 ;;
-    verify)         echo 20 ;;
-    review)         echo 25 ;;
-    pr)             echo 12 ;;
-    monitor-merge)  echo 50 ;;
-    monitor-deploy) echo 30 ;;
-    *)              echo "$DEFAULT_TURN_CAP" ;;
-  esac
+	case "$1" in
+	triage) echo 10 ;;
+	research) echo 35 ;;
+	plan) echo 25 ;;
+	implement) echo 75 ;;
+	verify) echo 20 ;;
+	review) echo 25 ;;
+	pr) echo 12 ;;
+	monitor-merge) echo 50 ;;
+	monitor-deploy) echo 30 ;;
+	*) echo "$DEFAULT_TURN_CAP" ;;
+	esac
 }
 
 # Prior-phase artifact lookup. Returns one of two shapes:
@@ -75,83 +78,114 @@ phase_default_turn_cap() {
 #                           the filename includes a date)
 # Empty output means this phase is the entry point — no prior artifact.
 prior_artifact_for_phase() {
-  case "$1" in
-    triage)         echo "" ;;
-    research)       echo "signal:triage.json" ;;
-    plan)           echo "glob:thoughts/shared/research/*-${TICKET,,}.md" ;;
-    implement)      echo "glob:thoughts/shared/plans/*-${TICKET,,}.md" ;;
-    verify)         echo "signal:phase-implement.json" ;;
-    review)         echo "signal:verify.json" ;;
-    pr)             echo "signal:review.json" ;;
-    monitor-merge)  echo "signal:phase-pr.json" ;;
-    monitor-deploy) echo "signal:phase-monitor-merge.json" ;;
-    *)              echo "" ;;
-  esac
+	case "$1" in
+	triage) echo "" ;;
+	research) echo "signal:triage.json" ;;
+	plan) echo "glob:thoughts/shared/research/*-${TICKET,,}.md" ;;
+	implement) echo "glob:thoughts/shared/plans/*-${TICKET,,}.md" ;;
+	verify) echo "signal:phase-implement.json" ;;
+	review) echo "signal:verify.json" ;;
+	pr) echo "signal:review.json" ;;
+	monitor-merge) echo "signal:phase-pr.json" ;;
+	monitor-deploy) echo "signal:phase-monitor-merge.json" ;;
+	*) echo "" ;;
+	esac
 }
 
 # ─── Parse args ─────────────────────────────────────────────────────────────
 
 PHASE=""
 TICKET=""
-ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
-ORCH_ID="${CATALYST_ORCHESTRATOR_ID:-}"
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR-}"
+ORCH_ID="${CATALYST_ORCHESTRATOR_ID-}"
 MODEL_FLAG=""
 TURN_CAP_FLAG=""
 CONFIG=""
 DRY_RUN=0
 
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --phase)     PHASE="$2"; shift 2 ;;
-    --ticket)    TICKET="$2"; shift 2 ;;
-    --orch-dir)  ORCH_DIR="$2"; shift 2 ;;
-    --orch-id)   ORCH_ID="$2"; shift 2 ;;
-    --model)     MODEL_FLAG="$2"; shift 2 ;;
-    --turn-cap)  TURN_CAP_FLAG="$2"; shift 2 ;;
-    --config)    CONFIG="$2"; shift 2 ;;
-    --dry-run)   DRY_RUN=1; shift ;;
-    -h|--help)   grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-    *)           die "unknown flag: $1" ;;
-  esac
+	case "$1" in
+	--phase)
+		PHASE="$2"
+		shift 2
+		;;
+	--ticket)
+		TICKET="$2"
+		shift 2
+		;;
+	--orch-dir)
+		ORCH_DIR="$2"
+		shift 2
+		;;
+	--orch-id)
+		ORCH_ID="$2"
+		shift 2
+		;;
+	--model)
+		MODEL_FLAG="$2"
+		shift 2
+		;;
+	--turn-cap)
+		TURN_CAP_FLAG="$2"
+		shift 2
+		;;
+	--config)
+		CONFIG="$2"
+		shift 2
+		;;
+	--dry-run)
+		DRY_RUN=1
+		shift
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*) die "unknown flag: $1" ;;
+	esac
 done
 
-[[ -n "$PHASE" ]]    || die "--phase is required"
-[[ -n "$TICKET" ]]   || die "--ticket is required"
-[[ -n "$ORCH_DIR" ]] || die "--orch-dir (or CATALYST_ORCHESTRATOR_DIR) is required"
+[[ -n $PHASE ]] || die "--phase is required"
+[[ -n $TICKET ]] || die "--ticket is required"
+[[ -n $ORCH_DIR ]] || die "--orch-dir (or CATALYST_ORCHESTRATOR_DIR) is required"
 
-if [[ ! "$TICKET" =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
-  die "invalid --ticket: $TICKET (expected e.g. CTL-100)"
+if [[ ! $TICKET =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
+	die "invalid --ticket: $TICKET (expected e.g. CTL-100)"
 fi
-if [[ "$PHASE" == *.* ]]; then
-  die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
+if [[ $PHASE == *.* ]]; then
+	die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
 fi
 
 # ─── Resolve config path ────────────────────────────────────────────────────
 
 resolve_config() {
-  if [[ -n "$CONFIG" && -f "$CONFIG" ]]; then echo "$CONFIG"; return; fi
-  local dir
-  dir="$(pwd)"
-  while [[ "$dir" != "/" ]]; do
-    if [[ -f "${dir}/.catalyst/config.json" ]]; then
-      echo "${dir}/.catalyst/config.json"; return
-    fi
-    dir="$(dirname "$dir")"
-  done
-  echo ""
+	if [[ -n $CONFIG && -f $CONFIG ]]; then
+		echo "$CONFIG"
+		return
+	fi
+	local dir
+	dir="$(pwd)"
+	while [[ $dir != "/" ]]; do
+		if [[ -f "${dir}/.catalyst/config.json" ]]; then
+			echo "${dir}/.catalyst/config.json"
+			return
+		fi
+		dir="$(dirname "$dir")"
+	done
+	echo ""
 }
 CONFIG_PATH="$(resolve_config)"
 
 config_value() {
-  local key="$1" default="$2"
-  if [[ -z "$CONFIG_PATH" ]] || ! command -v jq >/dev/null 2>&1; then
-    echo "$default"
-    return
-  fi
-  local v
-  v=$(jq -r "$key // empty" "$CONFIG_PATH" 2>/dev/null)
-  [[ -z "$v" ]] && v="$default"
-  echo "$v"
+	local key="$1" default="$2"
+	if [[ -z $CONFIG_PATH ]] || ! command -v jq >/dev/null 2>&1; then
+		echo "$default"
+		return
+	fi
+	local v
+	v=$(jq -r "$key // empty" "$CONFIG_PATH" 2>/dev/null)
+	[[ -z $v ]] && v="$default"
+	echo "$v"
 }
 
 # ─── OTEL resource attributes (CTL-492, CTL-495) ───────────────────────────
@@ -184,47 +218,56 @@ config_value() {
 # because all three values are required by the time this runs. The caller
 # still guards on `-n` to remain defensive against future helper changes.
 compose_otel_resource_attrs() {
-  local project_key worker_wt worker_branch attrs
-  project_key="$(config_value '.catalyst.projectKey' '')"
+	local project_key worker_wt worker_branch attrs
+	project_key="$(config_value '.catalyst.projectKey' '')"
 
-  worker_branch=""
-  if [[ -n "$project_key" ]]; then
-    worker_wt="${HOME}/catalyst/wt/${project_key}/${ORCH_ID}-${TICKET}"
-    if [[ -e "${worker_wt}/.git" ]] && command -v git >/dev/null 2>&1; then
-      worker_branch="$(git -C "$worker_wt" branch --show-current 2>/dev/null || true)"
-    fi
-    [[ -z "$worker_branch" ]] && worker_branch="${ORCH_ID}-${TICKET}"
-  fi
+	worker_branch=""
+	if [[ -n $project_key ]]; then
+		worker_wt="${HOME}/catalyst/wt/${project_key}/${ORCH_ID}-${TICKET}"
+		if [[ -e "${worker_wt}/.git" ]] && command -v git >/dev/null 2>&1; then
+			worker_branch="$(git -C "$worker_wt" branch --show-current 2>/dev/null || true)"
+		fi
+		[[ -z $worker_branch ]] && worker_branch="${ORCH_ID}-${TICKET}"
+	fi
 
-  if [[ -n "$project_key" ]]; then
-    attrs="project=${project_key},linear.key=${TICKET},catalyst.orchestration=${ORCH_ID}"
-    [[ -n "$worker_branch" ]] && attrs="${attrs},branch=${worker_branch}"
-  else
-    attrs="linear.key=${TICKET},catalyst.orchestration=${ORCH_ID}"
-  fi
-  attrs="${attrs},task.type=phase-${PHASE}"
-  printf '%s\n' "$attrs"
+	if [[ -n $project_key ]]; then
+		attrs="project=${project_key},linear.key=${TICKET},catalyst.orchestration=${ORCH_ID}"
+		[[ -n $worker_branch ]] && attrs="${attrs},branch=${worker_branch}"
+	else
+		attrs="linear.key=${TICKET},catalyst.orchestration=${ORCH_ID}"
+	fi
+	attrs="${attrs},task.type=phase-${PHASE}"
+	printf '%s\n' "$attrs"
 }
 
 # ─── Resolve model: CLI > modelOverrides > models > default ────────────────
 
 resolve_model() {
-  if [[ -n "$MODEL_FLAG" ]]; then echo "$MODEL_FLAG"; return; fi
-  local override
-  override=$(config_value \
-    ".catalyst.orchestration.phaseAgents.modelOverrides[\"${PHASE}\"][\"${TICKET}\"]" \
-    "")
-  if [[ -n "$override" ]]; then echo "$override"; return; fi
-  config_value ".catalyst.orchestration.phaseAgents.models[\"${PHASE}\"]" "$DEFAULT_MODEL"
+	if [[ -n $MODEL_FLAG ]]; then
+		echo "$MODEL_FLAG"
+		return
+	fi
+	local override
+	override=$(config_value \
+		".catalyst.orchestration.phaseAgents.modelOverrides[\"${PHASE}\"][\"${TICKET}\"]" \
+		"")
+	if [[ -n $override ]]; then
+		echo "$override"
+		return
+	fi
+	config_value ".catalyst.orchestration.phaseAgents.models[\"${PHASE}\"]" "$DEFAULT_MODEL"
 }
 MODEL="$(resolve_model)"
 
 # ─── Resolve turn cap: CLI > config.turnCaps > per-phase default ───────────
 
 resolve_turn_cap() {
-  if [[ -n "$TURN_CAP_FLAG" ]]; then echo "$TURN_CAP_FLAG"; return; fi
-  config_value ".catalyst.orchestration.phaseAgents.turnCaps[\"${PHASE}\"]" \
-    "$(phase_default_turn_cap "$PHASE")"
+	if [[ -n $TURN_CAP_FLAG ]]; then
+		echo "$TURN_CAP_FLAG"
+		return
+	fi
+	config_value ".catalyst.orchestration.phaseAgents.turnCaps[\"${PHASE}\"]" \
+		"$(phase_default_turn_cap "$PHASE")"
 }
 TURN_CAP="$(resolve_turn_cap)"
 
@@ -232,71 +275,71 @@ TURN_CAP="$(resolve_turn_cap)"
 
 ARTIFACT_SPEC="$(prior_artifact_for_phase "$PHASE")"
 ARTIFACT_OK=1
-if [[ -n "$ARTIFACT_SPEC" ]]; then
-  case "$ARTIFACT_SPEC" in
-    signal:*)
-      ARTIFACT_FILE="${ORCH_DIR}/workers/${TICKET}/${ARTIFACT_SPEC#signal:}"
-      [[ -f "$ARTIFACT_FILE" ]] || ARTIFACT_OK=0
-      ;;
-    glob:*)
-      # CTL-494: two-step match. The lowercase-ticket-at-tail form
-      # (phase-plan prose convention) is tried first; on miss, fall back to
-      # a wider pattern that accepts the canonical create-plan form
-      # (uppercase ticket + descriptive suffix). Case-insensitive nocaseglob
-      # is the final fallback. The ticket is still required to appear in the
-      # filename, so cross-ticket lookalikes do not satisfy this gate.
-      PATTERN="${ARTIFACT_SPEC#glob:}"
-      shopt -s nullglob
-      # shellcheck disable=SC2206  # word-splitting is required for glob expansion
-      MATCHES=( $PATTERN )
-      if [[ ${#MATCHES[@]} -eq 0 ]]; then
-        WIDE="${PATTERN/%-${TICKET,,}.md/*${TICKET}*.md}"
-        # shellcheck disable=SC2206
-        MATCHES=( $WIDE )
-        if [[ ${#MATCHES[@]} -eq 0 ]]; then
-          shopt -s nocaseglob
-          # shellcheck disable=SC2206
-          MATCHES=( $WIDE )
-          shopt -u nocaseglob
-        fi
-      fi
-      shopt -u nullglob
-      [[ ${#MATCHES[@]} -gt 0 ]] || ARTIFACT_OK=0
-      ;;
-  esac
+if [[ -n $ARTIFACT_SPEC ]]; then
+	case "$ARTIFACT_SPEC" in
+	signal:*)
+		ARTIFACT_FILE="${ORCH_DIR}/workers/${TICKET}/${ARTIFACT_SPEC#signal:}"
+		[[ -f $ARTIFACT_FILE ]] || ARTIFACT_OK=0
+		;;
+	glob:*)
+		# CTL-494: two-step match. The lowercase-ticket-at-tail form
+		# (phase-plan prose convention) is tried first; on miss, fall back to
+		# a wider pattern that accepts the canonical create-plan form
+		# (uppercase ticket + descriptive suffix). Case-insensitive nocaseglob
+		# is the final fallback. The ticket is still required to appear in the
+		# filename, so cross-ticket lookalikes do not satisfy this gate.
+		PATTERN="${ARTIFACT_SPEC#glob:}"
+		shopt -s nullglob
+		# shellcheck disable=SC2206  # word-splitting is required for glob expansion
+		MATCHES=($PATTERN)
+		if [[ ${#MATCHES[@]} -eq 0 ]]; then
+			WIDE="${PATTERN/%-${TICKET,,}.md/*${TICKET}*.md}"
+			# shellcheck disable=SC2206
+			MATCHES=($WIDE)
+			if [[ ${#MATCHES[@]} -eq 0 ]]; then
+				shopt -s nocaseglob
+				# shellcheck disable=SC2206
+				MATCHES=($WIDE)
+				shopt -u nocaseglob
+			fi
+		fi
+		shopt -u nullglob
+		[[ ${#MATCHES[@]} -gt 0 ]] || ARTIFACT_OK=0
+		;;
+	esac
 fi
 
-if [[ "$ARTIFACT_OK" -eq 0 ]]; then
-  REFUSAL_REASON="prior_artifact_missing"
-  echo "phase-agent-dispatch: refusing to launch ${PHASE} on ${TICKET}: prior artifact missing (${ARTIFACT_SPEC})" >&2
-  jq -nc \
-    --arg ticket "$TICKET" \
-    --arg phase "$PHASE" \
-    --arg model "$MODEL" \
-    --arg artifact "$ARTIFACT_SPEC" \
-    --arg reason "$REFUSAL_REASON" \
-    --argjson turnCap "$TURN_CAP" \
-    --argjson dryRun "$DRY_RUN" \
-    '{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+if [[ $ARTIFACT_OK -eq 0 ]]; then
+	REFUSAL_REASON="prior_artifact_missing"
+	echo "phase-agent-dispatch: refusing to launch ${PHASE} on ${TICKET}: prior artifact missing (${ARTIFACT_SPEC})" >&2
+	jq -nc \
+		--arg ticket "$TICKET" \
+		--arg phase "$PHASE" \
+		--arg model "$MODEL" \
+		--arg artifact "$ARTIFACT_SPEC" \
+		--arg reason "$REFUSAL_REASON" \
+		--argjson turnCap "$TURN_CAP" \
+		--argjson dryRun "$DRY_RUN" \
+		'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
       bg_job_id: null, signalFile: null, status: "refused",
       reason: $reason, artifact: $artifact, dryRun: ($dryRun == 1)}'
 
-  # CTL-494: emit phase.<name>.failed.<TICKET> so the broker wakes the
-  # orchestrator in seconds instead of waiting on the 16-minute
-  # state-json-stale path. Best-effort: never let emit failure mask the
-  # original refusal exit code. Skipped for --dry-run so previews don't
-  # write to the live event log.
-  if [[ "$DRY_RUN" -eq 0 && -x "$EMIT_COMPLETE" ]]; then
-    "$EMIT_COMPLETE" \
-      --phase "$PHASE" \
-      --ticket "$TICKET" \
-      --status failed \
-      --reason "$REFUSAL_REASON" \
-      --orch-dir "$ORCH_DIR" \
-      --orch-id "$ORCH_ID" >/dev/null 2>&1 || true
-  fi
+	# CTL-494: emit phase.<name>.failed.<TICKET> so the broker wakes the
+	# orchestrator in seconds instead of waiting on the 16-minute
+	# state-json-stale path. Best-effort: never let emit failure mask the
+	# original refusal exit code. Skipped for --dry-run so previews don't
+	# write to the live event log.
+	if [[ $DRY_RUN -eq 0 && -x $EMIT_COMPLETE ]]; then
+		"$EMIT_COMPLETE" \
+			--phase "$PHASE" \
+			--ticket "$TICKET" \
+			--status failed \
+			--reason "$REFUSAL_REASON" \
+			--orch-dir "$ORCH_DIR" \
+			--orch-id "$ORCH_ID" >/dev/null 2>&1 || true
+	fi
 
-  exit 2
+	exit 2
 fi
 
 # ─── Write phase signal file (with idempotency) ────────────────────────────
@@ -308,40 +351,40 @@ mkdir -p "$WORKER_DIR" 2>/dev/null || die "cannot create $WORKER_DIR"
 # Idempotency: if a signal exists and its status is one of dispatched|running|done,
 # we no-op. Failed signals are overwritten (retry path).
 EXISTING_STATUS=""
-if [[ -f "$SIGNAL_FILE" ]]; then
-  EXISTING_STATUS=$(jq -r '.status // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+if [[ -f $SIGNAL_FILE ]]; then
+	EXISTING_STATUS=$(jq -r '.status // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
 fi
 
-if [[ "$EXISTING_STATUS" == "dispatched" || "$EXISTING_STATUS" == "running" || "$EXISTING_STATUS" == "done" ]]; then
-  EXISTING_JOB=$(jq -r '.bg_job_id // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
-  jq -nc \
-    --arg ticket "$TICKET" \
-    --arg phase "$PHASE" \
-    --arg model "$MODEL" \
-    --argjson turnCap "$TURN_CAP" \
-    --arg job "$EXISTING_JOB" \
-    --arg signal "$SIGNAL_FILE" \
-    --arg status "$EXISTING_STATUS" \
-    --argjson dryRun "$DRY_RUN" \
-    '{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+if [[ $EXISTING_STATUS == "dispatched" || $EXISTING_STATUS == "running" || $EXISTING_STATUS == "done" ]]; then
+	EXISTING_JOB=$(jq -r '.bg_job_id // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+	jq -nc \
+		--arg ticket "$TICKET" \
+		--arg phase "$PHASE" \
+		--arg model "$MODEL" \
+		--argjson turnCap "$TURN_CAP" \
+		--arg job "$EXISTING_JOB" \
+		--arg signal "$SIGNAL_FILE" \
+		--arg status "$EXISTING_STATUS" \
+		--argjson dryRun "$DRY_RUN" \
+		'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
       bg_job_id: (if $job == "" then null else $job end),
       signalFile: $signal, status: $status, idempotent: true,
       dryRun: ($dryRun == 1)}'
-  exit 0
+	exit 0
 fi
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq -nc \
-  --arg ticket "$TICKET" \
-  --arg phase "$PHASE" \
-  --arg model "$MODEL" \
-  --argjson turnCap "$TURN_CAP" \
-  --arg orch "$ORCH_ID" \
-  --arg ts "$TS" \
-  '{ticket: $ticket, phase: $phase, orchestrator: $orch, model: $model,
+	--arg ticket "$TICKET" \
+	--arg phase "$PHASE" \
+	--arg model "$MODEL" \
+	--argjson turnCap "$TURN_CAP" \
+	--arg orch "$ORCH_ID" \
+	--arg ts "$TS" \
+	'{ticket: $ticket, phase: $phase, orchestrator: $orch, model: $model,
     turnCap: $turnCap, status: "dispatched", bg_job_id: null,
-    startedAt: $ts, updatedAt: $ts}' > "$SIGNAL_FILE" \
-  || die "failed to write signal file $SIGNAL_FILE"
+    startedAt: $ts, updatedAt: $ts}' >"$SIGNAL_FILE" ||
+	die "failed to write signal file $SIGNAL_FILE"
 
 # ─── CTL-511: launch-failure recovery helper ────────────────────────────────
 #
@@ -358,27 +401,27 @@ jq -nc \
 #      --no-signal-update mode (event only — step 1 above already owns the
 #      signal file, and a non-event-only emit would flip it to "failed").
 mark_launch_failed() {
-  local reason="$1"
-  local ts
-  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  if [[ -f "$SIGNAL_FILE" ]]; then
-    local tmp="${SIGNAL_FILE}.tmp.$$"
-    if jq --arg ts "$ts" --arg reason "$reason" \
-       '.status = "stalled"
+	local reason="$1"
+	local ts
+	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	if [[ -f $SIGNAL_FILE ]]; then
+		local tmp="${SIGNAL_FILE}.tmp.$$"
+		if jq --arg ts "$ts" --arg reason "$reason" \
+			'.status = "stalled"
         | .attentionReason = $reason
         | .updatedAt = $ts
         | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \
-       "$SIGNAL_FILE" > "$tmp" 2>/dev/null; then
-      mv "$tmp" "$SIGNAL_FILE"
-    else
-      rm -f "$tmp"
-    fi
-  fi
-  if [[ -x "$EMIT_COMPLETE" ]]; then
-    "$EMIT_COMPLETE" --phase "$PHASE" --ticket "$TICKET" --status failed \
-      --reason "$reason" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
-      --no-signal-update >/dev/null 2>&1 || true
-  fi
+			"$SIGNAL_FILE" >"$tmp" 2>/dev/null; then
+			mv "$tmp" "$SIGNAL_FILE"
+		else
+			rm -f "$tmp"
+		fi
+	fi
+	if [[ -x $EMIT_COMPLETE ]]; then
+		"$EMIT_COMPLETE" --phase "$PHASE" --ticket "$TICKET" --status failed \
+			--reason "$reason" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+			--no-signal-update >/dev/null 2>&1 || true
+	fi
 }
 
 # ─── Build prompt + spawn claude --bg ──────────────────────────────────────
@@ -396,28 +439,28 @@ PROMPT="/catalyst-dev:phase-${PHASE} ${TICKET} --orch-dir ${ORCH_DIR}"
 OTEL_RES_ATTRS="$(compose_otel_resource_attrs)"
 
 DISPATCH_ENV=(
-  "CATALYST_ORCHESTRATOR_DIR=${ORCH_DIR}"
-  "CATALYST_ORCHESTRATOR_ID=${ORCH_ID}"
-  "CATALYST_PHASE=${PHASE}"
-  "CATALYST_TICKET=${TICKET}"
+	"CATALYST_ORCHESTRATOR_DIR=${ORCH_DIR}"
+	"CATALYST_ORCHESTRATOR_ID=${ORCH_ID}"
+	"CATALYST_PHASE=${PHASE}"
+	"CATALYST_TICKET=${TICKET}"
 )
-[[ -n "$OTEL_RES_ATTRS" ]] && \
-  DISPATCH_ENV+=( "OTEL_RESOURCE_ATTRIBUTES=${OTEL_RES_ATTRS}" )
+[[ -n $OTEL_RES_ATTRS ]] &&
+	DISPATCH_ENV+=("OTEL_RESOURCE_ATTRIBUTES=${OTEL_RES_ATTRS}")
 
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  # Dry-run prints the command it would have run without spawning anything.
-  jq -nc \
-    --arg ticket "$TICKET" \
-    --arg phase "$PHASE" \
-    --arg model "$MODEL" \
-    --argjson turnCap "$TURN_CAP" \
-    --arg prompt "$PROMPT" \
-    --arg signal "$SIGNAL_FILE" \
-    --argjson env "$(printf '%s\n' "${DISPATCH_ENV[@]}" | jq -R . | jq -s .)" \
-    '{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+if [[ $DRY_RUN -eq 1 ]]; then
+	# Dry-run prints the command it would have run without spawning anything.
+	jq -nc \
+		--arg ticket "$TICKET" \
+		--arg phase "$PHASE" \
+		--arg model "$MODEL" \
+		--argjson turnCap "$TURN_CAP" \
+		--arg prompt "$PROMPT" \
+		--arg signal "$SIGNAL_FILE" \
+		--argjson env "$(printf '%s\n' "${DISPATCH_ENV[@]}" | jq -R . | jq -s .)" \
+		'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
       bg_job_id: null, prompt: $prompt, signalFile: $signal,
       env: $env, status: "dispatched", dryRun: true}'
-  exit 0
+	exit 0
 fi
 
 # Spawn the phase agent. `claude --bg` writes the new job ID to stdout as
@@ -433,18 +476,18 @@ trap 'rm -f "$BG_OUT" "$BG_ERR"' EXIT
 # without rewriting either dispatcher.
 CLAUDE_BIN="${CATALYST_DISPATCH_CLAUDE_BIN:-claude}"
 env "${DISPATCH_ENV[@]}" \
-  "$CLAUDE_BIN" --bg --dangerously-skip-permissions --model "$MODEL" "$PROMPT" \
-  >"$BG_OUT" 2>"$BG_ERR"
+	"$CLAUDE_BIN" --bg --dangerously-skip-permissions --model "$MODEL" "$PROMPT" \
+	>"$BG_OUT" 2>"$BG_ERR"
 RC=$?
 
 if [[ $RC -ne 0 ]]; then
-  echo "phase-agent-dispatch: claude --bg exited $RC: $(cat "$BG_ERR")" >&2
-  mark_launch_failed "claude-bg-launch-failed"
-  jq -n --arg status "failed" --arg reason "claude_bg_failed" \
-        --arg signal "$SIGNAL_FILE" \
-        '. + {status: $status, reason: $reason, signalFile: $signal}' \
-        <<<'{}'
-  exit 1
+	echo "phase-agent-dispatch: claude --bg exited $RC: $(cat "$BG_ERR")" >&2
+	mark_launch_failed "claude-bg-launch-failed"
+	jq -n --arg status "failed" --arg reason "claude_bg_failed" \
+		--arg signal "$SIGNAL_FILE" \
+		'. + {status: $status, reason: $reason, signalFile: $signal}' \
+		<<<'{}'
+	exit 1
 fi
 
 # Extract the bg job id — first 8-char lowercase hex on stdout (CTL-490).
@@ -452,26 +495,26 @@ fi
 # the previous `awk NR==1 {print $1}` captured the literal word "backgrounded".
 # Hex grep stays correct as long as job IDs remain hex tokens.
 BG_JOB_ID=$(grep -oE '[a-f0-9]{8}' "$BG_OUT" | head -1)
-if [[ -z "$BG_JOB_ID" ]]; then
-  mark_launch_failed "claude-bg-empty-job-id"
-  die "claude --bg returned empty job id (stdout: $(cat "$BG_OUT"))"
+if [[ -z $BG_JOB_ID ]]; then
+	mark_launch_failed "claude-bg-empty-job-id"
+	die "claude --bg returned empty job id (stdout: $(cat "$BG_OUT"))"
 fi
 
 # Record job id back into the signal file.
 TS2=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
 jq --arg job "$BG_JOB_ID" --arg ts "$TS2" \
-   '.bg_job_id = $job | .status = "running" | .updatedAt = $ts' \
-   "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+	'.bg_job_id = $job | .status = "running" | .updatedAt = $ts' \
+	"$SIGNAL_FILE" >"$TMP" && mv "$TMP" "$SIGNAL_FILE"
 
 jq -nc \
-  --arg ticket "$TICKET" \
-  --arg phase "$PHASE" \
-  --arg model "$MODEL" \
-  --argjson turnCap "$TURN_CAP" \
-  --arg job "$BG_JOB_ID" \
-  --arg signal "$SIGNAL_FILE" \
-  '{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+	--arg ticket "$TICKET" \
+	--arg phase "$PHASE" \
+	--arg model "$MODEL" \
+	--argjson turnCap "$TURN_CAP" \
+	--arg job "$BG_JOB_ID" \
+	--arg signal "$SIGNAL_FILE" \
+	'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
     bg_job_id: $job, signalFile: $signal, status: "running", dryRun: false}'
 
 exit 0

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -343,6 +343,44 @@ jq -nc \
     startedAt: $ts, updatedAt: $ts}' > "$SIGNAL_FILE" \
   || die "failed to write signal file $SIGNAL_FILE"
 
+# ─── CTL-511: launch-failure recovery helper ────────────────────────────────
+#
+# Called when `claude --bg` never produces a live worker (non-zero exit, or an
+# exit-0 run that prints no job id). Without this the signal file froze at
+# status="dispatched" and no phase.* event ever reached the broker, so the
+# orchestrator stayed blind until the periodic healthcheck (or, before CTL-511,
+# ~14 h). This:
+#   1. Rewrites the signal to status="stalled" — the one status orchestrate-revive
+#      Loop 2 redispatches. We deliberately use `attentionReason` (not
+#      `failureReason`): a `failureReason` would trip Loop 2 Branch 1's escalate
+#      path, which does NOT retry.
+#   2. Emits phase.<PHASE>.failed.<TICKET> via phase-agent-emit-complete's
+#      --no-signal-update mode (event only — step 1 above already owns the
+#      signal file, and a non-event-only emit would flip it to "failed").
+mark_launch_failed() {
+  local reason="$1"
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  if [[ -f "$SIGNAL_FILE" ]]; then
+    local tmp="${SIGNAL_FILE}.tmp.$$"
+    if jq --arg ts "$ts" --arg reason "$reason" \
+       '.status = "stalled"
+        | .attentionReason = $reason
+        | .updatedAt = $ts
+        | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \
+       "$SIGNAL_FILE" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$SIGNAL_FILE"
+    else
+      rm -f "$tmp"
+    fi
+  fi
+  if [[ -x "$EMIT_COMPLETE" ]]; then
+    "$EMIT_COMPLETE" --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "$reason" --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+      --no-signal-update >/dev/null 2>&1 || true
+  fi
+}
+
 # ─── Build prompt + spawn claude --bg ──────────────────────────────────────
 
 PROMPT="/catalyst-dev:phase-${PHASE} ${TICKET} --orch-dir ${ORCH_DIR}"
@@ -401,6 +439,7 @@ RC=$?
 
 if [[ $RC -ne 0 ]]; then
   echo "phase-agent-dispatch: claude --bg exited $RC: $(cat "$BG_ERR")" >&2
+  mark_launch_failed "claude-bg-launch-failed"
   jq -n --arg status "failed" --arg reason "claude_bg_failed" \
         --arg signal "$SIGNAL_FILE" \
         '. + {status: $status, reason: $reason, signalFile: $signal}' \
@@ -413,7 +452,10 @@ fi
 # the previous `awk NR==1 {print $1}` captured the literal word "backgrounded".
 # Hex grep stays correct as long as job IDs remain hex tokens.
 BG_JOB_ID=$(grep -oE '[a-f0-9]{8}' "$BG_OUT" | head -1)
-[[ -n "$BG_JOB_ID" ]] || die "claude --bg returned empty job id (stdout: $(cat "$BG_OUT"))"
+if [[ -z "$BG_JOB_ID" ]]; then
+  mark_launch_failed "claude-bg-empty-job-id"
+  die "claude --bg returned empty job id (stdout: $(cat "$BG_OUT"))"
+fi
 
 # Record job id back into the signal file.
 TS2=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -51,9 +51,9 @@ set -uo pipefail
 # ─── Resolve script dir through symlinks ────────────────────────────────────
 SOURCE="${BASH_SOURCE[0]}"
 while [ -L "$SOURCE" ]; do
-  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+	DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+	SOURCE="$(readlink "$SOURCE")"
+	[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
@@ -63,7 +63,10 @@ source "${SCRIPT_DIR}/lib/canonical-event.sh"
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 EVENTS_DIR="${CATALYST_DIR}/events"
 
-die() { echo "phase-agent-emit-complete: $*" >&2; exit 1; }
+die() {
+	echo "phase-agent-emit-complete: $*" >&2
+	exit 1
+}
 warn() { echo "phase-agent-emit-complete: warn: $*" >&2; }
 
 # ─── Parse args ─────────────────────────────────────────────────────────────
@@ -73,51 +76,81 @@ TICKET=""
 STATUS=""
 REASON=""
 HANDOFF_PATH=""
-ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
-ORCH_ID="${CATALYST_ORCHESTRATOR_ID:-}"
-SESSION_ID="${CATALYST_SESSION_ID:-}"
+ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR-}"
+ORCH_ID="${CATALYST_ORCHESTRATOR_ID-}"
+SESSION_ID="${CATALYST_SESSION_ID-}"
 NO_SIGNAL_UPDATE=0
 
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --phase)             PHASE="$2"; shift 2 ;;
-    --ticket)            TICKET="$2"; shift 2 ;;
-    --status)            STATUS="$2"; shift 2 ;;
-    --reason)            REASON="$2"; shift 2 ;;
-    --handoff-path)      HANDOFF_PATH="$2"; shift 2 ;;
-    --orch-dir)          ORCH_DIR="$2"; shift 2 ;;
-    --orch-id)           ORCH_ID="$2"; shift 2 ;;
-    --session-id)        SESSION_ID="$2"; shift 2 ;;
-    --no-signal-update)  NO_SIGNAL_UPDATE=1; shift ;;
-    -h|--help)           grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-    *)                   die "unknown flag: $1" ;;
-  esac
+	case "$1" in
+	--phase)
+		PHASE="$2"
+		shift 2
+		;;
+	--ticket)
+		TICKET="$2"
+		shift 2
+		;;
+	--status)
+		STATUS="$2"
+		shift 2
+		;;
+	--reason)
+		REASON="$2"
+		shift 2
+		;;
+	--handoff-path)
+		HANDOFF_PATH="$2"
+		shift 2
+		;;
+	--orch-dir)
+		ORCH_DIR="$2"
+		shift 2
+		;;
+	--orch-id)
+		ORCH_ID="$2"
+		shift 2
+		;;
+	--session-id)
+		SESSION_ID="$2"
+		shift 2
+		;;
+	--no-signal-update)
+		NO_SIGNAL_UPDATE=1
+		shift
+		;;
+	-h | --help)
+		grep '^#' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*) die "unknown flag: $1" ;;
+	esac
 done
 
-[[ -n "$PHASE" ]]  || die "--phase is required"
-[[ -n "$TICKET" ]] || die "--ticket is required"
-[[ -n "$STATUS" ]] || die "--status is required"
+[[ -n $PHASE ]] || die "--phase is required"
+[[ -n $TICKET ]] || die "--ticket is required"
+[[ -n $STATUS ]] || die "--status is required"
 
 case "$STATUS" in
-  complete|failed|turn-cap-exhausted) ;;
-  *) die "--status must be 'complete', 'failed', or 'turn-cap-exhausted' (got: $STATUS)" ;;
+complete | failed | turn-cap-exhausted) ;;
+*) die "--status must be 'complete', 'failed', or 'turn-cap-exhausted' (got: $STATUS)" ;;
 esac
 
 # Validate ticket shape against the same pattern the broker uses.
-if [[ ! "$TICKET" =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
-  die "invalid --ticket: $TICKET (expected e.g. CTL-100)"
+if [[ ! $TICKET =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
+	die "invalid --ticket: $TICKET (expected e.g. CTL-100)"
 fi
 
 # Validate phase name (no dots — they would break the event name parser).
-if [[ "$PHASE" == *.* ]]; then
-  die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
+if [[ $PHASE == *.* ]]; then
+	die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
 fi
 
 # ─── 1. Emit canonical event ────────────────────────────────────────────────
 
 EVENT_NAME="phase.${PHASE}.${STATUS}.${TICKET}"
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-SEVERITY=$([[ "$STATUS" == "complete" ]] && echo INFO || echo WARN)
+SEVERITY=$([[ $STATUS == "complete" ]] && echo INFO || echo WARN)
 TRACE_ID=$(derive_trace_id "$ORCH_ID" "$SESSION_ID")
 SPAN_ID=$(derive_span_id "$TICKET" "$SESSION_ID")
 
@@ -126,34 +159,34 @@ SPAN_ID=$(derive_span_id "$TICKET" "$SESSION_ID")
 # The broker's tryPhaseLifecycleRoute parser reads only event.name + ticket,
 # so payload extras don't change routing.
 PAYLOAD=$(jq -nc \
-  --arg phase "$PHASE" \
-  --arg ticket "$TICKET" \
-  --arg status "$STATUS" \
-  --arg reason "$REASON" \
-  --arg handoff "$HANDOFF_PATH" \
-  '{phase: $phase, ticket: $ticket, status: $status}
+	--arg phase "$PHASE" \
+	--arg ticket "$TICKET" \
+	--arg status "$STATUS" \
+	--arg reason "$REASON" \
+	--arg handoff "$HANDOFF_PATH" \
+	'{phase: $phase, ticket: $ticket, status: $status}
    + (if $reason == "" then {} else {failure_reason: $reason} end)
    + (if $handoff == "" then {} else {handoff_path: $handoff} end)')
 
 LINE=$(build_canonical_line \
-  --ts "$TS" \
-  --severity "$SEVERITY" \
-  --service "catalyst.phase-agent" \
-  --event-name "$EVENT_NAME" \
-  --trace-id "$TRACE_ID" \
-  --span-id "$SPAN_ID" \
-  --entity "phase" \
-  --action "$STATUS" \
-  --orch "$ORCH_ID" \
-  --worker "$TICKET" \
-  --session "$SESSION_ID" \
-  --linear-ticket "$TICKET" \
-  --message "Phase ${PHASE} ${STATUS} on ${TICKET}" \
-  --payload-json "$PAYLOAD" \
-  2>/dev/null) || warn "failed to build canonical event line"
+	--ts "$TS" \
+	--severity "$SEVERITY" \
+	--service "catalyst.phase-agent" \
+	--event-name "$EVENT_NAME" \
+	--trace-id "$TRACE_ID" \
+	--span-id "$SPAN_ID" \
+	--entity "phase" \
+	--action "$STATUS" \
+	--orch "$ORCH_ID" \
+	--worker "$TICKET" \
+	--session "$SESSION_ID" \
+	--linear-ticket "$TICKET" \
+	--message "Phase ${PHASE} ${STATUS} on ${TICKET}" \
+	--payload-json "$PAYLOAD" \
+	2>/dev/null) || warn "failed to build canonical event line"
 
-if [[ -n "$LINE" ]]; then
-  canonical_jsonl_append "$EVENTS_DIR" "$LINE" || warn "failed to append event to ${EVENTS_DIR}"
+if [[ -n $LINE ]]; then
+	canonical_jsonl_append "$EVENTS_DIR" "$LINE" || warn "failed to append event to ${EVENTS_DIR}"
 fi
 
 # ─── 2. Update phase signal file ────────────────────────────────────────────
@@ -162,69 +195,69 @@ fi
 # orchestrate-healthcheck stall) have already written the signal to
 # status="stalled" and need only the event from step 1 — skip the mutation.
 
-if [[ -n "$ORCH_DIR" && "$NO_SIGNAL_UPDATE" -eq 0 ]]; then
-  SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
-  if [[ -f "$SIGNAL_FILE" ]]; then
-    # CTL-484: turn-cap-exhausted is a non-terminal status the continuation
-    # branch of orchestrate-revive picks up. Map the canonical event status to
-    # the signal-file status separately so the broker (which only sees event
-    # names) and orchestrate-revive (which reads the per-phase signal file)
-    # agree on the distinction.
-    case "$STATUS" in
-      complete)           NEW_STATUS="done" ;;
-      failed)             NEW_STATUS="failed" ;;
-      turn-cap-exhausted) NEW_STATUS="turn-cap-exhausted" ;;
-    esac
-    # turn-cap-exhausted is NOT a terminal state — leave completedAt unset so
-    # consumers can distinguish "worker stopped at cap, awaiting continuation"
-    # from "worker reached its definition of done".
-    if [[ "$STATUS" == "turn-cap-exhausted" ]]; then
-      SET_COMPLETED='.'
-    else
-      SET_COMPLETED='.completedAt = $ts'
-    fi
-    TMP="${SIGNAL_FILE}.tmp.$$"
-    if jq --arg status "$NEW_STATUS" \
-          --arg ts "$TS" \
-          --arg reason "$REASON" \
-          --arg handoff "$HANDOFF_PATH" \
-          ".status = \$status
+if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
+	SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+	if [[ -f $SIGNAL_FILE ]]; then
+		# CTL-484: turn-cap-exhausted is a non-terminal status the continuation
+		# branch of orchestrate-revive picks up. Map the canonical event status to
+		# the signal-file status separately so the broker (which only sees event
+		# names) and orchestrate-revive (which reads the per-phase signal file)
+		# agree on the distinction.
+		case "$STATUS" in
+		complete) NEW_STATUS="done" ;;
+		failed) NEW_STATUS="failed" ;;
+		turn-cap-exhausted) NEW_STATUS="turn-cap-exhausted" ;;
+		esac
+		# turn-cap-exhausted is NOT a terminal state — leave completedAt unset so
+		# consumers can distinguish "worker stopped at cap, awaiting continuation"
+		# from "worker reached its definition of done".
+		if [[ $STATUS == "turn-cap-exhausted" ]]; then
+			SET_COMPLETED='.'
+		else
+			SET_COMPLETED='.completedAt = $ts'
+		fi
+		TMP="${SIGNAL_FILE}.tmp.$$"
+		if jq --arg status "$NEW_STATUS" \
+			--arg ts "$TS" \
+			--arg reason "$REASON" \
+			--arg handoff "$HANDOFF_PATH" \
+			".status = \$status
            | ${SET_COMPLETED}
            | .updatedAt = \$ts
            | (if \$reason  == \"\" then . else .failureReason = \$reason end)
            | (if \$handoff == \"\" then . else .handoffPath    = \$handoff end)" \
-          "$SIGNAL_FILE" > "$TMP" 2>/dev/null; then
-      mv "$TMP" "$SIGNAL_FILE"
-    else
-      rm -f "$TMP"
-      warn "failed to update signal file $SIGNAL_FILE"
-    fi
-  else
-    warn "signal file not found: $SIGNAL_FILE (skipping update)"
-  fi
+			"$SIGNAL_FILE" >"$TMP" 2>/dev/null; then
+			mv "$TMP" "$SIGNAL_FILE"
+		else
+			rm -f "$TMP"
+			warn "failed to update signal file $SIGNAL_FILE"
+		fi
+	else
+		warn "signal file not found: $SIGNAL_FILE (skipping update)"
+	fi
 fi
 
 # ─── 3. End catalyst-session ────────────────────────────────────────────────
 
-if [[ -n "$SESSION_ID" ]] && [[ -x "${SCRIPT_DIR}/catalyst-session.sh" ]]; then
-  # catalyst-session.sh end only accepts done|failed. turn-cap-exhausted maps
-  # to `failed` for the session DB (the session genuinely stopped before its
-  # /goal completed) but the reason carries the disambiguating signal so
-  # downstream telemetry can tell cap-exits apart from real errors (CTL-484).
-  case "$STATUS" in
-    complete)           SESSION_OUTCOME=done ;;
-    turn-cap-exhausted) SESSION_OUTCOME=failed ;;
-    *)                  SESSION_OUTCOME=failed ;;
-  esac
-  REASON_FLAG=()
-  if [[ -n "$REASON" ]]; then
-    REASON_FLAG=(--reason "$REASON")
-  elif [[ "$STATUS" == "turn-cap-exhausted" ]]; then
-    REASON_FLAG=(--reason "turn-cap-exhausted")
-  fi
-  "${SCRIPT_DIR}/catalyst-session.sh" end "$SESSION_ID" \
-    --status "$SESSION_OUTCOME" "${REASON_FLAG[@]}" >/dev/null 2>&1 \
-    || warn "catalyst-session.sh end failed for $SESSION_ID"
+if [[ -n $SESSION_ID ]] && [[ -x "${SCRIPT_DIR}/catalyst-session.sh" ]]; then
+	# catalyst-session.sh end only accepts done|failed. turn-cap-exhausted maps
+	# to `failed` for the session DB (the session genuinely stopped before its
+	# /goal completed) but the reason carries the disambiguating signal so
+	# downstream telemetry can tell cap-exits apart from real errors (CTL-484).
+	case "$STATUS" in
+	complete) SESSION_OUTCOME=done ;;
+	turn-cap-exhausted) SESSION_OUTCOME=failed ;;
+	*) SESSION_OUTCOME=failed ;;
+	esac
+	REASON_FLAG=()
+	if [[ -n $REASON ]]; then
+		REASON_FLAG=(--reason "$REASON")
+	elif [[ $STATUS == "turn-cap-exhausted" ]]; then
+		REASON_FLAG=(--reason "turn-cap-exhausted")
+	fi
+	"${SCRIPT_DIR}/catalyst-session.sh" end "$SESSION_ID" \
+		--status "$SESSION_OUTCOME" "${REASON_FLAG[@]}" >/dev/null 2>&1 ||
+		warn "catalyst-session.sh end failed for $SESSION_ID"
 fi
 
 exit 0

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -14,7 +14,7 @@
 #   2. Update the phase signal file
 #        ${ORCH_DIR}/workers/<TICKET>/phase-<name>.json
 #      with status=done|failed, completedAt timestamp, and (on failure) a
-#      failureReason field.
+#      failureReason field. Skipped when --no-signal-update is passed.
 #
 #   3. End the catalyst-session via catalyst-session.sh end so OTel session
 #      outcomes are emitted and the SQLite row is closed.
@@ -27,7 +27,15 @@
 #     [--reason <text>] \
 #     [--orch-dir <path>] \
 #     [--orch-id <id>] \
-#     [--session-id <id>]
+#     [--session-id <id>] \
+#     [--no-signal-update]
+#
+# --no-signal-update (CTL-511): emit the canonical event (step 1) and end the
+#   catalyst-session (step 3) but skip the signal-file mutation (step 2). Used
+#   by phase-agent-dispatch and orchestrate-healthcheck, which write the signal
+#   to status="stalled" themselves and only need this script to wake the
+#   orchestrator with the event — flipping the signal to "failed" here would
+#   make orchestrate-revive Loop 2 skip the redispatch.
 #
 # Defaults: --orch-dir = $CATALYST_ORCHESTRATOR_DIR
 #           --orch-id  = $CATALYST_ORCHESTRATOR_ID
@@ -68,19 +76,21 @@ HANDOFF_PATH=""
 ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
 ORCH_ID="${CATALYST_ORCHESTRATOR_ID:-}"
 SESSION_ID="${CATALYST_SESSION_ID:-}"
+NO_SIGNAL_UPDATE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --phase)        PHASE="$2"; shift 2 ;;
-    --ticket)       TICKET="$2"; shift 2 ;;
-    --status)       STATUS="$2"; shift 2 ;;
-    --reason)       REASON="$2"; shift 2 ;;
-    --handoff-path) HANDOFF_PATH="$2"; shift 2 ;;
-    --orch-dir)     ORCH_DIR="$2"; shift 2 ;;
-    --orch-id)      ORCH_ID="$2"; shift 2 ;;
-    --session-id)   SESSION_ID="$2"; shift 2 ;;
-    -h|--help)      grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-    *)              die "unknown flag: $1" ;;
+    --phase)             PHASE="$2"; shift 2 ;;
+    --ticket)            TICKET="$2"; shift 2 ;;
+    --status)            STATUS="$2"; shift 2 ;;
+    --reason)            REASON="$2"; shift 2 ;;
+    --handoff-path)      HANDOFF_PATH="$2"; shift 2 ;;
+    --orch-dir)          ORCH_DIR="$2"; shift 2 ;;
+    --orch-id)           ORCH_ID="$2"; shift 2 ;;
+    --session-id)        SESSION_ID="$2"; shift 2 ;;
+    --no-signal-update)  NO_SIGNAL_UPDATE=1; shift ;;
+    -h|--help)           grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)                   die "unknown flag: $1" ;;
   esac
 done
 
@@ -147,8 +157,12 @@ if [[ -n "$LINE" ]]; then
 fi
 
 # ─── 2. Update phase signal file ────────────────────────────────────────────
+#
+# CTL-511: --no-signal-update callers (phase-agent-dispatch launch-failure,
+# orchestrate-healthcheck stall) have already written the signal to
+# status="stalled" and need only the event from step 1 — skip the mutation.
 
-if [[ -n "$ORCH_DIR" ]]; then
+if [[ -n "$ORCH_DIR" && "$NO_SIGNAL_UPDATE" -eq 0 ]]; then
   SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
   if [[ -f "$SIGNAL_FILE" ]]; then
     # CTL-484: turn-cap-exhausted is a non-terminal status the continuation

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -522,12 +522,12 @@ For each provisioned worker worktree, dispatch a `/oneshot` session.
 
 **Register broker filter interests BEFORE dispatch (CTL-491):** Phase-agent workers can finish in
 well under a second when their work is a no-op (e.g. an already-triaged ticket). Emitting
-`filter.register` events AFTER dispatch opens a race window where the broker's interest map is
-still empty when `phase.<name>.complete.<TICKET>` arrives — `processEvent` early-returns and the
-event is dropped silently (`broker/index.mjs:1782`). Run the registration helper here so all four
-deterministic + per-ticket interests are durable in the broker BEFORE any `claude --bg`
-invocation. Idempotent at the broker (upserts by `interest_id`); the Phase 4 entry re-invokes
-the same helper as a belt-and-suspenders.
+`filter.register` events AFTER dispatch opens a race window where the broker's interest map is still
+empty when `phase.<name>.complete.<TICKET>` arrives — `processEvent` early-returns and the event is
+dropped silently (`broker/index.mjs:1782`). Run the registration helper here so all four
+deterministic + per-ticket interests are durable in the broker BEFORE any `claude --bg` invocation.
+Idempotent at the broker (upserts by `interest_id`); the Phase 4 entry re-invokes the same helper as
+a belt-and-suspenders.
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-register-interests.sh" \
@@ -686,12 +686,12 @@ worker activity. Key event types:
 | `{"type":"system","subtype":"api_retry"}`                                                                         | Worker hit rate limit / error; shows attempt and delay          |
 | `{"type":"result"}`                                                                                               | Worker finished; contains final answer and usage stats          |
 
-**Worker usage / cost is rolled in by the monitor pass (CTL-115, wired through `update-dashboard.sh
---roll-usage` since CTL-487).** The dispatch shell backgrounds workers with `&` and never `wait`s
-on them, so usage/cost extraction cannot happen here. Phase 4's `update-dashboard.sh` call passes
-`--roll-usage`, which iterates `${ORCH_DIR}/workers/*.json` and invokes
-`plugins/dev/scripts/orchestrate-roll-usage.sh -v` per worker before rendering. The helper parses
-the final `result` event from the worker's stream file and:
+**Worker usage / cost is rolled in by the monitor pass (CTL-115, wired through
+`update-dashboard.sh --roll-usage` since CTL-487).** The dispatch shell backgrounds workers with `&`
+and never `wait`s on them, so usage/cost extraction cannot happen here. Phase 4's
+`update-dashboard.sh` call passes `--roll-usage`, which iterates `${ORCH_DIR}/workers/*.json` and
+invokes `plugins/dev/scripts/orchestrate-roll-usage.sh -v` per worker before rendering. The helper
+parses the final `result` event from the worker's stream file and:
 
 1. Mirror cost into the worker's signal file (`.cost = USAGE`) — the dashboard reads signal files
    (not global state) for per-worker cost columns.
@@ -700,8 +700,8 @@ the final `result` event from the worker's stream file and:
 
 The helper is idempotent (gated on `signal.cost == null`) and safe to call every cycle. Because
 every dashboard render now sweeps every worker, `update-dashboard.sh --roll-usage` doubles as the
-periodic safety net for any worker whose stream contains a `result` event but whose `signal.cost`
-is still null. Audit trail lands at `${ORCH_DIR}/.roll-usage.log`.
+periodic safety net for any worker whose stream contains a `result` event but whose `signal.cost` is
+still null. Audit trail lands at `${ORCH_DIR}/.roll-usage.log`.
 
 **Emit dispatch event and update global state** after each worker dispatch:
 
@@ -718,13 +718,13 @@ is still null. Audit trail lands at `${ORCH_DIR}/.roll-usage.log`.
 
 After the wave's per-worker dispatch loop has completed, run the batch health check. This is the
 **per-wave** invocation (CTL-511 added a second call site — see the reactive scan in Phase 4). It
-sleeps briefly (default 15s — configurable via `--grace-seconds`), then verifies that
-every worker still sitting at `status="dispatched"`/`phase=0` has a live PID. Any worker whose PID
-has already died is transitioned to `status="failed"` with `failureReason="launch-failure"`, an
-attention item of type `launch-failure` is raised, and a `worker-launch-failed` event is emitted.
-This means dead-on-arrival workers surface in under 30 seconds instead of after the 15-minute
-stalled-worker timeout, and the orchestrator can re-dispatch them (via `orchestrate-fixup` or a
-manual redispatch) in the same wave.
+sleeps briefly (default 15s — configurable via `--grace-seconds`), then verifies that every worker
+still sitting at `status="dispatched"`/`phase=0` has a live PID. Any worker whose PID has already
+died is transitioned to `status="failed"` with `failureReason="launch-failure"`, an attention item
+of type `launch-failure` is raised, and a `worker-launch-failed` event is emitted. This means
+dead-on-arrival workers surface in under 30 seconds instead of after the 15-minute stalled-worker
+timeout, and the orchestrator can re-dispatch them (via `orchestrate-fixup` or a manual redispatch)
+in the same wave.
 
 ```bash
 # Run ONCE, after all workers in this wave have been dispatched.
@@ -743,7 +743,7 @@ the stalled-worker scan catches workers that die mid-run.
 
 **CTL-511:** the same `orchestrate-healthcheck` script also runs inside the reactive scan (Phase 4)
 on every wake-up and every 10-minute idle tick — it is no longer a once-per-wave-only check. That
-second call site catches phase agents that die *after* launch (printing a job id, then exiting
+second call site catches phase agents that die _after_ launch (printing a job id, then exiting
 before their terminal emit), bounding detection to one scan interval. The healthcheck is idempotent
 — terminal and `stalled` signals are skipped — so the extra call site adds no duplicate work.
 
@@ -911,8 +911,8 @@ The helper emits four deterministic interests (route without Groq):
 - `ticket_lifecycle` — Linear ticket state changes for the orchestrator's tickets.
 - `comms_lifecycle` — worker-posted `attention` / `done` messages on the shared channel.
 - `phase_lifecycle` (CTL-452, CTL-484) — `phase.<name>.complete.<TICKET>`,
-  `phase.<name>.failed.<TICKET>`, and `phase.<name>.turn-cap-exhausted.<TICKET>` events emitted
-  by phase agents. One interest per active ticket, covering all 9 phase names. The turn-cap status
+  `phase.<name>.failed.<TICKET>`, and `phase.<name>.turn-cap-exhausted.<TICKET>` events emitted by
+  phase agents. One interest per active ticket, covering all 9 phase names. The turn-cap status
   routes through `orchestrate-revive`'s continuation branch (separate budget from error revives).
   Only registered when `catalyst.orchestration.dispatchMode = "phase-agents"`.
 
@@ -930,13 +930,13 @@ change.
 # when neither catalyst-broker nor catalyst-filter is running.
 ```
 
-**Replay race-window phase events (CTL-491):** Before entering the event-driven wait loop, catch
-up on any `phase.<name>.{complete,failed,turn-cap-exhausted}.<TICKET>` events that landed between
-the Phase 2 baseline (`state.json.race.startLineCursor`) and now. With the Phase 3 pre-dispatch
+**Replay race-window phase events (CTL-491):** Before entering the event-driven wait loop, catch up
+on any `phase.<name>.{complete,failed,turn-cap-exhausted}.<TICKET>` events that landed between the
+Phase 2 baseline (`state.json.race.startLineCursor`) and now. With the Phase 3 pre-dispatch
 registration the window should be zero-length in steady state, but the replay is idempotent and
-cheap — it scans only the tail of the current month's event log past the baseline cursor and
-routes each match through `orchestrate-phase-advance` (for `complete`) or `orchestrate-revive`
-(for `failed` / `turn-cap-exhausted`). Cross-orchestrator events are filtered out by checking
+cheap — it scans only the tail of the current month's event log past the baseline cursor and routes
+each match through `orchestrate-phase-advance` (for `complete`) or `orchestrate-revive` (for
+`failed` / `turn-cap-exhausted`). Cross-orchestrator events are filtered out by checking
 `workers/*.json` for the ticket.
 
 ```bash
@@ -1089,23 +1089,23 @@ transcript fixture.
 scan so the response stays proportional. Every reaction reads authoritative state from `gh pr view`,
 `git rev-list`, or the signal file — events are wake-up triggers, never sources of truth.
 
-| Event                                                                                           | Reaction                                                                                                                                                                                                                                                                                                                                           |
-| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `orchestrator.worker.phase_advanced`                                                            | Routine in-flight progress; re-render `DASHBOARD.md`. Coalesced — `.body.payload.changes` carries the batch (CTL-229)                                                                                                                                                                                                                              |
-| `orchestrator.worker.status_terminal`, `orchestrator.worker.done`, `orchestrator.worker.failed` | Terminal transition; re-render `DASHBOARD.md` and run `orchestrate-dispatch-next` to fill freed slots. PR-bearing transitions carry `.body.payload.pr.{number,url}` (CTL-229)                                                                                                                                                                      |
-| `orchestrator.worker.pr_created`                                                                | Reconcile the PR number into signal/state; re-render `DASHBOARD.md`                                                                                                                                                                                                                                                                                |
-| `orchestrator.attention.raised`, `orchestrator.attention.resolved`                              | Re-render the `DASHBOARD.md` NEEDS ATTENTION banner                                                                                                                                                                                                                                                                                                |
-| `github.pr.merged`, `github.pr.closed`                                                          | Run the merge-confirmation scan for that PR                                                                                                                                                                                                                                                                                                        |
-| `github.pr.synchronize`, `github.push`                                                          | Re-evaluate `mergeStateStatus` for the affected PR; if DIRTY ≥2 min, `orchestrate-auto-rebase` may dispatch a rebase worker (BEHIND auto-resolves via auto-merge)                                                                                                                                                                                  |
-| `github.check_*`, `github.workflow_run.completed`                                               | Re-check CI; if BLOCKED ≥10 min, `orchestrate-auto-fixup` may dispatch a fix-up. `workflow_run.completed` is the most reliable CI-done signal                                                                                                                                                                                                      |
-| `github.pr_review*`, `github.pr_review_comment*`, `github.issue_comment.created`                | Re-evaluate `mergeStateStatus`; surface review activity on the dashboard. Codex review threads land as `pr_review_comment.created` — required for CTL-64 BLOCKED auto-fixup detection                                                                                                                                                              |
-| `github.deployment*`                                                                            | Record deploy outcome on the worker's signal file                                                                                                                                                                                                                                                                                                  |
-| `linear.issue.state_changed`                                                                    | Reconcile Linear state with the worker signal                                                                                                                                                                                                                                                                                                      |
-| `filter.wake.${ORCH_NAME}` (matched on full dotted `event.name`)                                | Daemon-filtered semantic wake: read `.body.payload.reason` for log context, then run the full reactive scan. The reason describes what triggered the daemon (e.g., "CI failed on PR #416") but is never the authoritative source                                                                                                                   |
-| `phase.<name>.complete.<TICKET>` (via phase_lifecycle, CTL-452)                                 | Resolve the next phase via `orchestrate-phase-advance --ticket <T> --completed-phase <name>`; that helper looks up the next phase in the canonical 9-phase sequence and calls `orchestrate-dispatch-next --phase <next> --ticket <T>`. If `completed-phase=monitor-deploy`, no advance (terminal). The advance is idempotent under redundant wakes |
-| `phase.<name>.failed.<TICKET>` (via phase_lifecycle, CTL-452)                                   | Run `orchestrate-revive` once for the affected ticket; on the **second** failure (reviveCount ≥ MAX_REVIVES), mark worker `stalled` and post `attention` to the shared comms channel. Matches the existing one-retry-then-escalate handling for legacy oneshot workers                                                                             |
+| Event                                                                                           | Reaction                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `orchestrator.worker.phase_advanced`                                                            | Routine in-flight progress; re-render `DASHBOARD.md`. Coalesced — `.body.payload.changes` carries the batch (CTL-229)                                                                                                                                                                                                                                                                                                                                                     |
+| `orchestrator.worker.status_terminal`, `orchestrator.worker.done`, `orchestrator.worker.failed` | Terminal transition; re-render `DASHBOARD.md` and run `orchestrate-dispatch-next` to fill freed slots. PR-bearing transitions carry `.body.payload.pr.{number,url}` (CTL-229)                                                                                                                                                                                                                                                                                             |
+| `orchestrator.worker.pr_created`                                                                | Reconcile the PR number into signal/state; re-render `DASHBOARD.md`                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `orchestrator.attention.raised`, `orchestrator.attention.resolved`                              | Re-render the `DASHBOARD.md` NEEDS ATTENTION banner                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `github.pr.merged`, `github.pr.closed`                                                          | Run the merge-confirmation scan for that PR                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `github.pr.synchronize`, `github.push`                                                          | Re-evaluate `mergeStateStatus` for the affected PR; if DIRTY ≥2 min, `orchestrate-auto-rebase` may dispatch a rebase worker (BEHIND auto-resolves via auto-merge)                                                                                                                                                                                                                                                                                                         |
+| `github.check_*`, `github.workflow_run.completed`                                               | Re-check CI; if BLOCKED ≥10 min, `orchestrate-auto-fixup` may dispatch a fix-up. `workflow_run.completed` is the most reliable CI-done signal                                                                                                                                                                                                                                                                                                                             |
+| `github.pr_review*`, `github.pr_review_comment*`, `github.issue_comment.created`                | Re-evaluate `mergeStateStatus`; surface review activity on the dashboard. Codex review threads land as `pr_review_comment.created` — required for CTL-64 BLOCKED auto-fixup detection                                                                                                                                                                                                                                                                                     |
+| `github.deployment*`                                                                            | Record deploy outcome on the worker's signal file                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `linear.issue.state_changed`                                                                    | Reconcile Linear state with the worker signal                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `filter.wake.${ORCH_NAME}` (matched on full dotted `event.name`)                                | Daemon-filtered semantic wake: read `.body.payload.reason` for log context, then run the full reactive scan. The reason describes what triggered the daemon (e.g., "CI failed on PR #416") but is never the authoritative source                                                                                                                                                                                                                                          |
+| `phase.<name>.complete.<TICKET>` (via phase_lifecycle, CTL-452)                                 | Resolve the next phase via `orchestrate-phase-advance --ticket <T> --completed-phase <name>`; that helper looks up the next phase in the canonical 9-phase sequence and calls `orchestrate-dispatch-next --phase <next> --ticket <T>`. If `completed-phase=monitor-deploy`, no advance (terminal). The advance is idempotent under redundant wakes                                                                                                                        |
+| `phase.<name>.failed.<TICKET>` (via phase_lifecycle, CTL-452)                                   | Run `orchestrate-revive` once for the affected ticket; on the **second** failure (reviveCount ≥ MAX_REVIVES), mark worker `stalled` and post `attention` to the shared comms channel. Matches the existing one-retry-then-escalate handling for legacy oneshot workers                                                                                                                                                                                                    |
 | `phase.<name>.turn-cap-exhausted.<TICKET>` (via phase_lifecycle, CTL-484)                       | Run `orchestrate-revive` (same script — its continuation branch handles this status). The branch reads `handoffPath` from the per-phase signal, dispatches a `claude --bg --resume` continuation with `CATALYST_IS_CONTINUATION=true` + `CATALYST_HANDOFF_PATH` + `CATALYST_CONTINUATION_COUNT`, and bumps `.continuationCount` on a budget separate from `.reviveCount` (default 3). On budget exhaustion: `stalled` + `attentionReason="continuation-budget-exhausted"` |
-| 10-minute idle (no event)                                                                       | Run the full reactive scan as a safety net                                                                                                                                                                                                                                                                                                         |
+| 10-minute idle (no event)                                                                       | Run the full reactive scan as a safety net                                                                                                                                                                                                                                                                                                                                                                                                                                |
 
 **Ground truth is git + PR, not the signal file.** The signal file is _advisory_ — it reports the
 worker's self-described phase. Authoritative decisions (done, stalled) come from `gh pr view` /
@@ -1417,20 +1417,20 @@ done
 ```
 
 **Refresh broker registration when PR or ticket set has changed (CTL-341, CTL-357, CTL-491).** On
-every Phase 4 wake-up, re-invoke the same registration helper with `--refresh`. The helper diffs
-the current active PR + ticket sets against the prior `.last-registration.json` baseline:
+every Phase 4 wake-up, re-invoke the same registration helper with `--refresh`. The helper diffs the
+current active PR + ticket sets against the prior `.last-registration.json` baseline:
 
 - If nothing changed, the helper exits 0 with zero events emitted — keeps the event log quiet.
-- If the PR set changed (a worker just opened a PR), it re-emits all three deterministic
-  interests (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`) with the updated set.
-- If the ticket set grew (wave 2 dispatched new workers mid-run), it ALSO emits a
-  `phase_lifecycle` interest for each newly-added ticket. Existing tickets already have
-  per-ticket interests upserted at the broker from the initial pre-dispatch registration.
+- If the PR set changed (a worker just opened a PR), it re-emits all three deterministic interests
+  (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`) with the updated set.
+- If the ticket set grew (wave 2 dispatched new workers mid-run), it ALSO emits a `phase_lifecycle`
+  interest for each newly-added ticket. Existing tickets already have per-ticket interests upserted
+  at the broker from the initial pre-dispatch registration.
 - Idempotent at the broker (upserts by `interest_id`); the diff just keeps the event log quiet.
 
-This block replaces the older `.last-pr-registration.json` PR-only refresh path — the helper
-covers both deterministic-set refreshes AND the previously-missing `phase_lifecycle` refresh that
-would otherwise leave wave 2 tickets without broker coverage (a localized CTL-491 race).
+This block replaces the older `.last-pr-registration.json` PR-only refresh path — the helper covers
+both deterministic-set refreshes AND the previously-missing `phase_lifecycle` refresh that would
+otherwise leave wave 2 tickets without broker coverage (a localized CTL-491 race).
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-register-interests.sh" \

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -716,8 +716,9 @@ is still null. Audit trail lands at `${ORCH_DIR}/.roll-usage.log`.
 
 **Post-dispatch health check (CTL-87):**
 
-After the wave's per-worker dispatch loop has completed, run the batch health check **once per
-wave**. It sleeps briefly (default 15s — configurable via `--grace-seconds`), then verifies that
+After the wave's per-worker dispatch loop has completed, run the batch health check. This is the
+**per-wave** invocation (CTL-511 added a second call site — see the reactive scan in Phase 4). It
+sleeps briefly (default 15s — configurable via `--grace-seconds`), then verifies that
 every worker still sitting at `status="dispatched"`/`phase=0` has a live PID. Any worker whose PID
 has already died is transitioned to `status="failed"` with `failureReason="launch-failure"`, an
 attention item of type `launch-failure` is raised, and a `worker-launch-failed` event is emitted.
@@ -739,6 +740,12 @@ Healthy workers are untouched. Workers that have already advanced past `dispatch
 `researching`) are skipped because reaching a later status is itself proof of life. This check
 complements the 15-minute stalled-worker detection in Phase 4 — healthcheck catches launch failures,
 the stalled-worker scan catches workers that die mid-run.
+
+**CTL-511:** the same `orchestrate-healthcheck` script also runs inside the reactive scan (Phase 4)
+on every wake-up and every 10-minute idle tick — it is no longer a once-per-wave-only check. That
+second call site catches phase agents that die *after* launch (printing a job id, then exiting
+before their terminal emit), bounding detection to one scan interval. The healthcheck is idempotent
+— terminal and `stalled` signals are skipped — so the extra call site adds no duplicate work.
 
 **Worker dispatch prompt includes mandatory testing AND lifecycle requirements:**
 
@@ -1110,6 +1117,18 @@ git/PR, the orchestrator reconciles the signal from the authoritative source.
 **Reactive scan (per wake-up):**
 
 ```bash
+# CTL-511: re-run the phase-agent stall scan on every reactive scan (every wake
+# + the 10-min idle fallback), not just once per dispatch wave. A phase agent
+# that dies after launch is flipped to status:"stalled" here; orchestrate-healthcheck
+# then emits phase.<name>.failed to wake orchestrate-revive within one scan
+# interval instead of ~14 h. Idempotent — terminal/stalled signals are skipped,
+# so frequent runs are safe. --grace-seconds 0 skips the 15s legacy-PID settle
+# sleep: the phase-mode state.json check has its own --stale-bg-seconds
+# threshold, so the sleep would only add latency to every wake.
+"${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-healthcheck" \
+  --orch-dir "${ORCH_DIR}" --orch-id "${ORCH_NAME}" --grace-seconds 0 \
+  >/dev/null 2>&1 || true
+
 # For each active worker:
 for WORKER_SIGNAL in ${ORCH_DIR}/workers/*.json; do
   TICKET=$(jq -r '.ticket' "$WORKER_SIGNAL")


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-20T00:00:00Z -->
<!-- Last updated: 2026-05-20T00:00:00Z -->
<!-- PR: #933 -->
<!-- Previous commits: ec76973a114e873a64724cde1f7b603e894d8bf5,86e8ed744a9e493f9b8ba6c1c95b5924a4a07301,190abaf7a8a139ee2b5cb5ae61c934f81bcc0178,3060c46ea5d662bcb9b533aaa2b44c664f514250,a68e53fcb660eb54f2c5c2c0912741a85697c71b,3c111cde54c8e783eb38380677c59525559c58c4 -->

## Summary

A phase-agent background job (e.g. `phase-monitor-merge`) could die at launch or
exit immediately without ever emitting a `phase.<name>.failed` event. The
orchestrator was left blind: the phase signal file stayed `status=running` until
`orchestrate-healthcheck` happened to flag it stalled — in the originating
incident, ~14h later — so a BLOCKED PR sat unrecovered.

This PR wires up failure detection at three points so a dead phase agent is
detected within one scan interval and immediately triggers recovery:

1. `phase-agent-dispatch` verifies the `claude --bg` job actually started and
   emits `phase.<name>.failed` if it did not.
2. `orchestrate-healthcheck` emits `phase.<name>.failed` when it flips a signal
   to `stalled`, so the broker wakes the orchestrator and `orchestrate-revive`
   fires.
3. The orchestrator runs `orchestrate-healthcheck` on every reactive scan, not
   just once per dispatch wave.

## Changes Made

### Phase 1 — shared event-only primitive

- `phase-agent-emit-complete`: added a `--no-signal-update` flag that emits the
  canonical `phase.<name>.<status>.<ticket>` event and ends the
  catalyst-session, but skips the signal-file mutation. Phases 2 and 3 write the
  signal to `status="stalled"` themselves and only need this script to wake the
  orchestrator — flipping the signal to `failed` here would make
  `orchestrate-revive` Loop 2 skip the redispatch.

### Phase 2 — detect launch failure

- `phase-agent-dispatch`: added a `mark_launch_failed` helper, called from both
  `claude --bg` launch-failure branches (non-zero exit and empty job id).
  Previously the signal was left frozen at `status="dispatched"` with no event.
  The helper rewrites the signal to `status="stalled"` with `attentionReason`
  (deliberately not `failureReason`, which would trip `orchestrate-revive`
  Loop 2 Branch 1's escalate-without-retry path) and emits
  `phase.<name>.failed.<TICKET>` via the Phase 1 event-only mode.

### Phase 3 — detect post-launch stall

- `orchestrate-healthcheck`: it already flipped a dead phase agent's signal to
  `status="stalled"` and emitted `worker-phase-stalled`, but that event does not
  match the broker's `PHASE_EVENT_PATTERN`, so it never woke the orchestrator.
  Added a `phase.<name>.failed.<TICKET>` emission right after the signal flip so
  the broker's `phase_lifecycle` route wakes the orchestrator immediately. The
  existing `worker-phase-stalled` event and attention item are unchanged.
- New `CATALYST_EMIT_COMPLETE` env override (test-only, documented in the
  script header) for both `phase-agent-dispatch` and `orchestrate-healthcheck`.

### Phase 4 — run healthcheck on every reactive scan

- `plugins/dev/skills/orchestrate/SKILL.md`: wired an
  `orchestrate-healthcheck --grace-seconds 0` call into the orchestrator's
  reactive-scan block so it runs on every wake-up and on the 10-minute idle
  fallback. `--grace-seconds 0` skips the 15s legacy-PID settle sleep
  (phase-mode uses its own `--stale-bg-seconds` threshold). Updated the
  once-per-wave prose to reflect the second call site.

### Test coverage and review follow-ups

- Rewrote the CTL-511 assertions in the dispatch and healthcheck suites as
  explicit `if/then/else` with `grep -rqs` to avoid SC2015/SC2012 shellcheck
  findings.
- Closed silent-regression coverage gaps surfaced by `pr-test-analyzer`:
  - Assert `attentionReason` is set to the expected cause string on every
    launch-failure / stall signal (previously only `failureReason` absence was
    checked).
  - `EMIT_COMPLETE` now honors `CATALYST_EMIT_COMPLETE` in `phase-agent-dispatch`
    too, with a test proving the signal write is independent of the event emit
    (recovery degrades to the slow path rather than not at all).
  - Pinned the intentional stdout/signal divergence on the non-zero-exit branch
    (stdout `status="failed"`, signal file `stalled`).
  - Added a healthcheck idempotency test: two runs against the same fixture emit
    exactly one `phase.*.failed` event, making the Phase 4 reactive-scan call
    site wake-storm-safe.

### Formatting

- One isolated `chore` commit applies `trunk fmt` (shfmt + prettier) to the
  seven CTL-511-touched files, which predated the current trunk config. No
  behavior change — review it with `git show -w`.

## How to Verify It

- [x] Shell test suites pass — `phase-agent-emit-complete.test.sh`,
  `phase-agent-dispatch.test.sh`, `orchestrate-healthcheck.test.sh`
- [x] `make lint` (trunk check) reports no new shellcheck/format issues
- [ ] Manual: confirm a phase agent killed immediately after `claude --bg`
  launch produces a `phase.<name>.failed` event and triggers `orchestrate-revive`

## Related Issues/PRs

- Fixes CTL-511

Refs: CTL-511
