### PR TITLE
CTL-610: alive-quiet keep-alive guard for execution-core revive sweep

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -397,6 +397,35 @@ export function defaultKillBgJob(
   }
 }
 
+// defaultPidAlive — positive keep-alive check (CTL-610). Returns true iff the
+// bg job's recorded pid is still a live `claude` process. This is the inverse
+// use of the same primitive defaultKillBgJob uses to gate its SIGKILL: read
+// ~/.claude/jobs/<id>/pid, verify via `ps -p <pid> -o comm=` that the pid maps
+// to a claude process. It signals "alive, do not revive", never kills.
+// Best-effort: any doubt (missing pid file, unreadable, recycled pid, falsy
+// id, throwing seam) returns false so the caller falls through to its existing
+// revive path. Critically, the production seam returning false on a missing
+// pid file keeps every pre-CTL-610 revive test (which uses bgJobId "bg-9"
+// with no real pid file) green when the alive-quiet guard goes live.
+// `spawn` and `jobsRoot` are injectable for tests; production defaults call
+// the real spawnSync against the real ~/.claude/jobs.
+export function defaultPidAlive(
+  { bgJobId },
+  { spawn = spawnSync, jobsRoot = getJobsRoot } = {},
+) {
+  if (!bgJobId) return false;
+  try {
+    const pidPath = join(jobsRoot(), bgJobId, "pid");
+    if (!existsSync(pidPath)) return false;
+    const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+    if (!Number.isFinite(pid) || pid <= 1) return false;
+    const ps = spawn("ps", ["-p", String(pid), "-o", "comm="], { encoding: "utf8" });
+    return ps.status === 0 && (ps.stdout || "").toLowerCase().includes("claude");
+  } catch {
+    return false;
+  }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // CTL-640: cold-start detection. The reference epoch = max(OS boot, claude-daemon
 // start). If that epoch is newer than EVERY ~/.claude/jobs/<id>/state.json mtime,

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -570,6 +570,16 @@ const STORM_WINDOW_MS = 10 * 60 * 1000;
 const STORM_THRESHOLD = 3;
 const KILL_RECENT_ACTIVITY_MS = 30 * 1000;
 
+// CTL-610 — hung cutoff for the alive-quiet keep-alive guard. A worker flagged
+// effectively-dead by stale state.json mtime but whose bg pid is still a live
+// `claude` process is alive-but-blocked-on-a-long-tool-call (a research/plan
+// sub-agent fan-out, or a long synchronous Edit/Bash inside implement), not
+// crashed — so we suppress its revive up to this bound. Past it, even a live
+// pid is treated as genuinely hung and revived as before. 15 minutes matches
+// the legacy STALE_BG_SECONDS the original ticket cites — a live worker gets
+// the full original grace before we conclude it is hung.
+const HUNG_CUTOFF_MS = 15 * 60 * 1000;
+
 // reclaimDeadWorkIfPossible — one signal in, one decision out. CTL-587 widens
 // the return set from CTL-574's five values to seven, transforming the two
 // silent dead-ends ('not-applicable' and 'not-done') into actionable outcomes:
@@ -607,6 +617,18 @@ const KILL_RECENT_ACTIVITY_MS = 30 * 1000;
 //                         ahead of the genuinely-active terminal phase. No
 //                         escalate/revive/reclaim — acting would spuriously flag
 //                         needs-human or spawn a duplicate worker at a past phase.
+//   'alive-quiet-suppressed' effectively dead by state.json mtime AND probe says
+//                         work NOT done BUT the bg pid is still a live `claude`
+//                         process within HUNG_CUTOFF_MS (CTL-610). The worker
+//                         is alive-blocked-on-a-long-tool-call (the pre-first-
+//                         output window for research/plan, or a long sync
+//                         Edit/Bash inside implement), not crashed. Suppress
+//                         the revive: no duplicate spawn, no budget consumed,
+//                         no .revive-N.applied marker, no defensive kill, no
+//                         events.jsonl append — log-only (to avoid the CTL-638
+//                         self-feeding storm). A dead pid (real crash) or a
+//                         live pid past the cutoff (genuinely hung) falls
+//                         through to the existing revive path.
 //
 // CTL-588 still defines "effectively dead" as classifyWorker:'dead' OR a
 // 'running' signal whose bg state.json mtime is older than staleMs.
@@ -644,6 +666,14 @@ export function reclaimDeadWorkIfPossible(
     // CTL-606 — supersede guard. Returns the ticket's dispatched phase names so
     // the guard can detect a dead signal the pipeline has already advanced past.
     listTicketPhases = (t) => listDispatchedPhases(orchDir, t),
+    // CTL-610 — alive-quiet keep-alive guard. pidAlive is the positive
+    // inverse of defaultKillBgJob's ps-verify: "is bg pid a live `claude`
+    // process?" Returning true within hungCutoffMs suppresses the revive
+    // entirely (the worker is alive on a long tool call, not crashed).
+    // Production defaults: pidAlive reads ~/.claude/jobs/<bg>/pid; the cutoff
+    // matches the legacy 15-min STALE_BG_SECONDS.
+    pidAlive = defaultPidAlive,
+    hungCutoffMs = HUNG_CUTOFF_MS,
     now = Date.now,
     staleMs = STALE_MS,
   } = {},
@@ -744,6 +774,33 @@ export function reclaimDeadWorkIfPossible(
   //     artifact is re-dispatched fresh rather than dead-ended at needs-human.
   //     defaultReviveDispatch is phase-agnostic (resets the signal to `stalled`
   //     and re-launches via phase-agent-dispatch).
+
+  // (C0) CTL-610 — alive-quiet keep-alive guard. The worker is effectively-dead
+  //     by state.json mtime and its probe reads not-done, but if its bg pid is
+  //     still a live `claude` process within the hung cutoff, it is alive-
+  //     blocked on a long synchronous tool call (the pre-first-output window
+  //     for research/plan, or a long Edit/Bash inside implement), not crashed.
+  //     Suppress the revive — no duplicate spawn, no budget spent, no marker,
+  //     no kill, no events.jsonl append (log-only, to avoid the CTL-638
+  //     self-feeding storm). A dead pid (real crash) or a live pid past the
+  //     cutoff (genuinely hung) falls through to the existing revive path
+  //     below. Runs BEFORE priorRevives so a live worker is never falsely
+  //     escalated to needs-human just because two prior false-revives consumed
+  //     its budget; runs BEFORE the storm-breaker so liveness wins over
+  //     fleet-wide noise. The first conjunct (prevStateJsonMtime !== null)
+  //     fails-closed on the classifyWorker:'dead' path (job dir gone — a real
+  //     crash) so the guard cannot mask one.
+  if (
+    prevStateJsonMtime !== null &&
+    now() - prevStateJsonMtime < hungCutoffMs &&
+    pidAlive({ bgJobId: prevBgJobId })
+  ) {
+    log.info(
+      { ticket, phase, prevBgJobId, prevStateJsonMtime },
+      "ctl-610: revive suppressed — bg pid alive within hung cutoff (worker is quiet, not dead)",
+    );
+    return "alive-quiet-suppressed";
+  }
 
   // Per-ticket revive budget from events.jsonl. The events file is the
   // authoritative counter — surviving daemon restarts, more truthful than the

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -16,6 +16,7 @@ import {
   reclaimDeadWorkIfPossible,
   defaultReviveDispatch,
   defaultKillBgJob,
+  defaultPidAlive,
   defaultAppendReviveEvent,
   readBootEpoch,
   readDaemonEpoch,
@@ -1318,6 +1319,110 @@ describe("defaultKillBgJob — pid-recycling guard", () => {
     const killCalls = calls.filter((c) => c.cmd === "kill");
     expect(killCalls).toHaveLength(1);
     expect(killCalls[0].args).toEqual(["-9", "12345"]);
+  });
+});
+
+// CTL-610: defaultPidAlive is the positive inverse of the ps-verify inside
+// defaultKillBgJob. It answers "is this bg job's pid still a live `claude`
+// process?" as a keep-alive signal. Best-effort: every doubt (missing pid
+// file, recycled pid, unreadable pid, falsy id) returns false so the caller's
+// existing revive path is preserved — critically, existing setupReviveScenario
+// tests use bgJobId "bg-9" with no real pid file under the real ~/.claude/jobs,
+// so the production default-seamed defaultPidAlive must return false there.
+describe("defaultPidAlive — positive bg-pid keep-alive (CTL-610)", () => {
+  let jobsRootDir;
+  beforeEach(() => {
+    jobsRootDir = mkdtempSync(join(tmpdir(), "ctl610-jobs-"));
+  });
+  afterEach(() => {
+    rmSync(jobsRootDir, { recursive: true, force: true });
+  });
+
+  function seedPid(bgJobId, pid) {
+    const dir = join(jobsRootDir, bgJobId);
+    mkdirSync(dir, { recursive: true });
+    if (pid !== undefined) writeFileSync(join(dir, "pid"), String(pid));
+  }
+
+  test("falsy bgJobId → false, no spawn", () => {
+    const spawn = recorder({ status: 0, stdout: "claude\n" });
+    expect(defaultPidAlive({ bgJobId: null }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
+    expect(spawn.calls.length).toBe(0);
+  });
+
+  test("missing pid file → false (the default-safe case existing revive tests rely on)", () => {
+    // bgJobId set but no pid file → fall through to false; production seam
+    // therefore leaves every existing setupReviveScenario (bg-9, no pid) green.
+    const spawn = recorder({ status: 0, stdout: "claude\n" });
+    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
+    expect(spawn.calls.length).toBe(0);
+  });
+
+  test("non-numeric pid file → false, no spawn", () => {
+    seedPid("bg-9", "abc");
+    const spawn = recorder({ status: 0, stdout: "claude\n" });
+    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
+    expect(spawn.calls.length).toBe(0);
+  });
+
+  test("pid <= 1 → false, no spawn (init / invalid)", () => {
+    seedPid("bg-9", "1");
+    const spawn = recorder({ status: 0, stdout: "claude\n" });
+    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
+    expect(spawn.calls.length).toBe(0);
+  });
+
+  test("ps exit non-zero (pid gone) → false, ps was invoked exactly once", () => {
+    seedPid("bg-9", "12345");
+    const calls = [];
+    const spawn = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { status: 1, stdout: "", stderr: "" };
+    };
+    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
+    expect(calls.filter((c) => c.cmd === "ps").length).toBe(1);
+  });
+
+  test("ps says 'node' (pid recycled to non-claude process) → false", () => {
+    seedPid("bg-9", "12345");
+    const spawn = () => ({ status: 0, stdout: "node\n", stderr: "" });
+    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
+  });
+
+  test("happy path: pid file present + ps says 'claude' → true, ps invoked with -p <pid> -o comm=", () => {
+    seedPid("bg-9", "12345");
+    const calls = [];
+    const spawn = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === "ps") return { status: 0, stdout: "claude\n", stderr: "" };
+      return { status: 127 };
+    };
+    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(true);
+    expect(calls.filter((c) => c.cmd === "ps")).toHaveLength(1);
+    expect(calls.find((c) => c.cmd === "ps").args).toEqual(["-p", "12345", "-o", "comm="]);
+  });
+
+  test("case-insensitive match: ps stdout 'Claude' (capitalised) is still a claude process", () => {
+    seedPid("bg-9", "12345");
+    const spawn = () => ({ status: 0, stdout: "Claude\n", stderr: "" });
+    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(true);
+  });
+
+  test("substring match: ps stdout 'claude-bg' still counts (process name truncations)", () => {
+    seedPid("bg-9", "12345");
+    const spawn = () => ({ status: 0, stdout: "claude-bg\n", stderr: "" });
+    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(true);
+  });
+
+  test("never throws on a hostile jobsRoot (returns false)", () => {
+    // jobsRoot resolver throws — defaultPidAlive must swallow.
+    const spawn = recorder({ status: 0, stdout: "claude\n" });
+    expect(
+      defaultPidAlive({ bgJobId: "bg-9" }, {
+        spawn,
+        jobsRoot: () => { throw new Error("boom"); },
+      }),
+    ).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -978,6 +978,160 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
   });
 });
 
