### PR TITLE
CTL-625: Auto-dispatch triage on Backlog→Ready when no triage.json

### DIFF
--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -97,6 +97,25 @@ on the right). Allow-listed roots (`projectKey`, `project.ticketPrefix`, `linear
 `linear.stateMap`, `linear.stateIds`) are suppressed to avoid double-warning — those are already
 checked individually by `check-project-setup.sh`.
 
+### Execution-core entry triggers (two-state monitor)
+
+In `execution-core` dispatch mode the daemon's monitor reacts to Linear
+`state_changed` events:
+
+- **`→Triage`** one-shot-dispatches the triage phase agent (the ticket is not
+  scheduler-pulled).
+- **`→Ready`** is the scheduler-eligible entry. New work enters the pipeline at
+  the `research` phase on the contract that a Ready ticket has already been
+  triaged.
+
+A user may move a ticket **Backlog → Ready directly**, skipping `→Triage`
+(an intentional human shortcut). When this happens and no `triage.json` exists
+for the ticket, the monitor **auto-dispatches the triage phase agent** rather
+than reconciling the ticket into the eligible set — triage then runs and its
+completion advances the ticket to `research` normally. This makes "Ready" a
+valid manual entry point: the system transparently runs the missing triage
+instead of dead-locking the research prior-artifact gate. (CTL-625)
+
 ## The 9-phase pipeline (phase-agents mode)
 
 Canonical sequence is defined in `plugins/dev/scripts/orchestrate-phase-advance`

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -11,8 +11,8 @@
 // RECONCILE (it may have entered) — the payload carries no project/label/
 // priority, so additions and scoping are resolved exclusively by the poll.
 
-import { watch, openSync, fstatSync, readSync, closeSync, mkdirSync } from "node:fs";
-import { dirname, basename } from "node:path";
+import { watch, openSync, fstatSync, readSync, closeSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, basename, join } from "node:path";
 import {
   getEventLogPath,
   RECONCILE_INTERVAL_MS,
@@ -165,10 +165,28 @@ export function handleStateChangedEvent(
       // (phase-agent-dispatch no-ops an existing signal file).
       dispatchTriage(parsed.identifier, { dispatch, orchDir });
     } else if (!parsed.toState || parsed.toState === query.status) {
-      // →Ready (or an unknown new state) — the event cannot confirm
-      // project/label/priority scoping, so a full poll is required. Debounce
-      // it so a burst of events coalesces into one reconcile.
-      scheduleDirtyReconcile(p.team, { exec, debounceMs });
+      // →Ready (or an unknown new state). CTL-625: a confirmed →Ready
+      // (toState === query.status) for a ticket with no prior triage.json means
+      // the user moved Backlog→Ready directly, skipping →Triage. Auto-dispatch
+      // triage (same seam as →Triage) so "Ready" transparently triages-then-
+      // proceeds instead of dead-locking the research prior-artifact gate. The
+      // triage agent's phase.triage.complete advances the ticket to research via
+      // the scheduler's advancement sweep, so we do NOT also reconcile here —
+      // reconciling would let the new-work pull dispatch research before
+      // triage.json exists (the no-backoff storm CTL-625 fixes). An unknown new
+      // state (!parsed.toState), an already-triaged Ready, or a standalone
+      // monitor with no orchDir falls through to the debounced reconcile
+      // (the event cannot confirm project/label/priority scoping, so a full
+      // poll is required; debounced so a burst coalesces into one reconcile).
+      if (
+        parsed.toState === query.status &&
+        orchDir &&
+        !hasTriageArtifact(orchDir, parsed.identifier)
+      ) {
+        dispatchTriage(parsed.identifier, { dispatch, orchDir });
+      } else {
+        scheduleDirtyReconcile(p.team, { exec, debounceMs });
+      }
     } else if (DRAG_OUT_STATES.has(parsed.toState)) {
       // Drag-out to Backlog/Canceled/Duplicate — kill signal. Confident
       // immediate removal, then abort any in-flight worker and tear down its
@@ -207,6 +225,13 @@ function dispatchTriage(identifier, { dispatch, orchDir }) {
   if (r.code !== 0) {
     log.warn({ identifier, code: r.code }, "monitor: triage dispatch failed");
   }
+}
+
+// hasTriageArtifact — does a triage.json exist for this ticket's worker dir?
+// CTL-625: the marker that distinguishes an already-triaged Ready ticket from
+// a Backlog→Ready-direct entry that skipped the triage phase agent.
+function hasTriageArtifact(orchDir, ticket) {
+  return existsSync(join(orchDir, "workers", ticket, "triage.json"));
 }
 
 function scheduleDirtyReconcile(team, { exec, debounceMs }) {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -77,6 +77,14 @@ function enroll(team, eligibleQuery) {
   return repoRoot;
 }
 
+// writeTriageArtifact — mark a ticket as already-triaged (CTL-625). orchDir is
+// a real tmpdir; the monitor checks workers/<ticket>/triage.json.
+function writeTriageArtifact(orchDir, ticket) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "triage.json"), JSON.stringify({ ticket }));
+}
+
 // unenroll — drop a team from the registry (an operator registry edit).
 function unenroll(team) {
   const i = registryEntries.findIndex((e) => e.team === team);
@@ -255,8 +263,10 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
     expect(dispatch).toHaveBeenCalledWith({ orchDir, ticket: "ENG-1", phase: "triage" });
   });
 
-  test("toState === eligible status (Ready) schedules a reconcile, never a triage dispatch", async () => {
+  test("→Ready with an existing triage.json reconciles, never a triage dispatch", async () => {
     enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core"); // real dir (beforeEach made it)
+    writeTriageArtifact(realOrchDir, "ENG-9");
     const exec = execReturning({ ENG: [node("ENG-9")] });
     const dispatch = mock(() => ({ code: 0 }));
     handleStateChangedEvent(
@@ -264,11 +274,49 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
         event: "linear.issue.state_changed",
         detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Ready" },
       },
-      { exec, dispatch, orchDir, debounceMs: 30 },
+      { exec, dispatch, orchDir: realOrchDir, debounceMs: 30 },
     );
     expect(dispatch).not.toHaveBeenCalled();
     await sleep(70);
     expect(exec.calls).toBe(1); // the debounced reconcile ran
+  });
+
+  test("CTL-625: →Ready with no triage.json auto-dispatches triage (Backlog→Ready-direct)", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core"); // real dir, NO triage.json
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    const dispatch = mock(() => ({ code: 0 }));
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Ready" },
+      },
+      { exec, dispatch, orchDir: realOrchDir, debounceMs: 30 },
+    );
+    expect(dispatch).toHaveBeenCalledWith({
+      orchDir: realOrchDir,
+      ticket: "ENG-9",
+      phase: "triage",
+    });
+    expect(exec.calls).toBe(0); // did NOT reconcile (no new-work pull → no storm)
+  });
+
+  test("CTL-625: →Ready with no orchDir wired falls back to reconcile, never throws", async () => {
+    enroll("ENG", { status: "Ready" });
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    const dispatch = mock(() => ({ code: 0 }));
+    expect(() =>
+      handleStateChangedEvent(
+        {
+          event: "linear.issue.state_changed",
+          detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Ready" },
+        },
+        { exec, dispatch, debounceMs: 30 }, // no orchDir
+      ),
+    ).not.toThrow();
+    expect(dispatch).not.toHaveBeenCalled();
+    await sleep(70);
+    expect(exec.calls).toBe(1);
   });
 
   // CTL-584: drag-out kill fires only for the enumerated DRAG_OUT_STATES.

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -160,6 +160,10 @@ machine-local `stateIds` cache,
 and upserts the team's registry entry. Run it directly with `--dry-run --json`
 to preview the contract without writing anything.
 
+Moving a ticket **Backlog → Ready** directly (skipping `Triage`) is supported:
+if no `triage.json` exists yet, the monitor auto-runs the triage phase before
+the ticket enters the pipeline at `Research`. (CTL-625)
+
 ### Central Registry (`~/catalyst/execution-core/registry.json`)
 
 For `execution-core` teams, the central registry is the single source of


### PR DESCRIPTION
## Summary

In `execution-core` dispatch mode the daemon monitor reacts to Linear `state_changed` events with a two-state entry contract (CTL-565): `→Triage` one-shot-dispatches the triage phase agent, and `→Ready` is the scheduler-eligible entry where new work joins the pipeline at the `research` phase **on the assumption the ticket was already triaged**.

A human can move a ticket **Backlog → Ready directly**, skipping `→Triage`. When that happened and no `triage.json` existed yet, the monitor reconciled the ticket into the eligible set, the new-work pull dispatched `research` before any triage artifact existed, and the research prior-artifact gate dead-locked (with no backoff — a reconcile storm).

This PR makes "Ready" a valid manual entry point: a confirmed `→Ready` for a ticket with **no** `triage.json` now auto-dispatches the triage phase agent (the same seam as `→Triage`) instead of reconciling. Triage runs, and its `phase.triage.complete` advances the ticket to `research` normally through the scheduler's advancement sweep.

## Changes

- **`plugins/dev/scripts/execution-core/monitor.mjs`**
  - In the `→Ready` / unknown-new-state branch of `handleStateChangedEvent`, branch on whether a `triage.json` already exists for the ticket's worker dir:
    - confirmed `→Ready` (`toState === query.status`) **with no** `triage.json` and an `orchDir` wired → `dispatchTriage(...)` (no reconcile, so no new-work pull → no storm).
    - already-triaged Ready, unknown new state (`!parsed.toState`), or a standalone monitor with no `orchDir` → existing debounced `scheduleDirtyReconcile`.
  - New `hasTriageArtifact(orchDir, ticket)` helper checks `workers/<ticket>/triage.json`.
  - Imports `existsSync` and `join`.

- **`plugins/dev/scripts/execution-core/monitor.test.mjs`**
  - New `writeTriageArtifact` helper.
  - Updated the existing CTL-565 test to seed a `triage.json` and assert the already-triaged Ready path still reconciles and never dispatches triage.
  - Added: `→Ready` with no `triage.json` auto-dispatches triage and does **not** reconcile (`exec.calls === 0`).
  - Added: `→Ready` with no `orchDir` wired falls back to reconcile and never throws.

- **Docs**: `docs/orchestrator-overview.md` (new "Execution-core entry triggers" section) and `website/src/content/docs/reference/configuration.md` document the Backlog→Ready-direct auto-triage behavior.

## Testing

- Unit tests in `monitor.test.mjs` cover all three branches (already-triaged reconcile, no-triage auto-dispatch, no-orchDir fallback).
- Verified by the orchestrator verify + review phases (no blocking findings).

Refs: CTL-625
