### PR TITLE
CTL-558: Phase-agent Linear status write-back

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-phase-advance.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-phase-advance.test.sh
@@ -63,13 +63,26 @@ echo "0"
 EOF
   chmod +x "${SCRATCH}/bin/cpuprobe"
   export CATALYST_EXECUTOR_CPU_PROBE="${SCRATCH}/bin/cpuprobe"
+
+  # CTL-558: fake linear-transition.sh — logs argv, exit code is overridable
+  # via LINEAR_TRANSITION_EXIT so a best-effort failure can be exercised.
+  cat > "${SCRATCH}/bin/linear-transition.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$LINEAR_TRANSITION_LOG"
+exit "${LINEAR_TRANSITION_EXIT:-0}"
+EOF
+  chmod +x "${SCRATCH}/bin/linear-transition.sh"
+  export LINEAR_TRANSITION_LOG="${SCRATCH}/linear-transition.log"
+  : > "$LINEAR_TRANSITION_LOG"
+  export CATALYST_LINEAR_TRANSITION_BIN="${SCRATCH}/bin/linear-transition.sh"
 }
 
 scratch_teardown() {
   rm -rf "$SCRATCH"
-  unset SCRATCH ORCH_DIR STATE_LOG DISPATCH_LOG CLAUDE_LOG
+  unset SCRATCH ORCH_DIR STATE_LOG DISPATCH_LOG CLAUDE_LOG LINEAR_TRANSITION_LOG
   unset CATALYST_STATE_SCRIPT CATALYST_DISPATCH_NEXT_BIN
   unset CATALYST_DISPATCH_CLAUDE_BIN CATALYST_EXECUTOR_CPU_PROBE
+  unset CATALYST_LINEAR_TRANSITION_BIN LINEAR_TRANSITION_EXIT
 }
 
 # make_phase_signal TICKET PHASE STATUS [EXTRA_JQ]
