### PR TITLE
CTL-567: Reap completed phase-agent claude --bg jobs (dispatcher-owned)

### DIFF
--- a/plugins/dev/scripts/__tests__/lib-executor.test.sh
+++ b/plugins/dev/scripts/__tests__/lib-executor.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Shell tests for lib/executor.sh (CTL-567).
+# Run: bash plugins/dev/scripts/__tests__/lib-executor.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/executor.sh"
+
+FAILURES=0
+PASSES=0
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+[ -f "$LIB" ] || {
+	echo "FATAL: lib not found at $LIB"
+	exit 1
+}
+# shellcheck source=/dev/null
+source "$LIB"
+
+# Fake `claude`: logs argv; `stop` honors $STOP_RC; `agents --json` echoes a
+# session whose pid is $FAKE_PID (default 0 → no live process).
+setup() {
+	SCRATCH="$(mktemp -d)"
+	CLAUDE_LOG="${SCRATCH}/claude.log"
+	: >"$CLAUDE_LOG"
+	cat >"${SCRATCH}/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$CLAUDE_LOG"
+case "$1" in
+  stop)   exit "${STOP_RC:-0}" ;;
+  agents) echo "[{\"sessionId\":\"sess-xyz\",\"pid\":${FAKE_PID:-0}}]" ;;
+esac
+EOF
+	chmod +x "${SCRATCH}/claude"
+	export CATALYST_DISPATCH_CLAUDE_BIN="${SCRATCH}/claude"
+	export CLAUDE_LOG
+	unset _EXECUTOR_AGENTS_CACHE
+}
+
+teardown() {
+	rm -rf "$SCRATCH"
+	unset SCRATCH CLAUDE_LOG CATALYST_DISPATCH_CLAUDE_BIN
+	unset CATALYST_EXECUTOR_CPU_PROBE CATALYST_EXECUTOR_JOBS_ROOT
+	unset STOP_RC FAKE_PID _EXECUTOR_AGENTS_CACHE
+}
+
+# make_cpu_probe VALUE — install a CPU probe that always echoes VALUE.
+make_cpu_probe() {
+	cat >"${SCRATCH}/cpuprobe" <<EOF
+#!/usr/bin/env bash
+echo "${1}"
+EOF
+	chmod +x "${SCRATCH}/cpuprobe"
+	export CATALYST_EXECUTOR_CPU_PROBE="${SCRATCH}/cpuprobe"
+}
+
+# ─── Test cases ───────────────────────────────────────────────────────────────
+
+echo "test 1: low CPU → job is stopped"
+setup
+make_cpu_probe "0.4"
+OUT=$(executor_reap "abc12345")
+RC=$?
+[ "$OUT" = "stopped" ] && pass "echoes 'stopped'" || fail "echoes 'stopped'" "got: $OUT"
+[ "$RC" = "0" ] && pass "returns 0" || fail "returns 0" "rc=$RC"
+grep -q -- "stop abc12345" "$CLAUDE_LOG" && pass "claude stop called" || fail "claude stop called" "log: $(cat "$CLAUDE_LOG")"
+teardown
+
+echo "test 2: high CPU → skipped-active, no stop call"
+setup
+make_cpu_probe "40"
+OUT=$(executor_reap "abc12345")
+RC=$?
+[ "$OUT" = "skipped-active" ] && pass "echoes 'skipped-active'" || fail "echoes 'skipped-active'" "got: $OUT"
+[ "$RC" = "1" ] && pass "returns 1" || fail "returns 1" "rc=$RC"
+! grep -q -- "stop" "$CLAUDE_LOG" && pass "claude stop NOT called" || fail "claude stop NOT called" "log: $(cat "$CLAUDE_LOG")"
+teardown
+
+echo "test 3: unknown CPU → job is stopped (fail-safe: nothing live to protect)"
+setup
+make_cpu_probe ""
+OUT=$(executor_reap "abc12345")
+[ "$OUT" = "stopped" ] && pass "unknown CPU still reaps" || fail "unknown CPU still reaps" "got: $OUT"
+teardown
+
+echo "test 4: empty job id → skipped-empty"
+setup
+OUT=$(executor_reap "")
+RC=$?
+[ "$OUT" = "skipped-empty" ] && pass "echoes 'skipped-empty'" || fail "echoes 'skipped-empty'" "got: $OUT"
+[ "$RC" = "1" ] && pass "returns 1" || fail "returns 1" "rc=$RC"
+teardown
+
+echo "test 5: claude stop exits non-zero → stop-failed"
+setup
+make_cpu_probe "0"
+export STOP_RC=1
+OUT=$(executor_reap "abc12345")
+RC=$?
+[ "$OUT" = "stop-failed" ] && pass "echoes 'stop-failed'" || fail "echoes 'stop-failed'" "got: $OUT"
+[ "$RC" = "1" ] && pass "returns 1" || fail "returns 1" "rc=$RC"
+teardown
+
+echo "test 6: executor_claude_bin honors CATALYST_DISPATCH_CLAUDE_BIN"
+setup
+[ "$(executor_claude_bin)" = "${SCRATCH}/claude" ] && pass "returns override" || fail "returns override" "got: $(executor_claude_bin)"
+teardown
+
+echo "test 7: CPU exactly at ceiling (3) is not 'active' — strictly greater wins"
+setup
+make_cpu_probe "3"
+OUT=$(executor_reap "abc12345")
+[ "$OUT" = "stopped" ] && pass "CPU==ceiling reaps" || fail "CPU==ceiling reaps" "got: $OUT"
+teardown
+
+echo "test 8: executor_job_cpu resolves via state.json → claude agents → ps"
+setup
+mkdir -p "${SCRATCH}/jobs/dead00ff"
+echo '{"sessionId":"sess-xyz"}' >"${SCRATCH}/jobs/dead00ff/state.json"
+export CATALYST_EXECUTOR_JOBS_ROOT="${SCRATCH}/jobs"
+export FAKE_PID=$$ # this test's own pid — a guaranteed-live process
+CPU=$(executor_job_cpu "dead00ff")
+echo "$CPU" | grep -qE '^[0-9.]+$' && pass "resolves a numeric CPU via the chain" || fail "resolves a numeric CPU via the chain" "got: '$CPU'"
+teardown
+
+echo "test 9: executor_job_cpu → empty when state.json is missing"
+setup
+export CATALYST_EXECUTOR_JOBS_ROOT="${SCRATCH}/jobs" # dir absent
+CPU=$(executor_job_cpu "nope0000")
+[ -z "$CPU" ] && pass "missing state.json → empty CPU" || fail "missing state.json → empty CPU" "got: '$CPU'"
+teardown
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
@@ -397,6 +397,68 @@ else
 	fi
 fi
 
