### PR TITLE
CTL-676: Hot-reload execution-core concurrency knobs from config

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -114,6 +114,12 @@ export function startDaemon({
   // .catalyst/config.json. Threaded into both the scheduler new-work pull and the
   // boot-resume ceiling. Empty {} (the test default) keeps the legacy state.json path.
   concurrency = {},
+  // CTL-676: the resolved config path. Threaded only into startScheduler so the
+  // scheduler can re-read concurrency knobs per tick (hot-reload). reconcileBoot
+  // intentionally stays on the boot-captured `concurrency` object — it fires
+  // once before the scheduler starts and never re-reads. Null in tests that
+  // never resolve a config path.
+  configPath = null,
 } = {}) {
   const orchDir = getExecutionCoreDir();
   ensureState(orchDir);
@@ -166,7 +172,7 @@ export function startDaemon({
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.
-    schedulerFn({ orchDir, cache, concurrency }); // CTL-536 + CTL-634 + CTL-665 — pull-loop scheduler
+    schedulerFn({ orchDir, cache, concurrency, configPath }); // CTL-536 + CTL-634 + CTL-665 + CTL-676 — pull-loop scheduler (configPath enables per-tick re-read)
 
     if (watchRegistry) {
       // Watch the execution-core dir for registry.json changes — the registry is
@@ -456,7 +462,7 @@ function main() {
   process.on("unhandledRejection", fatal("unhandled rejection"));
 
   try {
-    startDaemon({ pidFile, orphanReaperConfig, concurrency });
+    startDaemon({ pidFile, orphanReaperConfig, concurrency, configPath }); // CTL-676
   } catch (err) {
     log.error({ err }, "execution-core daemon: failed to start");
     process.exit(1);

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -159,6 +159,39 @@ describe("startDaemon", () => {
     expect(schedulerConcurrency).toEqual({});
   });
 
+  // CTL-676: `configPath` resolved in main() threads into startScheduler so
+  // the scheduler can re-read the concurrency knobs per tick (boot-resume
+  // continues to use the boot-captured `concurrency` object). Default is
+  // null when not passed — every existing test path keeps the back-compat
+  // shape (scheduler re-passes the boot-captured concurrency).
+  test("threads configPath into startScheduler (CTL-676)", () => {
+    const configPath = "/tmp/CTL-676/config.json";
+    let schedulerConfigPath = "unset";
+    startDaemon({
+      recover: () => ({ coldStart: false, workers: {} }),
+      startMonitor: () => {},
+      startScheduler: (o) => {
+        schedulerConfigPath = o.configPath;
+      },
+      watchRegistry: false,
+      configPath,
+    });
+    expect(schedulerConfigPath).toBe(configPath);
+  });
+
+  test("defaults configPath to null when not passed (CTL-676)", () => {
+    let schedulerConfigPath = "unset";
+    startDaemon({
+      recover: () => ({ coldStart: false, workers: {} }),
+      startMonitor: () => {},
+      startScheduler: (o) => {
+        schedulerConfigPath = o.configPath;
+      },
+      watchRegistry: false,
+    });
+    expect(schedulerConfigPath).toBeNull();
+  });
+
   // CTL-634: one cache instance is created in startDaemon and threaded into
   // BOTH composed boots, so the monitor's write-through and the scheduler's
   // read path share state. Capture each boot's `cache` arg and assert identity.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1154,6 +1154,19 @@ let runningOpts = null;
 
 function runTick() {
   try {
+    // CTL-676: hot-reload the concurrency knobs by re-reading the project
+    // config at the top of every tick. When `configPath` is unset (back-compat
+    // scheduler harnesses that never threaded it), fall back to the
+    // boot-captured `concurrency` object — byte-for-byte the pre-CTL-676
+    // behavior. `readExecutionCoreConcurrency` is null/ENOENT/parse-error
+    // safe (returns `{}`), so a malformed mid-run edit fails open exactly as
+    // a fresh daemon boot against the same malformed file would: the next
+    // `readMaxParallel` call falls through to state.json + the hardcoded
+    // default. Boot-resume keeps the boot-captured object — it fires once
+    // before the scheduler starts, and never re-reads.
+    const concurrency = runningOpts.configPath
+      ? readExecutionCoreConcurrency(runningOpts.configPath)
+      : runningOpts.concurrency;
     schedulerTick(runningOpts.orchDir, {
       readEligible: runningOpts.readEligible,
       dispatch: runningOpts.dispatch,
@@ -1161,7 +1174,11 @@ function runTick() {
       writeStatus: runningOpts.writeStatus,
       teardownWorktree: runningOpts.teardownWorktree,
       cache: runningOpts.cache, // CTL-634: shared out-of-set blocker state cache
-      concurrency: runningOpts.concurrency, // CTL-665: committed slot-ceiling knobs
+      concurrency, // CTL-665 + CTL-676: per-tick re-read, then threaded into readMaxParallel
+      // CTL-676: forward the optional liveBackgroundCount seam (test-only) so
+      // a unit test can drive freeSlots deterministically without shelling
+      // out to `claude agents`. Undefined here keeps the production default.
+      liveBackgroundCount: runningOpts.liveBackgroundCount,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -1188,13 +1205,35 @@ export function startScheduler({
   writeStatus,
   teardownWorktree,
   cache, // CTL-634: shared out-of-set blocker state cache (from startDaemon)
-  concurrency = {}, // CTL-665: committed executionCore concurrency knobs (from startDaemon)
+  concurrency = {}, // CTL-665 + CTL-676: boot-captured executionCore knobs. When
+  // `configPath` is also set (production wiring), runTick re-reads the live
+  // file every tick and ignores this object; the boot-captured value is the
+  // back-compat path for tests that never thread `configPath`.
+  configPath = null, // CTL-676: when set, runTick re-reads concurrency from
+  // this path per tick (hot-reload). Threaded from startDaemon, which resolves
+  // it from CATALYST_CONFIG_FILE || <cwd>/.catalyst/config.json. Null in tests
+  // that exercise the back-compat boot-captured-only shape.
+  liveBackgroundCount, // CTL-676: optional test-only seam, forwarded to
+  // schedulerTick where it defaults to countBackgroundAgents (the live
+  // `claude agents --json` count). Symmetric with the existing dispatch /
+  // exec / writeStatus / teardownWorktree seams on schedulerTick.
   preflight = preflightWorkspaceLabels, // CTL-585
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
 } = {}) {
   if (!orchDir) throw new Error("startScheduler: orchDir is required");
-  runningOpts = { orchDir, dispatch, readEligible, exec, writeStatus, teardownWorktree, cache, concurrency };
+  runningOpts = {
+    orchDir,
+    dispatch,
+    readEligible,
+    exec,
+    writeStatus,
+    teardownWorktree,
+    cache,
+    concurrency,
+    configPath, // CTL-676: per-tick re-read source
+    liveBackgroundCount, // CTL-676: test seam
+  };
 
   // CTL-585: warn once at startup if the Linear workspace lacks the labels
   // the CTL-558 sweep writes. Best-effort — never blocks startup.

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1322,6 +1322,267 @@ describe("startScheduler / stopScheduler", () => {
   });
 });
 
+// ── CTL-676: hot-reload concurrency knobs via per-tick re-read ──
+//
+// The scheduler stores `configPath` on `runningOpts` and, when set, re-reads
+// `readExecutionCoreConcurrency(configPath)` at the top of every `runTick`
+// instead of re-passing the boot-captured object. An edit to the config takes
+// effect on the next debounced tick (≤2s under event-log activity) or the
+// next periodic tick (≤30s in production; smaller in tests). When `configPath`
+// is unset (back-compat scheduler harnesses), `runTick` re-passes
+// `runningOpts.concurrency` exactly as before CTL-676.
+describe("startScheduler — per-tick concurrency re-read (CTL-676)", () => {
+  afterEach(() => __resetForTests());
+
+  // Test 5 (back-compat hinge) — calling startScheduler without `configPath`
+  // keeps the boot-captured concurrency object on every tick. Observable via
+  // the dispatch ceiling: with `concurrency: { maxParallel: 2 }` and 3 eligible
+  // ready tickets, exactly 2 dispatch on the first tick.
+  test("configPath unset → boot-captured concurrency reaches schedulerTick (back-compat)", () => {
+    const dispatch = fakeDispatch();
+    const tk = (id, priority) => ({
+      identifier: id,
+      priority,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    });
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [tk("CTL-A", 1), tk("CTL-B", 2), tk("CTL-C", 3)],
+      concurrency: { maxParallel: 2 },
+      liveBackgroundCount: () => 0, // CTL-676: deterministic in-flight count
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+    });
+    // 2 dispatches (the ceiling), not 3 — proves runningOpts.concurrency
+    // reached the schedulerTick call.
+    expect(dispatch.calls.length).toBe(2);
+  });
+
+  // Test 1 (happy path) — editing the config file between two ticks raises
+  // the slot ceiling on the next tick. The observation route is the dispatch
+  // count under a controlled-size ready set, gated by readMaxParallel which
+  // schedulerTick computes from the threaded `concurrency` object.
+  test("editing the config raises the ceiling on the next tick", async () => {
+    const configPath = join(orchDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 1 } } },
+      }),
+    );
+    // Pre-create the event log so a later append is an in-place `change`
+    // (not a `rename` that some macOS hosts can drop). Mirrors the existing
+    // "an event-log change triggers a debounced tick" test.
+    appendToEventLog("");
+    const dispatch = fakeDispatch();
+    const tk = (id, priority) => ({
+      identifier: id,
+      priority,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    });
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [tk("CTL-A", 1), tk("CTL-B", 2), tk("CTL-C", 3)],
+      configPath,
+      liveBackgroundCount: () => 0, // CTL-676
+      tickIntervalMs: 60_000,
+      debounceMs: 10,
+    });
+    // First tick honored the file's maxParallel: 1 → exactly one dispatch.
+    expect(dispatch.calls.length).toBe(1);
+    const firstTicket = dispatch.calls[0].ticket;
+
+    // Raise the ceiling. The already-dispatched ticket has a worker dir, so
+    // the new-work pull will skip it; on the next tick we expect the next
+    // two ranked tickets to dispatch.
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 3 } } },
+      }),
+    );
+    await waitFor(() => dispatch.calls.length >= 3, {
+      intervalMs: 100,
+      onTick: () => appendToEventLog('{"event":"wake.CTL-676"}\n'),
+    });
+    expect(dispatch.calls.length).toBe(3);
+    // The originally-dispatched ticket is not re-dispatched (its worker dir
+    // gates it out of the new-work pull).
+    expect(dispatch.calls.filter((c) => c.ticket === firstTicket).length).toBe(1);
+  });
+
+  // Test 2 (in-flight safety) — lowering the ceiling does NOT kill the
+  // already-dispatched worker; it gates only the next selectDispatchable
+  // result. teardownWorktree is the seam that would tear down a worker.
+  test("lowering the ceiling does not kill in-flight workers", async () => {
+    const configPath = join(orchDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 2 } } },
+      }),
+    );
+    appendToEventLog("");
+    const dispatch = fakeDispatch();
+    const teardownCalls = [];
+    const teardownWorktree = (args) => {
+      teardownCalls.push(args);
+    };
+    const tk = (id, priority) => ({
+      identifier: id,
+      priority,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    });
+    startScheduler({
+      orchDir,
+      dispatch,
+      teardownWorktree,
+      readEligible: () => [tk("CTL-A", 1), tk("CTL-B", 2)],
+      configPath,
+      liveBackgroundCount: () => 0, // CTL-676
+      tickIntervalMs: 60_000,
+      debounceMs: 10,
+    });
+    expect(dispatch.calls.length).toBe(2);
+
+    // Drop the ceiling below the in-flight count. The next tick must not
+    // tear down or re-dispatch anything.
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 1 } } },
+      }),
+    );
+    // Burn a few wake cycles so a hypothetical teardown would have fired.
+    for (let i = 0; i < 5; i++) {
+      appendToEventLog('{"event":"wake.CTL-676.b"}\n');
+      await new Promise((r) => setTimeout(r, 30));
+    }
+    expect(teardownCalls.length).toBe(0);
+    // No additional dispatches were issued either (no new eligible tickets,
+    // and the in-flight ones gate themselves out of the pull).
+    expect(dispatch.calls.length).toBe(2);
+  });
+
+  // Test 3 (invalid/partial new config falls back) — rewriting the file to
+  // malformed JSON makes readExecutionCoreConcurrency return {}, so the next
+  // tick falls back to state.json.maxParallel (here, 2) exactly as a fresh
+  // boot against the same malformed config would.
+  test("invalid new config falls back to state.json on the next tick", async () => {
+    const configPath = join(orchDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 1 } } },
+      }),
+    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    appendToEventLog("");
+    const dispatch = fakeDispatch();
+    const tk = (id, priority) => ({
+      identifier: id,
+      priority,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    });
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [tk("CTL-A", 1), tk("CTL-B", 2), tk("CTL-C", 3)],
+      configPath,
+      liveBackgroundCount: () => 0, // CTL-676
+      tickIntervalMs: 60_000,
+      debounceMs: 10,
+    });
+    // First tick: config wins → maxParallel = 1.
+    expect(dispatch.calls.length).toBe(1);
+
+    // Corrupt the config. Next tick must fall back to state.json (2).
+    writeFileSync(configPath, "{ not json");
+    await waitFor(() => dispatch.calls.length >= 2, {
+      intervalMs: 100,
+      onTick: () => appendToEventLog('{"event":"wake.CTL-676.c"}\n'),
+    });
+    // Exactly 2 (one before, one after) — config-absent ceiling of 2.
+    expect(dispatch.calls.length).toBe(2);
+  });
+
+  // Test 4 (surface pinning) — the per-tick re-read only consults
+  // `readExecutionCoreConcurrency`; out-of-scope fields in the new config
+  // (here `dispatchMode`) cannot change scheduler behavior. We assert this
+  // indirectly: an edit that flips `maxParallel` to 1 AND adds
+  // `dispatchMode: "oneshot-legacy"` is honored for maxParallel (the next
+  // tick gates dispatch to 1) and has no other visible effect on the
+  // scheduler's choices.
+  test("only readExecutionCoreConcurrency drives the per-tick re-read (no other fields)", async () => {
+    const configPath = join(orchDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: {
+          orchestration: {
+            executionCore: { maxParallel: 3, dispatchMode: "phase-agent" },
+          },
+        },
+      }),
+    );
+    appendToEventLog("");
+    const dispatch = fakeDispatch();
+    const tk = (id, priority) => ({
+      identifier: id,
+      priority,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    });
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [tk("CTL-A", 1), tk("CTL-B", 2), tk("CTL-C", 3), tk("CTL-D", 4)],
+      configPath,
+      liveBackgroundCount: () => 0, // CTL-676
+      tickIntervalMs: 60_000,
+      debounceMs: 10,
+    });
+    expect(dispatch.calls.length).toBe(3);
+
+    // Edit lowers maxParallel and flips dispatchMode. The maxParallel change
+    // bites the next tick; dispatchMode is structural (not re-read) and is a
+    // no-op here. The 3 in-flight tickets are still gated out of the pull,
+    // and the 4th ticket cannot dispatch because freeSlots = max(0, 1-3) = 0.
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: {
+          orchestration: {
+            executionCore: { maxParallel: 1, dispatchMode: "oneshot-legacy" },
+          },
+        },
+      }),
+    );
+    for (let i = 0; i < 5; i++) {
+      appendToEventLog('{"event":"wake.CTL-676.d"}\n');
+      await new Promise((r) => setTimeout(r, 30));
+    }
+    // Still 3 — the 4th ticket did not dispatch under the lower ceiling.
+    expect(dispatch.calls.length).toBe(3);
+  });
+});
+
 // ── CTL-539: idempotent-dispatch proof — re-deriving the tick after a
 // "crash" can never double-dispatch the same {ticket, phase} ──
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -930,6 +930,16 @@ The `executionCore` block carries **only** these three concurrency keys in the
 template; `eligibleQuery` is intentionally central (registry.json, CTL-582 D4).
 :::
 
