### PR TITLE
fix(dev): phase-mode turn-cap continuation — orchestrate-revive fires --resume in phase-agents mode (CTL-613)

### DIFF
--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -874,3 +874,91 @@ agent: "trust this summary; do not re-walk the plan."
   warrants it. The shared infrastructure (event status, emitter flags,
   broker regex, orchestrate-revive split, schema, resume hook) is
   reusable as-is.
+
+---
+
+## ADR-020: Phase-mode turn-cap continuation lives in `orchestrate-revive`, not the daemon (CTL-613)
+
+**Context**
+
+ADR-019 introduced the turn-cap continuation path against the legacy top-level
+`workers/<TICKET>.json` loop in `orchestrate-revive`. With phase-agents mode
+(ADR-017) now the default `dispatchMode`, phase-mode workers don't write the
+top-level signal — only the per-phase signal `workers/<TICKET>/phase-<name>.json`.
+ADR-019's loop is structurally a no-op for them. The CTL-493 per-phase loop
+that was added to plug the legacy/phase split only consumes `status="stalled"`
+and silently skips `status="turn-cap-exhausted"`, so a handoff doc written by
+`phase-implement` sits unused and the ticket hangs (incident ADV-1134).
+
+The daemon's terminal-status set (`execution-core/signal-reader.mjs`) classifies
+`turn-cap-exhausted` as a terminal phase status — a deliberate ADR-019 choice
+so the daemon doesn't try to resurrect a worker that the agent itself decided
+to stop. That terminal classification is correct: continuation is a different
+operation (resume + handoff) than reclaim (re-dispatch from scratch). What's
+missing is a code path that consumes the terminal signal and dispatches the
+continuation.
+
+**Decision**
+
+Add a fifth branch to `orchestrate-revive`'s CTL-493 per-phase loop that
+consumes `P_STATUS=="turn-cap-exhausted"` directly off the per-phase signal:
+budget-check against a new `.phaseContinuationCount` field, resolve the Claude
+session id, resolve the worktree from the orchestrator's `state.json`, spawn
+the continuation via the existing `spawn_continuation_bg` helper, mutate the
+per-phase signal back to `running`, and emit `phase.<name>.dispatched` so the
+broker re-arms. `phaseContinuationCount` shares the `MAX_CONTINUATIONS` budget
+with ADR-019's top-level counter (default 3); the two counters are tracked
+separately so a phase re-walked across the pipeline doesn't inherit a stale
+top-level count.
+
+Resolve the prior session id for `claude --bg` workers from
+`~/.claude/jobs/<bg_job_id>/state.json`'s `linkScanPath` field rather than
+plumbing the session id into the per-phase signal at dispatch time. The
+basename minus `.jsonl` is the canonical session id. This keeps the dispatcher
+contract (single-write of the per-phase signal) intact.
+
+**Rationale**
+
+- **Daemon terminal-status set stays intact**: `signal-reader.mjs` continues
+  to classify `turn-cap-exhausted` as terminal so the daemon doesn't try to
+  reclaim or re-dispatch on it. The recovery path is `orchestrate-revive`'s
+  job — a script invoked by the daemon's sweep, not the daemon's own decision
+  tree. Conflating those (e.g., un-terminalizing the status and adding a
+  continuation arm to the daemon) would mix two distinct lifecycles into one
+  state machine.
+- **Session-id resolver fallback over signal-side plumbing**: the
+  `linkScanPath` field is populated by Claude CLI within milliseconds of the
+  `--bg` worker starting. Reading it on demand is cheap and self-contained —
+  no `phase-agent-dispatch` change, no atomic-write contention with the
+  existing single-writer guarantee on per-phase signals. The alternative
+  (writing the session id into the signal at dispatch time) would require
+  `phase-agent-dispatch` to parse Claude's init output, race the per-phase
+  signal's initial write, and grow the schema surface for what is effectively
+  a derived field.
+- **Separate budget field, shared cap**: `phaseContinuationCount` ≠
+  `continuationCount` so the operator can disambiguate which lifecycle did
+  the continuing. Sharing `MAX_CONTINUATIONS` avoids a second config knob
+  for the same kind of decision.
+
+**Alternatives considered**
+
+- **Un-terminalize `turn-cap-exhausted` in the daemon**: would let the daemon's
+  reclaim/revive pass walk into the continuation logic, but conflates two
+  distinct recovery operations and grows the daemon's state surface.
+- **Plumb session id into the per-phase signal at dispatch time**: removes
+  the resolver fallback's dependency on Claude CLI's job dir layout, but
+  duplicates a derived field that the job dir already owns and adds a
+  signal-side race with the existing single-write contract. Deferred — the
+  fallback is sufficient and easy to revisit if `linkScanPath` proves flaky.
+
+**Consequences**
+
+- Phase-mode workers can chain `turn-cap-exhausted` continuations
+  automatically up to `MAX_CONTINUATIONS`.
+- `phaseContinuationCount` becomes a visible signal field. The schema
+  validator (`signal-schema.ts`) is documented with a sibling comment so
+  future readers see the parallel with the top-level `continuationCount`.
+- `--bg` session id resolution gains a second entry point
+  (`resolve_phase_session_id`) distinct from the stream-JSONL-driven
+  `resolve_session_id`; both coexist (the legacy resolver still serves
+  ADR-019's top-level branch).

--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -266,6 +266,19 @@ Revive budget: the top-level `workers/<TICKET>.json` carries `.reviveCount`. Whe
 `reviveCount >= MAX_REVIVES` (default 10), the worker is marked `stalled` with
 `attentionReason="revive-budget-exhausted"`.
 
+Phase-mode workers that emit `phase.<name>.turn-cap-exhausted.<TICKET>` are
+continued via `orchestrate-revive`'s per-phase loop (CTL-613): the loop reads
+`.handoffPath` off the per-phase signal, resolves the prior Claude session id
+from `${JOBS_ROOT}/<bg_job_id>/state.json`'s `linkScanPath` field, resolves the
+worktree from the orchestrator's `state.json`, and spawns a `claude --bg --resume`
+worker with `CATALYST_IS_CONTINUATION=true` + `CATALYST_HANDOFF_PATH=<path>` +
+`CATALYST_CONTINUATION_COUNT=<n>`. The per-phase signal flips back to `running`
+with the new `bg_job_id`, `phaseContinuationCount` bumps, and a
+`phase.<name>.dispatched` event re-arms the broker. `phaseContinuationCount` is
+budgeted separately from `phaseReviveCount` (which counts hard-error
+re-dispatches) and shares `MAX_CONTINUATIONS` with the legacy top-level
+continuation branch.
+
 ## The events JSONL is the unified log
 
 Everything Catalyst does — worker dispatch, phase transitions, PR lifecycle,

--- a/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
@@ -653,6 +653,148 @@ OUT=$(probe_worktree "WT-1"); RC=$?
 [ -z "$OUT" ] && pass "missing state.json → empty stdout" || fail "missing state.json → empty stdout" "got: $OUT"
 scratch_teardown
 
+# ─── CTL-613: per-phase turn-cap-exhausted continuation branch ──────────────
+#
+# Phase-mode-only fixture: writes ONLY the per-phase signal (no top-level
+# workers/<T>.json) so the legacy CTL-484 branch cannot fire. The new
+# CTL-613 branch on the CTL-493 per-phase loop must consume the signal
+# end-to-end.
+
+make_phase_turn_cap_worker() {
+  local ticket="$1" phase="${2:-implement}"
+  local handoff="${3:-thoughts/shared/handoffs/T/2026-05-26_00-00-00_turn-cap-continuation.md}"
+  local cc="${4:-0}"
+  local bg_job_id="${5:-cafe1234}"
+  local worktree="${WORKTREE_ROOT}/${ticket}"
+  mkdir -p "$worktree" "${ORCH_DIR}/workers/${ticket}"
+  # Orchestrator state.json — required for phase_worktree_path.
+  jq -n --arg t "$ticket" --arg wt "$worktree" \
+    '{workers:[{ticket:$t, worktreePath:$wt}]}' \
+    > "${ORCH_DIR}/state.json"
+  local updated; updated=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  # Per-phase signal ONLY — no top-level workers/<T>.json.
+  jq -n --arg phase "$phase" --arg ticket "$ticket" \
+        --arg status "turn-cap-exhausted" --arg hp "$handoff" \
+        --arg reason "turn cap hit (75)" --arg bg "$bg_job_id" \
+        --argjson cc "$cc" --arg ts "$updated" \
+    '{ticket:$ticket, phase:$phase, status:$status, handoffPath:$hp,
+      failureReason:$reason, bg_job_id:$bg, phaseContinuationCount:$cc,
+      updatedAt:$ts}' \
+    > "${ORCH_DIR}/workers/${ticket}/phase-${phase}.json"
+  # Plant fake bg_job dir so resolve_phase_session_id finds it.
+  mkdir -p "${CATALYST_REVIVE_JOBS_DIR}/${bg_job_id}"
+  jq -n --arg sid "sess-${ticket}-${phase}" \
+    '{linkScanPath:("/tmp/projects/-foo/" + $sid + ".jsonl")}' \
+    > "${CATALYST_REVIVE_JOBS_DIR}/${bg_job_id}/state.json"
+}
+
+echo "test (CTL-613): phase-only turn-cap → continuation spawn (happy path)"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+HANDOFF="thoughts/shared/handoffs/PCONT-1/2026-05-26_00-00-00_turn-cap-continuation.md"
+make_phase_turn_cap_worker "PCONT-1" "implement" "$HANDOFF" 0 "cafebabe"
+run_revive > "${SCRATCH}/out" 2>&1
+PS=$(jq -r '.status' "${ORCH_DIR}/workers/PCONT-1/phase-implement.json")
+PCC=$(jq -r '.phaseContinuationCount // 0' "${ORCH_DIR}/workers/PCONT-1/phase-implement.json")
+PBG=$(jq -r '.bg_job_id // ""' "${ORCH_DIR}/workers/PCONT-1/phase-implement.json")
+PHC=$(jq -r '.phaseContinuations | length' "${ORCH_DIR}/workers/PCONT-1/phase-implement.json")
+[ "$PS" = "running" ] && pass "per-phase status → running" || fail "per-phase status → running" "got: $PS"
+[ "$PCC" = "1" ] && pass "phaseContinuationCount bumped to 1" || fail "phaseContinuationCount bumped to 1" "got: $PCC"
+# bg_job_id update is best-effort — depends on claude's JSON init line landing
+# fast enough for spawn_continuation_bg to capture it. The fake claude here
+# writes only to CLAUDE_LOG (not stdout), so the field stays at its prior
+# value. The CTL-484 happy-path test makes the same simplification. The
+# semantically-meaningful evidence — that a NEW worker was launched — is
+# already covered by the env-var and --resume assertions below.
+[ -n "$PBG" ] && pass "bg_job_id remains non-empty after continuation" || fail "bg_job_id non-empty" "got: empty"
+[ "$PHC" = "1" ] && pass "phaseContinuations[] audit entry" || fail "phaseContinuations[] audit entry" "got: $PHC"
+[ ! -f "${ORCH_DIR}/workers/PCONT-1.json" ] && pass "no top-level workers/PCONT-1.json created" || fail "no top-level workers/PCONT-1.json" "file exists"
+grep -q "CATALYST_IS_CONTINUATION=true" "$CLAUDE_LOG" && pass "claude launched with CATALYST_IS_CONTINUATION=true" || fail "CATALYST_IS_CONTINUATION env var passed" "log: $(cat "$CLAUDE_LOG")"
+grep -q "CATALYST_HANDOFF_PATH=${HANDOFF}" "$CLAUDE_LOG" && pass "claude launched with CATALYST_HANDOFF_PATH" || fail "CATALYST_HANDOFF_PATH env var passed" "log: $(cat "$CLAUDE_LOG")"
+grep -q "CATALYST_CONTINUATION_COUNT=1" "$CLAUDE_LOG" && pass "claude launched with CATALYST_CONTINUATION_COUNT=1" || fail "CATALYST_CONTINUATION_COUNT env var passed" "log: $(cat "$CLAUDE_LOG")"
+grep -q -- "--resume sess-PCONT-1-implement" "$CLAUDE_LOG" && pass "claude resumed phase-resolved session_id" || fail "claude resumed phase-resolved session_id" "log: $(cat "$CLAUDE_LOG")"
+grep -q "phase.implement.dispatched" "$STATE_LOG" && pass "phase.implement.dispatched event emitted" || fail "phase.implement.dispatched event emitted" "log: $(cat "$STATE_LOG")"
+grep -q '"continuation":true' "$STATE_LOG" && pass "dispatched event marked continuation:true" || fail "dispatched event marked continuation:true" "log: $(cat "$STATE_LOG")"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): phase-mode budget exhausted → escalate, no spawn"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+HANDOFF="thoughts/shared/handoffs/PCONT-2/2026-05-26_00-00-00_turn-cap-continuation.md"
+make_phase_turn_cap_worker "PCONT-2" "implement" "$HANDOFF" 3 "deadbeef"
+run_revive --max-continuations 3 > "${SCRATCH}/out" 2>&1
+PS=$(jq -r '.status' "${ORCH_DIR}/workers/PCONT-2/phase-implement.json")
+PCC=$(jq -r '.phaseContinuationCount // 0' "${ORCH_DIR}/workers/PCONT-2/phase-implement.json")
+[ "$PS" = "turn-cap-exhausted" ] && pass "budget exhausted: status unchanged" || fail "budget exhausted: status unchanged" "got: $PS"
+[ "$PCC" = "3" ] && pass "phaseContinuationCount preserved at budget" || fail "phaseContinuationCount preserved" "got: $PCC"
+grep -q "phase-continuation-budget-exhausted" "$STATE_LOG" && pass "phase-continuation-budget-exhausted attention raised" || fail "phase-continuation-budget-exhausted attention raised" "log: $(cat "$STATE_LOG")"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude not invoked when phase budget exhausted" || fail "claude not invoked when phase budget exhausted"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): no resolvable session_id → escalate phase-no-session-id, no spawn"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+HANDOFF="thoughts/shared/handoffs/PCONT-3/2026-05-26_00-00-00_turn-cap-continuation.md"
+make_phase_turn_cap_worker "PCONT-3" "implement" "$HANDOFF" 0 "noresolv"
+# Delete the planted state.json so the resolver fails.
+rm -f "${CATALYST_REVIVE_JOBS_DIR}/noresolv/state.json"
+run_revive > "${SCRATCH}/out" 2>&1
+PS=$(jq -r '.status' "${ORCH_DIR}/workers/PCONT-3/phase-implement.json")
+PCC=$(jq -r '.phaseContinuationCount // 0' "${ORCH_DIR}/workers/PCONT-3/phase-implement.json")
+[ "$PS" = "turn-cap-exhausted" ] && pass "no-session: status unchanged" || fail "no-session: status unchanged" "got: $PS"
+[ "$PCC" = "0" ] && pass "phaseContinuationCount NOT bumped when session_id missing" || fail "phaseContinuationCount NOT bumped when session_id missing" "got: $PCC"
+grep -q "phase-no-session-id" "$STATE_LOG" && pass "phase-no-session-id attention raised" || fail "phase-no-session-id attention raised" "log: $(cat "$STATE_LOG")"
+[ ! -s "$CLAUDE_LOG" ] && pass "claude not invoked when session_id missing" || fail "claude not invoked when session_id missing"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): missing handoffPath → no-op, no escalation"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+make_phase_turn_cap_worker "PCONT-4" "implement" "stub" 0 "noholdoff"
+# Null out handoffPath to simulate operator-set state.
+jq '.handoffPath = null' "${ORCH_DIR}/workers/PCONT-4/phase-implement.json" \
+  > "${ORCH_DIR}/workers/PCONT-4/phase-implement.json.tmp" \
+  && mv "${ORCH_DIR}/workers/PCONT-4/phase-implement.json.tmp" \
+        "${ORCH_DIR}/workers/PCONT-4/phase-implement.json"
+run_revive > "${SCRATCH}/out" 2>&1
+PS=$(jq -r '.status' "${ORCH_DIR}/workers/PCONT-4/phase-implement.json")
+PCC=$(jq -r '.phaseContinuationCount // 0' "${ORCH_DIR}/workers/PCONT-4/phase-implement.json")
+[ "$PS" = "turn-cap-exhausted" ] && pass "missing-handoff: status unchanged" || fail "missing-handoff: status unchanged" "got: $PS"
+[ "$PCC" = "0" ] && pass "missing-handoff: phaseContinuationCount not bumped" || fail "missing-handoff: phaseContinuationCount not bumped" "got: $PCC"
+! grep -q "phase-continuation-" "$STATE_LOG" && pass "missing-handoff: no phase-continuation attention raised" || fail "missing-handoff: no phase-continuation attention raised" "log: $(cat "$STATE_LOG")"
+[ ! -s "$CLAUDE_LOG" ] && pass "missing-handoff: claude not invoked" || fail "missing-handoff: claude not invoked"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): dry-run prints intent, mutates nothing"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+HANDOFF="thoughts/shared/handoffs/PCONT-5/2026-05-26_00-00-00_turn-cap-continuation.md"
+make_phase_turn_cap_worker "PCONT-5" "implement" "$HANDOFF" 0 "drycafe1"
+run_revive --dry-run > "${SCRATCH}/out" 2>&1
+PS=$(jq -r '.status' "${ORCH_DIR}/workers/PCONT-5/phase-implement.json")
+PCC=$(jq -r '.phaseContinuationCount // 0' "${ORCH_DIR}/workers/PCONT-5/phase-implement.json")
+[ "$PS" = "turn-cap-exhausted" ] && pass "dry-run: status unchanged" || fail "dry-run: status unchanged" "got: $PS"
+[ "$PCC" = "0" ] && pass "dry-run: phaseContinuationCount unchanged" || fail "dry-run: phaseContinuationCount unchanged" "got: $PCC"
+[ ! -s "$CLAUDE_LOG" ] && pass "dry-run: claude not invoked" || fail "dry-run: claude not invoked"
+grep -q "PCONT-5" "${SCRATCH}/out" && pass "dry-run: stderr mentions PCONT-5" || fail "dry-run: stderr mentions PCONT-5" "out: $(cat "${SCRATCH}/out")"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): regression — CTL-484 legacy fixture still triggers top-level continuation branch"
+scratch_setup
+HANDOFF="thoughts/shared/handoffs/REGR-1/2026-05-17_00-00-00_turn-cap-continuation.md"
+make_turn_cap_worker "REGR-1" "implement" "$HANDOFF" 0
+write_stream_init "REGR-1" "sess-regr-1"
+run_revive > "${SCRATCH}/out" 2>&1
+CC=$(jq -r '.continuationCount // 0' "${ORCH_DIR}/workers/REGR-1.json")
+[ "$CC" = "1" ] && pass "regression: legacy continuationCount still bumped" || fail "regression: legacy continuationCount still bumped" "got: $CC"
+grep -q -- "--resume sess-regr-1" "$CLAUDE_LOG" && pass "regression: legacy continuation spawn still fires" || fail "regression: legacy continuation spawn still fires" "log: $(cat "$CLAUDE_LOG")"
+scratch_teardown
+
 # ─── Results ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
