### PR TITLE
feat(dev): Linear state TTL cache for execution-core daemon (CTL-634)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -20,6 +20,7 @@ import {
   startScheduler,
   stopScheduler,
   reconcileAll,
+  createTicketStateCache,
 } from "./index.mjs";
 
 const DEFAULT_MAX_PARALLEL = 3;
@@ -81,14 +82,19 @@ export function startDaemon({
   // try/catch logs and process.exit(1)s as before.
   try {
     recover({ orchDir }); // CTL-539 — rebuild routing + worker state on boot
+    // CTL-634: one shared TTL state cache. The monitor write-through populates
+    // it on every state_changed event; the scheduler read path consults it
+    // during out-of-set blocker hydration. A single instance threaded into
+    // both is what turns a write-through into a guaranteed next-tick hit.
+    const cache = createTicketStateCache();
     // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
     // agent on a →Triage transition. `dispatch` stays an injectable default
     // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
-    monitorFn({ orchDir }); // CTL-535 + CTL-565 — two-state trigger monitor
+    monitorFn({ orchDir, cache }); // CTL-535 + CTL-565 + CTL-634
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.
-    schedulerFn({ orchDir }); // CTL-536 — pull-loop scheduler
+    schedulerFn({ orchDir, cache }); // CTL-536 + CTL-634 — pull-loop scheduler
 
     if (watchRegistry) {
       // Watch the execution-core dir for registry.json changes — the registry is

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -48,6 +48,27 @@ describe("startDaemon", () => {
     expect(calls[0][1]).toBe(calls[2][1]);
   });
 
+  // CTL-634: one cache instance is created in startDaemon and threaded into
+  // BOTH composed boots, so the monitor's write-through and the scheduler's
+  // read path share state. Capture each boot's `cache` arg and assert identity.
+  test("constructs one cache and passes the SAME instance to monitor and scheduler", () => {
+    let monitorCache;
+    let schedulerCache;
+    startDaemon({
+      recover: () => {},
+      startMonitor: (o) => {
+        monitorCache = o.cache;
+      },
+      startScheduler: (o) => {
+        schedulerCache = o.cache;
+      },
+      watchRegistry: false,
+    });
+    expect(monitorCache).toBeDefined();
+    expect(typeof monitorCache.get).toBe("function"); // it's a cache instance
+    expect(schedulerCache).toBe(monitorCache); // same instance, not two
+  });
+
   test("ensures a machine-level state.json with a default maxParallel", () => {
     startDaemon({
       recover: () => {},

--- a/plugins/dev/scripts/execution-core/index.mjs
+++ b/plugins/dev/scripts/execution-core/index.mjs
@@ -15,6 +15,10 @@ import { makeScanAdapters } from "./scan-adapters.mjs";
 export * from "./config.mjs";
 export * from "./registry.mjs";
 export * from "./linear-query.mjs";
+// CTL-634: the Tier 1 TTL state cache, shared by the monitor write-through and
+// the scheduler read path. daemon.mjs imports createTicketStateCache from this
+// barrel alongside its other deps.
+export * from "./linear-cache.mjs";
 export * from "./eligible-set.mjs";
 // CTL-565: the shared worker-dispatch adapter (D9 executor seam) and the
 // kill-on-drag-out abort module.

--- a/plugins/dev/scripts/execution-core/linear-cache.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cache.mjs
@@ -1,0 +1,48 @@
+// linear-cache.mjs — in-process TTL cache for single-ticket Linear state reads
+// (CTL-634 Tier 1). One instance is created by startDaemon and shared by the
+// scheduler's out-of-set blocker hydration (read path) and the monitor's
+// state_changed handler (write-through). Cuts `linearis issues read` calls the
+// scheduler would otherwise re-issue every tick for the same blocker.
+//
+// Per-instance state (no module globals) so unit tests need no reset hook.
+// `now` and `ttlMs` are injected; the daemon uses the defaults. NEVER caches a
+// null/undefined value — a failed `linearis issues read` must stay un-cached so
+// the D5 fail-safe sentinel (UNFETCHED_BLOCKER_STATE) is never poisoned and a
+// recovered blocker is re-read promptly.
+
+// Default 60 s TTL; env-overridable to match the SCHEDULER_*_MS env idiom.
+const DEFAULT_TTL_MS = Number(process.env.LINEAR_STATE_CACHE_TTL_MS) || 60_000;
+
+export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS } = {}) {
+  const entries = new Map(); // identifier -> { state, expiresAt }
+  let hits = 0;
+  let misses = 0;
+
+  function get(identifier) {
+    const entry = entries.get(identifier);
+    if (entry && entry.expiresAt > now()) {
+      hits += 1;
+      return entry.state;
+    }
+    if (entry) entries.delete(identifier); // expired — drop eagerly
+    misses += 1;
+    return undefined;
+  }
+
+  function set(identifier, state) {
+    // Fail-safe: never cache a missing state. A null fetch must re-read.
+    if (state == null) return;
+    entries.set(identifier, { state, expiresAt: now() + ttlMs });
+  }
+
+  function invalidate(identifier) {
+    entries.delete(identifier);
+  }
+
+  function stats() {
+    const total = hits + misses;
+    return { hits, misses, hitRate: total === 0 ? 0 : hits / total };
+  }
+
+  return { get, set, invalidate, stats };
+}

--- a/plugins/dev/scripts/execution-core/linear-cache.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cache.test.mjs
@@ -1,0 +1,84 @@
+// Unit tests for the in-process TTL cache primitive (CTL-634 Tier 1).
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-cache.test.mjs
+//
+// The cache is the single-ticket-state read cache shared by the scheduler's
+// out-of-set blocker hydration and the monitor's state_changed write-through.
+// Time is controlled with an injectable numeric `now` — the only time-control
+// pattern in the repo (no fake-timer lib), per scheduler.test.mjs:282-288.
+
+import { describe, it, expect } from "bun:test";
+import { createTicketStateCache } from "./linear-cache.mjs";
+
+describe("createTicketStateCache", () => {
+  it("returns undefined on a cold miss", () => {
+    const c = createTicketStateCache({ now: () => 1000 });
+    expect(c.get("CTL-1")).toBeUndefined();
+  });
+
+  it("returns a set value within the TTL window", () => {
+    let t = 1000;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 60_000 });
+    c.set("CTL-1", "Done");
+    t = 1000 + 59_000;
+    expect(c.get("CTL-1")).toBe("Done");
+  });
+
+  it("expires a value past the TTL window (returns undefined)", () => {
+    let t = 1000;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 60_000 });
+    c.set("CTL-1", "Done");
+    t = 1000 + 60_001;
+    expect(c.get("CTL-1")).toBeUndefined();
+  });
+
+  it("set refreshes the expiry (write-through resets TTL)", () => {
+    let t = 0;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 60_000 });
+    c.set("CTL-1", "Ready");
+    t = 59_000;
+    c.set("CTL-1", "PR"); // write-through at 59s
+    t = 100_000; // 41s after the refresh — still fresh
+    expect(c.get("CTL-1")).toBe("PR");
+  });
+
+  it("invalidate drops an entry", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.set("CTL-1", "Done");
+    c.invalidate("CTL-1");
+    expect(c.get("CTL-1")).toBeUndefined();
+  });
+
+  it("never stores null or undefined (fail-safe: a failed read is not cacheable)", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.set("CTL-1", null);
+    c.set("CTL-2", undefined);
+    expect(c.get("CTL-1")).toBeUndefined();
+    expect(c.get("CTL-2")).toBeUndefined();
+  });
+
+  it("stats counts hits and misses and computes hitRate", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.get("CTL-1"); // miss
+    c.set("CTL-1", "Done");
+    c.get("CTL-1"); // hit
+    c.get("CTL-1"); // hit
+    const s = c.stats();
+    expect(s.hits).toBe(2);
+    expect(s.misses).toBe(1);
+    expect(s.hitRate).toBeCloseTo(2 / 3, 5);
+  });
+
+  it("an expired get counts as a miss", () => {
+    let t = 0;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 1000 });
+    c.set("CTL-1", "Done");
+    t = 2000;
+    expect(c.get("CTL-1")).toBeUndefined();
+    expect(c.stats().misses).toBe(1);
+  });
+
+  it("hitRate is 0 when there are zero lookups (no divide-by-zero)", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    expect(c.stats().hitRate).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -77,14 +77,26 @@ function normalizeTicket(node) {
 // JSON by default (its CLI header: "CLI for Linear.app with JSON output") so
 // there is NO --json flag to pass. Used to hydrate out-of-set blocker states
 // the bulk eligible query cannot see. CTL-565 D5.
-export function fetchTicketState(identifier, { exec = defaultExec } = {}) {
+// CTL-634: an opt-in `cache` (createTicketStateCache) deduplicates the
+// per-tick re-reads the scheduler issues for the same out-of-set blocker.
+// Consult before exec; populate only on a successful, non-null parse. A
+// failed/unparseable read is NEVER cached so the D5 fail-safe re-reads next
+// tick. The param is opt-in — callers that omit it exec on every call exactly
+// as before.
+export function fetchTicketState(identifier, { exec = defaultExec, cache } = {}) {
+  if (cache) {
+    const cached = cache.get(identifier);
+    if (cached !== undefined) return cached; // hit
+  }
   const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
-  if (code !== 0) return null;
+  if (code !== 0) return null; // fail-safe — not cached
   try {
     const node = JSON.parse(stdout);
-    return node?.state?.name ?? node?.state ?? null;
+    const state = node?.state?.name ?? node?.state ?? null;
+    if (cache && state != null) cache.set(identifier, state); // populate on success only
+    return state;
   } catch {
-    return null;
+    return null; // unparseable — not cached
   }
 }
 

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -8,6 +8,7 @@ import {
   fetchTicketState,
   fetchTicketLabels,
 } from "./linear-query.mjs";
+import { createTicketStateCache } from "./linear-cache.mjs";
 
 // A fake exec returning a canned linearis result. `exec(cmd, args)` ->
 // { code, stdout, stderr } — the injectable seam runEligibleQuery uses so a
@@ -269,5 +270,45 @@ describe("fetchTicketLabels", () => {
     fetchTicketLabels("CTL-9", { exec });
     expect(calls[0].cmd).toBe("linearis");
     expect(calls[0].args).toEqual(["issues", "read", "CTL-9"]);
+  });
+});
+
+// CTL-634 Tier 1 — fetchTicketState consults/populates an opt-in cache. The
+// cache is opt-in so the four tests above (which omit it) are unchanged; a
+// failed read is NEVER cached so the D5 fail-safe re-reads next call.
+describe("fetchTicketState — cache (CTL-634)", () => {
+  test("serves a second read from cache without a second exec", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    let calls = 0;
+    const exec = () => {
+      calls += 1;
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Done" } }), stderr: "" };
+    };
+    expect(fetchTicketState("CTL-1", { exec, cache })).toBe("Done");
+    expect(fetchTicketState("CTL-1", { exec, cache })).toBe("Done");
+    expect(calls).toBe(1); // second read was a cache hit
+  });
+
+  test("does NOT cache a failed read (null) — re-execs next call (fail-safe)", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    let calls = 0;
+    const exec = () => {
+      calls += 1;
+      return { code: 1, stdout: "", stderr: "boom" };
+    };
+    expect(fetchTicketState("CTL-1", { exec, cache })).toBeNull();
+    expect(fetchTicketState("CTL-1", { exec, cache })).toBeNull();
+    expect(calls).toBe(2); // null never cached → both calls hit exec
+  });
+
+  test("without a cache, behaves exactly as before (every call execs)", () => {
+    let calls = 0;
+    const exec = () => {
+      calls += 1;
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Ready" } }), stderr: "" };
+    };
+    fetchTicketState("CTL-1", { exec });
+    fetchTicketState("CTL-1", { exec });
+    expect(calls).toBe(2);
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -13,12 +13,7 @@
 
 import { watch, openSync, fstatSync, readSync, closeSync, mkdirSync, existsSync } from "node:fs";
 import { dirname, basename, join } from "node:path";
-import {
-  getEventLogPath,
-  RECONCILE_INTERVAL_MS,
-  EVENT_DEBOUNCE_MS,
-  log,
-} from "./config.mjs";
+import { getEventLogPath, RECONCILE_INTERVAL_MS, EVENT_DEBOUNCE_MS, log } from "./config.mjs";
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import { runEligibleQuery } from "./linear-query.mjs";
 import { setProjectEligible, removeTicket, dropProject } from "./eligible-set.mjs";
@@ -49,10 +44,7 @@ export function parseStateChangedEvent(event) {
   if (name !== "linear.issue.state_changed") return null;
   const payload = event?.body?.payload ?? event?.detail ?? {};
   const identifier =
-    event?.attributes?.["linear.issue.identifier"] ??
-    payload.ticket ??
-    payload.identifier ??
-    null;
+    event?.attributes?.["linear.issue.identifier"] ?? payload.ticket ?? payload.identifier ?? null;
   if (!identifier) return null;
   return {
     identifier,
@@ -84,10 +76,7 @@ export function reconcileProject(team, { exec } = {}) {
   try {
     tickets = runEligibleQuery(query, { exec });
   } catch (err) {
-    log.error(
-      { team, err: err.message },
-      "reconcile poll failed — preserving prior eligible set",
-    );
+    log.error({ team, err: err.message }, "reconcile poll failed — preserving prior eligible set");
     return;
   }
   try {
@@ -101,7 +90,7 @@ export function reconcileProject(team, { exec } = {}) {
     // reconcile tick retries the disk write.
     log.error(
       { team, err: err.message },
-      "eligible-set projection write failed — daemon continues, retry next reconcile",
+      "eligible-set projection write failed — daemon continues, retry next reconcile"
     );
   }
 }
@@ -151,10 +140,17 @@ export function handleStateChangedEvent(
     dispatch,
     orchDir,
     abortWorker = defaultAbortWorker,
-  } = {},
+    cache, // CTL-634: write-through target shared with the scheduler read path
+  } = {}
 ) {
   const parsed = parseStateChangedEvent(event);
   if (!parsed) return;
+  // CTL-634: write-through — refresh the cached state so the next scheduler
+  // tick's out-of-set blocker hydration is a hit instead of a re-read. set()
+  // ignores a null toState, so an event without an extractable state is a safe
+  // no-op. Runs before the project loop because the cache is keyed by ticket
+  // identifier, independent of which project's eligible set the event touches.
+  if (cache) cache.set(parsed.identifier, parsed.toState);
   for (const p of listProjects()) {
     const query = resolveEligibleQuery(p);
     if (query.team !== parsed.teamKey) continue;
@@ -207,7 +203,7 @@ export function handleStateChangedEvent(
       // CTL-584.
       log.debug(
         { ticket: parsed.identifier, toState: parsed.toState },
-        "monitor: non-trigger toState — no-op",
+        "monitor: non-trigger toState — no-op"
       );
     }
   }
@@ -241,7 +237,7 @@ function scheduleDirtyReconcile(team, { exec, debounceMs }) {
     setTimeout(() => {
       dirtyTimers.delete(team);
       reconcileProject(team, { exec });
-    }, debounceMs),
+    }, debounceMs)
   );
 }
 
@@ -375,12 +371,15 @@ export function startMonitor({
   orchDir,
   dispatch,
   abortWorker,
+  cache, // CTL-634: shared state cache for event-driven write-through
 } = {}) {
   // CTL-565: orchDir + dispatch + abortWorker are stored in tailerOpts so the
   // tailer-driven readNewEvents → handleStateChangedEvent path can one-shot-
   // dispatch triage and abort a dragged-out worker. When abortWorker is left
   // undefined, handleStateChangedEvent falls back to its real default.
-  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker };
+  // CTL-634: cache rides in tailerOpts too so the tailer's write-through path
+  // populates the same instance the scheduler reads.
+  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker, cache };
   reconcileAll({ exec });
   if (resumeFromCursor) {
     seedTailerFromCursor();

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -6,14 +6,7 @@
 // per-repo enrollment records are gone.
 
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
-import {
-  mkdtempSync,
-  rmSync,
-  mkdirSync,
-  writeFileSync,
-  appendFileSync,
-  statSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -30,6 +23,8 @@ import {
 } from "./monitor.mjs";
 import { setProjectEligible, getEligibleSet, dropProject } from "./eligible-set.mjs";
 import { loadCursor, saveCursor } from "./event-cursor.mjs";
+import { createTicketStateCache } from "./linear-cache.mjs";
+import { fetchTicketState } from "./linear-query.mjs";
 
 let catalystDir;
 let prevCatalystDir;
@@ -62,7 +57,7 @@ afterEach(() => {
 function writeRegistry() {
   writeFileSync(
     join(catalystDir, "execution-core", "registry.json"),
-    JSON.stringify({ projects: registryEntries }, null, 2),
+    JSON.stringify({ projects: registryEntries }, null, 2)
   );
 }
 
@@ -143,7 +138,7 @@ describe("parseStateChangedEvent", () => {
       parseStateChangedEvent({
         attributes: { "event.name": "linear.issue.state_changed" },
         body: { payload: { teamKey: "ENG", toState: "Todo" } },
-      }),
+      })
     ).toBeNull();
   });
 });
