### PR TITLE
CTL-531: Exec core tracer (phase-fsm module)

### DIFF
--- a/plugins/dev/scripts/lib/phase-fsm.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.mjs
@@ -99,11 +99,38 @@ export function transition(state, event) {
     );
   }
 
-  // Pipeline-phase happy path. (failed / turn-cap-exhausted / park / resume and the
-  // needs-input branch are added in Phase 2.)
-  if (PHASES.includes(state.phase) && event.type === "complete") {
-    return { phase: NEXT_PHASE[state.phase], reviveCount: 0, parkedFrom: null };
+  // ─── Park state: only 'resume' is legal ───
+  if (state.phase === PARK_STATE) {
+    if (event.type === "resume") {
+      return { phase: state.parkedFrom, reviveCount: state.reviveCount, parkedFrom: null };
+    }
+    throw new PhaseFsmError(`needs-input only accepts 'resume', got '${event.type}'`);
   }
 
-  throw new PhaseFsmError(`no transition for event '${event.type}' from phase '${state.phase}'`);
+  // ─── Pipeline phase ───
+  switch (event.type) {
+    case "complete":
+      return { phase: NEXT_PHASE[state.phase], reviveCount: 0, parkedFrom: null };
+
+    case "failed":
+      // Revive once per phase; the 2nd failure escalates to the terminal failure sink.
+      return state.reviveCount < REVIVE_BUDGET
+        ? { phase: state.phase, reviveCount: state.reviveCount + 1, parkedFrom: null }
+        : { phase: TERMINAL_FAILURE, reviveCount: state.reviveCount, parkedFrom: null };
+
+    case "turn-cap-exhausted":
+      // Continuation self-loop — same phase, revive budget untouched.
+      return { phase: state.phase, reviveCount: state.reviveCount, parkedFrom: null };
+
+    case "park":
+      return { phase: PARK_STATE, reviveCount: state.reviveCount, parkedFrom: state.phase };
+
+    case "resume":
+      throw new PhaseFsmError(`'resume' is only valid from '${PARK_STATE}'`);
+
+    default:
+      throw new PhaseFsmError(
+        `no transition for event '${event.type}' from phase '${state.phase}'`
+      );
+  }
 }

--- a/plugins/dev/scripts/lib/phase-fsm.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.mjs
@@ -1,0 +1,109 @@
+// phase-fsm.mjs — pure transition-table FSM for the 9-phase per-worker pipeline (CTL-531).
+//
+// CTL-531: collapses the scattered phase-advance control flow — phase_next() in
+// orchestrate-phase-advance, the revive decision tree in orchestrate-revive, and the
+// stall escalation in orchestrate-healthcheck — into a single pure, zero-dependency
+// transition table (NEXT_PHASE) plus a transition(state, event) function. Imports nothing.
+
+// ─── State vocabulary ───
+export const PHASES = [
+  "triage",
+  "research",
+  "plan",
+  "implement",
+  "verify",
+  "review",
+  "pr",
+  "monitor-merge",
+  "monitor-deploy",
+];
+export const PARK_STATE = "needs-input";
+export const TERMINAL_SUCCESS = "done";
+export const TERMINAL_FAILURE = "stalled";
+export const TERMINAL_STATES = new Set([TERMINAL_SUCCESS, TERMINAL_FAILURE]);
+
+// ─── Event vocabulary ───
+export const EVENT_TYPES = new Set(["complete", "failed", "turn-cap-exhausted", "park", "resume"]);
+
+// ─── Revive budget (CTL-531: revive once per phase; 2nd failure escalates) ───
+export const REVIVE_BUDGET = 1;
+
+// ─── Transition table — the happy path (replaces phase_next()) ───
+export const NEXT_PHASE = {
+  triage: "research",
+  research: "plan",
+  plan: "implement",
+  implement: "verify",
+  verify: "review",
+  review: "pr",
+  pr: "monitor-merge",
+  "monitor-merge": "monitor-deploy",
+  "monitor-deploy": TERMINAL_SUCCESS,
+};
+
+export class PhaseFsmError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PhaseFsmError";
+  }
+}
+
+// ─── Validation helpers (private) ───
+function assertState(state) {
+  if (state === null || typeof state !== "object" || Array.isArray(state)) {
+    throw new PhaseFsmError(`state must be a plain object, got ${describe(state)}`);
+  }
+  const known =
+    PHASES.includes(state.phase) || state.phase === PARK_STATE || TERMINAL_STATES.has(state.phase);
+  if (!known) {
+    throw new PhaseFsmError(`unknown phase '${state.phase}'`);
+  }
+  if (!Number.isInteger(state.reviveCount) || state.reviveCount < 0) {
+    throw new PhaseFsmError(`reviveCount must be a non-negative integer`);
+  }
+  if (state.phase === PARK_STATE && !PHASES.includes(state.parkedFrom)) {
+    throw new PhaseFsmError(`needs-input state requires parkedFrom to be a pipeline phase`);
+  }
+}
+
+function assertEvent(event) {
+  if (event === null || typeof event !== "object" || Array.isArray(event)) {
+    throw new PhaseFsmError(`event must be a plain object, got ${describe(event)}`);
+  }
+  if (!EVENT_TYPES.has(event.type)) {
+    throw new PhaseFsmError(`unknown event type '${event.type}'`);
+  }
+}
+
+function describe(v) {
+  return v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
+}
+
+// ─── Public API ───
+export function initialState() {
+  return { phase: PHASES[0], reviveCount: 0, parkedFrom: null };
+}
+
+export function isTerminal(state) {
+  assertState(state);
+  return TERMINAL_STATES.has(state.phase);
+}
+
+export function transition(state, event) {
+  assertState(state);
+  assertEvent(event);
+
+  if (TERMINAL_STATES.has(state.phase)) {
+    throw new PhaseFsmError(
+      `'${state.phase}' is terminal — no transition for event '${event.type}'`
+    );
+  }
+
+  // Pipeline-phase happy path. (failed / turn-cap-exhausted / park / resume and the
+  // needs-input branch are added in Phase 2.)
+  if (PHASES.includes(state.phase) && event.type === "complete") {
+    return { phase: NEXT_PHASE[state.phase], reviveCount: 0, parkedFrom: null };
+  }
+
+  throw new PhaseFsmError(`no transition for event '${event.type}' from phase '${state.phase}'`);
+}

