### PR TITLE
CTL-668: extend Linear phase comment trail to PR/monitor/deploy + run-metadata footer

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -540,6 +540,18 @@ if grep -qE 'feat: (first|second) commit' "$LOG_A" 2>/dev/null; then
 else
   fail "mirror-implement happy: commit subjects" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
 fi
+# CTL-632 follow-on: file/line breakdown (fixture adds a.txt + b.txt = 2 files
+# added, 1 line each = +2 / -0).
+if grep -qE 'Files.*2 added, 0 modified, 0 deleted' "$LOG_A" 2>/dev/null; then
+  pass "mirror-implement happy: renders files added/modified/deleted breakdown"
+else
+  fail "mirror-implement happy: files breakdown" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
+if grep -qE 'Lines.*\+2 / -0' "$LOG_A" 2>/dev/null; then
+  pass "mirror-implement happy: renders lines added/deleted"
+else
+  fail "mirror-implement happy: lines added/deleted" "log:$(printf '\n%s' "$(cat "$LOG_A" 2>/dev/null)")"
+fi
 if grep -qE '(Branch|feature)' "$LOG_A" 2>/dev/null; then
   pass "mirror-implement happy: body contains branch name"
 else
@@ -739,6 +751,269 @@ if grep -q 'could not resolve integration base' "$CASE_G/stderr.log" 2>/dev/null
 else
   fail "gate base-unknown: warning" "stderr:$(printf '\n%s' "$(cat "$CASE_G/stderr.log" 2>/dev/null)")"
 fi
