### PR TITLE
CTL-667: front-load merge-conflict surfacing via dispatch-time rebase

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,6 +229,36 @@ single shared JSONL log** at `~/catalyst/events/YYYY-MM.jsonl`. The orchestrator
 events via the broker (`filter.wake.<ORCH_NAME>`), advances the ticket through the canonical
 sequence in `orchestrate-phase-advance`, and dispatches the next `--bg` job.
 
+### Dispatch-time rebase (front-load conflict surfacing, CTL-667)
+
+On a **fresh** dispatch of a **build** phase (`research`, `plan`, `implement`, `verify`,
+`review`), `phase-agent-dispatch` rebases the ticket's worktree (its cwd) onto current
+`origin/<base>` **before** launching the `claude --bg` worker. This front-loads divergence
+detection: the worker starts current with merged sibling work, and a conflict surfaces here
+instead of riding stale assumptions all the way to `monitor-merge` (CTL-608).
+
+The rebase is gated and mechanical:
+
+- **Fresh-only.** A resume dispatch (`--resume-session` set, CTL-658) skips it — the resumed
+  session assumes the prior tree.
+- **Build-phase-only.** `triage`/`pr`/`remediate` and the `monitor-merge`/`monitor-deploy`
+  phases are exempt (the monitor phases operate on the PR / merged SHA and have their own
+  `BEHIND` handling). The build-phase set is `is_rebase_phase` in `lib/phase-sequence.sh`,
+  drift-guarded against `PHASES`.
+- **Local-only.** It never pushes and never touches the open PR (build branches aren't pushed
+  until `phase-pr`); machine-local noise (`.catalyst/config.json`, `.trunk/*`) is stashed across
+  the rebase. The git logic lives in `lib/worktree-rebase.sh` (`resolve_base_branch` +
+  `rebase_onto_base`).
+- **Clean → proceed.** A clean rebase falls through to the normal worker launch.
+- **Conflict → park.** A textual conflict aborts the rebase (HEAD returns to the pre-rebase
+  commit), rewrites the phase signal to `status:"stalled"` +
+  `failureReason:"rebase_conflict_with_origin_main"`, emits `phase.<phase>.failed.<ticket>`, and
+  exits **without launching a worker**. The daemon TERMINAL-classifies the stalled signal (no
+  revive) and the scheduler sweep applies the `needs-human` label — the conflict is never
+  auto-resolved.
+- **Transient fetch failure → proceed un-rebased.** A flaky `git fetch` (rc≠2) is non-fatal;
+  the phase proceeds as status quo, with `monitor-merge` remaining the backstop.
+
 ### Unified data-flow
 
 The same event log is the cross-process backbone for every observation surface:

--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -162,6 +162,21 @@ and the `catalyst.orchestration.phaseAgents.turnCaps[<phase>]` config key in tha
 order). The prior-artifact gate — which file must already exist before a phase
 launches — sits alongside in the same script.
 
