### PR TITLE
CTL-537: [M4·scheduler] Sequencing and dependency-detection seam

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -245,6 +245,30 @@ export function applyTriageStatus({
   }
 }
 
+// applyBlockedByRelation — additively write a durable blocked-by edge
+// (CTL-537). Best-effort, never throws; mirrors applyLabel but without a
+// read-back: a blocked-by relation is durable (research:140) and the seam
+// re-evaluates next tick if the write fails.
+export function applyBlockedByRelation({ ticket, blockedBy, exec = defaultExec }) {
+  try {
+    const res = exec("linearis", ["issues", "update", ticket, "--blocked-by", blockedBy]);
+    if (res.code !== 0) {
+      log.warn(
+        { ticket, blockedBy, code: res.code, stderr: res.stderr },
+        "linear-write: blocked-by write failed (exit non-zero)"
+      );
+      return { applied: false, reason: "transient" };
+    }
+    return { applied: true, reason: null };
+  } catch (err) {
+    log.warn(
+      { ticket, blockedBy, reason: "transient", err: err.message },
+      "linear-write: blocked-by write threw — swallowed"
+    );
+    return { applied: false, reason: "transient" };
+  }
+}
+
 // classifyLabelFailure — map a `linearis issues update --labels` stderr to
 // one of the tagged reason codes. The substrings are the literal forms observed
 // in ~/catalyst/execution-core/daemon.log:

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -7,6 +7,7 @@ import {
   applyLabel,
   applyTriageStatus,
   removeLabel,
+  applyBlockedByRelation,
   teamOf,
 } from "./linear-write.mjs";
 
