### PR TITLE
CTL-748: Disable per-phase turn caps; track tokens/$/turns per phase instead

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh
@@ -218,6 +218,18 @@ NOREPO_HAS="$(printf '%s' "$NOREPO_LINE" | jq -r '.attributes | has("vcs.reposit
 expect_eq "session.phase omits vcs.repository.name when \$REPO unset" \
   "false" "$NOREPO_HAS"
 
+# ─── 13. CTL-748: metric --turns persists num_turns to session_metrics ───────
+SID_TURNS="$(bash "$SESSION_SCRIPT" start --skill phase-research)"
+expect_not_empty "start returns id for turns test" "$SID_TURNS"
+
+bash "$SESSION_SCRIPT" metric "$SID_TURNS" \
+  --cost 0.25 --input 1000 --output 500 \
+  --cache-read 0 --cache-creation 0 --duration-ms 10000 --turns 12
+
+STORED_TURNS="$(sqlite3 "$CATALYST_DB_FILE" \
+  "SELECT num_turns FROM session_metrics WHERE session_id = '${SID_TURNS}';")"
+expect_eq "metric --turns writes num_turns to DB" "12" "$STORED_TURNS"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
 exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/emit-otel-event.test.sh
+++ b/plugins/dev/scripts/__tests__/emit-otel-event.test.sh
@@ -288,6 +288,29 @@ else
   fail "expected non-zero exit on outcome=bogus"
 fi
 
