### PR TITLE
CTL-573: Root worker worktrees on origin/<base> after pre-flight fetch

### DIFF
--- a/plugins/dev/scripts/__tests__/create-worktree-base-ref.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-base-ref.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Tests for CTL-573: create-worktree.sh must root new branches on
+# refs/remotes/origin/<BASE> after a pre-flight fetch, so worker worktrees
+# do not branch off a stale local <BASE>.
+# Run: bash plugins/dev/scripts/__tests__/create-worktree-base-ref.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CREATE_WT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+
+FAILURES=0
+PASSES=0
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+assert_eq() {
+	if [[ $1 == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi
+}
+assert_contains() {
+	if [[ $1 == *"$2"* ]]; then pass "$3"; else fail "$3 — '$2' not in output"; fi
+}
+
+# Build a scratch layout:
+#   SCRATCH/origin.git        bare repo, ref serves as "origin"
+#   SCRATCH/src               working clone with stale local main
+#   SCRATCH/wt                worktree base
+#   SCRATCH/bin/humanlayer    stub (no-op)
+build_scratch() {
+	SCRATCH="$(mktemp -d -t cwt-ctl573-XXXXXX)"
+	ORIGIN="$SCRATCH/origin.git"
+	SRC="$SCRATCH/src"
+	WT="$SCRATCH/wt"
+	BIN="$SCRATCH/bin"
+	FAKEHOME="$SCRATCH/home"
+	mkdir -p "$WT" "$BIN" "$FAKEHOME"
+	git init -q --bare "$ORIGIN"
+
+	# Seed origin/main with two commits.
+	local SEED="$SCRATCH/seed"
+	git clone -q "$ORIGIN" "$SEED"
+	git -C "$SEED" config user.email t@t.t
+	git -C "$SEED" config user.name t
+	git -C "$SEED" checkout -q -b main 2>/dev/null || git -C "$SEED" checkout -q main
+	git -C "$SEED" commit -q --allow-empty -m c1
+	git -C "$SEED" push -q -u origin main
+	git -C "$SEED" commit -q --allow-empty -m c2-on-origin
+	git -C "$SEED" push -q
+
+	# Clone, then rewind local main to c1 to simulate the CTL-573 stale state.
+	git clone -q "$ORIGIN" "$SRC"
+	git -C "$SRC" config user.email t@t.t
+	git -C "$SRC" config user.name t
+	git -C "$SRC" checkout -q main
+	ORIGIN_TIP="$(git -C "$SRC" rev-parse origin/main)"
+	C1="$(git -C "$SRC" rev-parse origin/main~1)"
+	git -C "$SRC" reset -q --hard "$C1"
+
+	mkdir -p "$SRC/.catalyst"
+	printf '{"catalyst":{"projectKey":"t"}}\n' >"$SRC/.catalyst/config.json"
+
+	cat >"$BIN/humanlayer" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "thoughts status") echo "Profile: testprofile" ;;
+  "thoughts init") mkdir -p thoughts/shared && echo x > thoughts/shared/.keep ;;
+  *) exit 0 ;;
+esac
+STUB
+	chmod +x "$BIN/humanlayer"
+}
+
+run_create() { # $1 worktree name; $@ extra args
+	local NAME="$1"
+	shift
+	OUTPUT="$(cd "$SRC" && PATH="$BIN:$PATH" HOME="$FAKEHOME" \
+		bash "$CREATE_WT" "$NAME" main --worktree-dir "$WT" "$@" 2>&1)"
+	EXIT=$?
+	WT_PATH="$WT/$NAME"
+}
+
+# Case 1 — default: fetch runs, new branch is rooted on origin/main, not stale local main.
+echo "Test 1: new branch is rooted on origin/main when fetch succeeds"
+build_scratch
+run_create wt-default
+assert_eq "0" "$EXIT" "exits 0 on default path"
+HEAD_SHA="$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || echo NA)"
+assert_eq "$ORIGIN_TIP" "$HEAD_SHA" "worktree HEAD matches origin/main, not stale local main"
+rm -rf "$SCRATCH"
+
+# Case 2 — fetch failure (no origin): warn + fall back to local, exit 0.
+echo "Test 2: fetch failure falls back to local base ref with a warning"
+build_scratch
+git -C "$SRC" remote remove origin # break origin to force fetch failure
+LOCAL_TIP="$(git -C "$SRC" rev-parse main)"
+run_create wt-no-origin
+assert_eq "0" "$EXIT" "exits 0 when origin is unreachable"
+assert_contains "$OUTPUT" "fetch" "warning mentions fetch"
+HEAD_SHA="$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || echo NA)"
+assert_eq "$LOCAL_TIP" "$HEAD_SHA" "worktree HEAD falls back to local base ref"
+rm -rf "$SCRATCH"
+
+# Case 3 — --reuse-existing on an already-present dir: no fetch, no change.
+echo "Test 3: --reuse-existing short-circuits before fetch"
+build_scratch
+mkdir -p "$WT/wt-reuse" # pre-create the path
+run_create wt-reuse --reuse-existing
+assert_eq "0" "$EXIT" "exits 0 on reuse"
+assert_contains "$OUTPUT" "Reusing existing worktree" "reuse path taken"
+rm -rf "$SCRATCH"
+
+# Case 4 — --skip-fetch: no fetch attempted, new branch rooted on local main.
+echo "Test 4: --skip-fetch suppresses the fetch and uses local base ref"
+build_scratch
+LOCAL_TIP="$(git -C "$SRC" rev-parse main)"
+run_create wt-skip --skip-fetch
+assert_eq "0" "$EXIT" "exits 0 with --skip-fetch"
+# Output must NOT contain the fetch-success banner.
+if [[ $OUTPUT != *"Fetched origin/"* ]]; then
+	pass "no 'Fetched origin/' banner when --skip-fetch is set"
+else
+	fail "fetch ran despite --skip-fetch"
+fi
+HEAD_SHA="$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || echo NA)"
+assert_eq "$LOCAL_TIP" "$HEAD_SHA" "worktree HEAD matches local main when fetch is skipped"
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Passed: $PASSES  Failed: $FAILURES"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh
@@ -58,7 +58,7 @@ case "\$1 \$2" in
 esac
 STUB
 	chmod +x "$BIN/humanlayer"
