### PR TITLE
CTL-695: Fix the broken phase-agent reaper (CTL-657 followup)

### DIFF
--- a/plugins/dev/scripts/execution-core/reap-intent.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.mjs
@@ -24,6 +24,10 @@ export const REAP_INTENT_TYPES = Object.freeze([
   "worktree.presweep.reap-requested",
   "pr.merged.cleanup-requested",
   "orphans.reap-requested",
+  // CTL-695: terminal-worker reap — a phase signal reached failed/stalled, or the
+  // final monitor-deploy phase completed, with no successor dispatch to trigger the
+  // happy-path predecessor reap. Routed to the single-target (busy-OK) reap path.
+  "phase.terminal.reap-requested",
 ]);
 
 // camelCase → snake_case key mapping. The on-disk schema uses snake_case so

--- a/plugins/dev/scripts/execution-core/reap-intent.test.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.test.mjs
@@ -46,12 +46,27 @@ describe("emitReapIntent", () => {
     await expect(emitReapIntent("bogus.event", {})).rejects.toThrow(/unknown/);
   });
 
-  it("exposes REAP_INTENT_TYPES with 10 entries", async () => {
+  it("exposes REAP_INTENT_TYPES with 11 entries", async () => {
     const { REAP_INTENT_TYPES } = await freshModule();
-    expect(REAP_INTENT_TYPES.length).toBe(10);
+    expect(REAP_INTENT_TYPES.length).toBe(11);
     expect(REAP_INTENT_TYPES).toContain("phase.yield.reap-requested");
     expect(REAP_INTENT_TYPES).toContain("pr.merged.cleanup-requested");
     expect(REAP_INTENT_TYPES).toContain("orphans.reap-requested");
+  });
+
+  it("accepts phase.terminal.reap-requested (CTL-695)", async () => {
+    const { emitReapIntent, REAP_INTENT_TYPES } = await freshModule();
+    expect(REAP_INTENT_TYPES).toContain("phase.terminal.reap-requested");
+    const ok = await emitReapIntent("phase.terminal.reap-requested", {
+      ticket: "CTL-695",
+      phase: "monitor-deploy",
+      bgJobId: "abcd1234",
+      reason: "ctl-695-terminal-worker",
+    });
+    expect(ok).toBe(true);
+    const last = JSON.parse(readFileSync(LOG_PATH, "utf8").trim().split("\n").pop());
+    expect(last.event).toBe("phase.terminal.reap-requested");
+    expect(last.bg_job_id).toBe("abcd1234");
   });
 
   it("accepts phase.reclaim.reap-requested (CTL-661 hole #3)", async () => {

--- a/plugins/dev/scripts/execution-core/reaper-metrics.mjs
+++ b/plugins/dev/scripts/execution-core/reaper-metrics.mjs
@@ -1,0 +1,82 @@
+// reaper-metrics.mjs — incremental reap-outcome counter (CTL-695 Phase 2).
+//
+// Reads the unified event log's flat reap-family lines (event field ending in
+// .reap-requested / .reap-complete / .reap-failed) and returns per-tick counters
+// that otel-forward ships as a pino gauge. Mirrors event-scan.mjs's per-path
+// incremental byte cursor + scanEventsChunked for bounded memory.
+//
+// Reap echoes use FLAT `ev.event` (not attributes["event.name"]) — a distinct
+// shape from OTLP-wrapped session events. Production 2026-05.jsonl: 8936
+// reap-requested, 498 reap-complete, 0 reap-failed — the gap is observable but
+// uninstrumented without this module.
+
+import { statSync } from "node:fs";
+import { scanEventsChunked } from "./event-tail.mjs";
+import { getEventLogPath } from "./config.mjs";
+
+const _index = new Map(); // path → { cursor, leftover, events: [{event, ts}] }
+
+function isReapEvent(name) {
+  return (
+    typeof name === "string" &&
+    (name.endsWith(".reap-requested") ||
+      name.endsWith(".reap-complete") ||
+      name.endsWith(".reap-failed"))
+  );
+}
+
+function refreshIndex(path) {
+  let entry = _index.get(path);
+  if (!entry) {
+    entry = { cursor: 0, leftover: "", events: [] };
+    _index.set(path, entry);
+  }
+  let size;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return entry; // missing log → cold start
+  }
+  if (size < entry.cursor) {
+    // Rotated or truncated — drop stale state.
+    entry.cursor = 0;
+    entry.leftover = "";
+    entry.events = [];
+  }
+  if (size === entry.cursor) return entry; // no new bytes
+  const { endOffset, leftover } = scanEventsChunked({
+    path,
+    fromOffset: entry.cursor,
+    leftover: entry.leftover,
+    onEvent: (ev) => {
+      const name = ev?.event;
+      if (!isReapEvent(name)) return;
+      entry.events.push({ event: name, ts: ev?.ts });
+    },
+  });
+  entry.cursor = endOffset;
+  entry.leftover = leftover;
+  return entry;
+}
+
+/**
+ * Count reap outcomes from the event log at `path` (defaults to the current
+ * month's log). Optional `since` ISO timestamp excludes earlier events.
+ * Returns { staleSeen, staleReaped, reapFailures }.
+ */
+export function countReapOutcomes({ since, path = getEventLogPath() } = {}) {
+  let staleSeen = 0;
+  let staleReaped = 0;
+  let reapFailures = 0;
+  for (const ev of refreshIndex(path).events) {
+    if (since && ev.ts && ev.ts < since) continue;
+    if (ev.event.endsWith(".reap-requested")) staleSeen++;
+    else if (ev.event.endsWith(".reap-complete")) staleReaped++;
+    else if (ev.event.endsWith(".reap-failed")) reapFailures++;
+  }
+  return { staleSeen, staleReaped, reapFailures };
+}
+
+export function __resetReaperMetricsIndexForTest() {
+  _index.clear();
+}

--- a/plugins/dev/scripts/execution-core/reaper-metrics.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper-metrics.test.mjs
@@ -1,0 +1,78 @@
+// reaper-metrics.test.mjs — unit tests for the incremental reap-outcome counter
+// (CTL-695 Phase 2). Run: cd plugins/dev/scripts/execution-core && bun test reaper-metrics.test.mjs
+import { describe, test, expect, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, appendFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let catalystDir;
+let logPath;
+
+// Append a flat reap-family JSONL line to the fixture event log.
+function appendFlat(obj) {
+  mkdirSync(join(catalystDir, "events"), { recursive: true });
+  appendFileSync(logPath, JSON.stringify(obj) + "\n");
+}
+
+beforeEach(async () => {
+  catalystDir = mkdtempSync(join(tmpdir(), "reap-metrics-"));
+  const ym = `${new Date().getUTCFullYear()}-${String(new Date().getUTCMonth() + 1).padStart(2, "0")}`;
+  logPath = join(catalystDir, "events", `${ym}.jsonl`);
+  // Reset the incremental index so each test starts from a clean slate.
+  const { __resetReaperMetricsIndexForTest } = await import(
+    `./reaper-metrics.mjs?reset=${Date.now()}-${Math.random()}`
+  );
+  __resetReaperMetricsIndexForTest();
+});
+
+async function freshMetrics() {
+  const { countReapOutcomes, __resetReaperMetricsIndexForTest } = await import(
+    `./reaper-metrics.mjs?cb=${Date.now()}-${Math.random()}`
+  );
+  __resetReaperMetricsIndexForTest();
+  return { countReapOutcomes };
+}
+
+describe("countReapOutcomes", () => {
+  test("counts reap-requested, reap-complete, reap-failed by family", async () => {
+    const { countReapOutcomes } = await freshMetrics();
+    appendFlat({ event: "phase.predecessor.reap-requested", bg_job_id: "a" });
+    appendFlat({ event: "phase.terminal.reap-requested", bg_job_id: "b" });
+    appendFlat({ event: "phase.predecessor.reap-complete", bg_job_id: "a" });
+    appendFlat({ event: "phase.revive.reap-failed", bg_job_id: "c" });
+    const m = countReapOutcomes({ path: logPath });
+    expect(m).toEqual({ staleSeen: 2, staleReaped: 1, reapFailures: 1 });
+  });
+
+  test("ignores OTLP-wrapped session lines (attributes['event.name'])", async () => {
+    const { countReapOutcomes } = await freshMetrics();
+    appendFlat({ ts: "2026-05-28T00:00:00Z", attributes: { "event.name": "github.issue_comment" } });
+    const m = countReapOutcomes({ path: logPath });
+    expect(m).toEqual({ staleSeen: 0, staleReaped: 0, reapFailures: 0 });
+  });
+
+  test("missing log → all zeros (cold start)", async () => {
+    const { countReapOutcomes } = await freshMetrics();
+    const m = countReapOutcomes({ path: "/no/such/log.jsonl" });
+    expect(m).toEqual({ staleSeen: 0, staleReaped: 0, reapFailures: 0 });
+  });
+
+  test("since filter excludes older events", async () => {
+    const { countReapOutcomes } = await freshMetrics();
+    appendFlat({ ts: "2026-05-01T00:00:00Z", event: "phase.predecessor.reap-complete" });
+    appendFlat({ ts: "2026-05-28T00:00:00Z", event: "phase.predecessor.reap-complete" });
+    const m = countReapOutcomes({ path: logPath, since: "2026-05-15T00:00:00Z" });
+    expect(m.staleReaped).toBe(1);
+  });
+
+  test("incremental: second call on the same path reads only new bytes", async () => {
+    const { countReapOutcomes } = await freshMetrics();
+    appendFlat({ event: "phase.predecessor.reap-requested", bg_job_id: "x" });
+    const first = countReapOutcomes({ path: logPath });
+    expect(first.staleSeen).toBe(1);
+    // Append a second event and call again — should see 2 total, not 1.
+    appendFlat({ event: "phase.terminal.reap-requested", bg_job_id: "y" });
+    const second = countReapOutcomes({ path: logPath });
+    expect(second.staleSeen).toBe(2);
+  });
+});

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -134,6 +134,9 @@ export class Reaper {
         // CTL-661 hole #3: single-target stop of a reclaimed (genuinely-hung)
         // worker on the recovery happy path. Busy-OK, like the others.
         case "phase.reclaim.reap-requested":
+        // CTL-695: terminal-worker reap — same authoritative single-target
+        // (busy-OK) path as predecessor/yield/supersede/revive/abort.
+        case "phase.terminal.reap-requested":
           await this._handleBgReap(event);
           break;
         // CTL-661 hole #4: the reconcile event is dual-purpose, disambiguated by

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -143,6 +143,24 @@ describe("Reaper._handleBgReap", () => {
     expect(executor).toHaveBeenCalledWith("abc12345");
   });
 
+  it("routes phase.terminal.reap-requested to _handleBgReap (busy-OK, CTL-695)", async () => {
+    // CTL-695: terminal-worker reap — must route to the single-target (busy-OK)
+    // path, not the periodic orphan sweep or an unknown-handler warn.
+    const executor = mock(() => Promise.resolve({ ok: true }));
+    const emitted = [];
+    const r = new Reaper({
+      executorReap: executor,
+      agents: agentsFixture([
+        { sessionId: "abcd1234-aaaa-bbbb-cccc-dddddddddddd", status: "busy", kind: "background" },
+      ]),
+      emit: (evt, f) => { emitted.push({ evt, f }); return Promise.resolve(); },
+      log: silentLog(),
+    });
+    await r.handle({ event: "phase.terminal.reap-requested", bg_job_id: "abcd1234", ticket: "CTL-695", phase: "monitor-deploy" });
+    expect(executor).toHaveBeenCalled(); // reaped even though status==="busy"
+    expect(emitted.find((e) => e.evt === "phase.terminal.reap-complete")).toBeTruthy();
+  });
+
   it("reaps an unknown-kind target (avoids regressing the leak fix if claude omits .kind)", async () => {
     const executor = mock(() => Promise.resolve({ ok: true }));
     const r = new Reaper({

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -83,6 +83,7 @@ import * as linearWrite from "./linear-write.mjs";
 // scheduler.mjs already imports reclaimDeadWorkIfPossible from recovery.mjs —
 // a cycle. label-guard.mjs is the leaf module both can import.
 import { labelOnce } from "./label-guard.mjs";
+import { countReapOutcomes } from "./reaper-metrics.mjs";
 import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
@@ -589,6 +590,29 @@ export function resolveReapPredecessor(signals, next) {
   }
   const pred = predecessorPhaseOf(sig, next);
   return pred ? { phase: pred, reason: "ctl-657-scheduler-advance" } : null;
+}
+
+// emitTerminalWorkerReapOnce — CTL-695: nominate a terminal worker for reaping
+// once per worker/phase. Covers the gaps the happy-path emitPredecessorReap
+// (advance-success only) never reaches: self-exited failed/stalled workers and
+// the final monitor-deploy worker. Once-marker prevents per-tick re-emission.
+// The marker is written BEFORE the emit (optimistic) so a synchronous second
+// tick sees it and skips — emitReapIntent uses appendFileSync (no await), so
+// the file is already written before this function returns.
+function emitTerminalWorkerReapOnce(orchDir, ticket, phase) {
+  const marker = join(orchDir, "workers", ticket, `.terminal-reap-${phase}.applied`);
+  if (existsSync(marker)) return;
+  const raw = readPhaseSignalRaw(orchDir, ticket, phase);
+  const bgJobId = raw?.bg_job_id;
+  if (!bgJobId) return; // no bg session to stop (unit-test signal / new-work entry)
+  writeFileSync(marker, ""); // optimistic pre-write: prevents re-spam even if emit fails
+  emitReapIntent("phase.terminal.reap-requested", {
+    ticket,
+    phase,
+    bgJobId,
+    worktreePath: raw?.worktreePath,
+    reason: "ctl-695-terminal-worker",
+  }).catch(() => {}); // best-effort; marker already guards against re-emission
 }
 
 // emitPredecessorReap — CTL-657 Bug 2: stop the predecessor worker now that its
@@ -1620,6 +1644,9 @@ export function schedulerTick(
           { ticket, phase: next, verifyReason: v.reason },
           "scheduler: dispatched signal verification failed"
         );
+        // CTL-695: reap the just-finished predecessor even though its successor
+        // did not come up — the failed dispatch leaves the predecessor alive.
+        emitPredecessorReap(orchDir, ticket, preResetSignals, next, { remediateRaw });
       }
     } else {
       const cd2 = recordDispatchFailure(orchDir, ticket, next, r.code, now()); // CTL-624: arm the cool-down window
@@ -1636,6 +1663,9 @@ export function schedulerTick(
       });
       maybeEscalateDispatchFailures(orchDir, cd2, { writeStatus, appendEvent: appendCooldownEscalatedEvent });
       log.warn({ ticket, phase: next, code: r.code }, "scheduler: advance dispatch failed");
+      // CTL-695: reap the just-finished predecessor even though its successor
+      // did not come up — the failed dispatch leaves the predecessor alive.
+      emitPredecessorReap(orchDir, ticket, preResetSignals, next, { remediateRaw });
     }
   }
 
@@ -1746,6 +1776,9 @@ export function schedulerTick(
   // the daemon's pino-only observability convention (schedulerTick's return
   // object is discarded by runTick, so a metric must be logged, not returned).
   if (cache) log.info(cache.stats(), "scheduler: cache stats");
+  // CTL-695: per-tick reaper telemetry — otel-forward ships this pino line as a
+  // gauge (same log-line-only convention as cache.stats / per-project slots).
+  log.info(countReapOutcomes(), "scheduler: reap stats");
   const ready = computeReadyTickets(eligible, { blockerStates });
   // CTL-657: the in-flight count is the live `background` claude-agents count,
   // not listInFlightTickets(orchDir).size. A worker that leaked (signal terminal
@@ -1883,6 +1916,19 @@ export function schedulerTick(
     }
     if (Object.values(signals).some((s) => s === "stalled")) {
       labelOnce(orchDir, ticket, "needs-human", writeStatus);
+    }
+    // CTL-695: nominate terminal workers for reaping once. Covers the gaps the
+    // happy-path emitPredecessorReap (advance-success only) never reaches:
+    // self-exited failed/stalled workers and the final monitor-deploy worker.
+    // Intermediate `done` phases are excluded — those advance, and the existing
+    // emitPredecessorReap (section 1, advance-success) owns their reap. The
+    // reaper's _inflight 60s dedup + the per-phase marker make any overlap benign.
+    for (const [phase, status] of Object.entries(signals)) {
+      const isFinalTerminal =
+        phase === TERMINAL_PHASE && (status === "done" || status === "skipped");
+      if (status === "failed" || status === "stalled" || isFinalTerminal) {
+        emitTerminalWorkerReapOnce(orchDir, ticket, phase);
+      }
     }
   }
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -47,7 +47,15 @@ import {
   clearDispatchCooldown,
   dispatchCooldownPath,
   verifyDispatchedSignal,
+  gcDispatchCooldowns,
+  maybeEscalateDispatchFailures,
   __resetForTests,
+  // CTL-705: Phase 2 helpers
+  STAGE_RANK,
+  stageRankForTicket,
+  readWorkerPriority,
+  writeWorkerPriority,
+  buildGlobalRanking,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { REMEDIATE_CYCLE_CAP } from "../lib/phase-fsm.mjs";
@@ -669,7 +677,8 @@ describe("dispatch cool-down helpers", () => {
   });
 
   test("within the window → in cool-down; past the window → not", () => {
-    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 5_000);
+    // code=1 (transient) → 60s window (CTL-713: code=2 uses 30 min permanent window).
+    recordDispatchFailure(orchDir, "CTL-1", "research", 1, 5_000);
     // 30 s later (< 60 s window) → still cooling down.
     expect(inDispatchCooldown(orchDir, "CTL-1", "research", 35_000)).toBe(true);
     // 61 s later (> 60 s window) → window elapsed.
@@ -696,6 +705,52 @@ describe("dispatch cool-down helpers", () => {
     writeFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "not json");
     expect(inDispatchCooldown(orchDir, "CTL-1", "research", 6_000)).toBe(false);
   });
+
+  // ── CTL-713: enriched marker schema (TTL + ticket + consecutiveFailures) ──
+
+  test("recordDispatchFailure stamps ticket, expiresAt, and consecutiveFailures", () => {
+    recordDispatchFailure(orchDir, "CTL-1", "research", 1, 5_000);
+    const m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "utf8"));
+    expect(m).toMatchObject({ ticket: "CTL-1", phase: "research", code: 1, failedAt: 5_000 });
+    expect(m.expiresAt).toBe(5_000 + 60_000);
+    expect(m.consecutiveFailures).toBe(1);
+  });
+
+  test("code=2 (prior_artifact_missing) uses the permanent cooldown window", () => {
+    recordDispatchFailure(orchDir, "CTL-1", "plan", 2, 5_000);
+    const m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-1", "plan"), "utf8"));
+    expect(m.expiresAt).toBe(5_000 + 30 * 60 * 1000);
+  });
+
+  test("consecutiveFailures increments on same-code overwrite, resets on a different code", () => {
+    recordDispatchFailure(orchDir, "CTL-1", "research", 1, 1_000);
+    recordDispatchFailure(orchDir, "CTL-1", "research", 1, 2_000);
+    let m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "utf8"));
+    expect(m.consecutiveFailures).toBe(2);
+    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 3_000);
+    m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "utf8"));
+    expect(m.consecutiveFailures).toBe(1);
+  });
+
+  test("recordDispatchFailure returns the written marker", () => {
+    const m = recordDispatchFailure(orchDir, "CTL-1", "review", 2, 5_000);
+    expect(m).toMatchObject({ ticket: "CTL-1", phase: "review", code: 2, consecutiveFailures: 1 });
+    expect(m.expiresAt).toBe(5_000 + 30 * 60 * 1000);
+  });
+
+  test("inDispatchCooldown honors expiresAt for permanent (code=2) markers", () => {
+    recordDispatchFailure(orchDir, "CTL-1", "plan", 2, 5_000);
+    expect(inDispatchCooldown(orchDir, "CTL-1", "plan", 5_000 + 5 * 60 * 1000)).toBe(true);
+    expect(inDispatchCooldown(orchDir, "CTL-1", "plan", 5_000 + 31 * 60 * 1000)).toBe(false);
+  });
+
+  test("inDispatchCooldown falls back to failedAt+COOLDOWN_MS for legacy markers without expiresAt", () => {
+    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
+    writeFileSync(dispatchCooldownPath(orchDir, "CTL-9", "research"),
+      JSON.stringify({ phase: "research", code: 1, failedAt: 5_000 }));
+    expect(inDispatchCooldown(orchDir, "CTL-9", "research", 35_000)).toBe(true);
+    expect(inDispatchCooldown(orchDir, "CTL-9", "research", 66_000)).toBe(false);
+  });
 });
 
 // ── CTL-624: dispatch cool-down wired into schedulerTick ──
