### PR TITLE
CTL-584: narrow execution-core monitor's drag-out kill to Backlog/Canceled/Duplicate

### DIFF
--- a/plugins/dev/scripts/execution-core/integration.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration.test.mjs
@@ -126,13 +126,16 @@ describe("execution-core integration — acceptance criteria", () => {
     expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-9"]);
   });
 
-  test("AC1b — a state_changed event OUT of the eligible state removes the ticket immediately", () => {
+  test("AC1b — a state_changed event OUT to a drag-out state removes the ticket immediately", () => {
     enroll("ENG", { status: "Todo" });
     const exec = mockExec({ ENG: [node("ENG-1"), node("ENG-2")] });
     startMonitor({ exec, reconcileIntervalMs: 60_000 });
     expect(getEligibleSet("ENG")).toHaveLength(2);
 
-    handleStateChangedEvent(evt("ENG-1", "ENG", "In Progress"));
+    // CTL-584: the leave-path fires only for DRAG_OUT_STATES (Backlog /
+    // Canceled / Duplicate). "In Progress" pre-CTL-584 was the broad-kill
+    // example; under the new model it is a pipeline state and a no-op.
+    handleStateChangedEvent(evt("ENG-1", "ENG", "Canceled"));
     expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-2"]);
   });
 

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -26,6 +26,18 @@ import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { dispatchTicket } from "./dispatch.mjs";
 import { abortWorker as defaultAbortWorker } from "./abort-worker.mjs";
 
+// DRAG_OUT_STATES — the Linear workflow states that signal "stop work on this
+// ticket". The monitor classifies these as a kill: remove the ticket from the
+// eligible projection and abort any in-flight worker. CTL-584: any other
+// non-Triage/non-Ready state — including the daemon's own CTL-558 write-backs
+// (Research/Plan/Implement/Validate/PR/Done) — is a NO-OP, not a kill. The
+// design (2026-05-21-linear-state-machine-trigger-model.md, "Human Override /
+// Kill") names Backlog/Canceled; Duplicate is included because Linear ships it
+// by default and users sometimes pick it instead of Canceled. Conservative
+// enumeration: a missed kill is recoverable (the next reconcile drops the
+// ticket from the eligible set anyway), a wrong kill destroys live work.
+const DRAG_OUT_STATES = new Set(["Backlog", "Canceled", "Duplicate"]);
+
 // --- Event parsing -------------------------------------------------------
 
 // parseStateChangedEvent — accept both the canonical OTel envelope
@@ -119,11 +131,18 @@ const dirtyTimers = new Map();
 // handleStateChangedEvent — fold one state_changed event into the eligible
 // sets of every project whose query team matches the event's team.
 //
-// CTL-565 two-state trigger: the toState branch is a three-way split.
-//   →triageStatus  one-shot-dispatches the triage phase agent (NOT the
-//                  eligible set — a Triage ticket is never scheduler-pulled).
-//   →status (Ready) reconciles into the scheduler-eligible set.
-//   anything else   the leave-path — a confident immediate removal.
+// CTL-565 + CTL-584 — the toState branch is a four-way split:
+//   →triageStatus              one-shot-dispatches the triage phase agent
+//                              (NOT the eligible set — a Triage ticket is
+//                              never scheduler-pulled).
+//   →status (Ready)            reconciles into the scheduler-eligible set
+//                              (debounced).
+//   →DRAG_OUT_STATES           the leave-path — confident immediate removal
+//                              + abortWorker on the in-flight worker.
+//   anything else (pipeline)   no-op. Research/Plan/Implement/Validate/PR/
+//                              Done are the daemon's own CTL-558 write-backs
+//                              echoed back; an unknown state is conservatively
+//                              treated as a hand-edit we don't recognize.
 export function handleStateChangedEvent(
   event,
   {
@@ -150,15 +169,28 @@ export function handleStateChangedEvent(
       // project/label/priority scoping, so a full poll is required. Debounce
       // it so a burst of events coalesces into one reconcile.
       scheduleDirtyReconcile(p.team, { exec, debounceMs });
-    } else {
-      // Left both watched states (→Backlog/→Canceled). Confident immediate
-      // removal, then abort any in-flight worker and tear down its worktree.
-      // removeTicket persists the projection itself; removing a non-member is
-      // a safe no-op. abortWorker no-ops when the ticket was never dispatched.
+    } else if (DRAG_OUT_STATES.has(parsed.toState)) {
+      // Drag-out to Backlog/Canceled/Duplicate — kill signal. Confident
+      // immediate removal, then abort any in-flight worker and tear down its
+      // worktree. removeTicket persists the projection itself; removing a
+      // non-member is a safe no-op. abortWorker no-ops when the ticket was
+      // never dispatched.
       removeTicket(p.team, parsed.identifier);
       if (orchDir) {
         abortWorker(orchDir, parsed.identifier, { repoRoot: p.repoRoot });
       }
+    } else {
+      // Pipeline state (the daemon's own CTL-558 write-back —
+      // Research/Plan/Implement/Validate/PR/Done) or an unknown state. No-op:
+      // the daemon must never kill its own worker on hearing its own write-
+      // back echoed through the broker, and an unknown state is conservatively
+      // treated as a hand-edit we don't recognize (let the next reconcile sort
+      // it out — a missed kill is safe, a wrong kill destroys live work).
+      // CTL-584.
+      log.debug(
+        { ticket: parsed.identifier, toState: parsed.toState },
+        "monitor: non-trigger toState — no-op",
+      );
     }
   }
 }

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -178,18 +178,12 @@ describe("reconcileProject", () => {
 });
 
 describe("handleStateChangedEvent", () => {
-  test("an event whose toState != eligible status fast-path-removes the ticket", () => {
-    enroll("ENG", { status: "Todo" });
-    setProjectEligible("ENG", [node("ENG-1"), node("ENG-2")], {
-      source: "reconcile",
-      query: { team: "ENG", status: "Todo" },
-    });
-    handleStateChangedEvent({
-      event: "linear.issue.state_changed",
-      detail: { ticket: "ENG-1", teamKey: "ENG", toState: "In Progress" },
-    });
-    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-2"]);
-  });
+  // CTL-584: the pre-CTL-565 "toState != eligible status → fast-path-remove"
+  // case is now covered by the parameterized DRAG_OUT_STATES test in the
+  // CTL-565 two-state-trigger block below (Backlog/Canceled/Duplicate). The
+  // old single-case version is dropped as redundant — its example toState
+  // ("In Progress") was a pipeline state under the new model, not a leave-path
+  // trigger.
 
   test("an event whose toState == eligible status schedules a debounced reconcile (no immediate poll)", async () => {
     enroll("ENG", { status: "Todo" });
@@ -277,18 +271,25 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
     expect(exec.calls).toBe(1); // the debounced reconcile ran
   });
 
-  test("toState that is neither Triage nor Ready fast-path-removes the ticket", () => {
-    enroll("ENG", { status: "Ready" });
-    setProjectEligible("ENG", [node("ENG-1"), node("ENG-2")], {
-      source: "reconcile",
-      query: { team: "ENG", status: "Ready" },
-    });
-    handleStateChangedEvent({
-      event: "linear.issue.state_changed",
-      detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Backlog" },
-    });
-    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-2"]);
-  });
+  // CTL-584: drag-out kill fires only for the enumerated DRAG_OUT_STATES.
+  // Backlog/Canceled/Duplicate each fast-path-remove the ticket from the
+  // eligible projection. Daemon-written pipeline states (covered below) do
+  // NOT.
+  test.each(["Backlog", "Canceled", "Duplicate"])(
+    "toState %s fast-path-removes the ticket from the eligible projection",
+    (toState) => {
+      enroll("ENG", { status: "Ready" });
+      setProjectEligible("ENG", [node("ENG-1"), node("ENG-2")], {
+        source: "reconcile",
+        query: { team: "ENG", status: "Ready" },
+      });
+      handleStateChangedEvent({
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState },
+      });
+      expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-2"]);
+    },
+  );
 
   test("a triage dispatch failure is logged and never throws", () => {
     enroll("ENG", { status: "Ready" });
@@ -319,37 +320,27 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  test("a drag-out (toState neither Triage nor Ready) invokes abortWorker", () => {
-    enroll("ENG", { status: "Ready" });
-    const abortWorker = mock(() => ({ aborted: true }));
-    handleStateChangedEvent(
-      {
-        event: "linear.issue.state_changed",
-        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Backlog" },
-      },
-      { orchDir, abortWorker },
-    );
-    expect(abortWorker).toHaveBeenCalledWith("/orch", "ENG-1", {
-      repoRoot: expect.any(String),
-    });
-  });
-
-  test("a drag-out still removes the ticket from the eligible projection", () => {
-    enroll("ENG", { status: "Ready" });
-    setProjectEligible("ENG", [node("ENG-1"), node("ENG-2")], {
-      source: "reconcile",
-      query: { team: "ENG", status: "Ready" },
-    });
-    const abortWorker = mock(() => ({ aborted: true }));
-    handleStateChangedEvent(
-      {
-        event: "linear.issue.state_changed",
-        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Canceled" },
-      },
-      { orchDir, abortWorker },
-    );
-    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-2"]);
-  });
+  // CTL-584: every DRAG_OUT_STATES toState invokes abortWorker. The drop of
+  // the parallel "a drag-out still removes" test is intentional — the
+  // parameterized fast-path-remove test above already covers Canceled, the
+  // dropped test's distinguishing case.
+  test.each(["Backlog", "Canceled", "Duplicate"])(
+    "toState %s invokes abortWorker for the in-flight worker",
+    (toState) => {
+      enroll("ENG", { status: "Ready" });
+      const abortWorker = mock(() => ({ aborted: true }));
+      handleStateChangedEvent(
+        {
+          event: "linear.issue.state_changed",
+          detail: { ticket: "ENG-1", teamKey: "ENG", toState },
+        },
+        { orchDir, abortWorker },
+      );
+      expect(abortWorker).toHaveBeenCalledWith("/orch", "ENG-1", {
+        repoRoot: expect.any(String),
+      });
+    },
+  );
 
   test("a drag-out with no orchDir wired removes the ticket and does not throw", () => {
     enroll("ENG", { status: "Ready" });
@@ -364,6 +355,55 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
       ),
     ).not.toThrow();
     expect(abortWorker).not.toHaveBeenCalled(); // no orchDir → abort skipped
+  });
+
+  // CTL-584: the daemon's own CTL-558 status write-backs (Research / Plan /
+  // Implement / Validate / PR / Done) must be no-ops in the monitor — the
+  // pipeline must never kill its own worker on hearing its own write echo.
+  // The eligible projection is unchanged; abortWorker + dispatch are never
+  // called. This is the negative coverage the original test suite missed.
+  test.each(["Research", "Plan", "Implement", "Validate", "PR", "Done"])(
+    "toState %s (daemon-written pipeline state) is a no-op — no removal, no abortWorker",
+    (toState) => {
+      enroll("ENG", { status: "Ready" });
+      setProjectEligible("ENG", [node("ENG-1"), node("ENG-2")], {
+        source: "reconcile",
+        query: { team: "ENG", status: "Ready" },
+      });
+      const abortWorker = mock(() => ({ aborted: true }));
+      const dispatch = mock(() => ({ code: 0 }));
+      handleStateChangedEvent(
+        {
+          event: "linear.issue.state_changed",
+          detail: { ticket: "ENG-1", teamKey: "ENG", toState },
+        },
+        { orchDir, abortWorker, dispatch },
+      );
+      expect(abortWorker).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-1", "ENG-2"]);
+    },
+  );
+
+  // CTL-584: an unknown toState is conservatively treated as a no-op — a
+  // missed kill is recoverable (next reconcile drops it from the eligible
+  // set); a wrong kill destroys live work.
+  test("an unknown toState is a no-op — no removal, no abortWorker (conservative default)", () => {
+    enroll("ENG", { status: "Ready" });
+    setProjectEligible("ENG", [node("ENG-1")], {
+      source: "reconcile",
+      query: { team: "ENG", status: "Ready" },
+    });
+    const abortWorker = mock(() => ({ aborted: true }));
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Mystery" },
+      },
+      { orchDir, abortWorker },
+    );
+    expect(abortWorker).not.toHaveBeenCalled();
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-1"]);
   });
 });
 
