### PR TITLE
feat(dev): capture Linear webhook scoping fields + drop per-event scoping poll (CTL-681)

### DIFF
--- a/plugins/dev/scripts/execution-core/integration.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration.test.mjs
@@ -81,7 +81,7 @@ function enroll(team, eligibleQuery) {
   registryEntries.push({ team, repoRoot, eligibleQuery: eligibleQuery ?? null });
   writeFileSync(
     join(catalystDir, "execution-core", "registry.json"),
-    JSON.stringify({ projects: registryEntries }, null, 2),
+    JSON.stringify({ projects: registryEntries }, null, 2)
   );
   enrolledTeams.add(team);
   return repoRoot;
@@ -113,7 +113,17 @@ function mockExec(nodesByTeam) {
 }
 
 describe("execution-core integration — acceptance criteria", () => {
-  test("AC1 — a state_changed event INTO the eligible state triggers a reconcile that adds the ticket", async () => {
+  test("CTL-681: AC1 — a state_changed event INTO the eligible state is a NO-OP; the periodic reconcile (or operator-triggered reconcileAll) adds the ticket", async () => {
+    // Pre-CTL-681 AC1: the event triggered a debounced per-event poll which
+    // rediscovered ENG-9 and folded it into the eligible set. That per-event
+    // poll was the load that exhausted the Linear 2500/hr quota.
+    //
+    // Post-CTL-681 AC1: the event is a no-op (per-event scoping reconcile
+    // removed). The webhook parser now captures project/labels/priority so a
+    // follow-up PR can fold the change incrementally without a poll; until then
+    // the eligible set is refreshed by the periodic reconcile timer
+    // (RECONCILE_INTERVAL_MS, 10 min in prod) or the startup reconcile. This
+    // test demonstrates BOTH halves of the new contract.
     enroll("ENG", { status: "Todo" });
     const reported = { ENG: [] };
     const exec = mockExec(reported);
@@ -123,6 +133,11 @@ describe("execution-core integration — acceptance criteria", () => {
     reported.ENG = [node("ENG-9")]; // linearis now reports ENG-9 as Todo
     handleStateChangedEvent(evt("ENG-9", "ENG", "Todo"), { exec, debounceMs: 25 });
     await sleep(70);
+    // The event itself did NOT add ENG-9 — that's the deliberate change.
+    expect(getEligibleSet("ENG")).toEqual([]);
+
+    // The next periodic reconcile (here driven directly) picks it up.
+    reconcileAll({ exec });
     expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-9"]);
   });
 
@@ -175,9 +190,7 @@ describe("execution-core integration — rebuild + isolation", () => {
     const exec = mockExec({ ENG: [node("ENG-1")] });
     startMonitor({ exec, reconcileIntervalMs: 60_000 });
     expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-1"]);
-    expect(
-      existsSync(join(catalystDir, "execution-core", "eligible", "ENG.json")),
-    ).toBe(true);
+    expect(existsSync(join(catalystDir, "execution-core", "eligible", "ENG.json"))).toBe(true);
   });
 
   test("a second enrolled project is served independently (per-project isolation)", () => {
@@ -189,10 +202,7 @@ describe("execution-core integration — rebuild + isolation", () => {
     });
     startMonitor({ exec, reconcileIntervalMs: 60_000 });
     expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-1"]);
-    expect(getEligibleSet("PLAT").map((t) => t.identifier)).toEqual([
-      "PLAT-1",
-      "PLAT-2",
-    ]);
+    expect(getEligibleSet("PLAT").map((t) => t.identifier)).toEqual(["PLAT-1", "PLAT-2"]);
   });
 });
 
@@ -220,10 +230,7 @@ describe("execution-core integration — crash recovery (CTL-539)", () => {
   function writeWorkerSignal(orchDir, ticket, phase, body) {
     const dir = join(orchDir, "workers", ticket);
     mkdirSync(dir, { recursive: true });
-    writeFileSync(
-      join(dir, `phase-${phase}.json`),
-      JSON.stringify({ ticket, phase, ...body }),
-    );
+    writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, ...body }));
   }
   // makeJobDir — a fake claude --bg job state dir under the fake jobs root.
   function makeJobDir(bgJobId) {

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -2,14 +2,25 @@
 //
 // The orchestration layer of the Linear Todo-state monitor: event parsing
 // (canonical OTel + legacy flat shapes), per-project and all-project
-// reconcile, the event-driven fast path (confident removal + debounced
-// reconcile), the byte-offset event-log tailer, the periodic reconcile timer,
+// reconcile, the event-driven fast path (confident removal + Triage auto-
+// dispatch), the byte-offset event-log tailer, the periodic reconcile timer,
 // and the startMonitor/stopMonitor lifecycle.
 //
-// Event-vs-poll division of labour: a linear.issue.state_changed event can
-// only CONFIRM A REMOVAL (the new state left the eligible state) or TRIGGER A
-// RECONCILE (it may have entered) — the payload carries no project/label/
-// priority, so additions and scoping are resolved exclusively by the poll.
+// Event-vs-poll division of labour (CTL-681 — was rewritten):
+// A linear.issue.state_changed event handles two cases inline (no poll):
+//   - DRAG_OUT_STATES (Backlog/Canceled/Duplicate) → confident immediate
+//     removal + abortWorker.
+//   - →Triage / →Ready-without-triage-artifact → one-shot triage dispatch.
+// Every other →Ready / unknown-new-state case is now a NO-OP — the
+// per-event scoping reconcile that used to fire here (because the parsed
+// event was missing project/labels/priority) is gone. CTL-681 captures those
+// fields in the event payload so a future incremental projection update can
+// fold the change without a poll; until that lands, the eligible set picks up
+// the new ticket on the next periodic reconcile (RECONCILE_INTERVAL_MS, 10
+// min) or on operator-restart startup reconcile. This trade-off — up to
+// ~10 min staleness for new Ready tickets in exchange for zero per-event
+// Linear polls — was explicitly chosen to remove the per-tick poll baseline
+// that exhausted the 2500/hr quota.
 
 import { watch, openSync, fstatSync, readSync, closeSync, mkdirSync, existsSync } from "node:fs";
 import { dirname, basename, join } from "node:path";
@@ -114,29 +125,33 @@ export function reconcileAll({ exec } = {}) {
 
 // --- Event-driven fast path ---------------------------------------------
 
-// team -> pending debounce timer handle.
-const dirtyTimers = new Map();
-
 // handleStateChangedEvent — fold one state_changed event into the eligible
 // sets of every project whose query team matches the event's team.
 //
-// CTL-565 + CTL-584 — the toState branch is a four-way split:
+// CTL-565 + CTL-584 + CTL-681 — the toState branch is a four-way split:
 //   →triageStatus              one-shot-dispatches the triage phase agent
 //                              (NOT the eligible set — a Triage ticket is
 //                              never scheduler-pulled).
-//   →status (Ready)            reconciles into the scheduler-eligible set
-//                              (debounced).
+//   →status (Ready)            no-op (CTL-681 removed the per-event scoping
+//                              poll). If the ticket has no triage.json the
+//                              one-shot triage auto-dispatch still fires
+//                              (CTL-625); otherwise the periodic reconcile
+//                              picks it up on the next 10-min tick.
 //   →DRAG_OUT_STATES           the leave-path — confident immediate removal
 //                              + abortWorker on the in-flight worker.
 //   anything else (pipeline)   no-op. Research/Plan/Implement/Validate/PR/
 //                              Done are the daemon's own CTL-558 write-backs
 //                              echoed back; an unknown state is conservatively
 //                              treated as a hand-edit we don't recognize.
+//
+// `exec` and `debounceMs` are kept in the signature for backwards-compat with
+// the previous reconcile-on-event contract; they are now unused inside the
+// function. Removing them would break call sites that still pass them.
 export function handleStateChangedEvent(
   event,
   {
-    exec,
-    debounceMs = EVENT_DEBOUNCE_MS,
+    exec: _exec, // CTL-681: retained for signature compat; no longer triggers a poll
+    debounceMs: _debounceMs = EVENT_DEBOUNCE_MS, // CTL-681: retained for signature compat; unused
     dispatch,
     orchDir,
     abortWorker = defaultAbortWorker,
@@ -166,14 +181,19 @@ export function handleStateChangedEvent(
       // the user moved Backlog→Ready directly, skipping →Triage. Auto-dispatch
       // triage (same seam as →Triage) so "Ready" transparently triages-then-
       // proceeds instead of dead-locking the research prior-artifact gate. The
-      // triage agent's phase.triage.complete advances the ticket to research via
-      // the scheduler's advancement sweep, so we do NOT also reconcile here —
-      // reconciling would let the new-work pull dispatch research before
-      // triage.json exists (the no-backoff storm CTL-625 fixes). An unknown new
-      // state (!parsed.toState), an already-triaged Ready, or a standalone
-      // monitor with no orchDir falls through to the debounced reconcile
-      // (the event cannot confirm project/label/priority scoping, so a full
-      // poll is required; debounced so a burst coalesces into one reconcile).
+      // triage agent's phase.triage.complete advances the ticket to research
+      // via the scheduler's advancement sweep, so we do NOT also reconcile
+      // here.
+      //
+      // CTL-681: anything that does NOT trigger the triage auto-dispatch
+      // (an already-triaged Ready, an unknown new state, or a standalone
+      // monitor with no orchDir) is now a NO-OP — the pre-CTL-681 debounced
+      // reconcile that fired here is gone. The eligible set picks up the new
+      // ticket on the next periodic reconcile (RECONCILE_INTERVAL_MS, ~10 min).
+      // The event payload now carries project/labels/priority (CTL-681 parser
+      // change) so a follow-up PR can fold the change incrementally into the
+      // projection without a poll; until then the 10-min reconcile + startup
+      // reconcile are the only Linear list-polls.
       if (
         parsed.toState === query.status &&
         orchDir &&
@@ -181,7 +201,14 @@ export function handleStateChangedEvent(
       ) {
         dispatchTriage(parsed.identifier, { dispatch, orchDir });
       } else {
-        scheduleDirtyReconcile(p.team, { exec, debounceMs });
+        log.debug(
+          {
+            ticket: parsed.identifier,
+            team: p.team,
+            toState: parsed.toState,
+          },
+          "monitor: →Ready event observed; per-event scoping poll removed (CTL-681), relying on 10-min reconcile"
+        );
       }
     } else if (DRAG_OUT_STATES.has(parsed.toState)) {
       // Drag-out to Backlog/Canceled/Duplicate — kill signal. Confident
@@ -230,16 +257,13 @@ function hasTriageArtifact(orchDir, ticket) {
   return existsSync(join(orchDir, "workers", ticket, "triage.json"));
 }
 
-function scheduleDirtyReconcile(team, { exec, debounceMs }) {
-  clearTimeout(dirtyTimers.get(team));
-  dirtyTimers.set(
-    team,
-    setTimeout(() => {
-      dirtyTimers.delete(team);
-      reconcileProject(team, { exec });
-    }, debounceMs)
-  );
-}
+// CTL-681 removed scheduleDirtyReconcile + its dirtyTimers Map. The
+// per-event scoping reconcile it implemented is the load that exhausted the
+// Linear 2500/hr quota: the parser dropped project/labels/priority, so every
+// relevant event triggered a full poll to recover them. CTL-681 captures those
+// fields in the event payload; the per-event reconcile is gone. The eligible
+// set is now refreshed by exactly two paths: the startup reconcile + the
+// 10-min periodic reconcile (RECONCILE_INTERVAL_MS).
 
 // --- Byte-offset event-log tailer ---------------------------------------
 // Mirrors broker/tailer.mjs: follow ~/catalyst/events/YYYY-MM.jsonl via
@@ -391,15 +415,14 @@ export function startMonitor({
   reconcileTimer = setInterval(() => reconcileAll({ exec }), reconcileIntervalMs);
 }
 
-// stopMonitor — clear the reconcile interval, all pending debounce timers,
-// and the file watcher. Idempotent and safe to call when nothing is running.
+// stopMonitor — clear the reconcile interval and the file watcher. Idempotent
+// and safe to call when nothing is running. CTL-681 removed the dirtyTimers
+// cleanup (the per-event debounce timers it tracked are gone).
 export function stopMonitor() {
   if (reconcileTimer) {
     clearInterval(reconcileTimer);
     reconcileTimer = null;
   }
-  for (const t of dirtyTimers.values()) clearTimeout(t);
-  dirtyTimers.clear();
   watcher?.close();
   watcher = null;
 }

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -188,7 +188,7 @@ describe("handleStateChangedEvent", () => {
   // ("In Progress") was a pipeline state under the new model, not a leave-path
   // trigger.
 
-  test("an event whose toState == eligible status schedules a debounced reconcile (no immediate poll)", async () => {
+  test("CTL-681: an event whose toState == eligible status does NOT trigger a poll (per-event scoping reconcile removed)", async () => {
     enroll("ENG", { status: "Todo" });
     const exec = execReturning({ ENG: [node("ENG-9")] });
     handleStateChangedEvent(
@@ -200,11 +200,14 @@ describe("handleStateChangedEvent", () => {
     );
     expect(exec.calls).toBe(0); // not polled synchronously
     await sleep(70);
-    expect(exec.calls).toBe(1);
-    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-9"]);
+    // Pre-CTL-681 this was 1 (the debounced reconcile fired). Post-CTL-681
+    // the eligible set is refreshed only by startup + 10-min reconcile; the
+    // event itself does not trigger a poll. The 10-min timer is mocked out
+    // of this test (no setInterval) so exec stays at 0.
+    expect(exec.calls).toBe(0);
   });
 
-  test("multiple events for one project within the debounce window coalesce into one reconcile", async () => {
+  test("CTL-681: multiple →Ready events do not trigger any poll (no debounced reconcile to coalesce)", async () => {
     enroll("ENG", { status: "Todo" });
     const exec = execReturning({ ENG: [node("ENG-9")] });
     for (const ticket of ["ENG-7", "ENG-8", "ENG-9"]) {
@@ -217,7 +220,9 @@ describe("handleStateChangedEvent", () => {
       );
     }
     await sleep(80);
-    expect(exec.calls).toBe(1);
+    // Pre-CTL-681 a 3-event burst coalesced into 1 reconcile (calls === 1).
+    // Post-CTL-681 there is no per-event reconcile to coalesce; calls stays 0.
+    expect(exec.calls).toBe(0);
   });
 
   test("an event whose teamKey matches no registered team is ignored", async () => {
@@ -258,7 +263,7 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
     expect(dispatch).toHaveBeenCalledWith({ orchDir, ticket: "ENG-1", phase: "triage" });
   });
 
-  test("→Ready with an existing triage.json reconciles, never a triage dispatch", async () => {
+  test("CTL-681: →Ready with an existing triage.json is a no-op (was: debounced reconcile, now: 10-min reconcile picks it up)", async () => {
     enroll("ENG", { status: "Ready" });
     const realOrchDir = join(catalystDir, "execution-core"); // real dir (beforeEach made it)
     writeTriageArtifact(realOrchDir, "ENG-9");
@@ -273,7 +278,10 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
     );
     expect(dispatch).not.toHaveBeenCalled();
     await sleep(70);
-    expect(exec.calls).toBe(1); // the debounced reconcile ran
+    // Pre-CTL-681 the debounced reconcile fired (calls === 1). Post-CTL-681
+    // an already-triaged →Ready is a no-op; the 10-min periodic reconcile is
+    // what picks it up.
+    expect(exec.calls).toBe(0);
   });
 
   test("CTL-625: →Ready with no triage.json auto-dispatches triage (Backlog→Ready-direct)", () => {
@@ -296,7 +304,7 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
     expect(exec.calls).toBe(0); // did NOT reconcile (no new-work pull → no storm)
   });
 
-  test("CTL-625: →Ready with no orchDir wired falls back to reconcile, never throws", async () => {
+  test("CTL-625 + CTL-681: →Ready with no orchDir wired is a no-op (was: fallback reconcile), never throws", async () => {
     enroll("ENG", { status: "Ready" });
     const exec = execReturning({ ENG: [node("ENG-9")] });
     const dispatch = mock(() => ({ code: 0 }));
@@ -311,7 +319,11 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
     ).not.toThrow();
     expect(dispatch).not.toHaveBeenCalled();
     await sleep(70);
-    expect(exec.calls).toBe(1);
+    // Pre-CTL-681 the no-orchDir branch fell back to the debounced reconcile
+    // (calls === 1). Post-CTL-681 there is no reconcile to fall back to; the
+    // 10-min periodic reconcile handles it. The throw-safety property is
+    // preserved (still no throw).
+    expect(exec.calls).toBe(0);
   });
 
   // CTL-584: drag-out kill fires only for the enumerated DRAG_OUT_STATES.

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
@@ -22,7 +22,7 @@ describe("parseLinearWebhookEvent — Issue", () => {
   it("Issue create → linear.issue.created", () => {
     const ev = parseLinearWebhookEvent(
       "Issue",
-      issuePayload({ action: "create", updatedFrom: undefined }),
+      issuePayload({ action: "create", updatedFrom: undefined })
     );
     expect(ev.kind).toBe("issue");
     if (ev.kind !== "issue") return;
@@ -37,7 +37,7 @@ describe("parseLinearWebhookEvent — Issue", () => {
       "Issue",
       issuePayload({
         updatedFrom: { stateId: "old-state-id" },
-      }),
+      })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.topic).toBe("linear.issue.state_changed");
@@ -57,7 +57,7 @@ describe("parseLinearWebhookEvent — Issue", () => {
           state: { id: "new-state-id", name: "In Progress" },
           priority: 2,
         },
-      }),
+      })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.toState).toBe("In Progress");
@@ -66,17 +66,14 @@ describe("parseLinearWebhookEvent — Issue", () => {
   it("toState is null when data.state is absent", () => {
     const ev = parseLinearWebhookEvent(
       "Issue",
-      issuePayload({ updatedFrom: { stateId: "old-state-id" } }),
+      issuePayload({ updatedFrom: { stateId: "old-state-id" } })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.toState).toBeNull();
   });
 
   it("extracts toPriority from data.priority", () => {
-    const ev = parseLinearWebhookEvent(
-      "Issue",
-      issuePayload({ updatedFrom: { priority: 3 } }),
-    );
+    const ev = parseLinearWebhookEvent("Issue", issuePayload({ updatedFrom: { priority: 3 } }));
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.toPriority).toBe(2);
   });
@@ -93,7 +90,7 @@ describe("parseLinearWebhookEvent — Issue", () => {
           team: { id: "team-uuid", key: "CTL", name: "Catalyst" },
           assignee: { id: "new-user-id", name: "Ryan" },
         },
-      }),
+      })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.toAssigneeId).toBe("new-user-id");
@@ -106,26 +103,20 @@ describe("parseLinearWebhookEvent — Issue", () => {
       issuePayload({
         updatedFrom: { stateId: "old" },
         actor: { id: "actor-uuid", name: "Alice" },
-      }),
+      })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.actorName).toBe("Alice");
   });
 
   it("actorName is null when actor is absent", () => {
-    const ev = parseLinearWebhookEvent(
-      "Issue",
-      issuePayload({ updatedFrom: { stateId: "old" } }),
-    );
+    const ev = parseLinearWebhookEvent("Issue", issuePayload({ updatedFrom: { stateId: "old" } }));
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.actorName).toBeNull();
   });
 
   it("Issue update with only priority → priority_changed", () => {
-    const ev = parseLinearWebhookEvent(
-      "Issue",
-      issuePayload({ updatedFrom: { priority: 3 } }),
-    );
+    const ev = parseLinearWebhookEvent("Issue", issuePayload({ updatedFrom: { priority: 3 } }));
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.topic).toBe("linear.issue.priority_changed");
   });
@@ -133,7 +124,7 @@ describe("parseLinearWebhookEvent — Issue", () => {
   it("Issue update with only assigneeId → assignee_changed", () => {
     const ev = parseLinearWebhookEvent(
       "Issue",
-      issuePayload({ updatedFrom: { assigneeId: "old-user" } }),
+      issuePayload({ updatedFrom: { assigneeId: "old-user" } })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.topic).toBe("linear.issue.assignee_changed");
@@ -144,7 +135,7 @@ describe("parseLinearWebhookEvent — Issue", () => {
       "Issue",
       issuePayload({
         updatedFrom: { stateId: "old", priority: 1 },
-      }),
+      })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.topic).toBe("linear.issue.state_changed");
@@ -153,7 +144,7 @@ describe("parseLinearWebhookEvent — Issue", () => {
   it("Issue update with no recognized changes → linear.issue.updated", () => {
     const ev = parseLinearWebhookEvent(
       "Issue",
-      issuePayload({ updatedFrom: { title: "old title" } }),
+      issuePayload({ updatedFrom: { title: "old title" } })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.topic).toBe("linear.issue.updated");
@@ -162,7 +153,7 @@ describe("parseLinearWebhookEvent — Issue", () => {
   it("Issue remove → linear.issue.removed", () => {
     const ev = parseLinearWebhookEvent(
       "Issue",
-      issuePayload({ action: "remove", updatedFrom: undefined }),
+      issuePayload({ action: "remove", updatedFrom: undefined })
     );
     if (ev.kind !== "issue") throw new Error("expected issue kind");
     expect(ev.topic).toBe("linear.issue.removed");
@@ -183,6 +174,128 @@ describe("parseLinearWebhookEvent — Issue", () => {
       type: "Issue",
     });
     expect(ev.kind).toBe("ignored");
+  });
+
+  // Scoping-field capture: the Linear webhook's raw payload.data carries the
+  // fields the daemon's eligibleQuery needs (project, labels, priority). The
+  // pre-existing parser dropped them, forcing the daemon to fall back to a full
+  // poll for every relevant event ("scoping resolved exclusively by the poll"
+  // comment in monitor.mjs). Capturing them now lets the daemon evaluate
+  // eligibility from the event payload directly and drop the per-event poll.
+
+  it("extracts toLabels from data.labels.nodes (Linear API shape)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        data: {
+          id: "issue-uuid-1",
+          identifier: "CTL-210",
+          title: "Build event bus",
+          team: { id: "team-uuid", key: "CTL", name: "Catalyst" },
+          labels: {
+            nodes: [
+              { id: "l1", name: "bug" },
+              { id: "l2", name: "p0" },
+            ],
+          },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toLabels).toEqual(["bug", "p0"]);
+  });
+
+  it("toLabels is null when data.labels is absent", () => {
+    const ev = parseLinearWebhookEvent("Issue", issuePayload());
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toLabels).toBeNull();
+  });
+
+  it("toLabels is an empty array when data.labels.nodes is empty", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        data: {
+          id: "issue-uuid-1",
+          identifier: "CTL-210",
+          title: "Build event bus",
+          team: { id: "team-uuid", key: "CTL", name: "Catalyst" },
+          labels: { nodes: [] },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toLabels).toEqual([]);
+  });
+
+  it("extracts toProject (name) and toProjectId from data.project", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        data: {
+          id: "issue-uuid-1",
+          identifier: "CTL-210",
+          title: "Build event bus",
+          team: { id: "team-uuid", key: "CTL", name: "Catalyst" },
+          project: { id: "proj-uuid", name: "Initiative 1" },
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toProject).toBe("Initiative 1");
+    expect(ev.toProjectId).toBe("proj-uuid");
+  });
+
+  it("toProject is null when data.project is absent", () => {
+    const ev = parseLinearWebhookEvent("Issue", issuePayload());
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toProject).toBeNull();
+    expect(ev.toProjectId).toBeNull();
+  });
+
+  it("toProjectId falls back to data.projectId when data.project object is absent", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        data: {
+          id: "issue-uuid-1",
+          identifier: "CTL-210",
+          title: "Build event bus",
+          team: { id: "team-uuid", key: "CTL", name: "Catalyst" },
+          projectId: "proj-uuid-only",
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.toProject).toBeNull();
+    expect(ev.toProjectId).toBe("proj-uuid-only");
+  });
+
+  it("previousFromValues mirrors the full updatedFrom object (not just keys)", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        updatedFrom: {
+          stateId: "old-state",
+          labelIds: ["old-label-1", "old-label-2"],
+          projectId: "old-proj",
+        },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.previousFromValues).toEqual({
+      stateId: "old-state",
+      labelIds: ["old-label-1", "old-label-2"],
+      projectId: "old-proj",
+    });
+    // updatedFromKeys still derived from Object.keys, unchanged
+    expect(ev.updatedFromKeys).toEqual(["stateId", "labelIds", "projectId"]);
+  });
+
+  it("previousFromValues is an empty object when updatedFrom is absent", () => {
+    const ev = parseLinearWebhookEvent("Issue", issuePayload({ updatedFrom: undefined }));
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.previousFromValues).toEqual({});
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -21,15 +21,14 @@ function makeReq(
     "linear-delivery": string;
     "linear-signature": string;
   }> = {},
-  method = "POST",
+  method = "POST"
 ): Request {
   const bodyStr = JSON.stringify(body);
   return new Request("http://localhost:7400/api/webhook/linear", {
     method,
     headers: {
       "linear-event": headers["linear-event"] ?? "Issue",
-      "linear-delivery":
-        headers["linear-delivery"] ?? `linear-delivery-${Math.random()}`,
+      "linear-delivery": headers["linear-delivery"] ?? `linear-delivery-${Math.random()}`,
       "linear-signature": headers["linear-signature"] ?? sign(bodyStr),
       "content-type": "application/json",
     },
@@ -90,7 +89,7 @@ describe("createLinearWebhookHandler", () => {
       linearSecrets: [{ key: "test", secret: SECRET }],
     });
     const res = await handler.handle(
-      makeReq(issueUpdatePayload(), { "linear-signature": "deadbeef" }),
+      makeReq(issueUpdatePayload(), { "linear-signature": "deadbeef" })
     );
     expect(res.status).toBe(401);
   });
@@ -99,9 +98,7 @@ describe("createLinearWebhookHandler", () => {
     const handler = createLinearWebhookHandler({
       linearSecrets: [{ key: "test", secret: SECRET }],
     });
-    const res = await handler.handle(
-      makeReq(issueUpdatePayload(), { "linear-event": "" }),
-    );
+    const res = await handler.handle(makeReq(issueUpdatePayload(), { "linear-event": "" }));
     expect(res.status).toBe(400);
   });
 
@@ -109,9 +106,7 @@ describe("createLinearWebhookHandler", () => {
     const handler = createLinearWebhookHandler({
       linearSecrets: [{ key: "test", secret: SECRET }],
     });
-    const res = await handler.handle(
-      makeReq(issueUpdatePayload(), { "linear-delivery": "" }),
-    );
+    const res = await handler.handle(makeReq(issueUpdatePayload(), { "linear-delivery": "" }));
     expect(res.status).toBe(400);
   });
 
@@ -125,9 +120,7 @@ describe("createLinearWebhookHandler", () => {
       headers: {
         "linear-event": "Issue",
         "linear-delivery": "delivery-1",
-        "linear-signature": createHmac("sha256", SECRET)
-          .update(bodyStr)
-          .digest("hex"),
+        "linear-signature": createHmac("sha256", SECRET).update(bodyStr).digest("hex"),
         "content-type": "application/json",
       },
       body: bodyStr,
@@ -172,13 +165,11 @@ describe("createLinearWebhookHandler", () => {
       eventLog,
     });
     const deliveryId = "stable-delivery-1";
-    await handler.handle(
-      makeReq(issueUpdatePayload(), { "linear-delivery": deliveryId }),
-    );
+    await handler.handle(makeReq(issueUpdatePayload(), { "linear-delivery": deliveryId }));
     expect(eventLog.appends.length).toBe(1);
 
     const res2 = await handler.handle(
-      makeReq(issueUpdatePayload(), { "linear-delivery": deliveryId }),
+      makeReq(issueUpdatePayload(), { "linear-delivery": deliveryId })
     );
     expect(res2.status).toBe(200);
     const body = (await res2.json()) as { ok: boolean; replay?: boolean };
@@ -210,8 +201,8 @@ describe("createLinearWebhookHandler", () => {
           type: "Project",
           data: { id: "p1" },
         },
-        { "linear-event": "Project" },
-      ),
+        { "linear-event": "Project" }
+      )
     );
     expect(res.status).toBe(200);
     expect(eventLog.appends.length).toBe(0);
@@ -245,8 +236,8 @@ describe("createLinearWebhookHandler", () => {
     await handler.handle(
       makeReq(
         { action: "create", type: "Project", data: { id: "p1" } },
-        { "linear-event": "Project" },
-      ),
+        { "linear-event": "Project" }
+      )
     );
     expect(seen).toHaveLength(0);
   });
@@ -278,9 +269,7 @@ describe("createLinearWebhookHandler", () => {
       updatedFrom: { description: "old desc" },
     };
     await handler.handle(makeReq(payload));
-    expect(
-      eventLog.appends[0]?.attributes["linear.actor.id"],
-    ).toBe("actor-uuid-999");
+    expect(eventLog.appends[0]?.attributes["linear.actor.id"]).toBe("actor-uuid-999");
     const bodyPayload = eventLog.appends[0]?.body.payload as { actorId: string };
     expect(bodyPayload.actorId).toBe("actor-uuid-999");
   });
@@ -377,9 +366,7 @@ describe("createLinearWebhookHandler", () => {
       actor: { id: "bot-uuid-123" },
       data: { id: "c1", issueId: "i1" },
     };
-    await handler.handle(
-      makeReq(commentPayload, { "linear-event": "Comment" }),
-    );
+    await handler.handle(makeReq(commentPayload, { "linear-event": "Comment" }));
     expect(eventLog.appends.length).toBe(1);
   });
 });
@@ -401,8 +388,12 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
-      TS,
+      TS
     );
     expect(env).not.toBeNull();
     expect(env!.attributes["event.name"]).toBe("linear.issue.state_changed");
@@ -428,8 +419,12 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
-      TS,
+      TS
     );
     const payload = env!.body.payload as Record<string, unknown>;
     expect(payload["toState"]).toBe("In Review");
@@ -451,8 +446,12 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
-      TS,
+      TS
     );
     const payload = env!.body.payload as Record<string, unknown>;
     expect(payload["toState"]).toBeNull();
@@ -474,8 +473,12 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
-      TS,
+      TS
     );
     expect(env!.attributes["linear.actor.id"]).toBe("actor-uuid-123");
     const payload = env!.body.payload as { actorId: string };
@@ -498,11 +501,51 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
-      TS,
+      TS
     );
     const payload = env!.body.payload as { actorId: string | null };
     expect(payload.actorId).toBeNull();
+  });
+
+  it("CTL-681: Issue event forwards toLabels/toProject/toProjectId/previousFromValues into body.payload", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "update",
+        topic: "linear.issue.state_changed",
+        ticket: "CTL-681",
+        teamKey: "CTL",
+        data: {},
+        updatedFromKeys: ["stateId", "labelIds"],
+        actorId: null,
+        actorName: null,
+        toState: "Ready",
+        toPriority: 2,
+        toAssigneeId: null,
+        toAssigneeName: null,
+        toLabels: ["bug", "p0"],
+        toProject: "Initiative 1",
+        toProjectId: "proj-uuid",
+        previousFromValues: {
+          stateId: "old-state",
+          labelIds: ["old-label"],
+        },
+      },
+      TS
+    );
+    const p = env!.body.payload as Record<string, unknown>;
+    expect(p.toLabels).toEqual(["bug", "p0"]);
+    expect(p.toProject).toBe("Initiative 1");
+    expect(p.toProjectId).toBe("proj-uuid");
+    expect(p.previousFromValues).toEqual({
+      stateId: "old-state",
+      labelIds: ["old-label"],
+    });
   });
 
   it("Issue event serializes toState, toPriority, toAssigneeName, actorName into body.payload (CTL-424)", () => {
@@ -521,8 +564,12 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toPriority: 2,
         toAssigneeId: "user-uuid-424",
         toAssigneeName: "Alice",
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
-      TS,
+      TS
     );
     const p = env!.body.payload as Record<string, unknown>;
     expect(p.toState).toBe("In Progress");
@@ -548,8 +595,12 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
-      TS,
+      TS
     );
     const p = env!.body.payload as Record<string, unknown>;
     expect(p.toState).toBeNull();
