### PR TITLE
fix(dev): orchestrate-dispatch-next phase-fork bugs — phase-aware RUNNING count + stdin drain guard (CTL-605)

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -114,6 +114,17 @@ run_dispatch() {
 	"$DISPATCH" --orch-dir "$ORCH_DIR" "$@"
 }
 
+# make_phase_signal TICKET PHASE STATUS — seed a nested phase-mode signal at
+# workers/<T>/phase-<PHASE>.json so the phase-aware running counter (CTL-605
+# Bug 2) observes it.
+make_phase_signal() {
+	local t="$1" p="$2" s="$3"
+	mkdir -p "${ORCH_DIR}/workers/${t}"
+	jq -n --arg t "$t" --arg p "$p" --arg s "$s" --arg ts "$(now_iso)" \
+		'{ticket: $t, phase: $p, status: $s, updatedAt: $ts}' \
+		>"${ORCH_DIR}/workers/${t}/phase-${p}.json"
+}
+
 # ─── Test cases ───────────────────────────────────────────────────────────────
 
 echo "test 1: empty queue reports queueEmpty and exits 0"
@@ -695,6 +706,69 @@ for SF in "${PHASE_STDIN_DIR}"/stdin-*.log; do
 done
 [ "$LEAK_COUNT" = "0" ] && pass "no phase worker received leftover herestring on stdin" ||
 	fail "no phase worker received leftover herestring on stdin" "$LEAK_COUNT saw stdin content"
+scratch_teardown
+
+echo "test 35 (CTL-605 Bug 2): nested phase signals count toward RUNNING and enforce maxParallel"
+scratch_setup
+phase_agent_dispatch_setup
+CONFIG_PATH=$(write_config "phase-agents")
+write_state "demo" 2 '{"wave1Pending": ["NEW-1"]}'
+make_phase_signal "BUSY-A" "implement" "running"
+make_phase_signal "BUSY-B" "research" "running"
+make_worktree "demo" "NEW-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --config "$CONFIG_PATH" 2>"${SCRATCH}/err")
+RUNNING=$(echo "$OUT" | jq -r '.running')
+[ "$RUNNING" = "2" ] && pass "nested in-flight counted (running=2)" || fail "running=2" "got: $RUNNING"
+echo "$OUT" | jq -e '.slotsAfter == 0 and .dispatched == []' >/dev/null &&
+	pass "cap enforced — no dispatch when full" || fail "cap enforced" "got: $OUT"
+scratch_teardown
+
+echo "test 36 (CTL-605 Bug 2): monitor-deploy done frees the slot"
+scratch_setup
+phase_agent_dispatch_setup
+CONFIG_PATH=$(write_config "phase-agents")
+write_state "demo" 1 '{"wave1Pending": ["NEW-1"]}'
+make_phase_signal "SHIPPED" "monitor-deploy" "done"
+make_worktree "demo" "NEW-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --config "$CONFIG_PATH" 2>"${SCRATCH}/err")
+[ "$(echo "$OUT" | jq -r '.running')" = "0" ] && pass "monitor-deploy done not counted" || fail "monitor-deploy done not counted" "$OUT"
+[ "$(echo "$OUT" | jq -r '.dispatched | join(",")')" = "NEW-1" ] && pass "freed slot dispatched NEW-1" || fail "freed slot dispatched NEW-1" "$OUT"
+scratch_teardown
+
+echo "test 37 (CTL-605 Bug 2): mid-pipeline done (non-monitor) still holds slot"
+scratch_setup
+phase_agent_dispatch_setup
+CONFIG_PATH=$(write_config "phase-agents")
+write_state "demo" 1 '{"wave1Pending": ["NEW-1"]}'
+make_phase_signal "MIDWAY" "implement" "done" # done, but not monitor-deploy
+make_worktree "demo" "NEW-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --config "$CONFIG_PATH" 2>"${SCRATCH}/err")
+[ "$(echo "$OUT" | jq -r '.running')" = "1" ] && pass "mid-pipeline done still in-flight" || fail "mid-pipeline done still in-flight" "$OUT"
+echo "$OUT" | jq -e '.dispatched == []' >/dev/null && pass "cap held — NEW-1 not dispatched" || fail "cap held" "$OUT"
+scratch_teardown
+
+echo "test 38 (CTL-605 Bug 2): failed/stalled phase is terminal (frees slot)"
+scratch_setup
+phase_agent_dispatch_setup
+CONFIG_PATH=$(write_config "phase-agents")
+write_state "demo" 1 '{"wave1Pending": ["NEW-1"]}'
+make_phase_signal "BROKEN" "verify" "failed"
+make_worktree "demo" "NEW-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --config "$CONFIG_PATH" 2>"${SCRATCH}/err")
+[ "$(echo "$OUT" | jq -r '.running')" = "0" ] && pass "failed phase terminal" || fail "failed phase terminal" "$OUT"
+scratch_teardown
+
+echo "test 39 (CTL-605 Bug 2 / OQ2): single-ticket advance is NOT slot-gated when cap full"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 1 '{"wave1Pending": []}'
+make_phase_signal "ADV-1" "implement" "running" # cap=1 already full
+make_worktree "demo" "ADV-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "ADV-1" --phase "verify" 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "advance exits 0 despite full cap" || fail "advance exits 0" "rc=$RC err=$(cat "${SCRATCH}/err")"
+[ "$(echo "$OUT" | jq -r '.dispatched | join(",")')" = "ADV-1" ] && pass "advance dispatched despite full cap" || fail "advance dispatched" "$OUT"
+grep -q -- "--phase verify" "$PHASE_DISPATCH_LOG" && pass "phase-agent-dispatch called for verify" || fail "verify dispatched" "$(cat "$PHASE_DISPATCH_LOG")"
 scratch_teardown
 
 echo ""

