### PR TITLE
CTL-509: git-activity liveness guard for orchestrate-healthcheck state-json-stale

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -204,6 +204,16 @@ sequenceDiagram
    - mtime older than `--stale-bg-seconds` (default 900s) AND `.state` not in
      `{done, failed, errored, stopped}` → `STALL_REASON="state-json-stale"`
 
+   A **git-activity liveness guard** (CTL-509) protects the `state-json-stale`
+   branch: before flagging, it reads the worker worktree's most-recent commit
+   timestamp and, if it is newer than `--git-activity-seconds` (defaults to
+   `--stale-bg-seconds`), suppresses the stall (signal left `running`, a
+   `worker-phase-stale-suppressed` event logged, `gitActiveSuppressed` bumped in
+   the summary). This mirrors the execution-core `stalled-detector.mjs` guard
+   (inactive in phase-agents mode) so a live worker blocked in one long tool call
+   is not falsely re-dispatched. It never guards `state-json-missing` and is
+   opt-out via `--no-git-guard` / `CATALYST_HEALTHCHECK_GIT_GUARD=0`.
+
 Revive budget: the top-level `workers/<TICKET>.json` carries `.reviveCount`. When
 `reviveCount >= MAX_REVIVES` (default 10), the worker is marked `stalled` with
 `attentionReason="revive-budget-exhausted"`.

--- a/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-healthcheck.test.sh
@@ -206,6 +206,33 @@ phase_status() {
 	jq -r '.status' "${ORCH_DIR}/workers/${ticket}/phase-${phase}.json"
 }
 
+# Read an arbitrary field from a per-phase signal.
+phase_field() {
+	local ticket="$1" phase="$2" field="$3"
+	jq -r ".${field}" "${ORCH_DIR}/workers/${ticket}/phase-${phase}.json"
+}
+
+# ─── CTL-509: git-activity liveness guard helpers ────────────────────────────
+#
+# make_worktree_commit TICKET AGE_SEC [ORCH_ID]
+# Build a real git worktree at ${SCRATCH}/wt/${ORCH_ID}-${TICKET} with one commit
+# whose committer date is AGE_SEC in the past, and point the healthcheck's
+# worktree-base override at ${SCRATCH}/wt. ORCH_ID in these tests is "demo".
+make_worktree_commit() {
+	local ticket="$1" age_sec="$2" orch_id="${3:-demo}"
+	local wt="${SCRATCH}/wt/${orch_id}-${ticket}"
+	mkdir -p "$wt"
+	git -C "$wt" init -q
+	git -C "$wt" config user.email t@t && git -C "$wt" config user.name t
+	echo x >"$wt/f"
+	git -C "$wt" add -A
+	local when
+	when=$(($(date -u +%s) - age_sec))
+	GIT_AUTHOR_DATE="@${when}" GIT_COMMITTER_DATE="@${when}" \
+		git -C "$wt" commit -q -m "c"
+	export CATALYST_HEALTHCHECK_WORKTREE_BASE="${SCRATCH}/wt"
+}
+
 echo "test (CTL-452): phase-mode worker with stale state.json marked stalled"
 scratch_setup
 make_phase_signal "T-A" "implement" "running" "bg-stale"
@@ -457,6 +484,133 @@ RC=$?
 REAPED=$(echo "$OUT" | jq -r '.reaped' 2>/dev/null || echo "")
 [ "$REAPED" = "0" ] && pass "summary.reaped=0 when watch-bg absent" || fail "summary.reaped=0 when watch-bg absent" "got: $REAPED; out: $OUT"
 unset CATALYST_WATCH_BG_BIN
