### PR TITLE
CTL-611: Surface dispatch failures as phase.dispatch.failed events

### DIFF
--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -865,6 +865,45 @@ DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
 [ "$DISPATCHED" = "" ] && pass "done signal NOT re-dispatched" || fail "done signal NOT re-dispatched" "got: $DISPATCHED"
 scratch_teardown
 
+echo "test 44 (CTL-611): phase-agent-dispatch failure emits phase.dispatch.failed event"
+scratch_setup
+# Install a stub phase-agent-dispatch that ALWAYS exits non-zero.
+cat >"${SCRATCH}/bin/phase-agent-dispatch" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$PHASE_DISPATCH_LOG"
+exit 1
+EOF
+chmod +x "${SCRATCH}/bin/phase-agent-dispatch"
+export PHASE_DISPATCH_LOG="${SCRATCH}/phase-dispatch.log"
+: >"$PHASE_DISPATCH_LOG"
+export CATALYST_PHASE_AGENT_DISPATCH="${SCRATCH}/bin/phase-agent-dispatch"
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "research" 2>"${SCRATCH}/err")
+RC=$?
+# Exit code stays 0 — idempotency contract unchanged.
+[ "$RC" = "0" ] && pass "exit 0 on phase-agent-dispatch failure (unchanged contract)" || fail "exit 0 on phase-agent-dispatch failure" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+# Stdout shape unchanged — dispatched stays empty.
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "" ] && pass "dispatched=[] on failure (unchanged shape)" || fail "dispatched=[] on failure" "got: $DISPATCHED"
+# State log gained exactly one phase.dispatch.failed.T-1 event.
+COUNT=$(grep -c "phase.dispatch.failed.T-1" "$STATE_LOG" || true)
+[ "$COUNT" = "1" ] && pass "exactly one phase.dispatch.failed.T-1 event" || fail "exactly one phase.dispatch.failed.T-1 event" "count=$COUNT log: $(cat "$STATE_LOG")"
+grep -q "research" "$STATE_LOG" && pass "event carries toPhase=research" || fail "event carries toPhase=research" "log: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test 45 (CTL-611): successful phase-agent-dispatch does NOT emit phase.dispatch.failed"
+scratch_setup
+phase_agent_dispatch_setup
+write_state "demo" 4 '{"wave1Pending": []}'
+make_worktree "demo" "T-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --ticket "T-1" --phase "research" 2>"${SCRATCH}/err")
+DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
+[ "$DISPATCHED" = "T-1" ] && pass "dispatched=[T-1] on success" || fail "dispatched=[T-1] on success" "got: $DISPATCHED"
+COUNT=$(grep -c "phase.dispatch.failed" "$STATE_LOG" || true)
+[ "$COUNT" = "0" ] && pass "no phase.dispatch.failed event on success" || fail "no phase.dispatch.failed event on success" "count=$COUNT log: $(cat "$STATE_LOG")"
+scratch_teardown
+
 echo ""
 echo "─────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/__tests__/orchestrate-phase-advance.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-phase-advance.test.sh
@@ -286,6 +286,40 @@ grep -q -- "--config /tmp/x/.catalyst/config.json" "$LINEAR_TRANSITION_LOG" \
   && pass "--config forwarded to linear-transition" || fail "--config forwarded to linear-transition" "log: $(cat "$LINEAR_TRANSITION_LOG")"
 scratch_teardown
 
