### PR TITLE
feat(dev): CTL-736 Phase 2-3 — state.json death trigger + progress probe (retire the revive-storm guard stack)

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -132,15 +132,6 @@ export const TAILER_POLL_INTERVAL_MS =
 export const STALE_WORKER_CUTOFF_MS =
   Number(process.env.EXECUTION_CORE_STALE_WORKER_CUTOFF_MS) || 15 * 60_000;
 
-// CTL-662 — idle-confirmation streak length. A phase worker observed `idle` by
-// `claude agents` is reclaim-eligible only after this many CONSECUTIVE idle
-// observations (a counter persisted on the signal, NOT an mtime window). A
-// couple of ticks confirms the worker is genuinely between-turns done, not
-// momentarily idle between sub-agent fan-out rounds. Env-overridable so tuning
-// from real failures needs no code change (the operator decision on the ticket).
-export const IDLE_CONFIRM_TICKS =
-  Number(process.env.EXECUTION_CORE_IDLE_CONFIRM_TICKS) || 2;
-
 // CTL-662 — busy-forever backstop ceiling. With STALE_MS / HUNG_CUTOFF_MS gone,
 // this is the SOLE long backstop: a worker that stays `busy` past this elapsed
 // time with no committed work flags for human (escalateOnce) — NEVER a silent
@@ -149,20 +140,6 @@ export const IDLE_CONFIRM_TICKS =
 // genuinely wedged worker does. Env-overridable for tuning.
 export const BUSY_CEILING_MS =
   Number(process.env.EXECUTION_CORE_BUSY_CEILING_MS) || 6 * 60 * 60_000;
-
-// CTL-735 — post-(re)dispatch grace window for the `absent` liveness class. A
-// worker whose bg_job_id is `absent` from the eventually-consistent `claude
-// agents` snapshot but whose signal was (re)dispatched within this window has
-// almost certainly just not registered yet (a fresh `claude --bg` takes seconds
-// to appear, slower under load) — NOT crashed. The reclaim sweep defers reviving
-// it until the window elapses: the missing analog of IDLE_CONFIRM_TICKS for
-// `absent`. Without it, the de-starved fast tick (CTL-731, ~2-4s) re-classifies
-// each just-revived worker as dead and revives it again → the revive storm.
-// Deliberately generous (90s) so a fresh worker registers even under high load,
-// while a genuinely-crashed fresh worker waits at most this long before revive.
-// Env-overridable for tuning from real failures.
-export const REVIVE_GRACE_MS =
-  Number(process.env.EXECUTION_CORE_REVIVE_GRACE_MS) || 90_000;
 
 // CTL-735 — per-tick revive cap. The reclaim sweep revives at most this many
 // dead workers per scheduler tick; further revivable workers are `revive-capped`
@@ -187,6 +164,23 @@ export const PER_TICK_REVIVE_CAP =
 // through to the pre-CTL-735 path (cannot judge age). Env-overridable.
 export const REVIVE_MAX_AGE_MS =
   Number(process.env.EXECUTION_CORE_REVIVE_MAX_AGE_MS) || 24 * 60 * 60_000;
+
+// CTL-736 Phase 2 — liveness-source selector for the reclaim death trigger.
+// 'state-json' (default, post-cutover): the authoritative local
+// ~/.claude/jobs/<bg>/state.json lifecycle (jobLifecycle in recovery.mjs) is
+// the death trigger — deterministic, fan-out-safe, no eventually-consistent
+// snapshot lag. 'shadow': act on state.json BUT also compute the legacy
+// `claude agents` snapshot verdict and log `liveness-shadow-mismatch` on
+// disagreement (live A/B observability). 'snapshot': the legacy
+// livenessForBgJob trigger — an env-only production rollback if the state.json
+// path ever misbehaves (no cache hotfix needed). Re-reads env per call (reader
+// idiom) so it can be flipped per-test and live; an unrecognized value falls
+// back to the safe 'state-json' default.
+const LIVENESS_SOURCES = new Set(["snapshot", "shadow", "state-json"]);
+export function readLivenessConfig() {
+  const raw = process.env.EXECUTION_CORE_LIVENESS_SOURCE;
+  return { source: LIVENESS_SOURCES.has(raw) ? raw : "state-json" };
+}
 
 // CTL-650 — the push-based session wait-state watcher. Default ON; the daemon
 // continuously classifies live sessions and emits agent.waiting_on_user /

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -141,27 +141,16 @@ export const STALE_WORKER_CUTOFF_MS =
 export const BUSY_CEILING_MS =
   Number(process.env.EXECUTION_CORE_BUSY_CEILING_MS) || 6 * 60 * 60_000;
 
-// CTL-735 — per-tick revive cap. The reclaim sweep revives at most this many
-// dead workers per scheduler tick; further revivable workers are `revive-capped`
-// (deferred to a later tick), so a fast (de-starved) loop cannot mass-revive ~85
-// historical worker dirs and outrun the event-count-lagged storm-breaker before
-// it clamps. The grace window (REVIVE_GRACE_MS) stops the re-revive RACE; this
-// cap bounds the BREADTH of a single tick. Deliberately small (2) — genuine
-// crashes are rare, so 2/tick clears a real backlog within a few ticks while
-// turning any storm into a slow, observable trickle. Env-overridable for tuning.
-export const PER_TICK_REVIVE_CAP =
-  Number(process.env.EXECUTION_CORE_PER_TICK_REVIVE_CAP) || 2;
-
-// CTL-735 — revival age ceiling. `isTicketInFlight` treats any ticket with a
-// non-terminal signal as in-flight, so a worker that crashed at `running` and
-// never flipped terminal stays swept forever. An absent/idle worker whose signal
-// has not been touched in this long is an abandoned historical dir (a long-since
-// Done or dead ticket), NOT a fresh crash — reviving it wastes budget and, once
-// MAX_REVIVES is hit, escalates dozens of dead tickets to needs-human. Such a
-// worker is treated as inert (no revive, no escalate). Deliberately well above
-// any real phase duration (24h) — a genuine multi-hour crash is still revived;
-// only a day-stale signal is inert. A signal with no parseable timestamp falls
-// through to the pre-CTL-735 path (cannot judge age). Env-overridable.
+// CTL-735 — revival age ceiling (KEPT in CTL-736). `isTicketInFlight` treats any
+// ticket with a non-terminal signal as in-flight, so a worker that crashed at
+// `running` and never flipped terminal stays swept forever. A reclaim-eligible
+// worker whose signal has not been touched in this long is an abandoned historical
+// dir (a long-since Done or dead ticket), NOT a fresh crash — it is treated as
+// inert (no revive, no escalate) BEFORE the Phase-3 progress gate, so the ~85
+// day-stale debris dirs do not each get a one-shot no-progress needs-human flag.
+// Deliberately well above any real phase duration (24h) — a genuine multi-hour
+// crash is still revived; only a day-stale signal is inert. A signal with no
+// parseable timestamp falls through (cannot judge age). Env-overridable.
 export const REVIVE_MAX_AGE_MS =
   Number(process.env.EXECUTION_CORE_REVIVE_MAX_AGE_MS) || 24 * 60 * 60_000;
 

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -154,23 +154,6 @@ export const BUSY_CEILING_MS =
 export const REVIVE_MAX_AGE_MS =
   Number(process.env.EXECUTION_CORE_REVIVE_MAX_AGE_MS) || 24 * 60 * 60_000;
 
