### PR TITLE
fix(execution-core): broaden reclaim trigger to cover stale bg jobs (CTL-588)

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -173,21 +173,40 @@ function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
   }
 }
 
+// STALE_MS — a healthy claude --bg worker updates ~/.claude/jobs/<id>/state.json
+// every few seconds (heartbeats, output appends, scan offsets). A state.json
+// untouched longer than this is conclusive evidence the worker stopped (CTL-588).
+// 5 minutes is a generous gap that won't false-positive a worker idling on a
+// long tool call.
+const STALE_MS = 5 * 60 * 1000;
+
 // reclaimDeadWorkIfPossible — one signal in, one decision out. The five-way
 // return discriminates the cases an operator might need to investigate:
 //
-//   'noop'             not 'dead' (terminal / running / unknown). No action.
-//   'not-applicable'   'dead' but the phase has no registered work-done probe.
-//                      Out of scope for CTL-574; CTL-587's territory.
-//   'not-done'         'dead' + probe says the work is NOT committed. The
-//                      worker really did die mid-implement. CTL-587 will
+//   'noop'             not effectively dead (terminal / unknown / live running).
+//                      No action.
+//   'not-applicable'   effectively dead but the phase has no registered
+//                      work-done probe. Out of scope for CTL-574; CTL-587's
+//                      territory.
+//   'not-done'         effectively dead + probe says the work is NOT committed.
+//                      The worker really did die mid-implement. CTL-587 will
 //                      re-dispatch when that lands.
-//   'reclaimed'        'dead' + work IS done. Reclaim succeeded — the canonical
-//                      audit + complete events were appended, the signal was
-//                      flipped, the session was ended.
-//   'reclaim-failed'   'dead' + work IS done BUT emit-complete exited non-zero.
-//                      The signal is NOT mutated (the emit-complete script
-//                      writes via atomic rename); the next tick retries.
+//   'reclaimed'        effectively dead + work IS done. Reclaim succeeded —
+//                      the canonical audit + complete events were appended,
+//                      the signal was flipped, the session was ended.
+//   'reclaim-failed'   effectively dead + work IS done BUT emit-complete
+//                      exited non-zero. The signal is NOT mutated (emit-
+//                      complete writes via atomic rename); the next tick
+//                      retries.
+//
+// CTL-588: "effectively dead" is broader than classifyWorker's `dead`. The
+// canonical `dead` requires the bg job dir to be GONE, but claude --bg leaves
+// job dirs behind indefinitely after the worker exits (memory
+// project_phase_agent_bg_no_reap). A worker that really died, but whose dir
+// lingers, classifies as `running`. We add a freshness check: a `running`
+// signal whose bg state.json hasn't been touched in `staleMs` is treated as
+// effectively dead. classifyWorker itself is unchanged — only this consumer
+// needs the stronger liveness signal.
 export function reclaimDeadWorkIfPossible(
   orchDir,
   signal,
@@ -197,10 +216,21 @@ export function reclaimDeadWorkIfPossible(
     probes = WORK_DONE_PROBES,
     emitComplete = defaultEmitComplete,
     appendEvent = defaultAppendReclaimEvent,
+    now = Date.now,
+    staleMs = STALE_MS,
   } = {},
 ) {
   const klass = classifyWorker(signal, { statJob });
-  if (klass !== "dead") return "noop";
+  let effectivelyDead = klass === "dead";
+  if (klass === "running" && signal?.liveness?.value) {
+    // The same statJob call classifyWorker just made is cheap to repeat once;
+    // keeps the freshness check local to this consumer.
+    const job = statJob(signal.liveness.value);
+    if (job && typeof job.mtimeMs === "number" && now() - job.mtimeMs > staleMs) {
+      effectivelyDead = true;
+    }
+  }
+  if (!effectivelyDead) return "noop";
   if (!hasProbe(signal.phase)) return "not-applicable";
 
   const probe = probes[signal.phase];

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -463,17 +463,67 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(appendEvent.calls.length).toBe(0);
   });
 
