### PR TITLE
CTL-549: [M5·seam] Human-in-the-loop clarification protocol

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -320,6 +320,61 @@ echo '{"ticket":"CTL-100","phase":"implement","status":"running"}' >"$SIGNAL"
 CATALYST_GENERATION=2 "$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status complete >/dev/null 2>&1
 assert_eq "done" "$(jq -r '.status' "$SIGNAL")" "signal without generation field still emits (no fence data)"
 
+# ─── CTL-549: park status ───────────────────────────────────────────────────
+
+echo ""
+echo "Test 17 (CTL-549): --status park is accepted (exit 0)"
+fresh_env t17
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 \
+	--status park --handoff-path /tmp/handoff.md \
+	>/dev/null 2>&1
+assert_eq "0" "$?" "park: script exits 0"
+
+echo ""
+echo "Test 18 (CTL-549): signal file gets status=needs-input and parkedFrom=implement"
+fresh_env t18
+mkdir -p "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' \
+	>"${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 \
+	--status park --handoff-path /tmp/handoff.md >/dev/null 2>&1
+SIG="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+STATUS=$(jq -r '.status' "$SIG")
+PARKED_FROM=$(jq -r '.parkedFrom' "$SIG")
+HANDOFF=$(jq -r '.handoffPath' "$SIG")
+assert_eq "needs-input" "$STATUS" "park: signal status=needs-input"
+assert_eq "implement" "$PARKED_FROM" "park: signal parkedFrom=implement"
+assert_eq "/tmp/handoff.md" "$HANDOFF" "park: signal handoffPath set"
+
+echo ""
+echo "Test 19 (CTL-549): completedAt is NOT set on park (non-terminal)"
+fresh_env t19
+mkdir -p "${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' \
+	>"${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status park >/dev/null 2>&1
+SIG="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+COMPLETED_AT=$(jq -r '.completedAt // "absent"' "$SIG")
+assert_eq "absent" "$COMPLETED_AT" "park: completedAt not set"
+
+echo ""
+echo "Test 20 (CTL-549): event name is phase.implement.park.CTL-100"
+fresh_env t20
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status park >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z $LINE ]]; then
+	fail "Test 20: no event line emitted for park"
+else
+	EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+	assert_eq "phase.implement.park.CTL-100" "$EVENT_NAME" "park: event name is phase.implement.park.CTL-100"
+fi
+
+echo ""
+echo "Test 21 (CTL-549): unknown status 'parked' still rejected (exit 1)"
+fresh_env t21
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status parked 2>/dev/null
+assert_eq "1" "$?" "invalid status parked: exits 1"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -121,6 +121,15 @@ export function selectBootResumeCandidates({
   for (const ticket of inFlight) {
     const active = activePhaseForTicket(byTicket.get(ticket) ?? []);
     if (!active) continue; // mid-advance: terminal active signal, nothing to resume
+    // CTL-549: needs-input is intentionally parked — never auto-resume on reboot.
+    // The comment-wake path in daemon.mjs handles re-dispatch when the human replies.
+    if (active.status === "needs-input") {
+      logger.debug(
+        { ticket, phase: active.phase },
+        "boot-resume: skipping needs-input (awaiting human comment)"
+      );
+      continue;
+    }
     if (!active.worktreePath) {
       logger.warn(
         { ticket, phase: active.phase },

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -625,3 +625,28 @@ describe("defaultAppendBootResumeEvent envelope", () => {
     expect(countReviveEvents({ ticket: "CTL-RT-654" })).toBe(0);
   });
 });
+
+// CTL-549: selectBootResumeCandidates skips needs-input signals
+describe("selectBootResumeCandidates — needs-input guard (CTL-549)", () => {
+  test("skips tickets with needs-input signal (not re-dispatched on reboot)", () => {
+    writeSignal(orchDir, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+      worktreePath: "/wt/CTL-1",
+    });
+    const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 4 });
+    expect(out.map((c) => c.ticket)).not.toContain("CTL-1");
+  });
+
+  test("other in-flight tickets are still resumed normally alongside a parked one", () => {
+    writeSignal(orchDir, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+      worktreePath: "/wt/CTL-1",
+    });
+    writeSignal(orchDir, "CTL-2", "verify", { worktreePath: "/wt/CTL-2" });
+    const out = selectBootResumeCandidates({ orchDir, agents: [], maxParallel: 4 });
+    expect(out.map((c) => c.ticket)).not.toContain("CTL-1");
+    expect(out.map((c) => c.ticket)).toContain("CTL-2");
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -22,8 +22,10 @@ import {
   fstatSync,
   readSync,
   closeSync,
+  readdirSync,
+  readFileSync,
 } from "node:fs";
-import { resolve, dirname, basename } from "node:path";
+import { resolve, dirname, basename, join } from "node:path";
 import { homedir } from "node:os";
 import { parseEventTailChunk } from "./event-tail.mjs";
 import {
@@ -66,6 +68,8 @@ import {
 } from "./scheduler.mjs";
 import { writeBootMarker, clearProgressMarks } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
+import { dispatchTicket } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch
+import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human/question on resume
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -104,6 +108,53 @@ function ensureState(orchDir) {
     const tmp = `${statePath}.tmp`;
     writeFileSync(tmp, JSON.stringify({ maxParallel: DEFAULT_MAX_PARALLEL }, null, 2));
     renameSync(tmp, statePath);
+  }
+}
+
+// handleCommentWake — CTL-549 re-dispatch hook. Called on each
+// `linear.comment.created` event by the daemon's `onComment` callback wired
+// into startMonitor. Scans all phase signals for the comment's ticket; for
+// each signal with status === "needs-input", removes the needs-human/question
+// label and re-dispatches via dispatchTicket with the parked handoffPath.
+// Fail-open throughout — a bad signal file or removeLabel failure is logged
+// and skipped, never fatal.
+export async function handleCommentWake(
+  parsed,
+  { orchDir, dispatch, removeLabel },
+) {
+  const { ticket } = parsed ?? {};
+  if (!ticket) return;
+
+  const workerDir = join(orchDir, "workers", ticket);
+  let signalFiles;
+  try {
+    signalFiles = readdirSync(workerDir).filter(
+      (f) => f.startsWith("phase-") && f.endsWith(".json"),
+    );
+  } catch {
+    return;
+  }
+
+  for (const fname of signalFiles) {
+    let sig;
+    try {
+      sig = JSON.parse(readFileSync(join(workerDir, fname), "utf8"));
+    } catch {
+      continue;
+    }
+
+    if (sig.status !== "needs-input") continue;
+
+    const parkedPhase = sig.parkedFrom ?? sig.phase;
+    const handoffPath = sig.handoffPath ?? undefined;
+
+    try {
+      await removeLabel(ticket, "needs-human/question");
+    } catch {
+      /* fail-open */
+    }
+
+    dispatch(orchDir, ticket, parkedPhase, { handoffPath });
   }
 }
 
@@ -208,7 +259,16 @@ export function startDaemon({
     // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
     // agent on a →Triage transition. `dispatch` stays an injectable default
     // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
-    monitorFn({ orchDir, cache }); // CTL-535 + CTL-565 + CTL-634
+    monitorFn({
+      orchDir,
+      cache,
+      onComment: (parsed) =>
+        handleCommentWake(parsed, {
+          orchDir,
+          dispatch: dispatchTicket,
+          removeLabel: defaultRemoveLabel,
+        }),
+    }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 (onComment)
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -24,6 +24,7 @@ import {
   consumeEventTail,
   parseEventTailChunk,
   resolveBootConcurrency,
+  handleCommentWake,
   __resetEventTailCursorForTest,
   __getEventTailLeftoverForTest,
 } from "./daemon.mjs";
@@ -802,5 +803,123 @@ describe("auto-tuner wiring (CTL-684)", () => {
     } catch {}
     // PID file must be removed by stopDaemon's cleanup path
     if (pidFile) expect(existsSync(pidFile)).toBe(false);
+  });
+});
+
+// CTL-549: handleCommentWake — re-dispatch a parked (needs-input) ticket
+describe("handleCommentWake (CTL-549)", () => {
+  const tmpOrcDir = () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl-549-orch-"));
+    return dir;
+  };
+  const writeSignal = (orch, ticket, phase, data) => {
+    const workerDir = join(orch, "workers", ticket);
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      join(workerDir, `phase-${phase}.json`),
+      JSON.stringify({ ticket, phase, ...data }),
+    );
+  };
+
+  test("re-dispatches ticket whose signal has status=needs-input", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+      handoffPath: "/path/handoff.md",
+      bg_job_id: "job123",
+    });
+    const dispatched = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", commentId: "c1", body: "Here is the answer" },
+      {
+        orchDir: orch,
+        dispatch: (dir, ticket, phase, opts) => { dispatched.push({ ticket, phase, opts }); return { code: 0 }; },
+        removeLabel: async () => {},
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].ticket).toBe("CTL-1");
+    expect(dispatched[0].phase).toBe("implement");
+    expect(dispatched[0].opts.handoffPath).toBe("/path/handoff.md");
+  });
+
+  test("no-ops for ticket with status=running (not parked)", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", { status: "running" });
+    const dispatched = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", body: "reply" },
+      {
+        orchDir: orch,
+        dispatch: (...a) => { dispatched.push(a); return { code: 0 }; },
+        removeLabel: async () => {},
+      },
+    );
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("calls removeLabel before dispatch on re-dispatch", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    const removed = [];
+    const dispatchOrder = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", body: "answer" },
+      {
+        orchDir: orch,
+        dispatch: () => { dispatchOrder.push("dispatch"); return { code: 0 }; },
+        removeLabel: async (ticket, label) => { removed.push({ ticket, label }); dispatchOrder.push("remove"); },
+      },
+    );
+    expect(removed).toContainEqual({ ticket: "CTL-1", label: "needs-human/question" });
+    expect(dispatchOrder.indexOf("remove")).toBeLessThan(dispatchOrder.indexOf("dispatch"));
+  });
+
+  test("no-ops when ticket has no worker dir", async () => {
+    const orch = tmpOrcDir();
+    const dispatched = [];
+    await handleCommentWake(
+      { ticket: "CTL-99", body: "hello" },
+      {
+        orchDir: orch,
+        dispatch: (...a) => { dispatched.push(a); return { code: 0 }; },
+        removeLabel: async () => {},
+      },
+    );
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("no-ops when parsed event has no ticket", async () => {
+    const orch = tmpOrcDir();
+    const dispatched = [];
+    await handleCommentWake(
+      { body: "hello" },
+      {
+        orchDir: orch,
+        dispatch: (...a) => { dispatched.push(a); return { code: 0 }; },
+        removeLabel: async () => {},
+      },
+    );
+    expect(dispatched).toHaveLength(0);
+  });
+});
+
+// CTL-549: startDaemon wires onComment to handleCommentWake
+describe("startDaemon — onComment wiring (CTL-549)", () => {
+  test("passes onComment callback to startMonitor", () => {
+    let capturedOnComment;
+    startDaemon({
+      recover: () => {},
+      reconcileBoot: () => {},
+      startMonitor: (opts) => { capturedOnComment = opts.onComment; },
+      startScheduler: () => {},
+      watchRegistry: false,
+    });
+    expect(typeof capturedOnComment).toBe("function");
+    stopDaemon();
   });
 });

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -53,11 +53,13 @@ function defaultResolveProject(ticket) {
 // when null/undefined → today's fresh-start behaviour. `spawn` is injectable so
 // the unit test can assert the built arg array without a real spawn.
 export function defaultRunPhaseAgent(
-  { orchDir, ticket, phase, worktreePath, resumeSession },
+  { orchDir, ticket, phase, worktreePath, resumeSession, handoffPath },
   { spawn = spawnSync } = {},
 ) {
   const args = ["--phase", phase, "--ticket", ticket, "--orch-dir", orchDir, "--orch-id", ticket];
   if (resumeSession) args.push("--resume-session", resumeSession);
+  const extraEnv = {};
+  if (handoffPath) extraEnv.CATALYST_HANDOFF_PATH = handoffPath;
   const res = spawn(PHASE_AGENT_DISPATCH_BIN, args, {
     cwd: worktreePath,
     encoding: "utf8",
@@ -68,6 +70,7 @@ export function defaultRunPhaseAgent(
       CATALYST_PHASE: phase,
       CATALYST_TICKET: ticket,
       CATALYST_EXECUTION_CORE: "1",
+      ...extraEnv,
     },
   });
   if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
@@ -91,7 +94,7 @@ export function defaultRunPhaseAgent(
 // verbatim to runPhaseAgent so the spawned phase-agent-dispatch carries
 // `--resume-session`. Absent on every cold dispatch — only the revive path sets it.
 export function defaultDispatch(
-  { orchDir, ticket, phase, expectedWorktreePath, resumeSession },
+  { orchDir, ticket, phase, expectedWorktreePath, resumeSession, handoffPath },
   {
     resolveProject = defaultResolveProject,
     createWorktree = defaultCreateWorktree,
@@ -125,7 +128,7 @@ export function defaultDispatch(
       worktreePath: wt.worktreePath,
     };
   }
-  const res = runPhaseAgent({ orchDir, ticket, phase, worktreePath: wt.worktreePath, resumeSession });
+  const res = runPhaseAgent({ orchDir, ticket, phase, worktreePath: wt.worktreePath, resumeSession, handoffPath });
   return { ...res, worktreePath: wt.worktreePath };
 }
 
@@ -135,9 +138,10 @@ export function defaultDispatch(
 // green because the key is not added when the value is falsy.
 export function dispatchTicket(
   orchDir, ticket, phase,
-  { dispatch = defaultDispatch, resumeSession } = {},
+  { dispatch = defaultDispatch, resumeSession, handoffPath } = {},
 ) {
   const args = { orchDir, ticket, phase };
   if (resumeSession) args.resumeSession = resumeSession;
+  if (handoffPath) args.handoffPath = handoffPath;
   return dispatch(args);
 }

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -288,4 +288,82 @@ describe("dispatchTicket", () => {
     dispatchTicket("/orch", "CTL-1", "implement", { dispatch, resumeSession: "uuid-123" });
     expect(calls[0].resumeSession).toBe("uuid-123");
   });
+
+  // CTL-549: handoffPath thread-through
+  test("backward compat: no handoffPath → dispatch receives no handoffPath key", () => {
+    const calls = [];
+    const dispatch = (args) => { calls.push(args); return { code: 0 }; };
+    dispatchTicket("/orch", "CTL-1", "triage", { dispatch });
+    expect("handoffPath" in calls[0]).toBe(false);
+  });
+
+  test("forwards handoffPath to dispatch when provided", () => {
+    const calls = [];
+    const dispatch = (args) => { calls.push(args); return { code: 0 }; };
+    dispatchTicket("/orch", "CTL-1", "implement", { dispatch, handoffPath: "/path/to/handoff.md" });
+    expect(calls[0].handoffPath).toBe("/path/to/handoff.md");
+  });
+});
+
+// CTL-549: handoffPath → CATALYST_HANDOFF_PATH env var in spawned process
+describe("defaultRunPhaseAgent — handoffPath env injection (CTL-549)", () => {
+  const spy = () => {
+    const calls = [];
+    const spawn = (bin, args, opts) => {
+      calls.push({ bin, args, opts });
+      return { status: 0, stdout: "ok", stderr: "" };
+    };
+    spawn.calls = calls;
+    return spawn;
+  };
+
+  test("sets CATALYST_HANDOFF_PATH when handoffPath provided", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", worktreePath: "/wt/CTL-1", handoffPath: "/path/to/handoff.md" },
+      { spawn },
+    );
+    expect(spawn.calls[0].opts.env.CATALYST_HANDOFF_PATH).toBe("/path/to/handoff.md");
+  });
+
+  test("does NOT set CATALYST_HANDOFF_PATH when handoffPath absent", () => {
+    const spawn = spy();
+    defaultRunPhaseAgent(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", worktreePath: "/wt/CTL-1" },
+      { spawn },
+    );
+    expect(spawn.calls[0].opts.env.CATALYST_HANDOFF_PATH).toBeUndefined();
+  });
+});
+
+// CTL-549: defaultDispatch forwards handoffPath to runPhaseAgent
+describe("defaultDispatch — handoffPath passthrough (CTL-549)", () => {
+  const seams = (handoffPath) => {
+    const calls = [];
+    return {
+      resolveProject: () => ({ repoRoot: "/repo" }),
+      createWorktree: () => ({ code: 0, worktreePath: "/wt/CTL-1" }),
+      runPhaseAgent: (args) => { calls.push(args); return { code: 0 }; },
+      calls,
+      handoffPath,
+    };
+  };
+
+  test("forwards handoffPath to runPhaseAgent when set", () => {
+    const s = seams("/path/to/handoff.md");
+    defaultDispatch(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", handoffPath: "/path/to/handoff.md" },
+      { resolveProject: s.resolveProject, createWorktree: s.createWorktree, runPhaseAgent: s.runPhaseAgent },
+    );
+    expect(s.calls[0].handoffPath).toBe("/path/to/handoff.md");
+  });
+
+  test("handoffPath is undefined on a cold dispatch (no handoffPath)", () => {
+    const s = seams(undefined);
+    defaultDispatch(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement" },
+      { resolveProject: s.resolveProject, createWorktree: s.createWorktree, runPhaseAgent: s.runPhaseAgent },
+    );
+    expect(s.calls[0].handoffPath).toBeUndefined();
+  });
 });

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -167,6 +167,34 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
   }
 }
 