+**Hot-reload (CTL-676).** `maxParallel`, `minParallel`, and `maxParallelCeiling`
+are re-read by the execution-core scheduler on every tick (~2s under event-log
+activity via the existing `fs.watch` + 2s debounce, ~30s otherwise via the
+periodic backstop). Edits take effect on the next tick without a daemon
+restart. Lowering `maxParallel` mid-run gates new dispatch only — in-flight
+workers continue (the dispatch gate is the only consumer of the resolved
+ceiling). Other `executionCore` fields (`eligibleQuery` lives in the central
+registry; `dispatchMode` and structural daemon fields elsewhere in the config)
+remain boot-time only.
+
 Resolution order for both `phaseAgents.models` and `phaseAgents.turnCaps` is **CLI flag >
 `modelOverrides[phase][ticket]` > `models[phase]` (or `turnCaps[phase]`) > built-in default**. The
 dispatcher reads `dispatchMode` at


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-28T05:02:46Z -->
<!-- Last updated: 2026-05-28T05:02:46Z -->
<!-- PR: #1143 -->
<!-- Previous commits: 44920bb33184a3b100531234340106b974135745,2c99b4231daed4741709a9446cedd3a187c92e9c -->

## Summary

Make the `executionCore` concurrency knobs (`maxParallel` / `minParallel` / `maxParallelCeiling`)
hot-reloadable. Today they are read **once at daemon boot** and threaded into every scheduler tick,
so editing `.catalyst/config.json` has no effect until the daemon is restarted. After this PR the
scheduler re-reads the knobs **at the top of every tick** and the new value takes effect on the
next dispatch pass — no reboot, no restart, no killed workers.

