### PR TITLE
CTL-632: phase agents mirror their output to Linear as a comment

### DIFF
--- a/plugins/dev/scripts/__tests__/lib/linearis-stub.sh
+++ b/plugins/dev/scripts/__tests__/lib/linearis-stub.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Shared linearis-stub helper for phase-agent e2e tests (CTL-632).
+#
+# Two functions:
+#   linearis_stub_install <bin_dir> <log_file> [read_fixture]
+#       Writes a `linearis` shim that supports `issues read|discuss|update`,
+#       logs every call's args to <log_file> one-per-line, and (for `read`)
+#       prints the contents of <read_fixture> if given, else '{}'.
+#
+#   linearis_stub_install_failing <bin_dir> <log_file> [read_fixture]
+#       Same shape, but the `issues discuss` arm exits non-zero (with a
+#       stderr line) so callers can exercise the CTL-632 fail-open mirror.
+#
+# The body of each stub mirrors plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+# (the canonical stub) so existing assertions stay compatible.
+
+linearis_stub_install() {
+	local bin_dir="${1:?bin_dir required}"
+	local log_file="${2:?log_file required}"
+	local read_fixture="${3:-}"
+	mkdir -p "${bin_dir}"
+
+	# `cat <<EOF` (unquoted) so $log_file and $read_fixture expand at install
+	# time; runtime variables ($1, $2, $@) are escaped with \$ to defer.
+	if [ -n "$read_fixture" ]; then
+		cat >"${bin_dir}/linearis" <<EOF
+#!/usr/bin/env bash
+LOG="${log_file}"
+case "\$1" in
+  issues)
+    case "\$2" in
+      read)
+        printf '%s\n' "\$@" >> "\$LOG"
+        cat "${read_fixture}"
+        ;;
+      discuss)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{"ok": true, "kind": "discuss"}'
+        ;;
+      update)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{"ok": true, "kind": "update"}'
+        ;;
+      *)
+        printf 'linearis stub: unsupported issues subcommand: %s\n' "\$2" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    printf 'linearis stub: unsupported domain: %s\n' "\$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+	else
+		cat >"${bin_dir}/linearis" <<EOF
+#!/usr/bin/env bash
+LOG="${log_file}"
+case "\$1" in
+  issues)
+    case "\$2" in
+      read)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{}'
+        ;;
+      discuss)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{"ok": true, "kind": "discuss"}'
+        ;;
+      update)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{"ok": true, "kind": "update"}'
+        ;;
+      *)
+        printf 'linearis stub: unsupported issues subcommand: %s\n' "\$2" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    printf 'linearis stub: unsupported domain: %s\n' "\$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+	fi
+	chmod +x "${bin_dir}/linearis"
+}
+
+linearis_stub_install_failing() {
+	local bin_dir="${1:?bin_dir required}"
+	local log_file="${2:?log_file required}"
+	local read_fixture="${3:-}"
+	mkdir -p "${bin_dir}"
+
+	if [ -n "$read_fixture" ]; then
+		cat >"${bin_dir}/linearis" <<EOF
+#!/usr/bin/env bash
+LOG="${log_file}"
+case "\$1" in
+  issues)
+    case "\$2" in
+      read)
+        printf '%s\n' "\$@" >> "\$LOG"
+        cat "${read_fixture}"
+        ;;
+      discuss)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo "linearis stub: simulated discuss failure" >&2
+        exit 1
+        ;;
+      update)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{"ok": true, "kind": "update"}'
+        ;;
+      *)
+        printf 'linearis stub: unsupported issues subcommand: %s\n' "\$2" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    printf 'linearis stub: unsupported domain: %s\n' "\$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+	else
+		cat >"${bin_dir}/linearis" <<EOF
+#!/usr/bin/env bash
+LOG="${log_file}"
+case "\$1" in
+  issues)
+    case "\$2" in
+      read)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{}'
+        ;;
+      discuss)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo "linearis stub: simulated discuss failure" >&2
+        exit 1
+        ;;
+      update)
+        printf '%s\n' "\$@" >> "\$LOG"
+        echo '{"ok": true, "kind": "update"}'
+        ;;
+      *)
+        printf 'linearis stub: unsupported issues subcommand: %s\n' "\$2" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    printf 'linearis stub: unsupported domain: %s\n' "\$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+	fi
+	chmod +x "${bin_dir}/linearis"
+}

--- a/plugins/dev/scripts/__tests__/lib/linearis-stub.sh.test.sh
+++ b/plugins/dev/scripts/__tests__/lib/linearis-stub.sh.test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Tests for the shared linearis stub helper (CTL-632 Phase 1).
+#
+# Run: bash plugins/dev/scripts/__tests__/lib/linearis-stub.sh.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/linearis-stub.sh"
+
+PASS=0
+FAIL=0
+
+ok() {
+	PASS=$((PASS + 1))
+	printf '  PASS: %s\n' "$1"
+}
+fail() {
+	FAIL=$((FAIL + 1))
+	printf '  FAIL: %s\n    %s\n' "$1" "$2"
+}
+
+assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+
+if [ ! -f "$HELPER" ]; then
+	echo "FAIL: helper not found at $HELPER"
+	exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$HELPER"
+
+TMPROOT="$(mktemp -d -t linearis-stub-test.XXXXXX)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+echo "linearis-stub helper tests"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 1: linearis_stub_install with default (no fixture) returns {} for read.
+
+CASE1="$TMPROOT/case1"
+mkdir -p "$CASE1/bin"
+LOG1="$CASE1/calls.log"
+
+linearis_stub_install "$CASE1/bin" "$LOG1"
+
+if [ -x "$CASE1/bin/linearis" ]; then
+	ok "case1: linearis stub is executable"
+else
+	fail "case1: stub executable" "$CASE1/bin/linearis not executable"
+fi
+
+OUT1="$(PATH="$CASE1/bin:$PATH" linearis issues read FOO 2>/dev/null)"
+assert_eq "case1: read returns {} when no fixture" "{}" "$OUT1"
+
+# Each arg on its own line per the phase-triage stub convention.
+if grep -q '^read$' "$LOG1" 2>/dev/null && grep -q '^FOO$' "$LOG1" 2>/dev/null; then
+	ok "case1: read args logged one-per-line"
+else
+	fail "case1: read args logged" "log:$(printf '\n%s' "$(cat "$LOG1")")"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 2: discuss logs args and returns ok JSON, exits 0.
+
+CASE2="$TMPROOT/case2"
+mkdir -p "$CASE2/bin"
+LOG2="$CASE2/calls.log"
+
+linearis_stub_install "$CASE2/bin" "$LOG2"
+
+OUT2="$(PATH="$CASE2/bin:$PATH" linearis issues discuss BAR --body "x" 2>/dev/null)"
+DISCUSS_EXIT=$?
+assert_eq "case2: discuss exits 0" 0 "$DISCUSS_EXIT"
+
+# Verify arg logging (discuss + BAR + --body + x, each on its own line)
+DISCUSS_LINES="$(grep -c '^discuss$' "$LOG2" 2>/dev/null || echo 0)"
+assert_eq "case2: discuss recorded once" 1 "$DISCUSS_LINES"
+
+if grep -q '^BAR$' "$LOG2" && grep -q '^--body$' "$LOG2" && grep -q '^x$' "$LOG2"; then
+	ok "case2: all discuss args logged one-per-line"
+else
+	fail "case2: discuss args" "log:$(printf '\n%s' "$(cat "$LOG2")")"
+fi
+
+# Verify body shape (the existing phase-triage assertions look for '"ok"' and 'discuss')
+case "$OUT2" in
+*ok*) ok "case2: discuss returns ok-shaped JSON" ;;
+*) fail "case2: discuss JSON shape" "got '$OUT2'" ;;
+esac
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 3: read with fixture path returns the fixture contents.
+
+FIXTURE3="$TMPROOT/fixture3.json"
+cat >"$FIXTURE3" <<'EOF'
+{"identifier":"CTL-1111","title":"hello"}
+EOF
+
+CASE3="$TMPROOT/case3"
+mkdir -p "$CASE3/bin"
+LOG3="$CASE3/calls.log"
+
+linearis_stub_install "$CASE3/bin" "$LOG3" "$FIXTURE3"
+
+OUT3="$(PATH="$CASE3/bin:$PATH" linearis issues read CTL-1111 2>/dev/null)"
+EXPECTED3='{"identifier":"CTL-1111","title":"hello"}'
+assert_eq "case3: read returns fixture JSON" "$EXPECTED3" "$OUT3"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 4: linearis_stub_install_failing — discuss exits non-zero, read still works.
+
+CASE4="$TMPROOT/case4"
+mkdir -p "$CASE4/bin"
+LOG4="$CASE4/calls.log"
+
+linearis_stub_install_failing "$CASE4/bin" "$LOG4" "$FIXTURE3"
+
+# discuss must exit non-zero
+PATH="$CASE4/bin:$PATH" linearis issues discuss CTL-1111 --body x >/dev/null 2>&1
+FAIL_EXIT=$?
+if [ "$FAIL_EXIT" -ne 0 ]; then
+	ok "case4: failing stub discuss exits non-zero"
+else
+	fail "case4: failing discuss exit" "expected non-zero got $FAIL_EXIT"
+fi
+
+# read still works and returns fixture
+OUT4="$(PATH="$CASE4/bin:$PATH" linearis issues read CTL-1111 2>/dev/null)"
+assert_eq "case4: failing stub read returns fixture JSON" "$EXPECTED3" "$OUT4"
+
+# Discuss args still logged so tests can assert which subcommands were attempted.
+if grep -q '^discuss$' "$LOG4"; then
+	ok "case4: failing stub still logs discuss args"
+else
+	fail "case4: failing stub logs discuss" "log:$(printf '\n%s' "$(cat "$LOG4")")"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case 5: update arm exists (phase-triage CTL-558 negative invariant must keep working
+# under the helper).
+
+CASE5="$TMPROOT/case5"
+mkdir -p "$CASE5/bin"
+LOG5="$CASE5/calls.log"
+linearis_stub_install "$CASE5/bin" "$LOG5"
+
+PATH="$CASE5/bin:$PATH" linearis issues update CTL-1 --state-id X >/dev/null 2>&1
+UPDATE_EXIT=$?
+assert_eq "case5: update arm exits 0" 0 "$UPDATE_EXIT"
+if grep -q '^update$' "$LOG5"; then
+	ok "case5: update args logged"
+else
+	fail "case5: update args" "log:$(printf '\n%s' "$(cat "$LOG5")")"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "$FAIL" -ne 0 ]; then
+	exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -35,6 +35,8 @@ PHASE_DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
 SKILL_IMPLEMENT="${REPO_ROOT}/plugins/dev/skills/phase-implement/SKILL.md"
 SKILL_PR="${REPO_ROOT}/plugins/dev/skills/phase-pr/SKILL.md"
 SKILL_MONITOR_MERGE="${REPO_ROOT}/plugins/dev/skills/phase-monitor-merge/SKILL.md"
