### PR TITLE
CTL-735: bound the reclaim/revive path (de-starvation revive-storm fix)

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -150,6 +150,20 @@ export const IDLE_CONFIRM_TICKS =
 export const BUSY_CEILING_MS =
   Number(process.env.EXECUTION_CORE_BUSY_CEILING_MS) || 6 * 60 * 60_000;
 
+// CTL-735 — post-(re)dispatch grace window for the `absent` liveness class. A
+// worker whose bg_job_id is `absent` from the eventually-consistent `claude
+// agents` snapshot but whose signal was (re)dispatched within this window has
+// almost certainly just not registered yet (a fresh `claude --bg` takes seconds
+// to appear, slower under load) — NOT crashed. The reclaim sweep defers reviving
+// it until the window elapses: the missing analog of IDLE_CONFIRM_TICKS for
+// `absent`. Without it, the de-starved fast tick (CTL-731, ~2-4s) re-classifies
+// each just-revived worker as dead and revives it again → the revive storm.
+// Deliberately generous (90s) so a fresh worker registers even under high load,
+// while a genuinely-crashed fresh worker waits at most this long before revive.
+// Env-overridable for tuning from real failures.
+export const REVIVE_GRACE_MS =
+  Number(process.env.EXECUTION_CORE_REVIVE_GRACE_MS) || 90_000;
+
 // CTL-650 — the push-based session wait-state watcher. Default ON; the daemon
 // continuously classifies live sessions and emits agent.waiting_on_user /
 // agent.resumed transition events. CATALYST_WAIT_WATCHER=0 disables it (the

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -175,6 +175,19 @@ export const REVIVE_GRACE_MS =
 export const PER_TICK_REVIVE_CAP =
   Number(process.env.EXECUTION_CORE_PER_TICK_REVIVE_CAP) || 2;
 
+// CTL-735 — revival age ceiling. `isTicketInFlight` treats any ticket with a
+// non-terminal signal as in-flight, so a worker that crashed at `running` and
+// never flipped terminal stays swept forever. An absent/idle worker whose signal
+// has not been touched in this long is an abandoned historical dir (a long-since
+// Done or dead ticket), NOT a fresh crash — reviving it wastes budget and, once
+// MAX_REVIVES is hit, escalates dozens of dead tickets to needs-human. Such a
+// worker is treated as inert (no revive, no escalate). Deliberately well above
+// any real phase duration (24h) — a genuine multi-hour crash is still revived;
+// only a day-stale signal is inert. A signal with no parseable timestamp falls
+// through to the pre-CTL-735 path (cannot judge age). Env-overridable.
+export const REVIVE_MAX_AGE_MS =
+  Number(process.env.EXECUTION_CORE_REVIVE_MAX_AGE_MS) || 24 * 60 * 60_000;
+
 // CTL-650 — the push-based session wait-state watcher. Default ON; the daemon
 // continuously classifies live sessions and emits agent.waiting_on_user /
 // agent.resumed transition events. CATALYST_WAIT_WATCHER=0 disables it (the

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -164,6 +164,17 @@ export const BUSY_CEILING_MS =
 export const REVIVE_GRACE_MS =
   Number(process.env.EXECUTION_CORE_REVIVE_GRACE_MS) || 90_000;
 
+// CTL-735 — per-tick revive cap. The reclaim sweep revives at most this many
+// dead workers per scheduler tick; further revivable workers are `revive-capped`
+// (deferred to a later tick), so a fast (de-starved) loop cannot mass-revive ~85
+// historical worker dirs and outrun the event-count-lagged storm-breaker before
+// it clamps. The grace window (REVIVE_GRACE_MS) stops the re-revive RACE; this
+// cap bounds the BREADTH of a single tick. Deliberately small (2) — genuine
+// crashes are rare, so 2/tick clears a real backlog within a few ticks while
+// turning any storm into a slow, observable trickle. Env-overridable for tuning.
+export const PER_TICK_REVIVE_CAP =
+  Number(process.env.EXECUTION_CORE_PER_TICK_REVIVE_CAP) || 2;
+
 // CTL-650 — the push-based session wait-state watcher. Default ON; the daemon
 // continuously classifies live sessions and emits agent.waiting_on_user /
 // agent.resumed transition events. CATALYST_WAIT_WATCHER=0 disables it (the

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -476,4 +476,54 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
       else process.env.CATALYST_REVIVE_JOBS_DIR = prevJobsDir;
     }
   });
