### PR TITLE
CTL-638: stop recovery-sweep escalation retry storm

### DIFF
--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -1,0 +1,118 @@
+// label-guard.mjs — shared once-marker + cool-down primitives for Linear label
+// writes from the execution-core daemon.
+//
+// Two guards live here because both need to be importable by `scheduler.mjs`
+// and `recovery.mjs`, and `scheduler.mjs` already imports from `recovery.mjs`
+// (the reclaim-dead-work seam) — so a recovery → scheduler import would
+// create a cycle. Keeping the shared utility in a leaf module is the standard
+// fix for that shape.
+//
+//   • labelOnce (CTL-585) — apply a Linear label to a ticket at most once per
+//     daemon lifetime, per (ticket, label). Marker file lives under workers/<T>/.
+//   • inEscalationCooldown / recordEscalation (CTL-638) — suppress the
+//     `appendEscalatedEvent` + `applyStalledLabel` pair on the recovery-sweep
+//     escalation path when the same (ticket, phase) already escalated within
+//     ESCALATION_COOLDOWN_MS. Marker file lives OUTSIDE workers/<T>/ (see the
+//     dispatch cool-down rationale in scheduler.mjs::dispatchCooldownPath and
+//     memory project_scheduler_marker_under_workers_excludes_ticket).
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "./config.mjs";
+
+// ─── labelOnce — moved from scheduler.mjs (CTL-585, then CTL-638 re-home) ───
+//
+// `linearis` label-add has no read-compare, so without a guard the scheduler
+// (and CTL-587's recovery-sweep escalation path) would re-hit the API on every
+// tick. Two marker files at workers/<T>/.linear-label-<label>.{applied,skipped}
+// record terminal outcomes:
+//
+//   .applied — applyLabel returned applied:true. Happy path.
+//   .skipped — applyLabel returned reason:"missing-label". The workspace lacks
+//              the label; retrying inside this daemon's lifetime would just
+//              storm the Linear API (CTL-585). An operator creates the label
+//              in the Linear UI and deletes this marker to re-arm the apply.
+//
+// Transient failures (reason:"rate-limited", "transient", undefined) write no
+// marker so the next tick retries — CTL-558's recovery contract. CTL-638 pairs
+// this with the escalation cool-down below to break the per-tick storm even
+// when the transient-failure path keeps re-attempting the write.
+export function labelOnce(orchDir, ticket, label, writeStatus) {
+  const base = join(orchDir, "workers", ticket, `.linear-label-${label}`);
+  if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) return;
+  try {
+    const res = writeStatus.applyLabel({ ticket, label });
+    // A fake that returns undefined (test stubs) is treated as success so
+    // the once-semantics stay testable without a real result.
+    if (res === undefined || res?.applied) {
+      writeFileSync(`${base}.applied`, "");
+    } else if (res?.reason === "missing-label") {
+      writeFileSync(`${base}.skipped`, "");
+      log.warn(
+        { ticket, label },
+        "scheduler: label missing in workspace — skipping retries for this run"
+      );
+    }
+  } catch (err) {
+    log.warn(
+      { ticket, label, err: err.message },
+      "scheduler: label write-back threw — continuing tick"
+    );
+  }
+}
+
+// ─── CTL-638: per-(ticket, phase) escalation cool-down ───
+//
+// The pre-CTL-638 recovery sweep called `appendEscalatedEvent` + `applyStalledLabel`
+// on every tick the same (ticket, phase) was classified effectively-dead. Each
+// `appendEscalatedEvent` append to events.jsonl re-triggered the scheduler's own
+// `fs.watch` fast-path, debouncing to ~2s — a self-feeding 28/min storm that
+// exhausted Linear's 2,500/hr quota in <1 hour.
+//
+// This cool-down throttles ONLY the recovery-sweep escalation call site
+// (`reclaimDeadWorkIfPossible` branches A, C, and revive-budget-exhausted).
+// Window = 10min by default — long enough to defeat the 2s debounce + 30s
+// periodic tick storm; short enough that a phase that ACTUALLY stalls
+// re-escalates once an operator clears the prior incident.
+//
+// Mirrors the CTL-624 dispatch cool-down primitive shape (file under
+// orchDir/.escalation-cooldowns/, JSON envelope with a numeric timestamp).
+// The marker deliberately lives OUTSIDE workers/<T>/ to avoid manufacturing
+// a worker dir for a ticket that has none — see scheduler.mjs comment block
+// at dispatchCooldownPath and memory project_scheduler_marker_under_workers_excludes_ticket.
+export const ESCALATION_COOLDOWN_MS =
+  Number(process.env.RECOVERY_ESCALATION_COOLDOWN_MS) || 10 * 60 * 1000;
+
+export function escalationCooldownPath(orchDir, ticket, phase) {
+  return join(orchDir, ".escalation-cooldowns", `${ticket}-${phase}.json`);
+}
+
+export function inEscalationCooldown(orchDir, ticket, phase, now) {
+  const p = escalationCooldownPath(orchDir, ticket, phase);
+  let escalatedAt;
+  try {
+    escalatedAt = JSON.parse(readFileSync(p, "utf8"))?.escalatedAt;
+  } catch {
+    return false; // absent / malformed → treat as no cool-down
+  }
+  if (typeof escalatedAt !== "number") return false;
+  return now - escalatedAt < ESCALATION_COOLDOWN_MS;
+}
+
+export function recordEscalation(orchDir, ticket, phase, reason, now) {
+  const dir = join(orchDir, ".escalation-cooldowns");
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      escalationCooldownPath(orchDir, ticket, phase),
+      JSON.stringify({ ticket, phase, reason, escalatedAt: now })
+    );
+  } catch (err) {
+    // Never let a marker write crash the tick — worst case is the next tick
+    // re-escalates (the pre-CTL-638 behavior we're throttling).
+    log.warn(
+      { ticket, phase, err: err.message },
+      "recovery: escalation cool-down marker write failed — continuing"
+    );
+  }
+}

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -1,0 +1,210 @@
+// label-guard.test.mjs — labelOnce moved from scheduler (CTL-585) + the new
+// escalation cool-down primitives (CTL-638). Run:
+//   cd plugins/dev/scripts/execution-core && bun test label-guard.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  labelOnce,
+  inEscalationCooldown,
+  recordEscalation,
+  escalationCooldownPath,
+  ESCALATION_COOLDOWN_MS,
+} from "./label-guard.mjs";
+
+let orchDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "label-guard-"));
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// recorder — minimal call-collecting fake; mirrors recovery.test.mjs convention.
+function recorder(returnValue) {
+  const fn = (...args) => {
+    fn.calls.push(args);
+    return returnValue;
+  };
+  fn.calls = [];
+  return fn;
+}
+
+// ─── labelOnce (CTL-585 — moved from scheduler.mjs) ───
+
+describe("labelOnce", () => {
+  test("first call: applyLabel returns applied:true → writes .applied marker", () => {
+    const ws = { applyLabel: recorder({ applied: true }) };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+
+    labelOnce(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(ws.applyLabel.calls.length).toBe(1);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.applied"))).toBe(
+      true
+    );
+  });
+
+  test("second call when .applied exists: short-circuits — applyLabel not called", () => {
+    const ws = { applyLabel: recorder({ applied: true }) };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+    writeFileSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.applied"), "");
+
+    labelOnce(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(ws.applyLabel.calls.length).toBe(0);
+  });
+
+  test("missing-label reason → writes .skipped marker (no retry within this run)", () => {
+    const ws = { applyLabel: recorder({ applied: false, reason: "missing-label" }) };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+
+    labelOnce(orchDir, "CTL-1", "needs-human", ws);
+
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.skipped"))).toBe(
+      true
+    );
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.applied"))).toBe(
+      false
+    );
+  });
+
+  test("rate-limited (any non-applied, non-missing-label) → no marker, next tick retries", () => {
+    const ws = { applyLabel: recorder({ applied: false, reason: "rate-limited" }) };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+
+    labelOnce(orchDir, "CTL-1", "needs-human", ws);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.applied"))).toBe(
+      false
+    );
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.skipped"))).toBe(
+      false
+    );
+
+    // Next call still attempts the write — by design.
+    labelOnce(orchDir, "CTL-1", "needs-human", ws);
+    expect(ws.applyLabel.calls.length).toBe(2);
+  });
+
+  test("applyLabel returning undefined (test stubs) → treated as success", () => {
+    const ws = { applyLabel: () => undefined };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+
+    labelOnce(orchDir, "CTL-1", "triaged", ws);
+
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-triaged.applied"))).toBe(
+      true
+    );
+  });
+
+  test("applyLabel throwing → swallowed (warn-only, no marker)", () => {
+    const ws = {
+      applyLabel: () => {
+        throw new Error("network");
+      },
+    };
+    mkdirSync(join(orchDir, "workers", "CTL-1"), { recursive: true });
+
+    expect(() => labelOnce(orchDir, "CTL-1", "needs-human", ws)).not.toThrow();
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".linear-label-needs-human.applied"))).toBe(
+      false
+    );
+  });
+});
+
+// ─── Escalation cool-down (CTL-638) ───
+
+describe("inEscalationCooldown / recordEscalation", () => {
+  test("inEscalationCooldown: no marker present → false", () => {
+    expect(inEscalationCooldown(orchDir, "CTL-9", "pr", 1_000_000)).toBe(false);
+  });
+
+  test("inEscalationCooldown: malformed JSON in marker → false (treated as absent)", () => {
+    mkdirSync(join(orchDir, ".escalation-cooldowns"), { recursive: true });
+    writeFileSync(escalationCooldownPath(orchDir, "CTL-9", "pr"), "not json");
+
+    expect(inEscalationCooldown(orchDir, "CTL-9", "pr", 1_000_000)).toBe(false);
+  });
+
+  test("inEscalationCooldown: marker present, missing escalatedAt → false", () => {
+    mkdirSync(join(orchDir, ".escalation-cooldowns"), { recursive: true });
+    writeFileSync(
+      escalationCooldownPath(orchDir, "CTL-9", "pr"),
+      JSON.stringify({ ticket: "CTL-9" })
+    );
+
+    expect(inEscalationCooldown(orchDir, "CTL-9", "pr", 1_000_000)).toBe(false);
+  });
+
+  test("recordEscalation then inEscalationCooldown within window → true", () => {
+    const t0 = 5_000_000;
+    recordEscalation(orchDir, "CTL-9", "pr", "no-probe-for-phase", t0);
+
+    expect(inEscalationCooldown(orchDir, "CTL-9", "pr", t0)).toBe(true);
+    expect(inEscalationCooldown(orchDir, "CTL-9", "pr", t0 + ESCALATION_COOLDOWN_MS - 1)).toBe(
+      true
+    );
+  });
+
+  test("inEscalationCooldown returns false exactly at the window boundary", () => {
+    const t0 = 5_000_000;
+    recordEscalation(orchDir, "CTL-9", "pr", "no-probe-for-phase", t0);
+
+    // Strictly less-than the window, so equal-to is already outside.
+    expect(inEscalationCooldown(orchDir, "CTL-9", "pr", t0 + ESCALATION_COOLDOWN_MS)).toBe(false);
+  });
+
+  test("recordEscalation creates the .escalation-cooldowns/ directory lazily", () => {
+    expect(existsSync(join(orchDir, ".escalation-cooldowns"))).toBe(false);
+
+    recordEscalation(orchDir, "CTL-9", "pr", "no-probe-for-phase", 1_000_000);
+
+    expect(existsSync(join(orchDir, ".escalation-cooldowns"))).toBe(true);
+    expect(existsSync(escalationCooldownPath(orchDir, "CTL-9", "pr"))).toBe(true);
+  });
+
+  test("recordEscalation persists ticket, phase, reason, escalatedAt for operator forensics", () => {
+    recordEscalation(orchDir, "CTL-9", "monitor-merge", "revive-budget-exhausted", 9_876_543);
+
+    const body = JSON.parse(
+      Bun.file(escalationCooldownPath(orchDir, "CTL-9", "monitor-merge")).text
+        ? require("node:fs").readFileSync(
+            escalationCooldownPath(orchDir, "CTL-9", "monitor-merge"),
+            "utf8"
+          )
+        : "{}"
+    );
+    expect(body).toEqual({
+      ticket: "CTL-9",
+      phase: "monitor-merge",
+      reason: "revive-budget-exhausted",
+      escalatedAt: 9_876_543,
+    });
+  });
+
+  test("recordEscalation swallows mkdir/writeFile failures (warn-only, no throw)", () => {
+    // Pass an orchDir under a path component that exists as a FILE — mkdirSync
+    // will reject with ENOTDIR. The function must not throw.
+    const f = join(orchDir, "not-a-dir");
+    writeFileSync(f, "");
+
+    expect(() => recordEscalation(f, "CTL-9", "pr", "any-reason", 1_000_000)).not.toThrow();
+  });
+
+  test("different (ticket, phase) pairs each get their own marker", () => {
+    const t0 = 1_000_000;
+    recordEscalation(orchDir, "CTL-9", "pr", "no-probe-for-phase", t0);
+    recordEscalation(orchDir, "CTL-10", "pr", "no-probe-for-phase", t0);
+    recordEscalation(orchDir, "CTL-9", "monitor-merge", "no-probe-for-phase", t0);
+
+    expect(inEscalationCooldown(orchDir, "CTL-9", "pr", t0)).toBe(true);
+    expect(inEscalationCooldown(orchDir, "CTL-10", "pr", t0)).toBe(true);
+    expect(inEscalationCooldown(orchDir, "CTL-9", "monitor-merge", t0)).toBe(true);
+    expect(inEscalationCooldown(orchDir, "CTL-11", "pr", t0)).toBe(false);
+    expect(inEscalationCooldown(orchDir, "CTL-9", "triage", t0)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -30,6 +30,15 @@ import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { WORK_DONE_PROBES, hasProbe } from "./work-done-probes.mjs";
 import { defaultDispatch } from "./dispatch.mjs";
 import { applyLabel as defaultApplyLabel } from "./linear-write.mjs";
+// CTL-638: pull the once-marker + per-(ticket, phase) cool-down primitives
+// from the shared leaf module. labelOnce is the same guard CTL-585 introduced
+// for scheduler.mjs's `needs-human` path — pre-CTL-638 the recovery sweep's
+// escalation call bypassed it entirely.
+import {
+  labelOnce,
+  inEscalationCooldown as defaultInEscalationCooldown,
+  recordEscalation as defaultRecordEscalation,
+} from "./label-guard.mjs";
 import {
   countReviveEvents as defaultCountReviveEvents,
   countDistinctRevivingTickets as defaultCountDistinctRevivingTickets,
@@ -316,23 +325,31 @@ export function defaultReviveDispatch({ orchDir, ticket, phase }, { dispatch = d
   return dispatch({ orchDir, ticket, phase });
 }
 
-// defaultApplyStalledLabel — apply the flat `needs-human` label via the
-// CTL-587-enhanced applyLabel (which reads back to verify the write landed,
-// closing the silent-success gap per memory project_linear_transition_silent_success).
-// Logs the `reason` discriminator on failure so operators see WHY the label
-// didn't land (rate limit, API shape change, exec exception) — not just that
-// it didn't. The escalation path returns 'escalated' regardless; the next
-// scheduler tick re-runs this function via labelOnce semantics (no marker is
-// written on applied:false, so retry naturally occurs).
-function defaultApplyStalledLabel({ ticket }) {
-  const res = defaultApplyLabel({ ticket, label: "needs-human" });
-  if (!res?.applied) {
-    log.warn(
-      { ticket, reason: res?.reason },
-      "ctl-587: needs-human label not confirmed on escalation — operator may miss this ticket until retry lands",
-    );
-  }
-  return res;
+// defaultApplyStalledLabel — apply the flat `needs-human` label through the
+// CTL-585 `labelOnce` guard (CTL-638). The pre-CTL-638 implementation called
+// `applyLabel` directly; the comment then claimed "the next scheduler tick
+// re-runs this function via labelOnce semantics" but no labelOnce wrapper
+// existed on this path — the recovery sweep's three escalation call sites
+// (no-probe-for-phase, non-implement-not-done, revive-budget-exhausted) all
+// bypassed CTL-585's marker-file guard. On a rate-limit, applyLabel returned
+// applied:false → no marker written → every scheduler tick (debounced to 2s
+// by the event-log fast path) re-fired the write, exhausting Linear's 2,500/hr
+// quota at ~28 writes/min.
+//
+// Routing through labelOnce gives this path the same once-per-daemon-lifetime
+// semantics as scheduler.mjs:653's stalled-signal label sweep:
+//   • On applied:true → writes workers/<T>/.linear-label-needs-human.applied.
+//     The next tick short-circuits before touching Linear.
+//   • On reason:"missing-label" → writes .skipped (operator creates the label
+//     manually + deletes the marker to re-arm).
+//   • On any transient failure (rate-limited, undefined, throw) → no marker,
+//     next tick retries. CTL-638's per-(ticket, phase) escalation cool-down
+//     (in label-guard.mjs) is the SECOND layer of protection for this case:
+//     even if labelOnce keeps retrying the write, the cool-down suppresses
+//     the audit-event + label-call pair entirely so the scheduler's own
+//     event-log fast path stops self-feeding.
+function defaultApplyStalledLabel({ orchDir, ticket }) {
+  return labelOnce(orchDir, ticket, "needs-human", { applyLabel: defaultApplyLabel });
 }
 
 // defaultKillBgJob — best-effort `kill -9` of a lingering bg pid. Gated by the
@@ -460,6 +477,12 @@ export function reclaimDeadWorkIfPossible(
     countReviveEvents = defaultCountReviveEvents,
     countDistinctRevivingTickets = defaultCountDistinctRevivingTickets,
     writeReviveMarker = defaultWriteReviveMarker,
+    // CTL-638 — per-(ticket, phase) escalation cool-down. Defaults read/write
+    // markers under orchDir/.escalation-cooldowns/; tests can inject fakes to
+    // run multiple escalations against the same scenario without filesystem
+    // I/O, or to drive the cool-down clock independently of `now`.
+    inEscalationCooldownFn = defaultInEscalationCooldown,
+    recordEscalationFn = defaultRecordEscalation,
     now = Date.now,
     staleMs = STALE_MS,
   } = {},
@@ -482,22 +505,38 @@ export function reclaimDeadWorkIfPossible(
   const orchId = signal.raw?.orchestrator;
   const prevBgJobId = signal.raw?.bg_job_id ?? null;
 
-  // (A) No probe registered for this phase → escalate. The pre-CTL-587 silent
-  //     'not-applicable' return is now an actionable outcome: the worker is
-  //     dead, we cannot prove its work landed, and no automation can recover
-  //     — so the human needs to look. needs-human label applied (verified by
-  //     the CTL-587 applyLabel read-back).
-  if (!hasProbe(phase)) {
+  // CTL-638 — escalation helper. Wraps the appendEscalatedEvent + applyStalledLabel
+  // pair in a per-(ticket, phase) cool-down. Pre-CTL-638 the three escalation
+  // call sites duplicated the same 9-line block, and each one re-emitted the
+  // audit event on every tick — feeding the scheduler's own event-log watcher
+  // back into the next tick (28/min sustained storm). Returning
+  // "escalation-suppressed" lets schedulerTick bucket the suppression as
+  // invisible (the original escalation event was already emitted).
+  function escalateOnce(reason, finalAttemptCount) {
+    if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
+      return "escalation-suppressed";
+    }
     appendEscalatedEvent({
       phase,
       ticket,
       orchId,
-      reason: "no-probe-for-phase",
-      final_attempt_count: 0,
+      reason,
+      final_attempt_count: finalAttemptCount,
     });
-    applyStalledLabel({ ticket });
-    log.warn({ ticket, phase }, "ctl-587: escalated (no probe registered for phase)");
+    applyStalledLabel({ orchDir, ticket });
+    recordEscalationFn(orchDir, ticket, phase, reason, now());
+    log.warn({ ticket, phase, reason }, "ctl-587: escalated");
     return "escalated";
+  }
+
+  // (A) No probe registered for this phase → escalate. The pre-CTL-587 silent
+  //     'not-applicable' return is now an actionable outcome: the worker is
+  //     dead, we cannot prove its work landed, and no automation can recover
+  //     — so the human needs to look. needs-human label applied (verified by
+  //     the CTL-587 applyLabel read-back). CTL-638 routes through escalateOnce
+  //     so the same (ticket, phase) cannot re-fire within the cool-down window.
+  if (!hasProbe(phase)) {
+    return escalateOnce("no-probe-for-phase", 0);
   }
 
   // (B) Probe says work IS done → CTL-574 reclaim. Unchanged.
@@ -520,15 +559,7 @@ export function reclaimDeadWorkIfPossible(
   //     `implement` has a probe; this branch's escalation is defensive for
   //     a future phase whose probe also returns false.
   if (phase !== "implement") {
-    appendEscalatedEvent({
-      phase,
-      ticket,
-      orchId,
-      reason: "non-implement-not-done",
-      final_attempt_count: 0,
-    });
-    applyStalledLabel({ ticket });
-    return "escalated";
+    return escalateOnce("non-implement-not-done", 0);
   }
 
   // Per-ticket revive budget from events.jsonl. The events file is the
@@ -536,16 +567,7 @@ export function reclaimDeadWorkIfPossible(
   // signal file (which the dispatcher rewrites each spawn).
   const priorRevives = countReviveEvents({ ticket, orchId });
   if (priorRevives >= MAX_REVIVES) {
-    appendEscalatedEvent({
-      phase,
-      ticket,
-      orchId,
-      reason: "revive-budget-exhausted",
-      final_attempt_count: priorRevives,
-    });
-    applyStalledLabel({ ticket });
-    log.warn({ ticket, phase, priorRevives }, "ctl-587: escalated (revive budget exhausted)");
-    return "escalated";
+    return escalateOnce("revive-budget-exhausted", priorRevives);
   }
 
   // Storm-breaker: if many distinct tickets are reviving inside the window,

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -866,6 +866,159 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
   });
 });
 
+// --- CTL-638: per-(ticket, phase) escalation cool-down ---------------------
+//
+// Pre-CTL-638 the recovery sweep re-fired `appendEscalatedEvent` +
+// `applyStalledLabel` on every tick the same (ticket, phase) classified
+// effectively-dead — and each `appendEscalatedEvent` append to events.jsonl
+// re-triggered the scheduler's own fs.watch fast path, debouncing to ~2s
+// (a self-feeding ~28/min storm that exhausted Linear's 2,500/hr quota in <1h).
+//
+// The cool-down throttles the audit-event + label-call pair so a tight
+// scheduler-tick loop emits at most one escalation per (ticket, phase) per
+// window. `applyStalledLabel` is ALSO routed through labelOnce for a second
+// layer of protection — if the cool-down marker is deleted mid-incident, the
+// `.linear-label-needs-human.applied` marker still prevents re-attempts.
+
+describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl638-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  // Re-create setupReviveScenario inline so we can swap `s.orch` to a REAL
+  // tmpdir without disturbing the upper-scope helper. The cool-down primitives
+  // need a writable orchDir to record markers.
+  function setupAt(orchPath, overrides = {}) {
+    const sig = {
+      ...implementSignal({ ticket: "CTL-9", status: "running", bgJobId: "bg-9" }),
+      phase: overrides.phase ?? "implement",
+    };
+    sig.raw.phase = overrides.phase ?? "implement";
+    return {
+      orch: orchPath,
+      sig,
+      opts: {
+        repoRoot: "/repo",
+        statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+        probes: overrides.phase === "implement" || !overrides.phase
+          ? { implement: recorder(overrides.probeResult ?? false) }
+          : {},
+        emitComplete: recorder({ code: 0 }),
+        appendEvent: recorder(undefined),
+        appendReviveEvent: recorder(undefined),
+        appendEscalatedEvent: recorder(undefined),
+        appendReviveSuppressedEvent: recorder(undefined),
+        reviveDispatch: recorder({ code: 0 }),
+        applyStalledLabel: recorder({ applied: true }),
+        killBgJob: recorder(undefined),
+        countReviveEvents: recorder(overrides.reviveCount ?? 0),
+        countDistinctRevivingTickets: recorder(1),
+        writeReviveMarker: recorder(undefined),
+        now: () => overrides.nowMs ?? 1_000 + 6 * 60 * 1000,
+        staleMs: 5 * 60 * 1000,
+        // inEscalationCooldownFn / recordEscalationFn use real defaults so we
+        // exercise the actual filesystem-backed cool-down primitive end-to-end.
+      },
+    };
+  }
+
+  test("acceptance: second tick on same (ticket, phase) suppresses — exactly one event + one label write", () => {
+    const s = setupAt(orchDir, { phase: "pr" }); // no-probe branch
+
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(1);
+    expect(s.opts.applyStalledLabel.calls.length).toBe(1);
+
+    // 1,500 simulated ticks in the storm window — every one suppressed.
+    for (let i = 0; i < 1500; i++) {
+      expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalation-suppressed");
+    }
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(1); // NOT 1,501
+    expect(s.opts.applyStalledLabel.calls.length).toBe(1); // NOT 1,501
+  });
+
+  test("escalation re-fires after the cool-down window elapses", () => {
+    let clock = 5_000_000;
+    const s = setupAt(orchDir, { phase: "pr", nowMs: clock });
+    s.opts.now = () => clock;
+
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    clock += 10 * 60 * 1000 + 1; // jump past the 10-min default window
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(2);
+  });
+
+  test("different phase on the same ticket gets an independent cool-down (pr → monitor-merge advancement)", () => {
+    // Reproduces the live CTL-624 timeline: escalations on `pr` for a stretch,
+    // then on `monitor-merge` after `pr` completes. Both should escalate; only
+    // the WITHIN-phase repeats are suppressed.
+    const sPr = setupAt(orchDir, { phase: "pr" });
+    expect(reclaimDeadWorkIfPossible(sPr.orch, sPr.sig, sPr.opts)).toBe("escalated");
+    expect(reclaimDeadWorkIfPossible(sPr.orch, sPr.sig, sPr.opts)).toBe("escalation-suppressed");
+
+    const sMm = setupAt(orchDir, { phase: "monitor-merge" });
+    expect(reclaimDeadWorkIfPossible(sMm.orch, sMm.sig, sMm.opts)).toBe("escalated");
+  });
+
+  test("revive-budget-exhausted branch also respects the cool-down", () => {
+    // Repro: implement phase, budget exhausted → escalation path. Second tick
+    // must suppress just like the no-probe branch.
+    const s = setupAt(orchDir, { phase: "implement", reviveCount: 2 });
+
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("revive-budget-exhausted");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalation-suppressed");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(1);
+  });
+
+  test("injected cool-down seams (inEscalationCooldownFn / recordEscalationFn) are honored", () => {
+    // The cool-down primitives are overridable for tests that want to drive
+    // the gate independently of the filesystem (or to assert calls).
+    const inCd = recorder(false);
+    const recCd = recorder(undefined);
+    const s = setupAt(orchDir, { phase: "pr" });
+    s.opts.inEscalationCooldownFn = inCd;
+    s.opts.recordEscalationFn = recCd;
+
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(inCd.calls.length).toBe(1);
+    expect(recCd.calls.length).toBe(1);
+    // recordEscalationFn signature: (orchDir, ticket, phase, reason, now)
+    expect(recCd.calls[0][1]).toBe("CTL-9");
+    expect(recCd.calls[0][2]).toBe("pr");
+    expect(recCd.calls[0][3]).toBe("no-probe-for-phase");
+  });
+
+  test("escalation-suppressed return path does NOT call appendEscalatedEvent / applyStalledLabel / recordEscalationFn", () => {
+    // Pure-fake seams to make the suppression observable as zero side-effects.
+    const s = setupAt(orchDir, { phase: "pr" });
+    s.opts.inEscalationCooldownFn = recorder(true); // cool-down already armed
+    s.opts.recordEscalationFn = recorder(undefined);
+
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalation-suppressed");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
+    expect(s.opts.applyStalledLabel.calls.length).toBe(0);
+    expect(s.opts.recordEscalationFn.calls.length).toBe(0);
+  });
+
+  test("applyStalledLabel is called with orchDir (so labelOnce can scope its marker)", () => {
+    // Regression guard for the signature change. The default seam now needs
+    // orchDir to drive labelOnce's per-ticket marker; without it, labelOnce
+    // would write to /workers/<T>/.linear-label-needs-human.applied — a
+    // relative path that depends on cwd and silently fails on most systems.
+    const s = setupAt(orchDir, { phase: "pr" });
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.applyStalledLabel.calls[0][0]).toEqual({
+      orchDir: s.orch,
+      ticket: "CTL-9",
+    });
+  });
+});
+
 // --- CTL-587: default-seam behavioural tests --------------------------------
 // The above describe block uses injected stubs for all seams. These tests
 // exercise the REAL defaults — the load-bearing logic inside

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -35,6 +35,12 @@ import { reclaimDeadWorkIfPossible as defaultReclaimDeadWork } from "./recovery.
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
 import * as linearWrite from "./linear-write.mjs";
+// CTL-638: labelOnce moved out of this file into a shared leaf module so the
+// recovery-sweep escalation path can use the same once-marker guard. Keeping
+// labelOnce here would force recovery.mjs → scheduler.mjs to import it, but
+// scheduler.mjs already imports reclaimDeadWorkIfPossible from recovery.mjs —
+// a cycle. label-guard.mjs is the leaf module both can import.
+import { labelOnce } from "./label-guard.mjs";
 import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
@@ -283,44 +289,9 @@ function safeWrite(fn, ctx) {
   }
 }
 
-// labelOnce — apply a Linear label to a ticket at most once for the run's
-// lifetime (CTL-558, CTL-585). `linearis` label-add has no read-compare,
-// so without a guard the scheduler would re-hit the API on every tick.
-//
-// Two marker files at workers/<T>/.linear-label-<label>.{applied,skipped}
-// (restart-safe — persist with the worker dir) record terminal outcomes:
-//   .applied — applyLabel returned applied:true. Happy path.
-//   .skipped — applyLabel returned reason:"missing-label". The workspace
-//              lacks the label; retrying inside this daemon's lifetime
-//              would just storm the Linear API (CTL-585). An operator
-//              creates the label in the Linear UI and deletes this
-//              marker to re-arm the apply.
-//
-// Transient failures (reason:"rate-limited", "transient", undefined) write
-// no marker so the next tick retries — CTL-558's recovery contract.
-function labelOnce(orchDir, ticket, label, writeStatus) {
-  const base = join(orchDir, "workers", ticket, `.linear-label-${label}`);
-  if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) return;
-  try {
-    const res = writeStatus.applyLabel({ ticket, label });
-    // A fake that returns undefined (test stubs) is treated as success so
-    // the once-semantics stay testable without a real result.
-    if (res === undefined || res?.applied) {
-      writeFileSync(`${base}.applied`, "");
-    } else if (res?.reason === "missing-label") {
-      writeFileSync(`${base}.skipped`, "");
-      log.warn(
-        { ticket, label },
-        "scheduler: label missing in workspace — skipping retries for this run",
-      );
-    }
-  } catch (err) {
-    log.warn(
-      { ticket, label, err: err.message },
-      "scheduler: label write-back threw — continuing tick",
-    );
-  }
-}
+// CTL-585 labelOnce now lives in `label-guard.mjs` (CTL-638 re-home — see the
+// import block at the top of this file). The shared module also hosts the
+// per-(ticket, phase) escalation cool-down used by the recovery sweep.
 
 // CTL-624: dispatch cool-down marker. Conceptually mirrors the labelOnce
 // once-marker (workers/<T>/.linear-label-*), but with two deliberate
@@ -563,6 +534,12 @@ export function schedulerTick(
         break;
       case "escalated":
         escalated.push(entry);
+        break;
+      case "escalation-suppressed":
+        // CTL-638: the per-(ticket, phase) cool-down throttled the audit event
+        // and label write. Invisible by design — operators saw the original
+        // escalation in events.jsonl already; surfacing this would re-recreate
+        // the noise the cool-down exists to prevent.
         break;
       default:
         // noop | not-done | not-applicable | reclaim-failed → invisible.


### PR DESCRIPTION
## Summary

Fixes the execution-core daemon escalation retry storm that exhausted Linear's 2,500/hr API quota in <1h (1,506 label-write attempts in 53 minutes, operator emergency kill on 2026-05-25).

`recovery.mjs::defaultApplyStalledLabel` called `applyLabel` directly, bypassing CTL-585's `labelOnce` once-marker guard. Each tick also appended an `escalated` event to `events.jsonl`, and the scheduler's own `fs.watch` on that log debounced to 2s — a self-feeding ~28/min storm.

## Two-layer fix

**Part A — labelOnce guard.** `labelOnce` moves from `scheduler.mjs` into a new shared leaf module `label-guard.mjs` (recovery.mjs cannot import from scheduler.mjs without a cycle — scheduler already imports `reclaimDeadWorkIfPossible` from recovery). `defaultApplyStalledLabel` now routes through `labelOnce`, so a successful write drops the `workers/<T>/.linear-label-needs-human.applied` marker and subsequent ticks short-circuit before touching Linear.

**Part B — per-(ticket, phase) escalation cool-down.** Same shape as CTL-624's dispatch cool-down: timestamped JSON marker under `orchDir/.escalation-cooldowns/<ticket>-<phase>.json`, 10-min window (env-overridable via `RECOVERY_ESCALATION_COOLDOWN_MS`). Wraps the `appendEscalatedEvent` + `applyStalledLabel` pair in `reclaimDeadWorkIfPossible` so the audit event itself can't re-feed the scheduler's fs.watch fast path. The three pre-existing escalation call sites collapse into one `escalateOnce(reason, attempt)` helper. New return discriminator `escalation-suppressed` buckets as invisible (the original escalation event was already emitted).

Marker location mirrors CTL-624 (outside `workers/<T>/`) — see memory `project_scheduler_marker_under_workers_excludes_ticket` for why a marker under `workers/<T>/` would permanently drop the ticket from `listStartedTickets`.

## Acceptance (per ticket)

- [x] `recovery.mjs` calls `labelOnce`, not `applyLabel` directly
- [x] Same orphan conditions → at most ONE escalation per (ticket, phase), not 1,500 (test: 1,500 simulated ticks → 1 audit event, not 1,501)
- [x] Existing CTL-585 / CTL-587 / CTL-624 tests pass
- [x] Comment at former `recovery.mjs:319-326` now accurately describes the two-layer guard
- [ ] Out of scope (Part C in ticket): raise `STALE_MS` for non-implement phases — separate ticket

## Files

| File | Action |
|------|--------|
| `plugins/dev/scripts/execution-core/label-guard.mjs` | new — moved labelOnce + new cool-down primitives |
| `plugins/dev/scripts/execution-core/label-guard.test.mjs` | new — 15 unit tests |
| `plugins/dev/scripts/execution-core/recovery.mjs` | wire labelOnce + cool-down into the escalation sites |
| `plugins/dev/scripts/execution-core/recovery.test.mjs` | +7 CTL-638 acceptance tests |
| `plugins/dev/scripts/execution-core/scheduler.mjs` | import labelOnce from label-guard, handle new return value |

## Test plan

- [x] `bun test label-guard.test.mjs` — 15 pass
- [x] `bun test recovery.test.mjs` — 70 pass (63 existing + 7 new)
- [x] `bun test scheduler.test.mjs` — 103 pass (labelOnce relocation, no behavior change)
- [x] Full execution-core suite — 462 pass, 0 fail across 24 files

## Refs

- Closes CTL-638
- Investigation: `thoughts/shared/research/2026-05-25-execution-core-escalation-retry-storm.md`
- Plan: `thoughts/shared/plans/2026-05-25-CTL-638-recovery-escalation-storm-fix.md`
- Related: CTL-585 (labelOnce storm fix), CTL-587 (auto-revive code that introduced the regression), CTL-624 (dispatch cool-down — sibling pattern, different call site)