### PR TITLE
fix(dev): stop execution-core label-retry storm on missing workspace labels (CTL-585)

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -95,19 +95,34 @@ export function applyTerminalDone({ ticket, resolveRepoRoot, exec }) {
   return runTransition({ ticket, key: TERMINAL_LINEAR_KEY, resolveRepoRoot, exec });
 }
 
-// applyLabel — additively apply a Linear label (triaged, needs-human) AND verify
-// the write landed. CTL-587: per memory project_linear_transition_silent_success,
-// linearis can exit 0 on a label update that did NOT actually land (rate
-// limiting, transient API). The read-back via fetchTicketLabels closes that
-// silent-success gap: `applied: true` now means a follow-up `linearis issues
-// read` confirmed the label is on the ticket. `applied: false` comes with a
-// `reason` discriminator so callers can distinguish:
-//   - 'write-failed'   — the update itself exited non-zero (no read-back run)
-//   - 'verify-failed'  — update exited 0 but the read-back is missing the label
-//                        (the silent-success case) OR the read-back exec failed
-//   - 'exception'      — the exec itself threw
-// All three are retryable next tick: labelOnce (scheduler.mjs) only writes its
-// marker when applied: true, so a failure naturally retries.
+// applyLabel — additively apply a Linear label (triaged, needs-human), classify
+// any failure, AND verify a successful write actually landed. Returns a tagged
+// { applied, reason } shape callers use to decide retry vs short-circuit.
+//
+// Two failure axes are folded together here:
+//   1. CTL-585 — when the write exits non-zero, classifyLabelFailure maps the
+//      stderr to a reason so callers can stop the retry storm on the one
+//      unrecoverable case ("missing-label": the workspace has no such label;
+//      retrying every tick just storms the Linear API).
+//   2. CTL-587 — when the write exits 0, linearis can still have silently NOT
+//      applied the label (rate limiting, transient API). A read-back via
+//      fetchTicketLabels closes that silent-success gap, so `applied: true`
+//      means a follow-up read confirmed the label is on the ticket.
+//
+// reason values:
+//   null            — success (applied: true)
+//   "missing-label" — workspace lacks the label; create it in the Linear UI.
+//                     Unrecoverable inside one daemon lifetime — callers
+//                     (scheduler.labelOnce) write a .skipped marker and do not
+//                     retry it this run.
+//   "rate-limited"  — Linear write rate-cap hit; retry next tick.
+//   "verify-failed" — write exited 0 but the read-back is missing the label
+//                     (the silent-success case) OR the read-back exec failed;
+//                     retry next tick.
+//   "transient"     — every other failure (network, spawn error, unknown
+//                     stderr, exec threw); retry next tick.
+// All reasons except "missing-label" are retryable next tick: labelOnce only
+// writes its .applied marker when applied: true, so a failure naturally retries.
 export function applyLabel({ ticket, label, exec = defaultExec }) {
   try {
     const writeRes = exec("linearis", [
@@ -120,11 +135,12 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
       "add",
     ]);
     if (writeRes.code !== 0) {
+      const reason = classifyLabelFailure(writeRes.stderr);
       log.warn(
-        { ticket, label, code: writeRes.code, stderr: writeRes.stderr },
+        { ticket, label, code: writeRes.code, reason, stderr: writeRes.stderr },
         "linear-write: label write failed (exit non-zero)"
       );
-      return { applied: false, reason: "write-failed" };
+      return { applied: false, reason };
     }
     const labels = fetchTicketLabels(ticket, { exec });
     if (!Array.isArray(labels) || !labels.includes(label)) {
@@ -134,12 +150,23 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
       );
       return { applied: false, reason: "verify-failed" };
     }
-    return { applied: true };
+    return { applied: true, reason: null };
   } catch (err) {
     log.warn(
-      { ticket, label, err: err.message },
+      { ticket, label, reason: "transient", err: err.message },
       "linear-write: label write threw — swallowed"
     );
-    return { applied: false, reason: "exception" };
+    return { applied: false, reason: "transient" };
   }
