### PR TITLE
fix(dev): auto-dispatch triage for pre-existing eligible tickets at startup (CTL-711)

### DIFF
--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -27,7 +27,7 @@ import { dirname, basename, join } from "node:path";
 import { getEventLogPath, RECONCILE_INTERVAL_MS, EVENT_DEBOUNCE_MS, log } from "./config.mjs";
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import { runEligibleQuery } from "./linear-query.mjs";
-import { setProjectEligible, removeTicket, dropProject } from "./eligible-set.mjs";
+import { setProjectEligible, removeTicket, dropProject, getEligibleSet } from "./eligible-set.mjs";
 import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { dispatchTicket } from "./dispatch.mjs";
 import { abortWorker as defaultAbortWorker } from "./abort-worker.mjs";
@@ -297,6 +297,45 @@ function hasTriageArtifact(orchDir, ticket) {
   return existsSync(join(orchDir, "workers", ticket, "triage.json"));
 }
 
+// sweepMissingTriage — the reconcile-path analogue of the CTL-625 webhook guard
+// (handleStateChangedEvent →Ready branch). After reconcileAll has (re)populated
+// the eligible sets, dispatch triage for every eligible ticket that lacks a
+// triage.json. Tickets already in the Ready state when the daemon boots — or
+// that appear in Linear between webhooks — never generate a →Ready event
+// (CTL-681 removed the per-event scoping poll), so without this sweep their
+// research dispatch dead-locks on phase-agent-dispatch's prior_artifact_missing
+// gate, looping prior_artifact_missing → 60s cooldown → retry forever (CTL-711:
+// CTL-704/705/706/710 each needed a manual triage dispatch after a restart).
+//
+// Idempotent by construction: hasTriageArtifact skips already-triaged tickets
+// (no duplicate dispatch on normal webhook-driven tickets), and an in-flight
+// triage's signal file is no-op'd downstream by phase-agent-dispatch. A missing
+// orchDir (standalone monitor) is a no-op. A non-zero dispatch for one ticket is
+// logged by dispatchTriage and never aborts the sweep for the rest.
+export function sweepMissingTriage({
+  orchDir,
+  dispatch,
+  applyTriageStatus = defaultApplyTriageStatus,
+  appendEvent = defaultAppendEvent,
+} = {}) {
+  if (!orchDir) {
+    log.debug("sweepMissingTriage: no orchDir wired — skipping triage sweep");
+    return;
+  }
+  for (const p of listProjects()) {
+    for (const t of getEligibleSet(p.team)) {
+      if (hasTriageArtifact(orchDir, t.identifier)) continue;
+      dispatchTriage(t.identifier, {
+        dispatch,
+        orchDir,
+        applyTriageStatus,
+        appendEvent,
+        orchId: t.identifier,
+      });
+    }
+  }
+}
+
 // CTL-681 removed scheduleDirtyReconcile + its dirtyTimers Map. The
 // per-event scoping reconcile it implemented is the load that exhausted the
 // Linear 2500/hr quota: the parser dropped project/labels/priority, so every
