### PR TITLE
CTL-653: verify⇄remediate cycle — fix-capable remediate phase with cap-3 loop

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -15,6 +15,7 @@
         "inProgress": "Implement",
         "verifying": "Validate",
         "reviewing": "Validate",
+        "remediating": "Remediate",
         "inReview": "PR",
         "done": "Done",
         "canceled": "Canceled"

--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -133,6 +133,27 @@ and mirrored in the orchestrate skill's pipeline reference table.
 | 8 | `monitor-merge` | `catalyst-events wait-for` loop → `gh pr merge --squash --delete-branch` | `done` | `phase-monitor-merge.json` | Opus | 50 |
 | 9 | `monitor-deploy` | `/canary` (gstack) | — | `phase-monitor-deploy.json` | Haiku | 30 |
 
+**Ancillary phase — `remediate` (CTL-653).** Not a member of the linear
+sequence: it is a *router-orchestrated conditional detour* the scheduler takes
+when `verify` produces a verdict-fail (`verify.json.regression_risk ≥ 5` OR any
+`severity:"high"` finding). It reads `verify.json.findings[]` as its brief, fixes
+the code, commits, emits `phase.remediate.complete`, and the router cycles back
+to a fresh `verify`. The loop repeats up to **3** times (a counter distinct from
+the revive budget, event-counted via `phase.remediate.complete.<ticket>`); only a
+verdict-fail *after* the budget is spent escalates to `stalled` → `needs-human`.
+
+| Phase | Sub-skill / agent | Linear state | Prior artifact | Default model | Turn cap |
+|---|---|---|---|---|---|
+| `remediate` | (none — fixes findings inline via Edit/Write) | `remediating` (→ Remediate) | `verify.json` | Opus | 40 |
+
+The conditional routing lives entirely in `deriveAdvancement`
+(`execution-core/scheduler.mjs`); the pure FSM (`lib/phase-fsm.mjs`) keeps
+`verify → review` as its single happy-path edge, so `remediate` is added only as
+a *known ancillary phase* (`isKnownPhase`, `ANCILLARY_PHASES`,
+`REMEDIATE_CYCLE_CAP = 3`). Re-entry past the `next.phase in sig` guard is done by
+deleting the verify+remediate cycle signals (`maybeResetForRemediateCycle`); the
+cap escalation stalls the verify signal (`maybeEscalateRemediateExhausted`).
+
 Each phase writes its signal file at
 `~/catalyst/runs/<orchId>/workers/<TICKET>/phase-<name>.json`. Per-phase turn-cap
 defaults live in `plugins/dev/scripts/phase-agent-dispatch` (functions
@@ -150,7 +171,10 @@ stateDiagram-v2
   research --> plan: phase.research.complete
   plan --> implement: phase.plan.complete
   implement --> verify: phase.implement.complete
-  verify --> review: phase.verify.complete
+  verify --> review: verdict-pass (risk<5, no high finding)
+  verify --> remediate: verdict-fail & cycle<3 (CTL-653)
+  remediate --> verify: re-verify (reset signals, cycle++)
+  verify --> stalled: verdict-fail & cycle≥3 → needs-human
   review --> pr: phase.review.complete
   pr --> monitor_merge: phase.pr.complete
   monitor_merge --> monitor_deploy: phase.monitor-merge.complete
@@ -168,6 +192,11 @@ stateDiagram-v2
 
 Revives are once-per-phase; on the second `phase.<name>.failed` for the same phase
 the orchestrator marks the worker `stalled`, posts `attention`, and stops advancing.
+The `verify ⇄ remediate` cycle (CTL-653) is the one exception to the
+"escalate on second failure" rule: a verify *verdict*-fail (a `complete` event
+with a high `regression_risk`, distinct from a verify *crash* `failed` event)
+self-heals through `remediate` up to 3 times before stalling — so a fixable
+verify failure no longer needs a human on the first try.
 
 ## Phase 4 monitor — broker interests + event flow
 

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -758,6 +758,35 @@ assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" \
 unset CLAUDE_STUB_EXIT CATALYST_EMIT_COMPLETE
 
 echo ""
+echo "Test 20 (CTL-653): remediate dispatches with turnCap 40 + verify.json prior gate"
+fresh_env t20_remediate
+# remediate's prior artifact is verify.json — create it so the gate passes.
+printf '%s\n' '{"regression_risk":7,"findings":[{"severity":"high"}],"tests_attempted":3,"gates":{},"generatedAt":"2026-05-27T00:00:00Z"}' \
+	>"${WORKER_DIR}/verify.json"
+"$DISPATCH" --phase remediate --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1
+SIGNAL_REM="${WORKER_DIR}/phase-remediate.json"
+if [[ ! -f $SIGNAL_REM ]]; then
+	fail "remediate signal file created: $SIGNAL_REM"
+else
+	pass "remediate signal file created"
+	assert_eq "remediate" "$(jq -r '.phase' "$SIGNAL_REM")" "signal.phase = remediate"
+	assert_eq "40" "$(jq -r '.turnCap' "$SIGNAL_REM")" "signal.turnCap = 40 (remediate, fix-scoped)"
+fi
+
+echo ""
+echo "Test 21 (CTL-653): remediate refuses when verify.json (prior artifact) is missing"
+fresh_env t21_remediate
+# No verify.json → the prior-artifact gate must refuse (exit 2, no signal).
+"$DISPATCH" --phase remediate --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	>"${TEST_DIR}/rem.out" 2>/dev/null
+RC_REM=$?
+assert_eq "2" "$RC_REM" "exit code 2 when remediate's verify.json is missing"
+assert_eq "refused" "$(jq -r '.status' "${TEST_DIR}/rem.out" 2>/dev/null || echo "")" \
+	"remediate stdout JSON status = refused"
+[[ -f "${WORKER_DIR}/phase-remediate.json" ]] && SIG_REM_EXISTS="yes" || SIG_REM_EXISTS="no"
+assert_eq "no" "$SIG_REM_EXISTS" "no remediate signal written when refused"
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then

--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -46,11 +46,14 @@ STATE_MAP_JSON="$(build_execution_core_state_map)"
 run "state map is valid JSON" \
   bash -c "echo '$STATE_MAP_JSON' | jq -e ."
 
-run "state map has 11 keys" \
-  bash -c "echo '$STATE_MAP_JSON' | jq -e 'length == 11'"
+run "state map has 12 keys" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e 'length == 12'"
 
 run "state map todo -> Ready" \
   bash -c "echo '$STATE_MAP_JSON' | jq -e '.todo == \"Ready\"'"
+
+run "state map remediating -> Remediate (CTL-653)" \
+  bash -c "echo '$STATE_MAP_JSON' | jq -e '.remediating == \"Remediate\"'"
 
 run "state map triage -> Triage" \
   bash -c "echo '$STATE_MAP_JSON' | jq -e '.triage == \"Triage\"'"

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -58,6 +58,28 @@ export function countReviveEvents({ ticket, orchId, since, path = getEventLogPat
   return n;
 }
 
+// countRemediateCycles — number of phase.remediate.complete.<ticket> envelopes
+// (CTL-653). The event-counted verify⇄remediate budget, mirroring
+// countReviveEvents but deliberately DISTINCT from it: a crash-revive
+// (phase.implement.revive.<T>) never consumes verdict-cycle budget, and the
+// cycle survives the per-cycle signal reset (signals are deleted each cycle;
+// events are durable). One completed cycle == one remediate-complete event.
+export function countRemediateCycles({ ticket, orchId, since, path = getEventLogPath() } = {}) {
+  if (!ticket) throw new Error("countRemediateCycles: ticket required");
+  const target = `phase.remediate.complete.${ticket}`;
+  let n = 0;
+  for (const line of readLinesSync(path)) {
+    const ev = safeParse(line);
+    if (!ev) continue;
+    const name = ev?.attributes?.["event.name"];
+    if (name !== target) continue;
+    if (orchId && ev?.attributes?.["catalyst.orchestration"] !== orchId) continue;
+    if (since && ev?.ts && ev.ts < since) continue;
+    n++;
+  }
+  return n;
+}
+
 // countDistinctRevivingTickets — unique tickets that have any revive event
 // inside `windowMs` of `now()`. Used by recovery.mjs to suppress revives when
 // the storm-breaker is open (default >3 distinct tickets in the last 10min).

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -12,7 +12,11 @@ import { describe, test, expect } from "bun:test";
 import { writeFileSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { countReviveEvents, countDistinctRevivingTickets } from "./event-scan.mjs";
+import {
+  countReviveEvents,
+  countDistinctRevivingTickets,
+  countRemediateCycles,
+} from "./event-scan.mjs";
 
 // makeEvent — minimal envelope mirroring buildEventEnvelope in recovery.mjs.
 function makeEvent({ phase = "implement", action = "revive", ticket, orchId, ts }) {
@@ -162,5 +166,48 @@ describe("countDistinctRevivingTickets", () => {
         path,
       })
     ).toBe(1);
+  });
+});
+
+// ─── CTL-653: countRemediateCycles — the event-counted verify⇄remediate budget ───
+// Distinct from countReviveEvents (crash-revive budget) so a crash never spends
+// verdict-cycle budget. One completed cycle == one phase.remediate.complete.<T>.
+
+describe("CTL-653: countRemediateCycles", () => {
+  test("missing event log returns 0 (cold start)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evtscan-"));
+    expect(countRemediateCycles({ ticket: "CTL-653", path: join(dir, "events.jsonl") })).toBe(0);
+  });
+
+  test("counts only phase.remediate.complete.<ticket> envelopes", () => {
+    const { path } = tempLog([
+      makeEvent({ phase: "remediate", action: "complete", ticket: "CTL-653", ts: "2026-05-27T00:00:00Z" }), // match
+      makeEvent({ phase: "remediate", action: "complete", ticket: "CTL-653", ts: "2026-05-27T00:01:00Z" }), // match
+      makeEvent({ phase: "remediate", action: "failed", ticket: "CTL-653", ts: "2026-05-27T00:02:00Z" }), // diff action
+      makeEvent({ phase: "implement", action: "revive", ticket: "CTL-653", ts: "2026-05-27T00:03:00Z" }), // diff phase
+      makeEvent({ phase: "remediate", action: "complete", ticket: "CTL-999", ts: "2026-05-27T00:04:00Z" }), // diff ticket
+      "not json", // skipped
+    ]);
+    expect(countRemediateCycles({ ticket: "CTL-653", path })).toBe(2);
+  });
+
+  test("respects orchId filter (mirrors countReviveEvents)", () => {
+    const { path } = tempLog([
+      makeEvent({ phase: "remediate", action: "complete", ticket: "CTL-653", orchId: "orch-A", ts: "2026-05-27T00:00:00Z" }),
+      makeEvent({ phase: "remediate", action: "complete", ticket: "CTL-653", orchId: "orch-B", ts: "2026-05-27T00:01:00Z" }),
+    ]);
+    expect(countRemediateCycles({ ticket: "CTL-653", orchId: "orch-A", path })).toBe(1);
+  });
+
+  test("respects since filter (mirrors countReviveEvents)", () => {
+    const { path } = tempLog([
+      makeEvent({ phase: "remediate", action: "complete", ticket: "CTL-653", ts: "2026-05-27T00:00:00Z" }),
+      makeEvent({ phase: "remediate", action: "complete", ticket: "CTL-653", ts: "2026-05-27T05:00:00Z" }),
+    ]);
+    expect(countRemediateCycles({ ticket: "CTL-653", since: "2026-05-27T01:00:00Z", path })).toBe(1);
+  });
+
+  test("throws without ticket", () => {
+    expect(() => countRemediateCycles({})).toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -28,7 +28,18 @@ import { analyzeDependencyGraph, referencedBlockerIds } from "../lib/dependency-
 // PHASES is still imported for deriveAdvancement; CTL-565 note: PHASES[0]
 // ("triage") is intentionally NO LONGER the new-work entry phase — new work
 // enters at NEW_WORK_ENTRY_PHASE ("research"), see schedulerTick.
-import { PHASES, transition, isTerminal } from "../lib/phase-fsm.mjs";
+import {
+  PHASES,
+  transition,
+  isTerminal,
+  REMEDIATE_PHASE,
+  REMEDIATE_CYCLE_CAP,
+} from "../lib/phase-fsm.mjs";
+// CTL-653: the verdict-router reads (verify.json verdict + event-counted cycle
+// budget) live here. deriveAdvancement stays pure — the impure reads happen in
+// the sweep and are injected, so the router itself is unit-testable.
+import { readVerifyVerdict } from "./work-done-probes.mjs";
+import { countRemediateCycles } from "./event-scan.mjs";
 import { rankTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
 import { fetchTicketState } from "./linear-query.mjs";
@@ -275,11 +286,27 @@ export function readAllEligibleTickets() {
 // known phase is `done` and its transition() successor is a non-terminal phase
 // with no signal yet. Advancement goes through phase-fsm.mjs — never a local
 // copy of NEXT_PHASE.
-export function deriveAdvancement(signals) {
+// CTL-653: the optional second param injects the verify verdict + the
+// event-counted remediate cycle count so the router can branch verify →
+// remediate vs verify → review while staying pure (no I/O). Backward compatible:
+// existing single-arg callers default to { verifyVerdict: undefined,
+// remediateCycleCount: 0 }, which preserves the legacy verify → review edge.
+export function deriveAdvancement(signals, { verifyVerdict, remediateCycleCount = 0 } = {}) {
   const sig = signals ?? {};
   let latest = null;
-  for (const p of PHASES) if (p in sig) latest = p;
+  for (const p of PHASES) if (p in sig) latest = p; // remediate ∉ PHASES → invisible here
   if (latest === null || sig[latest] !== "done") return null;
+
+  // CTL-653: verdict routing at verify. A verdict-fail detours to remediate
+  // (until the cycle cap); pass/null/undefined falls through to the normal
+  // verify → review edge. The cap-and-escalate path returns null here — the
+  // sweep's maybeEscalateRemediateExhausted owns the stall, not a dispatch.
+  if (latest === "verify" && verifyVerdict === "fail") {
+    if (remediateCycleCount >= REMEDIATE_CYCLE_CAP) return null; // exhausted → sweep stalls it
+    if (REMEDIATE_PHASE in sig) return null; // remediate already dispatched this cycle
+    return REMEDIATE_PHASE;
+  }
+
   const next = transition(
     { phase: latest, reviveCount: 0, parkedFrom: null },
     { type: "complete" }
@@ -287,6 +314,73 @@ export function deriveAdvancement(signals) {
   if (isTerminal(next)) return null; // pipeline reached monitor-deploy → done
   if (next.phase in sig) return null; // successor already dispatched
   return next.phase;
+}
+
+// REMEDIATE_CYCLE_FILES — the per-cycle signal/artifact files the sweep deletes
+// to re-enter verify after a completed remediation (CTL-653). Limited to the
+// three files that constitute one verify⇄remediate cycle; upstream signals
+// (triage/research/plan/implement) and their artifacts are never touched.
+const REMEDIATE_CYCLE_FILES = ["phase-verify.json", "phase-remediate.json", "verify.json"];
+
+// maybeResetForRemediateCycle — CTL-653 re-entry. A completed remediate cycles
+// back to a fresh verify, but deriveAdvancement's `next.phase in sig` guard
+// blocks re-dispatching verify while its signal exists. Rather than special-
+// casing the guard, reset the cycle by deleting the verify+remediate signals
+// (and verify.json). The next deriveAdvancement then sees implement as the
+// latest `done` phase and cleanly re-dispatches verify. The cycle count
+// survives because it is event-counted (countRemediateCycles), not signal-stored.
+// Returns true when a reset happened (so the caller re-reads the signals).
+export function maybeResetForRemediateCycle(
+  orchDir,
+  ticket,
+  { rm = rmSync, readSignals = readPhaseSignals } = {}
+) {
+  const sig = readSignals(orchDir, ticket);
+  if (sig[REMEDIATE_PHASE] !== "done") return false;
+  for (const f of REMEDIATE_CYCLE_FILES) {
+    try {
+      rm(join(orchDir, "workers", ticket, f), { force: true });
+    } catch {
+      // best-effort — a missing file is the desired end state anyway
+    }
+  }
+  return true;
+}
+
+// maybeEscalateRemediateExhausted — CTL-653 cap. A verify verdict-fail with no
+// remediation budget left escalates to terminal `stalled`, so the existing
+// terminal sweep (this file, ~line 653) applies the `needs-human` label and
+// frees the slot. Writes status:"stalled" onto the verify signal in place;
+// idempotent (a signal already stalled is a no-op success). Returns true when
+// the ticket is (or was already) escalated, so the caller skips its dispatch.
+export function maybeEscalateRemediateExhausted(
+  orchDir,
+  ticket,
+  signals,
+  verdict,
+  cycleCount,
+  { writeFile = writeFileSync, readFile = readFileSync } = {}
+) {
+  if (signals.verify !== "done" || verdict !== "fail" || cycleCount < REMEDIATE_CYCLE_CAP) {
+    return false;
+  }
+  const p = join(orchDir, "workers", ticket, "phase-verify.json");
+  try {
+    const cur = JSON.parse(readFile(p, "utf8"));
+    if (cur.status === "stalled") return true; // idempotent
+    writeFile(
+      p,
+      JSON.stringify({
+        ...cur,
+        status: "stalled",
+        stalledReason: "remediate-cycle-cap-exhausted",
+        updatedAt: new Date().toISOString(),
+      })
+    );
+  } catch {
+    // best-effort — a missing/unreadable signal means nothing to stall
+  }
+  return true;
 }
 
 // safeWrite — run a best-effort Linear-write call (CTL-558). A write failure
@@ -570,7 +664,24 @@ export function schedulerTick(
   // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
   const advanced = [];
   for (const ticket of listInFlightTickets(orchDir)) {
-    const next = deriveAdvancement(readPhaseSignals(orchDir, ticket));
+    // CTL-653: re-enter verify after a completed remediation (deletes the cycle
+    // signals so deriveAdvancement re-dispatches a fresh verify this tick).
+    maybeResetForRemediateCycle(orchDir, ticket);
+
+    const signals = readPhaseSignals(orchDir, ticket);
+    // CTL-653: the verdict-router reads — verify.json verdict + event-counted
+    // cycle budget. Injected into deriveAdvancement so the router stays pure.
+    const verdict = readVerifyVerdict({ ticket, orchDir });
+    const cycleCount = countRemediateCycles({ ticket });
+
+    // CTL-653: cap reached → stall (needs-human via the terminal sweep below),
+    // skip any dispatch for this ticket this tick.
+    if (maybeEscalateRemediateExhausted(orchDir, ticket, signals, verdict, cycleCount)) continue;
+
+    const next = deriveAdvancement(signals, {
+      verifyVerdict: verdict,
+      remediateCycleCount: cycleCount,
+    });
     if (!next) continue;
     if (inDispatchCooldown(orchDir, ticket, next, now())) continue; // CTL-624: throttle refused re-dispatch
     const r = dispatchTicket(orchDir, ticket, next, { dispatch });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1867,3 +1867,110 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
     expect(existsSync(join(orchDir, "workers", "CTL-23", ".terminal-done.applied"))).toBe(false);
   });
 });
+
+// ─── CTL-653: end-to-end verify⇄remediate cycle through schedulerTick ───
+// Drives the full router → reset → re-verify loop. The dispatch fake plays the
+// worker: it writes each phase's `done` signal, writes verify.json with a
+// verdict that fails for the first `failCycles` verify runs (then passes), and
+// on a remediate dispatch appends a phase.remediate.complete event so
+// countRemediateCycles advances. reclaimDeadWork + writeStatus are stubbed so
+// the test isolates the advancement sweep.
+describe("CTL-653: schedulerTick verify⇄remediate cycle (end-to-end)", () => {
+  const TICKET = "CTL-653";
+  // A no-op Linear writer: every method returns undefined, which labelOnce /
+  // terminalDoneOnce treat as success (so once-markers still get written).
+  const noopWriteStatus = new Proxy({}, { get: () => () => undefined });
+
+  // cyclingDispatch — the worker stand-in. failCycles = how many verify runs
+  // produce a verdict-fail (risk 7) before one passes (risk 1).
+  function cyclingDispatch(failCycles) {
+    const calls = [];
+    let verifyRuns = 0;
+    const fn = ({ orchDir: od, ticket, phase }) => {
+      calls.push(phase);
+      const wdir = join(od, "workers", ticket);
+      mkdirSync(wdir, { recursive: true });
+      if (phase === "verify") {
+        verifyRuns += 1;
+        const risk = verifyRuns <= failCycles ? 7 : 1;
+        writeFileSync(
+          join(wdir, "verify.json"),
+          JSON.stringify({
+            regression_risk: risk,
+            findings: risk >= 5 ? [{ severity: "high", kind: "test", message: "x" }] : [],
+            tests_attempted: 1,
+            gates: {},
+            generatedAt: "2026-05-27T00:00:00Z",
+          })
+        );
+        writeFileSync(join(wdir, "phase-verify.json"), JSON.stringify({ ticket, phase, status: "done" }));
+      } else if (phase === "remediate") {
+        writeFileSync(
+          join(wdir, "phase-remediate.json"),
+          JSON.stringify({ ticket, phase, status: "done" })
+        );
+        // one completed cycle == one phase.remediate.complete.<ticket> event
+        appendToEventLog(
+          JSON.stringify({
+            ts: new Date().toISOString(),
+            attributes: { "event.name": `phase.remediate.complete.${ticket}` },
+          }) + "\n"
+        );
+      } else {
+        writeFileSync(join(wdir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, status: "done" }));
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    fn.calls = calls;
+    return fn;
+  }
+
+  const runTicks = (dispatch, n) => {
+    for (let i = 0; i < n; i += 1) {
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch,
+        writeStatus: noopWriteStatus,
+        reclaimDeadWork: () => "noop",
+      });
+    }
+  };
+
+  test("fail once → remediate → re-verify pass → review", () => {
+    writeSignal(TICKET, "implement", "done"); // seed: implement landed
+    const dispatch = cyclingDispatch(1); // verify run #1 fails, #2 passes
+    runTicks(dispatch, 6);
+
+    // The self-heal path leads: verify(fail) → remediate → verify(pass) → review.
+    // (The fake auto-completes review/pr/… too, so assert the leading sequence
+    // and the exact cycle count rather than the full tail.)
+    expect(dispatch.calls.slice(0, 4)).toEqual(["verify", "remediate", "verify", "review"]);
+    expect(dispatch.calls.filter((p) => p === "remediate").length).toBe(1); // exactly one cycle
+    expect(dispatch.calls.filter((p) => p === "verify").length).toBe(2); // initial + one re-verify
+    // Landed on review against a now-passing branch — no human needed, no stall.
+    expect(readPhaseSignals(orchDir, TICKET).review).toBe("done");
+    expect(
+      JSON.parse(readFileSync(join(orchDir, "workers", TICKET, "phase-verify.json"), "utf8")).status
+    ).toBe("done");
+  });
+
+  test("verify never passes → 3 remediations, 3rd re-verified, then stall → needs-human", () => {
+    writeSignal(TICKET, "implement", "done");
+    const dispatch = cyclingDispatch(99); // verify always fails
+    runTicks(dispatch, 12);
+
+    const remediates = dispatch.calls.filter((p) => p === "remediate").length;
+    const verifies = dispatch.calls.filter((p) => p === "verify").length;
+    expect(remediates).toBe(REMEDIATE_CYCLE_CAP); // exactly 3 remediation attempts
+    expect(verifies).toBe(REMEDIATE_CYCLE_CAP + 1); // the 3rd remediation IS re-verified
+    // Never routed to review on a failing verdict.
+    expect(dispatch.calls).not.toContain("review");
+    // Cap exhausted → verify signal stalled → terminal sweep applies needs-human.
+    const verifySig = JSON.parse(
+      readFileSync(join(orchDir, "workers", TICKET, "phase-verify.json"), "utf8")
+    );
+    expect(verifySig.status).toBe("stalled");
+    expect(verifySig.stalledReason).toBe("remediate-cycle-cap-exhausted");
+    expect(existsSync(join(orchDir, "workers", TICKET, ".linear-label-needs-human.applied"))).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -24,6 +24,8 @@ import {
   computeReadyTickets,
   selectDispatchable,
   deriveAdvancement,
+  maybeResetForRemediateCycle,
+  maybeEscalateRemediateExhausted,
   listStartedTickets,
   schedulerTick,
   readAllEligibleTickets,
@@ -38,6 +40,7 @@ import {
   __resetForTests,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
+import { REMEDIATE_CYCLE_CAP } from "../lib/phase-fsm.mjs";
 
 let orchDir;
 let catalystDir;
@@ -421,6 +424,115 @@ describe("deriveAdvancement", () => {
   });
   test("no signals → null", () => {
     expect(deriveAdvancement({})).toBeNull();
+  });
+});
+
+// ─── CTL-653: verdict + cycle routing in deriveAdvancement ───
+describe("CTL-653: deriveAdvancement verdict + cycle routing", () => {
+  const base = { triage: "done", research: "done", plan: "done", implement: "done" };
+
+  test("no opts: verify done → review (legacy default treats absent verdict as pass)", () => {
+    expect(deriveAdvancement({ ...base, verify: "done" })).toBe("review");
+  });
+  test("verdict pass → review", () => {
+    expect(deriveAdvancement({ ...base, verify: "done" }, { verifyVerdict: "pass" })).toBe("review");
+  });
+  test("verdict null → review (conservative: missing verify.json is not a regression)", () => {
+    expect(deriveAdvancement({ ...base, verify: "done" }, { verifyVerdict: null })).toBe("review");
+  });
+  test("verdict fail + cycle < cap + remediate not dispatched → remediate", () => {
+    expect(
+      deriveAdvancement({ ...base, verify: "done" }, { verifyVerdict: "fail", remediateCycleCount: 0 })
+    ).toBe("remediate");
+  });
+  test("verdict fail + remediate already dispatched this cycle → null (no double-dispatch)", () => {
+    expect(
+      deriveAdvancement(
+        { ...base, verify: "done", remediate: "running" },
+        { verifyVerdict: "fail", remediateCycleCount: 0 }
+      )
+    ).toBeNull();
+  });
+  test("verdict fail + cycle >= cap → null (escalation handled by the sweep, not a dispatch)", () => {
+    expect(
+      deriveAdvancement(
+        { ...base, verify: "done" },
+        { verifyVerdict: "fail", remediateCycleCount: REMEDIATE_CYCLE_CAP }
+      )
+    ).toBeNull();
+  });
+  test("remediate signal is invisible to the latest-phase scan (not in PHASES)", () => {
+    // a remediate `done` signal must not make remediate the 'latest' phase.
+    expect(deriveAdvancement({ ...base, verify: "done", remediate: "done" }, { verifyVerdict: "pass" })).toBe(
+      "review"
+    );
+  });
+  test("post-reset: implement done is latest → verify", () => {
+    expect(deriveAdvancement(base)).toBe("verify");
+  });
+});
+
+// ─── CTL-653: maybeResetForRemediateCycle — re-entry deletes the cycle signals ───
+describe("CTL-653: maybeResetForRemediateCycle", () => {
+  test("remediate done → deletes the 3 cycle files, keeps the rest, returns true", () => {
+    writeSignal("CTL-653", "implement", "done");
+    writeSignal("CTL-653", "verify", "done");
+    writeSignal("CTL-653", "remediate", "done");
+    const wdir = join(orchDir, "workers", "CTL-653");
+    writeFileSync(join(wdir, "verify.json"), JSON.stringify({ regression_risk: 7, findings: [] }));
+    writeFileSync(join(wdir, "triage.json"), JSON.stringify({ classification: "feature" }));
+
+    expect(maybeResetForRemediateCycle(orchDir, "CTL-653")).toBe(true);
+    expect(existsSync(join(wdir, "phase-verify.json"))).toBe(false);
+    expect(existsSync(join(wdir, "phase-remediate.json"))).toBe(false);
+    expect(existsSync(join(wdir, "verify.json"))).toBe(false);
+    // never deletes upstream signals/artifacts:
+    expect(existsSync(join(wdir, "phase-implement.json"))).toBe(true);
+    expect(existsSync(join(wdir, "triage.json"))).toBe(true);
+  });
+  test("remediate not done → no-op, returns false (cycle signals untouched)", () => {
+    writeSignal("CTL-653", "verify", "done");
+    writeSignal("CTL-653", "remediate", "running");
+    expect(maybeResetForRemediateCycle(orchDir, "CTL-653")).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-653", "phase-verify.json"))).toBe(true);
+  });
+  test("no remediate signal at all → false", () => {
+    writeSignal("CTL-653", "verify", "done");
+    expect(maybeResetForRemediateCycle(orchDir, "CTL-653")).toBe(false);
+  });
+});
+
+// ─── CTL-653: maybeEscalateRemediateExhausted — cap → stalled ───
+describe("CTL-653: maybeEscalateRemediateExhausted", () => {
+  test("verify done + fail + cycle >= cap → writes phase-verify.json status:stalled, returns true", () => {
+    writeSignal("CTL-653", "verify", "done");
+    expect(
+      maybeEscalateRemediateExhausted(orchDir, "CTL-653", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP)
+    ).toBe(true);
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", "CTL-653", "phase-verify.json"), "utf8"));
+    expect(sig.status).toBe("stalled");
+    expect(sig.stalledReason).toBe("remediate-cycle-cap-exhausted");
+  });
+  test("idempotent: file already stalled → returns true, leaves it stalled", () => {
+    const wdir = join(orchDir, "workers", "CTL-653");
+    mkdirSync(wdir, { recursive: true });
+    writeFileSync(
+      join(wdir, "phase-verify.json"),
+      JSON.stringify({ ticket: "CTL-653", phase: "verify", status: "stalled" })
+    );
+    expect(
+      maybeEscalateRemediateExhausted(orchDir, "CTL-653", { verify: "done" }, "fail", REMEDIATE_CYCLE_CAP)
+    ).toBe(true);
+    expect(JSON.parse(readFileSync(join(wdir, "phase-verify.json"), "utf8")).status).toBe("stalled");
+  });
+  test("cycle < cap → no-op false", () => {
+    expect(maybeEscalateRemediateExhausted(orchDir, "CTL-653", { verify: "done" }, "fail", 0)).toBe(false);
+  });
+  test("verdict pass → no-op false (never stalls a passing verify)", () => {
+    expect(maybeEscalateRemediateExhausted(orchDir, "CTL-653", { verify: "done" }, "pass", 99)).toBe(false);
+  });
+  test("verify not done → no-op false", () => {
+    expect(maybeEscalateRemediateExhausted(orchDir, "CTL-653", { verify: "running" }, "fail", 99)).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -299,10 +299,18 @@ const planProbe = artifactProbe("thoughts/shared/plans", {
   allOf: ["## Phase ", "Success Criteria"],
 });
 
+// CTL-653: remediateProbe — remediate is fix-capable (like implement), so its
+// work-done signal is the same: a commit landed on the ticket branch + a clean
+// tree. It reuses implementProbe's commit-state check verbatim. Registering ANY
+// probe is the real point (research §9): without it, a false-dead during
+// remediate hits CTL-587's branch-(A) "no-probe-for-phase" escalation →
+// needs-human, defeating the very autonomy CTL-653 adds.
+const remediateProbe = implementProbe;
+
 // WORK_DONE_PROBES — phase → probe. Adding a probe is the entire opt-in for a
 // phase to participate in the CTL-574 reclaim sweep. All nine pipeline phases
-// now have an entry; only a genuinely-unknown phase falls through to CTL-587's
-// branch-(A) escalation.
+// plus the ancillary remediate phase (CTL-653) have an entry; only a
+// genuinely-unknown phase falls through to CTL-587's branch-(A) escalation.
 export const WORK_DONE_PROBES = {
   implement: implementProbe,
   research: researchProbe,
@@ -313,6 +321,7 @@ export const WORK_DONE_PROBES = {
   pr: prProbe,
   "monitor-merge": monitorMergeProbe,
   "monitor-deploy": monitorDeployProbe,
+  remediate: remediateProbe,
 };
 
 // hasProbe — true when the given phase has a registered probe. Used by the

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -113,6 +113,24 @@ function verifyProbe({ ticket, orchDir } = {}, { readFile = defaultReadFile } = 
   );
 }
 
+// CTL-653: readVerifyVerdict — the verdict the advancement router branches on
+// after a verify `done`. Reuses verifyProbe's verify.json read shape. Returns:
+//   "fail" — regression_risk ≥ 5 OR any severity:"high" finding (phase-verify
+//            SKILL.md:196-208 thresholds) → router detours verify → remediate.
+//   "pass" — readable verdict below threshold with no high finding → verify → review.
+//   null   — missing/malformed/non-numeric-risk artifact. Deliberately distinct
+//            from "pass" so the router can apply the conservative non-regressing
+//            default (route to review) rather than stalling on an absent verdict.
+// Pure given the injected readFile seam; never throws (readJson swallows misses).
+export function readVerifyVerdict({ ticket, orchDir } = {}, { readFile = defaultReadFile } = {}) {
+  if (!ticket || !orchDir) return null;
+  const { ok, value } = readJson(workerArtifact(orchDir, ticket, "verify.json"), readFile);
+  if (!ok || !value || typeof value.regression_risk !== "number") return null;
+  const highFinding =
+    Array.isArray(value.findings) && value.findings.some((f) => f?.severity === "high");
+  return value.regression_risk >= 5 || highFinding ? "fail" : "pass";
+}
+
 function reviewProbe({ ticket, orchDir } = {}, { readFile = defaultReadFile } = {}) {
   if (!ticket || !orchDir) return false;
   const { ok, value } = readJson(workerArtifact(orchDir, ticket, "review.json"), readFile);

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -8,6 +8,7 @@ import {
   defaultRunGit,
   resolveWorktree,
   defaultReadFile,
+  readVerifyVerdict,
 } from "./work-done-probes.mjs";
 
 // makeRunGit — a deterministic `git` fake keyed on the trailing positional args.
@@ -169,6 +170,47 @@ describe("WORK_DONE_PROBES.verify", () => {
   });
   test("false on missing file / invalid JSON", () => {
     expect(WORK_DONE_PROBES.verify({ ticket: "CTL-1", orchDir: ORCH }, { readFile: makeReadFile({}) })).toBe(false);
+  });
+});
+
+// CTL-653: readVerifyVerdict — regression_risk + high-finding → "pass"|"fail"|null.
+// Thresholds come from phase-verify SKILL.md:196-208 (risk ≥ 5 OR any high finding).
+// null (missing/malformed) is deliberately distinct from "pass" so the router can
+// pick the conservative non-regressing default (route to review) without stalling.
+describe("CTL-653: readVerifyVerdict", () => {
+  const verdict = (json) =>
+    readVerifyVerdict(
+      { ticket: "CTL-653", orchDir: ORCH },
+      { readFile: makeReadFile({ [wpath("CTL-653", "verify.json")]: JSON.stringify(json) }) }
+    );
+
+  test("regression_risk >= 5 → fail", () => {
+    expect(verdict({ regression_risk: 5, findings: [] })).toBe("fail");
+    expect(verdict({ regression_risk: 9, findings: [] })).toBe("fail");
+  });
+  test("any severity:high finding → fail (even if risk < 5)", () => {
+    expect(verdict({ regression_risk: 2, findings: [{ severity: "low" }, { severity: "high" }] })).toBe("fail");
+  });
+  test("risk < 5 and no high finding → pass", () => {
+    expect(verdict({ regression_risk: 4, findings: [{ severity: "low" }] })).toBe("pass");
+    expect(verdict({ regression_risk: 0, findings: [] })).toBe("pass");
+  });
+  test("missing/unreadable verify.json → null (router treats null as pass: no regression)", () => {
+    expect(
+      readVerifyVerdict({ ticket: "CTL-653", orchDir: ORCH }, { readFile: makeReadFile({}) })
+    ).toBeNull();
+  });
+  test("malformed verify.json (no numeric regression_risk) → null", () => {
+    expect(verdict({ findings: [] })).toBeNull();
+    expect(verdict({ regression_risk: "high", findings: [] })).toBeNull();
+  });
+  test("no readFile call on missing input → null", () => {
+    const boom = () => {
+      throw new Error("readFile must not be called");
+    };
+    expect(readVerifyVerdict({ ticket: null, orchDir: ORCH }, { readFile: boom })).toBeNull();
+    expect(readVerifyVerdict({ ticket: "CTL-653", orchDir: null }, { readFile: boom })).toBeNull();
+    expect(readVerifyVerdict(undefined, { readFile: boom })).toBeNull();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -105,6 +105,44 @@ describe("WORK_DONE_PROBES — registry shape", () => {
       expect(hasProbe(phase)).toBe(false);
     }
   });
+  test("CTL-653: remediate is registered (no false-dead no-probe escalation)", () => {
+    expect(hasProbe("remediate")).toBe(true);
+  });
+});
+
+// CTL-653: remediateProbe — remediate is fix-capable like implement, so "done"
+// means a commit landed on the ticket branch + a clean tree. The point of
+// registering ANY probe (research §9) is that a false-dead during remediate
+// resolves via reclaim/revive rather than escalating no-probe-for-phase →
+// needs-human, which would defeat CTL-653's autonomy goal.
+describe("WORK_DONE_PROBES.remediate", () => {
+  test("true when worktree exists + commits-ahead > 0 + clean tree", () => {
+    const wt = "/wt/CTL-1";
+    const runGit = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-1", wt), stderr: "" },
+      [`-C ${wt} rev-list --count origin/main..HEAD`]: { code: 0, stdout: "3\n", stderr: "" },
+      [`-C ${wt} status --porcelain`]: { code: 0, stdout: "", stderr: "" },
+    });
+    expect(WORK_DONE_PROBES.remediate({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit })).toBe(true);
+  });
+  test("false when no commits ahead / dirty tree", () => {
+    const wt = "/wt/CTL-1";
+    const noCommits = makeRunGit({
+      "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-1", wt), stderr: "" },
+      [`-C ${wt} rev-list --count origin/main..HEAD`]: { code: 0, stdout: "0\n", stderr: "" },
+      [`-C ${wt} status --porcelain`]: { code: 0, stdout: "", stderr: "" },
+    });
+    expect(WORK_DONE_PROBES.remediate({ ticket: "CTL-1", repoRoot: "/repo" }, { runGit: noCommits })).toBe(
+      false
+    );
+  });
+  test("false on missing input (no git spawn)", () => {
+    const boom = () => {
+      throw new Error("runGit must not be called");
+    };
+    expect(WORK_DONE_PROBES.remediate({ ticket: null, repoRoot: "/repo" }, { runGit: boom })).toBe(false);
+    expect(WORK_DONE_PROBES.remediate({ ticket: "CTL-1", repoRoot: null }, { runGit: boom })).toBe(false);
+  });
 });
 
 // makeReadFile — deterministic fs fake keyed on absolute path. Returns the

--- a/plugins/dev/scripts/lib/phase-fsm.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.mjs
@@ -28,6 +28,27 @@ export const EVENT_TYPES = new Set(["complete", "failed", "turn-cap-exhausted", 
 // ─── Revive budget (CTL-531: revive once per phase; 2nd failure escalates) ───
 export const REVIVE_BUDGET = 1;
 
+// ─── CTL-653: remediate — a router-orchestrated conditional detour, NOT a linear edge ───
+// `remediate` is a fix-capable phase the scheduler's router (deriveAdvancement)
+// detours into when `verify` produces a verdict-fail, then cycles back to a
+// fresh `verify`. It is deliberately NOT a member of PHASES / NEXT_PHASE: the
+// pure FSM stays a single-successor table (the happy-path edge loop stays 9
+// phases) and the conditional cycle lives entirely in the router. It IS a
+// *known ancillary phase* so the validation/order/Linear-key helpers accept it
+// (else applyPhaseStatus({phase:"remediate"}) and recovery's supersede guard
+// would throw on an "unknown phase").
+export const REMEDIATE_PHASE = "remediate";
+export const ANCILLARY_PHASES = [REMEDIATE_PHASE];
+// Max remediation attempts before escalating to needs-human. Distinct from
+// REVIVE_BUDGET (crash-revive = 1) so a crash never consumes verdict-cycle budget.
+export const REMEDIATE_CYCLE_CAP = 3;
+
+// isKnownPhase — true for any linear pipeline phase OR a known ancillary phase
+// (remediate). Lets consumers validate a phase name without re-deriving the set.
+export function isKnownPhase(phase) {
+  return PHASES.includes(phase) || ANCILLARY_PHASES.includes(phase);
+}
+
 // ─── Transition table — the happy path (replaces phase_next()) ───
 export const NEXT_PHASE = {
   triage: "research",
@@ -61,6 +82,9 @@ export const PHASE_LINEAR_KEY = {
   pr: "inReview",
   "monitor-merge": "inReview",
   "monitor-deploy": "inReview",
+  // CTL-653: the ancillary remediate phase maps to its own stateMap key
+  // (`remediating` → "Remediate"); it is not part of the 9→5 collapse.
+  [REMEDIATE_PHASE]: "remediating",
 };
 
 // The stateMap key for the terminal success state — written when monitor-deploy completes.
@@ -88,6 +112,13 @@ export function linearKeyForPhase(phase) {
 // an unknown phase so a typo fails loudly rather than silently returning -1
 // (which would misorder before `triage`).
 export function phaseIndex(phase) {
+  // CTL-653: remediate is ancillary (not in PHASES) but the recovery supersede
+  // guard (CTL-606) orders signals by phaseIndex. It cycles with verify, so it
+  // ranks at verify's position — a remediate signal must not be treated as a
+  // dead predecessor of verify.
+  if (phase === REMEDIATE_PHASE) {
+    return PHASES.indexOf("verify");
+  }
   const idx = PHASES.indexOf(phase);
   if (idx === -1) {
     throw new PhaseFsmError(`unknown phase '${phase}'`);
@@ -101,7 +132,10 @@ function assertState(state) {
     throw new PhaseFsmError(`state must be a plain object, got ${describe(state)}`);
   }
   const known =
-    PHASES.includes(state.phase) || state.phase === PARK_STATE || TERMINAL_STATES.has(state.phase);
+    PHASES.includes(state.phase) ||
+    ANCILLARY_PHASES.includes(state.phase) || // CTL-653: remediate is a known state
+    state.phase === PARK_STATE ||
+    TERMINAL_STATES.has(state.phase);
   if (!known) {
     throw new PhaseFsmError(`unknown phase '${state.phase}'`);
   }
@@ -152,6 +186,16 @@ export function transition(state, event) {
       return { phase: state.parkedFrom, reviveCount: state.reviveCount, parkedFrom: null };
     }
     throw new PhaseFsmError(`needs-input only accepts 'resume', got '${event.type}'`);
+  }
+
+  // ─── Ancillary phase: remediate is router-orchestrated, never a linear edge ───
+  // The verify⇄remediate cycle lives in deriveAdvancement (scheduler.mjs), which
+  // keeps transition() a pure single-successor table. Calling transition() with a
+  // remediate state is a programming error — fail loud rather than fabricate an edge.
+  if (state.phase === REMEDIATE_PHASE) {
+    throw new PhaseFsmError(
+      `'remediate' is router-orchestrated (deriveAdvancement) — not a transition() edge`
+    );
   }
 
   // ─── Pipeline phase ───

--- a/plugins/dev/scripts/lib/phase-fsm.test.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.test.mjs
@@ -5,7 +5,12 @@ import { describe, test, expect } from "bun:test";
 
 import {
   PHASES,
+  NEXT_PHASE,
   REVIVE_BUDGET,
+  REMEDIATE_PHASE,
+  REMEDIATE_CYCLE_CAP,
+  ANCILLARY_PHASES,
+  isKnownPhase,
   PhaseFsmError,
   PHASE_LINEAR_KEY,
   TERMINAL_LINEAR_KEY,
@@ -301,5 +306,47 @@ describe("PHASE_LINEAR_KEY — the 9→5 collapse (CTL-558)", () => {
   });
   test("linearKeyForPhase throws PhaseFsmError on an unknown phase", () => {
     expect(() => linearKeyForPhase("bogus")).toThrow(PhaseFsmError);
+  });
+});
+
+// ─── CTL-653: remediate — a router-orchestrated conditional detour, NOT a linear edge ───
+
+describe("CTL-653: remediate ancillary phase", () => {
+  test("REMEDIATE_CYCLE_CAP is 3 and distinct from REVIVE_BUDGET (1)", () => {
+    expect(REMEDIATE_CYCLE_CAP).toBe(3);
+    expect(REMEDIATE_CYCLE_CAP).not.toBe(REVIVE_BUDGET);
+  });
+  test("remediate is NOT a member of the linear PHASES chain", () => {
+    expect(PHASES).not.toContain("remediate"); // happy-path edge loop stays 9 phases
+    expect(NEXT_PHASE).not.toHaveProperty("remediate"); // no linear successor edge
+    expect(NEXT_PHASE.verify).toBe("review"); // happy path unchanged
+  });
+  test("remediate IS a known ancillary phase", () => {
+    expect(REMEDIATE_PHASE).toBe("remediate");
+    expect(ANCILLARY_PHASES).toContain("remediate");
+    expect(isKnownPhase("remediate")).toBe(true);
+    expect(isKnownPhase("bogus")).toBe(false);
+  });
+  test("isKnownPhase accepts every linear phase too", () => {
+    for (const p of PHASES) expect(isKnownPhase(p)).toBe(true);
+  });
+  test("phaseIndex(remediate) returns verify's index (it sits at the verify position)", () => {
+    expect(phaseIndex("remediate")).toBe(phaseIndex("verify"));
+  });
+  test("linearKeyForPhase(remediate) maps to the 'remediating' stateMap key", () => {
+    expect(linearKeyForPhase("remediate")).toBe("remediating");
+    expect(PHASE_LINEAR_KEY.remediate).toBe("remediating");
+  });
+  test("transition() refuses a remediate state — routing is router-owned, not a linear edge", () => {
+    expect(() =>
+      transition({ phase: "remediate", reviveCount: 0, parkedFrom: null }, { type: "complete" })
+    ).toThrow(PhaseFsmError);
+  });
+  test("a needs-input parked FROM remediate is rejected (remediate is not a pipeline park source)", () => {
+    // parkedFrom must be a *pipeline* phase; remediate is ancillary, so resuming
+    // into it would re-enter a non-linear edge — keep the park contract pipeline-only.
+    expect(() =>
+      transition({ phase: "needs-input", reviveCount: 0, parkedFrom: "remediate" }, { type: "resume" })
+    ).toThrow(PhaseFsmError);
   });
 });

--- a/plugins/dev/scripts/linear-transition.sh
+++ b/plugins/dev/scripts/linear-transition.sh
@@ -41,6 +41,7 @@ default_state_for() {
     inProgress)  echo "In Progress" ;;
     verifying)   echo "In Progress" ;;
     reviewing)   echo "In Progress" ;;
+    remediating) echo "In Progress" ;;  # CTL-653: fallback when no stateMap "remediating" key
     inReview)    echo "In Review" ;;
     done)        echo "Done" ;;
     canceled)    echo "Canceled" ;;

--- a/plugins/dev/scripts/orchestrate-phase-advance
+++ b/plugins/dev/scripts/orchestrate-phase-advance
@@ -106,6 +106,7 @@ linear_key_for_phase() {
     implement)                       echo "inProgress" ;;
     verify)                          echo "verifying" ;;
     review)                          echo "reviewing" ;;
+    remediate)                       echo "remediating" ;;  # CTL-653: ancillary phase, no phase_next edge
     pr|monitor-merge|monitor-deploy) echo "inReview" ;;
     *)                               echo "" ;;  # triage / unknown — no write
   esac

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -76,6 +76,7 @@ phase_default_turn_cap() {
 	pr) echo 12 ;;
 	monitor-merge) echo 50 ;;
 	monitor-deploy) echo 30 ;;
