### PR TITLE
CTL-662: status-based reclaim — retire mtime false-dead triggers

### DIFF
--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -62,6 +62,35 @@ export function isBgJobAlive(bgJobId, { exec, agents } = {}) {
   return agentForShortId(shortId, list) !== null;
 }
 
+// livenessForBgJob — the THREE-valued liveness CTL-662's reclaim keys on:
+//   "busy"   — a live session with an open turn (or present but status not
+//              explicitly "idle": active/null/unknown all normalize to busy, the
+//              conservative direction — we never reclaim a worker we cannot PROVE
+//              is idle). A busy worker is NEVER auto-reclaimed regardless of how
+//              long its state.json mtime has been stale (the CTL-662 fix: an
+//              in-process sub-agent fan-out keeps the parent's turn busy while
+//              mtime goes stale).
+//   "idle"   — a live session with status "idle" (registered, between turns).
+//              Reclaim-eligible, but only after the caller's idle-confirmation.
+//   "absent" — not a live `claude agents` session (crashed/exited). Dead.
+// isBgJobAlive stays for the presence-only concurrency callers; this is the
+// status-aware superset. Best-effort: any doubt (falsy/malformed id, failed
+// `claude agents` read) returns "absent" so the caller falls through to its
+// existing recovery path — same fail direction as isBgJobAlive returning false.
+export function livenessForBgJob(bgJobId, { exec, agents } = {}) {
+  if (!bgJobId) return "absent";
+  let shortId;
+  try {
+    shortId = shortIdFromSessionId(bgJobId);
+  } catch {
+    return "absent";
+  }
+  const list = agents ?? listClaudeAgents({ exec });
+  const agent = agentForShortId(shortId, list);
+  if (!agent) return "absent";
+  return agent.status === "idle" ? "idle" : "busy";
+}
+
 // countBackgroundAgents — number of live sessions with kind === "background".
 // The scheduler's concurrency gate: interactive (human) sessions are unlimited
 // and MUST NOT count against maxParallel, so only `background` agents are

--- a/plugins/dev/scripts/execution-core/claude-agents.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.test.mjs
@@ -8,6 +8,7 @@ import {
   listClaudeAgents,
   agentForShortId,
   isBgJobAlive,
+  livenessForBgJob,
   countBackgroundAgents,
   claudeStop,
 } from "./claude-agents.mjs";
@@ -76,6 +77,46 @@ describe("isBgJobAlive", () => {
   test("falls back to listing agents when no list is injected", () => {
     expect(isBgJobAlive("22222222", { exec: () => JSON.stringify(agents) })).toBe(true);
   });
+});
+
+describe("livenessForBgJob", () => {
+  // CTL-662 — the THREE-valued status reader reclaim keys on. Reuses the
+  // canonical status fixture shape `{ sessionId, status, kind }`. Covers the
+  // three-valued contract and the conservative present-but-not-idle ⇒ busy
+  // normalization (never reclaim a present worker we cannot PROVE is idle).
+  const statusAgents = [
+    { sessionId: "11111111-aaaa-bbbb-cccc-000000000001", status: "busy", kind: "background" },
+    { sessionId: "22222222-aaaa-bbbb-cccc-000000000002", status: "idle", kind: "background" },
+    { sessionId: "33333333-aaaa-bbbb-cccc-000000000003", status: "active", kind: "background" }, // synonym for busy
+    { sessionId: "44444444-aaaa-bbbb-cccc-000000000004", status: null, kind: "background" }, // present, status unknown
+  ];
+
+  test("present + status idle → 'idle'", () =>
+    expect(livenessForBgJob("22222222", { agents: statusAgents })).toBe("idle"));
+  test("present + status busy → 'busy'", () =>
+    expect(livenessForBgJob("11111111", { agents: statusAgents })).toBe("busy"));
+  test("present + status 'active' (busy synonym) → 'busy'", () =>
+    expect(livenessForBgJob("33333333", { agents: statusAgents })).toBe("busy"));
+  test("present + null status (unknown) → 'busy' (conservative: never reclaim a present worker we can't prove idle)", () =>
+    expect(livenessForBgJob("44444444", { agents: statusAgents })).toBe("busy"));
+  test("not listed → 'absent'", () =>
+    expect(livenessForBgJob("99999999", { agents: statusAgents })).toBe("absent"));
+  test("empty/falsy bgJobId → 'absent'", () =>
+    expect(livenessForBgJob("", { agents: statusAgents })).toBe("absent"));
+  test("malformed id (throws in shortIdFromSessionId, e.g. 'bg-9') → 'absent' WITHOUT shelling out", () =>
+    expect(livenessForBgJob("bg-9", { agents: statusAgents })).toBe("absent"));
+  test("failed `claude agents` read (exec throws) → 'absent'", () =>
+    expect(
+      livenessForBgJob("11111111", {
+        exec: () => {
+          throw new Error("boom");
+        },
+      }),
+    ).toBe("absent"));
+  test("accepts the full UUID form (truncates to the short id)", () =>
+    expect(
+      livenessForBgJob("22222222-aaaa-bbbb-cccc-000000000002", { agents: statusAgents }),
+    ).toBe("idle"));
 });
 
 describe("countBackgroundAgents", () => {

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -121,3 +121,21 @@ export const EVENT_DEBOUNCE_MS =
 // matching the legacy `date -u -v-15M` cutoff in orchestrate/SKILL.md.
 export const STALE_WORKER_CUTOFF_MS =
   Number(process.env.EXECUTION_CORE_STALE_WORKER_CUTOFF_MS) || 15 * 60_000;
+
+// CTL-662 — idle-confirmation streak length. A phase worker observed `idle` by
+// `claude agents` is reclaim-eligible only after this many CONSECUTIVE idle
+// observations (a counter persisted on the signal, NOT an mtime window). A
+// couple of ticks confirms the worker is genuinely between-turns done, not
+// momentarily idle between sub-agent fan-out rounds. Env-overridable so tuning
+// from real failures needs no code change (the operator decision on the ticket).
+export const IDLE_CONFIRM_TICKS =
+  Number(process.env.EXECUTION_CORE_IDLE_CONFIRM_TICKS) || 2;
+
+// CTL-662 — busy-forever backstop ceiling. With STALE_MS / HUNG_CUTOFF_MS gone,
+// this is the SOLE long backstop: a worker that stays `busy` past this elapsed
+// time with no committed work flags for human (escalateOnce) — NEVER a silent
+// reclaim-and-advance. Deliberately high (6h) so a legitimate multi-hour
+// sub-agent fan-out or a future Linear-webhook waiter never trips it; only a
+// genuinely wedged worker does. Env-overridable for tuning.
+export const BUSY_CEILING_MS =
+  Number(process.env.EXECUTION_CORE_BUSY_CEILING_MS) || 6 * 60 * 60_000;

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1149,11 +1149,14 @@ export function reclaimDeadWorkIfPossible(
         reason: "ctl-661-reclaim-happy-path",
       }).catch(() => {});
     }
-    // CTL-664: derive the reclaim observability fields from values already
-    // computed above. `death_signal` distinguishes an absent bg job (klass
-    // 'dead') from a running-but-stale one (mtime); kept as a single const so
-    // Phase 3's mirror body reuses it without recomputation.
-    const death_signal = klass === "dead" ? "absent" : "mtime";
+    // CTL-664/CTL-662: derive the reclaim observability fields from values
+    // already computed above. Post-CTL-662 this reclaim branch is reached ONLY
+    // for an `absent` bg job or an idle-confirmed one — `busy` returns at
+    // alive-busy-suppressed and an unconfirmed `idle` returns at idle-pending
+    // above, and mtime is no longer a reclaim trigger. So the death signal
+    // reflects the liveness verdict the trigger actually acted on, never the
+    // obsolete "mtime". Kept as a single const so the mirror body reuses it.
+    const death_signal = live === "absent" ? "absent" : "idle-confirmed";
     const probe_checked = describeProbe(phase);
     appendEvent({
       phase,

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -17,6 +17,7 @@ import {
   writeFileSync,
   renameSync,
   existsSync,
+  rmSync,
 } from "node:fs";
 import { dirname } from "node:path";
 import { join, basename } from "node:path";
@@ -24,13 +25,19 @@ import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
-import { getJobsRoot, getEventLogPath, log } from "./config.mjs";
+import {
+  getJobsRoot,
+  getEventLogPath,
+  log,
+  IDLE_CONFIRM_TICKS,
+  BUSY_CEILING_MS,
+} from "./config.mjs";
 import { phaseIndex } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
 import { emitReapIntent as emitReapIntentDefault } from "./reap-intent.mjs";
-import { isBgJobAlive, claudeStop } from "./claude-agents.mjs";
+import { livenessForBgJob, claudeStop } from "./claude-agents.mjs";
 import { shortIdFromSessionId } from "./claude-ids.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { WORK_DONE_PROBES, hasProbe, describeProbe } from "./work-done-probes.mjs";
@@ -635,25 +642,13 @@ export function defaultKillBgJob({ bgJobId }, { stop = claudeStop } = {}) {
   }
 }
 
-// defaultPidAlive — positive keep-alive check (CTL-610, rebuilt for CTL-657).
-// Returns true iff the bg worker is still a live `claude agents` session. It
-// signals "alive, do not revive", never kills. Pre-CTL-657 this read
-// ~/.claude/jobs/<id>/pid — absent on CC 2.1.152, so it ALWAYS returned false
-// and the daemon false-dead-revived every live worker (the 79-event revive
-// storm this ticket exists to kill). Now liveness comes from `claude agents`:
-// a crashed worker drops off the list, a live one (busy or idle between turns)
-// stays. Best-effort: any doubt (falsy/malformed id, failed `claude agents`
-// read) returns false so the caller falls through to its existing revive path.
-// A non-short-id ("bg-9" test fixture) returns false WITHOUT shelling out, so
-// every pre-CTL-610 revive test stays green unchanged. `isAlive` is injectable
-// for tests; the production default queries the real `claude agents`.
-export function defaultPidAlive({ bgJobId }, { isAlive = isBgJobAlive } = {}) {
-  try {
-    return isAlive(bgJobId);
-  } catch {
-    return false;
-  }
-}
+// CTL-662 removed defaultPidAlive (the CTL-610/657 positive keep-alive seam).
+// Its sole consumer was the alive-quiet gate's `pidAlive` injection, which is
+// gone: reclaim eligibility no longer asks "is the bg pid alive?" (a binary
+// presence check) but "what is the worker's `claude agents` status?" (the
+// three-valued busy|idle|absent reader livenessForBgJob). Presence is now
+// subsumed by `absent` (not listed → dead), so a separate pidAlive helper is
+// redundant.
 
 // ──────────────────────────────────────────────────────────────────────────
 // CTL-655: daemon-boot marker. The daemon writes this once at startup
@@ -824,97 +819,115 @@ function defaultWriteReviveMarker({ orchDir, ticket, attempt }) {
   }
 }
 
