### PR TITLE
CTL-577: Make stateIds a pure derived cache

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -19,20 +19,7 @@
         "done": "Done",
         "canceled": "Canceled"
       },
-      "teamId": "e7e703c4-13a8-42d4-97c1-25e342618f25",
-      "stateIds": {
-        "Validate": "0830b734-d080-443e-a083-a172802337bd",
-        "Ready": "11cfc4cf-fe4a-4714-91cd-7c0793152753",
-        "Duplicate": "3a81488a-293f-44ee-a28b-69d22f272e46",
-        "Plan": "b64f94a4-954d-4cb1-943f-daee603ed9f7",
-        "Research": "2d478844-8383-490f-9d8d-207363899764",
-        "PR": "06397ace-b4ac-4a52-9754-befb13dc6e9b",
-        "Triage": "a35390a0-5ae1-474d-804d-0533e5735303",
-        "Backlog": "71a1f143-cc27-4a6c-94fb-5ba0b164020e",
-        "Implement": "5e9c1bfb-0949-4a12-b375-c84670905c33",
-        "Done": "5d779765-6245-4f15-a2d1-a33f477b87a3",
-        "Canceled": "560f8e87-d745-420b-aa04-6ff418ae8b68"
-      }
+      "teamId": "e7e703c4-13a8-42d4-97c1-25e342618f25"
     },
     "thoughts": {
       "profile": "coalesce-labs",

--- a/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup-execution-core.test.sh
@@ -29,14 +29,14 @@ build_project() {
   mkdir -p "$dir/thoughts/shared/research" "$dir/thoughts/shared/plans" \
     "$dir/thoughts/shared/handoffs" "$dir/thoughts/shared/prs" "$dir/thoughts/shared/reports"
 
-  local state_map state_ids
+  # CTL-577: stateIds is no longer in config — the contract check validates
+  # stateMap (the authored contract) only.
+  local state_map
   if [[ $full == "1" ]]; then
     state_map='{"backlog":"Backlog","todo":"Ready","triage":"Triage","research":"Research","planning":"Plan","inProgress":"Implement","verifying":"Validate","reviewing":"Validate","inReview":"PR","done":"Done","canceled":"Canceled"}'
-    state_ids='{"Backlog":"id-b","Triage":"id-t","Ready":"id-rd","Research":"id-rs","Plan":"id-pl","Implement":"id-im","Validate":"id-va","PR":"id-pr","Done":"id-dn","Canceled":"id-cn"}'
   else
-    # missing Validate and PR from both stateMap values and stateIds keys
+    # missing Validate and PR from stateMap values
     state_map='{"backlog":"Backlog","todo":"Ready","triage":"Triage","research":"Research","planning":"Plan","inProgress":"Implement","done":"Done","canceled":"Canceled"}'
-    state_ids='{"Backlog":"id-b","Triage":"id-t","Ready":"id-rd","Research":"id-rs","Plan":"id-pl","Implement":"id-im","Done":"id-dn","Canceled":"id-cn"}'
   fi
 
   cat > "$dir/.catalyst/config.json" <<EOF
@@ -46,8 +46,7 @@ build_project() {
     "project": { "ticketPrefix": "CTL" },
     "linear": {
       "teamKey": "CTL",
-      "stateMap": ${state_map},
-      "stateIds": ${state_ids}
+      "stateMap": ${state_map}
     },
     "orchestration": { "dispatchMode": "${mode}" }
   }
@@ -67,11 +66,14 @@ EOF
 }
 
 # run_check <project-dir> <catalyst-dir> — run the script, capture output.
+# XDG_CONFIG_HOME is pinned at a scratch dir so the CTL-577 stateIds-cache
+# check reads a hermetic (absent) registry, not the developer's real one.
 run_check() {
   local cwd="$1" catalyst_dir="$2"
   ( cd "$cwd" \
     && env -i HOME="$HOME" PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
        CATALYST_AUTONOMOUS=1 CATALYST_DIR="$catalyst_dir" \
+       XDG_CONFIG_HOME="${SCRATCH}/xdg" \
        bash "$SCRIPT" 2>&1 )
 }
 

--- a/plugins/dev/scripts/__tests__/check-project-setup.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup.test.sh
@@ -276,6 +276,55 @@ EOF
     "check-config-drift exited 2"
 }
 
+# ─── Test: stateIds cache registry absent → warn (CTL-577) ──────────────────
+test_state_ids_cache_missing() {
+  echo "test: stateIds cache registry absent → warn"
+  local proj="$SCRATCH/proj-sid-missing" key="proj-sid-missing"
+  make_project "$proj" "$key"
+  mkdir -p "$SCRATCH/xdg/catalyst"
+  echo '{}' > "$SCRATCH/xdg/catalyst/config-${key}.json"
+  rm -f "$SCRATCH/xdg/catalyst/linear-state-ids.json"
+
+  local out
+  out=$(run_script "$proj" 2>&1)
+  assert_grep "stateIds cache warn fires when registry absent" "$out" \
+    "Linear state-id cache not yet resolved for team 'CTL'"
+}
+
+# ─── Test: stateIds cache registry present but no entry for team → warn ──────
+test_state_ids_cache_no_entry() {
+  echo "test: stateIds cache registry present but no entry for team → warn"
+  local proj="$SCRATCH/proj-sid-noentry" key="proj-sid-noentry"
+  make_project "$proj" "$key"
+  mkdir -p "$SCRATCH/xdg/catalyst"
+  echo '{}' > "$SCRATCH/xdg/catalyst/config-${key}.json"
+  echo '{"ADV":{"resolvedAt":"2026-01-01T00:00:00Z","stateIds":{"Done":"x"}}}' \
+    > "$SCRATCH/xdg/catalyst/linear-state-ids.json"
+
+  local out
+  out=$(run_script "$proj" 2>&1)
+  assert_grep "stateIds cache warn fires when no entry for team CTL" "$out" \
+    "Linear state-id cache not yet resolved for team 'CTL'"
+}
+
+# ─── Test: stateIds cache registry has the team entry → no warn (CTL-577) ────
+# Also implicitly proves XDG_CONFIG_HOME is honored — the registry is found at
+# $XDG_CONFIG_HOME/catalyst/linear-state-ids.json.
+test_state_ids_cache_present() {
+  echo "test: stateIds cache registry has the team entry → no warn"
+  local proj="$SCRATCH/proj-sid-present" key="proj-sid-present"
+  make_project "$proj" "$key"
+  mkdir -p "$SCRATCH/xdg/catalyst"
+  echo '{}' > "$SCRATCH/xdg/catalyst/config-${key}.json"
+  echo '{"CTL":{"resolvedAt":"2026-05-22T00:00:00Z","stateIds":{"Research":"r-id","Done":"d-id"}}}' \
+    > "$SCRATCH/xdg/catalyst/linear-state-ids.json"
+
+  local out
+  out=$(run_script "$proj" 2>&1)
+  assert_not_grep "stateIds cache warn suppressed when entry present" "$out" \
+    "Linear state-id cache not yet resolved"
+}
+
 # ─── Run ────────────────────────────────────────────────────────────────────
 test_smee_missing
 test_smee_channel_missing