+// removeLabel — remove a single label from a ticket via linearis --label-mode
+// remove (CTL-549). Counterpart to applyLabel; used by handleCommentWake to
+// clear needs-human/question when re-dispatching a parked worker. No read-back
+// (remove is idempotent for absent labels). Returns { removed: true } on
+// success, { removed: false, reason } on failure. Never throws.
+export async function removeLabel(ticket, label, { exec = defaultExec } = {}) {
+  try {
+    const res = exec("linearis", [
+      "issues",
+      "update",
+      ticket,
+      "--labels",
+      label,
+      "--label-mode",
+      "remove",
+    ]);
+    if ((res.code ?? res.status ?? 0) !== 0) {
+      const reason = classifyLabelFailure(res.stderr ?? "");
+      log.warn({ ticket, label, reason }, "removeLabel: failed");
+      return { removed: false, reason };
+    }
+    return { removed: true };
+  } catch (err) {
+    log.warn({ ticket, label, reason: "transient", err: err.message }, "removeLabel: threw");
+    return { removed: false, reason: "transient" };
+  }
+}
+
 // applyTriageStatus — verified Todo→Triage write-back (CTL-704). Reads the
 // pre-transition state, shells linear-transition.sh for the triage key, then
 // re-reads to confirm the state actually landed. Returns

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -6,6 +6,7 @@ import {
   applyTerminalDone,
   applyLabel,
   applyTriageStatus,
+  removeLabel,
   teamOf,
 } from "./linear-write.mjs";
 