@@ -711,9 +766,12 @@ describe("dispatch cool-down (schedulerTick)", () => {
     },
   ];
 
-  test("a refused new-work dispatch (code 2) writes a cool-down marker and stops re-dispatching", () => {
+  test("a refused new-work dispatch (transient code) writes a cool-down marker and stops re-dispatching", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
-    const dispatch = fakeDispatch({ code: 2 });
+    // code=1 is a transient failure → 60 s window (code=2 uses the 30-min
+    // permanent window, covered separately by the recordDispatchFailure unit
+    // tests). The < 60 s / > 60 s assertions below depend on the transient TTL.
+    const dispatch = fakeDispatch({ code: 1 });
     const marker = dispatchCooldownPath(orchDir, "CTL-3", "research");
 
     // Tick 1 at t=1000: dispatch refused → 1 call, marker written.
@@ -721,6 +779,7 @@ describe("dispatch cool-down (schedulerTick)", () => {
       readEligible: () => eligibleOne("CTL-3"),
       dispatch,
       now: () => 1_000,
+      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls).toHaveLength(1);
     expect(existsSync(marker)).toBe(true);
@@ -730,6 +789,7 @@ describe("dispatch cool-down (schedulerTick)", () => {
       readEligible: () => eligibleOne("CTL-3"),
       dispatch,
       now: () => 30_000,
+      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls).toHaveLength(1);
 
@@ -738,6 +798,7 @@ describe("dispatch cool-down (schedulerTick)", () => {
       readEligible: () => eligibleOne("CTL-3"),
       dispatch,
       now: () => 70_000,
+      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls).toHaveLength(2);
   });
@@ -746,11 +807,14 @@ describe("dispatch cool-down (schedulerTick)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const marker = dispatchCooldownPath(orchDir, "CTL-4", "research");
 
-    // First a refusal seeds the marker.
+    // First a refusal seeds the marker. code=1 is transient (60 s window) so
+    // the t=70_000 success below lands past the window; code=2 would hold a
+    // 30-min permanent marker and suppress the clearing dispatch entirely.
     schedulerTick(orchDir, {
       readEligible: () => eligibleOne("CTL-4"),
-      dispatch: fakeDispatch({ code: 2 }),
+      dispatch: fakeDispatch({ code: 1 }),
       now: () => 1_000,
+      liveBackgroundCount: () => 0,
     });
     expect(existsSync(marker)).toBe(true);
 
@@ -760,6 +824,7 @@ describe("dispatch cool-down (schedulerTick)", () => {
       dispatch: fakeDispatch({ code: 0 }),
       now: () => 70_000,
       verifyDispatched: verifyOk, // CTL-611: not testing the verifier here
+      liveBackgroundCount: () => 0,
     });
     expect(existsSync(marker)).toBe(false);
   });
@@ -787,6 +852,104 @@ describe("dispatch cool-down (schedulerTick)", () => {
 
     schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 30_000 });
     expect(dispatch.calls).toHaveLength(1); // suppressed within window
+  });
+});
+
+// ── CTL-713: GC sweep ──
+describe("dispatch cool-down GC", () => {
+  test("gcDispatchCooldowns deletes an expired marker for a non-eligible ticket", () => {
+    recordDispatchFailure(orchDir, "CTL-DONE", "review", 1, 1_000); // expiresAt = 61_000
+    const deleted = gcDispatchCooldowns(orchDir, new Set(["CTL-LIVE"]), 100_000);
+    expect(deleted).toEqual([{ ticket: "CTL-DONE", phase: "review" }]);
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-DONE", "review"))).toBe(false);
+  });
+
+  test("gc keeps a marker whose ticket is still eligible even if expired", () => {
+    recordDispatchFailure(orchDir, "CTL-LIVE", "research", 1, 1_000);
+    gcDispatchCooldowns(orchDir, new Set(["CTL-LIVE"]), 100_000);
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-LIVE", "research"))).toBe(true);
+  });
+
+  test("gc keeps an unexpired marker for a non-eligible ticket", () => {
+    recordDispatchFailure(orchDir, "CTL-DONE", "research", 1, 1_000); // expiresAt = 61_000
+    gcDispatchCooldowns(orchDir, new Set(), 30_000); // before expiry
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-DONE", "research"))).toBe(true);
+  });
+
+  test("gc reaps a legacy marker (no expiresAt/ticket) using failedAt+COOLDOWN_MS and filename", () => {
+    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
+    writeFileSync(join(orchDir, ".dispatch-cooldowns", "CTL-671-monitor-deploy.json"),
+      JSON.stringify({ phase: "monitor-deploy", code: 1, failedAt: 1_000 }));
+    const deleted = gcDispatchCooldowns(orchDir, new Set(), 100_000);
+    expect(deleted).toEqual([{ ticket: "CTL-671", phase: "monitor-deploy" }]);
+  });
+
+  test("gc tolerates a missing .dispatch-cooldowns dir and malformed files", () => {
+    expect(gcDispatchCooldowns(orchDir, new Set(), 100_000)).toEqual([]);
+    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
+    writeFileSync(join(orchDir, ".dispatch-cooldowns", "junk.json"), "not json");
+    expect(() => gcDispatchCooldowns(orchDir, new Set(), 100_000)).not.toThrow();
+  });
+
+  test("schedulerTick runs the GC sweep and emits a cooldown-gc event per reaped marker", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    recordDispatchFailure(orchDir, "CTL-GONE", "review", 1, 1_000);
+    const events = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      now: () => 100_000,
+      appendCooldownGcEvent: (e) => events.push(e),
+    });
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-GONE", "review"))).toBe(false);
+    expect(events).toEqual([expect.objectContaining({ ticket: "CTL-GONE", target_phase: "review" })]);
+  });
+});
+
+// ── CTL-713: consecutive-failure escalation ──
+describe("dispatch cool-down escalation", () => {
+  const fakeWriteStatus = (applied) => ({
+    applyLabel: ({ ticket, label }) => { applied.push({ ticket, label }); return { applied: true }; },
+    transition: () => {},
+    applyPhaseStatus: () => {},
+  });
+
+  test("maybeEscalateDispatchFailures applies needs-human at the threshold", () => {
+    const applied = [];
+    const ws = fakeWriteStatus(applied);
+    const marker = { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: 3 };
+    const events = [];
+    maybeEscalateDispatchFailures(orchDir, marker, { writeStatus: ws, appendEvent: (e) => events.push(e) });
+    expect(applied).toEqual([{ ticket: "CTL-5", label: "needs-human" }]);
+    expect(events).toEqual([expect.objectContaining({ ticket: "CTL-5", target_phase: "research", consecutiveFailures: 3 })]);
+  });
+
+  test("maybeEscalateDispatchFailures is a no-op below the threshold", () => {
+    const applied = [];
+    const ws = fakeWriteStatus(applied);
+    maybeEscalateDispatchFailures(orchDir, { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: 2 },
+      { writeStatus: ws, appendEvent: () => {} });
+    expect(applied).toEqual([]);
+  });
+
+  test("schedulerTick escalates after N consecutive same-code refusals on new-work", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 2 });
+    const applied = [];
+    const ws = fakeWriteStatus(applied);
+    let t = 0;
+    for (let i = 0; i < 3; i++) {
+      schedulerTick(orchDir, {
+        readEligible: () => [{ identifier: "CTL-7", priority: 1, createdAt: "x", state: "Todo",
+                               relations: { nodes: [] }, inverseRelations: { nodes: [] } }],
+        dispatch,
+        writeStatus: ws,
+        liveBackgroundCount: () => 0,
+        now: () => (t += 31 * 60 * 1000),
+      });
+    }
+    expect(applied).toContainEqual({ ticket: "CTL-7", label: "needs-human" });
   });
 });
 