+# shellcheck source=lib/linearis-stub.sh
+source "${SCRIPT_DIR}/lib/linearis-stub.sh"
 
 FAILURES=0
 PASSES=0
@@ -431,6 +433,189 @@ SIGNAL_STATUS=$(jq -r '.status' "$SIGNAL_T10")
 SIGNAL_HANDOFF=$(jq -r '.handoffPath' "$SIGNAL_T10")
 assert_eq "turn-cap-exhausted" "$SIGNAL_STATUS" "per-phase signal status = turn-cap-exhausted"
 assert_eq "$HANDOFF_T10" "$SIGNAL_HANDOFF" "per-phase signal .handoffPath set"
+
+# ─── Test 11 (CTL-632): phase-implement Linear comment-mirror block ──────
+echo ""
+echo "Test 11 (CTL-632): phase-implement contract — mirror block present"
+if [[ -f "$SKILL_IMPLEMENT" ]]; then
+  assert_grep 'phase-implement-mirror' "$SKILL_IMPLEMENT" "body contains uniquely-named mirror fence"
+  assert_grep '\.linear-mirror-' "$SKILL_IMPLEMENT" "body references the per-phase marker file"
+  assert_grep 'linearis issues discuss' "$SKILL_IMPLEMENT" "body calls linearis issues discuss"
+  assert_grep 'linearis discuss failed \(continuing\)' "$SKILL_IMPLEMENT" "body has fail-open warning string"
+fi
+
+# ─── Test 12 (CTL-632): runtime mirror exercises ──────────────────────────
+echo ""
+echo "Test 12 (CTL-632): phase-implement mirror — happy/fail-open/idempotent/no-base"
+
+MIRROR_BODY_FILE="${SCRATCH}/mirror-body.sh"
+awk '
+  /^```bash phase-implement-mirror$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL_IMPLEMENT" > "$MIRROR_BODY_FILE"
+
+if [[ -s "$MIRROR_BODY_FILE" ]]; then
+  pass "mirror block extractable from SKILL.md"
+else
+  fail "mirror block extractable — no \`\`\`bash phase-implement-mirror\`\`\` fence found"
+fi
+
+# Build a throwaway git repo so the mirror block's git rev-parse / merge-base
+# / log / diff calls have something to operate on.
+build_git_fixture() {
+  local repo_dir="$1" with_base="${2:-yes}"
+  mkdir -p "$repo_dir"
+  (
+    cd "$repo_dir" || exit 1
+    git init --quiet --initial-branch=main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "base" > base.txt
+    git add base.txt
+    git commit --quiet -m "base commit"
+    if [[ "$with_base" == "yes" ]]; then
+      # Set up an origin/main ref that lags behind, so the mirror's
+      # BASE_REF fallback chain works (try origin/main first).
+      git update-ref refs/remotes/origin/main HEAD
+    fi
+    # Make a feature commit on top so HEAD..origin/main is non-empty.
+    git checkout --quiet -b feature
+    echo "change one" > a.txt
+    git add a.txt
+    git commit --quiet -m "feat: first commit"
+    echo "change two" > b.txt
+    git add b.txt
+    git commit --quiet -m "feat: second commit"
+  )
+}
+
+run_implement_mirror() {
+  local case_name="$1" stub_kind="$2" preseed_marker="${3:-}" git_base="${4:-yes}"
+  local case_dir="${SCRATCH}/imp-mirror-${case_name}"
+  local worker_dir="${case_dir}/orch/workers/CTL-449"
+  local repo_dir="${case_dir}/repo"
+  mkdir -p "$case_dir/bin" "$worker_dir"
+
+  build_git_fixture "$repo_dir" "$git_base"
+
+  if [[ "$stub_kind" == "ok" ]]; then
+    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+  else
+    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+  fi
+
+  if [[ -n "$preseed_marker" ]]; then
+    : > "$worker_dir/.linear-mirror-implement"
+  fi
+
+  (
+    cd "$repo_dir" || exit 1
+    PATH="$case_dir/bin:$PATH" \
+      ORCH_DIR="${case_dir}/orch" \
+      TICKET="CTL-449" \
+      PHASE="implement" \
+      bash "$MIRROR_BODY_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+    echo "$?" > "$case_dir/exit-code"
+  )
+  echo "$case_dir"
+}
+
+# Case A: happy — git fixture has origin/main, two commits on feature.
+CASE_A="$(run_implement_mirror happy ok '' yes)"
+assert_eq "0" "$(cat "$CASE_A/exit-code")" "mirror-implement happy: exit 0"
+LOG_A="$CASE_A/linearis-calls.log"
+if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
+  pass "mirror-implement happy: discuss landed"
+else
+  fail "mirror-implement happy: discuss" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -q 'Phase Implement' "$LOG_A" 2>/dev/null; then
+  pass "mirror-implement happy: body contains 'Phase Implement' header"
+else
+  fail "mirror-implement happy: header" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -qE 'feat: (first|second) commit' "$LOG_A" 2>/dev/null; then
+  pass "mirror-implement happy: body contains commit subjects"
+else
+  fail "mirror-implement happy: commit subjects" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -qE '(Branch|feature)' "$LOG_A" 2>/dev/null; then
+  pass "mirror-implement happy: body contains branch name"
+else
+  fail "mirror-implement happy: branch" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+MARKER_A="$CASE_A/orch/workers/CTL-449/.linear-mirror-implement"
+[[ -e "$MARKER_A" ]] && pass "mirror-implement happy: marker written" || fail "marker missing $MARKER_A"
+
+# Case B: fail-open.
+CASE_B="$(run_implement_mirror failopen fail '' yes)"
+assert_eq "0" "$(cat "$CASE_B/exit-code")" "mirror-implement fail-open: exit 0"
+MARKER_B="$CASE_B/orch/workers/CTL-449/.linear-mirror-implement"
+[[ ! -e "$MARKER_B" ]] && pass "mirror-implement fail-open: no marker" || fail "marker should not exist"
+if grep -q 'linearis discuss failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
+  pass "mirror-implement fail-open: warning to stderr"
+else
+  fail "mirror-implement fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_B/stderr.log" 2>/dev/null)")"
+fi
+
+# Case C: idempotent.
+CASE_C="$(run_implement_mirror idempot ok seed yes)"
+assert_eq "0" "$(cat "$CASE_C/exit-code")" "mirror-implement idempotent: exit 0"
+LOG_C="$CASE_C/linearis-calls.log"
+if [[ ! -f "$LOG_C" ]] || ! grep -q '^discuss$' "$LOG_C" 2>/dev/null; then
+  pass "mirror-implement idempotent: discuss skipped"
+else
+  fail "mirror-implement idempotent: discuss" "marker not honored"
+fi
+
+# Case D: no-base-branch — fixture omits origin/main; delete main too so the
+# block falls through to the `_base branch unknown_` arm. The mirror block must
+# still post (the plan picks the "post anyway" arm).
+build_git_fixture_no_base() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir"
+  (
+    cd "$repo_dir" || exit 1
+    git init --quiet --initial-branch=feature
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "x" > x.txt
+    git add x.txt
+    git commit --quiet -m "feat: solo commit"
+    # No main, no origin/main.
+  )
+}
+
+CASE_D_DIR="${SCRATCH}/imp-mirror-nobase"
+WORKER_D="${CASE_D_DIR}/orch/workers/CTL-449"
+REPO_D="${CASE_D_DIR}/repo"
+mkdir -p "$CASE_D_DIR/bin" "$WORKER_D"
+build_git_fixture_no_base "$REPO_D"
+linearis_stub_install "$CASE_D_DIR/bin" "$CASE_D_DIR/linearis-calls.log"
+
+(
+  cd "$REPO_D" || exit 1
+  PATH="$CASE_D_DIR/bin:$PATH" \
+    ORCH_DIR="${CASE_D_DIR}/orch" \
+    TICKET="CTL-449" \
+    PHASE="implement" \
+    bash "$MIRROR_BODY_FILE" >"$CASE_D_DIR/stdout.log" 2>"$CASE_D_DIR/stderr.log"
+  echo "$?" > "$CASE_D_DIR/exit-code"
+)
+
+assert_eq "0" "$(cat "$CASE_D_DIR/exit-code")" "mirror-implement no-base: exit 0"
+LOG_D="$CASE_D_DIR/linearis-calls.log"
+if grep -q '^discuss$' "$LOG_D" 2>/dev/null; then
+  pass "mirror-implement no-base: still posts (the chosen arm)"
+else
+  fail "mirror-implement no-base: discuss" "log:$(printf '\n%s' "$(cat "$LOG_D" 2>/dev/null)")"
+fi
+if grep -q '_base branch unknown_' "$LOG_D" 2>/dev/null; then
+  pass "mirror-implement no-base: body renders fallback marker"
+else
+  fail "mirror-implement no-base: fallback" "log:$(printf '\n%s' "$(cat "$LOG_D" 2>/dev/null)")"
+fi
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SKILL="${REPO_ROOT}/plugins/dev/skills/phase-plan/SKILL.md"
 DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+# shellcheck source=lib/linearis-stub.sh
+source "${SCRIPT_DIR}/lib/linearis-stub.sh"
 
 FAILURES=0
 PASSES=0
@@ -60,6 +62,12 @@ if [[ -f "$SKILL" ]]; then
   assert_not_contains "$BODY" "--transition planning" "body does NOT self-transition Linear (coordinator owns it, CTL-558)"
 
   assert_contains "$BODY" "/goal" "body declares a /goal block"
+
+  # CTL-632: Linear comment-mirror block must be present.
+  assert_contains "$BODY" "phase-plan-mirror" "body contains uniquely-named mirror fence"
+  assert_contains "$BODY" ".linear-mirror-" "body references the per-phase marker file"
+  assert_contains "$BODY" "linearis issues discuss" "body calls linearis issues discuss"
+  assert_contains "$BODY" "linearis discuss failed (continuing)" "body has fail-open warning string"
 fi
 
 # ─── E2E: dispatcher launches phase-plan when research doc present ─────────
@@ -132,6 +140,113 @@ RC=$?
 REFUSED=$(echo "$OUT" | jq -r '.status' 2>/dev/null || echo "")
 assert_eq "2" "$RC" "exit code 2 when research doc missing"
 assert_eq "refused" "$REFUSED" "stdout status = refused"
+
+# ─── CTL-632: Linear comment-mirror runtime exercises ────────────────────
+echo ""
+echo "Test 4: phase-plan mirror block — happy/fail-open/idempotent"
+
+MIRROR_BODY_FILE="${SCRATCH}/mirror-body.sh"
+awk '
+  /^```bash phase-plan-mirror$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL" > "$MIRROR_BODY_FILE"
+
+if [[ -s "$MIRROR_BODY_FILE" ]]; then
+  pass "mirror block extractable from SKILL.md"
+else
+  fail "mirror block extractable" "no \`\`\`bash phase-plan-mirror\`\`\` fence found"
+fi
+
+run_mirror_case() {
+  local case_name="$1" stub_kind="$2" preseed_marker="${3:-}"
+  local case_dir="${SCRATCH}/mirror-${case_name}"
+  local worker_dir="${case_dir}/orch/workers/CTL-450"
+  local plan_doc="${case_dir}/plan.md"
+  local research_doc="${case_dir}/research.md"
+  mkdir -p "$case_dir/bin" "$worker_dir"
+
+  cat >"$plan_doc" <<'DOC'
+# Plan: CTL-450 — fixture plan title
+
+## Overview
+
+Stuff happens.
+
+## Phase 1 — first
+
+## Phase 2 — second
+DOC
+
+  cat >"$research_doc" <<'DOC'
+# Research: CTL-450
+DOC
+
+  if [[ "$stub_kind" == "ok" ]]; then
+    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+  else
+    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+  fi
+
+  if [[ -n "$preseed_marker" ]]; then
+    : > "$worker_dir/.linear-mirror-plan"
+  fi
+
+  PATH="$case_dir/bin:$PATH" \
+    ORCH_DIR="${case_dir}/orch" \
+    TICKET="CTL-450" \
+    PHASE="plan" \
+    PLAN_DOC="$plan_doc" \
+    RESEARCH_DOC="$research_doc" \
+    bash "$MIRROR_BODY_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+  echo "$?" > "$case_dir/exit-code"
+  echo "$case_dir"
+}
+
+CASE_A="$(run_mirror_case happy ok)"
+assert_eq "0" "$(cat "$CASE_A/exit-code")" "mirror happy: exit 0"
+LOG_A="$CASE_A/linearis-calls.log"
+if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: discuss landed"
+else
+  fail "mirror happy: discuss" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -q 'Phase Plan' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: body contains 'Phase Plan' header"
+else
+  fail "mirror happy: header" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -q 'plan.md' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: body contains plan doc path"
+else
+  fail "mirror happy: plan path" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -q 'research.md' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: body contains research backlink"
+else
+  fail "mirror happy: research backlink" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+MARKER_A="$CASE_A/orch/workers/CTL-450/.linear-mirror-plan"
+[[ -e "$MARKER_A" ]] && pass "mirror happy: marker written" || fail "mirror happy: marker" "missing $MARKER_A"
+
+CASE_B="$(run_mirror_case failopen fail)"
+assert_eq "0" "$(cat "$CASE_B/exit-code")" "mirror fail-open: exit 0 (continue past failed post)"
+MARKER_B="$CASE_B/orch/workers/CTL-450/.linear-mirror-plan"
+[[ ! -e "$MARKER_B" ]] && pass "mirror fail-open: no marker on failed post" || fail "mirror fail-open: marker" "should not exist"
+if grep -q 'linearis discuss failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
+  pass "mirror fail-open: warning to stderr"
+else
+  fail "mirror fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_B/stderr.log" 2>/dev/null)")"
+fi
+
+CASE_C="$(run_mirror_case idempot ok seed)"
+assert_eq "0" "$(cat "$CASE_C/exit-code")" "mirror idempotent: exit 0"
+LOG_C="$CASE_C/linearis-calls.log"
+if [[ ! -f "$LOG_C" ]] || ! grep -q '^discuss$' "$LOG_C" 2>/dev/null; then
+  pass "mirror idempotent: discuss skipped"
+else
+  fail "mirror idempotent: discuss" "marker not honored"
+fi
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-research-e2e.test.sh
@@ -23,6 +23,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SKILL="${REPO_ROOT}/plugins/dev/skills/phase-research/SKILL.md"
 DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+# shellcheck source=lib/linearis-stub.sh