@@ -301,5 +302,39 @@ describe("applyTriageStatus", () => {
     const r = applyTriageStatus({ ticket: "CTL-704", resolveRepoRoot, exec, fetchState });
     expect(r.applied).toBe(false);
     expect(r.verified).toBe(false);
+  });
+});
+
+// CTL-549: removeLabel — remove a single label via linearis --label-mode remove
+describe("removeLabel (CTL-549)", () => {
+  test("shells linearis issues update with --label-mode remove", async () => {
+    const cmds = [];
+    const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
+    await removeLabel("CTL-1", "needs-human/question", { exec });
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0].args).toContain("--label-mode");
+    expect(cmds[0].args).toContain("remove");
+    expect(cmds[0].args).toContain("needs-human/question");
+    expect(cmds[0].args).toContain("CTL-1");
+  });
+
+  test("returns { removed: true } on exit 0", async () => {
+    const exec = () => ({ code: 0, stdout: "", stderr: "" });
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec });
+    expect(result.removed).toBe(true);
+  });
+
+  test("returns { removed: false, reason } on non-zero exit", async () => {
+    const exec = () => ({ code: 1, stdout: "", stderr: "not found" });
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec });
+    expect(result.removed).toBe(false);
+    expect(result.reason).toBeTruthy();
+  });
+
+  test("returns { removed: false, reason: 'transient' } on thrown exec", async () => {
+    const exec = () => { throw new Error("spawn failed"); };
+    const result = await removeLabel("CTL-1", "needs-human/question", { exec });
+    expect(result.removed).toBe(false);
+    expect(result.reason).toBe("transient");
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1280,6 +1280,14 @@ export function reclaimDeadWorkIfPossible(
   // below; the job dir's existence/mtime is no longer the death signal.
   if (klass === "terminal" || klass === "unknown") return "noop";
 
+  // CTL-549: needs-input signals are intentionally parked awaiting a human
+  // comment. Neither reclaim nor escalate — the comment-wake path in daemon.mjs
+  // handles re-dispatch. Treat as noop so the per-tick sweep never interferes.
+  if (signal?.status === "needs-input") {
+    log.debug({ ticket: signal.ticket }, "reclaimDeadWork: skipping needs-input (parked for human)");
+    return "noop";
+  }
+
   const { ticket, phase } = signal;
   const orchId = signal.raw?.orchestrator;
   const prevBgJobId = signal.raw?.bg_job_id ?? null;

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -3038,3 +3038,36 @@ describe("parallelism event envelopes (CTL-684)", () => {
     expect(env.attributes["event.name"]).toBe("phase.scheduler.parallelism-adjusted.execution-core");
   });
 });
+
+// CTL-549: reclaimDeadWorkIfPossible returns "noop" for needs-input signal
+describe("reclaimDeadWorkIfPossible — needs-input guard (CTL-549)", () => {
+  test("returns 'noop' for a needs-input signal without touching any seams", () => {
+    const orch = "/orch";
+    const sig = implementSignal({ status: "needs-input" });
+    const probed = [];
+    const dispatched = [];
+    const r = reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ state: "stopped", firstTerminalAt: "2026-01-01T00:00:00Z" }),
+      probes: { implement: () => { probed.push(true); return false; } },
+      reviveDispatch: (...a) => { dispatched.push(a); return { code: 0 }; },
+      emitComplete: () => ({ code: 0 }),
+      appendEvent: () => {},
+      appendReviveEvent: () => {},
+      appendEscalatedEvent: () => {},
+      appendReviveSuppressedEvent: () => {},
+      applyStalledLabel: () => {},
+      killBgJob: () => {},
+      countReviveEvents: () => 0,
+      writeReviveMarker: () => {},
+      readBootSince: () => undefined,
+      progressMark: () => 0,
+      readProgressMark: () => 0,
+      writeProgressMark: () => {},
+      emitReapIntent: () => {},
+      postReclaimMirror: () => {},
+    });
+    expect(r).toBe("noop");
+    expect(probed).toHaveLength(0);
+    expect(dispatched).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -135,8 +135,8 @@ done
 [[ -n $STATUS ]] || die "--status is required"
 
 case "$STATUS" in
-complete | failed | turn-cap-exhausted | skipped) ;;
-*) die "--status must be 'complete', 'failed', 'turn-cap-exhausted', or 'skipped' (got: $STATUS)" ;;
+complete | failed | turn-cap-exhausted | skipped | park) ;;
+*) die "--status must be 'complete', 'failed', 'turn-cap-exhausted', 'skipped', or 'park' (got: $STATUS)" ;;
 esac
 
 # Validate ticket shape against the same pattern the broker uses.