+
+# ─── Test 15 (CTL-632): phase-pr + phase-monitor-merge mirror blocks present ──
+echo ""
+echo "Test 15 (CTL-632): phase-pr + phase-monitor-merge contract — mirror blocks present"
+if [[ -f "$SKILL_PR" ]]; then
+  assert_grep 'phase-pr-mirror' "$SKILL_PR" "phase-pr: body contains uniquely-named mirror fence"
+  assert_grep '\.linear-mirror-' "$SKILL_PR" "phase-pr: references the per-phase marker file"
+  assert_grep 'linearis issues discuss' "$SKILL_PR" "phase-pr: calls linearis issues discuss"
+  assert_grep 'phase-pr: linearis discuss failed \(continuing\)' "$SKILL_PR" "phase-pr: fail-open warning string"
+  assert_grep 'verify\.json' "$SKILL_PR" "phase-pr: surfaces verify.json pre-merge verification"
+fi
+if [[ -f "$SKILL_MONITOR_MERGE" ]]; then
+  assert_grep 'phase-monitor-merge-mirror' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: body contains uniquely-named mirror fence"
+  assert_grep '\.linear-mirror-' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: references the per-phase marker file"
+  assert_grep 'linearis issues discuss' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: calls linearis issues discuss"
+  assert_grep 'phase-monitor-merge: linearis discuss failed \(continuing\)' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: fail-open warning string"
+  assert_grep 'statusCheckRollup' "$SKILL_MONITOR_MERGE" "phase-monitor-merge: summarizes CI check rollup"
+fi
+
+# ─── Test 16 (CTL-632): phase-pr mirror runtime — happy/fail-open/idempotent ──
+echo ""
+echo "Test 16 (CTL-632): phase-pr mirror — happy / fail-open / idempotent (with gh stub)"
+
+PR_MIRROR_FILE="${SCRATCH}/pr-mirror-body.sh"
+awk '
+  /^```bash phase-pr-mirror$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL_PR" > "$PR_MIRROR_FILE"
+if [[ -s "$PR_MIRROR_FILE" ]]; then
+  pass "phase-pr mirror block extractable from SKILL.md"
+else
+  fail "phase-pr mirror block extractable — no \`\`\`bash phase-pr-mirror\`\`\` fence found"
+fi
+
+# gh stub: `gh pr view <n> --json ...` returns canned PR metadata.
+install_gh_stub() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "${bin_dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+# Minimal gh stub for phase mirror e2e: supports `gh pr view <n> --json ...`.
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  cat <<'JSON'
+{
+  "title": "CTL-449: do the thing",
+  "url": "https://github.com/acme/repo/pull/42",
+  "files": [{"path":"a.ts"},{"path":"b.ts"},{"path":"c.ts"}],
+  "additions": 120,
+  "deletions": 7,
+  "commits": [{"oid":"1"},{"oid":"2"}],
+  "baseRefName": "main",
+  "createdAt": "2026-05-27T10:00:00Z",
+  "statusCheckRollup": [
+    {"__typename":"CheckRun","conclusion":"SUCCESS"},
+    {"__typename":"CheckRun","conclusion":"SUCCESS"},
+    {"__typename":"StatusContext","state":"SUCCESS"}
+  ],
+  "reviews": [
+    {"author":{"login":"chatgpt-codex-connector"},"state":"COMMENTED"},
+    {"author":{"login":"ryan"},"state":"APPROVED"}
+  ]
+}
+JSON
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "${bin_dir}/gh"
+}
+
+# Writes the phase-pr signal file (with .pr) + optional verify.json into a worker dir.
+seed_pr_worker() {
+  local worker_dir="$1" with_verify="${2:-yes}"
+  mkdir -p "$worker_dir"
+  cat > "${worker_dir}/phase-pr.json" <<'JSON'
+{"status":"running","ticket":"CTL-449","phase":"pr","pr":{"number":42,"url":"https://github.com/acme/repo/pull/42"}}
+JSON
+  if [[ "$with_verify" == "yes" ]]; then
+    cat > "${worker_dir}/verify.json" <<'JSON'
+{"regression_risk":3,"tests_attempted":5,"gates":{"tests":{"status":"pass","summary":"192 passed / 0 failed"},"typecheck":{"status":"pass","summary":"tsc clean"},"lint":{"status":"pass"}},"findings":[]}
+JSON
+  fi
+}
+
+run_pr_mirror() {
+  local case_name="$1" stub_kind="$2" preseed_marker="${3:-}" with_verify="${4:-yes}"
+  local case_dir="${SCRATCH}/pr-mirror-${case_name}"
+  local worker_dir="${case_dir}/orch/workers/CTL-449"
+  mkdir -p "$case_dir/bin"
+  seed_pr_worker "$worker_dir" "$with_verify"
+  install_gh_stub "$case_dir/bin"
+  if [[ "$stub_kind" == "ok" ]]; then
+    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+  else
+    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+  fi
+  [[ -n "$preseed_marker" ]] && : > "$worker_dir/.linear-mirror-pr"
+  (
+    PATH="$case_dir/bin:$PATH" \
+      ORCH_DIR="${case_dir}/orch" \
+      TICKET="CTL-449" \
+      PHASE="pr" \
+      bash "$PR_MIRROR_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+    echo "$?" > "$case_dir/exit-code"
+  )
+  echo "$case_dir"
+}
+
+# Case PR-A: happy — gh returns PR metadata, verify.json present.
+CASE_PRA="$(run_pr_mirror happy ok '' yes)"
+assert_eq "0" "$(cat "$CASE_PRA/exit-code")" "mirror-pr happy: exit 0"
+LOG_PRA="$CASE_PRA/linearis-calls.log"
+assert_grep '^discuss$' "$LOG_PRA" "mirror-pr happy: discuss landed"
+assert_grep 'Phase PR' "$LOG_PRA" "mirror-pr happy: body has 'Phase PR' header"
+assert_grep 'Files changed.*3' "$LOG_PRA" "mirror-pr happy: renders changed-file count"
+assert_grep 'Regression risk.*3' "$LOG_PRA" "mirror-pr happy: surfaces verify.json regression risk"
+[[ -e "$CASE_PRA/orch/workers/CTL-449/.linear-mirror-pr" ]] && pass "mirror-pr happy: marker written" || fail "mirror-pr happy: marker missing"
+
+# Case PR-B: fail-open — linearis discuss fails, no marker, warning on stderr.
+CASE_PRB="$(run_pr_mirror failopen fail '' yes)"
+assert_eq "0" "$(cat "$CASE_PRB/exit-code")" "mirror-pr fail-open: exit 0"
+[[ ! -e "$CASE_PRB/orch/workers/CTL-449/.linear-mirror-pr" ]] && pass "mirror-pr fail-open: no marker" || fail "mirror-pr fail-open: marker should not exist"
+assert_grep 'phase-pr: linearis discuss failed \(continuing\)' "$CASE_PRB/stderr.log" "mirror-pr fail-open: warning to stderr"
+
+# Case PR-C: idempotent — marker preseeded, discuss skipped.
+CASE_PRC="$(run_pr_mirror idempot ok seed yes)"
+assert_eq "0" "$(cat "$CASE_PRC/exit-code")" "mirror-pr idempotent: exit 0"
+if [[ ! -f "$CASE_PRC/linearis-calls.log" ]] || ! grep -q '^discuss$' "$CASE_PRC/linearis-calls.log" 2>/dev/null; then
+  pass "mirror-pr idempotent: discuss skipped"
+else
+  fail "mirror-pr idempotent: discuss should have been skipped (marker not honored)"
+fi
+
+# Case PR-D: no verify.json — still posts, renders the fail-soft fallback line.
+CASE_PRD="$(run_pr_mirror noverify ok '' no)"
+assert_eq "0" "$(cat "$CASE_PRD/exit-code")" "mirror-pr no-verify: exit 0"
+assert_grep '^discuss$' "$CASE_PRD/linearis-calls.log" "mirror-pr no-verify: still posts"
+assert_grep 'no verify.json found' "$CASE_PRD/linearis-calls.log" "mirror-pr no-verify: renders fallback line"
+
+# ─── Test 17 (CTL-632): phase-monitor-merge mirror runtime ────────────────────
+echo ""
+echo "Test 17 (CTL-632): phase-monitor-merge mirror — happy / fail-open / idempotent"
+
+MM_MIRROR_FILE="${SCRATCH}/mm-mirror-body.sh"
+awk '
+  /^```bash phase-monitor-merge-mirror$/ {capture=1; next}
+  /^```$/ {if (capture) {capture=0}}
+  capture { print }
+' "$SKILL_MONITOR_MERGE" > "$MM_MIRROR_FILE"
+if [[ -s "$MM_MIRROR_FILE" ]]; then
+  pass "phase-monitor-merge mirror block extractable from SKILL.md"
+else
+  fail "phase-monitor-merge mirror block extractable — no \`\`\`bash phase-monitor-merge-mirror\`\`\` fence found"
+fi
+
+seed_mm_worker() {
+  local worker_dir="$1"
+  mkdir -p "$worker_dir"
+  cat > "${worker_dir}/phase-monitor-merge.json" <<'JSON'
+{"status":"running","ticket":"CTL-449","phase":"monitor-merge","pr":{"number":42,"mergeCommitSha":"deadbeef1234","mergedAt":"2026-05-27T12:00:00Z","ciStatus":"merged"}}
+JSON
+}
+
+run_mm_mirror() {
+  local case_name="$1" stub_kind="$2" preseed_marker="${3:-}"
+  local case_dir="${SCRATCH}/mm-mirror-${case_name}"
+  local worker_dir="${case_dir}/orch/workers/CTL-449"
+  mkdir -p "$case_dir/bin"
+  seed_mm_worker "$worker_dir"
+  install_gh_stub "$case_dir/bin"
+  if [[ "$stub_kind" == "ok" ]]; then
+    linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+  else
+    linearis_stub_install_failing "$case_dir/bin" "$case_dir/linearis-calls.log"
+  fi
+  [[ -n "$preseed_marker" ]] && : > "$worker_dir/.linear-mirror-monitor-merge"
+  (
+    PATH="$case_dir/bin:$PATH" \
+      ORCH_DIR="${case_dir}/orch" \
+      TICKET="CTL-449" \
+      PHASE="monitor-merge" \
+      bash "$MM_MIRROR_FILE" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
+    echo "$?" > "$case_dir/exit-code"
+  )
+  echo "$case_dir"
+}
+
+# Case MM-A: happy — gh returns CI rollup (3 SUCCESS) + 1 bot review.
+CASE_MMA="$(run_mm_mirror happy ok '')"
+assert_eq "0" "$(cat "$CASE_MMA/exit-code")" "mirror-monitor-merge happy: exit 0"
+LOG_MMA="$CASE_MMA/linearis-calls.log"
+assert_grep '^discuss$' "$LOG_MMA" "mirror-monitor-merge happy: discuss landed"
+assert_grep 'Phase Monitor-Merge' "$LOG_MMA" "mirror-monitor-merge happy: body has header"
+assert_grep '3/3 checks passed' "$LOG_MMA" "mirror-monitor-merge happy: renders CI rollup"
+assert_grep 'deadbeef1234' "$LOG_MMA" "mirror-monitor-merge happy: renders merge commit SHA"
+assert_grep 'Time to merge.*2h 0m' "$LOG_MMA" "mirror-monitor-merge happy: computes time-to-merge (10:00→12:00 = 2h)"
+assert_grep 'Bot reviews handled.*1' "$LOG_MMA" "mirror-monitor-merge happy: counts bot (Codex) reviews"
+[[ -e "$CASE_MMA/orch/workers/CTL-449/.linear-mirror-monitor-merge" ]] && pass "mirror-monitor-merge happy: marker written" || fail "mirror-monitor-merge happy: marker missing"
+
+# Case MM-B: fail-open.
+CASE_MMB="$(run_mm_mirror failopen fail '')"
+assert_eq "0" "$(cat "$CASE_MMB/exit-code")" "mirror-monitor-merge fail-open: exit 0"
+[[ ! -e "$CASE_MMB/orch/workers/CTL-449/.linear-mirror-monitor-merge" ]] && pass "mirror-monitor-merge fail-open: no marker" || fail "mirror-monitor-merge fail-open: marker should not exist"
+assert_grep 'phase-monitor-merge: linearis discuss failed \(continuing\)' "$CASE_MMB/stderr.log" "mirror-monitor-merge fail-open: warning to stderr"
+
+# Case MM-C: idempotent.
+CASE_MMC="$(run_mm_mirror idempot ok seed)"
+assert_eq "0" "$(cat "$CASE_MMC/exit-code")" "mirror-monitor-merge idempotent: exit 0"
+if [[ ! -f "$CASE_MMC/linearis-calls.log" ]] || ! grep -q '^discuss$' "$CASE_MMC/linearis-calls.log" 2>/dev/null; then
+  pass "mirror-monitor-merge idempotent: discuss skipped"
+else
+  fail "mirror-monitor-merge idempotent: discuss should have been skipped (marker not honored)"
+fi
+
+# ─── Test 18 (CTL-632 footer): mirror appends the metadata footer ─────────────
+echo ""
+echo "Test 18 (CTL-632 footer): implement mirror appends footer when PLUGIN_ROOT + bg fixture present"
+# Structural: every phase mirror skill wires the shared footer helper.
+for skill in "$SKILL_IMPLEMENT" "$SKILL_PR" "$SKILL_MONITOR_MERGE"; do
+  assert_grep 'phase-mirror-footer\.sh' "$skill" "$(basename "$(dirname "$skill")"): wires phase-mirror-footer.sh"
+done
+
+# Runtime: run the extracted implement mirror block with PLUGIN_ROOT pointed at
+# the real plugin + a bg-job fixture, and confirm the footer lands in the body.
+FOOT_DIR="${SCRATCH}/imp-mirror-footer"
+FOOT_WORKER="${FOOT_DIR}/orch/workers/CTL-449"
+FOOT_REPO="${FOOT_DIR}/repo"
+FOOT_JOBS="${FOOT_DIR}/jobs"
+mkdir -p "$FOOT_DIR/bin" "$FOOT_WORKER" "${FOOT_JOBS}/abcd1234"
+build_git_fixture "$FOOT_REPO" yes
+linearis_stub_install "$FOOT_DIR/bin" "$FOOT_DIR/linearis-calls.log"
+cat > "${FOOT_WORKER}/phase-implement.json" <<'JSON'
+{"status":"running","ticket":"CTL-449","phase":"implement","bg_job_id":"abcd1234","catalystSessionId":"sess_FOOTERTEST","model":"opus"}
+JSON
+cat > "${FOOT_DIR}/conv.jsonl" <<'JSONL'
+{"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"tool_use","name":"Task","input":{}}]}}
+{"type":"system","subtype":"turn_duration","durationMs":125000}
+{"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"text","text":"done"}]}}
+JSONL
+cat > "${FOOT_JOBS}/abcd1234/state.json" <<JSON
+{"sessionId":"abcd1234-aaaa-bbbb-cccc-000011112222","cwd":"/tmp/wt/CTL-449","linkScanPath":"${FOOT_DIR}/conv.jsonl"}
+JSON
+(
+  cd "$FOOT_REPO" || exit 1
+  env -u CLAUDE_CODE_SESSION_ID -u CATALYST_SESSION_ID \
+    PATH="$FOOT_DIR/bin:$PATH" \
+    ORCH_DIR="${FOOT_DIR}/orch" \
+    TICKET="CTL-449" \
+    PHASE="implement" \
+    PLUGIN_ROOT="${REPO_ROOT}/plugins/dev" \
+    CATALYST_BG_JOBS_DIR="${FOOT_JOBS}" \
+    bash "$MIRROR_BODY_FILE" >"$FOOT_DIR/stdout.log" 2>"$FOOT_DIR/stderr.log"
+  echo "$?" > "$FOOT_DIR/exit-code"
+)
+assert_eq "0" "$(cat "$FOOT_DIR/exit-code")" "mirror-footer: exit 0"
+LOG_FOOT="$FOOT_DIR/linearis-calls.log"
+assert_grep '^---$' "$LOG_FOOT" "mirror-footer: footer separator present in body"
+assert_grep 'model `claude-opus-4-7`' "$LOG_FOOT" "mirror-footer: footer renders model from JSONL"
+assert_grep '1 sub-agent\(s\) launched' "$LOG_FOOT" "mirror-footer: footer counts sub-agents"
+assert_grep 'active 2m 5s' "$LOG_FOOT" "mirror-footer: footer renders active working duration"
+assert_grep 'catalyst session `sess_FOOTERTEST`' "$LOG_FOOT" "mirror-footer: footer renders catalyst session id"
+assert_grep 'session uuid `abcd1234-aaaa-bbbb-cccc-000011112222`' "$LOG_FOOT" "mirror-footer: footer renders long session uuid"
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-mirror-footer.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-mirror-footer.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Unit tests for plugins/dev/scripts/lib/phase-mirror-footer.sh (CTL-632 footer).
+#
+# The footer is appended verbatim into every phase-agent Linear mirror comment,
+# so the contract is: ALWAYS exit 0, ALWAYS print a `---` + at least one line,
+# and resolve each field (model, sub-agent count, active working duration,
+# catalyst session id, short job id, long session uuid, cwd) independently and
+# fail-soft from the signal file + bg job state.json + conversation JSONL.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-mirror-footer.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+FOOTER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-mirror-footer.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-mirror-footer-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+assert_grep() {
+  local pattern="$1" str="$2" label="$3"
+  if grep -qE -- "$pattern" <<<"$str"; then pass "$label"; else fail "$label — '$pattern' not in:
+$str"; fi
+}
+assert_not_grep() {
+  local pattern="$1" str="$2" label="$3"
+  if grep -qE -- "$pattern" <<<"$str"; then fail "$label — '$pattern' unexpectedly present"; else pass "$label"; fi
+}
+
+# Build a worker dir (signal) + bg jobs dir (state.json) + conversation JSONL.
+build_fixture() {
+  local case_dir="$1" with_bg="${2:-yes}" with_jsonl="${3:-yes}"
+  local worker_dir="${case_dir}/orch/workers/CTL-449"
+  local jobs_dir="${case_dir}/jobs"
+  mkdir -p "$worker_dir" "$jobs_dir"
+
+  cat > "${worker_dir}/phase-implement.json" <<'JSON'
+{"status":"running","ticket":"CTL-449","phase":"implement","bg_job_id":"abcd1234","catalystSessionId":"sess_TESTSESSION","model":"opus"}
+JSON
+
+  if [[ "$with_jsonl" == "yes" ]]; then
+    cat > "${case_dir}/conv.jsonl" <<'JSONL'
+{"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"tool_use","name":"Task","input":{}}]}}
+{"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"tool_use","name":"Agent","input":{}}]}}
+{"type":"system","subtype":"turn_duration","durationMs":472338}
+{"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"text","text":"done"}]}}
+JSONL
+  fi
+
+  if [[ "$with_bg" == "yes" ]]; then
+    mkdir -p "${jobs_dir}/abcd1234"
+    local jsonl_path="${case_dir}/conv.jsonl"
+    [[ "$with_jsonl" == "yes" ]] || jsonl_path="${case_dir}/missing.jsonl"
+    cat > "${jobs_dir}/abcd1234/state.json" <<JSON
+{"sessionId":"abcd1234-dead-beef-0000-1234567890ab","cwd":"/tmp/wt/CTL-449","linkScanPath":"${jsonl_path}"}
+JSON
+  fi
+  echo "$case_dir"
+}
+
+run_footer() {
+  local case_dir="$1"
+  # Unset the controlling session's env so we exercise file-based resolution
+  # (otherwise the test host's own CLAUDE_CODE_SESSION_ID / CATALYST_SESSION_ID
+  # leak in and mask the signal/bg-state values).
+  env -u CLAUDE_CODE_SESSION_ID -u CATALYST_SESSION_ID \
+    CATALYST_BG_JOBS_DIR="${case_dir}/jobs" \
+    bash "$FOOTER" --orch-dir "${case_dir}/orch" --ticket CTL-449 --phase implement 2>/dev/null
+}
+
+# ─── Test 1: full resolution ──────────────────────────────────────────────────
+echo "Test 1: full resolution (signal + bg state + JSONL)"
+C1="$(build_fixture "${SCRATCH}/full" yes yes)"
+OUT1="$(run_footer "$C1")"
+assert_grep '^---$' "$OUT1" "emits --- separator"
+assert_grep 'model `claude-opus-4-7`' "$OUT1" "model resolved from JSONL last assistant"
+assert_grep '2 sub-agent\(s\) launched' "$OUT1" "counts Task + Agent tool_use = 2 sub-agents"
+assert_grep 'active 7m 52s' "$OUT1" "active duration = sum of turn_duration (472338ms)"
+assert_grep 'catalyst session `sess_TESTSESSION`' "$OUT1" "catalyst session id from signal"
+assert_grep 'job `abcd1234`' "$OUT1" "short job id from signal bg_job_id"
+assert_grep 'session uuid `abcd1234-dead-beef-0000-1234567890ab`' "$OUT1" "long uuid from bg state"
+assert_grep 'cwd `/tmp/wt/CTL-449`' "$OUT1" "cwd from bg state"
+
+# ─── Test 2: degraded — no bg state.json (no JSONL reachable) ─────────────────
+echo ""
+echo "Test 2: degraded — signal only, no bg state/JSONL"
+C2="$(build_fixture "${SCRATCH}/nobg" no no)"
+OUT2="$(run_footer "$C2")"
+assert_grep '^---$' "$OUT2" "still emits footer"
+assert_grep 'catalyst session `sess_TESTSESSION`' "$OUT2" "catalyst session id still from signal"
+assert_grep 'job `abcd1234`' "$OUT2" "short job id still from signal"
+assert_grep 'model `opus`' "$OUT2" "model falls back to signal .model when no JSONL"
+assert_grep '\? sub-agent\(s\) launched' "$OUT2" "sub-agent count is ? without JSONL"
+assert_not_grep 'active ' "$OUT2" "no active-duration line without JSONL"
+assert_not_grep 'session uuid' "$OUT2" "no uuid line when neither env nor bg state provides one"
+
+# ─── Test 3: missing args → minimal footer, exit 0 ────────────────────────────
+echo ""
+echo "Test 3: missing args → minimal footer, never breaks the body"
+OUT3="$(env -u CLAUDE_CODE_SESSION_ID -u CATALYST_SESSION_ID bash "$FOOTER" --phase implement)"
+RC3=$?
+assert_grep '^---$' "$OUT3" "minimal footer still has --- separator"
+assert_grep 'metadata unavailable' "$OUT3" "minimal footer placeholder line"
+[[ "$RC3" == "0" ]] && pass "exit 0 on missing args" || fail "exit 0 on missing args — got $RC3"
+
+# ─── Test 4: long uuid prefers CLAUDE_CODE_SESSION_ID env ─────────────────────
+echo ""
+echo "Test 4: CLAUDE_CODE_SESSION_ID env wins for the long uuid"
+C4="$(build_fixture "${SCRATCH}/env" yes yes)"
+OUT4="$(CLAUDE_CODE_SESSION_ID="feedface-1111-2222-3333-444455556666" \
+  CATALYST_BG_JOBS_DIR="${C4}/jobs" \
+  bash "$FOOTER" --orch-dir "${C4}/orch" --ticket CTL-449 --phase implement 2>/dev/null)"
+assert_grep 'session uuid `feedface-1111-2222-3333-444455556666`' "$OUT4" "uuid taken from CLAUDE_CODE_SESSION_ID env"
+
+# ─── Test 5: every phase mirror skill wires the footer helper ─────────────────
+echo ""
+echo "Test 5: all 9 phase mirror skills reference phase-mirror-footer.sh"
+SKILLS_DIR="${REPO_ROOT}/plugins/dev/skills"
+for phase in research plan implement verify remediate review triage pr monitor-merge; do
+  skill="${SKILLS_DIR}/phase-${phase}/SKILL.md"
+  if [[ -f "$skill" ]] && grep -q 'phase-mirror-footer\.sh' "$skill"; then
+    pass "phase-${phase} wires the footer helper"
+  else
+    fail "phase-${phase} wires the footer helper — not found in $skill"
+  fi
+done
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-mirror-footer: ${PASSES} passed, ${FAILURES} failed"
+echo "─────────────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
@@ -25,6 +25,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SKILL_FILE="${REPO_ROOT}/plugins/dev/skills/phase-monitor-deploy/SKILL.md"
 EMIT_HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
+# shellcheck source=lib/linearis-stub.sh
+source "${SCRIPT_DIR}/lib/linearis-stub.sh"
 
 PASS=0
 FAIL=0
@@ -59,12 +61,12 @@ TMPROOT="$(mktemp -d -t phase-monitor-deploy-test.XXXXXX)"
 trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
 
 # Helper: write a fixture canonical OTel event line for a deployment_status into $1.
-# $2 = sha, $3 = env, $4 = state ("success"|"failure")
+# $2 = sha, $3 = env, $4 = state ("success"|"failure"), $5 = environmentUrl (optional)
 write_deploy_event() {
-  local out_file="$1" sha="$2" env="$3" state="$4"
+  local out_file="$1" sha="$2" env="$3" state="$4" url="${5:-}"
   jq -nc \
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    --arg sha "$sha" --arg env "$env" --arg state "$state" \
+    --arg sha "$sha" --arg env "$env" --arg state "$state" --arg url "$url" \
     '{
       ts: $ts,
       id: "fixture-deploy-event",
@@ -77,7 +79,7 @@ write_deploy_event() {
         "deployment.environment": $env,
         "deployment.state": $state
       },
-      body: {payload: {state: $state}}
+      body: {payload: ({state: $state} + (if $url != "" then {environmentUrl: $url} else {} end))}
     }' >> "$out_file"
 }
 
@@ -154,6 +156,11 @@ jq -nc --arg s "$canary_status" '{status: \$s, observations: ["fixture"]}'
 EOF
   chmod +x "$case_dir/bin/canary-stub"
 
+  # linearis stub (CTL-632 deploy mirror): keep the skill's `linearis issues
+  # discuss` call hermetic — case_dir/bin is first on PATH so this shadows any
+  # real linearis. Logs each call so we can assert the mirror posted.
+  linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+
   # Run the skill body in the background so we can append the deploy event
   # AFTER catalyst-events wait-for has begun watching from EOF. This mirrors
   # the production flow where the deploy webhook arrives after the worker