--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -488,6 +488,42 @@ EOF
 	echo "${SCRATCH}/.catalyst/config.json"
 }
 
+# phase_agent_dispatch_drain_setup — like phase_agent_dispatch_setup, but the
+# stub also drains its own stdin to a per-pid file. This models the real bug:
+# phase-agent-dispatch synchronously launches `claude --bg` with fd 0 inherited,
+# which drains the dispatch loop's `done <<<"$PENDING"` herestring. With the leak
+# (missing </dev/null on the caller's command substitution) the leftover
+# `<wave>\t<ticket>` rows land in stdin-<pid>.log here and the outer loop stops
+# after the first ticket. Used by the CTL-605 Bug 1 regression test.
+phase_agent_dispatch_drain_setup() {
+	cat >"${SCRATCH}/bin/phase-agent-dispatch" <<'EOF'
+#!/usr/bin/env bash
+cat <&0 > "${PHASE_STDIN_DIR}/stdin-$$.log" 2>/dev/null || true
+echo "$@" >> "$PHASE_DISPATCH_LOG"
+ORCH_DIR=""; PHASE=""; TICKET=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --orch-dir) ORCH_DIR="$2"; shift 2 ;;
+    --phase)    PHASE="$2"; shift 2 ;;
+    --ticket)   TICKET="$2"; shift 2 ;;
+    *)          shift ;;
+  esac
+done
+if [ -n "$ORCH_DIR" ] && [ -n "$PHASE" ] && [ -n "$TICKET" ]; then
+  mkdir -p "${ORCH_DIR}/workers/${TICKET}"
+  echo "{\"ticket\":\"${TICKET}\",\"phase\":\"${PHASE}\",\"status\":\"dispatched\"}" \
+    > "${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+fi
+echo "{\"ticket\":\"${TICKET}\",\"phase\":\"${PHASE}\",\"bg_job_id\":\"fake-${TICKET}\",\"status\":\"running\"}"
+EOF
+	chmod +x "${SCRATCH}/bin/phase-agent-dispatch"
+	export PHASE_DISPATCH_LOG="${SCRATCH}/phase-dispatch.log"
+	: >"$PHASE_DISPATCH_LOG"
+	export PHASE_STDIN_DIR="${SCRATCH}/phase-stdin"
+	mkdir -p "$PHASE_STDIN_DIR"
+	export CATALYST_PHASE_AGENT_DISPATCH="${SCRATCH}/bin/phase-agent-dispatch"
+}
+
 echo "test 24 (CTL-452): --ticket without --phase exits 2"
 scratch_setup
 write_state "demo" 4 '{"wave1Pending": ["T-1"]}'
@@ -637,6 +673,28 @@ if ! grep -q "invalid dispatchMode" "${SCRATCH}/err"; then
 else
 	fail "no WARN for execution-core" "stderr=$(cat "${SCRATCH}/err")"
 fi