@@ -240,12 +240,11 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
 		failed) NEW_STATUS="failed" ;;
 		turn-cap-exhausted) NEW_STATUS="turn-cap-exhausted" ;;
 		skipped) NEW_STATUS="skipped" ;; # CTL-512: monitor-deploy terminal-no-deploy
+		park) NEW_STATUS="needs-input" ;; # CTL-549: parked waiting for human comment
 		esac
-		# turn-cap-exhausted is NOT a terminal state — leave completedAt unset so
-		# consumers can distinguish "worker stopped at cap, awaiting continuation"
-		# from "worker reached its definition of done". CTL-512: skipped IS terminal
-		# (slot frees), so it falls through to the default SET_COMPLETED branch.
-		if [[ $STATUS == "turn-cap-exhausted" ]]; then
+		# turn-cap-exhausted and park are NOT terminal states — leave completedAt unset.
+		# CTL-512: skipped IS terminal (slot frees), so it falls through to SET_COMPLETED.
+		if [[ $STATUS == "turn-cap-exhausted" || $STATUS == "park" ]]; then
 			SET_COMPLETED='.'
 		else
 			SET_COMPLETED='.completedAt = $ts'
@@ -255,11 +254,13 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
 			--arg ts "$TS" \
 			--arg reason "$REASON" \
 			--arg handoff "$HANDOFF_PATH" \
