### PR TITLE
CTL-615: codify bg_job_id yield + worktree-path revive guard

### DIFF
--- a/plugins/dev/scripts/__tests__/create-worktree-expected-branch.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-expected-branch.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Shell tests for create-worktree.sh --expected-branch (CTL-615).
+#
+# The flag's purpose is to guard --reuse-existing against landing in a
+# worktree directory that has been re-purposed for a different branch.
+# This is the wrong-cwd ADV-1134 signature: same on-disk path, different
+# `git rev-parse --abbrev-ref HEAD`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t expected-branch-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+# Build a real git repo + a stranger worktree at the canonical reuse path.
+REPO="${SCRATCH}/source-repo"
+mkdir -p "${REPO}"
+git -C "${REPO}" init -q
+git -C "${REPO}" -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
+# Override default branch name to "main" so the repo has a canonical base.
+git -C "${REPO}" branch -m main 2>/dev/null || true
+
+# Pre-create a stranger worktree at the path create-worktree.sh will reuse,
+# checked out to a different branch (ADV-1129).
+WORKTREES_BASE="${SCRATCH}/wt"
+mkdir -p "${WORKTREES_BASE}"
+git -C "${REPO}" worktree add -q -b "ADV-1129" "${WORKTREES_BASE}/CTL-T3" main
+
+# ─── Test 1: --expected-branch mismatch under --reuse-existing → exit 64 ───
+echo ""
+echo "--- Test 1: --expected-branch mismatch exits 64 with diagnostic ---"
+out=$(
+  cd "${REPO}" && \
+  bash "${SCRIPT}" CTL-T3 main \
+    --reuse-existing \
+    --worktree-dir "${WORKTREES_BASE}" \
+    --skip-fetch \
+    --expected-branch CTL-T3 2>&1
+)
+rc=$?
+if [[ $rc -eq 64 ]]; then
+  pass "exit code is 64 (expected-branch mismatch sentinel)"
+else
+  fail "expected exit 64, got $rc — output: $out"
+fi
+if echo "$out" | grep -q "expected-branch mismatch"; then
+  pass "diagnostic mentions 'expected-branch mismatch'"
+else
+  fail "diagnostic missing 'expected-branch mismatch' — output: $out"
+fi
+if echo "$out" | grep -q "ADV-1129"; then
+  pass "diagnostic includes actual branch name"
+else
+  fail "diagnostic missing actual branch — output: $out"
+fi
+
+# ─── Test 2: --expected-branch matching reuses worktree silently (exit 0) ──
+echo ""
+echo "--- Test 2: --expected-branch match short-circuits cleanly ---"
+# Add a matching worktree at the path the script will compute for ticket CTL-T4
+git -C "${REPO}" worktree add -q -b "CTL-T4" "${WORKTREES_BASE}/CTL-T4" main
+out2=$(
+  cd "${REPO}" && \
+  bash "${SCRIPT}" CTL-T4 main \
+    --reuse-existing \
+    --worktree-dir "${WORKTREES_BASE}" \
+    --skip-fetch \
+    --expected-branch CTL-T4 2>&1
+)
+rc2=$?
+if [[ $rc2 -eq 0 ]]; then
+  pass "match → exit 0"
+else
+  fail "expected exit 0, got $rc2 — output: $out2"
+fi
+if echo "$out2" | grep -q "WORKTREE_PATH=${WORKTREES_BASE}/CTL-T4"; then
+  pass "WORKTREE_PATH= line still printed on match"
+else
+  fail "WORKTREE_PATH= line missing — output: $out2"
+fi
+
+# ─── Test 3: --expected-branch omitted → legacy behaviour (no validation) ──
+echo ""
+echo "--- Test 3: --expected-branch omitted (legacy) — no check, exit 0 ---"
+# Reuse the ADV-1129 stranger worktree from Test 1 — without the flag, the
+# script must NOT validate and must short-circuit successfully.
+out3=$(
+  cd "${REPO}" && \
+  bash "${SCRIPT}" CTL-T3 main \
+    --reuse-existing \
+    --worktree-dir "${WORKTREES_BASE}" \
+    --skip-fetch 2>&1
+)
+rc3=$?
+if [[ $rc3 -eq 0 ]]; then
+  pass "no flag → exit 0 (backwards compatible)"
+else
+  fail "expected exit 0 without flag, got $rc3 — output: $out3"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════════"
+echo " ${PASSES} passed, ${FAILURES} failed"
+echo "══════════════════════════════════════════════"
+
+if [[ "${FAILURES}" -gt 0 ]]; then
+  exit 1
+fi