@@ -948,6 +1111,7 @@ describe("schedulerTick — new-work pull", () => {
       readEligible: () => eligible,
       dispatch,
       verifyDispatched: verifyOk, // CTL-611: bypass the dispatch verifier
+      liveBackgroundCount: () => 0,
     });
     // 2 free slots, both ready → both dispatched, urgent (CTL-8) first.
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-8", "CTL-9"]);
@@ -1013,7 +1177,7 @@ describe("schedulerTick — new-work pull", () => {
         inverseRelations: { nodes: [] },
       },
     ];
-    schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
+    schedulerTick(orchDir, { readEligible: () => eligible, dispatch, liveBackgroundCount: () => 0 });
     expect(dispatch.calls).toHaveLength(1);
     expect(dispatch.calls[0]).toMatchObject({ ticket: "CTL-1", phase: "research" });
   });
@@ -1119,6 +1283,7 @@ describe("schedulerTick — new-work pull", () => {
       readEligible: () => eligible,
       dispatch,
       verifyDispatched: verifyOk, // CTL-611: bypass dispatch verifier
+      liveBackgroundCount: () => 0,
     });
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
     expect(r.dispatched).toEqual(["CTL-X"]);
@@ -1554,6 +1719,7 @@ describe("hydrateOutOfSetBlockers / D5 readiness", () => {
       readEligible: () => [blkTk("CTL-1", { blockedBy: "CTL-99" })],
       dispatch,
       exec,
+      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-1"]);
   });
