### PR TITLE
fix(execution-core): reclaim dead phase-implement workers via commit-state probe (CTL-574)

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -5,13 +5,31 @@
 // (via the canonical signal reader), and classifies every in-flight claude --bg
 // worker's liveness so a restart resumes mid-run with no lost workers.
 
-import { statSync, readFileSync, openSync, fstatSync, closeSync } from "node:fs";
+import {
+  statSync,
+  readFileSync,
+  openSync,
+  fstatSync,
+  closeSync,
+  appendFileSync,
+  mkdirSync,
+} from "node:fs";
+import { dirname } from "node:path";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { randomBytes } from "node:crypto";
 import { getJobsRoot, getEventLogPath, log } from "./config.mjs";
 import { readWorkerSignals, TERMINAL } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
+import { WORK_DONE_PROBES, hasProbe } from "./work-done-probes.mjs";
+
+// phase-agent-emit-complete sits two directories up from execution-core/.
+const EMIT_COMPLETE_BIN = fileURLToPath(
+  new URL("../phase-agent-emit-complete", import.meta.url),
+);
 
 // defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
 // the job dir is gone (the worker's process no longer exists), else its mtime
@@ -67,6 +85,152 @@ export function reconstructWorkerState(orchDir, { statJob = defaultStatJob } = {
     );
   }
   return buckets;