+			--arg phase "$PHASE" \
 			".status = \$status
            | ${SET_COMPLETED}
            | .updatedAt = \$ts
            | (if \$reason  == \"\" then . else .failureReason = \$reason end)
-           | (if \$handoff == \"\" then . else .handoffPath    = \$handoff end)" \
+           | (if \$handoff == \"\" then . else .handoffPath    = \$handoff end)
+           | (if \$status  == \"needs-input\" then .parkedFrom = \$phase else . end)" \
 			"$SIGNAL_FILE" >"$TMP" 2>/dev/null; then
 			mv "$TMP" "$SIGNAL_FILE"
 		else
@@ -285,6 +286,7 @@ if [[ -n $SESSION_ID ]] && [[ -x "${SCRIPT_DIR}/catalyst-session.sh" ]]; then
 	complete) SESSION_OUTCOME=done ;;
 	skipped) SESSION_OUTCOME=done ;;
 	turn-cap-exhausted) SESSION_OUTCOME=failed ;;
+	park) SESSION_OUTCOME=failed ;;
 	*) SESSION_OUTCOME=failed ;;
 	esac
 	REASON_FLAG=()


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-02T05:30:00Z -->
<!-- Last updated: 2026-06-02T05:30:00Z -->
<!-- PR: #1267 -->
<!-- Previous commits: b816647b,67753d97,de5410da,1e2e4369 -->