@@ -201,7 +196,7 @@ describe("handleStateChangedEvent", () => {
         event: "linear.issue.state_changed",
         detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Todo" },
       },
-      { exec, debounceMs: 30 },
+      { exec, debounceMs: 30 }
     );
     expect(exec.calls).toBe(0); // not polled synchronously
     await sleep(70);
@@ -218,7 +213,7 @@ describe("handleStateChangedEvent", () => {
           event: "linear.issue.state_changed",
           detail: { ticket, teamKey: "ENG", toState: "Todo" },
         },
-        { exec, debounceMs: 30 },
+        { exec, debounceMs: 30 }
       );
     }
     await sleep(80);
@@ -237,7 +232,7 @@ describe("handleStateChangedEvent", () => {
         event: "linear.issue.state_changed",
         detail: { ticket: "OTHER-1", teamKey: "OTHER", toState: "In Progress" },
       },
-      { exec, debounceMs: 30 },
+      { exec, debounceMs: 30 }
     );
     await sleep(60);
     expect(exec.calls).toBe(0);
@@ -258,7 +253,7 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
         event: "linear.issue.state_changed",
         detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
       },
-      { dispatch, orchDir },
+      { dispatch, orchDir }
     );
     expect(dispatch).toHaveBeenCalledWith({ orchDir, ticket: "ENG-1", phase: "triage" });
   });
