### PR TITLE
CTL-380: orchestrate-fixup preserves multi-line --issues

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-fixup.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-fixup.test.sh
@@ -31,6 +31,14 @@ expect_contains() {
   grep -q -- "$needle" "$file" || { echo "    missing: $needle"; return 1; }
 }
 
+expect_not_contains() {
+  local file="$1" needle="$2"
+  if grep -q -- "$needle" "$file"; then
+    echo "    unexpected match: $needle in $file"
+    return 1
+  fi
+}
+
 expect_exit() {
   local expected="$1"; shift
   set +e
@@ -127,6 +135,34 @@ CATALYST_ORCHESTRATOR_ID="orch-test" CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR_4" \
   "$FIXUP" TEST-4 --issues "x" --pr 9 --worker-dir "$EXPLICIT_DIR" > "${SCRATCH}/run4.out" 2>&1
 run "--worker-dir override wins over state.json" \
   expect_contains "${ORCH_DIR_4}/workers/dispatch-fixup-TEST-4.sh" "WORKER_DIR=\"${EXPLICIT_DIR}\""
+
+# Test 9 (CTL-380): render() preserves multi-line --issues verbatim. The previous
+# awk -v implementation hit "newline in string" on BSD/mawk and silently truncated
+# $ISSUES to its first line, which broke orchestrate-auto-fixup whenever there
+# were ≥2 unresolved review threads.
+ORCH_DIR_5="${SCRATCH}/orch5"
+mkdir -p "${ORCH_DIR_5}/workers"
+ISSUES_ML=$'foo.ts:10: null deref in handler\nbar.ts:25: missing await on async call\nbaz.ts:7: unused import after refactor'
+CATALYST_ORCHESTRATOR_ID="orch-test" CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR_5" \
+  "$FIXUP" TEST-5 --issues "$ISSUES_ML" --pr 13 \
+    > "${SCRATCH}/run5.stdout" 2> "${SCRATCH}/run5.stderr" || true
+PROMPT_5="${ORCH_DIR_5}/workers/fixup-TEST-5-prompt.md"
+
+run "multi-line --issues: no 'newline in string' warnings on stderr" \
+  expect_not_contains "${SCRATCH}/run5.stderr" "newline in string"
+run "multi-line --issues: line 1 present in rendered prompt" \
+  expect_contains "$PROMPT_5" "foo.ts:10: null deref in handler"
+run "multi-line --issues: line 2 present in rendered prompt" \
+  expect_contains "$PROMPT_5" "bar.ts:25: missing await on async call"
+run "multi-line --issues: line 3 present in rendered prompt" \
+  expect_contains "$PROMPT_5" "baz.ts:7: unused import after refactor"
+# All N input lines land under the '## Blockers to resolve' section (count match)
+run "multi-line --issues: all 3 lines under '## Blockers to resolve'" \
+  bash -c "
+    awk '/^## Blockers to resolve\$/{f=1;next}/^## /{f=0}f' '$PROMPT_5' \
+      | grep -cE '^(foo|bar|baz)\.ts:[0-9]+:' \
+      | grep -qx 3
+  "
 
 echo ""
 echo "orchestrate-fixup: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/orchestrate-fixup
+++ b/plugins/dev/scripts/orchestrate-fixup
@@ -107,37 +107,40 @@ PR_NUMBER="${PR_NUMBER:-UNKNOWN}"
 PR_URL="${PR_URL:-UNKNOWN}"
 
 render() {
-  # Substitute ${VAR} placeholders from a template file. Only replaces variables we know about;
-  # leaves the rest literal so templates stay readable.
+  # CTL-380: substitute ${VAR} placeholders via jq -Rs so newline-bearing values
+  # (notably $ISSUES, which orchestrate-auto-fixup joins with \n) flow through
+  # verbatim. The previous awk -v implementation hit "newline in string" on
+  # BSD/mawk and silently truncated multi-line values to their first line.
   local template="$1"
-  awk -v tid="$TICKET_ID" \
-      -v orch="$ORCH_NAME" \
-      -v wd="$WORKER_DIR" \
-      -v bn="$BRANCH_NAME" \
-      -v prn="$PR_NUMBER" \
-      -v pru="$PR_URL" \
-      -v sf="$SIGNAL_FILE" \
-      -v issues="$ISSUES" \
-      -v od="$ORCH_DIR" \
-      -v pf="$PROMPT_FILE" \
-      -v wm="$WORKER_MODEL" \
-      -v scope="dev" \
-  '{
-    gsub(/\$\{TICKET_ID\}/, tid);
-    gsub(/\$\{ORCH_NAME\}/, orch);
-    gsub(/\$\{ORCH_DIR\}/, od);
-    gsub(/\$\{WORKTREE_PATH\}/, wd);
-    gsub(/\$\{WORKER_DIR\}/, wd);
-    gsub(/\$\{BRANCH_NAME\}/, bn);
-    gsub(/\$\{PR_NUMBER\}/, prn);
-    gsub(/\$\{PR_URL\}/, pru);
-    gsub(/\$\{SIGNAL_FILE\}/, sf);
-    gsub(/\$\{ISSUES\}/, issues);
-    gsub(/\$\{PROMPT_FILE\}/, pf);
-    gsub(/\$\{WORKER_MODEL\}/, wm);
-    gsub(/\$\{SCOPE\}/, scope);
-    print;
-  }' "$template"
+  jq -Rsr \
+    --arg tid    "$TICKET_ID" \
+    --arg orch   "$ORCH_NAME" \
+    --arg od     "$ORCH_DIR" \
+    --arg wd     "$WORKER_DIR" \
+    --arg bn     "$BRANCH_NAME" \
+    --arg prn    "$PR_NUMBER" \
+    --arg pru    "$PR_URL" \
+    --arg sf     "$SIGNAL_FILE" \
+    --arg issues "$ISSUES" \
+    --arg pf     "$PROMPT_FILE" \
+    --arg wm     "$WORKER_MODEL" \
+    --arg scope  "dev" \
+    '
+      gsub("\\$\\{TICKET_ID\\}";     $tid)
+      | gsub("\\$\\{ORCH_NAME\\}";    $orch)
+      | gsub("\\$\\{ORCH_DIR\\}";     $od)
+      | gsub("\\$\\{WORKTREE_PATH\\}";$wd)
+      | gsub("\\$\\{WORKER_DIR\\}";   $wd)
+      | gsub("\\$\\{BRANCH_NAME\\}";  $bn)
+      | gsub("\\$\\{PR_NUMBER\\}";    $prn)
+      | gsub("\\$\\{PR_URL\\}";       $pru)
+      | gsub("\\$\\{SIGNAL_FILE\\}";  $sf)
+      | gsub("\\$\\{ISSUES\\}";       $issues)
+      | gsub("\\$\\{PROMPT_FILE\\}";  $pf)
+      | gsub("\\$\\{WORKER_MODEL\\}"; $wm)
+      | gsub("\\$\\{SCOPE\\}";        $scope)
+      | sub("\n$"; "")
+    ' "$template"
 }
 
 if [ "$DRY_RUN" -eq 1 ]; then