+echo "test 18 (CTL-611): dispatch-failed emits phase.dispatch.failed event"
+scratch_setup
+# Install a stub dispatch-next that ALWAYS exits non-zero.
+cat > "${SCRATCH}/bin/orchestrate-dispatch-next" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$DISPATCH_LOG"
+exit 1
+EOF
+chmod +x "${SCRATCH}/bin/orchestrate-dispatch-next"
+make_phase_signal "T-1" "triage" "done"
+OUT=$(run_advance --ticket "T-1" --completed-phase "triage" 2>"${SCRATCH}/err")
+RC=$?
+# Exit code stays 0 — idempotency contract unchanged.
+[ "$RC" = "0" ] && pass "exit 0 on dispatch-failed (unchanged contract)" || fail "exit 0 on dispatch-failed (unchanged contract)" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+# Stdout shape unchanged.
+echo "$OUT" | jq -e '.advanced == false and .reason == "dispatch-failed" and .ticket == "T-1" and .toPhase == "research"' >/dev/null   && pass "stdout shape unchanged on dispatch-failed" || fail "stdout shape unchanged on dispatch-failed" "got: $OUT"
+# State log gained exactly one phase.dispatch.failed.T-1 event.
+COUNT=$(grep -c "phase.dispatch.failed.T-1" "$STATE_LOG" || true)
+[ "$COUNT" = "1" ] && pass "exactly one phase.dispatch.failed.T-1 event" || fail "exactly one phase.dispatch.failed.T-1 event" "count=$COUNT log: $(cat "$STATE_LOG")"
+# Event detail mentions fromPhase + toPhase.
+grep -q "fromPhase" "$STATE_LOG" && grep -q "research" "$STATE_LOG"   && pass "event carries fromPhase + toPhase" || fail "event carries fromPhase + toPhase" "log: $(cat "$STATE_LOG")"
+scratch_teardown
+
+echo "test 19 (CTL-611): successful dispatch does NOT emit phase.dispatch.failed"
+scratch_setup
+# Regression: the existing exit-0 stub stays in place; no phase.dispatch.failed event.
+make_phase_signal "T-1" "research" "done"
+run_advance --ticket "T-1" --completed-phase "research" >/dev/null 2>"${SCRATCH}/err"
+COUNT=$(grep -c "phase.dispatch.failed" "$STATE_LOG" || true)
+[ "$COUNT" = "0" ] && pass "no phase.dispatch.failed event on success" || fail "no phase.dispatch.failed event on success" "count=$COUNT log: $(cat "$STATE_LOG")"
+# The existing worker-phase-advanced event still fires.
+grep -q "worker-phase-advanced" "$STATE_LOG" && pass "worker-phase-advanced still emitted" || fail "worker-phase-advanced still emitted" "log: $(cat "$STATE_LOG")"
+scratch_teardown
+
 echo ""
 echo "─────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -309,6 +309,34 @@ function defaultAppendReviveSuppressedEvent({
   );
 }
 
+// CTL-611: dispatch-failed audit event. Fires whenever the scheduler observes
+// a dispatch attempt that did not produce a live successor worker (Gap 1
+// silent demotion: rc=0 but no bg_job_id signal; Gap 2: rc!=0). Routes via
+// the broker's PHASE_EVENT_PATTERN as phase.dispatch.failed.<TICKET> (phase
+// slot is the literal "dispatch", action slot is "failed"); the actual phase
+// being dispatched is carried in payload.target_phase so operators can filter.
+// Best-effort like every other audit emitter — return value lets the caller
+// log (no current caller gates on it; matches recordDispatchFailure shape).
+export function defaultAppendDispatchFailedEvent({
+  orchId,
+  ticket,
+  target_phase,
+  code,
+  reason,
+}) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "dispatch",
+      ticket,
+      orchId,
+      action: "failed",
+      reason,
+      payloadExtras: { target_phase, code },
+    }),
+    "dispatch-failed",
+  );
+}
+
 // CTL-587 default seams — all overridable for tests, all best-effort for prod.
 
 // defaultReviveDispatch — reset the signal to status: "stalled" first (to bypass

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -52,7 +52,12 @@ import { emitReapIntent } from "./reap-intent.mjs";
 // CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
 // is the real recovery-module function; tests inject a fake. See
 // reclaimDeadWorkIfPossible in recovery.mjs for the decision tree.
-import { reclaimDeadWorkIfPossible as defaultReclaimDeadWork } from "./recovery.mjs";
+// CTL-611: defaultAppendDispatchFailedEvent — emits phase.dispatch.failed.<T>
+// to the unified event log on every dispatch failure (Gap 1 + Gap 2).
+import {
+  reclaimDeadWorkIfPossible as defaultReclaimDeadWork,
+  defaultAppendDispatchFailedEvent,
+} from "./recovery.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -505,6 +510,39 @@ export function clearDispatchCooldown(orchDir, ticket, phase) {
   }
 }
 
