### PR TITLE
CTL-658: Complete daemon resume-on-revive (resolvePhaseSessionId)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -46,6 +46,15 @@ assert_contains() {
 	fi
 }
 
+assert_not_contains() {
+	local haystack="$1" needle="$2" label="$3"
+	if [[ $haystack != *"$needle"* ]]; then
+		pass "$label"
+	else
+		fail "$label — '$needle' unexpectedly found in '$haystack'"
+	fi
+}
+
 if [[ ! -x $DISPATCH ]]; then
 	echo "FATAL: $DISPATCH not found or not executable" >&2
 	exit 1
@@ -73,13 +82,27 @@ setup_claude_stub() {
 #!/usr/bin/env bash
 LOG="${CLAUDE_STUB_LOG:-/tmp/claude-stub.log}"
 JOB_ID="${CLAUDE_STUB_JOB_ID:-f124220a}"
+# CTL-658: detect a `--resume` invocation so a test can script the resume
+# outcome (stderr + exit) independently of the fresh-start fallback spawn that
+# may follow in the SAME dispatch.
+IS_RESUME=0
+for a in "$@"; do [ "$a" = "--resume" ] && IS_RESUME=1; done
 {
   echo "--ARGS--"
   printf '%s\n' "$@"
   echo "--ENV--"
   env | grep -E '^(CATALYST_(ORCHESTRATOR_(DIR|ID)|PHASE|TICKET)|OTEL_RESOURCE_ATTRIBUTES)=' | sort
   echo "--END--"
-} > "$LOG"
+} >> "$LOG"   # CTL-658: append (a resume-then-fresh dispatch invokes claude twice)
+# CTL-658: a --resume invocation honors the scripted resume outcome so a test
+# can drive launched (empty stderr) / alive (rejection marker) / failed (other
+# stderr) paths. A non-resume (fresh-start) invocation always succeeds below.
+if [ "$IS_RESUME" = "1" ]; then
+  [ -n "${CLAUDE_STUB_RESUME_STDERR:-}" ] && printf '%s\n' "$CLAUDE_STUB_RESUME_STDERR" >&2
+  if [ -n "${CLAUDE_STUB_RESUME_EXIT:-}" ] && [ "${CLAUDE_STUB_RESUME_EXIT}" != "0" ]; then
+    exit "${CLAUDE_STUB_RESUME_EXIT}"
+  fi
+fi
 # Mimic today's `claude --bg` multi-line stdout — the hex job ID lives on
 # line 1 after the bullet character; subsequent lines list helper commands.
 cat <<EOF
@@ -785,6 +808,93 @@ assert_eq "refused" "$(jq -r '.status' "${TEST_DIR}/rem.out" 2>/dev/null || echo
 	"remediate stdout JSON status = refused"
 [[ -f "${WORKER_DIR}/phase-remediate.json" ]] && SIG_REM_EXISTS="yes" || SIG_REM_EXISTS="no"
 assert_eq "no" "$SIG_REM_EXISTS" "no remediate signal written when refused"