@@ -2148,6 +2314,7 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
       readEligible: () => eligible,
       dispatch,
       verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
     });
     expect(r1.dispatched).toEqual(["CTL-9"]);
 
@@ -2244,6 +2411,7 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
       dispatch: okDispatch,
       writeStatus,
       verifyDispatched: verifyOk, // CTL-611
+      liveBackgroundCount: () => 0,
     });
     expect(writes).toContainEqual(expect.objectContaining({ ticket: "CTL-2", phase: "research" }));
   });
@@ -3260,6 +3428,14 @@ describe("CTL-653: schedulerTick verify⇄remediate cycle (end-to-end)", () => {
         writeStatus: noopWriteStatus,
         reclaimDeadWork: () => "noop",
         verifyDispatched: verifyOk, // CTL-611: cyclingDispatch writes status:"done", not a runnable dispatched signal; bypass the verifier
+        // CTL-705: inject the liveBackgroundCount seam so this end-to-end cycle
+        // test does NOT shell out to the real `claude agents --json` once per
+        // tick. With no eligible/queued tickets the slot-counting sweeps (0.5
+        // preemption, 2 new-work) are no-ops anyway, so a free-slot stub is
+        // behavior-preserving — and it makes the 12-tick run deterministic
+        // instead of dependent on real subprocess latency (which timed the test
+        // out under load even after the scheduler hoisted the call 3x→1x).
+        liveBackgroundCount: () => 0,
       });
     }
   };

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -47,15 +47,7 @@ import {
   clearDispatchCooldown,
   dispatchCooldownPath,
   verifyDispatchedSignal,
-  gcDispatchCooldowns,
-  maybeEscalateDispatchFailures,
   __resetForTests,
-  // CTL-705: Phase 2 helpers
-  STAGE_RANK,
-  stageRankForTicket,
-  readWorkerPriority,
-  writeWorkerPriority,
-  buildGlobalRanking,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { REMEDIATE_CYCLE_CAP } from "../lib/phase-fsm.mjs";
@@ -82,6 +74,31 @@ function writeSignal(ticket, phase, status) {
   const dir = join(orchDir, "workers", ticket);
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ ticket, phase, status }));
+}
+
+// writeSignalRaw — writes phase-<phase>.json with arbitrary raw fields (e.g.
+// bg_job_id, worktreePath) that the existing writeSignal helper omits.
+function writeSignalRaw(ticket, phase, obj) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify(obj));
+}
+
+// readEventLog — reads the current UTC YYYY-MM.jsonl under catalystDir/events/
+// and returns parsed event objects. Returns [] on missing/empty log.
+function readEventLog() {
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  const logPath = join(catalystDir, "events", `${ym}.jsonl`);
+  try {
+    return readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
 }
 
 // appendToEventLog — mkdirSync <CATALYST_DIR>/events/ and append to the
@@ -652,8 +669,7 @@ describe("dispatch cool-down helpers", () => {
   });
 
   test("within the window → in cool-down; past the window → not", () => {
-    // code=1 (transient) → 60s window (CTL-713: code=2 uses 30 min permanent window).
-    recordDispatchFailure(orchDir, "CTL-1", "research", 1, 5_000);
+    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 5_000);
     // 30 s later (< 60 s window) → still cooling down.
     expect(inDispatchCooldown(orchDir, "CTL-1", "research", 35_000)).toBe(true);
     // 61 s later (> 60 s window) → window elapsed.
@@ -680,52 +696,6 @@ describe("dispatch cool-down helpers", () => {
     writeFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "not json");
     expect(inDispatchCooldown(orchDir, "CTL-1", "research", 6_000)).toBe(false);
   });
-
-  // ── CTL-713: enriched marker schema (TTL + ticket + consecutiveFailures) ──
-
-  test("recordDispatchFailure stamps ticket, expiresAt, and consecutiveFailures", () => {
-    recordDispatchFailure(orchDir, "CTL-1", "research", 1, 5_000);
-    const m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "utf8"));
-    expect(m).toMatchObject({ ticket: "CTL-1", phase: "research", code: 1, failedAt: 5_000 });
-    expect(m.expiresAt).toBe(5_000 + 60_000);
-    expect(m.consecutiveFailures).toBe(1);
-  });
-
-  test("code=2 (prior_artifact_missing) uses the permanent cooldown window", () => {
-    recordDispatchFailure(orchDir, "CTL-1", "plan", 2, 5_000);
-    const m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-1", "plan"), "utf8"));
-    expect(m.expiresAt).toBe(5_000 + 30 * 60 * 1000);
-  });
-
-  test("consecutiveFailures increments on same-code overwrite, resets on a different code", () => {
-    recordDispatchFailure(orchDir, "CTL-1", "research", 1, 1_000);
-    recordDispatchFailure(orchDir, "CTL-1", "research", 1, 2_000);
-    let m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "utf8"));
-    expect(m.consecutiveFailures).toBe(2);
-    recordDispatchFailure(orchDir, "CTL-1", "research", 2, 3_000);
-    m = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CTL-1", "research"), "utf8"));
-    expect(m.consecutiveFailures).toBe(1);
-  });
-
-  test("recordDispatchFailure returns the written marker", () => {
-    const m = recordDispatchFailure(orchDir, "CTL-1", "review", 2, 5_000);
-    expect(m).toMatchObject({ ticket: "CTL-1", phase: "review", code: 2, consecutiveFailures: 1 });
-    expect(m.expiresAt).toBe(5_000 + 30 * 60 * 1000);
-  });
-
-  test("inDispatchCooldown honors expiresAt for permanent (code=2) markers", () => {
-    recordDispatchFailure(orchDir, "CTL-1", "plan", 2, 5_000);
-    expect(inDispatchCooldown(orchDir, "CTL-1", "plan", 5_000 + 5 * 60 * 1000)).toBe(true);
-    expect(inDispatchCooldown(orchDir, "CTL-1", "plan", 5_000 + 31 * 60 * 1000)).toBe(false);
-  });
-
-  test("inDispatchCooldown falls back to failedAt+COOLDOWN_MS for legacy markers without expiresAt", () => {
-    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
-    writeFileSync(dispatchCooldownPath(orchDir, "CTL-9", "research"),
-      JSON.stringify({ phase: "research", code: 1, failedAt: 5_000 }));
-    expect(inDispatchCooldown(orchDir, "CTL-9", "research", 35_000)).toBe(true);
-    expect(inDispatchCooldown(orchDir, "CTL-9", "research", 66_000)).toBe(false);
-  });
 });
 
 // ── CTL-624: dispatch cool-down wired into schedulerTick ──