+scratch_teardown
+
+echo "test 34 (CTL-605 Bug 1): phase-agents multi-ticket wave dispatches all in one call; no stdin leak"
+scratch_setup
+phase_agent_dispatch_drain_setup
+CONFIG_PATH=$(write_config "phase-agents")
+write_state "demo" 4 '{"wave1Pending": ["T-1", "T-2", "T-3"]}'
+for T in T-1 T-2 T-3; do make_worktree "demo" "$T"; done
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --config "$CONFIG_PATH" 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | sort | join(",")')
+[ "$DISPATCHED" = "T-1,T-2,T-3" ] && pass "all 3 dispatched in one phase-agents call" ||
+	fail "all 3 dispatched in one phase-agents call" "got: $DISPATCHED (leak symptom: only first ticket)"
+LEAK_COUNT=0
+for SF in "${PHASE_STDIN_DIR}"/stdin-*.log; do
+	[ -e "$SF" ] || continue
+	if [ -s "$SF" ]; then
+		LEAK_COUNT=$((LEAK_COUNT + 1))
+		echo "    LEAK in $SF: $(head -c 200 "$SF")" >&2
+	fi
+done
+[ "$LEAK_COUNT" = "0" ] && pass "no phase worker received leftover herestring on stdin" ||
+	fail "no phase worker received leftover herestring on stdin" "$LEAK_COUNT saw stdin content"
 scratch_teardown
 
 echo ""

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -246,7 +246,20 @@ if [ -z "$SESSION_ID" ]; then
 fi
 
 # ─── Count non-terminal workers ───────────────────────────────────────────────
+# CTL-605: count BOTH signal layouts.
+#   • Legacy flat   workers/<T>.json         — one signal == one ticket
+#   • Phase-mode    workers/<T>/phase-*.json — a pipeline of phases per ticket
+# A ticket holds a parallelism slot until its pipeline reaches a terminal
+# end-state. For the nested layout we mirror execution-core/scheduler.mjs
+# isTicketInFlight (scheduler.mjs:90-103), the proven phase-aware predicate:
+# terminal when any phase is failed/stalled/aborted, or monitor-deploy is
+# done/skipped; in-flight otherwise — INCLUDING a non-monitor `done` whose next
+# phase signal isn't written yet (mid-pipeline gap). This intentionally differs
+# from the flat loop's "any done is terminal" rule, which is correct for the
+# one-signal-per-ticket legacy layout.
 RUNNING=0
+
+# Legacy flat layout (unchanged).
 for SIGNAL in "$ORCH_DIR/workers/"*.json; do
 	[ -f "$SIGNAL" ] || continue
 	S=$(jq -r '.status // ""' "$SIGNAL" 2>/dev/null)
@@ -256,8 +269,35 @@ for SIGNAL in "$ORCH_DIR/workers/"*.json; do
 	esac
 done
 
+# Phase-mode nested layout (CTL-605 Bug 2).
+for WDIR in "$ORCH_DIR/workers/"*/; do
+	[ -d "$WDIR" ] || continue
+	HAS_PHASE=0
+	TERMINAL=0
+	for PF in "$WDIR"phase-*.json; do
+		[ -f "$PF" ] || continue
+		HAS_PHASE=1
+		PNAME=$(basename "$PF" .json)
+		PNAME=${PNAME#phase-}
+		PS=$(jq -r '.status // ""' "$PF" 2>/dev/null)
+		case "$PS" in
+		failed | stalled | aborted) TERMINAL=1 ;;
+		esac
+		if [ "$PNAME" = "monitor-deploy" ]; then
+			case "$PS" in done | skipped) TERMINAL=1 ;; esac
+		fi
+	done
+	[ "$HAS_PHASE" -eq 1 ] || continue
+	[ "$TERMINAL" -eq 1 ] && continue
+	RUNNING=$((RUNNING + 1))
+done
+
 SLOTS=$((MAX_PARALLEL - RUNNING))
-if [ "$SLOTS" -le 0 ]; then
+# CTL-605 (OQ2): the cap admits NEW tickets (wave fill). Single-ticket
+# phase-advance (--ticket --phase) advances an already-in-flight ticket and keeps
+# the in-flight count constant, so it must never be slot-gated — otherwise
+# advancement deadlocks once the cap is full. Skip the gate in single-ticket mode.
+if [ -z "$SINGLE_TICKET" ] && [ "$SLOTS" -le 0 ]; then
 	printf '{"running":%d,"slotsAfter":0,"dispatched":[]}\n' "$RUNNING"
 	exit 0
 fi
