### PR TITLE
fix(dev): classify Linear cross-team label-UUID errors as missing-label

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -168,12 +168,22 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
 }
 
 // classifyLabelFailure — map a `linearis issues update --labels` stderr to
-// one of the tagged reason codes. Both substrings are the literal forms
-// observed in ~/catalyst/execution-core/daemon.log during the CTL-380 QA
-// run (CTL-585 research §3, §7).
+// one of the tagged reason codes. The substrings are the literal forms observed
+// in ~/catalyst/execution-core/daemon.log:
+//   - "not found": workspace lacks the label (CTL-585 §3,§7 — CTL-380 QA run).
+//   - "Rate limit": linearis CLI surfaced an HTTP 429 (CTL-679 trigger).
+//   - "incorrect team": Linear's labels are team-scoped (different UUIDs per
+//     team for the same name). linearis resolved the label name in the wrong
+//     team's workspace context and sent the cross-team UUID, which Linear
+//     rejects. Permanent within one daemon lifetime (the resolver is global) —
+//     classified as missing-label so labelOnce writes the .skipped marker and
+//     stops the per-tick retry storm. (Observed on ADV tickets when the daemon
+//     orchestrates a team whose labels share names with the resolver's default
+//     team but have different UUIDs.)
 function classifyLabelFailure(stderr) {
   const s = String(stderr ?? "");
   if (s.includes("not found")) return "missing-label";
+  if (s.includes("incorrect team")) return "missing-label";
   if (s.includes("Rate limit")) return "rate-limited";
   return "transient";
 }

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -194,6 +194,21 @@ describe("applyLabel", () => {
     const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
     expect(r).toEqual({ applied: false, reason: "rate-limited" });
   });
+  test("classifies a cross-team label-UUID stderr as reason:'missing-label' (no per-tick retry storm)", () => {
+    // Linear's labels are team-scoped: same name, different UUID per team. When
+    // linearis resolves the label in the wrong team's workspace context and
+    // sends the cross-team UUID, Linear returns this exact error. It is
+    // permanently unrecoverable inside one daemon lifetime (the resolver is
+    // global), so it must classify as missing-label to short-circuit retries.
+    const exec = () => ({
+      code: 1,
+      stdout: "",
+      stderr:
+        'GraphQL request failed: LabelIds for incorrect team - The label \'needs-human\' is not associated with the same team as the issue.',
+    });
+    const r = applyLabel({ ticket: "ADV-1213", label: "needs-human", exec });
+    expect(r).toEqual({ applied: false, reason: "missing-label" });
+  });
   test("CTL-585: any other non-zero exit is reason:'transient'", () => {
     const exec = () => ({ code: 1, stdout: "", stderr: "boom" });
     const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });


### PR DESCRIPTION
## Summary
- `linear-write.mjs::classifyLabelFailure` — recognize `"LabelIds for incorrect team"` stderr and return `"missing-label"` so `labelOnce` writes the `.skipped` marker and stops the per-tick retry storm.

## Why
Linear's labels are team-scoped — same name, different UUID per team. `linearis` resolves a label name in its (global) workspace context and sends a UUID that belongs to one team, then tries to apply it to a ticket in a different team. Linear rejects with `"LabelIds for incorrect team - The label 'needs-human' is not associated with the same team as the issue."`

Today this falls through to `"transient"` → no marker → scheduler retries every tick. Observed after tonight's daemon restart: **~12 `needs-human` writes/minute against 6 ADV tickets** (ADV-1213/1235/1236/1237/1238/1239). At that rate it burns the 2500/hr Linear quota in ~50min and triggers CTL-679's circuit breaker. The breaker is supposed to be last-resort; this fix removes one of the conditions that would trip it.

Permanently unrecoverable inside one daemon lifetime (the `linearis` label-resolver is global, no per-call team override), so `missing-label` semantics are correct: writes a `.skipped` marker, no retries. If the resolver bug is ever fixed (linearis-side), the operator clears the marker.

## Test plan
- [x] `bun test linear-write.test.mjs` — 21/21 pass (incl. new cross-team test)
- [x] Live reproduction in `~/catalyst/execution-core/daemon.log` post-restart at pid 67877

## Followups (not in this PR)
- Properly team-aware label resolution in linearis (or this codebase's wrapper) so the `needs-human` writes against ADV tickets actually succeed instead of being skipped. Filed for tomorrow.
- Event-sourcing rework (capture Linear webhook scoping fields, drop per-event scoping polls) — in progress in a separate branch tonight.