### PR TITLE
fix(dev): make phase-triage body resilient to slash-arg substitution (CTL-602)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -60,12 +60,29 @@ if [ ! -s "$SKILL_BODY_FILE" ]; then
 	exit 1
 fi
 
-# Per-case runner. $1=case-name, $2=fixture-json-path, $3=ticket, $4=expected-status
+# ─────────────────────────────────────────────────────────────────────────────
+# CTL-602 static guard: the body must contain NO bare $<digit> token. Claude
+# Code's slash-command arg substitution ($0→ticket, $1→--orch-dir, …) rewrites
+# bare $N everywhere — including inside fenced bash — at dispatch, corrupting the
+# deterministic fallback. Braced ${N} and parenthesized $(N) are not bare $N and
+# are allowed; this filter excludes them.
+echo "phase-triage CTL-602 substitution-resilience guards"
+BARE_POSITIONALS="$(grep -nE '\$[0-9]' "$SKILL_BODY_FILE" | grep -vE '\$\{|\$\(' || true)"
+if [ -n "$BARE_POSITIONALS" ]; then
+	fail "ctl602-static: body has no bare \$<digit> (would be clobbered by slash-arg substitution)" \
+		"offending lines:$(printf '\n%s' "$BARE_POSITIONALS")"
+else
+	ok "ctl602-static: body has no bare \$<digit> tokens"
+fi
+
+# Per-case runner. $1=case-name, $2=fixture-json-path, $3=ticket,
+# $4=optional body-file override (defaults to the extracted $SKILL_BODY_FILE).
 TMPROOT="$(mktemp -d -t phase-triage-test.XXXXXX)"
 trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
 
 run_case() {
 	local case_name="$1" fixture="$2" ticket="$3"
+	local body_file="${4:-$SKILL_BODY_FILE}"
 	local case_dir="$TMPROOT/$case_name"
 	mkdir -p "$case_dir/bin"
 
@@ -112,7 +129,7 @@ EOF
 		CATALYST_EVENTS_FILE="$events_file" \
 		PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
 		PHASE_EMIT_HELPER="$EMIT_HELPER" \
-		bash "$SKILL_BODY_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+		bash "$body_file" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
 	echo $? >"$case_dir/exit-code"
 
 	# Stash for later assertions
@@ -328,6 +345,57 @@ fi
 
 FAIL_EVENT="$(jq -r '.attributes."event.name"' "$FAIL_DIR/events.jsonl" 2>/dev/null | head -1)"
 assert_eq "lin-fail: emits phase.triage.failed event" "phase.triage.failed.CTL-9001" "$FAIL_EVENT"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CTL-602 dynamic guard: simulate Claude Code slash-command arg substitution on
+# the extracted body, then run the SUBSTITUTED body. A real dispatch is
+# `/catalyst-dev:phase-triage <TICKET> --orch-dir <PATH>`, so $0→<TICKET>,
+# $1→--orch-dir, $2→<PATH>. The sed targets bare $N only (the `[0-9]` immediately
+# follows `$`); `${N}` and `$(N)` are untouched, matching the documented behavior.
+# Pre-fix this corrupts classify()/acronyms_json()/awk and the case fails; the
+# fixed (no-bare-$N) body is unaffected by the sed and still produces correct output.
+
+SUBST_BODY="$(mktemp -t phase-triage-subst.XXXXXX.sh)"
+# shellcheck disable=SC2064
+trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE" "$SUBST_BODY"' EXIT
+# Single quotes are deliberate: sed must receive the literal patterns \$0/\$1/\$2,
+# not shell-expanded values. (shellcheck SC2016 is a false positive here.)
+# shellcheck disable=SC2016
+sed -e 's/\$0/CTL-9999/g' \
+	-e 's/\$1/--orch-dir/g' \
+	-e 's#\$2#/tmp/orch#g' \
+	"$SKILL_BODY_FILE" >"$SUBST_BODY"
+
+CASE_DIR_SUBST="$(run_case subst "$FIXTURE_HAPPY" CTL-9999 "$SUBST_BODY")"
+
+assert_eq "ctl602-dynamic: substituted body exits 0" 0 "$(cat "$CASE_DIR_SUBST/exit-code")"
+
+TRIAGE_SUBST="$CASE_DIR_SUBST/worker/triage.json"
+assert_file_exists "ctl602-dynamic: substituted body produced triage.json" "$TRIAGE_SUBST"
+
+if [ -f "$TRIAGE_SUBST" ]; then
+	# FIXTURE_HAPPY has no bug/doc/refactor/chore keyword → must classify as feature.
+	# Pre-fix, $1→--orch-dir means the case never matches and it accidentally still
+	# yields feature — so also assert acronyms + summary, which pre-fix break hard.
+	CLASS_SUBST="$(jq -r '.classification' "$TRIAGE_SUBST")"
+	assert_eq "ctl602-dynamic: classification survives substitution" "feature" "$CLASS_SUBST"
+
+	ACR_SUBST="$(jq '.acronyms_expanded | length' "$TRIAGE_SUBST")"
+	if [ "${ACR_SUBST:-0}" -ge 1 ]; then
+		ok "ctl602-dynamic: acronym expansion survives substitution (≥1)"
+	else
+		fail "ctl602-dynamic: acronym expansion" "expected ≥1 acronym after substitution, got $ACR_SUBST"
+	fi
+
+	SUMMARY_SUBST="$(jq -r '.summary' "$TRIAGE_SUBST")"
+	# Pre-fix, awk $0→CTL-9999 collapses every line to the number -9999; the fixed
+	# body yields the real first prose sentence. Assert it starts with the fixture's
+	# opening prose and is not the corrupted numeric form.
+	case "$SUMMARY_SUBST" in
+	"Wire the CLI tool"*) ok "ctl602-dynamic: summary survives substitution (real prose, not awk-corrupted)" ;;
+	*) fail "ctl602-dynamic: summary content" "expected prefix 'Wire the CLI tool', got '$SUMMARY_SUBST'" ;;
+	esac
+fi
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Summary

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -90,18 +90,22 @@ ${DESCRIPTION}"
 
 # 2. Derive the five triage fields deterministically (the bash fallback path).
 
