### PR TITLE
CTL-681: Daemon first-class handlers for linear.issue.updated and linear.comment.created

### DIFF
--- a/plugins/dev/scripts/execution-core/eligible-set.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.mjs
@@ -131,6 +131,26 @@ export function dropProject(projectKey) {
   }
 }
 
+// upsertTicket — insert or merge a single ticket into a project's eligible set
+// and persist. CTL-681: the event-driven fold (handleIssueUpdatedEvent) adds a
+// newly-eligible ticket from the webhook payload alone, with no Linear poll.
+// Merge-over-existing preserves the richer fields (title, relations,
+// inverseRelations) the last reconcile filled in, since the event payload does
+// not carry them. writeProjection's skip-when-unchanged guard makes a no-op
+// upsert produce zero disk writes.
+export function upsertTicket(projectKey, ticket, { query } = {}) {
+  let entry = eligible.get(projectKey);
+  if (!entry) {
+    entry = { tickets: new Map(), source: null, query: null };
+    eligible.set(projectKey, entry);
+  }
+  const prev = entry.tickets.get(ticket.identifier);
+  entry.tickets.set(ticket.identifier, { ...(prev ?? {}), ...ticket });
+  entry.source = "event";
+  if (query !== undefined) entry.query = query;
+  writeProjection(projectKey);
+}
+
 // getEligibleSet - a sorted copy of a project's eligible tickets. Callers may
 // mutate the result freely; the internal state is never exposed.
 export function getEligibleSet(projectKey) {

--- a/plugins/dev/scripts/execution-core/eligible-set.test.mjs
+++ b/plugins/dev/scripts/execution-core/eligible-set.test.mjs
@@ -18,6 +18,7 @@ import {
   removeTicket,
   dropProject,
   getEligibleSet,
+  upsertTicket,
 } from "./eligible-set.mjs";
 
 // Keys touched by this suite — afterEach drops them so the module-level
@@ -214,5 +215,71 @@ describe("atomic write durability", () => {
     expect(existsSync(`${projFile("crashy")}.tmp`)).toBe(false);
     // remove the stand-in directory so the afterEach dropProject is quiet
     rmSync(projFile("crashy"), { recursive: true, force: true });
+  });
+});
+
+// CTL-681: upsertTicket — insert or merge a single ticket into the eligible set.
+describe("upsertTicket (CTL-681)", () => {
+  test("adds a brand-new ticket to an empty project and writes the projection", () => {
+    upsertTicket("beta", { identifier: "B-1", state: "Todo", priority: 2 });
+    const set = getEligibleSet("beta");
+    expect(set.map((t) => t.identifier)).toEqual(["B-1"]);
+    expect(existsSync(projFile("beta"))).toBe(true);
+  });
+
+  test("adds a ticket to an existing project alongside prior tickets (sorted)", () => {
+    setProjectEligible("beta", [{ identifier: "B-2", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    upsertTicket("beta", { identifier: "B-1", state: "Todo", priority: 2 });
+    expect(getEligibleSet("beta").map((t) => t.identifier)).toEqual(["B-1", "B-2"]);
+  });
+
+  test("merging over an existing ticket preserves relations, updates state/priority", () => {
+    setProjectEligible(
+      "beta",
+      [{ identifier: "B-1", state: "Todo", priority: 1, relations: [{ id: "r1" }] }],
+      { source: "reconcile", query: {} }
+    );
+    upsertTicket("beta", { identifier: "B-1", state: "In Progress", priority: 2 });
+    const ticket = getEligibleSet("beta").find((t) => t.identifier === "B-1");
+    expect(ticket.state).toBe("In Progress");
+    expect(ticket.priority).toBe(2);
+    expect(ticket.relations).toEqual([{ id: "r1" }]);
+  });
+
+  test("creates the project entry if absent (new projectKey)", () => {
+    expect(getEligibleSet("gamma")).toEqual([]);
+    upsertTicket("gamma", { identifier: "G-1", state: "Todo", priority: 1 });
+    expect(getEligibleSet("gamma").map((t) => t.identifier)).toEqual(["G-1"]);
+  });
+
+  test("stamps source = 'event'", () => {
+    upsertTicket("beta", { identifier: "B-1", state: "Todo", priority: 1 });
+    const doc = JSON.parse(readFileSync(projFile("beta"), "utf8"));
+    expect(doc.source).toBe("event");
+  });
+
+  test("skip-write when [identifier, state, priority] tuple is unchanged (mtime stable)", async () => {
+    setProjectEligible("beta", [{ identifier: "B-1", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    const mtime1 = statSync(projFile("beta")).mtimeMs;
+    await sleep(15);
+    upsertTicket("beta", { identifier: "B-1", state: "Todo", priority: 1 });
+    expect(statSync(projFile("beta")).mtimeMs).toBe(mtime1);
+  });
+
+  test("rewrites the projection when upserted ticket changes state", async () => {
+    setProjectEligible("beta", [{ identifier: "B-1", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    const mtime1 = statSync(projFile("beta")).mtimeMs;
+    await sleep(15);
+    upsertTicket("beta", { identifier: "B-1", state: "In Progress", priority: 1 });
+    expect(statSync(projFile("beta")).mtimeMs).toBeGreaterThan(mtime1);
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -27,7 +27,7 @@ import { dirname, basename, join } from "node:path";
 import { getEventLogPath, RECONCILE_INTERVAL_MS, EVENT_DEBOUNCE_MS, log } from "./config.mjs";
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import { runEligibleQuery } from "./linear-query.mjs";
-import { setProjectEligible, removeTicket, dropProject, getEligibleSet } from "./eligible-set.mjs";
+import { setProjectEligible, removeTicket, dropProject, getEligibleSet, upsertTicket } from "./eligible-set.mjs";
 import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
 import { dispatchTicket } from "./dispatch.mjs";
 import { abortWorker as defaultAbortWorker } from "./abort-worker.mjs";
@@ -64,6 +64,111 @@ export function parseStateChangedEvent(event) {
     teamKey: payload.teamKey ?? null,
     toState: payload.toState ?? null,
   };
+}
+
+// parseIssueUpdatedEvent — accept both canonical OTel and legacy flat shapes.
+// Returns null for anything that is not a linear.issue.updated event or that
+// lacks an extractable ticket identifier. CTL-681.
+export function parseIssueUpdatedEvent(event) {
+  const name = event?.attributes?.["event.name"] ?? event?.event;
+  if (name !== "linear.issue.updated") return null;
+  const payload = event?.body?.payload ?? event?.detail ?? {};
+  const identifier =
+    event?.attributes?.["linear.issue.identifier"] ?? payload.ticket ?? payload.identifier ?? null;
+  if (!identifier) return null;
+  return {
+    identifier,
+    teamKey: payload.teamKey ?? null,
+    toState: payload.toState ?? null,
+    toLabels: payload.toLabels ?? null,
+    toProject: payload.toProject ?? null,
+    toPriority: typeof payload.toPriority === "number" ? payload.toPriority : null,
+  };
+}
+
+// parseCommentCreatedEvent — accept canonical OTel and legacy flat shapes.
+// Returns null for anything that is not a linear.comment.created event. CTL-681.
+export function parseCommentCreatedEvent(event) {
+  const name = event?.attributes?.["event.name"] ?? event?.event;
+  if (name !== "linear.comment.created") return null;
+  const payload = event?.body?.payload ?? event?.detail ?? {};
+  const ticket =
+    event?.attributes?.["linear.issue.identifier"] ?? payload.ticket ?? null;
+  return {
+    ticket,
+    commentId: payload.commentId ?? null,
+    issueId: payload.issueId ?? null,
+    body: payload.body ?? null,
+    authorId: payload.authorId ?? null,
+    authorName: payload.authorName ?? null,
+  };
+}
+
+// ticketMatchesQuery — eligibility predicate for a linear.issue.updated fold.
+// All conditions must hold: state matches, label matches (or no label filter),
+// project matches (or no project filter), priority within floor (or no filter).
+// Mirrors linear-query.mjs:144-148 priority semantics. CTL-681.
+function ticketMatchesQuery(query, { toState, toLabels, toProject, toPriority }) {
+  if (toState !== query.status) return false;
+  if (query.label !== null) {
+    if (!Array.isArray(toLabels) || !toLabels.includes(query.label)) return false;
+  }
+  if (query.project !== null && toProject !== query.project) return false;
+  if (query.priority !== null) {
+    if (typeof toPriority !== "number" || toPriority < 1 || toPriority > query.priority) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// handleIssueUpdatedEvent — fold a linear.issue.updated event into the eligible
+// projection by evaluating the ticket against each matching project's query.
+// Upserts (newly eligible) or removes (no longer eligible) without a Linear poll.
+// Never aborts a worker — this is a projection edit only. CTL-681.
+export function handleIssueUpdatedEvent(
+  event,
+  {
+    cache,
+    abortWorker: _abortWorker, // accepted for signature symmetry, never invoked
+  } = {}
+) {
+  const parsed = parseIssueUpdatedEvent(event);
+  if (!parsed) return;
+  if (cache) cache.set(parsed.identifier, parsed.toState);
+  for (const p of listProjects()) {
+    const query = resolveEligibleQuery(p);
+    if (query.team !== parsed.teamKey) continue;
+    if (ticketMatchesQuery(query, parsed)) {
+      upsertTicket(query.team, {
+        identifier: parsed.identifier,
+        state: parsed.toState,
+        priority: parsed.toPriority,
+        project: parsed.toProject ?? null,
+      });
+    } else {
+      removeTicket(query.team, parsed.identifier);
+    }
+  }
+}
+
+// handleCommentCreatedEvent — parse a linear.comment.created event and surface
+// it via a log.info line and an injectable onComment callback. No eligibility
+// changes — this is a pure hook seam. CTL-681.
+export function handleCommentCreatedEvent(event, { onComment } = {}) {
+  const parsed = parseCommentCreatedEvent(event);
+  if (!parsed) return;
+  log.info(
+    { ticket: parsed.ticket, commentId: parsed.commentId, authorId: parsed.authorId },
+    "monitor: comment.created observed (CTL-681 hook seam)"
+  );
+  if (typeof onComment === "function") {
+    try {
+      onComment(parsed);
+    } catch (err) {
+      log.warn({ err: err.message }, "onComment subscriber threw — ignored");
+    }
+  }
 }
 
 // --- Reconcile -----------------------------------------------------------
@@ -439,6 +544,8 @@ export function readNewEvents() {
         continue; // skip a malformed line, keep tailing
       }
       handleStateChangedEvent(event, tailerOpts);
+      handleIssueUpdatedEvent(event, tailerOpts);   // CTL-681
+      handleCommentCreatedEvent(event, tailerOpts); // CTL-681
     }
   } catch {
     // log file not yet created or a transient read error — best-effort
@@ -475,6 +582,7 @@ export function startMonitor({
   dispatch,
   abortWorker,
   cache, // CTL-634: shared state cache for event-driven write-through
+  onComment, // CTL-681: optional comment subscriber
 } = {}) {
   // CTL-565: orchDir + dispatch + abortWorker are stored in tailerOpts so the
   // tailer-driven readNewEvents → handleStateChangedEvent path can one-shot-
@@ -482,7 +590,7 @@ export function startMonitor({
   // undefined, handleStateChangedEvent falls back to its real default.
   // CTL-634: cache rides in tailerOpts too so the tailer's write-through path
   // populates the same instance the scheduler reads.
-  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker, cache };
+  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker, cache, onComment };
   reconcileAll({ exec });
   sweepMissingTriage({ orchDir, dispatch }); // CTL-711: triage pre-existing eligible tickets
   if (resumeFromCursor) {

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -6,21 +6,24 @@
 // dispatch), the byte-offset event-log tailer, the periodic reconcile timer,
 // and the startMonitor/stopMonitor lifecycle.
 //
-// Event-vs-poll division of labour (CTL-681 — was rewritten):
-// A linear.issue.state_changed event handles two cases inline (no poll):
-//   - DRAG_OUT_STATES (Backlog/Canceled/Duplicate) → confident immediate
-//     removal + abortWorker.
-//   - →Triage / →Ready-without-triage-artifact → one-shot triage dispatch.
-// Every other →Ready / unknown-new-state case is now a NO-OP — the
-// per-event scoping reconcile that used to fire here (because the parsed
-// event was missing project/labels/priority) is gone. CTL-681 captures those
-// fields in the event payload so a future incremental projection update can
-// fold the change without a poll; until that lands, the eligible set picks up
-// the new ticket on the next periodic reconcile (RECONCILE_INTERVAL_MS, 10
-// min) or on operator-restart startup reconcile. This trade-off — up to
-// ~10 min staleness for new Ready tickets in exchange for zero per-event
-// Linear polls — was explicitly chosen to remove the per-tick poll baseline
-// that exhausted the 2500/hr quota.
+// Event-vs-poll division of labour (CTL-681):
+// Three event types are handled inline by the tailer, with no Linear poll:
+//   linear.issue.state_changed:
+//     - DRAG_OUT_STATES (Backlog/Canceled/Duplicate) → confident immediate
+//       removal + abortWorker.
+//     - →Triage / →Ready-without-triage-artifact → one-shot triage dispatch.
+//     - All other states: no-op (pipeline write-backs, unknown states).
+//   linear.issue.updated (CTL-681, handleIssueUpdatedEvent):
+//     - Evaluates the ticket against each project's eligibleQuery from the
+//       event payload (toState/toLabels/toProject/toPriority — no poll).
+//     - Upserts the ticket when it matches; removes it when it does not.
+//     - Up to one reconcile interval of staleness only for brand-new adds
+//       whose relations the event payload omits; removals are instant.
+//   linear.comment.created (CTL-681, handleCommentCreatedEvent):
+//     - Surfaces parsed comment (ticket, body, author) via log.info and an
+//       injectable onComment callback. No eligible-set changes, no poll.
+// The 10-min periodic reconcile (RECONCILE_INTERVAL_MS) remains the
+// missed-webhook backstop for all three handlers.
 
 import { watch, openSync, fstatSync, readSync, closeSync, mkdirSync, existsSync } from "node:fs";
 import { dirname, basename, join } from "node:path";
@@ -302,13 +305,10 @@ export function handleStateChangedEvent(
       //
       // CTL-681: anything that does NOT trigger the triage auto-dispatch
       // (an already-triaged Ready, an unknown new state, or a standalone
-      // monitor with no orchDir) is now a NO-OP — the pre-CTL-681 debounced
-      // reconcile that fired here is gone. The eligible set picks up the new
-      // ticket on the next periodic reconcile (RECONCILE_INTERVAL_MS, ~10 min).
-      // The event payload now carries project/labels/priority (CTL-681 parser
-      // change) so a follow-up PR can fold the change incrementally into the
-      // projection without a poll; until then the 10-min reconcile + startup
-      // reconcile are the only Linear list-polls.
+      // monitor with no orchDir) is a NO-OP here. The handleIssueUpdatedEvent
+      // fold (wired below readNewEvents) handles label/project/priority changes
+      // incrementally without a poll. The 10-min reconcile remains the
+      // missed-webhook backstop.
       if (
         parsed.toState === query.status &&
         orchDir &&
@@ -328,7 +328,7 @@ export function handleStateChangedEvent(
             team: p.team,
             toState: parsed.toState,
           },
-          "monitor: →Ready event observed; per-event scoping poll removed (CTL-681), relying on 10-min reconcile"
+          "monitor: →Ready event (no triage dispatch); handleIssueUpdatedEvent folds projection, 10-min reconcile backstop (CTL-681)"
         );
       }
     } else if (DRAG_OUT_STATES.has(parsed.toState)) {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -11,9 +11,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   parseStateChangedEvent,
+  parseIssueUpdatedEvent,
+  parseCommentCreatedEvent,
   reconcileProject,
   reconcileAll,
   handleStateChangedEvent,
+  handleIssueUpdatedEvent,
+  handleCommentCreatedEvent,
   sweepMissingTriage,
   startMonitor,
   stopMonitor,
@@ -868,6 +872,272 @@ describe("sweepMissingTriage (CTL-711)", () => {
       ticket: "ENG-1",
       phase: "triage",
     });
+    stopMonitor();
+  });
+});
+
+// --- CTL-681 Phase 3: parseIssueUpdatedEvent + handleIssueUpdatedEvent ------
+
+// Helper to build a canonical OTel-shaped linear.issue.updated event.
+function issueUpdatedEvent({ identifier, teamKey, toState, toLabels, toProject, toPriority } = {}) {
+  return {
+    attributes: {
+      "event.name": "linear.issue.updated",
+      "linear.issue.identifier": identifier ?? "ENG-9",
+    },
+    body: {
+      payload: {
+        ticket: identifier ?? "ENG-9",
+        teamKey: teamKey ?? "ENG",
+        toState: toState ?? "Todo",
+        toLabels: toLabels ?? null,
+        toProject: toProject ?? null,
+        toPriority: toPriority ?? null,
+      },
+    },
+  };
+}
+
+describe("parseIssueUpdatedEvent (CTL-681)", () => {
+  test("canonical OTel shape → returns parsed object", () => {
+    const parsed = parseIssueUpdatedEvent(issueUpdatedEvent({ identifier: "ENG-5" }));
+    expect(parsed).toMatchObject({ identifier: "ENG-5", teamKey: "ENG", toState: "Todo" });
+  });
+
+  test("legacy flat shape → returns parsed object", () => {
+    const parsed = parseIssueUpdatedEvent({
+      event: "linear.issue.updated",
+      detail: { ticket: "ENG-7", teamKey: "ENG", toState: "Backlog", toLabels: ["p0"] },
+    });
+    expect(parsed).toMatchObject({ identifier: "ENG-7", toState: "Backlog" });
+    expect(parsed.toLabels).toEqual(["p0"]);
+  });
+
+  test("returns null for linear.issue.state_changed", () => {
+    expect(
+      parseIssueUpdatedEvent({
+        attributes: { "event.name": "linear.issue.state_changed", "linear.issue.identifier": "ENG-1" },
+        body: { payload: {} },
+      })
+    ).toBeNull();
+  });
+
+  test("returns null for linear.comment.created", () => {
+    expect(
+      parseIssueUpdatedEvent({
+        attributes: { "event.name": "linear.comment.created", "linear.issue.identifier": "ENG-1" },
+        body: { payload: {} },
+      })
+    ).toBeNull();
+  });
+
+  test("returns null for empty object", () => {
+    expect(parseIssueUpdatedEvent({})).toBeNull();
+  });
+
+  test("returns null when no identifier extractable", () => {
+    expect(
+      parseIssueUpdatedEvent({
+        attributes: { "event.name": "linear.issue.updated" },
+        body: { payload: { teamKey: "ENG" } },
+      })
+    ).toBeNull();
+  });
+});
+
+describe("handleIssueUpdatedEvent (CTL-681)", () => {
+  test("adds a newly-eligible ticket when it matches the query", () => {
+    enroll("ENG", { status: "Todo", label: "p0" });
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ identifier: "ENG-9", toState: "Todo", toLabels: ["p0"] })
+    );
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toContain("ENG-9");
+  });
+
+  test("label-only change with no label filter: ticket is added when state matches", () => {
+    enroll("ENG", { status: "Todo", label: null });
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ identifier: "ENG-9", toState: "Todo", toLabels: ["something"] })
+    );
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toContain("ENG-9");
+  });
+
+  test("removes a now-ineligible ticket when it loses the required label", () => {
+    enroll("ENG", { status: "Todo", label: "p0" });
+    setProjectEligible("ENG", [{ identifier: "ENG-9", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ identifier: "ENG-9", toState: "Todo", toLabels: [] })
+    );
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).not.toContain("ENG-9");
+  });
+
+  test("team mismatch is a no-op (wrong teamKey)", () => {
+    enroll("ENG", { status: "Todo" });
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ identifier: "PROJ-1", teamKey: "PROJ", toState: "Todo" })
+    );
+    expect(getEligibleSet("ENG")).toEqual([]);
+  });
+
+  test("wrong state is not eligible (ticket absent after fold)", () => {
+    enroll("ENG", { status: "Todo" });
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ identifier: "ENG-9", toState: "In Progress" })
+    );
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).not.toContain("ENG-9");
+  });
+
+  test("priority floor respected: toPriority exceeds query.priority → not eligible", () => {
+    enroll("ENG", { status: "Todo", priority: 2 });
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ identifier: "ENG-9", toState: "Todo", toPriority: 3 })
+    );
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).not.toContain("ENG-9");
+  });
+
+  test("cache write-through: toState written to cache", () => {
+    enroll("ENG", { status: "Todo" });
+    const cache = createTicketStateCache({ now: () => 0 });
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ identifier: "ENG-9", toState: "Done" }),
+      { cache }
+    );
+    expect(cache.get("ENG-9")).toBe("Done");
+  });
+
+  test("no orchDir: does not throw", () => {
+    enroll("ENG", { status: "Todo" });
+    expect(() =>
+      handleIssueUpdatedEvent(issueUpdatedEvent(), { orchDir: undefined })
+    ).not.toThrow();
+  });
+
+  test("abortWorker is NEVER called (issue-updated is a projection edit, not a kill)", () => {
+    enroll("ENG", { status: "Todo" });
+    const abortWorker = mock(() => {});
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ identifier: "ENG-9", toState: "Backlog" }),
+      { abortWorker }
+    );
+    expect(abortWorker).not.toHaveBeenCalled();
+  });
+
+  test("no poll: the injected exec is never called by handleIssueUpdatedEvent", () => {
+    enroll("ENG", { status: "Todo" });
+    const exec = mock(() => ({ code: 0, stdout: "{}", stderr: "" }));
+    handleIssueUpdatedEvent(issueUpdatedEvent(), { exec });
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  test("readNewEvents integration: a linear.issue.updated line triggers the eligible fold", () => {
+    enroll("ENG", { status: "Todo" });
+    // Write the event first (using appendEventLog which creates the dir), seed
+    // the tailer at offset 0 so readNewEvents drains from the start.
+    const line = JSON.stringify(issueUpdatedEvent({ identifier: "ENG-42", toState: "Todo" }));
+    appendEventLog(line + "\n");
+    saveCursor({ logPath: eventLogPath(), byteOffset: 0 });
+    seedTailerFromCursor();
+    readNewEvents();
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toContain("ENG-42");
+  });
+});
+
+// --- CTL-681 Phase 4: parseCommentCreatedEvent + handleCommentCreatedEvent ---
+
+function commentCreatedEvent({ ticket, commentId, body, authorId, authorName } = {}) {
+  return {
+    attributes: {
+      "event.name": "linear.comment.created",
+      "linear.issue.identifier": ticket ?? "ENG-9",
+    },
+    body: {
+      payload: {
+        ticket: ticket ?? "ENG-9",
+        commentId: commentId ?? "c-1",
+        issueId: "i-1",
+        body: body ?? "a comment",
+        authorId: authorId ?? "u-1",
+        authorName: authorName ?? "Alice",
+      },
+    },
+  };
+}
+
+describe("parseCommentCreatedEvent (CTL-681)", () => {
+  test("canonical shape → parsed payload with all fields", () => {
+    const parsed = parseCommentCreatedEvent(commentCreatedEvent({ ticket: "ENG-5" }));
+    expect(parsed).toMatchObject({ ticket: "ENG-5", commentId: "c-1", body: "a comment" });
+  });
+
+  test("legacy flat shape via event.detail → same result", () => {
+    const parsed = parseCommentCreatedEvent({
+      event: "linear.comment.created",
+      detail: { ticket: "ENG-7", commentId: "c-7", issueId: "i-1", body: "hi", authorId: "u2", authorName: "Bob" },
+    });
+    expect(parsed).toMatchObject({ ticket: "ENG-7", body: "hi", authorId: "u2" });
+  });
+
+  test("returns null for other event names", () => {
+    expect(parseCommentCreatedEvent({ attributes: { "event.name": "linear.issue.updated" }, body: { payload: {} } })).toBeNull();
+    expect(parseCommentCreatedEvent({ attributes: { "event.name": "linear.comment.updated" }, body: { payload: {} } })).toBeNull();
+  });
+
+  test("returns null for empty object", () => {
+    expect(parseCommentCreatedEvent({})).toBeNull();
+  });
+});
+
+describe("handleCommentCreatedEvent (CTL-681)", () => {
+  test("invokes onComment with parsed payload when provided", () => {
+    const onComment = mock(() => {});
+    handleCommentCreatedEvent(commentCreatedEvent(), { onComment });
+    expect(onComment).toHaveBeenCalledTimes(1);
+    expect(onComment.mock.calls[0][0]).toMatchObject({ ticket: "ENG-9", body: "a comment" });
+  });
+
+  test("no-op when onComment is undefined (never throws)", () => {
+    expect(() => handleCommentCreatedEvent(commentCreatedEvent())).not.toThrow();
+  });
+
+  test("no-op (no throw) when event is non-comment (parsed = null)", () => {
+    expect(() =>
+      handleCommentCreatedEvent(
+        { attributes: { "event.name": "linear.issue.updated" }, body: { payload: {} } },
+        { onComment: mock(() => {}) }
+      )
+    ).not.toThrow();
+  });
+
+  test("does not touch the eligible set (no upsert/remove)", () => {
+    enroll("ENG", { status: "Todo" });
+    setProjectEligible("ENG", [{ identifier: "ENG-1", state: "Todo", priority: 1 }], {
+      source: "reconcile",
+      query: {},
+    });
+    handleCommentCreatedEvent(commentCreatedEvent({ ticket: "ENG-1" }));
+    expect(getEligibleSet("ENG")).toHaveLength(1); // unchanged
+  });
+
+  test("bot-authored comment fires onComment (not suppressed)", () => {
+    const onComment = mock(() => {});
+    handleCommentCreatedEvent(
+      commentCreatedEvent({ authorId: "bot-uuid-123" }),
+      { onComment }
+    );
+    expect(onComment).toHaveBeenCalledTimes(1);
+  });
+
+  test("readNewEvents integration: a linear.comment.created line invokes onComment via tailerOpts", () => {
+    const onComment = mock(() => {});
+    startMonitor({ exec: execReturning({}), reconcileIntervalMs: 60_000, onComment });
+    const line = JSON.stringify(commentCreatedEvent({ ticket: "ENG-10" }));
+    appendFileSync(eventLogPath(), line + "\n");
+    readNewEvents();
+    expect(onComment).toHaveBeenCalledTimes(1);
+    expect(onComment.mock.calls[0][0]).toMatchObject({ ticket: "ENG-10" });
     stopMonitor();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
@@ -337,6 +337,51 @@ describe("parseLinearWebhookEvent — Comment", () => {
     if (ev.kind !== "comment") throw new Error("expected comment kind");
     expect(ev.action).toBe("remove");
   });
+
+  it("CTL-681: captures body from data.body", () => {
+    const ev = parseLinearWebhookEvent("Comment", {
+      action: "create",
+      type: "Comment",
+      data: { id: "c1", body: "hello", issueId: "i1", issue: { id: "i1", identifier: "CTL-99" } },
+    });
+    if (ev.kind !== "comment") throw new Error("expected comment kind");
+    expect(ev.body).toBe("hello");
+  });
+
+  it("CTL-681: captures authorId + authorName from top-level actor", () => {
+    const ev = parseLinearWebhookEvent("Comment", {
+      action: "create",
+      type: "Comment",
+      actor: { id: "u1", name: "Ada" },
+      data: { id: "c1", issueId: "i1" },
+    });
+    if (ev.kind !== "comment") throw new Error("expected comment kind");
+    expect(ev.authorId).toBe("u1");
+    expect(ev.authorName).toBe("Ada");
+  });
+
+  it("CTL-681: falls back to data.user when top-level actor is absent", () => {
+    const ev = parseLinearWebhookEvent("Comment", {
+      action: "create",
+      type: "Comment",
+      data: { id: "c1", issueId: "i1", user: { id: "u2", name: "Bob" } },
+    });
+    if (ev.kind !== "comment") throw new Error("expected comment kind");
+    expect(ev.authorId).toBe("u2");
+    expect(ev.authorName).toBe("Bob");
+  });
+
+  it("CTL-681: null-safe when body and author are absent", () => {
+    const ev = parseLinearWebhookEvent("Comment", {
+      action: "create",
+      type: "Comment",
+      data: { id: "c1", issueId: "i1" },
+    });
+    if (ev.kind !== "comment") throw new Error("expected comment kind");
+    expect(ev.body).toBeNull();
+    expect(ev.authorId).toBeNull();
+    expect(ev.authorName).toBeNull();
+  });
 });
 
 describe("parseLinearWebhookEvent — Cycle", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -371,6 +371,69 @@ describe("createLinearWebhookHandler", () => {
   });
 });
 
+describe("buildLinearEventLogEnvelope — comment fields (CTL-681)", () => {
+  it("comment envelope includes body, authorId, authorName in body.payload", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "comment",
+        action: "create",
+        ticket: "CTL-99",
+        commentId: "c1",
+        issueId: "i1",
+        body: "hello there",
+        authorId: "u1",
+        authorName: "Ada",
+        data: {},
+      },
+      TS
+    );
+    expect(env).not.toBeNull();
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload["body"]).toBe("hello there");
+    expect(payload["authorId"]).toBe("u1");
+    expect(payload["authorName"]).toBe("Ada");
+  });
+
+  it("comment envelope with no body/author has null values in payload", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "comment",
+        action: "create",
+        ticket: "CTL-99",
+        commentId: "c1",
+        issueId: "i1",
+        body: null,
+        authorId: null,
+        authorName: null,
+        data: {},
+      },
+      TS
+    );
+    expect(env).not.toBeNull();
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload["body"]).toBeNull();
+    expect(payload["authorId"]).toBeNull();
+    expect(payload["authorName"]).toBeNull();
+  });
+
+  it("bot-authored comment is NOT suppressed (pin Finding 5)", async () => {
+    const eventLog2 = new FakeEventLog();
+    const handler = createLinearWebhookHandler({
+      linearSecrets: [{ key: "test", secret: SECRET }],
+      eventLog: eventLog2,
+      botUserId: "bot-uuid-123",
+    });
+    const botComment = {
+      action: "create",
+      type: "Comment",
+      actor: { id: "bot-uuid-123", name: "Catalyst Bot" },
+      data: { id: "c2", body: "Automated comment", issueId: "i1" },
+    };
+    await handler.handle(makeReq(botComment, { "linear-event": "Comment" }));
+    expect(eventLog2.appends.length).toBe(1);
+  });
+});
+
 describe("buildLinearEventLogEnvelope (canonical)", () => {
   it("Issue update → topic from event.topic, linear.issue.identifier from ticket", () => {
     const env = buildLinearEventLogEnvelope(
@@ -618,6 +681,9 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         ticket: "CTL-1",
         commentId: "c1",
         issueId: "i1",
+        body: null,
+        authorId: null,
+        authorName: null,
         data: {},
       },
       TS
@@ -760,6 +826,9 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         ticket: "ADV-42",
         commentId: "c1",
         issueId: "i1",
+        body: null,
+        authorId: null,
+        authorName: null,
         data: {},
       },
       TS,
@@ -778,6 +847,9 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         ticket: "FOO-1",
         commentId: "c1",
         issueId: "i1",
+        body: null,
+        authorId: null,
+        authorName: null,
         data: {},
       },
       TS,
@@ -795,6 +867,9 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         ticket: null,
         commentId: "c1",
         issueId: "i1",
+        body: null,
+        authorId: null,
+        authorName: null,
         data: {},
       },
       TS,

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
@@ -68,6 +68,9 @@ export type LinearWebhookEvent =
       ticket: string | null;
       commentId: string | null;
       issueId: string | null;
+      body: string | null;        // CTL-681
+      authorId: string | null;    // CTL-681
+      authorName: string | null;  // CTL-681
       data: Record<string, unknown>;
     }
   | {
@@ -210,12 +213,26 @@ function parseComment(payload: Record<string, unknown>): LinearWebhookEvent {
   if (isObject(data.issue)) {
     ticket = getOptStr(data.issue, "identifier");
   }
+  // CTL-681: capture body + author. Actor precedence mirrors parseIssue:
+  // top-level actor > data.user > data.userId.
+  const actor = isObject(payload.actor) ? payload.actor : null;
+  const userObj = isObject(data.user) ? data.user : null;
+  const authorId =
+    (actor !== null ? getOptStr(actor, "id") : null) ??
+    (userObj !== null ? getOptStr(userObj, "id") : null) ??
+    getOptStr(data, "userId");
+  const authorName =
+    (actor !== null ? getOptStr(actor, "name") : null) ??
+    (userObj !== null ? getOptStr(userObj, "name") : null);
   return {
     kind: "comment",
     action,
     ticket,
     commentId: getOptStr(data, "id"),
     issueId: getOptStr(data, "issueId"),
+    body: getOptStr(data, "body"),
+    authorId,
+    authorName,
     data,
   };
 }

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -159,6 +159,7 @@ export function buildLinearEventLogEnvelope(
       const eventName = `linear.comment.${event.action}d`;
       const attrs: Omit<Attributes, "event.name"> = {};
       if (event.ticket !== null) attrs["linear.issue.identifier"] = event.ticket;
+      if (event.authorId !== null) attrs["linear.actor.id"] = event.authorId; // CTL-681
       // Comments don't carry team data directly — derive from the ticket prefix
       // so we can both stamp linear.team.key and look up vcs.repository.name.
       const derivedTeamKey = deriveTeamKey(event.ticket);
@@ -181,6 +182,9 @@ export function buildLinearEventLogEnvelope(
           commentId: event.commentId,
           issueId: event.issueId,
           ticket: event.ticket,
+          body: event.body,            // CTL-681
+          authorId: event.authorId,    // CTL-681
+          authorName: event.authorName, // CTL-681
         },
       });
     }