+
+# ─── CTL-658: --resume-session (daemon resume-on-revive) ────────────────────
+# phase-agent-dispatch honors a resolved resume UUID by spawning
+# `claude --bg --resume <uuid>` instead of a fresh /catalyst-dev:phase-* prompt,
+# then classifies the resume stderr: launched / alive / failed-fallback.
+# triage is used as the carrier phase because it needs no prior artifact.
+
+echo ""
+echo "Test 22 (CTL-658): --resume-session plumbs --resume <uuid>, drops the fresh prompt"
+fresh_env t22_resume_flag
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	--resume-session abc-uuid >"${TEST_DIR}/t22.out" 2>/dev/null
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" "--resume" "resume invocation carries --resume flag"
+assert_contains "$LOG" "abc-uuid" "resume invocation carries the session uuid"
+assert_not_contains "$LOG" "/catalyst-dev:phase-" "resume invocation drops the fresh phase prompt"
+
+echo ""
+echo "Test 23 (CTL-658): clean resume (empty stderr) → signal running with new bg_job_id, exit 0"
+fresh_env t23_resume_launched
+export CLAUDE_STUB_JOB_ID="deadbeef"
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	--resume-session abc-uuid >"${TEST_DIR}/t23.out" 2>/dev/null
+RC23=$?
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "0" "$RC23" "clean resume exits 0"
+assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "clean resume leaves signal at running"
+assert_eq "deadbeef" "$(jq -r '.bg_job_id' "$SIGNAL")" "clean resume records the resumed bg_job_id"
+unset CLAUDE_STUB_JOB_ID
+
+echo ""
+echo "Test 24 (CTL-658): resume rejected as alive → signal stalled (resume-rejected-alive), no fresh spawn, exit non-zero"
+fresh_env t24_resume_alive
+export CATALYST_DIR="${TEST_DIR}/catalyst-events"
+mkdir -p "${CATALYST_DIR}/events"
+export CLAUDE_STUB_RESUME_STDERR="Error: session abc-uuid is currently running as a background agent (bg)"
+export CLAUDE_STUB_RESUME_EXIT=1
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	--resume-session abc-uuid >"${TEST_DIR}/t24.out" 2>/dev/null
+RC24=$?
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "1" "$RC24" "alive-rejected resume exits non-zero"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "alive-rejected resume flips signal to stalled"
+assert_eq "resume-rejected-alive" "$(jq -r '.attentionReason' "$SIGNAL")" \
+	"alive-rejected resume records attentionReason=resume-rejected-alive"
+assert_eq "resume_rejected_alive" "$(jq -r '.reason' "${TEST_DIR}/t24.out")" \
+	"alive-rejected resume stdout JSON reason=resume_rejected_alive"
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_not_contains "$LOG" "/catalyst-dev:phase-" "alive-rejected resume does NOT fall back to a fresh spawn"
+unset CLAUDE_STUB_RESUME_STDERR CLAUDE_STUB_RESUME_EXIT CATALYST_DIR
+
+echo ""
+echo "Test 25 (CTL-658): hard resume failure → fresh-start fallback in the same invocation"
+fresh_env t25_resume_fallback
+export CLAUDE_STUB_RESUME_STDERR="boom: unrecoverable resume error"
+export CLAUDE_STUB_RESUME_EXIT=1
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	--resume-session abc-uuid >"${TEST_DIR}/t25.out" 2>/dev/null
+RC25=$?
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "0" "$RC25" "fallback path exits 0 (the fresh start succeeded)"
+assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "fallback leaves signal at running"
+LOG=$(cat "$CLAUDE_STUB_LOG")
+ARGS_COUNT=$(grep -c -- '--ARGS--' "$CLAUDE_STUB_LOG")
+assert_eq "2" "$ARGS_COUNT" "claude was invoked twice (resume, then fresh fallback)"
+RESUME_COUNT=$(grep -c -- '--resume' "$CLAUDE_STUB_LOG")
+assert_eq "1" "$RESUME_COUNT" "only the first (resume) invocation carried --resume"
+assert_contains "$LOG" "/catalyst-dev:phase-triage CTL-100" "fresh fallback invocation carried the phase prompt"
+unset CLAUDE_STUB_RESUME_STDERR CLAUDE_STUB_RESUME_EXIT
+
+echo ""
+echo "Test 26 (CTL-658): no --resume-session → exactly today's single fresh-start spawn"
+fresh_env t26_no_resume
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	>"${TEST_DIR}/t26.out" 2>/dev/null
+LOG=$(cat "$CLAUDE_STUB_LOG")
+ARGS_COUNT=$(grep -c -- '--ARGS--' "$CLAUDE_STUB_LOG")
+assert_eq "1" "$ARGS_COUNT" "no-resume dispatch invokes claude exactly once"
+assert_not_contains "$LOG" "--resume" "no-resume dispatch carries no --resume flag"
+assert_contains "$LOG" "/catalyst-dev:phase-triage CTL-100" "no-resume dispatch carries the fresh phase prompt"
+
+echo ""
+echo "Test 27 (CTL-658): --dry-run --resume-session surfaces resumeSession in the JSON"
+fresh_env t27_dry_resume
+OUT_DRY=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	--resume-session abc-uuid --dry-run 2>/dev/null)
+assert_eq "abc-uuid" "$(jq -r '.resumeSession' <<<"$OUT_DRY")" "dry-run JSON echoes resumeSession"
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -45,23 +45,31 @@ function defaultResolveProject(ticket) {
 // (execution-core has no long-lived orchestrator); CATALYST_EXECUTION_CORE
 // tells phase-agent-dispatch to compose OTEL attrs for the one-worktree-per-
 // ticket path. Returns { code, stdout, stderr } — never throws.
-function defaultRunPhaseAgent({ orchDir, ticket, phase, worktreePath }) {
-  const res = spawnSync(
-    PHASE_AGENT_DISPATCH_BIN,
-    ["--phase", phase, "--ticket", ticket, "--orch-dir", orchDir, "--orch-id", ticket],
-    {
-      cwd: worktreePath,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        CATALYST_ORCHESTRATOR_DIR: orchDir,
-        CATALYST_ORCHESTRATOR_ID: ticket,
-        CATALYST_PHASE: phase,
-        CATALYST_TICKET: ticket,
-        CATALYST_EXECUTION_CORE: "1",
-      },
+//
+// CTL-658: when `resumeSession` is set (the daemon resolved a `claude --resume`-
+// compatible UUID from the dead worker's bg_job_id), append `--resume-session
+// <uuid>` so phase-agent-dispatch spawns `claude --bg --resume <uuid>` (continue
+// the dead session) instead of a fresh phase-0 `$PROMPT` start. Omitted entirely
+// when null/undefined → today's fresh-start behaviour. `spawn` is injectable so
+// the unit test can assert the built arg array without a real spawn.
+export function defaultRunPhaseAgent(
+  { orchDir, ticket, phase, worktreePath, resumeSession },
+  { spawn = spawnSync } = {},
+) {
+  const args = ["--phase", phase, "--ticket", ticket, "--orch-dir", orchDir, "--orch-id", ticket];
+  if (resumeSession) args.push("--resume-session", resumeSession);
+  const res = spawn(PHASE_AGENT_DISPATCH_BIN, args, {
+    cwd: worktreePath,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CATALYST_ORCHESTRATOR_DIR: orchDir,
+      CATALYST_ORCHESTRATOR_ID: ticket,
+      CATALYST_PHASE: phase,
+      CATALYST_TICKET: ticket,
+      CATALYST_EXECUTION_CORE: "1",
     },
-  );
+  });
   if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
   return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
 }
@@ -79,8 +87,11 @@ function defaultRunPhaseAgent({ orchDir, ticket, phase, worktreePath }) {
 // worktree even if the registry resolution chain is corrupt. The dispatch
 // result always carries `worktreePath` so callers (defaultReviveDispatch)
 // can record / cross-check on later cycles.
+// CTL-658: `resumeSession` (when the daemon resolved a resume UUID) is forwarded
+// verbatim to runPhaseAgent so the spawned phase-agent-dispatch carries
+// `--resume-session`. Absent on every cold dispatch — only the revive path sets it.
 export function defaultDispatch(
-  { orchDir, ticket, phase, expectedWorktreePath },
+  { orchDir, ticket, phase, expectedWorktreePath, resumeSession },
   {
     resolveProject = defaultResolveProject,
     createWorktree = defaultCreateWorktree,
@@ -114,7 +125,7 @@ export function defaultDispatch(
       worktreePath: wt.worktreePath,
     };
   }
-  const res = runPhaseAgent({ orchDir, ticket, phase, worktreePath: wt.worktreePath });
+  const res = runPhaseAgent({ orchDir, ticket, phase, worktreePath: wt.worktreePath, resumeSession });
   return { ...res, worktreePath: wt.worktreePath };
 }
 

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -6,7 +6,7 @@
 // so no test ever spawns a real script.
 
 import { describe, test, expect } from "bun:test";
-import { dispatchTicket, defaultDispatch, teamOf } from "./dispatch.mjs";
+import { dispatchTicket, defaultDispatch, defaultRunPhaseAgent, teamOf } from "./dispatch.mjs";
 
 describe("teamOf", () => {
   test("extracts the team prefix from a ticket identifier", () => {
@@ -184,6 +184,75 @@ describe("defaultDispatch — worktreePath / expectedBranch wiring (CTL-615)", (
     const r = defaultDispatch({ orchDir: "/ec", ticket: "CTL-9", phase: "research" }, s);
     expect(r.code).toBe(0);
     expect(s.calls.some((c) => c[0] === "run")).toBe(true);
+  });
+});
+
+// CTL-658: resumeSession threads from the daemon revive seam down to the
+// phase-agent-dispatch spawn args, so the dispatched worker runs
+// `claude --bg --resume <uuid>` instead of a fresh phase-0 start.
+describe("defaultDispatch — resumeSession passthrough (CTL-658)", () => {
+  const baseSeams = () => {
+    const calls = [];
+    return {
+      calls,
+      resolveProject: () => ({ team: "CTL", repoRoot: "/repo" }),
+      createWorktree: (args) => ({ code: 0, worktreePath: `/wt/${args.ticket}`, stderr: "" }),
+      runPhaseAgent: (args) => {
+        calls.push(args);
+        return { code: 0, stdout: "ok", stderr: "" };
+      },
+    };
+  };
+
+  test("forwards resumeSession to runPhaseAgent when set", () => {
+    const s = baseSeams();
+    defaultDispatch(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", resumeSession: "9f8e-uuid" },
+      s,
+    );
+    expect(s.calls[0].resumeSession).toBe("9f8e-uuid");
+  });
+
+  test("forwards resumeSession: undefined on a cold dispatch (no resume)", () => {
+    const s = baseSeams();
+    defaultDispatch({ orchDir: "/ec", ticket: "CTL-1", phase: "implement" }, s);
+    expect(s.calls[0].resumeSession).toBeUndefined();
+  });
+});
+
+describe("defaultRunPhaseAgent — spawn-arg construction (CTL-658)", () => {
+  // Inject a spawnSync spy so we assert the built arg array without a real spawn.
+  const spy = () => {
+    const calls = [];
+    const spawn = (bin, args, opts) => {
+      calls.push({ bin, args, opts });
+      return { status: 0, stdout: "ok", stderr: "" };
+    };
+    spawn.calls = calls;
+    return spawn;
+  };
+
+  test("appends --resume-session <uuid> when resumeSession is set", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", worktreePath: "/wt/CTL-1", resumeSession: "9f8e-uuid" },
+      { spawn },
+    );
+    const { args } = spawn.calls[0];
+    expect(args).toContain("--resume-session");
+    // The flag's value immediately follows the token.
+    expect(args[args.indexOf("--resume-session") + 1]).toBe("9f8e-uuid");
+  });
+
+  test("omits both tokens when resumeSession is null/undefined", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", worktreePath: "/wt/CTL-1" },
+      { spawn },
+    );
+    const { args } = spawn.calls[0];
+    expect(args).not.toContain("--resume-session");
+    expect(args).toEqual(["--phase", "implement", "--ticket", "CTL-1", "--orch-dir", "/ec", "--orch-id", "CTL-1"]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -357,4 +357,123 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     expect(result.escalated).toEqual([]);
     expect(reviveDispatchCalls).toHaveLength(1);
   });
+
+  // CTL-658: end-to-end resume-on-revive. A dead-by-stale-mtime implement worker
+  // whose bg_job_id has a resolvable state.json → the revive carries
+  // resumeSession AND skips the defensive kill. Exercises the REAL
+  // resolvePhaseSessionId against a fixture jobsDir (CATALYST_REVIVE_JOBS_DIR)
+  // rather than a stub, so the daemon→dispatch resume wiring is proven end-to-end.
+  test("resumable dead worker → dispatch carries resumeSession, kill skipped", () => {
+    const jobsDir = join(catalystDir, "jobs");
+    mkdirSync(join(jobsDir, "cafe1234"), { recursive: true });
+    writeFileSync(
+      join(jobsDir, "cafe1234", "state.json"),
+      JSON.stringify({ linkScanPath: "/p/abcd-uuid.jsonl" }),
+    );
+    const prevJobsDir = process.env.CATALYST_REVIVE_JOBS_DIR;
+    process.env.CATALYST_REVIVE_JOBS_DIR = jobsDir;
+    try {
+      seedSignal("CTL-658-E", "implement", {
+        status: "running",
+        bg_job_id: "cafe1234",
+        worktreePath: "/wt/CTL/CTL-658-E",
+        orchestrator: "CTL-658-E",
+      });
+
+      const reviveDispatchCalls = [];
+      const killCalls = [];
+      const result = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: () => ({ code: 0 }),
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          applyTerminalDone: () => {},
+          applyLabel: () => ({ applied: true }),
+        },
+        teardownWorktree: () => true,
+        reclaimDeadWork: (od, sig, opts) =>
+          reclaimDeadWorkIfPossible(od, sig, {
+            ...opts,
+            // 'running' classification + ancient mtime → effectively dead via the
+            // staleness path (also past hungCutoffMs so pidAlive is never read).
+            statJob: () => ({ exists: true, mtimeMs: 1000 }),
+            probes: { implement: () => false }, // work NOT done → revive territory
+            reviveDispatch: (args) => {
+              reviveDispatchCalls.push(args);
+              return { code: 0 };
+            },
+            killBgJob: (args) => killCalls.push(args),
+            applyStalledLabel: () => ({ applied: true }),
+            countReviveEvents: () => 0,
+            countDistinctRevivingTickets: () => 1,
+            // resolveSession left at the real default → reads CATALYST_REVIVE_JOBS_DIR.
+          }),
+      });
+
+      expect(result.revived).toEqual([{ ticket: "CTL-658-E", phase: "implement" }]);
+      expect(reviveDispatchCalls).toHaveLength(1);
+      expect(reviveDispatchCalls[0].resumeSession).toBe("abcd-uuid");
+      // Resume viable → the defensive kill must NOT fire (the session's jsonl
+      // must stay intact for `--resume`).
+      expect(killCalls).toHaveLength(0);
+    } finally {
+      if (prevJobsDir === undefined) delete process.env.CATALYST_REVIVE_JOBS_DIR;
+      else process.env.CATALYST_REVIVE_JOBS_DIR = prevJobsDir;
+    }
+  });
+
+  // CTL-658 companion: same fixture but NO state.json for the bg_job_id →
+  // resolvePhaseSessionId returns null → unchanged behaviour: the defensive kill
+  // fires and the dispatch carries no resumeSession (fresh re-dispatch).
+  test("unresumable dead worker → kill fires, no resumeSession (fresh dispatch)", () => {
+    const jobsDir = join(catalystDir, "jobs-empty");
+    mkdirSync(jobsDir, { recursive: true }); // no <bgJobId>/state.json inside
+    const prevJobsDir = process.env.CATALYST_REVIVE_JOBS_DIR;
+    process.env.CATALYST_REVIVE_JOBS_DIR = jobsDir;
+    try {
+      seedSignal("CTL-658-F", "implement", {
+        status: "running",
+        bg_job_id: "feedface",
+        worktreePath: "/wt/CTL/CTL-658-F",
+        orchestrator: "CTL-658-F",
+      });
+
+      const reviveDispatchCalls = [];
+      const killCalls = [];
+      const result = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: () => ({ code: 0 }),
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          applyTerminalDone: () => {},
+          applyLabel: () => ({ applied: true }),
+        },
+        teardownWorktree: () => true,
+        reclaimDeadWork: (od, sig, opts) =>
+          reclaimDeadWorkIfPossible(od, sig, {
+            ...opts,
+            statJob: () => ({ exists: true, mtimeMs: 1000 }),
+            probes: { implement: () => false },
+            reviveDispatch: (args) => {
+              reviveDispatchCalls.push(args);
+              return { code: 0 };
+            },
+            killBgJob: (args) => killCalls.push(args),
+            applyStalledLabel: () => ({ applied: true }),
+            countReviveEvents: () => 0,
+            countDistinctRevivingTickets: () => 1,
+          }),
+      });
+
+      expect(result.revived).toEqual([{ ticket: "CTL-658-F", phase: "implement" }]);
+      expect(reviveDispatchCalls).toHaveLength(1);
+      expect(reviveDispatchCalls[0].resumeSession).toBeNull();
+      // Unresumable → the defensive kill fires (free the abandoned bg worker).
+      expect(killCalls).toHaveLength(1);
+      expect(killCalls[0].bgJobId).toBe("feedface");
+    } finally {
+      if (prevJobsDir === undefined) delete process.env.CATALYST_REVIVE_JOBS_DIR;
+      else process.env.CATALYST_REVIVE_JOBS_DIR = prevJobsDir;
+    }
+  });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -19,7 +19,8 @@ import {
   existsSync,
 } from "node:fs";
 import { dirname } from "node:path";