-  test("'noop' for a running signal whose bg job is alive (no emit)", () => {
+  test("'noop' for a running signal whose bg job is FRESH (state.json mtime within staleMs)", () => {
+    // CTL-588: a `running` classification + fresh state.json mtime → live worker.
     const probe = recorder(true);
     const emit = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
-      statJob: () => ({ exists: true, mtimeMs: 1 }), // bg alive
+      statJob: () => ({ exists: true, mtimeMs: 1_000_000 }),
       probes: { implement: probe },
       emitComplete: emit,
       appendEvent: recorder(undefined),
+      // Pin "now" near the bg mtime so the staleness check sees a fresh worker.
+      now: () => 1_000_500,
     });
     expect(r).toBe("noop");
     expect(emit.calls.length).toBe(0);
+  });
+
+  test("CTL-588: 'running' with a STALE bg state.json (> staleMs) is treated as effectively dead", () => {
+    // The bug CTL-588 fixes: claude --bg leaves the job dir behind after the
+    // worker exits, so classifyWorker stays `running` indefinitely. We catch
+    // this via mtime — a real worker updates state.json every few seconds.
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const appendEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+      probes: { implement: probe },
+      emitComplete: emit,
+      appendEvent,
+      now: () => 1_000 + 6 * 60 * 1000, // 6 minutes past mtime — stale
+    });
+    expect(r).toBe("reclaimed");
+    expect(probe.calls.length).toBe(1);
+    expect(emit.calls.length).toBe(1);
+    expect(appendEvent.calls.length).toBe(1);
+  });
+
+  test("CTL-588: 'running' with a FRESH bg state.json (under staleMs) is NOT reclaimed", () => {
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => ({ exists: true, mtimeMs: 1_000_000 }),
+      probes: { implement: probe },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      now: () => 1_000_000 + 4 * 60 * 1000, // 4 minutes — under threshold
+    });
+    expect(r).toBe("noop");
+    expect(probe.calls.length).toBe(0);
+    expect(emit.calls.length).toBe(0);
+  });
+
+  test("CTL-588: staleMs is honored when explicitly passed (override)", () => {
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => ({ exists: true, mtimeMs: 100 }),
+      probes: { implement: () => true },
+      emitComplete: () => ({ code: 0 }),
+      appendEvent: () => {},
+      now: () => 100 + 60_000,
+      staleMs: 30_000, // 30s threshold — 1 min IS stale
+    });
+    expect(r).toBe("reclaimed");
   });
 
   test("'noop' for an unknown signal (no bg_job_id)", () => {


### PR DESCRIPTION
## Summary

CTL-574 (#985) added the reclaim-dead-work sweep but its trigger relied on `classifyWorker.dead`, which requires the bg job dir at `~/.claude/jobs/<id>/state.json` to be **gone**. But `claude --bg` leaves job dirs behind indefinitely after the worker exits (memory `project_phase_agent_bg_no_reap`). A worker that really died still classifies as `running`, so the reclaim returned `noop` and CTL-380's stuck implement was never reclaimed even after #985 merged + cache synced + daemon restarted.

## Live evidence

`~/.claude/jobs/4c59315d/state.json` (CTL-380's implement worker):

```jsonc
{
  "state": "working",
  "detail": "Phase 1 & 2 committed; running post-implementation security review + quality gates",
  "firstTerminalAt": null,
  "updatedAt": "2026-05-23T00:03:34.808Z"   // 9+ hours ago
}
```

mtime: `2026-05-23T00:03Z` — when the last real commit landed. Worker process gone from `ps`. Indistinguishable from `running` under the current `classifyWorker` contract.

## Fix

In `reclaimDeadWorkIfPossible`, extend the eligibility check from `dead` to **`dead OR (running AND state.json stale)`**. `STALE_MS = 5 minutes` — a healthy worker updates `state.json` every few seconds (heartbeats, output appends, scan offsets), so a 5-minute gap is conclusive without false-positiving a worker idling on a long tool call.

`classifyWorker` itself is unchanged — its contract is "is the dir there?" and it has other callers (`recoverStartup` logging, future code) that work fine. The freshness check is local to the reclaim path.

New injectable deps: `now` (default `Date.now`) and `staleMs` (default 5 min) — deterministic tests + future per-deploy override.

## Test changes

- Renamed the existing `'noop' for running` test → `'noop' for FRESH running`, pinning `now` near `mtimeMs` so the staleness check sees a live worker (the old test's `mtimeMs: 1` was ancient under the new semantics).
- Added 3 new tests:
  - `STALE running → reclaimed` (the bug fix)
  - `FRESH under threshold → noop` (no false positive)
  - `staleMs override honored`

## Verification

```
cd plugins/dev/scripts/execution-core && bun test
# 337 pass, 0 fail
```

## Manual verification (post-merge)

After cache sync + daemon restart, the next scheduler tick should reclaim CTL-380's stuck implement: `phase.implement.reclaim.CTL-380` → `phase.implement.complete.CTL-380` → advancement fires `verify`. This will be the third (and definitive) cross-validation of the reclaim path end-to-end.

## References

- CTL-574 (#985) — the work-done probe + reclaim wiring this extends
- Memory `project_phase_agent_bg_no_reap` — root cause of dir-persists-after-exit
- Live evidence: `~/.claude/jobs/4c59315d/state.json` (CTL-380's stuck worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)