@@ -569,7 +620,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         issueId: "i1",
         data: {},
       },
-      TS,
+      TS
     );
     expect(env!.attributes["event.name"]).toBe("linear.comment.created");
     expect(env!.attributes["linear.issue.identifier"]).toBe("CTL-1");
@@ -584,7 +635,7 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         teamKey: "CTL",
         data: {},
       },
-      TS,
+      TS
     );
     expect(env!.attributes["event.name"]).toBe("linear.cycle.updated");
     expect(env!.attributes["linear.team.key"]).toBe("CTL");
@@ -598,16 +649,13 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         reactionId: "r1",
         data: {},
       },
-      TS,
+      TS
     );
     expect(env!.attributes["event.name"]).toBe("linear.reaction.created");
   });
 
   it("ignored → null", () => {
-    const env = buildLinearEventLogEnvelope(
-      { kind: "ignored", reason: "test" },
-      TS,
-    );
+    const env = buildLinearEventLogEnvelope({ kind: "ignored", reason: "test" }, TS);
     expect(env).toBeNull();
   });
 });
@@ -637,9 +685,13 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
     expect(env!.attributes["linear.team.key"]).toBe("CTL");
@@ -661,9 +713,13 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
     expect(env!.attributes["linear.team.key"]).toBe("FOO");
