### PR TITLE
CTL-596: Harden orchestrate-verify (post-merge diff range, convention-aware test discovery, reward-hacking deltas)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
@@ -384,6 +384,61 @@ scratch_teardown
 echo
 
 # ---------------------------------------------------------------
+# CTL-596 defect #3: pre-existing `as any` the PR never touched must NOT FAIL
+# ---------------------------------------------------------------
+# Note (CTL-596): the PR must MODIFY legacy.ts (Check #7 only inspects changed
+# source files) — appending a benign line puts it in the changeset while the
+# pre-existing casts stay on untouched lines. Whole-file grep counts 3 (old =
+# FAIL); added-line delta counts 0 (new = PASS).
+echo "test: pre-existing as any casts on base do not fail Check #7 (CTL-596 #3)"
+scratch_setup
+mkdir -p src
+git checkout -q main
+cat > src/legacy.ts <<'EOF'
+export const a = (x: unknown) => x as any;
+export const b = (x: unknown) => x as any;
+export const c = (x: unknown) => x as any;
+EOF
+cat > src/legacy.test.ts <<'EOF'
+import { a } from './legacy';
+test('a', () => { a(1); });
+EOF
+git add -A && git commit -q -m "legacy with pre-existing casts"
+git checkout -q feature
+git merge -q --no-edit main 2>/dev/null || git rebase -q main
+# PR appends a benign line — legacy.ts is now in the diff, but the ADDED line
+# contains zero `as any`.
+echo 'export const d = () => 2;' >> src/legacy.ts
+seed_changes_and_gh '[]' \
+  '{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{"oid":"{{MERGE_SHA}}"}}'
+make_signal "TICK-596E"
+run_verify "TICK-596E" "backend"
+echo "$OUT" | grep -qE "'as any' cast" && fail "CTL-596 #3: pre-existing casts must not fail" "$OUT" || pass "CTL-596 #3: pre-existing casts ignored"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
+# CTL-596 defect #3: an ADDED `as any` still FAILs Check #7
+# ---------------------------------------------------------------
+echo "test: a newly added as any still fails Check #7 (CTL-596 #3)"
+scratch_setup
+mkdir -p src
+cat > src/added.ts <<'EOF'
+export const g = (x: unknown) => x as any;
+EOF
+cat > src/added.test.ts <<'EOF'
+import { g } from './added';
+test('g', () => { g(1); });
+EOF
+seed_changes_and_gh '[]' \
+  '{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{"oid":"{{MERGE_SHA}}"}}'
+make_signal "TICK-596F"
+run_verify "TICK-596F" "backend"
+echo "$OUT" | grep -qE "'as any' cast" && pass "CTL-596 #3: added cast detected" || fail "CTL-596 #3: added cast detected" "$OUT"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
 echo
 if [ $FAILURES -eq 0 ]; then
   echo "ALL PASSED ($PASSES)"

--- a/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
@@ -93,13 +93,15 @@ EOF
 
 run_verify() {
   local ticket="$1" req="${2:-backend}"
+  shift 2
+  # Any remaining args (e.g. --test-convention adjacency) pass through.
   set +e
   OUT=$("$VERIFY" \
     --worktree "$SCRATCH" \
     --ticket "$ticket" \
     --base-branch main \
     --signal-file "${ORCH_DIR}/workers/${ticket}.json" \
-    --test-requirements "$req" 2>&1)
+    --test-requirements "$req" "$@" 2>&1)
   RC=$?
   set -e
 }
@@ -437,6 +439,108 @@ run_verify "TICK-596F" "backend"
 echo "$OUT" | grep -qE "'as any' cast" && pass "CTL-596 #3: added cast detected" || fail "CTL-596 #3: added cast detected" "$OUT"
 scratch_teardown
 echo