+
+  // CTL-735 Guard 2 — the storm bound. Many dead-bg signals in ONE tick (the
+  // ~85-dir mass-revive scenario the de-starved fast loop hit) must NOT all
+  // revive at once: the per-tick cap bounds revives so a fast loop cannot outrun
+  // the event-count-lagged storm-breaker. With EXECUTION_CORE_PER_TICK_REVIVE_CAP=2,
+  // exactly 2 of 5 revivable workers revive this tick; the other 3 are
+  // `revive-capped` (deferred, no dispatch) and re-evaluated next tick. (No
+  // startedAt on the signals → Guard 1's grace window does not defer them, so the
+  // CAP is what bounds the count.)
+  test("per-tick revive cap bounds a mass-revive tick (5 dead → 2 revived, 3 capped)", () => {
+    for (let i = 0; i < 5; i++) {
+      seedSignal(`CTL-735-S${i}`, "implement", {
+        status: "running",
+        bg_job_id: `dead-bg-${i}`,
+        orchestrator: `CTL-735-S${i}`,
+      });
+    }
+
+    const reviveDispatchCalls = [];
+    const result = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      perTickReviveCap: 2, // injected — bound revives to 2 this tick
+      writeStatus: {
+        applyPhaseStatus: () => {},
+        applyTerminalDone: () => {},
+        applyLabel: () => ({ applied: true }),
+      },
+      teardownWorktree: () => true,
+      reclaimDeadWork: (od, sig, opts) =>
+        reclaimDeadWorkIfPossible(od, sig, {
+          ...opts, // carries the scheduler's per-tick reviveBudgetRemaining
+          statJob: () => null, // bg dead
+          probes: { implement: () => false }, // work NOT done → branch (C)
+          reviveDispatch: (args) => {
+            reviveDispatchCalls.push(args);
+            return { code: 0 };
+          },
+          applyStalledLabel: () => ({ applied: true }),
+          killBgJob: () => {},
+          countReviveEvents: () => 0, // per-ticket budget available for all
+          countDistinctRevivingTickets: () => 1, // storm-breaker NOT tripped
+        }),
+    });
+
+    // The cap — not the per-ticket budget or storm-breaker — is what bounds this.
+    expect(result.revived).toHaveLength(2);
+    expect(result.reviveCapped).toHaveLength(3);
+    expect(reviveDispatchCalls).toHaveLength(2); // only the uncapped revives dispatched
+  });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -526,4 +526,97 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     expect(result.reviveCapped).toHaveLength(3);
     expect(reviveDispatchCalls).toHaveLength(2); // only the uncapped revives dispatched
   });
+
+  // CTL-735 — the storm reproduction (handoff action item #3). This mirrors the
+  // real incident: many fast ticks (~2-4s) over multiple dead-bg signals whose
+  // freshly-revived replacement worker NEVER appears in the eventually-consistent
+  // `claude agents` snapshot (liveness always `absent` — the worst case). Pre-fix,
+  // every tick re-revived every worker → 5→18→62→74 workers, load 72. Post-fix the
+  // structural guards (grace window + per-tick cap) bound TOTAL revives: each
+  // worker revives exactly once and then sits `revive-pending` for the rest of the
+  // grace window. Budget is left always-available (countReviveEvents=0) so this
+  // isolates the structural guards, NOT the per-ticket MAX_REVIVES backstop.
+  test("storm repro: many fast ticks × 5 always-absent dead workers → bounded revives (no storm)", () => {
+    const N = 5;
+    for (let i = 0; i < N; i++) {
+      seedSignal(`CTL-735-T${i}`, "implement", {
+        status: "running",
+        bg_job_id: `dead-bg-${i}`,
+        orchestrator: `CTL-735-T${i}`,
+        // 10 min ago — past the 90s grace window, within the 24h inert ceiling →
+        // eligible to revive on the first tick.
+        startedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+        updatedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      });
+    }
+
+    // A controllable clock: each tick advances 3s (the fast de-starved cadence).
+    // 20 ticks = 60s total, strictly inside the 90s grace window, so a worker
+    // revived on tick K stays revive-pending for every remaining tick.
+    let clock = Date.now();
+    const TICK_MS = 3_000;
+    const TICKS = 20;
+
+    const reviveDispatchCalls = [];
+    const perTickRevived = [];
+
+    // Simulated dispatcher: rewrite the phase signal exactly as the real
+    // defaultReviveDispatch → phase-agent-dispatch does — fresh startedAt + new
+    // bg + status running — so the next tick re-reads a freshly-(re)dispatched
+    // worker (which the grace window must then defer).
+    const simulatedReviveDispatch = ({ orchDir: od, ticket, phase }) => {
+      reviveDispatchCalls.push({ ticket, tick: reviveDispatchCalls.length });
+      writeFileSync(
+        join(od, "workers", ticket, `phase-${phase}.json`),
+        JSON.stringify({
+          ticket,
+          phase,
+          status: "running",
+          bg_job_id: `revived-bg-${ticket}`,
+          orchestrator: ticket,
+          startedAt: new Date(clock).toISOString(), // fresh — arms the grace window
+          updatedAt: new Date(clock).toISOString(),
+        }),
+      );
+      return { code: 0 };
+    };
+
+    for (let t = 0; t < TICKS; t++) {
+      const result = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: () => ({ code: 0 }),
+        now: () => clock,
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          applyTerminalDone: () => {},
+          applyLabel: () => ({ applied: true }),
+        },
+        teardownWorktree: () => true,
+        reclaimDeadWork: (od, sig, opts) =>
+          reclaimDeadWorkIfPossible(od, sig, {
+            ...opts, // carries the per-tick reviveBudgetRemaining
+            statJob: () => null,
+            probes: { implement: () => false }, // work NOT done → revive territory
+            liveness: () => "absent", // worst case: replacement never registers
+            reviveDispatch: simulatedReviveDispatch,
+            applyStalledLabel: () => ({ applied: true }),
+            killBgJob: () => {},
+            countReviveEvents: () => 0, // budget always available — isolate structural guards
+            countDistinctRevivingTickets: () => 1, // storm-breaker NOT tripped
+            now: () => clock,
+          }),
+      });
+      perTickRevived.push(result.revived.length);
+      clock += TICK_MS;
+    }
+
+    // THE storm assertion: each of the 5 workers revived EXACTLY ONCE across all
+    // 20 ticks — not once per tick. Pre-fix this would be ~5 × 20 = 100 revives.
+    expect(reviveDispatchCalls).toHaveLength(N);
+    // And the per-tick cap held every tick (never more than 2 revives in one tick).
+    expect(Math.max(...perTickRevived)).toBeLessThanOrEqual(2);
+    // Every worker revived once and only once.
+    const revivedTickets = new Set(reviveDispatchCalls.map((c) => c.ticket));
+    expect(revivedTickets.size).toBe(N);
+  });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1290,31 +1290,6 @@ export function reclaimDeadWorkIfPossible(
     return "alive-busy-suppressed";
   }
 
