### PR TITLE
feat(dev): boot-resume passes --resume-session for true session continuation (CTL-690)

### DIFF
--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -1,4 +1,4 @@
-// boot-resume.mjs — execution-core daemon boot-resume (CTL-654).
+// boot-resume.mjs — execution-core daemon boot-resume (CTL-654, CTL-690).
 //
 // On a real reboot every prior `claude --bg` phase worker is provably dead at
 // once. The per-tick reclaim sweep (recovery.mjs::reclaimDeadWorkIfPossible) is
@@ -9,11 +9,22 @@
 // This module is a dedicated, synchronous boot-reconciliation pass that runs
 // once at daemon boot (between recover() and the monitor). For each in-flight
 // ticket whose persisted worktreePath has no live background session it
-// re-dispatches a fresh worker at the ticket's current phase via
+// re-dispatches a worker at the ticket's current phase via
 // defaultReviveDispatch — which bypasses the revive budget by construction (the
 // budget lives in reclaimDeadWorkIfPossible, not in the dispatch primitive) and
 // keeps the CTL-615 worktree-path cross-check. The fan-out is bounded by
 // maxParallel so a reboot never spawns a worker storm.
+//
+// CTL-690 — session continuation. Each candidate's bg_job_id is mapped (via
+// the same resolvePhaseSessionId helper recovery.mjs:1265 uses on the per-tick
+// reclaim path) to a `claude --resume`-compatible UUID. When that resolves, the
+// dispatcher relaunches `claude --bg --resume <uuid>` so the worker continues
+// where it left off. When it does NOT resolve (legacy signal, transcript
+// missing, etc.) the candidate falls through to today's fresh-dispatch path —
+// preserving the unchanged-from-CTL-654 fallback. Resume-launch failures are
+// reclassified by phase-agent-dispatch (CTL-658 launched/alive/failed) which
+// itself falls back to a fresh start inside the same dispatcher invocation, so
+// boot-resume never has to retry.
 //
 // Phase 1 (this section) is pure selection logic, dependency-free beyond the
 // scheduler/signal-reader read helpers, and exhaustively unit-tested. The
@@ -22,7 +33,11 @@
 import { readWorkerSignals, TERMINAL, byActivePhase } from "./signal-reader.mjs";
 import { listInFlightTickets, readMaxParallel, computeFreeSlots } from "./scheduler.mjs";
 import { log } from "./config.mjs";
-import { defaultReviveDispatch, defaultAppendBootResumeEvent } from "./recovery.mjs";
+import {
+  defaultReviveDispatch,
+  defaultAppendBootResumeEvent,
+  resolvePhaseSessionId,
+} from "./recovery.mjs";
 import { defaultDispatch } from "./dispatch.mjs";
 // liveAgents() is synchronous (execFileSync `claude agents --json`). A static
 // import is safe here: cli/sessions.mjs imports only signal-reader/reap-intent/
