### PR TITLE
CTL-528: Aggregate test runner for shell + bun suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint format check-frontmatter check install-user install-project test clean favicons
+.PHONY: help lint format check install-user install-project test clean favicons
 
 # Default target - show help
 help:
@@ -7,8 +7,8 @@ help:
 	@echo "Quality Checks:"
 	@echo "  make lint              - Run all Trunk linters (shellcheck, markdownlint, etc.)"
 	@echo "  make format            - Auto-fix formatting issues with Trunk"
-	@echo "  make check-frontmatter - Validate command/agent frontmatter consistency"
-	@echo "  make check             - Run all quality checks (lint + frontmatter)"
+	@echo "  make test              - Run the full test suite (shell + bun)"
+	@echo "  make check             - Run all quality checks (lint + test)"
 	@echo ""
 	@echo "Installation:"
 	@echo "  make install-user      - Install workspace to ~/.claude/"
@@ -31,20 +31,10 @@ format:
 	@echo "Auto-fixing formatting issues..."
 	trunk fmt
 
-# Validate frontmatter in commands and agents
-check-frontmatter:
-	@echo "Validating frontmatter in commands and agents..."
-	@for file in commands/**/*.md agents/**/*.md .claude/commands/**/*.md .claude/agents/**/*.md; do \
-		if [ -f "$$file" ]; then \
-			./hack/validate-frontmatter.sh "$$file" || exit 1; \
-		fi \
-	done
-	@echo "✅ All frontmatter valid!"
-
-# Run all quality checks
-check: lint check-frontmatter
+# Run all quality checks (real audit gate)
+check: lint test
 	@echo ""
-	@echo "✅ All quality checks passed!"
+	@echo "✅ All quality checks passed (lint + test)!"
 
 # Install to user's home directory
 install-user:
@@ -57,12 +47,10 @@ install-project:
 	@read -p "Enter project path: " path; \
 	./hack/install-project.sh "$$path"
 
-# Run tests
+# Run the full test suite (shell + bun)
 test:
-	@echo "Running plugin tests..."
-	@bash plugins/dev/scripts/test-workflow-context.sh
-	@echo ""
-	@echo "✅ All test suites passed!"
+	@echo "Running full test suite (shell + bun)..."
+	@bash plugins/dev/scripts/run-tests.sh
 
 # Build the V2 favicon set from CTL-147 mark assets and distribute to all consumer
 # locations (repo root, website/public, plugins/dev/scripts/orch-monitor/public).

--- a/plugins/dev/scripts/__tests__/makefile-targets.test.sh
+++ b/plugins/dev/scripts/__tests__/makefile-targets.test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Verifies the Makefile test/lint/check targets are wired correctly (CTL-528).
+# Run: bash plugins/dev/scripts/__tests__/makefile-targets.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+FAILURES=0
+PASSES=0
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+# make -n test invokes run-tests.sh
+if make -n -C "$REPO_ROOT" test 2>/dev/null | grep -q 'run-tests.sh'
+then pass "make test invokes run-tests.sh"
+else fail "make test does not invoke run-tests.sh"; fi
+
+# make -n lint invokes trunk check
+if make -n -C "$REPO_ROOT" lint 2>/dev/null | grep -q 'trunk check'
+then pass "make lint invokes trunk check"
+else fail "make lint does not invoke trunk check"; fi
+
+# make -n check covers BOTH lint and the test runner
+CHECK_OUT="$(make -n -C "$REPO_ROOT" check 2>/dev/null)"
+if grep -q 'trunk check' <<<"$CHECK_OUT" && grep -q 'run-tests.sh' <<<"$CHECK_OUT"
+then pass "make check chains lint + test"
+else fail "make check does not chain lint + test" "$CHECK_OUT"; fi
+
+# No broken hack/ reference remains in the Makefile
+if grep -q 'hack/validate-frontmatter' "$REPO_ROOT/Makefile"
+then fail "Makefile still references hack/validate-frontmatter.sh"
+else pass "no hack/validate-frontmatter reference in Makefile"; fi
+
+# check-frontmatter target is gone
+if make -n -C "$REPO_ROOT" check-frontmatter >/dev/null 2>&1
+then fail "check-frontmatter target still exists"
+else pass "check-frontmatter target removed"; fi
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/makefile-targets.test.sh
+++ b/plugins/dev/scripts/__tests__/makefile-targets.test.sh
@@ -8,33 +8,40 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 
 FAILURES=0
 PASSES=0
-pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
-fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
 
 # make -n test invokes run-tests.sh
-if make -n -C "$REPO_ROOT" test 2>/dev/null | grep -q 'run-tests.sh'
-then pass "make test invokes run-tests.sh"
+if make -n -C "$REPO_ROOT" test 2>/dev/null | grep -q 'run-tests.sh'; then
+	pass "make test invokes run-tests.sh"
 else fail "make test does not invoke run-tests.sh"; fi
 
 # make -n lint invokes trunk check
-if make -n -C "$REPO_ROOT" lint 2>/dev/null | grep -q 'trunk check'
-then pass "make lint invokes trunk check"
+if make -n -C "$REPO_ROOT" lint 2>/dev/null | grep -q 'trunk check'; then
+	pass "make lint invokes trunk check"
 else fail "make lint does not invoke trunk check"; fi
 
 # make -n check covers BOTH lint and the test runner
 CHECK_OUT="$(make -n -C "$REPO_ROOT" check 2>/dev/null)"
-if grep -q 'trunk check' <<<"$CHECK_OUT" && grep -q 'run-tests.sh' <<<"$CHECK_OUT"
-then pass "make check chains lint + test"
+if grep -q 'trunk check' <<<"$CHECK_OUT" && grep -q 'run-tests.sh' <<<"$CHECK_OUT"; then
+	pass "make check chains lint + test"
 else fail "make check does not chain lint + test" "$CHECK_OUT"; fi
 
 # No broken hack/ reference remains in the Makefile
-if grep -q 'hack/validate-frontmatter' "$REPO_ROOT/Makefile"
-then fail "Makefile still references hack/validate-frontmatter.sh"
+if grep -q 'hack/validate-frontmatter' "$REPO_ROOT/Makefile"; then
+	fail "Makefile still references hack/validate-frontmatter.sh"
 else pass "no hack/validate-frontmatter reference in Makefile"; fi
 
 # check-frontmatter target is gone
-if make -n -C "$REPO_ROOT" check-frontmatter >/dev/null 2>&1
-then fail "check-frontmatter target still exists"
+if make -n -C "$REPO_ROOT" check-frontmatter >/dev/null 2>&1; then
+	fail "check-frontmatter target still exists"
 else pass "check-frontmatter target removed"; fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/run-tests.test.sh
