### PR TITLE
CTL-637: vendor use_otel_context with LWW dedup helper

### DIFF
--- a/plugins/dev/direnv/lib/otel.sh
+++ b/plugins/dev/direnv/lib/otel.sh
@@ -1,0 +1,160 @@
+# plugins/dev/direnv/lib/otel.sh
+#
+# Vendored source-of-truth for the `use_otel_context` direnv helper. Install on
+# a user's machine by copying to ~/.config/direnv/lib/otel.sh — direnv loads
+# any *.sh in that directory automatically.
+#
+# Usage in .envrc files:
+#   use_otel_context                    # Auto-detect project from directory name
+#   use_otel_context "my-project"       # Explicit project name
+#
+# Sets OTEL_RESOURCE_ATTRIBUTES with:
+#   - project       (from argument or directory name)
+#   - hostname      (machine short name)
+#   - branch        (current branch, if in a git repo)
+#   - linear.key    (ticket ID from branch name, e.g. ADV-167 or ENG-123,
+#                    with fallback to .catalyst/.workflow-context.json)
+#   - catalyst.orchestration  (orchestration name, set when in a Catalyst worktree;
+#                              groups orchestrator + workers from the same run)
+#
+# These become Prometheus labels and Loki structured metadata via the
+# OTel Collector's resource_to_telemetry_conversion.
+#
+# Note: direnv sets $PWD to the directory containing the .envrc file, NOT
+# the directory you cd'd into. So for worktree containers (e.g. Adva/ with
+# baku/ inside), each worktree needs its own .envrc with source_up so that
+# $PWD correctly points to the worktree when this function runs.
+# If you switch branches without leaving the directory, run `direnv reload`.
+#
+# CTL-637: this file dedups OTEL_RESOURCE_ATTRIBUTES on every direnv reload
+# (last-write-wins per key). Without dedup, every `cd` / `direnv reload`
+# appended another full snapshot of project=, hostname=, branch=, linear.key=,
+# catalyst.orchestration= pairs and long-lived shells accumulated the same
+# key many times.
+
+# CTL-637: Pure helper. Dedups a comma-joined "k=v,k=v,..." string by keeping
+# the LAST occurrence of each key (matches OTLP last-write-wins). The position
+# of each surviving pair is the position of its FIRST occurrence in the input
+# — preserves a stable order for human readability without affecting OTLP,
+# which is order-insensitive. Tokens without '=' are preserved verbatim
+# (no key, no possible collision).
+#
+# Known limitation: values containing literal commas are not supported. The
+# attribute set produced by use_otel_context never embeds commas inside
+# values, so this is fine today. If a future key needs embedded commas,
+# update both this helper and use_otel_context.
+__catalyst_otel_dedup_attrs() {
+  local input="$1"
+  if [ -z "$input" ]; then
+    printf ''
+    return 0
+  fi
+
+  printf '%s' "$input" | awk -v RS=',' '
+    {
+      pos = index($0, "=")
+      if (pos == 0) {
+        # Token without "=" — preserve verbatim at first-seen position.
+        if (!($0 in seen_raw)) {
+          seen_raw[$0] = 1
+          order[++n] = $0
+          is_raw[$0] = 1
+        }
+        next
+      }
+      key = substr($0, 1, pos - 1)
+      if (!(key in val)) {
+        order[++n] = key
+      }
+      val[key] = $0
+    }
+    END {
+      for (i = 1; i <= n; i++) {
+        token = order[i]
+        if (token in is_raw) {
+          printf "%s%s", token, (i < n ? "," : "")
+        } else {
+          printf "%s%s", val[token], (i < n ? "," : "")
+        }
+      }
+    }
+  '
+}
+
+use_otel_context() {
+  local project="${1:-$(basename "$PWD")}"
+  local attrs="project=${project},hostname=$(hostname -s)"
+
+  # Git branch: use $PWD (correct when .envrc is in the worktree dir itself).
+  # Fallback to CONDUCTOR_WORKSPACE_PATH for Conductor-launched sessions where
+  # direnv sets $PWD to the .envrc's parent dir, not the worktree.
+  local git_dir="${PWD}"
+  if [ -z "$(git -C "$git_dir" branch --show-current 2>/dev/null)" ] && [ -n "${CONDUCTOR_WORKSPACE_PATH:-}" ]; then
+    git_dir="$CONDUCTOR_WORKSPACE_PATH"
+  fi
+  local branch
+  branch=$(git -C "$git_dir" branch --show-current 2>/dev/null)
+  if [ -n "$branch" ]; then
+    attrs="${attrs},branch=${branch}"
+  fi
+
+  # Linear ticket: extract from branch name (case-insensitive, uppercased).
+  # Uses tail -1 so Catalyst worker branches like "orch-prefix-ADV-220" pick up
+  # the ticket suffix (ADV-220) rather than a false match in the prefix.
+  local linear_key=""
+  local all_ticket_matches=""
+  local match_count=0
+  if [ -n "$branch" ]; then
+    all_ticket_matches=$(echo "$branch" | grep -oiE '[A-Za-z]+-[0-9]+' || true)
+    if [ -n "$all_ticket_matches" ]; then
+      match_count=$(echo "$all_ticket_matches" | wc -l | tr -d ' ')
+      linear_key=$(echo "$all_ticket_matches" | tail -1 | tr '[:lower:]' '[:upper:]')
+    fi
+  fi
+
+  # Fallback: read from .catalyst/.workflow-context.json if branch had no ticket
+  if [ -z "$linear_key" ] && [ -f "${PWD}/.catalyst/.workflow-context.json" ]; then
+    local ctx_ticket
+    ctx_ticket=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('${PWD}/.catalyst/.workflow-context.json'))
+    t = d.get('currentTicket')
+    if t and t not in ('null', 'general', 'None'):
+        print(t)
+except Exception:
+    pass
+" 2>/dev/null)
+    [ -n "$ctx_ticket" ] && linear_key="$ctx_ticket"
+  fi
+
+  [ -n "$linear_key" ] && attrs="${attrs},linear.key=${linear_key}"
+
+  # Catalyst orchestration: when in a Catalyst worktree, derive the orchestration
+  # name so all workers + orchestrator from the same run share a grouping label.
+  # Worker branches: "orch-name-TICKET" → strip ticket suffix → "orch-name"
+  # Orchestrator branches: use the branch name directly.
+  if [ -d "${PWD}/.catalyst" ] && [ -n "$branch" ]; then
+    local orch_name
+    if [ "$match_count" -gt 1 ]; then
+      local raw_last_match
+      raw_last_match=$(echo "$all_ticket_matches" | tail -1)
+      orch_name=$(echo "$branch" | sed "s/-${raw_last_match}$//")
+    else
+      orch_name="$branch"
+    fi
+    attrs="${attrs},catalyst.orchestration=${orch_name}"
+  fi
+
+  if [ -n "${OTEL_RESOURCE_ATTRIBUTES:-}" ]; then
+    OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},${attrs}"
+  else
+    OTEL_RESOURCE_ATTRIBUTES="${attrs}"
+  fi
+  # CTL-637: dedup keeping last value per key (OTLP LWW). Without this,
+  # every direnv reload appends another full copy of project=, hostname=,
+  # branch=, linear.key=, catalyst.orchestration= pairs — long-lived shells
+  # accumulate the same key many times.
+  OTEL_RESOURCE_ATTRIBUTES=$(__catalyst_otel_dedup_attrs "$OTEL_RESOURCE_ATTRIBUTES")
+  export OTEL_RESOURCE_ATTRIBUTES
+}

