### PR TITLE
CTL-566: detectCycles — replace Kahn peel with Tarjan SCC (correctness follow-up to CTL-530)

### DIFF
--- a/plugins/dev/scripts/lib/dependency-graph.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.mjs
@@ -3,7 +3,7 @@
 // Pure execution-core module: data in → data out, no I/O, no imports — a true
 // leaf module (cf. broker/state.mjs). Given Linear issues with their relations
 // it computes the ready set (eligible status AND no unfinished blocker) and
-// detects dependency cycles via a Kahn-style topological pass.
+// detects dependency cycles via Tarjan's strongly-connected-component pass.
 //
 // Canonical directed edge { from, to } means `from` blocks `to`: `to` depends
 // on `from` and cannot start until `from` finishes.
@@ -84,66 +84,74 @@ export function computeReadySet(issues, edges, options = {}) {
   return { ready, blocked };
 }
 
-// detectCycles — find dependency cycles via a Kahn-style topological pass
-// (CTL-530). Source-peel: repeatedly drop indegree-0 nodes (the Kahn pass);
-// survivors are in or downstream of a cycle. Sink-peel: repeatedly drop
-// outdegree-0 survivors; what remains is the set of nodes on a cycle. Those
-// are grouped by weakly-connected component — one anomaly per component.
-// Returns Anomaly[] ordered by first member.
+// detectCycles — find dependency cycles via Tarjan's strongly-connected-
+// component algorithm (CTL-530). Each SCC with more than one node is a cycle;
+// a single-node SCC is a cycle only when that node carries a self-loop edge.
+// A node that merely bridges two cycles — sitting on a one-way path between
+// them — falls into its own singleton SCC and is correctly excluded, and two
+// cycles joined by a one-way edge stay separate anomalies. Returns Anomaly[]
+// ordered by first member.
 export function detectCycles(nodeIds, edges) {
-  const live = new Set(nodeIds ?? []);
-  const liveEdges = (edges ?? []).filter((e) => live.has(e.from) && live.has(e.to));
+  const nodes = [...new Set(nodeIds ?? [])];
+  const nodeSet = new Set(nodes);
 
-  // peel(side): repeatedly delete nodes whose degree on `side` ("to" =
-  // indegree, "from" = outdegree) is 0, recomputed against the shrinking
-  // `live` set so removals cascade.
-  const peel = (side) => {
-    let changed = true;
-    while (changed) {
-      changed = false;
-      const deg = new Map([...live].map((n) => [n, 0]));
-      for (const e of liveEdges) {
-        if (!live.has(e.from) || !live.has(e.to)) continue;
-        deg.set(e[side], deg.get(e[side]) + 1);
-      }
-      for (const [n, d] of deg) {
-        if (d === 0) {
-          live.delete(n);
-          changed = true;
-        }
-      }
-    }
-  };
-  peel("to"); // Kahn source-peel — drop indegree-0 nodes
-  peel("from"); // sink-peel — drop outdegree-0 nodes
-
-  // `live` now holds exactly the nodes on (or bridging) a cycle. Group by
-  // weakly-connected component over the residual subgraph.
-  const adj = new Map([...live].map((n) => [n, new Set()]));
-  for (const e of liveEdges) {
-    if (!live.has(e.from) || !live.has(e.to) || e.from === e.to) continue;
-    adj.get(e.from).add(e.to);
-    adj.get(e.to).add(e.from);
+  // Adjacency over in-set nodes. Self-loops are tracked apart from the
+  // adjacency list so a singleton SCC can still be flagged as a one-issue
+  // cycle; out-of-set and malformed edges are dropped.
+  const adj = new Map(nodes.map((n) => [n, []]));
+  const selfLoop = new Set();
+  for (const e of edges ?? []) {
+    if (!e || !nodeSet.has(e.from) || !nodeSet.has(e.to)) continue;
+    if (e.from === e.to) selfLoop.add(e.from);
+    else adj.get(e.from).push(e.to);
   }
 
-  const anomalies = [];
-  const visited = new Set();
-  for (const start of [...live].sort()) {
-    if (visited.has(start)) continue;
-    const members = [];
-    const queue = [start];
-    visited.add(start);
-    while (queue.length > 0) {
-      const node = queue.shift();
-      members.push(node);
-      for (const peer of adj.get(node)) {
-        if (!visited.has(peer)) {
-          visited.add(peer);
-          queue.push(peer);
-        }
+  // Tarjan's SCC: a single DFS that stamps each node with a discovery `index`
+  // and a `lowlink` (the lowest index reachable from it). A node whose lowlink
+  // equals its own index roots an SCC, which is then popped off the stack.
+  const index = new Map();
+  const lowlink = new Map();
+  const onStack = new Set();
+  const stack = [];
+  const sccs = [];
+  let counter = 0;
+
+  const strongConnect = (v) => {
+    index.set(v, counter);
+    lowlink.set(v, counter);
+    counter += 1;
+    stack.push(v);
+    onStack.add(v);
+    for (const w of adj.get(v)) {
+      if (!index.has(w)) {
+        strongConnect(w);
+        lowlink.set(v, Math.min(lowlink.get(v), lowlink.get(w)));
+      } else if (onStack.has(w)) {
+        lowlink.set(v, Math.min(lowlink.get(v), index.get(w)));
       }
     }
-    members.sort();
+    if (lowlink.get(v) === index.get(v)) {
+      const scc = [];
+      let w;
+      do {
+        w = stack.pop();
+        onStack.delete(w);
+        scc.push(w);
+      } while (w !== v);
+      sccs.push(scc);
+    }
+  };
+  for (const n of nodes) {
+    if (!index.has(n)) strongConnect(n);
+  }
+
+  // An SCC is a cycle when it has multiple members, or a lone member that
+  // links to itself. One anomaly per cycle, members sorted, anomalies ordered
+  // by first member.
+  const anomalies = [];
+  for (const scc of sccs) {
+    if (scc.length === 1 && !selfLoop.has(scc[0])) continue;
+    const members = [...scc].sort();
     anomalies.push({
       type: "dependency_cycle",
       severity: "error",
@@ -154,6 +162,9 @@ export function detectCycles(nodeIds, edges) {
           : `Circular dependency among ${members.length} issues: ${members.join(", ")}.`,
     });
   }
+  anomalies.sort((a, b) =>
+    a.members[0] < b.members[0] ? -1 : a.members[0] > b.members[0] ? 1 : 0
+  );
   return anomalies;
 }
 

--- a/plugins/dev/scripts/lib/dependency-graph.test.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.test.mjs
@@ -335,6 +335,35 @@ describe("detectCycles", () => {
         },
       ],
     },
+    {
+      // Regression for the SCC upgrade: two DISTINCT cycles joined only by a
+      // one-way path stay separate anomalies, and the bridge node (CTL-3 —
+      // indegree 1, outdegree 1, on no cycle) is excluded from both.
+      name: "two cycles joined by a one-way bridge → two anomalies, bridge node excluded",
+      nodes: ["CTL-1", "CTL-2", "CTL-3", "CTL-4", "CTL-5"],
+      edges: [
+        ["CTL-1", "CTL-2"],
+        ["CTL-2", "CTL-1"],
+        ["CTL-2", "CTL-3"],
+        ["CTL-3", "CTL-4"],
+        ["CTL-4", "CTL-5"],
+        ["CTL-5", "CTL-4"],
+      ],
+      expected: [
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-1", "CTL-2"],
+          reason: "Circular dependency among 2 issues: CTL-1, CTL-2.",
+        },
+        {
+          type: "dependency_cycle",
+          severity: "error",
+          members: ["CTL-4", "CTL-5"],
+          reason: "Circular dependency among 2 issues: CTL-4, CTL-5.",
+        },
+      ],
+    },
   ];
 
   for (const c of cases) {


### PR DESCRIPTION
## Summary

Follow-up correctness fix to **CTL-530** (PR #938, merged). Replaces the
`detectCycles` algorithm in `plugins/dev/scripts/lib/dependency-graph.mjs`
with **Tarjan's strongly-connected-component algorithm**.

## The bug

CTL-530 shipped `detectCycles` using a Kahn-style **source-peel + sink-peel**
pass, then grouped survivors by **weakly-connected component**. That residual
set is not the set of nodes on a cycle — every residual node has indegree >= 1
and outdegree >= 1, but that does not imply it lies on a cycle.

A **bridge node** on a one-way path between two cycles survives both peels:

```
detectCycles(['A','B','C','D','X'],  A<->B,  C<->D,  B->X->C)
```

- **Before:** one anomaly, `members: [A,B,C,D,X]` — "Circular dependency among 5 issues"
- **After:** two anomalies `[A,B]` and `[C,D]`; bridge node `X` correctly excluded

Two consequences of the old behavior:
1. Bridge nodes falsely reported as cycle members.
2. Distinct cycles joined by a one-way edge merged into one anomaly with a wrong count.

The CTL-530 plan documented the weakly-connected-component behavior as
intended; CTL-566 records the explicit decision to override it.

## The fix

Tarjan's SCC — a single DFS stamping each node with a discovery `index` and a
`lowlink`. A cycle is an SCC of size > 1, or a size-1 SCC carrying a self-loop
edge. Bridge nodes fall into their own singleton SCC and are excluded;
distinct cycles joined by a one-way edge stay separate anomalies.

## Testing

- All 41 existing `dependency-graph` tests pass unchanged (public API,
  result shape, and ordering all preserved).
- Adds 1 regression test: two cycles joined by a one-way bridge -> two
  anomalies, bridge node excluded.
- `bun test`: **42 pass / 0 fail**. `trunk check`: clean.

## Provenance

Surfaced by the `/catalyst-dev:phase-review` gstack `/review` pass. The
original phase-review for CTL-530 completed and emitted before this was
caught, so PR #938 merged the buggy version — hence this follow-up PR.

Linear: **CTL-566** (relates to CTL-530).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
