### PR TITLE
CTL-600: Tracer bullet — verify execution-core thin slice end-to-end

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -1,3 +1,4 @@
+<!-- CTL tracer bullet: 2026-05-25 — verifies execution-core pickup -->
 # Orchestrator Overview
 
 How a Catalyst orchestrator runs today (post-CTL-452, post-2026-05-17 ship). This doc


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-25T01:42:08Z -->
<!-- Last updated: 2026-05-25T01:42:08Z -->
<!-- PR: #1009 -->
<!-- Previous commits: bd4b85c9be40030eb80321fad1d68e0421294405 -->

## Summary

Tracer-bullet change for **CTL-600** — verifies that the full Catalyst
phase-agent orchestrator pipeline (triage → research → plan → implement →
verify → review → pr → monitor-merge → monitor-deploy) executes end-to-end
against the `execution-core` scheduler, with no production behavior change.

The only diff is a single HTML comment at the top of
`docs/orchestrator-overview.md`. It is intentionally inert: it exercises the
pipeline's commit → review → PR path without touching code, SQL, or any
runtime surface.

## Changes Made

- Added a one-line HTML comment to `docs/orchestrator-overview.md` marking the
  CTL-600 tracer-bullet run and its date.

## How to Verify It

- [x] CI `validate` passes ✅
- [x] CI `audit-references` passes ✅
- [x] CI `check-versions` passes ✅
- [ ] Cloudflare Pages preview (docs deploy) — pending at time of writing

No tests apply: the change is a documentation comment with no executable surface.

## Changelog Entry

None — internal tracer-bullet, no user-facing change.

## Related Issues/PRs

- Refs: CTL-600 — Tracer bullet: verify execution-core thin slice end-to-end (no implementation needed)