+# ─── Test 11: CTL-748 — --phase flag adds phase attribute to log record ─────
+echo ""
+echo "--- Test 11: --phase flag adds phase attribute to log record ---"
+STUB_DIR_11="$SCRATCH/stub11"
+setup_curl_stub "$STUB_DIR_11"
+export PATH="$STUB_DIR_11:$PATH"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://x:4317"
+export CURL_STUB_ARGS="$SCRATCH/args11"
+export CURL_STUB_BODY="$SCRATCH/body11"
+
+"$EMIT_SCRIPT" \
+  --event "claude_code.session.outcome" \
+  --outcome success \
+  --session-id "sess_phase_test" \
+  --phase "research" \
+  >/dev/null 2>&1
+
+BODY_11=$(cat "$SCRATCH/body11" 2>/dev/null || echo "{}")
+PHASE_ATTR=$(echo "$BODY_11" | jq -r '
+  .resourceLogs[0].scopeLogs[0].logRecords[0].attributes[]
+  | select(.key == "phase") | .value.stringValue // ""')
+assert_eq "research" "$PHASE_ATTR" "--phase adds phase attribute to log record"
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh
@@ -394,6 +394,7 @@ CREATE TABLE session_metrics (
   cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
   cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
   duration_ms           INTEGER NOT NULL DEFAULT 0,
+  num_turns             INTEGER NOT NULL DEFAULT 0,
   updated_at            TEXT NOT NULL,
   plan_iterations       INTEGER NOT NULL DEFAULT 0,
   fix_iterations        INTEGER NOT NULL DEFAULT 0
@@ -814,6 +815,26 @@ run "phase: unknown-model signal.cost.outputTokens == 567" \
 # Reset env so subsequent (none here) tests don't inherit the override.
 unset CATALYST_DB_FILE
 unset CATALYST_BG_JOBS_DIR
+
+# ─── Test 31: CTL-748 — numTurns flows through to session_metrics.num_turns ──
+# Uses the legacy stream path (build_stream_with_result) which embeds
+# num_turns=12 in the result event. After roll-usage the DB row must show 12.
+ORCH_DIR=$(setup_orch "orch-t31")
+CATALYST_DB="${CATALYST_DIR}/catalyst.db"
+export CATALYST_DB_FILE="$CATALYST_DB"
+init_test_db
+SID_31="sess_t31_dddd"
+seed_session "$SID_31" "T-31"
+build_stream_with_result "${ORCH_DIR}/workers/output/T-31-stream.jsonl" \
+  "0.50" "500" "250" "100" "50" "12" "30000" "15000"
+build_signal_with_sid "${ORCH_DIR}/workers/T-31.json" "T-31" "$SID_31"
+
+"$HELPER" --orch "orch-t31" --ticket "T-31" --orch-dir "$ORCH_DIR"
+
+run "CTL-748: num_turns=12 persisted to session_metrics" \
+  bash -c "[ \"\$(sqlite3 '$CATALYST_DB' \"SELECT num_turns FROM session_metrics WHERE session_id='${SID_31}';\")\" = '12' ]"
+
+unset CATALYST_DB_FILE
 
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-goal-no-turn-caps.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-goal-no-turn-caps.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Regression guard: no phase skill /goal block may contain self-stop
+# turn-cap language after CTL-748.
+#
+# Run: bash plugins/dev/scripts/__tests__/phase-goal-no-turn-caps.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+SKILLS=(
+  "plugins/dev/skills/phase-triage/SKILL.md"
+  "plugins/dev/skills/phase-research/SKILL.md"
+  "plugins/dev/skills/phase-plan/SKILL.md"
+  "plugins/dev/skills/phase-implement/SKILL.md"
+  "plugins/dev/skills/phase-verify/SKILL.md"
+  "plugins/dev/skills/phase-review/SKILL.md"
+  "plugins/dev/skills/phase-pr/SKILL.md"
+  "plugins/dev/skills/phase-monitor-merge/SKILL.md"
+  "plugins/dev/skills/phase-remediate/SKILL.md"
+)
+
+FAILURES=0; PASSES=0
+
+for rel in "${SKILLS[@]}"; do
+  f="${REPO_ROOT}/${rel}"
+  if grep -q "OR I have stopped after\|OR I am within.*turn.*cap\|OR I am within.*turns\|stopped after.*turns" "$f" 2>/dev/null; then
+    echo "  FAIL: $rel still contains turn-cap self-stop language"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "  PASS: $rel — no turn-cap self-stop language"
+    PASSES=$((PASSES + 1))
+  fi
+done
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-implement-e2e.test.sh
@@ -393,21 +393,24 @@ else
   fail "claude stub captured no invocation"
 fi
 
-# ─── Test 9 (CTL-484): phase-implement turn-cap handoff write + new emit shape
+# ─── Test 9 (CTL-748): phase-implement keeps daemon-resume orientation but
+#     no longer self-writes a turn-cap handoff or self-emits turn-cap-exhausted.
 echo ""
-echo "Test 9 (CTL-484): phase-implement SKILL.md has continuation preamble + handoff write block"
+echo "Test 9 (CTL-748): phase-implement SKILL.md keeps continuation Prelude, drops self-stop handoff write"
 if [[ -f "$SKILL_IMPLEMENT" ]]; then
-  # Prelude check for CATALYST_IS_CONTINUATION — the resumed worker reads
-  # CATALYST_HANDOFF_PATH and orients without re-walking the plan.
+  # Prelude still orients a daemon-resumed continuation worker: it reads
+  # CATALYST_IS_CONTINUATION / CATALYST_HANDOFF_PATH so a --resume session
+  # picks up where the previous one left off (CTL-613 daemon-side resume).
   assert_grep 'CATALYST_IS_CONTINUATION' "$SKILL_IMPLEMENT" "Prelude checks CATALYST_IS_CONTINUATION env var"
   assert_grep 'CATALYST_HANDOFF_PATH'    "$SKILL_IMPLEMENT" "Prelude reads CATALYST_HANDOFF_PATH"
-  # Failure block has a turn-cap branch that writes a handoff and emits
-  # --status turn-cap-exhausted --handoff-path <path>.
-  assert_grep 'turn-cap-exhausted' "$SKILL_IMPLEMENT" "skill body references turn-cap-exhausted status"
-  assert_grep 'turn-cap-continuation\.md|turn-cap-continuation' "$SKILL_IMPLEMENT" "writes handoff named turn-cap-continuation.md"
-  assert_grep '\-\-handoff-path' "$SKILL_IMPLEMENT" "passes --handoff-path to phase-agent-emit-complete"
-  # /goal block updated to describe the new cap-exit behavior.
-  assert_grep 'turn-cap-exhausted|continuation' "$SKILL_IMPLEMENT" "/goal block references turn-cap-exhausted or continuation"
+  # CTL-748 removed the skill-side self-stop machinery: the failure block no
+  # longer writes a turn-cap-continuation handoff or self-emits
+  # turn-cap-exhausted. The turn cap is now enforced daemon-side.
+  assert_not_grep 'turn-cap-exhausted' "$SKILL_IMPLEMENT" "skill body no longer self-emits turn-cap-exhausted"
+  assert_not_grep 'turn-cap-continuation' "$SKILL_IMPLEMENT" "skill body no longer writes a turn-cap-continuation handoff"
+  assert_not_grep '[-][-]handoff-path' "$SKILL_IMPLEMENT" "skill body no longer passes --handoff-path"
+  # /goal block no longer carries turn-cap self-stop language (CTL-748).
+  assert_not_grep 'OR I have stopped after .*turn' "$SKILL_IMPLEMENT" "/goal block has no turn-cap self-stop clause"
 fi
 
 # Test 10 (CTL-484): the new emitter status round-trips through the canonical

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -362,8 +362,8 @@ cmd_phase() {
 
 # Metric keys expose a stable CLI surface; internal column names live in METRIC_MAP.
 # declare -A is bash 4+; macOS still ships bash 3.2, so use parallel arrays instead.
-METRIC_FLAGS=(--cost --input --output --cache-read --cache-creation --duration-ms)
-METRIC_COLS=(cost_usd input_tokens output_tokens cache_read_tokens cache_creation_tokens duration_ms)
+METRIC_FLAGS=(--cost --input --output --cache-read --cache-creation --duration-ms --turns)
+METRIC_COLS=(cost_usd input_tokens output_tokens cache_read_tokens cache_creation_tokens duration_ms num_turns)
 
 metric_col_for_flag() {
   local flag="$1" i

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -573,12 +573,16 @@ cmd_end() {
       done)   outcome="success" ;;
       failed) outcome="fail" ;;
     esac
+    local skill_name phase_name=""
+    skill_name=$(db_exec "SELECT COALESCE(skill_name,'') FROM sessions WHERE session_id = $(sql_quote "$sid");")
+    [[ "$skill_name" == phase-* ]] && phase_name="${skill_name#phase-}"
     local args=(
       --event "claude_code.session.outcome"
       --outcome "$outcome"
       --session-id "$sid"
     )
-    [[ -n "$reason" ]] && args+=(--reason "$reason")
+    [[ -n "$reason" ]]     && args+=(--reason "$reason")
+    [[ -n "$phase_name" ]] && args+=(--phase "$phase_name")
     "$emit_bin" "${args[@]}" >/dev/null 2>&1 || true
   fi
 
@@ -591,14 +595,18 @@ emit_iteration_metric() {
   local emit="${CATALYST_EMIT_METRIC:-$SCRIPT_DIR/emit-otel-metric.sh}"
   [[ -x "$emit" ]] || return 0
 
-  local plan_count fix_count ticket started_at
+  local plan_count fix_count ticket started_at skill_name
   plan_count=$(db_exec "SELECT COALESCE(plan_iterations,0) FROM session_metrics WHERE session_id = $(sql_quote "$sid");")
   fix_count=$( db_exec "SELECT COALESCE(fix_iterations,0)  FROM session_metrics WHERE session_id = $(sql_quote "$sid");")
   ticket=$(    db_exec "SELECT COALESCE(ticket_key,'')     FROM sessions        WHERE session_id = $(sql_quote "$sid");")
   started_at=$(db_exec "SELECT started_at                  FROM sessions        WHERE session_id = $(sql_quote "$sid");")
+  skill_name=$(db_exec "SELECT COALESCE(skill_name,'')     FROM sessions        WHERE session_id = $(sql_quote "$sid");")
 
   plan_count="${plan_count:-0}"
   fix_count="${fix_count:-0}"
+
+  local phase_name=""
+  [[ "$skill_name" == phase-* ]] && phase_name="${skill_name#phase-}"
 
   local start_s=""
   if [[ -n "$started_at" ]]; then
@@ -609,8 +617,10 @@ emit_iteration_metric() {
   local start_ns=""
   [[ -n "$start_s" ]] && start_ns="${start_s}000000000"
 
-  "$emit" iteration_count --kind plan --count "$plan_count" --linear-key "$ticket" ${start_ns:+--start-ns "$start_ns"} 2>/dev/null || true
-  "$emit" iteration_count --kind fix  --count "$fix_count"  --linear-key "$ticket" ${start_ns:+--start-ns "$start_ns"} 2>/dev/null || true
+  "$emit" iteration_count --kind plan --count "$plan_count" --linear-key "$ticket" \
+    ${start_ns:+--start-ns "$start_ns"} ${phase_name:+--phase "$phase_name"} 2>/dev/null || true
+  "$emit" iteration_count --kind fix  --count "$fix_count"  --linear-key "$ticket" \
+    ${start_ns:+--start-ns "$start_ns"} ${phase_name:+--phase "$phase_name"} 2>/dev/null || true
 }
 
 cmd_heartbeat() {

--- a/plugins/dev/scripts/db-migrations/006_num_turns.sql
+++ b/plugins/dev/scripts/db-migrations/006_num_turns.sql
@@ -1,0 +1,3 @@
+-- CTL-748: add num_turns to session_metrics so orchestrate-roll-usage.sh
+-- can persist the per-phase turn count alongside cost/token columns.
+ALTER TABLE session_metrics ADD COLUMN num_turns INTEGER NOT NULL DEFAULT 0;

--- a/plugins/dev/scripts/emit-otel-event.sh
+++ b/plugins/dev/scripts/emit-otel-event.sh
@@ -39,6 +39,7 @@ OUTCOME=""
 SESSION_ID=""
 REASON=""
 LINEAR_KEY=""
+PHASE=""
 EXTRA_ATTRS=()
 
 while [[ $# -gt 0 ]]; do
@@ -48,6 +49,7 @@ while [[ $# -gt 0 ]]; do
     --session-id)  SESSION_ID="$2"; shift 2 ;;
     --reason)      REASON="$2"; shift 2 ;;
     --linear-key)  LINEAR_KEY="$2"; shift 2 ;;
+    --phase)       PHASE="$2"; shift 2 ;;
     --attr)        EXTRA_ATTRS+=("$2"); shift 2 ;;
     -h|--help)     grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *)             die "unknown flag: $1" ;;
@@ -109,6 +111,11 @@ LOG_ATTRS_JSON=$(jq -nc \
 if [[ -n "$REASON" ]]; then
   LOG_ATTRS_JSON=$(echo "$LOG_ATTRS_JSON" \
     | jq -c --arg r "$REASON" '. + [{key:"reason",value:{stringValue:$r}}]')
+fi
+
+if [[ -n "$PHASE" ]]; then
+  LOG_ATTRS_JSON=$(echo "$LOG_ATTRS_JSON" \
+    | jq -c --arg p "$PHASE" '. + [{key:"phase",value:{stringValue:$p}}]')
 fi
 
 for kv in "${EXTRA_ATTRS[@]}"; do

--- a/plugins/dev/scripts/emit-otel-metric.sh
+++ b/plugins/dev/scripts/emit-otel-metric.sh
@@ -41,6 +41,7 @@ COUNT=""
 LINEAR_KEY=""
 START_NS=""
 SCOPE="catalyst.session"
+PHASE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -49,6 +50,7 @@ while [[ $# -gt 0 ]]; do
     --linear-key) LINEAR_KEY="$2"; shift 2 ;;
     --start-ns)   START_NS="$2";   shift 2 ;;
     --scope)      SCOPE="$2";      shift 2 ;;
+    --phase)      PHASE="$2";      shift 2 ;;
     *) die_silent ;;  # unknown flag — silent noop, we're on the session-end hot path
   esac
 done
