### PR TITLE
fix(dev): supersede guard for predecessor reaping (CTL-606)

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -24,7 +24,8 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import { getJobsRoot, getEventLogPath, log } from "./config.mjs";
-import { readWorkerSignals, TERMINAL } from "./signal-reader.mjs";
+import { phaseIndex } from "../lib/phase-fsm.mjs";
+import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
@@ -569,6 +570,14 @@ const KILL_RECENT_ACTIVITY_MS = 30 * 1000;
 //                         probe-less phase: verify/review/pr/monitor-*).
 //                         needs-human label applied (via the CTL-587 verified
 //                         applyLabel); ticket stays where it is for human triage.
+//   'superseded-noop'     effectively dead BUT the signal's phase precedes the
+//                         ticket's latest-dispatched phase (CTL-606). The ticket
+//                         has already advanced; the dead signal is a leftover
+//                         predecessor (left at `running`, never flipped to
+//                         `done`) that readWorkerSignals→byActivePhase ranked
+//                         ahead of the genuinely-active terminal phase. No
+//                         escalate/revive/reclaim — acting would spuriously flag
+//                         needs-human or spawn a duplicate worker at a past phase.
 //
 // CTL-588 still defines "effectively dead" as classifyWorker:'dead' OR a
 // 'running' signal whose bg state.json mtime is older than staleMs.
@@ -603,6 +612,9 @@ export function reclaimDeadWorkIfPossible(
     // I/O, or to drive the cool-down clock independently of `now`.
     inEscalationCooldownFn = defaultInEscalationCooldown,
     recordEscalationFn = defaultRecordEscalation,
+    // CTL-606 — supersede guard. Returns the ticket's dispatched phase names so
+    // the guard can detect a dead signal the pipeline has already advanced past.
+    listTicketPhases = (t) => listDispatchedPhases(orchDir, t),
     now = Date.now,
     staleMs = STALE_MS,
   } = {},
@@ -622,6 +634,25 @@ export function reclaimDeadWorkIfPossible(
   if (!effectivelyDead) return "noop";
 
   const { ticket, phase } = signal;
+
+  // CTL-606 — supersede guard. The reclaim sweep is fed ONE signal per ticket by
+  // readWorkerSignals→byActivePhase, which ranks by status+recency, NOT phase
+  // order. A stale predecessor left at `running` (never flipped to `done`) can
+  // therefore shadow the real, already-advanced phase and be handed here. If the
+  // dead signal's phase precedes the ticket's latest-dispatched phase, the ticket
+  // has moved on — escalating or reviving it would spuriously flag needs-human or
+  // spawn a duplicate worker at a past phase. No-op. Runs only after the dead
+  // check above, so live signals pay no filesystem read.
+  const dispatched = listTicketPhases(ticket);
+  const latestIdx = dispatched.reduce((max, p) => {
+    const i = phaseIndex(p);
+    return i > max ? i : max;
+  }, -1);
+  if (phaseIndex(phase) < latestIdx) {
+    log.info({ ticket, phase, latestPhaseIndex: latestIdx }, "ctl-606: superseded phase, no-op");
+    return "superseded-noop";
+  }
+
   const orchId = signal.raw?.orchestrator;
   const prevBgJobId = signal.raw?.bg_job_id ?? null;
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1437,3 +1437,55 @@ describe("runtime epoch readers", () => {
     });
   });
 });