-  // ── CTL-735: post-(re)dispatch grace window — the missing analog of the
-  //    idle-confirmation streak for `absent`. A just-(re)dispatched worker has a
-  //    NEW bg_job_id that a freshly-spawned `claude --bg` has not yet registered
-  //    in the eventually-consistent `claude agents` snapshot (seconds normally,
-  //    slower under load), so `liveness` reports `absent` — looking exactly like a
-  //    crash. Before CTL-735 the reclaim sweep treated that as unambiguous death
-  //    and revived again; at the de-starved ~2-4s tick rate (CTL-731) it re-revived
-  //    each worker every tick → the revive storm (5→18→62→74 workers, load 72).
-  //    Defer reviving an `absent` worker whose signal was (re)dispatched within
-  //    reviveGraceMs. Self-clearing: once startedAt ages past the window a
-  //    still-absent worker is genuinely dead and proceeds to reclaim/revive below.
-  //    `idle`/`busy` are unaffected — `busy` already returned; `idle` has its own
-  //    confirmation streak. A signal with no parseable startedAt (legacy / can't
-  //    prove freshness) falls through to the pre-CTL-735 revive behaviour.
-  if (live === "absent") {
-    const startedAtMs = Date.parse(signal.raw?.startedAt ?? "");
-    if (Number.isFinite(startedAtMs) && now() - startedAtMs < reviveGraceMs) {
-      log.info(
-        { ticket, phase, prevBgJobId, sinceDispatchMs: now() - startedAtMs, reviveGraceMs },
-        "ctl-735: absent worker within post-dispatch grace window — revive deferred (revive-pending)",
-      );
-      return "revive-pending";
-    }
-  }
-
   // ── idle | absent share the reclaim-eligible path below.
   // CTL-606 — supersede guard. The reclaim sweep is fed ONE signal per ticket by
   // readWorkerSignals→byActivePhase, which ranks by status+recency, NOT phase