+# ─── CTL-567: reap sweep delegates to phase-agent-watch-bg ───────────────────
+#
+# After the stall checks, the healthcheck `claude stop`s completed phase jobs by
+# calling `phase-agent-watch-bg reap --scope done`. Stub watch-bg so the test
+# never touches the real `claude` binary.
+
+# install_fake_watch_bg [REAPED_COUNT]
+install_fake_watch_bg() {
+	export WATCHBG_LOG="${SCRATCH}/watchbg.log"
+	: >"$WATCHBG_LOG"
+	export FAKE_REAPED="${1:-2}"
+	cat >"${SCRATCH}/bin/phase-agent-watch-bg" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$WATCHBG_LOG"
+echo "{\"scanned\":${FAKE_REAPED:-0},\"reaped\":${FAKE_REAPED:-0},\"skipped\":0,\"dryRun\":false,\"results\":[]}"
+EOF
+	chmod +x "${SCRATCH}/bin/phase-agent-watch-bg"
+	export CATALYST_WATCH_BG_BIN="${SCRATCH}/bin/phase-agent-watch-bg"
+}
+
+echo "test (CTL-567): healthcheck calls phase-agent-watch-bg reap --scope done"
+scratch_setup
+install_fake_watch_bg 2
+make_phase_signal "T-R1" "research" "done" "bg-r1"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
+if grep -q -- "reap" "$WATCHBG_LOG" && grep -q -- "--scope done" "$WATCHBG_LOG"; then
+	pass "reap invoked with --scope done"
+else
+	fail "reap invoked with --scope done" "log: $(cat "$WATCHBG_LOG")"
+fi
+grep -q -- "--orch-dir ${ORCH_DIR}" "$WATCHBG_LOG" && pass "reap passed --orch-dir" || fail "reap passed --orch-dir" "log: $(cat "$WATCHBG_LOG")"
+unset WATCHBG_LOG FAKE_REAPED CATALYST_WATCH_BG_BIN
+scratch_teardown
+
+echo "test (CTL-567): summary JSON carries the reaped count from watch-bg"
+scratch_setup
+install_fake_watch_bg 3
+OUT=$("$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 2>/dev/null)
+REAPED=$(echo "$OUT" | jq -r '.reaped' 2>/dev/null || echo "")
+[ "$REAPED" = "3" ] && pass "summary.reaped=3" || fail "summary.reaped=3" "got: $REAPED; out: $OUT"
+unset WATCHBG_LOG FAKE_REAPED CATALYST_WATCH_BG_BIN
+scratch_teardown
+
+echo "test (CTL-567): --dry-run forwards --dry-run to the reap sweep"
+scratch_setup
+install_fake_watch_bg 0
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --dry-run >/dev/null 2>&1
+grep -q -- "--dry-run" "$WATCHBG_LOG" && pass "--dry-run forwarded to watch-bg" || fail "--dry-run forwarded to watch-bg" "log: $(cat "$WATCHBG_LOG")"
+unset WATCHBG_LOG FAKE_REAPED CATALYST_WATCH_BG_BIN
+scratch_teardown
+
+echo "test (CTL-567): missing watch-bg binary is non-fatal — summary.reaped=0"
+scratch_setup
+export CATALYST_WATCH_BG_BIN="${SCRATCH}/bin/no-such-watch-bg"
+OUT=$("$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 2>/dev/null)
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 with watch-bg absent" || fail "exit 0 with watch-bg absent" "rc=$RC"
+REAPED=$(echo "$OUT" | jq -r '.reaped' 2>/dev/null || echo "")
+[ "$REAPED" = "0" ] && pass "summary.reaped=0 when watch-bg absent" || fail "summary.reaped=0 when watch-bg absent" "got: $REAPED; out: $OUT"
+unset CATALYST_WATCH_BG_BIN
+scratch_teardown
+
 echo
 echo "Results: $PASSES passed, $FAILURES failed"
 [ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/orchestrate-phase-advance.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-phase-advance.test.sh
@@ -41,12 +41,35 @@ EOF
   export DISPATCH_LOG="${SCRATCH}/dispatch.log"
   : > "$DISPATCH_LOG"
   export CATALYST_DISPATCH_NEXT_BIN="${SCRATCH}/bin/orchestrate-dispatch-next"
+
+  # CTL-567: fake `claude` for the predecessor reap — logs `stop` calls.
+  cat > "${SCRATCH}/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$CLAUDE_LOG"
+case "$1" in
+  stop)   exit 0 ;;
+  agents) echo '[]' ;;
+esac
+EOF
+  chmod +x "${SCRATCH}/bin/claude"
+  export CLAUDE_LOG="${SCRATCH}/claude.log"
+  : > "$CLAUDE_LOG"
+  export CATALYST_DISPATCH_CLAUDE_BIN="${SCRATCH}/bin/claude"
+
+  # Idle CPU probe so the safety belt always permits the reap.
+  cat > "${SCRATCH}/bin/cpuprobe" <<'EOF'
+#!/usr/bin/env bash
+echo "0"
+EOF
+  chmod +x "${SCRATCH}/bin/cpuprobe"
+  export CATALYST_EXECUTOR_CPU_PROBE="${SCRATCH}/bin/cpuprobe"
 }
 
 scratch_teardown() {
   rm -rf "$SCRATCH"
-  unset SCRATCH ORCH_DIR STATE_LOG DISPATCH_LOG
+  unset SCRATCH ORCH_DIR STATE_LOG DISPATCH_LOG CLAUDE_LOG
   unset CATALYST_STATE_SCRIPT CATALYST_DISPATCH_NEXT_BIN
+  unset CATALYST_DISPATCH_CLAUDE_BIN CATALYST_EXECUTOR_CPU_PROBE
 }
 
 # make_phase_signal TICKET PHASE STATUS [EXTRA_JQ]
