### PR TITLE
feat(dev): atomic single-flight worker claim + fencing token (CTL-736 Phase 1)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-claim-fence-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-claim-fence-e2e.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# End-to-end composition test for the CTL-736 Phase 1 claim + fencing token.
+#
+# The unit suites (claim.test.mjs, phase-agent-dispatch Tests 40-43,
+# phase-agent-emit-complete Tests 12-16) each exercise ONE script. This test
+# composes the REAL phase-agent-dispatch and phase-agent-emit-complete through
+# the full revive-storm loop — only `claude --bg` is stubbed — to prove Phase
+# 1's guarantee: a wrong "is this worker dead?" guess can neither double-spawn
+# nor double-emit.
+#
+#   1. fresh dispatch                      → generation 1, one worker
+#   2. concurrent revive storm (2 ticks)   → exactly ONE new worker, gen ⇒ 2
+#                                            (not 3 — the concurrent twin loses
+#                                            the O_EXCL claim, no runaway)
+#   3. stale gen-1 worker emits complete   → FENCED (no event, signal unchanged)
+#   4. current gen-2 worker emits complete → done, exactly one complete event
+#
+# Scope note: the daemon's revive DECISION (recovery.mjs death trigger) is
+# simulated here by flipping the signal to `stalled` and re-dispatching — Phase
+# 1 does not change that trigger (that is Phase 2). This validates the claim +
+# fence SAFETY NET against the still-live wrong-guess trigger.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-agent-claim-fence-e2e.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+DISPATCH="${REPO_ROOT}/plugins/dev/scripts/phase-agent-dispatch"
+EMIT="${REPO_ROOT}/plugins/dev/scripts/phase-agent-emit-complete"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t phase-claim-fence-e2e-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+assert_eq() {
+	local expected="$1" actual="$2" label="$3"
+	if [[ $expected == "$actual" ]]; then
+		pass "$label"
+	else
+		fail "$label — expected '$expected', got '$actual'"
+	fi
+}
+
+if [[ ! -x $DISPATCH || ! -x $EMIT ]]; then
+	echo "FATAL: dispatch/emit script not found or not executable" >&2
+	exit 1
+fi
+
+# ─── Fixture ─────────────────────────────────────────────────────────────────
+# A stub `claude` that records one line per spawn (with the generation it was
+# launched at) and prints a fresh 8-hex job id so the dispatcher's parser is
+# satisfied. triage is the carrier phase: it needs no prior artifact and is NOT
+# a rebase phase, so the dispatch path reduces to exactly the claim + spawn.
+BIN_DIR="${SCRATCH}/bin"
+ORCH_DIR="${SCRATCH}/orch"
+WORKER_DIR="${ORCH_DIR}/workers/CTL-100"
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+SPAWN_LOG="${SCRATCH}/spawns.log"
+mkdir -p "$BIN_DIR" "$WORKER_DIR" "${SCRATCH}/proj" "${SCRATCH}/catalyst/events"
+cat >"${BIN_DIR}/claude" <<'STUB'
+#!/usr/bin/env bash
+printf 'spawn gen=%s\n' "${CATALYST_GENERATION:-?}" >>"$SPAWN_LOG"
+printf 'backgrounded · %08x%08x\n' "$RANDOM$$" "$RANDOM" | cut -c1-30
+exit 0
+STUB
+chmod +x "${BIN_DIR}/claude"
+export PATH="${BIN_DIR}:${PATH}"
+export SPAWN_LOG
+export CATALYST_DIR="${SCRATCH}/catalyst"
+# Neutralize the machine-config fallback so the host's real config never leaks in.
+export CATALYST_MACHINE_CONFIG="${SCRATCH}/machine-config-absent.json"
+
+dispatch() { (cd "${SCRATCH}/proj" && "$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id CTL-100 "$@"); }
+# grep -c already prints 0 (exit 1) on no match, so a `|| echo 0` fallback would
+# emit a SECOND 0 ("0\n0"). Just read grep -c's stdout; the files always exist
+# (SPAWN_LOG is truncated before each count; the events glob fails to a clean 0).
+spawn_count() { grep -c '^spawn ' "$SPAWN_LOG" 2>/dev/null; }
+complete_events() { cat "${CATALYST_DIR}/events/"*.jsonl 2>/dev/null | grep -c '"phase.triage.complete.CTL-100"'; }
+
+# ─── 1. Fresh dispatch ───────────────────────────────────────────────────────
+echo "Step 1: fresh dispatch"
+: >"$SPAWN_LOG"
+dispatch >/dev/null 2>&1
+assert_eq "1" "$(jq -r '.generation' "$SIGNAL")" "fresh dispatch stamps generation = 1"
+assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "fresh dispatch leaves signal running"
+assert_eq "yes" "$([[ -f "${WORKER_DIR}/triage.claim.1" ]] && echo yes || echo no)" "claim file triage.claim.1 created"
+assert_eq "1" "$(spawn_count)" "exactly one worker spawned"
+
+# ─── 2. Concurrent revive storm ──────────────────────────────────────────────
+# Simulate the daemon falsely declaring the worker dead and reviving it TWICE
+# at the same instant (the storm shape from the research). The revive flips the
+# signal to stalled; two parallel re-dispatches then race the gen-2 claim.
+echo ""
+echo "Step 2: concurrent revive storm (2 simultaneous false revives)"
+: >"$SPAWN_LOG"
+jq '.status = "stalled" | .attentionReason = "ctl-587-revive-reset"' "$SIGNAL" >"${SIGNAL}.t" && mv "${SIGNAL}.t" "$SIGNAL"
+dispatch >/dev/null 2>&1 &
+dispatch >/dev/null 2>&1 &
+wait
+assert_eq "1" "$(spawn_count)" "storm spawned exactly ONE new worker (the concurrent twin lost the claim)"
+assert_eq "2" "$(jq -r '.generation' "$SIGNAL")" "generation advanced to 2 only (no runaway to 3)"
+assert_eq "yes" "$([[ -f "${WORKER_DIR}/triage.claim.2" ]] && echo yes || echo no)" "fresh claim file triage.claim.2 created"
+assert_eq "no" "$([[ -e "${WORKER_DIR}/triage.claim.3" ]] && echo yes || echo no)" "no triage.claim.3 (the twin did not win a new generation)"
+
+# ─── 3. Fencing: the stale gen-1 worker tries to complete ────────────────────
+echo ""
+echo "Step 3: the stale gen-1 worker (false-dead, still alive) tries to emit complete"
+FENCE_ERR=$(CATALYST_GENERATION=1 CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
+	"$EMIT" --phase triage --ticket CTL-100 --status complete --orch-dir "$ORCH_DIR" 2>&1)
+FENCE_RC=$?
+assert_eq "0" "$FENCE_RC" "stale emit exits 0 (clean bow-out)"
+assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "stale emit does NOT flip the signal (still running)"
+assert_eq "0" "$(complete_events)" "stale emit writes NO complete event"
+if [[ $FENCE_ERR == *"stale-generation-bow-out"* ]]; then
+	pass "stale emit logs stale-generation-bow-out"
+else
+	fail "stale emit should log stale-generation-bow-out (got: $FENCE_ERR)"
+fi
+
+# ─── 4. The current gen-2 worker completes ───────────────────────────────────
+echo ""
+echo "Step 4: the current gen-2 worker emits complete"
+CURGEN=$(jq -r '.generation' "$SIGNAL")
+CATALYST_GENERATION="$CURGEN" CATALYST_ORCHESTRATOR_DIR="$ORCH_DIR" \
+	"$EMIT" --phase triage --ticket CTL-100 --status complete --orch-dir "$ORCH_DIR" >/dev/null 2>&1
+assert_eq "done" "$(jq -r '.status' "$SIGNAL")" "current-generation emit flips the signal to done"
+assert_eq "1" "$(complete_events)" "exactly one phase.triage.complete event (no double-complete)"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "phase-agent-claim-fence-e2e: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1364,6 +1364,90 @@ NOW_HEAD="$(cd "$GWORK" && git rev-parse HEAD)"
 assert_eq "$ORIG_HEAD" "$NOW_HEAD" "fetch fail: worktree HEAD unchanged (un-rebased)"
 assert_eq "yes" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "fetch fail: worker still spawned"
 
+# ─── CTL-736 Phase 1: atomic single-flight generation claim + fencing token ──
+# The claim makes a duplicate worker spawn structurally impossible: each
+# (ticket, phase, generation) is O_EXCL-claimed, exactly one dispatcher wins.
+
+echo ""
+echo "Test 40 (CTL-736): fresh dispatch stamps generation=1 + exports CATALYST_GENERATION"
+fresh_env t40_generation
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "1" "$(jq -r '.generation' "$SIGNAL")" "fresh dispatch: signal.generation = 1"
+assert_eq "yes" "$([[ -f "${WORKER_DIR}/triage.claim.1" ]] && echo yes || echo no)" \
+	"fresh dispatch: O_EXCL claim file triage.claim.1 created"
+# The fencing token reaches the worker env. Use --dry-run (side-effect-free,
+# read-only generation) in a SEPARATE fixture so its env array is inspectable.
+fresh_env t40_env
+DRY=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run 2>/dev/null)
+GEN_ENTRY=$(echo "$DRY" | jq -r '.env[] | select(startswith("CATALYST_GENERATION="))')
+assert_eq "CATALYST_GENERATION=1" "$GEN_ENTRY" "dry-run env array carries CATALYST_GENERATION=1"
+assert_eq "no" "$([[ -e "${WORKER_DIR}/triage.claim.1" ]] && echo yes || echo no)" \
+	"dry-run never creates a real claim file (preview is side-effect-free)"
+
+echo ""
+echo "Test 41 (CTL-736): two concurrent dispatches → exactly one claude --bg spawn"
+fresh_env t41_concurrent
+# Launch two near-simultaneous dispatches for the same (ticket, phase). The
+# O_EXCL claim serializes them: exactly one wins (spawns), the other no-ops.
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	>"${TEST_DIR}/c1.out" 2>/dev/null &
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	>"${TEST_DIR}/c2.out" 2>/dev/null &
+wait
+SPAWN_COUNT=$(grep -c -- '--ARGS--' "$CLAUDE_STUB_LOG" 2>/dev/null || echo 0)
+assert_eq "1" "$SPAWN_COUNT" "exactly one claude --bg spawn across two concurrent dispatches"
+# Exactly one stdout reports a live spawn (status=running); the other no-ops.
+RUNNING_COUNT=0
+IDEMPOTENT_COUNT=0
+for f in "${TEST_DIR}/c1.out" "${TEST_DIR}/c2.out"; do
+	S=$(jq -r '.status // empty' "$f" 2>/dev/null || echo "")
+	[[ $S == "running" ]] && RUNNING_COUNT=$((RUNNING_COUNT + 1))
+	[[ "$(jq -r '.idempotent // false' "$f" 2>/dev/null || echo false)" == "true" ]] && \
+		IDEMPOTENT_COUNT=$((IDEMPOTENT_COUNT + 1))
+done
+assert_eq "1" "$RUNNING_COUNT" "exactly one dispatch reports status=running (the winner)"
+assert_eq "1" "$IDEMPOTENT_COUNT" "exactly one dispatch reports idempotent:true (the loser)"
+
+echo ""
+echo "Test 42 (CTL-736): a revive (stalled signal) bumps the generation and re-claims"
+fresh_env t42_revive
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+assert_eq "1" "$(jq -r '.generation' "$SIGNAL")" "first dispatch: generation = 1"
+# Simulate the daemon's defaultReviveDispatch: flip the signal to stalled.
+TMP_REVIVE="${SIGNAL}.tmp"
+jq '.status = "stalled" | .attentionReason = "ctl-587-revive-reset"' "$SIGNAL" >"$TMP_REVIVE" && mv "$TMP_REVIVE" "$SIGNAL"
+rm -f "$CLAUDE_STUB_LOG" # count only the revive's spawn
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1
+assert_eq "2" "$(jq -r '.generation' "$SIGNAL")" "revive: generation bumped to 2"
+assert_eq "yes" "$([[ -f "${WORKER_DIR}/triage.claim.2" ]] && echo yes || echo no)" \
+	"revive: fresh O_EXCL claim file triage.claim.2 created"
+assert_eq "1" "$(grep -c -- '--ARGS--' "$CLAUDE_STUB_LOG" 2>/dev/null || echo 0)" \
+	"revive spawned exactly one new worker"
+
+echo ""
+echo "Test 43 (CTL-736): fresh dispatch targets a FIXED gen (not high-water+1) → claim-lost, no spawn"
+fresh_env t43_fixed_target
+# Pre-seed a held claim at generation 1 with NO signal file. A fresh dispatch
+# must target generation 1 (fixed by the absent signal) and collide with the
+# tombstone — NOT advance to gen 2 off the claim-file high-water mark (which
+# would WIN and double-spawn). This deterministically exercises the new
+# `claim-lost` loser branch (the concurrent Test 41 loser can also exit via the
+# older status short-circuit, so it doesn't pin this branch).
+printf '{"generation":1,"claimedAt":"2026-05-30T00:00:00Z"}\n' >"${WORKER_DIR}/triage.claim.1"
+STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC43=$?
+assert_eq "0" "$RC43" "fixed-target claim-lost exits 0"
+assert_eq "claim-lost" "$(echo "$STDOUT" | jq -r '.status')" "loser stdout status = claim-lost (not a fresh spawn at gen 2)"
+assert_eq "true" "$(echo "$STDOUT" | jq -r '.idempotent')" "loser stdout idempotent = true"
+assert_eq "1" "$(echo "$STDOUT" | jq -r '.generation')" "loser reports the contested generation = 1 (fixed target)"
+assert_eq "no" "$([[ -e "${WORKER_DIR}/triage.claim.2" ]] && echo yes || echo no)" \
+	"fresh dispatch did NOT advance to gen 2 (proves target is fixed, not high-water+1)"
+assert_eq "no" "$([[ -f "${WORKER_DIR}/phase-triage.json" ]] && echo yes || echo no)" \
+	"loser writes no signal file (bows out before the signal write)"
+assert_eq "no" "$([[ -s "$CLAUDE_STUB_LOG" ]] && echo yes || echo no)" "loser did NOT spawn claude --bg"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -271,6 +271,55 @@ assert_eq "skipped" "$NEW_STATUS" "signal file status updated to skipped"
 assert_eq "true" "$HAS_COMPLETED" "skipped is terminal → completedAt set"
 assert_eq "abc" "$BG" "bg_job_id preserved (memory: project_phase_monitor_deploy_signal_overwrite)"
 
+# ─── CTL-736 Phase 1: fencing check (stale generation bows out) ──────────────
+
+echo ""
+echo "Test 12 (CTL-736): stale generation (mine < signal) bows out — no event, no signal write"
+fresh_env t12
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"ticket":"CTL-100","phase":"implement","status":"running","generation":3}' >"$SIGNAL"
+CATALYST_GENERATION=2 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+RC=$?
+assert_eq "0" "$RC" "stale-generation emit exits 0 (clean bow-out)"
+assert_eq "running" "$(jq -r '.status' "$SIGNAL")" "stale-generation emit does NOT flip the signal (still running)"
+LINE=$(read_event_line)
+assert_eq "" "$LINE" "stale-generation emit writes no phase event"
+
+echo ""
+echo "Test 13 (CTL-736): current generation (mine == signal) proceeds normally"
+fresh_env t13
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"ticket":"CTL-100","phase":"implement","status":"running","generation":2}' >"$SIGNAL"
+CATALYST_GENERATION=2 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+assert_eq "done" "$(jq -r '.status' "$SIGNAL")" "current-generation emit flips the signal to done"
+EVENT_NAME=$(read_event_line | jq -r '.attributes."event.name"')
+assert_eq "phase.implement.complete.CTL-100" "$EVENT_NAME" "current-generation emit writes the complete event"
+
+echo ""
+echo "Test 14 (CTL-736): a higher generation than the signal proceeds (never a false bow-out)"
+fresh_env t14
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"ticket":"CTL-100","phase":"implement","status":"running","generation":2}' >"$SIGNAL"
+CATALYST_GENERATION=3 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+assert_eq "done" "$(jq -r '.status' "$SIGNAL")" "mine > signal still emits (fences only on mine < signal)"
+
+echo ""
+echo "Test 15 (CTL-736): no CATALYST_GENERATION (legacy worker) proceeds — fail-open"
+fresh_env t15
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"ticket":"CTL-100","phase":"implement","status":"running","generation":5}' >"$SIGNAL"
+unset CATALYST_GENERATION
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+assert_eq "done" "$(jq -r '.status' "$SIGNAL")" "unfenced worker (no CATALYST_GENERATION) still emits"
+
+echo ""
+echo "Test 16 (CTL-736): legacy signal without a generation field proceeds — fail-open"
+fresh_env t16
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"ticket":"CTL-100","phase":"implement","status":"running"}' >"$SIGNAL"
+CATALYST_GENERATION=2 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
+assert_eq "done" "$(jq -r '.status' "$SIGNAL")" "signal without generation field still emits (no fence data)"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/execution-core/claim.mjs
+++ b/plugins/dev/scripts/execution-core/claim.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+// claim.mjs — atomic single-flight phase claim + fencing generation (CTL-736 Phase 1).
+//
+// The death-decision guard stack (busy short-circuit, idle-confirm streak,
+// revive-grace window, MAX_REVIVES, storm-breaker, the phase-skill bg_job_id
+// bow-out heuristics) all exist to dampen the SAME failure: a wrong "is this
+// worker dead?" guess spawns a SECOND worker for one (ticket, phase). This file
+// makes that duplicate structurally impossible.
+//
+//   • claimPhase(orchDir, ticket, phase, generation) — open(O_CREAT|O_EXCL) of
+//     ${orchDir}/workers/<ticket>/<phase>.claim.<generation>. Exactly one
+//     caller wins per generation; concurrent same-generation callers collide.
+//   • The generation is a monotonic FENCING TOKEN. A fresh dispatch claims
+//     gen=currentGeneration+1 (1 when nothing is held); a revive (sequential,
+//     post-death) claims the next generation — a NEW filename, so O_EXCL
+//     succeeds for it regardless of whether the dead generation's claim file is
+//     still on disk.
+//   • The signal carries `generation`; the worker receives CATALYST_GENERATION
+//     in its env and asserts isCurrentGeneration(signal, mine) before emitting
+//     any outcome (the structural replacement for the bg_job_id orphan-bow-out).
+//
+// PURE filesystem primitives — no event log, no spawn. Both a library (imported
+// by recovery.mjs / tests) and a CLI (shelled into by phase-agent-dispatch and
+// phase-agent-emit-complete, which are bash).
+
+import { openSync, writeSync, closeSync, unlinkSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// claimPath — the per-generation claim file. One file per generation so the
+// next generation is ALWAYS a fresh exclusive create (the revive never has to
+// wait on a release of the dead generation's claim).
+export function claimPath(orchDir, ticket, phase, generation) {
+  return join(orchDir, "workers", ticket, `${phase}.claim.${generation}`);
+}
+
+// claimPhase — atomic compare-and-set. open(…, "wx") is the Node spelling of
+// O_CREAT|O_EXCL: it creates the file or fails with EEXIST, never truncates an
+// existing one. Returns {won:true} for the single winner, {won:false} for every
+// loser at that generation. Any non-EEXIST error (e.g. ENOENT on a missing
+// worker dir) propagates — that is a real misconfiguration, not a lost race.
+export function claimPhase(orchDir, ticket, phase, generation) {
+  const path = claimPath(orchDir, ticket, phase, generation);
+  try {
+    const fd = openSync(path, "wx");
+    try {
+      writeSync(fd, JSON.stringify({ generation, claimedAt: new Date().toISOString() }));
+    } finally {
+      closeSync(fd);
+    }
+    return { won: true, generation };
+  } catch (e) {
+    if (e.code === "EEXIST") return { won: false, generation };
+    throw e;
+  }
+}
+
+// releaseClaim — unlink a generation's claim file (hygiene: teardown, or a
+// terminal phase whose claims will never be re-claimed). NOT required for the
+// revive path to win the next generation — that is guaranteed by the
+// per-generation filename. Returns true if a file was removed, false if absent.
+export function releaseClaim(orchDir, ticket, phase, generation) {
+  try {
+    unlinkSync(claimPath(orchDir, ticket, phase, generation));
+    return true;
+  } catch (e) {
+    if (e.code === "ENOENT") return false;
+    throw e;
+  }
+}
+
+// currentGeneration — the high-water generation held for (ticket, phase): the
+// max `.claim.<n>` suffix in the worker dir, or 0 if none. A spawn-path
+// dispatcher claims this + 1, which unifies fresh (0→1) and revive (N→N+1) and
+// survives a deleted-signal worktree recreate (a stale claim tombstone still
+// advances the high-water mark, so the recreate's re-dispatch claims a fresh
+// generation instead of colliding on gen 1).
+export function currentGeneration(orchDir, ticket, phase) {
+  let names;
+  try {
+    names = readdirSync(join(orchDir, "workers", ticket));
+  } catch {
+    return 0; // worker dir absent → nothing claimed yet
+  }
+  const prefix = `${phase}.claim.`;
+  let max = 0;
+  for (const name of names) {
+    if (!name.startsWith(prefix)) continue;
+    const n = Number.parseInt(name.slice(prefix.length), 10);
+    if (Number.isInteger(n) && n > max) max = n;
+  }
+  return max;
+}
+
+// isCurrentGeneration — the fencing predicate. true ⇒ this worker is current
+// (proceed); false ⇒ the signal generation has advanced past it (a duplicate
+// took over) so it must bow out. Conservative on missing data: a legacy signal
+// with no `generation`, or a worker with no generation, returns true so the
+// pre-CTL-736 bow-out heuristics still cover the migration window.
+export function isCurrentGeneration(signal, myGeneration) {
+  const sig = Number(signal?.generation);
+  if (!Number.isFinite(sig)) return true; // legacy signal — nothing to fence against
+  const mine = Number(myGeneration);
+  if (myGeneration === "" || myGeneration === undefined || !Number.isFinite(mine)) {
+    return true; // worker has no generation (legacy spawn) — don't bow out
+  }
+  return mine >= sig; // stale (mine < sig) ⇒ bow out
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+//
+// Subcommands (all stdout is one JSON line unless noted):
+//   dispatch-claim <orchDir> <ticket> <phase>
+//       compute gen = currentGeneration+1, claim it → {won, generation}. exit 0.
+//   claim <orchDir> <ticket> <phase> <generation>
+//       claim an explicit generation → {won, generation}. exit 0 even on loss
+//       (a lost race is a normal outcome the caller reads from .won).
+//   current-generation <orchDir> <ticket> <phase>
+//       print the high-water generation integer.
+//   release <orchDir> <ticket> <phase> <generation>
+//       unlink the claim → {released}. exit 0.
+//   fence-check <orchDir> <ticket> <phase>
+//       compare $CATALYST_GENERATION against signal.generation →
+//       {current, signalGeneration, myGeneration}. exit 0 when current
+//       (proceed), exit FENCE_STALE_EXIT (10) when stale (bow out).
+
+const FENCE_STALE_EXIT = 10;
+
+function isMain() {
+  // True when run as `node claim.mjs …`, false when imported.
+  return (
+    process.argv[1] &&
+    (process.argv[1].endsWith("/claim.mjs") || process.argv[1].endsWith("claim.mjs"))
+  );
+}
+
+function readSignal(orchDir, ticket, phase) {
+  const p = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  try {
+    return JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function cli(argv) {
+  const [cmd, orchDir, ticket, phase, gen] = argv;
+  switch (cmd) {
+    case "dispatch-claim": {
+      const generation = currentGeneration(orchDir, ticket, phase) + 1;
+      const res = claimPhase(orchDir, ticket, phase, generation);
+      process.stdout.write(JSON.stringify(res) + "\n");
+      return 0;
+    }
+    case "claim": {
+      const res = claimPhase(orchDir, ticket, phase, Number(gen));
+      process.stdout.write(JSON.stringify(res) + "\n");
+      return 0;
+    }
+    case "current-generation": {
+      process.stdout.write(String(currentGeneration(orchDir, ticket, phase)) + "\n");
+      return 0;
+    }
+    case "release": {
+      const released = releaseClaim(orchDir, ticket, phase, Number(gen));
+      process.stdout.write(JSON.stringify({ released }) + "\n");
+      return 0;
+    }
+    case "fence-check": {
+      const signal = readSignal(orchDir, ticket, phase);
+      const myGeneration = process.env.CATALYST_GENERATION;
+      const current = isCurrentGeneration(signal, myGeneration);
+      process.stdout.write(
+        JSON.stringify({
+          current,
+          signalGeneration: signal?.generation ?? null,
+          myGeneration: myGeneration ?? null,
+        }) + "\n",
+      );
+      return current ? 0 : FENCE_STALE_EXIT;
+    }
+    default:
+      process.stderr.write(
+        `claim.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
+          "usage: claim.mjs <dispatch-claim|claim|current-generation|release|fence-check> …\n",
+      );
+      return 1;
+  }
+}
+
+if (isMain()) {
+  process.exit(cli(process.argv.slice(2)));
+}

--- a/plugins/dev/scripts/execution-core/claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/claim.test.mjs
@@ -1,0 +1,198 @@
+// claim.test.mjs — atomic single-flight claim + fencing generation (CTL-736 Phase 1).
+//
+// The claim makes duplicate worker spawn structurally impossible: each
+// (ticket, phase, generation) is claimed by an atomic open(O_CREAT|O_EXCL);
+// exactly one dispatcher wins, all others no-op. The generation is a monotonic
+// fencing token written into the signal; a worker whose generation is stale
+// self-disqualifies before any outcome write.
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  claimPhase,
+  releaseClaim,
+  isCurrentGeneration,
+  currentGeneration,
+  claimPath,
+} from "./claim.mjs";
+
+const CLAIM_BIN = fileURLToPath(new URL("./claim.mjs", import.meta.url));
+
+let ORCH_DIR;
+
+beforeEach(() => {
+  ORCH_DIR = mkdtempSync(join(tmpdir(), "claim-"));
+  // claimPhase writes under ${orchDir}/workers/<ticket>/; make the ticket dir.
+  mkdirSync(join(ORCH_DIR, "workers", "CTL-1"), { recursive: true });
+});
+
+describe("claimPhase — atomic single-flight per generation", () => {
+  it("two concurrent claims at the same generation: exactly one wins", async () => {
+    const results = await Promise.all([
+      Promise.resolve().then(() => claimPhase(ORCH_DIR, "CTL-1", "implement", 1)),
+      Promise.resolve().then(() => claimPhase(ORCH_DIR, "CTL-1", "implement", 1)),
+    ]);
+    expect(results.filter((r) => r.won)).toHaveLength(1);
+    expect(results.filter((r) => !r.won)).toHaveLength(1);
+  });
+
+  it("a higher generation can re-claim after death (revive path)", () => {
+    expect(claimPhase(ORCH_DIR, "CTL-1", "implement", 1).won).toBe(true);
+    // gen 1 still held → same-gen reclaim fails…
+    expect(claimPhase(ORCH_DIR, "CTL-1", "implement", 1).won).toBe(false);
+    // …but the next generation is a fresh exclusive file → succeeds, even
+    // WITHOUT releasing gen 1 (per-generation filenames guarantee freshness).
+    expect(claimPhase(ORCH_DIR, "CTL-1", "implement", 2).won).toBe(true);
+  });
+
+  it("a lost claim reports the held generation and never overwrites the winner", () => {
+    const first = claimPhase(ORCH_DIR, "CTL-1", "implement", 1);
+    const second = claimPhase(ORCH_DIR, "CTL-1", "implement", 1);
+    expect(first.won).toBe(true);
+    expect(second.won).toBe(false);
+    // The winner's claim file is intact — the loser did not truncate it.
+    const body = JSON.parse(readFileSync(claimPath(ORCH_DIR, "CTL-1", "implement", 1), "utf8"));
+    expect(body.generation).toBe(1);
+    expect(typeof body.claimedAt).toBe("string");
+  });
+
+  it("claim is O_EXCL (create-exclusive), never a read-then-write race", () => {
+    // White-box: pre-create the claim file, then a claim at that generation must
+    // fail with won:false (EEXIST) rather than truncating/overwriting it. Proves
+    // the create uses the wx/O_EXCL flag, not existsSync()+write.
+    const path = claimPath(ORCH_DIR, "CTL-1", "implement", 7);
+    writeFileSync(path, "SENTINEL");
+    expect(claimPhase(ORCH_DIR, "CTL-1", "implement", 7).won).toBe(false);
+    expect(readFileSync(path, "utf8")).toBe("SENTINEL");
+  });
+
+  it("distinct (ticket, phase) pairs do not collide", () => {
+    mkdirSync(join(ORCH_DIR, "workers", "CTL-2"), { recursive: true });
+    expect(claimPhase(ORCH_DIR, "CTL-1", "implement", 1).won).toBe(true);
+    expect(claimPhase(ORCH_DIR, "CTL-1", "verify", 1).won).toBe(true);
+    expect(claimPhase(ORCH_DIR, "CTL-2", "implement", 1).won).toBe(true);
+  });
+});
+
+describe("releaseClaim", () => {
+  it("unlinks the claim file and reports released:true", () => {
+    claimPhase(ORCH_DIR, "CTL-1", "implement", 1);
+    expect(existsSync(claimPath(ORCH_DIR, "CTL-1", "implement", 1))).toBe(true);
+    expect(releaseClaim(ORCH_DIR, "CTL-1", "implement", 1)).toBe(true);
+    expect(existsSync(claimPath(ORCH_DIR, "CTL-1", "implement", 1))).toBe(false);
+  });
+
+  it("releasing an absent claim is a no-op (released:false), never throws", () => {
+    expect(releaseClaim(ORCH_DIR, "CTL-1", "implement", 99)).toBe(false);
+  });
+});
+
+describe("currentGeneration — max held generation", () => {
+  it("returns 0 when nothing is claimed (fresh dispatch ⇒ gen 1)", () => {
+    expect(currentGeneration(ORCH_DIR, "CTL-1", "implement")).toBe(0);
+  });
+
+  it("returns the highest claimed generation suffix", () => {
+    claimPhase(ORCH_DIR, "CTL-1", "implement", 1);
+    claimPhase(ORCH_DIR, "CTL-1", "implement", 2);
+    claimPhase(ORCH_DIR, "CTL-1", "implement", 5);
+    expect(currentGeneration(ORCH_DIR, "CTL-1", "implement")).toBe(5);
+  });
+
+  it("a released lower generation does not lower the high-water mark", () => {
+    claimPhase(ORCH_DIR, "CTL-1", "implement", 1);
+    claimPhase(ORCH_DIR, "CTL-1", "implement", 2);
+    releaseClaim(ORCH_DIR, "CTL-1", "implement", 1);
+    expect(currentGeneration(ORCH_DIR, "CTL-1", "implement")).toBe(2);
+  });
+
+  it("is scoped per phase — verify claims don't count toward implement", () => {
+    claimPhase(ORCH_DIR, "CTL-1", "verify", 3);
+    expect(currentGeneration(ORCH_DIR, "CTL-1", "implement")).toBe(0);
+  });
+});
+
+describe("isCurrentGeneration — fencing check", () => {
+  it("a worker whose generation < signal.generation bows out", () => {
+    expect(isCurrentGeneration({ generation: 3 }, 2)).toBe(false);
+    expect(isCurrentGeneration({ generation: 3 }, 3)).toBe(true);
+    expect(isCurrentGeneration({ generation: 3 }, 4)).toBe(true);
+  });
+
+  it("legacy signal without a generation field ⇒ proceed (never bow out)", () => {
+    expect(isCurrentGeneration({}, 1)).toBe(true);
+    expect(isCurrentGeneration(null, 1)).toBe(true);
+  });
+
+  it("worker without a generation (CATALYST_GENERATION unset) ⇒ proceed", () => {
+    expect(isCurrentGeneration({ generation: 3 }, undefined)).toBe(true);
+    expect(isCurrentGeneration({ generation: 3 }, "")).toBe(true);
+  });
+});
+
+// ─── CLI surface (the bash dispatch/emit/skill callers shell into this) ──────
+
+function runCli(args, env = {}) {
+  return spawnSync(process.execPath, [CLAIM_BIN, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+describe("CLI: dispatch-claim", () => {
+  it("computes gen = currentGeneration + 1, claims it, prints {won, generation}", () => {
+    const r = runCli(["dispatch-claim", ORCH_DIR, "CTL-1", "implement"]);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.won).toBe(true);
+    expect(out.generation).toBe(1); // fresh ⇒ gen 1
+    // A second dispatch-claim (e.g. revive) bumps to gen 2.
+    const r2 = runCli(["dispatch-claim", ORCH_DIR, "CTL-1", "implement"]);
+    expect(JSON.parse(r2.stdout).generation).toBe(2);
+  });
+});
+
+describe("CLI: claim (loss is a clean signal, not an error exit)", () => {
+  it("a lost same-generation claim prints won:false and still exits 0", () => {
+    runCli(["claim", ORCH_DIR, "CTL-1", "implement", "1"]);
+    const r = runCli(["claim", ORCH_DIR, "CTL-1", "implement", "1"]);
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).won).toBe(false);
+  });
+});
+
+describe("CLI: fence-check", () => {
+  function writeSignal(generation) {
+    const p = join(ORCH_DIR, "workers", "CTL-1", "phase-implement.json");
+    const body = { ticket: "CTL-1", phase: "implement", status: "running" };
+    if (generation !== undefined) body.generation = generation;
+    writeFileSync(p, JSON.stringify(body));
+  }
+
+  it("current generation ⇒ exit 0 (proceed)", () => {
+    writeSignal(2);
+    const r = runCli(["fence-check", ORCH_DIR, "CTL-1", "implement"], { CATALYST_GENERATION: "2" });
+    expect(r.status).toBe(0);
+  });
+
+  it("stale generation (mine < signal) ⇒ non-zero exit (bow out)", () => {
+    writeSignal(3);
+    const r = runCli(["fence-check", ORCH_DIR, "CTL-1", "implement"], { CATALYST_GENERATION: "2" });
+    expect(r.status).not.toBe(0);
+  });
+
+  it("no CATALYST_GENERATION (legacy worker) ⇒ exit 0 (proceed)", () => {
+    writeSignal(3);
+    const r = runCli(["fence-check", ORCH_DIR, "CTL-1", "implement"]);
+    expect(r.status).toBe(0);
+  });
+
+  it("missing signal file ⇒ exit 0 (proceed; nothing to fence against)", () => {
+    const r = runCli(["fence-check", ORCH_DIR, "CTL-1", "implement"], { CATALYST_GENERATION: "2" });
+    expect(r.status).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -440,8 +440,10 @@ mkdir -p "$WORKER_DIR" 2>/dev/null || die "cannot create $WORKER_DIR"
 # Idempotency: if a signal exists and its status is one of dispatched|running|done,
 # we no-op. Failed signals are overwritten (retry path).
 EXISTING_STATUS=""
+EXISTING_GENERATION=""
 if [[ -f $SIGNAL_FILE ]]; then
 	EXISTING_STATUS=$(jq -r '.status // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+	EXISTING_GENERATION=$(jq -r '.generation // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
 fi
 
 if [[ $EXISTING_STATUS == "dispatched" || $EXISTING_STATUS == "running" || $EXISTING_STATUS == "done" ]]; then
@@ -454,12 +456,91 @@ if [[ $EXISTING_STATUS == "dispatched" || $EXISTING_STATUS == "running" || $EXIS
 		--arg job "$EXISTING_JOB" \
 		--arg signal "$SIGNAL_FILE" \
 		--arg status "$EXISTING_STATUS" \
+		--arg generation "$EXISTING_GENERATION" \
 		--argjson dryRun "$DRY_RUN" \
 		'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
       bg_job_id: (if $job == "" then null else $job end),
       signalFile: $signal, status: $status, idempotent: true,
+      generation: (if $generation == "" then null else ($generation | tonumber) end),
       dryRun: ($dryRun == 1)}'
 	exit 0
+fi
+
+# ─── CTL-736 Phase 1: atomic single-flight generation claim ─────────────────
+#
+# The status short-circuit above is a soft check-then-write: two near-
+# simultaneous ticks on a `stalled` (revive) or absent (fresh) signal both fall
+# through it and both spawn — the revive-storm root cause. The claim closes
+# that race deterministically: every concurrent dispatcher computes the SAME
+# target generation from observable state, then O_EXCL-creates
+# ${WORKER_DIR}/<phase>.claim.<generation>. Exactly one wins; every loser
+# no-ops as `idempotent` exactly like the soft guard did.
+#
+#   TARGET_GENERATION is fixed by the state the racers all observe:
+#     • fresh (no signal)                     → 1
+#     • revive/retry (stalled|failed|… signal) → signal.generation + 1
+#   It must NOT be derived from the live claim-file high-water mark: a staggered
+#   pair would then see each other's claim and advance to DIFFERENT generations,
+#   each winning its own — re-opening the very double-spawn this closes.
+#
+# The won generation is the FENCING TOKEN: written into the signal and exported
+# as CATALYST_GENERATION so a stale (false-dead-revived) worker self-disqualifies
+# in phase-agent-emit-complete before any outcome — so even if the still-live
+# snapshot trigger spawns extra workers across generations, only the current one
+# can write a result.
+#
+# The claim is PURE BASH (`set -o noclobber` → the `>` open uses O_CREAT|O_EXCL):
+# no node/bun startup in the dispatch path — both because the path must stay
+# fast (cf. lib/phase-sequence.sh: "adding a node-startup dependency to the
+# recovery sweep would change the failure modes") AND because two `bun`
+# instances launched simultaneously race on the execution-core lockfile and one
+# returns empty — which would silently re-open the double-spawn this closes.
+# The claim-file FORMAT is kept in sync with execution-core/claim.mjs
+# claimPath(): ${WORKER_DIR}/<phase>.claim.<generation>.
+#
+# --dry-run NEVER claims (a preview must be side-effect-free): it computes the
+# would-be generation without creating the claim file.
+if [[ -z $EXISTING_STATUS ]]; then
+	TARGET_GENERATION=1
+else
+	# Any non-(dispatched|running|done) signal that reached here is a revive or
+	# retry (stalled, failed, refused, …) → claim the next generation.
+	TARGET_GENERATION=$((${EXISTING_GENERATION:-0} + 1))
+fi
+GENERATION="$TARGET_GENERATION"
+
+if [[ $DRY_RUN -eq 0 ]]; then
+	CLAIM_FILE="${WORKER_DIR}/${PHASE}.claim.${TARGET_GENERATION}"
+	CLAIM_BODY="{\"generation\":${TARGET_GENERATION},\"claimedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+	# Atomic create-exclusive-and-write: with noclobber the `>` fails (does not
+	# truncate) if CLAIM_FILE already exists — exactly one concurrent dispatcher
+	# wins the generation. Subshell so noclobber never leaks to the rest of the
+	# script.
+	if ! (set -o noclobber && printf '%s\n' "$CLAIM_BODY" >"$CLAIM_FILE") 2>/dev/null; then
+		# The write failed. Disambiguate the two causes — they must NOT collapse:
+		#   • file now EXISTS → EEXIST, a concurrent dispatcher won this
+		#     generation → no-op idempotent (race-free equivalent of the soft
+		#     status guard).
+		#   • file ABSENT → a genuine I/O error (EACCES / ENOSPC / read-only fs).
+		#     The claim is best-effort and must NEVER fail-closed: skipping the
+		#     dispatch here would strand the phase. Log and fall through to spawn
+		#     un-fenced (degraded, matching the no-runtime fallback).
+		if [[ -e $CLAIM_FILE ]]; then
+			jq -nc \
+				--arg ticket "$TICKET" \
+				--arg phase "$PHASE" \
+				--arg model "$MODEL" \
+				--argjson turnCap "$TURN_CAP" \
+				--arg signal "$SIGNAL_FILE" \
+				--argjson generation "$TARGET_GENERATION" \
+				--argjson dryRun "$DRY_RUN" \
+				'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+          bg_job_id: null, signalFile: $signal, status: "claim-lost", idempotent: true,
+          generation: $generation, dryRun: ($dryRun == 1)}'
+			exit 0
+		fi
+		echo "phase-agent-dispatch: claim write failed (no claim file at ${CLAIM_FILE}, not a lost race) for ${TICKET}/${PHASE}; proceeding un-fenced (generation=${GENERATION})" >&2
+	fi
 fi
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -477,9 +558,10 @@ jq -nc \
 	--arg orch "$ORCH_ID" \
 	--arg ts "$TS" \
 	--arg wt "$WORKTREE_PATH_RESOLVED" \
+	--argjson generation "$GENERATION" \
 	'{ticket: $ticket, phase: $phase, orchestrator: $orch, model: $model,
     turnCap: $turnCap, status: "dispatched", bg_job_id: null,
-    worktreePath: $wt,
+    worktreePath: $wt, generation: $generation,
     startedAt: $ts, updatedAt: $ts}' >"$SIGNAL_FILE" ||
 	die "failed to write signal file $SIGNAL_FILE"
 
@@ -561,6 +643,11 @@ DISPATCH_ENV=(
 	"CATALYST_ORCHESTRATOR_ID=${ORCH_ID}"
 	"CATALYST_PHASE=${PHASE}"
 	"CATALYST_TICKET=${TICKET}"
+	# CTL-736 Phase 1: the fencing token. The worker asserts
+	# signal.generation === CATALYST_GENERATION (phase-agent-emit-complete's
+	# fence-check) before emitting any outcome — a stale (false-dead-revived)
+	# generation bows out instead of double-completing.
+	"CATALYST_GENERATION=${GENERATION}"
 )
 [[ -n $OTEL_RES_ATTRS ]] &&
 	DISPATCH_ENV+=("OTEL_RESOURCE_ATTRIBUTES=${OTEL_RES_ATTRS}")
@@ -646,6 +733,10 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 					# guard finds no file and writes a fresh one (not "dispatched"
 					# which would short-circuit the re-exec as idempotent).
 					rm -f "$SIGNAL_FILE" 2>/dev/null || true
+					# CTL-736: this is a DELIBERATE clean restart — drop the claim
+					# tombstones too, so the re-exec's fresh (no-signal ⇒ gen 1)
+					# claim is exclusive and wins instead of colliding on gen 1.
+					rm -f "${WORKER_DIR}/${PHASE}.claim."* 2>/dev/null || true
 					echo "phase-agent-dispatch: recreated worktree at ${_NEW_WT}; re-dispatching ${TICKET}/${PHASE}" >&2
 					cd "$_NEW_WT"
 					exec "$0" --phase "$PHASE" --ticket "$TICKET" \

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -149,6 +149,35 @@ if [[ $PHASE == *.* ]]; then
 	die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
 fi
 
+# ─── 0. CTL-736 Phase 1: fencing check (stale generation bows out) ───────────
+#
+# A worker carries its dispatch generation in CATALYST_GENERATION. If the phase
+# signal has since advanced (a revive claimed a higher generation — this worker
+# is a false-dead-revived duplicate), this worker must NOT write an outcome: a
+# stale `complete`/`failed` would overwrite the live worker's signal or post a
+# duplicate Linear mirror. This is the STRUCTURAL replacement for the runtime
+# `bg_job_id != mine` orphan-bow-out heuristics scattered across the phase
+# skills (see the memory entries on duplicate-worker disambiguation).
+#
+# Pure bash + jq (no node/bun startup here, mirroring the dispatch path). The
+# semantics MUST match execution-core/claim.mjs `isCurrentGeneration`: bow out
+# ONLY when both generations are numeric AND mine < signal; on any missing /
+# non-numeric value, proceed (fail-open) so legacy workers and unfenced
+# dispatches are unaffected.
+if [[ -n ${CATALYST_GENERATION:-} && -n $ORCH_DIR ]]; then
+	_FENCE_SIGNAL="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+	if [[ -f $_FENCE_SIGNAL ]]; then
+		_SIG_GEN=$(jq -r '.generation // empty' "$_FENCE_SIGNAL" 2>/dev/null || echo "")
+		# Only act when BOTH are plain integers; anything else fails open.
+		if [[ $CATALYST_GENERATION =~ ^[0-9]+$ && $_SIG_GEN =~ ^[0-9]+$ ]]; then
+			if ((CATALYST_GENERATION < _SIG_GEN)); then
+				echo "phase-agent-emit-complete: stale-generation-bow-out — mine=${CATALYST_GENERATION} < signal=${_SIG_GEN} for ${TICKET}/${PHASE}; not emitting" >&2
+				exit 0
+			fi
+		fi
+	fi
+fi
+
 # ─── 1. Emit canonical event ────────────────────────────────────────────────
 
 EVENT_NAME="phase.${PHASE}.${STATUS}.${TICKET}"


### PR DESCRIPTION
## Summary

**Phase 1 of 3** of CTL-736 (retire the revive-storm guard stack). Introduces the first of three deterministic primitives: an **atomic single-flight claim + fencing generation token** that makes a duplicate phase-worker spawn structurally impossible.

The ~14 heuristic dampers (busy short-circuit, idle-confirm streak, revive-grace window, `MAX_REVIVES`, storm-breaker, the phase-skill `bg_job_id` bow-outs, …) all exist to soften a wrong *"is this worker dead?"* guess that spawns a second worker. This phase removes the **possibility**, not the symptom. It is **claim-first** by design — the safety net that makes the Phase 2 death-trigger cutover safe while the old snapshot trigger is still live.

Plan: `thoughts/shared/plans/2026-05-30-CTL-736-retire-revive-guard-stack.md` · Research: CTL-735 root-cause + lease design.

## What changed

| File | Change |
|---|---|
| `execution-core/claim.mjs` *(new)* | `claimPhase` (O_EXCL `wx`), `releaseClaim`, `isCurrentGeneration` (fencing predicate), `currentGeneration`, `claimPath` + CLI (`claim`/`dispatch-claim`/`current-generation`/`release`/`fence-check`). Pure fs primitives. |
| `execution-core/claim.test.mjs` *(new)* | 20 unit tests incl. a white-box O_EXCL proof + a concurrent-winner assertion. |
| `phase-agent-dispatch` | Claims `<phase>.claim.<gen>` before spawn. TARGET generation fixed by pre-race state (fresh ⇒ 1, stalled/failed ⇒ signal.generation+1) — **not** the live claim high-water mark — so staggered racers converge on one generation and exactly one wins. Won generation → signal + exported `CATALYST_GENERATION`. Worktree-recreate drops claim tombstones so its fresh re-exec wins. |
| `phase-agent-emit-complete` | Fences before any outcome: `CATALYST_GENERATION < signal.generation` (a false-dead-revived duplicate) → bow out (exit 0, no event, no signal write). Fail-open on missing/non-numeric. |
| 2 shell test suites | dispatch Tests 40–43, emit Tests 12–16. |

## Two design decisions

- **The dispatcher claim is pure bash** (`set -o noclobber` → O_CREAT\|O_EXCL), not a `claim.mjs` shell-out: two concurrent `bun` launches race on the execution-core lockfile and one returns empty (verified), which would silently re-open the double-spawn. `claim.mjs` stays the unit-tested library + `fence-check` CLI; the claim-file format is kept in sync between the two. Also keeps the dispatch path node-startup-free (cf. `lib/phase-sequence.sh`).
- **The soft `dispatched|running|done` idempotency guard and the phase-skill `bg_job_id` bow-out blocks are deliberately kept** — they protect in-flight (pre-generation) workers during rollout while the snapshot death trigger awaits Phase 2. The `emit-complete` fence is the single chokepoint that structurally replaces them across all phases. The net-negative-LOC guard deletions land in Phases 2–3.

## Test plan

- `claim.test.mjs` 20/20 · `phase-agent-dispatch` 157/157 (concurrent single-flight, revive bump, fixed-target `claim-lost`, dry-run side-effect-free) · `phase-agent-emit-complete` 46/46 + zsh 6/6 (stale bow-out, current/higher proceed, fail-open ×2).
- Full execution-core suite: **1513 pass / 1 fail** (the pre-existing `cli/sessions classifyRow`, unrelated).
- Reviewed by `code-reviewer` (fixed a fail-closed-on-IO-error bug it surfaced) + `pr-test-analyzer` (added Test 43 to pin the fixed-target invariant + the `claim-lost` branch).

## Rollout

Per the plan's staging, this PR should be followed by a **controlled daemon re-enable** (storm-repro watch protocol) before Phase 2 (`state.json` death trigger) and Phase 3 (progress probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)