@@ -311,7 +351,8 @@ fi
 DISPATCHED=()
 while IFS=$'\t' read -r W T; do
 	[ -z "$T" ] && continue
-	[ "$SLOTS" -le 0 ] && break
+	# CTL-605 (OQ2): single-ticket advance is never slot-gated (see RUNNING count).
+	[ -z "$SINGLE_TICKET" ] && [ "$SLOTS" -le 0 ] && break
 
 	WORKER_DIR="${WORKTREE_BASE}/${ORCH_ID}-${T}"
 
@@ -373,12 +414,13 @@ while IFS=$'\t' read -r W T; do
 		# Intentional divergence from the legacy path (see comment at signal-file
 		# selection above): we do NOT bump `.progress.inProgressTickets` here
 		# because a single ticket may dispatch through multiple phases — the
-		# legacy counter assumes one dispatch per ticket. Likewise the RUNNING
-		# count loop at line 154 globs `workers/*.json` and won't see phase-mode
-		# signals at `workers/<T>/phase-<name>.json`. Both divergences are
-		# acceptable in the MVP because phase-mode and legacy-mode never run
-		# against the same wave; the orchestrator state-machine rewrite in
-		# Initiative 1 Phase 6 reconciles both surfaces.
+		# legacy counter assumes one dispatch per ticket. (CTL-605 fixed the other
+		# former divergence: the RUNNING count loop above now also enumerates the
+		# nested workers/<T>/phase-*.json layout, so phase-mode parallelism is
+		# enforced.) The remaining inProgressTickets divergence is acceptable in
+		# the MVP because phase-mode and legacy-mode never run against the same
+		# wave; the orchestrator state-machine rewrite in Initiative 1 Phase 6
+		# reconciles both surfaces.
 		"$STATE_SCRIPT" worker "$ORCH_ID" "$T" '.status = "dispatched" | .phase = "'"$PHASE"'"' >/dev/null 2>&1 || true
 		"$STATE_SCRIPT" event "$(jq -nc \
 			--arg ts "$(now_iso)" --arg orch "$ORCH_ID" --arg w "$T" --arg phase "$PHASE" \

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -348,6 +348,10 @@ while IFS=$'\t' read -r W T; do
 		# on prior phase artifacts, and runs `claude --bg`. We capture its stdout
 		# JSON so we can mirror dispatch state to the global state script the
 		# same way the legacy path does.
+		# </dev/null (CTL-605): phase-agent-dispatch launches `claude --bg` with
+		# fd 0 inherited; without this the bg job drains the dispatch loop's
+		# `done <<<"$PENDING"` herestring and only one ticket dispatches per call.
+		# Same root cause as the legacy path's guard at line ~454 (CTL-334).
 		PHASE_STDOUT=$(
 			cd "$WORKER_DIR" || exit 1
 			CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
@@ -357,7 +361,7 @@ while IFS=$'\t' read -r W T; do
 				--phase "$PHASE" \
 				--ticket "$T" \
 				--orch-dir "$ORCH_DIR" \
-				--orch-id "$ORCH_ID"
+				--orch-id "$ORCH_ID" </dev/null
 		) || {
 			echo "phase-agent-dispatch failed for $T phase=$PHASE — see stderr" >&2
 			continue

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -517,9 +517,12 @@ trap 'rm -f "$BG_OUT" "$BG_ERR"' EXIT
 # function the reap path uses for `claude stop`. CATALYST_DISPATCH_CLAUDE_BIN
 # still overrides it, so existing tests and tooling are unaffected.
 CLAUDE_BIN="$(executor_claude_bin)"
+# </dev/null (CTL-605): `claude --bg` reads stdin; redirect it so a caller that
+# invokes us from inside a herestring/`while read` loop can't have its loop
+# stdin drained. Harmless for normal callers (fd 0 already a tty/pipe).
 env "${DISPATCH_ENV[@]}" \
 	"$CLAUDE_BIN" --bg --dangerously-skip-permissions --model "$MODEL" "$PROMPT" \
-	>"$BG_OUT" 2>"$BG_ERR"
+	>"$BG_OUT" 2>"$BG_ERR" </dev/null
 RC=$?
 
 if [[ $RC -ne 0 ]]; then


### PR DESCRIPTION
Recovered + shepherded to PR manually during the 2026-05-26 execution-core cold-start recovery (worker died after committing). Implements CTL-605; see ticket for full spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)