-	local -a CW_ARGS=(t-CTL-999 main --worktree-dir "$WT")
+	local -a CW_ARGS=(t-CTL-999 main --worktree-dir "$WT" --skip-fetch)
 	if [[ -n $HOOKS_JSON ]]; then
 		CW_ARGS+=(--hooks-json "$HOOKS_JSON")
 	fi

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # create-worktree.sh - Create a git worktree for isolated development
-# Usage: ./create-worktree.sh [worktree_name] [base_branch] [--worktree-dir <path>] [--hooks-json <json>] [--orchestration <name>] [--reuse-existing]
+# Usage: ./create-worktree.sh [worktree_name] [base_branch] [--worktree-dir <path>] [--hooks-json <json>] [--orchestration <name>] [--reuse-existing] [--skip-fetch]
 #
 # Options:
 #   --worktree-dir <path>       Override worktree base directory (used by orchestrator)
@@ -9,6 +9,10 @@
 #   --reuse-existing            If the worktree already exists, skip creation/setup
 #                               and succeed. Makes the script idempotent for tab-config
 #                               launchers that re-open a long-lived worktree (e.g. "pm").
+#   --skip-fetch                Do not fetch the base branch from origin before
+#                               creating the worktree. Use for offline or
+#                               test-isolated invocations; the new branch will
+#                               be rooted on the local <base_branch> tip.
 
 set -e
 
@@ -24,6 +28,7 @@ OVERRIDE_WORKTREE_DIR=""
 HOOKS_JSON=""
 ORCHESTRATION_NAME=""
 REUSE_EXISTING=false
+SKIP_FETCH=false
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -31,6 +36,7 @@ while [[ $# -gt 0 ]]; do
 		--hooks-json) HOOKS_JSON="$2"; shift 2 ;;
 		--orchestration) ORCHESTRATION_NAME="$2"; shift 2 ;;
 		--reuse-existing) REUSE_EXISTING=true; shift ;;
+		--skip-fetch) SKIP_FETCH=true; shift ;;
 		*) POSITIONAL+=("$1"); shift ;;
 	esac
 done
@@ -125,7 +131,16 @@ if git show-ref --verify --quiet "refs/heads/${WORKTREE_NAME}"; then
 	git worktree add "$WORKTREE_PATH" "$WORKTREE_NAME"
 else
 	echo "🆕 Creating new branch: ${WORKTREE_NAME}"
-	git worktree add -b "$WORKTREE_NAME" "$WORKTREE_PATH" "$BASE_BRANCH"
+	START_POINT="$BASE_BRANCH"
+	if [ "$SKIP_FETCH" = false ]; then
+		if git fetch --quiet origin "$BASE_BRANCH" 2>/dev/null; then
+			START_POINT="refs/remotes/origin/${BASE_BRANCH}"
+			echo "🔄 Fetched origin/${BASE_BRANCH}; rooting on remote tip"
+		else
+			echo -e "${YELLOW}⚠️  Could not fetch origin/${BASE_BRANCH}; falling back to local ${BASE_BRANCH} (worker may branch off stale ref)${NC}" >&2
+		fi
+	fi
+	git worktree add -b "$WORKTREE_NAME" "$WORKTREE_PATH" "$START_POINT"
 fi
 
 # Copy .claude directory if it exists (Claude Code native config)


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-24T23:48:00Z -->
<!-- Last updated: 2026-05-24T23:48:00Z -->
<!-- PR: #1002 -->
<!-- Previous commits: 68bfac0b -->

## Summary

