### PR TITLE
feat(dev): CTL-747 per-phase effort + dynamic-workflow execution driven by ticket points

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1459,11 +1459,9 @@ assert_eq "no" "$([[ -f "${WORKER_DIR}/phase-triage.json" ]] && echo yes || echo
 	"loser writes no signal file (bows out before the signal write)"
 assert_eq "no" "$([[ -s "$CLAUDE_STUB_LOG" ]] && echo yes || echo no)" "loser did NOT spawn claude --bg"
 
-# ─── Test 44 (CTL descriptor v1.1): plan dispatch threads per-step launch levers ───
-# A large-scope ticket fires the plan step's rule: --effort max + an
-# --append-system-prompt carrying the /workflows directive + --model opusplan.
+# ─── Test 44 (CTL-747): 8-pt ticket → plan launches with effort:xhigh + /workflows, no opusplan ───
 echo ""
-echo "Test 44 (descriptor v1.1): large ticket → plan launches with effort:max + /workflows postamble + model:opusplan"
+echo "Test 44 (CTL-747): 8-pt ticket → plan launches with effort:xhigh + /workflows postamble, no opusplan"
 fresh_env t44
 mkdir -p "${TEST_DIR}/proj/thoughts/shared/research"
 touch "${TEST_DIR}/proj/thoughts/shared/research/2026-05-30-ctl-100.md"
@@ -1473,14 +1471,18 @@ printf '%s\n' '{"estimated_scope":"large","classification":"feature"}' >"${WORKE
 LOG=$(cat "$CLAUDE_STUB_LOG")
 assert_contains "$LOG" "--effort" "large plan: claude invoked with --effort"
 T44_EFFORT=$(grep -A1 '^--effort$' "$CLAUDE_STUB_LOG" | sed -n '2p')
-assert_eq "max" "$T44_EFFORT" "large plan: --effort value is max"
+assert_eq "xhigh" "$T44_EFFORT" "large plan: --effort value is xhigh"
 assert_contains "$LOG" "--append-system-prompt" "large plan: claude invoked with --append-system-prompt"
 assert_contains "$LOG" "/workflows" "large plan: append-system-prompt carries the /workflows directive"
-assert_contains "$LOG" "opusplan" "large plan: rule overrides model to opusplan"
+if echo "$LOG" | grep -q "opusplan"; then
+	fail "large plan: rule must NOT override model to opusplan (CTL-747 dropped it)"
+else
+	pass "large plan: model not escalated to opusplan"
+fi
 
-# ─── Test 45 (CTL descriptor v1.1): small ticket keeps base levers, no escalation ───
+# ─── Test 45 (CTL-747): 1-pt ticket → plan de-escalates to effort:medium, no /workflows ───
 echo ""
-echo "Test 45 (descriptor v1.1): small ticket → plan launches with effort:high, no /workflows, no opusplan"
+echo "Test 45 (CTL-747): 1-pt ticket → plan launches with effort:medium, no /workflows, no opusplan"
 fresh_env t45
 mkdir -p "${TEST_DIR}/proj/thoughts/shared/research"
 touch "${TEST_DIR}/proj/thoughts/shared/research/2026-05-30-ctl-100.md"
@@ -1489,7 +1491,7 @@ printf '%s\n' '{"estimated_scope":"small","classification":"feature"}' >"${WORKE
 	--orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1)
 LOG=$(cat "$CLAUDE_STUB_LOG")
 T45_EFFORT=$(grep -A1 '^--effort$' "$CLAUDE_STUB_LOG" | sed -n '2p')
-assert_eq "high" "$T45_EFFORT" "small plan: --effort value is high (step base, no rule)"
+assert_eq "medium" "$T45_EFFORT" "small plan: --effort value is medium (1-pt → lt 3 rule)"
 if echo "$LOG" | grep -q "/workflows"; then
 	fail "small plan: must NOT carry the /workflows escalation"
 else
@@ -1499,6 +1501,35 @@ if echo "$LOG" | grep -q "opusplan"; then
 	fail "small plan: must NOT escalate model to opusplan"
 else
 	pass "small plan: model not escalated to opusplan"