@@ -563,6 +563,96 @@ RC=$(jq -r '.reviveCount // 0' "${ORCH_DIR}/workers/REG-1.json")
 [ -z "$(grep CATALYST_IS_CONTINUATION "$CLAUDE_LOG" 2>/dev/null)" ] && pass "regression: CATALYST_IS_CONTINUATION not set for normal revive" || fail "regression: CATALYST_IS_CONTINUATION leaked"
 scratch_teardown
 
+# ─── CTL-613: phase-mode session_id resolver (resolve_phase_session_id) ─────
+#
+# Unit tests for the new helper that resolves a Claude session_id from a
+# `claude --bg` job's state.json (bg_job_id → ~/.claude/jobs/<bg>/state.json
+# → linkScanPath → basename → strip .jsonl). Tests invoke the helper via the
+# `--probe-helper` flag.
+
+probe_resolver() {
+  # Echo just the resolver's stdout (one-line session id or empty); return its rc.
+  "$REVIVE" --probe-helper resolve_phase_session_id "$1"
+}
+
+echo "test (CTL-613): resolve_phase_session_id — bg_job_id → linkScanPath → session_id"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+mkdir -p "${CATALYST_REVIVE_JOBS_DIR}/cafe1234"
+jq -n '{linkScanPath:"/Users/ryan/.claude/projects/-foo-bar/abcdef12-3456-7890-abcd-ef1234567890.jsonl"}' \
+  > "${CATALYST_REVIVE_JOBS_DIR}/cafe1234/state.json"
+OUT=$(probe_resolver "cafe1234"); RC=$?
+[ "$RC" = "0" ] && pass "resolver rc=0 on happy path" || fail "resolver rc=0 on happy path" "got rc=$RC"
+[ "$OUT" = "abcdef12-3456-7890-abcd-ef1234567890" ] && pass "resolver returns session_id basename" || fail "resolver session_id" "got: $OUT"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): resolve_phase_session_id — missing state.json → rc=1 empty"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+mkdir -p "${CATALYST_REVIVE_JOBS_DIR}/dead0000"
+OUT=$(probe_resolver "dead0000"); RC=$?
+[ "$RC" != "0" ] && pass "missing state.json → rc!=0" || fail "missing state.json → rc!=0" "got rc=$RC"
+[ -z "$OUT" ] && pass "missing state.json → empty stdout" || fail "missing state.json → empty stdout" "got: $OUT"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): resolve_phase_session_id — malformed linkScanPath → rc=1 empty"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+mkdir -p "${CATALYST_REVIVE_JOBS_DIR}/bad00001"
+jq -n '{linkScanPath:"/garbage/no-extension"}' \
+  > "${CATALYST_REVIVE_JOBS_DIR}/bad00001/state.json"
+OUT=$(probe_resolver "bad00001"); RC=$?
+[ "$RC" != "0" ] && pass "malformed linkScanPath → rc!=0" || fail "malformed linkScanPath → rc!=0" "got rc=$RC"
+[ -z "$OUT" ] && pass "malformed linkScanPath → empty stdout" || fail "malformed linkScanPath → empty stdout" "got: $OUT"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): resolve_phase_session_id — empty bg_job_id arg → rc=1 empty"
+scratch_setup
+OUT=$(probe_resolver ""); RC=$?
+[ "$RC" != "0" ] && pass "empty bg_job_id → rc!=0" || fail "empty bg_job_id → rc!=0" "got rc=$RC"
+[ -z "$OUT" ] && pass "empty bg_job_id → empty stdout" || fail "empty bg_job_id → empty stdout" "got: $OUT"
+scratch_teardown
+
+# ─── CTL-613: phase_worktree_path resolver ──────────────────────────────────
+#
+# Unit tests for the helper that resolves a phase-mode worker's worktree
+# path from the orchestrator's state.json (workers[] array). Invoked via
+# the same --probe-helper shim.
+
+probe_worktree() {
+  "$REVIVE" --orch-dir "$ORCH_DIR" --orch-id "test" \
+    --probe-helper phase_worktree_path "$1"
+}
+
+echo "test (CTL-613): phase_worktree_path — workers[ticket].worktreePath → stdout, rc=0"
+scratch_setup
+jq -n '{workers:[{ticket:"WT-1", worktreePath:"/tmp/wt-1"}]}' \
+  > "${ORCH_DIR}/state.json"
+OUT=$(probe_worktree "WT-1"); RC=$?
+[ "$RC" = "0" ] && pass "phase_worktree_path rc=0 on happy path" || fail "phase_worktree_path rc=0 on happy path" "got rc=$RC"
+[ "$OUT" = "/tmp/wt-1" ] && pass "phase_worktree_path returns worktreePath" || fail "phase_worktree_path worktreePath" "got: $OUT"
+scratch_teardown
+
+echo "test (CTL-613): phase_worktree_path — ticket missing → rc=1 empty"
+scratch_setup
+jq -n '{workers:[{ticket:"WT-1", worktreePath:"/tmp/wt-1"}]}' \
+  > "${ORCH_DIR}/state.json"
+OUT=$(probe_worktree "WT-MISSING"); RC=$?
+[ "$RC" != "0" ] && pass "missing ticket → rc!=0" || fail "missing ticket → rc!=0" "got rc=$RC"
+[ -z "$OUT" ] && pass "missing ticket → empty stdout" || fail "missing ticket → empty stdout" "got: $OUT"
+scratch_teardown
+
+echo "test (CTL-613): phase_worktree_path — state.json missing → rc=1 empty"
+scratch_setup
+# Intentionally do not write state.json.
+OUT=$(probe_worktree "WT-1"); RC=$?
+[ "$RC" != "0" ] && pass "missing state.json → rc!=0" || fail "missing state.json → rc!=0" "got rc=$RC"
+[ -z "$OUT" ] && pass "missing state.json → empty stdout" || fail "missing state.json → empty stdout" "got: $OUT"
+scratch_teardown
+
 # ─── Results ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/orch-monitor/lib/signal-schema.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/signal-schema.ts
