### PR TITLE
feat(dev): machine-level config fallback for phase-agent-dispatch (CTL-689)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -59,14 +59,6 @@
           "label": null,
           "priority": null
         }
-      },
-      "phaseAgents": {
-        "models": {
-          "triage": "sonnet",
-          "research": "sonnet",
-          "implement": "sonnet",
-          "pr": "sonnet"
-        }
       }
     },
     "feedback": {

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -123,6 +123,9 @@ fresh_env() {
 	ORCH_DIR="${TEST_DIR}/orch"
 	WORKER_DIR="${ORCH_DIR}/workers/CTL-100"
 	CONFIG_DIR="${TEST_DIR}/proj/.catalyst"
+	# (CTL-689) Point machine-config fallback at a per-test non-existent path so
+	# the user's real ~/.config/catalyst/config.json never contaminates assertions.
+	export CATALYST_MACHINE_CONFIG="${TEST_DIR}/machine-config-absent.json"
 	mkdir -p "$STUB_DIR" "$WORKER_DIR" "$CONFIG_DIR"
 	setup_claude_stub "$STUB_DIR"
 	export CLAUDE_STUB_LOG="${TEST_DIR}/claude-stub.log"
@@ -135,8 +138,9 @@ fresh_env() {
 echo "Test 1: dispatcher writes signal file with correct schema"
 fresh_env t1
 # (CTL-689) cd into a scratch proj/ that has no parent .catalyst/config.json so
-# the "defaulted to opus" assertion isn't contaminated by the repo's shipped
-# per-phase overrides when the suite runs from the repo root.
+# the "defaulted to opus" assertion isn't contaminated by the shipped repo config
+# when the suite runs from the repo root. (CATALYST_MACHINE_CONFIG already
+# neutralized for the machine-level fallback in fresh_env.)
 OUT=$(cd "${TEST_DIR}/proj" && "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>&1)
 SIGNAL="${WORKER_DIR}/phase-triage.json"
 if [[ ! -f $SIGNAL ]]; then
@@ -1079,54 +1083,85 @@ assert_eq '{"committed":false,"dirty":true}' "$(cat "${GWORK}/.catalyst/config.j
 BASE_PRESENT="no"; [[ -f "${GWORK}/upstream.txt" ]] && BASE_PRESENT="yes"
 assert_eq "yes" "$BASE_PRESENT" "noise: rebase still advanced onto the new base"
 
-# ─── Test 34 (CTL-689): shipped repo config routes research/implement/pr to
-# sonnet; plan and review default to opus.
+# ─── Test 34 (CTL-689): machine-level config fallback resolves keys absent from
+# the repo config, and the repo config wins when both define the same key.
 #
-# Integration check: points --config at the repo's real `.catalyst/config.json`
-# (not a test-local synthetic) so any future drift in that file — e.g. a
-# rebased PR dropping the override or renaming `phaseAgents.models` — fails
-# this test instead of silently reverting the budget split.
+# Why: the host-wide ~/.config/catalyst/config.json is the canonical source for
+# settings (e.g. phase model overrides) that should apply across every repo a
+# worker dispatches from. The repo `.catalyst/config.json` may still pin its own
+# overrides — those must beat the machine value.
 echo ""
-echo "Test 34 (CTL-689): shipped config routes triage/research/implement/pr → sonnet"
-SHIPPED_CONFIG="${REPO_ROOT}/.catalyst/config.json"
-if [[ ! -f $SHIPPED_CONFIG ]]; then
-	fail "CTL-689: shipped config not found at ${SHIPPED_CONFIG}"
-else
-	declare -A EXPECT_MODEL=(
-		[triage]=sonnet
-		[research]=sonnet
-		[implement]=sonnet
-		[pr]=sonnet
-		[plan]=opus
-		[review]=opus
-	)
-	for phase in triage research implement pr plan review; do
-		fresh_env "t34_${phase}"
-		# Seed each phase's prior-phase artifact so the gate passes.
-		case "$phase" in
-		triage) : ;; # no prior-phase artifact required
-		research) : >"${WORKER_DIR}/triage.json" ;;
-		plan)
-			mkdir -p "${TEST_DIR}/proj/thoughts/shared/research"
-			: >"${TEST_DIR}/proj/thoughts/shared/research/2026-05-28-ctl-100.md"
-			;;
-		implement)
-			mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
-			: >"${TEST_DIR}/proj/thoughts/shared/plans/2026-05-28-ctl-100.md"
-			;;
-		review) : >"${WORKER_DIR}/verify.json" ;;
-		pr) : >"${WORKER_DIR}/review.json" ;;
-		esac
-		(cd "${TEST_DIR}/proj" &&
-			"$DISPATCH" --phase "$phase" --ticket CTL-100 \
-				--orch-dir "$ORCH_DIR" --orch-id orch-test \
-				--config "$SHIPPED_CONFIG" \
-				>"${TEST_DIR}/m34_${phase}.out" 2>/dev/null)
-		MODEL=$(jq -r '.model' "${TEST_DIR}/m34_${phase}.out")
-		assert_eq "${EXPECT_MODEL[$phase]}" "$MODEL" \
-			"shipped config: phase=${phase} → ${EXPECT_MODEL[$phase]}"
-	done
-fi
+echo "Test 34 (CTL-689): machine-config fallback resolves missing repo keys"
+fresh_env t34_machine_only
+# Write a machine config that pins implement → sonnet. No repo config.
+cat >"${TEST_DIR}/machine-config.json" <<'EOF'
+{
+  "catalyst": {
+    "orchestration": {
+      "phaseAgents": {
+        "models": { "implement": "sonnet" }
+      }
+    }
+  }
+}
+EOF
+export CATALYST_MACHINE_CONFIG="${TEST_DIR}/machine-config.json"
+mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
+: >"${TEST_DIR}/proj/thoughts/shared/plans/2026-05-28-ctl-100.md"
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/m34_machine.out" 2>/dev/null)
+MODEL_M=$(jq -r '.model' "${TEST_DIR}/m34_machine.out")
+assert_eq "sonnet" "$MODEL_M" "machine-only: implement → sonnet (from ~/.config fallback)"
+
+echo ""
+echo "Test 34b (CTL-689): repo config beats machine config for the same key"
+fresh_env t34_repo_beats_machine
+cat >"${TEST_DIR}/machine-config.json" <<'EOF'
+{
+  "catalyst": {
+    "orchestration": {
+      "phaseAgents": {
+        "models": { "implement": "sonnet" }
+      }
+    }
+  }
+}
+EOF
+export CATALYST_MACHINE_CONFIG="${TEST_DIR}/machine-config.json"
+cat >"${CONFIG_DIR}/config.json" <<'EOF'
+{
+  "catalyst": {
+    "orchestration": {
+      "phaseAgents": {
+        "models": { "implement": "haiku" }
+      }
+    }
+  }
+}
+EOF
+mkdir -p "${TEST_DIR}/proj/thoughts/shared/plans"
+: >"${TEST_DIR}/proj/thoughts/shared/plans/2026-05-28-ctl-100.md"
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase implement --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/m34b.out" 2>/dev/null)
+MODEL_R=$(jq -r '.model' "${TEST_DIR}/m34b.out")
+assert_eq "haiku" "$MODEL_R" "repo wins: implement → haiku (repo) over sonnet (machine)"
+
+echo ""
+echo "Test 34c (CTL-689): missing key in BOTH falls through to built-in default"
+fresh_env t34_default_fallthrough
+# Empty machine config + empty repo config — should default to opus.
+echo '{}' >"${TEST_DIR}/machine-config.json"
+export CATALYST_MACHINE_CONFIG="${TEST_DIR}/machine-config.json"
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 \
+		--orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>"${TEST_DIR}/m34c.out" 2>/dev/null)
+MODEL_D=$(jq -r '.model' "${TEST_DIR}/m34c.out")
+assert_eq "opus" "$MODEL_D" "default fallthrough: triage → opus when neither config sets it"
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -233,16 +233,35 @@ resolve_config() {
 }
 CONFIG_PATH="$(resolve_config)"
 