+scratch_teardown
+
+# ─── CTL-509: git-activity liveness guard ────────────────────────────────────
+#
+# A live phase-implement worker that blocks in one long synchronous tool call
+# (bun install + a full test suite) stops touching its --bg state.json for
+# >15 min, so the stale-mtime branch falsely flags it. Before honoring a
+# state-json-stale flag, the healthcheck consults git commit recency on the
+# worker's worktree: a recent commit proves the worker is alive and the stall
+# is suppressed. Mirrors the execution-core JS guard (stalled-detector.mjs),
+# inactive in phase-agents mode. state-json-missing is NEVER guarded.
+
+echo "test (CTL-509): recent commit suppresses a stale-mtime stall"
+scratch_setup
+make_phase_signal "T-G" "implement" "running" "bg-stale-g"
+make_bg_state "bg-stale-g" "running" 1200 # 20 min — stale
+make_worktree_commit "T-G" 60            # committed 60s ago — alive
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
+ST=$(phase_status "T-G" "implement")
+[ "$ST" = "running" ] && pass "recent commit → left running (not stalled)" || fail "recent commit → left running" "got: $ST"
+grep -q "worker-phase-stalled" "$STATE_LOG" && fail "no worker-phase-stalled for live worker" "log: $(cat "$STATE_LOG")" || pass "no worker-phase-stalled for live worker"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): old commit does not rescue a genuinely stuck worker"
+scratch_setup
+make_phase_signal "T-H" "implement" "running" "bg-stale-h"
+make_bg_state "bg-stale-h" "running" 1200
+make_worktree_commit "T-H" 1800 # 30 min ago — outside the 900s window
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
+ST=$(phase_status "T-H" "implement")
+[ "$ST" = "stalled" ] && pass "old commit → still stalled" || fail "old commit → still stalled" "got: $ST"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): no worktree → falls through to stalled (graceful degradation)"
+scratch_setup
+make_phase_signal "T-I" "implement" "running" "bg-stale-i"
+make_bg_state "bg-stale-i" "running" 1200
+mkdir -p "${SCRATCH}/wt-empty" # base exists but has no demo-T-I subdir
+export CATALYST_HEALTHCHECK_WORKTREE_BASE="${SCRATCH}/wt-empty"
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
+ST=$(phase_status "T-I" "implement")
+[ "$ST" = "stalled" ] && pass "no worktree → degrades to stalled" || fail "no worktree → degrades to stalled" "got: $ST"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): state-json-missing is never suppressed even with a recent commit"
+scratch_setup
+make_phase_signal "T-J" "implement" "running" "bg-missing-j"
+export CATALYST_HEALTHCHECK_JOBS_ROOT="${SCRATCH}/jobs" # exists, no per-job subdir
+mkdir -p "${SCRATCH}/jobs"
+make_worktree_commit "T-J" 60 # recent commit — but state.json is MISSING, not stale
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
+ST=$(phase_status "T-J" "implement")
+AR=$(phase_field "T-J" "implement" "attentionReason")
+[ "$ST" = "stalled" ] && pass "missing state.json → stalled despite recent commit" || fail "missing state.json → stalled" "got: $ST"
+[ "$AR" = "state-json-missing" ] && pass "attentionReason=state-json-missing (not suppressed)" || fail "attentionReason=state-json-missing" "got: $AR"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): --no-git-guard disables suppression"
+scratch_setup
+make_phase_signal "T-K" "implement" "running" "bg-stale-k"
+make_bg_state "bg-stale-k" "running" 1200
+make_worktree_commit "T-K" 60
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --no-git-guard >"${SCRATCH}/out" 2>&1
+ST=$(phase_status "T-K" "implement")
+[ "$ST" = "stalled" ] && pass "--no-git-guard → stalled despite recent commit" || fail "--no-git-guard → stalled" "got: $ST"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): CATALYST_HEALTHCHECK_GIT_GUARD=0 disables suppression"
+scratch_setup
+make_phase_signal "T-L" "implement" "running" "bg-stale-l"
+make_bg_state "bg-stale-l" "running" 1200
+make_worktree_commit "T-L" 60
+CATALYST_HEALTHCHECK_GIT_GUARD=0 "$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
+ST=$(phase_status "T-L" "implement")
+[ "$ST" = "stalled" ] && pass "GIT_GUARD=0 → stalled despite recent commit" || fail "GIT_GUARD=0 → stalled" "got: $ST"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): --git-activity-seconds tunes the window"
+scratch_setup
+make_phase_signal "T-M" "implement" "running" "bg-stale-m"
+make_bg_state "bg-stale-m" "running" 1200
+make_worktree_commit "T-M" 300 # 5 min ago
+# With a 120s window, the 300s-old commit is OUTSIDE the window → still stalled.
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 --git-activity-seconds 120 >"${SCRATCH}/out" 2>&1
+ST=$(phase_status "T-M" "implement")
+[ "$ST" = "stalled" ] && pass "commit outside tuned window → stalled" || fail "commit outside tuned window → stalled" "got: $ST"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): suppression emits worker-phase-stale-suppressed, NOT worker-phase-stalled"
+scratch_setup
+make_phase_signal "T-N" "implement" "running" "bg-stale-n"
+make_bg_state "bg-stale-n" "running" 1200
+make_worktree_commit "T-N" 60
+"$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 >"${SCRATCH}/out" 2>&1
+grep -q "worker-phase-stale-suppressed" "$STATE_LOG" && pass "emits worker-phase-stale-suppressed" || fail "emits worker-phase-stale-suppressed" "log: $(cat "$STATE_LOG")"
+grep -q "worker-phase-stalled" "$STATE_LOG" && fail "no worker-phase-stalled on suppression" "log: $(cat "$STATE_LOG")" || pass "no worker-phase-stalled on suppression"
+grep -q "attention demo .* T-N" "$STATE_LOG" && fail "no attention on suppression" "log: $(cat "$STATE_LOG")" || pass "no attention on suppression"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): summary JSON reports gitActiveSuppressed"
+scratch_setup
+make_phase_signal "T-O" "implement" "running" "bg-stale-o"
+make_bg_state "bg-stale-o" "running" 1200
+make_worktree_commit "T-O" 60
+OUT=$("$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 2>/dev/null)
+SUP=$(echo "$OUT" | jq -r '.gitActiveSuppressed' 2>/dev/null || echo "")
+[ "$SUP" = "1" ] && pass "summary.gitActiveSuppressed=1 for suppressed worker" || fail "summary.gitActiveSuppressed=1" "got: $SUP; out: $OUT"
+unset CATALYST_HEALTHCHECK_WORKTREE_BASE
+scratch_teardown
+
+echo "test (CTL-509): summary JSON reports gitActiveSuppressed=0 for a normal stall"
+scratch_setup
+make_phase_signal "T-P" "implement" "running" "bg-stale-p"
+make_bg_state "bg-stale-p" "running" 1200 # stale, no worktree configured → normal stall
+OUT=$("$HEALTHCHECK" --orch-dir "$ORCH_DIR" --orch-id "demo" --grace-seconds 0 2>/dev/null)
+SUP=$(echo "$OUT" | jq -r '.gitActiveSuppressed' 2>/dev/null || echo "")
+ST=$(phase_status "T-P" "implement")
+[ "$ST" = "stalled" ] && pass "normal stall still flagged (no worktree)" || fail "normal stall still flagged" "got: $ST"
+[ "$SUP" = "0" ] && pass "summary.gitActiveSuppressed=0 for normal stall" || fail "summary.gitActiveSuppressed=0" "got: $SUP; out: $OUT"
 scratch_teardown
 
 echo

--- a/plugins/dev/scripts/orchestrate-healthcheck
+++ b/plugins/dev/scripts/orchestrate-healthcheck
@@ -10,19 +10,34 @@
 #
 # Usage:
 #   orchestrate-healthcheck --orch-dir <path> --orch-id <name>
-#                           [--grace-seconds <n>]    # default 15 — for the legacy PID liveness pass
-#                           [--stale-bg-seconds <n>] # default 900 (15 min) — CTL-452 phase-mode threshold
+#                           [--grace-seconds <n>]       # default 15 — for the legacy PID liveness pass
+#                           [--stale-bg-seconds <n>]    # default 900 (15 min) — CTL-452 phase-mode threshold
+#                           [--no-git-guard]            # CTL-509: disable the git-activity liveness guard
+#                           [--git-activity-seconds <n>] # CTL-509: git-activity window (default: --stale-bg-seconds)
 #                           [--dry-run]
 #
 # Outputs a single JSON summary on stdout:
 #   {"checked":N,"dead":M,"deadTickets":["TID-1",...],"stalled":S,
-#    "stalledTickets":["TID-2",...],"reaped":R}
+#    "stalledTickets":["TID-2",...],"reaped":R,
+#    "gitActiveSuppressed":G,"gitActiveSuppressedTickets":["TID-3",...]}
 #
 # CTL-452 phase-mode pass: after the legacy PID check, scan
 # ${ORCH_DIR}/workers/<T>/phase-*.json for entries with bg_job_id; stat
 # ~/.claude/jobs/<bg_job_id>/state.json mtime; if missing OR (older than
 # --stale-bg-seconds AND .state not in done|failed|errored|stopped),
 # mark the per-phase signal status=stalled and emit worker-phase-stalled.
+#
+# CTL-509 git-activity liveness guard: before honoring a state-json-stale flag,
+# consult the worker's worktree commit recency. A live phase-implement worker
+# can block >15 min in one synchronous tool call (bun install + tests) without
+# claude touching state.json; a commit newer than --git-activity-seconds proves
+# it is alive, so the stall is suppressed (signal left running, no
+# phase.*.failed, a worker-phase-stale-suppressed event logged, gitActiveSuppressed
+# incremented). Mirrors execution-core's stalled-detector.mjs guard, which is
+# inactive in phase-agents mode. Applies ONLY to state-json-stale, never
+# state-json-missing; degrades to the current flagging behavior whenever a
+# worktree cannot be resolved or git errors. Opt out with --no-git-guard or
+# CATALYST_HEALTHCHECK_GIT_GUARD=0.
 #
 # Environment:
 #   CATALYST_STATE_SCRIPT             path to catalyst-state.sh (default: ../catalyst-state.sh
@@ -34,6 +49,12 @@
 #                                     Tests override this to avoid touching the real Claude state.
 #   CATALYST_WATCH_BG_BIN             path to phase-agent-watch-bg (default: sibling). CTL-567:
 #                                     the reap sweep delegates to its `reap` subcommand.
+#   CATALYST_HEALTHCHECK_GIT_GUARD    CTL-509: set to 0 to disable the git-activity liveness
+#                                     guard (default 1 = on; same as --no-git-guard).
+#   CATALYST_HEALTHCHECK_WORKTREE_BASE CTL-509: override the worktree-base used to resolve
+#                                     <base>/<orch-id>-<ticket> for the git guard. Default
+#                                     precedence: this env > ${ORCH_DIR}/state.json .worktreeBase
+#                                     > .catalyst/config.json. Tests override this.
 #
 # CTL-567 reap sweep: after the stall checks, `claude stop` every phase signal
 # at status="done" whose bg job is still alive (delegated to
@@ -71,7 +92,7 @@ WORKTREE_BASE_OVERRIDE="${CATALYST_HEALTHCHECK_WORKTREE_BASE:-}"
 JOBS_ROOT="${CATALYST_HEALTHCHECK_JOBS_ROOT:-${HOME}/.claude/jobs}"
 
 usage() {
-	sed -n '2,35p' "$0"
+	sed -n '2,61p' "$0"
 	exit "${1:-1}"
 }
 

--- a/plugins/dev/scripts/orchestrate-healthcheck
+++ b/plugins/dev/scripts/orchestrate-healthcheck
@@ -55,6 +55,16 @@ GRACE_SECONDS=15
 STALE_BG_SECONDS=900
 DRY_RUN=0
 
+# CTL-509: git-activity liveness guard. When a worker's --bg state.json mtime is
+# stale, consult its worktree's most-recent commit timestamp before flagging
+# state-json-stale — a recent commit proves the worker is alive (it just blocked
+# in one long synchronous tool call without claude touching state.json).
+# GIT_ACTIVITY_SECONDS defaults to STALE_BG_SECONDS after arg parse so
+# --stale-bg-seconds keeps the two aligned unless --git-activity-seconds overrides.
+GIT_GUARD="${CATALYST_HEALTHCHECK_GIT_GUARD:-1}"
+GIT_ACTIVITY_SECONDS=""
+WORKTREE_BASE_OVERRIDE="${CATALYST_HEALTHCHECK_WORKTREE_BASE:-}"
+
 # CTL-452: claude --bg writes state.json to ~/.claude/jobs/<id>/state.json by
 # default. Tests override CATALYST_HEALTHCHECK_JOBS_ROOT to avoid touching the
 # real Claude state directory.
@@ -87,6 +97,14 @@ while [[ $# -gt 0 ]]; do
 		DRY_RUN=1
 		shift
 		;;
+	--no-git-guard)
+		GIT_GUARD=0
+		shift
+		;;
+	--git-activity-seconds)
+		GIT_ACTIVITY_SECONDS="$2"
+		shift 2
+		;;
 	-h | --help) usage 0 ;;
 	*)
 		echo "unknown arg: $1" >&2
