### PR TITLE
CTL-604: Stop false-dead revive of research/plan phase workers

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-bg-revive.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-bg-revive.test.sh
@@ -221,6 +221,55 @@ echo "$LOG" | grep -q "task.type=phase-verify" \
   || fail "verify worker tagged task.type=phase-verify"
 scratch_teardown
 
+# ─── Test 8 (CTL-604): socket-close in the stream is detected as an API error ─
+# A live, non-stale worker whose stream shows "socket connection was closed"
+# must be revived (api-stream-idle-timeout), not ignored. Before CTL-604 the
+# detector regex matched only "Stream idle timeout|partial response received",
+# so socket-death fell through and the worker silently stalled.
+echo "test 8 (CTL-604): socket-close stream error is detected → revived (api-stream-idle-timeout)"
+scratch_setup
+sleep 600 &
+LIVE_PID=$!
+disown "$LIVE_PID" 2>/dev/null || true
+make_phase_signal "T-8" "implement" "implementing" "bg-old-8" "$LIVE_PID"
+write_stream_init "T-8" "sess-8-abc"
+# Append a socket-close result error event (with a uuid the detector requires).
+echo '{"type":"result","is_error":true,"uuid":"err-8-uuid","api_error_status":"API Error: The socket connection was closed unexpectedly"}' \
+  >> "${ORCH_DIR}/workers/output/T-8-stream.jsonl"
+# High stale threshold so the ONLY revive trigger is the API-error detection.
+"$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "demo" --stale-heartbeat-seconds 99999 \
+  > "${SCRATCH}/out" 2>"${SCRATCH}/err"
+RC8=$(jq -r '.reviveCount' "${ORCH_DIR}/workers/T-8.json")
+REASON8=$(jq -r '.lastReviveReason' "${ORCH_DIR}/workers/T-8.json")
+[ "$RC8" = "1" ] && pass "socket-close triggered a revive (reviveCount=1)" || fail "socket-close triggered a revive" "reviveCount=$RC8 stderr=$(cat "${SCRATCH}/err")"
+[ "$REASON8" = "api-stream-idle-timeout" ] && pass "lastReviveReason=api-stream-idle-timeout (not pid-dead)" || fail "lastReviveReason=api-stream-idle-timeout" "got: $REASON8"
+kill "$LIVE_PID" 2>/dev/null || true
+scratch_teardown
+
+# ─── Test 9 (CTL-604): a resume refused because the agent is still a bg job ───
+# must NOT be recorded as a successful pid-dead revive. The previous turn died
+# (socket close) but the process lives; claude refuses --resume. spawn_revive_bg
+# now reads stderr and reports "alive" so the caller leaves reviveCount alone.
+echo "test 9 (CTL-604): resume refused (agent still bg-alive) → NOT a false pid-dead revive"
+scratch_setup
+# Override the fake claude: refuse the resume on stderr, emit no bg-job stdout.
+cat > "${SCRATCH}/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "args: $*" >> "$CLAUDE_LOG"
+echo "Error: session is currently running as a background agent (bg)" >&2
+exit 1
+EOF
+chmod +x "${SCRATCH}/bin/claude"
+make_phase_signal "T-9" "implement" "implementing" "bg-old-9" "$DEAD_PID"
+write_stream_init "T-9" "sess-9-abc"
+"$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "demo" --stale-heartbeat-seconds 0 \
+  > "${SCRATCH}/out" 2>"${SCRATCH}/err"
+RC9=$(jq -r '.reviveCount' "${ORCH_DIR}/workers/T-9.json")
+REASON9=$(jq -r '.lastReviveReason // ""' "${ORCH_DIR}/workers/T-9.json")
+[ "$RC9" = "0" ] && pass "reviveCount NOT incremented (no false revive)" || fail "reviveCount NOT incremented" "got: $RC9"
+[ "$REASON9" != "pid-dead" ] && pass "lastReviveReason NOT set to pid-dead" || fail "lastReviveReason NOT set to pid-dead" "got: $REASON9"
+scratch_teardown
+
 echo ""
 echo "─────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -580,6 +580,48 @@ DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
 [ ! -s "$PHASE_DISPATCH_LOG" ] && pass "phase-agent-dispatch NOT called on idempotent" || fail "phase-agent-dispatch NOT called on idempotent" "log: $(cat "$PHASE_DISPATCH_LOG")"
 scratch_teardown
 
+echo "test 26b (CTL-604): re-dispatches when per-phase signal is failed (not just file-exists)"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+mkdir -p "${ORCH_DIR}/workers/T-1"
+# A failed signal must NOT block re-dispatch — a dead worker that never
+# recovered should be relaunched, not stranded on mere file existence.
+echo '{"ticket":"T-1","phase":"research","status":"failed"}' >"${ORCH_DIR}/workers/T-1/phase-research.json"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "research" 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 on failed re-dispatch" || fail "exit 0 on failed re-dispatch" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "T-1" ] && pass "failed per-phase signal re-dispatched" || fail "failed per-phase signal re-dispatched" "got: $DISPATCHED"
+grep -q -- "--ticket T-1" "$PHASE_DISPATCH_LOG" && pass "phase-agent-dispatch called for failed re-dispatch" || fail "phase-agent-dispatch called for failed re-dispatch" "log: $(cat "$PHASE_DISPATCH_LOG")"
+scratch_teardown
+
+echo "test 26c (CTL-604): re-dispatches when per-phase signal is stalled"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+mkdir -p "${ORCH_DIR}/workers/T-1"
+echo '{"ticket":"T-1","phase":"research","status":"stalled"}' >"${ORCH_DIR}/workers/T-1/phase-research.json"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "research" 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "T-1" ] && pass "stalled per-phase signal re-dispatched" || fail "stalled per-phase signal re-dispatched" "got: $DISPATCHED"
+scratch_teardown
+
+echo "test 26d (CTL-604): does NOT re-dispatch a done per-phase signal"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+mkdir -p "${ORCH_DIR}/workers/T-1"
+echo '{"ticket":"T-1","phase":"research","status":"done"}' >"${ORCH_DIR}/workers/T-1/phase-research.json"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "research" 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "" ] && pass "done per-phase signal NOT re-dispatched" || fail "done per-phase signal NOT re-dispatched" "got: $DISPATCHED"
+[ ! -s "$PHASE_DISPATCH_LOG" ] && pass "phase-agent-dispatch NOT called for done signal" || fail "phase-agent-dispatch NOT called for done signal" "log: $(cat "$PHASE_DISPATCH_LOG")"
+scratch_teardown
+
 echo "test 27 (CTL-452): dispatchMode=phase-agents in config — wave dispatches default phase=triage"
 scratch_setup
 phase_agent_dispatch_setup