@@ -685,9 +741,13 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
   });
@@ -703,7 +763,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         data: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBe("coalesce-labs/adva");
     expect(env!.attributes["linear.team.key"]).toBe("ADV");
@@ -721,7 +781,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         data: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
     expect(env!.attributes["linear.team.key"]).toBeUndefined();
@@ -738,7 +798,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         data: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
   });
@@ -753,7 +813,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         data: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
   });
@@ -767,7 +827,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         data: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
   });
@@ -781,7 +841,7 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         data: {},
       },
       TS,
-      TEAMS,
+      TEAMS
     );
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
   });
@@ -802,8 +862,12 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         toPriority: null,
         toAssigneeId: null,
         toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
       },
-      TS,
+      TS
     );
     expect(env!.attributes["vcs.repository.name"]).toBeUndefined();
   });

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
@@ -36,6 +36,31 @@ export type LinearWebhookEvent =
       toAssigneeName: string | null;
       /** Actor display name from actor.name; null when absent. CTL-424. */
       actorName: string | null;
+      /**
+       * Current label name list from data.labels.nodes[].name; null when the
+       * payload omits `labels` entirely (distinguishes "no label info" from
+       * "explicitly empty"). Eligible-set scoping needs this. CTL-681.
+       */
+      toLabels: string[] | null;
+      /**
+       * Current project name from data.project.name; null when absent. CTL-681.
+       */
+      toProject: string | null;
+      /**
+       * Current project UUID from data.project.id, falling back to
+       * data.projectId when the project object is omitted (partial payloads).
+       * Null when neither is present. Stable join key for incremental
+       * projection updates. CTL-681.
+       */
+      toProjectId: string | null;
+      /**
+       * Full updatedFrom map (previous values of changed fields). The pre-CTL-681
+       * parser kept only the KEY NAMES (`updatedFromKeys`). Retaining the full
+       * map lets a downstream consumer ask "did labels actually leave the set?"
+       * by diffing previous labelIds against current data.labels.nodes[].id
+       * without re-parsing the raw webhook payload.
+       */
+      previousFromValues: Record<string, unknown>;
     }
   | {
       kind: "comment";
@@ -127,6 +152,16 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
   const assigneeObj = isObject(data.assignee) ? data.assignee : null;
   const toAssigneeId = assigneeObj !== null ? getOptStr(assigneeObj, "id") : null;
   const toAssigneeName = assigneeObj !== null ? getOptStr(assigneeObj, "name") : null;
+  // CTL-681 — eligible-set scoping fields. Linear's API returns label info as
+  // `labels: { nodes: [{id, name, …}] }` (confirmed by orch-monitor/lib/
+  // linear.ts and linear-write.mjs:145). `null` when `labels` is absent
+  // entirely, `[]` when the array is present but empty — preserves the
+  // distinction the daemon's incremental projection needs.
+  const toLabels = parseLabelNames(data.labels);
+  const projectObj = isObject(data.project) ? data.project : null;
+  const toProject = projectObj !== null ? getOptStr(projectObj, "name") : null;
+  const toProjectId =
+    projectObj !== null ? getOptStr(projectObj, "id") : getOptStr(data, "projectId");
   return {
     kind: "issue",
     action,
@@ -141,7 +176,27 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
     toPriority,
     toAssigneeId,
     toAssigneeName,
+    toLabels,
+    toProject,
+    toProjectId,
+    previousFromValues: updatedFrom,
   };
+}
+
+// parseLabelNames — extract the label-name list from a webhook `data.labels`
+// value. Returns null when labels is absent (not an object), [] when present
+// with an empty nodes array, or the names otherwise. CTL-681.
+function parseLabelNames(value: unknown): string[] | null {
+  if (!isObject(value)) return null;
+  const nodes = value.nodes;
+  if (!Array.isArray(nodes)) return null;
+  const names: string[] = [];
+  for (const node of nodes) {
+    if (!isObject(node)) continue;
+    const name = getOptStr(node, "name");
+    if (name !== null) names.push(name);
+  }
+  return names;
 }
 
 function parseComment(payload: Record<string, unknown>): LinearWebhookEvent {

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -1,11 +1,7 @@
 import { verifyLinearSignature } from "./linear-webhook-verify";
 import { parseLinearWebhookEvent, type LinearWebhookEvent } from "./linear-webhook-events";
 import { type EventLogWriter } from "./event-log";
-import {
-  buildCanonicalEvent,
-  type CanonicalEvent,
-  type Attributes,
-} from "./canonical-event";
+import { buildCanonicalEvent, type CanonicalEvent, type Attributes } from "./canonical-event";
 
 const LINEAR_SERVICE_NAME = "catalyst.linear" as const;
 
@@ -117,7 +113,7 @@ function deriveTeamKey(ticket: string | null): string | null {
 export function buildLinearEventLogEnvelope(
   event: LinearWebhookEvent,
   ts: string = new Date().toISOString(),
-  teamsMap: ReadonlyMap<string, string> = new Map(),
+  teamsMap: ReadonlyMap<string, string> = new Map()
 ): CanonicalEvent | null {
   const lookupRepo = (teamKey: string | null): string | undefined =>
     teamKey !== null ? teamsMap.get(teamKey) : undefined;
@@ -150,6 +146,12 @@ export function buildLinearEventLogEnvelope(
           toPriority: event.toPriority,
           toAssigneeId: event.toAssigneeId,
           toAssigneeName: event.toAssigneeName,
+          // CTL-681 — scoping fields the daemon's eligibleQuery needs. The
+          // pre-CTL-681 envelope dropped these and forced a full poll per event.
+          toLabels: event.toLabels,
+          toProject: event.toProject,
+          toProjectId: event.toProjectId,
+          previousFromValues: event.previousFromValues,
         },
       });
     }
