### PR TITLE
fix(dev): add Linear rate-limit circuit breaker + drop redundant triaged label (CTL-679)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -6,8 +6,9 @@
 #   2. Stand up a fake `linearis` shim on PATH:
 #        - `linearis issues read <id>` → prints fixture JSON
 #        - `linearis issues discuss <id> --body <text>` → records call to a log
-#      (CTL-558: phase-triage no longer calls `linearis issues update` for the
-#       `triaged` label — the coordinator's label sweep owns it.)
+#      (phase-triage never calls `linearis issues update` for a `triaged`
+#       label — there is no such label; triage completion is signaled by the
+#       analysis comment plus the local triage.json.)
 #   3. Point CATALYST_EVENTS_FILE at a tempfile.
 #   4. Extract the executable bash body from the skill (fenced by
 #      `bash phase-triage-body`).
@@ -167,13 +168,13 @@ else
 	fail "happy: discuss call" "no 'discuss' entry in linearis log:$(printf '\n%s' "$(cat "$LINEARIS_LOG" 2>/dev/null)")"
 fi
 
-# CTL-558: the `triaged` label is applied by the coordinator (the execution-core
-# scheduler's label sweep), NOT by phase-triage. The skill must NOT call
-# `linearis issues update` for the label any more.
+# There is no `triaged` label (removed). phase-triage must never call
+# `linearis issues update` — triage completion is signaled by the analysis
+# comment plus the local triage.json, never a Linear label write.
 if grep -q '^update$' "$LINEARIS_LOG" 2>/dev/null; then
-	fail "happy: no label update call" "phase-triage still calls 'linearis issues update' — the coordinator owns the triaged label (CTL-558)"
+	fail "happy: no label update call" "phase-triage calls 'linearis issues update' — there is no triaged label to write"
 else
-	ok "happy: phase-triage does not self-apply the triaged label (coordinator owns it, CTL-558)"
+	ok "happy: phase-triage does not write any Linear label (no triaged label exists)"
 fi
 
 # Assert: emitted event has the right shape