+}
+
+// classifyLabelFailure — map a `linearis issues update --labels` stderr to
+// one of the tagged reason codes. Both substrings are the literal forms
+// observed in ~/catalyst/execution-core/daemon.log during the CTL-380 QA
+// run (CTL-585 research §3, §7).
+function classifyLabelFailure(stderr) {
+  const s = String(stderr ?? "");
+  if (s.includes("not found")) return "missing-label";
+  if (s.includes("Rate limit")) return "rate-limited";
+  return "transient";
 }

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -138,7 +138,7 @@ describe("applyLabel", () => {
     const calls = [];
     const exec = makeOkExec(calls); // read-back returns the label
     const r = applyLabel({ ticket: "CTL-1", label: "needs-human", exec });
-    expect(r).toEqual({ applied: true });
+    expect(r).toEqual({ applied: true, reason: null });
     expect(calls[0].args.slice(0, 2)).toEqual(["issues", "update"]);
     expect(calls[1].args.slice(0, 2)).toEqual(["issues", "read"]);
   });
@@ -151,20 +151,8 @@ describe("applyLabel", () => {
     expect(r.reason).toBe("verify-failed");
   });
 
-  test("CTL-587: write fails → applied:false, write-failed (NO read-back attempted)", () => {
-    const calls = [];
-    const exec = (cmd, args) => {
-      calls.push({ cmd, args });
-      return { code: 1, stdout: "", stderr: "rate limited" };
-    };
-    const r = applyLabel({ ticket: "CTL-1", label: "needs-human", exec });
-    expect(r.applied).toBe(false);
-    expect(r.reason).toBe("write-failed");
-    expect(calls).toHaveLength(1); // only the update; no read-back attempted
-  });
-
   test("CTL-587: read-back returns null (linearis read failure) → applied:false, verify-failed", () => {
-    const exec = (cmd, args) => {
+    const exec = (_cmd, args) => {
       if (args[1] === "update") return { code: 0, stdout: "", stderr: "" };
       if (args[1] === "read") return { code: 1, stdout: "", stderr: "" };
       return { code: 127 };
@@ -179,5 +167,48 @@ describe("applyLabel", () => {
       throw new Error("exec died");
     };
     expect(applyLabel({ ticket: "CTL-1", label: "needs-human", exec }).applied).toBe(false);
+  });
+
+  // CTL-585: tagged-reason return contract on the write-failure path. A
+  // non-zero exit is classified so callers can short-circuit the one
+  // unrecoverable case (missing-label) instead of storming the Linear API.
+  // The success path still flows through the CTL-587 read-back above.
+  test("CTL-585: zero exit + read-back confirms → applied:true, reason:null", () => {
+    const calls = [];
+    const exec = makeOkExec(calls, { readbackLabels: [{ name: "triaged" }] });
+    const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
+    expect(r).toEqual({ applied: true, reason: null });
+  });
+  test("CTL-585: classifies a missing-label stderr as reason:'missing-label' (no read-back)", () => {
+    const calls = [];
+    const exec = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 1, stdout: "", stderr: 'Label "triaged" not found' };
+    };
+    const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
+    expect(r).toEqual({ applied: false, reason: "missing-label" });
+    expect(calls).toHaveLength(1); // write failed → no read-back attempted
+  });
+  test("CTL-585: classifies a rate-limit stderr as reason:'rate-limited'", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "Rate limit exceeded" });
+    const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
+    expect(r).toEqual({ applied: false, reason: "rate-limited" });
+  });
+  test("CTL-585: any other non-zero exit is reason:'transient'", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "boom" });
+    const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
+    expect(r).toEqual({ applied: false, reason: "transient" });
+  });
+  test("CTL-585: a spawn-error (code 127) is reason:'transient'", () => {
+    const exec = () => ({ code: 127, stdout: "", stderr: "ENOENT" });
+    const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
+    expect(r).toEqual({ applied: false, reason: "transient" });
+  });
+  test("CTL-585: a thrown exec is reason:'transient' and never throws", () => {
+    const exec = () => {
+      throw new Error("spawn boom");
+    };
+    const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
+    expect(r).toEqual({ applied: false, reason: "transient" });
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -14,6 +14,7 @@
 // lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
 
 import { readdirSync, readFileSync, writeFileSync, existsSync, watch, mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { join, dirname, basename } from "node:path";
 import { analyzeDependencyGraph, referencedBlockerIds } from "../lib/dependency-graph.mjs";
 // PHASES is still imported for deriveAdvancement; CTL-565 note: PHASES[0]
@@ -23,7 +24,7 @@ import { PHASES, transition, isTerminal } from "../lib/phase-fsm.mjs";
 import { rankTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
 import { fetchTicketState } from "./linear-query.mjs";
-import { getProjectConfig } from "./registry.mjs";
+import { getProjectConfig, listProjects } from "./registry.mjs";
 import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
 // CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
@@ -321,6 +322,75 @@ function labelOnce(orchDir, ticket, label, writeStatus) {
   }
 }
 
+// REQUIRED_WORKSPACE_LABELS — the flat labels the CTL-558 coordinator sweep
+// writes. Both must pre-exist in the Linear workspace; linearis has no
+// `labels create`. CTL-585's preflight warns once at daemon start if either
+// is missing, so an operator sees the contract gap before the per-tick label
+// sweep starts (and so the missing-label short-circuit in labelOnce does not
+// surprise a fresh operator).
+const REQUIRED_WORKSPACE_LABELS = ["triaged", "needs-human"];
+
+// preflightWorkspaceLabels — best-effort daemon-start check. For each team,
+// list the team's labels and warn once per missing expected label. `exec`
+// defaults to a spawnSync wrapper that normalises the result shape; `log`
+// defaults to the module logger. Never throws — a broken linearis (missing
+// binary, network outage) logs a single info line and returns.
+export function preflightWorkspaceLabels({
+  teams,
+  exec = defaultPreflightExec,
+  log: logger = log,
+} = {}) {
+  if (!Array.isArray(teams) || teams.length === 0) return;
+  for (const team of teams) {
+    try {
+      const { code, stdout, stderr } = exec("linearis", [
+        "labels", "list", "--team", team,
+      ]);
+      if (code !== 0) {
+        logger.info(
+          { team, code, stderr },
+          "scheduler: workspace-label preflight skipped — linearis labels list failed",
+        );
+        continue;
+      }
+      // linearis labels list emits JSON ({nodes: [{name, ...}, ...]}) — match
+      // the parsing used in linear-query.mjs:100-106. A non-JSON stdout is
+      // treated as a soft preflight skip, not a throw.
+      let names = [];
+      try {
+        const parsed = JSON.parse(String(stdout || "{}"));
+        names = (parsed?.nodes ?? []).map((n) => n?.name).filter(Boolean);
+      } catch (err) {
+        logger.info(
+          { team, err: err.message },
+          "scheduler: workspace-label preflight skipped — linearis stdout is not JSON",
+        );
+        continue;
+      }
+      const present = new Set(names);
+      for (const label of REQUIRED_WORKSPACE_LABELS) {
+        if (!present.has(label)) {
+          logger.warn(
+            { team, label },
+            "scheduler: Linear workspace is missing required label — create it in the Linear UI; the label sweep will skip this label for this run",
+          );
+        }
+      }
+    } catch (err) {
+      logger.info(
+        { team, err: err.message },
+        "scheduler: workspace-label preflight threw — swallowed",
+      );
+    }
+  }
+}
+
+function defaultPreflightExec(cmd, args) {
+  const res = spawnSync(cmd, args, { encoding: "utf8" });
+  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
+  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
 // teardownWorktreeOnce — remove a ticket's git worktree once it reaches
 // terminal Done (CTL-582 Phase 4). The terminal sweep revisits every started
 // ticket each tick, so a once-marker at workers/<T>/.worktree-removed makes
@@ -550,11 +620,21 @@ export function startScheduler({
   exec,
   writeStatus,
   teardownWorktree,
+  preflight = preflightWorkspaceLabels, // CTL-585
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
 } = {}) {
   if (!orchDir) throw new Error("startScheduler: orchDir is required");
   runningOpts = { orchDir, dispatch, readEligible, exec, writeStatus, teardownWorktree };
+
+  // CTL-585: warn once at startup if the Linear workspace lacks the labels
+  // the CTL-558 sweep writes. Best-effort — never blocks startup.
+  try {
+    const teams = listProjects().map((p) => p.team).filter(Boolean);
+    preflight({ teams });
+  } catch (err) {
+    log.info({ err: err.message }, "scheduler: preflight wrapper threw — swallowed");
+  }
 
   runTick(); // authoritative initial pass
   tickTimer = setInterval(runTick, tickIntervalMs);

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -283,21 +283,35 @@ function safeWrite(fn, ctx) {
 }
 
 // labelOnce — apply a Linear label to a ticket at most once for the run's
-// lifetime (CTL-558). `linearis` label-add has no read-compare, so without a
-// guard the scheduler would re-hit the API on every 30s tick. A once-marker
-// file at workers/<T>/.linear-label-<label>.applied (restart-safe — persists
-// with the worker dir) records a successful apply. Best-effort: any throw is
-// logged and swallowed, never aborting the tick.
+// lifetime (CTL-558, CTL-585). `linearis` label-add has no read-compare,
+// so without a guard the scheduler would re-hit the API on every tick.
+//
+// Two marker files at workers/<T>/.linear-label-<label>.{applied,skipped}
+// (restart-safe — persist with the worker dir) record terminal outcomes:
+//   .applied — applyLabel returned applied:true. Happy path.
+//   .skipped — applyLabel returned reason:"missing-label". The workspace
+//              lacks the label; retrying inside this daemon's lifetime
+//              would just storm the Linear API (CTL-585). An operator
+//              creates the label in the Linear UI and deletes this
+//              marker to re-arm the apply.
+//
+// Transient failures (reason:"rate-limited", "transient", undefined) write
+// no marker so the next tick retries — CTL-558's recovery contract.
 function labelOnce(orchDir, ticket, label, writeStatus) {
-  const marker = join(orchDir, "workers", ticket, `.linear-label-${label}.applied`);
-  if (existsSync(marker)) return;
+  const base = join(orchDir, "workers", ticket, `.linear-label-${label}`);
+  if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) return;
   try {
     const res = writeStatus.applyLabel({ ticket, label });
-    // Write the marker only on a confirmed apply — a failed label-write is
-    // retried next tick. A fake that returns undefined (test stubs) is treated
-    // as success so the once-semantics stay testable without a real result.
+    // A fake that returns undefined (test stubs) is treated as success so
+    // the once-semantics stay testable without a real result.
     if (res === undefined || res?.applied) {
-      writeFileSync(marker, "");
+      writeFileSync(`${base}.applied`, "");
+    } else if (res?.reason === "missing-label") {
+      writeFileSync(`${base}.skipped`, "");
+      log.warn(
+        { ticket, label },
+        "scheduler: label missing in workspace — skipping retries for this run",
+      );
     }
   } catch (err) {
     log.warn(

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -29,6 +29,7 @@ import {
   hydrateOutOfSetBlockers,
   startScheduler,
   stopScheduler,
+  preflightWorkspaceLabels,
   __resetForTests,
 } from "./scheduler.mjs";
 
@@ -1333,3 +1334,129 @@ function recorder(returnValue) {
   fn.calls = calls;
   return fn;
 }
+
+// ── CTL-585: daemon-start preflight for missing workspace labels ──
+
+describe("preflightWorkspaceLabels (CTL-585)", () => {
+  test("warns once per missing label per team", () => {
+    const warnings = [];
+    const fakeLog = {
+      warn: (obj, msg) => warnings.push({ obj, msg }),
+      info: () => {},
+      error: () => {},
+    };
+    const exec = (cmd, args) => {
+      expect(cmd).toBe("linearis");
+      expect(args.slice(0, 3)).toEqual(["labels", "list", "--team"]);
+      const team = args[3];
+      // linearis labels list emits JSON ({nodes:[{name,...},...]}).
+      // CTL is missing both expected labels; ENG has both.
+      const nodes = team === "CTL"
+        ? [{ name: "orchestrate" }, { name: "enhancement" }]
+        : [{ name: "triaged" }, { name: "needs-human" }, { name: "bug" }];
+      return { code: 0, stdout: JSON.stringify({ nodes }), stderr: "" };
+    };
+    preflightWorkspaceLabels({
+      teams: ["CTL", "ENG"],
+      exec,
+      log: fakeLog,
+    });
+    const ctlWarns = warnings.filter(
+      (w) => w.obj?.team === "CTL" && w.msg.includes("missing required label"),
+    );
+    expect(ctlWarns.map((w) => w.obj.label).sort()).toEqual([
+      "needs-human",
+      "triaged",
+    ]);
+    const engWarns = warnings.filter((w) => w.obj?.team === "ENG");
+    expect(engWarns).toHaveLength(0);
+  });
+
+  test("does not throw on a linearis spawn failure", () => {
+    const fakeLog = { warn: () => {}, info: () => {}, error: () => {} };
+    const exec = () => ({ code: 127, stdout: "", stderr: "ENOENT" });
+    expect(() =>
+      preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog }),
+    ).not.toThrow();
+  });
+
+  test("does not throw on a thrown exec", () => {
+    const fakeLog = { warn: () => {}, info: () => {}, error: () => {} };
+    const exec = () => {
+      throw new Error("boom");
+    };
+    expect(() =>
+      preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog }),
+    ).not.toThrow();
+  });
+
+  test("real JSON shape with both labels present produces zero warnings", () => {
+    // Regression: an early draft split stdout on newlines, which produced
+    // false-positive warnings against the real JSON output every daemon start.
+    const warnings = [];
+    const fakeLog = {
+      warn: (obj, msg) => warnings.push({ obj, msg }),
+      info: () => {},
+      error: () => {},
+    };
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({
+        nodes: [
+          { name: "triaged", color: "#000" },
+          { name: "needs-human", color: "#fff" },
+          { name: "bug" },
+        ],
+      }),
+      stderr: "",
+    });
+    preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog });
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("non-JSON stdout is a soft skip, not a throw", () => {
+    const infos = [];
+    const fakeLog = {
+      warn: () => {},
+      info: (obj, msg) => infos.push({ obj, msg }),
+      error: () => {},
+    };
+    const exec = () => ({ code: 0, stdout: "not json at all", stderr: "" });
+    expect(() =>
+      preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog }),
+    ).not.toThrow();
+    expect(infos.some((i) => i.msg.includes("stdout is not JSON"))).toBe(true);
+  });
+
+  test("empty teams list is a no-op", () => {
+    const fakeLog = { warn: () => {}, info: () => {}, error: () => {} };
+    let calls = 0;
+    const exec = () => {
+      calls += 1;
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    preflightWorkspaceLabels({ teams: [], exec, log: fakeLog });
+    expect(calls).toBe(0);
+  });
+});
+
+describe("startScheduler — preflight wiring (CTL-585)", () => {
+  afterEach(() => __resetForTests());
+
+  test("invokes preflightWorkspaceLabels once at startup using listProjects() teams", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const calls = [];
+    const fakePreflight = (opts) => calls.push(opts);
+    startScheduler({
+      orchDir,
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus: { applyPhaseStatus() {}, applyTerminalDone() {}, applyLabel() {} },
+      preflight: fakePreflight,
+      tickIntervalMs: 1_000_000, // suppress the periodic tick from firing in-test
+    });
+    stopScheduler();
+    expect(calls).toHaveLength(1);
+    expect(Array.isArray(calls[0].teams)).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -877,6 +877,90 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
       schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus })
     ).not.toThrow();
   });