@@ -192,7 +199,9 @@ EOF
     # Give wait-for time to start. Its inner loop sleeps 1s, so we wait 2s
     # after writing to make sure the next poll picks it up.
     sleep 2
-    write_deploy_event "$events_file" "$sha" "production" "$deploy_state"
+    local deploy_url=""
+    [ "$deploy_state" = "success" ] && deploy_url="https://preview.example.dev/ctl-9999"
+    write_deploy_event "$events_file" "$sha" "production" "$deploy_state" "$deploy_url"
   fi
 
   wait "$skill_pid"
@@ -221,6 +230,24 @@ if [ -f "$CASE_DIR/orch/workers/CTL-9999/phase-monitor-deploy.json" ]; then
 
   CR_STATUS="$(jq -r '.canary_result.status' "$CASE_DIR/orch/workers/CTL-9999/phase-monitor-deploy.json")"
   assert_eq "success: canary_result.status recorded" "success" "$CR_STATUS"
+
+  # CTL-632 deploy mirror: preview URL persisted as structured data.
+  DURL="$(jq -r '.deployment.url' "$CASE_DIR/orch/workers/CTL-9999/phase-monitor-deploy.json")"
+  assert_eq "success: deployment.url persisted from environmentUrl" \
+    "https://preview.example.dev/ctl-9999" "$DURL"
+fi
+
+# CTL-632 deploy mirror: a Linear comment was posted with the env + preview URL.
+if grep -q '^discuss$' "$CASE_DIR/linearis-calls.log" 2>/dev/null; then
+  ok "success: deploy mirror posted to Linear"
+else
+  fail "success: deploy mirror posted" "no discuss in $(cat "$CASE_DIR/linearis-calls.log" 2>/dev/null)"
+fi
+if grep -q 'Phase Monitor-Deploy' "$CASE_DIR/linearis-calls.log" 2>/dev/null \
+   && grep -q 'preview.example.dev/ctl-9999' "$CASE_DIR/linearis-calls.log" 2>/dev/null; then
+  ok "success: deploy mirror body has header + preview URL"
+else
+  fail "success: deploy mirror body" "log: $(cat "$CASE_DIR/linearis-calls.log" 2>/dev/null)"
 fi
 
 # Canary stub was invoked exactly once