@@ -75,6 +75,12 @@ export function validateSignalFile(obj: unknown): boolean {
   // CTL-484 — continuation-budget bookkeeping. Distinct from reviveCount so the
   // operator can tell "this worker is making steady progress and just needs
   // more turns" apart from "this worker is failing and needs help".
+  //
+  // CTL-613 — The per-phase signal (workers/<T>/phase-<name>.json, not validated
+  // by this function) carries a sibling field `phaseContinuationCount` that
+  // tracks the same budget for phase-mode workers. Both fields share
+  // `MAX_CONTINUATIONS` in orchestrate-revive; they are tracked separately so a
+  // ticket re-walked across phases doesn't inherit a stale top-level count.
   if ("continuationCount" in o && o.continuationCount !== null && o.continuationCount !== undefined) {
     if (typeof o.continuationCount !== "number" || !Number.isInteger(o.continuationCount)) return false;
     if (o.continuationCount < 0) return false;

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -1122,11 +1122,12 @@ done
 # the top-level signal, so the previous loop is a structural no-op for them —
 # this loop is what gives phase-agents an actual recovery path.
 #
-# Decision tree per stalled signal:
-#   1. truly-failed (.failureReason set)     → escalate, no retry
-#   2. meaningful progress (commits/artifact) → emit synthetic complete
-#   3. budget exhausted                       → escalate
-#   4. fresh stall                            → re-dispatch, bump count
+# Decision tree per phase signal:
+#   1. CTL-613: turn-cap-exhausted → spawn continuation worker
+#   2. truly-failed (.failureReason set)     → escalate, no retry
+#   3. meaningful progress (commits/artifact) → emit synthetic complete
+#   4. budget exhausted                       → escalate
+#   5. fresh stall                            → re-dispatch, bump count
 
 PHASE_MODE_WORKERS=0
 PHASE_ELIGIBLE=0
@@ -1147,9 +1148,13 @@ for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
 
   PHASE_MODE_WORKERS=$((PHASE_MODE_WORKERS + 1))
 
-  if [ "$P_STATUS" != "stalled" ]; then
-    continue
-  fi
+  # CTL-613: also walk turn-cap-exhausted signals so the continuation branch
+  # below can fire. Everything else (stalled is the legacy CTL-493 trigger)
+  # continues to land in the four-way decision tree.
+  case "$P_STATUS" in
+    stalled|turn-cap-exhausted) ;;
+    *) continue ;;
+  esac
 
   # CTL-607: only the ticket's CURRENT (latest-index) phase is a live work
   # item. A stalled signal for an EARLIER phase is a reaping artifact