+}
+
+// ─── CTL-574: reclaim-dead-work sweep ───────────────────────────────────────
+//
+// A phase-implement worker can finish its real work (commits land, tree clean)
+// then die without emitting `phase.implement.complete` — a known class of bugs
+// in the worker's End block (see memory project_phase_implement_state_json_stale).
+// Pre-CTL-574 the resulting `phase-implement.json: status=running` + dead bg job
+// stalled the pipeline indefinitely: `classifyWorker` returned 'dead' but
+// nothing acted on it.
+//
+// `reclaimDeadWorkIfPossible` is called per signal by `schedulerTick`'s new
+// step (0). For the `dead` class only, it asks the per-phase work-done probe
+// whether the work IS committed. If so, it (a) emits a canonical
+// `phase.<phase>.reclaim.<ticket>` audit event, then (b) invokes the existing
+// `phase-agent-emit-complete` script with explicit `--orch-dir` + `--session-
+// id` flags so the script's signal-flip + canonical-complete + session-end
+// steps all run — exactly the same closer a healthy worker would have run.
+// Downstream consumers (scheduler advancement, HUD, Linear write-back) see a
+// normal `phase.<phase>.complete` and advance.
+//
+// PURE given the injected statJob / probes / emitComplete / appendEvent — no
+// fs / spawn of its own.
+
+function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
+  const args = [
+    "--phase", signal.phase,
+    "--ticket", signal.ticket,
+    "--status", "complete",
+    "--orch-dir", orchDir,
+    "--orch-id", signal.raw?.orchestrator ?? signal.ticket,
+  ];
+  const sessionId = signal.raw?.catalystSessionId;
+  if (sessionId) {
+    args.push("--session-id", sessionId);
+  }
+  const res = spawn(EMIT_COMPLETE_BIN, args, { encoding: "utf8" });
+  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
+  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// defaultAppendReclaimEvent — append a canonical phase.<phase>.reclaim.<ticket>
+// envelope to the event log. Shape mirrors lib/canonical-event.sh; only one
+// caller needs it, so we inline rather than wrap the bash builder. Best-effort:
+// a write failure is logged but does not abort the reclaim (the next
+// phase.<phase>.complete event still tells the story).
+function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const eventName = `phase.${phase}.reclaim.${ticket}`;
+  const line =
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: "WARN",
+      severityNumber: 13,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: {
+        "service.name": "catalyst.execution-core",
+        "service.namespace": "catalyst",
+      },
+      attributes: {
+        "event.name": eventName,
+        "event.entity": "phase",
+        "event.action": "reclaim",
+        "event.label": ticket,
+        "catalyst.orchestration": orchId ?? ticket,
+        "linear.issue.identifier": ticket,
+      },
+      body: {
+        payload: {
+          phase,
+          ticket,
+          status: "reclaim",
+          reason: "work-done-despite-dead-bg",
+        },
+      },
+    }) + "\n";
+  const logPath = getEventLogPath();
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+  } catch (err) {
+    log.warn({ err: err.message }, "reclaim-dead-work: failed to append reclaim event");
+  }
+}
+
+// reclaimDeadWorkIfPossible — one signal in, one decision out. The five-way
+// return discriminates the cases an operator might need to investigate:
+//
+//   'noop'             not 'dead' (terminal / running / unknown). No action.
+//   'not-applicable'   'dead' but the phase has no registered work-done probe.
+//                      Out of scope for CTL-574; CTL-587's territory.
+//   'not-done'         'dead' + probe says the work is NOT committed. The
+//                      worker really did die mid-implement. CTL-587 will
+//                      re-dispatch when that lands.
+//   'reclaimed'        'dead' + work IS done. Reclaim succeeded — the canonical
+//                      audit + complete events were appended, the signal was
+//                      flipped, the session was ended.
+//   'reclaim-failed'   'dead' + work IS done BUT emit-complete exited non-zero.
+//                      The signal is NOT mutated (the emit-complete script
+//                      writes via atomic rename); the next tick retries.
+export function reclaimDeadWorkIfPossible(
+  orchDir,
+  signal,
+  {
+    repoRoot,
+    statJob = defaultStatJob,
+    probes = WORK_DONE_PROBES,
+    emitComplete = defaultEmitComplete,
+    appendEvent = defaultAppendReclaimEvent,
+  } = {},
+) {
+  const klass = classifyWorker(signal, { statJob });
+  if (klass !== "dead") return "noop";
+  if (!hasProbe(signal.phase)) return "not-applicable";
+
+  const probe = probes[signal.phase];
+  if (!probe({ ticket: signal.ticket, repoRoot })) {
+    log.info(
+      { ticket: signal.ticket, phase: signal.phase },
+      "reclaim-dead-work: dead worker, work NOT done — left for CTL-587",
+    );
+    return "not-done";
+  }
+
+  appendEvent({
+    phase: signal.phase,
+    ticket: signal.ticket,
+    orchId: signal.raw?.orchestrator,
+  });
+
+  const r = emitComplete({ orchDir, signal });
+  if (r.code !== 0) {
+    log.warn(
+      { ticket: signal.ticket, phase: signal.phase, code: r.code, stderr: r.stderr },
+      "reclaim-dead-work: emit-complete failed; will retry next tick",
+    );
+    return "reclaim-failed";
+  }
+  log.info(
+    { ticket: signal.ticket, phase: signal.phase },
+    "reclaim-dead-work: dead worker reclaimed (work was committed)",
+  );
+  return "reclaimed";
 }
 
 // recoverStartup — the boot-time reconstruction CTL-554's daemon calls. Rebuilds

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -13,6 +13,7 @@ import {
   reconstructWorkerState,
   defaultStatJob,
   recoverStartup,
+  reclaimDeadWorkIfPossible,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -407,5 +408,173 @@ describe("recoverStartup", () => {
     const report = recoverStartup({ orchDir, exec, statJob: () => null });
     expect(report.cursor.byteOffset).toBe(0);
     expect(report.cursor.resumed).toBe(false);
+  });
+});
+
+// --- CTL-574: reclaim-dead-work --------------------------------------------
+
+// implementSignal — a bg-shaped phase-implement signal with the orchestrator +
+// session-id fields the reclaim path threads into emit-complete.
+function implementSignal({ ticket = "CTL-9", status = "running", bgJobId = "job-x" } = {}) {
+  return {
+    ticket,
+    phase: "implement",
+    status,
+    liveness: { kind: "bg", value: bgJobId },
+    signalPath: `/x/${ticket}/phase-implement.json`,
+    raw: {
+      ticket,
+      phase: "implement",
+      orchestrator: ticket,
+      status,
+      bg_job_id: bgJobId,
+      catalystSessionId: `sess_${ticket}_abc`,
+    },
+  };
+}
+
+// spies — record calls without bun:test's mock() so the assertions read plain.
+function recorder(returnValue) {
+  const calls = [];
+  const fn = (...args) => {
+    calls.push(args);
+    return typeof returnValue === "function" ? returnValue(...args) : returnValue;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe("reclaimDeadWorkIfPossible", () => {
+  const orch = "/orch";
+
+  test("'noop' for a terminal signal (no emit, no probe)", () => {
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const appendEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "done" }), {
+      statJob: () => null,
+      probes: { implement: probe },
+      emitComplete: emit,
+      appendEvent,
+    });
+    expect(r).toBe("noop");
+    expect(probe.calls.length).toBe(0);
+    expect(emit.calls.length).toBe(0);
+    expect(appendEvent.calls.length).toBe(0);
+  });
+
+  test("'noop' for a running signal whose bg job is alive (no emit)", () => {
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => ({ exists: true, mtimeMs: 1 }), // bg alive
+      probes: { implement: probe },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+    });
+    expect(r).toBe("noop");
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("'noop' for an unknown signal (no bg_job_id)", () => {
+    const sig = implementSignal();
+    sig.liveness = { kind: "bg", value: null };
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => null,
+      probes: { implement: recorder(true) },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+    });
+    expect(r).toBe("noop");
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("'not-applicable' when the phase has no registered probe", () => {
+    const sig = { ...implementSignal(), phase: "research" };
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => null, // bg dead
+      probes: { implement: recorder(true) }, // research not registered
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+    });
+    expect(r).toBe("not-applicable");
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("'not-done' when the dead worker's probe returns false (no emit)", () => {
+    const emit = recorder({ code: 0 });
+    const appendEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => null, // bg dead
+      probes: { implement: recorder(false) }, // probe: work NOT done
+      emitComplete: emit,
+      appendEvent,
+    });
+    expect(r).toBe("not-done");
+    expect(emit.calls.length).toBe(0);
+    expect(appendEvent.calls.length).toBe(0);
+  });
+
+  test("'reclaimed' fires append-event THEN emit-complete (in that order, with full flag set)", () => {
+    const order = [];
+    const appendEvent = (...args) => {
+      order.push(["append", ...args]);
+    };
+    const emit = (...args) => {
+      order.push(["emit", ...args]);
+      return { code: 0 };
+    };
+    const sig = implementSignal();
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => null, // bg dead
+      probes: { implement: () => true }, // work done
+      emitComplete: emit,
+      appendEvent,
+      repoRoot: "/repo",
+    });
+    expect(r).toBe("reclaimed");
+    // order: append first, then emit.
+    expect(order[0][0]).toBe("append");
+    expect(order[1][0]).toBe("emit");
+    // append-event payload mentions the phase + ticket + orch id.
+    expect(order[0][1]).toEqual({
+      phase: "implement",
+      ticket: "CTL-9",
+      orchId: "CTL-9",
+    });
+    // emit-complete receives the orchDir and the signal.
+    expect(order[1][1]).toEqual({ orchDir: orch, signal: sig });
+  });
+
+  test("'reclaim-failed' when emit-complete returns non-zero (event still appended)", () => {
+    const appendEvent = recorder(undefined);
+    const emit = recorder({ code: 1, stderr: "boom" });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => null,
+      probes: { implement: () => true },
+      emitComplete: emit,
+      appendEvent,
+    });
+    expect(r).toBe("reclaim-failed");
+    expect(appendEvent.calls.length).toBe(1);
+    expect(emit.calls.length).toBe(1);
+  });
+
+  test("repoRoot is forwarded to the probe (so the probe can resolve the worktree)", () => {
+    let seen = null;
+    const probe = (args) => {
+      seen = args;
+      return true;
+    };
+    reclaimDeadWorkIfPossible(orch, implementSignal({ ticket: "CTL-42" }), {
+      statJob: () => null,
+      probes: { implement: probe },
+      emitComplete: () => ({ code: 0 }),
+      appendEvent: () => {},
+      repoRoot: "/repo/x",
+    });
+    expect(seen).toEqual({ ticket: "CTL-42", repoRoot: "/repo/x" });
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -25,6 +25,11 @@ import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
 import { fetchTicketState } from "./linear-query.mjs";
 import { getProjectConfig } from "./registry.mjs";
 import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
+import { readWorkerSignals } from "./signal-reader.mjs";
+// CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
+// is the real recovery-module function; tests inject a fake. See
+// reclaimDeadWorkIfPossible in recovery.mjs for the decision tree.
+import { reclaimDeadWorkIfPossible as defaultReclaimDeadWork } from "./recovery.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -345,8 +350,25 @@ export function schedulerTick(
     exec,
     writeStatus = linearWrite,
     teardownWorktree = defaultTeardownWorktree,
+    reclaimDeadWork = defaultReclaimDeadWork,
   } = {},
 ) {
+  // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
+  // died but whose work was committed before the death. Runs BEFORE the
+  // advancement sweep so a reclaimed phase advances the same tick. Iterates
+  // every active worker signal (readWorkerSignals returns one per ticket — the
+  // active, non-terminal-first phase) and asks reclaimDeadWork to decide.
+  // Reclaim is a strict superset of "do nothing": only the dead+work-done case
+  // mutates the signal; all other classes (terminal/running/unknown/not-done/
+  // not-applicable) are zero-action no-ops.
+  const reclaimed = [];
+  for (const sig of readWorkerSignals(orchDir)) {
+    const team = teamOf(sig.ticket);
+    const repoRoot = team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
+    const r = reclaimDeadWork(orchDir, sig, { repoRoot });
+    if (r === "reclaimed") reclaimed.push({ ticket: sig.ticket, phase: sig.phase });
+  }
+
   // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
   const advanced = [];
   for (const ticket of listInFlightTickets(orchDir)) {
@@ -418,7 +440,7 @@ export function schedulerTick(
     }
   }
 
-  return { advanced, dispatched, freeSlots, ready: ready.map((t) => t.identifier) };
+  return { reclaimed, advanced, dispatched, freeSlots, ready: ready.map((t) => t.identifier) };
 }
 
 // ─── Phase 5: the pull-loop daemon ───

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -963,3 +963,132 @@ describe("schedulerTick — worktree teardown on Done (CTL-582)", () => {
     expect(existsSync(markerPath("CTL-4"))).toBe(false); // retryable — no marker
   });
 });