--- a/plugins/dev/scripts/execution-core/linear-breaker.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.mjs
@@ -1,0 +1,104 @@
+// linear-breaker.mjs — process-wide Linear rate-limit circuit breaker (CTL-679).
+//
+// Every execution-core Linear access shells out to `linearis` (or
+// linear-transition.sh, which itself calls linearis) via spawnSync. On an HTTP
+// 429 the failed write writes no success-marker, so the same call re-fires on
+// the next scheduler tick (~2s debounced / 30s timer) with NO backoff — a
+// self-perpetuating storm that keeps the 2500/hr quota pinned so it never
+// recovers (observed: 1302 failed writes/window, 8 tickets retried ~125× each).
+//
+// This breaker is the safety fix: a single 429 OPENS the breaker process-wide,
+// short-circuiting ALL subsequent Linear traffic (reads AND writes) for an
+// exponentially-backed-off cooldown — without spawning linearis at all — until
+// the cooldown elapses. A clean call CLOSES it and resets the backoff.
+import { log } from "./config.mjs";
+
+// The 429 shape linearis surfaces on stderr: "Rate limit exceeded. Only 2500
+// requests are allowed per 1 hour". Matched case-insensitively and loosely so a
+// reworded message still trips the breaker.
+export function isRateLimitError(stderr) {
+  return /rate limit exceeded/i.test(String(stderr ?? ""));
+}
+
+const BASE_COOLDOWN_MS = 60_000; // first 429 → 60s pause
+const MAX_COOLDOWN_MS = 15 * 60_000; // backoff ceiling
+
+// createLinearBreaker — a single breaker instance. The module also exports a
+// shared singleton (`linearBreaker`) that both exec wrappers consume so one 429
+// pauses the whole process; the factory exists so tests get an isolated breaker
+// and can drive its clock via the injected `now`.
+export function createLinearBreaker({
+  baseCooldownMs = BASE_COOLDOWN_MS,
+  maxCooldownMs = MAX_COOLDOWN_MS,
+  logger = log,
+} = {}) {
+  let openUntil = 0; // epoch ms the breaker stays open until (0 = closed)
+  let consecutive = 0; // consecutive 429s with no intervening success → backoff exponent
+
+  return {
+    // isOpen — true while we are inside the cooldown window; callers must NOT
+    // spawn linearis when open.
+    isOpen(now = Date.now()) {
+      return now < openUntil;
+    },
+
+    // recordRateLimited — a real spawn just returned a 429. Open (or re-arm) the
+    // breaker with exponential backoff (base × 2^(n-1), capped), honoring a
+    // larger Retry-After hint when present. Only ever called from a CLOSED state
+    // (an open breaker short-circuits before spawning), so each call is a
+    // closed→open transition and logs exactly one "circuit open" line.
+    recordRateLimited(now = Date.now(), { retryAfterMs } = {}) {
+      consecutive += 1;
+      const backoff = Math.min(baseCooldownMs * 2 ** (consecutive - 1), maxCooldownMs);
+      const cooldownMs = Math.max(backoff, retryAfterMs ?? 0);
+      openUntil = now + cooldownMs;
+      logger.warn(
+        { consecutive, cooldownMs, openUntil },
+        "ctl-679: Linear circuit breaker OPEN — pausing all Linear calls"
+      );
+    },
+
+    // recordSuccess — a clean call landed; close the breaker and reset backoff.
+    // Logs a single "circuit closed" line only when transitioning out of a
+    // degraded state (so steady-state successes stay silent).
+    recordSuccess() {
+      if (consecutive === 0 && openUntil === 0) return;
+      const wasDegraded = consecutive > 0;
+      consecutive = 0;
+      openUntil = 0;
+      if (wasDegraded) {
+        logger.info({}, "ctl-679: Linear circuit breaker CLOSED — calls resumed");
+      }
+    },
+
+    // state — test/introspection only.
+    state() {
+      return { openUntil, consecutive };
+    },
+  };
+}
+
+// The process-wide singleton both exec wrappers (linear-write.mjs,
+// linear-query.mjs) share so a 429 on any path pauses every path.
+export const linearBreaker = createLinearBreaker();
+
+// withBreaker — wrap a raw exec (the spawnSync normalizer) so it consults the
+// breaker before spawning and feeds the result back. When open it returns a
+// synthetic non-zero result (stderr "circuit-open") WITHOUT spawning. After a
+// real spawn: a 429 opens the breaker; a clean exit (code 0) closes it. A
+// non-429 failure leaves the breaker untouched (it is not a rate-limit signal).
+export function withBreaker(rawExec, { breaker = linearBreaker, now = Date.now } = {}) {
+  return (cmd, args) => {
+    const t = now();
+    if (breaker.isOpen(t)) {
+      return { code: 1, stdout: "", stderr: "circuit-open" };
+    }
+    const res = rawExec(cmd, args);
+    if (res.code !== 0 && isRateLimitError(res.stderr)) {
+      breaker.recordRateLimited(t);
+    } else if (res.code === 0) {
+      breaker.recordSuccess();
+    }
+    return res;
+  };
+}