### PR DESCRIPTION
<!-- Auto-generated: 2026-05-29T14:05:00Z -->
<!-- Last updated: 2026-05-29T14:05:00Z -->
<!-- PR: #1205 -->
<!-- Previous commits: 4c361a8edebefadbbbfd79b2bf71390a094a82e7,b581707018d3c26d8ee38bf2d2503e2776cbc55b,c06ba341f254453af20beae4b76d4e308a1e2fb6,2b96c93e94c8bdaa2f4acaa0872e479473676685 -->

## Summary

Adds first-class daemon-side handlers for `linear.issue.updated` and `linear.comment.created` events — the third event-sourcing step for the execution-core monitor. Previously, only `linear.issue.state_changed` was handled inline; all other Linear event types were logged by the orch-monitor layer but ignored by the daemon, leaving the eligible set dependent on the 10-min periodic reconcile for label, priority, and project changes.

After this PR the daemon handles three Linear event types inline with no outbound Linear poll:

- **`linear.issue.state_changed`** — existing handler (unchanged in scope)
- **`linear.issue.updated`** — `handleIssueUpdatedEvent` folds priority/label/project changes directly into the eligible projection via `upsertTicket` or `removeTicket`
- **`linear.comment.created`** — `handleCommentCreatedEvent` surfaces parsed comments via `log.info` and an injectable `onComment` callback hook seam

