### PR TITLE
CTL-704: Verify Todo→Triage auto-transition on first phase dispatch + telemetry

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 import { linearKeyForPhase, TERMINAL_LINEAR_KEY } from "../lib/phase-fsm.mjs";
 import { getProjectConfig } from "./registry.mjs";
 import { log } from "./config.mjs";
-import { fetchTicketLabels } from "./linear-query.mjs";
+import { fetchTicketLabels, fetchTicketState } from "./linear-query.mjs";
 import { withBreaker } from "./linear-breaker.mjs";
 
 // linear-transition.sh sits one directory up from execution-core/ — mirrors the
@@ -164,6 +164,56 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
       "linear-write: label write threw — swallowed"
     );
     return { applied: false, reason: "transient" };
+  }
+}
+
+// applyTriageStatus — verified Todo→Triage write-back (CTL-704). Reads the
+// pre-transition state, shells linear-transition.sh for the triage key, then
+// re-reads to confirm the state actually landed. Returns
+// {applied, verified, from_state, to_state, reason}. Never throws (best-effort).
+//
+// Modelled on applyLabel's read-back pattern (CTL-587). The `fetchState` seam
+// is injectable so tests never shell out to linearis; `resolveRepoRoot` + `exec`
+// are forwarded to runTransition unchanged.
+export function applyTriageStatus({
+  ticket,
+  resolveRepoRoot = defaultResolveRepoRoot,
+  exec = defaultExec,
+  fetchState = fetchTicketState,
+}) {
+  let from_state = null;
+  try {
+    // 1. Capture pre-transition state (best-effort — null is acceptable).
+    from_state = fetchState(ticket, { exec });
+
+    // 2. Shell the transition.
+    const t = runTransition({ ticket, key: "triage", resolveRepoRoot, exec });
+    if (!t.applied) {
+      return { applied: false, verified: false, from_state, to_state: null, reason: t.reason };
+    }
+
+    // 3. Resolve expected target state from the project config (stateMap.triage).
+    const team = teamOf(ticket);
+    const cfg = team ? getProjectConfig(team) : null;
+    const expectedState = cfg?.eligibleQuery?.triageStatus ?? "Triage";
+
+    // 4. Re-read to verify the state actually landed.
+    const to_state = fetchState(ticket, { exec });
+    if (to_state == null) {
+      log.warn({ ticket }, "linear-write: triage verify-unreadable — cannot confirm state landed");
+      return { applied: true, verified: false, from_state, to_state: null, reason: "verify-unreadable" };
+    }
+    if (to_state === expectedState) {
+      return { applied: true, verified: true, from_state, to_state, reason: null };
+    }
+    log.warn(
+      { ticket, expected: expectedState, actual: to_state },
+      "linear-write: triage exit-0 but read-back missing (silent-success gap)"
+    );
+    return { applied: true, verified: false, from_state, to_state, reason: "verify-failed" };
+  } catch (err) {
+    log.warn({ ticket, err: err.message }, "linear-write: applyTriageStatus threw — swallowed");
+    return { applied: false, verified: false, from_state, to_state: null, reason: "threw" };
   }
 }
 

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -5,6 +5,7 @@ import {
   applyPhaseStatus,
   applyTerminalDone,
   applyLabel,
+  applyTriageStatus,
   teamOf,
 } from "./linear-write.mjs";
 