+# (CTL-689) Machine-level fallback: keys absent from the repo `.catalyst/config.json`
+# resolve from `${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/config.json` so a single
+# host-wide source (e.g. phase model overrides) applies across every repo a worker
+# might dispatch from. `CATALYST_MACHINE_CONFIG` overrides the path for tests.
+# Precedence: repo > machine > built-in default.
+MACHINE_CONFIG_PATH="${CATALYST_MACHINE_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/config.json}"
+
 config_value() {
 	local key="$1" default="$2"
-	if [[ -z $CONFIG_PATH ]] || ! command -v jq >/dev/null 2>&1; then
+	if ! command -v jq >/dev/null 2>&1; then
 		echo "$default"
 		return
 	fi
 	local v
-	v=$(jq -r "$key // empty" "$CONFIG_PATH" 2>/dev/null)
-	[[ -z $v ]] && v="$default"
-	echo "$v"
+	if [[ -n $CONFIG_PATH && -f $CONFIG_PATH ]]; then
+		v=$(jq -r "$key // empty" "$CONFIG_PATH" 2>/dev/null)
+		if [[ -n $v ]]; then
+			echo "$v"
+			return
+		fi
+	fi
+	if [[ -f $MACHINE_CONFIG_PATH ]]; then
+		v=$(jq -r "$key // empty" "$MACHINE_CONFIG_PATH" 2>/dev/null)
+		if [[ -n $v ]]; then
+			echo "$v"
+			return
+		fi
+	fi
+	echo "$default"
 }
 
 # ─── OTEL resource attributes (CTL-492, CTL-495) ───────────────────────────