@@ -445,6 +484,7 @@ export function startMonitor({
   // populates the same instance the scheduler reads.
   tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker, cache };
   reconcileAll({ exec });
+  sweepMissingTriage({ orchDir, dispatch }); // CTL-711: triage pre-existing eligible tickets
   if (resumeFromCursor) {
     seedTailerFromCursor();
     readNewEvents(); // drain the cursor→EOF downtime gap immediately
@@ -452,7 +492,10 @@ export function startMonitor({
     seedTailerAtEof();
   }
   startTailing();
-  reconcileTimer = setInterval(() => reconcileAll({ exec }), reconcileIntervalMs);
+  reconcileTimer = setInterval(() => {
+    reconcileAll({ exec });
+    sweepMissingTriage({ orchDir, dispatch }); // CTL-711: catch tickets that appeared between webhooks
+  }, reconcileIntervalMs);
 }
 
 // stopMonitor — clear the reconcile interval and the file watcher. Idempotent

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -14,6 +14,7 @@ import {
   reconcileProject,
   reconcileAll,
   handleStateChangedEvent,
+  sweepMissingTriage,
   startMonitor,
   stopMonitor,
   seedTailerFromCursor,
@@ -740,5 +741,133 @@ describe("handleStateChangedEvent — cache write-through (CTL-634)", () => {
       { cache }
     );
     expect(cache.get("CTL-99")).toBeUndefined();
+  });
+});
+
+// --- CTL-711: sweepMissingTriage — reconcile-path triage dispatch ---------------
+
+describe("sweepMissingTriage (CTL-711)", () => {
+  test("dispatches triage for an eligible ticket with no triage.json", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core"); // real dir, NO triage.json
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    reconcileAll({ exec }); // populate the eligible set first
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({
+      orchDir: realOrchDir,
+      dispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      orchDir: realOrchDir,
+      ticket: "ENG-9",
+      phase: "triage",
+    });
+  });
+
+  test("does NOT dispatch for an already-triaged eligible ticket", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    writeTriageArtifact(realOrchDir, "ENG-9"); // already triaged
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({ orchDir: realOrchDir, dispatch });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("dispatches only the un-triaged subset across a mixed eligible set", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    writeTriageArtifact(realOrchDir, "ENG-1"); // triaged
+    // ENG-2 left un-triaged
+    const exec = execReturning({ ENG: [node("ENG-1"), node("ENG-2")] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({
+      orchDir: realOrchDir,
+      dispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    const dispatched = dispatch.mock.calls.map((c) => c[0].ticket);
+    expect(dispatched).toEqual(["ENG-2"]);
+  });
+
+  test("no orchDir wired → no dispatch, never throws", () => {
+    enroll("ENG", { status: "Ready" });
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    expect(() => sweepMissingTriage({ dispatch })).not.toThrow(); // no orchDir
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("a dispatch failure is logged and never throws (one bad ticket does not abort the sweep)", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [node("ENG-1"), node("ENG-2")] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 9, stderr: "boom" })); // non-zero
+    expect(() =>
+      sweepMissingTriage({
+        orchDir: realOrchDir,
+        dispatch,
+        applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+        appendEvent: () => {},
+      })
+    ).not.toThrow();
+    // both tickets attempted despite the first failing
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-1", "ENG-2"]);
+  });
+
+  test("startMonitor dispatches triage for a pre-existing eligible ticket lacking triage.json (CTL-711)", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core"); // real, NO triage.json
+    const exec = execReturning({ ENG: [node("ENG-1")] });
+    const dispatch = mock(() => ({ code: 0 }));
+    startMonitor({
+      exec,
+      orchDir: realOrchDir,
+      dispatch,
+      reconcileIntervalMs: 60_000,
+      resumeFromCursor: false, // avoid cursor/tailer side effects in the unit test
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      orchDir: realOrchDir,
+      ticket: "ENG-1",
+      phase: "triage",
+    });
+  });
+
+  test("the periodic reconcile timer also runs the triage sweep (CTL-711)", async () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core"); // NO triage.json
+    // First poll returns empty (nothing eligible yet at boot), later polls return ENG-1.
+    let polls = 0;
+    const exec = (_cmd, args) => {
+      polls += 1;
+      const team = args[args.indexOf("--team") + 1];
+      const nodes = polls === 1 ? [] : team === "ENG" ? [node("ENG-1")] : [];
+      return { code: 0, stdout: JSON.stringify({ nodes }), stderr: "" };
+    };
+    const dispatch = mock(() => ({ code: 0 }));
+    startMonitor({
+      exec,
+      orchDir: realOrchDir,
+      dispatch,
+      reconcileIntervalMs: 30, // fast periodic tick for the test
+      resumeFromCursor: false,
+    });
+    // Startup sweep saw an empty eligible set → no dispatch yet.
+    expect(dispatch).not.toHaveBeenCalled();
+    await sleep(80); // let the periodic reconcile + sweep fire
+    expect(dispatch).toHaveBeenCalledWith({
+      orchDir: realOrchDir,
+      ticket: "ENG-1",
+      phase: "triage",
+    });
+    stopMonitor();
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-28T23:52:00Z -->
<!-- Last updated: 2026-05-28T23:52:00Z -->
<!-- PR: #1191 -->
<!-- Previous commits: d4049515a2d8b80cd9b072abdbdde6f74812a349 -->

## Summary

Adds `sweepMissingTriage` to the execution-core monitor so tickets that are
already in the eligible state when the daemon boots — or that appear in Linear
between webhook deliveries — get triage dispatched automatically. Previously,
these tickets fell into a permanent `prior_artifact_missing → cooldown → retry`
loop because the startup reconcile never checked for missing triage artifacts.

**Root cause:** `monitor.mjs`'s `→Ready/→Triage` branch fires only on live
webhook events. The startup reconcile (`reconcileAll`) repopulates the eligible
set but has no equivalent triage-dispatch step, so pre-existing eligible tickets
never trigger `dispatchTriage`.

**Impact confirmed:** CTL-704, CTL-705, CTL-706, and CTL-710 all required
manual triage dispatch after daemon restart because they were in `Todo` state at
boot time.

## Changes Made

### `plugins/dev/scripts/execution-core/monitor.mjs`

- **Added `sweepMissingTriage({ orchDir, dispatch, applyTriageStatus, appendEvent })`** — iterates
  every project's eligible set and dispatches triage for any ticket that lacks a
  `triage.json` artifact. Mirrors the existing CTL-625 webhook guard but lives on
  the reconcile path.
- **Wired into startup**: called immediately after `reconcileAll({ exec })` in
  `startMonitor`, so boot-time pre-existing eligible tickets are caught on the
  first reconcile cycle.
- **Wired into the periodic reconcile timer** (10 min interval): the
  `setInterval` callback now calls `sweepMissingTriage` after each
  `reconcileAll`, catching tickets that appear between webhooks.
- **Added `getEligibleSet` import** from `eligible-set.mjs` (previously unused
  by this module).

**Invariants preserved:**
- Idempotent — `hasTriageArtifact` skips already-triaged tickets; no duplicate
  dispatch on normal webhook-driven tickets.
- Missing `orchDir` (standalone monitor without orchestration) is a safe no-op.
- A dispatch failure for one ticket is logged and never aborts the sweep for the
  rest.

### `plugins/dev/scripts/execution-core/monitor.test.mjs`

Seven new tests in `describe("sweepMissingTriage (CTL-711)")`:

| Test | What it verifies |
|------|-----------------|
| dispatches for un-triaged ticket | core happy path |
| skips already-triaged ticket | idempotency |
| dispatches only un-triaged subset in mixed set | partial-sweep correctness |
| no orchDir → no dispatch, no throw | standalone-monitor safety |
| dispatch failure → sweep continues | resilience |
| `startMonitor` dispatches for pre-existing eligible ticket | startup integration |
| periodic reconcile timer runs the sweep | timer-path integration |

## How to Verify It

- [x] Existing test suite passes (`bun test monitor.test.mjs`)
- [x] New `sweepMissingTriage` tests pass (7 cases)
- [ ] Integration: restart daemon with tickets in `Todo` state (no triage.json) and confirm triage is dispatched within one reconcile cycle
- [ ] Confirm no duplicate triage dispatches on tickets already in flight (triage.json present)

## Related Issues / PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-711

## Changelog Entry

```
fix(dev): auto-dispatch triage for pre-existing eligible tickets at startup (CTL-711)

Adds sweepMissingTriage to monitor.mjs, wired into both the startup reconcile
and the periodic 10-min reconcile timer. Tickets already in the eligible state
when the daemon boots — or appearing between webhooks — now auto-triage without
manual intervention, mirroring the CTL-625 webhook guard for the reconcile path.
```