`plugins/dev/scripts/create-worktree.sh` ran `git worktree add -b <new> <path> <BASE_BRANCH>` against the **local** base ref without ever contacting `origin` first. When the invoking clone's local `main` lagged `origin/main` — a near-permanent state for orchestrators running from a long-lived workspace — every worker worktree was rooted on stale code. The CTL-573 repro had 14 missing commits, which happened to be the entire execution-core daemon that three orchestrated tickets (CTL-564 / 565 / 558) depended on; their research and plan phases ran against a tree where `plugins/dev/scripts/execution-core/` did not yet exist, and the phase skills' mid-run `merge origin/main` came too late to save them. Required a full Wave-1 restart.

This PR adds a single pre-flight step to `create-worktree.sh`: best-effort `git fetch --quiet origin <BASE>`, and on success root the new branch on `refs/remotes/origin/<BASE>` instead of the local tip. Fetch failures (offline, network-isolated CI, etc.) fall back to the local ref with a visible warning, so existing behavior is preserved as the degraded path rather than the default. A new `--skip-fetch` flag opts a caller out entirely — required for the shell-test harness which builds a scratch bare repo with no usable `origin` for the worktree's parent clone.

## Changes Made

### `plugins/dev/scripts/create-worktree.sh` (+17 / -2)

The new-branch path (`git worktree add -b ... "$BASE_BRANCH"`) is replaced with a `START_POINT` indirection. When `SKIP_FETCH=false` (the default), the script attempts `git fetch --quiet origin "$BASE_BRANCH"`; on success `START_POINT` becomes `refs/remotes/origin/${BASE_BRANCH}` and a "🔄 Fetched origin/…; rooting on remote tip" banner is printed. On fetch failure (return code non-zero, stderr suppressed) it warns "Could not fetch origin/…; falling back to local … (worker may branch off stale ref)" in yellow and falls through to the original local-ref behavior. The existing-branch path (`git worktree add "$WORKTREE_PATH" "$WORKTREE_NAME"`) is untouched — re-attaching to an already-created branch never needed the fetch.

The `--skip-fetch` flag is added to the option parser and the usage comment. Documented as "for offline or test-isolated invocations; the new branch will be rooted on the local `<base_branch>` tip."

### `plugins/dev/scripts/__tests__/create-worktree-base-ref.test.sh` (+135, new)

Four scratch-repo test cases pin the new contract. Each builds a `mktemp -d` layout with `origin.git` (bare), `src/` (clone with local main reset to `c1` to simulate a stale state where `origin/main` is at `c2-on-origin`), `wt/` (worktree base), and a `bin/humanlayer` stub:

1. **`new branch is rooted on origin/main when fetch succeeds`** — default invocation; asserts the new worktree's `HEAD` equals `ORIGIN_TIP` (c2), not the stale local main (c1).
2. **`fetch failure falls back to local base ref`** — points the clone's `origin` at a path that does not exist so `git fetch` errors; asserts the script still exits 0, the worktree HEAD lands on the stale local tip, and the warning banner is printed.
3. **`--reuse-existing short-circuits before fetch`** — pre-creates the target worktree dir; asserts the script exits 0 with the "Reusing existing worktree" banner and never runs the fetch path.
4. **`--skip-fetch suppresses the fetch and uses local base ref`** — asserts the new worktree's HEAD equals the local main tip and that the "Fetched origin/" banner is absent from stdout.

The seed pattern (`git push -q -u origin main` then `commit --allow-empty -m c2-on-origin` then `git -C "$SRC" reset --hard "$C1"`) makes the stale-state repro deterministic without needing any network or timing tricks. All four cases run inside disposable `SCRATCH` dirs that are `rm -rf`'d after each case so they cannot leak between runs.

### `plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh` (+1 / -1)

The pre-existing thoughts-check harness calls `create-worktree.sh` against a bare `origin.git` that lives only on the local filesystem; with the new default-on fetch it would try (and fail noisily) to fetch from the parent clone's real `origin` and produce yellow warnings the assertions do not expect. Single-line change: appends `--skip-fetch` to the `CW_ARGS` array so the harness opts out of the network step. No assertion logic changes.

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/create-worktree-base-ref.test.sh` — 10/10 assertions pass
- [x] `bash plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh` — 15/15 assertions pass (no regression from the `--skip-fetch` addition)
- [x] `shellcheck plugins/dev/scripts/create-worktree.sh` — clean inside the diff range (2 pre-existing SC2034 warnings on L69–70 for `GITHUB_ORG`/`REPO` unused, untouched by this PR)
- [ ] On a clone with stale local main, run `bash plugins/dev/scripts/create-worktree.sh CTL-test main` and confirm the "🔄 Fetched origin/main; rooting on remote tip" banner and that `git -C <worktree> log -1` shows the origin/main tip, not the local tip

## Related

Refs: CTL-573
Research: `thoughts/shared/research/2026-05-24-ctl-573.md`
Plan: `thoughts/shared/plans/2026-05-24-CTL-573-worktree-base-ref-sync.md`
Original repro: orchestrate run `o-ctl-564-565-558`, where this stale-base bug forced a full Wave-1 restart after research and plan phases ran against a tree missing `plugins/dev/scripts/execution-core/`
