### PR TITLE
CTL-655: window revive budget to daemon-boot time so restarts grant a fresh shot

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -37,6 +37,7 @@ import {
 import { Reaper } from "./reaper.mjs";
 import { startOrphanReaperTimer, readOrphanReaperConfig } from "./orphan-reaper-timer.mjs";
 import { reconcileBootResume } from "./boot-resume.mjs";
+import { writeBootMarker } from "./recovery.mjs"; // CTL-655: window the revive budget to this run
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -93,6 +94,11 @@ export function startDaemon({
 } = {}) {
   const orchDir = getExecutionCoreDir();
   ensureState(orchDir);
+  // CTL-655: record this daemon process's start time so the first scheduler
+  // tick's reclaimDeadWorkIfPossible can window the per-ticket revive budget to
+  // the current run (a clean restart resets a budget burned by a prior storm).
+  // Must precede schedulerFn (the first reclaim read). Fail-open internally.
+  writeBootMarker(orchDir);
   _stopMonitor = stopMonitorFn;
   _stopScheduler = stopSchedulerFn;
 

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -166,6 +166,40 @@ describe("startDaemon", () => {
     expect(JSON.parse(readFileSync(statePath, "utf8")).maxParallel).toBe(9);
   });
 
+  // CTL-655: the daemon records its boot time so reclaimDeadWorkIfPossible can
+  // window the per-ticket revive budget to the current run.
+  test("writes a daemon-boot.json with a parseable ISO bootedAt", () => {
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+    });
+    const markerPath = join(process.env.CATALYST_DIR, "execution-core", "daemon-boot.json");
+    expect(existsSync(markerPath)).toBe(true);
+    const { bootedAt } = JSON.parse(readFileSync(markerPath, "utf8"));
+    expect(typeof bootedAt).toBe("string");
+    expect(Number.isFinite(Date.parse(bootedAt))).toBe(true);
+  });
+
+  test("a fresh boot overwrites bootedAt (restart resets the window)", () => {
+    const markerPath = join(process.env.CATALYST_DIR, "execution-core", "daemon-boot.json");
+    mkdirSync(dirname(markerPath), { recursive: true });
+    writeFileSync(markerPath, JSON.stringify({ bootedAt: "2000-01-01T00:00:00.000Z" }));
+    const startedAtMs = Date.now();
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+    });
+    const { bootedAt } = JSON.parse(readFileSync(markerPath, "utf8"));
+    // Rewritten (not appended/ignored): the stale marker is gone and the new
+    // timestamp is at/after this test's start.
+    expect(bootedAt).not.toBe("2000-01-01T00:00:00.000Z");
+    expect(Date.parse(bootedAt)).toBeGreaterThanOrEqual(startedAtMs);
+  });
+
   test("writes its PID to the given pidFile", () => {
     const pidFile = join(process.env.CATALYST_DIR, "daemon.pid");
     startDaemon({

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -177,6 +177,108 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     expect(labelCalls).toEqual(["CTL-587-B"]);
   });
 
+  // CTL-655: a daemon-boot.json marker windows the budget to the current run.
+  // Two revives that PRE-DATE the boot fall outside the window → the ticket is
+  // revived (budget reset), exercising the real readBootSince + countReviveEvents.
+  test("budget resets after restart — pre-boot revives are not counted → 'revived'", () => {
+    seedSignal("CTL-587-RESET", "implement", {
+      status: "running",
+      bg_job_id: "nonexistent-bg-id",
+      orchestrator: "CTL-587-RESET",
+    });
+    // Two prior revives, both BEFORE the boot time T.
+    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-RESET", ts: "2026-05-23T00:00:00Z" }));
+    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-RESET", ts: "2026-05-23T00:05:00Z" }));
+    // Boot marker newer than both revives → they fall outside the window.
+    writeFileSync(
+      join(orchDir, "daemon-boot.json"),
+      JSON.stringify({ bootedAt: "2026-05-24T00:00:00Z" }),
+    );
+
+    const labelCalls = [];
+    const reviveDispatchCalls = [];
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: {
+        applyPhaseStatus: () => {},
+        applyTerminalDone: () => {},
+        applyLabel: () => ({ applied: true }),
+      },
+      teardownWorktree: () => true,
+      reclaimDeadWork: (od, sig, opts) =>
+        reclaimDeadWorkIfPossible(od, sig, {
+          ...opts,
+          statJob: () => null, // bg dead
+          probes: { implement: () => false }, // work NOT done
+          reviveDispatch: (args) => {
+            reviveDispatchCalls.push(args);
+            return { code: 0 };
+          },
+          applyStalledLabel: ({ ticket }) => {
+            labelCalls.push(ticket);
+            return { applied: true };
+          },
+          killBgJob: () => {},
+          // Default countReviveEvents + default readBootSince (reads the marker
+          // we wrote in orchDir) — the real windowing path under test.
+        }),
+    });
+
+    expect(result.revived).toEqual([{ ticket: "CTL-587-RESET", phase: "implement" }]);
+    expect(result.escalated).toEqual([]);
+    expect(reviveDispatchCalls).toHaveLength(1);
+    expect(labelCalls).toEqual([]); // no needs-human escalation
+  });
+
+  // CTL-655 guard against an over-aggressive window: revives AT/AFTER the boot
+  // time ARE counted, so the budget still exhausts within a single daemon run.
+  test("budget still exhausts within one run — post-boot revives ARE counted → 'escalated'", () => {
+    seedSignal("CTL-587-INRUN", "implement", {
+      status: "running",
+      bg_job_id: "nonexistent-bg-id",
+      orchestrator: "CTL-587-INRUN",
+    });
+    const bootedAt = "2026-05-24T00:00:00Z";
+    // Two revives at/after the boot time → inside the window.
+    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-INRUN", ts: "2026-05-25T00:00:00Z" }));
+    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-INRUN", ts: "2026-05-25T00:05:00Z" }));
+    writeFileSync(join(orchDir, "daemon-boot.json"), JSON.stringify({ bootedAt }));
+
+    const labelCalls = [];
+    const reviveDispatchCalls = [];
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      writeStatus: {
+        applyPhaseStatus: () => {},
+        applyTerminalDone: () => {},
+        applyLabel: () => ({ applied: true }),
+      },
+      teardownWorktree: () => true,
+      reclaimDeadWork: (od, sig, opts) =>
+        reclaimDeadWorkIfPossible(od, sig, {
+          ...opts,
+          statJob: () => null,
+          probes: { implement: () => false },
+          reviveDispatch: (args) => {
+            reviveDispatchCalls.push(args);
+            return { code: 0 };
+          },
+          applyStalledLabel: ({ ticket }) => {
+            labelCalls.push(ticket);
+            return { applied: true };
+          },
+          killBgJob: () => {},
+        }),
+    });
+
+    expect(result.escalated).toEqual([{ ticket: "CTL-587-INRUN", phase: "implement" }]);
+    expect(result.revived).toEqual([]);
+    expect(reviveDispatchCalls).toHaveLength(0);
+    expect(labelCalls).toEqual(["CTL-587-INRUN"]);
+  });
+
   test("storm-breaker open: 4 distinct tickets reviving → 'revive-suppressed', no dispatch", () => {
     seedSignal("CTL-587-C", "implement", {
       status: "running",

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -460,6 +460,49 @@ export function defaultPidAlive(
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// CTL-655: daemon-boot marker. The daemon writes this once at startup
+// (writeBootMarker, below) and reclaimDeadWorkIfPossible reads it
+// (readBootSince) to window the per-ticket revive budget to the CURRENT daemon
+// run, so a clean restart resets a budget burned by a prior crash storm. This
+// is deliberately NOT the CTL-640 cold-start epoch (OS boot / claude-daemon
+// start) — that boundary would not reset on a daemon-only restart.
+// ──────────────────────────────────────────────────────────────────────────
+
+// bootMarkerPath — the single source of the marker location, shared by the
+// reader and writer. Lives alongside daemon.pid / state.json / cursor.json.
+export function bootMarkerPath(orchDir) {
+  return join(orchDir, "daemon-boot.json");
+}
+
+// readBootSince — the ISO-8601 boot timestamp to pass as countReviveEvents'
+// `since`, or undefined. Fail-open: a missing / unparseable / wrong-typed
+// marker returns undefined → the counter counts all events (the pre-CTL-655
+// behavior, the conservative direction — the budget can still exhaust).
+export function readBootSince(orchDir) {
+  try {
+    const raw = readFileSync(bootMarkerPath(orchDir), "utf8");
+    const bootedAt = JSON.parse(raw)?.bootedAt;
+    return typeof bootedAt === "string" && bootedAt ? bootedAt : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// writeBootMarker — record this daemon process's start time. Atomic tmp+rename,
+// fail-open: a write failure logs and the daemon continues (the budget simply
+// won't reset this run — the safe degradation). Injectable `now` for tests.
+export function writeBootMarker(orchDir, { now = () => new Date().toISOString() } = {}) {
+  try {
+    const p = bootMarkerPath(orchDir);
+    const tmp = `${p}.tmp`;
+    writeFileSync(tmp, JSON.stringify({ bootedAt: now() }));
+    renameSync(tmp, p);
+  } catch (err) {
+    log.warn({ err }, "ctl-655: failed to write daemon-boot.json (revive budget will not reset this run)");
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // CTL-640: cold-start detection. The reference epoch = max(OS boot, claude-daemon
 // start). If that epoch is newer than EVERY ~/.claude/jobs/<id>/state.json mtime,
 // every recorded --bg worker pre-dates the epoch and is provably dead → COLD
@@ -688,6 +731,11 @@ export function reclaimDeadWorkIfPossible(
     applyStalledLabel = defaultApplyStalledLabel,
     killBgJob = defaultKillBgJob,
     countReviveEvents = defaultCountReviveEvents,
+    // CTL-655 — boot-time window reader. Reads <orchDir>/daemon-boot.json and
+    // returns its `bootedAt` (or undefined) so the revive budget counts only
+    // revives from the current daemon run. Named ...Fn to avoid shadowing the
+    // module-level readBootSince used as the default.
+    readBootSince: readBootSinceFn = readBootSince,
     countDistinctRevivingTickets = defaultCountDistinctRevivingTickets,
     writeReviveMarker = defaultWriteReviveMarker,
     // CTL-638 — per-(ticket, phase) escalation cool-down. Defaults read/write
@@ -850,9 +898,13 @@ export function reclaimDeadWorkIfPossible(
   }
 
   // Per-ticket revive budget from events.jsonl. The events file is the
-  // authoritative counter — surviving daemon restarts, more truthful than the
-  // signal file (which the dispatcher rewrites each spawn).
-  const priorRevives = countReviveEvents({ ticket, orchId });
+  // authoritative counter — more truthful than the signal file (which the
+  // dispatcher rewrites each spawn). CTL-655: window the count to the current
+  // daemon run via the boot marker, so a clean restart resets a budget burned
+  // by a prior crash storm. `since` is undefined when the marker is absent →
+  // the count is unwindowed (the pre-CTL-655 behavior).
+  const since = readBootSinceFn(orchDir);
+  const priorRevives = countReviveEvents({ ticket, orchId, since });
   if (priorRevives >= MAX_REVIVES) {
     return escalateOnce("revive-budget-exhausted", priorRevives);
   }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -22,6 +22,7 @@ import {
   readDaemonEpoch,
   defaultReadRuntimeEpoch,
   detectColdStart,
+  readBootSince,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -749,6 +750,10 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     bgJobId = "bg-9",
     stateJsonMtime = 1_000, // far in the past — staleness triggers
     nowMs = 1_000 + 6 * 60 * 1000, // 6 min past mtime — > STALE_MS
+    // CTL-655: boot-time window seam. Default to a no-marker reader so every
+    // existing scenario behaves exactly as before (since=undefined → the
+    // injected countReviveEvents recorder value is the unwindowed count).
+    readBootSince = () => undefined,
   } = {}) {
     const sig = {
       ...implementSignal({ ticket, status: "running", bgJobId }),
@@ -776,6 +781,7 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
         countReviveEvents: recorder(reviveCount),
         countDistinctRevivingTickets: recorder(distinctRevivingTickets),
         writeReviveMarker: recorder(undefined),
+        readBootSince, // CTL-655: inject the boot-time window reader
         now: () => nowMs,
         staleMs: 5 * 60 * 1000,
       },
@@ -845,6 +851,34 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(s.opts.reviveDispatch.calls.length).toBe(1);
     expect(s.opts.appendReviveEvent.calls.length).toBe(1);
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
+  });
+
+  // CTL-655: the daemon-boot timestamp must reach countReviveEvents as `since`
+  // so the per-ticket budget windows to the current daemon run.
+  test("threads boot 'since' into countReviveEvents", () => {
+    const s = setupReviveScenario({
+      reviveCount: 0,
+      readBootSince: () => "2026-05-27T03:30:00Z",
+    });
+    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(r).toBe("revived");
+    // The boot value reached the budget counter…
+    expect(s.opts.countReviveEvents.calls[0][0].since).toBe("2026-05-27T03:30:00Z");
+    // …and the pre-existing args are still passed (no regression).
+    expect(s.opts.countReviveEvents.calls[0][0].ticket).toBe("CTL-9");
+    expect(s.opts.countReviveEvents.calls[0][0]).toHaveProperty("orchId");
+  });
+
+  // CTL-655: fail-open — a missing/unreadable marker yields no `since`, so the
+  // counter is unwindowed and the budget still exhausts (today's behavior).
+  test("omits 'since' when boot marker is absent (fail-open)", () => {
+    const s = setupReviveScenario({
+      reviveCount: 2,
+      readBootSince: () => undefined,
+    });
+    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(r).toBe("escalated");
+    expect(s.opts.countReviveEvents.calls[0][0].since).toBeUndefined();
   });
 
   test("dead plan worker, probe NOT done → 'revived'", () => {
@@ -1845,5 +1879,34 @@ describe("reclaimDeadWorkIfPossible — CTL-606 supersede guard", () => {
     });
     expect(r).toBe("noop");
     expect(listSpy.calls.length).toBe(0); // guard runs only after the dead check
+  });
+});
+
+describe("readBootSince — CTL-655 boot-time window reader", () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ctl655-boot-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns bootedAt from daemon-boot.json", () => {
+    writeFileSync(join(dir, "daemon-boot.json"), JSON.stringify({ bootedAt: "2026-05-27T03:30:00Z" }));
+    expect(readBootSince(dir)).toBe("2026-05-27T03:30:00Z");
+  });
+
+  test("returns undefined when marker missing / malformed (fail-open)", () => {
+    // Empty dir → no marker.
+    expect(readBootSince(dir)).toBeUndefined();
+    // Non-JSON body.
+    writeFileSync(join(dir, "daemon-boot.json"), "not json");
+    expect(readBootSince(dir)).toBeUndefined();
+    // Wrong-typed bootedAt (number, not ISO string).
+    writeFileSync(join(dir, "daemon-boot.json"), JSON.stringify({ bootedAt: 123 }));
+    expect(readBootSince(dir)).toBeUndefined();
+    // Empty-string bootedAt is also rejected.
+    writeFileSync(join(dir, "daemon-boot.json"), JSON.stringify({ bootedAt: "" }));
+    expect(readBootSince(dir)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
The revive budget was counted from the append-only month event log via `countReviveEvents`, which never reset on daemon restart — so a stalled ticket stays escalated to needs-human forever instead of getting one more autonomous attempt after a restart. This windows the count to the current daemon run.

- **Phase 1** — `recovery.mjs`: `bootMarkerPath` + `readBootSince` (fail-open: missing/invalid → `undefined`), threaded as `since` into `countReviveEvents({ticket, orchId, since})`, wired through `reclaimDeadWorkIfPossible`.
- **Phase 2** — `recovery.mjs` `writeBootMarker` (atomic tmp+rename, fail-open); `daemon.mjs` writes the boot marker at startup (after `ensureState`, before the scheduler).

## Test plan
- [x] recovery + daemon + event-scan + integration-ctl-587 + boot-resume: 185 pass / 0 fail (post-rebase onto CTL-654)
- [x] budget resets after restart / still exhausts within a run — both covered
- [x] no reward-hacking; diff scoped (blanket-fmt churn reverted)

Closes CTL-655.