-# 2a. Classification — first-match over a small regex table.
-classify() {
-  local txt; txt="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
-  case "$txt" in
-    *' bug '*|*'fix'*|*'bugfix'*|*'broken'*|*'regression'*) echo bug ;;
-    *' doc '*|*'docs'*|*'documentation'*|*'readme'*)        echo docs ;;
-    *'refactor'*|*'rename'*|*'cleanup'*|*'extract '*)        echo refactor ;;
-    *'chore'*|*'bump'*|*'dependency update'*|*'deps:'*)      echo chore ;;
-    *)                                                       echo feature ;;
-  esac
-}
-CLASSIFICATION="$(classify " $COMBINED ")"
+# 2a. Classification — first-match over a small regex table. Inlined (no helper
+#    function) so the body carries no bare positional parameter. At dispatch the
+#    skill is rendered as a slash command (`/catalyst-dev:phase-triage <TICKET>
+#    --orch-dir <PATH>`) and Claude Code substitutes bare positional tokens
+#    everywhere — including inside this fenced bash — so the second positional
+#    would become the literal "--orch-dir" flag and break every match (CTL-602).
+#    Keep this block free of bare positional tokens (a "$" immediately followed
+#    by a digit); braced and command-substitution forms are unaffected.
+_PT_LOWER="$(printf '%s' " $COMBINED " | tr '[:upper:]' '[:lower:]')"
+case "$_PT_LOWER" in
+  *' bug '*|*'fix'*|*'bugfix'*|*'broken'*|*'regression'*) CLASSIFICATION=bug ;;
+  *' doc '*|*'docs'*|*'documentation'*|*'readme'*)        CLASSIFICATION=docs ;;
+  *'refactor'*|*'rename'*|*'cleanup'*|*'extract '*)        CLASSIFICATION=refactor ;;
+  *'chore'*|*'bump'*|*'dependency update'*|*'deps:'*)      CLASSIFICATION=chore ;;
+  *)                                                       CLASSIFICATION=feature ;;
+esac
 
 # 2b. Estimated scope — word count thresholds.
 WORD_COUNT="$(printf '%s' "$DESCRIPTION" | wc -w | tr -d ' ')"