+
+# ---------------------------------------------------------------
+# CTL-596 defect #2: --test-convention adjacency NARROWS (ignores config root)
+# ---------------------------------------------------------------
+# Proves the flag is a real narrowing: the same config-declared test/** root
+# that glob mode honors (TICK-596D) must NOT be honored under adjacency, so the
+# source reports Missing tests.
+echo "test: adjacency mode does not honor config-declared test root (CTL-596 #2)"
+scratch_setup
+git checkout -q main
+mkdir -p src/tools test/tools
+cat > vitest.config.ts <<'EOF'
+export default { test: { include: ["test/**/*.test.ts"] } };
+EOF
+cat > test/tools/run.test.ts <<'EOF'
+import { run } from '../../src/tools/run';
+test('run', () => { run(); });
+EOF
+git add -A && git commit -q -m "vitest config + test root on base"
+git checkout -q feature
+git merge -q --no-edit main 2>/dev/null || git rebase -q main
+cat > src/tools/run.ts <<'EOF'
+export const run = () => 1;
+EOF
+seed_changes_and_gh '[]' \
+  '{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{"oid":"{{MERGE_SHA}}"}}'
+make_signal "TICK-596G"
+run_verify "TICK-596G" "backend" --test-convention adjacency
+echo "$OUT" | grep -q "Missing tests for" && pass "CTL-596 #2: adjacency ignores config root (narrowing verified)" || fail "CTL-596 #2: adjacency should ignore config root" "$OUT"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
+# CTL-596 defect #3: pre-existing console.log over threshold does NOT FAIL
+# ---------------------------------------------------------------
+# The >2 threshold pattern is where added-line vs whole-file confusion bites
+# hardest: a legacy file with 3 console.log the PR merely touches must PASS.
+echo "test: pre-existing console.log (>2) on a touched file does not fail Check #7 (CTL-596 #3)"
+scratch_setup
+mkdir -p src
+git checkout -q main
+cat > src/noisy.ts <<'EOF'
+export const a = () => { console.log('a'); };
+export const b = () => { console.log('b'); };
+export const c = () => { console.log('c'); };
+export const d = () => { console.log('d'); };
+EOF
+cat > src/noisy.test.ts <<'EOF'
+import { a } from './noisy';
+test('a', () => { a(); });
+EOF
+git add -A && git commit -q -m "noisy with pre-existing console.log"
+git checkout -q feature
+git merge -q --no-edit main 2>/dev/null || git rebase -q main
+# PR appends one benign line — adds zero console.log.
+echo 'export const e = () => 2;' >> src/noisy.ts
+seed_changes_and_gh '[]' \
+  '{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{"oid":"{{MERGE_SHA}}"}}'
+make_signal "TICK-596H"
+run_verify "TICK-596H" "backend"
+echo "$OUT" | grep -qE "console.log statements" && fail "CTL-596 #3: pre-existing console.log must not fail" "$OUT" || pass "CTL-596 #3: pre-existing console.log ignored"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
+# CTL-596 defect #1: diff range resolves via origin/<base> (production path)
+# ---------------------------------------------------------------
+# TICK-596A covers the local-main fallback (scratch repos have no origin).
+# Production worktrees track origin/<base>; this fixture creates a real origin
+# so the `git rev-parse origin/main` preference branch is exercised.
+echo "test: changeset resolves against origin/main when present (CTL-596 #1)"
+scratch_setup
+git checkout -q main
+ORIGIN596="$(mktemp -d)"
+git init -q --bare "$ORIGIN596"
+git remote add origin "$ORIGIN596"
+git push -q origin main
+git checkout -q feature
+mkdir -p src
+cat > src/origin.ts <<'EOF'
+export const o = () => 1;
+EOF
+cat > src/origin.test.ts <<'EOF'
+import { o } from './origin';
+test('o', () => { o(); });
+EOF
+seed_changes_and_gh '[]' \
+  '{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{"oid":"{{MERGE_SHA}}"}}'
+make_signal "TICK-596J"
+run_verify "TICK-596J" "backend"
+echo "$OUT" | grep -q "Source files changed: 1" && pass "CTL-596 #1: changeset resolved via origin/main" || fail "CTL-596 #1: changeset resolved via origin/main" "$OUT"
+echo "$OUT" | grep -q "No changed files found" && fail "CTL-596 #1: must not abort with origin/main present" "$OUT" || pass "CTL-596 #1: no empty-diff abort (origin path)"
+rm -rf "$ORIGIN596"; unset ORIGIN596
+scratch_teardown
+echo
+
+# Note (CTL-596): no empty-catch DETECTION fixture. The detection uses
+# `grep -Pzo`, which silently no-ops under BSD grep (the script runs `#!/bin/bash`
+# non-interactively, so `grep` is /usr/bin/grep, not ugrep/GNU). The plan scoped
+# the matcher as an unchanged "documented assumption", so the only CTL-596 change
+# here is the ADDED_LINES gate in front of it. The platform no-op is filed as a
+# separate finding rather than fixed in this PR.
 
 # ---------------------------------------------------------------
 echo

