### PR TITLE
CTL-614: decouple phase-triage from linearis discuss 429

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -319,6 +319,81 @@ FAIL_EVENT="$(jq -r '.attributes."event.name"' "$FAIL_DIR/events.jsonl" 2>/dev/n
 assert_eq "lin-fail: emits phase.triage.failed event" "phase.triage.failed.CTL-9001" "$FAIL_EVENT"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Case 4 (CTL-614): linearis issues discuss returns 429 — must NOT fail phase.
+# triage.json + phase.triage.complete event must still be produced, and the
+# 429 stderr must surface to the skill's stderr (no longer swallowed).
+
+DISCUSS_429_DIR="$TMPROOT/discuss-429"
+mkdir -p "$DISCUSS_429_DIR/bin"
+
+FIXTURE_429="$TMPROOT/fixture-429.json"
+cat >"$FIXTURE_429" <<'EOF'
+{
+  "identifier": "CTL-9002",
+  "title": "Some real ticket",
+  "description": "Fix a thing.",
+  "labels": {"nodes": []}
+}
+EOF
+
+cat >"$DISCUSS_429_DIR/bin/linearis" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+  issues)
+    case "\$2" in
+      read)
+        cat "$FIXTURE_429"
+        ;;
+      discuss)
+        echo "Error: Rate limit exceeded. Only 2500 requests are allowed per 1 hour." >&2
+        exit 1
+        ;;
+      *)
+        echo "linearis stub: unsupported issues subcommand: \$2" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    echo "linearis stub: unsupported domain: \$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$DISCUSS_429_DIR/bin/linearis"
+
+PATH="$DISCUSS_429_DIR/bin:$PATH" \
+	TICKET=CTL-9002 \
+	WORKER_DIR="$DISCUSS_429_DIR/worker" \
+	CATALYST_EVENTS_FILE="$DISCUSS_429_DIR/events.jsonl" \
+	PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
+	PHASE_EMIT_HELPER="$EMIT_HELPER" \
+	bash "$SKILL_BODY_FILE" >"$DISCUSS_429_DIR/stdout.log" 2>"$DISCUSS_429_DIR/stderr.log"
+D429_EXIT=$?
+
+assert_eq "discuss-429: exit code 0 (best-effort)" 0 "$D429_EXIT"
+assert_file_exists "discuss-429: triage.json written despite discuss failure" \
+	"$DISCUSS_429_DIR/worker/triage.json"
+
+D429_EVENT="$(jq -r '.attributes."event.name"' "$DISCUSS_429_DIR/events.jsonl" 2>/dev/null | head -1)"
+assert_eq "discuss-429: emits phase.triage.complete (not failed)" \
+	"phase.triage.complete.CTL-9002" "$D429_EVENT"
+
+if grep -q 'linearis issues discuss failed' "$DISCUSS_429_DIR/stderr.log" 2>/dev/null; then
+	ok "discuss-429: skill stderr logs the discuss failure (operator visibility)"
+else
+	fail "discuss-429: stderr surfacing" \
+		"expected 'linearis issues discuss failed' in stderr; got: $(cat "$DISCUSS_429_DIR/stderr.log" 2>/dev/null)"
+fi
+
+if grep -q 'Rate limit exceeded' "$DISCUSS_429_DIR/stderr.log" 2>/dev/null; then
+	ok "discuss-429: skill stderr includes the underlying 429 message (no longer swallowed)"
+else
+	fail "discuss-429: 429 message surfacing" \
+		"expected 'Rate limit exceeded' in stderr; got: $(cat "$DISCUSS_429_DIR/stderr.log" 2>/dev/null)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
 # CTL-602 dynamic guard: simulate Claude Code slash-command arg substitution on
 # the extracted body, then run the SUBSTITUTED body. A real dispatch is
 # `/catalyst-dev:phase-triage <TICKET> --orch-dir <PATH>`, so $0→<TICKET>,

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -199,7 +199,7 @@ jq -nc \
     generated_at: $generated_at
   }' > "$TRIAGE_FILE"
 
-# 4. Post triage comment to Linear.
+# 4. Post triage comment to Linear (best-effort: failure does not escalate the phase, CTL-614).
 # Render the dep + acronym lists with jq using single-quoted jq programs and
 # Unicode escapes for backticks (`) so the surrounding bash heredoc does
 # not need to escape them.

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -226,11 +226,14 @@ _Triaged automatically by the phase-triage agent (CTL-451)._
 EOF
 )"
 