@@ -94,6 +112,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	esac
 done
+
+# CTL-509: default the git-activity window to the stale-bg threshold so a single
+# --stale-bg-seconds keeps both aligned unless --git-activity-seconds overrides.
+[ -z "$GIT_ACTIVITY_SECONDS" ] && GIT_ACTIVITY_SECONDS="$STALE_BG_SECONDS"
 
 [ -z "$ORCH_DIR" ] && {
 	echo "ERROR: --orch-dir required" >&2
@@ -185,12 +207,58 @@ done
 # to be missing only briefly after dispatch — beyond --stale-bg-seconds we
 # treat it as a launch failure.
 STALLED_TICKETS=()
+SUPPRESSED_TICKETS=() # CTL-509: workers left running by the git-activity guard
 PHASE_TERMINAL_STATES="done failed errored stopped stalled"
 
 mtime_of() {
 	# macOS `stat -f` vs GNU `stat -c` — fall back if neither accepts.
 	local f="$1"
 	stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo ""
+}
+
+# CTL-509: resolve the worktree base for phase-mode workers. Precedence:
+# CATALYST_HEALTHCHECK_WORKTREE_BASE > ${ORCH_DIR}/state.json .worktreeBase >
+# <repo>/.catalyst/config.json catalyst.orchestration.worktreeBase. Mirrors
+# orchestrate-revive:432-445 (revive_worktree_base) with the state.json fallback
+# added — this repo's config.json carries worktreeBase=null, but state.json
+# always records the live base. Empty means "no detection possible".
+# DRY candidate: a shared sourced lib could host this + revive's copy; kept local
+# this phase to avoid regressing the revive path.
+hc_worktree_base() {
+	if [ -n "$WORKTREE_BASE_OVERRIDE" ]; then
+		echo "$WORKTREE_BASE_OVERRIDE"
+		return 0
+	fi
+	local b
+	b=$(jq -r '.worktreeBase // empty' "${ORCH_DIR}/state.json" 2>/dev/null || echo "")
+	if [ -n "$b" ]; then
+		echo "$b"
+		return 0
+	fi
+	if [ -f "${SCRIPT_DIR}/../../../.catalyst/config.json" ]; then
+		jq -r '.catalyst.orchestration.worktreeBase // empty' \
+			"${SCRIPT_DIR}/../../../.catalyst/config.json" 2>/dev/null || echo ""
+		return 0
+	fi
+	echo ""
+}
+
+# CTL-509: git-activity liveness probe. Returns 0 (live) iff the guard is on, a
+# worktree base resolves, the worktree is a git repo, and its most-recent commit
+# is younger than GIT_ACTIVITY_SECONDS. Any failure to resolve/read falls through
+# to return 1 (not live) so the caller flags state-json-stale exactly as today.
+git_worker_is_live() {
+	[ "$GIT_GUARD" = "1" ] || return 1
+	local ticket="$1" base wt last now age
+	base=$(hc_worktree_base)
+	[ -z "$base" ] && return 1
+	wt="${base}/${ORCH_ID}-${ticket}"
+	{ [ -d "$wt/.git" ] || [ -f "$wt/.git" ]; } || return 1
+	last=$(git -C "$wt" log -1 --format=%ct HEAD 2>/dev/null || echo "")
+	[ -z "$last" ] && return 1
+	now=$(date -u +%s)
+	age=$((now - last))
+	[ "$age" -lt "$GIT_ACTIVITY_SECONDS" ] # 0 == live
 }
 
 # Iterate every per-phase signal under workers/<T>/phase-*.json. Tickets with
@@ -232,6 +300,26 @@ for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
 	fi
 
 	[ -z "$STALL_REASON" ] && continue
+
+	# CTL-509: before honoring a stale-mtime stall, consult git commit recency on
+	# the worker's worktree. A worker stuck in one long tool call (bun install +
+	# tests) stops touching state.json, but a recent commit proves it is alive —
+	# suppress the false stall. Mirrors the execution-core JS guard
+	# (stalled-detector.mjs:40-46), which is inactive in phase-agents mode.
+	# state-json-missing is NOT guarded (a missing job dir is a real launch failure).
+	if [ "$STALL_REASON" = "state-json-stale" ] && git_worker_is_live "$P_TICKET"; then
+		SUPPRESSED_TICKETS+=("$P_TICKET")
+		if [ "$DRY_RUN" -eq 1 ]; then
+			echo "[dry-run] ${P_TICKET} phase=${P_PHASE} bg=${P_BG}: stale-mtime suppressed (recent-git-activity)" >&2
+		elif [ -x "$STATE_SCRIPT" ]; then
+			EVT=$(jq -nc --arg ts "$(now_iso)" --arg orch "$ORCH_ID" --arg w "$P_TICKET" \
+				--arg phase "$P_PHASE" --arg bg "$P_BG" \
+				'{ts:$ts, orchestrator:$orch, worker:$w, event:"worker-phase-stale-suppressed",
+          detail:{phase:$phase, bg_job_id:$bg, reason:"recent-git-activity"}}')
+			"$STATE_SCRIPT" event "$EVT" >/dev/null 2>&1 || true
+		fi
+		continue # leave signal running; no attention, no phase.*.failed
+	fi
 
 	STALLED_TICKETS+=("$P_TICKET")
 	if [ "$DRY_RUN" -eq 1 ]; then
@@ -306,6 +394,14 @@ else
 	STALLED_JSON=$(printf '%s\n' "${STALLED_TICKETS[@]}" | jq -R . | jq -s .)
 fi
 
+# CTL-509: additive summary fields for workers the git-activity guard left running.
+SUPPRESSED_COUNT=${#SUPPRESSED_TICKETS[@]}
+if [ "$SUPPRESSED_COUNT" -eq 0 ]; then
+	SUPPRESSED_JSON="[]"
+else
+	SUPPRESSED_JSON=$(printf '%s\n' "${SUPPRESSED_TICKETS[@]}" | jq -R . | jq -s .)
+fi
+
 jq -nc \
 	--argjson c "$CHECKED" \
 	--argjson d "$DEAD_COUNT" \
@@ -313,4 +409,7 @@ jq -nc \
 	--argjson s "$STALLED_COUNT" \
 	--argjson st "$STALLED_JSON" \
 	--argjson r "$REAPED_COUNT" \
-	'{checked:$c, dead:$d, deadTickets:$t, stalled:$s, stalledTickets:$st, reaped:$r}'
+	--argjson gs "$SUPPRESSED_COUNT" \
+	--argjson gst "$SUPPRESSED_JSON" \
+	'{checked:$c, dead:$d, deadTickets:$t, stalled:$s, stalledTickets:$st, reaped:$r,
+	  gitActiveSuppressed:$gs, gitActiveSuppressedTickets:$gst}'


### PR DESCRIPTION
## Summary

In **phase-agents mode**, the bash `orchestrate-healthcheck` flags a phase worker `state-json-stale` purely from the `--bg` `state.json` mtime against a flat 900s cutoff, with no git guard. A live `phase-implement` worker that blocks in one long synchronous tool call (`bun install` + full test suite) can go >15 min without `claude` touching `state.json`, so the healthcheck **falsely flips it to stalled** and emits `phase.implement.failed` — waking `orchestrate-revive` to re-dispatch a second worker that races the first on the same worktree.

This adds a **git-activity liveness guard**: before honoring a `state-json-stale` flag, the healthcheck resolves the worker's worktree and reads its most-recent commit timestamp. If the worktree committed within the activity window (default = the stale-bg cutoff), the worker is treated as alive and the false stall is suppressed — the signal is left `running`, no `phase.*.failed` is emitted, a benign `worker-phase-stale-suppressed` diagnostic event is logged, and `gitActiveSuppressed` is incremented in the summary JSON. This mirrors the execution-core JS guard (`stalled-detector.mjs`), which is inactive in phase-agents mode.

Fixes CTL-509.

## Changes

- **New helpers in `orchestrate-healthcheck`:**
  - `hc_worktree_base()` — resolves the worktree base (`CATALYST_HEALTHCHECK_WORKTREE_BASE` > `state.json .worktreeBase` > `.catalyst/config.json`).
  - `git_worker_is_live()` — returns live iff the guard is on, the worktree resolves, it is a git repo, and its most-recent commit is younger than `GIT_ACTIVITY_SECONDS`.
- **Guard scope:** applies **only** to `state-json-stale`, never `state-json-missing` (a missing job dir is a real launch failure). Degrades to current flagging behavior whenever a worktree cannot be resolved or git errors.
- **Controls:** opt-out via `--no-git-guard` / `CATALYST_HEALTHCHECK_GIT_GUARD=0`; tunable window via `--git-activity-seconds` (defaults to `--stale-bg-seconds`). Default **ON**.
- **Summary JSON:** adds `gitActiveSuppressed` + `gitActiveSuppressedTickets`.
- **Docs:** extends the `usage()` header (widened to lines 2–61 so `--help` shows the new flags/env), adds a CTL-509 explainer block, and adds a git-activity-guard paragraph to `docs/orchestrator-overview.md`.

## Testing

- 10 new test cases (suppress / no-suppress / degrade / missing / opt-out ×2 / tunable window / event contract / summary count ×2).
- Healthcheck suite: **58 passed, 0 failed.**

## Review notes

Reviewed (orchestrator phase-review): `reviewPassed: true`. One medium finding (`git_worker_is_live` has no lower bound on commit age — a future-dated commit from clock skew could pass the `< window` check) was **deferred to human decision** as an anomalous-clock-only path, not a normal one. Remaining findings are low-severity intended-design tradeoffs consistent with existing patterns in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