-// CTL-736 Phase 2 — liveness-source selector for the reclaim death trigger.
-// 'state-json' (default, post-cutover): the authoritative local
-// ~/.claude/jobs/<bg>/state.json lifecycle (jobLifecycle in recovery.mjs) is
-// the death trigger — deterministic, fan-out-safe, no eventually-consistent
-// snapshot lag. 'shadow': act on state.json BUT also compute the legacy
-// `claude agents` snapshot verdict and log `liveness-shadow-mismatch` on
-// disagreement (live A/B observability). 'snapshot': the legacy
-// livenessForBgJob trigger — an env-only production rollback if the state.json
-// path ever misbehaves (no cache hotfix needed). Re-reads env per call (reader
-// idiom) so it can be flipped per-test and live; an unrecognized value falls
-// back to the safe 'state-json' default.
-const LIVENESS_SOURCES = new Set(["snapshot", "shadow", "state-json"]);
-export function readLivenessConfig() {
-  const raw = process.env.EXECUTION_CORE_LIVENESS_SOURCE;
-  return { source: LIVENESS_SOURCES.has(raw) ? raw : "state-json" };
-}
-
 // CTL-650 — the push-based session wait-state watcher. Default ON; the daemon
 // continuously classifies live sessions and emits agent.waiting_on_user /
 // agent.resumed transition events. CATALYST_WAIT_WATCHER=0 disables it (the

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -11,7 +11,6 @@ import {
   readWaitWatcherConfig,
   EVENT_DEBOUNCE_MS,
   readMemorySamplerConfig,
-  readLivenessConfig,
   AUTOTUNE_SAMPLE_INTERVAL_MS,
   AUTOTUNE_WINDOW_SAMPLES,
   AUTOTUNE_TREND_MIN_SAMPLES,
@@ -119,45 +118,6 @@ describe("readMemorySamplerConfig (CTL-685)", () => {
   test("zero interval falls back to 30000", () => {
     process.env.EXECUTION_CORE_MEMORY_SAMPLE_INTERVAL_MS = "0";
     expect(readMemorySamplerConfig().intervalMs).toBe(30_000);
-  });
-});
-
-// CTL-736 Phase 2: liveness-source selector. readLivenessConfig re-reads
-// EXECUTION_CORE_LIVENESS_SOURCE on every call (reader idiom) so the cutover
-// knob can be flipped per-test and as an env-only production rollback.
-const LIVENESS_ENV = "EXECUTION_CORE_LIVENESS_SOURCE";
-let savedLivenessEnv;
-describe("readLivenessConfig (CTL-736 Phase 2)", () => {
-  beforeEach(() => {
-    savedLivenessEnv = process.env[LIVENESS_ENV];
-    delete process.env[LIVENESS_ENV];
-  });
-  afterEach(() => {
-    if (savedLivenessEnv === undefined) delete process.env[LIVENESS_ENV];
-    else process.env[LIVENESS_ENV] = savedLivenessEnv;
-  });
-
-  test("defaults to 'state-json' (the post-cutover authoritative trigger)", () => {
-    expect(readLivenessConfig().source).toBe("state-json");
-  });
-
-  test("accepts the three valid modes", () => {
-    for (const v of ["snapshot", "shadow", "state-json"]) {
-      process.env[LIVENESS_ENV] = v;
-      expect(readLivenessConfig().source).toBe(v);
-    }
-  });
-
-  test("an unrecognized value falls back to the safe default 'state-json'", () => {
-    process.env[LIVENESS_ENV] = "garbage";
-    expect(readLivenessConfig().source).toBe("state-json");
-  });
-
-  test("re-reads env on every call (not import-time pinned)", () => {
-    process.env[LIVENESS_ENV] = "snapshot";
-    expect(readLivenessConfig().source).toBe("snapshot");
-    process.env[LIVENESS_ENV] = "shadow";
-    expect(readLivenessConfig().source).toBe("shadow");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -11,6 +11,7 @@ import {
   readWaitWatcherConfig,
   EVENT_DEBOUNCE_MS,
   readMemorySamplerConfig,
+  readLivenessConfig,
   AUTOTUNE_SAMPLE_INTERVAL_MS,
   AUTOTUNE_WINDOW_SAMPLES,
   AUTOTUNE_TREND_MIN_SAMPLES,
@@ -118,6 +119,45 @@ describe("readMemorySamplerConfig (CTL-685)", () => {
   test("zero interval falls back to 30000", () => {
     process.env.EXECUTION_CORE_MEMORY_SAMPLE_INTERVAL_MS = "0";
     expect(readMemorySamplerConfig().intervalMs).toBe(30_000);
+  });
+});
+
+// CTL-736 Phase 2: liveness-source selector. readLivenessConfig re-reads
+// EXECUTION_CORE_LIVENESS_SOURCE on every call (reader idiom) so the cutover
+// knob can be flipped per-test and as an env-only production rollback.
+const LIVENESS_ENV = "EXECUTION_CORE_LIVENESS_SOURCE";
+let savedLivenessEnv;
+describe("readLivenessConfig (CTL-736 Phase 2)", () => {
+  beforeEach(() => {
+    savedLivenessEnv = process.env[LIVENESS_ENV];
+    delete process.env[LIVENESS_ENV];
+  });
+  afterEach(() => {
+    if (savedLivenessEnv === undefined) delete process.env[LIVENESS_ENV];
+    else process.env[LIVENESS_ENV] = savedLivenessEnv;
+  });
+
+  test("defaults to 'state-json' (the post-cutover authoritative trigger)", () => {
+    expect(readLivenessConfig().source).toBe("state-json");
+  });
+
+  test("accepts the three valid modes", () => {
+    for (const v of ["snapshot", "shadow", "state-json"]) {
+      process.env[LIVENESS_ENV] = v;
+      expect(readLivenessConfig().source).toBe(v);
+    }
+  });
+
+  test("an unrecognized value falls back to the safe default 'state-json'", () => {
+    process.env[LIVENESS_ENV] = "garbage";
+    expect(readLivenessConfig().source).toBe("state-json");
+  });
+
+  test("re-reads env on every call (not import-time pinned)", () => {
+    process.env[LIVENESS_ENV] = "snapshot";
+    expect(readLivenessConfig().source).toBe("snapshot");
+    process.env[LIVENESS_ENV] = "shadow";
+    expect(readLivenessConfig().source).toBe("shadow");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -64,7 +64,7 @@ import {
   readExecutionCoreConcurrencyLayer2,
   mergeExecutionCoreConcurrency,
 } from "./scheduler.mjs";
-import { writeBootMarker } from "./recovery.mjs"; // CTL-655: window the revive budget to this run
+import { writeBootMarker, clearProgressMarks } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 
 const DEFAULT_MAX_PARALLEL = 3;
@@ -165,6 +165,9 @@ export function startDaemon({
   // the current run (a clean restart resets a budget burned by a prior storm).
   // Must precede schedulerFn (the first reclaim read). Fail-open internally.
   writeBootMarker(orchDir);
+  // CTL-736 Phase 3: reset the per-(ticket, phase) progress high-water markers so a
+  // stale mark from a prior daemon run cannot false-STOP the first death this run.
+  clearProgressMarks(orchDir);
   _stopMonitor = stopMonitorFn;
   _stopScheduler = stopSchedulerFn;
 

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -464,4 +464,69 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     // No tick re-revived an already-converged worker: total revives == N exactly.
     expect(perTickRevived.reduce((a, b) => a + b, 0)).toBe(N);
   });
+
+  // CTL-736 Phase 3: the PROGRESS-GATE storm bound (distinct from the `alive`-
+  // suppression bound above). A worker that stays dead-gone every tick while
+  // making ZERO forward progress — the CTL-728/729 futile-respawn loop the gate
+  // retires — must revive EXACTLY ONCE (the first-death retry) and then STOP on
+  // every subsequent tick, never respawning. Here jobLifecycle is FIXED at
+  // dead-gone (the worker never re-registers), and a SHARED progress store is
+  // read/written across ticks so the gate, not `alive` suppression, is the bound.
+  test("progress gate bounds a perpetually-dead zero-progress worker: revive once, then STOP every tick", () => {
+    seedSignal("CTL-736-NP", "implement", {
+      status: "running",
+      bg_job_id: "dead-bg-np",
+      orchestrator: "CTL-736-NP",
+    });
+
+    let progressStore = -1; // shared high-water across ticks (absent ⇒ -1)
+    const reviveDispatchCalls = [];
+    const escalations = [];
+    const perTick = [];
+
+    for (let t = 0; t < 8; t++) {
+      const result = schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: () => ({ code: 0 }),
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          applyTerminalDone: () => {},
+          applyLabel: () => ({ applied: true }),
+        },
+        teardownWorktree: () => true,
+        reclaimDeadWork: (od, sig, opts) =>
+          reclaimDeadWorkIfPossible(od, sig, {
+            ...opts,
+            statJob: () => null,
+            jobLifecycle: () => "dead-gone", // never re-registers
+            probes: { implement: () => false }, // work NOT done → branch (C)
+            progressMark: () => 0, // measures zero progress every tick
+            readProgressMark: () => progressStore,
+            writeProgressMark: (_o, _t, _p, v) => {
+              progressStore = v;
+            },
+            reviveDispatch: (args) => {
+              reviveDispatchCalls.push(args);
+              return { code: 0 };
+            },
+            appendEscalatedEvent: (e) => escalations.push(e),
+            applyStalledLabel: () => ({ applied: true }),
+            killBgJob: () => {},
+            countReviveEvents: () => 0,
+            // real cooldown seams (orchDir is a real tmp dir) → escalation fires
+            // once, then the CTL-638 cool-down suppresses the repeat.
+          }),
+      });
+      perTick.push({ revived: result.revived.length, stopped: result.noProgressStopped.length });
+    }
+
+    // Tick 0: progress 0 > stored -1 → revive once, store := 0.
+    // Ticks 1-7: progress 0 <= stored 0 → no-progress-stopped, NEVER respawned.
+    expect(reviveDispatchCalls).toHaveLength(1);
+    expect(perTick[0]).toEqual({ revived: 1, stopped: 0 });
+    expect(perTick.slice(1).every((p) => p.revived === 0 && p.stopped === 1)).toBe(true);
+    // Escalation fired (needs-human), and the cool-down kept it to one audit event.
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0].reason).toBe("no-progress");
+  });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -394,9 +394,11 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         reclaimDeadWork: (od, sig, opts) =>
           reclaimDeadWorkIfPossible(od, sig, {
             ...opts,
-            // 'running' classification + ancient mtime → effectively dead via the
-            // staleness path (also past hungCutoffMs so pidAlive is never read).
-            statJob: () => ({ exists: true, mtimeMs: 1000 }),
+            // CTL-736: the liveness job dir is gone (dead-gone) → reclaim-eligible.
+            // resolveSession reads a SEPARATE dir (CATALYST_REVIVE_JOBS_DIR) where
+            // the resume jsonl still lives, so the revive carries a resumeSession.
+            statJob: () => null,
+            jobLifecycle: () => "dead-gone",
             probes: { implement: () => false }, // work NOT done → revive territory
             reviveDispatch: (args) => {
               reviveDispatchCalls.push(args);
@@ -452,7 +454,9 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         reclaimDeadWork: (od, sig, opts) =>
           reclaimDeadWorkIfPossible(od, sig, {
             ...opts,
-            statJob: () => ({ exists: true, mtimeMs: 1000 }),
+            // CTL-736: dead-gone (no state.json for feedface) → reclaim-eligible.
+            statJob: () => null,
+            jobLifecycle: () => "dead-gone",
             probes: { implement: () => false },
             reviveDispatch: (args) => {
               reviveDispatchCalls.push(args);
@@ -527,45 +531,42 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     expect(reviveDispatchCalls).toHaveLength(2); // only the uncapped revives dispatched
   });
 
-  // CTL-735 — the storm reproduction (handoff action item #3). This mirrors the
-  // real incident: many fast ticks (~2-4s) over multiple dead-bg signals whose
-  // freshly-revived replacement worker NEVER appears in the eventually-consistent
-  // `claude agents` snapshot (liveness always `absent` — the worst case). Pre-fix,
-  // every tick re-revived every worker → 5→18→62→74 workers, load 72. Post-fix the
-  // structural guards (grace window + per-tick cap) bound TOTAL revives: each
-  // worker revives exactly once and then sits `revive-pending` for the rest of the
-  // grace window. Budget is left always-available (countReviveEvents=0) so this
-  // isolates the structural guards, NOT the per-ticket MAX_REVIVES backstop.
-  test("storm repro: many fast ticks × 5 always-absent dead workers → bounded revives (no storm)", () => {
+  // CTL-736 — the storm reproduction (PR #1232), re-cast for the state.json death
+  // trigger. The original storm came from the eventually-consistent `claude
+  // agents` snapshot: a freshly-revived worker showed `absent` before it
+  // registered, so every fast tick re-revived it (5→18→62→74 workers, load 72).
+  // The structural fix is now the AUTHORITATIVE local state.json lifecycle — a
+  // revived worker writes state=working immediately, so jobLifecycle reads `alive`
+  // on the very next tick and suppresses re-revive. Convergence needs NO grace
+  // window, NO idle streak, NO per-tick cap: each worker revives EXACTLY ONCE.
+  // (This assertion is intentionally cap-independent so it holds across Phase 2
+  // — per-tick cap still present — and Phase 3, which removes it.)
+  test("storm repro: many fast ticks × 5 dead workers → each revives once then converges (state.json alive)", () => {
     const N = 5;
     for (let i = 0; i < N; i++) {
       seedSignal(`CTL-735-T${i}`, "implement", {
         status: "running",
         bg_job_id: `dead-bg-${i}`,
         orchestrator: `CTL-735-T${i}`,
-        // 10 min ago — past the 90s grace window, within the 24h inert ceiling →
-        // eligible to revive on the first tick.
         startedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
         updatedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
       });
     }
 
-    // A controllable clock: each tick advances 3s (the fast de-starved cadence).
-    // 20 ticks = 60s total, strictly inside the 90s grace window, so a worker
-    // revived on tick K stays revive-pending for every remaining tick.
     let clock = Date.now();
     const TICK_MS = 3_000;
     const TICKS = 20;
 
     const reviveDispatchCalls = [];
     const perTickRevived = [];
+    // A revived worker registers immediately (writes state=working) → jobLifecycle
+    // reads `alive` thereafter. The `registered` set simulates that local
+    // state.json transition — the structural replacement for the grace window.
+    const registered = new Set();
 
-    // Simulated dispatcher: rewrite the phase signal exactly as the real
-    // defaultReviveDispatch → phase-agent-dispatch does — fresh startedAt + new
-    // bg + status running — so the next tick re-reads a freshly-(re)dispatched
-    // worker (which the grace window must then defer).
     const simulatedReviveDispatch = ({ orchDir: od, ticket, phase }) => {
       reviveDispatchCalls.push({ ticket, tick: reviveDispatchCalls.length });
+      registered.add(ticket); // the replacement worker is now live (state=working)
       writeFileSync(
         join(od, "workers", ticket, `phase-${phase}.json`),
         JSON.stringify({
@@ -574,7 +575,7 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
           status: "running",
           bg_job_id: `revived-bg-${ticket}`,
           orchestrator: ticket,
-          startedAt: new Date(clock).toISOString(), // fresh — arms the grace window
+          startedAt: new Date(clock).toISOString(),
           updatedAt: new Date(clock).toISOString(),
         }),
       );
@@ -594,14 +595,16 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
         teardownWorktree: () => true,
         reclaimDeadWork: (od, sig, opts) =>
           reclaimDeadWorkIfPossible(od, sig, {
-            ...opts, // carries the per-tick reviveBudgetRemaining
+            ...opts, // carries the per-tick reviveBudgetRemaining (Phase 2)
             statJob: () => null,
+            // state.json lifecycle: a registered (revived) worker is `alive` →
+            // suppressed; an unregistered one is `dead-gone` → revives once.
+            jobLifecycle: () => (registered.has(sig.ticket) ? "alive" : "dead-gone"),
             probes: { implement: () => false }, // work NOT done → revive territory
-            liveness: () => "absent", // worst case: replacement never registers
             reviveDispatch: simulatedReviveDispatch,
             applyStalledLabel: () => ({ applied: true }),
             killBgJob: () => {},
-            countReviveEvents: () => 0, // budget always available — isolate structural guards
+            countReviveEvents: () => 0, // budget always available — isolate the trigger
             countDistinctRevivingTickets: () => 1, // storm-breaker NOT tripped
             now: () => clock,
           }),
@@ -610,13 +613,13 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
       clock += TICK_MS;
     }
 
-    // THE storm assertion: each of the 5 workers revived EXACTLY ONCE across all
-    // 20 ticks — not once per tick. Pre-fix this would be ~5 × 20 = 100 revives.
+    // THE convergence assertion: each of the 5 workers revived EXACTLY ONCE across
+    // all 20 ticks (pre-fix: ~5 × 20 = 100). The state.json `alive` suppression —
+    // not a grace window or per-tick cap — bounds it.
     expect(reviveDispatchCalls).toHaveLength(N);
-    // And the per-tick cap held every tick (never more than 2 revives in one tick).
-    expect(Math.max(...perTickRevived)).toBeLessThanOrEqual(2);
-    // Every worker revived once and only once.
     const revivedTickets = new Set(reviveDispatchCalls.map((c) => c.ticket));
     expect(revivedTickets.size).toBe(N);
+    // No tick re-revived an already-converged worker: total revives == N exactly.
+    expect(perTickRevived.reduce((a, b) => a + b, 0)).toBe(N);
   });
 });

--- a/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-587.test.mjs
@@ -131,56 +131,17 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     expect(countReviveEvents({ ticket: "CTL-587-A", path: eventLogPath })).toBe(1);
   });
 
-  test("budget exhausted: 2 prior revive events → 'escalated' + needs-human label", () => {
-    seedSignal("CTL-587-B", "implement", {
-      status: "running",
-      bg_job_id: "nonexistent-bg-id",
-      orchestrator: "CTL-587-B",
-    });
-    // Pre-seed events.jsonl with two prior revives so the budget is exhausted.
-    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-B", ts: "2026-05-23T00:00:00Z" }));
-    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-B", ts: "2026-05-23T00:05:00Z" }));
+  // CTL-736 Phase 3: the MAX_REVIVES budget-exhausted escalation is DELETED — a
+  // worker with N prior revives is NO LONGER escalated on a count threshold; it
+  // revives as long as it makes forward progress and STOPS (no-progress-stopped)
+  // when it does not. The two budget-exhaustion end-to-end tests are removed with
+  // the mechanism; the CTL-736 progress-gate unit tests cover revive-vs-stop, and
+  // the storm-repro convergence test below covers the no-storm guarantee.
 
-    const labelCalls = [];
-    const reviveDispatchCalls = [];
-    const result = schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: () => ({ code: 0 }),
-      writeStatus: {
-        applyPhaseStatus: () => {},
-        applyTerminalDone: () => {},
-        applyLabel: () => ({ applied: true }),
-      },
-      teardownWorktree: () => true,
-      reclaimDeadWork: (od, sig, opts) =>
-        reclaimDeadWorkIfPossible(od, sig, {
-          ...opts,
-          statJob: () => null, // bg dead
-          probes: { implement: () => false }, // work NOT done
-          reviveDispatch: (args) => {
-            reviveDispatchCalls.push(args);
-            return { code: 0 };
-          },
-          applyStalledLabel: ({ ticket }) => {
-            labelCalls.push(ticket);
-            return { applied: true };
-          },
-          killBgJob: () => {},
-          // Use the default countReviveEvents → reads the real events.jsonl
-          // we seeded above (no override).
-        }),
-    });
-
-    expect(result.escalated).toEqual([{ ticket: "CTL-587-B", phase: "implement" }]);
-    expect(result.revived).toEqual([]);
-    expect(reviveDispatchCalls).toHaveLength(0);
-    expect(labelCalls).toEqual(["CTL-587-B"]);
-  });
-
-  // CTL-655: a daemon-boot.json marker windows the budget to the current run.
-  // Two revives that PRE-DATE the boot fall outside the window → the ticket is
-  // revived (budget reset), exercising the real readBootSince + countReviveEvents.
-  test("budget resets after restart — pre-boot revives are not counted → 'revived'", () => {
+  // CTL-655 / CTL-736: readBootSince still windows the revive ATTEMPT count to the
+  // current daemon run (telemetry). Prior revives no longer gate the decision, so
+  // a worker with pre-boot revive events still revives (it makes forward progress).
+  test("a worker with prior revive events still revives (no MAX_REVIVES budget gate)", () => {
     seedSignal("CTL-587-RESET", "implement", {
       status: "running",
       bg_job_id: "nonexistent-bg-id",
@@ -231,91 +192,13 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     expect(labelCalls).toEqual([]); // no needs-human escalation
   });
 
-  // CTL-655 guard against an over-aggressive window: revives AT/AFTER the boot
-  // time ARE counted, so the budget still exhausts within a single daemon run.
-  test("budget still exhausts within one run — post-boot revives ARE counted → 'escalated'", () => {
-    seedSignal("CTL-587-INRUN", "implement", {
-      status: "running",
-      bg_job_id: "nonexistent-bg-id",
-      orchestrator: "CTL-587-INRUN",
-    });
-    const bootedAt = "2026-05-24T00:00:00Z";
-    // Two revives at/after the boot time → inside the window.
-    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-INRUN", ts: "2026-05-25T00:00:00Z" }));
-    appendEvent(makeReviveEnvelope({ ticket: "CTL-587-INRUN", ts: "2026-05-25T00:05:00Z" }));
-    writeFileSync(join(orchDir, "daemon-boot.json"), JSON.stringify({ bootedAt }));
-
-    const labelCalls = [];
-    const reviveDispatchCalls = [];
-    const result = schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: () => ({ code: 0 }),
-      writeStatus: {
-        applyPhaseStatus: () => {},
-        applyTerminalDone: () => {},
-        applyLabel: () => ({ applied: true }),
-      },
-      teardownWorktree: () => true,
-      reclaimDeadWork: (od, sig, opts) =>
-        reclaimDeadWorkIfPossible(od, sig, {
-          ...opts,
-          statJob: () => null,
-          probes: { implement: () => false },
-          reviveDispatch: (args) => {
-            reviveDispatchCalls.push(args);
-            return { code: 0 };
-          },
-          applyStalledLabel: ({ ticket }) => {
-            labelCalls.push(ticket);
-            return { applied: true };
-          },
-          killBgJob: () => {},
-        }),
-    });
-
-    expect(result.escalated).toEqual([{ ticket: "CTL-587-INRUN", phase: "implement" }]);
-    expect(result.revived).toEqual([]);
-    expect(reviveDispatchCalls).toHaveLength(0);
-    expect(labelCalls).toEqual(["CTL-587-INRUN"]);
-  });
-
-  test("storm-breaker open: 4 distinct tickets reviving → 'revive-suppressed', no dispatch", () => {
-    seedSignal("CTL-587-C", "implement", {
-      status: "running",
-      bg_job_id: "nonexistent-bg-id",
-      orchestrator: "CTL-587-C",
-    });
-
-    const reviveDispatchCalls = [];
-    const result = schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: () => ({ code: 0 }),
-      writeStatus: {
-        applyPhaseStatus: () => {},
-        applyTerminalDone: () => {},
-        applyLabel: () => ({ applied: true }),
-      },
-      teardownWorktree: () => true,
-      reclaimDeadWork: (od, sig, opts) =>
-        reclaimDeadWorkIfPossible(od, sig, {
-          ...opts,
-          statJob: () => null,
-          probes: { implement: () => false },
-          reviveDispatch: (args) => {
-            reviveDispatchCalls.push(args);
-            return { code: 0 };
-          },
-          applyStalledLabel: () => ({ applied: true }),
-          killBgJob: () => {},
-          countReviveEvents: () => 0,
-          countDistinctRevivingTickets: () => 4, // > STORM_THRESHOLD=3
-        }),
-    });
-
-    expect(result.reviveSuppressed).toEqual([{ ticket: "CTL-587-C", phase: "implement" }]);
-    expect(reviveDispatchCalls).toHaveLength(0);
-    expect(existsSync(join(orchDir, "workers", "CTL-587-C", ".revive-1.applied"))).toBe(false); // no marker on suppression
-  });
+  // CTL-736 Phase 3: the fleet-wide storm-breaker (revive-suppressed on >3 distinct
+  // reviving tickets) and the post-boot budget-exhaustion escalation are DELETED.
+  // The per-worker progress gate + Phase-1 O_EXCL claim bound the storm
+  // structurally (a revived worker registers state=working → alive → suppressed),
+  // so neither a count threshold nor a fleet breaker is needed. Their end-to-end
+  // tests are removed with the mechanisms (the storm-repro convergence test below
+  // is the structural-bound proof).
 
   // CTL-641 + CTL-604: pr now has a probe, but a dead pr worker whose
   // phase-pr.json carries no .pr.number reads as not-done → branch (C). CTL-604
@@ -481,55 +364,14 @@ describe("CTL-587 end-to-end (schedulerTick + recovery)", () => {
     }
   });
 
-  // CTL-735 Guard 2 — the storm bound. Many dead-bg signals in ONE tick (the
-  // ~85-dir mass-revive scenario the de-starved fast loop hit) must NOT all
-  // revive at once: the per-tick cap bounds revives so a fast loop cannot outrun
-  // the event-count-lagged storm-breaker. With EXECUTION_CORE_PER_TICK_REVIVE_CAP=2,
-  // exactly 2 of 5 revivable workers revive this tick; the other 3 are
-  // `revive-capped` (deferred, no dispatch) and re-evaluated next tick. (No
-  // startedAt on the signals → Guard 1's grace window does not defer them, so the
-  // CAP is what bounds the count.)
-  test("per-tick revive cap bounds a mass-revive tick (5 dead → 2 revived, 3 capped)", () => {
-    for (let i = 0; i < 5; i++) {
-      seedSignal(`CTL-735-S${i}`, "implement", {
-        status: "running",
-        bg_job_id: `dead-bg-${i}`,
-        orchestrator: `CTL-735-S${i}`,
-      });
-    }
-
-    const reviveDispatchCalls = [];
-    const result = schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: () => ({ code: 0 }),
-      perTickReviveCap: 2, // injected — bound revives to 2 this tick
-      writeStatus: {
-        applyPhaseStatus: () => {},
-        applyTerminalDone: () => {},
-        applyLabel: () => ({ applied: true }),
-      },
-      teardownWorktree: () => true,
-      reclaimDeadWork: (od, sig, opts) =>
-        reclaimDeadWorkIfPossible(od, sig, {
-          ...opts, // carries the scheduler's per-tick reviveBudgetRemaining
-          statJob: () => null, // bg dead
-          probes: { implement: () => false }, // work NOT done → branch (C)
-          reviveDispatch: (args) => {
-            reviveDispatchCalls.push(args);
-            return { code: 0 };
-          },
-          applyStalledLabel: () => ({ applied: true }),
-          killBgJob: () => {},
-          countReviveEvents: () => 0, // per-ticket budget available for all
-          countDistinctRevivingTickets: () => 1, // storm-breaker NOT tripped
-        }),
-    });
-
-    // The cap — not the per-ticket budget or storm-breaker — is what bounds this.
-    expect(result.revived).toHaveLength(2);
-    expect(result.reviveCapped).toHaveLength(3);
-    expect(reviveDispatchCalls).toHaveLength(2); // only the uncapped revives dispatched
-  });
+  // CTL-736 Phase 3: the CTL-735 per-tick revive cap (`revive-capped`) is DELETED.
+  // The mass-revive storm it bounded is now prevented structurally — the progress
+  // gate revives a worker ONLY while it advances (a freshly-revived worker writes
+  // state=working → `alive` → suppressed next tick) and the Phase-1 O_EXCL claim
+  // makes duplicate spawn impossible. The ~85 day-stale debris dirs are caught by
+  // the inert-stale (REVIVE_MAX_AGE_MS) gate before the progress gate. Its
+  // per-tick-cap test is removed with the mechanism; the storm-repro convergence
+  // test below proves the new bound.
 
   // CTL-736 — the storm reproduction (PR #1232), re-cast for the state.json death
   // trigger. The original storm came from the eventually-consistent `claude

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -40,7 +40,12 @@ import { emitReapIntent as emitReapIntentDefault } from "./reap-intent.mjs";
 import { livenessForBgJob, claudeStop } from "./claude-agents.mjs";
 import { shortIdFromSessionId } from "./claude-ids.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
-import { WORK_DONE_PROBES, hasProbe, describeProbe } from "./work-done-probes.mjs";
+import {
+  WORK_DONE_PROBES,
+  hasProbe,
+  describeProbe,
+  defaultProgressMark,
+} from "./work-done-probes.mjs";
 import { defaultDispatch } from "./dispatch.mjs";
 import { applyLabel as defaultApplyLabel } from "./linear-write.mjs";
 import { linearBreaker } from "./linear-breaker.mjs";
@@ -53,10 +58,7 @@ import {
   inEscalationCooldown as defaultInEscalationCooldown,
   recordEscalation as defaultRecordEscalation,
 } from "./label-guard.mjs";
-import {
-  countReviveEvents as defaultCountReviveEvents,
-  countDistinctRevivingTickets as defaultCountDistinctRevivingTickets,
-} from "./event-scan.mjs";
+import { countReviveEvents as defaultCountReviveEvents } from "./event-scan.mjs";
 
 // phase-agent-emit-complete sits two directories up from execution-core/.
 const EMIT_COMPLETE_BIN = fileURLToPath(
@@ -1048,24 +1050,23 @@ function defaultWriteReviveMarker({ orchDir, ticket, attempt }) {
   }
 }
 
-// CTL-662 — the reclaim death-trigger is now the worker's `claude agents`
-// status (busy/idle/absent via livenessForBgJob), NOT state.json mtime. The
-// three pre-CTL-662 time triggers (the 5-min mtime-staleness death flag, the
-// CTL-587 defensive-kill quiet-window gate, and the CTL-610 keep-alive ceiling)
-// are all gone: an in-process sub-agent fan-out keeps the parent's turn `busy`
-// while state.json mtime goes stale, so mtime is a false death signal (the
-// proven worker-10d6f123 failure). Reclaim eligibility is driven by status + an
-// idle-confirmation streak (IDLE_CONFIRM_TICKS) and bounded only by the high
-// BUSY_CEILING_MS no-progress human-flag backstop — both env-overridable
-// tunables imported from config.mjs.
+// CTL-736 — the reclaim death-trigger is the authoritative LOCAL state.json
+// lifecycle (jobLifecycle → alive | dead-terminal | dead-gone), NOT the
+// eventually-consistent `claude agents` snapshot and NOT state.json mtime. An
+// in-process sub-agent fan-out keeps .state=working while mtime goes stale, so
+// mtime was a false death signal (the proven worker-10d6f123 failure) and the
+// snapshot showed a fresh worker `absent` before it registered (the CTL-735
+// storm). The single long backstop that survives is the BUSY_CEILING_MS
+// no-committed-work human-flag escalation on an `alive` worker — an
+// env-overridable tunable imported from config.mjs.
 
-// CTL-587 — auto-revival constants. MAX_REVIVES is the per-ticket budget
-// (counted from events.jsonl). STORM_WINDOW_MS + STORM_THRESHOLD form the
-// breaker that suppresses revives when too many tickets are reviving at once
-// (a Linear-side or fleet-wide outage).
-const MAX_REVIVES = 2;
+// CTL-736 Phase 3: the MAX_REVIVES per-ticket budget and the STORM_THRESHOLD
+// fleet-wide storm-breaker are DELETED — the progress gate (revive only while a
+// worker makes forward progress; stop on zero progress) plus the Phase-1 O_EXCL
+// claim bound retries structurally, no heuristic budget needed. STORM_WINDOW_MS
+// is retained ONLY as the `window_ms` field of the revive-suppressed audit event
+// emitted on the audit-append-failure path below.
 const STORM_WINDOW_MS = 10 * 60 * 1000;
-const STORM_THRESHOLD = 3;
 
 // CTL-736 Phase 2: the CTL-662 idle-confirmation streak markers
 // (`.idle-streak-<phase>` + idleStreakMarkerPath / read / bump / reset) are
@@ -1074,57 +1075,85 @@ const STORM_THRESHOLD = 3;
 // local state.json lifecycle (jobLifecycle) has no such ambiguity — `working`
 // is alive, terminal is dead — so no streak is needed.
 
-// reclaimDeadWorkIfPossible — one signal in, one decision out. CTL-662 swaps the
-// death TRIGGER from state.json mtime (the false signal: an in-process sub-agent
-// fan-out keeps the parent's turn busy while mtime goes stale) to the worker's
-// `claude agents` status via livenessForBgJob → busy|idle|absent. Every
-// CTL-587/606/610/661 behavioral guarantee on the reclaim-eligible path below is
-// preserved; only what makes a worker reclaim-eligible changes. The return set:
+// CTL-736 Phase 3 — progress high-water mark. Persisted per-(ticket, phase) as a
+// worker-dir marker (`.progress-<phase>`), the same durable-state mechanism as
+// the CTL-587 .revive-N.applied markers. The reclaim path compares the CURRENT
+// progressMark (commits-ahead / artifact bytes) against this stored high-water to
+// decide revive (progressed) vs stop (zero progress). defaultReadProgressMark
+// returns -1 when absent so a first death always gets one revive.
+function progressMarkPath(orchDir, ticket, phase) {
+  return join(orchDir, "workers", ticket, `.progress-${phase}`);
+}
+function defaultReadProgressMark(orchDir, ticket, phase) {
+  try {
+    const n = parseInt(readFileSync(progressMarkPath(orchDir, ticket, phase), "utf8"), 10);
+    return Number.isFinite(n) ? n : -1;
+  } catch {
+    return -1; // marker absent → no prior progress observation
+  }
+}
+// defaultWriteProgressMark — persist the new high-water mark. Fail-open: a write
+// failure only costs one extra revive evaluation next tick (harmless).
+function defaultWriteProgressMark(orchDir, ticket, phase, value) {
+  try {
+    writeFileSync(progressMarkPath(orchDir, ticket, phase), String(value));
+  } catch (err) {
+    log.warn({ ticket, phase, err: err.message }, "ctl-736: progress-mark write failed");
+  }
+}
+
+// reclaimDeadWorkIfPossible — one signal in, one decision out. CTL-736 swaps the
+// death TRIGGER from the eventually-consistent `claude agents` snapshot to the
+// authoritative LOCAL state.json lifecycle (jobLifecycle → alive | dead-terminal
+// | dead-gone), and replaces the ~14 heuristic revive-storm guards with two
+// deterministic primitives: the Phase-1 O_EXCL claim + fencing generation (no
+// duplicate spawn) and the Phase-3 progress gate (revive only while forward
+// progress advances; stop, never respawn, on zero progress). The return set:
 //
 //   'noop'                classifyWorker says terminal (phase finished) or
 //                         unknown (no bg_job_id). No action.
-//   'alive-busy-suppressed' worker is `busy` (a live session with an open turn —
-//                         including the in-process sub-agent fan-out that keeps
-//                         the parent busy while state.json mtime goes stale: the
-//                         CTL-662 false-reclaim fix). NEVER auto-reclaimed at any
-//                         elapsed time. Resets the idle streak. The sole permitted
-//                         action is the BUSY_CEILING_MS no-progress backstop.
-//   'idle-pending'        worker is `idle` (live, between turns) but has not yet
-//                         reached idleConfirmTicks consecutive idle observations.
-//                         Streak incremented + persisted; no reclaim this tick.
-//   'reclaimed'           reclaim-eligible (absent, or idle-confirmed) + work IS
+//   'alive-suppressed'    jobLifecycle is `alive` (state.json non-terminal, e.g.
+//                         working — INCLUDING a multi-minute in-process sub-agent
+//                         fan-out with stale mtime: the CTL-662 false-reclaim fix).
+//                         NEVER auto-reclaimed. The sole permitted action is the
+//                         BUSY_CEILING_MS no-committed-work escalation backstop.
+//   'reclaimed'           reclaim-eligible (dead-terminal / dead-gone) + work IS
 //                         done. Canonical reclaim audit appended, emit-complete
 //                         flipped the signal, session ended.
 //   'reclaim-failed'      reclaim-eligible + work IS done BUT emit-complete exited
 //                         non-zero. Signal NOT mutated (atomic rename); retries.
-//   'revived'             reclaim-eligible + probe says work NOT done + revive
-//                         budget available + storm-breaker closed. Signal reset to
-//                         'stalled', defaultDispatch invoked, .revive-N.applied
-//                         marker written. CTL-604: every probed phase shares this.
-//   'revive-suppressed'   reclaim-eligible + work NOT done + storm-breaker OPEN
-//                         (>3 distinct tickets reviving in last 10min). No
-//                         dispatch; suppress event audited; next tick re-evaluates.
-//   'escalated'           reclaim-eligible + (revive budget exhausted OR no
-//                         work-done probe for this phase: verify/review/pr/
-//                         monitor-*) OR a `busy` worker past BUSY_CEILING_MS with
-//                         no committed work. needs-human label applied (CTL-587
-//                         verified applyLabel); ticket stays put for human triage.
+//   'revived'             reclaim-eligible + probe says work NOT done + progress
+//                         ADVANCED since the last attempt. Signal reset to
+//                         'stalled', defaultDispatch invoked (bumps the fencing
+//                         generation), high-water mark + .revive-N.applied marker
+//                         written. CTL-604: every probed phase shares this.
+//   'no-progress-stopped' reclaim-eligible + work NOT done + ZERO forward progress
+//                         since the last attempt (the futile idle-respawn loop).
+//                         The dead worker is stopped and needs-human applied;
+//                         NEVER respawned. (Phase-3 replacement for the deleted
+//                         MAX_REVIVES budget + storm-breaker.)
+//   'rate-limited-deferred' a no-progress STOP whose needs-human escalation is
+//                         deferred because the Linear breaker is open (CTL-679);
+//                         the worker is still stopped, the label retries next tick.
+//   'revive-suppressed'   reclaim-eligible + work NOT done BUT the revive audit
+//                         event could not be persisted (disk error) — dispatch
+//                         skipped to preserve the attempt counter; retries.
+//   'inert-stale'         reclaim-eligible + work NOT done + the signal is older
+//                         than reviveMaxAgeMs — an abandoned historical dir, left
+//                         inert (no revive, no escalate). (CTL-735, kept.)
+//   'escalated' / 'escalation-suppressed'
+//                         an `alive` worker past BUSY_CEILING_MS with no committed
+//                         work (the backstop), behind the CTL-638 cool-down.
 //   'superseded-noop'     reclaim-eligible BUT the signal's phase precedes the
-//                         ticket's latest-dispatched phase (CTL-606). A stale
-//                         predecessor left at `running`; acting would spuriously
-//                         flag needs-human or spawn a duplicate at a past phase.
-//                         A reap-intent is emitted so the reaper stops the bg.
+//                         ticket's latest-dispatched phase (CTL-606). A reap-intent
+//                         is emitted so the reaper stops the bg.
 //
-// CTL-662: a worker is reclaim-eligible iff livenessForBgJob is `absent` (not a
-// live `claude agents` session) OR `idle` for idleConfirmTicks consecutive
-// observations. state.json mtime is no longer a decision input on ANY branch.
-//
-// The function stays pure given its injected seams: statJob / probes /
-// emitComplete / appendEvent (pre-CTL-587) plus the CTL-587 seams
-// (appendReviveEvent, appendEscalatedEvent, appendReviveSuppressedEvent,
-// reviveDispatch, applyStalledLabel, killBgJob, countReviveEvents,
-// countDistinctRevivingTickets, writeReviveMarker) plus the CTL-662 liveness +
-// idle-streak seams. All have real defaults for prod; tests override every one.
+// The function stays pure given its injected seams: statJob / jobLifecycle /
+// livenessSource (death trigger) / probes / progressMark + read/writeProgressMark
+// (the Phase-3 progress gate) / emitComplete / the CTL-587 revive+escalate seams
+// (appendReviveEvent, appendEscalatedEvent, reviveDispatch, applyStalledLabel,
+// killBgJob, countReviveEvents, writeReviveMarker) + the CTL-638 cool-down +
+// CTL-679 breaker. All have real defaults for prod; tests override every one.
 export function reclaimDeadWorkIfPossible(
   orchDir,
   signal,
@@ -1140,14 +1169,25 @@ export function reclaimDeadWorkIfPossible(
     reviveDispatch = defaultReviveDispatch,
     applyStalledLabel = defaultApplyStalledLabel,
     killBgJob = defaultKillBgJob,
+    // CTL-736 Phase 3: countReviveEvents now supplies the revive ATTEMPT NUMBER
+    // for the audit event + `.revive-N.applied` marker only (telemetry) — it is
+    // no longer a budget gate (the progress gate bounds retries).
     countReviveEvents = defaultCountReviveEvents,
     // CTL-655 — boot-time window reader. Reads <orchDir>/daemon-boot.json and
-    // returns its `bootedAt` (or undefined) so the revive budget counts only
-    // revives from the current daemon run. Named ...Fn to avoid shadowing the
-    // module-level readBootSince used as the default.
+    // returns its `bootedAt` (or undefined) so the attempt count windows to the
+    // current daemon run. Named ...Fn to avoid shadowing the module-level
+    // readBootSince used as the default.
     readBootSince: readBootSinceFn = readBootSince,
-    countDistinctRevivingTickets = defaultCountDistinctRevivingTickets,
     writeReviveMarker = defaultWriteReviveMarker,
+    // CTL-736 Phase 3 — progress probe seams. progressMark returns a monotonic-ish
+    // non-negative forward-progress token (commits-ahead / artifact bytes);
+    // read/writeProgressMark persist the per-(ticket, phase) high-water mark under
+    // workers/<ticket>/.progress-<phase>. Replace the MAX_REVIVES budget, the
+    // storm-breaker, and the per-tick cap: revive only while progress advances,
+    // stop (never respawn) on zero progress.
+    progressMark = defaultProgressMark,
+    readProgressMark = defaultReadProgressMark,
+    writeProgressMark = defaultWriteProgressMark,
     // CTL-638 — per-(ticket, phase) escalation cool-down. Defaults read/write
     // markers under orchDir/.escalation-cooldowns/; tests can inject fakes to
     // run multiple escalations against the same scenario without filesystem
@@ -1175,13 +1215,6 @@ export function reclaimDeadWorkIfPossible(
     // (state-json | shadow | snapshot, default state-json). Read once per call
     // so an env flip / per-test override takes effect without a module reload.
     livenessSource = readLivenessConfig().source,
-    // CTL-735 — per-tick revive budget, threaded in by the scheduler sweep
-    // (PER_TICK_REVIVE_CAP minus revives already performed this tick). When <= 0
-    // an otherwise-revivable worker is `revive-capped` (deferred) rather than
-    // dispatched, so one tick cannot mass-revive. `undefined` (the default and
-    // every standalone/test caller that does not set it) disables the cap →
-    // pre-CTL-735 behaviour.
-    reviveBudgetRemaining = undefined,
     // CTL-735 — revival age ceiling. An absent/idle, work-not-done worker whose
     // signal has not been touched in this long is an abandoned historical dir,
     // not a fresh crash: treated as inert (no revive, no escalate). Injectable for
@@ -1458,14 +1491,15 @@ export function reclaimDeadWorkIfPossible(
   // state=working immediately, so jobLifecycle reads `alive` and never reaches
   // branch (C) until the job is genuinely terminal. No grace window is needed.
 
-  // CTL-735 Guard 3 — inert stale tickets. By here the worker is reclaim-eligible
-  // (dead-terminal or dead-gone), work NOT done. If its
-  // signal has not been touched in reviveMaxAgeMs it is an abandoned historical
-  // dir (isTicketInFlight keeps any non-terminal signal in-flight forever, so a
-  // worker that crashed at `running` and never flipped terminal is swept every
-  // tick). Reviving it wastes budget and — once MAX_REVIVES is hit — would
-  // escalate a long-dead ticket to needs-human. Treat it as inert: no revive, no
-  // escalate, no event. Branch (B) reclaim already ran above, so a genuinely
+  // CTL-735 Guard 3 — inert stale tickets (KEPT in CTL-736: orthogonal to the
+  // liveness mechanism). By here the worker is reclaim-eligible (dead-terminal or
+  // dead-gone), work NOT done. If its signal has not been touched in reviveMaxAgeMs
+  // it is an abandoned historical dir (isTicketInFlight keeps any non-terminal
+  // signal in-flight forever, so a worker that crashed at `running` and never
+  // flipped terminal is swept every tick). This gate runs BEFORE the progress gate
+  // so the ~85 day-stale debris dirs are treated as inert (no revive, no escalate,
+  // no event) rather than each getting a one-shot no-progress escalation →
+  // needs-human storm. Branch (B) reclaim already ran above, so a genuinely
   // work-done old worker was cleaned up; only no-work abandoned dirs reach here.
   // A signal with no parseable timestamp (legacy) falls through unchanged.
   const lastActiveMs = Math.max(
@@ -1480,53 +1514,50 @@ export function reclaimDeadWorkIfPossible(
     return "inert-stale";
   }
 
-  // Per-ticket revive budget from events.jsonl. The events file is the
-  // authoritative counter — more truthful than the signal file (which the
-  // dispatcher rewrites each spawn). CTL-655: window the count to the current
-  // daemon run via the boot marker, so a clean restart resets a budget burned
-  // by a prior crash storm. `since` is undefined when the marker is absent →
-  // the count is unwindowed (the pre-CTL-655 behavior).
+  // CTL-736 Phase 3 — THE progress gate. Replaces the MAX_REVIVES per-ticket
+  // budget, the fleet-wide storm-breaker, and the per-tick revive cap with ONE
+  // local, deterministic rule: a worker that ADVANCED its progress mark since the
+  // last attempt is resumably revived (gen+1 — duplicate spawn is structurally
+  // impossible via the Phase-1 O_EXCL claim + fencing generation, so no heuristic
+  // budget is needed); a worker with ZERO new forward progress is a futile
+  // respawn (the CTL-728/729 idle-never-takes-a-turn loop, research §3) → STOP +
+  // flag needs-human, NEVER respawn. progressMark is monotonic-ish (commits-ahead
+  // for code phases, artifact byte-size for doc/JSON phases); readProgressMark
+  // returns -1 when no prior mark exists, so a first death always gets one revive
+  // (a genuine early crash is retry-worthy) and a SECOND no-progress death stops.
+  const currentProgress = progressMark({ ticket, phase, repoRoot, orchDir });
+  const lastProgress = readProgressMark(orchDir, ticket, phase);
+  if (currentProgress <= lastProgress) {
+    // Stop the dead worker (the reaper + an inline best-effort stop) and flag for
+    // human — do NOT spawn another worker that would also make no progress.
+    if (prevBgJobId) {
+      emitReapIntent("phase.no-progress.reap-requested", {
+        ticket,
+        phase,
+        bgJobId: prevBgJobId,
+        worktreePath: signal.raw?.worktreePath,
+        prevStateJsonMtime,
+      }).catch(() => {});
+      killBgJob({ bgJobId: prevBgJobId });
+    }
+    log.warn(
+      { ticket, phase, prevBgJobId, currentProgress, lastProgress },
+      "ctl-736: no forward progress since last attempt — stopping, not respawning",
+    );
+    // needs-human (cool-down + breaker guarded). When the Linear breaker is open
+    // the escalation defers — surface that so the scheduler does not record a
+    // clean stop (the worker is killed, but the label retries next tick).
+    const esc = escalateOnce("no-progress", currentProgress);
+    return esc === "rate-limited-deferred" ? "rate-limited-deferred" : "no-progress-stopped";
+  }
+  // Forward progress was made → record the new high-water mark and revive below.
+  writeProgressMark(orchDir, ticket, phase, currentProgress);
+
+  // Attempt number for the revive audit + `.revive-N.applied` marker. This is now
+  // TELEMETRY ONLY (no longer a budget gate — the progress gate bounds retries).
+  // CTL-655: window the count to the current daemon run via the boot marker.
   const since = readBootSinceFn(orchDir);
   const priorRevives = countReviveEvents({ ticket, orchId, since });
-  if (priorRevives >= MAX_REVIVES) {
-    return escalateOnce("revive-budget-exhausted", priorRevives);
-  }
-
-  // Storm-breaker: if many distinct tickets are reviving inside the window,
-  // assume something is wrong fleet-wide and suppress (do nothing this tick).
-  const distinctStormTickets = countDistinctRevivingTickets({
-    windowMs: STORM_WINDOW_MS,
-    now,
-  });
-  if (distinctStormTickets > STORM_THRESHOLD) {
-    appendReviveSuppressedEvent({
-      phase,
-      ticket,
-      orchId,
-      window_distinct_tickets: distinctStormTickets,
-    });
-    log.warn(
-      { ticket, phase, distinctStormTickets },
-      "ctl-587: revive suppressed (storm-breaker open)",
-    );
-    return "revive-suppressed";
-  }
-
-  // CTL-735 — per-tick revive cap. Even with the per-ticket budget and the
-  // event-counted storm-breaker open, the de-starved fast tick can mass-revive
-  // many distinct dead workers in a single sweep before the storm-breaker's
-  // event count catches up. The scheduler threads the remaining per-tick budget;
-  // once exhausted, defer this worker (revive-capped) to a later tick rather than
-  // dispatch. No event is emitted (we did NOT revive) and no marker is written,
-  // so the next tick re-evaluates cleanly. Gated on a finite budget so standalone
-  // callers (no scheduler) keep pre-CTL-735 behaviour.
-  if (Number.isFinite(reviveBudgetRemaining) && reviveBudgetRemaining <= 0) {
-    log.warn(
-      { ticket, phase, prevBgJobId },
-      "ctl-735: revive deferred — per-tick revive cap reached (revive-capped)",
-    );
-    return "revive-capped";
-  }
 
   // CTL-658: resolve a `claude --resume`-compatible session id from the dead
   // worker's bg_job_id BEFORE the defensive kill. When a UUID resolves we are

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -17,7 +17,6 @@ import {
   writeFileSync,
   renameSync,
   existsSync,
-  rmSync,
 } from "node:fs";
 import { dirname } from "node:path";
 import { join, basename } from "node:path";
@@ -29,10 +28,9 @@ import {
   getJobsRoot,
   getEventLogPath,
   log,
-  IDLE_CONFIRM_TICKS,
   BUSY_CEILING_MS,
-  REVIVE_GRACE_MS,
   REVIVE_MAX_AGE_MS,
+  readLivenessConfig,
 } from "./config.mjs";
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
@@ -101,8 +99,14 @@ export function resolvePhaseSessionId(
 }
 
 // defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
-// the job dir is gone (the worker's process no longer exists), else its mtime
-// and parsed .state. Injectable so tests never touch real Claude job state.
+// the job dir is gone (the worker's process no longer exists), else its mtime,
+// parsed .state, and .firstTerminalAt. Injectable so tests never touch real
+// Claude job state.
+//
+// CTL-736 Phase 2: firstTerminalAt is the state-name-agnostic death signal —
+// Claude stamps it the moment a job reaches a terminal lifecycle state, so
+// jobLifecycle can declare death even when the .state string is one we don't
+// enumerate. Null for a live/non-terminal job (and when state.json is unreadable).
 export function defaultStatJob(bgJobId) {
   const file = join(getJobsRoot(), bgJobId, "state.json");
   let st;
@@ -112,26 +116,62 @@ export function defaultStatJob(bgJobId) {
     return null; // job dir missing → worker is gone
   }
   let state = null;
+  let firstTerminalAt = null;
   try {
-    state = JSON.parse(readFileSync(file, "utf8"))?.state ?? null;
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    state = parsed?.state ?? null;
+    firstTerminalAt = parsed?.firstTerminalAt ?? null;
   } catch {
     /* state.json unreadable — liveness still proven by the dir existing */
   }
-  return { exists: true, mtimeMs: st.mtimeMs, state };
+  return { exists: true, mtimeMs: st.mtimeMs, state, firstTerminalAt };
+}
+
+// CTL-736 Phase 2 — the authoritative job-lifecycle terminal states. These are
+// the `state` values Claude writes into ~/.claude/jobs/<id>/state.json when a
+// `claude --bg` job reaches a terminal lifecycle (empirically: stopped/failed/
+// done/blocked; `working` is the sole non-terminal value). DISTINCT from the
+// worker-SIGNAL `TERMINAL` set imported from signal-reader.mjs (phase signal
+// status like done/skipped) — do not conflate the two.
+export const TERMINAL_JOB_STATES = new Set(["stopped", "failed", "done", "blocked"]);
+
+// jobLifecycle — CTL-736 Phase 2's deterministic, LOCAL death verdict from a
+// `claude --bg` job's state.json, replacing the eventually-consistent `claude
+// agents` snapshot (livenessForBgJob) in the reclaim death trigger:
+//   'dead-gone'     — the job dir is gone (statJob null): the worker is gone.
+//   'dead-terminal' — firstTerminalAt is set OR .state ∈ TERMINAL_JOB_STATES:
+//                     Claude marked the job terminal. Definitive — no grace
+//                     window or idle-confirmation streak needed.
+//   'alive'         — any other readable state (notably 'working', or an
+//                     unreadable state.json whose dir still exists). mtime is
+//                     NOT consulted: a multi-minute in-process sub-agent fan-out
+//                     keeps .state non-terminal while mtime ages, and the
+//                     pre-CTL-662 mtime trigger false-reclaimed exactly that
+//                     (the worker-10d6f123 failure). Pure given statJob.
+export function jobLifecycle(bgJobId, { statJob = defaultStatJob } = {}) {
+  const job = statJob(bgJobId);
+  if (!job) return "dead-gone";
+  if (job.firstTerminalAt || TERMINAL_JOB_STATES.has(job.state)) return "dead-terminal";
+  return "alive";
 }
 
 // classifyWorker — PURE given statJob. One WorkerSignal (from readWorkerSignals)
 // → a liveness class:
 //   'terminal' — signal status is terminal; the phase finished, nothing to attach
-//   'running'  — non-terminal + the bg job dir exists → re-attached
-//   'dead'     — non-terminal + the bg job dir is gone → a lost worker
+//   'running'  — non-terminal signal + the bg job is alive (state.json non-terminal)
+//   'dead'     — non-terminal signal + the bg job is terminal OR its dir is gone
 //   'unknown'  — no bg_job_id (legacy pid signal, or an orphan `dispatched`
 //                signal written before claude --bg was spawned)
+//
+// CTL-736 Phase 2: consults the job LIFECYCLE (jobLifecycle → state.json), not
+// mere job-dir existence. A never-cleaned-up dir whose .state is terminal
+// (stopped/failed/done/blocked) now classifies 'dead' instead of 'running' —
+// the discard the plan called out (16,462 retained job dirs, 0 pid files).
 export function classifyWorker(signal, { statJob = defaultStatJob } = {}) {
   if (TERMINAL.has(signal?.status)) return "terminal";
   const live = signal?.liveness;
   if (live?.kind !== "bg" || !live?.value) return "unknown";
-  return statJob(live.value) ? "running" : "dead";
+  return jobLifecycle(live.value, { statJob }) === "alive" ? "running" : "dead";
 }
 
 // reconstructWorkerState — scan ${orchDir}/workers/ via the canonical reader and
@@ -1027,44 +1067,12 @@ const MAX_REVIVES = 2;
 const STORM_WINDOW_MS = 10 * 60 * 1000;
 const STORM_THRESHOLD = 3;
 
-// CTL-662 — idle-confirmation streak markers. The consecutive-idle-observation
-// counter is persisted as a per-(ticket, phase) worker-dir marker
-// (`.idle-streak-<phase>`), the same durable-state mechanism as the CTL-587
-// .revive-N.applied markers and the CTL-638 escalation cool-downs — a PERSISTED
-// counter, NOT an mtime window (the invariant the plan requires). A re-dispatch
-// recreates the worker dir, so the streak naturally resets on revive.
-function idleStreakMarkerPath(orchDir, ticket, phase) {
-  return join(orchDir, "workers", ticket, `.idle-streak-${phase}`);
-}
-function defaultReadIdleStreak(orchDir, ticket, phase) {
-  try {
-    const n = parseInt(readFileSync(idleStreakMarkerPath(orchDir, ticket, phase), "utf8"), 10);
-    return Number.isFinite(n) && n > 0 ? n : 0;
-  } catch {
-    return 0; // marker absent → no prior idle observation
-  }
-}
-// defaultBumpIdleStreak — increment + persist the counter, returning the NEW
-// count. Fail-open: a write failure returns the would-be count so a transient
-// fs error never wedges the streak (worst case: one extra idle tick before
-// reclaim, harmless).
-function defaultBumpIdleStreak(orchDir, ticket, phase) {
-  const next = defaultReadIdleStreak(orchDir, ticket, phase) + 1;
-  try {
-    writeFileSync(idleStreakMarkerPath(orchDir, ticket, phase), String(next));
-  } catch (err) {
-    log.warn({ ticket, phase, err: err.message }, "ctl-662: idle-streak write failed");
-  }
-  return next;
-}
-function defaultResetIdleStreak(orchDir, ticket, phase) {
-  try {
-    const path = idleStreakMarkerPath(orchDir, ticket, phase);
-    if (existsSync(path)) rmSync(path);
-  } catch {
-    /* best-effort — a stale streak marker only delays the next reclaim by ticks */
-  }
-}
+// CTL-736 Phase 2: the CTL-662 idle-confirmation streak markers
+// (`.idle-streak-<phase>` + idleStreakMarkerPath / read / bump / reset) are
+// DELETED. They existed to confirm an eventually-consistent `claude agents`
+// `idle` reading across consecutive ticks before reclaiming. The authoritative
+// local state.json lifecycle (jobLifecycle) has no such ambiguity — `working`
+// is alive, terminal is dead — so no streak is needed.
 
 // reclaimDeadWorkIfPossible — one signal in, one decision out. CTL-662 swaps the
 // death TRIGGER from state.json mtime (the false signal: an in-process sub-agent
@@ -1154,17 +1162,19 @@ export function reclaimDeadWorkIfPossible(
     // auto-reclaim; "idle" → reclaim-eligible only after an
     // idle-confirmation streak; "absent" (not a live `claude agents` session) →
     // reclaim-eligible immediately.
+    // CTL-736 Phase 2 — the legacy eventually-consistent `claude agents`
+    // snapshot reader. NO LONGER the default death trigger (jobLifecycle below
+    // is). Retained as a seam because the `snapshot` + `shadow` LIVENESS_SOURCE
+    // modes still consult it (the env-only rollback / live A/B observability).
     liveness = livenessForBgJob,
-    // CTL-662 — idle-confirmation streak seams. The consecutive-idle counter is
-    // a per-(ticket, phase) worker-dir marker, NOT an mtime window.
-    bumpIdleStreak = defaultBumpIdleStreak,
-    resetIdleStreak = defaultResetIdleStreak,
-    idleConfirmTicks = IDLE_CONFIRM_TICKS,
-    // CTL-735 — post-(re)dispatch grace window for the `absent` class. A worker
-    // (re)dispatched within this window whose new bg_job_id is not yet visible in
-    // the eventually-consistent `claude agents` snapshot is deferred (revive-
-    // pending) rather than re-revived. Injectable so tests drive it deterministically.
-    reviveGraceMs = REVIVE_GRACE_MS,
+    // CTL-736 Phase 2 — THE death trigger: the authoritative LOCAL state.json
+    // lifecycle (alive | dead-terminal | dead-gone). Aliased ...Fn to avoid
+    // shadowing the module-level jobLifecycle used as the default.
+    jobLifecycle: jobLifecycleFn = jobLifecycle,
+    // CTL-736 Phase 2 — which liveness source drives the trigger
+    // (state-json | shadow | snapshot, default state-json). Read once per call
+    // so an env flip / per-test override takes effect without a module reload.
+    livenessSource = readLivenessConfig().source,
     // CTL-735 — per-tick revive budget, threaded in by the scheduler sweep
     // (PER_TICK_REVIVE_CAP minus revives already performed this tick). When <= 0
     // an otherwise-revivable worker is `revive-capped` (deferred) rather than
@@ -1258,46 +1268,67 @@ export function reclaimDeadWorkIfPossible(
     return "escalated";
   }
 
-  // CTL-662 — THE DEATH TRIGGER. The worker's `claude agents` status, not its
-  // state.json mtime. busy → alive (never auto-reclaim); idle → reclaim-eligible
-  // after a confirmation streak; absent → reclaim-eligible immediately.
-  const live = liveness(prevBgJobId);
+  // CTL-736 Phase 2 — THE DEATH TRIGGER. The authoritative LOCAL state.json
+  // lifecycle (jobLifecycle), not the eventually-consistent `claude agents`
+  // snapshot. LIVENESS_SOURCE selects the source (default state-json):
+  //   state-json : jobLifecycle(prevBgJobId) is the trigger — deterministic,
+  //                fan-out-safe (a multi-minute in-process sub-agent fan-out
+  //                keeps .state=working while mtime ages; mtime is never read).
+  //   shadow     : act on jobLifecycle BUT also compute the legacy snapshot and
+  //                log `liveness-shadow-mismatch` on disagreement (live A/B).
+  //   snapshot   : env-only rollback to the legacy livenessForBgJob trigger
+  //                (busy ⇒ alive; idle/absent ⇒ reclaim-eligible — the deleted
+  //                idle-confirmation streak / grace window are GONE, so an idle
+  //                worker reclaims immediately, the pre-CTL-662 behaviour).
+  let lifecycle; // "alive" | "dead-terminal" | "dead-gone"
+  if (livenessSource === "snapshot") {
+    lifecycle = liveness(prevBgJobId) === "busy" ? "alive" : "dead-gone";
+  } else {
+    lifecycle = jobLifecycleFn(prevBgJobId, { statJob });
+    if (livenessSource === "shadow") {
+      const snap = liveness(prevBgJobId); // busy | idle | absent
+      const snapAlive = snap === "busy";
+      if (snapAlive !== (lifecycle === "alive")) {
+        log.warn(
+          { ticket, phase, prevBgJobId, jobLifecycle: lifecycle, snapshot: snap },
+          "ctl-736: liveness-shadow-mismatch — state.json and `claude agents` snapshot disagree",
+        );
+      }
+    }
+  }
 
-  // ── busy: NEVER auto-reclaimed at any elapsed time. This is the CTL-662 fix:
-  //    a phase worker's in-process Task sub-agent fan-out keeps the parent turn
-  //    `busy` while state.json mtime goes stale, so the pre-CTL-662 mtime trigger
-  //    false-reclaimed it (the proven worker-10d6f123 failure). The only action
-  //    permitted on a busy worker is the high-ceiling no-progress backstop: a
-  //    worker busy past BUSY_CEILING_MS whose work-done probe is STILL false is
-  //    flagged for human (escalateOnce) — never a silent reclaim-and-advance. A
-  //    busy worker that has already committed work is left to emit its own
-  //    authoritative complete. A single busy observation resets any in-progress
-  //    idle-confirmation streak.
-  if (live === "busy") {
-    resetIdleStreak(orchDir, ticket, phase);
+  // ── alive: NEVER auto-reclaimed. The job's state.json lifecycle is
+  //    non-terminal (`working`, or an unreadable-but-present state.json). The
+  //    fan-out-safe replacement for the CTL-662 busy short-circuit: no idle
+  //    streak, no grace window — `working` is immediately authoritative. The
+  //    sole permitted action is the no-committed-work backstop: an alive worker
+  //    past busyCeilingMs whose work-done probe is STILL false is flagged for
+  //    human (escalateOnce), never a silent reclaim-and-advance. (CTL-736
+  //    Phase 3 generalizes this ceiling into the progress probe.)
+  if (lifecycle === "alive") {
     const startedAtMs = Date.parse(signal.raw?.startedAt ?? "");
     if (Number.isFinite(startedAtMs) && now() - startedAtMs > busyCeilingMs) {
       const workDone = hasProbe(phase) && probes[phase]({ ticket, repoRoot, orchDir });
       if (!workDone) {
         log.warn(
-          { ticket, phase, prevBgJobId, busyForMs: now() - startedAtMs },
-          "ctl-662: busy worker past BUSY_CEILING_MS with no committed work — escalating (never silent reclaim)",
+          { ticket, phase, prevBgJobId, aliveForMs: now() - startedAtMs },
+          "ctl-736: alive worker past BUSY_CEILING_MS with no committed work — escalating (never silent reclaim)",
         );
         return escalateOnce("busy-ceiling-exceeded", 0);
       }
     }
-    log.info({ ticket, phase, prevBgJobId }, "ctl-662: busy worker — reclaim suppressed");
-    return "alive-busy-suppressed";
+    log.info({ ticket, phase, prevBgJobId }, "ctl-736: alive worker — reclaim suppressed");
+    return "alive-suppressed";
   }
 
-  // ── idle | absent share the reclaim-eligible path below.
+  // ── dead-terminal | dead-gone share the reclaim-eligible path below.
   // CTL-606 — supersede guard. The reclaim sweep is fed ONE signal per ticket by
   // readWorkerSignals→byActivePhase, which ranks by status+recency, NOT phase
   // order. A stale predecessor left at `running` (never flipped to `done`) can
   // shadow the real, already-advanced phase. If the dead signal's phase precedes
   // the ticket's latest-dispatched phase, the ticket has moved on — escalating or
   // reviving it would spuriously flag needs-human or spawn a duplicate worker at
-  // a past phase. Runs only once a worker is reclaim-eligible (not busy).
+  // a past phase. Runs only once a worker is reclaim-eligible (not alive).
   // CTL-702: defensive — listTicketPhases is read off the filesystem; if a
   // future on-disk variant slips past signal-reader's filter (e.g. yield
   // tombstone, manual operator file), isKnownPhase skips it instead of
@@ -1326,23 +1357,9 @@ export function reclaimDeadWorkIfPossible(
     return "superseded-noop";
   }
 
-  // ── idle requires an idle-confirmation streak before it is reclaim-eligible: a
-  //    couple of CONSECUTIVE idle observations confirm the worker is genuinely
-  //    between-turns done, not momentarily idle between sub-agent fan-out rounds.
-  //    `absent` skips this — absence is unambiguous. The streak is a persisted
-  //    per-(ticket, phase) counter (NOT an mtime window). Once we proceed to act
-  //    (reclaim/revive below), the streak is cleared.
-  if (live === "idle") {
-    const streak = bumpIdleStreak(orchDir, ticket, phase);
-    if (streak < idleConfirmTicks) {
-      log.info(
-        { ticket, phase, streak, idleConfirmTicks },
-        "ctl-662: idle worker pending confirmation — not yet reclaim-eligible",
-      );
-      return "idle-pending";
-    }
-  }
-  resetIdleStreak(orchDir, ticket, phase);
+  // CTL-736 Phase 2: a dead-terminal/dead-gone worker is reclaim-eligible
+  // immediately — the idle-confirmation streak (and its `.idle-streak-<phase>`
+  // markers) are deleted; the state.json lifecycle is unambiguous.
 
   // (A) No probe registered for this phase → escalate. The pre-CTL-587 silent
   //     'not-applicable' return is now an actionable outcome: the worker is
@@ -1377,14 +1394,13 @@ export function reclaimDeadWorkIfPossible(
         reason: "ctl-661-reclaim-happy-path",
       }).catch(() => {});
     }
-    // CTL-664/CTL-662: derive the reclaim observability fields from values
-    // already computed above. Post-CTL-662 this reclaim branch is reached ONLY
-    // for an `absent` bg job or an idle-confirmed one — `busy` returns at
-    // alive-busy-suppressed and an unconfirmed `idle` returns at idle-pending
-    // above, and mtime is no longer a reclaim trigger. So the death signal
-    // reflects the liveness verdict the trigger actually acted on, never the
-    // obsolete "mtime". Kept as a single const so the mirror body reuses it.
-    const death_signal = live === "absent" ? "absent" : "idle-confirmed";
+    // CTL-736 Phase 2 / CTL-664: derive the reclaim observability field from the
+    // jobLifecycle verdict the trigger acted on. This branch is reached ONLY for
+    // a reclaim-eligible worker (`dead-terminal` — Claude marked the job
+    // stopped/failed/done/blocked — or `dead-gone` — the job dir vanished); an
+    // `alive` worker returns at alive-suppressed above. Kept as a single const so
+    // the mirror body reuses it. (`prev_state_json_mtime` stays as telemetry.)
+    const death_signal = lifecycle;
     const probe_checked = describeProbe(phase);
     appendEvent({
       phase,
@@ -1430,42 +1446,20 @@ export function reclaimDeadWorkIfPossible(
   //     defaultReviveDispatch is phase-agnostic (resets the signal to `stalled`
   //     and re-launches via phase-agent-dispatch).
 
-  // CTL-662: by the time control reaches branch (C) the worker is reclaim-
-  // eligible — either `absent` (a real crash: no live `claude agents` session)
-  // or `idle`-confirmed (live but idle for idleConfirmTicks consecutive ticks,
-  // genuinely between-turns with no committed work). A `busy` worker can never
-  // reach here (the busy branch above returns first), so the revive/re-dispatch
-  // path below is correct for both reclaim-eligible cases.
-
-  // CTL-735 Guard 1 — post-(re)dispatch grace window. A just-(re)dispatched worker
-  // needs time to start working before the sweep judges it dead. It can present as
-  // EITHER `absent` (a freshly-spawned `claude --bg` not yet registered in the
-  // eventually-consistent `claude agents` snapshot) OR `idle` (registered but
-  // waiting for its first turn — common for triage/verify, which don't go `busy`
-  // immediately like implement does). Before CTL-735 the sweep revived an absent
-  // worker as dead; the short idle-confirmation streak (~2 ticks) re-revived an
-  // idle one every ~20-30s. Both produced the de-starved revive storm (5→18→62→74
-  // workers, load 72; live re-enable showed the idle path storm triage/verify).
-  // Defer reviving an `absent` OR `idle` worker whose signal was (re)dispatched
-  // within reviveGraceMs. `busy` is already handled above (a working worker is
-  // never reclaimed). Placed inside branch (C) (work NOT done) so a just-completed
-  // worker still reclaims promptly via branch (B). Self-clearing: once startedAt
-  // ages past the window the worker is judged on its real liveness and proceeds to
-  // revive below. A signal with no parseable startedAt (legacy) falls through to
-  // the pre-CTL-735 revive behaviour.
-  if (live === "absent" || live === "idle") {
-    const startedAtMs = Date.parse(signal.raw?.startedAt ?? "");
-    if (Number.isFinite(startedAtMs) && now() - startedAtMs < reviveGraceMs) {
-      log.info(
-        { ticket, phase, prevBgJobId, live, sinceDispatchMs: now() - startedAtMs, reviveGraceMs },
-        "ctl-735: worker within post-dispatch grace window — revive deferred (revive-pending)",
-      );
-      return "revive-pending";
-    }
-  }
+  // CTL-736 Phase 2: by the time control reaches branch (C) the worker is
+  // reclaim-eligible — `dead-terminal` (Claude marked the job
+  // stopped/failed/done/blocked) or `dead-gone` (the job dir vanished). Both are
+  // definitive local verdicts, so the revive/re-dispatch path below is correct.
+  //
+  // The CTL-735 post-dispatch grace window (Guard 1, `revive-pending`) is DELETED:
+  // it existed only because the eventually-consistent `claude agents` snapshot
+  // showed a freshly-spawned worker as `absent`/`idle` before it registered. The
+  // local state.json has no such lag — a just-(re)dispatched worker writes
+  // state=working immediately, so jobLifecycle reads `alive` and never reaches
+  // branch (C) until the job is genuinely terminal. No grace window is needed.
 
   // CTL-735 Guard 3 — inert stale tickets. By here the worker is reclaim-eligible
-  // (absent or idle-confirmed), past its grace window, work NOT done. If its
+  // (dead-terminal or dead-gone), work NOT done. If its
   // signal has not been touched in reviveMaxAgeMs it is an abandoned historical
   // dir (isTicketInFlight keeps any non-terminal signal in-flight forever, so a
   // worker that crashed at `running` and never flipped terminal is swept every

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -17,6 +17,7 @@ import {
   writeFileSync,
   renameSync,
   existsSync,
+  rmSync,
 } from "node:fs";
 import { dirname } from "node:path";
 import { join, basename } from "node:path";
@@ -30,14 +31,13 @@ import {
   log,
   BUSY_CEILING_MS,
   REVIVE_MAX_AGE_MS,
-  readLivenessConfig,
 } from "./config.mjs";
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
 import { emitReapIntent as emitReapIntentDefault } from "./reap-intent.mjs";
-import { livenessForBgJob, claudeStop } from "./claude-agents.mjs";
+import { claudeStop } from "./claude-agents.mjs";
 import { shortIdFromSessionId } from "./claude-ids.mjs";
 import { loadCursor, resolveStartOffset } from "./event-cursor.mjs";
 import {
@@ -909,6 +909,42 @@ export function writeBootMarker(orchDir, { now = () => new Date().toISOString() 
   }
 }
 
+// clearProgressMarks — CTL-736 Phase 3: delete every per-(ticket, phase) progress
+// high-water marker (`workers/<ticket>/.progress-<phase>`). Called at daemon boot
+// (alongside writeBootMarker) so a stale high-water left by a PRIOR daemon run
+// cannot false-STOP the FIRST death of this run (the progress gate's "a first
+// death always gets one revive" guarantee is per-run, windowed the same way the
+// revive ATTEMPT count is windowed by daemon-boot.json). Best-effort + fail-open:
+// a missing workers dir or an unlink error just leaves the marker, costing at
+// most one extra revive evaluation. Injectable rm for tests.
+export function clearProgressMarks(orchDir, { rm = rmSync } = {}) {
+  let entries;
+  try {
+    entries = readdirSync(join(orchDir, "workers"), { withFileTypes: true });
+  } catch {
+    return; // no workers dir yet — nothing to clear
+  }
+  for (const d of entries) {
+    if (!d.isDirectory()) continue;
+    const dir = join(orchDir, "workers", d.name);
+    let files;
+    try {
+      files = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const f of files) {
+      if (f.startsWith(".progress-")) {
+        try {
+          rm(join(dir, f), { force: true });
+        } catch {
+          /* best-effort — a leftover marker only costs one extra revive eval */
+        }
+      }
+    }
+  }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // CTL-640: cold-start detection. The reference epoch = max(OS boot, claude-daemon
 // start). If that epoch is newer than EVERY ~/.claude/jobs/<id>/state.json mtime,
@@ -1148,9 +1184,9 @@ function defaultWriteProgressMark(orchDir, ticket, phase, value) {
 //                         ticket's latest-dispatched phase (CTL-606). A reap-intent
 //                         is emitted so the reaper stops the bg.
 //
-// The function stays pure given its injected seams: statJob / jobLifecycle /
-// livenessSource (death trigger) / probes / progressMark + read/writeProgressMark
-// (the Phase-3 progress gate) / emitComplete / the CTL-587 revive+escalate seams
+// The function stays pure given its injected seams: statJob / jobLifecycle (the
+// death trigger) / probes / progressMark + read/writeProgressMark (the Phase-3
+// progress gate) / emitComplete / the CTL-587 revive+escalate seams
 // (appendReviveEvent, appendEscalatedEvent, reviveDispatch, applyStalledLabel,
 // killBgJob, countReviveEvents, writeReviveMarker) + the CTL-638 cool-down +
 // CTL-679 breaker. All have real defaults for prod; tests override every one.
@@ -1197,24 +1233,12 @@ export function reclaimDeadWorkIfPossible(
     // CTL-606 — supersede guard. Returns the ticket's dispatched phase names so
     // the guard can detect a dead signal the pipeline has already advanced past.
     listTicketPhases = (t) => listDispatchedPhases(orchDir, t),
-    // CTL-662 — three-valued liveness reader (replaces the pre-CTL-662 mtime
-    // staleness check + the CTL-610 keep-alive pair). "busy" → never
-    // auto-reclaim; "idle" → reclaim-eligible only after an
-    // idle-confirmation streak; "absent" (not a live `claude agents` session) →
-    // reclaim-eligible immediately.
-    // CTL-736 Phase 2 — the legacy eventually-consistent `claude agents`
-    // snapshot reader. NO LONGER the default death trigger (jobLifecycle below
-    // is). Retained as a seam because the `snapshot` + `shadow` LIVENESS_SOURCE
-    // modes still consult it (the env-only rollback / live A/B observability).
-    liveness = livenessForBgJob,
-    // CTL-736 Phase 2 — THE death trigger: the authoritative LOCAL state.json
-    // lifecycle (alive | dead-terminal | dead-gone). Aliased ...Fn to avoid
-    // shadowing the module-level jobLifecycle used as the default.
+    // CTL-736 — THE death trigger: the authoritative LOCAL state.json lifecycle
+    // (alive | dead-terminal | dead-gone). Aliased ...Fn to avoid shadowing the
+    // module-level jobLifecycle used as the default. This fully replaces the
+    // eventually-consistent `claude agents` snapshot reader (livenessForBgJob),
+    // which is no longer consulted by the reclaim/death path at all.
     jobLifecycle: jobLifecycleFn = jobLifecycle,
-    // CTL-736 Phase 2 — which liveness source drives the trigger
-    // (state-json | shadow | snapshot, default state-json). Read once per call
-    // so an env flip / per-test override takes effect without a module reload.
-    livenessSource = readLivenessConfig().source,
     // CTL-735 — revival age ceiling. An absent/idle, work-not-done worker whose
     // signal has not been touched in this long is an abandoned historical dir,
     // not a fresh crash: treated as inert (no revive, no escalate). Injectable for
@@ -1301,34 +1325,21 @@ export function reclaimDeadWorkIfPossible(
     return "escalated";
   }
 
-  // CTL-736 Phase 2 — THE DEATH TRIGGER. The authoritative LOCAL state.json
-  // lifecycle (jobLifecycle), not the eventually-consistent `claude agents`
-  // snapshot. LIVENESS_SOURCE selects the source (default state-json):
-  //   state-json : jobLifecycle(prevBgJobId) is the trigger — deterministic,
-  //                fan-out-safe (a multi-minute in-process sub-agent fan-out
-  //                keeps .state=working while mtime ages; mtime is never read).
-  //   shadow     : act on jobLifecycle BUT also compute the legacy snapshot and
-  //                log `liveness-shadow-mismatch` on disagreement (live A/B).
-  //   snapshot   : env-only rollback to the legacy livenessForBgJob trigger
-  //                (busy ⇒ alive; idle/absent ⇒ reclaim-eligible — the deleted
-  //                idle-confirmation streak / grace window are GONE, so an idle
-  //                worker reclaims immediately, the pre-CTL-662 behaviour).
-  let lifecycle; // "alive" | "dead-terminal" | "dead-gone"
-  if (livenessSource === "snapshot") {
-    lifecycle = liveness(prevBgJobId) === "busy" ? "alive" : "dead-gone";
-  } else {
-    lifecycle = jobLifecycleFn(prevBgJobId, { statJob });
-    if (livenessSource === "shadow") {
-      const snap = liveness(prevBgJobId); // busy | idle | absent
-      const snapAlive = snap === "busy";
-      if (snapAlive !== (lifecycle === "alive")) {
-        log.warn(
-          { ticket, phase, prevBgJobId, jobLifecycle: lifecycle, snapshot: snap },
-          "ctl-736: liveness-shadow-mismatch — state.json and `claude agents` snapshot disagree",
-        );
-      }
-    }
-  }
+  // CTL-736 — THE DEATH TRIGGER. The authoritative LOCAL state.json lifecycle
+  // (jobLifecycle → alive | dead-terminal | dead-gone), NOT the eventually-
+  // consistent `claude agents` snapshot. Deterministic and fan-out-safe: a
+  // multi-minute in-process sub-agent fan-out keeps .state=working (alive) while
+  // mtime ages, so mtime is never read. A terminal .state / firstTerminalAt is
+  // definitively dead; a missing job dir is dead-gone.
+  //
+  // (The earlier draft of this work added LIVENESS_SOURCE `snapshot`/`shadow`
+  // rollback modes. They were removed: both re-broke on the deleted idle-streak/
+  // grace/cold-skip machinery — `snapshot` reclaimed a live idle worker on the
+  // first tick, and a cold snapshot re-introduced the CTL-731 per-worker
+  // synchronous `claude agents` starvation. A degraded rollback that misfires in
+  // the very incident it would be used for is a footgun; the real rollback for a
+  // state.json regression is reverting this change.)
+  const lifecycle = jobLifecycleFn(prevBgJobId, { statJob });
 
   // ── alive: NEVER auto-reclaimed. The job's state.json lifecycle is
   //    non-terminal (`working`, or an unreadable-but-present state.json). The
@@ -1525,18 +1536,29 @@ export function reclaimDeadWorkIfPossible(
   // for code phases, artifact byte-size for doc/JSON phases); readProgressMark
   // returns -1 when no prior mark exists, so a first death always gets one revive
   // (a genuine early crash is retry-worthy) and a SECOND no-progress death stops.
+  //
+  // The gate is `<=` (stop on flat OR lower), NOT `===`. progressMark falls open
+  // to 0 on a read failure (git error, worktree lock) — `<=` then errs toward a
+  // STOP (a bounded, recoverable needs-human flag), whereas `===` would treat a
+  // transient low read as "changed" and revive forever (the very storm this
+  // retires). A legitimate decrease (origin/main advanced past the worker's
+  // commits) likewise stops → needs-human, which is the correct conservative
+  // outcome for a worker that is no longer ahead.
   const currentProgress = progressMark({ ticket, phase, repoRoot, orchDir });
   const lastProgress = readProgressMark(orchDir, ticket, phase);
   if (currentProgress <= lastProgress) {
     // Stop the dead worker (the reaper + an inline best-effort stop) and flag for
-    // human — do NOT spawn another worker that would also make no progress.
+    // human — do NOT spawn another worker that would also make no progress. The
+    // no-progress STOP is terminal (needs-human, no successor dispatch), so it
+    // routes through the CTL-695 `phase.terminal.reap-requested` single-target
+    // (busy-OK) reap path the reaper already handles — NOT a bespoke event type.
     if (prevBgJobId) {
-      emitReapIntent("phase.no-progress.reap-requested", {
+      emitReapIntent("phase.terminal.reap-requested", {
         ticket,
         phase,
         bgJobId: prevBgJobId,
         worktreePath: signal.raw?.worktreePath,
-        prevStateJsonMtime,
+        reason: "ctl-736-no-progress-stopped",
       }).catch(() => {});
       killBgJob({ bgJobId: prevBgJobId });
     }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   classifyWorker,
+  jobLifecycle,
   reconstructWorkerState,
   defaultStatJob,
   recoverStartup,
@@ -149,6 +150,65 @@ describe("classifyWorker", () => {
     expect(() => classifyWorker(bgSignal("dispatched", null))).not.toThrow();
     expect(classifyWorker(bgSignal("dispatched", null))).toBe("unknown");
   });
+
+  // CTL-736 Phase 2: classifyWorker now CONSULTS .state (it no longer treats
+  // job-dir existence alone as "running"). A terminal job lifecycle is "dead"
+  // even though the never-cleaned-up job dir still exists.
+  test("CTL-736: terminal .state + dir present → 'dead' (job lifecycle, not dir existence)", () => {
+    for (const state of ["stopped", "failed", "done", "blocked"]) {
+      expect(
+        classifyWorker(bgSignal("running", "job-term"), {
+          statJob: () => ({ exists: true, mtimeMs: Date.now(), state }),
+        }),
+      ).toBe("dead");
+    }
+  });
+
+  test("CTL-736: firstTerminalAt set + dir present → 'dead' even when .state name is unknown", () => {
+    expect(
+      classifyWorker(bgSignal("running", "job-ft"), {
+        statJob: () => ({ exists: true, mtimeMs: Date.now(), state: "weird", firstTerminalAt: "2026-05-30T00:00:00Z" }),
+      }),
+    ).toBe("dead");
+  });
+
+  test("CTL-736: non-terminal 'working' .state + STALE mtime → 'running' (fan-out safe)", () => {
+    // The CTL-662 killer: an in-process sub-agent fan-out keeps .state=working
+    // while mtime ages. mtime must NOT be a death input.
+    expect(
+      classifyWorker(bgSignal("running", "job-fanout"), {
+        statJob: () => ({ exists: true, mtimeMs: 0, state: "working" }),
+      }),
+    ).toBe("running");
+  });
+});
+
+// --- jobLifecycle — authoritative state.json death verdict (CTL-736 Phase 2) ---
+
+describe("jobLifecycle", () => {
+  test("terminal .state ⇒ 'dead-terminal' (definitive, no grace/streak)", () => {
+    for (const state of ["stopped", "failed", "done", "blocked"]) {
+      expect(jobLifecycle("j", { statJob: () => ({ exists: true, state }) })).toBe("dead-terminal");
+    }
+  });
+
+  test("firstTerminalAt set ⇒ 'dead-terminal' even if the .state name is unknown", () => {
+    expect(
+      jobLifecycle("j", { statJob: () => ({ exists: true, state: "x", firstTerminalAt: "2026-05-30T00:00:00Z" }) }),
+    ).toBe("dead-terminal");
+  });
+
+  test("non-terminal 'working' .state ⇒ 'alive', INCLUDING during a fan-out (stale mtime)", () => {
+    expect(jobLifecycle("j", { statJob: () => ({ exists: true, state: "working", mtimeMs: 0 }) })).toBe("alive");
+  });
+
+  test("a dir present with state:null (unreadable state.json) ⇒ 'alive' (presence proves liveness)", () => {
+    expect(jobLifecycle("j", { statJob: () => ({ exists: true, state: null, mtimeMs: 1 }) })).toBe("alive");
+  });
+
+  test("missing job dir ⇒ 'dead-gone'", () => {
+    expect(jobLifecycle("j", { statJob: () => null })).toBe("dead-gone");
+  });
 });
 
 // --- reconstructWorkerState — scan + bucket --------------------------------
@@ -277,6 +337,28 @@ describe("defaultStatJob", () => {
     expect(res?.exists).toBe(true);
     expect(typeof res?.mtimeMs).toBe("number");
     expect(res?.state).toBe("running");
+  });
+
+  // CTL-736 Phase 2: jobLifecycle needs the firstTerminalAt timestamp (set by
+  // Claude when a job reaches a terminal lifecycle state) as a state-name-agnostic
+  // death signal, so defaultStatJob must surface it.
+  test("CTL-736: surfaces firstTerminalAt when present in state.json", () => {
+    const dir = join(jobsRoot, "job-terminal");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "state.json"),
+      JSON.stringify({ state: "stopped", firstTerminalAt: "2026-05-30T12:00:00Z" }),
+    );
+    const res = defaultStatJob("job-terminal");
+    expect(res?.state).toBe("stopped");
+    expect(res?.firstTerminalAt).toBe("2026-05-30T12:00:00Z");
+  });
+
+  test("CTL-736: firstTerminalAt is null when absent (non-terminal job)", () => {
+    const dir = join(jobsRoot, "job-working");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "state.json"), JSON.stringify({ state: "working" }));
+    expect(defaultStatJob("job-working")?.firstTerminalAt).toBeNull();
   });
 
   test("returns liveness with state:null when state.json is unreadable JSON", () => {
@@ -584,101 +666,13 @@ describe("reclaimDeadWorkIfPossible — turn-cap-exhausted (CTL-701)", () => {
 // registered yet, NOT crashed. Without this the de-starved fast tick (CTL-731)
 // re-classifies each just-revived worker as dead and revives it again every
 // ~2-4s → the revive storm (5→18→62→74 workers, load 72).
-describe("reclaimDeadWorkIfPossible — CTL-735 post-revive grace window", () => {
-  const orch = "/orch";
-  const NOW = 1_000_000;
-  const GRACE = 90_000;
-
-  // The revive seams shared by these cases — a probe that says "work not done"
-  // (so control reaches branch (C) revive) plus the budget/storm gates open.
-  const reviveSeams = (reviveDispatch) => ({
-    statJob: () => null,
-    probes: { implement: recorder(false) },
-    emitComplete: recorder({ code: 0 }),
-    appendReviveEvent: recorder(true),
-    reviveDispatch,
-    countReviveEvents: recorder(0),
-    countDistinctRevivingTickets: recorder(1),
-    writeReviveMarker: recorder(undefined),
-    killBgJob: recorder(undefined),
-    applyStalledLabel: recorder({ applied: true }),
-    resolveSession: () => null,
-    liveness: () => "absent",
-    reviveGraceMs: GRACE,
-    now: () => NOW,
-  });
-
-  test("absent worker (re)dispatched WITHIN the grace window → 'revive-pending', NOT revived", () => {
-    const reviveDispatch = recorder({ code: 0 });
-    const sig = implementSignal({
-      // startedAt 10s ago — well inside the 90s grace window.
-      startedAt: new Date(NOW - 10_000).toISOString(),
-    });
-    const r = reclaimDeadWorkIfPossible(orch, sig, reviveSeams(reviveDispatch));
-    expect(r).toBe("revive-pending");
-    expect(reviveDispatch.calls.length).toBe(0); // the storm-causing re-revive is suppressed
-  });
-
-  test("absent worker (re)dispatched PAST the grace window → revives (genuinely dead)", () => {
-    const reviveDispatch = recorder({ code: 0 });
-    const sig = implementSignal({
-      // startedAt 100s ago — past the 90s window, so a still-absent worker is real death.
-      startedAt: new Date(NOW - 100_000).toISOString(),
-    });
-    const r = reclaimDeadWorkIfPossible(orch, sig, reviveSeams(reviveDispatch));
-    expect(r).toBe("revived");
-    expect(reviveDispatch.calls.length).toBe(1);
-  });
-
-  test("absent worker with NO startedAt → revives (back-compat: cannot prove freshness)", () => {
-    const reviveDispatch = recorder({ code: 0 });
-    const sig = implementSignal(); // no startedAt
-    const r = reclaimDeadWorkIfPossible(orch, sig, reviveSeams(reviveDispatch));
-    expect(r).toBe("revived");
-    expect(reviveDispatch.calls.length).toBe(1);
-  });
-
-  test("idle worker (re)dispatched WITHIN the grace window → 'revive-pending' (registered, not yet working)", () => {
-    // A freshly-revived worker commonly registers as `idle` (waiting for its
-    // first turn) before it goes `busy`. The short idle-confirmation streak
-    // (~2 ticks) would otherwise re-revive it every ~20-30s — the triage/verify
-    // storm seen at re-enable. The grace window must cover idle too, not just
-    // absent. idleConfirmTicks/bumpIdleStreak injected so the worker reaches
-    // branch (C) on the first idle observation (where the grace check lives).
-    const reviveDispatch = recorder({ code: 0 });
-    const seams = reviveSeams(reviveDispatch);
-    seams.liveness = () => "idle";
-    seams.idleConfirmTicks = 1;
-    seams.bumpIdleStreak = () => 1;
-    seams.resetIdleStreak = () => {};
-    const sig = implementSignal({ startedAt: new Date(NOW - 10_000).toISOString() });
-    const r = reclaimDeadWorkIfPossible(orch, sig, seams);
-    expect(r).toBe("revive-pending");
-    expect(reviveDispatch.calls.length).toBe(0);
-  });
-
-  test("idle worker PAST the grace window → revives (genuinely idle-done, not just-started)", () => {
-    const reviveDispatch = recorder({ code: 0 });
-    const seams = reviveSeams(reviveDispatch);
-    seams.liveness = () => "idle";
-    seams.idleConfirmTicks = 1;
-    seams.bumpIdleStreak = () => 1;
-    seams.resetIdleStreak = () => {};
-    const sig = implementSignal({ startedAt: new Date(NOW - 100_000).toISOString() });
-    const r = reclaimDeadWorkIfPossible(orch, sig, seams);
-    expect(r).toBe("revived");
-    expect(reviveDispatch.calls.length).toBe(1);
-  });
-
-  test("a busy worker is suppressed as alive (busy is handled before the grace window)", () => {
-    const reviveDispatch = recorder({ code: 0 });
-    const seams = reviveSeams(reviveDispatch);
-    seams.liveness = () => "busy";
-    const sig = implementSignal({ startedAt: new Date(NOW - 10_000).toISOString() });
-    const r = reclaimDeadWorkIfPossible(orch, sig, seams);
-    expect(r).toBe("alive-busy-suppressed");
-  });
-});
+// CTL-736 Phase 2: the CTL-735 post-revive grace window (`revive-pending`) is
+// DELETED. It existed only to absorb the eventually-consistent `claude agents`
+// snapshot lag (a freshly-spawned worker shows `absent`/`idle` before it
+// registers). The authoritative local state.json lifecycle has no such lag — a
+// just-(re)dispatched worker writes state=working immediately, so jobLifecycle
+// reads `alive` and the grace window has nothing to guard against. Its test
+// block is removed with the mechanism.
 
 // CTL-735 Guard 2 — per-tick revive cap. The scheduler passes the remaining
 // per-tick revive budget; once exhausted, an otherwise-revivable worker is
@@ -841,39 +835,37 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(appendEvent.calls.length).toBe(0);
   });
 
-  test("CTL-662: a BUSY worker is 'alive-busy-suppressed', never reclaimed (regardless of elapsed time)", () => {
-    // The CTL-662 fix: a busy worker (a live `claude agents` session with an open
-    // turn — e.g. an in-process sub-agent fan-out) is NEVER auto-reclaimed, even
-    // though its state.json mtime may be arbitrarily stale.
+  test("CTL-736: an ALIVE worker (state.json non-terminal) is 'alive-suppressed', never reclaimed (regardless of mtime)", () => {
+    // The CTL-736 fan-out-safe fix: an alive worker (state.json .state=working,
+    // e.g. an in-process sub-agent fan-out) is NEVER auto-reclaimed, even though
+    // its state.json mtime may be arbitrarily stale (mtime is not consulted).
     const probe = recorder(true);
     const emit = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
-      statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+      statJob: () => ({ exists: true, mtimeMs: 1_000, state: "working" }),
       probes: { implement: probe },
       emitComplete: emit,
       appendEvent: recorder(undefined),
-      liveness: () => "busy",
       now: () => 1_000 + 60 * 60 * 1000, // an hour past mtime — irrelevant now
     });
-    expect(r).toBe("alive-busy-suppressed");
-    expect(probe.calls.length).toBe(0); // busy short-circuits before the probe
+    expect(r).toBe("alive-suppressed");
+    expect(probe.calls.length).toBe(0); // alive short-circuits before the probe
     expect(emit.calls.length).toBe(0);
   });
 
-  test("CTL-662: an ABSENT worker (no live session) with work done is reclaimed", () => {
-    // absent = not listed by `claude agents` (crashed/exited) → reclaim-eligible
-    // immediately, no idle-confirmation needed. Replaces the pre-CTL-662
-    // stale-mtime "effectively dead" trigger.
+  test("CTL-736: a DEAD-GONE worker (job dir gone) with work done is reclaimed immediately", () => {
+    // dead-gone = the job dir vanished (crashed/exited) → reclaim-eligible
+    // immediately, no idle-confirmation, no grace window. Replaces the
+    // pre-CTL-736 `claude agents` absent trigger.
     const probe = recorder(true);
     const emit = recorder({ code: 0 });
     const appendEvent = recorder(undefined);
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
-      statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+      statJob: () => null, // job dir gone → dead-gone
       probes: { implement: probe },
       emitComplete: emit,
       appendEvent,
       postReclaimMirror: () => {}, // CTL-664: keep the test hermetic (no linearis spawn)
-      liveness: () => "absent",
       now: () => 1_000,
     });
     expect(r).toBe("reclaimed");
@@ -882,18 +874,17 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(appendEvent.calls.length).toBe(1);
   });
 
-  test("CTL-662: a BUSY worker with work done is still suppressed (left to emit its own complete)", () => {
+  test("CTL-736: an ALIVE worker with work done is still suppressed (left to emit its own complete)", () => {
     const probe = recorder(true);
     const emit = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
-      statJob: () => ({ exists: true, mtimeMs: 1_000_000 }),
+      statJob: () => ({ exists: true, mtimeMs: 1_000_000, state: "working" }),
       probes: { implement: probe },
       emitComplete: emit,
       appendEvent: recorder(undefined),
-      liveness: () => "busy",
       now: () => 1_000_000 + 60_000,
     });
-    expect(r).toBe("alive-busy-suppressed");
+    expect(r).toBe("alive-suppressed");
     expect(emit.calls.length).toBe(0);
   });
 
@@ -997,7 +988,7 @@ describe("reclaimDeadWorkIfPossible", () => {
       phase: "implement",
       ticket: "CTL-9",
       orchId: "CTL-9",
-      death_signal: "absent", // statJob:()=>null → klass 'dead' → absent
+      death_signal: "dead-gone", // statJob:()=>null → jobLifecycle 'dead-gone'
       probe_passed: true,
       probe_checked: expect.any(String),
       completion_origin: "inferred",
@@ -1008,19 +999,17 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(order[1][1]).toEqual({ orchDir: orch, signal: sig });
   });
 
-  // CTL-662: mtime is no longer a reclaim trigger, so a reclaim is never
-  // labeled death_signal='mtime'. The branch-(B) reclaim is reached only for an
-  // `absent` bg job or an idle-confirmed one — the death signal must report that
-  // liveness verdict. prev_state_json_mtime survives as pure telemetry (the last
-  // state.json write time), independent of the death-signal decision.
-  test("CTL-662: reclaim of an idle-confirmed worker reports death_signal='idle-confirmed' (never 'mtime') + prev_state_json_mtime", () => {
+  // CTL-736: mtime is no longer a reclaim trigger, so a reclaim is never
+  // labeled death_signal='mtime'. The branch-(B) reclaim is reached only for a
+  // dead-terminal or dead-gone job — the death signal must report that
+  // jobLifecycle verdict. prev_state_json_mtime survives as pure telemetry (the
+  // last state.json write time), independent of the death-signal decision.
+  test("CTL-736: reclaim of a dead-terminal worker reports death_signal='dead-terminal' (never 'mtime') + prev_state_json_mtime", () => {
     const staleMtime = 1_000;
     let appended = null;
     const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), {
-      statJob: () => ({ mtimeMs: staleMtime }), // state.json present but stale — NOT a trigger
-      liveness: () => "idle", // CTL-662: status is the trigger
-      bumpIdleStreak: () => 99, // already past IDLE_CONFIRM_TICKS → reclaim-eligible
-      resetIdleStreak: () => {},
+      // state.json present, stale mtime, but .state terminal → dead-terminal.
+      statJob: () => ({ exists: true, mtimeMs: staleMtime, state: "stopped" }),
       probes: { implement: () => true },
       emitComplete: () => ({ code: 0 }),
       appendEvent: (args) => {
@@ -1030,7 +1019,7 @@ describe("reclaimDeadWorkIfPossible", () => {
       repoRoot: "/repo",
     });
     expect(r).toBe("reclaimed");
-    expect(appended.death_signal).toBe("idle-confirmed");
+    expect(appended.death_signal).toBe("dead-terminal");
     expect(appended.death_signal).not.toBe("mtime");
     expect(appended.prev_state_json_mtime).toBe(staleMtime);
   });
@@ -1116,6 +1105,132 @@ describe("reclaimDeadWorkIfPossible", () => {
   });
 });
 
+// --- CTL-736 Phase 2: the state.json death trigger + LIVENESS_SOURCE modes ---
+
+describe("reclaimDeadWorkIfPossible — CTL-736 state.json death trigger", () => {
+  const orch = "/orch";
+
+  // Deterministic seam set: all downstream gates open so the verdict from the
+  // death trigger is what the test observes. now() is fixed; the breaker/cooldown
+  // are stubbed so escalateOnce is hermetic.
+  function seams(extra = {}) {
+    return {
+      repoRoot: "/repo",
+      probes: { implement: () => false },
+      emitComplete: recorder({ code: 0 }),
+      appendEvent: recorder(undefined),
+      appendReviveEvent: recorder(true),
+      appendEscalatedEvent: recorder(undefined),
+      appendReviveSuppressedEvent: recorder(undefined),
+      reviveDispatch: recorder({ code: 0 }),
+      applyStalledLabel: recorder({ applied: true }),
+      killBgJob: recorder(undefined),
+      countReviveEvents: recorder(0),
+      countDistinctRevivingTickets: recorder(0),
+      writeReviveMarker: recorder(undefined),
+      resolveSession: () => null,
+      postReclaimMirror: recorder(undefined),
+      listTicketPhases: () => ["implement"],
+      inEscalationCooldownFn: () => false,
+      recordEscalationFn: recorder(undefined),
+      emitReapIntent: () => Promise.resolve(),
+      readBootSince: () => undefined,
+      breaker: { isOpen: () => false },
+      now: () => 1_000_000,
+      ...extra,
+    };
+  }
+
+  test("state-json: alive (state=working) ⇒ 'alive-suppressed' — never reclaimed, no idle streak/grace", () => {
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
+      livenessSource: "state-json",
+      jobLifecycle: () => "alive",
+    }));
+    expect(r).toBe("alive-suppressed");
+  });
+
+  test("state-json: dead-terminal + work done ⇒ 'reclaimed' immediately (no grace/streak)", () => {
+    const emitComplete = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
+      livenessSource: "state-json",
+      jobLifecycle: () => "dead-terminal",
+      probes: { implement: () => true },
+      emitComplete,
+    }));
+    expect(r).toBe("reclaimed");
+    expect(emitComplete.calls.length).toBe(1);
+  });
+
+  test("state-json: dead-gone + work NOT done ⇒ 'revived' immediately, even with a fresh startedAt (no grace window)", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      // startedAt = now: pre-CTL-736 this was deferred 'revive-pending' by the 90s grace.
+      implementSignal({ status: "running", startedAt: new Date(1_000_000).toISOString() }),
+      seams({ livenessSource: "state-json", jobLifecycle: () => "dead-gone", reviveDispatch }),
+    );
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("state-json: never consults the legacy `claude agents` snapshot seam", () => {
+    const liveness = recorder("busy");
+    reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
+      livenessSource: "state-json",
+      jobLifecycle: () => "alive",
+      liveness,
+    }));
+    expect(liveness.calls.length).toBe(0);
+  });
+
+  test("shadow: logs the mismatch but ACTS ON state.json (jobLifecycle), not the snapshot", () => {
+    // jobLifecycle says alive; snapshot says absent (disagreement). Acts on alive.
+    const liveness = recorder("absent");
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
+      livenessSource: "shadow",
+      jobLifecycle: () => "alive",
+      liveness,
+    }));
+    expect(r).toBe("alive-suppressed"); // acted on state.json, not the absent snapshot
+    expect(liveness.calls.length).toBe(1); // but DID consult the snapshot (to compare/log)
+  });
+
+  test("snapshot rollback: busy ⇒ alive-suppressed; absent ⇒ reclaim-eligible (revive, no streak/grace)", () => {
+    const busy = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
+      livenessSource: "snapshot",
+      liveness: () => "busy",
+    }));
+    expect(busy).toBe("alive-suppressed");
+
+    const reviveDispatch = recorder({ code: 0 });
+    const absent = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
+      livenessSource: "snapshot",
+      liveness: () => "absent",
+      reviveDispatch,
+    }));
+    expect(absent).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("alive past BUSY_CEILING_MS with no committed work ⇒ 'escalated' (no silent reclaim)", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(
+      orch,
+      implementSignal({ status: "running", startedAt: new Date(0).toISOString() }),
+      seams({
+        livenessSource: "state-json",
+        jobLifecycle: () => "alive",
+        busyCeilingMs: 1,
+        now: () => 10_000,
+        probes: { implement: () => false },
+        appendEscalatedEvent,
+      }),
+    );
+    expect(r).toBe("escalated");
+    expect(appendEscalatedEvent.calls[0][0].reason).toBe("busy-ceiling-exceeded");
+  });
+});
+
 // --- CTL-661 Phase 2: reap-intent on the reclaim happy path (B) -------------
 //
 // When a stale-by-mtime worker reaches branch (B) (probe says work IS done) it