@@ -217,6 +230,60 @@ OUT=$(run_advance --ticket "T-1" --completed-phase "research" --dry-run 2>"${SCR
 echo "$OUT" | jq -e '.dryRun == true' >/dev/null \
   && pass "dry-run reported" || fail "dry-run reported" "got: $OUT"
 [ ! -s "$CLAUDE_LOG" ] && pass "claude stop NOT called in dry-run" || fail "claude stop NOT called in dry-run" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
+echo "test 13 (CTL-558): advancing to a phase writes the mapped Linear status"
+scratch_setup
+make_phase_signal "T-1" "research" "done"
+run_advance --ticket "T-1" --completed-phase "research" >/dev/null 2>"${SCRATCH}/err"
+# research → plan → linear-transition --transition planning
+grep -q -- "--transition planning" "$LINEAR_TRANSITION_LOG" \
+  && pass "linear-transition --transition planning for research→plan" \
+  || fail "linear-transition --transition planning for research→plan" "log: $(cat "$LINEAR_TRANSITION_LOG")"
+grep -q -- "--ticket T-1" "$LINEAR_TRANSITION_LOG" \
+  && pass "linear-transition --ticket T-1" || fail "linear-transition --ticket T-1" "log: $(cat "$LINEAR_TRANSITION_LOG")"
+scratch_teardown
+
+echo "test 14 (CTL-558): each non-terminal advance maps to the right stateMap key"
+scratch_setup
+declare -a KEYMAP=(triage:research research:planning plan:inProgress implement:verifying verify:reviewing review:inReview pr:inReview monitor-merge:inReview)
+for pair in "${KEYMAP[@]}"; do
+  FROM="${pair%%:*}"
+  KEY="${pair##*:}"
+  : > "$LINEAR_TRANSITION_LOG"
+  make_phase_signal "TKEY-${FROM}" "$FROM" "done"
+  run_advance --ticket "TKEY-${FROM}" --completed-phase "$FROM" >/dev/null 2>"${SCRATCH}/err"
+  grep -q -- "--transition ${KEY}" "$LINEAR_TRANSITION_LOG" \
+    && pass "completed-phase ${FROM} → --transition ${KEY}" \
+    || fail "completed-phase ${FROM} → --transition ${KEY}" "log: $(cat "$LINEAR_TRANSITION_LOG")"
+done
+scratch_teardown
+
+echo "test 15 (CTL-558): terminal monitor-deploy does NOT call linear-transition"
+scratch_setup
+make_phase_signal "T-1" "monitor-deploy" "done"
+run_advance --ticket "T-1" --completed-phase "monitor-deploy" >/dev/null 2>"${SCRATCH}/err"
+# monitor-deploy is terminal — orchestrate-phase-advance returns before any
+# write; terminal Done is phase-monitor-merge's job (plan Phase 4 §1).
+[ ! -s "$LINEAR_TRANSITION_LOG" ] \
+  && pass "no linear-transition call on terminal monitor-deploy" \
+  || fail "no linear-transition call on terminal monitor-deploy" "log: $(cat "$LINEAR_TRANSITION_LOG")"
+scratch_teardown
+
+echo "test 16 (CTL-558): a failed linear-transition never changes the advance exit code"
+scratch_setup
+make_phase_signal "T-1" "research" "done"
+LINEAR_TRANSITION_EXIT=2 run_advance --ticket "T-1" --completed-phase "research" >/dev/null 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "status write is best-effort (advance exit 0)" || fail "status write is best-effort (advance exit 0)" "rc=$RC"
+scratch_teardown
+
+echo "test 17 (CTL-558): --config is forwarded to linear-transition when set"
+scratch_setup
+make_phase_signal "T-1" "research" "done"
+run_advance --ticket "T-1" --completed-phase "research" --config "/tmp/x/.catalyst/config.json" >/dev/null 2>"${SCRATCH}/err"
+grep -q -- "--config /tmp/x/.catalyst/config.json" "$LINEAR_TRANSITION_LOG" \
+  && pass "--config forwarded to linear-transition" || fail "--config forwarded to linear-transition" "log: $(cat "$LINEAR_TRANSITION_LOG")"
 scratch_teardown
 
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -70,6 +70,14 @@ assert_grep() {
     fail "$label — pattern '$pattern' not found in $(basename "$file")"
   fi
 }
+assert_not_grep() {
+  local pattern="$1" file="$2" label="$3"
+  if grep -q -E -- "$pattern" "$file" 2>/dev/null; then
+    fail "$label — pattern '$pattern' unexpectedly present in $(basename "$file")"
+  else
+    pass "$label"
+  fi
+}
 
 # Per-test sandbox for emit-complete invocations.
 fresh_env() {
@@ -111,16 +119,17 @@ if [[ -f "$SKILL_IMPLEMENT" ]]; then
   assert_grep '/catalyst-dev:implement-plan' "$SKILL_IMPLEMENT" "delegates to /catalyst-dev:implement-plan"
 fi
 
-# ─── Test 2: phase-implement updates Linear to inProgress + has correct /goal
+# ─── Test 2: phase-implement does NOT self-transition Linear + has correct /goal
 echo ""
-echo "Test 2: phase-implement transitions Linear to inProgress and declares /goal"
+echo "Test 2: phase-implement leaves Linear write-back to the coordinator (CTL-558)"
 if [[ -f "$SKILL_IMPLEMENT" ]]; then
-  # Linear transition. Uses the shared linear-transition.sh helper (CTL-69)
-  # rather than rolling its own GraphQL call.
-  assert_grep 'linear-transition\.sh' "$SKILL_IMPLEMENT" "calls linear-transition.sh"
-  assert_grep 'inProgress' "$SKILL_IMPLEMENT" "transitions Linear to inProgress"
+  # CTL-558: Linear status write-back moved to the deterministic coordinator
+  # (execution-core scheduler / orchestrate-phase-advance). The phase agent no
+  # longer shells linear-transition.sh.
+  assert_not_grep 'linear-transition\.sh' "$SKILL_IMPLEMENT" "does NOT shell linear-transition.sh"
+  assert_not_grep '[-][-]transition inProgress' "$SKILL_IMPLEMENT" "does NOT self-transition Linear to inProgress"
   # /goal condition exists and matches the plan's transcript-evaluable shape
-  # (git diff non-empty AND tests pass AND Linear=inProgress).
+  # (git diff non-empty AND tests pass).
   assert_grep '^/goal' "$SKILL_IMPLEMENT" "declares a /goal line"
   assert_grep 'git diff' "$SKILL_IMPLEMENT" "/goal references git diff (diff non-empty)"
 fi

--- a/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
@@ -25,6 +25,7 @@ pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
 
 assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$1', got '$2'"; }
 assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 — '$2' unexpectedly present"; }
 assert_file_exists() { [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"; }
 
 # ─── Contract ───────────────────────────────────────────────────────────────
@@ -54,8 +55,9 @@ if [[ -f "$SKILL" ]]; then
   assert_contains "$BODY" '--status complete' "body emits --status complete on success"
   assert_contains "$BODY" '--status failed' "body emits --status failed on error path"
 
-  # Linear intermediate state — plan uses 'planning' (existing state, not new)
-  assert_contains "$BODY" "planning" "body transitions Linear ticket to planning state"
+  # CTL-558: Linear status write-back moved to the deterministic coordinator —
+  # the phase agent no longer carries the linear-transition prose.
+  assert_not_contains "$BODY" "--transition planning" "body does NOT self-transition Linear (coordinator owns it, CTL-558)"
 
   assert_contains "$BODY" "/goal" "body declares a /goal block"
 fi

--- a/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
@@ -40,6 +40,10 @@ assert_contains() {
   local haystack="$1" needle="$2" label="$3"
   [[ "$haystack" == *"$needle"* ]] && pass "$label" || fail "$label — '$needle' not found"
 }
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  [[ "$haystack" != *"$needle"* ]] && pass "$label" || fail "$label — '$needle' unexpectedly present"
+}
 assert_file_exists() {
   [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"
 }
@@ -79,8 +83,9 @@ if [[ -f "$SKILL" ]]; then
   assert_contains "$BODY" '--status complete' "body emits --status complete on success"
   assert_contains "$BODY" '--status failed' "body emits --status failed on error path"
 
-  # Linear state transition (CTL-454 intermediate states)
-  assert_contains "$BODY" "researching" "body transitions Linear ticket to researching state"
+  # CTL-558: Linear status write-back moved to the deterministic coordinator —
+  # the phase agent no longer carries the linear-transition prose.
+  assert_not_contains "$BODY" "--transition researching" "body does NOT self-transition Linear (coordinator owns it, CTL-558)"
 
   # /goal block (turn cap)
   assert_contains "$BODY" "/goal" "body declares a /goal block"

--- a/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
@@ -25,6 +25,7 @@ pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
 
 assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$1', got '$2'"; }
 assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 — '$2' unexpectedly present"; }
 assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 — '$2' WAS present (must not be)"; }
 assert_file_exists() { [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"; }
 
@@ -67,8 +68,9 @@ if [[ -f "$SKILL" ]]; then
   assert_contains "$BODY" "phase-agent-emit-complete" "body calls phase-agent-emit-complete"
   assert_contains "$BODY" '--status complete' "body emits --status complete on success"
 
-  # Linear intermediate state — reviewing (CTL-454)
-  assert_contains "$BODY" "reviewing" "body transitions Linear ticket to reviewing state"
+  # CTL-558: Linear status write-back moved to the deterministic coordinator —
+  # the phase agent no longer carries the linear-transition prose.
+  assert_not_contains "$BODY" "--transition reviewing" "body does NOT self-transition Linear (coordinator owns it, CTL-558)"
 
   assert_contains "$BODY" "/goal" "body declares a /goal block"
 

--- a/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
@@ -25,7 +25,6 @@ pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
 
 assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$1', got '$2'"; }
 assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
-assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 — '$2' unexpectedly present"; }
 assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 — '$2' WAS present (must not be)"; }
 assert_file_exists() { [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"; }
 

--- a/plugins/dev/scripts/__tests__/phase-skill-no-linear-prose.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-skill-no-linear-prose.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# CTL-558: the deterministic coordinator (execution-core scheduler /
+# orchestrate-phase-advance) owns Linear status write-back. The six shared
+# phase-* skills must NOT carry their own `linear-transition.sh --transition`
+# prose, and create-pr / describe-pr must gate their interactive inReview
+# transition on CATALYST_PHASE so the phase-agent path does not double-write.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SKILLS_DIR="${REPO_ROOT}/plugins/dev/skills"
+
+FAILURES=0
+PASSES=0
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+echo "Test: phase-* skills carry no linear-transition status-write prose"
+# The removed prose has two signatures: the `## Linear state transition`
+# heading, and a `--transition <statekey>` invocation. Either present means
+# the prose deliverable-4 removes still lingers.
+for skill in phase-research phase-plan phase-implement phase-verify phase-review; do
+  f="${SKILLS_DIR}/${skill}/SKILL.md"
+  if [[ ! -f "$f" ]]; then
+    fail "${skill}/SKILL.md exists"
+    continue
+  fi
+  hit=""
+  grep -qE '^## Linear state transition' "$f" && hit="heading"
+  grep -qE -- '--transition (researching|planning|inProgress|verifying|reviewing)' "$f" \
+    && hit="${hit:+$hit+}invocation"
+  if [[ -n "$hit" ]]; then
+    fail "${skill} carries no Linear status-write prose" \
+      "found: $hit — $(grep -nE '^## Linear state transition|--transition (researching|planning|inProgress|verifying|reviewing)' "$f" | head -2)"
+  else
+    pass "${skill} carries no Linear status-write prose"
+  fi
+done
+
+echo "Test: phase-monitor-merge KEEPS its terminal --transition done writer"
+# Plan Phase 4 §2 'Keep' — in phase-agents mode this is the terminal-Done
+# writer (orchestrate-phase-advance never advances past monitor-deploy).
+MM="${SKILLS_DIR}/phase-monitor-merge/SKILL.md"
+if grep -qE "linear-transition.*--transition done|--transition done" "$MM"; then
+  pass "phase-monitor-merge keeps --transition done (terminal writer)"
+else
+  fail "phase-monitor-merge keeps --transition done (terminal writer)" \
+    "the phase-agents-mode terminal Done writer must NOT be removed"
+fi
+
+echo "Test: create-pr / describe-pr gate the inReview transition on CATALYST_PHASE"
+for skill in create-pr describe-pr; do
+  f="${SKILLS_DIR}/${skill}/SKILL.md"
+  if [[ ! -f "$f" ]]; then
+    fail "${skill}/SKILL.md exists"
+    continue
+  fi
+  if grep -q "CATALYST_PHASE" "$f"; then
+    pass "${skill} references CATALYST_PHASE (transition gated under phase agents)"
+  else
+    fail "${skill} references CATALYST_PHASE (transition gated under phase agents)"
+  fi
+done
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -6,11 +6,12 @@
 #   2. Stand up a fake `linearis` shim on PATH:
 #        - `linearis issues read <id>` → prints fixture JSON
 #        - `linearis issues discuss <id> --body <text>` → records call to a log
-#        - `linearis issues update <id> --labels ... --label-mode add` → records call
+#      (CTL-558: phase-triage no longer calls `linearis issues update` for the
+#       `triaged` label — the coordinator's label sweep owns it.)
 #   3. Point CATALYST_EVENTS_FILE at a tempfile.
 #   4. Extract the executable bash body from the skill (fenced by
 #      `bash phase-triage-body`).
-#   5. Run it with TICKET set; assert artifact + comment + label + event.
+#   5. Run it with TICKET set; assert artifact + comment + event (no label call).
 #
 # Run: bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
 
@@ -177,10 +178,13 @@ else
 	fail "happy: discuss call" "no 'discuss' entry in linearis log:$(printf '\n%s' "$(cat "$LINEARIS_LOG" 2>/dev/null)")"
 fi
 
+# CTL-558: the `triaged` label is applied by the coordinator (the execution-core
+# scheduler's label sweep), NOT by phase-triage. The skill must NOT call
+# `linearis issues update` for the label any more.
 if grep -q '^update$' "$LINEARIS_LOG" 2>/dev/null; then
-	ok "happy: linearis issues update was called"
+	fail "happy: no label update call" "phase-triage still calls 'linearis issues update' — the coordinator owns the triaged label (CTL-558)"
 else
-	fail "happy: update call" "no 'update' entry in linearis log"
+	ok "happy: phase-triage does not self-apply the triaged label (coordinator owns it, CTL-558)"
 fi
 
 # Assert: emitted event has the right shape

--- a/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
@@ -34,6 +34,7 @@ pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
 
 assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$1', got '$2'"; }
 assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 — '$2' unexpectedly present"; }
 assert_file_exists() { [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"; }
 
 # ─── Contract ───────────────────────────────────────────────────────────────
@@ -77,8 +78,9 @@ if [[ -f "$SKILL" ]]; then
   assert_contains "$BODY" "phase-agent-emit-complete" "body calls phase-agent-emit-complete"
   assert_contains "$BODY" '--status complete' "body emits --status complete on success"
 
-  # Linear intermediate state — verifying (CTL-454)
-  assert_contains "$BODY" "verifying" "body transitions Linear ticket to verifying state"
+  # CTL-558: Linear status write-back moved to the deterministic coordinator —
+  # the phase agent no longer carries the linear-transition prose.
+  assert_not_contains "$BODY" "--transition verifying" "body does NOT self-transition Linear (coordinator owns it, CTL-558)"
 
   assert_contains "$BODY" "/goal" "body declares a /goal block"
 fi

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -66,6 +66,9 @@ export function startDaemon({
   // agent on a →Triage transition. `dispatch` stays an injectable default
   // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
   monitorFn({ orchDir }); // CTL-535 + CTL-565 — two-state trigger monitor
+  // CTL-558: the scheduler writes Linear status via its default `writeStatus`
+  // (linear-write.mjs) on every committed phase transition — no daemon wiring
+  // needed; production uses the real module, tests inject fakes.
   schedulerFn({ orchDir }); // CTL-536 — pull-loop scheduler
 
   if (watchEnrollment) {

--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -21,6 +21,8 @@ export * from "./eligible-set.mjs";
 // kill-on-drag-out abort module.
 export * from "./dispatch.mjs";
 export * from "./abort-worker.mjs";
+// CTL-558: the deterministic Linear status/label write seam (D9 write mirror).
+export * from "./linear-write.mjs";
 // monitor.mjs is re-exported explicitly so the test-only __resetForTests
 // helper stays out of the public barrel.
 export {

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -1,0 +1,123 @@
+// linear-write.mjs — execution-core deterministic Linear status write-back (CTL-558).
+//
+// The D9 cloud seam for status WRITES — the mirror of linear-query.mjs (reads).
+// Internals shell to the bash chokepoint linear-transition.sh (idempotency,
+// stateIds UUID resolution, 3-tier state precedence) so there is ONE write path;
+// a cloud fork swaps this module without touching the scheduler.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { linearKeyForPhase, TERMINAL_LINEAR_KEY } from "../lib/phase-fsm.mjs";
+import { getProjectConfig } from "./registry.mjs";
+import { log } from "./config.mjs";
+
+// linear-transition.sh sits one directory up from execution-core/ — mirrors the
+// sibling-bin spawnSync pattern dispatch.mjs uses for orchestrate-dispatch-next.
+const LINEAR_TRANSITION_BIN = fileURLToPath(
+  new URL("../linear-transition.sh", import.meta.url)
+);
+
+// defaultExec — spawnSync wrapper normalising the result shape. A spawn error
+// (binary missing, permission) is reported as code 127, never thrown.
+function defaultExec(cmd, args) {
+  const res = spawnSync(cmd, args, { encoding: "utf8" });
+  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
+  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// teamOf — the Linear team key is the identifier prefix: "CTL-558" → "CTL".
+export function teamOf(ticket) {
+  const m = /^([A-Za-z][A-Za-z0-9_]*)-\d+$/.exec(String(ticket ?? ""));
+  return m ? m[1] : null;
+}
+
+// defaultResolveRepoRoot — team → repoRoot via the central registry.
+function defaultResolveRepoRoot(ticket) {
+  const team = teamOf(ticket);
+  return team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
+}
+
+// runTransition — shell linear-transition.sh for one logical key. Best-effort:
+// returns { applied, reason } and never throws. Parses the --json result and
+// treats a zero exit (with no "update-failed" action) as applied.
+function runTransition({
+  ticket,
+  key,
+  resolveRepoRoot = defaultResolveRepoRoot,
+  exec = defaultExec,
+}) {
+  try {
+    const repoRoot = resolveRepoRoot(ticket);
+    if (!repoRoot) {
+      log.warn({ ticket, key }, "linear-write: no repoRoot — skipping status write");
+      return { applied: false, reason: "no-repo-root" };
+    }
+    const config = `${repoRoot}/.catalyst/config.json`;
+    const { code, stdout } = exec(LINEAR_TRANSITION_BIN, [
+      "--ticket",
+      ticket,
+      "--transition",
+      key,
+      "--config",
+      config,
+      "--json",
+    ]);
+    let action = null;
+    try {
+      action = JSON.parse(stdout)?.action ?? null;
+    } catch {
+      /* non-JSON stdout — leave action null */
+    }
+    const applied = code === 0 && action !== "update-failed";
+    if (!applied) {
+      log.warn({ ticket, key, code, action }, "linear-write: status write not applied");
+    }
+    return { applied, reason: applied ? null : `exit-${code}`, action };
+  } catch (err) {
+    log.warn(
+      { ticket, key, err: err.message },
+      "linear-write: status write threw — swallowed"
+    );
+    return { applied: false, reason: "threw" };
+  }
+}
+
+// applyPhaseStatus — write the Linear state mapped to `phase`. Idempotent
+// (linear-transition.sh read-compares first). triage → no-op (no status key).
+export function applyPhaseStatus({ ticket, phase, resolveRepoRoot, exec }) {
+  const key = linearKeyForPhase(phase); // throws PhaseFsmError on an unknown phase
+  if (key === null) return { applied: false, skipped: "no-status-key" };
+  return runTransition({ ticket, key, resolveRepoRoot, exec });
+}
+
+// applyTerminalDone — write the terminal Done state on monitor-deploy completion.
+export function applyTerminalDone({ ticket, resolveRepoRoot, exec }) {
+  return runTransition({ ticket, key: TERMINAL_LINEAR_KEY, resolveRepoRoot, exec });
+}
+
+// applyLabel — additively apply a Linear label (triaged, needs-human). Best-effort:
+// `--label-mode add` is additive so a re-applied label is harmless; callers guard
+// re-application with a once-marker (scheduler.mjs) since linearis has no
+// read-compare for labels.
+export function applyLabel({ ticket, label, exec = defaultExec }) {
+  try {
+    const { code, stderr } = exec("linearis", [
+      "issues",
+      "update",
+      ticket,
+      "--labels",
+      label,
+      "--label-mode",
+      "add",
+    ]);
+    if (code !== 0) {
+      log.warn({ ticket, label, code, stderr }, "linear-write: label not applied");
+    }
+    return { applied: code === 0 };
+  } catch (err) {
+    log.warn(
+      { ticket, label, err: err.message },
+      "linear-write: label write threw — swallowed"
+    );
+    return { applied: false };
+  }
+}

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -1,0 +1,113 @@
+// linear-write.test.mjs — execution-core Linear status write-back (CTL-558).
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-write.test.mjs
+import { describe, test, expect } from "bun:test";
+import {
+  applyPhaseStatus,
+  applyTerminalDone,
+  applyLabel,
+  teamOf,
+} from "./linear-write.mjs";
+
+const okExec = (calls) => (cmd, args) => {
+  calls.push({ cmd, args });
+  return { code: 0, stdout: JSON.stringify({ action: "transitioned" }), stderr: "" };
+};
+
+describe("teamOf", () => {
+  test("extracts the identifier prefix", () => {
+    expect(teamOf("CTL-558")).toBe("CTL");
+    expect(teamOf("ENG-1")).toBe("ENG");
+  });
+  test("returns null for a malformed identifier", () => {
+    expect(teamOf("nonsense")).toBeNull();
+    expect(teamOf("")).toBeNull();
+    expect(teamOf(null)).toBeNull();
+  });
+});
+
+describe("applyPhaseStatus", () => {
+  test("skips triage — no status key, no exec call", () => {
+    const calls = [];
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "triage",
+      resolveRepoRoot: () => "/repo",
+      exec: okExec(calls),
+    });
+    expect(r.skipped).toBe("no-status-key");
+    expect(calls).toHaveLength(0);
+  });
+  test("shells linear-transition.sh with the phase's mapped --transition key", () => {
+    const calls = [];
+    applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "verify",
+      resolveRepoRoot: () => "/repo",
+      exec: okExec(calls),
+    });
+    const args = calls[0].args;
+    expect(args).toContain("--transition");
+    expect(args[args.indexOf("--transition") + 1]).toBe("verifying");
+    expect(args).toContain("--ticket");
+    expect(args).toContain("CTL-1");
+    expect(args.join(" ")).toContain("/repo/.catalyst/config.json");
+  });
+  test("returns applied:false when the repo root cannot be resolved", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "plan",
+      resolveRepoRoot: () => null,
+      exec: okExec([]),
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("no-repo-root");
+  });
+  test("returns applied:false on a non-zero linear-transition exit", () => {
+    const exec = () => ({ code: 2, stdout: "", stderr: "update-failed" });
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "plan",
+      resolveRepoRoot: () => "/repo",
+      exec,
+    });
+    expect(r.applied).toBe(false);
+  });
+  test("never throws — a thrown exec is caught and reported", () => {
+    const exec = () => {
+      throw new Error("spawn boom");
+    };
+    expect(() =>
+      applyPhaseStatus({
+        ticket: "CTL-1",
+        phase: "plan",
+        resolveRepoRoot: () => "/repo",
+        exec,
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("applyTerminalDone", () => {
+  test("shells linear-transition.sh with --transition done", () => {
+    const calls = [];
+    applyTerminalDone({ ticket: "CTL-1", resolveRepoRoot: () => "/repo", exec: okExec(calls) });
+    const args = calls[0].args;
+    expect(args[args.indexOf("--transition") + 1]).toBe("done");
+  });
+});
+
+describe("applyLabel", () => {
+  test("shells linearis issues update --labels <l> --label-mode add", () => {
+    const calls = [];
+    applyLabel({ ticket: "CTL-1", label: "needs-human", exec: okExec(calls) });
+    const args = calls[0].args;
+    expect(args.slice(0, 3)).toEqual(["issues", "update", "CTL-1"]);
+    expect(args).toContain("--labels");
+    expect(args[args.indexOf("--labels") + 1]).toBe("needs-human");
+    expect(args[args.indexOf("--label-mode") + 1]).toBe("add");
+  });
+  test("never throws on a failed label exec", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "no such label" });
+    expect(() => applyLabel({ ticket: "CTL-1", label: "needs-human", exec })).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -13,7 +13,7 @@
 // Composes: lib/dependency-graph.mjs (readiness), scheduler-rank.mjs (ranking),
 // lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
 
-import { readdirSync, readFileSync, watch, mkdirSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync, existsSync, watch, mkdirSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { analyzeDependencyGraph, referencedBlockerIds } from "../lib/dependency-graph.mjs";
 // PHASES is still imported for deriveAdvancement; CTL-565 note: PHASES[0]
@@ -270,6 +270,31 @@ function safeWrite(fn, ctx) {
   }
 }
 
+// labelOnce — apply a Linear label to a ticket at most once for the run's
+// lifetime (CTL-558). `linearis` label-add has no read-compare, so without a
+// guard the scheduler would re-hit the API on every 30s tick. A once-marker
+// file at workers/<T>/.linear-label-<label>.applied (restart-safe — persists
+// with the worker dir) records a successful apply. Best-effort: any throw is
+// logged and swallowed, never aborting the tick.
+function labelOnce(orchDir, ticket, label, writeStatus) {
+  const marker = join(orchDir, "workers", ticket, `.linear-label-${label}.applied`);
+  if (existsSync(marker)) return;
+  try {
+    const res = writeStatus.applyLabel({ ticket, label });
+    // Write the marker only on a confirmed apply — a failed label-write is
+    // retried next tick. A fake that returns undefined (test stubs) is treated
+    // as success so the once-semantics stay testable without a real result.
+    if (res === undefined || res?.applied) {
+      writeFileSync(marker, "");
+    }
+  } catch (err) {
+    log.warn(
+      { ticket, label, err: err.message },
+      "scheduler: label write-back threw — continuing tick",
+    );
+  }
+}
+
 // schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull,
 // (3) terminal-Done sweep (CTL-558). Idempotent and restart-safe — derives
 // every action from filesystem state. `exec` is the injectable seam for the D5
@@ -327,14 +352,24 @@ export function schedulerTick(
     }
   }
 
-  // (3) Terminal-Done sweep (CTL-558) — deriveAdvancement returns null once
-  // monitor-deploy completes, so terminal `Done` is not a dispatch. Sweep every
-  // started ticket and write `Done` for any whose monitor-deploy signal is done.
-  // Idempotent — linear-transition.sh read-compares, so a re-applied Done is a
-  // no-op skip.
+  // (3) Terminal-Done + label sweep (CTL-558) — one pass over every started
+  // ticket. deriveAdvancement returns null once monitor-deploy completes, so
+  // terminal `Done` is not a dispatch — it needs this dedicated sweep. In the
+  // same pass: apply the `triaged` label on triage completion, and the flat
+  // `needs-human` label when any phase signal is `stalled` (D7 — the worker
+  // keeps its phase state, it does not bounce to Triage). Status writes are
+  // idempotent via linear-transition.sh; label writes are guarded once-per-run
+  // by labelOnce's marker file.
   for (const ticket of listStartedTickets(orchDir)) {
-    if (readPhaseSignals(orchDir, ticket)["monitor-deploy"] === "done") {
+    const signals = readPhaseSignals(orchDir, ticket);
+    if (signals["monitor-deploy"] === "done") {
       safeWrite(() => writeStatus.applyTerminalDone({ ticket }), { ticket });
+    }
+    if (signals.triage === "done") {
+      labelOnce(orchDir, ticket, "triaged", writeStatus);
+    }
+    if (Object.values(signals).some((s) => s === "stalled")) {
+      labelOnce(orchDir, ticket, "needs-human", writeStatus);
     }
   }
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -23,6 +23,10 @@ import { PHASES, transition, isTerminal } from "../lib/phase-fsm.mjs";
 import { rankTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket } from "./dispatch.mjs";
 import { fetchTicketState } from "./linear-query.mjs";
+// CTL-558: the deterministic Linear status/label write seam. The whole module
+// is injected as `writeStatus` so tests pass fakes; production uses the real
+// module (best-effort — every write swallows its own failures).
+import * as linearWrite from "./linear-write.mjs";
 import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
@@ -255,12 +259,25 @@ export function deriveAdvancement(signals) {
   return next.phase;
 }
 
-// schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull.
-// Idempotent and restart-safe — derives every action from filesystem state.
-// `exec` is the injectable seam for the D5 out-of-set blocker-state fetch.
+// safeWrite — run a best-effort Linear-write call (CTL-558). A write failure
+// must never abort the tick: a thrown error is logged and swallowed. `ctx` is
+// merged into the log line so the failing { ticket, phase } stays visible.
+function safeWrite(fn, ctx) {
+  try {
+    fn();
+  } catch (err) {
+    log.warn({ ...ctx, err: err.message }, "scheduler: Linear write-back threw — continuing tick");
+  }
+}
+
+// schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull,
+// (3) terminal-Done sweep (CTL-558). Idempotent and restart-safe — derives
+// every action from filesystem state. `exec` is the injectable seam for the D5
+// out-of-set blocker-state fetch; `writeStatus` is the injectable Linear-write
+// seam (CTL-558) — defaults to the real linear-write.mjs module.
 export function schedulerTick(
   orchDir,
-  { readEligible, dispatch = defaultDispatch, exec } = {},
+  { readEligible, dispatch = defaultDispatch, exec, writeStatus = linearWrite } = {},
 ) {
   // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
   const advanced = [];
@@ -268,8 +285,17 @@ export function schedulerTick(
     const next = deriveAdvancement(readPhaseSignals(orchDir, ticket));
     if (!next) continue;
     const r = dispatchTicket(orchDir, ticket, next, { dispatch });
-    if (r.code === 0) advanced.push({ ticket, phase: next });
-    else log.warn({ ticket, phase: next, code: r.code }, "scheduler: advance dispatch failed");
+    if (r.code === 0) {
+      advanced.push({ ticket, phase: next });
+      // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
+      // (linear-transition.sh read-compares first); never aborts the tick.
+      safeWrite(() => writeStatus.applyPhaseStatus({ ticket, phase: next }), {
+        ticket,
+        phase: next,
+      });
+    } else {
+      log.warn({ ticket, phase: next, code: r.code }, "scheduler: advance dispatch failed");
+    }
   }
 
   // (2) New-work pull — fill free slots with top-ranked ready tickets. D5:
@@ -285,8 +311,31 @@ export function schedulerTick(
   const dispatched = [];
   for (const t of selected) {
     const r = dispatchTicket(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, { dispatch });
-    if (r.code === 0) dispatched.push(t.identifier);
-    else log.warn({ ticket: t.identifier, code: r.code }, "scheduler: dispatch failed");
+    if (r.code === 0) {
+      dispatched.push(t.identifier);
+      // CTL-558: write the entry-phase (`research`) status for the new ticket.
+      safeWrite(
+        () =>
+          writeStatus.applyPhaseStatus({
+            ticket: t.identifier,
+            phase: NEW_WORK_ENTRY_PHASE,
+          }),
+        { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE },
+      );
+    } else {
+      log.warn({ ticket: t.identifier, code: r.code }, "scheduler: dispatch failed");
+    }
+  }
+
+  // (3) Terminal-Done sweep (CTL-558) — deriveAdvancement returns null once
+  // monitor-deploy completes, so terminal `Done` is not a dispatch. Sweep every
+  // started ticket and write `Done` for any whose monitor-deploy signal is done.
+  // Idempotent — linear-transition.sh read-compares, so a re-applied Done is a
+  // no-op skip.
+  for (const ticket of listStartedTickets(orchDir)) {
+    if (readPhaseSignals(orchDir, ticket)["monitor-deploy"] === "done") {
+      safeWrite(() => writeStatus.applyTerminalDone({ ticket }), { ticket });
+    }
   }
 
   return { advanced, dispatched, freeSlots, ready: ready.map((t) => t.identifier) };
@@ -312,6 +361,7 @@ function runTick() {
       readEligible: runningOpts.readEligible,
       dispatch: runningOpts.dispatch,
       exec: runningOpts.exec,
+      writeStatus: runningOpts.writeStatus,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -325,19 +375,22 @@ function scheduleDebouncedTick(debounceMs) {
 }
 
 // startScheduler — immediate authoritative tick, arm the periodic timer, then
-// start the event-log fast path. `dispatch` / `readEligible` / `exec` are
-// injectable so a test drives a hermetic daemon (`exec` is the D5 blocker-state
-// fetch seam, CTL-565).
+// start the event-log fast path. `dispatch` / `readEligible` / `exec` /
+// `writeStatus` are injectable so a test drives a hermetic daemon (`exec` is
+// the D5 blocker-state fetch seam, CTL-565; `writeStatus` is the CTL-558
+// Linear-write seam — undefined here defaults to the real module in
+// schedulerTick).
 export function startScheduler({
   orchDir,
   dispatch,
   readEligible,
   exec,
+  writeStatus,
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
 } = {}) {
   if (!orchDir) throw new Error("startScheduler: orchDir is required");
-  runningOpts = { orchDir, dispatch, readEligible, exec };
+  runningOpts = { orchDir, dispatch, readEligible, exec, writeStatus };
 
   runTick(); // authoritative initial pass
   tickTimer = setInterval(runTick, tickIntervalMs);

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -664,3 +664,99 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
     expect(r.advanced).toEqual([]);
   });
 });
+
+// ── CTL-558: deterministic Linear status write-back from the scheduler ──
+
+describe("schedulerTick — Linear status write-back (CTL-558)", () => {
+  const readyTicket = (id, priority = 2) => ({
+    identifier: id,
+    priority,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+  const okDispatch = fakeDispatch();
+  const failDispatch = fakeDispatch({ code: 1 });
+
+  test("writes the dispatched phase's status after a successful advancement dispatch", () => {
+    // research done → advancement owes `plan`
+    writeSignal("CTL-1", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const writes = [];
+    const writeStatus = {
+      applyPhaseStatus: (a) => writes.push(a),
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: okDispatch, writeStatus });
+    expect(writes).toContainEqual(
+      expect.objectContaining({ ticket: "CTL-1", phase: "plan" })
+    );
+  });
+
+  test("writes `research` status for a new-work pull dispatch", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const writes = [];
+    const writeStatus = {
+      applyPhaseStatus: (a) => writes.push(a),
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [readyTicket("CTL-2")],
+      dispatch: okDispatch,
+      writeStatus,
+    });
+    expect(writes).toContainEqual(
+      expect.objectContaining({ ticket: "CTL-2", phase: "research" })
+    );
+  });
+
+  test("does NOT write status when the dispatch fails", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const writes = [];
+    const writeStatus = {
+      applyPhaseStatus: (a) => writes.push(a),
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [readyTicket("CTL-3")],
+      dispatch: failDispatch,
+      writeStatus,
+    });
+    expect(writes).toHaveLength(0);
+  });
+
+  test("writes terminal Done when a ticket's monitor-deploy signal is done", () => {
+    writeSignal("CTL-4", "monitor-deploy", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dones = [];
+    const writeStatus = {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: (a) => dones.push(a),
+      applyLabel: () => {},
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: okDispatch, writeStatus });
+    expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-4" }));
+  });
+
+  test("a status-write throw never aborts the tick", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const writeStatus = {
+      applyPhaseStatus: () => {
+        throw new Error("boom");
+      },
+      applyTerminalDone: () => {},
+      applyLabel: () => {},
+    };
+    expect(() =>
+      schedulerTick(orchDir, {
+        readEligible: () => [readyTicket("CTL-5")],
+        dispatch: okDispatch,
+        writeStatus,
+      })
+    ).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4,7 +4,14 @@
 // Phase 3 adds the selection-core blocks; Phases 4-5 extend this same file.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  appendFileSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -757,6 +764,78 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
         dispatch: okDispatch,
         writeStatus,
       })
+    ).not.toThrow();
+  });
+});
+
+// ── CTL-558: deterministic label write-back (triaged / needs-human) ──
+
+describe("schedulerTick — label write-back (CTL-558)", () => {
+  const noWrites = () => ({
+    applyPhaseStatus() {},
+    applyTerminalDone() {},
+  });
+
+  test("applies the `triaged` label when a ticket's triage signal is done", () => {
+    writeSignal("CTL-6", "triage", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const labels = [];
+    const writeStatus = { ...noWrites(), applyLabel: (a) => labels.push(a) };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(labels).toContainEqual(
+      expect.objectContaining({ ticket: "CTL-6", label: "triaged" })
+    );
+  });
+
+  test("applies `needs-human` when any phase signal is stalled", () => {
+    writeSignal("CTL-7", "implement", "stalled");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const labels = [];
+    const writeStatus = { ...noWrites(), applyLabel: (a) => labels.push(a) };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(labels).toContainEqual(
+      expect.objectContaining({ ticket: "CTL-7", label: "needs-human" })
+    );
+  });
+
+  test("does not re-apply a label once the .applied marker exists", () => {
+    writeSignal("CTL-7", "implement", "stalled");
+    writeFileSync(
+      join(orchDir, "workers", "CTL-7", ".linear-label-needs-human.applied"),
+      ""
+    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const labels = [];
+    const writeStatus = { ...noWrites(), applyLabel: (a) => labels.push(a) };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(labels).toHaveLength(0);
+  });
+
+  test("writes the .applied marker only after applyLabel reports applied:true", () => {
+    writeSignal("CTL-8", "triage", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const markerPath = join(orchDir, "workers", "CTL-8", ".linear-label-triaged.applied");
+    // applyLabel reports failure → no marker written → retried next tick.
+    const failWrite = { ...noWrites(), applyLabel: () => ({ applied: false }) };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus: failWrite });
+    expect(existsSync(markerPath)).toBe(false);
+    // applyLabel succeeds → marker written → not retried.
+    const okWrite = { ...noWrites(), applyLabel: () => ({ applied: true }) };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus: okWrite });
+    expect(existsSync(markerPath)).toBe(true);
+  });
+
+  test("a label-write throw never aborts the tick", () => {
+    writeSignal("CTL-9", "triage", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => {
+        throw new Error("label boom");
+      },
+    };
+    expect(() =>
+      schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus })
     ).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/lib/phase-fsm.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.mjs
@@ -41,11 +41,45 @@ export const NEXT_PHASE = {
   "monitor-deploy": TERMINAL_SUCCESS,
 };
 
+// ─── Phase → Linear stateMap key — the 9→5 collapse (CTL-558) ───
+// Each pipeline phase maps to a `.catalyst.linear.stateMap` key; linear-transition.sh
+// resolves that key to a Linear workflow-state name (config stateMap > default_state_for).
+// The keys are the legacy stateMap vocabulary — an execution-core repo's stateMap
+// re-targets the SAME keys onto the 5 collapsed states (Research/Plan/Implement/
+// Validate/PR), see setup-execution-core-states.sh:build_execution_core_state_map.
+//   • `triage` → null: the human owns the Triage state; the daemon only tags `triaged`.
+//   • verify + review collapse onto `verifying`/`reviewing` (both → Validate).
+//   • pr + monitor-merge + monitor-deploy collapse onto `inReview` (→ PR) while in flight;
+//     terminal Done is written separately on monitor-deploy completion (TERMINAL_LINEAR_KEY).
+export const PHASE_LINEAR_KEY = {
+  triage: null,
+  research: "research",
+  plan: "planning",
+  implement: "inProgress",
+  verify: "verifying",
+  review: "reviewing",
+  pr: "inReview",
+  "monitor-merge": "inReview",
+  "monitor-deploy": "inReview",
+};
+
+// The stateMap key for the terminal success state — written when monitor-deploy completes.
+export const TERMINAL_LINEAR_KEY = "done";
+
 export class PhaseFsmError extends Error {
   constructor(message) {
     super(message);
     this.name = "PhaseFsmError";
   }
+}
+
+// linearKeyForPhase — the stateMap key for a pipeline phase, or null for `triage`.
+// Throws PhaseFsmError on an unknown phase so a typo fails loudly, never silently no-ops.
+export function linearKeyForPhase(phase) {
+  if (!(phase in PHASE_LINEAR_KEY)) {
+    throw new PhaseFsmError(`no Linear key for unknown phase '${phase}'`);
+  }
+  return PHASE_LINEAR_KEY[phase];
 }
 
 // ─── Validation helpers (private) ───

--- a/plugins/dev/scripts/lib/phase-fsm.test.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.test.mjs
@@ -7,6 +7,9 @@ import {
   PHASES,
   REVIVE_BUDGET,
   PhaseFsmError,
+  PHASE_LINEAR_KEY,
+  TERMINAL_LINEAR_KEY,
+  linearKeyForPhase,
   initialState,
   isTerminal,
   transition,
@@ -237,4 +240,48 @@ describe("transition — resume: needs-input returns to the parked phase", () =>
       ).toThrow(PhaseFsmError);
     });
   }
+});
+
+// ─── CTL-558: phase → Linear stateMap-key declaration (the 9→5 collapse) ───
+
+describe("PHASE_LINEAR_KEY — the 9→5 collapse (CTL-558)", () => {
+  test("declares an entry for every one of the 9 phases", () => {
+    for (const p of PHASES) expect(p in PHASE_LINEAR_KEY).toBe(true);
+  });
+  test("maps the in-flight phases to their stateMap keys", () => {
+    expect(PHASE_LINEAR_KEY).toMatchObject({
+      research: "research",
+      plan: "planning",
+      implement: "inProgress",
+      verify: "verifying",
+      review: "reviewing",
+      pr: "inReview",
+      "monitor-merge": "inReview",
+      "monitor-deploy": "inReview",
+    });
+  });
+  test("triage has no status key — the human owns the Triage state", () => {
+    expect(PHASE_LINEAR_KEY.triage).toBeNull();
+  });
+  test("verify and review carry the legacy verifying/reviewing keys (both resolve to Validate)", () => {
+    // The keys stay distinct (verifying ≠ reviewing) — the 9→5 collapse happens
+    // at the resolved state-NAME level: an execution-core stateMap re-targets both
+    // keys onto the single `Validate` state. linear-transition.sh owns key→name.
+    expect(PHASE_LINEAR_KEY.verify).toBe("verifying");
+    expect(PHASE_LINEAR_KEY.review).toBe("reviewing");
+  });
+  test("pr, monitor-merge, monitor-deploy collapse onto the PR-equivalent key", () => {
+    expect(PHASE_LINEAR_KEY.pr).toBe(PHASE_LINEAR_KEY["monitor-merge"]);
+    expect(PHASE_LINEAR_KEY.pr).toBe(PHASE_LINEAR_KEY["monitor-deploy"]);
+  });
+  test("TERMINAL_LINEAR_KEY is the done key", () => {
+    expect(TERMINAL_LINEAR_KEY).toBe("done");
+  });
+  test("linearKeyForPhase returns the key, or null for triage", () => {
+    expect(linearKeyForPhase("research")).toBe("research");
+    expect(linearKeyForPhase("triage")).toBeNull();
+  });
+  test("linearKeyForPhase throws PhaseFsmError on an unknown phase", () => {
+    expect(() => linearKeyForPhase("bogus")).toThrow(PhaseFsmError);
+  });
 });

--- a/plugins/dev/scripts/orchestrate-phase-advance
+++ b/plugins/dev/scripts/orchestrate-phase-advance
@@ -36,6 +36,9 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
 DISPATCH_NEXT_BIN="${CATALYST_DISPATCH_NEXT_BIN:-${SCRIPT_DIR}/orchestrate-dispatch-next}"
+# CTL-558: the bash status-write chokepoint — phase-agents mode's deterministic
+# Linear write site, mirroring the execution-core scheduler.
+LINEAR_TRANSITION_BIN="${CATALYST_LINEAR_TRANSITION_BIN:-${SCRIPT_DIR}/linear-transition.sh}"
 
 # shellcheck source=lib/executor.sh
 source "${SCRIPT_DIR}/lib/executor.sh"
@@ -91,6 +94,23 @@ phase_next() {
   esac
 }
 
+# linear_key_for_phase — the .catalyst.linear.stateMap key for a phase (CTL-558).
+# This is the bash mirror of PHASE_LINEAR_KEY in lib/phase-fsm.mjs — KEEP THE
+# TWO IN SYNC (bash cannot import the .mjs). `triage` has no status key (the
+# human owns the Triage state). linear-transition.sh resolves the key → state
+# name via the repo's stateMap, so this stays correct on a stale config.
+linear_key_for_phase() {
+  case "$1" in
+    research)                        echo "research" ;;
+    plan)                            echo "planning" ;;
+    implement)                       echo "inProgress" ;;
+    verify)                          echo "verifying" ;;
+    review)                          echo "reviewing" ;;
+    pr|monitor-merge|monitor-deploy) echo "inReview" ;;
+    *)                               echo "" ;;  # triage / unknown — no write
+  esac
+}
+
 NEXT_PHASE="$(phase_next "$COMPLETED_PHASE")" || {
   echo "ERROR: unknown phase '$COMPLETED_PHASE' (not in canonical 9-phase sequence)" >&2
   exit 2
@@ -143,6 +163,20 @@ fi
     '{advanced: false, fromPhase: $from, toPhase: $to, ticket: $ticket, reason: "dispatch-failed"}'
   exit 0
 }