--- a/plugins/dev/scripts/__tests__/lib-otel.test.sh
+++ b/plugins/dev/scripts/__tests__/lib-otel.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Unit tests for plugins/dev/direnv/lib/otel.sh — the dedup helper used by
+# use_otel_context.
+#
+# Run: bash plugins/dev/scripts/__tests__/lib-otel.test.sh
+#
+# Contract: __catalyst_otel_dedup_attrs "<comma-string>" echoes the input
+# with duplicate keys collapsed, keeping the LAST occurrence of each key
+# (matches OTLP last-write-wins). Position of each surviving pair is the
+# position of its FIRST occurrence in the input.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/direnv/lib/otel.sh"
+
+FAILURES=0
+PASSES=0
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+if [[ ! -f "$HELPER" ]]; then
+  echo "FATAL: $HELPER not found" >&2
+  exit 1
+fi
+
+# ─── Test 1: empty input → empty output
+echo "Test 1: empty input → empty output"
+RESULT=$(
+  # shellcheck source=/dev/null
+  . "$HELPER"
+  __catalyst_otel_dedup_attrs ""
+)
+assert_eq "" "$RESULT" "empty input produces empty output"
+
+# ─── Test 2: single pair → unchanged
+echo ""
+echo "Test 2: single pair → unchanged"
+RESULT=$(
+  . "$HELPER"
+  __catalyst_otel_dedup_attrs "project=foo"
+)
+assert_eq "project=foo" "$RESULT" "single pair preserved verbatim"
+
+# ─── Test 3: distinct keys → unchanged order
+echo ""
+echo "Test 3: distinct keys → unchanged"
+RESULT=$(
+  . "$HELPER"
+  __catalyst_otel_dedup_attrs "project=foo,hostname=h1,branch=main"
+)
+assert_eq "project=foo,hostname=h1,branch=main" "$RESULT" \
+  "no duplicates → no rewrite"
+
+# ─── Test 4: duplicate key → LAST occurrence value wins, FIRST position kept
+echo ""
+echo "Test 4: duplicate project= → last value, first position"
+RESULT=$(
+  . "$HELPER"
+  __catalyst_otel_dedup_attrs "project=old,hostname=h1,project=new"
+)
+assert_eq "project=new,hostname=h1" "$RESULT" \
+  "LWW value at first-seen position"
+
+# ─── Test 5: full triple-call scenario (three cd events)
+echo ""
+echo "Test 5: triple-call simulation"
+RESULT=$(
+  . "$HELPER"
+  INPUT="project=p1,hostname=h1,branch=b1"
+  INPUT="${INPUT},project=p2,hostname=h1,branch=b2,linear.key=CTL-1"
+  INPUT="${INPUT},project=p3,hostname=h1,branch=b3,linear.key=CTL-2,catalyst.orchestration=run-3"
+  __catalyst_otel_dedup_attrs "$INPUT"
+)
+assert_eq \
+  "project=p3,hostname=h1,branch=b3,linear.key=CTL-2,catalyst.orchestration=run-3" \
+  "$RESULT" "every key exactly once, third call's values win"
+
+# ─── Test 6: LWW direction sanity
+echo ""
+echo "Test 6: LWW direction — project=old,project=new → project=new"
+RESULT=$(
+  . "$HELPER"
+  __catalyst_otel_dedup_attrs "project=old,project=new"
+)
+assert_eq "project=new" "$RESULT" "last write wins"
+
+# ─── Test 7: idempotent on already-dedup'd input
+echo ""
+echo "Test 7: idempotency"
+RESULT=$(
+  . "$HELPER"
+  ONCE=$(__catalyst_otel_dedup_attrs "project=p1,hostname=h1")
+  __catalyst_otel_dedup_attrs "$ONCE"
+)
+assert_eq "project=p1,hostname=h1" "$RESULT" "dedup is idempotent"
+
+# ─── Test 8: value containing no '=' (defensive) — pass-through unchanged
+echo ""
+echo "Test 8: pair without '=' is preserved verbatim"
+RESULT=$(
+  . "$HELPER"
+  __catalyst_otel_dedup_attrs "project=foo,malformed,hostname=h1"
+)
+# Documents current behaviour: a token without '=' has no key, so it cannot
+# collide with anything and is preserved at its original position.
+assert_eq "project=foo,malformed,hostname=h1" "$RESULT" \
+  "malformed token preserved (no key to dedup against)"
+
+# ─── Test 9: use_otel_context integration — no duplicate keys after 3 calls
+echo ""
+echo "Test 9: use_otel_context integration — no duplicate keys after 3 calls"
+RESULT=$(
+  . "$HELPER"
+  unset OTEL_RESOURCE_ATTRIBUTES
+  use_otel_context "p1" >/dev/null 2>&1
+  use_otel_context "p2" >/dev/null 2>&1
+  use_otel_context "p3" >/dev/null 2>&1
+  printf '%s' "$OTEL_RESOURCE_ATTRIBUTES"
+)
+PROJECT_COUNT=$(printf '%s' "$RESULT" | tr ',' '\n' | grep -c '^project=' || true)
+HOSTNAME_COUNT=$(printf '%s' "$RESULT" | tr ',' '\n' | grep -c '^hostname=' || true)
+if [[ "$PROJECT_COUNT" -eq 1 && "$HOSTNAME_COUNT" -eq 1 ]]; then
+  pass "use_otel_context after 3 calls → each key once (project=$PROJECT_COUNT, hostname=$HOSTNAME_COUNT)"
+else
+  fail "expected each key once, got project=$PROJECT_COUNT hostname=$HOSTNAME_COUNT in: $RESULT"
+fi
+
+# AC #2 — last value wins.
+if [[ "$RESULT" == *"project=p3"* && "$RESULT" != *"project=p1"* && "$RESULT" != *"project=p2"* ]]; then
+  pass "LWW — only project=p3 survives"
+else
+  fail "expected only project=p3 to survive, got: $RESULT"
+fi
+
+# ─── Summary
+echo ""
+echo "─────────────────────────────────────"
+echo "Tests: $PASSES passed, $FAILURES failed"
+if [[ "$FAILURES" -gt 0 ]]; then
+  exit 1
+fi

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -450,10 +450,19 @@ if command -v direnv &>/dev/null; then
         warn "Missing $DIRENV_CONFIG/lib/profiles.sh — use_profile won't work"
     fi
 
