### PR TITLE
CTL-597: Add .terminal-done.applied once-marker to scheduler terminal sweep

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -425,6 +425,36 @@ function teardownWorktreeOnce(orchDir, ticket, teardownWorktree) {
   }
 }
 
+// terminalDoneOnce — write the terminal `Done` Linear state for a ticket at
+// most once for the run's lifetime (CTL-597). The terminal sweep revisits every
+// started worker dir each tick, and applyTerminalDone → linear-transition.sh
+// does an unconditional `linearis issues read` before it can decide the state
+// already matches — so without a guard every terminal dir burns one Linear API
+// read per tick, exhausting the rate-limit cap. A once-marker at
+// workers/<T>/.terminal-done.applied (restart-safe — persists with the worker
+// dir) records a confirmed apply, mirroring labelOnce / teardownWorktreeOnce.
+// Best-effort: any throw is logged and swallowed, never aborting the tick.
+function terminalDoneOnce(orchDir, ticket, writeStatus) {
+  const marker = join(orchDir, "workers", ticket, ".terminal-done.applied");
+  if (existsSync(marker)) return;
+  try {
+    const res = writeStatus.applyTerminalDone({ ticket });
+    // Write the marker only on a confirmed apply — a failed write is retried
+    // next tick. Note applyTerminalDone returns applied:true even for the
+    // already-Done `action:"skipped"` outcome, so the marker lands on the first
+    // confirming tick. A fake that returns undefined (test stubs) is treated as
+    // success so the once-semantics stay testable without a real result.
+    if (res === undefined || res?.applied) {
+      writeFileSync(marker, "");
+    }
+  } catch (err) {
+    log.warn(
+      { ticket, err: err.message },
+      "scheduler: terminal-Done write-back threw — continuing tick",
+    );
+  }
+}
+
 // schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull,
 // (3) terminal-Done sweep (CTL-558) + worktree teardown (CTL-582). Idempotent
 // and restart-safe — derives every action from filesystem state. `exec` is the
@@ -549,7 +579,8 @@ export function schedulerTick(
     // isTicketInFlight gate at line ~93. Without this, the ticket lingers
     // at `PR` in Linear and the worktree leaks on disk indefinitely.
     if (signals["monitor-deploy"] === "done" || signals["monitor-deploy"] === "skipped") {
-      safeWrite(() => writeStatus.applyTerminalDone({ ticket }), { ticket });
+      // CTL-597: once-marker guards the per-tick Linear read (was safeWrite-only).
+      terminalDoneOnce(orchDir, ticket, writeStatus);
       // CTL-582: the ticket reached terminal Done — tear down its worktree.
       teardownWorktreeOnce(orchDir, ticket, teardownWorktree);
     }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1460,3 +1460,77 @@ describe("startScheduler — preflight wiring (CTL-585)", () => {
     expect(Array.isArray(calls[0].teams)).toBe(true);
   });
 });