+
+# CTL-558: deterministic Linear status write-back for phase-agents mode. Now
+# that the next phase agent is dispatched, write its mapped Linear state via the
+# bash chokepoint linear-transition.sh (idempotent — it read-compares first).
+# Best-effort: a failed write must NOT change this script's exit code, exactly
+# like the execution-core scheduler's safeWrite. Terminal `Done` is NOT written
+# here — orchestrate-phase-advance never advances past monitor-deploy; phase-
+# agents-mode terminal Done is phase-monitor-merge's `--transition done`.
+LINEAR_KEY="$(linear_key_for_phase "$NEXT_PHASE")"
+if [ -n "$LINEAR_KEY" ] && [ -x "$LINEAR_TRANSITION_BIN" ]; then
+  TRANSITION_ARGS=( --ticket "$TICKET" --transition "$LINEAR_KEY" )
+  [ -n "$CONFIG_PATH" ] && TRANSITION_ARGS+=( --config "$CONFIG_PATH" )
+  "$LINEAR_TRANSITION_BIN" "${TRANSITION_ARGS[@]}" >/dev/null 2>&1 || true
+fi
 
 # CTL-567: reap the predecessor phase's `claude --bg` job now that its successor
 # is dispatched. This script runs ONLY on `phase.<name>.complete` — `failed` and

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -224,6 +224,13 @@ If ticket was extracted from branch:
 # Skip silently if CLI not available.
 ```
 
+**Skip the status transition (step 1) when `CATALYST_PHASE` is set** — under a
+phase agent the deterministic coordinator (CTL-558) owns the Linear status
+write-back (the execution-core scheduler / `orchestrate-phase-advance` writes
+the `inReview`-equivalent state on the `pr` phase). This status transition is
+only for interactive `/catalyst-dev:create-pr` use; the PR-link comment (step 2)
+is still posted in both modes.
+
 ### 12. Post-PR Monitoring & Resolution Loop
 
 **CRITICAL: Creating the PR is NOT the end of this skill.** You MUST monitor CI checks, wait for

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -358,6 +358,12 @@ If ticket found:
 # Skip silently if CLI not available.
 ```
 