@@ -741,12 +711,9 @@ describe("dispatch cool-down (schedulerTick)", () => {
     },
   ];
 
-  test("a refused new-work dispatch (transient code) writes a cool-down marker and stops re-dispatching", () => {
+  test("a refused new-work dispatch (code 2) writes a cool-down marker and stops re-dispatching", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
-    // code=1 is a transient failure → 60 s window (code=2 uses the 30-min
-    // permanent window, covered separately by the recordDispatchFailure unit
-    // tests). The < 60 s / > 60 s assertions below depend on the transient TTL.
-    const dispatch = fakeDispatch({ code: 1 });
+    const dispatch = fakeDispatch({ code: 2 });
     const marker = dispatchCooldownPath(orchDir, "CTL-3", "research");
 
     // Tick 1 at t=1000: dispatch refused → 1 call, marker written.
@@ -754,7 +721,6 @@ describe("dispatch cool-down (schedulerTick)", () => {
       readEligible: () => eligibleOne("CTL-3"),
       dispatch,
       now: () => 1_000,
-      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls).toHaveLength(1);
     expect(existsSync(marker)).toBe(true);
@@ -764,7 +730,6 @@ describe("dispatch cool-down (schedulerTick)", () => {
       readEligible: () => eligibleOne("CTL-3"),
       dispatch,
       now: () => 30_000,
-      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls).toHaveLength(1);
 
@@ -773,7 +738,6 @@ describe("dispatch cool-down (schedulerTick)", () => {
       readEligible: () => eligibleOne("CTL-3"),
       dispatch,
       now: () => 70_000,
-      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls).toHaveLength(2);
   });
@@ -782,14 +746,11 @@ describe("dispatch cool-down (schedulerTick)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const marker = dispatchCooldownPath(orchDir, "CTL-4", "research");
 
-    // First a refusal seeds the marker. code=1 is transient (60 s window) so
-    // the t=70_000 success below lands past the window; code=2 would hold a
-    // 30-min permanent marker and suppress the clearing dispatch entirely.
+    // First a refusal seeds the marker.
     schedulerTick(orchDir, {
       readEligible: () => eligibleOne("CTL-4"),
-      dispatch: fakeDispatch({ code: 1 }),
+      dispatch: fakeDispatch({ code: 2 }),
       now: () => 1_000,
-      liveBackgroundCount: () => 0,
     });
     expect(existsSync(marker)).toBe(true);
 
@@ -799,7 +760,6 @@ describe("dispatch cool-down (schedulerTick)", () => {
       dispatch: fakeDispatch({ code: 0 }),
       now: () => 70_000,
       verifyDispatched: verifyOk, // CTL-611: not testing the verifier here
-      liveBackgroundCount: () => 0,
     });
     expect(existsSync(marker)).toBe(false);
   });
@@ -827,104 +787,6 @@ describe("dispatch cool-down (schedulerTick)", () => {
 
     schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 30_000 });
     expect(dispatch.calls).toHaveLength(1); // suppressed within window
-  });
-});
-
-// ── CTL-713: GC sweep ──
-describe("dispatch cool-down GC", () => {
-  test("gcDispatchCooldowns deletes an expired marker for a non-eligible ticket", () => {
-    recordDispatchFailure(orchDir, "CTL-DONE", "review", 1, 1_000); // expiresAt = 61_000
-    const deleted = gcDispatchCooldowns(orchDir, new Set(["CTL-LIVE"]), 100_000);
-    expect(deleted).toEqual([{ ticket: "CTL-DONE", phase: "review" }]);
-    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-DONE", "review"))).toBe(false);
-  });
-
-  test("gc keeps a marker whose ticket is still eligible even if expired", () => {
-    recordDispatchFailure(orchDir, "CTL-LIVE", "research", 1, 1_000);
-    gcDispatchCooldowns(orchDir, new Set(["CTL-LIVE"]), 100_000);
-    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-LIVE", "research"))).toBe(true);
-  });
-
-  test("gc keeps an unexpired marker for a non-eligible ticket", () => {
-    recordDispatchFailure(orchDir, "CTL-DONE", "research", 1, 1_000); // expiresAt = 61_000
-    gcDispatchCooldowns(orchDir, new Set(), 30_000); // before expiry
-    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-DONE", "research"))).toBe(true);
-  });
-
-  test("gc reaps a legacy marker (no expiresAt/ticket) using failedAt+COOLDOWN_MS and filename", () => {
-    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
-    writeFileSync(join(orchDir, ".dispatch-cooldowns", "CTL-671-monitor-deploy.json"),
-      JSON.stringify({ phase: "monitor-deploy", code: 1, failedAt: 1_000 }));
-    const deleted = gcDispatchCooldowns(orchDir, new Set(), 100_000);
-    expect(deleted).toEqual([{ ticket: "CTL-671", phase: "monitor-deploy" }]);
-  });
-
-  test("gc tolerates a missing .dispatch-cooldowns dir and malformed files", () => {
-    expect(gcDispatchCooldowns(orchDir, new Set(), 100_000)).toEqual([]);
-    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
-    writeFileSync(join(orchDir, ".dispatch-cooldowns", "junk.json"), "not json");
-    expect(() => gcDispatchCooldowns(orchDir, new Set(), 100_000)).not.toThrow();
-  });
-
-  test("schedulerTick runs the GC sweep and emits a cooldown-gc event per reaped marker", () => {
-    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
-    recordDispatchFailure(orchDir, "CTL-GONE", "review", 1, 1_000);
-    const events = [];
-    schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: fakeDispatch({ code: 0 }),
-      liveBackgroundCount: () => 0,
-      now: () => 100_000,
-      appendCooldownGcEvent: (e) => events.push(e),
-    });
-    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-GONE", "review"))).toBe(false);
-    expect(events).toEqual([expect.objectContaining({ ticket: "CTL-GONE", target_phase: "review" })]);
-  });
-});
-
-// ── CTL-713: consecutive-failure escalation ──
-describe("dispatch cool-down escalation", () => {
-  const fakeWriteStatus = (applied) => ({
-    applyLabel: ({ ticket, label }) => { applied.push({ ticket, label }); return { applied: true }; },
-    transition: () => {},
-    applyPhaseStatus: () => {},
-  });
-
-  test("maybeEscalateDispatchFailures applies needs-human at the threshold", () => {
-    const applied = [];
-    const ws = fakeWriteStatus(applied);
-    const marker = { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: 3 };
-    const events = [];
-    maybeEscalateDispatchFailures(orchDir, marker, { writeStatus: ws, appendEvent: (e) => events.push(e) });
-    expect(applied).toEqual([{ ticket: "CTL-5", label: "needs-human" }]);
-    expect(events).toEqual([expect.objectContaining({ ticket: "CTL-5", target_phase: "research", consecutiveFailures: 3 })]);
-  });
-
-  test("maybeEscalateDispatchFailures is a no-op below the threshold", () => {
-    const applied = [];
-    const ws = fakeWriteStatus(applied);
-    maybeEscalateDispatchFailures(orchDir, { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: 2 },
-      { writeStatus: ws, appendEvent: () => {} });
-    expect(applied).toEqual([]);
-  });
-
-  test("schedulerTick escalates after N consecutive same-code refusals on new-work", () => {
-    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
-    const dispatch = fakeDispatch({ code: 2 });
-    const applied = [];
-    const ws = fakeWriteStatus(applied);
-    let t = 0;
-    for (let i = 0; i < 3; i++) {
-      schedulerTick(orchDir, {
-        readEligible: () => [{ identifier: "CTL-7", priority: 1, createdAt: "x", state: "Todo",
-                               relations: { nodes: [] }, inverseRelations: { nodes: [] } }],
-        dispatch,
-        writeStatus: ws,
-        liveBackgroundCount: () => 0,
-        now: () => (t += 31 * 60 * 1000),
-      });
-    }
-    expect(applied).toContainEqual({ ticket: "CTL-7", label: "needs-human" });
   });
 });
 