-import { join } from "node:path";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
@@ -53,6 +54,31 @@ import {
 const EMIT_COMPLETE_BIN = fileURLToPath(
   new URL("../phase-agent-emit-complete", import.meta.url),
 );
+
+// resolvePhaseSessionId — JS port of orchestrate-revive's resolve_phase_session_id
+// (orchestrate-revive:160-177). Resolves a `claude --resume`-compatible session
+// UUID from a dead worker's bg_job_id by reading the job's state.json linkScanPath.
+// Returns null on any miss (no bgJobId, no state.json, no/!.jsonl linkScanPath).
+// MUST stay in sync with the bash resolver — they read the same on-disk contract
+// and honour the same CATALYST_REVIVE_JOBS_DIR override (NOT getJobsRoot's
+// CATALYST_HEALTHCHECK_JOBS_ROOT) so a test overriding one env var matches bash.
+export function resolvePhaseSessionId(
+  bgJobId,
+  { jobsDir = process.env.CATALYST_REVIVE_JOBS_DIR || join(homedir(), ".claude", "jobs") } = {},
+) {
+  if (!bgJobId) return null;
+  const stateFile = join(jobsDir, bgJobId, "state.json");
+  if (!existsSync(stateFile)) return null;
+  let linkPath;
+  try {
+    linkPath = JSON.parse(readFileSync(stateFile, "utf8"))?.linkScanPath;
+  } catch {
+    return null;
+  }
+  if (typeof linkPath !== "string" || !linkPath.endsWith(".jsonl")) return null;
+  const sid = basename(linkPath, ".jsonl");
+  return sid || null;
+}
 
 // defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
 // the job dir is gone (the worker's process no longer exists), else its mtime

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -379,7 +379,7 @@ export function defaultAppendDispatchFailedEvent({
 // can be unit-tested (every test in recovery.test.mjs that overrides the
 // outer `reviveDispatch` would otherwise leave the signal-reset logic — the
 // load-bearing half — uncovered).
-export function defaultReviveDispatch({ orchDir, ticket, phase }, { dispatch = defaultDispatch } = {}) {
+export function defaultReviveDispatch({ orchDir, ticket, phase, resumeSession }, { dispatch = defaultDispatch } = {}) {
   const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
   if (!existsSync(signalPath)) {
     log.warn(
@@ -413,6 +413,10 @@ export function defaultReviveDispatch({ orchDir, ticket, phase }, { dispatch = d
   }
   const dispatchArgs = { orchDir, ticket, phase };
   if (expectedWorktreePath) dispatchArgs.expectedWorktreePath = expectedWorktreePath;
+  // CTL-658: forward the resolved resume UUID so defaultDispatch → runPhaseAgent
+  // spawns `claude --bg --resume <uuid>`. Only present on the resume path; a
+  // cold/unresumable revive omits it and falls through to a fresh dispatch.
+  if (resumeSession) dispatchArgs.resumeSession = resumeSession;
   return dispatch(dispatchArgs);
 }
 
@@ -784,6 +788,13 @@ export function reclaimDeadWorkIfPossible(
     // matches the legacy 15-min STALE_BG_SECONDS.
     pidAlive = defaultPidAlive,
     hungCutoffMs = HUNG_CUTOFF_MS,
+    // CTL-658 — resume-session resolver. Maps the dead worker's bg_job_id to a
+    // `claude --resume`-compatible UUID (or null) so the revive can continue the
+    // dead session instead of re-walking from phase 0. Default reads the real
+    // ~/.claude/jobs/<bg>/state.json; tests inject a stub. A null result (no
+    // bg_job_id, no state.json, no .jsonl linkScanPath) preserves the pre-CTL-658
+    // fresh-dispatch behaviour exactly.
+    resolveSession = resolvePhaseSessionId,
     now = Date.now,
     staleMs = STALE_MS,
   } = {},
@@ -958,6 +969,21 @@ export function reclaimDeadWorkIfPossible(
     return "revive-suppressed";
   }
 
+  // CTL-658: resolve a `claude --resume`-compatible session id from the dead
+  // worker's bg_job_id BEFORE the defensive kill. When a UUID resolves we are
+  // CONTINUING this session, not retiring it — so we skip the kill + reap-intent
+  // (stopping a session we're about to resume is the ordering hazard the plan
+  // resolves) and thread the id into reviveDispatch so phase-agent-dispatch runs
+  // `claude --bg --resume <uuid>` instead of a fresh phase-0 start. A null result
+  // (no bg_job_id, no state.json, no .jsonl linkScanPath) is the unchanged path:
+  // defensive kill + fresh dispatch. Resolving here (after the budget/storm gates
+  // pass) means only an actually-reviving worker pays the one state.json read.
+  const resumeSession = prevBgJobId ? resolveSession(prevBgJobId) : null;
+  log.info(
+    { ticket, phase, prevBgJobId, resumeSession },
+    "ctl-658: revive resume id resolved",
+  );
+
   // Defensive stop: if state.json has been quiet long enough we're confident
   // the worker is abandoned, so we stop it to free RAM and release any worktree
   // lock. CTL-657: killBgJob now issues `claude stop <shortId>` (the pre-CTL-657
@@ -967,7 +993,11 @@ export function reclaimDeadWorkIfPossible(
   // visibility and stops the same session via its own `claude stop`. The inline
   // stop stays so a standalone reconcile (no reaper consuming the log) cannot
   // regress to leaking the worker.
+  //
+  // CTL-658: gated on !resumeSession — when we're resuming we must NOT stop the
+  // session (its linkScanPath jsonl must stay intact for `--resume`).
   if (
+    !resumeSession &&
     prevStateJsonMtime !== null &&
     now() - prevStateJsonMtime > KILL_RECENT_ACTIVITY_MS &&
     prevBgJobId
@@ -1020,7 +1050,7 @@ export function reclaimDeadWorkIfPossible(
     });
     return "revive-suppressed";
   }
-  const dispatchRes = reviveDispatch({ orchDir, ticket, phase });
+  const dispatchRes = reviveDispatch({ orchDir, ticket, phase, resumeSession });
   if (dispatchRes.code === 0) {
     writeReviveMarker({ orchDir, ticket, attempt });
     log.info({ ticket, phase, attempt }, "ctl-587: revived");

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -15,6 +15,7 @@ import {
   recoverStartup,
   reclaimDeadWorkIfPossible,
   defaultReviveDispatch,
+  resolvePhaseSessionId,
   defaultKillBgJob,
   defaultPidAlive,
   defaultAppendReviveEvent,
@@ -1796,5 +1797,53 @@ describe("readBootSince — CTL-655 boot-time window reader", () => {
     // Empty-string bootedAt is also rejected.
     writeFileSync(join(dir, "daemon-boot.json"), JSON.stringify({ bootedAt: "" }));
     expect(readBootSince(dir)).toBeUndefined();
+  });
+});
+
+// CTL-658 — JS port of orchestrate-revive's resolve_phase_session_id. Resolves a
+// `claude --resume`-compatible session UUID from a dead worker's bg_job_id by
+// reading <jobsDir>/<bg_job_id>/state.json → .linkScanPath → basename minus .jsonl.
+// Mirrors the bash unit tests at __tests__/orchestrate-revive.test.sh:578-617.
+describe("resolvePhaseSessionId", () => {
+  let jobsDir;
+  beforeEach(() => {
+    jobsDir = mkdtempSync(join(tmpdir(), "exec-core-jobs-"));
+  });
+  afterEach(() => {
+    rmSync(jobsDir, { recursive: true, force: true });
+  });
+
+  test("happy path — linkScanPath .jsonl returns the UUID basename", () => {
+    mkdirSync(join(jobsDir, "cafe1234"), { recursive: true });
+    writeFileSync(
+      join(jobsDir, "cafe1234", "state.json"),
+      JSON.stringify({ linkScanPath: "/p/9f8e-uuid.jsonl" }),
+    );
+    expect(resolvePhaseSessionId("cafe1234", { jobsDir })).toBe("9f8e-uuid");
+  });
+
+  test("missing state.json returns null", () => {
+    mkdirSync(join(jobsDir, "nostate"), { recursive: true });
+    expect(resolvePhaseSessionId("nostate", { jobsDir })).toBeNull();
+  });
+
+  test("malformed linkScanPath (not .jsonl) returns null", () => {
+    mkdirSync(join(jobsDir, "baddir"), { recursive: true });
+    writeFileSync(
+      join(jobsDir, "baddir", "state.json"),
+      JSON.stringify({ linkScanPath: "/p/some-dir" }),
+    );
+    expect(resolvePhaseSessionId("baddir", { jobsDir })).toBeNull();
+  });
+
+  test("empty / null bgJobId returns null without fs access", () => {
+    expect(resolvePhaseSessionId(null, { jobsDir })).toBeNull();
+    expect(resolvePhaseSessionId("", { jobsDir })).toBeNull();
+  });
+
+  test("state.json without linkScanPath returns null", () => {
+    mkdirSync(join(jobsDir, "nolink"), { recursive: true });
+    writeFileSync(join(jobsDir, "nolink", "state.json"), JSON.stringify({}));
+    expect(resolvePhaseSessionId("nolink", { jobsDir })).toBeNull();
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1011,6 +1011,44 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
     expect(s.opts.killBgJob.calls.length).toBe(0);
   });
+
+  // ── CTL-658: resume-on-revive. When a resume UUID resolves from the dead
+  //    worker's bg_job_id, the revive dispatches with `resumeSession` AND skips
+  //    the defensive kill (we are continuing the session, not retiring it).
+  test("CTL-658: resolved resume UUID is forwarded to reviveDispatch", () => {
+    const s = setupReviveScenario({ reviveCount: 0 });
+    s.opts.resolveSession = recorder("uuid-1");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+    expect(s.opts.reviveDispatch.calls[0][0].resumeSession).toBe("uuid-1");
+    // The resolver was asked about the dead worker's bg_job_id.
+    expect(s.opts.resolveSession.calls[0][0]).toBe("bg-9");
+  });
+
+  test("CTL-658: resume viable → defensive kill is SKIPPED", () => {
+    // Same quiet-state fixture that fires the kill in the test above, but with a
+    // resolvable session: the kill must not fire (its jsonl must stay intact).
+    const s = setupReviveScenario({
+      stateJsonMtime: 1_000,
+      nowMs: 1_000 + 6 * 60 * 1000, // 6min past — stale + past kill threshold
+    });
+    s.opts.resolveSession = () => "uuid-1";
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.killBgJob.calls.length).toBe(0);
+    expect(s.opts.reviveDispatch.calls[0][0].resumeSession).toBe("uuid-1");
+  });
+
+  test("CTL-658: unresumable (resolver null) → kill fires, no resumeSession (unchanged)", () => {
+    const s = setupReviveScenario({
+      stateJsonMtime: 1_000,
+      nowMs: 1_000 + 6 * 60 * 1000,
+    });
+    s.opts.resolveSession = () => null;
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.killBgJob.calls.length).toBe(1);
+    // resumeSession is null on the dispatch (the fresh-start path).
+    expect(s.opts.reviveDispatch.calls[0][0].resumeSession).toBeNull();
+  });
 });
 
 // --- CTL-610: alive-quiet keep-alive guard (branch (C0)) -------------------
@@ -1423,6 +1461,28 @@ describe("defaultReviveDispatch — signal-reset behaviour", () => {
     });
     // No expectedWorktreePath key at all — undefined means "no check".
     expect("expectedWorktreePath" in dispatch.calls[0][0]).toBe(false);
+  });
+
+  // CTL-658: a resolved resume UUID is forwarded to dispatch so the spawned
+  // phase-agent-dispatch runs `claude --bg --resume <uuid>`.
+  test("resumeSession is forwarded to dispatch when set (CTL-658)", () => {
+    seed("CTL-658-A", "implement", { status: "running", bg_job_id: "bg-a" });
+    const dispatch = recorder({ code: 0 });
+    defaultReviveDispatch(
+      { orchDir, ticket: "CTL-658-A", phase: "implement", resumeSession: "9f8e-uuid" },
+      { dispatch },
+    );
+    expect(dispatch.calls[0][0].resumeSession).toBe("9f8e-uuid");
+  });
+
+  test("resumeSession absent → dispatch called without the key (CTL-658)", () => {
+    seed("CTL-658-B", "implement", { status: "running", bg_job_id: "bg-b" });
+    const dispatch = recorder({ code: 0 });
+    defaultReviveDispatch(
+      { orchDir, ticket: "CTL-658-B", phase: "implement" },
+      { dispatch },
+    );
+    expect("resumeSession" in dispatch.calls[0][0]).toBe(false);
   });
 
   test("signal flip happens BEFORE dispatch (so dispatcher sees 'stalled')", () => {

--- a/plugins/dev/scripts/lib/resume.sh
+++ b/plugins/dev/scripts/lib/resume.sh
@@ -1,0 +1,38 @@
+# lib/resume.sh — shared `claude --bg --resume` stderr classifier (CTL-658).
+#
+# Single source of truth for the launched/alive/failed decision used by both
+# the legacy bash revive path (orchestrate-revive) and the daemon revive path
+# (phase-agent-dispatch --resume-session). Extracted from orchestrate-revive's
+# inline classify_resume_stderr (CTL-604) so the two paths cannot drift.
+#
+# The resume-id RESOLVER stays per-runtime — bash `resolve_phase_session_id`
+# (orchestrate-revive) and JS `resolvePhaseSessionId` (recovery.mjs) read the
+# same ~/.claude/jobs/<bg>/state.json contract but run in different runtimes.
+# Only this classifier is shared.
+#
+# Source me; do not execute. Kept POSIX-ish (no bashisms) so any sh-family
+# caller can source it safely.
+
+# classify_resume_stderr — map a `claude --bg --resume` attempt's stderr to one
+# of three outcomes so the caller never records a false successful revive:
+#   "launched"  empty stderr — a clean resume (the normal path).
+#   "alive"     the agent is still running as a bg job; the resume was rejected
+#               ("currently running as a background agent (bg)" / "already
+#               running as a background agent"). The worker is NOT dead — the
+#               caller must NOT spawn a duplicate or record a successful revive.
+#   "failed"    any other non-empty stderr — a hard resume error; the caller
+#               falls back to a fresh start (phase-agent-dispatch) or records a
+#               spawn failure (orchestrate-revive).
+classify_resume_stderr() {
+  local stderr_text="$1"
+  if [ -z "$stderr_text" ]; then
+    echo "launched"
+    return 0
+  fi
+  if printf '%s' "$stderr_text" \
+       | grep -qiE "currently running as a background agent \(bg\)|already running as a background agent"; then
+    echo "alive"
+    return 0
+  fi
+  echo "failed"
+}

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -32,6 +32,10 @@ CLAUDE_BIN="${CATALYST_REVIVE_CLAUDE_BIN:-claude}"
 # CTL-607: current-phase guard helper (latest_phase_in_dir + PHASES mirror).
 # shellcheck source=lib/phase-sequence.sh
 . "${SCRIPT_DIR}/lib/phase-sequence.sh"
+# CTL-658: shared resume-stderr classifier (classify_resume_stderr), shared with
+# phase-agent-dispatch's daemon revive path.
+# shellcheck source=lib/resume.sh
+. "${SCRIPT_DIR}/lib/resume.sh"
 
 ORCH_DIR=""
 ORCH_ID=""
@@ -227,29 +231,12 @@ detect_api_error_in_stream() {
   return 1
 }
 
-# CTL-604: classify a `claude --bg --resume` attempt's resume stderr so the
-# caller can tell three outcomes apart and not record a false successful revive:
-#   "alive"    the agent is still running as a bg job; the resume was rejected
-#              ("currently running as a background agent (bg)"). The worker is
-#              NOT dead — this must NOT bump reviveCount or record pid-dead.
-#   "failed"   any other non-empty stderr — a hard resume error; the caller
-#              records revive-spawn-failed rather than a successful revive.
-#   "launched" empty stderr — a clean resume (the normal path).
-# Single source of truth for the alive-vs-failed-vs-launched decision so the
-# detector and the caller agree.
-classify_resume_stderr() {
-  local stderr_text="$1"
-  if [ -z "$stderr_text" ]; then
-    echo "launched"
-    return 0
-  fi
-  if printf '%s' "$stderr_text" \
-       | grep -qiE "currently running as a background agent \(bg\)|already running as a background agent"; then
-    echo "alive"
-    return 0
-  fi
-  echo "failed"
-}
+# CTL-658: classify_resume_stderr lives in the shared lib/resume.sh (sourced at
+# the top of this script) so this legacy bash path and the daemon revive path
+# (phase-agent-dispatch --resume-session) share one alive/failed/launched
+# decision and cannot drift. Behavior is unchanged (CTL-604 contract) — see
+# lib/resume.sh. The --probe-helper dispatch and the resume-site call below both
+# still resolve it because the function is sourced into this script's scope.
 
 # Emit a fresh-start event via the state script (no-op when state script is
 # missing or when this is a dry run).

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -16,12 +16,20 @@
 #     [--model <opus|sonnet|haiku>] \
 #     [--turn-cap <n>] \
 #     [--config <path>] \
+#     [--resume-session <uuid>] \
 #     [--dry-run]
 #
 # Defaults:
 #   --orch-dir = $CATALYST_ORCHESTRATOR_DIR
 #   --orch-id  = $CATALYST_ORCHESTRATOR_ID
 #   --config   = nearest ancestor .catalyst/config.json
+#
+# --resume-session (CTL-658): when set, spawn `claude --bg --resume <uuid>`
+#   (continue the dead worker's session) instead of a fresh `/catalyst-dev:phase-*`
+#   prompt. The daemon revive path resolves the UUID from the dead worker's
+#   bg_job_id and passes it here. A clean resume runs as-launched; an "alive"
+#   rejection marks the signal stalled (resume-rejected-alive) and exits non-zero;
+#   a hard resume failure falls back to a fresh start in the same invocation.
 #
 # Output (stdout):
 #   One JSON line with keys: ticket, phase, model, turnCap, bg_job_id,
@@ -51,6 +59,12 @@ EMIT_COMPLETE="${CATALYST_EMIT_COMPLETE:-${SCRIPT_DIR}/phase-agent-emit-complete
 # executor can swap the launch and the stop together (design doc D9).
 # shellcheck source=lib/executor.sh
 source "${SCRIPT_DIR}/lib/executor.sh"
+
+# CTL-658: shared resume-stderr classifier (classify_resume_stderr), shared with
+# orchestrate-revive's legacy bash revive path. Used when --resume-session is set
+# to tell a clean resume from an alive-rejection from a hard failure.
+# shellcheck source=lib/resume.sh
+source "${SCRIPT_DIR}/lib/resume.sh"
 
 die() {
 	echo "phase-agent-dispatch: $*" >&2
@@ -112,6 +126,9 @@ MODEL_FLAG=""
 TURN_CAP_FLAG=""
 CONFIG=""
 DRY_RUN=0
+# CTL-658: when set, spawn `claude --bg --resume $RESUME_SESSION` instead of a
+# fresh $PROMPT. Empty = today's fresh-start behaviour.
+RESUME_SESSION=""
 # CTL-649: --attempt threads the dispatch attempt number through to the
 # structured session name (`--name o-<orchId>:<ticket>:<phase>:<attempt>`).
 # Default 1 covers the cold-dispatch path; the recovery/revive callers should
@@ -151,6 +168,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--config)
 		CONFIG="$2"
+		shift 2
+		;;
+	--resume-session)
+		RESUME_SESSION="$2"
 		shift 2
 		;;
 	--dry-run)
@@ -532,10 +553,12 @@ if [[ $DRY_RUN -eq 1 ]]; then
 		--arg signal "$SIGNAL_FILE" \
 		--arg sessionName "$SESSION_NAME" \
 		--argjson attempt "$ATTEMPT" \
+		--arg resumeSession "$RESUME_SESSION" \
 		--argjson env "$(printf '%s\n' "${DISPATCH_ENV[@]}" | jq -R . | jq -s .)" \
 		'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
       bg_job_id: null, prompt: $prompt, signalFile: $signal,
       sessionName: $sessionName, attempt: $attempt,
+      resumeSession: (if $resumeSession == "" then null else $resumeSession end),
       env: $env, status: "dispatched", dryRun: true}'
 	exit 0
 fi
@@ -553,14 +576,57 @@ trap 'rm -f "$BG_OUT" "$BG_ERR"' EXIT
 # still overrides it, so existing tests and tooling are unaffected.
 CLAUDE_BIN="$(executor_claude_bin)"
 
+# spawn_claude_bg (CTL-658): run `claude --bg` with the shared envelope
+# (DISPATCH_ENV + --name + --model) and the caller-supplied trailing args
+# ("$PROMPT" for a fresh start, or `--resume <uuid>` for a session resume),
+# writing stdout/stderr to BG_OUT/BG_ERR. Returns claude's exit code. Both the
+# resume and fresh spawns share this so the env/name/model can never drift apart.
+#
 # </dev/null (CTL-605): `claude --bg` reads stdin; redirect it so a caller that
 # invokes us from inside a herestring/`while read` loop can't have its loop
 # stdin drained. Harmless for normal callers (fd 0 already a tty/pipe).
-env "${DISPATCH_ENV[@]}" \
-	"$CLAUDE_BIN" --bg --name "$SESSION_NAME" --dangerously-skip-permissions \
-	--model "$MODEL" "$PROMPT" \
-	>"$BG_OUT" 2>"$BG_ERR" </dev/null
-RC=$?
+spawn_claude_bg() {
+	env "${DISPATCH_ENV[@]}" \
+		"$CLAUDE_BIN" --bg --name "$SESSION_NAME" --dangerously-skip-permissions \
+		--model "$MODEL" "$@" \
+		>"$BG_OUT" 2>"$BG_ERR" </dev/null
+}
+
+# CTL-658: resume-first-then-fresh launch. When --resume-session is set, attempt
+# `claude --bg --resume <uuid>` and classify its stderr:
+#   launched → use it (the dead session continues where it left off).
+#   alive    → the worker is still a live bg job; the resume was rejected. Do NOT
+#              spawn a duplicate — mark the signal stalled (resume-rejected-alive)
+#              and exit non-zero so the next daemon liveness tick re-evaluates.
+#   failed   → a hard resume error; fall back to a fresh $PROMPT start in this
+#              same invocation so the phase still gets a worker.
+# With no --resume-session this is exactly today's single fresh-start spawn.
+if [[ -n $RESUME_SESSION ]]; then
+	spawn_claude_bg --resume "$RESUME_SESSION"
+	RC=$?
+	OUTCOME="$(classify_resume_stderr "$(cat "$BG_ERR")")"
+	if [[ $RC -ne 0 || $OUTCOME != "launched" ]]; then
+		case "$OUTCOME" in
+		alive)
+			echo "phase-agent-dispatch: resume rejected — worker still running as bg ($RESUME_SESSION)" >&2
+			mark_launch_failed "resume-rejected-alive"
+			jq -n --arg status "stalled" --arg reason "resume_rejected_alive" \
+				--arg signal "$SIGNAL_FILE" \
+				'. + {status: $status, reason: $reason, signalFile: $signal}' \
+				<<<'{}'
+			exit 1
+			;;
+		*)
+			echo "phase-agent-dispatch: resume failed ($RESUME_SESSION); falling back to a fresh start: $(cat "$BG_ERR")" >&2
+			spawn_claude_bg "$PROMPT"
+			RC=$?
+			;;
+		esac
+	fi
+else
+	spawn_claude_bg "$PROMPT"
+	RC=$?
+fi
 
 if [[ $RC -ne 0 ]]; then
 	echo "phase-agent-dispatch: claude --bg exited $RC: $(cat "$BG_ERR")" >&2


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-27T14:47:15Z -->
<!-- Last updated: 2026-05-27T14:47:15Z -->
<!-- PR: #1104 -->
<!-- Previous commits: 5e22489e96a9077668e998df7d907335df4594f4,a5ddd203cabf05c7bda2c0c2dac400f410f11897 -->