-// STALE_MS — a healthy claude --bg worker updates ~/.claude/jobs/<id>/state.json
-// every few seconds (heartbeats, output appends, scan offsets). A state.json
-// untouched longer than this is conclusive evidence the worker stopped (CTL-588).
-// 5 minutes is a generous gap that won't false-positive a worker idling on a
-// long tool call.
-const STALE_MS = 5 * 60 * 1000;
+// CTL-662 — the reclaim death-trigger is now the worker's `claude agents`
+// status (busy/idle/absent via livenessForBgJob), NOT state.json mtime. The
+// three pre-CTL-662 time triggers (the 5-min mtime-staleness death flag, the
+// CTL-587 defensive-kill quiet-window gate, and the CTL-610 keep-alive ceiling)
+// are all gone: an in-process sub-agent fan-out keeps the parent's turn `busy`
+// while state.json mtime goes stale, so mtime is a false death signal (the
+// proven worker-10d6f123 failure). Reclaim eligibility is driven by status + an
+// idle-confirmation streak (IDLE_CONFIRM_TICKS) and bounded only by the high
+// BUSY_CEILING_MS no-progress human-flag backstop — both env-overridable
+// tunables imported from config.mjs.
 
 // CTL-587 — auto-revival constants. MAX_REVIVES is the per-ticket budget
 // (counted from events.jsonl). STORM_WINDOW_MS + STORM_THRESHOLD form the
 // breaker that suppresses revives when too many tickets are reviving at once
-// (a Linear-side or fleet-wide outage). KILL_RECENT_ACTIVITY_MS gates the
-// defensive SIGKILL: only fire when the bg state.json has been quiet for that
-// long — i.e. the worker really is gone, not just idling on a long tool call.
+// (a Linear-side or fleet-wide outage).
 const MAX_REVIVES = 2;
 const STORM_WINDOW_MS = 10 * 60 * 1000;
 const STORM_THRESHOLD = 3;
-const KILL_RECENT_ACTIVITY_MS = 30 * 1000;
 
-// CTL-610 — hung cutoff for the alive-quiet keep-alive guard. A worker flagged
-// effectively-dead by stale state.json mtime but whose bg pid is still a live
-// `claude` process is alive-but-blocked-on-a-long-tool-call (a research/plan
-// sub-agent fan-out, or a long synchronous Edit/Bash inside implement), not
-// crashed — so we suppress its revive up to this bound. Past it, even a live
-// pid is treated as genuinely hung and revived as before. 15 minutes matches
-// the legacy STALE_BG_SECONDS the original ticket cites — a live worker gets
-// the full original grace before we conclude it is hung.
-const HUNG_CUTOFF_MS = 15 * 60 * 1000;
+// CTL-662 — idle-confirmation streak markers. The consecutive-idle-observation
+// counter is persisted as a per-(ticket, phase) worker-dir marker
+// (`.idle-streak-<phase>`), the same durable-state mechanism as the CTL-587
+// .revive-N.applied markers and the CTL-638 escalation cool-downs — a PERSISTED
+// counter, NOT an mtime window (the invariant the plan requires). A re-dispatch
+// recreates the worker dir, so the streak naturally resets on revive.
+function idleStreakMarkerPath(orchDir, ticket, phase) {
+  return join(orchDir, "workers", ticket, `.idle-streak-${phase}`);
+}
+function defaultReadIdleStreak(orchDir, ticket, phase) {
+  try {
+    const n = parseInt(readFileSync(idleStreakMarkerPath(orchDir, ticket, phase), "utf8"), 10);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  } catch {
+    return 0; // marker absent → no prior idle observation
+  }
+}
+// defaultBumpIdleStreak — increment + persist the counter, returning the NEW
+// count. Fail-open: a write failure returns the would-be count so a transient
+// fs error never wedges the streak (worst case: one extra idle tick before
+// reclaim, harmless).
+function defaultBumpIdleStreak(orchDir, ticket, phase) {
+  const next = defaultReadIdleStreak(orchDir, ticket, phase) + 1;
+  try {
+    writeFileSync(idleStreakMarkerPath(orchDir, ticket, phase), String(next));
+  } catch (err) {
+    log.warn({ ticket, phase, err: err.message }, "ctl-662: idle-streak write failed");
+  }
+  return next;
+}
+function defaultResetIdleStreak(orchDir, ticket, phase) {
+  try {
+    const path = idleStreakMarkerPath(orchDir, ticket, phase);
+    if (existsSync(path)) rmSync(path);
+  } catch {
+    /* best-effort — a stale streak marker only delays the next reclaim by ticks */
+  }
+}
 
-// reclaimDeadWorkIfPossible — one signal in, one decision out. CTL-587 widens
-// the return set from CTL-574's five values to seven, transforming the two
-// silent dead-ends ('not-applicable' and 'not-done') into actionable outcomes:
+// reclaimDeadWorkIfPossible — one signal in, one decision out. CTL-662 swaps the
+// death TRIGGER from state.json mtime (the false signal: an in-process sub-agent
+// fan-out keeps the parent's turn busy while mtime goes stale) to the worker's
+// `claude agents` status via livenessForBgJob → busy|idle|absent. Every
+// CTL-587/606/610/661 behavioral guarantee on the reclaim-eligible path below is
+// preserved; only what makes a worker reclaim-eligible changes. The return set:
 //
-//   'noop'                not effectively dead (terminal / unknown / live).
-//                         No action.
-//   'reclaimed'           effectively dead + work IS done. CTL-574 happy path
-//                         — canonical reclaim audit appended, emit-complete
+//   'noop'                classifyWorker says terminal (phase finished) or
+//                         unknown (no bg_job_id). No action.
+//   'alive-busy-suppressed' worker is `busy` (a live session with an open turn —
+//                         including the in-process sub-agent fan-out that keeps
+//                         the parent busy while state.json mtime goes stale: the
+//                         CTL-662 false-reclaim fix). NEVER auto-reclaimed at any
+//                         elapsed time. Resets the idle streak. The sole permitted
+//                         action is the BUSY_CEILING_MS no-progress backstop.
+//   'idle-pending'        worker is `idle` (live, between turns) but has not yet
+//                         reached idleConfirmTicks consecutive idle observations.
+//                         Streak incremented + persisted; no reclaim this tick.
+//   'reclaimed'           reclaim-eligible (absent, or idle-confirmed) + work IS
+//                         done. Canonical reclaim audit appended, emit-complete
 //                         flipped the signal, session ended.
-//   'reclaim-failed'      effectively dead + work IS done BUT emit-complete
-//                         exited non-zero. Signal NOT mutated (atomic rename);
-//                         next tick retries.
-//   'revived'             effectively dead + probe says work NOT done + revive
-//                         budget available + storm-breaker closed. Signal was
-//                         reset to 'stalled' to bypass the dispatcher's
-//                         idempotency guard; defaultDispatch was invoked; the
-//                         worker-dir .revive-N.applied marker was written.
-//                         CTL-604: implement/research/plan (every probed phase)
-//                         share this path — a probed worker that died before
-//                         writing its artifact is re-dispatched, not escalated.
-//   'revive-suppressed'   effectively dead + work NOT done + storm-breaker
-//                         OPEN (>3 distinct tickets reviving in last 10min).
-//                         No dispatch; suppress event audited; next tick
-//                         re-evaluates the window.
-//   'escalated'           effectively dead + (revive budget exhausted OR no
-//                         work-done probe registered for this phase — i.e. a
-//                         probe-less phase: verify/review/pr/monitor-*).
-//                         needs-human label applied (via the CTL-587 verified
-//                         applyLabel); ticket stays where it is for human triage.
-//   'superseded-noop'     effectively dead BUT the signal's phase precedes the
-//                         ticket's latest-dispatched phase (CTL-606). The ticket
-//                         has already advanced; the dead signal is a leftover
-//                         predecessor (left at `running`, never flipped to
-//                         `done`) that readWorkerSignals→byActivePhase ranked
-//                         ahead of the genuinely-active terminal phase. No
-//                         escalate/revive/reclaim — acting would spuriously flag
-//                         needs-human or spawn a duplicate worker at a past phase.
-//   'alive-quiet-suppressed' effectively dead by state.json mtime BUT the bg pid
-//                         is still a live `claude agents` session within
-//                         HUNG_CUTOFF_MS (CTL-610). The worker is alive-blocked-
-//                         on-a-long-tool-call (the pre-first-output window for
-//                         research/plan, or a long sync Edit/Bash inside
-//                         implement), not crashed. CTL-661 HOISTS this gate
-//                         ahead of branches (A)/(B)/(C): a live-but-quiet worker
-//                         is now suppressed regardless of whether its probe
-//                         reads done (B), its phase has no probe (A), or its
-//                         work is not done (C) — never reclaimed, escalated, or
-//                         revived. No duplicate spawn, no budget consumed, no
-//                         .revive-N.applied marker, no defensive kill, no
-//                         events.jsonl append — log-only (to avoid the CTL-638
-//                         self-feeding storm). A dead pid (real crash) or a live
-//                         pid past the cutoff (genuinely hung) opens the gate and
-//                         falls through to the branches below.
+//   'reclaim-failed'      reclaim-eligible + work IS done BUT emit-complete exited
+//                         non-zero. Signal NOT mutated (atomic rename); retries.
+//   'revived'             reclaim-eligible + probe says work NOT done + revive
+//                         budget available + storm-breaker closed. Signal reset to
+//                         'stalled', defaultDispatch invoked, .revive-N.applied
+//                         marker written. CTL-604: every probed phase shares this.
+//   'revive-suppressed'   reclaim-eligible + work NOT done + storm-breaker OPEN
+//                         (>3 distinct tickets reviving in last 10min). No
+//                         dispatch; suppress event audited; next tick re-evaluates.
+//   'escalated'           reclaim-eligible + (revive budget exhausted OR no
+//                         work-done probe for this phase: verify/review/pr/
+//                         monitor-*) OR a `busy` worker past BUSY_CEILING_MS with
+//                         no committed work. needs-human label applied (CTL-587
+//                         verified applyLabel); ticket stays put for human triage.
+//   'superseded-noop'     reclaim-eligible BUT the signal's phase precedes the
+//                         ticket's latest-dispatched phase (CTL-606). A stale
+//                         predecessor left at `running`; acting would spuriously
+//                         flag needs-human or spawn a duplicate at a past phase.
+//                         A reap-intent is emitted so the reaper stops the bg.
 //
