### PR TITLE
CTL-587: auto-revive dead claude --bg workers in execution-core

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch-test-kill.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch-test-kill.test.sh
@@ -195,11 +195,8 @@ awk '
   /^```$/ && found && !done { done=1; exit }
   found && !done { print }
 ' "$SKILL_MD" >"${PRELUDE_DIR}/prelude.sh"
-# Append the planned kill-hook check — RED test, this is what we expect the
-# real SKILL.md to contain once Phase 1 lands. Once SKILL.md has the hook,
-# this append becomes a no-op duplicate so it stays harmless.
-# (Once green, the extracted prelude itself contains the hook — appending it
-# again is idempotent: a second matching check still exits 137.)
+# The extracted prelude IS the source of truth — Phase 1 added the kill hook
+# to SKILL.md itself, so no extra append is needed.
 chmod +x "${PRELUDE_DIR}/prelude.sh"
 (
 	cd "${TEST_DIR}/proj" || exit

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch-test-kill.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch-test-kill.test.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# CTL-587: test-kill injection hook for phase-agent-dispatch + phase-implement/SKILL.md.
+#
+# Two modes via the `CATALYST_TEST_KILL_PHASE=<phase>:<mode>` env var:
+#   before-launch  — phase-agent-dispatch aborts BEFORE the claude --bg spawn;
+#                    signal goes stalled with attentionReason=test-kill-before-launch
+#                    (exercises the escalation path in CTL-587 revive).
+#   after-prelude  — phase-implement/SKILL.md prelude exits 137 AFTER flipping
+#                    the signal to "running" but BEFORE any commit work (exercises
+#                    the revive path: next reclaim tick sees a stale state.json,
+#                    work-done probe returns false, dispatcher re-spawns).
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-agent-dispatch-test-kill.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/phase-implement/SKILL.md"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t ctl-587-test-kill-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+assert_eq() {
+	local expected="$1" actual="$2" label="$3"
+	if [[ $expected == "$actual" ]]; then pass "$label"
+	else fail "$label — expected '$expected', got '$actual'"
+	fi
+}
+
+if [[ ! -x $DISPATCH ]]; then
+	echo "FATAL: $DISPATCH not found or not executable" >&2
+	exit 1
+fi
+
+# ─── Stub claude binary (mirrors phase-agent-dispatch.test.sh) ──────────────
+setup_claude_stub() {
+	local stub_dir="$1"
+	mkdir -p "$stub_dir"
+	cat >"$stub_dir/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
+JOB_ID="${CLAUDE_STUB_JOB_ID:-deadbeef}"
+{ echo "--ARGS--"; printf '%s\n' "$@"; } > "$LOG"
+cat <<EOF
+backgrounded · ${JOB_ID}
+EOF
+exit "${CLAUDE_STUB_EXIT:-0}"
+STUB
+	chmod +x "$stub_dir/claude"
+}
+
+fresh_env() {
+	local tag="$1"
+	TEST_DIR="${SCRATCH}/${tag}"
+	STUB_DIR="${TEST_DIR}/bin"
+	ORCH_DIR="${TEST_DIR}/orch"
+	WORKER_DIR="${ORCH_DIR}/workers/CTL-9"
+	mkdir -p "$STUB_DIR" "$WORKER_DIR"
+	# Stage the prior-artifact (plan file) so the implement gate passes.
+	mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
+	touch "${TEST_DIR}/proj/thoughts/shared/plans/2026-05-24-ctl-9.md"
+	setup_claude_stub "$STUB_DIR"
+	export CLAUDE_STUB_LOG="${TEST_DIR}/claude-stub.log"
+	export CLAUDE_STUB_JOB_ID="deadbeef"
+	unset CLAUDE_STUB_EXIT
+	export PATH="${STUB_DIR}:${PATH}"
+}
+
+# ─── Test 1: implement:before-launch → signal stalled, no claude spawn ──────
+echo "Test 1: CATALYST_TEST_KILL_PHASE=implement:before-launch aborts before spawn"
+fresh_env t1
+(
+	cd "${TEST_DIR}/proj"
+	CATALYST_TEST_KILL_PHASE="implement:before-launch" \
+		"$DISPATCH" --phase implement --ticket CTL-9 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/t1.out" 2>"${TEST_DIR}/t1.err"
+)
+RC=$?
+SIGNAL="${WORKER_DIR}/phase-implement.json"
+assert_eq "1" "$RC" "dispatch exits 1 on test-kill before-launch"
+if [[ -f $SIGNAL ]]; then
+	STATUS=$(jq -r '.status' "$SIGNAL")
+	REASON=$(jq -r '.attentionReason' "$SIGNAL")
+	BG=$(jq -r '.bg_job_id' "$SIGNAL")
+	assert_eq "stalled" "$STATUS" "signal.status = stalled"
+	assert_eq "test-kill-before-launch" "$REASON" "signal.attentionReason set by mark_launch_failed"
+	assert_eq "null" "$BG" "signal.bg_job_id null — claude --bg never spawned"
+else
+	fail "signal file written by pre-spawn step"
+fi
+# Claude stub should NOT have been invoked.
+if [[ -f $CLAUDE_STUB_LOG ]]; then
+	fail "claude --bg invoked despite before-launch kill"
+else
+	pass "claude --bg NOT invoked (no stub log written)"
+fi
+
+# ─── Test 2: env var with wrong phase name does NOT trigger ─────────────────
+echo ""
+echo "Test 2: CATALYST_TEST_KILL_PHASE with non-matching phase falls through"
+fresh_env t2
+(
+	cd "${TEST_DIR}/proj"
+	CATALYST_TEST_KILL_PHASE="research:before-launch" \
+		"$DISPATCH" --phase implement --ticket CTL-9 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/t2.out" 2>"${TEST_DIR}/t2.err"
+)
+RC=$?
+SIGNAL="${WORKER_DIR}/phase-implement.json"
+assert_eq "0" "$RC" "non-matching phase does not abort dispatch"
+if [[ -f $SIGNAL ]]; then
+	STATUS=$(jq -r '.status' "$SIGNAL")
+	assert_eq "running" "$STATUS" "signal flips to running on successful spawn"
+fi
+
+# ─── Test 3: env var unset → normal dispatch ─────────────────────────────────
+echo ""
+echo "Test 3: env unset → dispatcher behaves identically to pre-CTL-587"
+fresh_env t3
+unset CATALYST_TEST_KILL_PHASE
+(
+	cd "${TEST_DIR}/proj"
+	"$DISPATCH" --phase implement --ticket CTL-9 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/t3.out" 2>"${TEST_DIR}/t3.err"
+)
+RC=$?
+SIGNAL="${WORKER_DIR}/phase-implement.json"
+assert_eq "0" "$RC" "unset env → exit 0"
+STATUS=$(jq -r '.status' "$SIGNAL")
+assert_eq "running" "$STATUS" "unset env → signal = running"
+
+# ─── Test 4: SKILL.md prelude carries the after-prelude kill hook ───────────
+# A static grep test rather than a behavioural one — the prelude has too many
+# external dependencies (catalyst-comms, catalyst-session) to execute in a
+# fixture cleanly. The hook is a single `if` block; grep is sufficient to pin
+# the contract.
+echo ""
+echo "Test 4: phase-implement/SKILL.md contains the after-prelude kill hook"
+if grep -qE 'CATALYST_TEST_KILL_PHASE.*after-prelude' "$SKILL_MD"; then
+	pass "SKILL.md prelude references CATALYST_TEST_KILL_PHASE after-prelude"
+else
+	fail "SKILL.md prelude missing CATALYST_TEST_KILL_PHASE after-prelude hook"
+fi
+if grep -qE 'exit 137' "$SKILL_MD"; then
+	pass "SKILL.md prelude exits 137 (SIGKILL convention) on test-kill"
+else
+	fail "SKILL.md prelude missing 'exit 137'"
+fi
+# Pin ordering: the kill hook must be AFTER the signal status flip to "running"
+# (so the reclaim sweep sees a running-but-dead worker). Extract the prelude
+# bash block and check the kill block appears AFTER the `.status = "running"` jq.
+PRELUDE=$(awk '/^```bash$/{flag=1;next}/^```$/{flag=0}flag' "$SKILL_MD" | head -200)
+STATUS_LINE=$(printf '%s\n' "$PRELUDE" | grep -n '.status = "running"' | head -1 | cut -d: -f1)
+KILL_LINE=$(printf '%s\n' "$PRELUDE" | grep -n 'CATALYST_TEST_KILL_PHASE' | head -1 | cut -d: -f1)
+if [[ -n $STATUS_LINE && -n $KILL_LINE && $KILL_LINE -gt $STATUS_LINE ]]; then
+	pass "kill hook appears AFTER the signal flip to running (line $KILL_LINE > $STATUS_LINE)"
+else
+	fail "kill hook ordering: status flip at $STATUS_LINE, kill at $KILL_LINE"
+fi
+
+# ─── Test 5: behavioural smoke — extracted prelude with kill var exits 137 ──
+# Run the prelude bash block in a fixture. The optional bits (catalyst-comms,
+# catalyst-session) all guard with `[[ -x ... ]]` so an empty PLUGIN_ROOT
+# directory degrades gracefully.
+echo ""
+echo "Test 5: extracted SKILL.md prelude exits 137 when after-prelude kill set"
+fresh_env t5
+PRELUDE_DIR="${TEST_DIR}/prelude"
+mkdir -p "$PRELUDE_DIR" "${ORCH_DIR}/workers/CTL-9"
+# Pre-seed the signal file with a dispatched status — the prelude flips it to
+# running.
+cat >"${ORCH_DIR}/workers/CTL-9/phase-implement.json" <<EOF
+{"ticket":"CTL-9","phase":"implement","status":"dispatched","bg_job_id":null,"orchestrator":"orch-test"}
+EOF
+# Extract the prelude code block from SKILL.md (between the first ```bash and the next ```).
+awk '
+  /^```bash$/ && !found { found=1; next }
+  /^```$/ && found && !done { done=1; exit }
+  found && !done { print }
+' "$SKILL_MD" > "${PRELUDE_DIR}/prelude.sh"
+# Append the planned kill-hook check — RED test, this is what we expect the
+# real SKILL.md to contain once Phase 1 lands. Once SKILL.md has the hook,
+# this append becomes a no-op duplicate so it stays harmless.
+# (Once green, the extracted prelude itself contains the hook — appending it
+# again is idempotent: a second matching check still exits 137.)
+chmod +x "${PRELUDE_DIR}/prelude.sh"
+(
+	cd "${TEST_DIR}/proj"
+	CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
+	CATALYST_ORCHESTRATOR_ID="orch-test" \
+	CATALYST_PHASE="implement" \
+	CATALYST_TICKET="CTL-9" \
+	CATALYST_TEST_KILL_PHASE="implement:after-prelude" \
+	PLUGIN_ROOT="${TEST_DIR}/nonexistent-plugin-root" \
+		bash "${PRELUDE_DIR}/prelude.sh" >"${TEST_DIR}/t5.out" 2>"${TEST_DIR}/t5.err"
+)
+RC=$?
+assert_eq "137" "$RC" "extracted prelude exits 137 on after-prelude kill"
+# And the signal was flipped to running BEFORE the kill.
+STATUS=$(jq -r '.status' "${ORCH_DIR}/workers/CTL-9/phase-implement.json")
+assert_eq "running" "$STATUS" "signal status = running (flipped before kill)"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-agent-dispatch-test-kill: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -gt 0 ]] && exit 1
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch-test-kill.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch-test-kill.test.sh
@@ -24,12 +24,20 @@ PASSES=0
 SCRATCH="$(mktemp -d -t ctl-587-test-kill-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
-pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
 assert_eq() {
 	local expected="$1" actual="$2" label="$3"
-	if [[ $expected == "$actual" ]]; then pass "$label"
-	else fail "$label — expected '$expected', got '$actual'"
+	if [[ $expected == "$actual" ]]; then
+		pass "$label"
+	else
+		fail "$label — expected '$expected', got '$actual'"
 	fi
 }
 
@@ -76,7 +84,7 @@ fresh_env() {
 echo "Test 1: CATALYST_TEST_KILL_PHASE=implement:before-launch aborts before spawn"
 fresh_env t1
 (
-	cd "${TEST_DIR}/proj"
+	cd "${TEST_DIR}/proj" || exit
 	CATALYST_TEST_KILL_PHASE="implement:before-launch" \
 		"$DISPATCH" --phase implement --ticket CTL-9 \
 		--orch-dir "$ORCH_DIR" --orch-id orch-test \
@@ -107,7 +115,7 @@ echo ""
 echo "Test 2: CATALYST_TEST_KILL_PHASE with non-matching phase falls through"
 fresh_env t2
 (
-	cd "${TEST_DIR}/proj"
+	cd "${TEST_DIR}/proj" || exit
 	CATALYST_TEST_KILL_PHASE="research:before-launch" \
 		"$DISPATCH" --phase implement --ticket CTL-9 \
 		--orch-dir "$ORCH_DIR" --orch-id orch-test \
@@ -127,7 +135,7 @@ echo "Test 3: env unset → dispatcher behaves identically to pre-CTL-587"
 fresh_env t3
 unset CATALYST_TEST_KILL_PHASE
 (
-	cd "${TEST_DIR}/proj"
+	cd "${TEST_DIR}/proj" || exit
 	"$DISPATCH" --phase implement --ticket CTL-9 \
 		--orch-dir "$ORCH_DIR" --orch-id orch-test \
 		>"${TEST_DIR}/t3.out" 2>"${TEST_DIR}/t3.err"
@@ -186,7 +194,7 @@ awk '
   /^```bash$/ && !found { found=1; next }
   /^```$/ && found && !done { done=1; exit }
   found && !done { print }
-' "$SKILL_MD" > "${PRELUDE_DIR}/prelude.sh"
+' "$SKILL_MD" >"${PRELUDE_DIR}/prelude.sh"
 # Append the planned kill-hook check — RED test, this is what we expect the
 # real SKILL.md to contain once Phase 1 lands. Once SKILL.md has the hook,
 # this append becomes a no-op duplicate so it stays harmless.
@@ -194,13 +202,13 @@ awk '
 # again is idempotent: a second matching check still exits 137.)
 chmod +x "${PRELUDE_DIR}/prelude.sh"
 (
-	cd "${TEST_DIR}/proj"
+	cd "${TEST_DIR}/proj" || exit
 	CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
-	CATALYST_ORCHESTRATOR_ID="orch-test" \
-	CATALYST_PHASE="implement" \
-	CATALYST_TICKET="CTL-9" \
-	CATALYST_TEST_KILL_PHASE="implement:after-prelude" \
-	PLUGIN_ROOT="${TEST_DIR}/nonexistent-plugin-root" \
+		CATALYST_ORCHESTRATOR_ID="orch-test" \
+		CATALYST_PHASE="implement" \
+		CATALYST_TICKET="CTL-9" \
+		CATALYST_TEST_KILL_PHASE="implement:after-prelude" \
+		PLUGIN_ROOT="${TEST_DIR}/nonexistent-plugin-root" \
 		bash "${PRELUDE_DIR}/prelude.sh" >"${TEST_DIR}/t5.out" 2>"${TEST_DIR}/t5.err"
 )
 RC=$?

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -42,12 +42,7 @@ function safeParse(line) {
 // match the optional filters. Used by recovery.mjs to enforce MAX_REVIVES on a
 // per-ticket basis. orchId is currently always set in the envelope but the
 // match is tolerant of a missing attribute on either side (defensive default).
-export function countReviveEvents({
-  ticket,
-  orchId,
-  since,
-  path = getEventLogPath(),
-} = {}) {
+export function countReviveEvents({ ticket, orchId, since, path = getEventLogPath() } = {}) {
   if (!ticket) throw new Error("countReviveEvents: ticket required");
   const target = `phase.implement.revive.${ticket}`;
   let n = 0;

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -1,0 +1,90 @@
+// event-scan.mjs — CTL-587 historical scan of execution-core's events.jsonl.
+//
+// Two count queries no existing consumer provides:
+//   - countReviveEvents({ticket, orchId, since, path}) — the per-ticket revive
+//     budget for recovery.mjs.
+//   - countDistinctRevivingTickets({windowMs, now, path}) — the storm-breaker
+//     that prevents a chain reaction when many tickets revive at once.
+//
+// Both are read-only synchronous scans of the entire events.jsonl. Pure: no
+// caching, no cursor. The file is not yet hot enough to justify either. A
+// follow-up (sized as "What We're NOT Doing" in the plan) adds a tailed cache
+// keyed on `(file size, last line ts)` if the file grows beyond ~50 MB.
+//
+// Parse failures on a line are skipped silently (best-effort). A missing log
+// returns 0 from both functions — the cold-start path the daemon hits before
+// the first event lands.
+
+import { existsSync, readFileSync } from "node:fs";
+import { getEventLogPath } from "./config.mjs";
+
+const REVIVE_NAME_PREFIX = "phase.implement.revive.";
+
+function* readLinesSync(path) {
+  if (!existsSync(path)) return;
+  // events.jsonl is at MB-scale today; the whole-file read is simpler than a
+  // stream and the OS page cache makes repeat scans cheap.
+  const buf = readFileSync(path, "utf8");
+  for (const line of buf.split(/\r?\n/)) {
+    if (line) yield line;
+  }
+}
+
+function safeParse(line) {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+// countReviveEvents — number of phase.implement.revive.<ticket> envelopes that
+// match the optional filters. Used by recovery.mjs to enforce MAX_REVIVES on a
+// per-ticket basis. orchId is currently always set in the envelope but the
+// match is tolerant of a missing attribute on either side (defensive default).
+export function countReviveEvents({
+  ticket,
+  orchId,
+  since,
+  path = getEventLogPath(),
+} = {}) {
+  if (!ticket) throw new Error("countReviveEvents: ticket required");
+  const target = `phase.implement.revive.${ticket}`;
+  let n = 0;
+  for (const line of readLinesSync(path)) {
+    const ev = safeParse(line);
+    if (!ev) continue;
+    const name = ev?.attributes?.["event.name"];
+    if (name !== target) continue;
+    if (orchId && ev?.attributes?.["catalyst.orchestration"] !== orchId) continue;
+    if (since && ev?.ts && ev.ts < since) continue;
+    n++;
+  }
+  return n;
+}
+
+// countDistinctRevivingTickets — unique tickets that have any revive event
+// inside `windowMs` of `now()`. Used by recovery.mjs to suppress revives when
+// the storm-breaker is open (default >3 distinct tickets in the last 10min).
+// The shape `now: () => number` matches the recovery.mjs convention so tests
+// can pin the clock.
+export function countDistinctRevivingTickets({
+  windowMs,
+  now = Date.now,
+  path = getEventLogPath(),
+} = {}) {
+  if (!windowMs) throw new Error("countDistinctRevivingTickets: windowMs required");
+  const cutoff = now() - windowMs;
+  const seen = new Set();
+  for (const line of readLinesSync(path)) {
+    const ev = safeParse(line);
+    if (!ev) continue;
+    const name = ev?.attributes?.["event.name"];
+    if (typeof name !== "string" || !name.startsWith(REVIVE_NAME_PREFIX)) continue;
+    const tsMs = Date.parse(ev?.ts || "");
+    if (!Number.isFinite(tsMs) || tsMs < cutoff) continue;
+    const ticket = ev?.attributes?.["event.label"];
+    if (ticket) seen.add(ticket);
+  }
+  return seen.size;
+}

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -1,0 +1,181 @@
+// event-scan.test.mjs — CTL-587 historical-scan utility for events.jsonl.
+//
+// Two pure functions:
+//   countReviveEvents({ticket, orchId, since, path})  → number
+//   countDistinctRevivingTickets({windowMs, now, path}) → number
+// Both line-buffer-read the entire events.jsonl, skip malformed lines, and
+// return 0 when the file is missing.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test event-scan.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  countReviveEvents,
+  countDistinctRevivingTickets,
+} from "./event-scan.mjs";
+
+// makeEvent — minimal envelope mirroring buildEventEnvelope in recovery.mjs.
+function makeEvent({
+  phase = "implement",
+  action = "revive",
+  ticket,
+  orchId,
+  ts,
+}) {
+  return JSON.stringify({
+    ts,
+    attributes: {
+      "event.name": `phase.${phase}.${action}.${ticket}`,
+      "event.entity": "phase",
+      "event.action": action,
+      "event.label": ticket,
+      "catalyst.orchestration": orchId ?? ticket,
+      "linear.issue.identifier": ticket,
+    },
+    body: { payload: { phase, ticket, status: action } },
+  });
+}
+
+function tempLog(lines) {
+  const dir = mkdtempSync(join(tmpdir(), "evtscan-"));
+  const path = join(dir, "events.jsonl");
+  if (lines !== undefined) writeFileSync(path, lines.join("\n") + "\n");
+  return { dir, path };
+}
+
+describe("countReviveEvents", () => {
+  test("missing event log returns 0 (cold start)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evtscan-"));
+    expect(
+      countReviveEvents({ ticket: "CTL-9", path: join(dir, "events.jsonl") }),
+    ).toBe(0);
+  });
+
+  test("counts only the matching ticket + phase + action", () => {
+    const { path } = tempLog([
+      makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:00:00Z" }), // match
+      makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:01:00Z" }), // match
+      makeEvent({ ticket: "CTL-10", ts: "2026-05-24T00:00:00Z" }), // diff ticket
+      makeEvent({ ticket: "CTL-9", action: "reclaim", ts: "2026-05-24T00:02:00Z" }), // diff action
+      makeEvent({ ticket: "CTL-9", phase: "plan", ts: "2026-05-24T00:03:00Z" }), // diff phase
+      "not json", // skipped
+      "", // skipped (empty)
+    ]);
+    expect(countReviveEvents({ ticket: "CTL-9", path })).toBe(2);
+  });
+
+  test("respects orchId filter when set", () => {
+    const { path } = tempLog([
+      makeEvent({ ticket: "CTL-9", orchId: "orchA", ts: "2026-05-24T00:00:00Z" }),
+      makeEvent({ ticket: "CTL-9", orchId: "orchB", ts: "2026-05-24T00:01:00Z" }),
+      makeEvent({ ticket: "CTL-9", orchId: "orchA", ts: "2026-05-24T00:02:00Z" }),
+    ]);
+    expect(countReviveEvents({ ticket: "CTL-9", orchId: "orchA", path })).toBe(2);
+    expect(countReviveEvents({ ticket: "CTL-9", orchId: "orchB", path })).toBe(1);
+  });
+
+  test("respects since filter — only events at or after `since`", () => {
+    const { path } = tempLog([
+      makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:00:00Z" }),
+      makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:05:00Z" }),
+      makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:10:00Z" }),
+    ]);
+    expect(
+      countReviveEvents({ ticket: "CTL-9", path, since: "2026-05-24T00:04:00Z" }),
+    ).toBe(2);
+  });
+
+  test("throws when ticket is missing (programmer error)", () => {
+    const { path } = tempLog([]);
+    expect(() => countReviveEvents({ path })).toThrow();
+  });
+
+  test("tolerates parse errors and partial envelopes", () => {
+    const { path } = tempLog([
+      "{",
+      JSON.stringify({ ts: "x", body: {} }), // no attributes
+      JSON.stringify({ ts: "x", attributes: {} }), // no event.name
+      makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:00:00Z" }), // ok
+    ]);
+    expect(countReviveEvents({ ticket: "CTL-9", path })).toBe(1);
+  });
+});
+
+describe("countDistinctRevivingTickets", () => {
+  test("counts unique tickets in the time window", () => {
+    const nowMs = Date.parse("2026-05-24T00:10:00Z");
+    const { path } = tempLog([
+      makeEvent({ ticket: "CTL-1", ts: "2026-05-24T00:00:00Z" }), // 10min ago — IN
+      makeEvent({ ticket: "CTL-2", ts: "2026-05-24T00:05:00Z" }), // 5min ago — IN
+      makeEvent({ ticket: "CTL-1", ts: "2026-05-24T00:06:00Z" }), // dup ticket
+      makeEvent({ ticket: "CTL-3", ts: "2026-05-23T23:55:00Z" }), // 15min ago — OUT
+    ]);
+    expect(
+      countDistinctRevivingTickets({
+        windowMs: 10 * 60 * 1000,
+        now: () => nowMs,
+        path,
+      }),
+    ).toBe(2);
+  });
+
+  test("returns 0 for missing log (cold start, no events.jsonl yet)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evtscan-"));
+    expect(
+      countDistinctRevivingTickets({
+        windowMs: 600_000,
+        now: () => 0,
+        path: join(dir, "no-such-file.jsonl"),
+      }),
+    ).toBe(0);
+  });
+
+  test("ignores non-revive events even when in-window", () => {
+    const nowMs = Date.parse("2026-05-24T00:10:00Z");
+    const { path } = tempLog([
+      makeEvent({ ticket: "CTL-1", ts: "2026-05-24T00:05:00Z" }), // revive — IN
+      makeEvent({
+        ticket: "CTL-2",
+        action: "reclaim",
+        ts: "2026-05-24T00:05:00Z",
+      }), // not a revive — skip
+      makeEvent({
+        ticket: "CTL-3",
+        action: "escalated",
+        ts: "2026-05-24T00:05:00Z",
+      }), // not a revive — skip
+    ]);
+    expect(
+      countDistinctRevivingTickets({
+        windowMs: 10 * 60 * 1000,
+        now: () => nowMs,
+        path,
+      }),
+    ).toBe(1);
+  });
+
+  test("throws when windowMs is missing", () => {
+    const { path } = tempLog([]);
+    expect(() =>
+      countDistinctRevivingTickets({ now: () => 0, path }),
+    ).toThrow();
+  });
+
+  test("ignores events with unparseable ts", () => {
+    const nowMs = Date.parse("2026-05-24T00:10:00Z");
+    const { path } = tempLog([
+      makeEvent({ ticket: "CTL-1", ts: "not-a-date" }),
+      makeEvent({ ticket: "CTL-2", ts: "2026-05-24T00:05:00Z" }), // 5min ago — IN
+    ]);
+    expect(
+      countDistinctRevivingTickets({
+        windowMs: 10 * 60 * 1000,
+        now: () => nowMs,
+        path,
+      }),
+    ).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -12,19 +12,10 @@ import { describe, test, expect } from "bun:test";
 import { writeFileSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import {
-  countReviveEvents,
-  countDistinctRevivingTickets,
-} from "./event-scan.mjs";
+import { countReviveEvents, countDistinctRevivingTickets } from "./event-scan.mjs";
 
 // makeEvent — minimal envelope mirroring buildEventEnvelope in recovery.mjs.
-function makeEvent({
-  phase = "implement",
-  action = "revive",
-  ticket,
-  orchId,
-  ts,
-}) {
+function makeEvent({ phase = "implement", action = "revive", ticket, orchId, ts }) {
   return JSON.stringify({
     ts,
     attributes: {
@@ -49,9 +40,7 @@ function tempLog(lines) {
 describe("countReviveEvents", () => {
   test("missing event log returns 0 (cold start)", () => {
     const dir = mkdtempSync(join(tmpdir(), "evtscan-"));
-    expect(
-      countReviveEvents({ ticket: "CTL-9", path: join(dir, "events.jsonl") }),
-    ).toBe(0);
+    expect(countReviveEvents({ ticket: "CTL-9", path: join(dir, "events.jsonl") })).toBe(0);
   });
 
   test("counts only the matching ticket + phase + action", () => {
@@ -83,9 +72,7 @@ describe("countReviveEvents", () => {
       makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:05:00Z" }),
       makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:10:00Z" }),
     ]);
-    expect(
-      countReviveEvents({ ticket: "CTL-9", path, since: "2026-05-24T00:04:00Z" }),
-    ).toBe(2);
+    expect(countReviveEvents({ ticket: "CTL-9", path, since: "2026-05-24T00:04:00Z" })).toBe(2);
   });
 
   test("throws when ticket is missing (programmer error)", () => {
@@ -118,7 +105,7 @@ describe("countDistinctRevivingTickets", () => {
         windowMs: 10 * 60 * 1000,
         now: () => nowMs,
         path,
-      }),
+      })
     ).toBe(2);
   });
 
@@ -129,7 +116,7 @@ describe("countDistinctRevivingTickets", () => {
         windowMs: 600_000,
         now: () => 0,
         path: join(dir, "no-such-file.jsonl"),
-      }),
+      })
     ).toBe(0);
   });
 
@@ -153,15 +140,13 @@ describe("countDistinctRevivingTickets", () => {
         windowMs: 10 * 60 * 1000,
         now: () => nowMs,
         path,
-      }),
+      })
     ).toBe(1);
   });
 
   test("throws when windowMs is missing", () => {
     const { path } = tempLog([]);
-    expect(() =>
-      countDistinctRevivingTickets({ now: () => 0, path }),
-    ).toThrow();
+    expect(() => countDistinctRevivingTickets({ now: () => 0, path })).toThrow();
   });
 
   test("ignores events with unparseable ts", () => {
@@ -175,7 +160,7 @@ describe("countDistinctRevivingTickets", () => {
         windowMs: 10 * 60 * 1000,
         now: () => nowMs,
         path,
-      }),
+      })
     ).toBe(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -1,0 +1,265 @@
+// CTL-587 end-to-end integration tests.
+//
+// Exercises the full revive loop through schedulerTick + the real
+// reclaimDeadWorkIfPossible, with the daemon-side I/O seams (statJob,
+// emitComplete, applyStalledLabel, dispatch, killBgJob) stubbed. The intent is
+// to pin the wiring: a dead worker on first strike → 'revived' + new dispatch;
+// budget exhausted → 'escalated' + needs-human; storm-breaker open →
+// 'revive-suppressed' + no dispatch. The earlier per-module unit tests cover
+// the branch matrix; this file proves the seams compose.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test integration-ctl-587.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  appendFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { schedulerTick } from "./scheduler.mjs";
+import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
+
+let orchDir;
+let catalystDir;
+let prevCatalystDir;
+let eventLogPath;
+
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "ctl587-int-"));
+  process.env.CATALYST_DIR = catalystDir;
+  // Pre-create the events dir so appends in the recovery audit path land
+  // somewhere predictable. The default event-log path resolves under
+  // CATALYST_DIR/events/<YYYY-MM>.jsonl — we seed it explicitly for the
+  // budget-exhaustion test.
+  mkdirSync(join(catalystDir, "events"), { recursive: true });
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  eventLogPath = join(catalystDir, "events", `${ym}.jsonl`);
+  orchDir = join(catalystDir, "orch");
+  mkdirSync(join(orchDir, "workers"), { recursive: true });
+});
+
+afterEach(() => {
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+function seedSignal(ticket, phase, body) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, ...body }),
+  );
+}
+
+function appendEvent(envelope) {
+  appendFileSync(eventLogPath, JSON.stringify(envelope) + "\n");
+}
+
+function makeReviveEnvelope({ ticket, ts }) {
+  return {
+    ts,
+    attributes: {
+      "event.name": `phase.implement.revive.${ticket}`,
+      "event.entity": "phase",
+      "event.action": "revive",
+      "event.label": ticket,
+      "catalyst.orchestration": ticket,
+      "linear.issue.identifier": ticket,
+    },
+    body: { payload: { phase: "implement", ticket, status: "revive" } },
+  };
+}
+
+describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
+  test("first-strike: dead worker → 'revived' on next schedulerTick", () => {
+    seedSignal("CTL-587-A", "implement", {
+      status: "running",
+      bg_job_id: "nonexistent-bg-id",
+      liveness: { kind: "bg", value: "nonexistent-bg-id" },
+      orchestrator: "test-orch",
+    });
+
+    const reviveDispatchCalls = [];
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: {
+        applyPhaseStatus: () => {},
+        applyTerminalDone: () => {},
+        applyLabel: () => ({ applied: true }),
+      },
+      teardownWorktree: () => true,
+      // Capture the call but defer to the real reclaim function via injected
+      // seams. We exercise the wiring here, not the internal branch matrix
+      // (covered exhaustively in recovery.test.mjs).
+      reclaimDeadWork: (od, sig, opts) =>
+        reclaimDeadWorkIfPossible(od, sig, {
+          ...opts,
+          // bg job dir is gone — classifyWorker → 'dead' → effectivelyDead
+          statJob: () => null,
+          probes: { implement: () => false }, // work NOT done
+          reviveDispatch: (args) => {
+            reviveDispatchCalls.push(args);
+            return { code: 0 };
+          },
+          applyStalledLabel: () => ({ applied: true }),
+          killBgJob: () => {},
+          // No prior revive events.
+          countReviveEvents: () => 0,
+          countDistinctRevivingTickets: () => 1,
+        }),
+    });
+
+    expect(result.revived).toEqual([
+      { ticket: "CTL-587-A", phase: "implement" },
+    ]);
+    expect(result.escalated).toEqual([]);
+    expect(reviveDispatchCalls).toHaveLength(1);
+    expect(reviveDispatchCalls[0].ticket).toBe("CTL-587-A");
+    expect(reviveDispatchCalls[0].phase).toBe("implement");
+    // Marker file was written (operator-friendly forensic crumb).
+    expect(
+      existsSync(join(orchDir, "workers", "CTL-587-A", ".revive-1.applied")),
+    ).toBe(true);
+  });
+
+  test("budget exhausted: 2 prior revive events → 'escalated' + needs-human label", () => {
+    seedSignal("CTL-587-B", "implement", {
+      status: "running",
+      bg_job_id: "nonexistent-bg-id",
+      liveness: { kind: "bg", value: "nonexistent-bg-id" },
+      orchestrator: "CTL-587-B",
+    });
+    // Pre-seed events.jsonl with two prior revives so the budget is exhausted.
+    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-B", ts: "2026-05-23T00:00:00Z" }));
+    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-B", ts: "2026-05-23T00:05:00Z" }));
+
+    const labelCalls = [];
+    const reviveDispatchCalls = [];
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: {
+        applyPhaseStatus: () => {},
+        applyTerminalDone: () => {},
+        applyLabel: () => ({ applied: true }),
+      },
+      teardownWorktree: () => true,
+      reclaimDeadWork: (od, sig, opts) =>
+        reclaimDeadWorkIfPossible(od, sig, {
+          ...opts,
+          statJob: () => null, // bg dead
+          probes: { implement: () => false }, // work NOT done
+          reviveDispatch: (args) => {
+            reviveDispatchCalls.push(args);
+            return { code: 0 };
+          },
+          applyStalledLabel: ({ ticket }) => {
+            labelCalls.push(ticket);
+            return { applied: true };
+          },
+          killBgJob: () => {},
+          // Use the default countReviveEvents → reads the real events.jsonl
+          // we seeded above (no override).
+        }),
+    });
+
+    expect(result.escalated).toEqual([
+      { ticket: "CTL-587-B", phase: "implement" },
+    ]);
+    expect(result.revived).toEqual([]);
+    expect(reviveDispatchCalls).toHaveLength(0);
+    expect(labelCalls).toEqual(["CTL-587-B"]);
+  });
+
+  test("storm-breaker open: 4 distinct tickets reviving → 'revive-suppressed', no dispatch", () => {
+    seedSignal("CTL-587-C", "implement", {
+      status: "running",
+      bg_job_id: "nonexistent-bg-id",
+      liveness: { kind: "bg", value: "nonexistent-bg-id" },
+      orchestrator: "CTL-587-C",
+    });
+
+    const reviveDispatchCalls = [];
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: {
+        applyPhaseStatus: () => {},
+        applyTerminalDone: () => {},
+        applyLabel: () => ({ applied: true }),
+      },
+      teardownWorktree: () => true,
+      reclaimDeadWork: (od, sig, opts) =>
+        reclaimDeadWorkIfPossible(od, sig, {
+          ...opts,
+          statJob: () => null,
+          probes: { implement: () => false },
+          reviveDispatch: (args) => {
+            reviveDispatchCalls.push(args);
+            return { code: 0 };
+          },
+          applyStalledLabel: () => ({ applied: true }),
+          killBgJob: () => {},
+          countReviveEvents: () => 0,
+          countDistinctRevivingTickets: () => 4, // > STORM_THRESHOLD=3
+        }),
+    });
+
+    expect(result.reviveSuppressed).toEqual([
+      { ticket: "CTL-587-C", phase: "implement" },
+    ]);
+    expect(reviveDispatchCalls).toHaveLength(0);
+    expect(
+      existsSync(join(orchDir, "workers", "CTL-587-C", ".revive-1.applied")),
+    ).toBe(false); // no marker on suppression
+  });
+
+  test("no-probe phase (pr) on a dead worker → 'escalated' immediately", () => {
+    seedSignal("CTL-587-D", "pr", {
+      status: "running",
+      bg_job_id: "nonexistent-bg-id",
+      liveness: { kind: "bg", value: "nonexistent-bg-id" },
+      orchestrator: "CTL-587-D",
+    });
+
+    const labelCalls = [];
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: {
+        applyPhaseStatus: () => {},
+        applyTerminalDone: () => {},
+        applyLabel: () => ({ applied: true }),
+      },
+      teardownWorktree: () => true,
+      reclaimDeadWork: (od, sig, opts) =>
+        reclaimDeadWorkIfPossible(od, sig, {
+          ...opts,
+          statJob: () => null, // bg dead
+          // Default probes registry — only 'implement' has a probe; pr does not.
+          applyStalledLabel: ({ ticket }) => {
+            labelCalls.push(ticket);
+            return { applied: true };
+          },
+          reviveDispatch: () => {
+            throw new Error("revive must not be called for no-probe escalation");
+          },
+        }),
+    });
+
+    expect(result.escalated).toEqual([
+      { ticket: "CTL-587-D", phase: "pr" },
+    ]);
+    expect(labelCalls).toEqual(["CTL-587-D"]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -11,14 +11,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test integration-ctl-587.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import {
-  mkdtempSync,
-  rmSync,
-  mkdirSync,
-  writeFileSync,
-  existsSync,
-  appendFileSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, appendFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { schedulerTick } from "./scheduler.mjs";
@@ -54,10 +47,7 @@ afterEach(() => {
 function seedSignal(ticket, phase, body) {
   const dir = join(orchDir, "workers", ticket);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    join(dir, `phase-${phase}.json`),
-    JSON.stringify({ ticket, phase, ...body }),
-  );
+  writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, ...body }));
 }
 
 function appendEvent(envelope) {
@@ -119,17 +109,13 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         }),
     });
 
-    expect(result.revived).toEqual([
-      { ticket: "CTL-587-A", phase: "implement" },
-    ]);
+    expect(result.revived).toEqual([{ ticket: "CTL-587-A", phase: "implement" }]);
     expect(result.escalated).toEqual([]);
     expect(reviveDispatchCalls).toHaveLength(1);
     expect(reviveDispatchCalls[0].ticket).toBe("CTL-587-A");
     expect(reviveDispatchCalls[0].phase).toBe("implement");
     // Marker file was written (operator-friendly forensic crumb).
-    expect(
-      existsSync(join(orchDir, "workers", "CTL-587-A", ".revive-1.applied")),
-    ).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-587-A", ".revive-1.applied"))).toBe(true);
   });
 
   test("budget exhausted: 2 prior revive events → 'escalated' + needs-human label", () => {
@@ -173,9 +159,7 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         }),
     });
 
-    expect(result.escalated).toEqual([
-      { ticket: "CTL-587-B", phase: "implement" },
-    ]);
+    expect(result.escalated).toEqual([{ ticket: "CTL-587-B", phase: "implement" }]);
     expect(result.revived).toEqual([]);
     expect(reviveDispatchCalls).toHaveLength(0);
     expect(labelCalls).toEqual(["CTL-587-B"]);
@@ -215,13 +199,9 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         }),
     });
 
-    expect(result.reviveSuppressed).toEqual([
-      { ticket: "CTL-587-C", phase: "implement" },
-    ]);
+    expect(result.reviveSuppressed).toEqual([{ ticket: "CTL-587-C", phase: "implement" }]);
     expect(reviveDispatchCalls).toHaveLength(0);
-    expect(
-      existsSync(join(orchDir, "workers", "CTL-587-C", ".revive-1.applied")),
-    ).toBe(false); // no marker on suppression
+    expect(existsSync(join(orchDir, "workers", "CTL-587-C", ".revive-1.applied"))).toBe(false); // no marker on suppression
   });
 
   test("no-probe phase (pr) on a dead worker → 'escalated' immediately", () => {
@@ -257,9 +237,7 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         }),
     });
 
-    expect(result.escalated).toEqual([
-      { ticket: "CTL-587-D", phase: "pr" },
-    ]);
+    expect(result.escalated).toEqual([{ ticket: "CTL-587-D", phase: "pr" }]);
     expect(labelCalls).toEqual(["CTL-587-D"]);
   });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { schedulerTick } from "./scheduler.mjs";
 import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
+import { countReviveEvents } from "./event-scan.mjs";
 
 let orchDir;
 let catalystDir;
@@ -25,6 +26,13 @@ let eventLogPath;
 beforeEach(() => {
   prevCatalystDir = process.env.CATALYST_DIR;
   catalystDir = mkdtempSync(join(tmpdir(), "ctl587-int-"));
+  // Safety: refuse to run if the temp path somehow escaped tmpdir() — the
+  // test writes through default-real event-log paths and a misconfigured
+  // CATALYST_DIR could dirty the host's real ~/.catalyst/events/. Pin the
+  // contract loudly rather than silently corrupting an operator's log.
+  if (!catalystDir.startsWith(tmpdir())) {
+    throw new Error(`integration test refused: catalystDir not under tmpdir: ${catalystDir}`);
+  }
   process.env.CATALYST_DIR = catalystDir;
   // Pre-create the events dir so appends in the recovery audit path land
   // somewhere predictable. The default event-log path resolves under
@@ -74,7 +82,6 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     seedSignal("CTL-587-A", "implement", {
       status: "running",
       bg_job_id: "nonexistent-bg-id",
-      liveness: { kind: "bg", value: "nonexistent-bg-id" },
       orchestrator: "test-orch",
     });
 
@@ -88,9 +95,11 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         applyLabel: () => ({ applied: true }),
       },
       teardownWorktree: () => true,
-      // Capture the call but defer to the real reclaim function via injected
-      // seams. We exercise the wiring here, not the internal branch matrix
-      // (covered exhaustively in recovery.test.mjs).
+      // Defer to the real reclaim function — the per-tick I/O seams that
+      // would touch the filesystem are stubbed, but the real
+      // defaultAppendReviveEvent runs against the temp events.jsonl. The
+      // round-trip assertion at the end of the test confirms the envelope
+      // shape this writes matches what countReviveEvents reads.
       reclaimDeadWork: (od, sig, opts) =>
         reclaimDeadWorkIfPossible(od, sig, {
           ...opts,
@@ -116,13 +125,16 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     expect(reviveDispatchCalls[0].phase).toBe("implement");
     // Marker file was written (operator-friendly forensic crumb).
     expect(existsSync(join(orchDir, "workers", "CTL-587-A", ".revive-1.applied"))).toBe(true);
+    // Envelope round-trip: the real defaultAppendReviveEvent wrote a
+    // phase.implement.revive.CTL-587-A envelope; countReviveEvents reads it
+    // back. A field-name regression in buildEventEnvelope would break this.
+    expect(countReviveEvents({ ticket: "CTL-587-A", path: eventLogPath })).toBe(1);
   });
 
   test("budget exhausted: 2 prior revive events → 'escalated' + needs-human label", () => {
     seedSignal("CTL-587-B", "implement", {
       status: "running",
       bg_job_id: "nonexistent-bg-id",
-      liveness: { kind: "bg", value: "nonexistent-bg-id" },
       orchestrator: "CTL-587-B",
     });
     // Pre-seed events.jsonl with two prior revives so the budget is exhausted.
@@ -169,7 +181,6 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     seedSignal("CTL-587-C", "implement", {
       status: "running",
       bg_job_id: "nonexistent-bg-id",
-      liveness: { kind: "bg", value: "nonexistent-bg-id" },
       orchestrator: "CTL-587-C",
     });
 
@@ -208,7 +219,6 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     seedSignal("CTL-587-D", "pr", {
       status: "running",
       bg_job_id: "nonexistent-bg-id",
-      liveness: { kind: "bg", value: "nonexistent-bg-id" },
       orchestrator: "CTL-587-D",
     });
 

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -88,6 +88,24 @@ export function fetchTicketState(identifier, { exec = defaultExec } = {}) {
   }
 }
 
+// fetchTicketLabels — current label-name list for one ticket, or null on any
+// failure. CTL-587: used by linear-write.mjs::applyLabel for the
+// verify-write-landed step that closes the silent-success gap in linearis
+// label writes (memory project_linear_transition_silent_success). The shape
+// `labels.nodes[].name` is the Linear API contract — confirmed by
+// orch-monitor/lib/linear.ts and pre-assign-migrations.sh. null is the
+// "did not land — retry next tick" signal callers interpret as verify-failed.
+export function fetchTicketLabels(identifier, { exec = defaultExec } = {}) {
+  const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+  if (code !== 0) return null;
+  try {
+    const node = JSON.parse(stdout);
+    return node?.labels?.nodes?.map((n) => n.name) ?? [];
+  } catch {
+    return null;
+  }
+}
+
 // runEligibleQuery — run the query, parse + normalize, apply the priority
 // floor. A non-zero linearis exit THROWS (never a silent []): a silent empty
 // would let one failed poll flatten a project's eligible set to zero. The

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -2,7 +2,12 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test linear-query.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { buildLinearisArgs, runEligibleQuery, fetchTicketState } from "./linear-query.mjs";
+import {
+  buildLinearisArgs,
+  runEligibleQuery,
+  fetchTicketState,
+  fetchTicketLabels,
+} from "./linear-query.mjs";
 
 // A fake exec returning a canned linearis result. `exec(cmd, args)` ->
 // { code, stdout, stderr } — the injectable seam runEligibleQuery uses so a
@@ -207,5 +212,62 @@ describe("fetchTicketState", () => {
       stderr: "",
     });
     expect(fetchTicketState("CTL-99", { exec })).toBe("Done");
+  });
+});
+
+// CTL-587 — fetchTicketLabels reads back the current label list for a ticket.
+// Used by applyLabel's verify-write-landed step to close the silent-success
+// gap (linearis can exit 0 without the label actually landing — see memory
+// project_linear_transition_silent_success).
+describe("fetchTicketLabels", () => {
+  test("returns label names from linearis JSON", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({
+        identifier: "CTL-9",
+        labels: { nodes: [{ name: "triaged" }, { name: "needs-human" }] },
+      }),
+      stderr: "",
+    });
+    expect(fetchTicketLabels("CTL-9", { exec })).toEqual(["triaged", "needs-human"]);
+  });
+
+  test("returns [] when labels.nodes is empty", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-9", labels: { nodes: [] } }),
+      stderr: "",
+    });
+    expect(fetchTicketLabels("CTL-9", { exec })).toEqual([]);
+  });
+
+  test("returns null on a non-zero linearis exit (read failure → retry next tick)", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "boom" });
+    expect(fetchTicketLabels("CTL-9", { exec })).toBeNull();
+  });
+
+  test("returns null on JSON parse error", () => {
+    const exec = () => ({ code: 0, stdout: "not json", stderr: "" });
+    expect(fetchTicketLabels("CTL-9", { exec })).toBeNull();
+  });
+
+  test("returns [] when labels object is missing from the response", () => {
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-9" }),
+      stderr: "",
+    });
+    expect(fetchTicketLabels("CTL-9", { exec })).toEqual([]);
+  });
+
+  test("invokes linearis issues read <id>", () => {
+    const calls = [];
+    const exec = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 0, stdout: JSON.stringify({ labels: { nodes: [] } }), stderr: "" };
+    };
+    fetchTicketLabels("CTL-9", { exec });
+    expect(calls[0].cmd).toBe("linearis");
+    expect(calls[0].args).toEqual(["issues", "read", "CTL-9"]);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { linearKeyForPhase, TERMINAL_LINEAR_KEY } from "../lib/phase-fsm.mjs";
 import { getProjectConfig } from "./registry.mjs";
 import { log } from "./config.mjs";
+import { fetchTicketLabels } from "./linear-query.mjs";
 
 // linear-transition.sh sits one directory up from execution-core/ — mirrors the
 // sibling-bin spawnSync pattern dispatch.mjs uses for orchestrate-dispatch-next.
@@ -94,13 +95,22 @@ export function applyTerminalDone({ ticket, resolveRepoRoot, exec }) {
   return runTransition({ ticket, key: TERMINAL_LINEAR_KEY, resolveRepoRoot, exec });
 }
 
-// applyLabel — additively apply a Linear label (triaged, needs-human). Best-effort:
-// `--label-mode add` is additive so a re-applied label is harmless; callers guard
-// re-application with a once-marker (scheduler.mjs) since linearis has no
-// read-compare for labels.
+// applyLabel — additively apply a Linear label (triaged, needs-human) AND verify
+// the write landed. CTL-587: per memory project_linear_transition_silent_success,
+// linearis can exit 0 on a label update that did NOT actually land (rate
+// limiting, transient API). The read-back via fetchTicketLabels closes that
+// silent-success gap: `applied: true` now means a follow-up `linearis issues
+// read` confirmed the label is on the ticket. `applied: false` comes with a
+// `reason` discriminator so callers can distinguish:
+//   - 'write-failed'   — the update itself exited non-zero (no read-back run)
+//   - 'verify-failed'  — update exited 0 but the read-back is missing the label
+//                        (the silent-success case) OR the read-back exec failed
+//   - 'exception'      — the exec itself threw
+// All three are retryable next tick: labelOnce (scheduler.mjs) only writes its
+// marker when applied: true, so a failure naturally retries.
 export function applyLabel({ ticket, label, exec = defaultExec }) {
   try {
-    const { code, stderr } = exec("linearis", [
+    const writeRes = exec("linearis", [
       "issues",
       "update",
       ticket,
@@ -109,15 +119,27 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
       "--label-mode",
       "add",
     ]);
-    if (code !== 0) {
-      log.warn({ ticket, label, code, stderr }, "linear-write: label not applied");
+    if (writeRes.code !== 0) {
+      log.warn(
+        { ticket, label, code: writeRes.code, stderr: writeRes.stderr },
+        "linear-write: label write failed (exit non-zero)"
+      );
+      return { applied: false, reason: "write-failed" };
     }
-    return { applied: code === 0 };
+    const labels = fetchTicketLabels(ticket, { exec });
+    if (!Array.isArray(labels) || !labels.includes(label)) {
+      log.warn(
+        { ticket, label, readback: labels },
+        "linear-write: label write exit-0 but read-back missing label (silent-success gap)"
+      );
+      return { applied: false, reason: "verify-failed" };
+    }
+    return { applied: true };
   } catch (err) {
     log.warn(
       { ticket, label, err: err.message },
       "linear-write: label write threw — swallowed"
     );
-    return { applied: false };
+    return { applied: false, reason: "exception" };
   }
 }

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -97,17 +97,87 @@ describe("applyTerminalDone", () => {
 });
 
 describe("applyLabel", () => {
+  // okExec returns exit-0 for BOTH the update call AND the CTL-587 read-back —
+  // the read-back returns labels.nodes containing the requested label so the
+  // existing pre-CTL-587 tests still see `applied: true`.
+  function makeOkExec(calls, { readbackLabels } = {}) {
+    return (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === "issues" && args[1] === "update") {
+        return { code: 0, stdout: JSON.stringify({ action: "transitioned" }), stderr: "" };
+      }
+      if (args[0] === "issues" && args[1] === "read") {
+        const label = args[2] === "CTL-1" ? "needs-human" : "needs-human";
+        const labels = readbackLabels ?? [{ name: label }];
+        return { code: 0, stdout: JSON.stringify({ labels: { nodes: labels } }), stderr: "" };
+      }
+      return { code: 127, stdout: "", stderr: "unexpected" };
+    };
+  }
+
   test("shells linearis issues update --labels <l> --label-mode add", () => {
     const calls = [];
-    applyLabel({ ticket: "CTL-1", label: "needs-human", exec: okExec(calls) });
+    applyLabel({ ticket: "CTL-1", label: "needs-human", exec: makeOkExec(calls) });
     const args = calls[0].args;
     expect(args.slice(0, 3)).toEqual(["issues", "update", "CTL-1"]);
     expect(args).toContain("--labels");
     expect(args[args.indexOf("--labels") + 1]).toBe("needs-human");
     expect(args[args.indexOf("--label-mode") + 1]).toBe("add");
   });
+
   test("never throws on a failed label exec", () => {
     const exec = () => ({ code: 1, stdout: "", stderr: "no such label" });
     expect(() => applyLabel({ ticket: "CTL-1", label: "needs-human", exec })).not.toThrow();
+  });
+
+  // CTL-587: verify-write-landed. Closes the silent-success gap in linearis
+  // label writes (memory project_linear_transition_silent_success): the
+  // update exits 0 but the label never lands. The read-back makes applied:true
+  // mean the label is actually on the ticket.
+  test("CTL-587: write succeeds AND read-back confirms label present → applied:true", () => {
+    const calls = [];
+    const exec = makeOkExec(calls); // read-back returns the label
+    const r = applyLabel({ ticket: "CTL-1", label: "needs-human", exec });
+    expect(r).toEqual({ applied: true });
+    expect(calls[0].args.slice(0, 2)).toEqual(["issues", "update"]);
+    expect(calls[1].args.slice(0, 2)).toEqual(["issues", "read"]);
+  });
+
+  test("CTL-587: write succeeds BUT read-back missing label → applied:false, verify-failed", () => {
+    const calls = [];
+    const exec = makeOkExec(calls, { readbackLabels: [] }); // empty labels
+    const r = applyLabel({ ticket: "CTL-1", label: "needs-human", exec });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("verify-failed");
+  });
+
+  test("CTL-587: write fails → applied:false, write-failed (NO read-back attempted)", () => {
+    const calls = [];
+    const exec = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 1, stdout: "", stderr: "rate limited" };
+    };
+    const r = applyLabel({ ticket: "CTL-1", label: "needs-human", exec });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("write-failed");
+    expect(calls).toHaveLength(1); // only the update; no read-back attempted
+  });
+
+  test("CTL-587: read-back returns null (linearis read failure) → applied:false, verify-failed", () => {
+    const exec = (cmd, args) => {
+      if (args[1] === "update") return { code: 0, stdout: "", stderr: "" };
+      if (args[1] === "read") return { code: 1, stdout: "", stderr: "" };
+      return { code: 127 };
+    };
+    const r = applyLabel({ ticket: "CTL-1", label: "needs-human", exec });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("verify-failed");
+  });
+
+  test("CTL-587: throw in exec is swallowed → applied:false (existing behaviour preserved)", () => {
+    const exec = () => {
+      throw new Error("exec died");
+    };
+    expect(applyLabel({ ticket: "CTL-1", label: "needs-human", exec }).applied).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -13,6 +13,8 @@ import {
   closeSync,
   appendFileSync,
   mkdirSync,
+  writeFileSync,
+  existsSync,
 } from "node:fs";
 import { dirname } from "node:path";
 import { join } from "node:path";
@@ -25,6 +27,12 @@ import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { WORK_DONE_PROBES, hasProbe } from "./work-done-probes.mjs";
+import { defaultDispatch } from "./dispatch.mjs";
+import { applyLabel as defaultApplyLabel } from "./linear-write.mjs";
+import {
+  countReviveEvents as defaultCountReviveEvents,
+  countDistinctRevivingTickets as defaultCountDistinctRevivingTickets,
+} from "./event-scan.mjs";
 
 // phase-agent-emit-complete sits two directories up from execution-core/.
 const EMIT_COMPLETE_BIN = fileURLToPath(
@@ -126,15 +134,13 @@ function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
   return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
 }
 
-// defaultAppendReclaimEvent — append a canonical phase.<phase>.reclaim.<ticket>
-// envelope to the event log. Shape mirrors lib/canonical-event.sh; only one
-// caller needs it, so we inline rather than wrap the bash builder. Best-effort:
-// a write failure is logged but does not abort the reclaim (the next
-// phase.<phase>.complete event still tells the story).
-function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
+// buildEventEnvelope — shared canonical-event builder for the reclaim,
+// revive, escalated, and revive-suppressed audit events (CTL-574 + CTL-587).
+// Shape mirrors lib/canonical-event.sh. Centralizing it here keeps the four
+// per-action helpers tiny and prevents shape drift between actions.
+function buildEventEnvelope({ phase, ticket, orchId, action, reason, payloadExtras = {} }) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-  const eventName = `phase.${phase}.reclaim.${ticket}`;
-  const line =
+  return (
     JSON.stringify({
       ts,
       id: randomBytes(8).toString("hex"),
@@ -148,28 +154,161 @@ function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
         "service.namespace": "catalyst",
       },
       attributes: {
-        "event.name": eventName,
+        "event.name": `phase.${phase}.${action}.${ticket}`,
         "event.entity": "phase",
-        "event.action": "reclaim",
+        "event.action": action,
         "event.label": ticket,
         "catalyst.orchestration": orchId ?? ticket,
         "linear.issue.identifier": ticket,
       },
-      body: {
-        payload: {
-          phase,
-          ticket,
-          status: "reclaim",
-          reason: "work-done-despite-dead-bg",
-        },
-      },
-    }) + "\n";
+      body: { payload: { phase, ticket, status: action, reason, ...payloadExtras } },
+    }) + "\n"
+  );
+}
+
+function appendEnvelopeBestEffort(line, kind) {
   const logPath = getEventLogPath();
   try {
     mkdirSync(dirname(logPath), { recursive: true });
     appendFileSync(logPath, line);
   } catch (err) {
-    log.warn({ err: err.message }, "reclaim-dead-work: failed to append reclaim event");
+    log.warn({ err: err.message, kind }, "recovery: event append failed");
+  }
+}
+
+// defaultAppendReclaimEvent — phase.<phase>.reclaim.<ticket>. The CTL-574 path:
+// the worker died but its work committed, so the scheduler can advance.
+function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
+  appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "reclaim",
+      reason: "work-done-despite-dead-bg",
+    }),
+    "reclaim",
+  );
+}
+
+// CTL-587: three new audit-only event helpers. The broker's PHASE_EVENT_PATTERN
+// in router.mjs only matches complete|failed|turn-cap-exhausted|skipped, so
+// revive/escalated/revive-suppressed events are deliberately ignored by the
+// orchestrator and exist purely for operator forensics + the per-ticket
+// revive counter (event-scan.mjs::countReviveEvents).
+
+function defaultAppendReviveEvent({
+  phase,
+  ticket,
+  orchId,
+  attempt,
+  reason,
+  prev_state_json_mtime,
+  prev_bg_job_id,
+}) {
+  appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "revive",
+      reason,
+      payloadExtras: { attempt, prev_state_json_mtime, prev_bg_job_id },
+    }),
+    "revive",
+  );
+}
+
+function defaultAppendEscalatedEvent({ phase, ticket, orchId, reason, final_attempt_count }) {
+  appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "escalated",
+      reason,
+      payloadExtras: { final_attempt_count },
+    }),
+    "escalated",
+  );
+}
+
+function defaultAppendReviveSuppressedEvent({
+  phase,
+  ticket,
+  orchId,
+  window_distinct_tickets,
+}) {
+  appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "revive-suppressed",
+      reason: "storm-breaker-open",
+      payloadExtras: { window_distinct_tickets, window_ms: STORM_WINDOW_MS },
+    }),
+    "revive-suppressed",
+  );
+}
+
+// CTL-587 default seams — all overridable for tests, all best-effort for prod.
+
+// defaultReviveDispatch — reset the signal to status: "stalled" first (to bypass
+// the phase-agent-dispatch idempotency guard at lines 374-395; `stalled` is the
+// single status that falls through), then call defaultDispatch. Mirrors the
+// orchestrate-revive precedent (orchestrate-revive:577-611).
+function defaultReviveDispatch({ orchDir, ticket, phase }) {
+  const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  if (existsSync(signalPath)) {
+    try {
+      const sig = JSON.parse(readFileSync(signalPath, "utf8"));
+      sig.status = "stalled";
+      sig.attentionReason = "ctl-587-revive-reset";
+      sig.updatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+      writeFileSync(signalPath, JSON.stringify(sig, null, 2));
+    } catch (err) {
+      log.warn({ ticket, phase, err: err.message }, "revive: signal reset failed");
+      return { code: 1, stdout: "", stderr: err.message };
+    }
+  }
+  return defaultDispatch({ orchDir, ticket, phase });
+}
+
+// defaultApplyStalledLabel — apply the flat `needs-human` label via the
+// CTL-587-enhanced applyLabel (which reads back to verify the write landed,
+// closing the silent-success gap per memory project_linear_transition_silent_success).
+function defaultApplyStalledLabel({ ticket }) {
+  return defaultApplyLabel({ ticket, label: "needs-human" });
+}
+
+// defaultKillBgJob — best-effort `kill -9` of a lingering bg pid. Gated by the
+// caller on KILL_RECENT_ACTIVITY_MS so we never SIGKILL a worker whose
+// state.json was touched recently. The bg-job pid lives in
+// ~/.claude/jobs/<id>/pid (Claude Code job-state convention); a missing pid
+// file is the normal case for a reaped job.
+function defaultKillBgJob({ bgJobId }) {
+  if (!bgJobId) return;
+  try {
+    const pidPath = join(getJobsRoot(), bgJobId, "pid");
+    if (!existsSync(pidPath)) return;
+    const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+    if (!Number.isFinite(pid) || pid <= 1) return;
+    spawnSync("kill", ["-9", String(pid)], { stdio: "ignore" });
+  } catch (err) {
+    log.warn({ bgJobId, err: err.message }, "revive: defensive kill failed");
+  }
+}
+
+// defaultWriteReviveMarker — write workers/<ticket>/.revive-<N>.applied as an
+// operator-friendly forensic crumb. The authoritative counter is in
+// events.jsonl; the marker is just a quick `ls`-able count for operators.
+function defaultWriteReviveMarker({ orchDir, ticket, attempt }) {
+  try {
+    const path = join(orchDir, "workers", ticket, `.revive-${attempt}.applied`);
+    writeFileSync(path, new Date().toISOString());
+  } catch (err) {
+    log.warn({ ticket, attempt, err: err.message }, "revive: marker write failed");
   }
 }
 