--- a/plugins/dev/skills/orchestrate/SKILL.md
+++ b/plugins/dev/skills/orchestrate/SKILL.md
@@ -2401,6 +2401,11 @@ test/auth.test.ts: add regression test for the null-token path" \
   --dispatch
 ```
 
+`--issues` accepts a multi-line value verbatim — pass each blocker on its own
+line as shown above and the rendered prompt's `## Blockers to resolve` section
+will contain every line in order. No caller-side escaping or `\n`-joining is
+required.
+
 What this does:
 
 1. Renders `templates/fixup-prompt.md` → `${ORCH_DIR}/workers/fixup-${TICKET}-prompt.md`


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-23T10:00:36Z -->
<!-- Last updated: 2026-05-23T10:00:36Z -->
<!-- PR: #989 -->
<!-- Previous commits: 4c8e342a833cabbbf71c2c93e69465691d8add36,8af2eaa4ad74d0c1f49e3dec50733047682c3536 -->

## Summary

`orchestrate-fixup`'s `render()` templated the worker prompt with `awk -v issues="$ISSUES"`, which on BSD/mawk emits `awk: newline in string` whenever `--issues` contains literal newlines — and silently truncated the rendered `${ISSUES}` to its first line. Because `orchestrate-auto-fixup` already joins unresolved review threads with `\n` via `jq -r`, any fix-up with ≥2 blockers shipped a prompt missing every blocker after the first.

This PR replaces the awk pipeline with `jq -Rsr` substitution that round-trips newlines verbatim, and adds regression coverage so multi-line `--issues` can't silently regress again.

## Changes Made

### `plugins/dev/scripts/orchestrate-fixup` (+33 / -30)

`render()` now reads the template via `jq -Rsr` (raw input, raw output) and substitutes every `${VAR}` placeholder with `gsub("\\$\\{NAME\\}"; $arg)` chained through pipes. The placeholder set is unchanged (`TICKET_ID`, `ORCH_NAME`, `ORCH_DIR`, `WORKTREE_PATH`, `WORKER_DIR`, `BRANCH_NAME`, `PR_NUMBER`, `PR_URL`, `SIGNAL_FILE`, `ISSUES`, `PROMPT_FILE`, `WORKER_MODEL`, `SCOPE`). A trailing `sub("\n$"; "")` strips the single trailing newline `jq -Rs` adds so the rendered file matches the awk output byte-for-byte on single-line inputs. No behaviour change for callers that were already passing single-line `--issues`.

### `plugins/dev/scripts/__tests__/orchestrate-fixup.test.sh` (+36)

New test 9 (CTL-380) plus an `expect_not_contains` helper:

- pass a 3-line `--issues` value (`foo.ts:10`, `bar.ts:25`, `baz.ts:7`)
- assert stderr contains no `newline in string`
- assert each of the three lines appears in the rendered `prompt.md`
- assert all three land under the `## Blockers to resolve` section (awk-extracted, count must equal 3)

### `plugins/dev/skills/orchestrate/SKILL.md` (+5)

Pattern A (orchestrate-fixup) docs now explicitly state that `--issues` accepts a multi-line value and the renderer preserves every line under `## Blockers to resolve`. The old `\n`-join / semicolon-collapse workaround is no longer required and no longer mentioned as a caveat.

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/orchestrate-fixup.test.sh` — **26/26 passing** including the 5 new multi-line assertions
- [x] `git grep "awk -v issues=" plugins/dev/scripts/orchestrate-fixup` returns nothing
- [ ] Trigger `orchestrate-auto-fixup` on a real PR with ≥2 unresolved review threads and confirm the rendered `${ORCH_DIR}/workers/fixup-<TICKET>-prompt.md` contains every blocker line and no `awk: newline in string` on stderr

## Related

Refs: CTL-380
Reproduced during `orch-adv-898-2026-05-12` Wave 2 dispatch (2026-05-12).
