### PR TITLE
CTL-589: terminal-Done sweep accepts monitor-deploy=skipped (CTL-512 followup)

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -432,7 +432,13 @@ export function schedulerTick(
   // by labelOnce's marker file.
   for (const ticket of listStartedTickets(orchDir)) {
     const signals = readPhaseSignals(orchDir, ticket);
-    if (signals["monitor-deploy"] === "done") {
+    // CTL-589 (CTL-512 followup): `skipped` is the second terminal status for
+    // monitor-deploy — emitted when no GitHub Deployments arrive within the
+    // probe timeout (the skipDeployVerification path). It must trigger the
+    // same Linear Done write + worktree teardown as `done`, matching the
+    // isTicketInFlight gate at line ~93. Without this, the ticket lingers
+    // at `PR` in Linear and the worktree leaks on disk indefinitely.
+    if (signals["monitor-deploy"] === "done" || signals["monitor-deploy"] === "skipped") {
       safeWrite(() => writeStatus.applyTerminalDone({ ticket }), { ticket });
       // CTL-582: the ticket reached terminal Done — tear down its worktree.
       teardownWorktreeOnce(orchDir, ticket, teardownWorktree);

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -772,6 +772,22 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
     expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-4" }));
   });
 
+  test("writes terminal Done when a ticket's monitor-deploy signal is skipped (CTL-589)", () => {
+    // CTL-512 fixed isTicketInFlight to treat `skipped` as terminal; this is
+    // the matching half — the terminal-Done sweep must also fire on `skipped`
+    // so the Linear ticket actually lands at Done (not stale at PR).
+    writeSignal("CTL-4", "monitor-deploy", "skipped");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dones = [];
+    const writeStatus = {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: (a) => dones.push(a),
+      applyLabel: () => {},
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: okDispatch, writeStatus });
+    expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-4" }));
+  });
+
   test("a status-write throw never aborts the tick", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const writeStatus = {
@@ -886,6 +902,25 @@ describe("schedulerTick — worktree teardown on Done (CTL-582)", () => {
 
   test("calls teardownWorktree with { repoRoot, ticket } when monitor-deploy is done", () => {
     writeSignal("CTL-4", "monitor-deploy", "done");
+    writeRegistry("CTL", "/repo/ctl");
+    const calls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus: noStatusWrites(),
+      teardownWorktree: (a) => {
+        calls.push(a);
+        return true;
+      },
+    });
+    expect(calls).toEqual([{ repoRoot: "/repo/ctl", ticket: "CTL-4" }]);
+  });
+
+  test("calls teardownWorktree when monitor-deploy is skipped (CTL-589)", () => {
+    // CTL-512 followup — `skipped` is the second terminal status for
+    // monitor-deploy; without this, the worktree leaks on disk forever for
+    // tickets whose deploy verification was skipped.
+    writeSignal("CTL-4", "monitor-deploy", "skipped");
     writeRegistry("CTL", "/repo/ctl");
     const calls = [];
     schedulerTick(orchDir, {


### PR DESCRIPTION
## Summary

`scheduler.mjs`'s terminal-Done sweep gated on `signals["monitor-deploy"] === "done"` only,
silently leaving `skipped` tickets stuck at `PR` in Linear with their worktrees on disk.
PR #990 (CTL-512) fixed the matching `isTicketInFlight` gate but missed this sister site.
This is the one-line follow-up plus matching tests.

## Background

PR #990 (CTL-512) routed `phase.monitor-deploy.skipped` as a terminal completion at the
consumer (`isTicketInFlight`) so the wave-slot freed correctly. The producer was already
emitting `skipped` with a payload of `{ deploy_state: "skipped", reason: "no
deployment_status event matched within timeout" }` — this is the standard terminal
status when `skipDeployVerification=true` (the default for repos without GitHub
Deployments).

But the scheduler has **two** terminal-status gates, not one:

1. `isTicketInFlight` (line ~93) — controls wave-slot accounting. **Already correct
   after PR #990.**
2. The terminal-Done sweep (line ~435) — writes Linear `Done` and tears down the
   worktree. **Still gated on `=== "done"` only.**

Surfaced empirically during the second end-to-end QA tracer run on CTL-512 itself
(2026-05-23). The pipeline walked the ticket autonomously through every phase, but
once `monitor-deploy` emitted `skipped` the ticket stalled at `PR` and the worktree
leaked.

A local hot-patch has been carried in the plugin cache since 2026-05-23 — see the
handoff for the chain — but it never made it to `origin/main`, so re-syncing the
cache would blow it away.

## Fix

Extend the gate to accept `"skipped"` as well, mirroring `isTicketInFlight`. The
two terminal-status sites must stay in lockstep; a follow-on cleanup might
introduce a shared `TERMINAL_STATUSES` constant — out of scope here.

```diff
-    if (signals["monitor-deploy"] === "done") {
+    if (signals["monitor-deploy"] === "done" || signals["monitor-deploy"] === "skipped") {
       safeWrite(() => writeStatus.applyTerminalDone({ ticket }), { ticket });
       teardownWorktreeOnce(orchDir, ticket, teardownWorktree);
     }
```

## Tests

Two new RED-first unit tests (`scheduler.test.mjs`):

- `writes terminal Done when a ticket's monitor-deploy signal is skipped (CTL-589)` —
  asserts `applyTerminalDone` fires for `monitor-deploy=skipped`. (CTL-558 describe block.)
- `calls teardownWorktree when monitor-deploy is skipped (CTL-589)` —
  asserts `teardownWorktree` fires for `monitor-deploy=skipped`. (CTL-582 describe block.)

Both fail against the old gate and pass against the new one. The full execution-core
suite is unchanged: **343 pass / 0 fail across 20 files** (`bun test`).

## Validation

Per `/catalyst-dev:validate-type-safety`:

- Step 0 / 1 / 3 — N/A (no TypeScript in changed files).
- Step 2 — reward-hacking scan: PASS (pure equality-gate widening).
- Step 4 — tests: PASS (73 scheduler + 343 execution-core total).
- Step 5 — lint: PASS for the diff (prettier-clean on added lines; pre-existing
  drift in untouched code intentionally left alone per memory `no_trunk_ci_gate`).

## References

- PR #990 (the producer-side half of this fix): https://github.com/coalesce-labs/catalyst/pull/990
- `plugins/dev/scripts/execution-core/scheduler.mjs:435` (this fix)
- `plugins/dev/scripts/execution-core/scheduler.mjs:~93` (`isTicketInFlight` — sister gate)
- Handoff: `thoughts/shared/handoffs/CTL-587/2026-05-23_13-58-15_ctl-587-auto-revival-plus-ctl-512-followup.md`

Refs: CTL-589
Refs: CTL-512