@@ -1137,12 +1252,12 @@ describe("reclaimDeadWorkIfPossible — CTL-661 reclaim happy-path reap-intent",
     const emitReap = recorder(Promise.resolve(true));
     const r = reclaimDeadWorkIfPossible(orch, staleReclaimable(), {
       statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+      jobLifecycle: () => "dead-gone", // CTL-736: reclaim-eligible via state.json
       probes: { implement: () => true },
       emitComplete: recorder({ code: 0 }),
       appendEvent: recorder(undefined),
-      pidAlive: () => false, // genuinely dead → alive-quiet gate stays open
       emitReapIntent: emitReap,
-      now: () => 1_000 + 6 * 60 * 1000, // 6 min past mtime — stale
+      now: () => 1_000 + 6 * 60 * 1000,
     });
     expect(r).toBe("reclaimed");
     expect(emitReap.calls.length).toBe(1);
@@ -1178,10 +1293,10 @@ describe("reclaimDeadWorkIfPossible — CTL-661 reclaim happy-path reap-intent",
     const emitReap = recorder(Promise.resolve(true));
     const r = reclaimDeadWorkIfPossible(orch, sig, {
       statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+      jobLifecycle: () => "dead-gone", // CTL-736: reclaim-eligible via state.json
       probes: { implement: () => true },
       emitComplete: recorder({ code: 0 }),
       appendEvent: recorder(undefined),
-      pidAlive: () => false,
       emitReapIntent: emitReap,
       now: () => 1_000 + 6 * 60 * 1000,
     });
@@ -1220,7 +1335,7 @@ describe("CTL-664: reclaim Linear mirror", () => {
           orchDir: orch,
           ticket: "CTL-9",
           phase: "implement",
-          deathSignal: "absent", // statJob:()=>null → klass 'dead' → absent
+          deathSignal: "dead-gone", // statJob:()=>null → jobLifecycle 'dead-gone'
           reclaimedBgJobId: "job-x", // implementSignal default bgJobId
         }),
       ],
@@ -1365,11 +1480,11 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
         // (branch B) stay hermetic and don't spawn a real `linearis`.
         postReclaimMirror: recorder(undefined),
         readBootSince, // CTL-655: inject the boot-time window reader
-        // CTL-662: the death trigger is now status, not mtime. "absent" (no live
-        // `claude agents` session) is the reclaim-eligible case these revive/
-        // escalate/storm scenarios exercise — equivalent to the pre-CTL-662
-        // stale-mtime "effectively dead" they used to stage.
-        liveness: () => "absent",
+        // CTL-736: the death trigger is now the state.json lifecycle (jobLifecycle),
+        // not the `claude agents` snapshot. "dead-gone" (the job dir vanished) is
+        // the reclaim-eligible case these revive/escalate/storm scenarios exercise.
+        // statJob above still supplies the prev_state_json_mtime telemetry.
+        jobLifecycle: () => "dead-gone",
         now: () => nowMs,
       },
     };
