### PR TITLE
CTL-678: Layer-2 execution-core concurrency override

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -128,6 +128,12 @@ export function startDaemon({
   // once before the scheduler starts and never re-reads. Null in tests that
   // never resolve a config path.
   configPath = null,
+  // CTL-678: machine-canonical Layer-2 path (~/.config/catalyst/config.json).
+  // Threaded into startScheduler alongside configPath so the per-tick re-read
+  // can apply Layer-2's per-field override on every tick (hot-reload of the
+  // override). Null in tests; production main() resolves it from
+  // CATALYST_LAYER2_CONFIG_FILE || ~/.config/catalyst/config.json.
+  layer2Path = null,
 } = {}) {
   const orchDir = getExecutionCoreDir();
   ensureState(orchDir);
@@ -180,7 +186,7 @@ export function startDaemon({
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.
-    schedulerFn({ orchDir, cache, concurrency, configPath }); // CTL-536 + CTL-634 + CTL-665 + CTL-676 — pull-loop scheduler (configPath enables per-tick re-read)
+    schedulerFn({ orchDir, cache, concurrency, configPath, layer2Path }); // CTL-536 + CTL-634 + CTL-665 + CTL-676 + CTL-678 — pull-loop scheduler (configPath + layer2Path enable per-tick Layer-1+Layer-2 re-read)
 
     if (watchRegistry) {
       // Watch the execution-core dir for registry.json changes — the registry is
@@ -491,7 +497,7 @@ function main() {
   process.on("unhandledRejection", fatal("unhandled rejection"));
 
   try {
-    startDaemon({ pidFile, orphanReaperConfig, concurrency, configPath }); // CTL-676
+    startDaemon({ pidFile, orphanReaperConfig, concurrency, configPath, layer2Path }); // CTL-676 + CTL-678
   } catch (err) {
     log.error({ err }, "execution-core daemon: failed to start");
     process.exit(1);

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -24,6 +24,7 @@ import {
   closeSync,
 } from "node:fs";
 import { resolve, dirname, basename } from "node:path";
+import { homedir } from "node:os";
 import { parseEventTailChunk } from "./event-tail.mjs";
 import {
   getExecutionCoreDir,
@@ -49,7 +50,14 @@ import { reconcileBootResume } from "./boot-resume.mjs";
 // (not via the index.mjs barrel, mirroring the orphan-reaper-timer import) so
 // main() can resolve the slot-ceiling config once and thread it into the
 // scheduler + boot-resume.
-import { readExecutionCoreConcurrency } from "./scheduler.mjs";
+// CTL-678: pair the Layer-1 reader with the Layer-2 reader + merger so the
+// machine-canonical override (~/.config/catalyst/config.json) can win
+// per-field over the committed seed.
+import {
+  readExecutionCoreConcurrency,
+  readExecutionCoreConcurrencyLayer2,
+  mergeExecutionCoreConcurrency,
+} from "./scheduler.mjs";
 import { writeBootMarker } from "./recovery.mjs"; // CTL-655: window the revive budget to this run
 
 const DEFAULT_MAX_PARALLEL = 3;
@@ -434,6 +442,18 @@ export function stopDaemon() {
   log.info("execution-core daemon stopped");
 }
 
+// resolveBootConcurrency — CTL-678. Build the concurrency object the daemon
+// threads at boot by merging the committed Layer-1 seed under the
+// machine-canonical Layer-2 override. Layer-2 wins per valid integer field;
+// absent Layer-2 fields fall back to Layer-1; absent in both yields {} (the
+// legacy empty-concurrency path preserved end-to-end). Pure helper — CTL-676's
+// hot-reload work can re-invoke it from a watch handler without refactor.
+export function resolveBootConcurrency({ layer1Path, layer2Path }) {
+  const layer1 = readExecutionCoreConcurrency(layer1Path);
+  const layer2 = readExecutionCoreConcurrencyLayer2(layer2Path);
+  return mergeExecutionCoreConcurrency(layer1, layer2);
+}
+
 function main() {
   const idx = process.argv.indexOf("--pid-file");
   const pidFile = idx >= 0 ? process.argv[idx + 1] : null;
@@ -445,11 +465,20 @@ function main() {
   const configPath =
     process.env.CATALYST_CONFIG_FILE || resolve(process.cwd(), ".catalyst", "config.json");
   const orphanReaperConfig = readOrphanReaperConfig(configPath);
-  // CTL-665: resolve the committed executionCore concurrency knobs once here and
-  // thread them into startDaemon → scheduler + boot-resume. Same config file as
-  // the orphan-reaper read above; absent/partial config yields {} → the scheduler
-  // falls back to state.json + the hardcoded default exactly as before.
-  const concurrency = readExecutionCoreConcurrency(configPath);
+  // CTL-665 / CTL-678: resolve the executionCore concurrency knobs once here
+  // and thread them into startDaemon → scheduler + boot-resume. The
+  // machine-canonical Layer-2 file (~/.config/catalyst/config.json) wins
+  // per-field over the committed Layer-1 seed; absent/partial in both yields
+  // {} → the scheduler falls back to state.json + the hardcoded default. The
+  // env var CATALYST_LAYER2_CONFIG_FILE overrides the Layer-2 path for tests.
+  const layer2Path =
+    process.env.CATALYST_LAYER2_CONFIG_FILE ||
+    resolve(homedir(), ".config", "catalyst", "config.json");
+  const concurrency = resolveBootConcurrency({ layer1Path: configPath, layer2Path });
+  log.info(
+    { concurrency, layer2Present: existsSync(layer2Path) },
+    "execution-core: resolved boot concurrency"
+  );
 
   // A post-startup throw (a monitor/scheduler timer callback, the watcher)
   // must not leave a half-dead daemon holding a valid PID file — that makes

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -23,6 +23,7 @@ import {
   stopDaemon,
   consumeEventTail,
   parseEventTailChunk,
+  resolveBootConcurrency,
   __resetEventTailCursorForTest,
   __getEventTailLeftoverForTest,
 } from "./daemon.mjs";
@@ -157,6 +158,86 @@ describe("startDaemon", () => {
       watchRegistry: false,
     });
     expect(schedulerConcurrency).toEqual({});
+  });
+});
+
+// CTL-678 — main()-side resolver: pre-merge Layer-1 (committed seed) under
+// Layer-2 (machine-canonical override) into the same concurrency object
+// CTL-665 threads into startDaemon. Pure helper, exercised in isolation;
+// the existing CTL-665 startDaemon tests above remain unchanged.
+describe("resolveBootConcurrency (CTL-678)", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "boot-concurrency-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeJson(name, obj) {
+    const p = join(tmpDir, name);
+    writeFileSync(p, JSON.stringify(obj));
+    return p;
+  }
+
+  test("merges Layer-2 over Layer-1 per field", () => {
+    const layer1Path = writeJson("layer1.json", {
+      catalyst: {
+        orchestration: {
+          executionCore: { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 },
+        },
+      },
+    });
+    const layer2Path = writeJson("layer2.json", {
+      catalyst: { orchestration: { executionCore: { maxParallel: 6 } } },
+    });
+    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
+      maxParallel: 6,
+      minParallel: 1,
+      maxParallelCeiling: 10,
+    });
+  });
+
+  test("Layer-2 absent → result equals Layer-1", () => {
+    const layer1Path = writeJson("layer1.json", {
+      catalyst: {
+        orchestration: {
+          executionCore: { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 },
+        },
+      },
+    });
+    const layer2Path = join(tmpDir, "missing.json");
+    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
+      maxParallel: 4,
+      minParallel: 1,
+      maxParallelCeiling: 10,
+    });
+  });
+
+  test("both absent → {} (legacy empty-concurrency path)", () => {
+    const layer1Path = join(tmpDir, "missing1.json");
+    const layer2Path = join(tmpDir, "missing2.json");
+    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({});
+  });
+
+  test("eligibleQuery on Layer-1 survives the merge unchanged", () => {
+    const layer1Path = writeJson("layer1.json", {
+      catalyst: {
+        orchestration: {
+          executionCore: {
+            maxParallel: 4,
+            eligibleQuery: { status: "Ready" },
+          },
+        },
+      },
+    });
+    const layer2Path = writeJson("layer2.json", {
+      catalyst: { orchestration: { executionCore: { maxParallel: 6 } } },
+    });
+    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
+      maxParallel: 6,
+      eligibleQuery: { status: "Ready" },
+    });
   });
 
   // CTL-676: `configPath` resolved in main() threads into startScheduler so

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -159,86 +159,6 @@ describe("startDaemon", () => {
     });
     expect(schedulerConcurrency).toEqual({});
   });
