### PR TITLE
CTL-701: Cold-restart reclaim sweep — monitor-deploy, turn-cap-exhausted, exec-core epoch

### DIFF
--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -190,6 +190,38 @@ describe("selectBootResumeCandidates", () => {
     expect(out).toHaveLength(1);
   });
 
+  test("selectBootResumeCandidates picks up monitor-deploy/running (CTL-701)", () => {
+    writeSignal(orchDir, "CTL-MD", "monitor-deploy", {
+      worktreePath: "/wt/CTL-MD",
+      bg_job_id: "md-job-1",
+      status: "running",
+    });
+    const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 3 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      ticket: "CTL-MD",
+      phase: "monitor-deploy",
+      worktreePath: "/wt/CTL-MD",
+      bgJobId: "md-job-1",
+    });
+  });
+
+  test("selectBootResumeCandidates picks up implement/turn-cap-exhausted (CTL-701)", () => {
+    writeSignal(orchDir, "CTL-TCE", "implement", {
+      worktreePath: "/wt/CTL-TCE",
+      bg_job_id: "tce-job-1",
+      status: "turn-cap-exhausted",
+    });
+    const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 3 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      ticket: "CTL-TCE",
+      phase: "implement",
+      worktreePath: "/wt/CTL-TCE",
+      bgJobId: "tce-job-1",
+    });
+  });
+
   // CTL-665: a committed executionCore.maxParallel (threaded via `concurrency`)
   // overrides state.json for the boot-resume ceiling, mirroring the new-work pull.
   test("concurrency.maxParallel overrides state.json for the boot ceiling (CTL-665)", () => {
@@ -528,6 +560,37 @@ describe("reconcileBootResume", () => {
       "CTL-A": "uuid-A",
       "CTL-B": null,
       "CTL-C": null,
+    });
+  });
+});
+
+// ── CTL-701: turn-cap-exhausted boot-resume ───────────────────────────────────
+describe("reconcileBootResume — turn-cap-exhausted (CTL-701)", () => {
+  test("relaunches turn-cap-exhausted with --resume when session resolvable", () => {
+    writeMaxParallel(orchDir, 3);
+    writeSignal(orchDir, "CTL-TCE", "implement", {
+      worktreePath: "/wt/CTL-TCE",
+      bg_job_id: "tce-abc",
+      status: "turn-cap-exhausted",
+    });
+    const calls = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: (a) => {
+        calls.push(a);
+        return { code: 0 };
+      },
+      resolveSession: (id) => (id === "tce-abc" ? "uuid-resume" : null),
+      appendEvent: () => {},
+    });
+    expect(res.dispatched).toBe(1);
+    expect(res.resumed).toBe(1);
+    expect(calls[0]).toMatchObject({
+      ticket: "CTL-TCE",
+      phase: "implement",
+      resumeSession: "uuid-resume",
     });
   });
 });

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -648,6 +648,36 @@ describe("consumeEventTail (byte-offset + partial-line tail)", () => {
   });
 });
 