@@ -225,5 +226,80 @@ describe("applyLabel", () => {
     };
     const r = applyLabel({ ticket: "CTL-1", label: "triaged", exec });
     expect(r).toEqual({ applied: false, reason: "transient" });
+  });
+});
+
+// CTL-704: applyTriageStatus — verified Todo→Triage write-back with pre/post state reads.
+// Uses injectable `fetchState` seam for the reads and `exec` seam for the transition.
+describe("applyTriageStatus", () => {
+  const resolveRepoRoot = () => "/repo";
+
+  // Builds a fake exec that returns a successful transition response (code 0, action: transitioned).
+  function makeTransitionExec(calls = []) {
+    return (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 0, stdout: JSON.stringify({ action: "transitioned" }), stderr: "" };
+    };
+  }
+
+  test("happy path — state lands → verified:true, from_state captured", () => {
+    const calls = [];
+    const exec = makeTransitionExec(calls);
+    let readCount = 0;
+    const fetchState = (_ticket, _opts) => (++readCount === 1 ? "Todo" : "Triage");
+    const r = applyTriageStatus({ ticket: "CTL-704", resolveRepoRoot, exec, fetchState });
+    expect(r).toEqual({ applied: true, verified: true, from_state: "Todo", to_state: "Triage", reason: null });
+    // transition was called with --transition triage
+    const args = calls[0].args;
+    expect(args).toContain("--transition");
+    expect(args[args.indexOf("--transition") + 1]).toBe("triage");
+  });
+
+  test("false-success — exit 0 but stale state → verified:false", () => {
+    const exec = makeTransitionExec();
+    // Both reads return "Todo" — the write exited 0 but state never changed
+    const fetchState = () => "Todo";
+    const r = applyTriageStatus({ ticket: "CTL-704", resolveRepoRoot, exec, fetchState });
+    expect(r.applied).toBe(true);
+    expect(r.verified).toBe(false);
+    expect(r.to_state).toBe("Todo");
+    expect(r.reason).toBe("verify-failed");
+  });
+
+  test("transition fails (exit non-zero) — applied:false, no re-read attempted", () => {
+    const calls = [];
+    const exec = (cmd, args) => {
+      calls.push({ cmd, args });
+      return { code: 1, stdout: JSON.stringify({ action: "update-failed" }), stderr: "" };
+    };
+    let readCount = 0;
+    const fetchState = (_ticket, _opts) => { readCount++; return "Todo"; };
+    const r = applyTriageStatus({ ticket: "CTL-704", resolveRepoRoot, exec, fetchState });
+    expect(r.applied).toBe(false);
+    expect(r.verified).toBe(false);
+    // fetchState called once for from_state, NOT a second time for post-transition verify
+    expect(readCount).toBe(1);
+  });
+
+  test("re-read fails (fetchTicketState returns null) → applied:true, verified:false, verify-unreadable", () => {
+    const exec = makeTransitionExec();
+    let readCount = 0;
+    const fetchState = () => (++readCount === 1 ? "Todo" : null);
+    const r = applyTriageStatus({ ticket: "CTL-704", resolveRepoRoot, exec, fetchState });
+    expect(r.applied).toBe(true);
+    expect(r.verified).toBe(false);
+    expect(r.to_state).toBeNull();
+    expect(r.reason).toBe("verify-unreadable");
+  });
+
+  test("never throws — a thrown exec still yields a result object", () => {
+    const exec = () => { throw new Error("spawn boom"); };
+    const fetchState = () => { throw new Error("read boom"); };
+    expect(() =>
+      applyTriageStatus({ ticket: "CTL-704", resolveRepoRoot, exec, fetchState })
+    ).not.toThrow();
+    const r = applyTriageStatus({ ticket: "CTL-704", resolveRepoRoot, exec, fetchState });
+    expect(r.applied).toBe(false);
+    expect(r.verified).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -31,6 +31,8 @@ import { setProjectEligible, removeTicket, dropProject } from "./eligible-set.mj
 import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { dispatchTicket } from "./dispatch.mjs";
 import { abortWorker as defaultAbortWorker } from "./abort-worker.mjs";
+import { applyTriageStatus as defaultApplyTriageStatus } from "./linear-write.mjs";
+import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 
 // DRAG_OUT_STATES — the Linear workflow states that signal "stop work on this
 // ticket". The monitor classifies these as a kill: remove the ticket from the
@@ -156,6 +158,8 @@ export function handleStateChangedEvent(
     orchDir,
     abortWorker = defaultAbortWorker,
     cache, // CTL-634: write-through target shared with the scheduler read path
+    applyTriageStatus = defaultApplyTriageStatus, // CTL-704: injectable for tests
+    appendEvent = defaultAppendEvent, // CTL-704: injectable for tests
   } = {}
 ) {
   const parsed = parseStateChangedEvent(event);
@@ -174,7 +178,13 @@ export function handleStateChangedEvent(
       // →Triage — one-shot dispatch the triage phase agent. NOT the eligible
       // set: a Triage ticket is never scheduler-pulled. Idempotent downstream
       // (phase-agent-dispatch no-ops an existing signal file).
-      dispatchTriage(parsed.identifier, { dispatch, orchDir });
+      dispatchTriage(parsed.identifier, {
+        dispatch,
+        orchDir,
+        applyTriageStatus,
+        appendEvent,
+        orchId: parsed.identifier,
+      });
     } else if (!parsed.toState || parsed.toState === query.status) {
       // →Ready (or an unknown new state). CTL-625: a confirmed →Ready
       // (toState === query.status) for a ticket with no prior triage.json means
@@ -199,7 +209,13 @@ export function handleStateChangedEvent(
         orchDir &&
         !hasTriageArtifact(orchDir, parsed.identifier)
       ) {
-        dispatchTriage(parsed.identifier, { dispatch, orchDir });
+        dispatchTriage(parsed.identifier, {
+          dispatch,
+          orchDir,
+          applyTriageStatus,
+          appendEvent,
+          orchId: parsed.identifier,
+        });
       } else {
         log.debug(
           {
@@ -238,8 +254,15 @@ export function handleStateChangedEvent(
 
 // dispatchTriage — fire the triage phase agent for a →Triage transition. Guards
 // a missing orchDir (a standalone monitor with no daemon wiring) and logs —
-// never throws — a non-zero dispatch.
-function dispatchTriage(identifier, { dispatch, orchDir }) {
+// never throws — a non-zero dispatch. CTL-704: after a successful dispatch,
+// writes Linear Todo→Triage (verified) and emits a canonical observability event.
+function dispatchTriage(identifier, {
+  dispatch,
+  orchDir,
+  applyTriageStatus = defaultApplyTriageStatus,
+  appendEvent = defaultAppendEvent,
+  orchId,
+}) {
   if (!orchDir) {
     log.warn({ identifier }, "→Triage seen but monitor has no orchDir — skipping dispatch");
     return;
@@ -247,7 +270,24 @@ function dispatchTriage(identifier, { dispatch, orchDir }) {
   const r = dispatchTicket(orchDir, identifier, "triage", { dispatch });
   if (r.code !== 0) {
     log.warn({ identifier, code: r.code }, "monitor: triage dispatch failed");
+    return;
   }
+  // CTL-704: write Linear Todo→Triage (verified) + emit observability event.
+  let res = { applied: false, verified: false, from_state: null, to_state: null, reason: null };
+  try {
+    res = applyTriageStatus({ ticket: identifier });
+  } catch (err) {
+    log.warn({ identifier, err: err.message }, "monitor: triage status write threw");
+  }
+  appendEvent({
+    ticket: identifier,
+    orchId: orchId ?? identifier,
+    from_state: res.from_state,
+    to_state: res.to_state,
+    verified: res.verified,
+    applied: res.applied,
+    reason: res.reason,
+  });
 }
 
 // hasTriageArtifact — does a triage.json exist for this ticket's worker dir?

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -462,6 +462,101 @@ describe("handleStateChangedEvent — CTL-565 two-state trigger", () => {
   });
 });
 
+// --- CTL-704: verified Todo→Triage write-back wiring in dispatchTriage ---------
+
+describe("handleStateChangedEvent — CTL-704 triage write-back wiring", () => {
+  const orchDir = "/orch";
+
+  test("CTL-704: writes Triage after successful dispatch — applyTriageStatus + appendEvent called", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const applyTriageStatus = mock(() => ({
+      applied: true,
+      verified: true,
+      from_state: "Todo",
+      to_state: "Triage",
+      reason: null,
+    }));
+    const appendEvent = mock(() => true);
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
+      },
+      { dispatch, orchDir, applyTriageStatus, appendEvent }
+    );
+    expect(dispatch).toHaveBeenCalledWith({ orchDir, ticket: "ENG-1", phase: "triage" });
+    expect(applyTriageStatus).toHaveBeenCalledTimes(1);
+    const applyArg = applyTriageStatus.mock.calls[0][0];
+    expect(applyArg.ticket).toBe("ENG-1");
+    expect(appendEvent).toHaveBeenCalledTimes(1);
+    const appendArg = appendEvent.mock.calls[0][0];
+    expect(appendArg.ticket).toBe("ENG-1");
+    expect(appendArg.from_state).toBe("Todo");
+    expect(appendArg.to_state).toBe("Triage");
+    expect(appendArg.verified).toBe(true);
+  });
+
+  test("CTL-704: dispatch fails → applyTriageStatus and appendEvent are NOT called", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 1 }));
+    const applyTriageStatus = mock(() => ({ applied: false, verified: false }));
+    const appendEvent = mock(() => true);
+    handleStateChangedEvent(
+      {
+        event: "linear.issue.state_changed",
+        detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
+      },
+      { dispatch, orchDir, applyTriageStatus, appendEvent }
+    );
+    expect(applyTriageStatus).not.toHaveBeenCalled();
+    expect(appendEvent).not.toHaveBeenCalled();
+  });
+
+  test("CTL-704: write unverified → appendEvent still called with verified:false, never throws", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const applyTriageStatus = mock(() => ({
+      applied: true,
+      verified: false,
+      from_state: "Todo",
+      to_state: "Todo",
+      reason: "verify-failed",
+    }));
+    const appendEvent = mock(() => true);
+    expect(() =>
+      handleStateChangedEvent(
+        {
+          event: "linear.issue.state_changed",
+          detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
+        },
+        { dispatch, orchDir, applyTriageStatus, appendEvent }
+      )
+    ).not.toThrow();
+    expect(appendEvent).toHaveBeenCalledTimes(1);
+    expect(appendEvent.mock.calls[0][0].verified).toBe(false);
+  });
+
+  test("CTL-704: no orchDir → unchanged no-op, applyTriageStatus not called", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const applyTriageStatus = mock(() => ({ applied: true, verified: true }));
+    const appendEvent = mock(() => true);
+    expect(() =>
+      handleStateChangedEvent(
+        {
+          event: "linear.issue.state_changed",
+          detail: { ticket: "ENG-1", teamKey: "ENG", toState: "Triage" },
+        },
+        { dispatch, applyTriageStatus, appendEvent } // no orchDir
+      )
+    ).not.toThrow();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(applyTriageStatus).not.toHaveBeenCalled();
+    expect(appendEvent).not.toHaveBeenCalled();
+  });
+});
+
 describe("lifecycle", () => {
   test("startMonitor runs an immediate reconcileAll", () => {
     enroll("ENG", { status: "Todo" });

--- a/plugins/dev/scripts/execution-core/triage-transition-event.mjs
+++ b/plugins/dev/scripts/execution-core/triage-transition-event.mjs
@@ -1,0 +1,71 @@
+// triage-transition-event.mjs — canonical phase.triage.linear-transition event (CTL-704).
+//
+// Emits an INFO observability event when the daemon auto-transitions a ticket
+// from Todo→Triage on first dispatch. Separate from recovery.mjs's WARN-coded
+// audit events (reclaim/revive/escalated) — different family, different severity,
+// different action verb — so they stay independent modules.
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+
+// defaultAppend — writes a JSONL line to the canonical event log.
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+// buildTriageTransitionEvent — returns a canonical JSONL line (string + "\n")
+// for the phase.triage.linear-transition.<TICKET> INFO event.
+export function buildTriageTransitionEvent({
+  ticket,
+  orchId,
+  from_state = null,
+  to_state = null,
+  verified = false,
+  applied = false,
+  reason = null,
+} = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: "INFO",
+      severityNumber: 9,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: {
+        "service.name": "catalyst.execution-core",
+        "service.namespace": "catalyst",
+      },
+      attributes: {
+        "event.name": `phase.triage.linear-transition.${ticket}`,
+        "event.entity": "phase",
+        "event.action": "linear-transition",
+        "event.label": ticket,
+        "catalyst.orchestration": orchId ?? ticket,
+        "linear.issue.identifier": ticket,
+      },
+      body: {
+        payload: { phase: "triage", ticket, from_state, to_state, verified, applied, reason },
+      },
+    }) + "\n"
+  );
+}
+
+// appendTriageTransitionEvent — appends the event to the canonical event log.
+// The `append` seam defaults to the real file write; inject a recording function
+// in tests. Returns true on success, false on any error (log.error + swallow).
+export function appendTriageTransitionEvent({ append = defaultAppend, ...fields } = {}) {
+  try {
+    const line = buildTriageTransitionEvent(fields);
+    append(line);
+    return true;
+  } catch (err) {
+    log.error({ err: err.message }, "triage-transition-event: append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/triage-transition-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-transition-event.test.mjs
@@ -1,0 +1,83 @@
+// triage-transition-event.test.mjs — CTL-704: canonical phase.triage.linear-transition event.
+// Run: cd plugins/dev/scripts/execution-core && bun test triage-transition-event.test.mjs
+import { describe, test, expect } from "bun:test";
+import {
+  buildTriageTransitionEvent,
+  appendTriageTransitionEvent,
+} from "./triage-transition-event.mjs";
+
+describe("buildTriageTransitionEvent", () => {
+  test("envelope shape — required attributes, resource, severityText, payload", () => {
+    const line = buildTriageTransitionEvent({
+      ticket: "CTL-704",
+      orchId: "CTL-704",
+      from_state: "Todo",
+      to_state: "Triage",
+      verified: true,
+      applied: true,
+    });
+    expect(typeof line).toBe("string");
+    expect(line.endsWith("\n")).toBe(true);
+    const ev = JSON.parse(line);
+    expect(ev.attributes["event.name"]).toBe("phase.triage.linear-transition.CTL-704");
+    expect(ev.attributes["event.entity"]).toBe("phase");
+    expect(ev.attributes["event.action"]).toBe("linear-transition");
+    expect(ev.attributes["linear.issue.identifier"]).toBe("CTL-704");
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(ev.severityText).toBe("INFO");
+    expect(ev.severityNumber).toBe(9);
+    expect(ev.body.payload).toMatchObject({
+      phase: "triage",
+      ticket: "CTL-704",
+      from_state: "Todo",
+      to_state: "Triage",
+      verified: true,
+      applied: true,
+      reason: null,
+    });
+    // ts follows the no-millis ISO shape used elsewhere
+    expect(ev.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("broker-ignored — action is linear-transition, not a pipeline lifecycle action", () => {
+    const ev = JSON.parse(buildTriageTransitionEvent({ ticket: "CTL-704" }));
+    // The broker's PHASE_EVENT_PATTERN matches complete/failed/turn-cap-exhausted/skipped.
+    // linear-transition is an observability-only event and must NOT match those patterns.
+    const action = ev.attributes["event.action"];
+    expect(action).toBe("linear-transition");
+    expect(["complete", "failed", "turn-cap-exhausted", "skipped"]).not.toContain(action);
+  });
+
+  test("reason field defaults to null when omitted", () => {
+    const ev = JSON.parse(buildTriageTransitionEvent({ ticket: "CTL-1", verified: false }));
+    expect(ev.body.payload.reason).toBeNull();
+  });
+});
+
+describe("appendTriageTransitionEvent", () => {
+  test("best-effort: injected appendFn that throws returns false and does not throw", () => {
+    const result = appendTriageTransitionEvent({
+      ticket: "CTL-704",
+      append: () => { throw new Error("disk full"); },
+    });
+    expect(result).toBe(false);
+  });
+
+  test("best-effort: injected appendFn is called with valid JSONL, returns true", () => {
+    const appended = [];
+    const result = appendTriageTransitionEvent({
+      ticket: "CTL-704",
+      orchId: "CTL-704",
+      from_state: "Todo",
+      to_state: "Triage",
+      verified: true,
+      applied: true,
+      append: (line) => appended.push(line),
+    });
+    expect(result).toBe(true);
+    expect(appended).toHaveLength(1);
+    const ev = JSON.parse(appended[0]);
+    expect(ev.attributes["event.name"]).toBe("phase.triage.linear-transition.CTL-704");
+    expect(ev.body.payload.verified).toBe(true);
+  });
+});

--- a/website/src/content/docs/guided-workflows/index.md
+++ b/website/src/content/docs/guided-workflows/index.md
@@ -30,6 +30,7 @@ Each phase writes an artifact that the next phase reads. If you stop halfway (co
 - [Understanding phases](./phases/) — what each phase does, what it writes, and how workflow context tracks the handoff between them
 - [Oneshot vs manual](./oneshot-vs-manual/) — concrete guidance on which mode fits which ticket shape
 - [Handoffs and resume](./handoffs/) — how to stop midway and pick up later without losing context
+- [Todo column convention](./todo-column-convention/) — how moving a ticket to Todo hands it to the daemon and what the auto Todo→Triage transition does
 
 ## Level 1 vs Level 2 vs Level 3
 

--- a/website/src/content/docs/guided-workflows/phases.md
+++ b/website/src/content/docs/guided-workflows/phases.md
@@ -7,6 +7,8 @@ sidebar:
 
 The guided workflow has six phases. Each one does something discrete, writes an artifact, and hands off to the next phase via the **workflow context file** at `.catalyst/.workflow-context.json`. This page explains each phase and how they connect.
 
+Before the pipeline starts, the daemon auto-transitions a ticket from **Todo → Triage** when it dispatches the triage agent. See [Todo column convention](./todo-column-convention.md) for how that write-back and verification work.
+
 ## The phases
 
 | # | Phase | Skill | Writes | Typical duration |

--- a/website/src/content/docs/guided-workflows/todo-column-convention.md
+++ b/website/src/content/docs/guided-workflows/todo-column-convention.md
@@ -1,0 +1,60 @@
+---
+title: Todo column convention
+description: How the Todo Linear state signals the daemon to start work, and what the daemon does automatically when a ticket enters that column.
+sidebar:
+  order: 4
+---
+
+The **Todo** column in Linear is the daemon's eligible-work signal. Moving a ticket into Todo hands it to the execution-core orchestrator — no other action is required.
+
+## How it works
+
+The daemon's `eligibleQuery.status` is set to `"Todo"` in `.catalyst/config.json`. On each reconcile cycle the daemon polls Linear for all tickets matching that query and holds them as the eligible set. The periodic scheduler then picks from that set and dispatches work.
+
+### Auto-transition on first dispatch
+
+When the daemon dispatches the **triage phase agent** for a Todo ticket, it immediately writes the Linear state from **Todo → Triage**. The board column updates as soon as the agent is launched — the ticket does not linger visually in Todo during the triage phase.
+
+This write is **verified**: after shelling to `linear-transition.sh`, the daemon re-reads the ticket's state and confirms it matches the configured `stateMap.triage` value (default `"Triage"`). If the transition exits 0 but the re-read shows the state is still Todo (the [silent-success failure mode](/observability/)), the daemon records `verified: false` in the event and logs a warning — the dispatch still proceeds, but the false-success is observable.
+
+### Observability event
+
+Every dispatch emits a `phase.triage.linear-transition.<TICKET>` INFO event appended to the canonical event log at `~/catalyst/events/YYYY-MM.jsonl`. The event payload carries:
+
+```json
+{
+  "phase": "triage",
+  "ticket": "CTL-123",
+  "from_state": "Todo",
+  "to_state": "Triage",
+  "verified": true,
+  "applied": true,
+  "reason": null
+}
+```
+
+This event is **observability-only** — the broker's pipeline routing does not match `linear-transition` actions, so it cannot advance the pipeline state machine.
+
+## Putting a ticket into work
+
+1. Set the ticket's state to **Todo** in Linear (drag it to the column, or use `linearis issues update <TICKET> --status Todo`).
+2. The daemon picks it up on the next reconcile (up to 10 minutes, or immediately on a `state_changed` broker event).
+3. The triage phase agent launches. Linear flips **Todo → Triage** automatically.
+4. The pipeline continues through Research → Plan → Implement → Validate → PR → Done.
+
+For more on the phases themselves, see [Understanding phases](./phases.md).
+
+## Configuration
+
+The eligible-query status is set per project in `.catalyst/config.json`:
+
+```json
+{
+  "eligibleQuery": {
+    "status": "Todo",
+    "triageStatus": "Triage"
+  }
+}
+```
+
+`triageStatus` is the target state the daemon verifies after writing. Rename it here if your Linear workspace uses a different name for the Triage column.


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-28T21:35:00Z -->
<!-- Last updated: 2026-05-28T21:35:00Z -->
<!-- PR: #1178 -->
<!-- Previous commits: dff479e496d82b0880d7251ae6b99550118bd54e -->

## Summary

Adds verified Linear state write-back when the execution-core daemon dispatches the triage phase agent. When the daemon picks up a `Todo` ticket and launches `phase-triage`, it now immediately transitions the ticket `Todo → Triage` in Linear with post-write verification — closing the silent-success gap where `linear-transition.sh` exits 0 but the state never actually changes. A canonical `phase.triage.linear-transition.<TICKET>` INFO event is appended to the event log for observability.

## Changes Made

### Execution-Core: `linear-write.mjs`

- **New `applyTriageStatus` function** — reads the pre-transition state, shells `linear-transition.sh` for the `triage` key, then re-reads the ticket state to confirm it landed. Returns `{applied, verified, from_state, to_state, reason}`. Never throws (best-effort, all errors swallowed to avoid disrupting dispatch). Modelled on the existing `applyLabel` read-back pattern (CTL-587).
- Imports `fetchTicketState` from `linear-query.mjs` for the pre/post read seams.

### Execution-Core: `monitor.mjs`

- **`dispatchTriage` updated** — after a successful dispatch, calls `applyTriageStatus` then `appendTriageTransitionEvent`. Both are injectable via the function signature for test isolation.
- `handleStateChangedEvent` forwards the new `applyTriageStatus` and `appendEvent` seams through to `dispatchTriage`.

### New Module: `triage-transition-event.mjs`

- **`buildTriageTransitionEvent`** — constructs a canonical JSONL event envelope for `phase.triage.linear-transition.<TICKET>` (INFO severity, `event.action = "linear-transition"`). Separate from `recovery.mjs`'s WARN-coded audit events — different family, different severity.
- **`appendTriageTransitionEvent`** — appends to the canonical event log with best-effort error handling. The `append` function is injectable for tests.

### Tests

- **5 new `applyTriageStatus` tests** in `linear-write.test.mjs`: happy path (verified), false-success (exit 0, state unchanged), transition fails, re-read returns null, never-throws invariant.
- **5 new `triage-transition-event` tests**: event shape/attributes, broker-ignored assertion (action ≠ `complete`/`failed`/etc.), reason defaults to null, best-effort-on-throw, and round-trip JSONL validity.
- **4 new `monitor.mjs` wiring tests**: confirmed dispatch calls `applyTriageStatus`, event emitted on success, event not emitted on transition failure, and the no-dispatch path (→Ready) is unaffected.
- **Total: 79 tests, 0 failures.**

### Documentation

- **New doc: `todo-column-convention.md`** — explains that moving a ticket to Todo hands it to the daemon, describes the auto-transition behavior, observability event payload, and the `triageStatus` config key.
- Cross-links added to `guided-workflows/index.md` and `guided-workflows/phases.md`.

## How to Verify It

- [x] Tests pass: `cd plugins/dev/scripts/execution-core && bun test` — 79 tests, 0 fail
- [x] `applyTriageStatus` imported and wired in `monitor.mjs:dispatchTriage`
- [x] `triage-transition-event.mjs` exists and exports both functions
- [ ] Live: drop a ticket in Todo column → daemon dispatches triage → ticket moves to Triage in Linear; event log shows `phase.triage.linear-transition.<TICKET>` line

## Known Deferred Items (from review)

- **Medium / observability**: On `→Triage` state-changed events, `dispatchTriage` re-runs including `applyTriageStatus` even when a triage artifact already exists (the echo from its own write). Bounded to one echo (no-op dispatch + a second `linear-transition` event). Deferred — would require an `hasTriageArtifact` guard on the `→Triage` branch.
- **Low / docs**: `todo-column-convention.md` Configuration section references `eligibleQuery.triageStatus` as a top-level config key; actual runtime config is in the execution-core registry (`~/catalyst/execution-core/registry.json`). Deferred — doc confusion, not runtime bug.
- **Low / DRY**: `applyTriageStatus` resolves `triageStatus` inline (`cfg?.eligibleQuery?.triageStatus ?? "Triage"`) instead of calling `resolveEligibleQuery(cfg).triageStatus`. Behavior-identical today. Deferred — nit.

## Related Issues

- Fixes https://linear.app/coalescelabs/issue/CTL-704
