### PR TITLE
CTL-564: Execution-core Linear-state contract in setup tooling (Part A)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,9 @@ orchestrators and workers write to via `catalyst-state.sh` (lock-protected).
 │   └── YYYY-MM.jsonl
 ├── history/                # Archived orchestrator snapshots
 │   └── <id>--<timestamp>.json
+├── execution-core/         # Execution-core daemon state
+│   ├── registry.json       # Central team → repoRoot → eligibleQuery registry
+│   └── projects/           # Legacy per-repo enrollment records (pre-registry)
 └── wt/                     # Worktrees (existing)
 ```
 
@@ -86,6 +89,14 @@ orchestrators and workers write to via `catalyst-state.sh` (lock-protected).
   Consumer interface: `catalyst-events tail` (streaming) and `catalyst-events wait-for`
   (blocking single-event wait). See `website/src/content/docs/observability/catalyst-events.md`.
 - **history/**: Full orchestrator snapshots archived on completion, failure, or stale detection.
+- **execution-core/registry.json**: For `dispatchMode: execution-core` teams, the central
+  `team → repoRoot → eligibleQuery` registry. The Linear-state contract that drives the
+  execution-core daemon is **setup-tooling-owned** (design decision D8): `setup-catalyst.sh`
+  ensures the contract workflow states, writes the 9-phase → 5-state collapse `stateMap`, and
+  upserts each team's registry entry. The registry is the D4 successor to the per-repo
+  enrollment records under `execution-core/projects/`, and all access flows through the
+  `registry.mjs` `list-projects` / `get-project-config` interface — the D9 cloud seam, so the
+  store can later become a Supabase table without touching callers.
 - **Heartbeat**: Orchestrators write `lastHeartbeat` every 2-3 min. Stale entries (>10 min) are
   garbage-collected as `abandoned`.
 

--- a/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Tests for the check-project-setup.sh execution-core verification block (CTL-564
+# Phase 4). When dispatchMode is execution-core, the script must verify the
+# contract states are present in stateMap/stateIds and a registry entry exists,
+# emitting warnings (never errors) for any gap.
+#
+# Run: bash plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/plugins/dev/scripts/check-project-setup.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; }
+
+# build_project <dir> <dispatchMode> <full-contract:0|1> <registry-entry:0|1>
+# Writes an isolated fixture repo with a .catalyst/config.json and a temp
+# CATALYST_DIR holding a registry.json.
+build_project() {
+  local dir="$1" mode="$2" full="$3" registry="$4"
+  mkdir -p "$dir/.catalyst"
+  mkdir -p "$dir/thoughts/shared/research" "$dir/thoughts/shared/plans" \
+    "$dir/thoughts/shared/handoffs" "$dir/thoughts/shared/prs" "$dir/thoughts/shared/reports"
+
+  local state_map state_ids
+  if [[ $full == "1" ]]; then
+    state_map='{"backlog":"Backlog","todo":"Ready","triage":"Triage","research":"Research","planning":"Plan","inProgress":"Implement","verifying":"Validate","reviewing":"Validate","inReview":"PR","done":"Done","canceled":"Canceled"}'
+    state_ids='{"Backlog":"id-b","Triage":"id-t","Ready":"id-rd","Research":"id-rs","Plan":"id-pl","Implement":"id-im","Validate":"id-va","PR":"id-pr","Done":"id-dn","Canceled":"id-cn"}'
+  else
+    # missing Validate and PR from both stateMap values and stateIds keys
+    state_map='{"backlog":"Backlog","todo":"Ready","triage":"Triage","research":"Research","planning":"Plan","inProgress":"Implement","done":"Done","canceled":"Canceled"}'
+    state_ids='{"Backlog":"id-b","Triage":"id-t","Ready":"id-rd","Research":"id-rs","Plan":"id-pl","Implement":"id-im","Done":"id-dn","Canceled":"id-cn"}'
+  fi
+
+  cat > "$dir/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-project",
+    "project": { "ticketPrefix": "CTL" },
+    "linear": {
+      "teamKey": "CTL",
+      "stateMap": ${state_map},
+      "stateIds": ${state_ids}
+    },
+    "orchestration": { "dispatchMode": "${mode}" }
+  }
+}
+EOF
+
+  local catalyst_dir="${dir}.catalyst-home"
+  mkdir -p "${catalyst_dir}/execution-core"
+  if [[ $registry == "1" ]]; then
+    cat > "${catalyst_dir}/execution-core/registry.json" <<EOF
+{ "projects": [ { "team": "CTL", "repoRoot": "${dir}", "eligibleQuery": { "status": "Ready" } } ] }
+EOF
+  else
+    echo '{ "projects": [] }' > "${catalyst_dir}/execution-core/registry.json"
+  fi
+  echo "$catalyst_dir"
+}
+
+# run_check <project-dir> <catalyst-dir> — run the script, capture output.
+run_check() {
+  local cwd="$1" catalyst_dir="$2"
+  ( cd "$cwd" \
+    && env -i HOME="$HOME" PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+       CATALYST_AUTONOMOUS=1 CATALYST_DIR="$catalyst_dir" \
+       bash "$SCRIPT" 2>&1 )
+}
+
+echo "check-project-setup execution-core tests"
+
+# ─── Test 1: phase-agents → no execution-core contract warning ───────────────
+P1="${SCRATCH}/p1"
+CD1="$(build_project "$P1" "phase-agents" 1 0)"
+OUT1="$(run_check "$P1" "$CD1" || true)"
+if ! grep -qiE "contract state|execution-core registry entry" <<<"$OUT1"; then
+  pass "phase-agents repo emits no execution-core contract warning"
+else
+  fail "phase-agents repo emits no execution-core contract warning"
+  echo "$OUT1" | sed 's/^/    /'
+fi
+
+# ─── Test 2: execution-core, missing Validate/PR → warns about contract states
+P2="${SCRATCH}/p2"
+CD2="$(build_project "$P2" "execution-core" 0 1)"
+OUT2="$(run_check "$P2" "$CD2" || true)"
+if grep -qiE "Validate" <<<"$OUT2" && grep -qiE "contract state" <<<"$OUT2"; then
+  pass "execution-core repo warns about missing contract states"
+else
+  fail "execution-core repo warns about missing contract states"
+  echo "$OUT2" | sed 's/^/    /'
+fi
+
+# ─── Test 3: execution-core, contract present, no registry entry → warns ──────
+P3="${SCRATCH}/p3"
+CD3="$(build_project "$P3" "execution-core" 1 0)"
+OUT3="$(run_check "$P3" "$CD3" || true)"
+if grep -qiE "registry entry" <<<"$OUT3"; then
+  pass "execution-core repo warns about missing registry entry"
+else
+  fail "execution-core repo warns about missing registry entry"
+  echo "$OUT3" | sed 's/^/    /'
+fi
+
+# ─── Test 4: execution-core, contract present + registry entry → no warning ───
+P4="${SCRATCH}/p4"
+CD4="$(build_project "$P4" "execution-core" 1 1)"
+OUT4="$(run_check "$P4" "$CD4" || true)"
+if ! grep -qiE "contract state|registry entry" <<<"$OUT4"; then
+  pass "fully-configured execution-core repo emits no execution-core warning"
+else
+  fail "fully-configured execution-core repo emits no execution-core warning"
+  echo "$OUT4" | sed 's/^/    /'
+fi
+
+# ─── Test 5: execution-core warnings never set exit 1 (warnings-only → exit 0) ─
+P5="${SCRATCH}/p5"
+CD5="$(build_project "$P5" "execution-core" 0 0)"
+run_check "$P5" "$CD5" > /dev/null 2>&1
+RC5=$?
+if [[ $RC5 -eq 0 ]]; then
+  pass "execution-core gap stays a warning — script still exits 0"
+else
+  fail "execution-core gap stays a warning — script still exits 0 (got rc=$RC5)"
+fi
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/execution-core-docs-shape.test.sh
+++ b/plugins/dev/scripts/__tests__/execution-core-docs-shape.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Shape test for the CTL-564 Phase 5 config-template + documentation updates.
+# Asserts the config template stays valid JSON and the reference docs document
+# the central registry and the execution-core stateMap collapse.
+#
+# Run: bash plugins/dev/scripts/__tests__/execution-core-docs-shape.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+TEMPLATE="${REPO_ROOT}/plugins/dev/templates/config.template.json"
+CONFIG_DOC="${REPO_ROOT}/website/src/content/docs/reference/configuration.md"
+ARCH_DOC="${REPO_ROOT}/docs/architecture.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; }
+
+check() {
+  # check <name> <test-command...>
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then pass "$name"; else fail "$name"; fi
+}
+
+echo "execution-core docs shape tests"
+
+# Template: jq-stripped (comments removed) must be valid JSON.
+check "config.template.json is valid JSON" jq -e . "$TEMPLATE"
+
+# Template: the executionCore _comment mentions the contract Ready state.
+check "template executionCore comment mentions the contract" \
+  grep -qi "execution-core state contract\|registry" "$TEMPLATE"
+
+# configuration.md: documents the central registry.
+check "configuration.md documents registry.json" \
+  grep -qF "registry.json" "$CONFIG_DOC"
+
+# configuration.md: documents the execution-core stateMap collapse.
+check "configuration.md documents the execution-core state contract" \
+  grep -qiE "execution-core state contract|9-phase" "$CONFIG_DOC"
+
+# configuration.md: documents the new check-project-setup execution-core check.
+check "configuration.md mentions the check-project-setup execution-core check" \
+  grep -qF "setup-execution-core-states.sh" "$CONFIG_DOC"
+
+# architecture.md: notes the registry as the D4/D8/D9 seam.
+check "architecture.md documents the execution-core registry" \
+  grep -qF "execution-core/registry.json" "$ARCH_DOC"
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# Shell tests for setup-execution-core-states.sh (CTL-564 Phase 2).
+#
+# Two layers:
+#   1. Unit  — source the script (sourcing guard suppresses main) and assert
+#              its pure helpers directly.
+#   2. E2E   — run the script with a fake `curl` earlier on PATH returning
+#              canned GraphQL responses, against a fixture .catalyst/config.json.
+#
+# Run: bash plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/plugins/dev/scripts/setup-execution-core-states.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    PASSES=$((PASSES+1))
+    echo "  PASS: $name"
+  else
+    FAILURES=$((FAILURES+1))
+    echo "  FAIL: $name"
+    echo "    command: $*"
+    echo "    output:"
+    sed 's/^/      /' "${SCRATCH}/out"
+  fi
+}
+
+echo "setup-execution-core-states tests"
+
+# ─── Layer 1: pure helper unit tests (source with the guard suppressing main) ─
+# shellcheck source=/dev/null
+source "$SCRIPT"
+
+# build_execution_core_state_map — exact 11-key collapse map.
+STATE_MAP_JSON="$(build_execution_core_state_map)"
+
+run "state map is valid JSON" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e ."
+
+run "state map has 11 keys" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e 'length == 11'"
+
+run "state map todo -> Ready" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.todo == \"Ready\"'"
+
+run "state map triage -> Triage" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.triage == \"Triage\"'"
+
+run "state map research -> Research" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.research == \"Research\"'"
+
+run "state map planning -> Plan" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.planning == \"Plan\"'"
+
+run "state map inProgress -> Implement" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.inProgress == \"Implement\"'"
+
+run "state map verifying -> Validate" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.verifying == \"Validate\"'"
+
+run "state map reviewing -> Validate" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.reviewing == \"Validate\"'"
+
+run "state map inReview -> PR" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.inReview == \"PR\"'"
+
+run "state map backlog -> Backlog" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.backlog == \"Backlog\"'"
+
+run "state map done -> Done" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.done == \"Done\"'"
+
+run "state map canceled -> Canceled" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.canceled == \"Canceled\"'"
+
+# contract_states — exactly Ready Research Plan Implement Validate PR (no Triage).
+CONTRACT="$(contract_states)"
+
+run "contract_states lists the 6 contract names" \
+  bash -c "[ \"\$(echo '$CONTRACT' | jq -r '.[].name' | sort | tr '\n' ' ')\" = 'Implement Plan PR Ready Research Validate ' ]"
+
+run "contract_states excludes Triage" \
+  bash -c "! echo '$CONTRACT' | jq -e '.[] | select(.name == \"Triage\")'"
+
+run "contract_states: Ready is unstarted" \
+  bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"Ready\") | .type == \"unstarted\"'"
+
+run "contract_states: Research is unstarted" \
+  bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"Research\") | .type == \"unstarted\"'"
+
+run "contract_states: Plan is started" \
+  bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"Plan\") | .type == \"started\"'"
+
+run "contract_states: Implement is started" \
+  bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"Implement\") | .type == \"started\"'"
+
+run "contract_states: Validate is started" \
+  bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"Validate\") | .type == \"started\"'"
+
+run "contract_states: PR is started" \
+  bash -c "echo '$CONTRACT' | jq -e '.[] | select(.name==\"PR\") | .type == \"started\"'"
+
+# missing_contract_states — diff against a fetched-states JSON fixture.
+FETCHED_PARTIAL='[{"name":"Triage","type":"started"},{"name":"Research","type":"unstarted"},{"name":"Plan","type":"started"}]'
+MISSING="$(missing_contract_states "$FETCHED_PARTIAL")"
+
+run "missing_contract_states returns the absent contract states" \
+  bash -c "[ \"\$(echo '$MISSING' | tr ' ' '\n' | grep -v '^\$' | sort | tr '\n' ' ')\" = 'Implement PR Ready Validate ' ]"
+
+FETCHED_ALL='[{"name":"Triage","type":"started"},{"name":"Ready","type":"unstarted"},{"name":"Research","type":"unstarted"},{"name":"Plan","type":"started"},{"name":"Implement","type":"started"},{"name":"Validate","type":"started"},{"name":"PR","type":"started"}]'
+
+run "missing_contract_states returns empty when all present (idempotent)" \
+  bash -c "[ -z \"\$(missing_contract_states '$FETCHED_ALL' | tr -d '[:space:]')\" ]"
+
+# build_workflow_state_create_mutation — GraphQL mutation string.
+MUTATION="$(build_workflow_state_create_mutation 'team-uuid-123' 'Validate' 'started' '#abcdef')"
+
+run "mutation contains workflowStateCreate" \
+  bash -c "echo '$MUTATION' | grep -q 'workflowStateCreate'"
+
+run "mutation contains the teamId" \
+  bash -c "echo '$MUTATION' | grep -q 'team-uuid-123'"
+
+run "mutation contains the state name" \
+  bash -c "echo '$MUTATION' | grep -q 'Validate'"
+
+run "mutation contains the type" \
+  bash -c "echo '$MUTATION' | grep -q 'started'"
+
+# ─── Layer 2: E2E with a stubbed curl ────────────────────────────────────────
+
+# Build a fixture repo with .catalyst/config.json + a git repo + secrets.
+build_repo() {
+  local dir="$1" team_key="${2:-CTL}"
+  mkdir -p "${dir}/.catalyst"
+  cat > "${dir}/.catalyst/config.json" <<EOF
+{
+  "catalyst": {
+    "projectKey": "test-project",
+    "linear": {
+      "teamKey": "${team_key}",
+      "stateMap": {
+        "backlog": "Backlog",
+        "inProgress": "In Progress",
+        "inReview": "In Review",
+        "done": "Done"
+      }
+    },
+    "orchestration": {
+      "dispatchMode": "execution-core",
+      "executionCore": { "eligibleQuery": { "status": "Todo" } }
+    }
+  }
+}
+EOF
+  git -C "$dir" init -q 2>/dev/null || true
+}
+
+build_secrets() {
+  local home="$1"
+  mkdir -p "${home}/.config/catalyst"
+  cat > "${home}/.config/catalyst/config-test-project.json" <<'EOF'
+{
+  "catalyst": { "linear": { "apiToken": "lin_api_fake_token_12345" } }
+}
+EOF
+}
+
+FAKE_TEAM_ID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+# install_fake_curl — a curl stub. The states query returns whichever set the
+# caller specifies; the workflowStateCreate mutation either succeeds or errors.
+# $1 = bin dir, $2 = "all"|"partial", $3 = "ok"|"create-fails"
+install_fake_curl() {
+  local bin_dir="$1" states="$2" create="${3:-ok}"
+  mkdir -p "$bin_dir"
+
+  local states_nodes
+  if [ "$states" = "all" ]; then
+    states_nodes='{"id":"s-triage","name":"Triage","type":"started"},{"id":"s-ready","name":"Ready","type":"unstarted"},{"id":"s-research","name":"Research","type":"unstarted"},{"id":"s-plan","name":"Plan","type":"started"},{"id":"s-impl","name":"Implement","type":"started"},{"id":"s-val","name":"Validate","type":"started"},{"id":"s-pr","name":"PR","type":"started"},{"id":"s-backlog","name":"Backlog","type":"backlog"},{"id":"s-done","name":"Done","type":"completed"},{"id":"s-cancel","name":"Canceled","type":"canceled"}'
+  else
+    states_nodes='{"id":"s-triage","name":"Triage","type":"started"},{"id":"s-research","name":"Research","type":"unstarted"},{"id":"s-plan","name":"Plan","type":"started"},{"id":"s-backlog","name":"Backlog","type":"backlog"},{"id":"s-done","name":"Done","type":"completed"}'
+  fi
+
+  local create_resp
+  if [ "$create" = "create-fails" ]; then
+    create_resp='{"errors":[{"message":"insufficient permissions"}]}'
+  else
+    create_resp='{"data":{"workflowStateCreate":{"success":true,"workflowState":{"id":"new-state-id"}}}}'
+  fi
+
+  cat > "${bin_dir}/curl" <<SCRIPT
+#!/usr/bin/env bash
+# Read the request body to distinguish a states query from a create mutation.
+body=""
+for arg in "\$@"; do
+  case "\$arg" in
+    *workflowStateCreate*) body="create" ;;
+    *workflowStates*|*states*) [ -z "\$body" ] && body="query" ;;
+  esac
+done
+# -d @- form: body comes from stdin
+if [ -z "\$body" ]; then
+  stdin_body="\$(cat)"
+  case "\$stdin_body" in
+    *workflowStateCreate*) body="create" ;;
+    *) body="query" ;;
+  esac
+fi
+if [ "\$body" = "create" ]; then
+  echo '${create_resp}'
+else
+  echo '{"data":{"teams":{"nodes":[{"id":"${FAKE_TEAM_ID}","workflowStates":{"nodes":[${states_nodes}]}}]}}}'
+fi
+exit 0
+SCRIPT
+  chmod +x "${bin_dir}/curl"
+}
+
+# ─── Test: --dry-run --json reports actions, writes nothing ───────────────────
+WORK_DR="${SCRATCH}/dryrun"
+BIN_DR="${SCRATCH}/dryrun/bin"
+HOME_DR="${SCRATCH}/dryrun/home"
+build_repo "$WORK_DR"
+build_secrets "$HOME_DR"
+install_fake_curl "$BIN_DR" "all" "ok"
+BEFORE_DR="$(cat "${WORK_DR}/.catalyst/config.json")"
+
+HOME="$HOME_DR" PATH="$BIN_DR:$PATH" CATALYST_DIR="${SCRATCH}/dryrun/catalyst" \
+  "$SCRIPT" --config "${WORK_DR}/.catalyst/config.json" --dry-run --json \
+  > "${SCRATCH}/dryrun-out" 2>&1 || true
+
+run "--dry-run --json emits JSON" \
+  bash -c "jq -e . '${SCRATCH}/dryrun-out'"
+
+AFTER_DR="$(cat "${WORK_DR}/.catalyst/config.json")"
+run "--dry-run writes nothing to config" \
+  bash -c "[ \"\$BEFORE_DR\" = \"\$AFTER_DR\" ]"
+
+run "--dry-run creates no registry file" \
+  bash -c "[ ! -f '${SCRATCH}/dryrun/catalyst/execution-core/registry.json' ]"
+
+# ─── Test: states all present -> writes stateMap, no workflowStateCreate ──────
+WORK_OK="${SCRATCH}/ok"
+BIN_OK="${SCRATCH}/ok/bin"
+HOME_OK="${SCRATCH}/ok/home"
+build_repo "$WORK_OK"
+build_secrets "$HOME_OK"
+install_fake_curl "$BIN_OK" "all" "ok"
+
+run "exit 0 when all contract states present" \
+  bash -c "HOME='$HOME_OK' PATH='$BIN_OK:$PATH' CATALYST_DIR='${SCRATCH}/ok/catalyst' \
+    '$SCRIPT' --config '${WORK_OK}/.catalyst/config.json'"
+
+run "writes execution-core stateMap (verifying -> Validate)" \
+  bash -c "jq -e '.catalyst.linear.stateMap.verifying == \"Validate\"' '${WORK_OK}/.catalyst/config.json'"
+
+run "writes execution-core stateMap (inReview -> PR)" \
+  bash -c "jq -e '.catalyst.linear.stateMap.inReview == \"PR\"' '${WORK_OK}/.catalyst/config.json'"
+
+run "upserts a registry entry for the team" \
+  bash -c "jq -e '.projects[] | select(.team == \"CTL\")' '${SCRATCH}/ok/catalyst/execution-core/registry.json'"
+
+# ─── Test: idempotent — re-run produces identical config ─────────────────────
+CONFIG_AFTER1="$(cat "${WORK_OK}/.catalyst/config.json")"
+HOME="$HOME_OK" PATH="$BIN_OK:$PATH" CATALYST_DIR="${SCRATCH}/ok/catalyst" \
+  "$SCRIPT" --config "${WORK_OK}/.catalyst/config.json" > /dev/null 2>&1 || true
+CONFIG_AFTER2="$(cat "${WORK_OK}/.catalyst/config.json")"
+run "re-run is idempotent (config unchanged)" \
+  bash -c "[ \"\$CONFIG_AFTER1\" = \"\$CONFIG_AFTER2\" ]"
+
+# ─── Test: workflowStateCreate fails -> states_incomplete + fallback printed ──
+WORK_FAIL="${SCRATCH}/fail"
+BIN_FAIL="${SCRATCH}/fail/bin"
+HOME_FAIL="${SCRATCH}/fail/home"
+build_repo "$WORK_FAIL"
+build_secrets "$HOME_FAIL"
+install_fake_curl "$BIN_FAIL" "partial" "create-fails"
+
+HOME="$HOME_FAIL" PATH="$BIN_FAIL:$PATH" CATALYST_DIR="${SCRATCH}/fail/catalyst" \
+  "$SCRIPT" --config "${WORK_FAIL}/.catalyst/config.json" \
+  > "${SCRATCH}/fail-out" 2>&1
+FAIL_RC=$?
+
+run "create-failure prints admin fallback instructions" \
+  bash -c "grep -qi 'linear' '${SCRATCH}/fail-out' && grep -qiE 'admin|app|manually' '${SCRATCH}/fail-out'"
+
+run "create-failure flags states_incomplete (exit 3)" \
+  bash -c "[ '$FAIL_RC' = '3' ]"
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -156,6 +156,50 @@ if [[ -n $CONFIG_PATH ]]; then
 		fi
 	fi
 
+	# Execution-core Linear-state contract check (CTL-564). Only when the repo is
+	# dispatchMode: execution-core: verify the 6 contract states are present in
+	# both stateMap VALUES and stateIds KEYS, and that a central registry entry
+	# exists for the team. Local-only — reads stateIds (already resolved from
+	# Linear by resolve-linear-ids.sh) and the registry file; no API call. Gaps
+	# are warnings, consistent with every other linear-config issue here.
+	DISPATCH_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // empty' "$CONFIG_PATH" 2>/dev/null)
+	if [[ $DISPATCH_MODE == "execution-core" ]]; then
+		# The contract states this check expects. Mirrors contract_states() in
+		# setup-execution-core-states.sh — keep the two in sync (different
+		# languages, so a shared constant is not possible).
+		EXECUTION_CORE_CONTRACT_STATES=(Ready Research Plan Implement Validate PR)
+		execution_core_gaps=0
+		for contract_state in "${EXECUTION_CORE_CONTRACT_STATES[@]}"; do
+			in_state_map=$(jq -r --arg s "$contract_state" \
+				'[.catalyst.linear.stateMap // {} | to_entries[].value] | index($s) // empty' \
+				"$CONFIG_PATH" 2>/dev/null)
+			in_state_ids=$(jq -r --arg s "$contract_state" \
+				'.catalyst.linear.stateIds // {} | has($s) | if . then "yes" else empty end' \
+				"$CONFIG_PATH" 2>/dev/null)
+			if [[ -z $in_state_map || -z $in_state_ids ]]; then
+				warnings+=("Execution-core contract state '$contract_state' missing from stateMap/stateIds in $CONFIG_PATH")
+				execution_core_gaps=$((execution_core_gaps + 1))
+			fi
+		done
+
+		# Registry entry — resolved via the same logic as registry.mjs/config.mjs.
+		REGISTRY_PATH="${CATALYST_DIR:-$HOME/catalyst}/execution-core/registry.json"
+		registry_has_team=""
+		if [[ -f $REGISTRY_PATH && -n $TEAM_KEY ]]; then
+			registry_has_team=$(jq -r --arg t "$TEAM_KEY" \
+				'[.projects // [] | .[] | select(.team == $t)] | length | if . > 0 then "yes" else empty end' \
+				"$REGISTRY_PATH" 2>/dev/null)
+		fi
+		if [[ -z $registry_has_team ]]; then
+			warnings+=("No execution-core registry entry for team '$TEAM_KEY' in $REGISTRY_PATH")
+			execution_core_gaps=$((execution_core_gaps + 1))
+		fi
+
+		if [[ $execution_core_gaps -gt 0 ]]; then
+			warnings+=("  Run setup-catalyst or plugins/dev/scripts/setup-execution-core-states.sh to fix the contract")
+		fi
+	fi
+
 	# Check Linear webhook registration (CTL-253) — gates whether Linear events reach the event log.
 	# The record lives in the cross-project Layer 2 file ($HOME_CONFIG_PATH); per-project secrets
 	# files (config-<projectKey>.json) hold the API token only. See setup-linear-webhook.sh.

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -41,6 +41,14 @@ export function getCursorPath() {
   return resolve(getExecutionCoreDir(), "cursor.json");
 }
 
+// CTL-564: the central execution-core registry — the single source for
+// team → repoRoot → eligibleQuery. The D4 successor to the per-repo
+// enrollment records; all access flows through registry.mjs (the D9 cloud
+// seam — file today, a Supabase table later).
+export function getRegistryPath() {
+  return resolve(getExecutionCoreDir(), "registry.json");
+}
+
 // Root for `claude --bg` job state dirs — ~/.claude/jobs/<bg_job_id>/state.json.
 // Env name matches orchestrate-healthcheck's CATALYST_HEALTHCHECK_JOBS_ROOT so
 // tests override one variable for both.

--- a/plugins/dev/scripts/execution-core/registry.mjs
+++ b/plugins/dev/scripts/execution-core/registry.mjs
@@ -1,0 +1,175 @@
+// registry.mjs — the central execution-core project registry (CTL-564).
+//
+// The registry is the D4 successor to CTL-554's per-repo enrollment records:
+// a single registry.json holds { team, repoRoot, eligibleQuery } for every
+// execution-core team. Per the D9 cloud guardrail, ALL registry I/O — read and
+// write — flows through this module, so the later file → Supabase swap happens
+// at one seam. CTL-565 (Part B) rewires the daemon onto listProjects(); this
+// ticket only writes the registry (setup tooling), it stays unread by the
+// daemon until then.
+//
+// Schema (~/catalyst/execution-core/registry.json):
+//   { "projects": [ { "team": "CTL", "repoRoot": "/abs/path",
+//                      "eligibleQuery": { "status": "Ready", ... } } ] }
+
+import {
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  mkdirSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { getRegistryPath, log } from "./config.mjs";
+
+// listProjects() — every well-formed entry in the registry. Missing file → [].
+// Malformed JSON → log.warn + []. An entry missing `team` or `repoRoot` is
+// skipped (it cannot be addressed or dispatched), mirroring enrollment.mjs's
+// listEnrolledProjects() defensiveness.
+export function listProjects() {
+  const file = getRegistryPath();
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    // ENOENT — registry not created yet — is the common, non-error case.
+    if (err?.code === "ENOENT") return [];
+    log.warn({ file, err: err.message }, "skipping malformed execution-core registry");
+    return [];
+  }
+  const entries = Array.isArray(parsed?.projects) ? parsed.projects : [];
+  const projects = [];
+  for (const entry of entries) {
+    if (!entry?.team || !entry?.repoRoot) {
+      log.warn({ file }, "skipping registry entry missing team or repoRoot");
+      continue;
+    }
+    projects.push({
+      team: entry.team,
+      repoRoot: entry.repoRoot,
+      eligibleQuery: entry.eligibleQuery ?? null,
+    });
+  }
+  return projects;
+}
+
+// getProjectConfig(team) — the single registry entry for `team`, or null when
+// the registry is missing or carries no matching entry.
+export function getProjectConfig(team) {
+  return listProjects().find((p) => p.team === team) ?? null;
+}
+
+// upsertProjectEntry — idempotently write a team's registry entry. Creates the
+// execution-core/ dir if absent; replaces an entry with a matching `team` in
+// place (never duplicates); preserves every other entry. The write is atomic
+// (tmp + renameSync, mirroring enrollment.mjs) so listProjects() never observes
+// a torn registry. Throws on missing `team`/`repoRoot`.
+export function upsertProjectEntry({ team, repoRoot, eligibleQuery } = {}) {
+  if (!team || !repoRoot) {
+    throw new Error("upsertProjectEntry: team and repoRoot are required");
+  }
+  const entry = {
+    team,
+    repoRoot,
+    eligibleQuery: eligibleQuery ?? null,
+  };
+  // Start from the current entries, drop any prior record for this team, then
+  // append the fresh one — replace-in-place semantics with no duplicates.
+  const projects = listProjects().filter((p) => p.team !== team);
+  projects.push(entry);
+
+  const file = getRegistryPath();
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  try {
+    writeFileSync(tmp, JSON.stringify({ projects }, null, 2));
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* tmp already gone */
+    }
+    throw err;
+  }
+  return entry;
+}
+
+// --- CLI ---------------------------------------------------------------------
+// `registry.mjs list`                              → JSON array of entries
+// `registry.mjs get <team>`                        → JSON object or empty
+// `registry.mjs upsert --team T --repo-root R --eligible-query JSON`
+//
+// The setup tooling (setup-execution-core-states.sh) invokes this CLI rather
+// than hand-writing registry JSON, keeping the D9 seam single.
+
+function parseFlags(argv) {
+  const flags = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key?.startsWith("--")) {
+      throw new Error(`registry.mjs: unexpected argument '${key}'`);
+    }
+    if (value === undefined) {
+      throw new Error(`registry.mjs: flag '${key}' is missing a value`);
+    }
+    flags[key.slice(2)] = value;
+  }
+  return flags;
+}
+
+function main(argv) {
+  const [command, ...rest] = argv;
+  switch (command) {
+    case "list": {
+      process.stdout.write(`${JSON.stringify(listProjects(), null, 2)}\n`);
+      return 0;
+    }
+    case "get": {
+      const team = rest[0];
+      if (!team) {
+        process.stderr.write("registry.mjs get: <team> is required\n");
+        return 1;
+      }
+      const entry = getProjectConfig(team);
+      process.stdout.write(entry ? `${JSON.stringify(entry, null, 2)}\n` : "");
+      return 0;
+    }
+    case "upsert": {
+      const flags = parseFlags(rest);
+      let eligibleQuery = null;
+      if (flags["eligible-query"] !== undefined) {
+        try {
+          eligibleQuery = JSON.parse(flags["eligible-query"]);
+        } catch (err) {
+          process.stderr.write(`registry.mjs upsert: invalid --eligible-query JSON: ${err.message}\n`);
+          return 1;
+        }
+      }
+      const entry = upsertProjectEntry({
+        team: flags.team,
+        repoRoot: flags["repo-root"],
+        eligibleQuery,
+      });
+      process.stdout.write(`${JSON.stringify(entry, null, 2)}\n`);
+      return 0;
+    }
+    default: {
+      process.stderr.write(
+        "registry.mjs: usage — list | get <team> | " +
+          "upsert --team T --repo-root R [--eligible-query JSON]\n"
+      );
+      return 1;
+    }
+  }
+}
+
+if (import.meta.main) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (err) {
+    process.stderr.write(`registry.mjs: ${err.message}\n`);
+    process.exit(1);
+  }
+}

--- a/plugins/dev/scripts/execution-core/registry.test.mjs
+++ b/plugins/dev/scripts/execution-core/registry.test.mjs
@@ -1,0 +1,240 @@
+// Unit tests for the execution-core central registry (CTL-564 Phase 1).
+// Run: cd plugins/dev/scripts/execution-core && bun test registry.test.mjs
+//
+// The registry is the D4 successor to the per-repo enrollment records and the
+// D9 cloud seam: all registry I/O flows through registry.mjs. These tests
+// follow enrollment.test.mjs's fixture pattern — CATALYST_DIR redirection and
+// mkdtempSync temp dirs — so they never touch a real ~/catalyst.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { getRegistryPath } from "./config.mjs";
+import { listProjects, getProjectConfig, upsertProjectEntry } from "./registry.mjs";
+
+let catalystDir;
+let registryDir;
+let prevCatalystDir;
+
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "exec-core-registry-"));
+  process.env.CATALYST_DIR = catalystDir;
+  registryDir = join(catalystDir, "execution-core");
+});
+
+afterEach(() => {
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+// Write the registry.json file directly (raw fixture for reader tests).
+function writeRegistry(obj) {
+  mkdirSync(registryDir, { recursive: true });
+  writeFileSync(
+    getRegistryPath(),
+    typeof obj === "string" ? obj : JSON.stringify(obj, null, 2)
+  );
+}
+
+describe("getRegistryPath", () => {
+  test("resolves to <CATALYST_DIR>/execution-core/registry.json", () => {
+    expect(getRegistryPath()).toBe(join(catalystDir, "execution-core", "registry.json"));
+  });
+});
+
+describe("listProjects", () => {
+  test("returns [] when the registry file is absent", () => {
+    expect(listProjects()).toEqual([]);
+  });
+
+  test("returns [] (and does not throw) when the registry is malformed JSON", () => {
+    writeRegistry("{ not valid json");
+    let got;
+    expect(() => {
+      got = listProjects();
+    }).not.toThrow();
+    expect(got).toEqual([]);
+  });
+
+  test("parses { projects: [...] } into the entry array", () => {
+    writeRegistry({
+      projects: [
+        { team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: { status: "Ready" } },
+        { team: "ADV", repoRoot: "/repos/adv", eligibleQuery: { status: "Ready" } },
+      ],
+    });
+    const got = listProjects();
+    expect(got).toHaveLength(2);
+    expect(got.map((p) => p.team).sort()).toEqual(["ADV", "CTL"]);
+    expect(got[0]).toEqual({
+      team: "CTL",
+      repoRoot: "/repos/ctl",
+      eligibleQuery: { status: "Ready" },
+    });
+  });
+
+  test("skips an entry missing team or repoRoot", () => {
+    writeRegistry({
+      projects: [
+        { team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: { status: "Ready" } },
+        { repoRoot: "/repos/noteam", eligibleQuery: { status: "Ready" } },
+        { team: "NOROOT", eligibleQuery: { status: "Ready" } },
+      ],
+    });
+    expect(listProjects().map((p) => p.team)).toEqual(["CTL"]);
+  });
+
+  test("returns [] when projects key is absent", () => {
+    writeRegistry({});
+    expect(listProjects()).toEqual([]);
+  });
+});
+
+describe("getProjectConfig", () => {
+  test("returns the matching entry for a known team", () => {
+    writeRegistry({
+      projects: [
+        { team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: { status: "Ready" } },
+        { team: "ADV", repoRoot: "/repos/adv", eligibleQuery: { status: "Ready" } },
+      ],
+    });
+    expect(getProjectConfig("CTL")).toEqual({
+      team: "CTL",
+      repoRoot: "/repos/ctl",
+      eligibleQuery: { status: "Ready" },
+    });
+  });
+
+  test("returns null for an unknown team", () => {
+    writeRegistry({
+      projects: [{ team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: {} }],
+    });
+    expect(getProjectConfig("UNKNOWN")).toBeNull();
+  });
+
+  test("returns null when the registry file is missing", () => {
+    expect(getProjectConfig("CTL")).toBeNull();
+  });
+});
+
+describe("upsertProjectEntry", () => {
+  test("creates the registry file and execution-core/ dir when absent", () => {
+    expect(existsSync(registryDir)).toBe(false);
+    upsertProjectEntry({
+      team: "CTL",
+      repoRoot: "/repos/ctl",
+      eligibleQuery: { status: "Ready" },
+    });
+    expect(existsSync(getRegistryPath())).toBe(true);
+    expect(listProjects().map((p) => p.team)).toEqual(["CTL"]);
+  });
+
+  test("appends a new team without touching existing entries", () => {
+    upsertProjectEntry({ team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: { status: "Ready" } });
+    upsertProjectEntry({ team: "ADV", repoRoot: "/repos/adv", eligibleQuery: { status: "Ready" } });
+    const got = listProjects();
+    expect(got).toHaveLength(2);
+    expect(got.map((p) => p.team).sort()).toEqual(["ADV", "CTL"]);
+    expect(getProjectConfig("CTL").repoRoot).toBe("/repos/ctl");
+  });
+
+  test("replaces an existing team in place — no duplicates (idempotent)", () => {
+    upsertProjectEntry({ team: "CTL", repoRoot: "/repos/old", eligibleQuery: { status: "Ready" } });
+    upsertProjectEntry({ team: "CTL", repoRoot: "/repos/new", eligibleQuery: { status: "Triage" } });
+    const got = listProjects();
+    expect(got).toHaveLength(1);
+    expect(got[0].repoRoot).toBe("/repos/new");
+    expect(got[0].eligibleQuery).toEqual({ status: "Triage" });
+  });
+
+  test("is atomic — leaves no .tmp file behind in execution-core/", () => {
+    upsertProjectEntry({ team: "CTL", repoRoot: "/repos/ctl", eligibleQuery: { status: "Ready" } });
+    expect(readdirSync(registryDir).some((f) => f.endsWith(".tmp"))).toBe(false);
+  });
+
+  test("throws when team is missing", () => {
+    expect(() => upsertProjectEntry({ repoRoot: "/repos/ctl" })).toThrow();
+  });
+
+  test("throws when repoRoot is missing", () => {
+    expect(() => upsertProjectEntry({ team: "CTL" })).toThrow();
+  });
+
+  test("returns the written entry", () => {
+    const entry = upsertProjectEntry({
+      team: "CTL",
+      repoRoot: "/repos/ctl",
+      eligibleQuery: { status: "Ready" },
+    });
+    expect(entry).toEqual({
+      team: "CTL",
+      repoRoot: "/repos/ctl",
+      eligibleQuery: { status: "Ready" },
+    });
+  });
+});
+
+describe("CLI (import.meta.main)", () => {
+  const registryCli = join(import.meta.dir, "registry.mjs");
+
+  function runCli(args) {
+    return execFileSync(process.execPath, [registryCli, ...args], {
+      env: { ...process.env, CATALYST_DIR: catalystDir },
+      encoding: "utf8",
+    });
+  }
+
+  test("upsert then list round-trips the entry", () => {
+    runCli([
+      "upsert",
+      "--team",
+      "CTL",
+      "--repo-root",
+      "/repos/ctl",
+      "--eligible-query",
+      '{"status":"Ready"}',
+    ]);
+    const out = JSON.parse(runCli(["list"]));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      team: "CTL",
+      repoRoot: "/repos/ctl",
+      eligibleQuery: { status: "Ready" },
+    });
+  });
+
+  test("get <team> prints the matching entry", () => {
+    runCli([
+      "upsert",
+      "--team",
+      "CTL",
+      "--repo-root",
+      "/repos/ctl",
+      "--eligible-query",
+      '{"status":"Ready"}',
+    ]);
+    const out = JSON.parse(runCli(["get", "CTL"]));
+    expect(out.team).toBe("CTL");
+    expect(out.repoRoot).toBe("/repos/ctl");
+  });
+
+  test("re-running upsert produces no duplicate", () => {
+    const args = [
+      "upsert",
+      "--team",
+      "CTL",
+      "--repo-root",
+      "/repos/ctl",
+      "--eligible-query",
+      '{"status":"Ready"}',
+    ];
+    runCli(args);
+    runCli(args);
+    const out = JSON.parse(runCli(["list"]));
+    expect(out).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# setup-execution-core-states — ensure a team's execution-core Linear-state
+# contract (CTL-564, Part A of the Linear State-Machine Trigger Model).
+#
+# For an execution-core repo this script, idempotently:
+#   1. Ensures the contract workflow states exist for the team
+#      (Ready + Research, Plan, Implement, Validate, PR — Triage already exists).
+#      Missing states are created via raw `workflowStateCreate` GraphQL; on a
+#      permission/transport failure it prints admin-in-app fallback instructions.
+#   2. Writes the execution-core stateMap — the 9-phase -> 5-state collapse —
+#      atomically into .catalyst/config.json.
+#   3. Refreshes stateIds by invoking resolve-linear-ids.sh --force.
+#   4. Upserts the team's central registry.json entry via registry.mjs.
+#
+# Standalone and idempotent — safe to re-run; run once per team (CTL, then Adva).
+#
+# Usage:
+#   setup-execution-core-states.sh [--config <path>] [--dry-run] [--json] [--force]
+#
+# Exit codes:
+#   0  success — contract states present or created, config + registry written
+#   1  usage error or missing prerequisite
+#   2  Linear API call failed (states query)
+#   3  states incomplete — a workflowStateCreate failed, fallback printed
+#      (callers such as setup-catalyst.sh may tolerate this)
+
+set -uo pipefail
+
+# --- The contract -----------------------------------------------------------
+# The execution-core 9-phase -> 5-state collapse map. `todo` maps to the
+# pickable contract state `Ready`; verify+review collapse to `Validate`;
+# pr+monitor-merge+monitor-deploy collapse to `PR`.
+build_execution_core_state_map() {
+  jq -nc '{
+    backlog: "Backlog",
+    todo: "Ready",
+    triage: "Triage",
+    research: "Research",
+    planning: "Plan",
+    inProgress: "Implement",
+    verifying: "Validate",
+    reviewing: "Validate",
+    inReview: "PR",
+    done: "Done",
+    canceled: "Canceled"
+  }'
+}
+
+# The contract states this script ensures, each with its Linear `type`.
+# Triage is intentionally excluded — it already exists in every team workflow.
+contract_states() {
+  jq -nc '[
+    { name: "Ready",     type: "unstarted" },
+    { name: "Research",  type: "unstarted" },
+    { name: "Plan",      type: "started"   },
+    { name: "Implement", type: "started"   },
+    { name: "Validate",  type: "started"   },
+    { name: "PR",        type: "started"   }
+  ]'
+}
+
+# missing_contract_states <fetched-states-json> — the contract state NAMES
+# absent from the fetched workflow-state set. Prints a space-separated list
+# (empty when the team already carries every contract state — idempotent).
+missing_contract_states() {
+  local fetched="$1"
+  local have name
+  have="$(echo "$fetched" | jq -r '.[].name' 2>/dev/null)"
+  for name in $(contract_states | jq -r '.[].name'); do
+    if ! grep -qxF "$name" <<<"$have"; then
+      printf '%s ' "$name"
+    fi
+  done
+}
+
+# build_workflow_state_create_mutation <teamId> <name> <type> <color> —
+# the raw GraphQL mutation string that creates one workflow state. `color` is
+# cosmetic; see CONTRACT_STATE_COLOR.
+build_workflow_state_create_mutation() {
+  local team_id="$1" name="$2" type="$3" color="$4"
+  cat <<MUTATION
+mutation {
+  workflowStateCreate(input: {
+    teamId: "${team_id}",
+    name: "${name}",
+    type: "${type}",
+    color: "${color}"
+  }) {
+    success
+    workflowState { id name }
+  }
+}
+MUTATION
+}
+
+# Cosmetic default color for created contract states (a neutral blue).
+CONTRACT_STATE_COLOR="#5e6ad2"
+
+# --- GraphQL transport ------------------------------------------------------
+# Isolated so tests can stub it via a fake `curl` earlier on PATH.
+# linear_graphql_post <token> <payload-json> — prints the raw response body.
+linear_graphql_post() {
+  local token="$1" payload="$2"
+  curl -s -X POST https://api.linear.app/graphql \
+    -H "Content-Type: application/json" \
+    -H "Authorization: ${token}" \
+    -d "$payload" 2>&1
+}
+
+# --- main -------------------------------------------------------------------
+main() {
+  local config="" dry_run=0 json_out=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --config)  config="$2"; shift 2 ;;
+      --dry-run) dry_run=1; shift ;;
+      --json)    json_out=1; shift ;;
+      # --force is accepted for CLI parity with resolve-linear-ids.sh. This
+      # script is unconditionally idempotent — it always rewrites stateMap and
+      # re-resolves stateIds (resolve-linear-ids.sh is called with --force
+      # below) — so --force is a documented no-op, kept so callers can pass it
+      # uniformly.
+      --force)   shift ;;
+      -h|--help) sed -n '2,24p' "$0" >&2; return 0 ;;
+      *) echo "ERROR: unknown arg: $1" >&2; return 1 ;;
+    esac
+  done
+
+  for tool in jq curl git; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "ERROR: $tool required" >&2
+      return 1
+    fi
+  done
+
+  # --- resolve config path ---
+  if [[ -z $config ]]; then
+    local dir; dir="$(pwd)"
+    while [[ $dir != "/" ]]; do
+      if [[ -f "${dir}/.catalyst/config.json" ]]; then
+        config="${dir}/.catalyst/config.json"; break
+      fi
+      dir="$(dirname "$dir")"
+    done
+  fi
+  if [[ -z $config || ! -f $config ]]; then
+    echo "ERROR: .catalyst/config.json not found" >&2
+    return 1
+  fi
+
+  local team_key project_key
+  team_key=$(jq -r '.catalyst.linear.teamKey // empty' "$config" 2>/dev/null)
+  project_key=$(jq -r '.catalyst.projectKey // empty' "$config" 2>/dev/null)
+  if [[ -z $team_key ]]; then
+    echo "ERROR: catalyst.linear.teamKey not set in $config" >&2
+    return 1
+  fi
+  if [[ -z $project_key ]]; then
+    echo "ERROR: catalyst.projectKey not set in $config" >&2
+    return 1
+  fi
+
+  # --- resolve repo root ---
+  # Use --git-common-dir so a worktree resolves to its canonical repo (matching
+  # orchestrate-execution-core-route.sh) — the registry must agree with it.
+  local config_dir repo_root common_dir
+  config_dir="$(cd "$(dirname "$config")/.." && pwd)"
+  if common_dir=$(git -C "$config_dir" rev-parse --git-common-dir 2>/dev/null); then
+    case "$common_dir" in
+      /*) : ;;
+      *)  common_dir="${config_dir}/${common_dir}" ;;
+    esac
+    repo_root="$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    repo_root="$config_dir"
+  fi
+
+  # --- resolve the Linear admin token ---
+  # Both shapes exist in the codebase: setup-catalyst.sh writes
+  # .catalyst.linear.apiToken, resolve-linear-ids.sh reads .linear.apiToken.
+  local secrets_path token
+  secrets_path="${HOME}/.config/catalyst/config-${project_key}.json"
+  if [[ ! -f $secrets_path ]]; then
+    echo "ERROR: secrets config not found at $secrets_path" >&2
+    return 1
+  fi
+  token=$(jq -r '.catalyst.linear.apiToken // .linear.apiToken // empty' "$secrets_path" 2>/dev/null)
+  if [[ -z $token ]]; then
+    echo "ERROR: Linear apiToken not found in $secrets_path" >&2
+    return 1
+  fi
+
+  # --- fetch the team's current workflow states ---
+  local query payload response
+  # $teamKey is a GraphQL variable inside this single-quoted query, not a shell var.
+  # shellcheck disable=SC2016
+  query='query($teamKey: String!) { teams(filter: { key: { eq: $teamKey } }) { nodes { id workflowStates { nodes { id name type } } } } }'
+  payload=$(jq -nc --arg q "$query" --arg k "$team_key" '{query: $q, variables: {teamKey: $k}}')
+  response=$(linear_graphql_post "$token" "$payload")
+
+  if echo "$response" | jq -e '.errors' >/dev/null 2>&1; then
+    local err
+    err=$(echo "$response" | jq -r '.errors[0].message // "unknown error"')
+    echo "ERROR: Linear API error fetching workflow states: $err" >&2
+    return 2
+  fi
+
+  local team_node team_id fetched_states
+  team_node=$(echo "$response" | jq -c '.data.teams.nodes[0] // empty' 2>/dev/null)
+  if [[ -z $team_node || $team_node == "null" ]]; then
+    echo "ERROR: team '$team_key' not found in Linear" >&2
+    return 2
+  fi
+  team_id=$(echo "$team_node" | jq -r '.id')
+  fetched_states=$(echo "$team_node" | jq -c '.workflowStates.nodes // []')
+
+  # --- diff against the contract ---
+  local missing
+  missing="$(missing_contract_states "$fetched_states")"
+  missing="${missing% }"  # trim trailing space
+
+  local state_map registry_query
+  state_map="$(build_execution_core_state_map)"
+  registry_query=$(jq -nc '{ status: "Ready", project: null, label: null, priority: null }')
+
+  # --- dry-run: report intent, write nothing ---
+  if [[ $dry_run -eq 1 ]]; then
+    if [[ $json_out -eq 1 ]]; then
+      jq -nc \
+        --arg team "$team_key" \
+        --arg repoRoot "$repo_root" \
+        --argjson stateMap "$state_map" \
+        --arg missing "$missing" \
+        '{
+          action: "dry-run",
+          team: $team,
+          repoRoot: $repoRoot,
+          missingStates: ($missing | if . == "" then [] else (. / " ") end),
+          stateMap: $stateMap
+        }'
+    else
+      echo "Dry run — execution-core state contract for team $team_key:"
+      if [[ -z $missing ]]; then
+        echo "  contract states: all present"
+      else
+        echo "  would create: $missing"
+      fi
+      echo "  would write stateMap:"
+      echo "$state_map" | jq -r 'to_entries[] | "    \(.key): \(.value)"'
+      echo "  would upsert registry entry: team=$team_key repoRoot=$repo_root"
+    fi
+    return 0
+  fi
+
+  # --- ensure missing contract states via workflowStateCreate ---
+  local states_incomplete=0 name type create_payload create_resp
+  if [[ -n $missing ]]; then
+    for name in $missing; do
+      type=$(contract_states | jq -r --arg n "$name" '.[] | select(.name==$n) | .type')
+      local mutation
+      mutation="$(build_workflow_state_create_mutation "$team_id" "$name" "$type" "$CONTRACT_STATE_COLOR")"
+      create_payload=$(jq -nc --arg q "$mutation" '{query: $q}')
+      create_resp=$(linear_graphql_post "$token" "$create_payload")
+      if echo "$create_resp" | jq -e '.errors' >/dev/null 2>&1 \
+        || [[ "$(echo "$create_resp" | jq -r '.data.workflowStateCreate.success // false')" != "true" ]]; then
+        states_incomplete=1
+        echo "WARNING: failed to create workflow state '$name'" >&2
+      else
+        echo "Created workflow state '$name' ($type)"
+      fi
+    done
+  fi
+
+  if [[ $states_incomplete -eq 1 ]]; then
+    echo "" >&2
+    echo "Could not create one or more contract states automatically." >&2
+    echo "Ask a Linear workspace admin to create them manually in the Linear app" >&2
+    echo "(Settings -> Teams -> ${team_key} -> Workflow), then re-run this script." >&2
+    echo "Missing states: $missing" >&2
+  fi
+
+  # --- write the execution-core stateMap (atomic tmp + mv) ---
+  jq --argjson stateMap "$state_map" '.catalyst.linear.stateMap = $stateMap' \
+    "$config" > "${config}.tmp" && mv "${config}.tmp" "$config"
+  echo "Wrote execution-core stateMap to $config"
+
+  # --- refresh stateIds via resolve-linear-ids.sh --force ---
+  local script_dir resolve
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  resolve="${script_dir}/resolve-linear-ids.sh"
+  if [[ -x $resolve ]]; then
+    if bash "$resolve" --config "$config" --force >/dev/null 2>&1; then
+      echo "Refreshed stateIds via resolve-linear-ids.sh"
+    else
+      echo "WARNING: resolve-linear-ids.sh failed — stateIds may be stale" >&2
+    fi
+  else
+    echo "WARNING: resolve-linear-ids.sh not found — stateIds not refreshed" >&2
+  fi
+
+  # --- upsert the central registry entry via registry.mjs ---
+  local registry_mjs runner=""
+  registry_mjs="${script_dir}/execution-core/registry.mjs"
+  if command -v bun >/dev/null 2>&1; then
+    runner="bun"
+  elif command -v node >/dev/null 2>&1; then
+    runner="node"
+  fi
+  if [[ -n $runner && -f $registry_mjs ]]; then
+    if "$runner" "$registry_mjs" upsert \
+      --team "$team_key" \
+      --repo-root "$repo_root" \
+      --eligible-query "$registry_query" >/dev/null 2>&1; then
+      echo "Upserted registry entry for team $team_key"
+    else
+      echo "WARNING: registry.mjs upsert failed for team $team_key" >&2
+    fi
+  else
+    echo "WARNING: cannot run registry.mjs (no bun/node, or module missing)" >&2
+  fi
+
+  # --- summary ---
+  if [[ $json_out -eq 1 ]]; then
+    jq -nc \
+      --arg team "$team_key" \
+      --arg repoRoot "$repo_root" \
+      --argjson incomplete "$states_incomplete" \
+      '{
+        action: (if $incomplete == 1 then "states_incomplete" else "complete" end),
+        team: $team,
+        repoRoot: $repoRoot
+      }'
+  fi
+
+  if [[ $states_incomplete -eq 1 ]]; then
+    return 3
+  fi
+  return 0
+}
+
+# Sourcing guard — when sourced (by the test suite) main does not run, so the
+# pure helpers above can be asserted directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+  exit $?
+fi

--- a/plugins/dev/skills/setup-catalyst/SKILL.md
+++ b/plugins/dev/skills/setup-catalyst/SKILL.md
@@ -81,6 +81,20 @@ a unified diff and asks for confirmation before merging. Concretely:
 6. If the user declines, leave `.catalyst/config.json` untouched. The drift warning continues to
    appear on subsequent workflow invocations, providing passive nagging until resolved.
 
+**Execution-core state contract (CTL-564).** When a repo's
+`catalyst.orchestration.dispatchMode` is `execution-core`, `setup-catalyst.sh`
+runs an extra step — `setup_execution_core_states` — right after the Linear
+workflow-state fetch. That step delegates to the standalone
+`plugins/dev/scripts/setup-execution-core-states.sh`, which ensures the team's
+contract workflow states exist (`Ready` + `Research`, `Plan`, `Implement`,
+`Validate`, `PR`; `Triage` already exists), writes the 9-phase → 5-state
+collapse `stateMap`, refreshes `stateIds`, and upserts the team's entry in the
+central `~/catalyst/execution-core/registry.json`. The step is a silent no-op
+for `phase-agents` / `oneshot-legacy` repos, and a Linear-permission failure in
+the standalone script never aborts setup. The standalone script is also
+idempotent and can be run directly per team (`setup-execution-core-states.sh
+--config .catalyst/config.json [--dry-run] [--json]`).
+
 For issues needing user input, explain what's needed and how to provide it:
 
 | Issue | What to tell the user |

--- a/plugins/dev/skills/setup-catalyst/__tests__/skill-shape.test.sh
+++ b/plugins/dev/skills/setup-catalyst/__tests__/skill-shape.test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# Smoke test: setup-catalyst SKILL.md mentions the config-drift merge (CTL-489).
+# Smoke test: setup-catalyst SKILL.md mentions the config-drift merge (CTL-489)
+# and the execution-core state-contract step (CTL-564).
 # Run: bash plugins/dev/skills/setup-catalyst/__tests__/skill-shape.test.sh
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL="${SCRIPT_DIR}/../SKILL.md"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+SETUP_CATALYST="${REPO_ROOT}/setup-catalyst.sh"
 
 FAILURES=0
 PASSES=0
@@ -16,12 +19,35 @@ assert_contains() {
   fi
 }
 
+# assert_grep <name> <file> <pattern> — extended-regex grep against any file.
+assert_grep() {
+  if grep -qE -- "$3" "$2"; then
+    PASSES=$((PASSES+1)); echo "  PASS: $1"
+  else
+    FAILURES=$((FAILURES+1)); echo "  FAIL: $1 (no match: $3)"
+  fi
+}
+
 assert_contains "Phase 2 table mentions drift" "Drift detected"
 assert_contains "Phase 2 references check-config-drift.sh" "check-config-drift.sh"
 assert_contains "Phase 2 mentions unified diff" "diff -u"
 assert_contains "Phase 2 mentions user confirmation" "confirmation"
 assert_contains "Phase 3 re-runs check after merge" "Re-run"
 assert_contains "Output Format shows Config Drift section" "Config Drift"
+
+# CTL-564 — the execution-core state-contract step.
+assert_contains "SKILL.md documents the execution-core step" "execution-core"
+assert_contains "SKILL.md references setup-execution-core-states.sh" "setup-execution-core-states.sh"
+
+# CTL-564 — setup-catalyst.sh wiring shape.
+assert_grep "setup-catalyst.sh defines setup_execution_core_states" \
+  "$SETUP_CATALYST" "^setup_execution_core_states\(\)"
+assert_grep "setup_execution_core_states branches on dispatchMode" \
+  "$SETUP_CATALYST" "dispatchMode"
+assert_grep "setup_execution_core_states branches on execution-core" \
+  "$SETUP_CATALYST" "execution-core"
+assert_grep "main() calls setup_execution_core_states" \
+  "$SETUP_CATALYST" "^[[:space:]]+setup_execution_core_states"
 
 echo ""
 echo "Results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -49,7 +49,7 @@
       "_comment": "Worker dispatch mode. 'phase-agents' (default) dispatches the 9-phase pipeline on claude --bg; 'oneshot-legacy' keeps the pre-CTL-452 single-shot oneshot worker on claude -p.",
       "dispatchMode": "phase-agents",
       "executionCore": {
-        "_comment": "M4 scheduler. eligibleQuery selects the per-project pickable ticket set the Todo-state monitor maintains. team falls back to catalyst.linear.teamKey; status is the literal Linear workflow state name; project/label/priority are optional narrowing filters (priority is a floor).",
+        "_comment": "M4 scheduler. eligibleQuery selects the per-project pickable ticket set the Todo-state monitor maintains. team falls back to catalyst.linear.teamKey; status is the literal Linear workflow state name (the execution-core state contract uses 'Ready' as the pickable state — see setup-execution-core-states.sh); project/label/priority are optional narrowing filters (priority is a floor). For dispatchMode 'execution-core' the team's entry is also mirrored into the central ~/catalyst/execution-core/registry.json by setup tooling.",
         "eligibleQuery": {
           "status": "Todo",
           "team": null,

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -312,6 +312,44 @@ update_config_with_linear_states() {
 	fi
 }
 
+# Ensure the execution-core Linear-state contract (CTL-564). A thin wrapper:
+# only when the resolved config's orchestration.dispatchMode is "execution-core"
+# does it invoke the standalone setup-execution-core-states.sh, which ensures the
+# contract states exist, writes the 9->5 collapse stateMap, refreshes stateIds,
+# and upserts the central registry entry. For phase-agents / oneshot-legacy repos
+# this is a silent no-op. A non-zero exit from the standalone script (e.g. a
+# Linear-permission failure) is tolerated (|| true) so it never aborts setup.
+setup_execution_core_states() {
+	# Resolve config the same way update_config_with_linear_states does:
+	# .catalyst/ with a .claude/ backward-compat fallback.
+	local config_file="${PROJECT_DIR}/.catalyst/config.json"
+	if [[ ! -f $config_file && -f "${PROJECT_DIR}/.claude/config.json" ]]; then
+		config_file="${PROJECT_DIR}/.claude/config.json"
+	fi
+	[[ -f $config_file ]] || return 0
+
+	local dispatch_mode
+	dispatch_mode=$(jq -r '.catalyst.orchestration.dispatchMode // empty' "$config_file" 2>/dev/null)
+	# Gate: only execution-core repos get the state-contract step.
+	[[ $dispatch_mode == "execution-core" ]] || return 0
+
+	# Locate the standalone script — installed plugin root or the repo checkout.
+	local states_script=""
+	if [[ -n ${CLAUDE_PLUGIN_ROOT:-} && -f "${CLAUDE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh" ]]; then
+		states_script="${CLAUDE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh"
+	elif [[ -f "plugins/dev/scripts/setup-execution-core-states.sh" ]]; then
+		states_script="plugins/dev/scripts/setup-execution-core-states.sh"
+	fi
+	if [[ -z $states_script ]]; then
+		print_warning "execution-core repo, but setup-execution-core-states.sh not found — skipping state contract"
+		return 0
+	fi
+
+	echo ""
+	echo "🔗 Ensuring execution-core Linear-state contract..."
+	bash "$states_script" --config "$config_file" || true
+}
+
 # Discover existing Sentry auth token
 discover_sentry_token() {
 	local token=""
@@ -2115,6 +2153,7 @@ main() {
 	setup_humanlayer_config
 	setup_catalyst_secrets
 	update_config_with_linear_states
+	setup_execution_core_states
 	init_session_database
 	init_humanlayer_thoughts
 	sync_thoughts

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -113,6 +113,66 @@ writes the results to `.catalyst/config.json`. Re-run with `--force` after chang
 in Linear. The cache is optional — `linear-transition.sh` falls back to name-based calls when
 `stateIds` is absent.
 
+### Execution-Core State Contract
+
+When `orchestration.dispatchMode` is `"execution-core"`, the team's Linear
+workflow states become the daemon's state machine, and `stateMap` is rewritten
+to a fixed **9-phase → 5-state collapse**. Setup tooling owns this contract — it
+is not a one-off migration.
+
+| `stateMap` key | Execution-core value |
+| -------------- | -------------------- |
+| `backlog`      | `Backlog`            |
+| `todo`         | `Ready`              |
+| `triage`       | `Triage`             |
+| `research`     | `Research`           |
+| `planning`     | `Plan`               |
+| `inProgress`   | `Implement`          |
+| `verifying`    | `Validate`           |
+| `reviewing`    | `Validate`           |
+| `inReview`     | `PR`                 |
+| `done`         | `Done`               |
+| `canceled`     | `Canceled`           |
+
+`verify` + `review` collapse to `Validate`; `pr` + `monitor-merge` +
+`monitor-deploy` collapse to `PR`. The six **contract states** —
+`Ready`, `Research`, `Plan`, `Implement`, `Validate`, `PR` (`Triage` already
+exists in every team workflow) — are ensured in Linear by
+`plugins/dev/scripts/setup-execution-core-states.sh`. That script is idempotent,
+runs once per team, and is invoked automatically by `setup-catalyst.sh` for
+`execution-core` repos. It writes the collapse `stateMap`, refreshes `stateIds`,
+and upserts the team's registry entry. Run it directly with `--dry-run --json`
+to preview the contract without writing anything.
+
+### Central Registry (`~/catalyst/execution-core/registry.json`)
+
+For `execution-core` teams, the central registry is the single source of
+`team → repoRoot → eligibleQuery`. It is **execution-core only** — `phase-agents`
+and `oneshot-legacy` repos never write or read it. Schema:
+
+```jsonc
+{
+  "projects": [
+    {
+      "team": "CTL",
+      "repoRoot": "/abs/path/to/repo",
+      "eligibleQuery": { "status": "Ready", "project": null, "label": null, "priority": null }
+    }
+  ]
+}
+```
+
+All registry access flows through `plugins/dev/scripts/execution-core/registry.mjs`
+(`listProjects`, `getProjectConfig`, `upsertProjectEntry`, plus a
+`list | get | upsert` CLI) so the access path stays a single seam. The registry
+is the successor to the per-repo enrollment records under
+`~/catalyst/execution-core/projects/`.
+
+`check-project-setup.sh` adds an **execution-core verification check**: when a
+repo is `dispatchMode: execution-core`, it warns if any contract state is
+missing from `stateMap`/`stateIds` or if no registry entry exists for the team,
+pointing the operator at `setup-catalyst` / `setup-execution-core-states.sh`.
+
 ### Plain-Language State Flow
 
 In most teams, the intended meaning is:


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-21T20:16:28Z -->
<!-- Last updated: 2026-05-21T20:16:28Z -->
<!-- PR: #954 -->
<!-- Previous commits: 9e46fae830c227fcb3cd48b1ac2cc14adf038c85,78a18afaf6a65f0b97c1b523c16448e749533012,873c72055e003267b6d619d360e15c2f94fdd76c,c4702a83c8b8bfb9c35da4c5f41b63649f4afa0c,358c711481557ca3202f0e18adce2ed8937a239c -->

## Summary

Part A of the **Linear State-Machine Trigger Model** (design decision **D8**). The
execution-core's 5-state Linear contract becomes **setup-tooling-owned** rather than a
one-off migration — `setup-catalyst` now provisions and verifies the contract on every
run, and a central registry replaces CTL-554's per-repo enrollment records.

## Changes Made

### Execution-core state provisioning

- **`plugins/dev/scripts/setup-execution-core-states.sh`** (new, 347 lines) — standalone,
  idempotent script that, for an `execution-core` repo, ensures the contract Linear states
  exist (`Ready` + `Research`/`Plan`/`Implement`/`Validate`/`PR`; `Triage` already
  exists) via raw GraphQL `workflowStateCreate`, writes the 9-phase → 5-state `stateMap`,
  refreshes `stateIds`, and upserts the team's registry entry.
- **`setup-catalyst.sh`** — calls the script as a new step, gated on
  `dispatchMode: execution-core`.
- **`plugins/dev/skills/setup-catalyst/SKILL.md`** — documents the new step.

### Central registry

- **`plugins/dev/scripts/execution-core/registry.mjs`** (new, 175 lines) — central
  `registry.json` plus a `list-projects` / `get-project-config` interface module,
  replacing CTL-554's per-repo enrollment records.
- **`plugins/dev/scripts/execution-core/config.mjs`** — registry path config.

### Verification

- **`plugins/dev/scripts/check-project-setup.sh`** — adds an execution-core contract
  verification check.

### Docs & config

- **`docs/architecture.md`**, **`website/.../reference/configuration.md`** — document the
  registry and state contract.
- **`plugins/dev/templates/config.template.json`** — template update.

## How to Verify It

- [x] `audit-references` CI check — passed ✅
- [x] `check-versions` CI check — passed ✅
- [x] `validate` CI check — passed ✅
- [x] Test suite: 4 new test files (`setup-execution-core-states.test.sh`,
  `check-project-setup-execution-core.test.sh`, `execution-core-docs-shape.test.sh`,
  `registry.test.mjs`) — ~735 lines of coverage
- [ ] Cloudflare Pages docs preview (deploy-time, non-blocking)

## Notes

- The script is idempotent and intended to run per-team (CTL, then Adva).
- Diff: 14 files, +1461 / -2 — mostly new modules and their tests.

## Related Issues/PRs

- Refs: CTL-564
- Depends on: CTL-554 (registry supersedes its per-repo enrollment records)
