### PR TITLE
CTL-650: session wait-state watcher (agent.waiting_on_user events + sessions-waiting CLI)

### DIFF
--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -237,7 +237,7 @@ Usage: catalyst-execution-core <command> [args]
 
 Commands:
   daemon      manage the long-lived execution-core daemon (start|stop|restart|probe|status)
-  sessions    inventory / reap leaked `claude --bg` sessions (list|show|prune)
+  sessions    inventory / reap leaked `claude --bg` sessions (list|show|waiting|prune)
   worktrees   inventory / clean orphaned or merged git worktrees (list|prune)
   branches    inventory / delete merged or orphaned branch refs (list|prune)
   tidy        run sessions → worktrees → branches in the safe order, then prune git admin records

--- a/plugins/dev/scripts/execution-core/cli/sessions.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.mjs
@@ -25,8 +25,11 @@ import { fileURLToPath } from "node:url";
 import { shortIdFromSessionId, isSelfSession } from "../claude-ids.mjs";
 import { readWorkerSignals, TERMINAL } from "../signal-reader.mjs";
 import { emitReapIntent } from "../reap-intent.mjs";
-import { getRunsRoot, getExecutionCoreDir } from "../config.mjs";
-import { lastSeenMsForSession } from "../session-recency.mjs";
+import { getRunsRoot, getExecutionCoreDir, getEventLogPath } from "../config.mjs";
+import { lastSeenMsForSession, findTranscript, defaultProjectsDir } from "../session-recency.mjs";
+import { scanEventsChunked } from "../event-tail.mjs";
+import { classifyWaitState, isWaitingState } from "../wait-state-classifier.mjs";
+import { createTranscriptTracker } from "../transcript-tail.mjs";
 import { parseArgs, ArgError } from "./args.mjs";
 
 const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
@@ -313,6 +316,122 @@ export function buildLiveSessionsByWorktree(rows) {
   return map;
 }
 