@@ -248,7 +250,7 @@ export function createLinearWebhookHandler(deps: LinearWebhookHandlerDeps): Line
   // CTL-362: build the team→repo lookup once at construction so every webhook
   // call shares the same map without re-parsing.
   const teamsMap: ReadonlyMap<string, string> = new Map(
-    (deps.linearTeams ?? []).map((t) => [t.key, t.vcsRepo]),
+    (deps.linearTeams ?? []).map((t) => [t.key, t.vcsRepo])
   );
 
   function rememberDelivery(deliveryId: string): void {


### PR DESCRIPTION
## Summary

Steps 1+4 of the event-sourcing rework from the 2026-05-27 webhook-vs-poll research. Eliminates the per-event Linear scoping reconcile that exhausted the 2500/hr quota baseline (~9 calls per scheduler cycle).

### Parser changes (`linear-webhook-events.ts`)
The raw webhook's `payload.data` already carries `project`, `labels`, `priority`, and `updatedFrom` — the parser just dropped them. Now captured into the canonical event:
- `toLabels: string[] | null` — label-name list from `data.labels.nodes[].name`
- `toProject: string | null` — current project name from `data.project.name`
- `toProjectId: string | null` — project UUID from `data.project.id`, falling back to `data.projectId` for partial payloads
- `previousFromValues: Record<string, unknown>` — full `updatedFrom` map (complements the existing keys-only `updatedFromKeys`)

### Envelope wiring (`linear-webhook-handler.ts`)
The four new fields flow into `body.payload` of the canonical event-log envelope. Downstream consumers (the daemon's future incremental projection update) can now read them without re-parsing the raw webhook.

### Daemon change (`monitor.mjs`)
The `→Ready` / unknown-new-state branch in `handleStateChangedEvent` is now a no-op. Was: `scheduleDirtyReconcile(team, …)` triggered a debounced per-event poll because the parser had dropped the scoping fields. Now: the event is logged at debug level and the eligible set is refreshed only by the startup reconcile + the 10-min periodic reconcile (`RECONCILE_INTERVAL_MS`).

`scheduleDirtyReconcile` + its `dirtyTimers` Map are deleted (dead code after this); `stopMonitor`'s `dirtyTimers` cleanup goes too. The drag-out kill path, CTL-625 triage auto-dispatch, →Triage one-shot dispatch, registry-change reconcile, startup reconcile, and periodic reconcile timer are all unchanged.

### Trade-off
Staleness window for a new Ready ticket worsens from ~30s (debounced reconcile) to ≤10min (next periodic reconcile) — explicitly chosen to remove the per-event poll baseline. Operator can lower `EXECUTION_CORE_RECONCILE_INTERVAL_MS` env override if needed during the transition before step 2 lands.

### What's NOT in this PR
Steps 2 + 3 of the 4-step plan:
- Step 2: daemon evaluates `eligibleQuery` against the event and folds add/remove into the projection locally (uses the new fields)
- Step 3: first-class handlers for `linear.issue.updated` / `linear.comment.created` triggers

This PR is the prerequisite — fields captured + per-event poll removed. Once step 2 lands the staleness drops back near-zero with still zero per-event polls.

## Test plan
- [x] `bun test linear-webhook-events.test.ts` — 32/32 (8 new tests covering each new field's shape variants)
- [x] `bun test linear-webhook-handler.test.ts` — 42/42 (1 new envelope round-trip test for the new payload fields; 10 existing fixtures updated to include the new required fields as nulls/empty)
- [x] `bun test monitor.test.mjs` — 44/44 (4 reconcile-on-event tests inverted to assert `exec.calls === 0`, renamed to positively document the no-op contract)
- [x] `bun test integration.test.mjs` — 7/8 (AC1 rewritten to demonstrate the new two-half contract: event is a no-op, the next periodic reconcile adds the ticket; AC5 is the pre-existing env flake that also fails on origin/main — `claude agents` live bg workers → freeSlots=0)
- [x] Full execution-core suite — 1062 pass / 9 fail; all 9 failures are documented environmental dispatch tests, zero new failures
- [x] Full orch-monitor suite — 2085 pass / 7 fail; all 7 failures are environmental `catalyst-monitor.sh` shell tests, zero new failures

## Linked
- Research: `thoughts/shared/research/2026-05-27-webhook-vs-poll-minimal-outbound-need.md`
- Handoff: `thoughts/shared/handoffs/general/2026-05-27_20-42-16_linear-github-overcall-rate-limit.md`
- Built on: #1136 (CTL-679 rate-limit breaker — quiet safety net), #1137 (cross-team label-UUID classifier — eliminated the ADV `needs-human` per-tick storm)