@@ -60,8 +75,9 @@ export function activePhaseForTicket(signals) {
 
 // selectBootResumeCandidates — the set of in-flight tickets that need a fresh
 // worker, bounded by free slots. Pure over the filesystem + the supplied agents
-// list. Returns `{ ticket, phase, worktreePath }[]`, deterministically sorted by
-// ticket id and sliced to the free-slot cap so a reboot never over-dispatches.
+// list. Returns `{ ticket, phase, worktreePath, bgJobId }[]`, deterministically
+// sorted by ticket id and sliced to the free-slot cap so a reboot never
+// over-dispatches.
 //
 //   1. inFlight  = the tickets currently occupying a worker slot.
 //   2. signals   = one active signal per ticket (readWorkerSignals already
@@ -73,6 +89,12 @@ export function activePhaseForTicket(signals) {
 //                  so the boot pass and the surviving workers together stay under
 //                  the cap.
 //   5. return the no-live-worker candidates sorted by ticket id, sliced to free.
+//
+// CTL-690: bgJobId is captured from the active signal so reconcileBootResume
+// can resolve a `claude --resume`-compatible UUID and continue the dead
+// worker's session instead of starting fresh. May be null on legacy signals or
+// when the worker died before any bg job was recorded — the reconcile pass
+// treats null as "fresh dispatch", preserving today's behavior for those rows.
 export function selectBootResumeCandidates({
   orchDir,
   agents,
@@ -109,7 +131,17 @@ export function selectBootResumeCandidates({
     if (hasLiveBgWorker(agents, active.worktreePath)) {
       liveCount++;
     } else {
-      needResume.push({ ticket, phase: active.phase, worktreePath: active.worktreePath });
+      // CTL-690: capture bg_job_id (signal-reader exposes it as liveness.value
+      // when liveness.kind === 'bg'). The reconcile pass resolves it to a
+      // resume-compatible UUID; legacy/missing values stay null and the
+      // candidate falls back to fresh dispatch downstream.
+      const bgJobId = active.liveness?.kind === "bg" ? active.liveness.value : null;
+      needResume.push({
+        ticket,
+        phase: active.phase,
+        worktreePath: active.worktreePath,
+        bgJobId,
+      });
     }
   }
 
@@ -144,6 +176,12 @@ export function reconcileBootResume({
   dispatch = defaultDispatch, // inner seam handed to reviveDispatch
   reviveDispatch = defaultReviveDispatch,
   appendEvent = defaultAppendBootResumeEvent,
+  // CTL-690: session resolver — same helper recovery.mjs:1265 uses on the
+  // per-tick reclaim path so boot-resume and reclaim share resume semantics.
+  // Injectable so tests can drive both the resumable + unresumable branches
+  // without touching real ~/.claude/jobs state. Returns a UUID string when the
+  // dead worker's transcript is on disk, or null when not resumable.
+  resolveSession = resolvePhaseSessionId,
   orchId = undefined, // threaded into the audit envelope
   concurrency = {}, // CTL-665: committed executionCore concurrency knobs (from startDaemon)
 } = {}) {
@@ -155,29 +193,49 @@ export function reconcileBootResume({
   const candidates = selectBootResumeCandidates({ orchDir, agents: liveAgentList, concurrency });
 
   let dispatched = 0;
+  let resumed = 0;
   let failed = 0;
-  for (const { ticket, phase } of candidates) {
+  for (const { ticket, phase, bgJobId } of candidates) {
+    // CTL-690: try to map the dead worker's bg_job_id → resume UUID. Null
+    // result (no bg id, no state.json, no/!.jsonl transcript) falls through
+    // to the today-default fresh-dispatch path. The downstream stderr
+    // classifier in phase-agent-dispatch (CTL-658 launched/alive/failed)
+    // handles a resume that's recorded on disk but fails to launch.
+    let resumeSession = null;
+    if (bgJobId) {
+      try {
+        resumeSession = resolveSession(bgJobId);
+      } catch (err) {
+        log.warn(
+          { ticket, phase, bgJobId, err: err?.message ?? String(err) },
+          "boot-resume: resolveSession threw — falling back to fresh dispatch"
+        );
+        resumeSession = null;
+      }
+    }
+
     let res;
     try {
-      res = reviveDispatch({ orchDir, ticket, phase }, { dispatch });
+      res = reviveDispatch({ orchDir, ticket, phase, resumeSession }, { dispatch });
     } catch (err) {
       res = { code: 1, stderr: err?.message ?? String(err) };
     }
     if (res?.code === 0) {
       dispatched++;
+      if (resumeSession) resumed++;
       appendEvent({ phase, ticket, orchId });
     } else {
       failed++;
       log.warn(
-        { ticket, phase, code: res?.code, stderr: res?.stderr },
+        { ticket, phase, code: res?.code, stderr: res?.stderr, resumeSession },
         "boot-resume: dispatch failed (continuing)"
       );
     }
   }
 
   log.info(
-    { dispatched, failed, candidates: candidates.length },
+    { dispatched, resumed, failed, candidates: candidates.length },
     "boot-resume: cold-start reconciliation complete"
   );
-  return { dispatched, failed, candidates: candidates.length };
+  return { dispatched, resumed, failed, candidates: candidates.length };
 }

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -117,7 +117,31 @@ describe("selectBootResumeCandidates", () => {
     writeSignal(orchDir, "CTL-B", "verify", { worktreePath: "/wt/CTL-B" });
     const agents = [{ kind: "background", cwd: "/wt/CTL-A" }];
     const out = selectBootResumeCandidates({ orchDir, agents, maxParallel: 3 });
-    expect(out).toEqual([{ ticket: "CTL-B", phase: "verify", worktreePath: "/wt/CTL-B" }]);
+    // CTL-690: bgJobId is now also captured on each candidate so reconcile
+    // can resolve a resume UUID. writeSignal's default bg_job_id is 'deadbeef'.
+    expect(out).toEqual([
+      { ticket: "CTL-B", phase: "verify", worktreePath: "/wt/CTL-B", bgJobId: "deadbeef" },
+    ]);
+  });
+
+  // CTL-690: every candidate exposes bgJobId from the active signal's liveness
+  // field so reconcileBootResume can map it to a `--resume`-compatible UUID.
+  // Legacy signals without a bg_job_id surface bgJobId === null and fall back
+  // to fresh dispatch downstream.
+  test("captures bgJobId per candidate; null when the signal lacks bg_job_id (CTL-690)", () => {
+    writeSignal(orchDir, "CTL-1", "implement", {
+      worktreePath: "/wt/CTL-1",
+      bg_job_id: "abc12345",
+    });
+    writeSignal(orchDir, "CTL-2", "implement", {
+      worktreePath: "/wt/CTL-2",
+      bg_job_id: null,
+    });
+    const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 3 });
+    expect(out.map((c) => ({ ticket: c.ticket, bgJobId: c.bgJobId }))).toEqual([
+      { ticket: "CTL-1", bgJobId: "abc12345" },
+      { ticket: "CTL-2", bgJobId: null },
+    ]);
   });
 
   test("excludes an in-flight ticket whose active signal lacks a worktreePath, recording a warn", () => {
@@ -344,6 +368,167 @@ describe("reconcileBootResume", () => {
     });
     expect(res.dispatched).toBe(0);
     expect(res.failed).toBe(1);
+  });
+
+  // ── CTL-690: --resume-session continuation ─────────────────────────────
+  //
+  // The reconcile pass must thread the dead worker's bg_job_id through
+  // resolveSession() and forward the resulting UUID to reviveDispatch as
+  // `resumeSession`. The downstream phase-agent-dispatch (CTL-658) translates
+  // that into `claude --bg --resume <uuid>`. When resolveSession returns null
+  // (no transcript on disk, legacy signal, etc.) the candidate falls back to
+  // today's fresh-dispatch behavior — preserving the unchanged-from-CTL-654
+  // fallback path.
+  test("forwards resumeSession to reviveDispatch when resolveSession returns a UUID (CTL-690)", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-1", "implement", {
+      worktreePath: "/wt/CTL-1",
+      bg_job_id: "abc12345",
+    });
+    const calls = [];
+    const reviveDispatch = (args, _opts) => {
+      calls.push(args);
+      return { code: 0 };
+    };
+    const resolveSession = (bgJobId) => (bgJobId === "abc12345" ? "uuid-1111" : null);
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch,
+      resolveSession,
+      appendEvent: () => {},
+    });
+    expect(res.dispatched).toBe(1);
+    expect(res.resumed).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      orchDir,
+      ticket: "CTL-1",
+      phase: "implement",
+      resumeSession: "uuid-1111",
+    });
+  });
+
+  test("falls back to fresh dispatch (resumeSession=null) when resolveSession returns null (CTL-690)", () => {
+    writeMaxParallel(orchDir, 3);
+    // bg_job_id is recorded but the transcript is gone → resolveSession → null.
+    writeSignal(orchDir, "CTL-1", "implement", {
+      worktreePath: "/wt/CTL-1",
+      bg_job_id: "nope9999",
+    });
+    const calls = [];
+    const reviveDispatch = (args, _opts) => {
+      calls.push(args);
+      return { code: 0 };
+    };
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch,
+      resolveSession: () => null,
+      appendEvent: () => {},
+    });
+    expect(res.dispatched).toBe(1);
+    expect(res.resumed).toBe(0);
+    expect(calls[0]).toMatchObject({
+      orchDir,
+      ticket: "CTL-1",
+      phase: "implement",
+      resumeSession: null,
+    });
+  });
+
+  test("legacy signal with no bg_job_id skips resolveSession and falls back to fresh dispatch (CTL-690)", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-1", "implement", {
+      worktreePath: "/wt/CTL-1",
+      bg_job_id: null,
+    });
+    const resolveCalls = [];
+    const reviveCalls = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: (a) => {
+        reviveCalls.push(a);
+        return { code: 0 };
+      },
+      resolveSession: (id) => {
+        resolveCalls.push(id);
+        return "should-not-resolve";
+      },
+      appendEvent: () => {},
+    });
+    expect(resolveCalls).toEqual([]); // never called for null bgJobId
+    expect(reviveCalls[0]).toMatchObject({ resumeSession: null });
+    expect(res.dispatched).toBe(1);
+    expect(res.resumed).toBe(0);
+  });
+
+  test("a throwing resolveSession is contained and treated as unresumable (CTL-690)", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-1", "implement", {
+      worktreePath: "/wt/CTL-1",
+      bg_job_id: "boom",
+    });
+    const reviveCalls = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: (a) => {
+        reviveCalls.push(a);
+        return { code: 0 };
+      },
+      resolveSession: () => {
+        throw new Error("transcript read failed");
+      },
+      appendEvent: () => {},
+    });
+    // Dispatch still happens — the resume optimization is best-effort.
+    expect(res.dispatched).toBe(1);
+    expect(res.resumed).toBe(0);
+    expect(reviveCalls[0]).toMatchObject({ resumeSession: null });
+  });
+
+  test("mixed batch: some resume, some fresh, all dispatch (CTL-690)", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-A", "implement", {
+      worktreePath: "/wt/CTL-A",
+      bg_job_id: "aaa",
+    });
+    writeSignal(orchDir, "CTL-B", "implement", {
+      worktreePath: "/wt/CTL-B",
+      bg_job_id: "bbb",
+    });
+    writeSignal(orchDir, "CTL-C", "implement", {
+      worktreePath: "/wt/CTL-C",
+      bg_job_id: null,
+    });
+    const calls = [];
+    const resolveSession = (id) => (id === "aaa" ? "uuid-A" : null);
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: (a) => {
+        calls.push(a);
+        return { code: 0 };
+      },
+      resolveSession,
+      appendEvent: () => {},
+    });
+    expect(res.dispatched).toBe(3);
+    expect(res.resumed).toBe(1);
+    const byTicket = Object.fromEntries(calls.map((c) => [c.ticket, c.resumeSession]));
+    expect(byTicket).toEqual({
+      "CTL-A": "uuid-A",
+      "CTL-B": null,
+      "CTL-C": null,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

CTL-654 boot-resume only re-dispatched FRESH workers on cold restart — every in-flight phase worker lost its in-memory context. This plumbs session continuation: each candidate's `bg_job_id` is mapped (via the same `resolvePhaseSessionId` helper recovery.mjs uses on the per-tick reclaim path) to a `claude --resume`-compatible UUID, then forwarded to `reviveDispatch` so the dispatcher relaunches `claude --bg --resume <uuid>`.

## Why

Direct user request: enable unattended reboots without disruption. The Mac Mini host needs to survive reboots without nuking 30 min of progress per ticket. The plumbing was the only gap — everything downstream of `reconcileBootResume` already supports `resumeSession` (recovery.mjs:564-567, dispatch.mjs:94+128, phase-agent-dispatch:682+).

## Fallback (preserved end-to-end)

- `bg_job_id` absent on signal → skip resolveSession, pass `resumeSession=null`
- `resolveSession` returns null (no transcript on disk) → `resumeSession=null`
- `resolveSession` throws → catch, log, `resumeSession=null`
- Resume launch fails downstream → phase-agent-dispatch's CTL-658 stderr classifier (`launched`/`alive`/`failed`) falls back to a fresh start in the same dispatcher invocation; boot-resume never has to retry

So in the worst case (every resume fails) behavior is identical to today's fresh-dispatch path.

## Test plan

- [x] `bun test boot-resume.test.mjs` — 32 pass (5 new CTL-690 tests + 27 existing)
- [x] `bun test recovery.test.mjs` — 139 pass (no regression in the resolvePhaseSessionId path I import)
- [x] `bun test dispatch.test.mjs` — 18 pass (downstream resumeSession plumbing unaffected)
- [x] `bun test daemon.test.mjs` — 34 pass (daemon boot integration intact)
- [x] Confirmed the 8 scheduler.test.mjs failures pre-exist on main (known load flakes per memory CTL-602) — not introduced by this change
- [ ] After merge: hot-patch, restart daemon, observe `boot-resume: cold-start reconciliation complete dispatched=N resumed=M` log to verify the resume path fires for real candidates

## New tests (CTL-690)

1. `selectBootResumeCandidates` exposes `bgJobId` per candidate; null when signal lacks `bg_job_id`
2. `reconcileBootResume` forwards resolved UUID to `reviveDispatch`
3. `resolveSession` returns null → falls back to fresh dispatch with `resumeSession=null`
4. Missing `bg_job_id` never calls `resolveSession`
5. Throwing `resolveSession` is contained as unresumable
6. Mixed batch resumes some, fresh-dispatches others

## References

- CTL-654 — original boot-resume (deferred resume optimization)
- CTL-658 — per-tick revive's `--resume-session` path (this PR is the boot-pass analog)
- `boot-resume.mjs:162` — fixed: now passes `resumeSession`
- `recovery.mjs:73` — `resolvePhaseSessionId` (reused unchanged)
- `recovery.mjs:564-567` — `defaultReviveDispatch`'s resumeSession forward
- `phase-agent-dispatch:682+` — `claude --bg --resume` invocation + stderr classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)