+++ b/plugins/dev/scripts/__tests__/run-tests.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Smoke test for the aggregate test runner run-tests.sh (CTL-528).
+# Run: bash plugins/dev/scripts/__tests__/run-tests.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+RUNNER="${REPO_ROOT}/plugins/dev/scripts/run-tests.sh"
+
+FAILURES=0
+PASSES=0
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+# Build a fixture __tests__ dir; args are "name:exitcode[:stderr-line]" specs.
+make_fixture() {
+	local dir
+	dir="$(mktemp -d)"
+	local spec name code line
+	for spec in "$@"; do
+		name="${spec%%:*}"
+		spec="${spec#*:}"
+		code="${spec%%:*}"
+		line="${spec#*:}"
+		[[ $line == "$code" ]] && line=""
+		{
+			echo '#!/usr/bin/env bash'
+			[[ -n $line ]] && echo "echo '${line}' >&2"
+			echo "exit ${code}"
+		} >"${dir}/${name}.test.sh"
+	done
+	echo "$dir"
+}
+
+# Test 1: runner exists and is executable
+if [[ -x $RUNNER ]]; then
+	pass "run-tests.sh exists and is executable"
+else fail "run-tests.sh missing or not executable" "$RUNNER"; fi
+
+# Test 2: all-pass fixture exits 0
+FIX="$(make_fixture "aaa:0" "bbb:0")"
+trap 'rm -rf "$FIX" "$FIX2" "$FIX3" "$FIX4"' EXIT
+if SHELL_TEST_DIR="$FIX" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
+	pass "all-pass fixture exits 0"
+else fail "all-pass fixture should exit 0"; fi
+
+# Test 3: a failing test (exit 1) makes the runner exit non-zero
+FIX2="$(make_fixture "ok:0" "bad:1")"
+if SHELL_TEST_DIR="$FIX2" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
+	fail "fixture with a failing test should exit non-zero"
+else pass "failing test makes runner exit non-zero"; fi
+
+# Test 4: exit-with-count pattern (exit 3) is treated as failure, not pass
+FIX3="$(make_fixture "ok:0" "counted:3")"
+if SHELL_TEST_DIR="$FIX3" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
+	fail "exit-code 3 should count as failure"
+else pass "any rc>0 (exit 3) counts as failure"; fi
+
+# Test 5: SKIP (exit 0 + 'SKIP:' on stderr) is not a failure; summary line present
+FIX4="$(make_fixture "ok:0" "skipme:0:SKIP: dependency absent")"
+OUT="$(SHELL_TEST_DIR="$FIX4" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then
+	pass "SKIP test does not fail the runner"
+else fail "SKIP test should not fail the runner" "rc=$RC"; fi
+if grep -q 'summary:' <<<"$OUT" && grep -q 'skipped' <<<"$OUT"; then
+	pass "summary line printed and reports skips"
+else fail "summary line missing or has no skip count" "$OUT"; fi
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/run-tests.test.sh
+++ b/plugins/dev/scripts/__tests__/run-tests.test.sh
@@ -46,7 +46,7 @@ else fail "run-tests.sh missing or not executable" "$RUNNER"; fi
 
 # Test 2: all-pass fixture exits 0
 FIX="$(make_fixture "aaa:0" "bbb:0")"
-trap 'rm -rf "$FIX" "$FIX2" "$FIX3" "$FIX4"' EXIT
+trap 'rm -rf "$FIX" "$FIX2" "$FIX3" "$FIX4" "$FIX5"' EXIT
 if SHELL_TEST_DIR="$FIX" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
 	pass "all-pass fixture exits 0"
 else fail "all-pass fixture should exit 0"; fi
@@ -63,16 +63,30 @@ if SHELL_TEST_DIR="$FIX3" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/n
 	fail "exit-code 3 should count as failure"
 else pass "any rc>0 (exit 3) counts as failure"; fi
 
-# Test 5: SKIP (exit 0 + 'SKIP:' on stderr) is not a failure; summary line present
+# Test 5: a column-0 'SKIP:' (exit 0) is counted as a skip — not a pass, not a
+# failure. The exact-count assertion is load-bearing: the summary template
+# always contains the word "skipped", so a bare substring grep would pass even
+# if SKIP detection were broken and the suite miscounted as a pass.
 FIX4="$(make_fixture "ok:0" "skipme:0:SKIP: dependency absent")"
 OUT="$(SHELL_TEST_DIR="$FIX4" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 RC=$?
 if [[ $RC -eq 0 ]]; then
 	pass "SKIP test does not fail the runner"
 else fail "SKIP test should not fail the runner" "rc=$RC"; fi