## Changes Made

### `eligible-set.mjs` — `upsertTicket` primitive

New export `upsertTicket(projectKey, ticket, opts)`: inserts or merges a single ticket into a project's eligible projection without replacing the full set. Merge-over-existing preserves `relations` and `inverseRelations` fields that event payloads omit. Uses the existing atomic-write and skip-when-unchanged machinery, so a no-op upsert produces zero disk writes.

### `monitor.mjs` — three new exports + `startMonitor` option

**Parsers:**
- `parseIssueUpdatedEvent(event)` — accepts canonical OTel and legacy flat shapes; returns `{identifier, teamKey, toState, toLabels, toProject, toPriority}` or `null`
- `parseCommentCreatedEvent(event)` — returns `{ticket, commentId, issueId, body, authorId, authorName}` or `null`

**Handlers:**
- `handleIssueUpdatedEvent(event, {cache})` — evaluates the ticket against each project's `resolveEligibleQuery`; upserts when it matches, removes when it does not. Accepts `abortWorker` in its signature for symmetry but never calls it — this is a projection-only edit.
- `handleCommentCreatedEvent(event, {onComment})` — emits a structured `log.info` line and calls the optional `onComment(parsed)` subscriber, swallowing any subscriber throw.

**Wiring:** both handlers are called for every event in `readNewEvents`, after the existing `handleStateChangedEvent` call. `startMonitor` accepts a new `onComment` option that propagates into `tailerOpts`.

