### PR TITLE
CTL-576: migrate CTL config to the execution-core Linear-state contract

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -8,24 +8,28 @@
       "teamKey": "CTL",
       "stateMap": {
         "backlog": "Backlog",
-        "todo": "Backlog",
+        "todo": "Ready",
+        "triage": "Triage",
         "research": "Research",
-        "planning": "Planning",
-        "inProgress": "In Progress",
-        "verifying": "In Progress",
-        "reviewing": "In Progress",
-        "inReview": "In Review",
+        "planning": "Plan",
+        "inProgress": "Implement",
+        "verifying": "Validate",
+        "reviewing": "Validate",
+        "inReview": "PR",
         "done": "Done",
         "canceled": "Canceled"
       },
       "teamId": "e7e703c4-13a8-42d4-97c1-25e342618f25",
       "stateIds": {
-        "Planning": "b64f94a4-954d-4cb1-943f-daee603ed9f7",
+        "Validate": "0830b734-d080-443e-a083-a172802337bd",
+        "Ready": "11cfc4cf-fe4a-4714-91cd-7c0793152753",
+        "Duplicate": "3a81488a-293f-44ee-a28b-69d22f272e46",
+        "Plan": "b64f94a4-954d-4cb1-943f-daee603ed9f7",
         "Research": "2d478844-8383-490f-9d8d-207363899764",
-        "In Review": "06397ace-b4ac-4a52-9754-befb13dc6e9b",
+        "PR": "06397ace-b4ac-4a52-9754-befb13dc6e9b",
         "Triage": "a35390a0-5ae1-474d-804d-0533e5735303",
         "Backlog": "71a1f143-cc27-4a6c-94fb-5ba0b164020e",
-        "In Progress": "5e9c1bfb-0949-4a12-b375-c84670905c33",
+        "Implement": "5e9c1bfb-0949-4a12-b375-c84670905c33",
         "Done": "5d779765-6245-4f15-a2d1-a33f477b87a3",
         "Canceled": "560f8e87-d745-420b-aa04-6ff418ae8b68"
       }
@@ -43,8 +47,14 @@
       },
       "linear": {
         "teams": [
-          { "key": "CTL", "vcsRepo": "coalesce-labs/catalyst" },
-          { "key": "ADV", "vcsRepo": "coalesce-labs/adva" }
+          {
+            "key": "CTL",
+            "vcsRepo": "coalesce-labs/catalyst"
+          },
+          {
+            "key": "ADV",
+            "vcsRepo": "coalesce-labs/adva"
+          }
         ]
       }
     },


### PR DESCRIPTION
## Summary

CTL's live Linear workflow is fully migrated to the execution-core state contract (`Triage`, `Ready`, `Research`, `Plan`, `Implement`, `Validate`, `PR` + `Backlog`/`Done`/`Canceled`/`Duplicate`). But the committed `.catalyst/config.json` still carried the **old** `stateMap`/`stateIds` referencing states that **no longer exist** (`Planning`, `In Progress`, `In Review`). Any Linear write-back resolving through the config — including phase-agents mode — was writing to dead state names.

This commit is the output of running `setup-execution-core-states.sh` against the CTL config, now that CTL-575 unblocked that script.

## Changes

- **`stateMap`** — the 9-phase → 5-state collapse: `todo→Ready`, new `triage→Triage`, `planning→Plan`, `inProgress→Implement`, `verifying`/`reviewing→Validate`, `inReview→PR`.
- **`stateIds`** — refreshed to the real UUIDs for every live CTL workflow state.

The central `~/catalyst/execution-core/registry.json` entry is also upserted by the script, but that file is machine-local and not tracked.

## Test plan

- [x] Dry-run confirmed all 6 contract states already exist in Linear — **no `workflowStateCreate` mutations** were made
- [x] `setup-execution-core-states.sh` exited 0; `stateMap` + `stateIds` written
- [x] Every `stateMap` value resolves to a key present in `stateIds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)