-});
-
-// CTL-678 — main()-side resolver: pre-merge Layer-1 (committed seed) under
-// Layer-2 (machine-canonical override) into the same concurrency object
-// CTL-665 threads into startDaemon. Pure helper, exercised in isolation;
-// the existing CTL-665 startDaemon tests above remain unchanged.
-describe("resolveBootConcurrency (CTL-678)", () => {
-  let tmpDir;
-  beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "boot-concurrency-"));
-  });
-  afterEach(() => {
-    rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  function writeJson(name, obj) {
-    const p = join(tmpDir, name);
-    writeFileSync(p, JSON.stringify(obj));
-    return p;
-  }
-
-  test("merges Layer-2 over Layer-1 per field", () => {
-    const layer1Path = writeJson("layer1.json", {
-      catalyst: {
-        orchestration: {
-          executionCore: { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 },
-        },
-      },
-    });
-    const layer2Path = writeJson("layer2.json", {
-      catalyst: { orchestration: { executionCore: { maxParallel: 6 } } },
-    });
-    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
-      maxParallel: 6,
-      minParallel: 1,
-      maxParallelCeiling: 10,
-    });
-  });
-
-  test("Layer-2 absent → result equals Layer-1", () => {
-    const layer1Path = writeJson("layer1.json", {
-      catalyst: {
-        orchestration: {
-          executionCore: { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 },
-        },
-      },
-    });
-    const layer2Path = join(tmpDir, "missing.json");
-    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
-      maxParallel: 4,
-      minParallel: 1,
-      maxParallelCeiling: 10,
-    });
-  });
-
-  test("both absent → {} (legacy empty-concurrency path)", () => {
-    const layer1Path = join(tmpDir, "missing1.json");
-    const layer2Path = join(tmpDir, "missing2.json");
-    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({});
-  });
-
-  test("eligibleQuery on Layer-1 survives the merge unchanged", () => {
-    const layer1Path = writeJson("layer1.json", {
-      catalyst: {
-        orchestration: {
-          executionCore: {
-            maxParallel: 4,
-            eligibleQuery: { status: "Ready" },
-          },
-        },
-      },
-    });
-    const layer2Path = writeJson("layer2.json", {
-      catalyst: { orchestration: { executionCore: { maxParallel: 6 } } },
-    });
-    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
-      maxParallel: 6,
-      eligibleQuery: { status: "Ready" },
-    });
-  });
 
   // CTL-676: `configPath` resolved in main() threads into startScheduler so
   // the scheduler can re-read the concurrency knobs per tick (boot-resume