+// CTL-701 Phase 3: boot marker exists when recover() (detectColdStart) reads it
+describe("startDaemon — writeBootMarker ordering (CTL-701)", () => {
+  test("daemon-boot.json written BEFORE recover() runs", () => {
+    const orchDir = join(process.env.CATALYST_DIR, "execution-core");
+    let bootFileExistedAtRecover = false;
+    let bootedAtAtRecover = null;
+    startDaemon({
+      recover: (o) => {
+        const bootPath = join(o.orchDir, "daemon-boot.json");
+        try {
+          const raw = readFileSync(bootPath, "utf8");
+          const parsed = JSON.parse(raw);
+          bootFileExistedAtRecover = true;
+          bootedAtAtRecover = parsed.bootedAt;
+        } catch {
+          /* file not yet written — test will fail */
+        }
+        return {};
+      },
+      reconcileBoot: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+    });
+    expect(bootFileExistedAtRecover).toBe(true);
+    expect(typeof bootedAtAtRecover).toBe("string");
+    expect(Number.isNaN(Date.parse(bootedAtAtRecover))).toBe(false);
+  });
+});
+
 describe("stopDaemon", () => {
   test("stops monitor + scheduler and removes the pidFile", () => {
     const pidFile = join(process.env.CATALYST_DIR, "daemon.pid");

--- a/plugins/dev/scripts/execution-core/integration-ctl-701.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-701.test.mjs
@@ -1,0 +1,181 @@
+// integration-ctl-701.test.mjs — end-to-end regression for the 2026-05-28
+// incident: OS reboot with 4 in-flight tickets (2 × pr/running,
+// 1 × monitor-deploy/running, 1 × implement/turn-cap-exhausted) stranded
+// two tickets because signal-reader excluded monitor-deploy signals and
+// classifyWorker short-circuited turn-cap-exhausted as terminal.
+//
+// This file exercises Phases 1-3 in composition:
+//   Phase 1 fix: phase-monitor-deploy.json removed from ARTIFACT_NAMES
+//   Phase 2 fix: turn-cap-exhausted removed from TERMINAL
+//   Phase 3 fix: daemon-boot.json as exec-core epoch for detectColdStart
+//
+// Run: bun test plugins/dev/scripts/execution-core/integration-ctl-701.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { reconcileBootResume } from "./boot-resume.mjs";
+import { detectColdStart, classifyWorker } from "./recovery.mjs";
+import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
+
+let orchDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl701-integ-"));
+  mkdirSync(join(orchDir, "workers"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// write a phase signal under workers/<ticket>/phase-<phase>.json
+function writePhaseSignal(ticket, phase, overrides = {}) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  const sig = {
+    ticket,
+    phase,
+    status: "running",
+    bg_job_id: `job-${ticket.toLowerCase()}`,
+    worktreePath: `/wt/${ticket}`,
+    updatedAt: "2026-05-28T14:00:00Z",
+    ...overrides,
+  };
+  writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify(sig, null, 2));
+  return sig;
+}
+
+// Build the 4-ticket fixture: CTL-A, CTL-B (pr/running), CTL-C (monitor-deploy),
+// CTL-D (implement/turn-cap-exhausted). All bg jobs have mtime T_OLD < T_BOOT.
+const T_OLD = 1_000; // all job mtimes — before exec-core boot
+const T_BOOT = 5_000; // daemon-boot.json bootedAt (exec-core epoch)
+
+function buildFixture() {
+  writePhaseSignal("CTL-A", "pr");
+  writePhaseSignal("CTL-B", "pr");
+  writePhaseSignal("CTL-C", "monitor-deploy");
+  writePhaseSignal("CTL-D", "implement", { status: "turn-cap-exhausted" });
+
+  // Write state.json for maxParallel so reconcileBootResume doesn't cap at 1
+  writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 8 }));
+
+  // Write daemon-boot.json — T_BOOT > T_OLD → exec-core epoch wins
+  writeFileSync(
+    join(orchDir, "daemon-boot.json"),
+    JSON.stringify({ bootedAt: new Date(T_BOOT).toISOString() }),
+  );
+}
+
+// statJob that maps known job ids to T_OLD mtimes — for detectColdStart, which
+// checks mtime against the epoch. All jobs predate T_BOOT so the verdict is cold.
+function makeStatJob() {
+  const knownJobs = new Map([
+    ["job-ctl-a", { exists: true, mtimeMs: T_OLD }],
+    ["job-ctl-b", { exists: true, mtimeMs: T_OLD }],
+    ["job-ctl-c", { exists: true, mtimeMs: T_OLD }],
+    ["job-ctl-d", { exists: true, mtimeMs: T_OLD }],
+  ]);
+  return (id) => knownJobs.get(id) ?? null;
+}
+
+describe("CTL-701 incident integration (2026-05-28 scenario)", () => {
+  test("boot-resume reconciles all four in-flight tickets on logical cold start", () => {
+    buildFixture();
+
+    // Prove detectColdStart with exec-core epoch returns coldStart:true for our
+    // fixture: runtime epoch is LOW (daemon not restarted), exec-core is HIGH.
+    const coldReport = detectColdStart({
+      readEpoch: () => ({ epoch: T_OLD / 2, epochSource: "daemon", bootEpoch: 0, daemonEpoch: T_OLD / 2 }),
+      readDir: () => ["job-ctl-a", "job-ctl-b", "job-ctl-c", "job-ctl-d"],
+      statJob: makeStatJob(),
+      orchDir,
+    });
+    expect(coldReport.coldStart).toBe(true);
+    expect(coldReport.epochSource).toBe("exec-core");
+
+    // reconcileBootResume should dispatch all 4 tickets
+    const dispatched = [];
+    const events = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [], // no live bg workers
+      reviveDispatch: (a) => {
+        dispatched.push({ ticket: a.ticket, phase: a.phase });
+        return { code: 0 };
+      },
+      resolveSession: () => null, // no resume UUIDs available
+      appendEvent: (e) => events.push(e),
+    });
+
+    expect(res.dispatched).toBe(4);
+    expect(res.failed).toBe(0);
+
+    const tickets = dispatched.map((d) => d.ticket).sort();
+    expect(tickets).toEqual(["CTL-A", "CTL-B", "CTL-C", "CTL-D"]);
+
+    // Monitor-deploy and turn-cap-exhausted must be in the dispatch list
+    const phases = Object.fromEntries(dispatched.map((d) => [d.ticket, d.phase]));
+    expect(phases["CTL-C"]).toBe("monitor-deploy");
+    expect(phases["CTL-D"]).toBe("implement");
+  });
+
+  test("per-tick reclaim sweep does NOT short-circuit monitor-deploy or turn-cap-exhausted", () => {
+    buildFixture();
+    // deadStatJob simulates all bg jobs having exited (no state.json present)
+    const deadStatJob = () => null;
+
+    // Build canonical WorkerSignal shapes for all four tickets
+    function makeSig(ticket, phase, status = "running") {
+      return {
+        ticket,
+        phase,
+        status,
+        liveness: { kind: "bg", value: `job-${ticket.toLowerCase()}` },
+        signalPath: join(orchDir, "workers", ticket, `phase-${phase}.json`),
+        raw: { ticket, phase, orchestrator: ticket, status, bg_job_id: `job-${ticket.toLowerCase()}` },
+      };
+    }
+
+    const signals = [
+      makeSig("CTL-A", "pr"),
+      makeSig("CTL-B", "pr"),
+      makeSig("CTL-C", "monitor-deploy"),
+      makeSig("CTL-D", "implement", "turn-cap-exhausted"),
+    ];
+
+    // classifyWorker must return "dead" (not "terminal") for all four,
+    // including monitor-deploy (Phase 1 fix) and turn-cap-exhausted (Phase 2 fix)
+    for (const sig of signals) {
+      const klass = classifyWorker(sig, { statJob: deadStatJob });
+      expect(klass).toBe("dead");
+    }
+
+    // reclaimDeadWorkIfPossible must NOT return "noop" for any of the four
+    const results = signals.map((sig) =>
+      reclaimDeadWorkIfPossible(orchDir, sig, {
+        statJob: deadStatJob,
+        probes: { pr: () => false, "monitor-deploy": () => false, implement: () => false },
+        emitComplete: () => ({ code: 0 }),
+        appendEvent: () => undefined,
+        appendReviveEvent: () => undefined,
+        reviveDispatch: () => ({ code: 0 }),
+        countReviveEvents: () => 0,
+        countDistinctRevivingTickets: () => 1,
+        writeReviveMarker: () => undefined,
+        killBgJob: () => undefined,
+        applyStalledLabel: () => ({ applied: true }),
+        liveness: () => "absent",
+        postReclaimMirror: () => {},
+      }),
+    );
+
+    for (let i = 0; i < results.length; i++) {
+      expect(results[i]).not.toBe("noop");
+    }
+    // All four should enter the revive path (probe=false → revived)
+    expect(results.every((r) => r === "revived")).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -680,6 +680,25 @@ export function readBootSince(orchDir) {
   }
 }
 
+// readExecCoreBootEpoch — daemon-boot.json's bootedAt as epoch-ms, or 0 if
+// missing/malformed. CTL-701: the third cold-start epoch source. Unlike
+// readDaemonEpoch (claude-daemon socket dir mtime, fragile across socket
+// refreshes), this is THIS exec-core instance's own start time — written
+// atomically by writeBootMarker at startDaemon line 1, before detectColdStart
+// runs. Any --bg worker whose state.json mtime predates it is provably dead.
+export function readExecCoreBootEpoch(orchDir, { read = (p) => readFileSync(p, "utf8") } = {}) {
+  if (!orchDir) return 0;
+  try {
+    const raw = read(bootMarkerPath(orchDir));
+    const bootedAt = JSON.parse(raw)?.bootedAt;
+    if (typeof bootedAt !== "string" || !bootedAt) return 0;
+    const ms = Date.parse(bootedAt);
+    return Number.isFinite(ms) ? ms : 0;
+  } catch {
+    return 0;
+  }
+}
+
 // writeBootMarker — record this daemon process's start time. Atomic tmp+rename,
 // fail-open: a write failure logs and the daemon continues (the budget simply
 // won't reset this run — the safe degradation). Injectable `now` for tests.
@@ -777,13 +796,28 @@ export function defaultReadRuntimeEpoch({
 // remains the fallback. Enumerates ALL dirs under getJobsRoot() (not just
 // signalled bg_job_ids) so a live sibling-orchestrator worker can veto the
 // verdict. Pure aside from injected seams; never throws.
+//
+// Three epochs feed the cold-start verdict: (1) OS boot, (2) claude-daemon
+// socket dir, (3) exec-core daemon-boot.json. The latest wins. Adding the
+// exec-core epoch (CTL-701) catches manual daemon restarts where the socket
+// dir mtime was refreshed between the OS boot and the new daemon launch.
 export function detectColdStart({
   jobsRoot = getJobsRoot(),
   readDir = readdirSync,
   statJob = defaultStatJob,
   readEpoch = defaultReadRuntimeEpoch,
+  orchDir = undefined,                       // CTL-701: enables exec-core epoch
+  readExecCoreEpoch = readExecCoreBootEpoch, // CTL-701: injectable seam
 } = {}) {
-  const { epoch, epochSource } = readEpoch();
+  const { epoch: runtimeEpoch, epochSource: runtimeSource } = readEpoch();
+  const execCoreEpoch = readExecCoreEpoch(orchDir);
+
+  let epoch = runtimeEpoch;
+  let epochSource = runtimeSource;
+  if (execCoreEpoch > epoch) {
+    epoch = execCoreEpoch;
+    epochSource = "exec-core";
+  }
 
   let ids = [];
   try {
@@ -1388,7 +1422,9 @@ export function recoverStartup({ orchDir, exec, statJob, detectCold = detectCold
   //     runtime epoch? Surfaced for a downstream consumer (CTL-639) to gate the
   //     boot-time stale-wait. Pass statJob so a test-redirected jobs root flows
   //     through both the worker reconstruction and the cold-start scan.
-  const coldStart = detectCold({ statJob });
+  // CTL-701: forward orchDir so detectColdStart can read daemon-boot.json as
+  // the third cold-start epoch (exec-core restart without OS/daemon socket reboot).
+  const coldStart = detectCold({ statJob, orchDir });
 
   return {
     recoveredAt: new Date().toISOString(),

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -27,6 +27,7 @@ import {
   defaultReadRuntimeEpoch,
   detectColdStart,
   readBootSince,
+  readExecCoreBootEpoch,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -73,12 +74,28 @@ const bgSignal = (status, bgJobId) => ({
 // --- classifyWorker — pure given statJob ----------------------------------
 
 describe("classifyWorker", () => {
-  test("terminal status (done/failed/stalled/turn-cap-exhausted) → 'terminal'", () => {
-    for (const status of ["done", "failed", "stalled", "turn-cap-exhausted"]) {
+  test("terminal status (done/failed/stalled/skipped) → 'terminal' (CTL-701)", () => {
+    for (const status of ["done", "failed", "stalled", "skipped"]) {
       expect(
         classifyWorker(bgSignal(status, "job-x"), { statJob: () => null }),
       ).toBe("terminal");
     }
+  });
+
+  test("turn-cap-exhausted is NOT terminal — classified by liveness (CTL-701)", () => {
+    // Live bg job → "running"
+    const live = classifyWorker(
+      bgSignal("turn-cap-exhausted", "alive"),
+      { statJob: () => ({ mtimeMs: Date.now() }) },
+    );
+    expect(live).toBe("running");
+
+    // Dead bg job → "dead" (reclaim-eligible)
+    const dead = classifyWorker(
+      bgSignal("turn-cap-exhausted", "gone"),
+      { statJob: () => null },
+    );
+    expect(dead).toBe("dead");
   });
 
   test("non-terminal status + bg job dir present → 'running' (re-attached)", () => {
@@ -468,6 +485,88 @@ function recorder(returnValue) {
   fn.calls = calls;
   return fn;
 }
+
+// CTL-701 Phase 1: reclaim sweep visits a monitor-deploy/running signal
+describe("reclaimDeadWorkIfPossible — monitor-deploy (CTL-701)", () => {
+  const orch = "/orch";
+
+  test("classifies monitor-deploy/running/dead-bg as 'dead', visits probe (CTL-701)", () => {
+    const sig = {
+      ticket: "CTL-MD",
+      phase: "monitor-deploy",
+      status: "running",
+      liveness: { kind: "bg", value: "job-md" },
+      signalPath: `${orch}/workers/CTL-MD/phase-monitor-deploy.json`,
+      raw: {
+        ticket: "CTL-MD",
+        phase: "monitor-deploy",
+        orchestrator: "CTL-MD",
+        status: "running",
+        bg_job_id: "job-md",
+      },
+    };
+    const klass = classifyWorker(sig, { statJob: () => null });
+    expect(klass).toBe("dead");
+
+    // reclaimDeadWorkIfPossible proceeds to probe (not short-circuited)
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => null,
+      probes: { "monitor-deploy": probe },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      postReclaimMirror: () => {},
+      liveness: () => "absent",
+    });
+    expect(r).toBe("reclaimed");
+    expect(probe.calls.length).toBe(1);
+    expect(emit.calls.length).toBe(1);
+  });
+});
+
+// CTL-701 Phase 2: reclaim/revive for turn-cap-exhausted
+describe("reclaimDeadWorkIfPossible — turn-cap-exhausted (CTL-701)", () => {
+  const orch = "/orch";
+
+  test("reclaims turn-cap-exhausted/dead with commits ahead (CTL-701)", () => {
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "turn-cap-exhausted" }), {
+      statJob: () => null,
+      probes: { implement: probe },
+      emitComplete: emit,
+      appendEvent: recorder(undefined),
+      postReclaimMirror: () => {},
+      liveness: () => "absent",
+    });
+    expect(r).toBe("reclaimed");
+    expect(probe.calls.length).toBe(1);
+    expect(emit.calls.length).toBe(1);
+  });
+
+  test("revives turn-cap-exhausted/dead with --resume when no work done (CTL-701)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "turn-cap-exhausted" }), {
+      statJob: () => null,
+      probes: { implement: recorder(false) },
+      emitComplete: recorder({ code: 0 }),
+      appendEvent: recorder(undefined),
+      appendReviveEvent: recorder(undefined),
+      reviveDispatch,
+      countReviveEvents: recorder(0),
+      countDistinctRevivingTickets: recorder(1),
+      writeReviveMarker: recorder(undefined),
+      killBgJob: recorder(undefined),
+      applyStalledLabel: recorder({ applied: true }),
+      resolveSession: () => "uuid-resume",
+      liveness: () => "absent",
+    });
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+    expect(reviveDispatch.calls[0][0].resumeSession).toBe("uuid-resume");
+  });
+});
 
 describe("reclaimDeadWorkIfPossible", () => {
   const orch = "/orch";
@@ -2330,6 +2429,96 @@ describe("runtime epoch readers", () => {
       });
       expect(res).toMatchObject({ coldStart: true, jobsChecked: 0 });
     });
+  });
+});
+
+// CTL-701 Phase 3: readExecCoreBootEpoch + detectColdStart exec-core epoch
+describe("readExecCoreBootEpoch (CTL-701)", () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ctl701-epoch-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reads daemon-boot.json bootedAt as epoch-ms", () => {
+    writeFileSync(
+      join(dir, "daemon-boot.json"),
+      JSON.stringify({ bootedAt: "2026-05-28T15:00:00Z" }),
+    );
+    expect(readExecCoreBootEpoch(dir)).toBe(Date.parse("2026-05-28T15:00:00Z"));
+  });
+
+  test("returns 0 when file is missing (fail-open)", () => {
+    expect(readExecCoreBootEpoch(dir)).toBe(0);
+  });
+
+  test("returns 0 when file is malformed JSON (fail-open)", () => {
+    writeFileSync(join(dir, "daemon-boot.json"), "not json");
+    expect(readExecCoreBootEpoch(dir)).toBe(0);
+  });
+
+  test("returns 0 when bootedAt is wrong type (fail-open)", () => {
+    writeFileSync(join(dir, "daemon-boot.json"), JSON.stringify({ bootedAt: 12345 }));
+    expect(readExecCoreBootEpoch(dir)).toBe(0);
+    writeFileSync(join(dir, "daemon-boot.json"), JSON.stringify({ bootedAt: "" }));
+    expect(readExecCoreBootEpoch(dir)).toBe(0);
+  });
+
+  test("returns 0 for null orchDir (fail-open)", () => {
+    expect(readExecCoreBootEpoch(null)).toBe(0);
+    expect(readExecCoreBootEpoch(undefined)).toBe(0);
+  });
+});
+
+describe("detectColdStart — exec-core epoch (CTL-701)", () => {
+  const statJobFrom = (map) => (id) =>
+    id in map ? { exists: true, mtimeMs: map[id], state: {} } : null;
+
+  test("uses exec-core epoch when newer than OS/daemon (CTL-701 Option A)", () => {
+    const T1 = 1000; // runtime epoch (daemon)
+    const T2 = 2000; // job mtime — between T1 and T3
+    const T3 = 3000; // exec-core boot epoch — newest
+    const res = detectColdStart({
+      readEpoch: () => ({ epoch: T1, epochSource: "daemon", bootEpoch: 0, daemonEpoch: T1 }),
+      readDir: () => ["j1"],
+      statJob: statJobFrom({ j1: T2 }),
+      readExecCoreEpoch: () => T3,
+    });
+    // T2 < T3 → cold; exec-core epoch wins
+    expect(res.coldStart).toBe(true);
+    expect(res.epochSource).toBe("exec-core");
+    expect(res.epoch).toBe(T3);
+  });
+
+  test("keeps OS/daemon path when newer than exec-core (CTL-701)", () => {
+    const T1 = 5000; // runtime epoch (boot) — newest
+    const T2 = 3000; // job mtime < T1 → cold regardless
+    const T3 = 2000; // exec-core epoch — lower
+    const res = detectColdStart({
+      readEpoch: () => ({ epoch: T1, epochSource: "boot", bootEpoch: T1, daemonEpoch: 0 }),
+      readDir: () => ["j1"],
+      statJob: statJobFrom({ j1: T2 }),
+      readExecCoreEpoch: () => T3,
+    });
+    expect(res.coldStart).toBe(true);
+    expect(res.epochSource).toBe("boot"); // runtime wins
+    expect(res.epoch).toBe(T1);
+  });
+
+  test("unreadable exec-core epoch (0) falls through to runtime epoch (CTL-701)", () => {
+    const T1 = 5000;
+    const T2 = 3000;
+    const res = detectColdStart({
+      readEpoch: () => ({ epoch: T1, epochSource: "daemon", bootEpoch: 0, daemonEpoch: T1 }),
+      readDir: () => ["j1"],
+      statJob: statJobFrom({ j1: T2 }),
+      readExecCoreEpoch: () => 0, // missing / malformed
+    });
+    expect(res.coldStart).toBe(true);
+    expect(res.epochSource).toBe("daemon");
+    expect(res.epoch).toBe(T1);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/signal-reader.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.mjs
@@ -13,12 +13,13 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { log } from "./config.mjs";
 
-// Files inside workers/<T>/ that are phase OUTPUTS, not signals.
+// Files inside workers/<T>/ that are phase OUTPUTS ONLY (no phase signal
+// collision). Note: `phase-monitor-deploy.json` is intentionally NOT here —
+// it's dual-use (signal + artifact), tracked via CTL-701.
 const ARTIFACT_NAMES = new Set([
   "triage.json",
   "verify.json",
   "review.json",
-  "phase-monitor-deploy.json",
 ]);
 
 // Terminal worker statuses — exported so decision modules share one set.
@@ -26,7 +27,11 @@ const ARTIFACT_NAMES = new Set([
 // event arrived before the timeout (phase-monitor-deploy SKILL.md). Ranked
 // the same as 'done' by byActivePhase: a skipped terminal must never shadow
 // an in-flight phase.
-const TERMINAL = new Set(["done", "failed", "stalled", "turn-cap-exhausted", "skipped"]);
+// CTL-484 / CTL-701: 'turn-cap-exhausted' is NOT terminal — the worker's bg
+// session ended at the turn cap but the phase awaits continuation; reclaim /
+// revive probes work-done state to decide reclaim-as-done vs
+// `claude --bg --resume`.
+const TERMINAL = new Set(["done", "failed", "stalled", "skipped"]);
 
 // readWorkerSignals — glob both layouts under ${orchDir}/workers/ and return
 // a canonical WorkerSignal per worker:

--- a/plugins/dev/scripts/execution-core/signal-reader.test.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.test.mjs
@@ -5,7 +5,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readWorkerSignals, listDispatchedPhases } from "./signal-reader.mjs";
+import { readWorkerSignals, listDispatchedPhases, byActivePhase } from "./signal-reader.mjs";
 
 let orchDir;
 
@@ -100,20 +100,37 @@ describe("readWorkerSignals", () => {
     expect(sigs[0].signalPath.endsWith(".projected")).toBe(false);
   });
 
-  test("ignores phase-output artifacts (triage/verify/review/phase-monitor-deploy.json)", () => {
+  test("ignores phase-output artifacts (triage/verify/review) (CTL-701)", () => {
     writeNested("CTL-3", "implement", { status: "running" });
     const dir = join(workersDir(), "CTL-3");
-    for (const name of [
-      "triage.json",
-      "verify.json",
-      "review.json",
-      "phase-monitor-deploy.json",
-    ]) {
+    for (const name of ["triage.json", "verify.json", "review.json"]) {
       writeFileSync(join(dir, name), JSON.stringify({ artifact: true }));
     }
     const sigs = readWorkerSignals(orchDir);
     expect(sigs).toHaveLength(1);
     expect(sigs[0].phase).toBe("implement");
+  });
+
+  test("phase-monitor-deploy.json IS a phase signal (CTL-701)", () => {
+    const dir = join(workersDir(), "CTL-MD");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-monitor-deploy.json"),
+      JSON.stringify({
+        ticket: "CTL-MD",
+        phase: "monitor-deploy",
+        status: "running",
+        bg_job_id: "abc123",
+        updatedAt: "2026-05-28T16:00:00Z",
+        worktreePath: "/tmp/wt/CTL-MD",
+      }),
+    );
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs).toHaveLength(1);
+    expect(sigs[0].ticket).toBe("CTL-MD");
+    expect(sigs[0].phase).toBe("monitor-deploy");
+    expect(sigs[0].status).toBe("running");
+    expect(sigs[0].liveness).toEqual({ kind: "bg", value: "abc123" });
   });
 
   test("ignores the workers/output/ directory", () => {
@@ -178,10 +195,9 @@ describe("readWorkerSignals", () => {
         updatedAt: "2026-05-21T02:00:00Z",
       }),
     );
-    // NOTE: phase-monitor-deploy.json is in ARTIFACT_NAMES so it is filtered
-    // out as an artifact, not as a signal. To exercise byActivePhase with a
-    // skipped terminal we use a fresh worker dir whose terminal signal is on
-    // a different phase name.
+    // CTL-701: phase-monitor-deploy.json is now a real signal (not an artifact).
+    // CTL-512 dir exercises byActivePhase with monitor-deploy/skipped; CTL-512B
+    // uses a different phase name to provide a parallel smoke scenario.
     const dir2 = join(workersDir(), "CTL-512B");
     mkdirSync(dir2, { recursive: true });
     writeFileSync(
@@ -268,21 +284,43 @@ describe("listDispatchedPhases", () => {
     ]);
   });
 
-  test("ignores phase-output artifacts (triage/verify/review/phase-monitor-deploy.json)", () => {
+  test("ignores phase-output artifacts (triage/verify/review) (CTL-701)", () => {
     writeNested("CTL-9", "implement", { status: "running" });
     const dir = join(workersDir(), "CTL-9");
-    for (const name of [
-      "triage.json",
-      "verify.json",
-      "review.json",
-      "phase-monitor-deploy.json",
-    ]) {
+    for (const name of ["triage.json", "verify.json", "review.json"]) {
       writeFileSync(join(dir, name), JSON.stringify({ artifact: true }));
     }
     expect(listDispatchedPhases(orchDir, "CTL-9")).toEqual(["implement"]);
   });
 
+  test("monitor-deploy appears in dispatched phases (CTL-701)", () => {
+    writeNested("CTL-9", "implement", { status: "done" });
+    writeNested("CTL-9", "monitor-deploy", { status: "running" });
+    const phases = listDispatchedPhases(orchDir, "CTL-9").sort();
+    expect(phases).toContain("monitor-deploy");
+    expect(phases).toContain("implement");
+  });
+
   test("returns [] when the worker dir does not exist", () => {
     expect(listDispatchedPhases(orchDir, "NOPE")).toEqual([]);
+  });
+});
+
+// CTL-701 Phase 2: byActivePhase — turn-cap-exhausted is NOT terminal
+describe("byActivePhase — turn-cap-exhausted (CTL-701)", () => {
+  test("turn-cap-exhausted sorts before done regardless of updatedAt", () => {
+    const tce = {
+      phase: "implement",
+      status: "turn-cap-exhausted",
+      updatedAt: "2026-05-28T10:00:00Z",
+    };
+    const done = {
+      phase: "monitor-deploy",
+      status: "done",
+      updatedAt: "2026-05-28T12:00:00Z",
+    };
+    const sorted = [tce, done].sort(byActivePhase);
+    expect(sorted[0].status).toBe("turn-cap-exhausted");
+    expect(sorted[1].status).toBe("done");
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-28T16:26:00Z -->
<!-- Last updated: 2026-05-28T16:26:00Z -->
<!-- PR: #1169 -->
<!-- Previous commits: c45e7c4753529e8b233b7b5686b2967f05b7065e -->

## Summary

Fixes the 2026-05-28 OS-reboot incident where 4 in-flight tickets were stranded and 2 (`monitor-deploy/running`, `implement/turn-cap-exhausted`) were silently skipped by the automatic cold-restart recovery — requiring manual intervention. Three targeted fixes close all three escape hatches in the execution-core's revival pipeline, and a new end-to-end regression test reproduces the exact 4-ticket incident fixture.

## Problem

After a real OS reboot with 4 active tickets:

| Ticket | Phase | Status | Auto-revived? |
|--------|-------|--------|---------------|
| ADV-810 | pr | running | ✅ yes |
| ADV-882 | pr | running | ✅ yes |
| ADV-793 | monitor-deploy | running | ❌ skipped |
| ADV-1034 | implement | turn-cap-exhausted | ❌ skipped |

Both the per-tick reclaim sweep **and** the boot-resume cold-start gate missed the last two. Root cause: three independent bugs:

1. `phase-monitor-deploy.json` was in `ARTIFACT_NAMES` — causing `readWorkerSignals` to skip it as a non-phase signal
2. `turn-cap-exhausted` was in `TERMINAL` — causing `classifyWorker` to short-circuit it as a permanent done state rather than a revive candidate
3. `detectColdStart`'s cold-start gate used only OS-boot and claude-daemon socket dir mtimes; a manual daemon restart (without OS reboot) refreshed the socket dir mtime, making `newestJobMtime > epoch` → not cold → boot-resume didn't fire

## Changes Made

### Phase 1 — Remove `monitor-deploy` from `ARTIFACT_NAMES` (`signal-reader.mjs`)

`ARTIFACT_NAMES` is the set of signal filenames treated as opaque artifact blobs (not active phase signals). `phase-monitor-deploy.json` was inadvertently included there, causing `readWorkerSignals` to exclude it from the worker signal map fed to both the per-tick reclaim sweep and boot-resume candidate selection. Removed it so monitor-deploy signals are classified by the normal liveness path.

### Phase 2 — Remove `turn-cap-exhausted` from `TERMINAL` (`signal-reader.mjs`)

`TERMINAL` is the set of statuses `classifyWorker` treats as done (no further action needed). `turn-cap-exhausted` represents a phase that hit its turn cap mid-work and needs a `--resume` continuation dispatch — it is **not** terminal. Removed it so `classifyWorker` returns `"dead"` for these workers (bg job gone, reclaim-eligible) rather than `"terminal"` (no-op).

### Phase 3 — Add exec-core boot epoch to `detectColdStart` (`recovery.mjs`)

Added `readExecCoreBootEpoch` which reads `daemon-boot.json`'s `bootedAt` timestamp — written atomically by `writeBootMarker` at `startDaemon` line 1, before `detectColdStart` runs. Extended `detectColdStart` to accept an optional `orchDir` and take the maximum of the three epoch sources (OS boot, claude-daemon socket dir, exec-core start). Forwarded `orchDir` through `recoverStartup` so the production call path uses the new epoch. A manual daemon restart now correctly triggers the cold-start reconciliation gate.

### Phase 4 — End-to-end regression test (`integration-ctl-701.test.mjs`)

New integration test file reproducing the exact 4-ticket incident fixture (2×pr/running, 1×monitor-deploy/running, 1×implement/turn-cap-exhausted). Exercises Phases 1–3 in composition:
- `detectColdStart` returns `coldStart: true` with `epochSource: "exec-core"` when exec-core epoch > runtime epoch
- `reconcileBootResume` dispatches all 4 tickets (dispatched=4, failed=0)
- `classifyWorker` returns `"dead"` for all four (not `"terminal"`)
- `reclaimDeadWorkIfPossible` returns `"revived"` for all four (not `"noop"`)

## Files Changed

| File | +/- | Change |
|------|-----|--------|
| `signal-reader.mjs` | +8/-3 | Remove monitor-deploy from ARTIFACT_NAMES; remove turn-cap-exhausted from TERMINAL |
| `recovery.mjs` | +38/-2 | Add readExecCoreBootEpoch; extend detectColdStart with exec-core epoch; forward orchDir |
| `integration-ctl-701.test.mjs` | +181/0 | New end-to-end regression test |
| `boot-resume.test.mjs` | +63/0 | Unit tests for monitor-deploy and turn-cap-exhausted boot-resume candidates |
| `daemon.test.mjs` | +30/0 | Test writeBootMarker ordering guarantee (written before recover() runs) |
| `recovery.test.mjs` | +191/-2 | Tests for readExecCoreBootEpoch and updated classifyWorker terminal set |
| `signal-reader.test.mjs` | +57/-19 | Update tests for new ARTIFACT_NAMES and TERMINAL sets |

## How to Verify

- [x] `bun test integration-ctl-701.test.mjs` — 2 tests pass (4-ticket incident end-to-end)
- [x] `bun test signal-reader.test.mjs recovery.test.mjs boot-resume.test.mjs daemon.test.mjs` — 239 tests pass

**Manual verification (post-deploy):**
- [ ] Trigger a daemon restart (`catalyst-daemon restart`) with in-flight tickets; confirm all resume without manual intervention
- [ ] Confirm a `monitor-deploy/running` ticket is picked up by the next cold-start reconciliation after restart

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-701
- Builds on [CTL-690](https://linear.app/coalesce-labs/issue/CTL-690) (boot-resume session continuation)
- Builds on [CTL-658](https://linear.app/coalesce-labs/issue/CTL-658) (per-tick reclaim resume path)
