### PR TITLE
CTL-654: daemon boot-resume — reconcile in-flight work on cold start

### DIFF
--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -1,0 +1,107 @@
+// boot-resume.mjs — execution-core daemon boot-resume (CTL-654).
+//
+// On a real reboot every prior `claude --bg` phase worker is provably dead at
+// once. The per-tick reclaim sweep (recovery.mjs::reclaimDeadWorkIfPossible) is
+// revive-budget-gated (MAX_REVIVES) and escalates to `needs-human` on
+// exhaustion — so it treats a clean restart like a chronic-failure storm and
+// the in-flight tickets do NOT reliably auto-resume.
+//
+// This module is a dedicated, synchronous boot-reconciliation pass that runs
+// once at daemon boot (between recover() and the monitor). For each in-flight
+// ticket whose persisted worktreePath has no live background session it
+// re-dispatches a fresh worker at the ticket's current phase via
+// defaultReviveDispatch — which bypasses the revive budget by construction (the
+// budget lives in reclaimDeadWorkIfPossible, not in the dispatch primitive) and
+// keeps the CTL-615 worktree-path cross-check. The fan-out is bounded by
+// maxParallel so a reboot never spawns a worker storm.
+//
+// Phase 1 (this section) is pure selection logic, dependency-free beyond the
+// scheduler/signal-reader read helpers, and exhaustively unit-tested. The
+// reconcileBootResume orchestrator (Phase 2) wires in the side effects.
+
+import { readWorkerSignals, TERMINAL, byActivePhase } from "./signal-reader.mjs";
+import { listInFlightTickets, readMaxParallel, computeFreeSlots } from "./scheduler.mjs";
+import { log } from "./config.mjs";
+
+// hasLiveBgWorker — does `agents` contain a live BACKGROUND session whose cwd is
+// exactly `worktreePath`? This is the synchronous reduction of research §6's
+// buildLiveSessionsByWorktree predicate, sharing CTL-649's kind+cwd semantics:
+//   - kind === "background" (an interactive human session never counts as the
+//     ticket's worker), and
+//   - cwd === worktreePath by exact string equality (worktreePath is the
+//     canonical persisted value; no trailing-slash normalization).
+// The deliberate synchronous shape (vs. the async buildRows join) keeps the boot
+// pass inside startDaemon's synchronous boot ordering.
+export function hasLiveBgWorker(agents, worktreePath) {
+  return (
+    Array.isArray(agents) &&
+    agents.some((s) => s?.kind === "background" && s?.cwd === worktreePath)
+  );
+}
+
+// activePhaseForTicket — given a ticket's phase-signal list, return the single
+// non-terminal signal to resume (or null when every phase is terminal). When
+// more than one is non-terminal the most-recently-updated wins, reusing the
+// shared byActivePhase comparator (after the non-terminal filter that comparator
+// reduces to updatedAt-desc, so the result is the freshest in-flight phase).
+export function activePhaseForTicket(signals) {
+  const nonTerminal = (signals ?? []).filter((s) => s && !TERMINAL.has(s.status));
+  if (nonTerminal.length === 0) return null;
+  return nonTerminal.sort(byActivePhase)[0];
+}
+
+// selectBootResumeCandidates — the set of in-flight tickets that need a fresh
+// worker, bounded by free slots. Pure over the filesystem + the supplied agents
+// list. Returns `{ ticket, phase, worktreePath }[]`, deterministically sorted by
+// ticket id and sliced to the free-slot cap so a reboot never over-dispatches.
+//
+//   1. inFlight  = the tickets currently occupying a worker slot.
+//   2. signals   = one active signal per ticket (readWorkerSignals already
+//                  collapses each worker dir to its active phase).
+//   3. per ticket: resolve the active phase; skip (with a warn) when it is null
+//      or carries no worktreePath (cannot revive safely). Partition by whether a
+//      live bg worker already owns the worktree.
+//   4. free      = maxParallel − (# in-flight tickets that DO have a live worker)
+//                  so the boot pass and the surviving workers together stay under
+//                  the cap.
+//   5. return the no-live-worker candidates sorted by ticket id, sliced to free.
+export function selectBootResumeCandidates({
+  orchDir,
+  agents,
+  maxParallel = readMaxParallel(orchDir),
+  logger = log,
+} = {}) {
+  const inFlight = listInFlightTickets(orchDir);
+  if (inFlight.size === 0) return [];
+
+  const byTicket = new Map();
+  for (const sig of readWorkerSignals(orchDir)) {
+    if (!sig?.ticket) continue;
+    const list = byTicket.get(sig.ticket) ?? [];
+    list.push(sig);
+    byTicket.set(sig.ticket, list);
+  }
+
+  let liveCount = 0;
+  const needResume = [];
+  for (const ticket of inFlight) {
+    const active = activePhaseForTicket(byTicket.get(ticket) ?? []);
+    if (!active) continue; // mid-advance: terminal active signal, nothing to resume
+    if (!active.worktreePath) {
+      logger.warn(
+        { ticket, phase: active.phase },
+        "boot-resume: in-flight ticket has no worktreePath — cannot revive safely, skipping",
+      );
+      continue;
+    }
+    if (hasLiveBgWorker(agents, active.worktreePath)) {
+      liveCount++;
+    } else {
+      needResume.push({ ticket, phase: active.phase, worktreePath: active.worktreePath });
+    }
+  }
+
+  const free = computeFreeSlots(maxParallel, liveCount);
+  needResume.sort((a, b) => a.ticket.localeCompare(b.ticket));
+  return needResume.slice(0, free);
+}

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -43,8 +43,7 @@ import { liveAgents } from "./cli/sessions.mjs";
 // pass inside startDaemon's synchronous boot ordering.
 export function hasLiveBgWorker(agents, worktreePath) {
   return (
-    Array.isArray(agents) &&
-    agents.some((s) => s?.kind === "background" && s?.cwd === worktreePath)
+    Array.isArray(agents) && agents.some((s) => s?.kind === "background" && s?.cwd === worktreePath)
   );
 }
 
