### PR TITLE
fix(dev): stop scheduler tick from crashing on yield-tombstone files (CTL-702)

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -32,7 +32,7 @@ import {
   IDLE_CONFIRM_TICKS,
   BUSY_CEILING_MS,
 } from "./config.mjs";
-import { phaseIndex } from "../lib/phase-fsm.mjs";
+import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
@@ -375,6 +375,25 @@ export function defaultAppendReviveEvent({
       payloadExtras: { attempt, prev_state_json_mtime, prev_bg_job_id },
     }),
     "revive",
+  );
+}
+
+// defaultAppendYieldFileSkipEvent — phase.scheduler.yield-file-skip.<ticket>.
+// CTL-702: emitted once per observed yield tombstone per daemon lifetime so
+// yield rate is queryable from the event log. `phase` is "scheduler" — the
+// yielded phase lives inside body.payload.filename. See
+// website/src/content/docs/observability/event-flow.md#yield-tombstones.
+export function defaultAppendYieldFileSkipEvent({ ticket, orchId, filename }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "scheduler",
+      ticket,
+      orchId,
+      action: "yield-file-skip",
+      reason: "yield_tombstone_filtered",
+      payloadExtras: { filename },
+    }),
+    "yield-file-skip",
   );
 }
 
@@ -1127,8 +1146,13 @@ export function reclaimDeadWorkIfPossible(
   // the ticket's latest-dispatched phase, the ticket has moved on — escalating or
   // reviving it would spuriously flag needs-human or spawn a duplicate worker at
   // a past phase. Runs only once a worker is reclaim-eligible (not busy).
+  // CTL-702: defensive — listTicketPhases is read off the filesystem; if a
+  // future on-disk variant slips past signal-reader's filter (e.g. yield
+  // tombstone, manual operator file), isKnownPhase skips it instead of
+  // throwing. See website/src/content/docs/observability/event-flow.md#yield-tombstones.
   const dispatched = listTicketPhases(ticket);
   const latestIdx = dispatched.reduce((max, p) => {
+    if (!isKnownPhase(p)) return max; // CTL-702: defensive — skip unknown names
     const i = phaseIndex(p);
     return i > max ? i : max;
   }, -1);

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -22,6 +22,7 @@ import {
   defaultPostReclaimMirror,
   defaultAppendDispatchRequestedEvent,
   defaultAppendDispatchLaunchedEvent,
+  defaultAppendYieldFileSkipEvent,
   readBootEpoch,
   readDaemonEpoch,
   defaultReadRuntimeEpoch,
@@ -2289,6 +2290,47 @@ describe("reclaim event envelope round-trip (CTL-664)", () => {
   });
 });
 