@@ -112,36 +116,35 @@ else                                  ESTIMATED_SCOPE=epic
 fi
 
 # 2c. Acronym expansion — built-in dictionary; only emit acronyms actually present
-#    in the title+description.
-acronyms_json() {
-  local txt="$1"
-  jq -nc --arg t "$txt" '
-    [
-      {a:"PR",     e:"Pull Request"},
-      {a:"CI",     e:"Continuous Integration"},
-      {a:"CLI",    e:"Command-Line Interface"},
-      {a:"API",    e:"Application Programming Interface"},
-      {a:"MVP",    e:"Minimum Viable Product"},
-      {a:"TDD",    e:"Test-Driven Development"},
-      {a:"E2E",    e:"End-to-End"},
-      {a:"SHA",    e:"Secure Hash Algorithm"},
-      {a:"UUID",   e:"Universally Unique Identifier"},
-      {a:"JSON",   e:"JavaScript Object Notation"},
-      {a:"OTEL",   e:"OpenTelemetry"},
-      {a:"OTLP",   e:"OpenTelemetry Line Protocol"},
-      {a:"PromQL", e:"Prometheus Query Language"},
-      {a:"bg",     e:"background"},
-      {a:"HUD",    e:"Heads-Up Display"},
-      {a:"ADR",    e:"Architecture Decision Record"}
-    ]
-    | ($t | ascii_downcase) as $tl
-    | map(.a as $acr
-          | (.a | ascii_downcase) as $acl
-          | select($tl | test("\\b" + $acl + "\\b")))
-    | map({acronym: .a, expansion: .e})
-  '
-}
-ACRONYMS_EXPANDED="$(acronyms_json "$COMBINED")"
+#    in the title+description. Inlined (no helper function) so the body carries no
+#    bare positional parameter, which slash-command arg substitution would clobber
+#    at dispatch (CTL-602). The jq variables below ($t and friends) are not bare
+#    "$"-then-digit tokens, so they are unaffected.
+ACRONYMS_EXPANDED="$(jq -nc --arg t "$COMBINED" '
+  [
+    {a:"PR",     e:"Pull Request"},
+    {a:"CI",     e:"Continuous Integration"},
+    {a:"CLI",    e:"Command-Line Interface"},
+    {a:"API",    e:"Application Programming Interface"},
+    {a:"MVP",    e:"Minimum Viable Product"},
+    {a:"TDD",    e:"Test-Driven Development"},
+    {a:"E2E",    e:"End-to-End"},
+    {a:"SHA",    e:"Secure Hash Algorithm"},
+    {a:"UUID",   e:"Universally Unique Identifier"},
+    {a:"JSON",   e:"JavaScript Object Notation"},
+    {a:"OTEL",   e:"OpenTelemetry"},
+    {a:"OTLP",   e:"OpenTelemetry Line Protocol"},
+    {a:"PromQL", e:"Prometheus Query Language"},
+    {a:"bg",     e:"background"},
+    {a:"HUD",    e:"Heads-Up Display"},
+    {a:"ADR",    e:"Architecture Decision Record"}
+  ]
+  | ($t | ascii_downcase) as $tl
+  | map(.a as $acr
+        | (.a | ascii_downcase) as $acl
+        | select($tl | test("\\b" + $acl + "\\b")))
+  | map({acronym: .a, expansion: .e})
+')"
 
 # 2d. Dependencies — other CTL-style identifiers referenced in body, excluding self.
 #     Match any TEAM-NNN pattern; dedupe; exclude the ticket itself.
@@ -157,21 +160,24 @@ DEPENDENCIES="${DEPENDENCIES:-[]}"
 #     description that opens with "## Problem" yields the first sentence of prose,
 #     not the literal header. Falls back to an empty summary if the description is
 #     entirely headers/bullets/blank lines.
