### PR TITLE
CTL-664: Reclaim Linear mirror + enriched reclaim event payload

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -275,6 +275,46 @@ export function defaultAppendReclaimEvent({
   );
 }
 
+// CTL-664: post the reclaim Linear mirror the skill End block would have posted
+// had the worker survived. Marker-guarded by the SHARED .linear-mirror-<phase>
+// (first-writer-wins: if the skill already mirrored, the marker exists and we
+// skip — exactly the desired idempotency). Fail-open: a linearis failure logs
+// and returns without throwing, never breaking the reclaim. Seams injected for
+// recovery.test.mjs (no filesystem/network I/O).
+export function defaultPostReclaimMirror(
+  { orchDir, ticket, phase, deathSignal, probeChecked, reclaimedBgJobId },
+  {
+    existsSync: exists = existsSync,
+    writeMarker = (p) => writeFileSync(p, ""),
+    runLinearis = (t, bodyText) =>
+      spawnSync("linearis", ["issues", "discuss", t, "--body", bodyText], { encoding: "utf8" }),
+  } = {},
+) {
+  const marker = `${orchDir}/workers/${ticket}/.linear-mirror-${phase}`;
+  if (exists(marker)) return; // first-writer-wins
+  const bodyText = [
+    "**Phase Reclaim**",
+    "",
+    `- **Phase**: ${phase}`,
+    `- **Reason**: work-done-despite-dead-bg`,
+    `- **Death signal**: ${deathSignal}`,
+    `- **Probe verified**: ${probeChecked}`,
+    `- **Reclaimed bg_job_id**: \`${reclaimedBgJobId ?? "unknown"}\``,
+    "",
+    "_Posted automatically by the daemon reclaim sweep (CTL-664)._",
+  ].join("\n");
+  try {
+    const r = runLinearis(ticket, bodyText);
+    if (r && r.status === 0) {
+      writeMarker(marker);
+    } else {
+      log.warn({ ticket, phase }, "reclaim-mirror: linearis discuss failed (continuing)");
+    }
+  } catch (err) {
+    log.warn({ ticket, phase, err: err?.message }, "reclaim-mirror: post threw (continuing)");
+  }
+}
+
 // defaultAppendBootResumeEvent — phase.<phase>.boot-resume.<ticket>. The
 // CTL-654 path: a cold-start reboot re-dispatches an in-flight ticket whose
 // worktree has no live bg worker. The `boot-resume` action is deliberately
@@ -927,6 +967,11 @@ export function reclaimDeadWorkIfPossible(
     // reap all route through this so a test can inject a spy. Aliased default
     // (emitReapIntentDefault) keeps the production wiring identical.
     emitReapIntent = emitReapIntentDefault,
+    // CTL-664 — reclaim Linear mirror seam. Called on the successful reclaim
+    // path (branch (B), after emitComplete returns code 0) to post the
+    // "Phase Reclaim" comment the dead worker's skill End block never ran.
+    // Marker-guarded + fail-open; tests inject a spy to assert call order.
+    postReclaimMirror = defaultPostReclaimMirror,
     now = Date.now,
     staleMs = STALE_MS,
   } = {},
@@ -1082,9 +1127,7 @@ export function reclaimDeadWorkIfPossible(
       probe_checked,
       completion_origin: "inferred",
       reclaimed_bg_job_id: prevBgJobId,
-      // CTL-661 sources the reaped session via the reap-intent emitted above;
-      // record it here so the reclaim event mirrors the stopped set.
-      stopped_bg_job_ids: prevBgJobId ? [prevBgJobId] : [],
+      stopped_bg_job_ids: [], // CTL-661 will source the reconciled stopped set
       title: `phase ${phase} reclaimed (work-done-despite-dead-bg)`,
       body: `Daemon reclaimed dead ${phase} worker for ${ticket}: ${death_signal} death signal, probe verified ${probe_checked}. bg_job_id=${prevBgJobId ?? "?"}.`,
     });
@@ -1096,6 +1139,16 @@ export function reclaimDeadWorkIfPossible(
       );
       return "reclaim-failed";
     }