@@ -153,6 +176,47 @@ for pair in "${SEQ[@]}"; do
   TOPHASE=$(echo "$OUT" | jq -r '.toPhase')
   [ "$TOPHASE" = "$TO" ] && pass "$FROM → $TO" || fail "$FROM → $TO" "got toPhase=$TOPHASE for OUT=$OUT"
 done
+scratch_teardown
+
+echo "test 9 (CTL-567): predecessor with status=done + bg_job_id is reaped"
+scratch_setup
+make_phase_signal "T-1" "research" "done" '.bg_job_id = "abc12345"'
+OUT=$(run_advance --ticket "T-1" --completed-phase "research" 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0" || fail "exit 0" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+echo "$OUT" | jq -e '.advanced == true and .reapedPredecessor == true' >/dev/null \
+  && pass "reapedPredecessor=true in output" || fail "reapedPredecessor=true in output" "got: $OUT"
+grep -q -- "stop abc12345" "$CLAUDE_LOG" \
+  && pass "claude stop called on predecessor bg job" || fail "claude stop called on predecessor bg job" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test 10 (CTL-567): predecessor with bg_job_id but status!=done is NOT reaped"
+scratch_setup
+make_phase_signal "T-1" "research" "running" '.bg_job_id = "abc12345"'
+OUT=$(run_advance --ticket "T-1" --completed-phase "research" 2>"${SCRATCH}/err")
+echo "$OUT" | jq -e '.advanced == true and .reapedPredecessor == false' >/dev/null \
+  && pass "reapedPredecessor=false for non-done predecessor" || fail "reapedPredecessor=false for non-done predecessor" "got: $OUT"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude stop NOT called" || fail "claude stop NOT called" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test 11 (CTL-567): predecessor with no bg_job_id — advance still succeeds, no reap"
+scratch_setup
+make_phase_signal "T-1" "plan" "done"
+OUT=$(run_advance --ticket "T-1" --completed-phase "plan" 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 with no bg_job_id" || fail "exit 0 with no bg_job_id" "rc=$RC"
+echo "$OUT" | jq -e '.advanced == true and .reapedPredecessor == false' >/dev/null \
+  && pass "advances, reapedPredecessor=false" || fail "advances, reapedPredecessor=false" "got: $OUT"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude stop NOT called" || fail "claude stop NOT called"
+scratch_teardown
+
+echo "test 12 (CTL-567): --dry-run never reaps (returns before dispatch)"
+scratch_setup
+make_phase_signal "T-1" "research" "done" '.bg_job_id = "abc12345"'
+OUT=$(run_advance --ticket "T-1" --completed-phase "research" --dry-run 2>"${SCRATCH}/err")
+echo "$OUT" | jq -e '.dryRun == true' >/dev/null \
+  && pass "dry-run reported" || fail "dry-run reported" "got: $OUT"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude stop NOT called in dry-run" || fail "claude stop NOT called in dry-run" "log: $(cat "$CLAUDE_LOG")"
 scratch_teardown
 
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-agent-watch-bg.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-watch-bg.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Shell tests for the phase-agent-watch-bg `reap` subcommand (CTL-567).
+# Run: bash plugins/dev/scripts/__tests__/phase-agent-watch-bg.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+WATCH_BG="${REPO_ROOT}/plugins/dev/scripts/phase-agent-watch-bg"
+
+FAILURES=0
+PASSES=0
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+scratch_setup() {
+	SCRATCH="$(mktemp -d)"
+	ORCH_DIR="${SCRATCH}/orch"
+	mkdir -p "${ORCH_DIR}/workers"
+
+	# Fake `claude`: logs argv; `stop` succeeds; `agents` is unused (CPU probe).
+	CLAUDE_LOG="${SCRATCH}/claude.log"
+	: >"$CLAUDE_LOG"
+	cat >"${SCRATCH}/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$CLAUDE_LOG"
+case "$1" in
+  stop)   exit 0 ;;
+  agents) echo '[]' ;;
+esac
+EOF
+	chmod +x "${SCRATCH}/claude"
+	export CATALYST_DISPATCH_CLAUDE_BIN="${SCRATCH}/claude"
+	export CLAUDE_LOG
+
+	# CPU probe: every job idle (0%) unless its id contains "busy" (99%).
+	cat >"${SCRATCH}/cpuprobe" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  *busy*) echo "99" ;;
+  *)      echo "0" ;;
+esac
+EOF
+	chmod +x "${SCRATCH}/cpuprobe"
+	export CATALYST_EXECUTOR_CPU_PROBE="${SCRATCH}/cpuprobe"
+}
+
+scratch_teardown() {
+	rm -rf "$SCRATCH"
+	unset SCRATCH ORCH_DIR CLAUDE_LOG
+	unset CATALYST_DISPATCH_CLAUDE_BIN CATALYST_EXECUTOR_CPU_PROBE
+}
+
+# make_signal TICKET PHASE STATUS BG_JOB_ID  (BG_JOB_ID="null" → JSON null)
+make_signal() {
+	local t="$1" p="$2" s="$3" bg="$4"
+	mkdir -p "${ORCH_DIR}/workers/${t}"
+	if [ "$bg" = "null" ]; then
+		jq -n --arg t "$t" --arg p "$p" --arg s "$s" \
+			'{ticket:$t, phase:$p, status:$s, bg_job_id:null}' \
+			>"${ORCH_DIR}/workers/${t}/phase-${p}.json"
+	else
+		jq -n --arg t "$t" --arg p "$p" --arg s "$s" --arg bg "$bg" \
+			'{ticket:$t, phase:$p, status:$s, bg_job_id:$bg}' \
+			>"${ORCH_DIR}/workers/${t}/phase-${p}.json"
+	fi
+}
+
+run_reap() { "$WATCH_BG" reap --orch-dir "$ORCH_DIR" --json "$@"; }
+
+# ─── Test cases ───────────────────────────────────────────────────────────────
+
+echo "test 1: --scope done reaps only done signals"
+scratch_setup
+make_signal "T-1" "research" "done" "aaaa1111"
+make_signal "T-1" "plan" "running" "bbbb2222"
+make_signal "T-2" "implement" "failed" "cccc3333"
+OUT=$(run_reap --scope "done")
+echo "$OUT" | jq -e '.scanned == 1 and .reaped == 1 and .skipped == 0' >/dev/null \
+	&& pass "only the done signal is reaped" || fail "only the done signal is reaped" "got: $OUT"
+grep -q -- "stop aaaa1111" "$CLAUDE_LOG" && pass "done job stopped" || fail "done job stopped" "log: $(cat "$CLAUDE_LOG")"
+! grep -q "bbbb2222" "$CLAUDE_LOG" && pass "running job left alone" || fail "running job left alone"
+! grep -q "cccc3333" "$CLAUDE_LOG" && pass "failed job left alone (exemption)" || fail "failed job left alone (exemption)"
+scratch_teardown
+
+echo "test 2: --scope all reaps every signal with a bg_job_id"
+scratch_setup
+make_signal "T-1" "research" "done" "aaaa1111"
+make_signal "T-1" "plan" "running" "bbbb2222"
+make_signal "T-2" "implement" "failed" "cccc3333"
+OUT=$(run_reap --scope all)
+echo "$OUT" | jq -e '.scanned == 3 and .reaped == 3' >/dev/null \
+	&& pass "all three reaped" || fail "all three reaped" "got: $OUT"
+grep -q -- "stop aaaa1111" "$CLAUDE_LOG" && grep -q -- "stop bbbb2222" "$CLAUDE_LOG" &&
+	grep -q -- "stop cccc3333" "$CLAUDE_LOG" && pass "every bg job stopped" || fail "every bg job stopped" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test 3: signals with null bg_job_id are skipped"
+scratch_setup
+make_signal "T-1" "research" "done" "null"
+make_signal "T-2" "plan" "done" "dddd4444"
+OUT=$(run_reap --scope "done")
+echo "$OUT" | jq -e '.scanned == 1 and .reaped == 1' >/dev/null \
+	&& pass "null bg_job_id not counted" || fail "null bg_job_id not counted" "got: $OUT"
+grep -q -- "stop dddd4444" "$CLAUDE_LOG" && pass "real job still reaped" || fail "real job still reaped"
+scratch_teardown
+
+echo "test 4: --dry-run reaps nothing, reports would-reap"
+scratch_setup
+make_signal "T-1" "research" "done" "aaaa1111"
+OUT=$(run_reap --scope "done" --dry-run)
+echo "$OUT" | jq -e '.dryRun == true and .reaped == 1' >/dev/null \
+	&& pass "dry-run reports a candidate" || fail "dry-run reports a candidate" "got: $OUT"
+echo "$OUT" | jq -e '.results[0].result == "would-reap"' >/dev/null \
+	&& pass "result is would-reap" || fail "result is would-reap" "got: $OUT"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude stop NOT called in dry-run" || fail "claude stop NOT called in dry-run" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test 5: CPU safety belt — an active job is skipped, not stopped"
+scratch_setup
+make_signal "T-1" "research" "done" "busy0001"
+OUT=$(run_reap --scope "done")
+echo "$OUT" | jq -e '.scanned == 1 and .reaped == 0 and .skipped == 1' >/dev/null \
+	&& pass "active job counted as skipped" || fail "active job counted as skipped" "got: $OUT"
+echo "$OUT" | jq -e '.results[0].result == "skipped-active"' >/dev/null \
+	&& pass "result is skipped-active" || fail "result is skipped-active" "got: $OUT"
+! grep -q "stop busy0001" "$CLAUDE_LOG" && pass "active job NOT stopped" || fail "active job NOT stopped" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test 6: unknown --scope value → exit 1 with a clear message"
+scratch_setup
+OUT=$("$WATCH_BG" reap --orch-dir "$ORCH_DIR" --scope bogus 2>&1)
+RC=$?
+[ "$RC" = "1" ] && pass "exit 1 on bad scope" || fail "exit 1 on bad scope" "rc=$RC"
+echo "$OUT" | grep -qi "scope" && pass "message mentions scope" || fail "message mentions scope" "got: $OUT"
+scratch_teardown
+
+echo "test 7: empty run directory → scanned 0, reaped 0"
+scratch_setup
+OUT=$(run_reap --scope all)
+echo "$OUT" | jq -e '.scanned == 0 and .reaped == 0 and .skipped == 0' >/dev/null \
+	&& pass "empty run reaps nothing" || fail "empty run reaps nothing" "got: $OUT"
+scratch_teardown
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/lib/executor.sh
+++ b/plugins/dev/scripts/lib/executor.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# lib/executor.sh — executor seam for phase-agent background jobs (CTL-567).
+#
+# Sourceable library. The single place that owns the two `claude` background-job
+# verbs — `claude --bg` (launch) and `claude stop` (reap). Keeping both behind
+# this one file means a cloud executor (Claude Managed Agent, etc.) can swap the
+# launch and the stop together by replacing this file alone (design doc D9).
+#
+# This file is sourced into scripts that run with `set -uo pipefail`; it does
+# NOT `set -e` and every function is safe to call without aborting the caller.
+#
+# Functions:
+#   executor_claude_bin          echo the claude binary to use
+#   executor_job_cpu <job_id>    echo the job process CPU% (float), or "" if unknown
+#   executor_reap <job_id>       CPU-safety-belt + `claude stop`; echo a status word
+#
+# Env overrides:
+#   CATALYST_DISPATCH_CLAUDE_BIN  claude binary (default: `claude` on PATH). Same
+#                                 var the dispatchers already honor for the launch.
+#   CATALYST_EXECUTOR_JOBS_ROOT   bg-job state dir (default: $CLAUDE_BG_JOBS_DIR
+#                                 or ~/.claude/jobs)
+#   CATALYST_EXECUTOR_CPU_PROBE   test hook: a command run as `$cmd <job_id>` that
+#                                 echoes the job's CPU%, bypassing the
+#                                 state.json → claude agents → ps resolution chain
+#   EXECUTOR_CPU_REAP_CEILING     CPU% above which a job counts as actively
+#                                 computing and is NOT reaped (default: 3)
+
+# executor_claude_bin — the claude binary. Cloud-executor swap point.
+executor_claude_bin() {
+	echo "${CATALYST_DISPATCH_CLAUDE_BIN:-claude}"
+}
+
+# _executor_jobs_root — where `claude --bg` writes per-job state.json dirs.
+_executor_jobs_root() {
+	echo "${CATALYST_EXECUTOR_JOBS_ROOT:-${CLAUDE_BG_JOBS_DIR:-$HOME/.claude/jobs}}"
+}
+
+# _executor_agents_json — `claude agents --json`, memoized for this process so a
+# scan-and-reap loop pays the cost once rather than once per job.
+_executor_agents_json() {
+	if [ -z "${_EXECUTOR_AGENTS_CACHE+x}" ]; then
+		_EXECUTOR_AGENTS_CACHE="$("$(executor_claude_bin)" agents --json 2>/dev/null || echo '[]')"
+		[ -n "$_EXECUTOR_AGENTS_CACHE" ] || _EXECUTOR_AGENTS_CACHE='[]'
+	fi
+	printf '%s' "$_EXECUTOR_AGENTS_CACHE"
+}
+
+# executor_job_cpu <job_id> — echo the CPU% of the job's process, or "" when it
+# cannot be determined (no state.json, no live process, etc.). The 8-hex bg job
+# id does not itself name a process: resolve it via
+#   state.json.sessionId → `claude agents --json` match → .pid → ps %cpu.
+executor_job_cpu() {
+	local job_id="$1"
+	[ -n "$job_id" ] || {
+		echo ""
+		return 0
+	}
+
+	# Test hook: a probe command fully bypasses the resolution chain.
+	if [ -n "${CATALYST_EXECUTOR_CPU_PROBE:-}" ]; then
+		"$CATALYST_EXECUTOR_CPU_PROBE" "$job_id" 2>/dev/null || echo ""
+		return 0
+	fi
+
+	local state_file sid pid cpu
+	state_file="$(_executor_jobs_root)/${job_id}/state.json"
+	[ -f "$state_file" ] || {
+		echo ""
+		return 0
+	}
+	sid="$(jq -r '.sessionId // empty' "$state_file" 2>/dev/null || echo "")"
+	[ -n "$sid" ] || {
+		echo ""
+		return 0
+	}
+	pid="$(_executor_agents_json | jq -r --arg s "$sid" \
+		'.[]? | select(.sessionId == $s) | .pid' 2>/dev/null | head -1)"
+	[ -n "$pid" ] || {
+		echo ""
+		return 0
+	}
+	cpu="$(ps -o %cpu= -p "$pid" 2>/dev/null | tr -d ' ')"
+	echo "$cpu"
+}
+
+# executor_reap <job_id> — CPU safety belt, then `claude stop <job_id>`.
+# Echoes exactly one status word:
+#   stopped        the job was stopped
+#   skipped-active the process is above the CPU ceiling — left running
+#   skipped-empty  no job id given
+#   stop-failed    `claude stop` returned non-zero (already gone, or a real error)
+# Returns 0 only on `stopped`. Best-effort by contract — callers treat a
+# non-`stopped` result as informational, never fatal.
+executor_reap() {
+	local job_id="$1"
+	if [ -z "$job_id" ]; then
+		echo "skipped-empty"
+		return 1
+	fi
+
+	local ceiling cpu
+	ceiling="${EXECUTOR_CPU_REAP_CEILING:-3}"
+	cpu="$(executor_job_cpu "$job_id")"
+
+	# Safety belt: never reap an actively-computing process. Block only when the
+	# CPU is known AND strictly above the ceiling — an unknown CPU means there is
+	# no live process to protect, so reaping (a harmless no-op) is safe.
+	if [ -n "$cpu" ] && awk -v c="$cpu" -v ceil="$ceiling" \
+		'BEGIN { exit !((c + 0) > (ceil + 0)) }'; then
+		echo "skipped-active"
+		return 1
+	fi
+
+	if "$(executor_claude_bin)" stop "$job_id" >/dev/null 2>&1; then
+		echo "stopped"
+		return 0
+	fi
+	echo "stop-failed"
+	return 1
+}

