### PR TITLE
CTL-635: Scrub per-ticket OTEL attrs at execution-core daemon launch

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
@@ -93,12 +93,55 @@ if [ ! -f "$SCRATCH/execution-core/daemon.pid" ]; then
 else
 	fail "start does not fabricate a PID file" "pidfile present"
 fi
-if echo "$OUT" | grep -qi "hung"; then
+if echo "$OUT" | grep -qi "wedged"; then
 	pass "start reports the degraded state"
 else
 	fail "start reports the degraded state" "out=$OUT"
 fi
 pkill -f "nopid-daemon.sh" 2>/dev/null || true
+teardown
+
+echo "test 5 (CTL-635): _neutralize_otel_attrs transform"
+# shellcheck source=/dev/null
+source "$SCRIPT" # source-safe: dispatch guarded, helpers defined
+POISONED="project=adva,hostname=mac-1,branch=CTL-635-x,linear.key=ADV-1039,catalyst.orchestration=CTL-635,task.type=phase-plan"
+OUT="$(_neutralize_otel_attrs "$POISONED")"
+# poisoning keys gone
+if ! echo "$OUT" | grep -q 'linear.key='; then pass "drops linear.key"; else fail "drops linear.key" "out=$OUT"; fi
+if ! echo "$OUT" | grep -q 'catalyst.orchestration='; then pass "drops catalyst.orchestration"; else fail "drops catalyst.orchestration" "out=$OUT"; fi
+if ! echo "$OUT" | grep -q 'branch='; then pass "drops branch"; else fail "drops branch" "out=$OUT"; fi
+if ! echo "$OUT" | grep -q 'task.type='; then pass "drops task.type"; else fail "drops task.type" "out=$OUT"; fi
+if ! echo "$OUT" | grep -q 'project=adva'; then pass "drops borrowed project"; else fail "drops borrowed project" "out=$OUT"; fi
+# neutral identity + honest attrs preserved
+if echo "$OUT" | grep -q 'project=catalyst'; then pass "stamps project=catalyst"; else fail "stamps project=catalyst" "out=$OUT"; fi
+if echo "$OUT" | grep -q 'catalyst.role=execution-core-daemon'; then pass "stamps daemon role"; else fail "stamps daemon role" "out=$OUT"; fi
+if echo "$OUT" | grep -q 'hostname=mac-1'; then pass "preserves hostname"; else fail "preserves hostname" "out=$OUT"; fi
+# empty input still yields the neutral identity
+OUT_EMPTY="$(_neutralize_otel_attrs "")"
+if echo "$OUT_EMPTY" | grep -q 'catalyst.role=execution-core-daemon'; then pass "empty input → neutral identity"; else fail "empty input → neutral identity" "out=$OUT_EMPTY"; fi
+
+echo "test 6 (CTL-635): start neutralizes the daemon's OTEL_RESOURCE_ATTRIBUTES"
+setup
+# fake daemon that records the OTEL env it was launched with, then behaves normally
+ENVDUMP="$SCRATCH/otel-env.txt"
+REC="$SCRATCH/rec-daemon.sh"
+cat >"$REC" <<EOF
+#!/usr/bin/env bash
+printf '%s' "\${OTEL_RESOURCE_ATTRIBUTES-}" > "$ENVDUMP"
+while [ \$# -gt 0 ]; do [ "\$1" = "--pid-file" ] && echo \$\$ > "\$2"; shift; done
+sleep 30
+EOF
+chmod +x "$REC"
+export EXECUTION_CORE_DAEMON_SCRIPT="$REC"
+export EXECUTION_CORE_RUNTIME="bash"
+# simulate a poisoned launch environment
+export OTEL_RESOURCE_ATTRIBUTES="project=adva,hostname=mac-1,linear.key=ADV-1039,catalyst.orchestration=CTL-635"
+"$SCRIPT" start >/dev/null 2>&1
+sleep 0.3
+GOT="$(cat "$ENVDUMP" 2>/dev/null)"
+if ! echo "$GOT" | grep -q 'linear.key='; then pass "daemon env has no linear.key"; else fail "daemon env has no linear.key" "got=$GOT"; fi
+if echo "$GOT" | grep -q 'catalyst.role=execution-core-daemon'; then pass "daemon env carries neutral identity"; else fail "daemon env carries neutral identity" "got=$GOT"; fi
+unset OTEL_RESOURCE_ATTRIBUTES
 teardown
 
 echo ""

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -65,6 +65,27 @@ resolve_runtime() {
 	return 1
 }
 
+# CTL-635: the daemon's --bg-spare pool freezes OTEL_RESOURCE_ATTRIBUTES at warm
+# time and it is immutable thereafter, so every phase worker's
+# claude_code_cost_usage_USD_total inherits whatever per-ticket context the
+# launch shell composed. Strip the per-ticket keys and stamp a neutral, honest
+# daemon identity so bg cost lands in one truthful bucket instead of a borrowed
+# ticket. (Per-ticket attribution requires Option D — Anthropic per-job env API.)
+_neutralize_otel_attrs() {
+	local raw="${1-}" out="" pair key
+	local IFS=','
+	for pair in $raw; do
+		[[ -z $pair ]] && continue
+		key="${pair%%=*}"
+		case "$key" in
+		project | branch | linear.key | catalyst.orchestration | task.type) continue ;;
+		*) out="${out:+$out,}$pair" ;;
+		esac
+	done
+	out="${out:+$out,}project=catalyst,catalyst.role=execution-core-daemon"
+	printf '%s' "$out"
+}
+
 cmd_start() {
 	if read_pid >/dev/null 2>&1; then
 		echo "catalyst-execution-core already running (pid $(read_pid))"
@@ -77,6 +98,12 @@ cmd_start() {
 		return 1
 	fi
 	mkdir -p "$EC_DIR" 2>/dev/null || true
+	# CTL-635: scrub inherited per-ticket OTEL attrs so the spare pool freezes a
+	# neutral daemon bucket, not a borrowed ticket. (Assign then export separately
+	# to avoid masking the helper's return value — SC2155.)
+	local neutral_otel
+	neutral_otel="$(_neutralize_otel_attrs "${OTEL_RESOURCE_ATTRIBUTES-}")"
+	export OTEL_RESOURCE_ATTRIBUTES="$neutral_otel"
 	nohup "$runtime" "$DAEMON_SCRIPT" --pid-file "$PID_FILE" >"$LOG_FILE" 2>&1 &
 	local server_pid=$!
 	disown "$server_pid" 2>/dev/null || true
@@ -126,6 +153,8 @@ cmd_stop() {
 }
 
 cmd_restart() {
+	# CTL-635: restart re-applies OTEL env hygiene for free — the scrub lives in
+	# cmd_start, which re-warms a fresh daemon (and its spare pool) on restart.
 	cmd_stop
 	cmd_start
 }
@@ -143,14 +172,20 @@ cmd_status() {
 	echo "stopped"
 }
 
-case "${1-}" in
-start) cmd_start ;;
-stop) cmd_stop ;;
-restart) cmd_restart ;;
-probe) cmd_probe ;;
-status) cmd_status ;;
-*)
-	echo "Usage: catalyst-execution-core {start|stop|restart|probe|status}" >&2
-	exit 1
-	;;
-esac
+# Source-safety (CTL-635): when sourced (e.g. by the test suite to unit-test
+# helpers), define functions but do not dispatch a command. `(return 0 2>/dev/null)`
+# succeeds only when this file is sourced; the negation guards execution to the
+# direct-invocation case.
+if ! (return 0 2>/dev/null); then
+	case "${1-}" in
+	start) cmd_start ;;
+	stop) cmd_stop ;;
+	restart) cmd_restart ;;
+	probe) cmd_probe ;;
+	status) cmd_status ;;
+	*)
+		echo "Usage: catalyst-execution-core {start|stop|restart|probe|status}" >&2
+		exit 1
+		;;
+	esac
+fi


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-26T18:25:00Z -->
<!-- Last updated: 2026-05-26T18:25:00Z -->
<!-- PR: #1078 -->
<!-- Previous commits: 937ac16d -->