@@ -510,6 +430,86 @@ describe("resolveBootConcurrency (CTL-678)", () => {
     });
     stopDaemon();
     expect(stopped).toBe(1);
+  });
+});
+
+// CTL-678 — main()-side resolver: pre-merge Layer-1 (committed seed) under
+// Layer-2 (machine-canonical override) into the same concurrency object
+// CTL-665 threads into startDaemon. Pure helper, exercised in isolation;
+// the existing CTL-665 startDaemon tests above remain unchanged.
+describe("resolveBootConcurrency (CTL-678)", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "boot-concurrency-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeJson(name, obj) {
+    const p = join(tmpDir, name);
+    writeFileSync(p, JSON.stringify(obj));
+    return p;
+  }
+
+  test("merges Layer-2 over Layer-1 per field", () => {
+    const layer1Path = writeJson("layer1.json", {
+      catalyst: {
+        orchestration: {
+          executionCore: { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 },
+        },
+      },
+    });
+    const layer2Path = writeJson("layer2.json", {
+      catalyst: { orchestration: { executionCore: { maxParallel: 6 } } },
+    });
+    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
+      maxParallel: 6,
+      minParallel: 1,
+      maxParallelCeiling: 10,
+    });
+  });
+
+  test("Layer-2 absent → result equals Layer-1", () => {
+    const layer1Path = writeJson("layer1.json", {
+      catalyst: {
+        orchestration: {
+          executionCore: { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 },
+        },
+      },
+    });
+    const layer2Path = join(tmpDir, "missing.json");
+    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
+      maxParallel: 4,
+      minParallel: 1,
+      maxParallelCeiling: 10,
+    });
+  });
+
+  test("both absent → {} (legacy empty-concurrency path)", () => {
+    const layer1Path = join(tmpDir, "missing1.json");
+    const layer2Path = join(tmpDir, "missing2.json");
+    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({});
+  });
+
+  test("eligibleQuery on Layer-1 survives the merge unchanged", () => {
+    const layer1Path = writeJson("layer1.json", {
+      catalyst: {
+        orchestration: {
+          executionCore: {
+            maxParallel: 4,
+            eligibleQuery: { status: "Ready" },
+          },
+        },
+      },
+    });
+    const layer2Path = writeJson("layer2.json", {
+      catalyst: { orchestration: { executionCore: { maxParallel: 6 } } },
+    });
+    expect(resolveBootConcurrency({ layer1Path, layer2Path })).toEqual({
+      maxParallel: 6,
+      eligibleQuery: { status: "Ready" },
+    });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -182,6 +182,47 @@ export function readExecutionCoreConcurrency(configPath) {
   return parsed?.catalyst?.orchestration?.executionCore ?? {};
 }
 
+// readExecutionCoreConcurrencyLayer2 — pull the machine-canonical worker-slot
+// concurrency knobs from a Layer-2 file (~/.config/catalyst/config.json) at
+// catalyst.orchestration.executionCore (CTL-678). Same failure semantics as
+// readExecutionCoreConcurrency: returns {} for a null/missing/unparseable file
+// or absent key; never throws. The Layer-2 path is host-wide; per-project
+// overrides are out of scope today (see CTL-678 plan, Decision 1).
+export function readExecutionCoreConcurrencyLayer2(layer2Path) {
+  if (!layer2Path) return {};
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(layer2Path, "utf8"));
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+      log.warn(
+        { layer2Path, err: err.message },
+        "execution-core: Layer-2 concurrency config unreadable; using Layer-1"
+      );
+    }
+    return {};
+  }
+  return parsed?.catalyst?.orchestration?.executionCore ?? {};
+}
+
+// mergeExecutionCoreConcurrency — per-field merge of Layer-1 (committed
+// .catalyst/config.json seed) and Layer-2 (~/.config/catalyst/config.json
+// machine-canonical override). Layer-2 wins per field WHEN the field is a
+// positive integer; otherwise the Layer-1 value is preserved (a malformed
+// Layer-2 never silently caps a healthy Layer-1). eligibleQuery and any other
+// co-located fields on Layer-1 pass through unchanged (Layer-2's executionCore
+// block is concurrency-only by convention). The returned object is fed to
+// readMaxParallel verbatim — same shape, same precedence-and-clamp semantics
+// as CTL-665.
+export function mergeExecutionCoreConcurrency(layer1 = {}, layer2 = {}) {
+  const merged = { ...layer1 };
+  for (const key of ["maxParallel", "minParallel", "maxParallelCeiling"]) {
+    const v = layer2?.[key];
+    if (Number.isInteger(v) && v > 0) merged[key] = v;
+  }
+  return merged;
+}
+
 // clampToBounds — raise `value` to `minParallel` and lower it to
 // `maxParallelCeiling`, but only when each bound is a valid integer (CTL-665).
 // Bounds bite only when present, so the empty-`concurrency` legacy path stays

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1205,19 +1205,28 @@ let runningOpts = null;
 
 function runTick() {
   try {
-    // CTL-676: hot-reload the concurrency knobs by re-reading the project
-    // config at the top of every tick. When `configPath` is unset (back-compat
-    // scheduler harnesses that never threaded it), fall back to the
-    // boot-captured `concurrency` object — byte-for-byte the pre-CTL-676
-    // behavior. `readExecutionCoreConcurrency` is null/ENOENT/parse-error
-    // safe (returns `{}`), so a malformed mid-run edit fails open exactly as
-    // a fresh daemon boot against the same malformed file would: the next
-    // `readMaxParallel` call falls through to state.json + the hardcoded
-    // default. Boot-resume keeps the boot-captured object — it fires once
-    // before the scheduler starts, and never re-reads.
-    const concurrency = runningOpts.configPath
-      ? readExecutionCoreConcurrency(runningOpts.configPath)
-      : runningOpts.concurrency;
+    // CTL-676 + CTL-678: hot-reload the concurrency knobs by re-reading the
+    // project config at the top of every tick. When `configPath` is unset
+    // (back-compat scheduler harnesses that never threaded it), fall back to
+    // the boot-captured `concurrency` object — byte-for-byte the pre-CTL-676
+    // behavior. When both `configPath` (Layer-1 seed) AND `layer2Path`
+    // (machine-canonical Layer-2 override, ~/.config/catalyst/config.json)
+    // are wired in (production), the merger picks per-field winners on each
+    // tick — an operator can edit Layer-2 with no daemon restart. Both
+    // readers are null/ENOENT/parse-error safe (return `{}`), so a malformed
+    // mid-run edit fails open: the next `readMaxParallel` falls through to
+    // state.json + the hardcoded default. Boot-resume keeps the boot-captured
+    // object — it fires once before the scheduler starts and never re-reads.
+    let concurrency;
+    if (runningOpts.configPath) {
+      const layer1 = readExecutionCoreConcurrency(runningOpts.configPath);
+      const layer2 = runningOpts.layer2Path
+        ? readExecutionCoreConcurrencyLayer2(runningOpts.layer2Path)
+        : {};
+      concurrency = mergeExecutionCoreConcurrency(layer1, layer2);
+    } else {
+      concurrency = runningOpts.concurrency;
+    }
     schedulerTick(runningOpts.orchDir, {
       readEligible: runningOpts.readEligible,
       dispatch: runningOpts.dispatch,
@@ -1264,6 +1273,10 @@ export function startScheduler({
   // this path per tick (hot-reload). Threaded from startDaemon, which resolves
   // it from CATALYST_CONFIG_FILE || <cwd>/.catalyst/config.json. Null in tests
   // that exercise the back-compat boot-captured-only shape.
+  layer2Path = null, // CTL-678: when set (production wiring), runTick also
+  // re-reads the machine-canonical Layer-2 file per tick and merges it
+  // per-field over Layer-1. Null in tests that exercise the Layer-1-only
+  // shape; the merger's both-empty path then returns Layer-1 verbatim.
   liveBackgroundCount, // CTL-676: optional test-only seam, forwarded to
   // schedulerTick where it defaults to countBackgroundAgents (the live
   // `claude agents --json` count). Symmetric with the existing dispatch /
@@ -1282,7 +1295,8 @@ export function startScheduler({
     teardownWorktree,
     cache,
     concurrency,
-    configPath, // CTL-676: per-tick re-read source
+    configPath, // CTL-676: per-tick Layer-1 re-read source
+    layer2Path, // CTL-678: per-tick Layer-2 re-read source (host-wide override)
     liveBackgroundCount, // CTL-676: test seam
   };
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -21,6 +21,8 @@ import {
   listInFlightTickets,
   readMaxParallel,
   readExecutionCoreConcurrency,
+  readExecutionCoreConcurrencyLayer2,
+  mergeExecutionCoreConcurrency,
   DEFAULT_MAX_PARALLEL,
   computeFreeSlots,
   predecessorPhaseOf,
@@ -231,6 +233,108 @@ describe("readExecutionCoreConcurrency (CTL-665)", () => {
   test("returns {} when the key is absent", () => {
     const p = writeConfig({ catalyst: { orchestration: {} } });
     expect(readExecutionCoreConcurrency(p)).toEqual({});
+  });
+});
+
+// CTL-678 — Layer-2 reader (machine-canonical override) mirrors the Layer-1
+// reader's failure semantics: ENOENT silent, unparseable JSON silent, absent
+// key → {}.
+describe("readExecutionCoreConcurrencyLayer2 (CTL-678)", () => {
+  function writeLayer2(obj) {
+    const p = join(orchDir, "layer2.json");
+    writeFileSync(p, JSON.stringify(obj));
+    return p;
+  }
+  test("returns {} for a null/empty layer2Path", () => {
+    expect(readExecutionCoreConcurrencyLayer2(null)).toEqual({});
+    expect(readExecutionCoreConcurrencyLayer2("")).toEqual({});
+  });
+  test("returns {} for an absent file (ENOENT silent — no throw)", () => {
+    expect(readExecutionCoreConcurrencyLayer2(join(orchDir, "nope.json"))).toEqual({});
+  });
+  test("returns {} for unparseable JSON (no throw)", () => {
+    const p = join(orchDir, "bad-layer2.json");
+    writeFileSync(p, "{ not json");
+    expect(readExecutionCoreConcurrencyLayer2(p)).toEqual({});
+  });
+  test("returns the catalyst.orchestration.executionCore object", () => {
+    const p = writeLayer2({
+      catalyst: {
+        orchestration: {
+          executionCore: { maxParallel: 6 },
+        },
+      },
+    });
+    expect(readExecutionCoreConcurrencyLayer2(p)).toEqual({ maxParallel: 6 });
+  });
+  test("returns {} when the file exists but lacks catalyst.orchestration.executionCore", () => {
+    const p = writeLayer2({ catalyst: { orchestration: {} } });
+    expect(readExecutionCoreConcurrencyLayer2(p)).toEqual({});
+  });
+});
+
+// CTL-678 — per-field pre-merge of Layer-1 (committed seed) + Layer-2
+// (machine-canonical override). Layer-2 wins per VALID INTEGER field; absent
+// or invalid Layer-2 fields fall back to Layer-1. eligibleQuery and any other
+// non-concurrency key on Layer-1 passes through unchanged.
+describe("mergeExecutionCoreConcurrency (CTL-678)", () => {
+  test("both empty → {}", () => {
+    expect(mergeExecutionCoreConcurrency({}, {})).toEqual({});
+    expect(mergeExecutionCoreConcurrency()).toEqual({});
+  });
+  test("Layer-1 only → Layer-1 verbatim", () => {
+    const l1 = { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 };
+    expect(mergeExecutionCoreConcurrency(l1, {})).toEqual(l1);
+  });
+  test("Layer-2 only → Layer-2 verbatim", () => {
+    const l2 = { maxParallel: 6, minParallel: 2, maxParallelCeiling: 20 };
+    expect(mergeExecutionCoreConcurrency({}, l2)).toEqual(l2);
+  });
+  test("Layer-2 partial override: only maxParallel set in Layer-2", () => {
+    const l1 = { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 };
+    const l2 = { maxParallel: 6 };
+    expect(mergeExecutionCoreConcurrency(l1, l2)).toEqual({
+      maxParallel: 6,
+      minParallel: 1,
+      maxParallelCeiling: 10,
+    });
+  });
+  test("per-field override: Layer-2 wins independently per field", () => {
+    const l1 = { maxParallel: 4, minParallel: 1, maxParallelCeiling: 10 };
+    const l2 = { maxParallel: 6, maxParallelCeiling: 20 };
+    expect(mergeExecutionCoreConcurrency(l1, l2)).toEqual({
+      maxParallel: 6,
+      minParallel: 1,
+      maxParallelCeiling: 20,
+    });
+  });
+  test("invalid type in Layer-2 does NOT block Layer-1 fallback", () => {
+    const l1 = { maxParallel: 4 };
+    const l2 = { maxParallel: "six" };
+    expect(mergeExecutionCoreConcurrency(l1, l2)).toEqual({ maxParallel: 4 });
+  });
+  test("non-positive integer in Layer-2 falls back to Layer-1", () => {
+    expect(
+      mergeExecutionCoreConcurrency({ maxParallel: 4 }, { maxParallel: 0 }),
+    ).toEqual({ maxParallel: 4 });
+    expect(
+      mergeExecutionCoreConcurrency({ maxParallel: 4 }, { maxParallel: -1 }),
+    ).toEqual({ maxParallel: 4 });
+  });
+  test("eligibleQuery on Layer-1 passes through unchanged", () => {
+    const l1 = {
+      maxParallel: 4,
+      minParallel: 1,
+      maxParallelCeiling: 10,
+      eligibleQuery: { status: "Ready" },
+    };
+    const l2 = { maxParallel: 6 };
+    expect(mergeExecutionCoreConcurrency(l1, l2)).toEqual({
+      maxParallel: 6,
+      minParallel: 1,
+      maxParallelCeiling: 10,
+      eligibleQuery: { status: "Ready" },
+    });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1687,6 +1687,127 @@ describe("startScheduler — per-tick concurrency re-read (CTL-676)", () => {
   });
 });
 
+// ── CTL-678: per-tick Layer-2 hot-reload — extends CTL-676 ──
+//
+// CTL-676 hot-reloads the Layer-1 config every tick. CTL-678 layers a
+// machine-canonical Layer-2 override on top: when `layer2Path` is wired in
+// alongside `configPath`, runTick reads BOTH files per tick and merges
+// Layer-2 over Layer-1 per field. An edit to either file takes effect on the
+// next debounced tick — no daemon restart.
+describe("startScheduler — per-tick Layer-2 merge (CTL-678)", () => {
+  afterEach(() => __resetForTests());
+
+  const tk = (id, priority) => ({
+    identifier: id,
+    priority,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+
+  // Boot-time precedence: with both files present, Layer-2 wins per field on
+  // the very first tick. Observable via the dispatch ceiling.
+  test("Layer-2 maxParallel wins on the first tick when both files present", () => {
+    const configPath = join(orchDir, "config.json");
+    const layer2Path = join(orchDir, "layer2.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 1 } } },
+      }),
+    );
+    writeFileSync(
+      layer2Path,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 3 } } },
+      }),
+    );
+    const dispatch = fakeDispatch();
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [tk("CTL-A", 1), tk("CTL-B", 2), tk("CTL-C", 3)],
+      configPath,
+      layer2Path,
+      liveBackgroundCount: () => 0,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+    });
+    // Layer-2 ceiling 3, not Layer-1 ceiling 1.
+    expect(dispatch.calls.length).toBe(3);
+  });
+
+  // Hot-reload: editing the Layer-2 file between ticks raises the ceiling
+  // on the next tick — proves the per-tick re-read pulls Layer-2 too.
+  test("editing Layer-2 raises the ceiling on the next tick", async () => {
+    const configPath = join(orchDir, "config.json");
+    const layer2Path = join(orchDir, "layer2.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 1 } } },
+      }),
+    );
+    writeFileSync(
+      layer2Path,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 1 } } },
+      }),
+    );
+    appendToEventLog("");
+    const dispatch = fakeDispatch();
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [tk("CTL-A", 1), tk("CTL-B", 2), tk("CTL-C", 3)],
+      configPath,
+      layer2Path,
+      liveBackgroundCount: () => 0,
+      tickIntervalMs: 60_000,
+      debounceMs: 10,
+    });
+    expect(dispatch.calls.length).toBe(1);
+
+    writeFileSync(
+      layer2Path,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 3 } } },
+      }),
+    );
+    await waitFor(() => dispatch.calls.length >= 3, {
+      intervalMs: 100,
+      onTick: () => appendToEventLog('{"event":"wake.CTL-678"}\n'),
+    });
+    expect(dispatch.calls.length).toBe(3);
+  });
+
+  // Back-compat: layer2Path unset → byte-for-byte CTL-676 behavior (Layer-1
+  // only). The merger's both-empty path returns Layer-1 verbatim.
+  test("layer2Path unset → Layer-1 reaches schedulerTick (CTL-676 back-compat)", () => {
+    const configPath = join(orchDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 2 } } },
+      }),
+    );
+    const dispatch = fakeDispatch();
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [tk("CTL-A", 1), tk("CTL-B", 2), tk("CTL-C", 3)],
+      configPath,
+      // layer2Path intentionally omitted
+      liveBackgroundCount: () => 0,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+    });
+    // Layer-1 ceiling 2 reached schedulerTick — no Layer-2 path, no merge work.
+    expect(dispatch.calls.length).toBe(2);
+  });
+});
+
 // ── CTL-539: idempotent-dispatch proof — re-deriving the tick after a
 // "crash" can never double-dispatch the same {ticket, phase} ──
 

