### PR TITLE
CTL-684: Auto-tune maxParallel from system load + memory trends

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -56,7 +56,7 @@
       "executionCore": {
         "maxParallel": 4,
         "minParallel": 1,
-        "maxParallelCeiling": 10,
+        "maxParallelCeiling": 40,
         "eligibleQuery": {
           "status": "Todo",
           "team": null,

--- a/plugins/dev/scripts/execution-core/autotune-decision.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-decision.test.mjs
@@ -1,0 +1,315 @@
+// autotune-decision.test.mjs — Phase 1 TDD for the pure auto-tuner decision core
+// (CTL-684). All functions are seam-injected; no timers, fs, or real system load.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test autotune-decision.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  sampleSystem,
+  pushSample,
+  detectTrend,
+  memGuard,
+  decideMaxParallel,
+} from "./autotune.mjs";
+
+// --- sampleSystem -----------------------------------------------------------
+
+describe("sampleSystem", () => {
+  test("returns load1/load5/load15 from injected loadavg seam", () => {
+    const s = sampleSystem({
+      loadavg: () => [8, 4, 2],
+      freemem: () => 2e9,
+      totalmem: () => 10e9,
+      cpus: () => Array(12),
+    });
+    expect(s.load1).toBe(8);
+    expect(s.load5).toBe(4);
+    expect(s.load15).toBe(2);
+  });
+
+  test("computes memFreePct from freemem/totalmem", () => {
+    const s = sampleSystem({
+      loadavg: () => [0, 0, 0],
+      freemem: () => 2e9,
+      totalmem: () => 10e9,
+      cpus: () => Array(4),
+    });
+    expect(s.memFreePct).toBe(20);
+  });
+
+  test("computes coreCount from cpus array length", () => {
+    const s = sampleSystem({
+      loadavg: () => [0, 0, 0],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(12),
+    });
+    expect(s.coreCount).toBe(12);
+  });
+
+  test("rounds memFreePct to one decimal place", () => {
+    const s = sampleSystem({
+      loadavg: () => [0, 0, 0],
+      freemem: () => 1e9,
+      totalmem: () => 3e9,
+      cpus: () => Array(4),
+    });
+    expect(s.memFreePct).toBeCloseTo(33.3, 1);
+  });
+});
+
+// --- pushSample -------------------------------------------------------------
+
+describe("pushSample", () => {
+  test("appends a sample to the window", () => {
+    const w = pushSample([], { load1: 1, load5: 2, load15: 3, memFreePct: 50, coreCount: 4 }, 10);
+    expect(w).toHaveLength(1);
+    expect(w[0].load1).toBe(1);
+  });
+
+  test("trims to maxSamples (FIFO — oldest dropped)", () => {
+    let w = [];
+    for (let i = 0; i < 12; i++) {
+      w = pushSample(w, { load1: i, load5: 0, load15: 0, memFreePct: 50, coreCount: 4 }, 10);
+    }
+    expect(w).toHaveLength(10);
+    expect(w[0].load1).toBe(2); // oldest surviving = index 2
+    expect(w[9].load1).toBe(11);
+  });
+
+  test("never mutates the input array", () => {
+    const orig = [{ load1: 1, load5: 1, load15: 1, memFreePct: 50, coreCount: 4 }];
+    const frozen = Object.freeze([...orig]);
+    const w = pushSample(frozen, { load1: 2, load5: 2, load15: 2, memFreePct: 50, coreCount: 4 }, 10);
+    expect(w).not.toBe(frozen);
+    expect(frozen).toHaveLength(1);
+  });
+
+  test("length never exceeds maxSamples", () => {
+    let w = [];
+    for (let i = 0; i < 100; i++) {
+      w = pushSample(w, { load1: i, load5: 0, load15: 0, memFreePct: 50, coreCount: 4 }, 5);
+    }
+    expect(w).toHaveLength(5);
+  });
+});
+
+// --- detectTrend ------------------------------------------------------------
+
+describe("detectTrend", () => {
+  const minSamples = 3;
+  const coreCount = 4;
+  const loadSafeFactor = 2;
+
+  function makeWindow(triples) {
+    return triples.map(([load1, load5, load15]) => ({
+      load1,
+      load5,
+      load15,
+      memFreePct: 50,
+      coreCount,
+    }));
+  }
+
+  test("returns 'up' when last minSamples all have load1 > load5 > load15", () => {
+    const w = makeWindow([
+      [10, 8, 6],
+      [12, 9, 7],
+      [15, 11, 8],
+    ]);
+    expect(detectTrend(w, { minSamples, coreCount, loadSafeFactor })).toBe("up");
+  });
+
+  test("returns 'down' when last minSamples have load1 < load5 < load15 AND load1 < cores×factor", () => {
+    const w = makeWindow([
+      [2, 4, 6],
+      [1, 3, 5],
+      [1, 2, 4],
+    ]);
+    expect(detectTrend(w, { minSamples, coreCount, loadSafeFactor })).toBe("down");
+  });
+
+  test("down suppressed when load1 >= cores×factor even if strictly ordered", () => {
+    // cores=4, factor=2 → threshold = 8; load1=9 → not safe
+    const w = makeWindow([
+      [9, 11, 13],
+      [9, 10, 12],
+      [9, 10, 11],
+    ]);
+    expect(detectTrend(w, { minSamples, coreCount, loadSafeFactor })).toBe("none");
+  });
+
+  test("returns 'flat-high' when load1 and load5 both exceed cores×factor but no trend", () => {
+    const threshold = coreCount * loadSafeFactor; // 8
+    const w = makeWindow([
+      [threshold + 1, threshold + 1, threshold - 1],
+      [threshold + 2, threshold + 1, threshold + 3],
+      [threshold + 1, threshold + 2, threshold],
+    ]);
+    expect(detectTrend(w, { minSamples, coreCount, loadSafeFactor })).toBe("flat-high");
+  });
+
+  test("returns 'none' when fewer than minSamples exist", () => {
+    const w = makeWindow([[10, 8, 6], [12, 9, 7]]);
+    expect(detectTrend(w, { minSamples, coreCount, loadSafeFactor })).toBe("none");
+  });
+
+  test("returns 'none' when pattern is mixed (not consistently up or down)", () => {
+    const w = makeWindow([
+      [10, 8, 6],
+      [5, 7, 9],
+      [10, 8, 6],
+    ]);
+    expect(detectTrend(w, { minSamples, coreCount, loadSafeFactor })).toBe("none");
+  });
+
+  test("up uses only the last minSamples (ignores older contrary entries)", () => {
+    const w = makeWindow([
+      [2, 4, 6], // old — would be 'down'
+      [10, 8, 6],
+      [12, 9, 7],
+      [15, 11, 8],
+    ]);
+    // With minSamples=3, only the last 3 matter → all up
+    expect(detectTrend(w, { minSamples, coreCount, loadSafeFactor })).toBe("up");
+  });
+});
+
+// --- memGuard ---------------------------------------------------------------
+
+describe("memGuard", () => {
+  const criticalPct = 5;
+  const warnPct = 20;
+
+  test("returns 'critical' when memFreePct < criticalPct", () => {
+    expect(memGuard(3, { criticalPct, warnPct })).toBe("critical");
+  });
+
+  test("returns 'warn' when criticalPct <= memFreePct < warnPct", () => {
+    expect(memGuard(10, { criticalPct, warnPct })).toBe("warn");
+  });
+
+  test("returns 'ok' when memFreePct >= warnPct", () => {
+    expect(memGuard(20, { criticalPct, warnPct })).toBe("ok");
+    expect(memGuard(50, { criticalPct, warnPct })).toBe("ok");
+  });
+
+  test("boundary: criticalPct exactly → warn (not critical)", () => {
+    expect(memGuard(5, { criticalPct, warnPct })).toBe("warn");
+  });
+
+  test("boundary: warnPct exactly → ok (not warn)", () => {
+    expect(memGuard(20, { criticalPct, warnPct })).toBe("ok");
+  });
+});
+
+// --- decideMaxParallel ------------------------------------------------------
+
+describe("decideMaxParallel", () => {
+  const base = {
+    minSamples: 3,
+    loadSafeFactor: 2,
+    criticalPct: 5,
+    warnPct: 20,
+  };
+  const concurrency = { maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 };
+
+  function makeWindow(triples, memPct = 50) {
+    return triples.map(([load1, load5, load15]) => ({
+      load1,
+      load5,
+      load15,
+      memFreePct: memPct,
+      coreCount: 4,
+    }));
+  }
+
+  test("mem-critical overrides any trend → drop to minParallel", () => {
+    const w = makeWindow([[1, 2, 4]], 2); // 2% free < 5% critical
+    const result = decideMaxParallel({ window: w, concurrency, ...base });
+    expect(result.next).toBe(2);
+    expect(result.reason).toBe("mem-critical");
+  });
+
+  test("trend-up → floor(current * 0.75)", () => {
+    const w = makeWindow([[10, 8, 6], [12, 9, 7], [15, 11, 8]]);
+    const result = decideMaxParallel({ window: w, concurrency, ...base });
+    expect(result.next).toBe(Math.floor(10 * 0.75)); // 7
+    expect(result.reason).toBe("trend-up");
+  });
+
+  test("trend-up shrink never below minParallel", () => {
+    const tightConcurrency = { maxParallel: 2, minParallel: 2, maxParallelCeiling: 20 };
+    const w = makeWindow([[10, 8, 6], [12, 9, 7], [15, 11, 8]]);
+    const result = decideMaxParallel({ window: w, concurrency: tightConcurrency, ...base });
+    expect(result.next).toBe(2); // floor(2 * 0.75) = 1 → clamped to 2
+    expect(result.reason).toBe("trend-up");
+  });
+
+  test("trend-down AND mem ok → current + 1", () => {
+    const w = makeWindow([[2, 4, 6], [1, 3, 5], [1, 2, 4]], 50);
+    const result = decideMaxParallel({ window: w, concurrency, ...base });
+    expect(result.next).toBe(11);
+    expect(result.reason).toBe("trend-down");
+  });
+
+  test("trend-down AND mem warn → hold (growth suppressed)", () => {
+    const w = makeWindow([[2, 4, 6], [1, 3, 5], [1, 2, 4]], 10); // 10% free — warn range
+    const result = decideMaxParallel({ window: w, concurrency, ...base });
+    expect(result.next).toBe(10);
+    expect(result.reason).toBe("mem-warn");
+  });
+
+  test("flat-high → hold", () => {
+    const threshold = 4 * 2; // 8
+    const w = makeWindow([
+      [threshold + 1, threshold + 1, threshold - 1],
+      [threshold + 2, threshold + 1, threshold + 3],
+      [threshold + 1, threshold + 2, threshold],
+    ]);
+    const result = decideMaxParallel({ window: w, concurrency, ...base });
+    expect(result.next).toBe(10);
+    expect(result.reason).toBe("flat-high");
+  });
+
+  test("< minSamples → insufficient-samples, hold", () => {
+    const w = makeWindow([[2, 4, 6]]);
+    const result = decideMaxParallel({ window: w, concurrency, ...base });
+    expect(result.next).toBe(10);
+    expect(result.reason).toBe("insufficient-samples");
+  });
+
+  test("empty window → insufficient-samples, hold", () => {
+    const result = decideMaxParallel({ window: [], concurrency, ...base });
+    expect(result.next).toBe(10);
+    expect(result.reason).toBe("insufficient-samples");
+  });
+
+  test("otherwise (hold) when no pattern matches", () => {
+    const w = makeWindow([[5, 5, 5], [5, 5, 5], [5, 5, 5]], 50);
+    const result = decideMaxParallel({ window: w, concurrency, ...base });
+    expect(result.next).toBe(10);
+    expect(result.reason).toBe("hold");
+  });
+
+  test("trend-down growth never above maxParallelCeiling", () => {
+    const atCeiling = { maxParallel: 20, minParallel: 2, maxParallelCeiling: 20 };
+    const w = makeWindow([[2, 4, 6], [1, 3, 5], [1, 2, 4]], 50);
+    const result = decideMaxParallel({ window: w, concurrency: atCeiling, ...base });
+    expect(result.next).toBe(20); // already at ceiling → clamped
+    expect(result.reason).toBe("trend-down");
+  });
+
+  test("every branch result is within [minParallel, maxParallelCeiling]", () => {
+    const cases = [
+      { w: makeWindow([[1, 2, 4]], 2), label: "mem-critical" },
+      { w: makeWindow([[10, 8, 6], [12, 9, 7], [15, 11, 8]]), label: "trend-up" },
+      { w: makeWindow([[2, 4, 6], [1, 3, 5], [1, 2, 4]], 50), label: "trend-down" },
+    ];
+    for (const { w, label } of cases) {
+      const { next } = decideMaxParallel({ window: w, concurrency, ...base });
+      expect(next).toBeGreaterThanOrEqual(concurrency.minParallel);
+      expect(next).toBeLessThanOrEqual(concurrency.maxParallelCeiling);
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
@@ -1,0 +1,229 @@
+// autotune-lifecycle.test.mjs — Phase 3 TDD for the side-car lifecycle (CTL-684).
+// Run: cd plugins/dev/scripts/execution-core && bun test autotune-lifecycle.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  autoTuneTick,
+  startAutoTuner,
+  stopAutoTuner,
+} from "./autotune.mjs";
+
+// --- autoTuneTick -----------------------------------------------------------
+
+describe("autoTuneTick", () => {
+  function makeState(overrides = {}) {
+    return {
+      window: [],
+      windowSamples: 10,
+      trendMinSamples: 3,
+      loadSafeFactor: 4,
+      criticalPct: 5,
+      warnPct: 20,
+      ...overrides,
+    };
+  }
+
+  function makeSeams(overrides = {}) {
+    return {
+      liveBackgroundCount: () => 2,
+      loadavg: () => [1, 2, 3],
+      freemem: () => 8e9,
+      totalmem: () => 10e9,
+      cpus: () => Array(4),
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      writeLayer2: () => true,
+      appendSampledEvent: () => true,
+      appendAdjustedEvent: () => true,
+      ...overrides,
+    };
+  }
+
+  test("when liveBackgroundCount() === 0 → no sampled event, no write, window reset", () => {
+    const state = makeState({ window: [{ load1: 1, load5: 2, load15: 3, memFreePct: 50, coreCount: 4 }] });
+    const sampledCalls = [];
+    const writeCalls = [];
+    const seams = makeSeams({
+      liveBackgroundCount: () => 0,
+      appendSampledEvent: (args) => { sampledCalls.push(args); return true; },
+      writeLayer2: (v) => { writeCalls.push(v); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(sampledCalls).toHaveLength(0);
+    expect(writeCalls).toHaveLength(0);
+    expect(state.window).toHaveLength(0); // reset
+  });
+
+  test("when active → exactly one appendSampledEvent with correct fields", () => {
+    const state = makeState();
+    const sampledCalls = [];
+    const seams = makeSeams({
+      liveBackgroundCount: () => 3,
+      loadavg: () => [2.5, 3.0, 3.5],
+      freemem: () => 5e9,
+      totalmem: () => 10e9,
+      cpus: () => Array(8),
+      readConcurrency: () => ({ maxParallel: 12, minParallel: 2, maxParallelCeiling: 20 }),
+      appendSampledEvent: (args) => { sampledCalls.push(args); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(sampledCalls).toHaveLength(1);
+    const call = sampledCalls[0];
+    expect(call.load1).toBe(2.5);
+    expect(call.load5).toBe(3.0);
+    expect(call.load15).toBe(3.5);
+    expect(call.bgCount).toBe(3);
+    expect(call.maxParallelCurrent).toBe(12);
+  });
+
+  test("when active → state.window grows (trimmed to windowSamples)", () => {
+    const state = makeState({ windowSamples: 3, window: [] });
+    const seams = makeSeams();
+    autoTuneTick(state, seams);
+    expect(state.window).toHaveLength(1);
+    autoTuneTick(state, seams);
+    autoTuneTick(state, seams);
+    autoTuneTick(state, seams);
+    expect(state.window).toHaveLength(3); // trimmed
+  });
+
+  test("when decide returns next !== current → exactly one writeLayer2 AND one appendAdjustedEvent", () => {
+    // Seed 2 up-trend samples; the seam provides a 3rd completing the trend.
+    const upSamples = [
+      { load1: 10, load5: 8, load15: 6, memFreePct: 50, coreCount: 4 },
+      { load1: 12, load5: 9, load15: 7, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: upSamples });
+    const writeCalls = [];
+    const adjustedCalls = [];
+    const seams = makeSeams({
+      loadavg: () => [15, 11, 8], // 3rd up-trend sample — completes minSamples=3
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      writeLayer2: (v) => { writeCalls.push(v); return true; },
+      appendAdjustedEvent: (args) => { adjustedCalls.push(args); return true; },
+    });
+    autoTuneTick(state, seams);
+    // trend-up → next = floor(10 * 0.75) = 7 ≠ 10
+    expect(writeCalls).toHaveLength(1);
+    expect(writeCalls[0]).toBe(7);
+    expect(adjustedCalls).toHaveLength(1);
+    expect(adjustedCalls[0].oldMaxParallel).toBe(10);
+    expect(adjustedCalls[0].newMaxParallel).toBe(7);
+    expect(adjustedCalls[0].reason).toBe("trend-up");
+  });
+
+  test("when next === current → no writeLayer2, no appendAdjustedEvent", () => {
+    // Only 1 sample → insufficient-samples → hold
+    const state = makeState({ window: [{ load1: 5, load5: 5, load15: 5, memFreePct: 50, coreCount: 4 }] });
+    const writeCalls = [];
+    const adjustedCalls = [];
+    const seams = makeSeams({
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      writeLayer2: (v) => { writeCalls.push(v); return true; },
+      appendAdjustedEvent: (args) => { adjustedCalls.push(args); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(writeCalls).toHaveLength(0);
+    expect(adjustedCalls).toHaveLength(0);
+  });
+
+  test("a throwing writeLayer2 does not propagate out of autoTuneTick", () => {
+    const upSamples = [
+      { load1: 10, load5: 8, load15: 6, memFreePct: 50, coreCount: 4 },
+      { load1: 12, load5: 9, load15: 7, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: upSamples });
+    const seams = makeSeams({
+      loadavg: () => [15, 11, 8], // completes trend-up
+      readConcurrency: () => ({ maxParallel: 10, minParallel: 2, maxParallelCeiling: 20 }),
+      writeLayer2: () => { throw new Error("disk full"); },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+  });
+
+  test("a throwing appendSampledEvent does not propagate out of autoTuneTick", () => {
+    const state = makeState();
+    const seams = makeSeams({
+      appendSampledEvent: () => { throw new Error("io error"); },
+    });
+    expect(() => autoTuneTick(state, seams)).not.toThrow();
+  });
+});
+
+// --- startAutoTuner / stopAutoTuner lifecycle --------------------------------
+
+describe("startAutoTuner / stopAutoTuner", () => {
+  test("startAutoTuner calls setIntervalFn once with the configured interval and returns a stop handle", () => {
+    const intervals = [];
+    const setIntervalFn = (fn, ms) => { intervals.push(ms); return "timer-handle"; };
+    const clearIntervalFn = () => {};
+    const stop = startAutoTuner({
+      configPath: null,
+      layer2Path: null,
+      enabled: true,
+      sampleIntervalMs: 5000,
+      setIntervalFn,
+      clearIntervalFn,
+    });
+    expect(intervals).toHaveLength(1);
+    expect(intervals[0]).toBe(5000);
+    expect(typeof stop).toBe("function");
+    stop({ clearIntervalFn });
+  });
+
+  test("stopAutoTuner calls clearIntervalFn with the stored handle", () => {
+    const cleared = [];
+    const setIntervalFn = (fn, ms) => "my-timer";
+    const clearIntervalFn = (h) => cleared.push(h);
+    startAutoTuner({
+      configPath: null,
+      layer2Path: null,
+      enabled: true,
+      sampleIntervalMs: 1000,
+      setIntervalFn,
+      clearIntervalFn,
+    });
+    stopAutoTuner({ clearIntervalFn });
+    expect(cleared).toContain("my-timer");
+  });
+
+  test("stopAutoTuner is idempotent (safe to call twice)", () => {
+    const cleared = [];
+    const setIntervalFn = () => "t2";
+    const clearIntervalFn = (h) => cleared.push(h);
+    startAutoTuner({
+      configPath: null, layer2Path: null, enabled: true, sampleIntervalMs: 1000,
+      setIntervalFn, clearIntervalFn,
+    });
+    stopAutoTuner({ clearIntervalFn });
+    stopAutoTuner({ clearIntervalFn }); // second call should not throw
+    expect(cleared).toHaveLength(1); // only one real clear
+  });
+
+  test("stopAutoTuner before start does not throw", () => {
+    expect(() => stopAutoTuner({ clearIntervalFn: () => {} })).not.toThrow();
+  });
+
+  test("when EXECUTION_CORE_AUTOTUNE disabled → setIntervalFn is NOT called", () => {
+    const intervals = [];
+    const setIntervalFn = () => { intervals.push(true); return "t"; };
+    startAutoTuner({
+      configPath: null, layer2Path: null,
+      enabled: false,
+      sampleIntervalMs: 1000,
+      setIntervalFn,
+      clearIntervalFn: () => {},
+    });
+    expect(intervals).toHaveLength(0);
+  });
+
+  test("when disabled → returned stop handle is a no-op (does not throw)", () => {
+    const stop = startAutoTuner({
+      configPath: null, layer2Path: null,
+      enabled: false,
+      sampleIntervalMs: 1000,
+      setIntervalFn: () => "t",
+      clearIntervalFn: () => {},
+    });
+    expect(() => stop()).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
@@ -1,0 +1,93 @@
+// autotune-writeback.test.mjs — Phase 2 TDD for Layer-2 write-back (CTL-684).
+// Run: cd plugins/dev/scripts/execution-core && bun test autotune-writeback.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeLayer2MaxParallel } from "./autotune.mjs";
+
+let dir;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "autotune-writeback-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("writeLayer2MaxParallel", () => {
+  test("writes maxParallel into the nested path in an existing file", () => {
+    const p = join(dir, "config.json");
+    writeFileSync(p, JSON.stringify({
+      catalyst: { orchestration: { executionCore: { maxParallel: 5 } } },
+    }));
+    const ok = writeLayer2MaxParallel(p, 10);
+    expect(ok).toBe(true);
+    const out = JSON.parse(readFileSync(p, "utf8"));
+    expect(out.catalyst.orchestration.executionCore.maxParallel).toBe(10);
+  });
+
+  test("preserves sibling keys at every nesting level", () => {
+    const p = join(dir, "config.json");
+    writeFileSync(p, JSON.stringify({
+      catalyst: {
+        orchestration: {
+          eligibleQuery: { status: ["Ready"] },
+          executionCore: { maxParallel: 3, minParallel: 1 },
+        },
+      },
+      anotherTopKey: "preserved",
+    }, null, 2));
+    writeLayer2MaxParallel(p, 7);
+    const out = JSON.parse(readFileSync(p, "utf8"));
+    expect(out.catalyst.orchestration.executionCore.maxParallel).toBe(7);
+    expect(out.catalyst.orchestration.executionCore.minParallel).toBe(1);
+    expect(out.catalyst.orchestration.eligibleQuery.status).toEqual(["Ready"]);
+    expect(out.anotherTopKey).toBe("preserved");
+  });
+
+  test("creates the full nested path when file does not exist", () => {
+    const p = join(dir, "new-config.json");
+    const ok = writeLayer2MaxParallel(p, 12);
+    expect(ok).toBe(true);
+    const out = JSON.parse(readFileSync(p, "utf8"));
+    expect(out.catalyst.orchestration.executionCore.maxParallel).toBe(12);
+  });
+
+  test("does not throw and does not clobber on malformed JSON", () => {
+    const p = join(dir, "bad.json");
+    writeFileSync(p, "{ not valid json }{{{");
+    const ok = writeLayer2MaxParallel(p, 5);
+    expect(ok).toBe(false);
+    // file should be unchanged (still malformed)
+    const content = readFileSync(p, "utf8");
+    expect(content).toBe("{ not valid json }{{{");
+  });
+
+  test("write is atomic — no .tmp residue on success", () => {
+    const p = join(dir, "config.json");
+    const ok = writeLayer2MaxParallel(p, 8);
+    expect(ok).toBe(true);
+    // No .tmp file should remain
+    const files = require("node:fs").readdirSync(dir);
+    const hasTmp = files.some((f) => f.includes(".tmp."));
+    expect(hasTmp).toBe(false);
+  });
+
+  test("uses injected readFileSync / writeFileSync / renameSync seams", () => {
+    const reads = [];
+    const writes = [];
+    const renames = [];
+    const p = join(dir, "config.json");
+    writeLayer2MaxParallel(p, 6, {
+      readFileSync: (path, enc) => { reads.push(path); throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); },
+      writeFileSync: (path, data) => { writes.push(path); writeFileSync(path, data); },
+      renameSync: (src, dst) => { renames.push([src, dst]); require("node:fs").renameSync(src, dst); },
+    });
+    expect(reads).toHaveLength(1);
+    expect(writes).toHaveLength(1);
+    expect(renames).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -1,0 +1,325 @@
+// autotune.mjs — side-car auto-tuner for maxParallel (CTL-684).
+// Samples host pressure (loadavg + freemem) on a cadence, applies a
+// trend-based decision rule, and writes the adjusted value into Layer-2
+// config so the scheduler's existing hot-reload picks it up next tick.
+//
+// All OS calls, timers, and I/O are injectable seams so the decision core
+// and lifecycle are deterministically testable without real load or timers.
+
+import {
+  loadavg as osLoadavg,
+  freemem as osFreemem,
+  totalmem as osTotalmem,
+  cpus as osCpus,
+} from "node:os";
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { clampToBounds } from "./scheduler.mjs";
+import {
+  readExecutionCoreConcurrency,
+  readExecutionCoreConcurrencyLayer2,
+  mergeExecutionCoreConcurrency,
+} from "./scheduler.mjs";
+import { countBackgroundAgents } from "./claude-agents.mjs";
+import {
+  defaultAppendParallelismSampledEvent,
+  defaultAppendParallelismAdjustedEvent,
+} from "./recovery.mjs";
+import {
+  AUTOTUNE_SAMPLE_INTERVAL_MS,
+  AUTOTUNE_WINDOW_SAMPLES,
+  AUTOTUNE_TREND_MIN_SAMPLES,
+  AUTOTUNE_LOAD_SAFE_FACTOR,
+  AUTOTUNE_MEM_CRITICAL_PCT,
+  AUTOTUNE_MEM_WARN_PCT,
+  AUTOTUNE_ENABLED,
+  log,
+} from "./config.mjs";
+
+// --- Pure decision helpers --------------------------------------------------
+
+// sampleSystem — capture current load + memory snapshot from seam-injected OS
+// functions. Returns {load1, load5, load15, memFreePct, coreCount}.
+export function sampleSystem({
+  loadavg = osLoadavg,
+  freemem = osFreemem,
+  totalmem = osTotalmem,
+  cpus = osCpus,
+} = {}) {
+  const [load1, load5, load15] = loadavg();
+  const free = freemem();
+  const total = totalmem();
+  const memFreePct = Math.round((free / total) * 1000) / 10;
+  const coreCount = cpus().length;
+  return { load1, load5, load15, memFreePct, coreCount };
+}
+
+// pushSample — append a sample to the rolling window, trimming to maxSamples.
+// Never mutates the input array. Returns a new array.
+export function pushSample(window, sample, maxSamples) {
+  const next = [...window, sample];
+  if (next.length > maxSamples) return next.slice(next.length - maxSamples);
+  return next;
+}
+
+// strictlyOrdered — check if `a > b > c` (dir="up") or `a < b < c` (dir="down").
+function strictlyOrdered(sample, dir) {
+  const { load1, load5, load15 } = sample;
+  if (dir === "up") return load1 > load5 && load5 > load15;
+  return load1 < load5 && load5 < load15;
+}
+
+// detectTrend — classify the rolling window's load trend.
+// Returns "up" | "down" | "flat-high" | "none".
+export function detectTrend(window, { minSamples, coreCount, loadSafeFactor }) {
+  if (window.length < minSamples) return "none";
+  const tail = window.slice(-minSamples);
+  const threshold = coreCount * loadSafeFactor;
+
+  const allUp = tail.every((s) => strictlyOrdered(s, "up"));
+  if (allUp) return "up";
+
+  const allDown = tail.every((s) => strictlyOrdered(s, "down"));
+  const latestSafe = tail[tail.length - 1].load1 < threshold;
+  if (allDown && latestSafe) return "down";
+
+  // flat-high only when there is no directional trend — if the window shows a
+  // systematic pattern (allDown) that is merely suppressed by load, that is
+  // "none", not "flat-high" (no actionable decision either way).
+  if (!allUp && !allDown) {
+    const latest = tail[tail.length - 1];
+    if (latest.load1 > threshold && latest.load5 > threshold) return "flat-high";
+  }
+
+  return "none";
+}
+
+// memGuard — classify current memory pressure.
+// Returns "critical" | "warn" | "ok".
+export function memGuard(memFreePct, { criticalPct, warnPct }) {
+  if (memFreePct < criticalPct) return "critical";
+  if (memFreePct < warnPct) return "warn";
+  return "ok";
+}
+
+// decideMaxParallel — apply the decision matrix and return {next, reason}.
+// Every result is clamped to [minParallel, maxParallelCeiling].
+export function decideMaxParallel({
+  window,
+  concurrency,
+  minSamples,
+  loadSafeFactor,
+  criticalPct,
+  warnPct,
+}) {
+  const { maxParallel: current, minParallel, maxParallelCeiling } = concurrency;
+  const clamp = (v) => clampToBounds(v, { minParallel, maxParallelCeiling });
+
+  if (window.length === 0) {
+    return { next: clamp(current), reason: "insufficient-samples" };
+  }
+
+  const latest = window[window.length - 1];
+  const mem = memGuard(latest.memFreePct, { criticalPct, warnPct });
+
+  // mem-critical overrides everything — act even without a full window.
+  if (mem === "critical") {
+    return { next: clamp(minParallel), reason: "mem-critical" };
+  }
+
+  if (window.length < minSamples) {
+    return { next: clamp(current), reason: "insufficient-samples" };
+  }
+
+  const trend = detectTrend(window, {
+    minSamples,
+    coreCount: latest.coreCount,
+    loadSafeFactor,
+  });
+
+  if (trend === "up") {
+    return { next: clamp(Math.max(minParallel, Math.floor(current * 0.75))), reason: "trend-up" };
+  }
+
+  if (trend === "down") {
+    if (mem === "warn") return { next: clamp(current), reason: "mem-warn" };
+    return { next: clamp(current + 1), reason: "trend-down" };
+  }
+
+  if (trend === "flat-high") {
+    return { next: clamp(current), reason: "flat-high" };
+  }
+
+  return { next: clamp(current), reason: "hold" };
+}
+
+// --- Layer-2 write-back -----------------------------------------------------
+
+// writeLayer2MaxParallel — atomically update catalyst.orchestration.executionCore.maxParallel
+// in the Layer-2 config file. Preserves all other JSON keys. Returns true on
+// success, false on any parse/IO error (fail-safe).
+export function writeLayer2MaxParallel(layer2Path, next, {
+  readFileSync: readFile = readFileSync,
+  writeFileSync: writeFile = writeFileSync,
+  renameSync: rename = renameSync,
+} = {}) {
+  let existing = {};
+  try {
+    existing = JSON.parse(readFile(layer2Path, "utf8"));
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+      try {
+        log.warn({ err: err.message, layer2Path }, "autotune: Layer-2 parse error; skipping write");
+      } catch {}
+      return false;
+    }
+    // ENOENT → start from {}
+  }
+  try {
+    if (!existing.catalyst) existing.catalyst = {};
+    if (!existing.catalyst.orchestration) existing.catalyst.orchestration = {};
+    if (!existing.catalyst.orchestration.executionCore) existing.catalyst.orchestration.executionCore = {};
+    existing.catalyst.orchestration.executionCore.maxParallel = next;
+    const tmp = `${layer2Path}.tmp.${process.pid}`;
+    writeFile(tmp, JSON.stringify(existing, null, 2));
+    rename(tmp, layer2Path);
+    return true;
+  } catch (err) {
+    try {
+      log.warn({ err: err.message, layer2Path }, "autotune: Layer-2 write failed");
+    } catch {}
+    return false;
+  }
+}
+
+// --- Side-car lifecycle -----------------------------------------------------
+
+let _timer = null;
+let _state = null;
+
+// autoTuneTick — the per-interval body. All seams injected.
+export function autoTuneTick(state, seams) {
+  const {
+    liveBackgroundCount,
+    loadavg,
+    freemem,
+    totalmem,
+    cpus,
+    readConcurrency,
+    writeLayer2,
+    appendSampledEvent,
+    appendAdjustedEvent,
+  } = seams;
+
+  try {
+    const bgCount = liveBackgroundCount();
+    if (bgCount === 0) {
+      state.window = [];
+      return;
+    }
+
+    const sample = sampleSystem({ loadavg, freemem, totalmem, cpus });
+    state.window = pushSample(state.window, sample, state.windowSamples);
+
+    const concurrency = readConcurrency();
+    const current = concurrency.maxParallel ?? 3;
+
+    try {
+      appendSampledEvent({
+        label: "execution-core",
+        load1: sample.load1,
+        load5: sample.load5,
+        load15: sample.load15,
+        memFreePct: sample.memFreePct,
+        bgCount,
+        maxParallelCurrent: current,
+      });
+    } catch {}
+
+    const { next, reason } = decideMaxParallel({
+      window: state.window,
+      concurrency,
+      minSamples: state.trendMinSamples,
+      loadSafeFactor: state.loadSafeFactor,
+      criticalPct: state.criticalPct,
+      warnPct: state.warnPct,
+    });
+
+    if (next !== current) {
+      try {
+        writeLayer2(next);
+      } catch {}
+      try {
+        appendAdjustedEvent({
+          label: "execution-core",
+          oldMaxParallel: current,
+          newMaxParallel: next,
+          reason,
+        });
+      } catch {}
+    }
+  } catch {}
+}
+
+// startAutoTuner — start the sampling interval. Returns a stop handle.
+// When disabled, returns a no-op stop handle without starting any timer.
+export function startAutoTuner({
+  configPath,
+  layer2Path,
+  liveBackgroundCount = () => countBackgroundAgents(),
+  sampleIntervalMs = AUTOTUNE_SAMPLE_INTERVAL_MS,
+  windowSamples = AUTOTUNE_WINDOW_SAMPLES,
+  trendMinSamples = AUTOTUNE_TREND_MIN_SAMPLES,
+  loadSafeFactor = AUTOTUNE_LOAD_SAFE_FACTOR,
+  criticalPct = AUTOTUNE_MEM_CRITICAL_PCT,
+  warnPct = AUTOTUNE_MEM_WARN_PCT,
+  enabled = AUTOTUNE_ENABLED,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  loadavg = osLoadavg,
+  freemem = osFreemem,
+  totalmem = osTotalmem,
+  cpus = osCpus,
+  appendSampledEvent = defaultAppendParallelismSampledEvent,
+  appendAdjustedEvent = defaultAppendParallelismAdjustedEvent,
+} = {}) {
+  if (!enabled) return () => {};
+
+  _state = {
+    window: [],
+    windowSamples,
+    trendMinSamples,
+    loadSafeFactor,
+    criticalPct,
+    warnPct,
+  };
+
+  const seams = {
+    liveBackgroundCount,
+    loadavg,
+    freemem,
+    totalmem,
+    cpus,
+    readConcurrency: () =>
+      mergeExecutionCoreConcurrency(
+        readExecutionCoreConcurrency(configPath),
+        readExecutionCoreConcurrencyLayer2(layer2Path),
+      ),
+    writeLayer2: (next) => writeLayer2MaxParallel(layer2Path, next),
+    appendSampledEvent,
+    appendAdjustedEvent,
+  };
+
+  _timer = setIntervalFn(() => autoTuneTick(_state, seams), sampleIntervalMs);
+
+  return stopAutoTuner.bind(null, { clearIntervalFn });
+}
+
+// stopAutoTuner — clear the interval. Idempotent (safe to call before start
+// or multiple times).
+export function stopAutoTuner({ clearIntervalFn = clearInterval } = {}) {
+  if (_timer !== null) {
+    clearIntervalFn(_timer);
+    _timer = null;
+  }
+  _state = null;
+}

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -181,3 +181,32 @@ export function readMemorySamplerConfig() {
     killSustainedSamples: Number(process.env.EXECUTION_CORE_KILL_SUSTAINED_SAMPLES) || 3,
   };
 }
+
+// --- Auto-tuner (CTL-684) ---
+// Sample cadence — how often the auto-tuner polls load + memory.
+export const AUTOTUNE_SAMPLE_INTERVAL_MS =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_SAMPLE_INTERVAL_MS) || 30_000;
+
+// Rolling window depth (number of samples ≈ window_seconds/cadence).
+export const AUTOTUNE_WINDOW_SAMPLES =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_WINDOW_SAMPLES) || 10;
+
+// Consecutive samples required before a trend is declared.
+export const AUTOTUNE_TREND_MIN_SAMPLES =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_TREND_MIN_SAMPLES) || 3;
+
+// Load average "safe" multiplier — load1 must be below cores × factor for a
+// down-trend decision to proceed.
+export const AUTOTUNE_LOAD_SAFE_FACTOR =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_LOAD_SAFE_FACTOR) || 4;
+
+// Memory-free threshold for critical guard (below this → drop to minParallel).
+export const AUTOTUNE_MEM_CRITICAL_PCT =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_MEM_CRITICAL_PCT) || 5;
+
+// Memory-free threshold for warn guard (below this → suppress growth).
+export const AUTOTUNE_MEM_WARN_PCT =
+  Number(process.env.EXECUTION_CORE_AUTOTUNE_MEM_WARN_PCT) || 20;
+
+// Kill-switch: EXECUTION_CORE_AUTOTUNE=0 disables all sampling and Layer-2 writes.
+export const AUTOTUNE_ENABLED = process.env.EXECUTION_CORE_AUTOTUNE !== "0";

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -1,12 +1,24 @@
-// config.test.mjs — CTL-650 Phase 4 + CTL-685. Config knobs:
+// config.test.mjs — CTL-650 Phase 4 + CTL-685 + CTL-684. Config knobs:
 //   readWaitWatcherConfig() → { enabled, intervalMs }
 //   readMemorySamplerConfig() → { enabled, intervalMs, warnThresholdMb,
 //                                  killThresholdMb, killEnabled, killSustainedSamples }
+//   CTL-684: auto-tuner config constants and kill-switch.
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test config.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { readWaitWatcherConfig, EVENT_DEBOUNCE_MS, readMemorySamplerConfig } from "./config.mjs";
+import {
+  readWaitWatcherConfig,
+  EVENT_DEBOUNCE_MS,
+  readMemorySamplerConfig,
+  AUTOTUNE_SAMPLE_INTERVAL_MS,
+  AUTOTUNE_WINDOW_SAMPLES,
+  AUTOTUNE_TREND_MIN_SAMPLES,
+  AUTOTUNE_LOAD_SAFE_FACTOR,
+  AUTOTUNE_MEM_CRITICAL_PCT,
+  AUTOTUNE_MEM_WARN_PCT,
+  AUTOTUNE_ENABLED,
+} from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
 
@@ -106,5 +118,40 @@ describe("readMemorySamplerConfig (CTL-685)", () => {
   test("zero interval falls back to 30000", () => {
     process.env.EXECUTION_CORE_MEMORY_SAMPLE_INTERVAL_MS = "0";
     expect(readMemorySamplerConfig().intervalMs).toBe(30_000);
+  });
+});
+
+// CTL-684: auto-tuner config constants.
+// Note: env vars are read at module import time, so we test the already-imported
+// default values here (the module is loaded once per test run). Env-override
+// tests require a fresh require/import which is not straightforward in ESM — the
+// defaults are tested by asserting the expected literals below.
+describe("auto-tuner defaults (CTL-684)", () => {
+  test("AUTOTUNE_SAMPLE_INTERVAL_MS defaults to 30000", () => {
+    expect(AUTOTUNE_SAMPLE_INTERVAL_MS).toBe(30_000);
+  });
+
+  test("AUTOTUNE_WINDOW_SAMPLES defaults to 10", () => {
+    expect(AUTOTUNE_WINDOW_SAMPLES).toBe(10);
+  });
+
+  test("AUTOTUNE_TREND_MIN_SAMPLES defaults to 3", () => {
+    expect(AUTOTUNE_TREND_MIN_SAMPLES).toBe(3);
+  });
+
+  test("AUTOTUNE_LOAD_SAFE_FACTOR defaults to 4", () => {
+    expect(AUTOTUNE_LOAD_SAFE_FACTOR).toBe(4);
+  });
+
+  test("AUTOTUNE_MEM_CRITICAL_PCT defaults to 5", () => {
+    expect(AUTOTUNE_MEM_CRITICAL_PCT).toBe(5);
+  });
+
+  test("AUTOTUNE_MEM_WARN_PCT defaults to 20", () => {
+    expect(AUTOTUNE_MEM_WARN_PCT).toBe(20);
+  });
+
+  test("AUTOTUNE_ENABLED defaults to true (kill-switch off)", () => {
+    expect(AUTOTUNE_ENABLED).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -65,6 +65,7 @@ import {
   mergeExecutionCoreConcurrency,
 } from "./scheduler.mjs";
 import { writeBootMarker } from "./recovery.mjs"; // CTL-655: window the revive budget to this run
+import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -82,6 +83,8 @@ let _refreshTimer = null;
 let _waitWatcher = null;
 // CTL-685: per-worker memory sampler handle.
 let _memorySampler = null;
+// CTL-684: auto-tuner stop handle.
+let _stopAutoTuner = null;
 let _eventWatcher = null;
 let _eventDebounceTimer = null;
 let _eventLogCursor = 0;
@@ -150,6 +153,10 @@ export function startDaemon({
   // override). Null in tests; production main() resolves it from
   // CATALYST_LAYER2_CONFIG_FILE || ~/.config/catalyst/config.json.
   layer2Path = null,
+  // CTL-684: auto-tuner injectable seams (production uses the real module;
+  // tests inject spies). The stop handle is stored so stopDaemon can tear it
+  // down symmetrically with the scheduler block.
+  startAutoTuner: startAutoTunerFn = startAutoTuner,
 } = {}) {
   const orchDir = getExecutionCoreDir();
   ensureState(orchDir);
@@ -203,6 +210,11 @@ export function startDaemon({
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.
     schedulerFn({ orchDir, cache, concurrency, configPath, layer2Path }); // CTL-536 + CTL-634 + CTL-665 + CTL-676 + CTL-678 — pull-loop scheduler (configPath + layer2Path enable per-tick Layer-1+Layer-2 re-read)
+    // CTL-684: start the side-car auto-tuner AFTER the scheduler so the
+    // scheduler's first tick runs with the operator's current Layer-2 value
+    // before any auto-tune adjustments. configPath + layer2Path are threaded
+    // so the tuner can re-read the merged concurrency on every sample.
+    _stopAutoTuner = startAutoTunerFn({ configPath, layer2Path });
 
     if (watchRegistry) {
       // Watch the execution-core dir for registry.json changes — the registry is
@@ -484,6 +496,15 @@ export function stopDaemon() {
       log.warn({ err: err?.message }, "stopDaemon: memory-sampler stop failed");
     }
     _memorySampler = null;
+  }
+  // CTL-684: stop the auto-tuner.
+  if (_stopAutoTuner) {
+    try {
+      _stopAutoTuner();
+    } catch {
+      /* tuner already stopped */
+    }
+    _stopAutoTuner = null;
   }
   _eventLogCursor = 0;
   _eventLogLeftover = "";

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -751,3 +751,56 @@ describe("stopDaemon", () => {
     expect(existsSync(pidFile)).toBe(false);
   });
 });
+
+// CTL-684: auto-tuner wiring in startDaemon + stopDaemon.
+describe("auto-tuner wiring (CTL-684)", () => {
+  test("startDaemon invokes startAutoTuner once with configPath + layer2Path", () => {
+    const calls = [];
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      configPath: "/fake/config.json",
+      layer2Path: "/fake/layer2.json",
+      startAutoTuner: (opts) => {
+        calls.push(opts);
+        return () => {};
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].configPath).toBe("/fake/config.json");
+    expect(calls[0].layer2Path).toBe("/fake/layer2.json");
+    stopDaemon();
+  });
+
+  test("stopDaemon calls the stored _stopAutoTuner", () => {
+    const stopped = [];
+    startDaemon({
+      recover: () => {},
+      startMonitor: () => {},
+      startScheduler: () => {},
+      watchRegistry: false,
+      startAutoTuner: () => () => stopped.push("autoTuner"),
+    });
+    stopDaemon();
+    expect(stopped).toEqual(["autoTuner"]);
+  });
+
+  test("a throwing startAutoTuner triggers stopDaemon cleanup (daemon does not start half-up)", () => {
+    let pidFile = null;
+    try {
+      pidFile = join(process.env.CATALYST_DIR, "daemon2.pid");
+      startDaemon({
+        recover: () => {},
+        startMonitor: () => {},
+        startScheduler: () => {},
+        watchRegistry: false,
+        pidFile,
+        startAutoTuner: () => { throw new Error("tuner boot failed"); },
+      });
+    } catch {}
+    // PID file must be removed by stopDaemon's cleanup path
+    if (pidFile) expect(existsSync(pidFile)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -601,6 +601,52 @@ export function defaultAppendCooldownEscalatedEvent({
   );
 }
 
+// CTL-684: auto-tuner parallelism-sampled event — phase.scheduler.parallelism-sampled.<label>.
+// Emitted once per sample while background workers are active. `label` is "execution-core"
+// for host-wide tuning; payload carries the full pressure snapshot.
+export function defaultAppendParallelismSampledEvent({
+  label = "execution-core",
+  load1,
+  load5,
+  load15,
+  memFreePct,
+  bgCount,
+  maxParallelCurrent,
+}) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "scheduler",
+      ticket: label,
+      orchId: label,
+      action: "parallelism-sampled",
+      reason: "sample",
+      payloadExtras: { load1, load5, load15, mem_free_pct: memFreePct, bg_count: bgCount, maxParallel_current: maxParallelCurrent },
+    }),
+    "parallelism-sampled",
+  );
+}
+
+// CTL-684: auto-tuner parallelism-adjusted event — phase.scheduler.parallelism-adjusted.<label>.
+// Emitted only when maxParallel actually changes (write-on-change).
+export function defaultAppendParallelismAdjustedEvent({
+  label = "execution-core",
+  oldMaxParallel,
+  newMaxParallel,
+  reason,
+}) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "scheduler",
+      ticket: label,
+      orchId: label,
+      action: "parallelism-adjusted",
+      reason,
+      payloadExtras: { old_maxParallel: oldMaxParallel, new_maxParallel: newMaxParallel },
+    }),
+    "parallelism-adjusted",
+  );
+}
+
 // CTL-587 default seams — all overridable for tests, all best-effort for prod.
 
 // defaultReviveDispatch — reset the signal to status: "stalled" first (to bypass

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -23,6 +23,8 @@ import {
   defaultAppendDispatchRequestedEvent,
   defaultAppendDispatchLaunchedEvent,
   defaultAppendYieldFileSkipEvent,
+  defaultAppendParallelismSampledEvent,
+  defaultAppendParallelismAdjustedEvent,
   defaultAppendPreemptedEvent,
   defaultAppendResumedAfterPreemptionEvent,
   readBootEpoch,
@@ -2818,5 +2820,87 @@ describe("preemption event envelopes (CTL-705)", () => {
     expect(env.attributes["event.name"]).toBe("phase.research.resumed-after-preemption.CTL-2");
     expect(env.attributes["event.action"]).toBe("resumed-after-preemption");
     expect(env.body.payload.resume_session).toBe("sess-uuid");
+  });
+});
+
+// CTL-684: parallelism-sampled + parallelism-adjusted event emitter round-trips.
+describe("parallelism event envelopes (CTL-684)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl684-parallelism-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  function readBackEnvelope() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    return JSON.parse(lines[lines.length - 1]);
+  }
+
+  test("defaultAppendParallelismSampledEvent emits the expected envelope (CTL-684)", () => {
+    const ok = defaultAppendParallelismSampledEvent({
+      label: "execution-core",
+      load1: 8.5,
+      load5: 5.2,
+      load15: 3.1,
+      memFreePct: 45.0,
+      bgCount: 7,
+      maxParallelCurrent: 10,
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.scheduler.parallelism-sampled.execution-core");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.attributes["event.action"]).toBe("parallelism-sampled");
+    expect(env.attributes["catalyst.orchestration"]).toBe("execution-core");
+    expect(env.body.payload.load1).toBe(8.5);
+    expect(env.body.payload.load5).toBe(5.2);
+    expect(env.body.payload.load15).toBe(3.1);
+    expect(env.body.payload.mem_free_pct).toBe(45.0);
+    expect(env.body.payload.bg_count).toBe(7);
+    expect(env.body.payload.maxParallel_current).toBe(10);
+  });
+
+  test("defaultAppendParallelismSampledEvent uses 'execution-core' label by default (CTL-684)", () => {
+    defaultAppendParallelismSampledEvent({
+      load1: 1, load5: 1, load15: 1, memFreePct: 80, bgCount: 2, maxParallelCurrent: 5,
+    });
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.scheduler.parallelism-sampled.execution-core");
+  });
+
+  test("defaultAppendParallelismAdjustedEvent emits the expected envelope (CTL-684)", () => {
+    const ok = defaultAppendParallelismAdjustedEvent({
+      label: "execution-core",
+      oldMaxParallel: 10,
+      newMaxParallel: 7,
+      reason: "trend-up",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.scheduler.parallelism-adjusted.execution-core");
+    expect(env.attributes["event.action"]).toBe("parallelism-adjusted");
+    expect(env.body.payload.old_maxParallel).toBe(10);
+    expect(env.body.payload.new_maxParallel).toBe(7);
+    expect(env.body.payload.reason).toBe("trend-up");
+  });
+
+  test("defaultAppendParallelismAdjustedEvent uses 'execution-core' label by default (CTL-684)", () => {
+    defaultAppendParallelismAdjustedEvent({
+      oldMaxParallel: 5, newMaxParallel: 6, reason: "trend-down",
+    });
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("phase.scheduler.parallelism-adjusted.execution-core");
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -463,7 +463,7 @@ export function validatePerProjectBudgets(concurrency) {
 // `maxParallelCeiling`, but only when each bound is a valid integer (CTL-665).
 // Bounds bite only when present, so the empty-`concurrency` legacy path stays
 // unclamped — every existing state.json-driven test is untouched.
-function clampToBounds(value, { minParallel, maxParallelCeiling } = {}) {
+export function clampToBounds(value, { minParallel, maxParallelCeiling } = {}) {
   let resolved = value;
   if (Number.isInteger(minParallel) && resolved < minParallel) resolved = minParallel;
   if (Number.isInteger(maxParallelCeiling) && resolved > maxParallelCeiling) {

--- a/website/src/content/docs/observability/event-flow.md
+++ b/website/src/content/docs/observability/event-flow.md
@@ -390,6 +390,31 @@ grep cooldown-escalated ~/catalyst/events/$(date -u +%Y-%m).jsonl | jq .
 grep '"action":"failed"' ~/catalyst/events/$(date -u +%Y-%m).jsonl | jq 'select(.subject | startswith("phase.dispatch"))'
 ```
 
+## Auto-tuner parallelism events (CTL-684)
+
+The execution-core daemon's side-car auto-tuner emits two scheduler events into
+the unified event log, using `"execution-core"` as the host-wide sentinel label
+(no real ticket is attached):
+
+| Event name | Trigger | Payload fields |
+|---|---|---|
+| `phase.scheduler.parallelism-sampled.execution-core` | Every sample while bg workers are active (default 30s) | `load1`, `load5`, `load15`, `mem_free_pct`, `bg_count`, `maxParallel_current` |
+| `phase.scheduler.parallelism-adjusted.execution-core` | Only when `maxParallel` actually changes | `old_maxParallel`, `new_maxParallel`, `reason` (e.g. `trend-up`, `mem-critical`, `trend-down`) |
+
+The `reason` field on an adjusted event maps directly to the decision-matrix row
+that fired. See the
+[auto-tuner config knobs](../reference/configuration#auto-tuner-ctl-684)
+for env-var overrides and the kill-switch.
+
+**Observability queries**:
+```bash
+# See all parallelism samples
+grep parallelism-sampled ~/catalyst/events/$(date -u +%Y-%m).jsonl | jq .
+
+# See all adjustments and their reasons
+grep parallelism-adjusted ~/catalyst/events/$(date -u +%Y-%m).jsonl | jq '{reason: .body.payload.reason, old: .body.payload.old_maxParallel, new: .body.payload.new_maxParallel}'
+```
+
 ## Related
 
 - [catalyst-events CLI](./catalyst-events/) — command reference and jq filter cookbook

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1001,6 +1001,31 @@ the resolved ceiling). Other `executionCore` fields (`eligibleQuery` lives in
 the central registry; `dispatchMode` and structural daemon fields elsewhere
 in the config) remain boot-time only.
 
+**Auto-tuner (CTL-684).** The daemon runs a side-car auto-tuner that samples
+`os.loadavg()` and `os.freemem()` on a 30-second cadence while background
+workers are active, applies an asymmetric trend-based decision rule, and writes
+the adjusted `executionCore.maxParallel` into the Layer-2 config file. The
+scheduler's hot-reload picks up the new value on its next tick — no daemon
+restart required. Shrink is multiplicative (`×0.75`, fast back-off); growth is
+additive (`+1`, slow ramp) to resist oscillation. Every write is atomic
+(tmp + rename) and write-on-change only.
+
+The auto-tuner is controlled by environment variables:
+
+| Env var | Default | Effect |
+|---|---|---|
+| `EXECUTION_CORE_AUTOTUNE` | `1` (on) | Set to `0` to disable all sampling and Layer-2 writes |
+| `EXECUTION_CORE_AUTOTUNE_SAMPLE_INTERVAL_MS` | `30000` | Sample cadence in ms |
+| `EXECUTION_CORE_AUTOTUNE_WINDOW_SAMPLES` | `10` | Rolling window depth (~5 min at 30s) |
+| `EXECUTION_CORE_AUTOTUNE_TREND_MIN_SAMPLES` | `3` | Consecutive samples required to declare a trend |
+| `EXECUTION_CORE_AUTOTUNE_LOAD_SAFE_FACTOR` | `4` | `load1 < cores × factor` threshold for growth |
+| `EXECUTION_CORE_AUTOTUNE_MEM_CRITICAL_PCT` | `5` | Free-memory % below which drops to `minParallel` |
+| `EXECUTION_CORE_AUTOTUNE_MEM_WARN_PCT` | `20` | Free-memory % below which growth is suppressed |
+
+Tuner events appear in the unified event log as
+`phase.scheduler.parallelism-sampled.execution-core` and
+`phase.scheduler.parallelism-adjusted.execution-core`.
+
 Resolution order for both `phaseAgents.models` and `phaseAgents.turnCaps` is **CLI flag >
 `modelOverrides[phase][ticket]` > `models[phase]` (or `turnCaps[phase]`) > built-in default**. The
 dispatcher reads `dispatchMode` at


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-29T14:05:00Z -->
<!-- Last updated: 2026-05-29T14:05:00Z -->
<!-- PR: #1202 -->
<!-- Previous commits: 2592ec31,2099db23,1e4269bd,c0817e5a,c669c264 -->

## Summary

Adds an **active-only parallelism auto-tuner** to the execution-core daemon. The daemon now
observes CPU load averages and system memory pressure while bg phase workers are running, and
dynamically adjusts `maxParallel` up or down to keep the host in a healthy saturation band — no
manual knob-turning required.

This directly addresses the incident where `maxParallel` was bumped 4 → 10 → 40 and load average
climbed to 187 on a 12-core box before being rolled back to 20 by hand. The auto-tuner would have
stepped it back before hitting that ceiling.

## What Changed

### Phase 1 — `autotune.mjs`: pure decision core

New file with zero daemon coupling. All functions are pure or injected:

- `sampleSystem()` — reads load avg + memory free % + live bg worker count
- `pushSample(window, sample)` — appends to rolling window (depth configurable via `AUTOTUNE_WINDOW_SAMPLES`)
- `detectTrend(window)` — returns `up | down | flat` from sustained load trajectory (≥ `AUTOTUNE_TREND_MIN_SAMPLES` consecutive samples)
- `memGuard(sample, cfg)` — returns `critical | warn | ok` based on free% thresholds
- `decideMaxParallel(current, trend, memState, cfg)` — emits a new target and reason string
- `clampToBounds` re-exported from `scheduler.mjs` (behavior-inert, 1-token change)

**31 decision-matrix tests** covering trend detection, memory guard, and clamp semantics.

### Phase 2 — write-back + event emitters

- `writeLayer2MaxParallel(orchDir, newVal)` — atomic write (`tmp + rename`), preserves sibling keys in the Layer-2 JSON, fail-safe on malformed JSON
- `defaultAppendParallelismSampledEvent(orchDir, sample, maxParallel)` — emits `scheduler.parallelism.sampled` to the event log
- `defaultAppendParallelismAdjustedEvent(orchDir, oldVal, newVal, reason)` — emits `scheduler.parallelism.adjusted`

Both event emitters follow the same yield-file-skip / cooldown-gc shape as existing emitters.

**6 write-back tests** (atomicity, fail-safe on bad JSON) + **4 event round-trip tests**.

### Phase 3 — `autoTuneTick` lifecycle + daemon wiring

- `autoTuneTick(deps)` — single tick: sample → window → trend + memGuard → decide → write-back on change → emit events → idle-reset when no workers
- `startAutoTuner(deps)` / `stopAutoTuner(handle)` — interval management with kill-switch guard
- `daemon.mjs` wired symmetrically after `schedulerFn`: starts on `startDaemon`, torn down in `stopDaemon` via `_stopAutoTuner`

**13 lifecycle tests** + **3 daemon wiring tests** (start/stop, kill-switch bypass).

### Phase 4 — config constants + docs

`config.mjs` exports 7 new env-tunable constants (all `EXECUTION_CORE_AUTOTUNE_*`):

| Constant | Default | Env override |
|---|---|---|
| `AUTOTUNE_SAMPLE_INTERVAL_MS` | 30 000 | `EXECUTION_CORE_AUTOTUNE_SAMPLE_INTERVAL_MS` |
| `AUTOTUNE_WINDOW_SAMPLES` | 10 | `EXECUTION_CORE_AUTOTUNE_WINDOW_SAMPLES` |
| `AUTOTUNE_TREND_MIN_SAMPLES` | 3 | `EXECUTION_CORE_AUTOTUNE_TREND_MIN_SAMPLES` |
| `AUTOTUNE_LOAD_SAFE_FACTOR` | 4 | `EXECUTION_CORE_AUTOTUNE_LOAD_SAFE_FACTOR` |
| `AUTOTUNE_MEM_CRITICAL_PCT` | 5 | `EXECUTION_CORE_AUTOTUNE_MEM_CRITICAL_PCT` |
| `AUTOTUNE_MEM_WARN_PCT` | 20 | `EXECUTION_CORE_AUTOTUNE_MEM_WARN_PCT` |
| `AUTOTUNE_ENABLED` | `true` | `EXECUTION_CORE_AUTOTUNE=0` disables |

`configuration.md` documents all env vars with descriptions and hot-reload note.
`event-flow.md` documents `scheduler.parallelism.sampled` + `scheduler.parallelism.adjusted` with
example observability queries.

`maxParallelCeiling` default bumped 10 → 40 in `.catalyst/config.json` (the auto-tuner now keeps
it from actually reaching ceiling unless the host is genuinely healthy enough).

## Architecture

```
daemon.mjs
  └─ startAutoTuner(deps)        ← started with daemon, stopped on shutdown
       └─ setInterval(autoTuneTick, AUTOTUNE_SAMPLE_INTERVAL_MS)
            └─ autoTuneTick(deps)
                 ├─ sampleSystem()           ← load avg + memory + worker count
                 ├─ pushSample(window)       ← rolling window
                 ├─ detectTrend(window)      ← up/down/flat
                 ├─ memGuard(sample)         ← critical/warn/ok
                 ├─ decideMaxParallel(...)   ← new target + reason
                 ├─ writeLayer2MaxParallel() ← atomic JSON write (on change only)
                 └─ appendParallelism*Event() ← event log emission
```

## Test Coverage

- `autotune-decision.test.mjs` — 31 tests (decision matrix, trend detection, clamp)
- `autotune-writeback.test.mjs` — 10 tests (atomic write-back, event round-trips)
- `autotune-lifecycle.test.mjs` — 13 tests (tick lifecycle, idle-reset, kill-switch)
- `daemon.test.mjs` — 3 tests added (start/stop wiring)
- `config.test.mjs` — 7 tests added (constant defaults)

**532 total tests pass / 0 fail** across all 7 execution-core suites.

## How to Verify

- [x] `bun test` in `plugins/dev/scripts/execution-core/` → 532 pass, 0 fail ✅
- [x] No TypeScript / type-check target (pure `.mjs` package) ✅
- [x] Regression risk: 1 / 10 (pure new additions, no existing behavior changed) ✅
- [x] Kill-switch: `EXECUTION_CORE_AUTOTUNE=0` disables all sampling ✅
- [ ] Manual: start daemon, run a batch of workers, confirm `scheduler.parallelism.sampled` events appear in `~/catalyst/events/YYYY-MM.jsonl`
- [ ] Manual: simulate load by bumping `EXECUTION_CORE_AUTOTUNE_LOAD_SAFE_FACTOR=0.1` and confirm `scheduler.parallelism.adjusted` events fire

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-684

Refs: CTL-684
