### PR TITLE
CTL-675: anchor tidy/worktrees/branches git ops to a repo root and surface git failures loudly

### DIFF
--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -247,6 +247,13 @@ Backcompat: start|stop|restart|probe|status work as top-level aliases for the da
 Safe starting point:
   catalyst-execution-core tidy --dry-run     # show the full cleanup plan, change nothing
 
+Repo resolution (worktrees / branches / tidy):
+  git operations resolve their repo root, in order, from:
+    --repo-root <path> -> $CATALYST_REPO_ROOT -> the current repo -> the first
+    registry project. No `cd` into a repo is required. Run outside any
+    resolvable repo, these commands now FAIL LOUDLY (exit 1) instead of
+    silently reporting nothing to prune.
+
 Scripting:
   Every list / prune / tidy command and `daemon status` accepts --json for
   machine-readable output (pipe to jq).

--- a/plugins/dev/scripts/execution-core/cli/branches.mjs
+++ b/plugins/dev/scripts/execution-core/cli/branches.mjs
@@ -16,6 +16,7 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { parseArgs, ArgError } from "./args.mjs";
 import { ghPrList } from "./worktrees.mjs";
+import { resolveRepoRoot, runGitCapture } from "./repo.mjs";
 
 const SCOPES = new Set(["local", "remote", "both"]);
 