--- a/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
@@ -259,6 +259,53 @@ scratch_teardown
 echo
 
 # ---------------------------------------------------------------
+# CTL-596 defect #1: merge SHA absent from worktree objects must NOT abort
+# ---------------------------------------------------------------
+echo "test: merged PR whose merge SHA is not a local object still diffs (CTL-596 #1)"
+scratch_setup
+mkdir -p src
+cat > src/widget.ts <<'EOF'
+export const f = () => 1;
+EOF
+cat > src/widget.test.ts <<'EOF'
+import { f } from './widget';
+test('f', () => { f(); });
+EOF
+git add -A && git commit -q -m "feature work"
+
+# gh pr list returns [] (deleted head branch). Signal file carries a merge SHA
+# that does NOT exist in this repo's object database (40 hex chars, all dead).
+cat > "${SCRATCH}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"pr list"* ]]; then echo "[]"; exit 0; fi
+if [[ "$*" == *"repo view"* ]]; then echo "org/repo"; exit 0; fi
+if [[ "$*" == *"api repos"* ]]; then echo '{"merged":true,"merge_commit_sha":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}'; exit 0; fi
+echo "stub gh: unexpected: $*" >&2; exit 99
+EOF
+chmod +x "${SCRATCH}/bin/gh"
+export PATH="${SCRATCH}/bin:${PATH}"
+
+cat > "${ORCH_DIR}/workers/TICK-596A.json" <<'EOF'
+{
+  "ticket": "TICK-596A",
+  "pr": { "number": 700, "mergeCommitSha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" },
+  "definitionOfDone": {
+    "testsWrittenFirst": false,
+    "unitTests": {"exists": false, "count": 0},
+    "apiTests": {"exists": false, "count": 0},
+    "functionalTests": {"exists": false, "count": 0}
+  }
+}
+EOF
+run_verify "TICK-596A" "backend"
+# Must NOT abort with the empty-diff error, and MUST see the changed source file.
+echo "$OUT" | grep -q "No changed files found" && fail "CTL-596 #1: must not abort on absent merge SHA" "$OUT" || pass "CTL-596 #1: no empty-diff abort"
+echo "$OUT" | grep -q "Source files changed: 1" && pass "CTL-596 #1: changeset resolved via merge-base" || fail "CTL-596 #1: changeset resolved via merge-base" "$OUT"
+[ "$RC" -ne 2 ] && pass "CTL-596 #1: did not exit 2 (rc=$RC)" || fail "CTL-596 #1: exited 2" "rc=$RC; out: $OUT"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
 echo
 if [ $FAILURES -eq 0 ]; then
   echo "ALL PASSED ($PASSES)"

--- a/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-verify.test.sh
@@ -306,6 +306,84 @@ scratch_teardown
 echo
 
 # ---------------------------------------------------------------
