### PR TITLE
CTL-641: Add per-phase work-done probes for execution-core daemon

### DIFF
--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -215,14 +215,18 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     expect(existsSync(join(orchDir, "workers", "CTL-587-C", ".revive-1.applied"))).toBe(false); // no marker on suppression
   });
 
-  test("no-probe phase (pr) on a dead worker → 'escalated' immediately", () => {
+  // CTL-641 + CTL-604: pr now has a probe, but a dead pr worker whose
+  // phase-pr.json carries no .pr.number reads as not-done → branch (C). CTL-604
+  // made branch (C) phase-agnostic, so (with budget available) the worker is
+  // re-dispatched fresh rather than dead-ended — 'revived', reviveDispatch fires.
+  test("not-done pr phase on a dead worker → 'revived' (budget available)", () => {
     seedSignal("CTL-587-D", "pr", {
       status: "running",
       bg_job_id: "nonexistent-bg-id",
       orchestrator: "CTL-587-D",
     });
 
-    const labelCalls = [];
+    const reviveDispatchCalls = [];
     const result = schedulerTick(orchDir, {
       readEligible: () => [],
       dispatch: () => ({ code: 0 }),
@@ -236,18 +240,19 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         reclaimDeadWorkIfPossible(od, sig, {
           ...opts,
           statJob: () => null, // bg dead
-          // Default probes registry — only 'implement' has a probe; pr does not.
-          applyStalledLabel: ({ ticket }) => {
-            labelCalls.push(ticket);
-            return { applied: true };
+          // Default probes registry: pr's real probe reads .pr.number from
+          // phase-pr.json; the seeded signal has none → not-done → branch (C).
+          reviveDispatch: (args) => {
+            reviveDispatchCalls.push(args);
+            return { code: 0 };
           },
-          reviveDispatch: () => {
-            throw new Error("revive must not be called for no-probe escalation");
-          },
+          killBgJob: () => {},
+          // No prior revive events for CTL-587-D → budget available (0 < 2).
         }),
     });
 
-    expect(result.escalated).toEqual([{ ticket: "CTL-587-D", phase: "pr" }]);
-    expect(labelCalls).toEqual(["CTL-587-D"]);
+    expect(result.revived).toEqual([{ ticket: "CTL-587-D", phase: "pr" }]);
+    expect(result.escalated).toEqual([]);
+    expect(reviveDispatchCalls).toHaveLength(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -690,9 +690,11 @@ export function reclaimDeadWorkIfPossible(
     return escalateOnce("no-probe-for-phase", 0);
   }
 
-  // (B) Probe says work IS done → CTL-574 reclaim. Unchanged.
+  // (B) Probe says work IS done → CTL-574 reclaim. CTL-641 threads orchDir
+  //     (already this function's first param) so worker-dir / worktree probes
+  //     can locate their artifact; implementProbe ignores the extra key.
   const probe = probes[phase];
-  if (probe({ ticket, repoRoot })) {
+  if (probe({ ticket, repoRoot, orchDir })) {
     appendEvent({ phase, ticket, orchId });
     const r = emitComplete({ orchDir, signal });
     if (r.code !== 0) {

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -562,26 +562,32 @@ describe("reclaimDeadWorkIfPossible", () => {
   // CTL-587: this case used to return 'not-applicable' (a silent dead-end).
   // It now escalates immediately — no probe means no way to verify the work,
   // so the human must look. needs-human label is applied via the injected seam.
-  test("CTL-587: dead worker on a no-probe phase → 'escalated' + needs-human label", () => {
-    // CTL-604/CTL-641: implement/research/plan/triage/verify/review/monitor-deploy
-    // now have probes, so use `pr` — still probe-less — as the example of a phase
-    // that hits branch (A) escalation.
-    const sig = { ...implementSignal(), phase: "pr" };
-    sig.raw.phase = "pr";
+  test("CTL-587: dead worker, probe NOT done + revive budget exhausted → 'escalated' + needs-human label", () => {
+    // CTL-641: every pipeline phase now has a probe, so the old branch-(A)
+    // "no-probe-for-phase" escalation is unreachable for real phases (and CTL-606's
+    // supersede guard throws on a non-PHASES phase before branch (A) is reached).
+    // The reachable "dead worker → needs-human" path is branch (C) once the revive
+    // budget is spent.
+    const sig = { ...implementSignal(), phase: "verify" };
+    sig.raw.phase = "verify";
     const emit = recorder({ code: 0 });
     const appendEscalated = recorder(undefined);
     const applyLabel = recorder({ applied: true });
+    const reviveDispatch = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, sig, {
       statJob: () => null, // bg dead
-      probes: { implement: recorder(true) }, // pr not registered
+      probes: { verify: recorder(false) }, // artifact NOT complete
       emitComplete: emit,
       appendEvent: recorder(undefined),
       appendEscalatedEvent: appendEscalated,
       applyStalledLabel: applyLabel,
+      reviveDispatch,
+      countReviveEvents: recorder(2), // budget exhausted (MAX_REVIVES)
     });
     expect(r).toBe("escalated");
     expect(emit.calls.length).toBe(0);
-    expect(appendEscalated.calls[0][0].reason).toBe("no-probe-for-phase");
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(appendEscalated.calls[0][0].reason).toBe("revive-budget-exhausted");
     expect(applyLabel.calls[0][0].ticket).toBe("CTL-9");
   });
 
@@ -754,11 +760,10 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
       opts: {
         repoRoot: "/repo",
         statJob: () => ({ exists: true, mtimeMs: stateJsonMtime }),
-        // CTL-604: inject a probe for any probed phase (implement/research/plan)
-        // so branch (B)/(C) is exercised; probe-less phases (pr/verify/…) get {}.
-        probes: ["implement", "research", "plan"].includes(phase)
-          ? { [phase]: recorder(probeResult) }
-          : {},
+        // CTL-641: every pipeline phase now has a probe, so inject one for
+        // whatever phase the scenario uses (an unregistered phase still hits
+        // branch (A) before the probe is dereferenced, so a stub is harmless).
+        probes: { [phase]: recorder(probeResult) },
         emitComplete: recorder({ code: 0 }),
         appendEvent: recorder(undefined),
         appendReviveEvent: recorder(undefined),
@@ -815,12 +820,17 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
   });
 
-  test("not-applicable (no probe registered for phase) → 'escalated' immediately", () => {
-    const s = setupReviveScenario({ phase: "pr" });
+  // CTL-641: pr/monitor-merge are now registered, so branch (A) is reached only
+  // by a genuinely-unknown phase. Use one to keep the no-probe guard under test.
+  test("probe NOT done + revive budget exhausted → 'escalated' immediately", () => {
+    // CTL-641/CTL-606: branch (A) "no-probe-for-phase" is now unreachable (all
+    // real phases are probed; unknown phases throw at the supersede guard). The
+    // budget-exhausted escalation is the reachable dead-end-to-human path.
+    const s = setupReviveScenario({ phase: "verify", probeResult: false, reviveCount: 2 });
     const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
     expect(r).toBe("escalated");
-    expect(s.opts.appendEscalatedEvent.calls[0][0].phase).toBe("pr");
-    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("no-probe-for-phase");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].phase).toBe("verify");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("revive-budget-exhausted");
     expect(s.opts.applyStalledLabel.calls.length).toBe(1);
     expect(s.opts.reviveDispatch.calls.length).toBe(0);
   });
@@ -1005,9 +1015,13 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
       opts: {
         repoRoot: "/repo",
         statJob: () => ({ exists: true, mtimeMs: 1_000 }),
-        probes: overrides.phase === "implement" || !overrides.phase
-          ? { implement: recorder(overrides.probeResult ?? false) }
-          : {},
+        // CTL-641 + CTL-606: every real phase now has a probe (so branch (A) is
+        // skipped) and CTL-606's supersede guard throws on a non-PHASES phase, so
+        // these storm-prevention tests can no longer reach the old branch-(A)
+        // no-probe escalation. They instead drive the reachable branch-(C)
+        // revive-budget-exhausted escalation: a probe-false real phase with the
+        // revive budget exhausted (reviveCount default below = MAX_REVIVES).
+        probes: { [overrides.phase ?? "implement"]: recorder(overrides.probeResult ?? false) },
         emitComplete: recorder({ code: 0 }),
         appendEvent: recorder(undefined),
         appendReviveEvent: recorder(undefined),
@@ -1016,7 +1030,7 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
         reviveDispatch: recorder({ code: 0 }),
         applyStalledLabel: recorder({ applied: true }),
         killBgJob: recorder(undefined),
-        countReviveEvents: recorder(overrides.reviveCount ?? 0),
+        countReviveEvents: recorder(overrides.reviveCount ?? 2), // default = MAX_REVIVES → budget-exhausted escalation
         countDistinctRevivingTickets: recorder(1),
         writeReviveMarker: recorder(undefined),
         now: () => overrides.nowMs ?? 1_000 + 6 * 60 * 1000,
@@ -1028,7 +1042,7 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
   }
 
   test("acceptance: second tick on same (ticket, phase) suppresses — exactly one event + one label write", () => {
-    const s = setupAt(orchDir, { phase: "pr" }); // no-probe branch
+    const s = setupAt(orchDir, { phase: "pr" }); // branch (C): revive-budget-exhausted
 
     expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(1);
@@ -1091,7 +1105,7 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
     // recordEscalationFn signature: (orchDir, ticket, phase, reason, now)
     expect(recCd.calls[0][1]).toBe("CTL-9");
     expect(recCd.calls[0][2]).toBe("pr");
-    expect(recCd.calls[0][3]).toBe("no-probe-for-phase");
+    expect(recCd.calls[0][3]).toBe("revive-budget-exhausted");
   });
 
   test("escalation-suppressed return path does NOT call appendEscalatedEvent / applyStalledLabel / recordEscalationFn", () => {

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -563,16 +563,17 @@ describe("reclaimDeadWorkIfPossible", () => {
   // It now escalates immediately — no probe means no way to verify the work,
   // so the human must look. needs-human label is applied via the injected seam.
   test("CTL-587: dead worker on a no-probe phase → 'escalated' + needs-human label", () => {
-    // CTL-604: research/plan now have probes, so use `verify` — still probe-less
-    // — as the example of a phase that hits branch (A) escalation.
-    const sig = { ...implementSignal(), phase: "verify" };
-    sig.raw.phase = "verify";
+    // CTL-604/CTL-641: implement/research/plan/triage/verify/review/monitor-deploy
+    // now have probes, so use `pr` — still probe-less — as the example of a phase
+    // that hits branch (A) escalation.
+    const sig = { ...implementSignal(), phase: "pr" };
+    sig.raw.phase = "pr";
     const emit = recorder({ code: 0 });
     const appendEscalated = recorder(undefined);
     const applyLabel = recorder({ applied: true });
     const r = reclaimDeadWorkIfPossible(orch, sig, {
       statJob: () => null, // bg dead
-      probes: { implement: recorder(true) }, // verify not registered
+      probes: { implement: recorder(true) }, // pr not registered
       emitComplete: emit,
       appendEvent: recorder(undefined),
       appendEscalatedEvent: appendEscalated,
@@ -655,7 +656,7 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(emit.calls.length).toBe(1);
   });
 
-  test("repoRoot is forwarded to the probe (so the probe can resolve the worktree)", () => {
+  test("repoRoot + orchDir are forwarded to the probe (CTL-641: probes resolve worker-dir + worktree artifacts)", () => {
     let seen = null;
     const probe = (args) => {
       seen = args;
@@ -668,7 +669,55 @@ describe("reclaimDeadWorkIfPossible", () => {
       appendEvent: () => {},
       repoRoot: "/repo/x",
     });
-    expect(seen).toEqual({ ticket: "CTL-42", repoRoot: "/repo/x" });
+    // orchDir is the function's first positional arg (`orch` === "/orch").
+    expect(seen).toEqual({ ticket: "CTL-42", repoRoot: "/repo/x", orchDir: orch });
+  });
+
+  // CTL-641: a dead NON-implement worker is reclaimed when its probe says the
+  // artifact is complete (branch B). When the probe says it is NOT complete it
+  // enters CTL-604's phase-agnostic revive path (branch C) — CTL-604 removed the
+  // earlier "re-dispatch stays implement-only" rule, so every probe-backed phase
+  // (including the CTL-641 JSON worker-dir phases) is re-dispatched fresh rather
+  // than dead-ended at needs-human.
+  test("CTL-641: non-implement phase with probe true → 'reclaimed' (emit-complete called)", () => {
+    const sig = { ...implementSignal({ ticket: "CTL-7" }), phase: "verify" };
+    sig.raw.phase = "verify";
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => null, // bg dead
+      probes: { verify: () => true }, // artifact complete
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      repoRoot: "/repo",
+    });
+    expect(r).toBe("reclaimed");
+    expect(emit.calls.length).toBe(1);
+  });
+
+  test("CTL-641: non-implement phase with probe false → 'revived' (CTL-604 phase-agnostic re-dispatch)", () => {
+    const sig = { ...implementSignal({ ticket: "CTL-7" }), phase: "verify" };
+    sig.raw.phase = "verify";
+    const emit = recorder({ code: 0 });
+    const appendRevive = recorder(undefined);
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => null, // bg dead
+      probes: { verify: () => false }, // artifact NOT complete
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      appendReviveEvent: appendRevive,
+      reviveDispatch,
+      countReviveEvents: recorder(0),
+      countDistinctRevivingTickets: recorder(1),
+      writeReviveMarker: recorder(undefined),
+      killBgJob: recorder(undefined),
+      applyStalledLabel: recorder({ applied: true }),
+      repoRoot: "/repo",
+    });
+    expect(r).toBe("revived");
+    expect(emit.calls.length).toBe(0); // not reclaimed
+    expect(appendRevive.calls.length).toBe(1);
+    expect(reviveDispatch.calls.length).toBe(1); // CTL-604: non-implement phases re-dispatch too
   });
 });
 

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -5,8 +5,9 @@
 // The registry maps phase name → probe function. `implement` checks commit state
 // (CTL-574); `research`/`plan` check for a complete on-disk artifact (CTL-604);
 // `triage`/`verify`/`review`/`monitor-deploy` validate a worker-dir JSON artifact's
-// content (CTL-641). Only `pr`/`monitor-merge` remain without a probe — they have
-// no single on-disk artifact and stay CTL-587's auto-revival responsibility.
+// content and `pr`/`monitor-merge` query the PR's REST merge state (CTL-641).
+// Every pipeline phase now carries a probe — branch (A) "no-probe-for-phase"
+// escalation is reached only by a genuinely-unknown phase name.
 
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
@@ -133,6 +134,68 @@ function monitorDeployProbe({ ticket, orchDir } = {}, { readFile = defaultReadFi
   return ok && DEPLOY_DONE_STATES.has(value?.deploy_state);
 }
 
+// CTL-641 Phase 3: gh-backed probes (pr, monitor-merge). pr is done when its PR
+// is open or already merged; monitor-merge is done when the PR is merged. The
+// PR number/url come from the worker-dir signal; the merge state comes from the
+// REST endpoint (`gh api repos/<slug>/pulls/<n>` → lowercase `.state`/`.merged`,
+// per research §4 — NOT `gh pr view --json state`, whose GraphQL state is
+// uppercase and would never compare equal to "open").
+
+// defaultRunGh — `gh <args>` with stdout/stderr captured; never throws.
+export function defaultRunGh(args, { spawn = spawnSync } = {}) {
+  const res = spawn("gh", args, { encoding: "utf8" });
+  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
+  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// prInfoFromSignal — read { number, url } from a worker-dir signal's .pr. null
+// on any miss (missing file, parse error, no number).
+function prInfoFromSignal(orchDir, ticket, signalName, readFile) {
+  const { ok, value } = readJson(workerArtifact(orchDir, ticket, signalName), readFile);
+  if (!ok || !value?.pr?.number) return null;
+  return { number: value.pr.number, url: value.pr.url ?? null };
+}
+
+// repoSlugFromUrl — "https://github.com/owner/repo/pull/42" → "owner/repo", or null.
+function repoSlugFromUrl(url) {
+  const m = typeof url === "string" && url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/);
+  return m ? m[1] : null;
+}
+
+// ghPullRest — REST pull payload ({ state, merged, … }) for a PR, or null on any
+// gh/parse failure. Slug from the PR url; when absent, gh substitutes
+// {owner}/{repo} from the cwd repo.
+function ghPullRest(pr, runGh) {
+  const slug = repoSlugFromUrl(pr.url) || "{owner}/{repo}";
+  const res = runGh(["api", `repos/${slug}/pulls/${pr.number}`]);
+  if (res.code !== 0) return null;
+  try {
+    return JSON.parse(res.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function prProbe({ ticket, orchDir } = {}, { readFile = defaultReadFile, runGh = defaultRunGh } = {}) {
+  if (!ticket || !orchDir) return false;
+  const pr = prInfoFromSignal(orchDir, ticket, "phase-pr.json", readFile);
+  if (!pr) return false;
+  const json = ghPullRest(pr, runGh);
+  // open or already-merged both mean the PR phase landed its artifact.
+  return json?.state === "open" || json?.merged === true;
+}
+
+function monitorMergeProbe({ ticket, orchDir } = {}, { readFile = defaultReadFile, runGh = defaultRunGh } = {}) {
+  if (!ticket || !orchDir) return false;
+  const mm = prInfoFromSignal(orchDir, ticket, "phase-monitor-merge.json", readFile);
+  const prSig = prInfoFromSignal(orchDir, ticket, "phase-pr.json", readFile);
+  const number = mm?.number ?? prSig?.number;
+  if (!number) return false;
+  // phase-monitor-merge.json omits .pr.url, so prefer phase-pr.json for the slug.
+  const url = prSig?.url ?? mm?.url ?? null;
+  return ghPullRest({ number, url }, runGh)?.merged === true;
+}
+
 // implementProbe — commits-ahead>0 vs origin/main + clean tree on the worktree
 // bound to refs/heads/<ticket>. The worktree path is resolved from `git worktree
 // list --porcelain` (not reconstructed from projectKey config) so it's correct
@@ -219,8 +282,9 @@ const planProbe = artifactProbe("thoughts/shared/plans", {
 });
 
 // WORK_DONE_PROBES — phase → probe. Adding a probe is the entire opt-in for a
-// phase to participate in the CTL-574 reclaim sweep. Phases without an entry
-// (verify/review/pr/monitor-*) remain CTL-587's responsibility (auto-revival).
+// phase to participate in the CTL-574 reclaim sweep. All nine pipeline phases
+// now have an entry; only a genuinely-unknown phase falls through to CTL-587's
+// branch-(A) escalation.
 export const WORK_DONE_PROBES = {
   implement: implementProbe,
   research: researchProbe,
@@ -228,6 +292,8 @@ export const WORK_DONE_PROBES = {
   triage: triageProbe,
   verify: verifyProbe,
   review: reviewProbe,
+  pr: prProbe,
+  "monitor-merge": monitorMergeProbe,
   "monitor-deploy": monitorDeployProbe,
 };
 

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -3,9 +3,10 @@
 // at module load.
 //
 // The registry maps phase name → probe function. `implement` checks commit state
-// (CTL-574); `research`/`plan` check for a complete on-disk artifact (CTL-604).
-// Only `verify`/`review`/`pr`/`monitor-*` remain without a probe — they have no
-// single on-disk artifact and stay CTL-587's auto-revival responsibility.
+// (CTL-574); `research`/`plan` check for a complete on-disk artifact (CTL-604);
+// `triage`/`verify`/`review`/`monitor-deploy` validate a worker-dir JSON artifact's
+// content (CTL-641). Only `pr`/`monitor-merge` remain without a probe — they have
+// no single on-disk artifact and stay CTL-587's auto-revival responsibility.
 
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
@@ -53,6 +54,83 @@ export function resolveWorktree({ ticket, repoRoot } = {}, { runGit = defaultRun
   const list = runGit(["-C", repoRoot, "worktree", "list", "--porcelain"]);
   if (list.code !== 0) return null;
   return parseWorktreeForBranch(list.stdout, ticket) || null;
+}
+
+// defaultReadFile — read a file as utf8. Returns { ok, content }; never throws
+// (ENOENT / EACCES → { ok: false, content: "" }). Mirrors defaultRunGit's
+// never-throw contract so probes keep their safe-default-false logic linear.
+export function defaultReadFile(path, { read = readFileSync } = {}) {
+  try {
+    return { ok: true, content: read(path, "utf8") };
+  } catch {
+    return { ok: false, content: "" };
+  }
+}
+
+// readJson — { ok, value } parse of a worker-dir JSON artifact. ok=false on a
+// missing file OR a parse error (both mean "not done").
+function readJson(path, readFile) {
+  const { ok, content } = readFile(path);
+  if (!ok) return { ok: false, value: null };
+  try {
+    return { ok: true, value: JSON.parse(content) };
+  } catch {
+    return { ok: false, value: null };
+  }
+}
+
+// workerArtifact — ${orchDir}/workers/<ticket>/<name>; the canonical worker-dir
+// JSON/signal layout (signal-reader.mjs).
+const workerArtifact = (orchDir, ticket, name) => `${orchDir}/workers/${ticket}/${name}`;
+
+// CTL-641: JSON worker-dir probes (triage, verify, review, monitor-deploy).
+// Each validates artifact CONTENT, not mere existence (memory
+// project_phase_rewalk_artifact_validation: a truncated artifact must read as
+// not-done). Field shapes verified against the phase skills + real archived
+// artifacts: triage.json {classification,…}, verify.json
+// {regression_risk,findings,tests_attempted,gates,generatedAt} (phase-verify
+// SKILL.md:182-189), review.json
+// {findings,remediationCommit,reviewPassed,generatedAt} (phase-review
+// SKILL.md:167-175), phase-monitor-deploy.json {deploy_state,…}.
+
+function triageProbe({ ticket, orchDir } = {}, { readFile = defaultReadFile } = {}) {
+  if (!ticket || !orchDir) return false;
+  const { ok, value } = readJson(workerArtifact(orchDir, ticket, "triage.json"), readFile);
+  return ok && typeof value?.classification === "string" && value.classification.trim() !== "";
+}
+
+function verifyProbe({ ticket, orchDir } = {}, { readFile = defaultReadFile } = {}) {
+  if (!ticket || !orchDir) return false;
+  const { ok, value } = readJson(workerArtifact(orchDir, ticket, "verify.json"), readFile);
+  if (!ok || !value) return false;
+  return (
+    Array.isArray(value.findings) &&
+    "regression_risk" in value &&
+    "tests_attempted" in value &&
+    "gates" in value &&
+    typeof value.generatedAt === "string"
+  );
+}
+
+function reviewProbe({ ticket, orchDir } = {}, { readFile = defaultReadFile } = {}) {
+  if (!ticket || !orchDir) return false;
+  const { ok, value } = readJson(workerArtifact(orchDir, ticket, "review.json"), readFile);
+  if (!ok || !value) return false;
+  return (
+    Array.isArray(value.findings) &&
+    typeof value.reviewPassed === "boolean" &&
+    "remediationCommit" in value &&
+    typeof value.generatedAt === "string"
+  );
+}
+
+// deploy_state ∈ {success, skipped} is terminal-done (signal-reader.mjs:29 ranks
+// `skipped` the same as `done`: no deployment_status arrived before the timeout).
+const DEPLOY_DONE_STATES = new Set(["success", "skipped"]);
+function monitorDeployProbe({ ticket, orchDir } = {}, { readFile = defaultReadFile } = {}) {
+  if (!ticket || !orchDir) return false;
+  const { ok, value } = readJson(workerArtifact(orchDir, ticket, "phase-monitor-deploy.json"), readFile);
+  return ok && DEPLOY_DONE_STATES.has(value?.deploy_state);
 }
 
 // implementProbe — commits-ahead>0 vs origin/main + clean tree on the worktree
@@ -147,6 +225,10 @@ export const WORK_DONE_PROBES = {
   implement: implementProbe,
   research: researchProbe,
   plan: planProbe,
+  triage: triageProbe,
+  verify: verifyProbe,
+  review: reviewProbe,
+  "monitor-deploy": monitorDeployProbe,
 };
 
 // hasProbe — true when the given phase has a registered probe. Used by the

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -7,6 +7,7 @@ import {
   hasProbe,
   defaultRunGit,
   resolveWorktree,
+  defaultReadFile,
 } from "./work-done-probes.mjs";
 
 // makeRunGit — a deterministic `git` fake keyed on the trailing positional args.
@@ -84,18 +85,149 @@ ${"Overview prose to clear the size floor. ".repeat(8)}
 - [ ] tests pass
 `;
 
+// CTL-604 + CTL-641: the merged registry covers implement (CTL-574),
+// research/plan (CTL-604), and triage/verify/review/monitor-deploy (CTL-641).
+// pr/monitor-merge stay unregistered (no single on-disk artifact) — the recovery
+// sweep's "no-probe-for-phase" escalation stays a defensive guard for those and
+// for any genuinely-unknown phase.
 describe("WORK_DONE_PROBES — registry shape", () => {
-  test("implement, research, and plan are registered; other phases are not", () => {
-    for (const phase of ["implement", "research", "plan"]) {
+  test("all probe-backed phases are registered", () => {
+    for (const phase of [
+      "implement",
+      "research",
+      "plan",
+      "triage",
+      "verify",
+      "review",
+      "monitor-deploy",
+    ]) {
       expect(hasProbe(phase)).toBe(true);
     }
-    for (const phase of [
-      "triage",
-      "verify", "review", "pr", "monitor-merge", "monitor-deploy",
-      "unknown-phase",
-    ]) {
+  });
+  test("probe-less phases and unknown phases are not registered", () => {
+    for (const phase of ["pr", "monitor-merge", "unknown-phase"]) {
       expect(hasProbe(phase)).toBe(false);
     }
+  });
+});
+
+// makeReadFile — deterministic fs fake keyed on absolute path. Returns the
+// { ok, content } shape of defaultReadFile; an unknown path is a miss.
+function makeReadFile(files) {
+  return (path) => (path in files ? { ok: true, content: files[path] } : { ok: false, content: "" });
+}
+
+const ORCH = "/orch";
+const wpath = (ticket, name) => `${ORCH}/workers/${ticket}/${name}`;
+
+describe("WORK_DONE_PROBES.triage", () => {
+  test("true when triage.json parses with non-empty classification", () => {
+    const readFile = makeReadFile({
+      [wpath("CTL-1", "triage.json")]: JSON.stringify({ classification: "feature", summary: "x" }),
+    });
+    expect(WORK_DONE_PROBES.triage({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(true);
+  });
+  test("false when classification empty/missing (truncated)", () => {
+    const readFile = makeReadFile({ [wpath("CTL-1", "triage.json")]: JSON.stringify({ summary: "x" }) });
+    expect(WORK_DONE_PROBES.triage({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+  });
+  test("false when classification is whitespace-only (truncated)", () => {
+    const readFile = makeReadFile({ [wpath("CTL-1", "triage.json")]: JSON.stringify({ classification: "   " }) });
+    expect(WORK_DONE_PROBES.triage({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+  });
+  test("false when file missing", () => {
+    expect(WORK_DONE_PROBES.triage({ ticket: "CTL-1", orchDir: ORCH }, { readFile: makeReadFile({}) })).toBe(false);
+  });
+  test("false on invalid JSON (parse error is safe)", () => {
+    const readFile = makeReadFile({ [wpath("CTL-1", "triage.json")]: "{not json" });
+    expect(WORK_DONE_PROBES.triage({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+  });
+  test("false on missing input (no readFile call)", () => {
+    const readFile = () => { throw new Error("readFile must not be called"); };
+    expect(WORK_DONE_PROBES.triage({ ticket: null, orchDir: ORCH }, { readFile })).toBe(false);
+    expect(WORK_DONE_PROBES.triage({ ticket: "CTL-1", orchDir: null }, { readFile })).toBe(false);
+  });
+});
+
+// verify.json real schema (phase-verify SKILL.md:182-189):
+//   {regression_risk:int, findings:[...], tests_attempted:int, gates:{...}, generatedAt:string}
+describe("WORK_DONE_PROBES.verify", () => {
+  test("true with all required keys present", () => {
+    const readFile = makeReadFile({
+      [wpath("CTL-1", "verify.json")]: JSON.stringify({
+        regression_risk: 1, findings: [], tests_attempted: 0, gates: {}, generatedAt: "2026-05-26T00:00:00Z",
+      }),
+    });
+    expect(WORK_DONE_PROBES.verify({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(true);
+  });
+  test("false when a required key is absent (truncated)", () => {
+    const readFile = makeReadFile({ [wpath("CTL-1", "verify.json")]: JSON.stringify({ findings: [] }) });
+    expect(WORK_DONE_PROBES.verify({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+  });
+  test("false when findings is not an array (truncated)", () => {
+    const readFile = makeReadFile({
+      [wpath("CTL-1", "verify.json")]: JSON.stringify({
+        regression_risk: 1, findings: "oops", tests_attempted: 0, gates: {}, generatedAt: "x",
+      }),
+    });
+    expect(WORK_DONE_PROBES.verify({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+  });
+  test("false on missing file / invalid JSON", () => {
+    expect(WORK_DONE_PROBES.verify({ ticket: "CTL-1", orchDir: ORCH }, { readFile: makeReadFile({}) })).toBe(false);
+  });
+});
+
+// review.json real schema (phase-review SKILL.md:167-175):
+//   {findings:[...], remediationCommit:string|null, reviewPassed:bool, generatedAt:string}
+describe("WORK_DONE_PROBES.review", () => {
+  test("true with findings[], reviewPassed bool, remediationCommit present, generatedAt", () => {
+    const readFile = makeReadFile({
+      [wpath("CTL-1", "review.json")]: JSON.stringify({
+        findings: [], remediationCommit: null, reviewPassed: true, generatedAt: "2026-05-26T00:00:00Z",
+      }),
+    });
+    expect(WORK_DONE_PROBES.review({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(true);
+  });
+  test("false when reviewPassed is not a boolean (truncated)", () => {
+    const readFile = makeReadFile({ [wpath("CTL-1", "review.json")]: JSON.stringify({ findings: [], generatedAt: "x" }) });
+    expect(WORK_DONE_PROBES.review({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+  });
+  test("false when remediationCommit key absent (truncated)", () => {
+    const readFile = makeReadFile({
+      [wpath("CTL-1", "review.json")]: JSON.stringify({ findings: [], reviewPassed: true, generatedAt: "x" }),
+    });
+    expect(WORK_DONE_PROBES.review({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+  });
+  test("false on missing file", () => {
+    expect(WORK_DONE_PROBES.review({ ticket: "CTL-1", orchDir: ORCH }, { readFile: makeReadFile({}) })).toBe(false);
+  });
+});
+
+// monitor-deploy: deploy_state ∈ {success, skipped} is done (signal-reader.mjs:29
+// ranks skipped as terminal-equivalent); anything else / missing is not.
+describe("WORK_DONE_PROBES['monitor-deploy']", () => {
+  test.each(["success", "skipped"])("true when deploy_state=%s", (state) => {
+    const readFile = makeReadFile({
+      [wpath("CTL-1", "phase-monitor-deploy.json")]: JSON.stringify({ deploy_state: state, deploy_sha: "abc", completed_at: "x" }),
+    });
+    expect(WORK_DONE_PROBES["monitor-deploy"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(true);
+  });
+  test("false when deploy_state=failure", () => {
+    const readFile = makeReadFile({ [wpath("CTL-1", "phase-monitor-deploy.json")]: JSON.stringify({ deploy_state: "failure" }) });
+    expect(WORK_DONE_PROBES["monitor-deploy"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+  });
+  test("false when deploy_state absent / file missing", () => {
+    const readFile = makeReadFile({ [wpath("CTL-1", "phase-monitor-deploy.json")]: JSON.stringify({ status: "running" }) });
+    expect(WORK_DONE_PROBES["monitor-deploy"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile })).toBe(false);
+    expect(WORK_DONE_PROBES["monitor-deploy"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile: makeReadFile({}) })).toBe(false);
+  });
+});
+
+describe("defaultReadFile — never throws", () => {
+  test("missing file → { ok: false, content: '' }", () => {
+    const r = defaultReadFile("/no/such/path/xyz.json");
+    expect(r.ok).toBe(false);
+    expect(r.content).toBe("");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -85,27 +85,22 @@ ${"Overview prose to clear the size floor. ".repeat(8)}
 - [ ] tests pass
 `;
 
-// CTL-604 + CTL-641: the merged registry covers implement (CTL-574),
-// research/plan (CTL-604), and triage/verify/review/monitor-deploy (CTL-641).
-// pr/monitor-merge stay unregistered (no single on-disk artifact) — the recovery
-// sweep's "no-probe-for-phase" escalation stays a defensive guard for those and
-// for any genuinely-unknown phase.
+// CTL-604 + CTL-641: every pipeline phase now carries a probe — implement
+// (CTL-574), research/plan (CTL-604), and triage/verify/review/pr/monitor-merge/
+// monitor-deploy (CTL-641). hasProbe is false only for a genuinely-unknown phase,
+// keeping the recovery sweep's branch (A) "no-probe-for-phase" escalation as a
+// defensive guard.
 describe("WORK_DONE_PROBES — registry shape", () => {
-  test("all probe-backed phases are registered", () => {
+  test("all 9 pipeline phases are registered", () => {
     for (const phase of [
-      "implement",
-      "research",
-      "plan",
-      "triage",
-      "verify",
-      "review",
-      "monitor-deploy",
+      "implement", "triage", "research", "plan",
+      "verify", "review", "pr", "monitor-merge", "monitor-deploy",
     ]) {
       expect(hasProbe(phase)).toBe(true);
     }
   });
-  test("probe-less phases and unknown phases are not registered", () => {
-    for (const phase of ["pr", "monitor-merge", "unknown-phase"]) {
+  test("a genuinely-unknown phase is not registered", () => {
+    for (const phase of ["unknown-phase", "deploy", ""]) {
       expect(hasProbe(phase)).toBe(false);
     }
   });
@@ -568,5 +563,86 @@ describe("WORK_DONE_PROBES.research/plan — input guards (no fs/git spawn)", ()
         { runGit: boom, listArtifacts: boom, readArtifact: boom },
       ),
     ).toBe(false);
+    expect(
+      WORK_DONE_PROBES.plan(
+        { ticket: "CTL-604", repoRoot: null },
+        { runGit: boom, listArtifacts: boom, readArtifact: boom },
+      ),
+    ).toBe(false);
+  });
+});
+
+// --- CTL-641 Phase 3: gh REST probes (pr, monitor-merge) -------------------
+// pr is done when its PR is open (or already merged); monitor-merge is done
+// when the PR is merged. The PR number/url is read from the worker-dir signal
+// (.pr.number / .pr.url). We query the REST endpoint `gh api
+// repos/<slug>/pulls/<n>` (research §4 — REST `.state`/`.merged`, NOT GraphQL,
+// whose state field is uppercase). The repo slug is parsed from .pr.url; when
+// absent we fall back to gh's `{owner}/{repo}` placeholder (cwd inference).
+
+// makeRunGh — deterministic `gh` fake keyed on the joined args.
+function makeRunGh(responses) {
+  return (args) => responses[args.join(" ")] ?? { code: 1, stdout: "", stderr: "no match" };
+}
+
+describe("WORK_DONE_PROBES.pr", () => {
+  // url "u" has no parseable slug → falls back to the {owner}/{repo} placeholder.
+  const readFile = makeReadFile({ [wpath("CTL-1", "phase-pr.json")]: JSON.stringify({ pr: { number: 42, url: "u" } }) });
+  test("true when PR state is open (REST)", () => {
+    const runGh = makeRunGh({ "api repos/{owner}/{repo}/pulls/42": { code: 0, stdout: JSON.stringify({ state: "open" }), stderr: "" } });
+    expect(WORK_DONE_PROBES.pr({ ticket: "CTL-1", orchDir: ORCH }, { readFile, runGh })).toBe(true);
+  });
+  test("true when PR already merged (pr phase still done)", () => {
+    const runGh = makeRunGh({ "api repos/{owner}/{repo}/pulls/42": { code: 0, stdout: JSON.stringify({ state: "closed", merged: true }), stderr: "" } });
+    expect(WORK_DONE_PROBES.pr({ ticket: "CTL-1", orchDir: ORCH }, { readFile, runGh })).toBe(true);
+  });
+  test("false when PR is closed-unmerged", () => {
+    const runGh = makeRunGh({ "api repos/{owner}/{repo}/pulls/42": { code: 0, stdout: JSON.stringify({ state: "closed", merged: false }), stderr: "" } });
+    expect(WORK_DONE_PROBES.pr({ ticket: "CTL-1", orchDir: ORCH }, { readFile, runGh })).toBe(false);
+  });
+  test("real github url → slug parsed into the REST path", () => {
+    const rf = makeReadFile({
+      [wpath("CTL-1", "phase-pr.json")]: JSON.stringify({ pr: { number: 42, url: "https://github.com/coalesce-labs/catalyst/pull/42" } }),
+    });
+    const runGh = makeRunGh({ "api repos/coalesce-labs/catalyst/pulls/42": { code: 0, stdout: JSON.stringify({ state: "open" }), stderr: "" } });
+    expect(WORK_DONE_PROBES.pr({ ticket: "CTL-1", orchDir: ORCH }, { readFile: rf, runGh })).toBe(true);
+  });
+  test("false when no PR number on the signal (no gh call)", () => {
+    const runGh = () => { throw new Error("runGh must not be called"); };
+    expect(WORK_DONE_PROBES.pr({ ticket: "CTL-1", orchDir: ORCH }, { readFile: makeReadFile({ [wpath("CTL-1", "phase-pr.json")]: "{}" }), runGh })).toBe(false);
+  });
+  test("false when gh fails (safe default)", () => {
+    expect(WORK_DONE_PROBES.pr({ ticket: "CTL-1", orchDir: ORCH }, { readFile, runGh: makeRunGh({}) })).toBe(false);
+  });
+  test("false on missing input (no readFile/gh call)", () => {
+    const boom = () => { throw new Error("must not be called"); };
+    expect(WORK_DONE_PROBES.pr({ ticket: null, orchDir: ORCH }, { readFile: boom, runGh: boom })).toBe(false);
+    expect(WORK_DONE_PROBES.pr({ ticket: "CTL-1", orchDir: null }, { readFile: boom, runGh: boom })).toBe(false);
+  });
+});
+
+describe("WORK_DONE_PROBES['monitor-merge']", () => {
+  // phase-monitor-merge.json carries .pr.number but NOT .pr.url (it writes
+  // `.pr = {number}` only) — the probe reads the url from phase-pr.json.
+  const readFile = makeReadFile({
+    [wpath("CTL-1", "phase-monitor-merge.json")]: JSON.stringify({ pr: { number: 42 } }),
+    [wpath("CTL-1", "phase-pr.json")]: JSON.stringify({ pr: { number: 42, url: "https://github.com/coalesce-labs/catalyst/pull/42" } }),
+  });
+  test("true when merged==true (REST)", () => {
+    const runGh = makeRunGh({ "api repos/coalesce-labs/catalyst/pulls/42": { code: 0, stdout: JSON.stringify({ merged: true }), stderr: "" } });
+    expect(WORK_DONE_PROBES["monitor-merge"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile, runGh })).toBe(true);
+  });
+  test("false when merged==false", () => {
+    const runGh = makeRunGh({ "api repos/coalesce-labs/catalyst/pulls/42": { code: 0, stdout: JSON.stringify({ merged: false }), stderr: "" } });
+    expect(WORK_DONE_PROBES["monitor-merge"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile, runGh })).toBe(false);
+  });
+  test("falls back to phase-pr.json number when monitor-merge signal lacks one", () => {
+    const rf = makeReadFile({ [wpath("CTL-1", "phase-pr.json")]: JSON.stringify({ pr: { number: 7, url: "u" } }) });
+    const runGh = makeRunGh({ "api repos/{owner}/{repo}/pulls/7": { code: 0, stdout: JSON.stringify({ merged: true }), stderr: "" } });
+    expect(WORK_DONE_PROBES["monitor-merge"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile: rf, runGh })).toBe(true);
+  });
+  test("false when no PR number anywhere / gh fails", () => {
+    expect(WORK_DONE_PROBES["monitor-merge"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile: makeReadFile({}), runGh: () => { throw new Error("no"); } })).toBe(false);
+    expect(WORK_DONE_PROBES["monitor-merge"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile, runGh: makeRunGh({}) })).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds per-phase **work-done probes** to the execution-core daemon so its reclaim / escalation logic can distinguish a phase worker that genuinely produced its artifact from one that merely committed (or stalled before committing). Previously `implement` was the only phase with a registered probe; every other phase fell through to a generic check, which drove false-dead reclaims and `no-probe-for-phase` escalations (see memories on research-phase false-dead escalation and reclaim-premature-advance).

Each probe validates artifact **content**, not mere existence — a truncated or partially-written artifact reads as *not-done*, so it can never flow downstream as "complete."

## Changes

Three probe families, landed across three commits:

1. **JSON worker-dir probes** — `triage`, `verify`, `review`, `monitor-deploy`. Read `${orchDir}/workers/<ticket>/<artifact>.json` and assert the phase's required fields are present:
   - `triage.json` → `classification`
   - `verify.json` → `regression_risk`, `findings`, `tests_attempted`, `gates`, `generatedAt`
   - `review.json` → `findings`, `remediationCommit`, `reviewPassed`, `generatedAt`
   - `phase-monitor-deploy.json` → `deploy_state ∈ {success, skipped}` (both terminal-done, matching `signal-reader.mjs` ranking `skipped` == `done`)

2. **Markdown artifact probes** — `research`, `plan`. The docs live in the ticket's **worktree** under `thoughts/shared/{research,plans}/`, not under repoRoot, so the probe resolves the worktree via `git worktree list --porcelain`, globs the newest date-prefixed `*-<ticket>.md`, and validates content.

3. **gh REST probes** — `pr`, `monitor-merge`. `pr` is done when its PR is open or already merged; `monitor-merge` is done when the PR is merged. Backed by `gh api`; falls back to a literal `repos/{owner}/{repo}/pulls/N` path when `.pr.url` is absent. Safe-by-default: a null result → probe false → escalate, never a false reclaim.

## Design notes

- All probes share the never-throw contract of `defaultRunGit` / `defaultReadFile` (ENOENT / EACCES / parse error → `{ ok: false }`), keeping the safe-default-false logic linear.
- Dependency-injected `readFile` / `listDir` / `runGit` seams make every probe unit-testable without a real filesystem or git.

## Testing

- `work-done-probes.test.mjs` (+309 lines) — per-probe coverage including truncated-artifact and missing-file cases.
- `recovery.test.mjs` (+79 lines) and `integration-ctl-587.test.mjs` updated for the expanded probe registry.

## Review

`/review` passed with one LOW finding (the `pr` probe's literal-path fallback returns null from the scheduler cwd; safe-by-default, never a false reclaim, and `.pr.url` is always present in real archived `phase-pr.json` — no action required).

Refs: CTL-641