+**Skip the status transition (step 1) when `CATALYST_PHASE` is set** — under a
+phase agent the deterministic coordinator (CTL-558) owns the Linear status
+write-back. This status transition is only for interactive
+`/catalyst-dev:describe-pr` use; the PR-link comment (step 2) is still posted in
+both modes.
+
 ### 14. Report results
 
 **If first-time generation:**

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -115,14 +115,10 @@ shopt -u nullglob
 PLAN_PATH="${PLAN_MATCHES[0]}"
 echo "phase-implement: plan = ${PLAN_PATH}"
 
-# 5. Transition Linear to inProgress (worker-owned state per plan §Linear
-#    Integration). Best-effort — Linear connectivity issues should not block
-#    the implementation work.
-LINEAR_TRANSITION="${PLUGIN_ROOT}/scripts/linear-transition.sh"
-if [[ -x "$LINEAR_TRANSITION" ]]; then
-  "$LINEAR_TRANSITION" --ticket "$TICKET" --transition inProgress \
-    --config .catalyst/config.json 2>/dev/null || true
-fi
+# 5. Linear status is written by the coordinator (CTL-558): the execution-core
+#    scheduler / orchestrate-phase-advance applies the `Implement` state when
+#    it commits the implement-phase transition. The phase agent no longer
+#    transitions Linear itself.
 ```
 
 ## /goal condition
@@ -134,9 +130,8 @@ Plan §"Per-phase /goal conditions":
 ```
 /goal "I have run /catalyst-dev:implement-plan on ${PLAN_PATH} to completion
        AND `git diff <base>..HEAD` on this branch is non-empty AND the targeted