-// CTL-588 still defines "effectively dead" as classifyWorker:'dead' OR a
-// 'running' signal whose bg state.json mtime is older than staleMs.
+// CTL-662: a worker is reclaim-eligible iff livenessForBgJob is `absent` (not a
+// live `claude agents` session) OR `idle` for idleConfirmTicks consecutive
+// observations. state.json mtime is no longer a decision input on ANY branch.
 //
 // The function stays pure given its injected seams: statJob / probes /
-// emitComplete / appendEvent (pre-CTL-587) plus the six CTL-587 seams
+// emitComplete / appendEvent (pre-CTL-587) plus the CTL-587 seams
 // (appendReviveEvent, appendEscalatedEvent, appendReviveSuppressedEvent,
 // reviveDispatch, applyStalledLabel, killBgJob, countReviveEvents,
-// countDistinctRevivingTickets, writeReviveMarker). All have real defaults
-// for prod; tests override every one.
+// countDistinctRevivingTickets, writeReviveMarker) plus the CTL-662 liveness +
+// idle-streak seams. All have real defaults for prod; tests override every one.
 export function reclaimDeadWorkIfPossible(
   orchDir,
   signal,
@@ -947,14 +960,21 @@ export function reclaimDeadWorkIfPossible(
     // CTL-606 — supersede guard. Returns the ticket's dispatched phase names so
     // the guard can detect a dead signal the pipeline has already advanced past.
     listTicketPhases = (t) => listDispatchedPhases(orchDir, t),
-    // CTL-610 — alive-quiet keep-alive guard. pidAlive is the positive
-    // inverse of defaultKillBgJob's ps-verify: "is bg pid a live `claude`
-    // process?" Returning true within hungCutoffMs suppresses the revive
-    // entirely (the worker is alive on a long tool call, not crashed).
-    // Production defaults: pidAlive reads ~/.claude/jobs/<bg>/pid; the cutoff
-    // matches the legacy 15-min STALE_BG_SECONDS.
-    pidAlive = defaultPidAlive,
-    hungCutoffMs = HUNG_CUTOFF_MS,
+    // CTL-662 — three-valued liveness reader (replaces the pre-CTL-662 mtime
+    // staleness check + the CTL-610 keep-alive pair). "busy" → never
+    // auto-reclaim; "idle" → reclaim-eligible only after an
+    // idle-confirmation streak; "absent" (not a live `claude agents` session) →
+    // reclaim-eligible immediately.
+    liveness = livenessForBgJob,
+    // CTL-662 — idle-confirmation streak seams. The consecutive-idle counter is
+    // a per-(ticket, phase) worker-dir marker, NOT an mtime window.
+    bumpIdleStreak = defaultBumpIdleStreak,
+    resetIdleStreak = defaultResetIdleStreak,
+    idleConfirmTicks = IDLE_CONFIRM_TICKS,
+    // CTL-662 — busy-forever backstop ceiling (measured from signal.startedAt).
+    // The SOLE long backstop now that the mtime triggers are gone: a busy worker
+    // past it with no committed work is flagged for human, never silent-reclaimed.
+    busyCeilingMs = BUSY_CEILING_MS,
     // CTL-658 — resume-session resolver. Maps the dead worker's bg_job_id to a
     // `claude --resume`-compatible UUID (or null) so the revive can continue the
     // dead session instead of re-walking from phase 0. Default reads the real
@@ -973,67 +993,31 @@ export function reclaimDeadWorkIfPossible(
     // Marker-guarded + fail-open; tests inject a spy to assert call order.
     postReclaimMirror = defaultPostReclaimMirror,
     now = Date.now,
-    staleMs = STALE_MS,
   } = {},
 ) {
   const klass = classifyWorker(signal, { statJob });
-  let effectivelyDead = klass === "dead";
-  // CTL-587: capture the bg state.json mtime so the defensive kill + the revive
-  // audit payload can both reference it without re-statting.
-  let prevStateJsonMtime = null;
-  if (klass === "running" && signal?.liveness?.value) {
-    const job = statJob(signal.liveness.value);
-    if (job && typeof job.mtimeMs === "number") {
-      prevStateJsonMtime = job.mtimeMs;
-      if (now() - job.mtimeMs > staleMs) effectivelyDead = true;
-    }
-  }
-  if (!effectivelyDead) return "noop";
+  // CTL-662: terminal (phase finished) and unknown (no bg_job_id) still
+  // short-circuit — boot-classification gating is unchanged. Everything else
+  // (running, OR dead-by-missing-job-dir) is routed through the status trigger
+  // below; the job dir's existence/mtime is no longer the death signal.
+  if (klass === "terminal" || klass === "unknown") return "noop";
 
   const { ticket, phase } = signal;
-
-  // CTL-606 — supersede guard. The reclaim sweep is fed ONE signal per ticket by
-  // readWorkerSignals→byActivePhase, which ranks by status+recency, NOT phase
-  // order. A stale predecessor left at `running` (never flipped to `done`) can
-  // therefore shadow the real, already-advanced phase and be handed here. If the
-  // dead signal's phase precedes the ticket's latest-dispatched phase, the ticket
-  // has moved on — escalating or reviving it would spuriously flag needs-human or
-  // spawn a duplicate worker at a past phase. No-op. Runs only after the dead
-  // check above, so live signals pay no filesystem read.
-  const dispatched = listTicketPhases(ticket);
-  const latestIdx = dispatched.reduce((max, p) => {
-    const i = phaseIndex(p);
-    return i > max ? i : max;
-  }, -1);
-  if (phaseIndex(phase) < latestIdx) {
-    // CTL-649: emit a reap-intent so the daemon reaper can stop the lingering
-    // bg worker (pre-CTL-649 the supersede-noop branch did nothing and the
-    // stale worker kept running). Fire-and-forget — the periodic orphan
-    // reaper picks up anything the reconciler missed.
-    if (signal.raw?.bg_job_id) {
-      emitReapIntent("phase.supersede.reap-requested", {
-        ticket,
-        phase,
-        bgJobId: signal.raw.bg_job_id,
-        worktreePath: signal.raw.worktreePath,
-        dominantPhase: dispatched[dispatched.length - 1],
-        reason: "ctl-606-superseded",
-      }).catch(() => {});
-    }
-    log.info({ ticket, phase, latestPhaseIndex: latestIdx }, "ctl-606: superseded phase, no-op");
-    return "superseded-noop";
-  }
-
   const orchId = signal.raw?.orchestrator;
   const prevBgJobId = signal.raw?.bg_job_id ?? null;
 
-  // CTL-638 — escalation helper. Wraps the appendEscalatedEvent + applyStalledLabel
-  // pair in a per-(ticket, phase) cool-down. Pre-CTL-638 the three escalation
-  // call sites duplicated the same 9-line block, and each one re-emitted the
-  // audit event on every tick — feeding the scheduler's own event-log watcher
-  // back into the next tick (28/min sustained storm). Returning
-  // "escalation-suppressed" lets schedulerTick bucket the suppression as
-  // invisible (the original escalation event was already emitted).
+  // CTL-587: capture the bg state.json mtime for the revive AUDIT payload only.
+  // CTL-662 removed it from every DECISION branch — it is telemetry, not a
+  // trigger. Best-effort: a missing job dir (real crash) just leaves it null.
+  let prevStateJsonMtime = null;
+  if (signal?.liveness?.value) {
+    const job = statJob(signal.liveness.value);
+    if (job && typeof job.mtimeMs === "number") prevStateJsonMtime = job.mtimeMs;
+  }
+
+  // CTL-638 — escalation helper (unchanged): wraps appendEscalatedEvent +
+  // applyStalledLabel in a per-(ticket, phase) cool-down so the same escalation
+  // cannot re-fire within the window (the pre-CTL-638 self-feeding storm).
   function escalateOnce(reason, finalAttemptCount) {
     if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
       return "escalation-suppressed";
@@ -1051,31 +1035,86 @@ export function reclaimDeadWorkIfPossible(
     return "escalated";
   }
 
-  // (C0→hoisted) CTL-661 — alive-quiet liveness gate, repositioned ahead of
-  //     ALL downstream branches (was at the top of branch (C), recovery.mjs
-  //     :891-901 pre-CTL-661). A worker flagged effectively-dead by stale
-  //     state.json mtime but still a live `claude agents` session within
-  //     hungCutoffMs is alive-blocked-on-a-long-tool-call (the pre-first-output
-  //     window for research/plan sub-agent fan-outs, or a long synchronous
-  //     Edit/Bash inside implement), not crashed. Suppressing HERE — before
-  //     branch (A) escalate, branch (B) reclaim, and the branch (C) revive —
-  //     means a live-but-quiet worker is never reclaimed, escalated, or revived
-  //     on ANY path; it is left to finish on its own (its own emit-complete is
-  //     authoritative) or to genuinely die (mtime past the cutoff → the gate
-  //     opens and it falls through to the branches below). The first conjunct
-  //     (prevStateJsonMtime !== null) fails-closed on the classifyWorker:'dead'
-  //     path (job dir gone — a real crash) so the gate cannot mask one.
-  const isAliveQuiet = () =>
-    prevStateJsonMtime !== null &&
-    now() - prevStateJsonMtime < hungCutoffMs &&
-    pidAlive({ bgJobId: prevBgJobId });
-  if (isAliveQuiet()) {
-    log.info(
-      { ticket, phase, prevBgJobId, prevStateJsonMtime },
-      "ctl-661: reclaim suppressed — bg pid alive within hung cutoff (worker quiet, not dead); gate precedes branches A/B/C",
-    );
-    return "alive-quiet-suppressed";
+  // CTL-662 — THE DEATH TRIGGER. The worker's `claude agents` status, not its
+  // state.json mtime. busy → alive (never auto-reclaim); idle → reclaim-eligible
+  // after a confirmation streak; absent → reclaim-eligible immediately.
+  const live = liveness(prevBgJobId);
+
+  // ── busy: NEVER auto-reclaimed at any elapsed time. This is the CTL-662 fix:
+  //    a phase worker's in-process Task sub-agent fan-out keeps the parent turn
+  //    `busy` while state.json mtime goes stale, so the pre-CTL-662 mtime trigger
+  //    false-reclaimed it (the proven worker-10d6f123 failure). The only action
+  //    permitted on a busy worker is the high-ceiling no-progress backstop: a
+  //    worker busy past BUSY_CEILING_MS whose work-done probe is STILL false is
+  //    flagged for human (escalateOnce) — never a silent reclaim-and-advance. A
+  //    busy worker that has already committed work is left to emit its own
+  //    authoritative complete. A single busy observation resets any in-progress
+  //    idle-confirmation streak.
+  if (live === "busy") {
+    resetIdleStreak(orchDir, ticket, phase);
+    const startedAtMs = Date.parse(signal.raw?.startedAt ?? "");
+    if (Number.isFinite(startedAtMs) && now() - startedAtMs > busyCeilingMs) {
+      const workDone = hasProbe(phase) && probes[phase]({ ticket, repoRoot, orchDir });
+      if (!workDone) {
+        log.warn(
+          { ticket, phase, prevBgJobId, busyForMs: now() - startedAtMs },
+          "ctl-662: busy worker past BUSY_CEILING_MS with no committed work — escalating (never silent reclaim)",
+        );
+        return escalateOnce("busy-ceiling-exceeded", 0);
+      }
+    }
+    log.info({ ticket, phase, prevBgJobId }, "ctl-662: busy worker — reclaim suppressed");
+    return "alive-busy-suppressed";
   }
+
+  // ── idle | absent share the reclaim-eligible path below.
+  // CTL-606 — supersede guard. The reclaim sweep is fed ONE signal per ticket by
+  // readWorkerSignals→byActivePhase, which ranks by status+recency, NOT phase
+  // order. A stale predecessor left at `running` (never flipped to `done`) can
+  // shadow the real, already-advanced phase. If the dead signal's phase precedes
+  // the ticket's latest-dispatched phase, the ticket has moved on — escalating or
+  // reviving it would spuriously flag needs-human or spawn a duplicate worker at
+  // a past phase. Runs only once a worker is reclaim-eligible (not busy).
+  const dispatched = listTicketPhases(ticket);
+  const latestIdx = dispatched.reduce((max, p) => {
+    const i = phaseIndex(p);
+    return i > max ? i : max;
+  }, -1);
+  if (phaseIndex(phase) < latestIdx) {
+    // CTL-649: emit a reap-intent so the daemon reaper can stop the lingering
+    // bg worker. Fire-and-forget — the periodic orphan reaper picks up anything
+    // the reconciler missed.
+    if (signal.raw?.bg_job_id) {
+      emitReapIntent("phase.supersede.reap-requested", {
+        ticket,
+        phase,
+        bgJobId: signal.raw.bg_job_id,
+        worktreePath: signal.raw.worktreePath,
+        dominantPhase: dispatched[dispatched.length - 1],
+        reason: "ctl-606-superseded",
+      }).catch(() => {});
+    }
+    log.info({ ticket, phase, latestPhaseIndex: latestIdx }, "ctl-606: superseded phase, no-op");
+    return "superseded-noop";
+  }
+
+  // ── idle requires an idle-confirmation streak before it is reclaim-eligible: a
+  //    couple of CONSECUTIVE idle observations confirm the worker is genuinely
+  //    between-turns done, not momentarily idle between sub-agent fan-out rounds.
+  //    `absent` skips this — absence is unambiguous. The streak is a persisted
+  //    per-(ticket, phase) counter (NOT an mtime window). Once we proceed to act
+  //    (reclaim/revive below), the streak is cleared.
+  if (live === "idle") {
+    const streak = bumpIdleStreak(orchDir, ticket, phase);
+    if (streak < idleConfirmTicks) {
+      log.info(
+        { ticket, phase, streak, idleConfirmTicks },
+        "ctl-662: idle worker pending confirmation — not yet reclaim-eligible",
+      );
+      return "idle-pending";
+    }
+  }
+  resetIdleStreak(orchDir, ticket, phase);
 
   // (A) No probe registered for this phase → escalate. The pre-CTL-587 silent
   //     'not-applicable' return is now an actionable outcome: the worker is
@@ -1083,9 +1122,9 @@ export function reclaimDeadWorkIfPossible(
   //     — so the human needs to look. needs-human label applied (verified by
   //     the CTL-587 applyLabel read-back). CTL-638 routes through escalateOnce
   //     so the same (ticket, phase) cannot re-fire within the cool-down window.
-  //     CTL-661: a LIVE worker on a probe-less phase no longer reaches here —
-  //     the hoisted alive-quiet gate above suppresses it first, so this branch
-  //     only escalates a genuinely-dead probe-less worker.
+  //     CTL-662: a `busy` worker on a probe-less phase no longer reaches here —
+  //     the status trigger above suppresses it first, so this branch only
+  //     escalates a genuinely reclaim-eligible (absent/idle-confirmed) worker.
   if (!hasProbe(phase)) {
     return escalateOnce("no-probe-for-phase", 0);
   }
@@ -1095,13 +1134,12 @@ export function reclaimDeadWorkIfPossible(
   //     can locate their artifact; implementProbe ignores the extra key.
   const probe = probes[phase];
   if (probe({ ticket, repoRoot, orchDir })) {
-    // CTL-661 hole #3: a worker reaching branch (B) has already passed the
-    // hoisted alive-quiet gate, so it is either pid-dead (nothing to stop) or
-    // live-but-past-hung-cutoff (genuinely hung → must be stopped). Emit a
-    // fire-and-forget reap-intent BEFORE emitComplete so the reaper stops any
-    // lingering session rather than letting a hung-but-live worker keep running
-    // past its own reclaim. No-op when no bg_job_id was recorded — mirrors the
-    // CTL-606 supersede-guard guard above.
+    // CTL-661 hole #3: a worker reaching branch (B) is reclaim-eligible, so it
+    // is either `absent` (nothing live to stop) or `idle`-confirmed (between
+    // turns → safe to stop). Emit a fire-and-forget reap-intent BEFORE
+    // emitComplete so the reaper stops any lingering session rather than letting
+    // it keep running past its own reclaim. No-op when no bg_job_id was recorded
+    // — mirrors the CTL-606 supersede-guard guard above.
     if (prevBgJobId) {
       emitReapIntent("phase.reclaim.reap-requested", {
         ticket,
@@ -1161,12 +1199,12 @@ export function reclaimDeadWorkIfPossible(
   //     defaultReviveDispatch is phase-agnostic (resets the signal to `stalled`
   //     and re-launches via phase-agent-dispatch).
 
-  // CTL-661: the CTL-610 alive-quiet guard that formerly sat HERE (branch (C0))
-  // has been hoisted ahead of branches (A) and (B) — see the `isAliveQuiet`
-  // gate above. By the time control reaches this point the worker is either
-  // pid-dead (a real crash) or a live pid past the hung cutoff (genuinely hung),
-  // so the revive/escalate path below is correct for both. No duplicate guard
-  // is needed; removing it keeps the predicate single-sourced.
+  // CTL-662: by the time control reaches branch (C) the worker is reclaim-
+  // eligible — either `absent` (a real crash: no live `claude agents` session)
+  // or `idle`-confirmed (live but idle for idleConfirmTicks consecutive ticks,
+  // genuinely between-turns with no committed work). A `busy` worker can never
+  // reach here (the busy branch above returns first), so the revive/re-dispatch
+  // path below is correct for both reclaim-eligible cases.
 
   // Per-ticket revive budget from events.jsonl. The events file is the
   // authoritative counter — more truthful than the signal file (which the
@@ -1215,10 +1253,11 @@ export function reclaimDeadWorkIfPossible(
     "ctl-658: revive resume id resolved",
   );
 
-  // Defensive stop: if state.json has been quiet long enough we're confident
-  // the worker is abandoned, so we stop it to free RAM and release any worktree
-  // lock. CTL-657: killBgJob now issues `claude stop <shortId>` (the pre-CTL-657
-  // pid-file SIGKILL was a guaranteed no-op on CC 2.1.152 — no per-job pid file).
+  // Defensive stop: the worker is reclaim-eligible (absent or idle-confirmed),
+  // so we stop it to free RAM and release any worktree lock before re-dispatch.
+  // CTL-657: killBgJob issues `claude stop <shortId>` (the pre-CTL-657 pid-file
+  // SIGKILL was a guaranteed no-op on CC 2.1.152 — no per-job pid file); an
+  // `absent` worker has no live session so the stop is a harmless no-op.
   //
   // CTL-649: also emit a reap-intent so the daemon reaper has authoritative
   // visibility and stops the same session via its own `claude stop`. The inline
@@ -1227,18 +1266,16 @@ export function reclaimDeadWorkIfPossible(
   //
   // CTL-658: gated on !resumeSession — when we're resuming we must NOT stop the
   // session (its linkScanPath jsonl must stay intact for `--resume`).
-  if (
-    !resumeSession &&
-    prevStateJsonMtime !== null &&
-    now() - prevStateJsonMtime > KILL_RECENT_ACTIVITY_MS &&
-    prevBgJobId
-  ) {
+  // CTL-662: the pre-CTL-662 mtime quiet-window kill gate is gone — `idle`-
+  // confirmation already proved the worker is not mid-turn, so stopping it is
+  // safe without a separate quiet-window check.
+  if (!resumeSession && prevBgJobId) {
     emitReapIntent("phase.revive.reap-requested", {
       ticket,
       phase,
       bgJobId: prevBgJobId,
       worktreePath: signal.raw?.worktreePath,
-      quietMs: now() - prevStateJsonMtime,
+      prevStateJsonMtime,
     }).catch(() => {});
     killBgJob({ bgJobId: prevBgJobId });
   }
@@ -1328,7 +1365,7 @@ export function recoverStartup({ orchDir, exec, statJob, detectCold = detectCold
 
   // (4) Cold-start verdict (CTL-640) — does every prior --bg worker pre-date the
   //     runtime epoch? Surfaced for a downstream consumer (CTL-639) to gate the
-  //     STALE_MS stale-wait. Pass statJob so a test-redirected jobs root flows
+  //     boot-time stale-wait. Pass statJob so a test-redirected jobs root flows
   //     through both the worker reconstruction and the cold-start scan.
   const coldStart = detectCold({ statJob });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -17,7 +17,6 @@ import {
   defaultReviveDispatch,
   resolvePhaseSessionId,
   defaultKillBgJob,
-  defaultPidAlive,
   defaultAppendReviveEvent,
   defaultAppendReclaimEvent,
   defaultPostReclaimMirror,
@@ -489,26 +488,29 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(appendEvent.calls.length).toBe(0);
   });
 
-  test("'noop' for a running signal whose bg job is FRESH (state.json mtime within staleMs)", () => {
-    // CTL-588: a `running` classification + fresh state.json mtime → live worker.
+  test("CTL-662: a BUSY worker is 'alive-busy-suppressed', never reclaimed (regardless of elapsed time)", () => {
+    // The CTL-662 fix: a busy worker (a live `claude agents` session with an open
+    // turn — e.g. an in-process sub-agent fan-out) is NEVER auto-reclaimed, even
+    // though its state.json mtime may be arbitrarily stale.
     const probe = recorder(true);
     const emit = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
-      statJob: () => ({ exists: true, mtimeMs: 1_000_000 }),
+      statJob: () => ({ exists: true, mtimeMs: 1_000 }),
       probes: { implement: probe },
       emitComplete: emit,
       appendEvent: recorder(undefined),
-      // Pin "now" near the bg mtime so the staleness check sees a fresh worker.
-      now: () => 1_000_500,
+      liveness: () => "busy",
+      now: () => 1_000 + 60 * 60 * 1000, // an hour past mtime — irrelevant now
     });
-    expect(r).toBe("noop");
+    expect(r).toBe("alive-busy-suppressed");
+    expect(probe.calls.length).toBe(0); // busy short-circuits before the probe
     expect(emit.calls.length).toBe(0);
   });
 
-  test("CTL-588: 'running' with a STALE bg state.json (> staleMs) is treated as effectively dead", () => {
-    // The bug CTL-588 fixes: claude --bg leaves the job dir behind after the
-    // worker exits, so classifyWorker stays `running` indefinitely. We catch
-    // this via mtime — a real worker updates state.json every few seconds.
+  test("CTL-662: an ABSENT worker (no live session) with work done is reclaimed", () => {
+    // absent = not listed by `claude agents` (crashed/exited) → reclaim-eligible
+    // immediately, no idle-confirmation needed. Replaces the pre-CTL-662
+    // stale-mtime "effectively dead" trigger.
     const probe = recorder(true);
     const emit = recorder({ code: 0 });
     const appendEvent = recorder(undefined);
@@ -518,7 +520,8 @@ describe("reclaimDeadWorkIfPossible", () => {
       emitComplete: emit,
       appendEvent,
       postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
-      now: () => 1_000 + 6 * 60 * 1000, // 6 minutes past mtime — stale
+      liveness: () => "absent",
+      now: () => 1_000,
     });
     expect(r).toBe("reclaimed");
     expect(probe.calls.length).toBe(1);
@@ -526,7 +529,7 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(appendEvent.calls.length).toBe(1);
   });
 
-  test("CTL-588: 'running' with a FRESH bg state.json (under staleMs) is NOT reclaimed", () => {
+  test("CTL-662: a BUSY worker with work done is still suppressed (left to emit its own complete)", () => {
     const probe = recorder(true);
     const emit = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
@@ -534,24 +537,11 @@ describe("reclaimDeadWorkIfPossible", () => {
       probes: { implement: probe },
       emitComplete: emit,
       appendEvent: recorder(undefined),
-      now: () => 1_000_000 + 4 * 60 * 1000, // 4 minutes — under threshold
+      liveness: () => "busy",
+      now: () => 1_000_000 + 60_000,
     });
-    expect(r).toBe("noop");
-    expect(probe.calls.length).toBe(0);
+    expect(r).toBe("alive-busy-suppressed");
     expect(emit.calls.length).toBe(0);
-  });
-
-  test("CTL-588: staleMs is honored when explicitly passed (override)", () => {
-    const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
-      statJob: () => ({ exists: true, mtimeMs: 100 }),
-      probes: { implement: () => true },
-      emitComplete: () => ({ code: 0 }),
-      appendEvent: () => {},
-      postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
-      now: () => 100 + 60_000,
-      staleMs: 30_000, // 30s threshold — 1 min IS stale
-    });
-    expect(r).toBe("reclaimed");
   });
 
   test("'noop' for an unknown signal (no bg_job_id)", () => {
@@ -1014,8 +1004,12 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
         // (branch B) stay hermetic and don't spawn a real `linearis`.
         postReclaimMirror: recorder(undefined),
         readBootSince, // CTL-655: inject the boot-time window reader
+        // CTL-662: the death trigger is now status, not mtime. "absent" (no live
+        // `claude agents` session) is the reclaim-eligible case these revive/
+        // escalate/storm scenarios exercise — equivalent to the pre-CTL-662
+        // stale-mtime "effectively dead" they used to stage.
+        liveness: () => "absent",
         now: () => nowMs,
-        staleMs: 5 * 60 * 1000,
       },
     };
   }
@@ -1132,30 +1126,15 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(s.opts.reviveDispatch.calls.length).toBe(0);
   });
 
-  test("defensive kill: fires when state.json mtime > KILL_RECENT_ACTIVITY_MS old", () => {
-    // 60s past now — older than the 30s kill threshold.
-    const s = setupReviveScenario({
-      stateJsonMtime: 1_000,
-      nowMs: 1_000 + 6 * 60 * 1000, // 6min past — also stale
-    });
+  test("CTL-662: defensive stop fires on the revive path unconditionally (the mtime quiet-window gate is gone)", () => {
+    // Pre-CTL-662 the kill was gated on KILL_RECENT_ACTIVITY_MS (state.json quiet
+    // for ≥30s). CTL-662 removed that gate: a reclaim-eligible worker (absent, or
+    // idle-confirmed) is by definition not mid-turn, so the stop is always safe.
+    // It now fires whenever the revive path runs with a known bg_job_id.
+    const s = setupReviveScenario(); // liveness "absent", probe false → revive
     reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
     expect(s.opts.killBgJob.calls.length).toBe(1);
     expect(s.opts.killBgJob.calls[0][0].bgJobId).toBe("bg-9");
-  });
-
-  test("defensive kill: does NOT fire when classifyWorker:dead path is taken (no mtime captured)", () => {
-    // When statJob returns null (bg dir gone), classifyWorker returns 'dead'
-    // directly → prevStateJsonMtime stays null → the kill gate at
-    // recovery.mjs sees no mtime and skips. The separate freshness-vs-kill
-    // gate is exercised by the next test.
-    const sig = implementSignal({ ticket: "CTL-9", status: "running", bgJobId: "bg-9" });
-    const opts = {
-      ...setupReviveScenario().opts,
-      statJob: () => null,
-      now: () => 0,
-    };
-    reclaimDeadWorkIfPossible("/orch", sig, opts);
-    expect(opts.killBgJob.calls.length).toBe(0);
   });
 
   test("revive event payload contains attempt, reason, prev_state_json_mtime, prev_bg_job_id", () => {
@@ -1226,22 +1205,10 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(s.opts.appendReviveSuppressedEvent.calls[0][0].reason).toBe("audit-append-failed");
   });
 
-  // Defensive-kill freshness gate: a `running` worker with a stale-but-not-yet-
-  // KILL_RECENT_ACTIVITY_MS-stale state.json mtime must NOT be SIGKILL'd. We
-  // override staleMs so the worker still classifies as effectively dead (via
-  // the freshness path) but the kill threshold (30s) is NOT crossed.
-  test("defensive kill: state.json mtime within KILL_RECENT_ACTIVITY_MS → no kill", () => {
-    const s = setupReviveScenario({
-      stateJsonMtime: 1_000,
-      nowMs: 1_000 + 20_000, // 20s past mtime — under 30s kill threshold
-    });
-    // Override staleMs so the worker IS effectively dead via the freshness
-    // path even though only 20s have elapsed. This isolates the kill gate
-    // from the staleness gate.
-    s.opts.staleMs = 10_000;
-    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
-    expect(s.opts.killBgJob.calls.length).toBe(0);
-  });
+  // CTL-662: the pre-CTL-662 "no kill within the quiet window" case is gone —
+  // the mtime quiet-window gate no longer exists. The only remaining "no kill"
+  // scenario is CTL-658 resume-on-revive (the session's jsonl must stay intact
+  // for --resume), exercised below.
 
   // ── CTL-658: resume-on-revive. When a resume UUID resolves from the dead
   //    worker's bg_job_id, the revive dispatches with `resumeSession` AND skips
@@ -1282,48 +1249,48 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
   });
 });
 
-// --- CTL-610: alive-quiet keep-alive guard (branch (C0)) -------------------
+// --- CTL-662: busy-suppression (replaces the CTL-610/661 alive-quiet gate) -
 //
-// A worker can be effectively-dead by state.json mtime (5min stale) yet still
-// be alive-blocked-on-a-long-tool-call — the pre-first-output window for
-// research/plan sub-agent fan-outs, or a long synchronous Edit/Bash inside
-// implement. Pre-CTL-610 such a worker was revived (duplicate `claude --bg`
-// spawn, budget consumed, eventual escalation), producing the documented
-// ~50%-of-workers revive storm in 14-ticket runs. The (C0) guard inverts the
-// PID liveness check defaultKillBgJob already uses: when bg pid is a live
-// `claude` process AND state.json mtime is within HUNG_CUTOFF_MS, suppress
-// the revive entirely — no dispatch, no budget consumed, no marker, no kill,
-// no events.jsonl append, log-only. Past the cutoff the worker is treated as
-// genuinely hung and the existing revive path runs.
+// The pre-CTL-662 reclaim trigger was state.json mtime (5min stale → dead), with
+// the CTL-610/661 alive-quiet gate papering over false positives by checking the
+// bg pid within a 15min hung cutoff. CTL-662 deletes that whole time-based
+// machinery: the trigger is now the worker's `claude agents` status
+// (livenessForBgJob → busy|idle|absent). A `busy` worker — including the
+// in-process Task sub-agent fan-out that keeps the parent's turn busy while
+// state.json mtime goes arbitrarily stale (the proven worker-10d6f123 failure) —
+// is NEVER auto-reclaimed, escalated, or revived, regardless of elapsed time,
+// revive budget, or storm conditions. The sole permitted action on a busy worker
+// is the high-ceiling no-progress backstop (escalateOnce past BUSY_CEILING_MS
+// with no committed work — never a silent reclaim-and-advance).
 
-describe("reclaimDeadWorkIfPossible — CTL-610 alive-quiet keep-alive guard", () => {
-  // Inline scenario builder mirroring setupReviveScenario but with the CTL-610
-  // pidAlive + hungCutoffMs seams added. The same defaults (effectively dead by
-  // mtime, probe says NOT done) so we exercise branch (C) territory; the (C0)
-  // guard sits at the top of (C), before priorRevives is consulted.
-  function setupAliveQuietScenario({
-    pidAlive = () => true, // bg pid is a live claude process
-    hungCutoffMs = 15 * 60 * 1000, // CTL-610 default
+describe("reclaimDeadWorkIfPossible — CTL-662 busy-suppression", () => {
+  // A `busy` worker (a live `claude agents` session with an open turn). Defaults
+  // to probe=false (work not done) so we prove a busy worker is suppressed even
+  // when the work-done probe would otherwise revive it. `startedAt` is omitted by
+  // default so the busy-ceiling backstop never trips unless a test supplies it.
+  function setupBusyScenario({
     reviveCount = 0,
+    distinctRevivingTickets = 1,
     probeResult = false,
     phase = "implement",
     ticket = "CTL-9",
     bgJobId = "bg-9",
-    stateJsonMtime = 1_000,
-    // 6 min past mtime — staleMs (5min) crossed, well within hungCutoffMs (15min).
-    nowMs = 1_000 + 6 * 60 * 1000,
+    startedAt,
+    nowMs = 2_000_000,
   } = {}) {
     const sig = {
       ...implementSignal({ ticket, status: "running", bgJobId }),
       phase,
     };
     sig.raw.phase = phase;
+    if (startedAt !== undefined) sig.raw.startedAt = startedAt;
     return {
       orch: "/orch",
       sig,
       opts: {
         repoRoot: "/repo",
-        statJob: () => ({ exists: true, mtimeMs: stateJsonMtime }),
+        // mtime is arbitrarily stale — it is no longer a decision input.
+        statJob: () => ({ exists: true, mtimeMs: 1_000 }),
         probes: { [phase]: recorder(probeResult) },
         emitComplete: recorder({ code: 0 }),
         appendEvent: recorder(undefined),
@@ -1334,22 +1301,24 @@ describe("reclaimDeadWorkIfPossible — CTL-610 alive-quiet keep-alive guard", (
         applyStalledLabel: recorder({ applied: true }),
         killBgJob: recorder(undefined),
         countReviveEvents: recorder(reviveCount),
-        countDistinctRevivingTickets: recorder(1),
+        countDistinctRevivingTickets: recorder(distinctRevivingTickets),
         writeReviveMarker: recorder(undefined),
-        // CTL-664: stub the reclaim mirror so the probeResult:true scenario
-        // (branch B wins over alive-quiet) stays hermetic (no `linearis` spawn).
+        inEscalationCooldownFn: () => false,
+        recordEscalationFn: recorder(undefined),
+        liveness: recorder("busy"),
+        bumpIdleStreak: recorder(1),
+        resetIdleStreak: recorder(undefined),
+        // CTL-664: stub the reclaim mirror so a probeResult:true scenario
+        // (reclaim branch) stays hermetic (no `linearis` spawn).
         postReclaimMirror: recorder(undefined),
-        pidAlive: recorder(pidAlive()),
-        hungCutoffMs,
         now: () => nowMs,
-        staleMs: 5 * 60 * 1000,
       },
     };
   }
 
-  test("alive pid within hung cutoff → 'alive-quiet-suppressed' (no dispatch, no budget, no marker, no kill, no events)", () => {
-    const s = setupAliveQuietScenario({ pidAlive: () => true, reviveCount: 0 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+  test("busy → 'alive-busy-suppressed' (no dispatch, no budget, no marker, no kill, no escalate, no events)", () => {
+    const s = setupBusyScenario({ reviveCount: 0 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
     expect(s.opts.reviveDispatch.calls.length).toBe(0);
     expect(s.opts.appendReviveEvent.calls.length).toBe(0);
     expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(0);
@@ -1357,120 +1326,111 @@ describe("reclaimDeadWorkIfPossible — CTL-610 alive-quiet keep-alive guard", (
     expect(s.opts.writeReviveMarker.calls.length).toBe(0);
     expect(s.opts.killBgJob.calls.length).toBe(0);
     expect(s.opts.applyStalledLabel.calls.length).toBe(0);
-    // The guard MUST consult pidAlive — otherwise it cannot decide
-    expect(s.opts.pidAlive.calls.length).toBeGreaterThanOrEqual(1);
-    expect(s.opts.pidAlive.calls[0][0].bgJobId).toBe("bg-9");
+    // The trigger MUST consult liveness with the signal's bg_job_id.
+    expect(s.opts.liveness.calls.length).toBeGreaterThanOrEqual(1);
+    expect(s.opts.liveness.calls[0][0]).toBe("bg-9");
   });
 
-  test("alive pid but past hung cutoff → 'revived' (genuinely hung, existing path runs)", () => {
-    // 20 min past mtime > 15 min hung cutoff → fall through to existing revive
-    const s = setupAliveQuietScenario({
-      pidAlive: () => true,
-      stateJsonMtime: 1_000,
-      nowMs: 1_000 + 20 * 60 * 1000,
-    });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
-    expect(s.opts.reviveDispatch.calls.length).toBe(1);
-    expect(s.opts.appendReviveEvent.calls.length).toBe(1);
-  });
-
-  test("dead pid → 'revived' (regression-shaped — existing CTL-587 path unchanged)", () => {
-    const s = setupAliveQuietScenario({ pidAlive: () => false });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
-    expect(s.opts.reviveDispatch.calls.length).toBe(1);
-  });
-
-  test("alive pid + revive budget exhausted → still 'alive-quiet-suppressed' (NEVER false-escalate a live worker)", () => {
-    // The (C0) guard MUST run before the budget-exhausted check, otherwise a
-    // live but quiet worker would be falsely escalated to needs-human just
-    // because two prior false-revives consumed its budget. This is the worst
-    // case the guard exists to prevent.
-    const s = setupAliveQuietScenario({ pidAlive: () => true, reviveCount: 2 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+  test("busy + revive budget exhausted → still 'alive-busy-suppressed' (NEVER false-escalate a busy worker)", () => {
+    // The worst case the fix exists to prevent: a busy worker (a long sub-agent
+    // fan-out) whose budget two prior false-revives consumed must NOT be escalated
+    // to needs-human just because the budget is spent — it is alive and working.
+    const s = setupBusyScenario({ reviveCount: 2 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
     expect(s.opts.applyStalledLabel.calls.length).toBe(0);
   });
 
-  test("alive pid + storm-breaker open → still 'alive-quiet-suppressed' (guard runs before storm check)", () => {
-    // A live worker is alive regardless of fleet-wide storm conditions; the
-    // guard short-circuits storm bookkeeping too (no audit event emitted).
-    const s = setupAliveQuietScenario({ pidAlive: () => true });
-    s.opts.countDistinctRevivingTickets = recorder(4); // storm threshold open
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+  test("busy + storm-breaker open → still 'alive-busy-suppressed' (status check precedes storm bookkeeping)", () => {
+    const s = setupBusyScenario({ distinctRevivingTickets: 4 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
     expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(0);
   });
 
-  test("CTL-661: a LIVE worker whose work appears done is suppressed, NOT reclaimed (gate now precedes branch B)", () => {
-    // Pre-CTL-661 the alive-quiet guard sat at the top of branch (C), AFTER
-    // branch (B)'s reclaim, so a live worker whose probe read done was
-    // reclaimed (signal flipped, advanced past) even though it was still
-    // running. CTL-661 repositions the gate ahead of branches (A)/(B): a live
-    // worker within the hung cutoff is never reclaimed — it is left to finish
-    // (its own emit-complete is authoritative) or to genuinely die.
-    const s = setupAliveQuietScenario({ pidAlive: () => true, probeResult: true });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
-    // Gate MUST have been consulted and won over the work-done reclaim.
-    expect(s.opts.pidAlive.calls.length).toBeGreaterThanOrEqual(1);
+  test("busy + work appears done → 'alive-busy-suppressed', NOT reclaimed (left to emit its own complete)", () => {
+    // A busy worker whose probe reads done is still suppressed: it is live and its
+    // own emit-complete is authoritative. Reclaiming it would flip the signal out
+    // from under a running worker (the pre-CTL-661 hole the gate exists to close).
+    const s = setupBusyScenario({ probeResult: true });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
     expect(s.opts.emitComplete.calls.length).toBe(0);
     expect(s.opts.appendEvent.calls.length).toBe(0);
   });
 
-  test("production default seam returns false for a fake bgJobId → guard inert, existing revive path runs", () => {
-    // The original setupReviveScenario (in the CTL-587 describe block) uses
-    // bgJobId 'bg-9' with no real ~/.claude/jobs/bg-9/pid file and injects
-    // NO pidAlive seam — so the production defaultPidAlive runs and returns
-    // false on the missing pid file. The (C0) guard is therefore inert for
-    // every pre-CTL-610 revive test, and they continue to pass unchanged.
-    // This test asserts that contract explicitly using the same conditions.
-    const s = setupAliveQuietScenario({ reviveCount: 0 });
-    // Strip the test-injected pidAlive so we exercise the production default.
-    delete s.opts.pidAlive;
-    // bg-9 has no pid file under the real ~/.claude/jobs → defaultPidAlive
-    // returns false → guard inert → existing revive path runs.
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+  test("busy resets any in-progress idle-confirmation streak", () => {
+    // A single busy observation between idle ticks must reset the streak so a
+    // worker that flickers idle→busy→idle is never reclaimed on a stale count.
+    const s = setupBusyScenario();
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.resetIdleStreak.calls.length).toBe(1);
+    expect(s.opts.resetIdleStreak.calls[0]).toEqual(["/orch", "CTL-9", "implement"]);
+    expect(s.opts.bumpIdleStreak.calls.length).toBe(0);
   });
 
-  test("guard inert when prevStateJsonMtime is null (classifyWorker:'dead' path) — falls through to revive", () => {
-    // When statJob returns null (bg dir gone), classifyWorker returns 'dead'
-    // directly; prevStateJsonMtime stays null. The (C0) guard's first
-    // conjunct (prevStateJsonMtime !== null) MUST fail-closed here so a real
-    // crash still revives even if a (mis-)injected pidAlive lied "true".
-    const sig = implementSignal({ ticket: "CTL-9", status: "running", bgJobId: "bg-9" });
-    const opts = {
-      ...setupAliveQuietScenario().opts,
-      statJob: () => null, // bg dir gone → classifyWorker:'dead'
-      pidAlive: () => true,
-      now: () => 0,
-    };
-    // A 'dead' bg implies a real crash → revive must still fire.
-    expect(reclaimDeadWorkIfPossible("/orch", sig, opts)).toBe("revived");
+  test("busy past BUSY_CEILING_MS with NO committed work → 'escalated' (busy-ceiling-exceeded), never silent reclaim", () => {
+    // The sole long backstop. A worker busy longer than the ceiling whose
+    // work-done probe is STILL false is flagged for a human — genuinely wedged,
+    // not progressing. It is escalated, NEVER silently reclaimed-and-advanced.
+    const startedAt = "2026-05-27T00:00:00Z";
+    const s = setupBusyScenario({
+      probeResult: false,
+      startedAt,
+      nowMs: Date.parse(startedAt) + 7 * 60 * 60 * 1000, // 7h > 6h ceiling
+    });
+    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(r).toBe("escalated");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("busy-ceiling-exceeded");
+    expect(s.opts.applyStalledLabel.calls.length).toBe(1);
+    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("busy past BUSY_CEILING_MS but work IS done → 'alive-busy-suppressed' (progressing, not wedged)", () => {
+    // Past the ceiling but the probe reads done → it is making progress, not
+    // wedged. Suppress and let it emit its own complete; do not escalate.
+    const startedAt = "2026-05-27T00:00:00Z";
+    const s = setupBusyScenario({
+      probeResult: true,
+      startedAt,
+      nowMs: Date.parse(startedAt) + 7 * 60 * 60 * 1000,
+    });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
+  });
+
+  test("busy WITHIN BUSY_CEILING_MS is suppressed regardless of work-done (backstop not yet armed)", () => {
+    const startedAt = "2026-05-27T00:00:00Z";
+    const s = setupBusyScenario({
+      probeResult: false,
+      startedAt,
+      nowMs: Date.parse(startedAt) + 60 * 60 * 1000, // 1h < 6h ceiling
+    });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
   });
 });
 
-// --- CTL-661: reclaim liveness gate (repositioned ahead of branches A/B) ---
+// --- CTL-662: idle-confirmation + absent reclaim --------------------------
 //
-// CTL-610 introduced the alive-quiet guard but positioned it at the TOP of
-// branch (C) — after branch (A) (no-probe → escalate) and branch (B)
-// (work-done → reclaim) had already had a chance to return. A live-but-quiet
-// worker whose probe read done (B) or whose phase had no probe (A) was
-// therefore still reclaimed/escalated past while genuinely alive. CTL-661
-// hoists the same predicate ahead of (A) and (B) so a live worker within the
-// hung cutoff is suppressed on EVERY branch — never reclaimed, escalated, or
-// revived. These cases pin the repositioned semantics.
-describe("reclaimDeadWorkIfPossible — CTL-661 reclaim liveness gate", () => {
-  // Reuse the CTL-610 scenario shape. setupAliveQuietScenario is in the
-  // sibling describe block above; redeclare a local copy here so this block is
-  // self-contained and order-independent.
+// `absent` (not listed by `claude agents` → crashed/exited) is reclaim-eligible
+// immediately — absence is unambiguous. `idle` (live, between turns) is
+// reclaim-eligible only after IDLE_CONFIRM_TICKS CONSECUTIVE idle observations,
+// counted by a persisted per-(ticket, phase) streak marker (NOT an mtime window).
+// Once reclaim-eligible, the existing CTL-574/587/604 branches decide:
+// work-done → reclaim+advance; work-not-done → revive (budget/storm permitting).
+// This path replaces the pre-CTL-662 stale-mtime "effectively dead" trigger; the
+// revive/escalate/storm behaviour on it is otherwise unchanged.
+
+describe("reclaimDeadWorkIfPossible — CTL-662 idle-confirmation + absent reclaim", () => {
   function setup({
-    pidAlive = () => true,
-    hungCutoffMs = 15 * 60 * 1000,
-    reviveCount = 0,
+    live = "idle",
+    streak = 0, // the NEW post-increment count bumpIdleStreak returns this tick
+    idleConfirmTicks = 2,
     probeResult = false,
+    reviveCount = 0,
+    distinctRevivingTickets = 1,
     phase = "implement",
     ticket = "CTL-9",
     bgJobId = "bg-9",
-    stateJsonMtime = 1_000,
-    nowMs = 1_000 + 6 * 60 * 1000, // 6 min past mtime → stale, within cutoff
   } = {}) {
     const sig = {
       ...implementSignal({ ticket, status: "running", bgJobId }),
@@ -1482,7 +1442,7 @@ describe("reclaimDeadWorkIfPossible — CTL-661 reclaim liveness gate", () => {
       sig,
       opts: {
         repoRoot: "/repo",
-        statJob: () => ({ exists: true, mtimeMs: stateJsonMtime }),
+        statJob: () => ({ exists: true, mtimeMs: 1_000 }),
         probes: { [phase]: recorder(probeResult) },
         emitComplete: recorder({ code: 0 }),
         appendEvent: recorder(undefined),
@@ -1493,63 +1453,65 @@ describe("reclaimDeadWorkIfPossible — CTL-661 reclaim liveness gate", () => {
         applyStalledLabel: recorder({ applied: true }),
         killBgJob: recorder(undefined),
         countReviveEvents: recorder(reviveCount),
-        countDistinctRevivingTickets: recorder(1),
+        countDistinctRevivingTickets: recorder(distinctRevivingTickets),
         writeReviveMarker: recorder(undefined),
-        pidAlive: recorder(pidAlive()),
-        hungCutoffMs,
-        now: () => nowMs,
-        staleMs: 5 * 60 * 1000,
+        inEscalationCooldownFn: () => false,
+        recordEscalationFn: recorder(undefined),
+        listTicketPhases: () => ["triage", "research", "plan", "implement"],
+        liveness: recorder(live),
+        bumpIdleStreak: recorder(streak),
+        resetIdleStreak: recorder(undefined),
+        idleConfirmTicks,
+        now: () => 2_000_000,
       },
     };
   }
 
-  test("reclaim is suppressed when the bg worker is still live within the hung cutoff (probe says done)", () => {
-    const s = setup({ pidAlive: () => true, probeResult: true });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
+  test("idle, streak below confirm threshold → 'idle-pending' (bumped, not reclaimed)", () => {
+    const s = setup({ live: "idle", streak: 1, idleConfirmTicks: 2 });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("idle-pending");
+    expect(s.opts.bumpIdleStreak.calls.length).toBe(1);
+    expect(s.opts.bumpIdleStreak.calls[0]).toEqual(["/orch", "CTL-9", "implement"]);
+    // No reclaim/revive/escalate this tick — the streak is still building.
     expect(s.opts.emitComplete.calls.length).toBe(0);
-    expect(s.opts.appendEvent.calls.length).toBe(0);
-  });
-
-  test("a genuinely dead worker (pid gone) still reclaims when work is done", () => {
-    const s = setup({ pidAlive: () => false, probeResult: true });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
-    expect(s.opts.emitComplete.calls.length).toBe(1);
-  });
-
-  test("a live worker PAST the hung cutoff is NOT suppressed (genuinely hung → reclaim allowed)", () => {
-    // 16 min past mtime > 15 min cutoff → gate predicate false → falls through
-    // to branch (B), which reclaims because the probe reads done.
-    const s = setup({
-      pidAlive: () => true,
-      probeResult: true,
-      stateJsonMtime: 1_000,
-      nowMs: 1_000 + 16 * 60 * 1000,
-    });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
-    expect(s.opts.emitComplete.calls.length).toBe(1);
-  });
-
-  // NOTE (CTL-661, plan Open Question #3): the plan also wanted a "live worker
-  // on a probe-less phase is suppressed, not escalated" case. It is not
-  // constructible: the supersede guard at the top of reclaimDeadWorkIfPossible
-  // calls phaseIndex(phase), which THROWS for any phase outside PHASES+
-  // remediate, and every phase phaseIndex accepts has a WORK_DONE_PROBES entry
-  // — so branch (A) (`!hasProbe`) is unreachable for all real phases (a
-  // pre-existing property the plan's "What We're NOT Doing" acknowledges). The
-  // gate is placed in source order BEFORE branch (A) regardless, so the
-  // hypothetical is covered; we do not fabricate a fake phaseIndex to assert
-  // an unreachable path. The realizable precedence — gate over branch (B)'s
-  // reclaim — is pinned by the work-done cases above.
-  test("the gate's bg_job_id is the signal's, not a stale value (consults pidAlive with prevBgJobId)", () => {
-    const s = setup({ pidAlive: () => true, probeResult: true, bgJobId: "bg-77" });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
-    expect(s.opts.pidAlive.calls[0][0].bgJobId).toBe("bg-77");
-  });
-
-  test("regression: a live worker whose work is NOT done is still suppressed (the original C0 case)", () => {
-    const s = setup({ pidAlive: () => true, probeResult: false });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-quiet-suppressed");
     expect(s.opts.reviveDispatch.calls.length).toBe(0);
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
+  });
+
+  test("idle, streak reaches confirm threshold + work done → 'reclaimed' (streak cleared)", () => {
+    const s = setup({ live: "idle", streak: 2, idleConfirmTicks: 2, probeResult: true });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
+    expect(s.opts.emitComplete.calls.length).toBe(1);
+    // Once we proceed to act, the persisted streak is cleared.
+    expect(s.opts.resetIdleStreak.calls.length).toBe(1);
+  });
+
+  test("idle, streak reaches confirm threshold + work NOT done → 'revived' (streak cleared)", () => {
+    const s = setup({ live: "idle", streak: 2, idleConfirmTicks: 2, probeResult: false });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+    expect(s.opts.resetIdleStreak.calls.length).toBe(1);
+  });
+
+  test("absent → reclaim-eligible immediately (no idle-confirmation), work done → 'reclaimed'", () => {
+    const s = setup({ live: "absent", probeResult: true });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
+    expect(s.opts.emitComplete.calls.length).toBe(1);
+    // Absence skips the streak entirely — bump is never called.
+    expect(s.opts.bumpIdleStreak.calls.length).toBe(0);
+  });
+
+  test("absent + work NOT done → 'revived' (no idle-confirmation needed)", () => {
+    const s = setup({ live: "absent", probeResult: false });
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
+    expect(s.opts.reviveDispatch.calls.length).toBe(1);
+    expect(s.opts.bumpIdleStreak.calls.length).toBe(0);
+  });
+
+  test("the trigger consults liveness with the signal's bg_job_id (not a stale value)", () => {
+    const s = setup({ live: "absent", probeResult: true, bgJobId: "bg-77" });
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.liveness.calls[0][0]).toBe("bg-77");
   });
 });
 
@@ -2004,39 +1966,12 @@ describe("defaultKillBgJob — claude stop termination (CTL-657)", () => {
   });
 });
 
-// CTL-657: defaultPidAlive is the keep-alive signal "is this bg worker still a
-// live `claude agents` session?". It delegates to isBgJobAlive (claude-agents.mjs);
-// the seam is `isAlive`. Best-effort — any throw returns false so the caller's
-// existing revive path is preserved. Critically, the legacy setupReviveScenario
-// tests use bgJobId "bg-9" (not a valid short id), and isBgJobAlive returns
-// false for it WITHOUT shelling out, so those revive tests stay green unchanged.
-describe("defaultPidAlive — claude-agents keep-alive (CTL-657)", () => {
-  test("delegates to the isAlive seam (true)", () => {
-    const isAlive = recorder(true);
-    expect(defaultPidAlive({ bgJobId: "12345678" }, { isAlive })).toBe(true);
-    expect(isAlive.calls).toHaveLength(1);
-    expect(isAlive.calls[0][0]).toBe("12345678");
-  });
-
-  test("delegates to the isAlive seam (false → caller's revive path runs)", () => {
-    const isAlive = recorder(false);
-    expect(defaultPidAlive({ bgJobId: "12345678" }, { isAlive })).toBe(false);
-  });
-
-  test("a throwing isAlive seam is swallowed → false", () => {
-    const isAlive = () => {
-      throw new Error("claude agents exploded");
-    };
-    expect(defaultPidAlive({ bgJobId: "12345678" }, { isAlive })).toBe(false);
-  });
-
-  test("production default: malformed bgJobId ('bg-9') → false, no shell-out", () => {
-    // No isAlive seam → the real isBgJobAlive runs. "bg-9" is not a valid short
-    // id, so it returns false before touching `claude agents`. This is the
-    // contract every legacy setupReviveScenario (bg-9, no seam) relies on.
-    expect(defaultPidAlive({ bgJobId: "bg-9" })).toBe(false);
-  });
-});
+// CTL-662 removed defaultPidAlive (the CTL-610/657 positive keep-alive seam) and
+// its tests: its sole consumer was the alive-quiet gate's `pidAlive` injection,
+// which is gone. Reclaim eligibility no longer asks "is the bg pid alive?" (a
+// binary presence check) but "what is the worker's `claude agents` status?" (the
+// three-valued busy|idle|absent reader livenessForBgJob, covered in
+// claude-agents.test.mjs). Presence is subsumed by `absent` (not listed → dead).
 
 describe("revive event envelope round-trip (write → countReviveEvents)", () => {
   let envCatalystDir;
@@ -2411,14 +2346,18 @@ describe("reclaimDeadWorkIfPossible — CTL-606 supersede guard", () => {
     expect(r).toBe("reclaimed");
   });
 
-  test("guard never fires for a live signal (no filesystem read on the hot path)", () => {
+  test("guard never fires for a busy (live) signal — no listTicketPhases read on the hot path", () => {
+    // CTL-662: a live worker is now `busy`, which returns 'alive-busy-suppressed'
+    // from the status branch ABOVE the supersede guard — so the guard's
+    // listTicketPhases read is never reached for a live worker.
     const listSpy = recorder(["triage", "research", "plan", "implement"]);
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
-      statJob: () => ({ exists: true, mtimeMs: Date.now() }), // fresh → not dead
+      statJob: () => ({ exists: true, mtimeMs: Date.now() }),
+      liveness: () => "busy",
       listTicketPhases: listSpy,
     });
-    expect(r).toBe("noop");
-    expect(listSpy.calls.length).toBe(0); // guard runs only after the dead check
+    expect(r).toBe("alive-busy-suppressed");
+    expect(listSpy.calls.length).toBe(0); // guard runs only on the reclaim-eligible path
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -655,22 +655,30 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(order[1][1]).toEqual({ orchDir: orch, signal: sig });
   });
 
-  test("CTL-664: reclaim of an mtime-stale worker reports death_signal='mtime' + prev_state_json_mtime", () => {
+  // CTL-662: mtime is no longer a reclaim trigger, so a reclaim is never
+  // labeled death_signal='mtime'. The branch-(B) reclaim is reached only for an
+  // `absent` bg job or an idle-confirmed one — the death signal must report that
+  // liveness verdict. prev_state_json_mtime survives as pure telemetry (the last
+  // state.json write time), independent of the death-signal decision.
+  test("CTL-662: reclaim of an idle-confirmed worker reports death_signal='idle-confirmed' (never 'mtime') + prev_state_json_mtime", () => {
     const staleMtime = 1_000;
     let appended = null;
     const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), {
-      statJob: () => ({ mtimeMs: staleMtime }), // exists but stale
-      now: () => staleMtime + 10 * 60_000, // > STALE_MS
+      statJob: () => ({ mtimeMs: staleMtime }), // state.json present but stale — NOT a trigger
+      liveness: () => "idle", // CTL-662: status is the trigger
+      bumpIdleStreak: () => 99, // already past IDLE_CONFIRM_TICKS → reclaim-eligible
+      resetIdleStreak: () => {},
       probes: { implement: () => true },
       emitComplete: () => ({ code: 0 }),
       appendEvent: (args) => {
         appended = args;
       },
-      postReclaimMirror: () => {}, // stubbed (Phase 3 seam)
+      postReclaimMirror: () => {}, // keep hermetic (no linearis spawn)
       repoRoot: "/repo",
     });
     expect(r).toBe("reclaimed");
-    expect(appended.death_signal).toBe("mtime");
+    expect(appended.death_signal).toBe("idle-confirmed");
+    expect(appended.death_signal).not.toBe("mtime");
     expect(appended.prev_state_json_mtime).toBe(staleMtime);
   });
 


### PR DESCRIPTION
## CTL-662 — Status-based reclaim: retire mtime false-dead triggers

Keys the execution-core daemon's reclaim decision on the worker's live
`claude agents` status (busy / idle / absent) instead of `state.json` mtime.
This fixes the proven failure mode where a **busy** in-process sub-agent
fan-out worker (e.g. research/plan/verify doing multi-minute work that never
touches its signal mtime) was false-reclaimed once its mtime went stale —
the `worker-10d6f123` regression.

### What changed

**Phase 1 — `livenessForBgJob` three-valued reader** (`claude-agents.mjs`)
A standalone reader that maps a bg job to `busy | idle | absent` from
`claude agents --json`.

**Phases 2-3 — wire it into reclaim, retire mtime triggers** (`recovery.mjs`)
`reclaimDeadWorkIfPossible` now keys the death trigger on liveness, not mtime:
- **busy** → NEVER auto-reclaimed (`alive-busy-suppressed`); resets the idle
  streak. Only permitted action is the high-ceiling no-progress backstop:
  busy past `BUSY_CEILING_MS` with no committed work → `escalateOnce('busy-ceiling-exceeded')`, never a silent reclaim.
- **idle** → reclaim-eligible only after `IDLE_CONFIRM_TICKS` consecutive idle
  observations (persisted `.idle-streak-<phase>` marker, not an mtime window),
  then `work-done ? reclaim+advance : revive`.
- **absent** → reclaim-eligible immediately (absence is unambiguous).

Deleted as reclaim triggers: `STALE_MS`, `KILL_RECENT_ACTIVITY_MS`,
`HUNG_CUTOFF_MS`, the `effectivelyDead` mtime gate, the CTL-610/661
`isAliveQuiet` keep-alive gate, and the orphaned `defaultPidAlive` seam.
mtime is retained only as revive-audit telemetry.

**Remediation — additive CTL-664 rebase + status `death_signal`**
Rebased onto current origin/main and resolved the complementary
`recovery.test.mjs` conflict **additively** — kept both CTL-664's
reclaim-observability tests and CTL-662's status-trigger tests. `death_signal`
is now derived from the liveness verdict (`absent` vs `idle-confirmed`), never
`mtime`.

### Verification (verify.json, regression_risk 2)
- `tests_core` (claude-agents + recovery): **164 pass / 0 fail**
- `tests_guarantees` (integration-ctl-587 + work-done-probes): **77 pass / 0 fail**
- `tests_config`: **2 pass / 0 fail**
- `merge_conflict`: **CLEAN** vs origin/main
- `trigger_removal`: 0 active refs to retired mtime triggers
- `reward_hacking`: clean
- CTL-587/606/610/661 guarantees preserved

`scheduler.test.mjs` shows 8 sandbox-only failures (detached `nohup` spawn
blocked in the bg-job sandbox); `scheduler.mjs` is not in this diff — these
pass on a real machine/CI.

### Review (review.json)
`reviewPassed: true` — 3 low-severity findings, all deferred/accepted/sandbox
artifacts; no remediation required.

Closes CTL-662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
