### PR TITLE
CTL-660: Wire dispatch lifecycle events (requested/launched) + HUD latency

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -363,6 +363,58 @@ export function defaultAppendDispatchFailedEvent({
   );
 }
 
+// CTL-660: success-path dispatch lifecycle events — the complement to
+// defaultAppendDispatchFailedEvent. The daemon already emits on the dispatch
+// FAILURE path (above) and on phase COMPLETION, but nothing when it DECIDES to
+// dispatch a phase or when the `claude --bg` worker LAUNCHES, so the
+// "daemon-saw-Ready → worker-launched" latency is not derivable from the
+// unified event log. These two emitters close that gap. Like every audit
+// emitter they are best-effort (no caller gates on the return); the phase slot
+// is the literal "dispatch" and the real phase rides in payload.target_phase,
+// matching the dispatch.failed shape. They are deliberately NOT in the broker's
+// PHASE_EVENT_PATTERN (complete|failed|turn-cap-exhausted|skipped) — the HUD
+// reads the unified log directly, so no broker routing is required.
+
+// defaultAppendDispatchRequestedEvent — phase.dispatch.requested.<TICKET>.
+// Emitted when the scheduler/recovery DECIDES to dispatch a phase, before the
+// `claude --bg` spawn. reason ∈ {new-work, advance, revive}.
+export function defaultAppendDispatchRequestedEvent({ orchId, ticket, target_phase, reason }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "dispatch",
+      ticket,
+      orchId,
+      action: "requested",
+      reason,
+      payloadExtras: { target_phase },
+    }),
+    "dispatch-requested",
+  );
+}
+
+// defaultAppendDispatchLaunchedEvent — phase.dispatch.launched.<TICKET>.
+// Emitted after `claude --bg` returns and the signal is verified, carrying the
+// bg-job shortId (the de-facto session discriminator) + worktree path so the
+// launched↔complete wall-clock can be computed downstream.
+export function defaultAppendDispatchLaunchedEvent({
+  orchId,
+  ticket,
+  target_phase,
+  bg_job_id,
+  worktree_path,
+}) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "dispatch",
+      ticket,
+      orchId,
+      action: "launched",
+      payloadExtras: { target_phase, bg_job_id, worktree_path },
+    }),
+    "dispatch-launched",
+  );
+}
+
 // CTL-587 default seams — all overridable for tests, all best-effort for prod.
 
 // defaultReviveDispatch — reset the signal to status: "stalled" first (to bypass

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -431,7 +431,17 @@ export function defaultAppendDispatchLaunchedEvent({
 // can be unit-tested (every test in recovery.test.mjs that overrides the
 // outer `reviveDispatch` would otherwise leave the signal-reset logic — the
 // load-bearing half — uncovered).
-export function defaultReviveDispatch({ orchDir, ticket, phase, resumeSession }, { dispatch = defaultDispatch } = {}) {
+export function defaultReviveDispatch(
+  { orchDir, ticket, phase, resumeSession },
+  {
+    dispatch = defaultDispatch,
+    // CTL-660: success-path lifecycle emitters, injectable for tests. Default
+    // to the real best-effort helpers so production emits requested→launched
+    // on the revive path too (the failed path was already covered by CTL-611).
+    appendRequested = defaultAppendDispatchRequestedEvent,
+    appendLaunched = defaultAppendDispatchLaunchedEvent,
+  } = {},
+) {
   const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
   if (!existsSync(signalPath)) {
     log.warn(
@@ -445,10 +455,16 @@ export function defaultReviveDispatch({ orchDir, ticket, phase, resumeSession },
   // launching the bg worker. Pre-CTL-615 signals lack the field; in that case
   // we omit expectedWorktreePath and fall through to legacy behaviour.
   let expectedWorktreePath;
+  // CTL-660: orchId for the lifecycle emits, read from the same parse. Falls
+  // back to undefined → buildEventEnvelope defaults it to the ticket.
+  let orchId;
   try {
     const sig = JSON.parse(readFileSync(signalPath, "utf8"));
     if (typeof sig.worktreePath === "string" && sig.worktreePath.length > 0) {
       expectedWorktreePath = sig.worktreePath;
+    }
+    if (typeof sig.orchestrator === "string" && sig.orchestrator.length > 0) {
+      orchId = sig.orchestrator;
     }
     sig.status = "stalled";
     sig.attentionReason = "ctl-587-revive-reset";
@@ -469,7 +485,30 @@ export function defaultReviveDispatch({ orchDir, ticket, phase, resumeSession },
   // spawns `claude --bg --resume <uuid>`. Only present on the resume path; a
   // cold/unresumable revive omits it and falls through to a fresh dispatch.
   if (resumeSession) dispatchArgs.resumeSession = resumeSession;
-  return dispatch(dispatchArgs);
+  // CTL-660: record the revive DECISION before the spawn (reason="revive"),
+  // then the verified launch after a clean dispatch. Both best-effort — the
+  // default emitters swallow IO errors (appendEnvelopeBestEffort); the revive
+  // proceeds regardless of either return value.
+  appendRequested({ orchId, ticket, target_phase: phase, reason: "revive" });
+  const res = dispatch(dispatchArgs);
+  if (res && res.code === 0) {
+    // Re-read the signal the dispatcher just rewrote (status dispatched/running
+    // + bg_job_id + worktreePath) so launched carries the live worker's id.
+    let sig2 = null;
+    try {
+      sig2 = JSON.parse(readFileSync(signalPath, "utf8"));
+    } catch {
+      sig2 = null;
+    }
+    appendLaunched({
+      orchId,
+      ticket,
+      target_phase: phase,
+      bg_job_id: sig2?.bg_job_id,
+      worktree_path: sig2?.worktreePath,
+    });
+  }
+  return res;
 }
 
 // defaultApplyStalledLabel — apply the flat `needs-human` label through the

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1374,10 +1374,21 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
 
 describe("defaultReviveDispatch — signal-reset behaviour", () => {
   let orchDir;
+  let prevCatalystDir;
   beforeEach(() => {
     orchDir = mkdtempSync(join(tmpdir(), "ctl587-revdisp-"));
+    // CTL-660: defaultReviveDispatch now emits real dispatch-lifecycle events
+    // by default (appendRequested/appendLaunched default to the real helpers).
+    // Tests here inject only `dispatch`, so redirect CATALYST_DIR into the temp
+    // orchDir to keep those default emits out of the operator's real
+    // ~/catalyst/events log.
+    prevCatalystDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = orchDir;
+    mkdirSync(join(orchDir, "events"), { recursive: true });
   });
   afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
     rmSync(orchDir, { recursive: true, force: true });
   });
 
@@ -1523,6 +1534,86 @@ describe("defaultReviveDispatch — signal-reset behaviour", () => {
     const dir = join(orchDir, "workers", "CTL-9");
     const leftovers = readdirSync(dir).filter((f) => f.includes(".tmp."));
     expect(leftovers).toEqual([]);
+  });
+
+  // ── CTL-660: revive-path dispatch-lifecycle emission ────────────────────
+  test("CTL-660: revive success emits requested(revive) + launched with the relaunched signal's bg_job_id + worktreePath", () => {
+    const signalPath = seed("CTL-660-R", "implement", {
+      status: "running",
+      bg_job_id: "bg-orig",
+      worktreePath: "/wt/CTL/CTL-660-R",
+      orchestrator: "orch-rev",
+    });
+    // The real dispatcher rewrites the signal with the relaunched worker's
+    // bg_job_id; mimic that so the launched emit re-reads the NEW id.
+    const dispatch = () => {
+      const sig = JSON.parse(readFileSync(signalPath, "utf8"));
+      sig.status = "running";
+      sig.bg_job_id = "bg-new";
+      writeFileSync(signalPath, JSON.stringify(sig));
+      return { code: 0 };
+    };
+    const appendRequested = recorder(true);
+    const appendLaunched = recorder(true);
+
+    const r = defaultReviveDispatch(
+      { orchDir, ticket: "CTL-660-R", phase: "implement" },
+      { dispatch, appendRequested, appendLaunched },
+    );
+
+    expect(r.code).toBe(0);
+    expect(appendRequested.calls.length).toBe(1);
+    expect(appendRequested.calls[0][0]).toMatchObject({
+      orchId: "orch-rev",
+      ticket: "CTL-660-R",
+      target_phase: "implement",
+      reason: "revive",
+    });
+    expect(appendLaunched.calls.length).toBe(1);
+    expect(appendLaunched.calls[0][0]).toMatchObject({
+      orchId: "orch-rev",
+      ticket: "CTL-660-R",
+      target_phase: "implement",
+      bg_job_id: "bg-new",
+      worktree_path: "/wt/CTL/CTL-660-R",
+    });
+  });
+
+  test("CTL-660: revive dispatch failure (code!=0) emits requested but NOT launched", () => {
+    seed("CTL-660-F", "implement", {
+      status: "running",
+      bg_job_id: "bg-f",
+      orchestrator: "orch-rev",
+    });
+    const dispatch = recorder({ code: 2, stderr: "boom" });
+    const appendRequested = recorder(true);
+    const appendLaunched = recorder(true);
+
+    const r = defaultReviveDispatch(
+      { orchDir, ticket: "CTL-660-F", phase: "implement" },
+      { dispatch, appendRequested, appendLaunched },
+    );
+
+    expect(r.code).toBe(2);
+    expect(appendRequested.calls.length).toBe(1);
+    expect(appendRequested.calls[0][0]).toMatchObject({ reason: "revive", target_phase: "implement" });
+    expect(appendLaunched.calls.length).toBe(0);
+  });
+
+  test("CTL-660: signal-missing early return emits neither requested nor launched", () => {
+    const dispatch = recorder({ code: 0 });
+    const appendRequested = recorder(true);
+    const appendLaunched = recorder(true);
+
+    const r = defaultReviveDispatch(
+      { orchDir, ticket: "CTL-660-MISSING", phase: "implement" },
+      { dispatch, appendRequested, appendLaunched },
+    );
+
+    expect(r.code).toBe(1);
+    expect(r.stderr).toBe("signal-missing");
+    expect(appendRequested.calls.length).toBe(0);
+    expect(appendLaunched.calls.length).toBe(0);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -19,6 +19,8 @@ import {
   defaultKillBgJob,
   defaultPidAlive,
   defaultAppendReviveEvent,
+  defaultAppendDispatchRequestedEvent,
+  defaultAppendDispatchLaunchedEvent,
   readBootEpoch,
   readDaemonEpoch,
   defaultReadRuntimeEpoch,
@@ -1633,6 +1635,97 @@ describe("revive event envelope round-trip (write → countReviveEvents)", () =>
     expect(countReviveEvents({ ticket: "CTL-RT-1", orchId: "orch-rt" })).toBe(1);
     // orchId mismatch returns 0 — proves the orchId attribute round-trips.
     expect(countReviveEvents({ ticket: "CTL-RT-1", orchId: "wrong-orch" })).toBe(0);
+  });
+});
+
+// CTL-660: success-path dispatch lifecycle events — phase.dispatch.requested
+// and phase.dispatch.launched. Mirror the revive envelope round-trip: point
+// CATALYST_DIR at a temp dir, call the helper, read back the JSONL line and
+// assert the envelope shape (event.name, body.payload, service.name).
+describe("dispatch lifecycle event envelopes (CTL-660)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl660-disp-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  // Read back the single envelope written this test (current UTC month log).
+  function readBackEnvelope() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    return JSON.parse(lines[lines.length - 1]);
+  }
+
+  test("defaultAppendDispatchRequestedEvent writes a requested envelope", () => {
+    const ok = defaultAppendDispatchRequestedEvent({
+      orchId: "orch-rq",
+      ticket: "CTL-RQ-1",
+      target_phase: "implement",
+      reason: "advance",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.dispatch.requested.CTL-RQ-1");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.body.payload.status).toBe("requested");
+    expect(env.body.payload.reason).toBe("advance");
+    expect(env.body.payload.target_phase).toBe("implement");
+    expect(env.attributes["catalyst.orchestration"]).toBe("orch-rq");
+  });
+
+  test("defaultAppendDispatchLaunchedEvent writes a launched envelope", () => {
+    const ok = defaultAppendDispatchLaunchedEvent({
+      orchId: "orch-lc",
+      ticket: "CTL-LC-1",
+      target_phase: "research",
+      bg_job_id: "deadbeef",
+      worktree_path: "/wt/CTL/CTL-LC-1",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.dispatch.launched.CTL-LC-1");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.body.payload.status).toBe("launched");
+    expect(env.body.payload.target_phase).toBe("research");
+    expect(env.body.payload.bg_job_id).toBe("deadbeef");
+    expect(env.body.payload.worktree_path).toBe("/wt/CTL/CTL-LC-1");
+  });
+
+  test("both helpers are fail-open: return false when the log dir is unwriteable", () => {
+    // Point CATALYST_DIR at a path whose parent is a regular file, so the
+    // events/ mkdir + append cannot succeed. Mirrors appendEnvelopeBestEffort's
+    // documented fail-open contract (return false, never throw).
+    const filePath = join(envCatalystDir, "not-a-dir");
+    writeFileSync(filePath, "x");
+    process.env.CATALYST_DIR = join(filePath, "nested");
+    expect(
+      defaultAppendDispatchRequestedEvent({
+        orchId: "o",
+        ticket: "CTL-FAIL-1",
+        target_phase: "implement",
+        reason: "revive",
+      }),
+    ).toBe(false);
+    expect(
+      defaultAppendDispatchLaunchedEvent({
+        orchId: "o",
+        ticket: "CTL-FAIL-1",
+        target_phase: "implement",
+        bg_job_id: "x",
+        worktree_path: "/x",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -54,9 +54,15 @@ import { emitReapIntent } from "./reap-intent.mjs";
 // reclaimDeadWorkIfPossible in recovery.mjs for the decision tree.
 // CTL-611: defaultAppendDispatchFailedEvent — emits phase.dispatch.failed.<T>
 // to the unified event log on every dispatch failure (Gap 1 + Gap 2).
+// CTL-660: defaultAppendDispatchRequestedEvent/LaunchedEvent — the success-path
+// complement, emitted when the scheduler decides to dispatch (requested) and
+// after the bg worker is verified live (launched), so pickup→launch latency is
+// derivable from the unified event log.
 import {
   reclaimDeadWorkIfPossible as defaultReclaimDeadWork,
   defaultAppendDispatchFailedEvent,
+  defaultAppendDispatchRequestedEvent,
+  defaultAppendDispatchLaunchedEvent,
 } from "./recovery.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
@@ -451,6 +457,19 @@ function safeWrite(fn, ctx) {
   }
 }
 
+// CTL-660: best-effort guard for the dispatch-lifecycle emitters. The default
+// emitters (defaultAppendDispatchRequested/LaunchedEvent → appendEnvelopeBestEffort)
+// already swallow IO errors and return false, but the emitters are an injection
+// seam — a test or future caller could pass one that throws. An audit emit must
+// NEVER gate or abort a dispatch decision, so isolate the call here.
+function safeEmit(fn, arg, ctx) {
+  try {
+    fn(arg);
+  } catch (err) {
+    log.warn({ ...ctx, err: err.message }, "scheduler: dispatch-lifecycle emit threw — continuing tick");
+  }
+}
+
 // CTL-585 labelOnce now lives in `label-guard.mjs` (CTL-638 re-home — see the
 // import block at the top of this file). The shared module also hosts the
 // per-(ticket, phase) escalation cool-down used by the recovery sweep.
@@ -700,6 +719,11 @@ export function schedulerTick(
     // demotion path independently of fixture choice (fakeDispatch / recorder).
     verifyDispatched = verifyDispatchedSignal,
     appendDispatchFailedEvent = defaultAppendDispatchFailedEvent,
+    // CTL-660: success-path lifecycle emitters. requested fires when the
+    // scheduler DECIDES to dispatch; launched fires only after verifyDispatched
+    // confirms a live worker. Both best-effort — no branch gates on the return.
+    appendDispatchRequestedEvent = defaultAppendDispatchRequestedEvent,
+    appendDispatchLaunchedEvent = defaultAppendDispatchLaunchedEvent,
   } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -786,6 +810,12 @@ export function schedulerTick(
     });
     if (!next) continue;
     if (inDispatchCooldown(orchDir, ticket, next, now())) continue; // CTL-624: throttle refused re-dispatch
+    // CTL-660: record the dispatch DECISION before the spawn. Best-effort.
+    safeEmit(
+      appendDispatchRequestedEvent,
+      { orchId: ticket, ticket, target_phase: next, reason: "advance" },
+      { ticket, phase: next }
+    );
     const r = dispatchTicket(orchDir, ticket, next, { dispatch });
     if (r.code === 0) {
       // CTL-611: verify the dispatch actually produced a live worker before
@@ -795,6 +825,20 @@ export function schedulerTick(
       const v = verifyDispatched(orchDir, ticket, next);
       if (v.ok) {
         clearDispatchCooldown(orchDir, ticket, next); // CTL-624: success clears any prior cool-down
+        // CTL-660: record the VERIFIED launch. Re-read the signal for the
+        // bg_job_id + worktreePath the launched worker wrote.
+        const sig = readPhaseSignalRaw(orchDir, ticket, next);
+        safeEmit(
+          appendDispatchLaunchedEvent,
+          {
+            orchId: ticket,
+            ticket,
+            target_phase: next,
+            bg_job_id: sig?.bg_job_id,
+            worktree_path: sig?.worktreePath,
+          },
+          { ticket, phase: next }
+        );
         advanced.push({ ticket, phase: next });
         // CTL-657: stop the predecessor worker now that its successor is live.
         emitPredecessorReap(orchDir, ticket, signals, next);
@@ -856,6 +900,17 @@ export function schedulerTick(
   const dispatched = [];
   for (const t of selected) {
     if (inDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, now())) continue; // CTL-624: throttle refused re-dispatch
+    // CTL-660: record the new-work dispatch DECISION before the spawn.
+    safeEmit(
+      appendDispatchRequestedEvent,
+      {
+        orchId: t.identifier,
+        ticket: t.identifier,
+        target_phase: NEW_WORK_ENTRY_PHASE,
+        reason: "new-work",
+      },
+      { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
+    );
     const r = dispatchTicket(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, { dispatch });
     if (r.code === 0) {
       // CTL-611: same Gap 1 verifier as the advancement sweep — a rc=0
@@ -863,6 +918,19 @@ export function schedulerTick(
       const v = verifyDispatched(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE);
       if (v.ok) {
         clearDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE); // CTL-624: success clears any prior cool-down
+        // CTL-660: record the VERIFIED launch for the new ticket's entry phase.
+        const sig = readPhaseSignalRaw(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE);
+        safeEmit(
+          appendDispatchLaunchedEvent,
+          {
+            orchId: t.identifier,
+            ticket: t.identifier,
+            target_phase: NEW_WORK_ENTRY_PHASE,
+            bg_job_id: sig?.bg_job_id,
+            worktree_path: sig?.worktreePath,
+          },
+          { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
+        );
         dispatched.push(t.identifier);
         // CTL-558: write the entry-phase (`research`) status for the new ticket.
         safeWrite(

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -2354,3 +2354,179 @@ describe("phase.dispatch.failed event emission (CTL-611)", () => {
     expect(existsSync(dispatchCooldownPath(orchDir, "CTL-205", "plan"))).toBe(false);
   });
 });
+
+// ── CTL-660: phase.dispatch.requested / .launched emission (scheduler) ────
+//
+// The success-path complement to CTL-611's phase.dispatch.failed. `requested`
+// fires when the scheduler DECIDES to dispatch (before the spawn); `launched`
+// fires ONLY after verifyDispatched confirms a live worker, carrying the
+// signal's bg_job_id + worktreePath so pickup→launch latency is derivable.
+// Asserted via the injection seam (spy emitters) per the plan; the envelope
+// shape itself is round-tripped in recovery.test.mjs.
+describe("CTL-660: phase.dispatch.requested/launched emission (scheduler)", () => {
+  const eligibleOne = (id) => [
+    {
+      identifier: id,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      labels: ["Ready"],
+      blockedBy: [],
+      raw: { team: { key: "CTL" } },
+    },
+  ];
+
+  // Spy emitter: records each call's single argument object, returns true
+  // (the best-effort contract; no caller gates on it).
+  function spy() {
+    const calls = [];
+    const fn = (arg) => {
+      calls.push(arg);
+      return true;
+    };
+    fn.calls = calls;
+    return fn;
+  }
+
+  // A dispatch fake that writes a runnable signal carrying bg_job_id +
+  // worktreePath so the default verifyDispatchedSignal returns ok AND the
+  // launched emit (which re-reads the signal via readPhaseSignalRaw) sees them.
+  function dispatchWritesSignal({ bgJobId = "abcd1234", worktreePath = "/wt/x" } = {}) {
+    const calls = [];
+    const fn = ({ orchDir: od, ticket, phase }) => {
+      calls.push({ ticket, phase });
+      const dir = join(od, "workers", ticket);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, `phase-${phase}.json`),
+        JSON.stringify({ ticket, phase, status: "running", bg_job_id: bgJobId, worktreePath })
+      );
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    fn.calls = calls;
+    return fn;
+  }
+
+  test("advance success: requested(advance) then launched with signal bg_job_id + worktree_path", () => {
+    writeSignal("CTL-300", "research", "done"); // FSM owes plan
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = dispatchWritesSignal({ bgJobId: "deadbeef", worktreePath: "/wt/CTL-300" });
+    const requested = spy();
+    const launched = spy();
+
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => 1_000,
+      appendDispatchRequestedEvent: requested,
+      appendDispatchLaunchedEvent: launched,
+    });
+
+    expect(r.advanced).toContainEqual({ ticket: "CTL-300", phase: "plan" });
+    expect(requested.calls).toHaveLength(1);
+    expect(requested.calls[0]).toMatchObject({
+      ticket: "CTL-300",
+      target_phase: "plan",
+      reason: "advance",
+    });
+    expect(launched.calls).toHaveLength(1);
+    expect(launched.calls[0]).toMatchObject({
+      ticket: "CTL-300",
+      target_phase: "plan",
+      bg_job_id: "deadbeef",
+      worktree_path: "/wt/CTL-300",
+    });
+  });
+
+  test("new-work success: requested(new-work) then launched", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = dispatchWritesSignal({ bgJobId: "f00dface", worktreePath: "/wt/CTL-301" });
+    const requested = spy();
+    const launched = spy();
+
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligibleOne("CTL-301"),
+      dispatch,
+      now: () => 1_000,
+      liveBackgroundCount: () => 0,
+      appendDispatchRequestedEvent: requested,
+      appendDispatchLaunchedEvent: launched,
+    });
+
+    expect(r.dispatched).toContain("CTL-301");
+    expect(requested.calls).toHaveLength(1);
+    expect(requested.calls[0]).toMatchObject({
+      ticket: "CTL-301",
+      target_phase: "research",
+      reason: "new-work",
+    });
+    expect(launched.calls).toHaveLength(1);
+    expect(launched.calls[0]).toMatchObject({
+      ticket: "CTL-301",
+      target_phase: "research",
+      bg_job_id: "f00dface",
+      worktree_path: "/wt/CTL-301",
+    });
+  });
+
+  test("dispatch rc!=0: requested emitted (decision happened), launched NOT", () => {
+    writeSignal("CTL-302", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 1 });
+    const requested = spy();
+    const launched = spy();
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => 1_000,
+      appendDispatchRequestedEvent: requested,
+      appendDispatchLaunchedEvent: launched,
+    });
+
+    expect(requested.calls).toHaveLength(1);
+    expect(requested.calls[0]).toMatchObject({ ticket: "CTL-302", target_phase: "plan", reason: "advance" });
+    expect(launched.calls).toHaveLength(0);
+  });
+
+  test("verify !ok (rc=0, no live signal): requested emitted, launched NOT (no CTL-611 regression)", () => {
+    writeSignal("CTL-303", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 }); // writes no signal → verifier !ok
+    const requested = spy();
+    const launched = spy();
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => 1_000,
+      appendDispatchRequestedEvent: requested,
+      appendDispatchLaunchedEvent: launched,
+    });
+
+    expect(requested.calls).toHaveLength(1);
+    expect(launched.calls).toHaveLength(0);
+    // CTL-611 failure event still fires on the demotion.
+    expect(dispatchFailedEvents("CTL-303")).toHaveLength(1);
+  });
+
+  test("fail-open: a throwing requested/launched emitter does not break the tick", () => {
+    writeSignal("CTL-304", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = dispatchWritesSignal({ bgJobId: "abc12345", worktreePath: "/wt/CTL-304" });
+    const thrower = () => {
+      throw new Error("emit boom");
+    };
+
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => 1_000,
+      appendDispatchRequestedEvent: thrower,
+      appendDispatchLaunchedEvent: thrower,
+    });
+
+    // The dispatch still advanced despite both lifecycle emitters throwing.
+    expect(r.advanced).toContainEqual({ ticket: "CTL-304", phase: "plan" });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/dispatch-latency.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/dispatch-latency.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "bun:test";
+import type { CanonicalEvent } from "../lib/canonical-event.ts";
+import {
+  computeDispatchLatencies,
+  latencyKeyForEvent,
+} from "../cli/lib/dispatch-latency.ts";
+
+// Minimal canonical-event factory — only the fields computeDispatchLatencies
+// reads (ts, attributes["event.name"], body.payload.target_phase). The rest of
+// the envelope is irrelevant to the pairing math.
+function evt(
+  name: string,
+  ts: string,
+  payload: Record<string, unknown> = {},
+): CanonicalEvent {
+  return {
+    ts,
+    id: "x",
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: null,
+    spanId: null,
+    resource: { "service.name": "t", "service.namespace": "catalyst", "service.version": "0" },
+    attributes: { "event.name": name },
+    body: { payload },
+  } as CanonicalEvent;
+}
+
+const T0 = "2026-05-27T10:00:00.000Z";
+const T1 = "2026-05-27T10:00:02.500Z"; // +2500ms
+const T2 = "2026-05-27T10:05:00.000Z"; // +297500ms from T1
+
+describe("computeDispatchLatencies", () => {
+  it("pairs requested→launched→complete into pickupMs + wallClockMs", () => {
+    const events = [
+      evt("phase.dispatch.requested.CTL-1", T0, { target_phase: "implement", reason: "advance" }),
+      evt("phase.dispatch.launched.CTL-1", T1, { target_phase: "implement", bg_job_id: "ab12" }),
+      evt("phase.implement.complete.CTL-1", T2, {}),
+    ];
+    const map = computeDispatchLatencies(events);
+    const l = map.get("CTL-1:implement");
+    expect(l).toBeDefined();
+    expect(l?.pickupMs).toBe(Date.parse(T1) - Date.parse(T0)); // 2500
+    expect(l?.wallClockMs).toBe(Date.parse(T2) - Date.parse(T1));
+  });
+
+  it("missing launched → pickupMs/wallClockMs undefined (no crash)", () => {
+    const events = [
+      evt("phase.dispatch.requested.CTL-2", T0, { target_phase: "research" }),
+      evt("phase.research.complete.CTL-2", T2, {}),
+    ];
+    const map = computeDispatchLatencies(events);
+    const l = map.get("CTL-2:research");
+    expect(l).toBeDefined();
+    expect(l?.requestedTs).toBe(Date.parse(T0));
+    expect(l?.completeTs).toBe(Date.parse(T2));
+    expect(l?.pickupMs).toBeUndefined();
+    expect(l?.wallClockMs).toBeUndefined();
+  });
+
+  it("keys multiple tickets/phases independently and tolerates out-of-order arrival", () => {
+    const events = [
+      // complete arrives before its launched (out of order)
+      evt("phase.implement.complete.CTL-3", T2, {}),
+      evt("phase.dispatch.launched.CTL-3", T1, { target_phase: "implement" }),
+      evt("phase.dispatch.requested.CTL-3", T0, { target_phase: "implement", reason: "advance" }),
+      // a second, independent (ticket, phase) pairing
+      evt("phase.dispatch.requested.CTL-4", T0, { target_phase: "research", reason: "new-work" }),
+      evt("phase.dispatch.launched.CTL-4", T1, { target_phase: "research" }),
+    ];
+    const map = computeDispatchLatencies(events);
+    expect(map.get("CTL-3:implement")?.pickupMs).toBe(Date.parse(T1) - Date.parse(T0));
+    expect(map.get("CTL-3:implement")?.wallClockMs).toBe(Date.parse(T2) - Date.parse(T1));
+    expect(map.get("CTL-4:research")?.pickupMs).toBe(Date.parse(T1) - Date.parse(T0));
+    expect(map.get("CTL-4:research")?.wallClockMs).toBeUndefined(); // no complete
+  });
+
+  it("a dispatch event without target_phase is skipped (cannot be keyed)", () => {
+    const events = [
+      evt("phase.dispatch.requested.CTL-5", T0, {}), // no target_phase
+      evt("phase.dispatch.launched.CTL-5", T1, { target_phase: "plan" }),
+    ];
+    const map = computeDispatchLatencies(events);
+    // Only the launched event keyed CTL-5:plan; requested was dropped.
+    const l = map.get("CTL-5:plan");
+    expect(l?.launchedTs).toBe(Date.parse(T1));
+    expect(l?.requestedTs).toBeUndefined();
+  });
+
+  it("ignores non-lifecycle events and unparseable timestamps", () => {
+    const events = [
+      evt("phase.dispatch.failed.CTL-6", T0, { target_phase: "implement" }), // failed not paired
+      evt("github.pr.opened.CTL-6", T0, {}),
+      evt("phase.dispatch.requested.CTL-6", "not-a-date", { target_phase: "implement" }),
+    ];
+    const map = computeDispatchLatencies(events);
+    expect(map.size).toBe(0);
+  });
+
+  it("handles hyphenated phase slots in complete events (monitor-deploy)", () => {
+    const events = [
+      evt("phase.dispatch.launched.CTL-7", T1, { target_phase: "monitor-deploy" }),
+      evt("phase.monitor-deploy.complete.CTL-7", T2, {}),
+    ];
+    const map = computeDispatchLatencies(events);
+    expect(map.get("CTL-7:monitor-deploy")?.wallClockMs).toBe(Date.parse(T2) - Date.parse(T1));
+  });
+});
+
+describe("latencyKeyForEvent", () => {
+  it("derives <ticket>:<target_phase> for dispatch events", () => {
+    expect(
+      latencyKeyForEvent(evt("phase.dispatch.launched.CTL-1", T1, { target_phase: "implement" })),
+    ).toBe("CTL-1:implement");
+  });
+
+  it("derives <ticket>:<phase> from the name for complete events", () => {
+    expect(latencyKeyForEvent(evt("phase.implement.complete.CTL-1", T2, {}))).toBe("CTL-1:implement");
+  });
+
+  it("returns null for non-lifecycle events and dispatch events without target_phase", () => {
+    expect(latencyKeyForEvent(evt("github.pr.opened.CTL-1", T0, {}))).toBeNull();
+    expect(latencyKeyForEvent(evt("phase.dispatch.requested.CTL-1", T0, {}))).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/components/DetailPane.tsx
@@ -2,11 +2,15 @@ import { memo, useMemo } from "react";
 import { Box, Text, useStdout } from "ink";
 import type { CanonicalEvent } from "../../lib/canonical-event.ts";
 import { formatDateTime, formatDetailBody } from "../lib/format.ts";
+import type { DispatchLatency } from "../lib/dispatch-latency.ts";
 
 export interface DetailPaneProps {
   event: CanonicalEvent;
   scrollTop: number;
   maxHeight: number;
+  // CTL-660: the matched dispatch latency for this event's (ticket, phase),
+  // when the paired requested/launched/complete events are in the window.
+  dispatchLatency?: DispatchLatency;
 }
 
 type Line =
@@ -22,7 +26,11 @@ const SEV_COLOR: Record<string, string> = {
 
 const LABEL_W = 14;
 
-export function buildDetailLines(event: CanonicalEvent, cols: number): Line[] {
+export function buildDetailLines(
+  event: CanonicalEvent,
+  cols: number,
+  dispatchLatency?: DispatchLatency,
+): Line[] {
   const attrs = event.attributes ?? {};
   const name = attrs["event.name"] ?? "(unknown)";
   const ts = formatDateTime(event);
@@ -31,6 +39,19 @@ export function buildDetailLines(event: CanonicalEvent, cols: number): Line[] {
 
   lines.push({ k: "title", name, ts, sev });
   lines.push({ k: "sep" });
+
+  // CTL-660: surface the derived dispatch latencies for a dispatch/complete
+  // row when both ends of a leg are present in the window. pickup = daemon
+  // decided → worker live; wall-clock = worker live → phase done.
+  if (dispatchLatency?.pickupMs !== undefined || dispatchLatency?.wallClockMs !== undefined) {
+    if (dispatchLatency.pickupMs !== undefined) {
+      lines.push({ k: "field", label: "pickup", value: `${dispatchLatency.pickupMs}ms`, color: "cyan" });
+    }
+    if (dispatchLatency.wallClockMs !== undefined) {
+      lines.push({ k: "field", label: "wall-clock", value: `${dispatchLatency.wallClockMs}ms`, color: "cyan" });
+    }
+    lines.push({ k: "sep" });
+  }
 
   const repo = attrs["vcs.repository.name"];
   const pr = attrs["vcs.pr.number"];
@@ -182,12 +203,15 @@ function renderLine(line: Line, i: number, cols: number): React.ReactNode {
 
 // CTL-473: memo wrap. All three props (event, scrollTop, maxHeight) are
 // referentially stable from hud.tsx after Phase 1's prop stabilization.
-function DetailPaneImpl({ event, scrollTop, maxHeight }: DetailPaneProps) {
+function DetailPaneImpl({ event, scrollTop, maxHeight, dispatchLatency }: DetailPaneProps) {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 120;
   // CTL-473: avoid recomputing the detail-line array on every render. Only
-  // changes when the focused event or terminal width changes.
-  const lines = useMemo(() => buildDetailLines(event, cols), [event, cols]);
+  // changes when the focused event, terminal width, or matched latency changes.
+  const lines = useMemo(
+    () => buildDetailLines(event, cols, dispatchLatency),
+    [event, cols, dispatchLatency],
+  );
 
   // First line is always the title — pin it so it stays visible while scrolling.
   const titleLine = lines[0];

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -7,6 +7,7 @@ import { readBrokerState, type BrokerState } from "./lib/broker-key-health.ts";
 import { EventList } from "./components/EventList.tsx";
 import { PromptInput, type InputMode } from "./components/PromptInput.tsx";
 import { DetailPane, buildDetailLines } from "./components/DetailPane.tsx";
+import { computeDispatchLatencies, latencyKeyForEvent } from "./lib/dispatch-latency.ts";
 import { Dashboard } from "./components/Dashboard.tsx";
 import {
   computeBottomOverlaySize,
@@ -268,11 +269,20 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   // extracted into pure helpers for testability.
   const inDetailMode = showDetail && !!selectedEvent && !showHelp;
   const innerCols = cols - 1;
+  // CTL-660: pair the dispatch-lifecycle events once per event-array change and
+  // look up the single latency matching the selected row's (ticket, phase).
+  // Memoized on `events` identity so it does not recompute every render.
+  const dispatchLatencies = useMemo(() => computeDispatchLatencies(events), [events]);
+  const selectedLatency = useMemo(() => {
+    if (!selectedEvent) return undefined;
+    const key = latencyKeyForEvent(selectedEvent);
+    return key ? dispatchLatencies.get(key) : undefined;
+  }, [selectedEvent, dispatchLatencies]);
   // CTL-473: memoize buildDetailLines so it only recomputes when the selected
-  // event or column width changes — was re-running on every render.
+  // event, column width, or matched latency changes — was re-running on every render.
   const detailLines = useMemo(
-    () => (selectedEvent ? buildDetailLines(selectedEvent, innerCols) : []),
-    [selectedEvent, innerCols],
+    () => (selectedEvent ? buildDetailLines(selectedEvent, innerCols, selectedLatency) : []),
+    [selectedEvent, innerCols, selectedLatency],
   );
 
   let listRows: number;
@@ -527,6 +537,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
             event={selectedEvent}
             scrollTop={detailScrollTop}
             maxHeight={detailContentRows}
+            dispatchLatency={selectedLatency}
           />
         </Box>
       )}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/dispatch-latency.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/dispatch-latency.ts
@@ -1,0 +1,105 @@
+// CTL-660: pure pairing/latency helper for the dispatch-lifecycle events the
+// execution-core scheduler/recovery now emit (phase.dispatch.requested.<T>,
+// phase.dispatch.launched.<T>) plus the existing phase completion events
+// (phase.<phase>.complete.<T>). Pairs them by (ticket, target_phase) and
+// derives two durations:
+//   • pickupMs    = launched − requested  (daemon-decided → worker-live)
+//   • wallClockMs = complete − launched   (worker-live → phase done)
+//
+// Intentionally free of any Ink/React import so it stays trivially unit-
+// testable (Phase 4 of the plan, Key Decision 5: HUD scope minimal).
+
+import type { CanonicalEvent } from "../../lib/canonical-event.ts";
+
+export interface DispatchLatency {
+  /** ms epoch of phase.dispatch.requested (the dispatch decision). */
+  requestedTs?: number;
+  /** ms epoch of phase.dispatch.launched (verified live worker). */
+  launchedTs?: number;
+  /** ms epoch of phase.<phase>.complete. */
+  completeTs?: number;
+  /** launched − requested, present only when both ends exist. */
+  pickupMs?: number;
+  /** complete − launched, present only when both ends exist. */
+  wallClockMs?: number;
+}
+
+// phase.<phaseSlot>.<action>.<ticket>. For dispatch events the phaseSlot is the
+// literal "dispatch" and the real phase rides in body.payload.target_phase; for
+// complete events the phaseSlot IS the real phase. The ticket tail is greedy so
+// hyphenated ids (CTL-660) and any future dotted suffix stay intact.
+const NAME_RE = /^phase\.([^.]+)\.(requested|launched|complete)\.(.+)$/;
+
+function payloadOf(event: CanonicalEvent): Record<string, unknown> {
+  const p = event?.body?.payload;
+  return p && typeof p === "object" ? (p as Record<string, unknown>) : {};
+}
+
+/**
+ * The `<ticket>:<phase>` key a dispatch/complete event contributes to, or null
+ * when the event is not a lifecycle event (or a dispatch event missing
+ * target_phase, which cannot be keyed). Exported so the HUD can look up the
+ * single matched latency for a selected row without rebuilding the map shape.
+ */
+export function latencyKeyForEvent(event: CanonicalEvent): string | null {
+  const name = event?.attributes?.["event.name"];
+  if (typeof name !== "string") return null;
+  const m = NAME_RE.exec(name);
+  if (!m) return null;
+  const [, phaseSlot, action, ticket] = m;
+  if (action === "complete") return `${ticket}:${phaseSlot}`;
+  const tp = payloadOf(event)["target_phase"];
+  if (typeof tp !== "string" || tp.length === 0) return null;
+  return `${ticket}:${tp}`;
+}
+
+/**
+ * Reduce a window of canonical events into per-(ticket, phase) dispatch
+ * latencies. Out-of-order arrival is tolerated (each action just stamps its
+ * own field); durations are computed in a second pass once all events are
+ * folded in. Events that are not lifecycle events, that carry an unparseable
+ * ts, or that are dispatch events without a target_phase are skipped.
+ */
+export function computeDispatchLatencies(
+  events: CanonicalEvent[],
+): Map<string, DispatchLatency> {
+  const map = new Map<string, DispatchLatency>();
+
+  for (const event of events) {
+    const name = event?.attributes?.["event.name"];
+    if (typeof name !== "string") continue;
+    const m = NAME_RE.exec(name);
+    if (!m) continue;
+    const [, phaseSlot, action, ticket] = m;
+
+    let phase: string;
+    if (action === "complete") {
+      phase = phaseSlot;
+    } else {
+      const tp = payloadOf(event)["target_phase"];
+      if (typeof tp !== "string" || tp.length === 0) continue;
+      phase = tp;
+    }
+
+    const ts = Date.parse(event.ts);
+    if (Number.isNaN(ts)) continue;
+
+    const key = `${ticket}:${phase}`;
+    const entry = map.get(key) ?? {};
+    if (action === "requested") entry.requestedTs = ts;
+    else if (action === "launched") entry.launchedTs = ts;
+    else entry.completeTs = ts;
+    map.set(key, entry);
+  }
+
+  for (const entry of map.values()) {
+    if (entry.requestedTs !== undefined && entry.launchedTs !== undefined) {
+      entry.pickupMs = entry.launchedTs - entry.requestedTs;
+    }
+    if (entry.launchedTs !== undefined && entry.completeTs !== undefined) {
+      entry.wallClockMs = entry.completeTs - entry.launchedTs;
+    }
+  }
+
+  return map;
+}

--- a/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/format.ts
@@ -515,6 +515,26 @@ export function formatDetails(event: CanonicalEvent): string {
       return out;
     }
   }
+  // CTL-660: dispatch-lifecycle events carry the real phase in
+  // body.payload.target_phase (the EVENT cell shows the literal "dispatch"
+  // slot), so render that + the discriminating field rather than the generic
+  // payload dump. Only requested/launched are claimed here; phase.dispatch.failed
+  // (CTL-611) keeps its existing generic rendering.
+  if (name?.startsWith("phase.dispatch.requested.") || name?.startsWith("phase.dispatch.launched.")) {
+    const p = payload as Record<string, unknown> | undefined;
+    const targetPhase = typeof p?.["target_phase"] === "string" ? p["target_phase"] : "?";
+    let out: string;
+    if (name.startsWith("phase.dispatch.launched.")) {
+      const bg = typeof p?.["bg_job_id"] === "string" ? p["bg_job_id"] : "";
+      out = `launched ${targetPhase}${bg ? ` bg:${bg}` : ""}`;
+    } else {
+      const reason = typeof p?.["reason"] === "string" ? p["reason"] : "";
+      out = `dispatch → ${targetPhase}${reason ? ` (${reason})` : ""}`;
+    }
+    const sanitized = sanitize(out, "oneline");
+    detailsCache.set(event, sanitized);
+    return sanitized;
+  }
   const msg = event.body?.message ?? "";
   let raw = msg;
   if (payload && typeof payload === "object") {


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-27 -->
<!-- PR: #1106 -->
<!-- Previous commits: 2bf00f9de4547b517802ba6959d852d867188b90,d578262fc1ead82ed360f06de7bbcf5c19e4456e -->

## Summary

Wires **dispatch lifecycle events** (`phase.dispatch.requested` / `phase.dispatch.launched`) into the unified event log so the daemon-pickup → worker-launch latency gap is observable, and surfaces that latency in the orch-monitor HUD. These success-path audit emitters mirror the existing `phase.dispatch.failed` emitter, closing the visibility hole between when the scheduler decides to dispatch a phase and when the `claude --bg` worker actually launches.

## Changes Made

### Emit helpers (`recovery.mjs`)
- Added `defaultAppendDispatchRequestedEvent` and `defaultAppendDispatchLaunchedEvent`, modeled on the existing `defaultAppendDispatchFailedEvent`. Both are best-effort / fail-open audit emitters.
- `defaultReviveDispatch` now accepts `appendRequested` / `appendLaunched` options, reads `orchId` from the signal, emits `requested` (reason=`revive`) before dispatch, and emits `launched` after the spawn returns `code === 0`.

### Scheduler wiring (`scheduler.mjs`)
- Emits `phase.dispatch.requested` immediately before `dispatchTicket`, and `phase.dispatch.launched` inside the verified `v.ok` branch — at **both** the phase-advance site and the new-work site.
- Emitters are injectable; a `safeEmit` fail-open guard ensures a logging failure never blocks dispatch.

### Orch-monitor HUD (`orch-monitor`)
- New pure module `cli/lib/dispatch-latency.ts` — `computeDispatchLatencies` + `latencyKeyForEvent` pair requested/launched events and derive pickup + wall-clock latencies.
- `format.ts` gains a `phase.dispatch.requested` / `phase.dispatch.launched` formatting arm.
- `DetailPane.tsx` surfaces pickup / wall-clock latency, threaded through from `hud.tsx`.

## How to Verify It

- [x] `scheduler.test.mjs` — +5 tests (pass)
- [x] `recovery.test.mjs` — +3 tests (pass)
- [x] `dispatch-latency.test.ts` — +9 tests (pass)
- [x] Pre-landing review passed (mergeable, no HIGH findings, regression_risk addressed)

Note: the 8 pre-existing scheduler new-work failures are environment-only (real `claude agents` reports 0 free slots) and are unchanged by this diff.

## Related Issues/PRs

Refs: CTL-660