+source "${SCRIPT_DIR}/lib/linearis-stub.sh"
 
 FAILURES=0
 PASSES=0
@@ -89,6 +91,12 @@ if [[ -f "$SKILL" ]]; then
 
   # /goal block (turn cap)
   assert_contains "$BODY" "/goal" "body declares a /goal block"
+
+  # CTL-632: Linear comment-mirror block must be present.
+  assert_contains "$BODY" "phase-research-mirror" "body contains uniquely-named mirror fence (extractable by tests)"
+  assert_contains "$BODY" ".linear-mirror-" "body references the per-phase marker file"
+  assert_contains "$BODY" "linearis issues discuss" "body calls linearis issues discuss"
+  assert_contains "$BODY" "linearis discuss failed (continuing)" "body has fail-open warning string"
 fi
 
 # ─── E2E: dispatcher launches phase-research when triage.json exists ───────
@@ -164,6 +172,134 @@ assert_eq "refused" "$REFUSED" "stdout status = refused"
 SIGNAL_EXISTS="no"
 [[ -f "${WORKER_DIR}/phase-research.json" ]] && SIGNAL_EXISTS="yes"
 assert_eq "no" "$SIGNAL_EXISTS" "no signal file written on refusal"
+
+# ─── CTL-632: Linear comment-mirror block ─ runtime exercises ──────────────
+echo ""
+echo "Test 4: phase-research mirror block — happy path"
+
+extract_mirror() {
+  awk '
+    /^```bash phase-research-mirror$/ {capture=1; next}
+    /^```$/ {if (capture) {capture=0}}
+    capture { print }
+  ' "$SKILL"
+}
+
+MIRROR_BODY_FILE="${SCRATCH}/mirror-body.sh"
+extract_mirror > "$MIRROR_BODY_FILE"
+if [[ ! -s "$MIRROR_BODY_FILE" ]]; then
+  fail "mirror block extractable" "no \`\`\`bash phase-research-mirror\`\`\` fence found in SKILL.md"
+else
+  pass "mirror block extractable from SKILL.md"
+fi
+
+run_mirror_case() {
+  local case_name="$1" stub_kind="$2" preseed_marker="${3:-}"
+  local case_dir="${SCRATCH}/mirror-${case_name}"
+  local worker_dir="${case_dir}/orch/workers/CTL-450"
+  local research_doc="${case_dir}/research.md"
+  mkdir -p "$case_dir/bin" "$worker_dir"
+
+  cat >"$research_doc" <<'DOC'
+# Research: CTL-450 — fixture title
+
+## Summary
+
+This is the summary opening paragraph that the mirror block extracts.
+A second prose line.
+
+## Findings
+
+- foo
+DOC
+
+  if [[ "$stub_kind" == "ok" ]]; then
+    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+  else
+    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+  fi
+
+  if [[ -n "$preseed_marker" ]]; then
+    : > "$worker_dir/.linear-mirror-research"
+  fi
+
+  PATH="$case_dir/bin:$PATH" \
+    ORCH_DIR="${case_dir}/orch" \
+    TICKET="CTL-450" \
+    PHASE="research" \
+    RESEARCH_DOC="$research_doc" \
+    bash "$MIRROR_BODY_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+  echo "$?" > "$case_dir/exit-code"
+  echo "$case_dir"
+}
+
+# Case A: happy — stub OK, no pre-seeded marker.
+CASE_A="$(run_mirror_case happy ok)"
+EXIT_A="$(cat "$CASE_A/exit-code")"
+assert_eq "0" "$EXIT_A" "mirror happy: exit code 0 (fail-open: mirror never propagates non-zero)"
+
+LOG_A="$CASE_A/linearis-calls.log"
+if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: discuss call landed"
+else
+  fail "mirror happy: discuss call" "no 'discuss' in $LOG_A:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+
+# The body must contain the rendered template (Phase Research header).
+if grep -q 'Phase Research' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: body carries 'Phase Research' header"
+else
+  fail "mirror happy: body 'Phase Research'" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+
+# Doc path must appear in the body.
+if grep -q 'research.md' "$LOG_A" 2>/dev/null; then
+  pass "mirror happy: body carries research doc path"
+else
+  fail "mirror happy: doc path in body" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+
+# Marker written.
+MARKER_A="$CASE_A/orch/workers/CTL-450/.linear-mirror-research"
+if [[ -e "$MARKER_A" ]]; then
+  pass "mirror happy: .linear-mirror-research marker written"
+else
+  fail "mirror happy: marker file" "missing: $MARKER_A"
+fi
+
+# Case B: fail-open — failing stub, body still exits 0, marker NOT written, warning on stderr.
+echo ""
+echo "Test 5: phase-research mirror — fail-open"
+CASE_B="$(run_mirror_case failopen fail)"
+EXIT_B="$(cat "$CASE_B/exit-code")"
+assert_eq "0" "$EXIT_B" "mirror fail-open: still exits 0"
+
+MARKER_B="$CASE_B/orch/workers/CTL-450/.linear-mirror-research"
+if [[ ! -e "$MARKER_B" ]]; then
+  pass "mirror fail-open: marker NOT written on failed post"
+else
+  fail "mirror fail-open: marker" "marker should not exist when linearis discuss fails"
+fi
+
+if grep -q 'linearis discuss failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
+  pass "mirror fail-open: warning logged to stderr"
+else
+  fail "mirror fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_B/stderr.log" 2>/dev/null)")"
+fi
+
+# Case C: idempotent — pre-seeded marker, no discuss call.
+echo ""
+echo "Test 6: phase-research mirror — idempotent"
+CASE_C="$(run_mirror_case idempot ok seed)"
+EXIT_C="$(cat "$CASE_C/exit-code")"
+assert_eq "0" "$EXIT_C" "mirror idempotent: exit code 0"
+
+LOG_C="$CASE_C/linearis-calls.log"
+if [[ ! -f "$LOG_C" ]] || ! grep -q '^discuss$' "$LOG_C" 2>/dev/null; then
+  pass "mirror idempotent: no discuss call (marker honored)"
+else
+  fail "mirror idempotent: discuss call" "found discuss in $LOG_C — marker not honored"
+fi
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-review-e2e.test.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SKILL="${REPO_ROOT}/plugins/dev/skills/phase-review/SKILL.md"
 DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+# shellcheck source=lib/linearis-stub.sh
