### PR TITLE
fix(dev): carry project/linear.key/orchestration in canonical-event resource block (CTL-636)

### DIFF
--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -200,6 +200,47 @@ expect_eq "build_canonical_line service.name" "catalyst.session" "$SVC"
 NAMESPACE="$(echo "$LINE" | jq -r '.resource."service.namespace"')"
 expect_eq "build_canonical_line service.namespace" "catalyst" "$NAMESPACE"
 
+# CTL-636: orchestration context promoted into the resource block.
+LINE_RES="$(build_canonical_line \
+  --ts "2026-05-25T18:00:00Z" \
+  --severity INFO \
+  --service "catalyst.session" \
+  --event-name "phase.plan.complete" \
+  --orch "CTL-636" \
+  --linear-ticket "CTL-636")"
+
+LINEAR_KEY_OUT="$(echo "$LINE_RES" | jq -r '.resource."linear.key" // ""')"
+expect_eq "build_canonical_line promotes --linear-ticket to resource.linear.key" "CTL-636" "$LINEAR_KEY_OUT"
+
+ORCH_OUT="$(echo "$LINE_RES" | jq -r '.resource."catalyst.orchestration" // ""')"
+expect_eq "build_canonical_line promotes --orch to resource.catalyst.orchestration" "CTL-636" "$ORCH_OUT"
+
+# attributes preserved, not moved
+ATTR_LINEAR="$(echo "$LINE_RES" | jq -r '.attributes."linear.issue.identifier" // ""')"
+expect_eq "build_canonical_line keeps linear.issue.identifier in attributes" "CTL-636" "$ATTR_LINEAR"
+
+# absent when no context
+LINE_BARE="$(build_canonical_line \
+  --ts "2026-05-25T18:00:00Z" --severity INFO \
+  --service "catalyst.session" --event-name "session.heartbeat")"
+BARE_LINEAR="$(echo "$LINE_BARE" | jq -r '.resource | has("linear.key")')"
+expect_eq "build_canonical_line omits linear.key with no context" "false" "$BARE_LINEAR"
+
+# explicit override wins
+LINE_OVR="$(build_canonical_line \
+  --ts "2026-05-25T18:00:00Z" --severity INFO \
+  --service "catalyst.session" --event-name "x" \
+  --linear-ticket "CTL-636" --linear-key "CTL-999")"
+OVR_OUT="$(echo "$LINE_OVR" | jq -r '.resource."linear.key"')"
+expect_eq "build_canonical_line --linear-key overrides promotion" "CTL-999" "$OVR_OUT"
+
+# project sourced from OTEL_RESOURCE_ATTRIBUTES
+LINE_PROJ="$(OTEL_RESOURCE_ATTRIBUTES='project=catalyst-workspace,linear.key=CTL-636' \
+  build_canonical_line --ts "2026-05-25T18:00:00Z" --severity INFO \
+  --service "catalyst.session" --event-name "x")"
+PROJ_OUT="$(echo "$LINE_PROJ" | jq -r '.resource."project" // ""')"
+expect_eq "build_canonical_line sources project from OTEL_RESOURCE_ATTRIBUTES" "catalyst-workspace" "$PROJ_OUT"
+
 SEV_NUM="$(echo "$LINE" | jq -r '.severityNumber')"
 expect_eq "build_canonical_line severityNumber" "9" "$SEV_NUM"
 

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -132,6 +132,15 @@ synthesize_event_id() {
 #   --vcs-pr N            vcs.pr.number (integer)
 #   --vcs-repo NAME       vcs.repository.name
 #   --linear-ticket KEY   linear.issue.identifier
+#
+# CTL-636: optional resource-block orchestration context. When omitted, --orch
+# and --linear-ticket are promoted into the resource block automatically, and
+# `project` is read from the ambient OTEL_RESOURCE_ATTRIBUTES env. These flags
+# override that promotion; each key is omitted from the resource block when its
+# resolved value is empty.
+#   --project NAME                resource.project
+#   --linear-key KEY              resource."linear.key" (default: --linear-ticket)
+#   --catalyst-orchestration ID   resource."catalyst.orchestration" (default: --orch)
 #   --message STR         body.message
 #   --payload-json JSON   body.payload (must be valid JSON; default null)
 #   --service-version VER service.version (default = plugin_version)
@@ -152,6 +161,8 @@ build_canonical_line() {
   local vcs_pr="" vcs_repo="" linear_ticket=""
   local message="" payload="null"
   local service_version=""
+  # CTL-636: optional resource-block orchestration context.
+  local project="" linear_key="" cat_orch=""
   local claude_session_id="" claude_model=""
   local claude_context_used_pct="" claude_context_tokens="" claude_turn=""
 
@@ -175,6 +186,9 @@ build_canonical_line() {
       --vcs-pr)          vcs_pr="$2"; shift 2 ;;
       --vcs-repo)        vcs_repo="$2"; shift 2 ;;
       --linear-ticket)   linear_ticket="$2"; shift 2 ;;