+// CTL-611: post-dispatch verifier. A dispatch is only really successful if
+// workers/<T>/phase-<P>.json was written with a non-empty bg_job_id and a
+// runnable status. A --dry-run leak (no signal at all) or a mark_launch_failed
+// half-write (status="dispatched"/"running" but bg_job_id=null) used to be
+// silently treated as a real advance, leaving the orchestrator wedged. The
+// returned {ok, reason} feeds the demotion path: on !ok the rc=0 result is
+// reclassified as a failure with reason="verify_failed:<reason>" and a
+// phase.dispatch.failed.<T> event fires.
+export function verifyDispatchedSignal(orchDir, ticket, phase) {
+  const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  let raw;
+  try {
+    raw = readFileSync(signalPath, "utf8");
+  } catch {
+    return { ok: false, reason: "signal_missing" };
+  }
+  let signal;
+  try {
+    signal = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: "signal_unparseable" };
+  }
+  const status = signal?.status;
+  if (status !== "dispatched" && status !== "running") {
+    return { ok: false, reason: "status_not_runnable" };
+  }
+  const bgJob = signal?.bg_job_id;
+  if (typeof bgJob !== "string" || bgJob.length === 0) {
+    return { ok: false, reason: "bg_job_id_missing" };
+  }
+  return { ok: true };
+}
+
 // REQUIRED_WORKSPACE_LABELS — the flat labels the CTL-558 coordinator sweep
 // writes. Both must pre-exist in the Linear workspace; linearis has no
 // `labels create`. CTL-585's preflight warns once at daemon start if either
@@ -658,6 +696,10 @@ export function schedulerTick(
     // its slot. Interactive sessions are excluded (unlimited). Injectable for
     // tests so a unit tick need not shell out to `claude`.
     liveBackgroundCount = () => countBackgroundAgents(),
+    // CTL-611: injectable verifier + audit-event emitter so tests can pin the
+    // demotion path independently of fixture choice (fakeDispatch / recorder).
+    verifyDispatched = verifyDispatchedSignal,
+    appendDispatchFailedEvent = defaultAppendDispatchFailedEvent,
   } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -746,18 +788,50 @@ export function schedulerTick(
     if (inDispatchCooldown(orchDir, ticket, next, now())) continue; // CTL-624: throttle refused re-dispatch
     const r = dispatchTicket(orchDir, ticket, next, { dispatch });
     if (r.code === 0) {
-      clearDispatchCooldown(orchDir, ticket, next); // CTL-624: success clears any prior cool-down
-      advanced.push({ ticket, phase: next });
-      // CTL-657: stop the predecessor worker now that its successor is live.
-      emitPredecessorReap(orchDir, ticket, signals, next);
-      // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
-      // (linear-transition.sh read-compares first); never aborts the tick.
-      safeWrite(() => writeStatus.applyPhaseStatus({ ticket, phase: next }), {
-        ticket,
-        phase: next,
-      });
+      // CTL-611: verify the dispatch actually produced a live worker before
+      // declaring success. A --dry-run leak / mark_launch_failed half-write
+      // returns rc=0 with no usable signal, which used to silently leave the
+      // pipeline wedged. !ok demotes to failure (cool-down + event).
+      const v = verifyDispatched(orchDir, ticket, next);
+      if (v.ok) {
+        clearDispatchCooldown(orchDir, ticket, next); // CTL-624: success clears any prior cool-down
+        advanced.push({ ticket, phase: next });
+        // CTL-657: stop the predecessor worker now that its successor is live.
+        emitPredecessorReap(orchDir, ticket, signals, next);
+        // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
+        // (linear-transition.sh read-compares first); never aborts the tick.
+        safeWrite(() => writeStatus.applyPhaseStatus({ ticket, phase: next }), {
+          ticket,
+          phase: next,
+        });
+      } else {
+        // CTL-611 Gap 1 demotion: rc=0 but no live bg job. Same on-disk
+        // effects as a real rc!=0 failure so the broker / HUD / operator can
+        // see the drop.
+        recordDispatchFailure(orchDir, ticket, next, 0, now());
+        appendDispatchFailedEvent({
+          orchId: ticket,
+          ticket,
+          target_phase: next,
+          code: 0,
+          reason: `verify_failed:${v.reason}`,
+        });
+        log.warn(
+          { ticket, phase: next, verifyReason: v.reason },
+          "scheduler: dispatched signal verification failed"
+        );
+      }
     } else {
       recordDispatchFailure(orchDir, ticket, next, r.code, now()); // CTL-624: arm the cool-down window
+      // CTL-611 Gap 2: surface the silent drop as an event so the broker /
+      // HUD / operator can react. Best-effort; failure is logged inside.
+      appendDispatchFailedEvent({
+        orchId: ticket,
+        ticket,
+        target_phase: next,
+        code: r.code,
+        reason: "dispatch_nonzero_exit",
+      });
       log.warn({ ticket, phase: next, code: r.code }, "scheduler: advance dispatch failed");
     }
   }