--- a/plugins/dev/scripts/lib/phase-fsm.test.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.test.mjs
@@ -1,0 +1,113 @@
+// phase-fsm.test.mjs — pure phase-FSM transition tests (CTL-531).
+// Run: cd plugins/dev/scripts/broker && bun test ../lib/phase-fsm.test.mjs
+
+import { describe, test, expect } from "bun:test";
+
+import { PHASES, PhaseFsmError, initialState, isTerminal, transition } from "./phase-fsm.mjs";
+
+// ─── Phase 1: module scaffold + happy-path pipeline ───
+
+describe("initialState", () => {
+  test("starts at triage with a clean counter", () => {
+    expect(initialState()).toEqual({
+      phase: "triage",
+      reviveCount: 0,
+      parkedFrom: null,
+    });
+  });
+  test("returns a fresh object each call (no shared mutable reference)", () => {
+    expect(initialState()).not.toBe(initialState());
+  });
+});
+
+describe("transition — happy path (complete advances the pipeline)", () => {
+  // All 8 advance edges, driven off the canonical sequence.
+  for (let i = 0; i < PHASES.length - 1; i++) {
+    const from = PHASES[i];
+    const to = PHASES[i + 1];
+    test(`${from} --complete--> ${to}`, () => {
+      const next = transition(
+        { phase: from, reviveCount: 0, parkedFrom: null },
+        { type: "complete" }
+      );
+      expect(next).toEqual({ phase: to, reviveCount: 0, parkedFrom: null });
+    });
+  }
+
+  test("monitor-deploy --complete--> done (terminal success)", () => {
+    const next = transition(
+      { phase: "monitor-deploy", reviveCount: 0, parkedFrom: null },
+      { type: "complete" }
+    );
+    expect(next).toEqual({ phase: "done", reviveCount: 0, parkedFrom: null });
+  });
+
+  test("complete resets reviveCount for the new phase", () => {
+    const next = transition(
+      { phase: "implement", reviveCount: 1, parkedFrom: null },
+      { type: "complete" }
+    );
+    expect(next.reviveCount).toBe(0);
+  });
+
+  test("transition does not mutate its state argument (purity)", () => {
+    const state = { phase: "triage", reviveCount: 0, parkedFrom: null };
+    transition(state, { type: "complete" });
+    expect(state).toEqual({ phase: "triage", reviveCount: 0, parkedFrom: null });
+  });
+});
+
+describe("isTerminal", () => {
+  test("done and stalled are terminal", () => {
+    expect(isTerminal({ phase: "done", reviveCount: 0, parkedFrom: null })).toBe(true);
+    expect(isTerminal({ phase: "stalled", reviveCount: 0, parkedFrom: null })).toBe(true);
+  });
+  test("pipeline phases and needs-input are not terminal", () => {
+    expect(isTerminal({ phase: "triage", reviveCount: 0, parkedFrom: null })).toBe(false);
+    expect(isTerminal({ phase: "needs-input", reviveCount: 0, parkedFrom: "plan" })).toBe(false);
+  });
+});
+
+describe("transition — terminal states have no outgoing edges", () => {
+  test("any event from done throws", () => {
+    expect(() =>
+      transition({ phase: "done", reviveCount: 0, parkedFrom: null }, { type: "complete" })
+    ).toThrow(PhaseFsmError);
+  });
+});
+
+describe("transition — input validation throws PhaseFsmError", () => {
+  // bun's test.each spreads array rows as args, so a bare `[]` row would pass
+  // zero args and inject an uncalled `done` callback — a plain for-loop avoids
+  // that and matches the happy-path block's idiom above.
+  const label = (v) =>
+    v === undefined ? "undefined" : Array.isArray(v) ? "[]" : JSON.stringify(v);
+
+  for (const bad of [null, undefined, 42, "triage", []]) {
+    test(`rejects bad state ${label(bad)}`, () => {
+      expect(() => transition(bad, { type: "complete" })).toThrow(PhaseFsmError);
+    });
+  }
+  test("rejects unknown phase", () => {
+    expect(() =>
+      transition({ phase: "bogus", reviveCount: 0, parkedFrom: null }, { type: "complete" })
+    ).toThrow(PhaseFsmError);
+  });
+  test("rejects negative / non-integer reviveCount", () => {
+    expect(() =>
+      transition({ phase: "triage", reviveCount: -1, parkedFrom: null }, { type: "complete" })
+    ).toThrow(PhaseFsmError);
+  });
+  for (const bad of [null, undefined, 42, "complete", {}]) {
+    test(`rejects bad event ${label(bad)}`, () => {
+      expect(() => transition({ phase: "triage", reviveCount: 0, parkedFrom: null }, bad)).toThrow(
+        PhaseFsmError
+      );
+    });
+  }
+  test("rejects unknown event type", () => {
+    expect(() =>
+      transition({ phase: "triage", reviveCount: 0, parkedFrom: null }, { type: "explode" })
+    ).toThrow(PhaseFsmError);
+  });
+});

