### PR TITLE
CTL-601: gate implement-plan's inProgress Linear write on CATALYST_PHASE

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-skill-no-linear-prose.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-skill-no-linear-prose.test.sh
@@ -61,6 +61,34 @@ for skill in create-pr describe-pr; do
   fi
 done
 
+# CTL-601: implement-plan is invoked as a sub-task from inside other phase
+# agents (e.g. create-pr's Post-PR Monitoring & Resolution Loop calls it to
+# address review-comment fix-ups; monitor-merge calls it for CI fix-ups).
+# Without the CATALYST_PHASE gate, implement-plan writes stateMap.inProgress
+# directly, regressing the ticket state from PR back to Implement
+# (CTL-600 tracer-bullet evidence: 2 regression flickers during pr + monitor-merge).
+# Same risk for code-first-draft (could be called from re-implementation loops).
+echo "Test: implement-plan / code-first-draft gate inProgress writes on CATALYST_PHASE"
+for skill in implement-plan code-first-draft; do
+  f="${SKILLS_DIR}/${skill}/SKILL.md"
+  if [[ ! -f "$f" ]]; then
+    # code-first-draft is optional; only fail if it exists AND lacks the gate.
+    [[ "$skill" == "implement-plan" ]] && fail "${skill}/SKILL.md exists"
+    continue
+  fi
+  # If the skill writes stateMap.inProgress, it MUST also reference CATALYST_PHASE.
+  if grep -qE "stateMap\.inProgress|--transition[[:space:]]+inProgress|status.*[Ii]n.?[Pp]rogress" "$f"; then
+    if grep -q "CATALYST_PHASE" "$f"; then
+      pass "${skill} writes inProgress AND gates on CATALYST_PHASE"
+    else
+      fail "${skill} writes inProgress but does NOT gate on CATALYST_PHASE" \
+        "$(grep -nE 'stateMap\.inProgress|--transition[[:space:]]+inProgress' "$f" | head -2)"
+    fi
+  else
+    pass "${skill} does not write inProgress (vacuously safe)"
+  fi
+done
+
 echo ""
 echo "─────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -79,6 +79,12 @@ Once you have a plan path:
 - **Extract ticket from plan frontmatter** (`source_ticket` field) and update Linear state
   to `stateMap.inProgress` from config using Linearis CLI (run `linearis issues usage` for syntax).
   If Linearis CLI is not available, skip silently and continue implementation.
+  **Skip the status transition when `CATALYST_PHASE` is set** — under a phase agent
+  (e.g. `phase-implement`, or this skill invoked as a sub-task from `phase-pr` /
+  `phase-monitor-merge` during PR resolution / CI fix-up loops) the deterministic
+  coordinator (CTL-558) owns the Linear status write-back. A direct write here
+  would regress the ticket from `PR` back to `Implement`, producing operator-visible
+  state flicker (CTL-601). Mirrors the gate in `create-pr/SKILL.md:227-232`.
 - Think deeply about how the pieces fit together
 - Create a todo list to track your progress
 - Start implementing if you understand what needs to be done
@@ -388,4 +394,9 @@ If a ticket is detected (from plan document's `source_ticket` frontmatter or fro
 
 - **At implementation start** (Step 3): Update ticket status to `stateMap.inProgress` from config
   using Linearis CLI (run `linearis issues usage` for syntax).
+- **Skip the status transition when `CATALYST_PHASE` is set** — the deterministic coordinator
+  (CTL-558) owns Linear write-back under phase agents. See the gate at Step 3 above for
+  details. CTL-601 — without this gate, invoking this skill as a sub-task from another phase
+  agent (typical in `phase-pr` / `phase-monitor-merge` resolution loops) regresses the ticket
+  state to `Implement` and produces operator-visible flicker.
 - If Linearis CLI not available, skip silently and continue implementation


### PR DESCRIPTION
## Problem

\`/catalyst-dev:implement-plan\` is invoked as a sub-task from inside other
phase agents (\`phase-pr\` Post-PR Resolution Loop, \`phase-monitor-merge\`
CI fix-up). Without a \`CATALYST_PHASE\` gate, its \"update Linear to
stateMap.inProgress\" instruction fires and regresses the ticket from \`PR\`
back to \`Implement\`. The deterministic coordinator (CTL-558) corrects on
the next sweep, but the flicker is operator-visible and doubles write-back
traffic.

Live evidence from the CTL-600 tracer bullet (2026-05-25):

| t      | Linear state | cause                                        |
|--------|--------------|----------------------------------------------|
| +836s  | PR           | correct — phase-pr started                   |
| +969s  | Implement    | REGRESSION — sub-task implement-plan wrote   |
| +1054s | PR           | CTL-558 sweep corrected                      |
| +1167s | Implement    | REGRESSION — same path during monitor-merge  |
| +1194s | PR           | corrected                                    |
| +1320s | Done         | terminal                                     |

## Fix

Two locations in \`plugins/dev/skills/implement-plan/SKILL.md\` (Step 3 prelude
+ Linear Integration section) now skip the inProgress write when
\`CATALYST_PHASE\` is set. Mirrors the gate already in
\`create-pr/SKILL.md:227-232\` and \`describe-pr/SKILL.md:355\`.

## Test

Extends \`phase-skill-no-linear-prose.test.sh\` to enforce the gate for
\`implement-plan\` and \`code-first-draft\` (the helpers most likely to be
re-invoked from inside another phase agent's resolution loop). 10/10 pass.

Refs: CTL-601, CTL-558

🤖 Generated with [Claude Code](https://claude.com/claude-code)