@@ -784,19 +858,45 @@ export function schedulerTick(
     if (inDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, now())) continue; // CTL-624: throttle refused re-dispatch
     const r = dispatchTicket(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, { dispatch });
     if (r.code === 0) {
-      clearDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-624: success clears any prior cool-down
-      dispatched.push(t.identifier);
-      // CTL-558: write the entry-phase (`research`) status for the new ticket.
-      safeWrite(
-        () =>
-          writeStatus.applyPhaseStatus({
-            ticket: t.identifier,
-            phase: NEW_WORK_ENTRY_PHASE,
-          }),
-        { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
-      );
+      // CTL-611: same Gap 1 verifier as the advancement sweep — a rc=0
+      // without a live successor signal must be demoted.
+      const v = verifyDispatched(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE);
+      if (v.ok) {
+        clearDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-624: success clears any prior cool-down
+        dispatched.push(t.identifier);
+        // CTL-558: write the entry-phase (`research`) status for the new ticket.
+        safeWrite(
+          () =>
+            writeStatus.applyPhaseStatus({
+              ticket: t.identifier,
+              phase: NEW_WORK_ENTRY_PHASE,
+            }),
+          { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
+        );
+      } else {
+        recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, 0, now());
+        appendDispatchFailedEvent({
+          orchId: t.identifier,
+          ticket: t.identifier,
+          target_phase: NEW_WORK_ENTRY_PHASE,
+          code: 0,
+          reason: `verify_failed:${v.reason}`,
+        });
+        log.warn(
+          { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE, verifyReason: v.reason },
+          "scheduler: dispatched signal verification failed"
+        );
+      }
     } else {
       recordDispatchFailure(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, r.code, now()); // CTL-624: arm the cool-down window
+      // CTL-611: Gap 2 entry-phase silent-drop event.
+      appendDispatchFailedEvent({
+        orchId: t.identifier,
+        ticket: t.identifier,
+        target_phase: NEW_WORK_ENTRY_PHASE,
+        code: r.code,
+        reason: "dispatch_nonzero_exit",
+      });
       log.warn({ ticket: t.identifier, code: r.code }, "scheduler: dispatch failed");
     }
   }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -766,6 +766,7 @@ describe("schedulerTick — CTL-657 live-count concurrency & predecessor reap", 
       readEligible: () => oneEligible("CTL-2"),
       dispatch,
       liveBackgroundCount: () => 1, // 1 live bg worker, 1 slot free
+      verifyDispatched: verifyOk, // CTL-611: fakeDispatch writes no signal; bypass the verifier
     });
     expect(r.freeSlots).toBe(1);
     expect(r.dispatched).toEqual(["CTL-2"]);
@@ -781,6 +782,7 @@ describe("schedulerTick — CTL-657 live-count concurrency & predecessor reap", 
       readEligible: () => [],
       dispatch,
       liveBackgroundCount: () => 0,
+      verifyDispatched: verifyOk, // CTL-611: fakeDispatch writes no signal; bypass the verifier
     });
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "plan" }]);
     const reap = readEventLog().find(
@@ -2089,6 +2091,7 @@ describe("CTL-653: schedulerTick verify⇄remediate cycle (end-to-end)", () => {
         dispatch,
         writeStatus: noopWriteStatus,
         reclaimDeadWork: () => "noop",
+        verifyDispatched: verifyOk, // CTL-611: cyclingDispatch writes status:"done", not a runnable dispatched signal; bypass the verifier
       });
     }
   };
@@ -2274,6 +2277,7 @@ describe("phase.dispatch.failed event emission (CTL-611)", () => {
       readEligible: () => eligibleOne("CTL-202"),
       dispatch,
       now: () => 1_000,
+      liveBackgroundCount: () => 0, // CTL-611: deterministic free slot post-CTL-657 rebase
     });
 
     const events = dispatchFailedEvents("CTL-202");
@@ -2293,6 +2297,7 @@ describe("phase.dispatch.failed event emission (CTL-611)", () => {
       readEligible: () => eligibleOne("CTL-203"),
       dispatch,
       now: () => 1_000,
+      liveBackgroundCount: () => 0, // CTL-611: deterministic free slot post-CTL-657 rebase
     });
 
     expect(dispatch.calls).toHaveLength(1);