+source "${SCRIPT_DIR}/lib/linearis-stub.sh"
 
 FAILURES=0
 PASSES=0
@@ -75,6 +77,12 @@ if [[ -f "$SKILL" ]]; then
 
   # Remediation commit cap: at most ONE
   assert_contains "$BODY" "at most ONE" "body documents at-most-one-remediation-commit constraint"
+
+  # CTL-632: Linear comment-mirror block must be present.
+  assert_contains "$BODY" "phase-review-mirror" "body contains uniquely-named mirror fence"
+  assert_contains "$BODY" ".linear-mirror-" "body references the per-phase marker file"
+  assert_contains "$BODY" "linearis issues discuss" "body calls linearis issues discuss"
+  assert_contains "$BODY" "linearis discuss failed (continuing)" "body has fail-open warning string"
 fi
 
 # ─── E2E: dispatcher launches phase-review when verify.json present ────────
@@ -142,6 +150,132 @@ RC=$?
 REFUSED=$(echo "$OUT" | jq -r '.status' 2>/dev/null || echo "")
 assert_eq "2" "$RC" "exit code 2 when verify.json missing"
 assert_eq "refused" "$REFUSED" "stdout status = refused"
+
+# ─── CTL-632: Linear comment-mirror runtime exercises ────────────────────
+echo ""
+echo "Test 4: phase-review mirror block — happy-pass/happy-fail/fail-open/idempotent"
+
+# Note on the plan's 5th case (`emit-failed-not-complete` invariant tied to
+# memory #41): the current phase-review SKILL.md does not yet have an
+# emit-failed-on-block code path (it only emits `failed` on unrecoverable
+# verification crashes via the Failure handling block). Implementing
+# emit-failed-on-block is outside CTL-632's scope; the mirror block here
+# runs on the success end-block path, which is reached for both
+# reviewPassed=true and reviewPassed=false today. Case 5 is therefore
+# deferred to whichever ticket lands the emit-failed-on-block fix.
+
+MIRROR_BODY_FILE="${SCRATCH}/mirror-body.sh"
+awk '
+  /^```bash phase-review-mirror$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL" > "$MIRROR_BODY_FILE"
+
+if [[ -s "$MIRROR_BODY_FILE" ]]; then
+  pass "mirror block extractable from SKILL.md"
+else
+  fail "mirror block extractable — no \`\`\`bash phase-review-mirror\`\`\` fence found"
+fi
+
+run_review_mirror() {
+  local case_name="$1" stub_kind="$2" review_passed="$3" findings_json="$4" \
+        remediation_sha="$5" preseed_marker="${6:-}"
+  local case_dir="${SCRATCH}/review-mirror-${case_name}"
+  local worker_dir="${case_dir}/orch/workers/CTL-450"
+  mkdir -p "$case_dir/bin" "$worker_dir"
+
+  if [[ "$stub_kind" == "ok" ]]; then
+    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+  else
+    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+  fi
+
+  if [[ -n "$preseed_marker" ]]; then
+    : > "$worker_dir/.linear-mirror-review"
+  fi
+
+  PATH="$case_dir/bin:$PATH" \
+    ORCH_DIR="${case_dir}/orch" \
+    TICKET="CTL-450" \
+    PHASE="review" \
+    REVIEW_PASSED="$review_passed" \
+    REVIEW_FINDINGS_JSON="$findings_json" \
+    REMEDIATION_SHA="$remediation_sha" \
+    bash "$MIRROR_BODY_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+  echo "$?" > "$case_dir/exit-code"
+  echo "$case_dir"
+}
+
+FINDINGS_EMPTY='[]'
+FINDINGS_HIGH='[{"severity":"high","kind":"review","file":"a.ts","line":1,"message":"x","addressedBy":"deferred-to-human"}]'
+
+# Case A: happy-passed.
+CASE_A="$(run_review_mirror happy_pass ok true "$FINDINGS_EMPTY" "")"
+assert_eq "0" "$(cat "$CASE_A/exit-code")" "mirror-review happy-pass: exit 0"
+LOG_A="$CASE_A/linearis-calls.log"
+if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
+  pass "mirror-review happy-pass: discuss landed"
+else
+  fail "mirror-review happy-pass: discuss" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -qE 'Result.*PASS' "$LOG_A" 2>/dev/null; then
+  pass "mirror-review happy-pass: body shows Result: PASS"
+else
+  fail "mirror-review happy-pass: PASS label" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -q 'none' "$LOG_A" 2>/dev/null; then
+  pass "mirror-review happy-pass: 'none' fallback for empty findings"
+else
+  fail "mirror-review happy-pass: empty findings fallback" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+MARKER_A="$CASE_A/orch/workers/CTL-450/.linear-mirror-review"
+[[ -e "$MARKER_A" ]] && pass "mirror-review happy-pass: marker written" || fail "marker missing $MARKER_A"
+
+# Case B: happy-failed (reviewPassed=false, 1 HIGH finding, remediation sha).
+CASE_B="$(run_review_mirror happy_fail ok false "$FINDINGS_HIGH" "abc1234")"
+assert_eq "0" "$(cat "$CASE_B/exit-code")" "mirror-review happy-fail: exit 0"
+LOG_B="$CASE_B/linearis-calls.log"
+if grep -qE 'Result.*FAIL' "$LOG_B" 2>/dev/null; then
+  pass "mirror-review happy-fail: body shows Result: FAIL"
+else
+  fail "mirror-review happy-fail: FAIL label" "log:$(printf '\n%s' "$(cat "$LOG_B" 2>/dev/null)")"
+fi
+if grep -q 'high' "$LOG_B" 2>/dev/null; then
+  pass "mirror-review happy-fail: HIGH severity surfaced"
+else
+  fail "mirror-review happy-fail: severity" "log:$(printf '\n%s' "$(cat "$LOG_B" 2>/dev/null)")"
+fi
+if grep -q 'abc1234' "$LOG_B" 2>/dev/null; then
+  pass "mirror-review happy-fail: remediation sha rendered"
+else
+  fail "mirror-review happy-fail: remediation sha" "log:$(printf '\n%s' "$(cat "$LOG_B" 2>/dev/null)")"
+fi
+if grep -q '<details>' "$LOG_B" 2>/dev/null && grep -q 'a\.ts' "$LOG_B" 2>/dev/null; then
+  pass "mirror-review happy-fail: full findings JSON in <details>"
+else
+  fail "mirror-review happy-fail: details JSON" "log:$(printf '\n%s' "$(cat "$LOG_B" 2>/dev/null)")"
+fi
+
+# Case C: fail-open.
+CASE_C="$(run_review_mirror failopen fail true "$FINDINGS_EMPTY" "")"
+assert_eq "0" "$(cat "$CASE_C/exit-code")" "mirror-review fail-open: exit 0"
+MARKER_C="$CASE_C/orch/workers/CTL-450/.linear-mirror-review"
+[[ ! -e "$MARKER_C" ]] && pass "mirror-review fail-open: no marker" || fail "marker should not exist"
+if grep -q 'linearis discuss failed (continuing)' "$CASE_C/stderr.log" 2>/dev/null; then
+  pass "mirror-review fail-open: warning to stderr"
+else
+  fail "mirror-review fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_C/stderr.log" 2>/dev/null)")"
+fi
+
+# Case D: idempotent.
+CASE_D="$(run_review_mirror idempot ok true "$FINDINGS_EMPTY" "" seed)"
+assert_eq "0" "$(cat "$CASE_D/exit-code")" "mirror-review idempotent: exit 0"
+LOG_D="$CASE_D/linearis-calls.log"
+if [[ ! -f "$LOG_D" ]] || ! grep -q '^discuss$' "$LOG_D" 2>/dev/null; then
+  pass "mirror-review idempotent: discuss skipped"
+else
+  fail "mirror-review idempotent: discuss" "marker not honored"
+fi
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -21,6 +21,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SKILL_FILE="${REPO_ROOT}/plugins/dev/skills/phase-triage/SKILL.md"
 EMIT_HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
+# CTL-632 Phase 6 refactor: adopt the shared linearis-stub helper.
+# shellcheck source=lib/linearis-stub.sh
+source "${SCRIPT_DIR}/lib/linearis-stub.sh"
 
 PASS=0
 FAIL=0
@@ -86,39 +89,8 @@ run_case() {
 	local case_dir="$TMPROOT/$case_name"
 	mkdir -p "$case_dir/bin"
 
-	# Build the `linearis` stub.
-	cat >"$case_dir/bin/linearis" <<EOF
-#!/usr/bin/env bash
-LOG="$case_dir/linearis-calls.log"
-case "\$1" in
-  issues)
-    case "\$2" in
-      read)
-        printf '%s\n' "\$@" >> "\$LOG"
-        cat "$fixture"
-        ;;
-      discuss)
-        printf '%s\n' "\$@" >> "\$LOG"
-        # Mirror linearis: return JSON-ish "ok"
-        echo '{"ok": true, "kind": "discuss"}'
-        ;;
-      update)
-        printf '%s\n' "\$@" >> "\$LOG"
-        echo '{"ok": true, "kind": "update"}'
-        ;;
-      *)
-        printf 'linearis stub: unsupported issues subcommand: %s\n' "\$2" >&2
-        exit 2
-        ;;
-    esac
-    ;;
-  *)
-    printf 'linearis stub: unsupported domain: %s\n' "\$1" >&2
-    exit 2
-    ;;
-esac
-EOF
-	chmod +x "$case_dir/bin/linearis"
+	# CTL-632: use the shared helper instead of inlining the stub body.
+	linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log" "$fixture"
 
 	# Run the skill body with the stub on PATH.
 	local events_file="$case_dir/events.jsonl"

--- a/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
@@ -23,6 +23,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SKILL="${REPO_ROOT}/plugins/dev/skills/phase-verify/SKILL.md"
 DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+# shellcheck source=lib/linearis-stub.sh
+source "${SCRIPT_DIR}/lib/linearis-stub.sh"
 
 FAILURES=0
 PASSES=0
@@ -83,6 +85,12 @@ if [[ -f "$SKILL" ]]; then
   assert_not_contains "$BODY" "--transition verifying" "body does NOT self-transition Linear (coordinator owns it, CTL-558)"
 
   assert_contains "$BODY" "/goal" "body declares a /goal block"
+
+  # CTL-632: Linear comment-mirror block must be present.
+  assert_contains "$BODY" "phase-verify-mirror" "body contains uniquely-named mirror fence"
+  assert_contains "$BODY" ".linear-mirror-" "body references the per-phase marker file"
+  assert_contains "$BODY" "linearis issues discuss" "body calls linearis issues discuss"
+  assert_contains "$BODY" "linearis discuss failed (continuing)" "body has fail-open warning string"
 fi
 
 # ─── E2E: dispatcher launches phase-verify when phase-implement.json exists ─
@@ -148,6 +156,125 @@ RC=$?
 REFUSED=$(echo "$OUT" | jq -r '.status' 2>/dev/null || echo "")
 assert_eq "2" "$RC" "exit code 2 when phase-implement.json missing"
 assert_eq "refused" "$REFUSED" "stdout status = refused"
+
+# ─── CTL-632: Linear comment-mirror runtime exercises ────────────────────
+echo ""
+echo "Test 4: phase-verify mirror block — happy/fail-open/idempotent/findings-render"
+
+MIRROR_BODY_FILE="${SCRATCH}/mirror-body.sh"
+awk '
+  /^```bash phase-verify-mirror$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL" > "$MIRROR_BODY_FILE"
+
+if [[ -s "$MIRROR_BODY_FILE" ]]; then
+  pass "mirror block extractable from SKILL.md"
+else
+  fail "mirror block extractable — no \`\`\`bash phase-verify-mirror\`\`\` fence found"
+fi
+
+run_verify_mirror() {
+  local case_name="$1" stub_kind="$2" gates_json="$3" findings_json="$4" \
+        regression_risk="$5" tests_attempted="$6" preseed_marker="${7:-}"
+  local case_dir="${SCRATCH}/verify-mirror-${case_name}"
+  local worker_dir="${case_dir}/orch/workers/CTL-450"
+  mkdir -p "$case_dir/bin" "$worker_dir"
+
+  if [[ "$stub_kind" == "ok" ]]; then
+    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+  else
+    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+  fi
+
+  if [[ -n "$preseed_marker" ]]; then
+    : > "$worker_dir/.linear-mirror-verify"
+  fi
+
+  PATH="$case_dir/bin:$PATH" \
+    ORCH_DIR="${case_dir}/orch" \
+    TICKET="CTL-450" \
+    PHASE="verify" \
+    GATES_JSON="$gates_json" \
+    FINDINGS_JSON="$findings_json" \
+    REGRESSION_RISK="$regression_risk" \
+    TESTS_ATTEMPTED="$tests_attempted" \
+    ARTIFACT="${worker_dir}/verify.json" \
+    bash "$MIRROR_BODY_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+  echo "$?" > "$case_dir/exit-code"
+  echo "$case_dir"
+}
+
+GATES_PASS='{"tsc":{"status":"pass","summary":"clean"},"tests":{"status":"pass","summary":"42/42"},"lint":{"status":"skipped"}}'
+GATES_FAIL='{"tsc":{"status":"fail","summary":"3 errors"},"tests":{"status":"pass"}}'
+FINDINGS_EMPTY='[]'
+FINDINGS_TWO='[{"severity":"high","kind":"type","file":"a.ts","line":1,"message":"x"},{"severity":"low","kind":"lint","file":"b.ts","line":2,"message":"y"}]'
+
+# Case A: happy — pass gates, no findings.
+CASE_A="$(run_verify_mirror happy ok "$GATES_PASS" "$FINDINGS_EMPTY" 2 1)"
+assert_eq "0" "$(cat "$CASE_A/exit-code")" "mirror-verify happy: exit 0"
+LOG_A="$CASE_A/linearis-calls.log"
+if grep -q '^discuss$' "$LOG_A" 2>/dev/null; then
+  pass "mirror-verify happy: discuss landed"
+else
+  fail "mirror-verify happy: discuss" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -q 'Phase Verify' "$LOG_A" 2>/dev/null; then
+  pass "mirror-verify happy: body has 'Phase Verify' header"
+else
+  fail "mirror-verify happy: header" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -qE 'Regression risk.*2' "$LOG_A" 2>/dev/null; then
+  pass "mirror-verify happy: regression risk rendered"
+else
+  fail "mirror-verify happy: regression_risk" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+# All three gates referenced in body.
+for g in tsc tests lint; do
+  if grep -qE "\\*\\*${g}\\*\\*" "$LOG_A" 2>/dev/null; then
+    pass "mirror-verify happy: gate '$g' in body"
+  else
+    fail "mirror-verify happy: gate '$g'" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+  fi
+done
+MARKER_A="$CASE_A/orch/workers/CTL-450/.linear-mirror-verify"
+[[ -e "$MARKER_A" ]] && pass "mirror-verify happy: marker written" || fail "marker missing $MARKER_A"
+
+# Case B: fail-open.
+CASE_B="$(run_verify_mirror failopen fail "$GATES_PASS" "$FINDINGS_EMPTY" 0 0)"
+assert_eq "0" "$(cat "$CASE_B/exit-code")" "mirror-verify fail-open: exit 0"
+MARKER_B="$CASE_B/orch/workers/CTL-450/.linear-mirror-verify"
+[[ ! -e "$MARKER_B" ]] && pass "mirror-verify fail-open: no marker" || fail "marker should not exist"
+if grep -q 'linearis discuss failed (continuing)' "$CASE_B/stderr.log" 2>/dev/null; then
+  pass "mirror-verify fail-open: warning"
+else
+  fail "mirror-verify fail-open: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_B/stderr.log" 2>/dev/null)")"
+fi
+
+# Case C: idempotent.
+CASE_C="$(run_verify_mirror idempot ok "$GATES_PASS" "$FINDINGS_EMPTY" 0 0 seed)"
+assert_eq "0" "$(cat "$CASE_C/exit-code")" "mirror-verify idempotent: exit 0"
+LOG_C="$CASE_C/linearis-calls.log"
+if [[ ! -f "$LOG_C" ]] || ! grep -q '^discuss$' "$LOG_C" 2>/dev/null; then
+  pass "mirror-verify idempotent: discuss skipped"
+else
+  fail "mirror-verify idempotent: discuss" "marker not honored"
+fi
+
+# Case D: findings-render — 2 findings, both severities surfaced + full JSON in details.
+CASE_D="$(run_verify_mirror findings ok "$GATES_FAIL" "$FINDINGS_TWO" 8 0)"
+assert_eq "0" "$(cat "$CASE_D/exit-code")" "mirror-verify findings: exit 0"
+LOG_D="$CASE_D/linearis-calls.log"
+if grep -q 'high' "$LOG_D" 2>/dev/null && grep -q 'low' "$LOG_D" 2>/dev/null; then
+  pass "mirror-verify findings: both severity strings present"
+else
+  fail "mirror-verify findings: severities" "log:$(printf '\n%s' "$(cat "$LOG_D" 2>/dev/null)")"
+fi
+if grep -q '<details>' "$LOG_D" 2>/dev/null && grep -qE 'a\.ts|b\.ts' "$LOG_D" 2>/dev/null; then
+  pass "mirror-verify findings: full JSON in <details>"
+else
+  fail "mirror-verify findings: details JSON" "log:$(printf '\n%s' "$(cat "$LOG_D" 2>/dev/null)")"
+fi
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -204,6 +204,61 @@ before `stalled` + `attentionReason=continuation-budget-exhausted`.
 
 ## End block (terminal emit — copy verbatim)
 
