### PR TITLE
CTL-539: Exec core tracer

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -41,6 +41,16 @@ export function getCursorPath() {
   return resolve(getExecutionCoreDir(), "cursor.json");
 }
 
+// Root for `claude --bg` job state dirs — ~/.claude/jobs/<bg_job_id>/state.json.
+// Env name matches orchestrate-healthcheck's CATALYST_HEALTHCHECK_JOBS_ROOT so
+// tests override one variable for both.
+export function getJobsRoot() {
+  return (
+    process.env.CATALYST_HEALTHCHECK_JOBS_ROOT ??
+    resolve(homedir(), ".claude", "jobs")
+  );
+}
+
 // The unified monthly event log. UTC month to match the writer —
 // orch-monitor/lib/event-writer.ts uses getUTCFullYear/getUTCMonth, so the
 // tailer must resolve the same path or it would follow the wrong file.

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -35,6 +35,12 @@ export function getEligibleDir() {
   return resolve(getExecutionCoreDir(), "eligible");
 }
 
+// The durable event-log tailer cursor — monitor.mjs persists its byte offset
+// here so a daemon restart resumes the fast path instead of re-seeding at EOF.
+export function getCursorPath() {
+  return resolve(getExecutionCoreDir(), "cursor.json");
+}
+
 // The unified monthly event log. UTC month to match the writer —
 // orch-monitor/lib/event-writer.ts uses getUTCFullYear/getUTCMonth, so the
 // tailer must resolve the same path or it would follow the wrong file.

--- a/plugins/dev/scripts/execution-core/event-cursor.mjs
+++ b/plugins/dev/scripts/execution-core/event-cursor.mjs
@@ -1,0 +1,72 @@
+// event-cursor.mjs — durable event-log tailer cursor (CTL-539).
+//
+// monitor.mjs's byte-offset tailer persists {logPath, byteOffset} here on every
+// drain; on startup it resumes from the saved offset instead of re-seeding at
+// EOF, so events that arrived while the daemon was down reach the fast path
+// promptly. The cursor is a latency optimization only — every resolveStartOffset
+// failure mode falls back to EOF, and the periodic reconcile is the correctness
+// backstop regardless. Leaf module: depends only on config.mjs.
+
+import {
+  writeFileSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  mkdirSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { getCursorPath, log } from "./config.mjs";
+
+// loadCursor — read the persisted cursor, or null when absent/corrupt/invalid.
+export function loadCursor() {
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(getCursorPath(), "utf8"));
+  } catch {
+    return null; // no cursor file yet, or unreadable/malformed — caller seeds EOF
+  }
+  if (typeof raw?.logPath !== "string" || !Number.isInteger(raw?.byteOffset)) {
+    log.warn({ raw }, "event-cursor: malformed cursor — ignoring");
+    return null;
+  }
+  return { logPath: raw.logPath, byteOffset: raw.byteOffset };
+}
+
+// saveCursor — atomic tmp+rename write. Best-effort: a write failure is logged
+// but never thrown — the tailer must not crash because a cursor write failed.
+export function saveCursor({ logPath, byteOffset }) {
+  const file = getCursorPath();
+  const tmp = `${file}.tmp`;
+  try {
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(tmp, JSON.stringify({ logPath, byteOffset }));
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* tmp already gone */
+    }
+    log.warn(
+      { err: err.message },
+      "event-cursor: cursor write failed — fast path will re-seed at EOF next restart",
+    );
+  }
+}
+
+// resolveStartOffset — PURE. Decide the tailer's startup byte offset. Resume
+// from the saved cursor only when it is for the current log file and its offset
+// is in-range [0, fileSize]; otherwise seed at EOF (skip history). EOF is always
+// a correct fallback because the periodic reconcile poll catches missed events.
+export function resolveStartOffset({ cursor, logPath, fileSize }) {
+  if (
+    cursor &&
+    cursor.logPath === logPath &&
+    Number.isInteger(cursor.byteOffset) &&
+    cursor.byteOffset >= 0 &&
+    cursor.byteOffset <= fileSize
+  ) {
+    return cursor.byteOffset;
+  }
+  return fileSize;
+}