@@ -2313,6 +2318,7 @@ describe("phase.dispatch.failed event emission (CTL-611)", () => {
       readEligible: () => eligibleOne("CTL-204"),
       dispatch,
       now: () => 1_000,
+      liveBackgroundCount: () => 0, // CTL-611: deterministic free slot post-CTL-657 rebase
     });
     // Tick 2 inside the 60s window: suppressed by cool-down → 0 new dispatch,
     // 0 new event (the dispatch never re-attempts so emission never fires).
@@ -2320,6 +2326,7 @@ describe("phase.dispatch.failed event emission (CTL-611)", () => {
       readEligible: () => eligibleOne("CTL-204"),
       dispatch,
       now: () => 30_000,
+      liveBackgroundCount: () => 0, // CTL-611: deterministic free slot post-CTL-657 rebase
     });
 
     expect(dispatch.calls).toHaveLength(1);

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -38,6 +38,7 @@ import {
   recordDispatchFailure,
   clearDispatchCooldown,
   dispatchCooldownPath,
+  verifyDispatchedSignal,
   __resetForTests,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
@@ -270,6 +271,11 @@ function fakeDispatch({ code = 0 } = {}) {
   return fn;
 }
 
+// CTL-611: verifier-pass stub. The default verifyDispatchedSignal reads the
+// signal file and is `false` for tests that don't write one — pass this to
+// schedulerTick to opt out of demotion for non-CTL-611 tests.
+const verifyOk = () => ({ ok: true });
+
 // ── CTL-624: per-(ticket,phase) dispatch cool-down helpers ──
 describe("dispatch cool-down helpers", () => {
   test("no marker → not in cool-down", () => {
@@ -375,6 +381,7 @@ describe("dispatch cool-down (schedulerTick)", () => {
       readEligible: () => eligibleOne("CTL-4"),
       dispatch: fakeDispatch({ code: 0 }),
       now: () => 70_000,
+      verifyDispatched: verifyOk, // CTL-611: not testing the verifier here
     });
     expect(existsSync(marker)).toBe(false);
   });
@@ -559,7 +566,11 @@ describe("schedulerTick — new-work pull", () => {
         inverseRelations: { nodes: [] },
       },
     ];
-    const r = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      verifyDispatched: verifyOk, // CTL-611: bypass the dispatch verifier
+    });
     // 2 free slots, both ready → both dispatched, urgent (CTL-8) first.
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-8", "CTL-9"]);
     // CTL-565: new-work enters the pipeline at research, not triage.
@@ -638,7 +649,11 @@ describe("schedulerTick — new-work pull", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     writeSignal("CTL-7", "triage", "done"); // research is owed
     const dispatch = fakeDispatch();
-    const r = schedulerTick(orchDir, { readEligible: () => [], dispatch });
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      verifyDispatched: verifyOk, // CTL-611: bypass dispatch verifier
+    });
     expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
   });
@@ -678,7 +693,11 @@ describe("schedulerTick — new-work pull", () => {
         inverseRelations: { nodes: [] },
       },
     ];
-    const r = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      verifyDispatched: verifyOk, // CTL-611: bypass dispatch verifier
+    });
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
     expect(r.dispatched).toEqual(["CTL-X"]);
     expect(dispatch.calls).toEqual([
@@ -1095,12 +1114,25 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
       writeSignal(args.ticket, args.phase, "dispatched");
       return { code: 0, stdout: "", stderr: "" };
     };
-    const r1 = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    // CTL-611: inject verifyOk — the stub writes status:"dispatched" with no
+    // bg_job_id (the intermediate state phase-agent-dispatch leaves before
+    // spawn at :406). The verifier correctly rejects that shape; the real
+    // dispatch only returns AFTER status flips to running + bg_job_id is set.
+    // The idempotency proof here is orthogonal to verification.
+    const r1 = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      verifyDispatched: verifyOk,
+    });
     expect(r1.dispatched).toEqual(["CTL-9"]);
 
     // "Crash" — the daemon dies; the dispatched signal survives on disk.
     // Tick 2 (post-restart) re-derives everything from the filesystem.
-    const r2 = schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    const r2 = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      verifyDispatched: verifyOk,
+    });
 
     // CTL-9 now has a worker dir → excluded from the pull. research:dispatched
     // is not 'done' → deriveAdvancement returns null. No re-dispatch.