+    // CTL-664: mirror the reclaim to Linear (after emit-complete succeeds, so a
+    // reclaim-failed never posts). Reuses the Phase 2 consts — no recomputation.
+    postReclaimMirror({
+      orchDir,
+      ticket,
+      phase,
+      deathSignal: death_signal,
+      probeChecked: probe_checked,
+      reclaimedBgJobId: prevBgJobId,
+    });
     log.info({ ticket, phase }, "reclaim-dead-work: dead worker reclaimed (work was committed)");
     return "reclaimed";
   }

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -33,7 +33,7 @@ import { emitReapIntent as emitReapIntentDefault } from "./reap-intent.mjs";
 import { isBgJobAlive, claudeStop } from "./claude-agents.mjs";
 import { shortIdFromSessionId } from "./claude-ids.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
-import { WORK_DONE_PROBES, hasProbe } from "./work-done-probes.mjs";
+import { WORK_DONE_PROBES, hasProbe, describeProbe } from "./work-done-probes.mjs";
 import { defaultDispatch } from "./dispatch.mjs";
 import { applyLabel as defaultApplyLabel } from "./linear-write.mjs";
 // CTL-638: pull the once-marker + per-(ticket, phase) cool-down primitives
@@ -230,7 +230,28 @@ function appendEnvelopeBestEffort(line, kind) {
 // the worker died but its work committed, so the scheduler can advance.
 // Returns true iff the audit append succeeded (CTL-587 contract — callers may
 // gate on success; today the reclaim caller does not).
-function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
+//
+// CTL-664: the payload is enriched beyond the original {phase,ticket,reason}.
+// All extra fields arrive as named params (single options object so existing
+// callers are unaffected by field order) and flow through buildEventEnvelope's
+// payloadExtras seam — the same mechanism the revive emitter uses. `title` /
+// `body` make the HUD reclaim row's DETAILS cell render with no HUD code change
+// (the format.ts fallback reads body.payload.title/body). Exported so the
+// round-trip test can confirm the envelope shape.
+export function defaultAppendReclaimEvent({
+  phase,
+  ticket,
+  orchId,
+  death_signal,
+  prev_state_json_mtime = null,
+  probe_passed = true,
+  probe_checked,
+  completion_origin = "inferred",
+  reclaimed_bg_job_id = null,
+  stopped_bg_job_ids = [],
+  title,
+  body,
+}) {
   return appendEnvelopeBestEffort(
     buildEventEnvelope({
       phase,
@@ -238,6 +259,17 @@ function defaultAppendReclaimEvent({ phase, ticket, orchId }) {
       orchId,
       action: "reclaim",
       reason: "work-done-despite-dead-bg",
+      payloadExtras: {
+        death_signal,
+        prev_state_json_mtime,
+        probe_passed,
+        probe_checked,
+        completion_origin,
+        reclaimed_bg_job_id,
+        stopped_bg_job_ids,
+        title,
+        body,
+      },
     }),
     "reclaim",
   );
@@ -1034,7 +1066,28 @@ export function reclaimDeadWorkIfPossible(
         reason: "ctl-661-reclaim-happy-path",
       }).catch(() => {});
     }
-    appendEvent({ phase, ticket, orchId });
+    // CTL-664: derive the reclaim observability fields from values already
+    // computed above. `death_signal` distinguishes an absent bg job (klass
+    // 'dead') from a running-but-stale one (mtime); kept as a single const so
+    // Phase 3's mirror body reuses it without recomputation.
+    const death_signal = klass === "dead" ? "absent" : "mtime";
+    const probe_checked = describeProbe(phase);
+    appendEvent({
+      phase,
+      ticket,
+      orchId,
+      death_signal,
+      prev_state_json_mtime: prevStateJsonMtime,
+      probe_passed: true,
+      probe_checked,
+      completion_origin: "inferred",
+      reclaimed_bg_job_id: prevBgJobId,
+      // CTL-661 sources the reaped session via the reap-intent emitted above;
+      // record it here so the reclaim event mirrors the stopped set.
+      stopped_bg_job_ids: prevBgJobId ? [prevBgJobId] : [],
+      title: `phase ${phase} reclaimed (work-done-despite-dead-bg)`,
+      body: `Daemon reclaimed dead ${phase} worker for ${ticket}: ${death_signal} death signal, probe verified ${probe_checked}. bg_job_id=${prevBgJobId ?? "?"}.`,
+    });
     const r = emitComplete({ orchDir, signal });
     if (r.code !== 0) {
       log.warn(

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -19,6 +19,7 @@ import {
   defaultKillBgJob,
   defaultPidAlive,
   defaultAppendReviveEvent,
+  defaultAppendReclaimEvent,
   defaultAppendDispatchRequestedEvent,
   defaultAppendDispatchLaunchedEvent,
   readBootEpoch,
@@ -643,14 +644,40 @@ describe("reclaimDeadWorkIfPossible", () => {
     // order: append first, then emit.
     expect(order[0][0]).toBe("append");
     expect(order[1][0]).toBe("emit");
-    // append-event payload mentions the phase + ticket + orch id.
-    expect(order[0][1]).toEqual({
+    // append-event payload includes the phase + ticket + orch id (CTL-574) PLUS
+    // the CTL-664 enrichment.
+    expect(order[0][1]).toMatchObject({
       phase: "implement",
       ticket: "CTL-9",
       orchId: "CTL-9",
+      death_signal: "absent", // statJob:()=>null → klass 'dead' → absent
+      probe_passed: true,
+      probe_checked: expect.any(String),
+      completion_origin: "inferred",
+      reclaimed_bg_job_id: "job-x", // implementSignal default bgJobId
     });
+    expect(order[0][1].stopped_bg_job_ids).toEqual([]); // CTL-661 placeholder
     // emit-complete receives the orchDir and the signal.
     expect(order[1][1]).toEqual({ orchDir: orch, signal: sig });
+  });
+
+  test("CTL-664: reclaim of an mtime-stale worker reports death_signal='mtime' + prev_state_json_mtime", () => {
+    const staleMtime = 1_000;
+    let appended = null;
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), {
+      statJob: () => ({ mtimeMs: staleMtime }), // exists but stale
+      now: () => staleMtime + 10 * 60_000, // > STALE_MS
+      probes: { implement: () => true },
+      emitComplete: () => ({ code: 0 }),
+      appendEvent: (args) => {
+        appended = args;
+      },
+      postReclaimMirror: () => {}, // stubbed (Phase 3 seam)
+      repoRoot: "/repo",
+    });
+    expect(r).toBe("reclaimed");
+    expect(appended.death_signal).toBe("mtime");
+    expect(appended.prev_state_json_mtime).toBe(staleMtime);
   });
 
   test("'reclaim-failed' when emit-complete returns non-zero (event still appended)", () => {
@@ -2005,6 +2032,66 @@ describe("dispatch lifecycle event envelopes (CTL-660)", () => {
         worktree_path: "/x",
       }),
     ).toBe(false);
+  });
+});
+
+// CTL-664: enriched reclaim event envelope round-trip. Mirror the CTL-660
+// dispatch round-trip: point CATALYST_DIR at a temp dir, call the helper, read
+// back the JSONL line, and assert the enriched payload fields the HUD DETAILS
+// fallback (title/body) and the audit consumers (completion_origin etc.) read.
+describe("reclaim event envelope round-trip (CTL-664)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl664-reclaim-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  function readBackEnvelope() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    return JSON.parse(lines[lines.length - 1]);
+  }
+
+  test("defaultAppendReclaimEvent writes the enriched payload + HUD title/body", () => {
+    const ok = defaultAppendReclaimEvent({
+      phase: "implement",
+      ticket: "CTL-RC-1",
+      orchId: "orch-rc",
+      death_signal: "absent",
+      prev_state_json_mtime: null,
+      probe_passed: true,
+      probe_checked: "commits ahead of origin/main + clean worktree",
+      completion_origin: "inferred",
+      reclaimed_bg_job_id: "bg-rc",
+      stopped_bg_job_ids: [],
+      title: "phase implement reclaimed (work-done-despite-dead-bg)",
+      body: "Daemon reclaimed dead implement worker for CTL-RC-1.",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.implement.reclaim.CTL-RC-1");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.body.payload.status).toBe("reclaim");
+    expect(env.body.payload.reason).toBe("work-done-despite-dead-bg");
+    expect(env.body.payload.completion_origin).toBe("inferred");
+    expect(env.body.payload.death_signal).toBe("absent");
+    expect(env.body.payload.probe_passed).toBe(true);
+    expect(env.body.payload.reclaimed_bg_job_id).toBe("bg-rc");
+    expect(env.body.payload.stopped_bg_job_ids).toEqual([]);
+    expect(env.body.payload.title).toContain("reclaimed");
+    expect(typeof env.body.payload.body).toBe("string");
+    expect(env.attributes["catalyst.orchestration"]).toBe("orch-rc");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -20,6 +20,7 @@ import {
   defaultPidAlive,
   defaultAppendReviveEvent,
   defaultAppendReclaimEvent,
+  defaultPostReclaimMirror,
   defaultAppendDispatchRequestedEvent,
   defaultAppendDispatchLaunchedEvent,
   readBootEpoch,
@@ -516,6 +517,7 @@ describe("reclaimDeadWorkIfPossible", () => {
       probes: { implement: probe },
       emitComplete: emit,
       appendEvent,
+      postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
       now: () => 1_000 + 6 * 60 * 1000, // 6 minutes past mtime — stale
     });
     expect(r).toBe("reclaimed");
@@ -545,6 +547,7 @@ describe("reclaimDeadWorkIfPossible", () => {
       probes: { implement: () => true },
       emitComplete: () => ({ code: 0 }),
       appendEvent: () => {},
+      postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
       now: () => 100 + 60_000,
       staleMs: 30_000, // 30s threshold — 1 min IS stale
     });
@@ -638,6 +641,7 @@ describe("reclaimDeadWorkIfPossible", () => {
       probes: { implement: () => true }, // work done
       emitComplete: emit,
       appendEvent,
+      postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
       repoRoot: "/repo",
     });
     expect(r).toBe("reclaimed");
@@ -705,6 +709,7 @@ describe("reclaimDeadWorkIfPossible", () => {
       probes: { implement: probe },
       emitComplete: () => ({ code: 0 }),
       appendEvent: () => {},
+      postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
       repoRoot: "/repo/x",
     });
     // orchDir is the function's first positional arg (`orch` === "/orch").
@@ -726,6 +731,7 @@ describe("reclaimDeadWorkIfPossible", () => {
       probes: { verify: () => true }, // artifact complete
       emitComplete: emit,
       appendEvent: recorder(undefined),
+      postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
       repoRoot: "/repo",
     });
     expect(r).toBe("reclaimed");
@@ -833,6 +839,125 @@ describe("reclaimDeadWorkIfPossible — CTL-661 reclaim happy-path reap-intent",
   });
 });
 
+// --- CTL-664: reclaim Linear mirror -----------------------------------------
+//
+// On the successful reclaim path (branch B) the daemon posts the "Phase Reclaim"
+// Linear comment the dead worker's skill End block never ran. The seam is
+// marker-guarded (first-writer-wins vs a surviving skill mirror) and fail-open.
+describe("CTL-664: reclaim Linear mirror", () => {
+  const orch = "/orch";
+
+  test("postReclaimMirror is called once on a successful reclaim, after emit-complete", () => {
+    const order = [];
+    reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => null,
+      probes: { implement: () => true },
+      emitComplete: () => {
+        order.push("emit");
+        return { code: 0 };
+      },
+      appendEvent: () => order.push("append"),
+      postReclaimMirror: (args) => order.push(["mirror", args]),
+      repoRoot: "/repo",
+    });
+    expect(order).toEqual([
+      "append",
+      "emit",
+      [
+        "mirror",
+        expect.objectContaining({
+          orchDir: orch,
+          ticket: "CTL-9",
+          phase: "implement",
+          deathSignal: "absent", // statJob:()=>null → klass 'dead' → absent
+          reclaimedBgJobId: "job-x", // implementSignal default bgJobId
+        }),
+      ],
+    ]);
+  });
+
+  test("postReclaimMirror is NOT called when emit-complete fails (reclaim-failed)", () => {
+    const mirror = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
+      statJob: () => null,
+      probes: { implement: () => true },
+      emitComplete: () => ({ code: 1, stderr: "boom" }),
+      appendEvent: () => {},
+      postReclaimMirror: mirror,
+    });
+    expect(r).toBe("reclaim-failed");
+    expect(mirror.calls.length).toBe(0);
+  });
+});
+
+// defaultPostReclaimMirror — driven through its injected existsSync / writeMarker
+// / runLinearis seams (no filesystem or `linearis` spawn in the test).
+describe("defaultPostReclaimMirror (CTL-664)", () => {
+  const base = {
+    orchDir: "/orch",
+    ticket: "CTL-9",
+    phase: "implement",
+    deathSignal: "absent",
+    probeChecked: "commits ahead of origin/main",
+    reclaimedBgJobId: "job-x",
+  };
+
+  test("marker absent → posts the comment and writes the marker", () => {
+    const written = [];
+    const linearis = recorder({ status: 0 });
+    defaultPostReclaimMirror(base, {
+      existsSync: () => false,
+      writeMarker: (p) => written.push(p),
+      runLinearis: linearis,
+    });
+    expect(linearis.calls.length).toBe(1);
+    const [t, body] = linearis.calls[0];
+    expect(t).toBe("CTL-9");
+    expect(body).toContain("**Phase Reclaim**");
+    expect(body).toContain("work-done-despite-dead-bg");
+    expect(body).toContain("absent");
+    expect(written).toEqual(["/orch/workers/CTL-9/.linear-mirror-implement"]);
+  });
+
+  test("marker present → skips the post (first-writer-wins)", () => {
+    const linearis = recorder({ status: 0 });
+    const written = [];
+    defaultPostReclaimMirror(base, {
+      existsSync: () => true,
+      writeMarker: (p) => written.push(p),
+      runLinearis: linearis,
+    });
+    expect(linearis.calls.length).toBe(0);
+    expect(written.length).toBe(0);
+  });
+
+  test("linearis non-zero → no marker written, no throw (fail-open)", () => {
+    const written = [];
+    expect(() =>
+      defaultPostReclaimMirror(base, {
+        existsSync: () => false,
+        writeMarker: (p) => written.push(p),
+        runLinearis: () => ({ status: 1, stderr: "offline" }),
+      }),
+    ).not.toThrow();
+    expect(written.length).toBe(0);
+  });
+
+  test("runLinearis throws → swallowed, no marker, no throw (fail-open)", () => {
+    const written = [];
+    expect(() =>
+      defaultPostReclaimMirror(base, {
+        existsSync: () => false,
+        writeMarker: (p) => written.push(p),
+        runLinearis: () => {
+          throw new Error("spawn EACCES");
+        },
+      }),
+    ).not.toThrow();
+    expect(written.length).toBe(0);
+  });
+});
+
 // --- CTL-587: revive / revive-suppressed / escalated branches ---------------
 //
 // The pre-CTL-587 'not-applicable' and 'not-done' returns were silent dead-ends.
