### PR TITLE
CTL-530: Linear readiness filter + dependency-graph cycle detector

### DIFF
--- a/plugins/dev/scripts/lib/dependency-graph.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.mjs
@@ -1,0 +1,170 @@
+// dependency-graph.mjs — Linear readiness filter + cycle detector (CTL-530).
+//
+// Pure execution-core module: data in → data out, no I/O, no imports — a true
+// leaf module (cf. broker/state.mjs). Given Linear issues with their relations
+// it computes the ready set (eligible status AND no unfinished blocker) and
+// detects dependency cycles via a Kahn-style topological pass.
+//
+// Canonical directed edge { from, to } means `from` blocks `to`: `to` depends
+// on `from` and cannot start until `from` finishes.
+
+// Statuses treated as finished. A finished issue never blocks a dependent and
+// never appears in the ready/blocked sets. Override via options.terminalStatuses.
+const DEFAULT_TERMINAL_STATUSES = ["Done", "Canceled"];
+
+// buildDependencyEdges — normalize Linear relations into canonical directed
+// edges (CTL-530). Only edges whose BOTH endpoints are in the input set are
+// kept; non-blocking types (related, duplicate) are ignored; results are
+// deduped by (from,to). Live `linearis` emits only `blocks`; the API-native
+// `blocked_by` form is also accepted for forward-compat.
+export function buildDependencyEdges(issues) {
+  const list = issues ?? [];
+  const inSet = new Set(list.map((i) => i?.identifier).filter(Boolean));
+  const seen = new Set();
+  const edges = [];
+
+  const add = (from, to) => {
+    if (!from || !to) return; // malformed node — missing peer identifier
+    if (!inSet.has(from) || !inSet.has(to)) return; // out-of-set edge
+    const key = `${from} ${to}`;
+    if (seen.has(key)) return; // dedup symmetric relations/inverseRelations
+    seen.add(key);
+    edges.push({ from, to });
+  };
+
+  for (const issue of list) {
+    const self = issue?.identifier;
+    if (!self) continue;
+    // relations: edges this issue owns. `blocks` → self blocks peer;
+    // `blocked_by` (forward-compat) → self is blocked by peer.
+    for (const node of issue?.relations?.nodes ?? []) {
+      const peer = node?.relatedIssue?.identifier;
+      if (node?.type === "blocks") add(self, peer);
+      else if (node?.type === "blocked_by") add(peer, self);
+    }
+    // inverseRelations: edges pointing at this issue. `blocks` → peer blocks
+    // self; `blocked_by` (forward-compat) → peer is blocked by self.
+    for (const node of issue?.inverseRelations?.nodes ?? []) {
+      const peer = node?.issue?.identifier;
+      if (node?.type === "blocks") add(peer, self);
+      else if (node?.type === "blocked_by") add(self, peer);
+    }
+  }
+  return edges;
+}
+
+// computeReadySet — partition eligible issues into ready vs blocked (CTL-530).
+// An issue is eligible when its status is not terminal. An eligible issue is
+// blocked when some in-set edge points at it from an UNFINISHED blocker;
+// otherwise it is ready. Terminal issues appear in neither list. Returns
+// { ready: string[], blocked: string[] }, both sorted.
+export function computeReadySet(issues, edges, options = {}) {
+  const list = issues ?? [];
+  const terminal = new Set(options.terminalStatuses ?? DEFAULT_TERMINAL_STATUSES);
+  const isTerminal = (issue) => terminal.has(issue?.state?.name);
+  const byId = new Map(list.filter((i) => i?.identifier).map((i) => [i.identifier, i]));
+
+  // An issue is blocked if any unfinished blocker points at it. A blocker that
+  // is unknown (out-of-set) or terminal does not block.
+  const blockedIds = new Set();
+  for (const { from, to } of edges ?? []) {
+    const blocker = byId.get(from);
+    if (blocker && !isTerminal(blocker)) blockedIds.add(to);
+  }
+
+  const ready = [];
+  const blocked = [];
+  for (const issue of list) {
+    const id = issue?.identifier;
+    if (!id || isTerminal(issue)) continue;
+    (blockedIds.has(id) ? blocked : ready).push(id);
+  }
+  ready.sort();
+  blocked.sort();
+  return { ready, blocked };
+}
+
+// detectCycles — find dependency cycles via a Kahn-style topological pass
+// (CTL-530). Source-peel: repeatedly drop indegree-0 nodes (the Kahn pass);
+// survivors are in or downstream of a cycle. Sink-peel: repeatedly drop
+// outdegree-0 survivors; what remains is the set of nodes on a cycle. Those
+// are grouped by weakly-connected component — one anomaly per component.
+// Returns Anomaly[] ordered by first member.
+export function detectCycles(nodeIds, edges) {
+  const live = new Set(nodeIds ?? []);
+  const liveEdges = (edges ?? []).filter((e) => live.has(e.from) && live.has(e.to));
+
+  // peel(side): repeatedly delete nodes whose degree on `side` ("to" =
+  // indegree, "from" = outdegree) is 0, recomputed against the shrinking
+  // `live` set so removals cascade.
+  const peel = (side) => {
+    let changed = true;
+    while (changed) {
+      changed = false;
+      const deg = new Map([...live].map((n) => [n, 0]));
+      for (const e of liveEdges) {
+        if (!live.has(e.from) || !live.has(e.to)) continue;
+        deg.set(e[side], deg.get(e[side]) + 1);
+      }
+      for (const [n, d] of deg) {
+        if (d === 0) {
+          live.delete(n);
+          changed = true;
+        }
+      }
+    }
+  };
+  peel("to"); // Kahn source-peel — drop indegree-0 nodes
+  peel("from"); // sink-peel — drop outdegree-0 nodes
+
+  // `live` now holds exactly the nodes on (or bridging) a cycle. Group by
+  // weakly-connected component over the residual subgraph.
+  const adj = new Map([...live].map((n) => [n, new Set()]));
+  for (const e of liveEdges) {
+    if (!live.has(e.from) || !live.has(e.to) || e.from === e.to) continue;
+    adj.get(e.from).add(e.to);
+    adj.get(e.to).add(e.from);
+  }
+
+  const anomalies = [];
+  const visited = new Set();
+  for (const start of [...live].sort()) {
+    if (visited.has(start)) continue;
+    const members = [];
+    const queue = [start];
+    visited.add(start);
+    while (queue.length > 0) {
+      const node = queue.shift();
+      members.push(node);
+      for (const peer of adj.get(node)) {
+        if (!visited.has(peer)) {
+          visited.add(peer);
+          queue.push(peer);
+        }
+      }
+    }
+    members.sort();
+    anomalies.push({
+      type: "dependency_cycle",
+      severity: "error",
+      members,
+      reason:
+        members.length === 1
+          ? `Issue ${members[0]} depends on itself.`
+          : `Circular dependency among ${members.length} issues: ${members.join(", ")}.`,
+    });
+  }
+  return anomalies;
+}
+
+// analyzeDependencyGraph — public entry point (CTL-530). Composes edge
+// extraction, the readiness filter, and cycle detection over an array of
+// Linear issues. Returns { ready, blocked, anomalies } — ready/blocked are
+// sorted identifier arrays, anomalies a sorted Anomaly[].
+export function analyzeDependencyGraph(issues, options = {}) {
+  const list = issues ?? [];
+  const edges = buildDependencyEdges(list);
+  const { ready, blocked } = computeReadySet(list, edges, options);
+  const anomalies = detectCycles(list.map((i) => i?.identifier).filter(Boolean), edges);
+  return { ready, blocked, anomalies };
+}