-if grep -q 'summary:' <<<"$OUT" && grep -q 'skipped' <<<"$OUT"; then
-	pass "summary line printed and reports skips"
-else fail "summary line missing or has no skip count" "$OUT"; fi
+if grep -qE '^  SKIP .*skipme\.test\.sh' <<<"$OUT"; then
+	pass "skip fixture classified SKIP on its own line (not PASS)"
+else fail "skip fixture not classified SKIP" "$OUT"; fi
+if grep -q 'shell 1 passed / 0 failed / 1 skipped' <<<"$OUT"; then
+	pass "summary counts exactly 1 passed / 0 failed / 1 skipped"
+else fail "summary skip/pass/fail count wrong" "$OUT"; fi
+
+# Test 6: SKIP detection is anchored to '^SKIP:'. A passing suite that merely
+# mentions SKIP mid-line (indented, or with leading text) must stay PASS.
+FIX5="$(make_fixture "ok:0" "mentions:0:  note: SKIP: handling exercised")"
+OUT="$(SHELL_TEST_DIR="$FIX5" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+if grep -q 'shell 2 passed / 0 failed / 0 skipped' <<<"$OUT"; then
+	pass "indented 'SKIP:' does not trigger skip classification (^SKIP: anchored)"
+else fail "non-column-0 'SKIP:' wrongly classified" "$OUT"; fi
 
 echo ""
 echo "Results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/run-tests.sh