+Mirror the phase output to Linear as a single comment (CTL-632). Re-derives
+the commit list at end-block time (no captured variable upstream), falling
+back to `_base branch unknown_` if neither `origin/main` nor `main` exists.
+Fail-open and idempotent via the per-phase marker file. Uniquely-named
+fence so the e2e test can extract just this block.
+
+```bash phase-implement-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  BASE_REF=""
+  if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    BASE_REF="origin/main"
+  elif git rev-parse --verify --quiet main >/dev/null 2>&1; then
+    BASE_REF="main"
+  fi
+  BASE_SHA=""
+  if [[ -n "${BASE_REF}" ]]; then
+    BASE_SHA="$(git merge-base HEAD "${BASE_REF}" 2>/dev/null || true)"
+  fi
+  if [[ -n "${BASE_SHA}" ]]; then
+    COMMIT_LIST="$(git log --no-merges --oneline "${BASE_SHA}..HEAD" 2>/dev/null | sed 's/^/- /')"
+    COMMIT_COUNT="$(printf '%s\n' "${COMMIT_LIST}" | grep -c '^- ' || true)"
+    : "${COMMIT_COUNT:=0}"
+    DIFF_STAT="$(git diff --stat "${BASE_SHA}..HEAD" 2>/dev/null | tail -1)"
+  else
+    COMMIT_LIST="_base branch unknown_"
+    COMMIT_COUNT="?"
+    DIFF_STAT="_unavailable_"
+  fi
+  BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "${TICKET}")"
+  MIRROR_BODY="$(cat <<EOF
+**Phase Implement**
+
+- **Branch**: \`${BRANCH_NAME}\`
+- **Commits**: ${COMMIT_COUNT}
+- **Diff**: ${DIFF_STAT}
+
+<details>
+<summary>Commit list</summary>
+
+${COMMIT_LIST}
+
+</details>
+
+_Posted automatically by phase-implement (CTL-632)._
+EOF
+)"
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-implement: linearis discuss failed (continuing)" >&2
+  fi
+fi
+```
+
 ```bash
 EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
 if [[ -x "$EMIT" ]]; then

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -174,7 +174,38 @@ TMP="${SIGNAL_FILE}.tmp.$$"
 jq --arg ts "$TS" --arg doc "$PLAN_DOC" \
   '.updatedAt = $ts | .artifact = $doc' \
   "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+```
 
