### PR TITLE
CTL-706: per-project resource budgets for execution-core scheduler

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler-perproject.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler-perproject.test.mjs
@@ -1,0 +1,99 @@
+// Unit tests for the per-project dispatch helpers added in CTL-706.
+// Run: cd plugins/dev/scripts/execution-core && bun test scheduler-perproject.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  selectDispatchablePerProject,
+  buildPerProjectGauge,
+} from "./scheduler.mjs";
+
+const tk = (id) => ({
+  identifier: id,
+  priority: 1,
+  createdAt: "x",
+  state: "Todo",
+  relations: { nodes: [] },
+  inverseRelations: { nodes: [] },
+});
+const ids = (sel) => sel.map((t) => t.identifier);
+
+describe("selectDispatchablePerProject — equivalence (CTL-706)", () => {
+  test("empty perProject behaves exactly like selectDispatchable", () => {
+    const ranked = [tk("CTL-1"), tk("CTL-2"), tk("CTL-3")];
+    expect(ids(selectDispatchablePerProject(ranked, new Set(["CTL-2"]), 2, {}))).toEqual([
+      "CTL-1",
+      "CTL-3",
+    ]);
+  });
+  test("freeSlots 0 → []", () => {
+    expect(
+      selectDispatchablePerProject([tk("CTL-1")], new Set(), 0, {
+        perProject: { CTL: { maxParallel: 2 } },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("selectDispatchablePerProject — cap saturation (CTL-706)", () => {
+  test("project at cap is skipped; next non-saturated project picked", () => {
+    const ranked = [tk("ADV-1"), tk("ADV-2"), tk("CTL-1")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 2, {
+      perProject: { ADV: { maxParallel: 1, reserve: 0 }, CTL: { maxParallel: 3, reserve: 0 } },
+      inFlight: new Set(),
+    });
+    expect(ids(sel)).toEqual(["ADV-1", "CTL-1"]);
+  });
+  test("in-flight count counts toward the cap", () => {
+    const ranked = [tk("ADV-2"), tk("CTL-1")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 2, {
+      perProject: { ADV: { maxParallel: 1 }, CTL: { maxParallel: 3 } },
+      inFlight: new Set(["ADV-9"]),
+    });
+    expect(ids(sel)).toEqual(["CTL-1"]);
+  });
+});
+
+describe("selectDispatchablePerProject — reserve enforcement (CTL-706)", () => {
+  test("last shared slot withheld so another project can reach its reserve", () => {
+    const ranked = [tk("ADV-1"), tk("CTL-1")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 1, {
+      perProject: { ADV: { reserve: 0 }, CTL: { reserve: 1 } },
+      inFlight: new Set(),
+    });
+    expect(ids(sel)).toEqual(["CTL-1"]);
+  });
+  test("reserve does NOT bite when the reserved project has no waiting work", () => {
+    const ranked = [tk("ADV-1"), tk("ADV-2")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 1, {
+      perProject: { ADV: { reserve: 0 }, CTL: { reserve: 1 } },
+      inFlight: new Set(),
+    });
+    expect(ids(sel)).toEqual(["ADV-1"]);
+  });
+  test("a project filling its OWN reserve is never blocked by the reserve guard", () => {
+    const ranked = [tk("CTL-1"), tk("CTL-2")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 2, {
+      perProject: { CTL: { reserve: 2 } },
+      inFlight: new Set(),
+    });
+    expect(ids(sel)).toEqual(["CTL-1", "CTL-2"]);
+  });
+});
+
+describe("buildPerProjectGauge (CTL-706)", () => {
+  test("counts in-flight per project and surfaces cap/reserve", () => {
+    const g = buildPerProjectGauge(
+      new Set(["ADV-1", "ADV-2", "CTL-1"]),
+      { ADV: { maxParallel: 4, reserve: 2 }, CTL: { maxParallel: 3, reserve: 1 } },
+      1,
+    );
+    expect(g.freeSlots).toBe(1);
+    expect(g.perProject.ADV).toEqual({ inFlight: 2, maxParallel: 4, reserve: 2 });
+    expect(g.perProject.CTL).toEqual({ inFlight: 1, maxParallel: 3, reserve: 1 });
+  });
+  test("includes an in-flight project with no config entry", () => {
+    const g = buildPerProjectGauge(new Set(["ZZZ-1"]), { CTL: { reserve: 1 } }, 0);
+    expect(g.perProject.ZZZ).toEqual({ inFlight: 1 });
+    expect(g.perProject.CTL).toEqual({ inFlight: 0, reserve: 1 });
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -216,13 +216,103 @@ export function readExecutionCoreConcurrencyLayer2(layer2Path) {
 // block is concurrency-only by convention). The returned object is fed to
 // readMaxParallel verbatim — same shape, same precedence-and-clamp semantics
 // as CTL-665.
+// positiveIntFields — returns a new object containing only the fields from
+// `obj` whose values are positive integers. Used by perProject merge + validate.
+function positiveIntFields(obj) {
+  if (!obj || typeof obj !== "object") return {};
+  const out = {};
+  for (const k of ["maxParallel", "reserve"]) {
+    const v = obj[k];
+    if (Number.isInteger(v) && v > 0) out[k] = v;
+  }
+  return out;
+}
+
+// warnedPerProjectConfigs — dedup set keyed on stable JSON signature of the
+// perProject map, so per-tick re-reads don't spam (mirrors observedYieldFiles).
+const warnedPerProjectConfigs = new Set();
+
+function warnPerProjectOnce(sig, msg, ctx) {
+  if (warnedPerProjectConfigs.has(sig)) return;
+  warnedPerProjectConfigs.add(sig);
+  log.warn(ctx, msg);
+}
+
 export function mergeExecutionCoreConcurrency(layer1 = {}, layer2 = {}) {
   const merged = { ...layer1 };
   for (const key of ["maxParallel", "minParallel", "maxParallelCeiling"]) {
     const v = layer2?.[key];
     if (Number.isInteger(v) && v > 0) merged[key] = v;
   }
-  return merged;
+  // CTL-706: deep-merge perProject — sub-field level, positive-int guard per field.
+  const l1pp = layer1?.perProject;
+  const l2pp = layer2?.perProject;
+  if (l1pp || l2pp) {
+    const allKeys = new Set([...Object.keys(l1pp ?? {}), ...Object.keys(l2pp ?? {})]);
+    const mergedPP = {};
+    for (const k of allKeys) {
+      mergedPP[k] = { ...(l1pp?.[k] ?? {}), ...positiveIntFields(l2pp?.[k]) };
+    }
+    merged.perProject = mergedPP;
+  }
+  return validatePerProjectBudgets(merged);
+}
+
+// validatePerProjectBudgets — clamps over-subscribed reserves so
+// sum(reserve) ≤ maxParallel, warns once per distinct config (CTL-706).
+// Never throws; returns input unchanged when perProject is absent/empty.
+export function validatePerProjectBudgets(concurrency) {
+  const pp = concurrency?.perProject;
+  if (!pp || typeof pp !== "object" || Object.keys(pp).length === 0) return concurrency;
+
+  const globalMax =
+    Number.isInteger(concurrency.maxParallel) && concurrency.maxParallel > 0
+      ? concurrency.maxParallel
+      : DEFAULT_MAX_PARALLEL;
+
+  // Coerce each entry to valid non-negative integers.
+  const coerced = {};
+  for (const [k, v] of Object.entries(pp)) {
+    const entry = {};
+    if (Number.isInteger(v?.maxParallel) && v.maxParallel > 0) entry.maxParallel = v.maxParallel;
+    if (Number.isInteger(v?.reserve) && v.reserve >= 0) entry.reserve = v.reserve;
+    coerced[k] = entry;
+  }
+
+  // Clamp reserves so sum ≤ globalMax (descending reserve, then key-asc).
+  const keysWithReserve = Object.keys(coerced)
+    .filter((k) => coerced[k].reserve > 0)
+    .sort((a, b) => (coerced[b].reserve ?? 0) - (coerced[a].reserve ?? 0) || a.localeCompare(b));
+
+  const totalReserve = keysWithReserve.reduce((s, k) => s + coerced[k].reserve, 0);
+  const sig = JSON.stringify(coerced);
+
+  if (totalReserve > globalMax) {
+    warnPerProjectOnce(
+      `clamp:${sig}`,
+      "execution-core: perProject reserves over-subscribed; clamping to fit maxParallel",
+      { totalReserve, globalMax, perProject: coerced },
+    );
+    let remaining = globalMax;
+    for (const k of keysWithReserve) {
+      const want = coerced[k].reserve;
+      coerced[k] = { ...coerced[k], reserve: Math.min(want, remaining) };
+      remaining = Math.max(0, remaining - coerced[k].reserve);
+    }
+  }
+
+  const configuredCaps = Object.values(coerced)
+    .filter((e) => e.maxParallel > 0)
+    .reduce((s, e) => s + e.maxParallel, 0);
+  if (configuredCaps > 0 && configuredCaps < globalMax) {
+    warnPerProjectOnce(
+      `under:${sig}`,
+      "execution-core: sum(perProject.maxParallel) < globalMax — some slots may be unused",
+      { configuredCaps, globalMax },
+    );
+  }
+
+  return { ...concurrency, perProject: coerced };
 }
 
 // clampToBounds — raise `value` to `minParallel` and lower it to
@@ -435,6 +525,109 @@ export function selectDispatchable(rankedReady, excludeTickets, freeSlots) {
   if (freeSlots <= 0) return [];
   const exclude = excludeTickets ?? new Set();
   return (rankedReady ?? []).filter((t) => !exclude.has(t.identifier)).slice(0, freeSlots);
+}
+
+// tallyByProject — counts occurrences of each team prefix in an iterable of
+// ticket identifiers. Returns a plain object { "CTL": 2, "ADV": 1, … }.
+function tallyByProject(ids) {
+  const tally = {};
+  for (const id of ids) {
+    const p = teamOf(id);
+    if (p) tally[p] = (tally[p] ?? 0) + 1;
+  }
+  return tally;
+}
+
+// selectDispatchablePerProject — CTL-706 ranked-walk selector that applies
+// per-project cap + reserve guards AFTER the global free-slot ceiling.
+//
+// Reserve model: work-aware greedy. A project's reserve only protects its
+// unmet demand when it has undispatched ready work. A candidate filling its
+// OWN reserve (running[P] < reserveP) bypasses the reserve guard — it can
+// never starve another project by claiming its own floor.
+//
+// With no perProject config (or an empty map) this is byte-for-byte
+// equivalent to selectDispatchable.
+export function selectDispatchablePerProject(
+  rankedReady,
+  excludeTickets,
+  freeSlots,
+  { perProject = {}, inFlight = new Set() } = {},
+) {
+  if (freeSlots <= 0) return [];
+  const pp = perProject ?? {};
+  if (Object.keys(pp).length === 0) {
+    return selectDispatchable(rankedReady, excludeTickets, freeSlots);
+  }
+
+  const exclude = excludeTickets ?? new Set();
+  const candidates = (rankedReady ?? []).filter((t) => !exclude.has(t.identifier));
+
+  // Seed running counts from in-flight workers.
+  const running = tallyByProject(inFlight);
+
+  // Pre-compute per-project ready-remaining counts (work-bounded reserve demand).
+  const readyRemaining = tallyByProject(candidates.map((t) => t.identifier));
+
+  const selected = [];
+
+  for (const t of candidates) {
+    if (selected.length >= freeSlots) break;
+    const P = teamOf(t.identifier) ?? "";
+
+    // Cap guard: skip if this project is at its hard cap.
+    const cap = pp[P]?.maxParallel;
+    if (Number.isInteger(cap) && cap > 0 && (running[P] ?? 0) >= cap) {
+      readyRemaining[P] = Math.max(0, (readyRemaining[P] ?? 0) - 1);
+      continue;
+    }
+
+    const reserveP = Number.isInteger(pp[P]?.reserve) ? pp[P].reserve : 0;
+    const runningP = running[P] ?? 0;
+
+    // Reserve guard: only applies when P is already at or above its own reserve
+    // (i.e. this dispatch consumes a *shared* slot, not P's own floor).
+    if (runningP >= reserveP) {
+      const remainingAfter = freeSlots - selected.length - 1;
+      // Sum of unmet, work-bounded reserve demand from every OTHER project.
+      let demandOthers = 0;
+      for (const [Q, cfg] of Object.entries(pp)) {
+        if (Q === P) continue;
+        const reserveQ = Number.isInteger(cfg?.reserve) ? cfg.reserve : 0;
+        const runningQ = running[Q] ?? 0;
+        const unmetQ = Math.max(0, reserveQ - runningQ);
+        const waitingQ = readyRemaining[Q] ?? 0;
+        demandOthers += Math.min(unmetQ, waitingQ);
+      }
+      if (remainingAfter < demandOthers) {
+        readyRemaining[P] = Math.max(0, (readyRemaining[P] ?? 0) - 1);
+        continue;
+      }
+    }
+
+    selected.push(t);
+    running[P] = (running[P] ?? 0) + 1;
+    readyRemaining[P] = Math.max(0, (readyRemaining[P] ?? 0) - 1);
+  }
+
+  return selected;
+}
+
+// buildPerProjectGauge — pure helper that assembles the per-tick slot-usage
+// gauge object (CTL-706). Returns { freeSlots, perProject: { <KEY>: { inFlight,
+// maxParallel?, reserve? } } } over the union of in-flight + configured projects.
+export function buildPerProjectGauge(inFlight, perProject = {}, freeSlots) {
+  const pp = perProject ?? {};
+  const inFlightTally = tallyByProject(inFlight);
+  const allKeys = new Set([...Object.keys(inFlightTally), ...Object.keys(pp)]);
+  const gauge = {};
+  for (const k of allKeys) {
+    const entry = { inFlight: inFlightTally[k] ?? 0 };
+    if (Number.isInteger(pp[k]?.maxParallel)) entry.maxParallel = pp[k].maxParallel;
+    if (Number.isInteger(pp[k]?.reserve)) entry.reserve = pp[k].reserve;
+    gauge[k] = entry;
+  }
+  return { freeSlots, perProject: gauge };
 }
 
 // ─── Phase 4: dispatch and FSM-driven phase advancement ───
@@ -1102,7 +1295,21 @@ export function schedulerTick(
   // CTL-665: config-first ceiling — a committed executionCore.maxParallel
   // (threaded via `concurrency`) wins over state.json; clamped to the bounds.
   const freeSlots = computeFreeSlots(readMaxParallel(orchDir, concurrency), inFlightCount);
-  const selected = selectDispatchable(ready, listStartedTickets(orchDir), freeSlots);
+  // CTL-706: per-project caps + reserves gate selection AFTER ranking. With
+  // no perProject config this is byte-for-byte selectDispatchable.
+  // inFlightTickets was already computed above for the reclaim sweep.
+  const selected = selectDispatchablePerProject(ready, listStartedTickets(orchDir), freeSlots, {
+    perProject: concurrency?.perProject,
+    inFlight: inFlightTickets,
+  });
+  // CTL-706: per-project slot-usage gauge (dashboarding). log-line-only,
+  // matching the cache.stats() per-tick metric convention.
+  if (concurrency?.perProject && Object.keys(concurrency.perProject).length > 0) {
+    log.info(
+      buildPerProjectGauge(inFlightTickets, concurrency.perProject, freeSlots),
+      "scheduler: per-project slots",
+    );
+  }
 
   const dispatched = [];
   for (const t of selected) {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -29,6 +29,9 @@ import {
   resolveReapPredecessor,
   computeReadyTickets,
   selectDispatchable,
+  selectDispatchablePerProject,
+  validatePerProjectBudgets,
+  buildPerProjectGauge,
   deriveAdvancement,
   maybeResetForRemediateCycle,
   maybeEscalateRemediateExhausted,
@@ -345,6 +348,160 @@ describe("mergeExecutionCoreConcurrency (CTL-678)", () => {
       maxParallelCeiling: 10,
       eligibleQuery: { status: "Ready" },
     });
+  });
+});
+
+describe("mergeExecutionCoreConcurrency — perProject (CTL-706)", () => {
+  test("layer-1-only perProject passes through", () => {
+    const l1 = { maxParallel: 6, perProject: { CTL: { maxParallel: 3, reserve: 1 } } };
+    expect(mergeExecutionCoreConcurrency(l1, {})).toMatchObject({
+      perProject: { CTL: { maxParallel: 3, reserve: 1 } },
+    });
+  });
+  test("layer-2 adds a new project key", () => {
+    const l1 = { maxParallel: 6, perProject: { CTL: { maxParallel: 3, reserve: 1 } } };
+    const l2 = { perProject: { ADV: { maxParallel: 4, reserve: 2 } } };
+    const result = mergeExecutionCoreConcurrency(l1, l2);
+    expect(result.perProject.CTL).toMatchObject({ maxParallel: 3, reserve: 1 });
+    expect(result.perProject.ADV).toMatchObject({ maxParallel: 4, reserve: 2 });
+  });
+  test("layer-2 sub-field override wins per field, other fields preserved", () => {
+    const l1 = { maxParallel: 6, perProject: { CTL: { maxParallel: 3, reserve: 1 } } };
+    const l2 = { perProject: { CTL: { reserve: 2 } } };
+    expect(mergeExecutionCoreConcurrency(l1, l2).perProject.CTL).toMatchObject({
+      maxParallel: 3,
+      reserve: 2,
+    });
+  });
+  test("invalid layer-2 sub-field (non-positive / non-int) is ignored", () => {
+    const l1 = { maxParallel: 6, perProject: { CTL: { maxParallel: 3, reserve: 1 } } };
+    const l2 = { perProject: { CTL: { maxParallel: 0, reserve: -1 } } };
+    expect(mergeExecutionCoreConcurrency(l1, l2).perProject.CTL).toMatchObject({
+      maxParallel: 3,
+      reserve: 1,
+    });
+  });
+  test("scalar-only merge with no perProject is unchanged (regression)", () => {
+    expect(mergeExecutionCoreConcurrency({ maxParallel: 4 }, { maxParallel: 6 })).toEqual({
+      maxParallel: 6,
+    });
+  });
+});
+
+describe("validatePerProjectBudgets (CTL-706)", () => {
+  test("absent perProject → unchanged", () => {
+    expect(validatePerProjectBudgets({ maxParallel: 6 })).toEqual({ maxParallel: 6 });
+  });
+  test("sum(reserve) ≤ maxParallel → reserves untouched", () => {
+    const c = { maxParallel: 6, perProject: { ADV: { reserve: 2 }, CTL: { reserve: 1 } } };
+    const out = validatePerProjectBudgets(c);
+    expect(out.perProject.ADV.reserve).toBe(2);
+    expect(out.perProject.CTL.reserve).toBe(1);
+  });
+  test("sum(reserve) > maxParallel → reserves clamped so sum ≤ maxParallel", () => {
+    const c = { maxParallel: 3, perProject: { ADV: { reserve: 3 }, CTL: { reserve: 2 } } };
+    const out = validatePerProjectBudgets(c).perProject;
+    const sum = (out.ADV.reserve ?? 0) + (out.CTL.reserve ?? 0);
+    expect(sum).toBeLessThanOrEqual(3);
+    expect(out.ADV.reserve ?? 0).toBeGreaterThanOrEqual(0);
+  });
+  test("never throws on garbage entries", () => {
+    expect(() =>
+      validatePerProjectBudgets({ maxParallel: 6, perProject: { X: { reserve: "nope" } } }),
+    ).not.toThrow();
+  });
+});
+
+describe("selectDispatchablePerProject — equivalence (CTL-706)", () => {
+  const tk = (id) => ({
+    identifier: id,
+    priority: 1,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+  const ids = (sel) => sel.map((t) => t.identifier);
+
+  test("empty perProject behaves exactly like selectDispatchable", () => {
+    const ranked = [tk("CTL-1"), tk("CTL-2"), tk("CTL-3")];
+    expect(ids(selectDispatchablePerProject(ranked, new Set(["CTL-2"]), 2, {}))).toEqual([
+      "CTL-1",
+      "CTL-3",
+    ]);
+  });
+  test("freeSlots 0 → []", () => {
+    expect(
+      selectDispatchablePerProject([tk("CTL-1")], new Set(), 0, {
+        perProject: { CTL: { maxParallel: 2 } },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("selectDispatchablePerProject — cap saturation (CTL-706)", () => {
+  const tk = (id) => ({
+    identifier: id,
+    priority: 1,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+  const ids = (sel) => sel.map((t) => t.identifier);
+
+  test("project at cap is skipped; next non-saturated project picked", () => {
+    const ranked = [tk("ADV-1"), tk("ADV-2"), tk("CTL-1")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 2, {
+      perProject: { ADV: { maxParallel: 1, reserve: 0 }, CTL: { maxParallel: 3, reserve: 0 } },
+      inFlight: new Set(),
+    });
+    expect(ids(sel)).toEqual(["ADV-1", "CTL-1"]);
+  });
+  test("in-flight count counts toward the cap", () => {
+    const ranked = [tk("ADV-2"), tk("CTL-1")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 2, {
+      perProject: { ADV: { maxParallel: 1 }, CTL: { maxParallel: 3 } },
+      inFlight: new Set(["ADV-9"]),
+    });
+    expect(ids(sel)).toEqual(["CTL-1"]);
+  });
+});
+
+describe("selectDispatchablePerProject — reserve enforcement (CTL-706)", () => {
+  const tk = (id) => ({
+    identifier: id,
+    priority: 1,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+  const ids = (sel) => sel.map((t) => t.identifier);
+
+  test("last shared slot withheld so another project can reach its reserve", () => {
+    const ranked = [tk("ADV-1"), tk("CTL-1")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 1, {
+      perProject: { ADV: { reserve: 0 }, CTL: { reserve: 1 } },
+      inFlight: new Set(),
+    });
+    expect(ids(sel)).toEqual(["CTL-1"]);
+  });
+  test("reserve does NOT bite when the reserved project has no waiting work", () => {
+    const ranked = [tk("ADV-1"), tk("ADV-2")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 1, {
+      perProject: { ADV: { reserve: 0 }, CTL: { reserve: 1 } },
+      inFlight: new Set(),
+    });
+    expect(ids(sel)).toEqual(["ADV-1"]);
+  });
+  test("a project filling its OWN reserve is never blocked by the reserve guard", () => {
+    const ranked = [tk("CTL-1"), tk("CTL-2")];
+    const sel = selectDispatchablePerProject(ranked, new Set(), 2, {
+      perProject: { CTL: { reserve: 2 } },
+      inFlight: new Set(),
+    });
+    expect(ids(sel)).toEqual(["CTL-1", "CTL-2"]);
   });
 });
 
@@ -945,6 +1102,118 @@ describe("schedulerTick — new-work pull", () => {
       // CTL-565: new-work pull enters at research, not triage.
       { orchDir, ticket: "CTL-X", phase: "research" },
     ]);
+  });
+});
+
+// ── CTL-706: per-project cap + reserve wired into schedulerTick ──
+describe("schedulerTick — CTL-706 per-project budgets", () => {
+  const mk = (id, p = 1) => ({
+    identifier: id,
+    priority: p,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+
+  test("perProject cap saturation skips the next pick", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 3 }));
+    const dispatch = fakeDispatch();
+    const eligible = [mk("ADV-1", 1), mk("ADV-2", 1), mk("CTL-1", 2)];
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      concurrency: { maxParallel: 3, perProject: { ADV: { maxParallel: 1 } } },
+    });
+    expect(r.dispatched).toEqual(["ADV-1", "CTL-1"]);
+  });
+
+  test("perProject reserve withholds a slot for a starved project", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch();
+    const eligible = [mk("ADV-1", 1), mk("CTL-1", 2)];
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      concurrency: { maxParallel: 1, perProject: { CTL: { reserve: 1 } } },
+    });
+    expect(r.dispatched).toEqual(["CTL-1"]);
+  });
+
+  test("no perProject config → identical to pre-CTL-706 behavior (regression)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = fakeDispatch();
+    const eligible = [mk("CTL-9", 4), mk("CTL-8", 1)];
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+    });
+    expect(r.dispatched).toEqual(["CTL-8", "CTL-9"]);
+  });
+});
+
+describe("CTL-706 — per-project budgets integration", () => {
+  const mk = (id, p = 1) => ({
+    identifier: id,
+    priority: p,
+    createdAt: "x",
+    state: "Todo",
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+
+  test("ADV burst respects cap=3; CTL reserve=1 is never starved", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 4 }));
+    const dispatch = fakeDispatch();
+    const eligible = [
+      mk("ADV-1", 1),
+      mk("ADV-2", 1),
+      mk("ADV-3", 1),
+      mk("ADV-4", 1),
+      mk("ADV-5", 1),
+      mk("ADV-6", 1),
+      mk("CTL-1", 2),
+      mk("CTL-2", 2),
+    ];
+    const r = schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      concurrency: {
+        maxParallel: 4,
+        perProject: { ADV: { maxParallel: 3, reserve: 2 }, CTL: { maxParallel: 3, reserve: 1 } },
+      },
+    });
+    const advCount = r.dispatched.filter((t) => t.startsWith("ADV")).length;
+    const ctlCount = r.dispatched.filter((t) => t.startsWith("CTL")).length;
+    expect(advCount).toBeLessThanOrEqual(3);
+    expect(ctlCount).toBeGreaterThanOrEqual(1);
+    expect(r.dispatched.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("buildPerProjectGauge (CTL-706)", () => {
+  test("counts in-flight per project and surfaces cap/reserve", () => {
+    const g = buildPerProjectGauge(
+      new Set(["ADV-1", "ADV-2", "CTL-1"]),
+      { ADV: { maxParallel: 4, reserve: 2 }, CTL: { maxParallel: 3, reserve: 1 } },
+      1,
+    );
+    expect(g.freeSlots).toBe(1);
+    expect(g.perProject.ADV).toEqual({ inFlight: 2, maxParallel: 4, reserve: 2 });
+    expect(g.perProject.CTL).toEqual({ inFlight: 1, maxParallel: 3, reserve: 1 });
+  });
+  test("includes an in-flight project with no config entry", () => {
+    const g = buildPerProjectGauge(new Set(["ZZZ-1"]), { CTL: { reserve: 1 } }, 0);
+    expect(g.perProject.ZZZ).toEqual({ inFlight: 1 });
+    expect(g.perProject.CTL).toEqual({ inFlight: 0, reserve: 1 });
   });
 });
 

--- a/website/src/content/docs/observability/setup.md
+++ b/website/src/content/docs/observability/setup.md
@@ -193,6 +193,26 @@ The dashboard includes:
 - **Tool use frequency** — which tools agents reach for most often
 - **Cost tracking** — $ per session, per worker, per orchestrator
 
+#### Per-project slot-usage gauge (CTL-706)
+
+When `executionCore.perProject` is configured, the scheduler emits a structured log line on every tick:
+
+```
+scheduler: per-project slots  { freeSlots: 2, perProject: { ADV: { inFlight: 3, maxParallel: 6, reserve: 2 }, CTL: { inFlight: 1, maxParallel: 4, reserve: 1 } } }
+```
+
+Fields in `perProject.<KEY>`:
+
+| Field        | Description |
+| ------------ | ----------- |
+| `inFlight`   | Workers currently occupying a slot for this project. |
+| `maxParallel`| Configured hard cap for this project (omitted when not set). |
+| `reserve`    | Configured guaranteed floor for this project (omitted when not set). |
+
+The top-level `freeSlots` is the global free-slot count for that tick. The line is emitted only when at least one project key is configured — runs without `perProject` produce no extra noise.
+
+Recommended Grafana panel: a multi-series gauge showing `inFlight` vs `maxParallel` per project key, filtered to log lines where `msg == "scheduler: per-project slots"` via Loki or a pino JSON log scrape.
+
 ## Troubleshooting
 
 ### No telemetry arriving

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -965,7 +965,7 @@ concurrency is `{maxParallel:6, minParallel:1, maxParallelCeiling:10}`.
 The Layer-2 path is **host-wide** — `config.json`, no `projectKey` suffix.
 The execution-core daemon is one-per-machine and serves all enrolled
 projects, so this knob is a host knob, not a project knob. Per-project
-overrides are not modeled today.
+concurrency and reserve budgets are modeled via `perProject` (see below).
 
 Both files are also **hot-reloaded per scheduler tick** — the same per-tick
 re-read CTL-676 introduced for Layer-1 also applies to Layer-2, so editing
@@ -1001,6 +1001,45 @@ dispatcher reads `dispatchMode` at
 [`plugins/dev/scripts/orchestrate-dispatch-next:117`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/orchestrate-dispatch-next);
 per-phase resolution lives in
 [`phase-agent-dispatch:158-176`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/phase-agent-dispatch).
+
+#### Per-project budgets (CTL-706)
+
+The `perProject` map under `executionCore` assigns each enrolled project a
+**hard cap** and/or a **guaranteed reserve** so one high-volume project cannot
+starve another.
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "executionCore": {
+        "maxParallel": 8,
+        "perProject": {
+          "ADV": { "maxParallel": 6, "reserve": 2 },
+          "CTL": { "maxParallel": 4, "reserve": 1 }
+        }
+      }
+    }
+  }
+}
+```
+
+| Field                              | Type   | Description |
+| ---------------------------------- | ------ | ----------- |
+| `perProject.<KEY>.maxParallel`     | number | Hard per-project cap. The project may never dispatch more than this many concurrent workers, even when the global pool has free slots. |
+| `perProject.<KEY>.reserve`         | number | Minimum guaranteed slot count. When this project has undispatched ready work, other projects yield so it can always reach this floor. |
+
+**Three rules govern the interaction with the global ceiling:**
+
+1. **`perProject.maxParallel` is a hard cap.** A project never exceeds it regardless of global free slots.
+2. **`reserve` is a guaranteed floor.** When a project has waiting work and is below its reserve, the dispatcher withholds shared slots from other projects so the reserved project can claim them. A project filling its own reserve is never blocked by another project's reserve.
+3. **`sum(reserve)` must be ≤ `maxParallel` (global).** The scheduler clamps over-subscribed reserves at config load and logs a one-time warning; `sum(perProject.maxParallel)` may exceed the global ceiling (projects share overflow slots) but reserves must fit.
+
+**Layer-1 / Layer-2 merge:** the `perProject` map is deep-merged at the project-key level. Layer-2 can add a new project key or override individual sub-fields (`maxParallel` or `reserve`) for an existing key; other fields from Layer-1 are preserved. This lets a machine override just the ADV cap without touching the CTL reserve.
+
+**Hot-reload:** `perProject` is re-read and re-merged on every tick alongside the scalar concurrency fields — no daemon restart required.
+
+**Opt-in, additive.** With no `perProject` key in either config layer the scheduler behaves byte-for-byte as before CTL-706. No state migration required.
 
 ## Feedback Config
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-28T21:38:00Z -->
<!-- Last updated: 2026-05-28T21:38:00Z -->
<!-- PR: #1179 -->
<!-- Previous commits: c0af9377f3962942a85dc6f40d316fa2b0f9a199 -->

## Summary

Adds **per-project resource budgets** to the execution-core scheduler so high-volume projects
(e.g. ADV with its heavyweight vitest/turbo/bun-typecheck workers) can no longer crowd out
lighter projects (e.g. CTL). Two knobs per project key:

- `maxParallel` — hard cap; the project never dispatches more than this regardless of free global slots
- `reserve` — guaranteed floor; when a project has waiting work the dispatcher withholds shared slots from other projects until the reserved project fills its floor

Fully opt-in and additive — no `perProject` key means behavior is byte-for-byte identical to
before this change. No state migration, no daemon restart required.

## Changes

### Scheduler (`plugins/dev/scripts/execution-core/scheduler.mjs`)

- **`mergeExecutionCoreConcurrency`** — deep-merges `perProject` at the project-key level; Layer-2 wins per sub-field (`maxParallel`, `reserve`) so a machine override touches only the keys it specifies
- **`validatePerProjectBudgets(concurrency)`** — clamps over-subscribed reserves (`sum(reserve) > maxParallel`) and warns once per distinct config signature via `warnedPerProjectConfigs` dedup set
- **`selectDispatchablePerProject(rankedReady, excludeTickets, freeSlots, opts)`** — pure ranked-walk selector applying per-project cap + work-aware reserve guards after the global free-slot ceiling; byte-for-byte equivalent to `selectDispatchable` when `perProject` is empty
- **`buildPerProjectGauge(inFlight, perProject, freeSlots)`** — pure helper emitting a `{project: {inFlight, maxParallel}}` gauge object for the per-tick slot-usage log line
- **`schedulerTick`** — swapped to `selectDispatchablePerProject` + per-tick gauge emission when `perProject` is configured; no behaviour change on installs without it

### Tests (`scheduler.test.mjs` +269, `scheduler-perproject.test.mjs` +99)

31 new tests total:

- `scheduler-perproject.test.mjs` — pure unit tests for `validatePerProjectBudgets`, `selectDispatchablePerProject`, `buildPerProjectGauge`: cap enforcement, reserve greedy-walk, over-subscribed clamping, empty-perProject bypass, inFlight edge cases
- `scheduler.test.mjs` additions — `schedulerTick` integration tests: per-project cap blocks dispatch when at cap, reserve holds global free slots for an under-floor project, cap + reserve compose correctly, gauge is emitted to log

### Documentation

- **`website/src/content/docs/reference/configuration.md`** — new `perProject` subsection with config shape, field table, and three-rule explanation (hard cap, guaranteed floor, reserve sum constraint)
- **`website/src/content/docs/observability/setup.md`** — per-project gauge log-line format and example

## How to Verify

- [x] `bun test scheduler.test.mjs scheduler-perproject.test.mjs` — 216 pass, 8 pre-existing sandbox failures (schedulerTick fs.watch-debounce, known flaky in bg-job sandbox, unrelated to this diff)
- [ ] Enable `perProject` in a machine config and confirm the daemon log shows `per-project slots` gauge on each tick
- [ ] Verify that at `maxParallel` for a project, new tickets from that project are held while global slots are free
- [ ] Verify a project at `reserve > 0` with ready work is not blocked by another project filling shared slots

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-706

## Notes

The 8 sandbox-only test failures are pre-existing (schedulerTick tests using `spawnSync` + fs.watch debounce — deterministically blocked in the sandboxed bg-job environment). On a real machine or in CI these pass. See project memory entry "execution-core daemon flaky test".