--- a/plugins/dev/scripts/lib/phase-mirror-footer.sh
+++ b/plugins/dev/scripts/lib/phase-mirror-footer.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# lib/phase-mirror-footer.sh — render the shared metadata footer appended to
+# every phase-agent Linear "mirror" comment (CTL-632 follow-on).
+#
+# Prints a 2-line markdown block to stdout:
+#
+#   ---
+#   _model `<model>` · <N> sub-agent(s) launched · active <Xm Ys>_
+#   _catalyst session `<sess_…>` · job `<short>` · session uuid `<uuid>` · cwd `<dir>`_
+#
+# Every field is best-effort and resolved independently — a missing source
+# degrades that one field to a placeholder rather than dropping the footer.
+# The script ALWAYS exits 0 and always prints at least the `---` + a minimal
+# line, because the caller appends our stdout directly into the comment body
+# (a non-zero exit or empty output must never corrupt the mirror).
+#
+# Data sources (all fail-soft):
+#   * model / sub-agent count / active duration  ← the worker's conversation
+#       JSONL, resolved via the signal file's bg_job_id →
+#       ${CATALYST_BG_JOBS_DIR:-~/.claude/jobs}/<bg>/state.json → .linkScanPath
+#       (same chain orchestrate-roll-usage.sh uses). Active duration is the sum
+#       of `system`/`turn_duration` events — actual compute time, NOT wall-clock,
+#       so a phase that mostly waits (e.g. monitor-merge) reports only its work.
+#   * catalyst session id  ← $CATALYST_SESSION_ID, else signal .catalystSessionId
+#   * long session uuid    ← $CLAUDE_CODE_SESSION_ID, else bg state .sessionId
+#   * short job id         ← signal .bg_job_id, else first 8 hex of the uuid
+#   * working directory    ← bg state .cwd, else $PWD
+#
+# Cost/token totals are intentionally NOT emitted: the only reliable number
+# excludes sub-agent sessions (see CTL-666 to add a true sub-agent-inclusive
+# rollup, likely via OTEL).
+#
+# Usage: phase-mirror-footer.sh --orch-dir <dir> --ticket <id> --phase <name>
+
+set -uo pipefail
+
+ORCH_DIR="" TICKET="" PHASE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --orch-dir) ORCH_DIR="${2:-}"; shift 2 ;;
+    --ticket)   TICKET="${2:-}";   shift 2 ;;
+    --phase)    PHASE="${2:-}";    shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+emit_minimal_and_exit() {
+  printf '%s\n' "---"
+  printf '_phase-%s metadata unavailable_\n' "${PHASE:-?}"
+  exit 0
+}
+
+# Without the signal coordinates we cannot resolve anything useful — still emit
+# a footer so the caller's body stays well-formed.
+[ -n "$ORCH_DIR" ] && [ -n "$TICKET" ] && [ -n "$PHASE" ] || emit_minimal_and_exit
+command -v jq >/dev/null 2>&1 || emit_minimal_and_exit
+
+SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+
+CAT_SID="${CATALYST_SESSION_ID:-}"
+BG_JOB="" SIG_MODEL=""
+if [ -f "$SIGNAL" ]; then
+  [ -n "$CAT_SID" ] || CAT_SID="$(jq -r '.catalystSessionId // empty' "$SIGNAL" 2>/dev/null || true)"
+  BG_JOB="$(jq -r '.bg_job_id // empty' "$SIGNAL" 2>/dev/null || true)"
+  SIG_MODEL="$(jq -r '.model // empty' "$SIGNAL" 2>/dev/null || true)"
+fi
+
+# Resolve the bg job state.json → long uuid, cwd, JSONL path.
+LONG_UUID="${CLAUDE_CODE_SESSION_ID:-}"
+CWD="" JSONL=""
+BG_JOBS_DIR="${CATALYST_BG_JOBS_DIR:-${HOME}/.claude/jobs}"
+if [ -n "$BG_JOB" ] && [ -f "${BG_JOBS_DIR}/${BG_JOB}/state.json" ]; then
+  BG_STATE="${BG_JOBS_DIR}/${BG_JOB}/state.json"
+  [ -n "$LONG_UUID" ] || LONG_UUID="$(jq -r '.sessionId // empty' "$BG_STATE" 2>/dev/null || true)"
+  CWD="$(jq -r '.cwd // empty' "$BG_STATE" 2>/dev/null || true)"
+  JSONL="$(jq -r '.linkScanPath // empty' "$BG_STATE" 2>/dev/null || true)"
+fi
+[ -n "$CWD" ] || CWD="$(pwd 2>/dev/null || echo '?')"
+
+# short job id: prefer the signal's bg_job_id, else first 8 hex of the uuid.
+SHORT="$BG_JOB"
+if [ -z "$SHORT" ] && [[ "$LONG_UUID" =~ ^([0-9a-f]{8}) ]]; then
+  SHORT="${BASH_REMATCH[1]}"
+fi
+
+# model / sub-agent count / active duration from the conversation JSONL.
+MODEL="" SUBS="?" ACTIVE_MS=0
+if [ -n "$JSONL" ] && [ -f "$JSONL" ]; then
+  MODEL="$(jq -rs '[.[]|select(.type=="assistant")][-1].message.model // empty' "$JSONL" 2>/dev/null || true)"
+  SUBS="$(jq -rs '[.[]|select(.type=="assistant")|.message.content[]?|select(.type=="tool_use" and ((.name=="Task") or (.name=="Agent")))]|length' "$JSONL" 2>/dev/null || echo '?')"
+  ACTIVE_MS="$(jq -rs '[.[]|select(.type=="system" and .subtype=="turn_duration")|.durationMs // 0]|add // 0' "$JSONL" 2>/dev/null || echo 0)"
+fi
+[ -n "$MODEL" ] || MODEL="${SIG_MODEL:-unknown}"
+[ -n "$SUBS" ] || SUBS="?"
+[[ "$ACTIVE_MS" =~ ^[0-9]+$ ]] || ACTIVE_MS=0
+
+# Format active duration (ms → "Xm Ys" / "Ys").
+fmt_duration() {
+  local ms="$1" s m
+  s=$(( ms / 1000 ))
+  if [ "$s" -ge 60 ]; then
+    m=$(( s / 60 )); s=$(( s % 60 ))
+    printf '%dm %ds' "$m" "$s"
+  else
+    printf '%ds' "$s"
+  fi
+}
+
+# ── Line 1: run metadata ──────────────────────────────────────────────────────
+LINE1="model \`${MODEL}\` · ${SUBS} sub-agent(s) launched"
+if [ "$ACTIVE_MS" -gt 0 ]; then
+  LINE1="${LINE1} · active $(fmt_duration "$ACTIVE_MS")"
+fi
+
+# ── Line 2: identifiers + cwd (omit unknown id pieces) ────────────────────────
+LINE2="catalyst session \`${CAT_SID:-—}\`"
+[ -n "$SHORT" ]     && LINE2="${LINE2} · job \`${SHORT}\`"
+[ -n "$LONG_UUID" ] && LINE2="${LINE2} · session uuid \`${LONG_UUID}\`"
+LINE2="${LINE2} · cwd \`${CWD}\`"
+
+printf '%s\n' "---"
+printf '_%s_\n' "$LINE1"
+printf '_%s_\n' "$LINE2"
+exit 0

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -244,10 +244,18 @@ if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
     COMMIT_COUNT="$(printf '%s\n' "${COMMIT_LIST}" | grep -c '^- ' || true)"
     : "${COMMIT_COUNT:=0}"
     DIFF_STAT="$(git diff --stat "${BASE_SHA}..HEAD" 2>/dev/null | tail -1)"
