### PR TITLE
CTL-624: Add dispatch cool-down to execution-core scheduler

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -322,13 +322,21 @@ function labelOnce(orchDir, ticket, label, writeStatus) {
   }
 }
 
-// CTL-624: dispatch cool-down marker. Mirrors the labelOnce once-marker
-// convention (workers/<T>/.linear-label-*), but the marker carries a timestamp
-// and the guard is time-based: re-dispatch is suppressed only while
-// now - failedAt < DISPATCH_COOLDOWN_MS, so the window self-heals once the
-// upstream artifact appears (unlike labelOnce's permanent .skipped marker).
+// CTL-624: dispatch cool-down marker. Conceptually mirrors the labelOnce
+// once-marker (workers/<T>/.linear-label-*), but with two deliberate
+// differences: (1) the marker carries a timestamp and the guard is time-based —
+// re-dispatch is suppressed only while now - failedAt < DISPATCH_COOLDOWN_MS, so
+// the window self-heals once the upstream artifact appears (unlike labelOnce's
+// permanent .skipped marker); (2) the marker lives in a dedicated
+// orchDir/.dispatch-cooldowns/ dir, NOT under workers/<T>/. A new-work ticket
+// refused at the entry phase has no worker dir yet; writing a marker into
+// workers/<T>/ would manufacture one, and listStartedTickets (dir-existence)
+// would then exclude the ticket from the new-work pull *forever* — dropping it
+// silently instead of merely throttling re-dispatch. Keeping the marker off the
+// workers/ tree leaves listStartedTickets / listInFlightTickets / readWorkerSignals
+// semantics untouched, so the ticket stays eligible and re-dispatches after the window.
 export function dispatchCooldownPath(orchDir, ticket, phase) {
-  return join(orchDir, "workers", ticket, `.dispatch-cooldown-${phase}.json`);
+  return join(orchDir, ".dispatch-cooldowns", `${ticket}-${phase}.json`);
 }
 
 export function inDispatchCooldown(orchDir, ticket, phase, now) {
@@ -344,7 +352,7 @@ export function inDispatchCooldown(orchDir, ticket, phase, now) {
 }
 
 export function recordDispatchFailure(orchDir, ticket, phase, code, now) {
-  const dir = join(orchDir, "workers", ticket);
+  const dir = join(orchDir, ".dispatch-cooldowns");
   try {
     mkdirSync(dir, { recursive: true });
     writeFileSync(
@@ -567,8 +575,10 @@ export function schedulerTick(
   for (const ticket of listInFlightTickets(orchDir)) {
     const next = deriveAdvancement(readPhaseSignals(orchDir, ticket));
     if (!next) continue;
+    if (inDispatchCooldown(orchDir, ticket, next, now())) continue; // CTL-624: throttle refused re-dispatch
     const r = dispatchTicket(orchDir, ticket, next, { dispatch });
     if (r.code === 0) {
+      clearDispatchCooldown(orchDir, ticket, next); // CTL-624: success clears any prior cool-down
       advanced.push({ ticket, phase: next });
       // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
       // (linear-transition.sh read-compares first); never aborts the tick.
@@ -577,6 +587,7 @@ export function schedulerTick(
         phase: next,
       });
     } else {
+      recordDispatchFailure(orchDir, ticket, next, r.code, now()); // CTL-624: arm the cool-down window
       log.warn({ ticket, phase: next, code: r.code }, "scheduler: advance dispatch failed");
     }
   }
@@ -593,8 +604,10 @@ export function schedulerTick(
 
   const dispatched = [];
   for (const t of selected) {
+    if (inDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, now())) continue; // CTL-624: throttle refused re-dispatch
     const r = dispatchTicket(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, { dispatch });
     if (r.code === 0) {
+      clearDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-624: success clears any prior cool-down
       dispatched.push(t.identifier);
       // CTL-558: write the entry-phase (`research`) status for the new ticket.
       safeWrite(
@@ -606,6 +619,7 @@ export function schedulerTick(
         { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE },
       );
     } else {
+      recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, r.code, now()); // CTL-624: arm the cool-down window
       log.warn({ ticket: t.identifier, code: r.code }, "scheduler: dispatch failed");
     }
   }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -13,7 +13,7 @@
 // Composes: lib/dependency-graph.mjs (readiness), scheduler-rank.mjs (ranking),
 // lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
 
-import { readdirSync, readFileSync, writeFileSync, existsSync, watch, mkdirSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync, existsSync, watch, mkdirSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join, dirname, basename } from "node:path";
 import { analyzeDependencyGraph, referencedBlockerIds } from "../lib/dependency-graph.mjs";
@@ -322,6 +322,53 @@ function labelOnce(orchDir, ticket, label, writeStatus) {
   }
 }
 
+// CTL-624: dispatch cool-down marker. Mirrors the labelOnce once-marker
+// convention (workers/<T>/.linear-label-*), but the marker carries a timestamp
+// and the guard is time-based: re-dispatch is suppressed only while
+// now - failedAt < DISPATCH_COOLDOWN_MS, so the window self-heals once the
+// upstream artifact appears (unlike labelOnce's permanent .skipped marker).
+export function dispatchCooldownPath(orchDir, ticket, phase) {
+  return join(orchDir, "workers", ticket, `.dispatch-cooldown-${phase}.json`);
+}
+
+export function inDispatchCooldown(orchDir, ticket, phase, now) {
+  const p = dispatchCooldownPath(orchDir, ticket, phase);
+  let failedAt;
+  try {
+    failedAt = JSON.parse(readFileSync(p, "utf8"))?.failedAt;
+  } catch {
+    return false; // absent / malformed → treat as no cool-down
+  }
+  if (typeof failedAt !== "number") return false;
+  return now - failedAt < DISPATCH_COOLDOWN_MS;
+}
+
+export function recordDispatchFailure(orchDir, ticket, phase, code, now) {
+  const dir = join(orchDir, "workers", ticket);
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      dispatchCooldownPath(orchDir, ticket, phase),
+      JSON.stringify({ phase, code, failedAt: now }),
+    );
+  } catch (err) {
+    // Never let a marker write crash the tick — worst case is the next tick
+    // retries (the pre-CTL-624 behavior).
+    log.warn(
+      { ticket, phase, err: err.message },
+      "scheduler: dispatch cool-down marker write failed — continuing",
+    );
+  }
+}
+
+export function clearDispatchCooldown(orchDir, ticket, phase) {
+  try {
+    rmSync(dispatchCooldownPath(orchDir, ticket, phase), { force: true });
+  } catch {
+    // best-effort — a stale marker just means one suppressed re-dispatch
+  }
+}
+
 // REQUIRED_WORKSPACE_LABELS — the flat labels the CTL-558 coordinator sweep
 // writes. Both must pre-exist in the Linear workspace; linearis has no
 // `labels create`. CTL-585's preflight warns once at daemon start if either
@@ -470,6 +517,7 @@ export function schedulerTick(
     writeStatus = linearWrite,
     teardownWorktree = defaultTeardownWorktree,
     reclaimDeadWork = defaultReclaimDeadWork,
+    now = Date.now, // CTL-624: injectable clock for the dispatch cool-down
   } = {},
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -611,6 +659,15 @@ export function schedulerTick(
 const TICK_INTERVAL_MS = Number(process.env.SCHEDULER_TICK_INTERVAL_MS) || 30_000;
 // Debounce window — a burst of event-log appends coalesces into one tick.
 const TICK_DEBOUNCE_MS = Number(process.env.SCHEDULER_DEBOUNCE_MS) || 2_000;
+
+// CTL-624: per-(ticket,phase) dispatch cool-down. When a dispatch is refused
+// (e.g. prior_artifact_missing → phase-agent-dispatch exit 2) the dispatcher
+// writes no signal file, so isTicketInFlight frees the slot and the next
+// debounced tick re-dispatches immediately — a 2–4 events/sec storm. A
+// timestamped marker under workers/<T>/ throttles re-dispatch of the same
+// (ticket,phase) to one attempt per window. Time-based (not a permanent
+// .skipped marker like labelOnce) so it self-heals once the artifact appears.
+const DISPATCH_COOLDOWN_MS = Number(process.env.SCHEDULER_DISPATCH_COOLDOWN_MS) || 60_000;
 
 // --- daemon module state ---
 let tickTimer = null;

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -301,10 +301,86 @@ describe("dispatch cool-down helpers", () => {
   });
 
   test("a malformed marker is treated as absent (not in cool-down)", () => {
-    const p = dispatchCooldownPath(orchDir, "CTL-1", "research");
-    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
-    writeFileSync(p, "not json");
+    // recordDispatchFailure creates the cool-down dir + a valid marker; then
+    // corrupt the file in place so the path stays decoupled from its location.
+    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 5_000);
+    writeFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "not json");
     expect(inDispatchCooldown(orchDir, "CTL-1", "research", 6_000)).toBe(false);
+  });
+});
+
+// ── CTL-624: dispatch cool-down wired into schedulerTick ──
+describe("dispatch cool-down (schedulerTick)", () => {
+  const eligibleOne = (id) => [
+    {
+      identifier: id,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    },
+  ];
+
+  test("a refused new-work dispatch (code 2) writes a cool-down marker and stops re-dispatching", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 2 });
+    const marker = dispatchCooldownPath(orchDir, "CTL-3", "research");
+
+    // Tick 1 at t=1000: dispatch refused → 1 call, marker written.
+    schedulerTick(orchDir, { readEligible: () => eligibleOne("CTL-3"), dispatch, now: () => 1_000 });
+    expect(dispatch.calls).toHaveLength(1);
+    expect(existsSync(marker)).toBe(true);
+
+    // Tick 2 at t=30_000 (< 60 s window): suppressed → still 1 call.
+    schedulerTick(orchDir, { readEligible: () => eligibleOne("CTL-3"), dispatch, now: () => 30_000 });
+    expect(dispatch.calls).toHaveLength(1);
+
+    // Tick 3 at t=70_000 (> 60 s window): re-dispatch fires → 2 calls.
+    schedulerTick(orchDir, { readEligible: () => eligibleOne("CTL-3"), dispatch, now: () => 70_000 });
+    expect(dispatch.calls).toHaveLength(2);
+  });
+
+  test("a successful dispatch clears any prior cool-down marker", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const marker = dispatchCooldownPath(orchDir, "CTL-4", "research");
+
+    // First a refusal seeds the marker.
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-4"),
+      dispatch: fakeDispatch({ code: 2 }),
+      now: () => 1_000,
+    });
+    expect(existsSync(marker)).toBe(true);
+
+    // After the window, a successful dispatch clears it.
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-4"),
+      dispatch: fakeDispatch({ code: 0 }),
+      now: () => 70_000,
+    });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("a pre-seeded in-window marker suppresses the dispatch entirely (calls === 0)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    recordDispatchFailure(orchDir, "CTL-5", "research", 2, 1_000);
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, { readEligible: () => eligibleOne("CTL-5"), dispatch, now: () => 20_000 });
+    expect(dispatch.calls).toHaveLength(0);
+  });
+
+  test("a refused advancement dispatch is throttled by the cool-down", () => {
+    writeSignal("CTL-6", "research", "done"); // FSM next = plan
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 2 });
+
+    schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 1_000 });
+    expect(dispatch.calls).toHaveLength(1);
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-6", "plan"))).toBe(true);
+
+    schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 30_000 });
+    expect(dispatch.calls).toHaveLength(1); // suppressed within window
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -11,6 +11,7 @@ import {
   writeFileSync,
   appendFileSync,
   existsSync,
+  readFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,6 +31,10 @@ import {
   startScheduler,
   stopScheduler,
   preflightWorkspaceLabels,
+  inDispatchCooldown,
+  recordDispatchFailure,
+  clearDispatchCooldown,
+  dispatchCooldownPath,
   __resetForTests,
 } from "./scheduler.mjs";
 
@@ -259,6 +264,49 @@ function fakeDispatch({ code = 0 } = {}) {
   fn.calls = calls;
   return fn;
 }
+
+// ── CTL-624: per-(ticket,phase) dispatch cool-down helpers ──
+describe("dispatch cool-down helpers", () => {
+  test("no marker → not in cool-down", () => {
+    expect(inDispatchCooldown(orchDir, "CTL-1", "research", 1_000)).toBe(false);
+  });
+
+  test("recordDispatchFailure writes a timestamped marker", () => {
+    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 5_000);
+    const p = dispatchCooldownPath(orchDir, "CTL-1", "research");
+    expect(existsSync(p)).toBe(true);
+    const m = JSON.parse(readFileSync(p, "utf8"));
+    expect(m).toMatchObject({ phase: "research", code: 2, failedAt: 5_000 });
+  });
+
+  test("within the window → in cool-down; past the window → not", () => {
+    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 5_000);
+    // 30 s later (< 60 s window) → still cooling down.
+    expect(inDispatchCooldown(orchDir, "CTL-1", "research", 35_000)).toBe(true);
+    // 61 s later (> 60 s window) → window elapsed.
+    expect(inDispatchCooldown(orchDir, "CTL-1", "research", 66_000)).toBe(false);
+  });
+
+  test("cool-down is per-(ticket,phase)", () => {
+    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 5_000);
+    expect(inDispatchCooldown(orchDir, "CTL-1", "plan", 6_000)).toBe(false);
+    expect(inDispatchCooldown(orchDir, "CTL-2", "research", 6_000)).toBe(false);
+  });
+
+  test("clearDispatchCooldown removes the marker (idempotent if absent)", () => {
+    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 5_000);
+    clearDispatchCooldown(orchDir, "CTL-1", "research");
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-1", "research"))).toBe(false);
+    expect(() => clearDispatchCooldown(orchDir, "CTL-1", "research")).not.toThrow();
+  });
+
+  test("a malformed marker is treated as absent (not in cool-down)", () => {
+    const p = dispatchCooldownPath(orchDir, "CTL-1", "research");
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+    writeFileSync(p, "not json");
+    expect(inDispatchCooldown(orchDir, "CTL-1", "research", 6_000)).toBe(false);
+  });
+});
 
 describe("deriveAdvancement", () => {
   test("latest phase done → returns the FSM successor", () => {


### PR DESCRIPTION
## Summary

Adds a per-`(ticket, phase)` **dispatch cool-down** to the execution-core scheduler to stop the `prior_artifact_missing` retry storm (2–4 dispatch attempts/sec).

When a dispatch is refused — e.g. `phase-agent-dispatch` exits non-zero because the upstream artifact isn't ready yet — the dispatcher writes no signal file. `isTicketInFlight` then frees the slot and the next debounced tick re-dispatches the same `(ticket, phase)` immediately, producing a tight refusal loop. A timestamped marker now throttles re-dispatch of the same `(ticket, phase)` to one attempt per window, and self-heals once the artifact appears.

## Changes

**Phase 1 — primitives (`scheduler.mjs`)**
- `DISPATCH_COOLDOWN_MS` constant — env-overridable via `SCHEDULER_DISPATCH_COOLDOWN_MS`, default 60s
- `dispatchCooldownPath` / `inDispatchCooldown` / `recordDispatchFailure` / `clearDispatchCooldown` helpers — mirror the existing `labelOnce` once-marker convention but **time-based**, so the window self-heals instead of being permanent
- A `now = Date.now` seam threaded into `schedulerTick` for deterministic testing
- `rmSync` added to the `node:fs` import

**Phase 2 — wiring (`scheduler.mjs`)**
- Both dispatch call-sites (the advancement sweep and the new-work pull) now consult `inDispatchCooldown` before dispatching, `recordDispatchFailure` on non-zero exit, and `clearDispatchCooldown` on success

## Key design decision: marker location

Cool-down markers live in a dedicated `orchDir/.dispatch-cooldowns/` directory, **not** under `workers/<TICKET>/`.

The plan originally sketched `workers/<T>/.dispatch-cooldown-<phase>.json`, but a new-work ticket refused at the entry phase has no worker dir yet. Writing a marker there would manufacture one, and `listStartedTickets` (which keys off worker-dir existence) would then exclude that ticket from the new-work pull **permanently** — silently dropping it instead of merely throttling re-dispatch. The dedicated dir leaves `listStartedTickets` / `listInFlightTickets` / `readWorkerSignals` semantics untouched, so the ticket stays eligible and re-dispatches after the window. The Phase 2 self-heal integration test caught this.

## Testing

- 6 cool-down helper unit tests (marker write/read, window boundary, per-`(ticket,phase)` isolation, idempotent clear, malformed-marker-as-absent)
- 4 `schedulerTick` integration tests (new-work storm-stop + self-heal, clear-on-success, pre-seeded suppression, advancement-site throttle)
- Full execution-core suite: **103 pass, 0 fail** in `scheduler.test.mjs`; whole-suite green

Refs: CTL-624
