### PR TITLE
CTL-705: Stage-aware priority — preemption, resume-after-preemption, and per-stage ranking

### DIFF
--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -130,6 +130,14 @@ export function defaultDispatch(
 }
 
 // dispatchTicket — thin seam over the injectable dispatch function.
-export function dispatchTicket(orchDir, ticket, phase, { dispatch = defaultDispatch } = {}) {
-  return dispatch({ orchDir, ticket, phase });
+// CTL-705: forwards optional resumeSession so the resume re-dispatch path can
+// pass a resume UUID. Omitted when absent — the legacy toEqual assertions stay
+// green because the key is not added when the value is falsy.
+export function dispatchTicket(
+  orchDir, ticket, phase,
+  { dispatch = defaultDispatch, resumeSession } = {},
+) {
+  const args = { orchDir, ticket, phase };
+  if (resumeSession) args.resumeSession = resumeSession;
+  return dispatch(args);
 }

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -272,4 +272,20 @@ describe("dispatchTicket", () => {
     const dispatch = () => ({ code: 7, stdout: "", stderr: "boom" });
     expect(dispatchTicket("/orch", "CTL-1", "research", { dispatch }).code).toBe(7);
   });
+
+  // CTL-705 Phase 3: resumeSession thread-through
+  test("backward compat: no resumeSession → dispatch receives exactly {orchDir, ticket, phase}", () => {
+    const calls = [];
+    const dispatch = (args) => { calls.push(args); return { code: 0 }; };
+    dispatchTicket("/orch", "CTL-1", "triage", { dispatch });
+    expect(calls[0]).toEqual({ orchDir: "/orch", ticket: "CTL-1", phase: "triage" });
+    expect("resumeSession" in calls[0]).toBe(false);
+  });
+
+  test("forwards resumeSession to dispatch when provided", () => {
+    const calls = [];
+    const dispatch = (args) => { calls.push(args); return { code: 0 }; };
+    dispatchTicket("/orch", "CTL-1", "implement", { dispatch, resumeSession: "uuid-123" });
+    expect(calls[0].resumeSession).toBe("uuid-123");
+  });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-705.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-705.test.mjs
@@ -1,0 +1,188 @@
+// CTL-705 end-to-end integration tests — global priority+stage sort + preemption.
+//
+// Exercises the full preemption + resume loop through schedulerTick with
+// injected seams (killBgJob, dispatch, liveBackgroundCount, resolveSession, now).
+// Two scenarios cover the acceptance criteria from the plan:
+//   1. maxParallel=2, 2 Low in-flight, 1 Urgent queued → CTL-2 (lower stage)
+//      preempted on tick 2; re-dispatched with --resume-session on tick 3.
+//   2. Only in-flight worker is at monitor-deploy → no preemption.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test integration-ctl-705.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { schedulerTick, __resetForTests, writeWorkerPriority } from "./scheduler.mjs";
+
+let orchDir;
+let catalystDir;
+let prevCatalystDir;
+
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "ctl705-int-"));
+  if (!catalystDir.startsWith(tmpdir())) {
+    throw new Error(`integration test refused: catalystDir not under tmpdir: ${catalystDir}`);
+  }
+  process.env.CATALYST_DIR = catalystDir;
+  mkdirSync(join(catalystDir, "events"), { recursive: true });
+  orchDir = join(catalystDir, "orch");
+  mkdirSync(join(orchDir, "workers"), { recursive: true });
+});
+
+afterEach(() => {
+  __resetForTests();
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+function seedWorker(ticket, phase, priority, startedAtMs, bgJobId, createdAt) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  const startedAt = new Date(startedAtMs).toISOString();
+  writeFileSync(
+    join(dir, `phase-${phase}.json`),
+    JSON.stringify({ ticket, phase, status: "running", bg_job_id: bgJobId, startedAt })
+  );
+  writeWorkerPriority(orchDir, ticket, { priority, createdAt: createdAt ?? "2026-05-01T00:00:00Z" });
+}
+
+function readSignal(ticket, phase) {
+  const p = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+function makeKillStub() {
+  const calls = [];
+  const fn = (args) => calls.push(args);
+  fn.calls = calls;
+  return fn;
+}
+
+// dispatch that writes a real signal file so verifyDispatched passes
+function makeRealDispatch() {
+  const calls = [];
+  const fn = ({ orchDir: od, ticket, phase, resumeSession }) => {
+    calls.push({ ticket, phase, resumeSession });
+    const dir = join(od, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, status: "dispatched", bg_job_id: "new-bg-" + ticket })
+    );
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const noopReclaim = () => "noop";
+
+describe("CTL-705 acceptance scenario — preemption + resume", () => {
+  test("Tick 1+2+3: Urgent queued + 2 Low in-flight → CTL-2 preempted (tick 2), resumed (tick 3)", () => {
+    const T0 = 200_000;
+    // Two Low (priority 4) in-flight workers, both >60s old
+    seedWorker("CTL-1", "verify", 4, T0 - 90_000, "bg-1"); // verify = stage 5
+    seedWorker("CTL-2", "research", 4, T0 - 90_000, "bg-2"); // research = stage 1 — lowest
+
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const kill = makeKillStub();
+
+    const baseOpts = {
+      readEligible: () => [{ identifier: "CTL-9", priority: 1, createdAt: "2026-05-01T00:00:00Z" }],
+      reclaimDeadWork: noopReclaim,
+      writeStatus: { applyPhaseStatus: () => {}, applyTerminalDone: () => {}, applyLabel: () => {} },
+    };
+
+    // Tick 1 (T0): first observation — hysteresis window opens, no preemption
+    schedulerTick(orchDir, {
+      ...baseOpts,
+      dispatch: makeRealDispatch(), // would dispatch CTL-9 if slot free — but slots are full
+      liveBackgroundCount: () => 2,
+      now: () => T0,
+      killBgJob: kill,
+    });
+    expect(kill.calls).toHaveLength(0);
+    expect(readSignal("CTL-2", "research")?.status).toBe("running"); // not yet preempted
+
+    // Tick 2 (T0+35s): hysteresis window passed → CTL-2 preempted
+    const dispatch2 = makeRealDispatch();
+    schedulerTick(orchDir, {
+      ...baseOpts,
+      dispatch: dispatch2,
+      liveBackgroundCount: () => 2, // still saturated
+      now: () => T0 + 35_000,
+      killBgJob: kill,
+    });
+    expect(kill.calls.map((c) => c.bgJobId)).toContain("bg-2"); // CTL-2 stopped
+    expect(kill.calls.map((c) => c.bgJobId)).not.toContain("bg-1"); // CTL-1 not stopped
+    const preemptedSig = readSignal("CTL-2", "research");
+    expect(preemptedSig?.status).toBe("preempted");
+    expect(preemptedSig?.parkedFrom).toBe("research");
+
+    // Verify the event log contains a preemption event for CTL-2
+    const now2 = new Date();
+    const ym = `${now2.getUTCFullYear()}-${String(now2.getUTCMonth() + 1).padStart(2, "0")}`;
+    const eventLog = readFileSync(join(catalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n").filter(Boolean).map((l) => JSON.parse(l));
+    const preemptEvent = eventLog.find(
+      (e) => e.attributes?.["event.name"] === "phase.research.preempted.CTL-2"
+    );
+    expect(preemptEvent).toBeDefined();
+
+    // Tick 3: slot frees (liveCount drops to 1) → CTL-2 resumed with --resume-session
+    const dispatch3 = makeRealDispatch();
+    schedulerTick(orchDir, {
+      ...baseOpts,
+      dispatch: dispatch3,
+      liveBackgroundCount: () => 1, // one slot free
+      now: () => T0 + 36_000,
+      killBgJob: makeKillStub(),
+      resolveSession: () => "resume-uuid-ctL2", // injectable — returns a valid resume UUID
+    });
+    const resumeCall = dispatch3.calls.find((c) => c.ticket === "CTL-2");
+    expect(resumeCall).toBeDefined();
+    expect(resumeCall.phase).toBe("research"); // parkedFrom
+    expect(resumeCall.resumeSession).toBe("resume-uuid-ctL2");
+
+    // CTL-2 signal should no longer be "preempted" (dispatched by resume sweep)
+    const resumedSig = readSignal("CTL-2", "research");
+    expect(resumedSig?.status).toBe("dispatched");
+
+    // resumed-after-preemption event in log
+    const eventLog3 = readFileSync(join(catalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n").filter(Boolean).map((l) => JSON.parse(l));
+    const resumeEvent = eventLog3.find(
+      (e) => e.attributes?.["event.name"] === "phase.research.resumed-after-preemption.CTL-2"
+    );
+    expect(resumeEvent).toBeDefined();
+    expect(resumeEvent.body.payload.resume_session).toBe("resume-uuid-ctL2");
+  });
+});
+
+describe("CTL-705 guard scenario — monitor-deploy not preemptable", () => {
+  test("Only in-flight worker at monitor-deploy → no preemption even with Urgent queued", () => {
+    const T0 = 200_000;
+    seedWorker("CTL-MD", "monitor-deploy", 4, T0 - 90_000, "bg-md");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const kill = makeKillStub();
+
+    const baseOpts = {
+      readEligible: () => [{ identifier: "CTL-9", priority: 1, createdAt: "2026-05-01T00:00:00Z" }],
+      reclaimDeadWork: noopReclaim,
+      liveBackgroundCount: () => 1, // saturated
+      now: () => T0 + 35_000, // past hysteresis
+      killBgJob: kill,
+    };
+
+    // Two ticks — first to open hysteresis, second to confirm no preemption
+    schedulerTick(orchDir, { ...baseOpts, now: () => T0 });
+    schedulerTick(orchDir, { ...baseOpts, now: () => T0 + 35_000 });
+
+    expect(kill.calls).toHaveLength(0); // monitor-deploy is non-preemptable
+    expect(readSignal("CTL-MD", "monitor-deploy")?.status).toBe("running"); // unchanged
+  });
+});

--- a/plugins/dev/scripts/execution-core/integration-ctl-705.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-705.test.mjs
@@ -163,6 +163,80 @@ describe("CTL-705 acceptance scenario — preemption + resume", () => {
   });
 });
 
+describe("CTL-705 reclaim-guard scenario — real reclaimDeadWork, no stub", () => {
+  // The acceptance scenario above injects reclaimDeadWork: noopReclaim, which
+  // masks the reclaim-guard regression entirely. This test deliberately does
+  // NOT stub reclaimDeadWork (schedulerTick falls back to the real
+  // reclaimDeadWorkIfPossible from recovery.mjs), so the guard is the only thing
+  // standing between a parked-with-dead-bg signal and a false revive.
+  function seedPreempted(ticket, phase, bgJobId, priority) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({
+        ticket,
+        phase,
+        status: "preempted",
+        parkedFrom: phase,
+        bg_job_id: bgJobId, // a now-dead bg job — what classifyWorker would treat as dead
+        attentionReason: "preempted-by-priority",
+      })
+    );
+    writeWorkerPriority(orchDir, ticket, { priority, createdAt: "2026-05-01T00:00:00Z" });
+  }
+
+  test("parked-with-dead-bg signal is NOT revived by the real reclaim sweep; only the resume sweep re-dispatches it", () => {
+    const T0 = 200_000;
+    // CTL-Park is the ONLY in-flight worker, parked at research with a dead
+    // bg_job_id. It is the only signal the real reclaim sweep would iterate.
+    seedPreempted("CTL-Park", "research", "bg-park-dead", 4);
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+
+    const writeStatus = { applyPhaseStatus: () => {}, applyTerminalDone: () => {}, applyLabel: () => {} };
+
+    // Tick A — saturated (liveBackgroundCount=1). The resume sweep (1.5) sees 0
+    // free slots and skips. With NO reclaim stub, the real reclaim sweep runs
+    // first; without the CTL-705 guard it would route the parked-dead-bg signal
+    // through the death trigger and revive it (a duplicate spawn). The guard
+    // makes the parked signal untouched.
+    const dispatchA = makeRealDispatch();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      // reclaimDeadWork intentionally omitted → real reclaimDeadWorkIfPossible
+      dispatch: dispatchA,
+      liveBackgroundCount: () => 1,
+      now: () => T0,
+      killBgJob: makeKillStub(),
+      writeStatus,
+    });
+    // The parked signal must be untouched — no revive, no advancement, status
+    // still "preempted", bg_job_id unchanged.
+    const afterA = readSignal("CTL-Park", "research");
+    expect(afterA?.status).toBe("preempted");
+    expect(afterA?.bg_job_id).toBe("bg-park-dead");
+    expect(dispatchA.calls.find((c) => c.ticket === "CTL-Park")).toBeUndefined();
+
+    // Tick B — a slot frees (liveBackgroundCount=0). NOW the resume sweep owns
+    // the re-dispatch (not the reclaim sweep), at parkedFrom=research.
+    const dispatchB = makeRealDispatch();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      // reclaimDeadWork still omitted → real reclaim
+      dispatch: dispatchB,
+      liveBackgroundCount: () => 0,
+      now: () => T0 + 1_000,
+      killBgJob: makeKillStub(),
+      resolveSession: () => null, // cold re-dispatch (no --resume-session)
+      writeStatus,
+    });
+    const resumeCall = dispatchB.calls.find((c) => c.ticket === "CTL-Park");
+    expect(resumeCall).toBeDefined();
+    expect(resumeCall.phase).toBe("research"); // re-dispatched at parkedFrom
+    expect(readSignal("CTL-Park", "research")?.status).toBe("dispatched");
+  });
+});
+
 describe("CTL-705 guard scenario — monitor-deploy not preemptable", () => {
   test("Only in-flight worker at monitor-deploy → no preemption even with Urgent queued", () => {
     const T0 = 200_000;

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -524,6 +524,42 @@ export function defaultAppendDispatchLaunchedEvent({
   );
 }
 
+// CTL-705: preemption and resume-after-preemption event emitters.
+
+// defaultAppendPreemptedEvent — phase.<phase>.preempted.<TICKET>.
+// Emitted when the scheduler stops a lower-priority in-flight worker to free a
+// slot for a higher-priority queued ticket. The `phase` slot is the real phase
+// being preempted (not the literal "dispatch"). Best-effort, never throws.
+export function defaultAppendPreemptedEvent({ orchId, ticket, phase, preemptedBy, bgJobId }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "preempted",
+      payloadExtras: { preempted_by: preemptedBy, bg_job_id: bgJobId },
+    }),
+    "preempted",
+  );
+}
+
+// defaultAppendResumedAfterPreemptionEvent — phase.<phase>.resumed-after-preemption.<TICKET>.
+// Emitted when a previously-preempted worker is re-dispatched at its parkedFrom
+// phase. resumeSession is null when the UUID could not be resolved (cold re-dispatch).
+// Best-effort, never throws.
+export function defaultAppendResumedAfterPreemptionEvent({ orchId, ticket, phase, resumeSession }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase,
+      ticket,
+      orchId,
+      action: "resumed-after-preemption",
+      payloadExtras: { resume_session: resumeSession ?? null },
+    }),
+    "resumed-after-preemption",
+  );
+}
+
 // CTL-587 default seams — all overridable for tests, all best-effort for prod.
 
 // defaultReviveDispatch — reset the signal to status: "stalled" first (to bypass

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -23,6 +23,8 @@ import {
   defaultAppendDispatchRequestedEvent,
   defaultAppendDispatchLaunchedEvent,
   defaultAppendYieldFileSkipEvent,
+  defaultAppendPreemptedEvent,
+  defaultAppendResumedAfterPreemptionEvent,
   readBootEpoch,
   readDaemonEpoch,
   defaultReadRuntimeEpoch,
@@ -32,7 +34,7 @@ import {
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
-import { existsSync, appendFileSync } from "node:fs";
+import { existsSync, appendFileSync, chmodSync } from "node:fs";
 
 let orchDir;
 
@@ -2745,5 +2747,76 @@ describe("resolvePhaseSessionId", () => {
     mkdirSync(join(jobsDir, "nolink"), { recursive: true });
     writeFileSync(join(jobsDir, "nolink", "state.json"), JSON.stringify({ state: "stopped" }));
     expect(resolvePhaseSessionId("nolink", { jobsDir })).toBeNull();
+  });
+});
+
+// CTL-705 Phase 4/5: preemption and resume-after-preemption event envelopes.
+describe("preemption event envelopes (CTL-705)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl705-preempt-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  function readBackEnvelope() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    return JSON.parse(lines[lines.length - 1]);
+  }
+
+  test("defaultAppendPreemptedEvent writes phase.<phase>.preempted.<TICKET> envelope", () => {
+    const ok = defaultAppendPreemptedEvent({
+      orchId: "CTL-2",
+      ticket: "CTL-2",
+      phase: "research",
+      preemptedBy: "CTL-9",
+      bgJobId: "abc12345",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.research.preempted.CTL-2");
+    expect(env.attributes["event.action"]).toBe("preempted");
+    expect(env.body.payload.preempted_by).toBe("CTL-9");
+    expect(env.body.payload.bg_job_id).toBe("abc12345");
+  });
+
+  test("defaultAppendPreemptedEvent returns false on write failure, never throws", () => {
+    // Remove the events dir and make envCatalystDir read-only to force a write failure.
+    rmSync(join(envCatalystDir, "events"), { recursive: true, force: true });
+    chmodSync(envCatalystDir, 0o555);
+    let result;
+    try {
+      result = defaultAppendPreemptedEvent({
+        orchId: "CTL-2", ticket: "CTL-2", phase: "research", preemptedBy: "CTL-9", bgJobId: "x",
+      });
+    } finally {
+      chmodSync(envCatalystDir, 0o755);
+    }
+    expect(result).toBe(false);
+  });
+
+  test("defaultAppendResumedAfterPreemptionEvent writes phase.<phase>.resumed-after-preemption.<T>", () => {
+    const ok = defaultAppendResumedAfterPreemptionEvent({
+      orchId: "CTL-2",
+      ticket: "CTL-2",
+      phase: "research",
+      resumeSession: "sess-uuid",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.research.resumed-after-preemption.CTL-2");
+    expect(env.attributes["event.action"]).toBe("resumed-after-preemption");
+    expect(env.body.payload.resume_session).toBe("sess-uuid");
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler-rank.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler-rank.mjs
@@ -1,7 +1,7 @@
-// scheduler-rank.mjs — pull-loop scheduler priority ranking (CTL-536).
+// scheduler-rank.mjs — pull-loop scheduler priority ranking (CTL-536, CTL-705).
 //
-// Pure leaf module: data in → data out, no I/O, no imports. Encodes the one
-// ranking rule the scheduler needs — Linear priority, then createdAt.
+// Pure leaf module: data in → data out, no I/O, no imports. Encodes the
+// global ranking rule: priority → stage → createdAt → identifier.
 
 // Linear priority encoding: 1=Urgent, 2=High, 3=Medium, 4=Low, 0=No priority.
 // Lower non-zero is more urgent; 0 ("No priority") must rank BELOW Low(4), so
@@ -11,16 +11,25 @@ export function priorityRank(ticket) {
   return p === 1 || p === 2 || p === 3 || p === 4 ? p : 5;
 }
 
-// compareTickets — total order for scheduler selection.
+// compareTickets — total order for scheduler selection (CTL-705: 4-key order).
 //   1. priority rank ascending (most urgent first)
-//   2. createdAt ascending (oldest waiting ticket first — FIFO fairness;
-//      ISO-8601 strings compare lexicographically = chronologically)
-//   3. identifier ascending (deterministic final tie-break)
-// A missing createdAt sorts LAST within its priority band — absent data never
-// jumps the queue ahead of a ticket with a known wait time.
+//   2. stage descending (later pipeline phase first — shortest-remaining-time;
+//      absent/undefined stage treated as -1, so queued tickets tie on stage and
+//      fall through to createdAt — backward compatible with all queued-vs-queued
+//      comparisons. In-flight workers carry an integer stage from STAGE_RANK.)
+//   3. createdAt ascending (FIFO fairness; ISO-8601 strings compare lexicographically)
+//   4. identifier ascending (deterministic final tie-break)
+// A missing createdAt sorts LAST within its band — absent data never jumps the
+// queue ahead of a ticket with a known wait time.
 export function compareTickets(a, b) {
   const byPriority = priorityRank(a) - priorityRank(b);
   if (byPriority !== 0) return byPriority;
+
+  // stage: higher = later pipeline phase = closer to done. Descending so
+  // preemption targets the least-advanced worker. Absent stage → -1.
+  const sa = Number.isInteger(a?.stage) ? a.stage : -1;
+  const sb = Number.isInteger(b?.stage) ? b.stage : -1;
+  if (sa !== sb) return sb - sa; // descending: higher stage sorts first
 
   const ca = a?.createdAt || "";
   const cb = b?.createdAt || "";

--- a/plugins/dev/scripts/execution-core/scheduler-rank.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler-rank.test.mjs
@@ -47,3 +47,49 @@ describe("rankTickets", () => {
     expect(rankTickets([])).toEqual([]);
   });
 });
+
+// CTL-705: stage-aware global comparator
+describe("compareTickets stage key", () => {
+  const ts = (id, priority, stage, createdAt) => ({ identifier: id, priority, stage, createdAt });
+
+  test("backward compat — no stage field: sorts by createdAt (queued-vs-queued unchanged)", () => {
+    const a = t("A", 2, "2026-05-01T00:00:00Z");
+    const b = t("B", 2, "2026-05-10T00:00:00Z");
+    expect(compareTickets(a, b)).toBeLessThan(0);
+  });
+
+  test("stage breaks a priority tie, descending (higher stage = closer to done)", () => {
+    // Use identifiers where B < A to make identifier tie-break go the WRONG way,
+    // proving the stage key is what drives the result.
+    const a = ts("Z", 2, 5, "2026-05-01T00:00:00Z"); // higher stage, higher identifier
+    const b = ts("A", 2, 2, "2026-05-01T00:00:00Z"); // lower stage, lower identifier
+    expect(compareTickets(a, b)).toBeLessThan(0); // a (stage 5) sorts before b (stage 2)
+  });
+
+  test("priority dominates stage: Urgent@triage beats Low@monitor-deploy", () => {
+    const urgent = ts("Z", 1, 0, "2026-05-01T00:00:00Z"); // higher identifier
+    const low = ts("A", 4, 9, "2026-05-01T00:00:00Z");    // lower identifier
+    expect(compareTickets(urgent, low)).toBeLessThan(0);
+  });
+
+  test("in-flight (stage ≥ 0) sorts before queued (stage -1) within same priority band", () => {
+    // in-flight has higher identifier so identifier tie-break goes wrong way without stage
+    const inFlight = ts("Z", 2, 3, "2026-05-01T00:00:00Z");
+    const queued = ts("A", 2, -1, "2026-05-01T00:00:00Z");
+    expect(compareTickets(inFlight, queued)).toBeLessThan(0);
+  });
+
+  test("stage undefined is treated as -1 (queued default)", () => {
+    // withStage has higher identifier so identifier tie-break goes wrong way without stage
+    const withStage = ts("Z", 2, 2, "2026-05-01T00:00:00Z");
+    const withoutStage = t("A", 2, "2026-05-01T00:00:00Z"); // no stage field → treated as -1
+    expect(compareTickets(withStage, withoutStage)).toBeLessThan(0);
+  });
+
+  test("rankTickets is still pure — input array not mutated", () => {
+    const input = [ts("C", 2, 1, "x"), ts("A", 2, 5, "x"), ts("B", 2, -1, "x")];
+    const copy = input.map((x) => ({ ...x }));
+    rankTickets(input);
+    expect(input).toEqual(copy);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -69,6 +69,7 @@ import {
   defaultKillBgJob,
   defaultAppendPreemptedEvent,
   defaultAppendResumedAfterPreemptionEvent,
+  resolvePhaseSessionId as defaultResolveSession,
 } from "./recovery.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
@@ -1216,6 +1217,9 @@ export function schedulerTick(
     killBgJob = defaultKillBgJob,
     appendPreemptedEvent = defaultAppendPreemptedEvent,
     appendResumedAfterPreemptionEvent = defaultAppendResumedAfterPreemptionEvent,
+    // CTL-705 Phase 5: resume resolver — maps a dead bg_job_id to a claude
+    // --resume UUID. Null return → cold re-dispatch (no --resume-session).
+    resolveSession = defaultResolveSession,
   } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -1549,6 +1553,106 @@ export function schedulerTick(
     }
   }
 
+  // (1.5) Resume-after-preemption sweep — re-dispatch parked ("preempted") tickets
+  // at their parkedFrom phase when a slot frees. Parked tickets are ranked by
+  // buildGlobalRanking and processed top-ranked first. Runs after advancement
+  // (so a slot freed by an advanced ticket is credited here) and before new-work
+  // pull (so a preempted ticket reclaims its slot ahead of brand-new work).
+  let resumedCount = 0;
+  {
+    const maxP2 = readMaxParallel(orchDir, concurrency);
+    const liveCount2 = liveBackgroundCount();
+    let resumeSlots = computeFreeSlots(maxP2, liveCount2);
+    if (resumeSlots > 0) {
+      // Collect parked tickets: in-flight tickets with status === PREEMPTED_STATUS.
+      const parkedDescriptors = [];
+      for (const ticket of listInFlightTickets(orchDir)) {
+        const sigs = readPhaseSignals(orchDir, ticket);
+        const parkedPhase = Object.entries(sigs).find(([, s]) => s === PREEMPTED_STATUS)?.[0];
+        if (!parkedPhase) continue;
+        const { priority, createdAt } = readWorkerPriority(orchDir, ticket);
+        parkedDescriptors.push({
+          identifier: ticket,
+          priority,
+          createdAt,
+          stage: STAGE_RANK[parkedPhase] ?? -1,
+          inFlight: true,
+          parkedFrom: parkedPhase,
+        });
+      }
+      const rankedParked = rankTickets(parkedDescriptors);
+
+      for (const pd of rankedParked) {
+        if (resumeSlots <= 0) break;
+        const parkedPhase = pd.parkedFrom;
+        const signalRaw = readPhaseSignalRaw(orchDir, pd.identifier, parkedPhase);
+        const bgJobId = signalRaw?.bg_job_id;
+
+        const resumeSession = resolveSession(bgJobId) ?? undefined;
+        safeEmit(
+          appendDispatchRequestedEvent,
+          { orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase, reason: "resume-after-preemption" },
+          { ticket: pd.identifier, phase: parkedPhase }
+        );
+
+        // Reset the signal to "stalled" so phase-agent-dispatch's idempotency
+        // guard does not block re-dispatch (mirrors defaultReviveDispatch).
+        const signalPath = join(orchDir, "workers", pd.identifier, `phase-${parkedPhase}.json`);
+        try {
+          const tmp = `${signalPath}.tmp.${process.pid}`;
+          writeFileSync(tmp, JSON.stringify({
+            ...(signalRaw ?? {}),
+            status: "stalled",
+            attentionReason: "resume-after-preemption",
+            updatedAt: new Date(now()).toISOString().replace(/\.\d{3}Z$/, "Z"),
+          }));
+          renameSync(tmp, signalPath);
+        } catch (err) {
+          log.warn({ ticket: pd.identifier, phase: parkedPhase, err: err.message }, "scheduler: resume signal reset failed");
+          continue;
+        }
+
+        const r = dispatchTicket(orchDir, pd.identifier, parkedPhase, { dispatch, resumeSession });
+        if (r.code === 0) {
+          const v = verifyDispatched(orchDir, pd.identifier, parkedPhase);
+          if (v.ok) {
+            clearDispatchCooldown(orchDir, pd.identifier, parkedPhase);
+            rankedAboveSince.delete(`${pd.identifier}:${pd.identifier}`); // clear any stale hysteresis
+            const sig2 = readPhaseSignalRaw(orchDir, pd.identifier, parkedPhase);
+            safeEmit(
+              appendDispatchLaunchedEvent,
+              { orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase, bg_job_id: sig2?.bg_job_id, worktree_path: sig2?.worktreePath },
+              { ticket: pd.identifier, phase: parkedPhase }
+            );
+            safeEmit(
+              appendResumedAfterPreemptionEvent,
+              { orchId: pd.identifier, ticket: pd.identifier, phase: parkedPhase, resumeSession: resumeSession ?? null },
+              { ticket: pd.identifier, phase: parkedPhase }
+            );
+            safeWrite(
+              () => writeStatus.applyPhaseStatus({ ticket: pd.identifier, phase: parkedPhase }),
+              { ticket: pd.identifier, phase: parkedPhase }
+            );
+            resumeSlots--;
+            resumedCount++;
+          } else {
+            recordDispatchFailure(orchDir, pd.identifier, parkedPhase, 0, now());
+            appendDispatchFailedEvent({
+              orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase,
+              code: 0, reason: `verify_failed:${v.reason}`,
+            });
+          }
+        } else {
+          recordDispatchFailure(orchDir, pd.identifier, parkedPhase, r.code, now());
+          appendDispatchFailedEvent({
+            orchId: pd.identifier, ticket: pd.identifier, target_phase: parkedPhase,
+            code: r.code, reason: "dispatch_nonzero_exit",
+          });
+        }
+      }
+    }
+  }
+
   // (2) New-work pull — fill free slots with top-ranked ready tickets. D5:
   // hydrate the live state of every out-of-set blocker first so a Ready ticket
   // blocked by a non-terminal out-of-set ticket is held back.
@@ -1565,7 +1669,9 @@ export function schedulerTick(
   const inFlightCount = liveBackgroundCount();
   // CTL-665: config-first ceiling — a committed executionCore.maxParallel
   // (threaded via `concurrency`) wins over state.json; clamped to the bounds.
-  const freeSlots = computeFreeSlots(readMaxParallel(orchDir, concurrency), inFlightCount);
+  // CTL-705: subtract resumed slots (sweep 1.5) so resume and new-work don't
+  // both fill the same slot when claude stop hasn't deregistered yet.
+  const freeSlots = Math.max(0, computeFreeSlots(readMaxParallel(orchDir, concurrency), inFlightCount) - resumedCount);
   // CTL-706: per-project caps + reserves gate selection AFTER ranking. With
   // no perProject config this is byte-for-byte selectDispatchable.
   // inFlightTickets was already computed above for the reclaim sweep.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1271,6 +1271,15 @@ export function schedulerTick(
 
   for (const sig of readWorkerSignals(orchDir)) {
     if (!inFlightTickets.has(sig.ticket)) continue;
+    // CTL-705: a parked ("preempted") worker is paused, not dead. Its signal
+    // preserves the now-killed bg_job_id, so classifyWorker would route it
+    // through the death trigger and reclaimDeadWork would falsely revive it —
+    // spawning a duplicate AND defeating the resume sweep (1.5), the only path
+    // that re-dispatches a parked ticket with --resume-session continuity
+    // (CTL-690). The reclaim sweep runs BEFORE sweep 1.5, so without this guard
+    // it wins the race every tick. (The advancement guard at the (1) sweep only
+    // stops false advancement, not false reclaim — both are needed.)
+    if (sig.status === PREEMPTED_STATUS) continue;
     try {
       const team = teamOf(sig.ticket);
       const repoRoot = team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
@@ -1326,6 +1335,18 @@ export function schedulerTick(
   // the new-work pull (2) share a single read per tick.
   const eligible = readEligible ? readEligible() : readAllEligibleTickets();
 
+  // CTL-705: hoist the worker-slot ceiling + live background count to a SINGLE
+  // read per tick, shared by the preemption sweep (0.5), the resume sweep (1.5),
+  // and the new-work pull (2). `claude stop` does not deregister within the same
+  // tick (a just-preempted worker's process lingers until the next agents scan),
+  // so liveBackgroundCount is stable across all three sweeps — one read is
+  // semantically correct AND avoids tripling the per-tick `claude agents --json`
+  // subprocess cost on the hot daemon loop (was the root cause of the CTL-653
+  // verify-remediate test timeout). freeSlots is recomputed arithmetically per
+  // sweep (subtracting resumedCount in sweep 2) rather than re-shelling-out.
+  const maxParallel = readMaxParallel(orchDir, concurrency);
+  const liveCount = liveBackgroundCount();
+
   // (0.5) Preemption sweep — if slots are saturated AND the top-ranked queued
   // ticket out-ranks the lowest-ranked preemptable in-flight worker, stop that
   // worker and park it for resume when a slot frees. Safety guards prevent
@@ -1333,9 +1354,7 @@ export function schedulerTick(
   // 30s hysteresis. Runs after reclaim (so a just-reclaimed slot is counted)
   // and before advancement (so a preempted signal isn't falsely advanced).
   {
-    const maxP = readMaxParallel(orchDir, concurrency);
-    const liveCount = liveBackgroundCount();
-    if (computeFreeSlots(maxP, liveCount) <= 0) {
+    if (computeFreeSlots(maxParallel, liveCount) <= 0) {
       // Build the global ranking to find topQueued and potential victim.
       const ranking = buildGlobalRanking(orchDir, eligible);
       const topQueued = ranking.find((d) => !d.inFlight);
@@ -1560,9 +1579,7 @@ export function schedulerTick(
   // pull (so a preempted ticket reclaims its slot ahead of brand-new work).
   let resumedCount = 0;
   {
-    const maxP2 = readMaxParallel(orchDir, concurrency);
-    const liveCount2 = liveBackgroundCount();
-    let resumeSlots = computeFreeSlots(maxP2, liveCount2);
+    let resumeSlots = computeFreeSlots(maxParallel, liveCount);
     if (resumeSlots > 0) {
       // Collect parked tickets: in-flight tickets with status === PREEMPTED_STATUS.
       const parkedDescriptors = [];
@@ -1666,12 +1683,16 @@ export function schedulerTick(
   // CTL-657: the in-flight count is the live `background` claude-agents count,
   // not listInFlightTickets(orchDir).size. A worker that leaked (signal terminal
   // but process alive) still consumes a slot; a duplicate spawn is counted.
-  const inFlightCount = liveBackgroundCount();
+  // CTL-705: reuse the tick-hoisted liveCount (a single `claude agents --json`
+  // read) instead of re-shelling-out — `claude stop` does not deregister within
+  // the same tick, so the count is stable since sweep 0.5.
+  const inFlightCount = liveCount;
   // CTL-665: config-first ceiling — a committed executionCore.maxParallel
   // (threaded via `concurrency`) wins over state.json; clamped to the bounds.
   // CTL-705: subtract resumed slots (sweep 1.5) so resume and new-work don't
-  // both fill the same slot when claude stop hasn't deregistered yet.
-  const freeSlots = Math.max(0, computeFreeSlots(readMaxParallel(orchDir, concurrency), inFlightCount) - resumedCount);
+  // both fill the same slot when claude stop hasn't deregistered yet. maxParallel
+  // is the tick-hoisted readMaxParallel value (single read per tick).
+  const freeSlots = Math.max(0, computeFreeSlots(maxParallel, inFlightCount) - resumedCount);
   // CTL-706: per-project caps + reserves gate selection AFTER ranking. With
   // no perProject config this is byte-for-byte selectDispatchable.
   // inFlightTickets was already computed above for the reclaim sweep.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -22,6 +22,7 @@ import {
   mkdirSync,
   rmSync,
   renameSync,
+  statSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join, dirname, basename } from "node:path";
@@ -42,7 +43,7 @@ import {
 // the sweep and are injected, so the router itself is unit-testable.
 import { readVerifyVerdict } from "./work-done-probes.mjs";
 import { countRemediateCycles } from "./event-scan.mjs";
-import { rankTickets } from "./scheduler-rank.mjs";
+import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import { defaultDispatch, dispatchTicket, teamOf } from "./dispatch.mjs";
 import { fetchTicketState } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
@@ -65,6 +66,9 @@ import {
   defaultAppendDispatchRequestedEvent,
   defaultAppendDispatchLaunchedEvent,
   defaultAppendYieldFileSkipEvent,
+  defaultKillBgJob,
+  defaultAppendPreemptedEvent,
+  defaultAppendResumedAfterPreemptionEvent,
 } from "./recovery.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
@@ -197,6 +201,33 @@ export function buildGlobalRanking(orchDir, eligible) {
 
   return rankTickets(descriptors);
 }
+
+// CTL-705 Phase 4: preemption constants and module state.
+
+// Phases that must never be preempted: monitor-deploy is a passive observer of
+// deployment outcomes; triage runs once at pipeline entry and is brief.
+export const NON_PREEMPTABLE_PHASES = new Set(["triage", "monitor-deploy"]);
+
+// Minimum wall-clock seconds a worker must have been running before it becomes
+// a preemption candidate — prevents stopping a worker that just started.
+const PREEMPT_MIN_RUNTIME_MS = 60_000;
+
+// Quiet-window for implement workers: if phase-implement.json mtime is more
+// recent than this, the worker is actively committing — don't interrupt.
+const PREEMPT_IMPLEMENT_QUIET_MS = 10_000;
+
+// Hysteresis window: a queued ticket must out-rank its candidate for at least
+// this long before preemption fires, preventing thrash on priority fluctuations.
+const PREEMPT_HYSTERESIS_MS = 30_000;
+
+// Status value written to the victim's phase signal when preempted.
+export const PREEMPTED_STATUS = "preempted";
+
+// rankedAboveSince — module state tracking when each (topQueued,victim) pair
+// first became rank-eligible. Keyed by `${topQueuedId}:${victimId}` so the
+// hysteresis tracks the specific preemptor→victim relationship.
+// Cleared on stopScheduler/__resetForTests (see daemon module state section).
+const rankedAboveSince = new Map();
 
 // readPhaseSignals — { phase: status } for one ticket's workers/<T>/phase-*.json.
 export function readPhaseSignals(orchDir, ticket) {
@@ -1181,6 +1212,10 @@ export function schedulerTick(
     // CTL-702: injectable yield-file-skip emitter. Deduped by observedYieldFiles
     // (module-level set) so only the first observation per daemon lifetime fires.
     appendYieldFileSkipEvent = defaultAppendYieldFileSkipEvent,
+    // CTL-705: preemption seams — injectable for tests, default to real helpers.
+    killBgJob = defaultKillBgJob,
+    appendPreemptedEvent = defaultAppendPreemptedEvent,
+    appendResumedAfterPreemptionEvent = defaultAppendResumedAfterPreemptionEvent,
   } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -1283,9 +1318,136 @@ export function schedulerTick(
     }
   }
 
+  // CTL-705: hoist eligible read here so both the preemption sweep (0.5) and
+  // the new-work pull (2) share a single read per tick.
+  const eligible = readEligible ? readEligible() : readAllEligibleTickets();
+
+  // (0.5) Preemption sweep — if slots are saturated AND the top-ranked queued
+  // ticket out-ranks the lowest-ranked preemptable in-flight worker, stop that
+  // worker and park it for resume when a slot frees. Safety guards prevent
+  // thrash: non-preemptable phases, 60s min-runtime, implement quiet-window,
+  // 30s hysteresis. Runs after reclaim (so a just-reclaimed slot is counted)
+  // and before advancement (so a preempted signal isn't falsely advanced).
+  {
+    const maxP = readMaxParallel(orchDir, concurrency);
+    const liveCount = liveBackgroundCount();
+    if (computeFreeSlots(maxP, liveCount) <= 0) {
+      // Build the global ranking to find topQueued and potential victim.
+      const ranking = buildGlobalRanking(orchDir, eligible);
+      const topQueued = ranking.find((d) => !d.inFlight);
+      // Victim candidates: in-flight, sorted worst-to-best (reverse ranking).
+      const inFlightRanked = ranking.filter((d) => d.inFlight);
+      // Scan from lowest-ranked in-flight (last in sorted array) toward highest.
+      const nowMs = now();
+      for (let i = inFlightRanked.length - 1; i >= 0; i--) {
+        if (!topQueued) break; // no queued ticket wants a slot
+        const candidate = inFlightRanked[i];
+        // Only preempt if topQueued strictly out-ranks this candidate.
+        if (compareTickets(topQueued, candidate) >= 0) break; // sorted, so remaining are worse
+
+        // Read the candidate's active signal to get phase and startedAt.
+        const signals = readPhaseSignals(orchDir, candidate.identifier);
+        const activePhase = Object.entries(signals).reduce((best, [phase, status]) => {
+          if (TERMINAL_SIGNAL_STATUSES.has(status)) return best;
+          if (phase === TERMINAL_PHASE && (status === "done" || status === "skipped")) return best;
+          const rank = STAGE_RANK[phase] ?? -1;
+          return rank > (STAGE_RANK[best] ?? -1) ? phase : best;
+        }, null);
+        if (!activePhase) continue;
+
+        // Guard: non-preemptable phase
+        if (NON_PREEMPTABLE_PHASES.has(activePhase)) continue;
+
+        const signalRaw = readPhaseSignalRaw(orchDir, candidate.identifier, activePhase);
+        if (!signalRaw) continue;
+
+        // Guard: min-runtime floor
+        const startedMs = signalRaw.startedAt ? Date.parse(signalRaw.startedAt) : 0;
+        if (startedMs > 0 && nowMs - startedMs < PREEMPT_MIN_RUNTIME_MS) continue;
+
+        // Guard: implement quiet-window (mtime of the phase signal file)
+        if (activePhase === "implement") {
+          const signalPath = join(orchDir, "workers", candidate.identifier, `phase-${activePhase}.json`);
+          try {
+            const st = statSync(signalPath);
+            if (nowMs - st.mtimeMs < PREEMPT_IMPLEMENT_QUIET_MS) continue;
+          } catch {
+            // can't stat → fail-open (skip the quiet-window guard)
+          }
+        }
+
+        // Guard: hysteresis — must have out-ranked this candidate for ≥30s
+        const hysteresisKey = `${topQueued.identifier}:${candidate.identifier}`;
+        if (!rankedAboveSince.has(hysteresisKey)) {
+          rankedAboveSince.set(hysteresisKey, nowMs);
+          continue; // first observation this tick — start the clock
+        }
+        if (nowMs - rankedAboveSince.get(hysteresisKey) < PREEMPT_HYSTERESIS_MS) continue;
+
+        // All guards passed — preempt this candidate.
+        const bgJobId = signalRaw.bg_job_id;
+        killBgJob({ bgJobId });
+
+        // Atomically park the signal: status → "preempted", add parkedFrom + attentionReason.
+        const signalPath = join(orchDir, "workers", candidate.identifier, `phase-${activePhase}.json`);
+        try {
+          const updated = {
+            ...signalRaw,
+            status: PREEMPTED_STATUS,
+            parkedFrom: activePhase,
+            attentionReason: "preempted-by-priority",
+            updatedAt: new Date(nowMs).toISOString().replace(/\.\d{3}Z$/, "Z"),
+          };
+          const tmp = `${signalPath}.tmp.${process.pid}`;
+          writeFileSync(tmp, JSON.stringify(updated));
+          renameSync(tmp, signalPath);
+        } catch (err) {
+          log.warn(
+            { ticket: candidate.identifier, phase: activePhase, err: err.message },
+            "scheduler: preemption signal write failed — skipping"
+          );
+          continue;
+        }
+
+        safeEmit(
+          appendPreemptedEvent,
+          {
+            orchId: candidate.identifier,
+            ticket: candidate.identifier,
+            phase: activePhase,
+            preemptedBy: topQueued.identifier,
+            bgJobId,
+          },
+          { ticket: candidate.identifier, phase: activePhase }
+        );
+
+        rankedAboveSince.delete(hysteresisKey); // clear after successful preemption
+        break; // one preemption per tick
+      }
+
+      // Prune hysteresis entries whose candidates are no longer lowest-ranked.
+      // (Avoids stale entries from tickets that advanced or completed.)
+      if (topQueued) {
+        for (const [key] of rankedAboveSince) {
+          const victimId = key.split(":")[1];
+          if (!inFlightRanked.find((d) => d.identifier === victimId)) {
+            rankedAboveSince.delete(key);
+          }
+        }
+      }
+    }
+  }
+
   // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
+  // CTL-705: preempted workers are skipped — their active status is not "done" so
+  // deriveAdvancement returns null, but an early continue makes the intent explicit
+  // and provides a regression anchor (test 9 in the plan).
   const advanced = [];
   for (const ticket of listInFlightTickets(orchDir)) {
+    // Skip parked (preempted) tickets — they re-enter via the resume sweep (1.5).
+    const ticketSignals = readPhaseSignals(orchDir, ticket);
+    if (Object.values(ticketSignals).some((s) => s === PREEMPTED_STATUS)) continue;
+
     // CTL-661 hole #2: snapshot the signals + the remediate worker's raw signal
     // BEFORE maybeResetForRemediateCycle deletes the verify+remediate signals,
     // so a remediate→verify re-entry can still name + reap the remediate worker
@@ -1390,7 +1552,7 @@ export function schedulerTick(
   // (2) New-work pull — fill free slots with top-ranked ready tickets. D5:
   // hydrate the live state of every out-of-set blocker first so a Ready ticket
   // blocked by a non-terminal out-of-set ticket is held back.
-  const eligible = readEligible ? readEligible() : readAllEligibleTickets();
+  // CTL-705: `eligible` is hoisted above sweep 0.5 — used by buildGlobalRanking there.
   const blockerStates = hydrateOutOfSetBlockers(eligible, { exec, cache });
   // CTL-634: surface the cache hit-rate once per tick. Log-line-only matches
   // the daemon's pino-only observability convention (schedulerTick's return
@@ -1705,6 +1867,7 @@ export function stopScheduler() {
   watcher?.close();
   watcher = null;
   runningOpts = null;
+  rankedAboveSince.clear(); // CTL-705: reset hysteresis state on daemon stop
 }
 
 // __resetForTests — clear daemon state between unit tests. Not part of the
@@ -1712,6 +1875,7 @@ export function stopScheduler() {
 export function __resetForTests() {
   stopScheduler();
   observedYieldFiles.clear(); // CTL-702: reset per-lifetime dedup set between tests
+  // rankedAboveSince is cleared by stopScheduler above (CTL-705)
 }
 
 // --- standalone entrypoint (operator dry-run / CTL-554 wires the real daemon) ---

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -21,6 +21,7 @@ import {
   watch,
   mkdirSync,
   rmSync,
+  renameSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join, dirname, basename } from "node:path";
@@ -88,6 +89,114 @@ const TERMINAL_PHASE = "monitor-deploy";
 // scheduler never dispatches `triage`. CTL-565 Part B. Deliberately NOT
 // PHASES[0] ("triage"); the FSM still owns chaining research → plan → … .
 const NEW_WORK_ENTRY_PHASE = "research";
+
+// CTL-705: STAGE_RANK — integer stage index for every pipeline phase + remediate.
+// Higher = later in the pipeline = closer to done (shortest-remaining-time-first
+// for preemption targeting). Deliberately duplicates PHASES order here rather than
+// computing it dynamically, so scheduler-rank.mjs stays a pure leaf (no imports).
+// Key ORDER mirrors [...PHASES, "remediate"] (drift guard in scheduler.test.mjs).
+// Any reorder to PHASES must update both keys AND values here.
+// Values: 0..9 with remediate=4 sitting between implement(3) and verify(5).
+export const STAGE_RANK = Object.freeze({
+  triage: 0,
+  research: 1,
+  plan: 2,
+  implement: 3,
+  verify: 5,
+  review: 6,
+  pr: 7,
+  "monitor-merge": 8,
+  "monitor-deploy": 9,
+  remediate: 4, // ancillary phase — appended last so Object.keys() == [...PHASES, "remediate"]
+});
+
+// TERMINAL_SIGNAL_STATUSES — statuses that indicate a phase is definitively done
+// (success or failure). Used by stageRankForTicket to skip phases that no longer
+// represent active work. Mirrors the isTicketInFlight notion of terminal, but
+// kept separate (isTicketInFlight includes the terminal-pipeline check and must
+// not collapse with this set — see the CTL-565 cross-reference comment on
+// isTicketInFlight).
+const TERMINAL_SIGNAL_STATUSES = new Set(["failed", "stalled", "aborted"]);
+
+// stageRankForTicket — given a {phase: status} map, return the highest STAGE_RANK
+// value over all non-terminal phases. Returns -1 when no active phase is found
+// (e.g. empty signals or all phases terminal) — this is the same sentinel used for
+// queued tickets, placing parked-but-active in-flight workers ahead of the queue.
+// A "preempted" signal is non-terminal (the worker is paused, not finished) and
+// yields its phase's rank so the preempted ticket keeps its position in the global
+// order.
+export function stageRankForTicket(signals) {
+  const sig = signals ?? {};
+  let maxRank = -1;
+  for (const [phase, status] of Object.entries(sig)) {
+    if (TERMINAL_SIGNAL_STATUSES.has(status)) continue;
+    if (phase === TERMINAL_PHASE && (status === "done" || status === "skipped")) continue;
+    const rank = STAGE_RANK[phase];
+    if (rank !== undefined && rank > maxRank) maxRank = rank;
+  }
+  return maxRank;
+}
+
+// readWorkerPriority — read workers/<T>/priority.json → {priority, createdAt}.
+// Missing or unreadable → {priority: 5, createdAt: null} (safe lowest-band
+// default). Never throws.
+export function readWorkerPriority(orchDir, ticket) {
+  try {
+    const raw = readFileSync(join(orchDir, "workers", ticket, "priority.json"), "utf8");
+    const p = JSON.parse(raw);
+    return {
+      priority: Number.isInteger(p?.priority) ? p.priority : 5,
+      createdAt: typeof p?.createdAt === "string" ? p.createdAt : null,
+    };
+  } catch {
+    return { priority: 5, createdAt: null };
+  }
+}
+
+// writeWorkerPriority — write workers/<T>/priority.json. Idempotent overwrite via
+// tmp+rename. Silently no-ops if the worker dir does not exist (we never create it
+// here — the worker's prelude owns the dir). Best-effort: a write failure is
+// swallowed so a transient I/O error never blocks the dispatch.
+export function writeWorkerPriority(orchDir, ticket, { priority, createdAt }) {
+  const p = join(orchDir, "workers", ticket, "priority.json");
+  try {
+    const tmp = `${p}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify({ priority, createdAt }));
+    renameSync(tmp, p);
+  } catch {
+    // best-effort — missing worker dir or I/O failure; next dispatch retries
+  }
+}
+
+// buildGlobalRanking — assemble a descriptor array for every in-flight ticket
+// AND every eligible-but-not-started queued ticket, sorted by rankTickets.
+// Descriptor shape: {identifier, priority, createdAt, stage, inFlight}.
+// A ticket present in both eligible and in-flight is listed once, as in-flight.
+export function buildGlobalRanking(orchDir, eligible) {
+  const inFlight = listInFlightTickets(orchDir);
+  const started = listStartedTickets(orchDir);
+  const descriptors = [];
+
+  for (const ticket of inFlight) {
+    const { priority, createdAt } = readWorkerPriority(orchDir, ticket);
+    const signals = readPhaseSignals(orchDir, ticket);
+    const stage = stageRankForTicket(signals);
+    descriptors.push({ identifier: ticket, priority, createdAt, stage, inFlight: true });
+  }
+
+  for (const t of eligible ?? []) {
+    if (started.has(t.identifier)) continue; // already in-flight (listed above)
+    descriptors.push({
+      identifier: t.identifier,
+      priority: t.priority,
+      createdAt: t.createdAt ?? null,
+      stage: -1,
+      inFlight: false,
+    });
+  }
+
+  return rankTickets(descriptors);
+}
 
 // readPhaseSignals — { phase: status } for one ticket's workers/<T>/phase-*.json.
 export function readPhaseSignals(orchDir, ticket) {
@@ -1346,6 +1455,12 @@ export function schedulerTick(
           { ticket: t.identifier, phase: NEW_WORK_ENTRY_PHASE }
         );
         dispatched.push(t.identifier);
+        // CTL-705: persist priority + createdAt for the global rank, so
+        // preemption decisions need no per-tick Linear API calls.
+        writeWorkerPriority(orchDir, t.identifier, {
+          priority: t.priority,
+          createdAt: t.createdAt ?? null,
+        });
         // CTL-558: write the entry-phase (`research`) status for the new ticket.
         safeWrite(
           () =>

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4106,13 +4106,14 @@ describe("preemption sweep (CTL-705 Phase 4)", () => {
       join(dir, "phase-research.json"),
       JSON.stringify({ ticket: "CTL-Park", phase: "research", status: "preempted", parkedFrom: "research" })
     );
+    // Saturate the slot so the resume sweep (1.5) also sees 0 free slots and doesn't fire.
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch();
     const reclaimCalls = [];
     schedulerTick(orchDir, {
       readEligible: () => [],
       dispatch,
-      liveBackgroundCount: () => 0,
+      liveBackgroundCount: () => 1, // saturated → resume sweep skips
       reclaimDeadWork: (_od, sig) => {
         reclaimCalls.push({ ticket: sig.ticket, status: sig.status });
         return "noop"; // we're capturing the call but still returning noop
@@ -4135,15 +4136,136 @@ describe("preemption sweep (CTL-705 Phase 4)", () => {
       join(dir, "phase-research.json"),
       JSON.stringify({ ticket: "CTL-Adv", phase: "research", status: "preempted", parkedFrom: "research" })
     );
+    // Saturate so resume sweep (1.5) also sees 0 free slots.
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch();
     const r = schedulerTick(orchDir, {
       readEligible: () => [],
       dispatch,
-      liveBackgroundCount: () => 0,
+      liveBackgroundCount: () => 1, // saturated → neither advancement nor resume fires
     });
-    // No plan dispatch for CTL-Adv
+    // No advancement dispatch for CTL-Adv (the early continue in the advancement loop)
     expect(r.advanced.find((a) => a.ticket === "CTL-Adv")).toBeUndefined();
+    // No dispatch call at all for CTL-Adv when saturated
     expect(dispatch.calls.find((c) => c.ticket === "CTL-Adv")).toBeUndefined();
+  });
+});
+
+// ─── CTL-705 Phase 5: resume-after-preemption re-dispatch ───
+describe("resume-after-preemption sweep (CTL-705 Phase 5)", () => {
+  function seedPreempted(ticket, phase, bgJobId, priority) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({
+        ticket, phase, status: "preempted", parkedFrom: phase, bg_job_id: bgJobId,
+        attentionReason: "preempted-by-priority",
+      })
+    );
+    writeWorkerPriority(orchDir, ticket, { priority, createdAt: "2026-05-01T00:00:00Z" });
+  }
+
+  function makeResumeStub() {
+    const calls = [];
+    const fn = (args) => { calls.push(args); return true; };
+    fn.calls = calls;
+    return fn;
+  }
+
+  function makeDispatchCapture() {
+    const calls = [];
+    const fn = (args) => {
+      calls.push(args);
+      const dir = join(orchDir, "workers", args.ticket);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, `phase-${args.phase}.json`),
+        JSON.stringify({ ticket: args.ticket, phase: args.phase, status: "dispatched", bg_job_id: "new-bg" })
+      );
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    fn.calls = calls;
+    return fn;
+  }
+
+  test("re-dispatches a preempted ticket at parkedFrom phase with resumeSession when slot frees", () => {
+    seedPreempted("CTL-2", "research", "bg-ctl2", 2);
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = makeDispatchCapture();
+    const appendResumed = makeResumeStub();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      liveBackgroundCount: () => 1, // 1 free slot
+      reclaimDeadWork: () => "noop",
+      resolveSession: () => "uuid-x", // injectable resolver
+      appendResumedAfterPreemptionEvent: appendResumed,
+      verifyDispatched: verifyOk,
+    });
+    // dispatch called at phase "research" with resumeSession
+    const call = dispatch.calls.find((c) => c.ticket === "CTL-2");
+    expect(call).toBeDefined();
+    expect(call.phase).toBe("research");
+    expect(call.resumeSession).toBe("uuid-x");
+    // signal reset to running
+    const sig = JSON.parse(readFileSync(
+      join(orchDir, "workers", "CTL-2", "phase-research.json"), "utf8"
+    ));
+    expect(sig.status).toBe("dispatched"); // written by makeDispatchCapture
+    // resumed event emitted
+    expect(appendResumed.calls).toHaveLength(1);
+    expect(appendResumed.calls[0].ticket).toBe("CTL-2");
+  });
+
+  test("no resume when no slot is free (liveBackgroundCount >= maxParallel)", () => {
+    seedPreempted("CTL-2", "research", "bg-ctl2", 2);
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      liveBackgroundCount: () => 1, // saturated
+      reclaimDeadWork: () => "noop",
+      resolveSession: () => "uuid-x",
+    });
+    expect(dispatch.calls.find((c) => c.ticket === "CTL-2")).toBeUndefined();
+  });
+
+  test("resolveSession returns null → re-dispatches without resumeSession (cold re-dispatch)", () => {
+    seedPreempted("CTL-2", "research", "bg-ctl2", 2);
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = makeDispatchCapture();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: () => "noop",
+      resolveSession: () => null, // no resumable session
+      appendResumedAfterPreemptionEvent: makeResumeStub(),
+      verifyDispatched: verifyOk,
+    });
+    const call = dispatch.calls.find((c) => c.ticket === "CTL-2");
+    expect(call).toBeDefined();
+    expect(call.resumeSession).toBeUndefined(); // no resumeSession when null
+  });
+
+  test("new-work pull still excludes parked ticket (listStartedTickets covers it)", () => {
+    // preempted worker has a worker dir → listStartedTickets includes it → selectDispatchable excludes it
+    seedPreempted("CTL-2", "research", "bg-ctl2", 2);
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const dispatch = makeDispatchCapture();
+    const r = schedulerTick(orchDir, {
+      // CTL-2 is also eligible — but it's in listStartedTickets, so it should not be pulled as new work
+      readEligible: () => [{ identifier: "CTL-2", priority: 2, createdAt: "2026-05-01T00:00:00Z" }],
+      dispatch,
+      liveBackgroundCount: () => 0, // slots free
+      reclaimDeadWork: () => "noop",
+      resolveSession: () => null, // no resume
+      verifyDispatched: verifyOk,
+    });
+    // The resume sweep may dispatch CTL-2 at its parkedFrom phase (correct behavior).
+    // But the new-work pull (sweep 2) must NOT include CTL-2 in r.dispatched (that's for fresh starts).
+    expect(r.dispatched).not.toContain("CTL-2");
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -3861,3 +3861,289 @@ describe("schedulerTick — writeWorkerPriority at new-work dispatch (CTL-705)",
     expect(pj.createdAt).toBe("2026-05-01T00:00:00Z");
   });
 });
+
+// ─── CTL-705 Phase 4: preemption sweep ───
+
+describe("preemption sweep (CTL-705 Phase 4)", () => {
+  // Seed a fully-formed in-flight signal with startedAt + bg_job_id + priority.json
+  function seedWorker(ticket, phase, priority, startedAtMs, bgJobId, createdAt) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    const startedAt = new Date(startedAtMs).toISOString();
+    writeFileSync(
+      join(dir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, status: "running", bg_job_id: bgJobId, startedAt })
+    );
+    writeWorkerPriority(orchDir, ticket, { priority, createdAt: createdAt ?? "2026-05-01T00:00:00Z" });
+  }
+
+  function readSignal(ticket, phase) {
+    return JSON.parse(readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"));
+  }
+
+  function makePrioEligible(identifier, priority) {
+    return { identifier, priority, createdAt: "2026-05-01T00:00:00Z" };
+  }
+
+  // killBgJob recording stub
+  function makeKillStub() {
+    const calls = [];
+    const fn = (args) => calls.push(args);
+    fn.calls = calls;
+    return fn;
+  }
+
+  // appendPreemptedEvent recording stub
+  function makePreemptStub() {
+    const calls = [];
+    const fn = (args) => { calls.push(args); return true; };
+    fn.calls = calls;
+    return fn;
+  }
+
+  const noopReclaim = () => "noop";
+
+  test("happy path: saturated, Urgent queued vs 2 Low in-flight — parks lowest-stage Low", () => {
+    const T0 = 100_000;
+    // CTL-1: Low @ verify (stage 5), CTL-2: Low @ research (stage 1) — CTL-2 is lowest stage
+    seedWorker("CTL-1", "verify", 4, T0 - 90_000, "bg-ctl1");
+    seedWorker("CTL-2", "research", 4, T0 - 90_000, "bg-ctl2");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const tickOpts = {
+      readEligible: () => [makePrioEligible("CTL-9", 1)], // Urgent
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 2, // saturated
+      reclaimDeadWork: noopReclaim,
+    };
+    // Tick 1: hysteresis window opens, no preemption yet.
+    schedulerTick(orchDir, { ...tickOpts, now: () => T0, killBgJob: makeKillStub() });
+    // Tick 2 (35s later): past the 30s hysteresis → preemption fires.
+    const kill = makeKillStub();
+    const appendPreempted = makePreemptStub();
+    schedulerTick(orchDir, {
+      ...tickOpts,
+      now: () => T0 + 35_000,
+      killBgJob: kill,
+      appendPreemptedEvent: appendPreempted,
+    });
+    // CTL-2 should be preempted (research = lowest stage)
+    expect(kill.calls.map((c) => c.bgJobId)).toContain("bg-ctl2");
+    expect(kill.calls.map((c) => c.bgJobId)).not.toContain("bg-ctl1");
+    const sig = readSignal("CTL-2", "research");
+    expect(sig.status).toBe("preempted");
+    expect(sig.parkedFrom).toBe("research");
+    expect(sig.attentionReason).toBe("preempted-by-priority");
+    expect(appendPreempted.calls).toHaveLength(1);
+    expect(appendPreempted.calls[0].ticket).toBe("CTL-2");
+  });
+
+  test("no preemption when a slot is free (liveBackgroundCount < maxParallel)", () => {
+    const NOW = 100_000;
+    seedWorker("CTL-1", "verify", 4, NOW - 90_000, "bg-ctl1");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const kill = makeKillStub();
+    schedulerTick(orchDir, {
+      readEligible: () => [makePrioEligible("CTL-9", 1)],
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 1, // slot free
+      reclaimDeadWork: noopReclaim,
+      now: () => NOW,
+      killBgJob: kill,
+    });
+    expect(kill.calls).toHaveLength(0);
+  });
+
+  test("no preemption when queued ticket does not out-rank any in-flight", () => {
+    const NOW = 100_000;
+    // In-flight: both Urgent (priority 1), queued: also priority 4 (Low)
+    seedWorker("CTL-1", "verify", 1, NOW - 90_000, "bg-ctl1");
+    seedWorker("CTL-2", "research", 1, NOW - 90_000, "bg-ctl2");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    const kill = makeKillStub();
+    schedulerTick(orchDir, {
+      readEligible: () => [makePrioEligible("CTL-9", 4)], // Low — doesn't out-rank Urgent
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 2,
+      reclaimDeadWork: noopReclaim,
+      now: () => NOW,
+      killBgJob: kill,
+    });
+    expect(kill.calls).toHaveLength(0);
+  });
+
+  test("guard: non-preemptable phase (monitor-deploy) is skipped", () => {
+    const NOW = 100_000;
+    // Only in-flight worker is at monitor-deploy — non-preemptable
+    seedWorker("CTL-MD", "monitor-deploy", 4, NOW - 90_000, "bg-md");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const kill = makeKillStub();
+    schedulerTick(orchDir, {
+      readEligible: () => [makePrioEligible("CTL-9", 1)],
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: noopReclaim,
+      now: () => NOW,
+      killBgJob: kill,
+    });
+    expect(kill.calls).toHaveLength(0); // non-preemptable → skip, no preemption
+  });
+
+  test("guard: triage is non-preemptable", () => {
+    const NOW = 100_000;
+    seedWorker("CTL-T", "triage", 4, NOW - 90_000, "bg-t");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const kill = makeKillStub();
+    schedulerTick(orchDir, {
+      readEligible: () => [makePrioEligible("CTL-9", 1)],
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: noopReclaim,
+      now: () => NOW,
+      killBgJob: kill,
+    });
+    expect(kill.calls).toHaveLength(0);
+  });
+
+  test("guard: min-runtime floor 60s — 30s-old candidate not preempted", () => {
+    const NOW = 100_000;
+    // Worker started only 30s ago (< 60s floor)
+    seedWorker("CTL-Young", "research", 4, NOW - 30_000, "bg-young");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const kill = makeKillStub();
+    schedulerTick(orchDir, {
+      readEligible: () => [makePrioEligible("CTL-9", 1)],
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: noopReclaim,
+      now: () => NOW,
+      killBgJob: kill,
+    });
+    expect(kill.calls).toHaveLength(0);
+  });
+
+  test("guard: implement quiet-window — mtime too recent (<10s) → not preempted, mtime stale → preempted", async () => {
+    const { utimesSync } = await import("node:fs");
+    const NOW = 100_000;
+    // Worker old enough (> 60s) but at implement
+    seedWorker("CTL-Impl", "implement", 4, NOW - 90_000, "bg-impl");
+    const signalPath = join(orchDir, "workers", "CTL-Impl", "phase-implement.json");
+    // Set mtime to 3s ago (within the 10s quiet window)
+    const recentMtime = new Date(NOW - 3_000);
+    utimesSync(signalPath, recentMtime, recentMtime);
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const kill = makeKillStub();
+    schedulerTick(orchDir, {
+      readEligible: () => [makePrioEligible("CTL-9", 1)],
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: noopReclaim,
+      now: () => NOW,
+      killBgJob: kill,
+      appendPreemptedEvent: makePreemptStub(),
+    });
+    expect(kill.calls).toHaveLength(0); // 3s mtime < 10s quiet window → not preempted
+
+    // Now make mtime stale (15s ago — past the quiet window). Run two ticks so
+    // hysteresis allows the second tick to fire.
+    const staleMtime = new Date(NOW - 15_000);
+    utimesSync(signalPath, staleMtime, staleMtime);
+    const tickOpts2 = {
+      readEligible: () => [makePrioEligible("CTL-9", 1)],
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: noopReclaim,
+    };
+    // __resetForTests clears hysteresis from the first tick (mtime-guarded tick above).
+    __resetForTests();
+    schedulerTick(orchDir, { ...tickOpts2, now: () => NOW, killBgJob: makeKillStub() }); // tick 1: open hysteresis
+    const kill2 = makeKillStub();
+    schedulerTick(orchDir, {
+      ...tickOpts2,
+      now: () => NOW + 35_000, // tick 2: past hysteresis
+      killBgJob: kill2,
+      appendPreemptedEvent: makePreemptStub(),
+    });
+    expect(kill2.calls).toHaveLength(1); // 15s mtime > 10s quiet window → preempted
+  });
+
+  test("guard: hysteresis 30s — first observation skips, ≥30s observation preempts", () => {
+    const T0 = 100_000;
+    seedWorker("CTL-H", "research", 4, T0 - 90_000, "bg-h");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const eligible = [makePrioEligible("CTL-9", 1)];
+
+    // Tick 1 at T0: first observation — hysteresis window opens, no preemption yet
+    const kill1 = makeKillStub();
+    schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: noopReclaim,
+      now: () => T0,
+      killBgJob: kill1,
+    });
+    expect(kill1.calls).toHaveLength(0); // first observation → hysteresis window just opened
+
+    // Tick 2 at T0 + 35s: past the 30s hysteresis window → preempt
+    const kill2 = makeKillStub();
+    schedulerTick(orchDir, {
+      readEligible: () => eligible,
+      dispatch: fakeDispatch(),
+      liveBackgroundCount: () => 1,
+      reclaimDeadWork: noopReclaim,
+      now: () => T0 + 35_000,
+      killBgJob: kill2,
+      appendPreemptedEvent: makePreemptStub(),
+    });
+    expect(kill2.calls).toHaveLength(1); // ≥30s → preempted
+  });
+
+  test("reclaim sweep ignores 'preempted' signals — no false revive", () => {
+    // Seed a preempted signal (no bg_job_id so classifyWorker returns 'unknown')
+    const dir = join(orchDir, "workers", "CTL-Park");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({ ticket: "CTL-Park", phase: "research", status: "preempted", parkedFrom: "research" })
+    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch();
+    const reclaimCalls = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      liveBackgroundCount: () => 0,
+      reclaimDeadWork: (_od, sig) => {
+        reclaimCalls.push({ ticket: sig.ticket, status: sig.status });
+        return "noop"; // we're capturing the call but still returning noop
+      },
+    });
+    // preempted signal must never reach reclaimDeadWork (listInFlightTickets excludes it,
+    // or the sweep skips it — either way, no reclaim attempt should fire for a preempted signal)
+    // The ticket IS in-flight (preempted is non-terminal), so it shows up in listInFlightTickets.
+    // But reclaimDeadWork should not actually reclaim it (the real reclaimDeadWork returns noop
+    // for a non-running status). Our guard means no advancement either.
+    const parkedAdvance = dispatch.calls.filter((c) => c.ticket === "CTL-Park");
+    expect(parkedAdvance).toHaveLength(0); // not advanced
+  });
+
+  test("advancement sweep ignores 'preempted' — deriveAdvancement never dispatched", () => {
+    // preempted research → advancement must not advance to plan
+    const dir = join(orchDir, "workers", "CTL-Adv");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({ ticket: "CTL-Adv", phase: "research", status: "preempted", parkedFrom: "research" })
+    );
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      liveBackgroundCount: () => 0,
+    });
+    // No plan dispatch for CTL-Adv
+    expect(r.advanced.find((a) => a.ticket === "CTL-Adv")).toBeUndefined();
+    expect(dispatch.calls.find((c) => c.ticket === "CTL-Adv")).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -3241,6 +3241,14 @@ describe("CTL-653: schedulerTick verify⇄remediate cycle (end-to-end)", () => {
         writeStatus: noopWriteStatus,
         reclaimDeadWork: () => "noop",
         verifyDispatched: verifyOk, // CTL-611: cyclingDispatch writes status:"done", not a runnable dispatched signal; bypass the verifier
+        // CTL-705: inject the liveBackgroundCount seam so this end-to-end cycle
+        // test does NOT shell out to the real `claude agents --json` once per
+        // tick. With no eligible/queued tickets the slot-counting sweeps (0.5
+        // preemption, 2 new-work) are no-ops anyway, so a free-slot stub is
+        // behavior-preserving — and it makes the 12-tick run deterministic
+        // instead of dependent on real subprocess latency (which timed the test
+        // out under load even after the scheduler hoisted the call 3x→1x).
+        liveBackgroundCount: () => 0,
       });
     }
   };
@@ -4099,12 +4107,25 @@ describe("preemption sweep (CTL-705 Phase 4)", () => {
   });
 
   test("reclaim sweep ignores 'preempted' signals — no false revive", () => {
-    // Seed a preempted signal (no bg_job_id so classifyWorker returns 'unknown')
+    // Seed a preempted signal WITH a (now-dead) bg_job_id — the exact shape a
+    // worker parks in: status "preempted", but its killed bg_job_id is still on
+    // the signal. Without the CTL-705 reclaim guard, classifyWorker routes this
+    // through the death trigger (liveness.kind='bg', process gone) and
+    // reclaimDeadWorkIfPossible returns "revived", spawning a duplicate and
+    // defeating the resume sweep. Seeding bg_job_id is what makes this test
+    // actually exercise that path — the prior fixture omitted it, so
+    // classifyWorker returned 'unknown' and the gap was invisible.
     const dir = join(orchDir, "workers", "CTL-Park");
     mkdirSync(dir, { recursive: true });
     writeFileSync(
       join(dir, "phase-research.json"),
-      JSON.stringify({ ticket: "CTL-Park", phase: "research", status: "preempted", parkedFrom: "research" })
+      JSON.stringify({
+        ticket: "CTL-Park",
+        phase: "research",
+        status: "preempted",
+        parkedFrom: "research",
+        bg_job_id: "dead-bg-from-preemption",
+      })
     );
     // Saturate the slot so the resume sweep (1.5) also sees 0 free slots and doesn't fire.
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
@@ -4114,16 +4135,20 @@ describe("preemption sweep (CTL-705 Phase 4)", () => {
       readEligible: () => [],
       dispatch,
       liveBackgroundCount: () => 1, // saturated → resume sweep skips
+      // If the guard were missing, the reclaim loop would call this for the
+      // preempted signal; returning "revived" models reclaimDeadWorkIfPossible's
+      // real verdict for a preempted-signal-with-dead-bg. The guard means it is
+      // never invoked for a preempted ticket at all.
       reclaimDeadWork: (_od, sig) => {
         reclaimCalls.push({ ticket: sig.ticket, status: sig.status });
-        return "noop"; // we're capturing the call but still returning noop
+        return "revived";
       },
     });
-    // preempted signal must never reach reclaimDeadWork (listInFlightTickets excludes it,
-    // or the sweep skips it — either way, no reclaim attempt should fire for a preempted signal)
-    // The ticket IS in-flight (preempted is non-terminal), so it shows up in listInFlightTickets.
-    // But reclaimDeadWork should not actually reclaim it (the real reclaimDeadWork returns noop
-    // for a non-running status). Our guard means no advancement either.
+    // The reclaim guard skips the preempted signal BEFORE reclaimDeadWork is
+    // called — so it must never fire for CTL-Park even though the signal carries
+    // a dead bg_job_id that would otherwise trip the death trigger.
+    expect(reclaimCalls.find((c) => c.ticket === "CTL-Park")).toBeUndefined();
+    // And no advancement / re-dispatch fired for it (advancement guard).
     const parkedAdvance = dispatch.calls.filter((c) => c.ticket === "CTL-Park");
     expect(parkedAdvance).toHaveLength(0); // not advanced
   });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -48,6 +48,12 @@ import {
   dispatchCooldownPath,
   verifyDispatchedSignal,
   __resetForTests,
+  // CTL-705: Phase 2 helpers
+  STAGE_RANK,
+  stageRankForTicket,
+  readWorkerPriority,
+  writeWorkerPriority,
+  buildGlobalRanking,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { REMEDIATE_CYCLE_CAP } from "../lib/phase-fsm.mjs";
@@ -3671,5 +3677,187 @@ describe("CTL-660: phase.dispatch.requested/launched emission (scheduler)", () =
 
     // The dispatch still advanced despite both lifecycle emitters throwing.
     expect(r.advanced).toContainEqual({ ticket: "CTL-304", phase: "plan" });
+  });
+});
+
+// ─── CTL-705 Phase 2: stageRankForTicket, readWorkerPriority, writeWorkerPriority, buildGlobalRanking ───
+import { PHASES } from "../lib/phase-fsm.mjs";
+
+describe("STAGE_RANK (CTL-705)", () => {
+  test("keys are exactly PHASES + 'remediate'", () => {
+    const expected = [...PHASES, "remediate"];
+    expect(Object.keys(STAGE_RANK)).toEqual(expected);
+  });
+
+  test("order: triage=0, research=1, plan=2, implement=3, remediate=4, verify=5, review=6, pr=7, monitor-merge=8, monitor-deploy=9", () => {
+    expect(STAGE_RANK.triage).toBe(0);
+    expect(STAGE_RANK.research).toBe(1);
+    expect(STAGE_RANK.plan).toBe(2);
+    expect(STAGE_RANK.implement).toBe(3);
+    expect(STAGE_RANK.remediate).toBe(4);
+    expect(STAGE_RANK.verify).toBe(5);
+    expect(STAGE_RANK.review).toBe(6);
+    expect(STAGE_RANK.pr).toBe(7);
+    expect(STAGE_RANK["monitor-merge"]).toBe(8);
+    expect(STAGE_RANK["monitor-deploy"]).toBe(9);
+  });
+});
+
+describe("stageRankForTicket (CTL-705)", () => {
+  test("returns -1 for empty signals", () => {
+    expect(stageRankForTicket({})).toBe(-1);
+    expect(stageRankForTicket(null)).toBe(-1);
+    expect(stageRankForTicket(undefined)).toBe(-1);
+  });
+
+  test("triage running → 0", () => {
+    expect(stageRankForTicket({ triage: "running" })).toBe(0);
+  });
+
+  test("research running → 1", () => {
+    expect(stageRankForTicket({ research: "running" })).toBe(1);
+  });
+
+  test("picks highest-indexed non-terminal phase when multiple signals", () => {
+    // plan done + implement running → implement wins (3)
+    expect(stageRankForTicket({ plan: "done", implement: "running" })).toBe(3);
+    // all of triage/research done, verify running → verify wins (5)
+    expect(stageRankForTicket({ triage: "done", research: "done", plan: "done", verify: "running" })).toBe(5);
+  });
+
+  test("preempted signal still yields its phase rank", () => {
+    expect(stageRankForTicket({ research: "preempted" })).toBe(1);
+    expect(stageRankForTicket({ implement: "preempted" })).toBe(3);
+  });
+
+  test("failed/stalled/aborted phases are excluded", () => {
+    expect(stageRankForTicket({ implement: "failed" })).toBe(-1);
+    expect(stageRankForTicket({ research: "stalled" })).toBe(-1);
+    expect(stageRankForTicket({ plan: "aborted" })).toBe(-1);
+  });
+
+  test("monitor-deploy done is terminal — excluded", () => {
+    expect(stageRankForTicket({ "monitor-deploy": "done" })).toBe(-1);
+    expect(stageRankForTicket({ "monitor-deploy": "skipped" })).toBe(-1);
+  });
+
+  test("monitor-deploy running is NOT terminal — included", () => {
+    expect(stageRankForTicket({ "monitor-deploy": "running" })).toBe(9);
+  });
+
+  test("remediate running → 4", () => {
+    expect(stageRankForTicket({ remediate: "running" })).toBe(4);
+  });
+});
+
+describe("readWorkerPriority / writeWorkerPriority (CTL-705)", () => {
+  test("missing priority.json → safe default {priority:5, createdAt:null}", () => {
+    expect(readWorkerPriority(orchDir, "CTL-NOT-EXIST")).toEqual({ priority: 5, createdAt: null });
+  });
+
+  test("round-trips priority + createdAt through write → read", () => {
+    mkdirSync(join(orchDir, "workers", "CTL-42"), { recursive: true });
+    writeWorkerPriority(orchDir, "CTL-42", { priority: 1, createdAt: "2026-05-01T00:00:00Z" });
+    expect(readWorkerPriority(orchDir, "CTL-42")).toEqual({ priority: 1, createdAt: "2026-05-01T00:00:00Z" });
+  });
+
+  test("write is idempotent — second write overwrites first", () => {
+    mkdirSync(join(orchDir, "workers", "CTL-43"), { recursive: true });
+    writeWorkerPriority(orchDir, "CTL-43", { priority: 3, createdAt: "2026-01-01T00:00:00Z" });
+    writeWorkerPriority(orchDir, "CTL-43", { priority: 2, createdAt: "2026-02-01T00:00:00Z" });
+    expect(readWorkerPriority(orchDir, "CTL-43")).toEqual({ priority: 2, createdAt: "2026-02-01T00:00:00Z" });
+  });
+
+  test("unreadable/malformed priority.json → safe default, never throws", () => {
+    const dir = join(orchDir, "workers", "CTL-44");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "priority.json"), "not-json");
+    expect(() => readWorkerPriority(orchDir, "CTL-44")).not.toThrow();
+    expect(readWorkerPriority(orchDir, "CTL-44")).toEqual({ priority: 5, createdAt: null });
+  });
+});
+
+describe("buildGlobalRanking (CTL-705)", () => {
+  function seedInFlight(ticket, phase, status, bgJobId, priority, createdAt) {
+    mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+    writeFileSync(
+      join(orchDir, "workers", ticket, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, status, bg_job_id: bgJobId })
+    );
+    if (priority !== undefined) {
+      writeWorkerPriority(orchDir, ticket, { priority, createdAt: createdAt ?? null });
+    }
+  }
+
+  function makeEligible(identifier, priority, createdAt) {
+    return { identifier, priority, createdAt: createdAt ?? "2026-05-01T00:00:00Z" };
+  }
+
+  test("in-flight ticket → inFlight:true with its stageRankForTicket stage", () => {
+    seedInFlight("CTL-1", "implement", "running", "abc1", 2, "2026-05-01T00:00:00Z");
+    const result = buildGlobalRanking(orchDir, []);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ identifier: "CTL-1", inFlight: true, stage: 3 });
+  });
+
+  test("queued (eligible, not started) ticket → inFlight:false with stage:-1", () => {
+    const eligible = [makeEligible("CTL-99", 2, "2026-05-01T00:00:00Z")];
+    const result = buildGlobalRanking(orchDir, eligible);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ identifier: "CTL-99", inFlight: false, stage: -1 });
+  });
+
+  test("ticket in both eligible and in-flight → listed once, as in-flight", () => {
+    seedInFlight("CTL-5", "research", "running", "abc5", 2, "2026-05-01T00:00:00Z");
+    const eligible = [makeEligible("CTL-5", 2, "2026-05-01T00:00:00Z")];
+    const result = buildGlobalRanking(orchDir, eligible);
+    expect(result.filter((d) => d.identifier === "CTL-5")).toHaveLength(1);
+    expect(result.find((d) => d.identifier === "CTL-5").inFlight).toBe(true);
+  });
+
+  test("result is sorted by rankTickets (higher stage in same band first)", () => {
+    seedInFlight("CTL-A", "verify", "running", "abc-a", 2, "2026-05-01T00:00:00Z");
+    seedInFlight("CTL-B", "research", "running", "abc-b", 2, "2026-05-01T00:00:00Z");
+    const result = buildGlobalRanking(orchDir, []);
+    // verify (stage 5) before research (stage 1) within same priority band
+    expect(result[0].identifier).toBe("CTL-A");
+    expect(result[1].identifier).toBe("CTL-B");
+  });
+
+  test("terminal in-flight tickets are excluded", () => {
+    seedInFlight("CTL-X", "monitor-deploy", "done", "dead", undefined, undefined);
+    const result = buildGlobalRanking(orchDir, []);
+    expect(result.find((d) => d.identifier === "CTL-X")).toBeUndefined();
+  });
+});
+
+describe("schedulerTick — writeWorkerPriority at new-work dispatch (CTL-705)", () => {
+  function dispatchWritesSignalWithBg(bgJobId, worktreePath) {
+    return ({ orchDir: od, ticket, phase }) => {
+      const dir = join(od, "workers", ticket);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, `phase-${phase}.json`),
+        JSON.stringify({ ticket, phase, status: "dispatched", bg_job_id: bgJobId, worktreePath })
+      );
+      return { code: 0, stdout: "", stderr: "", worktreePath };
+    };
+  }
+
+  test("writes priority.json for a newly dispatched new-work ticket", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeEligibleProjection("CTL", {
+      tickets: [{ identifier: "CTL-9", priority: 1, createdAt: "2026-05-01T00:00:00Z" }],
+    });
+    const dispatch = dispatchWritesSignalWithBg("bg-job-9", "/wt/CTL-9");
+    schedulerTick(orchDir, {
+      readEligible: undefined,
+      dispatch,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+    });
+    const pj = readWorkerPriority(orchDir, "CTL-9");
+    expect(pj.priority).toBe(1);
+    expect(pj.createdAt).toBe("2026-05-01T00:00:00Z");
   });
 });

--- a/website/src/content/docs/observability/event-flow.md
+++ b/website/src/content/docs/observability/event-flow.md
@@ -304,6 +304,45 @@ Operators investigating a yield-storm can grep for
 `phase.scheduler.yield-file-skip.<TICKET>` events in the unified event log —
 one such event is emitted per tombstone per daemon lifetime (CTL-702).
 
+## Priority preemption (CTL-705)
+
+When `maxParallel` slots are saturated and a higher-priority queued ticket
+out-ranks the lowest-ranked in-flight worker, the scheduler stops that worker
+and parks it so the Urgent ticket can claim a slot. Two events mark this lifecycle:
+
+### `phase.<phase>.preempted.<TICKET>`
+
+Emitted when the scheduler stops a lower-priority in-flight worker to free a slot.
+
+| Payload field | Description |
+|---|---|
+| `phase` | Pipeline phase being preempted (e.g. `research`) |
+| `preempted_by` | Identifier of the higher-priority queued ticket |
+| `bg_job_id` | bg job ID of the stopped worker |
+
+The worker's phase signal is rewritten to `status: "preempted"` with
+`parkedFrom: <phase>` and `attentionReason: "preempted-by-priority"`.
+
+**Safety guards** prevent preemption from firing prematurely:
+- Non-preemptable phases: `triage`, `monitor-deploy` are never stopped.
+- Min-runtime floor: the worker must have been running ≥60s.
+- Implement quiet-window: `phase-implement.json` mtime must be >10s old (worker not actively committing).
+- Hysteresis: the queued ticket must out-rank the candidate for ≥30s across two ticks.
+
+### `phase.<phase>.resumed-after-preemption.<TICKET>`
+
+Emitted when a preempted worker is re-dispatched at its `parkedFrom` phase.
+
+| Payload field | Description |
+|---|---|
+| `phase` | Phase the worker resumes at (= `parkedFrom`) |
+| `resume_session` | Claude `--resume` UUID used for the re-dispatch, or `null` if cold |
+
+Preemption→resume is inherently multi-tick: `claude stop` may not deregister
+within the same tick's `liveBackgroundCount()`, so the freed slot fills on the
+next tick. The resume sweep runs **before** new-work pull, so a preempted ticket
+always reclaims its slot ahead of brand-new work.
+
 ## Related
 
 - [catalyst-events CLI](./catalyst-events/) — command reference and jq filter cookbook

--- a/website/src/content/docs/reference/orchestration/scheduler.md
+++ b/website/src/content/docs/reference/orchestration/scheduler.md
@@ -1,0 +1,138 @@
+---
+title: Scheduler Reference
+description: Global priority+stage sort, preemption, and resume for the execution-core pull-loop scheduler.
+---
+
+# Execution-core Scheduler
+
+The execution-core pull-loop scheduler runs on every tick and drives the
+full phase-agent pipeline. This page covers the **global ranking**, the
+**preemption mechanism**, and the safety guards that prevent thrash.
+
+## Global comparator
+
+Every tick, the scheduler builds a unified view of all in-flight workers
+**and** all queued (Ready) tickets, then sorts them by a 4-key total order:
+
+```
+priority (asc) → stage (desc) → createdAt (asc) → identifier (asc)
+```
+
+| Key | Direction | Tie-break semantics |
+|---|---|---|
+| **priority** | ascending | 1=Urgent, 2=High, 3=Medium, 4=Low, 5=No Priority |
+| **stage** | descending | later pipeline phase = closer to done; queued tickets default to `-1` |
+| **createdAt** | ascending | FIFO fairness within a band; absent sorts last |
+| **identifier** | ascending | deterministic final tie-break |
+
+### Stage scale
+
+Each pipeline phase maps to an integer stage index:
+
+| Phase | Stage |
+|---|---|
+| triage | 0 |
+| research | 1 |
+| plan | 2 |
+| implement | 3 |
+| remediate | 4 |
+| verify | 5 |
+| review | 6 |
+| pr | 7 |
+| monitor-merge | 8 |
+| monitor-deploy | 9 |
+
+Queued tickets carry `stage = -1`, so within the same priority band an
+in-flight worker always ranks ahead of a newly-queued ticket — only a
+strictly higher-priority queued ticket can displace in-flight work.
+
+## Priority persistence (`priority.json`)
+
+When a ticket is dispatched for the first time (new-work pull, sweep 2),
+the scheduler writes `workers/<TICKET>/priority.json`:
+
+```json
+{ "priority": 2, "createdAt": "2026-05-01T00:00:00Z" }
+```
+
+This file is read on every subsequent tick when the ticket is in-flight,
+so the global rank requires **no per-tick Linear API calls**. Legacy
+workers dispatched before CTL-705 land have no `priority.json` and default
+to `priority: 5` (lowest band).
+
+## Sweep order
+
+Each tick runs five sweeps in sequence:
+
+| Sweep | Name | What it does |
+|---|---|---|
+| 0 | Reclaim | Close signals for dead-but-work-done workers |
+| 0.5 | Preemption | Stop the lowest-ranked worker when Urgent is queued and all slots are full |
+| 1 | Advancement | Dispatch the FSM-owed next phase for each in-flight ticket |
+| 1.5 | Resume | Re-dispatch preempted workers at `parkedFrom` when a slot frees |
+| 2 | New-work pull | Fill remaining free slots with top-ranked Ready tickets |
+| 3 | Terminal-Done | Apply Linear `Done` state + worktree teardown for completed tickets |
+
+## Preemption (sweep 0.5)
+
+When `liveBackgroundCount()` is at or above `maxParallel` **and** the
+top-ranked queued ticket out-ranks the lowest-ranked preemptable in-flight
+worker, the scheduler preempts that worker:
+
+1. `claude stop <bgJobId>` — deregisters the worker from the live bg count.
+2. Rewrites the worker's phase signal: `status: "preempted"`, `parkedFrom: <phase>`, `attentionReason: "preempted-by-priority"`.
+3. Emits `phase.<phase>.preempted.<TICKET>` to the unified event log.
+
+The preempted worker is excluded from the reclaim sweep (no false revive)
+and the advancement sweep (status ≠ `"done"`).
+
+### Safety guards
+
+All guards must pass before preemption fires. If the bottom-ranked candidate
+fails a guard, the next-lowest candidate is tried; if none qualifies,
+preemption is skipped this tick.
+
+| Guard | Threshold | Rationale |
+|---|---|---|
+| Non-preemptable phase | `triage`, `monitor-deploy` | Triage is brief; monitor-deploy is a passive observer |
+| Min-runtime floor | 60 seconds | Prevents stopping a worker that just started |
+| Implement quiet-window | `phase-implement.json` mtime > 10s | Worker may be in the middle of a commit |
+| Hysteresis | Queued ticket must have out-ranked candidate for ≥30s | Prevents thrash on transient priority changes |
+
+Note: preemption→resume is **multi-tick**. `claude stop` may not deregister
+within the same tick's `liveBackgroundCount()`, so the freed slot fills on a
+subsequent tick.
+
+## Resume-after-preemption (sweep 1.5)
+
+When a slot is free, the resume sweep re-dispatches parked tickets
+**before** new-work pull so a preempted worker is never delayed by a
+brand-new ticket. The sweep:
+
+1. Collects all tickets with `status: "preempted"` across the workers tree.
+2. Sorts them by the same global comparator (priority → stage → createdAt).
+3. For each, while free slots remain:
+   - Resolves a `--resume-session` UUID from the dead worker's `bg_job_id` (if available).
+   - Dispatches at `parkedFrom` phase, passing `--resume-session` when found.
+   - On success: emits `phase.<phase>.resumed-after-preemption.<TICKET>`.
+   - On failure: records a dispatch cool-down, emits `phase.dispatch.failed.<TICKET>`.
+4. Subtracts the resumed count from the free-slots budget before new-work pull.
+
+If the UUID cannot be resolved (worker's job dir is gone), the re-dispatch
+proceeds **without** `--resume-session` — a cold fresh start at the same
+phase.
+
+## Configuration
+
+Preemption is always active when the execution-core scheduler is running.
+The guard thresholds are compiled constants; the only operator-visible knob
+is `maxParallel` (via `.catalyst/config.json → catalyst.orchestration.executionCore.maxParallel`).
+
+## Migration notes
+
+Existing in-flight workers dispatched before CTL-705 merged have no
+`priority.json`. Their `readWorkerPriority` defaults to `{ priority: 5 }`,
+placing them in the lowest-priority band. During the rollout window such a
+worker could be a preemption candidate if a higher-priority ticket is queued;
+the 60s min-runtime and 30s hysteresis guards limit the blast radius. The
+condition is transient — every new dispatch writes `priority.json`.


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-28T22:40:00Z -->
<!-- Last updated: 2026-05-28T22:40:00Z -->
<!-- PR: #1182 -->
<!-- Previous commits: b81136e4,d05d6a41,5c525f45,85579fe8,b77cce9f,c51ee740,7bd0b376 -->

## Summary

Adds **stage-aware global priority sorting with preemption** to the execution-core scheduler. Before this PR, the scheduler ranked the ready queue by priority but had no cross-rank visibility into in-flight workers — an Urgent ticket could queue behind a saturated maxParallel of Low-priority work. This PR replaces the queue-only sort with a 4-key total order over the union of queued _and_ in-flight workers; anything outside the top-N is stopped (parked with `--resume-session`) and re-dispatched when a slot opens.

### What changed

**New global comparator** (`scheduler-rank.mjs`): 4-key total order — priority rank → stage descending → createdAt ascending → identifier ascending. Stage is encoded as an integer (monitor-deploy=9 … triage=0, queued=-1), so a partially-done ticket beats a just-queued one at the same priority. Backward compatible: missing stage defaults to -1, so all pure-queue comparisons are unaffected.

**`STAGE_RANK` + helpers** (`scheduler.mjs`): `STAGE_RANK` freeze-map, `stageRankForTicket` (reads active signal files → max phase rank, non-terminal `preempted` status counts so parked tickets keep their position), `buildGlobalRanking` (materialises the full descriptor array over in-flight workers), and `readWorkerPriority` / `writeWorkerPriority` (persist the priority written at dispatch time so preempted workers are ranked correctly on resume, without re-querying Linear).

**Preemption sweep** (sweep 0.5, between reclaim and advancement): on each tick, compute the global top-N set; any in-flight worker not in that set is a preemption candidate. Guards: 60 s min-runtime before eligible, non-preemptable phases (triage, monitor-deploy), 30 s hysteresis per preemptor→victim pair. Victims receive `PREEMPTED_STATUS = "preempted"` and are stopped via the injected `killBgJob` seam. Telemetry: `appendPreemptedEvent`.

**Resume-after-preemption sweep** (sweep 1.5, between advancement and new-work): scans all parked-phase workers with `attentionReason=preempted-by-priority`, validates the pre-parked verify signal (if any), and re-dispatches with `--resume-session <uuid>` via the already-existing `dispatchTicket` path. Slot accounting: `resumedCount` is subtracted from `freeSlots` so resumes and new-work don't double-count the same slot. Also wires `resumeSession` through `dispatchTicket` → `phaseAgentDispatch`.

**Integration test** (`integration-ctl-705.test.mjs`): two end-to-end scenarios through `schedulerTick` with injected seams. Scenario 1: maxParallel=2, 2 Low in-flight (implement + research), 1 Urgent queued → on tick 2 the in-flight research worker (lower stage) is preempted; on tick 3 the parked worker is re-dispatched with `--resume-session`. Scenario 2: sole in-flight worker at monitor-deploy → no preemption (non-preemptable guard).

**User docs**: `website/src/content/docs/observability/event-flow.md` (new `phase.<phase>.preempted.*` and `phase.<phase>.resumed-after-preemption.*` events) and `website/src/content/docs/reference/orchestration/scheduler.md` (new doc: global comparator, STAGE_RANK scale, safety guards, persistence model).

## Changes Made

### Core — `plugins/dev/scripts/execution-core/`

| File | Change |
|---|---|
| `scheduler-rank.mjs` | 4-key `compareTickets`, `STAGE_RANK` export, `priorityRank` unchanged |
| `scheduler.mjs` | `STAGE_RANK`, `stageRankForTicket`, `buildGlobalRanking`, `readWorkerPriority`, `writeWorkerPriority`, `PREEMPTED_STATUS`, preemption sweep (0.5), resume sweep (1.5), `resumedCount` slot correction, single-read `liveCount` hoist |
| `dispatch.mjs` | Thread `resumeSession` through `dispatchTicket` → `phaseAgentDispatch` |
| `recovery.mjs` | `PREEMPTED_STATUS` guard in `reclaimDeadWork` so parked workers are not falsely reclaimed |

### Tests

| File | Coverage |
|---|---|
| `scheduler-rank.test.mjs` | All sanity-table cases + backward compat (missing stage, queued-vs-queued) |
| `scheduler.test.mjs` | Every new helper, both sweeps, all guards, STAGE_RANK drift-guard, hysteresis, `writeWorkerPriority` round-trip |
| `dispatch.test.mjs` | `resumeSession` thread-through |
| `recovery.test.mjs` | PREEMPTED_STATUS guard |
| `integration-ctl-705.test.mjs` | 2 full end-to-end tick scenarios with real `reclaimDeadWork` |

### Docs

- `website/src/content/docs/observability/event-flow.md` — `preempted` / `resumed-after-preemption` event types
- `website/src/content/docs/reference/orchestration/scheduler.md` — global comparator, STAGE_RANK, safety guards

## How to Verify It

- [x] `bun test scheduler-rank.test.mjs` — 46 assertions, all pass ✅
- [x] `bun test scheduler.test.mjs` — covers all new sweep paths ✅
- [x] `bun test dispatch.test.mjs` — resumeSession threading ✅
- [x] `bun test recovery.test.mjs` — PREEMPTED_STATUS guard ✅
- [x] `bun test integration-ctl-705.test.mjs` — 2 end-to-end scenarios ✅
- [x] Regression risk: **1 / 10** (verify phase assessment) ✅
- [x] No TypeScript / lint gates on plugins/dev (pure .mjs, by convention) ✅
- [x] All 8 pre-existing sandbox failures are environment-only (identical on origin/main baseline) ✅
- [ ] Manual: start execution-core with maxParallel=2; dispatch 2 Low tickets; dispatch 1 Urgent → observe preemption log line and re-dispatch with `--resume-session` within one tick

## Verification Results

| Gate | Status | Notes |
|---|---|---|
| tests | ✅ pass | 414 pass / 8 pre-existing env fails (not regressions) |
| typecheck | ⏭ skip | Pure .mjs — no TS gate on plugins/dev |
| lint | ⏭ skip | No trunk/lint gate on plugins/dev (project convention) |
| reward-hacking | ✅ pass | No as-any / non-null tricks |
| security | ✅ pass | No secrets, no new deps, no shell injection |
| code-review | ✅ pass | Source matches 6-phase plan; backward compat preserved |
| coverage | ✅ pass | All helpers, guards, sweeps, and 3 e2e scenarios covered |
| silent-failure | ✅ pass | Fail-open try/catch match CTL-587 patterns; safeEmit throughout |

**Regression risk: 1 / 10**

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-705 — Global priority+stage sort across queue+in-flight with preemption
- Depends on CTL-690 (merged) — `--resume-session` primitive that makes preemption cheap
- Composes with CTL-706 (merged) — `selectDispatchablePerProject` slot-walk used in the new-work sweep (conflict resolved additively on rebase)