@@ -885,6 +1010,9 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
         countReviveEvents: recorder(reviveCount),
         countDistinctRevivingTickets: recorder(distinctRevivingTickets),
         writeReviveMarker: recorder(undefined),
+        // CTL-664: stub the reclaim mirror so the probeResult:true scenarios
+        // (branch B) stay hermetic and don't spawn a real `linearis`.
+        postReclaimMirror: recorder(undefined),
         readBootSince, // CTL-655: inject the boot-time window reader
         now: () => nowMs,
         staleMs: 5 * 60 * 1000,
@@ -1208,6 +1336,9 @@ describe("reclaimDeadWorkIfPossible — CTL-610 alive-quiet keep-alive guard", (
         countReviveEvents: recorder(reviveCount),
         countDistinctRevivingTickets: recorder(1),
         writeReviveMarker: recorder(undefined),
+        // CTL-664: stub the reclaim mirror so the probeResult:true scenario
+        // (branch B wins over alive-quiet) stays hermetic (no `linearis` spawn).
+        postReclaimMirror: recorder(undefined),
         pidAlive: recorder(pidAlive()),
         hungCutoffMs,
         now: () => nowMs,
@@ -2275,6 +2406,7 @@ describe("reclaimDeadWorkIfPossible — CTL-606 supersede guard", () => {
       probes: { implement: recorder(true) }, // work done → 'reclaimed'
       emitComplete: recorder({ code: 0 }),
       appendEvent: recorder(undefined),
+      postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
     });
     expect(r).toBe("reclaimed");
   });

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -330,3 +330,29 @@ export const WORK_DONE_PROBES = {
 export function hasProbe(phase) {
   return Object.prototype.hasOwnProperty.call(WORK_DONE_PROBES, phase);
 }
+
+// CTL-664: human-readable description of what each work-done probe verifies.
+// Co-located with WORK_DONE_PROBES so adding a probe and describing it stay in
+// one place (the first probe-descriptions test enforces a description for every
+// registered probe). Surfaced in the enriched phase.*.reclaim payload
+// (probe_checked) so an operator reading the event/HUD knows what evidence the
+// daemon used to declare the dead worker's work complete.
+export const WORK_DONE_PROBE_DESCRIPTIONS = {
+  implement: "commits ahead of origin/main + clean worktree",
+  remediate: "commits ahead of origin/main + clean worktree",
+  research: "≥200-byte research md naming the ticket with ## Summary / ## Code References",
+  plan: "≥200-byte plan with ## Phase and Success Criteria",
+  triage: "triage.json with a non-empty classification",
+  verify: "verify.json with findings[], regression_risk, tests_attempted, gates, generatedAt",
+  review: "review.json with findings[], reviewPassed, remediationCommit, generatedAt",
+  pr: "GitHub PR state=open or merged=true",
+  "monitor-merge": "GitHub PR merged=true",
+  "monitor-deploy": "phase-monitor-deploy.json with deploy_state in {success,skipped}",
+};
+
+// describeProbe — the probe-checked string for the enriched reclaim payload.
+// Falls back to "unknown" for an unregistered phase (branch (A) territory, where
+// a dead worker has no probe and is escalated rather than reclaimed).
+export function describeProbe(phase) {
+  return WORK_DONE_PROBE_DESCRIPTIONS[phase] ?? "unknown";
+}

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -9,6 +9,8 @@ import {
   resolveWorktree,
   defaultReadFile,
   readVerifyVerdict,
+  describeProbe,
+  WORK_DONE_PROBE_DESCRIPTIONS,
 } from "./work-done-probes.mjs";
 
 // makeRunGit — a deterministic `git` fake keyed on the trailing positional args.
@@ -724,5 +726,23 @@ describe("WORK_DONE_PROBES['monitor-merge']", () => {
   test("false when no PR number anywhere / gh fails", () => {
     expect(WORK_DONE_PROBES["monitor-merge"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile: makeReadFile({}), runGh: () => { throw new Error("no"); } })).toBe(false);
     expect(WORK_DONE_PROBES["monitor-merge"]({ ticket: "CTL-1", orchDir: ORCH }, { readFile, runGh: makeRunGh({}) })).toBe(false);
+  });
+});
+
+describe("CTL-664: probe descriptions", () => {
+  test("every registered probe has a non-empty description", () => {
+    for (const phase of Object.keys(WORK_DONE_PROBES)) {
+      expect(typeof WORK_DONE_PROBE_DESCRIPTIONS[phase]).toBe("string");
+      expect(WORK_DONE_PROBE_DESCRIPTIONS[phase].length).toBeGreaterThan(0);
+    }
+  });
+
+  test("describeProbe returns the registered description for a known phase", () => {
+    expect(describeProbe("implement")).toBe(WORK_DONE_PROBE_DESCRIPTIONS.implement);
+    expect(describeProbe("plan")).toContain("Phase"); // plan probe checks for ## Phase + Success Criteria
+  });
+
+  test("describeProbe returns a safe fallback for an unknown phase", () => {
+    expect(describeProbe("nonexistent")).toBe("unknown");
   });
 });