@@ -180,33 +319,52 @@ function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
 // long tool call.
 const STALE_MS = 5 * 60 * 1000;
 
-// reclaimDeadWorkIfPossible — one signal in, one decision out. The five-way
-// return discriminates the cases an operator might need to investigate:
+// CTL-587 — auto-revival constants. MAX_REVIVES is the per-ticket budget
+// (counted from events.jsonl). STORM_WINDOW_MS + STORM_THRESHOLD form the
+// breaker that suppresses revives when too many tickets are reviving at once
+// (a Linear-side or fleet-wide outage). KILL_RECENT_ACTIVITY_MS gates the
+// defensive SIGKILL: only fire when the bg state.json has been quiet for that
+// long — i.e. the worker really is gone, not just idling on a long tool call.
+const MAX_REVIVES = 2;
+const STORM_WINDOW_MS = 10 * 60 * 1000;
+const STORM_THRESHOLD = 3;
+const KILL_RECENT_ACTIVITY_MS = 30 * 1000;
+
+// reclaimDeadWorkIfPossible — one signal in, one decision out. CTL-587 widens
+// the return set from CTL-574's five values to seven, transforming the two
+// silent dead-ends ('not-applicable' and 'not-done') into actionable outcomes:
 //
-//   'noop'             not effectively dead (terminal / unknown / live running).
-//                      No action.
-//   'not-applicable'   effectively dead but the phase has no registered
-//                      work-done probe. Out of scope for CTL-574; CTL-587's
-//                      territory.
-//   'not-done'         effectively dead + probe says the work is NOT committed.
-//                      The worker really did die mid-implement. CTL-587 will
-//                      re-dispatch when that lands.
-//   'reclaimed'        effectively dead + work IS done. Reclaim succeeded —
-//                      the canonical audit + complete events were appended,
-//                      the signal was flipped, the session was ended.
-//   'reclaim-failed'   effectively dead + work IS done BUT emit-complete
-//                      exited non-zero. The signal is NOT mutated (emit-
-//                      complete writes via atomic rename); the next tick
-//                      retries.
+//   'noop'                not effectively dead (terminal / unknown / live).
+//                         No action.
+//   'reclaimed'           effectively dead + work IS done. CTL-574 happy path
+//                         — canonical reclaim audit appended, emit-complete
+//                         flipped the signal, session ended.
+//   'reclaim-failed'      effectively dead + work IS done BUT emit-complete
+//                         exited non-zero. Signal NOT mutated (atomic rename);
+//                         next tick retries.
+//   'revived'             effectively dead + probe says work NOT done + revive
+//                         budget available + storm-breaker closed. Signal was
+//                         reset to 'stalled' to bypass the dispatcher's
+//                         idempotency guard; defaultDispatch was invoked; the
+//                         worker-dir .revive-N.applied marker was written.
+//   'revive-suppressed'   effectively dead + work NOT done + storm-breaker
+//                         OPEN (>3 distinct tickets reviving in last 10min).
+//                         No dispatch; suppress event audited; next tick
+//                         re-evaluates the window.
+//   'escalated'           effectively dead + (revive budget exhausted OR no
+//                         work-done probe registered for this phase). needs-human
+//                         label applied (via the CTL-587 verified applyLabel);
+//                         ticket stays where it is for human triage.
 //
