### PR TITLE
CTL-657: stop leaking bg workers — claude agents as liveness/termination/concurrency source of truth

### DIFF
--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -1,0 +1,90 @@
+// claude-agents.mjs — `claude agents --json` as the single source of truth for
+// background-worker liveness, termination, and concurrency (CTL-657).
+//
+// Pre-CTL-657 the recovery/reaper paths read ~/.claude/jobs/<id>/pid to decide
+// liveness and to SIGKILL a worker — but that pid file exists for 0/981 job
+// dirs on Claude Code 2.1.152 (spare-pool model, no per-job pid file). Every
+// pid-based primitive was therefore dead code: the keep-alive guard always read
+// "dead" (the 79-event false-dead revive storm) and the defensive kill always
+// no-op'd. Meanwhile `claude agents --json` reports the real live sessions
+// (.sessionId, .status, .kind) and `claude stop <shortId>` actually deregisters
+// one. This module centralizes both so recovery, the reaper, and the scheduler
+// share ONE liveness / termination / concurrency primitive.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { shortIdFromSessionId } from "./claude-ids.mjs";
+
+const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
+
+// listClaudeAgents — the parsed `claude agents --json` array, or [] on any
+// failure (binary missing, non-JSON output, non-array). Never throws.
+export function listClaudeAgents({ exec = execFileSync } = {}) {
+  try {
+    const out = exec(CLAUDE_BIN, ["agents", "--json"], { encoding: "utf8" });
+    const parsed = JSON.parse(out);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+// agentForShortId — the agent record whose sessionId truncates to `shortId`, or
+// null. `shortId` must already be the 8-char form.
+export function agentForShortId(shortId, agents) {
+  if (!shortId || !Array.isArray(agents)) return null;
+  return (
+    agents.find((a) => {
+      try {
+        return shortIdFromSessionId(a?.sessionId) === shortId;
+      } catch {
+        return false;
+      }
+    }) ?? null
+  );
+}
+
+// isBgJobAlive — true iff a live `claude agents` session matches bgJobId. This
+// replaces the pid-file keep-alive check: a crashed worker disappears from
+// `claude agents`, whereas a live one (busy OR idle between turns) is still
+// listed. Best-effort — a malformed id or a failed `claude agents` read returns
+// false so the caller falls through to its existing revive path. A non-short-id
+// (e.g. the "bg-9" test fixture) short-circuits to false WITHOUT shelling out,
+// keeping the pre-CTL-657 revive tests deterministic.
+export function isBgJobAlive(bgJobId, { exec, agents } = {}) {
+  if (!bgJobId) return false;
+  let shortId;
+  try {
+    shortId = shortIdFromSessionId(bgJobId);
+  } catch {
+    return false;
+  }
+  const list = agents ?? listClaudeAgents({ exec });
+  return agentForShortId(shortId, list) !== null;
+}
+
+// countBackgroundAgents — number of live sessions with kind === "background".
+// The scheduler's concurrency gate: interactive (human) sessions are unlimited
+// and MUST NOT count against maxParallel, so only `background` agents are
+// tallied. An absent/unknown kind is NOT counted as background (fail-low so a
+// kind-reporting quirk can never inflate the in-flight count and starve
+// dispatch).
+export function countBackgroundAgents({ exec, agents } = {}) {
+  const list = agents ?? listClaudeAgents({ exec });
+  return list.filter((a) => a?.kind === "background").length;
+}
+
+// claudeStop — `claude stop <shortId>`. shortId MUST be the 8-char form
+// (`claude stop` rejects full UUIDs with rc=1). Returns {ok, error?}; never
+// throws.
+export function claudeStop(shortId, { spawn = spawnSync } = {}) {
+  try {
+    const res = spawn(CLAUDE_BIN, ["stop", shortId], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if ((res.status ?? 0) === 0) return { ok: true };
+    return { ok: false, error: res.stderr?.trim() || `claude stop rc=${res.status}` };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}

--- a/plugins/dev/scripts/execution-core/claude-agents.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.test.mjs
@@ -1,0 +1,122 @@
+// claude-agents.test.mjs — CTL-657. `claude agents --json` is the single source
+// of truth for bg-worker liveness, termination, and concurrency. These tests
+// exercise the pure logic against injected payloads (the `exec`/`agents`/`spawn`
+// seams) so nothing shells out to the real `claude`.
+
+import { describe, test, expect } from "bun:test";
+import {
+  listClaudeAgents,
+  agentForShortId,
+  isBgJobAlive,
+  countBackgroundAgents,
+  claudeStop,
+} from "./claude-agents.mjs";
+
+const agents = [
+  { sessionId: "11111111-aaaa-bbbb-cccc-000000000001", status: "busy", kind: "background" },
+  { sessionId: "22222222-aaaa-bbbb-cccc-000000000002", status: "idle", kind: "background" },
+  { sessionId: "33333333-aaaa-bbbb-cccc-000000000003", status: "busy", kind: "interactive" },
+];
+
+describe("listClaudeAgents", () => {
+  test("parses the JSON array from exec", () => {
+    expect(listClaudeAgents({ exec: () => JSON.stringify(agents) })).toHaveLength(3);
+  });
+
+  test("returns [] on a throwing exec (binary missing)", () => {
+    const exec = () => {
+      throw new Error("claude: command not found");
+    };
+    expect(listClaudeAgents({ exec })).toEqual([]);
+  });
+
+  test("returns [] on non-JSON output", () => {
+    expect(listClaudeAgents({ exec: () => "not json" })).toEqual([]);
+  });
+
+  test("returns [] when the parsed value is not an array", () => {
+    expect(listClaudeAgents({ exec: () => JSON.stringify({ not: "an array" }) })).toEqual([]);
+  });
+});
+
+describe("agentForShortId", () => {
+  test("finds the matching session by 8-char prefix", () => {
+    expect(agentForShortId("22222222", agents)?.status).toBe("idle");
+  });
+
+  test("null when no session matches or inputs are malformed", () => {
+    expect(agentForShortId("deadbeef", agents)).toBeNull();
+    expect(agentForShortId("", agents)).toBeNull();
+    expect(agentForShortId("11111111", null)).toBeNull();
+  });
+});
+
+describe("isBgJobAlive", () => {
+  test("true for a busy matching session", () => {
+    expect(isBgJobAlive("11111111", { agents })).toBe(true);
+  });
+
+  test("true for an idle-between-turns session (still listed = alive)", () => {
+    expect(isBgJobAlive("22222222", { agents })).toBe(true);
+  });
+
+  test("false when no session matches (crashed → dropped off the list)", () => {
+    expect(isBgJobAlive("deadbeef", { agents })).toBe(false);
+  });
+
+  test("false for a falsy or malformed id, without consulting agents", () => {
+    expect(isBgJobAlive(null, { agents })).toBe(false);
+    expect(isBgJobAlive("bg-9", { agents })).toBe(false);
+  });
+
+  test("accepts the full UUID form (truncates to the short id)", () => {
+    expect(isBgJobAlive("11111111-aaaa-bbbb-cccc-000000000001", { agents })).toBe(true);
+  });
+
+  test("falls back to listing agents when no list is injected", () => {
+    expect(isBgJobAlive("22222222", { exec: () => JSON.stringify(agents) })).toBe(true);
+  });
+});
+
+describe("countBackgroundAgents", () => {
+  test("counts only kind==='background' (interactive sessions are excluded)", () => {
+    expect(countBackgroundAgents({ agents })).toBe(2);
+  });
+
+  test("does NOT count an absent/unknown kind (fail-low so it can't starve dispatch)", () => {
+    const mixed = [
+      { sessionId: "aaaaaaaa-0000-0000-0000-000000000000", kind: "background" },
+      { sessionId: "bbbbbbbb-0000-0000-0000-000000000000" }, // no kind
+      { sessionId: "cccccccc-0000-0000-0000-000000000000", kind: "interactive" },
+    ];
+    expect(countBackgroundAgents({ agents: mixed })).toBe(1);
+  });
+
+  test("0 for an empty fleet", () => {
+    expect(countBackgroundAgents({ agents: [] })).toBe(0);
+  });
+});
+
+describe("claudeStop", () => {
+  test("issues `claude stop <shortId>` and reports ok on rc 0", () => {
+    const calls = [];
+    const spawn = (bin, args) => {
+      calls.push({ bin, args });
+      return { status: 0 };
+    };
+    expect(claudeStop("12345678", { spawn })).toEqual({ ok: true });
+    expect(calls[0].args).toEqual(["stop", "12345678"]);
+  });
+
+  test("reports {ok:false} with stderr on a non-zero rc", () => {
+    const spawn = () => ({ status: 1, stderr: "no such session\n" });
+    expect(claudeStop("12345678", { spawn })).toEqual({ ok: false, error: "no such session" });
+  });
+
+  test("never throws — a throwing spawn becomes {ok:false}", () => {
+    const spawn = () => {
+      throw new Error("spawn EACCES");
+    };
+    expect(claudeStop("12345678", { spawn }).ok).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -144,13 +144,17 @@ export class Reaper {
       this.log.info({ bgJobId }, "reaper: skipping interactive session");
       return;
     }
-    // TODO(CTL-619): replace status==="idle" check with pidAlive+state.json
-    // freshness once CTL-619's primitive lands. Conservative until then —
-    // we never reap a session reporting `active`.
-    if (target.status !== "idle") {
-      this.log.info({ bgJobId, status: target.status }, "reaper: skipping non-idle session");
-      return;
-    }
+    // CTL-657: NO idle gate here. A single-target intent (yield/predecessor/
+    // supersede/revive/abort) is authoritative — the producer already decided
+    // this specific bg worker must die. A phase worker is almost always still
+    // `busy` finishing its last turn at the moment its successor's dispatch
+    // emits the predecessor reap, so the pre-CTL-657 `status !== "idle"` skip
+    // dropped the stop and never retried (the de-dupe at :93 consumes the event
+    // once) — the worker went idle seconds later and lingered forever (0
+    // reap-complete events ever; 35-session/28GB pileup). `claude stop` works
+    // on a busy session, so stop it regardless of busy/idle. The idle gate
+    // survives ONLY on the periodic orphan sweep + worktree presweep, which
+    // enumerate ALL sessions and so must stay conservative.
 
     let shortId;
     try {

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -47,8 +47,14 @@ describe("Reaper._handleBgReap", () => {
     expect(executor).not.toHaveBeenCalled();
   });
 
-  it("skips active sessions (await CTL-619 liveness gate)", async () => {
-    const executor = mock();
+  it("stops a busy/active session for an authoritative single-target intent (CTL-657)", async () => {
+    // CTL-657: an authoritative intent (yield/predecessor/supersede/revive/abort)
+    // is NOT idle-gated — a phase worker is almost always still busy finishing
+    // its last turn when its reap is requested, and the producer already decided
+    // it must die. Pre-CTL-657 the idle gate dropped the stop and never retried,
+    // so the worker lingered forever (the 28GB pileup). `claude stop` works on a
+    // busy session, so the executor MUST be invoked.
+    const executor = mock(() => Promise.resolve({ ok: true }));
     const r = new Reaper({
       executorReap: executor,
       agents: agentsFixture([
@@ -58,7 +64,7 @@ describe("Reaper._handleBgReap", () => {
       log: silentLog(),
     });
     await r.handle({ event: "phase.yield.reap-requested", bg_job_id: "abc12345" });
-    expect(executor).not.toHaveBeenCalled();
+    expect(executor).toHaveBeenCalledTimes(1);
   });
 
   it("never reaps the controlling session", async () => {

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -29,6 +29,8 @@ import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-read
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
+import { isBgJobAlive, claudeStop } from "./claude-agents.mjs";
+import { shortIdFromSessionId } from "./claude-ids.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { WORK_DONE_PROBES, hasProbe } from "./work-done-probes.mjs";
 import { defaultDispatch } from "./dispatch.mjs";
@@ -388,72 +390,45 @@ function defaultApplyStalledLabel({ orchDir, ticket }) {
   return labelOnce(orchDir, ticket, "needs-human", { applyLabel: defaultApplyLabel });
 }
 
-// defaultKillBgJob — best-effort `kill -9` of a lingering bg pid. Gated by the
-// caller on KILL_RECENT_ACTIVITY_MS so we never SIGKILL a worker whose
-// state.json was touched recently. The bg-job pid lives in
-// ~/.claude/jobs/<id>/pid (Claude Code job-state convention); a missing pid
-// file is the normal case for a reaped job. We verify the pid still maps to a
-// `claude` process before signalling to defensively avoid SIGKILL'ing a
-// recycled pid (~5+ minutes after the worker exited the PID space is fair
-// game for unrelated processes).
-//
-// `spawn` and `jobsRoot` are injectable for tests; production defaults call
-// the real spawnSync against the real ~/.claude/jobs.
-export function defaultKillBgJob(
-  { bgJobId },
-  { spawn = spawnSync, jobsRoot = getJobsRoot } = {},
-) {
+// defaultKillBgJob — terminate a dead/abandoned bg worker (CTL-657). Pre-CTL-657
+// this SIGKILL'd a pid read from ~/.claude/jobs/<id>/pid — a guaranteed no-op on
+// Claude Code 2.1.152 (no per-job pid file, so `existsSync(pidPath)` was always
+// false). Now it issues `claude stop <shortId>`, the primitive that actually
+// deregisters the session and frees its RAM. Best-effort; never throws. A
+// malformed id is a no-op (and never shells out — keeps the "bg-9" revive
+// fixtures deterministic). `stop` is injectable for tests; the production
+// default calls the real `claude stop`.
+export function defaultKillBgJob({ bgJobId }, { stop = claudeStop } = {}) {
   if (!bgJobId) return;
+  let shortId;
   try {
-    const pidPath = join(jobsRoot(), bgJobId, "pid");
-    if (!existsSync(pidPath)) return;
-    const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
-    if (!Number.isFinite(pid) || pid <= 1) return;
-    // Verify the pid still belongs to a claude process before SIGKILL'ing.
-    // `ps -p <pid> -o comm=` prints just the command; exit 1 means the pid
-    // is gone. On any verification doubt, skip the kill (best-effort).
-    const ps = spawn("ps", ["-p", String(pid), "-o", "comm="], { encoding: "utf8" });
-    if (ps.status !== 0 || !(ps.stdout || "").toLowerCase().includes("claude")) {
-      log.info(
-        { bgJobId, pid, comm: (ps.stdout || "").trim() },
-        "revive: defensive kill skipped — pid does not belong to a claude process",
-      );
-      return;
-    }
-    const k = spawn("kill", ["-9", String(pid)], { encoding: "utf8" });
-    log.info(
-      { bgJobId, pid, code: k.status },
-      "revive: defensive kill issued",
-    );
-  } catch (err) {
-    log.warn({ bgJobId, err: err.message }, "revive: defensive kill failed");
+    shortId = shortIdFromSessionId(bgJobId);
+  } catch {
+    return;
+  }
+  const res = stop(shortId);
+  if (res?.ok) {
+    log.info({ bgJobId, shortId }, "revive: claude stop issued for dead bg worker");
+  } else {
+    log.warn({ bgJobId, shortId, err: res?.error }, "revive: claude stop failed");
   }
 }
 
-// defaultPidAlive — positive keep-alive check (CTL-610). Returns true iff the
-// bg job's recorded pid is still a live `claude` process. This is the inverse
-// use of the same primitive defaultKillBgJob uses to gate its SIGKILL: read
-// ~/.claude/jobs/<id>/pid, verify via `ps -p <pid> -o comm=` that the pid maps
-// to a claude process. It signals "alive, do not revive", never kills.
-// Best-effort: any doubt (missing pid file, unreadable, recycled pid, falsy
-// id, throwing seam) returns false so the caller falls through to its existing
-// revive path. Critically, the production seam returning false on a missing
-// pid file keeps every pre-CTL-610 revive test (which uses bgJobId "bg-9"
-// with no real pid file) green when the alive-quiet guard goes live.
-// `spawn` and `jobsRoot` are injectable for tests; production defaults call
-// the real spawnSync against the real ~/.claude/jobs.
-export function defaultPidAlive(
-  { bgJobId },
-  { spawn = spawnSync, jobsRoot = getJobsRoot } = {},
-) {
-  if (!bgJobId) return false;
+// defaultPidAlive — positive keep-alive check (CTL-610, rebuilt for CTL-657).
+// Returns true iff the bg worker is still a live `claude agents` session. It
+// signals "alive, do not revive", never kills. Pre-CTL-657 this read
+// ~/.claude/jobs/<id>/pid — absent on CC 2.1.152, so it ALWAYS returned false
+// and the daemon false-dead-revived every live worker (the 79-event revive
+// storm this ticket exists to kill). Now liveness comes from `claude agents`:
+// a crashed worker drops off the list, a live one (busy or idle between turns)
+// stays. Best-effort: any doubt (falsy/malformed id, failed `claude agents`
+// read) returns false so the caller falls through to its existing revive path.
+// A non-short-id ("bg-9" test fixture) returns false WITHOUT shelling out, so
+// every pre-CTL-610 revive test stays green unchanged. `isAlive` is injectable
+// for tests; the production default queries the real `claude agents`.
+export function defaultPidAlive({ bgJobId }, { isAlive = isBgJobAlive } = {}) {
   try {
-    const pidPath = join(jobsRoot(), bgJobId, "pid");
-    if (!existsSync(pidPath)) return false;
-    const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
-    if (!Number.isFinite(pid) || pid <= 1) return false;
-    const ps = spawn("ps", ["-p", String(pid), "-o", "comm="], { encoding: "utf8" });
-    return ps.status === 0 && (ps.stdout || "").toLowerCase().includes("claude");
+    return isAlive(bgJobId);
   } catch {
     return false;
   }
@@ -929,15 +904,15 @@ export function reclaimDeadWorkIfPossible(
     return "revive-suppressed";
   }
 
-  // Defensive kill: if state.json has been quiet long enough we're confident
-  // the bg process is gone, so a SIGKILL on its pid is harmless and prevents
-  // a zombie holding a worktree lock. The kill is best-effort and pid-file-gated
-  // — if no pid file exists (the normal post-exit state) it's a no-op.
+  // Defensive stop: if state.json has been quiet long enough we're confident
+  // the worker is abandoned, so we stop it to free RAM and release any worktree
+  // lock. CTL-657: killBgJob now issues `claude stop <shortId>` (the pre-CTL-657
+  // pid-file SIGKILL was a guaranteed no-op on CC 2.1.152 — no per-job pid file).
   //
   // CTL-649: also emit a reap-intent so the daemon reaper has authoritative
-  // visibility and can issue `claude stop` on the supervisor entry (kill -9
-  // hits the OS pid but the claude supervisor lingers as idle/dead-pid). The
-  // inline kill stays so behaviour cannot regress.
+  // visibility and stops the same session via its own `claude stop`. The inline
+  // stop stays so a standalone reconcile (no reaper consuming the log) cannot
+  // regress to leaking the worker.
   if (
     prevStateJsonMtime !== null &&
     now() - prevStateJsonMtime > KILL_RECENT_ACTIVITY_MS &&

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1463,190 +1463,78 @@ describe("defaultReviveDispatch — signal-reset behaviour", () => {
   });
 });
 
-describe("defaultKillBgJob — pid-recycling guard", () => {
-  let jobsRootDir;
-  beforeEach(() => {
-    jobsRootDir = mkdtempSync(join(tmpdir(), "ctl587-jobs-"));
-  });
-  afterEach(() => {
-    rmSync(jobsRootDir, { recursive: true, force: true });
-  });
+describe("defaultKillBgJob — claude stop termination (CTL-657)", () => {
+  // CTL-657: the pre-CTL-657 pid-file SIGKILL was a guaranteed no-op on CC
+  // 2.1.152 (no ~/.claude/jobs/<id>/pid). killBgJob now issues
+  // `claude stop <shortId>` — the primitive that actually deregisters a session.
+  const FULL_UUID = "12345678-aaaa-bbbb-cccc-0123456789ab";
 
-  function seedPid(bgJobId, pid) {
-    const dir = join(jobsRootDir, bgJobId);
-    mkdirSync(dir, { recursive: true });
-    if (pid !== undefined) writeFileSync(join(dir, "pid"), String(pid));
-  }
-
-  test("missing bgJobId → no spawn invocation", () => {
-    const spawn = recorder({ status: 0, stdout: "claude\n", stderr: "" });
-    defaultKillBgJob({ bgJobId: null }, { spawn, jobsRoot: () => jobsRootDir });
-    expect(spawn.calls.length).toBe(0);
+  test("missing bgJobId → no stop invocation", () => {
+    const stop = recorder({ ok: true });
+    defaultKillBgJob({ bgJobId: null }, { stop });
+    expect(stop.calls.length).toBe(0);
   });
 
-  test("missing pid file → no spawn invocation", () => {
-    // bgJobId set but no pid file written.
-    const spawn = recorder({ status: 0, stdout: "claude\n", stderr: "" });
-    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
-    expect(spawn.calls.length).toBe(0);
+  test("malformed bgJobId (not a short/UUID id) → no stop invocation", () => {
+    // "bg-9" is the legacy revive fixture: not a valid short id, so it must
+    // short-circuit WITHOUT shelling out (keeps those revive tests deterministic).
+    const stop = recorder({ ok: true });
+    defaultKillBgJob({ bgJobId: "bg-9" }, { stop });
+    expect(stop.calls.length).toBe(0);
   });
 
-  test("pid <= 1 (init / invalid) → no spawn invocation", () => {
-    seedPid("bg-9", "1");
-    const spawn = recorder({ status: 0, stdout: "claude\n", stderr: "" });
-    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
-    expect(spawn.calls.length).toBe(0);
+  test("valid 8-char short id → claude stop issued with that id", () => {
+    const stop = recorder({ ok: true });
+    defaultKillBgJob({ bgJobId: "12345678" }, { stop });
+    expect(stop.calls).toHaveLength(1);
+    expect(stop.calls[0][0]).toBe("12345678");
   });
 
-  test("non-numeric pid → no spawn invocation", () => {
-    seedPid("bg-9", "abc");
-    const spawn = recorder({ status: 0, stdout: "claude\n", stderr: "" });
-    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
-    expect(spawn.calls.length).toBe(0);
+  test("full UUID → claude stop issued with the 8-char short id (UUIDs are rejected rc=1)", () => {
+    const stop = recorder({ ok: true });
+    defaultKillBgJob({ bgJobId: FULL_UUID }, { stop });
+    expect(stop.calls).toHaveLength(1);
+    expect(stop.calls[0][0]).toBe("12345678");
   });
 
-  test("ps exit non-zero (pid gone) → ps invoked, kill is NOT invoked", () => {
-    seedPid("bg-9", "12345");
-    const calls = [];
-    const spawn = (cmd, args) => {
-      calls.push({ cmd, args });
-      if (cmd === "ps") return { status: 1, stdout: "", stderr: "" };
-      return { status: 0 };
-    };
-    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
-    expect(calls.filter((c) => c.cmd === "ps").length).toBe(1);
-    expect(calls.filter((c) => c.cmd === "kill").length).toBe(0);
-  });
-
-  test("ps says pid is 'node' (recycled to non-claude process) → kill skipped", () => {
-    seedPid("bg-9", "12345");
-    const calls = [];
-    const spawn = (cmd, args) => {
-      calls.push({ cmd, args });
-      if (cmd === "ps") return { status: 0, stdout: "node\n", stderr: "" };
-      return { status: 0 };
-    };
-    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
-    expect(calls.filter((c) => c.cmd === "kill").length).toBe(0);
-  });
-
-  test("happy path: ps confirms 'claude' → kill -9 issued with the pid", () => {
-    seedPid("bg-9", "12345");
-    const calls = [];
-    const spawn = (cmd, args) => {
-      calls.push({ cmd, args });
-      if (cmd === "ps") return { status: 0, stdout: "claude\n", stderr: "" };
-      if (cmd === "kill") return { status: 0, stdout: "", stderr: "" };
-      return { status: 127 };
-    };
-    defaultKillBgJob({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir });
-    const killCalls = calls.filter((c) => c.cmd === "kill");
-    expect(killCalls).toHaveLength(1);
-    expect(killCalls[0].args).toEqual(["-9", "12345"]);
+  test("stop failure ({ok:false}) does not throw", () => {
+    const stop = recorder({ ok: false, error: "no such session" });
+    expect(() => defaultKillBgJob({ bgJobId: "12345678" }, { stop })).not.toThrow();
+    expect(stop.calls).toHaveLength(1);
   });
 });
 
-// CTL-610: defaultPidAlive is the positive inverse of the ps-verify inside
-// defaultKillBgJob. It answers "is this bg job's pid still a live `claude`
-// process?" as a keep-alive signal. Best-effort: every doubt (missing pid
-// file, recycled pid, unreadable pid, falsy id) returns false so the caller's
-// existing revive path is preserved — critically, existing setupReviveScenario
-// tests use bgJobId "bg-9" with no real pid file under the real ~/.claude/jobs,
-// so the production default-seamed defaultPidAlive must return false there.
-describe("defaultPidAlive — positive bg-pid keep-alive (CTL-610)", () => {
-  let jobsRootDir;
-  beforeEach(() => {
-    jobsRootDir = mkdtempSync(join(tmpdir(), "ctl610-jobs-"));
-  });
-  afterEach(() => {
-    rmSync(jobsRootDir, { recursive: true, force: true });
+// CTL-657: defaultPidAlive is the keep-alive signal "is this bg worker still a
+// live `claude agents` session?". It delegates to isBgJobAlive (claude-agents.mjs);
+// the seam is `isAlive`. Best-effort — any throw returns false so the caller's
+// existing revive path is preserved. Critically, the legacy setupReviveScenario
+// tests use bgJobId "bg-9" (not a valid short id), and isBgJobAlive returns
+// false for it WITHOUT shelling out, so those revive tests stay green unchanged.
+describe("defaultPidAlive — claude-agents keep-alive (CTL-657)", () => {
+  test("delegates to the isAlive seam (true)", () => {
+    const isAlive = recorder(true);
+    expect(defaultPidAlive({ bgJobId: "12345678" }, { isAlive })).toBe(true);
+    expect(isAlive.calls).toHaveLength(1);
+    expect(isAlive.calls[0][0]).toBe("12345678");
   });
 
-  function seedPid(bgJobId, pid) {
-    const dir = join(jobsRootDir, bgJobId);
-    mkdirSync(dir, { recursive: true });
-    if (pid !== undefined) writeFileSync(join(dir, "pid"), String(pid));
-  }
-
-  test("falsy bgJobId → false, no spawn", () => {
-    const spawn = recorder({ status: 0, stdout: "claude\n" });
-    expect(defaultPidAlive({ bgJobId: null }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
-    expect(spawn.calls.length).toBe(0);
+  test("delegates to the isAlive seam (false → caller's revive path runs)", () => {
+    const isAlive = recorder(false);
+    expect(defaultPidAlive({ bgJobId: "12345678" }, { isAlive })).toBe(false);
   });
 
-  test("missing pid file → false (the default-safe case existing revive tests rely on)", () => {
-    // bgJobId set but no pid file → fall through to false; production seam
-    // therefore leaves every existing setupReviveScenario (bg-9, no pid) green.
-    const spawn = recorder({ status: 0, stdout: "claude\n" });
-    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
-    expect(spawn.calls.length).toBe(0);
-  });
-
-  test("non-numeric pid file → false, no spawn", () => {
-    seedPid("bg-9", "abc");
-    const spawn = recorder({ status: 0, stdout: "claude\n" });
-    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
-    expect(spawn.calls.length).toBe(0);
-  });
-
-  test("pid <= 1 → false, no spawn (init / invalid)", () => {
-    seedPid("bg-9", "1");
-    const spawn = recorder({ status: 0, stdout: "claude\n" });
-    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
-    expect(spawn.calls.length).toBe(0);
-  });
-
-  test("ps exit non-zero (pid gone) → false, ps was invoked exactly once", () => {
-    seedPid("bg-9", "12345");
-    const calls = [];
-    const spawn = (cmd, args) => {
-      calls.push({ cmd, args });
-      return { status: 1, stdout: "", stderr: "" };
+  test("a throwing isAlive seam is swallowed → false", () => {
+    const isAlive = () => {
+      throw new Error("claude agents exploded");
     };
-    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
-    expect(calls.filter((c) => c.cmd === "ps").length).toBe(1);
+    expect(defaultPidAlive({ bgJobId: "12345678" }, { isAlive })).toBe(false);
   });
 
-  test("ps says 'node' (pid recycled to non-claude process) → false", () => {
-    seedPid("bg-9", "12345");
-    const spawn = () => ({ status: 0, stdout: "node\n", stderr: "" });
-    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(false);
-  });
-
-  test("happy path: pid file present + ps says 'claude' → true, ps invoked with -p <pid> -o comm=", () => {
-    seedPid("bg-9", "12345");
-    const calls = [];
-    const spawn = (cmd, args) => {
-      calls.push({ cmd, args });
-      if (cmd === "ps") return { status: 0, stdout: "claude\n", stderr: "" };
-      return { status: 127 };
-    };
-    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(true);
-    expect(calls.filter((c) => c.cmd === "ps")).toHaveLength(1);
-    expect(calls.find((c) => c.cmd === "ps").args).toEqual(["-p", "12345", "-o", "comm="]);
-  });
-
-  test("case-insensitive match: ps stdout 'Claude' (capitalised) is still a claude process", () => {
-    seedPid("bg-9", "12345");
-    const spawn = () => ({ status: 0, stdout: "Claude\n", stderr: "" });
-    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(true);
-  });
-
-  test("substring match: ps stdout 'claude-bg' still counts (process name truncations)", () => {
-    seedPid("bg-9", "12345");
-    const spawn = () => ({ status: 0, stdout: "claude-bg\n", stderr: "" });
-    expect(defaultPidAlive({ bgJobId: "bg-9" }, { spawn, jobsRoot: () => jobsRootDir })).toBe(true);
-  });
-
-  test("never throws on a hostile jobsRoot (returns false)", () => {
-    // jobsRoot resolver throws — defaultPidAlive must swallow.
-    const spawn = recorder({ status: 0, stdout: "claude\n" });
-    expect(
-      defaultPidAlive({ bgJobId: "bg-9" }, {
-        spawn,
-        jobsRoot: () => { throw new Error("boom"); },
-      }),
-    ).toBe(false);
+  test("production default: malformed bgJobId ('bg-9') → false, no shell-out", () => {
+    // No isAlive seam → the real isBgJobAlive runs. "bg-9" is not a valid short
+    // id, so it returns false before touching `claude agents`. This is the
+    // contract every legacy setupReviveScenario (bg-9, no seam) relies on.
+    expect(defaultPidAlive({ bgJobId: "bg-9" })).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -30,6 +30,7 @@ import { analyzeDependencyGraph, referencedBlockerIds } from "../lib/dependency-
 // enters at NEW_WORK_ENTRY_PHASE ("research"), see schedulerTick.
 import {
   PHASES,
+  NEXT_PHASE,
   transition,
   isTerminal,
   REMEDIATE_PHASE,
@@ -46,6 +47,8 @@ import { fetchTicketState } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
 import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
+import { countBackgroundAgents } from "./claude-agents.mjs";
+import { emitReapIntent } from "./reap-intent.mjs";
 // CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
 // is the real recovery-module function; tests inject a fake. See
 // reclaimDeadWorkIfPossible in recovery.mjs for the decision tree.
@@ -176,6 +179,55 @@ export function readMaxParallel(orchDir) {
 // computeFreeSlots — never negative (an over-subscribed run yields 0).
 export function computeFreeSlots(maxParallel, inFlightCount) {
   return Math.max(0, maxParallel - inFlightCount);
+}
+
+// readPhaseSignalRaw — the full parsed phase-<phase>.json for one ticket, or
+// null. readPhaseSignals returns only {phase: status}; the predecessor reap
+// needs the worker's bg_job_id, which lives in the raw signal.
+function readPhaseSignalRaw(orchDir, ticket, phase) {
+  try {
+    return JSON.parse(
+      readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"),
+    );
+  } catch {
+    return null;
+  }
+}
+
+// predecessorPhaseOf — the completed phase whose happy-path successor is `next`
+// (i.e. the worker that just finished and triggered this advance), or null.
+// Uses the NEXT_PHASE inversion so it is unambiguous on every linear edge; the
+// router-only remediate detour (no NEXT_PHASE entry) yields null and is left to
+// the periodic orphan reaper as a backstop.
+export function predecessorPhaseOf(signals, next) {
+  for (const [phase, status] of Object.entries(signals ?? {})) {
+    if (status === "done" && NEXT_PHASE[phase] === next) return phase;
+  }
+  return null;
+}
+
+// emitPredecessorReap — CTL-657 Bug 2: stop the predecessor worker now that its
+// successor is dispatched. orchestrate-phase-advance already does this on the
+// shell advance path (CTL-567), but the daemon scheduler's dispatchTicket path
+// bypassed that emit, so on a normal scheduler-driven phase switch the just-
+// finished worker was never nominated for stopping (only 1 predecessor reap
+// ever emitted across 12+ advances). Fire-and-forget — the reaper issues the
+// `claude stop`. No-op when the predecessor has no recorded bg_job_id (e.g. the
+// new-work entry phase, or a unit-test signal with no bg_job_id) so it never
+// shells out or appends to the event log spuriously.
+function emitPredecessorReap(orchDir, ticket, signals, next) {
+  const pred = predecessorPhaseOf(signals, next);
+  if (!pred) return;
+  const raw = readPhaseSignalRaw(orchDir, ticket, pred);
+  const bgJobId = raw?.bg_job_id;
+  if (!bgJobId) return;
+  emitReapIntent("phase.predecessor.reap-requested", {
+    ticket,
+    phase: pred,
+    bgJobId,
+    worktreePath: raw?.worktreePath,
+    reason: "ctl-657-scheduler-advance",
+  }).catch(() => {});
 }
 
 // A blocker fetch that failed (or any non-terminal hydrated state) holds the
@@ -598,6 +650,14 @@ export function schedulerTick(
     reclaimDeadWork = defaultReclaimDeadWork,
     now = Date.now, // CTL-624: injectable clock for the dispatch cool-down
     cache, // CTL-634: opt-in out-of-set blocker state cache
+    // CTL-657: concurrency = the real count of live `background` claude agents,
+    // NOT a scan of workers/ + signal files. A leaked-but-running worker freed
+    // its slot on paper (signal flipped terminal while the process lived on) and
+    // per-ticket duplicates went uncounted — so the daemon over-dispatched into
+    // the 28GB pileup. Querying `claude agents` makes a still-alive worker hold
+    // its slot. Interactive sessions are excluded (unlimited). Injectable for
+    // tests so a unit tick need not shell out to `claude`.
+    liveBackgroundCount = () => countBackgroundAgents(),
   } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -688,6 +748,8 @@ export function schedulerTick(
     if (r.code === 0) {
       clearDispatchCooldown(orchDir, ticket, next); // CTL-624: success clears any prior cool-down
       advanced.push({ ticket, phase: next });
+      // CTL-657: stop the predecessor worker now that its successor is live.
+      emitPredecessorReap(orchDir, ticket, signals, next);
       // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
       // (linear-transition.sh read-compares first); never aborts the tick.
       safeWrite(() => writeStatus.applyPhaseStatus({ ticket, phase: next }), {
@@ -710,7 +772,10 @@ export function schedulerTick(
   // object is discarded by runTick, so a metric must be logged, not returned).
   if (cache) log.info(cache.stats(), "scheduler: cache stats");
   const ready = computeReadyTickets(eligible, { blockerStates });
-  const inFlightCount = listInFlightTickets(orchDir).size; // recomputed post-sweep
+  // CTL-657: the in-flight count is the live `background` claude-agents count,
+  // not listInFlightTickets(orchDir).size. A worker that leaked (signal terminal
+  // but process alive) still consumes a slot; a duplicate spawn is counted.
+  const inFlightCount = liveBackgroundCount();
   const freeSlots = computeFreeSlots(readMaxParallel(orchDir), inFlightCount);
   const selected = selectDispatchable(ready, listStartedTickets(orchDir), freeSlots);
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -21,6 +21,7 @@ import {
   listInFlightTickets,
   readMaxParallel,
   computeFreeSlots,
+  predecessorPhaseOf,
   computeReadyTickets,
   selectDispatchable,
   deriveAdvancement,
@@ -598,7 +599,13 @@ describe("schedulerTick — new-work pull", () => {
         inverseRelations: { nodes: [] },
       },
     ];
-    const r = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    // CTL-657: concurrency is the live background-agent count, not a workers/
+    // scan — one live worker fills the single slot.
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      liveBackgroundCount: () => 1,
+    });
     expect(dispatch.calls).toHaveLength(0);
     expect(r.dispatched).toEqual([]);
   });
@@ -679,6 +686,117 @@ describe("schedulerTick — new-work pull", () => {
       // CTL-565: new-work pull enters at research, not triage.
       { orchDir, ticket: "CTL-X", phase: "research" },
     ]);
+  });
+});
+
+// ── CTL-657: live-count concurrency + predecessor reap on scheduler advance ──
+describe("schedulerTick — CTL-657 live-count concurrency & predecessor reap", () => {
+  // Write a phase signal that carries a bg_job_id (the default writeSignal
+  // helper omits it; the predecessor reap reads it from the raw signal).
+  function writeSignalWithBg(ticket, phase, status, bgJobId) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, status, bg_job_id: bgJobId }),
+    );
+  }
+
+  function readEventLog() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const p = join(catalystDir, "events", `${ym}.jsonl`);
+    if (!existsSync(p)) return [];
+    return readFileSync(p, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  }
+
+  const oneEligible = (id) => [
+    {
+      identifier: id,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    },
+  ];
+
+  test("holds at max — no new-work dispatch when live background count == maxParallel", () => {
+    // No worker dirs at all, but the live fleet already has 2 background agents
+    // (e.g. leaked workers whose signals went terminal). The paper-count model
+    // would see 0 in-flight and over-dispatch; the live-count model holds.
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => oneEligible("CTL-2"),
+      dispatch,
+      liveBackgroundCount: () => 2,
+    });
+    expect(r.freeSlots).toBe(0);
+    expect(r.dispatched).toEqual([]);
+    expect(dispatch.calls).toHaveLength(0);
+  });
+
+  test("fills exactly the freed slot — live count below max admits new work", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => oneEligible("CTL-2"),
+      dispatch,
+      liveBackgroundCount: () => 1, // 1 live bg worker, 1 slot free
+    });
+    expect(r.freeSlots).toBe(1);
+    expect(r.dispatched).toEqual(["CTL-2"]);
+  });
+
+  test("emits phase.predecessor.reap-requested for the completed phase on advance", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // research done (bg worker bg-aaaa1111) → FSM advances to plan; the research
+    // worker is the predecessor and must be nominated for stopping.
+    writeSignalWithBg("CTL-7", "research", "done", "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee");
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      liveBackgroundCount: () => 0,
+    });
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "plan" }]);
+    const reap = readEventLog().find(
+      (e) => e.event === "phase.predecessor.reap-requested" && e.ticket === "CTL-7",
+    );
+    expect(reap).toBeTruthy();
+    expect(reap.phase).toBe("research");
+    expect(reap.bg_job_id).toBe("aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+
+  test("no predecessor reap when the completed-phase signal has no bg_job_id", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-8", "research", "done"); // no bg_job_id
+    const dispatch = fakeDispatch();
+    schedulerTick(orchDir, { readEligible: () => [], dispatch, liveBackgroundCount: () => 0 });
+    expect(
+      readEventLog().filter((e) => e.event === "phase.predecessor.reap-requested"),
+    ).toHaveLength(0);
+  });
+});
+
+describe("predecessorPhaseOf", () => {
+  test("returns the done phase whose successor is `next`", () => {
+    expect(predecessorPhaseOf({ research: "done" }, "plan")).toBe("research");
+    expect(predecessorPhaseOf({ implement: "done" }, "verify")).toBe("implement");
+  });
+
+  test("ignores a non-done predecessor and unrelated done phases", () => {
+    expect(predecessorPhaseOf({ research: "running" }, "plan")).toBeNull();
+    expect(predecessorPhaseOf({ triage: "done" }, "plan")).toBeNull();
+  });
+
+  test("null for the router-only remediate detour (no NEXT_PHASE edge) and empty input", () => {
+    expect(predecessorPhaseOf({ verify: "done" }, "remediate")).toBeNull();
+    expect(predecessorPhaseOf(null, "plan")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
Background phase workers (`claude --bg`) were never stopped: a live snapshot showed **35 sessions / 28GB RSS**, ~6-7 duplicates per ticket, and **0 `reap-complete` events ever**. Root cause was three bugs that all read the `~/.claude/jobs/<id>/pid` file — absent for 0/981 job dirs on Claude Code 2.1.152. This routes liveness, termination, and concurrency through `claude agents --json` / `claude stop <shortId>` instead (both verified working).

- **New `claude-agents.mjs`** — the shared primitive: `listClaudeAgents` / `isBgJobAlive` / `countBackgroundAgents` / `claudeStop`.
- **Bug 1 — `reaper.mjs`**: drop the `status !== "idle"` gate for authoritative single-target intents (yield/predecessor/supersede/revive/abort). A worker was almost always still *busy* finishing its last turn at reap time → skipped, never retried, lingered forever. `claude stop` works on a busy session.
- **Bug 2 — `scheduler.mjs`**: concurrency is now the live `background` claude-agents count (interactive sessions excluded), not a `workers/` scan — a leaked-but-running worker holds its slot. Also emit `phase.predecessor.reap-requested` on every scheduler-driven advance (the daemon path bypassed `orchestrate-phase-advance`'s CTL-567 emit).
- **Bug 3 — `recovery.mjs`**: `defaultPidAlive` reads `claude agents` (ends the 79-event false-dead revive storm); `defaultKillBgJob` issues `claude stop`.

## Test plan
- [x] New `claude-agents.test.mjs`; rewrote the obsolete pid-file primitive suites for the new contract; added live-count + predecessor-reap scheduler tests; flipped the reaper busy-skip test to assert the stop.
- [x] Full execution-core + lib suite: **1160 pass / 0 fail**
- [x] Rebased onto origin/main (post CTL-653/655/654)

🤖 Generated with [Claude Code](https://claude.com/claude-code)