This is the foundation for a future resource-monitor / auto-tuner that watches CPU/memory load and
adjusts `maxParallel` in real time: the live file read is now the single source of truth, with no
in-memory cache an external writer can't invalidate.

## Changes Made

### `scheduler.mjs` — per-tick re-read in `runTick`

- `runTick()` now re-reads the concurrency knobs by calling
  `readExecutionCoreConcurrency(runningOpts.configPath)` at the top of every tick when a
  `configPath` is wired in (production), and falls back to the boot-captured `concurrency`
  object when it isn't (back-compat for the scheduler test harnesses that never threaded
  `configPath`).
- `startScheduler({...})` gains two new optional inputs:
  - `configPath` — threaded from `startDaemon`. When set, enables per-tick re-read.
  - `liveBackgroundCount` — optional test-only seam, forwarded straight to `schedulerTick`
    (where it already defaults to `countBackgroundAgents`). Lets a unit test drive `freeSlots`
    deterministically without shelling out to `claude agents`. Symmetric with the existing
    `dispatch` / `exec` / `writeStatus` / `teardownWorktree` seams.

### `daemon.mjs` — thread `configPath` into the scheduler

- `startDaemon({...})` accepts an additional `configPath` (the resolved
  `CATALYST_CONFIG_FILE || <cwd>/.catalyst/config.json`) and forwards it into `startScheduler`
  via the existing per-tick `schedulerFn` call. `reconcileBoot` intentionally keeps the
  boot-captured `concurrency` object — it fires once before the scheduler starts and never
  re-reads.