@@ -1086,7 +948,6 @@ describe("schedulerTick — new-work pull", () => {
       readEligible: () => eligible,
       dispatch,
       verifyDispatched: verifyOk, // CTL-611: bypass the dispatch verifier
-      liveBackgroundCount: () => 0,
     });
     // 2 free slots, both ready → both dispatched, urgent (CTL-8) first.
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-8", "CTL-9"]);
@@ -1152,7 +1013,7 @@ describe("schedulerTick — new-work pull", () => {
         inverseRelations: { nodes: [] },
       },
     ];
-    schedulerTick(orchDir, { readEligible: () => eligible, dispatch, liveBackgroundCount: () => 0 });
+    schedulerTick(orchDir, { readEligible: () => eligible, dispatch });
     expect(dispatch.calls).toHaveLength(1);
     expect(dispatch.calls[0]).toMatchObject({ ticket: "CTL-1", phase: "research" });
   });
@@ -1258,7 +1119,6 @@ describe("schedulerTick — new-work pull", () => {
       readEligible: () => eligible,
       dispatch,
       verifyDispatched: verifyOk, // CTL-611: bypass dispatch verifier
-      liveBackgroundCount: () => 0,
     });
     expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
     expect(r.dispatched).toEqual(["CTL-X"]);
@@ -1694,7 +1554,6 @@ describe("hydrateOutOfSetBlockers / D5 readiness", () => {
       readEligible: () => [blkTk("CTL-1", { blockedBy: "CTL-99" })],
       dispatch,
       exec,
-      liveBackgroundCount: () => 0,
     });
     expect(dispatch.calls.map((c) => c.ticket)).toEqual(["CTL-1"]);
   });