+
+describe("reclaimDeadWorkIfPossible — CTL-606 supersede guard", () => {
+  const orch = "/orch";
+
+  test("dead predecessor (triage) while a later phase is dispatched → 'superseded-noop', NO escalate", () => {
+    const escalate = recorder(undefined); // appendEscalatedEvent spy
+    const applyLabel = recorder(undefined); // applyStalledLabel spy
+    const triageSig = {
+      ticket: "CTL-9",
+      phase: "triage",
+      status: "running",
+      liveness: { kind: "bg", value: "job-old" },
+      raw: {
+        ticket: "CTL-9",
+        phase: "triage",
+        orchestrator: "CTL-9",
+        status: "running",
+        bg_job_id: "job-old",
+      },
+    };
+    const r = reclaimDeadWorkIfPossible(orch, triageSig, {
+      statJob: () => null, // dead bg job
+      listTicketPhases: () => ["triage", "research", "plan", "implement"],
+      appendEscalatedEvent: escalate,
+      applyStalledLabel: applyLabel,
+    });
+    expect(r).toBe("superseded-noop");
+    expect(escalate.calls.length).toBe(0);
+    expect(applyLabel.calls.length).toBe(0);
+  });
+
+  test("dead signal IS the latest dispatched phase → guard does NOT fire (existing behavior)", () => {
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => null,
+      listTicketPhases: () => ["triage", "research", "plan", "implement"],
+      probes: { implement: recorder(true) }, // work done → 'reclaimed'
+      emitComplete: recorder({ code: 0 }),
+      appendEvent: recorder(undefined),
+    });
+    expect(r).toBe("reclaimed");
+  });
+
+  test("guard never fires for a live signal (no filesystem read on the hot path)", () => {
+    const listSpy = recorder(["triage", "research", "plan", "implement"]);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => ({ exists: true, mtimeMs: Date.now() }), // fresh → not dead
+      listTicketPhases: listSpy,
+    });
+    expect(r).toBe("noop");
+    expect(listSpy.calls.length).toBe(0); // guard runs only after the dead check
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -514,11 +514,11 @@ export function schedulerTick(
   // Reclaim is a strict superset of "do nothing": only the dead+work-done case
   // mutates the signal; all other classes (terminal/running/unknown/not-done/
   // not-applicable) are zero-action no-ops.
-  // CTL-587: reclaimDeadWork now returns up to 7 discriminators. The four
+  // CTL-587: reclaimDeadWork now returns up to 8 discriminators. The four
   // that callers can act on (HUD, daemon log) populate parallel arrays; the
-  // other three (noop, not-done, not-applicable, reclaim-failed) are silent
-  // because they describe "no externally-visible change" — the next tick
-  // will re-evaluate. The 'reviveSuppressed' bucket is the storm-breaker
+  // others (noop, not-done, not-applicable, reclaim-failed, superseded-noop)
+  // are silent because they describe "no externally-visible change" — the next
+  // tick will re-evaluate. The 'reviveSuppressed' bucket is the storm-breaker
   // marker; 'escalated' fires `needs-human` via the per-phase recovery path.
   const reclaimed = [];
   const revived = [];
@@ -550,6 +550,9 @@ export function schedulerTick(
         break;
       default:
         // noop | not-done | not-applicable | reclaim-failed → invisible.
+        // CTL-606: superseded-noop also buckets here — a dead predecessor signal
+        // the ticket has already advanced past. Invisible by design (the active
+        // phase is progressing normally); surfacing it would be noise.
         break;
     }
   }

--- a/plugins/dev/scripts/execution-core/signal-reader.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.mjs
@@ -66,6 +66,27 @@ function isPhaseSignalFile(name) {
   return name.startsWith("phase-");
 }
 
+// listDispatchedPhases — the phase NAMES dispatched for one ticket: every
+// workers/<ticket>/phase-<name>.json (artifacts excluded). Pure over the
+// filesystem; carries no phase-order knowledge — callers map names→indices via
+// phaseIndex (phase-fsm.mjs). The primitive behind the CTL-606 supersede guard.
+export function listDispatchedPhases(orchDir, ticket) {
+  const dir = join(orchDir, "workers", ticket);
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return []; // no worker dir yet
+  }
+  const phases = [];
+  for (const name of names) {
+    if (!isPhaseSignalFile(name)) continue;
+    const m = /^phase-(.+)\.json$/.exec(name);
+    if (m) phases.push(m[1]);
+  }
+  return phases;
+}
+
 // readNestedDir — collect workers/<T>/phase-*.json, drop artifacts, and pick
 // the active phase: the latest updatedAt, preferring a non-terminal status so
 // a freshly-written terminal signal never shadows an in-flight phase.

--- a/plugins/dev/scripts/execution-core/signal-reader.test.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.test.mjs
@@ -5,7 +5,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readWorkerSignals } from "./signal-reader.mjs";
+import { readWorkerSignals, listDispatchedPhases } from "./signal-reader.mjs";
 
 let orchDir;
 
@@ -251,5 +251,38 @@ describe("readWorkerSignals", () => {
     writeFileSync(join(dir, "triage.json"), JSON.stringify({ artifact: true }));
     const sigs = readWorkerSignals(orchDir);
     expect(sigs).toEqual([]);
+  });
+});
+
+// --- CTL-606: listDispatchedPhases ----------------------------------------
+
+describe("listDispatchedPhases", () => {
+  test("returns every dispatched phase name under workers/<ticket>/", () => {
+    writeNested("CTL-9", "triage", { status: "done" });
+    writeNested("CTL-9", "research", { status: "done" });
+    writeNested("CTL-9", "plan", { status: "running" });
+    expect(listDispatchedPhases(orchDir, "CTL-9").sort()).toEqual([
+      "plan",
+      "research",
+      "triage",
+    ]);
+  });
+
+  test("ignores phase-output artifacts (triage/verify/review/phase-monitor-deploy.json)", () => {
+    writeNested("CTL-9", "implement", { status: "running" });
+    const dir = join(workersDir(), "CTL-9");
+    for (const name of [
+      "triage.json",
+      "verify.json",
+      "review.json",
+      "phase-monitor-deploy.json",
+    ]) {
+      writeFileSync(join(dir, name), JSON.stringify({ artifact: true }));
+    }
+    expect(listDispatchedPhases(orchDir, "CTL-9")).toEqual(["implement"]);
+  });
+
+  test("returns [] when the worker dir does not exist", () => {
+    expect(listDispatchedPhases(orchDir, "NOPE")).toEqual([]);
   });
 });