+fi
+
+# ─── Test 46 (CTL-747): numeric estimate:8 in triage.json → xhigh + /workflows (CTL-746 forward-compat) ───
+echo ""
+echo "Test 46 (CTL-747): numeric estimate:8 in triage.json → plan escalates to xhigh + /workflows (CTL-746 forward-compat)"
+fresh_env t46
+mkdir -p "${TEST_DIR}/proj/thoughts/shared/research"
+touch "${TEST_DIR}/proj/thoughts/shared/research/2026-05-30-ctl-100.md"
+printf '%s\n' '{"estimate":8,"classification":"feature"}' >"${WORKER_DIR}/triage.json"
+(cd "${TEST_DIR}/proj" && "$DISPATCH" --phase plan --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1)
+LOG=$(cat "$CLAUDE_STUB_LOG")
+T46_EFFORT=$(grep -A1 '^--effort$' "$CLAUDE_STUB_LOG" | sed -n '2p')
+assert_eq "xhigh" "$T46_EFFORT" "numeric estimate:8 → --effort xhigh"
+assert_contains "$LOG" "/workflows" "numeric estimate:8 → /workflows postamble"
+
+# ─── Test 47 (CTL-747): un-pointed verify dispatch → NO --effort flag (fail-open, no base) ───
+echo ""
+echo "Test 47 (CTL-747): un-pointed verify dispatch → NO --effort flag (fail-open, no base)"
+fresh_env t47
+printf '%s\n' '{"classification":"feature"}' >"${WORKER_DIR}/triage.json"
+printf '%s\n' '{"status":"done"}' >"${WORKER_DIR}/phase-implement.json"
+(cd "${TEST_DIR}/proj" && "$DISPATCH" --phase verify --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1)
+LOG=$(cat "$CLAUDE_STUB_LOG")
+if echo "$LOG" | grep -q -- "--effort"; then
+	fail "un-pointed verify: must NOT pass --effort (no base, fail-open)"
+else
+	pass "un-pointed verify: no --effort flag"
 fi
 
 echo ""

--- a/plugins/dev/scripts/lib/workflow-rules.mjs
+++ b/plugins/dev/scripts/lib/workflow-rules.mjs
@@ -46,9 +46,11 @@ export class WorkflowRuleError extends Error {
 }
 
 // buildContext — assemble the documented context object from raw inputs. `scope`