+      --project)                project="$2"; shift 2 ;;
+      --linear-key)             linear_key="$2"; shift 2 ;;
+      --catalyst-orchestration) cat_orch="$2"; shift 2 ;;
       --message)         message="$2"; shift 2 ;;
       --payload-json)    payload="${2:-null}"; shift 2 ;;
       --service-version) service_version="$2"; shift 2 ;;
@@ -192,6 +206,18 @@ build_canonical_line() {
   [[ -n "$service"    ]] || { echo "build_canonical_line: --service required" >&2; return 1; }
   [[ -n "$event_name" ]] || { echo "build_canonical_line: --event-name required" >&2; return 1; }
   [[ -n "$service_version" ]] || service_version="$(plugin_version)"
+
+  # CTL-636: promote orchestration context into the resource block. Existing
+  # callers already pass --orch / --linear-ticket (which land in attributes);
+  # mirror them into resource without a call-site change. Explicit --linear-key /
+  # --catalyst-orchestration / --project override. `project` is parsed from the
+  # ambient OTEL_RESOURCE_ATTRIBUTES the same way emit-otel-event.sh:82-88 does.
+  [[ -n "$linear_key" ]] || linear_key="$linear_ticket"
+  [[ -n "$cat_orch" ]]   || cat_orch="$orch"
+  if [[ -z "$project" && -n "${OTEL_RESOURCE_ATTRIBUTES:-}" ]]; then
+    project="$(printf '%s\n' "$OTEL_RESOURCE_ATTRIBUTES" \
+      | grep -oE 'project=[^,]+' | head -1 | cut -d= -f2- || true)"
+  fi
 
   local sev_num event_id
   sev_num="$(severity_number "$severity")"
@@ -219,6 +245,9 @@ build_canonical_line() {
     --arg vcs_pr "$vcs_pr" \
     --arg vcs_repo "$vcs_repo" \
     --arg linear_ticket "$linear_ticket" \
+    --arg project "$project" \
+    --arg linear_key "$linear_key" \
+    --arg cat_orch "$cat_orch" \
     --arg message "$message" \
     --argjson payload "$payload" \
     --arg claude_session_id "$claude_session_id" \
@@ -234,11 +263,16 @@ build_canonical_line() {
       severityNumber: $sev_num,
       traceId: (if $trace_id == "" then null else $trace_id end),
       spanId:  (if $span_id  == "" then null else $span_id  end),
-      resource: {
-        "service.name": $svc_name,
-        "service.namespace": "catalyst",
-        "service.version": $svc_ver
-      },
+      resource: (
+        {
+          "service.name": $svc_name,
+          "service.namespace": "catalyst",
+          "service.version": $svc_ver
+        }
+        + (if $project    == "" then {} else { "project": $project } end)
+        + (if $linear_key == "" then {} else { "linear.key": $linear_key } end)
+        + (if $cat_orch   == "" then {} else { "catalyst.orchestration": $cat_orch } end)
+      ),
       attributes: (
         { "event.name": $event_name }
         + (if $entity  == "" then {} else { "event.entity": $entity }  end)

--- a/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/canonical-event.test.ts
@@ -114,6 +114,85 @@ describe("buildCanonicalEvent", () => {
     expect(ev.spanId).toBe("b".repeat(16));
   });
 
+  it("promotes linear.issue.identifier and catalyst.orchestrator.id into resource (CTL-636)", () => {
+    const ev = buildCanonicalEvent({
+      ts: "2026-05-25T18:00:00.000Z",
+      severityText: "INFO",
+      traceId: null,
+      spanId: null,
+      resource: { "service.name": "catalyst.session" },
+      attributes: {
+        "event.name": "session.phase",
+        "linear.issue.identifier": "CTL-636",
+        "catalyst.orchestrator.id": "CTL-636",
+      },
+      body: {},
+    });
+    expect(ev.resource["linear.key"]).toBe("CTL-636");
+    expect(ev.resource["catalyst.orchestration"]).toBe("CTL-636");
+    // attributes must be preserved, not moved
+    expect(ev.attributes["linear.issue.identifier"]).toBe("CTL-636");
+    expect(ev.attributes["catalyst.orchestrator.id"]).toBe("CTL-636");
+  });
+
+  it("omits the new resource keys when no orchestration context is present (CTL-636)", () => {
+    // Clear the ambient env so a project= set by the orchestration test runner
+    // cannot pollute the no-context assertion.
+    const prev = process.env.OTEL_RESOURCE_ATTRIBUTES;
+    delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    try {
+      const ev = buildCanonicalEvent({
+        ts: "2026-05-25T18:00:00.000Z",
+        severityText: "INFO",
+        traceId: null,
+        spanId: null,
+        resource: { "service.name": "catalyst.github" },
+        attributes: { "event.name": "github.pr.merged" },
+        body: {},
+      });
+      expect("linear.key" in ev.resource).toBe(false);
+      expect("catalyst.orchestration" in ev.resource).toBe(false);
+      expect("project" in ev.resource).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+      else process.env.OTEL_RESOURCE_ATTRIBUTES = prev;
+    }
+  });
+
+  it("prefers an explicit resource key over the attribute fallback (CTL-636)", () => {
+    const ev = buildCanonicalEvent({
+      ts: "2026-05-25T18:00:00.000Z",
+      severityText: "INFO",
+      traceId: null,
+      spanId: null,
+      resource: { "service.name": "catalyst.session", "linear.key": "CTL-999" },
+      attributes: { "event.name": "x", "linear.issue.identifier": "CTL-636" },
+      body: {},
+    });
+    expect(ev.resource["linear.key"]).toBe("CTL-999");
+  });
+
+  it("sources project from OTEL_RESOURCE_ATTRIBUTES when present (CTL-636)", () => {
+    const prev = process.env.OTEL_RESOURCE_ATTRIBUTES;
+    process.env.OTEL_RESOURCE_ATTRIBUTES =
+      "project=catalyst-workspace,linear.key=CTL-636,catalyst.orchestration=CTL-636";
+    try {
+      const ev = buildCanonicalEvent({
+        ts: "2026-05-25T18:00:00.000Z",
+        severityText: "INFO",
+        traceId: null,
+        spanId: null,
+        resource: { "service.name": "catalyst.session" },
+        attributes: { "event.name": "x" },
+        body: {},
+      });
+      expect(ev.resource["project"]).toBe("catalyst-workspace");
+    } finally {
+      if (prev === undefined) delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+      else process.env.OTEL_RESOURCE_ATTRIBUTES = prev;
+    }
+  });
+
   it("preserves event.name, entity, action, label, channel attribute set", () => {
     const ev: CanonicalEvent = buildCanonicalEvent({
       ts: "2026-05-08T18:00:00.000Z",

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -39,6 +39,12 @@ export interface Resource {
   "service.name": string;
   "service.namespace": "catalyst";
   "service.version": string;
+  // CTL-636: optional orchestration-context resource keys. Present only when
+  // the event carries the corresponding data; omitted otherwise so external
+  // (webhook / broker-daemon) events keep the bare 3-key block.
+  "project"?: string;
+  "linear.key"?: string;
+  "catalyst.orchestration"?: string;
 }
 
 export interface Attributes {
@@ -114,7 +120,13 @@ export interface BuildInput {
   traceId: string | null;
   spanId: string | null;
   parentSpanId?: string | null;
-  resource: { "service.name": string; "service.version"?: string };
+  resource: {
+    "service.name": string;
+    "service.version"?: string;
+    "project"?: string;
+    "linear.key"?: string;
+    "catalyst.orchestration"?: string;
+  };
   attributes: Attributes;
   body: Body;
 }
@@ -154,6 +166,16 @@ export function pluginVersion(): string {
   return cachedVersion;
 }
 
+/** CTL-636: pull `project=<val>` out of the ambient OTEL_RESOURCE_ATTRIBUTES
+ *  env (set by phase-agent-dispatch for --bg workers and by direnv for
+ *  interactive sessions). Mirrors the bash parse in emit-otel-event.sh:82-88. */
+function projectFromEnv(): string | undefined {
+  const raw = process.env.OTEL_RESOURCE_ATTRIBUTES;
+  if (!raw) return undefined;
+  const m = raw.match(/(?:^|,)project=([^,]+)/);
+  return m ? m[1] : undefined;
+}
+
 /**
  * Build a canonical event with defaults applied:
  *   - id from generateEventId() (CTL-344)
@@ -165,6 +187,24 @@ export function pluginVersion(): string {
 export function buildCanonicalEvent(input: BuildInput): CanonicalEvent {
   const observedTs = input.observedTs ?? input.ts;
   const version = input.resource["service.version"] ?? pluginVersion();
+
+  const resource: Resource = {
+    "service.name": input.resource["service.name"],
+    "service.namespace": "catalyst",
+    "service.version": version,
+  };
+  // CTL-636: promote orchestration context into resource. Explicit resource
+  // input wins; otherwise fall back to the matching attribute (TS emitters
+  // already set these) or the ambient env (project only).
+  const project = input.resource["project"] ?? projectFromEnv();
+  if (project) resource["project"] = project;
+  const linearKey =
+    input.resource["linear.key"] ?? input.attributes["linear.issue.identifier"];
+  if (linearKey) resource["linear.key"] = linearKey;
+  const catOrch =
+    input.resource["catalyst.orchestration"] ?? input.attributes["catalyst.orchestrator.id"];
+  if (catOrch) resource["catalyst.orchestration"] = catOrch;
+
   const event: CanonicalEvent = {
     ts: input.ts,
     id: generateEventId(),
@@ -173,11 +213,7 @@ export function buildCanonicalEvent(input: BuildInput): CanonicalEvent {
     severityNumber: severityNumber(input.severityText),
     traceId: input.traceId,
     spanId: input.spanId,
-    resource: {
-      "service.name": input.resource["service.name"],
-      "service.namespace": "catalyst",
-      "service.version": version,
-    },
+    resource,
     attributes: input.attributes,
     body: input.body,
   };

--- a/plugins/dev/scripts/otel-forward/lib/destinations/otlp.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/otlp.test.ts
@@ -39,6 +39,26 @@ describe("buildOtlpPayload", () => {
     expect(svcName?.value?.stringValue).toBe("catalyst.session");
   });
 
+  test("propagates CTL-636 resource keys to OTLP resource.attributes", () => {
+    const event: CanonicalEvent = {
+      ...SAMPLE_EVENT,
+      resource: {
+        ...SAMPLE_EVENT.resource,
+        "project": "catalyst-workspace",
+        "linear.key": "CTL-636",
+        "catalyst.orchestration": "CTL-636",
+      },
+    };
+    const payload = buildOtlpPayload([event]) as any;
+    const resAttrs = payload.resourceLogs[0].resource.attributes;
+    const get = (k: string) => resAttrs.find((a: any) => a.key === k)?.value?.stringValue;
+    expect(get("project")).toBe("catalyst-workspace");
+    expect(get("linear.key")).toBe("CTL-636");
+    expect(get("catalyst.orchestration")).toBe("CTL-636");
+    // base key still present
+    expect(get("service.name")).toBe("catalyst.session");
+  });
+
   test("maps string attributes to stringValue", () => {
     const payload = buildOtlpPayload([SAMPLE_EVENT]) as any;
     const logAttrs = payload.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;


### PR DESCRIPTION
Recovered + shepherded to PR manually during the 2026-05-26 execution-core cold-start recovery (worker died after committing). Implements CTL-636; see ticket for full spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)