- `main()` threads the resolved `configPath` into `startDaemon`.

### `website/src/content/docs/reference/configuration.md`

- Documents that the `executionCore` concurrency subset is now hot-reloadable, plus the
  explicitly-out-of-scope fields (orphan-reaper interval, `dispatchMode`, paths, pidFile)
  that remain boot-time only.

## Safety properties

- **Lowering `maxParallel` mid-run is non-destructive.** It does not kill live workers — it
  only gates new-work dispatch until the in-flight count drops below the new ceiling. The
  scheduler's existing `freeSlots = ceiling - in_flight` math handles the rest.
- **Raising `maxParallel` mid-run** dispatches more on the next tick, as if the daemon had
  always seen that ceiling.
- **Invalid / partial config falls back exactly as today.** `readExecutionCoreConcurrency`
  is already null / ENOENT / parse-error safe — it returns `{}`, and `readMaxParallel` falls
  through to `state.json → DEFAULT_MAX_PARALLEL`. A malformed mid-run edit fails open exactly
  the same way a fresh daemon boot against the same malformed file would.
- **Out-of-scope fields are unchanged.** The orphan-reaper interval (`setInterval` bound at
  boot), `dispatchMode`, paths, and pidFile remain boot-time only. Hot-reloading those needs
  per-field reload-safety semantics (teardown + rebind for timers, identity-stable handling
  for paths) that are deliberately out of scope here.