--- a/plugins/dev/scripts/execution-core/event-cursor.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-cursor.test.mjs
@@ -1,0 +1,145 @@
+// Unit tests for the durable event-log tailer cursor (CTL-539 Phase 1).
+// Run: cd plugins/dev/scripts/execution-core && bun test event-cursor.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
+import { getCursorPath } from "./config.mjs";
+
+let catalystDir;
+let prevCatalystDir;
+
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "exec-core-cursor-"));
+  process.env.CATALYST_DIR = catalystDir;
+});
+
+afterEach(() => {
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+// --- resolveStartOffset — pure ------------------------------------------
+
+describe("resolveStartOffset", () => {
+  test("valid cursor matching logPath, offset <= size → resumes at cursor offset", () => {
+    expect(
+      resolveStartOffset({
+        cursor: { logPath: "/L", byteOffset: 50 },
+        logPath: "/L",
+        fileSize: 200,
+      }),
+    ).toBe(50);
+  });
+
+  test("cursor offset exactly equal to fileSize → resumes at that offset", () => {
+    expect(
+      resolveStartOffset({
+        cursor: { logPath: "/L", byteOffset: 200 },
+        logPath: "/L",
+        fileSize: 200,
+      }),
+    ).toBe(200);
+  });
+
+  test("no cursor → seeds at EOF (returns fileSize)", () => {
+    expect(
+      resolveStartOffset({ cursor: null, logPath: "/L", fileSize: 200 }),
+    ).toBe(200);
+  });
+
+  test("cursor logPath mismatch (month rollover) → seeds at EOF of current file", () => {
+    expect(
+      resolveStartOffset({
+        cursor: { logPath: "/2026-04.jsonl", byteOffset: 10 },
+        logPath: "/2026-05.jsonl",
+        fileSize: 200,
+      }),
+    ).toBe(200);
+  });
+
+  test("cursor offset > fileSize (log truncated/rotated) → seeds at EOF", () => {
+    expect(
+      resolveStartOffset({
+        cursor: { logPath: "/L", byteOffset: 9999 },
+        logPath: "/L",
+        fileSize: 200,
+      }),
+    ).toBe(200);
+  });
+
+  test("cursor offset negative → seeds at EOF", () => {
+    expect(
+      resolveStartOffset({
+        cursor: { logPath: "/L", byteOffset: -1 },
+        logPath: "/L",
+        fileSize: 200,
+      }),
+    ).toBe(200);
+  });
+
+  test("cursor offset non-integer → seeds at EOF", () => {
+    expect(
+      resolveStartOffset({
+        cursor: { logPath: "/L", byteOffset: 12.5 },
+        logPath: "/L",
+        fileSize: 200,
+      }),
+    ).toBe(200);
+  });
+});
+
+// --- loadCursor / saveCursor — round-trip + durability -----------------
+
+describe("loadCursor / saveCursor", () => {
+  test("saveCursor then loadCursor round-trips {logPath, byteOffset}", () => {
+    saveCursor({ logPath: "/events/2026-05.jsonl", byteOffset: 1234 });
+    expect(loadCursor()).toEqual({
+      logPath: "/events/2026-05.jsonl",
+      byteOffset: 1234,
+    });
+  });
+
+  test("loadCursor returns null when no cursor file exists", () => {
+    expect(loadCursor()).toBeNull();
+  });
+
+  test("loadCursor returns null on a corrupt (non-JSON) cursor file", () => {
+    mkdirSync(join(catalystDir, "execution-core"), { recursive: true });
+    writeFileSync(getCursorPath(), "{ not json");
+    expect(loadCursor()).toBeNull();
+  });
+
+  test("loadCursor returns null when the cursor file is missing required keys", () => {
+    mkdirSync(join(catalystDir, "execution-core"), { recursive: true });
+    writeFileSync(getCursorPath(), JSON.stringify({ logPath: "/L" })); // no byteOffset
+    expect(loadCursor()).toBeNull();
+    writeFileSync(getCursorPath(), JSON.stringify({ byteOffset: 5 })); // no logPath
+    expect(loadCursor()).toBeNull();
+  });
+
+  test("loadCursor returns null when byteOffset is not an integer", () => {
+    mkdirSync(join(catalystDir, "execution-core"), { recursive: true });
+    writeFileSync(
+      getCursorPath(),
+      JSON.stringify({ logPath: "/L", byteOffset: "fifty" }),
+    );
+    expect(loadCursor()).toBeNull();
+  });
+
+  test("saveCursor writes atomically — no <file>.tmp left behind on success", () => {
+    saveCursor({ logPath: "/L", byteOffset: 7 });
+    expect(existsSync(getCursorPath())).toBe(true);
+    expect(existsSync(`${getCursorPath()}.tmp`)).toBe(false);
+  });
+
+  test("saveCursor creates the execution-core dir if absent", () => {
+    expect(existsSync(join(catalystDir, "execution-core"))).toBe(false);
+    saveCursor({ logPath: "/L", byteOffset: 1 });
+    expect(loadCursor()).toEqual({ logPath: "/L", byteOffset: 1 });
+  });
+});

--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -24,6 +24,7 @@ export {
   reconcileAll,
   handleStateChangedEvent,
   seedTailerAtEof,
+  seedTailerFromCursor,
   startTailing,
   startMonitor,
   stopMonitor,

--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -40,6 +40,15 @@ export {
   readAllEligibleTickets,
 } from "./scheduler.mjs";
 
+// --- CTL-539: crash-recovery & startup reconstruction --------------------
+export * from "./event-cursor.mjs";
+export {
+  defaultStatJob,
+  classifyWorker,
+  reconstructWorkerState,
+  recoverStartup,
+} from "./recovery.mjs";
+
 // --- CTL-533: deterministic per-event scan module -----------------------
 export * from "./signal-reader.mjs";
 export * from "./merge-state.mjs";

--- a/plugins/dev/scripts/execution-core/integration.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration.test.mjs
@@ -6,7 +6,15 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test integration.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  appendFileSync,
+  statSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -14,13 +22,23 @@ import {
   stopMonitor,
   reconcileAll,
   handleStateChangedEvent,
+  readNewEvents,
   __resetForTests,
 } from "./monitor.mjs";
 import { getEligibleSet, dropProject } from "./eligible-set.mjs";
+import {
+  startScheduler,
+  stopScheduler,
+  __resetForTests as __resetScheduler,
+} from "./scheduler.mjs";
+import { recoverStartup, defaultStatJob } from "./recovery.mjs";
+import { loadCursor } from "./event-cursor.mjs";
 
 let catalystDir;
 let enrollmentDir;
 let prevCatalystDir;
+let jobsRoot;
+let prevJobsRoot;
 const enrolledKeys = new Set();
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -31,16 +49,27 @@ beforeEach(() => {
   process.env.CATALYST_DIR = catalystDir;
   enrollmentDir = join(catalystDir, "execution-core", "projects");
   mkdirSync(enrollmentDir, { recursive: true });
+  // A fake ~/.claude/jobs root so the worker-liveness scan never touches real
+  // Claude state (the env var orchestrate-healthcheck + getJobsRoot share).
+  prevJobsRoot = process.env.CATALYST_HEALTHCHECK_JOBS_ROOT;
+  jobsRoot = mkdtempSync(join(tmpdir(), "exec-core-int-jobs-"));
+  process.env.CATALYST_HEALTHCHECK_JOBS_ROOT = jobsRoot;
   __resetForTests();
+  __resetScheduler();
   enrolledKeys.clear();
 });
 
 afterEach(() => {
   stopMonitor();
+  stopScheduler();
   __resetForTests();
+  __resetScheduler();
   for (const k of enrolledKeys) dropProject(k);
   if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
   else process.env.CATALYST_DIR = prevCatalystDir;
+  if (prevJobsRoot === undefined) delete process.env.CATALYST_HEALTHCHECK_JOBS_ROOT;
+  else process.env.CATALYST_HEALTHCHECK_JOBS_ROOT = prevJobsRoot;
+  rmSync(jobsRoot, { recursive: true, force: true });
   rmSync(catalystDir, { recursive: true, force: true });
 });
 
@@ -164,5 +193,155 @@ describe("execution-core integration — rebuild + isolation", () => {
       "PLAT-1",
       "PLAT-2",
     ]);
+  });
+});
+
+// --- AC5: crash recovery — kill mid-run + restart (CTL-539) ---------------
+
+describe("execution-core integration — crash recovery (CTL-539)", () => {
+  // appendEventLog — append a line to the current UTC month's event log.
+  function eventLogPath() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    return join(catalystDir, "events", `${ym}.jsonl`);
+  }
+  function appendEventLog(line) {
+    mkdirSync(join(catalystDir, "events"), { recursive: true });
+    appendFileSync(eventLogPath(), line);
+  }
+  // stateChangedLine — a legacy flat state_changed event as a log line.
+  const stateChangedLine = (ticket, teamKey, toState) =>
+    `${JSON.stringify({
+      event: "linear.issue.state_changed",
+      detail: { ticket, teamKey, toState },
+    })}\n`;
+
+  // writeWorkerSignal — a nested phase-agent signal: workers/<T>/phase-<p>.json.
+  function writeWorkerSignal(orchDir, ticket, phase, body) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, ...body }),
+    );
+  }
+  // makeJobDir — a fake claude --bg job state dir under the fake jobs root.
+  function makeJobDir(bgJobId) {
+    const dir = join(jobsRoot, bgJobId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "state.json"), JSON.stringify({ state: "running" }));
+  }
+
+  test("AC5 — kill mid-run + restart: resumes with no double-dispatch and no lost workers", () => {
+    // ── Setup ──
+    const orchDir = mkdtempSync(join(catalystDir, "orch-"));
+    mkdirSync(join(orchDir, "workers"), { recursive: true });
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    enroll("alpha", { team: "ENG", status: "Todo" });
+
+    const reported = { ENG: [node("ENG-NEW")] };
+    const exec = mockExec(reported);
+
+    // A counting dispatch mock spanning the WHOLE kill/restart cycle. It also
+    // writes the dispatched signal the real phase-agent-dispatch would write
+    // (signal-first), so the post-restart tick sees the started ticket.
+    const dispatchCalls = [];
+    const dispatch = (args) => {
+      dispatchCalls.push(`${args.ticket}:${args.phase}`);
+      writeWorkerSignal(args.orchDir, args.ticket, args.phase, {
+        status: "dispatched",
+        bg_job_id: `job-${args.ticket}`,
+      });
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const readEligible = () => getEligibleSet("alpha");
+
+    // Pre-create the event log so later appends are in-place changes.
+    appendEventLog("");
+
+    // ── Run — compose the real monitor + scheduler ──
+    startMonitor({ exec, resumeFromCursor: true, reconcileIntervalMs: 60_000 });
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+    });
+    // startScheduler ran one tick → ENG-NEW (the eligible ready ticket) was
+    // dispatched into a free slot.
+    expect(dispatchCalls).toContain("ENG-NEW:triage");
+
+    // An event lands; drain the tailer deterministically (fs.watch is flaky).
+    appendEventLog(stateChangedLine("ENG-NEW", "ENG", "Todo"));
+    readNewEvents();
+    // The cursor now tracks the log size — a non-zero durable offset.
+    const preKillSize = statSync(eventLogPath()).size;
+    expect(loadCursor()).toEqual({
+      logPath: eventLogPath(),
+      byteOffset: preKillSize,
+    });
+    expect(preKillSize).toBeGreaterThan(0);
+
+    // ── Seed in-flight workers ── one with a live bg job dir, one without.
+    writeWorkerSignal(orchDir, "CTL-A", "research", {
+      status: "running",
+      bg_job_id: "job-a",
+    });
+    makeJobDir("job-a"); // CTL-A's process is alive → must classify 'running'
+    writeWorkerSignal(orchDir, "CTL-B", "plan", {
+      status: "running",
+      bg_job_id: "job-b",
+    });
+    // no job dir for job-b → CTL-B is a lost worker → must classify 'dead'
+
+    // ── Kill ── the daemon dies mid-run.
+    stopMonitor();
+    stopScheduler();
+
+    // ── Downtime ── an event arrives while the daemon is down.
+    appendEventLog(stateChangedLine("ENG-NEW", "ENG", "In Progress"));
+
+    // ── Restart — recoverStartup reconstructs everything ──
+    const report = recoverStartup({ orchDir, exec, statJob: defaultStatJob });
+
+    // The cursor resumed from the pre-kill saved offset — history is not
+    // reprocessed from 0, and the downtime gap is not skipped.
+    expect(report.cursor.resumed).toBe(true);
+    expect(report.cursor.byteOffset).toBe(preKillSize);
+
+    // No lost workers — every in-flight worker is accounted for.
+    expect(report.workers.running.map((w) => w.ticket)).toContain("CTL-A");
+    expect(report.workers.dead.map((w) => w.ticket)).toContain("CTL-B");
+    const allWorkers = [
+      ...report.workers.running,
+      ...report.workers.dead,
+      ...report.workers.terminal,
+      ...report.workers.unknown,
+    ].map((w) => w.ticket);
+    expect(allWorkers).toContain("CTL-A");
+    expect(allWorkers).toContain("CTL-B");
+    expect(allWorkers).toContain("ENG-NEW"); // the dispatched ticket survives
+
+    // ── Re-run — restart the composed daemon; it drains the downtime gap ──
+    startMonitor({ exec, resumeFromCursor: true, reconcileIntervalMs: 60_000 });
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+    });
+
+    // ── Assert no double-dispatch ── across the WHOLE kill/restart cycle,
+    // every {ticket,phase} key was dispatched exactly once.
+    const byKey = new Map();
+    for (const k of dispatchCalls) byKey.set(k, (byKey.get(k) ?? 0) + 1);
+    const duplicates = [...byKey.entries()].filter(([, n]) => n > 1);
+    expect(duplicates).toEqual([]);
+    // ENG-NEW:triage in particular is never re-dispatched after the restart.
+    expect(byKey.get("ENG-NEW:triage")).toBe(1);
+
+    rmSync(orchDir, { recursive: true, force: true });
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -22,6 +22,7 @@ import {
 import { listEnrolledProjects, loadProjectConfig } from "./enrollment.mjs";
 import { runEligibleQuery } from "./linear-query.mjs";
 import { setProjectEligible, removeTicket, dropProject } from "./eligible-set.mjs";
+import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
 
 // --- Event parsing -------------------------------------------------------
 
@@ -158,25 +159,49 @@ let watcher = null;
 let reconcileTimer = null;
 let tailerOpts = {};
 
+// fileSizeOrZero — current byte size of a file, or 0 when it does not exist
+// (the poll-only state). Shared by both tailer seeders.
+function fileSizeOrZero(path) {
+  try {
+    const fd = openSync(path, "r");
+    const { size } = fstatSync(fd);
+    closeSync(fd);
+    return size;
+  } catch {
+    return 0; // log file does not exist yet — poll-only mode
+  }
+}
+
 // seedTailerAtEof — pin the tailer to the current end of the event log so the
 // startup reconcile poll (not a log replay) is the authoritative rebuild.
 export function seedTailerAtEof() {
   lastLogPath = getEventLogPath();
   leftoverBuf = "";
-  try {
-    const fd = openSync(lastLogPath, "r");
-    lastByteOffset = fstatSync(fd).size;
-    closeSync(fd);
-  } catch {
-    lastByteOffset = 0; // log file does not exist yet — poll-only mode
-  }
+  lastByteOffset = fileSizeOrZero(lastLogPath);
+}
+
+// seedTailerFromCursor — pin the tailer to the durable cursor's saved offset so
+// a daemon restart resumes the fast path mid-stream. resolveStartOffset falls
+// back to EOF for a missing/stale/rotated cursor; the periodic reconcile is the
+// correctness backstop either way. CTL-539.
+export function seedTailerFromCursor() {
+  lastLogPath = getEventLogPath();
+  leftoverBuf = "";
+  lastByteOffset = resolveStartOffset({
+    cursor: loadCursor(),
+    logPath: lastLogPath,
+    fileSize: fileSizeOrZero(lastLogPath),
+  });
 }
 
 // readNewEvents — drain bytes appended since the last call, parse each
 // complete line, and feed it to handleStateChangedEvent. A leftover buffer
 // carries partial lines; on month rollover the new file is re-seeded at its
 // current size (its tail is not replayed).
-function readNewEvents() {
+//
+// Exported for deterministic test drives + the CTL-539 startup gap-drain; the
+// index.mjs barrel deliberately does not re-export it.
+export function readNewEvents() {
   const logPath = getEventLogPath();
   if (logPath !== lastLogPath) {
     lastLogPath = logPath;
@@ -202,6 +227,9 @@ function readNewEvents() {
     readSync(fd, buf, 0, newByteCount, lastByteOffset);
     closeSync(fd);
     lastByteOffset = size;
+    // CTL-539: persist the durable cursor so a restart resumes here. saveCursor
+    // is best-effort — it swallows and logs its own write failures.
+    saveCursor({ logPath: lastLogPath, byteOffset: lastByteOffset });
 
     const text = leftoverBuf + buf.toString("utf8");
     const lines = text.split("\n");
@@ -238,15 +266,24 @@ export function startTailing() {
 // --- Lifecycle -----------------------------------------------------------
 
 // startMonitor — immediate reconcileAll (authoritative initial rebuild), seed
-// the tailer at EOF, start tailing, then arm the periodic reconcile timer.
+// the tailer, start tailing, then arm the periodic reconcile timer. With
+// resumeFromCursor (default, CTL-539) the tailer resumes from the durable
+// cursor and the cursor→EOF downtime gap is drained immediately; otherwise it
+// seeds at EOF (the legacy poll-only-on-startup behavior).
 export function startMonitor({
   exec,
   debounceMs = EVENT_DEBOUNCE_MS,
   reconcileIntervalMs = RECONCILE_INTERVAL_MS,
+  resumeFromCursor = true,
 } = {}) {
   tailerOpts = { exec, debounceMs };
   reconcileAll({ exec });
-  seedTailerAtEof();
+  if (resumeFromCursor) {
+    seedTailerFromCursor();
+    readNewEvents(); // drain the cursor→EOF downtime gap immediately
+  } else {
+    seedTailerAtEof();
+  }
   startTailing();
   reconcileTimer = setInterval(() => reconcileAll({ exec }), reconcileIntervalMs);
 }
@@ -262,6 +299,12 @@ export function stopMonitor() {
   dirtyTimers.clear();
   watcher?.close();
   watcher = null;
+}
+
+// __tailerOffset — the tailer's current byte offset. Test-only, for
+// deterministic cursor-seeding assertions; kept out of the index.mjs barrel.
+export function __tailerOffset() {
+  return lastByteOffset;
 }
 
 // __resetForTests — clear all module-level state between unit tests. Not part

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -2,7 +2,15 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test monitor.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  unlinkSync,
+  appendFileSync,
+  statSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -12,9 +20,13 @@ import {
   handleStateChangedEvent,
   startMonitor,
   stopMonitor,
+  seedTailerFromCursor,
+  readNewEvents,
+  __tailerOffset,
   __resetForTests,
 } from "./monitor.mjs";
 import { setProjectEligible, getEligibleSet, dropProject } from "./eligible-set.mjs";
+import { loadCursor, saveCursor } from "./event-cursor.mjs";
 
 let catalystDir;
 let enrollmentDir;
@@ -263,5 +275,109 @@ describe("lifecycle", () => {
     stopMonitor(); // clears the queued debounce timer
     await sleep(80);
     expect(exec.calls).toBe(0);
+  });
+});
+
+// --- CTL-539: durable cursor wiring ---------------------------------------
+
+// eventLogPath / appendEventLog — resolve and append to the current UTC
+// month's log under the temp CATALYST_DIR (the path getEventLogPath() uses).
+function eventLogPath() {
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  return join(catalystDir, "events", `${ym}.jsonl`);
+}
+function appendEventLog(line) {
+  mkdirSync(join(catalystDir, "events"), { recursive: true });
+  appendFileSync(eventLogPath(), line);
+}
+
+describe("seedTailerFromCursor", () => {
+  test("no cursor file → tailer offset = EOF (poll-only parity)", () => {
+    appendEventLog('{"event":"a"}\n{"event":"b"}\n');
+    const size = statSync(eventLogPath()).size;
+    seedTailerFromCursor();
+    expect(__tailerOffset()).toBe(size);
+  });
+
+  test("no event log file at all → tailer offset = 0 (poll-only mode)", () => {
+    seedTailerFromCursor();
+    expect(__tailerOffset()).toBe(0);
+  });
+
+  test("valid cursor → tailer offset = saved offset", () => {
+    appendEventLog('{"event":"a"}\n{"event":"b"}\n{"event":"c"}\n');
+    const midpoint = 14; // a partial offset into the log
+    saveCursor({ logPath: eventLogPath(), byteOffset: midpoint });
+    seedTailerFromCursor();
+    expect(__tailerOffset()).toBe(midpoint);
+  });
+
+  test("stale cursor (offset > size) → tailer offset = EOF", () => {
+    appendEventLog('{"event":"a"}\n');
+    const size = statSync(eventLogPath()).size;
+    saveCursor({ logPath: eventLogPath(), byteOffset: 999999 });
+    seedTailerFromCursor();
+    expect(__tailerOffset()).toBe(size);
+  });
+});
+
+describe("readNewEvents — cursor persistence", () => {
+  test("persists the cursor after draining new bytes", () => {
+    appendEventLog('{"event":"first"}\n');
+    seedTailerFromCursor(); // seed at EOF of the one-line log
+    appendEventLog('{"event":"second"}\n'); // a new append while tailing
+    readNewEvents();
+    const size = statSync(eventLogPath()).size;
+    expect(loadCursor()).toEqual({ logPath: eventLogPath(), byteOffset: size });
+    expect(__tailerOffset()).toBe(size);
+  });
+});
+
+describe("startMonitor — resumeFromCursor", () => {
+  test("resumeFromCursor:false keeps the seed-at-EOF behavior", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = execReturning({ ENG: [node("ENG-1")] });
+    appendEventLog('{"event":"a"}\n{"event":"b"}\n');
+    const size = statSync(eventLogPath()).size;
+    startMonitor({
+      exec,
+      resumeFromCursor: false,
+      reconcileIntervalMs: 60_000,
+    });
+    expect(__tailerOffset()).toBe(size); // EOF — no cursor consulted
+  });
+
+  test("resumeFromCursor:true drains the gap between cursor and EOF", () => {
+    // alpha holds ENG-1 + ENG-2; an event in the downtime gap moved ENG-1 OUT
+    // of Todo. resumeFromCursor:true must drain that gap on startup and remove
+    // ENG-1 — proving the durable cursor, not a re-seed, drove the resume.
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = execReturning({ ENG: [node("ENG-1"), node("ENG-2")] });
+    // Pre-write a downtime-gap event and pin the cursor at offset 0.
+    appendEventLog(
+      `${JSON.stringify({
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "In Progress" },
+      })}\n`,
+    );
+    saveCursor({ logPath: eventLogPath(), byteOffset: 0 });
+    startMonitor({ exec, resumeFromCursor: true, reconcileIntervalMs: 60_000 });
+    // startup reconcileAll seeded {ENG-1, ENG-2}; the gap drain removed ENG-1.
+    expect(getEligibleSet("alpha").map((t) => t.identifier)).toEqual(["ENG-2"]);
+  });
+
+  test("resumeFromCursor defaults to true (the gap is drained without the flag)", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = execReturning({ ENG: [node("ENG-1"), node("ENG-2")] });
+    appendEventLog(
+      `${JSON.stringify({
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Done" },
+      })}\n`,
+    );
+    saveCursor({ logPath: eventLogPath(), byteOffset: 0 });
+    startMonitor({ exec, reconcileIntervalMs: 60_000 }); // no resumeFromCursor
+    expect(getEligibleSet("alpha").map((t) => t.identifier)).toEqual(["ENG-2"]);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1,0 +1,67 @@
+// recovery.mjs — execution-core crash-recovery & startup reconstruction (CTL-539).
+//
+// The recovery contract CTL-554's composing daemon calls on boot. Reconstructs
+// routing state (eligible sets, via reconcileAll) and dispatch/worker state
+// (via the canonical signal reader), and classifies every in-flight claude --bg
+// worker's liveness so a restart resumes mid-run with no lost workers.
+
+import { statSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getJobsRoot, log } from "./config.mjs";
+import { readWorkerSignals, TERMINAL } from "./signal-reader.mjs";
+
+// defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
+// the job dir is gone (the worker's process no longer exists), else its mtime
+// and parsed .state. Injectable so tests never touch real Claude job state.
+export function defaultStatJob(bgJobId) {
+  const file = join(getJobsRoot(), bgJobId, "state.json");
+  let st;
+  try {
+    st = statSync(file);
+  } catch {
+    return null; // job dir missing → worker is gone
+  }
+  let state = null;
+  try {
+    state = JSON.parse(readFileSync(file, "utf8"))?.state ?? null;
+  } catch {
+    /* state.json unreadable — liveness still proven by the dir existing */
+  }
+  return { exists: true, mtimeMs: st.mtimeMs, state };
+}
+
+// classifyWorker — PURE given statJob. One WorkerSignal (from readWorkerSignals)
+// → a liveness class:
+//   'terminal' — signal status is terminal; the phase finished, nothing to attach
+//   'running'  — non-terminal + the bg job dir exists → re-attached
+//   'dead'     — non-terminal + the bg job dir is gone → a lost worker
+//   'unknown'  — no bg_job_id (legacy pid signal, or an orphan `dispatched`
+//                signal written before claude --bg was spawned)
+export function classifyWorker(signal, { statJob = defaultStatJob } = {}) {
+  if (TERMINAL.has(signal?.status)) return "terminal";
+  const live = signal?.liveness;
+  if (live?.kind !== "bg" || !live?.value) return "unknown";
+  return statJob(live.value) ? "running" : "dead";
+}
+
+// reconstructWorkerState — scan ${orchDir}/workers/ via the canonical reader and
+// bucket every worker by classifyWorker. Pure given statJob + the filesystem.
+export function reconstructWorkerState(orchDir, { statJob = defaultStatJob } = {}) {
+  const buckets = { running: [], dead: [], terminal: [], unknown: [] };
+  for (const sig of readWorkerSignals(orchDir)) {
+    buckets[classifyWorker(sig, { statJob })].push({
+      ticket: sig.ticket,
+      phase: sig.phase,
+      status: sig.status,
+      bgJobId: sig.liveness?.kind === "bg" ? sig.liveness.value : null,
+      signalPath: sig.signalPath,
+    });
+  }
+  if (buckets.dead.length || buckets.unknown.length) {
+    log.warn(
+      { dead: buckets.dead.length, unknown: buckets.unknown.length },
+      "recovery: workers need attention (dead = lost process, unknown = orphan dispatch)",
+    );
+  }
+  return buckets;
+}

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -5,10 +5,13 @@
 // (via the canonical signal reader), and classifies every in-flight claude --bg
 // worker's liveness so a restart resumes mid-run with no lost workers.
 
-import { statSync, readFileSync } from "node:fs";
+import { statSync, readFileSync, openSync, fstatSync, closeSync } from "node:fs";
 import { join } from "node:path";
-import { getJobsRoot, log } from "./config.mjs";
+import { getJobsRoot, getEventLogPath, log } from "./config.mjs";
 import { readWorkerSignals, TERMINAL } from "./signal-reader.mjs";
+import { reconcileAll } from "./monitor.mjs";
+import { listEnrolledProjects } from "./enrollment.mjs";
+import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 
 // defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
 // the job dir is gone (the worker's process no longer exists), else its mtime
@@ -64,4 +67,41 @@ export function reconstructWorkerState(orchDir, { statJob = defaultStatJob } = {
     );
   }
   return buckets;
+}
+
+// recoverStartup — the boot-time reconstruction CTL-554's daemon calls. Rebuilds
+// routing state (reconcileAll — authoritative Linear poll), loads the durable
+// event-log cursor, and classifies every in-flight worker. Returns a
+// RecoveryReport; throws nothing the daemon must handle (reconcile is internally
+// best-effort, worker scan is filesystem-pure).
+export function recoverStartup({ orchDir, exec, statJob } = {}) {
+  if (!orchDir) throw new Error("recoverStartup: orchDir is required");
+
+  // (1) Routing state — reconcileAll re-globs enrollment + polls Linear per
+  //     project; reconcileProject internally swallows poll/write failures.
+  reconcileAll({ exec });
+  const projects = listEnrolledProjects().map((p) => p.projectKey);
+
+  // (2) Durable event-log cursor — what the monitor's fast path will resume at.
+  const logPath = getEventLogPath();
+  let fileSize = 0;
+  try {
+    const fd = openSync(logPath, "r");
+    fileSize = fstatSync(fd).size;
+    closeSync(fd);
+  } catch {
+    /* no event log yet — poll-only mode */
+  }
+  const cursor = loadCursor();
+  const startOffset = resolveStartOffset({ cursor, logPath, fileSize });
+
+  // (3) Dispatch/worker state — classify in-flight claude --bg workers.
+  const workers = reconstructWorkerState(orchDir, { statJob });
+
+  return {
+    recoveredAt: new Date().toISOString(),
+    routing: { projects, projectCount: projects.length },
+    cursor: { logPath, byteOffset: startOffset, resumed: startOffset !== fileSize },
+    workers,
+  };
 }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1,0 +1,250 @@
+// Unit + integration tests for execution-core crash recovery (CTL-539).
+// Run: cd plugins/dev/scripts/execution-core && bun test recovery.test.mjs
+//
+// Phase 2 covers classifyWorker + reconstructWorkerState; Phase 3 extends
+// this same file with recoverStartup composition tests.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyWorker,
+  reconstructWorkerState,
+  defaultStatJob,
+} from "./recovery.mjs";
+
+let orchDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "exec-core-recovery-"));
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// --- helpers --------------------------------------------------------------
+
+// Write a nested phase signal: workers/<T>/phase-<p>.json
+function writeNested(ticket, phase, body) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, ...body }),
+  );
+}
+
+// Write a flat legacy signal: workers/<T>.json
+function writeFlat(ticket, body) {
+  const dir = join(orchDir, "workers");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${ticket}.json`), JSON.stringify({ ticket, ...body }));
+}
+
+// A bg-signal shape as readWorkerSignals produces it.
+const bgSignal = (status, bgJobId) => ({
+  ticket: "CTL-1",
+  phase: "research",
+  status,
+  liveness: { kind: "bg", value: bgJobId },
+  signalPath: "/x/phase-research.json",
+});
+
+// --- classifyWorker — pure given statJob ----------------------------------
+
+describe("classifyWorker", () => {
+  test("terminal status (done/failed/stalled/turn-cap-exhausted) → 'terminal'", () => {
+    for (const status of ["done", "failed", "stalled", "turn-cap-exhausted"]) {
+      expect(
+        classifyWorker(bgSignal(status, "job-x"), { statJob: () => null }),
+      ).toBe("terminal");
+    }
+  });
+
+  test("non-terminal status + bg job dir present → 'running' (re-attached)", () => {
+    expect(
+      classifyWorker(bgSignal("running", "job-a"), {
+        statJob: () => ({ exists: true, mtimeMs: 1, state: "running" }),
+      }),
+    ).toBe("running");
+  });
+
+  test("non-terminal status + bg job dir missing → 'dead' (lost worker)", () => {
+    expect(
+      classifyWorker(bgSignal("running", "job-b"), { statJob: () => null }),
+    ).toBe("dead");
+  });
+
+  test("non-terminal status + bg_job_id null (orphan dispatch) → 'unknown'", () => {
+    expect(
+      classifyWorker(bgSignal("dispatched", null), { statJob: () => null }),
+    ).toBe("unknown");
+  });
+
+  test("flat/legacy pid signal (liveness.kind !== 'bg') → 'unknown'", () => {
+    const pidSignal = {
+      ticket: "CTL-2",
+      phase: 3,
+      status: "implementing",
+      liveness: { kind: "pid", value: 1234 },
+      signalPath: "/x/CTL-2.json",
+    };
+    expect(classifyWorker(pidSignal, { statJob: () => null })).toBe("unknown");
+  });
+
+  test("statJob is never called for a terminal signal (short-circuit)", () => {
+    let called = false;
+    const statJob = () => {
+      called = true;
+      return null;
+    };
+    classifyWorker(bgSignal("done", "job-x"), { statJob });
+    expect(called).toBe(false);
+  });
+
+  test("uses defaultStatJob when no statJob is injected (does not throw)", () => {
+    // bg_job_id null short-circuits to 'unknown' without touching the fs.
+    expect(() => classifyWorker(bgSignal("dispatched", null))).not.toThrow();
+    expect(classifyWorker(bgSignal("dispatched", null))).toBe("unknown");
+  });
+});
+
+// --- reconstructWorkerState — scan + bucket --------------------------------
+
+describe("reconstructWorkerState", () => {
+  test("buckets workers into {running, dead, terminal, unknown} by classification", () => {
+    writeNested("CTL-RUN", "research", { status: "running", bg_job_id: "job-run" });
+    writeNested("CTL-DEAD", "plan", { status: "running", bg_job_id: "job-dead" });
+    // phase-monitor-deploy.json is a signal-reader ARTIFACT, not a signal —
+    // use a regular phase carrying a terminal status to exercise 'terminal'.
+    writeNested("CTL-DONE", "implement", { status: "done", bg_job_id: "job-done" });
+    writeNested("CTL-ORPH", "triage", { status: "dispatched", bg_job_id: null });
+
+    const statJob = (id) => (id === "job-run" ? { exists: true, mtimeMs: 1 } : null);
+    const buckets = reconstructWorkerState(orchDir, { statJob });
+
+    expect(buckets.running.map((w) => w.ticket)).toEqual(["CTL-RUN"]);
+    expect(buckets.dead.map((w) => w.ticket)).toEqual(["CTL-DEAD"]);
+    expect(buckets.terminal.map((w) => w.ticket)).toEqual(["CTL-DONE"]);
+    expect(buckets.unknown.map((w) => w.ticket)).toEqual(["CTL-ORPH"]);
+  });
+
+  test("empty / missing workers dir → all buckets empty (no throw)", () => {
+    let buckets;
+    expect(() => {
+      buckets = reconstructWorkerState(orchDir, { statJob: () => null });
+    }).not.toThrow();
+    expect(buckets).toEqual({ running: [], dead: [], terminal: [], unknown: [] });
+  });
+
+  test("each bucketed worker carries ticket/phase/status/bgJobId/signalPath", () => {
+    writeNested("CTL-RUN", "research", { status: "running", bg_job_id: "job-run" });
+    const buckets = reconstructWorkerState(orchDir, {
+      statJob: () => ({ exists: true, mtimeMs: 1 }),
+    });
+    const w = buckets.running[0];
+    expect(w.ticket).toBe("CTL-RUN");
+    expect(w.phase).toBe("research");
+    expect(w.status).toBe("running");
+    expect(w.bgJobId).toBe("job-run");
+    expect(typeof w.signalPath).toBe("string");
+  });
+
+  test("one nested phase-agent signal per worker is classified once", () => {
+    // readWorkerSignals returns the single active phase per worker dir.
+    writeNested("CTL-A", "research", {
+      status: "done",
+      bg_job_id: "job-old",
+      updatedAt: "2026-05-21T01:00:00Z",
+    });
+    writeNested("CTL-A", "implement", {
+      status: "running",
+      bg_job_id: "job-new",
+      updatedAt: "2026-05-21T02:00:00Z",
+    });
+    const buckets = reconstructWorkerState(orchDir, {
+      statJob: () => ({ exists: true, mtimeMs: 1 }),
+    });
+    const all = [
+      ...buckets.running,
+      ...buckets.dead,
+      ...buckets.terminal,
+      ...buckets.unknown,
+    ];
+    expect(all).toHaveLength(1);
+    expect(all[0].phase).toBe("implement");
+  });
+
+  test("a malformed signal file is skipped, not fatal", () => {
+    writeNested("CTL-OK", "research", { status: "running", bg_job_id: "job-ok" });
+    writeFileSync(
+      join(orchDir, "workers", "CTL-OK", "phase-plan.json"),
+      "{ not json",
+    );
+    let buckets;
+    expect(() => {
+      buckets = reconstructWorkerState(orchDir, {
+        statJob: () => ({ exists: true, mtimeMs: 1 }),
+      });
+    }).not.toThrow();
+    // The valid phase-research signal still classifies.
+    const all = [
+      ...buckets.running,
+      ...buckets.dead,
+      ...buckets.terminal,
+      ...buckets.unknown,
+    ];
+    expect(all).toHaveLength(1);
+  });
+
+  test("a flat legacy signal buckets as 'unknown'", () => {
+    writeFlat("CTL-FLAT", { phase: 3, pid: 999, status: "implementing" });
+    const buckets = reconstructWorkerState(orchDir, { statJob: () => null });
+    expect(buckets.unknown.map((w) => w.ticket)).toEqual(["CTL-FLAT"]);
+    expect(buckets.unknown[0].bgJobId).toBeNull();
+  });
+});
+
+// --- defaultStatJob — real filesystem stat --------------------------------
+
+describe("defaultStatJob", () => {
+  let jobsRoot;
+  let prevJobsRoot;
+
+  beforeEach(() => {
+    prevJobsRoot = process.env.CATALYST_HEALTHCHECK_JOBS_ROOT;
+    jobsRoot = mkdtempSync(join(tmpdir(), "exec-core-jobs-"));
+    process.env.CATALYST_HEALTHCHECK_JOBS_ROOT = jobsRoot;
+  });
+
+  afterEach(() => {
+    if (prevJobsRoot === undefined) delete process.env.CATALYST_HEALTHCHECK_JOBS_ROOT;
+    else process.env.CATALYST_HEALTHCHECK_JOBS_ROOT = prevJobsRoot;
+    rmSync(jobsRoot, { recursive: true, force: true });
+  });
+
+  test("returns null when the job dir is gone", () => {
+    expect(defaultStatJob("no-such-job")).toBeNull();
+  });
+
+  test("returns {exists, mtimeMs, state} when state.json is present", () => {
+    const dir = join(jobsRoot, "job-live");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "state.json"), JSON.stringify({ state: "running" }));
+    const res = defaultStatJob("job-live");
+    expect(res?.exists).toBe(true);
+    expect(typeof res?.mtimeMs).toBe("number");
+    expect(res?.state).toBe("running");
+  });
+
+  test("returns liveness with state:null when state.json is unreadable JSON", () => {
+    const dir = join(jobsRoot, "job-corrupt");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "state.json"), "{ not json");
+    const res = defaultStatJob("job-corrupt");
+    expect(res?.exists).toBe(true);
+    expect(res?.state).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -12,7 +12,11 @@ import {
   classifyWorker,
   reconstructWorkerState,
   defaultStatJob,
+  recoverStartup,
 } from "./recovery.mjs";
+import { saveCursor } from "./event-cursor.mjs";
+import { dropProject } from "./eligible-set.mjs";
+import { existsSync, appendFileSync } from "node:fs";
 
 let orchDir;
 
@@ -246,5 +250,167 @@ describe("defaultStatJob", () => {
     const res = defaultStatJob("job-corrupt");
     expect(res?.exists).toBe(true);
     expect(res?.state).toBeNull();
+  });
+});
+
+// --- recoverStartup — composition (Phase 3) -------------------------------
+
+describe("recoverStartup", () => {
+  let catalystDir;
+  let prevCatalystDir;
+  let enrollmentDir;
+  const enrolledKeys = new Set();
+
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    catalystDir = mkdtempSync(join(tmpdir(), "exec-core-recover-"));
+    process.env.CATALYST_DIR = catalystDir;
+    enrollmentDir = join(catalystDir, "execution-core", "projects");
+    mkdirSync(enrollmentDir, { recursive: true });
+    enrolledKeys.clear();
+  });
+
+  afterEach(() => {
+    for (const k of enrolledKeys) dropProject(k);
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(catalystDir, { recursive: true, force: true });
+  });
+
+  // Stub a repo + enrollment record so reconcileAll has a project to reconcile.
+  function enroll(projectKey, eligibleQuery) {
+    const repoRoot = mkdtempSync(join(catalystDir, `repo-${projectKey}-`));
+    mkdirSync(join(repoRoot, ".catalyst"), { recursive: true });
+    const catalyst = { linear: { teamKey: eligibleQuery?.team ?? "T" } };
+    if (eligibleQuery) catalyst.orchestration = { executionCore: { eligibleQuery } };
+    writeFileSync(
+      join(repoRoot, ".catalyst", "config.json"),
+      JSON.stringify({ catalyst }),
+    );
+    writeFileSync(
+      join(enrollmentDir, `${projectKey}.json`),
+      JSON.stringify({ projectKey, repoRoot }),
+    );
+    enrolledKeys.add(projectKey);
+    return repoRoot;
+  }
+
+  // A mocked linearis exec keyed on the --team flag.
+  function mockExec(nodesByTeam) {
+    return (_cmd, args) => {
+      const team = args[args.indexOf("--team") + 1];
+      return {
+        code: 0,
+        stdout: JSON.stringify({ nodes: nodesByTeam[team] ?? [] }),
+        stderr: "",
+      };
+    };
+  }
+
+  const node = (identifier) => ({
+    identifier,
+    state: { name: "Todo" },
+    priority: 2,
+  });
+
+  // Append a line to the current UTC month's event log.
+  function eventLogPath() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    return join(catalystDir, "events", `${ym}.jsonl`);
+  }
+  function appendEvent(line) {
+    mkdirSync(join(catalystDir, "events"), { recursive: true });
+    appendFileSync(eventLogPath(), line);
+  }
+
+  test("throws when orchDir is missing", () => {
+    expect(() => recoverStartup({})).toThrow(/orchDir is required/);
+  });
+
+  test("rebuilds routing state — eligible projection exists after recoverStartup", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = mockExec({ ENG: [node("ENG-1")] });
+    recoverStartup({ orchDir, exec, statJob: () => null });
+    expect(
+      existsSync(join(catalystDir, "execution-core", "eligible", "alpha.json")),
+    ).toBe(true);
+  });
+
+  test("report.routing carries the enrolled project list", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    enroll("beta", { team: "PLAT", status: "Todo" });
+    const exec = mockExec({ ENG: [], PLAT: [] });
+    const report = recoverStartup({ orchDir, exec, statJob: () => null });
+    expect(report.routing.projectCount).toBe(2);
+    expect([...report.routing.projects].sort()).toEqual(["alpha", "beta"]);
+  });
+
+  test("report.cursor.resumed is true when a valid cursor is saved", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = mockExec({ ENG: [] });
+    appendEvent('{"event":"x"}\n{"event":"y"}\n'); // non-empty log
+    saveCursor({ logPath: eventLogPath(), byteOffset: 0 }); // cursor at start
+    const report = recoverStartup({ orchDir, exec, statJob: () => null });
+    expect(report.cursor.resumed).toBe(true);
+    expect(report.cursor.byteOffset).toBe(0);
+    expect(report.cursor.logPath).toBe(eventLogPath());
+  });
+
+  test("report.cursor.resumed is false when no cursor file exists", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = mockExec({ ENG: [] });
+    appendEvent('{"event":"x"}\n');
+    const report = recoverStartup({ orchDir, exec, statJob: () => null });
+    expect(report.cursor.resumed).toBe(false);
+  });
+
+  test("report.workers carries the running/dead/terminal/unknown buckets", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = mockExec({ ENG: [] });
+    writeNested("CTL-RUN", "research", { status: "running", bg_job_id: "job-run" });
+    writeNested("CTL-DEAD", "plan", { status: "running", bg_job_id: "job-dead" });
+    const report = recoverStartup({
+      orchDir,
+      exec,
+      statJob: (id) => (id === "job-run" ? { exists: true, mtimeMs: 1 } : null),
+    });
+    expect(report.workers.running.map((w) => w.ticket)).toEqual(["CTL-RUN"]);
+    expect(report.workers.dead.map((w) => w.ticket)).toEqual(["CTL-DEAD"]);
+    expect(report.workers.terminal).toEqual([]);
+    expect(report.workers.unknown).toEqual([]);
+  });
+
+  test("report.recoveredAt is an ISO-8601 timestamp", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = mockExec({ ENG: [] });
+    const report = recoverStartup({ orchDir, exec, statJob: () => null });
+    expect(report.recoveredAt).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+    expect(Number.isNaN(Date.parse(report.recoveredAt))).toBe(false);
+  });
+
+  test("a reconcile-poll failure does not abort recovery (routing best-effort)", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    writeNested("CTL-RUN", "research", { status: "running", bg_job_id: "job-run" });
+    // exec returns a non-zero code → runEligibleQuery throws → reconcileProject
+    // swallows it. recoverStartup must still return a report with workers.
+    const failingExec = () => ({ code: 1, stdout: "", stderr: "linearis down" });
+    let report;
+    expect(() => {
+      report = recoverStartup({
+        orchDir,
+        exec: failingExec,
+        statJob: () => ({ exists: true, mtimeMs: 1 }),
+      });
+    }).not.toThrow();
+    expect(report.workers.running.map((w) => w.ticket)).toEqual(["CTL-RUN"]);
+  });
+
+  test("no event log at all → cursor.byteOffset 0, resumed false (poll-only)", () => {
+    enroll("alpha", { team: "ENG", status: "Todo" });
+    const exec = mockExec({ ENG: [] });
+    const report = recoverStartup({ orchDir, exec, statJob: () => null });
+    expect(report.cursor.byteOffset).toBe(0);
+    expect(report.cursor.resumed).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -479,3 +479,75 @@ describe("startScheduler / stopScheduler", () => {
     }).not.toThrow();
   });
 });
+
+// ── CTL-539: idempotent-dispatch proof — re-deriving the tick after a
+// "crash" can never double-dispatch the same {ticket, phase} ──
+
+describe("CTL-539 — idempotent dispatch across a crash", () => {
+  const tk = (id, priority = 2) => ({
+    identifier: id,
+    priority,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+
+  test("re-running schedulerTick after a 'crash' never dispatches the same {ticket,phase} twice", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const eligible = [tk("CTL-9")];
+
+    // Tick 1 — dispatches PHASES[0] (triage) for the ready ticket. The stub
+    // writes the dispatched signal the real phase-agent-dispatch would have
+    // written BEFORE spawning claude --bg (signal-first ordering).
+    const calls = [];
+    const dispatch = (args) => {
+      calls.push(`${args.ticket}:${args.phase}`);
+      writeSignal(args.ticket, args.phase, "dispatched");
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const r1 = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    expect(r1.dispatched).toEqual(["CTL-9"]);
+
+    // "Crash" — the daemon dies; the dispatched signal survives on disk.
+    // Tick 2 (post-restart) re-derives everything from the filesystem.
+    const r2 = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+
+    // CTL-9 now has a worker dir → excluded from the pull. triage:dispatched
+    // is not 'done' → deriveAdvancement returns null. No re-dispatch.
+    expect(r2.dispatched).toEqual([]);
+    expect(r2.advanced).toEqual([]);
+    // Every {ticket,phase} appears exactly once across both ticks.
+    const byKey = new Map();
+    for (const k of calls) byKey.set(k, (byKey.get(k) ?? 0) + 1);
+    expect([...byKey.values()].every((n) => n === 1)).toBe(true);
+    expect(calls).toEqual(["CTL-9:triage"]);
+  });
+
+  test("an orphan 'dispatched' signal (bg_job_id:null) is not re-dispatched", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    // Pre-write the orphan signal a crash mid-dispatch leaves: the signal was
+    // written but claude --bg never spawned, so bg_job_id is null.
+    const dir = join(orchDir, "workers", "CTL-7");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-triage.json"),
+      JSON.stringify({
+        ticket: "CTL-7",
+        phase: "triage",
+        status: "dispatched",
+        bg_job_id: null,
+      }),
+    );
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [tk("CTL-7")],
+      dispatch,
+    });
+    // CTL-7 has a worker dir → excluded from the new-work pull; triage is
+    // dispatched (not done) → nothing owed. The orphan is not re-dispatched.
+    expect(dispatch.calls).toHaveLength(0);
+    expect(r.dispatched).toEqual([]);
+    expect(r.advanced).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the execution-core monitor daemon crash-recoverable. Adds a durable
event-log cursor so the byte-offset tailer resumes from where it left off
instead of re-seeding at EOF on every startup, and adds a startup
reconstruction routine that rebuilds routing state and re-attaches in-flight
`claude --bg` workers after a daemon restart.

Refs: CTL-539

## Changes

### Durable event-log cursor (`event-cursor.mjs`)

- `loadCursor` / `saveCursor` primitives persist `{logPath, byteOffset}` via an
  atomic tmp+rename write. Reads tolerate a missing, corrupt, or malformed
  cursor file by returning `null` so the caller seeds EOF.
- `resolveStartOffset` resolves the offset the tailer should resume from, with
  EOF as the fallback for every failure mode. The cursor is a latency
  optimization only — the periodic reconcile remains the correctness backstop.
- The tailer (`monitor.mjs`) now persists the cursor on every drain and resumes
  from the saved offset on startup, so events that arrived while the daemon was
  down reach the fast path promptly instead of waiting for the next reconcile.

### Startup reconstruction (`recovery.mjs`)

- `recoverStartup` is the recovery contract a composing daemon calls on boot.
  It reconstructs routing state (eligible sets via `reconcileAll`) and
  dispatch/worker state (via the canonical signal reader).
- `classifyWorker` is a pure classification of each in-flight worker's
  liveness — `terminal`, `running` (bg job dir exists → re-attached), `dead`
  (job dir gone → lost worker), or `unknown` (legacy/orphan signal with no
  `bg_job_id`). `defaultStatJob` is injectable so tests never touch real
  Claude job state.

## Testing

- `event-cursor.test.mjs` — cursor load/save round-trip, atomic write, and
  corrupt/malformed/missing fallback paths.
- `recovery.test.mjs` — `classifyWorker` liveness classification and
  `recoverStartup` reconstruction.
- `monitor.test.mjs` — cursor wiring into the tailer drain/resume path.
- `integration.test.mjs` — kill/restart integration test plus an
  idempotent-dispatch proof that a restart resumes mid-run with no lost or
  duplicated workers.

All new modules are leaf/near-leaf and depend only on `config.mjs` and the
existing canonical signal reader.
