### PR TITLE
feat(dev): cold-start detection signal for execution-core recovery (CTL-640)

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -470,6 +470,45 @@ export function defaultReadRuntimeEpoch({
   return { epoch, epochSource, bootEpoch, daemonEpoch };
 }
 
+// detectColdStart — proves every prior claude --bg worker is dead by comparing
+// each job's state.json mtime against the runtime epoch (max OS boot, daemon
+// start). COLD when the epoch is newer than ALL job mtimes (vacuously true with
+// zero jobs). The single hard invariant: an UNREADABLE epoch (0 / "none") can
+// prove nothing, so it is NEVER cold — the conservative CTL-588 stale-wait
+// remains the fallback. Enumerates ALL dirs under getJobsRoot() (not just
+// signalled bg_job_ids) so a live sibling-orchestrator worker can veto the
+// verdict. Pure aside from injected seams; never throws.
+export function detectColdStart({
+  jobsRoot = getJobsRoot(),
+  readDir = readdirSync,
+  statJob = defaultStatJob,
+  readEpoch = defaultReadRuntimeEpoch,
+} = {}) {
+  const { epoch, epochSource } = readEpoch();
+
+  let ids = [];
+  try {
+    ids = readDir(jobsRoot);
+  } catch {
+    ids = []; // jobs root absent → zero jobs
+  }
+
+  let jobsChecked = 0;
+  let newestJobMtime = 0;
+  for (const id of ids) {
+    const job = statJob(id);
+    if (!job || typeof job.mtimeMs !== "number") continue; // no usable evidence
+    jobsChecked += 1;
+    if (job.mtimeMs > newestJobMtime) newestJobMtime = job.mtimeMs;
+  }
+
+  // Unreadable epoch proves nothing. Otherwise cold iff every job mtime predates
+  // the epoch (vacuously true when jobsChecked === 0).
+  const coldStart = epoch > 0 && newestJobMtime < epoch;
+
+  return { coldStart, epoch, epochSource, jobsChecked, newestJobMtime };
+}
+
 // defaultWriteReviveMarker — write workers/<ticket>/.revive-<N>.applied as an
 // operator-friendly forensic crumb. The authoritative counter is in
 // events.jsonl; the marker is just a quick `ls`-able count for operators.

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -8,6 +8,7 @@
 import {
   statSync,
   readFileSync,
+  readdirSync,
   openSync,
   fstatSync,
   closeSync,
@@ -392,6 +393,81 @@ export function defaultKillBgJob(
   } catch (err) {
     log.warn({ bgJobId, err: err.message }, "revive: defensive kill failed");
   }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// CTL-640: cold-start detection. The reference epoch = max(OS boot, claude-daemon
+// start). If that epoch is newer than EVERY ~/.claude/jobs/<id>/state.json mtime,
+// every recorded --bg worker pre-dates the epoch and is provably dead → COLD
+// START. A false COLD is dangerous (unlocks aggressive recovery → storm risk),
+// so every reader fails open to 0 (the conservative floor) and the verdict biases
+// toward WARM. CTL-640 produces this signal only; consuming it is downstream.
+// ──────────────────────────────────────────────────────────────────────────
+
+// readBootEpoch — OS boot time in epoch-ms, or 0 if unobtainable.
+//   darwin: `sysctl -n kern.boottime` → "{ sec = <n>, usec = ... } <date>"
+//   linux:  /proc/stat line "btime <n>" (absolute boot epoch seconds; stable,
+//           unlike /proc/uptime which drifts with clock adjustments).
+// Injectable platform/spawn/readFile for deterministic tests. Never throws.
+export function readBootEpoch({
+  platform = process.platform,
+  spawn = spawnSync,
+  readFile = (p) => readFileSync(p, "utf8"),
+} = {}) {
+  try {
+    if (platform === "darwin") {
+      const res = spawn("sysctl", ["-n", "kern.boottime"], { encoding: "utf8" });
+      if (res.status !== 0) return 0;
+      const m = /sec\s*=\s*(\d+)/.exec(res.stdout || "");
+      return m ? Number(m[1]) * 1000 : 0;
+    }
+    if (platform === "linux") {
+      const m = /^btime\s+(\d+)/m.exec(readFile("/proc/stat") || "");
+      return m ? Number(m[1]) * 1000 : 0;
+    }
+  } catch {
+    /* fall through to 0 */
+  }
+  return 0;
+}
+
+// readDaemonEpoch — claude-daemon instance start in epoch-ms, or 0. The
+// per-instance socket dir /tmp/cc-daemon-<uid>/<instance>/ is recreated on each
+// daemon restart, so the newest immediate-subdir mtime IS the current instance's
+// start. (roster.json `updatedAt` is a heartbeat and is deliberately not used.)
+export function readDaemonEpoch({
+  socketRoot = `/tmp/cc-daemon-${process.getuid?.() ?? ""}`,
+  readDir = (p) => readdirSync(p),
+  statDir = (p) => statSync(p),
+} = {}) {
+  try {
+    let newest = 0;
+    for (const name of readDir(socketRoot)) {
+      try {
+        const m = statDir(join(socketRoot, name)).mtimeMs;
+        if (typeof m === "number" && m > newest) newest = m;
+      } catch {
+        /* skip unreadable entry */
+      }
+    }
+    return newest;
+  } catch {
+    return 0; // socket root absent
+  }
+}
+
+// defaultReadRuntimeEpoch — the cold-start reference epoch = max(boot, daemon).
+// epochSource names the winner for forensics; "none" when neither is readable.
+export function defaultReadRuntimeEpoch({
+  readBoot = readBootEpoch,
+  readDaemon = readDaemonEpoch,
+} = {}) {
+  const bootEpoch = readBoot();
+  const daemonEpoch = readDaemon();
+  const epoch = Math.max(bootEpoch, daemonEpoch);
+  let epochSource = "none";
+  if (epoch > 0) epochSource = daemonEpoch >= bootEpoch ? "daemon" : "boot";
+  return { epoch, epochSource, bootEpoch, daemonEpoch };
 }
 
 // defaultWriteReviveMarker — write workers/<ticket>/.revive-<N>.applied as an

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -776,7 +776,7 @@ export function reclaimDeadWorkIfPossible(
 // event-log cursor, and classifies every in-flight worker. Returns a
 // RecoveryReport; throws nothing the daemon must handle (reconcile is internally
 // best-effort, worker scan is filesystem-pure).
-export function recoverStartup({ orchDir, exec, statJob } = {}) {
+export function recoverStartup({ orchDir, exec, statJob, detectCold = detectColdStart } = {}) {
   if (!orchDir) throw new Error("recoverStartup: orchDir is required");
 
   // (1) Routing state — reconcileAll re-reads the registry + polls Linear per
@@ -800,10 +800,17 @@ export function recoverStartup({ orchDir, exec, statJob } = {}) {
   // (3) Dispatch/worker state — classify in-flight claude --bg workers.
   const workers = reconstructWorkerState(orchDir, { statJob });
 
+  // (4) Cold-start verdict (CTL-640) — does every prior --bg worker pre-date the
+  //     runtime epoch? Surfaced for a downstream consumer (CTL-639) to gate the
+  //     STALE_MS stale-wait. Pass statJob so a test-redirected jobs root flows
+  //     through both the worker reconstruction and the cold-start scan.
+  const coldStart = detectCold({ statJob });
+
   return {
     recoveredAt: new Date().toISOString(),
     routing: { projects, projectCount: projects.length },
     cursor: { logPath, byteOffset: startOffset, resumed: startOffset !== fileSize },
     workers,
+    coldStart,
   };
 }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -17,6 +17,9 @@ import {
   defaultReviveDispatch,
   defaultKillBgJob,
   defaultAppendReviveEvent,
+  readBootEpoch,
+  readDaemonEpoch,
+  defaultReadRuntimeEpoch,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -1240,5 +1243,84 @@ describe("revive event envelope round-trip (write → countReviveEvents)", () =>
     expect(countReviveEvents({ ticket: "CTL-RT-1", orchId: "orch-rt" })).toBe(1);
     // orchId mismatch returns 0 — proves the orchId attribute round-trips.
     expect(countReviveEvents({ ticket: "CTL-RT-1", orchId: "wrong-orch" })).toBe(0);
+  });
+});
+
+// CTL-640: cold-start detection — runtime epoch readers + detectColdStart.
+describe("runtime epoch readers", () => {
+  describe("readBootEpoch", () => {
+    test("darwin: parses `sec = <n>` from kern.boottime → ms", () => {
+      const spawn = (cmd, args) => {
+        expect(cmd).toBe("sysctl");
+        expect(args).toEqual(["-n", "kern.boottime"]);
+        return {
+          status: 0,
+          stdout: "{ sec = 1779212952, usec = 3402 } Tue May 19 12:49:12 2026\n",
+          stderr: "",
+        };
+      };
+      expect(readBootEpoch({ platform: "darwin", spawn })).toBe(1779212952 * 1000);
+    });
+
+    test("linux: parses `btime <n>` from /proc/stat → ms", () => {
+      const readFile = (p) => {
+        expect(p).toBe("/proc/stat");
+        return "cpu  1 2 3\nbtime 1779212952\nprocesses 99\n";
+      };
+      expect(readBootEpoch({ platform: "linux", readFile })).toBe(1779212952 * 1000);
+    });
+
+    test("unknown platform → 0", () => {
+      expect(readBootEpoch({ platform: "sunos" })).toBe(0);
+    });
+
+    test("spawn failure / unparseable output → 0", () => {
+      const spawn = () => ({ status: 1, stdout: "", stderr: "boom" });
+      expect(readBootEpoch({ platform: "darwin", spawn })).toBe(0);
+    });
+  });
+
+  describe("readDaemonEpoch", () => {
+    test("returns newest immediate-subdir mtime (ms)", () => {
+      const readDir = (root) => {
+        expect(root).toContain("cc-daemon-");
+        return ["old", "new"];
+      };
+      const statDir = (p) => (p.endsWith("new") ? { mtimeMs: 2000 } : { mtimeMs: 1000 });
+      expect(readDaemonEpoch({ socketRoot: "/tmp/cc-daemon-501", readDir, statDir })).toBe(2000);
+    });
+
+    test("missing socket root → 0", () => {
+      const readDir = () => {
+        throw new Error("ENOENT");
+      };
+      expect(readDaemonEpoch({ socketRoot: "/tmp/cc-daemon-501", readDir })).toBe(0);
+    });
+
+    test("no subdirs → 0", () => {
+      expect(readDaemonEpoch({ socketRoot: "/tmp/cc-daemon-501", readDir: () => [] })).toBe(0);
+    });
+  });
+
+  describe("defaultReadRuntimeEpoch", () => {
+    test("epoch = max(boot, daemon); epochSource names the winner", () => {
+      const res = defaultReadRuntimeEpoch({ readBoot: () => 1000, readDaemon: () => 5000 });
+      expect(res).toMatchObject({
+        epoch: 5000,
+        epochSource: "daemon",
+        bootEpoch: 1000,
+        daemonEpoch: 5000,
+      });
+    });
+
+    test("boot wins when daemon unreadable (0)", () => {
+      const res = defaultReadRuntimeEpoch({ readBoot: () => 8000, readDaemon: () => 0 });
+      expect(res).toMatchObject({ epoch: 8000, epochSource: "boot" });
+    });
+
+    test("both 0 → epoch 0, epochSource none", () => {
+      const res = defaultReadRuntimeEpoch({ readBoot: () => 0, readDaemon: () => 0 });
+      expect(res).toMatchObject({ epoch: 0, epochSource: "none" });
+    });
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -416,6 +416,18 @@ describe("recoverStartup", () => {
     expect(report.cursor.byteOffset).toBe(0);
     expect(report.cursor.resumed).toBe(false);
   });
+
+  test("RecoveryReport includes the coldStart verdict (CTL-640)", () => {
+    enroll("ENG", { status: "Todo" });
+    const exec = mockExec({ ENG: [] });
+    const report = recoverStartup({
+      orchDir,
+      exec,
+      statJob: () => null,
+      detectCold: () => ({ coldStart: true, epoch: 5000, epochSource: "daemon", jobsChecked: 0, newestJobMtime: 0 }),
+    });
+    expect(report.coldStart).toMatchObject({ coldStart: true, epochSource: "daemon" });
+  });
 });
 
 // --- CTL-574: reclaim-dead-work --------------------------------------------

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -20,6 +20,7 @@ import {
   readBootEpoch,
   readDaemonEpoch,
   defaultReadRuntimeEpoch,
+  detectColdStart,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -1321,6 +1322,70 @@ describe("runtime epoch readers", () => {
     test("both 0 → epoch 0, epochSource none", () => {
       const res = defaultReadRuntimeEpoch({ readBoot: () => 0, readDaemon: () => 0 });
       expect(res).toMatchObject({ epoch: 0, epochSource: "none" });
+    });
+  });
+
+  describe("detectColdStart", () => {
+    // Helper: build a statJob that maps job id → mtimeMs (or null when absent).
+    const statJobFrom = (map) => (id) =>
+      id in map ? { exists: true, mtimeMs: map[id], state: {} } : null;
+
+    test("(a) cold when epoch newer than ALL job mtimes", () => {
+      const res = detectColdStart({
+        readEpoch: () => ({ epoch: 5000, epochSource: "daemon", bootEpoch: 1000, daemonEpoch: 5000 }),
+        readDir: () => ["j1", "j2"],
+        statJob: statJobFrom({ j1: 1000, j2: 4000 }),
+      });
+      expect(res).toMatchObject({ coldStart: true, epoch: 5000, epochSource: "daemon", jobsChecked: 2, newestJobMtime: 4000 });
+    });
+
+    test("(b) NOT cold when any job mtime >= epoch", () => {
+      const res = detectColdStart({
+        readEpoch: () => ({ epoch: 5000, epochSource: "boot", bootEpoch: 5000, daemonEpoch: 0 }),
+        readDir: () => ["j1", "j2"],
+        statJob: statJobFrom({ j1: 1000, j2: 6000 }), // j2 touched after epoch → alive
+      });
+      expect(res.coldStart).toBe(false);
+      expect(res.newestJobMtime).toBe(6000);
+    });
+
+    test("(c) zero jobs + readable epoch → vacuously cold", () => {
+      const res = detectColdStart({
+        readEpoch: () => ({ epoch: 5000, epochSource: "boot", bootEpoch: 5000, daemonEpoch: 0 }),
+        readDir: () => [],
+        statJob: () => null,
+      });
+      expect(res).toMatchObject({ coldStart: true, jobsChecked: 0, newestJobMtime: 0 });
+    });
+
+    test("(d) unreadable epoch (0 / 'none') → NOT cold, regardless of jobs", () => {
+      const res = detectColdStart({
+        readEpoch: () => ({ epoch: 0, epochSource: "none", bootEpoch: 0, daemonEpoch: 0 }),
+        readDir: () => ["j1"],
+        statJob: statJobFrom({ j1: 1000 }),
+      });
+      expect(res.coldStart).toBe(false);
+      expect(res.epochSource).toBe("none");
+    });
+
+    test("job dir present but state.json missing (statJob null) is ignored, not counted alive", () => {
+      const res = detectColdStart({
+        readEpoch: () => ({ epoch: 5000, epochSource: "daemon", bootEpoch: 0, daemonEpoch: 5000 }),
+        readDir: () => ["j1", "ghost"],
+        statJob: statJobFrom({ j1: 1000 }), // "ghost" → null (no state.json)
+      });
+      // ghost has no mtime evidence; j1 < epoch → still cold. jobsChecked counts dirs with a usable mtime.
+      expect(res.coldStart).toBe(true);
+      expect(res.jobsChecked).toBe(1);
+    });
+
+    test("missing jobs root (readDir throws) → jobsChecked 0, vacuously cold when epoch readable", () => {
+      const res = detectColdStart({
+        readEpoch: () => ({ epoch: 5000, epochSource: "boot", bootEpoch: 5000, daemonEpoch: 0 }),
+        readDir: () => { throw new Error("ENOENT"); },
+        statJob: () => null,
+      });
+      expect(res).toMatchObject({ coldStart: true, jobsChecked: 0 });
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a cold-start detector to `execution-core` recovery that proves **every** prior `claude --bg` worker is dead before aggressive auto-recovery runs, preventing duplicate-worker storms. A reboot/battery-death is the *safe* moment to act because liveness is unambiguous.

Foundation for **CTL-639** (the recovery gate). No behavior change on warm restart.

## Mechanism

Compares a **runtime epoch** = `max(OS boot time, claude-daemon start time)` against the `state.json` mtime of every job dir under `~/.claude/jobs/`:

- Epoch newer than **all** job mtimes ⇒ every recorded worker pre-dates the epoch ⇒ provably dead ⇒ **COLD START**.
- Any job mtime newer than the epoch ⇒ a worker touched `state.json` after the epoch ⇒ **warm restart** (conservative path unchanged).

Job dirs survive reboot, so existence alone is insufficient — boot-time-vs-mtime is the discriminator.

## What changed

- **`recovery.mjs`** — three injectable, fail-open-to-`0` epoch readers (`readBootEpoch` darwin `sysctl -n kern.boottime` / linux `/proc/stat btime`; `readDaemonEpoch` newest `/tmp/cc-daemon-<uid>/` subdir mtime; `defaultReadRuntimeEpoch` = `max`), the `detectColdStart()` helper, and a new `coldStart` key on the `RecoveryReport` returned by `recoverStartup`.
- **`recovery.test.mjs`** — unit coverage for all verdict-flipping branches: cold true when epoch > all mtimes, false when any mtime > epoch, zero-jobs case, darwin + linux paths.

## Testing

- `bun test recovery.test.mjs`: **87 pass, 0 fail** (1707 expect() calls).
- Reward-hacking scan: clean (no `as any` / `@ts-ignore` / non-null / `forEach(async` / void tricks).
- Security: read-only surface (spawns `sysctl`, reads `/proc/stat` + `/tmp/cc-daemon` socket-dir mtimes + `~/.claude/jobs`); no new deps, no secrets, no untrusted input.
- Merges cleanly onto `origin/main`.

Every fail-open path biases toward WARM (the safe verdict); an `epoch > 0` floor forces WARM when the epoch is unreadable.

Closes CTL-640.