+    NAME_STATUS="$(git diff --name-status "${BASE_SHA}..HEAD" 2>/dev/null)"
+    FILES_ADDED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^A' || true)"
+    FILES_MODIFIED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^M' || true)"
+    FILES_DELETED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^D' || true)"
+    LINES_ADDED="$(git diff --numstat "${BASE_SHA}..HEAD" 2>/dev/null | awk '$1 ~ /^[0-9]+$/ {a+=$1} END {print a+0}')"
+    LINES_DELETED="$(git diff --numstat "${BASE_SHA}..HEAD" 2>/dev/null | awk '$2 ~ /^[0-9]+$/ {d+=$2} END {print d+0}')"
   else
     COMMIT_LIST="_base branch unknown_"
     COMMIT_COUNT="?"
     DIFF_STAT="_unavailable_"
+    FILES_ADDED="?"; FILES_MODIFIED="?"; FILES_DELETED="?"
+    LINES_ADDED="?"; LINES_DELETED="?"
   fi
   BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "${TICKET}")"
   MIRROR_BODY="$(cat <<EOF
@@ -255,6 +263,8 @@ if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
 
 - **Branch**: \`${BRANCH_NAME}\`
 - **Commits**: ${COMMIT_COUNT}
+- **Files**: ${FILES_ADDED} added, ${FILES_MODIFIED} modified, ${FILES_DELETED} deleted
+- **Lines**: +${LINES_ADDED} / -${LINES_DELETED}
 - **Diff**: ${DIFF_STAT}
 
 <details>
@@ -267,6 +277,12 @@ ${COMMIT_LIST}
 _Posted automatically by phase-implement (CTL-632)._
 EOF
 )"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
   if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -283,6 +283,11 @@ EOF
   fi
   [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
 ${MIRROR_FOOTER}"
+  if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
+    MIRROR_BODY="${MIRROR_BODY:0:30000}
+
+_... (truncated)_"
+  fi
   if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -204,6 +204,14 @@ fi
 DEPLOY_STATE="$(printf '%s' "$DEPLOY_EVENT" \
   | jq -r '.attributes."deployment.state" // .body.payload.state // empty' 2>/dev/null)"
 
+# Preview / live environment URL from the deployment_status payload. Prefer the
+# environment URL (the actual deployed/preview site, e.g. a Cloudflare Pages
+# preview); fall back to target_url (often the CI run). Surfaced in the mirror
+# comment and persisted to the signal as structured data so a HUD/agent can link
+# straight to the running deploy.
+DEPLOY_URL="$(printf '%s' "$DEPLOY_EVENT" \
+  | jq -r '.body.payload.environmentUrl // .body.payload.environment_url // .body.payload.targetUrl // .body.payload.target_url // empty' 2>/dev/null || true)"
+
 # 3. Branch on deploy state.
 case "$DEPLOY_STATE" in
   success)
@@ -268,6 +276,7 @@ jq -nc \
   --arg sha "$MERGE_SHA" \
   --arg env "$DEPLOY_ENV" \
   --arg ts "$DEPLOY_TIME" \
+  --arg url "$DEPLOY_URL" \
   --slurpfile canary "$CANARY_OUT_FILE" \
   '{
     ticket: $ticket,
@@ -275,9 +284,44 @@ jq -nc \
     deploy_env: $env,
     deploy_state: "success",
     deploy_time: $ts,
+    deployment: ({environment: $env} + (if $url != "" then {url: $url} else {} end)),
     canary_result: ($canary | first),
     completed_at: $ts
   }' > "$RESULT_FILE"
+
+CANARY_STATUS_FOR_MIRROR="$(jq -r '.status // "unknown"' "$CANARY_OUT_FILE" 2>/dev/null || echo "unknown")"
+
+# Mirror the deploy outcome to Linear as a single comment (CTL-632). Shows the
+# environment + preview/live URL (clickable straight from the ticket) and the
+# canary verdict. Fail-open + idempotent via the per-phase marker. The footer is
+# appended via the shared helper. monitor-deploy is the terminal phase, so this
+# is the last automated comment on the ticket.
+LINEAR_MIRROR_MARKER="${WORKER_DIR}/.linear-mirror-monitor-deploy"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]] && command -v linearis >/dev/null 2>&1; then
+  DEPLOY_URL_LINE="${DEPLOY_URL:-_none reported_}"
+  MIRROR_BODY="$(cat <<EOF
+**Phase Monitor-Deploy** — deployed to \`${DEPLOY_ENV}\`
+
+- **Deploy**: success · canary \`${CANARY_STATUS_FOR_MIRROR}\`
+- **Preview / environment URL**: ${DEPLOY_URL_LINE}
+- **Merge SHA**: \`${MERGE_SHA}\`
+
+_Posted automatically by phase-monitor-deploy (CTL-632)._
+EOF
+)"
+  ORCH_DIR_RESOLVED="${CATALYST_ORCHESTRATOR_DIR:-${ORCH_DIR:-$(cd "${WORKER_DIR}/../.." 2>/dev/null && pwd || echo "")}}"
+  FOOTER_BIN="${__PM_REPO_ROOT}/plugins/dev/scripts/lib/phase-mirror-footer.sh"
+  if [[ -n "${ORCH_DIR_RESOLVED}" && -x "${FOOTER_BIN}" ]]; then
+    MIRROR_FOOTER="$("${FOOTER_BIN}" --orch-dir "${ORCH_DIR_RESOLVED}" --ticket "${TICKET}" --phase "monitor-deploy" 2>/dev/null || true)"
+    [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
+  fi
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-monitor-deploy: linearis discuss failed (continuing)" >&2
+  fi
+fi
 
 # 6. Emit the canonical phase event based on canary status.
 if [[ "$CANARY_STATUS" == "success" ]]; then

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -243,6 +243,92 @@ This skill exits cleanly the moment the merge + Linear transition land.
 
 ## End block
 
+Mirror the merge outcome to Linear as a single comment (CTL-632). Best-effort
+end-of-loop summary (per the design decision — per-finding detail like
+individual CI fix-up commits or bot review threads stays on the PR itself):
+merge commit + base branch, the final CI check rollup (passed/total), and a
+count of bot reviews handled (e.g. Codex) whose threads were resolved before
+the merge. Merge metadata is re-read from the signal file (`.pr.mergeCommitSha`
+/ `.pr.mergedAt`, written in the merge step above); CI + reviews are pulled once
+from `gh pr view`. Runs after the auto-teardown `cd` to the primary worktree —
+it relies only on absolute signal paths and the PR number, never the (possibly
+removed) ticket worktree. Body hard-truncated to 30,000 bytes. Fail-open and
+idempotent via the per-phase marker file. Uniquely-named fence so the e2e test
+can extract just this block.
+
+```bash phase-monitor-merge-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  MM_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+  MM_PR_NUMBER="$(jq -r '.pr.number // empty' "${MM_SIGNAL}" 2>/dev/null || true)"
+  [[ -n "${MM_PR_NUMBER}" ]] || MM_PR_NUMBER="${PR_NUMBER:-}"
+  MERGE_SHA="$(jq -r '.pr.mergeCommitSha // empty' "${MM_SIGNAL}" 2>/dev/null || true)"
+  MERGED_AT="$(jq -r '.pr.mergedAt // empty' "${MM_SIGNAL}" 2>/dev/null || true)"
+  PR_VIEW="{}"
+  if [[ -n "${MM_PR_NUMBER}" ]]; then
+    PR_VIEW="$(gh pr view "${MM_PR_NUMBER}" --json url,baseRefName,createdAt,statusCheckRollup,reviews 2>/dev/null || echo '{}')"
+  fi
+  PR_URL="$(printf '%s' "${PR_VIEW}" | jq -r '.url // empty' 2>/dev/null || true)"
+  BASE_REF="$(printf '%s' "${PR_VIEW}" | jq -r '.baseRefName // "main"' 2>/dev/null || echo 'main')"
+  CREATED_AT="$(printf '%s' "${PR_VIEW}" | jq -r '.createdAt // empty' 2>/dev/null || true)"
+  CHECKS_TOTAL="$(printf '%s' "${PR_VIEW}" | jq -r '(.statusCheckRollup // []) | length' 2>/dev/null || echo 0)"
+  CHECKS_PASSED="$(printf '%s' "${PR_VIEW}" | jq -r '[(.statusCheckRollup // [])[] | select((.conclusion // .state) == "SUCCESS")] | length' 2>/dev/null || echo 0)"
+  BOT_REVIEWS="$(printf '%s' "${PR_VIEW}" | jq -r '[(.reviews // [])[] | select((.author.login // "" | ascii_downcase) | test("codex|bot"))] | length' 2>/dev/null || echo 0)"
+  if [[ "${CHECKS_TOTAL}" == "0" ]]; then
+    CI_LINE="_no CI checks reported_"
+  else
+    CI_LINE="${CHECKS_PASSED}/${CHECKS_TOTAL} checks passed"
+  fi
+  if [[ -n "${MERGE_SHA}" ]]; then
+    MERGE_LINE="\`${MERGE_SHA}\` into \`${BASE_REF}\`${MERGED_AT:+ at ${MERGED_AT}}"
+  else
+    MERGE_LINE="_merge commit unavailable_"
+  fi
+  # Wall-clock time the PR was open (opened → merged). This is total elapsed,
+  # most of it spent WAITING on GitHub (CI, reviews) — the agent's actual
+  # working time is the "active" figure in the footer below, so
+  # waiting ≈ time-to-merge − active. fromdateiso8601 is portable (needs the Z).
+  TIME_TO_MERGE="_unknown_"
+  if [[ -n "${CREATED_AT}" && -n "${MERGED_AT}" ]]; then
+    TTM_SECS="$(jq -n --arg a "${CREATED_AT}" --arg b "${MERGED_AT}" \
+      '(($b|fromdateiso8601) - ($a|fromdateiso8601)) | floor' 2>/dev/null || echo "")"
+    if [[ "${TTM_SECS}" =~ ^[0-9]+$ ]]; then
+      TTM_H=$(( TTM_SECS / 3600 )); TTM_M=$(( (TTM_SECS % 3600) / 60 ))
+      if [[ "${TTM_H}" -gt 0 ]]; then TIME_TO_MERGE="${TTM_H}h ${TTM_M}m"; else TIME_TO_MERGE="${TTM_M}m"; fi
+    fi
+  fi
+  MIRROR_BODY="$(cat <<EOF
+**Phase Monitor-Merge** — PR #${MM_PR_NUMBER:-?} merged
+
+- **PR**: ${PR_URL:-_url unavailable_}
+- **Merge commit**: ${MERGE_LINE}
+- **Time to merge** (PR opened → merged): ${TIME_TO_MERGE} — mostly waiting on CI/reviews; see the footer's _active_ figure for actual working time
+- **CI**: ${CI_LINE}
+- **Bot reviews handled** (e.g. Codex): ${BOT_REVIEWS} — threads resolved before merge
+
+_Posted automatically by phase-monitor-merge (CTL-632). Per-finding detail —
+individual CI fix-up commits and review threads — lives on the PR itself._
+EOF
+)"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
+  if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
+    MIRROR_BODY="${MIRROR_BODY:0:30000}
+
+_... (truncated)_"
+  fi
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-monitor-merge: linearis discuss failed (continuing)" >&2
+  fi
+fi
+```
+
 ```bash
 EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
 if [[ -x "$EMIT" ]]; then

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -197,6 +197,12 @@ if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
 _Posted automatically by phase-plan (CTL-632)._
 EOF
 )"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
   if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -133,6 +133,79 @@ the reasoning happens upstream in `create-pr` itself.
 
 ## End block
 