+**Dispatch-time rebase (CTL-667).** On a **fresh** dispatch of a **build** phase
+(`research`, `plan`, `implement`, `verify`, `review`), `phase-agent-dispatch`
+rebases the ticket's worktree onto current `origin/main` *before* launching the
+worker, so each build phase starts current with merged sibling work and a
+divergence surfaces at dispatch instead of riding all the way to `monitor-merge`.
+It is local-only (never pushes, never touches the PR) and mechanical: a clean
+rebase falls through to the normal launch; a textual **conflict** aborts, parks
+the ticket (`status:"stalled"` + `failureReason:"rebase_conflict_with_origin_main"`,
+`phase.<phase>.failed` emitted) and routes it to `needs-human` without launching a
+worker — conflicts are never auto-resolved. Resume dispatches (CTL-658) and the
+non-build phases (`triage`/`pr`/`remediate`/`monitor-merge`/`monitor-deploy`) skip
+the rebase; the `monitor-*` phases operate on the PR / merged SHA and keep their
+own `BEHIND` handling. Git logic lives in `lib/worktree-rebase.sh`; the build-phase
+set is `is_rebase_phase` in `lib/phase-sequence.sh`.
+
 ### State machine for one worker
 
 ```mermaid

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -896,6 +896,186 @@ OUT_DRY=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --o
 	--resume-session abc-uuid --dry-run 2>/dev/null)
 assert_eq "abc-uuid" "$(jq -r '.resumeSession' <<<"$OUT_DRY")" "dry-run JSON echoes resumeSession"
 
+# ─── CTL-667: front-load merge-conflict surfacing (dispatch-time rebase) ─────
+# These cases turn the per-test scratch worktree into a REAL git repo with a
+# bare `origin` and exercise the dispatcher's fresh+build-phase rebase block.
+# The dispatcher rebases its cwd, so each test cd's into the work clone.
+# CATALYST_BASE_BRANCH=main pins the rebase target for determinism.
+
+# Deterministic, non-interactive git for the fixtures.
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+export GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true
+
+# git_worktree_fixture <tag> → sets GORIGIN (bare), GUP (upstream editor clone),
+# GWORK (the worktree the dispatcher runs in, on branch `work`). Seeds an initial
+# commit with shared.txt (conflict target) + a tracked .catalyst/config.json.
+git_worktree_fixture() {
+	local tag="$1"
+	GORIGIN="${TEST_DIR}/${tag}-origin.git"
+	GUP="${TEST_DIR}/${tag}-up"
+	GWORK="${TEST_DIR}/${tag}-work"
+	git init --quiet --bare -b main "$GORIGIN"
+	git clone --quiet "$GORIGIN" "$GUP" 2>/dev/null
+	(
+		cd "$GUP" || exit 1
+		printf 'base-line\n' >shared.txt
+		mkdir -p .catalyst
+		printf '{"committed":true}\n' >.catalyst/config.json
+		git add -A
+		git commit --quiet -m "initial"
+		git push --quiet origin main
+	)
+	git clone --quiet "$GORIGIN" "$GWORK" 2>/dev/null
+	(cd "$GWORK" && git checkout --quiet -b work)
+}
+# advance_origin_clean → push a non-conflicting commit (new file) to origin/main.
+advance_origin_clean() {
+	(
+		cd "$GUP" && git checkout --quiet main
+		printf 'upstream-feature\n' >upstream.txt
+		git add -A && git commit --quiet -m "upstream clean feature"
+		git push --quiet origin main
+	)
+}
+# advance_origin_conflict → push a commit editing shared.txt's only line.
+advance_origin_conflict() {
+	(
+		cd "$GUP" && git checkout --quiet main
+		printf 'upstream-edit\n' >shared.txt
+		git add -A && git commit --quiet -m "upstream conflicting edit"
+		git push --quiet origin main
+	)
+}
+# seed_local_plan_commit → in GWORK, add the implement-gate plan artifact plus a
+# local commit so the rebase has something to replay. Extra arg = a file edit
+# applied before the commit (used to construct the conflicting local delta).
+seed_local_plan_commit() {
+	mkdir -p "${GWORK}/thoughts/shared/plans"
+	printf '# plan\n' >"${GWORK}/thoughts/shared/plans/2026-05-27-ctl-100.md"
+	printf 'local-feature\n' >"${GWORK}/local.txt"
+	(cd "$GWORK" && git add -A && git commit --quiet -m "local work + plan")
+}
+
+# ─── Test 28: fresh build phase, clean rebase, behind origin/main → launches on rebased tip
+echo ""
+echo "Test 28 (CTL-667): fresh build phase clean rebase launches on the rebased tip"
+fresh_env t28_rebase_clean
+git_worktree_fixture t28
+advance_origin_clean
+seed_local_plan_commit
+(cd "$GWORK" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase implement --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1)
+SIGNAL="${WORKER_DIR}/phase-implement.json"
+LOG_PRESENT="no"; [[ -s $CLAUDE_STUB_LOG ]] && LOG_PRESENT="yes"
+assert_eq "yes" "$LOG_PRESENT" "clean rebase: claude --bg WAS invoked"
+BASE_PRESENT="no"; [[ -f "${GWORK}/upstream.txt" ]] && BASE_PRESENT="yes"
+assert_eq "yes" "$BASE_PRESENT" "clean rebase: worktree HEAD now carries the new origin/main commit"
+assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "clean rebase: signal is the normal launched status (not stalled)"
+
+# ─── Test 29: fresh build phase, conflicting rebase → park stalled, no worker
+echo ""
+echo "Test 29 (CTL-667): conflicting rebase parks the phase (stalled), no worker launched"
+fresh_env t29_rebase_conflict
+export CATALYST_DIR="${TEST_DIR}/catalyst-events"
+mkdir -p "${CATALYST_DIR}/events"
+git_worktree_fixture t29
+advance_origin_conflict
+mkdir -p "${GWORK}/thoughts/shared/plans"
+printf '# plan\n' >"${GWORK}/thoughts/shared/plans/2026-05-27-ctl-100.md"
+printf 'local-edit\n' >"${GWORK}/shared.txt"
+(cd "$GWORK" && git add -A && git commit --quiet -m "local conflicting edit + plan")
+ORIG_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+(cd "$GWORK" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase implement --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >"${TEST_DIR}/t29.out" 2>/dev/null)
+RC29=$?
+SIGNAL="${WORKER_DIR}/phase-implement.json"
+assert_eq "1" "$RC29" "conflict park: dispatcher exits 1"
+CLAUDE_INVOKED="no"; [[ -s $CLAUDE_STUB_LOG ]] && CLAUDE_INVOKED="yes"
+assert_eq "no" "$CLAUDE_INVOKED" "conflict park: claude --bg was NOT invoked"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL")" "conflict park: signal status = stalled"
+assert_eq "rebase_conflict_with_origin_main" "$(jq -r '.failureReason' "$SIGNAL")" \
+	"conflict park: signal failureReason = rebase_conflict_with_origin_main"
+NOW_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+assert_eq "$ORIG_HEAD" "$NOW_HEAD" "conflict park: worktree HEAD back at the original local commit (abort succeeded)"
+if grep -rqs '"phase.implement.failed.CTL-100"' "${CATALYST_DIR}/events/"; then
+	pass "conflict park: phase.implement.failed.CTL-100 event emitted"
+else
+	fail "conflict park: no phase.implement.failed.CTL-100 event emitted"
+fi
+unset CATALYST_DIR
+
+# ─── Test 30: resume dispatch never rebases
+echo ""
+echo "Test 30 (CTL-667): --resume-session never rebases (HEAD unchanged)"
+fresh_env t30_resume_norebase
+git_worktree_fixture t30
+advance_origin_clean
+seed_local_plan_commit
+ORIG_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+(cd "$GWORK" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase implement --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test --resume-session res-uuid >/dev/null 2>&1)
+NOW_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+assert_eq "$ORIG_HEAD" "$NOW_HEAD" "resume: worktree HEAD unchanged (no fetch/rebase ran)"
+LOG=$(cat "$CLAUDE_STUB_LOG")
+assert_contains "$LOG" "--resume" "resume: the resume arm ran"
+
+# ─── Test 31: non-build phase never rebases
+echo ""
+echo "Test 31 (CTL-667): non-build phases (triage, pr) never rebase"
+fresh_env t31_nonbuild_norebase
+git_worktree_fixture t31
+advance_origin_clean
+# triage needs no prior artifact.
+ORIG_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+(cd "$GWORK" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase triage --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1)
+NOW_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+assert_eq "$ORIG_HEAD" "$NOW_HEAD" "triage: worktree HEAD unchanged"
+assert_eq "yes" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "triage: claude invoked normally"
+# pr needs review.json as its prior artifact.
+rm -f "$CLAUDE_STUB_LOG"
+echo '{"ticket":"CTL-100","status":"done"}' >"${WORKER_DIR}/review.json"
+(cd "$GWORK" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase pr --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1)
+NOW_HEAD2="$(cd "$GWORK" && git rev-parse HEAD)"
+assert_eq "$ORIG_HEAD" "$NOW_HEAD2" "pr: worktree HEAD unchanged"
+assert_eq "yes" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "pr: claude invoked normally"
+
+# ─── Test 32: re-walk idempotency — no rebase on an already-running signal
+echo ""
+echo "Test 32 (CTL-667): re-walk idempotency exits before the rebase block (HEAD unchanged)"
+fresh_env t32_rewalk_norebase
+git_worktree_fixture t32
+advance_origin_clean
+seed_local_plan_commit
+ORIG_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+# Pre-seed the signal as running → the idempotency guard (before the rebase block) fires.
+printf '%s\n' '{"ticket":"CTL-100","phase":"implement","status":"running","bg_job_id":"deadbeef"}' \
+	>"${WORKER_DIR}/phase-implement.json"
+STDOUT=$(cd "$GWORK" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase implement --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+assert_eq "true" "$(echo "$STDOUT" | jq -r '.idempotent // false')" "re-walk: dispatch reports idempotent:true"
+NOW_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
+assert_eq "$ORIG_HEAD" "$NOW_HEAD" "re-walk: worktree HEAD unchanged (no rebase ran)"
+
+# ─── Test 33: dirty noise survives a clean dispatch rebase
+echo ""
+echo "Test 33 (CTL-667): dirty .catalyst/config.json survives a clean dispatch rebase"
+fresh_env t33_noise_survives
+git_worktree_fixture t33
+advance_origin_clean
+seed_local_plan_commit
+# Dirty the tracked noise file — a plain rebase would refuse without the stash.
+printf '{"committed":false,"dirty":true}\n' >"${GWORK}/.catalyst/config.json"
+(cd "$GWORK" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase implement --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1)
+assert_eq "yes" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "noise: dispatch still launched (clean rebase)"
+assert_eq '{"committed":false,"dirty":true}' "$(cat "${GWORK}/.catalyst/config.json")" \
+	"noise: dirty .catalyst/config.json content intact after the rebase"
+BASE_PRESENT="no"; [[ -f "${GWORK}/upstream.txt" ]] && BASE_PRESENT="yes"
+assert_eq "yes" "$BASE_PRESENT" "noise: rebase still advanced onto the new base"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-sequence.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-sequence.test.sh
@@ -107,6 +107,40 @@ else
   fi
 fi
 
+# ─── 7. CTL-667: REBASE_PHASES subset + exact-set drift guard ────────────────
+# REBASE_PHASES drives the dispatch-time front-load rebase (phase-agent-dispatch).
+# It must stay a strict subset of PHASES and equal exactly the named build set —
+# adding/removing a build phase forces a conscious update here.
+echo "test 7: REBASE_PHASES subset of PHASES + exact named build set"
+missing=""
+for rp in "${REBASE_PHASES[@]}"; do
+  found=0
+  for p in "${PHASES[@]}"; do [ "$p" = "$rp" ] && found=1; done
+  [ "$found" = "1" ] || missing="$missing $rp"
+done
+[ -z "$missing" ] \
+  && pass "every REBASE_PHASES element is present in PHASES" \
+  || fail "REBASE_PHASES is a subset of PHASES" "not in PHASES:$missing"
+EXPECTED_REBASE="research plan implement verify review"
+[ "${REBASE_PHASES[*]}" = "$EXPECTED_REBASE" ] \
+  && pass "REBASE_PHASES equals exactly 'research plan implement verify review'" \
+  || fail "REBASE_PHASES exact set" "got: '${REBASE_PHASES[*]}'"
+
+# ─── 8. CTL-667: monitor phases are excluded from the front-load rebase ──────
+# Regression guard for the exemption: monitor-merge/monitor-deploy operate on the
+# PR / merged SHA and have their own BEHIND handling — they must never rebase.
+echo "test 8: is_rebase_phase false for monitor-merge and monitor-deploy"
+if is_rebase_phase monitor-merge; then
+  fail "is_rebase_phase monitor-merge → false"
+else
+  pass "is_rebase_phase monitor-merge → false"
+fi
+if is_rebase_phase monitor-deploy; then
+  fail "is_rebase_phase monitor-deploy → false"
+else
+  pass "is_rebase_phase monitor-deploy → false"
+fi
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Shell tests for lib/worktree-rebase.sh + is_rebase_phase (CTL-667 Phase 1) —
+# front-load merge-conflict surfacing: mechanically rebase a build-phase
+# worktree onto origin/<base> at dispatch time.
+#
+# Builds a REAL git fixture (bare origin + working clone + an upstream-editor
+# clone) so the rebase helpers are exercised against actual git, not a stub.
+#
+# Run: bash plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REBASE_LIB="$LIB_DIR/worktree-rebase.sh"
+SEQUENCE_LIB="$LIB_DIR/phase-sequence.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t worktree-rebase-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Deterministic, non-interactive git everywhere.
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+export GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+assert_eq() {
+	local expected="$1" actual="$2" label="$3"
+	if [[ $expected == "$actual" ]]; then pass "$label"; else
+		fail "$label — expected '$expected', got '$actual'"
+	fi
+}
+
+# Source the units under test.
+# shellcheck source=../phase-sequence.sh
+source "$SEQUENCE_LIB"
+# shellcheck source=../worktree-rebase.sh
+source "$REBASE_LIB"
+
+# ─── Fixture builder ────────────────────────────────────────────────────────
+# new_fixture <tag> → sets ORIGIN (bare), WORK (clone, on branch `work`), UP
+# (upstream-editor clone, on main). Seeds an initial commit on main with
+# shared.txt (the conflict target) + a tracked .catalyst/config.json.
+new_fixture() {
+	local tag="$1"
+	ORIGIN="$SCRATCH/$tag/origin.git"
+	WORK="$SCRATCH/$tag/work"
+	UP="$SCRATCH/$tag/up"
+	git init --quiet --bare -b main "$ORIGIN"
+
+	git clone --quiet "$ORIGIN" "$UP"
+	(
+		cd "$UP"
+		printf 'base-line\n' >shared.txt
+		mkdir -p .catalyst
+		printf '{"committed":true}\n' >.catalyst/config.json
+		git add -A
+		git commit --quiet -m "initial"
+		git push --quiet origin main
+	)
+
+	git clone --quiet "$ORIGIN" "$WORK"
+	(cd "$WORK" && git checkout --quiet -b work)
+}
+
+# advance_origin_main_clean → push a NON-conflicting commit to origin/main
+# (touches a brand-new file only).
+advance_origin_main_clean() {
+	(
+		cd "$UP"
+		git checkout --quiet main
+		printf 'upstream-feature\n' >upstream.txt
+		git add -A
+		git commit --quiet -m "upstream clean feature"
+		git push --quiet origin main
+	)
+}
+
+# advance_origin_main_conflict → push a commit editing shared.txt's only line.
+advance_origin_main_conflict() {
+	(
+		cd "$UP"
+		git checkout --quiet main
+		printf 'upstream-edit\n' >shared.txt
+		git add -A
+		git commit --quiet -m "upstream conflicting edit"
+		git push --quiet origin main
+	)
+}
+
+echo "worktree-rebase tests (CTL-667)"
+
+# ── 1. is_rebase_phase: build phases true, the rest false ───────────────────
+echo "1. is_rebase_phase membership"
+for p in research plan implement verify review; do
+	if is_rebase_phase "$p"; then pass "is_rebase_phase $p → true"; else fail "is_rebase_phase $p → true"; fi
+done
+for p in triage pr remediate monitor-merge monitor-deploy bogus ""; do
+	if is_rebase_phase "$p"; then fail "is_rebase_phase '$p' → false"; else pass "is_rebase_phase '$p' → false"; fi
+done
+
+# ── 2. resolve_base_branch precedence ───────────────────────────────────────
+echo "2. resolve_base_branch"
+new_fixture t2
+(
+	cd "$WORK"
+	# (a) explicit override wins
+	CATALYST_BASE_BRANCH=develop bash -c "source '$REBASE_LIB'; resolve_base_branch"
+) >"$SCRATCH/t2.a" 2>/dev/null
+assert_eq "develop" "$(cat "$SCRATCH/t2.a")" "resolve_base_branch honors CATALYST_BASE_BRANCH"
+
+(
+	cd "$WORK"
+	unset CATALYST_BASE_BRANCH
+	# origin/HEAD is set by clone → default branch (main)
+	resolve_base_branch
+) >"$SCRATCH/t2.b" 2>/dev/null
+assert_eq "main" "$(cat "$SCRATCH/t2.b")" "resolve_base_branch uses origin/HEAD default branch"
+
+(
+	cd "$WORK"
+	unset CATALYST_BASE_BRANCH
+	git remote set-head origin --delete 2>/dev/null
+	resolve_base_branch
+) >"$SCRATCH/t2.c" 2>/dev/null
+assert_eq "main" "$(cat "$SCRATCH/t2.c")" "resolve_base_branch falls back to main with no origin/HEAD"
+
+# ── 3. noise_stash_push / noise_stash_pop ───────────────────────────────────
+echo "3. noise stash push/pop"
+new_fixture t3
+(
+	cd "$WORK"
+	# Dirty a tracked noise file + create an untracked .trunk/out entry.
+	printf '{"committed":false,"dirty":true}\n' >.catalyst/config.json
+	mkdir -p .trunk/out
+	printf 'cache-data\n' >.trunk/out/cache
+
+	marker="$(noise_stash_push)"
+	echo "$marker" >"$SCRATCH/t3.marker"
+	# After push, the working tree must be clean of the noise paths.
+	git status --porcelain >"$SCRATCH/t3.afterpush"
+	cat .catalyst/config.json >"$SCRATCH/t3.config_afterpush"
+
+	noise_stash_pop "$marker"
+	cat .catalyst/config.json >"$SCRATCH/t3.config_afterpop"
+	cat .trunk/out/cache 2>/dev/null >"$SCRATCH/t3.cache_afterpop" || true
+)
+assert_eq "1" "$(cat "$SCRATCH/t3.marker")" "noise_stash_push reports something stashed"
+assert_eq "" "$(cat "$SCRATCH/t3.afterpush")" "working tree clean of noise after push"
+assert_eq '{"committed":true}' "$(cat "$SCRATCH/t3.config_afterpush")" "config reverted to committed content after push"
+assert_eq '{"committed":false,"dirty":true}' "$(cat "$SCRATCH/t3.config_afterpop")" "config dirty content restored after pop"
+assert_eq "cache-data" "$(cat "$SCRATCH/t3.cache_afterpop")" "untracked .trunk/out/cache restored after pop"
+
+# nothing-to-stash → push no-op (empty marker), pop safe no-op (rc 0)
+new_fixture t3b
+(
+	cd "$WORK"
+	marker="$(noise_stash_push)"
+	echo "$marker" >"$SCRATCH/t3b.marker"
+	noise_stash_pop "$marker"
+	echo "$?" >"$SCRATCH/t3b.poprc"
+)
+assert_eq "" "$(cat "$SCRATCH/t3b.marker")" "noise_stash_push no-op marker when nothing present/dirty"
+assert_eq "0" "$(cat "$SCRATCH/t3b.poprc")" "noise_stash_pop safe no-op returns 0"
+
+# ── 4. rebase_onto_base — clean ─────────────────────────────────────────────
+echo "4. rebase_onto_base clean"
+new_fixture t4
+advance_origin_main_clean
+(
+	cd "$WORK"
+	# local non-conflicting commit on a new file
+	printf 'local-feature\n' >local.txt
+	git add -A
+	git commit --quiet -m "local feature"
+	rebase_onto_base "main"
+	echo "$?" >"$SCRATCH/t4.rc"
+	# both the rebased local commit and the new base commit are present
+	[[ -f local.txt && -f upstream.txt ]] && echo yes >"$SCRATCH/t4.bothfiles" || echo no >"$SCRATCH/t4.bothfiles"
+	[[ -d .git/rebase-merge ]] && echo leftover >"$SCRATCH/t4.rebasedir" || echo clean >"$SCRATCH/t4.rebasedir"
+)
+assert_eq "0" "$(cat "$SCRATCH/t4.rc")" "clean rebase returns 0"
+assert_eq "yes" "$(cat "$SCRATCH/t4.bothfiles")" "clean rebase: both local + base commits present"
+assert_eq "clean" "$(cat "$SCRATCH/t4.rebasedir")" "clean rebase: no .git/rebase-merge left behind"
+
+# ── 5. rebase_onto_base — conflict (abort + sentinel 2) ─────────────────────
+echo "5. rebase_onto_base conflict"
+new_fixture t5
+advance_origin_main_conflict
+(
+	cd "$WORK"
+	printf 'local-edit\n' >shared.txt
+	git add -A
+	git commit --quiet -m "local conflicting edit"
+	ORIG_HEAD="$(git rev-parse HEAD)"
+	echo "$ORIG_HEAD" >"$SCRATCH/t5.orig"
+	rebase_onto_base "main"
+	echo "$?" >"$SCRATCH/t5.rc"
+	git rev-parse HEAD >"$SCRATCH/t5.head"
+	[[ -d .git/rebase-merge ]] && echo leftover >"$SCRATCH/t5.rebasedir" || echo clean >"$SCRATCH/t5.rebasedir"
+	git status --porcelain >"$SCRATCH/t5.status"
+)
+assert_eq "2" "$(cat "$SCRATCH/t5.rc")" "conflicting rebase returns sentinel 2"
+assert_eq "$(cat "$SCRATCH/t5.orig")" "$(cat "$SCRATCH/t5.head")" "conflict abort: HEAD back at original local commit"
+assert_eq "clean" "$(cat "$SCRATCH/t5.rebasedir")" "conflict abort: no .git/rebase-merge left behind"
+assert_eq "" "$(cat "$SCRATCH/t5.status")" "conflict abort: working tree clean"
+
+# ── 6. rebase_onto_base — noise stashed across a clean rebase ───────────────
+echo "6. rebase_onto_base survives dirty noise"
+new_fixture t6
+advance_origin_main_clean
+(
+	cd "$WORK"
+	printf 'local-feature\n' >local.txt
+	git add -A
+	git commit --quiet -m "local feature"
+	# Dirty a tracked noise file — plain rebase would refuse without a stash.
+	printf '{"committed":false,"dirty":true}\n' >.catalyst/config.json
+	rebase_onto_base "main"
+	echo "$?" >"$SCRATCH/t6.rc"
+	cat .catalyst/config.json >"$SCRATCH/t6.config"
+	[[ -f upstream.txt ]] && echo yes >"$SCRATCH/t6.base" || echo no >"$SCRATCH/t6.base"
+)
+assert_eq "0" "$(cat "$SCRATCH/t6.rc")" "clean rebase with dirty noise returns 0 (noise stashed)"
+assert_eq '{"committed":false,"dirty":true}' "$(cat "$SCRATCH/t6.config")" "dirty noise restored after rebase"
+assert_eq "yes" "$(cat "$SCRATCH/t6.base")" "rebase still advanced onto new base"
+
+echo
+echo "results: $PASSES passed, $FAILURES failed"
+[ $FAILURES -eq 0 ]

--- a/plugins/dev/scripts/lib/phase-sequence.sh
+++ b/plugins/dev/scripts/lib/phase-sequence.sh
@@ -15,6 +15,22 @@
 # shellcheck disable=SC2034  # PHASES is consumed by sourcing scripts
 PHASES=(triage research plan implement verify review pr monitor-merge monitor-deploy)
 
+# CTL-667: the BUILD phases that get a fresh-dispatch rebase onto origin/<base>.
+# Strict subset of PHASES — keep in that set (the phase-sequence drift test +
+# the CTL-667 subset guard assert this). triage/pr/remediate and the monitor-*
+# phases are intentionally excluded (see plan: What We're NOT Doing).
+# shellcheck disable=SC2034  # REBASE_PHASES is consumed by sourcing scripts
+REBASE_PHASES=(research plan implement verify review)
+
+# is_rebase_phase PHASE → exit 0 if PHASE is a front-load-rebase build phase.
+is_rebase_phase() {
+  local phase="$1" p
+  for p in "${REBASE_PHASES[@]}"; do
+    [[ $p == "$phase" ]] && return 0
+  done
+  return 1
+}
+
 # latest_phase_in_dir DIR
 # Echoes the highest-index PHASES entry that has a workers/<T>/phase-<name>.json
 # present in DIR, or the empty string if none. Mirrors scheduler.mjs:270

--- a/plugins/dev/scripts/lib/worktree-rebase.sh
+++ b/plugins/dev/scripts/lib/worktree-rebase.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# lib/worktree-rebase.sh — CTL-667: front-load merge-conflict surfacing.
+# Mechanically rebase a build-phase worktree onto origin/<base> at dispatch
+# time, stashing machine-local noise (.catalyst/config.json, .trunk/* symlink
+# dirs) across the rebase. Clean → 0; conflict → abort + restore + 2.
+# Pure git/bash; NO claude, NO force-push, NO PR interaction.
+
+set -uo pipefail
+
+# Single source of truth for the machine-local noise paths (mirrors the
+# operator pattern in memory/project_worktree_noise_before_pr.md).
+# shellcheck disable=SC2034
+WORKTREE_NOISE_PATHS=(
+  .catalyst/config.json
+  .trunk/actions .trunk/logs .trunk/notifications .trunk/out .trunk/tools
+)
+
+# resolve_base_branch → echoes the rebase target branch name (no origin/ prefix).
+resolve_base_branch() {
+  if [[ -n ${CATALYST_BASE_BRANCH:-} ]]; then printf '%s' "$CATALYST_BASE_BRANCH"; return 0; fi
+  local head
+  head="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)" \
+    && { printf '%s' "${head#origin/}"; return 0; }
+  printf 'main'
+}
+
+# noise_stash_push → stash only the noise paths that are actually present/dirty.
+# Echoes a marker ("1" = something stashed, "" = nothing) on stdout so the
+# caller knows whether to pop. Returns 0 on success.
+noise_stash_push() {
+  local present=()
+  local p
+  for p in "${WORKTREE_NOISE_PATHS[@]}"; do
+    [[ -e $p ]] && present+=("$p")
+  done
+  [[ ${#present[@]} -eq 0 ]] && { printf ''; return 0; }
+  # Only stash if at least one present noise path is actually dirty/untracked.
+  # On modern git a pathspec `git stash push` over CLEAN paths is a silent
+  # no-op (rc 0, no stash entry created) — so keying the marker off the exit
+  # code alone would report "1" with no stash on the stack, and a later
+  # noise_stash_pop would then pop an UNRELATED stash. Gate on a porcelain
+  # dirty-check so the marker can never lie.
+  local dirty
+  dirty="$(git status --porcelain -- "${present[@]}" 2>/dev/null)"
+  [[ -z $dirty ]] && { printf ''; return 0; }
+  if git stash push --include-untracked --quiet \
+       -m "catalyst-worktree-rebase-noise" -- "${present[@]}" 2>/dev/null; then
+    printf '1'
+  else
+    printf ''   # nothing got stashed (e.g. all ignored & clean) — pop must no-op
+  fi
+  return 0
+}
+
+# noise_stash_pop MARKER → restore the noise stash if push reported one.
+# Best-effort: a pop conflict prefers the stashed (machine-local) copy and drops
+# the stash, since these paths are intentionally machine-local noise.
+noise_stash_pop() {
+  local marker="$1"
+  [[ -z $marker ]] && return 0
+  if git stash pop --quiet 2>/dev/null; then return 0; fi
+  # Rare: base touched a noise path. Prefer our stashed copy, then drop.
+  git checkout --theirs -- "${WORKTREE_NOISE_PATHS[@]}" 2>/dev/null || true
+  git stash drop --quiet 2>/dev/null || true
+  return 0
+}
+
+# rebase_onto_base BASE → 0 clean, 2 conflict (aborted), 1 fetch/other failure.
+rebase_onto_base() {
+  local base="$1" marker
+  git fetch --quiet origin "$base" 2>/dev/null || return 1
+  marker="$(noise_stash_push)"
+  if git rebase --quiet "origin/${base}" 2>/dev/null; then
+    noise_stash_pop "$marker"
+    return 0
+  fi
+  git rebase --abort 2>/dev/null || true
+  noise_stash_pop "$marker"
+  return 2
+}

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -66,6 +66,17 @@ source "${SCRIPT_DIR}/lib/executor.sh"
 # shellcheck source=lib/resume.sh
 source "${SCRIPT_DIR}/lib/resume.sh"
 
+# CTL-667: front-load merge-conflict surfacing. phase-sequence.sh provides the
+# is_rebase_phase build-phase predicate; worktree-rebase.sh provides the
+# mechanical fetch + noise-stash + rebase (resolve_base_branch / rebase_onto_base).
+# The fresh-dispatch rebase block (before the launch fork below) calls both so a
+# build phase starts current with merged sibling work and a conflict surfaces here
+# instead of at monitor-merge. See thoughts/shared/plans/2026-05-27-ctl-667.md.
+# shellcheck source=lib/phase-sequence.sh
+source "${SCRIPT_DIR}/lib/phase-sequence.sh"
+# shellcheck source=lib/worktree-rebase.sh
+source "${SCRIPT_DIR}/lib/worktree-rebase.sh"
+
 die() {
 	echo "phase-agent-dispatch: $*" >&2
 	exit 1
@@ -561,6 +572,54 @@ if [[ $DRY_RUN -eq 1 ]]; then
       resumeSession: (if $resumeSession == "" then null else $resumeSession end),
       env: $env, status: "dispatched", dryRun: true}'
 	exit 0
+fi
+
+# ─── CTL-667: front-load merge-conflict surfacing ──────────────────────────
+# On a FRESH dispatch of a BUILD phase, rebase this worktree (cwd) onto current
+# origin/<base> so the worker starts current with merged sibling work and any
+# conflict surfaces HERE instead of at monitor-merge. Resume dispatches
+# (RESUME_SESSION set) are skipped — the resumed session assumes the prior tree
+# (CTL-658). Non-build phases (triage/pr/remediate/monitor-*) are skipped.
+# Placed after the --dry-run early-exit (a dry run must never mutate the tree)
+# and before the launch fork. Local-only: no push, no PR interaction (build
+# branches aren't pushed until phase-pr). Helpers live in lib/worktree-rebase.sh.
+if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
+	BASE_BRANCH="$(resolve_base_branch)"
+	rebase_onto_base "$BASE_BRANCH"
+	REBASE_RC=$?
+	if [[ $REBASE_RC -eq 2 ]]; then
+		# Textual conflict with origin/<base>. Do NOT auto-resolve. Park the
+		# phase to needs-human and do NOT launch a worker. We use failureReason
+		# (not attentionReason) so neither the daemon (TERMINAL-classified →
+		# no revive) nor bash orchestrate-revive retries into the same conflict.
+		echo "phase-agent-dispatch: rebase onto origin/${BASE_BRANCH} conflicted for ${TICKET}/${PHASE}; parking" >&2
+		TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+		tmp="${SIGNAL_FILE}.tmp.$$"
+		if jq --arg ts "$TS" \
+			'.status = "stalled"
+       | .failureReason = "rebase_conflict_with_origin_main"
+       | .updatedAt = $ts
+       | .phaseTimestamps = ((.phaseTimestamps // {}) | .stalled = $ts)' \
+			"$SIGNAL_FILE" >"$tmp" 2>/dev/null; then
+			mv "$tmp" "$SIGNAL_FILE"
+		else
+			rm -f "$tmp"
+		fi
+		if [[ -x $EMIT_COMPLETE ]]; then
+			"$EMIT_COMPLETE" --phase "$PHASE" --ticket "$TICKET" --status failed \
+				--reason "rebase_conflict_with_origin_main" \
+				--orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+				--no-signal-update >/dev/null 2>&1 || true
+		fi
+		jq -n --arg status "stalled" --arg reason "rebase_conflict_with_origin_main" \
+			--arg signal "$SIGNAL_FILE" \
+			'. + {status: $status, reason: $reason, signalFile: $signal}' <<<'{}'
+		exit 1
+	elif [[ $REBASE_RC -ne 0 ]]; then
+		# fetch/other transient failure — log and proceed un-rebased (status quo;
+		# monitor-merge still catches divergence). Do NOT block the phase.
+		echo "phase-agent-dispatch: rebase preflight skipped (rc=$REBASE_RC) for ${TICKET}/${PHASE}; proceeding un-rebased" >&2
+	fi
 fi
 
 # Spawn the phase agent. `claude --bg` writes the new job ID to stdout as


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-27T17:59:45Z -->
<!-- Last updated: 2026-05-27T17:59:45Z -->
<!-- PR: #1116 -->
<!-- Previous commits: e70cb7b1e1ded05d28e3112a6cb56fbdf2866ff7,8da4dd0a86664d0c16131022d238e5de7d540819 -->

## Summary

Front-loads merge-conflict surfacing across the phase-agent pipeline. At the
start of each BUILD phase (research / plan / implement / verify / review) the
ticket's worktree is rebased onto current `origin/main` — injected into
`phase-agent-dispatch` just before the `claude --bg` launch, mirroring
`create-worktree`'s existing fetch+reset. In-flight branches stay current with
merged sibling work, so conflicts appear early at dispatch instead of late at
monitor-merge.

`monitor-merge` / `monitor-deploy` are **exempt** — they operate on the open PR
/ merged SHA and have their own BEHIND handling.

Conflict policy:

- **Clean rebase** → proceed with launch.
- **Rebase conflict** (rc 2) → do *not* auto-resolve; park the signal
  (`status=stalled`, `failureReason=rebase_conflict_with_origin_main`), emit
  `phase.<phase>.failed`, exit 1 without launching (FSM routes to needs-input).
- **Transient fetch failure** (rc 1) → proceed un-rebased; monitor-merge's
  BEHIND handling is the backstop.

Machine-local worktree noise (`.trunk/*`, `.catalyst/config.json` drift) is
stashed before the rebase and restored after. A resumed session is never
rebased (CTL-658 — resume must not re-apply a rebase mid-flight).

## Changes Made

**Phase 1 — building blocks** (`e70cb7b1`)
- `lib/phase-sequence.sh`: `REBASE_PHASES` (research plan implement verify review)
  + `is_rebase_phase` predicate, a strict subset of `PHASES`.
- `lib/worktree-rebase.sh` (new): `resolve_base_branch`, `noise_stash_push/pop`
  (`.catalyst/config.json` + `.trunk/*` across the rebase), `rebase_onto_base`
  (clean→0, conflict→abort+2, fetch-fail→1). Pure git/bash — no claude, no
  force-push, no PR interaction. `noise_stash_push` gates on a
  `git status --porcelain` dirty-check so the stash marker is truthful (a
  pathspec stash over clean paths returns rc 0 but creates no entry — keying
  the marker off the exit code alone would manufacture a phantom stash).

**Phase 2 — dispatch wiring** (`8da4dd0a`)
- `phase-agent-dispatch` sources the libs and, on a fresh dispatch of a build
  phase (after the `--dry-run` early-exit, before the launch fork), rebases the
  worktree onto `origin/<base>` with the clean/conflict/transient handling above.

**Phase 3 — drift guard + docs** (`8da4dd0a`)
- `phase-sequence.test.sh` asserts `REBASE_PHASES ⊂ PHASES`, equals exactly the
  named build set, and that `is_rebase_phase` is false for monitor-merge /
  monitor-deploy.
- Documented the dispatch-time rebase + conflict→needs-human routing in
  `docs/architecture.md` (Phase-Agent Communication) and
  `docs/orchestrator-overview.md`.

## Files Changed (8 files, +648 / -0)

- `plugins/dev/scripts/lib/phase-sequence.sh`
- `plugins/dev/scripts/lib/worktree-rebase.sh` (new)
- `plugins/dev/scripts/phase-agent-dispatch`
- `plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh` (new)
- `plugins/dev/scripts/__tests__/phase-sequence.test.sh`
- `plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh`
- `docs/architecture.md`
- `docs/orchestrator-overview.md`

## How to Verify It

Verification surfaced from the verify phase (regression risk **1 / 10**):

- [x] **Tests** — worktree-rebase 32/32; phase-sequence 10/10 (incl.
  `REBASE_PHASES` subset + monitor-exclusion guards); phase-agent-dispatch
  119/119 (incl. CTL-667 cases 28–33); dispatch-name 6/6; dispatch-test-kill 14/14.
- [x] **Lint** — shellcheck -x clean on `worktree-rebase.sh` + `phase-sequence.sh`;
  only pre-existing SC1091 info on `phase-agent-dispatch`.
- [x] **Typecheck** — n/a (bash + markdown only).
- [x] **Reward-hacking scan** — clean (bash-only diff).
- [x] **Completeness** — all 3 plan phases landed, verified file-by-file vs the
  plan's Desired-End-State.

## Related Issues/PRs

- Refs: CTL-667