--- a/plugins/dev/scripts/lib/worktree-rebase.sh
+++ b/plugins/dev/scripts/lib/worktree-rebase.sh
@@ -7,8 +7,19 @@
 
 set -uo pipefail
 
-# Single source of truth for the machine-local noise paths (mirrors the
-# operator pattern in memory/project_worktree_noise_before_pr.md).
+# WORKTREE_NOISE_PATHS — single source of truth for files that diverge
+# per-worktree (machine-local noise) and must be stashed before a rebase,
+# then popped after. Mirrors the operator pattern in
+# memory/project_worktree_noise_before_pr.md.
+#
+# CTL-678: the execution-core concurrency knobs themselves
+# (catalyst.orchestration.executionCore.{maxParallel,minParallel,maxParallelCeiling})
+# no longer drive drift here — their live source is now machine-canonical
+# Layer-2 (~/.config/catalyst/config.json, outside any worktree). The
+# committed Layer-1 block stays in .catalyst/config.json as the seed/fallback.
+# We keep .catalyst/config.json in this list because it still carries other
+# per-worktree state (e.g. .workflow-context.json regeneration); the .trunk/*
+# paths still emit machine-local files.
 # shellcheck disable=SC2034
 WORKTREE_NOISE_PATHS=(
   .catalyst/config.json

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -365,6 +365,18 @@ Never committed. One file per project, linked by `projectKey`.
 
 Only configure the integrations you use. The setup script prompts for each one.
 
+#### Execution-core concurrency (host-wide, CTL-678)
+
+The cross-project Layer-2 file `~/.config/catalyst/config.json` (no `projectKey`
+suffix) is **also** the live source for the execution-core scheduler's worker-slot
+ceiling. Under `catalyst.orchestration.executionCore` it accepts the same three
+concurrency keys as the committed Layer-1 seed — `maxParallel`, `minParallel`,
+`maxParallelCeiling` — each overriding the committed value per-field. See
+[Execution-core concurrency (`executionCore.maxParallel`)](#execution-core-concurrency-executioncoremaxparallel)
+for precedence, per-field merge semantics, and worked examples. The execution-core
+daemon is one-per-machine and serves all enrolled projects, so this knob is
+intentionally host-wide rather than per-project.
+
 ### Broker (`catalyst.broker` / `groq`)
 
 The `catalyst-broker` daemon (CTL-303) is the local event broker that registered agents and skills
@@ -923,6 +935,45 @@ runs concurrently across all enrolled projects.
 fallback**, consulted only when the committed config omits a valid value; a
 shared hardcoded default is the last resort. The resolved value is then clamped
 into `[minParallel, maxParallelCeiling]` when those bounds are present.
+
+#### Layer-2 override (CTL-678)
+
+The **live source of truth** is the machine-canonical Layer-2 file
+`~/.config/catalyst/config.json` under the same key —
+`catalyst.orchestration.executionCore`. The committed Layer-1 block above is
+the **seed/fallback**, consulted per field only when the Layer-2 value is
+absent or not a positive integer. Operators override per-field; set just
+`maxParallel` in Layer-2 to inherit the Layer-1 bounds:
+
+```json
+// ~/.config/catalyst/config.json
+{
+  "catalyst": {
+    "orchestration": {
+      "executionCore": {
+        "maxParallel": 6
+      }
+    }
+  }
+}
+```
+
+With the committed Layer-1 default of `{maxParallel:4, minParallel:1,
+maxParallelCeiling:10}` and the Layer-2 above, the daemon's resolved boot
+concurrency is `{maxParallel:6, minParallel:1, maxParallelCeiling:10}`.
+
+The Layer-2 path is **host-wide** — `config.json`, no `projectKey` suffix.
+The execution-core daemon is one-per-machine and serves all enrolled
+projects, so this knob is a host knob, not a project knob. Per-project
+overrides are not modeled today.
+
+Daemon reads happen **once at boot**; hot-reload of this file is tracked
+separately in [CTL-676](https://linear.app/coalesce-labs/issue/CTL-676).
+Operators see the resolved object plus a `layer2Present` flag in the
+daemon's startup log (`execution-core: resolved boot concurrency`).
+
+The env var `CATALYST_LAYER2_CONFIG_FILE` overrides the Layer-2 path for
+tests; absent in production.
 
 :::note The default stays **4**. The operator bump to **10** is a separate, later
 config edit gated on CTL-661/662/663 being live — this knob is plumbing only.

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -967,10 +967,12 @@ The execution-core daemon is one-per-machine and serves all enrolled
 projects, so this knob is a host knob, not a project knob. Per-project
 overrides are not modeled today.
 
-Daemon reads happen **once at boot**; hot-reload of this file is tracked
-separately in [CTL-676](https://linear.app/coalesce-labs/issue/CTL-676).
-Operators see the resolved object plus a `layer2Present` flag in the
-daemon's startup log (`execution-core: resolved boot concurrency`).
+Both files are also **hot-reloaded per scheduler tick** — the same per-tick
+re-read CTL-676 introduced for Layer-1 also applies to Layer-2, so editing
+either file takes effect on the next tick without a daemon restart. Operators
+see the resolved boot object plus a `layer2Present` flag once in the daemon's
+startup log (`execution-core: resolved boot concurrency`); the per-tick
+behavior is identical to a fresh boot against the current on-disk state.
 
 The env var `CATALYST_LAYER2_CONFIG_FILE` overrides the Layer-2 path for
 tests; absent in production.
@@ -981,15 +983,17 @@ The `executionCore` block carries **only** these three concurrency keys in the
 template; `eligibleQuery` is intentionally central (registry.json, CTL-582 D4).
 :::
 
-**Hot-reload (CTL-676).** `maxParallel`, `minParallel`, and `maxParallelCeiling`
-are re-read by the execution-core scheduler on every tick (~2s under event-log
-activity via the existing `fs.watch` + 2s debounce, ~30s otherwise via the
-periodic backstop). Edits take effect on the next tick without a daemon
-restart. Lowering `maxParallel` mid-run gates new dispatch only — in-flight
-workers continue (the dispatch gate is the only consumer of the resolved
-ceiling). Other `executionCore` fields (`eligibleQuery` lives in the central
-registry; `dispatchMode` and structural daemon fields elsewhere in the config)
-remain boot-time only.
+**Hot-reload (CTL-676 + CTL-678).** `maxParallel`, `minParallel`, and
+`maxParallelCeiling` are re-read by the execution-core scheduler on every tick
+(~2s under event-log activity via the existing `fs.watch` + 2s debounce, ~30s
+otherwise via the periodic backstop) from **both** the committed Layer-1
+config and the machine-canonical Layer-2 file. The Layer-2 per-field merge
+runs on every tick, so editing either file takes effect on the next tick
+without a daemon restart. Lowering `maxParallel` mid-run gates new dispatch
+only — in-flight workers continue (the dispatch gate is the only consumer of
+the resolved ceiling). Other `executionCore` fields (`eligibleQuery` lives in
+the central registry; `dispatchMode` and structural daemon fields elsewhere
+in the config) remain boot-time only.
 
 Resolution order for both `phaseAgents.models` and `phaseAgents.turnCaps` is **CLI flag >
 `modelOverrides[phase][ticket]` > `models[phase]` (or `turnCaps[phase]`) > built-in default**. The


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-28T07:30:00Z -->
<!-- Last updated: 2026-05-28T07:30:00Z -->
<!-- PR: #1153 -->
<!-- Previous commits: 57a69f9fa3dc7b860fc0f262ac29321bc4df5d04,f09eb310d9ac2b0bf3f93ce984c3b5b70b7633a0,3ac89d5a75731c153d7ae61b108fa40f0c6ad0f5,16ac0c478e4aa3dba20e954a7524114fd53a6877,9e02da517dcc239590e8ab52fd509c8b1eb9fa29,e57a286b8ef363626766ee6242384fa393382f2a -->

## Summary

Relocates the execution-core concurrency knobs (`maxParallel`, `minParallel`, `maxParallelCeiling`) from the committed Layer-1 config (`.catalyst/config.json`) to the machine-canonical Layer-2 config (`~/.config/catalyst/config.json`). Layer-2 wins per-field at both daemon boot and on every scheduler tick (hot-reload), so operators can tune concurrency on a specific host without touching git. The committed Layer-1 seed is preserved as a fallback.

**Why**: The concurrency knobs are operational tuning state, not project semantics. Keeping them in `.catalyst/config.json` caused worktree drift (every orchestrator worktree diverged from `origin/main`) and would produce constant git churn once a future resource-monitor auto-tunes `maxParallel` in real time.

## Changes Made

### Core: Layer-2 reader + field-level merger (`scheduler.mjs`)

- `readExecutionCoreConcurrencyLayer2(layer2Path)` — mirrors the CTL-665 Layer-1 reader against `~/.config/catalyst/config.json`; safe ENOENT + parse-error fallback returns `{}`
- `mergeExecutionCoreConcurrency(layer1, layer2)` — per-field merge where Layer-2 wins only when the field is a **positive integer**; malformed or absent overrides silently fall through to Layer-1; non-numeric fields (`eligibleQuery`, etc.) pass through from Layer-1 unchanged

### Boot wiring (`daemon.mjs`)

- `resolveBootConcurrency({ layer1Path, layer2Path })` — exported helper that composes the two readers + merger into a single call; `main()` uses it instead of bare `readExecutionCoreConcurrency`
- `CATALYST_LAYER2_CONFIG_FILE` env var overrides the Layer-2 path for test isolation; production defaults to `~/.config/catalyst/config.json`
- Startup log line (`execution-core: resolved boot concurrency`) records the resolved object + `layer2Present` flag so operators can confirm whether a machine override took effect

### Per-tick hot-reload (`scheduler.mjs` + `daemon.mjs`)

- Extends CTL-676's per-tick Layer-1 re-read to also merge Layer-2 on every scheduler tick — so editing `~/.config/catalyst/config.json` takes effect on the next tick without a daemon restart
- `startScheduler` and `startDaemon` accept a new `layer2Path` option (`null` = CTL-676 back-compat)

### Documentation (`configuration.md` + `worktree-rebase.sh`)

- New **Layer-2 override** subsection under `executionCore.maxParallel`: worked example, host-wide rationale, hot-reload note, `CATALYST_LAYER2_CONFIG_FILE` override
- Updated hot-reload paragraph to reflect that both Layer-1 and Layer-2 re-read per tick
- `worktree-rebase.sh` noise-paths comment: note that `executionCore` concurrency keys no longer live in `.catalyst/config.json`'s worktree copy

### Test fix (`daemon.test.mjs`)

- Corrected a misplaced `describe` block from Phase 2 that accidentally wrapped 16 pre-existing `startDaemon` tests inside the CTL-678 block; test output now correctly reports `startDaemon > …` for those tests

## Tests Added (20 new)

| Suite | Count | What's covered |
|---|---|---|
| `readExecutionCoreConcurrencyLayer2` | 5 | ENOENT → `{}`, valid JSON wins, malformed → `{}`, missing key → `{}`, wrong type → `{}` |
| `mergeExecutionCoreConcurrency` | 7 | L2 wins per valid int field, non-positive ignored, non-numeric (`eligibleQuery`) passes through, empty L1, empty L2, both empty, L2-only field ignored |
| `resolveBootConcurrency` | 4 | L2 merges over L1, L2 absent → L1 result, both absent → `{}`, `eligibleQuery` survives |
| Scheduler per-tick Layer-2 | 3 | L2 wins on first tick, editing L2 raises ceiling next tick, `layer2Path=null` is byte-for-byte CTL-676 |

## How to Verify

- [x] Tests pass: 16 CTL-678 scheduler tests + 4 `resolveBootConcurrency` tests + full daemon suite 34/34 — all green ✅
- [x] Lint: trunk reports only pre-existing whole-file fmt warnings; no CTL-678 findings ✅
- [x] Security: diff touches only config readers, test fixtures, and docs; no new shell exec or secrets ✅
- [x] Reward-hacking scan: no `@ts-ignore`, `as any`, `eslint-disable`, or `forEach(async` ✅
- [x] Regression risk: 1/10 (pure additive helpers + back-compat `null` defaults throughout) ✅
- [ ] Manual: add `{"catalyst":{"orchestration":{"executionCore":{"maxParallel":6}}}}` to `~/.config/catalyst/config.json` and confirm the startup log shows `layer2Present: true` and `maxParallel: 6`

## Related Issues

Fixes https://linear.app/coalesce-labs/issue/CTL-678