+
+  // CTL-585: short-circuit the per-tick retry on an unrecoverable miss.
+  test("writes the .skipped marker on reason:'missing-label' and stops retrying", () => {
+    writeSignal("CTL-10", "triage", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const skipped = join(orchDir, "workers", "CTL-10", ".linear-label-triaged.skipped");
+    const applied = join(orchDir, "workers", "CTL-10", ".linear-label-triaged.applied");
+
+    let calls = 0;
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => {
+        calls += 1;
+        return { applied: false, reason: "missing-label" };
+      },
+    };
+
+    // Tick 1: missing-label → .skipped written, .applied not written.
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(existsSync(skipped)).toBe(true);
+    expect(existsSync(applied)).toBe(false);
+    expect(calls).toBe(1);
+
+    // Tick 2: marker present → applyLabel never invoked again.
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(calls).toBe(1);
+  });
+
+  test("a transient failure still retries on the next tick", () => {
+    writeSignal("CTL-11", "triage", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const skipped = join(orchDir, "workers", "CTL-11", ".linear-label-triaged.skipped");
+
+    let calls = 0;
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => {
+        calls += 1;
+        return { applied: false, reason: "transient" };
+      },
+    };
+
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(calls).toBe(2);
+    expect(existsSync(skipped)).toBe(false);
+  });
+
+  test("a rate-limited failure still retries on the next tick", () => {
+    writeSignal("CTL-12", "triage", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    let calls = 0;
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => {
+        calls += 1;
+        return { applied: false, reason: "rate-limited" };
+      },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(calls).toBe(2);
+  });
+
+  test("a pre-existing .skipped marker prevents re-attempt", () => {
+    writeSignal("CTL-13", "triage", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // Pre-seed the .skipped marker (simulates a previous daemon run that hit
+    // the missing-label path).
+    writeFileSync(
+      join(orchDir, "workers", "CTL-13", ".linear-label-triaged.skipped"),
+      ""
+    );
+    let calls = 0;
+    const writeStatus = {
+      ...noWrites(),
+      applyLabel: () => {
+        calls += 1;
+        return { applied: true, reason: null };
+      },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(calls).toBe(0);
+  });
 });
 
 // ── CTL-582: worktree teardown on terminal Done ──

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -28,7 +28,9 @@ Both modes produce the same `triage.json` shape and emit the same canonical phas
 The `triaged` workspace label must already exist in Linear. The label is applied by the
 deterministic coordinator (CTL-558) — the execution-core scheduler's label sweep tags `triaged`
 once the triage phase signal is `done` — not by this skill. `linearis` has no label-create, so the
-label must be created in the workspace beforehand.
+label must be created in the workspace beforehand. Verify with
+`linearis labels list --team <TEAM>`; create missing labels in the Linear workspace UI. The
+execution-core scheduler logs a startup warning per missing label (CTL-585).
 
 ## Inputs
 
@@ -227,6 +229,8 @@ fi
 # 5. The `triaged` label is applied by the coordinator (CTL-558): the
 #    execution-core scheduler's label sweep tags `triaged` once the triage
 #    phase signal is `done`. The phase agent no longer applies the label.
+#    The label must already exist in the workspace — verify with
+#    `linearis labels list --team <TEAM>` (CTL-585).
 
 # 6. Emit the canonical phase event.
 emit_phase_complete --phase triage --ticket "$TICKET" --status complete \


### PR DESCRIPTION
## Summary
- The execution-core daemon retried `applyLabel` every tick for a label that does not exist in the Linear workspace ("Label not found"), storming the Linear API. This classifies failure modes so the one unrecoverable case (`missing-label`) short-circuits instead of retrying.
- `applyLabel` now returns a tagged `{ applied, reason }` shape: `missing-label` / `rate-limited` / `verify-failed` / `transient` / `null`. Only `missing-label` is non-retryable within a daemon lifetime.
- `scheduler.labelOnce` writes a `.skipped` marker on `reason: "missing-label"` so the sweep stops retrying that label for the run; transient failures still retry next tick.
- `preflightWorkspaceLabels` warns once at daemon start when an expected label is missing from a team's workspace, pointing the operator at the Linear UI fix.

## Merge note
This branch predated three sibling PRs that landed on `main` (CTL-578 #1003, CTL-586 #1001, CTL-573 #1002) and the CTL-587 `applyLabel` read-back verification. Rebased onto current `origin/main`; the `applyLabel` conflict was resolved by **combining** both protections — CTL-587's exit-0 read-back verification (silent-success gap) AND CTL-585's non-zero-exit stderr classification (retry-storm fix). Neither behavior was dropped.

## Test plan
- [x] `bun test linear-write.test.mjs` — 20 pass (missing-label / rate-limited / transient / verify-failed classification + read-back)
- [x] `bun test scheduler.test.mjs` — 89 pass (labelOnce `.skipped` short-circuit, preflight warn-once)
- [x] `bun test` (full execution-core suite) — 424 pass, 0 fail