@@ -769,6 +811,58 @@ RC=$?
 [ "$RC" = "0" ] && pass "advance exits 0 despite full cap" || fail "advance exits 0" "rc=$RC err=$(cat "${SCRATCH}/err")"
 [ "$(echo "$OUT" | jq -r '.dispatched | join(",")')" = "ADV-1" ] && pass "advance dispatched despite full cap" || fail "advance dispatched" "$OUT"
 grep -q -- "--phase verify" "$PHASE_DISPATCH_LOG" && pass "phase-agent-dispatch called for verify" || fail "verify dispatched" "$(cat "$PHASE_DISPATCH_LOG")"
+scratch_teardown
+echo "test 40 (CTL-604): --ticket --phase re-dispatches when per-phase signal is 'failed'"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+# Pre-existing signal at status:failed — a dead phase that never emitted complete.
+mkdir -p "${ORCH_DIR}/workers/T-1"
+echo '{"ticket":"T-1","phase":"research","status":"failed"}' >"${ORCH_DIR}/workers/T-1/phase-research.json"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "research" 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 on failed re-dispatch" || fail "exit 0 on failed re-dispatch" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "T-1" ] && pass "failed signal IS re-dispatched" || fail "failed signal IS re-dispatched" "got: $DISPATCHED"
+grep -q -- "--phase research" "$PHASE_DISPATCH_LOG" && pass "phase-agent-dispatch called for re-dispatch" || fail "phase-agent-dispatch called for re-dispatch" "log: $(cat "$PHASE_DISPATCH_LOG")"
+scratch_teardown
+
+echo "test 41 (CTL-604): --ticket --phase re-dispatches when per-phase signal is 'stalled'"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+mkdir -p "${ORCH_DIR}/workers/T-1"
+echo '{"ticket":"T-1","phase":"plan","status":"stalled"}' >"${ORCH_DIR}/workers/T-1/phase-plan.json"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "plan" 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "T-1" ] && pass "stalled signal IS re-dispatched" || fail "stalled signal IS re-dispatched" "got: $DISPATCHED"
+scratch_teardown
+
+echo "test 42 (CTL-604): --ticket --phase still no-ops when per-phase signal is 'running'"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+mkdir -p "${ORCH_DIR}/workers/T-1"
+echo '{"ticket":"T-1","phase":"research","status":"running"}' >"${ORCH_DIR}/workers/T-1/phase-research.json"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "research" 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "" ] && pass "running signal NOT re-dispatched" || fail "running signal NOT re-dispatched" "got: $DISPATCHED"
+[ ! -s "$PHASE_DISPATCH_LOG" ] && pass "phase-agent-dispatch NOT called for running" || fail "phase-agent-dispatch NOT called for running" "log: $(cat "$PHASE_DISPATCH_LOG")"
+scratch_teardown
+
+echo "test 43 (CTL-604): --ticket --phase still no-ops when per-phase signal is 'done'"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+mkdir -p "${ORCH_DIR}/workers/T-1"
+echo '{"ticket":"T-1","phase":"research","status":"done"}' >"${ORCH_DIR}/workers/T-1/phase-research.json"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "research" 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "" ] && pass "done signal NOT re-dispatched" || fail "done signal NOT re-dispatched" "got: $DISPATCHED"
 scratch_teardown
 
 echo ""