+# CTL-596 defect #2: __tests__/ sibling with -service suffix is recognized
+# ---------------------------------------------------------------
+echo "test: src/core/__tests__/foo-service.test.ts covers src/core/foo-service.ts (CTL-596 #2)"
+scratch_setup
+mkdir -p src/core/__tests__
+cat > src/core/foo-service.ts <<'EOF'
+export const foo = () => 1;
+EOF
+cat > src/core/__tests__/foo-service.test.ts <<'EOF'
+import { foo } from '../foo-service';
+test('foo', () => { foo(); });
+EOF
+seed_changes_and_gh '[]' \
+  '{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{"oid":"{{MERGE_SHA}}"}}'
+make_signal "TICK-596B"
+run_verify "TICK-596B" "backend"
+echo "$OUT" | grep -q "Missing tests for" && fail "CTL-596 #2: __tests__ sibling should be found" "$OUT" || pass "CTL-596 #2: __tests__ sibling recognized"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
+# CTL-596 defect #2: qualifier .integration.test.ts is recognized
+# ---------------------------------------------------------------
+echo "test: __tests__/widget.integration.test.ts covers src/widget.ts (CTL-596 #2)"
+scratch_setup
+mkdir -p src/__tests__
+cat > src/widget.ts <<'EOF'
+export const w = () => 1;
+EOF
+cat > src/__tests__/widget.integration.test.ts <<'EOF'
+import { w } from '../widget';
+test('w', () => { w(); });
+EOF
+seed_changes_and_gh '[]' \
+  '{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{"oid":"{{MERGE_SHA}}"}}'
+make_signal "TICK-596C"
+run_verify "TICK-596C" "backend"
+echo "$OUT" | grep -q "Missing tests for" && fail "CTL-596 #2: qualifier test should be found" "$OUT" || pass "CTL-596 #2: qualifier test recognized"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
+# CTL-596 defect #2: config-declared test/** root is honored
+# ---------------------------------------------------------------
+# Note (CTL-596): the config (vitest.config.ts) and the test live on the BASE,
+# not in the PR — this is realistic (config pre-exists) and avoids two artifacts
+# of the unchanged file-categorization (:191): a *.config.ts counts as a "source
+# file" needing its own test, and a test file in the diff would be matched by the
+# stem-in-diff step before test_roots_for runs. Putting both on base forces the
+# on-disk config-root discovery path (step 2) to be the thing under test.
+echo "test: vitest include test/**/*.test.ts covers src/tools/run.ts (CTL-596 #2)"
+scratch_setup
+git checkout -q main
+mkdir -p src/tools test/tools
+cat > vitest.config.ts <<'EOF'
+export default { test: { include: ["test/**/*.test.ts"] } };
+EOF
+cat > test/tools/run.test.ts <<'EOF'
+import { run } from '../../src/tools/run';
+test('run', () => { run(); });
+EOF
+git add -A && git commit -q -m "vitest config + test root on base"
+git checkout -q feature
+git merge -q --no-edit main 2>/dev/null || git rebase -q main
+# The PR adds only the source file; its test already lives under the
+# config-declared test/ root.
+cat > src/tools/run.ts <<'EOF'
+export const run = () => 1;
+EOF
+seed_changes_and_gh '[]' \
+  '{"state":"MERGED","mergeStateStatus":"UNKNOWN","mergeCommit":{"oid":"{{MERGE_SHA}}"}}'
+make_signal "TICK-596D"
+run_verify "TICK-596D" "backend"
+echo "$OUT" | grep -q "Missing tests for" && fail "CTL-596 #2: config-declared test root should be honored" "$OUT" || pass "CTL-596 #2: config test root recognized"
+scratch_teardown
+echo
+
+# ---------------------------------------------------------------
 echo
 if [ $FAILURES -eq 0 ]; then
   echo "ALL PASSED ($PASSES)"

--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -43,15 +43,17 @@ count_lines() {
   fi
 }
 