## Summary

Implements the park/resume protocol for Catalyst's human-in-the-loop clarification flow ([M5·seam]). When a phase-agent worker needs human input, it now parks itself in a `needs-input` state (freeing its concurrency slot), posts a question to the Linear ticket, and exits cleanly. When the human replies via a Linear comment, the daemon wakes and re-dispatches the worker with the handoff path — without bouncing the ticket back to Triage.

This is a pure addition: no existing behavior changes for running, complete, or failed workers. All new paths have full test coverage.

## Changes Made

### Phase 1 — `phase-agent-emit-complete`: park status (`b816647b`)

`plugins/dev/scripts/phase-agent-emit-complete`

- Adds `park` as a recognized `--status` value alongside `complete`, `failed`, `turn-cap-exhausted`, and `skipped`
- When invoked with `--status park`, writes `status: "needs-input"` + `parkedFrom: <phase>` + `handoffPath` to the signal file
- Leaves `completedAt` unset (non-terminal, like `turn-cap-exhausted`) so the concurrency model knows the slot is freed but the ticket isn't done
- Session outcome maps to `failed` (same as `turn-cap-exhausted`) so cost accounting stays accurate
- 5 new tests covering: accepted exit 0, signal fields written correctly, `completedAt` absent, event name `phase.<name>.park.<ticket>`, and invalid alias `parked` still rejected