@@ -274,7 +269,7 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
         event: "linear.issue.state_changed",
         detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Ready" },
       },
-      { exec, dispatch, orchDir: realOrchDir, debounceMs: 30 },
+      { exec, dispatch, orchDir: realOrchDir, debounceMs: 30 }
     );
     expect(dispatch).not.toHaveBeenCalled();
     await sleep(70);
@@ -291,7 +286,7 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
         event: "linear.issue.state_changed",
         detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Ready" },
       },
-      { exec, dispatch, orchDir: realOrchDir, debounceMs: 30 },
+      { exec, dispatch, orchDir: realOrchDir, debounceMs: 30 }
     );
     expect(dispatch).toHaveBeenCalledWith({
       orchDir: realOrchDir,
@@ -311,8 +306,8 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
           event: "linear.issue.state_changed",
           detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Ready" },
         },
-        { exec, dispatch, debounceMs: 30 }, // no orchDir
-      ),
+        { exec, dispatch, debounceMs: 30 } // no orchDir
+      )
     ).not.toThrow();
     expect(dispatch).not.toHaveBeenCalled();
     await sleep(70);
@@ -336,7 +331,7 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
         detail: { ticket: "ENG-1", teamKey: "ENG", toState },
       });
       expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-2"]);
-    },
+    }
   );
 
   test("a triage dispatch failure is logged and never throws", () => {
@@ -348,8 +343,8 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
           event: "linear.issue.state_changed",
           detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
         },
-        { dispatch, orchDir },
-      ),
+        { dispatch, orchDir }
+      )
     ).not.toThrow();
   });
 