--- a/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
@@ -1,0 +1,146 @@
+// linear-breaker.test.mjs — Linear rate-limit circuit breaker (CTL-679).
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-breaker.test.mjs
+import { describe, test, expect } from "bun:test";
+import { createLinearBreaker, withBreaker, isRateLimitError } from "./linear-breaker.mjs";
+
+const silentLogger = { warn() {}, info() {}, error() {} };
+const RATE_LIMIT_STDERR = "Rate limit exceeded. Only 2500 requests are allowed per 1 hour";
+
+describe("isRateLimitError", () => {
+  test("matches the linearis 429 stderr (case-insensitive)", () => {
+    expect(isRateLimitError(RATE_LIMIT_STDERR)).toBe(true);
+    expect(isRateLimitError("RATE LIMIT EXCEEDED")).toBe(true);
+  });
+  test("does not match unrelated errors or empty input", () => {
+    expect(isRateLimitError("label not found")).toBe(false);
+    expect(isRateLimitError("")).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+  });
+});
+
+describe("createLinearBreaker", () => {
+  test("starts closed", () => {
+    const b = createLinearBreaker({ logger: silentLogger });
+    expect(b.isOpen(0)).toBe(false);
+  });
+
+  test("a 429 opens the breaker for the base cooldown", () => {
+    const b = createLinearBreaker({ logger: silentLogger, baseCooldownMs: 1000 });
+    b.recordRateLimited(0);
+    expect(b.isOpen(0)).toBe(true);
+    expect(b.isOpen(999)).toBe(true);
+    // boundary: cooldown elapsed → closed again
+    expect(b.isOpen(1000)).toBe(false);
+  });
+
+  test("consecutive 429s back off exponentially, capped at maxCooldownMs", () => {
+    const b = createLinearBreaker({
+      logger: silentLogger,
+      baseCooldownMs: 1000,
+      maxCooldownMs: 5000,
+    });
+    b.recordRateLimited(0); // 1000
+    expect(b.state().openUntil).toBe(1000);
+    b.recordRateLimited(1000); // base*2^1 = 2000
+    expect(b.state().openUntil).toBe(3000);
+    b.recordRateLimited(3000); // base*2^2 = 4000
+    expect(b.state().openUntil).toBe(7000);
+    b.recordRateLimited(7000); // base*2^3 = 8000 → capped to 5000
+    expect(b.state().openUntil).toBe(12000);
+  });
+
+  test("honors a larger Retry-After hint over the computed backoff", () => {
+    const b = createLinearBreaker({ logger: silentLogger, baseCooldownMs: 1000 });
+    b.recordRateLimited(0, { retryAfterMs: 9000 });
+    expect(b.state().openUntil).toBe(9000);
+  });
+
+  test("a success closes the breaker and resets the backoff exponent", () => {
+    const b = createLinearBreaker({ logger: silentLogger, baseCooldownMs: 1000 });
+    b.recordRateLimited(0);
+    b.recordRateLimited(1000); // exponent now 2 → would be 2000
+    b.recordSuccess();
+    expect(b.isOpen(2000)).toBe(false);
+    expect(b.state().consecutive).toBe(0);
+    // next 429 starts from base again, not the prior exponent
+    b.recordRateLimited(10000);
+    expect(b.state().openUntil).toBe(11000);
+  });
+
+  test("logs exactly one OPEN line per 429 and one CLOSE line on recovery", () => {
+    const lines = [];
+    const logger = {
+      warn: (_o, m) => lines.push(["warn", m]),
+      info: (_o, m) => lines.push(["info", m]),
+    };
+    const b = createLinearBreaker({ logger, baseCooldownMs: 1000 });
+    b.recordRateLimited(0);
+    b.recordSuccess();
+    expect(lines.filter(([lvl]) => lvl === "warn")).toHaveLength(1);
+    expect(lines.filter(([lvl]) => lvl === "info")).toHaveLength(1);
+  });
+
+  test("a success while already closed logs nothing", () => {
+    const lines = [];
+    const logger = { warn: () => lines.push("warn"), info: () => lines.push("info") };
+    const b = createLinearBreaker({ logger });
+    b.recordSuccess();
+    expect(lines).toHaveLength(0);
+  });
+});
+
+describe("withBreaker", () => {
+  test("short-circuits without spawning while open", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger, baseCooldownMs: 1000 });
+    const calls = [];
+    const raw = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 1, stdout: "", stderr: RATE_LIMIT_STDERR };
+    };
+    let clock = 0;
+    const exec = withBreaker(raw, { breaker, now: () => clock });
+
+    // first call spawns, hits 429, opens the breaker
+    const first = exec("linearis", ["issues", "list"]);
+    expect(first.code).not.toBe(0);
+    expect(calls).toHaveLength(1);
+
+    // subsequent calls within the cooldown DO NOT spawn — synthetic circuit-open
+    clock = 500;
+    const second = exec("linearis", ["issues", "list"]);
+    expect(calls).toHaveLength(1); // raw exec NOT called again
+    expect(second.stderr).toBe("circuit-open");
+    expect(second.code).not.toBe(0);
+  });
+
+  test("resumes spawning after the cooldown elapses", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger, baseCooldownMs: 1000 });
+    const calls = [];
+    let stderr = RATE_LIMIT_STDERR;
+    let code = 1;
+    const raw = () => {
+      calls.push(1);
+      return { code, stdout: "", stderr };
+    };
+    let clock = 0;
+    const exec = withBreaker(raw, { breaker, now: () => clock });
+
+    exec("linearis", ["x"]); // opens breaker, calls=1
+    clock = 1000; // cooldown elapsed
+    code = 0;
+    stderr = "";
+    const r = exec("linearis", ["x"]); // spawns again, succeeds
+    expect(calls).toHaveLength(2);
+    expect(r.code).toBe(0);
+    expect(breaker.isOpen(1000)).toBe(false); // success closed it
+  });
+
+  test("a non-429 failure does not open the breaker", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger });
+    const raw = () => ({ code: 1, stdout: "", stderr: "label not found" });
+    const exec = withBreaker(raw, { breaker });
+    exec("linearis", ["x"]);
+    expect(breaker.isOpen()).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -5,6 +5,7 @@
 // post-filter that linearis cannot express server-side.
 
 import { spawnSync } from "node:child_process";
