### PR TITLE
fix(dev): make phase-emit-complete.sh sourceable under zsh (CTL-618)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-emit-complete-zsh.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-emit-complete-zsh.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# CTL-618: phase-emit-complete.sh must be sourceable AND runnable under zsh, not
+# just bash. The existing phase-agent-emit-complete.test.sh sources the lib under
+# `bash -c`, so it cannot catch the zsh-only failures (BASH_SOURCE unset →
+# sibling-source 127; `local status` → read-only collision). This test drives the
+# lib through `zsh -c` from a foreign cwd to reproduce + guard both.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-emit-complete-zsh.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-emit-zsh-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+assert_eq() {
+  if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi
+}
+
+[[ -f "$LIB" ]] || { echo "FATAL: lib missing at $LIB" >&2; exit 1; }
+
+if ! command -v zsh >/dev/null 2>&1; then
+  echo "SKIP: zsh not available on this host — zsh source-safety not exercised"
+  exit 0
+fi
+
+# Run the lib under zsh from a foreign cwd ("/"), the exact condition that broke:
+# BASH_SOURCE is unset for sourced files under zsh, so a bare ${BASH_SOURCE[0]}
+# would resolve to "/" and fail to find the sibling.
+run_under_zsh() {  # $1 = events file ; emits one phase event
+  # set -uo pipefail mirrors the real consumer skill bodies (phase-triage /
+  # phase-monitor-deploy run under `set -u`); without it, an un-renamed bare
+  # $status would silently use zsh's $? special var instead of erroring.
+  ( cd / && CATALYST_EVENTS_FILE="$1" \
+      CATALYST_ORCHESTRATOR_ID="orch-zsh" CATALYST_SESSION_ID="sess_zsh" \
+      zsh -c "set -uo pipefail; . '$LIB' && emit_phase_complete --phase triage --ticket CTL-618 --status complete" ) 2>&1
+}
+
+echo "Test 1: lib sources + emits cleanly under zsh from a foreign cwd"
+EVENTS="${SCRATCH}/zsh-emit.jsonl"
+OUT="$(run_under_zsh "$EVENTS")"; RC=$?
+assert_eq "0" "$RC" "emit_phase_complete returns 0 under zsh"
+if [[ "$OUT" == *"read-only variable: status"* ]]; then
+  fail "no 'read-only variable: status' error under zsh — got: $OUT"
+else
+  pass "no 'read-only variable: status' error under zsh"
+fi
+if [[ "$OUT" == *"no such file or directory"*canonical-event* || "$OUT" == *"canonical-event.sh"*"no such file"* ]]; then
+  fail "sibling canonical-event.sh resolved under zsh — got: $OUT"
+else
+  pass "sibling canonical-event.sh resolved under zsh"
+fi
+if [[ -s "$EVENTS" ]]; then
+  EVENT_NAME="$(jq -r '.attributes."event.name"' "$EVENTS" | tail -n 1)"
+  assert_eq "phase.triage.complete.CTL-618" "$EVENT_NAME" "zsh emit wrote canonical phase event"
+else
+  fail "zsh emit wrote no event line to $EVENTS"
+fi
+
+echo ""
+echo "Test 2 (regression): lib still sources + emits cleanly under bash from a foreign cwd"
+# set -uo pipefail mirrors the real skill-body invocation. This is the path that
+# catches a bare $status left un-renamed: under bash `set -u`, $status is an
+# unbound variable (unlike zsh, where $status is always defined as $?).
+EVENTS_B="${SCRATCH}/bash-emit.jsonl"
+BASH_OUT="$( cd / && CATALYST_EVENTS_FILE="$EVENTS_B" CATALYST_ORCHESTRATOR_ID="orch-bash" \
+    CATALYST_SESSION_ID="sess_bash" \
+    bash -c "set -uo pipefail; . '$LIB' && emit_phase_complete --phase triage --ticket CTL-618 --status complete" 2>&1 )"
+if [[ "$BASH_OUT" == *"unbound variable"* ]]; then
+  fail "no 'unbound variable' under bash set -u — got: $BASH_OUT"
+else
+  pass "no 'unbound variable' under bash set -u"
+fi
+if [[ -s "$EVENTS_B" ]]; then
+  EVENT_NAME_B="$(jq -r '.attributes."event.name"' "$EVENTS_B" | tail -n 1)"
+  assert_eq "phase.triage.complete.CTL-618" "$EVENT_NAME_B" "bash emit still writes canonical phase event"
+else
+  fail "bash emit wrote no event line (regression)"
+fi
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-emit-complete-zsh: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -gt 0 ]] && exit 1
+exit 0

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -22,7 +22,9 @@ __CATALYST_CANONICAL_SOURCED=1
 # Resolve plugin.json relative to this file:
 #   plugins/dev/scripts/lib/canonical-event.sh
 #   plugins/dev/.claude-plugin/plugin.json