@@ -1461,6 +1436,32 @@ export function reclaimDeadWorkIfPossible(
   // genuinely between-turns with no committed work). A `busy` worker can never
   // reach here (the busy branch above returns first), so the revive/re-dispatch
   // path below is correct for both reclaim-eligible cases.
+
+  // CTL-735 Guard 1 — post-(re)dispatch grace window: the missing analog of the
+  // idle-confirmation streak for `absent`. A just-(re)dispatched worker has a NEW
+  // bg_job_id that a freshly-spawned `claude --bg` has not yet registered in the
+  // eventually-consistent `claude agents` snapshot (seconds normally, slower under
+  // load), so `liveness` reports `absent` — looking exactly like a crash. Before
+  // CTL-735 the sweep treated that as unambiguous death and revived again; at the
+  // de-starved ~2-4s tick rate (CTL-731) it re-revived each worker every tick →
+  // the revive storm (5→18→62→74 workers, load 72). Defer reviving an `absent`
+  // worker whose signal was (re)dispatched within reviveGraceMs. Placed inside
+  // branch (C) (work NOT done) so a just-completed worker still reclaims promptly
+  // via branch (B) above — only the storm-causing RE-REVIVE is deferred.
+  // Self-clearing: once startedAt ages past the window a still-absent worker is
+  // genuinely dead and proceeds to revive below. `idle` is unaffected (it has its
+  // own confirmation streak); a signal with no parseable startedAt (legacy) falls
+  // through to the pre-CTL-735 revive behaviour.
+  if (live === "absent") {
+    const startedAtMs = Date.parse(signal.raw?.startedAt ?? "");
+    if (Number.isFinite(startedAtMs) && now() - startedAtMs < reviveGraceMs) {
+      log.info(
+        { ticket, phase, prevBgJobId, sinceDispatchMs: now() - startedAtMs, reviveGraceMs },
+        "ctl-735: absent worker within post-dispatch grace window — revive deferred (revive-pending)",
+      );
+      return "revive-pending";
+    }
+  }
 
   // CTL-735 Guard 3 — inert stale tickets. By here the worker is reclaim-eligible
   // (absent or idle-confirmed), past its grace window, work NOT done. If its

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -31,6 +31,7 @@ import {
   log,
   IDLE_CONFIRM_TICKS,
   BUSY_CEILING_MS,
+  REVIVE_GRACE_MS,
 } from "./config.mjs";
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
@@ -1158,6 +1159,11 @@ export function reclaimDeadWorkIfPossible(
     bumpIdleStreak = defaultBumpIdleStreak,
     resetIdleStreak = defaultResetIdleStreak,
     idleConfirmTicks = IDLE_CONFIRM_TICKS,
+    // CTL-735 — post-(re)dispatch grace window for the `absent` class. A worker
+    // (re)dispatched within this window whose new bg_job_id is not yet visible in
+    // the eventually-consistent `claude agents` snapshot is deferred (revive-
+    // pending) rather than re-revived. Injectable so tests drive it deterministically.
+    reviveGraceMs = REVIVE_GRACE_MS,
     // CTL-662 — busy-forever backstop ceiling (measured from signal.startedAt).
     // The SOLE long backstop now that the mtime triggers are gone: a busy worker
     // past it with no committed work is flagged for human, never silent-reclaimed.
@@ -1269,6 +1275,31 @@ export function reclaimDeadWorkIfPossible(
     }
     log.info({ ticket, phase, prevBgJobId }, "ctl-662: busy worker — reclaim suppressed");
     return "alive-busy-suppressed";
+  }
+
+  // ── CTL-735: post-(re)dispatch grace window — the missing analog of the
+  //    idle-confirmation streak for `absent`. A just-(re)dispatched worker has a
+  //    NEW bg_job_id that a freshly-spawned `claude --bg` has not yet registered
+  //    in the eventually-consistent `claude agents` snapshot (seconds normally,
+  //    slower under load), so `liveness` reports `absent` — looking exactly like a
+  //    crash. Before CTL-735 the reclaim sweep treated that as unambiguous death
+  //    and revived again; at the de-starved ~2-4s tick rate (CTL-731) it re-revived
+  //    each worker every tick → the revive storm (5→18→62→74 workers, load 72).
+  //    Defer reviving an `absent` worker whose signal was (re)dispatched within
+  //    reviveGraceMs. Self-clearing: once startedAt ages past the window a
+  //    still-absent worker is genuinely dead and proceeds to reclaim/revive below.
+  //    `idle`/`busy` are unaffected — `busy` already returned; `idle` has its own
+  //    confirmation streak. A signal with no parseable startedAt (legacy / can't
+  //    prove freshness) falls through to the pre-CTL-735 revive behaviour.
+  if (live === "absent") {
+    const startedAtMs = Date.parse(signal.raw?.startedAt ?? "");
+    if (Number.isFinite(startedAtMs) && now() - startedAtMs < reviveGraceMs) {
+      log.info(
+        { ticket, phase, prevBgJobId, sinceDispatchMs: now() - startedAtMs, reviveGraceMs },
+        "ctl-735: absent worker within post-dispatch grace window — revive deferred (revive-pending)",
+      );
+      return "revive-pending";
+    }
   }
 
   // ── idle | absent share the reclaim-eligible path below.

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1164,6 +1164,13 @@ export function reclaimDeadWorkIfPossible(
     // the eventually-consistent `claude agents` snapshot is deferred (revive-
     // pending) rather than re-revived. Injectable so tests drive it deterministically.
     reviveGraceMs = REVIVE_GRACE_MS,
+    // CTL-735 — per-tick revive budget, threaded in by the scheduler sweep
+    // (PER_TICK_REVIVE_CAP minus revives already performed this tick). When <= 0
+    // an otherwise-revivable worker is `revive-capped` (deferred) rather than
+    // dispatched, so one tick cannot mass-revive. `undefined` (the default and
+    // every standalone/test caller that does not set it) disables the cap →
+    // pre-CTL-735 behaviour.
+    reviveBudgetRemaining = undefined,
     // CTL-662 — busy-forever backstop ceiling (measured from signal.startedAt).
     // The SOLE long backstop now that the mtime triggers are gone: a busy worker
     // past it with no committed work is flagged for human, never silent-reclaimed.
@@ -1479,6 +1486,22 @@ export function reclaimDeadWorkIfPossible(
       "ctl-587: revive suppressed (storm-breaker open)",
     );
     return "revive-suppressed";
+  }
+
+  // CTL-735 — per-tick revive cap. Even with the per-ticket budget and the
+  // event-counted storm-breaker open, the de-starved fast tick can mass-revive
+  // many distinct dead workers in a single sweep before the storm-breaker's
+  // event count catches up. The scheduler threads the remaining per-tick budget;
+  // once exhausted, defer this worker (revive-capped) to a later tick rather than
+  // dispatch. No event is emitted (we did NOT revive) and no marker is written,
+  // so the next tick re-evaluates cleanly. Gated on a finite budget so standalone
+  // callers (no scheduler) keep pre-CTL-735 behaviour.
+  if (Number.isFinite(reviveBudgetRemaining) && reviveBudgetRemaining <= 0) {
+    log.warn(
+      { ticket, phase, prevBgJobId },
+      "ctl-735: revive deferred — per-tick revive cap reached (revive-capped)",
+    );
+    return "revive-capped";
   }
 
   // CTL-658: resolve a `claude --resume`-compatible session id from the dead

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -32,6 +32,7 @@ import {
   IDLE_CONFIRM_TICKS,
   BUSY_CEILING_MS,
   REVIVE_GRACE_MS,
+  REVIVE_MAX_AGE_MS,
 } from "./config.mjs";
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
@@ -1171,6 +1172,11 @@ export function reclaimDeadWorkIfPossible(
     // every standalone/test caller that does not set it) disables the cap →
     // pre-CTL-735 behaviour.
     reviveBudgetRemaining = undefined,
+    // CTL-735 — revival age ceiling. An absent/idle, work-not-done worker whose
+    // signal has not been touched in this long is an abandoned historical dir,
+    // not a fresh crash: treated as inert (no revive, no escalate). Injectable for
+    // tests; defaults to the env-overridable config const.
+    reviveMaxAgeMs = REVIVE_MAX_AGE_MS,
     // CTL-662 — busy-forever backstop ceiling (measured from signal.startedAt).
     // The SOLE long backstop now that the mtime triggers are gone: a busy worker
     // past it with no committed work is flagged for human, never silent-reclaimed.
@@ -1455,6 +1461,28 @@ export function reclaimDeadWorkIfPossible(
   // genuinely between-turns with no committed work). A `busy` worker can never
   // reach here (the busy branch above returns first), so the revive/re-dispatch
   // path below is correct for both reclaim-eligible cases.
+
+  // CTL-735 Guard 3 — inert stale tickets. By here the worker is reclaim-eligible
+  // (absent or idle-confirmed), past its grace window, work NOT done. If its
+  // signal has not been touched in reviveMaxAgeMs it is an abandoned historical
+  // dir (isTicketInFlight keeps any non-terminal signal in-flight forever, so a
+  // worker that crashed at `running` and never flipped terminal is swept every
+  // tick). Reviving it wastes budget and — once MAX_REVIVES is hit — would
+  // escalate a long-dead ticket to needs-human. Treat it as inert: no revive, no
+  // escalate, no event. Branch (B) reclaim already ran above, so a genuinely
+  // work-done old worker was cleaned up; only no-work abandoned dirs reach here.
+  // A signal with no parseable timestamp (legacy) falls through unchanged.
+  const lastActiveMs = Math.max(
+    Date.parse(signal.raw?.updatedAt ?? "") || 0,
+    Date.parse(signal.raw?.startedAt ?? "") || 0,
+  );
+  if (lastActiveMs > 0 && now() - lastActiveMs > reviveMaxAgeMs) {
+    log.info(
+      { ticket, phase, prevBgJobId, ageMs: now() - lastActiveMs, reviveMaxAgeMs },
+      "ctl-735: signal too old to revive — abandoned historical dir, inert",
+    );
+    return "inert-stale";
+  }
 
   // Per-ticket revive budget from events.jsonl. The events file is the
   // authoritative counter — more truthful than the signal file (which the

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -462,7 +462,7 @@ describe("recoverStartup", () => {
 
 // implementSignal — a bg-shaped phase-implement signal with the orchestrator +
 // session-id fields the reclaim path threads into emit-complete.
-function implementSignal({ ticket = "CTL-9", status = "running", bgJobId = "job-x" } = {}) {
+function implementSignal({ ticket = "CTL-9", status = "running", bgJobId = "job-x", startedAt } = {}) {
   return {
     ticket,
     phase: "implement",
@@ -476,6 +476,10 @@ function implementSignal({ ticket = "CTL-9", status = "running", bgJobId = "job-
       status,
       bg_job_id: bgJobId,
       catalystSessionId: `sess_${ticket}_abc`,
+      // CTL-735: only present when a test exercises the post-(re)dispatch grace
+      // window. Absent by default so the existing absent-revive tests (which can't
+      // prove worker freshness) keep their pre-CTL-735 revive behaviour.
+      ...(startedAt !== undefined ? { startedAt } : {}),
     },
   };
 }
@@ -570,6 +574,79 @@ describe("reclaimDeadWorkIfPossible — turn-cap-exhausted (CTL-701)", () => {
     expect(r).toBe("revived");
     expect(reviveDispatch.calls.length).toBe(1);
     expect(reviveDispatch.calls[0][0].resumeSession).toBe("uuid-resume");
+  });
+});
+
+// CTL-735: post-(re)dispatch grace window — the missing analog of the
+// idle-confirmation streak for `absent`. A worker whose NEW bg_job_id is merely
+// `absent` from the eventually-consistent `claude agents` snapshot but whose
+// signal was (re)dispatched within REVIVE_GRACE_MS has almost certainly just not
+// registered yet, NOT crashed. Without this the de-starved fast tick (CTL-731)
+// re-classifies each just-revived worker as dead and revives it again every
+// ~2-4s → the revive storm (5→18→62→74 workers, load 72).
+describe("reclaimDeadWorkIfPossible — CTL-735 post-revive grace window", () => {
+  const orch = "/orch";
+  const NOW = 1_000_000;
+  const GRACE = 90_000;
+
+  // The revive seams shared by these cases — a probe that says "work not done"
+  // (so control reaches branch (C) revive) plus the budget/storm gates open.
+  const reviveSeams = (reviveDispatch) => ({
+    statJob: () => null,
+    probes: { implement: recorder(false) },
+    emitComplete: recorder({ code: 0 }),
+    appendReviveEvent: recorder(true),
+    reviveDispatch,
+    countReviveEvents: recorder(0),
+    countDistinctRevivingTickets: recorder(1),
+    writeReviveMarker: recorder(undefined),
+    killBgJob: recorder(undefined),
+    applyStalledLabel: recorder({ applied: true }),
+    resolveSession: () => null,
+    liveness: () => "absent",
+    reviveGraceMs: GRACE,
+    now: () => NOW,
+  });
+
+  test("absent worker (re)dispatched WITHIN the grace window → 'revive-pending', NOT revived", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const sig = implementSignal({
+      // startedAt 10s ago — well inside the 90s grace window.
+      startedAt: new Date(NOW - 10_000).toISOString(),
+    });
+    const r = reclaimDeadWorkIfPossible(orch, sig, reviveSeams(reviveDispatch));
+    expect(r).toBe("revive-pending");
+    expect(reviveDispatch.calls.length).toBe(0); // the storm-causing re-revive is suppressed
+  });
+
+  test("absent worker (re)dispatched PAST the grace window → revives (genuinely dead)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const sig = implementSignal({
+      // startedAt 100s ago — past the 90s window, so a still-absent worker is real death.
+      startedAt: new Date(NOW - 100_000).toISOString(),
+    });
+    const r = reclaimDeadWorkIfPossible(orch, sig, reviveSeams(reviveDispatch));
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("absent worker with NO startedAt → revives (back-compat: cannot prove freshness)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const sig = implementSignal(); // no startedAt
+    const r = reclaimDeadWorkIfPossible(orch, sig, reviveSeams(reviveDispatch));
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("grace window applies ONLY to absent — a busy worker is still suppressed as before", () => {
+    // A busy worker within the window must NOT become 'revive-pending'; it keeps
+    // its CTL-662 'alive-busy-suppressed' verdict (the grace guard is absent-only).
+    const reviveDispatch = recorder({ code: 0 });
+    const seams = reviveSeams(reviveDispatch);
+    seams.liveness = () => "busy";
+    const sig = implementSignal({ startedAt: new Date(NOW - 10_000).toISOString() });
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams);
+    expect(r).toBe("alive-busy-suppressed");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -654,6 +654,90 @@ describe("reclaimDeadWorkIfPossible — CTL-735 post-revive grace window", () =>
 // per-tick revive budget; once exhausted, an otherwise-revivable worker is
 // `revive-capped` (deferred to a later tick) instead of dispatched. This bounds
 // a fast loop that would otherwise outrun the event-count-lagged storm-breaker.
+// CTL-735 Guard 3 — keep long-dead tickets inert. isTicketInFlight treats any
+// ticket with a non-terminal signal as in-flight, so a worker that crashed at
+// `running` and never flipped terminal stays swept forever. Reviving such an
+// abandoned historical dir wastes budget and — once MAX_REVIVES is hit —
+// escalates dozens of long-dead tickets to needs-human. An absent/idle worker
+// whose signal has not been touched in REVIVE_MAX_AGE_MS (24h, well above any
+// real phase) is inert: no revive, no escalate. Branch (B) reclaim (work IS done)
+// still runs, so a genuinely-completed old worker is still cleaned up.
+describe("reclaimDeadWorkIfPossible — CTL-735 inert stale tickets", () => {
+  const orch = "/orch";
+  const NOW = 10_000_000_000; // a large epoch so "24h ago" is positive
+  const AGE = 24 * 60 * 60_000;
+
+  const seams = (reviveDispatch, escalate, probeDone, extra = {}) => ({
+    statJob: () => null,
+    probes: { implement: recorder(probeDone) },
+    emitComplete: recorder({ code: 0 }),
+    appendEvent: recorder(undefined),
+    appendReviveEvent: recorder(true),
+    appendEscalatedEvent: escalate,
+    reviveDispatch,
+    countReviveEvents: recorder(0),
+    countDistinctRevivingTickets: recorder(1),
+    writeReviveMarker: recorder(undefined),
+    killBgJob: recorder(undefined),
+    applyStalledLabel: recorder({ applied: true }),
+    resolveSession: () => null,
+    postReclaimMirror: () => {},
+    liveness: () => "absent",
+    reviveMaxAgeMs: AGE,
+    now: () => NOW,
+    ...extra,
+  });
+
+  test("absent, work-not-done, signal older than REVIVE_MAX_AGE_MS → 'inert-stale' (no revive, no escalate)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const escalate = recorder(undefined);
+    const sig = implementSignal({
+      // updatedAt 25h ago — past the 24h inert threshold.
+      startedAt: new Date(NOW - 25 * 60 * 60_000).toISOString(),
+    });
+    sig.raw.updatedAt = new Date(NOW - 25 * 60 * 60_000).toISOString();
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams(reviveDispatch, escalate, false));
+    expect(r).toBe("inert-stale");
+    expect(reviveDispatch.calls.length).toBe(0);
+    expect(escalate.calls.length).toBe(0);
+  });
+
+  test("absent, work-not-done, signal WITHIN the age window → revives (fresh crash, not abandoned)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const escalate = recorder(undefined);
+    // 10 min ago: past the 90s grace window (Guard 1) but well within the 24h
+    // inert threshold (Guard 3) — a genuine recent crash that should revive.
+    const sig = implementSignal({
+      startedAt: new Date(NOW - 10 * 60_000).toISOString(),
+    });
+    sig.raw.updatedAt = new Date(NOW - 10 * 60_000).toISOString();
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams(reviveDispatch, escalate, false));
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("old signal but work IS done → still reclaimed (branch B), NOT left inert", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const escalate = recorder(undefined);
+    const sig = implementSignal({
+      startedAt: new Date(NOW - 25 * 60 * 60_000).toISOString(),
+    });
+    sig.raw.updatedAt = new Date(NOW - 25 * 60 * 60_000).toISOString();
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams(reviveDispatch, escalate, true));
+    expect(r).toBe("reclaimed");
+    expect(reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("old signal with NO parseable timestamps → revives (back-compat: cannot judge age)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const escalate = recorder(undefined);
+    const sig = implementSignal(); // no startedAt/updatedAt
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams(reviveDispatch, escalate, false));
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+});
+
 describe("reclaimDeadWorkIfPossible — CTL-735 per-tick revive cap", () => {
   const orch = "/orch";
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -650,6 +650,64 @@ describe("reclaimDeadWorkIfPossible — CTL-735 post-revive grace window", () =>
   });
 });
 
+// CTL-735 Guard 2 — per-tick revive cap. The scheduler passes the remaining
+// per-tick revive budget; once exhausted, an otherwise-revivable worker is
+// `revive-capped` (deferred to a later tick) instead of dispatched. This bounds
+// a fast loop that would otherwise outrun the event-count-lagged storm-breaker.
+describe("reclaimDeadWorkIfPossible — CTL-735 per-tick revive cap", () => {
+  const orch = "/orch";
+
+  // All gates open so control reaches branch (C) and WOULD revive absent the cap.
+  const openReviveSeams = (reviveDispatch, extra = {}) => ({
+    statJob: () => null,
+    probes: { implement: recorder(false) },
+    emitComplete: recorder({ code: 0 }),
+    appendReviveEvent: recorder(true),
+    reviveDispatch,
+    countReviveEvents: recorder(0),
+    countDistinctRevivingTickets: recorder(1),
+    writeReviveMarker: recorder(undefined),
+    killBgJob: recorder(undefined),
+    applyStalledLabel: recorder({ applied: true }),
+    resolveSession: () => null,
+    liveness: () => "absent",
+    ...extra,
+  });
+
+  test("reviveBudgetRemaining = 0 → 'revive-capped', does NOT dispatch", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal(),
+      openReviveSeams(reviveDispatch, { reviveBudgetRemaining: 0 }),
+    );
+    expect(r).toBe("revive-capped");
+    expect(reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("reviveBudgetRemaining = 1 → revives normally (budget available)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal(),
+      openReviveSeams(reviveDispatch, { reviveBudgetRemaining: 1 }),
+    );
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("reviveBudgetRemaining undefined → revives (back-compat: no cap enforced)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal(),
+      openReviveSeams(reviveDispatch), // no reviveBudgetRemaining
+    );
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+});
+
 describe("reclaimDeadWorkIfPossible", () => {
   const orch = "/orch";
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1384,6 +1384,11 @@ export function schedulerTick(
   const reclaimed = [];
   const revived = [];
   const reviveSuppressed = [];
+  // CTL-735: workers deferred by the post-(re)dispatch grace window (absent but
+  // recently dispatched → not yet registered in `claude agents`). A high count
+  // here with low `revived` is the healthy steady state during the controlled
+  // daemon re-enable — it means the storm-causing re-revive race is suppressed.
+  const revivePending = [];
   const escalated = [];
   // CTL-643: drop terminal tickets from the reclaim attention set.
   // reclaimDeadWorkIfPossible already short-circuits on terminal signals
@@ -1464,6 +1469,12 @@ export function schedulerTick(
           break;
         case "revive-suppressed":
           reviveSuppressed.push(entry);
+          break;
+        case "revive-pending":
+          // CTL-735: absent worker still inside its post-dispatch grace window —
+          // deferred, not revived. Surfaced (not silent) so the controlled
+          // re-enable can confirm the storm-causing re-revive race is suppressed.
+          revivePending.push(entry);
           break;
         case "escalated":
           escalated.push(entry);
@@ -2049,6 +2060,7 @@ export function schedulerTick(
     reclaimed,
     revived,
     reviveSuppressed,
+    revivePending,
     escalated,
     advanced,
     dispatched,

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -84,7 +84,7 @@ import * as linearWrite from "./linear-write.mjs";
 // a cycle. label-guard.mjs is the leaf module both can import.
 import { labelOnce } from "./label-guard.mjs";
 import { countReapOutcomes } from "./reaper-metrics.mjs";
-import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
+import { log, getEligibleDir, getEventLogPath, PER_TICK_REVIVE_CAP } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -1317,6 +1317,12 @@ export function schedulerTick(
     reclaimDeadWork = defaultReclaimDeadWork,
     now = Date.now, // CTL-624: injectable clock for the dispatch cool-down
     cache, // CTL-634: opt-in out-of-set blocker state cache
+    // CTL-735 — max revives per tick. The reclaim sweep threads the remaining
+    // budget (cap minus revives so far this tick) into reclaimDeadWork; once
+    // exhausted, further revivable workers are `revive-capped` (deferred). Bounds
+    // a fast loop so it cannot mass-revive ahead of the storm-breaker. Injectable
+    // for tests; defaults to the env-overridable config const.
+    perTickReviveCap = PER_TICK_REVIVE_CAP,
     // CTL-665: the committed worker-slot concurrency knobs (maxParallel +
     // minParallel/maxParallelCeiling bounds), threaded from the daemon via
     // startScheduler → runningOpts → runTick. Empty {} preserves the legacy
@@ -1389,6 +1395,10 @@ export function schedulerTick(
   // here with low `revived` is the healthy steady state during the controlled
   // daemon re-enable — it means the storm-causing re-revive race is suppressed.
   const revivePending = [];
+  // CTL-735: workers deferred because this tick's per-tick revive cap was reached.
+  // A non-empty bucket means a real backlog is draining at the bounded rate (not a
+  // storm); it empties over subsequent ticks as the cap re-arms.
+  const reviveCapped = [];
   const escalated = [];
   // CTL-643: drop terminal tickets from the reclaim attention set.
   // reclaimDeadWorkIfPossible already short-circuits on terminal signals
@@ -1458,6 +1468,10 @@ export function schedulerTick(
       if (liveAgents) {
         reclaimOpts.liveness = (bgJobId) => livenessForBgJob(bgJobId, { agents: liveAgents });
       }
+      // CTL-735: remaining per-tick revive budget = cap minus revives already
+      // performed this tick. reclaimDeadWork returns "revive-capped" (deferred)
+      // once this is <= 0 instead of dispatching, so one sweep cannot mass-revive.
+      reclaimOpts.reviveBudgetRemaining = perTickReviveCap - revived.length;
       const r = reclaimDeadWork(orchDir, sig, reclaimOpts);
       const entry = { ticket: sig.ticket, phase: sig.phase };
       switch (r) {
@@ -1475,6 +1489,12 @@ export function schedulerTick(
           // deferred, not revived. Surfaced (not silent) so the controlled
           // re-enable can confirm the storm-causing re-revive race is suppressed.
           revivePending.push(entry);
+          break;
+        case "revive-capped":
+          // CTL-735: this tick's per-tick revive cap was reached — deferred to a
+          // later tick. Surfaced so the re-enable can confirm a backlog drains at
+          // the bounded rate rather than storming.
+          reviveCapped.push(entry);
           break;
         case "escalated":
           escalated.push(entry);
@@ -2061,6 +2081,7 @@ export function schedulerTick(
     revived,
     reviveSuppressed,
     revivePending,
+    reviveCapped,
     escalated,
     advanced,
     dispatched,

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1520,6 +1520,9 @@ export function schedulerTick(
           // CTL-606: superseded-noop also buckets here — a dead predecessor signal
           // the ticket has already advanced past. Invisible by design (the active
           // phase is progressing normally); surfacing it would be noise.
+          // CTL-735: inert-stale also buckets here — an abandoned historical dir
+          // too old to revive. Invisible by design (steady-state; ~85 such dirs
+          // would otherwise be persistent noise).
           break;
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Follow-up to **CTL-731** (#1225, #1226). The de-starvation work sped the execution-core scheduler tick to ~2–4s, which **unmasked a pre-existing reclaim/revive defect into a runaway worker-spawn storm**: each daemon restart this session escalated 5 → 18 → 62 → 74 live `claude` workers; load average hit **72**. The daemon has been **stopped** since the incident.

This PR adds three complementary guards that bound the revive path so de-starvation is safe.

## Root cause

A **liveness-lag race** amplified by the fast tick. A worker revived 2–4s ago has a NEW `bg_job_id`, but a freshly-spawned `claude --bg` is not yet registered in the eventually-consistent `claude agents` snapshot → `liveness` reports `absent` — indistinguishable from a crash. The reclaim sweep then re-revived it every tick. The existing bounds failed at speed: `MAX_REVIVES` resets per boot, and the fleet storm-breaker is event-count-lagged (it fired 1954× but ~86 leaked first). The sweep also walks ~85 historical worker dirs.

`defaultReviveDispatch` *does* write the new `bg_job_id` back on a successful dispatch — the bug is the absent-after-revive re-classification race + insufficient fast-tick bounds, not a missing writeback.

## The three guards

1. **Post-(re)dispatch grace window** (`recovery.mjs`, branch C) — an `absent` worker (re)dispatched within `REVIVE_GRACE_MS` (90s) is `revive-pending`, not re-revived. The missing analog of the idle-confirmation streak for `absent`; self-clearing via the worker's fresh `startedAt`. Placed in branch C so a just-completed worker still reclaims promptly via branch B.
2. **Per-tick revive cap** (`scheduler.mjs` → `recovery.mjs`) — at most `PER_TICK_REVIVE_CAP` (2) revives per tick; further revivable workers are `revive-capped` (deferred). A fast loop can't outrun the lagged storm-breaker.
3. **Inert stale tickets** (`recovery.mjs`, branch C) — an absent/idle, work-not-done worker whose signal hasn't been touched in `REVIVE_MAX_AGE_MS` (24h) is an abandoned historical dir → `inert-stale` (no revive, no escalate). Prevents reviving + escalating dozens of long-dead tickets to needs-human. Branch B (work-done) still reclaims; legacy signals without a timestamp fall through.

All three constants are env-overridable. New `revivePending` / `reviveCapped` scheduler-result buckets give observability for the controlled re-enable.

## Tests

- `recovery.test.mjs` — grace-window, per-tick-cap, and inert-stale unit blocks (within/past thresholds, back-compat fall-through, busy-still-suppressed, work-done-still-reclaimed).
- `integration-ctl-587.test.mjs` — single-tick breadth bound (5 dead → 2 revived, 3 capped) **and a storm reproduction**: 20 fast ticks × 5 always-absent dead workers → each revives **exactly once** (not once-per-tick; pre-fix ≈ 100 spawns).
- Full execution-core suite: **1486 pass, 1 fail** — the failure is the pre-existing `cli/sessions` `classifyRow` test (red on `origin/main`, untouched by this branch).

## ⚠️ Merge + re-enable (human-gated)

This is a **hot-path** change to recovery/scheduler. The execution-core daemon is **STOPPED and must stay stopped** until this merges. **Do not auto-merge.** After merge, perform the controlled re-enable: hotpatch the cache (`rsync -ac`, never `--delete`) into the running-pinned `10.1.0`, start the daemon, and **watch the first 2–3 minutes** — confirm revives stay bounded (high `revivePending`, low `revived`, no storm) with `catalyst-execution-core stop` ready.

Refs CTL-735. Related to CTL-731.