**Module doc rewrite:** the comment block at the top of `monitor.mjs` now describes all three shipped handlers instead of the previous "follow-up PR" placeholder language.

### `linear-webhook-events.ts` + `linear-webhook-handler.ts` — comment enrichment

The orch-monitor `parseComment` function now extracts `body`, `authorId`, and `authorName` from the webhook payload (actor → data.user → data.userId precedence). `buildLinearEventLogEnvelope` includes these fields in `body.payload` and stamps `linear.actor.id` in attributes when `authorId` is present. The existing bot-event suppression rule in `linear-webhook-handler.ts` is unchanged.

## Test Coverage

| File | New tests |
|---|---|
| `eligible-set.test.mjs` | 7 tests for `upsertTicket` (add to empty, add alongside existing, merge-preserves-relations, new project key, source stamping, skip-write no-op, rewrite on state change) |
| `monitor.test.mjs` | Suites for `parseIssueUpdatedEvent` (canonical + legacy shapes, wrong event names, missing identifier), `handleIssueUpdatedEvent` (upserts matching, removes non-matching, cross-team skip, cache write-through), `handleCommentCreatedEvent` (dispatches parsed comment, swallows subscriber throw, skips non-comment events) |
| `linear-webhook-events.test.ts` | 3 tests verifying `body`/`authorId`/`authorName` extraction |
| `linear-webhook-handler.test.ts` | Integration tests for enriched comment envelope field presence |