@@ -477,16 +517,19 @@ describe("startMonitor — resumeFromCursor", () => {
   });
 
   test("resumeFromCursor:true drains the gap between cursor and EOF", () => {
-    // ENG holds ENG-1 + ENG-2; an event in the downtime gap moved ENG-1 OUT
-    // of Todo. resumeFromCursor:true must drain that gap on startup and remove
-    // ENG-1 — proving the durable cursor, not a re-seed, drove the resume.
+    // ENG holds ENG-1 + ENG-2; an event in the downtime gap dragged ENG-1
+    // OUT (Backlog — DRAG_OUT_STATES). resumeFromCursor:true must drain that
+    // gap on startup and remove ENG-1 — proving the durable cursor, not a
+    // re-seed, drove the resume. CTL-584: toState must be a drag-out for the
+    // leave-path to fire (was "In Progress" pre-CTL-584 when the leave-path
+    // fired on anything non-Triage/non-Ready).
     enroll("ENG", { status: "Todo" });
     const exec = execReturning({ ENG: [node("ENG-1"), node("ENG-2")] });
     // Pre-write a downtime-gap event and pin the cursor at offset 0.
     appendEventLog(
       `${JSON.stringify({
         event: "linear.issue.state_changed",
-        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "In Progress" },
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Backlog" },
       })}\n`,
     );
     saveCursor({ logPath: eventLogPath(), byteOffset: 0 });
@@ -501,7 +544,10 @@ describe("startMonitor — resumeFromCursor", () => {
     appendEventLog(
       `${JSON.stringify({
         event: "linear.issue.state_changed",
-        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Done" },
+        // CTL-584: a drag-out state — "Done" was a pipeline state under the
+        // new model (not a leave-trigger), so we use Canceled here to drive
+        // the gap-drain removal.
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Canceled" },
       })}\n`,
     );
     saveCursor({ logPath: eventLogPath(), byteOffset: 0 });


### PR DESCRIPTION
## Summary

The execution-core monitor's `handleStateChangedEvent` had a residual `else` branch that aborted the in-flight worker on ANY `toState` that wasn't `Triage` or `Ready` — silently including the daemon's own CTL-558 status write-backs to `Research`/`Plan`/`Implement`/`Validate`/`PR`/`Done`. The daemon would dispatch a worker, write the phase's Linear state, hear its own write echoed through Linear's webhook → broker → event log → monitor tailer, classify it as a drag-out, and kill the worker ~3 seconds after dispatch. **The execution-core pipeline could not advance past phase 1.**

Bug surfaced live during the 2026-05-22 thin-slice QA on CTL-380 (see ticket body for the dispatch → abort timeline).

## Fix

Add a `DRAG_OUT_STATES = {Backlog, Canceled, Duplicate}` constant in `monitor.mjs` and gate the kill branch on `.has(toState)`. Everything else (pipeline state, unknown name) is a no-op with a single `log.debug` line. The orch-monitor's parallel `botUserId` echo-skip (`linear-webhook-handler.ts:314`) is the right long-term suppression layer but depends on CTL-550 (Linear for Agents — agent-actor identity) and is not operational today; this monitor-level fix is the necessary defense in depth.

**Conservative:** a missed kill is recoverable (the next reconcile drops the ticket from the eligible set anyway); a wrong kill destroys live work.

## Test changes

- `monitor.test.mjs:280-291 + :322-335` rewritten as parameterized tests over the three drag-outs.
- New `test.each` blocks add **negative coverage** the original suite was missing: every pipeline state (`Research`/`Plan`/`Implement`/`Validate`/`PR`/`Done`) and an unknown state are no-ops (no `removeTicket`, no `abortWorker`).
- The pre-CTL-565 \"toState != eligible status fast-path-removes\" test dropped as redundant.
- Cursor-resume tests + `integration.test.mjs` AC1b changed their example `toState` from `\"In Progress\"`/`\"Done\"` to drag-outs — they relied on the broad-kill behavior to demonstrate the gap-drain and leave-path mechanisms.

## Verification

\`\`\`
cd plugins/dev/scripts/execution-core && bun test
# 311 pass, 0 fail
\`\`\`

## References

- Research: \`thoughts/shared/research/2026-05-22-CTL-584-monitor-self-fire.md\`
- Plan: \`thoughts/shared/plans/2026-05-22-CTL-584-monitor-narrow-drag-out-kill.md\`
- Design (binding): \`thoughts/shared/plans/2026-05-21-linear-state-machine-trigger-model.md\`
- Live evidence from the QA: \`~/catalyst/execution-core/workers/CTL-380/phase-research.json\` (status: aborted), \`~/catalyst/execution-core/daemon.log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)