-if ! linearis issues discuss "$TICKET" --body "$COMMENT_BODY" >/dev/null 2>&1; then
-  emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
-    --reason "linearis issues discuss failed"
-  exit 1
-fi
+# CTL-614: the Linear comment post is best-effort. triage.json is already on
+# disk; the canonical pipeline contract is `phase.triage.complete.<TICKET>`
+# (see CTL-452). A transient `linearis issues discuss` failure (notably the
+# rolling-hour HTTP 429 rate-limit from `linearis`) must NOT escalate the
+# ticket to `needs-human`. Capture stderr and surface it so operators can
+# still diagnose 429s from `daemon.log`.
+DISCUSS_STDERR="$(linearis issues discuss "$TICKET" --body "$COMMENT_BODY" 2>&1 >/dev/null)" \
+  || echo "phase-triage: linearis issues discuss failed (continuing): ${DISCUSS_STDERR}" >&2
 
 # 5. The `triaged` label is applied by the coordinator (CTL-558): the
 #    execution-core scheduler's label sweep tags `triaged` once the triage


### PR DESCRIPTION
## Summary

A transient Linear API 429 rate-limit on `linearis issues discuss` was escalating the entire triage phase to `needs-human` and emitting `phase.triage.failed`, even though `triage.json` had already been written. The comment post is metadata; the canonical pipeline contract is the `phase.triage.complete.<TICKET>` event (CTL-452). This decouples comment-post failure from phase outcome and surfaces the underlying stderr so 429s remain diagnosable.

## Problem

Observed on ADV-1126 during a 14-ticket / 3-wave orchestrator run that burned the Linear hourly budget (2500 req/hr):

1. The deterministic phase-triage body computed `triage.json` correctly (`classification=feature`, `scope=medium`).
2. It then ran `linearis issues discuss "$TICKET" --body "$COMMENT_BODY" >/dev/null 2>&1`.
3. Linearis returned HTTP 429 — a **transient** condition with a rolling-window recovery.
4. The skill treated the non-zero exit as fatal: emitted `phase.triage.failed.ADV-1126` and exited, indistinguishable from a real triage failure.
5. The `2>&1 >/dev/null` redirection swallowed the 429 message, so the failure had no diagnostic surface.

Recovered manually by re-running discuss ~2 min later and emitting a `phase.triage.complete.ADV-1126` that superseded the failed event.

## Fix (`plugins/dev/skills/phase-triage/SKILL.md`)

Replace the fatal `if ! linearis ...; then emit failed; exit 1; fi` block with a best-effort post that:

- Captures `linearis issues discuss` stderr into `$DISCUSS_STDERR` (no longer redirected to `/dev/null`).
- On non-zero exit, prints `phase-triage: linearis issues discuss failed (continuing): <stderr>` to stderr.
- Lets the skill body fall through to the normal `phase.triage.complete.<TICKET>` emit — `triage.json` is already on disk, the pipeline contract is satisfied.

The comment is metadata; the event is the contract.

## Test (`plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` — Case 4)

New end-to-end case `discuss-429`:

- Stubs `linearis` so `issues read` returns a real fixture but `issues discuss` exits 1 with the actual 429 message on stderr.
- Asserts:
  - skill exit code is `0` (best-effort)
  - `triage.json` is written despite the discuss failure
  - the emitted event is `phase.triage.complete.CTL-9002`, **not** `phase.triage.failed.CTL-9002`
  - skill stderr surfaces `linearis issues discuss failed` (operator visibility)
  - skill stderr includes the underlying `Rate limit exceeded` message (no longer swallowed)

Runs alongside the existing `lin-ok` and `lin-fail` cases — no regressions to the read-failure path (which IS still fatal: a missing ticket should escalate).

## Why this is safe

- `triage.json` is the artifact downstream phases consume; it is written before the discuss call.
- The pipeline contract per CTL-452 is the `phase.triage.complete.<TICKET>` event, not the Linear comment.
- Operators retain full diagnostic visibility: the 429 message goes to stderr → `daemon.log`, where it can be detected without affecting phase routing.
- `linearis issues read` failures (which indicate a structural problem, e.g. missing ticket) remain fatal — only the comment-post is downgraded to best-effort.

## Followups (out of scope)

The Linear ticket also notes two recovery-time gotchas that are NOT addressed here:

- Bash-only emit helper (zsh chokes on unset `BASH_SOURCE[0]` and read-only `status`) — separate concern, run helper as `bash phase-emit-complete.sh ...`.
- Slash-command arg-templating corruption when dispatched (already tracked under CTL-602 dynamic-guard E2E case).

A broader retry-with-backoff for Linear mutations on 429 across all phase agents is worth considering but is not in this change.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` — all four cases pass (lin-ok, lin-fail, discuss-429, CTL-602 dispatch-render)
- [x] Phase-triage SKILL.md note marks the discuss post as best-effort (CTL-614)
- [x] Existing `lin-fail` case (issues read failure) still emits `phase.triage.failed` — error semantics preserved for non-transient failures

Refs: CTL-614