## How to Verify

- [ ] `cd plugins/dev/scripts/execution-core && bun test eligible-set.test.mjs monitor.test.mjs` — all suites pass
- [ ] `cd plugins/dev/scripts/orch-monitor && bun test __tests__/linear-webhook-events.test.ts __tests__/linear-webhook-handler.test.ts` — all suites pass
- [ ] Start the daemon; mutate a ticket's label in Linear; confirm the eligible set updates within seconds (no 10-min wait)
- [ ] Verify `log.info` line appears when a comment is posted on a tracked ticket
- [ ] `grep "follow-up PR" plugins/dev/scripts/execution-core/monitor.mjs` — returns nothing

## Files Changed

| File | +/- |
|---|---|
| `plugins/dev/scripts/execution-core/eligible-set.mjs` | +20 |
| `plugins/dev/scripts/execution-core/eligible-set.test.mjs` | +67 |
| `plugins/dev/scripts/execution-core/monitor.mjs` | +133 / -25 |
| `plugins/dev/scripts/execution-core/monitor.test.mjs` | +270 |
| `plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts` | +17 |
| `plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts` | +4 |
| `plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts` | +45 |
| `plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts` | +75 |

**Total: +631 / -25**

## Related

- Refs: [CTL-681](https://linear.app/coalesce-labs/issue/CTL-681)
- Follows PR #1138 (step-2 orch-monitor comment enrichment)
- Research: `thoughts/shared/research/2026-05-27-webhook-vs-poll-minimal-outbound-need.md`
