### PR TITLE
CTL-572: probe webhookTunnel.connected in oneshot Phase 5 pre-flight

### DIFF
--- a/plugins/dev/scripts/__tests__/oneshot-tunnel-preflight.test.sh
+++ b/plugins/dev/scripts/__tests__/oneshot-tunnel-preflight.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# CTL-572: the oneshot Phase 5 listen-loop pre-flight must probe the webhook
+# tunnel field that actually exists. `catalyst-monitor status --json` exposes
+# `.webhookTunnel.connected` (boolean) and `.webhookTunnel.lastEventAt` — there
+# is NO `.webhookTunnel.state` field, so the old `.webhookTunnel.state` probe
+# always resolved to "unknown" and forced REST polling on every run.
+#
+# This test guards three skills:
+#   - oneshot           — must use .connected + a lastEventAt staleness check
+#   - wait-for-github   — already correct; guard against regressing to .state
+#   - monitor-events    — already correct; guard against regressing to .state
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+ONESHOT="${REPO_ROOT}/plugins/dev/skills/oneshot/SKILL.md"
+WAIT_FOR_GITHUB="${REPO_ROOT}/plugins/dev/skills/wait-for-github/SKILL.md"
+MONITOR_EVENTS="${REPO_ROOT}/plugins/dev/skills/monitor-events/SKILL.md"
+
+FAILURES=0
+PASSES=0
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_grep() {
+  local file="$1" pattern="$2" label="$3"
+  if grep -qF "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label — expected '$pattern' in $(basename "$(dirname "$file")")/$(basename "$file")"
+  fi
+}
+
+assert_not_grep() {
+  local file="$1" pattern="$2" label="$3"
+  if grep -qF "$pattern" "$file"; then
+    fail "$label — forbidden '$pattern' found in $(basename "$(dirname "$file")")/$(basename "$file")"
+  else
+    pass "$label"
+  fi
+}
+
+for f in "$ONESHOT" "$WAIT_FOR_GITHUB" "$MONITOR_EVENTS"; do
+  if [[ ! -f "$f" ]]; then
+    echo "FATAL: skill file missing: $f" >&2
+    exit 1
+  fi
+done
+
+echo "Test: oneshot SKILL probes the webhook-tunnel field that exists"
+assert_not_grep "$ONESHOT" 'webhookTunnel.state' \
+  "oneshot SKILL does not probe the non-existent .webhookTunnel.state field"
+assert_grep "$ONESHOT" 'webhookTunnel.connected' \
+  "oneshot SKILL probes .webhookTunnel.connected"
+assert_grep "$ONESHOT" 'lastEventAt' \
+  "oneshot SKILL includes a lastEventAt staleness check"
+
+echo ""
+echo "Test: already-correct skills do not regress to .webhookTunnel.state"
+assert_not_grep "$WAIT_FOR_GITHUB" 'webhookTunnel.state' \
+  "wait-for-github SKILL does not probe .webhookTunnel.state"
+assert_not_grep "$MONITOR_EVENTS" 'webhookTunnel.state' \
+  "monitor-events SKILL does not probe .webhookTunnel.state"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "oneshot-tunnel-preflight: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/skills/oneshot/SKILL.md
+++ b/plugins/dev/skills/oneshot/SKILL.md
@@ -756,10 +756,32 @@ jq --arg ts "$PR_OPENED_AT" '.pr.prOpenedAt = $ts | .status = "pr-created"' \
   "$SIGNAL_FILE" > "$SIGNAL_FILE.tmp" && mv "$SIGNAL_FILE.tmp" "$SIGNAL_FILE"
 
 # Pre-flight: verify event infrastructure (from [[wait-for-github]])
+# CTL-572: probe .webhookTunnel.connected — the field that exists. The old
+# probe read a field catalyst-monitor never emits, so it always resolved to
+# "unknown" and forced REST polling on every run. .connected is optimistic
+# (EventSource.isStarted(), not live delivery), so also fall back when the
+# tunnel has gone quiet: no webhook event across the shared smee channel for
+# TUNNEL_STALE_AGE_SEC.
 INFRA_STATUS=$(catalyst-monitor status --json 2>/dev/null)
-TUNNEL=$(echo "$INFRA_STATUS" | jq -r '.webhookTunnel.state // "unknown"' 2>/dev/null)
+TUNNEL_STALE_AGE_SEC="${CATALYST_TUNNEL_STALE_AGE_SEC:-21600}"  # 6h default
 USE_REST=false