@@ -285,6 +334,9 @@ test_all_configured
 test_drift_warning_appears
 test_no_drift
 test_drift_setup_error_surfaces
+test_state_ids_cache_missing
+test_state_ids_cache_no_entry
+test_state_ids_cache_present
 
 echo ""
 echo "Results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/__tests__/linear-transition.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-transition.test.sh
@@ -19,6 +19,14 @@ PASSES=0
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
+# CTL-577: the stateIds UUID cache is a machine-level registry at
+# $HOME/.config/catalyst/linear-state-ids.json. Fake HOME so the registry path
+# is hermetic — an absent registry makes every transition fall back to the
+# state name (always correct), which is what the name-based tests below expect.
+export HOME="${SCRATCH}/home"
+mkdir -p "${HOME}/.config/catalyst"
+REGISTRY="${HOME}/.config/catalyst/linear-state-ids.json"
+
 run() {
   local name="$1"; shift
   if "$@" > "${SCRATCH}/out" 2>&1; then
@@ -95,6 +103,29 @@ fi
 exit 0
 EOF
   chmod +x "${bin_dir}/linearis"
+}
+
+# Install a fake `curl` that echoes a canned GraphQL response, so the real
+# resolve-linear-ids.sh (shelled out by linear-transition.sh on a cache miss)
+# can succeed inside the auto-resolve happy-path tests (CTL-577).
+install_fake_curl() {
+  local bin_dir="$1" response="$2"
+  mkdir -p "$bin_dir"
+  cat > "${bin_dir}/curl" <<SCRIPT
+#!/usr/bin/env bash
+echo '${response}'
+SCRIPT
+  chmod +x "${bin_dir}/curl"
+}
+
+# Write a Layer-2 secrets file under the faked HOME so resolve-linear-ids.sh
+# can locate an API token. <project_key> must match the config's projectKey.
+build_secrets() {
+  local project_key="$1"
+  mkdir -p "${HOME}/.config/catalyst"
+  cat > "${HOME}/.config/catalyst/config-${project_key}.json" <<'EOF'
+{ "linear": { "apiToken": "lin_api_fake_token" } }
+EOF
 }
 
 [ -x "$TRANSITION" ] || { echo "SKIP: $TRANSITION not present yet (expected during TDD)"; }
@@ -294,7 +325,7 @@ run "state names with spaces passed through correctly" \
 run "multi-word state name preserved" \
   expect_contains "$LOG13" "linearis issues update TST-13 --status In Review"
 
-# ─── Test 14: UUID pass-through when stateIds cached (CTL-207) ────────────
+# ─── Test 14: UUID pass-through when stateIds cached in the registry (CTL-577)
 WORK14="${SCRATCH}/t14"
 BIN14="${SCRATCH}/t14/bin"
 LOG14="${SCRATCH}/t14/log"
@@ -307,11 +338,18 @@ cat > "${WORK14}/.catalyst/config.json" <<'EOF'
       "stateMap": {
         "done": "Done",
         "inReview": "In Review"
-      },
-      "stateIds": {
-        "Done": "44444444-5555-6666-7777-888888888888",
-        "In Review": "33333333-4444-5555-6666-777777777777"
       }
+    }
+  }
+}
+EOF
+cat > "$REGISTRY" <<'EOF'
+{
+  "TST": {
+    "resolvedAt": "2026-05-22T00:00:00Z",
+    "stateIds": {
+      "Done": "44444444-5555-6666-7777-888888888888",
+      "In Review": "33333333-4444-5555-6666-777777777777"
     }
   }
 }
@@ -319,29 +357,30 @@ EOF
 install_fake_linearis "$BIN14"
 touch "$LOG14"
 
-run "UUID passed to --status when stateIds cached" \
+run "UUID passed to --status when stateIds cached in registry" \
   bash -c "FAKE_LINEARIS_LOG='$LOG14' PATH='$BIN14:$PATH' \
     '$TRANSITION' --ticket TST-14 --transition done --config '$WORK14/.catalyst/config.json'"
 
 run "update call uses UUID instead of state name" \
   expect_contains "$LOG14" "linearis issues update TST-14 --status 44444444-5555-6666-7777-888888888888"
 
-# ─── Test 15: falls back to name when stateIds not present ────────────────
+# ─── Test 15: falls back to name when no registry entry exists (CTL-577) ──
 WORK15="${SCRATCH}/t15"
 BIN15="${SCRATCH}/t15/bin"
 LOG15="${SCRATCH}/t15/log"
 build_config "$WORK15"
 install_fake_linearis "$BIN15"
 touch "$LOG15"
+rm -f "$REGISTRY"   # no registry → cache miss → auto-resolve fails (no secrets) → name fallback
 
-run "falls back to state name when no stateIds" \
+run "falls back to state name when registry absent" \
   bash -c "FAKE_LINEARIS_LOG='$LOG15' PATH='$BIN15:$PATH' \
     '$TRANSITION' --ticket TST-15 --transition done --config '$WORK15/.catalyst/config.json'"
 
-run "name-based update when stateIds absent" \
+run "name-based update when registry absent" \
   expect_contains "$LOG15" "linearis issues update TST-15 --status Done"
 
-# ─── Test 16: partial stateIds — uses UUID for cached, name for uncached ──
+# ─── Test 16: partial registry — name fallback for an uncached state (CTL-577)
 WORK16="${SCRATCH}/t16"
 BIN16="${SCRATCH}/t16/bin"
 LOG16="${SCRATCH}/t16/log"
@@ -349,15 +388,23 @@ mkdir -p "${WORK16}/.catalyst"
 cat > "${WORK16}/.catalyst/config.json" <<'EOF'
 {
   "catalyst": {
+    "projectKey": "test",
     "linear": {
       "teamKey": "TST",
       "stateMap": {
         "done": "Done",
         "inReview": "In Review"
-      },
-      "stateIds": {
-        "Done": "44444444-5555-6666-7777-888888888888"
       }
+    }
+  }
+}
+EOF
+cat > "$REGISTRY" <<'EOF'
+{
+  "TST": {
+    "resolvedAt": "2026-05-22T00:00:00Z",
+    "stateIds": {
+      "Done": "44444444-5555-6666-7777-888888888888"
     }
   }
 }