## Summary

Scrub per-ticket OTEL resource attributes at execution-core daemon launch so the daemon's `--bg-spare` pool freezes a neutral, honest identity instead of whichever ticket happened to be active in the launch shell. This removes the cost-misattribution where every phase worker's `claude_code_cost_usage_USD_total` was tagged with the daemon's startup ticket regardless of which ticket the worker actually ran.

The execution-core daemon is started via `nohup` and inherits the launching shell's full env, including the per-ticket `OTEL_RESOURCE_ATTRIBUTES` direnv composed for the launch directory (`project`, `branch`, `linear.key`, `catalyst.orchestration`, `task.type`). Because the spare-pool warms with that frozen env and Anthropic does not yet expose a per-job env API, the value cannot be overwritten downstream — it leaks into every spawned worker as a borrowed ticket attribution.

This PR implements **Option C** ("daemon-launch env scrub") from the [plan](thoughts/shared/plans/2026-05-26-ctl-635.md). It is intentionally minimal: pure-bash, no runtime dependency, no daemon-side changes, no new flags. After this lands, the bogus `linear.key=<random-ticket>` row in cost dashboards disappears and bg cost lands in one truthful bucket (`project=catalyst, catalyst.role=execution-core-daemon`).

True per-ticket attribution on the in-process metric is **Option D** — an Anthropic per-job env API, tracked as an external follow-up.

