### PR TITLE
feat(dev): aggregate sub-agent-inclusive cost/token totals for the phase mirror footer (CTL-666)

### DIFF
--- a/plugins/dev/scripts/__tests__/extract-cost-from-jsonl.test.sh
+++ b/plugins/dev/scripts/__tests__/extract-cost-from-jsonl.test.sh
@@ -176,6 +176,18 @@ build_jsonl_with_turns() {
   done
 }
 
+# Build a deterministic sub-agent JSONL alongside a parent at
+# <parent-without-.jsonl>/subagents/agent-<id>.jsonl — the exact path the
+# extractor derives for `--include-subagents` (research §deterministic path:
+# strip .jsonl from the parent, then /subagents/*.jsonl). Reuses the parent
+# builder so the line shape stays identical (CTL-666).
+build_subagent_jsonl() {
+  local parent="$1" id="$2"; shift 2
+  local subdir="${parent%.jsonl}/subagents"
+  mkdir -p "$subdir"
+  build_jsonl_single_model "${subdir}/agent-${id}.jsonl" "$@"
+}
+
 # Build a JSONL with a single assistant event for an unknown (unpriced) model.
 build_jsonl_unknown_model() {
   local out="$1"; shift
@@ -314,6 +326,88 @@ run "real fixture durationMs from turn_duration" \
   bash -c "[ \"\$(echo '$USAGE' | jq -r .durationMs)\" = '1406556' ]"
 run "real fixture numTurns counts only assistant" \
   bash -c "[ \"\$(echo '$USAGE' | jq -r .numTurns)\" = '2' ]"
+
+# ─── Test 12: default path ignores sub-agents (signal.cost contract guard) ────
+# A parent JSONL plus a sub-agent file with extra usage; WITHOUT the flag the
+# sub-agent file must be invisible, so existing callers (orchestrate-roll-usage,
+# which feeds signal.cost) keep byte-identical parent-only semantics.
+SA_REGR="${SCRATCH}/sa-default/parent.jsonl"
+mkdir -p "$(dirname "$SA_REGR")"
+build_jsonl_single_model "$SA_REGR" --model claude-opus-4-7 --assistant-events 1 \
+  --input-tokens 1000 --output-tokens 500
+build_subagent_jsonl "$SA_REGR" x --model claude-opus-4-7 --assistant-events 1 \
+  --input-tokens 4000 --output-tokens 2000
+USAGE=$("$HELPER" --jsonl "$SA_REGR" --pricing "$PRICING")
+run "default path ignores sub-agent file (inputTokens parent-only)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '1000' ]"
+run "default path ignores sub-agent file (numTurns parent-only)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .numTurns)\" = '1' ]"
+# parent cost = 1000*15/1e6 + 500*75/1e6 = 0.015 + 0.0375 = 0.0525
+run "default path ignores sub-agent file (costUSD parent-only)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .costUSD)\" = '0.0525' ]"
+
+# ─── Test 13: --include-subagents sums parent + sub-agent ─────────────────────
+USAGE=$("$HELPER" --jsonl "$SA_REGR" --pricing "$PRICING" --include-subagents)
+# input = 1000+4000 = 5000, output = 500+2000 = 2500
+# cost = 5000*15/1e6 + 2500*75/1e6 = 0.075 + 0.1875 = 0.2625
+run "include-subagents sums inputTokens (parent+sub)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '5000' ]"
+run "include-subagents sums outputTokens (parent+sub)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .outputTokens)\" = '2500' ]"
+run "include-subagents sums costUSD (parent+sub)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .costUSD)\" = '0.2625' ]"
+run "include-subagents numTurns is combined assistant count" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .numTurns)\" = '2' ]"
+
+# ─── Test 14: multiple sub-agent files all summed ────────────────────────────
+SA_MULTI="${SCRATCH}/sa-multi/parent.jsonl"
+mkdir -p "$(dirname "$SA_MULTI")"
+build_jsonl_single_model "$SA_MULTI" --assistant-events 1 --input-tokens 1000 --output-tokens 0
+build_subagent_jsonl "$SA_MULTI" a --assistant-events 1 --input-tokens 2000 --output-tokens 0
+build_subagent_jsonl "$SA_MULTI" b --assistant-events 1 --input-tokens 3000 --output-tokens 0
+USAGE=$("$HELPER" --jsonl "$SA_MULTI" --pricing "$PRICING" --include-subagents)
+run "multiple sub-agent files summed (inputTokens 1000+2000+3000)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '6000' ]"
+run "multiple sub-agent files summed (numTurns = 3)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .numTurns)\" = '3' ]"
+
+# ─── Test 15: no subagents/ dir present + flag → parent-only, exit 0 ──────────
+SA_NONE="${SCRATCH}/sa-none/parent.jsonl"
+mkdir -p "$(dirname "$SA_NONE")"
+build_jsonl_single_model "$SA_NONE" --assistant-events 1 --input-tokens 1000 --output-tokens 0
+USAGE=$("$HELPER" --jsonl "$SA_NONE" --pricing "$PRICING" --include-subagents)
+run "no subagents dir + flag → parent-only inputTokens" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '1000' ]"
+run "no subagents dir + flag exits 0" \
+  bash -c "'$HELPER' --jsonl '$SA_NONE' --pricing '$PRICING' --include-subagents >/dev/null"
+
+# ─── Test 16: partially-written sub-agent line tolerated ──────────────────────
+SA_TRUNC="${SCRATCH}/sa-trunc/parent.jsonl"
+mkdir -p "$(dirname "$SA_TRUNC")"
+build_jsonl_single_model "$SA_TRUNC" --assistant-events 1 --input-tokens 1000 --output-tokens 0
+build_subagent_jsonl "$SA_TRUNC" trunc --assistant-events 1 --input-tokens 2000 --output-tokens 0
+# Append a truncated/non-JSON fragment as the last line (no trailing newline).
+printf '%s' '{"type":"assistant","message":{"model":"claude-opus-4-7","usage":{"input_to' \
+  >> "${SA_TRUNC%.jsonl}/subagents/agent-trunc.jsonl"
+USAGE=$("$HELPER" --jsonl "$SA_TRUNC" --pricing "$PRICING" --include-subagents)
+# valid lines: parent 1000 + sub-agent 2000 = 3000; the truncated line dropped
+run "partial sub-agent line tolerated (valid lines still summed = 3000)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '3000' ]"
+run "partial sub-agent line tolerated (exit 0, no parse abort)" \
+  bash -c "'$HELPER' --jsonl '$SA_TRUNC' --pricing '$PRICING' --include-subagents >/dev/null"
+
+# ─── Test 17: durationMs still comes from the parent ──────────────────────────
+# Sub-agent JSONLs carry no system.turn_duration events; the flag must not
+# change durationMs (research §3 — sub-agent files carry zero duration).
+SA_DUR="${SCRATCH}/sa-dur/parent.jsonl"
+mkdir -p "$(dirname "$SA_DUR")"
+build_jsonl_with_durations "$SA_DUR" --turns 2 --total-ms 30000
+build_subagent_jsonl "$SA_DUR" d --assistant-events 1 --input-tokens 500 --output-tokens 0
+USAGE=$("$HELPER" --jsonl "$SA_DUR" --pricing "$PRICING" --include-subagents)
+run "durationMs unchanged by flag (parent-only turn_duration = 30000)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .durationMs)\" = '30000' ]"
+run "durationMs case still folds sub-agent tokens (inputTokens = 500)" \
+  bash -c "[ \"\$(echo '$USAGE' | jq -r .inputTokens)\" = '500' ]"
 
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-mirror-footer.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-mirror-footer.test.sh
@@ -33,8 +33,15 @@ assert_not_grep() {
 }
 
 # Build a worker dir (signal) + bg jobs dir (state.json) + conversation JSONL.