--- a/plugins/dev/scripts/lib/phase-fsm.test.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.test.mjs
@@ -3,7 +3,14 @@
 
 import { describe, test, expect } from "bun:test";
 
-import { PHASES, PhaseFsmError, initialState, isTerminal, transition } from "./phase-fsm.mjs";
+import {
+  PHASES,
+  REVIVE_BUDGET,
+  PhaseFsmError,
+  initialState,
+  isTerminal,
+  transition,
+} from "./phase-fsm.mjs";
 
 // ─── Phase 1: module scaffold + happy-path pipeline ───
 
@@ -108,6 +115,101 @@ describe("transition — input validation throws PhaseFsmError", () => {
   test("rejects unknown event type", () => {
     expect(() =>
       transition({ phase: "triage", reviveCount: 0, parkedFrom: null }, { type: "explode" })
+    ).toThrow(PhaseFsmError);
+  });
+});
+
+// ─── Phase 2: failure / revive / escalation + turn-cap + needs-input park ───
+
+describe("transition — failed: revive once, then escalate", () => {
+  test("REVIVE_BUDGET is 1", () => {
+    expect(REVIVE_BUDGET).toBe(1);
+  });
+
+  for (const phase of PHASES) {
+    test(`${phase}: 1st failure revives in place (reviveCount 0 -> 1)`, () => {
+      const next = transition({ phase, reviveCount: 0, parkedFrom: null }, { type: "failed" });
+      expect(next).toEqual({ phase, reviveCount: 1, parkedFrom: null });
+    });
+
+    test(`${phase}: 2nd failure escalates to stalled`, () => {
+      const next = transition({ phase, reviveCount: 1, parkedFrom: null }, { type: "failed" });
+      expect(next.phase).toBe("stalled");
+    });
+  }
+
+  test("stalled is terminal — any event throws", () => {
+    expect(() =>
+      transition({ phase: "stalled", reviveCount: 1, parkedFrom: null }, { type: "failed" })
+    ).toThrow(PhaseFsmError);
+  });
+});
+
+describe("transition — turn-cap-exhausted: continuation self-loop", () => {
+  for (const phase of PHASES) {
+    test(`${phase}: stays in place, reviveCount preserved`, () => {
+      expect(
+        transition({ phase, reviveCount: 1, parkedFrom: null }, { type: "turn-cap-exhausted" })
+      ).toEqual({ phase, reviveCount: 1, parkedFrom: null });
+    });
+  }
+  test("does not consume the revive budget", () => {
+    const next = transition(
+      { phase: "implement", reviveCount: 0, parkedFrom: null },
+      { type: "turn-cap-exhausted" }
+    );
+    expect(next.reviveCount).toBe(0);
+  });
+});
+
+describe("transition — park: any phase parks into needs-input", () => {
+  for (const phase of PHASES) {
+    test(`${phase} --park--> needs-input (parkedFrom recorded)`, () => {
+      expect(transition({ phase, reviveCount: 0, parkedFrom: null }, { type: "park" })).toEqual({
+        phase: "needs-input",
+        reviveCount: 0,
+        parkedFrom: phase,
+      });
+    });
+  }
+  test("park preserves reviveCount", () => {
+    const next = transition(
+      { phase: "research", reviveCount: 1, parkedFrom: null },
+      { type: "park" }
+    );
+    expect(next.reviveCount).toBe(1);
+  });
+});
+
+describe("transition — resume: needs-input returns to the parked phase", () => {
+  test("resume returns to parkedFrom and clears it", () => {
+    expect(
+      transition({ phase: "needs-input", reviveCount: 0, parkedFrom: "plan" }, { type: "resume" })
+    ).toEqual({ phase: "plan", reviveCount: 0, parkedFrom: null });
+  });
+  test("resume preserves reviveCount", () => {
+    const next = transition(
+      { phase: "needs-input", reviveCount: 1, parkedFrom: "verify" },
+      { type: "resume" }
+    );
+    expect(next.reviveCount).toBe(1);
+  });
+
+  for (const type of ["complete", "failed", "turn-cap-exhausted", "park"]) {
+    test(`needs-input rejects event '${type}'`, () => {
+      expect(() =>
+        transition({ phase: "needs-input", reviveCount: 0, parkedFrom: "plan" }, { type })
+      ).toThrow(PhaseFsmError);
+    });
+  }
+  test("resume from a pipeline phase throws", () => {
+    expect(() =>
+      transition({ phase: "triage", reviveCount: 0, parkedFrom: null }, { type: "resume" })
+    ).toThrow(PhaseFsmError);
+  });
+  test("needs-input with a missing parkedFrom throws", () => {
+    expect(() =>
+      transition({ phase: "needs-input", reviveCount: 0, parkedFrom: null }, { type: "resume" })
     ).toThrow(PhaseFsmError);
   });
 });

