### PR TITLE
CTL-749: Mid-flight context updates via inbox.jsonl

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/inbox-checkpoint.test.sh
+++ b/plugins/dev/scripts/execution-core/__tests__/inbox-checkpoint.test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# CTL-749: Verify inbox.jsonl is written and readable at a phase checkpoint.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXEC_CORE_DIR="$(dirname "$SCRIPT_DIR")"
+
+ORCH_DIR=$(mktemp -d)
+TICKET="CTL-999"
+mkdir -p "${ORCH_DIR}/workers/${TICKET}"
+
+node --input-type=module <<EOF
+import { createCommentInboxWriter, createUpdateInboxWriter } from '${EXEC_CORE_DIR}/daemon.mjs';
+
+// Test 1: comment writer
+const commentWriter = createCommentInboxWriter('${ORCH_DIR}', '');
+commentWriter({ ticket: '${TICKET}', commentId: 'c1', body: 'please add tests', authorId: 'u1', authorName: 'Ryan' });
+
+// Test 2: description update writer
+const updateWriter = createUpdateInboxWriter('${ORCH_DIR}', '');
+updateWriter({ ticket: '${TICKET}', identifier: '${TICKET}', description: 'new desc', descriptionChanged: true, actorId: 'u1', actorName: 'Ryan' });
+EOF
+
+INBOX="${ORCH_DIR}/workers/${TICKET}/inbox.jsonl"
+[[ -f "$INBOX" ]] || { echo "FAIL: inbox.jsonl not created"; rm -rf "$ORCH_DIR"; exit 1; }
+
+ENTRIES=$(cat "$INBOX")
+echo "$ENTRIES" | grep -q '"kind":"comment"' \
+  || { echo "FAIL: missing comment entry"; echo "Got: $ENTRIES"; rm -rf "$ORCH_DIR"; exit 1; }
+echo "$ENTRIES" | grep -q '"body":"please add tests"' \
+  || { echo "FAIL: wrong comment body"; echo "Got: $ENTRIES"; rm -rf "$ORCH_DIR"; exit 1; }
+echo "$ENTRIES" | grep -q '"kind":"description_changed"' \
+  || { echo "FAIL: missing description_changed entry"; echo "Got: $ENTRIES"; rm -rf "$ORCH_DIR"; exit 1; }
+echo "$ENTRIES" | grep -q '"description":"new desc"' \
+  || { echo "FAIL: wrong description"; echo "Got: $ENTRIES"; rm -rf "$ORCH_DIR"; exit 1; }
+
+echo "PASS: inbox.jsonl written with correct schema (comment + description_changed)"
+rm -rf "$ORCH_DIR"

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -12,7 +12,9 @@
 
 import {
   watch,
+  readFileSync,
   writeFileSync,
+  appendFileSync,
   renameSync,
   mkdirSync,
   existsSync,
@@ -23,7 +25,6 @@ import {
   readSync,
   closeSync,
   readdirSync,
-  readFileSync,
 } from "node:fs";
 import { resolve, dirname, basename, join } from "node:path";
 import { homedir } from "node:os";
@@ -97,6 +98,67 @@ let _eventLogCursor = 0;
 // stitches the leftover onto the front so a line split across two writes (or a
 // half-written line at read time) is parsed exactly once, never truncated.
 let _eventLogLeftover = "";
+
+// readLinearBotUserId — read catalyst.monitor.linear.botUserId from Layer 1
+// config (.catalyst/config.json). Returns "" when absent/unreadable so callers
+// can treat it as "no filter". Never throws. CTL-749.
+function readLinearBotUserId(configPath) {
+  if (!configPath) return "";
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+    const uid = parsed?.catalyst?.monitor?.linear?.botUserId;
+    return typeof uid === "string" && uid.length > 0 ? uid : "";
+  } catch {
+    return "";
+  }
+}
+
+// createCommentInboxWriter — factory for a per-daemon onComment subscriber.
+// Appends a JSONL entry to ORCH_DIR/workers/<ticket>/inbox.jsonl when the
+// ticket is in-flight (workers/ dir exists). Filters bot self-echo via
+// botUserId. Exported for testing. CTL-749.
+export function createCommentInboxWriter(orchDir, botUserId) {
+  return function writeCommentToInbox(parsed) {
+    const ticket = parsed.ticket ?? parsed.identifier ?? null;
+    if (!ticket) return;
+    if (botUserId && parsed.authorId === botUserId) return;
+    const workerDir = join(orchDir, "workers", ticket);
+    if (!existsSync(workerDir)) return;
+    const entry = JSON.stringify({
+      kind: "comment",
+      ticket,
+      commentId: parsed.commentId,
+      body: parsed.body,
+      authorId: parsed.authorId,
+      authorName: parsed.authorName ?? null,
+      receivedAt: new Date().toISOString(),
+    });
+    appendFileSync(join(workerDir, "inbox.jsonl"), entry + "\n");
+  };
+}
+
+// createUpdateInboxWriter — factory for a per-daemon onUpdate subscriber.
+// Appends a JSONL entry only when descriptionChanged is true and the ticket is
+// in-flight. Filters bot self-echo via botUserId. Exported for testing. CTL-749.
+export function createUpdateInboxWriter(orchDir, botUserId) {
+  return function writeUpdateToInbox(parsed) {
+    if (!parsed.descriptionChanged) return;
+    const ticket = parsed.ticket ?? parsed.identifier ?? null;
+    if (!ticket) return;
+    if (botUserId && parsed.actorId === botUserId) return;
+    const workerDir = join(orchDir, "workers", ticket);
+    if (!existsSync(workerDir)) return;
+    const entry = JSON.stringify({
+      kind: "description_changed",
+      ticket,
+      description: parsed.description ?? null,
+      actorId: parsed.actorId ?? null,
+      actorName: parsed.actorName ?? null,
+      receivedAt: new Date().toISOString(),
+    });
+    appendFileSync(join(workerDir, "inbox.jsonl"), entry + "\n");
+  };
+}
 
 // ensureState — idempotently write a minimal machine-level state.json so the
 // CTL-536 scheduler has a maxParallel to read. Never overwrites an operator's