-SUMMARY="$(printf '%s' "$DESCRIPTION" | awk '
-  BEGIN { skipping = 1; buf = "" }
-  {
-    line = $0
-    if (skipping) {
-      if (line ~ /^[[:space:]]*$/)       { next }
-      if (line ~ /^#+[[:space:]]+/)      { next }
-      if (line ~ /^[-*+][[:space:]]+/)   { next }
-      skipping = 0
-    }
-    if (line ~ /^[[:space:]]*$/) { exit }
-    buf = (buf == "" ? line : buf " " line)
-  }
-  END { print buf }
-' | head -c 400)"
+#     Implemented as a pure-bash loop rather than awk: awk's whole-line field is a
+#     bare positional token, which Claude Code's slash-command arg substitution
+#     would rewrite to the ticket id at dispatch, turning every line into broken
+#     awk arithmetic (CTL-602). This loop uses only bash+zsh-safe constructs
+#     ([[ =~ ]], <<<, head -c) and carries no bare "$"-then-digit token.
+SUMMARY=""
+_PT_SKIPPING=1
+while IFS= read -r line; do
+  if [ "$_PT_SKIPPING" -eq 1 ]; then
+    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+    [[ "$line" =~ ^#+[[:space:]]+ ]] && continue
+    [[ "$line" =~ ^[-*+][[:space:]]+ ]] && continue
+    _PT_SKIPPING=0
+  fi
+  [[ "$line" =~ ^[[:space:]]*$ ]] && break
+  if [ -z "$SUMMARY" ]; then SUMMARY="$line"; else SUMMARY="$SUMMARY $line"; fi
+done <<< "$DESCRIPTION"
+SUMMARY="$(printf '%s' "$SUMMARY" | head -c 400)"
 
 # 3. Compose triage.json.
 TRIAGE_FILE="$WORKER_DIR/triage.json"


### PR DESCRIPTION
## Summary

The `phase-triage` skill body's deterministic bash fallback was silently corrupted on **every** dispatch. The orchestrator launches it as a slash command:

```
/catalyst-dev:phase-triage <TICKET> --orch-dir <PATH>
```

and Claude Code's slash-command argument substitution rewrites every bare `$N` token — including **inside the fenced bash body** — where `$N` is shorthand for `$ARGUMENTS[N]` (0-indexed: `$0`=ticket, `$1`=`--orch-dir`, `$2`=path). That clobbered three sites:

| Site | Bare token | Corruption | Effect |
|------|-----------|------------|--------|
| `classify()` | `$1` → `--orch-dir` | no branch matches | every ticket classified `feature` |
| `acronyms_json()` | `$1` → `--orch-dir` | empty input | `acronyms_expanded` always `[]` |
| awk summary | `$0` → `<TICKET>` | `CTL`−`602` arithmetic on undefined awk vars | every line → a number; garbage summary |

The on-disk source was correct — the corruption is introduced at render time by **Claude Code itself** (confirmed: `phase-agent-dispatch:471` just builds a slash string; there is no repo-side renderer, and the Claude Code docs confirm bare-`$N` substitution everywhere with no escape mechanism). So the fix makes the body free of any bare `$<digit>`, matching the other 8 phase skills (which contain zero bare `$N`).

## Changes

- **`plugins/dev/skills/phase-triage/SKILL.md`** — inline the two single-use helpers (`classify()`, `acronyms_json()`) so they no longer take a positional `$1`; rewrite the summary `awk` block (which needs `$0` = whole line) as an equivalent pure-bash `while read` loop. Output (triage.json shape, classification, acronyms, deps, summary) is unchanged. Uses only bash+zsh-safe constructs; verified under both shells.
- **`plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh`** — adds a **static guard** (body must contain no bare `$<digit>`) and a **dynamic guard** (simulate Claude Code's `$N` substitution on the extracted body, run it, assert classification/acronyms/summary survive). Both fail on the pre-fix body and pass on the fix.

## Testing

- `bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` → **34 passed, 0 failed** (existing + 2 new regression guards)
- Ran the full body under **zsh** with a `linearis` stub — triage.json fields all correct
- `shellcheck` clean

## Scope

phase-triage is the only phase skill with bare `$N` (verified across all `phase-*/SKILL.md`). No sibling fix needed. A separate pre-existing zsh incompatibility in `phase-emit-complete.sh` (`BASH_SOURCE[0]` unset, `local status` collision) was observed during verification and filed as a finding — out of scope here.

Closes CTL-602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)