--- a/plugins/dev/scripts/__tests__/phase-agent-yield.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-yield.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Shell tests for the codified bg_job_id yield helper (CTL-615).
+#
+# Asserts the four operator invariants from memories #43/#44/#49/#50:
+#   1. A duplicate worker (signal.bg_job_id != $CLAUDE_JOB_DIR's basename)
+#      whose canonical job dir is still present writes a yield sidecar and
+#      exits 0 — leaving the signal file untouched and emitting no event.
+#   2. The canonical worker (matching bg_job_id) does NOT yield — caller
+#      proceeds with normal prelude.
+#   3. A duplicate whose canonical job dir has been reaped also does NOT
+#      yield — there is nothing live to yield to. Caller proceeds.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/scripts/phase-agent-yield-check.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-agent-yield-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+# Stub bin: emit-complete invocation under any yield path is a hard test fail.
+STUB_BIN="${SCRATCH}/stubs"
+mkdir -p "${STUB_BIN}"
+cat > "${STUB_BIN}/phase-agent-emit-complete" <<'STUB'
+#!/usr/bin/env bash
+echo "FAIL: phase-agent-emit-complete invoked from yield path" >&2
+exit 99
+STUB
+chmod +x "${STUB_BIN}/phase-agent-emit-complete"
+export PATH="${STUB_BIN}:${PATH}"
+
+# Common scratch layout
+WORKER_DIR="${SCRATCH}/orch/workers/CTL-TEST"
+JOBS_ROOT="${SCRATCH}/jobs"
+OUR_JOB_DIR="${JOBS_ROOT}/our-job"
+OTHER_JOB_DIR="${JOBS_ROOT}/other-job"
+mkdir -p "${WORKER_DIR}" "${OUR_JOB_DIR}" "${OTHER_JOB_DIR}"
+export CLAUDE_JOB_DIR="${OUR_JOB_DIR}"
+
+SIGNAL="${WORKER_DIR}/phase-implement.json"
+SIDECAR="${WORKER_DIR}/.phase-implement-yield"
+
+reset_signal_other() {
+  cat > "${SIGNAL}" <<JSON
+{"ticket":"CTL-TEST","phase":"implement","status":"running","bg_job_id":"other-job"}
+JSON
+  rm -f "${SIDECAR}"
+}
+
+reset_signal_ours() {
+  cat > "${SIGNAL}" <<JSON
+{"ticket":"CTL-TEST","phase":"implement","status":"running","bg_job_id":"our-job"}
+JSON
+  rm -f "${SIDECAR}"
+}
+
+run_helper() {
+  bash "${HELPER}" \
+    --signal "${SIGNAL}" \
+    --jobs-root "${JOBS_ROOT}" \
+    --phase implement \
+    --worker-dir "${WORKER_DIR}"
+}
+
+# ─── Test 1: duplicate worker yields (canonical alive) ───────────────────────
+echo ""
+echo "--- Test 1: duplicate worker yields when canonical job is alive ---"
+reset_signal_other
+mkdir -p "${OTHER_JOB_DIR}"
+EXPECTED_PRE="$(jq -S . "${SIGNAL}")"
+
+if run_helper; then
+  pass "helper exited 0 (yield fired)"
+else
+  fail "helper must exit 0 when duplicate; got non-zero"
+fi
+if [[ -f "${SIDECAR}" ]]; then
+  pass "yield sidecar written"
+  if jq -e '.canonicalJob == "other-job" and .ourJob == "our-job"' "${SIDECAR}" >/dev/null 2>&1; then
+    pass "sidecar names canonical and our job correctly"
+  else
+    fail "sidecar payload missing/wrong ourJob/canonicalJob"
+  fi
+else
+  fail "yield sidecar not written"
+fi
+ACTUAL_POST="$(jq -S . "${SIGNAL}")"
+if [[ "${EXPECTED_PRE}" == "${ACTUAL_POST}" ]]; then
+  pass "signal file untouched by yield"
+else
+  fail "signal file mutated during yield"
+fi
+
+# ─── Test 2: canonical worker does not yield ─────────────────────────────────
+echo ""
+echo "--- Test 2: canonical worker (matching bg_job_id) does not yield ---"
+reset_signal_ours
+mkdir -p "${OTHER_JOB_DIR}"
+
+if run_helper; then
+  fail "helper must exit non-zero when canonical (no yield); got 0"
+else
+  pass "helper exited non-zero (proceed-with-prelude)"
+fi
+if [[ -f "${SIDECAR}" ]]; then
+  fail "sidecar must not be written for canonical worker"
+else
+  pass "no sidecar (canonical case)"
+fi
+
+# ─── Test 3: duplicate but canonical reaped — proceed normally ───────────────
+echo ""
+echo "--- Test 3: duplicate but canonical job reaped — no yield ---"
+reset_signal_other
+rm -rf "${OTHER_JOB_DIR}"
+
+if run_helper; then
+  fail "helper must exit non-zero when canonical is dead; got 0"
+else
+  pass "helper exited non-zero (canonical reaped)"
+fi
+if [[ -f "${SIDECAR}" ]]; then
+  fail "sidecar must not be written when canonical is reaped"
+else
+  pass "no sidecar (canonical reaped)"
+fi
+
+# ─── Test 4: missing CLAUDE_JOB_DIR — caller proceeds ────────────────────────
+echo ""
+echo "--- Test 4: missing CLAUDE_JOB_DIR — caller proceeds ---"
+mkdir -p "${OTHER_JOB_DIR}"
+reset_signal_other
+unset CLAUDE_JOB_DIR
+if run_helper; then
+  fail "helper must exit non-zero when CLAUDE_JOB_DIR unset; got 0"
+else
+  pass "helper exited non-zero (no env, proceed)"
+fi
+if [[ -f "${SIDECAR}" ]]; then
+  fail "sidecar must not be written when CLAUDE_JOB_DIR unset"
+else
+  pass "no sidecar (no env)"
+fi
+export CLAUDE_JOB_DIR="${OUR_JOB_DIR}"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════════"
+echo " ${PASSES} passed, ${FAILURES} failed"
+echo "══════════════════════════════════════════════"
+
+if [[ "${FAILURES}" -gt 0 ]]; then
+  exit 1
+fi

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -29,6 +29,7 @@ HOOKS_JSON=""
 ORCHESTRATION_NAME=""
 REUSE_EXISTING=false
 SKIP_FETCH=false