@@ -259,16 +321,19 @@ export function startDaemon({
     // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
     // agent on a →Triage transition. `dispatch` stays an injectable default
     // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
+    // CTL-749: resolve the bot user ID from .catalyst/config.json so the inbox
+    // writers can filter out self-echo comments (the bot posting mirror comments).
+    const linearBotUserId = readLinearBotUserId(configPath);
+    const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserId);
     monitorFn({
       orchDir,
       cache,
-      onComment: (parsed) =>
-        handleCommentWake(parsed, {
-          orchDir,
-          dispatch: dispatchTicket,
-          removeLabel: defaultRemoveLabel,
-        }),
-    }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 (onComment)
+      onComment: (parsed) => {
+        commentInboxWriter(parsed); // CTL-749: write to inbox.jsonl for in-flight workers
+        handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel }); // CTL-549: re-dispatch parked tickets
+      },
+      onUpdate: createUpdateInboxWriter(orchDir, linearBotUserId), // CTL-749
+    }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -27,6 +27,8 @@ import {
   handleCommentWake,
   __resetEventTailCursorForTest,
   __getEventTailLeftoverForTest,
+  createCommentInboxWriter,
+  createUpdateInboxWriter,
 } from "./daemon.mjs";
 import { upsertProjectEntry } from "./registry.mjs";
 
@@ -908,18 +910,110 @@ describe("handleCommentWake (CTL-549)", () => {
   });
 });
 