+Mirror the phase output to Linear as a single comment (CTL-632). Fail-open
+and idempotent via the per-phase marker file. Uniquely-named fence so the
+e2e test can extract just this block.
+
+```bash phase-plan-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  PLAN_TITLE="$(awk '/^# /{print; exit}' "${PLAN_DOC}" | sed 's/^# //')"
+  PLAN_PHASES_COUNT="$(grep -c '^## Phase ' "${PLAN_DOC}" || true)"
+  : "${PLAN_PHASES_COUNT:=0}"
+  MIRROR_BODY="$(cat <<EOF
+**Phase Plan**
+
+- **Document**: \`${PLAN_DOC}\`
+- **Title**: ${PLAN_TITLE:-_untitled_}
+- **Phases**: ${PLAN_PHASES_COUNT}
+- **Research backlink**: \`${RESEARCH_DOC}\`
+
+_Posted automatically by phase-plan (CTL-632)._
+EOF
+)"
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-plan: linearis discuss failed (continuing)" >&2
+  fi
+fi
+```
+
+```bash
 "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
   --phase "$PHASE" --ticket "$TICKET" --status complete
 

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -164,7 +164,43 @@ TMP="${SIGNAL_FILE}.tmp.$$"
 jq --arg ts "$TS" --arg doc "$RESEARCH_DOC" \
   '.updatedAt = $ts | .artifact = $doc' \
   "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+```
 
