### PR TITLE
fix(dev): stabilize main — revive idle/budget gaps + cache-only de-starvation reconciliation (CTL-735 / CTL-736 PR-0)

### DIFF
--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -36,7 +36,14 @@ import { statSync } from "node:fs";
 import { scanEventsChunked } from "./event-tail.mjs";
 import { getEventLogPath } from "./config.mjs";
 
-const REVIVE_NAME_PREFIX = "phase.implement.revive.";
+// CTL-735: revive events are phase-agnostic — `phase.<phase>.revive.<ticket>`.
+// CTL-604 extended revive to triage/research/plan/verify, but this scan still
+// matched only `phase.implement.revive.` — so the per-ticket budget (MAX_REVIVES)
+// and the storm-breaker never counted non-implement revives, and those phases
+// slow-looped forever (the triage/verify storm at the CTL-731 re-enable). Match
+// ANY single phase segment. (`[^.]+` is one segment, so this does NOT match
+// `phase.remediate.complete.` or `phase.revive.reap-requested`.)
+const REVIVE_NAME_RE = /^phase\.[^.]+\.revive\./;
 const REMEDIATE_NAME_PREFIX = "phase.remediate.complete.";
 
 // Per-path incremental index. We retain ONLY the two event families the counters
@@ -46,7 +53,7 @@ const _index = new Map(); // path -> { cursor, leftover, events: [{ name, orchId
 function isRelevant(name) {
   return (
     typeof name === "string" &&
-    (name.startsWith(REVIVE_NAME_PREFIX) || name.startsWith(REMEDIATE_NAME_PREFIX))
+    (REVIVE_NAME_RE.test(name) || name.startsWith(REMEDIATE_NAME_PREFIX))
   );
 }
 