+
+// ── CTL-597: terminal-Done once-marker (.terminal-done.applied) ──
+
+describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
+  // Helper consistent with the existing suites: a writeStatus whose label/phase
+  // writes are no-ops; only applyTerminalDone is the subject under test.
+  function terminalNoWrites() {
+    return { applyPhaseStatus() {}, applyLabel() {} };
+  }
+
+  test("does not re-write terminal Done once the .terminal-done.applied marker exists", () => {
+    writeSignal("CTL-20", "monitor-deploy", "done");
+    writeFileSync(
+      join(orchDir, "workers", "CTL-20", ".terminal-done.applied"),
+      ""
+    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dones = [];
+    const writeStatus = {
+      ...terminalNoWrites(),
+      applyTerminalDone: (a) => dones.push(a),
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    // Marker present → applyTerminalDone (and its Linear read) is never called.
+    expect(dones).toHaveLength(0);
+  });
+
+  test("writes the .terminal-done.applied marker only after applyTerminalDone reports applied:true", () => {
+    writeSignal("CTL-21", "monitor-deploy", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const markerPath = join(orchDir, "workers", "CTL-21", ".terminal-done.applied");
+    // applied:false → no marker → retried next tick.
+    const failWrite = { ...terminalNoWrites(), applyTerminalDone: () => ({ applied: false }) };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus: failWrite });
+    expect(existsSync(markerPath)).toBe(false);
+    // applied:true → marker written → not retried.
+    const okWrite = { ...terminalNoWrites(), applyTerminalDone: () => ({ applied: true }) };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus: okWrite });
+    expect(existsSync(markerPath)).toBe(true);
+  });
+
+  test("fires applyTerminalDone once across ticks (skipped is also terminal, CTL-589)", () => {
+    writeSignal("CTL-22", "monitor-deploy", "skipped");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    let count = 0;
+    const writeStatus = {
+      ...terminalNoWrites(),
+      applyTerminalDone: () => {
+        count++;
+        return { applied: true };
+      },
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
+    expect(count).toBe(1);
+    expect(existsSync(join(orchDir, "workers", "CTL-22", ".terminal-done.applied"))).toBe(true);
+  });
+
+  test("a terminal-Done write throw never aborts the tick", () => {
+    writeSignal("CTL-23", "monitor-deploy", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const writeStatus = {
+      ...terminalNoWrites(),
+      applyTerminalDone: () => {
+        throw new Error("terminal boom");
+      },
+    };
+    expect(() =>
+      schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus })
+    ).not.toThrow();
+    // No marker on a thrown apply → retried next tick.
+    expect(existsSync(join(orchDir, "workers", "CTL-23", ".terminal-done.applied"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `.terminal-done.applied` once-marker to the execution-core scheduler's
terminal-`Done` sweep so each finished ticket writes its terminal Linear state
**at most once per run** instead of every tick.

## Problem

The terminal sweep in `schedulerTick` revisits every started worker dir on each
tick. For any ticket whose `monitor-deploy` signal is `done`/`skipped`, it called
`writeStatus.applyTerminalDone({ ticket })` unconditionally. That path runs
`linear-transition.sh`, which issues an unconditional `linearis issues read`
*before* it can detect the state already matches. The result: every terminal
worker dir burned one Linear API read per tick, steadily exhausting the
rate-limit cap on long-lived runs.

## Change

- New `terminalDoneOnce(orchDir, ticket, writeStatus)` helper
  (`scheduler.mjs`) — mirrors the existing `labelOnce` / `teardownWorktreeOnce`
  once-marker pattern:
  - Skips immediately if `workers/<ticket>/.terminal-done.applied` exists.
  - Writes the marker only on a **confirmed apply** (`res.applied`, or
    `undefined` for test stubs). `applyTerminalDone` returns `applied: true`
    even for the already-`Done` `action: "skipped"` outcome, so the marker
    lands on the first confirming tick.
  - A failed apply leaves no marker → retried next tick.
  - Best-effort: any throw is logged and swallowed, never aborting the tick.
- The terminal sweep now calls `terminalDoneOnce(...)` instead of the raw
  `safeWrite(() => writeStatus.applyTerminalDone(...))`.

The marker lives alongside the worker dir, so it is **restart-safe** — a
scheduler restart won't re-issue the terminal write for already-applied tickets.

## Tests

Adds a `schedulerTick — terminal-Done once-marker (CTL-597)` suite
(`scheduler.test.mjs`) covering:
- marker present → `applyTerminalDone` (and its Linear read) never called;
- marker written only after `applied: true`; `applied: false` → no marker, retried;
- fires once across ticks, including the `skipped` terminal outcome (CTL-589);
- a thrown terminal-Done write never aborts the tick and writes no marker.

Full `scheduler.test.mjs` suite passes (93 tests, 0 fail).

Refs: CTL-597
