### PR TITLE
CTL-670: Add always-running path-aware docs-gate workflow

### DIFF
--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -1,0 +1,48 @@
+name: docs-gate
+
+# Required status check for merges to main. Runs on EVERY PR (no path filter) so
+# the required context always reports — see configuration.md and CTL-670. The job
+# itself is path-aware: it only builds the docs site when docs-relevant files
+# changed, so non-docs PRs pass in seconds while docs PRs block until the build
+# is green. Cloudflare Pages still deploys via Build watch paths but is no longer
+# a required check.
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  docs-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute changed paths
+        id: changed
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+               | bash scripts/ci/docs-paths-changed.sh; then
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip (no docs changes)
+        if: steps.changed.outputs.docs == 'false'
+        run: echo "No docs-relevant changes — docs build not required for this PR."
+
+      - uses: actions/setup-node@v4
+        if: steps.changed.outputs.docs == 'true'
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Build docs site
+        if: steps.changed.outputs.docs == 'true'
+        working-directory: website
+        run: |
+          npm ci
+          npm run build

--- a/docs/ci-required-checks-rollout.md
+++ b/docs/ci-required-checks-rollout.md
@@ -1,0 +1,171 @@
+# CI required-checks rollout — swap `Cloudflare Pages` → `docs-gate` (CTL-670)
+
+Operator runbook for making `docs-gate` the sole required status check on `main` and demoting the
+slow `Cloudflare Pages` preview build to a non-required, build-watch-path-gated deploy.
+
+**Why:** ~75% of PRs change nothing under `website/`, yet every PR pays the ~3-min Cloudflare Pages
+build before it can merge, because `Cloudflare Pages` is the repo's *sole* required check under a
+strict policy. Cloudflare posts **no** check-run/commit-status when a build is skipped (CI Skip,
+build watch paths, or branch deployment controls), so we cannot simply skip the CF build on non-docs
+PRs — that would leave a required check that never reports, blocking every non-docs PR forever.
+Instead we introduce an in-repo `docs-gate` Action that *always* reports (honoring the invariant in
+[configuration.md](https://github.com/coalesce-labs/catalyst/blob/main/website/src/content/docs/reference/configuration.md):
+"only mark a check as required if it runs on every PR to `main`"), make **it** the required check,
+and let Cloudflare Pages keep deploying via watch paths without being required.
+
+**What `docs-gate` does** (`.github/workflows/docs-gate.yml`): runs on every PR with no path filter;
+computes changed paths and delegates the docs-relevance decision to
+`scripts/ci/docs-paths-changed.sh` (docs-relevant = anything under `website/`, or any
+`plugins/*/CHANGELOG.md` — the changelog dependency in `website/astro.config.mjs`). Non-docs PRs
+pass in seconds; docs PRs run `npm ci && npm run build` and must be green.
+
+---
+
+## ⚠️ Critical ordering invariant
+
+**Never set the Cloudflare "Build watch paths" (step 5) before removing `Cloudflare Pages` from the
+required set (step 4).** In the gap between those two actions, non-docs PRs would skip the CF build
+(no status posted) while CF is still required → every non-docs PR becomes permanently unmergeable.
+The ordering below keeps `main` mergeable at every step, and every step is reversible (re-add
+`Cloudflare Pages` to the required set to roll back).
+
+Read branch protection from the **ruleset** endpoint, not classic protection — the classic
+`/branches/main/protection` endpoint returns **404** for this repo and reading it lies:
+
+```bash
+gh api repos/coalesce-labs/catalyst/rules/branches/main
+```
+
+---
+
+## Rollout steps
+
+### 1. Merge the `docs-gate` workflow (this PR)
+
+Once merged, `docs-gate` runs on subsequent PRs but is **not yet required**. (This PR itself is
+still gated by the current `Cloudflare Pages`-only requirement — that is fine.)
+
+### 2. Empirical pre-flight (research OQ #1) — confirm the CF skip behavior
+
+Open a **scratch non-docs PR** (e.g. touch a root file). Confirm `docs-gate` passes fast:
+
+```bash
+gh pr checks <n>           # docs-gate should complete in seconds with the
+                           # "No docs-relevant changes" log line
+```
+
+At this point `Cloudflare Pages` still builds — expected, because CF watch paths are not set yet.
+This step exists to confirm the vendor-documented skip behavior empirically *before* touching
+branch protection.
+
+### 3. Add `docs-gate` to the required set **alongside** `Cloudflare Pages`
+
+Both required. Nothing skips yet, so this is safe. Verify on an open PR that `docs-gate` reports.
+
+```bash
+# Read the current ruleset and find the required_status_checks rule + the ruleset id.
+gh api repos/coalesce-labs/catalyst/rules/branches/main
+gh api repos/coalesce-labs/catalyst/rulesets --jq '.[] | {id, name}'
+
+# Fetch the full ruleset, edit the required_status_checks rule to list BOTH
+# "Cloudflare Pages" and "docs-gate" (keep strict_required_status_checks_policy: true),
+# then PUT it back.
+gh api repos/coalesce-labs/catalyst/rulesets/<RULESET_ID> > /tmp/ruleset.json
+# (edit /tmp/ruleset.json: required_status_checks → [Cloudflare Pages, docs-gate], strict=true)
+gh api -X PUT repos/coalesce-labs/catalyst/rulesets/<RULESET_ID> --input /tmp/ruleset.json
+```
+
+> The `docs-gate` required-context **string** is the job name. With job key `docs-gate` (and `name:`
+> defaulting to it) the context is `docs-gate`. Confirm on the first PR run:
+> `gh pr checks <n> --json name`.
+
+### 4. Remove `Cloudflare Pages` from the required set
+
+Now only `docs-gate` is required. CF still builds but no longer gates merges — harmless.
+
+```bash
+# Edit /tmp/ruleset.json: required_status_checks → [docs-gate] only, strict=true
+gh api -X PUT repos/coalesce-labs/catalyst/rulesets/<RULESET_ID> --input /tmp/ruleset.json
+```
+
+### 5. Set Cloudflare "Build watch paths"
+
+In the Cloudflare Pages dashboard: **Settings → Builds & deployments → Build watch paths**. Set
+**Include paths** to mirror the Phase 1 docs-relevant set (CF `*` crosses `/`, so `website/*`
+recurses):
+
+- `website/*`
+- `plugins/*/CHANGELOG.md`
+
+Now non-docs PRs skip the CF build and are no longer blocked.
+
+> Keep this include set in sync with `scripts/ci/docs-paths-changed.sh`'s two patterns. If they
+> drift, a PR could build in CF but skip `docs-gate`'s build (or vice-versa).
+
+### 6. Confirm the skip behavior on the scratch non-docs PR
+
+```bash
+gh pr checks <n>   # expect: docs-gate pass; NO "Cloudflare Pages" row (CF skipped, no status)
+```
+
+### 7. Confirm docs PRs still deploy
+
+Open a scratch `website/` PR:
+
+```bash
+gh pr checks <n>   # expect: docs-gate running the build, AND a "Cloudflare Pages" deploy row
+```
+
+Optionally prove the gate blocks broken docs: push a deliberately malformed `.mdx` and confirm
+`docs-gate` **fails**.
+
+### 8. Re-verify `phase-monitor-merge` picks up `docs-gate` dynamically
+
+The merge monitor reads the required-check set from the ruleset at runtime — it does **not**
+hardcode `Cloudflare Pages`. Confirm no hardcoded required-check string regressed:
+
+```bash
+grep -rn "Cloudflare Pages" plugins/dev/scripts plugins/dev/skills | grep -iv test
+```
+
+This should return nothing that treats `Cloudflare Pages` as *the required check*. No
+`phase-monitor-merge` code change is needed.
+
+---
+
+## End-state verification
+
+```bash
+gh api repos/coalesce-labs/catalyst/rules/branches/main \
+  --jq '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks'
+# → lists docs-gate, NOT Cloudflare Pages; strict_required_status_checks_policy: true
+```
+
+- A real non-docs PR (e.g. the next pipeline PR) merges without waiting on CF.
+- A real docs PR builds in `docs-gate` and deploys via CF.
+- `phase-monitor-merge` merges a post-rollout PR without manual intervention.
+
+## Rollback
+
+Re-add `Cloudflare Pages` to the required set (step 3 in reverse) and/or clear the CF Build watch
+paths so CF builds on every push again. Every step above is individually reversible.
+
+## Notes / edge cases
+
+- **CF force-builds** on 0-file, 3000+-file, or 20+-commit pushes regardless of watch paths. These
+  produce a `Cloudflare Pages` status on PRs that `docs-gate` classifies non-docs — harmless (CF is
+  no longer required), but worth knowing if anyone re-adds CF to the required set.
+- **Hard-block on deploy vs build** is out of scope. `docs-gate` blocks docs PRs on the in-CI
+  `astro build`, not the CF *deployment*. Blocking merge on the CF preview/production deploy itself
+  needs a different mechanism (a job polling the CF deployment commit-status / CF API) and is a
+  follow-up — it is *not* achievable by keeping CF as a required check while it skips.
+- **Context-name coupling:** if the `docs-gate` job is ever renamed, the ruleset's required-context
+  string must be updated in lockstep (the same coupling `Cloudflare Pages` had).
+
+## References
+
+- [`website/src/content/docs/reference/configuration.md`](https://github.com/coalesce-labs/catalyst/blob/main/website/src/content/docs/reference/configuration.md)
+  — the required-check model and the "only require checks that run on every PR" invariant.
+- `.github/workflows/docs-gate.yml` — the always-running, path-aware gate.
+- `scripts/ci/docs-paths-changed.sh` — the docs-relevance decision helper (keep in sync with the CF
+  watch-path include set).

--- a/plugins/dev/scripts/__tests__/docs-gate.test.sh
+++ b/plugins/dev/scripts/__tests__/docs-gate.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tests for scripts/ci/docs-paths-changed.sh — the docs-relevance decision
+# helper behind the docs-gate required check (CTL-670).
+# Run: bash plugins/dev/scripts/__tests__/docs-gate.test.sh
+#
+# Contract under test: the helper reads newline-delimited changed paths on
+# stdin, prints "docs" + exits 0 if ANY path is docs-relevant (would change
+# what the Cloudflare Pages docs build deploys), else prints "nodocs" + exits 1.
+# Docs-relevant = anything under website/, or any plugins/<name>/CHANGELOG.md
+# (the docs build renders changelog pages from ../plugins/*/CHANGELOG.md — see
+# website/astro.config.mjs).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/ci/docs-paths-changed.sh"
+
+FAILURES=0
+PASSES=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+# run_case LABEL EXPECTED_OUTPUT EXPECTED_RC <<< "paths"
+# Feeds the heredoc/stdin to the helper and asserts both its stdout and exit code.
+run_case() {
+  local label="$1" exp_out="$2" exp_rc="$3" input="$4"
+  local out rc
+  out="$(printf '%s' "$input" | bash "$SCRIPT" 2>/dev/null)"
+  rc=$?
+  assert_eq "${label} (output)" "$exp_out" "$out"
+  assert_eq "${label} (exit code)" "$exp_rc" "$rc"
+}
+
+echo "docs-gate: docs-paths-changed.sh"
+
+# 1. A single website/ file → docs, 0
+run_case "single website/ file" "docs" "0" $'website/src/content/docs/index.mdx\n'
+
+# 2. A nested website/ file (config) → docs, 0
+run_case "nested website/ file" "docs" "0" $'website/astro.config.mjs\n'
+
+# 3. A plugin changelog → docs, 0 (the astro.config.mjs changelog dependency)
+run_case "dev changelog" "docs" "0" $'plugins/dev/CHANGELOG.md\n'
+
+# 4. Another plugin's changelog → docs, 0
+run_case "pm changelog" "docs" "0" $'plugins/pm/CHANGELOG.md\n'
+
+# 5. A pure non-docs change → nodocs, 1
+run_case "non-docs scheduler" "nodocs" "1" $'plugins/dev/scripts/scheduler.mjs\n'
+
+# 6. Root files that are not deployed → nodocs, 1
+run_case "root non-docs files" "nodocs" "1" $'README.md\npackage.json\n'
+
+# 7. Mixed: any docs-relevant path wins → docs, 0
+run_case "mixed wins docs" "docs" "0" $'plugins/dev/scripts/x.mjs\nwebsite/src/x.md\n'
+
+# 8. A non-CHANGELOG file under plugins/ → nodocs, 1 (guard against over-broad plugins/ match)
+run_case "plugins non-changelog" "nodocs" "1" $'plugins/dev/scripts/y.ts\n'
+
+# 9. Empty stdin (no changed files) → nodocs, 1
+run_case "empty stdin" "nodocs" "1" ""
+
+echo
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/ci/docs-paths-changed.sh
+++ b/scripts/ci/docs-paths-changed.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# scripts/ci/docs-paths-changed.sh — CTL-670.
+# Decide whether a PR's changed paths are "docs-relevant" (i.e. would change what
+# the Cloudflare Pages docs build deploys). Reads newline-delimited changed paths
+# on stdin. Prints "docs" + exit 0 if any path is docs-relevant; else "nodocs" + exit 1.
+#
+# Docs-relevant = anything under website/, or any plugins/<name>/CHANGELOG.md (the docs
+# build renders changelog pages from ../plugins/*/CHANGELOG.md — see
+# website/astro.config.mjs). Pure string matching; no git, no network.
+#
+# Consumed by .github/workflows/docs-gate.yml: that workflow is the sole required
+# check for merges to main and runs on every PR (no path filter), so the required
+# context always reports. The build step it gates only runs when this helper says
+# "docs". Keep the two docs-relevant patterns here in sync with the Cloudflare Pages
+# "Build watch paths" include set (website/* + plugins/*/CHANGELOG.md) — see
+# docs/ci-required-checks-rollout.md.
+set -uo pipefail
+
+is_docs_path() {
+  local p="$1"
+  case "$p" in
+    website/*) return 0 ;;
+  esac
+  # plugins/<name>/CHANGELOG.md — exactly one path segment after plugins/.
+  if [[ "$p" =~ ^plugins/[^/]+/CHANGELOG\.md$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if is_docs_path "$line"; then
+    echo "docs"
+    exit 0
+  fi
+done
+
+echo "nodocs"
+exit 1

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -265,26 +265,32 @@ This gives you a fully automated merge path where Catalyst can:
 
 without waiting for a human approval click.
 
-For this repo shape, the recommended required check currently enabled in GitHub is:
+For this repo shape, the recommended (and only) required check is:
 
-- `Cloudflare Pages`
+- `docs-gate`
 
-Once your repository runs the following checks on **every** PR to `main`, you should add them as
-required checks too:
+`docs-gate` is an in-repo GitHub Action (`.github/workflows/docs-gate.yml`) that runs on **every**
+PR to `main` with no path filter, so the required context always reports. It is path-aware: on
+non-docs PRs it passes in seconds, and on docs PRs (anything under `website/`, or a
+`plugins/*/CHANGELOG.md` the docs build renders) it runs `npm run build` (`astro build`) and must
+be green. This lets the slow `Cloudflare Pages` preview build be **build-watch-path gated and no
+longer required** — non-docs PRs (the ~75% that change nothing the docs site deploys) merge without
+waiting on it, while docs PRs still block on the in-CI build. See
+[CI required checks rollout](https://github.com/coalesce-labs/catalyst/blob/main/docs/ci-required-checks-rollout.md)
+for the operator runbook that performs this swap safely (CTL-670).
 
-- `audit-references`
-- `check-versions`
-- `validate`
-
-`Cloudflare Pages` covers preview deploy readiness. The other three checks are repository-owned
-guardrails:
+`audit-references`, `check-versions`, and `validate` also run on every PR and report status, but are
+**not** required gates. They are repository-owned guardrails you may add to the required set if you
+want them enforced:
 
 - `audit-references` catches broken plugin references
 - `check-versions` verifies plugin changes are releasable through Release Please
 - `validate` checks release configuration consistency
 
 If your repository has additional always-on checks, add them too. The important rule is: only mark a
-check as required if it runs on every PR to `main`.
+check as required if it runs on every PR to `main` — which is exactly why `docs-gate` (no path
+filter) is the required check and `Cloudflare Pages` (skips on non-docs PRs, posting no status) is
+not.
 
 ### Optional Human-In-The-Loop Mode
 


### PR DESCRIPTION
## Summary

Introduces `docs-gate`, an in-repo GitHub Action that becomes the **sole required status check** for merges to `main`, replacing the slow `Cloudflare Pages` preview build as the required gate.

The problem: `Cloudflare Pages` is the repo's only required check under a strict policy, yet ~75% of PRs change nothing under `website/`. Every PR pays the ~3-min CF build before it can merge. We can't just skip the CF build on non-docs PRs because Cloudflare posts **no** check-run/commit-status when a build is skipped — that would leave a required check that never reports, blocking every non-docs PR forever.

The fix: an always-running, path-aware `docs-gate` Action that *always* reports (honoring the invariant "only require checks that run on every PR to `main`"), is path-aware so non-docs PRs pass in seconds, and lets `Cloudflare Pages` keep deploying via watch paths without being required.

## Changes

- **`scripts/ci/docs-paths-changed.sh`** (Phase 1) — docs-relevance decision helper. Reads newline-delimited changed paths on stdin; prints `docs` + exit 0 if any path is docs-relevant, else `nodocs` + exit 1. Docs-relevant = anything under `website/`, or any `plugins/<name>/CHANGELOG.md` (the docs build renders changelog pages from `../plugins/*/CHANGELOG.md` per `website/astro.config.mjs`). Pure string matching — no git, no network.
- **`plugins/dev/scripts/__tests__/docs-gate.test.sh`** (Phase 1) — 9 test cases for the helper covering website/ files, nested paths, plugin changelogs, non-docs changes, mixed inputs, the over-broad-`plugins/` guard, and empty stdin.
- **`.github/workflows/docs-gate.yml`** (Phase 2) — the always-running workflow. Runs on every PR to `main` with no path filter so the required context always reports. Computes changed paths and delegates the decision to `docs-paths-changed.sh`; on non-docs PRs it logs a skip and passes fast, on docs PRs it runs `npm ci && npm run build` (`astro build`) and must be green.
- **`docs/ci-required-checks-rollout.md`** (Phase 3) — operator runbook for swapping `Cloudflare Pages` → `docs-gate` as the required check, with a critical ordering invariant (never set CF Build watch paths before removing CF from the required set, or non-docs PRs become permanently unmergeable), ruleset-endpoint guidance (`/branches/main/protection` 404s — use `/rules/branches/main`), step-by-step rollout, end-state verification, rollback, and edge cases (CF force-builds, deploy-vs-build scope, context-name coupling).
- **`website/src/content/docs/reference/configuration.md`** (Phase 3) — updates the required-check model docs to describe `docs-gate` as the recommended/only required check, demotes `Cloudflare Pages` to a non-required build-watch-path-gated deploy, and reframes `audit-references`/`check-versions`/`validate` as optional guardrails.

## How it works

`docs-gate` runs on every PR (`on: pull_request: branches: [main]`). A "Compute changed paths" step diffs `origin/<base>...HEAD` and pipes the file list into `scripts/ci/docs-paths-changed.sh`, setting `docs=true|false`. The Node setup + `npm ci && npm run build` steps are gated on `docs == 'true'`; a no-op skip step runs when `docs == 'false'`. Either way the `docs-gate` context reports a conclusion, so it satisfies the strict required-check policy on every PR.

`phase-monitor-merge` reads the required-check set from the ruleset at runtime and does not hardcode `Cloudflare Pages`, so no merge-monitor code change is needed.

## Testing

- `bash plugins/dev/scripts/__tests__/docs-gate.test.sh` — 9 assertions over the decision helper (all passing).

## Rollout note

Merging this PR ships the workflow but does **not** make it required. The branch-protection swap (adding `docs-gate` to the required set, removing `Cloudflare Pages`, then setting CF Build watch paths) is a manual operator step documented in `docs/ci-required-checks-rollout.md` and must follow the ordering invariant.

Refs: CTL-670