+	remediate) echo 40 ;; # CTL-653: fix-scoped — smaller than implement's 75
 	*) echo "$DEFAULT_TURN_CAP" ;;
 	esac
 }
@@ -96,6 +97,7 @@ prior_artifact_for_phase() {
 	pr) echo "signal:review.json" ;;
 	monitor-merge) echo "signal:phase-pr.json" ;;
 	monitor-deploy) echo "signal:phase-monitor-merge.json" ;;
+	remediate) echo "signal:verify.json" ;; # CTL-653: reads verify's findings[], NOT review.json
 	*) echo "" ;;
 	esac
 }

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -43,6 +43,7 @@ build_execution_core_state_map() {
     inProgress: "Implement",
     verifying: "Validate",
     reviewing: "Validate",
+    remediating: "Remediate",
     inReview: "PR",
     done: "Done",
     canceled: "Canceled"

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -1,0 +1,443 @@
+---
+name: phase-remediate
+description: |
+  Phase-agent that fixes a failing verify verdict so the pipeline self-heals
+  instead of stalling to needs-human (CTL-653). Reads
+  `${ORCH_DIR}/workers/<ticket>/verify.json`, fixes the `findings[]` (every
+  severity:"high" plus the regression_risk drivers) directly via Edit/Write,
+  commits the remediation, and emits `phase.remediate.complete.<ticket>`. The
+  scheduler's router then re-dispatches `verify` to re-check (the verify⇄remediate
+  cycle, cap 3). Dispatched as a `claude --bg` job by `phase-agent-dispatch`,
+  which invokes it via slash command — hence `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Task
+---
+
+# phase-remediate
+
+Phase-agent that owns the **fix** half of the verify⇄remediate cycle (CTL-653).
+Today a failing `verify` is a dead-end: the router marches into `review` against
+a known-bad branch, or a verify crash revives once then stalls to needs-human.
+`phase-remediate` is the conditional detour the router takes when `verify`
+produces a verdict-fail (`regression_risk ≥ 5` OR any `severity:"high"`
+finding): it reads `verify.json.findings[]` as its brief, fixes the code,
+commits, and hands back to a fresh `verify`. The loop repeats up to 3 times
+before escalating — so a verify failure self-heals autonomously.
+
+Unlike `phase-implement` (a thin wrapper around `/catalyst-dev:implement-plan`),
+there is **no canonical "fix-findings" skill** to delegate to — the fix work
+lives in this skill body. It is otherwise the same fix-capable envelope
+(Edit/Write/Task, CTL-615 yield check, CTL-632 Linear mirror, terminal emit).
+
+## Prerequisites
+
+- `CATALYST_ORCHESTRATOR_DIR`, `CATALYST_ORCHESTRATOR_ID`, `CATALYST_PHASE=remediate`, `CATALYST_TICKET` set by [[phase-agent-dispatch]].
+- A `verify.json` exists at `${ORCH_DIR}/workers/<ticket>/verify.json` — the dispatcher's prior-artifact gate (`signal:verify.json`) already validates this; this skill re-reads it.
+- Current working directory is the ticket's worktree (already carries the implement-phase commits).
+
+## Prelude (template — copy verbatim into the running session)
+
+```bash
+set -euo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required (set by phase-agent-dispatch)}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="${ORCH_ID}"
+
+# CTL-484: continuation-worker orientation. Set by orchestrate-revive's
+# continuation branch when this skill is resumed via `claude --bg --resume`
+# after a previous session hit its /goal turn cap. Read the handoff doc and
+# trust its summary instead of re-deriving the fix set from scratch.
+if [[ "${CATALYST_IS_CONTINUATION:-}" == "true" ]]; then
+  CONT_HANDOFF="${CATALYST_HANDOFF_PATH:-}"
+  CONT_N="${CATALYST_CONTINUATION_COUNT:-?}"
+  if [[ -n "$CONT_HANDOFF" && -f "$CONT_HANDOFF" ]]; then
+    echo "phase-remediate: continuation #${CONT_N} — resuming from ${CONT_HANDOFF}"
+    echo "phase-remediate: reading handoff (do NOT re-derive the fix set from scratch)"
+    cat "$CONT_HANDOFF"
+  else
+    echo "warn: CATALYST_IS_CONTINUATION=true but handoff path missing or unreadable" >&2
+  fi
+fi
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+
+# 0. Codified bg_job_id yield (CTL-615). If the signal file's bg_job_id names a
+#    DIFFERENT live bg job, we are a redispatch duplicate of a still-running
+#    canonical worker. Bow out without touching the signal, without emitting any
+#    phase event. Encodes operator memories #43/#44/#49/#50. phase-remediate
+#    commits code (like implement), so it carries the gate.
+YIELD_CHECK="${PLUGIN_ROOT}/scripts/phase-agent-yield-check.sh"
+if [[ -x "$YIELD_CHECK" ]] && bash "$YIELD_CHECK" \
+     --signal "$SIGNAL_FILE" \
+     --phase "$PHASE" \
+     --worker-dir "$(dirname "$SIGNAL_FILE")"; then
+  echo "phase-${PHASE}: yielding to canonical worker (CTL-615)" >&2
+  exit 0
+fi
+
+# 1. Join the shared comms channel (best-effort).
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" && -x "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-remediate: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-remediate started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+# 2. Start a catalyst-session for cost/token instrumentation.
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-remediate" \
+    --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+# 3. Mark the signal file as running + persist catalystSessionId (CTL-496:
+#    orchestrate-roll-usage --phase reads this to attribute cost).
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+
+# CTL-587: test-kill after-prelude. Exits AFTER the signal is flipped to running
+# but BEFORE any commit work, so reclaimDeadWorkIfPossible's remediate-probe
+# returns false on the next staleness tick and the revive path engages. Mode
+# suffix `${PHASE}:after-prelude` keeps the env var phase-agnostic.
+if [[ "${CATALYST_TEST_KILL_PHASE:-}" == "${PHASE}:after-prelude" ]]; then
+  echo "[CTL-587 test-kill] aborting after prelude" >&2
+  exit 137
+fi
+
+# 4. Locate verify.json — the fix brief. The dispatcher already gated on its
+#    existence; we re-read to extract the findings + regression_risk.
+VERIFY_ARTIFACT="${ORCH_DIR}/workers/${TICKET}/verify.json"
+[[ -f "$VERIFY_ARTIFACT" ]] || { echo "phase-remediate: verify.json missing for ${TICKET}" >&2; exit 1; }
+REGRESSION_RISK="$(jq -r '.regression_risk // 0' "$VERIFY_ARTIFACT")"
+HIGH_COUNT="$(jq -r '[.findings[]? | select(.severity == "high")] | length' "$VERIFY_ARTIFACT")"
+echo "phase-remediate: verify.json = ${VERIFY_ARTIFACT} (regression_risk=${REGRESSION_RISK}, high findings=${HIGH_COUNT})"
+jq -r '.findings[]? | "- [\(.severity)] \(.kind) \(.file // "?"):\(.line // "?") — \(.message)\n    fix: \(.recommendation // "(none)")"' "$VERIFY_ARTIFACT" || true
+
+# 5. Linear status is written by the coordinator (CTL-558): the execution-core
+#    scheduler applies the `remediating` → Remediate state when it dispatches
+#    this phase. The phase agent no longer transitions Linear itself.
+```
+
+## /goal condition
+
+Transcript-evaluable so a `/goal` evaluator (which only sees Claude's text
+output, not the filesystem) can decide pass/fail from what the agent prints.
+
+```
+/goal "I have read verify.json's findings[] and addressed every severity:high
+       finding (plus the lower-severity regression_risk drivers I can fix
+       deterministically), committed the remediation so `git diff <base>..HEAD`
+       includes my new fix commit, and printed the commit subject + a targeted
+       gate (tsc/test/lint on the touched files) showing `exit 0` to my
+       transcript. The router re-dispatches `verify` to re-check the whole
+       diff (CTL-653) — I do NOT re-run the full verify suite myself.
+       (Linear status is written by the coordinator — CTL-558 — not this agent.)
+       OR I am within ~5 turns of the 40-turn cap, in which case I have
+       (a) written a structured handoff to
+           thoughts/shared/handoffs/${TICKET}/<ts>_turn-cap-continuation.md
+           using the bash template in the 'Failure handling' section,
+       (b) called phase-agent-emit-complete --status turn-cap-exhausted
+           --handoff-path <the file> --reason 'turn cap hit (N)', and
+       (c) exited 0 (cleanly — the orchestrator dispatches a continuation
+           worker on a separate budget)."
+```
+
+Turn cap defaults to 40 (from `phase-agent-dispatch:phase_default_turn_cap`) and
+is overridable via `.catalyst/config.json:catalyst.orchestration.phaseAgents.turnCaps.remediate`.
+
+**CTL-484 parity:** impending cap exhaustion takes the second `/goal` branch —
+write a handoff, emit `phase.remediate.turn-cap-exhausted.<TICKET>`, exit 0.
+`orchestrate-revive` dispatches a continuation worker on a separate budget.
+
+## Phase-specific work
+
+Remediate is **fix-capable** and reads `verify.json.findings[]` as its brief.
+There is no canonical wrapper — do the fix work here:
+
+1. **Triage the findings.** Order by severity (every `severity:"high"` is
+   must-fix) and by `kind` (`type` / `test` / `lint` / `security` /
+   `reward-hacking` are deterministic; `review` / `coverage` / `silent-failure`
+   may need judgment). Each finding carries `file`, `line`, `message`, and a
+   `recommendation` — that recommendation is what `phase-verify` asks for.
+
+2. **Apply the fixes** via Edit/Write directly on the named files. Stay scoped
+   to what the findings call out — phase-remediate is a fix pass, not a redesign.
+   If a finding is a false positive or already addressed on HEAD, note it in the
+   transcript and skip it (do not fabricate a change to satisfy it).
+
+3. **Re-run the targeted gates** for the files you touched (the project's tsc /
+   test / lint, e.g. via `/catalyst-dev:validate-type-safety` scoped to the
+   diff). Print the command and its `exit 0` to the transcript so `/goal` has
+   signal. You do NOT need to re-run the full eight-gate verify suite — that is
+   the next `verify` pass's job (the router cycles back to it).
+
+4. **Commit the remediation** as a discrete commit, e.g.
+   `fix(<scope>): ${TICKET} remediate verify findings (regression_risk N)`.
+   The empty-branch gate below refuses to emit complete on a branch with zero
+   commits ahead of the integration base.
+
+> **Why remediate always emits `complete` (not `failed`) on a normal run.**
+> Mirroring `phase-verify`'s always-`complete` semantics: the *verdict* lives in
+> the re-run `verify.json`, not in this phase's status. The router re-verifies
+> after every remediation and the cycle counter (cap 3) owns escalation — so a
+> remediation that did not fully fix the issue is caught by the next `verify`,
+> not by emitting `failed` here. `--status failed` is reserved for remediation
+> *itself* breaking (the failure-handling block below).
+
+## End block (terminal emit — copy verbatim)
+
+Mirror the phase output to Linear as a single comment (CTL-632). Re-derives the
+commit list at end-block time, falling back to `_base branch unknown_` if
+neither `origin/main` nor `main` exists. Fail-open and idempotent via the
+per-phase marker file. Uniquely-named fence so the e2e test can extract just
+this block.
+
+```bash phase-remediate-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  BASE_REF=""
+  if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    BASE_REF="origin/main"
+  elif git rev-parse --verify --quiet main >/dev/null 2>&1; then
+    BASE_REF="main"
+  fi
+  BASE_SHA=""
+  if [[ -n "${BASE_REF}" ]]; then
+    BASE_SHA="$(git merge-base HEAD "${BASE_REF}" 2>/dev/null || true)"
+  fi
+  if [[ -n "${BASE_SHA}" ]]; then
+    COMMIT_LIST="$(git log --no-merges --oneline "${BASE_SHA}..HEAD" 2>/dev/null | sed 's/^/- /')"
+    COMMIT_COUNT="$(printf '%s\n' "${COMMIT_LIST}" | grep -c '^- ' || true)"
+    : "${COMMIT_COUNT:=0}"
+    DIFF_STAT="$(git diff --stat "${BASE_SHA}..HEAD" 2>/dev/null | tail -1)"
+  else
+    COMMIT_LIST="_base branch unknown_"
+    COMMIT_COUNT="?"
+    DIFF_STAT="_unavailable_"
+  fi
+  BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "${TICKET}")"
+  REGRESSION_RISK="$(jq -r '.regression_risk // "?"' "${ORCH_DIR}/workers/${TICKET}/verify.json" 2>/dev/null || echo "?")"
+  MIRROR_BODY="$(cat <<EOF
+**Phase Remediate**
+
+- **Branch**: \`${BRANCH_NAME}\`
+- **Commits**: ${COMMIT_COUNT}
+- **Diff**: ${DIFF_STAT}
+- **Acted on verify.json regression_risk**: ${REGRESSION_RISK}
+
+<details>
+<summary>Commit list</summary>
+
+${COMMIT_LIST}
+
+</details>
+
+_Posted automatically by phase-remediate (CTL-653 / CTL-632). The router
+re-dispatches verify to re-check; the verify⇄remediate cycle caps at 3._
+EOF
+)"
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-remediate: linearis discuss failed (continuing)" >&2
+  fi
+fi
+```
+
+Then the empty-branch self-emit gate (CTL-608). Runs **before** the terminal
+`--status complete` so a worker cannot self-report remediate success on an empty
+ticket branch (0 commits ahead of its integration base). Uses only POSIX/zsh-safe
+`git rev-list --count`. Fail-open (warn + allow) only when the base is
+unresolvable. Uniquely-named fence so the e2e harness can extract+exercise it.
+
+```bash phase-remediate-empty-branch-gate
+EMPTY_BRANCH_GATE_BASE=""
+if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  EMPTY_BRANCH_GATE_BASE="origin/main"
+elif git rev-parse --verify --quiet main >/dev/null 2>&1; then
+  EMPTY_BRANCH_GATE_BASE="main"
+fi
+if [[ -n "${EMPTY_BRANCH_GATE_BASE}" ]]; then
+  AHEAD="$(git rev-list --count "${EMPTY_BRANCH_GATE_BASE}..HEAD" 2>/dev/null || echo 0)"
+  if [[ "${AHEAD:-0}" -le 0 ]]; then
+    echo "phase-remediate: 0 commits ahead of ${EMPTY_BRANCH_GATE_BASE}; refusing to emit complete on an empty branch (CTL-608)" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "empty_branch:0_commits_ahead_of_${EMPTY_BRANCH_GATE_BASE}"
+    [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+      "phase-remediate failed: empty branch (0 commits ahead of ${EMPTY_BRANCH_GATE_BASE})" \
+      --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+else
+  echo "phase-remediate: could not resolve integration base (no origin/main or main); skipping empty-branch gate (CTL-608)" >&2
+fi
+```
+
+```bash
+EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+if [[ -x "$EMIT" ]]; then
+  # No --reason on success: phase-agent-emit-complete stamps --reason into
+  # .failureReason even on --status complete (operator memory).
+  "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status complete
+fi
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+Two failure modes — turn-cap exhaustion (recoverable via continuation) and hard
+error (caller-supplied reason). The branch is determined by the reason string:
+anything starting with `turn cap hit` takes the CTL-484 continuation path;
+everything else takes the hard-error path.
+
+```bash
+REASON="${1:-remediation failed}"  # caller-supplied short string
+
+# ── CTL-484: turn-cap branch — write handoff, emit turn-cap-exhausted, exit 0.
+if [[ "$REASON" =~ ^turn\ cap\ hit ]]; then
+  TS_HO=$(date -u +%Y-%m-%d_%H-%M-%S)
+  HANDOFF_DIR="thoughts/shared/handoffs/${TICKET}"
+  HANDOFF_FILE="${HANDOFF_DIR}/${TS_HO}_turn-cap-continuation.md"
+  mkdir -p "$HANDOFF_DIR"
+
+  GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "")
+  BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+  BASE_REF=$(git merge-base HEAD main 2>/dev/null || echo HEAD)
+  DIFF_STAT=$(git diff --stat "${BASE_REF}..HEAD" 2>/dev/null || echo "")
+  CONT_N="${CATALYST_CONTINUATION_COUNT:-1}"
+
+  cat > "$HANDOFF_FILE" <<EOF
+---
+date: $(date -u +%Y-%m-%d)
+researcher: phase-remediate
+git_commit: ${GIT_COMMIT}
+branch: ${BRANCH}
+topic: "Continuation handoff for ${TICKET} (remediate turn cap hit)"
+status: in-progress
+type: handoff
+source_ticket: ${TICKET}
+source_artifact: ${VERIFY_ARTIFACT:-unknown}
+---
+
+# ${TICKET} — remediate turn-cap continuation handoff
+
+## Task(s)
+
+Fix the verify findings in \`${VERIFY_ARTIFACT:-the worker's verify.json}\`.
+The previous session reached its 40-turn cap before finishing. The continuation
+worker should resume from the first unaddressed finding and commit the rest.
+
+## Recent changes (this session)
+
+\`\`\`
+${DIFF_STAT}
+\`\`\`
+
+Last commit: \`${GIT_COMMIT}\`
+Branch: \`${BRANCH}\`
+
+## Action Items & Next Steps
+
+1. You are reading this handoff via \`CATALYST_HANDOFF_PATH\` — the Prelude
+   block has already cat'd it to the transcript.
+2. Re-read verify.json's findings[]; cross-check against \`git log --oneline
+   ${BASE_REF}..HEAD\`. **Do NOT redo committed fixes.**
+3. Address the remaining high-severity / regression_risk findings, commit.
+4. On completion, call \`phase-agent-emit-complete --status complete\`
+   (terminal). The router re-dispatches verify to re-check.
+5. If you also hit the cap, write a fresh continuation handoff here and emit
+   \`--status turn-cap-exhausted\` again. Budget is 3 continuations per phase.
+
+## Other Notes
+
+- Catalyst session: ${CATALYST_SESSION_ID:-unknown}
+- Continuation count: ${CONT_N}
+- verify.json: ${VERIFY_ARTIFACT:-unknown}
+EOF
+
+  "$EMIT" --phase "$PHASE" --ticket "$TICKET" \
+    --status turn-cap-exhausted \
+    --reason "$REASON" \
+    --handoff-path "$HANDOFF_FILE"
+
+  [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+    "phase-remediate turn-cap-exhausted; handoff: ${HANDOFF_FILE}" \
+    --as "$TICKET" --type info --orch "$ORCH_ID" >/dev/null 2>&1 || true
+  exit 0
+fi
+
+# ── Hard-error branch: emit failed + attention, exit non-zero. A `failed`
+#    event lets the FSM revive remediate once (REVIVE_BUDGET) before stalling —
+#    distinct from the verdict-cycle cap, which counts `complete` events.
+"$EMIT" --phase "$PHASE" --ticket "$TICKET" --status failed --reason "$REASON"
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-remediate failed: ${REASON}" \
+  --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```
+
+The orchestrator receives `phase.remediate.complete.${TICKET}` and the
+scheduler's router (`deriveAdvancement` + `maybeResetForRemediateCycle`,
+CTL-653) deletes the verify+remediate cycle signals and re-dispatches a fresh
+`verify`. `countRemediateCycles` counts this `complete` event toward the cap of
+3; the 3rd remediation is still re-verified, and only a verify verdict-fail
+*after* the budget is spent escalates to `stalled` → `needs-human` (the sole
+human entry).
+
+## Comms discipline
+
+Inherits the contract from [[_phase-agent-template]]:
+
+| Type        | When                                                                                  |
+|-------------|--------------------------------------------------------------------------------------|
+| `info`      | At start; once after the fix pass commits; once on turn-cap handoff write (CTL-484). |
+| `attention` | Missing verify.json, unfixable findings, hard error. (Turn cap is NOT an attention event.) |
+| `question`  | A finding the agent cannot resolve unilaterally.                                      |
+| `done`      | Emitted by `phase-agent-emit-complete` on success.                                   |
+
+Read inbound `directive` / `pause` / `abort` after each fix round — the
+orchestrator may abort the worker while remediation is in flight.
+
+## Why remediate is a phase, not a `verify` branch
+
+CTL-653 keeps the pure FSM (`transition()` in `lib/phase-fsm.mjs`) a single-
+successor table — `verify → review` stays the happy-path edge so the FSM's edge
+tests are untouched. `remediate` is a **router-orchestrated conditional detour**
+(`deriveAdvancement` reads the verify verdict and branches), not a linear FSM
+edge. This skill is the worker that detour dispatches. It is designed reusably
+(any fix-capable phase could mirror it), but only the verify⇄remediate edge is
+wired today. See `thoughts/shared/plans/2026-05-27-ctl-653.md` for the full
+design.


### PR DESCRIPTION
## Summary
Adds a `remediate` ancillary FSM phase so a failed `verify` can route to a fix-capable phase-remediate worker and loop back through verify, bounded at 3 cycles before escalating to needs-human.

- Phases 1–3: `remediate` as a known FSM phase + verdict reader / cycle counter (pure helpers) + verdict+cycle-aware router with sweep reset/escalation.
- Phases 4–6: dispatch + work-done-probe wiring; Linear stateMap gains `remediating → Remediate`; the `phase-remediate` fix-capable skill.
- Phase 7: end-to-end verify⇄remediate cycle test through `schedulerTick` + docs.

## Test plan
- [x] `bun test` execution-core + phase-fsm: 959 pass / 0 fail
- [x] Rebased onto origin/main (post-CTL-655), no conflicts