### PR TITLE
CTL-536: Add the pull-loop scheduler to the execution core

### DIFF
--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -26,6 +26,17 @@ export {
   startMonitor,
   stopMonitor,
 } from "./monitor.mjs";
+// scheduler.mjs (CTL-536) — re-exported explicitly so the test-only
+// __resetForTests helper stays out of the public barrel.
+export {
+  schedulerTick,
+  startScheduler,
+  stopScheduler,
+  computeReadyTickets,
+  selectDispatchable,
+  deriveAdvancement,
+  readAllEligibleTickets,
+} from "./scheduler.mjs";
 
 // --- Standalone entrypoint ----------------------------------------------
 function main() {

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -16,9 +16,7 @@ const DEFAULT_LIMIT = 200;
 // filter (keep more-urgent-or-equal), not a server-side equality match.
 export function buildLinearisArgs(query) {
   if (!query.team) {
-    throw new Error(
-      "eligibleQuery.team is required (linearis --status requires --team)",
-    );
+    throw new Error("eligibleQuery.team is required (linearis --status requires --team)");
   }
   const args = [
     "issues",
@@ -52,6 +50,13 @@ function defaultExec(cmd, args) {
 // normalizeTicket — flatten linearis's nested shape into a stable record.
 // `state` and `project` arrive as `{ name }` objects from the Linear API;
 // a missing `priority` normalizes to 0 ("No priority", the least urgent).
+//
+// CTL-536: `createdAt` feeds the pull-loop scheduler's priority tie-break;
+// `relations` / `inverseRelations` feed analyzeDependencyGraph
+// (lib/dependency-graph.mjs). Relations default to an empty node list so the
+// graph builder can read `.nodes` unconditionally. Relation capture depends on
+// `linearis issues list` emitting them — if it omits relations the graph
+// simply sees no edges and the scheduler degrades to `ready == eligible`.
 function normalizeTicket(node) {
   return {
     identifier: node.identifier ?? null,
@@ -60,6 +65,9 @@ function normalizeTicket(node) {
     priority: typeof node.priority === "number" ? node.priority : 0,
     project: node.project?.name ?? node.project ?? null,
     updatedAt: node.updatedAt ?? null,
+    createdAt: node.createdAt ?? null,
+    relations: node.relations ?? { nodes: [] },
+    inverseRelations: node.inverseRelations ?? { nodes: [] },
   };
 }
 
@@ -70,9 +78,7 @@ function normalizeTicket(node) {
 export function runEligibleQuery(query, { exec = defaultExec } = {}) {
   const { code, stdout, stderr } = exec("linearis", buildLinearisArgs(query));
   if (code !== 0) {
-    throw new Error(
-      `linearis issues list failed (exit ${code}): ${(stderr || "").trim()}`,
-    );
+    throw new Error(`linearis issues list failed (exit ${code}): ${(stderr || "").trim()}`);
   }
   let parsed;
   try {
@@ -84,9 +90,7 @@ export function runEligibleQuery(query, { exec = defaultExec } = {}) {
   // Priority is a floor: keep tickets whose priority is more-urgent-or-equal
   // (1=Urgent … 4=Low). 0 ("No priority") is always below any floor.
   if (query.priority != null) {
-    tickets = tickets.filter(
-      (t) => t.priority >= 1 && t.priority <= query.priority,
-    );
+    tickets = tickets.filter((t) => t.priority >= 1 && t.priority <= query.priority);
   }
   return tickets;
 }

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -136,4 +136,39 @@ describe("runEligibleQuery", () => {
     expect(args[args.indexOf("--team") + 1]).toBe("PLAT");
     expect(args[args.indexOf("--status") + 1]).toBe("Backlog");
   });
+
+  // CTL-536: the scheduler's priority tie-break needs createdAt; the readiness
+  // filter (analyzeDependencyGraph) needs relations / inverseRelations.
+  test("captures createdAt when present", () => {
+    const exec = fakeExec({
+      stdout: ticketsJson([
+        {
+          identifier: "ENG-1",
+          state: { name: "Todo" },
+          priority: 2,
+          createdAt: "2026-05-01T00:00:00Z",
+        },
+      ]),
+    });
+    expect(runEligibleQuery(query, { exec })[0].createdAt).toBe("2026-05-01T00:00:00Z");
+  });
+
+  test("createdAt is null when absent (never undefined)", () => {
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "ENG-1", state: { name: "Todo" } }]),
+    });
+    expect(runEligibleQuery(query, { exec })[0].createdAt).toBeNull();
+  });
+
+  test("passes relations / inverseRelations through verbatim for the dependency graph", () => {
+    const relations = {
+      nodes: [{ type: "blocks", relatedIssue: { identifier: "ENG-2" } }],
+    };
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "ENG-1", state: { name: "Todo" }, relations }]),
+    });
+    const t = runEligibleQuery(query, { exec })[0];
+    expect(t.relations).toEqual(relations);
+    expect(t.inverseRelations).toEqual({ nodes: [] });
+  });
 });

--- a/plugins/dev/scripts/execution-core/scheduler-rank.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler-rank.mjs
@@ -1,0 +1,38 @@
+// scheduler-rank.mjs — pull-loop scheduler priority ranking (CTL-536).
+//
+// Pure leaf module: data in → data out, no I/O, no imports. Encodes the one
+// ranking rule the scheduler needs — Linear priority, then createdAt.
+
+// Linear priority encoding: 1=Urgent, 2=High, 3=Medium, 4=Low, 0=No priority.
+// Lower non-zero is more urgent; 0 ("No priority") must rank BELOW Low(4), so
+// it maps to 5. A missing / non-numeric priority is treated as No priority.
+export function priorityRank(ticket) {
+  const p = ticket?.priority;
+  return p === 1 || p === 2 || p === 3 || p === 4 ? p : 5;
+}
+
+// compareTickets — total order for scheduler selection.
+//   1. priority rank ascending (most urgent first)
+//   2. createdAt ascending (oldest waiting ticket first — FIFO fairness;
+//      ISO-8601 strings compare lexicographically = chronologically)
+//   3. identifier ascending (deterministic final tie-break)
+// A missing createdAt sorts LAST within its priority band — absent data never
+// jumps the queue ahead of a ticket with a known wait time.
+export function compareTickets(a, b) {
+  const byPriority = priorityRank(a) - priorityRank(b);
+  if (byPriority !== 0) return byPriority;
+
+  const ca = a?.createdAt || "";
+  const cb = b?.createdAt || "";
+  if (ca !== cb) {
+    if (!ca) return 1; // a has no createdAt → a sorts after b
+    if (!cb) return -1; // b has no createdAt → a sorts before b
+    return ca < cb ? -1 : 1;
+  }
+  return String(a?.identifier).localeCompare(String(b?.identifier));
+}
+
+// rankTickets — a new array sorted by compareTickets. Never mutates the input.
+export function rankTickets(tickets) {
+  return [...(tickets ?? [])].sort(compareTickets);
+}