@@ -1631,271 +1746,13 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
   });
 });
 
-// --- CTL-662: busy-suppression (replaces the CTL-610/661 alive-quiet gate) -
-//
-// The pre-CTL-662 reclaim trigger was state.json mtime (5min stale → dead), with
-// the CTL-610/661 alive-quiet gate papering over false positives by checking the
-// bg pid within a 15min hung cutoff. CTL-662 deletes that whole time-based
-// machinery: the trigger is now the worker's `claude agents` status
-// (livenessForBgJob → busy|idle|absent). A `busy` worker — including the
-// in-process Task sub-agent fan-out that keeps the parent's turn busy while
-// state.json mtime goes arbitrarily stale (the proven worker-10d6f123 failure) —
-// is NEVER auto-reclaimed, escalated, or revived, regardless of elapsed time,
-// revive budget, or storm conditions. The sole permitted action on a busy worker
-// is the high-ceiling no-progress backstop (escalateOnce past BUSY_CEILING_MS
-// with no committed work — never a silent reclaim-and-advance).
-
-describe("reclaimDeadWorkIfPossible — CTL-662 busy-suppression", () => {
-  // A `busy` worker (a live `claude agents` session with an open turn). Defaults
-  // to probe=false (work not done) so we prove a busy worker is suppressed even
-  // when the work-done probe would otherwise revive it. `startedAt` is omitted by
-  // default so the busy-ceiling backstop never trips unless a test supplies it.
-  function setupBusyScenario({
-    reviveCount = 0,
-    distinctRevivingTickets = 1,
-    probeResult = false,
-    phase = "implement",
-    ticket = "CTL-9",
-    bgJobId = "bg-9",
-    startedAt,
-    nowMs = 2_000_000,
-  } = {}) {
-    const sig = {
-      ...implementSignal({ ticket, status: "running", bgJobId }),
-      phase,
-    };
-    sig.raw.phase = phase;
-    if (startedAt !== undefined) sig.raw.startedAt = startedAt;
-    return {
-      orch: "/orch",
-      sig,
-      opts: {
-        repoRoot: "/repo",
-        // mtime is arbitrarily stale — it is no longer a decision input.
-        statJob: () => ({ exists: true, mtimeMs: 1_000 }),
-        probes: { [phase]: recorder(probeResult) },
-        emitComplete: recorder({ code: 0 }),
-        appendEvent: recorder(undefined),
-        appendReviveEvent: recorder(undefined),
-        appendEscalatedEvent: recorder(undefined),
-        appendReviveSuppressedEvent: recorder(undefined),
-        reviveDispatch: recorder({ code: 0 }),
-        applyStalledLabel: recorder({ applied: true }),
-        killBgJob: recorder(undefined),
-        countReviveEvents: recorder(reviveCount),
-        countDistinctRevivingTickets: recorder(distinctRevivingTickets),
-        writeReviveMarker: recorder(undefined),
-        inEscalationCooldownFn: () => false,
-        recordEscalationFn: recorder(undefined),
-        liveness: recorder("busy"),
-        bumpIdleStreak: recorder(1),
-        resetIdleStreak: recorder(undefined),
-        // CTL-664: stub the reclaim mirror so a probeResult:true scenario
-        // (reclaim branch) stays hermetic (no `linearis` spawn).
-        postReclaimMirror: recorder(undefined),
-        now: () => nowMs,
-      },
-    };
-  }
-
-  test("busy → 'alive-busy-suppressed' (no dispatch, no budget, no marker, no kill, no escalate, no events)", () => {
-    const s = setupBusyScenario({ reviveCount: 0 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
-    expect(s.opts.reviveDispatch.calls.length).toBe(0);
-    expect(s.opts.appendReviveEvent.calls.length).toBe(0);
-    expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(0);
-    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
-    expect(s.opts.writeReviveMarker.calls.length).toBe(0);
-    expect(s.opts.killBgJob.calls.length).toBe(0);
-    expect(s.opts.applyStalledLabel.calls.length).toBe(0);
-    // The trigger MUST consult liveness with the signal's bg_job_id.
-    expect(s.opts.liveness.calls.length).toBeGreaterThanOrEqual(1);
-    expect(s.opts.liveness.calls[0][0]).toBe("bg-9");
-  });
-
-  test("busy + revive budget exhausted → still 'alive-busy-suppressed' (NEVER false-escalate a busy worker)", () => {
-    // The worst case the fix exists to prevent: a busy worker (a long sub-agent
-    // fan-out) whose budget two prior false-revives consumed must NOT be escalated
-    // to needs-human just because the budget is spent — it is alive and working.
-    const s = setupBusyScenario({ reviveCount: 2 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
-    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
-    expect(s.opts.applyStalledLabel.calls.length).toBe(0);
-  });
-
-  test("busy + storm-breaker open → still 'alive-busy-suppressed' (status check precedes storm bookkeeping)", () => {
-    const s = setupBusyScenario({ distinctRevivingTickets: 4 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
-    expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(0);
-  });
-
-  test("busy + work appears done → 'alive-busy-suppressed', NOT reclaimed (left to emit its own complete)", () => {
-    // A busy worker whose probe reads done is still suppressed: it is live and its
-    // own emit-complete is authoritative. Reclaiming it would flip the signal out
-    // from under a running worker (the pre-CTL-661 hole the gate exists to close).
-    const s = setupBusyScenario({ probeResult: true });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
-    expect(s.opts.emitComplete.calls.length).toBe(0);
-    expect(s.opts.appendEvent.calls.length).toBe(0);
-  });
-
-  test("busy resets any in-progress idle-confirmation streak", () => {
-    // A single busy observation between idle ticks must reset the streak so a
-    // worker that flickers idle→busy→idle is never reclaimed on a stale count.
-    const s = setupBusyScenario();
-    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
-    expect(s.opts.resetIdleStreak.calls.length).toBe(1);
-    expect(s.opts.resetIdleStreak.calls[0]).toEqual(["/orch", "CTL-9", "implement"]);
-    expect(s.opts.bumpIdleStreak.calls.length).toBe(0);
-  });
-
-  test("busy past BUSY_CEILING_MS with NO committed work → 'escalated' (busy-ceiling-exceeded), never silent reclaim", () => {
-    // The sole long backstop. A worker busy longer than the ceiling whose
-    // work-done probe is STILL false is flagged for a human — genuinely wedged,
-    // not progressing. It is escalated, NEVER silently reclaimed-and-advanced.
-    const startedAt = "2026-05-27T00:00:00Z";
-    const s = setupBusyScenario({
-      probeResult: false,
-      startedAt,
-      nowMs: Date.parse(startedAt) + 7 * 60 * 60 * 1000, // 7h > 6h ceiling
-    });
-    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
-    expect(r).toBe("escalated");
-    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("busy-ceiling-exceeded");
-    expect(s.opts.applyStalledLabel.calls.length).toBe(1);
-    expect(s.opts.reviveDispatch.calls.length).toBe(0);
-  });
-
-  test("busy past BUSY_CEILING_MS but work IS done → 'alive-busy-suppressed' (progressing, not wedged)", () => {
-    // Past the ceiling but the probe reads done → it is making progress, not
-    // wedged. Suppress and let it emit its own complete; do not escalate.
-    const startedAt = "2026-05-27T00:00:00Z";
-    const s = setupBusyScenario({
-      probeResult: true,
-      startedAt,
-      nowMs: Date.parse(startedAt) + 7 * 60 * 60 * 1000,
-    });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
-    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
-  });
-
-  test("busy WITHIN BUSY_CEILING_MS is suppressed regardless of work-done (backstop not yet armed)", () => {
-    const startedAt = "2026-05-27T00:00:00Z";
-    const s = setupBusyScenario({
-      probeResult: false,
-      startedAt,
-      nowMs: Date.parse(startedAt) + 60 * 60 * 1000, // 1h < 6h ceiling
-    });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("alive-busy-suppressed");
-    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
-  });
-});
-
-// --- CTL-662: idle-confirmation + absent reclaim --------------------------
-//
-// `absent` (not listed by `claude agents` → crashed/exited) is reclaim-eligible
-// immediately — absence is unambiguous. `idle` (live, between turns) is
-// reclaim-eligible only after IDLE_CONFIRM_TICKS CONSECUTIVE idle observations,
-// counted by a persisted per-(ticket, phase) streak marker (NOT an mtime window).
-// Once reclaim-eligible, the existing CTL-574/587/604 branches decide:
-// work-done → reclaim+advance; work-not-done → revive (budget/storm permitting).
-// This path replaces the pre-CTL-662 stale-mtime "effectively dead" trigger; the
-// revive/escalate/storm behaviour on it is otherwise unchanged.
-
-describe("reclaimDeadWorkIfPossible — CTL-662 idle-confirmation + absent reclaim", () => {
-  function setup({
-    live = "idle",
-    streak = 0, // the NEW post-increment count bumpIdleStreak returns this tick
-    idleConfirmTicks = 2,
-    probeResult = false,
-    reviveCount = 0,
-    distinctRevivingTickets = 1,
-    phase = "implement",
-    ticket = "CTL-9",
-    bgJobId = "bg-9",
-  } = {}) {
-    const sig = {
-      ...implementSignal({ ticket, status: "running", bgJobId }),
-      phase,
-    };
-    sig.raw.phase = phase;
-    return {
-      orch: "/orch",
-      sig,
-      opts: {
-        repoRoot: "/repo",
-        statJob: () => ({ exists: true, mtimeMs: 1_000 }),
-        probes: { [phase]: recorder(probeResult) },
-        emitComplete: recorder({ code: 0 }),
-        appendEvent: recorder(undefined),
-        appendReviveEvent: recorder(undefined),
-        appendEscalatedEvent: recorder(undefined),
-        appendReviveSuppressedEvent: recorder(undefined),
-        reviveDispatch: recorder({ code: 0 }),
-        applyStalledLabel: recorder({ applied: true }),
-        killBgJob: recorder(undefined),
-        countReviveEvents: recorder(reviveCount),
-        countDistinctRevivingTickets: recorder(distinctRevivingTickets),
-        writeReviveMarker: recorder(undefined),
-        inEscalationCooldownFn: () => false,
-        recordEscalationFn: recorder(undefined),
-        listTicketPhases: () => ["triage", "research", "plan", "implement"],
-        liveness: recorder(live),
-        bumpIdleStreak: recorder(streak),
-        resetIdleStreak: recorder(undefined),
-        idleConfirmTicks,
-        now: () => 2_000_000,
-      },
-    };
-  }
-
-  test("idle, streak below confirm threshold → 'idle-pending' (bumped, not reclaimed)", () => {
-    const s = setup({ live: "idle", streak: 1, idleConfirmTicks: 2 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("idle-pending");
-    expect(s.opts.bumpIdleStreak.calls.length).toBe(1);
-    expect(s.opts.bumpIdleStreak.calls[0]).toEqual(["/orch", "CTL-9", "implement"]);
-    // No reclaim/revive/escalate this tick — the streak is still building.
-    expect(s.opts.emitComplete.calls.length).toBe(0);
-    expect(s.opts.reviveDispatch.calls.length).toBe(0);
-    expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
-  });
-
-  test("idle, streak reaches confirm threshold + work done → 'reclaimed' (streak cleared)", () => {
-    const s = setup({ live: "idle", streak: 2, idleConfirmTicks: 2, probeResult: true });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
-    expect(s.opts.emitComplete.calls.length).toBe(1);
-    // Once we proceed to act, the persisted streak is cleared.
-    expect(s.opts.resetIdleStreak.calls.length).toBe(1);
-  });
-
-  test("idle, streak reaches confirm threshold + work NOT done → 'revived' (streak cleared)", () => {
-    const s = setup({ live: "idle", streak: 2, idleConfirmTicks: 2, probeResult: false });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
-    expect(s.opts.reviveDispatch.calls.length).toBe(1);
-    expect(s.opts.resetIdleStreak.calls.length).toBe(1);
-  });
-
-  test("absent → reclaim-eligible immediately (no idle-confirmation), work done → 'reclaimed'", () => {
-    const s = setup({ live: "absent", probeResult: true });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("reclaimed");
-    expect(s.opts.emitComplete.calls.length).toBe(1);
-    // Absence skips the streak entirely — bump is never called.
-    expect(s.opts.bumpIdleStreak.calls.length).toBe(0);
-  });
-
-  test("absent + work NOT done → 'revived' (no idle-confirmation needed)", () => {
-    const s = setup({ live: "absent", probeResult: false });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
-    expect(s.opts.reviveDispatch.calls.length).toBe(1);
-    expect(s.opts.bumpIdleStreak.calls.length).toBe(0);
-  });
-
-  test("the trigger consults liveness with the signal's bg_job_id (not a stale value)", () => {
-    const s = setup({ live: "absent", probeResult: true, bgJobId: "bg-77" });
-    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
-    expect(s.opts.liveness.calls[0][0]).toBe("bg-77");
-  });
-});
+// CTL-736 Phase 2: the CTL-662 busy-suppression and idle-confirmation+absent
+// describe blocks are DELETED. The busy/idle/absent three-valued `claude agents`
+// snapshot trigger is replaced by the state.json lifecycle (jobLifecycle →
+// alive | dead-terminal | dead-gone). `alive` (≈ the old `busy`) is covered by
+// the new "CTL-736 state.json death trigger" block + the main-block alive tests;
+// dead-terminal/dead-gone reclaim/revive is covered by the CTL-587 block. The
+// idle-confirmation streak and its markers no longer exist.
 
 // --- CTL-638: per-(ticket, phase) escalation cool-down ---------------------
 //
@@ -1935,6 +1792,10 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
       opts: {
         repoRoot: "/repo",
         statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+        // CTL-736: the death trigger is the state.json lifecycle. "dead-gone"
+        // (job dir vanished) is reclaim-eligible, the case these escalation
+        // cool-down scenarios exercise.
+        jobLifecycle: () => "dead-gone",
         // CTL-641 + CTL-606: every real phase now has a probe (so branch (A) is
         // skipped) and CTL-606's supersede guard throws on a non-PHASES phase, so
         // these storm-prevention tests can no longer reach the old branch-(A)
@@ -2859,17 +2720,16 @@ describe("reclaimDeadWorkIfPossible — CTL-606 supersede guard", () => {
     expect(r).toBe("reclaimed");
   });
 
-  test("guard never fires for a busy (live) signal — no listTicketPhases read on the hot path", () => {
-    // CTL-662: a live worker is now `busy`, which returns 'alive-busy-suppressed'
-    // from the status branch ABOVE the supersede guard — so the guard's
-    // listTicketPhases read is never reached for a live worker.
+  test("guard never fires for an alive (state=working) signal — no listTicketPhases read on the hot path", () => {
+    // CTL-736: a live worker has a non-terminal state.json lifecycle (`alive`),
+    // which returns 'alive-suppressed' from the trigger branch ABOVE the
+    // supersede guard — so the guard's listTicketPhases read is never reached.
     const listSpy = recorder(["triage", "research", "plan", "implement"]);
     const r = reclaimDeadWorkIfPossible(orch, implementSignal(), {
-      statJob: () => ({ exists: true, mtimeMs: Date.now() }),
-      liveness: () => "busy",
+      statJob: () => ({ exists: true, mtimeMs: Date.now(), state: "working" }),
       listTicketPhases: listSpy,
     });
-    expect(r).toBe("alive-busy-suppressed");
+    expect(r).toBe("alive-suppressed");
     expect(listSpy.calls.length).toBe(0); // guard runs only on the reclaim-eligible path
   });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -762,59 +762,11 @@ describe("reclaimDeadWorkIfPossible — CTL-735 inert stale tickets", () => {
   });
 });
 
-describe("reclaimDeadWorkIfPossible — CTL-735 per-tick revive cap", () => {
-  const orch = "/orch";
-
-  // All gates open so control reaches branch (C) and WOULD revive absent the cap.
-  const openReviveSeams = (reviveDispatch, extra = {}) => ({
-    statJob: () => null,
-    probes: { implement: recorder(false) },
-    emitComplete: recorder({ code: 0 }),
-    appendReviveEvent: recorder(true),
-    reviveDispatch,
-    countReviveEvents: recorder(0),
-    countDistinctRevivingTickets: recorder(1),
-    writeReviveMarker: recorder(undefined),
-    killBgJob: recorder(undefined),
-    applyStalledLabel: recorder({ applied: true }),
-    resolveSession: () => null,
-    liveness: () => "absent",
-    ...extra,
-  });
-
-  test("reviveBudgetRemaining = 0 → 'revive-capped', does NOT dispatch", () => {
-    const reviveDispatch = recorder({ code: 0 });
-    const r = reclaimDeadWorkIfPossible(
-      orch,
-      implementSignal(),
-      openReviveSeams(reviveDispatch, { reviveBudgetRemaining: 0 }),
-    );
-    expect(r).toBe("revive-capped");
-    expect(reviveDispatch.calls.length).toBe(0);
-  });
-
-  test("reviveBudgetRemaining = 1 → revives normally (budget available)", () => {
-    const reviveDispatch = recorder({ code: 0 });
-    const r = reclaimDeadWorkIfPossible(
-      orch,
-      implementSignal(),
-      openReviveSeams(reviveDispatch, { reviveBudgetRemaining: 1 }),
-    );
-    expect(r).toBe("revived");
-    expect(reviveDispatch.calls.length).toBe(1);
-  });
-
-  test("reviveBudgetRemaining undefined → revives (back-compat: no cap enforced)", () => {
-    const reviveDispatch = recorder({ code: 0 });
-    const r = reclaimDeadWorkIfPossible(
-      orch,
-      implementSignal(),
-      openReviveSeams(reviveDispatch), // no reviveBudgetRemaining
-    );
-    expect(r).toBe("revived");
-    expect(reviveDispatch.calls.length).toBe(1);
-  });
-});
+// CTL-736 Phase 3: the CTL-735 per-tick revive cap (`revive-capped`) is DELETED.
+// The progress gate (revive only while forward progress advances; stop on zero
+// progress) plus the Phase-1 O_EXCL claim bound retries structurally, so a single
+// tick can no longer mass-revive a backlog of dead workers. Its test block is
+// removed with the mechanism; see the CTL-736 progress-gate block below.
 
 describe("reclaimDeadWorkIfPossible", () => {
   const orch = "/orch";
@@ -902,15 +854,10 @@ describe("reclaimDeadWorkIfPossible", () => {
     expect(emit.calls.length).toBe(0);
   });
 
-  // CTL-587: this case used to return 'not-applicable' (a silent dead-end).
-  // It now escalates immediately — no probe means no way to verify the work,
-  // so the human must look. needs-human label is applied via the injected seam.
-  test("CTL-587: dead worker, probe NOT done + revive budget exhausted → 'escalated' + needs-human label", () => {
-    // CTL-641: every pipeline phase now has a probe, so the old branch-(A)
-    // "no-probe-for-phase" escalation is unreachable for real phases (and CTL-606's
-    // supersede guard throws on a non-PHASES phase before branch (A) is reached).
-    // The reachable "dead worker → needs-human" path is branch (C) once the revive
-    // budget is spent.
+  // CTL-736: the reachable "dead worker → needs-human" path is the branch-(C)
+  // no-progress STOP (a dead worker that made zero forward progress is flagged,
+  // never respawned), replacing the deleted MAX_REVIVES budget-exhausted path.
+  test("CTL-736: dead worker, probe NOT done + ZERO progress → 'no-progress-stopped' + needs-human label", () => {
     const sig = { ...implementSignal(), phase: "verify" };
     sig.raw.phase = "verify";
     const emit = recorder({ code: 0 });
@@ -918,19 +865,21 @@ describe("reclaimDeadWorkIfPossible", () => {
     const applyLabel = recorder({ applied: true });
     const reviveDispatch = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, sig, {
-      statJob: () => null, // bg dead
+      statJob: () => null, // bg dead → dead-gone
       probes: { verify: recorder(false) }, // artifact NOT complete
       emitComplete: emit,
       appendEvent: recorder(undefined),
       appendEscalatedEvent: appendEscalated,
       applyStalledLabel: applyLabel,
       reviveDispatch,
-      countReviveEvents: recorder(2), // budget exhausted (MAX_REVIVES)
+      // zero forward progress (current 0 <= prior 0) → STOP, never respawn.
+      progressMark: () => 0,
+      readProgressMark: () => 0,
     });
-    expect(r).toBe("escalated");
+    expect(r).toBe("no-progress-stopped");
     expect(emit.calls.length).toBe(0);
     expect(reviveDispatch.calls.length).toBe(0);
-    expect(appendEscalated.calls[0][0].reason).toBe("revive-budget-exhausted");
+    expect(appendEscalated.calls[0][0].reason).toBe("no-progress");
     expect(applyLabel.calls[0][0].ticket).toBe("CTL-9");
   });
 
@@ -1438,7 +1387,6 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
   // stale state.json mtime) and threads every CTL-587 seam through opts.
   function setupReviveScenario({
     reviveCount = 0,
-    distinctRevivingTickets = 1,
     probeResult = false, // false = "work not done" → enters CTL-587 territory
     phase = "implement",
     ticket = "CTL-9",
@@ -1447,8 +1395,11 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     nowMs = 1_000 + 6 * 60 * 1000, // 6 min past mtime — > STALE_MS
     // CTL-655: boot-time window seam. Default to a no-marker reader so every
     // existing scenario behaves exactly as before (since=undefined → the
-    // injected countReviveEvents recorder value is the unwindowed count).
+    // injected countReviveEvents recorder value is the unwindowed attempt count).
     readBootSince = () => undefined,
+    // CTL-736 Phase 3: progress gate. Default = progressed (current 1 > prior 0)
+    // so the scenario revives; noProgress:true → current 0 <= prior 0 → STOP path.
+    noProgress = false,
   } = {}) {
     const sig = {
       ...implementSignal({ ticket, status: "running", bgJobId }),
@@ -1474,7 +1425,6 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
         applyStalledLabel: recorder({ applied: true }),
         killBgJob: recorder(undefined),
         countReviveEvents: recorder(reviveCount),
-        countDistinctRevivingTickets: recorder(distinctRevivingTickets),
         writeReviveMarker: recorder(undefined),
         // CTL-664: stub the reclaim mirror so the probeResult:true scenarios
         // (branch B) stay hermetic and don't spawn a real `linearis`.
@@ -1482,9 +1432,13 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
         readBootSince, // CTL-655: inject the boot-time window reader
         // CTL-736: the death trigger is now the state.json lifecycle (jobLifecycle),
         // not the `claude agents` snapshot. "dead-gone" (the job dir vanished) is
-        // the reclaim-eligible case these revive/escalate/storm scenarios exercise.
+        // the reclaim-eligible case these revive/escalate scenarios exercise.
         // statJob above still supplies the prev_state_json_mtime telemetry.
         jobLifecycle: () => "dead-gone",
+        // CTL-736 Phase 3 progress-gate seams (replace MAX_REVIVES/storm/per-tick).
+        progressMark: () => (noProgress ? 0 : 1),
+        readProgressMark: () => 0,
+        writeProgressMark: recorder(undefined),
         now: () => nowMs,
       },
     };
@@ -1506,18 +1460,14 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(s.opts.appendReviveEvent.calls[0][0].attempt).toBe(2);
   });
 
-  test("budget exhausted: count=2 → 'escalated', applies needs-human label, no dispatch", () => {
-    const s = setupReviveScenario({ reviveCount: 2 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
-    expect(s.opts.appendEscalatedEvent.calls.length).toBe(1);
-    expect(s.opts.applyStalledLabel.calls[0][0].ticket).toBe("CTL-9");
-    expect(s.opts.reviveDispatch.calls.length).toBe(0);
-    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("revive-budget-exhausted");
-    expect(s.opts.appendEscalatedEvent.calls[0][0].final_attempt_count).toBe(2);
-  });
+  // CTL-736 Phase 3: the MAX_REVIVES budget-exhausted escalation and the
+  // fleet-wide storm-breaker (revive-suppressed) are DELETED — a worker now
+  // revives as long as it makes forward progress, and STOPS (no-progress-stopped)
+  // when it does not. The escalation MECHANISM (CTL-679 breaker, CTL-638 cool-down)
+  // is now exercised through that no-progress STOP path instead of budget-exhausted.
 
-  test("CTL-679: breaker open → 'rate-limited-deferred', no escalation event, no label write", () => {
-    const s = setupReviveScenario({ reviveCount: 2 }); // would otherwise escalate
+  test("CTL-679: breaker open on the no-progress STOP → 'rate-limited-deferred', no escalation event, no label write", () => {
+    const s = setupReviveScenario({ noProgress: true }); // zero progress → STOP path
     const r = reclaimDeadWorkIfPossible(s.orch, s.sig, {
       ...s.opts,
       breaker: { isOpen: () => true },
@@ -1525,44 +1475,20 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(r).toBe("rate-limited-deferred");
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
     expect(s.opts.applyStalledLabel.calls.length).toBe(0);
+    expect(s.opts.reviveDispatch.calls.length).toBe(0); // never respawned
   });
 
-  test("CTL-679: breaker closed → escalation proceeds as normal", () => {
-    const s = setupReviveScenario({ reviveCount: 2 });
+  test("CTL-679: breaker closed on the no-progress STOP → 'no-progress-stopped', needs-human applied, no respawn", () => {
+    const s = setupReviveScenario({ noProgress: true });
     const r = reclaimDeadWorkIfPossible(s.orch, s.sig, {
       ...s.opts,
       breaker: { isOpen: () => false },
     });
-    expect(r).toBe("escalated");
+    expect(r).toBe("no-progress-stopped");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("no-progress");
     expect(s.opts.applyStalledLabel.calls.length).toBe(1);
-  });
-
-  test("storm-breaker: distinct=4 > 3 → 'revive-suppressed', no dispatch", () => {
-    const s = setupReviveScenario({ reviveCount: 0, distinctRevivingTickets: 4 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revive-suppressed");
-    expect(s.opts.reviveDispatch.calls.length).toBe(0);
-    expect(s.opts.appendReviveSuppressedEvent.calls.length).toBe(1);
-    expect(s.opts.appendReviveSuppressedEvent.calls[0][0].window_distinct_tickets).toBe(4);
-  });
-
-  test("storm-breaker at the threshold: distinct=3 is NOT suppressed (>3, not >=3)", () => {
-    const s = setupReviveScenario({ reviveCount: 0, distinctRevivingTickets: 3 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
-  });
-
-  // CTL-641: pr/monitor-merge are now registered, so branch (A) is reached only
-  // by a genuinely-unknown phase. Use one to keep the no-probe guard under test.
-  test("probe NOT done + revive budget exhausted → 'escalated' immediately", () => {
-    // CTL-641/CTL-606: branch (A) "no-probe-for-phase" is now unreachable (all
-    // real phases are probed; unknown phases throw at the supersede guard). The
-    // budget-exhausted escalation is the reachable dead-end-to-human path.
-    const s = setupReviveScenario({ phase: "verify", probeResult: false, reviveCount: 2 });
-    const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
-    expect(r).toBe("escalated");
-    expect(s.opts.appendEscalatedEvent.calls[0][0].phase).toBe("verify");
-    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("revive-budget-exhausted");
-    expect(s.opts.applyStalledLabel.calls.length).toBe(1);
-    expect(s.opts.reviveDispatch.calls.length).toBe(0);
+    expect(s.opts.reviveDispatch.calls.length).toBe(0); // never respawned
+    expect(s.opts.killBgJob.calls.length).toBe(1); // the dead worker is stopped
   });
 
   // CTL-604: research/plan now share the bounded revive/re-dispatch path with
@@ -1592,35 +1518,24 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(s.opts.countReviveEvents.calls[0][0]).toHaveProperty("orchId");
   });
 
-  // CTL-655: fail-open — a missing/unreadable marker yields no `since`, so the
-  // counter is unwindowed and the budget still exhausts (today's behavior).
+  // CTL-655: the boot 'since' windows the attempt counter; a missing marker is
+  // fail-open (since=undefined → unwindowed count). CTL-736: the count is now the
+  // revive ATTEMPT NUMBER (telemetry), not a budget gate, so the worker revives.
   test("omits 'since' when boot marker is absent (fail-open)", () => {
     const s = setupReviveScenario({
       reviveCount: 2,
       readBootSince: () => undefined,
     });
     const r = reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
-    expect(r).toBe("escalated");
+    expect(r).toBe("revived"); // CTL-736: no MAX_REVIVES gate — progress drives it
     expect(s.opts.countReviveEvents.calls[0][0].since).toBeUndefined();
+    expect(s.opts.appendReviveEvent.calls[0][0].attempt).toBe(3); // count 2 + 1
   });
 
   test("dead plan worker, probe NOT done → 'revived'", () => {
     const s = setupReviveScenario({ phase: "plan", probeResult: false, reviveCount: 0 });
     expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revived");
     expect(s.opts.reviveDispatch.calls.length).toBe(1);
-  });
-
-  test("dead research worker, revive budget exhausted → 'escalated' (revive-budget-exhausted)", () => {
-    const s = setupReviveScenario({ phase: "research", probeResult: false, reviveCount: 2 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
-    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("revive-budget-exhausted");
-    expect(s.opts.reviveDispatch.calls.length).toBe(0);
-  });
-
-  test("dead research worker, storm-breaker open → 'revive-suppressed'", () => {
-    const s = setupReviveScenario({ phase: "research", probeResult: false, distinctRevivingTickets: 4 });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("revive-suppressed");
-    expect(s.opts.reviveDispatch.calls.length).toBe(0);
   });
 
   test("CTL-662: defensive stop fires on the revive path unconditionally (the mtime quiet-window gate is gone)", () => {
@@ -1644,14 +1559,13 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
     expect(body.prev_bg_job_id).toBe("bg-9");
   });
 
-  test("escalation still records 'escalated' even when applyStalledLabel fails (no dispatch)", () => {
-    // Failure to apply the label still returns 'escalated' so the scheduler
-    // records the outcome. The labelOnce semantics in scheduler.mjs guard
-    // re-application — a verify-failed result returns no marker, so the next
-    // tick retries the label apply.
-    const s = setupReviveScenario({ reviveCount: 2 });
+  test("no-progress escalation still records the outcome even when applyStalledLabel fails (no dispatch)", () => {
+    // CTL-736: a failed label apply still returns 'no-progress-stopped' so the
+    // scheduler records the outcome. labelOnce guards re-application — a
+    // verify-failed result returns no marker, so the next tick retries the apply.
+    const s = setupReviveScenario({ noProgress: true });
     s.opts.applyStalledLabel = recorder({ applied: false, reason: "verify-failed" });
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
     expect(s.opts.reviveDispatch.calls.length).toBe(0);
   });
 
@@ -1746,6 +1660,98 @@ describe("reclaimDeadWorkIfPossible — CTL-587 revive/suppress/escalate", () =>
   });
 });
 
+// --- CTL-736 Phase 3: the progress gate (revive-while-progressing vs stop) -----
+
+describe("reclaimDeadWorkIfPossible — CTL-736 progress gate", () => {
+  const orch = "/orch";
+
+  // A reclaim-eligible (dead-gone), work-not-done worker with the downstream
+  // revive/escalate seams stubbed; progressMark / readProgressMark are the levers.
+  function gateSeams(extra = {}) {
+    return {
+      repoRoot: "/repo",
+      jobLifecycle: () => "dead-gone",
+      probes: { implement: () => false }, // work NOT done → branch (C)
+      emitComplete: recorder({ code: 0 }),
+      appendEvent: recorder(undefined),
+      appendReviveEvent: recorder(true),
+      appendEscalatedEvent: recorder(undefined),
+      appendReviveSuppressedEvent: recorder(undefined),
+      reviveDispatch: recorder({ code: 0 }),
+      applyStalledLabel: recorder({ applied: true }),
+      killBgJob: recorder(undefined),
+      countReviveEvents: recorder(0),
+      writeReviveMarker: recorder(undefined),
+      writeProgressMark: recorder(undefined),
+      resolveSession: () => null,
+      readBootSince: () => undefined,
+      inEscalationCooldownFn: () => false,
+      recordEscalationFn: recorder(undefined),
+      emitReapIntent: () => Promise.resolve(),
+      breaker: { isOpen: () => false },
+      now: () => 1_000_000,
+      ...extra,
+    };
+  }
+
+  test("progress advanced since the last attempt ⇒ 'revived' + new high-water recorded (gen+1 via dispatch)", () => {
+    const writeProgressMark = recorder(undefined);
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 5, // 5 commits now…
+      readProgressMark: () => 2, // …vs 2 recorded → advanced
+      writeProgressMark,
+      reviveDispatch,
+    }));
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+    expect(writeProgressMark.calls.length).toBe(1);
+    expect(writeProgressMark.calls[0]).toEqual([orch, "CTL-9", "implement", 5]);
+  });
+
+  test("zero progress since the last attempt ⇒ 'no-progress-stopped', NEVER respawned + needs-human", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const appendEscalatedEvent = recorder(undefined);
+    const killBgJob = recorder(undefined);
+    const writeProgressMark = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2, // unchanged…
+      readProgressMark: () => 2, // …same high-water → no forward progress
+      reviveDispatch,
+      appendEscalatedEvent,
+      killBgJob,
+      writeProgressMark,
+    }));
+    expect(r).toBe("no-progress-stopped");
+    expect(reviveDispatch.calls.length).toBe(0); // the futile respawn is suppressed
+    expect(appendEscalatedEvent.calls[0][0].reason).toBe("no-progress");
+    expect(killBgJob.calls.length).toBe(1); // the dead worker is stopped
+    expect(writeProgressMark.calls.length).toBe(0); // no new high-water on a stop
+  });
+
+  test("first death with no prior mark (readProgressMark -1) always gets one revive — even at zero progress", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 0, // a worker that crashed before its first commit…
+      readProgressMark: () => -1, // …no prior mark → 0 > -1 → one retry
+      reviveDispatch,
+    }));
+    expect(r).toBe("revived");
+    expect(reviveDispatch.calls.length).toBe(1);
+  });
+
+  test("the SECOND zero-progress death (mark now recorded at 0) stops — bounds the futile loop", () => {
+    const reviveDispatch = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 0,
+      readProgressMark: () => 0, // the first revive recorded 0; still 0 → stop
+      reviveDispatch,
+    }));
+    expect(r).toBe("no-progress-stopped");
+    expect(reviveDispatch.calls.length).toBe(0);
+  });
+});
+
 // CTL-736 Phase 2: the CTL-662 busy-suppression and idle-confirmation+absent
 // describe blocks are DELETED. The busy/idle/absent three-valued `claude agents`
 // snapshot trigger is replaced by the state.json lifecycle (jobLifecycle →
@@ -1796,12 +1802,12 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
         // (job dir vanished) is reclaim-eligible, the case these escalation
         // cool-down scenarios exercise.
         jobLifecycle: () => "dead-gone",
-        // CTL-641 + CTL-606: every real phase now has a probe (so branch (A) is
-        // skipped) and CTL-606's supersede guard throws on a non-PHASES phase, so
-        // these storm-prevention tests can no longer reach the old branch-(A)
-        // no-probe escalation. They instead drive the reachable branch-(C)
-        // revive-budget-exhausted escalation: a probe-false real phase with the
-        // revive budget exhausted (reviveCount default below = MAX_REVIVES).
+        // CTL-736 Phase 3: drive escalation through the reachable no-progress STOP
+        // path (zero forward progress → escalateOnce + needs-human, never respawn),
+        // replacing the deleted MAX_REVIVES budget-exhausted escalation.
+        progressMark: () => 0,
+        readProgressMark: () => 0,
+        writeProgressMark: recorder(undefined),
         probes: { [overrides.phase ?? "implement"]: recorder(overrides.probeResult ?? false) },
         emitComplete: recorder({ code: 0 }),
         appendEvent: recorder(undefined),
@@ -1811,8 +1817,7 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
         reviveDispatch: recorder({ code: 0 }),
         applyStalledLabel: recorder({ applied: true }),
         killBgJob: recorder(undefined),
-        countReviveEvents: recorder(overrides.reviveCount ?? 2), // default = MAX_REVIVES → budget-exhausted escalation
-        countDistinctRevivingTickets: recorder(1),
+        countReviveEvents: recorder(overrides.reviveCount ?? 0),
         writeReviveMarker: recorder(undefined),
         now: () => overrides.nowMs ?? 1_000 + 6 * 60 * 1000,
         staleMs: 5 * 60 * 1000,
@@ -1823,15 +1828,16 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
   }
 
   test("acceptance: second tick on same (ticket, phase) suppresses — exactly one event + one label write", () => {
-    const s = setupAt(orchDir, { phase: "pr" }); // branch (C): revive-budget-exhausted
+    const s = setupAt(orchDir, { phase: "pr" }); // branch (C): no-progress STOP
 
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(1);
     expect(s.opts.applyStalledLabel.calls.length).toBe(1);
 
-    // 1,500 simulated ticks in the storm window — every one suppressed.
+    // 1,500 simulated ticks in the storm window — the escalation cool-down keeps
+    // the event + label at exactly one even though every tick re-stops the worker.
     for (let i = 0; i < 1500; i++) {
-      expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalation-suppressed");
+      expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
     }
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(1); // NOT 1,501
     expect(s.opts.applyStalledLabel.calls.length).toBe(1); // NOT 1,501
@@ -1842,32 +1848,36 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
     const s = setupAt(orchDir, { phase: "pr", nowMs: clock });
     s.opts.now = () => clock;
 
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
     clock += 10 * 60 * 1000 + 1; // jump past the 10-min default window
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(2);
   });
 
   test("different phase on the same ticket gets an independent cool-down (pr → monitor-merge advancement)", () => {
     // Reproduces the live CTL-624 timeline: escalations on `pr` for a stretch,
     // then on `monitor-merge` after `pr` completes. Both should escalate; only
-    // the WITHIN-phase repeats are suppressed.
+    // the WITHIN-phase repeats are suppressed (cool-down keeps the event count
+    // pinned, even though the return is no-progress-stopped each time).
     const sPr = setupAt(orchDir, { phase: "pr" });
-    expect(reclaimDeadWorkIfPossible(sPr.orch, sPr.sig, sPr.opts)).toBe("escalated");
-    expect(reclaimDeadWorkIfPossible(sPr.orch, sPr.sig, sPr.opts)).toBe("escalation-suppressed");
+    expect(reclaimDeadWorkIfPossible(sPr.orch, sPr.sig, sPr.opts)).toBe("no-progress-stopped");
+    const eventsAfterPr = sPr.opts.appendEscalatedEvent.calls.length;
+    expect(reclaimDeadWorkIfPossible(sPr.orch, sPr.sig, sPr.opts)).toBe("no-progress-stopped");
+    expect(sPr.opts.appendEscalatedEvent.calls.length).toBe(eventsAfterPr); // suppressed
 
     const sMm = setupAt(orchDir, { phase: "monitor-merge" });
-    expect(reclaimDeadWorkIfPossible(sMm.orch, sMm.sig, sMm.opts)).toBe("escalated");
+    expect(reclaimDeadWorkIfPossible(sMm.orch, sMm.sig, sMm.opts)).toBe("no-progress-stopped");
+    expect(sMm.opts.appendEscalatedEvent.calls.length).toBe(1); // independent cool-down → fired
   });
 
-  test("revive-budget-exhausted branch also respects the cool-down", () => {
-    // Repro: implement phase, budget exhausted → escalation path. Second tick
-    // must suppress just like the no-probe branch.
-    const s = setupAt(orchDir, { phase: "implement", reviveCount: 2 });
+  test("the no-progress escalation branch also respects the cool-down", () => {
+    // Repro: implement phase, zero progress → escalation path. Second tick must
+    // suppress the escalation event/label just like any other escalation.
+    const s = setupAt(orchDir, { phase: "implement" });
 
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
-    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("revive-budget-exhausted");
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalation-suppressed");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
+    expect(s.opts.appendEscalatedEvent.calls[0][0].reason).toBe("no-progress");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(1);
   });
 
@@ -1880,22 +1890,24 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
     s.opts.inEscalationCooldownFn = inCd;
     s.opts.recordEscalationFn = recCd;
 
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalated");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
     expect(inCd.calls.length).toBe(1);
     expect(recCd.calls.length).toBe(1);
     // recordEscalationFn signature: (orchDir, ticket, phase, reason, now)
     expect(recCd.calls[0][1]).toBe("CTL-9");
     expect(recCd.calls[0][2]).toBe("pr");
-    expect(recCd.calls[0][3]).toBe("revive-budget-exhausted");
+    expect(recCd.calls[0][3]).toBe("no-progress");
   });
 
-  test("escalation-suppressed return path does NOT call appendEscalatedEvent / applyStalledLabel / recordEscalationFn", () => {
+  test("cool-down-suppressed escalation does NOT call appendEscalatedEvent / applyStalledLabel / recordEscalationFn", () => {
     // Pure-fake seams to make the suppression observable as zero side-effects.
+    // The worker is still STOPPED (no-progress-stopped); only the escalation
+    // event/label is throttled by the cool-down.
     const s = setupAt(orchDir, { phase: "pr" });
     s.opts.inEscalationCooldownFn = recorder(true); // cool-down already armed
     s.opts.recordEscalationFn = recorder(undefined);
 
-    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("escalation-suppressed");
+    expect(reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts)).toBe("no-progress-stopped");
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(0);
     expect(s.opts.applyStalledLabel.calls.length).toBe(0);
     expect(s.opts.recordEscalationFn.calls.length).toBe(0);

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -34,6 +34,7 @@ import {
   detectColdStart,
   readBootSince,
   readExecCoreBootEpoch,
+  clearProgressMarks,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -1090,18 +1091,16 @@ describe("reclaimDeadWorkIfPossible — CTL-736 state.json death trigger", () =>
     };
   }
 
-  test("state-json: alive (state=working) ⇒ 'alive-suppressed' — never reclaimed, no idle streak/grace", () => {
+  test("alive (state=working) ⇒ 'alive-suppressed' — never reclaimed, no idle streak/grace", () => {
     const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
-      livenessSource: "state-json",
       jobLifecycle: () => "alive",
     }));
     expect(r).toBe("alive-suppressed");
   });
 
-  test("state-json: dead-terminal + work done ⇒ 'reclaimed' immediately (no grace/streak)", () => {
+  test("dead-terminal + work done ⇒ 'reclaimed' immediately (no grace/streak)", () => {
     const emitComplete = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
-      livenessSource: "state-json",
       jobLifecycle: () => "dead-terminal",
       probes: { implement: () => true },
       emitComplete,
@@ -1110,55 +1109,25 @@ describe("reclaimDeadWorkIfPossible — CTL-736 state.json death trigger", () =>
     expect(emitComplete.calls.length).toBe(1);
   });
 
-  test("state-json: dead-gone + work NOT done ⇒ 'revived' immediately, even with a fresh startedAt (no grace window)", () => {
+  test("dead-gone + work NOT done ⇒ 'revived' immediately, even with a fresh startedAt (no grace window)", () => {
     const reviveDispatch = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(
       orch,
       // startedAt = now: pre-CTL-736 this was deferred 'revive-pending' by the 90s grace.
       implementSignal({ status: "running", startedAt: new Date(1_000_000).toISOString() }),
-      seams({ livenessSource: "state-json", jobLifecycle: () => "dead-gone", reviveDispatch }),
+      seams({ jobLifecycle: () => "dead-gone", reviveDispatch }),
     );
     expect(r).toBe("revived");
     expect(reviveDispatch.calls.length).toBe(1);
   });
 
-  test("state-json: never consults the legacy `claude agents` snapshot seam", () => {
-    const liveness = recorder("busy");
-    reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
-      livenessSource: "state-json",
-      jobLifecycle: () => "alive",
-      liveness,
+  test("the death trigger is jobLifecycle (state.json), consulted with the worker's bg_job_id", () => {
+    const jobLifecycle = recorder("alive");
+    reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running", bgJobId: "bg-77" }), seams({
+      jobLifecycle,
     }));
-    expect(liveness.calls.length).toBe(0);
-  });
-
-  test("shadow: logs the mismatch but ACTS ON state.json (jobLifecycle), not the snapshot", () => {
-    // jobLifecycle says alive; snapshot says absent (disagreement). Acts on alive.
-    const liveness = recorder("absent");
-    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
-      livenessSource: "shadow",
-      jobLifecycle: () => "alive",
-      liveness,
-    }));
-    expect(r).toBe("alive-suppressed"); // acted on state.json, not the absent snapshot
-    expect(liveness.calls.length).toBe(1); // but DID consult the snapshot (to compare/log)
-  });
-
-  test("snapshot rollback: busy ⇒ alive-suppressed; absent ⇒ reclaim-eligible (revive, no streak/grace)", () => {
-    const busy = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
-      livenessSource: "snapshot",
-      liveness: () => "busy",
-    }));
-    expect(busy).toBe("alive-suppressed");
-
-    const reviveDispatch = recorder({ code: 0 });
-    const absent = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), seams({
-      livenessSource: "snapshot",
-      liveness: () => "absent",
-      reviveDispatch,
-    }));
-    expect(absent).toBe("revived");
-    expect(reviveDispatch.calls.length).toBe(1);
+    expect(jobLifecycle.calls.length).toBe(1);
+    expect(jobLifecycle.calls[0][0]).toBe("bg-77");
   });
 
   test("alive past BUSY_CEILING_MS with no committed work ⇒ 'escalated' (no silent reclaim)", () => {
@@ -1167,7 +1136,6 @@ describe("reclaimDeadWorkIfPossible — CTL-736 state.json death trigger", () =>
       orch,
       implementSignal({ status: "running", startedAt: new Date(0).toISOString() }),
       seams({
-        livenessSource: "state-json",
         jobLifecycle: () => "alive",
         busyCeilingMs: 1,
         now: () => 10_000,
@@ -2794,6 +2762,51 @@ describe("readBootSince — CTL-655 boot-time window reader", () => {
     // Empty-string bootedAt is also rejected.
     writeFileSync(join(dir, "daemon-boot.json"), JSON.stringify({ bootedAt: "" }));
     expect(readBootSince(dir)).toBeUndefined();
+  });
+});
+
+// CTL-736 Phase 3: at daemon boot, every per-(ticket, phase) progress high-water
+// marker is cleared so a stale mark from a prior run cannot false-STOP this run's
+// first death (the gate's "first death gets one revive" guarantee is per-run).
+describe("clearProgressMarks — CTL-736 boot-time progress reset", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl736-progress-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  function writeWorkerFile(ticket, name, body = "x") {
+    const d = join(orchDir, "workers", ticket);
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, name), body);
+  }
+
+  test("deletes every .progress-<phase> marker across all worker dirs", () => {
+    writeWorkerFile("CTL-1", ".progress-implement", "4");
+    writeWorkerFile("CTL-1", ".progress-verify", "120");
+    writeWorkerFile("CTL-2", ".progress-research", "800");
+    clearProgressMarks(orchDir);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".progress-implement"))).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".progress-verify"))).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-2", ".progress-research"))).toBe(false);
+  });
+
+  test("leaves non-progress worker files untouched (signals, claims, revive markers)", () => {
+    writeWorkerFile("CTL-1", "phase-implement.json", "{}");
+    writeWorkerFile("CTL-1", "implement.claim.1", "{}");
+    writeWorkerFile("CTL-1", ".revive-1.applied", "ts");
+    writeWorkerFile("CTL-1", ".progress-implement", "4");
+    clearProgressMarks(orchDir);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", "phase-implement.json"))).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", "implement.claim.1"))).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".revive-1.applied"))).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-1", ".progress-implement"))).toBe(false);
+  });
+
+  test("no workers dir → no-op (fail-open, no throw)", () => {
+    expect(() => clearProgressMarks(orchDir)).not.toThrow();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -60,7 +60,7 @@ import { fetchTicketState } from "./linear-query.mjs";
 import { getProjectConfig, listProjects } from "./registry.mjs";
 import { teardownWorktree as defaultTeardownWorktree } from "./worktree.mjs";
 import { readWorkerSignals } from "./signal-reader.mjs";
-import { countBackgroundAgents, getAgentsCached, livenessForBgJob } from "./claude-agents.mjs";
+import { countBackgroundAgents, getAgentsCached } from "./claude-agents.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
 // CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
 // is the real recovery-module function; tests inject a fake. See
@@ -927,14 +927,19 @@ export function maybeResetForRemediateCycle(
   }
   // GATE-0: also drop the cycle members' claim tombstones so the re-dispatch's
   // fresh (no-signal ⇒ gen 1) claim is exclusive and wins instead of colliding.
-  let claimEntries;
+  // CTL-736 Phase 3: AND drop their `.progress-<phase>` high-water markers, so the
+  // fresh verify/remediate attempt is measured from zero — a stale high-water from
+  // the prior cycle would otherwise false-STOP the new attempt on its first death.
+  let workerEntries;
   try {
-    claimEntries = readdir(workerDir);
+    workerEntries = readdir(workerDir);
   } catch {
-    claimEntries = []; // worker dir gone — nothing to clean
+    workerEntries = []; // worker dir gone — nothing to clean
   }
-  for (const f of claimEntries) {
-    if (REMEDIATE_CYCLE_CLAIM_PHASES.some((p) => f.startsWith(`${p}.claim.`))) {
+  for (const f of workerEntries) {
+    const isCycleClaim = REMEDIATE_CYCLE_CLAIM_PHASES.some((p) => f.startsWith(`${p}.claim.`));
+    const isCycleProgress = REMEDIATE_CYCLE_CLAIM_PHASES.some((p) => f === `.progress-${p}`);
+    if (isCycleClaim || isCycleProgress) {
       try {
         rm(join(workerDir, f), { force: true });
       } catch {
@@ -1362,18 +1367,15 @@ export function schedulerTick(
     // its slot. Interactive sessions are excluded (unlimited). Injectable for
     // tests so a unit tick need not shell out to `claude`.
     liveBackgroundCount = () => countBackgroundAgents(),
-    // CTL-731 Phase 00: the hardened-liveness seams. `livenessSnapshot` returns
-    // the warm, never-blocking `claude agents` snapshot once per tick (the daemon
-    // injects `() => getAgentsCached()`); when non-null, the SAME agents list is
-    // bound into the per-worker reclaim liveness so the reclaim sweep no longer
-    // shells out synchronously per worker (a hot-loop starvation source). Null
-    // (the test default) preserves the legacy per-worker liveness path.
-    // `livenessIsFresh` gates new-work admission: a stale/never-populated snapshot
-    // means the live count is untrustworthy, so we HOLD new dispatch (fail-safe,
-    // never over-spawn) while advancement of in-flight phases continues. Defaults
-    // to fresh so existing tests (which inject only liveBackgroundCount) dispatch
-    // exactly as before.
-    livenessSnapshot = null,
+    // CTL-731 Phase 00 / CTL-736: `livenessIsFresh` gates new-work admission — a
+    // stale/never-populated `claude agents` snapshot means the live count is
+    // untrustworthy, so we HOLD new dispatch (fail-safe, never over-spawn) while
+    // advancement of in-flight phases continues. Defaults to fresh so existing
+    // tests (which inject only liveBackgroundCount) dispatch exactly as before.
+    // (The companion `livenessSnapshot` seam that bound the shared agents list
+    // into the per-worker reclaim liveness was removed with CTL-736: the reclaim
+    // death trigger now reads each worker's local state.json and never consults
+    // the snapshot.)
     livenessIsFresh = () => true,
     // CTL-611: injectable verifier + audit-event emitter so tests can pin the
     // demotion path independently of fixture choice (fakeDispatch / recorder).
@@ -1405,14 +1407,14 @@ export function schedulerTick(
   // every active worker signal (readWorkerSignals returns one per ticket — the
   // active, non-terminal-first phase) and asks reclaimDeadWork to decide.
   // Reclaim is a strict superset of "do nothing": only the dead+work-done case
-  // mutates the signal; all other classes (terminal/running/unknown/not-done/
-  // not-applicable) are zero-action no-ops.
-  // CTL-587: reclaimDeadWork now returns up to 8 discriminators. The four
-  // that callers can act on (HUD, daemon log) populate parallel arrays; the
-  // others (noop, not-done, not-applicable, reclaim-failed, superseded-noop)
-  // are silent because they describe "no externally-visible change" — the next
-  // tick will re-evaluate. The 'reviveSuppressed' bucket is the storm-breaker
-  // marker; 'escalated' fires `needs-human` via the per-phase recovery path.
+  // mutates the signal; all other classes (terminal/running/unknown/alive-
+  // suppressed/superseded-noop) are zero-action no-ops.
+  // CTL-736: reclaimDeadWork's actionable returns populate parallel arrays for
+  // the HUD / daemon log; the rest (noop, reclaim-failed, superseded-noop,
+  // inert-stale, alive-suppressed, rate-limited-deferred, escalation-suppressed)
+  // are silent — they describe "no externally-visible change" the next tick
+  // re-evaluates. 'reviveSuppressed' now marks only the audit-append-failure
+  // path; 'noProgressStopped' + 'escalated' fire `needs-human`.
   const reclaimed = [];
   const revived = [];
   // CTL-736: reviveSuppressed now marks ONLY the audit-append-failure path (the
@@ -1435,27 +1437,14 @@ export function schedulerTick(
   // failed/stalled/aborted" — exactly the set this sweep cares about.
   const inFlightTickets = listInFlightTickets(orchDir);
 
-  // CTL-731 Phase 00: read the warm, never-blocking `claude agents` snapshot ONCE
-  // per tick (no subprocess on the event loop). Its agents list is bound into the
-  // per-worker reclaim liveness below so the reclaim sweep — which iterates every
-  // in-flight worker — no longer shells out `claude agents --json` per worker (a
-  // proven starvation source). Its freshness gates new-work admission later. Null
-  // snapshot seam (test default) → legacy per-worker liveness, fresh-by-default.
-  const liveSnapshot = livenessSnapshot ? livenessSnapshot() : null;
-  // CTL-731: only bind the snapshot's agents into the reclaim liveness when it is
-  // POPULATED. Used ONLY by the non-default `snapshot`/`shadow` LIVENESS_SOURCE
-  // escape-hatch modes (see recovery.mjs reclaimDeadWorkIfPossible); the default
-  // `state-json` death trigger reads each worker's local state.json and never
-  // consults this list. A populated-but-stale snapshot is fine for reclaim
-  // (≤ a few seconds old, same as the 5s TTL) — only NEW-work dispatch needs isFresh.
-  const liveAgents = liveSnapshot && liveSnapshot.populated ? liveSnapshot.agents : null;
-
-  // CTL-736 Phase 2: the CTL-731 reclaimColdSkip (skip the whole reclaim sweep on
-  // a cold snapshot) is DELETED. It existed because the cold `claude agents`
-  // snapshot would resolve every worker to "absent" and mass-false-revive. The
-  // default state-json death trigger reads a LOCAL per-worker state.json — there
-  // is no cold/warm distinction and no per-worker `claude agents` fan-out to
-  // guard against, so the sweep runs every tick.
+  // CTL-736: the reclaim death trigger is the authoritative LOCAL state.json
+  // lifecycle (jobLifecycle), so the reclaim sweep no longer reads the `claude
+  // agents` snapshot at all. The CTL-731 per-tick snapshot read + per-worker
+  // liveness binding AND the cold-snapshot skip (reclaimColdSkip) are both gone:
+  // a local statSync of one job dir per worker has no cold/warm distinction and
+  // no per-worker subprocess fan-out to guard against, so the sweep runs every
+  // tick. (New-work admission still gates on `livenessIsFresh()` below — a
+  // separate concern that keeps the snapshot warm for concurrency counting.)
 
   // CTL-702: scan worker dirs for yield tombstones. Emit once per unique
   // absolute path per daemon lifetime (deduped via observedYieldFiles).
@@ -1490,13 +1479,9 @@ export function schedulerTick(
     try {
       const team = teamOf(sig.ticket);
       const repoRoot = team ? (getProjectConfig(team)?.repoRoot ?? null) : null;
-      // CTL-731 Phase 00: when we have a warm snapshot, bind its agents list into
-      // the reclaim's liveness reader so it resolves busy/idle/absent against the
-      // ONE shared `claude agents` read instead of shelling out per worker.
+      // CTL-736: reclaim reads only the local state.json lifecycle — no snapshot
+      // liveness binding (the death trigger never consults `claude agents`).
       const reclaimOpts = { repoRoot };
-      if (liveAgents) {
-        reclaimOpts.liveness = (bgJobId) => livenessForBgJob(bgJobId, { agents: liveAgents });
-      }
       // CTL-736 Phase 3: no per-tick revive budget is threaded — the progress gate
       // (revive only while progressing; stop on zero progress) + the Phase-1 O_EXCL
       // claim bound the mass-revive storm structurally.
@@ -1529,24 +1514,22 @@ export function schedulerTick(
           // escalation in events.jsonl already; surfacing this would re-recreate
           // the noise the cool-down exists to prevent.
           break;
-        case "alive-quiet-suppressed":
-          // CTL-610: the bg worker is alive (kill -0) but quiet on a long tool
-          // call (the pre-first-output window for research/plan, or a long
-          // synchronous Edit/Bash inside implement). Invisible by design — no
-          // duplicate spawn, no state change; the next tick re-evaluates the
-          // mtime + pidAlive pair. Surfacing it in result.revived / .escalated
-          // / .reviveSuppressed would re-create the very revive-storm noise the
-          // (C0) guard exists to suppress (and would re-feed the scheduler's own
-          // fs.watch fast path via any audit-event write — CTL-638 lineage).
+        case "rate-limited-deferred":
+          // CTL-736/CTL-679: a no-progress STOP whose needs-human escalation
+          // deferred because the Linear breaker is open. The worker WAS stopped;
+          // the label retries next tick once the breaker closes. Bucket it with
+          // the no-progress stops so the killed-but-pending-flag worker is visible
+          // (rather than silently invisible in `default`).
+          noProgressStopped.push(entry);
           break;
         default:
-          // noop | not-done | not-applicable | reclaim-failed → invisible.
+          // noop | reclaim-failed → invisible.
           // CTL-606: superseded-noop also buckets here — a dead predecessor signal
           // the ticket has already advanced past. Invisible by design (the active
           // phase is progressing normally); surfacing it would be noise.
-          // CTL-735: inert-stale also buckets here — an abandoned historical dir
-          // too old to revive. Invisible by design (steady-state; ~85 such dirs
-          // would otherwise be persistent noise).
+          // CTL-736: alive-suppressed (worker still working) + inert-stale (an
+          // abandoned historical dir too old to revive) also bucket here — both
+          // steady-state non-events that would otherwise be persistent noise.
           break;
       }
     } catch (err) {
@@ -2197,21 +2180,17 @@ function runTick() {
       // a unit test can drive freeSlots deterministically without shelling
       // out to `claude agents`. Undefined here keeps the production default.
       liveBackgroundCount: runningOpts.liveBackgroundCount,
-      // CTL-731 Phase 00: production wiring for the hardened-liveness seams.
-      // Both read the ONE warm, never-blocking snapshot (getAgentsCached) — no
-      // subprocess on the event loop. livenessSnapshot binds the shared agents
-      // list into the per-worker reclaim liveness; livenessIsFresh gates new-work
-      // dispatch on staleness.
+      // CTL-731 Phase 00: production wiring for the new-work staleness gate. It
+      // reads the ONE warm, never-blocking snapshot (getAgentsCached) — no
+      // subprocess on the event loop — and HOLDS new dispatch when the live count
+      // is untrustworthy.
       //
       // Coupling: an injected liveBackgroundCount means the caller is supplying a
       // deterministic, trustworthy count (the CTL-676 test seam), so the staleness
-      // gate has nothing to protect against — default freshness to true and skip
-      // the snapshot-derived reclaim binding (avoids a real `claude agents` spawn
-      // in tests). Production never injects liveBackgroundCount, so it always gets
-      // the real snapshot + real freshness. Explicit overrides win over both.
-      livenessSnapshot:
-        runningOpts.livenessSnapshot ??
-        (runningOpts.liveBackgroundCount !== undefined ? null : () => getAgentsCached()),
+      // gate has nothing to protect against — default freshness to true. Production
+      // never injects liveBackgroundCount, so it gets the real freshness. An
+      // explicit override wins over both. (The CTL-736 reclaim death trigger reads
+      // local state.json, so the old snapshot-derived reclaim binding is gone.)
       livenessIsFresh:
         runningOpts.livenessIsFresh ??
         (runningOpts.liveBackgroundCount !== undefined ? () => true : () => getAgentsCached().isFresh),
@@ -2257,7 +2236,6 @@ export function startScheduler({
   // schedulerTick where it defaults to countBackgroundAgents (the live
   // `claude agents --json` count). Symmetric with the existing dispatch /
   // exec / writeStatus / teardownWorktree seams on schedulerTick.
-  livenessSnapshot, // CTL-731: optional override; runTick defaults to getAgentsCached.
   livenessIsFresh, // CTL-731: optional override; runTick defaults to getAgentsCached().isFresh.
   preflight = preflightWorkspaceLabels, // CTL-585
   tickIntervalMs = TICK_INTERVAL_MS,
@@ -2276,7 +2254,6 @@ export function startScheduler({
     configPath, // CTL-676: per-tick Layer-1 re-read source
     layer2Path, // CTL-678: per-tick Layer-2 re-read source (host-wide override)
     liveBackgroundCount, // CTL-676: test seam
-    livenessSnapshot, // CTL-731: optional override (default getAgentsCached in runTick)
     livenessIsFresh, // CTL-731: optional override (default getAgentsCached().isFresh)
   };
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -95,7 +95,7 @@ import * as linearWrite from "./linear-write.mjs";
 // a cycle. label-guard.mjs is the leaf module both can import.
 import { labelOnce } from "./label-guard.mjs";
 import { countReapOutcomes } from "./reaper-metrics.mjs";
-import { log, getEligibleDir, getEventLogPath, PER_TICK_REVIVE_CAP } from "./config.mjs";
+import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -1345,12 +1345,10 @@ export function schedulerTick(
     reclaimDeadWork = defaultReclaimDeadWork,
     now = Date.now, // CTL-624: injectable clock for the dispatch cool-down
     cache, // CTL-634: opt-in out-of-set blocker state cache
-    // CTL-735 — max revives per tick. The reclaim sweep threads the remaining
-    // budget (cap minus revives so far this tick) into reclaimDeadWork; once
-    // exhausted, further revivable workers are `revive-capped` (deferred). Bounds
-    // a fast loop so it cannot mass-revive ahead of the storm-breaker. Injectable
-    // for tests; defaults to the env-overridable config const.
-    perTickReviveCap = PER_TICK_REVIVE_CAP,
+    // CTL-736 Phase 3: the CTL-735 per-tick revive cap (perTickReviveCap /
+    // reviveBudgetRemaining) is DELETED. The progress gate + Phase-1 O_EXCL claim
+    // bound the mass-revive storm structurally, so the sweep no longer threads a
+    // per-tick budget into reclaimDeadWork.
     // CTL-665: the committed worker-slot concurrency knobs (maxParallel +
     // minParallel/maxParallelCeiling bounds), threaded from the daemon via
     // startScheduler → runningOpts → runTick. Empty {} preserves the legacy
@@ -1417,16 +1415,15 @@ export function schedulerTick(
   // marker; 'escalated' fires `needs-human` via the per-phase recovery path.
   const reclaimed = [];
   const revived = [];
+  // CTL-736: reviveSuppressed now marks ONLY the audit-append-failure path (the
+  // revive event could not be persisted, so the dispatch is skipped to preserve
+  // the attempt counter). The fleet-wide storm-breaker that used to populate it is
+  // deleted. The CTL-735 revivePending (grace window) + reviveCapped (per-tick cap)
+  // buckets are deleted with their mechanisms.
   const reviveSuppressed = [];
-  // CTL-735: workers deferred by the post-(re)dispatch grace window (absent but
-  // recently dispatched → not yet registered in `claude agents`). A high count
-  // here with low `revived` is the healthy steady state during the controlled
-  // daemon re-enable — it means the storm-causing re-revive race is suppressed.
-  const revivePending = [];
-  // CTL-735: workers deferred because this tick's per-tick revive cap was reached.
-  // A non-empty bucket means a real backlog is draining at the bounded rate (not a
-  // storm); it empties over subsequent ticks as the cap re-arms.
-  const reviveCapped = [];
+  // CTL-736 Phase 3: workers STOPPED for making zero forward progress (the futile
+  // idle-respawn loop) — flagged needs-human, never respawned.
+  const noProgressStopped = [];
   const escalated = [];
   // CTL-643: drop terminal tickets from the reclaim attention set.
   // reclaimDeadWorkIfPossible already short-circuits on terminal signals
@@ -1500,10 +1497,9 @@ export function schedulerTick(
       if (liveAgents) {
         reclaimOpts.liveness = (bgJobId) => livenessForBgJob(bgJobId, { agents: liveAgents });
       }
-      // CTL-735: remaining per-tick revive budget = cap minus revives already
-      // performed this tick. reclaimDeadWork returns "revive-capped" (deferred)
-      // once this is <= 0 instead of dispatching, so one sweep cannot mass-revive.
-      reclaimOpts.reviveBudgetRemaining = perTickReviveCap - revived.length;
+      // CTL-736 Phase 3: no per-tick revive budget is threaded — the progress gate
+      // (revive only while progressing; stop on zero progress) + the Phase-1 O_EXCL
+      // claim bound the mass-revive storm structurally.
       const r = reclaimDeadWork(orchDir, sig, reclaimOpts);
       const entry = { ticket: sig.ticket, phase: sig.phase };
       switch (r) {
@@ -1514,19 +1510,15 @@ export function schedulerTick(
           revived.push(entry);
           break;
         case "revive-suppressed":
+          // CTL-736: the revive event could not be persisted (audit-append failure)
+          // so the dispatch was skipped to preserve the attempt counter; retries
+          // next tick. (The fleet-wide storm-breaker that also used this is gone.)
           reviveSuppressed.push(entry);
           break;
-        case "revive-pending":
-          // CTL-735: absent worker still inside its post-dispatch grace window —
-          // deferred, not revived. Surfaced (not silent) so the controlled
-          // re-enable can confirm the storm-causing re-revive race is suppressed.
-          revivePending.push(entry);
-          break;
-        case "revive-capped":
-          // CTL-735: this tick's per-tick revive cap was reached — deferred to a
-          // later tick. Surfaced so the re-enable can confirm a backlog drains at
-          // the bounded rate rather than storming.
-          reviveCapped.push(entry);
+        case "no-progress-stopped":
+          // CTL-736 Phase 3: a dead worker that made zero forward progress was
+          // stopped + flagged needs-human, never respawned (the futile idle loop).
+          noProgressStopped.push(entry);
           break;
         case "escalated":
           escalated.push(entry);
@@ -2115,8 +2107,7 @@ export function schedulerTick(
     reclaimed,
     revived,
     reviveSuppressed,
-    revivePending,
-    reviveCapped,
+    noProgressStopped,
     escalated,
     advanced,
     dispatched,

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1446,33 +1446,19 @@ export function schedulerTick(
   // snapshot seam (test default) → legacy per-worker liveness, fresh-by-default.
   const liveSnapshot = livenessSnapshot ? livenessSnapshot() : null;
   // CTL-731: only bind the snapshot's agents into the reclaim liveness when it is
-  // POPULATED. A cold / never-populated snapshot returns agents:[] — binding that
-  // empty list would make EVERY live worker resolve to "absent" (agentForShortId
-  // over []) and trigger a mass false-revive on the first post-boot tick, before
-  // the async read has resolved. When unpopulated, leave liveAgents null; in
-  // production (a wired snapshot seam) reclaimColdSkip below then defers the whole
-  // sweep for that one cold tick, and the snapshot warms within a sub-second so
-  // later ticks reclaim against it. A null seam (tests) keeps the legacy
-  // per-worker real read. A populated-but-stale snapshot is fine for reclaim (≤ a
-  // few seconds old, same as the 5s TTL) — only NEW-work dispatch needs isFresh.
+  // POPULATED. Used ONLY by the non-default `snapshot`/`shadow` LIVENESS_SOURCE
+  // escape-hatch modes (see recovery.mjs reclaimDeadWorkIfPossible); the default
+  // `state-json` death trigger reads each worker's local state.json and never
+  // consults this list. A populated-but-stale snapshot is fine for reclaim
+  // (≤ a few seconds old, same as the 5s TTL) — only NEW-work dispatch needs isFresh.
   const liveAgents = liveSnapshot && liveSnapshot.populated ? liveSnapshot.agents : null;
 
-  // CTL-731: when a snapshot seam is wired (production) but the snapshot is still
-  // COLD (never-populated — the first post-boot tick, before the async read
-  // resolves), SKIP the reclaim sweep this tick rather than fall back to a
-  // per-worker SYNC `claude agents` read for EVERY in-flight worker. Under heavy
-  // session load that fan-out of synchronous spawns re-starves the loop (the very
-  // failure mode Phase 00 removed) and would wedge the boot tick. The snapshot
-  // warms within a sub-second async refresh (getAgentsCached already fired one);
-  // the next tick reclaims against the shared warm list. A null seam (tests) keeps
-  // the legacy per-worker reclaim path.
-  const reclaimColdSkip = Boolean(livenessSnapshot) && !liveAgents;
-  if (reclaimColdSkip) {
-    log.info(
-      {},
-      "scheduler: reclaim sweep skipped — liveness snapshot cold, awaiting warm read (CTL-731)",
-    );
-  }
+  // CTL-736 Phase 2: the CTL-731 reclaimColdSkip (skip the whole reclaim sweep on
+  // a cold snapshot) is DELETED. It existed because the cold `claude agents`
+  // snapshot would resolve every worker to "absent" and mass-false-revive. The
+  // default state-json death trigger reads a LOCAL per-worker state.json — there
+  // is no cold/warm distinction and no per-worker `claude agents` fan-out to
+  // guard against, so the sweep runs every tick.
 
   // CTL-702: scan worker dirs for yield tombstones. Emit once per unique
   // absolute path per daemon lifetime (deduped via observedYieldFiles).
@@ -1494,7 +1480,6 @@ export function schedulerTick(
   }
 
   for (const sig of readWorkerSignals(orchDir)) {
-    if (reclaimColdSkip) break; // CTL-731: cold snapshot — defer reclaim to the next (warm) tick
     if (!inFlightTickets.has(sig.ticket)) continue;
     // CTL-705: a parked ("preempted") worker is paused, not dead. Its signal
     // preserves the now-killed bg_job_id, so classifyWorker would route it

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1487,16 +1487,15 @@ describe("schedulerTick — new-work pull", () => {
     expect(r.dispatched).toEqual(["CTL-9"]);
   });
 
-  // CTL-731: a COLD/never-populated snapshot with a WIRED seam (production) must
-  // SKIP the whole reclaim sweep for that one boot tick (reclaimColdSkip) — NOT
-  // bind its empty agents list (which would resolve every live worker to "absent"
-  // and mass-false-revive) AND not fall back to a per-worker SYNC `claude agents`
-  // read for every worker (N synchronous spawns that re-starve the loop, the very
-  // failure mode Phase 00 removed). The snapshot warms within a sub-second; the
-  // next (warm) tick reclaims against the shared list.
-  test("a cold liveness snapshot SKIPS the reclaim sweep (no boot mass-false-revive, no per-worker re-starve)", () => {
+  // CTL-736 Phase 2: the CTL-731 reclaimColdSkip is DELETED. A cold/never-populated
+  // snapshot no longer skips the reclaim sweep — the default state-json death
+  // trigger reads each worker's LOCAL state.json (no `claude agents` snapshot, no
+  // per-worker fan-out, no cold/warm distinction). The sweep runs every tick; a
+  // cold snapshot simply leaves liveAgents null so no snapshot liveness is bound
+  // (the escape-hatch snapshot/shadow modes fall back to their own reader).
+  test("a cold liveness snapshot no longer skips the reclaim sweep (state.json trigger needs no warm snapshot)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
-    writeSignal("CTL-1", "implement", "running"); // an in-flight worker the sweep would visit
+    writeSignal("CTL-1", "implement", "running"); // an in-flight worker the sweep visits
     const reclaimOpts = [];
     const reclaimDeadWork = (_orchDir, _sig, opts) => {
       reclaimOpts.push(opts);
@@ -1510,8 +1509,9 @@ describe("schedulerTick — new-work pull", () => {
       livenessSnapshot: () => ({ populated: false, agents: [], isFresh: false }),
       livenessIsFresh: () => false,
     });
-    // cold + wired seam → the entire sweep is deferred; reclaimDeadWork never runs
-    expect(reclaimOpts.length).toBe(0);
+    // cold snapshot → sweep STILL runs (CTL-1 visited); no snapshot liveness bound.
+    expect(reclaimOpts.length).toBe(1);
+    expect(reclaimOpts[0].liveness).toBeUndefined();
   });
 
   // The skip is gated on a WIRED seam: a null livenessSnapshot (legacy/test

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1058,6 +1058,24 @@ describe("CTL-653: maybeResetForRemediateCycle", () => {
     expect(existsSync(join(wdir, "remediate.claim.1"))).toBe(false);
     expect(existsSync(join(wdir, "implement.claim.1"))).toBe(true);
   });
+  test("CTL-736: clears the cycle members' .progress-<phase> high-water markers (fresh verify/remediate not false-STOPPED)", () => {
+    writeSignal("CTL-736P", "implement", "done");
+    writeSignal("CTL-736P", "verify", "done");
+    writeSignal("CTL-736P", "remediate", "done");
+    const wdir = join(orchDir, "workers", "CTL-736P");
+    // leftover progress high-waters from the prior cycle's verify + remediate…
+    writeFileSync(join(wdir, ".progress-verify"), "120");
+    writeFileSync(join(wdir, ".progress-remediate"), "3");
+    // …and an UNRELATED phase's progress marker, which must survive.
+    writeFileSync(join(wdir, ".progress-implement"), "4");
+
+    expect(maybeResetForRemediateCycle(orchDir, "CTL-736P")).toBe(true);
+    // cycle-member progress markers cleared → the fresh verify/remediate attempt
+    // is measured from zero, not false-STOPPED by the prior cycle's high-water.
+    expect(existsSync(join(wdir, ".progress-verify"))).toBe(false);
+    expect(existsSync(join(wdir, ".progress-remediate"))).toBe(false);
+    expect(existsSync(join(wdir, ".progress-implement"))).toBe(true);
+  });
   test("remediate not done → no-op, returns false (cycle signals untouched)", () => {
     writeSignal("CTL-653", "verify", "done");
     writeSignal("CTL-653", "remediate", "running");
@@ -1487,79 +1505,40 @@ describe("schedulerTick — new-work pull", () => {
     expect(r.dispatched).toEqual(["CTL-9"]);
   });
 
-  // CTL-736 Phase 2: the CTL-731 reclaimColdSkip is DELETED. A cold/never-populated
-  // snapshot no longer skips the reclaim sweep — the default state-json death
-  // trigger reads each worker's LOCAL state.json (no `claude agents` snapshot, no
-  // per-worker fan-out, no cold/warm distinction). The sweep runs every tick; a
-  // cold snapshot simply leaves liveAgents null so no snapshot liveness is bound
-  // (the escape-hatch snapshot/shadow modes fall back to their own reader).
-  test("a cold liveness snapshot no longer skips the reclaim sweep (state.json trigger needs no warm snapshot)", () => {
-    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
-    writeSignal("CTL-1", "implement", "running"); // an in-flight worker the sweep visits
-    const reclaimOpts = [];
-    const reclaimDeadWork = (_orchDir, _sig, opts) => {
-      reclaimOpts.push(opts);
-      return "noop";
-    };
-    schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: fakeDispatch(),
-      reclaimDeadWork,
-      liveBackgroundCount: () => 1,
-      livenessSnapshot: () => ({ populated: false, agents: [], isFresh: false }),
-      livenessIsFresh: () => false,
+  // CTL-736: the reclaim death trigger is the LOCAL state.json lifecycle, so the
+  // sweep no longer reads the `claude agents` snapshot nor binds a per-worker
+  // liveness — the CTL-731 reclaimColdSkip + snapshot-binding are both deleted.
+  // The sweep runs every tick (no cold/warm distinction) and NEVER passes a
+  // `liveness` reclaim option, regardless of snapshot state.
+  for (const [label, livenessSnapshot, livenessIsFresh] of [
+    ["cold/unpopulated snapshot", () => ({ populated: false, agents: [], isFresh: false }), () => false],
+    ["null snapshot seam (legacy/test)", null, () => false],
+    [
+      "populated snapshot",
+      () => ({ populated: true, agents: [{ sessionId: "1111-2222", kind: "background", status: "idle" }], isFresh: true }),
+      () => true,
+    ],
+  ]) {
+    test(`reclaim sweep runs and binds NO snapshot liveness — ${label}`, () => {
+      writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+      writeSignal("CTL-1", "implement", "running"); // an in-flight worker the sweep visits
+      const reclaimOpts = [];
+      const reclaimDeadWork = (_orchDir, _sig, opts) => {
+        reclaimOpts.push(opts);
+        return "noop";
+      };
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: fakeDispatch(),
+        reclaimDeadWork,
+        liveBackgroundCount: () => 1,
+        livenessSnapshot,
+        livenessIsFresh,
+      });
+      expect(reclaimOpts.length).toBe(1); // sweep runs every tick
+      expect(reclaimOpts[0].liveness).toBeUndefined(); // state.json trigger — no snapshot binding
     });
-    // cold snapshot → sweep STILL runs (CTL-1 visited); no snapshot liveness bound.
-    expect(reclaimOpts.length).toBe(1);
-    expect(reclaimOpts[0].liveness).toBeUndefined();
-  });
-
-  // The skip is gated on a WIRED seam: a null livenessSnapshot (legacy/test
-  // harnesses) keeps the per-worker reclaim path so those callers are unaffected.
-  test("a null liveness seam still runs the per-worker reclaim sweep (reclaimColdSkip off)", () => {
-    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
-    writeSignal("CTL-1", "implement", "running");
-    const reclaimOpts = [];
-    const reclaimDeadWork = (_orchDir, _sig, opts) => {
-      reclaimOpts.push(opts);
-      return "noop";
-    };
-    schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: fakeDispatch(),
-      reclaimDeadWork,
-      liveBackgroundCount: () => 1,
-      livenessSnapshot: null, // no seam → reclaimColdSkip is false
-      livenessIsFresh: () => false,
-    });
-    expect(reclaimOpts.length).toBeGreaterThan(0);
-    expect(reclaimOpts.every((o) => o.liveness === undefined)).toBe(true);
-  });
-
-  test("a populated liveness snapshot binds the shared agents into reclaim liveness", () => {
-    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
-    writeSignal("CTL-1", "implement", "running");
-    const reclaimOpts = [];
-    const reclaimDeadWork = (_orchDir, _sig, opts) => {
-      reclaimOpts.push(opts);
-      return "noop";
-    };
-    schedulerTick(orchDir, {
-      readEligible: () => [],
-      dispatch: fakeDispatch(),
-      reclaimDeadWork,
-      liveBackgroundCount: () => 1,
-      livenessSnapshot: () => ({
-        populated: true,
-        agents: [{ sessionId: "1111-2222", kind: "background", status: "idle" }],
-        isFresh: true,
-      }),
-      livenessIsFresh: () => true,
-    });
-    expect(reclaimOpts.length).toBeGreaterThan(0);
-    // populated → reclaim receives the bound shared-snapshot liveness fn
-    expect(reclaimOpts.every((o) => typeof o.liveness === "function")).toBe(true);
-  });
+  }
 });
 
 // ── CTL-706: per-project cap + reserve wired into schedulerTick ──

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -356,3 +356,67 @@ export const WORK_DONE_PROBE_DESCRIPTIONS = {
 export function describeProbe(phase) {
   return WORK_DONE_PROBE_DESCRIPTIONS[phase] ?? "unknown";
 }
+
+// CTL-736 Phase 3: per-phase worker-dir JSON artifact whose byte-size measures
+// forward progress (a growing artifact = progress, even before it is "done").
+const PROGRESS_ARTIFACT = {
+  triage: "triage.json",
+  verify: "verify.json",
+  review: "review.json",
+  "monitor-deploy": "phase-monitor-deploy.json",
+  pr: "phase-pr.json",
+  "monitor-merge": "phase-monitor-merge.json",
+};
+
+// defaultProgressMark — CTL-736 Phase 3's forward-progress quantity for the
+// reclaim path. Unlike the boolean work-done probes, this returns a MONOTONIC-ish
+// non-negative integer so the reclaim path can tell progressed-then-died (revive)
+// from zero-progress (stop, never respawn): code phases (implement/remediate) →
+// commits-ahead-of-origin/main count; doc phases (research/plan) → matching
+// markdown byte size; JSON worker-dir phases → artifact byte size. 0 on any miss
+// (no worktree, no artifact, git failure) — the safe "no progress observed"
+// default. Pure given the injected seams; never throws.
+export function defaultProgressMark(
+  { ticket, phase, repoRoot, orchDir } = {},
+  {
+    runGit = defaultRunGit,
+    listArtifacts = defaultListArtifacts,
+    readArtifact = defaultReadArtifact,
+    readFile = defaultReadFile,
+  } = {},
+) {
+  if (!ticket) return 0;
+
+  // Code phases: commits ahead of origin/main on the ticket worktree.
+  if (phase === "implement" || phase === "remediate") {
+    const worktreePath = resolveWorktree({ ticket, repoRoot }, { runGit });
+    if (!worktreePath) return 0;
+    const ahead = runGit(["-C", worktreePath, "rev-list", "--count", "origin/main..HEAD"]);
+    if (ahead.code !== 0) return 0;
+    return Math.max(0, Number(ahead.stdout.trim()) || 0);
+  }
+
+  // Worktree markdown artifacts: research/plan → byte size of the matching doc.
+  if (phase === "research" || phase === "plan") {
+    const worktreePath = resolveWorktree({ ticket, repoRoot }, { runGit });
+    if (!worktreePath) return 0;
+    const subdir = phase === "research" ? "thoughts/shared/research" : "thoughts/shared/plans";
+    let files;
+    try {
+      files = listArtifacts(`${worktreePath}/${subdir}`);
+    } catch {
+      return 0;
+    }
+    const match = (Array.isArray(files) ? files : []).find((f) => matchesTicket(f, ticket));
+    if (!match) return 0;
+    return (readArtifact(`${worktreePath}/${subdir}/${match}`) || "").length;
+  }
+
+  // JSON worker-dir phases (triage/verify/review/pr/monitor-*): artifact byte size.
+  const name = PROGRESS_ARTIFACT[phase];
+  if (name && orchDir) {
+    const { ok, content } = readFile(workerArtifact(orchDir, ticket, name));
+    return ok ? content.length : 0;
+  }
+  return 0;
+}

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -11,6 +11,7 @@ import {
   readVerifyVerdict,
   describeProbe,
   WORK_DONE_PROBE_DESCRIPTIONS,
+  defaultProgressMark,
 } from "./work-done-probes.mjs";
 
 // makeRunGit — a deterministic `git` fake keyed on the trailing positional args.
@@ -744,5 +745,86 @@ describe("CTL-664: probe descriptions", () => {
 
   test("describeProbe returns a safe fallback for an unknown phase", () => {
     expect(describeProbe("nonexistent")).toBe("unknown");
+  });
+});
+
+// --- CTL-736 Phase 3: defaultProgressMark (forward-progress quantity) ---------
+
+describe("defaultProgressMark (CTL-736 Phase 3)", () => {
+  const WT = "/wt/CTL-9";
+
+  test("returns 0 when no ticket is supplied", () => {
+    expect(defaultProgressMark({ phase: "implement" })).toBe(0);
+  });
+
+  test("implement/remediate → commits-ahead count of origin/main", () => {
+    const runGit = makeRunGit({
+      "worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-9", WT), stderr: "" },
+      "rev-list --count origin/main..HEAD": { code: 0, stdout: "3\n", stderr: "" },
+    });
+    expect(defaultProgressMark({ ticket: "CTL-9", phase: "implement", repoRoot: "/repo" }, { runGit })).toBe(3);
+    expect(defaultProgressMark({ ticket: "CTL-9", phase: "remediate", repoRoot: "/repo" }, { runGit })).toBe(3);
+  });
+
+  test("implement → 0 when the worktree does not resolve (no progress observable)", () => {
+    const runGit = makeRunGit({
+      "worktree list --porcelain": { code: 0, stdout: porcelainFor("OTHER", WT), stderr: "" },
+    });
+    expect(defaultProgressMark({ ticket: "CTL-9", phase: "implement", repoRoot: "/repo" }, { runGit })).toBe(0);
+  });
+
+  test("implement → 0 when the rev-list git call fails (safe default)", () => {
+    const runGit = makeRunGit({
+      "worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-9", WT), stderr: "" },
+      "rev-list --count origin/main..HEAD": { code: 128, stdout: "", stderr: "bad ref" },
+    });
+    expect(defaultProgressMark({ ticket: "CTL-9", phase: "implement", repoRoot: "/repo" }, { runGit })).toBe(0);
+  });
+
+  test("research/plan → byte size of the matching markdown artifact (grows = progress)", () => {
+    const runGit = makeRunGit({
+      "worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-9", WT), stderr: "" },
+    });
+    const listArtifacts = makeListArtifacts({
+      "thoughts/shared/research": ["2026-05-30-ctl-9.md"],
+      "thoughts/shared/plans": ["2026-05-30-ctl-9.md"],
+    });
+    const readArtifact = makeReadArtifact({ "ctl-9.md": "x".repeat(742) });
+    expect(
+      defaultProgressMark({ ticket: "CTL-9", phase: "research", repoRoot: "/repo" }, { runGit, listArtifacts, readArtifact }),
+    ).toBe(742);
+    expect(
+      defaultProgressMark({ ticket: "CTL-9", phase: "plan", repoRoot: "/repo" }, { runGit, listArtifacts, readArtifact }),
+    ).toBe(742);
+  });
+
+  test("research → 0 when no matching artifact exists", () => {
+    const runGit = makeRunGit({
+      "worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-9", WT), stderr: "" },
+    });
+    const listArtifacts = makeListArtifacts({ "thoughts/shared/research": ["unrelated.md"] });
+    expect(
+      defaultProgressMark({ ticket: "CTL-9", phase: "research", repoRoot: "/repo" }, { runGit, listArtifacts }),
+    ).toBe(0);
+  });
+
+  test("JSON worker-dir phases (verify/triage/review) → artifact byte size", () => {
+    const body = JSON.stringify({ regression_risk: 3, findings: [] });
+    const readFile = (p) =>
+      p.endsWith("/workers/CTL-9/verify.json") ? { ok: true, content: body } : { ok: false, content: "" };
+    expect(
+      defaultProgressMark({ ticket: "CTL-9", phase: "verify", orchDir: "/orch" }, { readFile }),
+    ).toBe(body.length);
+  });
+
+  test("JSON worker-dir phase → 0 when the artifact is absent", () => {
+    const readFile = () => ({ ok: false, content: "" });
+    expect(
+      defaultProgressMark({ ticket: "CTL-9", phase: "triage", orchDir: "/orch" }, { readFile }),
+    ).toBe(0);
+  });
+
+  test("an unknown phase → 0 (no progress signal)", () => {
+    expect(defaultProgressMark({ ticket: "CTL-9", phase: "mystery", orchDir: "/orch" })).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Completes **CTL-736** (Phases 2 & 3) — the second half of retiring the
execution-core revive-storm guard stack. Phase 1 (the `O_EXCL` atomic claim +
fencing generation) merged earlier (#1235/#1237) and was live-validated. This PR
replaces the ~14 heuristic "is this worker dead?" guards with **two more
deterministic primitives**, so the whole stack collapses to three:

1. **(Phase 1, merged)** atomic claim + fencing generation → no duplicate spawn.
2. **(Phase 2, here)** `state.json` lifecycle death trigger → deterministic, local, fan-out-safe death decision.
3. **(Phase 3, here)** progress probe → alive-but-no-progress STOPs + flags, never the futile respawn.

Source is roughly LOC-neutral (`+470 −437`, net +33) — the three primitives add
~33 lines while deleting the logic of ~14 guards; the test files are net-negative
(deleted whole busy/idle/grace/budget/storm/per-tick blocks).

## Phase 2 — `state.json` lifecycle death trigger (`4e82637b`)

- `jobLifecycle(bgJobId, {statJob})` → `alive` | `dead-terminal` | `dead-gone`,
  reading `~/.claude/jobs/<id>/state.json` instead of the eventually-consistent
  `claude agents` snapshot. `working` is **alive even with arbitrarily stale
  mtime** (the CTL-662 sub-agent-fan-out killer); a terminal `.state` /
  `firstTerminalAt` is definitively dead; a missing job dir is `dead-gone`.
- `defaultStatJob` now surfaces `firstTerminalAt`; `classifyWorker` consults
  `.state` (no longer treats a never-cleaned-up job dir as `running`).
- **Deleted:** `IDLE_CONFIRM_TICKS` + idle-streak markers, `REVIVE_GRACE_MS` grace
  window (recovery.mjs), `reclaimColdSkip` (scheduler.mjs) — all artifacts of the
  snapshot's eventual-consistency lag, which the local `state.json` doesn't have.

## Phase 3 — progress probe (`0248418e`)

- `progressMark(ticket, phase, {repoRoot, orchDir})` = commits-ahead (code phases)
  / artifact byte-size (doc/JSON phases), persisted as a per-(ticket,phase)
  high-water at `workers/<ticket>/.progress-<phase>`.
- On a confirmed dead worker with work-not-done: **progressed since last attempt
  → revive (gen+1)**; **zero progress → `escalateOnce("no-progress")` +
  `no-progress-stopped`, never respawn** — kills the CTL-728/729 futile
  idle-respawn loop.
- **Deleted:** `MAX_REVIVES` budget, the fleet-wide storm-breaker
  (`STORM_THRESHOLD`), `PER_TICK_REVIVE_CAP` + the scheduler's
  `reviveBudgetRemaining` threading and `revivePending`/`reviveCapped` buckets.
- **Kept (intentionally, not in the plan's delete list):** `REVIVE_MAX_AGE_MS` /
  inert-stale (runs *before* the progress gate so the ~85 day-stale debris dirs
  stay inert rather than each getting a needs-human flag), and `BUSY_CEILING_MS`
  (the alive-worker no-committed-work backstop).

## Review fixes (`c24d36f0`)

A multi-agent adversarial review of the diff confirmed 12 findings. The cluster
all lived in a `LIVENESS_SOURCE` `snapshot`/`shadow` rollback knob the first draft
added — those modes re-broke on the very idle-streak/grace/cold-skip machinery
this work deletes (idle-reclaim, mismatch-log flood, cold-snapshot per-worker
`claude agents` starvation). A degraded rollback that misfires in the exact
incident it'd be used for is a footgun, so:

- **Removed the `snapshot`/`shadow` modes + `LIVENESS_SOURCE` entirely** —
  `state.json` is the single hardcoded trigger; the real rollback is reverting
  this change. (Also drops the per-worker snapshot→liveness binding + cold-skip
  from the scheduler, removing the starvation vector.)
- **Clear `.progress-<phase>` markers at daemon boot + in the verify⇄remediate
  reset**, so a stale high-water from a prior run/cycle can't false-STOP a fresh
  attempt's first death.
- Route the no-progress reap through the valid `phase.terminal.reap-requested`
  vocabulary (the bespoke type threw + was swallowed); scheduler-switch hygiene
  (dead `alive-quiet-suppressed` case removed, explicit `rate-limited-deferred`
  case added, stale comments corrected).
- +3 coverage tests: a multi-tick progress-gate STOP integration test,
  `clearProgressMarks` units, a remediate-cycle progress-reset test.

## Testing

`cd plugins/dev/scripts/execution-core && bun test` → **1514 pass / 1 fail**. The
lone failure is the pre-existing `cli/sessions classifyRow` red on `main`
(byte-identical to origin/main, untouched here). The `daemon.test.mjs`
fs.watch-debounce reconcile test is a known load-flake (passes in isolation).

## ⚠️ Merge / deploy gating

Per the CTL-736 supervised-validation protocol, **merging this is a release →
cache → live production daemon change** (the registry enrolls the ADV production
repo). It should land only via a supervised, constrained daemon re-enable (mirror
the Phase-1 recipe: neutralize boot-resume, drop ADV from the registry, one
throwaway CTL ticket, kill-switch ready). Do **not** auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)