### PR TITLE
CTL-575: fix setup-execution-core-states.sh Linear GraphQL query

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -205,7 +205,7 @@ body=""
 for arg in "\$@"; do
   case "\$arg" in
     *workflowStateCreate*) body="create" ;;
-    *workflowStates*|*states*) [ -z "\$body" ] && body="query" ;;
+    *states*) [ -z "\$body" ] && body="query" ;;
   esac
 done
 # -d @- form: body comes from stdin
@@ -219,7 +219,7 @@ fi
 if [ "\$body" = "create" ]; then
   echo '${create_resp}'
 else
-  echo '{"data":{"teams":{"nodes":[{"id":"${FAKE_TEAM_ID}","workflowStates":{"nodes":[${states_nodes}]}}]}}}'
+  echo '{"data":{"teams":{"nodes":[{"id":"${FAKE_TEAM_ID}","states":{"nodes":[${states_nodes}]}}]}}}'
 fi
 exit 0
 SCRIPT

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -195,7 +195,7 @@ main() {
   local query payload response
   # $teamKey is a GraphQL variable inside this single-quoted query, not a shell var.
   # shellcheck disable=SC2016
-  query='query($teamKey: String!) { teams(filter: { key: { eq: $teamKey } }) { nodes { id workflowStates { nodes { id name type } } } } }'
+  query='query($teamKey: String!) { teams(filter: { key: { eq: $teamKey } }) { nodes { id states { nodes { id name type } } } } }'
   payload=$(jq -nc --arg q "$query" --arg k "$team_key" '{query: $q, variables: {teamKey: $k}}')
   response=$(linear_graphql_post "$token" "$payload")
 
@@ -213,7 +213,7 @@ main() {
     return 2
   fi
   team_id=$(echo "$team_node" | jq -r '.id')
-  fetched_states=$(echo "$team_node" | jq -c '.workflowStates.nodes // []')
+  fetched_states=$(echo "$team_node" | jq -c '.states.nodes // []')
 
   # --- diff against the contract ---
   local missing


### PR DESCRIPTION
## Summary

`plugins/dev/scripts/setup-execution-core-states.sh` (shipped in CTL-564) queried the Linear GraphQL API for `workflowStates` on the `Team` type. That field does not exist — Linear's `Team` type exposes its workflow states through the `states` connection. Every real run aborted:

```
ERROR: Linear API error fetching workflow states: Cannot query field "workflowStates" on type "Team". Did you mean "draftWorkflowState", "mergeWorkflowState", or "startWorkflowState"?
```

The script returned exit 2 before creating any states or writing config — it had **never run successfully end-to-end** against the live API. This is a hard blocker for the Linear State-Machine Trigger Model rollout: the script is the per-team execution-core state-contract setup tool (CTL, ADVA).

## Root cause

The test suite stubbed `curl` with a canned response that *also* used `workflowStates`, so the test was self-consistently wrong and CI passed. The correct shape is in `resolve-linear-ids.sh:106`, which queries the same `teams { nodes { states { nodes ... } } }` structure correctly.

## Changes

- `setup-execution-core-states.sh` — GraphQL query + response parse: `workflowStates` → `states`
- `__tests__/setup-execution-core-states.test.sh` — fixture response shape now matches the real Linear schema, so the suite actually guards the field name

## Test plan

- [x] All 37 tests in `setup-execution-core-states.test.sh` pass
- [x] `bash -n` clean on both files
- [x] `--dry-run` against the **live CTL team** now succeeds (exit 0) and correctly reports all 6 contract states present

🤖 Generated with [Claude Code](https://claude.com/claude-code)