-// CTL-549: startDaemon wires onComment to handleCommentWake
-describe("startDaemon — onComment wiring (CTL-549)", () => {
-  test("passes onComment callback to startMonitor", () => {
-    let capturedOnComment;
+// CTL-749: inbox writer factory functions
+describe("inbox writer — createCommentInboxWriter (CTL-749)", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), "inbox-comment-test-")); });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  test("writes comment entry to inbox.jsonl when ticket is in-flight", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const writer = createCommentInboxWriter(tmpDir, "");
+    writer({ ticket, commentId: "c1", body: "hello", authorId: "u1", authorName: "Ryan" });
+    const lines = readFileSync(join(tmpDir, "workers", ticket, "inbox.jsonl"), "utf8")
+      .trim().split("\n").map(JSON.parse);
+    expect(lines[0]).toMatchObject({ kind: "comment", ticket, body: "hello" });
+    expect(lines[0].receivedAt).toBeTruthy();
+  });
+
+  test("skips write when workers/<ticket>/ does not exist (ticket not in-flight)", () => {
+    const writer = createCommentInboxWriter(tmpDir, "");
+    writer({ ticket: "CTL-99", commentId: "c1", body: "hello", authorId: "u1", authorName: "Ryan" });
+    expect(existsSync(join(tmpDir, "workers", "CTL-99", "inbox.jsonl"))).toBe(false);
+  });
+
+  test("skips write when authorId matches botUserId (self-echo filter)", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const writer = createCommentInboxWriter(tmpDir, "bot-user-id");
+    writer({ ticket, commentId: "c1", body: "mirror", authorId: "bot-user-id", authorName: "Bot" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(false);
+  });
+
+  test("writes when authorId does NOT match botUserId", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const writer = createCommentInboxWriter(tmpDir, "bot-user-id");
+    writer({ ticket, commentId: "c2", body: "human reply", authorId: "human-user", authorName: "Alice" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(true);
+  });
+
+  test("appends multiple entries sequentially", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const writer = createCommentInboxWriter(tmpDir, "");
+    writer({ ticket, commentId: "c1", body: "first", authorId: "u1", authorName: "A" });
+    writer({ ticket, commentId: "c2", body: "second", authorId: "u2", authorName: "B" });
+    const lines = readFileSync(join(tmpDir, "workers", ticket, "inbox.jsonl"), "utf8")
+      .trim().split("\n").map(JSON.parse);
+    expect(lines).toHaveLength(2);
+    expect(lines[1].body).toBe("second");
+  });
+});
+
+describe("inbox writer — createUpdateInboxWriter (CTL-749)", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), "inbox-update-test-")); });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  test("writes description_changed entry when descriptionChanged is true and ticket is in-flight", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const writer = createUpdateInboxWriter(tmpDir, "");
+    writer({ ticket, description: "new text", descriptionChanged: true, actorId: "u1", actorName: "Ryan" });
+    const lines = readFileSync(join(tmpDir, "workers", ticket, "inbox.jsonl"), "utf8")
+      .trim().split("\n").map(JSON.parse);
+    expect(lines[0]).toMatchObject({ kind: "description_changed", ticket, description: "new text" });
+    expect(lines[0].receivedAt).toBeTruthy();
+  });
+
+  test("skips write when descriptionChanged is false", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const writer = createUpdateInboxWriter(tmpDir, "");
+    writer({ ticket, description: null, descriptionChanged: false, actorId: "u1" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(false);
+  });
+
+  test("skips write when workers/<ticket>/ does not exist (ticket not in-flight)", () => {
+    const writer = createUpdateInboxWriter(tmpDir, "");
+    writer({ ticket: "CTL-99", description: "x", descriptionChanged: true, actorId: "u1" });
+    expect(existsSync(join(tmpDir, "workers", "CTL-99", "inbox.jsonl"))).toBe(false);
+  });
+
+  test("skips write when actorId matches botUserId (self-echo filter)", () => {
+    const ticket = "CTL-99";
+    mkdirSync(join(tmpDir, "workers", ticket), { recursive: true });
+    const writer = createUpdateInboxWriter(tmpDir, "bot-id");
+    writer({ ticket, description: "bot edit", descriptionChanged: true, actorId: "bot-id", actorName: "Bot" });
+    expect(existsSync(join(tmpDir, "workers", ticket, "inbox.jsonl"))).toBe(false);
+  });
+});
+
+// CTL-549 + CTL-749: daemon wires onComment (handleCommentWake + inbox writer) and onUpdate
+describe("daemon wires onComment and onUpdate to monitorFn (CTL-549 + CTL-749)", () => {
+  test("passes onComment and onUpdate callbacks to startMonitor", () => {
+    let capturedOpts = null;
     startDaemon({
       recover: () => {},
       reconcileBoot: () => {},
-      startMonitor: (opts) => { capturedOnComment = opts.onComment; },
+      startMonitor: (opts) => { capturedOpts = opts; },
       startScheduler: () => {},
       watchRegistry: false,
     });
-    expect(typeof capturedOnComment).toBe("function");
     stopDaemon();
+    expect(typeof capturedOpts?.onComment).toBe("function");
+    expect(typeof capturedOpts?.onUpdate).toBe("function");
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -98,6 +98,10 @@ export function parseIssueUpdatedEvent(event) {
     toLabels: payload.toLabels ?? null,
     toProject: payload.toProject ?? null,
     toPriority: typeof payload.toPriority === "number" ? payload.toPriority : null,
+    description: typeof payload.description === "string" ? payload.description : null, // CTL-749
+    descriptionChanged: payload.descriptionChanged === true, // CTL-749
+    actorId: payload.actorId ?? null,   // CTL-749
+    actorName: payload.actorName ?? null, // CTL-749
   };
 }
 
@@ -146,6 +150,7 @@ export function handleIssueUpdatedEvent(
   {
     cache,
     abortWorker: _abortWorker, // accepted for signature symmetry, never invoked
+    onUpdate,                  // CTL-749: optional issue-update subscriber
   } = {}
 ) {
   const parsed = parseIssueUpdatedEvent(event);
@@ -164,6 +169,10 @@ export function handleIssueUpdatedEvent(
     } else {
       removeTicket(query.team, parsed.identifier);
     }
+  }
+  if (typeof onUpdate === "function") {
+    try { onUpdate(parsed); }
+    catch (err) { log.warn({ err: err.message }, "onUpdate subscriber threw — ignored"); }
   }
 }
 
@@ -601,7 +610,7 @@ export function readNewEvents({ foldOnly = false } = {}) {
       // handleCommentCreatedEvent's onComment is a side-effect — withhold it on
       // the fold-only boot drain so replayed comments don't re-fire subscribers.
       handleStateChangedEvent(event, { ...tailerOpts, foldOnly });
-      handleIssueUpdatedEvent(event, tailerOpts); // CTL-681
+      handleIssueUpdatedEvent(event, foldOnly ? { ...tailerOpts, onUpdate: undefined } : tailerOpts); // CTL-681 + CTL-749
       handleCommentCreatedEvent(event, foldOnly ? {} : tailerOpts); // CTL-681
     }
   } catch {
@@ -641,6 +650,7 @@ export function startMonitor({
   abortWorker,
   cache, // CTL-634: shared state cache for event-driven write-through
   onComment, // CTL-681: optional comment subscriber
+  onUpdate,  // CTL-749: optional issue-update subscriber
 } = {}) {
   // CTL-565: orchDir + dispatch + abortWorker are stored in tailerOpts so the
   // tailer-driven readNewEvents → handleStateChangedEvent path can one-shot-
@@ -648,7 +658,7 @@ export function startMonitor({
   // undefined, handleStateChangedEvent falls back to its real default.
   // CTL-634: cache rides in tailerOpts too so the tailer's write-through path
   // populates the same instance the scheduler reads.
-  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker, cache, onComment };
+  tailerOpts = { exec, debounceMs, orchDir, dispatch, abortWorker, cache, onComment, onUpdate };
   reconcileAll({ exec });
   sweepMissingTriage({ orchDir, dispatch }); // CTL-711: triage pre-existing eligible tickets
   if (resumeFromCursor) {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -949,7 +949,7 @@ describe("sweepMissingTriage (CTL-711)", () => {
 // --- CTL-681 Phase 3: parseIssueUpdatedEvent + handleIssueUpdatedEvent ------
 
 // Helper to build a canonical OTel-shaped linear.issue.updated event.
-function issueUpdatedEvent({ identifier, teamKey, toState, toLabels, toProject, toPriority } = {}) {
+function issueUpdatedEvent({ identifier, teamKey, toState, toLabels, toProject, toPriority, description, descriptionChanged, actorId, actorName } = {}) {
   return {
     attributes: {
       "event.name": "linear.issue.updated",
@@ -963,6 +963,10 @@ function issueUpdatedEvent({ identifier, teamKey, toState, toLabels, toProject, 
         toLabels: toLabels ?? null,
         toProject: toProject ?? null,
         toPriority: toPriority ?? null,
+        description: description ?? null,
+        descriptionChanged: descriptionChanged ?? false,
+        actorId: actorId ?? null,
+        actorName: actorName ?? null,
       },
     },
   };
@@ -1208,6 +1212,61 @@ describe("handleCommentCreatedEvent (CTL-681)", () => {
     readNewEvents();
     expect(onComment).toHaveBeenCalledTimes(1);
     expect(onComment.mock.calls[0][0]).toMatchObject({ ticket: "ENG-10" });
+    stopMonitor();
+  });
+});
+
+// --- CTL-749: parseIssueUpdatedEvent description fields + onUpdate seam -----
+
+describe("parseIssueUpdatedEvent — description fields (CTL-749)", () => {
+  test("extracts description and descriptionChanged from payload", () => {
+    const parsed = parseIssueUpdatedEvent(
+      issueUpdatedEvent({ description: "new text", descriptionChanged: true })
+    );
+    expect(parsed).toMatchObject({ description: "new text", descriptionChanged: true });
+  });
+
+  test("description is null and descriptionChanged false when absent from payload", () => {
+    const parsed = parseIssueUpdatedEvent(issueUpdatedEvent({}));
+    expect(parsed.description).toBeNull();
+    expect(parsed.descriptionChanged).toBe(false);
+  });
+});
+
+describe("handleIssueUpdatedEvent — onUpdate seam (CTL-749)", () => {
+  test("calls onUpdate with parsed payload when descriptionChanged", () => {
+    const onUpdate = mock(() => {});
+    handleIssueUpdatedEvent(
+      issueUpdatedEvent({ descriptionChanged: true, description: "new" }),
+      { onUpdate }
+    );
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate.mock.calls[0][0]).toMatchObject({ descriptionChanged: true, description: "new" });
+  });
+
+  test("calls onUpdate even when descriptionChanged is false (subscriber decides)", () => {
+    const onUpdate = mock(() => {});
+    handleIssueUpdatedEvent(issueUpdatedEvent({ descriptionChanged: false }), { onUpdate });
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("no-op when onUpdate is undefined (never throws)", () => {
+    expect(() => handleIssueUpdatedEvent(issueUpdatedEvent())).not.toThrow();
+  });
+
+  test("onUpdate subscriber throw is swallowed (fail-open)", () => {
+    const onUpdate = mock(() => { throw new Error("subscriber boom"); });
+    expect(() => handleIssueUpdatedEvent(issueUpdatedEvent(), { onUpdate })).not.toThrow();
+  });
+
+  test("readNewEvents integration: a linear.issue.updated line invokes onUpdate via tailerOpts", () => {
+    const onUpdate = mock(() => {});
+    startMonitor({ exec: execReturning({}), reconcileIntervalMs: 60_000, onUpdate });
+    const line = JSON.stringify(issueUpdatedEvent({ identifier: "ENG-20", descriptionChanged: true, description: "updated" }));
+    appendFileSync(eventLogPath(), line + "\n");
+    readNewEvents();
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate.mock.calls[0][0]).toMatchObject({ identifier: "ENG-20", descriptionChanged: true });
     stopMonitor();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-events.test.ts
@@ -452,3 +452,43 @@ describe("parseLinearWebhookEvent — ignored", () => {
     expect(ev.kind).toBe("issue");
   });
 });
+
+describe("parseLinearWebhookEvent — description fields (CTL-749)", () => {
+  it("extracts description from data.description", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ data: { description: "new text" }, updatedFrom: {} })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.description).toBe("new text");
+    expect(ev.descriptionChanged).toBe(false);
+  });
+
+  it("description is null when absent from data", () => {
+    const ev = parseLinearWebhookEvent("Issue", issuePayload({ data: {}, updatedFrom: {} }));
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.description).toBeNull();
+  });
+
+  it("descriptionChanged: true when description in updatedFrom", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({
+        data: { description: "updated text" },
+        updatedFrom: { description: "old text" },
+      })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.descriptionChanged).toBe(true);
+    expect(ev.description).toBe("updated text");
+  });
+
+  it("descriptionChanged: false when description not in updatedFrom", () => {
+    const ev = parseLinearWebhookEvent(
+      "Issue",
+      issuePayload({ data: {}, updatedFrom: { title: "old title" } })
+    );
+    if (ev.kind !== "issue") throw new Error("expected issue kind");
+    expect(ev.descriptionChanged).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -371,6 +371,68 @@ describe("createLinearWebhookHandler", () => {
   });
 });
 
+describe("buildLinearEventLogEnvelope — description fields (CTL-749)", () => {
+  it("issue.updated envelope carries description and descriptionChanged", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "update",
+        topic: "linear.issue.updated",
+        ticket: "CTL-749",
+        teamKey: "CTL",
+        data: {},
+        updatedFromKeys: ["description"],
+        actorId: null,
+        actorName: null,
+        toState: null,
+        toPriority: null,
+        toAssigneeId: null,
+        toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: { description: "old text" },
+        description: "new text",
+        descriptionChanged: true,
+      },
+      TS
+    );
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload["description"]).toBe("new text");
+    expect(payload["descriptionChanged"]).toBe(true);
+  });
+
+  it("description is null and descriptionChanged is false when not a description edit", () => {
+    const env = buildLinearEventLogEnvelope(
+      {
+        kind: "issue",
+        action: "update",
+        topic: "linear.issue.updated",
+        ticket: "CTL-749",
+        teamKey: "CTL",
+        data: {},
+        updatedFromKeys: [],
+        actorId: null,
+        actorName: null,
+        toState: null,
+        toPriority: null,
+        toAssigneeId: null,
+        toAssigneeName: null,
+        toLabels: null,
+        toProject: null,
+        toProjectId: null,
+        previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
+      },
+      TS
+    );
+    const payload = env!.body.payload as Record<string, unknown>;
+    expect(payload["description"]).toBeNull();
+    expect(payload["descriptionChanged"]).toBe(false);
+  });
+});
+
 describe("buildLinearEventLogEnvelope — comment fields (CTL-681)", () => {
   it("comment envelope includes body, authorId, authorName in body.payload", () => {
     const env = buildLinearEventLogEnvelope(
@@ -455,6 +517,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );
@@ -486,6 +550,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );
@@ -513,6 +579,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );
@@ -540,6 +608,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );
@@ -568,6 +638,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );
@@ -598,6 +670,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
           stateId: "old-state",
           labelIds: ["old-label"],
         },
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );
@@ -631,6 +705,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );
@@ -662,6 +738,8 @@ describe("buildLinearEventLogEnvelope (canonical)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );
@@ -755,6 +833,8 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS,
       TEAMS
@@ -783,6 +863,8 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS,
       TEAMS
@@ -811,6 +893,8 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS,
       TEAMS
@@ -941,6 +1025,8 @@ describe("buildLinearEventLogEnvelope — team→repo lookup (CTL-362)", () => {
         toProject: null,
         toProjectId: null,
         previousFromValues: {},
+        description: null,
+        descriptionChanged: false,
       },
       TS
     );

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-events.ts
@@ -61,6 +61,10 @@ export type LinearWebhookEvent =
        * without re-parsing the raw webhook payload.
        */
       previousFromValues: Record<string, unknown>;
+      /** Current description text from data.description; null when absent. CTL-749. */
+      description: string | null;
+      /** True when "description" key appears in updatedFrom (description was edited). CTL-749. */
+      descriptionChanged: boolean;
     }
   | {
       kind: "comment";
@@ -165,6 +169,8 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
   const toProject = projectObj !== null ? getOptStr(projectObj, "name") : null;
   const toProjectId =
     projectObj !== null ? getOptStr(projectObj, "id") : getOptStr(data, "projectId");
+  const description = getOptStr(data, "description") ?? null; // CTL-749
+  const descriptionChanged = updatedFromKeys.includes("description"); // CTL-749
   return {
     kind: "issue",
     action,
@@ -183,6 +189,8 @@ function parseIssue(payload: Record<string, unknown>): LinearWebhookEvent {
     toProject,
     toProjectId,
     previousFromValues: updatedFrom,
+    description,
+    descriptionChanged,
   };
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -152,6 +152,8 @@ export function buildLinearEventLogEnvelope(
           toProject: event.toProject,
           toProjectId: event.toProjectId,
           previousFromValues: event.previousFromValues,
+          description: event.description,           // CTL-749
+          descriptionChanged: event.descriptionChanged, // CTL-749
         },
       });
     }

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -196,6 +196,28 @@ Plan §"Per-phase /goal conditions":
    phase-verify exists yet — the cutover is a one-line change to the Task
    invocation when that phase lands.
 