@@ -97,9 +104,15 @@ function refreshIndex(path) {
 // full `event.name`, with the optional orchId / since filters applied exactly
 // as the pre-CTL-673 whole-file scan did.
 function countByExactName(target, { orchId, since, path }) {
+  return countByMatch((name) => name === target, { orchId, since, path });
+}
+
+// countByMatch — like countByExactName but matches names via a predicate, so the
+// phase-agnostic revive counter (CTL-735) can match `phase.<any>.revive.<ticket>`.
+function countByMatch(nameMatches, { orchId, since, path }) {
   let n = 0;
   for (const ev of refreshIndex(path).events) {
-    if (ev.name !== target) continue;
+    if (typeof ev.name !== "string" || !nameMatches(ev.name)) continue;
     if (orchId && ev.orchId !== orchId) continue;
     if (since && ev.ts && ev.ts < since) continue;
     n++;
@@ -113,7 +126,16 @@ function countByExactName(target, { orchId, since, path }) {
 // match is tolerant of a missing attribute on either side (defensive default).
 export function countReviveEvents({ ticket, orchId, since, path = getEventLogPath() } = {}) {
   if (!ticket) throw new Error("countReviveEvents: ticket required");
-  return countByExactName(`${REVIVE_NAME_PREFIX}${ticket}`, { orchId, since, path });
+  // CTL-735: match `phase.<any-phase>.revive.<ticket>` (the suffix uniquely
+  // identifies a revive for this exact ticket — `.revive.CTL-728` cannot match
+  // `.revive.CTL-7281`/`.revive.CTL-1728`). Phase-agnostic so every phase's
+  // revive consumes the per-ticket MAX_REVIVES budget, not just implement.
+  const suffix = `.revive.${ticket}`;
+  return countByMatch((name) => name.startsWith("phase.") && name.endsWith(suffix), {
+    orchId,
+    since,
+    path,
+  });
 }
 
 // countRemediateCycles — number of phase.remediate.complete.<ticket> envelopes
@@ -141,7 +163,7 @@ export function countDistinctRevivingTickets({
   const cutoff = now() - windowMs;
   const seen = new Set();
   for (const ev of refreshIndex(path).events) {
-    if (typeof ev.name !== "string" || !ev.name.startsWith(REVIVE_NAME_PREFIX)) continue;
+    if (typeof ev.name !== "string" || !REVIVE_NAME_RE.test(ev.name)) continue; // CTL-735: any phase
     const tsMs = Date.parse(ev.ts || "");
     if (!Number.isFinite(tsMs) || tsMs < cutoff) continue;
     if (ev.label) seen.add(ev.label);

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -48,17 +48,40 @@ describe("countReviveEvents", () => {
     expect(countReviveEvents({ ticket: "CTL-9", path: join(dir, "events.jsonl") })).toBe(0);
   });
 
-  test("counts only the matching ticket + phase + action", () => {
+  test("counts the matching ticket + revive action across ALL phases (CTL-735)", () => {
+    // CTL-604 made revive phase-agnostic (triage/research/plan/verify, not just
+    // implement). The per-ticket budget MUST count every phase's revive, else a
+    // non-implement phase never exhausts MAX_REVIVES and slow-loops forever (the
+    // triage/verify storm seen at the CTL-731 re-enable).
     const { path } = tempLog([
-      makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:00:00Z" }), // match
-      makeEvent({ ticket: "CTL-9", ts: "2026-05-24T00:01:00Z" }), // match
-      makeEvent({ ticket: "CTL-10", ts: "2026-05-24T00:00:00Z" }), // diff ticket
-      makeEvent({ ticket: "CTL-9", action: "reclaim", ts: "2026-05-24T00:02:00Z" }), // diff action
-      makeEvent({ ticket: "CTL-9", phase: "plan", ts: "2026-05-24T00:03:00Z" }), // diff phase
+      makeEvent({ ticket: "CTL-9", phase: "implement", ts: "2026-05-24T00:00:00Z" }), // match
+      makeEvent({ ticket: "CTL-9", phase: "implement", ts: "2026-05-24T00:01:00Z" }), // match
+      makeEvent({ ticket: "CTL-10", ts: "2026-05-24T00:00:00Z" }), // diff ticket — excluded
+      makeEvent({ ticket: "CTL-9", action: "reclaim", ts: "2026-05-24T00:02:00Z" }), // diff action — excluded
+      makeEvent({ ticket: "CTL-9", phase: "plan", ts: "2026-05-24T00:03:00Z" }), // plan revive — NOW counts
       "not json", // skipped
       "", // skipped (empty)
     ]);
-    expect(countReviveEvents({ ticket: "CTL-9", path })).toBe(2);
+    expect(countReviveEvents({ ticket: "CTL-9", path })).toBe(3);
+  });
+
+  test("counts triage and verify revives (phase-agnostic budget) (CTL-735)", () => {
+    const { path } = tempLog([
+      makeEvent({ ticket: "CTL-728", phase: "triage", ts: "2026-05-24T00:00:00Z" }),
+      makeEvent({ ticket: "CTL-728", phase: "triage", ts: "2026-05-24T00:01:00Z" }),
+      makeEvent({ ticket: "CTL-726", phase: "verify", ts: "2026-05-24T00:00:00Z" }),
+    ]);
+    expect(countReviveEvents({ ticket: "CTL-728", path })).toBe(2);
+    expect(countReviveEvents({ ticket: "CTL-726", path })).toBe(1);
+  });
+
+  test("does not let a similar ticket id bleed across (suffix-safe)", () => {
+    const { path } = tempLog([
+      makeEvent({ ticket: "CTL-728", phase: "triage", ts: "2026-05-24T00:00:00Z" }),
+      makeEvent({ ticket: "CTL-7281", phase: "triage", ts: "2026-05-24T00:01:00Z" }),
+      makeEvent({ ticket: "CTL-1728", phase: "triage", ts: "2026-05-24T00:02:00Z" }),
+    ]);
+    expect(countReviveEvents({ ticket: "CTL-728", path })).toBe(1);
   });
 
   test("respects orchId filter when set", () => {

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -14,13 +14,14 @@
 // managed-agents port lands, only the executors here swap to control-plane
 // APIs. The schema, the producers, and the consumer count are all stable.
 
-import { spawnSync, execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { scanEventsChunked } from "./event-tail.mjs";
 import { shortIdFromSessionId, isSelfSession } from "./claude-ids.mjs";
 import { emitReapIntent, REAP_INTENT_TYPES } from "./reap-intent.mjs";
 import { lastSeenMsForSession } from "./session-recency.mjs";
+import { getAgentsCached } from "./claude-agents.mjs";
 import { log } from "./config.mjs";
 
 const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
@@ -642,13 +643,17 @@ async function defaultExecutorReap(shortId) {
   }
 }
 
-async function defaultAgents() {
-  try {
-    const out = execFileSync(CLAUDE_BIN, ["agents", "--json"], { encoding: "utf8" });
-    return JSON.parse(out);
-  } catch {
-    return [];
-  }
+// CTL-731: the reaper runs on the shared daemon event loop alongside the
+// scheduler. Pre-CTL-731 it shelled out `claude agents --json` SYNCHRONOUSLY
+// here every pass — and under heavy session load (many duplicate workers) that
+// call balloons to multiple seconds, blocking the loop and starving the
+// scheduler tick (a self-sustaining wedge: dupes make `claude agents` slow → the
+// sync read blocks the loop → the scheduler can't tick → can't reclaim the dupes).
+// Route it through the warm, never-blocking snapshot instead — the same primitive
+// the scheduler/autotune/wait-watcher use. Returns last-good synchronously and
+// fires a background refresh when stale; never spawns on the calling thread.
+export async function defaultAgents() {
+  return getAgentsCached().agents;
 }
 
 async function defaultEmit(eventType, fields) {

--- a/plugins/dev/scripts/execution-core/reaper.test.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.test.mjs
@@ -6,7 +6,13 @@ import {
   ticketFromCwd,
   groupBackgroundSessionsByTicket,
   CLEANUP_GRACE_MS,
+  defaultAgents,
 } from "./reaper.mjs";
+import {
+  refreshAgents,
+  getAgentsCached,
+  resetLivenessCache,
+} from "./claude-agents.mjs";
 
 function silentLog() {
   return { info: () => {}, warn: () => {}, error: () => {} };
@@ -18,6 +24,36 @@ function agentsFixture(rows = []) {
 
 beforeEach(() => {
   delete process.env.CLAUDE_CODE_SESSION_ID;
+});
+
+// CTL-731 de-starvation: the reaper's default agent source must read through the
+// warm, never-blocking getAgentsCached snapshot — NOT a synchronous
+// execFileSync("claude agents --json") on the shared daemon loop (the starvation
+// source). These lock in that defaultAgents delegates to the cached snapshot.
+describe("defaultAgents (CTL-731 non-blocking agent source)", () => {
+  beforeEach(() => resetLivenessCache());
+
+  it("returns the warm getAgentsCached snapshot, never spawning synchronously", async () => {
+    const rows = [
+      { sessionId: "11111111-aaaa-bbbb-cccc-dddddddddddd", status: "idle", kind: "background" },
+      { sessionId: "22222222-aaaa-bbbb-cccc-dddddddddddd", status: "busy", kind: "background" },
+    ];
+    // Populate the async snapshot via the same async seam the scheduler uses —
+    // no real subprocess, and crucially no SYNC spawn.
+    await refreshAgents({ execFileAsync: async () => JSON.stringify(rows) });
+
+    const fromCache = getAgentsCached().agents;
+    const fromReaper = await defaultAgents();
+
+    expect(fromReaper).toEqual(rows);
+    expect(fromReaper).toEqual(fromCache);
+  });
+
+  it("serves [] from a cold snapshot rather than blocking on a read", async () => {
+    // Cold cache (just reset) → getter returns [] synchronously and only fires a
+    // fire-and-forget refresh; defaultAgents must mirror that, never await a spawn.
+    expect(await defaultAgents()).toEqual([]);
+  });
 });
 
 describe("Reaper._handleBgReap", () => {

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1437,27 +1437,28 @@ export function reclaimDeadWorkIfPossible(
   // reach here (the busy branch above returns first), so the revive/re-dispatch
   // path below is correct for both reclaim-eligible cases.
 
-  // CTL-735 Guard 1 — post-(re)dispatch grace window: the missing analog of the
-  // idle-confirmation streak for `absent`. A just-(re)dispatched worker has a NEW
-  // bg_job_id that a freshly-spawned `claude --bg` has not yet registered in the
-  // eventually-consistent `claude agents` snapshot (seconds normally, slower under
-  // load), so `liveness` reports `absent` — looking exactly like a crash. Before
-  // CTL-735 the sweep treated that as unambiguous death and revived again; at the
-  // de-starved ~2-4s tick rate (CTL-731) it re-revived each worker every tick →
-  // the revive storm (5→18→62→74 workers, load 72). Defer reviving an `absent`
-  // worker whose signal was (re)dispatched within reviveGraceMs. Placed inside
-  // branch (C) (work NOT done) so a just-completed worker still reclaims promptly
-  // via branch (B) above — only the storm-causing RE-REVIVE is deferred.
-  // Self-clearing: once startedAt ages past the window a still-absent worker is
-  // genuinely dead and proceeds to revive below. `idle` is unaffected (it has its
-  // own confirmation streak); a signal with no parseable startedAt (legacy) falls
-  // through to the pre-CTL-735 revive behaviour.
-  if (live === "absent") {
+  // CTL-735 Guard 1 — post-(re)dispatch grace window. A just-(re)dispatched worker
+  // needs time to start working before the sweep judges it dead. It can present as
+  // EITHER `absent` (a freshly-spawned `claude --bg` not yet registered in the
+  // eventually-consistent `claude agents` snapshot) OR `idle` (registered but
+  // waiting for its first turn — common for triage/verify, which don't go `busy`
+  // immediately like implement does). Before CTL-735 the sweep revived an absent
+  // worker as dead; the short idle-confirmation streak (~2 ticks) re-revived an
+  // idle one every ~20-30s. Both produced the de-starved revive storm (5→18→62→74
+  // workers, load 72; live re-enable showed the idle path storm triage/verify).
+  // Defer reviving an `absent` OR `idle` worker whose signal was (re)dispatched
+  // within reviveGraceMs. `busy` is already handled above (a working worker is
+  // never reclaimed). Placed inside branch (C) (work NOT done) so a just-completed
+  // worker still reclaims promptly via branch (B). Self-clearing: once startedAt
+  // ages past the window the worker is judged on its real liveness and proceeds to
+  // revive below. A signal with no parseable startedAt (legacy) falls through to
+  // the pre-CTL-735 revive behaviour.
+  if (live === "absent" || live === "idle") {
     const startedAtMs = Date.parse(signal.raw?.startedAt ?? "");
     if (Number.isFinite(startedAtMs) && now() - startedAtMs < reviveGraceMs) {
       log.info(
-        { ticket, phase, prevBgJobId, sinceDispatchMs: now() - startedAtMs, reviveGraceMs },
-        "ctl-735: absent worker within post-dispatch grace window — revive deferred (revive-pending)",
+        { ticket, phase, prevBgJobId, live, sinceDispatchMs: now() - startedAtMs, reviveGraceMs },
+        "ctl-735: worker within post-dispatch grace window — revive deferred (revive-pending)",
       );
       return "revive-pending";
     }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -638,9 +638,39 @@ describe("reclaimDeadWorkIfPossible — CTL-735 post-revive grace window", () =>
     expect(reviveDispatch.calls.length).toBe(1);
   });
 
-  test("grace window applies ONLY to absent — a busy worker is still suppressed as before", () => {
-    // A busy worker within the window must NOT become 'revive-pending'; it keeps
-    // its CTL-662 'alive-busy-suppressed' verdict (the grace guard is absent-only).
+  test("idle worker (re)dispatched WITHIN the grace window → 'revive-pending' (registered, not yet working)", () => {
+    // A freshly-revived worker commonly registers as `idle` (waiting for its
+    // first turn) before it goes `busy`. The short idle-confirmation streak
+    // (~2 ticks) would otherwise re-revive it every ~20-30s — the triage/verify
+    // storm seen at re-enable. The grace window must cover idle too, not just
+    // absent. idleConfirmTicks/bumpIdleStreak injected so the worker reaches
+    // branch (C) on the first idle observation (where the grace check lives).
+    const reviveDispatch = recorder({ code: 0 });
+    const seams = reviveSeams(reviveDispatch);
+    seams.liveness = () => "idle";
+    seams.idleConfirmTicks = 1;
+    seams.bumpIdleStreak = () => 1;
+    seams.resetIdleStreak = () => {};
+    const sig = implementSignal({ startedAt: new Date(NOW - 10_000).toISOString() });
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams);
+    expect(r).toBe("revive-pending");
+    expect(reviveDispatch.calls.length).toBe(0);
+  });
+
+  test("idle worker PAST the grace window → revives (genuinely idle-done, not just-started)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const seams = reviveSeams(reviveDispatch);
+    seams.liveness = () => "idle";
+    seams.idleConfirmTicks = 1;
+    seams.bumpIdleStreak = () => 1;
+    seams.resetIdleStreak = () => {};
+    const sig = implementSignal({ startedAt: new Date(NOW - 100_000).toISOString() });
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams);
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("a busy worker is suppressed as alive (busy is handled before the grace window)", () => {
     const reviveDispatch = recorder({ code: 0 });
     const seams = reviveSeams(reviveDispatch);
     seams.liveness = () => "busy";

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1421,12 +1421,30 @@ export function schedulerTick(
   // POPULATED. A cold / never-populated snapshot returns agents:[] — binding that
   // empty list would make EVERY live worker resolve to "absent" (agentForShortId
   // over []) and trigger a mass false-revive on the first post-boot tick, before
-  // the async read has resolved. When unpopulated, leave liveAgents null so the
-  // reclaim falls back to its per-worker real read (pre-CTL-731 behavior) for the
-  // one cold tick; the snapshot warms within a sub-second and later ticks use it.
-  // A populated-but-stale snapshot is fine for reclaim (≤ a few seconds old, same
-  // as the pre-existing 5s TTL) — only NEW-work dispatch needs the isFresh gate.
+  // the async read has resolved. When unpopulated, leave liveAgents null; in
+  // production (a wired snapshot seam) reclaimColdSkip below then defers the whole
+  // sweep for that one cold tick, and the snapshot warms within a sub-second so
+  // later ticks reclaim against it. A null seam (tests) keeps the legacy
+  // per-worker real read. A populated-but-stale snapshot is fine for reclaim (≤ a
+  // few seconds old, same as the 5s TTL) — only NEW-work dispatch needs isFresh.
   const liveAgents = liveSnapshot && liveSnapshot.populated ? liveSnapshot.agents : null;
+
+  // CTL-731: when a snapshot seam is wired (production) but the snapshot is still
+  // COLD (never-populated — the first post-boot tick, before the async read
+  // resolves), SKIP the reclaim sweep this tick rather than fall back to a
+  // per-worker SYNC `claude agents` read for EVERY in-flight worker. Under heavy
+  // session load that fan-out of synchronous spawns re-starves the loop (the very
+  // failure mode Phase 00 removed) and would wedge the boot tick. The snapshot
+  // warms within a sub-second async refresh (getAgentsCached already fired one);
+  // the next tick reclaims against the shared warm list. A null seam (tests) keeps
+  // the legacy per-worker reclaim path.
+  const reclaimColdSkip = Boolean(livenessSnapshot) && !liveAgents;
+  if (reclaimColdSkip) {
+    log.info(
+      {},
+      "scheduler: reclaim sweep skipped — liveness snapshot cold, awaiting warm read (CTL-731)",
+    );
+  }
 
   // CTL-702: scan worker dirs for yield tombstones. Emit once per unique
   // absolute path per daemon lifetime (deduped via observedYieldFiles).
@@ -1448,6 +1466,7 @@ export function schedulerTick(
   }
 
   for (const sig of readWorkerSignals(orchDir)) {
+    if (reclaimColdSkip) break; // CTL-731: cold snapshot — defer reclaim to the next (warm) tick
     if (!inFlightTickets.has(sig.ticket)) continue;
     // CTL-705: a parked ("preempted") worker is paused, not dead. Its signal
     // preserves the now-killed bg_job_id, so classifyWorker would route it

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1469,13 +1469,16 @@ describe("schedulerTick — new-work pull", () => {
     expect(r.dispatched).toEqual(["CTL-9"]);
   });
 
-  // CTL-731: a COLD/never-populated snapshot must NOT bind its empty agents list
-  // into the reclaim liveness — doing so would resolve every live worker to
-  // "absent" (agentForShortId over []) and mass-false-revive on the first
-  // post-boot tick. Cold → reclaim falls back to its own per-worker real read.
-  test("a cold liveness snapshot does NOT bind reclaim liveness (no boot mass-false-revive)", () => {
+  // CTL-731: a COLD/never-populated snapshot with a WIRED seam (production) must
+  // SKIP the whole reclaim sweep for that one boot tick (reclaimColdSkip) — NOT
+  // bind its empty agents list (which would resolve every live worker to "absent"
+  // and mass-false-revive) AND not fall back to a per-worker SYNC `claude agents`
+  // read for every worker (N synchronous spawns that re-starve the loop, the very
+  // failure mode Phase 00 removed). The snapshot warms within a sub-second; the
+  // next (warm) tick reclaims against the shared list.
+  test("a cold liveness snapshot SKIPS the reclaim sweep (no boot mass-false-revive, no per-worker re-starve)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
-    writeSignal("CTL-1", "implement", "running"); // an in-flight worker the reclaim sweep visits
+    writeSignal("CTL-1", "implement", "running"); // an in-flight worker the sweep would visit
     const reclaimOpts = [];
     const reclaimDeadWork = (_orchDir, _sig, opts) => {
       reclaimOpts.push(opts);
@@ -1489,8 +1492,29 @@ describe("schedulerTick — new-work pull", () => {
       livenessSnapshot: () => ({ populated: false, agents: [], isFresh: false }),
       livenessIsFresh: () => false,
     });
+    // cold + wired seam → the entire sweep is deferred; reclaimDeadWork never runs
+    expect(reclaimOpts.length).toBe(0);
+  });
+
+  // The skip is gated on a WIRED seam: a null livenessSnapshot (legacy/test
+  // harnesses) keeps the per-worker reclaim path so those callers are unaffected.
+  test("a null liveness seam still runs the per-worker reclaim sweep (reclaimColdSkip off)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-1", "implement", "running");
+    const reclaimOpts = [];
+    const reclaimDeadWork = (_orchDir, _sig, opts) => {
+      reclaimOpts.push(opts);
+      return "noop";
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      reclaimDeadWork,
+      liveBackgroundCount: () => 1,
+      livenessSnapshot: null, // no seam → reclaimColdSkip is false
+      livenessIsFresh: () => false,
+    });
     expect(reclaimOpts.length).toBeGreaterThan(0);
-    // cold → no injected liveness binding (reclaim uses its default real read)
     expect(reclaimOpts.every((o) => o.liveness === undefined)).toBe(true);
   });
 


### PR DESCRIPTION
## What & why

**PR-0 of the CTL-736 revive-storm root-cause work** — pure stabilization of `main`, no redesign yet. Lands two test-green follow-up fixes from the CTL-735 live re-enable, and reconciles two de-starvation fixes that were hotpatched into the live plugin cache but **never merged to main** (a fresh install / version bump would silently regress the daemon).

Research + design proposal for the full redesign: `thoughts/shared/research/2026-05-29_CTL-735_revive-liveness-root-cause-and-lease-design.md` (tracked in CTL-736).

## Changes

### 1. Revive-bound follow-up fixes (CTL-735)
- **idle-grace gap** (`recovery.mjs`) — the post-dispatch grace window only covered `absent`, not `idle`. A freshly-revived triage/verify worker registers `idle` while awaiting its first turn and was re-revived every ~20–30s (implement workers go `busy` immediately, so only triage/verify stormed). Grace now guards `live === "absent" || live === "idle"`.
- **phase-blind revive budget** (`event-scan.mjs`) — the revive counters hardcoded the `phase.implement.revive.` prefix, so `MAX_REVIVES` only ever bounded IMPLEMENT (since CTL-604 made revive phase-agnostic). Triage/verify revives were never indexed → budget never exhausted → infinite slow-loop. Now phase-agnostic `REVIVE_NAME_RE = /^phase\.[^.]+\.revive\./` + a suffix-safe `countByMatch`.

Both proven by the round-3 controlled re-enable (revives plateaued at 4, `bg` stable, no slow-loop).

### 2. Cache-only de-starvation reconciliation (CTL-736 PR-0)
- **reaper `getAgentsCached`** (`reaper.mjs`) — the reaper ran a synchronous `execFileSync("claude agents --json")` every pass on the shared daemon loop; under load that blocks the loop and starves the scheduler tick. Routed through the warm, never-blocking snapshot (same primitive the scheduler/autotune use).
- **scheduler `reclaimColdSkip`** (`scheduler.mjs`) — on the first cold post-boot tick, the prior fallback did a per-worker sync `claude agents` read for *every* in-flight worker (N synchronous spawns → re-starvation). Now the whole reclaim sweep is deferred for that one cold tick; the snapshot warms within a sub-second. Gated on a wired seam, so null-seam (test/legacy) callers keep the per-worker path.

> Note: `reclaimColdSkip` is slated for retirement by CTL-736 (the `state.json` death-trigger redesign supersedes the cold-snapshot fallback). Porting it now keeps `main` == the proven live cache until that lands.

## Tests
- `recovery.test.mjs`: idle-within-grace / idle-past-grace cases.
- `event-scan.test.mjs`: triage/verify + suffix-collision budget cases (flipped the old implement-only spec, which was the bug-as-spec).
- `reaper.test.mjs`: `defaultAgents` delegates to the warm snapshot, never a sync spawn (+ cold → `[]`).
- `scheduler.test.mjs`: cold snapshot SKIPS the sweep; null seam keeps the per-worker path.
- Full execution-core suite: **1493 pass / 1 fail** — the single failure (`cli/sessions classifyRow`) pre-exists on clean `main`, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)