@@ -1168,6 +1173,114 @@ for PHASE_SIGNAL in "${ORCH_DIR}"/workers/*/phase-*.json; do
   echo "phase-mode worker detected: ${P_TICKET}/${P_PHASE} (status=${P_STATUS})" >&2
 
   PHASE_REVIVE_COUNT=$(jq -r '.phaseReviveCount // 0' "$PHASE_SIGNAL" 2>/dev/null || echo 0)
+
+  # ─── CTL-613: turn-cap-exhausted continuation branch ──────────────────────
+  #
+  # Mirrors the legacy CTL-484 top-level branch but reads everything off the
+  # per-phase signal. Runs BEFORE the truly-failed branch so a
+  # turn-cap-exhausted signal that also carries .failureReason (the emitter
+  # sets both — see phase-agent-emit-complete) routes to continuation, not
+  # escalation.
+  if [ "$P_STATUS" = "turn-cap-exhausted" ]; then
+    P_HANDOFF=$(jq -r '.handoffPath // ""' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+    P_BG_JOB=$(jq -r '.bg_job_id // ""' "$PHASE_SIGNAL" 2>/dev/null || echo "")
+    P_CC=$(jq -r '.phaseContinuationCount // 0' "$PHASE_SIGNAL" 2>/dev/null || echo 0)
+
+    if [ -z "$P_HANDOFF" ] || [ "$P_HANDOFF" = "null" ]; then
+      # No handoff → cannot continue. Leave signal alone (operator visibility);
+      # don't escalate — a real failure carries .failureReason and the
+      # truly-failed branch below handles it.
+      echo "phase-revive: ${P_TICKET}/${P_PHASE} turn-cap-exhausted with no handoffPath; skipping" >&2
+      continue
+    fi
+
+    # Budget check.
+    if [ "$P_CC" -ge "$MAX_CONTINUATIONS" ]; then
+      phase_revive_escalate "$P_TICKET" "$P_PHASE" \
+        "phase-continuation-budget-exhausted count=${P_CC}"
+      PHASE_ESCALATED=$((PHASE_ESCALATED + 1))
+      continue
+    fi
+
+    # Resolve session_id via the bg-job dir.
+    P_SID=$(resolve_phase_session_id "$P_BG_JOB" 2>/dev/null || echo "")
+    if [ -z "$P_SID" ]; then
+      phase_revive_escalate "$P_TICKET" "$P_PHASE" "phase-no-session-id"
+      PHASE_ESCALATED=$((PHASE_ESCALATED + 1))
+      continue
+    fi
+
+    # Resolve worktree path from orchestrator state.json.
+    P_WT=$(phase_worktree_path "$P_TICKET" 2>/dev/null || echo "")
+    if [ -z "$P_WT" ]; then
+      phase_revive_escalate "$P_TICKET" "$P_PHASE" "phase-no-worktree-path"
+      PHASE_ESCALATED=$((PHASE_ESCALATED + 1))
+      continue
+    fi
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "[dry-run] ${P_TICKET}/${P_PHASE}: would continue via session ${P_SID} from ${P_HANDOFF}" >&2
+      PHASE_REVIVED=$((PHASE_REVIVED + 1))
+      continue
+    fi
+
+    NEW_P_CC=$((P_CC + 1))
+    SPAWN_OUT=$(spawn_continuation_bg "$P_TICKET" "$P_WT" "$P_SID" \
+                                       "$P_HANDOFF" "$NEW_P_CC" \
+                                       "$P_PHASE" || echo "")
+    # spawn_continuation_bg shape: "pid:<pid>:<bg_job_id>". The bg_job_id is
+    # best-effort (depends on claude's JSON init line landing fast enough); the
+    # pid is the authoritative liveness signal. Mirrors the CTL-484 legacy
+    # branch — gate on pid, fall back to old bg_job_id when the new one isn't
+    # parseable in time.
+    NEW_P_PID="${SPAWN_OUT#pid:}"
+    NEW_P_PID="${NEW_P_PID%%:*}"
+    NEW_P_BG="${SPAWN_OUT##*:}"
+    [ "$NEW_P_BG" = "$SPAWN_OUT" ] && NEW_P_BG=""
+
+    if [ -z "$NEW_P_PID" ]; then
+      phase_revive_escalate "$P_TICKET" "$P_PHASE" "phase-continuation-spawn-failed"
+      PHASE_ESCALATED=$((PHASE_ESCALATED + 1))
+      continue
+    fi
+
+    # Mutate the per-phase signal: flip to running, bump count, swap bg_job_id
+    # (only when parseable — empty means the JSON init line didn't land yet, in
+    # which case keep the previous bg_job_id so the revive sweep still has a
+    # handle), append audit entry. Keep handoffPath so a subsequent turn-cap
+    # emit can overwrite with a fresh path instead of losing the reference.
+    TS=$(now_iso)
+    TMP="${PHASE_SIGNAL}.tmp.$$"
+    jq --arg ts "$TS" --arg bg "$NEW_P_BG" --arg sid "$P_SID" \
+       --arg hp "$P_HANDOFF" --argjson cc "$NEW_P_CC" \
+       '.status = "running"
+        | .updatedAt = $ts
+        | (if $bg == "" then . else .bg_job_id = $bg end)
+        | .phaseContinuationCount = $cc
+        | .phaseContinuations = ((.phaseContinuations // []) + [{ts:$ts, sessionId:$sid, handoffPath:$hp, bg_job_id:$bg}])' \
+       "$PHASE_SIGNAL" > "$TMP" && mv "$TMP" "$PHASE_SIGNAL"
+
+    # Re-emit phase.<name>.dispatched so the broker re-arms.
+    emit_state event "$(jq -nc \
+      --arg ts "$TS" --arg orch "$ORCH_ID" --arg w "$P_TICKET" \
+      --arg phase "$P_PHASE" --arg sid "$P_SID" --arg bg "$NEW_P_BG" \
+      "{ts:\$ts, orchestrator:\$orch, worker:\$w,
+        event:(\"phase.\" + \$phase + \".dispatched\"),
+        detail:{phase:\$phase, sessionId:\$sid, bg_job_id:\$bg, continuation:true}}")"
+
+    emit_state event "$(jq -nc --arg ts "$TS" --arg orch "$ORCH_ID" \
+      --arg w "$P_TICKET" --arg phase "$P_PHASE" --arg sid "$P_SID" \
+      --arg hp "$P_HANDOFF" --argjson cc "$NEW_P_CC" \
+      '{ts:$ts, orchestrator:$orch, worker:$w,
+        event:"phase-continuation-spawned",
+        detail:{phase:$phase, sessionId:$sid, handoffPath:$hp,
+                phaseContinuationCount:$cc}}')"
+
+    echo "PHASE-CONTINUED: ${P_TICKET}/${P_PHASE} (sid=${P_SID}, count=${NEW_P_CC}, handoff=${P_HANDOFF})" >&2
+    PHASE_REVIVED=$((PHASE_REVIVED + 1))
+    continue
+  fi
+  # ─── End CTL-613 branch ───────────────────────────────────────────────────
 
   # Branch 1: truly failed → escalate, no retry.
   if phase_is_truly_failed "$PHASE_SIGNAL"; then

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -49,6 +49,13 @@ STALE_HEARTBEAT_SECONDS=900
 WORKER_COMMAND="/catalyst-dev:oneshot"
 MODEL="opus"
 DRY_RUN=0
+# CTL-613: --probe-helper invokes one helper function from the test harness
+# without running the main revive loop. PROBE_HELPER holds the function name,
+# PROBE_ARG holds its single argument. When set, the script skips
+# --orch-dir/--orch-id validation, defines its helpers, dispatches the call,
+# and exits with the helper's return code.
+PROBE_HELPER=""
+PROBE_ARG=""
 
 usage() {
   sed -n '2,32p' "$0"
@@ -66,14 +73,17 @@ while [[ $# -gt 0 ]]; do
     --worker-command)           WORKER_COMMAND="$2"; shift 2 ;;
     --model)                    MODEL="$2"; shift 2 ;;
     --dry-run)                  DRY_RUN=1; shift ;;
+    --probe-helper)             PROBE_HELPER="$2"; PROBE_ARG="${3:-}"; shift 3 ;;
     -h|--help)                  usage 0 ;;
     *)                          echo "unknown arg: $1" >&2; usage ;;
   esac
 done
 
-[ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
-[ -z "$ORCH_ID" ]  && { echo "ERROR: --orch-id required"  >&2; exit 2; }
-[ ! -d "$ORCH_DIR/workers" ] && { echo "ERROR: no workers dir at $ORCH_DIR/workers" >&2; exit 2; }
+if [ -z "$PROBE_HELPER" ]; then
+  [ -z "$ORCH_DIR" ] && { echo "ERROR: --orch-dir required" >&2; exit 2; }
+  [ -z "$ORCH_ID" ]  && { echo "ERROR: --orch-id required"  >&2; exit 2; }
+  [ ! -d "$ORCH_DIR/workers" ] && { echo "ERROR: no workers dir at $ORCH_DIR/workers" >&2; exit 2; }
+fi
 
 now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
@@ -133,6 +143,37 @@ resolve_session_id() {
   fi
 
   return 1
+}
+
+# CTL-613: resolve the Claude session_id for a phase-mode worker spawned via
+# `claude --bg`. The bg job dir is the source of truth — its state.json
+# carries a `linkScanPath` field whose basename (minus `.jsonl`) is the
+# Claude session id used for `--resume`. This is the fallback used by the
+# per-phase turn-cap-exhausted continuation branch because phase-mode workers
+# don't write the legacy stream JSONL that `resolve_session_id` reads.
+#
+# Returns:
+#   stdout: session_id on success, empty on failure
+#   exit:   0 on success, 1 on failure
+#
+# CATALYST_REVIVE_JOBS_DIR overrides ~/.claude/jobs for tests.
+resolve_phase_session_id() {
+  local bg_job_id="$1"
+  [ -z "$bg_job_id" ] && return 1
+  local jobs_dir="${CATALYST_REVIVE_JOBS_DIR:-${HOME}/.claude/jobs}"
+  local state_file="${jobs_dir}/${bg_job_id}/state.json"
+  [ -f "$state_file" ] || return 1
+  local link_path
+  link_path=$(jq -r '.linkScanPath // empty' "$state_file" 2>/dev/null || echo "")
+  [ -z "$link_path" ] && return 1
+  case "$link_path" in
+    *.jsonl) : ;;
+    *) return 1 ;;
+  esac
+  local sid
+  sid=$(basename "$link_path" .jsonl)
+  [ -z "$sid" ] && return 1
+  echo "$sid"
 }
 
 # Detect an API stream-idle-timeout failure in the tail of the worker's stream
@@ -604,6 +645,24 @@ phase_revive_escalate() {
   fi
 }
 
+# CTL-613: phase_worktree_path TICKET
+# Returns the worktreePath for a phase-mode worker by reading the
+# orchestrator's state.json (workers[] array). Phase-mode per-phase signals
+# do not carry worktreePath directly — it lives on the orchestrator state.
+# Returns empty + rc=1 on miss (no state.json, no matching ticket, or empty
+# worktreePath field).
+phase_worktree_path() {
+  local ticket="$1"
+  local state="${ORCH_DIR}/state.json"
+  [ -f "$state" ] || return 1
+  local wt
+  wt=$(jq -r --arg t "$ticket" \
+    '.workers[]? | select(.ticket == $t) | .worktreePath // empty' \
+    "$state" 2>/dev/null | head -1)
+  [ -z "$wt" ] && return 1
+  echo "$wt"
+}
+
 # phase_revive_emit_complete TICKET PHASE PROGRESS_REASON
 # Calls phase-agent-emit-complete to publish the synthetic complete event +
 # mutate the signal status to "done". Best-effort.
@@ -666,6 +725,21 @@ phase_revive_redispatch() {
     fi
   fi
 }
+
+# ─── CTL-613: probe-helper dispatch ─────────────────────────────────────────
+#
+# Test harness shim: when `--probe-helper FUNC ARG` was passed, invoke the
+# named helper with the single arg, then exit with the helper's return code.
+# Used by orchestrate-revive.test.sh to unit-test helpers (resolve_phase_session_id,
+# phase_worktree_path) without driving the full revive loop.
+if [ -n "$PROBE_HELPER" ]; then
+  case "$PROBE_HELPER" in
+    resolve_phase_session_id|phase_worktree_path) ;;
+    *) echo "ERROR: --probe-helper does not allow ${PROBE_HELPER}" >&2; exit 2 ;;
+  esac
+  "$PROBE_HELPER" "$PROBE_ARG"
+  exit $?
+fi
 
 # ─── Main loop ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `orchestrate-revive`'s CTL-484 turn-cap continuation branch only read `status=turn-cap-exhausted` from the **top-level** `workers/<T>.json` signal, so in `dispatchMode=phase-agents` (where status lives at `workers/<T>/phase-<name>.json`) it never fired — a turn-capped phase worker hung indefinitely with a valid handoff doc sitting unused.
- Adds a per-phase continuation branch: scans `workers/<T>/phase-*.json` for `turn-cap-exhausted` + `handoffPath`, then relaunches `claude --bg --resume <sessionId>` with `CATALYST_IS_CONTINUATION=true` + `CATALYST_HANDOFF_PATH`, bumping `phaseContinuationCount` on the per-phase signal (separate budget from the top-level `continuationCount`).
- New helpers `resolve_phase_session_id` + `phase_worktree_path`; ADR-020 + orchestrator-overview docs.

## Test plan
- [x] `orchestrate-revive.test.sh` — 125 pass / 0 fail (incl. CTL-484 legacy top-level regression + new phase-mode continuation)
- [x] `orchestrate-revive-phase.test.sh` — 30 pass / 0 fail (CTL-607 predecessor-guard coexistence verified post-rebase)
- [x] Rebased onto origin/main; CTL-607's orchestrate-revive guard preserved
- [x] signal-schema.ts change is comment-only (documents the sibling `phaseContinuationCount` field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)