+++ b/plugins/dev/scripts/run-tests.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Aggregate test runner — discovers and runs every shell + in-scope bun test
+# suite, prints one summary line, exits non-zero if any suite failed. (CTL-528)
+#
+# Env overrides (used by the smoke test):
+#   SHELL_TEST_DIR     dir of *.test.sh files     (default: <scripts>/__tests__)
+#   EXTRA_SHELL_TESTS  space-separated extra files (default: test-workflow-context.sh)
+#   SKIP_BUN=1         skip the bun surfaces entirely
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+BROKER_DIR="${REPO_ROOT}/plugins/dev/scripts/broker"
+
+SHELL_TEST_DIR="${SHELL_TEST_DIR:-${SCRIPT_DIR}/__tests__}"
+# +x test: distinguishes "unset" (use default) from "set to empty" (smoke test).
+if [[ -z ${EXTRA_SHELL_TESTS+x} ]]; then
+	EXTRA_SHELL_TESTS="${SCRIPT_DIR}/test-workflow-context.sh"
+fi
+SKIP_BUN="${SKIP_BUN:-0}"
+
+shell_pass=0
+shell_fail=0
+shell_skip=0
+bun_pass=0
+bun_fail=0
+bun_skip=0
+failed_suites=()
+
+run_shell_test() {
+	local f="$1" out rc
+	out="$(bash "$f" 2>&1)"
+	rc=$?
+	if [[ $rc -eq 0 ]]; then
+		if grep -q '^SKIP:' <<<"$out"; then
+			shell_skip=$((shell_skip + 1))
+			echo "  SKIP $f"
+		else
+			shell_pass=$((shell_pass + 1))
+			echo "  PASS $f"
+		fi
+	else
+		shell_fail=$((shell_fail + 1))
+		failed_suites+=("$f")
+		echo "  FAIL $f (rc=$rc)"
+		printf '%s\n' "    | ${out//$'\n'/$'\n'    | }"
+	fi
+}
+
+# broker-phase-lifecycle.test.sh (a shell suite member) delegates to bun and
+# imports broker/index.mjs, which needs `pino` — so broker deps must be present
+# BEFORE the shell suite runs, not just before the bun surfaces. (CTL-528)
+ensure_broker_deps() {
+	[[ $SKIP_BUN == "1" ]] && return 0
+	command -v bun >/dev/null 2>&1 || return 0
+	[[ -d "${BROKER_DIR}/node_modules" ]] && return 0
+	echo "installing broker deps..."
+	(cd "$BROKER_DIR" && bun install --frozen-lockfile) || true
+}
+
+ensure_broker_deps
+
+echo "=== Shell suite ==="
+shopt -s nullglob
+for f in "$SHELL_TEST_DIR"/*.test.sh; do
+	run_shell_test "$f"
+done
+for f in $EXTRA_SHELL_TESTS; do
+	[[ -f $f ]] && run_shell_test "$f"
+done
+shopt -u nullglob
+
+echo "=== Bun suite ==="
+if [[ $SKIP_BUN == "1" ]]; then
+	echo "  SKIP (SKIP_BUN=1)"
+elif ! command -v bun >/dev/null 2>&1; then
+	echo "  SKIP (bun not on PATH)"
+	bun_skip=2
+else
+	# broker deps were installed before the shell suite (ensure_broker_deps).
+	# broker surface
+	if (cd "$BROKER_DIR" && bun test); then
+		bun_pass=$((bun_pass + 1))
+		echo "  PASS broker bun suite"
+	else
+		bun_fail=$((bun_fail + 1))
+		failed_suites+=("broker bun suite")
+		echo "  FAIL broker bun suite"
+	fi
+	# lib surface — run from broker/ per lib/*.test.mjs documented run directive
+	if (cd "$BROKER_DIR" && bun test ../lib/*.test.mjs); then
+		bun_pass=$((bun_pass + 1))
+		echo "  PASS lib bun suite"
+	else
+		bun_fail=$((bun_fail + 1))
+		failed_suites+=("lib bun suite")
+		echo "  FAIL lib bun suite"
+	fi
+fi
+
+total_fail=$((shell_fail + bun_fail))
+result="PASS"
+[[ $total_fail -ne 0 ]] && result="FAIL"
+echo ""
+echo "make test summary: shell ${shell_pass} passed / ${shell_fail} failed / ${shell_skip} skipped | bun ${bun_pass} passed / ${bun_fail} failed / ${bun_skip} skipped | RESULT: ${result}"
+
+if [[ $total_fail -ne 0 ]]; then
+	printf '  failed suite: %s\n' "${failed_suites[@]}"
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a single aggregate test runner (`plugins/dev/scripts/run-tests.sh`) that discovers and
executes every shell test suite plus the in-scope bun suites, prints one summary line, and exits
non-zero if any suite fails. The `Makefile` `test`/`check` targets are rewired to call it, and the
stale `check-frontmatter` target (which referenced a non-existent `hack/validate-frontmatter.sh`)
is removed so `make check` is once again a real audit gate.

## Changes

- **`plugins/dev/scripts/run-tests.sh`** (new) — aggregate runner. Discovers `*.test.sh` files
  under `__tests__/`, runs the `test-workflow-context.sh` extra suite, and runs the broker + lib
  bun surfaces. Classifies each shell suite as PASS / FAIL / SKIP (a column-0 `^SKIP:` line on an
  exit-0 suite counts as skipped). Installs broker deps before the shell suite runs, because
  `broker-phase-lifecycle.test.sh` imports `broker/index.mjs` (which needs `pino`). Honors
  `SHELL_TEST_DIR`, `EXTRA_SHELL_TESTS`, and `SKIP_BUN` env overrides for testability.
- **`Makefile`** — `make test` now runs `run-tests.sh` (the full shell + bun suite); `make check`
  chains `lint + test`. The broken `check-frontmatter` target and its `hack/validate-frontmatter.sh`
  reference are deleted, and `help` text is updated accordingly.
- **`plugins/dev/scripts/__tests__/run-tests.test.sh`** (new) — smoke test for the runner. Uses
  fixture `__tests__` dirs to verify: all-pass exits 0, any `rc>0` (including exit-with-count
  patterns like exit 3) fails the runner, a column-0 `SKIP:` is classified as skipped with exact
  pass/fail/skip counts, and an indented/mid-line `SKIP:` stays PASS (anchoring to `^SKIP:`).
- **`plugins/dev/scripts/__tests__/makefile-targets.test.sh`** (new) — verifies the Makefile wiring
  via `make -n`: `test` invokes `run-tests.sh`, `lint` invokes `trunk check`, `check` chains both,
  no `hack/validate-frontmatter` reference remains, and the `check-frontmatter` target is gone.

## Testing

- `bash plugins/dev/scripts/__tests__/run-tests.test.sh` — 8 assertions covering pass/fail/skip
  classification and `^SKIP:` anchoring.
- `bash plugins/dev/scripts/__tests__/makefile-targets.test.sh` — 5 assertions covering Makefile
  target wiring.
- `make test` runs the full aggregate suite end to end.

Refs: CTL-528