-// CTL-588: "effectively dead" is broader than classifyWorker's `dead`. The
-// canonical `dead` requires the bg job dir to be GONE, but claude --bg leaves
-// job dirs behind indefinitely after the worker exits (memory
-// project_phase_agent_bg_no_reap). A worker that really died, but whose dir
-// lingers, classifies as `running`. We add a freshness check: a `running`
-// signal whose bg state.json hasn't been touched in `staleMs` is treated as
-// effectively dead. classifyWorker itself is unchanged — only this consumer
-// needs the stronger liveness signal.
+// CTL-588 still defines "effectively dead" as classifyWorker:'dead' OR a
+// 'running' signal whose bg state.json mtime is older than staleMs.
+//
+// The function stays pure given its injected seams: statJob / probes /
+// emitComplete / appendEvent (pre-CTL-587) plus the six CTL-587 seams
+// (appendReviveEvent, appendEscalatedEvent, appendReviveSuppressedEvent,
+// reviveDispatch, applyStalledLabel, killBgJob, countReviveEvents,
+// countDistinctRevivingTickets, writeReviveMarker). All have real defaults
+// for prod; tests override every one.
 export function reclaimDeadWorkIfPossible(
   orchDir,
   signal,
@@ -216,51 +374,162 @@ export function reclaimDeadWorkIfPossible(
     probes = WORK_DONE_PROBES,
     emitComplete = defaultEmitComplete,
     appendEvent = defaultAppendReclaimEvent,
+    appendReviveEvent = defaultAppendReviveEvent,
+    appendEscalatedEvent = defaultAppendEscalatedEvent,
+    appendReviveSuppressedEvent = defaultAppendReviveSuppressedEvent,
+    reviveDispatch = defaultReviveDispatch,
+    applyStalledLabel = defaultApplyStalledLabel,
+    killBgJob = defaultKillBgJob,
+    countReviveEvents = defaultCountReviveEvents,
+    countDistinctRevivingTickets = defaultCountDistinctRevivingTickets,
+    writeReviveMarker = defaultWriteReviveMarker,
     now = Date.now,
     staleMs = STALE_MS,
   } = {},
 ) {
   const klass = classifyWorker(signal, { statJob });
   let effectivelyDead = klass === "dead";
+  // CTL-587: capture the bg state.json mtime so the defensive kill + the revive
+  // audit payload can both reference it without re-statting.
+  let prevStateJsonMtime = null;
   if (klass === "running" && signal?.liveness?.value) {
-    // The same statJob call classifyWorker just made is cheap to repeat once;
-    // keeps the freshness check local to this consumer.
     const job = statJob(signal.liveness.value);
-    if (job && typeof job.mtimeMs === "number" && now() - job.mtimeMs > staleMs) {
-      effectivelyDead = true;
+    if (job && typeof job.mtimeMs === "number") {
+      prevStateJsonMtime = job.mtimeMs;
+      if (now() - job.mtimeMs > staleMs) effectivelyDead = true;
     }
   }
   if (!effectivelyDead) return "noop";
-  if (!hasProbe(signal.phase)) return "not-applicable";
 
-  const probe = probes[signal.phase];
-  if (!probe({ ticket: signal.ticket, repoRoot })) {
-    log.info(
-      { ticket: signal.ticket, phase: signal.phase },
-      "reclaim-dead-work: dead worker, work NOT done — left for CTL-587",
-    );
-    return "not-done";
+  const { ticket, phase } = signal;
+  const orchId = signal.raw?.orchestrator;
+  const prevBgJobId = signal.raw?.bg_job_id ?? null;
+
+  // (A) No probe registered for this phase → escalate. The pre-CTL-587 silent
+  //     'not-applicable' return is now an actionable outcome: the worker is
+  //     dead, we cannot prove its work landed, and no automation can recover
+  //     — so the human needs to look. needs-human label applied (verified by
+  //     the CTL-587 applyLabel read-back).
+  if (!hasProbe(phase)) {
+    appendEscalatedEvent({
+      phase,
+      ticket,
+      orchId,
+      reason: "no-probe-for-phase",
+      final_attempt_count: 0,
+    });
+    applyStalledLabel({ ticket });
+    log.warn({ ticket, phase }, "ctl-587: escalated (no probe registered for phase)");
+    return "escalated";
   }
 
-  appendEvent({
-    phase: signal.phase,
-    ticket: signal.ticket,
-    orchId: signal.raw?.orchestrator,
+  // (B) Probe says work IS done → CTL-574 reclaim. Unchanged.
+  const probe = probes[phase];
+  if (probe({ ticket, repoRoot })) {
+    appendEvent({ phase, ticket, orchId });
+    const r = emitComplete({ orchDir, signal });
+    if (r.code !== 0) {
+      log.warn(
+        { ticket, phase, code: r.code, stderr: r.stderr },
+        "reclaim-dead-work: emit-complete failed; will retry next tick",
+      );
+      return "reclaim-failed";
+    }
+    log.info({ ticket, phase }, "reclaim-dead-work: dead worker reclaimed (work was committed)");
+    return "reclaimed";
+  }
+
+  // (C) Probe says work is NOT done → CTL-587 revive territory. Today only
+  //     `implement` has a probe; this branch's escalation is defensive for
+  //     a future phase whose probe also returns false.
+  if (phase !== "implement") {
+    appendEscalatedEvent({
+      phase,
+      ticket,
+      orchId,
+      reason: "non-implement-not-done",
+      final_attempt_count: 0,
+    });
+    applyStalledLabel({ ticket });
+    return "escalated";
+  }
+
+  // Per-ticket revive budget from events.jsonl. The events file is the
+  // authoritative counter — surviving daemon restarts, more truthful than the
+  // signal file (which the dispatcher rewrites each spawn).
+  const priorRevives = countReviveEvents({ ticket, orchId });
+  if (priorRevives >= MAX_REVIVES) {
+    appendEscalatedEvent({
+      phase,
+      ticket,
+      orchId,
+      reason: "revive-budget-exhausted",
+      final_attempt_count: priorRevives,
+    });
+    applyStalledLabel({ ticket });
+    log.warn({ ticket, phase, priorRevives }, "ctl-587: escalated (revive budget exhausted)");
+    return "escalated";
+  }
+
+  // Storm-breaker: if many distinct tickets are reviving inside the window,
+  // assume something is wrong fleet-wide and suppress (do nothing this tick).
+  const distinctStormTickets = countDistinctRevivingTickets({
+    windowMs: STORM_WINDOW_MS,
+    now,
   });
-
-  const r = emitComplete({ orchDir, signal });
-  if (r.code !== 0) {
+  if (distinctStormTickets > STORM_THRESHOLD) {
+    appendReviveSuppressedEvent({
+      phase,
+      ticket,
+      orchId,
+      window_distinct_tickets: distinctStormTickets,
+    });
     log.warn(
-      { ticket: signal.ticket, phase: signal.phase, code: r.code, stderr: r.stderr },
-      "reclaim-dead-work: emit-complete failed; will retry next tick",
+      { ticket, phase, distinctStormTickets },
+      "ctl-587: revive suppressed (storm-breaker open)",
     );
-    return "reclaim-failed";
+    return "revive-suppressed";
   }
-  log.info(
-    { ticket: signal.ticket, phase: signal.phase },
-    "reclaim-dead-work: dead worker reclaimed (work was committed)",
-  );
-  return "reclaimed";
+
+  // Defensive kill: if state.json has been quiet long enough we're confident
+  // the bg process is gone, so a SIGKILL on its pid is harmless and prevents
+  // a zombie holding a worktree lock. The kill is best-effort and pid-file-gated
+  // — if no pid file exists (the normal post-exit state) it's a no-op.
+  if (
+    prevStateJsonMtime !== null &&
+    now() - prevStateJsonMtime > KILL_RECENT_ACTIVITY_MS &&
+    prevBgJobId
+  ) {
+    killBgJob({ bgJobId: prevBgJobId });
+  }
+
+  const attempt = priorRevives + 1;
+  // Emit BEFORE the dispatch so a daemon crash mid-revive leaves the event
+  // behind. The next tick's count(events) sees attempt N — correctly entering
+  // attempt N+1 instead of repeating N forever.
+  appendReviveEvent({
+    phase,
+    ticket,
+    orchId,
+    attempt,
+    reason: "work-not-done-after-stale-bg",
+    prev_state_json_mtime: prevStateJsonMtime,
+    prev_bg_job_id: prevBgJobId,
+  });
+  const dispatchRes = reviveDispatch({ orchDir, ticket, phase });
+  if (dispatchRes.code === 0) {
+    writeReviveMarker({ orchDir, ticket, attempt });
+    log.info({ ticket, phase, attempt }, "ctl-587: revived");
+  } else {
+    // Dispatch failed; the next tick will retry. The marker is intentionally
+    // NOT written so the marker-file count stays an accurate "successful
+    // revives" record (audit-vs-marker drift is fine: the event is the truth).
+    log.warn(
+      { ticket, phase, attempt, code: dispatchRes.code, stderr: dispatchRes.stderr },
+      "ctl-587: revive dispatch failed; will retry next tick",
+    );
+  }
+  return "revived";
 }
 
 // recoverStartup — the boot-time reconstruction CTL-554's daemon calls. Rebuilds

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -14,6 +14,7 @@ import {
   appendFileSync,
   mkdirSync,
   writeFileSync,
+  renameSync,
   existsSync,
 } from "node:fs";
 import { dirname } from "node:path";
@@ -187,6 +188,8 @@ function appendEnvelopeBestEffort(line, kind) {
 
 // defaultAppendReclaimEvent — phase.<phase>.reclaim.<ticket>. The CTL-574 path:
 // the worker died but its work committed, so the scheduler can advance.
+// Returns true iff the audit append succeeded (CTL-587 contract — callers may
+// gate on success; today the reclaim caller does not).
 function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
   return appendEnvelopeBestEffort(
     buildEventEnvelope({
@@ -209,8 +212,9 @@ function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
 // defaultAppendReviveEvent — returns true iff the audit append succeeded.
 // reclaimDeadWorkIfPossible gates the dispatch on this so a failed append
 // does not lose the budget counter (next tick would repeat attempt N instead
-// of advancing to N+1).
-function defaultAppendReviveEvent({
+// of advancing to N+1). Exported so the round-trip test can confirm the
+// envelope shape this writes matches what countReviveEvents reads.
+export function defaultAppendReviveEvent({
   phase,
   ticket,
   orchId,
@@ -246,11 +250,15 @@ function defaultAppendEscalatedEvent({ phase, ticket, orchId, reason, final_atte
   );
 }
 
+// reason defaults to the storm-breaker case; the audit-append-failed branch
+// passes its own discriminator so operators can filter the two suppression
+// causes apart in events.jsonl.
 function defaultAppendReviveSuppressedEvent({
   phase,
   ticket,
   orchId,
   window_distinct_tickets,
+  reason = "storm-breaker-open",
 }) {
   return appendEnvelopeBestEffort(
     buildEventEnvelope({
@@ -258,7 +266,7 @@ function defaultAppendReviveSuppressedEvent({
       ticket,
       orchId,
       action: "revive-suppressed",
-      reason: "storm-breaker-open",
+      reason,
       payloadExtras: { window_distinct_tickets, window_ms: STORM_WINDOW_MS },
     }),
     "revive-suppressed",
@@ -276,7 +284,12 @@ function defaultAppendReviveSuppressedEvent({
 // idempotency guard rejects the spawn for any non-failed signal. A missing
 // signal file is therefore treated as an error — falling through to dispatch
 // without a signal would silently no-op and burn the revive budget.
-function defaultReviveDispatch({ orchDir, ticket, phase }) {
+//
+// Exported with an injectable `dispatch` seam so the default behaviour itself
+// can be unit-tested (every test in recovery.test.mjs that overrides the
+// outer `reviveDispatch` would otherwise leave the signal-reset logic — the
+// load-bearing half — uncovered).
+export function defaultReviveDispatch({ orchDir, ticket, phase }, { dispatch = defaultDispatch } = {}) {
   const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
   if (!existsSync(signalPath)) {
     log.warn(
@@ -290,12 +303,17 @@ function defaultReviveDispatch({ orchDir, ticket, phase }) {
     sig.status = "stalled";
     sig.attentionReason = "ctl-587-revive-reset";
     sig.updatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-    writeFileSync(signalPath, JSON.stringify(sig, null, 2));
+    // Atomic write — mirrors abort-worker.mjs:77-79 ("the signal is the source
+    // of truth"). A bare writeFileSync would let a concurrent reader observe a
+    // partially-written file and misclassify the worker as 'unknown'.
+    const tmp = `${signalPath}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(sig, null, 2));
+    renameSync(tmp, signalPath);
   } catch (err) {
     log.warn({ ticket, phase, err: err.message }, "revive: signal reset failed");
     return { code: 1, stdout: "", stderr: err.message };
   }
-  return defaultDispatch({ orchDir, ticket, phase });
+  return dispatch({ orchDir, ticket, phase });
 }
 
 // defaultApplyStalledLabel — apply the flat `needs-human` label via the
@@ -325,17 +343,23 @@ function defaultApplyStalledLabel({ ticket }) {
 // `claude` process before signalling to defensively avoid SIGKILL'ing a
 // recycled pid (~5+ minutes after the worker exited the PID space is fair
 // game for unrelated processes).
-function defaultKillBgJob({ bgJobId }) {
+//
+// `spawn` and `jobsRoot` are injectable for tests; production defaults call
+// the real spawnSync against the real ~/.claude/jobs.
+export function defaultKillBgJob(
+  { bgJobId },
+  { spawn = spawnSync, jobsRoot = getJobsRoot } = {},
+) {
   if (!bgJobId) return;
   try {
-    const pidPath = join(getJobsRoot(), bgJobId, "pid");
+    const pidPath = join(jobsRoot(), bgJobId, "pid");
     if (!existsSync(pidPath)) return;
     const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
     if (!Number.isFinite(pid) || pid <= 1) return;
     // Verify the pid still belongs to a claude process before SIGKILL'ing.
     // `ps -p <pid> -o comm=` prints just the command; exit 1 means the pid
     // is gone. On any verification doubt, skip the kill (best-effort).
-    const ps = spawnSync("ps", ["-p", String(pid), "-o", "comm="], { encoding: "utf8" });
+    const ps = spawn("ps", ["-p", String(pid), "-o", "comm="], { encoding: "utf8" });
     if (ps.status !== 0 || !(ps.stdout || "").toLowerCase().includes("claude")) {
       log.info(
         { bgJobId, pid, comm: (ps.stdout || "").trim() },
@@ -343,7 +367,7 @@ function defaultKillBgJob({ bgJobId }) {
       );
       return;
     }
-    const k = spawnSync("kill", ["-9", String(pid)], { encoding: "utf8" });
+    const k = spawn("kill", ["-9", String(pid)], { encoding: "utf8" });
     log.info(
       { bgJobId, pid, code: k.status },
       "revive: defensive kill issued",
@@ -580,6 +604,18 @@ export function reclaimDeadWorkIfPossible(
       { ticket, phase, attempt },
       "ctl-587: revive event append failed — aborting dispatch to preserve budget counter (will retry next tick)",
     );
+    // Best-effort suppression audit so operators see SOMETHING in events.jsonl
+    // (if the audit log is writeable for this kind even though the revive
+    // kind failed — e.g. a transient EAGAIN on the prior write). The
+    // suppressed event uses a distinct reason so it can be filtered from the
+    // storm-breaker case.
+    appendReviveSuppressedEvent({
+      phase,
+      ticket,
+      orchId,
+      window_distinct_tickets: 0, // not applicable — audit failure, not storm
+      reason: "audit-append-failed",
+    });
     return "revive-suppressed";
   }
   const dispatchRes = reviveDispatch({ orchDir, ticket, phase });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -166,20 +166,29 @@ function buildEventEnvelope({ phase, ticket, orchId, action, reason, payloadExtr
   );
 }
 
+// appendEnvelopeBestEffort — try to append; return true on success, false on
+// any failure. Revive event callers gate the dispatch on this return value:
+// the per-ticket revive counter lives in events.jsonl, so a missed append
+// means countReviveEvents undercounts on the next tick and the budget cannot
+// be enforced. Better to skip the dispatch than to lose the counter.
 function appendEnvelopeBestEffort(line, kind) {
   const logPath = getEventLogPath();
   try {
     mkdirSync(dirname(logPath), { recursive: true });
     appendFileSync(logPath, line);
+    return true;
   } catch (err) {
-    log.warn({ err: err.message, kind }, "recovery: event append failed");
+    // log.error (not warn) — a daemon-health-critical failure: the audit log
+    // is unwriteable. Disk full, EACCES, EROFS during incident response.
+    log.error({ err: err.message, kind }, "recovery: event append failed");
+    return false;
   }
 }
 
 // defaultAppendReclaimEvent — phase.<phase>.reclaim.<ticket>. The CTL-574 path:
 // the worker died but its work committed, so the scheduler can advance.
 function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
-  appendEnvelopeBestEffort(
+  return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase,
       ticket,
@@ -197,6 +206,10 @@ function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
 // orchestrator and exist purely for operator forensics + the per-ticket
 // revive counter (event-scan.mjs::countReviveEvents).
 
+// defaultAppendReviveEvent — returns true iff the audit append succeeded.
+// reclaimDeadWorkIfPossible gates the dispatch on this so a failed append
+// does not lose the budget counter (next tick would repeat attempt N instead
+// of advancing to N+1).
 function defaultAppendReviveEvent({
   phase,
   ticket,
@@ -206,7 +219,7 @@ function defaultAppendReviveEvent({
   prev_state_json_mtime,
   prev_bg_job_id,
 }) {
-  appendEnvelopeBestEffort(
+  return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase,
       ticket,
@@ -220,7 +233,7 @@ function defaultAppendReviveEvent({
 }
 
 function defaultAppendEscalatedEvent({ phase, ticket, orchId, reason, final_attempt_count }) {
-  appendEnvelopeBestEffort(
+  return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase,
       ticket,
@@ -239,7 +252,7 @@ function defaultAppendReviveSuppressedEvent({
   orchId,
   window_distinct_tickets,
 }) {
-  appendEnvelopeBestEffort(
+  return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase,
       ticket,
@@ -258,19 +271,29 @@ function defaultAppendReviveSuppressedEvent({
 // the phase-agent-dispatch idempotency guard at lines 374-395; `stalled` is the
 // single status that falls through), then call defaultDispatch. Mirrors the
 // orchestrate-revive precedent (orchestrate-revive:577-611).
+//
+// The reset is load-bearing: without flipping to `stalled` the dispatcher's
+// idempotency guard rejects the spawn for any non-failed signal. A missing
+// signal file is therefore treated as an error — falling through to dispatch
+// without a signal would silently no-op and burn the revive budget.
 function defaultReviveDispatch({ orchDir, ticket, phase }) {
   const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
-  if (existsSync(signalPath)) {
-    try {
-      const sig = JSON.parse(readFileSync(signalPath, "utf8"));
-      sig.status = "stalled";
-      sig.attentionReason = "ctl-587-revive-reset";
-      sig.updatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-      writeFileSync(signalPath, JSON.stringify(sig, null, 2));
-    } catch (err) {
-      log.warn({ ticket, phase, err: err.message }, "revive: signal reset failed");
-      return { code: 1, stdout: "", stderr: err.message };
-    }
+  if (!existsSync(signalPath)) {
+    log.warn(
+      { ticket, phase, signalPath },
+      "revive: signal file missing — cannot reset to stalled, refusing dispatch",
+    );
+    return { code: 1, stdout: "", stderr: "signal-missing" };
+  }
+  try {
+    const sig = JSON.parse(readFileSync(signalPath, "utf8"));
+    sig.status = "stalled";
+    sig.attentionReason = "ctl-587-revive-reset";
+    sig.updatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    writeFileSync(signalPath, JSON.stringify(sig, null, 2));
+  } catch (err) {
+    log.warn({ ticket, phase, err: err.message }, "revive: signal reset failed");
+    return { code: 1, stdout: "", stderr: err.message };
   }
   return defaultDispatch({ orchDir, ticket, phase });
 }
@@ -278,15 +301,30 @@ function defaultReviveDispatch({ orchDir, ticket, phase }) {
 // defaultApplyStalledLabel — apply the flat `needs-human` label via the
 // CTL-587-enhanced applyLabel (which reads back to verify the write landed,
 // closing the silent-success gap per memory project_linear_transition_silent_success).
+// Logs the `reason` discriminator on failure so operators see WHY the label
+// didn't land (rate limit, API shape change, exec exception) — not just that
+// it didn't. The escalation path returns 'escalated' regardless; the next
+// scheduler tick re-runs this function via labelOnce semantics (no marker is
+// written on applied:false, so retry naturally occurs).
 function defaultApplyStalledLabel({ ticket }) {
-  return defaultApplyLabel({ ticket, label: "needs-human" });
+  const res = defaultApplyLabel({ ticket, label: "needs-human" });
+  if (!res?.applied) {
+    log.warn(
+      { ticket, reason: res?.reason },
+      "ctl-587: needs-human label not confirmed on escalation — operator may miss this ticket until retry lands",
+    );
+  }
+  return res;
 }
 
 // defaultKillBgJob — best-effort `kill -9` of a lingering bg pid. Gated by the
 // caller on KILL_RECENT_ACTIVITY_MS so we never SIGKILL a worker whose
 // state.json was touched recently. The bg-job pid lives in
 // ~/.claude/jobs/<id>/pid (Claude Code job-state convention); a missing pid
-// file is the normal case for a reaped job.
+// file is the normal case for a reaped job. We verify the pid still maps to a
+// `claude` process before signalling to defensively avoid SIGKILL'ing a
+// recycled pid (~5+ minutes after the worker exited the PID space is fair
+// game for unrelated processes).
 function defaultKillBgJob({ bgJobId }) {
   if (!bgJobId) return;
   try {
@@ -294,7 +332,22 @@ function defaultKillBgJob({ bgJobId }) {
     if (!existsSync(pidPath)) return;
     const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
     if (!Number.isFinite(pid) || pid <= 1) return;
-    spawnSync("kill", ["-9", String(pid)], { stdio: "ignore" });
+    // Verify the pid still belongs to a claude process before SIGKILL'ing.
+    // `ps -p <pid> -o comm=` prints just the command; exit 1 means the pid
+    // is gone. On any verification doubt, skip the kill (best-effort).
+    const ps = spawnSync("ps", ["-p", String(pid), "-o", "comm="], { encoding: "utf8" });
+    if (ps.status !== 0 || !(ps.stdout || "").toLowerCase().includes("claude")) {
+      log.info(
+        { bgJobId, pid, comm: (ps.stdout || "").trim() },
+        "revive: defensive kill skipped — pid does not belong to a claude process",
+      );
+      return;
+    }
+    const k = spawnSync("kill", ["-9", String(pid)], { encoding: "utf8" });
+    log.info(
+      { bgJobId, pid, code: k.status },
+      "revive: defensive kill issued",
+    );
   } catch (err) {
     log.warn({ bgJobId, err: err.message }, "revive: defensive kill failed");
   }
@@ -507,7 +560,13 @@ export function reclaimDeadWorkIfPossible(
   // Emit BEFORE the dispatch so a daemon crash mid-revive leaves the event
   // behind. The next tick's count(events) sees attempt N — correctly entering
   // attempt N+1 instead of repeating N forever.
-  appendReviveEvent({
+  //
+  // The audit emit can fail (disk full, EROFS, permissions during incident).
+  // The per-ticket revive counter LIVES in events.jsonl, so a missed append
+  // means the next tick will undercount and the budget cannot be enforced.
+  // Safer to skip this dispatch and retry next tick than to spawn a worker
+  // we cannot account for.
+  const eventLanded = appendReviveEvent({
     phase,
     ticket,
     orchId,
@@ -516,6 +575,13 @@ export function reclaimDeadWorkIfPossible(
     prev_state_json_mtime: prevStateJsonMtime,
     prev_bg_job_id: prevBgJobId,
   });
+  if (eventLanded === false) {
+    log.error(
+      { ticket, phase, attempt },
+      "ctl-587: revive event append failed — aborting dispatch to preserve budget counter (will retry next tick)",
+    );
+    return "revive-suppressed";
+  }
   const dispatchRes = reviveDispatch({ orchDir, ticket, phase });
   if (dispatchRes.code === 0) {
     writeReviveMarker({ orchDir, ticket, attempt });

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -5,7 +5,7 @@
 // this same file with recoverStartup composition tests.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -14,6 +14,9 @@ import {
   defaultStatJob,
   recoverStartup,
   reclaimDeadWorkIfPossible,
+  defaultReviveDispatch,
+  defaultKillBgJob,
+  defaultAppendReviveEvent,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -762,20 +765,14 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(s.opts.killBgJob.calls[0][0].bgJobId).toBe("bg-9");
   });
 
-  test("defensive kill: does NOT fire when state.json mtime is recent (< 30s)", () => {
-    // 10s past — under 30s kill threshold. But still > 5min stale path...
-    // Actually mtime 0 with now=6min and stale 5min triggers the stale path
-    // but mtime delta is 6min > 30s. To test the kill-skip we need recent mtime.
-    // The staleness check ALSO uses staleMs=5min — we must override that too
-    // so the worker is still effectively-dead (via classifyWorker dead) but
-    // has recent state.json activity. Trick: use null statJob (bg dir gone)
-    // and forget the freshness check.
+  test("defensive kill: does NOT fire when classifyWorker:dead path is taken (no mtime captured)", () => {
+    // When statJob returns null (bg dir gone), classifyWorker returns 'dead'
+    // directly → prevStateJsonMtime stays null → the kill gate at
+    // recovery.mjs sees no mtime and skips. The separate freshness-vs-kill
+    // gate is exercised by the next test.
     const sig = implementSignal({ ticket: "CTL-9", status: "running", bgJobId: "bg-9" });
     const opts = {
       ...setupReviveScenario().opts,
-      // classifyWorker returns 'dead' for null statJob → effectivelyDead=true
-      // without needing the stale-mtime path. prevStateJsonMtime stays null,
-      // so killBgJob is never called.
       statJob: () => null,
       now: () => 0,
     };
@@ -844,5 +841,251 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revive-suppressed");
     expect(s.opts.reviveDispatch.calls.length).toBe(0);
     expect(s.opts.writeReviveMarker.calls.length).toBe(0);
+    // Operator forensics trail: a 'revive-suppressed' audit event is emitted
+    // with reason: audit-append-failed so the suppression is visible in
+    // events.jsonl (distinct from the storm-breaker case).
+    expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(1);
+    expect(s.opts.appendReviveSuppressedEvent.calls[0][0].reason).toBe("audit-append-failed");
+  });
+
+  // Defensive-kill freshness gate: a `running` worker with a stale-but-not-yet-
+  // KILL_RECENT_ACTIVITY_MS-stale state.json mtime must NOT be SIGKILL'd. We
+  // override staleMs so the worker still classifies as effectively dead (via
+  // the freshness path) but the kill threshold (30s) is NOT crossed.
+  test("defensive kill: state.json mtime within KILL_RECENT_ACTIVITY_MS → no kill", () => {
+    const s = setupReviveScenario({
+      stateJsonMtime: 1_000,
+      nowMs: 1_000 + 20_000, // 20s past mtime — under 30s kill threshold
+    });
+    // Override staleMs so the worker IS effectively dead via the freshness
+    // path even though only 20s have elapsed. This isolates the kill gate
+    // from the staleness gate.
+    s.opts.staleMs = 10_000;
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.killBgJob.calls.length).toBe(0);
+  });
+});
+
+// --- CTL-587: default-seam behavioural tests --------------------------------
+// The above describe block uses injected stubs for all seams. These tests
+// exercise the REAL defaults — the load-bearing logic inside
+// defaultReviveDispatch, defaultKillBgJob, and the audit-event envelope shape.
+// Without these, a regression in (a) the signal-reset half of revive dispatch,
+// (b) the pid-recycling guard, or (c) the envelope shape would slip past every
+// other test, because every other test stubs them out.
+
+describe("defaultReviveDispatch — signal-reset behaviour", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl587-revdisp-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  function seed(ticket, phase, body) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, ...body }),
+    );
+    return join(dir, `phase-${phase}.json`);
+  }
+
+  test("missing signal file → returns code:1 stderr:'signal-missing', no dispatch", () => {
+    const dispatch = recorder({ code: 0 });
+    const r = defaultReviveDispatch(
+      { orchDir, ticket: "CTL-9", phase: "implement" },
+      { dispatch },
+    );
+    expect(r.code).toBe(1);
+    expect(r.stderr).toBe("signal-missing");
+    expect(dispatch.calls.length).toBe(0);
+  });
+
+  test("signal present → flips to 'stalled' with attentionReason and calls dispatch", () => {
+    const signalPath = seed("CTL-9", "implement", {
+      status: "running",
+      bg_job_id: "bg-9",
+      orchestrator: "test-orch",
+    });
+    const dispatch = recorder({ code: 0 });
+    const r = defaultReviveDispatch(
+      { orchDir, ticket: "CTL-9", phase: "implement" },
+      { dispatch },
+    );
+    expect(r.code).toBe(0);
+    const sig = JSON.parse(readFileSync(signalPath, "utf8"));
+    expect(sig.status).toBe("stalled");
+    expect(sig.attentionReason).toBe("ctl-587-revive-reset");
+    expect(typeof sig.updatedAt).toBe("string");
+    // Original fields preserved.
+    expect(sig.bg_job_id).toBe("bg-9");
+    expect(sig.orchestrator).toBe("test-orch");
+    expect(dispatch.calls.length).toBe(1);
+    expect(dispatch.calls[0][0]).toEqual({
+      orchDir,
+      ticket: "CTL-9",
+      phase: "implement",
+    });
+  });
+
+  test("signal flip happens BEFORE dispatch (so dispatcher sees 'stalled')", () => {
+    const signalPath = seed("CTL-9", "implement", { status: "running" });
+    let seenStatus = null;
+    const dispatch = () => {
+      seenStatus = JSON.parse(readFileSync(signalPath, "utf8")).status;
+      return { code: 0 };
+    };
+    defaultReviveDispatch({ orchDir, ticket: "CTL-9", phase: "implement" }, { dispatch });
+    expect(seenStatus).toBe("stalled");
+  });
+
+  test("malformed JSON in signal → returns code:1 with err message, no dispatch", () => {
+    const dir = join(orchDir, "workers", "CTL-9");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-implement.json"), "{ not json");
+    const dispatch = recorder({ code: 0 });
+    const r = defaultReviveDispatch(
+      { orchDir, ticket: "CTL-9", phase: "implement" },
+      { dispatch },
+    );
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/JSON|json/i);
+    expect(dispatch.calls.length).toBe(0);
+  });
+
+  test("signal write uses tmp + rename (atomic — no partial file visible)", () => {
+    // We can't observe the rename directly without racing it, but we can
+    // confirm no `.tmp.*` files linger after the call — proves the rename
+    // actually moved the tmp into place.
+    seed("CTL-9", "implement", { status: "running", bg_job_id: "bg-9" });
+    defaultReviveDispatch({ orchDir, ticket: "CTL-9", phase: "implement" }, {
+      dispatch: () => ({ code: 0 }),
+    });
+    const dir = join(orchDir, "workers", "CTL-9");
+    const leftovers = readdirSync(dir).filter((f) => f.includes(".tmp."));
+    expect(leftovers).toEqual([]);
+  });
+});
+
+describe("defaultKillBgJob — pid-recycling guard", () => {
+  let jobsRootDir;
+  beforeEach(() => {
+    jobsRootDir = mkdtempSync(join(tmpdir(), "ctl587-jobs-"));
+  });
+  afterEach(() => {
+    rmSync(jobsRootDir, { recursive: true, force: true });
+  });
+
+  function seedPid(bgJobId, pid) {
+    const dir = join(jobsRootDir, bgJobId);
+    mkdirSync(dir, { recursive: true });
+    if (pid !== undefined) writeFileSync(join(dir, "pid"), String(pid));
+  }
+
+  test("missing bgJobId → no spawn invocation", () => {
+    const spawn = recorder({ status: 0, stdout: "claude\n", stderr: "" });
+    defaultKillBgJob({ bgJobId: null }, { spawn, jobsRoot: () => jobsRootDir });
+    expect(spawn.calls.length).toBe(0);
+  });
+
+  test("missing pid file → no spawn invocation", () => {
+    // bgJobId set but no pid file written.
+    const spawn = recorder({ status: 0, stdout: "claude\n", stderr: "" });
+    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
+    expect(spawn.calls.length).toBe(0);
+  });
+
+  test("pid <= 1 (init / invalid) → no spawn invocation", () => {
+    seedPid("bg-9", "1");
+    const spawn = recorder({ status: 0, stdout: "claude\n", stderr: "" });
+    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
+    expect(spawn.calls.length).toBe(0);
+  });
+
+  test("non-numeric pid → no spawn invocation", () => {
+    seedPid("bg-9", "abc");
+    const spawn = recorder({ status: 0, stdout: "claude\n", stderr: "" });
+    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
+    expect(spawn.calls.length).toBe(0);
+  });
+
+  test("ps exit non-zero (pid gone) → ps invoked, kill is NOT invoked", () => {
+    seedPid("bg-9", "12345");
+    const calls = [];
+    const spawn = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === "ps") return { status: 1, stdout: "", stderr: "" };
+      return { status: 0 };
+    };
+    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
+    expect(calls.filter((c) => c.cmd === "ps").length).toBe(1);
+    expect(calls.filter((c) => c.cmd === "kill").length).toBe(0);
+  });
+
+  test("ps says pid is 'node' (recycled to non-claude process) → kill skipped", () => {
+    seedPid("bg-9", "12345");
+    const calls = [];
+    const spawn = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === "ps") return { status: 0, stdout: "node\n", stderr: "" };
+      return { status: 0 };
+    };
+    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
+    expect(calls.filter((c) => c.cmd === "kill").length).toBe(0);
+  });
+
+  test("happy path: ps confirms 'claude' → kill -9 issued with the pid", () => {
+    seedPid("bg-9", "12345");
+    const calls = [];
+    const spawn = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === "ps") return { status: 0, stdout: "claude\n", stderr: "" };
+      if (cmd === "kill") return { status: 0, stdout: "", stderr: "" };
+      return { status: 127 };
+    };
+    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
+    const killCalls = calls.filter((c) => c.cmd === "kill");
+    expect(killCalls).toHaveLength(1);
+    expect(killCalls[0].args).toEqual(["-9", "12345"]);
+  });
+});
+
+describe("revive event envelope round-trip (write → countReviveEvents)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl587-rt-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  test("defaultAppendReviveEvent writes an envelope that countReviveEvents counts", async () => {
+    // Dynamic-import so the test sees process.env.CATALYST_DIR set above.
+    const { countReviveEvents } = await import("./event-scan.mjs");
+    const ok = defaultAppendReviveEvent({
+      phase: "implement",
+      ticket: "CTL-RT-1",
+      orchId: "orch-rt",
+      attempt: 1,
+      reason: "work-not-done-after-stale-bg",
+      prev_state_json_mtime: 12345,
+      prev_bg_job_id: "bg-rt-1",
+    });
+    expect(ok).toBe(true);
+    // The default path resolves the event log via getEventLogPath, so a no-
+    // arg call must find the envelope we just wrote.
+    expect(countReviveEvents({ ticket: "CTL-RT-1" })).toBe(1);
+    expect(countReviveEvents({ ticket: "CTL-RT-1", orchId: "orch-rt" })).toBe(1);
+    // orchId mismatch returns 0 — proves the orchId attribute round-trips.
+    expect(countReviveEvents({ ticket: "CTL-RT-1", orchId: "wrong-orch" })).toBe(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -540,31 +540,53 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(emit.calls.length).toBe(0);
   });
 
-  test("'not-applicable' when the phase has no registered probe", () => {
+  // CTL-587: this case used to return 'not-applicable' (a silent dead-end).
+  // It now escalates immediately — no probe means no way to verify the work,
+  // so the human must look. needs-human label is applied via the injected seam.
+  test("CTL-587: dead worker on a no-probe phase → 'escalated' + needs-human label", () => {
     const sig = { ...implementSignal(), phase: "research" };
+    sig.raw.phase = "research";
     const emit = recorder({ code: 0 });
+    const appendEscalated = recorder(undefined);
+    const applyLabel = recorder({ applied: true });
     const r = reclaimDeadWorkIfPossible(orch, sig, {
       statJob: () => null, // bg dead
       probes: { implement: recorder(true) }, // research not registered
       emitComplete: emit,
       appendEvent: recorder(undefined),
+      appendEscalatedEvent: appendEscalated,
+      applyStalledLabel: applyLabel,
     });
-    expect(r).toBe("not-applicable");
+    expect(r).toBe("escalated");
     expect(emit.calls.length).toBe(0);
+    expect(appendEscalated.calls[0][0].reason).toBe("no-probe-for-phase");
+    expect(applyLabel.calls[0][0].ticket).toBe("CTL-9");
   });
 
-  test("'not-done' when the dead worker's probe returns false (no emit)", () => {
+  // CTL-587: this case used to return 'not-done' (the other silent dead-end).
+  // It now enters the revive path. With reviveCount=0 and storm window open
+  // the return is 'revived' and the dispatcher seam fires once.
+  test("CTL-587: dead worker + probe says NOT done → 'revived' (first attempt)", () => {
     const emit = recorder({ code: 0 });
-    const appendEvent = recorder(undefined);
+    const appendRevive = recorder(undefined);
+    const reviveDispatch = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
       statJob: () => null, // bg dead
       probes: { implement: recorder(false) }, // probe: work NOT done
       emitComplete: emit,
-      appendEvent,
+      appendEvent: recorder(undefined),
+      appendReviveEvent: appendRevive,
+      reviveDispatch,
+      countReviveEvents: recorder(0),
+      countDistinctRevivingTickets: recorder(1),
+      writeReviveMarker: recorder(undefined),
+      killBgJob: recorder(undefined),
+      applyStalledLabel: recorder({ applied: true }),
     });
-    expect(r).toBe("not-done");
-    expect(emit.calls.length).toBe(0);
-    expect(appendEvent.calls.length).toBe(0);
+    expect(r).toBe("revived");
+    expect(emit.calls.length).toBe(0); // CTL-574 reclaim path NOT taken
+    expect(appendRevive.calls.length).toBe(1);
+    expect(reviveDispatch.calls.length).toBe(1);
   });
 
   test("'reclaimed' fires append-event THEN emit-complete (in that order, with full flag set)", () => {
@@ -626,5 +648,187 @@ describe("reclaimDeadWorkIfPossible", () => {
       repoRoot: "/repo/x",
     });
     expect(seen).toEqual({ ticket: "CTL-42", repoRoot: "/repo/x" });
+  });
+});
+
+// --- CTL-587: revive / revive-suppressed / escalated branches ---------------
+//
+// The pre-CTL-587 'not-applicable' and 'not-done' returns were silent dead-ends.
+// CTL-587 turns them into actions:
+//   - 'not-applicable' (no probe)             → 'escalated' + needs-human label
+//   - 'not-done' + budget available + no storm → 'revived' (re-dispatch)
+//   - 'not-done' + budget exhausted           → 'escalated' + needs-human label
+//   - 'not-done' + storm-breaker open         → 'revive-suppressed' (next tick)
+
+describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () => {
+  // setupReviveScenario stages an effectively-dead worker (running signal +
+  // stale state.json mtime) and threads every CTL-587 seam through opts.
+  function setupReviveScenario({
+    reviveCount = 0,
+    distinctRevivingTickets = 1,
+    probeResult = false, // false = "work not done" → enters CTL-587 territory
+    phase = "implement",
+    ticket = "CTL-9",
+    bgJobId = "bg-9",
+    stateJsonMtime = 1_000, // far in the past — staleness triggers
+    nowMs = 1_000 + 6 * 60 * 1000, // 6 min past mtime — > STALE_MS
+  } = {}) {
+    const sig = {
+      ...implementSignal({ ticket, status: "running", bgJobId }),
+      phase,
+    };
+    sig.raw.phase = phase;
+    return {
+      orch: "/orch",
+      sig,
+      opts: {
+        repoRoot: "/repo",
+        statJob: () => ({ exists: true, mtimeMs: stateJsonMtime }),
+        probes: phase === "implement" ? { implement: recorder(probeResult) } : {},
+        emitComplete: recorder({ code: 0 }),
+        appendEvent: recorder(undefined),
+        appendReviveEvent: recorder(undefined),
+        appendEscalatedEvent: recorder(undefined),
+        appendReviveSuppressedEvent: recorder(undefined),
+        reviveDispatch: recorder({ code: 0 }),
+        applyStalledLabel: recorder({ applied: true }),
+        killBgJob: recorder(undefined),
+        countReviveEvents: recorder(reviveCount),
+        countDistinctRevivingTickets: recorder(distinctRevivingTickets),
+        writeReviveMarker: recorder(undefined),
+        now: () => nowMs,
+        staleMs: 5 * 60 * 1000,
+      },
+    };
+  }
+
+  test("first revive: count=0, no storm → 'revived', event before dispatch, marker written", () => {
+    const s = setupReviveScenario({ reviveCount: 0 });
+    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(r).toBe("revived");
+    expect(s.opts.appendReviveEvent.calls.length).toBe(1);
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+    expect(s.opts.writeReviveMarker.calls.length).toBe(1);
+    expect(s.opts.appendReviveEvent.calls[0][0].attempt).toBe(1);
+  });
+
+  test("second revive: count=1 → still 'revived', attempt=2", () => {
+    const s = setupReviveScenario({ reviveCount: 1 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    expect(s.opts.appendReviveEvent.calls[0][0].attempt).toBe(2);
+  });
+
+  test("budget exhausted: count=2 → 'escalated', applies needs-human label, no dispatch", () => {
+    const s = setupReviveScenario({ reviveCount: 2 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(1);
+    expect(s.opts.applyStalledLabel.calls[0][0].ticket).toBe("CTL-9");
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("revive-budget-exhausted");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].final_attempt_count).toBe(2);
+  });
+
+  test("storm-breaker: distinct=4 > 3 → 'revive-suppressed', no dispatch", () => {
+    const s = setupReviveScenario({ reviveCount: 0, distinctRevivingTickets: 4 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revive-suppressed");
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+    expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(1);
+    expect(s.opts.appendReviveSuppressedEvent.calls[0][0].window_distinct_tickets).toBe(4);
+  });
+
+  test("storm-breaker at the threshold: distinct=3 is NOT suppressed (>3, not >=3)", () => {
+    const s = setupReviveScenario({ reviveCount: 0, distinctRevivingTickets: 3 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+  });
+
+  test("not-applicable (no probe registered for phase) → 'escalated' immediately", () => {
+    const s = setupReviveScenario({ phase: "pr" });
+    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(r).toBe("escalated");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].phase).toBe("pr");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("no-probe-for-phase");
+    expect(s.opts.applyStalledLabel.calls.length).toBe(1);
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("defensive kill: fires when state.json mtime > KILL_RECENT_ACTIVITY_MS old", () => {
+    // 60s past now — older than the 30s kill threshold.
+    const s = setupReviveScenario({
+      stateJsonMtime: 1_000,
+      nowMs: 1_000 + 6 * 60 * 1000, // 6min past — also stale
+    });
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.killBgJob.calls.length).toBe(1);
+    expect(s.opts.killBgJob.calls[0][0].bgJobId).toBe("bg-9");
+  });
+
+  test("defensive kill: does NOT fire when state.json mtime is recent (< 30s)", () => {
+    // 10s past — under 30s kill threshold. But still > 5min stale path...
+    // Actually mtime 0 with now=6min and stale 5min triggers the stale path
+    // but mtime delta is 6min > 30s. To test the kill-skip we need recent mtime.
+    // The staleness check ALSO uses staleMs=5min — we must override that too
+    // so the worker is still effectively-dead (via classifyWorker dead) but
+    // has recent state.json activity. Trick: use null statJob (bg dir gone)
+    // and forget the freshness check.
+    const sig = implementSignal({ ticket: "CTL-9", status: "running", bgJobId: "bg-9" });
+    const opts = {
+      ...setupReviveScenario().opts,
+      // classifyWorker returns 'dead' for null statJob → effectivelyDead=true
+      // without needing the stale-mtime path. prevStateJsonMtime stays null,
+      // so killBgJob is never called.
+      statJob: () => null,
+      now: () => 0,
+    };
+    reclaimDeadWorkIfPossible("/orch", sig, opts);
+    expect(opts.killBgJob.calls.length).toBe(0);
+  });
+
+  test("revive event payload contains attempt, reason, prev_state_json_mtime, prev_bg_job_id", () => {
+    const s = setupReviveScenario({ reviveCount: 0 });
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    const body = s.opts.appendReviveEvent.calls[0][0];
+    expect(body.attempt).toBe(1);
+    expect(body.reason).toBe("work-not-done-after-stale-bg");
+    expect(typeof body.prev_state_json_mtime).toBe("number");
+    expect(body.prev_bg_job_id).toBe("bg-9");
+  });
+
+  test("escalation still records 'escalated' even when applyStalledLabel fails (no dispatch)", () => {
+    // Failure to apply the label still returns 'escalated' so the scheduler
+    // records the outcome. The labelOnce semantics in scheduler.mjs guard
+    // re-application — a verify-failed result returns no marker, so the next
+    // tick retries the label apply.
+    const s = setupReviveScenario({ reviveCount: 2 });
+    s.opts.applyStalledLabel = recorder({ applied: false, reason: "verify-failed" });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("revive emits event BEFORE dispatch (audit-survives-crash ordering)", () => {
+    // If the daemon crashes mid-revive AFTER appending the event but BEFORE
+    // dispatch, the next tick correctly sees attempt N in events.jsonl and
+    // enters attempt N+1. The reverse order would lose the attempt counter.
+    const order = [];
+    const s = setupReviveScenario({ reviveCount: 0 });
+    s.opts.appendReviveEvent = (...args) => {
+      order.push(["event", ...args]);
+    };
+    s.opts.reviveDispatch = (...args) => {
+      order.push(["dispatch", ...args]);
+      return { code: 0 };
+    };
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(order[0][0]).toBe("event");
+    expect(order[1][0]).toBe("dispatch");
+  });
+
+  test("revive dispatch failure does NOT write the marker (next tick retries)", () => {
+    const s = setupReviveScenario({ reviveCount: 0 });
+    s.opts.reviveDispatch = recorder({ code: 1, stderr: "dispatch boom" });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    // The event still gets appended (it tracks the attempt), but the marker
+    // is only written on a successful dispatch.
+    expect(s.opts.appendReviveEvent.calls.length).toBe(1);
+    expect(s.opts.writeReviveMarker.calls.length).toBe(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -824,11 +824,25 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
 
   test("revive dispatch failure does NOT write the marker (next tick retries)", () => {
     const s = setupReviveScenario({ reviveCount: 0 });
+    s.opts.appendReviveEvent = recorder(true); // event lands
     s.opts.reviveDispatch = recorder({ code: 1, stderr: "dispatch boom" });
     expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
     // The event still gets appended (it tracks the attempt), but the marker
     // is only written on a successful dispatch.
     expect(s.opts.appendReviveEvent.calls.length).toBe(1);
+    expect(s.opts.writeReviveMarker.calls.length).toBe(0);
+  });
+
+  // Audit-budget invariant: if the revive event append fails (disk full,
+  // EROFS, permissions), the per-ticket counter cannot be enforced on the
+  // next tick. Better to skip the dispatch and retry next tick than to spawn
+  // a worker we cannot account for. Returns 'revive-suppressed' so the
+  // scheduler logs the suppression and re-evaluates.
+  test("audit-append failure → 'revive-suppressed', dispatch NOT invoked, no marker", () => {
+    const s = setupReviveScenario({ reviveCount: 0 });
+    s.opts.appendReviveEvent = recorder(false); // simulate append failure
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revive-suppressed");
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
     expect(s.opts.writeReviveMarker.calls.length).toBe(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -366,12 +366,38 @@ export function schedulerTick(
   // Reclaim is a strict superset of "do nothing": only the dead+work-done case
   // mutates the signal; all other classes (terminal/running/unknown/not-done/
   // not-applicable) are zero-action no-ops.
+  // CTL-587: reclaimDeadWork now returns up to 7 discriminators. The four
+  // that callers can act on (HUD, daemon log) populate parallel arrays; the
+  // other three (noop, not-done, not-applicable, reclaim-failed) are silent
+  // because they describe "no externally-visible change" — the next tick
+  // will re-evaluate. The 'reviveSuppressed' bucket is the storm-breaker
+  // marker; 'escalated' fires `needs-human` via the per-phase recovery path.
   const reclaimed = [];
+  const revived = [];
+  const reviveSuppressed = [];
+  const escalated = [];
   for (const sig of readWorkerSignals(orchDir)) {
     const team = teamOf(sig.ticket);
     const repoRoot = team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
     const r = reclaimDeadWork(orchDir, sig, { repoRoot });
-    if (r === "reclaimed") reclaimed.push({ ticket: sig.ticket, phase: sig.phase });
+    const entry = { ticket: sig.ticket, phase: sig.phase };
+    switch (r) {
+      case "reclaimed":
+        reclaimed.push(entry);
+        break;
+      case "revived":
+        revived.push(entry);
+        break;
+      case "revive-suppressed":
+        reviveSuppressed.push(entry);
+        break;
+      case "escalated":
+        escalated.push(entry);
+        break;
+      default:
+        // noop | not-done | not-applicable | reclaim-failed → invisible.
+        break;
+    }
   }
 
   // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
@@ -451,7 +477,16 @@ export function schedulerTick(
     }
   }
 
-  return { reclaimed, advanced, dispatched, freeSlots, ready: ready.map((t) => t.identifier) };
+  return {
+    reclaimed,
+    revived,
+    reviveSuppressed,
+    escalated,
+    advanced,
+    dispatched,
+    freeSlots,
+    ready: ready.map((t) => t.identifier),
+  };
 }
 
 // ─── Phase 5: the pull-loop daemon ───

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1138,6 +1138,105 @@ describe("schedulerTick — CTL-574 reclaim-dead-work sweep", () => {
   });
 });
 
+// CTL-587: scheduler Step 0 returns parallel arrays for the new outcomes
+// from reclaimDeadWorkIfPossible — revived, reviveSuppressed, escalated —
+// alongside the pre-existing reclaimed[]. Existing consumers that ignore
+// unknown keys are unaffected.
+describe("schedulerTick — CTL-587 Step 0 multi-result shape", () => {
+  function writeNestedSignal(ticket, phase, body) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, ...body }),
+    );
+  }
+
+  const writeStatus = {
+    applyPhaseStatus: () => {},
+    applyTerminalDone: () => {},
+    applyLabel: () => ({ applied: true }),
+  };
+
+  test("'revived' result populates result.revived (and leaves reclaimed empty)", () => {
+    writeNestedSignal("CTL-7", "implement", { status: "running", bg_job_id: "bg-7" });
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus,
+      teardownWorktree: () => true,
+      reclaimDeadWork: () => "revived",
+    });
+    expect(result.revived).toEqual([{ ticket: "CTL-7", phase: "implement" }]);
+    expect(result.reclaimed).toEqual([]);
+    expect(result.escalated).toEqual([]);
+    expect(result.reviveSuppressed).toEqual([]);
+  });
+
+  test("'revive-suppressed' result populates result.reviveSuppressed", () => {
+    writeNestedSignal("CTL-8", "implement", { status: "running", bg_job_id: "bg-8" });
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus,
+      teardownWorktree: () => true,
+      reclaimDeadWork: () => "revive-suppressed",
+    });
+    expect(result.reviveSuppressed).toEqual([{ ticket: "CTL-8", phase: "implement" }]);
+    expect(result.revived).toEqual([]);
+  });
+
+  test("'escalated' result populates result.escalated", () => {
+    writeNestedSignal("CTL-9", "pr", { status: "running", bg_job_id: "bg-9" });
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus,
+      teardownWorktree: () => true,
+      reclaimDeadWork: () => "escalated",
+    });
+    expect(result.escalated).toEqual([{ ticket: "CTL-9", phase: "pr" }]);
+  });
+
+  test("mixed returns across multiple signals end up in the right buckets", () => {
+    writeNestedSignal("CTL-7", "implement", { status: "running", bg_job_id: "bg-7" });
+    writeNestedSignal("CTL-8", "implement", { status: "running", bg_job_id: "bg-8" });
+    writeNestedSignal("CTL-9", "pr", { status: "running", bg_job_id: "bg-9" });
+    const reclaimDeadWork = (_orchDir, sig) => {
+      if (sig.ticket === "CTL-7") return "revived";
+      if (sig.ticket === "CTL-8") return "reclaimed";
+      if (sig.ticket === "CTL-9") return "escalated";
+      return "noop";
+    };
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus,
+      teardownWorktree: () => true,
+      reclaimDeadWork,
+    });
+    expect(result.revived).toEqual([{ ticket: "CTL-7", phase: "implement" }]);
+    expect(result.escalated).toEqual([{ ticket: "CTL-9", phase: "pr" }]);
+    // reclaimed: emit-complete is stubbed via the seam, but the canonical
+    // path mutates the signal — we just check the array is populated.
+    expect(result.reclaimed.map((e) => e.ticket)).toContain("CTL-8");
+  });
+
+  test("clean tick (no dead workers) returns empty arrays for every CTL-587 outcome", () => {
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus,
+      teardownWorktree: () => true,
+      reclaimDeadWork: () => "noop",
+    });
+    expect(result.revived).toEqual([]);
+    expect(result.reviveSuppressed).toEqual([]);
+    expect(result.escalated).toEqual([]);
+    expect(result.reclaimed).toEqual([]);
+  });
+});
+
 // recorder — small spy that records args and returns either a constant value or
 // a function-derived value. Local to this describe to avoid leaking into the
 // existing block-scope helpers.

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -445,6 +445,27 @@ mark_launch_failed() {
 	fi
 }
 
+# ─── CTL-587: test-kill injection hook ─────────────────────────────────────
+#
+# `CATALYST_TEST_KILL_PHASE=<phase>:<mode>` lets the CTL-587 integration tests
+# exercise the dead-worker revival paths without an OOM or kill -9. Two modes:
+#   before-launch  — abort before the claude --bg spawn. Signal flips to
+#                    `stalled` via mark_launch_failed (exercises the escalation
+#                    branch in recovery.mjs::reclaimDeadWorkIfPossible).
+#   after-prelude  — handled in phase-implement/SKILL.md prelude (this script
+#                    no-ops for that mode and lets the spawn proceed; the
+#                    prelude itself exits 137 AFTER flipping the signal to
+#                    `running`, exercising the revive path).
+# A non-matching phase or unset env falls through to the normal dispatch path.
+if [[ -n ${CATALYST_TEST_KILL_PHASE:-} ]]; then
+	TK_PHASE="${CATALYST_TEST_KILL_PHASE%%:*}"
+	TK_MODE="${CATALYST_TEST_KILL_PHASE#*:}"
+	if [[ $TK_PHASE == "$PHASE" && $TK_MODE == "before-launch" ]]; then
+		mark_launch_failed "test-kill-before-launch"
+		exit 1
+	fi
+fi
+
 # ─── Build prompt + spawn claude --bg ──────────────────────────────────────
 
 PROMPT="/catalyst-dev:phase-${PHASE} ${TICKET} --orch-dir ${ORCH_DIR}"

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -105,6 +105,17 @@ jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
 ' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
 
+# CTL-587: test-kill after-prelude. Exits AFTER the signal is flipped to
+# running (so classifyWorker sees a non-terminal worker) but BEFORE any
+# commit work, so reclaimDeadWorkIfPossible's implement-probe returns false
+# on the next staleness tick and the revive path engages. Mode suffix
+# `${PHASE}:after-prelude` keeps the env var phase-agnostic — only the
+# matching phase aborts.
+if [[ "${CATALYST_TEST_KILL_PHASE:-}" == "${PHASE}:after-prelude" ]]; then
+  echo "[CTL-587 test-kill] aborting after prelude" >&2
+  exit 137
+fi
+
 # 4. Locate the approved plan. The dispatcher already validated this glob;
 #    we re-resolve to capture the actual filename for the delegated skill.
 TICKET_LC="$(printf '%s' "$TICKET" | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
## Summary

Closes the silent dead-ends in the CTL-574 reclaim sweep. Pre-CTL-587, when a `phase-implement` worker died mid-flight (OOM, kill -9, daemon force-restart) and the work-done probe said the work was NOT committed, the daemon logged one line and the ticket stalled forever. CTL-587 turns the two silent returns into actions:

- **`not-applicable`** (no probe registered for the phase) → **`escalated`** + applies the flat `needs-human` Linear label (verified via read-back). The human has to look; we cannot prove the work landed.
- **`not-done`** on `implement` → revive ladder:
  - **`revived`** when budget < `MAX_REVIVES=2` AND storm-breaker closed (≤ 3 distinct tickets reviving in last 10min). Resets signal to `stalled` (bypassing the dispatcher's idempotency guard), defensively SIGKILLs any lingering bg pid that ps confirms is still a `claude` process, then re-dispatches.
  - **`escalated`** when budget exhausted.
  - **`revive-suppressed`** when the storm-breaker is open.

The per-ticket revive counter lives in **`events.jsonl`** (authoritative across daemon restarts) plus an operator-friendly `.revive-N.applied` marker file under `workers/<ticket>/`.

## Phases (TDD per phase)

1. **Test-kill injection** — `CATALYST_TEST_KILL_PHASE=<phase>:<mode>` env var in `phase-agent-dispatch` (before-launch → escalation path) and `phase-implement/SKILL.md` prelude (after-prelude → revive path). 14 shell-test assertions.
2. **`event-scan.mjs`** — new pure utility: `countReviveEvents` (per-ticket budget) + `countDistinctRevivingTickets` (storm-breaker). 11 unit tests.
3. **`applyLabel` read-back** — closes the silent-success gap in `linearis ... update --labels` documented in memory `project_linear_transition_silent_success`. New `fetchTicketLabels` in `linear-query.mjs`. `applyLabel` returns `{ applied, reason: 'write-failed'|'verify-failed'|'exception' }`. 10 new tests.
4. **`recovery.mjs` revive/suppress/escalate** — extends `reclaimDeadWorkIfPossible` from a 5-way to 7-way return. Six new injectable seams, four envelope-action helpers sharing `buildEventEnvelope`. 14 new behavioural tests pinning revive ordering, defensive-kill threshold, audit-survives-crash invariant.
5. **`scheduler.mjs` multi-result shape** — Step 0 sweep populates `result.revived[]`, `result.reviveSuppressed[]`, `result.escalated[]` alongside `reclaimed[]`. 5 new tests; the return shape stays open-ended (existing consumers unaffected).
6. **End-to-end integration test** — 4 behavioural cases driving the full `schedulerTick` + real `reclaimDeadWorkIfPossible` against a temp events.jsonl. Includes envelope round-trip assertion (writer-reader contract pinned).

## Review fixups (post-implementation)

- **silent-failure-hunter**: 3 HIGH + 1 MEDIUM correctness gaps closed (commit `531d7754`). The audit-append-failure path now aborts dispatch to preserve budget counter integrity. `defaultKillBgJob` verifies the pid is still a `claude` process via `ps -p` before SIGKILL'ing (recycled-pid guard).
- **code-reviewer**: 1 MUST FIX + 4 SHOULD FIX closed (commit `0e1e74ed`). `defaultReviveDispatch` now writes the signal atomically (`tmp + renameSync`), matching `abort-worker.mjs:77-79`. Audit-append-failure suppression emits a distinct `reason: 'audit-append-failed'` so operators can filter it apart from storm-breaker suppression.
- **pr-test-analyzer**: 3 CRITICAL + 1 IMPORTANT test gaps closed (commit `0e1e74ed`). The load-bearing logic inside `defaultReviveDispatch` (signal reset + atomicity) and `defaultKillBgJob` (pid-recycling guard) is now directly exercised — previously every test stubbed these seams. The envelope round-trip test pins the `buildEventEnvelope` ↔ `countReviveEvents` contract.

## Testing

| Suite | Pass |
|---|---|
| `bun test` (execution-core, 22 files) | 401 / 401 |
| `phase-agent-dispatch-test-kill.test.sh` | 14 / 14 |
| `phase-agent-dispatch.test.sh` (regression) | 73 / 73 |

The known-flaky `daemon.test.mjs: reconciles when the registry changes` (fs.watch latency under concurrent load — comment at `daemon.test.mjs:103` calls it out) occasionally fails in one of three sequential full-suite runs; a re-run goes green. Unrelated to CTL-587.

## What's NOT in scope (deferred follow-ups)

- `events.jsonl` rotation / tail cache (file is MB-scale today; sized as a follow-up if it grows past ~50 MB).
- Probes for `research`/`plan`/`pr`/`monitor-*` phases — they escalate to `needs-human` immediately when their workers die mid-flight (no work-done probe to consult).
- 7 lower-impact pr-test-analyzer "nice-to-have" gaps and 4 code-reviewer NITs (Linux `ps` truncation, snake_case payload keys, single-pass event scan, etc.) — listed in the relevant fixup commits.

Refs: [CTL-587](https://linear.app/coalesce-labs/issue/CTL-587)
Related research: \`thoughts/shared/research/2026-05-23-CTL-587-dead-worker-auto-revival.md\`
Implementation plan: \`thoughts/shared/plans/2026-05-24-CTL-587-dead-worker-auto-revival.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)