+import { withBreaker } from "./linear-breaker.mjs";
 
 // linearis caps a single page; 200 comfortably covers a project's pickable
 // set without pagination (the reconcile poll runs every 10 min anyway).
@@ -33,9 +34,9 @@ export function buildLinearisArgs(query) {
   return args;
 }
 
-// defaultExec — thin spawnSync wrapper. Injected in tests so no test ever
+// rawExec — thin spawnSync wrapper. Injected in tests so no test ever
 // shells out to the real linearis CLI or touches the network.
-function defaultExec(cmd, args) {
+function rawExec(cmd, args) {
   const res = spawnSync(cmd, args, { encoding: "utf8" });
   if (res.error) {
     return { code: 127, stdout: "", stderr: res.error.message };
@@ -46,6 +47,12 @@ function defaultExec(cmd, args) {
     stderr: res.stderr ?? "",
   };
 }
+
+// defaultExec — rawExec behind the CTL-679 process-wide rate-limit breaker. The
+// eligible poll and per-ticket reads short-circuit without spawning linearis
+// while the breaker is open. Shared singleton with linear-write.mjs so a 429 on
+// the write path also pauses reads (and vice-versa).
+const defaultExec = withBreaker(rawExec);
 
 // normalizeTicket — flatten linearis's nested shape into a stable record.
 // `state` and `project` arrive as `{ name }` objects from the Linear API;

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -10,6 +10,7 @@ import { linearKeyForPhase, TERMINAL_LINEAR_KEY } from "../lib/phase-fsm.mjs";
 import { getProjectConfig } from "./registry.mjs";
 import { log } from "./config.mjs";
 import { fetchTicketLabels } from "./linear-query.mjs";
+import { withBreaker } from "./linear-breaker.mjs";
 
 // linear-transition.sh sits one directory up from execution-core/ — mirrors the
 // sibling-bin spawnSync pattern dispatch.mjs uses for orchestrate-dispatch-next.
@@ -17,13 +18,19 @@ const LINEAR_TRANSITION_BIN = fileURLToPath(
   new URL("../linear-transition.sh", import.meta.url)
 );
 
-// defaultExec — spawnSync wrapper normalising the result shape. A spawn error
+// rawExec — spawnSync wrapper normalising the result shape. A spawn error
 // (binary missing, permission) is reported as code 127, never thrown.
-function defaultExec(cmd, args) {
+function rawExec(cmd, args) {
   const res = spawnSync(cmd, args, { encoding: "utf8" });
   if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
   return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
 }
+
+// defaultExec — rawExec behind the CTL-679 process-wide rate-limit breaker, so
+// the status-write path (which shells linear-transition.sh, itself a Linear
+// read+write) short-circuits without spawning while the breaker is open. Shared
+// singleton with linear-query.mjs: one 429 on any path pauses every path.
+const defaultExec = withBreaker(rawExec);
 
 // teamOf — the Linear team key is the identifier prefix: "CTL-558" → "CTL".
 export function teamOf(ticket) {
@@ -95,7 +102,7 @@ export function applyTerminalDone({ ticket, resolveRepoRoot, exec }) {
   return runTransition({ ticket, key: TERMINAL_LINEAR_KEY, resolveRepoRoot, exec });
 }
 
-// applyLabel — additively apply a Linear label (triaged, needs-human), classify
+// applyLabel — additively apply a Linear label (needs-human), classify
 // any failure, AND verify a successful write actually landed. Returns a tagged
 // { applied, reason } shape callers use to decide retry vs short-circuit.
 //

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -43,6 +43,7 @@ import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { WORK_DONE_PROBES, hasProbe, describeProbe } from "./work-done-probes.mjs";
 import { defaultDispatch } from "./dispatch.mjs";
 import { applyLabel as defaultApplyLabel } from "./linear-write.mjs";
+import { linearBreaker } from "./linear-breaker.mjs";
 // CTL-638: pull the once-marker + per-(ticket, phase) cool-down primitives
 // from the shared leaf module. labelOnce is the same guard CTL-585 introduced
 // for scheduler.mjs's `needs-human` path — pre-CTL-638 the recovery sweep's
@@ -992,6 +993,11 @@ export function reclaimDeadWorkIfPossible(
     // "Phase Reclaim" comment the dead worker's skill End block never ran.
     // Marker-guarded + fail-open; tests inject a spy to assert call order.
     postReclaimMirror = defaultPostReclaimMirror,
+    // CTL-679 — the process-wide Linear rate-limit breaker. escalateOnce defers
+    // the needs-human apply while the breaker is open so a transient 429 is
+    // never treated as a human-intervention condition (and never adds to the
+    // write storm). Injected for tests; defaults to the shared singleton.
+    breaker = linearBreaker,
     now = Date.now,
   } = {},
 ) {
@@ -1019,6 +1025,18 @@ export function reclaimDeadWorkIfPossible(
   // applyStalledLabel in a per-(ticket, phase) cool-down so the same escalation
   // cannot re-fire within the window (the pre-CTL-638 self-feeding storm).
   function escalateOnce(reason, finalAttemptCount) {
+    // CTL-679 — while the Linear breaker is open we are rate-limited; the
+    // needs-human apply would 429 and write no marker, re-firing every tick.
+    // Defer: skip the audit event + label write entirely (no cool-down record,
+    // so a genuine escalation re-fires cleanly once the breaker closes). A
+    // transient 429 is not a human-intervention condition.
+    if (breaker.isOpen(now())) {
+      log.warn(
+        { ticket, phase, reason },
+        "ctl-679: escalation deferred — Linear breaker open"
+      );
+      return "rate-limited-deferred";
+    }
     if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
       return "escalation-suppressed";
     }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -1048,6 +1048,27 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(s.opts.appendEscalatedEvent.calls[0][0].final_attempt_count).toBe(2);
   });
 
+  test("CTL-679: breaker open → 'rate-limited-deferred', no escalation event, no label write", () => {
+    const s = setupReviveScenario({ reviveCount: 2 }); // would otherwise escalate
+    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, {
+      ...s.opts,
+      breaker: { isOpen: () => true },
+    });
+    expect(r).toBe("rate-limited-deferred");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
+    expect(s.opts.applyStalledLabel.calls.length).toBe(0);
+  });
+
+  test("CTL-679: breaker closed → escalation proceeds as normal", () => {
+    const s = setupReviveScenario({ reviveCount: 2 });
+    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, {
+      ...s.opts,
+      breaker: { isOpen: () => false },
+    });
+    expect(r).toBe("escalated");
+    expect(s.opts.applyStalledLabel.calls.length).toBe(1);
+  });
+
   test("storm-breaker: distinct=4 > 3 → 'revive-suppressed', no dispatch", () => {
     const s = setupReviveScenario({ reviveCount: 0, distinctRevivingTickets: 4 });
     expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revive-suppressed");

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -667,12 +667,12 @@ export function verifyDispatchedSignal(orchDir, ticket, phase) {
 }
 
 // REQUIRED_WORKSPACE_LABELS — the flat labels the CTL-558 coordinator sweep
-// writes. Both must pre-exist in the Linear workspace; linearis has no
-// `labels create`. CTL-585's preflight warns once at daemon start if either
+// writes. Must pre-exist in the Linear workspace; linearis has no
+// `labels create`. CTL-585's preflight warns once at daemon start if it
 // is missing, so an operator sees the contract gap before the per-tick label
 // sweep starts (and so the missing-label short-circuit in labelOnce does not
 // surprise a fresh operator).
-const REQUIRED_WORKSPACE_LABELS = ["triaged", "needs-human"];
+const REQUIRED_WORKSPACE_LABELS = ["needs-human"];
 
 // preflightWorkspaceLabels — best-effort daemon-start check. For each team,
 // list the team's labels and warn once per missing expected label. `exec`
@@ -1094,11 +1094,10 @@ export function schedulerTick(
   // (3) Terminal-Done + label sweep (CTL-558) — one pass over every started
   // ticket. deriveAdvancement returns null once monitor-deploy completes, so
   // terminal `Done` is not a dispatch — it needs this dedicated sweep. In the
-  // same pass: apply the `triaged` label on triage completion, and the flat
-  // `needs-human` label when any phase signal is `stalled` (D7 — the worker
-  // keeps its phase state, it does not bounce to Triage). Status writes are
-  // idempotent via linear-transition.sh; label writes are guarded once-per-run
-  // by labelOnce's marker file.
+  // same pass: apply the flat `needs-human` label when any phase signal is
+  // `stalled` (D7 — the worker keeps its phase state, it does not bounce to
+  // Triage). Status writes are idempotent via linear-transition.sh; label
+  // writes are guarded once-per-run by labelOnce's marker file.
   for (const ticket of listStartedTickets(orchDir)) {
     const signals = readPhaseSignals(orchDir, ticket);
     // CTL-589 (CTL-512 followup): `skipped` is the second terminal status for
@@ -1112,9 +1111,6 @@ export function schedulerTick(
       terminalDoneOnce(orchDir, ticket, writeStatus);
       // CTL-582: the ticket reached terminal Done — tear down its worktree.
       teardownWorktreeOnce(orchDir, ticket, teardownWorktree);
-    }
-    if (signals.triage === "done") {
-      labelOnce(orchDir, ticket, "triaged", writeStatus);
     }
     if (Object.values(signals).some((s) => s === "stalled")) {
       labelOnce(orchDir, ticket, "needs-human", writeStatus);

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1522,21 +1522,12 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
   });
 });
 
-// ── CTL-558: deterministic label write-back (triaged / needs-human) ──
+// ── CTL-558: deterministic label write-back (needs-human) ──
 
 describe("schedulerTick — label write-back (CTL-558)", () => {
   const noWrites = () => ({
     applyPhaseStatus() {},
     applyTerminalDone() {},
-  });
-
-  test("applies the `triaged` label when a ticket's triage signal is done", () => {
-    writeSignal("CTL-6", "triage", "done");
-    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
-    const labels = [];
-    const writeStatus = { ...noWrites(), applyLabel: (a) => labels.push(a) };
-    schedulerTick(orchDir, { readEligible: () => [], dispatch: fakeDispatch(), writeStatus });
-    expect(labels).toContainEqual(expect.objectContaining({ ticket: "CTL-6", label: "triaged" }));
   });
 
   test("applies `needs-human` when any phase signal is stalled", () => {
@@ -1561,9 +1552,9 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
   });
 
   test("writes the .applied marker only after applyLabel reports applied:true", () => {
-    writeSignal("CTL-8", "triage", "done");
+    writeSignal("CTL-8", "implement", "stalled");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
-    const markerPath = join(orchDir, "workers", "CTL-8", ".linear-label-triaged.applied");
+    const markerPath = join(orchDir, "workers", "CTL-8", ".linear-label-needs-human.applied");
     // applyLabel reports failure → no marker written → retried next tick.
     const failWrite = { ...noWrites(), applyLabel: () => ({ applied: false }) };
     schedulerTick(orchDir, {
@@ -1583,7 +1574,7 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
   });
 
   test("a label-write throw never aborts the tick", () => {
-    writeSignal("CTL-9", "triage", "done");
+    writeSignal("CTL-9", "implement", "stalled");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const writeStatus = {
       ...noWrites(),
@@ -1598,10 +1589,10 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
 
   // CTL-585: short-circuit the per-tick retry on an unrecoverable miss.
   test("writes the .skipped marker on reason:'missing-label' and stops retrying", () => {
-    writeSignal("CTL-10", "triage", "done");
+    writeSignal("CTL-10", "implement", "stalled");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
-    const skipped = join(orchDir, "workers", "CTL-10", ".linear-label-triaged.skipped");
-    const applied = join(orchDir, "workers", "CTL-10", ".linear-label-triaged.applied");
+    const skipped = join(orchDir, "workers", "CTL-10", ".linear-label-needs-human.skipped");
+    const applied = join(orchDir, "workers", "CTL-10", ".linear-label-needs-human.applied");
 
     let calls = 0;
     const writeStatus = {
@@ -1624,9 +1615,9 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
   });
 
   test("a transient failure still retries on the next tick", () => {
-    writeSignal("CTL-11", "triage", "done");
+    writeSignal("CTL-11", "implement", "stalled");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
-    const skipped = join(orchDir, "workers", "CTL-11", ".linear-label-triaged.skipped");
+    const skipped = join(orchDir, "workers", "CTL-11", ".linear-label-needs-human.skipped");
 
     let calls = 0;
     const writeStatus = {
@@ -1644,7 +1635,7 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
   });
 
   test("a rate-limited failure still retries on the next tick", () => {
-    writeSignal("CTL-12", "triage", "done");
+    writeSignal("CTL-12", "implement", "stalled");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     let calls = 0;
     const writeStatus = {
@@ -1660,11 +1651,11 @@ describe("schedulerTick — label write-back (CTL-558)", () => {
   });
 
   test("a pre-existing .skipped marker prevents re-attempt", () => {
-    writeSignal("CTL-13", "triage", "done");
+    writeSignal("CTL-13", "implement", "stalled");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     // Pre-seed the .skipped marker (simulates a previous daemon run that hit
     // the missing-label path).
-    writeFileSync(join(orchDir, "workers", "CTL-13", ".linear-label-triaged.skipped"), "");
+    writeFileSync(join(orchDir, "workers", "CTL-13", ".linear-label-needs-human.skipped"), "");
     let calls = 0;
     const writeStatus = {
       ...noWrites(),
@@ -2078,11 +2069,11 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
       expect(args.slice(0, 3)).toEqual(["labels", "list", "--team"]);
       const team = args[3];
       // linearis labels list emits JSON ({nodes:[{name,...},...]}).
-      // CTL is missing both expected labels; ENG has both.
+      // CTL is missing the expected label; ENG has it.
       const nodes =
         team === "CTL"
           ? [{ name: "orchestrate" }, { name: "enhancement" }]
-          : [{ name: "triaged" }, { name: "needs-human" }, { name: "bug" }];
+          : [{ name: "needs-human" }, { name: "bug" }];
       return { code: 0, stdout: JSON.stringify({ nodes }), stderr: "" };
     };
     preflightWorkspaceLabels({
@@ -2093,7 +2084,7 @@ describe("preflightWorkspaceLabels (CTL-585)", () => {
     const ctlWarns = warnings.filter(
       (w) => w.obj?.team === "CTL" && w.msg.includes("missing required label")
     );
-    expect(ctlWarns.map((w) => w.obj.label).sort()).toEqual(["needs-human", "triaged"]);
+    expect(ctlWarns.map((w) => w.obj.label).sort()).toEqual(["needs-human"]);
     const engWarns = warnings.filter((w) => w.obj?.team === "ENG");
     expect(engWarns).toHaveLength(0);
   });

--- a/plugins/dev/scripts/lib/phase-fsm.mjs
+++ b/plugins/dev/scripts/lib/phase-fsm.mjs
@@ -68,7 +68,7 @@ export const NEXT_PHASE = {
 // The keys are the legacy stateMap vocabulary — an execution-core repo's stateMap
 // re-targets the SAME keys onto the 5 collapsed states (Research/Plan/Implement/
 // Validate/PR), see setup-execution-core-states.sh:build_execution_core_state_map.
-//   • `triage` → null: the human owns the Triage state; the daemon only tags `triaged`.
+//   • `triage` → null: the human owns the Triage state; the daemon does not write it back.
 //   • verify + review collapse onto `verifying`/`reviewing` (both → Validate).
 //   • pr + monitor-merge + monitor-deploy collapse onto `inReview` (→ PR) while in flight;
 //     terminal Done is written separately on monitor-deploy completion (TERMINAL_LINEAR_KEY).

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phase-triage
-description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies dependencies, estimates scope, writes triage.json, and posts a triaged comment to Linear. The `triaged` label is applied by the coordinator (CTL-558). Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-triage ..."` resolves.
+description: Phase agent that triages a Linear ticket — expands acronyms, classifies (feature/bug/docs/refactor/chore), identifies dependencies, estimates scope, writes triage.json, and posts a triage analysis comment to Linear. Triage completion is signaled by that comment plus the local triage.json — there is no `triaged` label. Emits phase.triage.complete.<TICKET> on success and phase.triage.failed.<TICKET> on error. Dispatched by the phase-agent orchestrator (CTL-452) via slash command — `user-invocable: true` so the dispatcher's `claude --bg "/catalyst-dev:phase-triage ..."` resolves.
 user-invocable: true
 disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
 allowed-tools: Bash, Read, Write, Grep
@@ -30,7 +30,7 @@ Both modes produce the same `triage.json` shape and emit the same canonical phas
        classification (feature|bug|docs|refactor|chore), estimated_scope,
        acronyms_expanded, dependencies, and a non-empty summary — refined with
        real analysis (not just the deterministic placeholders), AND posted the
-       triaged analysis comment to the Linear ticket, AND printed the triage.json
+       triage analysis comment to the Linear ticket, AND printed the triage.json
        path on stdout. OR I have stopped after 15 turns and recorded a partial
        triage.json with whatever I could classify."
 ```
@@ -42,14 +42,11 @@ blocker (unreadable ticket, a Linear 4xx on the comment) surfaces as needs-input
 rather than a silently-thin `triage.json`. (Production/Opus mode only; the CI
 bash body is self-sufficient and does not invoke the evaluator.)
 
-## Setup prerequisite
+## Triage completion signal
 
-The `triaged` workspace label must already exist in Linear. The label is applied by the
-deterministic coordinator (CTL-558) — the execution-core scheduler's label sweep tags `triaged`
-once the triage phase signal is `done` — not by this skill. `linearis` has no label-create, so the
-label must be created in the workspace beforehand. Verify with
-`linearis labels list --team <TEAM>`; create missing labels in the Linear workspace UI. The
-execution-core scheduler logs a startup warning per missing label (CTL-585).
+Triage completion is recorded by two artifacts, not a Linear label: the analysis comment this skill
+posts to the ticket, and the local `triage.json` the coordinator reads (`hasTriageArtifact`). There
+is no `triaged` workspace label — the daemon never writes one.
 
 ## Inputs
 
@@ -264,11 +261,11 @@ fi
 DISCUSS_STDERR="$(linearis issues discuss "$TICKET" --body "$COMMENT_BODY" 2>&1 >/dev/null)" \
   || echo "phase-triage: linearis issues discuss failed (continuing): ${DISCUSS_STDERR}" >&2
 
-# 5. The `triaged` label is applied by the coordinator (CTL-558): the
-#    execution-core scheduler's label sweep tags `triaged` once the triage
-#    phase signal is `done`. The phase agent no longer applies the label.
-#    The label must already exist in the workspace — verify with
-#    `linearis labels list --team <TEAM>` (CTL-585).
+# 5. There is no `triaged` label. Triage completion is signaled by the
+#    analysis comment posted above plus the local triage.json the coordinator
+#    reads — the phase agent and the daemon both leave Linear labels alone.
+#    (Historical note for anyone grepping CTL-558: the old coordinator label
+#    sweep that tagged `triaged` was removed.)
 
 # 6. Emit the canonical phase event.
 emit_phase_complete --phase triage --ticket "$TICKET" --status complete \


### PR DESCRIPTION
## Summary
- Adds `execution-core/linear-breaker.mjs` — a process-wide circuit breaker that short-circuits all Linear traffic for an exponentially-backed-off cooldown when `linearis` returns a 429, without spawning. Shared singleton wired into both `defaultExec` wrappers (`linear-write.mjs`, `linear-query.mjs`) so one 429 on any path pauses every path (incl. the `linear-transition.sh` status writes).
- `recovery.mjs` — `escalateOnce` now defers (`rate-limited-deferred`) while the breaker is open, so a transient 429 never triggers a `needs-human` apply. A rate-limit is not a human-intervention condition.
- Bundled with the redundant `triaged`-label removal: triage completion is signaled by the analysis comment + local `triage.json` only, halving per-stuck-ticket write volume.

### Why this is urgent
The execution-core daemon is currently stopped. Without rate-limit awareness, a single 429 re-fires every tick with no backoff, pinning the 2500/hr quota so it never recovers (observed 1302 failed writes/window, 8 tickets retried ~125× each). This is the gating fix for safely restarting orchestration.

### Design — last-resort, not trigger-happy
- Only opens on an actual 429 (regex matches `/rate limit exceeded/i`, nothing else)
- Steady-state silent — no logs, no behavior change
- Exponential backoff: 60s → 2m → 4m → 8m → 15m cap. Repeat triggers get *more* conservative, not less
- Defers escalation rather than escalating-while-rate-limited

Refs: handoff `thoughts/shared/handoffs/general/2026-05-27_20-42-16_linear-github-overcall-rate-limit.md`; research `thoughts/shared/research/2026-05-27-webhook-vs-poll-minimal-outbound-need.md`.

## Test plan
- [x] `bun test linear-breaker.test.mjs` — 12/12 pass (factory, exponential backoff w/ cap, Retry-After honored, OPEN/CLOSE log gating, withBreaker short-circuits without spawn, non-429 failures don't open it)
- [x] `bun test linear-write.test.mjs linear-query.test.mjs recovery.test.mjs` — 199/199 pass (incl. new `breaker.isOpen → 'rate-limited-deferred'` test asserting no `applyStalledLabel` / no `appendEscalatedEvent`)
- [x] `bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh` — 39/39 pass
- [x] `bun test scheduler.test.mjs` — 157 pass; 8 fail are the documented environmental dispatch failures (live `claude agents` → freeSlots=0), not from this diff

## Operator follow-up (after merge)
1. Triage the stuck batch (ADV-1191/1213/1235-1239, CTL-650) — likely misfiled ADV tickets in CTL's `eligibleQuery`
2. `catalyst-execution-core restart` — watch `~/catalyst/execution-core/daemon.log` for a single "circuit open" line on the first 429 instead of the retry firehose