### PR TITLE
CTL-533: Exec core tracer

### DIFF
--- a/plugins/dev/scripts/execution-core/comms-drain.mjs
+++ b/plugins/dev/scripts/execution-core/comms-drain.mjs
@@ -1,0 +1,33 @@
+// comms-drain.mjs — execution-core Step F comms-channel drain decision (CTL-533).
+//
+// Pure mirror of the comms-attention promotion in orchestrate/SKILL.md
+// (CTL-111, CTL-269): workers post type:"attention" messages to the
+// orchestrator's channel when blocked; the scan promotes each one to a
+// state-level attention item.
+//
+// The caller is responsible for reading messages from the channel file since
+// the cursor. This function is pure: given the already-read messages and the
+// prior cursor, it returns the attention items and the advanced cursor.
+
+// TICKET_PREFIX — workers post with their TICKET_ID as the author (--as),
+// matching the legacy `grep -oE '^[A-Z]+-[0-9]+'` extraction.
+const TICKET_PREFIX = /^[A-Z]+-[0-9]+/;
+
+// drainComms — promote attention messages and advance the cursor.
+//
+// inputs: { messages:[{type,from,body}], cursor:number }
+// returns: { attentions:[{kind,ticket,body}], newCursor:number }
+export function drainComms({ messages = [], cursor = 0 }) {
+  const attentions = [];
+  for (const msg of messages) {
+    if (msg?.type !== "attention") continue;
+    const from = msg.from ?? "";
+    const match = from.match(TICKET_PREFIX);
+    attentions.push({
+      kind: "comms-attention",
+      ticket: match ? match[0] : from,
+      body: `[${from}] ${msg.body ?? ""}`,
+    });
+  }
+  return { attentions, newCursor: cursor + messages.length };
+}

--- a/plugins/dev/scripts/execution-core/comms-drain.test.mjs
+++ b/plugins/dev/scripts/execution-core/comms-drain.test.mjs
@@ -1,0 +1,68 @@
+// Unit tests for the execution-core Step F comms-drain decision (CTL-533).
+// Run: cd plugins/dev/scripts/execution-core && bun test comms-drain.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { drainComms } from "./comms-drain.mjs";
+
+describe("drainComms", () => {
+  test("promotes type:'attention' messages to attention items", () => {
+    const out = drainComms({
+      cursor: 0,
+      messages: [
+        { type: "attention", from: "CTL-7", body: "blocked on review" },
+      ],
+    });
+    expect(out.attentions).toHaveLength(1);
+    expect(out.attentions[0].kind).toBe("comms-attention");
+    expect(out.attentions[0].ticket).toBe("CTL-7");
+    expect(out.attentions[0].body).toContain("blocked on review");
+    expect(out.attentions[0].body).toContain("CTL-7");
+  });
+
+  test("ignores non-attention message types", () => {
+    const out = drainComms({
+      cursor: 0,
+      messages: [
+        { type: "status", from: "CTL-7", body: "still working" },
+        { type: "info", from: "CTL-8", body: "fyi" },
+      ],
+    });
+    expect(out.attentions).toEqual([]);
+  });
+
+  test("advances the cursor by the number of messages consumed", () => {
+    const out = drainComms({
+      cursor: 5,
+      messages: [
+        { type: "attention", from: "CTL-1", body: "a" },
+        { type: "status", from: "CTL-2", body: "b" },
+        { type: "attention", from: "CTL-3", body: "c" },
+      ],
+    });
+    expect(out.newCursor).toBe(8);
+  });
+
+  test("empty message list → no attentions, cursor unchanged", () => {
+    const out = drainComms({ cursor: 12, messages: [] });
+    expect(out.attentions).toEqual([]);
+    expect(out.newCursor).toBe(12);
+  });
+
+  test("extracts the ticket id from the author name prefix", () => {
+    const out = drainComms({
+      cursor: 0,
+      messages: [
+        { type: "attention", from: "CTL-99-worker", body: "help" },
+      ],
+    });
+    expect(out.attentions[0].ticket).toBe("CTL-99");
+  });
+
+  test("falls back to the raw author when no ticket id prefix is present", () => {
+    const out = drainComms({
+      cursor: 0,
+      messages: [{ type: "attention", from: "operator", body: "manual ping" }],
+    });
+    expect(out.attentions[0].ticket).toBe("operator");
+  });
+});

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -53,3 +53,10 @@ export const RECONCILE_INTERVAL_MS =
 // into one reconcile poll per affected project per burst.
 export const EVENT_DEBOUNCE_MS =
   Number(process.env.EXECUTION_CORE_DEBOUNCE_MS) || 5_000;
+
+// CTL-533: a worker whose signal has not been updated within this window is
+// "stale" — a precondition for the Step G stalled scan to consult git/PR
+// state. A stale signal alone is never stall evidence (CTL-32). Default 15 min,
+// matching the legacy `date -u -v-15M` cutoff in orchestrate/SKILL.md.
+export const STALE_WORKER_CUTOFF_MS =
+  Number(process.env.EXECUTION_CORE_STALE_WORKER_CUTOFF_MS) || 15 * 60_000;

--- a/plugins/dev/scripts/execution-core/deploy-state.mjs
+++ b/plugins/dev/scripts/execution-core/deploy-state.mjs
@@ -1,0 +1,11 @@
+// deploy-state.mjs — execution-core re-export of the canonical deploy
+// state machine (CTL-533).
+//
+// nextDeployState is NOT duplicated here: it lives in
+// orch-monitor/lib/deploy-state-machine.ts and is reused verbatim — the
+// Step E deploy sub-loop in orchestrate/SKILL.md is its bash glue, and that
+// file's own header confirms the .ts function is the authoritative mirror.
+// Bun resolves the .ts import directly, so the execution-core barrel and
+// scan.mjs get a single in-package import site with zero logic duplication.
+
+export { nextDeployState } from "../orch-monitor/lib/deploy-state-machine.ts";

--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -8,6 +8,8 @@
 
 import { startMonitor, stopMonitor } from "./monitor.mjs";
 import { log } from "./config.mjs";
+import { runScan } from "./scan.mjs";
+import { makeScanAdapters } from "./scan-adapters.mjs";
 
 // --- Barrel re-exports (every public symbol of the monitor) -------------
 export * from "./config.mjs";
@@ -38,8 +40,67 @@ export {
   readAllEligibleTickets,
 } from "./scheduler.mjs";
 