+#
+# with_usage (4th arg, default "no"): when "yes", the conversation assistant
+# events additionally carry message.usage AND a deterministic sub-agent JSONL
+# is written at <conv-without-.jsonl>/subagents/agent-x.jsonl with extra usage,
+# so the footer's CTL-666 cost segment resolves to a positive, sub-agent-
+# inclusive total. Default "no" keeps the original usage-free conv.jsonl so the
+# pre-existing tests (and the zero-usage fail-soft case) are unaffected.
 build_fixture() {
-  local case_dir="$1" with_bg="${2:-yes}" with_jsonl="${3:-yes}"
+  local case_dir="$1" with_bg="${2:-yes}" with_jsonl="${3:-yes}" with_usage="${4:-no}"
   local worker_dir="${case_dir}/orch/workers/CTL-449"
   local jobs_dir="${case_dir}/jobs"
   mkdir -p "$worker_dir" "$jobs_dir"
@@ -44,12 +51,28 @@ build_fixture() {
 JSON
 
   if [[ "$with_jsonl" == "yes" ]]; then
-    cat > "${case_dir}/conv.jsonl" <<'JSONL'
+    if [[ "$with_usage" == "yes" ]]; then
+      # Same model / Task+Agent / turn_duration shape as the default fixture
+      # (so the model, sub-agent-count, and active-duration assertions still
+      # hold) but with message.usage so a non-zero cost resolves.
+      cat > "${case_dir}/conv.jsonl" <<'JSONL'
+{"type":"assistant","message":{"model":"claude-opus-4-7","usage":{"input_tokens":1000,"output_tokens":500,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"content":[{"type":"tool_use","name":"Task","input":{}}]}}
+{"type":"assistant","message":{"model":"claude-opus-4-7","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"content":[{"type":"tool_use","name":"Agent","input":{}}]}}
+{"type":"system","subtype":"turn_duration","durationMs":472338}
+{"type":"assistant","message":{"model":"claude-opus-4-7","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"content":[{"type":"text","text":"done"}]}}
+JSONL
+      mkdir -p "${case_dir}/conv/subagents"
+      cat > "${case_dir}/conv/subagents/agent-x.jsonl" <<'JSONL'
+{"type":"assistant","message":{"model":"claude-opus-4-7","usage":{"input_tokens":4000,"output_tokens":2000,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}}}}
+JSONL
+    else
+      cat > "${case_dir}/conv.jsonl" <<'JSONL'
 {"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"tool_use","name":"Task","input":{}}]}}
 {"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"tool_use","name":"Agent","input":{}}]}}
 {"type":"system","subtype":"turn_duration","durationMs":472338}
 {"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"text","text":"done"}]}}
 JSONL
+    fi
   fi
 
   if [[ "$with_bg" == "yes" ]]; then
@@ -129,6 +152,51 @@ for phase in research plan implement verify remediate review triage pr monitor-m
     fail "phase-${phase} wires the footer helper — not found in $skill"
   fi
 done
+
+# ─── Test 6: CTL-666 cost segment present when JSONL + pricing resolve ────────
+echo ""
+echo "Test 6: cost segment present (sub-agent-inclusive) when usage resolves"
+C6="$(build_fixture "${SCRATCH}/cost" yes yes yes)"
+OUT6="$(run_footer "$C6")"
+# parent 1000in/500out opus = 0.0525; sub-agent 4000in/2000out = 0.21; total 0.2625 → ~$0.26
+assert_grep '~\$[0-9]+\.[0-9]{2}' "$OUT6" "cost segment has a \$X.XX figure"
+assert_grep '~\$0\.26' "$OUT6" "cost reflects parent+sub-agent total (not parent-only \$0.05)"
+# tokens: input 5000 + output 2500 = 7500 → 7.5k
+assert_grep '7\.5k tokens \(incl\. sub-agents\)' "$OUT6" "token total humanized + incl. sub-agents marker"
+# the cost segment is additive — the pre-existing line fields still resolve
+assert_grep 'model `claude-opus-4-7`' "$OUT6" "model still resolved alongside cost segment"
+assert_grep '2 sub-agent\(s\) launched' "$OUT6" "sub-agent count still resolved alongside cost segment"
+assert_grep 'active 7m 52s' "$OUT6" "active duration still resolved alongside cost segment"
+
+# ─── Test 7: fail-soft — no JSONL → no cost segment, footer otherwise intact ──
+echo ""
+echo "Test 7: fail-soft — no JSONL reachable → no cost segment"
+C7="$(build_fixture "${SCRATCH}/cost-nojsonl" no no)"
+OUT7="$(run_footer "$C7")"
+assert_grep '^---$' "$OUT7" "still emits footer separator"
+assert_not_grep '\$[0-9]' "$OUT7" "no cost segment when JSONL unresolvable"
+assert_not_grep 'incl\. sub-agents' "$OUT7" "no sub-agents marker when JSONL unresolvable"
+
+# ─── Test 8: fail-soft — zero-usage JSONL → no cost segment (no ~\$0.00) ───────
+echo ""
+echo "Test 8: fail-soft — zero-usage JSONL → cost segment omitted"
+C8="$(build_fixture "${SCRATCH}/cost-zero" yes yes)"   # default with_usage=no → no usage blocks
+OUT8="$(run_footer "$C8")"
+assert_grep 'model `claude-opus-4-7`' "$OUT8" "footer still resolves model on zero-usage JSONL"
+assert_not_grep '\$[0-9]' "$OUT8" "no cost segment when cost resolves to 0 (no ~\$0.00)"
+assert_not_grep 'incl\. sub-agents' "$OUT8" "no sub-agents marker on zero-usage JSONL"
+
+# ─── Test 9: fail-soft — pricing file missing → no cost segment, exit 0 ───────
+echo ""
+echo "Test 9: fail-soft — missing pricing file → cost segment omitted, exit 0"
+C9="$(build_fixture "${SCRATCH}/cost-nopricing" yes yes yes)"
+OUT9="$(env -u CLAUDE_CODE_SESSION_ID -u CATALYST_SESSION_ID \
+  CATALYST_BG_JOBS_DIR="${C9}/jobs" \
+  CATALYST_MIRROR_PRICING="/no/such/pricing.json" \
+  bash "$FOOTER" --orch-dir "${C9}/orch" --ticket CTL-449 --phase implement 2>/dev/null)"
+RC9=$?
+assert_not_grep '\$[0-9]' "$OUT9" "no cost segment when pricing file missing"
+[[ "$RC9" == "0" ]] && pass "exit 0 when pricing file missing" || fail "exit 0 when pricing file missing — got $RC9"
 
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/extract-cost-from-jsonl.sh
+++ b/plugins/dev/scripts/extract-cost-from-jsonl.sh
@@ -22,11 +22,17 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'EOF'
-usage: extract-cost-from-jsonl.sh --jsonl <path> --pricing <path>
+usage: extract-cost-from-jsonl.sh --jsonl <path> --pricing <path> [--include-subagents]
 
 required:
   --jsonl <path>     Claude conversation JSONL (~/.claude/projects/.../<sid>.jsonl)
   --pricing <path>   pricing table JSON (see plugins/dev/scripts/claude-pricing.json)
+
+optional:
+  --include-subagents  Also sum the deterministic sub-agent JSONLs derived from
+                       the parent path (<parent-without-.jsonl>/subagents/*.jsonl).
+                       Default OFF — every existing caller keeps parent-only,
+                       byte-identical output (the signal.cost contract).
 
 Emits a USAGE record on stdout matching the orchestrate-roll-usage.sh schema:
   { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens,
@@ -38,11 +44,12 @@ EOF
   exit 2
 }
 
-JSONL="" PRICING=""
+JSONL="" PRICING="" INCLUDE_SUBAGENTS=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --jsonl)   JSONL="$2";   shift 2 ;;
-    --pricing) PRICING="$2"; shift 2 ;;
+    --jsonl)              JSONL="$2";   shift 2 ;;
+    --pricing)            PRICING="$2"; shift 2 ;;
+    --include-subagents)  INCLUDE_SUBAGENTS=1; shift ;;
     -h|--help) usage ;;
     *) echo "unknown arg: $1" >&2; usage ;;
   esac
@@ -53,11 +60,36 @@ done
 [ -f "$JSONL" ]   || { echo "jsonl not found: $JSONL"     >&2; exit 1; }
 [ -f "$PRICING" ] || { echo "pricing not found: $PRICING" >&2; exit 1; }
 
-# Single jq pass: slurps the JSONL into an array, slurps pricing as a side
-# input, computes per-model token bucket → per-model cost → aggregate USAGE.
-# The reduce-over-assistant-events is the hot path; everything else is a
+# Resolve the input set. By default it is the parent JSONL alone. With
+# --include-subagents we also fold the deterministic sub-agent JSONLs that the
+# CLI writes for in-process Task/Agent sub-agents: strip `.jsonl` from the
+# parent's path to recover its session dir, then glob `<dir>/subagents/*.jsonl`
+# (the same linkScanPath → /subagents linkage documented in CTL-666 research).
+# Sub-agents complete before a phase's End block, so these files are fully
+# written by the time the footer (the only --include-subagents caller) runs.
+# This is invoked as `bash extract-cost-from-jsonl.sh` (a real bash shell), so
+# `shopt`/`nullglob` are safe here — NOT the zsh Bash-tool path.
+INPUTS=( "$JSONL" )
+if [ "$INCLUDE_SUBAGENTS" = "1" ]; then
+  shopt -s nullglob
+  SUBDIR="${JSONL%.jsonl}/subagents"
+  for f in "$SUBDIR"/*.jsonl; do INPUTS+=( "$f" ); done
+  shopt -u nullglob
+fi
+
+# Single jq aggregation: slurps the input events into an array, slurps pricing
+# as a side input, computes per-model token bucket → per-model cost → aggregate
+# USAGE. The reduce-over-assistant-events is the hot path; everything else is a
 # constant-time post-pass.
-jq -s --slurpfile pricing "$PRICING" '
+#
+# The inputs are concatenated through a tolerant raw-line pre-parse
+# (`jq -R 'fromjson? // empty'`) so a partially-written sub-agent file (last
+# line truncated mid-write) drops only the bad line instead of aborting the
+# whole run. The aggregation program below is byte-for-byte the original; only
+# its input source changed from one file arg to the sanitized stdin stream.
+cat "${INPUTS[@]}" 2>/dev/null \
+  | jq -R 'fromjson? // empty' 2>/dev/null \
+  | jq -s --slurpfile pricing "$PRICING" '
   ($pricing[0].models) as $p
   # Per-model token bucket
   | ([.[] | select(.type == "assistant" and .message.usage != null)]
@@ -102,4 +134,4 @@ jq -s --slurpfile pricing "$PRICING" '
       durationApiMs:       0,
       model:               ($primary.model // null)
     }
-' "$JSONL"
+'

--- a/plugins/dev/scripts/lib/phase-mirror-footer.sh
+++ b/plugins/dev/scripts/lib/phase-mirror-footer.sh
@@ -26,9 +26,15 @@
 #   * short job id         ← signal .bg_job_id, else first 8 hex of the uuid
 #   * working directory    ← bg state .cwd, else $PWD
 #
-# Cost/token totals are intentionally NOT emitted: the only reliable number
-# excludes sub-agent sessions (see CTL-666 to add a true sub-agent-inclusive
-# rollup, likely via OTEL).
+# Cost/token total (CTL-666): a best-effort, sub-agent-inclusive figure computed
+# via extract-cost-from-jsonl.sh --include-subagents over the resolved parent
+# JSONL (which also sums <parent>/subagents/*.jsonl). It is timing-safe — the
+# sub-agent JSONLs are fully written by End-block time — and fail-soft: the
+# `~$X.XX · <N> tokens (incl. sub-agents)` segment is appended to line 1 ONLY
+# when a positive cost resolves; otherwise the footer is byte-identical to
+# before. The canonical (exact, scrape-validated) total via an OTEL/Prometheus
+# query by linear_key remains a future enhancement (CTL-666 Open Questions) —
+# no shell PromQL client exists yet.
 #
 # Usage: phase-mirror-footer.sh --orch-dir <dir> --ticket <id> --phase <name>
 
@@ -106,11 +112,50 @@ fmt_duration() {
   fi
 }
 
+# Humanize a token count: ≥1M → "X.XM", ≥1k → "X.Xk", else the raw integer.
+# Pure bash/awk; fail-soft to the raw value for non-numeric input.
+humanize_tokens() {
+  local n="$1"
+  [[ "$n" =~ ^[0-9]+$ ]] || { printf '%s' "$n"; return; }
+  if [ "$n" -ge 1000000 ]; then
+    awk "BEGIN{printf \"%.1fM\", $n/1000000}"
+  elif [ "$n" -ge 1000 ]; then
+    awk "BEGIN{printf \"%.1fk\", $n/1000}"
+  else
+    printf '%s' "$n"
+  fi
+}
+
+# ── CTL-666 cost segment (fail-soft, sub-agent-inclusive) ─────────────────────
+# Compute a true cost/token total via the Phase-1 extractor with
+# --include-subagents, but only when the parent JSONL, the extractor, and the
+# pricing table all resolve. Every call is guarded (the footer runs under
+# `set -uo pipefail` with NO -e), so no branch here can produce a non-zero exit
+# or leak error text into the comment body. The segment is appended to LINE1
+# only when a strictly-positive cost resolves; otherwise it is omitted entirely
+# and the footer stays byte-identical to the pre-CTL-666 output.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+EXTRACTOR="${SCRIPT_DIR}/../extract-cost-from-jsonl.sh"
+PRICING="${CATALYST_MIRROR_PRICING:-${SCRIPT_DIR}/../claude-pricing.json}"
+COST_SEG=""
+if [ -n "$JSONL" ] && [ -f "$JSONL" ] && [ -x "$EXTRACTOR" ] && [ -f "$PRICING" ]; then
+  USAGE_JSON="$(bash "$EXTRACTOR" --jsonl "$JSONL" --pricing "$PRICING" \
+    --include-subagents 2>/dev/null || true)"
+  if [ -n "$USAGE_JSON" ]; then
+    COST_USD="$(jq -r '.costUSD // 0' <<<"$USAGE_JSON" 2>/dev/null || echo 0)"
+    TOK_TOTAL="$(jq -r '((.inputTokens//0)+(.outputTokens//0)+(.cacheReadTokens//0)+(.cacheCreationTokens//0))' <<<"$USAGE_JSON" 2>/dev/null || echo 0)"
+    if awk "BEGIN{exit !($COST_USD > 0)}" 2>/dev/null; then
+      COST_SEG="~\$$(printf '%.2f' "$COST_USD" 2>/dev/null || echo "$COST_USD") · $(humanize_tokens "$TOK_TOTAL") tokens (incl. sub-agents)"
+    fi
+  fi
+fi
+
 # ── Line 1: run metadata ──────────────────────────────────────────────────────
 LINE1="model \`${MODEL}\` · ${SUBS} sub-agent(s) launched"
 if [ "$ACTIVE_MS" -gt 0 ]; then
   LINE1="${LINE1} · active $(fmt_duration "$ACTIVE_MS")"
 fi
+[ -n "$COST_SEG" ] && LINE1="${LINE1} · ${COST_SEG}"
 
 # ── Line 2: identifiers + cwd (omit unknown id pieces) ────────────────────────
 LINE2="catalyst session \`${CAT_SID:-—}\`"


### PR DESCRIPTION
## Summary

Implements a trustworthy **cost + token total per phase that includes sub-agent sessions** for the Linear mirror footer (CTL-666). The phase's own `signal.cost` only captures the *parent* session JSONL; sub-agents/teams dispatched via `Task`/`Agent` write to separate, unlinked session logs and were silently undercounted.

This takes **Option 2 (cross-session JSONL aggregation)** from the ticket: discover the sub-agent session logs co-located with the phase run and sum them with the parent, behind an explicit opt-in so the existing parent-only contract is untouched.

## Changes

- **Phase 1 — `extract-cost-from-jsonl.sh`**: add opt-in `--include-subagents`. Default behavior is unchanged (parent session only, so `orchestrate-roll-usage`'s `session_metrics` contract stays parent-only). With the flag, it sums the parent JSONL plus sibling sub-agent session logs (sourced via nullglob), preserving the duration invariant.
- **Phase 2 — `lib/phase-mirror-footer.sh`**: emit a sub-agent-inclusive cost/token segment in the mirror footer using the new flag, e.g. `$1.97 / 4.8M tokens (incl. N sub-agents)`. Fail-soft: the footer wraps the call in `|| true` so a missing/partial log never breaks a mirror post.

## Verification

From the verify phase (`verify.json`), regression risk **1/10**, all gates green:

- `extract-cost-from-jsonl.test.sh` — 44/0 (6 new sub-agent cases: default-ignores-subagents, include-subagents sum, multi-file, no-dir, partial-line, duration-invariance)
- `phase-mirror-footer.test.sh` — 42/0 (4 new cost cases incl. fail-soft x3)
- `orchestrate-roll-usage.test.sh` — 91/0 (parent-only `signal.cost` contract intact)
- shellcheck 0.11.0 clean on both scripts; `bash -n` clean
- `git merge-tree` vs current `origin/main`: no conflicts
- Coverage: both new code paths have direct tests

Review phase: **PASS** (1 low-severity informational finding, self-mitigating — no remediation needed).

Closes CTL-666.