-[ "$TUNNEL" != "running" ] && { echo "WARN: tunnel not running — using REST fallback"; USE_REST=true; }
+TUNNEL_CONNECTED=$(echo "$INFRA_STATUS" | jq -r '.webhookTunnel.connected // false' 2>/dev/null)
+if [ "$TUNNEL_CONNECTED" != "true" ]; then
+  echo "WARN: webhook tunnel not connected — using REST fallback"
+  USE_REST=true
+else
+  # Staleness guard. jq handles the ISO-8601 math (portable across GNU/BSD date).
+  # lastEventAt absent (null) => fresh monitor, NOT treated as stale.
+  TUNNEL_EVENT_AGE=$(echo "$INFRA_STATUS" | jq -r '
+    (.webhookTunnel.lastEventAt // "") as $t
+    | if $t == "" then ""
+      else (now - (($t | sub("\\.[0-9]+Z$"; "Z")) | fromdateiso8601)) | floor
+      end' 2>/dev/null)
+  if [ -n "$TUNNEL_EVENT_AGE" ] && [ "$TUNNEL_EVENT_AGE" -gt "$TUNNEL_STALE_AGE_SEC" ]; then
+    echo "WARN: webhook tunnel last event ${TUNNEL_EVENT_AGE}s ago (> ${TUNNEL_STALE_AGE_SEC}s) — stale, using REST fallback"
+    USE_REST=true
+  fi
+fi
 
 # CTL-303: use broker auto-correlation. Emit a second agent.checkin with claimed_pr
 # so the broker auto-derives a pr_lifecycle interest — no explicit filter.register needed.
@@ -818,9 +840,11 @@ while [ "$PR_DONE" = "false" ]; do
       _SINCE_LINE=$(( ${_LOG_LINES:-0} > 500 ? ${_LOG_LINES:-0} - 500 : 0 ))
       HEARTBEATS=$(catalyst-events tail --since-line "$_SINCE_LINE" 2>/dev/null \
         | jq -c 'select(.attributes."event.name" == "heartbeat")' | wc -l | tr -d ' ')
+      # CTL-572: probe .webhookTunnel.connected (the field that exists). The
+      # HEARTBEATS == 0 term remains the stronger liveness signal here.
       TUNNEL_NOW=$(catalyst-monitor status --json 2>/dev/null \
-        | jq -r '.webhookTunnel.state // "unknown"')
-      if [ "${HEARTBEATS:-0}" -eq 0 ] || [ "$TUNNEL_NOW" != "running" ]; then
+        | jq -r '.webhookTunnel.connected // false')
+      if [ "${HEARTBEATS:-0}" -eq 0 ] || [ "$TUNNEL_NOW" != "true" ]; then
         echo "Infrastructure issue detected — switching to REST polling"
         USE_REST=true
       else


### PR DESCRIPTION
## Problem

The `oneshot` Phase 5 listen-loop pre-flight probed `.webhookTunnel.state` — a
field `catalyst-monitor status --json` never emits. `.webhookTunnel.state // "unknown"`
always resolved to `"unknown"`, `"unknown" != "running"` was always true, so
`USE_REST=true` was set on **every** run and the event-driven
`catalyst-events wait-for` path was dead code in practice.

Confirmed live: the ADV-1078 oneshot run (2026-05-21) polled CI via REST for
~6 min despite the tunnel being fully connected.

## Fix

Probe `.webhookTunnel.connected` (the boolean liveness field that exists) at
both pre-flight sites in `oneshot/SKILL.md`:

- **Site 1** (Phase 5 Step 2 pre-flight) — `.connected == true`, plus a
  `lastEventAt` staleness guard: `.connected` is optimistic (it reflects
  `EventSource.isStarted()`, not live delivery), so a connected-but-silent
  tunnel (no webhook event across the shared smee channel for
  `TUNNEL_STALE_AGE_SEC`, 6h default, overridable via
  `CATALYST_TUNNEL_STALE_AGE_SEC`) also forces the REST fallback. The
  ISO-8601 age math runs inside `jq` to stay portable across GNU/BSD `date`.
- **Site 2** (Phase-1 timeout diagnostic) — `.connected` fix only; the
  `HEARTBEATS == 0` term remains the stronger liveness signal there.

## Audit

`wait-for-github` and `monitor-events` already probe `.webhookTunnel.connected`
correctly — no change needed. Grep confirms no other `.webhookTunnel.state`
references in `plugins/`, `docs/`, or `website/`.

## Test

Adds `plugins/dev/scripts/__tests__/oneshot-tunnel-preflight.test.sh`
(modeled on `phase-skill-globs.test.sh`) — guards all three webhook-tunnel
skills against the `.webhookTunnel.state` regression and asserts oneshot
uses `.connected` + the `lastEventAt` staleness check.

Refs: CTL-572