+Mirror the phase output to Linear as a single comment (CTL-632). Fail-open
+(a failed Linear post must not break the phase) and idempotent (re-walks
+after orchestrator restart skip already-posted phases via a marker file).
+The fence is uniquely named so the e2e test can extract just this block.
+
+```bash phase-research-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  RESEARCH_TITLE="$(awk '/^# /{print; exit}' "${RESEARCH_DOC}" | sed 's/^# //')"
+  RESEARCH_SUMMARY="$(awk '/^## Summary/{flag=1; next} /^## /{flag=0} flag && NF' "${RESEARCH_DOC}" | head -5)"
+  MIRROR_BODY="$(cat <<EOF
+**Phase Research**
+
+- **Document**: \`${RESEARCH_DOC}\`
+- **Title**: ${RESEARCH_TITLE:-_untitled_}
+
+<details>
+<summary>Summary preview</summary>
+
+${RESEARCH_SUMMARY}
+
+</details>
+
+_Posted automatically by phase-research (CTL-632)._
+EOF
+)"
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-research: linearis discuss failed (continuing)" >&2
+  fi
+fi
+```
+
+```bash
 # Emit phase-complete event, close signal file, end catalyst-session.
 "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
   --phase "$PHASE" --ticket "$TICKET" --status complete

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -198,7 +198,69 @@ TMP="${SIGNAL_FILE}.tmp.$$"
 jq --arg ts "$TS" --arg artifact "$ARTIFACT" \
   '.updatedAt = $ts | .artifact = $artifact' \
   "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+```
 