-__CE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Portable self-path: BASH_SOURCE under bash, prompt-expansion %x under zsh (CTL-618).
+__CE_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
+__CE_LIB_DIR="$(cd "$(dirname "$__CE_SELF")" && pwd)"
 __CE_PLUGIN_JSON="${__CE_LIB_DIR}/../../.claude-plugin/plugin.json"
 __CE_VERSION_CACHED=""
 

--- a/plugins/dev/scripts/lib/phase-emit-complete.sh
+++ b/plugins/dev/scripts/lib/phase-emit-complete.sh
@@ -27,7 +27,11 @@ if [[ -n "${__CATALYST_PHASE_EMIT_SOURCED:-}" ]]; then
 fi
 __CATALYST_PHASE_EMIT_SOURCED=1
 
-__PEC_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve this file's own dir portably: BASH_SOURCE under bash; under zsh
+# BASH_SOURCE is unset for a sourced file, so fall back to prompt-expansion %x
+# (the sourced file's path). Verified in both shells (CTL-618).
+__PEC_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
+__PEC_LIB_DIR="$(cd "$(dirname "$__PEC_SELF")" && pwd)"
 
 # canonical-event.sh provides build_canonical_line / canonical_jsonl_append /
 # derive_trace_id / derive_span_id / plugin_version.
@@ -35,13 +39,14 @@ __PEC_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${__PEC_LIB_DIR}/canonical-event.sh"
 
 emit_phase_complete() {
-  local phase="" ticket="" status="" reason="" payload="null"
+  # 'status' is a read-only special var in zsh ($?); use phase_status (CTL-618)
+  local phase="" ticket="" phase_status="" reason="" payload="null"
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --phase)        phase="$2"; shift 2 ;;
       --ticket)       ticket="$2"; shift 2 ;;
-      --status)       status="$2"; shift 2 ;;
+      --status)       phase_status="$2"; shift 2 ;;
       --reason)       reason="$2"; shift 2 ;;
       --payload-json) payload="${2:-null}"; shift 2 ;;
       *) echo "emit_phase_complete: unknown flag: $1" >&2; return 1 ;;
@@ -50,18 +55,18 @@ emit_phase_complete() {
 
   [[ -n "$phase"  ]] || { echo "emit_phase_complete: --phase required"  >&2; return 1; }
   [[ -n "$ticket" ]] || { echo "emit_phase_complete: --ticket required" >&2; return 1; }
-  [[ -n "$status" ]] || { echo "emit_phase_complete: --status required" >&2; return 1; }
+  [[ -n "$phase_status" ]] || { echo "emit_phase_complete: --status required" >&2; return 1; }
 
-  case "$status" in
+  case "$phase_status" in
     complete|failed|skipped|turn-cap-exhausted) ;;
     *) echo "emit_phase_complete: --status must be complete|failed|skipped|turn-cap-exhausted" >&2; return 1 ;;
   esac
 
   local severity="INFO" event_name
-  case "$status" in
+  case "$phase_status" in
     failed|turn-cap-exhausted) severity="WARN" ;;
   esac
-  event_name="phase.${phase}.${status}.${ticket}"
+  event_name="phase.${phase}.${phase_status}.${ticket}"
 
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
@@ -72,7 +77,7 @@ emit_phase_complete() {
 
   local message="$reason"
   if [[ -z "$message" ]]; then
-    case "$status" in
+    case "$phase_status" in
       complete)           message="Phase ${phase} complete on ${ticket}" ;;
       failed)             message="Phase ${phase} failed on ${ticket}" ;;
       skipped)            message="Phase ${phase} skipped on ${ticket}" ;;
@@ -100,7 +105,7 @@ emit_phase_complete() {
     --trace-id "$trace_id" \
     --span-id "$span_id" \
     --entity "phase" \
-    --action "$status" \
+    --action "$phase_status" \
     --linear-ticket "$ticket" \
     --orch "${CATALYST_ORCHESTRATOR_ID:-}" \
     --session "${CATALYST_SESSION_ID:-}" \
@@ -123,6 +128,8 @@ emit_phase_complete() {
 # When run as a script (not sourced), expose the function via CLI shimming so
 # downstream callers without bash-source semantics can still invoke it.
 # Detect script-mode by checking BASH_SOURCE[0] vs $0.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# Auto-run only when executed directly under bash (the shebang path). Under zsh
+# this file is always sourced and BASH_SOURCE is unset, so the guard is false.
+if [[ -n "${BASH_SOURCE:-}" && "${BASH_SOURCE[0]}" == "${0}" ]]; then
   emit_phase_complete "$@"
 fi


### PR DESCRIPTION
Fixes CTL-618. `phase-emit-complete.sh` used bash-4 constructs (`${BASH_SOURCE[0]}`, etc.) that break when sourced under the zsh Bash-tool, silently skipping the signal-flip + Linear mirror. This makes it zsh-safe.

Recovered + shepherded to PR manually during the 2026-05-26 execution-core cold-start recovery (worker had died at the verify→PR boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)