--- a/plugins/dev/scripts/execution-core/scheduler-rank.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler-rank.test.mjs
@@ -8,9 +8,7 @@ const t = (id, priority, createdAt) => ({ identifier: id, priority, createdAt })
 
 describe("priorityRank", () => {
   test("Urgent..Low map to 1..4; No priority (0) maps to 5", () => {
-    expect([1, 2, 3, 4, 0].map((p) => priorityRank({ priority: p }))).toEqual([
-      1, 2, 3, 4, 5,
-    ]);
+    expect([1, 2, 3, 4, 0].map((p) => priorityRank({ priority: p }))).toEqual([1, 2, 3, 4, 5]);
   });
   test("missing / non-numeric priority ranks as No priority (5)", () => {
     expect(priorityRank({})).toBe(5);
@@ -27,21 +25,14 @@ describe("compareTickets", () => {
   });
   test("equal priority: older createdAt sorts first (FIFO fairness)", () => {
     expect(
-      compareTickets(
-        t("A", 2, "2026-05-01T00:00:00Z"),
-        t("B", 2, "2026-05-10T00:00:00Z"),
-      ),
+      compareTickets(t("A", 2, "2026-05-01T00:00:00Z"), t("B", 2, "2026-05-10T00:00:00Z"))
     ).toBeLessThan(0);
   });
   test("missing createdAt sorts last within equal priority", () => {
-    expect(
-      compareTickets(t("A", 2, null), t("B", 2, "2026-05-01T00:00:00Z")),
-    ).toBeGreaterThan(0);
+    expect(compareTickets(t("A", 2, null), t("B", 2, "2026-05-01T00:00:00Z"))).toBeGreaterThan(0);
   });
   test("identical priority + createdAt: identifier breaks the tie (total order)", () => {
-    expect(compareTickets(t("ENG-1", 2, "x"), t("ENG-2", 2, "x"))).toBeLessThan(
-      0,
-    );
+    expect(compareTickets(t("ENG-1", 2, "x"), t("ENG-2", 2, "x"))).toBeLessThan(0);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler-rank.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler-rank.test.mjs
@@ -1,0 +1,58 @@
+// Unit tests for the pull-loop scheduler priority ranking (CTL-536 Phase 2).
+// Run: cd plugins/dev/scripts/execution-core && bun test scheduler-rank.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { priorityRank, compareTickets, rankTickets } from "./scheduler-rank.mjs";
+
+const t = (id, priority, createdAt) => ({ identifier: id, priority, createdAt });
+
+describe("priorityRank", () => {
+  test("Urgent..Low map to 1..4; No priority (0) maps to 5", () => {
+    expect([1, 2, 3, 4, 0].map((p) => priorityRank({ priority: p }))).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+  });
+  test("missing / non-numeric priority ranks as No priority (5)", () => {
+    expect(priorityRank({})).toBe(5);
+    expect(priorityRank({ priority: null })).toBe(5);
+  });
+});
+
+describe("compareTickets", () => {
+  test("more-urgent priority sorts first", () => {
+    expect(compareTickets(t("A", 1, "x"), t("B", 3, "x"))).toBeLessThan(0);
+  });
+  test("No priority (0) sorts after Low (4)", () => {
+    expect(compareTickets(t("A", 0, "x"), t("B", 4, "x"))).toBeGreaterThan(0);
+  });
+  test("equal priority: older createdAt sorts first (FIFO fairness)", () => {
+    expect(
+      compareTickets(
+        t("A", 2, "2026-05-01T00:00:00Z"),
+        t("B", 2, "2026-05-10T00:00:00Z"),
+      ),
+    ).toBeLessThan(0);
+  });
+  test("missing createdAt sorts last within equal priority", () => {
+    expect(
+      compareTickets(t("A", 2, null), t("B", 2, "2026-05-01T00:00:00Z")),
+    ).toBeGreaterThan(0);
+  });
+  test("identical priority + createdAt: identifier breaks the tie (total order)", () => {
+    expect(compareTickets(t("ENG-1", 2, "x"), t("ENG-2", 2, "x"))).toBeLessThan(
+      0,
+    );
+  });
+});
+
+describe("rankTickets", () => {
+  test("returns a new sorted array, does not mutate the input", () => {
+    const input = [t("C", 3, "x"), t("A", 1, "x"), t("B", 1, "a")];
+    const ranked = rankTickets(input);
+    expect(ranked.map((x) => x.identifier)).toEqual(["B", "A", "C"]);
+    expect(input.map((x) => x.identifier)).toEqual(["C", "A", "B"]); // unmutated
+  });
+  test("empty input yields empty output", () => {
+    expect(rankTickets([])).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1,0 +1,109 @@
+// scheduler.mjs — pull-loop scheduler for the execution core (CTL-536).
+//
+// Replaces wave-based push dispatch with a continuous pull loop: on every tick
+// it computes a fresh ready set (eligible ∩ no-open-blocker), priority-ranks
+// it, and dispatches the top ticket whenever a worker slot is free. In-flight
+// tickets are advanced phase-by-phase through the FSM. Every dispatch is
+// idempotent (signal-file existence guard).
+//
+// Composes: lib/dependency-graph.mjs (readiness), scheduler-rank.mjs (ranking),
+// lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { analyzeDependencyGraph } from "../lib/dependency-graph.mjs";
+import { rankTickets } from "./scheduler-rank.mjs";
+
+// The last pipeline phase — its `done` signal means the whole pipeline
+// finished. `done` is otherwise phase-dependent: a `triage: done` signal still
+// occupies a slot (the ticket is mid-pipeline), so isTicketInFlight checks the
+// phase, not just the status.
+const TERMINAL_PHASE = "monitor-deploy";
+
+// readPhaseSignals — { phase: status } for one ticket's workers/<T>/phase-*.json.
+export function readPhaseSignals(orchDir, ticket) {
+  const dir = join(orchDir, "workers", ticket);
+  const signals = {};
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return signals; // no worker dir yet
+  }
+  for (const f of files) {
+    const m = /^phase-(.+)\.json$/.exec(f);
+    if (!m) continue;
+    try {
+      signals[m[1]] = JSON.parse(readFileSync(join(dir, f), "utf8"))?.status ?? null;
+    } catch {
+      // unreadable / malformed signal — skip; treated as absent
+    }
+  }
+  return signals;
+}
+
+// isTicketInFlight — true when a ticket still occupies a worker slot. Pure over
+// a phase→status map. In-flight = has ≥1 signal AND is neither pipeline-complete
+// (monitor-deploy done) nor failed/stalled. A ticket mid-advance (plan done, no
+// later signal yet) is still in-flight — correct slot accounting through the
+// advance window.
+export function isTicketInFlight(signals) {
+  const phases = Object.keys(signals ?? {});
+  if (phases.length === 0) return false;
+  for (const [phase, status] of Object.entries(signals)) {
+    if (status === "failed" || status === "stalled") return false;
+    if (phase === TERMINAL_PHASE && status === "done") return false;
+  }
+  return true;
+}
+
+// listInFlightTickets — Set of ticket ids currently occupying a worker slot.
+export function listInFlightTickets(orchDir) {
+  const inFlight = new Set();
+  let dirs;
+  try {
+    dirs = readdirSync(join(orchDir, "workers"), { withFileTypes: true });
+  } catch {
+    return inFlight; // no workers dir yet
+  }
+  for (const d of dirs) {
+    if (!d.isDirectory()) continue;
+    if (isTicketInFlight(readPhaseSignals(orchDir, d.name))) inFlight.add(d.name);
+  }
+  return inFlight;
+}
+
+// readMaxParallel — the run's worker-slot ceiling from state.json (parity with
+// orchestrate-dispatch-next:176). Defaults to 1 when unset/unreadable.
+export function readMaxParallel(orchDir) {
+  try {
+    const n = JSON.parse(readFileSync(join(orchDir, "state.json"), "utf8"))?.maxParallel;
+    return Number.isInteger(n) && n > 0 ? n : 1;
+  } catch {
+    return 1;
+  }
+}
+
+// computeFreeSlots — never negative (an over-subscribed run yields 0).
+export function computeFreeSlots(maxParallel, inFlightCount) {
+  return Math.max(0, maxParallel - inFlightCount);
+}
+
+// computeReadyTickets — eligible tickets with no open blocker, priority-ranked.
+// analyzeDependencyGraph returns ready identifier strings; map back to the full
+// ticket objects (selection and dispatch need priority/createdAt) and rank.
+export function computeReadyTickets(eligibleTickets) {
+  const list = eligibleTickets ?? [];
+  const readyIds = new Set(analyzeDependencyGraph(list).ready);
+  return rankTickets(list.filter((t) => readyIds.has(t.identifier)));
+}
+
+// selectDispatchable — the top `freeSlots` ready tickets not in the given
+// exclude set (the tick passes already-started tickets, Phase 4).
+export function selectDispatchable(rankedReady, excludeTickets, freeSlots) {
+  if (freeSlots <= 0) return [];
+  const exclude = excludeTickets ?? new Set();
+  return (rankedReady ?? [])
+    .filter((t) => !exclude.has(t.identifier))
+    .slice(0, freeSlots);
+}

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -10,9 +10,13 @@
 // lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
 
 import { readdirSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { analyzeDependencyGraph } from "../lib/dependency-graph.mjs";
+import { PHASES, transition, isTerminal } from "../lib/phase-fsm.mjs";
 import { rankTickets } from "./scheduler-rank.mjs";
+import { log, getEligibleDir } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -106,4 +110,115 @@ export function selectDispatchable(rankedReady, excludeTickets, freeSlots) {
   return (rankedReady ?? [])
     .filter((t) => !exclude.has(t.identifier))
     .slice(0, freeSlots);
+}
+
+// ─── Phase 4: dispatch and FSM-driven phase advancement ───
+
+// orchestrate-dispatch-next sits one directory up from execution-core/.
+const DISPATCH_BIN = fileURLToPath(
+  new URL("../orchestrate-dispatch-next", import.meta.url),
+);
+
+// defaultDispatch — shell out to orchestrate-dispatch-next, which delegates to
+// phase-agent-dispatch (idempotent: an existing dispatched/running/done signal
+// is a no-op). Injected in tests so no test ever spawns a real worker.
+function defaultDispatch({ orchDir, ticket, phase }) {
+  const res = spawnSync(
+    DISPATCH_BIN,
+    ["--orch-dir", orchDir, "--ticket", ticket, "--phase", phase],
+    { encoding: "utf8" },
+  );
+  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
+  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// dispatchTicket — thin seam over the injectable dispatch function.
+export function dispatchTicket(orchDir, ticket, phase, { dispatch = defaultDispatch } = {}) {
+  return dispatch({ orchDir, ticket, phase });
+}
+
+// listStartedTickets — every ticket that already has a worker dir, in any
+// status. The pull step excludes these so a finished/failed ticket is never
+// re-pulled as new work (revive of a failed ticket is a separate owner's job).
+export function listStartedTickets(orchDir) {
+  try {
+    return new Set(
+      readdirSync(join(orchDir, "workers"), { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+// readAllEligibleTickets — concatenate every per-project eligible projection
+// (~/catalyst/execution-core/eligible/*.json — the CTL-535 monitor's output).
+export function readAllEligibleTickets() {
+  let files;
+  try {
+    files = readdirSync(getEligibleDir());
+  } catch {
+    return []; // eligible dir not created yet
+  }
+  const all = [];
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const proj = JSON.parse(readFileSync(join(getEligibleDir(), f), "utf8"));
+      if (Array.isArray(proj?.tickets)) all.push(...proj.tickets);
+    } catch {
+      // malformed projection — skip, the next reconcile rewrites it
+    }
+  }
+  return all;
+}
+
+// deriveAdvancement — pure. Given a ticket's phase→status signals, return the
+// phase the FSM owes next, or null. The next phase is owed when the latest
+// known phase is `done` and its transition() successor is a non-terminal phase
+// with no signal yet. Advancement goes through phase-fsm.mjs — never a local
+// copy of NEXT_PHASE.
+export function deriveAdvancement(signals) {
+  const sig = signals ?? {};
+  let latest = null;
+  for (const p of PHASES) if (p in sig) latest = p;
+  if (latest === null || sig[latest] !== "done") return null;
+  const next = transition(
+    { phase: latest, reviveCount: 0, parkedFrom: null },
+    { type: "complete" },
+  );
+  if (isTerminal(next)) return null; // pipeline reached monitor-deploy → done
+  if (next.phase in sig) return null; // successor already dispatched
+  return next.phase;
+}
+
+// schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull.
+// Idempotent and restart-safe — derives every action from filesystem state.
+export function schedulerTick(orchDir, { readEligible, dispatch = defaultDispatch } = {}) {
+  // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
+  const advanced = [];
+  for (const ticket of listInFlightTickets(orchDir)) {
+    const next = deriveAdvancement(readPhaseSignals(orchDir, ticket));
+    if (!next) continue;
+    const r = dispatchTicket(orchDir, ticket, next, { dispatch });
+    if (r.code === 0) advanced.push({ ticket, phase: next });
+    else log.warn({ ticket, phase: next, code: r.code }, "scheduler: advance dispatch failed");
+  }
+
+  // (2) New-work pull — fill free slots with top-ranked ready tickets.
+  const eligible = readEligible ? readEligible() : readAllEligibleTickets();
+  const ready = computeReadyTickets(eligible);
+  const inFlightCount = listInFlightTickets(orchDir).size; // recomputed post-sweep
+  const freeSlots = computeFreeSlots(readMaxParallel(orchDir), inFlightCount);
+  const selected = selectDispatchable(ready, listStartedTickets(orchDir), freeSlots);
+
+  const dispatched = [];
+  for (const t of selected) {
+    const r = dispatchTicket(orchDir, t.identifier, PHASES[0], { dispatch });
+    if (r.code === 0) dispatched.push(t.identifier);
+    else log.warn({ ticket: t.identifier, code: r.code }, "scheduler: dispatch failed");
+  }
+
+  return { advanced, dispatched, freeSlots, ready: ready.map((t) => t.identifier) };
 }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -82,14 +82,39 @@ export function listInFlightTickets(orchDir) {
 }
 
 // readMaxParallel — the run's worker-slot ceiling from state.json (parity with
-// orchestrate-dispatch-next:176). Defaults to 1 when unset/unreadable.
+// orchestrate-dispatch-next:176). Defaults to 1 when unset/unreadable. ENOENT is
+// expected and stays silent; any other read error or a JSON parse failure would
+// otherwise silently cap the run to one slot forever, so it is logged loudly
+// before the fallback to keep the cause operator-visible.
 export function readMaxParallel(orchDir) {
+  let raw;
   try {
-    const n = JSON.parse(readFileSync(join(orchDir, "state.json"), "utf8"))?.maxParallel;
-    return Number.isInteger(n) && n > 0 ? n : 1;
-  } catch {
+    raw = readFileSync(join(orchDir, "state.json"), "utf8");
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      log.error(
+        { err: err.message, code: err.code, orchDir },
+        "scheduler: state.json unreadable — defaulting maxParallel to 1"
+      );
+    }
     return 1;
   }
+  let n;
+  try {
+    n = JSON.parse(raw)?.maxParallel;
+  } catch (err) {
+    log.error(
+      { err: err.message, orchDir },
+      "scheduler: state.json is not valid JSON — defaulting maxParallel to 1"
+    );
+    return 1;
+  }
+  if (Number.isInteger(n) && n > 0) return n;
+  log.warn(
+    { maxParallel: n, orchDir },
+    "scheduler: state.json has no valid maxParallel — defaulting to 1"
+  );
+  return 1;
 }
 
 // computeFreeSlots — never negative (an over-subscribed run yields 0).
@@ -154,11 +179,20 @@ export function listStartedTickets(orchDir) {
 
 // readAllEligibleTickets — concatenate every per-project eligible projection
 // (~/catalyst/execution-core/eligible/*.json — the CTL-535 monitor's output).
+// ENOENT on the dir is expected and stays silent; any other read error or a
+// malformed projection is logged — a persistent upstream bug (the monitor
+// writing bad JSON every reconcile) must not look like a healthy idle scheduler.
 export function readAllEligibleTickets() {
   let files;
   try {
     files = readdirSync(getEligibleDir());
-  } catch {
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      log.warn(
+        { err: err.message, code: err.code, dir: getEligibleDir() },
+        "scheduler: eligible dir unreadable — treating as empty"
+      );
+    }
     return []; // eligible dir not created yet
   }
   const all = [];
@@ -167,8 +201,11 @@ export function readAllEligibleTickets() {
     try {
       const proj = JSON.parse(readFileSync(join(getEligibleDir(), f), "utf8"));
       if (Array.isArray(proj?.tickets)) all.push(...proj.tickets);
-    } catch {
-      // malformed projection — skip, the next reconcile rewrites it
+    } catch (err) {
+      log.warn(
+        { err: err.message, file: f },
+        "scheduler: malformed eligible projection — skipping"
+      );
     }
   }
   return all;

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -111,17 +111,13 @@ export function computeReadyTickets(eligibleTickets) {
 export function selectDispatchable(rankedReady, excludeTickets, freeSlots) {
   if (freeSlots <= 0) return [];
   const exclude = excludeTickets ?? new Set();
-  return (rankedReady ?? [])
-    .filter((t) => !exclude.has(t.identifier))
-    .slice(0, freeSlots);
+  return (rankedReady ?? []).filter((t) => !exclude.has(t.identifier)).slice(0, freeSlots);
 }
 
 // ─── Phase 4: dispatch and FSM-driven phase advancement ───
 
 // orchestrate-dispatch-next sits one directory up from execution-core/.
-const DISPATCH_BIN = fileURLToPath(
-  new URL("../orchestrate-dispatch-next", import.meta.url),
-);
+const DISPATCH_BIN = fileURLToPath(new URL("../orchestrate-dispatch-next", import.meta.url));
 
 // defaultDispatch — shell out to orchestrate-dispatch-next, which delegates to
 // phase-agent-dispatch (idempotent: an existing dispatched/running/done signal
@@ -130,7 +126,7 @@ function defaultDispatch({ orchDir, ticket, phase }) {
   const res = spawnSync(
     DISPATCH_BIN,
     ["--orch-dir", orchDir, "--ticket", ticket, "--phase", phase],
-    { encoding: "utf8" },
+    { encoding: "utf8" }
   );
   if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
   return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
@@ -149,7 +145,7 @@ export function listStartedTickets(orchDir) {
     return new Set(
       readdirSync(join(orchDir, "workers"), { withFileTypes: true })
         .filter((d) => d.isDirectory())
-        .map((d) => d.name),
+        .map((d) => d.name)
     );
   } catch {
     return new Set();
@@ -190,7 +186,7 @@ export function deriveAdvancement(signals) {
   if (latest === null || sig[latest] !== "done") return null;
   const next = transition(
     { phase: latest, reviveCount: 0, parkedFrom: null },
-    { type: "complete" },
+    { type: "complete" }
   );
   if (isTerminal(next)) return null; // pipeline reached monitor-deploy → done
   if (next.phase in sig) return null; // successor already dispatched

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -6,17 +6,21 @@
 // tickets are advanced phase-by-phase through the FSM. Every dispatch is
 // idempotent (signal-file existence guard).
 //
+// Daemon correctness rests on the periodic tick — every action is re-derived
+// from filesystem state, so the periodic pass alone guarantees forward
+// progress. The event-log watcher is purely a latency optimization.
+//
 // Composes: lib/dependency-graph.mjs (readiness), scheduler-rank.mjs (ranking),
 // lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync, watch, mkdirSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { join } from "node:path";
+import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { analyzeDependencyGraph } from "../lib/dependency-graph.mjs";
 import { PHASES, transition, isTerminal } from "../lib/phase-fsm.mjs";
 import { rankTickets } from "./scheduler-rank.mjs";
-import { log, getEligibleDir } from "./config.mjs";
+import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -222,3 +226,109 @@ export function schedulerTick(orchDir, { readEligible, dispatch = defaultDispatc
 
   return { advanced, dispatched, freeSlots, ready: ready.map((t) => t.identifier) };
 }
+
+// ─── Phase 5: the pull-loop daemon ───
+
+// Periodic tick interval — the correctness backstop. The event fast path makes
+// the daemon react sooner; this guarantees forward progress if events are missed.
+const TICK_INTERVAL_MS = Number(process.env.SCHEDULER_TICK_INTERVAL_MS) || 30_000;
+// Debounce window — a burst of event-log appends coalesces into one tick.
+const TICK_DEBOUNCE_MS = Number(process.env.SCHEDULER_DEBOUNCE_MS) || 2_000;
+
+// --- daemon module state ---
+let tickTimer = null;
+let debounceTimer = null;
+let watcher = null;
+let runningOpts = null;
+
+function runTick() {
+  try {
+    schedulerTick(runningOpts.orchDir, {
+      readEligible: runningOpts.readEligible,
+      dispatch: runningOpts.dispatch,
+    });
+  } catch (err) {
+    // A tick must never crash the daemon — log and let the next tick retry.
+    log.error({ err: err.message }, "scheduler: tick failed");
+  }
+}
+
+function scheduleDebouncedTick(debounceMs) {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(runTick, debounceMs);
+}
+
+// startScheduler — immediate authoritative tick, arm the periodic timer, then
+// start the event-log fast path. `dispatch` / `readEligible` are injectable so
+// a test drives a hermetic daemon.
+export function startScheduler({
+  orchDir,
+  dispatch,
+  readEligible,
+  tickIntervalMs = TICK_INTERVAL_MS,
+  debounceMs = TICK_DEBOUNCE_MS,
+} = {}) {
+  if (!orchDir) throw new Error("startScheduler: orchDir is required");
+  runningOpts = { orchDir, dispatch, readEligible };
+
+  runTick(); // authoritative initial pass
+  tickTimer = setInterval(runTick, tickIntervalMs);
+
+  // Event fast path: any change to the event log wakes a debounced tick. No
+  // parsing — schedulerTick re-derives every action from filesystem state, so
+  // "something changed, re-tick" is both correct and cheap.
+  //
+  // The event type is deliberately NOT filtered: macOS fs.watch on a directory
+  // reports `rename` even for in-place appends, while Linux reports `change`.
+  // Reacting to either keeps the fast path working on both platforms; the
+  // periodic tick is the correctness backstop regardless.
+  const eventsDir = dirname(getEventLogPath());
+  mkdirSync(eventsDir, { recursive: true });
+  watcher = watch(eventsDir, (_eventType, filename) => {
+    if (filename !== null && filename !== basename(getEventLogPath())) return;
+    scheduleDebouncedTick(debounceMs);
+  });
+}
+
+// stopScheduler — clear the timer, the debounce timer, and the watcher.
+// Idempotent and safe to call before startScheduler.
+export function stopScheduler() {
+  if (tickTimer) {
+    clearInterval(tickTimer);
+    tickTimer = null;
+  }
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  watcher?.close();
+  watcher = null;
+  runningOpts = null;
+}
+
+// __resetForTests — clear daemon state between unit tests. Not part of the
+// public contract; the index.mjs barrel does not re-export it.
+export function __resetForTests() {
+  stopScheduler();
+}
+
+// --- standalone entrypoint (operator dry-run / CTL-554 wires the real daemon) ---
+function main() {
+  const idx = process.argv.indexOf("--orch-dir");
+  const orchDir = idx >= 0 ? process.argv[idx + 1] : process.env.CATALYST_ORCHESTRATOR_DIR;
+  if (!orchDir) {
+    console.error("usage: bun scheduler.mjs --orch-dir <path>");
+    process.exit(1);
+  }
+  log.info({ orchDir }, "execution-core scheduler starting");
+  startScheduler({ orchDir });
+  const shutdown = (sig) => {
+    log.info({ sig }, "execution-core scheduler shutting down");
+    stopScheduler();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+}
+
+if (import.meta.main) main();

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1,0 +1,137 @@
+// Unit + filesystem-fixture tests for the pull-loop scheduler (CTL-536).
+// Run: cd plugins/dev/scripts/execution-core && bun test scheduler.test.mjs
+//
+// Phase 3 adds the selection-core blocks; Phases 4-5 extend this same file.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readPhaseSignals,
+  isTicketInFlight,
+  listInFlightTickets,
+  readMaxParallel,
+  computeFreeSlots,
+  computeReadyTickets,
+  selectDispatchable,
+} from "./scheduler.mjs";
+
+let orchDir;
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "sched-"));
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+function writeSignal(ticket, phase, status) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, status }),
+  );
+}
+
+describe("readPhaseSignals", () => {
+  test("returns a phase→status map for a worker dir", () => {
+    writeSignal("CTL-1", "triage", "done");
+    writeSignal("CTL-1", "research", "running");
+    expect(readPhaseSignals(orchDir, "CTL-1")).toEqual({
+      triage: "done",
+      research: "running",
+    });
+  });
+  test("returns {} when the worker dir does not exist", () => {
+    expect(readPhaseSignals(orchDir, "CTL-404")).toEqual({});
+  });
+});
+
+describe("isTicketInFlight", () => {
+  test("a non-terminal signal means in-flight", () => {
+    expect(isTicketInFlight({ triage: "done", research: "running" })).toBe(
+      true,
+    );
+  });
+  test("plan done + no later signal (advance window) is still in-flight", () => {
+    expect(
+      isTicketInFlight({ triage: "done", research: "done", plan: "done" }),
+    ).toBe(true);
+  });
+  test("monitor-deploy done is terminal success → NOT in-flight", () => {
+    expect(isTicketInFlight({ "monitor-deploy": "done" })).toBe(false);
+  });
+  test("a failed or stalled signal is terminal → NOT in-flight", () => {
+    expect(isTicketInFlight({ implement: "failed" })).toBe(false);
+    expect(isTicketInFlight({ verify: "stalled" })).toBe(false);
+  });
+  test("no signals at all → NOT in-flight", () => {
+    expect(isTicketInFlight({})).toBe(false);
+  });
+});
+
+describe("listInFlightTickets / readMaxParallel / computeFreeSlots", () => {
+  test("counts only in-flight worker dirs", () => {
+    writeSignal("CTL-1", "implement", "running");
+    writeSignal("CTL-2", "monitor-deploy", "done");
+    writeSignal("CTL-3", "triage", "failed");
+    expect([...listInFlightTickets(orchDir)]).toEqual(["CTL-1"]);
+  });
+  test("readMaxParallel reads state.json, defaults to 1", () => {
+    expect(readMaxParallel(orchDir)).toBe(1);
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 3 }),
+    );
+    expect(readMaxParallel(orchDir)).toBe(3);
+  });
+  test("computeFreeSlots never goes negative", () => {
+    expect(computeFreeSlots(3, 1)).toBe(2);
+    expect(computeFreeSlots(3, 5)).toBe(0);
+  });
+});
+
+describe("computeReadyTickets", () => {
+  const tk = (id, priority, createdAt, relations) => ({
+    identifier: id,
+    priority,
+    createdAt,
+    state: "Todo",
+    relations: relations ?? { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+
+  test("returns ranked ready tickets, excluding blocked ones", () => {
+    // CTL-2 blocks CTL-1 → CTL-1 blocked; CTL-2 and CTL-3 ready. Distinct
+    // priorities (CTL-2 Urgent=1, CTL-3 High=2) make the ranked order exact.
+    const eligible = [
+      tk("CTL-1", 3, "x", {
+        nodes: [{ type: "blocked_by", relatedIssue: { identifier: "CTL-2" } }],
+      }),
+      tk("CTL-2", 1, "x"),
+      tk("CTL-3", 2, "x"),
+    ];
+    const ready = computeReadyTickets(eligible);
+    expect(ready.map((t) => t.identifier)).toEqual(["CTL-2", "CTL-3"]);
+  });
+  test("with no relations every eligible ticket is ready, priority-ranked", () => {
+    const ready = computeReadyTickets([tk("CTL-9", 4, "x"), tk("CTL-8", 1, "x")]);
+    expect(ready.map((t) => t.identifier)).toEqual(["CTL-8", "CTL-9"]);
+  });
+  test("empty eligible set → empty ready set", () => {
+    expect(computeReadyTickets([])).toEqual([]);
+  });
+});
+
+describe("selectDispatchable", () => {
+  const tk = (id) => ({ identifier: id });
+  test("takes the top freeSlots ready tickets not already in-flight", () => {
+    const ranked = [tk("A"), tk("B"), tk("C"), tk("D")];
+    const sel = selectDispatchable(ranked, new Set(["B"]), 2);
+    expect(sel.map((t) => t.identifier)).toEqual(["A", "C"]);
+  });
+  test("freeSlots 0 → selects nothing", () => {
+    expect(selectDispatchable([tk("A")], new Set(), 0)).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4,13 +4,7 @@
 // Phase 3 adds the selection-core blocks; Phases 4-5 extend this same file.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import {
-  mkdtempSync,
-  rmSync,
-  mkdirSync,
-  writeFileSync,
-  appendFileSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -24,6 +18,7 @@ import {
   deriveAdvancement,
   listStartedTickets,
   schedulerTick,
+  readAllEligibleTickets,
   startScheduler,
   stopScheduler,
   __resetForTests,
@@ -50,10 +45,7 @@ afterEach(() => {
 function writeSignal(ticket, phase, status) {
   const dir = join(orchDir, "workers", ticket);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    join(dir, `phase-${phase}.json`),
-    JSON.stringify({ ticket, phase, status }),
-  );
+  writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, status }));
 }
 
 // appendToEventLog — mkdirSync <CATALYST_DIR>/events/ and append to the
@@ -64,6 +56,19 @@ function appendToEventLog(line) {
   const now = new Date();
   const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
   appendFileSync(join(dir, `${ym}.jsonl`), line);
+}
+
+// eligibleDir / writeEligibleProjection — getEligibleDir() resolves to
+// <CATALYST_DIR>/execution-core/eligible (config.mjs); write a per-project
+// projection there so readAllEligibleTickets() reads a fixture. `raw` writes
+// arbitrary file content (used for the malformed-JSON case).
+const eligibleDir = () => join(catalystDir, "execution-core", "eligible");
+function writeEligibleProjection(projectKey, body, { raw = false } = {}) {
+  mkdirSync(eligibleDir(), { recursive: true });
+  writeFileSync(
+    join(eligibleDir(), `${projectKey}.json`),
+    raw ? body : JSON.stringify(body),
+  );
 }
 
 describe("readPhaseSignals", () => {
@@ -82,14 +87,10 @@ describe("readPhaseSignals", () => {
 
 describe("isTicketInFlight", () => {
   test("a non-terminal signal means in-flight", () => {
-    expect(isTicketInFlight({ triage: "done", research: "running" })).toBe(
-      true,
-    );
+    expect(isTicketInFlight({ triage: "done", research: "running" })).toBe(true);
   });
   test("plan done + no later signal (advance window) is still in-flight", () => {
-    expect(
-      isTicketInFlight({ triage: "done", research: "done", plan: "done" }),
-    ).toBe(true);
+    expect(isTicketInFlight({ triage: "done", research: "done", plan: "done" })).toBe(true);
   });
   test("monitor-deploy done is terminal success → NOT in-flight", () => {
     expect(isTicketInFlight({ "monitor-deploy": "done" })).toBe(false);
@@ -112,10 +113,7 @@ describe("listInFlightTickets / readMaxParallel / computeFreeSlots", () => {
   });
   test("readMaxParallel reads state.json, defaults to 1", () => {
     expect(readMaxParallel(orchDir)).toBe(1);
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 3 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 3 }));
     expect(readMaxParallel(orchDir)).toBe(3);
   });
   test("computeFreeSlots never goes negative", () => {
@@ -154,6 +152,31 @@ describe("computeReadyTickets", () => {
   test("empty eligible set → empty ready set", () => {
     expect(computeReadyTickets([])).toEqual([]);
   });
+  test("a blocker outside the eligible set does not block (finished/non-Todo)", () => {
+    // The eligible set is all-Todo; a finished (Done/Canceled) or otherwise
+    // non-Todo blocker is simply absent from it. buildDependencyEdges drops
+    // any edge with an out-of-set endpoint, so CTL-1's blocked_by edge to the
+    // absent CTL-99 is dropped and CTL-1 is ready.
+    const ready = computeReadyTickets([
+      tk("CTL-1", 2, "x", {
+        nodes: [{ type: "blocked_by", relatedIssue: { identifier: "CTL-99" } }],
+      }),
+    ]);
+    expect(ready.map((t) => t.identifier)).toEqual(["CTL-1"]);
+  });
+  test("a mutual dependency cycle leaves both tickets blocked — no crash", () => {
+    // CTL-A blocked_by CTL-B and CTL-B blocked_by CTL-A. The scheduler must
+    // tolerate the cycle: both partition as blocked, neither is dispatched.
+    const ready = computeReadyTickets([
+      tk("CTL-A", 1, "x", {
+        nodes: [{ type: "blocked_by", relatedIssue: { identifier: "CTL-B" } }],
+      }),
+      tk("CTL-B", 1, "x", {
+        nodes: [{ type: "blocked_by", relatedIssue: { identifier: "CTL-A" } }],
+      }),
+    ]);
+    expect(ready).toEqual([]);
+  });
 });
 
 describe("selectDispatchable", () => {
@@ -165,6 +188,10 @@ describe("selectDispatchable", () => {
   });
   test("freeSlots 0 → selects nothing", () => {
     expect(selectDispatchable([tk("A")], new Set(), 0)).toEqual([]);
+  });
+  test("caps the selection at freeSlots when more tickets are ready", () => {
+    const ranked = [tk("A"), tk("B"), tk("C")];
+    expect(selectDispatchable(ranked, new Set(), 1).map((t) => t.identifier)).toEqual(["A"]);
   });
 });
 
@@ -184,9 +211,7 @@ function fakeDispatch({ code = 0 } = {}) {
 describe("deriveAdvancement", () => {
   test("latest phase done → returns the FSM successor", () => {
     expect(deriveAdvancement({ triage: "done" })).toBe("research");
-    expect(
-      deriveAdvancement({ triage: "done", research: "done", plan: "done" }),
-    ).toBe("implement");
+    expect(deriveAdvancement({ triage: "done", research: "done", plan: "done" })).toBe("implement");
   });
   test("latest phase not done → null (nothing owed)", () => {
     expect(deriveAdvancement({ triage: "done", research: "running" })).toBeNull();
@@ -198,6 +223,9 @@ describe("deriveAdvancement", () => {
   test("monitor-deploy done → null (pipeline terminal)", () => {
     expect(deriveAdvancement({ "monitor-deploy": "done" })).toBeNull();
   });
+  test("latest phase failed → null (nothing owed — revive is another owner's job)", () => {
+    expect(deriveAdvancement({ implement: "failed" })).toBeNull();
+  });
   test("no signals → null", () => {
     expect(deriveAdvancement({})).toBeNull();
   });
@@ -205,10 +233,7 @@ describe("deriveAdvancement", () => {
 
 describe("schedulerTick — new-work pull", () => {
   test("dispatches triage for the top-ranked ready ticket into a free slot", () => {
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 2 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     const dispatch = fakeDispatch();
     const eligible = [
       {
@@ -236,10 +261,7 @@ describe("schedulerTick — new-work pull", () => {
   });
 
   test("respects maxParallel — no dispatch when slots are full", () => {
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 1 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     writeSignal("CTL-1", "implement", "running"); // 1 in-flight, ceiling 1
     const dispatch = fakeDispatch();
     const eligible = [
@@ -258,10 +280,7 @@ describe("schedulerTick — new-work pull", () => {
   });
 
   test("is idempotent — a second tick re-dispatches nothing", () => {
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 2 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     const eligible = [
       {
         identifier: "CTL-5",
@@ -285,24 +304,16 @@ describe("schedulerTick — new-work pull", () => {
   });
 
   test("advancement sweep dispatches the owed next phase for an in-flight ticket", () => {
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 1 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     writeSignal("CTL-7", "triage", "done"); // research is owed
     const dispatch = fakeDispatch();
     const r = schedulerTick(orchDir, { readEligible: () => [], dispatch });
-    expect(dispatch.calls).toEqual([
-      { orchDir, ticket: "CTL-7", phase: "research" },
-    ]);
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
   });
 
   test("a failed-dispatch (non-zero exit) is a soft skip, not a throw", () => {
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 1 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch({ code: 1 });
     const eligible = [
       {
@@ -318,6 +329,35 @@ describe("schedulerTick — new-work pull", () => {
     expect(r.dispatched).toEqual([]); // dispatch failed → not recorded
     // no throw — the tick completes
   });
+
+  test("one tick both advances an in-flight ticket and pulls new work", () => {
+    // maxParallel 2; CTL-7 in-flight at triage:done (advances to research,
+    // still 1 in-flight); 1 free slot remains → CTL-X is pulled. The
+    // advancement sweep must NOT consume the slot the pull then fills.
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 2 }),
+    );
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const eligible = [
+      {
+        identifier: "CTL-X",
+        priority: 1,
+        createdAt: "x",
+        state: "Todo",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      },
+    ];
+    const r = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+    expect(r.dispatched).toEqual(["CTL-X"]);
+    expect(dispatch.calls).toEqual([
+      { orchDir, ticket: "CTL-7", phase: "research" },
+      { orchDir, ticket: "CTL-X", phase: "triage" },
+    ]);
+  });
 });
 
 describe("listStartedTickets", () => {
@@ -325,11 +365,34 @@ describe("listStartedTickets", () => {
     writeSignal("CTL-1", "implement", "running");
     writeSignal("CTL-2", "triage", "failed");
     writeSignal("CTL-3", "monitor-deploy", "done");
-    expect([...listStartedTickets(orchDir)].sort()).toEqual([
-      "CTL-1",
-      "CTL-2",
-      "CTL-3",
-    ]);
+    expect([...listStartedTickets(orchDir)].sort()).toEqual(["CTL-1", "CTL-2", "CTL-3"]);
+  });
+});
+
+describe("readAllEligibleTickets", () => {
+  test("returns [] when the eligible dir does not exist", () => {
+    expect(readAllEligibleTickets()).toEqual([]);
+  });
+  test("concatenates tickets across every per-project projection", () => {
+    writeEligibleProjection("alpha", { tickets: [{ identifier: "A-1" }] });
+    writeEligibleProjection("beta", {
+      tickets: [{ identifier: "B-1" }, { identifier: "B-2" }],
+    });
+    expect(
+      readAllEligibleTickets()
+        .map((t) => t.identifier)
+        .sort(),
+    ).toEqual(["A-1", "B-1", "B-2"]);
+  });
+  test("skips a malformed projection file and still returns the valid ones", () => {
+    writeEligibleProjection("good", { tickets: [{ identifier: "G-1" }] });
+    writeEligibleProjection("bad", "{ not valid json", { raw: true });
+    expect(readAllEligibleTickets().map((t) => t.identifier)).toEqual(["G-1"]);
+  });
+  test("skips a projection whose `tickets` field is not an array", () => {
+    writeEligibleProjection("shapeless", { tickets: "nope" });
+    writeEligibleProjection("ok", { tickets: [{ identifier: "OK-1" }] });
+    expect(readAllEligibleTickets().map((t) => t.identifier)).toEqual(["OK-1"]);
   });
 });
 
@@ -340,10 +403,7 @@ describe("startScheduler / stopScheduler", () => {
 
   test("startScheduler runs one tick immediately", () => {
     const dispatch = fakeDispatch();
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 1 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     writeSignal("CTL-1", "triage", "done"); // research owed
     startScheduler({
       orchDir,
@@ -352,17 +412,12 @@ describe("startScheduler / stopScheduler", () => {
       tickIntervalMs: 60_000,
       debounceMs: 5,
     });
-    expect(dispatch.calls).toEqual([
-      { orchDir, ticket: "CTL-1", phase: "research" },
-    ]);
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-1", phase: "research" }]);
   });
 
   test("the periodic timer fires another tick", async () => {
     const dispatch = fakeDispatch();
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 1 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     startScheduler({
       orchDir,
       dispatch,
@@ -377,10 +432,7 @@ describe("startScheduler / stopScheduler", () => {
 
   test("an event-log change triggers a debounced tick", async () => {
     const dispatch = fakeDispatch();
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 1 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     // Pre-create the event log so the later append is an in-place change
     // (fs.watch fires `change`), not a create (`rename`). In production the
     // event log always exists — workers append to it continuously.
@@ -397,11 +449,7 @@ describe("startScheduler / stopScheduler", () => {
     // macOS FSEvents watcher latency (observed ~40ms) plus the debounce.
     appendToEventLog('{"event":"phase.triage.complete.CTL-3"}\n');
     await new Promise((r) => setTimeout(r, 400));
-    expect(
-      dispatch.calls.some(
-        (c) => c.ticket === "CTL-3" && c.phase === "research",
-      ),
-    ).toBe(true);
+    expect(dispatch.calls.some((c) => c.ticket === "CTL-3" && c.phase === "research")).toBe(true);
   });
 
   test("stopScheduler is idempotent and safe before start", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -65,10 +65,7 @@ function appendToEventLog(line) {
 const eligibleDir = () => join(catalystDir, "execution-core", "eligible");
 function writeEligibleProjection(projectKey, body, { raw = false } = {}) {
   mkdirSync(eligibleDir(), { recursive: true });
-  writeFileSync(
-    join(eligibleDir(), `${projectKey}.json`),
-    raw ? body : JSON.stringify(body),
-  );
+  writeFileSync(join(eligibleDir(), `${projectKey}.json`), raw ? body : JSON.stringify(body));
 }
 
 describe("readPhaseSignals", () => {
@@ -334,10 +331,7 @@ describe("schedulerTick — new-work pull", () => {
     // maxParallel 2; CTL-7 in-flight at triage:done (advances to research,
     // still 1 in-flight); 1 free slot remains → CTL-X is pulled. The
     // advancement sweep must NOT consume the slot the pull then fills.
-    writeFileSync(
-      join(orchDir, "state.json"),
-      JSON.stringify({ maxParallel: 2 }),
-    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     writeSignal("CTL-7", "triage", "done");
     const dispatch = fakeDispatch();
     const eligible = [
@@ -381,7 +375,7 @@ describe("readAllEligibleTickets", () => {
     expect(
       readAllEligibleTickets()
         .map((t) => t.identifier)
-        .sort(),
+        .sort()
     ).toEqual(["A-1", "B-1", "B-2"]);
   });
   test("skips a malformed projection file and still returns the valid ones", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -68,6 +68,26 @@ function writeEligibleProjection(projectKey, body, { raw = false } = {}) {
   writeFileSync(join(eligibleDir(), `${projectKey}.json`), raw ? body : JSON.stringify(body));
 }
 
+// waitFor — poll `predicate` every `intervalMs` until it returns truthy, or
+// throw after `timeoutMs`. Replaces fixed-duration sleeps in the daemon tests:
+// fs.watch / timer delivery latency is variable (macOS FSEvents spikes well past
+// a fixed sleep, and can drop an event that lands before the watch finishes
+// registering), so a fixed sleep races the watcher and flakes. A bounded poll is
+// deterministic — it returns as soon as the condition holds and only fails if it
+// genuinely never does. `onTick` runs once per poll, so a test can re-trigger a
+// droppable event each iteration instead of relying on a single delivery.
+async function waitFor(predicate, { timeoutMs = 5000, intervalMs = 25, onTick } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    onTick?.();
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  if (!predicate()) {
+    throw new Error(`waitFor: predicate not satisfied within ${timeoutMs}ms`);
+  }
+}
+
 describe("readPhaseSignals", () => {
   test("returns a phase→status map for a worker dir", () => {
     writeSignal("CTL-1", "triage", "done");
@@ -420,7 +440,7 @@ describe("startScheduler / stopScheduler", () => {
       debounceMs: 5,
     });
     writeSignal("CTL-2", "triage", "done"); // becomes owed after the first tick
-    await new Promise((r) => setTimeout(r, 60));
+    await waitFor(() => dispatch.calls.some((c) => c.ticket === "CTL-2"));
     expect(dispatch.calls.some((c) => c.ticket === "CTL-2")).toBe(true);
   });
 
@@ -439,11 +459,17 @@ describe("startScheduler / stopScheduler", () => {
       debounceMs: 10,
     });
     writeSignal("CTL-3", "triage", "done");
-    // Appending to the event log must wake the scheduler. The await covers
-    // macOS FSEvents watcher latency (observed ~40ms) plus the debounce.
-    appendToEventLog('{"event":"phase.triage.complete.CTL-3"}\n');
-    await new Promise((r) => setTimeout(r, 400));
-    expect(dispatch.calls.some((c) => c.ticket === "CTL-3" && c.phase === "research")).toBe(true);
+    const dispatched = () =>
+      dispatch.calls.some((c) => c.ticket === "CTL-3" && c.phase === "research");
+    // Appending to the event log must wake the scheduler. macOS FSEvents can
+    // drop an append that lands before the watcher finishes registering, so
+    // re-append once per poll — each append is a fresh chance for the watcher to
+    // fire — instead of racing a single fixed sleep against watcher latency.
+    await waitFor(dispatched, {
+      intervalMs: 100,
+      onTick: () => appendToEventLog('{"event":"phase.triage.complete.CTL-3"}\n'),
+    });
+    expect(dispatched()).toBe(true);
   });
 
   test("stopScheduler is idempotent and safe before start", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4,7 +4,13 @@
 // Phase 3 adds the selection-core blocks; Phases 4-5 extend this same file.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  appendFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -18,14 +24,27 @@ import {
   deriveAdvancement,
   listStartedTickets,
   schedulerTick,
+  startScheduler,
+  stopScheduler,
+  __resetForTests,
 } from "./scheduler.mjs";
 
 let orchDir;
+let catalystDir;
+let prevCatalystDir;
 beforeEach(() => {
   orchDir = mkdtempSync(join(tmpdir(), "sched-"));
+  // Redirect CATALYST_DIR so getEventLogPath() resolves under a fixture —
+  // the same redirect monitor.test.mjs uses.
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "sched-cat-"));
+  process.env.CATALYST_DIR = catalystDir;
 });
 afterEach(() => {
   rmSync(orchDir, { recursive: true, force: true });
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
 });
 
 function writeSignal(ticket, phase, status) {
@@ -35,6 +54,16 @@ function writeSignal(ticket, phase, status) {
     join(dir, `phase-${phase}.json`),
     JSON.stringify({ ticket, phase, status }),
   );
+}
+
+// appendToEventLog — mkdirSync <CATALYST_DIR>/events/ and append to the
+// current UTC YYYY-MM.jsonl (the path getEventLogPath() resolves).
+function appendToEventLog(line) {
+  const dir = join(catalystDir, "events");
+  mkdirSync(dir, { recursive: true });
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  appendFileSync(join(dir, `${ym}.jsonl`), line);
 }
 
 describe("readPhaseSignals", () => {
@@ -301,5 +330,84 @@ describe("listStartedTickets", () => {
       "CTL-2",
       "CTL-3",
     ]);
+  });
+});
+
+// ── Phase 5: the pull-loop daemon ──
+
+describe("startScheduler / stopScheduler", () => {
+  afterEach(() => __resetForTests());
+
+  test("startScheduler runs one tick immediately", () => {
+    const dispatch = fakeDispatch();
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 1 }),
+    );
+    writeSignal("CTL-1", "triage", "done"); // research owed
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [],
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+    });
+    expect(dispatch.calls).toEqual([
+      { orchDir, ticket: "CTL-1", phase: "research" },
+    ]);
+  });
+
+  test("the periodic timer fires another tick", async () => {
+    const dispatch = fakeDispatch();
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 1 }),
+    );
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [],
+      tickIntervalMs: 20,
+      debounceMs: 5,
+    });
+    writeSignal("CTL-2", "triage", "done"); // becomes owed after the first tick
+    await new Promise((r) => setTimeout(r, 60));
+    expect(dispatch.calls.some((c) => c.ticket === "CTL-2")).toBe(true);
+  });
+
+  test("an event-log change triggers a debounced tick", async () => {
+    const dispatch = fakeDispatch();
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 1 }),
+    );
+    // Pre-create the event log so the later append is an in-place change
+    // (fs.watch fires `change`), not a create (`rename`). In production the
+    // event log always exists — workers append to it continuously.
+    appendToEventLog("");
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [],
+      tickIntervalMs: 60_000,
+      debounceMs: 10,
+    });
+    writeSignal("CTL-3", "triage", "done");
+    // Appending to the event log must wake the scheduler. The await covers
+    // macOS FSEvents watcher latency (observed ~40ms) plus the debounce.
+    appendToEventLog('{"event":"phase.triage.complete.CTL-3"}\n');
+    await new Promise((r) => setTimeout(r, 400));
+    expect(
+      dispatch.calls.some(
+        (c) => c.ticket === "CTL-3" && c.phase === "research",
+      ),
+    ).toBe(true);
+  });
+
+  test("stopScheduler is idempotent and safe before start", () => {
+    expect(() => {
+      stopScheduler();
+      stopScheduler();
+    }).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -15,6 +15,9 @@ import {
   computeFreeSlots,
   computeReadyTickets,
   selectDispatchable,
+  deriveAdvancement,
+  listStartedTickets,
+  schedulerTick,
 } from "./scheduler.mjs";
 
 let orchDir;
@@ -133,5 +136,170 @@ describe("selectDispatchable", () => {
   });
   test("freeSlots 0 → selects nothing", () => {
     expect(selectDispatchable([tk("A")], new Set(), 0)).toEqual([]);
+  });
+});
+
+// ── Phase 4: dispatch and FSM-driven phase advancement ──
+
+// A dispatch stub: records every call, returns a configurable exit code.
+function fakeDispatch({ code = 0 } = {}) {
+  const calls = [];
+  const fn = (args) => {
+    calls.push(args);
+    return { code, stdout: "", stderr: "" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe("deriveAdvancement", () => {
+  test("latest phase done → returns the FSM successor", () => {
+    expect(deriveAdvancement({ triage: "done" })).toBe("research");
+    expect(
+      deriveAdvancement({ triage: "done", research: "done", plan: "done" }),
+    ).toBe("implement");
+  });
+  test("latest phase not done → null (nothing owed)", () => {
+    expect(deriveAdvancement({ triage: "done", research: "running" })).toBeNull();
+  });
+  test("successor already has a signal → null (already advanced)", () => {
+    expect(deriveAdvancement({ triage: "done", research: "running" })).toBeNull();
+    expect(deriveAdvancement({ research: "done", plan: "dispatched" })).toBeNull();
+  });
+  test("monitor-deploy done → null (pipeline terminal)", () => {
+    expect(deriveAdvancement({ "monitor-deploy": "done" })).toBeNull();
+  });
+  test("no signals → null", () => {
+    expect(deriveAdvancement({})).toBeNull();
+  });
+});
+
+describe("schedulerTick — new-work pull", () => {
+  test("dispatches triage for the top-ranked ready ticket into a free slot", () => {
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 2 }),
+    );
+    const dispatch = fakeDispatch();
+    const eligible = [
+      {
+        identifier: "CTL-9",
+        priority: 4,
+        createdAt: "x",
+        state: "Todo",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      },
+      {
+        identifier: "CTL-8",
+        priority: 1,
+        createdAt: "x",
+        state: "Todo",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      },
+    ];
+    const r = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    // 2 free slots, both ready → both dispatched, urgent (CTL-8) first.
+    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-8", "CTL-9"]);
+    expect(dispatch.calls.every((c) => c.phase === "triage")).toBe(true);
+    expect(r.dispatched).toEqual(["CTL-8", "CTL-9"]);
+  });
+
+  test("respects maxParallel — no dispatch when slots are full", () => {
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 1 }),
+    );
+    writeSignal("CTL-1", "implement", "running"); // 1 in-flight, ceiling 1
+    const dispatch = fakeDispatch();
+    const eligible = [
+      {
+        identifier: "CTL-2",
+        priority: 1,
+        createdAt: "x",
+        state: "Todo",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      },
+    ];
+    const r = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    expect(dispatch.calls).toHaveLength(0);
+    expect(r.dispatched).toEqual([]);
+  });
+
+  test("is idempotent — a second tick re-dispatches nothing", () => {
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 2 }),
+    );
+    const eligible = [
+      {
+        identifier: "CTL-5",
+        priority: 2,
+        createdAt: "x",
+        state: "Todo",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      },
+    ];
+    // First tick dispatches; the stub also writes the signal
+    // phase-agent-dispatch would.
+    const dispatch = (args) => {
+      writeSignal(args.ticket, args.phase, "dispatched");
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    const second = fakeDispatch();
+    schedulerTick(orchDir, { readEligible: () => eligible, dispatch: second });
+    expect(second.calls).toHaveLength(0); // CTL-5 already started → not re-pulled
+  });
+
+  test("advancement sweep dispatches the owed next phase for an in-flight ticket", () => {
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 1 }),
+    );
+    writeSignal("CTL-7", "triage", "done"); // research is owed
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, { readEligible: () => [], dispatch });
+    expect(dispatch.calls).toEqual([
+      { orchDir, ticket: "CTL-7", phase: "research" },
+    ]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+  });
+
+  test("a failed-dispatch (non-zero exit) is a soft skip, not a throw", () => {
+    writeFileSync(
+      join(orchDir, "state.json"),
+      JSON.stringify({ maxParallel: 1 }),
+    );
+    const dispatch = fakeDispatch({ code: 1 });
+    const eligible = [
+      {
+        identifier: "CTL-3",
+        priority: 1,
+        createdAt: "x",
+        state: "Todo",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      },
+    ];
+    const r = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    expect(r.dispatched).toEqual([]); // dispatch failed → not recorded
+    // no throw — the tick completes
+  });
+});
+
+describe("listStartedTickets", () => {
+  test("returns every worker dir regardless of status (started ≠ in-flight)", () => {
+    writeSignal("CTL-1", "implement", "running");
+    writeSignal("CTL-2", "triage", "failed");
+    writeSignal("CTL-3", "monitor-deploy", "done");
+    expect([...listStartedTickets(orchDir)].sort()).toEqual([
+      "CTL-1",
+      "CTL-2",
+      "CTL-3",
+    ]);
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-21T10:21:27Z -->
<!-- Last updated: 2026-05-21T10:21:27Z -->
<!-- PR: #940 -->
<!-- Previous commits: 12a4b6b0e303857ee1306963645147c1d980ba40,11e12218acf96a5e8856b9c739204fa9a1d90cc7,4688dc38bdc5e02965344f59f1d4f9a605b845e0,5687e15cc81a0f96f5076aed450042e158c42727,19faed368f13bd99fc48c6ff94d74183a3d0f3bc,8110e9a2e6d4d79a663a5ccc399ed57044665c20,619850f3c4b0c7cca448238007e6cadb34fd7af0,bb32b8b58ef180bc2940e970ef17797588fcc26e -->

## Summary

Adds the pull-loop scheduler to the execution core. This replaces wave-based push
dispatch with a continuous pull loop: on every tick the scheduler computes a fresh
ready set (eligible ∩ no-open-blocker), priority-ranks it, and dispatches the
top-ranked ticket whenever a worker slot is free. In-flight tickets are advanced
phase-by-phase through the FSM. Every dispatch is idempotent, guarded by signal-file
existence, so a tick that re-runs never double-dispatches.

The work is split into three new leaf/composite modules plus a runnable daemon, all
under `plugins/dev/scripts/execution-core/`.

## Changes Made

### Scheduler ranking (`scheduler-rank.mjs`)

- New pure leaf module — data in, data out, no I/O, no imports.
- `priorityRank` encodes Linear priority (1=Urgent … 4=Low, 0=No priority → 5 so it
  ranks below Low); missing/non-numeric priority is treated as No priority.
- `compareTickets` defines the total order for selection: priority ascending, then
  `createdAt` ascending (FIFO fairness — oldest waiting ticket first), then
  identifier ascending as a deterministic final tie-break. A missing `createdAt`
  sorts last within its priority band so absent data never jumps the queue.

### Scheduler selection core + daemon (`scheduler.mjs`)

- Ready-set computation: intersects the eligible set with the dependency graph's
  no-open-blocker set, with slot accounting against in-flight workers.
- FSM-driven phase advancement: in-flight tickets are walked through the pipeline
  phases via `lib/phase-fsm.mjs`.
- Pull-loop daemon: a periodic tick re-derives every action from filesystem state,
  so the periodic pass alone guarantees forward progress; the event-log watcher is
  purely a latency optimization.
- Idempotent dispatch via a signal-file existence guard.
- Composes `lib/dependency-graph.mjs`, `scheduler-rank.mjs`, `lib/phase-fsm.mjs`,
  and `eligible-set.mjs`.

### Eligible-ticket shape (`linear-query.mjs`)

- Eligible-ticket projection now captures `createdAt` and ticket relations, so the
  scheduler can apply FIFO fairness and dependency-aware readiness without a second
  query.

### Barrel export (`index.mjs`)

- Re-exports the new scheduler surface from the execution-core barrel.

### Tests & formatting

- New test suites for `scheduler.mjs`, `scheduler-rank.mjs`, and the extended
  `linear-query.mjs` projection (`scheduler.test.mjs`, `scheduler-rank.test.mjs`,
  `linear-query.test.mjs`).
- Coverage hardened from PR test-analysis feedback.
- Trunk autofix formatting applied across the scheduler modules.
- Phase-review remediations applied.

## How to Verify It

- [x] Module tests pass: `bun test scheduler.test.mjs scheduler-rank.test.mjs linear-query.test.mjs` — 63 pass, 0 fail (86 assertions) ✅
- [x] CI `validate` check passes ✅
- [x] CI `audit-references` check passes ✅
- [x] CI `check-versions` check passes ✅

## Related Issues/PRs

- Refs CTL-536

## Changelog Entry

Add the pull-loop scheduler to the execution core — continuous tick-based
dispatch with priority/FIFO ranking, FSM-driven phase advancement, and idempotent
signal-file-guarded dispatch.