### PR DESCRIPTION
## Summary

- `phase-agent-dispatch` now consults `~/.config/catalyst/config.json` as a fallback layer when a key is absent from the repo's `.catalyst/config.json`. Precedence: **repo > machine > built-in default**.
- Override via `$CATALYST_MACHINE_CONFIG` (used by tests for hermeticity).
- Removes the `phaseAgents.models` block introduced by #1150 from the repo config — it'll live in `~/.config/catalyst/config.json` instead.

## Why

`phase-agent-dispatch` `resolve_config()` walks up from CWD looking for `.catalyst/config.json`. The daemon `cd`s into per-ticket worktrees before invoking the dispatcher — so for ADV tickets the dispatcher reads `/Users/ryan/catalyst/wt/adva/<TICKET>/.catalyst/config.json` (i.e. the adva repo's config), **not** the catalyst-workspace orchestrator config. Result: the `phaseAgents.models` override #1150 shipped only worked for CTL tickets. ADV (and every other repo using catalyst) silently fell back to opus.

Machine config gives one source of truth — same Sonnet routing across every repo without having to maintain duplicate overrides in each downstream `.catalyst/config.json`.

## How precedence works

`config_value(<jq-path>, <default>)`:
1. If repo config returns a non-empty value for the jq path → use it.
2. Else if `$CATALYST_MACHINE_CONFIG` (or `~/.config/catalyst/config.json`) returns non-empty → use it.
3. Else → built-in default.

Per-key, so repo and machine deep-merge naturally: a repo override of just `{"implement": "haiku"}` wins for implement only and lets machine values fill in the rest.

## Follow-up (out of scope — manual machine-config edit post-merge)

After merge I'll write the `phaseAgents.models` block (triage/research/implement/pr → sonnet) into `~/.config/catalyst/config.json` and restart the daemon. That doesn't go through this PR because the machine config is `.gitignore`d / lives outside the repo.

## Test plan

- [x] `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` — 122 passed, 0 failed
- [x] Test 34: machine-only override resolves when repo lacks the key
- [x] Test 34b: repo override beats machine override for the same key
- [x] Test 34c: missing key in both falls through to default opus
- [x] `fresh_env` neutralizes `CATALYST_MACHINE_CONFIG` so user's real machine config can't contaminate assertions
- [ ] After merge: write machine config, restart daemon, confirm ADV implement workers spawn with `--model sonnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)