+### Inbox check (CTL-749)
+
+Before continuing to the End block, check for mid-flight context updates from the human:
+
+1. If `${ORCH_DIR}/workers/${TICKET}/inbox.jsonl` exists and is non-empty, read it fully.
+2. Parse each JSONL line — entries have `kind: "comment"` or `kind: "description_changed"`.
+3. For each entry, decide:
+   - **Absorb and continue**: the update is additive context (clarification, extra constraints,
+     "also handle X") — fold it into your working context and continue. Post a brief reply comment
+     acknowledging the update (one sentence).
+   - **Pause and replan**: the update fundamentally changes scope or invalidates the current
+     approach — emit `failed` with `reason: "mid_flight_replan_needed"` via
+     `${PLUGIN_ROOT}/scripts/phase-agent-emit-complete` and post the reason to Linear as a
+     comment before exiting.
+4. After reading, archive processed entries:
+   ```bash
+   [[ -f "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" ]] && \
+     mv "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" \
+        "${ORCH_DIR}/workers/${TICKET}/inbox.processed-$(date +%s).jsonl" || true
+   ```
+5. If no inbox file or it is empty, continue normally.
+
 ## End block (terminal emit — copy verbatim)
 
 Mirror the phase output to Linear as a single comment (CTL-632). Re-derives

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -165,6 +165,28 @@ If [[create-plan]] runs into a question it cannot resolve from the research
 document, post a `question` comms message to the orchestrator with `--re <msg_id>`
 correlation; do not block waiting for a reply — record the assumption and proceed.
 