--- a/plugins/dev/scripts/orchestrate-healthcheck
+++ b/plugins/dev/scripts/orchestrate-healthcheck
@@ -15,7 +15,8 @@
 #                           [--dry-run]
 #
 # Outputs a single JSON summary on stdout:
-#   {"checked":N,"dead":M,"deadTickets":["TID-1",...],"stalled":S,"stalledTickets":["TID-2",...]}
+#   {"checked":N,"dead":M,"deadTickets":["TID-1",...],"stalled":S,
+#    "stalledTickets":["TID-2",...],"reaped":R}
 #
 # CTL-452 phase-mode pass: after the legacy PID check, scan
 # ${ORCH_DIR}/workers/<T>/phase-*.json for entries with bg_job_id; stat
@@ -31,6 +32,12 @@
 #                                     signal is flipped to stalled, waking the orchestrator.
 #   CATALYST_HEALTHCHECK_JOBS_ROOT    root for --bg job state dirs (default: $HOME/.claude/jobs).
 #                                     Tests override this to avoid touching the real Claude state.
+#   CATALYST_WATCH_BG_BIN             path to phase-agent-watch-bg (default: sibling). CTL-567:
+#                                     the reap sweep delegates to its `reap` subcommand.
+#
+# CTL-567 reap sweep: after the stall checks, `claude stop` every phase signal
+# at status="done" whose bg job is still alive (delegated to
+# phase-agent-watch-bg reap --scope done). The summary gains a "reaped" count.
 
 set -uo pipefail
 
