### PR TITLE
CTL-674: Point sessions audit index at execution-core signal root

### DIFF
--- a/plugins/dev/scripts/execution-core/cli/sessions.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.mjs
@@ -25,7 +25,7 @@ import { fileURLToPath } from "node:url";
 import { shortIdFromSessionId, isSelfSession } from "../claude-ids.mjs";
 import { readWorkerSignals, TERMINAL } from "../signal-reader.mjs";
 import { emitReapIntent } from "../reap-intent.mjs";
-import { getRunsRoot } from "../config.mjs";
+import { getRunsRoot, getExecutionCoreDir } from "../config.mjs";
 import { lastSeenMsForSession } from "../session-recency.mjs";
 import { parseArgs, ArgError } from "./args.mjs";
 
@@ -149,23 +149,22 @@ export function parseSessionName(name) {
 // ─── I/O: signal index ───────────────────────────────────────────────────────
 
 /**
- * indexSignalsByBgJobId — walk every ~/catalyst/runs/<orchId>/workers tree and
- * index the nested phase signals by their 8-char bg_job_id, joining each onto
- * its orchestratorId. The CLI then looks up a live session's short id here to
- * recover worker status / ticket / phase. Missing runs root → empty map.
+ * indexSignalsByBgJobId — index nested bg phase signals by their 8-char
+ * bg_job_id short id so the CLI can join a live `claude agents` session onto
+ * its worker signal. Reads TWO roots:
+ *   • legacy runs/<orchId>/workers/...  — orchestratorId is the subdir name
+ *   • the execution-core orchDir (no orchId layer) — orchestratorId comes from
+ *     the signal's raw.orchestrator field
+ * The execution-core dir is indexed last so a live signal wins any short-id
+ * collision against a historical runs/ entry (CTL-674). Missing roots → skipped.
  */
-export function indexSignalsByBgJobId(runsRoot = getRunsRoot()) {
+export function indexSignalsByBgJobId(
+  runsRoot = getRunsRoot(),
+  execCoreDir = getExecutionCoreDir()
+) {
   const index = new Map();
-  let orchDirs;
-  try {
-    orchDirs = readdirSync(runsRoot, { withFileTypes: true });
-  } catch {
-    return index;
-  }
-  for (const entry of orchDirs) {
-    if (!entry.isDirectory()) continue;
-    const orchestratorId = entry.name;
-    const orchDir = join(runsRoot, orchestratorId);
+
+  const indexOrchDir = (orchDir, orchestratorIdFromDir) => {
     for (const sig of readWorkerSignals(orchDir)) {
       if (sig.liveness?.kind !== "bg" || !sig.liveness.value) continue;
       let shortId;
@@ -178,11 +177,28 @@ export function indexSignalsByBgJobId(runsRoot = getRunsRoot()) {
         status: sig.status,
         ticket: sig.ticket,
         phase: sig.phase,
-        orchestratorId,
+        orchestratorId: orchestratorIdFromDir ?? sig.raw?.orchestrator ?? null,
         worktreePath: sig.worktreePath,
       });
     }
+  };
+
+  // Legacy runs/<orchId> — orchestratorId is the subdir name.
+  let orchDirs = [];
+  try {
+    orchDirs = readdirSync(runsRoot, { withFileTypes: true });
+  } catch {
+    orchDirs = []; // no runs root → skip the legacy walk
   }
+  for (const entry of orchDirs) {
+    if (!entry.isDirectory()) continue;
+    indexOrchDir(join(runsRoot, entry.name), entry.name);
+  }
+
+  // Execution-core single orchDir (no orchId layer) — indexed LAST so live
+  // signals win short-id collisions; orchestratorId falls back to raw.orchestrator.
+  indexOrchDir(execCoreDir, null);
+
   return index;
 }
 

--- a/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
@@ -6,6 +6,9 @@
 // `claude` / `ps` / the event log.
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   classifyRow,
   applyDuplicates,
@@ -16,6 +19,7 @@ import {
   buildLiveSessionsByWorktree,
   runPrune,
   parseSessionArgs,
+  indexSignalsByBgJobId,
 } from "./sessions.mjs";
 import { ArgError } from "./args.mjs";
 
@@ -224,9 +228,7 @@ describe("buildRows (joins agents + worker signals + rss, injected deps)", () =>
       now: 5000,
     });
     expect(rows[0].lastSeenMs).toBe(12345);
-    expect(seen).toEqual([
-      { sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd", now: 5000 },
-    ]);
+    expect(seen).toEqual([{ sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd", now: 5000 }]);
   });
 
   it("classifies ORPHAN when cwd is missing", async () => {
@@ -692,5 +694,92 @@ describe("parseSessionArgs (strict shared parser + option mapping)", () => {
   it("THROWS ArgError on --min-idle-seconds abc (devex finding #2 — no silent NaN)", () => {
     expect(() => parseSessionArgs(["--min-idle-seconds", "abc"])).toThrow(ArgError);
     expect(() => parseSessionArgs(["--min-idle-seconds", "abc"])).toThrow(/expects a number/);
+  });
+});
+
+describe("indexSignalsByBgJobId (real directory walk — CTL-674 regression)", () => {
+  let catalystDir;
+  let prevDir;
+
+  beforeEach(() => {
+    catalystDir = mkdtempSync(join(tmpdir(), "exec-core-sessions-idx-"));
+    prevDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = catalystDir;
+  });
+
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevDir;
+    rmSync(catalystDir, { recursive: true, force: true });
+  });
+
+  function writeExecCoreSignal(ticket, phase, body) {
+    const dir = join(catalystDir, "execution-core", "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, orchestrator: ticket, ...body })
+    );
+  }
+
+  function writeLegacyRunSignal(orchId, ticket, phase, body) {
+    const dir = join(catalystDir, "runs", orchId, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, ...body }));
+  }
+
+  it("indexes a live execution-core worker by its bg_job_id short id (FAILS pre-fix)", () => {
+    writeExecCoreSignal("CTL-900", "research", {
+      bg_job_id: "24e1e48c",
+      status: "running",
+      worktreePath: "/tmp/wt/CTL-900",
+    });
+    const idx = indexSignalsByBgJobId();
+    const worker = idx.get("24e1e48c");
+    expect(worker).toBeTruthy();
+    expect(worker.ticket).toBe("CTL-900");
+    expect(worker.phase).toBe("research");
+    expect(worker.status).toBe("running");
+    expect(worker.orchestratorId).toBe("CTL-900"); // from raw.orchestrator
+    expect(worker.worktreePath).toBe("/tmp/wt/CTL-900");
+  });
+
+  it("still indexes legacy runs/<orchId> workers with orchId from the dir name", () => {
+    writeLegacyRunSignal("o-adv-xyz", "CTL-901", "plan", {
+      bg_job_id: "deadbeef",
+      status: "running",
+    });
+    const worker = indexSignalsByBgJobId().get("deadbeef");
+    expect(worker).toBeTruthy();
+    expect(worker.orchestratorId).toBe("o-adv-xyz");
+  });
+
+  it("execution-core wins a short-id collision over a historical runs/ entry", () => {
+    writeLegacyRunSignal("o-old", "CTL-902", "plan", {
+      bg_job_id: "cafebabe",
+      status: "done",
+    });
+    writeExecCoreSignal("CTL-903", "implement", {
+      bg_job_id: "cafebabe",
+      status: "running",
+    });
+    const worker = indexSignalsByBgJobId().get("cafebabe");
+    expect(worker.ticket).toBe("CTL-903");
+    expect(worker.status).toBe("running");
+  });
+
+  it("skips flat/pid signals (no bg liveness) under execution-core", () => {
+    // flat layout = workers/<T>.json → {kind:"pid"} → filtered out
+    const wdir = join(catalystDir, "execution-core", "workers");
+    mkdirSync(wdir, { recursive: true });
+    writeFileSync(
+      join(wdir, "CTL-904.json"),
+      JSON.stringify({ ticket: "CTL-904", phase: 3, pid: 123, status: "running" })
+    );
+    expect(indexSignalsByBgJobId().size).toBe(0);
+  });
+
+  it("returns an empty map when neither root exists", () => {
+    expect(indexSignalsByBgJobId().size).toBe(0); // temp dir has no runs/ or execution-core/
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-27T21:17:50Z -->
<!-- Last updated: 2026-05-27T21:17:50Z -->
<!-- PR: #1128 -->
<!-- Previous commits: 08787fb3f359b35e2079318a0ea3a6258d85acc9 -->

## Summary

The `sessions`/`tidy` audit CLI indexed bg phase signals only under the legacy
`~/catalyst/runs/<orchId>/workers` tree. Under the execution-core dispatch model, signals live in a
single orchDir with no `<orchId>` layer, so the index came up empty and every live worker session
was mis-classified as `UNKNOWN`. This points the index at the execution-core signal root in addition
to the legacy runs root.

## Changes Made

- `indexSignalsByBgJobId` now walks **two** signal roots:
  - the legacy `runs/<orchId>/workers/...` tree (orchestratorId derived from the subdir name)
  - the execution-core `orchDir` (no orchId layer; orchestratorId falls back to the signal's
    `raw.orchestrator` field)
- The execution-core dir is indexed **last** so a live signal wins any 8-char bg_job_id short-id
  collision against a historical `runs/` entry.
- Missing roots are skipped gracefully (empty walk), preserving prior behavior when either root is absent.
- Added a real-directory-walk regression test covering the execution-core root and the collision
  precedence (`sessions.test.mjs`).

## How to Verify It

- [x] Tests pass: `bun test plugins/dev/scripts/execution-core/cli/sessions.test.mjs`
- [x] Live workers classify correctly (no longer `UNKNOWN`) when signals are under the execution-core orchDir

## Related Issues/PRs

- Fixes CTL-674

Refs: CTL-674