+### Inbox check (CTL-749)
+
+After `/catalyst-dev:create-plan` Task returns, check for mid-flight context updates from the human:
+
+1. If `${ORCH_DIR}/workers/${TICKET}/inbox.jsonl` exists and is non-empty, read it fully.
+2. Parse each JSONL line — entries have `kind: "comment"` or `kind: "description_changed"`.
+3. For each entry, decide:
+   - **Absorb and continue**: the update is additive context (clarification, extra constraints,
+     "also handle X") — fold it into your working context and continue. Post a brief reply comment
+     acknowledging the update (one sentence).
+   - **Pause and replan**: the update fundamentally changes scope or invalidates the current
+     approach — emit `failed` with `reason: "mid_flight_replan_needed"` via
+     `${PLUGIN_ROOT}/scripts/phase-agent-emit-complete` and post the reason to Linear as a
+     comment before exiting.
+4. After reading, archive processed entries:
+   ```bash
+   [[ -f "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" ]] && \
+     mv "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" \
+        "${ORCH_DIR}/workers/${TICKET}/inbox.processed-$(date +%s).jsonl" || true
+   ```
+5. If no inbox file or it is empty, continue normally.
+
 ## End block
 
 ```bash

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -154,6 +154,28 @@ is performed.
 If [[research-codebase]] hits a question it cannot resolve, post a `question` comms
 message and continue with the best-effort answer — do not block the pipeline.
 
+### Inbox check (CTL-749)
+
+After `/catalyst-dev:research-codebase` Task returns, check for mid-flight context updates from the human:
+
+1. If `${ORCH_DIR}/workers/${TICKET}/inbox.jsonl` exists and is non-empty, read it fully.
+2. Parse each JSONL line — entries have `kind: "comment"` or `kind: "description_changed"`.
+3. For each entry, decide:
+   - **Absorb and continue**: the update is additive context (clarification, extra constraints,
+     "also handle X") — fold it into your working context and continue. Post a brief reply comment
+     acknowledging the update (one sentence).
+   - **Pause and replan**: the update fundamentally changes scope or invalidates the current
+     approach — emit `failed` with `reason: "mid_flight_replan_needed"` via
+     `${PLUGIN_ROOT}/scripts/phase-agent-emit-complete` and post the reason to Linear as a
+     comment before exiting.
+4. After reading, archive processed entries:
+   ```bash
+   [[ -f "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" ]] && \
+     mv "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" \
+        "${ORCH_DIR}/workers/${TICKET}/inbox.processed-$(date +%s).jsonl" || true
+   ```
+5. If no inbox file or it is empty, continue normally.
+
 ## End block
 
 ```bash

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -189,6 +189,28 @@ jq -nc \
 }
 ```
 
+### Inbox check (CTL-749)
+
+After `/review` Task returns, check for mid-flight context updates from the human:
+
+1. If `${ORCH_DIR}/workers/${TICKET}/inbox.jsonl` exists and is non-empty, read it fully.
+2. Parse each JSONL line — entries have `kind: "comment"` or `kind: "description_changed"`.
+3. For each entry, decide:
+   - **Absorb and continue**: the update is additive context (clarification, extra constraints,
+     "also handle X") — fold it into your working context and continue. Post a brief reply comment
+     acknowledging the update (one sentence).
+   - **Pause and replan**: the update fundamentally changes scope or invalidates the current
+     approach — emit `failed` with `reason: "mid_flight_replan_needed"` via
+     `${PLUGIN_ROOT}/scripts/phase-agent-emit-complete` and post the reason to Linear as a
+     comment before exiting.
+4. After reading, archive processed entries:
+   ```bash
+   [[ -f "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" ]] && \
+     mv "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" \
+        "${ORCH_DIR}/workers/${TICKET}/inbox.processed-$(date +%s).jsonl" || true
+   ```
+5. If no inbox file or it is empty, continue normally.
+
 ## End block
 
 ```bash

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -252,6 +252,28 @@ jq -nc \
 }
 ```
 
+### Inbox check (CTL-749)
+
+After all gates have run, check for mid-flight context updates from the human:
+
+1. If `${ORCH_DIR}/workers/${TICKET}/inbox.jsonl` exists and is non-empty, read it fully.
+2. Parse each JSONL line — entries have `kind: "comment"` or `kind: "description_changed"`.
+3. For each entry, decide:
+   - **Absorb and continue**: the update is additive context (clarification, extra constraints,
+     "also handle X") — fold it into your working context and continue. Post a brief reply comment
+     acknowledging the update (one sentence).
+   - **Pause and replan**: the update fundamentally changes scope or invalidates the current
+     approach — emit `failed` with `reason: "mid_flight_replan_needed"` via
+     `${PLUGIN_ROOT}/scripts/phase-agent-emit-complete` and post the reason to Linear as a
+     comment before exiting.
+4. After reading, archive processed entries:
+   ```bash
+   [[ -f "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" ]] && \
+     mv "${ORCH_DIR}/workers/${TICKET}/inbox.jsonl" \
+        "${ORCH_DIR}/workers/${TICKET}/inbox.processed-$(date +%s).jsonl" || true
+   ```
+5. If no inbox file or it is empty, continue normally.
+
 ## End block
 
 ```bash


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-02T05:48:00Z -->
<!-- Last updated: 2026-06-02T05:48:00Z -->
<!-- PR: #1269 -->
<!-- Previous commits: 687a8b67fd7b34a52782fa3b942a9499c52c96d4 -->

