### PR TITLE
CTL-617: gate orchestrate-auto-rebase on phase-monitor-merge ownership

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-auto-rebase.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-auto-rebase.test.sh
@@ -262,6 +262,77 @@ ATTEMPTS=$(jq -r '.rebaseAttempts // 0' "${ORCH_DIR}/workers/T-10.json")
 [ "$ATTEMPTS" = "0" ] && pass "rebaseAttempts not bumped on dispatch failure" || fail "rebaseAttempts not bumped on dispatch failure" "got: $ATTEMPTS"
 scratch_teardown
 
+# CTL-617: gate dispatch on phase-monitor-merge ownership.
+# phase-monitor-merge handles BEHIND inline; auto-rebase dispatching a
+# parallel rebase worker into the same worktree is the two-merge-owners
+# race. The "dispatched|running|done" set mirrors phase-agent-dispatch's
+# idempotency guard.
+
+echo "test: dispatch skipped when phase-monitor-merge is running"
+scratch_setup
+old=$(date -u -v-10M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "10 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+set_pr_view "OPEN" "DIRTY" "main"
+make_signal "CTL-617A" "running" "901" "https://github.com/coalesce-labs/catalyst/pull/901" "$old" "0"
+mkdir -p "${ORCH_DIR}/workers/CTL-617A"
+jq -n '{ticket:"CTL-617A", phase:"monitor-merge", status:"running"}' \
+  > "${ORCH_DIR}/workers/CTL-617A/phase-monitor-merge.json"
+"$AUTO_REBASE" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 1 > "${SCRATCH}/out" 2>&1
+[ ! -s "$REBASE_LOG" ] && pass "no rebase dispatch when phase-monitor-merge is running" \
+  || fail "no rebase dispatch when phase-monitor-merge is running" "log: $(cat "$REBASE_LOG")"
+scratch_teardown
+
+echo "test: dispatch skipped when phase-monitor-merge is dispatched"
+scratch_setup
+old=$(date -u -v-10M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "10 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+set_pr_view "OPEN" "DIRTY" "main"
+make_signal "CTL-617D" "running" "903" "https://github.com/coalesce-labs/catalyst/pull/903" "$old" "0"
+mkdir -p "${ORCH_DIR}/workers/CTL-617D"
+jq -n '{ticket:"CTL-617D", phase:"monitor-merge", status:"dispatched"}' \
+  > "${ORCH_DIR}/workers/CTL-617D/phase-monitor-merge.json"
+"$AUTO_REBASE" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 1 > "${SCRATCH}/out" 2>&1
+[ ! -s "$REBASE_LOG" ] && pass "no rebase dispatch when phase-monitor-merge is dispatched" \
+  || fail "no rebase dispatch when phase-monitor-merge is dispatched" "log: $(cat "$REBASE_LOG")"
+scratch_teardown
+
+echo "test: dispatch skipped when phase-monitor-merge is done"
+scratch_setup
+old=$(date -u -v-10M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "10 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+set_pr_view "OPEN" "DIRTY" "main"
+make_signal "CTL-617E" "running" "904" "https://github.com/coalesce-labs/catalyst/pull/904" "$old" "0"
+mkdir -p "${ORCH_DIR}/workers/CTL-617E"
+jq -n '{ticket:"CTL-617E", phase:"monitor-merge", status:"done"}' \
+  > "${ORCH_DIR}/workers/CTL-617E/phase-monitor-merge.json"
+"$AUTO_REBASE" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 1 > "${SCRATCH}/out" 2>&1
+[ ! -s "$REBASE_LOG" ] && pass "no rebase dispatch when phase-monitor-merge is done" \
+  || fail "no rebase dispatch when phase-monitor-merge is done" "log: $(cat "$REBASE_LOG")"
+scratch_teardown
+
+echo "test: dispatch proceeds when phase-monitor-merge signal absent (negative control)"
+scratch_setup
+old=$(date -u -v-10M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "10 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+set_pr_view "OPEN" "DIRTY" "main"
+make_signal "CTL-617B" "running" "902" "https://github.com/coalesce-labs/catalyst/pull/902" "$old" "0"
+# Deliberately do NOT create workers/CTL-617B/phase-monitor-merge.json.
+"$AUTO_REBASE" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 1 > "${SCRATCH}/out" 2>&1
+grep -q "^REBASE_CALLED " "$REBASE_LOG" \
+  && pass "dispatch proceeds without phase-monitor-merge signal" \
+  || fail "dispatch proceeds without phase-monitor-merge signal" "REBASE_LOG empty; expected REBASE_CALLED"
+scratch_teardown
+
+echo "test: dispatch proceeds when phase-monitor-merge is failed (non-live status)"
+scratch_setup
+old=$(date -u -v-10M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "10 minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+set_pr_view "OPEN" "DIRTY" "main"
+make_signal "CTL-617C" "running" "905" "https://github.com/coalesce-labs/catalyst/pull/905" "$old" "0"
+mkdir -p "${ORCH_DIR}/workers/CTL-617C"
+jq -n '{ticket:"CTL-617C", phase:"monitor-merge", status:"failed"}' \
+  > "${ORCH_DIR}/workers/CTL-617C/phase-monitor-merge.json"
+"$AUTO_REBASE" --orch-dir "$ORCH_DIR" --orch-id demo --stable-minutes 1 > "${SCRATCH}/out" 2>&1
+grep -q "^REBASE_CALLED " "$REBASE_LOG" \
+  && pass "dispatch proceeds when phase-monitor-merge is failed" \
+  || fail "dispatch proceeds when phase-monitor-merge is failed" "REBASE_LOG: $(cat "$REBASE_LOG")"
+scratch_teardown
+
 echo
 echo "orchestrate-auto-rebase: ${PASSES} passed, ${FAILURES} failed"
 exit "$FAILURES"

--- a/plugins/dev/scripts/orchestrate-auto-rebase
+++ b/plugins/dev/scripts/orchestrate-auto-rebase
@@ -149,6 +149,22 @@ for SIGNAL in "${ORCH_DIR}"/workers/*.json; do
     continue
   fi
 
+  # CTL-617: skip rebase dispatch while phase-monitor-merge owns the worktree.
+  # phase-monitor-merge handles BEHIND inline (plugins/dev/skills/phase-monitor-merge/SKILL.md);
+  # dispatching a parallel rebase worker into the same worktree is the
+  # two-merge-owners race from CTL-133. The "dispatched|running|done" set
+  # mirrors phase-agent-dispatch's idempotency guard.
+  MONITOR_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-monitor-merge.json"
+  if [ -f "$MONITOR_SIGNAL" ]; then
+    MONITOR_STATUS=$(jq -r '.status // empty' "$MONITOR_SIGNAL" 2>/dev/null || echo "")
+    case "$MONITOR_STATUS" in
+      dispatched|running|done)
+        SKIPPED=$((SKIPPED+1))
+        continue
+        ;;
+    esac
+  fi
+
   CHECKED=$((CHECKED+1))
 
   PR_VIEW="${TMP_DIR}/pr-${TICKET}.json"


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-26T18:47:27Z -->
<!-- Last updated: 2026-05-26T18:47:27Z -->
<!-- PR: #1079 -->
<!-- Previous commits: 1df3d582 -->

## Summary

Fixes [CTL-617](https://linear.app/rozich/issue/CTL-617): the orchestrator
could co-dispatch a standalone `orchestrate-auto-rebase` worker against a PR
whose `phase-monitor-merge` agent was already handling `BEHIND`/`DIRTY`
inline as part of its listen loop. With both agents acting as merge-owners
on the same worktree, the rebase worker observed its in-progress rebase
counter advance and HEAD get rewritten between its own read-only `git status`
calls (no corruption thanks to the `--force-with-lease` guard + identical
resolved content, but the same two-merge-owners pattern flagged in
[CTL-133](https://linear.app/rozich/issue/CTL-133)).

Reproduced on [ADV-1133](https://linear.app/rozich/issue/ADV-1133) /
[catalyst#860](https://github.com/coalesce-labs/catalyst/pull/860).

## Changes Made

`plugins/dev/scripts/orchestrate-auto-rebase` (+16):

- Add a 6-line ownership gate to the per-worker loop, placed between the
  REPO presence check and the `CHECKED++` counter.
- Read `${ORCH_DIR}/workers/${TICKET}/phase-monitor-merge.json`; if
  `.status` is in `{dispatched, running, done}`, bump `SKIPPED` and
  `continue`.
- The live-status set mirrors `phase-agent-dispatch`'s authoritative
  idempotency guard so the two paths stay in sync.

`plugins/dev/scripts/__tests__/orchestrate-auto-rebase.test.sh` (+71):

- 5 new cases covering each live status (`running`, `dispatched`, `done` →
  skip), the absent-signal negative control (dispatch proceeds), and the
  non-live status fall-through (`failed` → dispatch).

## How to Verify It

- [x] Targeted suite: `bash plugins/dev/scripts/__tests__/orchestrate-auto-rebase.test.sh` — 35/35 (baseline 30/30, net +5 asserts).
- [ ] Smoke: with a PR whose `phase-monitor-merge` is `running`, confirm
  `orchestrate-auto-rebase` increments `SKIPPED` rather than dispatching a
  standalone rebase worker.

## Related Issues/PRs

- Fixes [CTL-617](https://linear.app/rozich/issue/CTL-617)
- Reproduces [ADV-1133](https://linear.app/rozich/issue/ADV-1133) /
  [catalyst#860](https://github.com/coalesce-labs/catalyst/pull/860)
- Related: [CTL-232](https://linear.app/rozich/issue/CTL-232) (introduced
  the standalone rebase worker), [CTL-449](https://linear.app/rozich/issue/CTL-449)
  (introduced phase-monitor-merge's inline BEHIND handling),
  [CTL-133](https://linear.app/rozich/issue/CTL-133) (prior two-merge-owners
  race)

Refs: CTL-617