-       tests pass (I have printed the test command + `exit 0` to my transcript)
-       AND I have updated Linear to inProgress (the linear-transition.sh
-       output line is in my transcript);
+       tests pass (I have printed the test command + `exit 0` to my transcript);
+       (Linear status is written by the coordinator — CTL-558 — not this agent.)
        OR I am within ~5 turns of the 75-turn cap, in which case I have
        (a) written a structured handoff to
            thoughts/shared/handoffs/${TICKET}/<ts>_turn-cap-continuation.md

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -110,15 +110,9 @@ fi
 RESEARCH_DOC="${RESEARCH_MATCHES[-1]}"
 ```
 
-## Linear state transition
-
-```bash
-LT="${PLUGIN_ROOT}/scripts/linear-transition.sh"
-if [[ -x "$LT" ]]; then
-  "$LT" --ticket "$TICKET" --transition planning --config .catalyst/config.json \
-    >/dev/null 2>&1 || true
-fi
-```
+<!-- Linear status is written by the coordinator (CTL-558): the execution-core
+     scheduler / orchestrate-phase-advance applies the mapped state on every
+     committed phase transition. The phase agent no longer transitions Linear. -->
 
 ## /goal
 

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -96,19 +96,9 @@ fi
 TRIAGE_SUMMARY=$(jq -r '.summary // .classification // ""' "$TRIAGE_FILE" 2>/dev/null || echo "")
 ```
 
