### PR TITLE
CTL-688: Rename bg phase-agent sessions to scannable TICKET PHASE format

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch-name.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch-name.test.sh
@@ -32,7 +32,8 @@ assert_jq() {
 	local label="$1" json="$2" filter="$3"
 	local got
 	got=$(printf '%s' "$json" | jq -r "$filter" 2>/dev/null)
-	if [ "$got" = "true" ] || [ -n "$got" ]; then
+	# Treat jq boolean false / null / empty output as failure.
+	if [ "$got" = "true" ] || ([ -n "$got" ] && [ "$got" != "false" ] && [ "$got" != "null" ]); then
 		PASSES=$((PASSES + 1))
 		echo "  PASS: $label"
 	else
@@ -43,9 +44,9 @@ assert_jq() {
 	fi
 }
 
-echo "phase-agent-dispatch --name / --attempt tests (CTL-649)"
+echo "phase-agent-dispatch --name / --attempt tests (CTL-688)"
 
-# ── 1. default attempt=1, name includes structured form ──────────────────────
+# ── 1. default attempt=1 → "<TICKET> <PHASE>" (no suffix) ────────────────────
 setup_orch_fixture "o-test-1" "CTL-999"
 OUT=$(dispatch_dry --phase triage --ticket CTL-999)
 RC=$?
@@ -55,10 +56,11 @@ if [ $RC -ne 0 ]; then
 	FAILURES=$((FAILURES + 1))
 else
 	assert_jq "default attempt is 1" "$OUT" '.attempt == 1 | tostring | test("true")'
-	assert_jq "sessionName uses structured shape" "$OUT" '.sessionName | test("^o-o-test-1:CTL-999:triage:1$")'
+	assert_jq "sessionName is '<TICKET> <PHASE>' with no suffix" "$OUT" \
+		'.sessionName | test("^CTL-999 triage$")'
 fi
 
-# ── 2. --attempt 3 threads into sessionName ──────────────────────────────────
+# ── 2. --attempt 3 → "<TICKET> <PHASE> #3" ───────────────────────────────────
 setup_orch_fixture "o-test-2" "CTL-999"
 OUT=$(dispatch_dry --phase triage --ticket CTL-999 --attempt 3)
 RC=$?
@@ -67,11 +69,12 @@ if [ $RC -ne 0 ]; then
 	echo "    output: $OUT"
 	FAILURES=$((FAILURES + 1))
 else
-	assert_jq "sessionName includes attempt=3 suffix" "$OUT" '.sessionName | test("o-test-2:CTL-999:triage:3$")'
+	assert_jq "sessionName appends ' #3' for attempt 3" "$OUT" \
+		'.sessionName | test("^CTL-999 triage #3$")'
 	assert_jq "attempt field is numeric 3" "$OUT" '.attempt == 3 | tostring | test("true")'
 fi
 
-# ── 3. invalid --attempt rejected ────────────────────────────────────────────
+# ── 3. invalid --attempt rejected (UNCHANGED) ─────────────────────────────────
 setup_orch_fixture "o-test-1" "CTL-999"
 if "$DISPATCH" --dry-run --phase triage --ticket CTL-999 --attempt "abc" >/dev/null 2>&1; then
 	echo "  FAIL: invalid --attempt should have been rejected"
@@ -81,7 +84,7 @@ else
 	echo "  PASS: invalid --attempt rejected"
 fi
 
-# ── 4. orch_id sourced from env when no --orch-id ────────────────────────────
+# ── 4. env-only orch_id path still dispatches; name no longer carries orch id ─
 setup_orch_fixture "o-env-only" "CTL-100"
 OUT=$(dispatch_dry --phase triage --ticket CTL-100)
 RC=$?
@@ -90,8 +93,8 @@ if [ $RC -ne 0 ]; then
 	echo "    output: $OUT"
 	FAILURES=$((FAILURES + 1))
 else
-	assert_jq "sessionName uses env CATALYST_ORCHESTRATOR_ID" "$OUT" \
-		'.sessionName | test("^o-o-env-only:CTL-100:triage:1$")'
+	assert_jq "sessionName is '<TICKET> <PHASE>' (orch id not in name)" "$OUT" \
+		'.sessionName | test("^CTL-100 triage$")'
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/cli/sessions.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.mjs
@@ -133,20 +133,23 @@ export function rssTotalForPid(snapshot, pid) {
 // ─── Pure: name parsing ──────────────────────────────────────────────────────
 
 /**
- * parseSessionName — decode the structured name Phase 1 stamps at dispatch:
- *   o-<orchId>:<ticket>:<phase>:<attempt>
- * orchId itself never contains a colon (it is hyphen-joined). Returns null for
- * a legacy prompt-derived name ("phase monitor merge") or empty input.
+ * parseSessionName — decode the scannable name CTL-688 stamps at dispatch:
+ *   <TICKET> <PHASE>        — attempt 1 (no suffix)
+ *   <TICKET> <PHASE> #<N>  — retry attempt N
+ * Under execution-core ORCH_ID == ticket (dispatch.mjs:59), so orchestratorId
+ * is derivable from the ticket token. Returns null for legacy colon-form names
+ * ("o-...:...:...:1") or prompt-derived names ("phase monitor merge").
  */
 export function parseSessionName(name) {
   if (!name) return null;
-  const parts = String(name).split(":");
-  if (parts.length !== 4) return null;
-  const [orchestratorId, ticket, phase, attemptRaw] = parts;
-  if (!orchestratorId.startsWith("o-")) return null;
-  const attempt = Number(attemptRaw);
-  if (!Number.isInteger(attempt)) return null;
-  return { orchestratorId, ticket, phase, attempt };
+  // Matches "<TICKET> <PHASE>" or "<TICKET> <PHASE> #<N>".
+  // Phase may be hyphenated (e.g. "monitor-merge"); ticket and phase are
+  // single whitespace-delimited tokens; the " #<N>" suffix is optional.
+  const m = String(name).match(/^(\S+)\s+(\S+)(?:\s+#(\d+))?$/);
+  if (!m) return null;
+  const [, ticket, phase, attemptRaw] = m;
+  const attempt = attemptRaw ? Number(attemptRaw) : 1;
+  return { orchestratorId: ticket, ticket, phase, attempt };
 }
 
 // ─── I/O: signal index ───────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
@@ -129,17 +129,35 @@ describe("RSS attribution (single ps snapshot, ancestor walk)", () => {
   });
 });
 
-describe("parseSessionName (structured --name from Phase 1)", () => {
-  it("parses o-<orchId>:<ticket>:<phase>:<attempt>", () => {
-    expect(parseSessionName("o-adv-1103-1088:CTL-649:implement:1")).toEqual({
-      orchestratorId: "o-adv-1103-1088",
+describe("parseSessionName (scannable --name from CTL-688)", () => {
+  it("parses '<TICKET> <PHASE>' with default attempt 1", () => {
+    expect(parseSessionName("CTL-649 implement")).toEqual({
+      orchestratorId: "CTL-649",
       ticket: "CTL-649",
       phase: "implement",
       attempt: 1,
     });
   });
 
-  it("returns null for a legacy prompt-derived name", () => {
+  it("parses the '#<N>' retry suffix", () => {
+    expect(parseSessionName("ADV-1034 plan #2")).toEqual({
+      orchestratorId: "ADV-1034",
+      ticket: "ADV-1034",
+      phase: "plan",
+      attempt: 2,
+    });
+  });
+
+  it("parses a hyphenated phase name", () => {
+    expect(parseSessionName("CTL-1 monitor-merge")).toMatchObject({
+      ticket: "CTL-1",
+      phase: "monitor-merge",
+      attempt: 1,
+    });
+  });
+
+  it("returns null for a legacy colon/prompt-derived name", () => {
+    expect(parseSessionName("o-adv-1103-1088:CTL-649:implement:1")).toBeNull();
     expect(parseSessionName("phase monitor merge")).toBeNull();
   });
 
@@ -157,7 +175,7 @@ describe("buildRows (joins agents + worker signals + rss, injected deps)", () =>
       kind: "background",
       startedAt: 1000,
       sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd",
-      name: "o-test:CTL-1:implement:1",
+      name: "CTL-1 implement",
       status: "idle",
     },
   ];

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -565,12 +565,16 @@ DISPATCH_ENV=(
 [[ -n $OTEL_RES_ATTRS ]] &&
 	DISPATCH_ENV+=("OTEL_RESOURCE_ATTRIBUTES=${OTEL_RES_ATTRS}")
 
-# CTL-649: structured session name. `claude --name` is in dispatch.respawnFlags
-# (verified empirically) so it survives daemon restart. The structured form
-# (`o-<orchId>:<ticket>:<phase>:<attempt>`) is what the new
-# `catalyst-execution-core sessions list` joins on; before this, the daemon
-# roster surfaces prompt-derived auto-names that operators can't grep.
-SESSION_NAME="o-${ORCH_ID}:${TICKET}:${PHASE}:${ATTEMPT}"
+# CTL-688: scannable session name. `claude --name` is in dispatch.respawnFlags
+# (verified empirically) so it survives daemon restart. Format:
+#   <TICKET> <PHASE>        — default (attempt 1)
+#   <TICKET> <PHASE> #<N>  — retries (attempt > 1)
+# Short and grep-able; no redundant orch-id prefix (under execution-core
+# ORCH_ID == ticket, so the old `o-<orchId>:<ticket>:...` repeated the ticket).
+SESSION_NAME="${TICKET} ${PHASE}"
+if [[ "${ATTEMPT}" -gt 1 ]]; then
+	SESSION_NAME="${SESSION_NAME} #${ATTEMPT}"
+fi
 
 if [[ $DRY_RUN -eq 1 ]]; then
 	# Dry-run prints the command it would have run without spawning anything.


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-29T13:36:00Z -->
<!-- Last updated: 2026-05-29T13:36:00Z -->
<!-- PR: #1199 -->
<!-- Previous commits: 261bc42857abdfe81f81a4284aca7419f58362e5 -->

## Summary

Renames phase-agent bg session names from the verbose `o-<orchId>:<ticket>:<phase>:<attempt>` format to the short, scannable `<TICKET> <PHASE>` (e.g. `ADV-1034 plan`, `CTL-678 implement`). Under execution-core, `ORCH_ID == ticket`, so the old format redundantly repeated the ticket twice with a dead `o-` prefix from the legacy oneshot model. The new format eliminates that noise and makes sessions greppable at a glance in `claude agents`, the HUD, and any other surface that surfaces `--name`.

Retry attempts append a ` #<N>` suffix (e.g. `CTL-688 implement #2`) so re-dispatched workers remain uniquely named without cluttering first-attempt names.

## Changes Made

### `plugins/dev/scripts/phase-agent-dispatch`

- **SESSION_NAME assembly** (line ~565): replaced `o-${ORCH_ID}:${TICKET}:${PHASE}:${ATTEMPT}` with `${TICKET} ${PHASE}`, conditionally appending ` #${ATTEMPT}` only when `ATTEMPT > 1`.

### `plugins/dev/scripts/execution-core/cli/sessions.mjs`

- **`parseSessionName`**: rewrote from colon-split logic (expected `o-<orchId>:<ticket>:<phase>:<attempt>`) to a space-delimited regex (`/^(\S+)\s+(\S+)(?:\s+#(\d+))?$/`). Legacy colon-form names now return `null` (correctly treated as unknown). `orchestratorId` is set equal to `ticket` since ORCH_ID == ticket under execution-core.

### `plugins/dev/scripts/execution-core/cli/sessions.test.mjs`

- Updated `parseSessionName` unit tests to cover the new format: `"CTL-649 implement"`, `"ADV-1034 plan #2"`, `"CTL-1 monitor-merge"` (hyphenated phase names). Added explicit `null` assertion for the legacy colon form.
- Updated `buildRows` fixture to use new name format.

### `plugins/dev/scripts/__tests__/phase-agent-dispatch-name.test.sh`

- Updated all `sessionName` assertions from `^o-<orchId>:<ticket>:<phase>:1$` to `^<TICKET> <PHASE>$` / `^<TICKET> <PHASE> #3$`.
- Fixed `assert_jq` helper: previous check `[ -n "$got" ]` passed on jq-output `"false"` and `"null"` (non-empty strings); now explicitly excludes those values.

## How to Verify It

- [x] Bash dispatch-name test: `bash plugins/dev/scripts/__tests__/phase-agent-dispatch-name.test.sh` — 6/6 pass
- [x] Bun sessions unit test: `bun test plugins/dev/scripts/execution-core/cli/sessions.test.mjs` — all new CTL-688 cases pass; 66 pass / 1 pre-existing unrelated failure
- [x] `parseSessionName("CTL-649 implement")` → `{ orchestratorId: "CTL-649", ticket: "CTL-649", phase: "implement", attempt: 1 }`
- [x] `parseSessionName("ADV-1034 plan #2")` → `{ ..., attempt: 2 }`
- [x] `parseSessionName("o-adv-1103-1088:CTL-649:implement:1")` → `null` (legacy form rejected)
- [ ] Observe `claude agents` showing `CTL-<N> <phase>` for any new dispatch after merge (manual, requires a live dispatch)

## Migration Note

Any monitoring script, grep pattern, or alerting rule built on the `o-` prefix or the `<orch>:<ticket>:<phase>:<attempt>` colon format will no longer match new dispatches after merge. Existing live sessions (dispatched before the merge) keep their old names — the daemon tracks workers by UUID, not name, so they continue to be reaped normally. Only new dispatches from `phase-agent-dispatch` produce the new format.

## Pre-merge Verification (from verify phase)

- **Regression risk**: 0 / 10
- **Tests (bash)**: pass — phase-agent-dispatch-name.test.sh 6/6
- **Tests (bun)**: pass — 66 pass / 1 pre-existing unrelated failure (classifyRow terminal-status, byte-identical on origin/main)
- **Typecheck**: skip — no TypeScript in diff
- **Lint**: skip — no configured lint gate on plugins/dev/**
- **Security**: pass — no dependency, secret, network, or auth surface changes
- **Code review**: pass — regex correct across all name forms
- **Coverage**: pass — both production sites have direct unit tests

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-688
