### PR TITLE
CTL-608: Gate phase-implement and phase-verify on empty branch

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -617,6 +617,129 @@ else
   fail "mirror-implement no-base: fallback" "log:$(printf '\n%s' "$(cat "$LOG_D" 2>/dev/null)")"
 fi
 
+# ─── Test 13 (CTL-608): phase-implement empty-branch self-emit gate ───────
+echo ""
+echo "Test 13 (CTL-608): phase-implement contract — empty-branch gate present"
+if [[ -f "$SKILL_IMPLEMENT" ]]; then
+  # The gate must live in its own uniquely-named fence so this harness can
+  # extract+run it, exactly like the mirror fence (Test 12).
+  assert_grep 'phase-implement-empty-branch-gate' "$SKILL_IMPLEMENT" "body contains uniquely-named empty-branch gate fence"
+  assert_grep 'rev-list --count' "$SKILL_IMPLEMENT" "gate counts commits-ahead via rev-list --count"
+  assert_grep 'empty_branch:' "$SKILL_IMPLEMENT" "gate emits failure reason prefixed empty_branch:"
+fi
+
+# ─── Test 14 (CTL-608): empty-branch gate runtime — empty/non-empty/no-base ─
+echo ""
+echo "Test 14 (CTL-608): phase-implement empty-branch gate — empty/non-empty/base-unknown"
+
+GATE_BODY_FILE="${SCRATCH}/empty-branch-gate.sh"
+awk '
+  /^```bash phase-implement-empty-branch-gate$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL_IMPLEMENT" > "$GATE_BODY_FILE"
+
+if [[ -s "$GATE_BODY_FILE" ]]; then
+  pass "empty-branch gate extractable from SKILL.md"
+else
+  fail "empty-branch gate extractable — no \`\`\`bash phase-implement-empty-branch-gate\`\`\` fence found"
+fi
+
+# Stub phase-agent-emit-complete under $PLUGIN_ROOT/scripts/ — the gate calls
+# "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" directly. Captures argv to
+# $EMIT_CAPTURE so the gate's --status / --reason can be asserted.
+install_emit_stub() {
+  local plugin_root="$1"
+  mkdir -p "$plugin_root/scripts"
+  cat > "$plugin_root/scripts/phase-agent-emit-complete" <<'STUB'
+#!/usr/bin/env bash
+# CTL-608 test stub: capture argv so the gate's terminal emit can be asserted.
+echo "$*" >> "${EMIT_CAPTURE:-/dev/null}"
+exit 0
+STUB
+  chmod +x "$plugin_root/scripts/phase-agent-emit-complete"
+}
+
+# Empty branch: HEAD == origin/main (0 commits ahead).
+build_git_fixture_empty() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir"
+  (
+    cd "$repo_dir" || exit 1
+    git init --quiet --initial-branch=main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "base" > base.txt
+    git add base.txt
+    git commit --quiet -m "base commit"
+    git update-ref refs/remotes/origin/main HEAD
+    # Branch sits exactly at origin/main — nothing committed ahead.
+    git checkout --quiet -b feature
+  )
+}
+
+run_empty_branch_gate() {
+  local case_name="$1" fixture_fn="$2"
+  local case_dir="${SCRATCH}/imp-gate-${case_name}"
+  local repo_dir="${case_dir}/repo"
+  local plugin_root="${case_dir}/plugin"
+  mkdir -p "$case_dir"
+  "$fixture_fn" "$repo_dir"
+  install_emit_stub "$plugin_root"
+  (
+    cd "$repo_dir" || exit 1
+    EMIT_CAPTURE="${case_dir}/emit-capture.log" \
+      PLUGIN_ROOT="$plugin_root" \
+      PHASE="implement" \
+      TICKET="CTL-449" \
+      COMMS="" \
+      CHANNEL="orch-e2e" \
+      ORCH_ID="orch-e2e" \
+      bash "$GATE_BODY_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+    echo "$?" > "$case_dir/exit-code"
+  )
+  echo "$case_dir"
+}
+
+# Case E — empty branch: gate must emit --status failed (empty_branch:) + exit 1.
+CASE_E="$(run_empty_branch_gate empty build_git_fixture_empty)"
+assert_eq "1" "$(cat "$CASE_E/exit-code")" "gate empty-branch: exit 1"
+if grep -q -- '--status failed' "$CASE_E/emit-capture.log" 2>/dev/null; then
+  pass "gate empty-branch: emits --status failed"
+else
+  fail "gate empty-branch: --status failed" "capture:$(printf '\n%s' "$(cat "$CASE_E/emit-capture.log" 2>/dev/null)")"
+fi
+if grep -q 'empty_branch:' "$CASE_E/emit-capture.log" 2>/dev/null; then
+  pass "gate empty-branch: reason prefixed empty_branch:"
+else
+  fail "gate empty-branch: reason" "capture:$(printf '\n%s' "$(cat "$CASE_E/emit-capture.log" 2>/dev/null)")"
+fi
+
+# Case F — non-empty branch (origin/main + 2 commits ahead): gate falls through,
+# exit 0, no --status failed captured.
+CASE_F="$(run_empty_branch_gate nonempty build_git_fixture)"
+assert_eq "0" "$(cat "$CASE_F/exit-code")" "gate non-empty: exit 0 (falls through)"
+if grep -q -- '--status failed' "$CASE_F/emit-capture.log" 2>/dev/null; then
+  fail "gate non-empty: must NOT emit --status failed" "capture:$(printf '\n%s' "$(cat "$CASE_F/emit-capture.log" 2>/dev/null)")"
+else
+  pass "gate non-empty: no --status failed (gate is silent on success)"
+fi
+
+# Case G — base unknown (no origin/main, no main): fail-open, exit 0, warn on
+# stderr, no --status failed.
+CASE_G="$(run_empty_branch_gate nobase build_git_fixture_no_base)"
+assert_eq "0" "$(cat "$CASE_G/exit-code")" "gate base-unknown: exit 0 (fail-open)"
+if grep -q -- '--status failed' "$CASE_G/emit-capture.log" 2>/dev/null; then
+  fail "gate base-unknown: must NOT emit --status failed" "capture:$(printf '\n%s' "$(cat "$CASE_G/emit-capture.log" 2>/dev/null)")"
+else
+  pass "gate base-unknown: no --status failed"
+fi
+if grep -q 'could not resolve integration base' "$CASE_G/stderr.log" 2>/dev/null; then
+  pass "gate base-unknown: warns on stderr"
+else
+  fail "gate base-unknown: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_G/stderr.log" 2>/dev/null)")"
+fi
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh
@@ -276,6 +276,171 @@ else
   fail "mirror-verify findings: details JSON" "log:$(printf '\n%s' "$(cat "$LOG_D" 2>/dev/null)")"
 fi
 
+# ─── Test 5 (CTL-608): phase-verify empty-branch backstop gate present ────
+echo ""
+echo "Test 5 (CTL-608): phase-verify contract — empty-branch backstop gate present"
+if [[ -f "$SKILL" ]]; then
+  # Backstop for the live phase-implement gate (Phase 1, already landed): if an
+  # empty branch (0 commits ahead) somehow reaches verify — e.g. via the
+  # reclaim-dead-work path, which emits implement-complete without running the
+  # phase-implement End block / gate — verify must fail fast instead of running
+  # gates and advancing an empty branch to phase-pr. Lives in its own
+  # uniquely-named fence so this harness can extract+run it (like the mirror).
+  assert_contains "$BODY" "phase-verify-empty-branch-gate" "body contains uniquely-named empty-branch gate fence"
+  assert_contains "$BODY" "rev-list --count" "gate counts commits-ahead via rev-list --count"
+  assert_contains "$BODY" "empty_branch:" "gate emits failure reason prefixed empty_branch:"
+  assert_contains "$BODY" "empty branch" "gate body documents the empty-branch condition"
+fi
+
+# ─── Test 6 (CTL-608): empty-branch gate runtime — empty/non-empty/no-base ─
+echo ""
+echo "Test 6 (CTL-608): phase-verify empty-branch gate — empty/non-empty/base-unknown"
+
+VERIFY_GATE_FILE="${SCRATCH}/verify-empty-branch-gate.sh"
+awk '
+  /^```bash phase-verify-empty-branch-gate$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL" > "$VERIFY_GATE_FILE"
+
+if [[ -s "$VERIFY_GATE_FILE" ]]; then
+  pass "empty-branch gate extractable from SKILL.md"
+else
+  fail "empty-branch gate extractable — no \`\`\`bash phase-verify-empty-branch-gate\`\`\` fence found"
+fi
+
+# Stub phase-agent-emit-complete under $PLUGIN_ROOT/scripts/ — the gate calls it
+# directly. Captures argv to $EMIT_CAPTURE so --status / --reason can be asserted.
+install_verify_emit_stub() {
+  local plugin_root="$1"
+  mkdir -p "$plugin_root/scripts"
+  cat > "$plugin_root/scripts/phase-agent-emit-complete" <<'STUB'
+#!/usr/bin/env bash
+# CTL-608 test stub: capture argv so the gate's terminal emit can be asserted.
+echo "$*" >> "${EMIT_CAPTURE:-/dev/null}"
+exit 0
+STUB
+  chmod +x "$plugin_root/scripts/phase-agent-emit-complete"
+}
+
+# Empty branch: HEAD == origin/main (0 commits ahead).
+build_verify_fixture_empty() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir"
+  (
+    cd "$repo_dir" || exit 1
+    git init --quiet --initial-branch=main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "base" > base.txt
+    git add base.txt
+    git commit --quiet -m "base commit"
+    git update-ref refs/remotes/origin/main HEAD
+    git checkout --quiet -b feature
+  )
+}
+
+# Non-empty branch: origin/main + 2 commits ahead.
+build_verify_fixture_nonempty() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir"
+  (
+    cd "$repo_dir" || exit 1
+    git init --quiet --initial-branch=main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "base" > base.txt
+    git add base.txt
+    git commit --quiet -m "base commit"
+    git update-ref refs/remotes/origin/main HEAD
+    git checkout --quiet -b feature
+    echo "change one" > a.txt
+    git add a.txt
+    git commit --quiet -m "feat: first commit"
+    echo "change two" > b.txt
+    git add b.txt
+    git commit --quiet -m "feat: second commit"
+  )
+}
+
+# Base unknown: no main, no origin/main.
+build_verify_fixture_no_base() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir"
+  (
+    cd "$repo_dir" || exit 1
+    git init --quiet --initial-branch=feature
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "x" > x.txt
+    git add x.txt
+    git commit --quiet -m "feat: solo commit"
+  )
+}
+
+run_verify_empty_branch_gate() {
+  local case_name="$1" fixture_fn="$2"
+  local case_dir="${SCRATCH}/ver-gate-${case_name}"
+  local repo_dir="${case_dir}/repo"
+  local plugin_root="${case_dir}/plugin"
+  mkdir -p "$case_dir"
+  "$fixture_fn" "$repo_dir"
+  install_verify_emit_stub "$plugin_root"
+  (
+    cd "$repo_dir" || exit 1
+    EMIT_CAPTURE="${case_dir}/emit-capture.log" \
+      PLUGIN_ROOT="$plugin_root" \
+      PHASE="verify" \
+      TICKET="CTL-450" \
+      BASE_BRANCH="main" \
+      COMMS="" \
+      CHANNEL="orch-e2e" \
+      ORCH_ID="orch-e2e" \
+      bash "$VERIFY_GATE_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+    echo "$?" > "$case_dir/exit-code"
+  )
+  echo "$case_dir"
+}
+
+# Case E — empty branch: gate must emit --status failed (empty_branch:) + exit 1.
+VCASE_E="$(run_verify_empty_branch_gate empty build_verify_fixture_empty)"
+assert_eq "1" "$(cat "$VCASE_E/exit-code")" "verify gate empty-branch: exit 1"
+if grep -q -- '--status failed' "$VCASE_E/emit-capture.log" 2>/dev/null; then
+  pass "verify gate empty-branch: emits --status failed"
+else
+  fail "verify gate empty-branch: --status failed — capture:$(printf '\n%s' "$(cat "$VCASE_E/emit-capture.log" 2>/dev/null)")"
+fi
+if grep -q 'empty_branch:' "$VCASE_E/emit-capture.log" 2>/dev/null; then
+  pass "verify gate empty-branch: reason prefixed empty_branch:"
+else
+  fail "verify gate empty-branch: reason — capture:$(printf '\n%s' "$(cat "$VCASE_E/emit-capture.log" 2>/dev/null)")"
+fi
+
+# Case F — non-empty branch (origin/main + 2 commits ahead): gate falls through,
+# exit 0, no --status failed captured.
+VCASE_F="$(run_verify_empty_branch_gate nonempty build_verify_fixture_nonempty)"
+assert_eq "0" "$(cat "$VCASE_F/exit-code")" "verify gate non-empty: exit 0 (falls through)"
+if grep -q -- '--status failed' "$VCASE_F/emit-capture.log" 2>/dev/null; then
+  fail "verify gate non-empty: must NOT emit --status failed — capture:$(printf '\n%s' "$(cat "$VCASE_F/emit-capture.log" 2>/dev/null)")"
+else
+  pass "verify gate non-empty: no --status failed (gate is silent on success)"
+fi
+
+# Case G — base unknown (no origin/main, no main): fail-open, exit 0, warn on
+# stderr, no --status failed.
+VCASE_G="$(run_verify_empty_branch_gate nobase build_verify_fixture_no_base)"
+assert_eq "0" "$(cat "$VCASE_G/exit-code")" "verify gate base-unknown: exit 0 (fail-open)"
+if grep -q -- '--status failed' "$VCASE_G/emit-capture.log" 2>/dev/null; then
+  fail "verify gate base-unknown: must NOT emit --status failed — capture:$(printf '\n%s' "$(cat "$VCASE_G/emit-capture.log" 2>/dev/null)")"
+else
+  pass "verify gate base-unknown: no --status failed"
+fi
+if grep -q 'could not resolve integration base' "$VCASE_G/stderr.log" 2>/dev/null; then
+  pass "verify gate base-unknown: warns on stderr"
+else
+  fail "verify gate base-unknown: warning — stderr:$(printf '\n%s' "$(cat "$VCASE_G/stderr.log" 2>/dev/null)")"
+fi
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-verify-e2e: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -259,6 +259,40 @@ EOF
 fi
 ```
 
+Then the empty-branch self-emit gate (CTL-608). Runs **before** the terminal
+`--status complete` so a worker cannot self-report implement success on an empty
+ticket branch (0 commits ahead of its integration base). This is the ADV-1128
+failure mode: sub-agent commits stranded in nested `.claude/worktrees/agent-*`
+worktrees never reach `refs/heads/<ticket>`, leaving HEAD at base and opening an
+empty PR. Uniquely-named fence so the e2e harness can extract+exercise it; uses
+only POSIX/zsh-safe `git rev-list --count` (no `${VAR,,}` / `shopt`). Fail-open
+(warn + allow) only when the base is unresolvable, mirroring the mirror block's
+`_base branch unknown_` tolerance.
+
+```bash phase-implement-empty-branch-gate
+EMPTY_BRANCH_GATE_BASE=""
+if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  EMPTY_BRANCH_GATE_BASE="origin/main"
+elif git rev-parse --verify --quiet main >/dev/null 2>&1; then
+  EMPTY_BRANCH_GATE_BASE="main"
+fi
+if [[ -n "${EMPTY_BRANCH_GATE_BASE}" ]]; then
+  AHEAD="$(git rev-list --count "${EMPTY_BRANCH_GATE_BASE}..HEAD" 2>/dev/null || echo 0)"
+  if [[ "${AHEAD:-0}" -le 0 ]]; then
+    echo "phase-implement: 0 commits ahead of ${EMPTY_BRANCH_GATE_BASE}; refusing to emit complete on an empty branch (CTL-608)" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "empty_branch:0_commits_ahead_of_${EMPTY_BRANCH_GATE_BASE}"
+    [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+      "phase-implement failed: empty branch (0 commits ahead of ${EMPTY_BRANCH_GATE_BASE})" \
+      --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+else
+  echo "phase-implement: could not resolve integration base (no origin/main or main); skipping empty-branch gate (CTL-608)" >&2
+fi
+```
+
 ```bash
 EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
 if [[ -x "$EMIT" ]]; then

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -132,6 +132,47 @@ BASE_BRANCH="${BASE_BRANCH:-main}"
 DIFF_RANGE="origin/${BASE_BRANCH}...HEAD"
 ```
 
+#### CTL-608: empty-branch backstop
+
+Defense-in-depth for the live `phase-implement` empty-branch gate. That gate runs
+in the phase-implement End block, but the execution-core **reclaim-dead-work**
+path emits `implement-complete` on a worker's behalf *without* running that End
+block — so an empty branch (0 commits ahead) can still reach verify. Counting
+commits-ahead here means an empty branch emits `phase.verify.failed` instead of
+running the full gate suite and advancing an empty branch to `phase-pr`. Reuses
+`BASE_BRANCH` from step 1; uses only POSIX/zsh-safe `git rev-list --count`.
+Fail-open (warn + continue) when the base is unresolvable, matching
+phase-implement and the mirror block's `_base branch unknown_` tolerance.
+Uniquely-named fence so the e2e harness can extract+exercise it.
+
+```bash phase-verify-empty-branch-gate
+# CTL-608: backstop — an empty branch (0 commits ahead) means there is nothing
+# to verify and advancing would open an empty PR. phase-implement's gate should
+# already have caught this; this is defense-in-depth for the reclaim path.
+# Fail-open if the base is unresolvable (warn + continue), matching phase-implement.
+VERIFY_GATE_BASE=""
+if git rev-parse --verify --quiet "origin/${BASE_BRANCH}" >/dev/null 2>&1; then
+  VERIFY_GATE_BASE="origin/${BASE_BRANCH}"
+elif git rev-parse --verify --quiet "${BASE_BRANCH}" >/dev/null 2>&1; then
+  VERIFY_GATE_BASE="${BASE_BRANCH}"
+fi
+if [[ -n "${VERIFY_GATE_BASE}" ]]; then
+  VERIFY_AHEAD="$(git rev-list --count "${VERIFY_GATE_BASE}..HEAD" 2>/dev/null || echo 0)"
+  if [[ "${VERIFY_AHEAD:-0}" -le 0 ]]; then
+    echo "phase-verify: 0 commits ahead of ${VERIFY_GATE_BASE}; empty branch, nothing to verify (CTL-608)" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "empty_branch:0_commits_ahead_of_${VERIFY_GATE_BASE}"
+    [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+      "phase-verify failed: empty branch (0 commits ahead of ${VERIFY_GATE_BASE})" \
+      --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+else
+  echo "phase-verify: could not resolve integration base (no origin/${BASE_BRANCH} or ${BASE_BRANCH}); skipping empty-branch gate (CTL-608)" >&2
+fi
+```
+
 ### 2. Run read-only gates
 
 Run each gate; record pass/fail/skip into the in-memory results map. Do not stop


### PR DESCRIPTION
<!-- PR: #1073 -->

## Summary

Adds two empty-branch backstop gates to the orchestrator phase pipeline so a
ticket branch with **0 commits ahead of its integration base** can never
self-report `implement-complete` or advance through `verify` to open an empty
PR. This is the ADV-1128 failure mode: a `phase-implement` worker delegates to
sub-agents whose commits land in nested `.claude/worktrees/agent-*` worktrees and
never reach `refs/heads/<ticket>`, leaving HEAD at the base branch.

## Changes Made

### `plugins/dev/skills/phase-implement/SKILL.md`

- New **empty-branch self-emit gate** in the End block, running *before* the
  terminal `--status complete` emit. Resolves the integration base
  (`origin/main` → `main`), counts commits-ahead via `git rev-list --count`, and
  if `<= 0` emits `phase-agent-emit-complete --status failed` with reason
  `empty_branch:0_commits_ahead_of_<base>`, sends a comms attention message, and
  exits 1.
- Fail-open: when no base is resolvable, it warns on stderr and falls through
  (matching the mirror block's `_base branch unknown_` tolerance).
- Uses only POSIX/zsh-safe shell (`git rev-list --count`, no `${VAR,,}` /
  `shopt`). Wrapped in a uniquely-named ```` ```bash phase-implement-empty-branch-gate ````
  fence so the e2e harness can extract and exercise it.

### `plugins/dev/skills/phase-verify/SKILL.md`

- New **empty-branch backstop gate** after base-range setup. Defense-in-depth
  for the reclaim path: execution-core `reclaim-dead-work` can emit
  `implement-complete` on a worker's behalf *without* running the phase-implement
  End block, so an empty branch can still reach verify. This gate counts
  commits-ahead of `BASE_BRANCH` and emits `phase.verify.failed` rather than
  running the full gate suite and advancing an empty branch to `phase-pr`.
- Same fail-open semantics and zsh-safe shell as the phase-implement gate.

### Tests

- `plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh` — Tests 13/14:
  contract assertions (gate fence present, uses `rev-list --count`, emits
  `empty_branch:` reason) plus runtime cases E/F/G (empty branch → exit 1 +
  `--status failed`; non-empty → exit 0 silent; base-unknown → fail-open exit 0).
- `plugins/dev/scripts/__tests__/phase-verify-e2e.test.sh` — parallel contract +
  runtime coverage for the verify backstop.

## How to Verify It

- [x] phase-implement e2e suite passes (verify phase, all gates green)
- [x] phase-verify e2e suite passes
- [x] `git merge-tree` clean against origin/main (0 behind, 2 ahead, no conflicts)
- [x] Markdown/shell-only change; no application runtime code touched

## Related Issues/PRs

- Fixes CTL-608 — phase-implement sub-agents commit to nested worktrees; work
  stranded off the ticket branch

Refs: CTL-608