-## Linear state transition
-
-Move the ticket to the `researching` state added in CTL-454. Best-effort; if the
-transition fails (state map missing, network), the phase continues — Linear state
-is observability, not gating.
-
-```bash
-LT="${PLUGIN_ROOT}/scripts/linear-transition.sh"
-if [[ -x "$LT" ]]; then
-  "$LT" --ticket "$TICKET" --transition researching --config .catalyst/config.json \
-    >/dev/null 2>&1 || true
-fi
-```
+<!-- Linear status is written by the coordinator (CTL-558): the execution-core
+     scheduler / orchestrate-phase-advance applies the mapped state on every
+     committed phase transition. The phase agent no longer transitions Linear. -->
 
 ## /goal
 

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -94,17 +94,10 @@ fi
 REGRESSION_RISK=$(jq -r '.regression_risk // 0' "$VERIFY_ARTIFACT")
 ```
 
-## Linear state transition
+<!-- Linear status is written by the coordinator (CTL-558): the execution-core
+     scheduler / orchestrate-phase-advance applies the mapped state on every
+     committed phase transition. The phase agent no longer transitions Linear. -->
 
-Move the ticket to `reviewing` (added in CTL-454).
-
-```bash
-LT="${PLUGIN_ROOT}/scripts/linear-transition.sh"
-if [[ -x "$LT" ]]; then
-  "$LT" --ticket "$TICKET" --transition reviewing --config .catalyst/config.json \
-    >/dev/null 2>&1 || true
-fi
-```
 
 ## /goal
 

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phase-triage
-description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies dependencies, estimates scope, writes triage.json, posts a triaged comment to Linear, and applies the `triaged` label. Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-triage ..."` resolves.
+description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies dependencies, estimates scope, writes triage.json, and posts a triaged comment to Linear. The `triaged` label is applied by the coordinator (CTL-558). Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-triage ..."` resolves.
 user-invocable: true
 disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools: Bash, Read, Write, Grep
