### PR TITLE
CTL-714: Phase-pr already-merged detection guard

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Tests for the phase-pr skill — CTL-714 already-merged detection guard.
+#
+# These tests verify:
+#   Suite A — SKILL.md contract: the detection section + fence + skip block
+#             are present with the correct strings.
+#   Suite B — Detection fence behavior: extracted fence executes correctly
+#             against scratch git repos in ancestor/non-ancestor states,
+#             plus the gh-stubbed merged-PR recovery path.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL="${REPO_ROOT}/plugins/dev/skills/phase-pr/SKILL.md"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-pr-e2e-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+
+assert_eq()          { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$1', got '$2'"; }
+assert_contains()    { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
+assert_not_contains(){ [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 — '$2' unexpectedly present"; }
+assert_file_exists() { [[ -f "$1" ]] && pass "$2" || fail "$2 — file missing: $1"; }
+
+# Extract a uniquely-named bash fence from a SKILL.md.
+# $1 = fence label (e.g. phase-pr-already-merged-detect), $2 = skill file
+extract_fence() {
+  awk -v label="$1" '
+    $0 ~ "^```bash[ \t]+" label "[ \t]*$" {grab=1; next}
+    grab && /^```[ \t]*$/ {grab=0}
+    grab {print}
+  ' "$2"
+}
+
+# ─── Suite A: SKILL.md contract ──────────────────────────────────────────────
+echo "Suite A: phase-pr SKILL.md contract (CTL-714 already-merged detection)"
+
+assert_file_exists "$SKILL" "SKILL.md exists at plugins/dev/skills/phase-pr/SKILL.md"
+
+if [[ -f "$SKILL" ]]; then
+  BODY="$(cat "$SKILL")"
+
+  assert_contains "$BODY" "Already-merged detection" \
+    "SKILL.md has the already-merged detection section (CTL-714)"
+  assert_contains "$BODY" "phase-pr-already-merged-detect" \
+    "SKILL.md has the uniquely-named detection fence"
+  assert_contains "$BODY" "merge-base --is-ancestor" \
+    "detection uses git merge-base --is-ancestor HEAD origin/main"
+  assert_contains "$BODY" "git fetch origin main" \
+    "detection fetches origin/main first (worktree ref can lag)"
+  assert_contains "$BODY" "--state merged" \
+    "detection checks gh pr list --state merged (open-only gotcha — research §3)"
+  assert_contains "$BODY" "already-merged-to-main" \
+    "skip path writes attentionReason=already-merged-to-main"
+  assert_contains "$BODY" "ALREADY_MERGED" \
+    "detection sets the ALREADY_MERGED flag the skip block gates on"
+  assert_contains "$BODY" ".pr = {number:" \
+    "skip path writes .pr = {number, url} into the signal file (work-done-probes.mjs:171)"
+  assert_contains "$BODY" "--status complete" \
+    "skip path emits --status complete (code is in main — research §7)"
+fi
+
+# ─── Suite B: detection fence behavior ───────────────────────────────────────
+echo ""
+echo "Suite B: phase-pr-already-merged-detect fence behavior"
+
+FENCE_FILE="${SCRATCH}/detect-fence.sh"
+extract_fence "phase-pr-already-merged-detect" "$SKILL" > "$FENCE_FILE"
+
+if [[ -s "$FENCE_FILE" ]]; then
+  pass "detection fence extractable from SKILL.md"
+else
+  fail "detection fence extractable — no phase-pr-already-merged-detect fence found in SKILL.md"
+fi
+
+if [[ -f "$FENCE_FILE" ]]; then
+  FENCE_BODY="$(cat "$FENCE_FILE")"
+  assert_not_contains "$FENCE_BODY" "exit " \
+    "detection fence has no 'exit' (must be side-effect-free for sourcing)"
+  assert_not_contains "$FENCE_BODY" "emit-complete" \
+    "detection fence has no 'emit-complete' (side-effect-free)"
+fi
+
+# ─── Scratch repo builders ────────────────────────────────────────────────────
+
+# Creates a repo where HEAD == origin/main (already merged scenario).
+build_merged_repo() {
+  local repo_dir="$1"
+  local bare_dir="${repo_dir}-bare.git"
+  mkdir -p "$repo_dir"
+  git init --quiet "$bare_dir" --bare
+  (
+    cd "$repo_dir" || exit 1
+    git init --quiet
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "base" > base.txt
+    git add base.txt
+    git commit --quiet -m "base commit"
+    git remote add origin "$bare_dir"
+    git push --quiet origin HEAD:main
+  )
+}
+
+# Creates a repo where HEAD is ahead of origin/main (not merged yet).
+build_ahead_repo() {
+  local repo_dir="$1"
+  local bare_dir="${repo_dir}-bare.git"
+  mkdir -p "$repo_dir"
+  git init --quiet "$bare_dir" --bare
+  (
+    cd "$repo_dir" || exit 1
+    git init --quiet
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "base" > base.txt
+    git add base.txt
+    git commit --quiet -m "base commit"
+    git remote add origin "$bare_dir"
+    git push --quiet origin HEAD:main
+    echo "change" > change.txt
+    git add change.txt
+    git commit --quiet -m "feat: additional commit"
+  )
+}
+
+# Installs a gh stub that returns pr_list_json for `gh pr list` calls.
+# Uses unquoted heredoc so ${pr_list_json} expands at install time.
+install_gh_stub() {
+  local bin_dir="$1"
+  local pr_list_json="${2:-[]}"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
+  printf '%s\n' '${pr_list_json}'
+else
+  printf '%s\n' '[]'
+fi
+STUB
+  chmod +x "$bin_dir/gh"
+}
+
+# Sources the detection fence in the given repo with the gh stub on PATH.
+# Writes "ALREADY_MERGED=<val>" and "MERGED_PR_NUMBER=<val>" lines to output_file.
+run_detection_fence() {
+  local repo_dir="$1"
+  local stub_bin="$2"
+  local output_file="$3"
+  (
+    cd "$repo_dir" || exit 1
+    export PATH="${stub_bin}:${PATH}"
+    set +e
+    # shellcheck disable=SC1090
+    source "$FENCE_FILE" 2>/dev/null
+    echo "ALREADY_MERGED=${ALREADY_MERGED:-0}"
+    echo "MERGED_PR_NUMBER=${MERGED_PR_NUMBER:-}"
+  ) > "$output_file" 2>/dev/null
+}
+
+# ─── Test B1: HEAD in origin/main → ALREADY_MERGED=1 ────────────────────────
+echo ""
+echo "Test B1: branch already contained in origin/main → ALREADY_MERGED=1"
+
+if [[ -s "$FENCE_FILE" ]]; then
+  B1_REPO="${SCRATCH}/b1-repo"
+  B1_BIN="${SCRATCH}/b1-bin"
+  B1_OUT="${SCRATCH}/b1-out.txt"
+
+  build_merged_repo "$B1_REPO"
+  install_gh_stub "$B1_BIN" "[]"
+  run_detection_fence "$B1_REPO" "$B1_BIN" "$B1_OUT"
+
+  B1_AM="$(grep '^ALREADY_MERGED=' "$B1_OUT" 2>/dev/null | cut -d= -f2)"
+  assert_eq "1" "${B1_AM:-}" "HEAD in origin/main (rescue) ⇒ ALREADY_MERGED=1"
+else
+  fail "B1 skipped — fence not extractable"
+fi
+
+# ─── Test B2: HEAD ahead of origin/main → ALREADY_MERGED=0 ──────────────────
+echo ""
+echo "Test B2: HEAD ahead of origin/main → ALREADY_MERGED=0"
+
+if [[ -s "$FENCE_FILE" ]]; then
+  B2_REPO="${SCRATCH}/b2-repo"
+  B2_BIN="${SCRATCH}/b2-bin"
+  B2_OUT="${SCRATCH}/b2-out.txt"
+
+  build_ahead_repo "$B2_REPO"
+  install_gh_stub "$B2_BIN" "[]"
+  run_detection_fence "$B2_REPO" "$B2_BIN" "$B2_OUT"
+
+  B2_AM="$(grep '^ALREADY_MERGED=' "$B2_OUT" 2>/dev/null | cut -d= -f2)"
+  assert_eq "0" "${B2_AM:-}" "HEAD ahead of origin/main ⇒ ALREADY_MERGED=0"
+else
+  fail "B2 skipped — fence not extractable"
+fi
+
+# ─── Test B3: merged PR found via gh → ALREADY_MERGED=1, MERGED_PR_NUMBER set ─
+echo ""
+echo "Test B3: merged PR returned by gh → ALREADY_MERGED=1, MERGED_PR_NUMBER=1170"
+
+if [[ -s "$FENCE_FILE" ]]; then
+  B3_REPO="${SCRATCH}/b3-repo"
+  B3_BIN="${SCRATCH}/b3-bin"
+  B3_OUT="${SCRATCH}/b3-out.txt"
+
+  build_ahead_repo "$B3_REPO"
+  install_gh_stub "$B3_BIN" '[{"number":1170,"url":"https://github.com/x/y/pull/1170"}]'
+  run_detection_fence "$B3_REPO" "$B3_BIN" "$B3_OUT"
+
+  B3_AM="$(grep '^ALREADY_MERGED=' "$B3_OUT" 2>/dev/null | cut -d= -f2)"
+  B3_NUM="$(grep '^MERGED_PR_NUMBER=' "$B3_OUT" 2>/dev/null | cut -d= -f2)"
+  assert_eq "1" "${B3_AM:-}" "merged PR in gh ⇒ ALREADY_MERGED=1"
+  assert_eq "1170" "${B3_NUM:-}" "merged PR in gh ⇒ MERGED_PR_NUMBER=1170"
+else
+  fail "B3 skipped — fence not extractable"
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-pr-e2e: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -gt 0 ]] && exit 1
+exit 0

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -84,6 +84,65 @@ jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
   && mv "$TMP" "$SIGNAL_FILE"
 ```
 
+## Already-merged detection (CTL-714)
+
+Before delegating to `create-pr`, detect whether this branch's `HEAD` is already contained in
+`origin/main` (manual rescue, or a sibling PR landed the same commits). If so, skip PR creation
+to avoid a duplicate / empty-diff PR. Two complementary checks: `git merge-base --is-ancestor`
+(works even if the branch was deleted from the remote) and `gh pr list --state merged` (recovers
+the merged PR number for the downstream probe).
+
+The detection fence is **side-effect-free** so the e2e test can source it in isolation.
+
+```bash phase-pr-already-merged-detect
+git fetch origin main --quiet 2>/dev/null || true
+ALREADY_MERGED=0
+MERGED_PR_NUMBER=""
+MERGED_PR_URL=""
+
+# Check 1: is HEAD already contained in origin/main? (must be in `if` — set -e)
+if git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+  ALREADY_MERGED=1
+fi
+
+# Check 2: does a MERGED PR exist for this branch? (--state merged is required —
+# `gh pr list --head` with no --state returns only OPEN PRs; orchestrate-verify.sh:563)
+BRANCH_NAME="$(git branch --show-current 2>/dev/null || true)"
+if [[ -n "$BRANCH_NAME" ]]; then
+  MERGED_PR_JSON="$(gh pr list --head "$BRANCH_NAME" --state merged \
+    --json number,url --limit 1 2>/dev/null || echo '[]')"
+  MERGED_PR_NUMBER="$(echo "$MERGED_PR_JSON" | jq -r '.[0].number // empty' 2>/dev/null || true)"
+  MERGED_PR_URL="$(echo "$MERGED_PR_JSON" | jq -r '.[0].url // empty' 2>/dev/null || true)"
+  if [[ -n "$MERGED_PR_NUMBER" ]]; then
+    ALREADY_MERGED=1
+  fi
+fi
+```
+
+When `ALREADY_MERGED=1`, write the disposition into the signal file and complete without
+creating a PR:
+
+```bash
+if [[ "$ALREADY_MERGED" -eq 1 ]]; then
+  echo "phase-pr: HEAD already in origin/main — skipping PR creation (CTL-714)" >&2
+  TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  TMP="${SIGNAL_FILE}.tmp.$$"
+  jq --arg ts "$TS" \
+     --arg reason "already-merged-to-main" \
+     --argjson prNum "${MERGED_PR_NUMBER:-null}" \
+     --arg prUrl "${MERGED_PR_URL:-}" '
+    .updatedAt = $ts
+    | .attentionReason = $reason
+    | if $prNum != null then .pr = {number: $prNum, url: $prUrl} else . end
+  ' "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+
+  "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+    --phase "$PHASE" --ticket "$TICKET" --status complete
+  [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+  exit 0
+fi
+```
+
 ## /goal condition
 
 Plan §"Per-phase /goal conditions":


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-29T13:00:00Z -->
<!-- Last updated: 2026-05-29T13:00:00Z -->
<!-- PR: #1194 -->
<!-- Previous commits: 217f0d59ab0170d30b356195df4360ca348f5728 -->

## Summary

Adds an already-merged detection guard to `phase-pr` that fires before `create-pr` is invoked. When a branch's `HEAD` is already contained in `origin/main` (manual rescue path, e.g. CTL-702) or a merged PR exists for the same branch, phase-pr now skips PR creation, writes `attentionReason=already-merged-to-main` into the signal file, and emits `--status complete` so the pipeline advances cleanly — no duplicate PR, no empty-diff PR, no ghost CI runs.

## Problem

When an operator manually rescues a ticket (merges code directly, writes `phase-pr.json` done), the orchestrator's phase-pr worker can still fire after the fact. Previously it would attempt `git push` + `gh pr create` against a base that already contains the same commits, producing either a duplicate PR or an error. CTL-702 needed a manual `phase-pr.json done` write to avoid this; without a guard, any future manual rescue would require the same operator intervention.

## Changes

### `plugins/dev/skills/phase-pr/SKILL.md` (+59 lines)

Adds the **Already-merged detection** section between the Prelude and the `/goal` block:

- **Side-effect-free detection fence** (`phase-pr-already-merged-detect`): fetches `origin/main`, runs `git merge-base --is-ancestor HEAD origin/main`, and queries `gh pr list --head <branch> --state merged`. Sets `ALREADY_MERGED`, `MERGED_PR_NUMBER`, `MERGED_PR_URL`.
- **Skip block**: when `ALREADY_MERGED=1`, writes `.attentionReason` and (if a merged PR number is known) `.pr = {number, url}` into the signal file — the `prProbe` in `work-done-probes.mjs:171` keys off `.pr.number` to confirm phase-pr work-done, so populating it allows `phase-monitor-merge` to resolve without creating a new PR. Emits `--status complete` and exits.

### `plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh` (new, 232 lines)

Two test suites:

- **Suite A — SKILL.md contract** (10 assertions): verifies the detection section, fence name, `merge-base --is-ancestor`, `git fetch origin main`, `--state merged`, `attentionReason=already-merged-to-main`, `ALREADY_MERGED` flag, `.pr = {number:`, and `--status complete` are all present in SKILL.md.
- **Suite B — fence behavior** (7 assertions): extracts the `phase-pr-already-merged-detect` fence into a scratch file, sources it against three scratch git repos (HEAD==origin/main, HEAD ahead of origin/main, `gh` stub returning a merged PR), and asserts `ALREADY_MERGED` and `MERGED_PR_NUMBER` output.

## How to Verify

- [x] `bash plugins/dev/scripts/__tests__/phase-pr-e2e.test.sh` → 17 passed, 0 failed ✅
- [x] Detection fence is side-effect-free (no `exit`, no `emit-complete` calls) ✅
- [x] `git merge-base --is-ancestor HEAD origin/main` correctly classifies already-merged vs ahead branches ✅
- [x] `gh pr list --state merged` guard recovers the PR number for the `prProbe` ✅
- [ ] End-to-end: plant a `phase-review.json done` + branch ahead of main; run `phase-pr`; verify it emits complete without touching GitHub — manual verification with the execution-core running

## Implementation Notes

The detection fence uses `--state merged` on `gh pr list` rather than the default open-only filter. This is intentional: `gh pr list --head <branch>` with no `--state` flag returns only OPEN PRs (documented in `orchestrate-verify.sh:563` and the CTL-714 research file). A merged PR would be silently absent without the flag.

The fence is designed to be sourced rather than executed so the e2e test can run it in a subshell against scratch repos without triggering side effects. All mutations (signal file writes, `emit-complete`, `comms done`) live in the separate skip block.

## Related

- Fixes CTL-714
- Motivated by CTL-702 (manual rescue for PR #1170)
- Related reliability chain: CTL-711 (infinite retry storm), CTL-712 (cooldown TTL)