--- a/plugins/dev/scripts/lib/phase-fsm.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.mjs
@@ -82,6 +82,19 @@ export function linearKeyForPhase(phase) {
   return PHASE_LINEAR_KEY[phase];
 }
 
+// phaseIndex — 0-based position of a pipeline phase in the canonical PHASES
+// sequence. The missing comparator (CTL-606): lets consumers decide whether a
+// phase precedes another without re-deriving the order. Throws PhaseFsmError on
+// an unknown phase so a typo fails loudly rather than silently returning -1
+// (which would misorder before `triage`).
+export function phaseIndex(phase) {
+  const idx = PHASES.indexOf(phase);
+  if (idx === -1) {
+    throw new PhaseFsmError(`unknown phase '${phase}'`);
+  }
+  return idx;
+}
+
 // ─── Validation helpers (private) ───
 function assertState(state) {
   if (state === null || typeof state !== "object" || Array.isArray(state)) {

--- a/plugins/dev/scripts/lib/phase-fsm.test.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.test.mjs
@@ -10,6 +10,7 @@ import {
   PHASE_LINEAR_KEY,
   TERMINAL_LINEAR_KEY,
   linearKeyForPhase,
+  phaseIndex,
   initialState,
   isTerminal,
   transition,
@@ -17,6 +18,23 @@ import {
 
 // Render an arbitrary value as a readable test-name fragment.
 const label = (v) => (v === undefined ? "undefined" : Array.isArray(v) ? "[]" : JSON.stringify(v));
+
+// ─── CTL-606: phaseIndex — the canonical 0-based phase-order comparator ───
+
+describe("phaseIndex", () => {
+  test("returns the canonical 0-based index for every pipeline phase", () => {
+    PHASES.forEach((p, i) => expect(phaseIndex(p)).toBe(i));
+  });
+  test("triage < research < … < monitor-deploy (monotonic ordering)", () => {
+    expect(phaseIndex("triage")).toBeLessThan(phaseIndex("research"));
+    expect(phaseIndex("implement")).toBeLessThan(phaseIndex("verify"));
+    expect(phaseIndex("monitor-merge")).toBeLessThan(phaseIndex("monitor-deploy"));
+  });
+  test("throws PhaseFsmError on an unknown phase (fail loud, never silent -1)", () => {
+    expect(() => phaseIndex("bogus")).toThrow(PhaseFsmError);
+    expect(() => phaseIndex(null)).toThrow(PhaseFsmError);
+  });
+});
 
 // ─── Phase 1: module scaffold + happy-path pipeline ───
 


### PR DESCRIPTION
## Summary

Fixes **CTL-606** — predecessor reaping emitted `phase.<oldphase>.failed.<TICKET>` events that mimicked real failures, risking a healthy in-flight ticket being wrongly revived back to a past phase.

When `orchestrate-phase-advance` reaps a leftover earlier-phase bg job, it marks the old phase signal `stalled` and emits `phase.<oldphase>.failed.<TICKET>`. Any handler that revives on `phase.*.failed.*` would wrongly drag a healthy, already-advanced ticket back to a past phase. This adds a **supersede guard**: a reap/false-dead signal for a phase the ticket has already advanced past is ignored.

## Changes

- **`lib/phase-fsm.mjs`** — add `phaseIndex()` comparator returning the ordinal position of a canonical phase.
- **`execution-core/signal-reader.mjs`** — add `listDispatchedPhases()` reader enumerating dispatched `phase-*.json` signals for a ticket.
- **`execution-core/recovery.mjs`** — supersede guard in `reclaimDeadWorkIfPossible`: no-op when `phaseIndex(phase) < latestDispatchedPhaseIndex(ticket)`.
- **`execution-core/scheduler.mjs`** — wire the guard into the reclaim path.

## Test plan

- New unit coverage: `phase-fsm.test.mjs`, `signal-reader.test.mjs`, `recovery.test.mjs`.
- Adversarial verify + review phases passed (`reviewPassed: true`, no HIGH findings; 1 medium defensive edge deferred-to-human, 2 low pre-existing observations).

Closes CTL-606