+// ─── CTL-650: `waiting` — the wait-watcher reference consumer ─────────────────
+
+/**
+ * netWaitingSessions — reduce a stream of agent.waiting_on_user / agent.resumed
+ * envelopes (append-ordered) to the sessions whose NET latest event is a
+ * waiting event. Last-event-per-session wins, so a session that later resumed is
+ * excluded. Returns Map<sessionId, payload>. Pure.
+ */
+export function netWaitingSessions(events) {
+  const net = new Map(); // sessionId → { name, payload }
+  for (const ev of events ?? []) {
+    const name = ev?.attributes?.["event.name"];
+    if (name !== "agent.waiting_on_user" && name !== "agent.resumed") continue;
+    const payload = ev?.body?.payload ?? {};
+    if (!payload.sessionId) continue;
+    net.set(payload.sessionId, { name, payload });
+  }
+  const waiting = new Map();
+  for (const [sessionId, { name, payload }] of net) {
+    if (name === "agent.waiting_on_user") waiting.set(sessionId, payload);
+  }
+  return waiting;
+}
+
+/**
+ * buildWaitingRows — the `waiting` read-path. Source of truth for "currently
+ * waiting" is the net state of agent.waiting_on_user / agent.resumed events on
+ * the bus; ticket/phase are joined from the signal index (the event payload
+ * already carries them when the watcher saw the signal). When the bus has no
+ * such events (daemon off / fresh log) it falls back to inline classification
+ * over the live sessions. All side-effecting inputs are injectable.
+ */
+export async function buildWaitingRows({
+  events,
+  eventLogPath = getEventLogPath(),
+  signalsByBgJobId = indexSignalsByBgJobId(),
+  agents = liveAgents,
+  findTranscriptFn = findTranscript,
+  makeTracker = (p) => createTranscriptTracker({ path: p }),
+  projectsDir = defaultProjectsDir(),
+} = {}) {
+  // Read the bus unless events were injected (tests pass [] to force fallback).
+  let evs = events;
+  if (evs === undefined) {
+    evs = [];
+    scanEventsChunked({ path: eventLogPath, onEvent: (e) => evs.push(e) });
+  }
+
+  // Trust the bus whenever it carries ANY wait/resume event — an empty net set
+  // then legitimately means "nobody is waiting" (return []). Only fall back to
+  // inline classification when the bus has no such events at all (daemon off /
+  // fresh log), NOT when every waiter has since resumed.
+  const sawWaitEvents = evs.some((e) => {
+    const n = e?.attributes?.["event.name"];
+    return n === "agent.waiting_on_user" || n === "agent.resumed";
+  });
+  const waitingMap = netWaitingSessions(evs);
+  if (sawWaitEvents) {
+    const rows = [];
+    for (const [sessionId, payload] of waitingMap) {
+      let shortId = payload.shortId ?? null;
+      if (!shortId) {
+        try {
+          shortId = shortIdFromSessionId(sessionId);
+        } catch {
+          shortId = null;
+        }
+      }
+      const meta = (shortId && signalsByBgJobId.get(shortId)) || {};
+      rows.push({
+        sessionId,
+        shortId,
+        ticket: payload.ticket ?? meta.ticket ?? null,
+        phase: payload.phase ?? meta.phase ?? null,
+        waitState: payload.waitState ?? null,
+        waitingText: payload.waitingText ?? null,
+        cwd: payload.cwd ?? meta.worktreePath ?? null,
+      });
+    }
+    return rows;
+  }
+
+  // Fallback: no events on the bus — classify the live sessions inline.
+  const sessions = typeof agents === "function" ? agents() : agents;
+  const rows = [];
+  for (const s of sessions ?? []) {
+    if (!s || !s.sessionId) continue;
+    const path = findTranscriptFn(s.sessionId, projectsDir);
+    let snap = { hasTranscript: false };
+    if (path) {
+      const tracker = makeTracker(path);
+      tracker.poll();
+      snap = tracker.snapshot();
+    }
+    const { state, waitingText } = classifyWaitState({ ...snap, status: s.status });
+    if (!isWaitingState(state)) continue;
+    let shortId = null;
+    try {
+      shortId = shortIdFromSessionId(s.sessionId);
+    } catch {
+      shortId = null;
+    }
+    const meta = (shortId && signalsByBgJobId.get(shortId)) || {};
+    rows.push({
+      sessionId: s.sessionId,
+      shortId,
+      ticket: meta.ticket ?? null,
+      phase: meta.phase ?? null,
+      waitState: state,
+      waitingText: waitingText ?? null,
+      cwd: s.cwd ?? meta.worktreePath ?? null,
+    });
+  }
+  return rows;
+}
+
 // ─── prune: the write path ───────────────────────────────────────────────────
 
 /**
@@ -517,6 +636,35 @@ async function cmdPrune(opts) {
   return 0;
 }
 
+async function cmdWaiting({ json }) {
+  const rows = await buildWaitingRows();
+  if (json) {
+    process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+    return 0;
+  }
+  printWaitingTable(rows);
+  return 0;
+}
+
+// printWaitingTable — focused listing: shortId TICKET PHASE WAIT_STATE cwd, with
+// the blocking text on a wrapped continuation line so a long question stays
+// readable. Mirrors printTable's column-padding style.
+function printWaitingTable(rows) {
+  if (rows.length === 0) {
+    process.stdout.write("No sessions are currently waiting on the user.\n");
+    return;
+  }
+  for (const r of rows) {
+    process.stdout.write(
+      `${String(r.shortId ?? "-").padEnd(9)} ${String(r.ticket ?? "-").padEnd(10)} ` +
+        `${String(r.phase ?? "-").padEnd(16)} ${String(r.waitState ?? "-").padEnd(15)} ` +
+        `${r.cwd ?? ""}\n`,
+    );
+    if (r.waitingText) process.stdout.write(`            ↳ ${r.waitingText}\n`);
+  }
+  process.stdout.write(`──\ntotal: ${rows.length} waiting\n`);
+}
+
 function printTable(rows) {
   const byCat = new Map();
   let totalRss = 0;
@@ -547,11 +695,12 @@ function printTable(rows) {
 
 function usage() {
   process.stderr.write(
-    "Usage: catalyst-execution-core sessions {list|show|prune} [flags]\n" +
-      "  list  [--json] [--ticket X] [--phase Y]\n" +
-      "  show  <ticket>\n" +
-      "  prune [--yes] [--dry-run] [--max N] [--include-idle] [--include-interactive]\n" +
-      "        [--min-idle-seconds N] [--categories LIST]\n"
+    "Usage: catalyst-execution-core sessions {list|show|waiting|prune} [flags]\n" +
+      "  list    [--json] [--ticket X] [--phase Y]\n" +
+      "  show    <ticket>\n" +
+      "  waiting [--json]   list sessions currently blocked on the user (CTL-650)\n" +
+      "  prune   [--yes] [--dry-run] [--max N] [--include-idle] [--include-interactive]\n" +
+      "          [--min-idle-seconds N] [--categories LIST]\n"
   );
 }
 
@@ -563,6 +712,8 @@ async function main(argv) {
       return cmdList(opts);
     case "show":
       return cmdShow({ ticket: argv[1] });
+    case "waiting":
+      return cmdWaiting(opts);
     case "prune":
       return cmdPrune(opts);
     default:

--- a/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
@@ -20,6 +20,8 @@ import {
   runPrune,
   parseSessionArgs,
   indexSignalsByBgJobId,
+  netWaitingSessions,
+  buildWaitingRows,
 } from "./sessions.mjs";
 import { ArgError } from "./args.mjs";
 
@@ -781,5 +783,129 @@ describe("indexSignalsByBgJobId (real directory walk — CTL-674 regression)", (
 
   it("returns an empty map when neither root exists", () => {
     expect(indexSignalsByBgJobId().size).toBe(0); // temp dir has no runs/ or execution-core/
+  });
+});
+
+// ─── CTL-650: `sessions waiting` reference consumer ───────────────────────────
+
+const waitEvent = (name, sessionId, payload = {}) => ({
+  attributes: { "event.name": name },
+  body: { payload: { sessionId, ...payload } },
+});
+
+describe("netWaitingSessions (net-last-event-per-session reducer)", () => {
+  it("keeps only sessions whose net last event is waiting_on_user", () => {
+    const net = netWaitingSessions([
+      waitEvent("agent.waiting_on_user", "aaaaaaaa-1", { waitState: "WAITING_USER" }),
+      waitEvent("agent.waiting_on_user", "bbbbbbbb-2", { waitState: "WAITING_PERM" }),
+    ]);
+    expect([...net.keys()].sort()).toEqual(["aaaaaaaa-1", "bbbbbbbb-2"]);
+  });
+
+  it("excludes a session whose later event is agent.resumed", () => {
+    const net = netWaitingSessions([
+      waitEvent("agent.waiting_on_user", "aaaaaaaa-1", { waitState: "WAITING_USER" }),
+      waitEvent("agent.resumed", "aaaaaaaa-1", { waitState: "ACTIVE" }),
+    ]);
+    expect(net.has("aaaaaaaa-1")).toBe(false);
+  });
+
+  it("a re-waiting after a resume is included again (last wins)", () => {
+    const net = netWaitingSessions([
+      waitEvent("agent.waiting_on_user", "aaaaaaaa-1"),
+      waitEvent("agent.resumed", "aaaaaaaa-1"),
+      waitEvent("agent.waiting_on_user", "aaaaaaaa-1", { waitState: "WAITING_TOOL_OK" }),
+    ]);
+    expect(net.get("aaaaaaaa-1")?.waitState).toBe("WAITING_TOOL_OK");
+  });
+
+  it("ignores unrelated event names", () => {
+    const net = netWaitingSessions([
+      { attributes: { "event.name": "phase.implement.complete.CTL-1" }, body: { payload: { sessionId: "x" } } },
+    ]);
+    expect(net.size).toBe(0);
+  });
+});
+
+describe("buildWaitingRows", () => {
+  it("lists waiting sessions and joins ticket/phase via the signal index", async () => {
+    const sessionId = "abcd1234-eeee-ffff-0000-111122223333";
+    const rows = await buildWaitingRows({
+      events: [
+        waitEvent("agent.waiting_on_user", sessionId, {
+          shortId: "abcd1234",
+          waitState: "WAITING_USER",
+          waitingText: "Should I proceed?",
+          cwd: "/wt/CTL-650",
+        }),
+      ],
+      signalsByBgJobId: new Map([
+        ["abcd1234", { ticket: "CTL-650", phase: "implement", worktreePath: "/wt/CTL-650" }],
+      ]),
+    });
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({
+      sessionId,
+      shortId: "abcd1234",
+      ticket: "CTL-650",
+      phase: "implement",
+      waitState: "WAITING_USER",
+      waitingText: "Should I proceed?",
+      cwd: "/wt/CTL-650",
+    });
+  });
+
+  it("excludes a session that has since resumed", async () => {
+    const sessionId = "abcd1234-eeee-ffff-0000-111122223333";
+    const rows = await buildWaitingRows({
+      events: [
+        waitEvent("agent.waiting_on_user", sessionId, { shortId: "abcd1234" }),
+        waitEvent("agent.resumed", sessionId, { shortId: "abcd1234" }),
+      ],
+      signalsByBgJobId: new Map(),
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it("falls back to inline classification when no events exist (daemon off)", async () => {
+    const sessionId = "abcd1234-eeee-ffff-0000-111122223333";
+    const rows = await buildWaitingRows({
+      events: [], // empty bus → fallback path
+      agents: () => [{ sessionId, status: "idle", cwd: "/wt/CTL-650" }],
+      findTranscriptFn: () => "/fake/transcript.jsonl",
+      makeTracker: () => ({
+        poll() {},
+        snapshot: () => ({
+          hasTranscript: true,
+          lastBlockType: "text",
+          stopReason: "end_turn",
+          lastText: "Need your call here?",
+          postUserOrResultCount: 0,
+        }),
+      }),
+      signalsByBgJobId: new Map([["abcd1234", { ticket: "CTL-650", phase: "implement" }]]),
+    });
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({
+      shortId: "abcd1234",
+      ticket: "CTL-650",
+      phase: "implement",
+      waitState: "WAITING_USER",
+    });
+    expect(rows[0].waitingText).toContain("Need your call here?");
+  });
+
+  it("fallback excludes non-waiting (busy/mid-turn) sessions", async () => {
+    const rows = await buildWaitingRows({
+      events: [],
+      agents: () => [{ sessionId: "abcd1234-x", status: "busy", cwd: "/wt" }],
+      findTranscriptFn: () => "/fake/transcript.jsonl",
+      makeTracker: () => ({
+        poll() {},
+        snapshot: () => ({ hasTranscript: true, lastBlockType: "text", stopReason: "end_turn" }),
+      }),
+      signalsByBgJobId: new Map(),
+    });
+    expect(rows).toEqual([]); // busy → ACTIVE, not waiting
   });
 });

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -139,3 +139,16 @@ export const IDLE_CONFIRM_TICKS =
 // genuinely wedged worker does. Env-overridable for tuning.
 export const BUSY_CEILING_MS =
   Number(process.env.EXECUTION_CORE_BUSY_CEILING_MS) || 6 * 60 * 60_000;
+
+// CTL-650 — the push-based session wait-state watcher. Default ON; the daemon
+// continuously classifies live sessions and emits agent.waiting_on_user /
+// agent.resumed transition events. CATALYST_WAIT_WATCHER=0 disables it (the
+// test/opt-out knob, mirroring EXECUTION_CORE_DISABLE_REAPER). The tick cadence
+// reuses EVENT_DEBOUNCE_MS (env-tunable via EXECUTION_CORE_DEBOUNCE_MS) so the
+// watcher's enumeration sweep runs at the same order as the reaper sweep.
+export function readWaitWatcherConfig() {
+  return {
+    enabled: process.env.CATALYST_WAIT_WATCHER !== "0",
+    intervalMs: EVENT_DEBOUNCE_MS,
+  };
+}

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -1,0 +1,34 @@
+// config.test.mjs — CTL-650 Phase 4. The wait-watcher config knob:
+// readWaitWatcherConfig() → { enabled, intervalMs }, default-on, env-disable via
+// CATALYST_WAIT_WATCHER=0, interval from EVENT_DEBOUNCE_MS.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test config.test.mjs
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { readWaitWatcherConfig, EVENT_DEBOUNCE_MS } from "./config.mjs";
+
+const PREV = process.env.CATALYST_WAIT_WATCHER;
+
+afterEach(() => {
+  if (PREV === undefined) delete process.env.CATALYST_WAIT_WATCHER;
+  else process.env.CATALYST_WAIT_WATCHER = PREV;
+});
+
+describe("readWaitWatcherConfig", () => {
+  test("defaults to enabled with the EVENT_DEBOUNCE_MS interval", () => {
+    delete process.env.CATALYST_WAIT_WATCHER;
+    const cfg = readWaitWatcherConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.intervalMs).toBe(EVENT_DEBOUNCE_MS);
+  });
+
+  test("CATALYST_WAIT_WATCHER=0 disables it", () => {
+    process.env.CATALYST_WAIT_WATCHER = "0";
+    expect(readWaitWatcherConfig().enabled).toBe(false);
+  });
+
+  test("any other value keeps it enabled", () => {
+    process.env.CATALYST_WAIT_WATCHER = "1";
+    expect(readWaitWatcherConfig().enabled).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -25,7 +25,14 @@ import {
 } from "node:fs";
 import { resolve, dirname, basename } from "node:path";
 import { parseEventTailChunk } from "./event-tail.mjs";
-import { getExecutionCoreDir, getEventLogPath, log, EVENT_DEBOUNCE_MS } from "./config.mjs";
+import {
+  getExecutionCoreDir,
+  getEventLogPath,
+  log,
+  EVENT_DEBOUNCE_MS,
+  readWaitWatcherConfig,
+} from "./config.mjs";
+import { startWaitWatcher as realStartWaitWatcher } from "./wait-watcher.mjs";
 import {
   recoverStartup,
   startMonitor,
@@ -55,6 +62,8 @@ let _pidFile = null;
 // CTL-649: reap-intent reconciler + periodic orphan-sweep timer.
 let _reaper = null;
 let _orphanTimer = null;
+// CTL-650: the push-based session wait-state watcher handle.
+let _waitWatcher = null;
 let _eventWatcher = null;
 let _eventDebounceTimer = null;
 let _eventLogCursor = 0;
@@ -97,6 +106,10 @@ export function startDaemon({
   // that only exercise monitor + scheduler.
   enableReaper = process.env.EXECUTION_CORE_DISABLE_REAPER !== "1",
   orphanReaperConfig = null,
+  // CTL-650: the session wait-state watcher. Injectable for tests; gated by a
+  // config knob (default-on, CATALYST_WAIT_WATCHER=0 disables) like the reaper.
+  startWaitWatcher = realStartWaitWatcher,
+  enableWaitWatcher = readWaitWatcherConfig().enabled,
   // CTL-665: committed executionCore concurrency knobs resolved in main() from
   // .catalyst/config.json. Threaded into both the scheduler new-work pull and the
   // boot-resume ceiling. Empty {} (the test default) keeps the legacy state.json path.
@@ -185,6 +198,12 @@ export function startDaemon({
 
     if (enableReaper) {
       startReaperAndTimer({ orphanReaperConfig, debounceMs, orchDir });
+    }
+
+    // CTL-650: start the push-based session wait-state watcher. Inside the same
+    // try/catch so a throw triggers PID-file cleanup via stopDaemon.
+    if (enableWaitWatcher) {
+      _waitWatcher = startWaitWatcher({ intervalMs: readWaitWatcherConfig().intervalMs });
     }
   } catch (err) {
     stopDaemon();
@@ -387,6 +406,15 @@ export function stopDaemon() {
     _orphanTimer = null;
   }
   _reaper = null;
+  // CTL-650: stop the wait-state watcher.
+  if (_waitWatcher) {
+    try {
+      _waitWatcher.stop();
+    } catch {
+      /* watcher already stopped */
+    }
+    _waitWatcher = null;
+  }
   _eventLogCursor = 0;
   _eventLogLeftover = "";
   if (_pidFile) {

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -344,6 +344,59 @@ describe("startDaemon", () => {
     }
     expect(reconciled).toBeGreaterThan(0);
   });