@@ -1165,7 +1197,12 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
       applyTerminalDone: () => {},
       applyLabel: () => {},
     };
-    schedulerTick(orchDir, { readEligible: () => [], dispatch: okDispatch, writeStatus });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: okDispatch,
+      writeStatus,
+      verifyDispatched: verifyOk, // CTL-611
+    });
     expect(writes).toContainEqual(expect.objectContaining({ ticket: "CTL-1", phase: "plan" }));
   });
 
@@ -1181,6 +1218,7 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
       readEligible: () => [readyTicket("CTL-2")],
       dispatch: okDispatch,
       writeStatus,
+      verifyDispatched: verifyOk, // CTL-611
     });
     expect(writes).toContainEqual(expect.objectContaining({ ticket: "CTL-2", phase: "research" }));
   });
@@ -1613,6 +1651,7 @@ describe("schedulerTick — CTL-574 reclaim-dead-work sweep", () => {
       writeStatus,
       teardownWorktree: () => true,
       reclaimDeadWork,
+      verifyDispatched: verifyOk, // CTL-611: not testing dispatch verification
     });
 
     // Advancement saw the reclaimed implement: dispatch was called with the
@@ -2090,5 +2129,221 @@ describe("CTL-653: schedulerTick verify⇄remediate cycle (end-to-end)", () => {
     expect(verifySig.status).toBe("stalled");
     expect(verifySig.stalledReason).toBe("remediate-cycle-cap-exhausted");
     expect(existsSync(join(orchDir, "workers", TICKET, ".linear-label-needs-human.applied"))).toBe(true);
+  });
+});
+
+// ── CTL-611: post-dispatch verifier + phase.dispatch.failed event ─────────
+//
+// Two defects in the existing dispatch flow:
+//   Gap 1: rc=0 with no successor signal (--dry-run leak / half-write) was
+//          silently treated as a real advance. The verifier closes this.
+//   Gap 2: rc!=0 wrote a cool-down marker but emitted no event, so the
+//          broker / HUD / operator never saw the dropped advancement.
+// Every dispatch failure (real or demoted) now appends a single
+// phase.dispatch.failed.<TICKET> entry to ~/catalyst/events/YYYY-MM.jsonl.
+
+// readEventLogLines — read every line of the current UTC YYYY-MM.jsonl under
+// the redirected CATALYST_DIR; returns [] when the file does not exist (the
+// happy-path regression assertion). Each line is parsed as a canonical
+// envelope.
+function readEventLogLines() {
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  const logPath = join(catalystDir, "events", `${ym}.jsonl`);
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+// dispatchFailedEvents — narrow the unified log to just the CTL-611 emissions
+// for a given ticket. The canonical name is phase.dispatch.failed.<TICKET>.
+function dispatchFailedEvents(ticket) {
+  return readEventLogLines().filter(
+    (e) => e?.attributes?.["event.name"] === `phase.dispatch.failed.${ticket}`
+  );
+}
+
+describe("verifyDispatchedSignal (CTL-611)", () => {
+  test("returns false when signal file is absent", () => {
+    expect(verifyDispatchedSignal(orchDir, "CTL-100", "research")).toEqual({
+      ok: false,
+      reason: "signal_missing",
+    });
+  });
+
+  test("returns false when bg_job_id is null (--dry-run leak shape)", () => {
+    const dir = join(orchDir, "workers", "CTL-101");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({ ticket: "CTL-101", phase: "research", status: "dispatched", bg_job_id: null })
+    );
+    expect(verifyDispatchedSignal(orchDir, "CTL-101", "research")).toEqual({
+      ok: false,
+      reason: "bg_job_id_missing",
+    });
+  });
+
+  test("returns false when status is not runnable (e.g. stalled)", () => {
+    const dir = join(orchDir, "workers", "CTL-102");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({ ticket: "CTL-102", phase: "research", status: "stalled", bg_job_id: "abc" })
+    );
+    expect(verifyDispatchedSignal(orchDir, "CTL-102", "research")).toEqual({
+      ok: false,
+      reason: "status_not_runnable",
+    });
+  });
+
+  test("returns true on a healthy dispatched signal", () => {
+    const dir = join(orchDir, "workers", "CTL-103");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({ ticket: "CTL-103", phase: "research", status: "running", bg_job_id: "abcd1234" })
+    );
+    expect(verifyDispatchedSignal(orchDir, "CTL-103", "research")).toEqual({ ok: true });
+  });
+});
+
+describe("phase.dispatch.failed event emission (CTL-611)", () => {
+  const eligibleOne = (id) => [
+    {
+      identifier: id,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      labels: ["Ready"],
+      blockedBy: [],
+      raw: { team: { key: "CTL" } },
+    },
+  ];
+
+  test("advancement sweep demotes rc=0 + missing bg job to failure", () => {
+    // FSM owes plan; fakeDispatch returns rc=0 but does NOT write the signal.
+    writeSignal("CTL-200", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0, writeSignal: false });
+
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => 1_000,
+    });
+
+    expect(dispatch.calls).toHaveLength(1);
+    // Demotion: no advance recorded.
+    expect(result?.advanced ?? []).not.toContainEqual({ ticket: "CTL-200", phase: "plan" });
+    // Cool-down marker exists (failure-on-disk effect).
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-200", "plan"))).toBe(true);
+    // Exactly one event emitted with verify_failed reason + code=0.
+    const events = dispatchFailedEvents("CTL-200");
+    expect(events).toHaveLength(1);
+    expect(events[0].body.payload).toMatchObject({
+      target_phase: "plan",
+      code: 0,
+    });
+    expect(events[0].body.payload.reason).toMatch(/^verify_failed:/);
+  });
+
+  test("advancement sweep emits phase.dispatch.failed on rc!=0", () => {
+    writeSignal("CTL-201", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 1 });
+
+    schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 1_000 });
+
+    const events = dispatchFailedEvents("CTL-201");
+    expect(events).toHaveLength(1);
+    expect(events[0].body.payload).toMatchObject({
+      target_phase: "plan",
+      code: 1,
+      reason: "dispatch_nonzero_exit",
+    });
+  });
+
+  test("new-work sweep emits phase.dispatch.failed on rc!=0", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 1 });
+
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-202"),
+      dispatch,
+      now: () => 1_000,
+    });
+
+    const events = dispatchFailedEvents("CTL-202");
+    expect(events).toHaveLength(1);
+    expect(events[0].body.payload).toMatchObject({
+      target_phase: "research",
+      code: 1,
+      reason: "dispatch_nonzero_exit",
+    });
+  });
+
+  test("new-work sweep demotes rc=0 + missing bg job to failure", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0, writeSignal: false });
+
+    const result = schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-203"),
+      dispatch,
+      now: () => 1_000,
+    });
+
+    expect(dispatch.calls).toHaveLength(1);
+    expect(result?.dispatched ?? []).not.toContain("CTL-203");
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-203", "research"))).toBe(true);
+    const events = dispatchFailedEvents("CTL-203");
+    expect(events).toHaveLength(1);
+    expect(events[0].body.payload).toMatchObject({ target_phase: "research", code: 0 });
+    expect(events[0].body.payload.reason).toMatch(/^verify_failed:/);
+  });
+
+  test("event is emitted exactly once per failure (cool-down suppresses retry)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 1 });
+
+    // Tick 1: failure → 1 dispatch, 1 event.
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-204"),
+      dispatch,
+      now: () => 1_000,
+    });
+    // Tick 2 inside the 60s window: suppressed by cool-down → 0 new dispatch,
+    // 0 new event (the dispatch never re-attempts so emission never fires).
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-204"),
+      dispatch,
+      now: () => 30_000,
+    });
+
+    expect(dispatch.calls).toHaveLength(1);
+    expect(dispatchFailedEvents("CTL-204")).toHaveLength(1);
+  });
+
+  test("successful dispatch with verified signal does NOT emit phase.dispatch.failed", () => {
+    // Advancement happy-path regression — verifier returns ok, no failure
+    // event is appended. fakeDispatch does not write a signal, so the
+    // verifier is injected directly to assert the success-branch behaviour.
+    writeSignal("CTL-205", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => 1_000,
+      verifyDispatched: verifyOk,
+    });
+
+    expect(dispatch.calls).toHaveLength(1);
+    expect(dispatchFailedEvents("CTL-205")).toHaveLength(0);
+    // No cool-down marker either — verifier ok ⇒ existing CTL-624 clear path.
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-205", "plan"))).toBe(false);
   });
 });

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -443,6 +443,16 @@ while IFS=$'\t' read -r W T; do
 				--orch-id "$ORCH_ID" </dev/null
 		) || {
 			echo "phase-agent-dispatch failed for $T phase=$PHASE — see stderr" >&2
+			# CTL-611: surface the silent drop as a phase.dispatch.failed.<TICKET>
+			# event so the broker / HUD / operator can react. Without this, the
+			# `continue` advanced to the next ticket with no machine-readable
+			# signal — the legacy silent-drop the plan §Phase 2 closes. Best-effort.
+			"$STATE_SCRIPT" event "$(jq -nc \
+				--arg ts "$(now_iso)" --arg orch "$ORCH_ID" --arg w "$T" --arg phase "$PHASE" \
+				'{ts:$ts, orchestrator:$orch, worker:$w,
+				  event:("phase.dispatch.failed." + $w),
+				  detail:{toPhase:$phase, reason:"dispatch-failed"}}')" \
+				>/dev/null 2>&1 || true
 			continue
 		}
 