@@ -99,7 +98,7 @@ export function selectBootResumeCandidates({
     if (!active.worktreePath) {
       logger.warn(
         { ticket, phase: active.phase },
-        "boot-resume: in-flight ticket has no worktreePath — cannot revive safely, skipping",
+        "boot-resume: in-flight ticket has no worktreePath — cannot revive safely, skipping"
       );
       continue;
     }
@@ -166,14 +165,14 @@ export function reconcileBootResume({
       failed++;
       log.warn(
         { ticket, phase, code: res?.code, stderr: res?.stderr },
-        "boot-resume: dispatch failed (continuing)",
+        "boot-resume: dispatch failed (continuing)"
       );
     }
   }
 
   log.info(
     { dispatched, failed, candidates: candidates.length },
-    "boot-resume: cold-start reconciliation complete",
+    "boot-resume: cold-start reconciliation complete"
   );
   return { dispatched, failed, candidates: candidates.length };
 }

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -22,6 +22,15 @@
 import { readWorkerSignals, TERMINAL, byActivePhase } from "./signal-reader.mjs";
 import { listInFlightTickets, readMaxParallel, computeFreeSlots } from "./scheduler.mjs";
 import { log } from "./config.mjs";
+import { defaultReviveDispatch, defaultAppendBootResumeEvent } from "./recovery.mjs";
+import { defaultDispatch } from "./dispatch.mjs";
+// liveAgents() is synchronous (execFileSync `claude agents --json`). A static
+// import is safe here: cli/sessions.mjs imports only signal-reader/reap-intent/
+// config/claude-ids/session-recency/cli-args — none of which import this module,
+// so there is no import cycle. (The plan floated a lazy import to keep the pure
+// Phase-1 exports import-light, but a lazy `import()` is async and the boot pass
+// must stay synchronous to complete before the monitor/scheduler start.)
+import { liveAgents } from "./cli/sessions.mjs";
 
 // hasLiveBgWorker — does `agents` contain a live BACKGROUND session whose cwd is
 // exactly `worktreePath`? This is the synchronous reduction of research §6's
@@ -104,4 +113,67 @@ export function selectBootResumeCandidates({
   const free = computeFreeSlots(maxParallel, liveCount);
   needResume.sort((a, b) => a.ticket.localeCompare(b.ticket));
   return needResume.slice(0, free);
+}
+
+// resolveAgents — normalize the injectable `agents` seam to a concrete array.
+// An array is used as-is; a function is invoked; undefined falls back to the
+// synchronous production liveAgents() shell-out. Keeps reconcileBootResume's
+// agent resolution test-injectable while the production default needs no wiring.
+function resolveAgents(agents) {
+  if (Array.isArray(agents)) return agents;
+  if (typeof agents === "function") return agents();
+  return liveAgents();
+}
+
+// reconcileBootResume — the side-effecting boot driver (Phase 2). Gated on a
+// cold start, it dispatches each selected candidate via defaultReviveDispatch
+// (which resets the signal to `stalled` and applies the CTL-615 worktree-path
+// cross-check, and bypasses the revive budget because the budget lives in
+// reclaimDeadWorkIfPossible, not in the dispatch primitive), and emits one
+// audit event per successful dispatch. A non-cold-start restart is a no-op so
+// the existing budget-gated per-tick reclaim sweep keeps chronic-failure
+// protection. No single failure throws out of the loop — a boot pass must never
+// crash daemon boot.
+export function reconcileBootResume({
+  orchDir,
+  report,
+  agents = undefined, // array | fn | undefined→liveAgents()
+  dispatch = defaultDispatch, // inner seam handed to reviveDispatch
+  reviveDispatch = defaultReviveDispatch,
+  appendEvent = defaultAppendBootResumeEvent,
+  orchId = undefined, // threaded into the audit envelope
+} = {}) {
+  if (!report || report.coldStart !== true) {
+    return { dispatched: 0, failed: 0, skipped: "not-cold-start" };
+  }
+
+  const liveAgentList = resolveAgents(agents);
+  const candidates = selectBootResumeCandidates({ orchDir, agents: liveAgentList });
+
+  let dispatched = 0;
+  let failed = 0;
+  for (const { ticket, phase } of candidates) {
+    let res;
+    try {
+      res = reviveDispatch({ orchDir, ticket, phase }, { dispatch });
+    } catch (err) {
+      res = { code: 1, stderr: err?.message ?? String(err) };
+    }
+    if (res?.code === 0) {
+      dispatched++;
+      appendEvent({ phase, ticket, orchId });
+    } else {
+      failed++;
+      log.warn(
+        { ticket, phase, code: res?.code, stderr: res?.stderr },
+        "boot-resume: dispatch failed (continuing)",
+      );
+    }
+  }
+
+  log.info(
+    { dispatched, failed, candidates: candidates.length },
+    "boot-resume: cold-start reconciliation complete",
+  );
+  return { dispatched, failed, candidates: candidates.length };
 }

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -228,7 +228,7 @@ describe("reconcileBootResume", () => {
     });
     // Went through defaultReviveDispatch: the signal on disk is reset to stalled.
     const sig = JSON.parse(
-      readFileSync(join(orchDir, "workers", "CTL-1", "phase-implement.json"), "utf8"),
+      readFileSync(join(orchDir, "workers", "CTL-1", "phase-implement.json"), "utf8")
     );
     expect(sig.status).toBe("stalled");
     // One audit event routed through the injected appendEvent.

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -1,0 +1,167 @@
+// boot-resume.test.mjs — CTL-654. Daemon boot-resume: re-dispatch in-flight
+// tickets that have no live --bg worker after a cold start.
+//
+// Phase 1 (this block): pure selection logic — hasLiveBgWorker,
+// activePhaseForTicket, selectBootResumeCandidates. No ambient I/O beyond
+// mkdtempSync signal fixtures (mirrors recovery.test.mjs idiom).
+// Phase 2 (below): reconcileBootResume orchestration with injected
+// dispatch/agents/appendEvent/report.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  hasLiveBgWorker,
+  activePhaseForTicket,
+  selectBootResumeCandidates,
+} from "./boot-resume.mjs";
+
+let orchDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "exec-core-boot-"));
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// writeSignal — write workers/<ticket>/phase-<phase>.json with the canonical
+// fields. Defaults model a running, freshly-dispatched phase worker.
+function writeSignal(dir, ticket, phase, overrides = {}) {
+  const wdir = join(dir, "workers", ticket);
+  mkdirSync(wdir, { recursive: true });
+  const sig = {
+    ticket,
+    phase,
+    status: "running",
+    bg_job_id: "deadbeef",
+    worktreePath: `/wt/${ticket}`,
+    updatedAt: "2026-05-27T02:00:00Z",
+    ...overrides,
+  };
+  writeFileSync(join(wdir, `phase-${phase}.json`), JSON.stringify(sig, null, 2));
+  return sig;
+}
+
+// writeMaxParallel — minimal state.json so readMaxParallel resolves a known cap.
+function writeMaxParallel(dir, n) {
+  writeFileSync(join(dir, "state.json"), JSON.stringify({ maxParallel: n }));
+}
+
+describe("hasLiveBgWorker", () => {
+  test("true for a background agent whose cwd matches the worktree", () => {
+    expect(hasLiveBgWorker([{ kind: "background", cwd: "/wt/A" }], "/wt/A")).toBe(true);
+  });
+
+  test("false when the only matching-cwd entry is interactive (human session)", () => {
+    expect(hasLiveBgWorker([{ kind: "interactive", cwd: "/wt/A" }], "/wt/A")).toBe(false);
+  });
+
+  test("false when no entry's cwd equals the worktree", () => {
+    expect(hasLiveBgWorker([{ kind: "background", cwd: "/wt/B" }], "/wt/A")).toBe(false);
+  });
+
+  test("false for an empty or undefined agents array (defensive)", () => {
+    expect(hasLiveBgWorker([], "/wt/A")).toBe(false);
+    expect(hasLiveBgWorker(undefined, "/wt/A")).toBe(false);
+  });
+
+  test("requires exact-string cwd equality — no trailing-slash normalization", () => {
+    expect(hasLiveBgWorker([{ kind: "background", cwd: "/wt/A/" }], "/wt/A")).toBe(false);
+  });
+});
+
+describe("activePhaseForTicket", () => {
+  test("returns the single non-terminal phase, ignoring terminal siblings", () => {
+    const sigs = [
+      { phase: "plan", status: "done", updatedAt: "2026-05-27T01:00:00Z" },
+      { phase: "implement", status: "running", updatedAt: "2026-05-27T02:00:00Z" },
+    ];
+    expect(activePhaseForTicket(sigs)?.phase).toBe("implement");
+  });
+
+  test("returns the most-recently-updated when more than one is non-terminal", () => {
+    const sigs = [
+      { phase: "implement", status: "running", updatedAt: "2026-05-27T01:00:00Z" },
+      { phase: "verify", status: "dispatched", updatedAt: "2026-05-27T03:00:00Z" },
+    ];
+    expect(activePhaseForTicket(sigs)?.phase).toBe("verify");
+  });
+
+  test("returns null when every phase is terminal (nothing to resume)", () => {
+    const sigs = [
+      { phase: "plan", status: "done", updatedAt: "2026-05-27T01:00:00Z" },
+      { phase: "implement", status: "failed", updatedAt: "2026-05-27T02:00:00Z" },
+    ];
+    expect(activePhaseForTicket(sigs)).toBeNull();
+  });
+
+  test("returns null for an empty list", () => {
+    expect(activePhaseForTicket([])).toBeNull();
+  });
+});
+
+describe("selectBootResumeCandidates", () => {
+  test("returns [] when there are no in-flight tickets", () => {
+    // A fully-completed ticket: monitor-deploy done is terminal-not-in-flight.
+    writeSignal(orchDir, "CTL-1", "monitor-deploy", { status: "done" });
+    expect(selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 3 })).toEqual([]);
+  });
+
+  test("returns only the in-flight ticket WITHOUT a live bg worker", () => {
+    // CTL-A has a live bg worker; CTL-B does not.
+    writeSignal(orchDir, "CTL-A", "implement", { worktreePath: "/wt/CTL-A" });
+    writeSignal(orchDir, "CTL-B", "verify", { worktreePath: "/wt/CTL-B" });
+    const agents = [{ kind: "background", cwd: "/wt/CTL-A" }];
+    const out = selectBootResumeCandidates({ orchDir, agents, maxParallel: 3 });
+    expect(out).toEqual([{ ticket: "CTL-B", phase: "verify", worktreePath: "/wt/CTL-B" }]);
+  });
+
+  test("excludes an in-flight ticket whose active signal lacks a worktreePath, recording a warn", () => {
+    writeSignal(orchDir, "CTL-NOWT", "implement", { worktreePath: null });
+    const warns = [];
+    const logger = { warn: (obj, msg) => warns.push({ obj, msg }), info: () => {} };
+    const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 3, logger });
+    expect(out).toEqual([]);
+    expect(warns).toHaveLength(1);
+    expect(warns[0].obj.ticket).toBe("CTL-NOWT");
+  });
+
+  test("slot bound: maxParallel=2 with 3 no-live-worker tickets returns exactly 2", () => {
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2" });
+    writeSignal(orchDir, "CTL-3", "implement", { worktreePath: "/wt/CTL-3" });
+    const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 2 });
+    expect(out).toHaveLength(2);
+  });
+
+  test("slot bound subtracts in-flight tickets that DO have a live worker", () => {
+    // maxParallel=3; CTL-LIVE has a live worker, 3 others do not → free = 3-1 = 2.
+    writeSignal(orchDir, "CTL-LIVE", "implement", { worktreePath: "/wt/CTL-LIVE" });
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2" });
+    writeSignal(orchDir, "CTL-3", "implement", { worktreePath: "/wt/CTL-3" });
+    const agents = [{ kind: "background", cwd: "/wt/CTL-LIVE" }];
+    const out = selectBootResumeCandidates({ orchDir, agents, maxParallel: 3 });
+    expect(out).toHaveLength(2);
+    expect(out.every((c) => c.ticket !== "CTL-LIVE")).toBe(true);
+  });
+
+  test("slices deterministically by ticket id so the cap is reproducible", () => {
+    writeSignal(orchDir, "CTL-3", "implement", { worktreePath: "/wt/CTL-3" });
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2" });
+    const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 2 });
+    expect(out.map((c) => c.ticket)).toEqual(["CTL-1", "CTL-2"]);
+  });
+
+  test("defaults maxParallel from state.json when not passed", () => {
+    writeMaxParallel(orchDir, 1);
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2" });
+    const out = selectBootResumeCandidates({ orchDir, agents: [] });
+    expect(out).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -8,13 +8,14 @@
 // dispatch/agents/appendEvent/report.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   hasLiveBgWorker,
   activePhaseForTicket,
   selectBootResumeCandidates,
+  reconcileBootResume,
 } from "./boot-resume.mjs";
 
 let orchDir;
@@ -163,5 +164,200 @@ describe("selectBootResumeCandidates", () => {
     writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2" });
     const out = selectBootResumeCandidates({ orchDir, agents: [] });
     expect(out).toHaveLength(1);
+  });
+});
+
+// ── Phase 2: reconcileBootResume orchestration ────────────────────────────
+describe("reconcileBootResume", () => {
+  test("cold-start gate: report.coldStart === false ⇒ 0 dispatches, no-op", () => {
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    const calls = [];
+    const dispatch = (a) => {
+      calls.push(a);
+      return { code: 0 };
+    };
+    const appendEvent = () => calls.push("event");
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: false },
+      agents: [],
+      dispatch,
+      appendEvent,
+    });
+    expect(res.dispatched).toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(res.skipped).toBe("not-cold-start");
+  });
+
+  test("missing/undefined report ⇒ no-op (defensive)", () => {
+    const calls = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: undefined,
+      agents: [],
+      dispatch: () => calls.push("d"),
+      appendEvent: () => calls.push("e"),
+    });
+    expect(res.dispatched).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("happy path: dispatches once with expectedWorktreePath and resets the signal to stalled", () => {
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1", status: "running" });
+    const dispatched = [];
+    const events = [];
+    const dispatch = (a) => {
+      dispatched.push(a);
+      return { code: 0 };
+    };
+    const appendEvent = (a) => events.push(a);
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      dispatch,
+      appendEvent,
+    });
+    expect(res.dispatched).toBe(1);
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]).toMatchObject({
+      orchDir,
+      ticket: "CTL-1",
+      phase: "implement",
+      expectedWorktreePath: "/wt/CTL-1",
+    });
+    // Went through defaultReviveDispatch: the signal on disk is reset to stalled.
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-1", "phase-implement.json"), "utf8"),
+    );
+    expect(sig.status).toBe("stalled");
+    // One audit event routed through the injected appendEvent.
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ ticket: "CTL-1", phase: "implement" });
+  });
+
+  test("slot bound end-to-end: maxParallel=1, 2 no-live tickets ⇒ exactly 1 dispatch + 1 event", () => {
+    writeMaxParallel(orchDir, 1);
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2" });
+    const dispatched = [];
+    const events = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      dispatch: (a) => {
+        dispatched.push(a);
+        return { code: 0 };
+      },
+      appendEvent: (a) => events.push(a),
+    });
+    expect(res.dispatched).toBe(1);
+    expect(dispatched).toHaveLength(1);
+    expect(events).toHaveLength(1);
+  });
+
+  test("skip-when-live: a ticket WITH a live bg worker is never dispatched", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-LIVE", "implement", { worktreePath: "/wt/CTL-LIVE" });
+    const dispatched = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [{ kind: "background", cwd: "/wt/CTL-LIVE" }],
+      dispatch: (a) => {
+        dispatched.push(a);
+        return { code: 0 };
+      },
+      appendEvent: () => {},
+    });
+    expect(res.dispatched).toBe(0);
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("dispatch failure is isolated: ticket B still attempted, failure counted, no throw", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-A", "implement", { worktreePath: "/wt/CTL-A" });
+    writeSignal(orchDir, "CTL-B", "implement", { worktreePath: "/wt/CTL-B" });
+    const attempted = [];
+    const events = [];
+    const dispatch = (a) => {
+      attempted.push(a.ticket);
+      return a.ticket === "CTL-A" ? { code: 1, stderr: "boom" } : { code: 0 };
+    };
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      dispatch,
+      appendEvent: (a) => events.push(a),
+    });
+    expect(attempted.sort()).toEqual(["CTL-A", "CTL-B"]);
+    expect(res.dispatched).toBe(1);
+    expect(res.failed).toBe(1);
+    // No audit event for the failed dispatch.
+    expect(events).toHaveLength(1);
+    expect(events[0].ticket).toBe("CTL-B");
+  });
+
+  test("missing-signal safety: a reviveDispatch signal-missing return is a failure, not a throw", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: () => ({ code: 1, stderr: "signal-missing" }),
+      appendEvent: () => {},
+    });
+    expect(res.dispatched).toBe(0);
+    expect(res.failed).toBe(1);
+  });
+
+  test("a throwing reviveDispatch is contained and counted as a failure", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1" });
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: () => {
+        throw new Error("kaboom");
+      },
+      appendEvent: () => {},
+    });
+    expect(res.dispatched).toBe(0);
+    expect(res.failed).toBe(1);
+  });
+});
+
+// ── Phase 2: audit event round-trip — boot-resume must NOT count as a revive ──
+describe("defaultAppendBootResumeEvent envelope", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl654-rt-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  test("writes phase.<phase>.boot-resume.<ticket> and is NOT counted by countReviveEvents", async () => {
+    const { defaultAppendBootResumeEvent } = await import("./recovery.mjs");
+    const { countReviveEvents } = await import("./event-scan.mjs");
+    const ok = defaultAppendBootResumeEvent({
+      phase: "implement",
+      ticket: "CTL-RT-654",
+      orchId: "orch-654",
+    });
+    expect(ok).toBe(true);
+    // boot-resume is a distinct action: the implement-only revive counter must
+    // stay at 0 so a reboot does not consume the chronic-failure budget.
+    expect(countReviveEvents({ ticket: "CTL-RT-654" })).toBe(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/cli/sessions.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.mjs
@@ -188,7 +188,11 @@ export function indexSignalsByBgJobId(runsRoot = getRunsRoot()) {
 
 // ─── I/O: live agents + ps ───────────────────────────────────────────────────
 
-function liveAgents() {
+// Exported (CTL-654) so the synchronous daemon boot-resume pass can resolve the
+// live-agent inventory without the async buildRows join. Shells
+// `claude agents --json` via execFileSync, so it is synchronous and safe inside
+// startDaemon's synchronous boot ordering.
+export function liveAgents() {
   try {
     const out = execFileSync(CLAUDE_BIN, ["agents", "--json"], { encoding: "utf8" });
     const parsed = JSON.parse(out);

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -36,6 +36,7 @@ import {
 } from "./index.mjs";
 import { Reaper } from "./reaper.mjs";
 import { startOrphanReaperTimer, readOrphanReaperConfig } from "./orphan-reaper-timer.mjs";
+import { reconcileBootResume } from "./boot-resume.mjs";
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -74,6 +75,9 @@ function ensureState(orchDir) {
 // wiring needs no arguments and tests inject deterministic fakes.
 export function startDaemon({
   recover = recoverStartup,
+  // CTL-654: synchronous boot-resume pass. Runs once between recover() and the
+  // monitor, consuming recover()'s previously-discarded RecoveryReport.
+  reconcileBoot = reconcileBootResume,
   startMonitor: monitorFn = startMonitor,
   startScheduler: schedulerFn = startScheduler,
   stopMonitor: stopMonitorFn = stopMonitor,
@@ -110,7 +114,17 @@ export function startDaemon({
   // stopDaemon removes _pidFile via unlinkSync. Rethrow so the main()-level
   // try/catch logs and process.exit(1)s as before.
   try {
-    recover({ orchDir }); // CTL-539 — rebuild routing + worker state on boot
+    // CTL-539 — rebuild routing + worker state on boot. CTL-654: capture the
+    // RecoveryReport (previously discarded) so the boot-resume pass can consume
+    // its `coldStart` verdict + worker buckets.
+    const report = recover({ orchDir });
+    // CTL-654: boot-resume — on a cold start, re-dispatch in-flight tickets whose
+    // worktree has no live --bg worker, BEFORE the monitor/scheduler start. This
+    // bypasses the per-tick reclaim sweep's revive budget (a clean reboot is not
+    // a chronic-failure storm) and is bounded by maxParallel so a reboot never
+    // spawns a worker storm. Synchronous and inside the same try/catch so a throw
+    // still triggers PID-file cleanup. A non-cold-start restart is a no-op.
+    reconcileBoot({ orchDir, report });
     // CTL-634: one shared TTL state cache. The monitor write-through populates
     // it on every state_changed event; the scheduler read path consults it
     // during out-of-set blocker hydration. A single instance threaded into

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -51,17 +51,73 @@ afterEach(() => {
 });
 
 describe("startDaemon", () => {
-  test("calls recover, startMonitor, startScheduler exactly once each", () => {
+  test("calls recover, boot, startMonitor, startScheduler exactly once each in order", () => {
     const calls = [];
     startDaemon({
       recover: (o) => calls.push(["recover", o.orchDir]),
+      // CTL-654: the boot-resume pass runs after recover, before the monitor.
+      reconcileBoot: (o) => calls.push(["boot", o.orchDir]),
       startMonitor: () => calls.push(["monitor"]),
       startScheduler: (o) => calls.push(["scheduler", o.orchDir]),
       watchRegistry: false,
     });
-    expect(calls.map((c) => c[0])).toEqual(["recover", "monitor", "scheduler"]);
-    // recover + scheduler both got the machine-level orchDir
-    expect(calls[0][1]).toBe(calls[2][1]);
+    expect(calls.map((c) => c[0])).toEqual(["recover", "boot", "monitor", "scheduler"]);
+    // recover + boot + scheduler all got the machine-level orchDir
+    expect(calls[0][1]).toBe(calls[1][1]);
+    expect(calls[0][1]).toBe(calls[3][1]);
+  });
+
+  // CTL-654: the boot-resume pass consumes the object recover() RETURNS as its
+  // `report` — the recover RecoveryReport was previously discarded.
+  test("threads recover()'s return value into reconcileBoot as report", () => {
+    const fakeReport = { coldStart: true, workers: { dead: ["CTL-1"] } };
+    let seenReport;
+    let bootCallCount = 0;
+    startDaemon({
+      recover: () => fakeReport,
+      reconcileBoot: (o) => {
+        bootCallCount++;
+        seenReport = o.report;
+      },
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+    });
+    expect(bootCallCount).toBe(1);
+    expect(seenReport).toBe(fakeReport);
+  });
+
+  // CTL-654: a throw from the boot-resume pass must not leave a stale PID file —
+  // it runs inside the same try/catch as recover/monitor/scheduler.
+  test("removes the PID file if reconcileBoot throws synchronously", () => {
+    const pidFile = join(process.env.CATALYST_DIR, "daemon.pid");
+    expect(() =>
+      startDaemon({
+        recover: () => ({ coldStart: true }),
+        reconcileBoot: () => {
+          throw new Error("simulated boot-resume failure");
+        },
+        startMonitor: () => {},
+        startScheduler: () => {},
+        watchRegistry: false,
+        pidFile,
+      })
+    ).toThrow("simulated boot-resume failure");
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  // CTL-654: the default no-arg-reconcileBoot path wires the real
+  // reconcileBootResume. A coldStart:false report must make it a safe no-op
+  // (no agent shell-out, no dispatch) and not throw.
+  test("default reconcileBoot is wired to reconcileBootResume and no-ops on a warm restart", () => {
+    expect(() =>
+      startDaemon({
+        recover: () => ({ coldStart: false, workers: {} }),
+        startMonitor: () => {},
+        startScheduler: () => {},
+        watchRegistry: false,
+      })
+    ).not.toThrow();
   });
 
   // CTL-634: one cache instance is created in startDaemon and threaded into

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -215,6 +215,28 @@ function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
   );
 }
 
+// defaultAppendBootResumeEvent — phase.<phase>.boot-resume.<ticket>. The
+// CTL-654 path: a cold-start reboot re-dispatches an in-flight ticket whose
+// worktree has no live bg worker. The `boot-resume` action is deliberately
+// distinct from `revive`/`reclaim` so countReviveEvents (event-scan.mjs,
+// implement-only `phase.implement.revive.<ticket>`) is unaffected and the
+// broker's PHASE_EVENT_PATTERN (complete|failed|turn-cap-exhausted|skipped)
+// ignores it — audit-only, like the other CTL-587 helpers. Exported so the
+// round-trip test can confirm the envelope shape, and so boot-resume.mjs imports
+// it as the default appendEvent seam.
+export function defaultAppendBootResumeEvent({ phase, ticket, orchId }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "boot-resume",
+      reason: "cold-start-no-live-worker",
+    }),
+    "boot-resume",
+  );
+}
+
 // CTL-587: three new audit-only event helpers. The broker's PHASE_EVENT_PATTERN
 // in router.mjs only matches complete|failed|turn-cap-exhausted|skipped, so
 // revive/escalated/revive-suppressed events are deliberately ignored by the

--- a/plugins/dev/scripts/execution-core/signal-reader.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.mjs
@@ -111,7 +111,9 @@ function readNestedDir(dir) {
 
 // byActivePhase — rank nested phase signals so the active one sorts first:
 // non-terminal status beats terminal, then most-recent updatedAt wins.
-function byActivePhase(a, b) {
+// CTL-654: exported so boot-resume.mjs's activePhaseForTicket reuses the same
+// comparator instead of duplicating the tiebreak (single source of truth).
+export function byActivePhase(a, b) {
   const aTerminal = TERMINAL.has(a.status);
   const bTerminal = TERMINAL.has(b.status);
   if (aTerminal !== bTerminal) return aTerminal ? 1 : -1;


### PR DESCRIPTION
## Summary
When the execution-core daemon cold-starts, it now reconciles and resumes in-flight phase work instead of dropping it on the floor.

- **Phase 1** — pure candidate selection (`boot-resume.mjs`): `hasLiveBgWorker` (background-kind + exact-cwd), `activePhaseForTicket` (reuses `byActivePhase` from `signal-reader.mjs`), `selectBootResumeCandidates` (slot-bounded via `computeFreeSlots`, deterministic sort). Reuses scheduler primitives, no reimplementation.
- **Phase 2** — orchestration (`reconcileBootResume`): gates on cold-start, dispatches via the revive path (budget bypass + CTL-615 worktree check), emits a distinct `boot-resume` audit event (kept separate from revive so `countReviveEvents` stays accurate).
- **Phase 3** — daemon wiring: `daemon.mjs` threads the recover report into `reconcileBoot` between recover and monitor, inside the PID-cleanup try/catch.

## Test plan
- [x] boot-resume suite: 25 pass / 0 fail
- [x] execution-core full suite: 810 pass / 0 fail
- [x] `node --check` clean; no reward-hacking patterns
- [x] call-order (recover→boot→monitor→scheduler) + throw-containment verified

Closes CTL-654.