### Phase 2 — `dispatch.mjs`: `handoffPath` forwarding (`67753d97`)

`plugins/dev/scripts/execution-core/dispatch.mjs`

- `dispatchTicket` / `defaultDispatch` options bag now accepts `handoffPath`
- `defaultRunPhaseAgent` injects it as `CATALYST_HANDOFF_PATH` env var into the spawned `phase-agent-dispatch` process
- Key is absent when value is falsy (matches the existing `resumeSession` conditional-key pattern), so all pre-existing assertions stay green with no changes

### Phases 3+4 — `daemon.mjs` + `linear-write.mjs`: comment-wake handler (`de5410da`)

`plugins/dev/scripts/execution-core/daemon.mjs`

- New exported `handleCommentWake(parsed, { orchDir, dispatch, removeLabel })`: on each `linear.comment.created` event, scans `workers/<ticket>/phase-*.json` for any signal with `status === "needs-input"`, removes the `needs-human/question` label, and re-dispatches via `dispatchTicket` with the stored `handoffPath`
- Wired into `startDaemon` as the `onComment` callback passed to `startMonitor` — fully injectable for testing
- Fail-open throughout: bad signal files, missing worker dirs, and `removeLabel` failures are logged and skipped, never fatal
- 5 new tests: re-dispatch fires on `needs-input`, no-op on `running`, `removeLabel` called before `dispatch`, no-op for missing worker dir, no-op for ticketless event