-    if [[ -f "$DIRENV_CONFIG/lib/otel.sh" ]]; then
-        pass "Library: otel.sh"
+    # CTL-637: compare installed copy against vendored source-of-truth.
+    VENDORED_OTEL="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/direnv/lib/otel.sh"
+    INSTALLED_OTEL="$DIRENV_CONFIG/lib/otel.sh"
+    if [[ -f "$INSTALLED_OTEL" ]]; then
+        if [[ -f "$VENDORED_OTEL" ]] && ! cmp -s "$VENDORED_OTEL" "$INSTALLED_OTEL"; then
+            warn "Library: otel.sh present but differs from vendored copy (CTL-637 dedup may be missing)"
+            info "Re-install: cp '$VENDORED_OTEL' '$INSTALLED_OTEL' && direnv reload"
+        else
+            pass "Library: otel.sh (matches vendored copy)"
+        fi
     else
-        warn "Missing $DIRENV_CONFIG/lib/otel.sh — use_otel_context won't work"
+        warn "Missing $INSTALLED_OTEL — use_otel_context won't work"
+        [[ -f "$VENDORED_OTEL" ]] && info "Install: cp '$VENDORED_OTEL' '$INSTALLED_OTEL'"
     fi
 
     profile_count=$(ls "$DIRENV_CONFIG/profiles/"*.env 2>/dev/null | wc -l | tr -d ' ')

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1108,12 +1108,21 @@ available in all `.envrc` files:
 # Later profiles override earlier ones.
 ```
 
-**`use_otel_context`** — sets `OTEL_RESOURCE_ATTRIBUTES` for telemetry correlation:
+**`use_otel_context`** — sets `OTEL_RESOURCE_ATTRIBUTES` for telemetry correlation. The
+canonical source lives at `plugins/dev/direnv/lib/otel.sh` in the catalyst repo; install it
+into `~/.config/direnv/lib/`:
 
 ```bash