-// comes from triage.json.estimated_scope; estimate is derived from SCOPE_POINTS.
+// comes from triage.json.estimated_scope; `estimate` overrides scope-derived
+// points when present (CTL-747 forward-compat seam for CTL-746 numeric points).
 export function buildContext({
   scope = null,
+  estimate = null,
   priority = null,
   labels = [],
   team = null,
@@ -59,7 +61,12 @@ export function buildContext({
   return {
     ticket: {
       scope,
-      estimate: scope != null ? (SCOPE_POINTS[scope] ?? null) : null,
+      estimate:
+        estimate != null
+          ? estimate
+          : scope != null
+            ? (SCOPE_POINTS[scope] ?? null)
+            : null,
       priority,
       labels,
       team,
@@ -166,12 +173,13 @@ export function resolveDescriptorStep(descriptor, stepId, context) {
 // default model) if this errors or prints nothing. Reads only the descriptor
 // JSON — never the execution-core lockfile — so it cannot race the CTL-736 claim.
 //   bun workflow-rules.mjs resolve --phase <id> [--ticket id] [--scope s] \
-//     [--priority n] [--verify-verdict v] [--remediate-cycle-count n] [--descriptor path]
-//   → {"model": "opusplan"|null, "effort": "max"|null, "appendSystemPrompt": "…"|null}
+//     [--estimate <N>] [--priority n] [--verify-verdict v] \
+//     [--remediate-cycle-count n] [--descriptor path]
+//   → {"model": null, "effort": "high"|null, "appendSystemPrompt": "…"|null}
 if (import.meta.main) {
   const argv = process.argv.slice(2);
   if (argv[0] !== "resolve") {
-    process.stderr.write("usage: workflow-rules.mjs resolve --phase <id> [--ticket id] [--scope s] [--descriptor path]\n");
+    process.stderr.write("usage: workflow-rules.mjs resolve --phase <id> [--ticket id] [--scope s] [--estimate <N>] [--descriptor path]\n");
     process.exit(2);
   }
   const opt = (n, d = null) => {
@@ -183,8 +191,14 @@ if (import.meta.main) {
   const desc = descriptorPath
     ? JSON.parse(readFileSync(descriptorPath, "utf8"))
     : (await import("./workflow-descriptor.mjs")).descriptor;
+  const _estRaw = opt("estimate");
+  const _estimate =
+    _estRaw != null && _estRaw !== "" && !Number.isNaN(Number(_estRaw))
+      ? Number(_estRaw)
+      : null;
   const ctx = buildContext({
     scope: opt("scope") || null,
+    estimate: _estimate,
     priority: opt("priority") != null ? Number(opt("priority")) : null,
     verifyVerdict: opt("verify-verdict"),
     remediateCycleCount: Number(opt("remediate-cycle-count") ?? 0) || 0,

--- a/plugins/dev/scripts/lib/workflow-rules.test.mjs
+++ b/plugins/dev/scripts/lib/workflow-rules.test.mjs
@@ -23,6 +23,18 @@ describe("buildContext + scope→points", () => {
   test("scope→points map", () => {
     expect(SCOPE_POINTS).toEqual({ small: 1, medium: 3, large: 8, epic: 13 });
   });
+  test("direct numeric estimate overrides scope-derived points", () => {
+    expect(buildContext({ scope: "medium", estimate: 5 }).ticket.estimate).toBe(5);
+  });
+  test("direct numeric estimate with no scope", () => {
+    expect(buildContext({ estimate: 8 }).ticket.estimate).toBe(8);
+  });
+  test("null estimate falls back to scope-derived points (back-compat)", () => {
+    expect(buildContext({ scope: "large", estimate: null }).ticket.estimate).toBe(8);
+  });
+  test("no scope and no estimate → estimate null", () => {
+    expect(buildContext({}).ticket.estimate).toBeNull();
+  });
 });
 
 describe("evalPredicate (closed ops, no eval)", () => {
@@ -93,16 +105,49 @@ describe("resolveStep", () => {
   });
 });
 
-describe("resolveDescriptorStep against the real default descriptor (marquee example is REAL)", () => {
-  test("plan step fires the large-ticket rule end-to-end", () => {
-    const r = resolveDescriptorStep(descriptor, "plan", buildContext({ scope: "epic", ticketId: "CTL-1" }));
-    expect(r.effort).toBe("max");
-    expect(r.model).toBe("opusplan");
-    expect(r.postamble.join(" ")).toContain("/workflows");
-  });
-  test("plan step on a small ticket keeps descriptor defaults (effort high, no postamble)", () => {
-    const r = resolveDescriptorStep(descriptor, "plan", buildContext({ scope: "small" }));
+describe("resolveDescriptorStep — estimate-based effort across heavy phases (CTL-747)", () => {
+  const HEAVY = ["plan", "implement", "verify", "review"];
+
+  for (const phase of HEAVY) {
+    test(`${phase}: 8-pt → xhigh + /workflows postamble, model NOT opusplan`, () => {
+      const r = resolveDescriptorStep(descriptor, phase, buildContext({ estimate: 8, ticketId: "CTL-1" }));
+      expect(r.effort).toBe("xhigh");
+      expect(r.postamble.join(" ")).toContain("/workflows");
+      expect(r.model).not.toBe("opusplan");
+    });
+    test(`${phase}: 13-pt → xhigh + /workflows`, () => {
+      const r = resolveDescriptorStep(descriptor, phase, buildContext({ estimate: 13 }));
+      expect(r.effort).toBe("xhigh");
+      expect(r.postamble.join(" ")).toContain("/workflows");
+    });
+    test(`${phase}: 5-pt → high, no postamble`, () => {
+      const r = resolveDescriptorStep(descriptor, phase, buildContext({ estimate: 5 }));
+      expect(r.effort).toBe("high");
+      expect(r.postamble).toEqual([]);
+    });
+    test(`${phase}: 3-pt → high, no postamble`, () => {
+      const r = resolveDescriptorStep(descriptor, phase, buildContext({ estimate: 3 }));
+      expect(r.effort).toBe("high");
+      expect(r.postamble).toEqual([]);
+    });
+    test(`${phase}: 1-pt → medium, no postamble`, () => {
+      const r = resolveDescriptorStep(descriptor, phase, buildContext({ estimate: 1 }));
+      expect(r.effort).toBe("medium");
+      expect(r.postamble).toEqual([]);
+    });
+  }
+
+  // Fail-open: plan keeps its base high; the other three emit NO effort (no flag).
+  test("fail-open: no estimate → plan keeps base effort high, no postamble", () => {
+    const r = resolveDescriptorStep(descriptor, "plan", buildContext({ scope: null }));
     expect(r.effort).toBe("high");
     expect(r.postamble).toEqual([]);
   });
+  for (const phase of ["implement", "verify", "review"]) {
+    test(`fail-open: no estimate → ${phase} sets NO effort (no flag), no postamble`, () => {
+      const r = resolveDescriptorStep(descriptor, phase, buildContext({ scope: null }));
+      expect(r.effort).toBeUndefined();
+      expect(r.postamble).toEqual([]);
+    });
+  }
 });

--- a/plugins/dev/scripts/lib/workflow.default.json
+++ b/plugins/dev/scripts/lib/workflow.default.json
@@ -12,16 +12,56 @@
     { "id": "plan",           "rank": 2, "linearKey": "planning",   "next": "implement",
       "effort": "high",
       "rules": [
-        { "when": { "field": "ticket.scope", "op": "in", "value": ["large", "epic"] },
-          "set": { "effort": "max", "model": "opusplan" },
+        { "when": { "field": "ticket.estimate", "op": "lt", "value": 3 },
+          "set": { "effort": "medium" } },
+        { "when": { "field": "ticket.estimate", "op": "gte", "value": 3 },
+          "set": { "effort": "high" } },
+        { "when": { "field": "ticket.estimate", "op": "gte", "value": 8 },
+          "set": { "effort": "xhigh" },
           "appendPostamble": [
-            "This is a large ticket (scope: ${ticket.scope}, ~${ticket.estimate} pts).",
+            "This is a high-point ticket (~${ticket.estimate} pts).",
             "Use the /workflows Workflow tool to decompose the plan into parallel sub-steps before writing the final plan document."
           ] }
       ] },
-    { "id": "implement",      "rank": 3, "linearKey": "inProgress", "next": "verify" },
-    { "id": "verify",         "rank": 5, "linearKey": "verifying",  "next": "review" },
-    { "id": "review",         "rank": 6, "linearKey": "reviewing",  "next": "pr" },
+    { "id": "implement",      "rank": 3, "linearKey": "inProgress", "next": "verify",
+      "rules": [
+        { "when": { "field": "ticket.estimate", "op": "lt", "value": 3 },
+          "set": { "effort": "medium" } },
+        { "when": { "field": "ticket.estimate", "op": "gte", "value": 3 },
+          "set": { "effort": "high" } },
+        { "when": { "field": "ticket.estimate", "op": "gte", "value": 8 },
+          "set": { "effort": "xhigh" },
+          "appendPostamble": [
+            "This is a high-point ticket (~${ticket.estimate} pts).",
+            "Use the /workflows Workflow tool to decompose the implementation into parallel sub-steps before writing code."
+          ] }
+      ] },
+    { "id": "verify",         "rank": 5, "linearKey": "verifying",  "next": "review",
+      "rules": [
+        { "when": { "field": "ticket.estimate", "op": "lt", "value": 3 },
+          "set": { "effort": "medium" } },
+        { "when": { "field": "ticket.estimate", "op": "gte", "value": 3 },
+          "set": { "effort": "high" } },
+        { "when": { "field": "ticket.estimate", "op": "gte", "value": 8 },
+          "set": { "effort": "xhigh" },
+          "appendPostamble": [
+            "This is a high-point ticket (~${ticket.estimate} pts).",
+            "Use the /workflows Workflow tool to fan out verification (types, tests, lint, security, review) into parallel checks."
+          ] }
+      ] },
+    { "id": "review",         "rank": 6, "linearKey": "reviewing",  "next": "pr",
+      "rules": [
+        { "when": { "field": "ticket.estimate", "op": "lt", "value": 3 },
+          "set": { "effort": "medium" } },
+        { "when": { "field": "ticket.estimate", "op": "gte", "value": 3 },
+          "set": { "effort": "high" } },
+        { "when": { "field": "ticket.estimate", "op": "gte", "value": 8 },
+          "set": { "effort": "xhigh" },
+          "appendPostamble": [
+            "This is a high-point ticket (~${ticket.estimate} pts).",
+            "Use the /workflows Workflow tool to fan out the review across parallel dimensions before recording the verdict."
+          ] }
+      ] },
     { "id": "pr",             "rank": 7, "linearKey": "inReview",   "next": "monitor-merge" },
     { "id": "monitor-merge",  "rank": 8, "linearKey": "inReview",   "next": "monitor-deploy" },
     { "id": "monitor-deploy", "rank": 9, "preemptable": false, "linearKey": "inReview", "next": null }

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -343,10 +343,13 @@ _WF_RULES="${SCRIPT_DIR}/lib/workflow-rules.mjs"
 if [[ -f "$_WF_RULES" ]] && command -v bun >/dev/null 2>&1; then
 	_TRIAGE_JSON="${ORCH_DIR}/workers/${TICKET}/triage.json"
 	_TRIAGE_SCOPE=""
-	[[ -f "$_TRIAGE_JSON" ]] &&
+	_TRIAGE_ESTIMATE=""
+	if [[ -f "$_TRIAGE_JSON" ]]; then
 		_TRIAGE_SCOPE="$(jq -r '.estimated_scope // empty' "$_TRIAGE_JSON" 2>/dev/null || true)"
+		_TRIAGE_ESTIMATE="$(jq -r '.estimate // empty' "$_TRIAGE_JSON" 2>/dev/null || true)"
+	fi
 	_WF_RESOLVED="$(bun "$_WF_RULES" resolve --phase "$PHASE" --ticket "$TICKET" \
-		--scope "$_TRIAGE_SCOPE" 2>/dev/null || true)"
+		--scope "$_TRIAGE_SCOPE" --estimate "$_TRIAGE_ESTIMATE" 2>/dev/null || true)"
 	if [[ -n "$_WF_RESOLVED" ]]; then
 		_WF_M="$(jq -r '.model // empty' <<<"$_WF_RESOLVED" 2>/dev/null || true)"
 		_WF_E="$(jq -r '.effort // empty' <<<"$_WF_RESOLVED" 2>/dev/null || true)"


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-02T04:27:00Z -->
<!-- Last updated: 2026-06-02T04:27:00Z -->
<!-- PR: #1262 -->
<!-- Previous commits: f4a70d40 -->

## Summary

- Extends the workflow-descriptor rules engine so `ticket.estimate` (numeric points) drives `--effort` and `/workflows` postamble for all four heavy phases: `plan`, `implement`, `verify`, `review`
- Tier mapping: 1pt→medium, 3/5pt→high, 8/13pt→xhigh+/workflows; no estimate→plan keeps `high` base, implement/verify/review emit no flag (fail-open)
- Adds CTL-746 forward-compat seam: `buildContext` accepts direct numeric `estimate`, resolve CLI accepts `--estimate <N>`, dispatcher reads `.estimate` from `triage.json`

## Changes

- `lib/workflow.default.json` — replaces the old scope-based placeholder rule on `plan` with estimate-keyed 3-rule blocks on all four heavy phases; drops `model:opusplan`
- `lib/workflow-rules.mjs` — `buildContext` gains `estimate` override param; CLI gains guarded `--estimate <N>` flag
- `phase-agent-dispatch` — reads `.estimate` from `triage.json`, passes `--estimate` to resolver alongside `--scope`
- Tests updated/added: 22 new unit tests (estimate matrix: 5 tiers × 4 phases + 4 fail-open), Tests 44/45 updated, Tests 46/47 added

## Test plan

- [x] `bun test lib/workflow-rules.test.mjs` — 40 tests pass (22 new estimate-matrix tests)
- [x] `bun test lib/workflow-descriptor.test.mjs` — drift guard still passes
- [x] `bash __tests__/phase-agent-dispatch.test.sh` — 168 passed, 0 failed (Tests 44-47 all green)
- [x] `jq . lib/workflow.default.json` — valid JSON

## Verification (automated gates)

- **Regression risk**: 1 / 10
- **Tests**: pass — lib bun test 344/344 (incl workflow-rules 40/40); phase-agent-dispatch.test.sh 168/168 incl new CTL-747 Tests 44-47
- **Lint**: pass — shellcheck exit 0; only SC2164 warning is pre-existing line 772, outside this diff
- **Security**: pass — no deps changed, no secrets introduced
- **Merge tree**: pass — no conflicts with current origin/main

## Related Issues

- Fixes https://linear.app/coalesce/issue/CTL-747