## Summary

Completes the daemon-side half of resume-on-revive. CTL-613 taught the legacy bash
`orchestrate-revive` path to fire `claude --bg --resume <uuid>` in phase-agents mode; this PR
makes the **execution-core daemon** revive path do the same true `--resume` instead of
re-dispatching a fresh worker from phase 0. A fresh re-dispatch is the "re-walk hazard" — it
restarts the phase from scratch rather than continuing the dead session's work.

The daemon now resolves a `claude --resume`-compatible session UUID from a dead worker's
`bg_job_id` and, when one resolves, **continues** that session: it skips the defensive
`claude-stop` + reap-intent (you don't stop a session you're about to resume) and threads the id
through `reviveDispatch → defaultDispatch → runPhaseAgent` so the worker is spawned with
`claude --bg --resume <uuid>`. When no UUID resolves (no `bg_job_id`, no `state.json`, no
`.jsonl` linkScanPath), behaviour is byte-identical to the pre-CTL-658 fresh-dispatch path.

## Changes Made

- **`recovery.mjs`** — new exported `resolvePhaseSessionId(bgJobId)`: JS port of
  `orchestrate-revive`'s `resolve_phase_session_id`, reading `~/.claude/jobs/<bg>/state.json`'s
  `linkScanPath` to derive the session UUID. Honours the `CATALYST_REVIVE_JOBS_DIR` override to
  match the bash resolver. `reclaimDeadWorkIfPossible` now resolves the session id **before** the
  defensive kill and skips the kill + reap-intent on the resume path (gated on `!resumeSession`);
  `defaultReviveDispatch` forwards `resumeSession` into the dispatch args only when present.