-# ~/.config/direnv/lib/otel.sh
-# Sets project, hostname, git.branch, linear.key, catalyst.orchestration
+cp ~/.claude/plugins/marketplaces/catalyst/plugins/dev/direnv/lib/otel.sh \
+   ~/.config/direnv/lib/otel.sh
+direnv reload
 ```
+
+The function sets `project`, `hostname`, `branch`, `linear.key`, and `catalyst.orchestration`.
+It dedups `OTEL_RESOURCE_ATTRIBUTES` on every direnv reload (last-write-wins per key, per
+CTL-637) — older copies of the file accumulate duplicate keys across multiple `cd` events.
+`check-setup.sh` warns if the installed copy differs from the vendored source and prints the
+re-install command.
 
 ### Profile Files
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-25T22:40:00Z -->
<!-- Last updated: 2026-05-25T22:40:00Z -->
<!-- PR: #1056 -->
<!-- Previous commits: 4de87e5948435bd2e5a42b7a136899575e98651a,0747363c4c2b893ae424059ff98265bee840b3e6 -->

## Summary

`use_otel_context` in `~/.config/direnv/lib/otel.sh` unconditionally concatenates new resource attrs onto `OTEL_RESOURCE_ATTRIBUTES` on every `cd` into a tagged worktree. After hopping through several worktrees in one shell session the env var contained the same key multiple times (`project=`, `hostname=`). OTLP applies last-write-wins so metrics tagging stayed sane, but the env string grew unboundedly and `ps -E` output was noisy.

This PR vendors a fixed copy of `use_otel_context` into the plugin (`plugins/dev/direnv/lib/otel.sh`) with an LWW dedup helper, ships unit + integration tests, and teaches `check-setup.sh` to warn when the stale `~/.config/direnv/lib/otel.sh` is still on disk so users get nudged to point direnv at the vendored copy.

## Changes Made

### Vendored direnv helper (`plugins/dev/direnv/lib/otel.sh`)

- New file: full `use_otel_context` implementation with `_dedup_otel_attrs` helper.
- Dedup keeps the **last** occurrence of each key (matches OTLP LWW semantics).
- Idempotent — repeated calls collapse to the same single-value-per-key string.
- Tokens without `=` are preserved verbatim (no key to dedup against).

### Test coverage (`plugins/dev/scripts/__tests__/lib-otel.test.sh`)

- 10 tests covering: empty input, single key, true duplicates, multi-key dedup, mixed dup/unique, LWW direction, idempotency, malformed tokens, and a 3-call integration scenario for `use_otel_context`.
- All tests pass locally (`bash plugins/dev/scripts/__tests__/lib-otel.test.sh` → `10 passed, 0 failed`).

### Setup warning (`plugins/dev/scripts/check-setup.sh`)

- New check: if `~/.config/direnv/lib/otel.sh` exists and differs from the vendored copy, emit a warning telling the user to either delete it or replace it with a symlink to the plugin file.
- Surfaces silently when the user is already on the vendored copy.

### Docs (`website/src/content/docs/reference/configuration.md`)

- Reference the vendored copy as the canonical OTEL direnv helper.
- Note the deprecation/migration path away from the hand-maintained `~/.config/direnv/lib/otel.sh`.

## How to Verify It

- [x] Unit + integration tests pass: `bash plugins/dev/scripts/__tests__/lib-otel.test.sh` → 10/10 ✅
- [ ] Source the vendored helper in a fresh shell and `cd` through 2-3 tagged worktrees; confirm `OTEL_RESOURCE_ATTRIBUTES` contains each key at most once and the last `cd`'s value wins.
- [ ] Run `bash plugins/dev/scripts/check-setup.sh` on a host that still has `~/.config/direnv/lib/otel.sh`; confirm the new "stale direnv helper" warning fires.
- [ ] Confirm no regression in tagged-cost attribution on Grafana for the legacy `claude -p` path.

## Reviewer Notes

- Three low-severity shellcheck nits flagged by phase-review (`SC2155`, `SC2001`, `SC1090`) left as-is — first two are stylistic on the hostname/sed paths, the third is a runtime-resolved `source` path that shellcheck can't follow.
- Scope is intentionally limited to vendoring + warning. Cleaning up users' existing `~/.config/direnv/lib/otel.sh` is left as a follow-up — the warning is the user-facing nudge.

## Related Issues/PRs

- Fixes CTL-637
