### PR TITLE
CTL-656: add /goal blocks to phase-triage + phase-monitor-deploy (goal-driven deploy)

### DIFF
--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -58,6 +58,27 @@ The file is written by [[phase-monitor-merge]] after `gh pr merge --squash`
 confirms via REST (`gh api repos/<owner>/<repo>/pulls/<num>` returns
 `.merged == true`).
 
+## /goal
+
+```
+/goal "The deploy for the merge SHA actually SUCCEEDED — a terminal
+       deployment_status success event arrived for the SHA AND the /canary check
+       passed — and I have written ${WORKER_DIR}/phase-monitor-deploy.json
+       recording that success. If the deploy FAILED (a deployment_status failure
+       or a failing canary), I have driven at least one remediation attempt
+       rather than passively recording failed/skipped. OR no deployment_status
+       event arrived within PHASE_DEPLOY_TIMEOUT_SEC and I have recorded
+       status:skipped with a reason (the PR is already merged, so a missing
+       deploy event is a skip, not a failure)."
+```
+
+CTL-656: monitor-deploy is **not** a passive watch — its goal is that the deploy
+*actually succeeded*, so the `/goal` evaluator keeps the agent driving toward a
+green canary, including a remediation attempt on a failed deploy, instead of
+emitting `failed`/`skipped` and walking away on the first terminal signal. The
+timeout path is the one legitimate early exit. (Production mode only; the CI
+bash body below remains self-sufficient and deterministic.)
+
 ## Body
 
 ```bash phase-monitor-deploy-body

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -23,6 +23,25 @@ The skill is dispatched in two modes:
 
 Both modes produce the same `triage.json` shape and emit the same canonical phase event.
 
+## /goal
+
+```
+/goal "I have written ${WORKER_DIR}/triage.json populated with all five fields —
+       classification (feature|bug|docs|refactor|chore), estimated_scope,
+       acronyms_expanded, dependencies, and a non-empty summary — refined with
+       real analysis (not just the deterministic placeholders), AND posted the
+       triaged analysis comment to the Linear ticket, AND printed the triage.json
+       path on stdout. OR I have stopped after 15 turns and recorded a partial
+       triage.json with whatever I could classify."
+```
+
+CTL-656: the `/goal` evaluator keeps the agent working until the triage is
+genuinely complete — every field populated and the Linear comment posted —
+instead of emitting the first-pass deterministic placeholder and exiting. A real
+blocker (unreadable ticket, a Linear 4xx on the comment) surfaces as needs-input
+rather than a silently-thin `triage.json`. (Production/Opus mode only; the CI
+bash body is self-sufficient and does not invoke the evaluator.)
+
 ## Setup prerequisite
 
 The `triaged` workspace label must already exist in Linear. The label is applied by the


### PR DESCRIPTION
## Summary
Closes scope item 1 of CTL-656 (the unconditional one) and addresses item 2 at the agent-behavior level. `/goal` is the Claude Code built-in (v2.1.139) whose evaluator keeps an agent working until its completion condition is met. 7 of 9 phase skills already had a `## /goal` block; this adds the two that were missing.

- **phase-triage**: goal = a fully-populated `triage.json` (all five fields, real analysis — not the deterministic placeholders) + the Linear comment posted.
- **phase-monitor-deploy**: goal = the deploy *actually succeeded* (terminal `deployment_status` success + a green `/canary`). This makes monitor-deploy drive a remediation attempt on a failed deploy instead of passively recording `failed`/`skipped` (item 2, at the agent-behavior level). The timeout path stays the one legitimate early skip.

Both blocks are production/Opus-mode only; the CI bash bodies are untouched and remain deterministic.

## Intentionally deferred (not premature-optimized)
The ticket scopes items 2-deep and 3 **"do as we observe the failures — do not premature-optimize"** and marks item 3 **"(As observed)"**:
- FSM deploy-fail remediation *routing* (beyond the goal block).
- `implement→plan` / `plan→research` fail→previous-phase routing with re-entry notes.

These change core `transition()`/revive semantics and can only be validated against real failures once the execution-core daemon is restarted — so they are follow-on work, deliberately not built speculatively here.

## Test plan
- [x] phase-triage e2e: 39 passed / 0 failed
- [x] phase-monitor-deploy e2e: 23 passed / 0 failed
- [x] `/goal` fences are unnamed → the e2e named-fence extractor ignores them (bash bodies unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)