+Mirror the phase output to Linear as a single comment (CTL-632). Renders
+the PASS/FAIL result label, findings-by-severity, remediation commit SHA,
+and the full findings JSON inside a `<details>` block. Body is
+hard-truncated to 30,000 bytes. Fail-open and idempotent via the
+per-phase marker file.
+
+```bash phase-review-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  if [[ "${REVIEW_PASSED}" == "true" ]]; then
+    RESULT_LABEL="PASS"
+  else
+    RESULT_LABEL="FAIL"
+  fi
+  FINDINGS_COUNT="$(printf '%s' "${REVIEW_FINDINGS_JSON}" | jq -r 'length' 2>/dev/null || echo 0)"
+  FINDINGS_BY_SEVERITY="$(printf '%s' "${REVIEW_FINDINGS_JSON}" | jq -r '
+    group_by(.severity)
+    | map("- " + (.[0].severity // "unknown") + ": " + (length|tostring))
+    | join("\n")' 2>/dev/null)"
+  FINDINGS_PRETTY="$(printf '%s' "${REVIEW_FINDINGS_JSON}" | jq -r '.' 2>/dev/null)"
+  if [[ -n "${REMEDIATION_SHA}" ]]; then
+    REMEDIATION_LINE="- **Remediation commit**: \`${REMEDIATION_SHA}\`"
+  else
+    REMEDIATION_LINE="- **Remediation commit**: _none_"
+  fi
+  MIRROR_BODY="$(cat <<EOF
+**Phase Review**
+
+- **Result**: ${RESULT_LABEL}
+- **Findings**: ${FINDINGS_COUNT}
+${REMEDIATION_LINE}
+
+**Findings by severity**:
+${FINDINGS_BY_SEVERITY:-_none_}
+
+<details>
+<summary>Full findings JSON</summary>
+
+\`\`\`json
+${FINDINGS_PRETTY}
+\`\`\`
+
+</details>
+
+_Posted automatically by phase-review (CTL-632)._
+EOF
+)"
+  if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
+    MIRROR_BODY="${MIRROR_BODY:0:30000}
+
+_... (truncated)_"
+  fi
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-review: linearis discuss failed (continuing)" >&2
+  fi
+fi
+```
+
+```bash
 "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
   --phase "$PHASE" --ticket "$TICKET" --status complete
 

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -220,7 +220,67 @@ TMP="${SIGNAL_FILE}.tmp.$$"
 jq --arg ts "$TS" --arg artifact "$ARTIFACT" \
   '.updatedAt = $ts | .artifact = $artifact' \
   "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+```
 
+Mirror the phase output to Linear as a single comment (CTL-632). Renders
+regression risk, per-gate pass/fail/skip, findings-by-severity, and the
+full findings JSON inside a `<details>` block. Body is hard-truncated to
+30,000 bytes (well under Linear's effective comment cap) with a marker.
+Fail-open and idempotent via the per-phase marker file.
+
+```bash phase-verify-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  GATES_RENDERED="$(printf '%s' "${GATES_JSON}" | jq -r '
+    to_entries
+    | map("- **" + .key + "**: " + (.value.status // "unknown")
+          + (if .value.summary then " — " + .value.summary else "" end))
+    | join("\n")' 2>/dev/null)"
+  FINDINGS_COUNT="$(printf '%s' "${FINDINGS_JSON}" | jq -r 'length' 2>/dev/null || echo 0)"
+  FINDINGS_BY_SEVERITY="$(printf '%s' "${FINDINGS_JSON}" | jq -r '
+    group_by(.severity)
+    | map("- " + (.[0].severity // "unknown") + ": " + (length|tostring))
+    | join("\n")' 2>/dev/null)"
+  FINDINGS_PRETTY="$(printf '%s' "${FINDINGS_JSON}" | jq -r '.' 2>/dev/null)"
+  MIRROR_BODY="$(cat <<EOF
+**Phase Verify**
+
+- **Regression risk**: ${REGRESSION_RISK} / 10
+- **Tests attempted**: ${TESTS_ATTEMPTED}
+- **Findings**: ${FINDINGS_COUNT}
+
+**Gates**:
+${GATES_RENDERED}
+
+**Findings by severity**:
+${FINDINGS_BY_SEVERITY:-_none_}
+
+<details>
+<summary>Full findings JSON</summary>
+
+\`\`\`json
+${FINDINGS_PRETTY}
+\`\`\`
+
+</details>
+
+_Posted automatically by phase-verify (CTL-632)._
+EOF
+)"
+  if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
+    MIRROR_BODY="${MIRROR_BODY:0:30000}
+
+_... (truncated)_"
+  fi
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-verify: linearis discuss failed (continuing)" >&2
+  fi
+fi
+```
+
+```bash
 "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
   --phase "$PHASE" --ticket "$TICKET" --status complete
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-25T23:00:21Z -->
<!-- Last updated: 2026-05-25T23:00:21Z -->
<!-- PR: #1057 -->
<!-- Previous commits: bb0f9655,22ca7b38,c13f2997,18a6d9ca,b615a8ab,afab6847 -->

## Summary

Brings the remaining phase agents to parity with `phase-triage` on Linear comment-mirroring. Before this change only `phase-triage` posted its output back to the Linear ticket as a comment; the `research`, `plan`, `implement`, `verify`, and `review` phases produced artifacts (research docs, plans, diffs, gate results) that never surfaced on the ticket. This PR adds a Linear comment-mirror block to each of those phase skills so a human watching the ticket sees each phase's result as it lands.

It also extracts the inline linearis test double the phase e2e suites were duplicating into a single shared `linearis-stub.sh` helper, and adds e2e coverage for every mirror block.

## Changes Made

### Phase skills — Linear comment-mirror blocks
- `phase-research/SKILL.md` — posts the research-doc summary as a Linear comment.
- `phase-plan/SKILL.md` — posts the plan summary as a Linear comment.
- `phase-implement/SKILL.md` — posts the implementation summary as a Linear comment.
- `phase-verify/SKILL.md` — posts the verify-gate results as a Linear comment.
- `phase-review/SKILL.md` — posts the review findings as a Linear comment.

The status transition stays owned by the deterministic coordinator (CTL-558); these blocks only add the comment mirror, matching the existing `phase-triage` pattern.

### Shared test helper
- `__tests__/lib/linearis-stub.sh` — single linearis test double shared across the phase e2e suites (replaces per-suite inline stubs).
- `__tests__/lib/linearis-stub.sh.test.sh` — unit coverage for the stub helper.
- `phase-triage-e2e.test.sh` — migrated to the shared stub (net −33 lines of duplicated stub code).

### New e2e coverage
- `phase-research-e2e.test.sh`, `phase-plan-e2e.test.sh`, `phase-implement-e2e.test.sh`, `phase-verify-e2e.test.sh`, `phase-review-e2e.test.sh` — assert each phase posts its comment mirror via the stub.

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/lib/linearis-stub.sh.test.sh` ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-research-e2e.test.sh` ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-plan-e2e.test.sh` ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh` ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh` ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-review-e2e.test.sh` ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` ✅ (regression — still green after stub migration)

All 7 suites pass (7/7).

## Changelog Entry

`feat(dev): phase research/plan/implement/verify/review agents now mirror their output to Linear as a comment`

## Related Issues/PRs

- Fixes CTL-632