`plugins/dev/scripts/execution-core/linear-write.mjs`

- New `removeLabel(ticket, label, { exec })` counterpart to `applyLabel`
- Shells `linearis issues update --labels <label> --label-mode remove` (idempotent for absent labels)
- Returns `{ removed: true }` on exit 0, `{ removed: false, reason }` on failure; never throws
- 4 new tests: arg shape, success, non-zero exit, thrown exec

### Phase 5 — `recovery.mjs` + `boot-resume.mjs`: needs-input guards (`1e2e4369`)

`plugins/dev/scripts/execution-core/recovery.mjs`

- `reclaimDeadWorkIfPossible` early-returns `"noop"` for `needs-input` signals before any reclaim/escalate logic runs
- Ensures the per-tick recovery sweep never interferes with intentionally-parked workers
- 1 new test: returns `"noop"` and invokes zero probes/dispatches for a `needs-input` signal

`plugins/dev/scripts/execution-core/boot-resume.mjs`

- `selectBootResumeCandidates` skips tickets whose active signal has `status === "needs-input"`
- Daemon restarts never auto-re-dispatch a worker awaiting human input
- Other in-flight tickets continue to resume normally alongside parked ones
- 2 new tests: parked ticket excluded, sibling in-flight ticket still included

## Architecture

The park/resume flow uses two orthogonal axes (per design doc D3 and D7):
- **Phase state** (implement, verify, etc.) — tracks WHERE the ticket is in the pipeline; never changes on park
- **needs-human label** — a Linear label sub-category indicating the ticket needs human attention

```
worker needs input
  → phase-agent-emit-complete --status park --handoff-path <file>
  → signal: { status: "needs-input", parkedFrom: "implement", handoffPath: "..." }
  → daemon applies needs-human/question label (separate label application path)
  → worker exits, slot freed

human replies on Linear comment
  → broker emits linear.comment.created event
  → daemon.handleCommentWake fires
  → removeLabel(ticket, "needs-human/question")
  → dispatchTicket(orchDir, ticket, parkedPhase, { handoffPath })
  → fresh --bg worker resumes with CATALYST_HANDOFF_PATH set
```

## How to Verify It

- [ ] Run `bun test plugins/dev/scripts/execution-core/daemon.test.mjs` — 5 new `handleCommentWake` tests pass
- [ ] Run `bun test plugins/dev/scripts/execution-core/dispatch.test.mjs` — handoffPath forwarding tests pass
- [ ] Run `bun test plugins/dev/scripts/execution-core/linear-write.test.mjs` — 4 new `removeLabel` tests pass
- [ ] Run `bun test plugins/dev/scripts/execution-core/recovery.test.mjs` — needs-input guard test passes
- [ ] Run `bun test plugins/dev/scripts/execution-core/boot-resume.test.mjs` — 2 new guard tests pass
- [ ] Run `bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` — 5 new tests (17-21) pass
- [ ] All existing tests continue to pass (no behavioral changes to running/complete/failed paths)

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-549

## Changelog Entry

```
feat(dev): [M5·seam] Human-in-the-loop clarification protocol (CTL-549)

- phase-agent-emit-complete: add `park` status that writes needs-input signal
- dispatch.mjs: thread handoffPath through dispatchTicket → CATALYST_HANDOFF_PATH env
- daemon.mjs: handleCommentWake re-dispatches parked workers on linear.comment.created
- linear-write.mjs: removeLabel counterpart to applyLabel for clearing needs-human/question
- recovery.mjs: early-return noop for needs-input signals (skip reclaim/escalate)
- boot-resume.mjs: skip needs-input candidates in selectBootResumeCandidates
- 17 new tests across 6 test files
```