+
+  // CTL-650: the push-based session wait-state watcher is started from
+  // startDaemon (default-on), gated by enableWaitWatcher, and stopped in
+  // stopDaemon — mirroring the reaper's enableReaper wiring.
+  test("starts the wait-watcher when enabled (CTL-650)", () => {
+    let started = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startWaitWatcher: () => {
+        started++;
+        return { stop: () => {} };
+      },
+      enableWaitWatcher: true,
+    });
+    expect(started).toBe(1);
+  });
+
+  test("skips the wait-watcher when disabled (CTL-650)", () => {
+    let started = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startWaitWatcher: () => {
+        started++;
+        return { stop: () => {} };
+      },
+      enableWaitWatcher: false,
+    });
+    expect(started).toBe(0);
+  });
+
+  test("stopDaemon stops the wait-watcher (CTL-650)", () => {
+    let stopped = 0;
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startWaitWatcher: () => ({
+        stop: () => {
+          stopped++;
+        },
+      }),
+      enableWaitWatcher: true,
+    });
+    stopDaemon();
+    expect(stopped).toBe(1);
+  });
 });
 
 // CTL-649: consumeEventTail must read by BYTE offset, not JS-string code units,

--- a/plugins/dev/scripts/execution-core/session-recency.mjs
+++ b/plugins/dev/scripts/execution-core/session-recency.mjs
@@ -19,7 +19,10 @@ export function defaultProjectsDir() {
 // `<sessionId>.jsonl` and lives one level under the projects dir (the
 // intervening directory is the URL-encoded project cwd), so we scan the
 // project dirs rather than doing a full recursive walk.
-function findTranscript(sessionId, projectsDir) {
+//
+// CTL-650: exported so the wait-watcher can locate a session's transcript
+// without duplicating the project-dir scan. Visibility-only change.
+export function findTranscript(sessionId, projectsDir) {
   let entries;
   try {
     entries = readdirSync(projectsDir, { withFileTypes: true });

--- a/plugins/dev/scripts/execution-core/transcript-tail.mjs
+++ b/plugins/dev/scripts/execution-core/transcript-tail.mjs
@@ -1,0 +1,133 @@
+// transcript-tail.mjs — CTL-650 Phase 2. Per-session transcript state tracker.
+//
+// Maintains, per Claude session, exactly the fields classifyWaitState() needs —
+// derived by INCREMENTALLY tailing the session's transcript JSONL with the
+// CTL-673 scanEventsChunked primitive (byte cursor + leftover, O(new bytes) per
+// poll, never re-reading the whole file). Tracks the last assistant turn's
+// stop_reason / last content-block type / last tool / last text, plus the count
+// of user|tool_result entries seen since that assistant turn. Resets the cursor
+// on truncation/rotation, mirroring the daemon's live tailer (daemon.mjs:300-305).
+
+import { openSync, fstatSync, closeSync } from "node:fs";
+import { scanEventsChunked } from "./event-tail.mjs";
+
+/**
+ * freshState — the zeroed tracker state. Exposed so applyEntry can be unit-tested
+ * directly without constructing a tracker.
+ */
+export function freshState() {
+  return {
+    stopReason: null,
+    lastBlockType: null,
+    lastTool: null,
+    lastText: null,
+    postUserOrResultCount: 0,
+  };
+}
+
+// hasToolResultBlock — true when a transcript entry carries a tool_result content
+// block. Claude transcripts deliver tool results inside a type:"user" message, so
+// the prototype counted any line matching `"type":"user"` OR `"tool_result"`; we
+// reproduce that by treating either signal as one post-assistant entry.
+function hasToolResultBlock(entry) {
+  const content = entry?.message?.content;
+  if (Array.isArray(content)) {
+    return content.some((b) => b?.type === "tool_result");
+  }
+  return false;
+}
+
+/**
+ * applyEntry — pure reducer folding one transcript entry into the tracker state.
+ * `assistant` entries set the last-turn fields and reset the post-assistant
+ * counter; `user`/`tool_result` entries increment it. Mutates and returns state.
+ */
+export function applyEntry(state, entry) {
+  if (entry?.type === "assistant") {
+    const content = entry.message?.content;
+    const last = Array.isArray(content) && content.length ? content[content.length - 1] : undefined;
+    state.stopReason = entry.message?.stop_reason ?? null;
+    state.lastBlockType = last?.type ?? null;
+    state.lastTool = last?.name ?? null;
+    state.lastText = last?.text ?? null;
+    state.postUserOrResultCount = 0;
+  } else if (entry?.type === "user" || entry?.type === "tool_result" || hasToolResultBlock(entry)) {
+    state.postUserOrResultCount += 1;
+  }
+  return state;
+}
+
+// statSizeOrNull — current byte size of the file, or null when it cannot be
+// stat'd (missing/transient). Used only to detect truncation/rotation.
+function statSizeOrNull(path) {
+  let fd;
+  try {
+    fd = openSync(path, "r");
+    const { size } = fstatSync(fd);
+    return size;
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* fd already gone */
+      }
+    }
+  }
+}
+
+/**
+ * createTranscriptTracker — a stateful per-session tracker over a transcript path.
+ * `poll()` reads only the bytes appended since the last poll and folds them into
+ * the state; `snapshot()` returns the classifyWaitState() input object.
+ *
+ * `scan` and `statSize` are injectable seams (default to the real primitives) so
+ * the reducer can be driven without real I/O in tests.
+ *
+ * @param {object} opts
+ * @param {string} opts.path                 transcript JSONL path
+ * @param {Function} [opts.scan=scanEventsChunked]
+ * @param {Function} [opts.statSize=statSizeOrNull]
+ */
+export function createTranscriptTracker({ path, scan = scanEventsChunked, statSize = statSizeOrNull } = {}) {
+  const state = freshState();
+  let cursor = 0;
+  let leftover = "";
+
+  function poll() {
+    // Truncation/rotation: a file shorter than our cursor was replaced — restart
+    // from 0 and drop the partial line stitched from the now-vanished bytes
+    // (mirror daemon.mjs:300-305).
+    const size = statSize(path);
+    if (size != null && size < cursor) {
+      cursor = 0;
+      leftover = "";
+    }
+    const { endOffset, leftover: nextLeftover } = scan({
+      path,
+      fromOffset: cursor,
+      leftover,
+      onEvent: (entry) => applyEntry(state, entry),
+    });
+    cursor = endOffset;
+    leftover = nextLeftover;
+  }
+
+  function snapshot() {
+    // hasTranscript is always true here: a tracker only exists because the
+    // watcher resolved a transcript path. The "no transcript" case is handled
+    // upstream by not constructing a tracker at all.
+    return {
+      hasTranscript: true,
+      lastBlockType: state.lastBlockType,
+      lastTool: state.lastTool,
+      stopReason: state.stopReason,
+      lastText: state.lastText,
+      postUserOrResultCount: state.postUserOrResultCount,
+    };
+  }
+
+  return { poll, snapshot };
+}

--- a/plugins/dev/scripts/execution-core/transcript-tail.test.mjs
+++ b/plugins/dev/scripts/execution-core/transcript-tail.test.mjs
@@ -1,0 +1,159 @@
+// transcript-tail.test.mjs — CTL-650 Phase 2. Per-session transcript state
+// tracker built on the CTL-673 scanEventsChunked primitive. The pure
+// applyEntry() reducer is tested directly (cheap); poll()'s incremental read,
+// cross-poll leftover stitching, and truncation reset are exercised against
+// real temp files (the scanEventsChunked contract opens the fd itself).
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, appendFileSync, truncateSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTranscriptTracker, applyEntry, freshState } from "./transcript-tail.mjs";
+
+const assistant = (stop_reason, lastBlock) => ({
+  type: "assistant",
+  message: { stop_reason, content: [{ type: "text", text: "preamble" }, lastBlock] },
+});
+const assistantText = (text, stop_reason = "end_turn") =>
+  assistant(stop_reason, { type: "text", text });
+const assistantTool = (name) => assistant(null, { type: "tool_use", name });
+const userMsg = () => ({ type: "user", message: { content: [{ type: "text", text: "go" }] } });
+const toolResult = () => ({
+  type: "user",
+  message: { content: [{ type: "tool_result", content: "ok" }] },
+});
+
+// ─── applyEntry (pure reducer) ────────────────────────────────────────────────
+
+describe("applyEntry", () => {
+  test("tracks last assistant block type, tool, stop_reason, text", () => {
+    const s = freshState();
+    applyEntry(s, assistantTool("AskUserQuestion"));
+    expect(s.lastBlockType).toBe("tool_use");
+    expect(s.lastTool).toBe("AskUserQuestion");
+    expect(s.stopReason).toBe(null);
+
+    applyEntry(s, assistantText("Should I proceed?"));
+    expect(s.lastBlockType).toBe("text");
+    expect(s.lastText).toBe("Should I proceed?");
+    expect(s.stopReason).toBe("end_turn");
+  });
+
+  test("counts user + tool_result entries after the last assistant", () => {
+    const s = freshState();
+    applyEntry(s, assistantText("done"));
+    applyEntry(s, userMsg());
+    applyEntry(s, toolResult());
+    expect(s.postUserOrResultCount).toBe(2);
+  });
+
+  test("a new assistant entry resets postUserOrResultCount to 0", () => {
+    const s = freshState();
+    applyEntry(s, assistantText("a"));
+    applyEntry(s, userMsg());
+    applyEntry(s, userMsg());
+    expect(s.postUserOrResultCount).toBe(2);
+    applyEntry(s, assistantText("b"));
+    expect(s.postUserOrResultCount).toBe(0);
+  });
+
+  test("standalone tool_result-typed entry also counts", () => {
+    const s = freshState();
+    applyEntry(s, assistantTool("Bash"));
+    applyEntry(s, { type: "tool_result" });
+    expect(s.postUserOrResultCount).toBe(1);
+  });
+});
+
+// ─── createTranscriptTracker.snapshot ─────────────────────────────────────────
+
+describe("createTranscriptTracker.snapshot", () => {
+  test("snapshot() returns the classifier input shape", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl650-tt-"));
+    const path = join(dir, "s.jsonl");
+    writeFileSync(path, `${JSON.stringify(assistantText("Ready?"))}\n`);
+    const tracker = createTranscriptTracker({ path });
+    tracker.poll();
+    const snap = tracker.snapshot();
+    expect(snap).toMatchObject({
+      hasTranscript: true,
+      lastBlockType: "text",
+      stopReason: "end_turn",
+      lastText: "Ready?",
+      postUserOrResultCount: 0,
+    });
+  });
+});
+
+// ─── createTranscriptTracker.poll (real FS) ───────────────────────────────────
+
+describe("createTranscriptTracker.poll", () => {
+  test("incremental poll picks up only newly-appended lines", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl650-tt-"));
+    const path = join(dir, "s.jsonl");
+    writeFileSync(path, `${JSON.stringify(assistantTool("Bash"))}\n`);
+    const tracker = createTranscriptTracker({ path });
+    tracker.poll();
+    expect(tracker.snapshot().lastBlockType).toBe("tool_use");
+    expect(tracker.snapshot().postUserOrResultCount).toBe(0);
+
+    appendFileSync(path, `${JSON.stringify(toolResult())}\n`);
+    tracker.poll();
+    expect(tracker.snapshot().postUserOrResultCount).toBe(1);
+  });
+
+  test("a line split across two polls is reassembled via leftover", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl650-tt-"));
+    const path = join(dir, "s.jsonl");
+    const line = JSON.stringify(assistantText("partial line test"));
+    const half = Math.floor(line.length / 2);
+    writeFileSync(path, line.slice(0, half)); // no newline yet — partial
+    const tracker = createTranscriptTracker({ path });
+    tracker.poll();
+    // Nothing complete yet.
+    expect(tracker.snapshot().lastText).toBe(null);
+    appendFileSync(path, `${line.slice(half)}\n`); // complete the line
+    tracker.poll();
+    expect(tracker.snapshot().lastText).toBe("partial line test");
+  });
+
+  test("truncation (size < cursor) resets the cursor and re-reads", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl650-tt-"));
+    const path = join(dir, "s.jsonl");
+    writeFileSync(
+      path,
+      `${JSON.stringify(assistantText("first"))}\n${JSON.stringify(userMsg())}\n`,
+    );
+    const tracker = createTranscriptTracker({ path });
+    tracker.poll();
+    expect(tracker.snapshot().postUserOrResultCount).toBe(1);
+
+    // Rotate: replace with a shorter file whose size < the old cursor.
+    truncateSync(path, 0);
+    writeFileSync(path, `${JSON.stringify(assistantTool("Edit"))}\n`);
+    tracker.poll();
+    const snap = tracker.snapshot();
+    expect(snap.lastBlockType).toBe("tool_use");
+    expect(snap.lastTool).toBe("Edit");
+    expect(snap.postUserOrResultCount).toBe(0);
+  });
+
+  test("malformed JSON line is skipped (parseEventTailChunk contract)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl650-tt-"));
+    const path = join(dir, "s.jsonl");
+    writeFileSync(
+      path,
+      `{not json\n${JSON.stringify(assistantText("after bad line"))}\n`,
+    );
+    const tracker = createTranscriptTracker({ path });
+    tracker.poll();
+    expect(tracker.snapshot().lastText).toBe("after bad line");
+  });
+
+  test("snapshot() before any poll on a missing file still reports hasTranscript", () => {
+    const tracker = createTranscriptTracker({ path: "/nonexistent/never.jsonl" });
+    tracker.poll(); // no throw
+    expect(tracker.snapshot().hasTranscript).toBe(true);
+    expect(tracker.snapshot().lastBlockType).toBe(null);
+  });
+});