+
+// --- CTL-574: reclaim-dead-work step in schedulerTick -----------------------
+
+describe("schedulerTick — CTL-574 reclaim-dead-work sweep", () => {
+  // writeNestedSignal — write a worker signal with the full shape signal-reader
+  // produces (status + bg_job_id), so classifyWorker can be driven by the real
+  // pipeline. The reclaim path uses this signal's phase + ticket.
+  function writeNestedSignal(ticket, phase, body) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, ...body }),
+    );
+  }
+
+  test("schedulerTick calls the injected reclaimDeadWork once per worker signal", () => {
+    // Two in-flight tickets with a single phase signal each — readWorkerSignals
+    // returns one (active) per ticket, so reclaimDeadWork is called twice.
+    writeNestedSignal("CTL-1", "implement", { status: "running", bg_job_id: "j1" });
+    writeNestedSignal("CTL-2", "implement", { status: "running", bg_job_id: "j2" });
+
+    const reclaimDeadWork = recorder("noop");
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: { applyPhaseStatus: () => {}, applyTerminalDone: () => {} },
+      teardownWorktree: () => true,
+      reclaimDeadWork,
+    });
+    expect(reclaimDeadWork.calls.length).toBe(2);
+    // each call gets (orchDir, signal, { repoRoot }).
+    for (const args of reclaimDeadWork.calls) {
+      expect(args[0]).toBe(orchDir);
+      expect(args[1].phase).toBe("implement");
+      expect(["CTL-1", "CTL-2"]).toContain(args[1].ticket);
+      expect(typeof args[2]).toBe("object");
+      expect(args[2]).toHaveProperty("repoRoot");
+    }
+  });
+
+  test("a 'reclaimed' result flips the signal (via emit-complete) so advancement fires the next phase same tick", () => {
+    // The reclaim's emit-complete spawns phase-agent-emit-complete which flips
+    // the signal on disk. In this unit test we don't actually run that script,
+    // so we simulate it by mutating the on-disk signal inside the injected
+    // reclaimDeadWork itself — the canonical "reclaim outcome" the production
+    // path produces.
+    writeNestedSignal("CTL-1", "implement", { status: "running", bg_job_id: "j1" });
+    writeNestedSignal("CTL-1", "research", { status: "done" });
+    writeNestedSignal("CTL-1", "plan", { status: "done" });
+    writeNestedSignal("CTL-1", "triage", { status: "done" });
+
+    const reclaimDeadWork = (_orchDir, sig) => {
+      // simulate the emit-complete signal flip
+      const signalPath = join(orchDir, "workers", sig.ticket, `phase-${sig.phase}.json`);
+      writeFileSync(
+        signalPath,
+        JSON.stringify({ ticket: sig.ticket, phase: sig.phase, status: "done", completedAt: "t" }),
+      );
+      return "reclaimed";
+    };
+    const dispatch = recorder({ code: 0 });
+    const writeStatus = { applyPhaseStatus: () => {}, applyTerminalDone: () => {} };
+
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus,
+      teardownWorktree: () => true,
+      reclaimDeadWork,
+    });
+
+    // Advancement saw the reclaimed implement: dispatch was called with the
+    // next phase (`verify`) for CTL-1. dispatchTicket invokes the seam as
+    // `dispatch({ orchDir, ticket, phase })`, so calls[i][0] is the object.
+    const verifyDispatches = dispatch.calls.filter((args) => args[0]?.phase === "verify");
+    expect(verifyDispatches.length).toBe(1);
+    expect(verifyDispatches[0][0].ticket).toBe("CTL-1");
+
+    // The tick's return object reports the reclaim alongside the advance.
+    expect(result.reclaimed).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+    expect(result.advanced).toEqual([{ ticket: "CTL-1", phase: "verify" }]);
+  });
+
+  test("a 'noop' / 'not-done' / 'not-applicable' result is invisible to advancement", () => {
+    writeNestedSignal("CTL-1", "implement", { status: "running", bg_job_id: "j1" });
+
+    // reclaim returns not-done — signal stays running, advancement skips.
+    const reclaimDeadWork = () => "not-done";
+    const dispatch = recorder({ code: 0 });
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: { applyPhaseStatus: () => {}, applyTerminalDone: () => {} },
+      teardownWorktree: () => true,
+      reclaimDeadWork,
+    });
+    expect(dispatch.calls.length).toBe(0);
+    expect(result.reclaimed).toEqual([]);
+  });
+
+  test("default reclaimDeadWork is wired to the real recovery function (no injection still safe)", () => {
+    // No injected reclaimDeadWork. With no dead workers in the fixture, the
+    // real reclaim short-circuits to 'noop' for every signal and the tick is
+    // a normal-path no-op. This proves the default seam doesn't throw on a
+    // clean tick.
+    expect(() =>
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: () => ({ code: 0 }),
+        writeStatus: { applyPhaseStatus: () => {}, applyTerminalDone: () => {} },
+        teardownWorktree: () => true,
+      }),
+    ).not.toThrow();
+  });
+});
+
+// recorder — small spy that records args and returns either a constant value or
+// a function-derived value. Local to this describe to avoid leaking into the
+// existing block-scope helpers.
+function recorder(returnValue) {
+  const calls = [];
+  const fn = (...args) => {
+    calls.push(args);
+    return typeof returnValue === "function" ? returnValue(...args) : returnValue;
+  };
+  fn.calls = calls;
+  return fn;
+}

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -1,0 +1,55 @@
+// work-done-probes.mjs — per-phase "is the work committed already?" probes for the
+// CTL-574 reclaim sweep. Pure given the injected runGit; spawns nothing of its own
+// at module load.
+//
+// The registry maps phase name → probe function. Phases without an entry are
+// not-applicable to commit-state reclaim (research/plan have artifact-on-disk
+// shapes that can be added later; verify/review have no filesystem artifact).
+
+import { spawnSync } from "node:child_process";
+import { parseWorktreeForBranch } from "./worktree.mjs";
+
+// defaultRunGit — `git <args>` with stdout/stderr captured. Returns
+// { code, stdout, stderr }; never throws.
+export function defaultRunGit(args, { spawn = spawnSync } = {}) {
+  const res = spawn("git", args, { encoding: "utf8" });
+  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
+  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// implementProbe — commits-ahead>0 vs origin/main + clean tree on the worktree
+// bound to refs/heads/<ticket>. The worktree path is resolved from `git worktree
+// list --porcelain` (not reconstructed from projectKey config) so it's correct
+// regardless of any per-team config drift — same precedent as teardownWorktree.
+// Returns false on any git failure (safe default — missing worktree, stale ref,
+// permission error, etc.).
+function implementProbe({ ticket, repoRoot } = {}, { runGit = defaultRunGit } = {}) {
+  if (!ticket || !repoRoot) return false;
+
+  const list = runGit(["-C", repoRoot, "worktree", "list", "--porcelain"]);
+  if (list.code !== 0) return false;
+  const worktreePath = parseWorktreeForBranch(list.stdout, ticket);
+  if (!worktreePath) return false;
+
+  const ahead = runGit(["-C", worktreePath, "rev-list", "--count", "origin/main..HEAD"]);
+  if (ahead.code !== 0) return false;
+  if (Number(ahead.stdout.trim() || "0") <= 0) return false;
+
+  const status = runGit(["-C", worktreePath, "status", "--porcelain"]);
+  if (status.code !== 0) return false;
+  return status.stdout.trim() === "";
+}
+
+// WORK_DONE_PROBES — phase → probe. Adding a probe is the entire opt-in for a
+// phase to participate in the CTL-574 reclaim sweep. Phases without an entry
+// remain CTL-587's responsibility (auto-revival).
+export const WORK_DONE_PROBES = {
+  implement: implementProbe,
+};
+
+// hasProbe — true when the given phase has a registered probe. Used by the
+// reclaim function to classify a `dead` worker as 'not-applicable' when the
+// phase has no work-done probe yet.
+export function hasProbe(phase) {
+  return Object.prototype.hasOwnProperty.call(WORK_DONE_PROBES, phase);
+}

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -1,0 +1,165 @@
+// Unit tests for the CTL-574 per-phase work-done probe registry.
+// Run: cd plugins/dev/scripts/execution-core && bun test work-done-probes.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { WORK_DONE_PROBES, hasProbe, defaultRunGit } from "./work-done-probes.mjs";
+
+// makeRunGit — a deterministic `git` fake keyed on the trailing positional args.
+// Returns { code, stdout, stderr } shaped like spawnSync's output.
+function makeRunGit(responses) {
+  return (args) => {
+    const key = args.join(" ");
+    if (responses[key]) return responses[key];
+    // Match a known prefix so callers can ignore the cwd prefix in the key.
+    for (const [k, v] of Object.entries(responses)) {
+      if (key.endsWith(k)) return v;
+    }
+    return { code: 1, stdout: "", stderr: `fake runGit: no match for ${key}` };
+  };
+}
+
+// porcelainFor — a `git worktree list --porcelain` block for one ticket bound to
+// the given worktree path. Mirrors the real porcelain shape (blank-line-separated).
+function porcelainFor(ticket, worktreePath) {
+  return [
+    "worktree /repo",
+    "HEAD abcdef0",
+    "branch refs/heads/main",
+    "",
+    `worktree ${worktreePath}`,
+    "HEAD 1234567",
+    `branch refs/heads/${ticket}`,
+    "",
+  ].join("\n");
+}
+
+describe("WORK_DONE_PROBES — registry shape", () => {
+  test("implement is registered, other phases are not", () => {
+    expect(hasProbe("implement")).toBe(true);
+    for (const phase of [
+      "triage", "research", "plan",
+      "verify", "review", "pr", "monitor-merge", "monitor-deploy",
+      "unknown-phase",
+    ]) {
+      expect(hasProbe(phase)).toBe(false);
+    }
+  });
+});
+
+describe("WORK_DONE_PROBES.implement — happy path", () => {
+  test("returns true when worktree exists + commits-ahead > 0 + clean tree", () => {
+    const wt = "/wt/CTL-1";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-1", wt), stderr: "" },
+      [`-C ${wt} rev-list --count origin/main..HEAD`]: { code: 0, stdout: "2\n", stderr: "" },
+      [`-C ${wt} status --porcelain`]: { code: 0, stdout: "", stderr: "" },
+    });
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit }),
+    ).toBe(true);
+  });
+});
+
+describe("WORK_DONE_PROBES.implement — false (work not done)", () => {
+  test("returns false when no commits ahead", () => {
+    const wt = "/wt/CTL-1";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-1", wt), stderr: "" },
+      [`-C ${wt} rev-list --count origin/main..HEAD`]: { code: 0, stdout: "0\n", stderr: "" },
+      [`-C ${wt} status --porcelain`]: { code: 0, stdout: "", stderr: "" },
+    });
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit }),
+    ).toBe(false);
+  });
+
+  test("returns false when tree is dirty", () => {
+    const wt = "/wt/CTL-1";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-1", wt), stderr: "" },
+      [`-C ${wt} rev-list --count origin/main..HEAD`]: { code: 0, stdout: "2\n", stderr: "" },
+      [`-C ${wt} status --porcelain`]: { code: 0, stdout: " M plugins/dev/foo.mjs\n", stderr: "" },
+    });
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit }),
+    ).toBe(false);
+  });
+
+  test("returns false when no worktree matches the ticket branch", () => {
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": {
+        code: 0,
+        stdout: "worktree /repo\nHEAD abcdef0\nbranch refs/heads/main\n\n",
+        stderr: "",
+      },
+    });
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit }),
+    ).toBe(false);
+  });
+});
+
+describe("WORK_DONE_PROBES.implement — git failures are safe (return false)", () => {
+  test("worktree list non-zero exit → false", () => {
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 1, stdout: "", stderr: "not a git repo" },
+    });
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit }),
+    ).toBe(false);
+  });
+
+  test("rev-list non-zero (e.g., origin/main missing) → false", () => {
+    const wt = "/wt/CTL-1";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-1", wt), stderr: "" },
+      [`-C ${wt} rev-list --count origin/main..HEAD`]: { code: 128, stdout: "", stderr: "bad revision" },
+    });
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit }),
+    ).toBe(false);
+  });
+
+  test("status non-zero → false", () => {
+    const wt = "/wt/CTL-1";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-1", wt), stderr: "" },
+      [`-C ${wt} rev-list --count origin/main..HEAD`]: { code: 0, stdout: "1\n", stderr: "" },
+      [`-C ${wt} status --porcelain`]: { code: 1, stdout: "", stderr: "permission denied" },
+    });
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit }),
+    ).toBe(false);
+  });
+});
+
+describe("WORK_DONE_PROBES.implement — input guards", () => {
+  test("missing ticket → false (no git spawn)", () => {
+    const runGit = () => {
+      throw new Error("runGit must not be called");
+    };
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: null, repoRoot: "/repo" }, { runGit }),
+    ).toBe(false);
+  });
+
+  test("missing repoRoot → false (no git spawn)", () => {
+    const runGit = () => {
+      throw new Error("runGit must not be called");
+    };
+    expect(
+      WORK_DONE_PROBES.implement({ ticket: "CTL-1", repoRoot: null }, { runGit }),
+    ).toBe(false);
+  });
+});
+
+describe("defaultRunGit — spawn error is non-fatal", () => {
+  test("a spawn error returns { code: 127, … } and never throws", () => {
+    const r = defaultRunGit(["worktree", "list"], {
+      spawn: () => ({ error: new Error("ENOENT") }),
+    });
+    expect(r.code).toBe(127);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toContain("ENOENT");
+  });
+});


