### PR TITLE
CTL-586: hoist PID-file write in execution-core daemon

### DIFF
--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -89,16 +89,19 @@ cmd_start() {
 		sleep 0.1
 		waited=$((waited + 1))
 	done
-	# The daemon writes its own PID file last — only after recover, monitor,
-	# and scheduler boot (daemon.mjs). A missing PID file with the process
-	# still alive means it is hung mid-init. Fabricating a PID file here would
-	# defeat that "fully initialized" signal and report success for a daemon
-	# that may never finish booting, so report the uncertain state and fail.
-	# The daemon stays the sole PID-file writer.
+	# CTL-586: the daemon writes its PID file early — immediately after
+	# ensureState, before recover/monitor/scheduler boot (daemon.mjs). PID
+	# presence means "process up", not "fully reconciled" — the
+	# "execution-core daemon started" log line remains the fully-booted
+	# signal. A missing PID file after 2s with the process still alive means
+	# the daemon wedged before its very-first synchronous write completed —
+	# a hard failure, not a transient slow-boot. Fabricating a PID file here
+	# would mask a daemon that never wrote one, so report and fail. The
+	# daemon stays the sole PID-file writer.
 	if is_alive "$server_pid"; then
 		echo "error: catalyst-execution-core process $server_pid is alive but has" \
-			"not written its PID file after 2s — daemon may be hung mid-init;" \
-			"check $LOG_FILE" >&2
+			"not written its PID file after 2s — daemon wedged before initial" \
+			"write; check $LOG_FILE" >&2
 		return 1
 	fi
 	echo "error: catalyst-execution-core failed to start — check $LOG_FILE" >&2

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -62,50 +62,66 @@ export function startDaemon({
   _stopMonitor = stopMonitorFn;
   _stopScheduler = stopSchedulerFn;
 
-  recover({ orchDir }); // CTL-539 — rebuild routing + worker state on boot
-  // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
-  // agent on a →Triage transition. `dispatch` stays an injectable default
-  // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
-  monitorFn({ orchDir }); // CTL-535 + CTL-565 — two-state trigger monitor
-  // CTL-558: the scheduler writes Linear status via its default `writeStatus`
-  // (linear-write.mjs) on every committed phase transition — no daemon wiring
-  // needed; production uses the real module, tests inject fakes.
-  schedulerFn({ orchDir }); // CTL-536 — pull-loop scheduler
-
-  if (watchRegistry) {
-    // Watch the execution-core dir for registry.json changes — the registry is
-    // the single source of enrolled projects (CTL-582 D4). ensureState already
-    // created the dir. registry.mjs writes the registry tmp+rename, so the
-    // directory watch sees the rename; the filename filter ignores the noisy
-    // state.json / cursor.json writes that share the directory.
-    _watcher = watch(getExecutionCoreDir(), (_eventType, filename) => {
-      if (filename !== null && filename !== "registry.json") return;
-      // _debounceTimer is module-scoped so stopDaemon can cancel a pending
-      // reconcile that would otherwise fire after teardown.
-      clearTimeout(_debounceTimer);
-      _debounceTimer = setTimeout(() => {
-        log.info("execution-core daemon: registry changed — reconciling");
-        try {
-          reconcile();
-        } catch (err) {
-          // A reconcile failure means registry changes silently stop being
-          // applied — newly registered projects are never picked up. Surface
-          // it at error level with the full error, not a swallowed warning.
-          log.error(
-            { err },
-            "execution-core daemon: reconcile failed — registry changes are NOT being applied"
-          );
-        }
-      }, debounceMs);
-    });
-  }
-
+  // CTL-586: write the PID file BEFORE the synchronous boot work
+  // (recover/monitor/scheduler each trigger a blocking reconcile that fans
+  // out one spawnSync("linearis", ...) per registered team). The wrapper's
+  // 2s PID-file poll (catalyst-execution-core:83-91) otherwise times out
+  // and reports "may be hung mid-init" against a daemon that is in fact
+  // booting normally. PID-file presence now means "process up" — callers
+  // do `kill 0 <pid>` for liveness; the daemon stays the sole writer.
   if (pidFile) {
     _pidFile = pidFile;
     const tmp = `${pidFile}.tmp`;
     writeFileSync(tmp, String(process.pid));
     renameSync(tmp, pidFile);
   }
+
+  // A throw from any composed boot step must not leave a stale PID file —
+  // stopDaemon removes _pidFile via unlinkSync. Rethrow so the main()-level
+  // try/catch logs and process.exit(1)s as before.
+  try {
+    recover({ orchDir }); // CTL-539 — rebuild routing + worker state on boot
+    // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
+    // agent on a →Triage transition. `dispatch` stays an injectable default
+    // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
+    monitorFn({ orchDir }); // CTL-535 + CTL-565 — two-state trigger monitor
+    // CTL-558: the scheduler writes Linear status via its default `writeStatus`
+    // (linear-write.mjs) on every committed phase transition — no daemon wiring
+    // needed; production uses the real module, tests inject fakes.
+    schedulerFn({ orchDir }); // CTL-536 — pull-loop scheduler
+
+    if (watchRegistry) {
+      // Watch the execution-core dir for registry.json changes — the registry is
+      // the single source of enrolled projects (CTL-582 D4). ensureState already
+      // created the dir. registry.mjs writes the registry tmp+rename, so the
+      // directory watch sees the rename; the filename filter ignores the noisy
+      // state.json / cursor.json writes that share the directory.
+      _watcher = watch(getExecutionCoreDir(), (_eventType, filename) => {
+        if (filename !== null && filename !== "registry.json") return;
+        // _debounceTimer is module-scoped so stopDaemon can cancel a pending
+        // reconcile that would otherwise fire after teardown.
+        clearTimeout(_debounceTimer);
+        _debounceTimer = setTimeout(() => {
+          log.info("execution-core daemon: registry changed — reconciling");
+          try {
+            reconcile();
+          } catch (err) {
+            // A reconcile failure means registry changes silently stop being
+            // applied — newly registered projects are never picked up. Surface
+            // it at error level with the full error, not a swallowed warning.
+            log.error(
+              { err },
+              "execution-core daemon: reconcile failed — registry changes are NOT being applied"
+            );
+          }
+        }, debounceMs);
+      });
+    }
+  } catch (err) {
+    stopDaemon();
+    throw err;
+  }
+
   log.info({ orchDir }, "execution-core daemon started");
 }
 

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -85,6 +85,77 @@ describe("startDaemon", () => {
     expect(Number(readFileSync(pidFile, "utf8").trim())).toBe(process.pid);
   });
 
+  // CTL-586: the wrapper's 2s PID-file poll otherwise times out against a
+  // daemon doing N × spawnSync("linearis") inside recover/monitor/scheduler.
+  // The write must land BEFORE any composed boot step runs.
+  test("writes the PID file BEFORE invoking recover (so the wrapper's poll sees it)", () => {
+    const pidFile = join(process.env.CATALYST_DIR, "daemon.pid");
+    let pidFileExistedBeforeRecover = false;
+    startDaemon({
+      recover: () => {
+        pidFileExistedBeforeRecover = existsSync(pidFile);
+      },
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      pidFile,
+    });
+    expect(pidFileExistedBeforeRecover).toBe(true);
+    expect(Number(readFileSync(pidFile, "utf8").trim())).toBe(process.pid);
+  });
+
+  // CTL-586: a synchronous throw from any composed boot step must trigger
+  // stopDaemon's PID-file unlink — otherwise the moved-up write leaves a
+  // stale PID file pointing at a dead pid.
+  test("removes the PID file if recover throws synchronously", () => {
+    const pidFile = join(process.env.CATALYST_DIR, "daemon.pid");
+    const boom = new Error("simulated recover failure");
+    expect(() =>
+      startDaemon({
+        recover: () => {
+          throw boom;
+        },
+        startMonitor: () => {},
+        startScheduler: () => {},
+        watchRegistry: false,
+        pidFile,
+      })
+    ).toThrow("simulated recover failure");
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  test("removes the PID file if startMonitor throws synchronously", () => {
+    const pidFile = join(process.env.CATALYST_DIR, "daemon.pid");
+    expect(() =>
+      startDaemon({
+        recover: () => {},
+        startMonitor: () => {
+          throw new Error("simulated monitor failure");
+        },
+        startScheduler: () => {},
+        watchRegistry: false,
+        pidFile,
+      })
+    ).toThrow("simulated monitor failure");
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  test("removes the PID file if startScheduler throws synchronously", () => {
+    const pidFile = join(process.env.CATALYST_DIR, "daemon.pid");
+    expect(() =>
+      startDaemon({
+        recover: () => {},
+        startMonitor: () => {},
+        startScheduler: () => {
+          throw new Error("simulated scheduler failure");
+        },
+        watchRegistry: false,
+        pidFile,
+      })
+    ).toThrow("simulated scheduler failure");
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
   test("reconciles when the registry changes (debounced)", async () => {
     let reconciled = 0;
     startDaemon({


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-24T23:32:00Z -->
<!-- Last updated: 2026-05-24T23:32:00Z -->
<!-- PR: #1001 -->
<!-- Previous commits: 04b290e2,49d11cc1 -->

## Summary

`catalyst-execution-core start` reported `error: ... process is alive but has not written its PID file after 2s — daemon may be hung mid-init` and exited 1 on fresh boots, even though the daemon came up correctly seconds later. Root cause: `startDaemon` (`plugins/dev/scripts/execution-core/daemon.mjs`) wrote the PID file *last*, after `recover()`, `startMonitor()`, and `startScheduler()` had each completed their synchronous first-tick reconciles. Each reconcile fans out one `spawnSync("linearis", ...)` per registered team — with two teams (CTL + ADV), the first reconcile took ~2.4 s in the failing QA run, blowing past the wrapper's 2 s PID-file poll. The daemon booted normally; only the wrapper's exit code was wrong.

This PR inverts the contract so "PID file present" means **process up**, not "first reconcile finished". `startDaemon` now writes the PID file immediately after `ensureState`, before invoking `recover/monitor/scheduler`. The composed boot steps are wrapped in a `try/catch` that calls `stopDaemon()` (which unlinks the PID file) before rethrowing, so a synchronous failure in any step never leaves a stale PID file. The wrapper's error message and surrounding comment are updated to reflect the new contract — a missing PID file after 2 s with the process still alive now genuinely means the daemon wedged before its first synchronous write, which is a hard failure.

## Changes Made

### `plugins/dev/scripts/execution-core/daemon.mjs` (+58 / -42)

Hoisted the `writeFileSync(tmp, pid) + renameSync(tmp, pidFile)` block to run *before* `recover/monitor/scheduler` instead of after. The three boot steps and the optional `watchRegistry` setup now live inside a `try { ... } catch (err) { stopDaemon(); throw err; }`, so any synchronous throw from a composed step (recover, monitor, scheduler, or `watch()` itself) unlinks the freshly-written PID file via `stopDaemon`'s existing `unlinkSync` path before rethrowing. The CTL-586 comment block explains *why* the hoist is necessary (2 s wrapper poll vs. N × `spawnSync("linearis")` reconcile) and what PID-file presence now signals.

### `plugins/dev/scripts/catalyst-execution-core` (+11 / -8)

The CTL-586 wrapper comment at lines 92-104 now describes the new contract: "PID file presence means process up, not fully reconciled; the 'execution-core daemon started' log line remains the fully-booted signal." The error message changes from "daemon may be hung mid-init" to "daemon wedged before initial write" — accurate under the new write order. Phase-review remediation (commit 49d11cc1) rewrote the comment + error string after the review caught that the original text was stale.

### `plugins/dev/scripts/execution-core/daemon.test.mjs` (+71)

Four new tests pin the new contract:

1. **`writes the PID file BEFORE invoking recover`** — injects a `recover` fake that records `existsSync(pidFile)` and asserts it returns `true`. Without the hoist this is `false`.
2. **`removes the PID file if recover throws synchronously`** — injects a throwing `recover`, asserts `startDaemon` rethrows the original error AND `existsSync(pidFile)` is `false`.
3. **`removes the PID file if startMonitor throws synchronously`** — same pattern for `startMonitor`.
4. **`removes the PID file if startScheduler throws synchronously`** — same pattern for `startScheduler`.

These guard against a regression that would either (a) move the write back below `recover` (breaking the 2 s poll again) or (b) drop the `try/catch` and leave a stale PID file on a failed boot.

## How to Verify It

- [x] `node --test plugins/dev/scripts/execution-core/daemon.test.mjs` — all four new CTL-586 cases pass alongside the existing suite
- [x] `bash plugins/dev/scripts/__tests__/run-tests.sh plugins/dev/scripts/execution-core/daemon.test.mjs` — aggregate gate green for the affected file (3 unrelated shell suites red on main; pre-existing per project memory `project_run_tests_preexisting_failures`)
- [ ] On a host with ≥2 enrolled teams (CTL + ADV), run `catalyst-execution-core stop && catalyst-execution-core start` and confirm exit code 0 and no false-negative "may be hung" message; `catalyst-execution-core status` reports `running (pid N)` immediately

## Related

Refs: CTL-586
Research: `thoughts/shared/research/2026-05-24-ctl-586.md`
Plan: `thoughts/shared/plans/2026-05-24-ctl-586.md`
QA report that surfaced the false-negative: `thoughts/shared/handoffs/exec-core-tracer/2026-05-22_13-28-31_ctl-582-merged-qa-next.md`