-# Count regex matches in a file. Always emits a single integer.
-count_matches() {
-  local pattern="$1" file="$2"
-  if [ ! -f "$file" ]; then
-    echo 0
-    return
-  fi
+# CTL-596 #3: count regex matches only in lines ADDED by the diff range, not
+# the whole file — so pre-existing patterns the PR never touched don't FAIL.
+# Strips the `+++ b/...` header so the filename itself is never counted.
+# $3 is the diff range (DIFF_RANGE).
+count_added_matches() {
+  local pattern="$1" file="$2" range="$3"
+  if [ ! -f "$file" ]; then echo 0; return; fi
   local n
-  n=$(grep -cE "$pattern" "$file" 2>/dev/null)
+  n=$(git diff "$range" -- "$file" 2>/dev/null \
+      | grep '^+' | grep -v '^+++' \
+      | grep -cE "$pattern" 2>/dev/null)
   echo "${n:-0}"
 }
 
@@ -498,33 +500,39 @@ RH_ISSUES=()
 for SRC in $SOURCE_FILES; do
   if [ ! -f "$SRC" ]; then continue; fi
 
+  # CTL-596 #3: count only patterns ADDED by this changeset (not the whole
+  # file), so a PR that merely touches a file with pre-existing `as any`,
+  # @ts-ignore, console.log, or `!` no longer FAILs verification.
+
   # as any casts
-  AS_ANY_COUNT=$(count_matches 'as any' "$SRC")
+  AS_ANY_COUNT=$(count_added_matches 'as any' "$SRC" "$DIFF_RANGE")
   if [ "$AS_ANY_COUNT" -gt 0 ]; then
     RH_ISSUES+=("$AS_ANY_COUNT 'as any' cast(s) in $SRC")
   fi
 
   # @ts-ignore / @ts-expect-error without explanation
-  TS_IGNORE_COUNT=$(count_matches '@ts-(ignore|expect-error)' "$SRC")
+  TS_IGNORE_COUNT=$(count_added_matches '@ts-(ignore|expect-error)' "$SRC" "$DIFF_RANGE")
   if [ "$TS_IGNORE_COUNT" -gt 0 ]; then
     RH_ISSUES+=("$TS_IGNORE_COUNT @ts-ignore/@ts-expect-error in $SRC")
   fi
 
-  # Empty catch blocks
-  if grep -Pzo 'catch\s*\([^)]*\)\s*\{\s*\}' "$SRC" >/dev/null 2>&1; then
+  # Empty catch blocks — gate the whole-file span match behind "file has ≥1
+  # added line" so untouched files no longer trip it (CTL-596 #3).
+  ADDED_LINES=$(git diff "$DIFF_RANGE" -- "$SRC" 2>/dev/null | grep -c '^+' || echo 0)
+  if [ "${ADDED_LINES:-0}" -gt 0 ] && grep -Pzo 'catch\s*\([^)]*\)\s*\{\s*\}' "$SRC" >/dev/null 2>&1; then
     RH_ISSUES+=("Empty catch block in $SRC")
   fi
 
   # console.log left in (non-test files)
   if ! echo "$SRC" | grep -qE '(test|spec)'; then
-    LOG_COUNT=$(count_matches 'console\.log' "$SRC")
+    LOG_COUNT=$(count_added_matches 'console\.log' "$SRC" "$DIFF_RANGE")
     if [ "$LOG_COUNT" -gt 2 ]; then
       RH_ISSUES+=("$LOG_COUNT console.log statements in $SRC (possible debug leftovers)")
     fi
   fi
 
   # Non-null assertions (!)
-  BANG_COUNT=$(count_matches '\w+!' "$SRC")
+  BANG_COUNT=$(count_added_matches '\w+!' "$SRC" "$DIFF_RANGE")
   if [ "$BANG_COUNT" -gt 5 ]; then
     RH_ISSUES+=("$BANG_COUNT non-null assertions in $SRC (excessive)")
   fi

--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -136,7 +136,10 @@ if [ -n "$SIGNAL_FILE" ] && [ -f "$SIGNAL_FILE" ]; then
     if [ -n "$SIG_SHA" ]; then
       PR_MERGE_SHA="$SIG_SHA"
       PR_STATE="MERGED"
-      DIFF_RANGE="${PR_MERGE_SHA}~..${PR_MERGE_SHA}"
+      # CTL-596 #1: do NOT derive DIFF_RANGE from the merge SHA — it is not in
+      # this worktree's object DB after --delete-branch. The authoritative
+      # merge-base range is computed below (before Check #1). Merge SHA stays
+      # set for Check #8 PR-state reporting.
     else
       # Have PR number but no merge SHA — ask REST API for authoritative state
       REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
@@ -145,7 +148,7 @@ if [ -n "$SIGNAL_FILE" ] && [ -f "$SIGNAL_FILE" ]; then
         if echo "$PR_REST" | jq -e '.merged == true' >/dev/null 2>&1; then
           PR_STATE="MERGED"
           PR_MERGE_SHA=$(echo "$PR_REST" | jq -r '.merge_commit_sha // empty' 2>/dev/null || echo "")
-          [ -n "$PR_MERGE_SHA" ] && DIFF_RANGE="${PR_MERGE_SHA}~..${PR_MERGE_SHA}"
+          # CTL-596 #1: merge SHA kept for Check #8 only; DIFF_RANGE set below.
         elif echo "$PR_REST" | jq -e '.state == "open"' >/dev/null 2>&1; then
           PR_STATE="OPEN"
         else
@@ -167,9 +170,27 @@ if [ -z "$PR_NUMBER" ] && [ -n "$BRANCH" ]; then
   if [ "$PR_STATE" = "MERGED" ] && [ -n "$PR_NUMBER" ]; then
     PR_VIEW_JSON=$(gh pr view "$PR_NUMBER" --json mergeCommit 2>/dev/null || echo "{}")
     PR_MERGE_SHA=$(echo "$PR_VIEW_JSON" | jq -r '.mergeCommit.oid // empty' 2>/dev/null || echo "")
-    if [ -n "$PR_MERGE_SHA" ]; then
-      DIFF_RANGE="${PR_MERGE_SHA}~..${PR_MERGE_SHA}"
-    fi
+    # CTL-596 #1: merge SHA kept for Check #8 only; DIFF_RANGE set below.
+  fi
+fi
+
+# CTL-596 #1: Resolve the diff range from objects guaranteed present in the
+# worker worktree. The GitHub squash-merge commit is NOT in this worktree's
+# object DB after --delete-branch, so a SHA~..SHA range diffs to nothing.
+# merge-base(base, HEAD)..HEAD is the worker's true changeset both pre- and
+# post-merge (the worktree retains its checked-out branch tip regardless of
+# remote/local branch deletion). The merge SHA stays resolved above for the
+# Check #8 PR-state report.
+BASE_REF="$BASE_BRANCH"
+if git rev-parse --verify --quiet "origin/${BASE_BRANCH}" >/dev/null 2>&1; then
+  BASE_REF="origin/${BASE_BRANCH}"
+elif ! git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null 2>&1; then
+  BASE_REF=""
+fi
+if [ -n "$BASE_REF" ] && git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then
+  MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "")
+  if [ -n "$MERGE_BASE" ]; then
+    DIFF_RANGE="${MERGE_BASE}..HEAD"
   fi
 fi
 

