### PR TITLE
fix(dev): clear verify/remediate claim tombstones on cycle reset (CTL-736 GATE-0)

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -892,26 +892,56 @@ export function deriveAdvancement(signals, { verifyVerdict, remediateCycleCount 
 // (triage/research/plan/implement) and their artifacts are never touched.
 const REMEDIATE_CYCLE_FILES = ["phase-verify.json", "phase-remediate.json", "verify.json"];
 
+// REMEDIATE_CYCLE_CLAIM_PHASES — the cycle members whose CTL-736 single-flight
+// claim tombstones (`<phase>.claim.<gen>`) must ALSO be dropped on a reset.
+// GATE-0: the reset deletes the signal files above, so the re-dispatch derives a
+// fresh generation 1 (phase-agent-dispatch reads the generation from the
+// now-absent signal). A leftover `verify.claim.1` / `remediate.claim.1` from the
+// prior cycle would collide on the O_EXCL create → claim-lost → the re-verify is
+// silently suppressed and the self-healing cycle stalls to needs-human. The
+// worktree-recreate path drops claims for exactly this reason
+// (phase-agent-dispatch:735-739); the cycle reset must do the same.
+const REMEDIATE_CYCLE_CLAIM_PHASES = ["verify", REMEDIATE_PHASE];
+
 // maybeResetForRemediateCycle — CTL-653 re-entry. A completed remediate cycles
 // back to a fresh verify, but deriveAdvancement's `next.phase in sig` guard
 // blocks re-dispatching verify while its signal exists. Rather than special-
 // casing the guard, reset the cycle by deleting the verify+remediate signals
-// (and verify.json). The next deriveAdvancement then sees implement as the
-// latest `done` phase and cleanly re-dispatches verify. The cycle count
+// (and verify.json) AND their claim tombstones (GATE-0). The next
+// deriveAdvancement then sees implement as the latest `done` phase and cleanly
+// re-dispatches verify at a fresh, exclusive generation. The cycle count
 // survives because it is event-counted (countRemediateCycles), not signal-stored.
 // Returns true when a reset happened (so the caller re-reads the signals).
 export function maybeResetForRemediateCycle(
   orchDir,
   ticket,
-  { rm = rmSync, readSignals = readPhaseSignals } = {}
+  { rm = rmSync, readSignals = readPhaseSignals, readdir = readdirSync } = {}
 ) {
   const sig = readSignals(orchDir, ticket);
   if (sig[REMEDIATE_PHASE] !== "done") return false;
+  const workerDir = join(orchDir, "workers", ticket);
   for (const f of REMEDIATE_CYCLE_FILES) {
     try {
-      rm(join(orchDir, "workers", ticket, f), { force: true });
+      rm(join(workerDir, f), { force: true });
     } catch {
       // best-effort — a missing file is the desired end state anyway
+    }
+  }
+  // GATE-0: also drop the cycle members' claim tombstones so the re-dispatch's
+  // fresh (no-signal ⇒ gen 1) claim is exclusive and wins instead of colliding.
+  let claimEntries;
+  try {
+    claimEntries = readdir(workerDir);
+  } catch {
+    claimEntries = []; // worker dir gone — nothing to clean
+  }
+  for (const f of claimEntries) {
+    if (REMEDIATE_CYCLE_CLAIM_PHASES.some((p) => f.startsWith(`${p}.claim.`))) {
+      try {
+        rm(join(workerDir, f), { force: true });
+      } catch {
+        // best-effort
+      }
     }
   }
   return true;

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1040,6 +1040,24 @@ describe("CTL-653: maybeResetForRemediateCycle", () => {
     expect(existsSync(join(wdir, "phase-implement.json"))).toBe(true);
     expect(existsSync(join(wdir, "triage.json"))).toBe(true);
   });
+  test("GATE-0: clears the cycle members' claim tombstones (verify/remediate) so the re-verify wins a fresh gen-1 claim", () => {
+    writeSignal("CTL-736", "implement", "done");
+    writeSignal("CTL-736", "verify", "done");
+    writeSignal("CTL-736", "remediate", "done");
+    const wdir = join(orchDir, "workers", "CTL-736");
+    // leftover CTL-736 claim tombstones from the first verify + the remediate
+    writeFileSync(join(wdir, "verify.claim.1"), "{}");
+    writeFileSync(join(wdir, "remediate.claim.1"), "{}");
+    // an UNRELATED phase's claim must survive (only the cycle members are cleared)
+    writeFileSync(join(wdir, "implement.claim.1"), "{}");
+
+    expect(maybeResetForRemediateCycle(orchDir, "CTL-736")).toBe(true);
+    // cycle-member claims cleared → the re-dispatch's fresh (no-signal ⇒ gen 1)
+    // claim is exclusive and wins instead of colliding on the leftover gen-1 file
+    expect(existsSync(join(wdir, "verify.claim.1"))).toBe(false);
+    expect(existsSync(join(wdir, "remediate.claim.1"))).toBe(false);
+    expect(existsSync(join(wdir, "implement.claim.1"))).toBe(true);
+  });
   test("remediate not done → no-op, returns false (cycle signals untouched)", () => {
     writeSignal("CTL-653", "verify", "done");
     writeSignal("CTL-653", "remediate", "running");


### PR DESCRIPTION
## Summary

Fixes a **confirmed latent bug** on `main` (`d09fb2b2`): the `verify→remediate→verify` self-healing cycle silently dies under the CTL-736 single-flight fencing.

`maybeResetForRemediateCycle` deleted the three cycle **signal** files but not the CTL-736 `<phase>.claim.<gen>` **tombstones**. After a reset the re-dispatch derives generation 1 from the now-absent signal (`phase-agent-dispatch:503-509`), then the `O_EXCL` create of `verify.claim.1` collides with the leftover tombstone → `claim-lost` → **no spawn** → demoted to a dispatch failure → `escalateDispatchExhausted` → `needs-human`.

The author already fixed the **identical** failure mode in the worktree-recreate path (`phase-agent-dispatch:735-739`, "drop the claim tombstones too, so the re-exec's fresh gen-1 claim is exclusive") — this just applies the same cleanup in the cycle reset, globbing `verify.claim.*` + `remediate.claim.*` (cycle members only; unrelated phases' claims survive).

## Test (TDD, Red→Green)

- New `scheduler.test.mjs` GATE-0 case: leftover `verify.claim.1`/`remediate.claim.1` are cleared by the reset; an unrelated `implement.claim.1` survives. (Failed before the fix, passes after.)
- Full `execution-core` suite: **1514 pass / 1 fail** (the +1 is this test; the lone fail is the pre-existing `cli/sessions classifyRow`).
- `phase-agent-claim-fence-e2e.test.sh`: **14/14**.

## Context

Found while grounding the workflow-descriptor design (see `docs/workflow-descriptors-design.md` Appendix A). Independent of the descriptor work — a CTL-736-thread correctness fix. Recommended of 3 candidate fixes (co-locates the cleanup with the reset, preserving the deliberate fixed-generation single-flight invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)