--- a/plugins/dev/scripts/__tests__/orchestrate-revive-socket-death.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive-socket-death.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Shell tests for orchestrate-revive socket-death / bg-idle resume handling (CTL-604).
+#
+# Covers the legacy-bash misclassification fixed in CTL-604:
+#   1. detect_api_error_in_stream must also match a socket-connection-closed /
+#      "running as a background agent" stream result (previously fell through to
+#      pid-dead, masking the real cause).
+#   2. spawn_revive_bg must classify the resume stderr: an "already running as a
+#      background agent (bg)" message means the agent is ALIVE — the resume was a
+#      no-op, NOT a fresh revive — so the caller must NOT bump reviveCount or
+#      record lastReviveReason="pid-dead". A hard resume error must surface a
+#      failure sentinel so the caller records revive-spawn-failed, not a false
+#      successful revive.
+#
+# Run: bash plugins/dev/scripts/__tests__/orchestrate-revive-socket-death.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+REVIVE="${REPO_ROOT}/plugins/dev/scripts/orchestrate-revive"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+DEAD_PID=99999999
+while kill -0 "$DEAD_PID" 2>/dev/null; do DEAD_PID=$((DEAD_PID+1)); done
+
+# scratch_setup [CLAUDE_STDERR] — optional stderr text the fake claude emits to
+# its stderr file (simulating a bg-idle / resume error). Default: empty (clean
+# resume that materializes a fresh bg_job_id on stdout).
+scratch_setup() {
+  local claude_stderr="${1:-}"
+  SCRATCH="$(mktemp -d)"
+  ORCH_DIR="${SCRATCH}/orch"
+  mkdir -p "${ORCH_DIR}/workers/output" "${SCRATCH}/bin" "${SCRATCH}/worktrees"
+
+  cat > "${SCRATCH}/bin/catalyst-state.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$STATE_LOG"
+EOF
+  chmod +x "${SCRATCH}/bin/catalyst-state.sh"
+  export STATE_LOG="${SCRATCH}/state.log"
+  : > "$STATE_LOG"
+  export CATALYST_STATE_SCRIPT="${SCRATCH}/bin/catalyst-state.sh"
+
+  # Fake claude — emits CLAUDE_FAKE_STDERR to its own stderr (the resume stderr
+  # the spawn captures), and a bg_job_id JSON to stdout only when no stderr was
+  # configured (a clean resume).
+  export CLAUDE_FAKE_STDERR="$claude_stderr"
+  cat > "${SCRATCH}/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+{
+  echo "---"
+  echo "args: $*"
+} >> "$CLAUDE_LOG"
+if [ -n "${CLAUDE_FAKE_STDERR:-}" ]; then
+  echo "$CLAUDE_FAKE_STDERR" >&2
+else
+  HAS_BG=0
+  for a in "$@"; do [ "$a" = "--bg" ] && HAS_BG=1; done
+  if [ "$HAS_BG" = "1" ]; then
+    echo "{\"id\":\"job-$$\",\"state\":\"running\"}"
+  fi
+fi
+sleep 30 &
+disown $! 2>/dev/null || true
+EOF
+  chmod +x "${SCRATCH}/bin/claude"
+  export CLAUDE_LOG="${SCRATCH}/claude.log"
+  : > "$CLAUDE_LOG"
+  export CATALYST_REVIVE_CLAUDE_BIN="${SCRATCH}/bin/claude"
+}
+
+scratch_teardown() {
+  pkill -f "sleep 30" 2>/dev/null || true
+  rm -rf "$SCRATCH"
+  unset SCRATCH ORCH_DIR STATE_LOG CLAUDE_LOG CLAUDE_FAKE_STDERR
+  unset CATALYST_STATE_SCRIPT CATALYST_REVIVE_CLAUDE_BIN
+}
+
+# make_phase_signal TICKET PHASE STATUS BG PID
+make_phase_signal() {
+  local ticket="$1" phase="$2" status="$3" bg="$4" pid="${5:-$DEAD_PID}"
+  local ts; ts=$(now_iso)
+  jq -n \
+    --arg t "$ticket" --arg s "$status" --arg phase "$phase" --arg pid "$pid" \
+    --arg ts "$ts" --arg wt "${SCRATCH}/worktrees/${ticket}" \
+    --arg wn "${ticket}-worker" \
+    '{ticket:$t, status:$s, phase:$phase, activePhase:$phase, phaseMode:true,
+      pid:($pid|tonumber), startedAt:$ts, updatedAt:$ts, lastHeartbeat:$ts,
+      worktreePath:$wt, workerName:$wn, reviveCount:0}' \
+    > "${ORCH_DIR}/workers/${ticket}.json"
+  mkdir -p "${ORCH_DIR}/workers/${ticket}"
+  jq -n \
+    --arg t "$ticket" --arg p "$phase" --arg s "$status" --arg bg "$bg" --arg ts "$ts" \
+    '{ticket:$t, phase:$p, status:$s, bg_job_id:$bg, startedAt:$ts, updatedAt:$ts}' \
+    > "${ORCH_DIR}/workers/${ticket}/phase-${phase}.json"
+  mkdir -p "${SCRATCH}/worktrees/${ticket}"
+}
+
+write_stream_init() {
+  local ticket="$1" sid="$2"
+  echo "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"${sid}\"}" \
+    > "${ORCH_DIR}/workers/output/${ticket}-stream.jsonl"
+}
+
+# write_stream_result TICKET RESULT_TEXT — append a result event with the given
+# api_error_status text so detect_api_error_in_stream can scan it.
+write_stream_result() {
+  local ticket="$1" text="$2"
+  jq -nc --arg t "$text" --arg u "uuid-$RANDOM" \
+    '{type:"result", is_error:true, api_error_status:$t, uuid:$u}' \
+    >> "${ORCH_DIR}/workers/output/${ticket}-stream.jsonl"
+}
+
+# ─── Test 1: socket-connection-closed stream is detected as an API error ───────
+echo "test 1 (CTL-604): 'socket connection was closed' stream → api-stream error reason"
+scratch_setup
+# Use a LIVE pid so pid-dead does NOT fire — only the stream error should trigger.
+LIVE_PID=$$
+make_phase_signal "T-SOCK" "research" "researching" "bg-old" "$LIVE_PID"
+write_stream_init "T-SOCK" "sess-sock"
+write_stream_result "T-SOCK" "API Error: The socket connection was closed unexpectedly"
+"$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "demo" --stale-heartbeat-seconds 999999 \
+  > "${SCRATCH}/out" 2>"${SCRATCH}/err"
+REASON=$(jq -r '.lastReviveReason // ""' "${ORCH_DIR}/workers/T-SOCK.json")
+[ "$REASON" = "api-stream-idle-timeout" ] && pass "socket-closed → api-stream reason (not pid-dead)" || fail "socket-closed → api-stream reason" "got: $REASON"
+scratch_teardown
+
+# ─── Test 2: 'running as a background agent' stream is detected too ────────────
+echo "test 2 (CTL-604): 'running as a background agent' stream → api-stream error reason"
+scratch_setup
+LIVE_PID=$$
+make_phase_signal "T-BG" "plan" "planning" "bg-old" "$LIVE_PID"
+write_stream_init "T-BG" "sess-bg"
+write_stream_result "T-BG" "this session is currently running as a background agent"
+"$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "demo" --stale-heartbeat-seconds 999999 \
+  > "${SCRATCH}/out" 2>"${SCRATCH}/err"
+REASON=$(jq -r '.lastReviveReason // ""' "${ORCH_DIR}/workers/T-BG.json")
+[ "$REASON" = "api-stream-idle-timeout" ] && pass "bg-agent stream → api-stream reason" || fail "bg-agent stream → api-stream reason" "got: $REASON"
+scratch_teardown
+
+# ─── Test 3: bg-idle resume failure is NOT recorded as a successful pid-dead revive ─
+echo "test 3 (CTL-604): resume stderr 'currently running as a background agent (bg)' → no false revive"
+scratch_setup "Error: this session is currently running as a background agent (bg) and cannot be resumed"
+make_phase_signal "T-ALIVE" "research" "researching" "bg-old" "$DEAD_PID"
+write_stream_init "T-ALIVE" "sess-alive"
+"$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "demo" --stale-heartbeat-seconds 0 \
+  > "${SCRATCH}/out" 2>"${SCRATCH}/err"
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0" || fail "exit 0" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+RC_COUNT=$(jq -r '.reviveCount' "${ORCH_DIR}/workers/T-ALIVE.json")
+[ "$RC_COUNT" = "0" ] && pass "reviveCount NOT incremented (agent still alive)" || fail "reviveCount NOT incremented" "got: $RC_COUNT (expected 0)"
+REASON=$(jq -r '.lastReviveReason // "none"' "${ORCH_DIR}/workers/T-ALIVE.json")
+[ "$REASON" = "none" ] && pass "lastReviveReason NOT set to pid-dead" || fail "lastReviveReason NOT set" "got: $REASON"
+scratch_teardown
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "Results: ${PASSES} pass, ${FAILURES} fail"
+echo "─────────────────────────────────────────"
+[ "$FAILURES" -eq 0 ]

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -330,8 +330,9 @@ export function defaultReviveDispatch({ orchDir, ticket, phase }, { dispatch = d
 // CTL-585 `labelOnce` guard (CTL-638). The pre-CTL-638 implementation called
 // `applyLabel` directly; the comment then claimed "the next scheduler tick
 // re-runs this function via labelOnce semantics" but no labelOnce wrapper
-// existed on this path — the recovery sweep's three escalation call sites
-// (no-probe-for-phase, non-implement-not-done, revive-budget-exhausted) all
+// existed on this path — the recovery sweep's escalation call sites
+// (no-probe-for-phase, revive-budget-exhausted; non-implement-not-done was
+// removed in CTL-604 when research/plan gained probes) all
 // bypassed CTL-585's marker-file guard. On a rate-limit, applyLabel returned
 // applied:false → no marker written → every scheduler tick (debounced to 2s
 // by the event-log fast path) re-fired the write, exhausting Linear's 2,500/hr
@@ -556,14 +557,18 @@ const KILL_RECENT_ACTIVITY_MS = 30 * 1000;
 //                         reset to 'stalled' to bypass the dispatcher's
 //                         idempotency guard; defaultDispatch was invoked; the
 //                         worker-dir .revive-N.applied marker was written.
+//                         CTL-604: implement/research/plan (every probed phase)
+//                         share this path — a probed worker that died before
+//                         writing its artifact is re-dispatched, not escalated.
 //   'revive-suppressed'   effectively dead + work NOT done + storm-breaker
 //                         OPEN (>3 distinct tickets reviving in last 10min).
 //                         No dispatch; suppress event audited; next tick
 //                         re-evaluates the window.
 //   'escalated'           effectively dead + (revive budget exhausted OR no
-//                         work-done probe registered for this phase). needs-human
-//                         label applied (via the CTL-587 verified applyLabel);
-//                         ticket stays where it is for human triage.
+//                         work-done probe registered for this phase — i.e. a
+//                         probe-less phase: verify/review/pr/monitor-*).
+//                         needs-human label applied (via the CTL-587 verified
+//                         applyLabel); ticket stays where it is for human triage.
 //
 // CTL-588 still defines "effectively dead" as classifyWorker:'dead' OR a
 // 'running' signal whose bg state.json mtime is older than staleMs.
@@ -670,12 +675,13 @@ export function reclaimDeadWorkIfPossible(
     return "reclaimed";
   }
 
-  // (C) Probe says work is NOT done → CTL-587 revive territory. Today only
-  //     `implement` has a probe; this branch's escalation is defensive for
-  //     a future phase whose probe also returns false.
-  if (phase !== "implement") {
-    return escalateOnce("non-implement-not-done", 0);
-  }
+  // (C) Probe says work is NOT done → CTL-587 revive territory. CTL-604: every
+  //     phase that reaches here has a probe (branch (A) already returned for the
+  //     probe-less phases), so implement/research/plan all share the bounded
+  //     revive/re-dispatch path below. A worker that died before writing its
+  //     artifact is re-dispatched fresh rather than dead-ended at needs-human.
+  //     defaultReviveDispatch is phase-agnostic (resets the signal to `stalled`
+  //     and re-launches via phase-agent-dispatch).
 
   // Per-ticket revive budget from events.jsonl. The events file is the
   // authoritative counter — surviving daemon restarts, more truthful than the

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -705,7 +705,11 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
       opts: {
         repoRoot: "/repo",
         statJob: () => ({ exists: true, mtimeMs: stateJsonMtime }),
-        probes: phase === "implement" ? { implement: recorder(probeResult) } : {},
+        // CTL-604: inject a probe for any probed phase (implement/research/plan)
+        // so branch (B)/(C) is exercised; probe-less phases (pr/verify/…) get {}.
+        probes: ["implement", "research", "plan"].includes(phase)
+          ? { [phase]: recorder(probeResult) }
+          : {},
         emitComplete: recorder({ code: 0 }),
         appendEvent: recorder(undefined),
         appendReviveEvent: recorder(undefined),
@@ -769,6 +773,36 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(s.opts.appendEscalatedEvent.calls[0][0].phase).toBe("pr");
     expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("no-probe-for-phase");
     expect(s.opts.applyStalledLabel.calls.length).toBe(1);
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+  });
+
+  // CTL-604: research/plan now share the bounded revive/re-dispatch path with
+  // implement. A worker that died before writing its artifact (probe=false) is
+  // re-dispatched, not dead-ended at needs-human.
+  test("dead research worker, probe NOT done, budget+storm OK → 'revived', no escalation", () => {
+    const s = setupReviveScenario({ phase: "research", probeResult: false, reviveCount: 0 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+    expect(s.opts.appendReviveEvent.calls.length).toBe(1);
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
+  });
+
+  test("dead plan worker, probe NOT done → 'revived'", () => {
+    const s = setupReviveScenario({ phase: "plan", probeResult: false, reviveCount: 0 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("dead research worker, revive budget exhausted → 'escalated' (revive-budget-exhausted)", () => {
+    const s = setupReviveScenario({ phase: "research", probeResult: false, reviveCount: 2 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("revive-budget-exhausted");
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("dead research worker, storm-breaker open → 'revive-suppressed'", () => {
+    const s = setupReviveScenario({ phase: "research", probeResult: false, distinctRevivingTickets: 4 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revive-suppressed");
     expect(s.opts.reviveDispatch.calls.length).toBe(0);
   });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -563,14 +563,16 @@ describe("reclaimDeadWorkIfPossible", () => {
   // It now escalates immediately — no probe means no way to verify the work,
   // so the human must look. needs-human label is applied via the injected seam.
   test("CTL-587: dead worker on a no-probe phase → 'escalated' + needs-human label", () => {
-    const sig = { ...implementSignal(), phase: "research" };
-    sig.raw.phase = "research";
+    // CTL-604: research/plan now have probes, so use `verify` — still probe-less
+    // — as the example of a phase that hits branch (A) escalation.
+    const sig = { ...implementSignal(), phase: "verify" };
+    sig.raw.phase = "verify";
     const emit = recorder({ code: 0 });
     const appendEscalated = recorder(undefined);
     const applyLabel = recorder({ applied: true });
     const r = reclaimDeadWorkIfPossible(orch, sig, {
       statJob: () => null, // bg dead
-      probes: { implement: recorder(true) }, // research not registered
+      probes: { implement: recorder(true) }, // verify not registered
       emitComplete: emit,
       appendEvent: recorder(undefined),
       appendEscalatedEvent: appendEscalated,

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -1,13 +1,21 @@
 // work-done-probes.mjs — per-phase "is the work committed already?" probes for the
-// CTL-574 reclaim sweep. Pure given the injected runGit; spawns nothing of its own
+// CTL-574 reclaim sweep. Pure given the injected seams; spawns nothing of its own
 // at module load.
 //
-// The registry maps phase name → probe function. Phases without an entry are
-// not-applicable to commit-state reclaim (research/plan have artifact-on-disk
-// shapes that can be added later; verify/review have no filesystem artifact).
+// The registry maps phase name → probe function. `implement` checks commit state
+// (CTL-574); `research`/`plan` check for a complete on-disk artifact (CTL-604).
+// Only `verify`/`review`/`pr`/`monitor-*` remain without a probe — they have no
+// single on-disk artifact and stay CTL-587's auto-revival responsibility.
 
 import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
 import { parseWorktreeForBranch } from "./worktree.mjs";
+
+// MIN_ARTIFACT_BYTES — a small size floor below which an artifact is treated as a
+// truncated mid-write and NOT reclaimed (CTL-604, re-walk-artifact-validation
+// precedent). Erring strict means a borderline artifact is re-dispatched (safe)
+// rather than advanced on a partial doc (unsafe).
+const MIN_ARTIFACT_BYTES = 200;
 
 // defaultRunGit — `git <args>` with stdout/stderr captured. Returns
 // { code, stdout, stderr }; never throws.
@@ -15,6 +23,36 @@ export function defaultRunGit(args, { spawn = spawnSync } = {}) {
   const res = spawn("git", args, { encoding: "utf8" });
   if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
   return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// defaultListArtifacts — `readdirSync(dir)` → filenames; [] on any error (missing
+// directory, permission, etc.). The injected-seam discipline mirrors defaultRunGit.
+export function defaultListArtifacts(dir) {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+// defaultReadArtifact — `readFileSync(path, "utf8")` → string; "" on any error.
+export function defaultReadArtifact(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+// resolveWorktree — find the worktree path bound to refs/heads/<ticket> via
+// `git worktree list --porcelain`. Shared by implementProbe and the artifact
+// probes. Returns the path or null (missing input, git failure, or no match) —
+// never throws, never spawns when input is incomplete.
+export function resolveWorktree({ ticket, repoRoot } = {}, { runGit = defaultRunGit } = {}) {
+  if (!ticket || !repoRoot) return null;
+  const list = runGit(["-C", repoRoot, "worktree", "list", "--porcelain"]);
+  if (list.code !== 0) return null;
+  return parseWorktreeForBranch(list.stdout, ticket) || null;
 }
 
 // implementProbe — commits-ahead>0 vs origin/main + clean tree on the worktree
@@ -26,9 +64,7 @@ export function defaultRunGit(args, { spawn = spawnSync } = {}) {
 function implementProbe({ ticket, repoRoot } = {}, { runGit = defaultRunGit } = {}) {
   if (!ticket || !repoRoot) return false;
 
-  const list = runGit(["-C", repoRoot, "worktree", "list", "--porcelain"]);
-  if (list.code !== 0) return false;
-  const worktreePath = parseWorktreeForBranch(list.stdout, ticket);
+  const worktreePath = resolveWorktree({ ticket, repoRoot }, { runGit });
   if (!worktreePath) return false;
 
   const ahead = runGit(["-C", worktreePath, "rev-list", "--count", "origin/main..HEAD"]);
@@ -40,11 +76,77 @@ function implementProbe({ ticket, repoRoot } = {}, { runGit = defaultRunGit } = 
   return status.stdout.trim() === "";
 }
 
+// matchesTicket — true when `filename` is a markdown file naming `ticket`. Mirrors
+// the dispatcher's CTL-494 two-step match (strict `*-<ticket-lower>.md` then a
+// wider case-insensitive `*<ticket>*.md`): the strict tail is a subset of the
+// case-insensitive substring, so the substring check is the effective behavior.
+function matchesTicket(filename, ticket) {
+  const lf = filename.toLowerCase();
+  return lf.endsWith(".md") && lf.includes(ticket.toLowerCase());
+}
+
+// bodyHasMarkers — completeness gate. `anyOf` requires at least one marker
+// present; `allOf` requires every marker present. Either may be empty.
+function bodyHasMarkers(body, { anyOf = [], allOf = [] }) {
+  if (anyOf.length > 0 && !anyOf.some((m) => body.includes(m))) return false;
+  if (allOf.length > 0 && !allOf.every((m) => body.includes(m))) return false;
+  return true;
+}
+
+// artifactProbe — factory for an on-disk-artifact work-done probe (CTL-604). The
+// probe is true only when (a) the ticket's worktree resolves, (b) a markdown file
+// naming the ticket exists under `<worktree>/<subdir>`, and (c) that file clears
+// the size floor AND carries the schema's closing markers. Any failure (missing
+// worktree, no match, short/truncated body, throwing seam) returns false — the
+// established safe default, so a borderline artifact is re-dispatched, not advanced.
+function artifactProbe(subdir, markers) {
+  return (
+    { ticket, repoRoot } = {},
+    { runGit = defaultRunGit, listArtifacts = defaultListArtifacts, readArtifact = defaultReadArtifact } = {},
+  ) => {
+    if (!ticket || !repoRoot) return false;
+    const worktreePath = resolveWorktree({ ticket, repoRoot }, { runGit });
+    if (!worktreePath) return false;
+
+    const dir = `${worktreePath}/${subdir}`;
+    let files;
+    try {
+      files = listArtifacts(dir);
+    } catch {
+      return false;
+    }
+    if (!Array.isArray(files) || files.length === 0) return false;
+
+    const match = files.find((f) => matchesTicket(f, ticket));
+    if (!match) return false;
+
+    const body = readArtifact(`${dir}/${match}`);
+    if (!body || body.length < MIN_ARTIFACT_BYTES) return false;
+    return bodyHasMarkers(body, markers);
+  };
+}
+
+// researchProbe — a complete research doc under thoughts/shared/research/ (CTL-604).
+// Completeness requires the closing `## Code References` or `## Summary` section the
+// research artifact schema guarantees.
+const researchProbe = artifactProbe("thoughts/shared/research", {
+  anyOf: ["## Code References", "## Summary"],
+});
+
+// planProbe — a complete plan under thoughts/shared/plans/ (CTL-604). Completeness
+// requires at least one `## Phase ` heading AND a `Success Criteria` marker (the
+// create-plan schema).
+const planProbe = artifactProbe("thoughts/shared/plans", {
+  allOf: ["## Phase ", "Success Criteria"],
+});
+
 // WORK_DONE_PROBES — phase → probe. Adding a probe is the entire opt-in for a
 // phase to participate in the CTL-574 reclaim sweep. Phases without an entry
-// remain CTL-587's responsibility (auto-revival).
+// (verify/review/pr/monitor-*) remain CTL-587's responsibility (auto-revival).
 export const WORK_DONE_PROBES = {
   implement: implementProbe,
+  research: researchProbe,
+  plan: planProbe,
 };
 
 // hasProbe — true when the given phase has a registered probe. Used by the

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -2,7 +2,12 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test work-done-probes.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { WORK_DONE_PROBES, hasProbe, defaultRunGit } from "./work-done-probes.mjs";
+import {
+  WORK_DONE_PROBES,
+  hasProbe,
+  defaultRunGit,
+  resolveWorktree,
+} from "./work-done-probes.mjs";
 
 // makeRunGit — a deterministic `git` fake keyed on the trailing positional args.
 // Returns { code, stdout, stderr } shaped like spawnSync's output.
@@ -33,11 +38,59 @@ function porcelainFor(ticket, worktreePath) {
   ].join("\n");
 }
 
+// makeListArtifacts — a deterministic `readdir` fake. `map` keys are directory
+// suffixes (so a test can ignore the worktree prefix); the value is the array of
+// filenames in that directory. Unmatched directories return [] (the empty-dir
+// case), mirroring defaultListArtifacts' safe default.
+function makeListArtifacts(map) {
+  return (dir) => {
+    for (const [k, v] of Object.entries(map)) {
+      if (dir.endsWith(k)) return v;
+    }
+    return [];
+  };
+}
+
+// makeReadArtifact — a deterministic file-read fake keyed on a path suffix.
+// Unmatched paths return "" (the read-error default).
+function makeReadArtifact(map) {
+  return (p) => {
+    for (const [k, v] of Object.entries(map)) {
+      if (p.endsWith(k)) return v;
+    }
+    return "";
+  };
+}
+
+// A research body comfortably above the completeness size floor that carries the
+// schema's closing `## Code References` section.
+const RESEARCH_BODY_COMPLETE = `# Research: CTL-604
+
+## Summary
+${"Investigated the silent-stall path. ".repeat(8)}
+
+## Code References
+- recovery.mjs:462 — reclaimDeadWorkIfPossible
+`;
+
+// A plan body above the floor carrying both required markers.
+const PLAN_BODY_COMPLETE = `# Plan: CTL-604
+
+${"Overview prose to clear the size floor. ".repeat(8)}
+
+## Phase 1 — do the thing
+
+### Success Criteria
+- [ ] tests pass
+`;
+
 describe("WORK_DONE_PROBES — registry shape", () => {
-  test("implement is registered, other phases are not", () => {
-    expect(hasProbe("implement")).toBe(true);
+  test("implement, research, and plan are registered; other phases are not", () => {
+    for (const phase of ["implement", "research", "plan"]) {
+      expect(hasProbe(phase)).toBe(true);
+    }
     for (const phase of [
-      "triage", "research", "plan",
+      "triage",
       "verify", "review", "pr", "monitor-merge", "monitor-deploy",
       "unknown-phase",
     ]) {
@@ -161,5 +214,227 @@ describe("defaultRunGit — spawn error is non-fatal", () => {
     expect(r.code).toBe(127);
     expect(r.stdout).toBe("");
     expect(r.stderr).toContain("ENOENT");
+  });
+});
+
+describe("resolveWorktree — shared worktree resolution", () => {
+  test("returns the worktree path bound to the ticket branch", () => {
+    const wt = "/wt/CTL-604";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-604", wt), stderr: "" },
+    });
+    expect(resolveWorktree({ ticket: "CTL-604", repoRoot: "/repo" }, { runGit })).toBe(wt);
+  });
+
+  test("returns null on git failure, missing match, or input gaps (no spawn)", () => {
+    const fail = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 1, stdout: "", stderr: "boom" },
+    });
+    expect(resolveWorktree({ ticket: "CTL-604", repoRoot: "/repo" }, { runGit: fail })).toBe(null);
+
+    const noMatch = makeRunGit({
+      "-C /repo worktree list --porcelain": {
+        code: 0,
+        stdout: "worktree /repo\nHEAD abcdef0\nbranch refs/heads/main\n\n",
+        stderr: "",
+      },
+    });
+    expect(resolveWorktree({ ticket: "CTL-604", repoRoot: "/repo" }, { runGit: noMatch })).toBe(null);
+
+    const throwGit = () => {
+      throw new Error("runGit must not be called");
+    };
+    expect(resolveWorktree({ ticket: null, repoRoot: "/repo" }, { runGit: throwGit })).toBe(null);
+    expect(resolveWorktree({ ticket: "CTL-604", repoRoot: null }, { runGit: throwGit })).toBe(null);
+  });
+});
+
+describe("WORK_DONE_PROBES.research — happy path", () => {
+  test("true when worktree resolves + a complete ticket artifact is present", () => {
+    const wt = "/wt/CTL-604";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-604", wt), stderr: "" },
+    });
+    const listArtifacts = makeListArtifacts({
+      "thoughts/shared/research": ["2026-05-26-ctl-604.md"],
+    });
+    const readArtifact = makeReadArtifact({
+      "2026-05-26-ctl-604.md": RESEARCH_BODY_COMPLETE,
+    });
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        { runGit, listArtifacts, readArtifact },
+      ),
+    ).toBe(true);
+  });
+
+  test("case-insensitive filename match with a descriptive suffix", () => {
+    const wt = "/wt/CTL-604";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-604", wt), stderr: "" },
+    });
+    const listArtifacts = makeListArtifacts({
+      "thoughts/shared/research": ["2026-05-26-CTL-604-some-suffix.md"],
+    });
+    const readArtifact = makeReadArtifact({
+      "2026-05-26-CTL-604-some-suffix.md": RESEARCH_BODY_COMPLETE,
+    });
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        { runGit, listArtifacts, readArtifact },
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("WORK_DONE_PROBES.research — false cases", () => {
+  const wt = "/wt/CTL-604";
+  const runGitOk = makeRunGit({
+    "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-604", wt), stderr: "" },
+  });
+
+  test("no worktree match → false", () => {
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": {
+        code: 0,
+        stdout: "worktree /repo\nHEAD abcdef0\nbranch refs/heads/main\n\n",
+        stderr: "",
+      },
+    });
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        { runGit, listArtifacts: () => ["2026-05-26-ctl-604.md"], readArtifact: () => RESEARCH_BODY_COMPLETE },
+      ),
+    ).toBe(false);
+  });
+
+  test("empty directory → false", () => {
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        { runGit: runGitOk, listArtifacts: makeListArtifacts({ "thoughts/shared/research": [] }), readArtifact: () => "" },
+      ),
+    ).toBe(false);
+  });
+
+  test("no ticket-matching file → false", () => {
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        {
+          runGit: runGitOk,
+          listArtifacts: makeListArtifacts({ "thoughts/shared/research": ["2026-05-26-ctl-999.md", "notes.md"] }),
+          readArtifact: () => RESEARCH_BODY_COMPLETE,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  test("artifact below size floor → false", () => {
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        {
+          runGit: runGitOk,
+          listArtifacts: makeListArtifacts({ "thoughts/shared/research": ["2026-05-26-ctl-604.md"] }),
+          readArtifact: makeReadArtifact({ "2026-05-26-ctl-604.md": "## Code References\n" }),
+        },
+      ),
+    ).toBe(false);
+  });
+
+  test("artifact missing the closing section (truncated mid-write) → false", () => {
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        {
+          runGit: runGitOk,
+          listArtifacts: makeListArtifacts({ "thoughts/shared/research": ["2026-05-26-ctl-604.md"] }),
+          readArtifact: makeReadArtifact({ "2026-05-26-ctl-604.md": "x".repeat(400) }),
+        },
+      ),
+    ).toBe(false);
+  });
+
+  test("readdir throws → safe default [] → false", () => {
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        {
+          runGit: runGitOk,
+          listArtifacts: () => {
+            throw new Error("readdir blew up");
+          },
+          readArtifact: () => RESEARCH_BODY_COMPLETE,
+        },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("WORK_DONE_PROBES.plan — completeness gate", () => {
+  const wt = "/wt/CTL-604";
+  const runGitOk = makeRunGit({
+    "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-604", wt), stderr: "" },
+  });
+
+  test("true when a complete plan with `## Phase ` + `Success Criteria` is present", () => {
+    expect(
+      WORK_DONE_PROBES.plan(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        {
+          runGit: runGitOk,
+          listArtifacts: makeListArtifacts({ "thoughts/shared/plans": ["2026-05-26-ctl-604.md"] }),
+          readArtifact: makeReadArtifact({ "2026-05-26-ctl-604.md": PLAN_BODY_COMPLETE }),
+        },
+      ),
+    ).toBe(true);
+  });
+
+  test("plan missing the `## Phase ` heading (truncated) → false", () => {
+    const truncated = `# Plan: CTL-604\n\n${"prose ".repeat(60)}\n\n### Success Criteria\n- [ ] x\n`;
+    expect(
+      WORK_DONE_PROBES.plan(
+        { ticket: "CTL-604", repoRoot: "/repo" },
+        {
+          runGit: runGitOk,
+          listArtifacts: makeListArtifacts({ "thoughts/shared/plans": ["2026-05-26-ctl-604.md"] }),
+          readArtifact: makeReadArtifact({ "2026-05-26-ctl-604.md": truncated }),
+        },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("WORK_DONE_PROBES.research/plan — input guards (no fs/git spawn)", () => {
+  const boom = () => {
+    throw new Error("seam must not be called");
+  };
+
+  test("missing ticket → false", () => {
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: null, repoRoot: "/repo" },
+        { runGit: boom, listArtifacts: boom, readArtifact: boom },
+      ),
+    ).toBe(false);
+    expect(
+      WORK_DONE_PROBES.plan(
+        { ticket: null, repoRoot: "/repo" },
+        { runGit: boom, listArtifacts: boom, readArtifact: boom },
+      ),
+    ).toBe(false);
+  });
+
+  test("missing repoRoot → false", () => {
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-604", repoRoot: null },
+        { runGit: boom, listArtifacts: boom, readArtifact: boom },
+      ),
+    ).toBe(false);
   });
 });

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -367,8 +367,21 @@ while IFS=$'\t' read -r W T; do
 	fi
 
 	if [ -f "$SIGNAL_FILE" ]; then
-		# Already has a signal (idempotent — previously dispatched)
-		continue
+		# CTL-604: status-aware idempotency. A signal that is still in flight
+		# (running/dispatched/…) or already terminal-success (done/merged) means a
+		# prior dispatch is owned elsewhere — skip. But a failed/stalled signal is
+		# re-dispatchable: a worker that died without recovery must be relaunched,
+		# not stranded on mere file existence. Default (missing/malformed status)
+		# stays conservative — skip — so we never double-dispatch a live worker.
+		EXISTING_STATUS=$(jq -r '.status // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+		case "$EXISTING_STATUS" in
+		failed | stalled)
+			: # fall through to (re-)dispatch
+			;;
+		*)
+			continue
+			;;
+		esac
 	fi
 
 	if [ ! -d "$WORKER_DIR" ]; then

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -160,20 +160,50 @@ detect_api_error_in_stream() {
 
   # Scan the last 50 lines for a matching API-error result event.
   # The jq filter returns the uuid of the most recent matching event, or nothing.
+  # CTL-604: also match a socket-connection-closed / bg-idle stream result.
+  # The reported incident died with "API Error: The socket connection was
+  # closed unexpectedly" (and, for a bg-idle resume, "running as a background
+  # agent"); neither matched the old regex, so the worker fell through to the
+  # less-informative pid-dead reason instead of being recognised as a recoverable
+  # stream error.
+  local api_error_re="Stream idle timeout|partial response received|socket connection was closed|running as a background agent"
   local uuid
   uuid=$(tail -n 50 "$stream" 2>/dev/null \
-    | jq -r 'select(.type == "result" and .is_error == true)
+    | jq -r --arg re "$api_error_re" \
+            'select(.type == "result" and .is_error == true)
              | select(
-                 (.api_error_status // "" | tostring
-                   | test("Stream idle timeout|partial response received"; "i"))
+                 (.api_error_status // "" | tostring | test($re; "i"))
                  or
-                 ((.result // "" | tostring)
-                   | test("Stream idle timeout|partial response received"; "i"))
+                 ((.result // "" | tostring) | test($re; "i"))
                )
              | .uuid // empty' 2>/dev/null \
     | tail -n 1)
   [ -n "$uuid" ] && { echo "$uuid"; return 0; }
   return 1
+}
+
+# CTL-604: classify a `claude --bg --resume` attempt's resume stderr so the
+# caller can tell three outcomes apart and not record a false successful revive:
+#   "alive"    the agent is still running as a bg job; the resume was rejected
+#              ("currently running as a background agent (bg)"). The worker is
+#              NOT dead — this must NOT bump reviveCount or record pid-dead.
+#   "failed"   any other non-empty stderr — a hard resume error; the caller
+#              records revive-spawn-failed rather than a successful revive.
+#   "launched" empty stderr — a clean resume (the normal path).
+# Single source of truth for the alive-vs-failed-vs-launched decision so the
+# detector and the caller agree.
+classify_resume_stderr() {
+  local stderr_text="$1"
+  if [ -z "$stderr_text" ]; then
+    echo "launched"
+    return 0
+  fi
+  if printf '%s' "$stderr_text" \
+       | grep -qiE "currently running as a background agent \(bg\)|already running as a background agent"; then
+    echo "alive"
+    return 0
+  fi
+  echo "failed"
 }
 
 # Emit a fresh-start event via the state script (no-op when state script is
@@ -263,6 +293,11 @@ spawn_revive_bg() {
   local stderr_file="${ORCH_DIR}/workers/output/${ticket}-bg-stderr.log"
   mkdir -p "$(dirname "$stdout_file")"
 
+  # CTL-604: record the stderr file size before this invocation so we can read
+  # ONLY the bytes this resume appends (the file is append-only across revives).
+  local stderr_pre=0
+  [ -f "$stderr_file" ] && stderr_pre=$(wc -c < "$stderr_file" 2>/dev/null | tr -d ' ')
+
   # CTL-495: compose OTEL_RESOURCE_ATTRIBUTES inline so the revived session
   # carries task.type=phase-<phase>. Each revive iteration may target a
   # different phase, so we cannot rely on the parent shell's value (which is
@@ -295,18 +330,35 @@ spawn_revive_bg() {
 
   # Wait briefly for stdout to materialize (real claude --bg returns almost
   # immediately; tests stub it the same way). Cap at 5s to avoid stalling.
+  # CTL-604: also stop early if the resume produced new stderr (a bg-idle/hard
+  # error never materializes stdout, so the loop would otherwise burn the full
+  # cap before we classify the failure).
   local waited=0
   while [ ! -s "$stdout_file" ] && [ "$waited" -lt 50 ]; do
+    local stderr_now=0
+    [ -f "$stderr_file" ] && stderr_now=$(wc -c < "$stderr_file" 2>/dev/null | tr -d ' ')
+    [ "$stderr_now" -gt "$stderr_pre" ] && break
     sleep 0.1
     waited=$((waited+1))
   done
+
+  # CTL-604: read only the stderr this resume appended and classify the outcome.
+  local resume_stderr=""
+  if [ -f "$stderr_file" ]; then
+    resume_stderr=$(tail -c "+$((stderr_pre + 1))" "$stderr_file" 2>/dev/null)
+  fi
+  local outcome
+  outcome=$(classify_resume_stderr "$resume_stderr")
 
   local new_bg=""
   if [ -s "$stdout_file" ]; then
     new_bg=$(jq -r 'select(.id) | .id' "$stdout_file" 2>/dev/null | head -1)
   fi
 
-  echo "pid:${pid}:${new_bg}"
+  # CTL-604: prefix the result with the outcome so the caller can tell
+  # "launched" (fresh revive) from "alive" (agent still running — no-op) and
+  # "failed" (hard resume error). Shape: "<outcome>:pid:<pid>:<bg_job_id>".
+  echo "${outcome}:pid:${pid}:${new_bg}"
 }
 
 # CTL-484: spawn a continuation worker for a turn-cap-exhausted phase agent.
@@ -892,11 +944,19 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
   # see the fresh job. Legacy workers keep the original -p --resume spawn.
   NEW_BG_JOB_ID=""
   ACTIVE_PHASE=""
+  RESUME_OUTCOME="launched"
   if is_phase_mode "$TICKET"; then
     ACTIVE_PHASE=$(active_phase_of "$TICKET")
     # CTL-495: pass ACTIVE_PHASE so the revived session gets task.type=phase-<phase>.
     SPAWN_OUT=$(spawn_revive_bg "$TICKET" "$WORKTREE" "$SESSION_ID" "$ACTIVE_PHASE" || echo "")
-    # SPAWN_OUT shape: "pid:<pid>:<bg_job_id>"
+    # CTL-604: SPAWN_OUT shape: "<outcome>:pid:<pid>:<bg_job_id>" where outcome
+    # is launched|alive|failed. Strip the outcome prefix before parsing pid/bg.
+    RESUME_OUTCOME="${SPAWN_OUT%%:*}"
+    case "$RESUME_OUTCOME" in
+      launched | alive | failed) SPAWN_OUT="${SPAWN_OUT#*:}" ;;
+      *) RESUME_OUTCOME="launched" ;;  # legacy shape (no prefix) → treat as launched
+    esac
+    # Remaining shape: "pid:<pid>:<bg_job_id>"
     NEW_PID="${SPAWN_OUT#pid:}"
     NEW_PID="${NEW_PID%%:*}"
     NEW_BG_JOB_ID="${SPAWN_OUT##*:}"
@@ -904,6 +964,20 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
   else
     PROMPT=$(build_prompt "$STATUS")
     NEW_PID=$(spawn_revive "$TICKET" "$WORKTREE" "$SESSION_ID" "$PROMPT" || echo "")
+  fi
+
+  # CTL-604: the agent is still running as a bg job (resume rejected) — NOT dead.
+  # Do not bump reviveCount or record pid-dead; leave the signal untouched and
+  # let the next sweep re-check liveness. This is the false-pid-dead fix.
+  if [ "$RESUME_OUTCOME" = "alive" ]; then
+    echo "STILL-ALIVE: ${TICKET} (resume rejected — agent running as bg; no revive recorded)" >&2
+    continue
+  fi
+
+  # CTL-604: a hard resume error (failed) is a real spawn failure → record
+  # revive-spawn-failed rather than a successful revive.
+  if [ "$RESUME_OUTCOME" = "failed" ]; then
+    NEW_PID=""
   fi
 
   if [ -z "$NEW_PID" ]; then


### PR DESCRIPTION
## Summary

Stops the orchestrator from falsely escalating live or recoverable research/plan
phase workers to `needs-human`. Three related fixes:

1. **Research/plan work-done probes** — the CTL-574 reclaim sweep only knew how to
   tell whether `implement` had finished (commits-ahead check). `research` and
   `plan` had no probe, so a worker that died before writing its artifact (or one
   the sweep merely *thought* was dead) was dead-ended at `needs-human` instead of
   being re-dispatched.

2. **Re-dispatch dead research/plan workers instead of escalating** — with probes
   in place, every phase reaching the "work not done" branch now shares the bounded
   revive / re-dispatch path. The `non-implement-not-done` escalation branch is
   removed; only genuinely probe-less phases (`verify`/`review`/`pr`/`monitor-*`)
   still escalate.

3. **Legacy `orchestrate-revive` false pid-dead** — the API-error stream detector
   didn't recognize `"socket connection was closed unexpectedly"` or the bg-idle
   `"running as a background agent"` result, so those recoverable stream deaths fell
   through to the less-informative pid-dead reason. Detection regex widened and
   dispatch made status-aware.

## Changes

### `execution-core/work-done-probes.mjs`
- New `resolveWorktree` seam (shared by `implementProbe` and the new artifact
  probes) — resolves the worktree bound to `refs/heads/<ticket>` via
  `git worktree list --porcelain`.
- New `defaultListArtifacts` / `defaultReadArtifact` injected seams (mirror the
  `defaultRunGit` discipline).
- New `artifactProbe(subdir, markers)` factory: true only when the worktree
  resolves, a markdown file naming the ticket exists under `<worktree>/<subdir>`,
  and that file clears `MIN_ARTIFACT_BYTES` (200) **and** carries the schema's
  closing markers. Any failure → `false` (re-dispatch is the safe default, so a
  truncated mid-write artifact is never advanced).
- `researchProbe` (thoughts/shared/research, requires `## Code References` or
  `## Summary`) and `planProbe` (thoughts/shared/plans, requires a `## Phase `
  heading and a `Success Criteria` marker) registered into `WORK_DONE_PROBES`.

### `execution-core/recovery.mjs`
- Removed the `non-implement-not-done` escalation branch in
  `reclaimDeadWorkIfPossible` — every phase that reaches the "work not done"
  branch now has a probe and shares the bounded revive/re-dispatch path.
- Updated the escalation-outcome documentation to reflect that `escalated` now
  means only probe-less phases.

### `orchestrate-revive` (legacy)
- Widened `detect_api_error_in_stream` regex to also match
  `socket connection was closed` and `running as a background agent`.
- Status-aware dispatch so recoverable stream deaths are recognized rather than
  reported as pid-dead.

### `orchestrate-dispatch-next`
- Phase-aware adjustments supporting the status-aware dispatch path.

## Tests

- `work-done-probes.test.mjs` (+279) — coverage for `resolveWorktree`, the artifact
  probe factory, size-floor / marker-completeness gates, and the research/plan
  registry entries.
- `recovery.test.mjs` (+40) — re-dispatch-instead-of-escalate behavior for
  research/plan.
- `__tests__/orchestrate-revive-socket-death.test.sh` (new, +168) — socket-closed /
  bg-idle stream-death detection.
- `__tests__/orchestrate-bg-revive.test.sh` (new, +49) and
  `__tests__/orchestrate-dispatch-next.test.sh` (new, +94) — dispatch path coverage.

Refs: CTL-604