--- a/plugins/dev/scripts/orchestrate-phase-advance
+++ b/plugins/dev/scripts/orchestrate-phase-advance
@@ -162,6 +162,19 @@ fi
   echo "ERROR: dispatch-next failed for ${TICKET} phase=${NEXT_PHASE}" >&2
   jq -nc --arg from "$COMPLETED_PHASE" --arg to "$NEXT_PHASE" --arg ticket "$TICKET" \
     '{advanced: false, fromPhase: $from, toPhase: $to, ticket: $ticket, reason: "dispatch-failed"}'
+  # CTL-611: surface the silent drop as a phase.dispatch.failed.<TICKET> event
+  # so the broker / HUD / operator can react. Without this, exit 0 + stderr-only
+  # ERROR left no machine-readable signal that the next-phase worker never
+  # launched. Best-effort — never changes the exit code.
+  if [ -x "$STATE_SCRIPT" ]; then
+    "$STATE_SCRIPT" event "$(jq -nc \
+      --arg ts "$(now_iso)" --arg orch "$ORCH_ID" --arg w "$TICKET" \
+      --arg from "$COMPLETED_PHASE" --arg to "$NEXT_PHASE" \
+      '{ts:$ts, orchestrator:$orch, worker:$w,
+        event:("phase.dispatch.failed." + $w),
+        detail:{fromPhase:$from, toPhase:$to, reason:"dispatch-failed"}}')" \
+      >/dev/null 2>&1 || true
+  fi
   exit 0
 }
 