@@ -25,10 +25,10 @@ Both modes produce the same `triage.json` shape and emit the same canonical phas
 
 ## Setup prerequisite
 
-The `triaged` workspace label must already exist in Linear. The skill applies it via
-`linearis issues update --labels triaged --label-mode add` and tolerates a non-zero exit (logs a
-warning, does not fail the phase). Future work in CTL-452 may add a `linearis labels create` call to
-bootstrap the label.
+The `triaged` workspace label must already exist in Linear. The label is applied by the
+deterministic coordinator (CTL-558) — the execution-core scheduler's label sweep tags `triaged`
+once the triage phase signal is `done` — not by this skill. `linearis` has no label-create, so the
+label must be created in the workspace beforehand.
 
 ## Inputs
 
@@ -224,10 +224,9 @@ if ! linearis issues discuss "$TICKET" --body "$COMMENT_BODY" >/dev/null 2>&1; t
   exit 1
 fi
 
-# 5. Apply the `triaged` label. Tolerate failure (label may not exist yet).
-if ! linearis issues update "$TICKET" --labels triaged --label-mode add >/dev/null 2>&1; then
-  echo "phase-triage: warning — could not apply triaged label (does it exist in the workspace?)" >&2
-fi
+# 5. The `triaged` label is applied by the coordinator (CTL-558): the
+#    execution-core scheduler's label sweep tags `triaged` once the triage
+#    phase signal is `done`. The phase agent no longer applies the label.
 
 # 6. Emit the canonical phase event.
 emit_phase_complete --phase triage --ticket "$TICKET" --status complete \

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -103,17 +103,10 @@ if [[ ! -f "$IMPLEMENT_SIGNAL" ]]; then
 fi
 ```
 
-## Linear state transition
+<!-- Linear status is written by the coordinator (CTL-558): the execution-core
+     scheduler / orchestrate-phase-advance applies the mapped state on every
+     committed phase transition. The phase agent no longer transitions Linear. -->
 
-Move the ticket to `verifying` (added in CTL-454).
-
-```bash
-LT="${PLUGIN_ROOT}/scripts/linear-transition.sh"
-if [[ -x "$LT" ]]; then
-  "$LT" --ticket "$TICKET" --transition verifying --config .catalyst/config.json \
-    >/dev/null 2>&1 || true
-fi
-```
 
 ## /goal
 


### PR DESCRIPTION
## Summary

CTL-558 moves Linear status write-back out of the per-phase agents and into the
**deterministic orchestrator coordinator**. Previously each `phase-*` skill
shelled `linear-transition.sh` to advance the ticket's workflow state, which
duplicated logic across six skills and was prone to drift. The coordinator
(execution-core scheduler / `orchestrate-phase-advance`) now owns a single,
idempotent write path keyed off the phase FSM.

Refs: CTL-558

## Changes

### Phase FSM — phase→Linear-key declaration
- `plugins/dev/scripts/lib/phase-fsm.mjs` — adds `linearKeyForPhase()` and
  `TERMINAL_LINEAR_KEY`, declaring the mapping from each pipeline phase to its
  Linear `stateMap` key (`triage`→none, `research`→`researching`,
  `plan`→`planning`, `implement`→`inProgress`, `verify`→`verifying`,
  `review`→`reviewing`, `pr`/`monitor-merge`→`inReview`). `triage` has no
  status key (no-op).

### `linear-write.mjs` — ESM status-write seam
- New `plugins/dev/scripts/execution-core/linear-write.mjs` — the D9 cloud seam
  for status **writes** (mirror of `linear-query.mjs` reads). Exports
  `applyPhaseStatus`, `applyTerminalDone`, `applyLabel`, and `teamOf`. Internals
  shell to the bash chokepoint `linear-transition.sh` so there is one write path
  with idempotency, UUID stateId resolution, and 3-tier state precedence.
  Every write is **best-effort** — failures are logged and swallowed, never thrown.
- Re-exported from the execution-core barrel (`index.mjs`).

### Scheduler — wire status write-back
- `plugins/dev/scripts/execution-core/scheduler.mjs` — calls the `linear-write`
  module (injected as `writeStatus` so tests pass fakes; production uses the
  real module) on every committed phase transition.
- `plugins/dev/scripts/execution-core/daemon.mjs` — note clarifying the
  scheduler writes Linear status via its default `writeStatus`; no extra daemon
  wiring required.
- `plugins/dev/scripts/orchestrate-phase-advance` — writes the mapped Linear
  status when advancing to a non-terminal phase; forwards `--config`; terminal
  `monitor-deploy` does not write (terminal Done is `phase-monitor-merge`'s job).

### Phase-agents-mode writer + prose removal
- Removed the `linear-transition.sh --transition` prose from the six shared
  `phase-*` skills (`phase-research`, `phase-plan`, `phase-implement`,
  `phase-verify`, `phase-review`) — the coordinator owns the write now.
- `phase-monitor-merge` keeps its terminal `--transition done` writer.
- `create-pr` / `describe-pr` SKILL.md now gate their interactive `inReview`
  transition on `CATALYST_PHASE` so the phase-agent path does not double-write.

### Triaged + needs-human label write-back
- `phase-triage` no longer self-applies the `triaged` label via
  `linearis issues update` — the coordinator's label sweep owns it.
- `applyLabel` handles additive (`--label-mode add`) application of the
  `triaged` and `needs-human` labels.

## Testing

- `lib/phase-fsm.test.mjs` — phase→Linear-key mapping.
- `execution-core/linear-write.test.mjs` — `applyPhaseStatus`, `applyTerminalDone`,
  `applyLabel`, `teamOf`; covers triage no-op, repo-root resolution failure,
  non-zero exit, and never-throws behavior.
- `execution-core/scheduler.test.mjs` — status write-back wiring with injected fakes.
- `__tests__/orchestrate-phase-advance.test.sh` — tests 13–17: per-phase
  `--transition` mapping, terminal no-write, best-effort exit code, `--config`
  forwarding.
- `__tests__/phase-skill-no-linear-prose.test.sh` (new) — asserts the six
  `phase-*` skills carry no Linear status-write prose, `phase-monitor-merge`
  keeps its terminal writer, and `create-pr` / `describe-pr` gate on
  `CATALYST_PHASE`.
- Updated `phase-{research,plan,implement,verify,review,triage}` e2e tests to
  assert the prose is gone (no self-transition).
