### PR TITLE
CTL-731 follow-up: don't bind a cold liveness snapshot into reclaim (boot mass-false-revive)

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1402,7 +1402,16 @@ export function schedulerTick(
   // proven starvation source). Its freshness gates new-work admission later. Null
   // snapshot seam (test default) → legacy per-worker liveness, fresh-by-default.
   const liveSnapshot = livenessSnapshot ? livenessSnapshot() : null;
-  const liveAgents = liveSnapshot ? liveSnapshot.agents : null;
+  // CTL-731: only bind the snapshot's agents into the reclaim liveness when it is
+  // POPULATED. A cold / never-populated snapshot returns agents:[] — binding that
+  // empty list would make EVERY live worker resolve to "absent" (agentForShortId
+  // over []) and trigger a mass false-revive on the first post-boot tick, before
+  // the async read has resolved. When unpopulated, leave liveAgents null so the
+  // reclaim falls back to its per-worker real read (pre-CTL-731 behavior) for the
+  // one cold tick; the snapshot warms within a sub-second and later ticks use it.
+  // A populated-but-stale snapshot is fine for reclaim (≤ a few seconds old, same
+  // as the pre-existing 5s TTL) — only NEW-work dispatch needs the isFresh gate.
+  const liveAgents = liveSnapshot && liveSnapshot.populated ? liveSnapshot.agents : null;
 
   // CTL-702: scan worker dirs for yield tombstones. Emit once per unique
   // absolute path per daemon lifetime (deduped via observedYieldFiles).

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1468,6 +1468,56 @@ describe("schedulerTick — new-work pull", () => {
     });
     expect(r.dispatched).toEqual(["CTL-9"]);
   });
+
+  // CTL-731: a COLD/never-populated snapshot must NOT bind its empty agents list
+  // into the reclaim liveness — doing so would resolve every live worker to
+  // "absent" (agentForShortId over []) and mass-false-revive on the first
+  // post-boot tick. Cold → reclaim falls back to its own per-worker real read.
+  test("a cold liveness snapshot does NOT bind reclaim liveness (no boot mass-false-revive)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-1", "implement", "running"); // an in-flight worker the reclaim sweep visits
+    const reclaimOpts = [];
+    const reclaimDeadWork = (_orchDir, _sig, opts) => {
+      reclaimOpts.push(opts);
+      return "noop";
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      reclaimDeadWork,
+      liveBackgroundCount: () => 1,
+      livenessSnapshot: () => ({ populated: false, agents: [], isFresh: false }),
+      livenessIsFresh: () => false,
+    });
+    expect(reclaimOpts.length).toBeGreaterThan(0);
+    // cold → no injected liveness binding (reclaim uses its default real read)
+    expect(reclaimOpts.every((o) => o.liveness === undefined)).toBe(true);
+  });
+
+  test("a populated liveness snapshot binds the shared agents into reclaim liveness", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-1", "implement", "running");
+    const reclaimOpts = [];
+    const reclaimDeadWork = (_orchDir, _sig, opts) => {
+      reclaimOpts.push(opts);
+      return "noop";
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      reclaimDeadWork,
+      liveBackgroundCount: () => 1,
+      livenessSnapshot: () => ({
+        populated: true,
+        agents: [{ sessionId: "1111-2222", kind: "background", status: "idle" }],
+        isFresh: true,
+      }),
+      livenessIsFresh: () => true,
+    });
+    expect(reclaimOpts.length).toBeGreaterThan(0);
+    // populated → reclaim receives the bound shared-snapshot liveness fn
+    expect(reclaimOpts.every((o) => typeof o.liveness === "function")).toBe(true);
+  });
 });
 
 // ── CTL-706: per-project cap + reserve wired into schedulerTick ──


### PR DESCRIPTION
## Summary

Follow-up to #1225, caught during live-verification of the Phase 00 hotpatch.

Phase 00 routed the per-worker reclaim liveness through the shared `getAgentsCached()` snapshot to kill the per-tick `claude agents` shell-out. But `getAgentsCached()` returns `agents: []` when the snapshot is **never-populated** (cold start), and the binding treated that empty array as authoritative. On the **first post-boot scheduler tick** — before the async read resolves — every live worker resolved to `"absent"` (`agentForShortId` over `[]`), triggering a **mass false-revive**.

**Observed live:** after the #1225 hotpatch + restart, 7 workers were revived at boot (01:10:23–24), spawning duplicates (bg agents 9→13). The reclaim sweep runs *before* the new-work staleness gate, so it hit the cold snapshot first.

## Fix

Only bind the snapshot's agents into reclaim when it is **populated**; while cold, leave `liveAgents` null so reclaim falls back to its own per-worker real read (the pre-Phase-00 behavior) for the one cold tick. The snapshot warms sub-second, so subsequent ticks use the shared snapshot as intended. A populated-but-stale snapshot is still fine for reclaim (≤ a few seconds old, same as the prior 5s TTL); only NEW-work admission needs the stricter `isFresh` gate, which is unchanged.

## Testing
- 2 new scheduler tests: a **cold** snapshot leaves reclaim's `liveness` unbound (real read); a **populated** snapshot binds the shared-agents `liveness` fn.
- `cd plugins/dev/scripts/execution-core && bun test` → **1473 pass**, 1 pre-existing unrelated fail (`cli/sessions` `classifyRow`, fails on `0694e5bf`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)