@@ -365,11 +412,11 @@ EOF
 install_fake_linearis "$BIN16"
 touch "$LOG16"
 
-run "partial stateIds: name for uncached state" \
+run "partial registry: name fallback for uncached state" \
   bash -c "FAKE_LINEARIS_STATE='Backlog' FAKE_LINEARIS_LOG='$LOG16' PATH='$BIN16:$PATH' \
     '$TRANSITION' --ticket TST-16 --transition inReview --config '$WORK16/.catalyst/config.json'"
 
-run "In Review passed as name (not in stateIds)" \
+run "In Review passed as name (not in registry)" \
   expect_contains "$LOG16" "linearis issues update TST-16 --status In Review"
 
 # ─── Test 17: orchestrate SKILL.md references the helper (no drift) ───────
@@ -490,6 +537,72 @@ run "verifying honors custom 'Verifying' state name from config" \
 
 run "custom Verifying state passed to linearis" \
   expect_contains "$LOG24" "linearis issues update TST-24 --status Verifying"
+
+# ─── Test 25: cache-miss auto-resolve happy path (CTL-577) ───────────────
+# On a registry cache miss, linear-transition.sh shells out to the real
+# resolve-linear-ids.sh. With a fake curl + secrets the resolver succeeds:
+# the registry is created and the transition uses the freshly-resolved UUID.
+WORK25="${SCRATCH}/t25"
+BIN25="${SCRATCH}/t25/bin"
+LOG25="${SCRATCH}/t25/log"
+DONE_UUID="aaaa1111-2222-3333-4444-555566667777"
+RESP25="{\"data\":{\"teams\":{\"nodes\":[{\"id\":\"team-tst-uuid\",\"states\":{\"nodes\":[{\"id\":\"${DONE_UUID}\",\"name\":\"Done\",\"type\":\"completed\"}]}}]}}}"
+mkdir -p "${WORK25}/.catalyst"
+cat > "${WORK25}/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "test",
+    "linear": {
+      "teamKey": "TST",
+      "stateMap": { "done": "Done" }
+    }
+  }
+}
+EOF
+install_fake_linearis "$BIN25"
+install_fake_curl "$BIN25" "$RESP25"
+build_secrets "test"
+touch "$LOG25"
+rm -f "$REGISTRY"
+
+run "cache-miss transition auto-resolves and exits 0" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG25' PATH='$BIN25:$PATH' \
+    '$TRANSITION' --ticket TST-25 --transition done --config '$WORK25/.catalyst/config.json'"
+
+run "auto-resolve created the registry entry" \
+  bash -c "[ -f '$REGISTRY' ] && jq -e '.[\"TST\"].stateIds[\"Done\"] == \"$DONE_UUID\"' '$REGISTRY'"
+
+run "transition used the auto-resolved UUID" \
+  expect_contains "$LOG25" "linearis issues update TST-25 --status $DONE_UUID"
+
+# ─── Test 26: --dry-run skips auto-resolve — no registry side effect ──────
+WORK26="${SCRATCH}/t26"
+BIN26="${SCRATCH}/t26/bin"
+LOG26="${SCRATCH}/t26/log"
+mkdir -p "${WORK26}/.catalyst"
+cat > "${WORK26}/.catalyst/config.json" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "test",
+    "linear": {
+      "teamKey": "TST",
+      "stateMap": { "done": "Done" }
+    }
+  }
+}
+EOF
+install_fake_linearis "$BIN26"
+install_fake_curl "$BIN26" "$RESP25"
+build_secrets "test"
+touch "$LOG26"
+rm -f "$REGISTRY"
+
+run "--dry-run transition exits 0 on a cache miss" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG26' PATH='$BIN26:$PATH' \
+    '$TRANSITION' --ticket TST-26 --transition done --dry-run --config '$WORK26/.catalyst/config.json'"
+
+run "--dry-run did NOT create the registry (auto-resolve skipped)" \
+  bash -c "[ ! -f '$REGISTRY' ]"
 
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/resolve-linear-ids.test.sh
+++ b/plugins/dev/scripts/__tests__/resolve-linear-ids.test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Shell tests for resolve-linear-ids (CTL-207).
+# Shell tests for resolve-linear-ids (CTL-207, CTL-577).
+#
+# CTL-577: stateIds is no longer written into .catalyst/config.json. It is
+# written to a machine-level registry at ~/.config/catalyst/linear-state-ids.json,
+# keyed by Linear teamKey. teamId is still written to config.json. Tests fake
+# HOME so the registry path resolves into a scratch dir.
 #
 # Run: bash plugins/dev/scripts/__tests__/resolve-linear-ids.test.sh
 
@@ -26,11 +31,6 @@ run() {
     echo "    output:"
     sed 's/^/      /' "${SCRATCH}/out"
   fi
-}
-
-expect_contains() {
-  local file="$1" needle="$2"
-  grep -qF "$needle" "$file"
 }
 
 # ─── Setup: fake curl that returns a canned GraphQL response ─────────────
@@ -85,10 +85,11 @@ build_config() {
 EOF
 }
 