- **`dispatch.mjs`** — threads `resumeSession` through to `runPhaseAgent` so the daemon spawns
  `claude --bg --resume <uuid>`.
- **`phase-agent-dispatch`** — accepts a `--resume-session` flag and runs the resume launch,
  classifying stderr via the shared classifier.
- **`lib/resume.sh`** (new) — `classify_resume_stderr` extracted from `orchestrate-revive`'s
  inline CTL-604 logic into a single source of truth shared by both revive paths
  (launched / alive / failed), so the two paths cannot drift. The resume-id *resolver* stays
  per-runtime (bash vs JS read the same on-disk contract).
- **`orchestrate-revive`** — refactored to source the shared classifier.

## How to Verify It

- [x] `bun test` (execution-core): recovery 122, dispatch 18, integration-ctl-587 8 — pass
      (885 pass / 9 pre-existing sandbox-spawn fails identical to origin/main baseline, 0 new)
- [x] bash suites: `phase-agent-dispatch` 99/0 (incl launched/alive/failed-fallback/no-flag/dry-run),
      `orchestrate-revive` 125/0
- [x] `bash -n` clean: phase-agent-dispatch, lib/resume.sh, orchestrate-revive
- [x] No reward-hacking / secrets in added lines
- [x] CI gating checks (audit-references, check-versions, validate) green

## Test Coverage

New tests: resolver 5 cases, revive-seam passthrough + kill-skip, dispatch args, an e2e
integration test, and bash `launched/alive/failed/no-flag/dry-run` coverage.

## Related Issues/PRs

- Refs: CTL-658
- Builds on CTL-613 (#1099) — phase-mode turn-cap resume in the bash revive path
- Reuses the CTL-604 stderr classifier (now shared via `lib/resume.sh`)