@@ -54,59 +55,65 @@ export function classify({
 
 // ─── I/O sources ─────────────────────────────────────────────────────────────
 
-function gitLines(args) {
-  try {
-    const out = execFileSync("git", args, { encoding: "utf8" });
-    return out
-      .split("\n")
-      .map((l) => l.trim())
-      .filter(Boolean);
-  } catch {
-    return [];
-  }
+/**
+ * gitLines — shared listing runner. Routes through runGitCapture (anchored to a
+ * resolved repoRoot) so a git failure THROWS a clean wrapped error instead of
+ * swallowing to [] — the silent-no-op fix (CTL-675). Exported for tests; `run`
+ * is the injectable git runner.
+ */
+export function gitLines(args, repoRoot, run) {
+  const cwd = repoRoot ?? resolveRepoRoot();
+  const out = runGitCapture(args, run ? { cwd, run } : { cwd });
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
 }
 
-function listLocalBranches() {
-  return gitLines(["branch", "--format=%(refname:short)"]);
+function listLocalBranches(repoRoot) {
+  return gitLines(["branch", "--format=%(refname:short)"], repoRoot);
 }
 
-function listRemoteBranches() {
+function listRemoteBranches(repoRoot) {
   // origin/<name> → <name>; skip the symbolic origin/HEAD.
-  return gitLines(["branch", "-r", "--format=%(refname:short)"])
+  return gitLines(["branch", "-r", "--format=%(refname:short)"], repoRoot)
     .filter((b) => b.startsWith("origin/") && !b.includes("HEAD"))
     .map((b) => b.slice("origin/".length));
 }
 
-function listMergedLocal(base = "main") {
-  return new Set(gitLines(["branch", "--merged", base, "--format=%(refname:short)"]));
+function listMergedLocal(base = "main", repoRoot) {
+  return new Set(gitLines(["branch", "--merged", base, "--format=%(refname:short)"], repoRoot));
 }
 
-function worktreeBranchSet() {
+function worktreeBranchSet(repoRoot) {
+  // Route through runGitCapture so an outside-a-repo failure escalates (this is
+  // an inventory call that decides whether a branch is worktree-backed).
   const set = new Set();
-  try {
-    const out = execFileSync("git", ["worktree", "list", "--porcelain"], { encoding: "utf8" });
-    for (const line of out.split("\n")) {
-      if (line.startsWith("branch ")) {
-        set.add(
-          line
-            .slice("branch ".length)
-            .trim()
-            .replace(/^refs\/heads\//, "")
-        );
-      }
+  const out = runGitCapture(["worktree", "list", "--porcelain"], {
+    cwd: repoRoot ?? resolveRepoRoot(),
+  });
+  for (const line of out.split("\n")) {
+    if (line.startsWith("branch ")) {
+      set.add(
+        line
+          .slice("branch ".length)
+          .trim()
+          .replace(/^refs\/heads\//, "")
+      );
     }
-  } catch {
-    /* git unavailable → empty */
   }
   return set;
 }
 
-function ageDaysForBranch(name) {
+function ageDaysForBranch(name, repoRoot) {
   // A remote-only branch has no local ref — fall back to origin/<name>. stderr
-  // is dropped so a missing ref never prints `fatal: ambiguous argument`.
+  // is dropped so a missing ref never prints `fatal: ambiguous argument`. This
+  // is best-effort metadata, so it keeps its local catch → 0 (CTL-675).
+  const cwd = repoRoot ?? resolveRepoRoot();
   for (const ref of [name, `origin/${name}`]) {
     try {
       const out = execFileSync("git", ["log", "-1", "--format=%ct", ref], {
+        cwd,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
       }).trim();
@@ -122,12 +129,13 @@ function ageDaysForBranch(name) {
 // ─── buildRows ───────────────────────────────────────────────────────────────
 
 export async function buildRows({
-  localBranches = listLocalBranches(),
-  remoteBranches = listRemoteBranches(),
-  worktreeBranches = worktreeBranchSet(),
-  mergedLocal = listMergedLocal(),
-  prs = ghPrList(),
-  ageDaysFor = ageDaysForBranch,
+  repoRoot, // undefined → the git/gh helpers resolve lazily (CTL-675)
+  localBranches = listLocalBranches(repoRoot),
+  remoteBranches = listRemoteBranches(repoRoot),
+  worktreeBranches = worktreeBranchSet(repoRoot),
+  mergedLocal = listMergedLocal("main", repoRoot),
+  prs = ghPrList(repoRoot),
+  ageDaysFor = (name) => ageDaysForBranch(name, repoRoot),
   staleDays = DEFAULT_STALE_DAYS,
 } = {}) {
   const localSet = new Set(localBranches);
@@ -169,9 +177,13 @@ export async function buildRows({
 
 // ─── prune ───────────────────────────────────────────────────────────────────
 
-async function defaultDeleteLocal(branch) {
+// Per-item action helpers: cwd is anchored (CTL-675) but they KEEP their local
+// catch → { ok:false } — a single ref failing to delete is legitimately
+// non-fatal (unlike the inventory listing calls, which escalate).
+async function defaultDeleteLocal(branch, repoRoot) {
   try {
     execFileSync("git", ["branch", "-D", branch], {
+      cwd: repoRoot ?? resolveRepoRoot(),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -181,9 +193,10 @@ async function defaultDeleteLocal(branch) {
   }
 }
 
-async function defaultDeleteRemote(branch) {
+async function defaultDeleteRemote(branch, repoRoot) {
   try {
     execFileSync("git", ["push", "origin", "--delete", branch], {
+      cwd: repoRoot ?? resolveRepoRoot(),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -269,7 +282,7 @@ export async function runBranchesPrune({
 const BRANCHES_SPEC = {
   booleans: ["json", "yes", "dry-run", "force"],
   numbers: ["max", "stale-days"],
-  strings: ["scope"],
+  strings: ["scope", "repo-root"],
 };
 
 /**
@@ -298,11 +311,12 @@ export function parseBranchArgs(argv) {
   }
   if (raw.max !== undefined) out.max = raw.max;
   if (raw["stale-days"] !== undefined) out.staleDays = raw["stale-days"];
+  if (raw["repo-root"] !== undefined) out.repoRoot = raw["repo-root"];
   return out;
 }
 
-async function cmdList({ json, staleDays }) {
-  const rows = await buildRows({ staleDays: staleDays ?? DEFAULT_STALE_DAYS });
+async function cmdList({ json, staleDays, repoRoot }) {
+  const rows = await buildRows({ repoRoot, staleDays: staleDays ?? DEFAULT_STALE_DAYS });
   if (json) {
     process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
     return 0;
@@ -317,8 +331,16 @@ async function cmdList({ json, staleDays }) {
 }
 
 async function cmdPrune(opts) {
-  const rows = await buildRows({ staleDays: opts.staleDays ?? DEFAULT_STALE_DAYS });
-  const { planned, deleted, plannedRows, skippedRows } = await runBranchesPrune({ ...opts, rows });
+  const rows = await buildRows({ repoRoot: opts.repoRoot, staleDays: opts.staleDays ?? DEFAULT_STALE_DAYS });
+  // Bind repoRoot into the default delete helpers via closures so the ref
+  // deletes are anchored too (CTL-675); runBranchesPrune still calls them with
+  // a single arg, and injected test deletes are untouched.
+  const { planned, deleted, plannedRows, skippedRows } = await runBranchesPrune({
+    ...opts,
+    rows,
+    deleteLocalBranch: (b) => defaultDeleteLocal(b, opts.repoRoot),
+    deleteRemoteBranch: (b) => defaultDeleteRemote(b, opts.repoRoot),
+  });
   const isDryRun = !(opts.yes && !opts.dryRun);
   if (opts.json) {
     // One structured object so a headless agent can inspect the destructive
@@ -341,8 +363,9 @@ async function cmdPrune(opts) {
 function usage() {
   process.stderr.write(
     "Usage: catalyst-execution-core branches {list|prune} [flags]\n" +
-      "  list  [--json] [--scope local|remote|both] [--stale-days N]\n" +
-      "  prune [--yes] [--dry-run] [--json] [--scope ...] [--force] [--max N]\n"
+      "  list  [--json] [--scope local|remote|both] [--stale-days N] [--repo-root <path>]\n" +
+      "  prune [--yes] [--dry-run] [--json] [--scope ...] [--force] [--max N] [--repo-root <path>]\n" +
+      "  Repo resolution: --repo-root → $CATALYST_REPO_ROOT → current repo → first registry project.\n"
   );
 }
 

--- a/plugins/dev/scripts/execution-core/cli/branches.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/branches.test.mjs
@@ -3,7 +3,7 @@
 // directly (git branch -D / git push origin --delete), NOT through the reaper.
 
 import { describe, it, expect } from "bun:test";
-import { classify, buildRows, runBranchesPrune, parseBranchArgs } from "./branches.mjs";
+import { classify, buildRows, runBranchesPrune, parseBranchArgs, gitLines } from "./branches.mjs";
 import { ArgError } from "./args.mjs";
 
 describe("branches classify", () => {
@@ -304,5 +304,34 @@ describe("parseBranchArgs (strict shared parser + option mapping)", () => {
     expect(parseBranchArgs(["--scope", "local"]).scope).toBe("local");
     expect(parseBranchArgs(["--scope", "remote"]).scope).toBe("remote");
     expect(parseBranchArgs(["--scope", "both"]).scope).toBe("both");
+  });
+
+  it("accepts --repo-root <path> (CTL-675)", () => {
+    expect(parseBranchArgs(["prune", "--repo-root", "/r"]).repoRoot).toBe("/r");
+  });
+});
+
+// CTL-675: the shared listing runner now propagates a git failure (anchored to
+// a resolved repoRoot) instead of swallowing it to [] — the silent no-op fix.
+describe("gitLines (CTL-675 throw-propagation + cwd anchor)", () => {
+  it("propagates a git failure instead of returning empty", () => {
+    const run = () => {
+      const e = new Error("x");
+      e.stderr = "fatal: not a git repository\n";
+      throw e;
+    };
+    expect(() => gitLines(["branch", "--format=%(refname:short)"], "/r", run)).toThrow(
+      /fatal: not a git repository/
+    );
+  });
+
+  it("splits stdout lines on success, anchored to repoRoot", () => {
+    let seenCwd;
+    const run = (_a, opts) => {
+      seenCwd = opts.cwd;
+      return "main\nfeat\n";
+    };
+    expect(gitLines(["branch"], "/r", run)).toEqual(["main", "feat"]);
+    expect(seenCwd).toBe("/r");
   });
 });

--- a/plugins/dev/scripts/execution-core/cli/repo.mjs
+++ b/plugins/dev/scripts/execution-core/cli/repo.mjs
@@ -1,0 +1,60 @@
+// cli/repo.mjs — repo-root resolution + a throwing, stderr-capturing git runner
+// shared by the audit nouns (CTL-675).
+//
+// Two defects motivate this module:
+//   1. The audit nouns shelled out to git with NO cwd anchor, so git resolved
+//      the repo from the operator's inherited process cwd. Run from outside a
+//      repo, every call threw `fatal: not a git repository`.
+//   2. The inventory helpers swallowed that throw into ""/[], so tidy continued
+//      and printed a success line — a silent no-op.
+//
+// resolveRepoRoot is the single anchor resolver; runGitCapture is the throwing,
+// stderr-capturing runner the *inventory* helpers use (per-item action helpers
+// and best-effort metadata keep their own local catch). Resolution precedence:
+//   1. explicit --repo-root   2. $CATALYST_REPO_ROOT
+//   3. current repo (git rev-parse --show-toplevel)   4. first registry repoRoot
+import { execFileSync } from "node:child_process";
+import { existsSync as fsExistsSync } from "node:fs";
+import { listProjects } from "../registry.mjs";
+
+export function resolveRepoRoot({
+  explicit,
+  env = process.env,
+  cwd = process.cwd(),
+  projects = listProjects(),
+  existsSync = fsExistsSync,
+  runGit = (args, opts) => execFileSync("git", args, opts),
+} = {}) {
+  if (explicit) return explicit; // 1
+  if (env.CATALYST_REPO_ROOT) return env.CATALYST_REPO_ROOT; // 2
+  try {
+    // 3
+    const top = runGit(["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (top) return top;
+  } catch {
+    /* not in a repo — fall through */
+  }
+  const reg = projects.find((p) => p.repoRoot && existsSync(p.repoRoot)); // 4
+  if (reg) return reg.repoRoot;
+  throw new Error(
+    "cannot resolve a git repo root: not in a git repo, $CATALYST_REPO_ROOT unset, " +
+      "and the registry has no usable repoRoot. Pass --repo-root <path>."
+  );
+}
+
+export function runGitCapture(args, { cwd, run = (a, opts) => execFileSync("git", a, opts) } = {}) {
+  try {
+    return run(args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (err) {
+    const detail =
+      String(err?.stderr || err?.message || "")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean)[0] || "git failed";
+    throw new Error(`git ${args.join(" ")} failed: ${detail}`);
+  }
+}

--- a/plugins/dev/scripts/execution-core/cli/repo.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/repo.test.mjs
@@ -1,0 +1,75 @@
+// repo.test.mjs — CTL-675. Hermetic coverage for the shared repo-root resolver
+// and the throwing, stderr-capturing git runner. Every external dependency
+// (git, fs, registry) is injected — no real git is invoked.
+
+import { describe, it, expect } from "bun:test";
+import { resolveRepoRoot, runGitCapture } from "./repo.mjs";
+
+describe("resolveRepoRoot", () => {
+  const noGit = () => {
+    throw new Error("not a repo");
+  };
+
+  it("returns the explicit --repo-root verbatim, ahead of everything", () => {
+    expect(
+      resolveRepoRoot({
+        explicit: "/x/repo",
+        env: { CATALYST_REPO_ROOT: "/y" },
+        runGit: noGit,
+        projects: [{ repoRoot: "/z" }],
+      })
+    ).toBe("/x/repo");
+  });
+
+  it("falls back to $CATALYST_REPO_ROOT when no explicit flag", () => {
+    expect(
+      resolveRepoRoot({
+        env: { CATALYST_REPO_ROOT: "/y/repo" },
+        runGit: noGit,
+        projects: [],
+      })
+    ).toBe("/y/repo");
+  });
+
+  it("uses the current repo toplevel when in a repo and no flag/env", () => {
+    const runGit = () => "/cwd/repo\n";
+    expect(resolveRepoRoot({ env: {}, runGit, projects: [] })).toBe("/cwd/repo");
+  });
+
+  it("falls back to the first usable registry repoRoot outside any repo", () => {
+    expect(
+      resolveRepoRoot({
+        env: {},
+        runGit: noGit,
+        projects: [{ repoRoot: "" }, { repoRoot: "/reg/repo" }],
+        existsSync: () => true,
+      })
+    ).toBe("/reg/repo");
+  });
+
+  it("throws a clear, actionable error when nothing resolves", () => {
+    expect(() => resolveRepoRoot({ env: {}, runGit: noGit, projects: [] })).toThrow(
+      /cannot resolve a git repo root.*--repo-root/s
+    );
+  });
+});
+
+describe("runGitCapture", () => {
+  it("returns stdout on success", () => {
+    const run = () => "worktree /a\n";
+    expect(runGitCapture(["worktree", "list", "--porcelain"], { cwd: "/r", run })).toBe(
+      "worktree /a\n"
+    );
+  });
+
+  it("throws a wrapped error carrying git's first stderr line (no leak)", () => {
+    const run = () => {
+      const e = new Error("Command failed");
+      e.stderr = "fatal: not a git repository (or any of the parent directories): .git\n";
+      throw e;
+    };
+    expect(() => runGitCapture(["worktree", "list", "--porcelain"], { cwd: "/r", run })).toThrow(
+      /git worktree list --porcelain failed: fatal: not a git repository/
+    );
+  });
+});

--- a/plugins/dev/scripts/execution-core/cli/tidy.mjs
+++ b/plugins/dev/scripts/execution-core/cli/tidy.mjs
@@ -25,6 +25,7 @@ import { buildRows as buildSessionRows, runPrune as runSessionsPrune } from "./s
 import { buildRows as buildWorktreeRows, runWorktreesPrune } from "./worktrees.mjs";
 import { buildRows as buildBranchRows, runBranchesPrune } from "./branches.mjs";
 import { parseArgs, ArgError } from "./args.mjs";
+import { resolveRepoRoot } from "./repo.mjs";
 
 async function defaultCmdSessions(opts) {
   const rows = await buildSessionRows({});
@@ -32,18 +33,22 @@ async function defaultCmdSessions(opts) {
 }
 
 async function defaultCmdWorktrees(opts) {
-  const rows = await buildWorktreeRows({});
+  const rows = await buildWorktreeRows({ repoRoot: opts.repoRoot });
   return runWorktreesPrune({ ...opts, rows });
 }
 
 async function defaultCmdBranches(opts) {
-  const rows = await buildBranchRows({});
+  const rows = await buildBranchRows({ repoRoot: opts.repoRoot });
   return runBranchesPrune({ ...opts, rows });
 }
 
-async function defaultCmdGitWorktreePrune() {
+async function defaultCmdGitWorktreePrune(opts = {}) {
+  // Anchor cwd to a resolved repoRoot (CTL-675); keep the best-effort swallow —
+  // this only mutates admin records and runs after worktrees+branches complete,
+  // so outside-a-repo the chain has already aborted before this is reached.
   try {
     execFileSync("git", ["worktree", "prune"], {
+      cwd: opts.repoRoot ?? resolveRepoRoot(),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -136,7 +141,7 @@ const TIDY_SPEC = {
     "force",
   ],
   numbers: ["max", "min-idle-seconds", "stale-days"],
-  strings: [],
+  strings: ["repo-root"],
 };
 
 /**
@@ -165,6 +170,7 @@ export function parseTidyArgs(argv) {
   if (raw.max !== undefined) out.max = raw.max;
   if (raw["min-idle-seconds"] !== undefined) out.minIdleMs = raw["min-idle-seconds"] * 1000;
   if (raw["stale-days"] !== undefined) out.staleDays = raw["stale-days"];
+  if (raw["repo-root"] !== undefined) out.repoRoot = raw["repo-root"];
   return out;
 }
 
@@ -176,7 +182,8 @@ function usage() {
       "  Runs sessions → worktrees → branches → git worktree prune in safe order.\n" +
       "  [--json] [--dry-run] [--yes] [--max N]\n" +
       "  [--include-idle] [--include-interactive] [--min-idle-seconds N]\n" +
-      "  [--include-stale] [--stale-days N] [--force]\n"
+      "  [--include-stale] [--stale-days N] [--force] [--repo-root <path>]\n" +
+      "  Repo resolution: --repo-root → $CATALYST_REPO_ROOT → current repo → first registry project.\n"
   );
 }
 

--- a/plugins/dev/scripts/execution-core/cli/tidy.regression.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/tidy.regression.test.mjs
@@ -1,0 +1,34 @@
+// tidy.regression.test.mjs — CTL-675 end-to-end regression. Drives the REAL
+// tidy.mjs in a child process against a temp NON-repo dir with an empty
+// registry — the exact ticket scenario — and asserts the fixed behavior: exit
+// non-zero + a git-failure line, NOT the `planned (dry-run)` success line and
+// no raw `fatal:` leak. This is the coverage research §6 found missing: every
+// other test injects fixtures, so none exercised the outside-a-repo git path.
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("tidy outside a git repo (CTL-675 regression)", () => {
+  let dir;
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "ctl675-"));
+  });
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("exits non-zero and surfaces the git failure instead of a fake success", () => {
+    const r = spawnSync("bun", [join(import.meta.dir, "tidy.mjs"), "--dry-run"], {
+      cwd: dir, // NOT a git repo
+      // CATALYST_DIR points the registry at the empty temp dir (no registry.json
+      // → listProjects() === []); CATALYST_REPO_ROOT="" so step 2 doesn't resolve.
+      env: { ...process.env, CATALYST_DIR: dir, CATALYST_REPO_ROOT: "" },
+      encoding: "utf8",
+    });
+    expect(r.status).not.toBe(0);
+    const out = `${r.stdout}${r.stderr}`;
+    expect(out).toMatch(/aborted at worktrees|cannot resolve a git repo root|not a git repository/);
+    expect(out).not.toMatch(/tidy: planned \(dry-run\) — steps: sessions, worktrees, branches/);
+  });
+});

--- a/plugins/dev/scripts/execution-core/cli/tidy.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/tidy.test.mjs
@@ -213,6 +213,10 @@ describe("parseTidyArgs (strict)", () => {
     expect(() => parseTidyArgs(["--max", "abc"])).toThrow(/--max expects a number/);
     expect(() => parseTidyArgs(["--min-idle-seconds", "NaN"])).toThrow(ArgError);
   });
+
+  it("accepts --repo-root <path> (CTL-675)", () => {
+    expect(parseTidyArgs(["--repo-root", "/r"]).repoRoot).toBe("/r");
+  });
 });
 
 describe("runTidy --json shape", () => {

--- a/plugins/dev/scripts/execution-core/cli/worktrees.mjs
+++ b/plugins/dev/scripts/execution-core/cli/worktrees.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 import { emitReapIntent } from "../reap-intent.mjs";
 import { parseArgs, ArgError } from "./args.mjs";
 import { buildRows as buildSessionRows, buildLiveSessionsByWorktree } from "./sessions.mjs";
+import { resolveRepoRoot, runGitCapture } from "./repo.mjs";
 
 const GH_BIN = process.env.CATALYST_GH_BIN || "gh";
 const DEFAULT_STALE_DAYS = Number(process.env.CATALYST_WORKTREE_STALE_DAYS) || 14;
@@ -109,24 +110,30 @@ export function classify({
 
 // ─── I/O sources ─────────────────────────────────────────────────────────────
 
-function gitWorktreePorcelain() {
-  try {
-    return execFileSync("git", ["worktree", "list", "--porcelain"], { encoding: "utf8" });
-  } catch {
-    return "";
-  }
+/**
+ * gitWorktreePorcelain — `git worktree list --porcelain`, anchored to repoRoot
+ * (resolved lazily when omitted) and routed through runGitCapture so a git
+ * failure THROWS a clean wrapped error instead of swallowing to "" (CTL-675).
+ * Exported for tests; `run` is the injectable git runner.
+ */
+export function gitWorktreePorcelain(repoRoot, run) {
+  const cwd = repoRoot ?? resolveRepoRoot();
+  return runGitCapture(["worktree", "list", "--porcelain"], run ? { cwd, run } : { cwd });
 }
 
 /**
  * ghPrList — every PR (any state) as { number, headRefName, state } with state
  * lowercased to open|closed|merged. Empty on any gh failure (no auth, no remote).
+ * cwd is anchored to repoRoot for correct repo auto-detect (CTL-675), but a gh
+ * failure stays swallowed-to-empty — "no PRs" is not the silent-no-op bug.
  */
-export function ghPrList() {
+export function ghPrList(repoRoot) {
+  const cwd = repoRoot ?? resolveRepoRoot();
   try {
     const out = execFileSync(
       GH_BIN,
       ["pr", "list", "--state", "all", "--limit", "500", "--json", "number,headRefName,state"],
-      { encoding: "utf8" }
+      { cwd, encoding: "utf8" }
     );
     const parsed = JSON.parse(out);
     return (Array.isArray(parsed) ? parsed : []).map((p) => ({
@@ -155,8 +162,9 @@ function mtimeMsFor(path) {
  * session rows; tests pass fixtures.
  */
 export async function buildRows({
-  porcelain = gitWorktreePorcelain(),
-  prs = ghPrList(),
+  repoRoot, // undefined → the git/gh helpers resolve lazily (CTL-675)
+  porcelain = gitWorktreePorcelain(repoRoot),
+  prs = ghPrList(repoRoot),
   liveByWorktree,
   mtimeFor = mtimeMsFor,
   linearStateFor = () => null,
@@ -272,7 +280,7 @@ export async function runWorktreesPrune({
 const WORKTREES_SPEC = {
   booleans: ["json", "yes", "dry-run", "include-stale"],
   numbers: ["max", "stale-days"],
-  strings: [],
+  strings: ["repo-root"],
 };
 
 /**
@@ -293,11 +301,12 @@ export function parseWorktreeArgs(argv) {
   if (raw["include-stale"] !== undefined) out.includeStale = raw["include-stale"];
   if (raw.max !== undefined) out.max = raw.max;
   if (raw["stale-days"] !== undefined) out.staleDays = raw["stale-days"];
+  if (raw["repo-root"] !== undefined) out.repoRoot = raw["repo-root"];
   return out;
 }
 
-async function cmdList({ json, staleDays }) {
-  const rows = await buildRows({ staleDays: staleDays ?? DEFAULT_STALE_DAYS });
+async function cmdList({ json, staleDays, repoRoot }) {
+  const rows = await buildRows({ repoRoot, staleDays: staleDays ?? DEFAULT_STALE_DAYS });
   if (json) {
     process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
     return 0;
@@ -313,7 +322,7 @@ async function cmdList({ json, staleDays }) {
 }
 
 async function cmdPrune(opts) {
-  const rows = await buildRows({ staleDays: opts.staleDays ?? DEFAULT_STALE_DAYS });
+  const rows = await buildRows({ repoRoot: opts.repoRoot, staleDays: opts.staleDays ?? DEFAULT_STALE_DAYS });
   const { planned, emitted, plannedRows, skippedRows } = await runWorktreesPrune({ ...opts, rows });
   const isDryRun = !(opts.yes && !opts.dryRun);
   if (opts.json) {
@@ -337,8 +346,9 @@ async function cmdPrune(opts) {
 function usage() {
   process.stderr.write(
     "Usage: catalyst-execution-core worktrees {list|prune} [flags]\n" +
-      "  list  [--json] [--stale-days N]\n" +
-      "  prune [--yes] [--dry-run] [--json] [--max N] [--include-stale]\n"
+      "  list  [--json] [--stale-days N] [--repo-root <path>]\n" +
+      "  prune [--yes] [--dry-run] [--json] [--max N] [--include-stale] [--repo-root <path>]\n" +
+      "  Repo resolution: --repo-root → $CATALYST_REPO_ROOT → current repo → first registry project.\n"
   );
 }
 

--- a/plugins/dev/scripts/execution-core/cli/worktrees.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/worktrees.test.mjs
@@ -10,6 +10,7 @@ import {
   buildRows,
   runWorktreesPrune,
   parseWorktreeArgs,
+  gitWorktreePorcelain,
 } from "./worktrees.mjs";
 import { ArgError } from "./args.mjs";
 
@@ -320,5 +321,32 @@ describe("parseWorktreeArgs (strict shared parser + option mapping)", () => {
     expect(() => parseWorktreeArgs(["--stale-days", "abc"])).toThrow(ArgError);
     expect(() => parseWorktreeArgs(["--stale-days", "abc"])).toThrow(/expects a number/);
     expect(() => parseWorktreeArgs(["--max", "abc"])).toThrow(ArgError);
+  });
+
+  it("accepts --repo-root <path> (CTL-675)", () => {
+    expect(parseWorktreeArgs(["prune", "--repo-root", "/r"]).repoRoot).toBe("/r");
+  });
+});
+
+// CTL-675: the inventory call now propagates a git failure (anchored to a
+// resolved repoRoot) instead of swallowing it to "" — the silent no-op fix.
+describe("gitWorktreePorcelain (CTL-675 throw-propagation + cwd anchor)", () => {
+  it("propagates a git failure instead of returning empty", () => {
+    const run = () => {
+      const e = new Error("x");
+      e.stderr = "fatal: not a git repository\n";
+      throw e;
+    };
+    expect(() => gitWorktreePorcelain("/r", run)).toThrow(/fatal: not a git repository/);
+  });
+
+  it("returns porcelain on success, anchored to repoRoot", () => {
+    let seenCwd;
+    const run = (_a, opts) => {
+      seenCwd = opts.cwd;
+      return "worktree /a\nbranch refs/heads/x\n";
+    };
+    expect(gitWorktreePorcelain("/r", run)).toContain("worktree /a");
+    expect(seenCwd).toBe("/r");
   });
 });

--- a/website/src/content/docs/reference/orchestration/tidy-cli.md
+++ b/website/src/content/docs/reference/orchestration/tidy-cli.md
@@ -99,6 +99,36 @@ a typo'd `--include-interactive` used to silently do nothing. Now both error out
 reverting the flag, so a slip of the keyboard can never weaken a safety guard.
 :::
 
+## Resolving the repository root
+
+`worktrees`, `branches`, and `tidy` all shell out to `git`. They resolve which repository to operate
+on — in this order — from:
+
+1. **`--repo-root <path>`** — an explicit flag (highest precedence; accepted by all three nouns).
+2. **`$CATALYST_REPO_ROOT`** — an environment override.
+3. **The current repository** — `git rev-parse --show-toplevel` from the process working directory.
+4. **The first registry project** — the first entry in the execution-core registry with a usable
+   `repoRoot`.
+
+You do **not** need to `cd` into the repository first — pass `--repo-root` (or set
+`$CATALYST_REPO_ROOT`) and the commands work from anywhere:
+
+```bash
+# From /tmp, audit a specific repo without changing directory:
+catalyst-execution-core worktrees list --repo-root /path/to/repo
+catalyst-execution-core tidy --dry-run --repo-root /path/to/repo
+```
+
+:::caution[Outside a resolvable repo, these commands now fail loudly]
+If none of the four sources resolves a repository root, `worktrees`/`branches`/`tidy` **exit `1`**
+with a clear message (e.g. `tidy: aborted at worktrees — cannot resolve a git repo root … Pass
+--repo-root <path>.`). Previously the underlying `git` error was swallowed into an empty inventory,
+so the command **exited `0` with a success-shaped `planned (dry-run)` line** — a silent no-op. Any
+automation that relied on the old behavior (running from a non-repo directory and ignoring the exit
+code) was already a no-op; it now gets a real signal. Run from inside the repo, or pass
+`--repo-root` / `$CATALYST_REPO_ROOT`, for the unchanged success path.
+:::
+
 ## Headless / agent use
 
 Every command — not just `list`/`show` — accepts `--json` and emits a **single structured object**


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-27T21:21:19Z -->
<!-- Last updated: 2026-05-27T21:21:19Z -->
<!-- PR: #1129 -->
<!-- Previous commits: 8ccf748c397baea8600b38b40e50219aa211e0d4,62d1caece816b603b86611a9b571f644b58b8383,f52b076c739d957e311929d50a9235896256a2a6,aa12b113b761a4d93fed097cf91da83b120a49e8,eff8dc9581d4387f1afe785fa71d4148ae0e77cd -->

## Summary

`catalyst-execution-core tidy` (and the `worktrees`/`branches` nouns it builds on) shelled out to git with no working-directory anchor. Run from anywhere outside a git repository, every `git` call threw `fatal: not a git repository` — but the inventory functions caught that error and returned an **empty list**, so `tidy` sailed on and printed a success line. The result was a silent no-op that looked like "nothing to prune."

This PR fixes both halves of that defect:

1. **Undocumented hard cwd dependency** → git operations are now resolved against an explicit repo root via a new `--repo-root` flag (falling back to env → `git rev-parse` → registry), threaded through every noun.
2. **Git errors masquerading as "nothing to prune"** → the inventory helpers now propagate git failures instead of swallowing them into `[]`/`""`, so a failed `git` call escalates through `runTidy` to a non-zero exit with the real git stderr surfaced.

## Changes Made

- **`cli/repo.mjs` (new)** — `resolveRepoRoot()` (flag → env → `git rev-parse --show-toplevel` → registry fallback) and `runGitCapture()`, a git runner that **throws** on non-zero exit (surfacing the first line of git stderr) instead of returning empty output.
- **`cli/worktrees.mjs` / `cli/branches.mjs`** — inventory helpers (`gitLines`, `worktreeBranchSet`, `gitWorktreePorcelain`) now route through `runGitCapture` so list failures become real errors. Per-item action and best-effort metadata helpers (`defaultDeleteLocal/Remote`, `ageDaysForBranch`, `ghPrList`, `git worktree prune`) intentionally keep their local catch.
- **`cli/tidy.mjs`** — threads `--repo-root` through to the nouns and lets git-list failures escalate to exit 1.
- **`catalyst-execution-core`** — wires the `--repo-root` flag into the CLI entrypoint.
- **`website/.../reference/orchestration/tidy-cli.md`** — documents repo-root resolution order and the new loud-failure behavior.

## How to Verify It

Verification ran in the verify phase (`verify.json`, regression risk 0/10):

- [x] **Tests**: 87/87 diff-touched CLI tests pass (repo/worktrees/branches/tidy + the new outside-a-repo regression). Full suite 970 pass / 9 fail — the 9 are pre-existing spawn-based scheduler/integration tests that fail only in the bg-job sandbox; none import the changed CLI nouns or appear in this diff.
- [x] **Reward-hacking scan**: clean — no `as any`/`@ts-ignore`/non-null/`forEach(async`/void tricks in changed source.
- [x] **Security**: all git/gh calls use `execFileSync` arg-arrays (no shell interpolation); cwd derived from the `--repo-root` flag/env/git/registry; no new external-input surface.
- [x] **Code review**: faithful to the approved 5-phase plan; `reviewPassed: true` with no findings.
- [ ] Typecheck / lint: N/A — plain ESM `.mjs` modules, no tsconfig or lint gate configured for execution-core.

**Manual repro of the original bug** (now fixed):

```bash
cd /tmp && catalyst-execution-core tidy   # before: prints success; after: exits non-zero with the git failure surfaced
```

## Related Issues/PRs

- Fixes CTL-675

Refs: CTL-675