### PR DESCRIPTION
## Summary

A `phase-implement` worker can complete its real work — land commits, leave the tree clean — but exit without emitting `phase.implement.complete` (multiple existing Layer-1 causes: missed env-var prelude, bash `$0/$1` clobber, mid-skill process death). When that happens the execution-core pipeline stalls indefinitely on `phase-implement.json: status=running` with a dead bg job. `classifyWorker` already returns `'dead'` for this state but nothing acts on it.

Live evidence: CTL-380 during the 2026-05-22 CTL-584 QA — `phase-implement.json` stuck at `status: running`, `updatedAt` 1 minute after start, no `phase.implement.*` events in the log, but two real commits on the branch and a clean tree.

## Fix

A new `schedulerTick` step (0) **reclaim-dead-work sweep**, running before the advancement sweep. For each active worker signal, calls a new `recovery.reclaimDeadWorkIfPossible` that classifies via `classifyWorker` and — only for `'dead'` — asks a per-phase work-done probe. On `'reclaimed'` it (1) appends a canonical `phase.<phase>.reclaim.<ticket>` audit event, then (2) invokes the existing `phase-agent-emit-complete` script with explicit `--orch-dir` + `--session-id` so its signal-flip + canonical-complete + session-end all run. The advancement sweep on the same tick picks up the freshly-reclaimed phase.