+// --- CTL-610: alive-quiet keep-alive guard (branch (C0)) -------------------
+//
+// A worker can be effectively-dead by state.json mtime (5min stale) yet still
+// be alive-blocked-on-a-long-tool-call — the pre-first-output window for
+// research/plan sub-agent fan-outs, or a long synchronous Edit/Bash inside
+// implement. Pre-CTL-610 such a worker was revived (duplicate `claude --bg`
+// spawn, budget consumed, eventual escalation), producing the documented
+// ~50%-of-workers revive storm in 14-ticket runs. The (C0) guard inverts the
+// PID liveness check defaultKillBgJob already uses: when bg pid is a live
+// `claude` process AND state.json mtime is within HUNG_CUTOFF_MS, suppress
+// the revive entirely — no dispatch, no budget consumed, no marker, no kill,
+// no events.jsonl append, log-only. Past the cutoff the worker is treated as
+// genuinely hung and the existing revive path runs.
+
+describe("reclaimDeadWorkIfPossible — CTL-610 alive-quiet keep-alive guard", () => {
+  // Inline scenario builder mirroring setupReviveScenario but with the CTL-610
+  // pidAlive + hungCutoffMs seams added. The same defaults (effectively dead by
+  // mtime, probe says NOT done) so we exercise branch (C) territory; the (C0)
+  // guard sits at the top of (C), before priorRevives is consulted.
+  function setupAliveQuietScenario({
+    pidAlive = () => true, // bg pid is a live claude process
+    hungCutoffMs = 15 * 60 * 1000, // CTL-610 default
+    reviveCount = 0,
+    probeResult = false,
+    phase = "implement",
+    ticket = "CTL-9",
+    bgJobId = "bg-9",
+    stateJsonMtime = 1_000,
+    // 6 min past mtime — staleMs (5min) crossed, well within hungCutoffMs (15min).
+    nowMs = 1_000 + 6 * 60 * 1000,
+  } = {}) {
+    const sig = {
+      ...implementSignal({ ticket, status: "running", bgJobId }),
+      phase,
+    };
+    sig.raw.phase = phase;
+    return {
+      orch: "/orch",
+      sig,
+      opts: {
+        repoRoot: "/repo",
+        statJob: () => ({ exists: true, mtimeMs: stateJsonMtime }),
+        probes: { [phase]: recorder(probeResult) },
+        emitComplete: recorder({ code: 0 }),
+        appendEvent: recorder(undefined),
+        appendReviveEvent: recorder(undefined),
+        appendEscalatedEvent: recorder(undefined),
+        appendReviveSuppressedEvent: recorder(undefined),
+        reviveDispatch: recorder({ code: 0 }),
+        applyStalledLabel: recorder({ applied: true }),
+        killBgJob: recorder(undefined),
+        countReviveEvents: recorder(reviveCount),
+        countDistinctRevivingTickets: recorder(1),
+        writeReviveMarker: recorder(undefined),
+        pidAlive: recorder(pidAlive()),
+        hungCutoffMs,
+        now: () => nowMs,
+        staleMs: 5 * 60 * 1000,
+      },
+    };
+  }
+
+  test("alive pid within hung cutoff → 'alive-quiet-suppressed' (no dispatch, no budget, no marker, no kill, no events)", () => {
+    const s = setupAliveQuietScenario({ pidAlive: () => true, reviveCount: 0 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+    expect(s.opts.appendReviveEvent.calls.length).toBe(0);
+    expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(0);
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
+    expect(s.opts.writeReviveMarker.calls.length).toBe(0);
+    expect(s.opts.killBgJob.calls.length).toBe(0);
+    expect(s.opts.applyStalledLabel.calls.length).toBe(0);
+    // The guard MUST consult pidAlive — otherwise it cannot decide
+    expect(s.opts.pidAlive.calls.length).toBeGreaterThanOrEqual(1);
+    expect(s.opts.pidAlive.calls[0][0].bgJobId).toBe("bg-9");
+  });
+
+  test("alive pid but past hung cutoff → 'revived' (genuinely hung, existing path runs)", () => {
+    // 20 min past mtime > 15 min hung cutoff → fall through to existing revive
+    const s = setupAliveQuietScenario({
+      pidAlive: () => true,
+      stateJsonMtime: 1_000,
+      nowMs: 1_000 + 20 * 60 * 1000,
+    });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+    expect(s.opts.appendReviveEvent.calls.length).toBe(1);
+  });
+
+  test("dead pid → 'revived' (regression-shaped — existing CTL-587 path unchanged)", () => {
+    const s = setupAliveQuietScenario({ pidAlive: () => false });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("alive pid + revive budget exhausted → still 'alive-quiet-suppressed' (NEVER false-escalate a live worker)", () => {
+    // The (C0) guard MUST run before the budget-exhausted check, otherwise a
+    // live but quiet worker would be falsely escalated to needs-human just
+    // because two prior false-revives consumed its budget. This is the worst
+    // case the guard exists to prevent.
+    const s = setupAliveQuietScenario({ pidAlive: () => true, reviveCount: 2 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
+    expect(s.opts.applyStalledLabel.calls.length).toBe(0);
+  });
+
+  test("alive pid + storm-breaker open → still 'alive-quiet-suppressed' (guard runs before storm check)", () => {
+    // A live worker is alive regardless of fleet-wide storm conditions; the
+    // guard short-circuits storm bookkeeping too (no audit event emitted).
+    const s = setupAliveQuietScenario({ pidAlive: () => true });
+    s.opts.countDistinctRevivingTickets = recorder(4); // storm threshold open
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+    expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(0);
+  });
+
+  test("work-done (branch B) wins over alive-quiet (B returns before C0 is reached)", () => {
+    const s = setupAliveQuietScenario({ pidAlive: () => true, probeResult: true });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
+    // Guard MUST NOT have been consulted — branch (B) returned first
+    expect(s.opts.pidAlive.calls.length).toBe(0);
+  });
+
+  test("production default seam returns false for a fake bgJobId → guard inert, existing revive path runs", () => {
+    // The original setupReviveScenario (in the CTL-587 describe block) uses
+    // bgJobId 'bg-9' with no real ~/.claude/jobs/bg-9/pid file and injects
+    // NO pidAlive seam — so the production defaultPidAlive runs and returns
+    // false on the missing pid file. The (C0) guard is therefore inert for
+    // every pre-CTL-610 revive test, and they continue to pass unchanged.
+    // This test asserts that contract explicitly using the same conditions.
+    const s = setupAliveQuietScenario({ reviveCount: 0 });
+    // Strip the test-injected pidAlive so we exercise the production default.
+    delete s.opts.pidAlive;
+    // bg-9 has no pid file under the real ~/.claude/jobs → defaultPidAlive
+    // returns false → guard inert → existing revive path runs.
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+  });
+
+  test("guard inert when prevStateJsonMtime is null (classifyWorker:'dead' path) — falls through to revive", () => {
+    // When statJob returns null (bg dir gone), classifyWorker returns 'dead'
+    // directly; prevStateJsonMtime stays null. The (C0) guard's first
+    // conjunct (prevStateJsonMtime !== null) MUST fail-closed here so a real
+    // crash still revives even if a (mis-)injected pidAlive lied "true".
+    const sig = implementSignal({ ticket: "CTL-9", status: "running", bgJobId: "bg-9" });
+    const opts = {
+      ...setupAliveQuietScenario().opts,
+      statJob: () => null, // bg dir gone → classifyWorker:'dead'
+      pidAlive: () => true,
+      now: () => 0,
+    };
+    // A 'dead' bg implies a real crash → revive must still fire.
+    expect(reclaimDeadWorkIfPossible("/orch", sig, opts)).toBe("revived");
+  });
+});
+
 // --- CTL-638: per-(ticket, phase) escalation cool-down ---------------------
 //
 // Pre-CTL-638 the recovery sweep re-fired `appendEscalatedEvent` +

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -548,6 +548,16 @@ export function schedulerTick(
         // escalation in events.jsonl already; surfacing this would re-recreate
         // the noise the cool-down exists to prevent.
         break;
+      case "alive-quiet-suppressed":
+        // CTL-610: the bg worker is alive (kill -0) but quiet on a long tool
+        // call (the pre-first-output window for research/plan, or a long
+        // synchronous Edit/Bash inside implement). Invisible by design — no
+        // duplicate spawn, no state change; the next tick re-evaluates the
+        // mtime + pidAlive pair. Surfacing it in result.revived / .escalated
+        // / .reviveSuppressed would re-create the very revive-storm noise the
+        // (C0) guard exists to suppress (and would re-feed the scheduler's own
+        // fs.watch fast path via any audit-event write — CTL-638 lineage).
+        break;
       default:
         // noop | not-done | not-applicable | reclaim-failed → invisible.
         // CTL-606: superseded-noop also buckets here — a dead predecessor signal

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1511,6 +1511,26 @@ describe("schedulerTick — CTL-587 Step 0 multi-result shape", () => {
     expect(result.reclaimed.map((e) => e.ticket)).toContain("CTL-8");
   });
 
+  test("CTL-610: 'alive-quiet-suppressed' is invisible by design — no crash, not in any bucket", () => {
+    // The alive-quiet guard exists precisely to suppress noise. Bucketing it
+    // explicitly into result.revived / .reviveSuppressed / .escalated would
+    // re-create the very revive-storm reporting the guard exists to eliminate.
+    // It MUST handle the case without crashing, and MUST NOT populate any of
+    // the visible buckets — the next tick re-evaluates.
+    writeNestedSignal("CTL-10", "implement", { status: "running", bg_job_id: "bg-10" });
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus,
+      teardownWorktree: () => true,
+      reclaimDeadWork: () => "alive-quiet-suppressed",
+    });
+    expect(result.revived).toEqual([]);
+    expect(result.reviveSuppressed).toEqual([]);
+    expect(result.escalated).toEqual([]);
+    expect(result.reclaimed).toEqual([]);
+  });
+
   test("clean tick (no dead workers) returns empty arrays for every CTL-587 outcome", () => {
     const result = schedulerTick(orchDir, {
       readEligible: () => [],


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-26T16:50:00Z -->
<!-- Last updated: 2026-05-26T16:50:00Z -->
<!-- PR: #1077 -->
<!-- Previous commits: 5d9df722,ebd8a6f1,709be651 -->

## Summary

Closes the **pre-first-output revive window** in the execution-core coordinator: when a phase worker is flagged effectively-dead by stale `state.json` mtime but its background `claude` process is still alive (and within a bounded hung cutoff), suppress the revive instead of spawning a duplicate worker.

CTL-610 reported that ~50% of phase workers in a 14-ticket run were revived despite making real progress — paying ~25% extra Opus cost on false positives, and risking the duplicate-worker bug. CTL-509 and the work-done probes (CTL-574/587/641/604) closed the *post-output* false-positive cases, but a research/plan worker that is alive and actively running tool calls before its first commit/artifact still reads as "not-done" by its probe and gets revived. This PR closes that residual gap.

This implements the un-landed half of the ticket's option (b) ("healthcheck consults bg-job liveness via `kill -0`"). It is intentionally **invisible-by-design**: log-only, no new `events.jsonl` kind, no HUD changes, no revive-budget consumption.

## Changes Made

### `recovery.mjs` (+86)

1. **`defaultPidAlive` keep-alive primitive (Phase 1)** — new exported, injectable function that answers "is this bg job's PID a live `claude` process?". Reads `$JOBS_ROOT/<bg_job_id>/pid`, checks `ps -p <pid> -o comm=` for "claude". Default-safe: missing pid file → `false` (so an unknown bg-job state can never suppress a real recovery).
2. **Bounded alive-quiet guard in branch (C) (Phase 2)** — at the top of the "work NOT done → revive territory" branch, before the revive-budget check / storm-breaker / defensive kill / dispatch, consult `defaultPidAlive`. If the PID is live AND the worker is within the hung cutoff window, return discriminator `"alive-quiet-suppressed"`: no revive dispatch, no marker, no kill, no event, just a `log.info`. Beyond the hung cutoff, fall through to the existing revive path.

### `scheduler.mjs` (+10)

Bucket the new `"alive-quiet-suppressed"` discriminator in the dispatch switch so the scheduler treats it the same as branch (B) — "nothing to do here, the worker is healthy".

### Tests (+279)

- `recovery.test.mjs` — `defaultPidAlive` primitive (live claude PID, missing pid file, dead PID, non-claude PID, malformed pid), plus alive-quiet guard behavior in branch (C) (suppression inside the window, fall-through past the cutoff, dead-PID still revives at 5 min).
- `scheduler.test.mjs` — verifies the dispatcher bucketing of `alive-quiet-suppressed`.

## Why this is safe

- **Dead PID → still revives at 5 min as today.** A real crash is unaffected because `defaultPidAlive` returns `false` when the pid file is missing or the process is gone.
- **Hung worker → still recovered.** A live PID past `HUNG_CUTOFF_MS` falls through to the existing revive + defensive kill path.
- **Work-done case unchanged.** Branch (B) (probe says work IS done → reclaim) still wins before this guard is consulted.

## How to Verify It

- [x] `bun test recovery.test.mjs` — passes
- [x] `bun test scheduler.test.mjs` — passes
- [x] Reward-hacking scan — clean
- [x] Merge-tree vs origin/main — clean (no conflicts)
- [x] Code review (sub-agent) — `reviewPassed: true`
- [x] Test coverage gate — pass
- [x] Silent-failure scan — pass
- [ ] Manual: dry-run an orchestrator run with a long-running research phase and confirm zero duplicate `claude --bg` spawns during the pre-first-output window

## Out of Scope / Not Doing

- Not changing `STALE_MS` (still 5 min — crashes must be detected promptly).
- Not touching the work-done probes or the existing `git_worker_is_live`.
- Not touching `orchestrate-healthcheck` (legacy path; CTL-509 already guards it).
- Not adding a worker-side per-tool-call heartbeat (rejected in the plan — LLM tool sequencing cannot reliably emit a heartbeat).
- Not emitting a new `events.jsonl` kind for the suppressed outcome (storm-avoidance; log-only).

## Related

- Refs: CTL-610
- Plan: `thoughts/shared/plans/2026-05-26-ctl-610.md`
- Research: `thoughts/shared/research/2026-05-26-ctl-610.md`
- Builds on: CTL-509 (git-activity guard), CTL-574/587/641/604 (work-done probes)