## Summary

Implements mid-flight context delivery so that description edits and comments made on a Linear ticket while a phase agent is running are captured in a per-worker `inbox.jsonl` file. Phase agents check that inbox at safe checkpoints and decide whether to absorb the update and continue, or pause and replan.

This is the *human-initiated* complement to CTL-549 (which handles the *agent-initiated* park/resume via `@mention`). The two features share the `onComment` seam in the daemon — this PR chains both handlers additively (inbox write first, then comment-wake re-dispatch).

## Changes Made

### Phase 1 — Webhook Enrichment (`orch-monitor`)

- `linear-webhook-events.ts`: Added `description` and `descriptionChanged` fields to `LinearWebhookEvent` (issue variant). Previously description edits arrived as `linear.issue.updated` with no description payload.
- `linear-webhook-handler.ts`: Extracts and carries `description`/`descriptionChanged` through `buildLinearEventLogEnvelope`.
- Tests: 40 + 86 new assertions covering the enriched event shape and handler paths.

### Phase 2 — Per-Worker Inbox Writer (`execution-core`)

- `monitor.mjs`: Extended `parseIssueUpdatedEvent` to return `description`/`descriptionChanged`/`actorId`/`actorName`. Added `onUpdate` seam to `handleIssueUpdatedEvent` (fail-open, logged) and `startMonitor`. Suppressed `onUpdate` during boot drain fold-only pass (same pattern as `onComment` — CTL-681).
- `daemon.mjs`:
  - Added `readLinearBotUserId` — reads `catalyst.monitor.linear.botUserId` from Layer-1 config for self-echo filtering.
  - Added `createCommentInboxWriter` — appends `{kind:"comment", ...}` entries to `ORCH_DIR/workers/<ticket>/inbox.jsonl` for in-flight tickets, filtered by bot user ID.
  - Added `createUpdateInboxWriter` — appends `{kind:"description_changed", ...}` entries when `descriptionChanged === true`.
  - Chained both with CTL-549's `handleCommentWake` in the `monitorFn` `onComment` callback (inbox write runs first, then re-dispatch for parked tickets). Added `onUpdate` wire.