@@ -39,6 +46,8 @@ STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
 # CTL-511: phase-agent-emit-complete emits the broker-routable phase.<name>.failed
 # event when a phase signal is flipped to stalled. Test-overridable.
 EMIT_COMPLETE="${CATALYST_EMIT_COMPLETE:-${SCRIPT_DIR}/phase-agent-emit-complete}"
+# CTL-567: phase-agent-watch-bg owns the reap scan. Test-overridable.
+WATCH_BG="${CATALYST_WATCH_BG_BIN:-${SCRIPT_DIR}/phase-agent-watch-bg}"
 
 ORCH_DIR=""
 ORCH_ID=""
@@ -265,6 +274,23 @@ for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
 	echo "PHASE-STALLED: ${P_TICKET} phase=${P_PHASE} bg=${P_BG} (${STALL_REASON})" >&2
 done
 
+# ─── CTL-567: reap completed-but-still-running phase bg jobs ──────────────────
+#
+# Backstop for the dispatcher reap in orchestrate-phase-advance: `claude stop`
+# every phase signal at status="done" whose bg job is still alive. The scan is
+# delegated to `phase-agent-watch-bg reap` so there is a single reaping
+# implementation. --scope done leaves failed / turn-cap-exhausted / stalled /
+# running signals alone (the ticket's exemptions). Best-effort — a missing or
+# failing watch-bg never derails the healthcheck.
+REAPED_COUNT=0
+if [ -x "$WATCH_BG" ]; then
+	REAP_ARGS=(reap --orch-dir "$ORCH_DIR" --scope "done" --json)
+	[ "$DRY_RUN" -eq 1 ] && REAP_ARGS+=(--dry-run)
+	REAP_OUT=$("$WATCH_BG" "${REAP_ARGS[@]}" 2>/dev/null || echo '{}')
+	REAPED_COUNT=$(echo "$REAP_OUT" | jq -r '.reaped // 0' 2>/dev/null || echo 0)
+	[ -n "$REAPED_COUNT" ] || REAPED_COUNT=0
+fi
+
 # Summary on stdout (machine-readable).
 DEAD_COUNT=${#DEAD_TICKETS[@]}
 if [ "$DEAD_COUNT" -eq 0 ]; then
@@ -286,4 +312,5 @@ jq -nc \
 	--argjson t "$DEAD_JSON" \
 	--argjson s "$STALLED_COUNT" \
 	--argjson st "$STALLED_JSON" \
-	'{checked:$c, dead:$d, deadTickets:$t, stalled:$s, stalledTickets:$st}'
+	--argjson r "$REAPED_COUNT" \
+	'{checked:$c, dead:$d, deadTickets:$t, stalled:$s, stalledTickets:$st, reaped:$r}'

--- a/plugins/dev/scripts/orchestrate-phase-advance
+++ b/plugins/dev/scripts/orchestrate-phase-advance
@@ -28,12 +28,17 @@
 # Environment overrides (for tests):
 #   CATALYST_STATE_SCRIPT       path to catalyst-state.sh (default: sibling)
 #   CATALYST_DISPATCH_NEXT_BIN  path to orchestrate-dispatch-next (default: sibling)
+#   CATALYST_DISPATCH_CLAUDE_BIN, CATALYST_EXECUTOR_JOBS_ROOT,
+#   CATALYST_EXECUTOR_CPU_PROBE — see lib/executor.sh (predecessor reap, CTL-567)
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
 DISPATCH_NEXT_BIN="${CATALYST_DISPATCH_NEXT_BIN:-${SCRIPT_DIR}/orchestrate-dispatch-next}"
+
+# shellcheck source=lib/executor.sh
+source "${SCRIPT_DIR}/lib/executor.sh"
 
 ORCH_DIR=""
 ORCH_ID=""
@@ -139,6 +144,24 @@ fi
   exit 0
 }
 
