### PR TITLE
fix(dev): enforce one-worker-per-ticket — liveness-gate reclaim + reap on remediate cycle (CTL-661)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -34,7 +34,7 @@ import {
   reconcileAll,
   createTicketStateCache,
 } from "./index.mjs";
-import { Reaper } from "./reaper.mjs";
+import { Reaper, defaultReadActivePhaseSignal } from "./reaper.mjs";
 import { startOrphanReaperTimer, readOrphanReaperConfig } from "./orphan-reaper-timer.mjs";
 import { reconcileBootResume } from "./boot-resume.mjs";
 import { writeBootMarker } from "./recovery.mjs"; // CTL-655: window the revive budget to this run
@@ -174,7 +174,7 @@ export function startDaemon({
     }
 
     if (enableReaper) {
-      startReaperAndTimer({ orphanReaperConfig, debounceMs });
+      startReaperAndTimer({ orphanReaperConfig, debounceMs, orchDir });
     }
   } catch (err) {
     stopDaemon();
@@ -192,13 +192,17 @@ export function startDaemon({
 //
 // Boot replay is best-effort: if it throws, log and continue with live
 // consumption only.
-function startReaperAndTimer({ orphanReaperConfig, debounceMs }) {
+function startReaperAndTimer({ orphanReaperConfig, debounceMs, orchDir }) {
   const eventLogPath = getEventLogPath();
   // CTL-649: the periodic sweep honors the configured recency floor
   // (minIdleSeconds, default 900s). includeInteractive stays at its safe
   // default false — the daemon never opts into reaping human sessions.
+  // CTL-661: bind the per-ticket reconciler's canonical-owner reader to this
+  // daemon's orchDir so the sweep resolves the authoritative active-phase
+  // bg_job_id (falling back to newest-by-last_seen when no signal is found).
   _reaper = new Reaper({
     minIdleMs: (orphanReaperConfig?.minIdleSeconds ?? 900) * 1000,
+    readActivePhaseSignal: (ticket) => defaultReadActivePhaseSignal(orchDir, ticket),
   });
 
   // Boot replay: cover for any intents that landed while the daemon was down.

--- a/plugins/dev/scripts/execution-core/orphan-reaper-timer.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-reaper-timer.mjs
@@ -56,7 +56,16 @@ export function startOrphanReaperTimer({
   const ms = Math.max(1, intervalSeconds) * 1000;
   const handle = clock.setInterval(async () => {
     try {
-      await emit("orphans.reap-requested", {});
+      // CTL-661 hole #4: drive the per-ticket reconciliation sweep off the same
+      // timer (no new daemon timer). A bare reconcile event — no bg_job_id — is
+      // the TRIGGER the Reaper routes to its reconcile sweep; the sweep then
+      // emits per-session phase.reconcile.reap-requested intents WITH a target.
+      // Both emits are issued synchronously (before any await) so a single tick
+      // fires both even when the producer is async.
+      await Promise.all([
+        emit("orphans.reap-requested", {}),
+        emit("phase.reconcile.reap-requested", {}),
+      ]);
     } catch (err) {
       // CTL-649: a persistently-unwritable event log would make every tick
       // fail silently, turning the periodic orphan safety-net into a permanent

--- a/plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-reaper-timer.test.mjs
@@ -30,15 +30,17 @@ function fakeClock() {
 }
 
 describe("startOrphanReaperTimer", () => {
-  it("emits orphans.reap-requested every interval", () => {
+  it("emits orphans + reconcile reap-requested every interval (CTL-661)", () => {
     const emitted = [];
     const clock = fakeClock();
     startOrphanReaperTimer({ intervalSeconds: 600, emit: (e) => emitted.push(e), clock });
     clock.advance(600_000);
-    expect(emitted.length).toBe(1);
+    // CTL-661: each tick now drives BOTH the orphan sweep and the per-ticket
+    // reconcile sweep (the bare reconcile event is the sweep trigger).
+    expect(emitted).toEqual(["orphans.reap-requested", "phase.reconcile.reap-requested"]);
     clock.advance(600_000);
-    expect(emitted.length).toBe(2);
-    expect(emitted[0]).toBe("orphans.reap-requested");
+    expect(emitted.filter((e) => e === "orphans.reap-requested").length).toBe(2);
+    expect(emitted.filter((e) => e === "phase.reconcile.reap-requested").length).toBe(2);
   });
 
   it("honors a config-overridden interval", () => {
@@ -46,7 +48,8 @@ describe("startOrphanReaperTimer", () => {
     const clock = fakeClock();
     startOrphanReaperTimer({ intervalSeconds: 60, emit: (e) => emitted.push(e), clock });
     clock.advance(60_000);
-    expect(emitted.length).toBe(1);
+    expect(emitted.filter((e) => e === "orphans.reap-requested").length).toBe(1);
+    expect(emitted.filter((e) => e === "phase.reconcile.reap-requested").length).toBe(1);
   });
 
   it("is a no-op when disabled", () => {

--- a/plugins/dev/scripts/execution-core/reap-intent.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.mjs
@@ -15,6 +15,12 @@ export const REAP_INTENT_TYPES = Object.freeze([
   "phase.supersede.reap-requested",
   "phase.revive.reap-requested",
   "phase.abort.reap-requested",
+  // CTL-661 hole #3: the reclaim happy path (recovery.mjs branch (B)) nominates
+  // the (possibly genuinely-hung) worker it is reclaiming for a stop.
+  "phase.reclaim.reap-requested",
+  // CTL-661 hole #4: the per-ticket reconciliation sweep (reaper.mjs
+  // reconcileTicketWorkers) reaps every non-canonical live bg session.
+  "phase.reconcile.reap-requested",
   "worktree.presweep.reap-requested",
   "pr.merged.cleanup-requested",
   "orphans.reap-requested",

--- a/plugins/dev/scripts/execution-core/reap-intent.test.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.test.mjs
@@ -46,12 +46,43 @@ describe("emitReapIntent", () => {
     await expect(emitReapIntent("bogus.event", {})).rejects.toThrow(/unknown/);
   });
 
-  it("exposes REAP_INTENT_TYPES with 8 entries", async () => {
+  it("exposes REAP_INTENT_TYPES with 10 entries", async () => {
     const { REAP_INTENT_TYPES } = await freshModule();
-    expect(REAP_INTENT_TYPES.length).toBe(8);
+    expect(REAP_INTENT_TYPES.length).toBe(10);
     expect(REAP_INTENT_TYPES).toContain("phase.yield.reap-requested");
     expect(REAP_INTENT_TYPES).toContain("pr.merged.cleanup-requested");
     expect(REAP_INTENT_TYPES).toContain("orphans.reap-requested");
+  });
+
+  it("accepts phase.reclaim.reap-requested (CTL-661 hole #3)", async () => {
+    const { emitReapIntent } = await freshModule();
+    const ok = await emitReapIntent("phase.reclaim.reap-requested", {
+      ticket: "CTL-661",
+      phase: "implement",
+      bgJobId: "abc12345",
+      reason: "ctl-661-reclaim-happy-path",
+    });
+    expect(ok).toBe(true);
+    const last = JSON.parse(readFileSync(LOG_PATH, "utf8").trim().split("\n").pop());
+    expect(last.event).toBe("phase.reclaim.reap-requested");
+    expect(last.bg_job_id).toBe("abc12345");
+  });
+
+  it("accepts phase.reconcile.reap-requested with canonical/dominant fields (CTL-661 hole #4)", async () => {
+    const { emitReapIntent } = await freshModule();
+    const ok = await emitReapIntent("phase.reconcile.reap-requested", {
+      ticket: "CTL-661",
+      phase: "verify",
+      bgJobId: "bbbb2222",
+      canonicalBgJobId: "aaaa1111",
+      dominantPhase: "verify",
+      reason: "ctl-661-one-worker-per-ticket",
+    });
+    expect(ok).toBe(true);
+    const last = JSON.parse(readFileSync(LOG_PATH, "utf8").trim().split("\n").pop());
+    expect(last.event).toBe("phase.reconcile.reap-requested");
+    expect(last.canonical_bg_job_id).toBe("aaaa1111");
+    expect(last.dominant_phase).toBe("verify");
   });
 
   it("camelCase keys map to snake_case JSON fields", async () => {

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -100,6 +100,12 @@ export class Reaper {
         case "phase.supersede.reap-requested":
         case "phase.revive.reap-requested":
         case "phase.abort.reap-requested":
+        // CTL-661 hole #3: single-target stop of a reclaimed (genuinely-hung)
+        // worker on the recovery happy path. Busy-OK, like the others.
+        case "phase.reclaim.reap-requested":
+        // CTL-661 hole #4: single-target stop of a non-canonical live bg session
+        // identified by the per-ticket reconciliation sweep.
+        case "phase.reconcile.reap-requested":
           await this._handleBgReap(event);
           break;
         case "worktree.presweep.reap-requested":

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -15,7 +15,8 @@
 // APIs. The schema, the producers, and the consumer count are all stable.
 
 import { spawnSync, execFileSync } from "node:child_process";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { shortIdFromSessionId, isSelfSession } from "./claude-ids.mjs";
 import { emitReapIntent, REAP_INTENT_TYPES } from "./reap-intent.mjs";
 import { lastSeenMsForSession } from "./session-recency.mjs";
@@ -24,6 +25,25 @@ import { log } from "./config.mjs";
 const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
 const DEDUPE_WINDOW_MS = Number(process.env.REAPER_DEDUPE_WINDOW_MS) || 60_000;
 const DEFAULT_MIN_IDLE_MS = 15 * 60 * 1000; // 15 min
+
+// CTL-661 Phase 5 — the per-ticket reconciler's spawn-grace window. A revive or
+// advance reassigns a ticket's bg_job_id to a fresh successor; for a brief
+// window two background sessions co-exist by design while the new one takes
+// over the signal. The reconciler must grant that window so it never stops a
+// legitimate freshly-spawned successor mid-handoff.
+//
+// ─── Three DISTINCT time constants — do NOT conflate (research called this out) ───
+//   • STALE_MS          (recovery.mjs, 5 min)  — dead-detection: a state.json
+//                         quiet longer than this is *candidate*-dead.
+//   • minIdleMs         (this file, 15 min)    — periodic-sweep recency floor:
+//                         a transcript touched within this is "still in use".
+//   • CLEANUP_GRACE_MS  (this file, 60 s)      — reconciler spawn-grace: a
+//                         non-canonical session younger than this is a likely
+//                         just-spawned successor; spare it this tick.
+// DEDUPE_WINDOW_MS (60 s) coincidentally shares the grace's magnitude but serves
+// a different role (suppress re-emitting the same intent), so they are kept as
+// separate named constants.
+export const CLEANUP_GRACE_MS = 60_000;
 
 /**
  * Reaper — composes injectable executors so the unit test never shells out.
@@ -47,6 +67,14 @@ export class Reaper {
     includeInteractive = false,
     minIdleMs = DEFAULT_MIN_IDLE_MS,
     lastSeenMs = (sessionId) => lastSeenMsForSession(sessionId),
+    // CTL-661 hole #4: per-ticket reconciliation seams.
+    //  - readActivePhaseSignal(ticket): the ticket's authoritative active-phase
+    //    signal { bg_job_id, phase } | null, used to pick the canonical owner.
+    //    Default returns null so the sweep falls back to newest-by-last_seen;
+    //    the daemon injects a real orchDir-backed reader.
+    //  - now: injectable clock for the Phase-5 cleanup-grace skip.
+    readActivePhaseSignal = () => null,
+    now = () => Date.now(),
     log: logger = log,
   } = {}) {
     this.executorReap = executorReap;
@@ -58,6 +86,8 @@ export class Reaper {
     this.includeInteractive = includeInteractive;
     this.minIdleMs = minIdleMs;
     this.lastSeenMs = lastSeenMs;
+    this.readActivePhaseSignal = readActivePhaseSignal;
+    this.now = now;
     this.log = logger;
     this._inflight = new Map(); // key → expiresAt
   }
@@ -103,10 +133,15 @@ export class Reaper {
         // CTL-661 hole #3: single-target stop of a reclaimed (genuinely-hung)
         // worker on the recovery happy path. Busy-OK, like the others.
         case "phase.reclaim.reap-requested":
-        // CTL-661 hole #4: single-target stop of a non-canonical live bg session
-        // identified by the per-ticket reconciliation sweep.
-        case "phase.reconcile.reap-requested":
           await this._handleBgReap(event);
+          break;
+        // CTL-661 hole #4: the reconcile event is dual-purpose, disambiguated by
+        // bg_job_id. With a target it is a per-session stop (the sweep's own
+        // emit, round-tripped through the log) → _handleBgReap. Without one it is
+        // the periodic timer's TRIGGER → run the per-ticket reconciliation sweep.
+        case "phase.reconcile.reap-requested":
+          if (event.bg_job_id) await this._handleBgReap(event);
+          else await this._handleReconcile(event);
           break;
         case "worktree.presweep.reap-requested":
           await this._handleWorktreePresweep(event);
@@ -334,6 +369,115 @@ export class Reaper {
     }
   }
 
+  // CTL-661 hole #4: trigger handler for the periodic reconcile tick.
+  async _handleReconcile(_event) {
+    await this.reconcileTicketWorkers();
+  }
+
+  /**
+   * reconcileTicketWorkers — enforce one-live-bg-worker-per-ticket. Group live
+   * `background` sessions by the ticket derived from their worktree cwd; for any
+   * ticket with >1 live session, keep the canonical owner (the active-phase
+   * signal's bg_job_id, else newest-by-last_seen) and emit a
+   * `phase.reconcile.reap-requested` for every other live session — except those
+   * younger than CLEANUP_GRACE_MS (a likely just-spawned successor still taking
+   * over the signal; the next tick re-evaluates). Interactive/unknown-kind
+   * sessions and sessions outside a recognizable worktree are never reconciled.
+   */
+  async reconcileTicketWorkers() {
+    const live = await this.agents();
+    const groups = groupBackgroundSessionsByTicket(live);
+    for (const [ticket, sessions] of groups) {
+      if (sessions.length <= 1) continue; // single live session → nothing to do
+      const signal = this.readActivePhaseSignal(ticket);
+      const dominantPhase = signal?.phase ?? null;
+      const canonical = this._resolveCanonical(ticket, sessions, signal);
+      if (!canonical) continue;
+      let canonicalShortId;
+      try {
+        canonicalShortId = shortIdFromSessionId(canonical.sessionId);
+      } catch {
+        continue; // can't name the keeper safely → leave the whole group alone
+      }
+      for (const s of sessions) {
+        if (s === canonical) continue;
+        if (isSelfSession(s.sessionId)) continue; // never reap the controller
+        let shortId;
+        try {
+          shortId = shortIdFromSessionId(s.sessionId);
+        } catch {
+          continue;
+        }
+        // Phase 5 — spawn-grace skip: a non-canonical session whose recency proxy
+        // is within CLEANUP_GRACE_MS is likely a just-spawned successor still
+        // taking over the signal. Spare it; the next tick re-evaluates. A null
+        // proxy (no transcript) does NOT spare it.
+        const seen = this.lastSeenMs(s.sessionId);
+        if (seen !== null && seen !== undefined && seen < CLEANUP_GRACE_MS) {
+          this.log.info(
+            { ticket, sessionId: s.sessionId, lastSeenS: Math.round(seen / 1000) },
+            "reaper: reconcile sparing freshly-spawned session (within cleanup grace)",
+          );
+          continue;
+        }
+        await this.emit("phase.reconcile.reap-requested", {
+          ticket,
+          phase: dominantPhase,
+          bgJobId: shortId,
+          worktreePath: s.cwd,
+          canonicalBgJobId: canonicalShortId,
+          dominantPhase,
+          reason: "ctl-661-one-worker-per-ticket",
+        });
+      }
+    }
+  }
+
+  /**
+   * _resolveCanonical — pick the live session to KEEP for a ticket group.
+   *   1. the session whose shortId matches the active-phase signal's bg_job_id;
+   *   2. else the newest session by last_seen (smallest age);
+   *   3. else (no signal, every last_seen null) the first-enumerated, + log.
+   */
+  _resolveCanonical(ticket, sessions, signal) {
+    if (signal?.bg_job_id) {
+      let target;
+      try {
+        target = shortIdFromSessionId(signal.bg_job_id);
+      } catch {
+        target = null;
+      }
+      if (target) {
+        const match = sessions.find((s) => {
+          try {
+            return shortIdFromSessionId(s.sessionId) === target;
+          } catch {
+            return false;
+          }
+        });
+        if (match) return match;
+      }
+    }
+    // Newest-by-last_seen: lastSeenMs is an AGE (ms since last activity), so the
+    // most recently active session has the SMALLEST value.
+    let best = null;
+    let bestSeen = Infinity;
+    for (const s of sessions) {
+      const seen = this.lastSeenMs(s.sessionId);
+      if (seen === null || seen === undefined) continue;
+      if (seen < bestSeen) {
+        bestSeen = seen;
+        best = s;
+      }
+    }
+    if (best) return best;
+    this.log.info(
+      { ticket },
+      "reaper: reconcile canonical fallback — no signal, no last_seen; keeping first-enumerated",
+    );
+    return sessions[0] ?? null;
+  }
+
   /**
    * bootReplay — on daemon startup, scan the current month's event log for
    * `*.reap-requested` entries with no matching `*.reap-complete` echo and
@@ -398,6 +542,77 @@ function stripTrailingSlash(p) {
 function cwdUnder(cwd, worktree) {
   if (!cwd || !worktree) return false;
   return cwd === worktree || cwd.startsWith(worktree + "/");
+}
+
+/**
+ * ticketFromCwd — derive a ticket id from a worktree cwd (CTL-661 hole #4).
+ * Worktrees follow the `…/wt/<TICKET>` convention, so the basename IS the
+ * ticket. Grouping by basename is boundary-safe by construction: `/wt/CTL-64`
+ * and `/wt/CTL-649` yield the distinct keys `CTL-64` / `CTL-649`. Returns null
+ * for an empty/unusable cwd so the reconciler never reaps on a guess.
+ */
+export function ticketFromCwd(cwd) {
+  if (!cwd || typeof cwd !== "string") return null;
+  const base = stripTrailingSlash(cwd).split("/").filter(Boolean).pop();
+  return base || null;
+}
+
+/**
+ * groupBackgroundSessionsByTicket — bucket live `background` sessions by the
+ * ticket their cwd resolves to (CTL-661 hole #4). Interactive/unknown-kind
+ * sessions, sessions without a sessionId/cwd, and sessions outside a
+ * recognizable worktree are dropped — never counted, never reaped. Returns a
+ * Map<ticket, sessions[]> preserving enumeration order within each group.
+ */
+export function groupBackgroundSessionsByTicket(live) {
+  const groups = new Map();
+  for (const s of live ?? []) {
+    if (!s || !s.sessionId || !s.cwd) continue;
+    if (s.kind !== "background") continue; // interactive/unknown never reconciled
+    const ticket = ticketFromCwd(s.cwd);
+    if (!ticket) continue;
+    if (!groups.has(ticket)) groups.set(ticket, []);
+    groups.get(ticket).push(s);
+  }
+  return groups;
+}
+
+/**
+ * defaultReadActivePhaseSignal — production reader for the reconciler's
+ * canonical-owner resolution (CTL-661 hole #4). Reads
+ * <orchDir>/workers/<ticket>/phase-*.json and returns { bg_job_id, phase } for
+ * the active worker: the `running` signal, else the newest by updatedAt. Returns
+ * null when the worker dir is absent or no signal carries a bg_job_id. Best-
+ * effort — never throws. The daemon binds `orchDir` and injects the bound form.
+ */
+export function defaultReadActivePhaseSignal(orchDir, ticket, { readDir = readdirSync, readFile = readFileSync } = {}) {
+  if (!orchDir || !ticket) return null;
+  const dir = join(orchDir, "workers", ticket);
+  let files;
+  try {
+    files = readDir(dir).filter((f) => f.startsWith("phase-") && f.endsWith(".json"));
+  } catch {
+    return null;
+  }
+  let best = null;
+  let bestRank = -1;
+  for (const f of files) {
+    let sig;
+    try {
+      sig = JSON.parse(readFile(join(dir, f), "utf8"));
+    } catch {
+      continue;
+    }
+    if (!sig?.bg_job_id) continue;
+    const running = sig.status === "running" ? 1 : 0;
+    const ts = Date.parse(sig.updatedAt ?? sig.startedAt ?? "") || 0;
+    const rank = running * 1e15 + ts; // prefer running, then newest
+    if (rank > bestRank) {
+      bestRank = rank;
+      best = sig;
+    }
+  }
+  return best ? { bg_job_id: best.bg_job_id, phase: best.phase } : null;
 }
 
 // ─── Default executors ──────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -1,7 +1,12 @@
 // reaper.test.mjs — Reaper reconciler unit tests (CTL-649 Phase 4).
 // All executors are injected; no real claude / git invocations.
 import { describe, it, expect, beforeEach, mock } from "bun:test";
-import { Reaper } from "./reaper.mjs";
+import {
+  Reaper,
+  ticketFromCwd,
+  groupBackgroundSessionsByTicket,
+  CLEANUP_GRACE_MS,
+} from "./reaper.mjs";
 
 function silentLog() {
   return { info: () => {}, warn: () => {}, error: () => {} };
@@ -568,5 +573,202 @@ describe("Reaper.bootReplay", () => {
     await r.bootReplay("/nonexistent/log/path.jsonl");
     // No throw == pass
     expect(true).toBe(true);
+  });
+});
+
+// ─── CTL-661 hole #4: pure grouping helpers ──────────────────────────────────
+describe("ticketFromCwd", () => {
+  it("derives the ticket from the worktree basename", () => {
+    expect(ticketFromCwd("/Users/x/catalyst/wt/CTL-661")).toBe("CTL-661");
+    expect(ticketFromCwd("/wt/CTL-661")).toBe("CTL-661");
+    expect(ticketFromCwd("/wt/CTL-661/")).toBe("CTL-661"); // trailing slash
+  });
+
+  it("keeps the /wt/CTL-64 vs /wt/CTL-649 boundary distinct", () => {
+    expect(ticketFromCwd("/wt/CTL-64")).toBe("CTL-64");
+    expect(ticketFromCwd("/wt/CTL-649")).toBe("CTL-649");
+    expect(ticketFromCwd("/wt/CTL-64")).not.toBe(ticketFromCwd("/wt/CTL-649"));
+  });
+
+  it("returns null for empty / non-string input", () => {
+    expect(ticketFromCwd("")).toBeNull();
+    expect(ticketFromCwd(null)).toBeNull();
+    expect(ticketFromCwd(undefined)).toBeNull();
+  });
+});
+
+describe("groupBackgroundSessionsByTicket", () => {
+  const bg = (sessionId, cwd) => ({ sessionId, cwd, kind: "background", status: "busy" });
+
+  it("buckets background sessions by ticket and groups distinct worktrees apart", () => {
+    const groups = groupBackgroundSessionsByTicket([
+      bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661"),
+      bg("bbbb2222-0000-0000-0000-000000000000", "/wt/CTL-661"),
+      bg("cccc3333-0000-0000-0000-000000000000", "/wt/CTL-660"),
+    ]);
+    expect(groups.get("CTL-661")).toHaveLength(2);
+    expect(groups.get("CTL-660")).toHaveLength(1);
+  });
+
+  it("drops interactive/unknown-kind sessions and sessions with no cwd", () => {
+    const groups = groupBackgroundSessionsByTicket([
+      bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661"),
+      { sessionId: "dddd4444-0000-0000-0000-000000000000", cwd: "/wt/CTL-661", kind: "interactive" },
+      { sessionId: "eeee5555-0000-0000-0000-000000000000", kind: "background" }, // no cwd
+    ]);
+    expect(groups.get("CTL-661")).toHaveLength(1);
+  });
+});
+
+// ─── CTL-661 hole #4: reconcileTicketWorkers ─────────────────────────────────
+describe("Reaper.reconcileTicketWorkers", () => {
+  const bg = (sessionId, cwd, status = "busy") => ({ sessionId, cwd, kind: "background", status });
+
+  it("keeps the canonical bg_job_id owner and reaps the rest", async () => {
+    const emit = mock(() => Promise.resolve());
+    const r = new Reaper({
+      agents: agentsFixture([
+        bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661"),
+        bg("bbbb2222-0000-0000-0000-000000000000", "/wt/CTL-661"),
+      ]),
+      emit,
+      readActivePhaseSignal: () => ({ bg_job_id: "aaaa1111", phase: "verify" }),
+      lastSeenMs: () => null, // null does NOT trip the cleanup-grace skip
+      log: silentLog(),
+    });
+    await r.reconcileTicketWorkers();
+    expect(emit).toHaveBeenCalledTimes(1);
+    const [evt, fields] = emit.mock.calls[0];
+    expect(evt).toBe("phase.reconcile.reap-requested");
+    expect(fields.bgJobId).toBe("bbbb2222");
+    expect(fields.canonicalBgJobId).toBe("aaaa1111");
+    expect(fields.dominantPhase).toBe("verify");
+    expect(fields.reason).toBe("ctl-661-one-worker-per-ticket");
+  });
+
+  it("leaves a ticket with a single live session alone", async () => {
+    const emit = mock(() => Promise.resolve());
+    const r = new Reaper({
+      agents: agentsFixture([bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661")]),
+      emit,
+      readActivePhaseSignal: () => ({ bg_job_id: "aaaa1111", phase: "verify" }),
+      lastSeenMs: () => null,
+      log: silentLog(),
+    });
+    await r.reconcileTicketWorkers();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("falls back to newest-by-last_seen when the signal is unresolvable", async () => {
+    const emit = mock(() => Promise.resolve());
+    // lastSeenMs is an AGE: aaaa1111 is 10s old (newest), bbbb2222 is 5min old.
+    const ages = {
+      "aaaa1111-0000-0000-0000-000000000000": 10_000,
+      "bbbb2222-0000-0000-0000-000000000000": 300_000,
+    };
+    const r = new Reaper({
+      agents: agentsFixture([
+        bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661"),
+        bg("bbbb2222-0000-0000-0000-000000000000", "/wt/CTL-661"),
+      ]),
+      emit,
+      readActivePhaseSignal: () => null, // unresolvable → newest fallback
+      lastSeenMs: (sid) => ages[sid] ?? null,
+      log: silentLog(),
+    });
+    await r.reconcileTicketWorkers();
+    expect(emit).toHaveBeenCalledTimes(1);
+    // newest (aaaa1111) kept → older bbbb2222 reaped.
+    expect(emit.mock.calls[0][1].bgJobId).toBe("bbbb2222");
+  });
+
+  it("never reconciles interactive sessions sharing the cwd", async () => {
+    const emit = mock(() => Promise.resolve());
+    const r = new Reaper({
+      agents: agentsFixture([
+        bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661"),
+        { sessionId: "dddd4444-0000-0000-0000-000000000000", cwd: "/wt/CTL-661", kind: "interactive", status: "busy" },
+      ]),
+      emit,
+      readActivePhaseSignal: () => ({ bg_job_id: "aaaa1111", phase: "verify" }),
+      lastSeenMs: () => null,
+      log: silentLog(),
+    });
+    await r.reconcileTicketWorkers();
+    // only 1 background session in the group → nothing to reap.
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("reconciles distinct worktrees independently", async () => {
+    const emit = mock(() => Promise.resolve());
+    const r = new Reaper({
+      agents: agentsFixture([
+        bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661"),
+        bg("bbbb2222-0000-0000-0000-000000000000", "/wt/CTL-661"),
+        bg("cccc3333-0000-0000-0000-000000000000", "/wt/CTL-660"), // lone session, untouched
+      ]),
+      emit,
+      readActivePhaseSignal: (ticket) =>
+        ticket === "CTL-661" ? { bg_job_id: "aaaa1111", phase: "verify" } : null,
+      lastSeenMs: () => null,
+      log: silentLog(),
+    });
+    await r.reconcileTicketWorkers();
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit.mock.calls[0][1].bgJobId).toBe("bbbb2222");
+  });
+
+  it("routes a no-target reconcile event (timer trigger) to the sweep", async () => {
+    const emit = mock(() => Promise.resolve());
+    const r = new Reaper({
+      agents: agentsFixture([
+        bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661"),
+        bg("bbbb2222-0000-0000-0000-000000000000", "/wt/CTL-661"),
+      ]),
+      emit,
+      readActivePhaseSignal: () => ({ bg_job_id: "aaaa1111", phase: "verify" }),
+      lastSeenMs: () => null,
+      log: silentLog(),
+    });
+    await r.handle({ event: "phase.reconcile.reap-requested" }); // no bg_job_id → trigger
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit.mock.calls[0][1].bgJobId).toBe("bbbb2222");
+  });
+});
+
+// ─── CTL-661 Phase 5: cleanup-grace ──────────────────────────────────────────
+describe("Reaper.reconcileTicketWorkers — CLEANUP_GRACE_MS spawn grace", () => {
+  const bg = (sessionId, cwd) => ({ sessionId, cwd, kind: "background", status: "busy" });
+
+  function reconciler(emit, ageMs) {
+    return new Reaper({
+      agents: agentsFixture([
+        bg("aaaa1111-0000-0000-0000-000000000000", "/wt/CTL-661"),
+        bg("bbbb2222-0000-0000-0000-000000000000", "/wt/CTL-661"),
+      ]),
+      emit,
+      readActivePhaseSignal: () => ({ bg_job_id: "aaaa1111", phase: "verify" }),
+      lastSeenMs: (sid) => (sid.startsWith("bbbb2222") ? ageMs : null),
+      log: silentLog(),
+    });
+  }
+
+  it("spares a non-canonical session younger than the cleanup grace", async () => {
+    const emit = mock(() => Promise.resolve());
+    await reconciler(emit, 30_000).reconcileTicketWorkers(); // 30s < 60s grace
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("reaps the same session once it is past the grace", async () => {
+    const emit = mock(() => Promise.resolve());
+    await reconciler(emit, 90_000).reconcileTicketWorkers(); // 90s > 60s grace
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit.mock.calls[0][1].bgJobId).toBe("bbbb2222");
+  });
+
+  it("CLEANUP_GRACE_MS is distinct from STALE_MS (5m) and minIdleMs (15m)", () => {
+    expect(CLEANUP_GRACE_MS).toBe(60_000);
+    expect(CLEANUP_GRACE_MS).not.toBe(5 * 60 * 1000); // STALE_MS
+    expect(CLEANUP_GRACE_MS).not.toBe(15 * 60 * 1000); // DEFAULT_MIN_IDLE_MS
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -817,18 +817,22 @@ const HUNG_CUTOFF_MS = 15 * 60 * 1000;
 //                         ahead of the genuinely-active terminal phase. No
 //                         escalate/revive/reclaim — acting would spuriously flag
 //                         needs-human or spawn a duplicate worker at a past phase.
-//   'alive-quiet-suppressed' effectively dead by state.json mtime AND probe says
-//                         work NOT done BUT the bg pid is still a live `claude`
-//                         process within HUNG_CUTOFF_MS (CTL-610). The worker
-//                         is alive-blocked-on-a-long-tool-call (the pre-first-
-//                         output window for research/plan, or a long sync
-//                         Edit/Bash inside implement), not crashed. Suppress
-//                         the revive: no duplicate spawn, no budget consumed,
-//                         no .revive-N.applied marker, no defensive kill, no
+//   'alive-quiet-suppressed' effectively dead by state.json mtime BUT the bg pid
+//                         is still a live `claude agents` session within
+//                         HUNG_CUTOFF_MS (CTL-610). The worker is alive-blocked-
+//                         on-a-long-tool-call (the pre-first-output window for
+//                         research/plan, or a long sync Edit/Bash inside
+//                         implement), not crashed. CTL-661 HOISTS this gate
+//                         ahead of branches (A)/(B)/(C): a live-but-quiet worker
+//                         is now suppressed regardless of whether its probe
+//                         reads done (B), its phase has no probe (A), or its
+//                         work is not done (C) — never reclaimed, escalated, or
+//                         revived. No duplicate spawn, no budget consumed, no
+//                         .revive-N.applied marker, no defensive kill, no
 //                         events.jsonl append — log-only (to avoid the CTL-638
-//                         self-feeding storm). A dead pid (real crash) or a
-//                         live pid past the cutoff (genuinely hung) falls
-//                         through to the existing revive path.
+//                         self-feeding storm). A dead pid (real crash) or a live
+//                         pid past the cutoff (genuinely hung) opens the gate and
+//                         falls through to the branches below.
 //
 // CTL-588 still defines "effectively dead" as classifyWorker:'dead' OR a
 // 'running' signal whose bg state.json mtime is older than staleMs.
@@ -965,12 +969,41 @@ export function reclaimDeadWorkIfPossible(
     return "escalated";
   }
 
+  // (C0→hoisted) CTL-661 — alive-quiet liveness gate, repositioned ahead of
+  //     ALL downstream branches (was at the top of branch (C), recovery.mjs
+  //     :891-901 pre-CTL-661). A worker flagged effectively-dead by stale
+  //     state.json mtime but still a live `claude agents` session within
+  //     hungCutoffMs is alive-blocked-on-a-long-tool-call (the pre-first-output
+  //     window for research/plan sub-agent fan-outs, or a long synchronous
+  //     Edit/Bash inside implement), not crashed. Suppressing HERE — before
+  //     branch (A) escalate, branch (B) reclaim, and the branch (C) revive —
+  //     means a live-but-quiet worker is never reclaimed, escalated, or revived
+  //     on ANY path; it is left to finish on its own (its own emit-complete is
+  //     authoritative) or to genuinely die (mtime past the cutoff → the gate
+  //     opens and it falls through to the branches below). The first conjunct
+  //     (prevStateJsonMtime !== null) fails-closed on the classifyWorker:'dead'
+  //     path (job dir gone — a real crash) so the gate cannot mask one.
+  const isAliveQuiet = () =>
+    prevStateJsonMtime !== null &&
+    now() - prevStateJsonMtime < hungCutoffMs &&
+    pidAlive({ bgJobId: prevBgJobId });
+  if (isAliveQuiet()) {
+    log.info(
+      { ticket, phase, prevBgJobId, prevStateJsonMtime },
+      "ctl-661: reclaim suppressed — bg pid alive within hung cutoff (worker quiet, not dead); gate precedes branches A/B/C",
+    );
+    return "alive-quiet-suppressed";
+  }
+
   // (A) No probe registered for this phase → escalate. The pre-CTL-587 silent
   //     'not-applicable' return is now an actionable outcome: the worker is
   //     dead, we cannot prove its work landed, and no automation can recover
   //     — so the human needs to look. needs-human label applied (verified by
   //     the CTL-587 applyLabel read-back). CTL-638 routes through escalateOnce
   //     so the same (ticket, phase) cannot re-fire within the cool-down window.
+  //     CTL-661: a LIVE worker on a probe-less phase no longer reaches here —
+  //     the hoisted alive-quiet gate above suppresses it first, so this branch
+  //     only escalates a genuinely-dead probe-less worker.
   if (!hasProbe(phase)) {
     return escalateOnce("no-probe-for-phase", 0);
   }
@@ -1001,32 +1034,12 @@ export function reclaimDeadWorkIfPossible(
   //     defaultReviveDispatch is phase-agnostic (resets the signal to `stalled`
   //     and re-launches via phase-agent-dispatch).
 
-  // (C0) CTL-610 — alive-quiet keep-alive guard. The worker is effectively-dead
-  //     by state.json mtime and its probe reads not-done, but if its bg pid is
-  //     still a live `claude` process within the hung cutoff, it is alive-
-  //     blocked on a long synchronous tool call (the pre-first-output window
-  //     for research/plan, or a long Edit/Bash inside implement), not crashed.
-  //     Suppress the revive — no duplicate spawn, no budget spent, no marker,
-  //     no kill, no events.jsonl append (log-only, to avoid the CTL-638
-  //     self-feeding storm). A dead pid (real crash) or a live pid past the
-  //     cutoff (genuinely hung) falls through to the existing revive path
-  //     below. Runs BEFORE priorRevives so a live worker is never falsely
-  //     escalated to needs-human just because two prior false-revives consumed
-  //     its budget; runs BEFORE the storm-breaker so liveness wins over
-  //     fleet-wide noise. The first conjunct (prevStateJsonMtime !== null)
-  //     fails-closed on the classifyWorker:'dead' path (job dir gone — a real
-  //     crash) so the guard cannot mask one.
-  if (
-    prevStateJsonMtime !== null &&
-    now() - prevStateJsonMtime < hungCutoffMs &&
-    pidAlive({ bgJobId: prevBgJobId })
-  ) {
-    log.info(
-      { ticket, phase, prevBgJobId, prevStateJsonMtime },
-      "ctl-610: revive suppressed — bg pid alive within hung cutoff (worker is quiet, not dead)",
-    );
-    return "alive-quiet-suppressed";
-  }
+  // CTL-661: the CTL-610 alive-quiet guard that formerly sat HERE (branch (C0))
+  // has been hoisted ahead of branches (A) and (B) — see the `isAliveQuiet`
+  // gate above. By the time control reaches this point the worker is either
+  // pid-dead (a real crash) or a live pid past the hung cutoff (genuinely hung),
+  // so the revive/escalate path below is correct for both. No duplicate guard
+  // is needed; removing it keeps the predicate single-sourced.
 
   // Per-ticket revive budget from events.jsonl. The events file is the
   // authoritative counter — more truthful than the signal file (which the

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -29,7 +29,7 @@ import { phaseIndex } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
-import { emitReapIntent } from "./reap-intent.mjs";
+import { emitReapIntent as emitReapIntentDefault } from "./reap-intent.mjs";
 import { isBgJobAlive, claudeStop } from "./claude-agents.mjs";
 import { shortIdFromSessionId } from "./claude-ids.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
@@ -890,6 +890,11 @@ export function reclaimDeadWorkIfPossible(
     // bg_job_id, no state.json, no .jsonl linkScanPath) preserves the pre-CTL-658
     // fresh-dispatch behaviour exactly.
     resolveSession = resolvePhaseSessionId,
+    // CTL-661 — reap-intent emitter seam. Defaults to the module producer; the
+    // supersede guard, the branch-(B) reclaim reap, and the branch-(C) revive
+    // reap all route through this so a test can inject a spy. Aliased default
+    // (emitReapIntentDefault) keeps the production wiring identical.
+    emitReapIntent = emitReapIntentDefault,
     now = Date.now,
     staleMs = STALE_MS,
   } = {},
@@ -1013,6 +1018,22 @@ export function reclaimDeadWorkIfPossible(
   //     can locate their artifact; implementProbe ignores the extra key.
   const probe = probes[phase];
   if (probe({ ticket, repoRoot, orchDir })) {
+    // CTL-661 hole #3: a worker reaching branch (B) has already passed the
+    // hoisted alive-quiet gate, so it is either pid-dead (nothing to stop) or
+    // live-but-past-hung-cutoff (genuinely hung → must be stopped). Emit a
+    // fire-and-forget reap-intent BEFORE emitComplete so the reaper stops any
+    // lingering session rather than letting a hung-but-live worker keep running
+    // past its own reclaim. No-op when no bg_job_id was recorded — mirrors the
+    // CTL-606 supersede-guard guard above.
+    if (prevBgJobId) {
+      emitReapIntent("phase.reclaim.reap-requested", {
+        ticket,
+        phase,
+        bgJobId: prevBgJobId,
+        worktreePath: signal.raw?.worktreePath,
+        reason: "ctl-661-reclaim-happy-path",
+      }).catch(() => {});
+    }
     appendEvent({ phase, ticket, orchId });
     const r = emitComplete({ orchDir, signal });
     if (r.code !== 0) {

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -732,6 +732,80 @@ describe("reclaimDeadWorkIfPossible", () => {
   });
 });
 
+// --- CTL-661 Phase 2: reap-intent on the reclaim happy path (B) -------------
+//
+// When a stale-by-mtime worker reaches branch (B) (probe says work IS done) it
+// has already cleared the hoisted alive-quiet gate, so it is either pid-dead or
+// genuinely hung. Before emitComplete, the reclaim emits a fire-and-forget
+// phase.reclaim.reap-requested so the reaper stops any lingering session.
+describe("reclaimDeadWorkIfPossible — CTL-661 reclaim happy-path reap-intent", () => {
+  const orch = "/orch";
+
+  // A stale (6-min-quiet) running implement signal that reaches branch (B):
+  // probe true, pidAlive false (so the alive-quiet gate does NOT suppress).
+  function staleReclaimable({ bgJobId = "job-x", worktreePath = "/wt/CTL-9" } = {}) {
+    const sig = implementSignal({ bgJobId });
+    sig.raw.worktreePath = worktreePath;
+    return sig;
+  }
+
+  test("branch (B) emits phase.reclaim.reap-requested with bgJobId before reclaiming", () => {
+    const emitReap = recorder(Promise.resolve(true));
+    const r = reclaimDeadWorkIfPossible(orch, staleReclaimable(), {
+      statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+      probes: { implement: () => true },
+      emitComplete: recorder({ code: 0 }),
+      appendEvent: recorder(undefined),
+      pidAlive: () => false, // genuinely dead → alive-quiet gate stays open
+      emitReapIntent: emitReap,
+      now: () => 1_000 + 6 * 60 * 1000, // 6 min past mtime — stale
+    });
+    expect(r).toBe("reclaimed");
+    expect(emitReap.calls.length).toBe(1);
+    const [eventType, fields] = emitReap.calls[0];
+    expect(eventType).toBe("phase.reclaim.reap-requested");
+    expect(fields).toMatchObject({
+      ticket: "CTL-9",
+      phase: "implement",
+      bgJobId: "job-x",
+      worktreePath: "/wt/CTL-9",
+      reason: "ctl-661-reclaim-happy-path",
+    });
+  });
+
+  test("branch (B) does NOT emit a reap-intent when the worker has no bg_job_id", () => {
+    // liveness.value present (so statJob can stale-flag it) but raw.bg_job_id
+    // absent — mirrors the supersede-guard no-op.
+    const sig = {
+      ticket: "CTL-9",
+      phase: "implement",
+      status: "running",
+      liveness: { kind: "bg", value: "job-x" },
+      signalPath: "/x/CTL-9/phase-implement.json",
+      raw: {
+        ticket: "CTL-9",
+        phase: "implement",
+        orchestrator: "CTL-9",
+        status: "running",
+        catalystSessionId: "sess_CTL-9_abc",
+        // no bg_job_id
+      },
+    };
+    const emitReap = recorder(Promise.resolve(true));
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+      probes: { implement: () => true },
+      emitComplete: recorder({ code: 0 }),
+      appendEvent: recorder(undefined),
+      pidAlive: () => false,
+      emitReapIntent: emitReap,
+      now: () => 1_000 + 6 * 60 * 1000,
+    });
+    expect(r).toBe("reclaimed");
+    expect(emitReap.calls.length).toBe(0);
+  });
+});
+
 // --- CTL-587: revive / revive-suppressed / escalated branches ---------------
 //
 // The pre-CTL-587 'not-applicable' and 'not-done' returns were silent dead-ends.

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1168,11 +1168,19 @@ describe("reclaimDeadWorkIfPossible — CTL-610 alive-quiet keep-alive guard", (
     expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(0);
   });
 
-  test("work-done (branch B) wins over alive-quiet (B returns before C0 is reached)", () => {
+  test("CTL-661: a LIVE worker whose work appears done is suppressed, NOT reclaimed (gate now precedes branch B)", () => {
+    // Pre-CTL-661 the alive-quiet guard sat at the top of branch (C), AFTER
+    // branch (B)'s reclaim, so a live worker whose probe read done was
+    // reclaimed (signal flipped, advanced past) even though it was still
+    // running. CTL-661 repositions the gate ahead of branches (A)/(B): a live
+    // worker within the hung cutoff is never reclaimed — it is left to finish
+    // (its own emit-complete is authoritative) or to genuinely die.
     const s = setupAliveQuietScenario({ pidAlive: () => true, probeResult: true });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
-    // Guard MUST NOT have been consulted — branch (B) returned first
-    expect(s.opts.pidAlive.calls.length).toBe(0);
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+    // Gate MUST have been consulted and won over the work-done reclaim.
+    expect(s.opts.pidAlive.calls.length).toBeGreaterThanOrEqual(1);
+    expect(s.opts.emitComplete.calls.length).toBe(0);
+    expect(s.opts.appendEvent.calls.length).toBe(0);
   });
 
   test("production default seam returns false for a fake bgJobId → guard inert, existing revive path runs", () => {
@@ -1204,6 +1212,112 @@ describe("reclaimDeadWorkIfPossible — CTL-610 alive-quiet keep-alive guard", (
     };
     // A 'dead' bg implies a real crash → revive must still fire.
     expect(reclaimDeadWorkIfPossible("/orch", sig, opts)).toBe("revived");
+  });
+});
+
+// --- CTL-661: reclaim liveness gate (repositioned ahead of branches A/B) ---
+//
+// CTL-610 introduced the alive-quiet guard but positioned it at the TOP of
+// branch (C) — after branch (A) (no-probe → escalate) and branch (B)
+// (work-done → reclaim) had already had a chance to return. A live-but-quiet
+// worker whose probe read done (B) or whose phase had no probe (A) was
+// therefore still reclaimed/escalated past while genuinely alive. CTL-661
+// hoists the same predicate ahead of (A) and (B) so a live worker within the
+// hung cutoff is suppressed on EVERY branch — never reclaimed, escalated, or
+// revived. These cases pin the repositioned semantics.
+describe("reclaimDeadWorkIfPossible — CTL-661 reclaim liveness gate", () => {
+  // Reuse the CTL-610 scenario shape. setupAliveQuietScenario is in the
+  // sibling describe block above; redeclare a local copy here so this block is
+  // self-contained and order-independent.
+  function setup({
+    pidAlive = () => true,
+    hungCutoffMs = 15 * 60 * 1000,
+    reviveCount = 0,
+    probeResult = false,
+    phase = "implement",
+    ticket = "CTL-9",
+    bgJobId = "bg-9",
+    stateJsonMtime = 1_000,
+    nowMs = 1_000 + 6 * 60 * 1000, // 6 min past mtime → stale, within cutoff
+  } = {}) {
+    const sig = {
+      ...implementSignal({ ticket, status: "running", bgJobId }),
+      phase,
+    };
+    sig.raw.phase = phase;
+    return {
+      orch: "/orch",
+      sig,
+      opts: {
+        repoRoot: "/repo",
+        statJob: () => ({ exists: true, mtimeMs: stateJsonMtime }),
+        probes: { [phase]: recorder(probeResult) },
+        emitComplete: recorder({ code: 0 }),
+        appendEvent: recorder(undefined),
+        appendReviveEvent: recorder(undefined),
+        appendEscalatedEvent: recorder(undefined),
+        appendReviveSuppressedEvent: recorder(undefined),
+        reviveDispatch: recorder({ code: 0 }),
+        applyStalledLabel: recorder({ applied: true }),
+        killBgJob: recorder(undefined),
+        countReviveEvents: recorder(reviveCount),
+        countDistinctRevivingTickets: recorder(1),
+        writeReviveMarker: recorder(undefined),
+        pidAlive: recorder(pidAlive()),
+        hungCutoffMs,
+        now: () => nowMs,
+        staleMs: 5 * 60 * 1000,
+      },
+    };
+  }
+
+  test("reclaim is suppressed when the bg worker is still live within the hung cutoff (probe says done)", () => {
+    const s = setup({ pidAlive: () => true, probeResult: true });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+    expect(s.opts.emitComplete.calls.length).toBe(0);
+    expect(s.opts.appendEvent.calls.length).toBe(0);
+  });
+
+  test("a genuinely dead worker (pid gone) still reclaims when work is done", () => {
+    const s = setup({ pidAlive: () => false, probeResult: true });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
+    expect(s.opts.emitComplete.calls.length).toBe(1);
+  });
+
+  test("a live worker PAST the hung cutoff is NOT suppressed (genuinely hung → reclaim allowed)", () => {
+    // 16 min past mtime > 15 min cutoff → gate predicate false → falls through
+    // to branch (B), which reclaims because the probe reads done.
+    const s = setup({
+      pidAlive: () => true,
+      probeResult: true,
+      stateJsonMtime: 1_000,
+      nowMs: 1_000 + 16 * 60 * 1000,
+    });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
+    expect(s.opts.emitComplete.calls.length).toBe(1);
+  });
+
+  // NOTE (CTL-661, plan Open Question #3): the plan also wanted a "live worker
+  // on a probe-less phase is suppressed, not escalated" case. It is not
+  // constructible: the supersede guard at the top of reclaimDeadWorkIfPossible
+  // calls phaseIndex(phase), which THROWS for any phase outside PHASES+
+  // remediate, and every phase phaseIndex accepts has a WORK_DONE_PROBES entry
+  // — so branch (A) (`!hasProbe`) is unreachable for all real phases (a
+  // pre-existing property the plan's "What We're NOT Doing" acknowledges). The
+  // gate is placed in source order BEFORE branch (A) regardless, so the
+  // hypothetical is covered; we do not fabricate a fake phaseIndex to assert
+  // an unreachable path. The realizable precedence — gate over branch (B)'s
+  // reclaim — is pinned by the work-done cases above.
+  test("the gate's bg_job_id is the signal's, not a stale value (consults pidAlive with prevBgJobId)", () => {
+    const s = setup({ pidAlive: () => true, probeResult: true, bgJobId: "bg-77" });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+    expect(s.opts.pidAlive.calls[0][0].bgJobId).toBe("bg-77");
+  });
+
+  test("regression: a live worker whose work is NOT done is still suppressed (the original C0 case)", () => {
+    const s = setup({ pidAlive: () => true, probeResult: false });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -207,14 +207,43 @@ function readPhaseSignalRaw(orchDir, ticket, phase) {
 
 // predecessorPhaseOf — the completed phase whose happy-path successor is `next`
 // (i.e. the worker that just finished and triggered this advance), or null.
-// Uses the NEXT_PHASE inversion so it is unambiguous on every linear edge; the
-// router-only remediate detour (no NEXT_PHASE entry) yields null and is left to
-// the periodic orphan reaper as a backstop.
+// Uses the NEXT_PHASE inversion so it is unambiguous on every LINEAR edge. The
+// router-only verify⇄remediate detour (no NEXT_PHASE entry) is resolved
+// separately by resolveReapPredecessor (CTL-661) — it is no longer left to the
+// periodic orphan reaper as a backstop.
 export function predecessorPhaseOf(signals, next) {
   for (const [phase, status] of Object.entries(signals ?? {})) {
     if (status === "done" && NEXT_PHASE[phase] === next) return phase;
   }
   return null;
+}
+
+// resolveReapPredecessor — CTL-661 hole #2. Pure resolution of "which just-
+// finished worker should be reaped now that `next` is dispatched", covering the
+// two verify⇄remediate detour edges that NEXT_PHASE cannot express, then the
+// linear edges. Returns `{ phase, reason } | null`.
+//   • verify → remediate (next === REMEDIATE_PHASE): the verify worker just
+//     produced the fail verdict — reap verify.
+//   • remediate → verify (next === "verify" && remediate done): the remediate
+//     worker just committed its fix — reap remediate, NOT the long-finished
+//     implement the NEXT_PHASE inversion would return.
+//   • every linear edge: fall through to the NEXT_PHASE inversion.
+// NOTE: on the real remediate→verify re-entry, maybeResetForRemediateCycle has
+// already deleted the remediate signal by the time the scheduler advances, so
+// the call site passes resolveReapPredecessor the PRE-reset signals (and the
+// pre-reset remediate raw) — see the advancement sweep below.
+export function resolveReapPredecessor(signals, next) {
+  const sig = signals ?? {};
+  if (next === REMEDIATE_PHASE) {
+    return sig.verify === "done"
+      ? { phase: "verify", reason: "ctl-661-remediate-detour" }
+      : null;
+  }
+  if (next === "verify" && sig[REMEDIATE_PHASE] === "done") {
+    return { phase: REMEDIATE_PHASE, reason: "ctl-661-remediate-detour" };
+  }
+  const pred = predecessorPhaseOf(sig, next);
+  return pred ? { phase: pred, reason: "ctl-657-scheduler-advance" } : null;
 }
 
 // emitPredecessorReap — CTL-657 Bug 2: stop the predecessor worker now that its
@@ -226,18 +255,24 @@ export function predecessorPhaseOf(signals, next) {
 // `claude stop`. No-op when the predecessor has no recorded bg_job_id (e.g. the
 // new-work entry phase, or a unit-test signal with no bg_job_id) so it never
 // shells out or appends to the event log spuriously.
-function emitPredecessorReap(orchDir, ticket, signals, next) {
-  const pred = predecessorPhaseOf(signals, next);
+// CTL-661: `remediateRaw` is the remediate phase signal captured BEFORE
+// maybeResetForRemediateCycle deletes it — passed in so the remediate→verify
+// re-entry can still read the dead remediate worker's bg_job_id.
+function emitPredecessorReap(orchDir, ticket, signals, next, { remediateRaw = null } = {}) {
+  const pred = resolveReapPredecessor(signals, next);
   if (!pred) return;
-  const raw = readPhaseSignalRaw(orchDir, ticket, pred);
+  const raw =
+    pred.phase === REMEDIATE_PHASE
+      ? (remediateRaw ?? readPhaseSignalRaw(orchDir, ticket, pred.phase))
+      : readPhaseSignalRaw(orchDir, ticket, pred.phase);
   const bgJobId = raw?.bg_job_id;
   if (!bgJobId) return;
   emitReapIntent("phase.predecessor.reap-requested", {
     ticket,
-    phase: pred,
+    phase: pred.phase,
     bgJobId,
     worktreePath: raw?.worktreePath,
-    reason: "ctl-657-scheduler-advance",
+    reason: pred.reason,
   }).catch(() => {});
 }
 
@@ -790,6 +825,14 @@ export function schedulerTick(
   // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
   const advanced = [];
   for (const ticket of listInFlightTickets(orchDir)) {
+    // CTL-661 hole #2: snapshot the signals + the remediate worker's raw signal
+    // BEFORE maybeResetForRemediateCycle deletes the verify+remediate signals,
+    // so a remediate→verify re-entry can still name + reap the remediate worker
+    // (the NEXT_PHASE inversion alone would wrongly pick the long-finished
+    // implement worker, and the deleted signal would carry no bg_job_id).
+    const preResetSignals = readPhaseSignals(orchDir, ticket);
+    const remediateRaw = readPhaseSignalRaw(orchDir, ticket, REMEDIATE_PHASE);
+
     // CTL-653: re-enter verify after a completed remediation (deletes the cycle
     // signals so deriveAdvancement re-dispatches a fresh verify this tick).
     maybeResetForRemediateCycle(orchDir, ticket);
@@ -840,8 +883,11 @@ export function schedulerTick(
           { ticket, phase: next }
         );
         advanced.push({ ticket, phase: next });
-        // CTL-657: stop the predecessor worker now that its successor is live.
-        emitPredecessorReap(orchDir, ticket, signals, next);
+        // CTL-657 / CTL-661: stop the predecessor worker now that its successor
+        // is live. resolveReapPredecessor reads the PRE-reset signals so the
+        // verify⇄remediate detour edges name the correct just-finished worker;
+        // remediateRaw supplies the bg_job_id the reset already deleted.
+        emitPredecessorReap(orchDir, ticket, preResetSignals, next, { remediateRaw });
         // CTL-558: write the dispatched phase's mapped Linear status. Idempotent
         // (linear-transition.sh read-compares first); never aborts the tick.
         safeWrite(() => writeStatus.applyPhaseStatus({ ticket, phase: next }), {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -22,6 +22,7 @@ import {
   readMaxParallel,
   computeFreeSlots,
   predecessorPhaseOf,
+  resolveReapPredecessor,
   computeReadyTickets,
   selectDispatchable,
   deriveAdvancement,
@@ -802,6 +803,66 @@ describe("schedulerTick — CTL-657 live-count concurrency & predecessor reap", 
       readEventLog().filter((e) => e.event === "phase.predecessor.reap-requested"),
     ).toHaveLength(0);
   });
+
+  // CTL-661 hole #2 — verify⇄remediate detour reaps, driven through schedulerTick.
+  function writeVerifyJson(ticket, regressionRisk) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "verify.json"),
+      JSON.stringify({ regression_risk: regressionRisk, findings: [], gates: {} }),
+    );
+  }
+
+  test("verify→remediate advance reaps the verify worker", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // implement+verify done; verify.json verdict-fail (regression_risk≥5) routes
+    // verify → remediate. The verify worker is the detour predecessor.
+    writeSignalWithBg("CTL-7", "implement", "done", "impl1111-0000-0000-0000-000000000000");
+    writeSignalWithBg("CTL-7", "verify", "done", "veri2222-0000-0000-0000-000000000000");
+    writeVerifyJson("CTL-7", 8);
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      liveBackgroundCount: () => 0,
+      verifyDispatched: verifyOk,
+    });
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "remediate" }]);
+    const reap = readEventLog().find(
+      (e) => e.event === "phase.predecessor.reap-requested" && e.ticket === "CTL-7",
+    );
+    expect(reap).toBeTruthy();
+    expect(reap.phase).toBe("verify");
+    expect(reap.bg_job_id).toBe("veri2222-0000-0000-0000-000000000000");
+    expect(reap.reason).toBe("ctl-661-remediate-detour");
+  });
+
+  test("remediate→verify re-entry reaps the remediate worker, NOT implement", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // implement+verify+remediate all done → maybeResetForRemediateCycle wipes the
+    // verify+remediate signals and re-dispatches a fresh verify. The remediate
+    // worker (captured before the reset) is the predecessor to reap.
+    writeSignalWithBg("CTL-7", "implement", "done", "impl1111-0000-0000-0000-000000000000");
+    writeSignalWithBg("CTL-7", "verify", "done", "veri2222-0000-0000-0000-000000000000");
+    writeSignalWithBg("CTL-7", "remediate", "done", "reme3333-0000-0000-0000-000000000000");
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      liveBackgroundCount: () => 0,
+      verifyDispatched: verifyOk,
+    });
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "verify" }]);
+    const reaps = readEventLog().filter(
+      (e) => e.event === "phase.predecessor.reap-requested" && e.ticket === "CTL-7",
+    );
+    expect(reaps).toHaveLength(1);
+    expect(reaps[0].phase).toBe("remediate");
+    expect(reaps[0].bg_job_id).toBe("reme3333-0000-0000-0000-000000000000");
+    // Explicitly NOT the long-finished implement worker.
+    expect(reaps[0].phase).not.toBe("implement");
+  });
 });
 
 describe("predecessorPhaseOf", () => {
@@ -818,6 +879,41 @@ describe("predecessorPhaseOf", () => {
   test("null for the router-only remediate detour (no NEXT_PHASE edge) and empty input", () => {
     expect(predecessorPhaseOf({ verify: "done" }, "remediate")).toBeNull();
     expect(predecessorPhaseOf(null, "plan")).toBeNull();
+  });
+});
+
+// ── CTL-661 hole #2: detour-aware reap predecessor resolution ──
+describe("resolveReapPredecessor", () => {
+  test("linear edge → NEXT_PHASE inversion (ctl-657 reason)", () => {
+    expect(resolveReapPredecessor({ research: "done" }, "plan")).toEqual({
+      phase: "research",
+      reason: "ctl-657-scheduler-advance",
+    });
+    expect(resolveReapPredecessor({ implement: "done" }, "verify")).toEqual({
+      phase: "implement",
+      reason: "ctl-657-scheduler-advance",
+    });
+  });
+
+  test("verify → remediate detour reaps the verify worker", () => {
+    expect(
+      resolveReapPredecessor({ implement: "done", verify: "done" }, "remediate"),
+    ).toEqual({ phase: "verify", reason: "ctl-661-remediate-detour" });
+  });
+
+  test("remediate → verify detour reaps remediate, NOT implement", () => {
+    const r = resolveReapPredecessor(
+      { implement: "done", verify: "done", remediate: "done" },
+      "verify",
+    );
+    expect(r).toEqual({ phase: "remediate", reason: "ctl-661-remediate-detour" });
+    expect(r.phase).not.toBe("implement");
+  });
+
+  test("no resolvable predecessor → null", () => {
+    // verify → remediate but verify is not done yet.
+    expect(resolveReapPredecessor({ implement: "done" }, "remediate")).toBeNull();
+    expect(resolveReapPredecessor(null, "plan")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes CTL-661 — execution-core was leaking multiple live `claude --bg` phase
workers per ticket (observed 3 concurrent on CTL-658's verify⇄remediate cycle).
The `claude stop` primitive was already verified working; the daemon simply
never issued the stop in four code paths. This change enforces a
**one-worker-per-ticket** invariant via a root-cause liveness gate plus a
belt-and-suspenders reconciliation sweep.

## Root causes addressed (4 holes)

1. **Reclaim dead-check was `state.json`-mtime-only.** A `verify`/`review`/
   `remediate` worker busy in a >5-min sub-agent fan-out stopped touching
   `state.json`, tripped the 5-min staleness, and was false-declared dead →
   reclaimed → advanced past while still a live, busy session. The CTL-610
   `pidAlive`/hung-cutoff guard existed only on the *revive* branch.
2. **No predecessor reap-intent on the verify⇄remediate detour.**
   `predecessorPhaseOf` was built on the linear `NEXT_PHASE` table;
   `remediate` is a router-only detour with no edges, so neither the detouring
   verify nor the completing remediate worker was ever nominated for reap.
3. **The reclaim branch advanced with `emitComplete` but issued no
   stop/reap-intent** — a false-dead-reclaimed worker was left running.
4. **The periodic reaper's recency floor (CTL-649) protected live orphans** —
   the "backstop" never fired while an orphan was active.

## Changes

- **Phase 1** (`recovery.mjs`): hoist the alive-quiet liveness gate ahead of
  the reclaim/escalate branches so a live `claude agents` session is never
  declared dead regardless of `state.json` mtime. `STALE_MS` (5 min) left
  intact — dead-detection now gates on liveness, not a shorter timer.
- **Phase 2** (`recovery.mjs`): emit reap-intent on the reclaim happy path.
- **Phase 3** (`scheduler.mjs`): teach `predecessorPhaseOf` the
  verify⇄remediate detour edges so reap-intent fires on the detour (both the
  detouring verify and the completing remediate worker).
- **Phases 4–5** (`reaper.mjs`, `orphan-reaper-timer.mjs`, `daemon.mjs`):
  per-ticket reconciliation sweep — group live background workers by ticket;
  if >1, keep the canonical `bg_job_id` owner (fall back to newest only when
  ownership is unresolvable) and `claude stop` the rest, emitting an audit
  event. Adds a bounded ~60s `CLEANUP_GRACE_MS` distinct from the 5-min
  `STALE_MS` dead-detection threshold.

## Verification

- **Targeted suites** (recovery + scheduler + reaper + reap-intent +
  orphan-reaper-timer): all new CTL-661 tests pass, incl. the Phase-3 detour
  reap (remediate→verify reaps remediate, not implement) 8/8.
- **Full execution-core suite**: 914 pass / 9 fail — the 9 failures are
  pre-existing sandbox `nohup`-detached-spawn failures, proven byte-identical
  on `origin/main`. None touch the reap machinery this diff changes.
- **regression_risk: 1** (verify). Reward-hacking scan clean; no new deps; no
  secrets/network/SQL/eval.
- Review passed (`reviewPassed: true`); remaining findings are low/medium
  non-blocking (one deferred-to-human note on `ticketFromCwd` basename
  validation, plus a vestigial unused `now` injection seam).

## Acceptance criteria

- [x] A full verify⇄remediate cycle leaves exactly ONE live bg worker per ticket.
- [x] A worker busy in a >5-min sub-agent fan-out is NOT reclaimed/advanced-past.
- [x] After any phase advance (linear or remediate), the predecessor worker is
      stopped within ~60s.
- [x] The reaper reconciliation reduces >1 live-workers-per-ticket to 1
      (canonical owner kept) and emits an audit event.

Closes CTL-661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