@@ -362,8 +357,8 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
           event: "linear.issue.state_changed",
           detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
         },
-        { dispatch },
-      ),
+        { dispatch }
+      )
     ).not.toThrow();
     expect(dispatch).not.toHaveBeenCalled();
   });
@@ -382,12 +377,12 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
           event: "linear.issue.state_changed",
           detail: { ticket: "ENG-1", teamKey: "ENG", toState },
         },
-        { orchDir, abortWorker },
+        { orchDir, abortWorker }
       );
       expect(abortWorker).toHaveBeenCalledWith("/orch", "ENG-1", {
         repoRoot: expect.any(String),
       });
-    },
+    }
   );
 
   test("a drag-out with no orchDir wired removes the ticket and does not throw", () => {
@@ -399,8 +394,8 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
           event: "linear.issue.state_changed",
           detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Backlog" },
         },
-        { abortWorker },
-      ),
+        { abortWorker }
+      )
     ).not.toThrow();
     expect(abortWorker).not.toHaveBeenCalled(); // no orchDir → abort skipped
   });
@@ -425,12 +420,12 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
           event: "linear.issue.state_changed",
           detail: { ticket: "ENG-1", teamKey: "ENG", toState },
         },
-        { orchDir, abortWorker, dispatch },
+        { orchDir, abortWorker, dispatch }
       );
       expect(abortWorker).not.toHaveBeenCalled();
       expect(dispatch).not.toHaveBeenCalled();
       expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-1", "ENG-2"]);
-    },
+    }
   );
 
   // CTL-584: an unknown toState is conservatively treated as a no-op — a
@@ -448,7 +443,7 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
         event: "linear.issue.state_changed",
         detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Mystery" },
       },
-      { orchDir, abortWorker },
+      { orchDir, abortWorker }
     );
     expect(abortWorker).not.toHaveBeenCalled();
     expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-1"]);
@@ -486,7 +481,7 @@ describe("lifecycle", () => {
         event: "linear.issue.state_changed",
         detail: { ticket: "ENG-9", teamKey: "ENG", toState: "Todo" },
       },
-      { exec, debounceMs: 40 },
+      { exec, debounceMs: 40 }
     );
     stopMonitor(); // clears the queued debounce timer
     await sleep(80);