--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -284,8 +284,10 @@ else
     FOUND_TEST=false
     # CTL-596 #2: stem match — <stem>(.<qualifier>)*.(test|spec).<ext>. Matches
     # -service suffixes, .integration qualifiers, and config-declared roots that
-    # the old literal-candidate list missed.
-    STEM_RE="${BASENAME}([.-][A-Za-z0-9]+)*\.(test|spec)${EXT//./\\.}\$"
+    # the old literal-candidate list missed. Escape regex metachars in the stem
+    # (e.g. a dotted basename) so it can't over-match an unrelated test file.
+    BASENAME_RE=$(printf '%s' "$BASENAME" | sed -E 's/[.[\*+?(){}^$|]/\\&/g')
+    STEM_RE="${BASENAME_RE}([.-][A-Za-z0-9]+)*\.(test|spec)${EXT//./\\.}\$"
 
     # 1) test files already present in the diff
     if echo "$CHANGED_FILES" | grep -qE "(^|/)${STEM_RE}"; then
@@ -303,7 +305,10 @@ else
       fi
       while read -r ROOT; do
         [ -d "$ROOT" ] || continue
-        if find "$ROOT" -type f 2>/dev/null | grep -qE "(^|/)${STEM_RE}"; then
+        # CTL-596: prune node_modules/.git so a root-level config (ROOT=".")
+        # does not turn this into a whole-worktree scan over installed deps.
+        if find "$ROOT" \( -name node_modules -o -name .git \) -prune -o -type f -print 2>/dev/null \
+             | grep -qE "(^|/)${STEM_RE}"; then
           FOUND_TEST=true; break
         fi
       done <<< "$ROOTS"
@@ -518,7 +523,10 @@ for SRC in $SOURCE_FILES; do
 
   # Empty catch blocks — gate the whole-file span match behind "file has ≥1
   # added line" so untouched files no longer trip it (CTL-596 #3).
-  ADDED_LINES=$(git diff "$DIFF_RANGE" -- "$SRC" 2>/dev/null | grep -c '^+' || echo 0)
+  # grep -c always emits a single integer (0 on no match); avoid the
+  # `|| echo 0` idiom that produces the broken "0\n0" string (see count_lines).
+  ADDED_LINES=$(git diff "$DIFF_RANGE" -- "$SRC" 2>/dev/null | grep -c '^+')
+  ADDED_LINES=${ADDED_LINES:-0}
   if [ "${ADDED_LINES:-0}" -gt 0 ] && grep -Pzo 'catch\s*\([^)]*\)\s*\{\s*\}' "$SRC" >/dev/null 2>&1; then
     RH_ISSUES+=("Empty catch block in $SRC")
   fi

--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -10,7 +10,8 @@
 #     --ticket <ID> \
 #     --base-branch <branch> \
 #     --signal-file <path> \
-#     [--test-requirements <backend|frontend|fullstack>]
+#     [--test-requirements <backend|frontend|fullstack>] \
+#     [--test-convention <glob|adjacency>]   # default: glob (CTL-596 #2)
 #
 # Exit codes:
 #   0 — PASS (all required coverage present)
@@ -54,12 +55,48 @@ count_matches() {
   echo "${n:-0}"
 }
 