- `daemon.test.mjs`: 100 lines of new tests for both writer factories and the combined daemon wiring (merged the CTL-549 wiring test with CTL-749's into one `describe` block that checks both `onComment` and `onUpdate`).
- `__tests__/inbox-checkpoint.test.sh`: Bash integration test that verifies inbox entries can be written and archived.

### Phase 3 — Phase Agent Checkpoints (Skills)

Added "Inbox check (CTL-749)" prose to five phase skills at natural stopping points (before the End block):

- `phase-research`, `phase-plan`, `phase-implement`, `phase-verify`, `phase-review`

Each checkpoint: reads `inbox.jsonl` if present, parses each entry, decides absorb-and-continue vs pause-and-replan (agent's call), posts a one-sentence acknowledgment comment, then archives the file with a timestamp suffix.

## How to Verify

- [ ] `cd plugins/dev/scripts/execution-core && bun test daemon.test.mjs` — inbox writer + wiring tests pass
- [ ] `cd plugins/dev/scripts/execution-core && bun test monitor.test.mjs` — onUpdate seam tests pass
- [ ] `cd plugins/dev/scripts/orch-monitor && bun test` — webhook enrichment tests pass
- [ ] `bash plugins/dev/scripts/execution-core/__tests__/inbox-checkpoint.test.sh` — integration test passes
- [ ] Start the daemon, edit a ticket description while a phase is running, confirm a `inbox.jsonl` entry appears in `~/catalyst/execution-core/workers/<ticket>/`
- [ ] Confirm the agent's own mirror comments do NOT appear in `inbox.jsonl` (bot self-echo filter)

## Related Issues

- Closes https://linear.app/coalesce-labs/issue/CTL-749
- Depends on CTL-549 (comment-wake re-dispatch — both wire `onComment`; this PR chains them)
- References CTL-281 (enriched issue events), CTL-550 (agent identity / botUserId)