--- a/plugins/dev/scripts/lib/dependency-graph.test.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.test.mjs
@@ -1,0 +1,328 @@
+// dependency-graph.test.mjs — readiness filter + cycle detector tests (CTL-530).
+// Run: bun test plugins/dev/scripts/lib/dependency-graph.test.mjs
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  buildDependencyEdges,
+  computeReadySet,
+  detectCycles,
+  analyzeDependencyGraph,
+} from "./dependency-graph.mjs";
+
+// issue(id, state, relations[], inverseRelations[]) — terse fixture builder.
+// A relation tuple is [type, peerId]; rel nests peer under relatedIssue,
+// inv nests it under issue.
+const rel = (type, id) => ({ id: `r-${type}-${id}`, type, relatedIssue: { identifier: id } });
+const inv = (type, id) => ({ id: `i-${type}-${id}`, type, issue: { identifier: id } });
+const issue = (identifier, stateName = "Backlog", relations = [], inverseRelations = []) => ({
+  identifier,
+  state: { name: stateName },
+  relations: { nodes: relations },
+  inverseRelations: { nodes: inverseRelations },
+});
+const sortEdges = (edges) =>
+  [...edges].sort((a, b) => `${a.from}>${a.to}`.localeCompare(`${b.from}>${b.to}`));
+
+describe("buildDependencyEdges", () => {
+  const cases = [
+    {
+      name: "empty input → no edges",
+      issues: [],
+      expected: [],
+    },
+    {
+      name: "single issue, no relations → no edges",
+      issues: [issue("CTL-1")],
+      expected: [],
+    },
+    {
+      name: "forward `blocks` relation → from blocks to",
+      issues: [issue("CTL-1", "Backlog", [rel("blocks", "CTL-2")]), issue("CTL-2")],
+      expected: [{ from: "CTL-1", to: "CTL-2" }],
+    },
+    {
+      name: "inverse `blocks` relation → peer blocks self",
+      issues: [issue("CTL-1"), issue("CTL-2", "Backlog", [], [inv("blocks", "CTL-1")])],
+      expected: [{ from: "CTL-1", to: "CTL-2" }],
+    },
+    {
+      name: "same edge from both relations + inverseRelations → deduped once",
+      issues: [
+        issue("CTL-1", "Backlog", [rel("blocks", "CTL-2")]),
+        issue("CTL-2", "Backlog", [], [inv("blocks", "CTL-1")]),
+      ],
+      expected: [{ from: "CTL-1", to: "CTL-2" }],
+    },
+    {
+      name: "forward-compat `blocked_by` on relations → reversed edge",
+      issues: [issue("CTL-1", "Backlog", [rel("blocked_by", "CTL-2")]), issue("CTL-2")],
+      expected: [{ from: "CTL-2", to: "CTL-1" }],
+    },
+    {
+      name: "`related` / `duplicate` types are ignored",
+      issues: [
+        issue("CTL-1", "Backlog", [rel("related", "CTL-2"), rel("duplicate", "CTL-2")]),
+        issue("CTL-2"),
+      ],
+      expected: [],
+    },
+    {
+      name: "edge to an out-of-set issue is dropped",
+      issues: [issue("CTL-1", "Backlog", [rel("blocks", "CTL-999")])],
+      expected: [],
+    },
+    {
+      name: "self-loop (issue blocks itself) is kept",
+      issues: [issue("CTL-1", "Backlog", [rel("blocks", "CTL-1")])],
+      expected: [{ from: "CTL-1", to: "CTL-1" }],
+    },
+    {
+      name: "malformed relation node (missing peer identifier) is skipped",
+      issues: [issue("CTL-1", "Backlog", [{ id: "r-x", type: "blocks", relatedIssue: {} }])],
+      expected: [],
+    },
+    {
+      name: "missing relations / inverseRelations containers do not throw",
+      issues: [{ identifier: "CTL-1", state: { name: "Backlog" } }],
+      expected: [],
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(sortEdges(buildDependencyEdges(c.issues))).toEqual(sortEdges(c.expected));
+    });
+  }
+});
+
+describe("computeReadySet", () => {
+  const cases = [
+    {
+      name: "empty input → empty ready and blocked",
+      issues: [],
+      edges: [],
+      expected: { ready: [], blocked: [] },
+    },
+    {
+      name: "single eligible issue, no edges → ready",
+      issues: [issue("CTL-1", "Backlog")],
+      edges: [],
+      expected: { ready: ["CTL-1"], blocked: [] },
+    },
+    {
+      name: "terminal issue appears in neither list",
+      issues: [issue("CTL-1", "Done")],
+      edges: [],
+      expected: { ready: [], blocked: [] },
+    },
+    {
+      name: "A blocks B, both eligible → A ready, B blocked",
+      issues: [issue("CTL-1", "Backlog"), issue("CTL-2", "Backlog")],
+      edges: [{ from: "CTL-1", to: "CTL-2" }],
+      expected: { ready: ["CTL-1"], blocked: ["CTL-2"] },
+    },
+    {
+      name: "blocker is Done → dependent becomes ready",
+      issues: [issue("CTL-1", "Done"), issue("CTL-2", "Backlog")],
+      edges: [{ from: "CTL-1", to: "CTL-2" }],
+      expected: { ready: ["CTL-2"], blocked: [] },
+    },
+    {
+      name: "blocker is Canceled → dependent becomes ready",
+      issues: [issue("CTL-1", "Canceled"), issue("CTL-2", "Backlog")],
+      edges: [{ from: "CTL-1", to: "CTL-2" }],
+      expected: { ready: ["CTL-2"], blocked: [] },
+    },
+    {
+      name: "unknown / out-of-set blocker does not block",
+      issues: [issue("CTL-2", "Backlog")],
+      edges: [{ from: "CTL-999", to: "CTL-2" }],
+      expected: { ready: ["CTL-2"], blocked: [] },
+    },
+    {
+      name: "diamond — only the root is ready",
+      issues: ["CTL-1", "CTL-2", "CTL-3", "CTL-4"].map((id) => issue(id, "Backlog")),
+      edges: [
+        { from: "CTL-1", to: "CTL-2" },
+        { from: "CTL-1", to: "CTL-3" },
+        { from: "CTL-2", to: "CTL-4" },
+        { from: "CTL-3", to: "CTL-4" },
+      ],
+      expected: { ready: ["CTL-1"], blocked: ["CTL-2", "CTL-3", "CTL-4"] },
+    },
+    {
+      name: "custom terminalStatuses option is honored",
+      issues: [issue("CTL-1", "Shipped"), issue("CTL-2", "Backlog")],
+      edges: [{ from: "CTL-1", to: "CTL-2" }],
+      options: { terminalStatuses: ["Shipped"] },
+      expected: { ready: ["CTL-2"], blocked: [] },
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(computeReadySet(c.issues, c.edges, c.options)).toEqual(c.expected);
+    });
+  }
+});
+
+describe("detectCycles", () => {
+  // edge tuple [from,to]; nodes inferred from the case's `nodes` list.
+  const cases = [
+    { name: "empty graph → no anomalies", nodes: [], edges: [], expected: [] },
+    {
+      name: "single node, no edges → no anomalies",
+      nodes: ["CTL-1"],
+      edges: [],
+      expected: [],
+    },
+    {
+      name: "linear chain A→B→C → no anomalies",
+      nodes: ["CTL-1", "CTL-2", "CTL-3"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-2", "CTL-3"],
+      ],
+      expected: [],
+    },
+    {
+      name: "diamond → no anomalies",
+      nodes: ["CTL-1", "CTL-2", "CTL-3", "CTL-4"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-1", "CTL-3"],
+        ["CTL-2", "CTL-4"],
+        ["CTL-3", "CTL-4"],
+      ],
+      expected: [],
+    },
+    {
+      name: "two-node cycle A→B→A → one anomaly with both members",
+      nodes: ["CTL-1", "CTL-2"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-2", "CTL-1"],
+      ],
+      expected: [
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-1", "CTL-2"],
+          reason: "Circular dependency among 2 issues: CTL-1, CTL-2.",
+        },
+      ],
+    },
+    {
+      name: "self-loop A→A → one anomaly with a single member",
+      nodes: ["CTL-1"],
+      edges: [["CTL-1", "CTL-1"]],
+      expected: [
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-1"],
+          reason: "Issue CTL-1 depends on itself.",
+        },
+      ],
+    },
+    {
+      name: "cycle with a downstream descendant → descendant excluded",
+      nodes: ["CTL-1", "CTL-2", "CTL-3"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-2", "CTL-1"],
+        ["CTL-2", "CTL-3"],
+      ],
+      expected: [
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-1", "CTL-2"],
+          reason: "Circular dependency among 2 issues: CTL-1, CTL-2.",
+        },
+      ],
+    },
+    {
+      name: "cycle with an upstream predecessor → predecessor excluded",
+      nodes: ["CTL-1", "CTL-2", "CTL-3"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-2", "CTL-3"],
+        ["CTL-3", "CTL-2"],
+      ],
+      expected: [
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-2", "CTL-3"],
+          reason: "Circular dependency among 2 issues: CTL-2, CTL-3.",
+        },
+      ],
+    },
+    {
+      name: "two disjoint cycles → two anomalies",
+      nodes: ["CTL-1", "CTL-2", "CTL-3", "CTL-4"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-2", "CTL-1"],
+        ["CTL-3", "CTL-4"],
+        ["CTL-4", "CTL-3"],
+      ],
+      expected: [
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-1", "CTL-2"],
+          reason: "Circular dependency among 2 issues: CTL-1, CTL-2.",
+        },
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-3", "CTL-4"],
+          reason: "Circular dependency among 2 issues: CTL-3, CTL-4.",
+        },
+      ],
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      const edges = c.edges.map(([from, to]) => ({ from, to }));
+      expect(detectCycles(c.nodes, edges)).toEqual(c.expected);
+    });
+  }
+});
+
+describe("analyzeDependencyGraph", () => {
+  test("realistic mixed graph — ready, blocked and a cycle", () => {
+    // CTL-1 Done; CTL-2 ready; CTL-3 blocked by CTL-2; CTL-4<->CTL-5 cycle.
+    const issues = [
+      issue("CTL-1", "Done", [rel("blocks", "CTL-2")]),
+      issue("CTL-2", "Backlog", [rel("blocks", "CTL-3")]),
+      issue("CTL-3", "Backlog"),
+      issue("CTL-4", "Backlog", [rel("blocks", "CTL-5")]),
+      issue("CTL-5", "Backlog", [rel("blocks", "CTL-4")]),
+    ];
+    const result = analyzeDependencyGraph(issues);
+    expect(result.ready).toEqual(["CTL-2"]);
+    expect(result.blocked).toEqual(["CTL-3", "CTL-4", "CTL-5"]);
+    expect(result.anomalies).toEqual([
+      {
+        type: "dependency_cycle",
+        severity: "error",
+        members: ["CTL-4", "CTL-5"],
+        reason: "Circular dependency among 2 issues: CTL-4, CTL-5.",
+      },
+    ]);
+  });
+
+  test("empty input → empty result", () => {
+    expect(analyzeDependencyGraph([])).toEqual({ ready: [], blocked: [], anomalies: [] });
+  });
+
+  test("acyclic graph → no anomalies", () => {
+    const issues = [issue("CTL-1", "Backlog", [rel("blocks", "CTL-2")]), issue("CTL-2", "Backlog")];
+    expect(analyzeDependencyGraph(issues).anomalies).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/lib/dependency-graph.test.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.test.mjs
@@ -83,6 +83,16 @@ describe("buildDependencyEdges", () => {
       expected: [],
     },
     {
+      name: "forward-compat `blocked_by` on inverseRelations → reversed edge",
+      issues: [issue("CTL-1"), issue("CTL-2", "Backlog", [], [inv("blocked_by", "CTL-1")])],
+      expected: [{ from: "CTL-2", to: "CTL-1" }],
+    },
+    {
+      name: "malformed inverse relation node (missing peer identifier) is skipped",
+      issues: [issue("CTL-1", "Backlog", [], [{ id: "i-x", type: "blocks", issue: {} }])],
+      expected: [],
+    },
+    {
       name: "missing relations / inverseRelations containers do not throw",
       issues: [{ identifier: "CTL-1", state: { name: "Backlog" } }],
       expected: [],
@@ -157,6 +167,12 @@ describe("computeReadySet", () => {
       edges: [{ from: "CTL-1", to: "CTL-2" }],
       options: { terminalStatuses: ["Shipped"] },
       expected: { ready: ["CTL-2"], blocked: [] },
+    },
+    {
+      name: "issue with missing state object → treated as eligible, ready",
+      issues: [{ identifier: "CTL-1", relations: { nodes: [] }, inverseRelations: { nodes: [] } }],
+      edges: [],
+      expected: { ready: ["CTL-1"], blocked: [] },
     },
   ];
 
@@ -284,6 +300,41 @@ describe("detectCycles", () => {
         },
       ],
     },
+    {
+      name: "three-node cycle A→B→C→A → one anomaly with all three members",
+      nodes: ["CTL-1", "CTL-2", "CTL-3"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-2", "CTL-3"],
+        ["CTL-3", "CTL-1"],
+      ],
+      expected: [
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-1", "CTL-2", "CTL-3"],
+          reason: "Circular dependency among 3 issues: CTL-1, CTL-2, CTL-3.",
+        },
+      ],
+    },
+    {
+      name: "two cycles sharing a node → merged into one anomaly",
+      nodes: ["CTL-1", "CTL-2", "CTL-3"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-2", "CTL-1"],
+        ["CTL-2", "CTL-3"],
+        ["CTL-3", "CTL-2"],
+      ],
+      expected: [
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-1", "CTL-2", "CTL-3"],
+          reason: "Circular dependency among 3 issues: CTL-1, CTL-2, CTL-3.",
+        },
+      ],
+    },
   ];
 
   for (const c of cases) {
@@ -324,5 +375,26 @@ describe("analyzeDependencyGraph", () => {
   test("acyclic graph → no anomalies", () => {
     const issues = [issue("CTL-1", "Backlog", [rel("blocks", "CTL-2")]), issue("CTL-2", "Backlog")];
     expect(analyzeDependencyGraph(issues).anomalies).toEqual([]);
+  });
+});
+
+// CTL-530 verify phase: null/undefined inputs must degrade gracefully rather
+// than throw — every export guards with `?? []`, so assert that contract.
+describe("null / undefined inputs degrade gracefully", () => {
+  test("buildDependencyEdges(null | undefined) → []", () => {
+    expect(buildDependencyEdges(undefined)).toEqual([]);
+    expect(buildDependencyEdges(null)).toEqual([]);
+  });
+
+  test("computeReadySet(undefined, undefined) → empty partition", () => {
+    expect(computeReadySet(undefined, undefined)).toEqual({ ready: [], blocked: [] });
+  });
+
+  test("detectCycles(undefined, undefined) → []", () => {
+    expect(detectCycles(undefined, undefined)).toEqual([]);
+  });
+
+  test("analyzeDependencyGraph(undefined) → empty result", () => {
+    expect(analyzeDependencyGraph(undefined)).toEqual({ ready: [], blocked: [], anomalies: [] });
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-21T00:00:00Z -->
<!-- Last updated: 2026-05-21T00:00:00Z -->
<!-- PR: #938 -->
<!-- Previous commits: 7fa843f237f9b8357172536b8052abefe9c1f6c1,e2867f3b3b8695a4d6149c9bfe114d35c7eb2acf -->

## Summary

Adds `dependency-graph.mjs`, a pure execution-core module that turns a set of Linear issues plus their relations into three derived views: the **ready set** (issues eligible to start), the **blocked set** (issues with an unfinished blocker), and **dependency-cycle anomalies**. The module has no I/O and no imports — a true leaf module, in the same shape as `broker/state.mjs` — so it is fully unit-testable as data-in / data-out.

## Changes Made

### New module: `plugins/dev/scripts/lib/dependency-graph.mjs`

- **`buildDependencyEdges(issues)`** — normalizes Linear `relations`/`inverseRelations` into canonical directed edges `{ from, to }` where `from` blocks `to`. Keeps only edges whose both endpoints are in the input set, ignores non-blocking relation types (`related`, `duplicate`), and dedupes symmetric relation/inverse-relation pairs. Accepts both the live `linearis` `blocks` form and the API-native `blocked_by` form for forward-compatibility.
- **`computeReadySet(issues, edges, options)`** — partitions non-terminal issues into `ready` vs `blocked`. An issue is blocked when an in-set edge points at it from an unfinished blocker; terminal issues (`Done`, `Canceled` by default, overridable via `options.terminalStatuses`) appear in neither list. Returns sorted identifier arrays.
- **`detectCycles(nodeIds, edges)`** — Kahn-style topological pass: a source-peel drops indegree-0 nodes, then a sink-peel drops outdegree-0 survivors; remaining nodes are grouped into anomalies by weakly-connected component (one anomaly per component). Returns a sorted `Anomaly[]`, distinguishing self-dependency from multi-issue circular dependency in the `reason` text.
- **`analyzeDependencyGraph(issues, options)`** — public entry point composing the three functions; returns `{ ready, blocked, anomalies }`.

### Tests: `plugins/dev/scripts/lib/dependency-graph.test.mjs`

41 tests covering edge normalization (both relation directions, dedup, out-of-set filtering, non-blocking types), readiness partitioning (terminal-status handling, custom terminal statuses, unfinished-blocker logic), and cycle detection (self-loops, two-node cycles, multi-node cycles, the `blocked_by` inverse form, and null/empty inputs).

## How to Verify It

- [x] Tests pass: `bun test plugins/dev/scripts/lib/dependency-graph.test.mjs` — 41 pass, 0 fail
- [ ] Manual verification (per approved plan): confirm cycle-detector behavior on bridged-cycle graphs matches the documented peel+WCC limitation (see Reviewer Notes)

## Reviewer Notes / Known Limitation

The cycle detector uses a source-peel/sink-peel pass followed by weakly-connected-component grouping. This approach is **faithful to the approved plan** (`thoughts/shared/plans/2026-05-21-ctl-530.md`, which documents the peel+WCC approach and explicitly accepts this imprecision as a Manual Verification criterion). Two known edge-case behaviors:

- A bridge node lying on a one-way path between two distinct cycles can be falsely included in the reported anomaly.
- Two distinct cycles bridged by a one-way edge can be merged into a single reported anomaly.

A Tarjan/Kosaraju strongly-connected-components pass would resolve both precisely, but adopting it overrides an approved plan decision and is therefore out of scope for this PR. Flagging for reviewer awareness — this is a deferred-to-human decision, not an implementation defect.

## Changelog Entry

`feat(dev)`: Add dependency-graph module — Linear readiness filter and dependency-cycle detector.

## Related Issues/PRs

- Refs: CTL-530