--- a/plugins/dev/scripts/execution-core/wait-event.mjs
+++ b/plugins/dev/scripts/execution-core/wait-event.mjs
@@ -1,0 +1,100 @@
+// wait-event.mjs — CTL-650 Phase 3. The agent.* canonical-event builder + a
+// best-effort appender. Modeled on recovery.mjs's buildEventEnvelope
+// (recovery.mjs:189-215) but emits `event.entity:"agent"` with
+// `event.name:"agent.waiting_on_user"|"agent.resumed"` and INFO severity. These
+// names match no broker self-emit pattern (shouldSkipEvent), so the daemon
+// tailing its own log cannot feed a wait event back to itself.
+//
+// buildWaitEnvelope returns the envelope OBJECT (FS-free, unit-testable shape);
+// emitWaitEvent serializes it and appends one line, never throwing — a missing
+// event log is best-effort like every other daemon emitter.
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, log } from "./config.mjs";
+import { shortIdFromSessionId } from "./claude-ids.mjs";
+
+/**
+ * buildWaitEnvelope — assemble the canonical OTel envelope for a wait/resume
+ * transition. Pure (modulo random ids + timestamp); no I/O.
+ *
+ * @param {string} name  "agent.waiting_on_user" | "agent.resumed"
+ * @param {object} args
+ * @param {object} args.a            the live `claude agents` entry ({sessionId,status,cwd})
+ * @param {string} args.state        the classified wait state
+ * @param {?string} [args.waitingText]
+ * @param {?string} [args.detail]
+ * @param {object} [args.meta]       the joined signal ({ticket,phase,orchestratorId,worktreePath})
+ * @returns {object} the envelope object
+ */
+export function buildWaitEnvelope(name, { a = {}, state, waitingText, detail, meta = {} } = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const sessionId = a.sessionId ?? null;
+  let shortId = null;
+  if (sessionId) {
+    try {
+      shortId = shortIdFromSessionId(sessionId);
+    } catch {
+      shortId = null;
+    }
+  }
+  const ticket = meta.ticket ?? null;
+  const phase = meta.phase ?? null;
+  const orchId = meta.orchestratorId ?? ticket ?? null;
+  const cwd = a.cwd ?? meta.worktreePath ?? null;
+  const action = name.startsWith("agent.") ? name.slice("agent.".length) : name;
+
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId: randomBytes(16).toString("hex"),
+    spanId: randomBytes(8).toString("hex"),
+    resource: {
+      "service.name": "catalyst.execution-core",
+      "service.namespace": "catalyst",
+    },
+    attributes: {
+      "event.name": name,
+      "event.entity": "agent",
+      "event.action": action,
+      "event.label": ticket ?? shortId ?? sessionId ?? "unknown",
+      "catalyst.orchestration": orchId ?? "",
+      // Only stamp the Linear identifier when we actually joined a ticket — an
+      // unjoined session must not invent a `linear.issue.identifier`.
+      ...(ticket ? { "linear.issue.identifier": ticket } : {}),
+    },
+    body: {
+      payload: {
+        sessionId,
+        shortId,
+        ticket,
+        phase,
+        waitState: state ?? null,
+        waitingText: waitingText ?? null,
+        cwd,
+        detail: detail ?? null,
+      },
+    },
+  };
+}
+
+/**
+ * emitWaitEvent — build + append one envelope line to the event log. Returns
+ * true on success, false on any failure (best-effort; never throws). `logPath`
+ * is injectable for tests.
+ */
+export function emitWaitEvent(name, args, { logPath = getEventLogPath() } = {}) {
+  const line = `${JSON.stringify(buildWaitEnvelope(name, args))}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message, name }, "wait-event: event append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/wait-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/wait-event.test.mjs
@@ -1,0 +1,85 @@
+// wait-event.test.mjs — CTL-650 Phase 3. The agent.* canonical-event builder
+// and best-effort appender. buildWaitEnvelope is asserted without touching the
+// FS; emitWaitEvent is exercised against a temp event log.
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildWaitEnvelope, emitWaitEvent } from "./wait-event.mjs";
+
+const sessionId = "abcd1234-5555-6666-7777-888888888888";
+const baseArgs = {
+  a: { sessionId, status: "idle", cwd: "/wt/CTL-650" },
+  state: "WAITING_USER",
+  waitingText: "Should I proceed?",
+  detail: "",
+  meta: { ticket: "CTL-650", phase: "implement", orchestratorId: "CTL-650" },
+};
+
+describe("buildWaitEnvelope", () => {
+  test("sets agent entity, INFO severity, and the given event name", () => {
+    const env = buildWaitEnvelope("agent.waiting_on_user", baseArgs);
+    expect(env.attributes["event.name"]).toBe("agent.waiting_on_user");
+    expect(env.attributes["event.entity"]).toBe("agent");
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+  });
+
+  test("payload carries sessionId/shortId/ticket/phase/waitState/waitingText/cwd", () => {
+    const env = buildWaitEnvelope("agent.waiting_on_user", baseArgs);
+    expect(env.body.payload).toMatchObject({
+      sessionId,
+      shortId: "abcd1234",
+      ticket: "CTL-650",
+      phase: "implement",
+      waitState: "WAITING_USER",
+      waitingText: "Should I proceed?",
+      cwd: "/wt/CTL-650",
+    });
+  });
+
+  test("sets the Linear identifier attribute when a ticket is present", () => {
+    const env = buildWaitEnvelope("agent.waiting_on_user", baseArgs);
+    expect(env.attributes["linear.issue.identifier"]).toBe("CTL-650");
+    expect(env.attributes["event.label"]).toBe("CTL-650");
+  });
+
+  test("tolerates missing meta — null ticket/phase, no linear attribute", () => {
+    const env = buildWaitEnvelope("agent.resumed", {
+      a: { sessionId, status: "busy", cwd: "/wt" },
+      state: "ACTIVE",
+    });
+    expect(env.body.payload.ticket).toBe(null);
+    expect(env.body.payload.phase).toBe(null);
+    expect(env.body.payload.waitState).toBe("ACTIVE");
+    expect("linear.issue.identifier" in env.attributes).toBe(false);
+  });
+
+  test("ts is a Z-suffixed timestamp with no millisecond fraction", () => {
+    const env = buildWaitEnvelope("agent.waiting_on_user", baseArgs);
+    expect(env.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+});
+
+describe("emitWaitEvent", () => {
+  test("appends exactly one valid JSON line to the event log", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl650-we-"));
+    const logPath = join(dir, "2026-05.jsonl");
+    const ok = emitWaitEvent("agent.waiting_on_user", baseArgs, { logPath });
+    expect(ok).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.attributes["event.name"]).toBe("agent.waiting_on_user");
+    expect(parsed.body.payload.ticket).toBe("CTL-650");
+  });
+
+  test("creates the parent directory when missing (never throws)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl650-we-"));
+    const logPath = join(dir, "nested", "deep", "2026-05.jsonl");
+    expect(emitWaitEvent("agent.resumed", baseArgs, { logPath })).toBe(true);
+    expect(readFileSync(logPath, "utf8").trim().split("\n").length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/wait-state-classifier.mjs
+++ b/plugins/dev/scripts/execution-core/wait-state-classifier.mjs
@@ -1,0 +1,117 @@
+// wait-state-classifier.mjs — CTL-650 Phase 1. The pure, I/O-free core of the
+// push-based session wait-state watcher: a faithful port of the prototype's
+// decision tree (~/bin/claude-bg-waiting.sh:171-202) and its last_sentences
+// text extractor (:53-79).
+//
+// The classifier takes a flattened snapshot of one session's most recent
+// assistant turn (derived elsewhere by tailing the transcript) plus the
+// authoritative live `status` from `claude agents --json`, and returns the
+// session's wait state. Keeping this a pure function makes the risky branching
+// fully unit-testable without touching the filesystem or shelling out.
+
+// The three states that mean "a human (or a permission grant) is the only thing
+// that will move this session forward." Exported so the watcher (Phase 3) and
+// the CLI consumer (Phase 5) classify transitions against the same set.
+export const WAITING_STATES = new Set(["WAITING_USER", "WAITING_TOOL_OK", "WAITING_PERM"]);
+
+// Tools whose pending call is a deliberate, expected ask of the user rather than
+// a permission prompt — they are the agent's own UI for blocking on input.
+const TOOL_OK = new Set(["AskUserQuestion", "ExitPlanMode", "EnterPlanMode"]);
+
+/**
+ * classifyWaitState — map one session's last-assistant snapshot to a wait state.
+ *
+ * @param {object} input
+ * @param {?string} input.status               live `claude agents` status; "busy" is authoritative
+ * @param {?string} input.lastBlockType        type of the last content block ("text"/"tool_use"/…)
+ * @param {?string} input.lastTool             name of the last tool_use block, if any
+ * @param {?string} input.stopReason           message.stop_reason of the last assistant turn
+ * @param {?string} input.lastText             text of the last content block (for WAITING_USER)
+ * @param {number}  [input.postUserOrResultCount=0] user/tool_result lines after the last assistant
+ * @param {boolean} [input.hasTranscript=true] false when no JSONL exists on disk
+ * @returns {{ state: string, detail?: string, waitingText?: string }}
+ */
+export function classifyWaitState({
+  status,
+  lastBlockType,
+  lastTool,
+  stopReason,
+  lastText,
+  postUserOrResultCount = 0,
+  hasTranscript = true,
+} = {}) {
+  if (!hasTranscript) return { state: "NO_TRANSCRIPT", detail: "" };
+
+  // The daemon's status is authoritative for "is it executing right now." A busy
+  // session is actively working and is NEVER waiting on the user, no matter what
+  // the last turn's stop_reason says — background agents post a text summary then
+  // keep going, which reads as end_turn but isn't a wait (prototype :164-170).
+  const busy = status === "busy";
+  if (busy) {
+    return lastBlockType === "tool_use"
+      ? { state: "MID_TURN", detail: `tool=${lastTool}` }
+      : { state: "ACTIVE", detail: "working" };
+  }
+
+  // Not busy + last action was a tool call with no result yet → blocked. An
+  // AskUserQuestion/Plan-mode tool is an expected user-action ask; anything else
+  // is a permission prompt.
+  if (lastBlockType === "tool_use" && postUserOrResultCount === 0) {
+    return TOOL_OK.has(lastTool)
+      ? { state: "WAITING_TOOL_OK", detail: `tool=${lastTool}` }
+      : { state: "WAITING_PERM", detail: `tool=${lastTool}` };
+  }
+
+  // Not busy + turn ended cleanly → parked waiting for the next prompt.
+  if (stopReason === "end_turn") {
+    return { state: "WAITING_USER", waitingText: extractWaitingText(lastText), detail: "" };
+  }
+
+  // Not busy, tool call already resolved → paused between sub-steps.
+  if (lastBlockType === "tool_use") {
+    return { state: "MID_TURN", detail: `tool=${lastTool}` };
+  }
+
+  return { state: "UNKNOWN", detail: `stop=${stopReason} block=${lastBlockType}` };
+}
+
+/** isWaitingState — true iff `state` is one of the three waiting states. */
+export function isWaitingState(state) {
+  return WAITING_STATES.has(state);
+}
+
+/**
+ * extractWaitingText — the agent's actual question or closing statement lands at
+ * the END of the last assistant text, not the start, so we keep the tail. Port
+ * of `last_sentences` (~/bin/claude-bg-waiting.sh:53-79): the trailing one-to-two
+ * complete sentences plus any dangling unpunctuated fragment, whitespace-collapsed
+ * and length-capped from the end.
+ *
+ * @param {?string} text         the raw last-block text
+ * @param {number}  [maxLen=200] cap on the returned length
+ * @returns {string} the trimmed trailing text, "" for empty/whitespace input
+ */
+export function extractWaitingText(text, maxLen = 200) {
+  if (text == null) return "";
+  // Trim trailing whitespace (the bash version trims the tail before matching).
+  const trimmed = String(text).replace(/\s+$/, "");
+  if (trimmed === "") return "";
+
+  // Last 2 complete sentences (chunks ending in . ! or ?)…
+  const sentences = trimmed.match(/[^.!?]+[.!?]+/g) ?? [];
+  const tail2 = sentences.slice(-2).join(" ");
+  // …plus any dangling fragment after the final terminator (an unpunctuated ask).
+  // The `s` flag lets `.*` span newlines so the greedy match reaches the LAST
+  // terminator, mirroring `sed -E 's/.*[.!?]//'`.
+  const frag = trimmed.replace(/.*[.!?]/s, "");
+
+  let out = `${tail2} ${frag}`.replace(/\s+/g, " ").trim();
+  // No punctuation anywhere → fall back to the whole (collapsed) text.
+  if (out === "") out = trimmed.replace(/\s+/g, " ").trim();
+
+  // Cap length, keeping the END of the string (prepend an ellipsis when cut).
+  if (out.length > maxLen) {
+    out = `…${out.slice(-(maxLen - 1))}`;
+  }
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/wait-state-classifier.test.mjs
+++ b/plugins/dev/scripts/execution-core/wait-state-classifier.test.mjs
@@ -1,0 +1,180 @@
+// wait-state-classifier.test.mjs — CTL-650 Phase 1. Exhaustive branch coverage
+// of the pure wait-state decision tree ported from
+// ~/bin/claude-bg-waiting.sh:171-202, plus the extractWaitingText port
+// (claude-bg-waiting.sh:53-79).
+
+import { test, expect } from "bun:test";
+import {
+  classifyWaitState,
+  isWaitingState,
+  extractWaitingText,
+  WAITING_STATES,
+} from "./wait-state-classifier.mjs";
+
+// input shape: { status, lastBlockType, lastTool, stopReason, lastText,
+//                postUserOrResultCount, hasTranscript }
+
+test("no transcript → NO_TRANSCRIPT", () => {
+  expect(classifyWaitState({ hasTranscript: false }).state).toBe("NO_TRANSCRIPT");
+});
+
+test("busy + tool_use → MID_TURN", () => {
+  expect(
+    classifyWaitState({
+      hasTranscript: true,
+      status: "busy",
+      lastBlockType: "tool_use",
+      lastTool: "Bash",
+    }).state,
+  ).toBe("MID_TURN");
+});
+
+test("busy + text → ACTIVE", () => {
+  expect(
+    classifyWaitState({ hasTranscript: true, status: "busy", lastBlockType: "text" }).state,
+  ).toBe("ACTIVE");
+});
+
+test("idle + unresolved AskUserQuestion → WAITING_TOOL_OK", () => {
+  expect(
+    classifyWaitState({
+      hasTranscript: true,
+      status: "idle",
+      lastBlockType: "tool_use",
+      lastTool: "AskUserQuestion",
+      postUserOrResultCount: 0,
+    }).state,
+  ).toBe("WAITING_TOOL_OK");
+});
+
+test("idle + unresolved other tool → WAITING_PERM", () => {
+  expect(
+    classifyWaitState({
+      hasTranscript: true,
+      status: "idle",
+      lastBlockType: "tool_use",
+      lastTool: "Bash",
+      postUserOrResultCount: 0,
+    }).state,
+  ).toBe("WAITING_PERM");
+});
+
+test("idle + end_turn → WAITING_USER with waitingText", () => {
+  const r = classifyWaitState({
+    hasTranscript: true,
+    status: "idle",
+    lastBlockType: "text",
+    stopReason: "end_turn",
+    lastText: "First. Should I proceed?",
+  });
+  expect(r.state).toBe("WAITING_USER");
+  expect(r.waitingText).toContain("Should I proceed?");
+});
+
+test("idle + resolved tool_use → MID_TURN", () => {
+  expect(
+    classifyWaitState({
+      hasTranscript: true,
+      status: "idle",
+      lastBlockType: "tool_use",
+      lastTool: "Bash",
+      postUserOrResultCount: 1,
+    }).state,
+  ).toBe("MID_TURN");
+});
+
+test("idle + unknown → UNKNOWN", () => {
+  expect(
+    classifyWaitState({
+      hasTranscript: true,
+      status: "idle",
+      lastBlockType: "text",
+      stopReason: "max_tokens",
+    }).state,
+  ).toBe("UNKNOWN");
+});
+
+test("null status treated as not-busy", () => {
+  // claude agents --json returns status:null for some sessions (research §6)
+  expect(
+    classifyWaitState({
+      hasTranscript: true,
+      status: null,
+      lastBlockType: "text",
+      stopReason: "end_turn",
+      lastText: "Done.",
+    }).state,
+  ).toBe("WAITING_USER");
+});
+
+test("ExitPlanMode and EnterPlanMode also map to WAITING_TOOL_OK", () => {
+  for (const lastTool of ["ExitPlanMode", "EnterPlanMode"]) {
+    expect(
+      classifyWaitState({
+        hasTranscript: true,
+        status: "idle",
+        lastBlockType: "tool_use",
+        lastTool,
+        postUserOrResultCount: 0,
+      }).state,
+    ).toBe("WAITING_TOOL_OK");
+  }
+});
+
+test("isWaitingState true only for the three waiting states", () => {
+  expect(isWaitingState("WAITING_USER")).toBe(true);
+  expect(isWaitingState("WAITING_TOOL_OK")).toBe(true);
+  expect(isWaitingState("WAITING_PERM")).toBe(true);
+  expect(isWaitingState("MID_TURN")).toBe(false);
+  expect(isWaitingState("ACTIVE")).toBe(false);
+  expect(isWaitingState("NO_TRANSCRIPT")).toBe(false);
+  expect(isWaitingState("UNKNOWN")).toBe(false);
+  expect(isWaitingState("")).toBe(false);
+  expect(isWaitingState(undefined)).toBe(false);
+});
+
+test("WAITING_STATES export contains exactly the three waiting states", () => {
+  expect([...WAITING_STATES].sort()).toEqual(
+    ["WAITING_PERM", "WAITING_TOOL_OK", "WAITING_USER"].sort(),
+  );
+});
+
+// ─── extractWaitingText (port of last_sentences, :53-79) ──────────────────────
+
+test("extractWaitingText keeps the trailing 1-2 sentences", () => {
+  const out = extractWaitingText("I did the first thing. Then the second. Should I proceed?");
+  expect(out).toContain("Should I proceed?");
+  expect(out).toContain("Then the second.");
+  expect(out).not.toContain("first thing");
+});
+
+test("extractWaitingText keeps an unpunctuated trailing fragment", () => {
+  const out = extractWaitingText("All done. Now what next");
+  expect(out).toContain("Now what next");
+});
+
+test("extractWaitingText collapses whitespace", () => {
+  const out = extractWaitingText("Hello   world.   Ready?");
+  expect(out).toBe("Hello world. Ready?");
+});
+
+test("extractWaitingText with no punctuation falls back to the whole text", () => {
+  expect(extractWaitingText("just a phrase no terminator")).toBe(
+    "just a phrase no terminator",
+  );
+});
+
+test("extractWaitingText caps length keeping the END and prepends an ellipsis", () => {
+  const long = "x".repeat(50) + " important tail";
+  const out = extractWaitingText(long, 20);
+  expect(out.length).toBe(20);
+  expect(out.startsWith("…")).toBe(true);
+  expect(out.endsWith("important tail")).toBe(true);
+});
+
+test("extractWaitingText returns empty string for empty/null input", () => {
+  expect(extractWaitingText("")).toBe("");
+  expect(extractWaitingText(null)).toBe("");
+  expect(extractWaitingText(undefined)).toBe("");
+  expect(extractWaitingText("   ")).toBe("");
+});

--- a/plugins/dev/scripts/execution-core/wait-watcher.mjs
+++ b/plugins/dev/scripts/execution-core/wait-watcher.mjs
@@ -1,0 +1,116 @@
+// wait-watcher.mjs — CTL-650 Phase 3. The push-based session wait-state watcher.
+//
+// On each tick it (a) enumerates live sessions via `claude agents --json` (the
+// authoritative busy/idle source), (b) incrementally tails each session's
+// transcript through a per-session tracker, (c) classifies the wait state, and
+// (d) emits a debounced `agent.waiting_on_user` / `agent.resumed` event ONLY on
+// a real transition (per-session lastState map, the broker debounce model
+// router.mjs:1634-1646). Sessions that disappear are purged so the maps stay
+// bounded. Every dependency is injected (the startDaemon/Reaper test idiom) so
+// the tick is fully unit-testable with a fake clock + fake emitter.
+
+import { listClaudeAgents } from "./claude-agents.mjs";
+import { indexSignalsByBgJobId } from "./cli/sessions.mjs";
+import { createTranscriptTracker } from "./transcript-tail.mjs";
+import { findTranscript, defaultProjectsDir } from "./session-recency.mjs";
+import { classifyWaitState, isWaitingState } from "./wait-state-classifier.mjs";
+import { shortIdFromSessionId } from "./claude-ids.mjs";
+import { emitWaitEvent } from "./wait-event.mjs";
+import { EVENT_DEBOUNCE_MS, log } from "./config.mjs";
+
+function realClock() {
+  return {
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
+  };
+}
+
+/**
+ * startWaitWatcher — start the periodic wait-state tick. Returns `{ stop, tick }`.
+ *
+ * @param {object} opts
+ * @param {object}   [opts.clock=realClock()]                  fake-clock seam
+ * @param {number}   [opts.intervalMs=EVENT_DEBOUNCE_MS]       tick cadence
+ * @param {Function} [opts.listAgents=listClaudeAgents]        live-session enumerator
+ * @param {Function} [opts.indexSignals=indexSignalsByBgJobId] signal join (ticket/phase)
+ * @param {Function} [opts.makeTracker]                        per-session tracker factory
+ * @param {Function} [opts.findTranscriptFn=findTranscript]    transcript locator
+ * @param {Function} [opts.emit=emitWaitEvent]                 transition emitter
+ * @param {string}   [opts.projectsDir=defaultProjectsDir()]   transcripts root
+ */
+export function startWaitWatcher({
+  clock = realClock(),
+  intervalMs = EVENT_DEBOUNCE_MS,
+  listAgents = listClaudeAgents,
+  indexSignals = indexSignalsByBgJobId,
+  makeTracker = (p) => createTranscriptTracker({ path: p }),
+  findTranscriptFn = findTranscript,
+  emit = emitWaitEvent,
+  projectsDir = defaultProjectsDir(),
+} = {}) {
+  const trackers = new Map(); // sessionId → tracker
+  const lastState = new Map(); // sessionId → state (debounce)
+
+  function tick() {
+    let agents;
+    let sigIndex;
+    try {
+      agents = listAgents() ?? [];
+      sigIndex = indexSignals() ?? new Map();
+    } catch (err) {
+      // A failed enumeration/index read is a transient — skip this tick, never
+      // crash the daemon's watcher thread.
+      log.warn({ err: err?.message }, "wait-watcher: tick enumeration failed");
+      return;
+    }
+
+    const live = new Set();
+    for (const a of agents) {
+      if (!a || !a.sessionId) continue;
+      live.add(a.sessionId);
+
+      const path = findTranscriptFn(a.sessionId, projectsDir);
+      let tracker = trackers.get(a.sessionId);
+      if (!tracker && path) {
+        tracker = makeTracker(path);
+        trackers.set(a.sessionId, tracker);
+      }
+      if (tracker) tracker.poll();
+      const snap = tracker ? tracker.snapshot() : { hasTranscript: false };
+
+      const { state, waitingText, detail } = classifyWaitState({ ...snap, status: a.status });
+      const prev = lastState.get(a.sessionId);
+      if (state !== prev) {
+        let meta = {};
+        try {
+          meta = sigIndex.get(shortIdFromSessionId(a.sessionId)) ?? {};
+        } catch {
+          meta = {};
+        }
+        if (isWaitingState(state) && !isWaitingState(prev ?? "")) {
+          emit("agent.waiting_on_user", { a, state, waitingText, detail, meta });
+        } else if (!isWaitingState(state) && isWaitingState(prev ?? "")) {
+          emit("agent.resumed", { a, state, detail, meta });
+        }
+        lastState.set(a.sessionId, state);
+      }
+    }
+
+    // Purge sessions that disappeared so the maps stay bounded and a returning
+    // session re-emits its first transition rather than being debounced against
+    // a stale state.
+    for (const id of [...trackers.keys()]) {
+      if (!live.has(id)) {
+        trackers.delete(id);
+        lastState.delete(id);
+      }
+    }
+    for (const id of [...lastState.keys()]) {
+      if (!live.has(id)) lastState.delete(id);
+    }
+  }
+
+  const handle = clock.setInterval(tick, intervalMs);
+  if (typeof handle?.unref === "function") handle.unref();
+  return { stop: () => clock.clearInterval(handle), tick };
+}

--- a/plugins/dev/scripts/execution-core/wait-watcher.test.mjs
+++ b/plugins/dev/scripts/execution-core/wait-watcher.test.mjs
@@ -1,0 +1,159 @@
+// wait-watcher.test.mjs — CTL-650 Phase 3. The watcher tick: enumerate agents,
+// poll each tracker, classify, and emit transition events through a per-session
+// debounce. All dependencies injected so the tick runs with no real I/O; tick()
+// is exposed and called directly (no real timer needed).
+
+import { test, expect } from "bun:test";
+import { startWaitWatcher } from "./wait-watcher.mjs";
+
+const SID = "aaaaaaaa-1111-2222-3333-444444444444";
+const SHORT = "aaaaaaaa";
+
+// A clock that records the registered handle and whether clearInterval fired.
+function recordingClock() {
+  const handle = { id: Symbol("interval") };
+  let cleared = false;
+  return {
+    setInterval: () => handle,
+    clearInterval: (h) => {
+      if (h === handle) cleared = true;
+    },
+    wasCleared: () => cleared,
+  };
+}
+
+// snapshots for the classifier (status is merged in by the watcher from the agent)
+const MID_TURN_SNAP = {
+  hasTranscript: true,
+  lastBlockType: "tool_use",
+  lastTool: "Bash",
+  stopReason: null,
+  postUserOrResultCount: 1,
+};
+const WAITING_USER_SNAP = {
+  hasTranscript: true,
+  lastBlockType: "text",
+  stopReason: "end_turn",
+  lastText: "Should I proceed?",
+  postUserOrResultCount: 0,
+};
+const ACTIVE_SNAP = { hasTranscript: true, lastBlockType: "text", stopReason: "end_turn" };
+
+// Build a watcher whose tracker returns whatever `snapRef.current` holds, and
+// whose agent list is whatever `agentsRef.current` holds, so a test can mutate
+// state between manual tick() calls.
+function harness({ agentsRef, snapRef, sigIndex = new Map() }) {
+  const emitted = [];
+  const clock = recordingClock();
+  const w = startWaitWatcher({
+    clock,
+    listAgents: () => agentsRef.current,
+    indexSignals: () => sigIndex,
+    makeTracker: () => ({ poll() {}, snapshot: () => snapRef.current }),
+    findTranscriptFn: () => "/fake/transcript.jsonl",
+    emit: (name, payload) => emitted.push({ name, payload }),
+  });
+  return { w, emitted, clock };
+}
+
+test("nonWaiting→WAITING_USER emits exactly one agent.waiting_on_user", () => {
+  const agentsRef = { current: [{ sessionId: SID, status: "idle", cwd: "/wt" }] };
+  const snapRef = { current: MID_TURN_SNAP };
+  const { w, emitted } = harness({ agentsRef, snapRef });
+
+  w.tick(); // MID_TURN — not waiting
+  expect(emitted).toEqual([]);
+
+  snapRef.current = WAITING_USER_SNAP;
+  w.tick(); // → WAITING_USER
+  expect(emitted.length).toBe(1);
+  expect(emitted[0].name).toBe("agent.waiting_on_user");
+});
+
+test("staying WAITING_USER across ticks does NOT re-emit (debounce)", () => {
+  const agentsRef = { current: [{ sessionId: SID, status: "idle", cwd: "/wt" }] };
+  const snapRef = { current: WAITING_USER_SNAP };
+  const { w, emitted } = harness({ agentsRef, snapRef });
+
+  w.tick();
+  w.tick();
+  w.tick();
+  expect(emitted.length).toBe(1);
+});
+
+test("WAITING_*→ACTIVE emits exactly one agent.resumed", () => {
+  const agentsRef = { current: [{ sessionId: SID, status: "idle", cwd: "/wt" }] };
+  const snapRef = { current: WAITING_USER_SNAP };
+  const { w, emitted } = harness({ agentsRef, snapRef });
+
+  w.tick(); // WAITING_USER → waiting_on_user
+  agentsRef.current = [{ sessionId: SID, status: "busy", cwd: "/wt" }];
+  snapRef.current = ACTIVE_SNAP;
+  w.tick(); // busy → ACTIVE → resumed
+  expect(emitted.length).toBe(2);
+  expect(emitted[1].name).toBe("agent.resumed");
+});
+
+test("busy session never emits waiting even if last stop_reason=end_turn", () => {
+  const agentsRef = { current: [{ sessionId: SID, status: "busy", cwd: "/wt" }] };
+  const snapRef = { current: WAITING_USER_SNAP }; // end_turn text, but busy wins
+  const { w, emitted } = harness({ agentsRef, snapRef });
+
+  w.tick();
+  w.tick();
+  expect(emitted).toEqual([]);
+});
+
+test("emitted payload carries ticket/phase/meta from indexSignalsByBgJobId", () => {
+  const agentsRef = { current: [{ sessionId: SID, status: "idle", cwd: "/wt" }] };
+  const snapRef = { current: WAITING_USER_SNAP };
+  const sigIndex = new Map([
+    [SHORT, { ticket: "CTL-650", phase: "implement", orchestratorId: "CTL-650" }],
+  ]);
+  const { w, emitted } = harness({ agentsRef, snapRef, sigIndex });
+
+  w.tick();
+  expect(emitted[0].payload.meta).toMatchObject({ ticket: "CTL-650", phase: "implement" });
+  expect(emitted[0].payload.state).toBe("WAITING_USER");
+  expect(emitted[0].payload.waitingText).toContain("Should I proceed?");
+});
+
+test("a session that disappears is purged (re-emits if it reappears)", () => {
+  const agentsRef = { current: [{ sessionId: SID, status: "idle", cwd: "/wt" }] };
+  const snapRef = { current: WAITING_USER_SNAP };
+  const { w, emitted } = harness({ agentsRef, snapRef });
+
+  w.tick(); // emit #1
+  agentsRef.current = []; // session gone → purge lastState
+  w.tick(); // no emit
+  agentsRef.current = [{ sessionId: SID, status: "idle", cwd: "/wt" }];
+  w.tick(); // prev purged → emits again
+  expect(emitted.length).toBe(2);
+  expect(emitted.every((e) => e.name === "agent.waiting_on_user")).toBe(true);
+});
+
+test("NO_TRANSCRIPT does not emit waiting", () => {
+  const agentsRef = { current: [{ sessionId: SID, status: "idle", cwd: "/wt" }] };
+  const snapRef = { current: { hasTranscript: false } };
+  const emitted = [];
+  const w = startWaitWatcher({
+    clock: recordingClock(),
+    listAgents: () => agentsRef.current,
+    indexSignals: () => new Map(),
+    makeTracker: () => ({ poll() {}, snapshot: () => snapRef.current }),
+    findTranscriptFn: () => null, // no transcript → no tracker created
+    emit: (name, payload) => emitted.push({ name, payload }),
+  });
+  w.tick();
+  w.tick();
+  expect(emitted).toEqual([]);
+});
+
+test("stop() clears the interval", () => {
+  const agentsRef = { current: [] };
+  const snapRef = { current: WAITING_USER_SNAP };
+  const { w, clock } = harness({ agentsRef, snapRef });
+  expect(clock.wasCleared()).toBe(false);
+  w.stop();
+  expect(clock.wasCleared()).toBe(true);
+});


### PR DESCRIPTION
## Summary

Adds a push-based **wait-state watcher** to the execution-core daemon. It tails live Claude session transcript JSONLs, classifies each session's wait state (`WAITING_USER` / `WAITING_TOOL_OK` / `WAITING_PERM` vs `MID_TURN`), and emits debounced `agent.waiting_on_user` / `agent.resumed` events on the `catalyst-events` bus. Detection is decoupled from notification: a reference consumer (`catalyst-execution-core sessions waiting`) reads those events to list each waiting session's ticket, phase, and the text it's blocked on.

This ports the `~/bin/claude-bg-waiting.sh` prototype into testable, I/O-free building blocks and wires them into the daemon lifecycle behind a config knob.

Refs: CTL-650

## Changes

Built in 5 TDD phases:

1. **Wait-state classifier** (`wait-state-classifier.mjs`) — pure, I/O-free `classifyWaitState()` / `isWaitingState()` / `extractWaitingText()`, porting the prototype decision tree and `last_sentences` extractor. Authoritative-busy rule preserved: a busy session is never "waiting".
2. **Per-session transcript tracker** (`transcript-tail.mjs`) — `createTranscriptTracker({path})` incrementally tails a transcript JSONL via the CTL-673 `scanEventsChunked` primitive (byte cursor + leftover, O(new bytes)/poll), folding entries through a pure `applyEntry()` reducer. Resets on truncation/rotation.
3. **Watcher tick + event emitter** (`wait-watcher.mjs`, `wait-event.mjs`) — `startWaitWatcher` composes session enumeration + per-session poll + classify + per-session debounce + emit, firing `agent.waiting_on_user` on `nonWaiting→WAITING_*` and `agent.resumed` on the reverse, exactly once per transition. Disappeared sessions are purged. `wait-event.mjs` builds the canonical OTel envelope.
4. **Daemon lifecycle wiring** (`daemon.mjs`, `config.mjs`) — `startDaemon`/`stopDaemon` start/stop the watcher (default-on, injectable, gated by `enableWaitWatcher`), mirroring the reaper wiring. `readWaitWatcherConfig()` returns `{enabled, intervalMs}` with `CATALYST_WAIT_WATCHER=0` opt-out.
5. **Reference consumer** (`cli/sessions.mjs`) — `catalyst-execution-core sessions waiting [--json]`. `netWaitingSessions()` reduces the event stream to the net-waiting set (last-event-per-session wins); `buildWaitingRows()` joins ticket/phase via `indexSignalsByBgJobId`, falling back to inline classification only when the bus carries no wait events (daemon off).

## Testing

- **NO_TRANSCRIPT**, idle/busy/idle debounce, truncation/rotation, and the full prototype decision tree (incl. `status:null`) are covered.
- ~80 new unit tests across the 5 modules plus a `session-recency` regression test.
- Phase 5 verified end-to-end against live sessions.

## Verification (pre-merge)

- typecheck / tests / lint / coverage gates: passing (verify phase)
- reward-hacking + silent-failure scans: clean
- regression risk: 2 / 10