+# CTL-567: reap the predecessor phase's `claude --bg` job now that its successor
+# is dispatched. This script runs ONLY on `phase.<name>.complete` — `failed` and
+# `turn-cap-exhausted` route to orchestrate-revive, never here — so the job
+# reaped is always a genuinely-completed phase, and the parked / failed-pending-
+# revive / turn-cap exemptions are satisfied structurally. The `status == "done"`
+# guard is belt-and-suspenders; executor_reap applies the CPU safety belt.
+REAPED_PRED=false
+PRED_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${COMPLETED_PHASE}.json"
+if [ -f "$PRED_SIGNAL" ]; then
+  PRED_STATUS="$(jq -r '.status // empty' "$PRED_SIGNAL" 2>/dev/null || echo "")"
+  PRED_BG="$(jq -r '.bg_job_id // empty' "$PRED_SIGNAL" 2>/dev/null || echo "")"
+  if [ "$PRED_STATUS" = "done" ] && [ -n "$PRED_BG" ]; then
+    REAP_RESULT="$(executor_reap "$PRED_BG" 2>/dev/null || true)"
+    [ "$REAP_RESULT" = "stopped" ] && REAPED_PRED=true
+    echo "phase-advance: reap predecessor ${COMPLETED_PHASE} bg=${PRED_BG} → ${REAP_RESULT:-unknown}" >&2
+  fi
+fi
+
 # Emit advancement event (best-effort — tests assert via fake state script).
 if [ -x "$STATE_SCRIPT" ]; then
   TS="$(now_iso)"
@@ -151,4 +174,6 @@ if [ -x "$STATE_SCRIPT" ]; then
 fi
 
 jq -nc --arg from "$COMPLETED_PHASE" --arg to "$NEXT_PHASE" --arg ticket "$TICKET" \
-  '{advanced: true, fromPhase: $from, toPhase: $to, ticket: $ticket, dryRun: false}'
+  --argjson reaped "$REAPED_PRED" \
+  '{advanced: true, fromPhase: $from, toPhase: $to, ticket: $ticket,
+    dryRun: false, reapedPredecessor: $reaped}'

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -46,6 +46,12 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 # so the launch-failure tests can point at a stub or a non-existent path.
 EMIT_COMPLETE="${CATALYST_EMIT_COMPLETE:-${SCRIPT_DIR}/phase-agent-emit-complete}"
 