+// CTL-702: yield-file-skip OTEL emitter round-trip.
+describe("yield-file-skip event envelope (CTL-702)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl702-yield-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  function readBackEnvelope() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    return JSON.parse(lines[lines.length - 1]);
+  }
+
+  test("defaultAppendYieldFileSkipEvent emits the expected envelope shape (CTL-702)", () => {
+    const ok = defaultAppendYieldFileSkipEvent({
+      ticket: "CTL-FOO",
+      orchId: "ORCH-1",
+      filename: "phase-plan-yield-20260528T050740Z.json",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.scheduler.yield-file-skip.CTL-FOO");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.body.payload.filename).toBe("phase-plan-yield-20260528T050740Z.json");
+    expect(env.body.payload.reason).toBe("yield_tombstone_filtered");
+    expect(env.attributes["catalyst.orchestration"]).toBe("ORCH-1");
+  });
+});
+
 // CTL-640: cold-start detection — runtime epoch readers + detectColdStart.
 describe("runtime epoch readers", () => {
   describe("readBootEpoch", () => {
@@ -2576,6 +2618,28 @@ describe("reclaimDeadWorkIfPossible — CTL-606 supersede guard", () => {
     });
     expect(r).toBe("alive-busy-suppressed");
     expect(listSpy.calls.length).toBe(0); // guard runs only on the reclaim-eligible path
+  });
+
+  test("supersede guard tolerates unknown phase names in listTicketPhases (CTL-702)", () => {
+    // listTicketPhases returns a yield-tombstone name. The reduce must skip it
+    // via isKnownPhase, not throw PhaseFsmError. The triage signal is the dead
+    // predecessor; implement is the latest KNOWN dispatched phase, so the
+    // guard fires and returns 'superseded-noop'.
+    const triasSig = {
+      ticket: "CTL-702D",
+      phase: "triage",
+      status: "running",
+      liveness: { kind: "bg", value: "job-old" },
+      raw: { ticket: "CTL-702D", phase: "triage", status: "running", bg_job_id: "job-old" },
+    };
+    expect(() => {
+      reclaimDeadWorkIfPossible(orch, triasSig, {
+        statJob: () => null,
+        listTicketPhases: () => ["triage", "plan-yield-20260528T050740Z", "plan", "implement"],
+        appendEscalatedEvent: recorder(undefined),
+        applyStalledLabel: recorder(undefined),
+      });
+    }).not.toThrow();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -63,6 +63,7 @@ import {
   defaultAppendDispatchFailedEvent,
   defaultAppendDispatchRequestedEvent,
   defaultAppendDispatchLaunchedEvent,
+  defaultAppendYieldFileSkipEvent,
 } from "./recovery.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
@@ -101,6 +102,7 @@ export function readPhaseSignals(orchDir, ticket) {
   for (const f of files) {
     const m = /^phase-(.+)\.json$/.exec(f);
     if (!m) continue;
+    if (m[1].includes("-yield-")) continue; // CTL-702: skip yield tombstones
     try {
       signals[m[1]] = JSON.parse(readFileSync(join(dir, f), "utf8"))?.status ?? null;
     } catch {
@@ -874,6 +876,9 @@ export function schedulerTick(
     // confirms a live worker. Both best-effort — no branch gates on the return.
     appendDispatchRequestedEvent = defaultAppendDispatchRequestedEvent,
     appendDispatchLaunchedEvent = defaultAppendDispatchLaunchedEvent,
+    // CTL-702: injectable yield-file-skip emitter. Deduped by observedYieldFiles
+    // (module-level set) so only the first observation per daemon lifetime fires.
+    appendYieldFileSkipEvent = defaultAppendYieldFileSkipEvent,
   } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -903,47 +908,76 @@ export function schedulerTick(
   // neither pipeline-complete (monitor-deploy done/skipped) nor
   // failed/stalled/aborted" — exactly the set this sweep cares about.
   const inFlightTickets = listInFlightTickets(orchDir);
+
+  // CTL-702: scan worker dirs for yield tombstones. Emit once per unique
+  // absolute path per daemon lifetime (deduped via observedYieldFiles).
+  try {
+    const workersDirEntries = readdirSync(join(orchDir, "workers"), { withFileTypes: true });
+    for (const d of workersDirEntries) {
+      if (!d.isDirectory()) continue;
+      const ticket = d.name;
+      for (const f of readdirSync(join(orchDir, "workers", ticket))) {
+        if (!f.startsWith("phase-") || !f.endsWith(".json") || !f.includes("-yield-")) continue;
+        const absPath = join(orchDir, "workers", ticket, f);
+        if (observedYieldFiles.has(absPath)) continue;
+        observedYieldFiles.add(absPath);
+        appendYieldFileSkipEvent({ ticket, orchId: ticket, filename: f });
+      }
+    }
+  } catch {
+    // fail-open — a missing/unreadable workers dir does not abort the tick
+  }
+
   for (const sig of readWorkerSignals(orchDir)) {
     if (!inFlightTickets.has(sig.ticket)) continue;
-    const team = teamOf(sig.ticket);
-    const repoRoot = team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
-    const r = reclaimDeadWork(orchDir, sig, { repoRoot });
-    const entry = { ticket: sig.ticket, phase: sig.phase };
-    switch (r) {
-      case "reclaimed":
-        reclaimed.push(entry);
-        break;
-      case "revived":
-        revived.push(entry);
-        break;
-      case "revive-suppressed":
-        reviveSuppressed.push(entry);
-        break;
-      case "escalated":
-        escalated.push(entry);
-        break;
-      case "escalation-suppressed":
-        // CTL-638: the per-(ticket, phase) cool-down throttled the audit event
-        // and label write. Invisible by design — operators saw the original
-        // escalation in events.jsonl already; surfacing this would re-recreate
-        // the noise the cool-down exists to prevent.
-        break;
-      case "alive-quiet-suppressed":
-        // CTL-610: the bg worker is alive (kill -0) but quiet on a long tool
-        // call (the pre-first-output window for research/plan, or a long
-        // synchronous Edit/Bash inside implement). Invisible by design — no
-        // duplicate spawn, no state change; the next tick re-evaluates the
-        // mtime + pidAlive pair. Surfacing it in result.revived / .escalated
-        // / .reviveSuppressed would re-create the very revive-storm noise the
-        // (C0) guard exists to suppress (and would re-feed the scheduler's own
-        // fs.watch fast path via any audit-event write — CTL-638 lineage).
-        break;
-      default:
-        // noop | not-done | not-applicable | reclaim-failed → invisible.
-        // CTL-606: superseded-noop also buckets here — a dead predecessor signal
-        // the ticket has already advanced past. Invisible by design (the active
-        // phase is progressing normally); surfacing it would be noise.
-        break;
+    try {
+      const team = teamOf(sig.ticket);
+      const repoRoot = team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
+      const r = reclaimDeadWork(orchDir, sig, { repoRoot });
+      const entry = { ticket: sig.ticket, phase: sig.phase };
+      switch (r) {
+        case "reclaimed":
+          reclaimed.push(entry);
+          break;
+        case "revived":
+          revived.push(entry);
+          break;
+        case "revive-suppressed":
+          reviveSuppressed.push(entry);
+          break;
+        case "escalated":
+          escalated.push(entry);
+          break;
+        case "escalation-suppressed":
+          // CTL-638: the per-(ticket, phase) cool-down throttled the audit event
+          // and label write. Invisible by design — operators saw the original
+          // escalation in events.jsonl already; surfacing this would re-recreate
+          // the noise the cool-down exists to prevent.
+          break;
+        case "alive-quiet-suppressed":
+          // CTL-610: the bg worker is alive (kill -0) but quiet on a long tool
+          // call (the pre-first-output window for research/plan, or a long
+          // synchronous Edit/Bash inside implement). Invisible by design — no
+          // duplicate spawn, no state change; the next tick re-evaluates the
+          // mtime + pidAlive pair. Surfacing it in result.revived / .escalated
+          // / .reviveSuppressed would re-create the very revive-storm noise the
+          // (C0) guard exists to suppress (and would re-feed the scheduler's own
+          // fs.watch fast path via any audit-event write — CTL-638 lineage).
+          break;
+        default:
+          // noop | not-done | not-applicable | reclaim-failed → invisible.
+          // CTL-606: superseded-noop also buckets here — a dead predecessor signal
+          // the ticket has already advanced past. Invisible by design (the active
+          // phase is progressing normally); surfacing it would be noise.
+          break;
+      }
+    } catch (err) {
+      // CTL-702: per-worker isolation — one bad signal cannot abort the whole
+      // tick. Log and continue to the next worker.
+      log.warn(
+        { ticket: sig.ticket, phase: sig.phase, step: "reclaim", err: err.message },
+        "scheduler: per-worker step failed — skipping signal, continuing tick (CTL-702)",
+      );
     }
   }
 
@@ -1203,6 +1237,11 @@ let debounceTimer = null;
 let watcher = null;
 let runningOpts = null;
 
+// CTL-702: observed yield tombstones for the lifetime of this daemon process.
+// Keyed by absolute path so the same file across multiple ticks emits exactly
+// one event. Cleared only on daemon restart (via __resetForTests in tests).
+const observedYieldFiles = new Set();
+
 function runTick() {
   try {
     // CTL-676 + CTL-678: hot-reload the concurrency knobs by re-reading the
@@ -1350,6 +1389,7 @@ export function stopScheduler() {
 // public contract; the index.mjs barrel does not re-export it.
 export function __resetForTests() {
   stopScheduler();
+  observedYieldFiles.clear(); // CTL-702: reset per-lifetime dedup set between tests
 }
 
 // --- standalone entrypoint (operator dry-run / CTL-554 wires the real daemon) ---

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -125,6 +125,16 @@ describe("readPhaseSignals", () => {
   test("returns {} when the worker dir does not exist", () => {
     expect(readPhaseSignals(orchDir, "CTL-404")).toEqual({});
   });
+
+  test("ignores phase-*-yield-*.json files (CTL-702)", () => {
+    const dir = join(orchDir, "workers", "CTL-702");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-plan.json"), JSON.stringify({ status: "done" }));
+    writeFileSync(join(dir, "phase-plan-yield-20260528T050740Z.json"), JSON.stringify({}));
+    const signals = readPhaseSignals(orchDir, "CTL-702");
+    expect(Object.keys(signals)).toEqual(["plan"]);
+    expect(signals.plan).toBe("done");
+  });
 });
 
 describe("isTicketInFlight", () => {
@@ -2408,6 +2418,67 @@ describe("schedulerTick — CTL-574 reclaim-dead-work sweep", () => {
         teardownWorktree: () => true,
       })
     ).not.toThrow();
+  });
+});
+
+// CTL-702: per-worker error isolation in schedulerTick reclaim sweep.
+describe("schedulerTick — per-worker error isolation (CTL-702)", () => {
+  function writeNestedSignal(ticket, phase, body) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, ...body }));
+  }
+
+  test("schedulerTick continues past one worker's per-worker exception", () => {
+    // Two in-flight worker dirs. reclaimDeadWork throws for CTL-BAD-702 — the
+    // tick must survive and still process CTL-GOOD-702.
+    writeNestedSignal("CTL-GOOD-702", "plan", { status: "running", bg_job_id: "j1" });
+    writeNestedSignal("CTL-BAD-702", "plan", { status: "running", bg_job_id: "j2" });
+
+    const processedTickets = [];
+    const reclaimDeadWork = (_orchDir, sig) => {
+      if (sig.ticket === "CTL-BAD-702") throw new Error("injected crash for CTL-BAD-702");
+      processedTickets.push(sig.ticket);
+      return "noop";
+    };
+
+    expect(() => {
+      schedulerTick(orchDir, {
+        reclaimDeadWork,
+        readEligible: () => [],
+        dispatch: () => ({ code: 1 }),
+      });
+    }).not.toThrow();
+
+    expect(processedTickets).toContain("CTL-GOOD-702");
+  });
+
+  test("schedulerTick emits yield-file-skip once per observed yield file (CTL-702)", () => {
+    // Worker dir with one yield tombstone. schedulerTick emits once on the first
+    // tick and nothing on the second (same absolute path already in the observed set).
+    const dir = join(orchDir, "workers", "CTL-YIELD-702");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-plan.json"), JSON.stringify({ ticket: "CTL-YIELD-702", phase: "plan", status: "done" }));
+    writeFileSync(join(dir, "phase-plan-yield-20260528T050740Z.json"), JSON.stringify({}));
+
+    const emits = [];
+    schedulerTick(orchDir, {
+      appendYieldFileSkipEvent: (args) => { emits.push(args); return true; },
+      readEligible: () => [],
+      dispatch: () => ({ code: 1 }),
+    });
+    expect(emits).toHaveLength(1);
+    expect(emits[0]).toMatchObject({
+      ticket: "CTL-YIELD-702",
+      filename: "phase-plan-yield-20260528T050740Z.json",
+    });
+    // Second tick with same seam — same absolute path, no second emit.
+    schedulerTick(orchDir, {
+      appendYieldFileSkipEvent: (args) => { emits.push(args); return true; },
+      readEligible: () => [],
+      dispatch: () => ({ code: 1 }),
+    });
+    expect(emits).toHaveLength(1);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/signal-reader.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.mjs
@@ -64,11 +64,16 @@ export function readWorkerSignals(orchDir) {
 }
 
 // isPhaseSignalFile — a nested phase signal is phase-<name>.json and is NOT a
-// phase-output artifact (those are listed in ARTIFACT_NAMES).
+// phase-output artifact (those are listed in ARTIFACT_NAMES). CTL-702: also
+// rejects yield tombstones (phase-*-yield-*.json) — read-only audit files
+// written by phase-agent-yield-check. See
+// website/src/content/docs/observability/event-flow.md#yield-tombstones.
 function isPhaseSignalFile(name) {
   if (!name.endsWith(".json")) return false;
   if (ARTIFACT_NAMES.has(name)) return false;
-  return name.startsWith("phase-");
+  if (!name.startsWith("phase-")) return false;
+  if (name.includes("-yield-")) return false; // CTL-702
+  return true;
 }
 
 // listDispatchedPhases — the phase NAMES dispatched for one ticket: every

--- a/plugins/dev/scripts/execution-core/signal-reader.test.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.test.mjs
@@ -324,3 +324,52 @@ describe("byActivePhase — turn-cap-exhausted (CTL-701)", () => {
     expect(sorted[1].status).toBe("done");
   });
 });
+
+// --- CTL-702: yield-tombstone exclusion -----------------------------------
+
+describe("yield-tombstone exclusion (CTL-702)", () => {
+  test("readWorkerSignals ignores phase-*-yield-*.json files", () => {
+    const dir = join(workersDir(), "CTL-702A");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-plan.json"),
+      JSON.stringify({
+        ticket: "CTL-702A",
+        phase: "plan",
+        status: "done",
+        updatedAt: "2026-05-28T00:00:00Z",
+      }),
+    );
+    writeFileSync(
+      join(dir, "phase-plan-yield-20260528T050740Z.json"),
+      JSON.stringify({
+        yieldedAt: "2026-05-28T05:07:40Z",
+        ourJob: "abc123",
+        canonicalJob: "def456",
+      }),
+    );
+    const sigs = readWorkerSignals(orchDir);
+    const forTicket = sigs.filter((s) => s.ticket === "CTL-702A");
+    expect(forTicket).toHaveLength(1);
+    expect(forTicket[0].phase).toBe("plan");
+    expect(forTicket[0].status).toBe("done");
+  });
+
+  test("listDispatchedPhases excludes -yield- names", () => {
+    const dir = join(workersDir(), "CTL-702B");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-plan.json"), JSON.stringify({ ticket: "CTL-702B", phase: "plan", status: "done" }));
+    writeFileSync(join(dir, "phase-plan-yield-20260528T050740Z.json"), JSON.stringify({}));
+    writeFileSync(join(dir, "phase-research-yield-20260527T120000Z.json"), JSON.stringify({}));
+    const phases = listDispatchedPhases(orchDir, "CTL-702B");
+    expect(phases).toEqual(["plan"]);
+  });
+
+  test("yield-file-only worker dir returns no signals", () => {
+    const dir = join(workersDir(), "CTL-702C");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-plan-yield-20260528T050740Z.json"), JSON.stringify({}));
+    const sigs = readWorkerSignals(orchDir);
+    expect(sigs.find((s) => s.ticket === "CTL-702C")).toBeUndefined();
+  });
+});

--- a/website/src/content/docs/observability/event-flow.md
+++ b/website/src/content/docs/observability/event-flow.md
@@ -282,6 +282,28 @@ The replay uses the same handler as live deliveries (including HMAC verification
 synthetic signature — the orch-monitor owns the secret it uses to re-sign). Replayed events
 are appended to the log only if they're not already present (deduplication by delivery ID).
 
+## Yield tombstones
+
+When a phase agent detects that its `bg_job_id` is no longer the canonical
+worker for a ticket (the orphan-bg pattern, CTL-649), it gracefully yields
+instead of editing the worker tree. The yield is recorded two ways:
+
+1. **Hidden sidecar**: `workers/<TICKET>/.phase-<phase>-yield` — written by
+   `phase-agent-yield-check.sh`. No `.json` extension, leading dot, no
+   timestamp. Used by phase-agent prelude code for the inverse-yield detection
+   pattern.
+2. **Visible tombstone**: `workers/<TICKET>/phase-<phase>-yield-<timestamp>.json` —
+   audit trail of the yield event. Status is `null`, phase is `null`, no
+   `bg_job_id`. **These are read-only audit files.** The scheduler explicitly
+   skips any filename matching `phase-*-yield-*.json` in both
+   `signal-reader.mjs:isPhaseSignalFile` and `scheduler.mjs:readPhaseSignals`
+   (CTL-702). Treating one as a live signal extracts an invalid phase name and
+   crashes the supersede guard.
+
+Operators investigating a yield-storm can grep for
+`phase.scheduler.yield-file-skip.<TICKET>` events in the unified event log —
+one such event is emitted per tombstone per daemon lifetime (CTL-702).
+
 ## Related
 
 - [catalyst-events CLI](./catalyst-events/) — command reference and jq filter cookbook


### PR DESCRIPTION
## Summary

Closes CTL-702. Phase agents that yield (CTL-649 orphan-bg pattern) leave behind `phase-*-yield-<ts>.json` tombstones in the worker dir. The scheduler's signal reader was treating these as live phase signals, extracting an invalid phase name (e.g. `plan-yield-20260528T050740Z`), and the CTL-606 supersede-guard threw `PhaseFsmError` — wedging the daemon's forward-progress loop indefinitely.

Observed 2026-05-28 live: ADV-1034 had a yield tombstone from earlier in the session; the scheduler tick failed every ~10s for 11 min before manual intervention (file moved to `.yields/` subdir).

## Fix

Four-layer defense — surgical filter + structural error isolation:

- **signal-reader.mjs / scheduler.mjs** — `isPhaseSignalFile` and the worker-dir glob now skip `phase-*-yield-*.json` files
- **recovery.mjs** — yield-aware path in the reclaim/cleanup logic so the artifact stays as audit trail
- **Per-tick error isolation** — wrap individual signal processing in try/catch + warn so one bad signal can never silently take down the daemon's forward-progress loop again

## Tests

- `signal-reader.test.mjs` — yield-tombstone exclusion (3 new tests, complementary to CTL-701's turn-cap-exhausted tests at the same location, additively merged)
- `scheduler.test.mjs` — per-tick error isolation regression
- `recovery.test.mjs` — yield-aware cleanup path

All directly-affected suites pass (21/21 signal-reader, 139/139 recovery, etc). The 8 scheduler.test.mjs failures + 1 integration.test.mjs failure pre-exist on origin/main (load-sensitive scheduler flakes + a CTL-701 integration test) — verified against a fresh clone of origin/main, zero new failures introduced by this rebase.

## Test plan

- [x] `bun test signal-reader.test.mjs` — 21/21
- [x] `bun test scheduler.test.mjs` — same 8 failures as main (load flakes)
- [x] `bun test integration.test.mjs` — same 1 failure as main (CTL-701-era)
- [x] Verified against a fresh clone of origin/main: zero new failures
- [ ] After merge: hot-patch plugin cache; on next daemon restart the yield-file scheduler crash is impossible

🤖 Generated with [Claude Code](https://claude.com/claude-code)