### PR DESCRIPTION
## Summary

Makes the execution-core daemon recovery path observable and self-mirroring when it reclaims a phase whose `--bg` worker died after committing its work. Previously the daemon's `reclaim-dead-work` path advanced the pipeline silently: the dead worker's skill End block never ran, so no "Phase Reclaim" comment reached Linear, and the emitted `phase.*.reclaim` event carried no detail about why the worker was declared dead or what the probe checked.

## Changes

- **Reclaim Linear mirror** (`defaultPostReclaimMirror` in `recovery.mjs`): on the successful reclaim path (branch B, after `emitComplete` returns code 0), the daemon posts the "Phase Reclaim" comment the dead worker's skill End block never got to run. Marker-guarded (first-writer-wins versus a surviving skill mirror via `.linear-mirror-<phase>`) and fail-open (a `linearis` non-zero exit or thrown spawn is swallowed, no marker written, no throw).
- **Enriched `phase.*.reclaim` event payload**: the reclaim `appendEvent` now carries `death_signal` (`absent` for a missing bg job vs `mtime` for a stale-but-present one), `prev_state_json_mtime`, `probe_passed`, `probe_checked`, `completion_origin`, and `reclaimed_bg_job_id`, plus a human-readable title/body.
- **Probe descriptions** (`work-done-probes.mjs`): `describeProbe(phase)` exposes a human-readable description of what each phase's work-done probe checks, surfaced in the reclaim event and the Linear mirror.

## Testing

- `recovery.test.mjs` — 143 pass (reclaim mirror call order, fail-open paths, marker guard, enriched payload fields).
- `work-done-probes.test.mjs` — 69 pass.

## Notes

Rebased onto current `origin/main` (which included CTL-661's reclaim reap-intent). The reclaim happy path now runs: reap-intent emit (CTL-661) → enriched `appendEvent` (CTL-664) → `emitComplete` → `postReclaimMirror` (CTL-664). `stopped_bg_job_ids` is left as the CTL-661-owned placeholder per its existing contract.

Refs: CTL-664