@@ -578,7 +573,7 @@ describe("startMonitor — resumeFromCursor", () => {
       `${JSON.stringify({
         event: "linear.issue.state_changed",
         detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Backlog" },
-      })}\n`,
+      })}\n`
     );
     saveCursor({ logPath: eventLogPath(), byteOffset: 0 });
     startMonitor({ exec, resumeFromCursor: true, reconcileIntervalMs: 60_000 });
@@ -596,10 +591,47 @@ describe("startMonitor — resumeFromCursor", () => {
         // new model (not a leave-trigger), so we use Canceled here to drive
         // the gap-drain removal.
         detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Canceled" },
-      })}\n`,
+      })}\n`
     );
     saveCursor({ logPath: eventLogPath(), byteOffset: 0 });
     startMonitor({ exec, reconcileIntervalMs: 60_000 }); // no resumeFromCursor
     expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-2"]);
+  });
+});
+
+// CTL-634 Tier 1 — every state_changed event write-through-refreshes the
+// cached state so the next scheduler tick's out-of-set blocker hydration is a
+// hit instead of a re-read. The write-through runs before the project loop, so
+// it needs no enrolled team — set() ignores a null toState, making an event
+// with no extractable state a safe no-op.
+describe("handleStateChangedEvent — cache write-through (CTL-634)", () => {
+  test("writes the toState into the cache so a later read is a hit (zero exec)", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "CTL-99", teamKey: "ENG", toState: "Done" },
+      },
+      { cache }
+    );
+    let calls = 0;
+    const execProbe = () => {
+      calls += 1;
+      return { code: 0, stdout: "{}", stderr: "" };
+    };
+    expect(fetchTicketState("CTL-99", { exec: execProbe, cache })).toBe("Done");
+    expect(calls).toBe(0); // served entirely from the written-through cache
+  });
+
+  test("a missing toState does not write a bogus cache entry", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "CTL-99", teamKey: "ENG" }, // no toState
+      },
+      { cache }
+    );
+    expect(cache.get("CTL-99")).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -13,7 +13,15 @@
 // Composes: lib/dependency-graph.mjs (readiness), scheduler-rank.mjs (ranking),
 // lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
 
-import { readdirSync, readFileSync, writeFileSync, existsSync, watch, mkdirSync, rmSync } from "node:fs";
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  watch,
+  mkdirSync,
+  rmSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join, dirname, basename } from "node:path";
 import { analyzeDependencyGraph, referencedBlockerIds } from "../lib/dependency-graph.mjs";
@@ -170,16 +178,19 @@ const UNFETCHED_BLOCKER_STATE = "__unfetched__";
 // live Linear state once, and return a { identifier: stateName } map. A failed
 // fetch yields the non-terminal UNFETCHED_BLOCKER_STATE sentinel so the
 // dependent is held back — failing safe. CTL-565 D5.
+// CTL-634: the opt-in `cache` is threaded into each fetchState call so the
+// same out-of-set blocker is read at most once per TTL window across ticks.
+// Absent the cache, every tick re-reads (the pre-CTL-634 behavior).
 export function hydrateOutOfSetBlockers(
   eligibleTickets,
-  { exec, fetchState = fetchTicketState } = {},
+  { exec, fetchState = fetchTicketState, cache } = {}
 ) {
   const list = eligibleTickets ?? [];
   const inSet = new Set(list.map((t) => t?.identifier).filter(Boolean));
   const externalBlockers = referencedBlockerIds(list).filter((id) => !inSet.has(id));
   const blockerStates = {};
   for (const id of externalBlockers) {
-    const state = fetchState(id, { exec });
+    const state = fetchState(id, { exec, cache });
     blockerStates[id] = state ?? UNFETCHED_BLOCKER_STATE; // non-terminal → fails safe
   }
   return blockerStates;
@@ -328,14 +339,14 @@ export function recordDispatchFailure(orchDir, ticket, phase, code, now) {
     mkdirSync(dir, { recursive: true });
     writeFileSync(
       dispatchCooldownPath(orchDir, ticket, phase),
-      JSON.stringify({ phase, code, failedAt: now }),
+      JSON.stringify({ phase, code, failedAt: now })
     );
   } catch (err) {
     // Never let a marker write crash the tick — worst case is the next tick
     // retries (the pre-CTL-624 behavior).
     log.warn(
       { ticket, phase, err: err.message },
-      "scheduler: dispatch cool-down marker write failed — continuing",
+      "scheduler: dispatch cool-down marker write failed — continuing"
     );
   }
 }
@@ -369,13 +380,11 @@ export function preflightWorkspaceLabels({
   if (!Array.isArray(teams) || teams.length === 0) return;
   for (const team of teams) {
     try {
-      const { code, stdout, stderr } = exec("linearis", [
-        "labels", "list", "--team", team,
-      ]);
+      const { code, stdout, stderr } = exec("linearis", ["labels", "list", "--team", team]);
       if (code !== 0) {
         logger.info(
           { team, code, stderr },
-          "scheduler: workspace-label preflight skipped — linearis labels list failed",
+          "scheduler: workspace-label preflight skipped — linearis labels list failed"
         );
         continue;
       }
@@ -389,7 +398,7 @@ export function preflightWorkspaceLabels({
       } catch (err) {
         logger.info(
           { team, err: err.message },
-          "scheduler: workspace-label preflight skipped — linearis stdout is not JSON",
+          "scheduler: workspace-label preflight skipped — linearis stdout is not JSON"
         );
         continue;
       }
@@ -398,14 +407,14 @@ export function preflightWorkspaceLabels({
         if (!present.has(label)) {
           logger.warn(
             { team, label },
-            "scheduler: Linear workspace is missing required label — create it in the Linear UI; the label sweep will skip this label for this run",
+            "scheduler: Linear workspace is missing required label — create it in the Linear UI; the label sweep will skip this label for this run"
           );
         }
       }
     } catch (err) {
       logger.info(
         { team, err: err.message },
-        "scheduler: workspace-label preflight threw — swallowed",
+        "scheduler: workspace-label preflight threw — swallowed"
       );
     }
   }
@@ -435,7 +444,7 @@ function teardownWorktreeOnce(orchDir, ticket, teardownWorktree) {
     // restored registry entry is retried on a later tick.
     log.warn(
       { ticket },
-      "scheduler: worktree teardown deferred — ticket's team has no registry entry",
+      "scheduler: worktree teardown deferred — ticket's team has no registry entry"
     );
     return;
   }
@@ -444,10 +453,7 @@ function teardownWorktreeOnce(orchDir, ticket, teardownWorktree) {
       writeFileSync(marker, "");
     }
   } catch (err) {
-    log.warn(
-      { ticket, err: err.message },
-      "scheduler: worktree teardown threw — continuing tick",
-    );
+    log.warn({ ticket, err: err.message }, "scheduler: worktree teardown threw — continuing tick");
   }
 }
 
@@ -476,7 +482,7 @@ function terminalDoneOnce(orchDir, ticket, writeStatus) {
   } catch (err) {
     log.warn(
       { ticket, err: err.message },
-      "scheduler: terminal-Done write-back threw — continuing tick",
+      "scheduler: terminal-Done write-back threw — continuing tick"
     );
   }
 }
@@ -497,7 +503,8 @@ export function schedulerTick(
     teardownWorktree = defaultTeardownWorktree,
     reclaimDeadWork = defaultReclaimDeadWork,
     now = Date.now, // CTL-624: injectable clock for the dispatch cool-down
-  } = {},
+    cache, // CTL-634: opt-in out-of-set blocker state cache
+  } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
   // died but whose work was committed before the death. Runs BEFORE the
@@ -573,7 +580,11 @@ export function schedulerTick(
   // hydrate the live state of every out-of-set blocker first so a Ready ticket
   // blocked by a non-terminal out-of-set ticket is held back.
   const eligible = readEligible ? readEligible() : readAllEligibleTickets();
-  const blockerStates = hydrateOutOfSetBlockers(eligible, { exec });
+  const blockerStates = hydrateOutOfSetBlockers(eligible, { exec, cache });
+  // CTL-634: surface the cache hit-rate once per tick. Log-line-only matches
+  // the daemon's pino-only observability convention (schedulerTick's return
+  // object is discarded by runTick, so a metric must be logged, not returned).
+  if (cache) log.info(cache.stats(), "scheduler: cache stats");
   const ready = computeReadyTickets(eligible, { blockerStates });
   const inFlightCount = listInFlightTickets(orchDir).size; // recomputed post-sweep
   const freeSlots = computeFreeSlots(readMaxParallel(orchDir), inFlightCount);
@@ -593,7 +604,7 @@ export function schedulerTick(
             ticket: t.identifier,
             phase: NEW_WORK_ENTRY_PHASE,
           }),
-        { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE },
+        { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
       );
     } else {
       recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, r.code, now()); // CTL-624: arm the cool-down window
@@ -674,6 +685,7 @@ function runTick() {
       exec: runningOpts.exec,
       writeStatus: runningOpts.writeStatus,
       teardownWorktree: runningOpts.teardownWorktree,
+      cache: runningOpts.cache, // CTL-634: shared out-of-set blocker state cache
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -699,17 +711,20 @@ export function startScheduler({
   exec,
   writeStatus,
   teardownWorktree,
+  cache, // CTL-634: shared out-of-set blocker state cache (from startDaemon)
   preflight = preflightWorkspaceLabels, // CTL-585
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
 } = {}) {
   if (!orchDir) throw new Error("startScheduler: orchDir is required");
-  runningOpts = { orchDir, dispatch, readEligible, exec, writeStatus, teardownWorktree };
+  runningOpts = { orchDir, dispatch, readEligible, exec, writeStatus, teardownWorktree, cache };
 
   // CTL-585: warn once at startup if the Linear workspace lacks the labels
   // the CTL-558 sweep writes. Best-effort — never blocks startup.
   try {
-    const teams = listProjects().map((p) => p.team).filter(Boolean);
+    const teams = listProjects()
+      .map((p) => p.team)
+      .filter(Boolean);
     preflight({ teams });
   } catch (err) {
     log.info({ err: err.message }, "scheduler: preflight wrapper threw — swallowed");

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -37,6 +37,7 @@ import {
   dispatchCooldownPath,
   __resetForTests,
 } from "./scheduler.mjs";
+import { createTicketStateCache } from "./linear-cache.mjs";
 
 let orchDir;
 let catalystDir;
@@ -328,16 +329,28 @@ describe("dispatch cool-down (schedulerTick)", () => {
     const marker = dispatchCooldownPath(orchDir, "CTL-3", "research");
 
     // Tick 1 at t=1000: dispatch refused → 1 call, marker written.
-    schedulerTick(orchDir, { readEligible: () => eligibleOne("CTL-3"), dispatch, now: () => 1_000 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-3"),
+      dispatch,
+      now: () => 1_000,
+    });
     expect(dispatch.calls).toHaveLength(1);
     expect(existsSync(marker)).toBe(true);
 
     // Tick 2 at t=30_000 (< 60 s window): suppressed → still 1 call.
-    schedulerTick(orchDir, { readEligible: () => eligibleOne("CTL-3"), dispatch, now: () => 30_000 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-3"),
+      dispatch,
+      now: () => 30_000,
+    });
     expect(dispatch.calls).toHaveLength(1);
 
     // Tick 3 at t=70_000 (> 60 s window): re-dispatch fires → 2 calls.
-    schedulerTick(orchDir, { readEligible: () => eligibleOne("CTL-3"), dispatch, now: () => 70_000 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-3"),
+      dispatch,
+      now: () => 70_000,
+    });
     expect(dispatch.calls).toHaveLength(2);
   });
 
@@ -366,7 +379,11 @@ describe("dispatch cool-down (schedulerTick)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     recordDispatchFailure(orchDir, "CTL-5", "research", 2, 1_000);
     const dispatch = fakeDispatch({ code: 0 });
-    schedulerTick(orchDir, { readEligible: () => eligibleOne("CTL-5"), dispatch, now: () => 20_000 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-5"),
+      dispatch,
+      now: () => 20_000,
+    });
     expect(dispatch.calls).toHaveLength(0);
   });
 
@@ -612,7 +629,7 @@ describe("hydrateOutOfSetBlockers / D5 readiness", () => {
     };
     const map = hydrateOutOfSetBlockers(
       [blkTk("CTL-1", { blockedBy: "CTL-99" }), blkTk("CTL-2", { blockedBy: "CTL-99" })],
-      { exec },
+      { exec }
     );
     expect(fetched).toEqual(["CTL-99"]); // deduped — one fetch
     expect(map).toEqual({ "CTL-99": "Backlog" });
@@ -625,10 +642,7 @@ describe("hydrateOutOfSetBlockers / D5 readiness", () => {
       return { code: 0, stdout: JSON.stringify({ state: { name: "Backlog" } }), stderr: "" };
     };
     // CTL-2 is in the eligible set, so the CTL-1→CTL-2 edge is in-set.
-    hydrateOutOfSetBlockers(
-      [blkTk("CTL-1", { blockedBy: "CTL-2" }), blkTk("CTL-2")],
-      { exec },
-    );
+    hydrateOutOfSetBlockers([blkTk("CTL-1", { blockedBy: "CTL-2" }), blkTk("CTL-2")], { exec });
     expect(fetched).toEqual([]);
   });
 
@@ -674,6 +688,83 @@ describe("hydrateOutOfSetBlockers / D5 readiness", () => {
       exec,
     });
     expect(dispatch.calls).toHaveLength(0);
+  });
+});
+
+// CTL-634 Tier 1 — an opt-in cache deduplicates out-of-set blocker reads
+// across ticks. The blocker-ticket fixture matches the D5 `blkTk` shape above
+// verbatim: a `blocked_by` relation carrying `relatedIssue.identifier`, the
+// edge `referencedBlockerIds` reads.
+describe("hydrateOutOfSetBlockers — cache reuse (CTL-634)", () => {
+  const blkTk = (id, blockedBy) => ({
+    identifier: id,
+    priority: 2,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [{ type: "blocked_by", relatedIssue: { identifier: blockedBy } }] },
+    inverseRelations: { nodes: [] },
+  });
+
+  test("reads an out-of-set blocker once across two hydrations within TTL", () => {
+    const cache = createTicketStateCache({ now: () => 0, ttlMs: 60_000 });
+    const fetched = [];
+    const exec = (_cmd, args) => {
+      fetched.push(args[2]);
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Backlog" } }), stderr: "" };
+    };
+    const eligible = [blkTk("CTL-1", "CTL-99")];
+    hydrateOutOfSetBlockers(eligible, { exec, cache });
+    hydrateOutOfSetBlockers(eligible, { exec, cache });
+    expect(fetched).toEqual(["CTL-99"]); // one read, second hydration is a hit
+  });
+
+  test("preserves the fail-safe: a failed fetch is the sentinel AND is not cached", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    let calls = 0;
+    const exec = () => {
+      calls += 1;
+      return { code: 1, stdout: "", stderr: "" };
+    };
+    const eligible = [blkTk("CTL-1", "CTL-99")];
+    const a = hydrateOutOfSetBlockers(eligible, { exec, cache });
+    const b = hydrateOutOfSetBlockers(eligible, { exec, cache });
+    expect(a["CTL-99"]).toBe("__unfetched__");
+    expect(b["CTL-99"]).toBe("__unfetched__");
+    expect(calls).toBe(2); // never cached the failure
+  });
+});
+
+// CTL-634 — schedulerTick threads the cache into hydration and logs per-tick
+// stats. Asserting the observable cache counters (a log-line assertion is
+// impractical under bun:test): one tick that hydrates an out-of-set blocker
+// records exactly one cache miss.
+describe("schedulerTick — cache stats (CTL-634)", () => {
+  const blkTk = (id, blockedBy) => ({
+    identifier: id,
+    priority: 2,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [{ type: "blocked_by", relatedIssue: { identifier: blockedBy } }] },
+    inverseRelations: { nodes: [] },
+  });
+
+  test("a tick that hydrates an out-of-set blocker records cache activity", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const cache = createTicketStateCache({ now: () => 0 });
+    const dispatch = fakeDispatch({ code: 0 });
+    const exec = () => ({
+      code: 0,
+      stdout: JSON.stringify({ state: { name: "Backlog" } }),
+      stderr: "",
+    });
+    schedulerTick(orchDir, {
+      readEligible: () => [blkTk("CTL-1", "CTL-99")],
+      dispatch,
+      exec,
+      cache,
+    });
+    const s = cache.stats();
+    expect(s.misses + s.hits).toBeGreaterThan(0); // the hydrate read went through the cache
   });
 });
 
@@ -805,7 +896,7 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
         phase: "triage",
         status: "dispatched",
         bg_job_id: null,
-      }),
+      })
     );
     const dispatch = fakeDispatch();
     const r = schedulerTick(orchDir, {
@@ -845,9 +936,7 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
       applyLabel: () => {},
     };
     schedulerTick(orchDir, { readEligible: () => [], dispatch: okDispatch, writeStatus });
-    expect(writes).toContainEqual(
-      expect.objectContaining({ ticket: "CTL-1", phase: "plan" })
-    );
+    expect(writes).toContainEqual(expect.objectContaining({ ticket: "CTL-1", phase: "plan" }));
   });
 
   test("writes `research` status for a new-work pull dispatch", () => {
@@ -863,9 +952,7 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
       dispatch: okDispatch,
       writeStatus,
     });
-    expect(writes).toContainEqual(
-      expect.objectContaining({ ticket: "CTL-2", phase: "research" })
-    );
+    expect(writes).toContainEqual(expect.objectContaining({ ticket: "CTL-2", phase: "research" }));
   });
 
   test("does NOT write status when the dispatch fails", () => {
@@ -946,9 +1033,7 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
     const labels = [];
     const writeStatus = { ...noWrites(), applyLabel: (a) => labels.push(a) };
     schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
-    expect(labels).toContainEqual(
-      expect.objectContaining({ ticket: "CTL-6", label: "triaged" })
-    );
+    expect(labels).toContainEqual(expect.objectContaining({ ticket: "CTL-6", label: "triaged" }));
   });
 
   test("applies `needs-human` when any phase signal is stalled", () => {
@@ -964,10 +1049,7 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
 
   test("does not re-apply a label once the .applied marker exists", () => {
     writeSignal("CTL-7", "implement", "stalled");
-    writeFileSync(
-      join(orchDir, "workers", "CTL-7", ".linear-label-needs-human.applied"),
-      ""
-    );
+    writeFileSync(join(orchDir, "workers", "CTL-7", ".linear-label-needs-human.applied"), "");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const labels = [];
     const writeStatus = { ...noWrites(), applyLabel: (a) => labels.push(a) };
@@ -981,11 +1063,19 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
     const markerPath = join(orchDir, "workers", "CTL-8", ".linear-label-triaged.applied");
     // applyLabel reports failure → no marker written → retried next tick.
     const failWrite = { ...noWrites(), applyLabel: () => ({ applied: false }) };
-    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus: failWrite });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus: failWrite,
+    });
     expect(existsSync(markerPath)).toBe(false);
     // applyLabel succeeds → marker written → not retried.
     const okWrite = { ...noWrites(), applyLabel: () => ({ applied: true }) };
-    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus: okWrite });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus: okWrite,
+    });
     expect(existsSync(markerPath)).toBe(true);
   });
 
@@ -1071,10 +1161,7 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     // Pre-seed the .skipped marker (simulates a previous daemon run that hit
     // the missing-label path).
-    writeFileSync(
-      join(orchDir, "workers", "CTL-13", ".linear-label-triaged.skipped"),
-      ""
-    );
+    writeFileSync(join(orchDir, "workers", "CTL-13", ".linear-label-triaged.skipped"), "");
     let calls = 0;
     const writeStatus = {
       ...noWrites(),
@@ -1098,7 +1185,7 @@ describe("schedulerTick — worktree teardown on Done (CTL-582)", () => {
     mkdirSync(ecDir, { recursive: true });
     writeFileSync(
       join(ecDir, "registry.json"),
-      JSON.stringify({ projects: [{ team, repoRoot, eligibleQuery: {} }] }),
+      JSON.stringify({ projects: [{ team, repoRoot, eligibleQuery: {} }] })
     );
   }
   const noStatusWrites = () => ({
@@ -1106,8 +1193,7 @@ describe("schedulerTick — worktree teardown on Done (CTL-582)", () => {
     applyTerminalDone() {},
     applyLabel() {},
   });
-  const markerPath = (ticket) =>
-    join(orchDir, "workers", ticket, ".worktree-removed");
+  const markerPath = (ticket) => join(orchDir, "workers", ticket, ".worktree-removed");
 
   test("calls teardownWorktree with { repoRoot, ticket } when monitor-deploy is done", () => {
     writeSignal("CTL-4", "monitor-deploy", "done");
@@ -1193,7 +1279,7 @@ describe("schedulerTick — worktree teardown on Done (CTL-582)", () => {
         teardownWorktree: () => {
           throw new Error("boom");
         },
-      }),
+      })
     ).not.toThrow();
   });
 
@@ -1240,10 +1326,7 @@ describe("schedulerTick — CTL-574 reclaim-dead-work sweep", () => {
   function writeNestedSignal(ticket, phase, body) {
     const dir = join(orchDir, "workers", ticket);
     mkdirSync(dir, { recursive: true });
-    writeFileSync(
-      join(dir, `phase-${phase}.json`),
-      JSON.stringify({ ticket, phase, ...body }),
-    );
+    writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, ...body }));
   }
 
   test("schedulerTick calls the injected reclaimDeadWork once per worker signal", () => {
@@ -1287,7 +1370,7 @@ describe("schedulerTick — CTL-574 reclaim-dead-work sweep", () => {
       const signalPath = join(orchDir, "workers", sig.ticket, `phase-${sig.phase}.json`);
       writeFileSync(
         signalPath,
-        JSON.stringify({ ticket: sig.ticket, phase: sig.phase, status: "done", completedAt: "t" }),
+        JSON.stringify({ ticket: sig.ticket, phase: sig.phase, status: "done", completedAt: "t" })
       );
       return "reclaimed";
     };
@@ -1342,7 +1425,7 @@ describe("schedulerTick — CTL-574 reclaim-dead-work sweep", () => {
         dispatch: () => ({ code: 0 }),
         writeStatus: { applyPhaseStatus: () => {}, applyTerminalDone: () => {} },
         teardownWorktree: () => true,
-      }),
+      })
     ).not.toThrow();
   });
 });
@@ -1355,10 +1438,7 @@ describe("schedulerTick — CTL-587 Step 0 multi-result shape", () => {
   function writeNestedSignal(ticket, phase, body) {
     const dir = join(orchDir, "workers", ticket);
     mkdirSync(dir, { recursive: true });
-    writeFileSync(
-      join(dir, `phase-${phase}.json`),
-      JSON.stringify({ ticket, phase, ...body }),
-    );
+    writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, ...body }));
   }
 
   const writeStatus = {
@@ -1475,9 +1555,10 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
       const team = args[3];
       // linearis labels list emits JSON ({nodes:[{name,...},...]}).
       // CTL is missing both expected labels; ENG has both.
-      const nodes = team === "CTL"
-        ? [{ name: "orchestrate" }, { name: "enhancement" }]
-        : [{ name: "triaged" }, { name: "needs-human" }, { name: "bug" }];
+      const nodes =
+        team === "CTL"
+          ? [{ name: "orchestrate" }, { name: "enhancement" }]
+          : [{ name: "triaged" }, { name: "needs-human" }, { name: "bug" }];
       return { code: 0, stdout: JSON.stringify({ nodes }), stderr: "" };
     };
     preflightWorkspaceLabels({
@@ -1486,12 +1567,9 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
       log: fakeLog,
     });
     const ctlWarns = warnings.filter(
-      (w) => w.obj?.team === "CTL" && w.msg.includes("missing required label"),
+      (w) => w.obj?.team === "CTL" && w.msg.includes("missing required label")
     );
-    expect(ctlWarns.map((w) => w.obj.label).sort()).toEqual([
-      "needs-human",
-      "triaged",
-    ]);
+    expect(ctlWarns.map((w) => w.obj.label).sort()).toEqual(["needs-human", "triaged"]);
     const engWarns = warnings.filter((w) => w.obj?.team === "ENG");
     expect(engWarns).toHaveLength(0);
   });
@@ -1499,9 +1577,7 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
   test("does not throw on a linearis spawn failure", () => {
     const fakeLog = { warn: () => {}, info: () => {}, error: () => {} };
     const exec = () => ({ code: 127, stdout: "", stderr: "ENOENT" });
-    expect(() =>
-      preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog }),
-    ).not.toThrow();
+    expect(() => preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog })).not.toThrow();
   });
 
   test("does not throw on a thrown exec", () => {
@@ -1509,9 +1585,7 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
     const exec = () => {
       throw new Error("boom");
     };
-    expect(() =>
-      preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog }),
-    ).not.toThrow();
+    expect(() => preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog })).not.toThrow();
   });
 
   test("real JSON shape with both labels present produces zero warnings", () => {
@@ -1546,9 +1620,7 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
       error: () => {},
     };
     const exec = () => ({ code: 0, stdout: "not json at all", stderr: "" });
-    expect(() =>
-      preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog }),
-    ).not.toThrow();
+    expect(() => preflightWorkspaceLabels({ teams: ["CTL"], exec, log: fakeLog })).not.toThrow();
     expect(infos.some((i) => i.msg.includes("stdout is not JSON"))).toBe(true);
   });
 
@@ -1596,10 +1668,7 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
 
   test("does not re-write terminal Done once the .terminal-done.applied marker exists", () => {
     writeSignal("CTL-20", "monitor-deploy", "done");
-    writeFileSync(
-      join(orchDir, "workers", "CTL-20", ".terminal-done.applied"),
-      ""
-    );
+    writeFileSync(join(orchDir, "workers", "CTL-20", ".terminal-done.applied"), "");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dones = [];
     const writeStatus = {
@@ -1617,11 +1686,19 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
     const markerPath = join(orchDir, "workers", "CTL-21", ".terminal-done.applied");
     // applied:false → no marker → retried next tick.
     const failWrite = { ...terminalNoWrites(), applyTerminalDone: () => ({ applied: false }) };
-    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus: failWrite });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus: failWrite,
+    });
     expect(existsSync(markerPath)).toBe(false);
     // applied:true → marker written → not retried.
     const okWrite = { ...terminalNoWrites(), applyTerminalDone: () => ({ applied: true }) };
-    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus: okWrite });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus: okWrite,
+    });
     expect(existsSync(markerPath)).toBe(true);
   });
 


### PR DESCRIPTION
Recovered + shepherded to PR manually during the 2026-05-26 execution-core cold-start recovery (worker died after committing). Implements CTL-634; see ticket for full spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)