### PR TITLE
feat(dev): route triage/research/implement/pr phase workers to Sonnet (CTL-689)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -59,6 +59,14 @@
           "label": null,
           "priority": null
         }
+      },
+      "phaseAgents": {
+        "models": {
+          "triage": "sonnet",
+          "research": "sonnet",
+          "implement": "sonnet",
+          "pr": "sonnet"
+        }
       }
     },
     "feedback": {

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -134,7 +134,10 @@ fresh_env() {
 # ─── Test 1: dispatcher writes the per-phase signal file with the right schema
 echo "Test 1: dispatcher writes signal file with correct schema"
 fresh_env t1
-OUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>&1)
+# (CTL-689) cd into a scratch proj/ that has no parent .catalyst/config.json so
+# the "defaulted to opus" assertion isn't contaminated by the repo's shipped
+# per-phase overrides when the suite runs from the repo root.
+OUT=$(cd "${TEST_DIR}/proj" && "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>&1)
 SIGNAL="${WORKER_DIR}/phase-triage.json"
 if [[ ! -f $SIGNAL ]]; then
 	fail "signal file created: $SIGNAL"
@@ -1075,6 +1078,55 @@ assert_eq '{"committed":false,"dirty":true}' "$(cat "${GWORK}/.catalyst/config.j
 	"noise: dirty .catalyst/config.json content intact after the rebase"
 BASE_PRESENT="no"; [[ -f "${GWORK}/upstream.txt" ]] && BASE_PRESENT="yes"
 assert_eq "yes" "$BASE_PRESENT" "noise: rebase still advanced onto the new base"
+
+# ─── Test 34 (CTL-689): shipped repo config routes research/implement/pr to
+# sonnet; plan and review default to opus.
+#
+# Integration check: points --config at the repo's real `.catalyst/config.json`
+# (not a test-local synthetic) so any future drift in that file — e.g. a
+# rebased PR dropping the override or renaming `phaseAgents.models` — fails
+# this test instead of silently reverting the budget split.
+echo ""
+echo "Test 34 (CTL-689): shipped config routes triage/research/implement/pr → sonnet"
+SHIPPED_CONFIG="${REPO_ROOT}/.catalyst/config.json"
+if [[ ! -f $SHIPPED_CONFIG ]]; then
+	fail "CTL-689: shipped config not found at ${SHIPPED_CONFIG}"
+else
+	declare -A EXPECT_MODEL=(
+		[triage]=sonnet
+		[research]=sonnet
+		[implement]=sonnet
+		[pr]=sonnet
+		[plan]=opus
+		[review]=opus
+	)
+	for phase in triage research implement pr plan review; do
+		fresh_env "t34_${phase}"
+		# Seed each phase's prior-phase artifact so the gate passes.
+		case "$phase" in
+		triage) : ;; # no prior-phase artifact required
+		research) : >"${WORKER_DIR}/triage.json" ;;
+		plan)
+			mkdir -p "${TEST_DIR}/proj/thoughts/shared/research"
+			: >"${TEST_DIR}/proj/thoughts/shared/research/2026-05-28-ctl-100.md"
+			;;
+		implement)
+			mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
+			: >"${TEST_DIR}/proj/thoughts/shared/plans/2026-05-28-ctl-100.md"
+			;;
+		review) : >"${WORKER_DIR}/verify.json" ;;
+		pr) : >"${WORKER_DIR}/review.json" ;;
+		esac
+		(cd "${TEST_DIR}/proj" &&
+			"$DISPATCH" --phase "$phase" --ticket CTL-100 \
+				--orch-dir "$ORCH_DIR" --orch-id orch-test \
+				--config "$SHIPPED_CONFIG" \
+				>"${TEST_DIR}/m34_${phase}.out" 2>/dev/null)
+		MODEL=$(jq -r '.model' "${TEST_DIR}/m34_${phase}.out")
+		assert_eq "${EXPECT_MODEL[$phase]}" "$MODEL" \
+			"shipped config: phase=${phase} → ${EXPECT_MODEL[$phase]}"
+	done
+fi
 
 echo ""
 echo "─────────────────────────────────────────────"


### PR DESCRIPTION
## Summary

- Add per-phase model overrides to `.catalyst/config.json`:
  - **Sonnet**: `triage`, `research`, `implement`, `pr`
  - **Opus** (defaults, unchanged): `plan`, `verify`, `review`, `remediate`, `monitor-merge`, `monitor-deploy`
- Add integration test pointing `--config` at the real shipped config so future drift dropping/renaming the override fails CI instead of silently reverting the split.
- Tighten Test 1 to `cd` into a scratch `proj/` so its "defaulted to opus" assertion isn't contaminated by the shipped overrides when run from the repo root.

## Why

The 5-hour rate budget is per-model-class — Opus and Sonnet have separate counters. Splitting the cost-heavy phases off Opus:

1. Stretches both budgets independently — running out of Opus doesn't exhaust Sonnet.
2. Lets each turn do more work before compaction kicks in.
3. Keeps Opus on the phases where reasoning quality matters most (plan, verify, review).

## Phase rationale

| Phase | Model | Why |
|---|---|---|
| triage | sonnet | Classifier + label tagging; mechanical |
| research | sonnet | Token-heavy doc generation; mechanical synthesis |
| plan | opus | Reasoning-heavy; sets the trajectory of all downstream work |
| implement | sonnet | Single biggest token sink (Edit/Write/Bash cycles); mechanical execution of an approved plan |
| verify | opus | Adversarial verification — reasoning quality matters |
| review | opus | Adversarial review — reasoning quality matters |
| remediate | opus | Fixes verify findings — needs the same reasoning level |
| pr | sonnet | Mechanical `gh` wrapper + description generation |
| monitor-merge/deploy | opus (default) | Out of scope for this PR |

## Sub-agent inheritance

Confirmed: every agent in `plugins/dev/agents/*.md` already pins its own `model:` frontmatter (codebase-analyzer: sonnet, codebase-locator: haiku, linear-research: haiku, etc.). Task-tool spawned children resolve model from the agent definition, not the parent process — so this PR only switches parent phase workers. Sub-agents continue on their existing pins.

## How it works

`plugins/dev/scripts/phase-agent-dispatch:316-330` already supports `catalyst.orchestration.phaseAgents.models["<phase>"]` config. Pure config edit — no script changes needed.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` — 125 passed, 0 failed
- [x] New Test 34 asserts shipped config resolves triage/research/implement/pr → sonnet, plan/review → opus
- [ ] After merge: hot-patch plugin cache, restart `catalyst-execution-core`, verify next implement worker spawns with `--model sonnet` (`ps -ef | grep "claude --bg" | grep implement`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)