--- a/plugins/dev/scripts/lib/phase-fsm.test.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.test.mjs
@@ -12,6 +12,9 @@ import {
   transition,
 } from "./phase-fsm.mjs";
 
+// Render an arbitrary value as a readable test-name fragment.
+const label = (v) => (v === undefined ? "undefined" : Array.isArray(v) ? "[]" : JSON.stringify(v));
+
 // ─── Phase 1: module scaffold + happy-path pipeline ───
 
 describe("initialState", () => {
@@ -75,6 +78,17 @@ describe("isTerminal", () => {
   });
 });
 
+describe("isTerminal — input validation throws PhaseFsmError", () => {
+  // isTerminal funnels through the same assertState as transition; its
+  // validation contract needs its own coverage so a dropped assertState
+  // call would not silently return false.
+  for (const bad of [null, undefined, 42, "done", []]) {
+    test(`rejects bad state ${label(bad)}`, () => {
+      expect(() => isTerminal(bad)).toThrow(PhaseFsmError);
+    });
+  }
+});
+
 describe("transition — terminal states have no outgoing edges", () => {
   test("any event from done throws", () => {
     expect(() =>
@@ -85,11 +99,8 @@ describe("transition — terminal states have no outgoing edges", () => {
 
 describe("transition — input validation throws PhaseFsmError", () => {
   // bun's test.each spreads array rows as args, so a bare `[]` row would pass
-  // zero args and inject an uncalled `done` callback — a plain for-loop avoids
-  // that and matches the happy-path block's idiom above.
-  const label = (v) =>
-    v === undefined ? "undefined" : Array.isArray(v) ? "[]" : JSON.stringify(v);
-
+  // zero args and inject an uncalled `done` callback — the plain for-loops
+  // below avoid that and match the happy-path block's idiom above.
   for (const bad of [null, undefined, 42, "triage", []]) {
     test(`rejects bad state ${label(bad)}`, () => {
       expect(() => transition(bad, { type: "complete" })).toThrow(PhaseFsmError);
@@ -100,12 +111,16 @@ describe("transition — input validation throws PhaseFsmError", () => {
       transition({ phase: "bogus", reviveCount: 0, parkedFrom: null }, { type: "complete" })
     ).toThrow(PhaseFsmError);
   });
-  test("rejects negative / non-integer reviveCount", () => {
-    expect(() =>
-      transition({ phase: "triage", reviveCount: -1, parkedFrom: null }, { type: "complete" })
-    ).toThrow(PhaseFsmError);
-  });
-  for (const bad of [null, undefined, 42, "complete", {}]) {
+  // -1 hits the `< 0` operand; 1.5 / "0" / NaN are caught only by the
+  // !Number.isInteger operand — both sides of the predicate are exercised.
+  for (const reviveCount of [-1, 1.5, "0", NaN]) {
+    test(`rejects bad reviveCount ${String(reviveCount)}`, () => {
+      expect(() =>
+        transition({ phase: "triage", reviveCount, parkedFrom: null }, { type: "complete" })
+      ).toThrow(PhaseFsmError);
+    });
+  }
+  for (const bad of [null, undefined, 42, "complete", {}, []]) {
     test(`rejects bad event ${label(bad)}`, () => {
       expect(() => transition({ phase: "triage", reviveCount: 0, parkedFrom: null }, bad)).toThrow(
         PhaseFsmError
@@ -212,4 +227,14 @@ describe("transition — resume: needs-input returns to the parked phase", () =>
       transition({ phase: "needs-input", reviveCount: 0, parkedFrom: null }, { type: "resume" })
     ).toThrow(PhaseFsmError);
   });
+  // parkedFrom must be a *pipeline* phase — a known-but-non-pipeline state
+  // name (done / stalled / needs-input) must still be rejected, else resume
+  // could jump straight into a terminal state.
+  for (const parkedFrom of ["done", "stalled", "needs-input"]) {
+    test(`needs-input with non-pipeline parkedFrom '${parkedFrom}' throws`, () => {
+      expect(() =>
+        transition({ phase: "needs-input", reviveCount: 0, parkedFrom }, { type: "resume" })
+      ).toThrow(PhaseFsmError);
+    });
+  }
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-21T07:16:35Z -->
<!-- Last updated: 2026-05-21T07:16:35Z -->
<!-- PR: #937 -->
<!-- Previous commits: 27694643323c0ba7f7c3883a8671e7fb9e78fa92,105028f127a2b362b56ba720593c6ac01218bd73,d95daa8cfb0b1cd8803c03b2538cb630b6371754 -->

## Summary

Introduces `phase-fsm.mjs` — a pure, zero-dependency finite-state machine for the
9-phase per-worker orchestrator pipeline (CTL-531). It collapses the phase-advance
control flow that was previously scattered across `orchestrate-phase-advance`
(`phase_next()`), `orchestrate-revive` (the revive decision tree), and
`orchestrate-healthcheck` (stall escalation) into a single transition table
(`NEXT_PHASE`) plus a pure `transition(state, event)` function.

## Changes Made

### New module — `plugins/dev/scripts/lib/phase-fsm.mjs` (136 lines)

- **State vocabulary**: the 9 pipeline `PHASES` (triage → research → plan →
  implement → verify → review → pr → monitor-merge → monitor-deploy), a
  `needs-input` park state, and two terminal states (`done`, `stalled`).
- **Event vocabulary**: `complete`, `failed`, `turn-cap-exhausted`, `park`,
  `resume`.
- **Happy path**: `NEXT_PHASE` transition table advances the pipeline on
  `complete`; `monitor-deploy` completes to terminal `done`.
- **Recovery**: `failed` revives the same phase once (`REVIVE_BUDGET = 1`); a
  second failure escalates to terminal `stalled`. `turn-cap-exhausted` is a
  continuation self-loop that leaves the revive budget untouched.
- **Park / resume**: `park` records `parkedFrom` and moves to `needs-input`;
  only `resume` is legal from there, returning to the parked phase.
- **Validation**: `assertState` / `assertEvent` reject malformed input with a
  typed `PhaseFsmError`; terminal states reject all transitions.
- Public API: `initialState()`, `isTerminal()`, `transition()`.

### New tests — `plugins/dev/scripts/lib/phase-fsm.test.mjs` (240 lines)

- Covers all 8 happy-path advance edges, terminal-success completion, the
  revive budget, turn-cap self-loop, park/resume round-trips, terminal-state
  rejection, and the input-validation branches.

## How to Verify It

- [x] Tests pass: `cd plugins/dev/scripts/broker && bun test ../lib/phase-fsm.test.mjs` — 89 pass, 0 fail

## Related Issues/PRs

- Refs: CTL-531