@@ -2289,7 +2148,6 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
       readEligible: () => eligible,
       dispatch,
       verifyDispatched: verifyOk,
-      liveBackgroundCount: () => 0,
     });
     expect(r1.dispatched).toEqual(["CTL-9"]);
 
@@ -2386,7 +2244,6 @@ describe("schedulerTick — Linear status write-back (CTL-558)", () => {
       dispatch: okDispatch,
       writeStatus,
       verifyDispatched: verifyOk, // CTL-611
-      liveBackgroundCount: () => 0,
     });
     expect(writes).toContainEqual(expect.objectContaining({ ticket: "CTL-2", phase: "research" }));
   });
@@ -3403,14 +3260,6 @@ describe("CTL-653: schedulerTick verify⇄remediate cycle (end-to-end)", () => {
         writeStatus: noopWriteStatus,
         reclaimDeadWork: () => "noop",
         verifyDispatched: verifyOk, // CTL-611: cyclingDispatch writes status:"done", not a runnable dispatched signal; bypass the verifier
-        // CTL-705: inject the liveBackgroundCount seam so this end-to-end cycle
-        // test does NOT shell out to the real `claude agents --json` once per
-        // tick. With no eligible/queued tickets the slot-counting sweeps (0.5
-        // preemption, 2 new-work) are no-ops anyway, so a free-slot stub is
-        // behavior-preserving — and it makes the 12-tick run deterministic
-        // instead of dependent on real subprocess latency (which timed the test
-        // out under load even after the scheduler hoisted the call 3x→1x).
-        liveBackgroundCount: () => 0,
       });
     }
   };