## How to Verify It

- [x] `bun test plugins/dev/scripts/execution-core/scheduler.test.mjs` — 5/5 CTL-676 cases
      pass (back-compat boot-captured shape, edit picks up on next tick, no in-flight kill on
      lowered ceiling, malformed-config fallback, surface pinning for the new `configPath`
      knob).
- [x] `bun test plugins/dev/scripts/execution-core/daemon.test.mjs` — 2/2 CTL-676 cases pass
      (configPath threading into `startScheduler`).
- [x] `bun test plugins/dev/scripts/execution-core/boot-resume.test.mjs` — 26/26 pass
      (reconcileBoot keeps the boot-captured object, by design).
- [x] `bun test plugins/dev/scripts/execution-core/execution-core-config-drift.test.mjs` — 5/5.
- [x] `bun test plugins/dev/scripts/execution-core/docs-drift-references.test.mjs` — 4/4.
- [x] `git merge-tree HEAD origin/main` — clean, branch is 2 commits ahead.
- [ ] Manual: start the daemon, edit `executionCore.maxParallel` in `.catalyst/config.json`,
      confirm the dispatch ceiling changes on the next tick without restart.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-676 — *Hot-reload execution-core concurrency
  knobs from config (no daemon restart)*
- Origin: CTL-665 (committed-config concurrency knobs)

Refs: CTL-676