### PR DESCRIPTION
## Summary

Closes the silent-drop gaps where a failed phase dispatch in the orchestrator left the run wedged with **no event surfaced** to the broker, HUD, or operator. Failures are now uniformly emitted as `phase.dispatch.failed.<TICKET>` across both the modern execution-core scheduler and the legacy bash phase-agent paths.

## Changes

**execution-core scheduler (`scheduler.mjs`, `recovery.mjs`)**
- `verifyDispatchedSignal` — pure read of `workers/<T>/phase-<P>.json`. An `rc=0` result without `{status: "dispatched"|"running"}` + a non-empty `bg_job_id` is reclassified as a failure (catches `--dry-run` leaks and `mark_launch_failed` half-writes that previously masqueraded as real advances).
- `defaultAppendDispatchFailedEvent` — reuses `recovery.mjs`'s canonical event builder + appender (no second writer), routing via the broker's existing `PHASE_EVENT_PATTERN`.
- Wired into both the advancement sweep and the new-work sweep through injectable seams so tests can pin the demotion path independently of fixture choice.

**legacy bash paths (`orchestrate-phase-advance`, `orchestrate-dispatch-next`)**
- `orchestrate-phase-advance`: on dispatch-next non-zero exit, emits `phase.dispatch.failed.<TICKET>` via the catalyst-state event channel. Existing stdout JSON + stderr ERROR and the idempotency contract are unchanged.
- `orchestrate-dispatch-next`: on phase-agent-dispatch failure, the `continue` semantics are preserved (one failed ticket does not block others) but the silent drop is now surfaced as an event.
- Both emits are best-effort (`|| true`) so a stale `STATE_SCRIPT` or `jq` error cannot change the dispatcher's exit code.

## Tests

- `scheduler.test.mjs` — covers the verifier demotion path and the failure-event emission for both sweeps.
- `orchestrate-dispatch-next.test.sh`, `orchestrate-phase-advance.test.sh` — assert the legacy paths emit the event without altering exit codes.

Refs: CTL-611