+# CTL-567: the executor seam — `claude --bg` (the launch below) and `claude stop`
+# (the reap) both resolve their binary through lib/executor.sh, so a cloud
+# executor can swap the launch and the stop together (design doc D9).
+# shellcheck source=lib/executor.sh
+source "${SCRIPT_DIR}/lib/executor.sh"
+
 die() {
 	echo "phase-agent-dispatch: $*" >&2
 	exit 1
@@ -473,10 +479,10 @@ BG_ERR=$(mktemp)
 trap 'rm -f "$BG_OUT" "$BG_ERR"' EXIT
 
 # Use env so we propagate the dispatch env without modifying our own shell.
-# CATALYST_DISPATCH_CLAUDE_BIN mirrors the override honored by
-# orchestrate-dispatch-next so tests (and tooling) can swap the claude binary
-# without rewriting either dispatcher.
-CLAUDE_BIN="${CATALYST_DISPATCH_CLAUDE_BIN:-claude}"
+# CLAUDE_BIN resolves through the executor seam (lib/executor.sh) — the same
+# function the reap path uses for `claude stop`. CATALYST_DISPATCH_CLAUDE_BIN
+# still overrides it, so existing tests and tooling are unaffected.
+CLAUDE_BIN="$(executor_claude_bin)"
 env "${DISPATCH_ENV[@]}" \
 	"$CLAUDE_BIN" --bg --dangerously-skip-permissions --model "$MODEL" "$PROMPT" \
 	>"$BG_OUT" 2>"$BG_ERR"

--- a/plugins/dev/scripts/phase-agent-watch-bg
+++ b/plugins/dev/scripts/phase-agent-watch-bg
@@ -24,12 +24,34 @@
 #     the terminal set (done|failed|errored|stopped). These are the
 #     candidates the healthcheck should mark as stalled.
 #
+#   reap [--orch-dir <path>] [--scope done|all] [--dry-run] [--json]
+#     `claude stop` the bg jobs of phase agents (CTL-567). Classification is
+#     off the Catalyst phase signal `.status`, NOT the daemon state.json.
+#       --scope done (default): only signals with status="done". Safe mid-run —
+#         failed / turn-cap-exhausted / running signals are left alone.
+#       --scope all: every signal carrying a bg_job_id. For run-end teardown.
+#     A CPU safety belt (lib/executor.sh) never reaps an actively-computing
+#     process. --dry-run reports candidates without stopping anything. Prints a
+#     summary {scanned, reaped, skipped, dryRun, results:[...]}.
+#
 # Defaults: --orch-dir = $CATALYST_ORCHESTRATOR_DIR
 #           jobs root  = $CLAUDE_BG_JOBS_DIR or ~/.claude/jobs
 #
 # Exit codes: 0 on success (even if no jobs found), 1 on argument error.
 
 set -uo pipefail
+
+# ─── Resolve script dir through symlinks (sources lib/executor.sh) ──────────
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+# shellcheck source=lib/executor.sh
+source "${SCRIPT_DIR}/lib/executor.sh"
 
 die() { echo "phase-agent-watch-bg: $*" >&2; exit 1; }
 
@@ -98,12 +120,17 @@ list_phase_agents() {
       if [[ $stale_sec -ge 900 ]]; then stale="true"; fi
     fi
 
+    # signalStatus is the Catalyst phase signal `.status` (dispatched/running/
+    # done/failed/turn-cap-exhausted/stalled) — distinct from `state` above,
+    # which is the (unreliable) daemon state.json value. `reap` classifies off
+    # signalStatus per CTL-567.
     jq -nc \
       --slurpfile s "$signal" \
       --argjson payload "$payload" \
       --arg stale "$stale" \
       --arg signalpath "$signal" \
       '{ticket: $s[0].ticket, phase: $s[0].phase, bg_job_id: $s[0].bg_job_id,
+        signalStatus: $s[0].status,
         state: $payload.state, endedAt: $payload.endedAt,
         stateFilePath: $payload.stateFilePath, mtimeEpoch: $payload.mtimeEpoch,
         stale: ($stale == "true"), signalFile: $signalpath}' \
@@ -115,7 +142,7 @@ list_phase_agents() {
 # ─── Parse args ─────────────────────────────────────────────────────────────
 
 SUB="${1:-}"
-[[ -n "$SUB" ]] || die "subcommand required: list|status|stale"
+[[ -n "$SUB" ]] || die "subcommand required: list|status|stale|reap"
 shift
 
 ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR:-}"
@@ -123,6 +150,8 @@ STATE_FILTER="all"
 JOB_ID=""
 MAX_IDLE_SEC=900
 OUTPUT_JSON=0
+SCOPE="done"
+DRY_RUN=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -130,6 +159,8 @@ while [[ $# -gt 0 ]]; do
     --state)       STATE_FILTER="$2"; shift 2 ;;
     --job)         JOB_ID="$2"; shift 2 ;;
     --max-idle-sec) MAX_IDLE_SEC="$2"; shift 2 ;;
+    --scope)       SCOPE="$2"; shift 2 ;;
+    --dry-run)     DRY_RUN=1; shift ;;
     --json)        OUTPUT_JSON=1; shift ;;
     -h|--help)     grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *)             die "unknown flag: $1" ;;
@@ -204,8 +235,63 @@ case "$SUB" in
     done < <(list_phase_agents "$ORCH_DIR")
     ;;
 
+  reap)
+    [[ -n "$ORCH_DIR" ]] || die "reap: --orch-dir (or CATALYST_ORCHESTRATOR_DIR) is required"
+    case "$SCOPE" in
+      done|all) ;;
+      *) die "reap: --scope must be 'done' or 'all' (got: $SCOPE)" ;;
+    esac
+
+    SCANNED=0
+    REAPED=0
+    SKIPPED=0
+    RESULTS="[]"
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      JOB=$(echo "$line" | jq -r '.bg_job_id // empty')
+      [[ -n "$JOB" ]] || continue
+      SIGSTATUS=$(echo "$line" | jq -r '.signalStatus // ""')
+      # --scope done leaves running / failed / turn-cap-exhausted / stalled
+      # signals alone (the ticket's exemptions). --scope all takes everything
+      # — only correct at run-end teardown, when no revive can follow.
+      if [[ "$SCOPE" == "done" && "$SIGSTATUS" != "done" ]]; then
+        continue
+      fi
+      SCANNED=$((SCANNED + 1))
+      TICKET=$(echo "$line" | jq -r '.ticket')
+      PHASE=$(echo "$line" | jq -r '.phase')
+      if [[ $DRY_RUN -eq 1 ]]; then
+        RESULT="would-reap"
+      else
+        RESULT=$(executor_reap "$JOB" || true)
+      fi
+      case "$RESULT" in
+        stopped|would-reap) REAPED=$((REAPED + 1)) ;;
+        *)                  SKIPPED=$((SKIPPED + 1)) ;;
+      esac
+      RESULTS=$(echo "$RESULTS" | jq -c \
+        --arg t "$TICKET" --arg p "$PHASE" --arg j "$JOB" --arg r "$RESULT" \
+        '. + [{ticket: $t, phase: $p, bg_job_id: $j, result: $r}]')
+    done < <(list_phase_agents "$ORCH_DIR")
+
+    DRY_JSON=$([[ $DRY_RUN -eq 1 ]] && echo true || echo false)
+    SUMMARY=$(jq -nc \
+      --argjson scanned "$SCANNED" --argjson reaped "$REAPED" \
+      --argjson skipped "$SKIPPED" --argjson dry "$DRY_JSON" \
+      --argjson results "$RESULTS" \
+      '{scanned: $scanned, reaped: $reaped, skipped: $skipped,
+        dryRun: $dry, results: $results}')
+    if [[ $OUTPUT_JSON -eq 1 ]]; then
+      echo "$SUMMARY"
+    else
+      echo "$SUMMARY" | jq -r \
+        '"reap: \(.scanned) scanned, \(.reaped) reaped, \(.skipped) skipped" +
+         (if .dryRun then " (dry-run)" else "" end)'
+    fi
+    ;;
+
   *)