@@ -336,5 +337,47 @@ describe("removeLabel (CTL-549)", () => {
     const result = await removeLabel("CTL-1", "needs-human/question", { exec });
     expect(result.removed).toBe(false);
     expect(result.reason).toBe("transient");
+  });
+});
+
+// CTL-537: applyBlockedByRelation — durable blocked-by edge write.
+describe("applyBlockedByRelation", () => {
+  test("success — exec returns code 0 → applied:true, reason:null", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r = applyBlockedByRelation({ ticket: "CTL-1", blockedBy: "CTL-2", exec });
+    expect(r).toEqual({ applied: true, reason: null });
+  });
+
+  test("arg order — exact argv: issues update CTL-1 --blocked-by CTL-2", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    applyBlockedByRelation({ ticket: "CTL-1", blockedBy: "CTL-2", exec });
+    expect(calls[0].cmd).toBe("linearis");
+    expect(calls[0].args).toEqual(["issues", "update", "CTL-1", "--blocked-by", "CTL-2"]);
+  });
+
+  test("non-zero exit → applied:false, reason:transient, never throws", () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "some error" });
+    expect(() => applyBlockedByRelation({ ticket: "CTL-1", blockedBy: "CTL-2", exec })).not.toThrow();
+    const r = applyBlockedByRelation({ ticket: "CTL-1", blockedBy: "CTL-2", exec });
+    expect(r).toEqual({ applied: false, reason: "transient" });
+  });
+
+  test("exec throws → applied:false, reason:transient, never throws", () => {
+    const exec = () => { throw new Error("spawn boom"); };
+    expect(() => applyBlockedByRelation({ ticket: "CTL-1", blockedBy: "CTL-2", exec })).not.toThrow();
+    const r = applyBlockedByRelation({ ticket: "CTL-1", blockedBy: "CTL-2", exec });
+    expect(r).toEqual({ applied: false, reason: "transient" });
+  });
+
+  test("idempotent re-apply — two successive calls both return applied:true, two update calls recorded", () => {
+    const calls = [];
+    const exec = (cmd, args) => { calls.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    const r1 = applyBlockedByRelation({ ticket: "CTL-1", blockedBy: "CTL-2", exec });
+    const r2 = applyBlockedByRelation({ ticket: "CTL-1", blockedBy: "CTL-2", exec });
+    expect(r1.applied).toBe(true);
+    expect(r2.applied).toBe(true);
+    expect(calls).toHaveLength(2);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -96,6 +96,7 @@ import * as linearWrite from "./linear-write.mjs";
 import { labelOnce } from "./label-guard.mjs";
 import { countReapOutcomes } from "./reaper-metrics.mjs";
 import { log, getEligibleDir, getEventLogPath } from "./config.mjs";
+import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -1399,6 +1400,10 @@ export function schedulerTick(
     // CTL-713: GC + escalation emitters. Injectable for tests.
     appendCooldownGcEvent = defaultAppendCooldownGcEvent,
     appendCooldownEscalatedEvent = defaultAppendCooldownEscalatedEvent,
+    // CTL-537: sequencing seam. Default undefined → the new-work gate is skipped
+    // entirely (byte-for-byte legacy dispatch for every test that doesn't inject
+    // it). Production wires defaultCheckSequencing via runTick/startScheduler.
+    checkSequencing = undefined,
   } = {}
 ) {
   // (0) Reclaim-dead-work sweep (CTL-574) — close phase signals whose bg worker
@@ -1955,6 +1960,26 @@ export function schedulerTick(
   const dispatched = [];
   for (const t of selected) {
     if (inDispatchCooldown(orchDir, t.identifier, NEW_WORK_ENTRY_PHASE, now())) continue; // CTL-624: throttle refused re-dispatch
+    // CTL-537: sequencing gate — only when a worker is already in-flight and a
+    // seam is wired. Fail-open verdicts dispatch normally.
+    if (inFlightCount >= 1 && checkSequencing) {
+      const verdict = checkSequencing({
+        candidate: t.identifier,
+        inFlightTickets,
+        orchDir,
+      });
+      if (verdict?.hard_dependencies?.length > 0) {
+        for (const dep of verdict.hard_dependencies) {
+          safeWrite(
+            () => writeStatus.applyBlockedByRelation({ ticket: dep.candidate, blockedBy: dep.blocked_by }),
+            { ticket: dep.candidate, phase: "sequencing" }
+          );
+        }
+        continue; // hold — D5 enforces the new edge next tick
+      }
+      if (verdict?.verdict === "hold") continue; // soft conflict — no cooldown marker
+      // "go" → fall through to existing dispatch
+    }
     // CTL-660: record the new-work dispatch DECISION before the spawn.
     safeEmit(
       appendDispatchRequestedEvent,
@@ -2194,6 +2219,9 @@ function runTick() {
       livenessIsFresh:
         runningOpts.livenessIsFresh ??
         (runningOpts.liveBackgroundCount !== undefined ? () => true : () => getAgentsCached().isFresh),
+      // CTL-537: production defaults to defaultCheckSequencing; tests inject via
+      // startScheduler({ checkSequencing }) or directly into schedulerTick.
+      checkSequencing: runningOpts.checkSequencing ?? defaultCheckSequencing,
     });
   } catch (err) {
     // A tick must never crash the daemon — log and let the next tick retry.
@@ -2237,6 +2265,7 @@ export function startScheduler({
   // `claude agents --json` count). Symmetric with the existing dispatch /
   // exec / writeStatus / teardownWorktree seams on schedulerTick.
   livenessIsFresh, // CTL-731: optional override; runTick defaults to getAgentsCached().isFresh.
+  checkSequencing, // CTL-537: optional override; runTick defaults to defaultCheckSequencing.
   preflight = preflightWorkspaceLabels, // CTL-585
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
@@ -2255,6 +2284,7 @@ export function startScheduler({
     layer2Path, // CTL-678: per-tick Layer-2 re-read source (host-wide override)
     liveBackgroundCount, // CTL-676: test seam
     livenessIsFresh, // CTL-731: optional override (default getAgentsCached().isFresh)
+    checkSequencing, // CTL-537: optional override (default defaultCheckSequencing)
   };
 
   // CTL-585: warn once at startup if the Linear workspace lacks the labels

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1968,8 +1968,24 @@ export function schedulerTick(
         inFlightTickets,
         orchDir,
       });
-      if (verdict?.hard_dependencies?.length > 0) {
-        for (const dep of verdict.hard_dependencies) {
+      // CTL-537 (phase-review hardening): the verdict is LLM-generated, so its
+      // hard_dependencies IDs are untrusted. Only honor an edge that arbitrates
+      // the pair THIS gate is deciding — candidate must be the current ticket
+      // and blocked_by must be a currently in-flight ticket. Dropping anything
+      // else prevents a hallucinated/prompt-injected ID from writing a durable
+      // blocked-by edge on an unrelated ticket (which D5 would wrongly stall).
+      const rawDeps = verdict?.hard_dependencies ?? [];
+      const validDeps = rawDeps.filter(
+        (dep) => dep.candidate === t.identifier && inFlightTickets.has(dep.blocked_by)
+      );
+      if (rawDeps.length > validDeps.length) {
+        log.warn(
+          { candidate: t.identifier, dropped: rawDeps.length - validDeps.length },
+          "sequencing: dropped hard_dependencies not arbitrating the (candidate, in-flight) pair"
+        );
+      }
+      if (validDeps.length > 0) {
+        for (const dep of validDeps) {
           safeWrite(
             () => writeStatus.applyBlockedByRelation({ ticket: dep.candidate, blockedBy: dep.blocked_by }),
             { ticket: dep.candidate, phase: "sequencing" }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4924,6 +4924,41 @@ describe("CTL-537 sequencing seam (schedulerTick)", () => {
     expect(dispatchedNew).toBe(false);
   });
 
+  test("untrusted dep ids dropped → no blocked-by write, falls through to verdict (phase-review hardening)", () => {
+    const dispatch = fakeDispatch({ code: 0 });
+    const blockedByRelationCalls = [];
+    const writeStatus = {
+      applyPhaseStatus: () => ({ applied: true, reason: null }),
+      applyTerminalDone: () => ({ applied: true, reason: null }),
+      applyBlockedByRelation: (args) => { blockedByRelationCalls.push(args); return { applied: true, reason: null }; },
+    };
+    // LLM returns deps that DON'T arbitrate the (CTL-NEW, in-flight) pair:
+    // one with a foreign candidate, one blocked_by a non-in-flight ticket.
+    const checkSequencing = () => ({
+      verdict: "go",
+      reason: "",
+      hard_dependencies: [
+        { candidate: "CTL-OTHER", blocked_by: "CTL-IN", reason: "hallucinated candidate" },
+        { candidate: "CTL-NEW", blocked_by: "CTL-NOTLIVE", reason: "blocked_by not in-flight" },
+      ],
+    });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleTwo("CTL-NEW"),
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1,
+      checkSequencing,
+      writeStatus,
+    });
+    // No durable blocked-by edge written for the bogus deps
+    expect(blockedByRelationCalls).toHaveLength(0);
+    // With no VALID hard dep and a "go" verdict, dispatch proceeds
+    const dispatchedNew = dispatch.calls.some(
+      (c) => c.ticket === "CTL-NEW" || (Array.isArray(c) && c[1] === "CTL-NEW")
+    );
+    expect(dispatchedNew).toBe(true);
+  });
+
   test("seam undefined → byte-for-byte legacy: dispatch proceeds with one in-flight + free slot", () => {
     const dispatch = fakeDispatch({ code: 0 });
     schedulerTick(orchDir, {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4825,3 +4825,171 @@ describe("schedulerTick — predecessor reap on dispatch failure (CTL-695)", () 
     ).toBe(true);
   });
 });
+
+// ── CTL-537: sequencing seam in schedulerTick ──
+describe("CTL-537 sequencing seam (schedulerTick)", () => {
+  const eligibleTwo = (id) => [
+    {
+      identifier: id,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    },
+  ];
+
+  beforeEach(() => {
+    // maxParallel:2 so a 2nd candidate can be admitted while one is in-flight
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    // Write an in-flight signal so listInFlightTickets returns a non-empty set
+    writeSignal("CTL-IN", "research", "running");
+  });
+
+  test("seam not consulted when nothing in-flight — checkSequencing spy never called", () => {
+    let spyCount = 0;
+    const checkSequencing = () => { spyCount++; return { verdict: "go", hard_dependencies: [] }; };
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleTwo("CTL-NEW"),
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0, // nothing in-flight
+      checkSequencing,
+    });
+    expect(spyCount).toBe(0);
+    expect(dispatch.calls).toHaveLength(1); // dispatch still proceeds
+  });
+
+  test("go verdict → dispatch proceeds", () => {
+    const dispatch = fakeDispatch({ code: 0 });
+    const checkSequencing = () => ({ verdict: "go", hard_dependencies: [] });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleTwo("CTL-NEW"),
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1,
+      checkSequencing,
+    });
+    expect(dispatch.calls.some((c) => c.ticket === "CTL-NEW" || c[1] === "CTL-NEW")).toBe(true);
+  });
+
+  test("hold verdict → dispatch suppressed, no cooldown marker written", () => {
+    const dispatch = fakeDispatch({ code: 0 });
+    const checkSequencing = () => ({ verdict: "hold", hard_dependencies: [] });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleTwo("CTL-NEW"),
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1,
+      checkSequencing,
+    });
+    // Dispatch must not have been called for CTL-NEW
+    const dispatchedNew = dispatch.calls.some(
+      (c) => (c.ticket === "CTL-NEW" || (Array.isArray(c) && c[1] === "CTL-NEW"))
+    );
+    expect(dispatchedNew).toBe(false);
+    // No cooldown marker must have been written (hold is transient — no marker)
+    expect(existsSync(dispatchCooldownPath(orchDir, "CTL-NEW", "research"))).toBe(false);
+  });
+
+  test("hard_dependencies verdict → applyBlockedByRelation called + dispatch held", () => {
+    const dispatch = fakeDispatch({ code: 0 });
+    const blockedByRelationCalls = [];
+    const writeStatus = {
+      applyPhaseStatus: () => ({ applied: true, reason: null }),
+      applyTerminalDone: () => ({ applied: true, reason: null }),
+      applyBlockedByRelation: (args) => { blockedByRelationCalls.push(args); return { applied: true, reason: null }; },
+    };
+    const checkSequencing = () => ({
+      verdict: "go",
+      reason: "",
+      hard_dependencies: [{ candidate: "CTL-NEW", blocked_by: "CTL-IN", reason: "ordering" }],
+    });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleTwo("CTL-NEW"),
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1,
+      checkSequencing,
+      writeStatus,
+    });
+    // applyBlockedByRelation called with the dep
+    expect(blockedByRelationCalls).toHaveLength(1);
+    expect(blockedByRelationCalls[0]).toMatchObject({ ticket: "CTL-NEW", blockedBy: "CTL-IN" });
+    // Dispatch suppressed
+    const dispatchedNew = dispatch.calls.some(
+      (c) => (c.ticket === "CTL-NEW" || (Array.isArray(c) && c[1] === "CTL-NEW"))
+    );
+    expect(dispatchedNew).toBe(false);
+  });
+
+  test("seam undefined → byte-for-byte legacy: dispatch proceeds with one in-flight + free slot", () => {
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleTwo("CTL-NEW"),
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1,
+      // checkSequencing omitted → undefined default
+    });
+    // Dispatch must proceed (legacy behavior — seam absent means no gate)
+    const dispatchedNew = dispatch.calls.some(
+      (c) => c.ticket === "CTL-NEW" || (Array.isArray(c) && c[1] === "CTL-NEW")
+    );
+    expect(dispatchedNew).toBe(true);
+  });
+
+  test("cooldown precedes seam — checkSequencing spy NOT called for a cooling-down candidate", () => {
+    let spyCount = 0;
+    const checkSequencing = () => { spyCount++; return { verdict: "go", hard_dependencies: [] }; };
+    // Pre-seed a cooldown marker for CTL-NEW
+    recordDispatchFailure(orchDir, "CTL-NEW", "research", 1, 1_000);
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleTwo("CTL-NEW"),
+      dispatch: fakeDispatch({ code: 0 }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1,
+      now: () => 30_000, // within the 60 s window
+      checkSequencing,
+    });
+    expect(spyCount).toBe(0);
+  });
+});
+
+// ── CTL-537 Phase 5: startScheduler forwards checkSequencing to runTick ──
+describe("CTL-537 Phase 5: startScheduler forwards checkSequencing (runTick wiring)", () => {
+  afterEach(() => __resetForTests());
+
+  test("startScheduler forwards an injected checkSequencing spy — it is consulted on the initial tick", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    // Write an in-flight signal so inFlightCount >= 1
+    writeSignal("CTL-INFLIGHT", "research", "running");
+
+    let spyCount = 0;
+    const checkSequencing = () => { spyCount++; return { verdict: "go", hard_dependencies: [] }; };
+
+    const dispatch = fakeDispatch({ code: 0 });
+    startScheduler({
+      orchDir,
+      dispatch,
+      readEligible: () => [
+        {
+          identifier: "CTL-NEW",
+          priority: 1,
+          createdAt: "x",
+          state: "Todo",
+          relations: { nodes: [] },
+          inverseRelations: { nodes: [] },
+        },
+      ],
+      liveBackgroundCount: () => 1,
+      checkSequencing,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+    });
+
+    // The spy must have been consulted during the initial synchronous tick
+    expect(spyCount).toBeGreaterThan(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/sequencing.mjs
+++ b/plugins/dev/scripts/execution-core/sequencing.mjs
@@ -1,0 +1,120 @@
+// sequencing.mjs — CTL-537 sequencing-seam pure core + defaultCheckSequencing.
+// No I/O except injected seams (readTriage for Phase 2; spawn/cache for Phase 3).
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { log } from "./config.mjs";
+
+const GO = Object.freeze({ verdict: "go", hard_dependencies: [] });
+
+// defaultReadTriage — reads the triage.json artifact for a ticket, or null if
+// missing/unreadable. Degrading to null causes buildSequencingContext to use
+// id-only context for that ticket.
+export function defaultReadTriage(orchDir, ticket) {
+  try {
+    return JSON.parse(readFileSync(join(orchDir, "workers", ticket, "triage.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function compact(triage, id) {
+  if (!triage) return { id };
+  const { classification, summary } = triage;
+  const result = { id };
+  if (classification != null) result.classification = classification;
+  if (summary != null) result.summary = summary;
+  return result;
+}
+
+export function buildSequencingContext({ candidate, inFlightTickets, orchDir, readTriage = defaultReadTriage }) {
+  return {
+    candidate: compact(readTriage(orchDir, candidate), candidate),
+    inFlight: [...inFlightTickets].map((id) => compact(readTriage(orchDir, id), id)),
+  };
+}
+
+export function buildSequencingPrompt(context) {
+  return [
+    "You are a scheduling judge for parallel autonomous coding workers.",
+    "A candidate ticket is about to be dispatched while others are already in-flight.",
+    "Decide whether to admit it now, hold it (soft code-area conflict), or block it on a",
+    "hard dependency. Respond with ONLY a JSON object:",
+    '{"verdict":"go"|"hold","reason":"...","hard_dependencies":[{"candidate":"<id>","blocked_by":"<id>","reason":"..."}]}',
+    'Use "hold" for soft conflicts (likely to touch the same code area). Use',
+    "hard_dependencies ONLY for a true ordering dependency (candidate cannot correctly",
+    'land until an in-flight ticket merges). Default to "go" when unsure.',
+    "",
+    `CONTEXT:\n${JSON.stringify(context, null, 2)}`,
+  ].join("\n");
+}
+
+const VALID = new Set(["go", "hold"]);
+
+export function parseSequencingVerdict(raw) {
+  try {
+    let obj = JSON.parse(raw);
+    // Unwrap a `claude --output-format json` envelope if present.
+    if (obj && typeof obj === "object" && typeof obj.result === "string") {
+      obj = JSON.parse(obj.result);
+    } else if (obj && typeof obj === "object" && typeof obj.text === "string") {
+      obj = JSON.parse(obj.text);
+    }
+    if (!obj || !VALID.has(obj.verdict)) return { ...GO };
+    const deps = Array.isArray(obj.hard_dependencies)
+      ? obj.hard_dependencies.filter((d) => d && d.candidate && d.blocked_by)
+      : [];
+    return {
+      verdict: obj.verdict,
+      reason: typeof obj.reason === "string" ? obj.reason : "",
+      hard_dependencies: deps,
+    };
+  } catch {
+    return { ...GO };
+  }
+}
+
+export function sequencingCacheKey(candidateId, inFlightIds) {
+  return `${candidateId}::${[...inFlightIds].sort().join(",")}`;
+}
+
+// ── Phase 3: defaultCheckSequencing ──
+
+const CLAUDE_BIN = process.env.CATALYST_DISPATCH_CLAUDE_BIN || "claude";
+const _cache = new Map();
+
+export function __resetSequencingCacheForTests() {
+  _cache.clear();
+}
+
+function defaultSpawn(prompt) {
+  const r = spawnSync(CLAUDE_BIN, ["--print", "--output-format", "json", prompt], {
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  if (r.error) throw r.error;
+  return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+export function defaultCheckSequencing({
+  candidate,
+  inFlightTickets,
+  orchDir,
+  readTriage = defaultReadTriage,
+  spawn = defaultSpawn,
+  cache = _cache,
+}) {
+  const key = sequencingCacheKey(candidate, inFlightTickets);
+  if (cache.has(key)) return cache.get(key);
+  let verdict;
+  try {
+    const context = buildSequencingContext({ candidate, inFlightTickets, orchDir, readTriage });
+    const out = spawn(buildSequencingPrompt(context));
+    verdict = out.status === 0 ? parseSequencingVerdict(out.stdout) : { ...GO };
+  } catch (err) {
+    log.warn({ candidate, err: err.message }, "sequencing: judgment threw — fail-open go");
+    verdict = { ...GO };
+  }
+  cache.set(key, verdict);
+  return verdict;
+}

--- a/plugins/dev/scripts/execution-core/sequencing.test.mjs
+++ b/plugins/dev/scripts/execution-core/sequencing.test.mjs
@@ -1,0 +1,258 @@
+// sequencing.test.mjs — CTL-537 sequencing-seam unit tests.
+// Run: cd plugins/dev/scripts/execution-core && bun test sequencing.test.mjs
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  buildSequencingContext,
+  buildSequencingPrompt,
+  parseSequencingVerdict,
+  sequencingCacheKey,
+  defaultCheckSequencing,
+  __resetSequencingCacheForTests,
+} from "./sequencing.mjs";
+
+// ── Phase 2: pure core ──
+
+describe("buildSequencingContext", () => {
+  test("present triage contributes classification + summary", () => {
+    const readTriage = (_orchDir, id) =>
+      id === "CTL-1"
+        ? { classification: "feature", summary: "Add auth" }
+        : null;
+    const ctx = buildSequencingContext({
+      candidate: "CTL-1",
+      inFlightTickets: ["CTL-2", "CTL-3"],
+      orchDir: "/fake",
+      readTriage,
+    });
+    expect(ctx.candidate).toEqual({ id: "CTL-1", classification: "feature", summary: "Add auth" });
+    expect(ctx.inFlight).toEqual([{ id: "CTL-2" }, { id: "CTL-3" }]);
+  });
+
+  test("missing triage degrades to id-only", () => {
+    const readTriage = () => null;
+    const ctx = buildSequencingContext({
+      candidate: "CTL-1",
+      inFlightTickets: ["CTL-2"],
+      orchDir: "/fake",
+      readTriage,
+    });
+    expect(ctx.candidate).toEqual({ id: "CTL-1" });
+    expect(ctx.inFlight).toEqual([{ id: "CTL-2" }]);
+  });
+
+  test("empty inFlightTickets → empty inFlight array", () => {
+    const readTriage = () => null;
+    const ctx = buildSequencingContext({
+      candidate: "CTL-1",
+      inFlightTickets: [],
+      orchDir: "/fake",
+      readTriage,
+    });
+    expect(ctx.inFlight).toEqual([]);
+  });
+});
+
+describe("buildSequencingPrompt", () => {
+  test("deterministic — same input yields identical output", () => {
+    const ctx = { candidate: { id: "CTL-1" }, inFlight: [{ id: "CTL-2" }] };
+    expect(buildSequencingPrompt(ctx)).toBe(buildSequencingPrompt(ctx));
+  });
+
+  test("contains candidate id, in-flight ids, and JSON key instruction", () => {
+    const ctx = { candidate: { id: "CTL-1" }, inFlight: [{ id: "CTL-2" }] };
+    const prompt = buildSequencingPrompt(ctx);
+    expect(prompt).toContain("CTL-1");
+    expect(prompt).toContain("CTL-2");
+    expect(prompt).toContain("hard_dependencies");
+    expect(prompt).toContain("verdict");
+  });
+});
+
+describe("parseSequencingVerdict", () => {
+  test("valid hold verdict parsed verbatim", () => {
+    const raw = JSON.stringify({ verdict: "hold", reason: "same area", hard_dependencies: [] });
+    expect(parseSequencingVerdict(raw)).toEqual({ verdict: "hold", reason: "same area", hard_dependencies: [] });
+  });
+
+  test("valid verdict with hard_dependencies preserved", () => {
+    const raw = JSON.stringify({
+      verdict: "go",
+      reason: "",
+      hard_dependencies: [{ candidate: "CTL-1", blocked_by: "CTL-2", reason: "needs merge" }],
+    });
+    const v = parseSequencingVerdict(raw);
+    expect(v.verdict).toBe("go");
+    expect(v.hard_dependencies).toHaveLength(1);
+    expect(v.hard_dependencies[0]).toMatchObject({ candidate: "CTL-1", blocked_by: "CTL-2" });
+  });
+
+  test("unknown verdict value → fail-open go", () => {
+    const raw = JSON.stringify({ verdict: "unknown", reason: "", hard_dependencies: [] });
+    expect(parseSequencingVerdict(raw)).toEqual({ verdict: "go", hard_dependencies: [] });
+  });
+
+  test("missing keys → fail-open go", () => {
+    expect(parseSequencingVerdict(JSON.stringify({}))).toEqual({ verdict: "go", hard_dependencies: [] });
+  });
+
+  test("non-JSON → fail-open go", () => {
+    expect(parseSequencingVerdict("not json")).toEqual({ verdict: "go", hard_dependencies: [] });
+  });
+
+  test("empty string → fail-open go", () => {
+    expect(parseSequencingVerdict("")).toEqual({ verdict: "go", hard_dependencies: [] });
+  });
+
+  test("claude --output-format json envelope (result field) → unwraps inner verdict", () => {
+    const inner = { verdict: "hold", reason: "x", hard_dependencies: [] };
+    const envelope = JSON.stringify({ result: JSON.stringify(inner) });
+    expect(parseSequencingVerdict(envelope)).toEqual({ verdict: "hold", reason: "x", hard_dependencies: [] });
+  });
+
+  test("claude --output-format json envelope (text field) → unwraps inner verdict", () => {
+    const inner = { verdict: "go", reason: "", hard_dependencies: [] };
+    const envelope = JSON.stringify({ text: JSON.stringify(inner) });
+    const v = parseSequencingVerdict(envelope);
+    expect(v.verdict).toBe("go");
+  });
+
+  test("non-extractable envelope → fail-open go", () => {
+    const envelope = JSON.stringify({ result: "not json" });
+    expect(parseSequencingVerdict(envelope)).toEqual({ verdict: "go", hard_dependencies: [] });
+  });
+
+  test("hard_dependencies with missing fields filtered out", () => {
+    const raw = JSON.stringify({
+      verdict: "go",
+      reason: "",
+      hard_dependencies: [
+        { candidate: "CTL-1", blocked_by: "CTL-2", reason: "ok" },
+        { candidate: "CTL-3" }, // missing blocked_by → filtered
+        { blocked_by: "CTL-4" }, // missing candidate → filtered
+      ],
+    });
+    const v = parseSequencingVerdict(raw);
+    expect(v.hard_dependencies).toHaveLength(1);
+  });
+});
+
+describe("sequencingCacheKey", () => {
+  test("order-independent — different in-flight order yields same key", () => {
+    expect(sequencingCacheKey("CTL-1", ["CTL-2", "CTL-3"])).toBe(
+      sequencingCacheKey("CTL-1", ["CTL-3", "CTL-2"])
+    );
+  });
+
+  test("different candidate → different key", () => {
+    expect(sequencingCacheKey("CTL-1", ["CTL-2"])).not.toBe(
+      sequencingCacheKey("CTL-9", ["CTL-2"])
+    );
+  });
+
+  test("different in-flight set → different key", () => {
+    expect(sequencingCacheKey("CTL-1", ["CTL-2"])).not.toBe(
+      sequencingCacheKey("CTL-1", ["CTL-3"])
+    );
+  });
+});
+
+// ── Phase 3: defaultCheckSequencing ──
+
+describe("defaultCheckSequencing", () => {
+  beforeEach(() => __resetSequencingCacheForTests());
+
+  const readTriage = () => null;
+  const orchDir = "/fake";
+
+  test("happy path — spawn returns valid verdict → returned verbatim; one spawn call", () => {
+    const spawnCalls = [];
+    const spawn = (_prompt) => {
+      spawnCalls.push(true);
+      return { status: 0, stdout: JSON.stringify({ verdict: "hold", reason: "area", hard_dependencies: [] }), stderr: "" };
+    };
+    const result = defaultCheckSequencing({
+      candidate: "CTL-1",
+      inFlightTickets: ["CTL-2"],
+      orchDir,
+      readTriage,
+      spawn,
+    });
+    expect(result.verdict).toBe("hold");
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  test("fail-open on non-zero spawn status → go", () => {
+    const spawn = () => ({ status: 1, stdout: "", stderr: "error" });
+    const result = defaultCheckSequencing({
+      candidate: "CTL-1",
+      inFlightTickets: ["CTL-2"],
+      orchDir,
+      readTriage,
+      spawn,
+    });
+    expect(result.verdict).toBe("go");
+    expect(result.hard_dependencies).toEqual([]);
+  });
+
+  test("fail-open on garbage stdout → go", () => {
+    const spawn = () => ({ status: 0, stdout: "not json at all", stderr: "" });
+    const result = defaultCheckSequencing({
+      candidate: "CTL-1",
+      inFlightTickets: ["CTL-2"],
+      orchDir,
+      readTriage,
+      spawn,
+    });
+    expect(result.verdict).toBe("go");
+  });
+
+  test("fail-open on spawn throw → go, does not throw", () => {
+    const spawn = () => { throw new Error("spawn died"); };
+    expect(() =>
+      defaultCheckSequencing({ candidate: "CTL-1", inFlightTickets: ["CTL-2"], orchDir, readTriage, spawn })
+    ).not.toThrow();
+    const result = defaultCheckSequencing({
+      candidate: "CTL-1",
+      inFlightTickets: ["CTL-2"],
+      orchDir,
+      readTriage,
+      spawn,
+    });
+    expect(result.verdict).toBe("go");
+  });
+
+  test("cache hit — same (candidate, inFlightTickets) → spawn invoked once; second call served from cache", () => {
+    const spawnCalls = [];
+    const verdict = { verdict: "hold", reason: "area", hard_dependencies: [] };
+    const spawn = () => { spawnCalls.push(true); return { status: 0, stdout: JSON.stringify(verdict), stderr: "" }; };
+    const opts = { candidate: "CTL-1", inFlightTickets: ["CTL-2"], orchDir, readTriage, spawn };
+    const r1 = defaultCheckSequencing(opts);
+    const r2 = defaultCheckSequencing(opts);
+    expect(spawnCalls).toHaveLength(1);
+    expect(r1).toBe(r2); // same object reference from cache
+  });
+
+  test("cache invalidation — different in-flight set → spawn invoked twice", () => {
+    const spawnCalls = [];
+    const spawn = () => {
+      spawnCalls.push(true);
+      return { status: 0, stdout: JSON.stringify({ verdict: "go", reason: "", hard_dependencies: [] }), stderr: "" };
+    };
+    defaultCheckSequencing({ candidate: "CTL-1", inFlightTickets: ["CTL-2"], orchDir, readTriage, spawn });
+    defaultCheckSequencing({ candidate: "CTL-1", inFlightTickets: ["CTL-3"], orchDir, readTriage, spawn });
+    expect(spawnCalls).toHaveLength(2);
+  });
+
+  test("__resetSequencingCacheForTests clears the cache", () => {
+    const spawnCalls = [];
+    const spawn = () => {
+      spawnCalls.push(true);
+      return { status: 0, stdout: JSON.stringify({ verdict: "go", reason: "", hard_dependencies: [] }), stderr: "" };
+    };
+    const opts = { candidate: "CTL-1", inFlightTickets: ["CTL-2"], orchDir, readTriage, spawn };
+    defaultCheckSequencing(opts);
+    __resetSequencingCacheForTests();
+    defaultCheckSequencing(opts);
+    expect(spawnCalls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-02T05:30:00Z -->
<!-- Last updated: 2026-06-02T05:30:00Z -->
<!-- PR: #1266 -->
<!-- Previous commits: a3f8bc416dd4566757a18d80d380bc2e2bc4dce7,225fe9c62581d360297b660776f91cf5d1f50b92 -->

## Summary

Adds the M4 scheduler sequencing gate — the LLM seam that fires when ≥1 worker is in-flight and a second candidate is about to be dispatched. A short-lived `claude --print` judgment returns one of: **go** (dispatch proceeds), **hold** (soft code-area conflict, candidate deferred one tick, no cooldown marker), or **hard_dependencies** (durable blocked-by edges written to Linear, candidate held until D5's readiness filter promotes it again).

The seam is fully injectable and **backward-compatible**: existing tests see `checkSequencing = undefined` and the gate is skipped entirely — zero changes to the established dispatch path for single-ticket or non-sequencing runs.

## Changes Made

### New module: `sequencing.mjs`
- `buildSequencingPrompt(ctx)` — constructs the LLM prompt from candidate + in-flight ticket context (triage summaries when available)
- `parseSequencingVerdict(raw)` — parse + validate LLM output; unwraps `claude --output-format json` envelope; normalizes unknown verdict values to fail-open `go`; filters `hard_dependencies` entries missing required `candidate`/`blocked_by` fields
- `sequencingCacheKey(candidate, inFlightTickets)` — order-independent cache key so the same (candidate, in-flight set) pair isn't re-evaluated each tick
- `defaultCheckSequencing({ candidate, inFlightTickets, orchDir, spawn })` — module-level verdict cache + injectable `spawn` (no test spawns a real `claude`); fail-open on non-zero exit, garbage stdout, or spawn throw

### `linear-write.mjs` — `applyBlockedByRelation`
- Best-effort, never-throws helper that writes a durable `linearis issues update <ticket> --blocked-by <dep>` edge
- Returns `{ applied, reason }` — mirrors `applyLabel` but without a read-back (blocked-by relations are durable; the seam re-evaluates next tick on transient failure)

### `scheduler.mjs` — sequencing seam wired into dispatch loop
- `schedulerTick` accepts optional `checkSequencing` parameter (default `undefined` → legacy path unchanged)
- Gate fires only when `inFlightCount >= 1` and `checkSequencing` is non-null
- **Phase-review hardening (commit 2):** LLM-returned `hard_dependencies` IDs are validated before writing — `candidate` must equal the ticket being decided and `blocked_by` must be in the current in-flight set; hallucinated or prompt-injected IDs are dropped (logged) to prevent durable blocked-by edges on unrelated tickets
- `runTick` defaults to `defaultCheckSequencing`; `startScheduler` exposes the override for integration testing

### Tests (694 lines added, 0 deleted)
- `linear-write.test.mjs` — 5 tests for `applyBlockedByRelation` (success, arg order, non-zero exit, spawn throw, idempotent re-apply)
- `sequencing.test.mjs` — 258 lines covering `buildSequencingPrompt`, `parseSequencingVerdict` (10 cases including envelope unwrap and field filtering), `sequencingCacheKey`, and `defaultCheckSequencing` (7 cases including cache hit, cache invalidation, and fail-open paths)
- `scheduler.test.mjs` — 203 lines for the `CTL-537 sequencing seam` suite: seam-not-consulted (nothing in-flight), go verdict, hold verdict (no cooldown marker), hard_dependencies verdict (applyBlockedByRelation called + dispatch held), untrusted dep IDs dropped

## How to Verify It

- [ ] `cd plugins/dev/scripts/execution-core && bun install && bun test linear-write.test.mjs sequencing.test.mjs` — all tests pass
- [ ] `bun test scheduler.test.mjs` — full scheduler suite (4800+ existing tests) passes alongside the 5 new CTL-537 sequencing seam tests
- [ ] Confirm `sequencing.test.mjs` cache-hit test: spawn invoked once for same `(candidate, inFlightTickets)` pair
- [ ] Confirm `scheduler.test.mjs` `hold verdict` test: no dispatch call for the held candidate, no cooldown marker file written
- [ ] Confirm `scheduler.test.mjs` `untrusted dep ids dropped` test: hallucinated IDs do not call `applyBlockedByRelation`

## Architecture Notes

- The seam integrates with the D5 trigger model: `applyBlockedByRelation` writes a native Linear `blocked-by` relation that the readiness filter's blocker-state hydration checks each tick. A held candidate re-enters the eligible set once its blocker reaches `Done`.
- Verdict caching is module-level (reset between test suites via `__resetSequencingCacheForTests`). The cache key is order-independent over the in-flight ticket set, so a different in-flight composition always re-evaluates.
- Fail-open is unconditional: any error in prompt construction, spawn, parsing, or validation falls through to `{ verdict: "go", hard_dependencies: [] }`, ensuring the gate never stalls the scheduler.

## Related Issues

- Fixes https://linear.app/rozich/issue/CTL-537
- Design doc: `thoughts/shared/plans/2026-05-21-linear-state-machine-trigger-model.md` (M4 §scheduler sequencing)