@@ -92,6 +94,7 @@ PAYLOAD=$(jq -nc \
   --arg count      "$COUNT" \
   --arg start_ns   "$START_NS" \
   --arg now_ns     "$NOW_NS" \
+  --arg phase      "$PHASE" \
   '{
     resourceLogs: null,
     resourceMetrics: [{
@@ -110,7 +113,12 @@ PAYLOAD=$(jq -nc \
           unit: "1",
           sum: {
             dataPoints: [{
-              attributes: [{key: "kind", value: {stringValue: $kind}}],
+              attributes: (
+                [{key: "kind", value: {stringValue: $kind}}] +
+                (if $phase == "" then [] else
+                  [{key: "phase", value: {stringValue: $phase}}]
+                end)
+              ),
               startTimeUnixNano: $start_ns,
               timeUnixNano: $now_ns,
               asInt: $count

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -860,6 +860,9 @@ describe("SQLite session endpoints", () => {
       "001_initial_schema.sql",
       "002_session_context.sql",
       "003_archives.sql",
+      "004_iteration_counts.sql",
+      "005_claude_session_metadata.sql",
+      "006_num_turns.sql",
     ]) {
       db.exec(readFileSync(join(migDir, f), "utf8"));
     }
@@ -953,6 +956,9 @@ describe("History API endpoints", () => {
       "001_initial_schema.sql",
       "002_session_context.sql",
       "003_archives.sql",
+      "004_iteration_counts.sql",
+      "005_claude_session_metadata.sql",
+      "006_num_turns.sql",
     ]) {
       db.exec(readFileSync(join(migDir2, f), "utf8"));
     }

--- a/plugins/dev/scripts/orch-monitor/__tests__/session-store.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/session-store.test.ts
@@ -17,6 +17,9 @@ function loadMigrations(): string[] {
     "001_initial_schema.sql",
     "002_session_context.sql",
     "003_archives.sql",
+    "004_iteration_counts.sql",
+    "005_claude_session_metadata.sql",
+    "006_num_turns.sql",
   ].map((f) => readFileSync(join(migDir, f), "utf8"));
 }
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/state-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/state-reader.test.ts
@@ -458,6 +458,9 @@ describe("buildSnapshot", () => {
       "001_initial_schema.sql",
       "002_session_context.sql",
       "003_archives.sql",
+      "004_iteration_counts.sql",
+      "005_claude_session_metadata.sql",
+      "006_num_turns.sql",
     ]) {
       db.exec(readFileSync(join(migDir, f), "utf8"));
     }

--- a/plugins/dev/scripts/orch-monitor/__tests__/watcher.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/watcher.test.ts
@@ -315,6 +315,9 @@ describe("startWatching integration", () => {
       "001_initial_schema.sql",
       "002_session_context.sql",
       "003_archives.sql",
+      "004_iteration_counts.sql",
+      "005_claude_session_metadata.sql",
+      "006_num_turns.sql",
     ]) {
       db.exec(readFileSync(join(migDir, f), "utf8"));
     }

--- a/plugins/dev/scripts/orch-monitor/board-data-phase-costs.test.ts
+++ b/plugins/dev/scripts/orch-monitor/board-data-phase-costs.test.ts
@@ -1,0 +1,80 @@
+// CTL-748: unit test for costByPhase() in board-data.mjs.
+// Exercises the SQL query indirectly by building a temp DB with
+// session + session_metrics rows and asserting the per-phase shape
+// returned by assembleBoard().
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+describe("board-data costByPhase SQL correctness", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "board-phase-test-"));
+    dbPath = join(tmpDir, "catalyst.db");
+    execFileSync("sqlite3", [
+      dbPath,
+      `
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        ticket_key TEXT,
+        skill_name TEXT,
+        status TEXT DEFAULT 'done',
+        started_at TEXT DEFAULT '2026-06-02T00:00:00Z',
+        updated_at TEXT DEFAULT '2026-06-02T00:00:00Z'
+      );
+      CREATE TABLE session_metrics (
+        session_id TEXT PRIMARY KEY,
+        cost_usd REAL DEFAULT 0,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_creation_tokens INTEGER DEFAULT 0,
+        duration_ms INTEGER DEFAULT 0,
+        num_turns INTEGER DEFAULT 0,
+        updated_at TEXT DEFAULT '2026-06-02T00:00:00Z'
+      );
+      INSERT INTO sessions VALUES ('s1','CTL-999','phase-research','done','2026-06-02T00:00:00Z','2026-06-02T00:00:00Z');
+      INSERT INTO sessions VALUES ('s2','CTL-999','phase-implement','done','2026-06-02T00:00:00Z','2026-06-02T00:00:00Z');
+      INSERT INTO session_metrics VALUES ('s1',0.10,500,250,0,0,5000,7,'2026-06-02T00:00:00Z');
+      INSERT INTO session_metrics VALUES ('s2',0.50,2000,1000,0,0,25000,42,'2026-06-02T00:00:00Z');
+      `,
+    ]);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns per-phase cost breakdown with correct turns", () => {
+    const sql = [
+      "SELECT s.ticket_key, s.skill_name,",
+      "  ROUND(COALESCE(SUM(m.cost_usd),0),4),",
+      "  COALESCE(SUM(m.input_tokens+m.output_tokens),0),",
+      "  COALESCE(SUM(m.num_turns),0)",
+      "FROM sessions s JOIN session_metrics m ON m.session_id=s.session_id",
+      "WHERE s.ticket_key IS NOT NULL AND s.skill_name LIKE 'phase-%'",
+      "GROUP BY s.ticket_key, s.skill_name;",
+    ].join(" ");
+    const out = execFileSync("sqlite3", ["-separator", "\t", dbPath, sql], {
+      encoding: "utf8",
+    });
+    const rows = out.trim().split("\n").map((l) => l.split("\t"));
+    const research = rows.find((r) => r[1] === "phase-research");
+    const implement = rows.find((r) => r[1] === "phase-implement");
+
+    expect(research).toBeDefined();
+    expect(Number(research![2])).toBeCloseTo(0.10);
+    expect(Number(research![3])).toBe(750);   // 500+250 tokens
+    expect(Number(research![4])).toBe(7);     // num_turns
+
+    expect(implement).toBeDefined();
+    expect(Number(implement![2])).toBeCloseTo(0.50);
+    expect(Number(implement![3])).toBe(3000); // 2000+1000 tokens
+    expect(Number(implement![4])).toBe(42);   // num_turns
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -21,6 +21,12 @@ export interface BoardWorker {
   sessionId: string;
 }
 
+export interface BoardPhaseCost {
+  costUSD: number;
+  tokens: number;
+  turns: number;
+}
+
 export interface BoardTicket {
   id: string;
   title: string;
@@ -41,6 +47,8 @@ export interface BoardTicket {
   project: string | null;
   costUSD: number | null;
   tokens: number | null;
+  turns: number | null;
+  phaseCosts: Record<string, BoardPhaseCost> | null;
   pr: number | null;
   updatedAt: string;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -230,6 +230,35 @@ async function costByTicket() {
   return map;
 }
 
+// ── cost + turns rollup per ticket per phase ─────────────────────────────────
+async function costByPhase() {
+  const map = {};
+  if (!(await exists(DB))) return map;
+  try {
+    const sql =
+      "SELECT s.ticket_key, s.skill_name, ROUND(COALESCE(SUM(m.cost_usd),0),4), " +
+      "COALESCE(SUM(m.input_tokens+m.output_tokens),0), COALESCE(SUM(m.num_turns),0) " +
+      "FROM sessions s JOIN session_metrics m ON m.session_id=s.session_id " +
+      "WHERE s.ticket_key IS NOT NULL AND s.skill_name LIKE 'phase-%' " +
+      "GROUP BY s.ticket_key, s.skill_name;";
+    const { stdout } = await execFileP("sqlite3", ["-separator", "\t", DB, sql], {
+      encoding: "utf8", timeout: 8000, maxBuffer: 8 * 1024 * 1024,
+    });
+    for (const line of stdout.trim().split("\n")) {
+      if (!line) continue;
+      const [tk, skill, cost, tokens, turns] = line.split("\t");
+      const phase = skill.replace(/^phase-/, "");
+      if (!map[tk]) map[tk] = {};
+      map[tk][phase] = {
+        costUSD: Number(cost) || 0,
+        tokens: Number(tokens) || 0,
+        turns: Number(turns) || 0,
+      };
+    }
+  } catch { /* sqlite missing or schema pre-migration */ }
+  return map;
+}
+
 // ── ranked eligible queue (mirrors scheduler-rank.mjs compareTickets) ───────
 const PRIORITY_RANK = (p) => (p && p >= 1 && p <= 4 ? p : 5); // 1=urgent..4=low, 0/none→5
 function compareQueued(a, b) {
@@ -288,8 +317,8 @@ async function readTicketArtifacts(id) {
 
 // ── main assembly ───────────────────────────────────────────────────────────
 export async function assembleBoard() {
-  const [agents, costs, eligible, linfo, mp] = await Promise.all([
-    liveAgents(), costByTicket(), loadEligible(), linearInfo(), maxParallel(),
+  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp] = await Promise.all([
+    liveAgents(), costByTicket(), costByPhase(), loadEligible(), linearInfo(), maxParallel(),
   ]);
   const eligibleIndex = Object.fromEntries(eligible.map((e) => [e.id, e]));
 
@@ -339,6 +368,10 @@ export async function assembleBoard() {
       estimate: linfo[id]?.estimate ?? null, scope: ticketScope(triage),
       project: linfo[id]?.project ?? null,
       costUSD: costs[id]?.costUSD ?? null, tokens: costs[id]?.tokens ?? null,
+      turns: phaseCostsByTicket[id]
+        ? Object.values(phaseCostsByTicket[id]).reduce((s, p) => s + p.turns, 0)
+        : null,
+      phaseCosts: phaseCostsByTicket[id] ?? null,
       pr: prFor(prSigs),
       updatedAt: ticketUpdatedAt(phaseSigs),
     };

--- a/plugins/dev/scripts/orch-monitor/lib/session-store.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/session-store.ts
@@ -94,6 +94,7 @@ interface SessionRow {
   input_tokens: number | null;
   output_tokens: number | null;
   cache_read_tokens: number | null;
+  num_turns: number | null;
   pr_number: number | null;
   pr_url: string | null;
   ci_status: string | null;
@@ -118,6 +119,7 @@ function rowToState(row: SessionRow): SessionState {
           inputTokens: row.input_tokens ?? 0,
           outputTokens: row.output_tokens ?? 0,
           cacheReadTokens: row.cache_read_tokens ?? 0,
+          numTurns: row.num_turns ?? 0,
         };
 
   const pr: SessionPr | null =
@@ -215,6 +217,7 @@ export function readSessionStore(
         m.input_tokens,
         m.output_tokens,
         m.cache_read_tokens,
+        m.num_turns,
         p.pr_number,
         p.pr_url,
         p.ci_status,

--- a/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/state-reader.ts
@@ -30,6 +30,7 @@ export interface WorkerCost {
   inputTokens?: number;
   outputTokens?: number;
   cacheReadTokens?: number;
+  numTurns?: number;
 }
 
 export interface WorkerState {
@@ -373,6 +374,7 @@ function toWorkerState(signal: Record<string, unknown>): WorkerState {
       inputTokens: asNumber(c.inputTokens),
       outputTokens: asNumber(c.outputTokens),
       cacheReadTokens: asNumber(c.cacheReadTokens),
+      numTurns: asNumber(c.numTurns),
     };
   }
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -200,6 +200,7 @@ function TicketCard({ t, colorBy }: { t: Ticket; colorBy: ColorBy }) {
           {t.activeState == null && t.status !== "done" ? `idle · ${fmtAgo(t.updatedAt)}` : fmtAgo(t.updatedAt)}
         </span>
         <span style={{ flex: 1 }} />
+        {t.turns != null && <span style={{ fontFamily: C.mono, fontSize: 10, color: C.fgDim }} title="total turns">{t.turns}t</span>}
         {t.pr ? <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.green }}>#{t.pr}</span> : <Cost v={t.costUSD} />}
       </div>
     </div>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -22,6 +22,12 @@ export interface BoardWorker {
   sessionId?: string;
 }
 
+export interface BoardPhaseCost {
+  costUSD: number;
+  tokens: number;
+  turns: number;
+}
+
 export interface BoardTicket {
   id: string;
   title: string;
@@ -42,6 +48,8 @@ export interface BoardTicket {
   project: string | null;
   costUSD: number | null;
   tokens: number | null;
+  turns: number | null;
+  phaseCosts: Record<string, BoardPhaseCost> | null;
   pr: number | null;
   updatedAt: string;
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/worker-detail-drawer.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/worker-detail-drawer.tsx
@@ -489,6 +489,11 @@ export function WorkerDetailDrawer({
               label="tokens"
               value={tokens > 0 ? fmtTokens(tokens) : "—"}
             />
+            <MetricPill
+              icon={<RotateCw className="h-3 w-3 text-muted" />}
+              label="turns"
+              value={worker.cost?.numTurns != null ? String(worker.cost.numTurns) : "—"}
+            />
             {worker.activity && (
               <>
                 <MetricPill

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/types.ts
@@ -14,6 +14,7 @@ export interface WorkerCost {
   inputTokens?: number;
   outputTokens?: number;
   cacheReadTokens?: number;
+  numTurns?: number;
 }
 
 export interface TaskSummary {

--- a/plugins/dev/scripts/orchestrate-roll-usage.sh
+++ b/plugins/dev/scripts/orchestrate-roll-usage.sh
@@ -296,9 +296,11 @@ if [ -n "$CATALYST_SID" ] && [ -x "$SESSION_SH" ]; then
   CRD=$( echo "$USAGE" | jq -r '.cacheReadTokens')
   CCR=$( echo "$USAGE" | jq -r '.cacheCreationTokens')
   DUR=$( echo "$USAGE" | jq -r '.durationMs')
+  TURNS=$(echo "$USAGE" | jq -r '.numTurns // 0')
   if "$SESSION_SH" metric "$CATALYST_SID" \
        --cost "$COST" --input "$ITOK" --output "$OTOK" \
        --cache-read "$CRD" --cache-creation "$CCR" --duration-ms "$DUR" \
+       --turns "$TURNS" \
        >/dev/null 2>&1; then
     log_action "wrote-metric"
   else

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -158,30 +158,8 @@ Plan §"Per-phase /goal conditions":
 /goal "I have run /catalyst-dev:implement-plan on ${PLAN_PATH} to completion
        AND `git diff <base>..HEAD` on this branch is non-empty AND the targeted
        tests pass (I have printed the test command + `exit 0` to my transcript);
-       (Linear status is written by the coordinator — CTL-558 — not this agent.)
-       OR I am within ~5 turns of the 75-turn cap, in which case I have
-       (a) written a structured handoff to
-           thoughts/shared/handoffs/${TICKET}/<ts>_turn-cap-continuation.md
-           using the bash template in the 'Failure handling' section,
-       (b) called phase-agent-emit-complete --status turn-cap-exhausted
-           --handoff-path <the file> --reason 'turn cap hit (N)', and
-       (c) exited 0 (cleanly — this is NOT a failure; the orchestrator
-           dispatches a continuation worker on a separate budget)."
+       (Linear status is written by the coordinator — CTL-558 — not this agent.)"
 ```
-
-Turn cap defaults to 75 (from `phase-agent-dispatch:phase_default_turn_cap`)
-and is overridable via `.catalyst/config.json:catalyst.orchestration.phaseAgents.turnCaps.implement`.
-
-**CTL-484:** when the agent self-detects impending cap exhaustion (typically
-~5 turns remaining), it takes the second `/goal` branch: writes a structured
-handoff, emits `phase.implement.turn-cap-exhausted.<TICKET>`, and exits 0.
-`orchestrate-revive`'s continuation branch reads the handoff path from the
-per-phase signal file, dispatches a fresh `claude --bg --resume` session with
-`CATALYST_IS_CONTINUATION=true` + `CATALYST_HANDOFF_PATH=<path>` +
-`CATALYST_CONTINUATION_COUNT=<n>`, and the resumed session enters this skill
-again — the Prelude check above orients it from the handoff instead of
-re-walking the plan. Default budget: 3 continuations per ticket per phase
-before `stalled` + `attentionReason=continuation-budget-exhausted`.
 
 ## Phase-specific work
 
@@ -372,93 +350,11 @@ fi
 
 ## Failure handling
 
-Two failure modes — turn-cap exhaustion (recoverable via continuation) and
-hard error (caller-supplied reason). The branch is determined by the reason
-string: anything starting with `turn cap hit` takes the CTL-484 continuation
-path; everything else takes the legacy hard-error path.
+One failure mode — hard error (caller-supplied reason).
 
 ```bash
 REASON="${1:-implement-plan exited non-zero}"  # caller-supplied short string
 
-# ── CTL-484: turn-cap branch — write handoff, emit turn-cap-exhausted,
-#    exit 0. Orchestrator dispatches a continuation worker on a separate
-#    budget; this is NOT a failure from the orchestrator's perspective.
-if [[ "$REASON" =~ ^turn\ cap\ hit ]]; then
-  TS_HO=$(date -u +%Y-%m-%d_%H-%M-%S)
-  HANDOFF_DIR="thoughts/shared/handoffs/${TICKET}"
-  HANDOFF_FILE="${HANDOFF_DIR}/${TS_HO}_turn-cap-continuation.md"
-  mkdir -p "$HANDOFF_DIR"
-
-  GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "")
-  BRANCH=$(git branch --show-current 2>/dev/null || echo "")
-  BASE_REF=$(git merge-base HEAD main 2>/dev/null || echo HEAD)
-  DIFF_STAT=$(git diff --stat "${BASE_REF}..HEAD" 2>/dev/null || echo "")
-  CONT_N="${CATALYST_CONTINUATION_COUNT:-1}"
-
-  cat > "$HANDOFF_FILE" <<EOF
----
-date: $(date -u +%Y-%m-%d)
-researcher: phase-implement
-git_commit: ${GIT_COMMIT}
-branch: ${BRANCH}
-topic: "Continuation handoff for ${TICKET} (turn cap hit)"
-status: in-progress
-type: handoff
-source_ticket: ${TICKET}
-source_plan: ${PLAN_PATH:-unknown}
----
-
-# ${TICKET} — turn-cap continuation handoff
-
-## Task(s)
-
-Implement plan at \`${PLAN_PATH:-unknown}\`. The previous session reached
-its 75-turn cap before completing all phases. The continuation worker
-should resume from the last committed phase and complete the remaining
-ones.
-
-## Recent changes (this session)
-
-\`\`\`
-${DIFF_STAT}
-\`\`\`
-
-Last commit: \`${GIT_COMMIT}\`
-Branch: \`${BRANCH}\`
-
-## Action Items & Next Steps
-
-1. You are reading this handoff via \`CATALYST_HANDOFF_PATH\` — the
-   Prelude block has already cat'd it to the transcript.
-2. Read \`${PLAN_PATH:-the plan in thoughts/shared/plans/}\` only if you
-   need detail beyond what \`git log --oneline ${BASE_REF}..HEAD\` shows.
-   **Do NOT redo committed work** — trust the commit log.
-3. Resume from the first uncommitted plan phase. Continue TDD rhythm.
-4. On success, call \`phase-agent-emit-complete --status complete\`
-   (terminal).
-5. If you also hit the cap, write a fresh continuation handoff in this
-   same directory and emit \`--status turn-cap-exhausted\` again. Budget
-   is 3 continuations per ticket per phase before stall.
-
-## Other Notes
-
-- Catalyst session: ${CATALYST_SESSION_ID:-unknown}
-- Continuation count: ${CONT_N}
-- Plan path: ${PLAN_PATH:-unknown}
-EOF
-
-  "$EMIT" --phase "$PHASE" --ticket "$TICKET" \
-    --status turn-cap-exhausted \
-    --reason "$REASON" \
-    --handoff-path "$HANDOFF_FILE"
-
-  [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
-    "phase-implement turn-cap-exhausted; handoff: ${HANDOFF_FILE}" \
-    --as "$TICKET" --type info --orch "$ORCH_ID" >/dev/null 2>&1 || true
-  exit 0
-fi
-
-# ── Hard-error branch (existing): emit failed + attention, exit non-zero.
 "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status failed --reason "$REASON"
 [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
   "phase-implement failed: ${REASON}" \
@@ -469,12 +365,6 @@ exit 1
 The orchestrator's Phase 4 monitor receives `phase.implement.failed.${TICKET}`
 via the broker `phase_lifecycle` route (CTL-447) and dispatches one fix-up
 phase agent. A second failure escalates to the user via the `attention` post.
-
-For the turn-cap branch, the orchestrator instead receives
-`phase.implement.turn-cap-exhausted.${TICKET}` and runs `orchestrate-revive`,
-which detects the new status + handoff path on the per-phase signal and
-dispatches a continuation worker on a budget separate from the error-revive
-budget (CTL-484).
 
 ## Comms discipline
 

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -372,8 +372,8 @@ Inherits the contract from [[_phase-agent-template]]:
 
 | Type        | When                                                                                  |
 |-------------|--------------------------------------------------------------------------------------|
-| `info`      | At start; once after `implement-plan` returns; once on turn-cap handoff write (CTL-484). ~2-3 per session. |
-| `attention` | Missing plan, unresolved 3+ test failures, hard error. (Turn cap is NOT an attention event — see CTL-484.) |
+| `info`      | At start; once after `implement-plan` returns. ~1-2 per session. |
+| `attention` | Missing plan, unresolved 3+ test failures, hard error. (Turn caps are enforced daemon-side — CTL-748 — not self-detected by this skill.) |
 | `question`  | Plan ambiguity the agent cannot resolve unilaterally.                                 |
 | `done`      | Emitted by `phase-agent-emit-complete` on success.                                    |
 

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -98,13 +98,12 @@ Plan §"Per-phase /goal conditions":
 ```
 /goal "`gh pr view --json merged` returns `true` for the PR linked to
        ${TICKET} (PR #${PR_NUMBER}) AND Linear state is `Done` (I have
-       printed both confirmations to my transcript); OR I have stopped after
-       50 turns or 24 wall-clock hours."
+       printed both confirmations to my transcript);
+       OR 24 wall-clock hours have elapsed without merge completion
+       and I have recorded status:timeout."
 ```
 
-Turn cap defaults to 50 — high relative to other phases because the work is
-event-driven and one wake = one turn. Wall-clock cap is 24h (per plan
-§Failure handling).
+Wall-clock cap is 24h (per plan §Failure handling).
 
 ## Phase-specific work — active listen loop
 

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -120,8 +120,7 @@ RESEARCH_DOC="${RESEARCH_MATCHES[-1]}"
 /goal "I have written thoughts/shared/plans/<date>-${ticket-lower}.md containing the
        full plan with: Overview, Phase 1..N sections each with Tests First (Red),
        Implementation (Green), Refactor, and Success Criteria (Automated + Manual).
-       I have printed the path on stdout. OR I have stopped after 25 turns and
-       printed a clear partial-progress summary."
+       I have printed the path on stdout."
 ```
 
 ## Work block

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -206,7 +206,7 @@ Plan §"Per-phase /goal conditions":
 /goal "`gh pr view --json number,state,headRefName` shows an open PR linked
        to ${TICKET} AND Linear state is `In Review` AND describe-pr has run
        successfully (I have printed the PR URL and `describe-pr ran` to my
-       transcript); OR I have stopped after 12 turns."
+       transcript)."
 ```
 
 Turn cap defaults to 12 (from `phase-agent-dispatch:phase_default_turn_cap`).

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -163,23 +163,8 @@ output, not the filesystem) can decide pass/fail from what the agent prints.
        gate (tsc/test/lint on the touched files) showing `exit 0` to my
        transcript. The router re-dispatches `verify` to re-check the whole
        diff (CTL-653) — I do NOT re-run the full verify suite myself.
-       (Linear status is written by the coordinator — CTL-558 — not this agent.)
-       OR I am within ~5 turns of the 40-turn cap, in which case I have
-       (a) written a structured handoff to
-           thoughts/shared/handoffs/${TICKET}/<ts>_turn-cap-continuation.md
-           using the bash template in the 'Failure handling' section,
-       (b) called phase-agent-emit-complete --status turn-cap-exhausted
-           --handoff-path <the file> --reason 'turn cap hit (N)', and
-       (c) exited 0 (cleanly — the orchestrator dispatches a continuation
-           worker on a separate budget)."
+       (Linear status is written by the coordinator — CTL-558 — not this agent.)"
 ```
-
-Turn cap defaults to 40 (from `phase-agent-dispatch:phase_default_turn_cap`) and
-is overridable via `.catalyst/config.json:catalyst.orchestration.phaseAgents.turnCaps.remediate`.
-
-**CTL-484 parity:** impending cap exhaustion takes the second `/goal` branch —
-write a handoff, emit `phase.remediate.turn-cap-exhausted.<TICKET>`, exit 0.
-`orchestrate-revive` dispatches a continuation worker on a separate budget.
 
 ## Phase-specific work
 
@@ -339,90 +324,14 @@ fi
 
 ## Failure handling
 
-Two failure modes — turn-cap exhaustion (recoverable via continuation) and hard
-error (caller-supplied reason). The branch is determined by the reason string:
-anything starting with `turn cap hit` takes the CTL-484 continuation path;
-everything else takes the hard-error path.
+One failure mode — hard error (caller-supplied reason).
 
 ```bash
 REASON="${1:-remediation failed}"  # caller-supplied short string
 
-# ── CTL-484: turn-cap branch — write handoff, emit turn-cap-exhausted, exit 0.
-if [[ "$REASON" =~ ^turn\ cap\ hit ]]; then
-  TS_HO=$(date -u +%Y-%m-%d_%H-%M-%S)
-  HANDOFF_DIR="thoughts/shared/handoffs/${TICKET}"
-  HANDOFF_FILE="${HANDOFF_DIR}/${TS_HO}_turn-cap-continuation.md"
-  mkdir -p "$HANDOFF_DIR"
-
-  GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "")
-  BRANCH=$(git branch --show-current 2>/dev/null || echo "")
-  BASE_REF=$(git merge-base HEAD main 2>/dev/null || echo HEAD)
-  DIFF_STAT=$(git diff --stat "${BASE_REF}..HEAD" 2>/dev/null || echo "")
-  CONT_N="${CATALYST_CONTINUATION_COUNT:-1}"
-
-  cat > "$HANDOFF_FILE" <<EOF
----
-date: $(date -u +%Y-%m-%d)
-researcher: phase-remediate
-git_commit: ${GIT_COMMIT}
-branch: ${BRANCH}
-topic: "Continuation handoff for ${TICKET} (remediate turn cap hit)"
-status: in-progress
-type: handoff
-source_ticket: ${TICKET}
-source_artifact: ${VERIFY_ARTIFACT:-unknown}
----
-
-# ${TICKET} — remediate turn-cap continuation handoff
-
-## Task(s)
-
-Fix the verify findings in \`${VERIFY_ARTIFACT:-the worker's verify.json}\`.
-The previous session reached its 40-turn cap before finishing. The continuation
-worker should resume from the first unaddressed finding and commit the rest.
-
-## Recent changes (this session)
-
-\`\`\`
-${DIFF_STAT}
-\`\`\`
-
-Last commit: \`${GIT_COMMIT}\`
-Branch: \`${BRANCH}\`
-
-## Action Items & Next Steps
-
-1. You are reading this handoff via \`CATALYST_HANDOFF_PATH\` — the Prelude
-   block has already cat'd it to the transcript.
-2. Re-read verify.json's findings[]; cross-check against \`git log --oneline
-   ${BASE_REF}..HEAD\`. **Do NOT redo committed fixes.**
-3. Address the remaining high-severity / regression_risk findings, commit.
-4. On completion, call \`phase-agent-emit-complete --status complete\`
-   (terminal). The router re-dispatches verify to re-check.
-5. If you also hit the cap, write a fresh continuation handoff here and emit
-   \`--status turn-cap-exhausted\` again. Budget is 3 continuations per phase.
-
-## Other Notes
-
-- Catalyst session: ${CATALYST_SESSION_ID:-unknown}
-- Continuation count: ${CONT_N}
-- verify.json: ${VERIFY_ARTIFACT:-unknown}
-EOF
-
-  "$EMIT" --phase "$PHASE" --ticket "$TICKET" \
-    --status turn-cap-exhausted \
-    --reason "$REASON" \
-    --handoff-path "$HANDOFF_FILE"
-
-  [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
-    "phase-remediate turn-cap-exhausted; handoff: ${HANDOFF_FILE}" \
-    --as "$TICKET" --type info --orch "$ORCH_ID" >/dev/null 2>&1 || true
-  exit 0
-fi
-
-# ── Hard-error branch: emit failed + attention, exit non-zero. A `failed`
-#    event lets the FSM revive remediate once (REVIVE_BUDGET) before stalling —
-#    distinct from the verdict-cycle cap, which counts `complete` events.
+# Hard-error: emit failed + attention, exit non-zero. A `failed` event lets
+# the FSM revive remediate once (REVIVE_BUDGET) before stalling — distinct
+# from the verdict-cycle cap, which counts `complete` events.
 "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status failed --reason "$REASON"
 [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
   "phase-remediate failed: ${REASON}" \

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -353,8 +353,8 @@ Inherits the contract from [[_phase-agent-template]]:
 
 | Type        | When                                                                                  |
 |-------------|--------------------------------------------------------------------------------------|
-| `info`      | At start; once after the fix pass commits; once on turn-cap handoff write (CTL-484). |
-| `attention` | Missing verify.json, unfixable findings, hard error. (Turn cap is NOT an attention event.) |
+| `info`      | At start; once after the fix pass commits. |
+| `attention` | Missing verify.json, unfixable findings, hard error. (Turn caps are enforced daemon-side — CTL-748 — not self-detected by this skill.) |
 | `question`  | A finding the agent cannot resolve unilaterally.                                      |
 | `done`      | Emitted by `phase-agent-emit-complete` on success.                                   |
 

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -106,8 +106,7 @@ TRIAGE_SUMMARY=$(jq -r '.summary // .classification // ""' "$TRIAGE_FILE" 2>/dev
 /goal "I have written thoughts/shared/research/<date>-${ticket-lower}.md with valid
        frontmatter, a 'Summary' section, a 'Findings' section containing at least 10
        file:line references, and a 'References' section linking related thoughts/plans.
-       I have printed the path on stdout. OR I have stopped after 35 turns and printed
-       a clear partial-progress summary."
+       I have printed the path on stdout."
 ```
 
 Replace `<date>` with `$(date -u +%Y-%m-%d)` and `<ticket-lower>` with the lowercased

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -105,8 +105,7 @@ REGRESSION_RISK=$(jq -r '.regression_risk // 0' "$VERIFY_ARTIFACT")
 /goal "I have written ${ORCH_DIR}/workers/${TICKET}/review.json with
        {findings:[...], remediationCommit:string|null, reviewPassed:bool} AND any
        HIGH-severity finding with a deterministic fix has a corresponding
-       remediation commit on HEAD. I have printed the path on stdout. OR I have
-       stopped after 25 turns and recorded a partial review.json."
+       remediation commit on HEAD. I have printed the path on stdout."
 ```
 
 ## Work block

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -31,8 +31,7 @@ Both modes produce the same `triage.json` shape and emit the same canonical phas
        acronyms_expanded, dependencies, and a non-empty summary — refined with
        real analysis (not just the deterministic placeholders), AND posted the
        triage analysis comment to the Linear ticket, AND printed the triage.json
-       path on stdout. OR I have stopped after 15 turns and recorded a partial
-       triage.json with whatever I could classify."
+       path on stdout."
 ```
 
 CTL-656: the `/goal` evaluator keeps the agent working until the triage is

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -114,8 +114,7 @@ fi
 /goal "I have written ${ORCH_DIR}/workers/${TICKET}/verify.json with the schema
        {regression_risk:int, findings:[...], tests_attempted:int, gates:{...}} AND
        I have NOT modified any application source files (only test files). I have
-       printed the path on stdout. OR I have stopped after 20 turns and recorded
-       a partial verify.json with whatever I have."
+       printed the path on stdout."
 ```
 
 ## Work block


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-02T03:47:00Z -->
<!-- Last updated: 2026-06-02T03:47:00Z -->
<!-- PR: #1260 -->
<!-- Previous commits: 42e5e7d550c11f8eeaf8a0c9710657c8aaedd6c7,435456b234cd1eafeaae8201c107b24736134fda,7c5764194b6f0a85fbbf0953c459ff8013095f5e,5bcff3d6 -->

## Summary

Removes the per-phase turn-cap self-stop clauses from all phase skill `/goal` blocks and replaces the static thresholds with real measurement: `num_turns` is now persisted to `session_metrics`, emitted to OTel with a `phase` attribute, and surfaced in the HUD/monitor as per-phase turn data. This gives the evidence needed to set data-driven limits later, without forcing premature self-stops now.

## Motivation

Turn caps were enforced as prose inside each phase's `/goal` block ("OR I have stopped after N turns"), not as a CLI flag — there is no `--max-turns` in the installed Claude Code CLI. These static thresholds proved unreliable (phases that legitimately need more turns were cut short) and had no calibration data behind them. The fix is to remove the caps and measure real spend so we can set evidence-based bounds later.

## Changes Made

### Phase 1 — Remove turn-cap self-stop clauses

Removed "OR I have stopped after N turns" from nine phase skill `/goal` blocks:
- `phase-triage`, `phase-research`, `phase-plan`, `phase-implement`, `phase-verify`, `phase-review`, `phase-pr`, `phase-monitor-merge`, `phase-remediate`

CTL-484's handoff-continuation infrastructure is left in place but dormant (no cap to trigger it).

### Phase 2 — Persist `num_turns` to `session_metrics`

- `db-migrations/006_num_turns.sql`: adds `num_turns INTEGER NOT NULL DEFAULT 0` column to `session_metrics`
- `catalyst-session.sh`: adds `--turns` flag to the `metric` subcommand, mapping to the new column
- `orchestrate-roll-usage.sh`: reads `numTurns` from the session result event and writes it via `catalyst-session metric --turns` (field was previously computed but silently dropped)

### Phase 3 — OTel `phase` attribute + HUD per-phase turns

- `emit-otel-event.sh`: adds `--phase <name>` flag that injects a `phase` string attribute into log records
- `emit-otel-metric.sh`: adds `--phase <name>` flag that injects a `phase` attribute into metric data points
- `catalyst-session.sh` (`cmd_end` / `emit_iteration_metric`): auto-derives `phase_name` from the session's `skill_name` (strip `phase-` prefix) and passes it to both emit scripts
- `orch-monitor` board data + `session-store`: threads `num_turns` through to the per-phase worker detail drawer in the HUD UI

### Phase-review remediations

- `phase-goal-no-turn-caps.test.sh`: new regression guard that fails if any phase skill `/goal` block still contains turn-cap self-stop language
- Synced the `orchestrate-roll-usage` test's in-memory schema to include `num_turns`, preventing test divergence from the real schema
- Removed a stale "up to N turns" reference from `phase-pr/SKILL.md` docs

## How to Verify It

- [x] All CI checks pass (audit-references, check-versions, docs-gate, quality, validate, Cloudflare Pages) ✅
- [x] `bun test` in `plugins/dev/scripts/orch-monitor/` passes ✅
- [ ] `bash plugins/dev/scripts/__tests__/phase-goal-no-turn-caps.test.sh` — no turn-cap language found in any phase skill
- [ ] `bash plugins/dev/scripts/__tests__/catalyst-session-claude.test.sh` — test 13 passes (`metric --turns` writes `num_turns` to DB)
- [ ] `bash plugins/dev/scripts/__tests__/emit-otel-event.test.sh` — test 11 passes (`--phase` adds `phase` attribute to log record)
- [ ] `bash plugins/dev/scripts/__tests__/orchestrate-roll-usage.test.sh` — test 31 passes (`num_turns=12` persisted via roll-usage)
- [ ] After a phase completes, `sqlite3 ~/catalyst/catalyst.db "SELECT num_turns FROM session_metrics ORDER BY updated_at DESC LIMIT 5;"` shows non-zero values
- [ ] OTel traces include `phase` attribute on `claude_code.session.outcome` events

## Changelog Entry

```markdown
### catalyst-dev

**feat:** Remove per-phase turn caps; track turns/tokens/cost per phase instead

- Removed "OR I have stopped after N turns" self-stop clauses from all 9 phase skill `/goal` blocks (phase-research / plan / implement / verify / review / remediate / pr / monitor-merge / triage)
- Added `num_turns` column to `session_metrics` DB (migration 006) and `--turns` flag to `catalyst-session metric`
- `orchestrate-roll-usage.sh` now persists `numTurns` from session result events
- `emit-otel-event.sh` and `emit-otel-metric.sh` accept `--phase` flag; `catalyst-session end` auto-injects phase name from skill context
- HUD worker detail drawer surfaces per-phase turn count
- New regression test `phase-goal-no-turn-caps.test.sh` guards against turn-cap re-introduction
```

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-748
- Related: CTL-484 / CTL-613 (turn-cap handoff infra), CTL-746 (turns-persistence sibling)