-    die "unknown subcommand: $SUB (expected list|status|stale)"
+    die "unknown subcommand: $SUB (expected list|status|stale|reap)"
     ;;
 esac
 

--- a/plugins/dev/skills/teardown/SKILL.md
+++ b/plugins/dev/skills/teardown/SKILL.md
@@ -76,13 +76,30 @@ Use `--force` to bypass the preconditions (you own the consequences).
    - For the runs dir: no `workers/*.json` has `status: "in_progress"` or `alive: true`
      (or `--force`).
 
-5. **Delete**
+5. **Stop background jobs** (CTL-567)
+
+   A `phase-agents` run spawns one `claude --bg` job per phase; a completed bg job keeps
+   its process alive until the ~1h supervisor reaper. Before deleting the runtime
+   directory, `claude stop` every remaining job of the run:
+
+   ```bash
+   plugins/dev/scripts/phase-agent-watch-bg reap \
+     --orch-dir ~/catalyst/runs/<orchId> --scope all
+   ```
+
+   `--scope all` is correct here — the run is terminal, so the mid-run exemptions
+   (failed-pending-revive, turn-cap-exhausted) no longer apply. Prefer `claude stop` over
+   `claude rm`: phase agents for one ticket share a worktree, so `claude rm` could delete a
+   live sibling's worktree. With `--dry-run`, pass `--dry-run` through. A missing run
+   directory or `phase-agent-watch-bg` is non-fatal — skip and continue.
+
+6. **Delete**
 
    - `git worktree remove <path>` for each worktree (add `--force` if step 4 flagged dirty
      state AND user passed `--force`).
    - `rm -rf ~/catalyst/runs/<orchId>/` for the runs directory.
 
-6. **Verify**
+7. **Verify**
 
    - Re-run the archive listing to confirm the orchestrator is still discoverable:
 
@@ -99,6 +116,7 @@ On success, print a summary:
 ```
 Teardown complete for <orchId>
   archived to: ~/catalyst/archives/<orchId>/
+  bg jobs stopped: <N>
   deleted:
     runs: ~/catalyst/runs/<orchId>/
     worktrees: <paths...>


### PR DESCRIPTION
## Summary

Phase agents in `phase-agents` dispatchMode launch as `claude --bg` jobs. A `claude --bg` session does **not** exit when its task completes — it persists as a resumable process until the Claude Code supervisor reaps it ~1h later. With a phase completing every 3–12 min, a 3-ticket × 9-phase run accumulates ~25 idle processes (~9 GB observed, machine thrashed to 106 MB free). Nothing in Catalyst called `claude stop`.

This PR adds dispatcher-owned reaping in three layers, plus a CPU safety belt and a cloud-executor seam.

## Changes

- **`lib/executor.sh`** (new) — the executor seam. `executor_claude_bin` / `executor_job_cpu` / `executor_reap`. Both `claude --bg` (launch) and `claude stop` (reap) resolve their binary through this one file, so a cloud executor can swap them together (design doc D9). The CPU safety belt never reaps a process computing above ~3% CPU; it resolves the job's pid via `state.json.sessionId` → `claude agents --json` → `ps`, and fails safe (an unknown CPU still reaps — there is no live process to protect).
- **`orchestrate-phase-advance`** — reaps the predecessor phase's bg job once its successor is dispatched. This script runs **only** on `phase.<name>.complete`; `failed` and `turn-cap-exhausted` route to `orchestrate-revive` instead, so the parked / failed-pending-revive / turn-cap exemptions hold structurally. Output JSON gains `reapedPredecessor`.
- **`phase-agent-watch-bg`** — new `reap` subcommand. Scans `workers/*/phase-*.json` and `claude stop`s their bg jobs, **classifying off the Catalyst signal `.status`, not the unreliable daemon `state.json`**. `--scope done` (default, mid-run — leaves failed/turn-cap/running alone) and `--scope all` (run-end teardown).
- **`orchestrate-healthcheck`** — backstop sweep delegating to `phase-agent-watch-bg reap --scope done`; the summary JSON gains a `reaped` count.
- **`teardown`** skill — stops every remaining bg job of a run before deleting the runtime directory (prefers `claude stop` over `claude rm` — phase agents of one ticket share a worktree).
- **`phase-agent-dispatch`** — routes the `claude --bg` launch through the executor seam.

## Testing

- New suites: `lib-executor.test.sh` (15), `phase-agent-watch-bg.test.sh` (17).
- Extended: `orchestrate-phase-advance.test.sh` (+4 CTL-567 cases), `orchestrate-healthcheck.test.sh` (+4).
- All affected suites green; `shellcheck` clean on new code. The 4 pre-existing baseline failures (`broker-phase-lifecycle` missing `pino`, etc.) are unrelated and present on `main`.

## Acceptance

- No completed-phase `claude --bg` process outlives its successor's dispatch by more than one scheduler tick — dispatcher reap (immediate) + healthcheck backstop.
- Parked / turn-cap-exhausted / failed-pending-revive sessions are never reaped — every mid-run path is gated to `status == "done"`; only run-end `teardown` uses `--scope all`.

Refs: CTL-567