+EXPECTED_BRANCH=""
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -37,6 +38,13 @@ while [[ $# -gt 0 ]]; do
 		--orchestration) ORCHESTRATION_NAME="$2"; shift 2 ;;
 		--reuse-existing) REUSE_EXISTING=true; shift ;;
 		--skip-fetch) SKIP_FETCH=true; shift ;;
+		# CTL-615: when --reuse-existing returns an existing worktree dir,
+		# assert its HEAD is on this branch. Mismatch → exit 64 with a
+		# clear diagnostic. The daemon's revive path passes the ticket name
+		# so a project-key collision (~/catalyst/wt/CTL/CTL-T3 checked out
+		# to ADV-1129) is caught before the bg worker spawns into the wrong
+		# tree.
+		--expected-branch) EXPECTED_BRANCH="$2"; shift 2 ;;
 		*) POSITIONAL+=("$1"); shift ;;
 	esac
 done
@@ -117,6 +125,17 @@ fi
 # Check if worktree already exists
 if [ -d "$WORKTREE_PATH" ]; then
 	if [ "$REUSE_EXISTING" = true ]; then
+		# CTL-615: when the caller declared which branch this path MUST be
+		# on, verify HEAD before short-circuiting. A mismatch is the
+		# wrong-cwd ADV-1134 signature — fail loud rather than land a
+		# revive in a stranger's worktree.
+		if [ -n "$EXPECTED_BRANCH" ]; then
+			CUR_BRANCH="$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+			if [ "$CUR_BRANCH" != "$EXPECTED_BRANCH" ]; then
+				echo -e "${RED}❌ create-worktree: expected-branch mismatch — path ${WORKTREE_PATH} is on '${CUR_BRANCH}', expected '${EXPECTED_BRANCH}' (CTL-615)${NC}" >&2
+				exit 64
+			fi
+		fi
 		echo -e "${GREEN}♻️  Reusing existing worktree: $WORKTREE_PATH${NC}"
 		echo "WORKTREE_PATH=${WORKTREE_PATH}"
 		exit 0

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -70,8 +70,17 @@ function defaultRunPhaseAgent({ orchDir, ticket, phase, worktreePath }) {
 // (or reuse) the worktree, run phase-agent-dispatch in it. The three steps are
 // injectable seams so the unit test never spawns a real script. A failure at
 // any step returns a non-zero code with a descriptive stderr — never silent.
+//
+// CTL-615: now also threads `expectedBranch: ticket` into createWorktree
+// (which forwards --expected-branch to the script) and, when callers pass
+// `expectedWorktreePath`, cross-checks that against the path createWorktree
+// actually resolved. A mismatch returns `revive-aborted-wrong-cwd` without
+// launching the phase agent — so a revive can never land in a stranger's
+// worktree even if the registry resolution chain is corrupt. The dispatch
+// result always carries `worktreePath` so callers (defaultReviveDispatch)
+// can record / cross-check on later cycles.
 export function defaultDispatch(
-  { orchDir, ticket, phase },
+  { orchDir, ticket, phase, expectedWorktreePath },
   {
     resolveProject = defaultResolveProject,
     createWorktree = defaultCreateWorktree,
@@ -86,15 +95,27 @@ export function defaultDispatch(
       stderr: `dispatch: no registry entry for the team of ${ticket}`,
     };
   }
-  const wt = createWorktree({ ticket, repoRoot: project.repoRoot });
+  const wt = createWorktree({ ticket, repoRoot: project.repoRoot, expectedBranch: ticket });
   if (wt.code !== 0 || !wt.worktreePath) {
     return {
       code: wt.code || 1,
       stdout: "",
       stderr: `dispatch: worktree provisioning failed for ${ticket}: ${wt.stderr}`,
+      worktreePath: wt.worktreePath ?? null,
     };
   }
-  return runPhaseAgent({ orchDir, ticket, phase, worktreePath: wt.worktreePath });
+  if (expectedWorktreePath && expectedWorktreePath !== wt.worktreePath) {
+    return {
+      code: 1,
+      stdout: "",
+      stderr:
+        `dispatch: revive-aborted-wrong-cwd — expected ${expectedWorktreePath}, ` +
+        `got ${wt.worktreePath} for ${ticket}`,
+      worktreePath: wt.worktreePath,
+    };
+  }
+  const res = runPhaseAgent({ orchDir, ticket, phase, worktreePath: wt.worktreePath });
+  return { ...res, worktreePath: wt.worktreePath };
 }
 
 // dispatchTicket — thin seam over the injectable dispatch function.

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -47,14 +47,20 @@ describe("defaultDispatch", () => {
     const s = baseSeams();
     const r = defaultDispatch({ orchDir: "/ec", ticket: "CTL-1", phase: "research" }, s);
     expect(s.calls.map((c) => c[0])).toEqual(["resolve", "create", "run"]);
-    expect(s.calls[1][1]).toEqual({ ticket: "CTL-1", repoRoot: "/repo" });
+    // CTL-615: createWorktree now receives expectedBranch === ticket.
+    expect(s.calls[1][1]).toEqual({
+      ticket: "CTL-1",
+      repoRoot: "/repo",
+      expectedBranch: "CTL-1",
+    });
     expect(s.calls[2][1]).toEqual({
       orchDir: "/ec",
       ticket: "CTL-1",
       phase: "research",
       worktreePath: "/wt/CTL-1",
     });
-    expect(r).toEqual({ code: 0, stdout: "ok", stderr: "" });
+    // CTL-615: dispatch result now also surfaces worktreePath.
+    expect(r).toEqual({ code: 0, stdout: "ok", stderr: "", worktreePath: "/wt/CTL-1" });
   });
 
   test("no registry entry → code 1, createWorktree never called", () => {
@@ -92,11 +98,92 @@ describe("defaultDispatch", () => {
     expect(s.calls.map((c) => c[0])).toEqual(["resolve", "create"]);
   });
 
-  test("the runPhaseAgent result is returned verbatim", () => {
+  test("the runPhaseAgent result is returned verbatim (plus worktreePath — CTL-615)", () => {
     const s = baseSeams();
     s.runPhaseAgent = () => ({ code: 7, stdout: "", stderr: "phase boom" });
     const r = defaultDispatch({ orchDir: "/ec", ticket: "CTL-1", phase: "plan" }, s);
-    expect(r).toEqual({ code: 7, stdout: "", stderr: "phase boom" });
+    expect(r).toEqual({ code: 7, stdout: "", stderr: "phase boom", worktreePath: "/wt/CTL-1" });
+  });
+});
+
+describe("defaultDispatch — worktreePath / expectedBranch wiring (CTL-615)", () => {
+  const baseSeams = () => {
+    const calls = [];
+    return {
+      calls,
+      resolveProject: (ticket) => {
+        calls.push(["resolve", ticket]);
+        return { team: "CTL", repoRoot: "/repo" };
+      },
+      createWorktree: (args) => {
+        calls.push(["create", args]);
+        return { code: 0, worktreePath: `/wt/${args.ticket}`, stderr: "" };
+      },
+      runPhaseAgent: (args) => {
+        calls.push(["run", args]);
+        return { code: 0, stdout: "ok", stderr: "" };
+      },
+    };
+  };
+
+  test("passes expectedBranch: ticket through to createWorktree", () => {
+    const s = baseSeams();
+    defaultDispatch({ orchDir: "/ec", ticket: "CTL-7", phase: "implement" }, s);
+    const createCall = s.calls.find((c) => c[0] === "create");
+    expect(createCall[1].expectedBranch).toBe("CTL-7");
+  });
+
+  test("the dispatch result carries the resolved worktreePath", () => {
+    const s = baseSeams();
+    const r = defaultDispatch({ orchDir: "/ec", ticket: "CTL-8", phase: "implement" }, s);
+    expect(r.worktreePath).toBe("/wt/CTL-8");
+  });
+
+  test("expectedWorktreePath match → dispatch proceeds, runs phase agent", () => {
+    const s = baseSeams();
+    const r = defaultDispatch(
+      {
+        orchDir: "/ec",
+        ticket: "CTL-9",
+        phase: "implement",
+        expectedWorktreePath: "/wt/CTL-9",
+      },
+      s,
+    );
+    expect(r.code).toBe(0);
+    expect(s.calls.some((c) => c[0] === "run")).toBe(true);
+  });
+
+  test("expectedWorktreePath mismatch → code:1, runPhaseAgent never called, reason='revive-aborted-wrong-cwd'", () => {
+    const s = baseSeams();
+    s.createWorktree = (args) => {
+      s.calls.push(["create", args]);
+      return { code: 0, worktreePath: "/wt/ADV-1129", stderr: "" };
+    };
+    const r = defaultDispatch(
+      {
+        orchDir: "/ec",
+        ticket: "CTL-9",
+        phase: "implement",
+        expectedWorktreePath: "/wt/CTL-9",
+      },
+      s,
+    );
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/revive-aborted-wrong-cwd/);
+    expect(r.worktreePath).toBe("/wt/ADV-1129");
+    expect(s.calls.map((c) => c[0])).toEqual(["resolve", "create"]);
+  });
+
+  test("expectedWorktreePath unset (initial dispatch) → no comparison, proceeds normally", () => {
+    const s = baseSeams();
+    s.createWorktree = (args) => {
+      s.calls.push(["create", args]);
+      return { code: 0, worktreePath: "/wt/whatever", stderr: "" };
+    };
+    const r = defaultDispatch({ orchDir: "/ec", ticket: "CTL-9", phase: "research" }, s);
+    expect(r.code).toBe(0);
+    expect(s.calls.some((c) => c[0] === "run")).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -309,8 +309,16 @@ export function defaultReviveDispatch({ orchDir, ticket, phase }, { dispatch = d
     );
     return { code: 1, stdout: "", stderr: "signal-missing" };
   }
+  // CTL-615: capture the previously-dispatched worktreePath so dispatch can
+  // cross-check the registry-resolved path against the canonical cwd before
+  // launching the bg worker. Pre-CTL-615 signals lack the field; in that case
+  // we omit expectedWorktreePath and fall through to legacy behaviour.
+  let expectedWorktreePath;
   try {
     const sig = JSON.parse(readFileSync(signalPath, "utf8"));
+    if (typeof sig.worktreePath === "string" && sig.worktreePath.length > 0) {
+      expectedWorktreePath = sig.worktreePath;
+    }
     sig.status = "stalled";
     sig.attentionReason = "ctl-587-revive-reset";
     sig.updatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
@@ -324,7 +332,9 @@ export function defaultReviveDispatch({ orchDir, ticket, phase }, { dispatch = d
     log.warn({ ticket, phase, err: err.message }, "revive: signal reset failed");
     return { code: 1, stdout: "", stderr: err.message };
   }
-  return dispatch({ orchDir, ticket, phase });
+  const dispatchArgs = { orchDir, ticket, phase };
+  if (expectedWorktreePath) dispatchArgs.expectedWorktreePath = expectedWorktreePath;
+  return dispatch(dispatchArgs);
 }
 
 // defaultApplyStalledLabel — apply the flat `needs-human` label through the

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1354,6 +1354,42 @@ describe("defaultReviveDispatch — signal-reset behaviour", () => {
     });
   });
 
+  test("signal.worktreePath is forwarded to dispatch as expectedWorktreePath (CTL-615)", () => {
+    seed("CTL-15", "implement", {
+      status: "running",
+      bg_job_id: "bg-15",
+      worktreePath: "/wt/CTL/CTL-15",
+    });
+    const dispatch = recorder({ code: 0 });
+    defaultReviveDispatch(
+      { orchDir, ticket: "CTL-15", phase: "implement" },
+      { dispatch },
+    );
+    expect(dispatch.calls.length).toBe(1);
+    expect(dispatch.calls[0][0]).toEqual({
+      orchDir,
+      ticket: "CTL-15",
+      phase: "implement",
+      expectedWorktreePath: "/wt/CTL/CTL-15",
+    });
+  });
+
+  test("signal without worktreePath → dispatch called without expectedWorktreePath (CTL-615 migration)", () => {
+    seed("CTL-16", "implement", { status: "running", bg_job_id: "bg-16" });
+    const dispatch = recorder({ code: 0 });
+    defaultReviveDispatch(
+      { orchDir, ticket: "CTL-16", phase: "implement" },
+      { dispatch },
+    );
+    expect(dispatch.calls[0][0]).toEqual({
+      orchDir,
+      ticket: "CTL-16",
+      phase: "implement",
+    });
+    // No expectedWorktreePath key at all — undefined means "no check".
+    expect("expectedWorktreePath" in dispatch.calls[0][0]).toBe(false);
+  });
+
   test("signal flip happens BEFORE dispatch (so dispatcher sees 'stalled')", () => {
     const signalPath = seed("CTL-9", "implement", { status: "running" });
     let seenStatus = null;

--- a/plugins/dev/scripts/execution-core/signal-reader.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.mjs
@@ -141,6 +141,11 @@ function parseSignal(path, layout) {
         : { kind: "bg", value: raw.bg_job_id ?? null },
     updatedAt: raw.updatedAt ?? null,
     pr: raw.pr ?? null,
+    // CTL-615: the absolute worktree path the dispatch landed in. The
+    // canonical cwd of record; revive cross-checks against the registry-
+    // derived path to catch wrong-cwd redispatch (memory: ADV-1134). Null
+    // for pre-CTL-615 signals — revive treats null as "skip check".
+    worktreePath: raw.worktreePath ?? null,
     raw,
   };
 }

--- a/plugins/dev/scripts/execution-core/worktree.mjs
+++ b/plugins/dev/scripts/execution-core/worktree.mjs
@@ -18,8 +18,17 @@ const CREATE_WORKTREE_BIN = fileURLToPath(new URL("../create-worktree.sh", impor
 // — never throws. `worktreePath` is parsed from the trailing WORKTREE_PATH=
 // line create-worktree.sh prints on a successful create and on the
 // --reuse-existing short-circuit.
-export function createWorktree({ ticket, repoRoot }, { spawn = spawnSync } = {}) {
-  const res = spawn(CREATE_WORKTREE_BIN, [ticket, "main", "--reuse-existing"], {
+//
+// CTL-615: when `expectedBranch` is supplied, the script's --reuse-existing
+// short-circuit validates the existing worktree is on that branch and exits
+// non-zero on mismatch. The daemon's revive path passes ticket as the
+// expectedBranch so a project-key collision (~/catalyst/wt/CTL/CTL-T3
+// pointing at a worktree checked out to ADV-1129) surfaces immediately
+// instead of silently landing the redispatch in the wrong tree.
+export function createWorktree({ ticket, repoRoot, expectedBranch }, { spawn = spawnSync } = {}) {
+  const argv = [ticket, "main", "--reuse-existing"];
+  if (expectedBranch) argv.push("--expected-branch", expectedBranch);
+  const res = spawn(CREATE_WORKTREE_BIN, argv, {
     cwd: repoRoot,
     encoding: "utf8",
   });

--- a/plugins/dev/scripts/execution-core/worktree.test.mjs
+++ b/plugins/dev/scripts/execution-core/worktree.test.mjs
@@ -53,6 +53,27 @@ describe("createWorktree", () => {
     expect(r.worktreePath).toBeNull();
     expect(r.stderr).toMatch(/ENOENT/);
   });
+
+  // CTL-615 — expectedBranch plumbing
+  test("expectedBranch is appended as --expected-branch <name> to argv", () => {
+    const calls = [];
+    const spawn = (cmd, args, opts) => {
+      calls.push({ cmd, args, opts });
+      return { status: 0, stdout: "WORKTREE_PATH=/wt/CTL-6\n", stderr: "" };
+    };
+    createWorktree({ ticket: "CTL-6", repoRoot: "/repo", expectedBranch: "CTL-6" }, { spawn });
+    expect(calls[0].args).toEqual(["CTL-6", "main", "--reuse-existing", "--expected-branch", "CTL-6"]);
+  });
+
+  test("expectedBranch omitted → argv unchanged (backwards compatible)", () => {
+    const calls = [];
+    const spawn = (_cmd, args) => {
+      calls.push(args);
+      return { status: 0, stdout: "WORKTREE_PATH=/wt/CTL-6\n", stderr: "" };
+    };
+    createWorktree({ ticket: "CTL-6", repoRoot: "/repo" }, { spawn });
+    expect(calls[0]).toEqual(["CTL-6", "main", "--reuse-existing"]);
+  });
 });
 
 describe("parseWorktreeForBranch", () => {

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -395,6 +395,12 @@ if [[ $EXISTING_STATUS == "dispatched" || $EXISTING_STATUS == "running" || $EXIS
 fi
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+# CTL-615: persist the dispatcher's cwd as the canonical worktreePath. The
+# caller (execution-core defaultRunPhaseAgent) sets cwd === the freshly-
+# resolved worktree, so `pwd` is the ground-truth land site for this
+# dispatch. A later revive reads this field back and asserts the registry-
+# derived path matches it before launching the bg worker.
+WORKTREE_PATH_RESOLVED="$(pwd)"
 jq -nc \
 	--arg ticket "$TICKET" \
 	--arg phase "$PHASE" \
@@ -402,8 +408,10 @@ jq -nc \
 	--argjson turnCap "$TURN_CAP" \
 	--arg orch "$ORCH_ID" \
 	--arg ts "$TS" \
+	--arg wt "$WORKTREE_PATH_RESOLVED" \
 	'{ticket: $ticket, phase: $phase, orchestrator: $orch, model: $model,
     turnCap: $turnCap, status: "dispatched", bg_job_id: null,
+    worktreePath: $wt,
     startedAt: $ts, updatedAt: $ts}' >"$SIGNAL_FILE" ||
 	die "failed to write signal file $SIGNAL_FILE"
 

--- a/plugins/dev/scripts/phase-agent-yield-check.sh
+++ b/plugins/dev/scripts/phase-agent-yield-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Codified bg_job_id yield helper (CTL-615).
+#
+# Returns 0 (yield fired) when the running process is a redispatch duplicate
+# of another live phase-agent worker — caller MUST exit 0 without touching
+# the signal file and without emitting any phase event. Returns 1 (proceed)
+# otherwise: canonical worker, missing env, or canonical job dir reaped.
+#
+# Encodes operator memories #43/#44/#49/#50 into code:
+# - Read signal.bg_job_id.
+# - If it matches $(basename $CLAUDE_JOB_DIR) → we are canonical, proceed.
+# - If it names a DIFFERENT job AND that job's $JOBS_ROOT dir still exists →
+#   we are a duplicate of a live worker, yield (write sidecar, exit 0).
+# - Otherwise (canonical reaped, missing env, malformed signal) → proceed;
+#   the caller's normal prelude handles the edge case.
+#
+# Failure mode is fail-open: any internal error (missing jq, unreadable
+# signal, etc.) returns 1 so the caller falls through to normal prelude
+# rather than hanging silently. This is deliberate — a false-positive
+# yield is far worse than a missed yield, because it would silently drop
+# work on the floor.
+
+set -uo pipefail
+
+SIGNAL=""
+JOBS_ROOT="${HOME}/.claude/jobs"
+PHASE=""
+WORKER_DIR=""
+
+usage() {
+  cat >&2 <<EOF
+usage: phase-agent-yield-check.sh \\
+  --signal <signal.json> \\
+  --phase <phase-name> \\
+  --worker-dir <orch/workers/TICKET> \\
+  [--jobs-root <dir>]
+
+Exit codes:
+  0   yield fired (sidecar written; caller MUST exit 0)
+  1   proceed with normal prelude
+  2   bad invocation (missing required args)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --signal)     SIGNAL="$2"; shift 2 ;;
+    --jobs-root)  JOBS_ROOT="$2"; shift 2 ;;
+    --phase)      PHASE="$2"; shift 2 ;;
+    --worker-dir) WORKER_DIR="$2"; shift 2 ;;
+    -h|--help)    usage; exit 2 ;;
+    *)            echo "phase-agent-yield-check: unknown arg $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$SIGNAL" || -z "$PHASE" || -z "$WORKER_DIR" ]]; then
+  echo "phase-agent-yield-check: --signal, --phase, --worker-dir are required" >&2
+  exit 2
+fi
+
+# Fail-open paths: any of these → proceed (exit 1), do nothing destructive.
+[[ -f "$SIGNAL" ]] || exit 1
+[[ -n "${CLAUDE_JOB_DIR:-}" ]] || exit 1
+command -v jq >/dev/null 2>&1 || exit 1
+
+OUR_JOB="$(basename "${CLAUDE_JOB_DIR}")"
+OTHER_JOB="$(jq -r '.bg_job_id // empty' "$SIGNAL" 2>/dev/null || true)"
+
+# Canonical worker — no yield.
+if [[ -z "$OTHER_JOB" || "$OTHER_JOB" == "$OUR_JOB" ]]; then
+  exit 1
+fi
+
+# Duplicate-but-canonical-reaped — no yield.
+if [[ ! -d "${JOBS_ROOT}/${OTHER_JOB}" ]]; then
+  exit 1
+fi
+
+# Real yield case — write sidecar, exit 0.
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+mkdir -p "$WORKER_DIR"
+cat > "${WORKER_DIR}/.phase-${PHASE}-yield" <<EOF
+{"yieldedAt":"${TS}","ourJob":"${OUR_JOB}","canonicalJob":"${OTHER_JOB}","reason":"bg_job_id_mismatch_other_alive","phase":"${PHASE}"}
+EOF
+exit 0

--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -80,6 +80,22 @@ SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-/Users/ryan/.claude/plugins/cache/catalyst/catalyst-dev/$(jq -r .version "${CLAUDE_PLUGIN_ROOT:-.}/.claude-plugin/plugin.json" 2>/dev/null || echo 0.0.0)}"
 
+# 0. Codified bg_job_id yield (CTL-615). If the signal file's bg_job_id
+#    names a DIFFERENT live bg job, we are a redispatch duplicate of a
+#    still-running canonical worker. Bow out without touching the signal,
+#    without emitting any phase event. The helper writes a yield sidecar
+#    `${ORCH_DIR}/workers/${TICKET}/.phase-${PHASE}-yield` so the
+#    operator/daemon can attribute the no-op. Exit 0 by design — this is
+#    NOT a failure; the canonical worker keeps running.
+YIELD_CHECK="${PLUGIN_ROOT}/scripts/phase-agent-yield-check.sh"
+if [[ -x "$YIELD_CHECK" ]] && bash "$YIELD_CHECK" \
+     --signal "$SIGNAL_FILE" \
+     --phase "$PHASE" \
+     --worker-dir "$(dirname "$SIGNAL_FILE")"; then
+  echo "phase-${PHASE}: yielding to canonical worker (CTL-615)" >&2
+  exit 0
+fi
+
 # 1. Join the shared comms channel (best-effort — phase agents must not crash
 #    if catalyst-comms is unavailable).
 COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -73,6 +73,22 @@ SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
 [[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
 
+# 0. Codified bg_job_id yield (CTL-615). If the signal file's bg_job_id
+#    names a DIFFERENT live bg job, we are a redispatch duplicate of a
+#    still-running canonical worker. Bow out without touching the signal,
+#    without emitting any phase event. Encodes operator memories
+#    #43/#44/#49/#50 — the playbook is now code. phase-implement carries
+#    the highest blast radius (commits land here), so it gets the gate
+#    even though the template inheritance also provides it.
+YIELD_CHECK="${PLUGIN_ROOT}/scripts/phase-agent-yield-check.sh"
+if [[ -x "$YIELD_CHECK" ]] && bash "$YIELD_CHECK" \
+     --signal "$SIGNAL_FILE" \
+     --phase "$PHASE" \
+     --worker-dir "$(dirname "$SIGNAL_FILE")"; then
+  echo "phase-${PHASE}: yielding to canonical worker (CTL-615)" >&2
+  exit 0
+fi
+
 # 1. Join the shared comms channel (best-effort).
 COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
 [[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-26T18:59:00Z -->
<!-- Last updated: 2026-05-26T18:59:00Z -->
<!-- PR: #1081 -->
<!-- Previous commits: 0e256e4dc90203728f374baaa1b3fd8a65cbc816,a780735baade015715809fb4c7181ccbcf122880 -->

## Summary

ADV-1134 recurred for the fourth time (after ADV-1135 / ADV-1126 / ADV-1128): the execution-core daemon
declared a still-live phase-implement worker stale, redispatched a fresh worker, and both ended up
running concurrently — the fresh one in the WRONG worktree (an ADV-1129 worktree, not ADV-1134's).
Recovery only worked by accident because the fresh worker happened to notice the bg_job_id mismatch
and wrote a yield sidecar.

This PR codifies the operator-discovered "yield to the canonical worker" pattern (project memories
#43/#44/#49/#50) into shared code, and closes the wrong-cwd half of the same incident by making
every dispatch persist the absolute worktree path it landed in and every revive cross-check the
registry-resolved path against that ground truth before launching the bg worker. A second guard
inside `create-worktree.sh` catches the project-key-collision symptom even when the registry chain
agrees.

Net effect: the next false-stall redispatch terminates cleanly without operator intervention and
without the possibility of dual-writer corruption on the worktree.

## Changes Made

### Phase 1 — codified bg_job_id yield for phase agents (`0e256e4d`)

#### `plugins/dev/scripts/phase-agent-yield-check.sh` (+85, new)

New helper invoked from every phase-agent prelude. Returns exit 0 (yield) ONLY on the strict
triplet: signal `bg_job_id` mismatches `$CLAUDE_JOB_DIR` basename **AND** the canonical
`$JOBS_ROOT/<id>` directory still exists **AND** `jq` + `CLAUDE_JOB_DIR` are both set. Otherwise
exits 1 so the caller falls through to its normal prelude. Fail-open by design — a false-positive
yield silently drops work; a missed yield is recoverable on the next sweep.

On yield, the helper writes `.phase-<phase>-yield` in the worker dir as a forensic marker and exits
0 without touching the signal file or emitting any phase event. The canonical worker keeps running
unmolested.

#### `plugins/dev/skills/_phase-agent-template/SKILL.md` (+16)

Template prelude gets the check immediately after `PLUGIN_ROOT` resolution, before the
`status=running` flip. Every concrete phase agent inherits it on its next regeneration.

#### `plugins/dev/skills/phase-implement/SKILL.md` (+16)

Same yield block inlined into phase-implement directly. It has the highest blast radius (commits
land here) and the template-copy is the belt-and-suspenders defense for cases where the
regeneration pass hasn't run.

#### `plugins/dev/scripts/__tests__/phase-agent-yield.test.sh` (+160, new)

Covers the four critical cases:

- duplicate worker with canonical alive → yield (exit 0, sidecar written, no signal mutation)
- canonical worker (bg_job_id matches) → proceed (exit 1)
- duplicate worker with canonical reaped → proceed (exit 1)
- missing `$CLAUDE_JOB_DIR` → proceed (exit 1, fail-open)

### Phase 2 — persist worktreePath + revive-cwd guard (`a780735b`)

#### `plugins/dev/scripts/execution-core/signal-reader.mjs` (+5)

Parsed signal shape gains a new `worktreePath` field. Pre-CTL-615 signals lack it; `null` means "no
check", which preserves backward-compatibility for in-flight workers.

#### `plugins/dev/scripts/execution-core/worktree.mjs` (+11/-2)

`createWorktree` accepts a new `expectedBranch` parameter and forwards it to `create-worktree.sh`
as `--expected-branch`. Existing callers that omit the field keep the legacy argv unchanged.

#### `plugins/dev/scripts/execution-core/dispatch.mjs` (+24/-3)

`defaultDispatch` now: (a) passes `expectedBranch: ticket` to `createWorktree`, (b) accepts a new
`expectedWorktreePath` argument and aborts with status `revive-aborted-wrong-cwd` BEFORE
`runPhaseAgent` when the resolved worktree disagrees, (c) always surfaces `worktreePath` in its
result so the recovery layer can record / compare it.

#### `plugins/dev/scripts/execution-core/recovery.mjs` (+11/-1)

`defaultReviveDispatch` reads the persisted `worktreePath` from the prior signal and passes it as
`expectedWorktreePath`. A pre-CTL-615 signal (no field) falls through to legacy behaviour — no
migration sweep needed; old workers age out naturally.

#### `plugins/dev/scripts/create-worktree.sh` (+19)

New `--expected-branch <name>` flag validates the `--reuse-existing` short-circuit's HEAD is on
the expected branch. Exits 64 with a clear diagnostic on mismatch. Reuses the same path but a
different branch (the project-key-collision scenario) is now a loud failure, not a silent
wrong-cwd land.

#### `plugins/dev/scripts/phase-agent-dispatch` (+8)

Persists the dispatcher's `cwd` (the canonical land site, set by `defaultRunPhaseAgent` via
`spawnSync` cwd) into the fresh signal at write time. This is the ground truth every subsequent
revive will check against.

#### Test coverage (+265 / -4 across 5 test files)

- `worktree.test.mjs` — `expectedBranch` plumbing through `createWorktree`
- `dispatch.test.mjs` — `expectedWorktreePath` match/mismatch paths
- `recovery.test.mjs` — revive reads persisted `worktreePath` and forwards it
- `__tests__/create-worktree-expected-branch.test.sh` — script-level guard, exit 64 on mismatch

## How to Verify It

- [x] `bun test` in `plugins/dev/scripts/execution-core/` — unit tests for dispatch / recovery / worktree / signal-reader
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-yield.test.sh` — yield helper unit tests
- [x] `bash plugins/dev/scripts/__tests__/create-worktree-expected-branch.test.sh` — script-level expected-branch guard
- [ ] Smoke test: re-run an orchestrator with `CATALYST_TEST_FORCE_STALE=1` in the implement phase and confirm the duplicate worker writes a `.phase-implement-yield` sidecar and exits 0 without mutating the signal
- [ ] Smoke test: corrupt the worktree registry so a revive resolves to a different path than the persisted `worktreePath`, confirm `defaultDispatch` aborts with `revive-aborted-wrong-cwd` before `runPhaseAgent`

## Related Issues

- Fixes https://linear.app/rozich/issue/CTL-615
- Recurrence of: ADV-1134, ADV-1135, ADV-1126, ADV-1128

## Reviewer Notes

- The yield helper is **fail-open by design** (`set +e` semantics in the strict triplet). The
  trade-off is documented in the helper header — a false-positive yield drops work that the next
  revive will pick up; a missed yield can corrupt the signal. The strictness of the triplet
  (mismatch + canonical-dir-present + jq + CLAUDE_JOB_DIR) keeps false positives rare in practice.
- The `worktreePath` field on the signal is optional. Pre-CTL-615 signals lack it, and the revive
  path treats `null` as "no check" rather than as a guard violation. No migration is required —
  old workers age out naturally as the orchestrator drains.
- The `--expected-branch` guard on `create-worktree.sh` only fires on the `--reuse-existing`
  short-circuit path (the project-key-collision symptom). Fresh worktree creation is unaffected.

## Changelog Entry

`feat(dev)`: codify the bg_job_id yield pattern for phase agents and add a wrong-cwd guard on
phase-agent revive. Closes the ADV-1134 recurrence class.
