### PR TITLE
CTL-565: Execution-core daemon two-state trigger rewiring

### DIFF
--- a/plugins/dev/scripts/execution-core/abort-worker.mjs
+++ b/plugins/dev/scripts/execution-core/abort-worker.mjs
@@ -1,0 +1,122 @@
+// abort-worker.mjs — kill-on-drag-out (CTL-565 Part B, deliverable 4).
+//
+// When a human drags an in-flight ticket out of {Triage, Ready}, the monitor
+// leave-path calls abortWorker. The deterministic guarantee is filesystem-level:
+// every non-terminal phase signal is rewritten status:"aborted", which
+// isTicketInFlight (scheduler.mjs) treats as slot-freeing — the scheduler stops
+// advancing the ticket on its next tick. The bg kill and the worktree teardown
+// are best-effort, behind the injectable killJob / teardownWorktree seams (D9).
+
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { join, basename } from "node:path";
+
+// Signal statuses that mean a phase no longer holds a live worker — left as-is.
+//
+// CROSS-REFERENCE (CTL-565 Refactor note): this set and the
+// failed/stalled/aborted set in scheduler.mjs:isTicketInFlight describe the
+// same lifecycle from two angles but are deliberately NOT the same set and
+// must not be collapsed into one shared constant. A phase mid-advance with
+// `done` is settled-as-a-signal (abort-worker leaves it untouched), but the
+// *ticket* is still in-flight (isTicketInFlight returns true on a non-terminal
+// `done`). The divergence is intentional.
+const SETTLED_STATUSES = new Set(["done", "failed", "stalled", "aborted"]);
+
+// defaultKillJob — best-effort terminate a `claude --bg` job by bg_job_id.
+//
+// IMPLEMENT-TIME VERIFICATION (CTL-565 Assumptions §5): the live `claude` CLI
+// (claude --help) exposes NO bg-job kill subcommand — there is no `claude jobs
+// kill`, and `claude agents` only lists/manages the agent view (`--json`
+// lists live sessions, but offers no kill verb). Per the plan's documented
+// fallback, defaultKillJob is therefore a best-effort no-op that returns false.
+// This is acceptable: the signal-marking in abortWorker already froze
+// scheduler advancement, which is the deterministic guarantee regardless of
+// whether the bg process is reaped. Never throws.
+export function defaultKillJob(bgJobId) {
+  if (!bgJobId) return false;
+  // No `claude` bg-job kill subcommand exists — see the comment above. A future
+  // `claude` release that adds one (or a cloud executor with a real kill API)
+  // swaps this seam via the injectable killJob option.
+  return false;
+}
+
+// defaultTeardownWorktree — `git worktree remove --force` the worker's worktree.
+// Path convention: ~/catalyst/wt/<projectKey>/<orchId>-<ticket>
+// (phase-agent-dispatch). Runs with `-C <repoRoot>` so it works regardless of
+// the daemon's cwd. Never throws.
+export function defaultTeardownWorktree({ projectKey, orchId, ticket, repoRoot }) {
+  if (!projectKey || !orchId || !ticket || !repoRoot) return false;
+  const wt = join(process.env.HOME ?? "", "catalyst", "wt", projectKey, `${orchId}-${ticket}`);
+  const res = spawnSync("git", ["-C", repoRoot, "worktree", "remove", "--force", wt], {
+    encoding: "utf8",
+  });
+  return !res.error && (res.status ?? 1) === 0;
+}
+
+// abortWorker — abort an in-flight ticket dragged out of {Triage, Ready}.
+// Returns { aborted, signalsMarked, jobsKilled, worktreeRemoved }. A ticket
+// that was never dispatched (no worker dir) or has only settled signals is a
+// clean no-op — no kill, no teardown.
+export function abortWorker(
+  orchDir,
+  ticket,
+  {
+    projectKey,
+    repoRoot,
+    killJob = defaultKillJob,
+    teardownWorktree = defaultTeardownWorktree,
+  } = {},
+) {
+  const empty = { aborted: false, signalsMarked: [], jobsKilled: [], worktreeRemoved: false };
+  const dir = join(orchDir, "workers", ticket);
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return empty; // no worker dir — never dispatched — no-op
+  }
+
+  const signalsMarked = [];
+  const jobIds = new Set();
+  for (const f of files) {
+    const m = /^phase-(.+)\.json$/.exec(f);
+    if (!m) continue;
+    let signal;
+    try {
+      signal = JSON.parse(readFileSync(join(dir, f), "utf8"));
+    } catch {
+      continue; // unreadable / malformed signal — skip
+    }
+    if (SETTLED_STATUSES.has(signal?.status)) continue; // already settled — leave it
+    if (signal?.bg_job_id) jobIds.add(signal.bg_job_id);
+    const updated = { ...signal, status: "aborted", abortedAt: new Date().toISOString() };
+    try {
+      const tmp = join(dir, `${f}.tmp.${process.pid}`);
+      writeFileSync(tmp, `${JSON.stringify(updated, null, 2)}\n`);
+      renameSync(tmp, join(dir, f)); // atomic — the signal is the source of truth
+      signalsMarked.push(m[1]);
+    } catch {
+      /* unwritable signal — skip; other signals still mark */
+    }
+  }
+  if (signalsMarked.length === 0) return empty; // nothing in-flight — no-op
+
+  const jobsKilled = [];
+  for (const id of jobIds) {
+    try {
+      if (killJob(id)) jobsKilled.push(id);
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  let worktreeRemoved = false;
+  try {
+    worktreeRemoved =
+      teardownWorktree({ projectKey, orchId: basename(orchDir), ticket, repoRoot }) === true;
+  } catch {
+    /* best-effort */
+  }
+
+  return { aborted: true, signalsMarked, jobsKilled, worktreeRemoved };
+}

--- a/plugins/dev/scripts/execution-core/abort-worker.test.mjs
+++ b/plugins/dev/scripts/execution-core/abort-worker.test.mjs
@@ -1,0 +1,122 @@
+// Unit tests for the kill-on-drag-out abort module (CTL-565 Phase 4).
+// Run: cd plugins/dev/scripts/execution-core && bun test abort-worker.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, basename } from "node:path";
+import { abortWorker } from "./abort-worker.mjs";
+
+let orchDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "abort-worker-"));
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// writeSignal — write workers/<ticket>/phase-<phase>.json with the given body.
+function writeSignal(ticket, phase, body) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify(body));
+}
+
+// readSignal — parse a worker's phase-<phase>.json back.
+function readSignal(ticket, phase) {
+  return JSON.parse(
+    readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"),
+  );
+}
+
+describe("abortWorker", () => {
+  test("rewrites every non-terminal phase signal to status 'aborted'", () => {
+    writeSignal("CTL-1", "research", { status: "done" });
+    writeSignal("CTL-1", "plan", { status: "running" });
+    const r = abortWorker(orchDir, "CTL-1", {
+      killJob: () => {},
+      teardownWorktree: () => true,
+    });
+    expect(r.signalsMarked).toEqual(["plan"]); // 'research' (done) left untouched
+    expect(readSignal("CTL-1", "plan").status).toBe("aborted");
+    expect(readSignal("CTL-1", "research").status).toBe("done");
+  });
+
+  test("calls killJob once per distinct bg_job_id", () => {
+    writeSignal("CTL-1", "plan", { status: "running", bg_job_id: "abc" });
+    const killed = [];
+    abortWorker(orchDir, "CTL-1", {
+      killJob: (id) => killed.push(id),
+      teardownWorktree: () => true,
+    });
+    expect(killed).toEqual(["abc"]);
+  });
+
+  test("calls teardownWorktree once with the derived coordinates", () => {
+    writeSignal("CTL-1", "plan", { status: "running" });
+    const calls = [];
+    abortWorker(orchDir, "CTL-1", {
+      projectKey: "catalyst",
+      repoRoot: "/repo",
+      killJob: () => {},
+      teardownWorktree: (a) => {
+        calls.push(a);
+        return true;
+      },
+    });
+    expect(calls).toEqual([
+      { projectKey: "catalyst", orchId: basename(orchDir), ticket: "CTL-1", repoRoot: "/repo" },
+    ]);
+  });
+
+  test("a ticket with no worker dir is a clean no-op", () => {
+    const r = abortWorker(orchDir, "CTL-NOPE", {
+      killJob: () => {
+        throw new Error("x");
+      },
+      teardownWorktree: () => {
+        throw new Error("x");
+      },
+    });
+    expect(r).toMatchObject({ aborted: false, signalsMarked: [] });
+  });
+
+  test("a ticket whose every signal is already terminal is a no-op (no kill, no teardown)", () => {
+    writeSignal("CTL-DONE", "research", { status: "done" });
+    writeSignal("CTL-DONE", "monitor-deploy", { status: "done" });
+    let teardownCalled = false;
+    const r = abortWorker(orchDir, "CTL-DONE", {
+      killJob: () => {},
+      teardownWorktree: () => {
+        teardownCalled = true;
+        return true;
+      },
+    });
+    expect(r.aborted).toBe(false);
+    expect(teardownCalled).toBe(false);
+  });
+
+  test("a throwing killJob / teardownWorktree never propagates — signals still marked", () => {
+    writeSignal("CTL-1", "plan", { status: "running" });
+    const r = abortWorker(orchDir, "CTL-1", {
+      killJob: () => {
+        throw new Error("kill boom");
+      },
+      teardownWorktree: () => {
+        throw new Error("teardown boom");
+      },
+    });
+    expect(r.aborted).toBe(true);
+    expect(readSignal("CTL-1", "plan").status).toBe("aborted"); // marking survives the throws
+  });
+
+  test("stamps an abortedAt ISO timestamp on a marked signal", () => {
+    writeSignal("CTL-1", "implement", { status: "running" });
+    abortWorker(orchDir, "CTL-1", { killJob: () => {}, teardownWorktree: () => true });
+    const signal = readSignal("CTL-1", "implement");
+    expect(typeof signal.abortedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(signal.abortedAt))).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -62,7 +62,10 @@ export function startDaemon({
   _stopScheduler = stopSchedulerFn;
 
   recover({ orchDir }); // CTL-539 — rebuild routing + worker state on boot
-  monitorFn(); // CTL-535 — Todo-state monitor + event tailer
+  // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
+  // agent on a →Triage transition. `dispatch` stays an injectable default
+  // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
+  monitorFn({ orchDir }); // CTL-535 + CTL-565 — two-state trigger monitor
   schedulerFn({ orchDir }); // CTL-536 — pull-loop scheduler
 
   if (watchEnrollment) {

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -1,0 +1,34 @@
+// dispatch.mjs — execution-core worker-dispatch adapter (CTL-565).
+//
+// The single executor seam (D9): the trigger/state layer emits a phase-owed
+// intent { orchDir, ticket, phase }; the executor is pluggable. defaultDispatch
+// shells out to orchestrate-dispatch-next (local claude --bg); a cloud fork
+// swaps the injected dispatch function at one call site.
+//
+// Extracted from scheduler.mjs so both the scheduler's pull loop AND the
+// monitor's →Triage one-shot dispatch share one adapter — they must not each
+// hardcode their own shell-out.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// orchestrate-dispatch-next sits one directory up from execution-core/.
+const DISPATCH_BIN = fileURLToPath(new URL("../orchestrate-dispatch-next", import.meta.url));
+
+// defaultDispatch — shell out to orchestrate-dispatch-next, which delegates to
+// phase-agent-dispatch (idempotent: an existing dispatched/running/done signal
+// is a no-op). Injected in tests so no test ever spawns a real worker.
+export function defaultDispatch({ orchDir, ticket, phase }) {
+  const res = spawnSync(
+    DISPATCH_BIN,
+    ["--orch-dir", orchDir, "--ticket", ticket, "--phase", phase],
+    { encoding: "utf8" },
+  );
+  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
+  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// dispatchTicket — thin seam over the injectable dispatch function.
+export function dispatchTicket(orchDir, ticket, phase, { dispatch = defaultDispatch } = {}) {
+  return dispatch({ orchDir, ticket, phase });
+}

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -1,0 +1,23 @@
+// Unit tests for the shared worker-dispatch adapter (CTL-565 Phase 1).
+// Run: cd plugins/dev/scripts/execution-core && bun test dispatch.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { dispatchTicket } from "./dispatch.mjs";
+
+describe("dispatchTicket", () => {
+  test("delegates to the injected dispatch function with orchDir/ticket/phase", () => {
+    const calls = [];
+    const dispatch = (args) => {
+      calls.push(args);
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const r = dispatchTicket("/orch", "CTL-1", "triage", { dispatch });
+    expect(calls).toEqual([{ orchDir: "/orch", ticket: "CTL-1", phase: "triage" }]);
+    expect(r.code).toBe(0);
+  });
+
+  test("surfaces a non-zero dispatch code without throwing", () => {
+    const dispatch = () => ({ code: 7, stdout: "", stderr: "boom" });
+    expect(dispatchTicket("/orch", "CTL-1", "research", { dispatch }).code).toBe(7);
+  });
+});

--- a/plugins/dev/scripts/execution-core/enrollment.mjs
+++ b/plugins/dev/scripts/execution-core/enrollment.mjs
@@ -90,6 +90,10 @@ export function loadProjectConfig(repoRoot) {
   return {
     team: eligibleQuery.team ?? catalyst?.linear?.teamKey ?? null,
     status: eligibleQuery.status ?? "Todo",
+    // CTL-565: the Linear state whose →transition one-shot-dispatches the
+    // triage phase agent. Distinct from `status` (the scheduler-eligible
+    // state). Defaults to "Triage".
+    triageStatus: eligibleQuery.triageStatus ?? "Triage",
     project: eligibleQuery.project ?? null,
     label: eligibleQuery.label ?? null,
     priority: eligibleQuery.priority ?? null,

--- a/plugins/dev/scripts/execution-core/enrollment.test.mjs
+++ b/plugins/dev/scripts/execution-core/enrollment.test.mjs
@@ -136,6 +136,7 @@ describe("loadProjectConfig", () => {
     expect(q).toEqual({
       team: "ENG",
       status: "Todo",
+      triageStatus: "Triage",
       project: "Platform",
       label: "ready",
       priority: 2,
@@ -173,6 +174,28 @@ describe("loadProjectConfig", () => {
     expect(q.project).toBeNull();
     expect(q.label).toBeNull();
     expect(q.priority).toBeNull();
+  });
+
+  test("defaults triageStatus to 'Triage' when absent (CTL-565)", () => {
+    const repoRoot = writeRepo({
+      linear: { teamKey: "ENG" },
+      orchestration: {
+        executionCore: { eligibleQuery: { team: "ENG", status: "Ready" } },
+      },
+    });
+    expect(loadProjectConfig(repoRoot).triageStatus).toBe("Triage");
+  });
+
+  test("honors an explicit eligibleQuery.triageStatus override (CTL-565)", () => {
+    const repoRoot = writeRepo({
+      linear: { teamKey: "ENG" },
+      orchestration: {
+        executionCore: {
+          eligibleQuery: { team: "ENG", status: "Ready", triageStatus: "Intake" },
+        },
+      },
+    });
+    expect(loadProjectConfig(repoRoot).triageStatus).toBe("Intake");
   });
 
   test("returns null (project skipped) when executionCore.eligibleQuery is absent", () => {

--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -17,8 +17,10 @@ export * from "./config.mjs";
 export * from "./enrollment.mjs";
 export * from "./linear-query.mjs";
 export * from "./eligible-set.mjs";
-// CTL-565: the shared worker-dispatch adapter (D9 executor seam).
+// CTL-565: the shared worker-dispatch adapter (D9 executor seam) and the
+// kill-on-drag-out abort module.
 export * from "./dispatch.mjs";
+export * from "./abort-worker.mjs";
 // monitor.mjs is re-exported explicitly so the test-only __resetForTests
 // helper stays out of the public barrel.
 export {

--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -42,6 +42,7 @@ export {
   selectDispatchable,
   deriveAdvancement,
   readAllEligibleTickets,
+  hydrateOutOfSetBlockers,
 } from "./scheduler.mjs";
 
 // --- CTL-539: crash-recovery & startup reconstruction --------------------

--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -17,6 +17,8 @@ export * from "./config.mjs";
 export * from "./enrollment.mjs";
 export * from "./linear-query.mjs";
 export * from "./eligible-set.mjs";
+// CTL-565: the shared worker-dispatch adapter (D9 executor seam).
+export * from "./dispatch.mjs";
 // monitor.mjs is re-exported explicitly so the test-only __resetForTests
 // helper stays out of the public barrel.
 export {

--- a/plugins/dev/scripts/execution-core/integration.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration.test.mjs
@@ -269,8 +269,9 @@ describe("execution-core integration — crash recovery (CTL-539)", () => {
       debounceMs: 5,
     });
     // startScheduler ran one tick → ENG-NEW (the eligible ready ticket) was
-    // dispatched into a free slot.
-    expect(dispatchCalls).toContain("ENG-NEW:triage");
+    // dispatched into a free slot at the research entry phase (CTL-565: a Ready
+    // ticket is already triaged, so new work enters at research, not triage).
+    expect(dispatchCalls).toContain("ENG-NEW:research");
 
     // An event lands; drain the tailer deterministically (fs.watch is flaky).
     appendEventLog(stateChangedLine("ENG-NEW", "ENG", "Todo"));
@@ -339,8 +340,8 @@ describe("execution-core integration — crash recovery (CTL-539)", () => {
     for (const k of dispatchCalls) byKey.set(k, (byKey.get(k) ?? 0) + 1);
     const duplicates = [...byKey.entries()].filter(([, n]) => n > 1);
     expect(duplicates).toEqual([]);
-    // ENG-NEW:triage in particular is never re-dispatched after the restart.
-    expect(byKey.get("ENG-NEW:triage")).toBe(1);
+    // ENG-NEW:research in particular is never re-dispatched after the restart.
+    expect(byKey.get("ENG-NEW:research")).toBe(1);
 
     rmSync(orchDir, { recursive: true, force: true });
   });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -71,6 +71,23 @@ function normalizeTicket(node) {
   };
 }
 
+// fetchTicketState — the current Linear workflow-state name of one ticket, or
+// null on any failure (the D5 caller fails safe: a null state holds the
+// dependent back). Wraps `linearis issues read <identifier>`; linearis emits
+// JSON by default (its CLI header: "CLI for Linear.app with JSON output") so
+// there is NO --json flag to pass. Used to hydrate out-of-set blocker states
+// the bulk eligible query cannot see. CTL-565 D5.
+export function fetchTicketState(identifier, { exec = defaultExec } = {}) {
+  const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+  if (code !== 0) return null;
+  try {
+    const node = JSON.parse(stdout);
+    return node?.state?.name ?? node?.state ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // runEligibleQuery — run the query, parse + normalize, apply the priority
 // floor. A non-zero linearis exit THROWS (never a silent []): a silent empty
 // would let one failed poll flatten a project's eligible set to zero. The

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -2,7 +2,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test linear-query.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { buildLinearisArgs, runEligibleQuery } from "./linear-query.mjs";
+import { buildLinearisArgs, runEligibleQuery, fetchTicketState } from "./linear-query.mjs";
 
 // A fake exec returning a canned linearis result. `exec(cmd, args)` ->
 // { code, stdout, stderr } — the injectable seam runEligibleQuery uses so a
@@ -170,5 +170,42 @@ describe("runEligibleQuery", () => {
     const t = runEligibleQuery(query, { exec })[0];
     expect(t.relations).toEqual(relations);
     expect(t.inverseRelations).toEqual({ nodes: [] });
+  });
+});
+
+// CTL-565 D5 — fetchTicketState wraps `linearis issues read <id>` to hydrate
+// an out-of-set blocker's live Linear state. linearis emits JSON by default
+// (its header: "CLI for Linear.app with JSON output") — no --json flag exists.
+describe("fetchTicketState", () => {
+  test("runs `linearis issues read <id>` and returns the state name", () => {
+    const exec = (cmd, args) => {
+      expect(cmd).toBe("linearis");
+      expect(args).toEqual(["issues", "read", "CTL-99"]);
+      return {
+        code: 0,
+        stdout: JSON.stringify({ identifier: "CTL-99", state: { name: "Backlog" } }),
+        stderr: "",
+      };
+    };
+    expect(fetchTicketState("CTL-99", { exec })).toBe("Backlog");
+  });
+
+  test("returns null on a non-zero linearis exit (caller fails safe)", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "not found" });
+    expect(fetchTicketState("CTL-99", { exec })).toBeNull();
+  });
+
+  test("returns null on unparseable stdout", () => {
+    const exec = () => ({ code: 0, stdout: "not json", stderr: "" });
+    expect(fetchTicketState("CTL-99", { exec })).toBeNull();
+  });
+
+  test("accepts a flat string `state` field too", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-99", state: "Done" }),
+      stderr: "",
+    });
+    expect(fetchTicketState("CTL-99", { exec })).toBe("Done");
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -24,6 +24,7 @@ import { runEligibleQuery } from "./linear-query.mjs";
 import { setProjectEligible, removeTicket, dropProject } from "./eligible-set.mjs";
 import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { dispatchTicket } from "./dispatch.mjs";
+import { abortWorker as defaultAbortWorker } from "./abort-worker.mjs";
 
 // --- Event parsing -------------------------------------------------------
 
@@ -124,7 +125,13 @@ const dirtyTimers = new Map();
 //   anything else   the leave-path — a confident immediate removal.
 export function handleStateChangedEvent(
   event,
-  { exec, debounceMs = EVENT_DEBOUNCE_MS, dispatch, orchDir } = {},
+  {
+    exec,
+    debounceMs = EVENT_DEBOUNCE_MS,
+    dispatch,
+    orchDir,
+    abortWorker = defaultAbortWorker,
+  } = {},
 ) {
   const parsed = parseStateChangedEvent(event);
   if (!parsed) return;
@@ -143,10 +150,17 @@ export function handleStateChangedEvent(
       // it so a burst of events coalesces into one reconcile.
       scheduleDirtyReconcile(p.projectKey, p.repoRoot, { exec, debounceMs });
     } else {
-      // Left both watched states — a confident immediate removal. removeTicket
-      // persists the projection itself; removing a non-member is a safe no-op.
+      // Left both watched states (→Backlog/→Canceled). Confident immediate
+      // removal, then abort any in-flight worker and tear down its worktree.
+      // removeTicket persists the projection itself; removing a non-member is
+      // a safe no-op. abortWorker no-ops when the ticket was never dispatched.
       removeTicket(p.projectKey, parsed.identifier);
-      // Phase 4 attaches the kill-on-drag-out abort hook here.
+      if (orchDir) {
+        abortWorker(orchDir, parsed.identifier, {
+          projectKey: p.projectKey,
+          repoRoot: p.repoRoot,
+        });
+      }
     }
   }
 }
@@ -305,10 +319,13 @@ export function startMonitor({
   resumeFromCursor = true,
   orchDir,
   dispatch,
+  abortWorker,
 } = {}) {
-  // CTL-565: orchDir + dispatch are stored in tailerOpts so the tailer-driven
-  // readNewEvents → handleStateChangedEvent path can one-shot-dispatch triage.
-  tailerOpts = { exec, debounceMs, orchDir, dispatch };
+  // CTL-565: orchDir + dispatch + abortWorker are stored in tailerOpts so the
+  // tailer-driven readNewEvents → handleStateChangedEvent path can one-shot-
+  // dispatch triage and abort a dragged-out worker. When abortWorker is left
+  // undefined, handleStateChangedEvent falls back to its real default.
+  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker };
   reconcileAll({ exec });
   if (resumeFromCursor) {
     seedTailerFromCursor();

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -23,6 +23,7 @@ import { listEnrolledProjects, loadProjectConfig } from "./enrollment.mjs";
 import { runEligibleQuery } from "./linear-query.mjs";
 import { setProjectEligible, removeTicket, dropProject } from "./eligible-set.mjs";
 import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
+import { dispatchTicket } from "./dispatch.mjs";
 
 // --- Event parsing -------------------------------------------------------
 
@@ -115,25 +116,52 @@ const dirtyTimers = new Map();
 
 // handleStateChangedEvent — fold one state_changed event into the eligible
 // sets of every project whose query team matches the event's team.
+//
+// CTL-565 two-state trigger: the toState branch is a three-way split.
+//   →triageStatus  one-shot-dispatches the triage phase agent (NOT the
+//                  eligible set — a Triage ticket is never scheduler-pulled).
+//   →status (Ready) reconciles into the scheduler-eligible set.
+//   anything else   the leave-path — a confident immediate removal.
 export function handleStateChangedEvent(
   event,
-  { exec, debounceMs = EVENT_DEBOUNCE_MS } = {},
+  { exec, debounceMs = EVENT_DEBOUNCE_MS, dispatch, orchDir } = {},
 ) {
   const parsed = parseStateChangedEvent(event);
   if (!parsed) return;
   for (const p of listEnrolledProjects()) {
     const query = loadProjectConfig(p.repoRoot);
     if (!query || query.team !== parsed.teamKey) continue;
-    if (parsed.toState && parsed.toState !== query.status) {
-      // Left the eligible state — a confident immediate removal. removeTicket
-      // persists the projection itself; removing a non-member is a safe no-op.
-      removeTicket(p.projectKey, parsed.identifier);
-    } else {
-      // Entered (or an unknown new state) — the event cannot confirm
+
+    if (parsed.toState === query.triageStatus) {
+      // →Triage — one-shot dispatch the triage phase agent. NOT the eligible
+      // set: a Triage ticket is never scheduler-pulled. Idempotent downstream
+      // (phase-agent-dispatch no-ops an existing signal file).
+      dispatchTriage(parsed.identifier, { dispatch, orchDir });
+    } else if (!parsed.toState || parsed.toState === query.status) {
+      // →Ready (or an unknown new state) — the event cannot confirm
       // project/label/priority scoping, so a full poll is required. Debounce
       // it so a burst of events coalesces into one reconcile.
       scheduleDirtyReconcile(p.projectKey, p.repoRoot, { exec, debounceMs });
+    } else {
+      // Left both watched states — a confident immediate removal. removeTicket
+      // persists the projection itself; removing a non-member is a safe no-op.
+      removeTicket(p.projectKey, parsed.identifier);
+      // Phase 4 attaches the kill-on-drag-out abort hook here.
     }
+  }
+}
+
+// dispatchTriage — fire the triage phase agent for a →Triage transition. Guards
+// a missing orchDir (a standalone monitor with no daemon wiring) and logs —
+// never throws — a non-zero dispatch.
+function dispatchTriage(identifier, { dispatch, orchDir }) {
+  if (!orchDir) {
+    log.warn({ identifier }, "→Triage seen but monitor has no orchDir — skipping dispatch");
+    return;
+  }
+  const r = dispatchTicket(orchDir, identifier, "triage", { dispatch });
+  if (r.code !== 0) {
+    log.warn({ identifier, code: r.code }, "monitor: triage dispatch failed");
   }
 }
 
@@ -275,8 +303,12 @@ export function startMonitor({
   debounceMs = EVENT_DEBOUNCE_MS,
   reconcileIntervalMs = RECONCILE_INTERVAL_MS,
   resumeFromCursor = true,
+  orchDir,
+  dispatch,
 } = {}) {
-  tailerOpts = { exec, debounceMs };
+  // CTL-565: orchDir + dispatch are stored in tailerOpts so the tailer-driven
+  // readNewEvents → handleStateChangedEvent path can one-shot-dispatch triage.
+  tailerOpts = { exec, debounceMs, orchDir, dispatch };
   reconcileAll({ exec });
   if (resumeFromCursor) {
     seedTailerFromCursor();

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -314,6 +314,54 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
     ).not.toThrow();
     expect(dispatch).not.toHaveBeenCalled();
   });
+
+  test("a drag-out (toState neither Triage nor Ready) invokes abortWorker", () => {
+    enroll("alpha", { team: "ENG", status: "Ready" });
+    const abortWorker = mock(() => ({ aborted: true }));
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Backlog" },
+      },
+      { orchDir, abortWorker },
+    );
+    expect(abortWorker).toHaveBeenCalledWith("/orch", "ENG-1", {
+      projectKey: expect.any(String),
+      repoRoot: expect.any(String),
+    });
+  });
+
+  test("a drag-out still removes the ticket from the eligible projection", () => {
+    enroll("alpha", { team: "ENG", status: "Ready" });
+    setProjectEligible("alpha", [node("ENG-1"), node("ENG-2")], {
+      source: "reconcile",
+      query: { team: "ENG", status: "Ready" },
+    });
+    const abortWorker = mock(() => ({ aborted: true }));
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Canceled" },
+      },
+      { orchDir, abortWorker },
+    );
+    expect(getEligibleSet("alpha").map((t) => t.identifier)).toEqual(["ENG-2"]);
+  });
+
+  test("a drag-out with no orchDir wired removes the ticket and does not throw", () => {
+    enroll("alpha", { team: "ENG", status: "Ready" });
+    const abortWorker = mock(() => ({ aborted: true }));
+    expect(() =>
+      handleStateChangedEvent(
+        {
+          event: "linear.issue.state_changed",
+          detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Backlog" },
+        },
+        { abortWorker },
+      ),
+    ).not.toThrow();
+    expect(abortWorker).not.toHaveBeenCalled(); // no orchDir → abort skipped
+  });
 });
 
 describe("lifecycle", () => {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1,7 +1,7 @@
 // Unit tests for the execution-core monitor core (CTL-535 Phase 4).
 // Run: cd plugins/dev/scripts/execution-core && bun test monitor.test.mjs
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   mkdtempSync,
   rmSync,
@@ -236,6 +236,83 @@ describe("handleStateChangedEvent", () => {
     await sleep(60);
     expect(exec.calls).toBe(0);
     expect(getEligibleSet("alpha").map((t) => t.identifier)).toEqual(["ENG-1"]);
+  });
+});
+
+// --- CTL-565 Phase 1: three-way toState split + triage one-shot dispatch -----
+
+describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
+  const orchDir = "/orch";
+
+  test("toState === triageStatus one-shot-dispatches the triage phase agent", () => {
+    enroll("alpha", { team: "ENG", status: "Ready" }); // triageStatus defaults to "Triage"
+    const dispatch = mock(() => ({ code: 0 }));
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
+      },
+      { dispatch, orchDir },
+    );
+    expect(dispatch).toHaveBeenCalledWith({ orchDir, ticket: "ENG-1", phase: "triage" });
+  });
+
+  test("toState === eligible status (Ready) schedules a reconcile, never a triage dispatch", async () => {
+    enroll("alpha", { team: "ENG", status: "Ready" });
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    const dispatch = mock(() => ({ code: 0 }));
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Ready" },
+      },
+      { exec, dispatch, orchDir, debounceMs: 30 },
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+    await sleep(70);
+    expect(exec.calls).toBe(1); // the debounced reconcile ran
+  });
+
+  test("toState that is neither Triage nor Ready fast-path-removes the ticket", () => {
+    enroll("alpha", { team: "ENG", status: "Ready" });
+    setProjectEligible("alpha", [node("ENG-1"), node("ENG-2")], {
+      source: "reconcile",
+      query: { team: "ENG", status: "Ready" },
+    });
+    handleStateChangedEvent({
+      event: "linear.issue.state_changed",
+      detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Backlog" },
+    });
+    expect(getEligibleSet("alpha").map((t) => t.identifier)).toEqual(["ENG-2"]);
+  });
+
+  test("a triage dispatch failure is logged and never throws", () => {
+    enroll("alpha", { team: "ENG", status: "Ready" });
+    const dispatch = () => ({ code: 9, stderr: "x" });
+    expect(() =>
+      handleStateChangedEvent(
+        {
+          event: "linear.issue.state_changed",
+          detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
+        },
+        { dispatch, orchDir },
+      ),
+    ).not.toThrow();
+  });
+
+  test("a →Triage transition with no orchDir wired does not throw or dispatch", () => {
+    enroll("alpha", { team: "ENG", status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    expect(() =>
+      handleStateChangedEvent(
+        {
+          event: "linear.issue.state_changed",
+          detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
+        },
+        { dispatch },
+      ),
+    ).not.toThrow();
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -61,14 +61,19 @@ export function readPhaseSignals(orchDir, ticket) {
 
 // isTicketInFlight — true when a ticket still occupies a worker slot. Pure over
 // a phase→status map. In-flight = has ≥1 signal AND is neither pipeline-complete
-// (monitor-deploy done) nor failed/stalled. A ticket mid-advance (plan done, no
-// later signal yet) is still in-flight — correct slot accounting through the
-// advance window.
+// (monitor-deploy done) nor failed/stalled/aborted. A ticket mid-advance (plan
+// done, no later signal yet) is still in-flight — correct slot accounting
+// through the advance window.
+//
+// CROSS-REFERENCE (CTL-565): the failed/stalled/aborted set here is NOT the
+// same as SETTLED_STATUSES in abort-worker.mjs — a non-terminal `done` is
+// settled-as-a-signal there but still in-flight here. The divergence is
+// intentional; do not collapse the two into one shared constant.
 export function isTicketInFlight(signals) {
   const phases = Object.keys(signals ?? {});
   if (phases.length === 0) return false;
   for (const [phase, status] of Object.entries(signals)) {
-    if (status === "failed" || status === "stalled") return false;
+    if (status === "failed" || status === "stalled" || status === "aborted") return false;
     if (phase === TERMINAL_PHASE && status === "done") return false;
   }
   return true;

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -30,6 +30,12 @@ import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
 // phase, not just the status.
 const TERMINAL_PHASE = "monitor-deploy";
 
+// New work enters the pipeline at `research`: a Ready ticket has already been
+// triaged (the →Triage watcher dispatched its triage agent — monitor.mjs). The
+// scheduler never dispatches `triage`. CTL-565 Part B. Deliberately NOT
+// PHASES[0] ("triage"); the FSM still owns chaining research → plan → … .
+const NEW_WORK_ENTRY_PHASE = "research";
+
 // readPhaseSignals — { phase: status } for one ticket's workers/<T>/phase-*.json.
 export function readPhaseSignals(orchDir, ticket) {
   const dir = join(orchDir, "workers", ticket);
@@ -236,7 +242,7 @@ export function schedulerTick(orchDir, { readEligible, dispatch = defaultDispatc
 
   const dispatched = [];
   for (const t of selected) {
-    const r = dispatchTicket(orchDir, t.identifier, PHASES[0], { dispatch });
+    const r = dispatchTicket(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, { dispatch });
     if (r.code === 0) dispatched.push(t.identifier);
     else log.warn({ ticket: t.identifier, code: r.code }, "scheduler: dispatch failed");
   }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -14,12 +14,14 @@
 // lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
 
 import { readdirSync, readFileSync, watch, mkdirSync } from "node:fs";
-import { spawnSync } from "node:child_process";
 import { join, dirname, basename } from "node:path";
-import { fileURLToPath } from "node:url";
 import { analyzeDependencyGraph } from "../lib/dependency-graph.mjs";
+// PHASES is still imported for deriveAdvancement; CTL-565 note: PHASES[0]
+// ("triage") is intentionally NO LONGER the new-work entry phase — new work
+// enters at NEW_WORK_ENTRY_PHASE ("research"), see schedulerTick.
 import { PHASES, transition, isTerminal } from "../lib/phase-fsm.mjs";
 import { rankTickets } from "./scheduler-rank.mjs";
+import { defaultDispatch, dispatchTicket } from "./dispatch.mjs";
 import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
@@ -140,27 +142,9 @@ export function selectDispatchable(rankedReady, excludeTickets, freeSlots) {
 }
 
 // ─── Phase 4: dispatch and FSM-driven phase advancement ───
-
-// orchestrate-dispatch-next sits one directory up from execution-core/.
-const DISPATCH_BIN = fileURLToPath(new URL("../orchestrate-dispatch-next", import.meta.url));
-
-// defaultDispatch — shell out to orchestrate-dispatch-next, which delegates to
-// phase-agent-dispatch (idempotent: an existing dispatched/running/done signal
-// is a no-op). Injected in tests so no test ever spawns a real worker.
-function defaultDispatch({ orchDir, ticket, phase }) {
-  const res = spawnSync(
-    DISPATCH_BIN,
-    ["--orch-dir", orchDir, "--ticket", ticket, "--phase", phase],
-    { encoding: "utf8" }
-  );
-  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
-  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
-}
-
-// dispatchTicket — thin seam over the injectable dispatch function.
-export function dispatchTicket(orchDir, ticket, phase, { dispatch = defaultDispatch } = {}) {
-  return dispatch({ orchDir, ticket, phase });
-}
+//
+// The dispatch adapter (defaultDispatch / dispatchTicket) lives in dispatch.mjs
+// (CTL-565) so the monitor's →Triage one-shot dispatch shares the same seam.
 
 // listStartedTickets — every ticket that already has a worker dir, in any
 // status. The pull step excludes these so a finished/failed ticket is never

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -15,13 +15,14 @@
 
 import { readdirSync, readFileSync, watch, mkdirSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
-import { analyzeDependencyGraph } from "../lib/dependency-graph.mjs";
+import { analyzeDependencyGraph, referencedBlockerIds } from "../lib/dependency-graph.mjs";
 // PHASES is still imported for deriveAdvancement; CTL-565 note: PHASES[0]
 // ("triage") is intentionally NO LONGER the new-work entry phase — new work
 // enters at NEW_WORK_ENTRY_PHASE ("research"), see schedulerTick.
 import { PHASES, transition, isTerminal } from "../lib/phase-fsm.mjs";
 import { rankTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket } from "./dispatch.mjs";
+import { fetchTicketState } from "./linear-query.mjs";
 import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
@@ -130,12 +131,41 @@ export function computeFreeSlots(maxParallel, inFlightCount) {
   return Math.max(0, maxParallel - inFlightCount);
 }
 
+// A blocker fetch that failed (or any non-terminal hydrated state) holds the
+// dependent back. The sentinel is a deliberately non-terminal placeholder
+// state so a failed `linearis issues read` fails safe — the dependent is
+// treated as blocked, never silently dispatched. CTL-565 D5.
+const UNFETCHED_BLOCKER_STATE = "__unfetched__";
+
+// hydrateOutOfSetBlockers — find every blocker referenced by an eligible
+// ticket's blocked-by edge that is NOT itself in the eligible set, fetch its
+// live Linear state once, and return a { identifier: stateName } map. A failed
+// fetch yields the non-terminal UNFETCHED_BLOCKER_STATE sentinel so the
+// dependent is held back — failing safe. CTL-565 D5.
+export function hydrateOutOfSetBlockers(
+  eligibleTickets,
+  { exec, fetchState = fetchTicketState } = {},
+) {
+  const list = eligibleTickets ?? [];
+  const inSet = new Set(list.map((t) => t?.identifier).filter(Boolean));
+  const externalBlockers = referencedBlockerIds(list).filter((id) => !inSet.has(id));
+  const blockerStates = {};
+  for (const id of externalBlockers) {
+    const state = fetchState(id, { exec });
+    blockerStates[id] = state ?? UNFETCHED_BLOCKER_STATE; // non-terminal → fails safe
+  }
+  return blockerStates;
+}
+
 // computeReadyTickets — eligible tickets with no open blocker, priority-ranked.
 // analyzeDependencyGraph returns ready identifier strings; map back to the full
 // ticket objects (selection and dispatch need priority/createdAt) and rank.
-export function computeReadyTickets(eligibleTickets) {
+//
+// CTL-565 D5: options.blockerStates is threaded into the readiness filter so a
+// dependent blocked by a non-terminal out-of-set blocker is held back.
+export function computeReadyTickets(eligibleTickets, { blockerStates } = {}) {
   const list = eligibleTickets ?? [];
-  const readyIds = new Set(analyzeDependencyGraph(list).ready);
+  const readyIds = new Set(analyzeDependencyGraph(list, { blockerStates }).ready);
   return rankTickets(list.filter((t) => readyIds.has(t.identifier)));
 }
 
@@ -222,7 +252,11 @@ export function deriveAdvancement(signals) {
 
 // schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull.
 // Idempotent and restart-safe — derives every action from filesystem state.
-export function schedulerTick(orchDir, { readEligible, dispatch = defaultDispatch } = {}) {
+// `exec` is the injectable seam for the D5 out-of-set blocker-state fetch.
+export function schedulerTick(
+  orchDir,
+  { readEligible, dispatch = defaultDispatch, exec } = {},
+) {
   // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
   const advanced = [];
   for (const ticket of listInFlightTickets(orchDir)) {
@@ -233,9 +267,12 @@ export function schedulerTick(orchDir, { readEligible, dispatch = defaultDispatc
     else log.warn({ ticket, phase: next, code: r.code }, "scheduler: advance dispatch failed");
   }
 
-  // (2) New-work pull — fill free slots with top-ranked ready tickets.
+  // (2) New-work pull — fill free slots with top-ranked ready tickets. D5:
+  // hydrate the live state of every out-of-set blocker first so a Ready ticket
+  // blocked by a non-terminal out-of-set ticket is held back.
   const eligible = readEligible ? readEligible() : readAllEligibleTickets();
-  const ready = computeReadyTickets(eligible);
+  const blockerStates = hydrateOutOfSetBlockers(eligible, { exec });
+  const ready = computeReadyTickets(eligible, { blockerStates });
   const inFlightCount = listInFlightTickets(orchDir).size; // recomputed post-sweep
   const freeSlots = computeFreeSlots(readMaxParallel(orchDir), inFlightCount);
   const selected = selectDispatchable(ready, listStartedTickets(orchDir), freeSlots);
@@ -269,6 +306,7 @@ function runTick() {
     schedulerTick(runningOpts.orchDir, {
       readEligible: runningOpts.readEligible,
       dispatch: runningOpts.dispatch,
+      exec: runningOpts.exec,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -282,17 +320,19 @@ function scheduleDebouncedTick(debounceMs) {
 }
 
 // startScheduler — immediate authoritative tick, arm the periodic timer, then
-// start the event-log fast path. `dispatch` / `readEligible` are injectable so
-// a test drives a hermetic daemon.
+// start the event-log fast path. `dispatch` / `readEligible` / `exec` are
+// injectable so a test drives a hermetic daemon (`exec` is the D5 blocker-state
+// fetch seam, CTL-565).
 export function startScheduler({
   orchDir,
   dispatch,
   readEligible,
+  exec,
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
 } = {}) {
   if (!orchDir) throw new Error("startScheduler: orchDir is required");
-  runningOpts = { orchDir, dispatch, readEligible };
+  runningOpts = { orchDir, dispatch, readEligible, exec };
 
   runTick(); // authoritative initial pass
   tickTimer = setInterval(runTick, tickIntervalMs);

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -117,6 +117,9 @@ describe("isTicketInFlight", () => {
     expect(isTicketInFlight({ implement: "failed" })).toBe(false);
     expect(isTicketInFlight({ verify: "stalled" })).toBe(false);
   });
+  test("an 'aborted' signal frees the slot (CTL-565 kill-on-drag-out)", () => {
+    expect(isTicketInFlight({ research: "done", implement: "aborted" })).toBe(false);
+  });
   test("no signals at all → NOT in-flight", () => {
     expect(isTicketInFlight({})).toBe(false);
   });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -19,6 +19,7 @@ import {
   listStartedTickets,
   schedulerTick,
   readAllEligibleTickets,
+  hydrateOutOfSetBlockers,
   startScheduler,
   stopScheduler,
   __resetForTests,
@@ -427,6 +428,94 @@ describe("readAllEligibleTickets", () => {
     writeEligibleProjection("shapeless", { tickets: "nope" });
     writeEligibleProjection("ok", { tickets: [{ identifier: "OK-1" }] });
     expect(readAllEligibleTickets().map((t) => t.identifier)).toEqual(["OK-1"]);
+  });
+});
+
+// ── CTL-565 D5: out-of-set blocker-state hydration ──
+
+describe("hydrateOutOfSetBlockers / D5 readiness", () => {
+  // blkTk — an eligible ticket carrying a `blocked_by` relation to `blockedBy`.
+  const blkTk = (id, { priority = 2, blockedBy } = {}) => ({
+    identifier: id,
+    priority,
+    createdAt: "x",
+    state: "Todo",
+    relations: blockedBy
+      ? { nodes: [{ type: "blocked_by", relatedIssue: { identifier: blockedBy } }] }
+      : { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+
+  test("fetches each unique out-of-set blocker once (deduped)", () => {
+    const fetched = [];
+    const exec = (_cmd, args) => {
+      fetched.push(args[2]);
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Backlog" } }), stderr: "" };
+    };
+    const map = hydrateOutOfSetBlockers(
+      [blkTk("CTL-1", { blockedBy: "CTL-99" }), blkTk("CTL-2", { blockedBy: "CTL-99" })],
+      { exec },
+    );
+    expect(fetched).toEqual(["CTL-99"]); // deduped — one fetch
+    expect(map).toEqual({ "CTL-99": "Backlog" });
+  });
+
+  test("an in-set blocker is not fetched (only out-of-set blockers hydrate)", () => {
+    const fetched = [];
+    const exec = (_cmd, args) => {
+      fetched.push(args[2]);
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Backlog" } }), stderr: "" };
+    };
+    // CTL-2 is in the eligible set, so the CTL-1→CTL-2 edge is in-set.
+    hydrateOutOfSetBlockers(
+      [blkTk("CTL-1", { blockedBy: "CTL-2" }), blkTk("CTL-2")],
+      { exec },
+    );
+    expect(fetched).toEqual([]);
+  });
+
+  test("a Ready ticket blocked by a Backlog out-of-set blocker is not dispatched", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ state: { name: "Backlog" } }),
+      stderr: "",
+    });
+    schedulerTick(orchDir, {
+      readEligible: () => [blkTk("CTL-1", { blockedBy: "CTL-99" })],
+      dispatch,
+      exec,
+    });
+    expect(dispatch.calls).toHaveLength(0);
+  });
+
+  test("a Ready ticket blocked by a Done out-of-set blocker IS dispatched", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ state: { name: "Done" } }),
+      stderr: "",
+    });
+    schedulerTick(orchDir, {
+      readEligible: () => [blkTk("CTL-1", { blockedBy: "CTL-99" })],
+      dispatch,
+      exec,
+    });
+    expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-1"]);
+  });
+
+  test("a failed blocker fetch fails safe — the dependent is held back, not dispatched", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const exec = () => ({ code: 1, stdout: "", stderr: "boom" });
+    schedulerTick(orchDir, {
+      readEligible: () => [blkTk("CTL-1", { blockedBy: "CTL-99" })],
+      dispatch,
+      exec,
+    });
+    expect(dispatch.calls).toHaveLength(0);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -249,7 +249,7 @@ describe("deriveAdvancement", () => {
 });
 
 describe("schedulerTick — new-work pull", () => {
-  test("dispatches triage for the top-ranked ready ticket into a free slot", () => {
+  test("dispatches research for the top-ranked ready ticket into a free slot", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     const dispatch = fakeDispatch();
     const eligible = [
@@ -273,8 +273,27 @@ describe("schedulerTick — new-work pull", () => {
     const r = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
     // 2 free slots, both ready → both dispatched, urgent (CTL-8) first.
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-8", "CTL-9"]);
-    expect(dispatch.calls.every((c) => c.phase === "triage")).toBe(true);
+    // CTL-565: new-work enters the pipeline at research, not triage.
+    expect(dispatch.calls.every((c) => c.phase === "research")).toBe(true);
     expect(r.dispatched).toEqual(["CTL-8", "CTL-9"]);
+  });
+
+  test("new-work pull dispatches Ready tickets at the research phase, not triage (CTL-565)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch();
+    const eligible = [
+      {
+        identifier: "CTL-1",
+        priority: 2,
+        createdAt: "x",
+        state: "Todo",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      },
+    ];
+    schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    expect(dispatch.calls).toHaveLength(1);
+    expect(dispatch.calls[0]).toMatchObject({ ticket: "CTL-1", phase: "research" });
   });
 
   test("respects maxParallel — no dispatch when slots are full", () => {
@@ -369,7 +388,8 @@ describe("schedulerTick — new-work pull", () => {
     expect(r.dispatched).toEqual(["CTL-X"]);
     expect(dispatch.calls).toEqual([
       { orchDir, ticket: "CTL-7", phase: "research" },
-      { orchDir, ticket: "CTL-X", phase: "triage" },
+      // CTL-565: new-work pull enters at research, not triage.
+      { orchDir, ticket: "CTL-X", phase: "research" },
     ]);
   });
 });
@@ -497,9 +517,10 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
     const eligible = [tk("CTL-9")];
 
-    // Tick 1 — dispatches PHASES[0] (triage) for the ready ticket. The stub
-    // writes the dispatched signal the real phase-agent-dispatch would have
-    // written BEFORE spawning claude --bg (signal-first ordering).
+    // Tick 1 — dispatches the new-work entry phase (research, CTL-565) for the
+    // ready ticket. The stub writes the dispatched signal the real
+    // phase-agent-dispatch would have written BEFORE spawning claude --bg
+    // (signal-first ordering).
     const calls = [];
     const dispatch = (args) => {
       calls.push(`${args.ticket}:${args.phase}`);
@@ -513,7 +534,7 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
     // Tick 2 (post-restart) re-derives everything from the filesystem.
     const r2 = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
 
-    // CTL-9 now has a worker dir → excluded from the pull. triage:dispatched
+    // CTL-9 now has a worker dir → excluded from the pull. research:dispatched
     // is not 'done' → deriveAdvancement returns null. No re-dispatch.
     expect(r2.dispatched).toEqual([]);
     expect(r2.advanced).toEqual([]);
@@ -521,7 +542,7 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
     const byKey = new Map();
     for (const k of calls) byKey.set(k, (byKey.get(k) ?? 0) + 1);
     expect([...byKey.values()].every((n) => n === 1)).toBe(true);
-    expect(calls).toEqual(["CTL-9:triage"]);
+    expect(calls).toEqual(["CTL-9:research"]);
   });
 
   test("an orphan 'dispatched' signal (bg_job_id:null) is not re-dispatched", () => {

--- a/plugins/dev/scripts/lib/dependency-graph.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.mjs
@@ -13,19 +13,28 @@
 const DEFAULT_TERMINAL_STATUSES = ["Done", "Canceled"];
 
 // buildDependencyEdges — normalize Linear relations into canonical directed
-// edges (CTL-530). Only edges whose BOTH endpoints are in the input set are
-// kept; non-blocking types (related, duplicate) are ignored; results are
-// deduped by (from,to). Live `linearis` emits only `blocks`; the API-native
-// `blocked_by` form is also accepted for forward-compat.
-export function buildDependencyEdges(issues) {
+// edges (CTL-530). An edge is kept when both endpoints are in-set, OR (CTL-565
+// D5) when `to` is in-set and `from` is a declared external blocker — so an
+// out-of-set blocker's edge survives for computeReadySet. Non-blocking types
+// (related, duplicate) are ignored; results are deduped by (from,to). Live
+// `linearis` emits only `blocks`; the API-native `blocked_by` form is also
+// accepted for forward-compat.
+//
+// options.externalIds — out-of-set blocker identifiers (D5) that remain valid
+// edge endpoints on the `from` side.
+export function buildDependencyEdges(issues, { externalIds } = {}) {
   const list = issues ?? [];
   const inSet = new Set(list.map((i) => i?.identifier).filter(Boolean));
+  const ext = externalIds instanceof Set ? externalIds : new Set(externalIds ?? []);
   const seen = new Set();
   const edges = [];
 
   const add = (from, to) => {
     if (!from || !to) return; // malformed node — missing peer identifier
-    if (!inSet.has(from) || !inSet.has(to)) return; // out-of-set edge
+    // Keep an edge only when `to` is in-set AND `from` is either in-set or a
+    // declared external blocker. A genuinely out-of-set edge is dropped.
+    if (!inSet.has(to)) return;
+    if (!inSet.has(from) && !ext.has(from)) return;
     const key = `${from} ${to}`;
     if (seen.has(key)) return; // dedup symmetric relations/inverseRelations
     seen.add(key);
@@ -55,21 +64,34 @@ export function buildDependencyEdges(issues) {
 
 // computeReadySet — partition eligible issues into ready vs blocked (CTL-530).
 // An issue is eligible when its status is not terminal. An eligible issue is
-// blocked when some in-set edge points at it from an UNFINISHED blocker;
-// otherwise it is ready. Terminal issues appear in neither list. Returns
+// blocked when some edge points at it from an UNFINISHED blocker; otherwise it
+// is ready. Terminal issues appear in neither list. Returns
 // { ready: string[], blocked: string[] }, both sorted.
+//
+// CTL-565 D5: options.blockerStates is a { identifier: stateName } map for
+// out-of-set blockers. A blocker absent from `issues` is non-blocking ONLY
+// when blockerStates omits it (legacy) or says it is terminal; a non-terminal
+// out-of-set blocker now blocks.
 export function computeReadySet(issues, edges, options = {}) {
   const list = issues ?? [];
   const terminal = new Set(options.terminalStatuses ?? DEFAULT_TERMINAL_STATUSES);
+  const blockerStates = options.blockerStates ?? {};
   const isTerminal = (issue) => terminal.has(issue?.state?.name);
   const byId = new Map(list.filter((i) => i?.identifier).map((i) => [i.identifier, i]));
 
-  // An issue is blocked if any unfinished blocker points at it. A blocker that
-  // is unknown (out-of-set) or terminal does not block.
+  // An issue is blocked if any unfinished blocker points at it. An in-set
+  // blocker blocks unless it is terminal. An out-of-set blocker blocks only
+  // when blockerStates carries a non-terminal state for it; an unknown
+  // out-of-set blocker (no hydrated state) is non-blocking — legacy behavior.
   const blockedIds = new Set();
   for (const { from, to } of edges ?? []) {
-    const blocker = byId.get(from);
-    if (blocker && !isTerminal(blocker)) blockedIds.add(to);
+    const inSetBlocker = byId.get(from);
+    if (inSetBlocker) {
+      if (!isTerminal(inSetBlocker)) blockedIds.add(to);
+    } else if (from in blockerStates) {
+      if (!terminal.has(blockerStates[from])) blockedIds.add(to);
+    }
+    // else: unknown out-of-set blocker, no hydrated state — non-blocking.
   }
 
   const ready = [];
@@ -168,13 +190,43 @@ export function detectCycles(nodeIds, edges) {
   return anomalies;
 }
 
+// referencedBlockerIds — every `from` identifier referenced by a `blocked-by`
+// edge across the issue list, regardless of set membership (CTL-565 D5). The
+// D5 hydration step uses this to discover out-of-set blocker ids BEFORE
+// buildDependencyEdges can be told which external endpoints to retain. Kept
+// separate so buildDependencyEdges stays single-purpose.
+export function referencedBlockerIds(issues) {
+  const list = issues ?? [];
+  const blockerIds = new Set();
+  const add = (id) => {
+    if (id) blockerIds.add(id);
+  };
+  for (const issue of list) {
+    const self = issue?.identifier;
+    for (const node of issue?.relations?.nodes ?? []) {
+      const peer = node?.relatedIssue?.identifier;
+      if (node?.type === "blocked_by") add(peer); // peer blocks self
+    }
+    for (const node of issue?.inverseRelations?.nodes ?? []) {
+      const peer = node?.issue?.identifier;
+      if (node?.type === "blocks" && self) add(peer); // peer blocks self
+    }
+  }
+  return [...blockerIds];
+}
+
 // analyzeDependencyGraph — public entry point (CTL-530). Composes edge
 // extraction, the readiness filter, and cycle detection over an array of
 // Linear issues. Returns { ready, blocked, anomalies } — ready/blocked are
 // sorted identifier arrays, anomalies a sorted Anomaly[].
+//
+// CTL-565 D5: options.blockerStates ({ id: stateName }) makes the out-of-set
+// blockers it names valid edge endpoints AND feeds their state to the
+// readiness filter.
 export function analyzeDependencyGraph(issues, options = {}) {
   const list = issues ?? [];
-  const edges = buildDependencyEdges(list);
+  const externalIds = Object.keys(options.blockerStates ?? {});
+  const edges = buildDependencyEdges(list, { externalIds });
   const { ready, blocked } = computeReadySet(list, edges, options);
   const anomalies = detectCycles(list.map((i) => i?.identifier).filter(Boolean), edges);
   return { ready, blocked, anomalies };

--- a/plugins/dev/scripts/lib/dependency-graph.test.mjs
+++ b/plugins/dev/scripts/lib/dependency-graph.test.mjs
@@ -8,6 +8,7 @@ import {
   computeReadySet,
   detectCycles,
   analyzeDependencyGraph,
+  referencedBlockerIds,
 } from "./dependency-graph.mjs";
 
 // issue(id, state, relations[], inverseRelations[]) — terse fixture builder.
@@ -372,6 +373,52 @@ describe("detectCycles", () => {
       expect(detectCycles(c.nodes, edges)).toEqual(c.expected);
     });
   }
+});
+
+// CTL-565 D5 — out-of-set blocker-state awareness. A Ready ticket blocked by a
+// ticket outside the eligible set must be held back unless the blocker's live
+// Linear state is terminal. The blocker is passed as a { id: stateName } map,
+// never injected into the issue list (that would make blockers dispatchable).
+describe("D5 — out-of-set blocker-state hydration", () => {
+  test("a Ready ticket blocked by a non-terminal out-of-set blocker is held back", () => {
+    // CTL-1 is eligible with an inverse `blocks` edge from out-of-set CTL-99.
+    const issues = [issue("CTL-1", "Backlog", [], [inv("blocks", "CTL-99")])];
+    const r = analyzeDependencyGraph(issues, { blockerStates: { "CTL-99": "Backlog" } });
+    expect(r.ready).toEqual([]);
+    expect(r.blocked).toEqual(["CTL-1"]);
+  });
+
+  test("a Ready ticket blocked by a Done out-of-set blocker is ready", () => {
+    const issues = [issue("CTL-1", "Backlog", [], [inv("blocks", "CTL-99")])];
+    const r = analyzeDependencyGraph(issues, { blockerStates: { "CTL-99": "Done" } });
+    expect(r.ready).toEqual(["CTL-1"]);
+  });
+
+  test("with no blockerStates supplied, an out-of-set blocker still does not block (legacy)", () => {
+    const issues = [issue("CTL-1", "Backlog", [], [inv("blocks", "CTL-99")])];
+    expect(analyzeDependencyGraph(issues).ready).toEqual(["CTL-1"]);
+  });
+
+  test("an out-of-set blocker is never itself classified as ready/blocked", () => {
+    const issues = [issue("CTL-1", "Backlog", [], [inv("blocks", "CTL-99")])];
+    const r = analyzeDependencyGraph(issues, { blockerStates: { "CTL-99": "Backlog" } });
+    expect(r.ready).not.toContain("CTL-99");
+    expect(r.blocked).not.toContain("CTL-99");
+  });
+
+  test("a Canceled out-of-set blocker does not block (terminal)", () => {
+    const issues = [issue("CTL-1", "Backlog", [], [inv("blocks", "CTL-99")])];
+    expect(analyzeDependencyGraph(issues, { blockerStates: { "CTL-99": "Canceled" } }).ready)
+      .toEqual(["CTL-1"]);
+  });
+
+  test("referencedBlockerIds returns every blocked-by peer regardless of membership", () => {
+    const issues = [
+      issue("CTL-1", "Backlog", [], [inv("blocks", "CTL-99")]),
+      issue("CTL-2", "Backlog", [rel("blocked_by", "CTL-88")]),
+    ];
+    expect(referencedBlockerIds(issues).sort()).toEqual(["CTL-88", "CTL-99"]);
+  });
 });
 
 describe("analyzeDependencyGraph", () => {


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-21T19:45:00Z -->
<!-- Last updated: 2026-05-21T19:45:00Z -->
<!-- PR: #953 -->
<!-- Previous commits: d812cf87,0d326c59,b5573c21,cf2aa1bb -->

## Summary

Rewires the execution-core scheduler daemon around a two-state Linear trigger model. The
monitor now watches both the `Triage` and `Ready` states with distinct trigger paths, the
scheduler dispatches `Ready` pulls starting at the research phase (triage already done),
the dependency graph hydrates blocker state for out-of-set external blockers, and dragging
an in-flight ticket out of `{Triage, Ready}` aborts its worker.

Delivered in four sequenced phases (M4 milestone).

## Changes Made

### Phase 1 — Monitor watches `{Triage, Ready}` with split trigger paths

- Extracted the worker-dispatch adapter into a shared `dispatch.mjs` (the D9 executor seam)
  consumed by both the scheduler and the monitor.
- The monitor's `toState` branch now does a three-way split:
  - `→Triage` transition one-shot-dispatches the triage phase agent (never the eligible set).
  - `→Ready` transition reconciles into the scheduler-eligible set.
  - Any other state is the leave-path.
- Threaded `orchDir` + `dispatch` through `startMonitor`/`tailerOpts` and `daemon.mjs`.
- Resolved a new `triageStatus` field (default `"Triage"`) in `enrollment.mjs` config resolution.

### Phase 2 — Scheduler dispatches `Ready` pulls at research

- Flipped the scheduler's new-work entry phase from `triage` to `research`. A `Ready` ticket
  has already been triaged, so the scheduler never dispatches triage.
- Introduced the named `NEW_WORK_ENTRY_PHASE` constant; `PHASES[0]` is no longer the entry
  phase. The phase FSM still chains research → plan → implement → … unchanged.

### Phase 3 — D5 out-of-set blocker-state hydration

- Extended the pure dependency-graph module with out-of-set blocker awareness:
  - `buildDependencyEdges` keeps an edge whose `from` is a declared external blocker.
  - `computeReadySet` consults a `blockerStates` map (a non-terminal out-of-set blocker now
    blocks).
  - New `referencedBlockerIds` helper discovers external blocker ids.
- Added `fetchTicketState` to `linear-query.mjs` wrapping `linearis issues read`.
- Added `hydrateOutOfSetBlockers` to the scheduler, threaded through `schedulerTick` /
  `startScheduler` via an injectable exec seam. A failed fetch fails safe behind a
  non-terminal sentinel so the dependent is held back rather than dispatched.

### Phase 4 — Kill-on-drag-out worker abort

- Added a new `abort-worker.mjs` module wired into the monitor leave-path. Dragging an
  in-flight ticket out of `{Triage, Ready}` now aborts its worker: every non-terminal
  `phase-*.json` signal is atomically rewritten `status:"aborted"` — the deterministic
  filesystem-level guarantee.
- The bg-job kill plus worktree teardown run best-effort behind injectable
  `killJob`/`teardownWorktree` seams (D9). The default `killJob` is a documented best-effort
  no-op (the live `claude` CLI exposes no bg-job kill subcommand).
- `isTicketInFlight` now treats `"aborted"` as slot-freeing so the scheduler stops advancing
  the ticket.

## How to Verify It

- [ ] `bun test` for the execution-core suite — `abort-worker.test.mjs`, `dispatch.test.mjs`,
      `enrollment.test.mjs`, `linear-query.test.mjs`, `monitor.test.mjs`,
      `scheduler.test.mjs`, `dependency-graph.test.mjs`, `integration.test.mjs`
- [ ] CI: `validate`, `check-versions`, `audit-references`

## Related Issues/PRs

- Refs: CTL-565 — [M4·scheduler] Execution-core daemon two-state trigger rewiring

## Changelog Entry

Execution-core scheduler daemon now uses a two-state (`Triage`/`Ready`) trigger model with
out-of-set blocker hydration and kill-on-drag-out worker abort.