+# CTL-596 #2: locate the configured test root(s) for the package nearest to a
+# source file. Reads vitest/jest `include` globs when present; otherwise falls
+# back to the source dir subtree (vitest default: tests colocated or under
+# __tests__). Emits the directory prefixes (one per line) to search.
+test_roots_for() {
+  local src="$1" dir pkg cfg glob
+  dir=$(dirname "$src")
+  # nearest dir containing a vitest/jest config (walk up to AND INCLUDING the
+  # repo root "."). The break-after-check structure ensures "." is tested —
+  # a leading `while [ "$pkg" != "." ]` would skip a root-level config.
+  pkg="$dir"
+  while true; do
+    for cfg in vitest.config.ts vitest.config.js vitest.config.mjs \
+               jest.config.ts jest.config.js jest.config.mjs; do
+      if [ -f "${pkg}/${cfg}" ]; then
+        # crude but sufficient: pull the leading literal segment of each
+        # include glob, e.g. "test/**/*.test.ts" -> "test"
+        grep -oE 'include[^]]*\]' "${pkg}/${cfg}" 2>/dev/null \
+          | grep -oE '"[^"*]+' | tr -d '"' \
+          | sed -E 's#/+$##' \
+          | while read -r glob; do
+              [ -n "$glob" ] && echo "${pkg%/}/${glob%%/**}"
+            done
+        echo "$pkg"   # always also search the package root subtree
+        return
+      fi
+    done
+    { [ "$pkg" = "." ] || [ "$pkg" = "/" ]; } && break
+    pkg=$(dirname "$pkg")
+  done
+  echo "$dir"   # no config found — default to the source dir subtree
+}
+
 # Parse arguments
 WORKTREE=""
 TICKET=""
 BASE_BRANCH="main"
 SIGNAL_FILE=""
 TEST_REQUIREMENTS="backend"
+# CTL-596 #2: glob = config-aware discovery (default); adjacency = legacy
+# colocated/__tests__-only matching. Additive — no existing caller passes it.
+TEST_CONVENTION="glob"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -68,6 +105,7 @@ while [[ $# -gt 0 ]]; do
     --base-branch) BASE_BRANCH="$2"; shift 2 ;;
     --signal-file) SIGNAL_FILE="$2"; shift 2 ;;
     --test-requirements) TEST_REQUIREMENTS="$2"; shift 2 ;;
+    --test-convention) TEST_CONVENTION="$2"; shift 2 ;;
     *) echo -e "${RED}Unknown option: $1${NC}"; exit 2 ;;
   esac
 done
@@ -237,26 +275,37 @@ else
   # Check if test files exist for changed source files
   MISSING_TESTS=()
   for SRC in $SOURCE_FILES; do
-    # Derive expected test file paths
     DIR=$(dirname "$SRC")
     BASENAME=$(basename "$SRC" | sed -E 's/\.(ts|tsx|js|jsx|py|go|rs)$//')
     EXT=$(echo "$SRC" | grep -oE '\.[^.]+$')
 
-    # Common test file patterns
     FOUND_TEST=false
-    for PATTERN in \
-      "${DIR}/${BASENAME}.test${EXT}" \
-      "${DIR}/${BASENAME}.spec${EXT}" \
-      "${DIR}/__tests__/${BASENAME}${EXT}" \
-      "${DIR}/__tests__/${BASENAME}.test${EXT}" \
-      "${DIR}/../__tests__/${BASENAME}${EXT}" \
-      "test/${DIR}/${BASENAME}${EXT}" \
-      "tests/${DIR}/${BASENAME}${EXT}"; do
-      if [ -f "$PATTERN" ] || echo "$CHANGED_FILES" | grep -qF "$PATTERN"; then
-        FOUND_TEST=true
-        break
+    # CTL-596 #2: stem match — <stem>(.<qualifier>)*.(test|spec).<ext>. Matches
+    # -service suffixes, .integration qualifiers, and config-declared roots that
+    # the old literal-candidate list missed.
+    STEM_RE="${BASENAME}([.-][A-Za-z0-9]+)*\.(test|spec)${EXT//./\\.}\$"
+
+    # 1) test files already present in the diff
+    if echo "$CHANGED_FILES" | grep -qE "(^|/)${STEM_RE}"; then
+      FOUND_TEST=true
+    fi
+
+    # 2) on-disk search across plausible roots (skipped in adjacency mode)
+    if [ "$FOUND_TEST" = false ]; then
+      if [ "$TEST_CONVENTION" = "adjacency" ]; then
+        ROOTS=$(printf '%s\n%s\n%s\n' "$DIR" "${DIR}/__tests__" "${DIR}/../__tests__" | sort -u)
+      else
+        ROOTS=$(printf '%s\n%s\n%s\n%s\n' \
+                  "$DIR" "${DIR}/__tests__" "${DIR}/../__tests__" \
+                  "$(test_roots_for "$SRC")" | sort -u)
       fi