@@ -4454,5 +4303,103 @@ describe("resume-after-preemption sweep (CTL-705 Phase 5)", () => {
     // The resume sweep may dispatch CTL-2 at its parkedFrom phase (correct behavior).
     // But the new-work pull (sweep 2) must NOT include CTL-2 in r.dispatched (that's for fresh starts).
     expect(r.dispatched).not.toContain("CTL-2");
+  });
+});
+
+// ── CTL-695: terminal-worker reap sweep ──────────────────────────────────────
+
+describe("schedulerTick — terminal-worker reap sweep (CTL-695)", () => {
+  test("emits phase.terminal.reap-requested for a failed worker with a bg_job_id", () => {
+    writeSignalRaw("CTL-1", "implement", {
+      status: "failed",
+      bg_job_id: "dead1234",
+      worktreePath: "/wt/CTL-1",
+    });
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: () => ({ code: 0 }) });
+    const evts = readEventLog().filter(
+      (e) => e.event === "phase.terminal.reap-requested" && e.bg_job_id === "dead1234"
+    );
+    expect(evts.length).toBe(1);
+    expect(evts[0].phase).toBe("implement");
+  });
+
+  test("emits for stalled worker and for terminal monitor-deploy done/skipped", () => {
+    writeSignalRaw("CTL-2", "review", { status: "stalled", bg_job_id: "stl12345" });
+    writeSignalRaw("CTL-3", "monitor-deploy", { status: "done", bg_job_id: "fin12345" });
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: () => ({ code: 0 }) });
+    const evts = readEventLog();
+    expect(evts.some((e) => e.event === "phase.terminal.reap-requested" && e.bg_job_id === "stl12345")).toBe(true);
+    expect(evts.some((e) => e.event === "phase.terminal.reap-requested" && e.bg_job_id === "fin12345")).toBe(true);
+  });
+
+  test("does NOT re-emit on a second tick (once-marker)", () => {
+    writeSignalRaw("CTL-1", "implement", { status: "failed", bg_job_id: "dead1234" });
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: () => ({ code: 0 }) });
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: () => ({ code: 0 }) });
+    const n = readEventLog().filter(
+      (e) => e.event === "phase.terminal.reap-requested" && e.bg_job_id === "dead1234"
+    ).length;
+    expect(n).toBe(1);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".terminal-reap-implement.applied"))).toBe(true);
+  });
+
+  test("skips a terminal signal with no bg_job_id (no spurious emit, no marker)", () => {
+    writeSignalRaw("CTL-1", "implement", { status: "failed" }); // no bg_job_id
+    schedulerTick(orchDir, { readEligible: () => [], dispatch: () => ({ code: 0 }) });
+    expect(readEventLog().some((e) => e.event === "phase.terminal.reap-requested")).toBe(false);
+    expect(
+      existsSync(join(orchDir, "workers", "CTL-1", ".terminal-reap-implement.applied"))
+    ).toBe(false);
+  });
+
+  test("does NOT emit terminal-reap for an intermediate done phase that is advancing", () => {
+    // research:done → plan dispatches (advancement sweep); the terminal-reap sweep
+    // must not also emit phase.terminal.reap-requested for the research worker.
+    writeSignalRaw("CTL-4", "research", { status: "done", bg_job_id: "res12345" });
+    const dispatch = ({ orchDir: od, ticket, phase }) => {
+      const dir = join(od, "workers", ticket);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, `phase-${phase}.json`),
+        JSON.stringify({ ticket, phase, status: "running" })
+      );
+      return { code: 0 };
+    };
+    schedulerTick(orchDir, { readEligible: () => [], dispatch });
+    const evts = readEventLog();
+    expect(evts.some((e) => e.event === "phase.terminal.reap-requested" && e.bg_job_id === "res12345")).toBe(false);
+  });
+});
+
+describe("schedulerTick — predecessor reap on dispatch failure (CTL-695)", () => {
+  test("reaps the finished predecessor when successor dispatch fails (rc!=0)", () => {
+    writeSignalRaw("CTL-5", "research", {
+      status: "done",
+      bg_job_id: "pre12345",
+      worktreePath: "/wt/CTL-5",
+    });
+    const dispatch = () => ({ code: 1 }); // plan dispatch fails
+    schedulerTick(orchDir, { readEligible: () => [], dispatch });
+    expect(
+      readEventLog().some(
+        (e) => e.event === "phase.predecessor.reap-requested" && e.bg_job_id === "pre12345"
+      )
+    ).toBe(true);
+  });
+
+  test("reaps the finished predecessor when verify-dispatched check fails (rc=0, no live signal)", () => {
+    writeSignalRaw("CTL-6", "research", {
+      status: "done",
+      bg_job_id: "pre67890",
+      worktreePath: "/wt/CTL-6",
+    });
+    // rc=0 but dispatch does NOT write a signal → verifyDispatched returns !ok
+    const dispatch = () => ({ code: 0 });
+    schedulerTick(orchDir, { readEligible: () => [], dispatch });
+    expect(
+      readEventLog().some(
+        (e) => e.event === "phase.predecessor.reap-requested" && e.bg_job_id === "pre67890"
+      )
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-29T13:10:00Z -->
<!-- Last updated: 2026-05-29T13:10:00Z -->
<!-- PR: #1197 -->
<!-- Previous commits: 96f917c2 -->

## Summary

Closes the two reaper emission gaps CTL-657 left open — workers that exit in a terminal state (failed/stalled) with no successor dispatch, and the final `monitor-deploy` worker whose pipeline completion signals the end of all work. Adds a per-tick OTEL telemetry gauge (`reap stats`) so these transitions are observable from the otel-forward log pipeline going forward.

**Before:** ~8,936 `reap-requested` events recorded in production with only 498 `reap-complete` — a >17× gap. Workers that died in failed/stalled states, or completed monitor-deploy, accumulated as UNKNOWN sessions with no automatic cleanup.

**After:** Every terminal worker (failed, stalled, monitor-deploy done/skipped) emits `phase.terminal.reap-requested` on the next scheduler tick (once-per-phase marker prevents re-spam). The reaper's existing single-target busy-OK `_handleBgReap` path routes the new event type.

## Changes

### `reap-intent.mjs`
- Added `"phase.terminal.reap-requested"` as the 11th entry in `REAP_INTENT_TYPES` — covers the terminal-worker reap path that the happy-path predecessor reap (advance-success only) never reached.

### `reaper.mjs`
- Added a `case "phase.terminal.reap-requested":` fallthrough onto `_handleBgReap` — the single-target busy-OK path (same as predecessor/yield/supersede/revive/abort/reclaim).

### `scheduler.mjs`
- `emitTerminalWorkerReapOnce(orchDir, ticket, phase)` — new function. Writes a once-per-phase marker file before the `emitReapIntent` call (optimistic pre-write prevents re-spam even if the emit throws). Skips signals with no `bg_job_id`.
- Terminal-worker reap sweep added to `schedulerTick`: iterates all signal statuses per ticket; emits for `failed`, `stalled`, and `monitor-deploy done|skipped`. Excludes intermediate `done` phases — those are advancing and `emitPredecessorReap` owns their reap.
- `emitPredecessorReap` now also called on dispatch failure (rc!=0 or `verifyDispatched` !ok) — predecessor stays alive when its successor never comes up.
- `countReapOutcomes()` integrated at the end of each tick: emits a pino `info` line `"scheduler: reap stats"` with `{ staleSeen, staleReaped, reapFailures }` that otel-forward ships as a gauge.

### `reaper-metrics.mjs` (new)
- Incremental byte-cursor reader over the unified event log, scanning for reap-family events (`.reap-requested` / `.reap-complete` / `.reap-failed`).
- Mirrors `event-scan.mjs`'s `scanEventsChunked` + cursor pattern for bounded memory. Handles log rotation (cursor reset on size decrease).
- Exports `countReapOutcomes({ since?, path? })` returning `{ staleSeen, staleReaped, reapFailures }`.

### Tests
- `reap-intent.test.mjs`: updated count assertion (10→11); added acceptance test for `phase.terminal.reap-requested`.
- `reaper.test.mjs`: added routing test confirming `phase.terminal.reap-requested` reaches `_handleBgReap` and emits `phase.terminal.reap-complete`.
- `reaper-metrics.test.mjs` (new): 5 tests covering counts by family, OTLP-line exclusion, missing-log cold start, `since` filter, and incremental (byte-cursor) reads.
- `scheduler.test.mjs`: 7 new tests for the terminal-worker reap sweep (once-marker idempotency, no spurious emit on intermediate `done`, no emit when `bg_job_id` absent) + 2 tests for predecessor-reap-on-dispatch-failure.

## How to Verify

- [x] `bun test reaper.test.mjs reaper-metrics.test.mjs reap-intent.test.mjs` — 63 pass, 0 fail
- [x] `bun test scheduler.test.mjs --test-name-pattern "CTL-695"` — 7 pass, 0 fail
- [ ] In a running execution-core, let a phase worker die (failed signal). Confirm `phase.terminal.reap-requested` appears in `~/catalyst/events/YYYY-MM.jsonl` on the next scheduler tick.
- [ ] Confirm `claude agents` no longer accumulates UNKNOWN sessions for dead workers after several ticks.
- [ ] Check otel-forward log for `scheduler: reap stats` lines with non-zero `staleSeen`.

## Related

Fixes https://linear.app/coalesce-labs/issue/CTL-695

CTL-657 predecessor (existing reap infrastructure); CTL-661 (reclaim path hole #3 — same `_handleBgReap` fan-in).