+Mirror the phase output to Linear as a single comment (CTL-632). Describes the
+PR that was opened (number, URL, title, files changed, additions/deletions,
+commit count) plus the pre-merge verification surfaced from the verify phase's
+`verify.json` (test/typecheck/lint gate status + regression risk) so the trail
+records what was checked before the PR went up. PR metadata is re-read from the
+phase signal file (`.pr.number`/`.pr.url`, written in the phase-specific work
+above) and enriched via `gh pr view`; the verify summary is fail-soft if no
+`verify.json` exists. Body hard-truncated to 30,000 bytes. Fail-open and
+idempotent via the per-phase marker file. Uniquely-named fence so the e2e test
+can extract just this block.
+
+```bash phase-pr-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  PR_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+  PR_NUMBER="$(jq -r '.pr.number // empty' "${PR_SIGNAL}" 2>/dev/null || true)"
+  PR_URL="$(jq -r '.pr.url // empty' "${PR_SIGNAL}" 2>/dev/null || true)"
+  PR_VIEW="{}"
+  if [[ -n "${PR_NUMBER}" ]]; then
+    PR_VIEW="$(gh pr view "${PR_NUMBER}" --json title,files,additions,deletions,commits 2>/dev/null || echo '{}')"
+  fi
+  PR_TITLE="$(printf '%s' "${PR_VIEW}" | jq -r '.title // "_untitled_"' 2>/dev/null || echo '_untitled_')"
+  FILES_CHANGED="$(printf '%s' "${PR_VIEW}" | jq -r '(.files // []) | length' 2>/dev/null || echo '?')"
+  ADDITIONS="$(printf '%s' "${PR_VIEW}" | jq -r '.additions // "?"' 2>/dev/null || echo '?')"
+  DELETIONS="$(printf '%s' "${PR_VIEW}" | jq -r '.deletions // "?"' 2>/dev/null || echo '?')"
+  COMMIT_COUNT="$(printf '%s' "${PR_VIEW}" | jq -r '(.commits // []) | length' 2>/dev/null || echo '?')"
+  VERIFY_JSON_FILE="${ORCH_DIR}/workers/${TICKET}/verify.json"
+  VERIFY_RENDERED="_no verify.json found — verification ran in a prior phase or was skipped_"
+  if [[ -f "${VERIFY_JSON_FILE}" ]]; then
+    VERIFY_RENDERED="$(jq -r '
+      ("- **Regression risk**: " + ((.regression_risk // "?")|tostring) + " / 10")
+      + "\n"
+      + ((.gates // {})
+         | to_entries
+         | map(select(.key | test("test|typecheck|lint|coverage")))
+         | map("- **" + .key + "**: " + (.value.status // "unknown")
+               + (if .value.summary then " — " + .value.summary else "" end))
+         | join("\n"))
+    ' "${VERIFY_JSON_FILE}" 2>/dev/null || echo '_verify.json unreadable_')"
+  fi
+  MIRROR_BODY="$(cat <<EOF
+**Phase PR** — opened PR #${PR_NUMBER:-?}
+
+- **PR**: ${PR_URL:-_url unavailable_}
+- **Title**: ${PR_TITLE}
+- **Files changed**: ${FILES_CHANGED} (+${ADDITIONS} / -${DELETIONS})
+- **Commits**: ${COMMIT_COUNT}
+
+**Pre-merge verification** (from the verify phase):
+${VERIFY_RENDERED}
+
+_Posted automatically by phase-pr (CTL-632)._
+EOF
+)"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
+  if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
+    MIRROR_BODY="${MIRROR_BODY:0:30000}
+
+_... (truncated)_"
+  fi
+  if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-pr: linearis discuss failed (continuing)" >&2
+  fi
+fi
+```
+
 ```bash
 EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
 if [[ -x "$EMIT" ]]; then

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -284,6 +284,11 @@ EOF
   fi
   [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
 ${MIRROR_FOOTER}"
+  if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
+    MIRROR_BODY="${MIRROR_BODY:0:30000}
+
+_... (truncated)_"
+  fi
   if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -242,10 +242,18 @@ if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
     COMMIT_COUNT="$(printf '%s\n' "${COMMIT_LIST}" | grep -c '^- ' || true)"
     : "${COMMIT_COUNT:=0}"
     DIFF_STAT="$(git diff --stat "${BASE_SHA}..HEAD" 2>/dev/null | tail -1)"
+    NAME_STATUS="$(git diff --name-status "${BASE_SHA}..HEAD" 2>/dev/null)"
+    FILES_ADDED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^A' || true)"
+    FILES_MODIFIED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^M' || true)"
+    FILES_DELETED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^D' || true)"
+    LINES_ADDED="$(git diff --numstat "${BASE_SHA}..HEAD" 2>/dev/null | awk '$1 ~ /^[0-9]+$/ {a+=$1} END {print a+0}')"
+    LINES_DELETED="$(git diff --numstat "${BASE_SHA}..HEAD" 2>/dev/null | awk '$2 ~ /^[0-9]+$/ {d+=$2} END {print d+0}')"
   else
     COMMIT_LIST="_base branch unknown_"
     COMMIT_COUNT="?"
     DIFF_STAT="_unavailable_"
+    FILES_ADDED="?"; FILES_MODIFIED="?"; FILES_DELETED="?"
+    LINES_ADDED="?"; LINES_DELETED="?"
   fi
   BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "${TICKET}")"
   REGRESSION_RISK="$(jq -r '.regression_risk // "?"' "${ORCH_DIR}/workers/${TICKET}/verify.json" 2>/dev/null || echo "?")"
@@ -254,6 +262,8 @@ if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
 
 - **Branch**: \`${BRANCH_NAME}\`
 - **Commits**: ${COMMIT_COUNT}
+- **Files**: ${FILES_ADDED} added, ${FILES_MODIFIED} modified, ${FILES_DELETED} deleted
+- **Lines**: +${LINES_ADDED} / -${LINES_DELETED}
 - **Diff**: ${DIFF_STAT}
 - **Acted on verify.json regression_risk**: ${REGRESSION_RISK}
 
@@ -268,6 +278,12 @@ _Posted automatically by phase-remediate (CTL-653 / CTL-632). The router
 re-dispatches verify to re-check; the verify⇄remediate cycle caps at 3._
 EOF
 )"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
   if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -192,6 +192,12 @@ ${RESEARCH_SUMMARY}
 _Posted automatically by phase-research (CTL-632)._
 EOF
 )"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
   if linearis issues discuss "${TICKET}" --body "${MIRROR_BODY}" >/dev/null 2>&1; then
     : > "${LINEAR_MIRROR_MARKER}"
   else

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -247,6 +247,12 @@ ${FINDINGS_PRETTY}
 _Posted automatically by phase-review (CTL-632)._
 EOF
 )"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
   if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
     MIRROR_BODY="${MIRROR_BODY:0:30000}
 

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -245,6 +245,16 @@ _Triaged automatically by the phase-triage agent (CTL-451)._
 EOF
 )"
 
+# Append the shared run-metadata footer (CTL-632 follow-on): model, sub-agent
+# count, active working duration, session ids, cwd. Fail-soft — a missing helper
+# or unresolved orch dir simply omits the footer.
+__PT_FOOTER="${__PT_REPO_ROOT}/plugins/dev/scripts/lib/phase-mirror-footer.sh"
+if [[ -n "${ORCH_DIR:-}" && -x "${__PT_FOOTER}" ]]; then
+  MIRROR_FOOTER="$("${__PT_FOOTER}" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "triage" 2>/dev/null || true)"
+  [[ -n "${MIRROR_FOOTER}" ]] && COMMENT_BODY="${COMMENT_BODY}
+${MIRROR_FOOTER}"
+fi
+
 # CTL-614: the Linear comment post is best-effort. triage.json is already on
 # disk; the canonical pipeline contract is `phase.triage.complete.<TICKET>`
 # (see CTL-452). A transient `linearis issues discuss` failure (notably the

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -308,6 +308,12 @@ ${FINDINGS_PRETTY}
 _Posted automatically by phase-verify (CTL-632)._
 EOF
 )"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
   if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
     MIRROR_BODY="${MIRROR_BODY:0:30000}
 

--- a/website/src/content/docs/reference/orchestration/phase-agents.md
+++ b/website/src/content/docs/reference/orchestration/phase-agents.md
@@ -49,15 +49,42 @@ Turn caps follow the same precedence: `--turn-cap` CLI flag >
 
 ### Linear comment trail (CTL-632)
 
-Every phase from `phase-triage` through `phase-review` (phases 1–6) mirrors its output back to the
-Linear ticket as a single comment in its End block — not just `phase-triage`. So the ticket
+Every phase from `phase-triage` through `phase-monitor-deploy` (phases 1–9) mirrors its output back
+to the Linear ticket as a single comment in its End block — not just `phase-triage`. So the ticket
 accumulates a running commentary as the pipeline walks: the triaged classification, then the
-research summary, the plan summary, the implement summary, the verify gates + findings, and the
-review verdict. The mirror is **idempotent** — guarded by a per-phase marker file
+research summary, the plan summary, the implement summary (files/lines), the verify gates +
+findings, the review verdict, the PR (with pre-merge verification), the merge outcome (CI rollup +
+bot/Codex reviews handled + time-to-merge), and the deploy (environment + preview URL + canary
+verdict). The mirror is **idempotent** — guarded by a per-phase marker file
 (`${ORCH_DIR}/workers/${TICKET}/.linear-mirror-<phase>`) so a re-dispatched or revived phase agent
 doesn't double-post — and **fail-open** (a `linearis` failure logs and continues, never blocking the
 phase). Each comment body is hard-truncated to 30,000 bytes (under Linear's effective comment cap)
 with a truncation marker.
+
+**Caveat:** the mirror lives in each skill's End block, so a phase the execution-core daemon
+*reclaims* (false-declares dead and advances past) never runs its End block and posts no comment —
+the daemon's reclaim path has no mirror fallback.
+
+#### Run-metadata footer
+
+Every mirror comment ends with a shared footer rendered by
+`plugins/dev/scripts/lib/phase-mirror-footer.sh`:
+
+```
+---
+_model `claude-opus-4-7` · 3 sub-agent(s) launched · active 7m 52s_
+_catalyst session `sess_…` · job `bc222a77` · session uuid `bc222a77-…` · cwd `/…/wt/…`_
+```
+
+- **model / sub-agent count / active working duration** are read from the worker's conversation
+  JSONL (resolved via the signal's `bg_job_id` → `~/.claude/jobs/<bg>/state.json` → `.linkScanPath`).
+  _active_ is the sum of `turn_duration` events — actual compute time, **not** wall-clock — so a
+  mostly-waiting phase like `phase-monitor-merge` reports only the time it was working.
+- **identifiers + cwd** let an operator resume or inspect the exact session.
+- The footer is **best-effort**: each field degrades to a placeholder independently and the helper
+  never fails the comment. **Cost/token totals are intentionally omitted** — the only number
+  reliably available at post time excludes sub-agent sessions; a true sub-agent-inclusive rollup
+  (likely via OTEL/Prometheus, which Grafana already aggregates per ticket) is tracked in CTL-666.
 
 ### 1. `phase-triage`
 
@@ -143,6 +170,12 @@ matching `$PHASE_DEPLOY_ENV` (default `production`), then runs the `/canary` ski
 verify the live deployment. Writes `phase-monitor-deploy.json` and emits
 `phase.monitor-deploy.complete.<TICKET>`, `.failed.<TICKET>`, or `.skipped.<TICKET>`. Uses Haiku by
 default — most of the work is polling and reading deployment status events.
+
+On a successful deploy it extracts the **preview / environment URL** from the `deployment_status`
+event (`environmentUrl`, falling back to `targetUrl`), persists it to the signal as structured data
+(`.deployment.url`) so a HUD or agent can link straight to the running deploy, and mirrors a deploy
+comment to Linear (environment + clickable preview URL + canary verdict). As the terminal phase,
+this is the last automated comment on the ticket.
 
 Skipped automatically when no deploy event arrives within the wall-clock timeout, so projects
 without deployment hooks don't block on this phase forever.


### PR DESCRIPTION
## Summary

Completes the CTL-632 per-phase Linear "mirror" comment trail so **every phase 1–9** posts a comment, and adds a shared **run-metadata footer** to each one. Linear: CTL-668.

- **phase-pr** — PR #/URL/title, files (+/−), commits, pre-merge verification from `verify.json`
- **phase-monitor-merge** — merge commit, **time-to-merge** (opened→merged), CI rollup, bot/Codex reviews handled
- **phase-monitor-deploy** — env + **clickable preview/environment URL** + canary verdict; URL also persisted to the signal as `.deployment.url` (structured data for HUD/agents)
- **phase-implement / phase-remediate** — files added/modified/deleted + lines +/− (now truncated to 30k like siblings)
- **Footer on all 9** (`lib/phase-mirror-footer.sh`) — model, sub-agent count, **active working time** (turn-duration; excludes waiting), catalyst session id, short bg job id, long claude session uuid, cwd. Fail-soft, always exits 0.

Cost/token totals omitted from the footer (reliable number excludes sub-agent sessions) → tracked in **CTL-666**.

## Test plan

- [x] `phase-mirror-footer.test.sh` — 28/28 (resolution, degraded, missing-args, env-precedence, all-9-wired)
- [x] `phase-implement-e2e.test.sh` — 133/133 (pr/monitor-merge/implement mirrors, files/lines, time-to-merge, footer wiring)
- [x] `phase-monitor-deploy-e2e.test.sh` — 26/26 (deploy mirror, preview URL, structured `.deployment.url`)
- [x] research/plan/verify/review/triage e2e suites green
- [x] code-review + security-review subagents: no HIGH findings, nothing exploitable
- Note: CI has no unit-test gate; the bash suites above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)