-    done
+      while read -r ROOT; do
+        [ -d "$ROOT" ] || continue
+        if find "$ROOT" -type f 2>/dev/null | grep -qE "(^|/)${STEM_RE}"; then
+          FOUND_TEST=true; break
+        fi
+      done <<< "$ROOTS"
+    fi
 
     if [ "$FOUND_TEST" = false ]; then
       MISSING_TESTS+=("$SRC")


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-25T03:31:32Z -->
<!-- Last updated: 2026-05-25T03:31:32Z -->
<!-- PR: #1014 -->
<!-- Previous commits: 2dda7414,ed6ecd74,06f70e97,f7f0a56c -->

## Summary

Hardens the `orchestrate-verify.sh` phase-verify verifier so it judges work by the changeset the worker actually produced rather than by whole-file state or merge artifacts that are unavailable in the worker worktree. Three independent defects are fixed (one commit each), plus a review-remediation commit. Behavior is additive — no existing caller signature changes.

## Changes Made

### #1 — Post-merge-aware diff range (`f7f0a56c`)

The verifier previously derived its diff range from the squash-merge commit SHA (`SHA~..SHA`). After `gh pr merge --delete-branch`, that commit is **not** in the worker worktree's object DB, so the range diffed to nothing and the verifier saw an empty changeset.

- `DIFF_RANGE` is now computed as `merge-base(base, HEAD)..HEAD`, which resolves entirely from objects present in the worktree (the checked-out branch tip survives remote/local branch deletion).
- Base ref resolution prefers `origin/<base>`, falls back to a local `<base>`, then to empty.
- The merge SHA is still resolved for the Check #8 PR-state report — it is just no longer used to build the diff range.

### #2 — Convention-aware test discovery (`06f70e97`)

Test-file matching was a fixed list of literal candidate paths that missed `-service` suffixes, `.integration` qualifiers, and config-declared test roots.

- Discovery now uses a stem regex: `<stem>([.-]<seg>)*.(test|spec).<ext>`, matching against both the diff's changed files and an on-disk search.
- New `test_roots_for()` walks up from the source file to the nearest `vitest`/`jest` config (up to and including repo root `.`) and reads its `include` globs to derive search roots, falling back to the source dir subtree.
- New `--test-convention <glob|adjacency>` flag (default `glob`): `glob` is config-aware discovery; `adjacency` restores legacy colocated/`__tests__`-only matching. Additive — no existing caller passes it.
- On-disk searches prune `node_modules`/`.git` so a root-level config (`ROOT="."`) cannot turn discovery into a whole-worktree scan over installed deps.

### #3 — Reward-hacking counts use added-line deltas (`ed6ecd74`)

The reward-hacking scan (Check #7) counted matches across the **whole file**, so a PR that merely touched a file containing pre-existing `as any`, `@ts-ignore`, `console.log`, or `!` would FAIL even though it introduced none of them.

- New `count_added_matches()` counts a pattern only in lines **added** by the diff range (`git diff <range> | grep '^+' | grep -v '^+++'`), stripping the file-header line so the filename is never counted.
- `as any`, `@ts-ignore`/`@ts-expect-error`, `console.log`, and non-null assertion counts all switch to added-line deltas.
- Empty-catch-block detection (a whole-file span match) is gated behind "file has ≥1 added line," so untouched files no longer trip it.

### Review remediation (`2dda7414`)

- `BASENAME_RE` now escapes regex metacharacters in the source stem (e.g. a dotted basename) before building `STEM_RE`, preventing over-match against unrelated test files.
- Test-fixture fixes.

## How to Verify It

- [x] Verifier test suite passes: `bash plugins/dev/scripts/__tests__/orchestrate-verify.test.sh` — **ALL PASSED (23)** ✅

No configured project-level test/lint/build commands apply to this shell-only change; the script's own suite is the authoritative gate.

## Related Issues/PRs

- Refs: CTL-596
