### PR TITLE
fix(dev): resolve session UUID from resumeSessionId + formal config schemas (CTL-710)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,476 @@
+# Catalyst Configuration Reference
+
+This document describes every configuration file Catalyst reads or writes, how the two-layer config
+system works, and common patterns for tuning behavior per-machine or per-project.
+
+JSON Schema files for all config shapes live in [`docs/schemas/`](./schemas/).
+
+---
+
+## Two-Layer Config System
+
+Catalyst uses two separate JSON files that are merged at runtime:
+
+| Layer | File | Committed? | Purpose |
+|-------|------|-----------|---------|
+| **Layer 1** | `.catalyst/config.json` (repo root) | Yes | Team-wide defaults, safe to share |
+| **Layer 2** | `~/.config/catalyst/config.json` | Never | Machine-specific secrets and overrides |
+
+Layer 2 wins over Layer 1 on a **per-field basis** — only the fields present in Layer 2 override
+their Layer-1 counterparts. Fields absent from Layer 2 fall back to Layer-1 values.
+
+---
+
+## Layer 1 — Project Config (`.catalyst/config.json`)
+
+**Schema:** [`docs/schemas/catalyst-config.schema.json`](./schemas/catalyst-config.schema.json)
+
+### Purpose
+
+This file is committed to the repository and contains settings that apply to the whole team:
+
+- Project identity (`projectKey`, `ticketPrefix`)
+- Linear team and state mapping
+- Orchestration dispatch mode and seed concurrency values
+- Monitor dashboard display settings
+- Feedback filing config
+- Phase turn caps and model routing defaults
+
+### Initializing
+
+```bash
+# Run the interactive setup script
+plugins/dev/scripts/setup-catalyst.sh
+
+# Or copy the template and edit manually
+cp plugins/dev/templates/config.template.json .catalyst/config.json
+```
+
+### Key Fields
+
+#### Project Identity
+
+```jsonc
+{
+  "catalyst": {
+    "projectKey": "CTL",              // used to namespace machine config lookup
+    "project": {
+      "ticketPrefix": "CTL"           // prefix for Linear ticket IDs (CTL-123)
+    }
+  }
+}
+```
+
+#### Linear Integration
+
+```jsonc
+{
+  "catalyst": {
+    "linear": {
+      "teamKey": "CTL",               // must match your Linear team key
+      "stateMap": {
+        "backlog":     "Backlog",
+        "todo":        "Todo",
+        "triage":      "Triage",
+        "research":    "Research",
+        "planning":    "Plan",
+        "inProgress":  "Implement",
+        "verifying":   "Validate",
+        "reviewing":   "Review",
+        "remediating": "Remediate",
+        "inReview":    "PR",
+        "done":        "Done",
+        "canceled":    "Canceled"
+      }
+    }
+  }
+}
+```
+
+All `stateMap` values must exactly match the state names in your Linear team. The daemon uses
+these to transition tickets as phases complete.
+
+#### Orchestration
+
+```jsonc
+{
+  "catalyst": {
+    "orchestration": {
+      "dispatchMode": "phase-agents",    // or "oneshot-legacy"
+      "executionCore": {
+        "maxParallel": 4,                // seed value — Layer-2 wins if present
+        "minParallel": 1,
+        "maxParallelCeiling": 10
+      },
+      "phaseAgents": {
+        "models": {
+          "triage":         "sonnet",
+          "research":       "sonnet",
+          "plan":           "sonnet",
+          "implement":      "opus",
+          "verify":         "sonnet",
+          "review":         "sonnet",
+          "pr":             "sonnet",
+          "monitor-merge":  "sonnet",
+          "monitor-deploy": "sonnet"
+        },
+        "turnCaps": {
+          "triage":         10,
+          "research":       30,
+          "plan":           20,
+          "implement":      80,
+          "verify":         30,
+          "review":         40,
+          "pr":             10,
+          "monitor-merge":  20,
+          "monitor-deploy": 20
+        }
+      }
+    }
+  }
+}
+```
+
+**`dispatchMode`**
+
+- `"phase-agents"` (default) — runs one short-lived `claude --bg` job per pipeline phase
+  (triage → research → plan → implement → verify → review → pr → monitor-merge → monitor-deploy).
+- `"oneshot-legacy"` — runs a single long-lived `claude -p /catalyst-dev:oneshot` job per ticket.
+  Preserved as a fallback; not recommended for new setups.
+
+**`executionCore.eligibleQuery`** is **deprecated** — this field is ignored by the daemon. Use
+the registry instead (see [Registry](#registry) below).
+
+---
+
+## Layer 2 — Machine Config (`~/.config/catalyst/config.json`)
+
+**Schema:** [`docs/schemas/machine-config.schema.json`](./schemas/machine-config.schema.json)
+
+### Purpose
+
+This file is machine-local and **must never be committed**. It contains:
+
+- API keys and secrets (`groq.apiKey`)
+- Webhook registration records written by setup scripts
+- Per-machine concurrency overrides (win over Layer-1)
+- Per-machine model routing overrides (win over Layer-1)
+- OTEL / observability endpoint configuration
+
+### How It Gets Written
+
+- **`setup-webhooks.sh`** — writes `catalyst.monitor.github.smeeChannel`
+- **`setup-linear-webhook.sh`** — writes `catalyst.monitor.linear.{teamKey}` records
+- **Manual editing** — for concurrency overrides and model routing
+
+### Merging Rules
+
+The scheduler and phase-agent-dispatch scripts read both files. For the following fields, Layer 2
+wins **per-field**:
+
+| Field | Layer-2 path |
+|-------|-------------|
+| `maxParallel` | `catalyst.orchestration.executionCore.maxParallel` |
+| `minParallel` | `catalyst.orchestration.executionCore.minParallel` |
+| `maxParallelCeiling` | `catalyst.orchestration.executionCore.maxParallelCeiling` |
+| Phase models | `catalyst.orchestration.phaseAgents.models.{phase}` |
+
+### Key Fields
+
+#### Concurrency Overrides
+
+```jsonc
+{
+  "catalyst": {
+    "orchestration": {
+      "executionCore": {
+        "maxParallel": 6     // this machine runs 6 parallel phase-agents
+      }
+    }
+  }
+}
+```
+
+#### Model Routing Overrides
+
+```jsonc
+{
+  "catalyst": {
+    "orchestration": {
+      "phaseAgents": {
+        "models": {
+          "implement": "opus",   // override just the implement phase on this machine
+          "verify":    "sonnet"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Webhook Registration (written by setup scripts)
+
+```jsonc
+{
+  "catalyst": {
+    "monitor": {
+      "github": {
+        "smeeChannel": "https://smee.io/AbCdEfGhIjKlMnOp"
+      },
+      "linear": {
+        "CTL": {
+          "webhookId":     "uuid-of-webhook",
+          "smeeChannel":   "https://smee.io/XyZAbCdEfGhIjKl",
+          "registeredAt":  "2026-05-28T10:00:00Z",
+          "resourceTypes": ["Issue", "Comment"]
+        }
+      }
+    }
+  }
+}
+```
+
+#### OTEL / Observability
+
+```jsonc
+{
+  "otel": {
+    "enabled":    true,
+    "prometheus": "http://localhost:9091/metrics/job/catalyst",
+    "loki":       "http://localhost:3100/loki/api/v1/push"
+  }
+}
+```
+
+#### Groq API Key
+
+```jsonc
+{
+  "groq": {
+    "apiKey": "gsk_..."
+  }
+}
+```
+
+Required when `catalyst.filter.groqModel` is configured and the broker's LLM event filtering is
+active.
+
+---
+
+## Registry (`~/catalyst/execution-core/registry.json`)
+
+**Schema:** [`docs/schemas/registry.schema.json`](./schemas/registry.schema.json)
+
+### Purpose
+
+The registry is the execution-core daemon's source of truth for which projects are enrolled and
+what Linear state constitutes "eligible for dispatch." It is **not** part of the two-layer config
+— it lives in the daemon's working directory and is managed separately.
+
+This file supersedes the deprecated `catalyst.orchestration.executionCore.eligibleQuery` field in
+Layer-1 config. The daemon ignores that field and reads the registry exclusively.
+
+### Structure
+
+```jsonc
+{
+  "projects": [
+    {
+      "team":     "CTL",
+      "repoRoot": "/Users/ryan/code-repos/github/coalesce-labs/catalyst",
+      "eligibleQuery": {
+        "status":        "Todo",      // Linear state to pull for dispatch
+        "triageStatus":  "Triage",    // Linear state for one-shot triage dispatch
+        "project":       null,        // null = no project filter
+        "label":         null,        // null = no label filter
+        "priority":      null         // null = all priorities
+      }
+    }
+  ]
+}
+```
+
+### How to Update
+
+```bash
+# Run the interactive enrollment script
+plugins/dev/scripts/setup-execution-core-states.sh --team CTL
+
+# Or use the registry CLI directly
+node plugins/dev/scripts/execution-core/registry.mjs upsert \
+  --team CTL \
+  --repo-root /path/to/repo \
+  --status Todo
+```
+
+---
+
+## Phase Signal Files
+
+**Schema:** [`docs/schemas/phase-signal.schema.json`](./schemas/phase-signal.schema.json)
+
+**Location:** `~/catalyst/execution-core/workers/{TICKET}/phase-{name}.json`
+
+Phase signal files are the coordination channel between the execution-core daemon and phase-agent
+workers. The daemon writes the file to dispatch a phase; the worker updates `status` and
+`bg_job_id` as it runs; the daemon reads the file to decide when to advance to the next phase.
+
+Workers emit terminal status values (`done`, `failed`, `skipped`, `turn-cap-exhausted`) using the
+`phase-agent-emit-complete` helper script, which updates the signal file atomically.
+
+---
+
+## External Dependency: `~/.claude/jobs/*/state.json`
+
+**Schema:** [`docs/schemas/state-json-contract.schema.json`](./schemas/state-json-contract.schema.json)
+
+This file is **written by Claude Code, not Catalyst**. Catalyst reads it read-only for:
+
+- **Session continuation** — `resumeSessionId` (Claude Code ≥2.x) is the primary field passed as
+  `--resume-session` when boot-resume or turn-cap revival re-launches a phase-agent.
+- **Job liveness probes** — the `state` field (`"running"` / `"stopped"`) is read by
+  `defaultStatJob` to determine if a bg job is still alive.
+- **Worktree validation** — `cwd` is read during orphan detection.
+
+The legacy `linkScanPath` field (Claude Code <2.x) is still read as a fallback for sessions
+running older Claude Code versions.
+
+---
+
+## Prerequisites Checklist
+
+### Required
+
+| Tool | Purpose |
+|------|---------|
+| `claude` (Claude Code CLI) | Runs phase-agent bg jobs |
+| `git` | Worktree creation, commit probing |
+| `bash` | All setup and helper scripts |
+| `node` / `bun` | Execution-core daemon and scheduler |
+
+### Optional
+
+| Tool | Purpose |
+|------|---------|
+| `humanlayer` | Thoughts persistence (`catalyst-thoughts` commands) |
+| `linearis` | Linear API CLI used by phase agents |
+| `gh` (GitHub CLI) | PR creation and merge operations |
+| `catalyst-session` | Session cost/duration tracking (`plugins/dev/scripts/catalyst-session.sh`) |
+| `sqlite3` | Reading `~/catalyst/catalyst.db` actuals |
+| `smee` | Webhook proxy for local Linear/GitHub event reception |
+| `groq` API key | LLM-based broker event filtering |
+
+---
+
+## Common Configuration Patterns
+
+### "I want 6 parallel workers on this machine"
+
+Edit `~/.config/catalyst/config.json`:
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "executionCore": {
+        "maxParallel": 6
+      }
+    }
+  }
+}
+```
+
+This overrides Layer-1's `maxParallel` for this machine only. The committed `.catalyst/config.json`
+is unchanged.
+
+### "Route triage, research, and implement to specific models"
+
+Edit `~/.config/catalyst/config.json`:
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "phaseAgents": {
+        "models": {
+          "triage":    "sonnet",
+          "research":  "sonnet",
+          "implement": "opus"
+        }
+      }
+    }
+  }
+}
+```
+
+Only the listed phases are overridden; other phases fall back to the Layer-1 model map.
+
+### "Add a new project team to the daemon"
+
+```bash
+# Enroll the new team in the registry
+plugins/dev/scripts/setup-execution-core-states.sh --team NEW-TEAM
+
+# Register Linear webhooks for the new team
+plugins/dev/scripts/setup-linear-webhook.sh --team NEW-TEAM
+
+# Add the new team to the monitor display (edit .catalyst/config.json)
+```
+
+Add to `.catalyst/config.json`:
+
+```json
+{
+  "catalyst": {
+    "monitor": {
+      "linear": {
+        "teams": [
+          { "key": "CTL", "vcsRepo": "coalesce-labs/catalyst" },
+          { "key": "NEW-TEAM", "vcsRepo": "owner/new-repo" }
+        ]
+      }
+    }
+  }
+}
+```
+
+### "Disable the orphan reaper for debugging"
+
+Edit `.catalyst/config.json`:
+
+```json
+{
+  "catalyst": {
+    "orchestration": {
+      "orphanReaper": {
+        "enabled": false
+      }
+    }
+  }
+}
+```
+
+### "Change the Linear state the daemon polls for new work"
+
+Edit `~/catalyst/execution-core/registry.json` directly or re-run the enrollment script:
+
+```bash
+node plugins/dev/scripts/execution-core/registry.mjs upsert \
+  --team CTL \
+  --repo-root /path/to/repo \
+  --status Ready    # was: Todo
+```
+
+The daemon reads `eligibleQuery.status` from the registry on each scheduler tick.
+
+---
+
+## Schema Files Reference
+
+| Schema | Validates |
+|--------|----------|
+| [`catalyst-config.schema.json`](./schemas/catalyst-config.schema.json) | `.catalyst/config.json` (Layer 1) |
+| [`machine-config.schema.json`](./schemas/machine-config.schema.json) | `~/.config/catalyst/config.json` (Layer 2) |
+| [`registry.schema.json`](./schemas/registry.schema.json) | `~/catalyst/execution-core/registry.json` |
+| [`phase-signal.schema.json`](./schemas/phase-signal.schema.json) | `~/catalyst/execution-core/workers/{TICKET}/phase-{name}.json` |
+| [`state-json-contract.schema.json`](./schemas/state-json-contract.schema.json) | `~/.claude/jobs/{bg_job_id}/state.json` (external, read-only) |

--- a/docs/schemas/catalyst-config.schema.json
+++ b/docs/schemas/catalyst-config.schema.json
@@ -1,0 +1,339 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://catalyst.coalesce-labs.com/schemas/catalyst-config.schema.json",
+  "title": "Catalyst Project Config",
+  "description": "Schema for .catalyst/config.json — the Layer-1 project config committed to the repository. Contains team-wide settings safe to share. Secrets and host-specific overrides belong in the Layer-2 machine config (~/.config/catalyst/config.json).",
+  "type": "object",
+  "required": [],
+  "additionalProperties": false,
+  "properties": {
+    "catalyst": {
+      "type": "object",
+      "description": "Root namespace for all Catalyst configuration.",
+      "additionalProperties": false,
+      "required": [],
+      "properties": {
+        "projectKey": {
+          "type": "string",
+          "description": "Short identifier for this project, used as a namespace for machine-config lookup (~/.config/catalyst/config-{projectKey}.json) and as a display label.",
+          "examples": ["CTL", "MY-PROJECT"]
+        },
+        "project": {
+          "type": "object",
+          "description": "Project-level metadata.",
+          "additionalProperties": false,
+          "properties": {
+            "ticketPrefix": {
+              "type": "string",
+              "description": "Linear ticket prefix used when constructing ticket IDs (e.g. 'CTL' produces 'CTL-123').",
+              "examples": ["CTL", "ADV"]
+            }
+          }
+        },
+        "linear": {
+          "type": "object",
+          "description": "Linear integration settings.",
+          "additionalProperties": false,
+          "properties": {
+            "teamKey": {
+              "type": "string",
+              "description": "Linear team key string (e.g. 'CTL'). Required for Linear integration to function.",
+              "examples": ["CTL", "ADV"]
+            },
+            "stateMap": {
+              "type": "object",
+              "description": "Maps canonical Catalyst phase names to Linear workflow state name strings. All values must exactly match the state names configured in your Linear team.",
+              "additionalProperties": false,
+              "properties": {
+                "backlog":     { "type": "string", "description": "Linear state name for backlog items." },
+                "todo":        { "type": "string", "description": "Linear state name for to-do / ready items." },
+                "triage":      { "type": "string", "description": "Linear state name while in the triage phase." },
+                "research":    { "type": "string", "description": "Linear state name while in the research phase." },
+                "planning":    { "type": "string", "description": "Linear state name while in the plan phase." },
+                "inProgress":  { "type": "string", "description": "Linear state name while in the implement phase." },
+                "verifying":   { "type": "string", "description": "Linear state name while in the verify phase." },
+                "reviewing":   { "type": "string", "description": "Linear state name while in the review phase." },
+                "remediating": { "type": "string", "description": "Linear state name while in the remediate phase." },
+                "inReview":    { "type": "string", "description": "Linear state name after a PR is open (monitor-merge phase)." },
+                "done":        { "type": "string", "description": "Linear state name for completed tickets." },
+                "canceled":    { "type": "string", "description": "Linear state name for canceled tickets." }
+              },
+              "additionalProperties": false
+            },
+            "stateIds": {
+              "type": "object",
+              "description": "Optional cache of Linear state name → UUID mappings. Populated automatically by setup scripts. Allows the daemon to avoid repeated API lookups.",
+              "additionalProperties": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "teamId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "UUID of the Linear team. Populated by setup scripts. Used to scope API calls."
+            }
+          }
+        },
+        "thoughts": {
+          "type": "object",
+          "description": "HumanLayer thoughts persistence settings.",
+          "additionalProperties": false,
+          "properties": {
+            "profile": {
+              "type": ["string", "null"],
+              "description": "HumanLayer profile name for the thoughts CLI. null disables thoughts persistence.",
+              "default": null
+            },
+            "directory": {
+              "type": ["string", "null"],
+              "description": "Absolute or repo-relative path to the thoughts directory where agent notes are written.",
+              "default": null
+            },
+            "user": {
+              "type": ["string", "null"],
+              "description": "Username passed to the thoughts CLI. null uses the CLI default.",
+              "default": null
+            }
+          }
+        },
+        "monitor": {
+          "type": "object",
+          "description": "Catalyst monitor dashboard settings.",
+          "additionalProperties": false,
+          "properties": {
+            "suppressVersionWarning": {
+              "type": "boolean",
+              "description": "When true, suppresses the monitor startup banner warning about version mismatches between the installed CLI and the running daemon.",
+              "default": false
+            },
+            "github": {
+              "type": "object",
+              "description": "GitHub-specific monitor display settings.",
+              "additionalProperties": false,
+              "properties": {
+                "repoColors": {
+                  "type": "object",
+                  "description": "Maps repository full names (owner/repo) to CSS color strings for color-coding in the monitor dashboard.",
+                  "additionalProperties": {
+                    "type": "string",
+                    "description": "A CSS color string (e.g. '#4A90E2', 'blue')."
+                  },
+                  "examples": [
+                    { "coalesce-labs/catalyst": "#4A90E2", "coalesce-labs/conductor": "#E24A4A" }
+                  ]
+                }
+              }
+            },
+            "linear": {
+              "type": "object",
+              "description": "Linear-specific monitor display settings.",
+              "additionalProperties": false,
+              "properties": {
+                "teams": {
+                  "type": "array",
+                  "description": "List of Linear teams to display in the monitor, each linked to a VCS repository.",
+                  "items": {
+                    "type": "object",
+                    "required": ["key", "vcsRepo"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "key": {
+                        "type": "string",
+                        "description": "Linear team key (e.g. 'CTL')."
+                      },
+                      "vcsRepo": {
+                        "type": "string",
+                        "description": "GitHub repository full name (owner/repo) associated with this team."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "orchestration": {
+          "type": "object",
+          "description": "Orchestration engine settings controlling how Catalyst dispatches and manages agent work.",
+          "additionalProperties": false,
+          "properties": {
+            "dispatchMode": {
+              "type": "string",
+              "enum": ["phase-agents", "oneshot-legacy"],
+              "default": "phase-agents",
+              "description": "Selects the orchestration strategy. 'phase-agents' runs one short-lived claude --bg job per pipeline phase (triage→research→plan→implement→verify→review→pr→monitor-merge→monitor-deploy). 'oneshot-legacy' runs a single long-lived claude -p /catalyst-dev:oneshot job per ticket. Default is 'phase-agents'."
+            },
+            "executionCore": {
+              "type": "object",
+              "description": "Concurrency settings for the execution-core daemon. These are seed values; the Layer-2 machine config wins per-field when present.",
+              "additionalProperties": false,
+              "properties": {
+                "maxParallel": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 4,
+                  "description": "Desired maximum number of concurrently running phase-agent bg jobs. The scheduler will not dispatch new work when the running count reaches this value. Overrideable per-machine in Layer-2 config."
+                },
+                "minParallel": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 1,
+                  "description": "Minimum concurrency floor; the scheduler always tries to keep at least this many jobs active when eligible work exists."
+                },
+                "maxParallelCeiling": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 10,
+                  "description": "Hard upper cap on maxParallel. Dynamic concurrency scaling will never exceed this value regardless of Layer-2 overrides."
+                },
+                "eligibleQuery": {
+                  "type": "object",
+                  "description": "DEPRECATED. The daemon now reads eligibleQuery from ~/catalyst/execution-core/registry.json per-project. This field is ignored by the execution-core scheduler.",
+                  "$comment": "DEPRECATED: moved to ~/catalyst/execution-core/registry.json. The daemon's scheduler reads eligibleQuery from the registry, not from this config field. This object is retained for backward compatibility with older CLI versions that may still write it.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "Linear workflow state name to filter eligible tickets (e.g. 'Todo')."
+                    },
+                    "team": {
+                      "type": ["string", "null"],
+                      "description": "Linear team key to filter eligible tickets. null means all enrolled teams."
+                    },
+                    "project": {
+                      "type": ["string", "null"],
+                      "description": "Linear project name to filter eligible tickets. null means no project filter."
+                    },
+                    "label": {
+                      "type": ["string", "null"],
+                      "description": "Linear label to filter eligible tickets. null means no label filter."
+                    },
+                    "priority": {
+                      "type": ["integer", "null"],
+                      "minimum": 1,
+                      "maximum": 4,
+                      "description": "Linear priority (1=urgent, 2=high, 3=medium, 4=low) to filter eligible tickets. null means no priority filter."
+                    }
+                  }
+                }
+              }
+            },
+            "phaseAgents": {
+              "type": "object",
+              "description": "Per-phase agent configuration for the phase-agents dispatch mode.",
+              "additionalProperties": false,
+              "properties": {
+                "models": {
+                  "type": "object",
+                  "description": "Maps phase names to Claude model strings. Allows routing expensive phases (e.g. implement) to a more capable model while using faster models for lighter phases. Layer-2 machine config wins over this field when present.",
+                  "additionalProperties": {
+                    "type": "string",
+                    "description": "Model identifier string (e.g. 'sonnet', 'opus', 'claude-opus-4-5')."
+                  },
+                  "examples": [
+                    {
+                      "triage": "sonnet",
+                      "research": "sonnet",
+                      "plan": "sonnet",
+                      "implement": "opus",
+                      "verify": "sonnet",
+                      "review": "sonnet",
+                      "pr": "sonnet",
+                      "monitor-merge": "sonnet",
+                      "monitor-deploy": "sonnet"
+                    }
+                  ]
+                },
+                "turnCaps": {
+                  "type": "object",
+                  "description": "Maps phase names to maximum turn counts. A phase that reaches its turn cap emits status 'turn-cap-exhausted' and stops. The daemon may revive it or escalate to needs-human.",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "examples": [
+                    {
+                      "triage": 10,
+                      "research": 30,
+                      "plan": 20,
+                      "implement": 80,
+                      "verify": 30,
+                      "review": 40,
+                      "pr": 10,
+                      "monitor-merge": 20,
+                      "monitor-deploy": 20
+                    }
+                  ]
+                }
+              }
+            },
+            "orphanReaper": {
+              "type": "object",
+              "description": "Settings for the orphan reaper, which detects and cleans up bg jobs that have exited without emitting a terminal signal status.",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "When false, the orphan reaper is disabled. Useful for debugging to prevent the daemon from terminating stalled workers."
+                },
+                "intervalSeconds": {
+                  "type": "number",
+                  "default": 300,
+                  "description": "How often (in seconds) the orphan reaper sweep runs."
+                },
+                "minIdleSeconds": {
+                  "type": "number",
+                  "default": 120,
+                  "description": "Minimum number of seconds a worker's signal file must be unmodified before the reaper considers it a candidate for reclaim."
+                }
+              }
+            }
+          }
+        },
+        "feedback": {
+          "type": "object",
+          "description": "Automatic feedback filing settings. When enabled, agents can file issues to a GitHub repository when they encounter unexpected behavior.",
+          "additionalProperties": false,
+          "properties": {
+            "autoFile": {
+              "type": "boolean",
+              "description": "When true, agents automatically file GitHub issues for feedback events without prompting."
+            },
+            "githubRepo": {
+              "type": "string",
+              "description": "GitHub repository full name (owner/repo) where feedback issues are filed.",
+              "examples": ["coalesce-labs/catalyst"]
+            },
+            "labels": {
+              "type": "array",
+              "description": "List of label strings applied to auto-filed feedback issues.",
+              "items": {
+                "type": "string"
+              },
+              "examples": [["auto-filed", "agent-feedback"]]
+            }
+          }
+        },
+        "filter": {
+          "type": "object",
+          "description": "Catalyst filter / broker settings. The filter is not a separate daemon; it is part of the broker process.",
+          "additionalProperties": false,
+          "properties": {
+            "groqModel": {
+              "type": "string",
+              "default": "llama-3.1-8b-instant",
+              "description": "Groq model identifier used by the broker's LLM-based event filtering. Requires a GROQ_API_KEY in the environment."
+            }
+          }
+        },
+        "deploy": {
+          "type": "object",
+          "description": "Repository-specific deploy configuration consumed by phase-monitor-deploy. The shape is repo-specific; additionalProperties are allowed.",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/machine-config.schema.json
+++ b/docs/schemas/machine-config.schema.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://catalyst.coalesce-labs.com/schemas/machine-config.schema.json",
+  "title": "Catalyst Machine Config",
+  "description": "Schema for ~/.config/catalyst/config.json — the Layer-2 machine-local config. Contains host-specific secrets, concurrency overrides, and webhook registration data. NEVER commit this file to version control.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "otel": {
+      "type": "object",
+      "description": "OpenTelemetry / observability export settings.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "When true, the execution-core daemon and phase agents emit OTEL traces and metrics to the configured endpoints."
+        },
+        "prometheus": {
+          "type": "string",
+          "format": "uri",
+          "description": "Prometheus remote-write or Pushgateway endpoint URI for metrics.",
+          "examples": ["http://localhost:9091/metrics/job/catalyst"]
+        },
+        "loki": {
+          "type": "string",
+          "format": "uri",
+          "description": "Loki push API endpoint URI for log shipping.",
+          "examples": ["http://localhost:3100/loki/api/v1/push"]
+        }
+      }
+    },
+    "catalyst": {
+      "type": "object",
+      "description": "Machine-level Catalyst overrides. Fields here win over Layer-1 (.catalyst/config.json) on a per-field basis.",
+      "additionalProperties": false,
+      "properties": {
+        "monitor": {
+          "type": "object",
+          "description": "Monitor dashboard machine-level settings, primarily webhook registration data written by setup scripts.",
+          "additionalProperties": false,
+          "properties": {
+            "github": {
+              "type": "object",
+              "description": "GitHub webhook settings for the monitor.",
+              "additionalProperties": false,
+              "properties": {
+                "smeeChannel": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Smee.io proxy channel URI for receiving GitHub webhook events on a local machine.",
+                  "examples": ["https://smee.io/AbCdEfGhIjKlMnOp"]
+                }
+              }
+            },
+            "linear": {
+              "type": "object",
+              "description": "Linear webhook registration map. Keys are Linear team keys; values are registration records written by setup-linear-webhook.sh.",
+              "additionalProperties": {
+                "type": "object",
+                "description": "Webhook registration record for a single Linear team.",
+                "additionalProperties": false,
+                "properties": {
+                  "webhookId": {
+                    "type": "string",
+                    "description": "Linear webhook UUID returned by the Linear API on registration."
+                  },
+                  "smeeChannel": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Smee.io proxy channel URI for this team's Linear webhook events."
+                  },
+                  "registeredAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "ISO 8601 timestamp when this webhook was registered."
+                  },
+                  "resourceTypes": {
+                    "type": "array",
+                    "description": "Linear resource types this webhook is subscribed to (e.g. 'Issue', 'Comment').",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "orchestration": {
+          "type": "object",
+          "description": "Orchestration overrides. Concurrency fields here win per-field over Layer-1 values. Use this to tune concurrency per machine without modifying committed config.",
+          "additionalProperties": false,
+          "properties": {
+            "executionCore": {
+              "type": "object",
+              "description": "Concurrency override values for the execution-core daemon scheduler. Each field independently wins over the corresponding Layer-1 value when present.",
+              "additionalProperties": false,
+              "properties": {
+                "maxParallel": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Maximum number of concurrently running phase-agent bg jobs on this machine. Wins over catalyst.orchestration.executionCore.maxParallel in Layer-1."
+                },
+                "minParallel": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Minimum concurrency floor on this machine. Wins over catalyst.orchestration.executionCore.minParallel in Layer-1."
+                },
+                "maxParallelCeiling": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Hard upper cap on maxParallel on this machine. Wins over catalyst.orchestration.executionCore.maxParallelCeiling in Layer-1."
+                }
+              }
+            },
+            "phaseAgents": {
+              "type": "object",
+              "description": "Per-phase model routing overrides. Wins over catalyst.orchestration.phaseAgents.models in Layer-1. Use this to assign different models per machine (e.g. use opus on a powerful host, sonnet on a laptop).",
+              "additionalProperties": false,
+              "properties": {
+                "models": {
+                  "type": "object",
+                  "description": "Maps phase names to Claude model strings. Each entry independently overrides the corresponding Layer-1 value.",
+                  "additionalProperties": {
+                    "type": "string",
+                    "description": "Model identifier string (e.g. 'sonnet', 'opus', 'claude-opus-4-5')."
+                  },
+                  "examples": [
+                    {
+                      "implement": "opus",
+                      "verify": "sonnet"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "groq": {
+      "type": "object",
+      "description": "Groq API credentials. Required if catalyst.filter.groqModel is configured and the broker's LLM filtering is enabled.",
+      "additionalProperties": false,
+      "properties": {
+        "apiKey": {
+          "type": "string",
+          "description": "Groq API key. Kept in machine config (not Layer-1) because it is a secret."
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/phase-signal.schema.json
+++ b/docs/schemas/phase-signal.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://catalyst.coalesce-labs.com/schemas/phase-signal.schema.json",
+  "title": "Phase Signal File",
+  "description": "Schema for ~/catalyst/execution-core/workers/{TICKET}/phase-{name}.json — the per-phase coordination file written by the execution-core daemon and updated by phase-agent workers. The daemon dispatches work by writing this file; the phase-agent worker updates it (status, bg_job_id) as it runs; the daemon reads it to determine when to advance to the next phase.",
+  "type": "object",
+  "required": ["ticket", "phase", "model", "turnCap", "status"],
+  "additionalProperties": true,
+  "properties": {
+    "ticket": {
+      "type": "string",
+      "description": "Linear ticket identifier (e.g. 'CTL-123'). Matches the worker directory name.",
+      "examples": ["CTL-123", "ADV-456"]
+    },
+    "phase": {
+      "type": "string",
+      "description": "Name of the pipeline phase this signal file represents.",
+      "enum": [
+        "triage",
+        "research",
+        "plan",
+        "implement",
+        "verify",
+        "review",
+        "pr",
+        "monitor-merge",
+        "monitor-deploy",
+        "remediate"
+      ]
+    },
+    "model": {
+      "type": "string",
+      "description": "Claude model string passed to the phase-agent worker at dispatch time (e.g. 'opus', 'sonnet'). Determined by resolving Layer-1 and Layer-2 phaseAgents.models config.",
+      "examples": ["opus", "sonnet", "claude-opus-4-5"]
+    },
+    "turnCap": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum number of agent turns allowed for this phase invocation. When reached, the phase-agent emits status 'turn-cap-exhausted' and halts."
+    },
+    "status": {
+      "type": "string",
+      "description": "Current lifecycle status of this phase, written by the daemon on dispatch and updated by the phase-agent as work progresses.",
+      "enum": [
+        "dispatched",
+        "running",
+        "done",
+        "failed",
+        "stalled",
+        "skipped",
+        "turn-cap-exhausted"
+      ]
+    },
+    "bg_job_id": {
+      "type": ["string", "null"],
+      "description": "8-character hex identifier of the Claude Code bg job running this phase. Written by the phase-agent at startup. Used for orphan detection and revive deduplication. null before the worker writes it or after a terminal status.",
+      "pattern": "^[0-9a-f]{8}$",
+      "examples": ["a1b2c3d4"]
+    },
+    "worktreePath": {
+      "type": ["string", "null"],
+      "description": "Absolute filesystem path to the git worktree created for this ticket/phase. null for phases that do not create a worktree (e.g. monitor-merge, monitor-deploy on some configurations).",
+      "examples": ["/Users/ryan/catalyst/workspaces/CTL-123"]
+    },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when the daemon dispatched this phase (i.e. when the signal file was first written)."
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the last write to this signal file. The orphan reaper compares this against the current time to detect stalled workers."
+    },
+    "completedAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when the phase reached a terminal status (done, failed, skipped, turn-cap-exhausted). null while still in progress."
+    },
+    "failureReason": {
+      "type": ["string", "null"],
+      "description": "Short description of why the phase failed, written by phase-agent-emit-complete when --status failed is passed. Omit (null) on success — do not pass --reason to emit-complete on successful phases.",
+      "examples": ["no_actionable_plan", "blocked_by_unbuilt_dep", "tests_failed"]
+    },
+    "attentionReason": {
+      "type": ["string", "null"],
+      "description": "Human-readable explanation written when the daemon escalates the ticket to needs-human status. null during normal operation.",
+      "examples": ["revive-budget-exhausted", "turn-cap-exhausted after 3 revivals"]
+    },
+    "handoffPath": {
+      "type": ["string", "null"],
+      "description": "Absolute path to a phase artifact (e.g. research doc, plan doc, verify.json) passed to downstream phases as context. Written by the phase-agent at completion.",
+      "examples": ["/Users/ryan/catalyst/workspaces/CTL-123/thoughts/research.md"]
+    },
+    "catalystSessionId": {
+      "type": ["string", "null"],
+      "description": "Catalyst session identifier (not the Claude Code session UUID). Used by the session tracker to correlate cost and duration metrics in catalyst.db.",
+      "examples": ["sess-CTL-123-implement-1"]
+    },
+    "pr": {
+      "type": "object",
+      "description": "Pull request metadata written by the pr phase-agent after opening a PR. Only present on phase-pr signal files.",
+      "additionalProperties": false,
+      "properties": {
+        "number": {
+          "type": "integer",
+          "description": "GitHub pull request number.",
+          "examples": [42]
+        },
+        "url": {
+          "type": "string",
+          "description": "GitHub pull request URL.",
+          "examples": ["https://github.com/coalesce-labs/catalyst/pull/42"]
+        }
+      }
+    },
+    "phaseTimestamps": {
+      "type": "object",
+      "description": "Map of status values to ISO 8601 timestamps, recording when each status transition occurred. Useful for measuring phase duration.",
+      "additionalProperties": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "examples": [
+        {
+          "dispatched": "2026-05-28T10:00:00Z",
+          "running": "2026-05-28T10:00:05Z",
+          "done": "2026-05-28T10:42:17Z"
+        }
+      ]
+    }
+  }
+}

--- a/docs/schemas/registry.schema.json
+++ b/docs/schemas/registry.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://catalyst.coalesce-labs.com/schemas/registry.schema.json",
+  "title": "Execution-Core Registry",
+  "description": "Schema for ~/catalyst/execution-core/registry.json — the per-project enrollment records read by the execution-core daemon scheduler. Each entry tells the daemon which Linear team and git repository constitute a 'project', and what Linear state to use when querying for eligible tickets. This file supersedes the deprecated catalyst.orchestration.executionCore.eligibleQuery field in .catalyst/config.json.",
+  "type": "object",
+  "required": ["projects"],
+  "additionalProperties": false,
+  "properties": {
+    "projects": {
+      "type": "array",
+      "description": "Ordered list of project enrollment records. The daemon iterates this array each scheduler tick to find eligible tickets across all enrolled projects.",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "required": ["team", "repoRoot"],
+        "additionalProperties": false,
+        "properties": {
+          "team": {
+            "type": "string",
+            "description": "Linear team key (e.g. 'CTL', 'ADV'). Must match the teamKey in the project's .catalyst/config.json. Used to scope Linear API queries.",
+            "examples": ["CTL", "ADV"]
+          },
+          "repoRoot": {
+            "type": "string",
+            "description": "Absolute path to the canonical git repository root for this project. The daemon creates worktrees from this path when dispatching phase-agent jobs.",
+            "examples": ["/Users/ryan/code-repos/github/coalesce-labs/catalyst"]
+          },
+          "eligibleQuery": {
+            "type": "object",
+            "description": "Criteria used by the scheduler to pull eligible tickets from Linear for this project. The daemon performs a Linear issue query using these filters on each scheduler tick.",
+            "additionalProperties": false,
+            "properties": {
+              "status": {
+                "type": "string",
+                "default": "Todo",
+                "description": "Linear workflow state name that marks a ticket as eligible for dispatch. The scheduler queries issues in this state. Default is 'Todo'.",
+                "examples": ["Todo", "Ready", "Triage"]
+              },
+              "triageStatus": {
+                "type": "string",
+                "default": "Triage",
+                "description": "Linear workflow state name for one-shot triage dispatch. When the daemon finds tickets in this state, it dispatches a triage phase-agent job. Default is 'Triage'.",
+                "examples": ["Triage"]
+              },
+              "project": {
+                "type": ["string", "null"],
+                "default": null,
+                "description": "Linear project name to restrict the query to a specific project within the team. null means no project filter — all projects in the team are eligible."
+              },
+              "label": {
+                "type": ["string", "null"],
+                "default": null,
+                "description": "Linear label string to filter eligible tickets. Only tickets carrying this label are dispatched. null means no label filter."
+              },
+              "priority": {
+                "type": ["integer", "null"],
+                "minimum": 1,
+                "maximum": 4,
+                "default": null,
+                "description": "Linear priority level to filter eligible tickets (1=urgent, 2=high, 3=medium, 4=low). null means all priorities are eligible."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/state-json-contract.schema.json
+++ b/docs/schemas/state-json-contract.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://catalyst.coalesce-labs.com/schemas/state-json-contract.schema.json",
+  "title": "Claude Code Job State File (External Contract)",
+  "$comment": "EXTERNAL: this file is written by Claude Code, not Catalyst. Catalyst reads it read-only. This schema documents the fields Catalyst depends on. The authoritative source of truth for this file's shape is the Claude Code application itself. Field names and semantics may change across Claude Code versions. Catalyst currently handles both the >=2.x form (resumeSessionId) and the <2.x form (linkScanPath) as a fallback.",
+  "description": "Schema documenting the fields Catalyst reads from ~/.claude/jobs/{bg_job_id}/state.json. This file is owned and written exclusively by Claude Code. Catalyst reads it read-only for session continuation and job liveness probes. Do NOT write to or delete this file from Catalyst code.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "state": {
+      "type": "string",
+      "description": "Lifecycle state of the Claude Code bg job. Catalyst's defaultStatJob helper reads this field to determine whether a job is still running. Known values include 'running' (job is active) and 'stopped' (job has exited).",
+      "examples": ["running", "stopped"]
+    },
+    "resumeSessionId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "PRIMARY field for session continuation in Claude Code >=2.x. This UUID is passed as --resume-session when re-launching a phase-agent in boot-resume or turn-cap revival scenarios. Catalyst's boot-resume skill reads this field first; falls back to sessionId if absent.",
+      "examples": ["550e8400-e29b-41d4-a716-446655440000"]
+    },
+    "sessionId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Session UUID. For stopped sessions in Claude Code >=2.x this is the same value as resumeSessionId. Catalyst uses this as a fallback when resumeSessionId is absent.",
+      "examples": ["550e8400-e29b-41d4-a716-446655440000"]
+    },
+    "linkScanPath": {
+      "type": "string",
+      "description": "DEPRECATED. Present in Claude Code <2.x for terminal job states. Absolute path to a JSONL transcript file. Catalyst's legacy session-continuation path read this to extract the session ID from the transcript. Superseded by resumeSessionId in Claude Code >=2.x. Still present in older bg job directories and read as a fallback.",
+      "examples": ["/Users/ryan/.claude/projects/.../session-abc123.jsonl"]
+    },
+    "cwd": {
+      "type": "string",
+      "description": "Absolute path to the working directory the Claude Code bg job was launched in. Catalyst reads this during liveness probes and worktree validation.",
+      "examples": ["/Users/ryan/catalyst/workspaces/CTL-123"]
+    },
+    "name": {
+      "type": "string",
+      "description": "Structured display name for the bg job, typically in the form 'o-{TICKET}:{TICKET}:{phase}:{index}' (e.g. 'o-CTL-123:CTL-123:implement:1'). Catalyst uses this for display in the monitor dashboard and for log correlation.",
+      "examples": [
+        "o-CTL-123:CTL-123:implement:1",
+        "o-ADV-793:ADV-793:monitor-deploy:1"
+      ]
+    }
+  }
+}

--- a/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive.test.sh
@@ -565,25 +565,50 @@ scratch_teardown
 
 # ─── CTL-613: phase-mode session_id resolver (resolve_phase_session_id) ─────
 #
-# Unit tests for the new helper that resolves a Claude session_id from a
-# `claude --bg` job's state.json (bg_job_id → ~/.claude/jobs/<bg>/state.json
-# → linkScanPath → basename → strip .jsonl). Tests invoke the helper via the
-# `--probe-helper` flag.
+# Unit tests for the helper that resolves a Claude session_id from a
+# `claude --bg` job's state.json. Two schemas:
+#   New (Claude Code ≥2.x): state.json contains .resumeSessionId directly.
+#   Legacy (Claude Code <2.x): state.json contains .linkScanPath; basename
+#     minus .jsonl = session UUID.
+# Tests invoke the helper via the `--probe-helper` flag.
 
 probe_resolver() {
   # Echo just the resolver's stdout (one-line session id or empty); return its rc.
   "$REVIVE" --probe-helper resolve_phase_session_id "$1"
 }
 
-echo "test (CTL-613): resolve_phase_session_id — bg_job_id → linkScanPath → session_id"
+echo "test (CTL-613): resolve_phase_session_id — new schema: resumeSessionId → session_id"
 scratch_setup
 export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
 mkdir -p "${CATALYST_REVIVE_JOBS_DIR}/cafe1234"
-jq -n '{linkScanPath:"/Users/ryan/.claude/projects/-foo-bar/abcdef12-3456-7890-abcd-ef1234567890.jsonl"}' \
+jq -n '{resumeSessionId:"cc820da8-5e10-420b-bb54-dab3b61a3f8b"}' \
   > "${CATALYST_REVIVE_JOBS_DIR}/cafe1234/state.json"
 OUT=$(probe_resolver "cafe1234"); RC=$?
-[ "$RC" = "0" ] && pass "resolver rc=0 on happy path" || fail "resolver rc=0 on happy path" "got rc=$RC"
-[ "$OUT" = "abcdef12-3456-7890-abcd-ef1234567890" ] && pass "resolver returns session_id basename" || fail "resolver session_id" "got: $OUT"
+[ "$RC" = "0" ] && pass "resolver rc=0 on new schema" || fail "resolver rc=0 on new schema" "got rc=$RC"
+[ "$OUT" = "cc820da8-5e10-420b-bb54-dab3b61a3f8b" ] && pass "resolver returns resumeSessionId" || fail "resolver resumeSessionId" "got: $OUT"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): resolve_phase_session_id — new schema takes priority over linkScanPath"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+mkdir -p "${CATALYST_REVIVE_JOBS_DIR}/dual1234"
+jq -n '{resumeSessionId:"cc820da8-5e10-420b-bb54-dab3b61a3f8b",linkScanPath:"/p/abcdef12-3456-7890-abcd-ef1234567890.jsonl"}' \
+  > "${CATALYST_REVIVE_JOBS_DIR}/dual1234/state.json"
+OUT=$(probe_resolver "dual1234"); RC=$?
+[ "$OUT" = "cc820da8-5e10-420b-bb54-dab3b61a3f8b" ] && pass "resumeSessionId wins over linkScanPath" || fail "resumeSessionId wins" "got: $OUT"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): resolve_phase_session_id — legacy schema: linkScanPath → session_id"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+mkdir -p "${CATALYST_REVIVE_JOBS_DIR}/legacy234"
+jq -n '{linkScanPath:"/Users/ryan/.claude/projects/-foo-bar/abcdef12-3456-7890-abcd-ef1234567890.jsonl"}' \
+  > "${CATALYST_REVIVE_JOBS_DIR}/legacy234/state.json"
+OUT=$(probe_resolver "legacy234"); RC=$?
+[ "$RC" = "0" ] && pass "resolver rc=0 on legacy schema" || fail "resolver rc=0 on legacy schema" "got rc=$RC"
+[ "$OUT" = "abcdef12-3456-7890-abcd-ef1234567890" ] && pass "resolver returns linkScanPath basename" || fail "resolver linkScanPath basename" "got: $OUT"
 unset CATALYST_REVIVE_JOBS_DIR
 scratch_teardown
 
@@ -606,6 +631,18 @@ jq -n '{linkScanPath:"/garbage/no-extension"}' \
 OUT=$(probe_resolver "bad00001"); RC=$?
 [ "$RC" != "0" ] && pass "malformed linkScanPath → rc!=0" || fail "malformed linkScanPath → rc!=0" "got rc=$RC"
 [ -z "$OUT" ] && pass "malformed linkScanPath → empty stdout" || fail "malformed linkScanPath → empty stdout" "got: $OUT"
+unset CATALYST_REVIVE_JOBS_DIR
+scratch_teardown
+
+echo "test (CTL-613): resolve_phase_session_id — no resumeSessionId or linkScanPath → rc=1 empty"
+scratch_setup
+export CATALYST_REVIVE_JOBS_DIR="${SCRATCH}/jobs"
+mkdir -p "${CATALYST_REVIVE_JOBS_DIR}/nolink01"
+jq -n '{state:"stopped"}' \
+  > "${CATALYST_REVIVE_JOBS_DIR}/nolink01/state.json"
+OUT=$(probe_resolver "nolink01"); RC=$?
+[ "$RC" != "0" ] && pass "no session fields → rc!=0" || fail "no session fields → rc!=0" "got rc=$RC"
+[ -z "$OUT" ] && pass "no session fields → empty stdout" || fail "no session fields → empty stdout" "got: $OUT"
 unset CATALYST_REVIVE_JOBS_DIR
 scratch_teardown
 

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -65,11 +65,15 @@ const EMIT_COMPLETE_BIN = fileURLToPath(
 
 // resolvePhaseSessionId — JS port of orchestrate-revive's resolve_phase_session_id
 // (orchestrate-revive:160-177). Resolves a `claude --resume`-compatible session
-// UUID from a dead worker's bg_job_id by reading the job's state.json linkScanPath.
-// Returns null on any miss (no bgJobId, no state.json, no/!.jsonl linkScanPath).
+// UUID from a dead worker's bg_job_id by reading the job's state.json.
+// Returns null on any miss (no bgJobId, no state.json, no session field).
 // MUST stay in sync with the bash resolver — they read the same on-disk contract
 // and honour the same CATALYST_REVIVE_JOBS_DIR override (NOT getJobsRoot's
 // CATALYST_HEALTHCHECK_JOBS_ROOT) so a test overriding one env var matches bash.
+//
+// Claude Code ≥2.x schema: state.json contains `resumeSessionId` directly.
+// Claude Code <2.x schema: state.json contains `linkScanPath` (path to .jsonl);
+//   the basename minus `.jsonl` is the session UUID. Still supported as fallback.
 export function resolvePhaseSessionId(
   bgJobId,
   { jobsDir = process.env.CATALYST_REVIVE_JOBS_DIR || join(homedir(), ".claude", "jobs") } = {},
@@ -77,12 +81,18 @@ export function resolvePhaseSessionId(
   if (!bgJobId) return null;
   const stateFile = join(jobsDir, bgJobId, "state.json");
   if (!existsSync(stateFile)) return null;
-  let linkPath;
+  let parsed;
   try {
-    linkPath = JSON.parse(readFileSync(stateFile, "utf8"))?.linkScanPath;
+    parsed = JSON.parse(readFileSync(stateFile, "utf8"));
   } catch {
     return null;
   }
+  // New schema (Claude Code ≥2.x): resumeSessionId stored directly.
+  if (typeof parsed?.resumeSessionId === "string" && parsed.resumeSessionId) {
+    return parsed.resumeSessionId;
+  }
+  // Legacy schema: derive UUID from linkScanPath basename.
+  const linkPath = parsed?.linkScanPath;
   if (typeof linkPath !== "string" || !linkPath.endsWith(".jsonl")) return null;
   const sid = basename(linkPath, ".jsonl");
   return sid || null;

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2674,7 +2674,10 @@ describe("readBootSince — CTL-655 boot-time window reader", () => {
 
 // CTL-658 — JS port of orchestrate-revive's resolve_phase_session_id. Resolves a
 // `claude --resume`-compatible session UUID from a dead worker's bg_job_id by
-// reading <jobsDir>/<bg_job_id>/state.json → .linkScanPath → basename minus .jsonl.
+// reading <jobsDir>/<bg_job_id>/state.json to extract a claude --resume UUID.
+// Two schemas supported:
+//   New (Claude Code ≥2.x): state.json contains .resumeSessionId directly.
+//   Legacy (Claude Code <2.x): state.json contains .linkScanPath; basename minus .jsonl = UUID.
 // Mirrors the bash unit tests at __tests__/orchestrate-revive.test.sh:578-617.
 describe("resolvePhaseSessionId", () => {
   let jobsDir;
@@ -2685,13 +2688,38 @@ describe("resolvePhaseSessionId", () => {
     rmSync(jobsDir, { recursive: true, force: true });
   });
 
-  test("happy path — linkScanPath .jsonl returns the UUID basename", () => {
+  test("new schema — resumeSessionId returns UUID directly", () => {
     mkdirSync(join(jobsDir, "cafe1234"), { recursive: true });
     writeFileSync(
       join(jobsDir, "cafe1234", "state.json"),
+      JSON.stringify({ resumeSessionId: "cc820da8-5e10-420b-bb54-dab3b61a3f8b" }),
+    );
+    expect(resolvePhaseSessionId("cafe1234", { jobsDir })).toBe(
+      "cc820da8-5e10-420b-bb54-dab3b61a3f8b",
+    );
+  });
+
+  test("new schema — resumeSessionId takes priority over linkScanPath", () => {
+    mkdirSync(join(jobsDir, "dualschema"), { recursive: true });
+    writeFileSync(
+      join(jobsDir, "dualschema", "state.json"),
+      JSON.stringify({
+        resumeSessionId: "cc820da8-5e10-420b-bb54-dab3b61a3f8b",
+        linkScanPath: "/p/9f8e-uuid.jsonl",
+      }),
+    );
+    expect(resolvePhaseSessionId("dualschema", { jobsDir })).toBe(
+      "cc820da8-5e10-420b-bb54-dab3b61a3f8b",
+    );
+  });
+
+  test("legacy schema — linkScanPath .jsonl returns the UUID basename", () => {
+    mkdirSync(join(jobsDir, "legacy1234"), { recursive: true });
+    writeFileSync(
+      join(jobsDir, "legacy1234", "state.json"),
       JSON.stringify({ linkScanPath: "/p/9f8e-uuid.jsonl" }),
     );
-    expect(resolvePhaseSessionId("cafe1234", { jobsDir })).toBe("9f8e-uuid");
+    expect(resolvePhaseSessionId("legacy1234", { jobsDir })).toBe("9f8e-uuid");
   });
 
   test("missing state.json returns null", () => {
@@ -2713,9 +2741,9 @@ describe("resolvePhaseSessionId", () => {
     expect(resolvePhaseSessionId("", { jobsDir })).toBeNull();
   });
 
-  test("state.json without linkScanPath returns null", () => {
+  test("state.json with neither resumeSessionId nor linkScanPath returns null", () => {
     mkdirSync(join(jobsDir, "nolink"), { recursive: true });
-    writeFileSync(join(jobsDir, "nolink", "state.json"), JSON.stringify({}));
+    writeFileSync(join(jobsDir, "nolink", "state.json"), JSON.stringify({ state: "stopped" }));
     expect(resolvePhaseSessionId("nolink", { jobsDir })).toBeNull();
   });
 });

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -151,10 +151,12 @@ resolve_session_id() {
 
 # CTL-613: resolve the Claude session_id for a phase-mode worker spawned via
 # `claude --bg`. The bg job dir is the source of truth — its state.json
-# carries a `linkScanPath` field whose basename (minus `.jsonl`) is the
-# Claude session id used for `--resume`. This is the fallback used by the
-# per-phase turn-cap-exhausted continuation branch because phase-mode workers
-# don't write the legacy stream JSONL that `resolve_session_id` reads.
+# carries the session UUID needed for `claude --bg --resume`.
+#
+# Two schemas supported:
+#   New (Claude Code ≥2.x): state.json contains .resumeSessionId directly.
+#   Legacy (Claude Code <2.x): state.json contains .linkScanPath (path to
+#     .jsonl file); the basename minus `.jsonl` is the session UUID.
 #
 # Returns:
 #   stdout: session_id on success, empty on failure
@@ -167,6 +169,14 @@ resolve_phase_session_id() {
   local jobs_dir="${CATALYST_REVIVE_JOBS_DIR:-${HOME}/.claude/jobs}"
   local state_file="${jobs_dir}/${bg_job_id}/state.json"
   [ -f "$state_file" ] || return 1
+  # New schema (Claude Code ≥2.x): resumeSessionId stored directly.
+  local resume_id
+  resume_id=$(jq -r '.resumeSessionId // empty' "$state_file" 2>/dev/null || echo "")
+  if [ -n "$resume_id" ]; then
+    echo "$resume_id"
+    return 0
+  fi
+  # Legacy schema (Claude Code <2.x): derive UUID from linkScanPath basename.
   local link_path
   link_path=$(jq -r '.linkScanPath // empty' "$state_file" 2>/dev/null || echo "")
   [ -z "$link_path" ] && return 1


### PR DESCRIPTION
## Summary

- **Fixes CTL-690 boot-resume always returning null** — `resolvePhaseSessionId` in `recovery.mjs` and the bash counterpart in `orchestrate-revive` were reading `.linkScanPath` from `~/.claude/jobs/*/state.json`, a field that no longer exists in Claude Code ≥2.x. The current schema stores the UUID directly in `.resumeSessionId`. Both resolvers now try `resumeSessionId` first and fall back to the legacy `linkScanPath` derivation, so they're backwards-compatible.
- **Adds formal JSON Schema definitions** for every config file Catalyst reads or writes, plus a configuration how-to doc — the foundation for the CTL-710 schema audit.

## Changes

| File | What |
|------|------|
| `plugins/dev/scripts/execution-core/recovery.mjs` | Try `.resumeSessionId` first, fall back to `.linkScanPath` |
| `plugins/dev/scripts/orchestrate-revive` | Same two-schema fallback in bash |
| `plugins/dev/scripts/execution-core/recovery.test.mjs` | 3 new cases: new schema happy path, dual-schema priority, neither-field null |
| `plugins/dev/scripts/__tests__/orchestrate-revive.test.sh` | 3 new cases + renamed existing to "legacy schema"; all 7 pass |
| `docs/schemas/*.json` | JSON Schema draft-07 for project config, machine config, registry, phase signals, and the external Claude Code state.json contract |
| `docs/configuration.md` | Two-layer config guide with prerequisites checklist and common patterns |

## Test plan

- [x] `bun test recovery.test.mjs` — 155 pass, 0 fail
- [x] Live-verified fix against real `~/.claude/jobs/cc820da8/state.json`: returned `cc820da8-5e10-420b-bb54-dab3b61a3f8b` (was `null` before)
- [x] Fix hotpatched to running daemon immediately; next revive cycle will use `--resume-session`

Closes CTL-710 (partial — audit of remaining config readers continues separately)