Decision branches (return values):
- `noop` — not `'dead'` (terminal/running/unknown)
- `not-applicable` — `'dead'` but no probe registered for this phase (CTL-587's territory)
- `not-done` — `'dead'` + probe says work NOT committed (CTL-587)
- `reclaimed` — `'dead'` + work IS committed → audit + emit-complete
- `reclaim-failed` — emit-complete non-zero; signal not mutated; next tick retries

## Scope

- **Probe registered for `implement` only.** Commits-ahead>0 vs `origin/main` + clean tree on the worktree bound to `refs/heads/<ticket>`. Path resolved from `git worktree list --porcelain` (not reconstructed from `projectKey`) — same precedent as `teardownWorktree`.
- Other phases (research/plan/triage/verify/review/pr/monitor-*) return `not-applicable`. Probes for those phases (artifact-on-disk shapes) are a fast-follow ticket if needed.
- Reuses `phase-agent-emit-complete` as-is — no duplicate signal-mutation logic in `.mjs`. Downstream sees a normal `phase.<phase>.complete` event identically.
- No fix for the Layer-1 worker-side missed-emit (multiple existing tickets + memories cover prevention). This is a server-side defense in depth.

## Test changes

| File | Adds |
|---|---|
| `work-done-probes.test.mjs` (new) | 11 tests: registry shape, happy path, false branches (no commits / dirty / no worktree), git-failure safety, input guards, spawn-error path |
| `recovery.test.mjs` | 8 tests covering all five decision branches + append→emit ordering + flag set + `repoRoot` forwarding |
| `scheduler.test.mjs` | 4 tests: per-signal invocation, reclaim→advancement same-tick fire-through, no-effect for non-reclaimed results, default seam doesn't throw on clean tick |

## Verification

```
cd plugins/dev/scripts/execution-core && bun test
# 334 pass, 0 fail
```

## Manual verification (post-merge + cache sync + daemon restart)

CTL-380 is currently stuck at `Implement` in the live execution-core daemon due to exactly this bug. After this PR's cache sync + daemon restart, the next scheduler tick should:

1. Append `phase.implement.reclaim.CTL-380` to the event log.
2. Invoke `phase-agent-emit-complete`, which appends `phase.implement.complete.CTL-380` and flips `phase-implement.json` to `status: done`.
3. The advancement sweep on the same tick dispatches `verify` for CTL-380, and Linear writes `Validate`.

This will be the final cross-validation of the fix.

## References

- Research: `thoughts/shared/research/2026-05-23-CTL-574-implement-emit-stale-signal.md`
- Plan: `thoughts/shared/plans/2026-05-23-CTL-574-implement-reclaim-dead-work.md`
- Related follow-up: CTL-587 (auto-revive dead workers whose work is NOT done)
- Marked duplicate: CTL-580

🤖 Generated with [Claude Code](https://claude.com/claude-code)