+// --- CTL-533: deterministic per-event scan module -----------------------
+export * from "./signal-reader.mjs";
+export * from "./merge-state.mjs";
+export * from "./stalled-detector.mjs";
+export * from "./comms-drain.mjs";
+export * from "./deploy-state.mjs";
+export { runScan } from "./scan.mjs";
+
+// --- CLI arg parsing ----------------------------------------------------
+// parseFlags — minimal `--key value` parser for the scan subcommand.
+function parseFlags(argv) {
+  const flags = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    if (typeof key === "string" && key.startsWith("--")) {
+      flags[key.slice(2)] = argv[i + 1];
+    }
+  }
+  return flags;
+}
+
+// runScanCli — `bun index.mjs scan --orch-dir <dir> --orch-id <id> [...]`.
+// Builds real git/gh/deploy/comms adapters, runs one deterministic scan, and
+// prints the result JSON to stdout. Apply-nothing dry run (CTL-533 Phase 4):
+// the integration ticket wires the patches back to disk.
+function runScanCli(argv) {
+  const flags = parseFlags(argv);
+  const orchDir = flags["orch-dir"];
+  const orchId = flags["orch-id"];
+  if (!orchDir || !orchId) {
+    log.error("scan requires --orch-dir <dir> and --orch-id <id>");
+    process.exit(2);
+  }
+  const adapters = makeScanAdapters({
+    orchId,
+    worktreeBase: flags["worktree-base"] ?? `${orchDir}/../worktrees`,
+    configPath: flags["config"] ?? null,
+    channelFile: flags["channel-file"] ?? null,
+  });
+  const result = runScan({
+    orchDir,
+    orchId,
+    event: null,
+    nowMs: Date.now(),
+    commsCursor: Number(flags["comms-cursor"]) || 0,
+    adapters,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.exit(0);
+}
+
 // --- Standalone entrypoint ----------------------------------------------
 function main() {
+  const argv = process.argv.slice(2);
+  // CTL-533: `scan` subcommand — one-shot deterministic scan dry run.
+  if (argv[0] === "scan") {
+    runScanCli(argv.slice(1));
+    return;
+  }
+
+  // Default: the CTL-535 Todo-state monitor.
   log.info("execution-core Todo-state monitor starting");
   startMonitor();
   const shutdown = (sig) => {

--- a/plugins/dev/scripts/execution-core/merge-state.mjs
+++ b/plugins/dev/scripts/execution-core/merge-state.mjs
@@ -1,0 +1,79 @@
+// merge-state.mjs — execution-core Step C merge-confirmation decision (CTL-533).
+//
+// Pure mirror of the `case "$PR_STATE"` block in orchestrate/SKILL.md
+// (the CTL-31/CTL-80/CTL-133/CTL-211/CTL-243/CTL-252 merge-confirmation
+// fallback scan). All non-determinism — PR state, merge SHA, deploy config —
+// is injected; the function returns a { patch, attention, events } decision
+// and never mutates anything.
+
+import { TERMINAL } from "./signal-reader.mjs";
+
+const NO_OP = Object.freeze({ patch: {}, attention: null, events: [] });
+
+// nextMergeState — decide the Step C transition for one worker.
+//
+// inputs: {
+//   ticket, prState:'MERGED'|'CLOSED'|'OPEN'|'UNKNOWN',
+//   mergeStateStatus, prNumber, mergedAt (PR.mergedAt from GitHub),
+//   mergeCommitSha, signalMergedAt (.pr.mergedAt already on the signal),
+//   skipDeployVerification, currentStatus,
+// }
+// returns: { patch, attention, events }
+export function nextMergeState(inputs) {
+  // Terminal worker states absorb everything (the bash scan `continue`s on
+  // status=failed / status=stalled before touching GitHub).
+  if (TERMINAL.has(inputs.currentStatus)) return NO_OP;
+
+  // Already-reconciled merges are a no-op (the bash scan `continue`s when
+  // .pr.mergedAt is already set).
+  if (inputs.signalMergedAt) return NO_OP;
+
+  switch (inputs.prState) {
+    case "MERGED":
+      return onMerged(inputs);
+    case "CLOSED":
+      return {
+        patch: {},
+        attention: {
+          kind: "pr-closed",
+          ticket: inputs.ticket,
+          message: `PR #${inputs.prNumber} was closed without merging`,
+        },
+        events: [],
+      };
+    // OPEN (and any unknown state): not merged yet — normal. DIRTY/BEHIND/
+    // BLOCKED merge states are handled out-of-band by the incident handlers,
+    // so this step raises nothing for them.
+    default:
+      return NO_OP;
+  }
+}
+
+// onMerged — MERGED → done (skipDeployVerification) or → merged (CTL-211).
+function onMerged(inputs) {
+  const skip = inputs.skipDeployVerification !== false;
+  const status = skip ? "done" : "merged";
+  const phase = skip ? 6 : 5;
+
+  const patch = {
+    status,
+    phase,
+    pr: {
+      ciStatus: "merged",
+      mergedAt: inputs.mergedAt ?? null,
+    },
+  };
+  if (inputs.mergeCommitSha) patch.pr.mergeCommitSha = inputs.mergeCommitSha;
+
+  return {
+    patch,
+    attention: null,
+    events: [
+      {
+        event: "worker-pr-merged",
+        worker: inputs.ticket,
+        detail: { pr: inputs.prNumber, mergedAt: inputs.mergedAt ?? null },
+      },
+    ],
+  };
+}

--- a/plugins/dev/scripts/execution-core/merge-state.test.mjs
+++ b/plugins/dev/scripts/execution-core/merge-state.test.mjs
@@ -1,0 +1,118 @@
+// Unit tests for the execution-core Step C merge-state decision (CTL-533).
+// Run: cd plugins/dev/scripts/execution-core && bun test merge-state.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { nextMergeState } from "./merge-state.mjs";
+
+// makeInputs — a deterministic fixture factory mirroring deploy-state-machine.test.ts.
+function makeInputs(over = {}) {
+  return {
+    ticket: "CTL-1",
+    prState: "OPEN",
+    mergeStateStatus: "CLEAN",
+    prNumber: 42,
+    mergedAt: null, // PR.mergedAt from GitHub
+    mergeCommitSha: "abc123",
+    signalMergedAt: null, // .pr.mergedAt already recorded on the signal
+    skipDeployVerification: true,
+    currentStatus: "implementing",
+    ...over,
+  };
+}
+
+describe("nextMergeState", () => {
+  test("MERGED + skipDeployVerification → status:'done', phase:6", () => {
+    const out = nextMergeState(
+      makeInputs({
+        prState: "MERGED",
+        mergedAt: "2026-05-21T03:00:00Z",
+        skipDeployVerification: true,
+      }),
+    );
+    expect(out.patch.status).toBe("done");
+    expect(out.patch.phase).toBe(6);
+  });
+
+  test("MERGED + !skipDeployVerification → status:'merged', phase:5 (CTL-211)", () => {
+    const out = nextMergeState(
+      makeInputs({
+        prState: "MERGED",
+        mergedAt: "2026-05-21T03:00:00Z",
+        skipDeployVerification: false,
+      }),
+    );
+    expect(out.patch.status).toBe("merged");
+    expect(out.patch.phase).toBe(5);
+  });
+
+  test("MERGED emits a worker-pr-merged event", () => {
+    const out = nextMergeState(
+      makeInputs({ prState: "MERGED", mergedAt: "2026-05-21T03:00:00Z" }),
+    );
+    expect(out.events).toHaveLength(1);
+    expect(out.events[0].event).toBe("worker-pr-merged");
+    expect(out.events[0].detail.pr).toBe(42);
+    expect(out.events[0].detail.mergedAt).toBe("2026-05-21T03:00:00Z");
+  });
+
+  test("MERGED records pr.mergedAt + mergeCommitSha on the patch", () => {
+    const out = nextMergeState(
+      makeInputs({
+        prState: "MERGED",
+        mergedAt: "2026-05-21T03:00:00Z",
+        mergeCommitSha: "def456",
+      }),
+    );
+    expect(out.patch.pr.mergedAt).toBe("2026-05-21T03:00:00Z");
+    expect(out.patch.pr.mergeCommitSha).toBe("def456");
+  });
+
+  test("MERGED is a no-op when mergedAt already recorded on the signal", () => {
+    const out = nextMergeState(
+      makeInputs({
+        prState: "MERGED",
+        mergedAt: "2026-05-21T03:00:00Z",
+        signalMergedAt: "2026-05-21T03:00:00Z",
+      }),
+    );
+    expect(out.patch).toEqual({});
+    expect(out.attention).toBeNull();
+    expect(out.events).toEqual([]);
+  });
+
+  test("CLOSED → raises a pr-closed attention", () => {
+    const out = nextMergeState(makeInputs({ prState: "CLOSED" }));
+    expect(out.attention).not.toBeNull();
+    expect(out.attention.kind).toBe("pr-closed");
+    expect(out.attention.ticket).toBe("CTL-1");
+    expect(out.patch).toEqual({});
+  });
+
+  test("OPEN → no patch, no attention", () => {
+    const out = nextMergeState(makeInputs({ prState: "OPEN" }));
+    expect(out.patch).toEqual({});
+    expect(out.attention).toBeNull();
+    expect(out.events).toEqual([]);
+  });
+
+  test("OPEN + DIRTY/BEHIND/BLOCKED → no patch (handlers act out-of-band)", () => {
+    for (const ms of ["DIRTY", "BEHIND", "BLOCKED"]) {
+      const out = nextMergeState(
+        makeInputs({ prState: "OPEN", mergeStateStatus: ms }),
+      );
+      expect(out.patch).toEqual({});
+      expect(out.attention).toBeNull();
+    }
+  });
+
+  test("status failed/stalled → absorbed as no-op", () => {
+    for (const st of ["failed", "stalled"]) {
+      const out = nextMergeState(
+        makeInputs({ currentStatus: st, prState: "MERGED", mergedAt: "x" }),
+      );
+      expect(out.patch).toEqual({});
+      expect(out.attention).toBeNull();
+      expect(out.events).toEqual([]);
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/scan-adapters.mjs
+++ b/plugins/dev/scripts/execution-core/scan-adapters.mjs
@@ -1,0 +1,188 @@
+// scan-adapters.mjs — real git/gh/deploy/comms adapters for the scan CLI
+// (CTL-533 Phase 4).
+//
+// runScan in scan.mjs is pure given injected adapters. For the `scan` CLI
+// dry-run mode (and any future real integration) these adapters back those
+// injection points with actual git/gh/filesystem calls. Construction is
+// isolated here so index.mjs stays a thin entrypoint.
+//
+// All adapter methods fail soft — a git/gh error yields a null/empty result
+// rather than throwing, mirroring the `|| echo ""` discipline of the bash
+// scan body. The CLI mode is apply-nothing, so a soft failure just produces
+// a smaller scan result.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// run — a fail-soft synchronous subprocess. Returns trimmed stdout, or "" on
+// any non-zero exit / spawn error.
+function run(cmd, args, opts = {}) {
+  try {
+    const res = spawnSync(cmd, args, { encoding: "utf8", ...opts });
+    if (res.status !== 0 || res.error) return "";
+    return (res.stdout ?? "").trim();
+  } catch {
+    return "";
+  }
+}
+
+// repoSlug — parse "<owner>/<repo>" from a git remote URL.
+function repoSlug(worktree) {
+  const url = run("git", ["-C", worktree, "remote", "get-url", "origin"]);
+  const m = url.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
+  return m ? m[1] : null;
+}
+
+// makeScanAdapters — build the adapter bundle for runScan.
+//
+// `worktreeFor(ticket)` resolves a worker's worktree path. The orchestrator
+// convention is `${worktreeBase}/${orchId}-${ticket}`; callers may override.
+export function makeScanAdapters({
+  orchId,
+  worktreeBase,
+  configPath,
+  channelFile,
+}) {
+  const worktreeFor = (ticket) => join(worktreeBase, `${orchId}-${ticket}`);
+
+  const config = loadConfig(configPath);
+
+  const git = {
+    branch: (ticket) =>
+      run("git", ["-C", worktreeFor(ticket), "branch", "--show-current"]),
+    commitCount: (ticket) => {
+      const n = run("git", [
+        "-C",
+        worktreeFor(ticket),
+        "rev-list",
+        "--count",
+        "HEAD",
+      ]);
+      return Number(n) || 0;
+    },
+    remoteBranchExists: (ticket) => {
+      const wt = worktreeFor(ticket);
+      const branch = run("git", ["-C", wt, "branch", "--show-current"]);
+      if (!branch) return false;
+      const out = run("git", [
+        "-C",
+        wt,
+        "ls-remote",
+        "--heads",
+        "origin",
+        branch,
+      ]);
+      return out.length > 0;
+    },
+  };
+
+  const gh = {
+    prForBranch: (ticket, branch) => {
+      const slug = repoSlug(worktreeFor(ticket));
+      if (!slug || !branch) return null;
+      const json = run("gh", [
+        "-R",
+        slug,
+        "pr",
+        "list",
+        "--head",
+        branch,
+        "--state",
+        "all",
+        "--json",
+        "number,url,state",
+        "--limit",
+        "1",
+      ]);
+      const arr = parseJson(json, []);
+      if (!Array.isArray(arr) || arr.length === 0) return null;
+      return { ...arr[0], repo: slug };
+    },
+    prView: (ticket, pr) => {
+      const slug = pr?.repo ?? repoSlug(worktreeFor(ticket));
+      if (!slug || !pr?.number) {
+        return {
+          state: "UNKNOWN",
+          mergeStateStatus: "UNKNOWN",
+          mergedAt: null,
+          mergeCommitSha: null,
+        };
+      }
+      const json = run("gh", [
+        "-R",
+        slug,
+        "pr",
+        "view",
+        String(pr.number),
+        "--json",
+        "state,mergeStateStatus,mergedAt,mergeCommit",
+      ]);
+      const v = parseJson(json, {});
+      return {
+        state: v.state ?? "UNKNOWN",
+        mergeStateStatus: v.mergeStateStatus ?? "UNKNOWN",
+        mergedAt: v.mergedAt ?? null,
+        mergeCommitSha: v.mergeCommit?.oid ?? null,
+      };
+    },
+  };
+
+  const deploy = {
+    skipDeployVerification: (repo) =>
+      deployField(config, repo, "skipDeployVerification", true) !== false,
+    productionEnvironment: (repo) =>
+      deployField(config, repo, "productionEnvironment", "production"),
+    timeoutSec: (repo) => deployField(config, repo, "timeoutSec", 1800),
+  };
+
+  const comms = {
+    readSince: (cursor) => readChannelSince(channelFile, cursor),
+  };
+
+  return { git, gh, deploy, comms };
+}
+
+// loadConfig — read .catalyst/config.json; {} on any failure.
+function loadConfig(configPath) {
+  if (!configPath) return {};
+  try {
+    return JSON.parse(readFileSync(configPath, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+// deployField — read catalyst.deploy[<repo>].<field> with a default.
+function deployField(config, repo, field, fallback) {
+  const val = config?.catalyst?.deploy?.[repo]?.[field];
+  return val === undefined ? fallback : val;
+}
+
+// parseJson — JSON.parse with a fallback on any error.
+function parseJson(text, fallback) {
+  if (!text) return fallback;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+// readChannelSince — read comms-channel JSONL messages after `cursor` lines.
+function readChannelSince(channelFile, cursor) {
+  const file =
+    channelFile ?? join(homedir(), "catalyst", "comms", "channels");
+  let text;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  return lines
+    .slice(cursor)
+    .map((l) => parseJson(l, null))
+    .filter((m) => m !== null);
+}

--- a/plugins/dev/scripts/execution-core/scan-adapters.mjs
+++ b/plugins/dev/scripts/execution-core/scan-adapters.mjs
@@ -16,6 +16,8 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
+import { log } from "./config.mjs";
+
 // run — a fail-soft synchronous subprocess. Returns trimmed stdout, or "" on
 // any non-zero exit / spawn error.
 function run(cmd, args, opts = {}) {
@@ -138,18 +140,43 @@ export function makeScanAdapters({
   };
 
   const comms = {
-    readSince: (cursor) => readChannelSince(channelFile, cursor),
+    readSince: (cursor) => readChannelSince(channelFile, orchId, cursor),
   };
 
   return { git, gh, deploy, comms };
 }
 
-// loadConfig — read .catalyst/config.json; {} on any failure.
+// loadConfig — read .catalyst/config.json. With no --config the absent file is
+// silent; an explicitly-named config that is missing or unparseable is logged
+// loudly — falling back to {} silently flips deployField defaults
+// (skipDeployVerification → true) for every worker, so the failure must be
+// visible rather than swallowed.
 function loadConfig(configPath) {
   if (!configPath) return {};
+  let text;
   try {
-    return JSON.parse(readFileSync(configPath, "utf8"));
-  } catch {
+    text = readFileSync(configPath, "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT") {
+      log.warn(
+        { configPath },
+        "scan: --config file not found; falling back to deploy defaults",
+      );
+    } else {
+      log.error(
+        { configPath, code: err?.code, err: err?.message },
+        "scan: --config unreadable; falling back to deploy defaults",
+      );
+    }
+    return {};
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    log.error(
+      { configPath, err: err?.message },
+      "scan: --config is not valid JSON; falling back to deploy defaults",
+    );
     return {};
   }
 }
@@ -171,13 +198,26 @@ function parseJson(text, fallback) {
 }
 
 // readChannelSince — read comms-channel JSONL messages after `cursor` lines.
-function readChannelSince(channelFile, cursor) {
+// The default path follows the orchestrator channel convention,
+// channels/orch-<orchId>.jsonl — `channels/` itself is a directory, so reading
+// it directly would EISDIR and silently drop every comms-attention.
+function readChannelSince(channelFile, orchId, cursor) {
   const file =
-    channelFile ?? join(homedir(), "catalyst", "comms", "channels");
+    channelFile ??
+    join(homedir(), "catalyst", "comms", "channels", `orch-${orchId}.jsonl`);
   let text;
   try {
     text = readFileSync(file, "utf8");
-  } catch {
+  } catch (err) {
+    // A not-yet-created channel file is normal (no worker has posted yet).
+    // Any other error — EISDIR, EACCES — is a real misconfiguration that
+    // would otherwise silently disable Step F; surface it.
+    if (err?.code !== "ENOENT") {
+      log.warn(
+        { file, code: err?.code, err: err?.message },
+        "scan: comms channel unreadable; skipping comms-drain",
+      );
+    }
     return [];
   }
   const lines = text.split("\n").filter((l) => l.trim().length > 0);

--- a/plugins/dev/scripts/execution-core/scan.mjs
+++ b/plugins/dev/scripts/execution-core/scan.mjs
@@ -1,0 +1,211 @@
+// scan.mjs — execution-core deterministic per-event scan (CTL-533).
+//
+// The Phase-4 orchestrator monitor scan body, extracted from
+// orchestrate/SKILL.md as an LLM-free function. On each event it walks
+// Steps A/C/E/F/G over the unified worker-signal set and returns an
+// aggregate of patches + attentions + events + incident-handler invocations
+// for a thin caller to apply. All non-determinism is injected via `adapters`,
+// so the whole scan is testable without a real repo or network.
+//
+//   Step A — gather ground truth (git branch/commits, PR) per worker
+//   Step C — merge confirmation        → nextMergeState
+//   Step E — deploy state machine      → nextDeployState
+//   Step F — comms-channel drain       → drainComms
+//   Step G — stalled detection         → detectStalled
+//
+// Steps B/D/K (dashboard render, broker refresh, deregister) and Step 0
+// (healthcheck) are intentionally out of scope — they carry non-deterministic
+// side effects or are already standalone scripts.
+
+import { readWorkerSignals } from "./signal-reader.mjs";
+import { nextMergeState } from "./merge-state.mjs";
+import { nextDeployState } from "./deploy-state.mjs";
+import { drainComms } from "./comms-drain.mjs";
+import { detectStalled } from "./stalled-detector.mjs";
+
+// Worker statuses for which the Step E deploy sub-loop runs.
+const DEPLOY_RELEVANT = new Set(["merged", "deploying", "deploy-failed"]);
+
+// runScan — the deterministic per-event scan entry point.
+//
+// inputs: {
+//   orchDir, orchId, event (unified-log event | null), nowMs,
+//   commsCursor, adapters:{ git, gh, deploy, comms },
+// }
+// returns: {
+//   patches:[{signalPath, patch}], attentions:[], events:[],
+//   handlerInvocations:[{name, args}], newCommsCursor,
+// }
+export function runScan({
+  orchDir,
+  orchId,
+  event,
+  nowMs,
+  commsCursor = 0,
+  adapters,
+}) {
+  const signals = readWorkerSignals(orchDir);
+  const patches = [];
+  const attentions = [];
+  const events = [];
+
+  for (const sig of signals) {
+    const derived = gatherWorkerState(sig, adapters); // Step A
+
+    // Step C — merge confirmation.
+    collect(
+      { patches, attentions, events },
+      sig,
+      nextMergeState(mergeInputs(sig, derived, adapters)),
+    );
+
+    // Step E — deploy state machine (only deploy-relevant workers).
+    if (DEPLOY_RELEVANT.has(sig.status)) {
+      collect(
+        { patches, attentions, events },
+        sig,
+        nextDeployState(deployInputs(sig, derived, adapters, nowMs, event)),
+      );
+    }
+
+    // Step G — stalled detection.
+    collect(
+      { patches, attentions, events },
+      sig,
+      detectStalled(stalledInputs(sig, derived, nowMs)),
+    );
+  }
+
+  // Step F — comms-channel drain (orchestrator-scoped, runs once).
+  const messages = adapters.comms.readSince(commsCursor);
+  const { attentions: commsAtt, newCursor } = drainComms({
+    messages,
+    cursor: commsCursor,
+  });
+  attentions.push(...commsAtt);
+
+  return {
+    patches,
+    attentions,
+    events,
+    handlerInvocations: incidentHandlers(orchDir, orchId),
+    newCommsCursor: newCursor,
+  };
+}
+
+// gatherWorkerState — Step A: re-derive ground truth (git branch, commit
+// count, remote-branch existence, PR + merge view) through injected adapters.
+// The signal file is advisory only; GitHub/git are authoritative.
+function gatherWorkerState(sig, adapters) {
+  const ticket = sig.ticket;
+  const branch = adapters.git.branch(ticket) || "";
+  const commitCount = branch ? adapters.git.commitCount(ticket) : 0;
+  const remoteBranchExists = branch
+    ? adapters.git.remoteBranchExists(ticket)
+    : false;
+
+  // Discover the PR: prefer the one recorded on the signal, else by branch.
+  const signalPr = sig.pr && sig.pr.number ? sig.pr : null;
+  const discovered = branch ? adapters.gh.prForBranch(ticket, branch) : null;
+  const pr = signalPr ?? discovered ?? null;
+
+  // Authoritative merge view, only when a PR is known.
+  const prView = pr ? adapters.gh.prView(ticket, pr) : null;
+
+  return { branch, commitCount, remoteBranchExists, pr, prView };
+}
+
+// mergeInputs — shape a worker's state for nextMergeState (Step C).
+function mergeInputs(sig, derived, adapters) {
+  const view = derived.prView;
+  const repo = repoFor(sig, derived);
+  return {
+    ticket: sig.ticket,
+    prState: view?.state ?? "NONE",
+    mergeStateStatus: view?.mergeStateStatus ?? "UNKNOWN",
+    prNumber: derived.pr?.number ?? null,
+    mergedAt: view?.mergedAt ?? null,
+    mergeCommitSha: view?.mergeCommitSha ?? null,
+    signalMergedAt: sig.pr?.mergedAt ?? null,
+    skipDeployVerification: adapters.deploy.skipDeployVerification(repo),
+    currentStatus: sig.status,
+  };
+}
+
+// deployInputs — shape a worker's state for nextDeployState (Step E).
+function deployInputs(sig, derived, adapters, nowMs, event) {
+  const deploy = sig.raw?.deploy ?? {};
+  const repo = repoFor(sig, derived);
+  return {
+    nowMs,
+    currentStatus: sig.status,
+    mergeCommitSha: sig.pr?.mergeCommitSha ?? derived.pr?.mergeCommitSha ?? null,
+    productionEnvironment: adapters.deploy.productionEnvironment(repo),
+    timeoutSec: adapters.deploy.timeoutSec(repo),
+    skipDeployVerification: adapters.deploy.skipDeployVerification(repo),
+    deployStartedAtMs: deploy.startedAt ? Date.parse(deploy.startedAt) : null,
+    failedAttempts: deploy.failedAttempts ?? 0,
+    maxAttempts: 3,
+    event: toDeployEvent(event),
+  };
+}
+
+// stalledInputs — shape a worker's state for detectStalled (Step G).
+function stalledInputs(sig, derived, nowMs) {
+  return {
+    ticket: sig.ticket,
+    nowMs,
+    updatedAtMs: sig.updatedAt ? Date.parse(sig.updatedAt) : null,
+    currentStatus: sig.status,
+    prState: derived.prView?.state ?? derived.pr?.state ?? "NONE",
+    commitCount: derived.commitCount,
+    remoteBranchExists: derived.remoteBranchExists,
+    branch: derived.branch,
+  };
+}
+
+// toDeployEvent — narrow a unified-log event to the DeployEvent shape
+// nextDeployState expects; null for unrelated events or polling ticks.
+function toDeployEvent(event) {
+  if (!event || typeof event.type !== "string") return null;
+  if (!event.type.startsWith("github.deployment") &&
+      event.type !== "github.pr.merged") {
+    return null;
+  }
+  return {
+    type: event.type,
+    environment: event.environment ?? null,
+    state: event.state ?? null,
+    sha: event.sha ?? "",
+  };
+}
+
+// repoFor — the GitHub "<owner>/<repo>" slug for a worker, used to look up
+// per-repo deploy config through the deploy adapter. Null when unknown.
+function repoFor(sig, derived) {
+  return derived.pr?.repo ?? sig.raw?.repo ?? null;
+}
+
+// incidentHandlers — the bash scan runs all three unconditionally after the
+// loops. We return them as descriptors for the thin caller to exec.
+function incidentHandlers(orchDir, orchId) {
+  const args = ["--orch-dir", orchDir, "--orch-id", orchId];
+  return [
+    { name: "orchestrate-revive", args },
+    { name: "orchestrate-auto-fixup", args },
+    { name: "orchestrate-auto-rebase", args },
+  ];
+}
+
+// collect — the single place patches/attentions/events are appended. Patches
+// are keyed by signalPath so the caller knows which file to merge into.
+function collect(acc, sig, result) {
+  if (!result) return;
+  if (result.patch && Object.keys(result.patch).length > 0) {
+    acc.patches.push({ signalPath: sig.signalPath, patch: result.patch });
+  }
+  if (result.attention) acc.attentions.push(result.attention);
+  if (Array.isArray(result.events) && result.events.length > 0) {
+    acc.events.push(...result.events);
+  }
+}

--- a/plugins/dev/scripts/execution-core/scan.mjs
+++ b/plugins/dev/scripts/execution-core/scan.mjs
@@ -64,7 +64,10 @@ export function runScan({
       collect(
         { patches, attentions, events },
         sig,
-        nextDeployState(deployInputs(sig, derived, adapters, nowMs, event)),
+        normalizeDeployResult(
+          nextDeployState(deployInputs(sig, derived, adapters, nowMs, event)),
+          sig,
+        ),
       );
     }
 
@@ -161,6 +164,23 @@ function stalledInputs(sig, derived, nowMs) {
     commitCount: derived.commitCount,
     remoteBranchExists: derived.remoteBranchExists,
     branch: derived.branch,
+  };
+}
+
+// normalizeDeployResult — nextDeployState (the canonical orch-monitor .ts state
+// machine) returns `attention` as a bare string, but every other Step result
+// and every attentions[] consumer uses the structured { kind, ticket, message }
+// shape. Wrap the deploy result's attention so collect() emits a uniform
+// attention item carrying a ticket the orchestrator can route on.
+function normalizeDeployResult(result, sig) {
+  if (!result || typeof result.attention !== "string") return result;
+  return {
+    ...result,
+    attention: {
+      kind: "deploy",
+      ticket: sig.ticket,
+      message: result.attention,
+    },
   };
 }
 

--- a/plugins/dev/scripts/execution-core/scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/scan.test.mjs
@@ -310,3 +310,15 @@ describe("runScan", () => {
     expect(out.newCommsCursor).toBe(6);
   });
 });
+
+describe("index.mjs barrel", () => {
+  test("re-exports runScan, readWorkerSignals and the decision functions", async () => {
+    const barrel = await import("./index.mjs");
+    expect(typeof barrel.runScan).toBe("function");
+    expect(typeof barrel.readWorkerSignals).toBe("function");
+    expect(typeof barrel.nextMergeState).toBe("function");
+    expect(typeof barrel.detectStalled).toBe("function");
+    expect(typeof barrel.drainComms).toBe("function");
+    expect(typeof barrel.nextDeployState).toBe("function");
+  });
+});

--- a/plugins/dev/scripts/execution-core/scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/scan.test.mjs
@@ -1,0 +1,312 @@
+// Integration tests for the execution-core deterministic scan (CTL-533).
+// Run: cd plugins/dev/scripts/execution-core && bun test scan.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runScan } from "./scan.mjs";
+
+let orchDir;
+const NOW = Date.parse("2026-05-21T12:00:00Z");
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "exec-core-scan-"));
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// --- fixture helpers ------------------------------------------------------
+
+function workersDir() {
+  const dir = join(orchDir, "workers");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeFlat(ticket, body) {
+  writeFileSync(
+    join(workersDir(), `${ticket}.json`),
+    JSON.stringify({ ticket, ...body }),
+  );
+}
+
+function writeNested(ticket, phase, body) {
+  const dir = join(workersDir(), ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, ...body }),
+  );
+}
+
+// stubAdapters — deterministic fixtures for every injected I/O dependency.
+// `over` deep-merges per sub-adapter so a test overrides only what it cares
+// about.
+function stubAdapters(over = {}) {
+  return {
+    git: {
+      branch: () => "feat/branch",
+      commitCount: () => 0,
+      remoteBranchExists: () => false,
+      ...over.git,
+    },
+    gh: {
+      // prForBranch → { number, url, state } | null
+      prForBranch: () => null,
+      // prView → { state, mergeStateStatus, mergedAt, mergeCommitSha }
+      prView: () => ({
+        state: "OPEN",
+        mergeStateStatus: "CLEAN",
+        mergedAt: null,
+        mergeCommitSha: null,
+      }),
+      ...over.gh,
+    },
+    deploy: {
+      // skipDeployVerification per repo
+      skipDeployVerification: () => true,
+      productionEnvironment: () => "production",
+      timeoutSec: () => 1800,
+      ...over.deploy,
+    },
+    comms: {
+      readSince: () => [],
+      ...over.comms,
+    },
+  };
+}
+
+function baseInputs(over = {}) {
+  const { adapters: adapterOver, ...rest } = over;
+  return {
+    orchDir,
+    orchId: "test-orch",
+    event: null,
+    nowMs: NOW,
+    commsCursor: 0,
+    ...rest,
+    adapters: stubAdapters(adapterOver),
+  };
+}
+
+// --- tests ----------------------------------------------------------------
+
+describe("runScan", () => {
+  test("Step A: gathers branch + commit count + PR per worker via adapters", () => {
+    writeFlat("CTL-1", { phase: 3, status: "implementing", pid: 1 });
+    let branchCalls = 0;
+    const out = runScan(
+      baseInputs({
+        adapters: { git: { branch: () => (branchCalls++, "feat/ctl-1") } },
+      }),
+    );
+    expect(branchCalls).toBe(1);
+    expect(out).toBeDefined();
+  });
+
+  test("Step C: a MERGED PR yields a patch + a worker-pr-merged event", () => {
+    writeFlat("CTL-1", {
+      phase: 4,
+      status: "merging",
+      pid: 1,
+      pr: { number: 7, url: "https://github.com/o/r/pull/7" },
+    });
+    const out = runScan(
+      baseInputs({
+        adapters: {
+          gh: {
+            prForBranch: () => ({
+              number: 7,
+              url: "https://github.com/o/r/pull/7",
+              state: "MERGED",
+            }),
+            prView: () => ({
+              state: "MERGED",
+              mergeStateStatus: "CLEAN",
+              mergedAt: "2026-05-21T11:00:00Z",
+              mergeCommitSha: "deadbeef",
+            }),
+          },
+        },
+      }),
+    );
+    expect(out.patches).toHaveLength(1);
+    expect(out.patches[0].patch.status).toBe("done");
+    expect(out.events.some((e) => e.event === "worker-pr-merged")).toBe(true);
+  });
+
+  test("Step E: a 'merged'-status worker advances via nextDeployState", () => {
+    writeFlat("CTL-1", {
+      phase: 5,
+      status: "merged",
+      pid: 1,
+      pr: {
+        number: 7,
+        url: "https://github.com/o/r/pull/7",
+        mergeCommitSha: "abc",
+      },
+      // startedAt within the 1800s deploy timeout (now is 12:00:00Z).
+      deploy: { startedAt: "2026-05-21T11:50:00Z" },
+    });
+    const out = runScan(
+      baseInputs({
+        event: {
+          type: "github.deployment.created",
+          environment: "production",
+          state: null,
+          sha: "abc",
+        },
+      }),
+    );
+    const deployPatch = out.patches.find(
+      (p) => p.patch.status === "deploying",
+    );
+    expect(deployPatch).toBeDefined();
+  });
+
+  test("Step E: skips workers whose status is not merged/deploying/deploy-failed", () => {
+    writeFlat("CTL-1", { phase: 3, status: "implementing", pid: 1 });
+    const out = runScan(
+      baseInputs({
+        event: {
+          type: "github.deployment.created",
+          environment: "production",
+          state: null,
+          sha: "abc",
+        },
+      }),
+    );
+    expect(out.patches.some((p) => p.patch.status === "deploying")).toBe(false);
+  });
+
+  test("Step F: attention comms messages surface in result.attentions", () => {
+    writeFlat("CTL-1", { phase: 3, status: "implementing", pid: 1 });
+    const out = runScan(
+      baseInputs({
+        adapters: {
+          comms: {
+            readSince: () => [
+              { type: "attention", from: "CTL-9", body: "blocked" },
+            ],
+          },
+        },
+      }),
+    );
+    expect(out.attentions.some((a) => a.kind === "comms-attention")).toBe(true);
+  });
+
+  test("Step G: a stale no-PR worker surfaces a stalled attention", () => {
+    writeFlat("CTL-1", {
+      phase: 3,
+      status: "implementing",
+      pid: 1,
+      updatedAt: "2026-05-21T10:00:00Z", // 2h stale
+    });
+    const out = runScan(baseInputs());
+    expect(out.attentions.some((a) => a.kind === "stalled")).toBe(true);
+  });
+
+  test("always returns the 3 incident-handler invocation descriptors with --orch-dir/--orch-id", () => {
+    writeFlat("CTL-1", { phase: 3, status: "implementing", pid: 1 });
+    const out = runScan(baseInputs());
+    expect(out.handlerInvocations).toHaveLength(3);
+    const names = out.handlerInvocations.map((h) => h.name);
+    expect(names).toEqual([
+      "orchestrate-revive",
+      "orchestrate-auto-fixup",
+      "orchestrate-auto-rebase",
+    ]);
+    for (const h of out.handlerInvocations) {
+      expect(h.args).toContain("--orch-dir");
+      expect(h.args).toContain(orchDir);
+      expect(h.args).toContain("--orch-id");
+      expect(h.args).toContain("test-orch");
+    }
+  });
+
+  test("patches are keyed by signalPath so the caller knows which file to merge", () => {
+    writeFlat("CTL-1", {
+      phase: 4,
+      status: "merging",
+      pid: 1,
+      pr: { number: 7, url: "https://github.com/o/r/pull/7" },
+    });
+    const out = runScan(
+      baseInputs({
+        adapters: {
+          gh: {
+            prForBranch: () => ({
+              number: 7,
+              url: "https://github.com/o/r/pull/7",
+              state: "MERGED",
+            }),
+            prView: () => ({
+              state: "MERGED",
+              mergeStateStatus: "CLEAN",
+              mergedAt: "2026-05-21T11:00:00Z",
+              mergeCommitSha: "deadbeef",
+            }),
+          },
+        },
+      }),
+    );
+    expect(out.patches[0].signalPath).toContain("CTL-1.json");
+  });
+
+  test("an empty workers/ dir → empty patches/attentions/events, handlers still listed", () => {
+    workersDir(); // create empty workers/
+    const out = runScan(baseInputs());
+    expect(out.patches).toEqual([]);
+    expect(out.events).toEqual([]);
+    expect(out.attentions).toEqual([]);
+    expect(out.handlerInvocations).toHaveLength(3);
+  });
+
+  test("no workers/ dir at all → empty result, handlers still listed", () => {
+    const out = runScan(baseInputs());
+    expect(out.patches).toEqual([]);
+    expect(out.handlerInvocations).toHaveLength(3);
+  });
+
+  test("reads BOTH flat and nested signals in one scan (CTL-505 regression guard)", () => {
+    writeFlat("CTL-1", {
+      phase: 3,
+      status: "implementing",
+      pid: 1,
+      updatedAt: "2026-05-21T10:00:00Z",
+    });
+    writeNested("CTL-2", "implement", {
+      status: "running",
+      bg_job_id: "x1",
+      updatedAt: "2026-05-21T10:00:00Z",
+    });
+    const out = runScan(baseInputs());
+    // Both stale, no PR → each surfaces a stalled attention.
+    const stalledTickets = out.attentions
+      .filter((a) => a.kind === "stalled")
+      .map((a) => a.ticket)
+      .sort();
+    expect(stalledTickets).toEqual(["CTL-1", "CTL-2"]);
+  });
+
+  test("advances the comms cursor by the number of messages drained", () => {
+    writeFlat("CTL-1", { phase: 3, status: "implementing", pid: 1 });
+    const out = runScan(
+      baseInputs({
+        commsCursor: 4,
+        adapters: {
+          comms: {
+            readSince: () => [
+              { type: "attention", from: "CTL-1", body: "a" },
+              { type: "status", from: "CTL-1", body: "b" },
+            ],
+          },
+        },
+      }),
+    );
+    expect(out.newCommsCursor).toBe(6);
+  });
+});

--- a/plugins/dev/scripts/execution-core/signal-reader.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.mjs
@@ -1,0 +1,123 @@
+// signal-reader.mjs — execution-core unified worker-signal reader (CTL-533).
+//
+// Resolves BOTH orchestrator signal layouts under ${ORCH_DIR}/workers/ —
+// the flat legacy oneshot signal (workers/<T>.json) and the nested
+// phase-agent signal (workers/<T>/phase-<p>.json) — into one canonical
+// WorkerSignal shape. Subsumes CTL-505: a single reader, so the flat-only
+// globs in orchestrate/SKILL.md and orchestrate-dispatch-next can never
+// again diverge from orchestrate-healthcheck Pass 2.
+//
+// Pure given a filesystem directory: no clock, no network.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "./config.mjs";
+
+// Files inside workers/<T>/ that are phase OUTPUTS, not signals.
+const ARTIFACT_NAMES = new Set([
+  "triage.json",
+  "verify.json",
+  "review.json",
+  "phase-monitor-deploy.json",
+]);
+
+// Terminal worker statuses — exported so decision modules share one set.
+const TERMINAL = new Set(["done", "failed", "stalled", "turn-cap-exhausted"]);
+
+// readWorkerSignals — glob both layouts under ${orchDir}/workers/ and return
+// a canonical WorkerSignal per worker:
+//   { ticket, layout:'flat'|'nested', signalPath, phase, status,
+//     liveness:{kind:'pid'|'bg', value}, updatedAt, pr, raw }
+export function readWorkerSignals(orchDir) {
+  const workersDir = join(orchDir, "workers");
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(workersDir, { withFileTypes: true });
+  } catch {
+    return out; // no workers/ dir yet → []
+  }
+
+  for (const e of entries) {
+    if (
+      e.isFile() &&
+      e.name.endsWith(".json") &&
+      !e.name.endsWith(".json.projected")
+    ) {
+      const sig = parseSignal(join(workersDir, e.name), "flat");
+      if (sig) out.push(sig);
+    } else if (e.isDirectory() && e.name !== "output") {
+      const nested = readNestedDir(join(workersDir, e.name));
+      if (nested) out.push(nested);
+    }
+  }
+  return out;
+}
+
+// isPhaseSignalFile — a nested phase signal is phase-<name>.json and is NOT a
+// phase-output artifact (those are listed in ARTIFACT_NAMES).
+function isPhaseSignalFile(name) {
+  if (!name.endsWith(".json")) return false;
+  if (ARTIFACT_NAMES.has(name)) return false;
+  return name.startsWith("phase-");
+}
+
+// readNestedDir — collect workers/<T>/phase-*.json, drop artifacts, and pick
+// the active phase: the latest updatedAt, preferring a non-terminal status so
+// a freshly-written terminal signal never shadows an in-flight phase.
+function readNestedDir(dir) {
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return null;
+  }
+
+  const candidates = [];
+  for (const name of names) {
+    if (!isPhaseSignalFile(name)) continue;
+    const sig = parseSignal(join(dir, name), "nested");
+    if (sig) candidates.push(sig);
+  }
+  if (candidates.length === 0) return null;
+
+  return candidates.sort(byActivePhase)[0];
+}
+
+// byActivePhase — rank nested phase signals so the active one sorts first:
+// non-terminal status beats terminal, then most-recent updatedAt wins.
+function byActivePhase(a, b) {
+  const aTerminal = TERMINAL.has(a.status);
+  const bTerminal = TERMINAL.has(b.status);
+  if (aTerminal !== bTerminal) return aTerminal ? 1 : -1;
+  return String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? ""));
+}
+
+// parseSignal — the single JSON-parse site. Reads a signal file and normalizes
+// it onto the canonical shape. A malformed file is logged and skipped (null).
+function parseSignal(path, layout) {
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    log.warn({ path, err: err.message }, "skipping malformed signal");
+    return null;
+  }
+  return {
+    ticket: raw.ticket ?? null,
+    layout,
+    signalPath: path,
+    // phase: number (flat) or string (nested) — kept as-is, divergence is real.
+    phase: raw.phase ?? null,
+    status: raw.status ?? "",
+    liveness:
+      layout === "flat"
+        ? { kind: "pid", value: raw.pid ?? null }
+        : { kind: "bg", value: raw.bg_job_id ?? null },
+    updatedAt: raw.updatedAt ?? null,
+    pr: raw.pr ?? null,
+    raw,
+  };
+}
+
+export { TERMINAL };

--- a/plugins/dev/scripts/execution-core/signal-reader.test.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.test.mjs
@@ -1,0 +1,200 @@
+// Unit tests for the execution-core unified worker-signal reader (CTL-533).
+// Run: cd plugins/dev/scripts/execution-core && bun test signal-reader.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readWorkerSignals } from "./signal-reader.mjs";
+
+let orchDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "exec-core-sigreader-"));
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// --- helpers --------------------------------------------------------------
+
+function workersDir() {
+  const dir = join(orchDir, "workers");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// Write a flat legacy signal: workers/<T>.json
+function writeFlat(ticket, body) {
+  writeFileSync(
+    join(workersDir(), `${ticket}.json`),
+    JSON.stringify({ ticket, ...body }),
+  );
+}
+
+// Write a nested phase signal: workers/<T>/phase-<p>.json
+function writeNested(ticket, phase, body) {
+  const dir = join(workersDir(), ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, ...body }),
+  );
+}
+
+function byTicket(signals) {
+  const m = new Map();
+  for (const s of signals) m.set(s.ticket, s);
+  return m;
+}
+
+// --- tests ----------------------------------------------------------------
+
+describe("readWorkerSignals", () => {
+  test("reads a flat legacy signal and tags layout='flat'", () => {
+    writeFlat("CTL-1", { phase: 3, pid: 123, status: "implementing" });
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(1);
+    const s = sigs[0];
+    expect(s.ticket).toBe("CTL-1");
+    expect(s.layout).toBe("flat");
+    expect(s.phase).toBe(3);
+    expect(s.liveness).toEqual({ kind: "pid", value: 123 });
+    expect(s.status).toBe("implementing");
+  });
+
+  test("reads a nested phase signal and tags layout='nested'", () => {
+    writeNested("CTL-2", "research", {
+      bg_job_id: "ab12",
+      status: "running",
+    });
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(1);
+    const s = sigs[0];
+    expect(s.ticket).toBe("CTL-2");
+    expect(s.layout).toBe("nested");
+    expect(s.phase).toBe("research");
+    expect(s.liveness).toEqual({ kind: "bg", value: "ab12" });
+  });
+
+  test("returns both layouts from one orch dir in a single call", () => {
+    writeFlat("CTL-1", { phase: 3, pid: 123, status: "implementing" });
+    writeNested("CTL-2", "research", { bg_job_id: "ab12", status: "running" });
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(2);
+    const m = byTicket(sigs);
+    expect(m.get("CTL-1").layout).toBe("flat");
+    expect(m.get("CTL-2").layout).toBe("nested");
+  });
+
+  test("ignores broker shadow projections (*.json.projected)", () => {
+    writeFlat("CTL-1", { phase: 1, pid: 1, status: "running" });
+    writeFileSync(
+      join(workersDir(), "CTL-1.json.projected"),
+      JSON.stringify({ ticket: "CTL-1", shadow: true }),
+    );
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(1);
+    expect(sigs[0].signalPath.endsWith(".json")).toBe(true);
+    expect(sigs[0].signalPath.endsWith(".projected")).toBe(false);
+  });
+
+  test("ignores phase-output artifacts (triage/verify/review/phase-monitor-deploy.json)", () => {
+    writeNested("CTL-3", "implement", { status: "running" });
+    const dir = join(workersDir(), "CTL-3");
+    for (const name of [
+      "triage.json",
+      "verify.json",
+      "review.json",
+      "phase-monitor-deploy.json",
+    ]) {
+      writeFileSync(join(dir, name), JSON.stringify({ artifact: true }));
+    }
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(1);
+    expect(sigs[0].phase).toBe("implement");
+  });
+
+  test("ignores the workers/output/ directory", () => {
+    writeFlat("CTL-1", { phase: 1, pid: 1, status: "running" });
+    const outDir = join(workersDir(), "output");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "CTL-1-stream.jsonl"), "{}");
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(1);
+    expect(sigs[0].ticket).toBe("CTL-1");
+  });
+
+  test("when a ticket has multiple nested phase-*.json, picks the active (latest non-terminal) one", () => {
+    const dir = join(workersDir(), "CTL-4");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({
+        ticket: "CTL-4",
+        phase: "research",
+        status: "done",
+        updatedAt: "2026-05-21T01:00:00Z",
+      }),
+    );
+    writeFileSync(
+      join(dir, "phase-implement.json"),
+      JSON.stringify({
+        ticket: "CTL-4",
+        phase: "implement",
+        status: "running",
+        updatedAt: "2026-05-21T02:00:00Z",
+      }),
+    );
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(1);
+    expect(sigs[0].phase).toBe("implement");
+    expect(sigs[0].status).toBe("running");
+  });
+
+  test("tolerates malformed JSON — skips the file, does not throw", () => {
+    writeFlat("CTL-1", { phase: 1, pid: 1, status: "running" });
+    writeFileSync(join(workersDir(), "CTL-bad.json"), "{ not json");
+    let sigs;
+    expect(() => {
+      sigs = readWorkerSignals(orchDir);
+    }).not.toThrow();
+    expect(sigs).toHaveLength(1);
+    expect(sigs[0].ticket).toBe("CTL-1");
+  });
+
+  test("returns [] for an orch dir with no workers/ directory", () => {
+    const empty = mkdtempSync(join(tmpdir(), "exec-core-empty-"));
+    try {
+      expect(readWorkerSignals(empty)).toEqual([]);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  test("normalizes status/updatedAt/pr fields onto the canonical shape", () => {
+    writeFlat("CTL-5", {
+      phase: 4,
+      pid: 99,
+      status: "merging",
+      updatedAt: "2026-05-21T03:00:00Z",
+      pr: { number: 42, url: "https://github.com/o/r/pull/42" },
+    });
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(1);
+    const s = sigs[0];
+    expect(s.status).toBe("merging");
+    expect(s.updatedAt).toBe("2026-05-21T03:00:00Z");
+    expect(s.pr).toEqual({ number: 42, url: "https://github.com/o/r/pull/42" });
+    expect(s.raw.ticket).toBe("CTL-5");
+  });
+
+  test("a nested dir with only artifacts (no phase-*.json) yields no signal", () => {
+    const dir = join(workersDir(), "CTL-6");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "triage.json"), JSON.stringify({ artifact: true }));
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/stalled-detector.mjs
+++ b/plugins/dev/scripts/execution-core/stalled-detector.mjs
@@ -1,0 +1,62 @@
+// stalled-detector.mjs — execution-core Step G stalled-worker decision (CTL-533).
+//
+// Pure mirror of the stalled-worker scan in orchestrate/SKILL.md. CTL-32
+// invariant: a stale signal file is NEVER stall evidence on its own — when
+// the worker's branch has an OPEN or MERGED PR the worker is progressing (or
+// finished) regardless of the signal's age, so a stale-but-progressing worker
+// gets its prior stalled attention RESOLVED, not re-raised. Escalation to a
+// `stalled` attention happens only when no authoritative source shows activity.
+//
+// All non-determinism (clock, git/PR state) is injected; returns a
+// { patch, attention } decision and never mutates anything.
+
+import { TERMINAL } from "./signal-reader.mjs";
+import { STALE_WORKER_CUTOFF_MS } from "./config.mjs";
+
+const NO_OP = Object.freeze({ patch: {}, attention: null });
+
+// detectStalled — decide the Step G transition for one worker.
+//
+// inputs: {
+//   ticket, nowMs, updatedAtMs (signal .updatedAt as epoch ms; null = unknown),
+//   currentStatus, prState:'MERGED'|'OPEN'|'NONE'|...,
+//   commitCount, remoteBranchExists, branch,
+// }
+// returns: { patch, attention }
+export function detectStalled(inputs) {
+  // Terminal worker states absorb everything.
+  if (TERMINAL.has(inputs.currentStatus)) return NO_OP;
+
+  // A missing/unknown updatedAt is treated as not-stale — escalating on
+  // missing data would be a false positive.
+  if (inputs.updatedAtMs == null) return NO_OP;
+
+  // Fresh signal — nothing to do.
+  if (inputs.nowMs - inputs.updatedAtMs <= STALE_WORKER_CUTOFF_MS) return NO_OP;
+
+  // Signal IS stale. CTL-32: consult git + PR state before escalating.
+  // An OPEN or MERGED PR is the authoritative progress signal — clear any
+  // prior stalled attention an earlier wake-up may have raised on staleness
+  // alone (the merge-confirmation scan reconciles a MERGED PR to done).
+  if (inputs.prState === "MERGED" || inputs.prState === "OPEN") {
+    return {
+      patch: {},
+      attention: { kind: "resolve-attention", ticket: inputs.ticket },
+    };
+  }
+
+  // No PR progress — escalate.
+  const branch = inputs.branch || "?";
+  return {
+    patch: {},
+    attention: {
+      kind: "stalled",
+      ticket: inputs.ticket,
+      message:
+        `No progress for ${Math.round(STALE_WORKER_CUTOFF_MS / 60_000)}+ ` +
+        `minutes; branch=${branch} commits=${inputs.commitCount ?? 0} ` +
+        `pushed=${inputs.remoteBranchExists ? 1 : 0} ` +
+        `pr=${inputs.prState ?? "NONE"}`,
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/stalled-detector.test.mjs
+++ b/plugins/dev/scripts/execution-core/stalled-detector.test.mjs
@@ -1,0 +1,98 @@
+// Unit tests for the execution-core Step G stalled-detector decision (CTL-533).
+// Run: cd plugins/dev/scripts/execution-core && bun test stalled-detector.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { detectStalled } from "./stalled-detector.mjs";
+import { STALE_WORKER_CUTOFF_MS } from "./config.mjs";
+
+const NOW = Date.parse("2026-05-21T12:00:00Z");
+
+// makeInputs — fixture factory: a fresh, non-stale, non-terminal worker.
+function makeInputs(over = {}) {
+  return {
+    ticket: "CTL-1",
+    nowMs: NOW,
+    updatedAtMs: NOW - 60_000, // 1 minute ago — fresh
+    currentStatus: "implementing",
+    prState: "NONE",
+    commitCount: 0,
+    remoteBranchExists: false,
+    branch: "feat/ctl-1",
+    ...over,
+  };
+}
+
+describe("detectStalled", () => {
+  test("updatedAt within cutoff → no-op", () => {
+    const out = detectStalled(makeInputs());
+    expect(out.patch).toEqual({});
+    expect(out.attention).toBeNull();
+  });
+
+  test("updatedAt older than STALE_WORKER_CUTOFF_MS + PR MERGED → resolve-attention", () => {
+    const out = detectStalled(
+      makeInputs({
+        updatedAtMs: NOW - STALE_WORKER_CUTOFF_MS - 60_000,
+        prState: "MERGED",
+      }),
+    );
+    expect(out.attention).not.toBeNull();
+    expect(out.attention.kind).toBe("resolve-attention");
+    expect(out.attention.ticket).toBe("CTL-1");
+    expect(out.patch).toEqual({});
+  });
+
+  test("stale + PR OPEN → resolve-attention (not a stall)", () => {
+    const out = detectStalled(
+      makeInputs({
+        updatedAtMs: NOW - STALE_WORKER_CUTOFF_MS - 60_000,
+        prState: "OPEN",
+      }),
+    );
+    expect(out.attention.kind).toBe("resolve-attention");
+  });
+
+  test("stale + no PR + no commits → raises a stalled attention", () => {
+    const out = detectStalled(
+      makeInputs({
+        updatedAtMs: NOW - STALE_WORKER_CUTOFF_MS - 60_000,
+        prState: "NONE",
+        commitCount: 0,
+      }),
+    );
+    expect(out.attention).not.toBeNull();
+    expect(out.attention.kind).toBe("stalled");
+    expect(out.attention.ticket).toBe("CTL-1");
+  });
+
+  test("terminal status (done/failed/stalled) → absorbed as no-op", () => {
+    for (const st of ["done", "failed", "stalled"]) {
+      const out = detectStalled(
+        makeInputs({
+          currentStatus: st,
+          updatedAtMs: NOW - STALE_WORKER_CUTOFF_MS - 60_000,
+          prState: "NONE",
+        }),
+      );
+      expect(out.patch).toEqual({});
+      expect(out.attention).toBeNull();
+    }
+  });
+
+  test("a stale signal alone is never stall evidence (CTL-32)", () => {
+    // Stale signal, but the PR is OPEN — the PR is authoritative progress.
+    const out = detectStalled(
+      makeInputs({
+        updatedAtMs: NOW - STALE_WORKER_CUTOFF_MS - 10 * 60_000,
+        prState: "OPEN",
+      }),
+    );
+    expect(out.attention.kind).not.toBe("stalled");
+  });
+
+  test("missing updatedAtMs → treated as not-stale, no-op", () => {
+    const out = detectStalled(makeInputs({ updatedAtMs: null }));
+    expect(out.patch).toEqual({});
+    expect(out.attention).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the orchestrator's per-event reconciliation scan out of the imperative
bash in `orchestrate/SKILL.md` into a dedicated, deterministic `execution-core`
scan module. Each scan step is now a pure decision function — all
non-determinism (git/PR/deploy/comms state) is injected — and `runScan`
composes them into a single one-shot reconcile pass with full unit coverage.

Delivered across four phases (Refs: CTL-533):

- **Phase 1** — unified worker-signal-layout reader (`signal-reader.mjs`)
- **Phase 2** — pure per-step scan decision modules (merge / stalled / comms / deploy)
- **Phase 3** — `runScan` deterministic scan orchestrator
- **Phase 4** — barrel exports + `scan` CLI subcommand

## Changes

### New decision modules (`plugins/dev/scripts/execution-core/`)

- `signal-reader.mjs` — unified reader for the worker-signal directory layout;
  exposes the shared `TERMINAL` status set used by downstream steps.
- `merge-state.mjs` — Step C merge-confirmation decision. Pure mirror of the
  `case "$PR_STATE"` block in `orchestrate/SKILL.md`. Returns a
  `{ patch, attention, events }` decision; `MERGED` routes to `done`/phase 6
  when deploy verification is skipped, or `merged`/phase 5 otherwise (CTL-211),
  and emits a `worker-pr-merged` event. `CLOSED` raises a `pr-closed`
  attention. No-ops on terminal worker states and already-reconciled merges.
- `stalled-detector.mjs` — Step G stall detection. A stale signal alone is
  never stall evidence (CTL-32); staleness is only a precondition for
  consulting git/PR state.
- `comms-drain.mjs` — Step F comms-channel drain. Promotes `type:"attention"`
  messages to state-level attention items and advances the channel cursor.
  Pure: the caller reads messages, this function decides.
- `deploy-state.mjs` — re-export of the canonical `nextDeployState` from
  `orch-monitor/lib/deploy-state-machine.ts` (no logic duplication).
- `scan.mjs` — `runScan` orchestrator composing every step into one
  deterministic reconcile pass.
- `scan-adapters.mjs` — builds the real git/gh/deploy/comms adapters that
  inject live state into the otherwise-pure scan.

### Integration points

- `config.mjs` — adds `STALE_WORKER_CUTOFF_MS` (default 15 min, env-overridable
  via `EXECUTION_CORE_STALE_WORKER_CUTOFF_MS`), matching the legacy
  `date -u -v-15M` cutoff.
- `index.mjs` — barrel re-exports the new scan modules and adds a `scan`
  subcommand (`bun index.mjs scan --orch-dir <dir> --orch-id <id> [...]`) that
  runs one deterministic dry-run scan and prints the result JSON.

## Testing

Each decision module ships with a `bun:test` suite using deterministic fixture
factories:

- `signal-reader.test.mjs`
- `merge-state.test.mjs`
- `stalled-detector.test.mjs`
- `comms-drain.test.mjs`
- `scan.test.mjs`

Run: `cd plugins/dev/scripts/execution-core && bun test`

## Notes

Phase 4 is an apply-nothing dry run — the `scan` CLI prints decisions but does
not write patches back to disk. A follow-up integration ticket wires the
patches into the running orchestrator.

Refs: CTL-533