+# build_secrets <home_dir> <project_key>
 build_secrets() {
-  local project_key="$1"
-  mkdir -p "${SCRATCH}/home/.config/catalyst"
-  cat > "${SCRATCH}/home/.config/catalyst/config-${project_key}.json" <<'EOF'
+  local home_dir="$1" project_key="$2"
+  mkdir -p "${home_dir}/.config/catalyst"
+  cat > "${home_dir}/.config/catalyst/config-${project_key}.json" <<'EOF'
 {
   "linear": {
     "apiToken": "lin_api_fake_token_12345"
@@ -97,27 +98,36 @@ build_secrets() {
 EOF
 }
 
+# registry path for a given faked HOME
+reg_path() { echo "$1/.config/catalyst/linear-state-ids.json"; }
+
 echo "resolve-linear-ids tests"
 
-# ─── Test 1: resolves and writes teamId + stateIds to config ──────────────
-WORK1="${SCRATCH}/t1"
-BIN1="${SCRATCH}/t1/bin"
+# ─── Test 1: resolves teamId to config, stateIds to the registry ──────────
+WORK1="${SCRATCH}/t1"; HOME1="${WORK1}/home"; BIN1="${WORK1}/bin"
 build_config "$WORK1"
-build_secrets "test-project"
+build_secrets "$HOME1" "test-project"
 install_fake_curl "$BIN1"
+REG1="$(reg_path "$HOME1")"
 
 run "resolves teamId and stateIds" \
-  bash -c "HOME='$SCRATCH/home' PATH='$BIN1:$PATH' \
+  bash -c "HOME='$HOME1' PATH='$BIN1:$PATH' \
     '$RESOLVE' --config '$WORK1/.catalyst/config.json'"
 
 run "teamId written to config" \
   bash -c "jq -e '.catalyst.linear.teamId == \"$FAKE_TEAM_ID\"' '$WORK1/.catalyst/config.json'"
 
-run "stateIds written to config" \
-  bash -c "jq -e '.catalyst.linear.stateIds[\"Backlog\"] == \"$FAKE_STATE_BACKLOG_ID\"' '$WORK1/.catalyst/config.json'"
+run "stateIds NOT written to config" \
+  bash -c "jq -e '.catalyst.linear | has(\"stateIds\") | not' '$WORK1/.catalyst/config.json'"
 
-run "stateIds contains all states" \
-  bash -c "jq -e '.catalyst.linear.stateIds | length == 4' '$WORK1/.catalyst/config.json'"
+run "stateIds written to registry under teamKey" \
+  bash -c "jq -e '.[\"TST\"].stateIds[\"Backlog\"] == \"$FAKE_STATE_BACKLOG_ID\"' '$REG1'"
+
+run "registry entry contains all states" \
+  bash -c "jq -e '.[\"TST\"].stateIds | length == 4' '$REG1'"
+
+run "registry entry records resolvedAt" \
+  bash -c "jq -e '.[\"TST\"].resolvedAt | type == \"string\" and (length > 0)' '$REG1'"
 
 run "existing config fields preserved" \
   bash -c "jq -e '.catalyst.linear.teamKey == \"TST\"' '$WORK1/.catalyst/config.json'"
@@ -125,30 +135,34 @@ run "existing config fields preserved" \
 run "stateMap preserved after write" \
   bash -c "jq -e '.catalyst.linear.stateMap.done == \"Done\"' '$WORK1/.catalyst/config.json'"
 
-# ─── Test 2: --dry-run does not modify config ────────────────────────────
-WORK2="${SCRATCH}/t2"
-BIN2="${SCRATCH}/t2/bin"
+# ─── Test 2: --dry-run does not modify config or registry ─────────────────
+WORK2="${SCRATCH}/t2"; HOME2="${WORK2}/home"; BIN2="${WORK2}/bin"
 build_config "$WORK2"
+build_secrets "$HOME2" "test-project"
 install_fake_curl "$BIN2"
+REG2="$(reg_path "$HOME2")"
 
 BEFORE=$(cat "$WORK2/.catalyst/config.json")
 
 run "--dry-run exits 0" \
-  bash -c "HOME='$SCRATCH/home' PATH='$BIN2:$PATH' \
+  bash -c "HOME='$HOME2' PATH='$BIN2:$PATH' \
     '$RESOLVE' --config '$WORK2/.catalyst/config.json' --dry-run"
 
 AFTER=$(cat "$WORK2/.catalyst/config.json")
 run "--dry-run does not modify config" \
   bash -c "[ '$BEFORE' = '$AFTER' ]"
 
+run "--dry-run does not create registry" \
+  bash -c "[ ! -f '$REG2' ]"
+
 # ─── Test 3: --json produces JSON output ──────────────────────────────────
-WORK3="${SCRATCH}/t3"
-BIN3="${SCRATCH}/t3/bin"
-OUT3="${SCRATCH}/t3/stdout"
+WORK3="${SCRATCH}/t3"; HOME3="${WORK3}/home"; BIN3="${WORK3}/bin"
+OUT3="${WORK3}/stdout"
 build_config "$WORK3"
+build_secrets "$HOME3" "test-project"
 install_fake_curl "$BIN3"
 
-HOME="$SCRATCH/home" PATH="$BIN3:$PATH" \
+HOME="$HOME3" PATH="$BIN3:$PATH" \
   "$RESOLVE" --config "$WORK3/.catalyst/config.json" --json > "$OUT3" 2>&1 || true
 
 run "--json output has action" \
@@ -160,45 +174,43 @@ run "--json output has teamId" \
 run "--json output has stateCount" \
   bash -c "jq -e '.stateCount == 4' '$OUT3'"
 
-# ─── Test 4: skips when stateIds already cached ──────────────────────────
-WORK4="${SCRATCH}/t4"
-BIN4="${SCRATCH}/t4/bin"
+# ─── Test 4: skips when stateIds already cached in the registry ───────────
+WORK4="${SCRATCH}/t4"; HOME4="${WORK4}/home"; BIN4="${WORK4}/bin"
 build_config "$WORK4"
+build_secrets "$HOME4" "test-project"
 install_fake_curl "$BIN4"
-
-jq '.catalyst.linear.stateIds = {"Backlog": "existing-uuid"}' \
-  "$WORK4/.catalyst/config.json" > "$WORK4/.catalyst/config.json.tmp" \
-  && mv "$WORK4/.catalyst/config.json.tmp" "$WORK4/.catalyst/config.json"
+REG4="$(reg_path "$HOME4")"
+mkdir -p "$(dirname "$REG4")"
+echo '{"TST":{"resolvedAt":"2026-01-01T00:00:00Z","stateIds":{"Backlog":"existing-uuid"}}}' > "$REG4"
 
 run "skips when stateIds already cached" \
-  bash -c "HOME='$SCRATCH/home' PATH='$BIN4:$PATH' \
+  bash -c "HOME='$HOME4' PATH='$BIN4:$PATH' \
     '$RESOLVE' --config '$WORK4/.catalyst/config.json' 2>&1 | grep -q 'already cached'"
 
 # ─── Test 5: --force re-resolves even when cached ────────────────────────
-WORK5="${SCRATCH}/t5"
-BIN5="${SCRATCH}/t5/bin"
+WORK5="${SCRATCH}/t5"; HOME5="${WORK5}/home"; BIN5="${WORK5}/bin"
 build_config "$WORK5"
+build_secrets "$HOME5" "test-project"
 install_fake_curl "$BIN5"
-
-jq '.catalyst.linear.stateIds = {"Backlog": "old-uuid"}' \
-  "$WORK5/.catalyst/config.json" > "$WORK5/.catalyst/config.json.tmp" \
-  && mv "$WORK5/.catalyst/config.json.tmp" "$WORK5/.catalyst/config.json"
+REG5="$(reg_path "$HOME5")"
+mkdir -p "$(dirname "$REG5")"
+echo '{"TST":{"resolvedAt":"2026-01-01T00:00:00Z","stateIds":{"Backlog":"old-uuid"}}}' > "$REG5"
 
 run "--force re-resolves even when cached" \
-  bash -c "HOME='$SCRATCH/home' PATH='$BIN5:$PATH' \
+  bash -c "HOME='$HOME5' PATH='$BIN5:$PATH' \
     '$RESOLVE' --config '$WORK5/.catalyst/config.json' --force"
 
-run "--force overwrites old stateIds" \
-  bash -c "jq -e '.catalyst.linear.stateIds[\"Backlog\"] == \"$FAKE_STATE_BACKLOG_ID\"' '$WORK5/.catalyst/config.json'"
+run "--force overwrites old stateIds in registry" \
+  bash -c "jq -e '.[\"TST\"].stateIds[\"Backlog\"] == \"$FAKE_STATE_BACKLOG_ID\"' '$REG5'"
 
 # ─── Test 6: fails gracefully when API token missing ─────────────────────
-WORK6="${SCRATCH}/t6"
+WORK6="${SCRATCH}/t6"; HOME6="${WORK6}/home"
 build_config "$WORK6"
-mkdir -p "${SCRATCH}/home6/.config/catalyst"
-echo '{}' > "${SCRATCH}/home6/.config/catalyst/config-test-project.json"
+mkdir -p "${HOME6}/.config/catalyst"
+echo '{}' > "${HOME6}/.config/catalyst/config-test-project.json"
 
 run "fails when API token missing" \
-  bash -c "! HOME='$SCRATCH/home6' '$RESOLVE' --config '$WORK6/.catalyst/config.json' 2>/dev/null"
+  bash -c "! HOME='$HOME6' '$RESOLVE' --config '$WORK6/.catalyst/config.json' 2>/dev/null"
 
 # ─── Test 7: fails gracefully when config missing ────────────────────────
 run "fails when config missing" \
@@ -213,14 +225,83 @@ run "fails when teamKey missing" \
   bash -c "! '$RESOLVE' --config '$WORK8/.catalyst/config.json' 2>/dev/null"
 
 # ─── Test 9: API error returns exit code 2 ────────────────────────────────
-WORK9="${SCRATCH}/t9"
-BIN9="${SCRATCH}/t9/bin"
+WORK9="${SCRATCH}/t9"; HOME9="${WORK9}/home"; BIN9="${WORK9}/bin"
 build_config "$WORK9"
+build_secrets "$HOME9" "test-project"
 install_fake_curl "$BIN9" 22 ""
 
 run "API failure returns exit 2" \
-  bash -c "HOME='$SCRATCH/home' PATH='$BIN9:$PATH' \
+  bash -c "HOME='$HOME9' PATH='$BIN9:$PATH' \
     '$RESOLVE' --config '$WORK9/.catalyst/config.json' 2>/dev/null; [ \$? -eq 2 ]"
+
+# ─── Test 10: registry write preserves sibling team entries ──────────────
+WORK10="${SCRATCH}/t10"; HOME10="${WORK10}/home"; BIN10="${WORK10}/bin"
+build_config "$WORK10"
+build_secrets "$HOME10" "test-project"
+install_fake_curl "$BIN10"
+REG10="$(reg_path "$HOME10")"
+mkdir -p "$(dirname "$REG10")"
+echo '{"ADV":{"resolvedAt":"2026-01-01T00:00:00Z","stateIds":{"Done":"adv-done-uuid"}}}' > "$REG10"
+
+run "resolves TST alongside an existing ADV entry" \
+  bash -c "HOME='$HOME10' PATH='$BIN10:$PATH' \
+    '$RESOLVE' --config '$WORK10/.catalyst/config.json' --force"
+
+run "sibling ADV entry preserved after TST resolve" \
+  bash -c "jq -e '.[\"ADV\"].stateIds[\"Done\"] == \"adv-done-uuid\"' '$REG10'"
+
+run "TST entry written alongside ADV" \
+  bash -c "jq -e '.[\"TST\"].stateIds[\"Done\"] == \"$FAKE_STATE_DONE_ID\"' '$REG10'"
+
+# ─── Test 11: creates the registry directory when absent ─────────────────
+WORK11="${SCRATCH}/t11"; HOME11="${WORK11}/home"; BIN11="${WORK11}/bin"
+build_config "$WORK11"
+build_secrets "$HOME11" "test-project"
+install_fake_curl "$BIN11"
+REG11="$(reg_path "$HOME11")"
+# Note: build_secrets created ~/.config/catalyst; remove it to prove mkdir -p.
+rm -rf "${HOME11}/.config/catalyst/linear-state-ids.json"
+
+run "creates registry when the file does not exist" \
+  bash -c "HOME='$HOME11' PATH='$BIN11:$PATH' \
+    '$RESOLVE' --config '$WORK11/.catalyst/config.json'"
+
+run "registry file exists after resolve" \
+  bash -c "[ -f '$REG11' ] && jq -e '.[\"TST\"].stateIds | length == 4' '$REG11'"
+
+# ─── Test 12: a corrupt registry file is recovered, not silently kept ────
+WORK12="${SCRATCH}/t12"; HOME12="${WORK12}/home"; BIN12="${WORK12}/bin"
+build_config "$WORK12"
+build_secrets "$HOME12" "test-project"
+install_fake_curl "$BIN12"
+REG12="$(reg_path "$HOME12")"
+mkdir -p "$(dirname "$REG12")"
+printf 'not json{{{' > "$REG12"
+
+run "resolves over a corrupt registry file" \
+  bash -c "HOME='$HOME12' PATH='$BIN12:$PATH' \
+    '$RESOLVE' --config '$WORK12/.catalyst/config.json' --force"
+
+run "corrupt registry replaced with valid resolved data" \
+  bash -c "jq -e '.[\"TST\"].stateIds[\"Done\"] == \"$FAKE_STATE_DONE_ID\"' '$REG12'"
+
+# ─── Test 13: --dry-run leaves an already-populated registry unchanged ────
+WORK13="${SCRATCH}/t13"; HOME13="${WORK13}/home"; BIN13="${WORK13}/bin"
+build_config "$WORK13"
+build_secrets "$HOME13" "test-project"
+install_fake_curl "$BIN13"
+REG13="$(reg_path "$HOME13")"
+mkdir -p "$(dirname "$REG13")"
+echo '{"ADV":{"resolvedAt":"2026-01-01T00:00:00Z","stateIds":{"Done":"adv-done"}}}' > "$REG13"
+REG13_BEFORE=$(cat "$REG13")
+
+run "--dry-run --force exits 0 with a populated registry" \
+  bash -c "HOME='$HOME13' PATH='$BIN13:$PATH' \
+    '$RESOLVE' --config '$WORK13/.catalyst/config.json' --dry-run --force"
+
+REG13_AFTER=$(cat "$REG13")
+run "--dry-run does not modify the existing registry" \
+  bash -c "[ '$REG13_BEFORE' = '$REG13_AFTER' ]"
 
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -148,20 +148,28 @@ if [[ -n $CONFIG_PATH ]]; then
 		warnings+=("  Run setup-catalyst.sh or add linear config manually — see docs/reference/configuration")
 	fi
 
-	# Check for cached Linear UUIDs (CTL-207) — reduces API calls during orchestrator runs
+	# Check for the cached Linear UUID registry (CTL-207, CTL-577). stateIds is a
+	# machine-level derived cache at ~/.config/catalyst/linear-state-ids.json,
+	# resolved on demand by resolve-linear-ids.sh (and auto-resolved by
+	# linear-transition.sh on a cache miss) — never committed to git.
 	if [[ -n $TEAM_KEY ]]; then
-		STATE_IDS=$(jq -r '.catalyst.linear.stateIds // empty' "$CONFIG_PATH" 2>/dev/null)
-		if [[ -z $STATE_IDS || $STATE_IDS == "null" ]]; then
-			warnings+=("Missing catalyst.linear.stateIds — run: plugins/dev/scripts/resolve-linear-ids.sh")
+		STATE_IDS_REGISTRY="${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/linear-state-ids.json"
+		registry_has_state_ids=""
+		if [[ -f $STATE_IDS_REGISTRY ]]; then
+			registry_has_state_ids=$(jq -r --arg t "$TEAM_KEY" \
+				'.[$t].stateIds // {} | if length > 0 then "yes" else empty end' \
+				"$STATE_IDS_REGISTRY" 2>/dev/null)
+		fi
+		if [[ -z $registry_has_state_ids ]]; then
+			warnings+=("Linear state-id cache not yet resolved for team '$TEAM_KEY' — generated on demand, or run: plugins/dev/scripts/resolve-linear-ids.sh")
 		fi
 	fi
 
-	# Execution-core Linear-state contract check (CTL-564). Only when the repo is
-	# dispatchMode: execution-core: verify the 6 contract states are present in
-	# both stateMap VALUES and stateIds KEYS, and that a central registry entry
-	# exists for the team. Local-only — reads stateIds (already resolved from
-	# Linear by resolve-linear-ids.sh) and the registry file; no API call. Gaps
-	# are warnings, consistent with every other linear-config issue here.
+	# Execution-core Linear-state contract check (CTL-564, CTL-577). Only when the
+	# repo is dispatchMode: execution-core: verify the 6 contract states are
+	# present in stateMap VALUES (the authored contract), and that a central
+	# registry entry exists for the team. Local-only — no API call. Gaps are
+	# warnings, consistent with every other linear-config issue here.
 	DISPATCH_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // empty' "$CONFIG_PATH" 2>/dev/null)
 	if [[ $DISPATCH_MODE == "execution-core" ]]; then
 		# The contract states this check expects. Mirrors contract_states() in
@@ -173,11 +181,8 @@ if [[ -n $CONFIG_PATH ]]; then
 			in_state_map=$(jq -r --arg s "$contract_state" \
 				'[.catalyst.linear.stateMap // {} | to_entries[].value] | index($s) // empty' \
 				"$CONFIG_PATH" 2>/dev/null)
-			in_state_ids=$(jq -r --arg s "$contract_state" \
-				'.catalyst.linear.stateIds // {} | has($s) | if . then "yes" else empty end' \
-				"$CONFIG_PATH" 2>/dev/null)
-			if [[ -z $in_state_map || -z $in_state_ids ]]; then
-				warnings+=("Execution-core contract state '$contract_state' missing from stateMap/stateIds in $CONFIG_PATH")
+			if [[ -z $in_state_map ]]; then
+				warnings+=("Execution-core contract state '$contract_state' missing from stateMap in $CONFIG_PATH")
 				execution_core_gaps=$((execution_core_gaps + 1))
 			fi
 		done

--- a/plugins/dev/scripts/linear-transition.sh
+++ b/plugins/dev/scripts/linear-transition.sh
@@ -116,11 +116,34 @@ if [ -z "$TARGET_STATE" ]; then
   exit 1
 fi
 
-# ─── Look up cached UUID for the target state (CTL-207) ───────────────────
-TARGET_STATE_ID=""
+# ─── Look up the cached UUID from the machine-level registry (CTL-577) ─────
+# stateIds is a derived cache keyed by teamKey at
+# ~/.config/catalyst/linear-state-ids.json — never committed, never stale in
+# git. On a cache miss we resolve once (resolve-linear-ids.sh fetches the whole
+# team set in one call), then re-read. If the resolve cannot run, STATUS_ARG
+# falls back to the state name, which linearis resolves correctly anyway.
+REGISTRY_PATH="${HOME}/.config/catalyst/linear-state-ids.json"
+TEAM_KEY=""
 if [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ] && command -v jq >/dev/null 2>&1; then
-  TARGET_STATE_ID=$(jq -r --arg s "$TARGET_STATE" \
-    '.catalyst.linear.stateIds[$s] // empty' "$CONFIG_PATH" 2>/dev/null)
+  TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CONFIG_PATH" 2>/dev/null)
+fi
+
+lookup_state_id() {
+  [ -n "$TEAM_KEY" ] && [ -f "$REGISTRY_PATH" ] && command -v jq >/dev/null 2>&1 || return 0
+  jq -r --arg t "$TEAM_KEY" --arg s "$TARGET_STATE" \
+    '.[$t].stateIds[$s] // empty' "$REGISTRY_PATH" 2>/dev/null
+}
+
+TARGET_STATE_ID="$(lookup_state_id)"
+
+# Cache miss → resolve once, then re-read. Skipped under --dry-run (no side
+# effects) and when there is no teamKey (the resolver requires one).
+if [ -z "$TARGET_STATE_ID" ] && [ -n "$TEAM_KEY" ] && [ "$DRY_RUN" -ne 1 ]; then
+  RESOLVER="${SCRIPT_DIR}/resolve-linear-ids.sh"
+  if [ -x "$RESOLVER" ] && [ -n "$CONFIG_PATH" ]; then
+    bash "$RESOLVER" --config "$CONFIG_PATH" --force >/dev/null 2>&1 || true
+    TARGET_STATE_ID="$(lookup_state_id)"
+  fi
 fi
 STATUS_ARG="${TARGET_STATE_ID:-$TARGET_STATE}"
 

--- a/plugins/dev/scripts/resolve-linear-ids.sh
+++ b/plugins/dev/scripts/resolve-linear-ids.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # resolve-linear-ids — Resolve and cache Linear team UUID and workflow state
-# UUIDs in `.catalyst/config.json`. Uses a single GraphQL query to fetch all
-# states for the configured team, then writes `teamId` and `stateIds` so that
-# downstream tools (linear-transition.sh) can pass UUIDs directly to linearis,
-# skipping per-call name resolution. CTL-207.
+# UUIDs. Uses a single GraphQL query to fetch all states for the configured
+# team, then writes `teamId` to `.catalyst/config.json` and caches `stateIds`
+# per team in the machine-level registry `~/.config/catalyst/linear-state-ids.json`
+# so downstream tools (linear-transition.sh) can pass UUIDs directly to
+# linearis, skipping per-call name resolution. CTL-207, CTL-577.
 #
 # Usage:
 #   resolve-linear-ids.sh [--config <path>] [--dry-run] [--json] [--force]
@@ -56,6 +57,10 @@ if [ -z "$CONFIG_PATH" ] || [ ! -f "$CONFIG_PATH" ]; then
   exit 1
 fi
 
+# CTL-577: stateIds is cached in a machine-level registry, keyed by teamKey,
+# so the UUID table is never committed to (and never goes stale through) git.
+REGISTRY_PATH="${HOME}/.config/catalyst/linear-state-ids.json"
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq required" >&2
   exit 1
@@ -73,9 +78,12 @@ if [ -z "$TEAM_KEY" ]; then
 fi
 
 if [ "$FORCE" -eq 0 ]; then
-  EXISTING_IDS=$(jq -r '.catalyst.linear.stateIds // empty' "$CONFIG_PATH" 2>/dev/null)
+  EXISTING_IDS=""
+  if [ -f "$REGISTRY_PATH" ]; then
+    EXISTING_IDS=$(jq -r --arg t "$TEAM_KEY" '.[$t].stateIds // empty' "$REGISTRY_PATH" 2>/dev/null)
+  fi
   if [ -n "$EXISTING_IDS" ] && [ "$EXISTING_IDS" != "null" ]; then
-    COUNT=$(jq '.catalyst.linear.stateIds | length' "$CONFIG_PATH" 2>/dev/null)
+    COUNT=$(jq --arg t "$TEAM_KEY" '.[$t].stateIds | length' "$REGISTRY_PATH" 2>/dev/null)
     if [ "$JSON_OUT" -eq 1 ]; then
       jq -nc --arg count "$COUNT" '{action:"skipped",reason:"stateIds already cached","stateCount":($count|tonumber)}'
     else
@@ -135,23 +143,43 @@ if [ "$DRY_RUN" -eq 1 ]; then
     jq -nc --arg tid "$TEAM_ID" --argjson sids "$STATE_IDS" --argjson count "$STATE_COUNT" \
       '{action:"dry-run",teamId:$tid,stateIds:$sids,stateCount:$count}'
   else
-    echo "Would write to $CONFIG_PATH:"
+    echo "Would write teamId to $CONFIG_PATH:"
     echo "  teamId: $TEAM_ID"
-    echo "  stateIds ($STATE_COUNT states):"
+    echo "Would write stateIds to $REGISTRY_PATH (team $TEAM_KEY, $STATE_COUNT states):"
     echo "$STATE_IDS" | jq -r 'to_entries[] | "    \(.key): \(.value)"'
   fi
   exit 0
 fi
 
-jq --arg tid "$TEAM_ID" --argjson sids "$STATE_IDS" \
-  '.catalyst.linear.teamId = $tid | .catalyst.linear.stateIds = $sids' \
+# teamId stays in committed config (stable; out of CTL-577 scope).
+jq --arg tid "$TEAM_ID" '.catalyst.linear.teamId = $tid' \
   "$CONFIG_PATH" > "${CONFIG_PATH}.tmp" && mv "${CONFIG_PATH}.tmp" "$CONFIG_PATH"
+
+# stateIds → machine-level per-team registry (CTL-577). Atomic tmp+mv; the
+# `.[$t] = …` merge replaces only this team's entry, preserving sibling teams.
+RESOLVED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+mkdir -p "$(dirname "$REGISTRY_PATH")"
+# Start from {} when the registry is missing or unparseable. It is a derived
+# cache — discarding a corrupt file is safe; it repopulates on this resolve.
+if [ ! -f "$REGISTRY_PATH" ] || ! jq -e . "$REGISTRY_PATH" >/dev/null 2>&1; then
+  echo '{}' > "$REGISTRY_PATH"
+fi
+if jq --arg t "$TEAM_KEY" --argjson sids "$STATE_IDS" --arg at "$RESOLVED_AT" \
+    '.[$t] = {resolvedAt: $at, stateIds: $sids}' \
+    "$REGISTRY_PATH" > "${REGISTRY_PATH}.tmp" && mv "${REGISTRY_PATH}.tmp" "$REGISTRY_PATH"; then
+  :
+else
+  rm -f "${REGISTRY_PATH}.tmp"
+  echo "ERROR: failed to write stateIds registry at $REGISTRY_PATH" >&2
+  exit 2
+fi
 
 if [ "$JSON_OUT" -eq 1 ]; then
   jq -nc --arg tid "$TEAM_ID" --argjson sids "$STATE_IDS" --argjson count "$STATE_COUNT" \
-    '{action:"resolved",teamId:$tid,stateIds:$sids,stateCount:$count}'
+    --arg reg "$REGISTRY_PATH" \
+    '{action:"resolved",teamId:$tid,stateIds:$sids,stateCount:$count,registry:$reg}'
 else
   echo "Resolved and cached $STATE_COUNT workflow states for team $TEAM_KEY"
-  echo "  teamId: $TEAM_ID"
-  echo "  config: $CONFIG_PATH"
+  echo "  teamId:   $TEAM_ID  ($CONFIG_PATH)"
+  echo "  stateIds: $REGISTRY_PATH"
 fi

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -285,18 +285,20 @@ main() {
     "$config" > "${config}.tmp" && mv "${config}.tmp" "$config"
   echo "Wrote execution-core stateMap to $config"
 
-  # --- refresh stateIds via resolve-linear-ids.sh --force ---
+  # --- refresh the machine-local stateIds cache via resolve-linear-ids.sh --force ---
+  # CTL-577: stateIds is cached in ~/.config/catalyst/linear-state-ids.json,
+  # keyed by teamKey — not committed to .catalyst/config.json.
   local script_dir resolve
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   resolve="${script_dir}/resolve-linear-ids.sh"
   if [[ -x $resolve ]]; then
     if bash "$resolve" --config "$config" --force >/dev/null 2>&1; then
-      echo "Refreshed stateIds via resolve-linear-ids.sh"
+      echo "Refreshed stateIds cache (~/.config/catalyst/linear-state-ids.json)"
     else
-      echo "WARNING: resolve-linear-ids.sh failed — stateIds may be stale" >&2
+      echo "WARNING: resolve-linear-ids.sh failed — stateIds cache may be stale" >&2
     fi
   else
-    echo "WARNING: resolve-linear-ids.sh not found — stateIds not refreshed" >&2
+    echo "WARNING: resolve-linear-ids.sh not found — stateIds cache not refreshed" >&2
   fi
 
   # --- upsert the central registry entry via registry.mjs ---

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -61,7 +61,6 @@ project structure, ticket conventions, and workflow state mapping.
 | `catalyst.linear.teamKey`       | string       | Linear team identifier used in ticket IDs (e.g., "ACME" for ACME-123). Must match `ticketPrefix`. |
 | `catalyst.linear.teamId`        | string\|null | Cached Linear team UUID. Resolved by `resolve-linear-ids.sh`.                                     |
 | `catalyst.linear.stateMap`      | object       | Maps workflow phases to your Linear workspace state names                                         |
-| `catalyst.linear.stateIds`      | object\|null | Map of Linear state display names to UUIDs. Eliminates per-call UUID resolution.                  |
 | `catalyst.thoughts.user`        | string\|null | HumanLayer thoughts user name                                                                     |
 
 ### State Map
@@ -98,20 +97,36 @@ correct names. Manual customization is only needed for non-standard state names.
 
 ### Cached UUIDs
 
-The `teamId` and `stateIds` fields cache Linear UUIDs so that `linear-transition.sh` can pass them
-directly to the linearis CLI, skipping per-call name-to-UUID resolution. This reduces Linear API
-requests by ~17% per state transition — significant during orchestrator runs with parallel workers.
+`linear-transition.sh` passes Linear UUIDs directly to the linearis CLI to skip per-call
+name-to-UUID resolution — roughly a 17% drop in Linear API requests per state transition,
+significant during orchestrator runs with parallel workers.
 
-Populate the cache by running:
+- **`teamId`** is cached in `.catalyst/config.json` — a Linear team UUID is stable.
+- **`stateIds`** is a **machine-local derived cache** at `~/.config/catalyst/linear-state-ids.json`
+  — a registry keyed by Linear `teamKey`. It is **never committed to git**, so the UUID table can
+  never travel stale (the failure mode behind CTL-575/576). Each entry records a `resolvedAt`
+  timestamp:
+
+  ```json
+  {
+    "CTL": {
+      "resolvedAt": "2026-05-22T15:00:00Z",
+      "stateIds": { "Backlog": "71a1…", "Plan": "b64f…", "Done": "5d77…" }
+    }
+  }
+  ```
+
+Populate or refresh the cache explicitly:
 
 ```bash
-plugins/dev/scripts/resolve-linear-ids.sh
+plugins/dev/scripts/resolve-linear-ids.sh          # resolve if not already cached
+plugins/dev/scripts/resolve-linear-ids.sh --force  # re-resolve after Linear state changes
 ```
 
-This makes a single Linear GraphQL query to fetch all workflow states for the configured team and
-writes the results to `.catalyst/config.json`. Re-run with `--force` after changing workflow states
-in Linear. The cache is optional — `linear-transition.sh` falls back to name-based calls when
-`stateIds` is absent.
+`resolve-linear-ids.sh` makes a single Linear GraphQL query for the team's whole state set. The
+cache is also **self-healing** — on a cache miss `linear-transition.sh` resolves it automatically,
+and if the resolver cannot run it falls back to name-based calls (always correct). `stateMap`
+remains the single committed source of truth.
 
 ### Execution-Core State Contract
 
@@ -140,7 +155,8 @@ is not a one-off migration.
 exists in every team workflow) — are ensured in Linear by
 `plugins/dev/scripts/setup-execution-core-states.sh`. That script is idempotent,
 runs once per team, and is invoked automatically by `setup-catalyst.sh` for
-`execution-core` repos. It writes the collapse `stateMap`, refreshes `stateIds`,
+`execution-core` repos. It writes the collapse `stateMap`, refreshes the
+machine-local `stateIds` cache,
 and upserts the team's registry entry. Run it directly with `--dry-run --json`
 to preview the contract without writing anything.
 


### PR DESCRIPTION
## Summary

`stateIds` (Linear state-name → UUID map) was committed inside `.catalyst/config.json`. Because it was committed, it travelled **stale** through git — when a team's Linear workflow states are renamed/recreated, the committed UUIDs point at dead states. This caused real breakage twice: CTL-575 and CTL-576.

This PR makes `stateIds` a **pure derived cache** — a machine-level registry at `~/.config/catalyst/linear-state-ids.json`, keyed by Linear `teamKey`, never committed and never stale in git. `stateMap` (the hand-authored phase-key → state-name contract) remains the single committed source of truth.

## Changes

- **`resolve-linear-ids.sh`** — writes `stateIds` + `resolvedAt` into the machine-level registry instead of `config.json`. Atomic `tmp+mv`; the per-team merge preserves sibling teams; recovers from a corrupt registry file. Still writes `teamId` to `config.json` (a Linear team UUID is stable).
- **`linear-transition.sh`** — resolves the target-state UUID from the registry. On a cache miss it auto-runs `resolve-linear-ids.sh` once (one GraphQL call fetches the whole team set), re-reads, and falls back to the state name — `linearis` resolves names correctly, so the path stays correct. Skipped under `--dry-run`.
- **`check-project-setup.sh`** — the cached-UUID check now reports registry cache status; the execution-core contract check validates the authored `stateMap` only.
- **`setup-execution-core-states.sh`** — comment updated; it still refreshes the cache via `resolve-linear-ids.sh --force`.
- **`.catalyst/config.json`** — committed `stateIds` removed (`teamId` retained).
- **`configuration.md`** — documents `stateIds` as a machine-local derived cache.

## Design decisions

- **Registry keyed by `teamKey`** — `stateIds` belong to a Linear team; two projects sharing a team share one fresh entry.
- **Cache miss → resolve + store** — standard cache behaviour; the name fallback is the safety net when the resolver cannot run.
- **No TTL** — the registry is machine-local, so git-staleness (the actual bug) is structurally impossible; `resolvedAt` is stored for diagnostics.

## Backward compatibility

A pre-existing committed `stateIds` in an installed project simply becomes inert — no reader looks at it, and `check-config-drift.sh`'s existing suppression keeps it quiet. No migration needed.

## Testing

TDD across 4 phases. 6 shell suites green — **195 tests, 0 failures**:

| Suite | Tests |
| --- | --- |
| resolve-linear-ids | 30 |
| linear-transition | 51 |
| check-project-setup | 21 |
| check-project-setup-execution-core | 5 |
| setup-execution-core-states | 37 |
| check-config-drift (regression) | 51 |

New coverage includes the cache-miss auto-resolve happy path (end-to-end: miss → resolve → registry write → UUID read), `--dry-run` skipping auto-resolve, sibling-team preservation, corrupt-registry recovery, and the registry-aware health check.

Refs: CTL-577