## Changes Made

### `plugins/dev/scripts/catalyst-execution-core` (+45)

1. **`_neutralize_otel_attrs` helper (pure bash, exported function).** Splits the inherited `OTEL_RESOURCE_ATTRIBUTES` CSV on `,`, drops the per-ticket keys (`project`, `branch`, `linear.key`, `catalyst.orchestration`, `task.type`), preserves honest non-ticket attrs (e.g. `hostname`, future `service.*`), and appends a neutral daemon identity (`project=catalyst,catalyst.role=execution-core-daemon`). Empty input still yields the neutral identity.
2. **`cmd_start` call-site (immediately before `nohup`).** Assigns the neutralized value into a local then exports separately to avoid masking the helper's return value (SC2155). The spare pool warms with this clean env and freezes it for all bg jobs.
3. **`cmd_restart` inherits the hygiene for free** — it just calls `cmd_stop` then `cmd_start`, re-warming a fresh daemon with the scrub already applied.
4. **Source-safety guard at the bottom.** Wrapped the existing dispatch `case` in `if ! (return 0 2>/dev/null); then ... fi` so the file can be `source`d by the test suite to unit-test helpers without dispatching a subcommand. The check succeeds only when the file is being executed directly.

### `plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh` (+44, –1)

- **Test 5 — `_neutralize_otel_attrs` transform.** Drives the helper with a fully-poisoned CSV and asserts: all five per-ticket keys dropped, borrowed `project=adva` dropped, neutral `project=catalyst` + `catalyst.role=execution-core-daemon` stamped, honest `hostname=mac-1` preserved, empty input still yields the neutral identity.
- **Test 6 — `cmd_start` neutralizes the daemon's env.** Stands up a fake daemon (`rec-daemon.sh`) that records the `OTEL_RESOURCE_ATTRIBUTES` it was launched with, simulates a poisoned launch env, runs `catalyst-execution-core start`, and asserts the recorded env has no `linear.key=` and carries `catalyst.role=execution-core-daemon`.
- **Drive-by — fix stale CTL-554 Test 4 assertion.** The assertion grepped for `"hung"` but the CTL-586 message has since changed to `"wedged before initial write"`; updated the grep so the existing test passes again.

## Why this is safe

- **Pure bash, no runtime dep.** No new requirement on `jq`, `awk`, or Python in the daemon launch path.
- **No daemon-side changes.** The daemon binary itself is untouched; the scrub happens entirely in the wrapper script before `nohup`.
- **Honest non-ticket attrs preserved.** `hostname` (and any future `service.*`) round-trip through the helper unchanged.
- **Empty-input safety.** A launch shell with no `OTEL_RESOURCE_ATTRIBUTES` still yields the neutral daemon identity — never an empty string that downstream consumers might mis-parse.
- **Source-safety guard is the standard idiom.** `(return 0 2>/dev/null)` succeeds only inside a sourced file; the negated form gates dispatch to direct invocation. Tested by Test 5 itself, which sources the script.

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh` — passes (incl. Tests 5 & 6, and the revived Test 4)
- [x] Reward-hacking scan — clean
- [x] Code review (sub-agent) — `reviewPassed: true`
- [x] Test coverage gate — pass
- [x] Silent-failure scan — pass
- [ ] Manual: restart the daemon in a worktree with a per-ticket direnv loaded and confirm `claude_code_cost_usage_USD_total` for new bg jobs no longer carries `linear.key`

## Out of Scope / Not Doing

- **Option B (prelude re-export).** Probe-ABORTed earlier in this ticket as architecturally dead — the spare-pool env is frozen at warm time, so re-exporting at prelude time cannot reach the in-process OTEL exporter. See [thoughts/shared/research/2026-05-25-ctl-635-otel-prelude-reexport.md](thoughts/shared/research/2026-05-25-ctl-635-otel-prelude-reexport.md).
- **Option D (Anthropic per-job env API).** Tracked as external follow-up; required for true per-ticket attribution on the in-process metric. Out of scope here.
- **No HUD / dashboard changes.** Cost dashboards will naturally reflect the new bucketing once daemon is restarted; no view-layer work needed.
- **No new events.jsonl kind.** The scrub is invisible-by-design — log-free, event-free, marker-free.

## Related

- Refs: CTL-635
- Plan: [thoughts/shared/plans/2026-05-26-ctl-635.md](thoughts/shared/plans/2026-05-26-ctl-635.md)
- Research: [thoughts/shared/research/2026-05-26-ctl-635.md](thoughts/shared/research/2026-05-26-ctl-635.md)
- Disposition note: [thoughts/shared/research/2026-05-26-ctl-635-option-c-landed.md](thoughts/shared/research/2026-05-26-ctl-635-option-c-landed.md)
